### PR TITLE
Add OpenAI and Ollama provider drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A lightweight, multi-tenant agentic runtime — one Go sidecar that owns the LLM tool-use loop end-to-end across Anthropic, OpenAI and Ollama. Consumed from Next.js (TS adapter) and Python over a local HTTP+SSE API.
 
-> **Status:** v0.1 in active development. Not production-ready. Anthropic provider works; OpenAI / Ollama / MCP / SQLite store / Python adapter / caching layers are scaffolded but not yet implemented.
+> **Status:** v0.1 in active development. Not production-ready. Anthropic, OpenAI, and Ollama providers work; MCP / SQLite store / Python adapter / response cache are scaffolded but not yet implemented.
 
 ## Why
 

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
+	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
+	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
@@ -70,17 +72,28 @@ func main() {
 	_ = httpServer.Shutdown(ctx)
 }
 
-// providerResolver constructs and caches Provider instances on demand.
-// Anthropic is the only one wired at v0.1; the others return a clear error.
+// providerResolver constructs Provider instances at startup based on which
+// env vars are set. A provider that wasn't configured returns a clear error
+// when an agent tries to use it (rather than failing the whole startup).
 type providerResolver struct {
-	cfg       *config.Config
 	anthropic providers.Provider
+	openai    providers.Provider
+	ollama    providers.Provider
 }
 
 func newProviderResolver(cfg *config.Config) *providerResolver {
-	pr := &providerResolver{cfg: cfg}
+	pr := &providerResolver{}
 	if cfg.Env.AnthropicAPIKey != "" {
 		pr.anthropic = anthropic.New(cfg.Env.AnthropicAPIKey, "", nil)
+	}
+	if cfg.Env.OpenAIAPIKey != "" {
+		pr.openai = openai.New(cfg.Env.OpenAIAPIKey, "", nil)
+	}
+	// Ollama has no API key — wire it up if a base URL is configured (the
+	// loader defaults this to http://localhost:11434 so it's effectively
+	// always-on; users disable it by setting OLLAMA_BASE_URL=disabled).
+	if cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled" {
+		pr.ollama = ollama.New(cfg.Env.OllamaBaseURL, nil)
 	}
 	return pr
 }
@@ -93,9 +106,15 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 		}
 		return p.anthropic, nil
 	case "openai":
-		return nil, fmt.Errorf("openai provider: not implemented in v0.1 thin slice")
+		if p.openai == nil {
+			return nil, fmt.Errorf("openai provider not configured (set OPENAI_API_KEY)")
+		}
+		return p.openai, nil
 	case "ollama":
-		return nil, fmt.Errorf("ollama provider: not implemented in v0.1 thin slice")
+		if p.ollama == nil {
+			return nil, fmt.Errorf("ollama provider not configured (set OLLAMA_BASE_URL or unset OLLAMA_BASE_URL=disabled)")
+		}
+		return p.ollama, nil
 	default:
 		return nil, fmt.Errorf("unknown provider %q", id)
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,8 +116,8 @@ that continues an existing session.
 
 | Area | Status | Notes |
 |---|---|---|
-| OpenAI provider | not started | Driver plug-in, same `Provider` interface |
-| Ollama provider | not started | Same |
+| OpenAI provider | landed (phase_0_2) | Chat Completions API; index-keyed tool_call accumulator; `[DONE]` sentinel |
+| Ollama provider | landed (phase_0_2) | NDJSON streaming `/api/chat`; tool_calls work only on tool-tuned models |
 | MCP stdio pool | not started | `internal/tools/mcp/stdio/` empty |
 | MCP HTTP client | not started | `internal/tools/mcp/http/` empty |
 | Sub-agents | not started | Anthropic-only at v0.2 |

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -81,7 +81,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 
 	out := make(chan providers.Event, 16)
-	go streamEvents(resp.Body, out)
+	go streamEvents(ctx, resp.Body, out)
 	return out, nil
 }
 
@@ -197,9 +197,21 @@ type sseFrame struct {
 	data  []byte
 }
 
-func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
 	defer body.Close()
 	defer close(out)
+
+	// send respects ctx so a cancelled request doesn't leak this goroutine on
+	// a full unread channel. Returns false if ctx ended; callers should return
+	// immediately so defer close(out) fires and the consumer's range exits.
+	send := func(ev providers.Event) bool {
+		select {
+		case out <- ev:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
@@ -214,7 +226,9 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		if len(line) == 0 {
 			// dispatch frame
 			if frame.event != "" || len(frame.data) > 0 {
-				processFrame(frame, &current, &stopReason, &usage, out)
+				if !processFrame(frame, &current, &stopReason, &usage, send) {
+					return
+				}
 			}
 			frame = sseFrame{}
 			continue
@@ -226,11 +240,11 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		out <- providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()}
+		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
 		return
 	}
 	// Final done event with stop_reason + usage.
-	out <- providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage}
+	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
 }
 
 type pendingBlock struct {
@@ -240,13 +254,15 @@ type pendingBlock struct {
 	toolInput strings.Builder
 }
 
+// processFrame returns false if the caller should abort (ctx cancelled while
+// trying to send). All non-send paths return true unconditionally.
 func processFrame(
 	f sseFrame,
 	current *pendingBlock,
 	stopReason *string,
 	usage **providers.Usage,
-	out chan<- providers.Event,
-) {
+	send func(providers.Event) bool,
+) bool {
 	switch f.event {
 	case "content_block_start":
 		var ev struct {
@@ -258,7 +274,7 @@ func processFrame(
 			} `json:"content_block"`
 		}
 		if err := json.Unmarshal(f.data, &ev); err != nil {
-			return
+			return true
 		}
 		current.kind = ev.ContentBlock.Type
 		current.toolID = ev.ContentBlock.ID
@@ -278,11 +294,13 @@ func processFrame(
 			} `json:"delta"`
 		}
 		if err := json.Unmarshal(f.data, &ev); err != nil {
-			return
+			return true
 		}
 		switch ev.Delta.Type {
 		case "text_delta":
-			out <- providers.Event{Type: providers.EventText, Text: ev.Delta.Text}
+			if !send(providers.Event{Type: providers.EventText, Text: ev.Delta.Text}) {
+				return false
+			}
 		case "input_json_delta":
 			current.toolInput.WriteString(ev.Delta.PartialJSON)
 		}
@@ -293,13 +311,15 @@ func processFrame(
 			if len(input) == 0 {
 				input = json.RawMessage("{}")
 			}
-			out <- providers.Event{
+			if !send(providers.Event{
 				Type: providers.EventToolCall,
 				ToolUse: &providers.ToolUse{
 					ID:    current.toolID,
 					Name:  current.toolName,
 					Input: input,
 				},
+			}) {
+				return false
 			}
 		}
 		current.kind = ""
@@ -318,7 +338,7 @@ func processFrame(
 			} `json:"usage"`
 		}
 		if err := json.Unmarshal(f.data, &ev); err != nil {
-			return
+			return true
 		}
 		if ev.Delta.StopReason != "" {
 			*stopReason = ev.Delta.StopReason
@@ -339,9 +359,9 @@ func processFrame(
 			} `json:"error"`
 		}
 		if err := json.Unmarshal(f.data, &ev); err != nil {
-			out <- providers.Event{Type: providers.EventError, Error: "anthropic stream error (unparseable)"}
-			return
+			return send(providers.Event{Type: providers.EventError, Error: "anthropic stream error (unparseable)"})
 		}
-		out <- providers.Event{Type: providers.EventError, Error: ev.Error.Type + ": " + ev.Error.Message}
+		return send(providers.Event{Type: providers.EventError, Error: ev.Error.Type + ": " + ev.Error.Message})
 	}
+	return true
 }

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
@@ -124,6 +126,54 @@ func TestStreamToolUse(t *testing.T) {
 	if stop != "tool_use" {
 		t.Errorf("stop_reason = %q", stop)
 	}
+}
+
+// Regression: cancelling ctx mid-stream must not leak the streaming goroutine
+// even when the consumer never drains the channel. We verify by inspecting
+// `runtime.Stack(all=true)` and looking for our function name; if it's still
+// running after a generous post-cancel grace period, the goroutine is stuck.
+//
+// Important: a naive "wait for channel close" test won't catch this — once
+// you start draining, the buffer frees up and the stuck producer unblocks
+// regardless of the bug. The leak only manifests when nobody drains.
+func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		for i := 0; i < 30; i++ {
+			fmt.Fprint(w, "event: content_block_delta\ndata: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"x\"}}\n\n")
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := New("test-key", srv.URL, nil)
+	_, err := d.Call(ctx, providers.Request{Model: "x"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	// Let the producer fill the 16-event buffer and block on the next send.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	// Generous grace window for the goroutine to observe ctx and exit.
+	time.Sleep(300 * time.Millisecond)
+
+	if isStreamEventsRunning(t) {
+		t.Fatal("streamEvents goroutine still alive 300ms after ctx cancel — leaked")
+	}
+}
+
+// isStreamEventsRunning dumps all goroutine stacks and reports whether any
+// stack contains our streamEvents function. Bytes scanned, no allocs in the
+// hot path; safe for tests.
+func isStreamEventsRunning(t *testing.T) bool {
+	t.Helper()
+	buf := make([]byte, 64*1024)
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), ".streamEvents(")
 }
 
 func TestRequestBodyShape(t *testing.T) {

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -279,6 +279,11 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 	var stopReason string
 	var usage *providers.Usage
 	var model string
+	// hadToolCalls tracks whether *any* frame emitted tool_calls. Ollama may
+	// emit tool_calls on a non-final frame, then send a separate done:true
+	// frame with an empty tool_calls array. We must remember the earlier
+	// emission so the loop iterates instead of breaking on "end_turn".
+	var hadToolCalls bool
 
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -297,6 +302,7 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 			out <- providers.Event{Type: providers.EventText, Text: c.Message.Content}
 		}
 		for _, tc := range c.Message.ToolCalls {
+			hadToolCalls = true
 			args := tc.Function.Arguments
 			if len(args) == 0 {
 				args = json.RawMessage("{}")
@@ -312,7 +318,7 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		}
 
 		if c.Done {
-			stopReason = mapStopReason(c.DoneReason, len(c.Message.ToolCalls) > 0)
+			stopReason = mapStopReason(c.DoneReason, hadToolCalls)
 			if c.PromptEvalCount > 0 || c.EvalCount > 0 {
 				usage = &providers.Usage{
 					InputTokens:  c.PromptEvalCount,

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -89,7 +89,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 
 	out := make(chan providers.Event, 16)
-	go streamEvents(resp.Body, out)
+	go streamEvents(ctx, resp.Body, out)
 	return out, nil
 }
 
@@ -269,9 +269,21 @@ type chunkToolCallFn struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
 	defer body.Close()
 	defer close(out)
+
+	// send respects ctx so a cancelled request doesn't leak this goroutine on
+	// a full unread channel. Returns false if ctx ended; callers should return
+	// immediately so defer close(out) fires and the consumer's range exits.
+	send := func(ev providers.Event) bool {
+		select {
+		case out <- ev:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
@@ -299,7 +311,9 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		}
 
 		if c.Message.Content != "" {
-			out <- providers.Event{Type: providers.EventText, Text: c.Message.Content}
+			if !send(providers.Event{Type: providers.EventText, Text: c.Message.Content}) {
+				return
+			}
 		}
 		for _, tc := range c.Message.ToolCalls {
 			hadToolCalls = true
@@ -307,13 +321,15 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 			if len(args) == 0 {
 				args = json.RawMessage("{}")
 			}
-			out <- providers.Event{
+			if !send(providers.Event{
 				Type: providers.EventToolCall,
 				ToolUse: &providers.ToolUse{
 					ID:    "", // Ollama doesn't issue tool_call IDs; loop assigns one
 					Name:  tc.Function.Name,
 					Input: args,
 				},
+			}) {
+				return
 			}
 		}
 
@@ -329,11 +345,11 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		out <- providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()}
+		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
 		return
 	}
 
-	out <- providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage}
+	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
 }
 
 // mapStopReason translates Ollama's done_reason into our shared vocabulary.

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -1,0 +1,349 @@
+// Package ollama implements the Provider interface for Ollama's /api/chat
+// endpoint.
+//
+// Two things diverge from the cloud providers and are worth knowing:
+//
+//  1. Wire format is NDJSON (newline-delimited JSON), not SSE. The stream ends
+//     when the body closes; the final line carries "done":true plus usage
+//     counters in the eval-* fields.
+//
+//  2. Tool-use reliability depends on the model. Tool-tuned models (llama3.1+,
+//     qwen2.5, mistral-large, ...) emit structured tool_calls correctly.
+//     Non-tuned models silently ignore the "tools" field — no error, just no
+//     tool_calls in the response. We trust the native API and document the
+//     limitation rather than papering over it with prompt-engineering shims.
+package ollama
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+const (
+	defaultBaseURL = "http://localhost:11434"
+	defaultTimeout = 10 * time.Minute // local generation can be slow
+)
+
+// Driver speaks Ollama's /api/chat. No API key — local trust model.
+type Driver struct {
+	baseURL string
+	http    *http.Client
+}
+
+// New constructs a Driver. baseURL may be empty for the default localhost endpoint.
+func New(baseURL string, httpClient *http.Client) *Driver {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Driver{baseURL: baseURL, http: httpClient}
+}
+
+func (d *Driver) ID() string { return "ollama" }
+
+func (d *Driver) Capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		NativePromptCache: false,
+		ParallelToolCalls: true, // model-dependent; we report the optimistic case
+		Streaming:         true,
+		MaxContextTokens:  0, // varies wildly by model; 0 means "ask the model"
+		SupportsThinking:  false,
+	}
+}
+
+// Call sends the chat request and streams Events. The goroutine that reads
+// the response closes the channel when the stream ends.
+func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	body, err := buildRequestBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/api/chat", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/x-ndjson")
+
+	resp, err := d.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("ollama %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	out := make(chan providers.Event, 16)
+	go streamEvents(resp.Body, out)
+	return out, nil
+}
+
+// --- request marshalling ---
+//
+// /api/chat takes:
+//
+//	{
+//	  "model":   "llama3.1",
+//	  "stream":  true,
+//	  "messages":[
+//	    {"role":"system","content":"..."},
+//	    {"role":"user","content":"..."},
+//	    {"role":"assistant","content":"...","tool_calls":[...]},
+//	    {"role":"tool","content":"..."}            // result of a tool_use
+//	  ],
+//	  "tools":[ {"type":"function","function":{...}} ],
+//	  "options":{"temperature":..., "num_predict":...}
+//	}
+
+type wireRequest struct {
+	Model    string             `json:"model"`
+	Stream   bool               `json:"stream"`
+	Messages []wireMessage      `json:"messages"`
+	Tools    []wireTool         `json:"tools,omitempty"`
+	Options  *wireOptions       `json:"options,omitempty"`
+}
+
+type wireOptions struct {
+	Temperature *float64 `json:"temperature,omitempty"`
+	NumPredict  int      `json:"num_predict,omitempty"` // Ollama's name for max_tokens
+}
+
+type wireMessage struct {
+	Role      string         `json:"role"`
+	Content   string         `json:"content"`
+	ToolCalls []wireToolCall `json:"tool_calls,omitempty"`
+}
+
+type wireToolCall struct {
+	Function wireToolCallFn `json:"function"`
+}
+
+type wireToolCallFn struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"` // object, not string (unlike OpenAI)
+}
+
+type wireTool struct {
+	Type     string       `json:"type"`
+	Function wireFunction `json:"function"`
+}
+
+type wireFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+func buildRequestBody(req providers.Request) ([]byte, error) {
+	w := wireRequest{
+		Model:  req.Model,
+		Stream: true,
+	}
+
+	if req.Temperature != nil || req.MaxTokens > 0 {
+		w.Options = &wireOptions{Temperature: req.Temperature, NumPredict: req.MaxTokens}
+	}
+
+	// System blocks → one role:"system" message.
+	if len(req.System) > 0 {
+		var sys strings.Builder
+		for _, sb := range req.System {
+			if sys.Len() > 0 {
+				sys.WriteString("\n\n")
+			}
+			sys.WriteString(sb.Text)
+		}
+		w.Messages = append(w.Messages, wireMessage{Role: "system", Content: sys.String()})
+	}
+
+	for _, m := range req.Messages {
+		w.Messages = append(w.Messages, flattenMessage(m)...)
+	}
+
+	for _, t := range req.Tools {
+		w.Tools = append(w.Tools, wireTool{
+			Type: "function",
+			Function: wireFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+
+	return json.Marshal(w)
+}
+
+// flattenMessage maps one of our ContentBlock-union messages into one or more
+// Ollama wire messages. The split rules match OpenAI: assistant messages
+// combine text + tool_use blocks; tool_result blocks split into role:"tool".
+func flattenMessage(m providers.Message) []wireMessage {
+	if m.Role == "assistant" {
+		var text strings.Builder
+		var calls []wireToolCall
+		for _, c := range m.Content {
+			switch c.Type {
+			case "text":
+				text.WriteString(c.Text)
+			case "tool_use":
+				calls = append(calls, wireToolCall{
+					Function: wireToolCallFn{
+						Name:      c.ToolName,
+						Arguments: c.ToolInput,
+					},
+				})
+			}
+		}
+		return []wireMessage{{Role: "assistant", Content: text.String(), ToolCalls: calls}}
+	}
+
+	// user role: split tool_result into role:"tool" entries.
+	var out []wireMessage
+	var userText strings.Builder
+	for _, c := range m.Content {
+		switch c.Type {
+		case "tool_result":
+			out = append(out, wireMessage{Role: "tool", Content: c.Text})
+		case "text":
+			if userText.Len() > 0 {
+				userText.WriteString("\n")
+			}
+			userText.WriteString(c.Text)
+		}
+	}
+	if userText.Len() > 0 {
+		out = append([]wireMessage{{Role: "user", Content: userText.String()}}, out...)
+	}
+	return out
+}
+
+// --- streaming response parsing ---
+//
+// NDJSON frames look like:
+//
+//	{"model":"llama3.1","created_at":"...","message":{"role":"assistant","content":"hel"},"done":false}
+//	{"model":"llama3.1","created_at":"...","message":{"role":"assistant","content":"lo"},"done":false}
+//	{"model":"llama3.1","created_at":"...","message":{"role":"assistant","content":"","tool_calls":[...]},"done":true,"done_reason":"stop","prompt_eval_count":42,"eval_count":7}
+//
+// Ollama doesn't index-stream tool_calls (deltas) — they arrive whole on the
+// final or near-final line. So no accumulator is needed.
+
+type chunk struct {
+	Model     string  `json:"model"`
+	Message   message `json:"message"`
+	Done      bool    `json:"done"`
+	DoneReason string `json:"done_reason"`
+
+	// Usage fields (only present on the final "done":true frame).
+	PromptEvalCount int `json:"prompt_eval_count"`
+	EvalCount       int `json:"eval_count"`
+}
+
+type message struct {
+	Role      string         `json:"role"`
+	Content   string         `json:"content"`
+	ToolCalls []chunkToolCall `json:"tool_calls"`
+}
+
+type chunkToolCall struct {
+	Function chunkToolCallFn `json:"function"`
+}
+
+type chunkToolCallFn struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
+	defer body.Close()
+	defer close(out)
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+
+	var stopReason string
+	var usage *providers.Usage
+	var model string
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var c chunk
+		if err := json.Unmarshal(line, &c); err != nil {
+			continue
+		}
+		if model == "" && c.Model != "" {
+			model = c.Model
+		}
+
+		if c.Message.Content != "" {
+			out <- providers.Event{Type: providers.EventText, Text: c.Message.Content}
+		}
+		for _, tc := range c.Message.ToolCalls {
+			args := tc.Function.Arguments
+			if len(args) == 0 {
+				args = json.RawMessage("{}")
+			}
+			out <- providers.Event{
+				Type: providers.EventToolCall,
+				ToolUse: &providers.ToolUse{
+					ID:    "", // Ollama doesn't issue tool_call IDs; loop assigns one
+					Name:  tc.Function.Name,
+					Input: args,
+				},
+			}
+		}
+
+		if c.Done {
+			stopReason = mapStopReason(c.DoneReason, len(c.Message.ToolCalls) > 0)
+			if c.PromptEvalCount > 0 || c.EvalCount > 0 {
+				usage = &providers.Usage{
+					InputTokens:  c.PromptEvalCount,
+					OutputTokens: c.EvalCount,
+					Model:        model,
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		out <- providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()}
+		return
+	}
+
+	out <- providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage}
+}
+
+// mapStopReason translates Ollama's done_reason into our shared vocabulary.
+// Ollama uses "stop"/"length"; if any tool_calls were emitted on the final
+// frame, that's the equivalent of OpenAI's "tool_calls" finish_reason and we
+// surface "tool_use" so the loop runs another iteration.
+func mapStopReason(ollamaReason string, hadToolCalls bool) string {
+	if hadToolCalls {
+		return "tool_use"
+	}
+	switch ollamaReason {
+	case "stop", "":
+		return "end_turn"
+	case "length":
+		return "max_tokens"
+	default:
+		return ollamaReason
+	}
+}

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -1,0 +1,209 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// fakeStream serves a canned NDJSON script as one /api/chat response.
+func fakeStream(t *testing.T, frames []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/chat" {
+			t.Errorf("path = %q, want /api/chat", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(200)
+		for _, f := range frames {
+			fmt.Fprint(w, f)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+	}))
+}
+
+func TestStreamTextThenStop(t *testing.T) {
+	frames := []string{
+		`{"model":"llama3.1","message":{"role":"assistant","content":"hello "},"done":false}` + "\n",
+		`{"model":"llama3.1","message":{"role":"assistant","content":"world"},"done":false}` + "\n",
+		`{"model":"llama3.1","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":42,"eval_count":7}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "llama3.1",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var text strings.Builder
+	var done providers.Event
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventText:
+			text.WriteString(ev.Text)
+		case providers.EventDone:
+			done = ev
+		case providers.EventError:
+			t.Fatalf("unexpected error: %s", ev.Error)
+		}
+	}
+	if text.String() != "hello world" {
+		t.Errorf("text = %q, want %q", text.String(), "hello world")
+	}
+	if done.StopReason != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn (normalised from 'stop')", done.StopReason)
+	}
+	if done.Usage == nil || done.Usage.InputTokens != 42 || done.Usage.OutputTokens != 7 {
+		t.Errorf("usage = %+v", done.Usage)
+	}
+	if done.Usage.Model != "llama3.1" {
+		t.Errorf("usage.Model = %q, want llama3.1", done.Usage.Model)
+	}
+}
+
+func TestStreamToolCallOnFinalFrame(t *testing.T) {
+	// Ollama doesn't index-stream tool_calls — they ship complete on the
+	// frame where the model decides to invoke them (often the final one).
+	frames := []string{
+		`{"model":"llama3.1","message":{"role":"assistant","content":""},"done":false}` + "\n",
+		`{"model":"llama3.1","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"Read","arguments":{"path":"/tmp/x"}}}]},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":3}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
+
+	var toolCall *providers.ToolUse
+	var stop string
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			toolCall = ev.ToolUse
+		}
+		if ev.Type == providers.EventDone {
+			stop = ev.StopReason
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("no tool_call emitted")
+	}
+	if toolCall.Name != "Read" {
+		t.Errorf("tool: %+v", toolCall)
+	}
+	var input struct{ Path string }
+	if err := json.Unmarshal(toolCall.Input, &input); err != nil {
+		t.Fatalf("tool input json: %v (raw %s)", err, string(toolCall.Input))
+	}
+	if input.Path != "/tmp/x" {
+		t.Errorf("tool input path = %q", input.Path)
+	}
+	// Tool calls override done_reason to "tool_use" so the loop iterates.
+	if stop != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use (overridden because tool_calls present)", stop)
+	}
+}
+
+func TestRequestBodyShape(t *testing.T) {
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	temp := 0.7
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:       "llama3.1",
+		Temperature: &temp,
+		MaxTokens:   100,
+		System: []providers.ContentBlock{
+			{Type: "text", Text: "you are helpful"},
+		},
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []providers.ContentBlock{
+				{Type: "text", Text: "ok"},
+				{Type: "tool_use", ToolUseID: "call_1", ToolName: "Read", ToolInput: json.RawMessage(`{"path":"/x"}`)},
+			}},
+			{Role: "user", Content: []providers.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Text: "file contents"},
+			}},
+		},
+		Tools: []providers.ToolSpec{
+			{Name: "Read", Description: "read a file", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	body := string(captured)
+	if !strings.Contains(body, `"role":"system"`) || !strings.Contains(body, `"you are helpful"`) {
+		t.Errorf("system block missing/malformed:\n%s", body)
+	}
+	if !strings.Contains(body, `"tool_calls":[{"function":{"name":"Read","arguments":{"path":"/x"}}}]`) {
+		t.Errorf("assistant tool_calls missing/malformed:\n%s", body)
+	}
+	if !strings.Contains(body, `"role":"tool"`) || !strings.Contains(body, `"content":"file contents"`) {
+		t.Errorf("role:tool message missing:\n%s", body)
+	}
+	if !strings.Contains(body, `"temperature":0.7`) || !strings.Contains(body, `"num_predict":100`) {
+		t.Errorf("options.temperature/num_predict missing:\n%s", body)
+	}
+	if !strings.Contains(body, `"tools":[{"type":"function","function":{"name":"Read"`) {
+		t.Errorf("tools array missing/malformed:\n%s", body)
+	}
+}
+
+func TestNon200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+		fmt.Fprint(w, `{"error":"model not found"}`)
+	}))
+	defer srv.Close()
+	d := New(srv.URL, nil)
+	_, err := d.Call(context.Background(), providers.Request{Model: "nope"})
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error doesn't mention status code: %v", err)
+	}
+}
+
+func TestStopReasonWithoutToolCalls(t *testing.T) {
+	// done_reason "length" should map to max_tokens.
+	frames := []string{
+		`{"model":"llama3.1","message":{"role":"assistant","content":"truncated…"},"done":true,"done_reason":"length","prompt_eval_count":1,"eval_count":1}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
+	var stop string
+	for ev := range ch {
+		if ev.Type == providers.EventDone {
+			stop = ev.StopReason
+		}
+	}
+	if stop != "max_tokens" {
+		t.Errorf("stop_reason = %q, want max_tokens", stop)
+	}
+}

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
@@ -201,6 +203,44 @@ func TestRequestBodyShape(t *testing.T) {
 	if !strings.Contains(body, `"tools":[{"type":"function","function":{"name":"Read"`) {
 		t.Errorf("tools array missing/malformed:\n%s", body)
 	}
+}
+
+// Regression: cancelling ctx mid-stream must not leak the streaming goroutine
+// when nobody drains the channel. See the Anthropic driver test for the
+// rationale on why `runtime.Stack(all=true)` is the right signal here.
+func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		flusher := w.(http.Flusher)
+		for i := 0; i < 30; i++ {
+			fmt.Fprint(w, `{"model":"llama3.1","message":{"role":"assistant","content":"x"},"done":false}`+"\n")
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := New(srv.URL, nil)
+	_, err := d.Call(ctx, providers.Request{Model: "llama3.1"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	time.Sleep(300 * time.Millisecond)
+
+	if isStreamEventsRunning(t) {
+		t.Fatal("streamEvents goroutine still alive 300ms after ctx cancel — leaked")
+	}
+}
+
+func isStreamEventsRunning(t *testing.T) bool {
+	t.Helper()
+	buf := make([]byte, 64*1024)
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), ".streamEvents(")
 }
 
 func TestNon200Status(t *testing.T) {

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -116,6 +116,37 @@ func TestStreamToolCallOnFinalFrame(t *testing.T) {
 	}
 }
 
+// Regression: Ollama may emit tool_calls on a non-final frame and then a
+// separate done:true frame with no tool_calls. Stop reason must still be
+// "tool_use" so the agent loop runs the tool we already emitted.
+func TestStreamToolCallOnNonFinalFrame(t *testing.T) {
+	frames := []string{
+		`{"model":"llama3.1","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"Read","arguments":{"path":"/x"}}}]},"done":false}` + "\n",
+		`{"model":"llama3.1","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":3}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
+
+	var toolCalls int
+	var stop string
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			toolCalls++
+		}
+		if ev.Type == providers.EventDone {
+			stop = ev.StopReason
+		}
+	}
+	if toolCalls != 1 {
+		t.Errorf("got %d tool_calls, want 1", toolCalls)
+	}
+	if stop != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use (must persist across frames so the loop can run the tool emitted earlier)", stop)
+	}
+}
+
 func TestRequestBodyShape(t *testing.T) {
 	var captured []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -1,0 +1,405 @@
+// Package openai implements the Provider interface for OpenAI's Chat
+// Completions API. We picked Chat Completions over the newer Responses API
+// because (a) most OpenAI-compatible endpoints (vLLM, LiteLLM, Anyscale,
+// Together, ...) speak Chat Completions, not Responses, and (b) the Responses
+// API ships built-in tools (web_search, code_interpreter) that fight our
+// "we own the tool loop" stance — Chat Completions stays out of our way.
+package openai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+const (
+	defaultBaseURL = "https://api.openai.com/v1"
+	defaultTimeout = 5 * time.Minute
+)
+
+// Driver speaks Chat Completions.
+type Driver struct {
+	apiKey  string
+	baseURL string
+	http    *http.Client
+}
+
+// New constructs a Driver. baseURL may be empty for the default endpoint, or
+// set to any OpenAI-compatible base (e.g. "http://localhost:8000/v1" for vLLM).
+func New(apiKey, baseURL string, httpClient *http.Client) *Driver {
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient}
+}
+
+func (d *Driver) ID() string { return "openai" }
+
+func (d *Driver) Capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		NativePromptCache: false, // OpenAI auto-caches; no explicit knob like Anthropic
+		ParallelToolCalls: true,
+		Streaming:         true,
+		MaxContextTokens:  128_000, // gpt-4o family default; bigger on some
+		SupportsThinking:  false,
+	}
+}
+
+// Call sends the request and returns a channel of Events. The goroutine that
+// reads the response closes the channel when the stream ends.
+func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	body, err := buildRequestBody(req)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	if d.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+	}
+
+	resp, err := d.http.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("openai %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	out := make(chan providers.Event, 16)
+	go streamEvents(resp.Body, out)
+	return out, nil
+}
+
+// --- request marshalling ---
+//
+// Chat Completions message shapes:
+//
+//   { "role": "system",    "content": "..." }
+//   { "role": "user",      "content": "..." }
+//   { "role": "assistant", "content": "...", "tool_calls": [...] }
+//   { "role": "tool",      "tool_call_id": "...", "content": "..." }
+//
+// Our internal ContentBlock union flattens to these as follows:
+//   - Anthropic-style assistant message with tool_use blocks → role:"assistant"
+//     with the text concatenated into "content" and tool_use blocks lifted
+//     into "tool_calls".
+//   - tool_result blocks (which we encode in user-role messages) → split out
+//     into separate role:"tool" messages.
+
+type wireRequest struct {
+	Model       string        `json:"model"`
+	Messages    []wireMessage `json:"messages"`
+	Tools       []wireTool    `json:"tools,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Temperature *float64      `json:"temperature,omitempty"`
+	Stream      bool          `json:"stream"`
+
+	// stream_options.include_usage tells OpenAI to include final usage in the
+	// last data frame before [DONE]. Without this we have no token counts.
+	StreamOptions *wireStreamOptions `json:"stream_options,omitempty"`
+}
+
+type wireStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+type wireMessage struct {
+	Role       string         `json:"role"`
+	Content    string         `json:"content,omitempty"`
+	Name       string         `json:"name,omitempty"`
+	ToolCallID string         `json:"tool_call_id,omitempty"`
+	ToolCalls  []wireToolCall `json:"tool_calls,omitempty"`
+}
+
+type wireToolCall struct {
+	ID       string         `json:"id"`
+	Type     string         `json:"type"` // always "function"
+	Function wireToolCallFn `json:"function"`
+}
+
+type wireToolCallFn struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"` // JSON string, not a JSON object
+}
+
+type wireTool struct {
+	Type     string       `json:"type"` // "function"
+	Function wireFunction `json:"function"`
+}
+
+type wireFunction struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Parameters  json.RawMessage `json:"parameters"`
+}
+
+func buildRequestBody(req providers.Request) ([]byte, error) {
+	w := wireRequest{
+		Model:       req.Model,
+		MaxTokens:   req.MaxTokens,
+		Temperature: req.Temperature,
+		Stream:      true,
+		StreamOptions: &wireStreamOptions{IncludeUsage: true},
+	}
+
+	// System blocks become a single role:"system" message at the top.
+	// Cacheable hint is dropped — OpenAI auto-caches and gives no API knob.
+	if len(req.System) > 0 {
+		var sysText strings.Builder
+		for _, sb := range req.System {
+			if sysText.Len() > 0 {
+				sysText.WriteString("\n\n")
+			}
+			sysText.WriteString(sb.Text)
+		}
+		w.Messages = append(w.Messages, wireMessage{Role: "system", Content: sysText.String()})
+	}
+
+	for _, m := range req.Messages {
+		w.Messages = append(w.Messages, flattenMessage(m)...)
+	}
+
+	for _, t := range req.Tools {
+		w.Tools = append(w.Tools, wireTool{
+			Type: "function",
+			Function: wireFunction{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+
+	return json.Marshal(w)
+}
+
+// flattenMessage maps one of our ContentBlock-union messages into one or more
+// Chat Completions wire messages. The split is needed because:
+//   - Assistant messages combine text + tool_use blocks (one wire message).
+//   - User messages may carry tool_result blocks; each tool_result becomes
+//     its own role:"tool" wire message, and any non-tool_result text blocks
+//     stay in the original user message.
+func flattenMessage(m providers.Message) []wireMessage {
+	if m.Role == "assistant" {
+		var text strings.Builder
+		var calls []wireToolCall
+		for _, c := range m.Content {
+			switch c.Type {
+			case "text":
+				text.WriteString(c.Text)
+			case "tool_use":
+				calls = append(calls, wireToolCall{
+					ID:   c.ToolUseID,
+					Type: "function",
+					Function: wireToolCallFn{
+						Name:      c.ToolName,
+						Arguments: string(c.ToolInput),
+					},
+				})
+			}
+		}
+		return []wireMessage{{Role: "assistant", Content: text.String(), ToolCalls: calls}}
+	}
+
+	// user role: split tool_result blocks into their own messages.
+	var out []wireMessage
+	var userText strings.Builder
+	for _, c := range m.Content {
+		switch c.Type {
+		case "tool_result":
+			out = append(out, wireMessage{
+				Role:       "tool",
+				ToolCallID: c.ToolUseID,
+				Content:    c.Text,
+			})
+		case "text":
+			if userText.Len() > 0 {
+				userText.WriteString("\n")
+			}
+			userText.WriteString(c.Text)
+		}
+	}
+	if userText.Len() > 0 {
+		// Plain user text comes first; tool messages follow.
+		out = append([]wireMessage{{Role: "user", Content: userText.String()}}, out...)
+	}
+	return out
+}
+
+// --- streaming response parsing ---
+//
+// Chat Completions SSE frames look like:
+//   data: {"choices":[{"delta":{"content":"..."}}]}\n\n
+//   data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"...","function":{...}}]}}]}\n\n
+//   data: [DONE]\n\n
+//
+// Tool calls stream by index: the first delta for an index has the id +
+// function.name, subsequent deltas only fill in function.arguments piecewise.
+// We accumulate into toolAcc[index] and emit one EventToolCall per index when
+// streaming completes.
+
+type chunkDelta struct {
+	Content   string             `json:"content"`
+	ToolCalls []chunkToolCallDel `json:"tool_calls"`
+}
+
+type chunkToolCallDel struct {
+	Index    int            `json:"index"`
+	ID       string         `json:"id"`
+	Type     string         `json:"type"`
+	Function chunkFunctionD `json:"function"`
+}
+
+type chunkFunctionD struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type chunk struct {
+	Choices []struct {
+		Delta        chunkDelta `json:"delta"`
+		FinishReason string     `json:"finish_reason"`
+	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+		// gpt-4o-mini and later expose cached prompt tokens here:
+		PromptTokensDetails *struct {
+			CachedTokens int `json:"cached_tokens"`
+		} `json:"prompt_tokens_details"`
+	} `json:"usage"`
+}
+
+// toolAccumulator buffers a streaming tool_call.
+type toolAccumulator struct {
+	id   string
+	name string
+	args strings.Builder
+}
+
+func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
+	defer body.Close()
+	defer close(out)
+
+	scanner := bufio.NewScanner(body)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	tools := map[int]*toolAccumulator{}
+	var stopReason string
+	var usage *providers.Usage
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 || !bytes.HasPrefix(line, []byte("data:")) {
+			continue
+		}
+		payload := bytes.TrimSpace(line[len("data:"):])
+		if string(payload) == "[DONE]" {
+			break
+		}
+
+		var c chunk
+		if err := json.Unmarshal(payload, &c); err != nil {
+			continue // skip malformed frames; final usage frame may be malformed in cancelled streams
+		}
+
+		for _, ch := range c.Choices {
+			if ch.Delta.Content != "" {
+				out <- providers.Event{Type: providers.EventText, Text: ch.Delta.Content}
+			}
+			for _, tc := range ch.Delta.ToolCalls {
+				acc, ok := tools[tc.Index]
+				if !ok {
+					acc = &toolAccumulator{}
+					tools[tc.Index] = acc
+				}
+				if tc.ID != "" {
+					acc.id = tc.ID
+				}
+				if tc.Function.Name != "" {
+					acc.name = tc.Function.Name
+				}
+				if tc.Function.Arguments != "" {
+					acc.args.WriteString(tc.Function.Arguments)
+				}
+			}
+			if ch.FinishReason != "" {
+				stopReason = mapStopReason(ch.FinishReason)
+			}
+		}
+
+		if c.Usage != nil {
+			u := &providers.Usage{
+				InputTokens:  c.Usage.PromptTokens,
+				OutputTokens: c.Usage.CompletionTokens,
+			}
+			if c.Usage.PromptTokensDetails != nil {
+				u.CacheReadTokens = c.Usage.PromptTokensDetails.CachedTokens
+			}
+			usage = u
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		out <- providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()}
+		return
+	}
+
+	// Emit accumulated tool calls in index order before the done event.
+	for i := 0; i < len(tools); i++ {
+		acc, ok := tools[i]
+		if !ok {
+			continue
+		}
+		args := acc.args.String()
+		if args == "" {
+			args = "{}"
+		}
+		out <- providers.Event{
+			Type: providers.EventToolCall,
+			ToolUse: &providers.ToolUse{
+				ID:    acc.id,
+				Name:  acc.name,
+				Input: json.RawMessage(args),
+			},
+		}
+	}
+
+	out <- providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage}
+}
+
+// mapStopReason translates OpenAI's finish_reason vocabulary into our shared
+// vocabulary. Both sides have "stop"/"end_turn", "tool_calls"/"tool_use", and
+// "length"/"max_tokens"; we normalise on the Anthropic spelling because the
+// agent loop already branches on that.
+func mapStopReason(openaiReason string) string {
+	switch openaiReason {
+	case "stop":
+		return "end_turn"
+	case "tool_calls":
+		return "tool_use"
+	case "length":
+		return "max_tokens"
+	default:
+		return openaiReason
+	}
+}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -87,7 +87,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 
 	out := make(chan providers.Event, 16)
-	go streamEvents(resp.Body, out)
+	go streamEvents(ctx, resp.Body, out)
 	return out, nil
 }
 
@@ -298,9 +298,21 @@ type toolAccumulator struct {
 	args strings.Builder
 }
 
-func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
 	defer body.Close()
 	defer close(out)
+
+	// send respects ctx so a cancelled request doesn't leak this goroutine on
+	// a full unread channel. Returns false if ctx ended; callers should return
+	// immediately so defer close(out) fires and the consumer's range exits.
+	send := func(ev providers.Event) bool {
+		select {
+		case out <- ev:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
@@ -326,7 +338,9 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 
 		for _, ch := range c.Choices {
 			if ch.Delta.Content != "" {
-				out <- providers.Event{Type: providers.EventText, Text: ch.Delta.Content}
+				if !send(providers.Event{Type: providers.EventText, Text: ch.Delta.Content}) {
+					return
+				}
 			}
 			for _, tc := range ch.Delta.ToolCalls {
 				acc, ok := tools[tc.Index]
@@ -361,7 +375,7 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		out <- providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()}
+		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
 		return
 	}
 
@@ -380,17 +394,19 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 		if args == "" {
 			args = "{}"
 		}
-		out <- providers.Event{
+		if !send(providers.Event{
 			Type: providers.EventToolCall,
 			ToolUse: &providers.ToolUse{
 				ID:    acc.id,
 				Name:  acc.name,
 				Input: json.RawMessage(args),
 			},
+		}) {
+			return
 		}
 	}
 
-	out <- providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage}
+	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
 }
 
 // mapStopReason translates OpenAI's finish_reason vocabulary into our shared

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -365,11 +366,16 @@ func streamEvents(body io.ReadCloser, out chan<- providers.Event) {
 	}
 
 	// Emit accumulated tool calls in index order before the done event.
-	for i := 0; i < len(tools); i++ {
-		acc, ok := tools[i]
-		if !ok {
-			continue
-		}
+	// Indices may be non-contiguous (e.g. 0, 2 with a gap at 1) — legal per
+	// the OpenAI spec — so we sort the actual keys rather than iterating
+	// 0..len(tools), which would silently drop any index >= len(tools).
+	indices := make([]int, 0, len(tools))
+	for i := range tools {
+		indices = append(indices, i)
+	}
+	sort.Ints(indices)
+	for _, i := range indices {
+		acc := tools[i]
 		args := acc.args.String()
 		if args == "" {
 			args = "{}"

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -1,0 +1,226 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// fakeStream serves a canned SSE script as one Chat Completions response.
+func fakeStream(t *testing.T, frames []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization header = %q, want %q", got, "Bearer test-key")
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		for _, f := range frames {
+			fmt.Fprint(w, f)
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+	}))
+}
+
+func TestStreamTextThenStop(t *testing.T) {
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"hello "}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"world"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":10}}}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "gpt-4o-mini",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var text strings.Builder
+	var done providers.Event
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventText:
+			text.WriteString(ev.Text)
+		case providers.EventDone:
+			done = ev
+		case providers.EventError:
+			t.Fatalf("unexpected error: %s", ev.Error)
+		}
+	}
+	if text.String() != "hello world" {
+		t.Errorf("text = %q, want %q", text.String(), "hello world")
+	}
+	if done.StopReason != "end_turn" {
+		t.Errorf("stop_reason = %q, want end_turn (normalised from 'stop')", done.StopReason)
+	}
+	if done.Usage == nil || done.Usage.InputTokens != 42 || done.Usage.OutputTokens != 7 {
+		t.Errorf("usage = %+v", done.Usage)
+	}
+	if done.Usage.CacheReadTokens != 10 {
+		t.Errorf("cache_read_tokens = %d, want 10", done.Usage.CacheReadTokens)
+	}
+}
+
+func TestStreamToolCallAccumulation(t *testing.T) {
+	// First delta carries id + function.name; subsequent deltas dribble out
+	// the JSON arguments piecewise. Verify we accumulate into one tool_call.
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"Read","arguments":""}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"path\":"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"/tmp/x\"}"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		`data: {"choices":[],"usage":{"prompt_tokens":10,"completion_tokens":3}}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "gpt-4o-mini"})
+
+	var toolCall *providers.ToolUse
+	var stop string
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			toolCall = ev.ToolUse
+		}
+		if ev.Type == providers.EventDone {
+			stop = ev.StopReason
+		}
+	}
+	if toolCall == nil {
+		t.Fatal("no tool_call emitted")
+	}
+	if toolCall.ID != "call_1" || toolCall.Name != "Read" {
+		t.Errorf("tool: %+v", toolCall)
+	}
+	var input struct{ Path string }
+	if err := json.Unmarshal(toolCall.Input, &input); err != nil {
+		t.Fatalf("tool input json: %v (raw %s)", err, string(toolCall.Input))
+	}
+	if input.Path != "/tmp/x" {
+		t.Errorf("tool input path = %q", input.Path)
+	}
+	if stop != "tool_use" {
+		t.Errorf("stop_reason = %q, want tool_use (normalised from 'tool_calls')", stop)
+	}
+}
+
+func TestStreamMultipleToolCalls(t *testing.T) {
+	// Two tool_calls in parallel (index 0 and 1), interleaved deltas.
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[` +
+			`{"index":0,"id":"call_a","type":"function","function":{"name":"Read","arguments":"{}"}},` +
+			`{"index":1,"id":"call_b","type":"function","function":{"name":"Write","arguments":"{\"x\":1}"}}` +
+			`]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New("test-key", srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
+
+	var got []providers.ToolUse
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			got = append(got, *ev.ToolUse)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d tool_calls, want 2", len(got))
+	}
+	if got[0].ID != "call_a" || got[0].Name != "Read" {
+		t.Errorf("tool 0: %+v", got[0])
+	}
+	if got[1].ID != "call_b" || got[1].Name != "Write" {
+		t.Errorf("tool 1: %+v", got[1])
+	}
+}
+
+func TestRequestBodyShape(t *testing.T) {
+	// Verify the request marshalling: system block flattened, tool_use →
+	// tool_calls on assistant message, tool_result → role:"tool" message.
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model: "gpt-4o-mini",
+		System: []providers.ContentBlock{
+			{Type: "text", Text: "you are helpful", Cacheable: true},
+		},
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []providers.ContentBlock{
+				{Type: "text", Text: "ok"},
+				{Type: "tool_use", ToolUseID: "call_1", ToolName: "Read", ToolInput: json.RawMessage(`{"path":"/x"}`)},
+			}},
+			{Role: "user", Content: []providers.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Text: "file contents"},
+			}},
+		},
+		Tools: []providers.ToolSpec{
+			{Name: "Read", Description: "read a file", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	body := string(captured)
+	if !strings.Contains(body, `"role":"system"`) || !strings.Contains(body, `"you are helpful"`) {
+		t.Errorf("system block missing/malformed:\n%s", body)
+	}
+	if !strings.Contains(body, `"tool_calls":[{"id":"call_1","type":"function","function":{"name":"Read"`) {
+		t.Errorf("assistant tool_calls missing/malformed:\n%s", body)
+	}
+	if !strings.Contains(body, `"role":"tool"`) || !strings.Contains(body, `"tool_call_id":"call_1"`) {
+		t.Errorf("role:tool message missing:\n%s", body)
+	}
+	if !strings.Contains(body, `"include_usage":true`) {
+		t.Errorf("stream_options.include_usage missing — usage tokens won't arrive:\n%s", body)
+	}
+	if !strings.Contains(body, `"tools":[{"type":"function","function":{"name":"Read"`) {
+		t.Errorf("tools array missing/malformed:\n%s", body)
+	}
+}
+
+func TestNon200Status(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		fmt.Fprint(w, `{"error":{"message":"invalid api key"}}`)
+	}))
+	defer srv.Close()
+	d := New("bad-key", srv.URL, nil)
+	_, err := d.Call(context.Background(), providers.Request{Model: "x"})
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error doesn't mention status code: %v", err)
+	}
+}

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -154,6 +154,41 @@ func TestStreamMultipleToolCalls(t *testing.T) {
 	}
 }
 
+// Regression: OpenAI may emit tool_calls at non-contiguous indices (e.g.
+// 0 and 2 with a gap at 1). The accumulator must surface every present
+// index in sorted order, not iterate 0..len(map) and drop anything past
+// len.
+func TestStreamToolCallNonContiguousIndices(t *testing.T) {
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[` +
+			`{"index":0,"id":"call_a","type":"function","function":{"name":"Read","arguments":"{}"}},` +
+			`{"index":2,"id":"call_c","type":"function","function":{"name":"Write","arguments":"{\"k\":1}"}}` +
+			`]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New("test-key", srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
+
+	var got []providers.ToolUse
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			got = append(got, *ev.ToolUse)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d tool_calls, want 2 (indices 0 and 2 must both be emitted despite the gap)", len(got))
+	}
+	if got[0].ID != "call_a" || got[0].Name != "Read" {
+		t.Errorf("tool 0: %+v", got[0])
+	}
+	if got[1].ID != "call_c" || got[1].Name != "Write" {
+		t.Errorf("tool 1 (was at index 2): %+v", got[1])
+	}
+}
+
 func TestRequestBodyShape(t *testing.T) {
 	// Verify the request marshalling: system block flattened, tool_use →
 	// tool_calls on assistant message, tool_result → role:"tool" message.

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
@@ -242,6 +244,46 @@ func TestRequestBodyShape(t *testing.T) {
 	if !strings.Contains(body, `"tools":[{"type":"function","function":{"name":"Read"`) {
 		t.Errorf("tools array missing/malformed:\n%s", body)
 	}
+}
+
+// Regression: cancelling ctx mid-stream must not leak the streaming goroutine
+// when nobody drains the channel. See the Anthropic driver test for the
+// rationale on why `runtime.Stack(all=true)` is the right signal here (a
+// "wait for channel close" test would silently pass under the bug because
+// any drain unblocks the stuck producer).
+func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		for i := 0; i < 30; i++ {
+			fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"x"}}]}`+"\n\n")
+			flusher.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	d := New("test-key", srv.URL, nil)
+	_, err := d.Call(ctx, providers.Request{Model: "x"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	time.Sleep(300 * time.Millisecond)
+
+	if isStreamEventsRunning(t) {
+		t.Fatal("streamEvents goroutine still alive 300ms after ctx cancel — leaked")
+	}
+}
+
+func isStreamEventsRunning(t *testing.T) bool {
+	t.Helper()
+	buf := make([]byte, 64*1024)
+	n := runtime.Stack(buf, true)
+	return strings.Contains(string(buf[:n]), ".streamEvents(")
 }
 
 func TestNon200Status(t *testing.T) {

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -7,9 +7,10 @@ defaults:
   model: claude-sonnet-4-6
 
 models:
-  cheap: { provider: anthropic, model: claude-haiku-4-5 }
-  smart: { provider: anthropic, model: claude-opus-4-7 }
-  # local: { provider: ollama, model: llama3.1:8b }   # v0.1 stub
+  cheap:  { provider: anthropic, model: claude-haiku-4-5 }
+  smart:  { provider: anthropic, model: claude-opus-4-7 }
+  gpt:    { provider: openai,    model: gpt-4o-mini }
+  local:  { provider: ollama,    model: llama3.1:8b }     # tool-tuned model
 
 agents:
   default:


### PR DESCRIPTION
## Summary

- Adds OpenAI Chat Completions and Ollama `/api/chat` driver implementations of the `providers.Provider` interface, completing the v0.1 multi-provider story (Anthropic + OpenAI + Ollama).
- Validates that the `Provider` interface defined in v0.1 is genuinely provider-neutral by exercising it against two new wire formats (SSE-without-event-names for OpenAI, NDJSON for Ollama) and three different tool-call models — without touching `internal/loop/loop.go`.
- Pushes stop-reason vocabulary normalisation down into each driver (`stop`/`tool_calls`/`length` → `end_turn`/`tool_use`/`max_tokens`) so the agent loop stays one branch on `iterStop`.

## What's in the diff

- `internal/providers/openai/driver.go` (+405) + `driver_test.go` (+226) — index-keyed tool_call accumulator, `[DONE]` sentinel, `stream_options.include_usage` to surface token counts.
- `internal/providers/ollama/driver.go` (+349) + `driver_test.go` (+209) — NDJSON streaming, tool_calls passed through verbatim from tool-tuned models. Non-tuned models silently no-op (documented).
- `cmd/loomcycle/main.go` — providerResolver now constructs both drivers when env vars are set; errors deferred to first-use, not startup.
- `loomcycle.example.yaml` adds `gpt` (gpt-4o-mini) and `local` (llama3.1:8b) model aliases.
- README + `docs/ARCHITECTURE.md` reflect both drivers as landed.

## Test plan

- [x] `go test ./...` — all 8 packages pass (3 new test files, 10 new test cases, all from clean cache)
- [x] `go vet ./...` — clean
- [x] `go build -o bin/loomcycle ./cmd/loomcycle` — clean, single binary
- [x] Smoke: binary boots with no provider env vars set, `/healthz` returns `{"ok":true}`
- [ ] End-to-end live test against real OpenAI endpoint (gated; do once before merging)
- [ ] End-to-end live test against local Ollama with a tool-tuned model (e.g. llama3.1:8b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)