### PR TITLE
phase_0_3 part 2: MCP stdio + HTTP transports + pool + per-server allowed_tools

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"syscall"
 	"time"
 
@@ -72,9 +73,16 @@ func main() {
 			if srv.Transport != "stdio" {
 				return nil, fmt.Errorf("mcp_servers.%s: transport %q not supported in this build (only stdio for now)", name, srv.Transport)
 			}
-			env := make([]string, 0, len(srv.Env))
-			for k, v := range srv.Env {
-				env = append(env, k+"="+v)
+			// Sort env keys so process listings and logs are deterministic
+			// across runs — Go map iteration is randomised.
+			keys := make([]string, 0, len(srv.Env))
+			for k := range srv.Env {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			env := make([]string, 0, len(keys))
+			for _, k := range keys {
+				env = append(env, k+"="+srv.Env[k])
 			}
 			return mcpstdio.Spawn(mcpstdio.Config{
 				Command: srv.Command,

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -28,6 +28,8 @@ import (
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
 )
 
 func main() {
@@ -50,12 +52,62 @@ func main() {
 	// The Read tool is sandboxed: it refuses every call when Root is empty.
 	// Operators must set LOOMCYCLE_READ_ROOT explicitly to enable it (no
 	// silent default — the wrong default would leak file contents).
-	builtins := []tools.Tool{
+	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")
 	}
+
+	// MCP: spawn declared stdio servers, discover their tools, register
+	// each as `mcp__{server}__{tool}` alongside the built-ins. Failures
+	// to spawn or handshake are logged and the server is skipped — the
+	// other servers still come up.
+	mcpPool := mcp.NewPool(
+		func(name string) (mcp.Caller, error) {
+			srv, ok := cfg.MCPServers[name]
+			if !ok {
+				return nil, fmt.Errorf("mcp_servers.%s: not in config", name)
+			}
+			if srv.Transport != "stdio" {
+				return nil, fmt.Errorf("mcp_servers.%s: transport %q not supported in this build (only stdio for now)", name, srv.Transport)
+			}
+			env := make([]string, 0, len(srv.Env))
+			for k, v := range srv.Env {
+				env = append(env, k+"="+v)
+			}
+			return mcpstdio.Spawn(mcpstdio.Config{
+				Command: srv.Command,
+				Args:    srv.Args,
+				Env:     env,
+				OnStderr: func(line string) {
+					log.Printf("mcp[%s]: %s", name, line)
+				},
+			})
+		},
+		func(c mcp.Caller) {
+			if cl, ok := c.(*mcpstdio.Client); ok {
+				_ = cl.Close()
+			}
+		},
+	)
+	defer mcpPool.Close()
+
+	for name, srv := range cfg.MCPServers {
+		if srv.Transport != "stdio" {
+			log.Printf("mcp[%s]: skipped (transport %q not yet supported)", name, srv.Transport)
+			continue
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		_, descs, err := mcpPool.Get(ctx, name)
+		cancel()
+		if err != nil {
+			log.Printf("mcp[%s]: skipped — %v", name, err)
+			continue
+		}
+		log.Printf("mcp[%s]: ready, %d tools registered", name, len(descs))
+	}
+	allTools = append(allTools, mcpPool.Tools()...)
 
 	// Storage: open SQLite under DataDir. We could no-op when DataDir is
 	// unset, but that would silently disable the transcript/continuation
@@ -72,7 +124,7 @@ func main() {
 	log.Printf("store: sqlite at %s", dbPath)
 
 	var storeIface store.Store = st
-	srv := lchttp.New(cfg, pr, builtins, sem, storeIface)
+	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
 	httpServer := &http.Server{
 		Addr:              cfg.Env.ListenAddr,
 		Handler:           srv.Mux(),

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	mcphttp "github.com/denn-gubsky/loomcycle/internal/tools/mcp/http"
 	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
 )
 
@@ -60,52 +61,41 @@ func main() {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")
 	}
 
-	// MCP: spawn declared stdio servers, discover their tools, register
-	// each as `mcp__{server}__{tool}` alongside the built-ins. Failures
-	// to spawn or handshake are logged and the server is skipped — the
-	// other servers still come up.
+	// MCP: spawn declared servers (stdio or http), discover their tools,
+	// register each as `mcp__{server}__{tool}` alongside the built-ins.
+	// Failures to spawn or handshake are logged and the server is skipped —
+	// the other servers still come up.
 	mcpPool := mcp.NewPool(
 		func(name string) (mcp.Caller, error) {
 			srv, ok := cfg.MCPServers[name]
 			if !ok {
 				return nil, fmt.Errorf("mcp_servers.%s: not in config", name)
 			}
-			if srv.Transport != "stdio" {
-				return nil, fmt.Errorf("mcp_servers.%s: transport %q not supported in this build (only stdio for now)", name, srv.Transport)
+			switch srv.Transport {
+			case "stdio":
+				return spawnStdioMCP(name, srv)
+			case "http":
+				return mcphttp.New(mcphttp.Config{
+					URL:     srv.URL,
+					Headers: srv.Headers,
+				})
+			default:
+				return nil, fmt.Errorf("mcp_servers.%s: unknown transport %q", name, srv.Transport)
 			}
-			// Sort env keys so process listings and logs are deterministic
-			// across runs — Go map iteration is randomised.
-			keys := make([]string, 0, len(srv.Env))
-			for k := range srv.Env {
-				keys = append(keys, k)
-			}
-			sort.Strings(keys)
-			env := make([]string, 0, len(keys))
-			for _, k := range keys {
-				env = append(env, k+"="+srv.Env[k])
-			}
-			return mcpstdio.Spawn(mcpstdio.Config{
-				Command: srv.Command,
-				Args:    srv.Args,
-				Env:     env,
-				OnStderr: func(line string) {
-					log.Printf("mcp[%s]: %s", name, line)
-				},
-			})
 		},
 		func(c mcp.Caller) {
-			if cl, ok := c.(*mcpstdio.Client); ok {
+			// Both transports implement io.Closer-shaped Close() error.
+			type closer interface{ Close() error }
+			if cl, ok := c.(closer); ok {
 				_ = cl.Close()
 			}
 		},
 	)
 	defer mcpPool.Close()
 
+	// Initialise each server, apply per-server allowed_tools filter, and
+	// register the resulting tools alongside the built-ins.
 	for name, srv := range cfg.MCPServers {
-		if srv.Transport != "stdio" {
-			log.Printf("mcp[%s]: skipped (transport %q not yet supported)", name, srv.Transport)
-			continue
-		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		_, descs, err := mcpPool.Get(ctx, name)
 		cancel()
@@ -113,9 +103,13 @@ func main() {
 			log.Printf("mcp[%s]: skipped — %v", name, err)
 			continue
 		}
-		log.Printf("mcp[%s]: ready, %d tools registered", name, len(descs))
+		filtered := applyAllowedToolsFilter(descs, srv.AllowedTools)
+		for _, d := range filtered {
+			allTools = append(allTools, mcp.NewTool(mcpPool, name, d))
+		}
+		log.Printf("mcp[%s]: ready, %d/%d tools registered (transport=%s)",
+			name, len(filtered), len(descs), srv.Transport)
 	}
-	allTools = append(allTools, mcpPool.Tools()...)
 
 	// Storage: open SQLite under DataDir. We could no-op when DataDir is
 	// unset, but that would silently disable the transcript/continuation
@@ -206,4 +200,46 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 	default:
 		return nil, fmt.Errorf("unknown provider %q", id)
 	}
+}
+
+// spawnStdioMCP starts a stdio MCP child for one server entry. Env keys are
+// sorted so process listings are deterministic across runs.
+func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {
+	keys := make([]string, 0, len(srv.Env))
+	for k := range srv.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	env := make([]string, 0, len(keys))
+	for _, k := range keys {
+		env = append(env, k+"="+srv.Env[k])
+	}
+	return mcpstdio.Spawn(mcpstdio.Config{
+		Command: srv.Command,
+		Args:    srv.Args,
+		Env:     env,
+		OnStderr: func(line string) {
+			log.Printf("mcp[%s]: %s", name, line)
+		},
+	})
+}
+
+// applyAllowedToolsFilter narrows a server's discovered tool descriptors
+// to the operator-permitted subset. Empty allowed = pass-through (default
+// behaviour: expose every tool the server advertises).
+func applyAllowedToolsFilter(descs []mcp.ToolDescriptor, allowed []string) []mcp.ToolDescriptor {
+	if len(allowed) == 0 {
+		return descs
+	}
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowSet[name] = struct{}{}
+	}
+	out := make([]mcp.ToolDescriptor, 0, len(descs))
+	for _, d := range descs {
+		if _, ok := allowSet[d.Name]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
 }

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -84,21 +84,33 @@ func main() {
 			}
 		},
 		func(c mcp.Caller) {
-			// Both transports implement io.Closer-shaped Close() error.
+			// Both stdio.Client and http.Client implement Close() error.
+			// A future transport that doesn't gets logged so the leak is
+			// at least visible to operators.
 			type closer interface{ Close() error }
-			if cl, ok := c.(closer); ok {
-				_ = cl.Close()
+			cl, ok := c.(closer)
+			if !ok {
+				log.Printf("mcp pool: teardown skipped (%T does not implement Close)", c)
+				return
 			}
+			_ = cl.Close()
 		},
 	)
 	defer mcpPool.Close()
 
 	// Initialise each server, apply per-server allowed_tools filter, and
 	// register the resulting tools alongside the built-ins.
+	//
+	// Budget: 30s SHARED across all servers, not per-server. With many
+	// servers configured, per-server timeouts can serially stack up past
+	// K8s liveness/readiness deadlines and put the pod in a restart loop
+	// before /healthz ever serves once. A shared ctx caps total startup
+	// blocking; remaining servers after the budget exits are skipped with
+	// a clear log line — they can be retried on demand via the lazy
+	// pool resolution path on the first agent run that needs them.
+	mcpInitCtx, mcpInitCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	for name, srv := range cfg.MCPServers {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		_, descs, err := mcpPool.Get(ctx, name)
-		cancel()
+		_, descs, err := mcpPool.Get(mcpInitCtx, name)
 		if err != nil {
 			log.Printf("mcp[%s]: skipped — %v", name, err)
 			continue
@@ -110,6 +122,7 @@ func main() {
 		log.Printf("mcp[%s]: ready, %d/%d tools registered (transport=%s)",
 			name, len(filtered), len(descs), srv.Transport)
 	}
+	mcpInitCancel()
 
 	// Storage: open SQLite under DataDir. We could no-op when DataDir is
 	// unset, but that would silently disable the transcript/continuation

--- a/cmd/loomcycle/main_test.go
+++ b/cmd/loomcycle/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+func TestApplyAllowedToolsFilter(t *testing.T) {
+	descs := []mcp.ToolDescriptor{
+		{Name: "search"},
+		{Name: "fetch"},
+		{Name: "summarise"},
+	}
+
+	tests := []struct {
+		name    string
+		allowed []string
+		want    []string // tool names
+	}{
+		{
+			name:    "empty allowed = pass through",
+			allowed: nil,
+			want:    []string{"search", "fetch", "summarise"},
+		},
+		{
+			name:    "exact match keeps named tools",
+			allowed: []string{"search", "fetch"},
+			want:    []string{"search", "fetch"},
+		},
+		{
+			name:    "non-matching name dropped",
+			allowed: []string{"nonexistent"},
+			want:    []string{},
+		},
+		{
+			name:    "duplicate in allowed is harmless",
+			allowed: []string{"search", "search"},
+			want:    []string{"search"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyAllowedToolsFilter(descs, tc.allowed)
+			gotNames := make([]string, 0, len(got))
+			for _, d := range got {
+				gotNames = append(gotNames, d.Name)
+			}
+			if len(gotNames) == 0 {
+				gotNames = []string{} // normalise nil vs empty
+			}
+			if !reflect.DeepEqual(gotNames, tc.want) {
+				t.Errorf("got %v, want %v", gotNames, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,11 +47,17 @@ type AgentDef struct {
 // MCPServer declares one MCP server. Transport "stdio" or "http".
 type MCPServer struct {
 	Transport string            `yaml:"transport"`
-	Command   string            `yaml:"command"`
-	Args      []string          `yaml:"args"`
-	Env       map[string]string `yaml:"env"`
-	URL       string            `yaml:"url"`
+	Command   string            `yaml:"command"` // stdio
+	Args      []string          `yaml:"args"`    // stdio
+	Env       map[string]string `yaml:"env"`     // stdio
+	URL       string            `yaml:"url"`     // http
+	Headers   map[string]string `yaml:"headers"` // http
 	PoolSize  int               `yaml:"pool_size"`
+	// AllowedTools narrows which of the server's discovered tools are
+	// exposed to agents. Empty (default) = expose every tool the server
+	// advertises via tools/list. Use this to opt out of expensive or
+	// unwanted tools without forking the MCP server itself.
+	AllowedTools []string `yaml:"allowed_tools"`
 }
 
 // Concurrency caps for the runtime.

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -1,0 +1,206 @@
+// Package http implements an MCP transport over HTTP. v0.3 supports the
+// "single POST → JSON response" path of the MCP streamable-HTTP spec —
+// enough for tool dispatch but not for server-pushed notifications. SSE
+// upgrade can be added later without changing the Caller surface.
+//
+// Per-session state is held in the Mcp-Session-Id header the server
+// hands out on the initialize response. The Client stores it after the
+// first successful Call and attaches it to subsequent requests
+// (including notifications). If the server invalidates a session it
+// returns 404 with a JSON-RPC error; the Client surfaces that and the
+// pool's Healthy check evicts the entry.
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+const (
+	defaultTimeout = 5 * time.Minute
+	// sessionHeader is the MCP streamable-HTTP session correlator.
+	sessionHeader = "Mcp-Session-Id"
+)
+
+// Config configures an HTTP MCP client.
+type Config struct {
+	// URL is the absolute endpoint, e.g. "https://mcp.example.com/v1".
+	URL string
+	// Headers are added to every request. Useful for Authorization tokens
+	// per-tenant when the operator deploys a multi-tenant MCP server.
+	Headers map[string]string
+	// HTTPClient overrides the default. Tests pass an httptest-driven
+	// client; production passes nil to use the package default.
+	HTTPClient *http.Client
+}
+
+// Client speaks MCP over HTTP. Implements mcp.Caller.
+type Client struct {
+	url     string
+	headers map[string]string
+	http    *http.Client
+
+	ids  mcp.IDGenerator
+	dead atomic.Bool // set to true on session invalidation; Healthy returns false
+
+	sessMu    sync.Mutex
+	sessionID string // populated after first response that carries one
+}
+
+// New constructs a Client. URL must be absolute.
+func New(cfg Config) (*Client, error) {
+	if cfg.URL == "" {
+		return nil, errors.New("mcp http: URL is required")
+	}
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: defaultTimeout}
+	}
+	return &Client{
+		url:     cfg.URL,
+		headers: cfg.Headers,
+		http:    hc,
+	}, nil
+}
+
+// Call sends a JSON-RPC request and waits for the JSON response.
+//
+//   - 200 OK with JSON body → decode and return.
+//   - 404 with JSON-RPC error → marks the client dead, surfaces the error.
+//   - Other 4xx/5xx → transport error.
+//   - Network failure → transport error.
+func (c *Client) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if c.dead.Load() {
+		return nil, errors.New("mcp http: session invalidated; create a new client")
+	}
+	id := c.ids.Next()
+	req, err := mcp.NewRequest(id, method, params)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if sid := resp.Header.Get(sessionHeader); sid != "" {
+		c.sessMu.Lock()
+		c.sessionID = sid
+		c.sessMu.Unlock()
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusAccepted:
+		// Fall through to parse.
+	case resp.StatusCode == http.StatusNotFound:
+		// Session was invalidated server-side. Mark dead so the pool
+		// evicts and respawns on next Get.
+		c.dead.Store(true)
+		return nil, fmt.Errorf("mcp http: session invalidated (404): %s", strings.TrimSpace(string(respBody)))
+	default:
+		return nil, fmt.Errorf("mcp http: %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	if len(bytes.TrimSpace(respBody)) == 0 {
+		// Some servers return 202 + empty body for notifications-as-requests.
+		// For a real Call we expect a JSON-RPC response.
+		return nil, errors.New("mcp http: empty response body for request")
+	}
+
+	var rpcResp mcp.Response
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("mcp http: decode response: %w (body: %s)", err, truncate(string(respBody), 200))
+	}
+	if rpcResp.Error != nil {
+		return nil, rpcResp.Error
+	}
+	return rpcResp.Result, nil
+}
+
+// Notify sends a JSON-RPC notification (no response expected).
+// MCP servers respond 202 Accepted to notifications.
+func (c *Client) Notify(method string, params any) error {
+	if c.dead.Load() {
+		return errors.New("mcp http: session invalidated")
+	}
+	n, err := mcp.NewNotification(method, params)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+	// Notifications shouldn't block on a long-running ctx. Use a short
+	// fire-and-forget timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	resp, err := c.do(ctx, body)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("mcp http notify: %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// Healthy reports whether the client can still reach the server. Returns
+// false once we've observed a session-invalidated 404; the pool will then
+// evict + respawn on the next Get.
+func (c *Client) Healthy() bool { return !c.dead.Load() }
+
+// Close is a no-op for HTTP — there's no persistent connection to tear
+// down. Kept so the pool can call Close uniformly across transports.
+func (c *Client) Close() error { return nil }
+
+// do performs one POST with the JSON-RPC body and returns the raw http
+// response (caller closes Body). Adds session header + operator headers.
+func (c *Client) do(ctx context.Context, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", c.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+	c.sessMu.Lock()
+	sid := c.sessionID
+	c.sessMu.Unlock()
+	if sid != "" {
+		req.Header.Set(sessionHeader, sid)
+	}
+	return c.http.Do(req)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -132,15 +132,24 @@ func (c *Client) Call(ctx context.Context, method string, params any) (json.RawM
 	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
 		return nil, fmt.Errorf("mcp http: decode response: %w (body: %s)", err, truncate(string(respBody), 200))
 	}
+	// JSON-RPC 2.0 requires the response id to match the request id. The
+	// streamable-HTTP single-POST shape makes correlation implicit, but a
+	// misbehaving server returning a stale id is a protocol violation we
+	// surface rather than silently accept (and feed back to the model).
+	if rpcResp.ID != id {
+		return nil, fmt.Errorf("mcp http: response id %d does not match request id %d (server protocol violation)", rpcResp.ID, id)
+	}
 	if rpcResp.Error != nil {
 		return nil, rpcResp.Error
 	}
 	return rpcResp.Result, nil
 }
 
-// Notify sends a JSON-RPC notification (no response expected).
-// MCP servers respond 202 Accepted to notifications.
-func (c *Client) Notify(method string, params any) error {
+// Notify sends a JSON-RPC notification (no response expected). MCP servers
+// respond 202 Accepted to notifications. ctx caps the request — callers
+// pass the same ctx they used for surrounding Call invocations so a
+// run-level cancellation tears down the whole chain consistently.
+func (c *Client) Notify(ctx context.Context, method string, params any) error {
 	if c.dead.Load() {
 		return errors.New("mcp http: session invalidated")
 	}
@@ -152,10 +161,6 @@ func (c *Client) Notify(method string, params any) error {
 	if err != nil {
 		return err
 	}
-	// Notifications shouldn't block on a long-running ctx. Use a short
-	// fire-and-forget timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
 	resp, err := c.do(ctx, body)
 	if err != nil {
 		return err

--- a/internal/tools/mcp/http/client_test.go
+++ b/internal/tools/mcp/http/client_test.go
@@ -1,0 +1,329 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// fakeServer wraps httptest with a minimal MCP-over-HTTP responder.
+// Mode picks the response set, mirroring the stdio test fakes.
+type fakeServer struct {
+	mode      string
+	sessionID string
+	requests  atomic.Int64
+}
+
+func newFakeServer(t *testing.T, mode string) *httptest.Server {
+	t.Helper()
+	f := &fakeServer{mode: mode, sessionID: "s_" + mode}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.requests.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var probe struct {
+			ID     *int64          `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		_ = json.Unmarshal(body, &probe)
+
+		// On the first call (probe is initialize), set the session header.
+		if probe.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", f.sessionID)
+		}
+
+		// Notifications: 202 + empty body.
+		if probe.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+
+		switch probe.Method {
+		case "initialize":
+			writeJSON(w, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"protocolVersion": mcp.ProtocolVersion,
+					"capabilities":    map[string]any{},
+					"serverInfo":      map[string]any{"name": "fake-http", "version": "0.1"},
+				},
+			})
+		case "tools/list":
+			writeJSON(w, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{"name": "search", "description": "search", "inputSchema": map[string]any{"type": "object"}},
+					},
+				},
+			})
+		case "tools/call":
+			if f.mode == "session-invalidated" {
+				w.WriteHeader(http.StatusNotFound)
+				w.Write([]byte(`{"error":"session expired"}`))
+				return
+			}
+			if f.mode == "rpc-error" {
+				writeJSON(w, map[string]any{
+					"jsonrpc": "2.0",
+					"id":      *probe.ID,
+					"error":   map[string]any{"code": -32603, "message": "synthetic"},
+				})
+				return
+			}
+			if f.mode == "auth-required" {
+				if r.Header.Get("Authorization") != "Bearer test-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+			}
+			var p struct {
+				Name string `json:"name"`
+			}
+			_ = json.Unmarshal(probe.Params, &p)
+			writeJSON(w, map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"content": []map[string]any{{"type": "text", "text": "got: " + p.Name}},
+				},
+			})
+		}
+	}))
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func TestHandshakeAndCall(t *testing.T) {
+	srv := newFakeServer(t, "ok")
+	defer srv.Close()
+
+	c, err := New(Config{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	init, err := mcp.Initialize(ctx, c, "loomcycle-test", "1.0")
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if init.ServerInfo.Name != "fake-http" {
+		t.Errorf("ServerInfo: %+v", init.ServerInfo)
+	}
+
+	tools, err := mcp.ListTools(ctx, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 || tools[0].Name != "search" {
+		t.Errorf("tools = %+v", tools)
+	}
+
+	res, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{"q":"x"}`))
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if got := mcp.JoinTextContent(res); got != "got: search" {
+		t.Errorf("text = %q", got)
+	}
+}
+
+// Regression: session ID returned on initialize must be sent on every
+// subsequent request (including the next initialize call would the server
+// expect that — we test by counting that the same header is on tools/list).
+func TestSessionIDIsPropagated(t *testing.T) {
+	var mu sync.Mutex
+	var sessionsSeen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var probe struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &probe)
+
+		mu.Lock()
+		sessionsSeen = append(sessionsSeen, r.Header.Get("Mcp-Session-Id"))
+		mu.Unlock()
+
+		if probe.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "s_canonical")
+		}
+		if probe.ID != nil {
+			writeJSON(w, map[string]any{
+				"jsonrpc": "2.0", "id": *probe.ID,
+				"result": map[string]any{
+					"protocolVersion": mcp.ProtocolVersion,
+					"capabilities":    map[string]any{},
+					"serverInfo":      map[string]any{"name": "x", "version": "1"},
+					"tools":           []any{},
+				},
+			})
+		}
+	}))
+	defer srv.Close()
+
+	c, _ := New(Config{URL: srv.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mcp.ListTools(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sessionsSeen) < 3 {
+		t.Fatalf("requests = %d, want >=3 (init, initialized notif, tools/list)", len(sessionsSeen))
+	}
+	if sessionsSeen[0] != "" {
+		t.Errorf("first request had Mcp-Session-Id = %q (server hadn't issued one yet)", sessionsSeen[0])
+	}
+	for i, sid := range sessionsSeen[1:] {
+		if sid != "s_canonical" {
+			t.Errorf("post-init request %d: session = %q, want s_canonical", i+1, sid)
+		}
+	}
+}
+
+func TestRPCErrorPropagates(t *testing.T) {
+	srv := newFakeServer(t, "rpc-error")
+	defer srv.Close()
+	c, _ := New(Config{URL: srv.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "synthetic") {
+		t.Errorf("error doesn't mention server message: %v", err)
+	}
+}
+
+func TestSessionInvalidatedMarksDead(t *testing.T) {
+	srv := newFakeServer(t, "session-invalidated")
+	defer srv.Close()
+	c, _ := New(Config{URL: srv.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	if !c.Healthy() {
+		t.Fatal("client should be Healthy before the 404")
+	}
+
+	_, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected 404 error")
+	}
+	if c.Healthy() {
+		t.Errorf("client should be !Healthy after session invalidation")
+	}
+
+	// Subsequent calls fail fast without hitting the network.
+	_, err = mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected dead-client error on subsequent call")
+	}
+	if !strings.Contains(err.Error(), "invalidated") {
+		t.Errorf("error doesn't mention invalidation: %v", err)
+	}
+}
+
+func TestHeadersForwarded(t *testing.T) {
+	srv := newFakeServer(t, "auth-required")
+	defer srv.Close()
+	c, _ := New(Config{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer test-token"},
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	res, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !strings.Contains(mcp.JoinTextContent(res), "got: search") {
+		t.Errorf("got %q", mcp.JoinTextContent(res))
+	}
+}
+
+func TestHeadersMissingReturnsAuthError(t *testing.T) {
+	srv := newFakeServer(t, "auth-required")
+	defer srv.Close()
+	c, _ := New(Config{URL: srv.URL}) // no headers
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("error doesn't mention 401: %v", err)
+	}
+}
+
+func TestCtxCancelMidCall(t *testing.T) {
+	// Slow server: sleeps 200ms before responding so a 30ms ctx fires first.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		var probe struct {
+			ID *int64 `json:"id"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &probe)
+		if probe.ID != nil {
+			writeJSON(w, map[string]any{"jsonrpc": "2.0", "id": *probe.ID, "result": map[string]any{}})
+		}
+	}))
+	defer srv.Close()
+	c, _ := New(Config{URL: srv.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, err := c.Call(ctx, "tools/call", map[string]any{})
+	if err == nil {
+		t.Fatal("expected ctx err")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "deadline") {
+		t.Errorf("error doesn't surface context: %v", err)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	c, _ := New(Config{URL: "http://example.invalid"})
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("second Close errored: %v", err)
+	}
+}

--- a/internal/tools/mcp/http/client_test.go
+++ b/internal/tools/mcp/http/client_test.go
@@ -318,6 +318,87 @@ func TestCtxCancelMidCall(t *testing.T) {
 	}
 }
 
+// Regression: a server that returns a response with an id that doesn't
+// match the request id is a JSON-RPC 2.0 protocol violation. The
+// single-POST streamable-HTTP shape makes correlation implicit, but if
+// a buggy server returns a stale id we surface it as an error rather
+// than silently feeding the wrong result back to the agent loop.
+func TestRPCResponseIDMismatchSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var probe struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &probe)
+		if probe.ID == nil {
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		// Initialize: respond with the right id (so handshake succeeds).
+		// tools/call: respond with the WRONG id to simulate a buggy server.
+		respID := *probe.ID
+		if probe.Method == "tools/call" {
+			respID = 99999
+		}
+		if probe.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "s")
+		}
+		writeJSON(w, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      respID,
+			"result":  map[string]any{},
+		})
+	}))
+	defer srv.Close()
+
+	c, _ := New(Config{URL: srv.URL})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := c.Call(ctx, "tools/call", map[string]any{})
+	if err == nil {
+		t.Fatal("expected id-mismatch error")
+	}
+	if !strings.Contains(err.Error(), "id") {
+		t.Errorf("error doesn't mention id: %v", err)
+	}
+}
+
+// Regression: Notify must honour the caller's ctx. Previously the http
+// transport hardcoded a 30s background context for notifications, so a
+// run-level ctx-cancel during the initialized notification (sent inside
+// Initialize) would not propagate.
+func TestNotifyHonoursCallerCtx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var probe struct {
+			ID *int64 `json:"id"`
+		}
+		_ = json.Unmarshal(body, &probe)
+		if probe.ID == nil {
+			// Notification — sleep so a 30ms ctx fires before we 202.
+			time.Sleep(200 * time.Millisecond)
+			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+	}))
+	defer srv.Close()
+	c, _ := New(Config{URL: srv.URL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	err := c.Notify(ctx, "loomcycle/probe", nil)
+	if err == nil {
+		t.Fatal("expected ctx error from Notify")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "deadline") {
+		t.Errorf("err = %v, want context-related", err)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	c, _ := New(Config{URL: "http://example.invalid"})
 	if err := c.Close(); err != nil {

--- a/internal/tools/mcp/jsonrpc.go
+++ b/internal/tools/mcp/jsonrpc.go
@@ -1,0 +1,116 @@
+// Package mcp speaks the Model Context Protocol — JSON-RPC 2.0 over either
+// stdio (this package's stdio subpackage) or HTTP (planned). The root package
+// holds the wire types and small helpers shared by both transports.
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+)
+
+// Request is a JSON-RPC 2.0 request. MCP is strictly 2.0 — implementations
+// must reject anything else.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Notification is a JSON-RPC 2.0 notification (no ID, no expected response).
+// MCP uses these for "initialized", server-side progress updates, etc.
+type Notification struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is a JSON-RPC 2.0 response. Either Result or Error is set, not both.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}
+
+// Error is a JSON-RPC 2.0 error object.
+type Error struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return "<nil mcp error>"
+	}
+	return fmt.Sprintf("jsonrpc error %d: %s", e.Code, e.Message)
+}
+
+// IDGenerator hands out monotonically increasing IDs for outbound requests.
+// Safe for concurrent use.
+type IDGenerator struct{ n atomic.Int64 }
+
+// Next returns a fresh request ID (positive, starting at 1).
+func (g *IDGenerator) Next() int64 { return g.n.Add(1) }
+
+// NewRequest builds a Request with the given method and params (params may
+// be nil for parameterless methods).
+func NewRequest(id int64, method string, params any) (Request, error) {
+	req := Request{JSONRPC: "2.0", ID: id, Method: method}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			return Request{}, fmt.Errorf("marshal params: %w", err)
+		}
+		req.Params = raw
+	}
+	return req, nil
+}
+
+// NewNotification builds a Notification with the given method and params.
+func NewNotification(method string, params any) (Notification, error) {
+	n := Notification{JSONRPC: "2.0", Method: method}
+	if params != nil {
+		raw, err := json.Marshal(params)
+		if err != nil {
+			return Notification{}, fmt.Errorf("marshal params: %w", err)
+		}
+		n.Params = raw
+	}
+	return n, nil
+}
+
+// IncomingFrame represents one line read from an MCP transport. Exactly one
+// of Response or Notification is non-nil. Returns ParseErr when the line is
+// not a recognisable JSON-RPC frame; callers should log and skip.
+type IncomingFrame struct {
+	Response     *Response
+	Notification *Notification
+	ParseErr     error
+}
+
+// DecodeFrame inspects a single JSON-RPC frame and routes it to the right
+// kind. JSON-RPC distinguishes by presence of "id": responses have one,
+// notifications don't. We use a probe struct with explicit "id" presence.
+func DecodeFrame(line []byte) IncomingFrame {
+	var probe struct {
+		ID *int64 `json:"id"`
+	}
+	if err := json.Unmarshal(line, &probe); err != nil {
+		return IncomingFrame{ParseErr: fmt.Errorf("decode probe: %w", err)}
+	}
+	if probe.ID != nil {
+		var resp Response
+		if err := json.Unmarshal(line, &resp); err != nil {
+			return IncomingFrame{ParseErr: fmt.Errorf("decode response: %w", err)}
+		}
+		return IncomingFrame{Response: &resp}
+	}
+	var n Notification
+	if err := json.Unmarshal(line, &n); err != nil {
+		return IncomingFrame{ParseErr: fmt.Errorf("decode notification: %w", err)}
+	}
+	return IncomingFrame{Notification: &n}
+}

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -54,13 +54,36 @@ func NewPool(build func(name string) (Caller, error), teardown func(c Caller)) *
 // first use and performing the MCP handshake + tools/list. Concurrent Get
 // callers for the same name share one in-flight init; concurrent Get
 // callers for different names don't block each other.
+//
+// If a cached entry's Caller is no longer Healthy (e.g. the stdio child
+// crashed), Get evicts it and re-initialises a fresh entry inline. The
+// caller never sees a "permanently dead" slot.
 func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
 	// Phase 1 (fast path): check the map under the lock. If the entry
-	// exists and is ready, return immediately. If it exists but is still
-	// initialising (some other goroutine got here first), wait on its
-	// ready channel without holding p.mu.
+	// exists, ready, and healthy, return immediately. If it exists but is
+	// still initialising, wait on its ready channel without holding p.mu.
+	// If it's ready but unhealthy, evict and fall through to a fresh init.
 	p.mu.Lock()
 	e, exists := p.servers[name]
+	if exists {
+		select {
+		case <-e.ready:
+			// Init finished. Check the result.
+			if e.err == nil && e.caller != nil && e.caller.Healthy() {
+				p.mu.Unlock()
+				return e.caller, e.tools, nil
+			}
+			// Either init failed earlier or the caller is now unhealthy.
+			// Evict so the rest of this function creates a fresh entry.
+			if e.err == nil && e.caller != nil && p.teardown != nil {
+				p.teardown(e.caller)
+			}
+			delete(p.servers, name)
+			exists = false
+		default:
+			// Still initialising — fall through to wait.
+		}
+	}
 	if !exists {
 		e = &entry{ready: make(chan struct{})}
 		p.servers[name] = e
@@ -68,10 +91,18 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 	p.mu.Unlock()
 
 	if exists {
-		// Wait for the in-progress init (or already-finished entry).
+		// Wait for the in-progress init.
 		select {
 		case <-e.ready:
-			return e.caller, e.tools, e.err
+			if e.err == nil && e.caller != nil && e.caller.Healthy() {
+				return e.caller, e.tools, nil
+			}
+			if e.err != nil {
+				return nil, nil, e.err
+			}
+			// Won the race in the most awkward way: it became unhealthy
+			// between ready and our re-check. One retry resolves it.
+			return p.Get(ctx, name)
 		case <-ctx.Done():
 			return nil, nil, ctx.Err()
 		}
@@ -153,12 +184,7 @@ func (p *Pool) Tools() []tools.Tool {
 			continue
 		}
 		for _, td := range e.tools {
-			out = append(out, &mcpTool{
-				server:     serverName,
-				toolName:   td.Name,
-				descriptor: td,
-				caller:     e.caller,
-			})
+			out = append(out, NewTool(p, serverName, td))
 		}
 	}
 	return out
@@ -189,11 +215,28 @@ func (p *Pool) Close() {
 
 // mcpTool wraps an MCP server-side tool descriptor as a loomcycle tools.Tool
 // so the dispatcher can route to it the same way it routes to built-ins.
+//
+// Critically, the tool resolves its Caller via Pool.Get on every Execute —
+// not via a captured pointer at registration time. That way, if the stdio
+// child crashes and Pool.Get respawns it, this tool's next call uses the
+// new caller automatically, with no re-registration step.
 type mcpTool struct {
 	server     string
 	toolName   string
 	descriptor ToolDescriptor
-	caller     Caller
+	pool       *Pool
+}
+
+// NewTool wraps a single MCP tool descriptor as a tools.Tool. Operators
+// that want per-server allowed_tools filtering can call this directly with
+// the subset of descriptors they want to expose.
+func NewTool(pool *Pool, server string, descriptor ToolDescriptor) tools.Tool {
+	return &mcpTool{
+		server:     server,
+		toolName:   descriptor.Name,
+		descriptor: descriptor,
+		pool:       pool,
+	}
 }
 
 func (t *mcpTool) Name() string {
@@ -210,7 +253,17 @@ func (t *mcpTool) InputSchema() json.RawMessage {
 }
 
 func (t *mcpTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
-	res, err := CallTool(ctx, t.caller, t.toolName, input)
+	caller, _, err := t.pool.Get(ctx, t.server)
+	if err != nil {
+		// Pool spawn / handshake failed. ctx cancellation goes through as
+		// a hard error; everything else as a recoverable IsError so the
+		// model can see "MCP server unavailable" and decide what to do.
+		if ctx.Err() != nil {
+			return tools.Result{}, err
+		}
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	res, err := CallTool(ctx, caller, t.toolName, input)
 	if err != nil {
 		// Distinguish two failure modes:
 		//   1. ctx cancellation — the run is going away; the model should

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -27,9 +27,15 @@ type Pool struct {
 	teardown func(c Caller) // Close hook for the concrete transport
 }
 
+// entry is one server slot. Once created it lives in p.servers until Pool.Close
+// or until init failure removes it. The ready channel is closed exactly once,
+// when init has finished (success or failure). Concurrent Get callers block
+// on ready (with ctx) instead of holding p.mu across the network round-trip.
 type entry struct {
+	ready  chan struct{} // closed when caller/tools/initErr are final
 	caller Caller
 	tools  []ToolDescriptor
+	err    error // non-nil means init failed and the entry is unusable
 }
 
 // NewPool creates a pool. build is called the first time a server is needed;
@@ -45,17 +51,64 @@ func NewPool(build func(name string) (Caller, error), teardown func(c Caller)) *
 }
 
 // Get returns the Caller for a named server, spawning the connection on
-// first use and performing the MCP handshake + tools/list. On subsequent
-// calls the cached entry is returned without re-handshaking.
+// first use and performing the MCP handshake + tools/list. Concurrent Get
+// callers for the same name share one in-flight init; concurrent Get
+// callers for different names don't block each other.
 func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
+	// Phase 1 (fast path): check the map under the lock. If the entry
+	// exists and is ready, return immediately. If it exists but is still
+	// initialising (some other goroutine got here first), wait on its
+	// ready channel without holding p.mu.
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	if e, ok := p.servers[name]; ok {
-		return e.caller, e.tools, nil
+	e, exists := p.servers[name]
+	if !exists {
+		e = &entry{ready: make(chan struct{})}
+		p.servers[name] = e
 	}
+	p.mu.Unlock()
+
+	if exists {
+		// Wait for the in-progress init (or already-finished entry).
+		select {
+		case <-e.ready:
+			return e.caller, e.tools, e.err
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		}
+	}
+
+	// Phase 2: we created the entry; we're responsible for initialising it.
+	// Drop the lock during build/initialize/list; other goroutines wait on
+	// e.ready. On failure, remove the entry from the map so a retry can
+	// re-attempt rather than seeing a permanently-dead slot.
+	caller, descs, err := p.initEntry(ctx, name)
+	if err != nil {
+		p.mu.Lock()
+		// Only remove if it's still our entry (paranoid against a Close
+		// having already cleared the map).
+		if cur, ok := p.servers[name]; ok && cur == e {
+			delete(p.servers, name)
+		}
+		p.mu.Unlock()
+		e.err = err
+		close(e.ready)
+		return nil, nil, err
+	}
+	e.caller = caller
+	e.tools = descs
+	close(e.ready)
+	return caller, descs, nil
+}
+
+// initEntry runs build → Initialize → ListTools without any pool locks held.
+// On failure the caller (Get) removes the half-built entry from the map.
+func (p *Pool) initEntry(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
 	caller, err := p.build(name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("mcp pool: build %q: %w", name, err)
+	}
+	if caller == nil {
+		return nil, nil, fmt.Errorf("mcp pool: build %q returned nil caller without error", name)
 	}
 	if _, err := Initialize(ctx, caller, "loomcycle", "0.3"); err != nil {
 		if p.teardown != nil {
@@ -70,18 +123,35 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 		}
 		return nil, nil, fmt.Errorf("mcp pool: tools/list %q: %w", name, err)
 	}
-	p.servers[name] = &entry{caller: caller, tools: descs}
 	return caller, descs, nil
 }
 
-// Tools returns wrapped tools.Tool entries for every server discovered so
-// far. Each tool is named "mcp__{server}__{tool}" to match the convention
-// used by Claude Code (and therefore by jobs-search-agent's policies).
+// Tools returns wrapped tools.Tool entries for every server that has
+// finished initialising. Each tool is named "mcp__{server}__{tool}" to match
+// the convention used by Claude Code (and therefore by jobs-search-agent's
+// policies). Entries that are still initialising or that failed init are
+// skipped.
 func (p *Pool) Tools() []tools.Tool {
 	p.mu.Lock()
-	defer p.mu.Unlock()
+	// Snapshot the entry pointers so we can safely iterate the ready
+	// channels without holding p.mu (ready is closed under no lock).
+	entries := make(map[string]*entry, len(p.servers))
+	for name, e := range p.servers {
+		entries[name] = e
+	}
+	p.mu.Unlock()
+
 	var out []tools.Tool
-	for serverName, e := range p.servers {
+	for serverName, e := range entries {
+		select {
+		case <-e.ready:
+			if e.err != nil {
+				continue
+			}
+		default:
+			// Still initialising — skip; caller can ask again later.
+			continue
+		}
 		for _, td := range e.tools {
 			out = append(out, &mcpTool{
 				server:     serverName,
@@ -94,16 +164,27 @@ func (p *Pool) Tools() []tools.Tool {
 	return out
 }
 
-// Close tears down all live connections. Idempotent.
+// Close tears down all live connections. Idempotent. Skips entries that
+// are still initialising or that failed init (no caller to tear down).
 func (p *Pool) Close() {
 	p.mu.Lock()
-	defer p.mu.Unlock()
-	for _, e := range p.servers {
-		if p.teardown != nil {
-			p.teardown(e.caller)
+	entries := p.servers
+	p.servers = map[string]*entry{}
+	p.mu.Unlock()
+
+	for _, e := range entries {
+		select {
+		case <-e.ready:
+			if e.err == nil && p.teardown != nil {
+				p.teardown(e.caller)
+			}
+		default:
+			// Still initialising — leave it alone; the goroutine that
+			// is initing it will close ready and observe the empty map
+			// on next Tools() / Get(). Its caller (if any) will be torn
+			// down when GC sees no remaining references.
 		}
 	}
-	p.servers = map[string]*entry{}
 }
 
 // mcpTool wraps an MCP server-side tool descriptor as a loomcycle tools.Tool
@@ -131,8 +212,18 @@ func (t *mcpTool) InputSchema() json.RawMessage {
 func (t *mcpTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
 	res, err := CallTool(ctx, t.caller, t.toolName, input)
 	if err != nil {
-		// Transport / protocol error — surface as an error result so the
-		// model sees it and can retry, rather than failing the run.
+		// Distinguish two failure modes:
+		//   1. ctx cancellation — the run is going away; the model should
+		//      not see a "tool failed, retry" message because the next
+		//      iteration's provider call will also fail with ctx.Err and
+		//      tear down the run. Surface as a hard error so the dispatcher
+		//      reports it once instead of feeding a confusing tool_result
+		//      back to the model.
+		//   2. Genuine transport/protocol failure — IsError result so the
+		//      model can self-correct (e.g. retry with different args).
+		if ctx.Err() != nil {
+			return tools.Result{}, err
+		}
 		return tools.Result{Text: err.Error(), IsError: true}, nil
 	}
 	return tools.Result{

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Pool manages MCP server connections — at most one Caller per server name
+// at a time. Connections are spawned lazily on first use and re-spawned on
+// the next call after a crash. Concurrent in-flight calls multiplex over
+// the shared connection (the underlying transport handles the JSON-RPC ID
+// demuxing).
+//
+// The Pool is intentionally shared across sessions and tenants: per-tenant
+// auth is passed through tool arguments, not by spawning per-tenant
+// children. This keeps memory bounded — n active sessions doesn't mean
+// n × m MCP child processes.
+type Pool struct {
+	mu       sync.Mutex
+	servers  map[string]*entry
+	build    func(name string) (Caller, error)
+	teardown func(c Caller) // Close hook for the concrete transport
+}
+
+type entry struct {
+	caller Caller
+	tools  []ToolDescriptor
+}
+
+// NewPool creates a pool. build is called the first time a server is needed;
+// it should spawn the transport (e.g. stdio.Spawn) and return its Caller.
+// teardown is called on Pool.Close for each live entry; pass a function
+// that closes the underlying transport.
+func NewPool(build func(name string) (Caller, error), teardown func(c Caller)) *Pool {
+	return &Pool{
+		servers:  make(map[string]*entry),
+		build:    build,
+		teardown: teardown,
+	}
+}
+
+// Get returns the Caller for a named server, spawning the connection on
+// first use and performing the MCP handshake + tools/list. On subsequent
+// calls the cached entry is returned without re-handshaking.
+func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if e, ok := p.servers[name]; ok {
+		return e.caller, e.tools, nil
+	}
+	caller, err := p.build(name)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mcp pool: build %q: %w", name, err)
+	}
+	if _, err := Initialize(ctx, caller, "loomcycle", "0.3"); err != nil {
+		if p.teardown != nil {
+			p.teardown(caller)
+		}
+		return nil, nil, fmt.Errorf("mcp pool: handshake %q: %w", name, err)
+	}
+	descs, err := ListTools(ctx, caller)
+	if err != nil {
+		if p.teardown != nil {
+			p.teardown(caller)
+		}
+		return nil, nil, fmt.Errorf("mcp pool: tools/list %q: %w", name, err)
+	}
+	p.servers[name] = &entry{caller: caller, tools: descs}
+	return caller, descs, nil
+}
+
+// Tools returns wrapped tools.Tool entries for every server discovered so
+// far. Each tool is named "mcp__{server}__{tool}" to match the convention
+// used by Claude Code (and therefore by jobs-search-agent's policies).
+func (p *Pool) Tools() []tools.Tool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []tools.Tool
+	for serverName, e := range p.servers {
+		for _, td := range e.tools {
+			out = append(out, &mcpTool{
+				server:     serverName,
+				toolName:   td.Name,
+				descriptor: td,
+				caller:     e.caller,
+			})
+		}
+	}
+	return out
+}
+
+// Close tears down all live connections. Idempotent.
+func (p *Pool) Close() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, e := range p.servers {
+		if p.teardown != nil {
+			p.teardown(e.caller)
+		}
+	}
+	p.servers = map[string]*entry{}
+}
+
+// mcpTool wraps an MCP server-side tool descriptor as a loomcycle tools.Tool
+// so the dispatcher can route to it the same way it routes to built-ins.
+type mcpTool struct {
+	server     string
+	toolName   string
+	descriptor ToolDescriptor
+	caller     Caller
+}
+
+func (t *mcpTool) Name() string {
+	return "mcp__" + sanitiseServerName(t.server) + "__" + t.toolName
+}
+
+func (t *mcpTool) Description() string { return t.descriptor.Description }
+
+func (t *mcpTool) InputSchema() json.RawMessage {
+	if len(t.descriptor.InputSchema) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return t.descriptor.InputSchema
+}
+
+func (t *mcpTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	res, err := CallTool(ctx, t.caller, t.toolName, input)
+	if err != nil {
+		// Transport / protocol error — surface as an error result so the
+		// model sees it and can retry, rather than failing the run.
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	return tools.Result{
+		Text:    JoinTextContent(res),
+		IsError: res.IsError,
+	}, nil
+}
+
+// sanitiseServerName replaces characters that aren't valid in tool names —
+// MCP server names allow hyphens, but tool names in our model dispatcher
+// should be conservative. We replace `-` with `_` to match Claude Code's
+// `mcp__brave-search__...` → it actually keeps hyphens in the segment, so
+// we mirror that. Nothing to sanitise; helper is a no-op stub for now.
+func sanitiseServerName(name string) string {
+	return strings.ReplaceAll(name, " ", "_")
+}

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -1,0 +1,255 @@
+package mcp_test
+
+// Tests for the Pool and Tool wrapper. Lives in an _test package so it can
+// import the stdio subpackage without an import cycle, and so it exercises
+// the public surface of mcp from a real consumer's vantage point.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
+)
+
+// fakeMCPBinary is the path to the stdio test binary. Tests rely on the
+// stdio package's TestMain installing the BE_MCP_SERVER hook — we run the
+// stdio test binary from this package's test process by invoking
+//
+//	go test -c -o /tmp/.../stdio.test ./internal/tools/mcp/stdio
+//
+// at TestMain time. That's heavy. Cheaper: re-use the *current* test
+// binary's BE_MCP_SERVER hook by spawning os.Args[0] with the env. But
+// THIS test process doesn't have that hook (its TestMain is the default).
+// We therefore declare a TestMain here too that mirrors the stdio one.
+
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("BE_MCP_SERVER"); mode != "" {
+		runFakeServer(mode)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runFakeServer is duplicated from the stdio test helper; small enough to
+// duplicate rather than build a shared test-helper package just for two
+// callers. If a third caller appears, factor out.
+func runFakeServer(mode string) {
+	dec := json.NewDecoder(os.Stdin)
+	enc := json.NewEncoder(os.Stdout)
+	for {
+		var probe struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      *int64          `json:"id"`
+			Method  string          `json:"method"`
+			Params  json.RawMessage `json:"params"`
+		}
+		if err := dec.Decode(&probe); err != nil {
+			return
+		}
+		if probe.ID == nil {
+			continue
+		}
+		switch probe.Method {
+		case "initialize":
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"protocolVersion": mcp.ProtocolVersion,
+					"capabilities":    map[string]any{},
+					"serverInfo":      map[string]any{"name": "fake-pool", "version": "0.1"},
+				},
+			})
+		case "tools/list":
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{
+							"name":        "web_search",
+							"description": "search the web",
+							"inputSchema": map[string]any{"type": "object"},
+						},
+					},
+				},
+			})
+		case "tools/call":
+			var p struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			_ = json.Unmarshal(probe.Params, &p)
+			if mode == "tool_iserror" {
+				_ = enc.Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      *probe.ID,
+					"result": map[string]any{
+						"content": []map[string]any{{"type": "text", "text": "tool failed"}},
+						"isError": true,
+					},
+				})
+				continue
+			}
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"content": []map[string]any{{"type": "text", "text": "got: " + p.Name}},
+				},
+			})
+		}
+	}
+}
+
+func newPoolWithFake(t *testing.T, mode string) *mcp.Pool {
+	t.Helper()
+	build := func(name string) (mcp.Caller, error) {
+		c, err := stdio.Spawn(stdio.Config{
+			Command: os.Args[0],
+			Env:     []string{"BE_MCP_SERVER=" + mode},
+		})
+		if err != nil {
+			return nil, err
+		}
+		return c, nil
+	}
+	teardown := func(c mcp.Caller) {
+		if cl, ok := c.(*stdio.Client); ok {
+			_ = cl.Close()
+		}
+	}
+	pool := mcp.NewPool(build, teardown)
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestPoolGetSpawnsAndDiscoversTools(t *testing.T) {
+	pool := newPoolWithFake(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, descs, err := pool.Get(ctx, "search")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(descs) != 1 || descs[0].Name != "web_search" {
+		t.Errorf("descs: %+v", descs)
+	}
+
+	tools := pool.Tools()
+	if len(tools) != 1 {
+		t.Fatalf("tools = %d", len(tools))
+	}
+	want := "mcp__search__web_search"
+	if got := tools[0].Name(); got != want {
+		t.Errorf("tool name = %q, want %q", got, want)
+	}
+}
+
+func TestPoolToolExecuteRoutesToServer(t *testing.T) {
+	pool := newPoolWithFake(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, _, err := pool.Get(ctx, "search"); err != nil {
+		t.Fatal(err)
+	}
+	tool := pool.Tools()[0]
+	res, err := tool.Execute(ctx, json.RawMessage(`{"q":"hi"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(res.Text, "got: web_search") {
+		t.Errorf("text = %q", res.Text)
+	}
+	if res.IsError {
+		t.Errorf("IsError true unexpectedly")
+	}
+}
+
+func TestPoolToolPropagatesIsError(t *testing.T) {
+	pool := newPoolWithFake(t, "tool_iserror")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, _, err := pool.Get(ctx, "search"); err != nil {
+		t.Fatal(err)
+	}
+	tool := pool.Tools()[0]
+	res, err := tool.Execute(ctx, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("IsError = false, want true")
+	}
+}
+
+func TestPoolGetCachesConnection(t *testing.T) {
+	build := newCountingBuild(t, "ok")
+	pool := mcp.NewPool(build.fn, func(c mcp.Caller) {
+		if cl, ok := c.(*stdio.Client); ok {
+			_ = cl.Close()
+		}
+	})
+	t.Cleanup(pool.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, _, err := pool.Get(ctx, "search"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := pool.Get(ctx, "search"); err != nil {
+		t.Fatal(err)
+	}
+	if build.count != 1 {
+		t.Errorf("build called %d times, want 1 (cache miss on second Get)", build.count)
+	}
+}
+
+func TestPoolGetReturnsBuildError(t *testing.T) {
+	pool := mcp.NewPool(
+		func(name string) (mcp.Caller, error) {
+			return nil, errors.New("synthetic build failure")
+		},
+		nil,
+	)
+	t.Cleanup(pool.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _, err := pool.Get(ctx, "broken")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "synthetic build failure") {
+		t.Errorf("error doesn't propagate underlying cause: %v", err)
+	}
+}
+
+type countingBuild struct {
+	t     *testing.T
+	mode  string
+	count int
+}
+
+func newCountingBuild(t *testing.T, mode string) *countingBuild {
+	return &countingBuild{t: t, mode: mode}
+}
+
+func (b *countingBuild) fn(name string) (mcp.Caller, error) {
+	b.count++
+	c, err := stdio.Spawn(stdio.Config{
+		Command: os.Args[0],
+		Env:     []string{"BE_MCP_SERVER=" + b.mode},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -86,6 +87,9 @@ func runFakeServer(mode string) {
 				Arguments json.RawMessage `json:"arguments"`
 			}
 			_ = json.Unmarshal(probe.Params, &p)
+			if mode == "slow-call" {
+				time.Sleep(200 * time.Millisecond)
+			}
 			if mode == "tool_iserror" {
 				_ = enc.Encode(map[string]any{
 					"jsonrpc": "2.0",
@@ -173,6 +177,33 @@ func TestPoolToolExecuteRoutesToServer(t *testing.T) {
 	}
 }
 
+// Regression: when ctx fires mid-Execute, the wrapper must surface a hard
+// error (non-nil err) rather than dressing the cancellation as a recoverable
+// tool failure (Result{IsError:true}, nil). The model would otherwise see a
+// confusing "tool errored" message in the transcript before the loop's next
+// provider call detects the same ctx and terminates the run.
+//
+// Test approach: drive an Execute against a slow server with a tight ctx.
+// Without the fix, Execute returns (Result{IsError:true, Text:"context..."}, nil).
+// With the fix, Execute returns (Result{}, err) so dispatcher's err branch fires.
+func TestPoolToolReturnsErrOnCtxCancel(t *testing.T) {
+	pool := newPoolWithFake(t, "slow-call")
+	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer initCancel()
+	if _, _, err := pool.Get(initCtx, "search"); err != nil {
+		t.Fatal(err)
+	}
+	tool := pool.Tools()[0]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	_, err := tool.Execute(ctx, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected non-nil err on ctx cancel; tool dressed cancel as IsError")
+	}
+}
+
 func TestPoolToolPropagatesIsError(t *testing.T) {
 	pool := newPoolWithFake(t, "tool_iserror")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -209,6 +240,131 @@ func TestPoolGetCachesConnection(t *testing.T) {
 	}
 	if build.count != 1 {
 		t.Errorf("build called %d times, want 1 (cache miss on second Get)", build.count)
+	}
+}
+
+// Regression: concurrent Get on the same server name must share one
+// in-flight init — not block under one lock and not double-spawn.
+func TestPoolGetSharesInFlightInit(t *testing.T) {
+	build := newCountingBuild(t, "ok")
+	pool := mcp.NewPool(build.fn, func(c mcp.Caller) {
+		if cl, ok := c.(*stdio.Client); ok {
+			_ = cl.Close()
+		}
+	})
+	t.Cleanup(pool.Close)
+
+	const N = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, _, err := pool.Get(ctx, "shared")
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent Get failed: %v", err)
+	}
+	if build.count != 1 {
+		t.Errorf("build called %d times, want 1 (concurrent Get must share init)", build.count)
+	}
+}
+
+// Regression: a failed init removes the entry from the map so subsequent
+// Get calls can retry, rather than getting back the cached error forever.
+func TestPoolGetRetriesAfterInitFailure(t *testing.T) {
+	var attempts int
+	pool := mcp.NewPool(
+		func(name string) (mcp.Caller, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, errors.New("transient build failure")
+			}
+			c, err := stdio.Spawn(stdio.Config{
+				Command: os.Args[0],
+				Env:     []string{"BE_MCP_SERVER=ok"},
+			})
+			return c, err
+		},
+		func(c mcp.Caller) {
+			if cl, ok := c.(*stdio.Client); ok {
+				_ = cl.Close()
+			}
+		},
+	)
+	t.Cleanup(pool.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, _, err := pool.Get(ctx, "retry"); err == nil {
+		t.Fatal("first Get expected to fail")
+	}
+	if _, _, err := pool.Get(ctx, "retry"); err != nil {
+		t.Errorf("second Get should succeed after failed entry was evicted: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("attempts = %d, want 2", attempts)
+	}
+}
+
+// Regression: Get respects ctx cancellation while waiting on an in-flight
+// init started by another goroutine.
+func TestPoolGetRespectsCtxWhileWaitingOnPeerInit(t *testing.T) {
+	// Use a slow build so the second Get can race the first's init.
+	releaseBuild := make(chan struct{})
+	pool := mcp.NewPool(
+		func(name string) (mcp.Caller, error) {
+			<-releaseBuild
+			return stdio.Spawn(stdio.Config{
+				Command: os.Args[0],
+				Env:     []string{"BE_MCP_SERVER=ok"},
+			})
+		},
+		func(c mcp.Caller) {
+			if cl, ok := c.(*stdio.Client); ok {
+				_ = cl.Close()
+			}
+		},
+	)
+	t.Cleanup(func() {
+		// Unblock any stuck build before Close.
+		select {
+		case <-releaseBuild:
+		default:
+			close(releaseBuild)
+		}
+		pool.Close()
+	})
+
+	// First Get starts an init that hangs on releaseBuild.
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, _, _ = pool.Get(ctx, "slow")
+	}()
+	// Give it a moment to register the entry.
+	time.Sleep(50 * time.Millisecond)
+
+	// Second Get races in with a tight ctx. Must return ctx.Err()
+	// before the first Get's init completes.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	_, _, err := pool.Get(ctx, "slow")
+	if err == nil {
+		t.Fatal("expected ctx error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want DeadlineExceeded", err)
 	}
 }
 

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -368,6 +368,58 @@ func TestPoolGetRespectsCtxWhileWaitingOnPeerInit(t *testing.T) {
 	}
 }
 
+// Regression: when a cached entry's caller goes unhealthy (e.g. the stdio
+// child crashed), the next Pool.Get must evict + respawn rather than handing
+// back a dead caller forever.
+func TestPoolGetRespawnsAfterUnhealthy(t *testing.T) {
+	build := newCountingBuild(t, "ok")
+	pool := mcp.NewPool(build.fn, func(c mcp.Caller) {
+		if cl, ok := c.(*stdio.Client); ok {
+			_ = cl.Close()
+		}
+	})
+	t.Cleanup(pool.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// First Get → spawn 1.
+	caller1, _, err := pool.Get(ctx, "rs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !caller1.Healthy() {
+		t.Fatal("first caller should be Healthy")
+	}
+
+	// Kill the child. After this the cached caller reports !Healthy.
+	if cl, ok := caller1.(*stdio.Client); ok {
+		_ = cl.Close()
+	}
+	// Give the readLoop a moment to observe EOF and close doneCh.
+	for i := 0; i < 100 && caller1.Healthy(); i++ {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if caller1.Healthy() {
+		t.Fatal("caller still Healthy after Close — test setup wrong")
+	}
+
+	// Next Get must respawn (build called again).
+	caller2, _, err := pool.Get(ctx, "rs")
+	if err != nil {
+		t.Fatalf("Get after crash: %v", err)
+	}
+	if !caller2.Healthy() {
+		t.Fatal("respawned caller should be Healthy")
+	}
+	if caller2 == caller1 {
+		t.Fatal("Get returned the dead caller, not a respawn")
+	}
+	if build.count != 2 {
+		t.Errorf("build called %d times, want 2 (spawn + respawn)", build.count)
+	}
+}
+
 func TestPoolGetReturnsBuildError(t *testing.T) {
 	pool := mcp.NewPool(
 		func(name string) (mcp.Caller, error) {

--- a/internal/tools/mcp/protocol.go
+++ b/internal/tools/mcp/protocol.go
@@ -7,11 +7,17 @@ import (
 )
 
 // Caller is the minimum surface a transport must expose to drive the MCP
-// protocol. Both stdio.Client and a future http.Client satisfy this so the
+// protocol. Both stdio.Client and http.Client satisfy this so the
 // protocol-layer helpers below stay transport-agnostic.
 type Caller interface {
 	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
 	Notify(method string, params any) error
+	// Healthy reports whether the underlying transport is still able to
+	// serve calls. For stdio: true while the child is alive. For HTTP:
+	// effectively always true (stateless), unless a session has been
+	// invalidated and we know about it. The Pool uses this to decide
+	// whether to evict + respawn before returning a cached entry.
+	Healthy() bool
 }
 
 // ProtocolVersion is what we advertise to MCP servers. 2024-11-05 is the

--- a/internal/tools/mcp/protocol.go
+++ b/internal/tools/mcp/protocol.go
@@ -11,7 +11,10 @@ import (
 // protocol-layer helpers below stay transport-agnostic.
 type Caller interface {
 	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
-	Notify(method string, params any) error
+	// Notify sends a fire-and-forget notification. The ctx caps the time
+	// the implementation may spend writing — needed for stdio, where a
+	// stuck pipe could otherwise block past the caller's deadline.
+	Notify(ctx context.Context, method string, params any) error
 	// Healthy reports whether the underlying transport is still able to
 	// serve calls. For stdio: true while the child is alive. For HTTP:
 	// effectively always true (stateless), unless a session has been
@@ -124,7 +127,7 @@ func Initialize(ctx context.Context, c Caller, clientName, clientVersion string)
 	if err := json.Unmarshal(raw, &res); err != nil {
 		return nil, fmt.Errorf("initialize result: %w", err)
 	}
-	if err := c.Notify("notifications/initialized", nil); err != nil {
+	if err := c.Notify(ctx, "notifications/initialized", nil); err != nil {
 		return nil, fmt.Errorf("initialized notify: %w", err)
 	}
 	return &res, nil

--- a/internal/tools/mcp/protocol.go
+++ b/internal/tools/mcp/protocol.go
@@ -1,0 +1,177 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Caller is the minimum surface a transport must expose to drive the MCP
+// protocol. Both stdio.Client and a future http.Client satisfy this so the
+// protocol-layer helpers below stay transport-agnostic.
+type Caller interface {
+	Call(ctx context.Context, method string, params any) (json.RawMessage, error)
+	Notify(method string, params any) error
+}
+
+// ProtocolVersion is what we advertise to MCP servers. 2024-11-05 is the
+// current widely-supported version; 2025-06-18 added structured content but
+// is server-side-optional. Bumping requires adjusting any tools/list result
+// shape we depend on.
+const ProtocolVersion = "2024-11-05"
+
+// ClientInfo is the "we are loomcycle" advert sent in initialize.
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// InitializeParams is the body of the `initialize` request.
+type InitializeParams struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ClientInfo      ClientInfo     `json:"clientInfo"`
+}
+
+// InitializeResult is the server's reply.
+type InitializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities"`
+	ServerInfo      ServerInfo     `json:"serverInfo"`
+}
+
+// ServerInfo is the server's identification.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ToolsListResult is the body of `tools/list` responses.
+type ToolsListResult struct {
+	Tools []ToolDescriptor `json:"tools"`
+}
+
+// ToolDescriptor is one tool the server exposes.
+type ToolDescriptor struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	InputSchema json.RawMessage `json:"inputSchema"`
+}
+
+// CallToolParams is the body of `tools/call`.
+type CallToolParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments"`
+}
+
+// CallToolResult is the body of `tools/call` responses. MCP servers return
+// `content` as a heterogeneous array of typed blocks; for now we only handle
+// text blocks (the dominant case for jobs-search-agent's brave-search use).
+// Future: image, resource, audio.
+type CallToolResult struct {
+	Content []ContentBlock `json:"content"`
+	IsError bool           `json:"isError,omitempty"`
+}
+
+// ContentBlock is one piece of tool output. v0.3 supports type=="text"; other
+// kinds round-trip as opaque raw JSON in the Raw field for callers that want
+// to inspect them.
+type ContentBlock struct {
+	Type string          `json:"type"`
+	Text string          `json:"text,omitempty"`
+	Raw  json.RawMessage `json:"-"` // entire block JSON, set by UnmarshalJSON
+}
+
+// UnmarshalJSON preserves the raw block JSON in Raw so non-text blocks
+// (image, resource, …) survive the round-trip even though we only typed-decode
+// the text branch.
+func (b *ContentBlock) UnmarshalJSON(data []byte) error {
+	type wire struct {
+		Type string `json:"type"`
+		Text string `json:"text,omitempty"`
+	}
+	var w wire
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	b.Type = w.Type
+	b.Text = w.Text
+	b.Raw = make(json.RawMessage, len(data))
+	copy(b.Raw, data)
+	return nil
+}
+
+// Initialize performs the MCP handshake: send `initialize`, receive the
+// server's capabilities, send the `notifications/initialized` notification.
+// After this call the connection is ready for `tools/list` and `tools/call`.
+func Initialize(ctx context.Context, c Caller, clientName, clientVersion string) (*InitializeResult, error) {
+	params := InitializeParams{
+		ProtocolVersion: ProtocolVersion,
+		Capabilities:    map[string]any{},
+		ClientInfo:      ClientInfo{Name: clientName, Version: clientVersion},
+	}
+	raw, err := c.Call(ctx, "initialize", params)
+	if err != nil {
+		return nil, fmt.Errorf("initialize: %w", err)
+	}
+	var res InitializeResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("initialize result: %w", err)
+	}
+	if err := c.Notify("notifications/initialized", nil); err != nil {
+		return nil, fmt.Errorf("initialized notify: %w", err)
+	}
+	return &res, nil
+}
+
+// ListTools fetches the server's tool descriptors via `tools/list`.
+func ListTools(ctx context.Context, c Caller) ([]ToolDescriptor, error) {
+	raw, err := c.Call(ctx, "tools/list", map[string]any{})
+	if err != nil {
+		return nil, fmt.Errorf("tools/list: %w", err)
+	}
+	var res ToolsListResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("tools/list result: %w", err)
+	}
+	return res.Tools, nil
+}
+
+// CallTool invokes a tool via `tools/call`. Arguments must be a JSON object
+// matching the tool's input schema; encode it ahead of time and pass as
+// json.RawMessage. Returns the typed CallToolResult; the server's `isError`
+// flag is preserved.
+func CallTool(ctx context.Context, c Caller, name string, args json.RawMessage) (*CallToolResult, error) {
+	if len(args) == 0 {
+		args = json.RawMessage("{}")
+	}
+	raw, err := c.Call(ctx, "tools/call", CallToolParams{Name: name, Arguments: args})
+	if err != nil {
+		return nil, fmt.Errorf("tools/call %s: %w", name, err)
+	}
+	var res CallToolResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("tools/call %s result: %w", name, err)
+	}
+	return &res, nil
+}
+
+// JoinTextContent concatenates all text blocks in a tool result, separating
+// with newlines. Callers that need the raw structured content should walk
+// res.Content directly.
+func JoinTextContent(res *CallToolResult) string {
+	if res == nil {
+		return ""
+	}
+	var out string
+	for i, b := range res.Content {
+		if b.Type != "text" {
+			continue
+		}
+		if i > 0 && out != "" {
+			out += "\n"
+		}
+		out += b.Text
+	}
+	return out
+}

--- a/internal/tools/mcp/stdio/client.go
+++ b/internal/tools/mcp/stdio/client.go
@@ -152,8 +152,11 @@ func (c *Client) Healthy() bool {
 	}
 }
 
-// Notify sends a JSON-RPC notification (no response expected).
-func (c *Client) Notify(method string, params any) error {
+// Notify sends a JSON-RPC notification (no response expected). The ctx
+// caps the write; if a stuck child has filled the pipe buffer, the write
+// blocks past ctx and Notify returns ctx.Err(). The orphaned write
+// goroutine drains naturally when Close fires (which closes stdin).
+func (c *Client) Notify(ctx context.Context, method string, params any) error {
 	if c.closed.Load() {
 		return errors.New("mcp: client closed")
 	}
@@ -161,7 +164,17 @@ func (c *Client) Notify(method string, params any) error {
 	if err != nil {
 		return err
 	}
-	return c.write(n)
+	done := make(chan error, 1)
+	go func() { done <- c.write(n) }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.doneCh:
+		// Reader goroutine exited (child died) — write is doomed.
+		return errors.New("mcp: server exited")
+	}
 }
 
 // Close terminates the child process. Any in-flight Calls receive a

--- a/internal/tools/mcp/stdio/client.go
+++ b/internal/tools/mcp/stdio/client.go
@@ -1,0 +1,268 @@
+// Package stdio implements an MCP transport over a child process's stdin/stdout.
+// One Client manages one child process. Concurrent Call() invocations multiplex
+// over the same stdio pair — JSON-RPC IDs correlate responses to callers.
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// Config configures a stdio MCP client.
+type Config struct {
+	// Command is the executable to run (e.g. "npx").
+	Command string
+	// Args is passed verbatim to the child.
+	Args []string
+	// Env is appended to the child's environment. Each entry is "KEY=VALUE".
+	Env []string
+	// OnNotification, when non-nil, is invoked for every incoming
+	// notification (e.g. progress updates). Optional.
+	OnNotification func(mcp.Notification)
+	// OnStderr, when non-nil, is called for every line the child writes to
+	// stderr. Useful for surfacing server-side logs in test output.
+	// The default behaviour is to discard stderr.
+	OnStderr func(string)
+}
+
+// Client is one connection to a stdio MCP server. Spawn() spawns the child
+// and starts the reader goroutine; Call sends a request and waits for the
+// matching response. Close kills the child and fails any in-flight Calls.
+type Client struct {
+	cfg Config
+
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+
+	ids     mcp.IDGenerator
+	writeMu sync.Mutex // serialises writes to stdin
+
+	pendMu  sync.Mutex
+	pending map[int64]chan mcp.Response // request ID → response sink
+
+	closed  atomic.Bool
+	doneCh  chan struct{} // closed when the reader goroutine exits
+	exitErr error         // set before doneCh closes; read after
+}
+
+// Spawn starts a child process and returns a connected Client. The caller
+// must Close the client to terminate the child.
+func Spawn(cfg Config) (*Client, error) {
+	cmd := exec.Command(cfg.Command, cfg.Args...) //nolint:gosec // command is operator-supplied via YAML
+	if len(cfg.Env) > 0 {
+		cmd.Env = append(cmd.Environ(), cfg.Env...)
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+	c := &Client{
+		cfg:     cfg,
+		cmd:     cmd,
+		stdin:   stdin,
+		stdout:  stdout,
+		stderr:  stderr,
+		pending: make(map[int64]chan mcp.Response),
+		doneCh:  make(chan struct{}),
+	}
+	go c.readLoop()
+	go c.stderrLoop()
+	return c, nil
+}
+
+// Call sends a JSON-RPC request and waits for the matching response. Returns
+// ctx.Err() if ctx fires; *mcp.Error if the server returned a JSON-RPC error
+// object; or a transport error if the child died mid-call.
+func (c *Client) Call(ctx context.Context, method string, params any) (json.RawMessage, error) {
+	if c.closed.Load() {
+		return nil, errors.New("mcp: client closed")
+	}
+	id := c.ids.Next()
+	req, err := mcp.NewRequest(id, method, params)
+	if err != nil {
+		return nil, err
+	}
+
+	respCh := make(chan mcp.Response, 1)
+	c.pendMu.Lock()
+	c.pending[id] = respCh
+	c.pendMu.Unlock()
+	defer func() {
+		c.pendMu.Lock()
+		delete(c.pending, id)
+		c.pendMu.Unlock()
+	}()
+
+	if err := c.write(req); err != nil {
+		return nil, fmt.Errorf("write: %w", err)
+	}
+
+	select {
+	case resp := <-respCh:
+		if resp.Error != nil {
+			return nil, resp.Error
+		}
+		return resp.Result, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.doneCh:
+		// Reader exited (child died). Surface a useful error.
+		if c.exitErr != nil {
+			return nil, fmt.Errorf("mcp: server exited: %w", c.exitErr)
+		}
+		return nil, errors.New("mcp: server exited")
+	}
+}
+
+// Notify sends a JSON-RPC notification (no response expected).
+func (c *Client) Notify(method string, params any) error {
+	if c.closed.Load() {
+		return errors.New("mcp: client closed")
+	}
+	n, err := mcp.NewNotification(method, params)
+	if err != nil {
+		return err
+	}
+	return c.write(n)
+}
+
+// Close terminates the child process. Any in-flight Calls receive a
+// transport error via doneCh. Idempotent.
+func (c *Client) Close() error {
+	if !c.closed.CompareAndSwap(false, true) {
+		return nil
+	}
+	// Closing stdin signals EOF to a well-behaved server, which should
+	// exit cleanly. If it doesn't, Wait() below will hang until we kill.
+	_ = c.stdin.Close()
+	// Best-effort kill if it hasn't exited; ignore errors.
+	if c.cmd.Process != nil {
+		_ = c.cmd.Process.Kill()
+	}
+	<-c.doneCh
+	return nil
+}
+
+// Wait waits for the reader goroutine to exit (child closed stdout). Useful
+// when the caller wants to drain a finite-script test server.
+func (c *Client) Wait() error {
+	<-c.doneCh
+	return c.exitErr
+}
+
+// write serialises a JSON value as one newline-terminated line on stdin.
+// Concurrent callers are serialised by writeMu so a write doesn't interleave
+// with another's (JSON would still parse, but mixing is brittle).
+func (c *Client) write(v any) error {
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if _, err := c.stdin.Write(buf); err != nil {
+		return err
+	}
+	if _, err := c.stdin.Write([]byte("\n")); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readLoop is the demuxer: it pulls lines off stdout, decodes each as either
+// a Response (routed to pending[id]) or a Notification (handed to OnNotification).
+func (c *Client) readLoop() {
+	defer close(c.doneCh)
+	defer c.failPending()
+
+	scanner := bufio.NewScanner(c.stdout)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// Copy because scanner reuses its buffer.
+		buf := make([]byte, len(line))
+		copy(buf, line)
+
+		frame := mcp.DecodeFrame(buf)
+		switch {
+		case frame.ParseErr != nil:
+			// Malformed line — log via stderr handler if any, otherwise drop.
+			if c.cfg.OnStderr != nil {
+				c.cfg.OnStderr("mcp: parse error: " + frame.ParseErr.Error())
+			}
+		case frame.Response != nil:
+			c.deliver(*frame.Response)
+		case frame.Notification != nil:
+			if c.cfg.OnNotification != nil {
+				c.cfg.OnNotification(*frame.Notification)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		c.exitErr = err
+	}
+	// Reap the child so it doesn't linger as a zombie.
+	if waitErr := c.cmd.Wait(); waitErr != nil && c.exitErr == nil {
+		c.exitErr = waitErr
+	}
+}
+
+// stderrLoop forwards every stderr line to the configured handler (or
+// discards if none). Exits when the child closes stderr.
+func (c *Client) stderrLoop() {
+	scanner := bufio.NewScanner(c.stderr)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		if c.cfg.OnStderr != nil {
+			c.cfg.OnStderr(scanner.Text())
+		}
+	}
+}
+
+func (c *Client) deliver(resp mcp.Response) {
+	c.pendMu.Lock()
+	ch, ok := c.pending[resp.ID]
+	c.pendMu.Unlock()
+	if !ok {
+		// Late or stray response — no caller waiting. Drop silently.
+		return
+	}
+	select {
+	case ch <- resp:
+	default:
+		// Caller already gave up (ctx); buffer was 1; drop.
+	}
+}
+
+// failPending cancels all in-flight Calls when the reader goroutine exits.
+// They observe the closed doneCh in their select.
+func (c *Client) failPending() {
+	c.pendMu.Lock()
+	defer c.pendMu.Unlock()
+	c.pending = map[int64]chan mcp.Response{}
+}

--- a/internal/tools/mcp/stdio/client.go
+++ b/internal/tools/mcp/stdio/client.go
@@ -197,8 +197,13 @@ func (c *Client) readLoop() {
 	defer close(c.doneCh)
 	defer c.failPending()
 
+	// 16 MiB per-line cap. Real-world MCP servers (brave-search, fetch,
+	// filesystem) routinely return single JSON-RPC frames > 4 MiB when a
+	// tool result includes raw HTML or a large file. Hitting the cap
+	// produces bufio.ErrTooLong, which kills the connection — we'd rather
+	// allocate up to 16 MiB once than mark the server permanently dead.
 	scanner := bufio.NewScanner(c.stdout)
-	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
 	for scanner.Scan() {
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -236,7 +241,7 @@ func (c *Client) readLoop() {
 // discards if none). Exits when the child closes stderr.
 func (c *Client) stderrLoop() {
 	scanner := bufio.NewScanner(c.stderr)
-	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	scanner.Buffer(make([]byte, 64*1024), 16*1024*1024)
 	for scanner.Scan() {
 		if c.cfg.OnStderr != nil {
 			c.cfg.OnStderr(scanner.Text())

--- a/internal/tools/mcp/stdio/client.go
+++ b/internal/tools/mcp/stdio/client.go
@@ -136,6 +136,22 @@ func (c *Client) Call(ctx context.Context, method string, params any) (json.RawM
 	}
 }
 
+// Healthy reports whether the child process is still serving calls.
+// Returns false once Close has fired or the readLoop has exited (child
+// died). The check is non-blocking and safe for the Pool's cached-entry
+// fast path.
+func (c *Client) Healthy() bool {
+	if c.closed.Load() {
+		return false
+	}
+	select {
+	case <-c.doneCh:
+		return false
+	default:
+		return true
+	}
+}
+
 // Notify sends a JSON-RPC notification (no response expected).
 func (c *Client) Notify(method string, params any) error {
 	if c.closed.Load() {

--- a/internal/tools/mcp/stdio/client_test.go
+++ b/internal/tools/mcp/stdio/client_test.go
@@ -301,6 +301,35 @@ func TestServerCrashFailsInFlightCalls(t *testing.T) {
 	}
 }
 
+// Regression: a Notify whose ctx is already cancelled must return ctx.Err
+// rather than blocking on the pipe write. We test the easy direction
+// (cancel-then-call) because synthesising a stuck pipe in a unit test is
+// not portable; the goroutine + select shape means a cancelled ctx is
+// honoured immediately if the write is even slightly slow.
+func TestNotifyHonoursCtxCancel(t *testing.T) {
+	c := newClient(t, "ok")
+	// Initialize first so the client is ready (uses a non-cancelled ctx).
+	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer initCancel()
+	if _, err := mcp.Initialize(initCtx, c, "t", "1"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// Now call Notify with an already-cancelled ctx. The goroutine + select
+	// in Notify must return ctx.Err() rather than waiting on the write.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := c.Notify(ctx, "loomcycle/probe", nil)
+	// On a healthy fast pipe the write may complete BEFORE the select sees
+	// ctx.Done — the test passes if the function returned at all without
+	// deadlocking. We only assert that *if* an error was returned, it's
+	// the cancel.
+	if err != nil && err != context.Canceled {
+		t.Errorf("err = %v, want nil or context.Canceled", err)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	c, err := Spawn(Config{Command: os.Args[0], Env: []string{"BE_MCP_SERVER=ok"}})
 	if err != nil {

--- a/internal/tools/mcp/stdio/client_test.go
+++ b/internal/tools/mcp/stdio/client_test.go
@@ -1,0 +1,315 @@
+package stdio
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// TestMain acts as both the test harness AND a fake MCP server. When the
+// test binary is run with BE_MCP_SERVER set, it loops on stdin reading
+// JSON-RPC requests and writing back canned responses. Tests spawn
+// os.Args[0] with that env var to drive a real subprocess through the
+// stdio transport — same code path production will hit.
+func TestMain(m *testing.M) {
+	if mode := os.Getenv("BE_MCP_SERVER"); mode != "" {
+		runFakeServer(mode)
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runFakeServer is a tiny MCP server that handles initialize, tools/list,
+// and tools/call. The mode env value picks the response set:
+//   - "ok"           → ToolEcho returns its input as a text block
+//   - "error"        → tools/call returns a JSON-RPC error
+//   - "tool_iserror" → tools/call returns a result with isError=true
+//   - "slow"         → tools/call sleeps 200ms before responding
+//   - "crash"        → server exits 1 immediately after initialize
+func runFakeServer(mode string) {
+	enc := json.NewEncoder(os.Stdout)
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		// Decode just enough to see method + id.
+		var probe struct {
+			JSONRPC string          `json:"jsonrpc"`
+			ID      *int64          `json:"id"`
+			Method  string          `json:"method"`
+			Params  json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(line, &probe); err != nil {
+			continue
+		}
+		// Notifications: no response.
+		if probe.ID == nil {
+			continue
+		}
+		switch probe.Method {
+		case "initialize":
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"protocolVersion": mcp.ProtocolVersion,
+					"capabilities":    map[string]any{},
+					"serverInfo":      map[string]any{"name": "fake", "version": "0.1"},
+				},
+			})
+			if mode == "crash" {
+				os.Exit(1)
+			}
+		case "tools/list":
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result": map[string]any{
+					"tools": []map[string]any{
+						{
+							"name":        "Echo",
+							"description": "echoes the input string",
+							"inputSchema": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"text": map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "tools/call":
+			if mode == "slow" {
+				time.Sleep(200 * time.Millisecond)
+			}
+			if mode == "error" {
+				_ = enc.Encode(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      *probe.ID,
+					"error":   map[string]any{"code": -32603, "message": "synthetic server error"},
+				})
+				continue
+			}
+			// Decode args to echo back.
+			var p struct {
+				Name      string          `json:"name"`
+				Arguments json.RawMessage `json:"arguments"`
+			}
+			_ = json.Unmarshal(probe.Params, &p)
+			var args struct {
+				Text string `json:"text"`
+			}
+			_ = json.Unmarshal(p.Arguments, &args)
+
+			result := map[string]any{
+				"content": []map[string]any{
+					{"type": "text", "text": "echo: " + args.Text},
+				},
+			}
+			if mode == "tool_iserror" {
+				result["isError"] = true
+			}
+			_ = enc.Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      *probe.ID,
+				"result":  result,
+			})
+		}
+	}
+}
+
+func newClient(t *testing.T, mode string) *Client {
+	t.Helper()
+	c, err := Spawn(Config{
+		Command: os.Args[0],
+		Env:     []string{"BE_MCP_SERVER=" + mode},
+		OnStderr: func(s string) {
+			// Surface server-side errors in test output for debuggability.
+			t.Logf("server stderr: %s", s)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+func TestHandshakeAndListTools(t *testing.T) {
+	c := newClient(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	init, err := mcp.Initialize(ctx, c, "loomcycle-test", "1.0")
+	if err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	if init.ServerInfo.Name != "fake" {
+		t.Errorf("ServerInfo.Name = %q", init.ServerInfo.Name)
+	}
+
+	tools, err := mcp.ListTools(ctx, c)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	if len(tools) != 1 || tools[0].Name != "Echo" {
+		t.Errorf("tools = %+v", tools)
+	}
+}
+
+func TestCallToolHappyPath(t *testing.T) {
+	c := newClient(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	res, err := mcp.CallTool(ctx, c, "Echo", json.RawMessage(`{"text":"hello"}`))
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if got := mcp.JoinTextContent(res); got != "echo: hello" {
+		t.Errorf("text = %q", got)
+	}
+	if res.IsError {
+		t.Errorf("IsError unexpectedly true")
+	}
+}
+
+func TestCallToolReturnsServerError(t *testing.T) {
+	c := newClient(t, "error")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	_, err := mcp.CallTool(ctx, c, "Echo", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected JSON-RPC error")
+	}
+	var rpcErr *mcp.Error
+	// errors.As-equivalent for the typed error path — protocol returns
+	// the raw *mcp.Error wrapped in a fmt.Errorf "%w".
+	if !strings.Contains(err.Error(), "synthetic server error") {
+		t.Errorf("error doesn't mention server message: %v", err)
+	}
+	_ = rpcErr
+}
+
+func TestCallToolPropagatesIsError(t *testing.T) {
+	c := newClient(t, "tool_iserror")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	res, err := mcp.CallTool(ctx, c, "Echo", json.RawMessage(`{"text":"x"}`))
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Errorf("IsError = false, want true")
+	}
+}
+
+func TestConcurrentCalls(t *testing.T) {
+	c := newClient(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	const N = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			args := json.RawMessage(fmt.Sprintf(`{"text":"msg-%d"}`, i))
+			res, err := mcp.CallTool(ctx, c, "Echo", args)
+			if err != nil {
+				errs <- err
+				return
+			}
+			want := fmt.Sprintf("echo: msg-%d", i)
+			if got := mcp.JoinTextContent(res); got != want {
+				errs <- fmt.Errorf("got %q, want %q", got, want)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+func TestCtxCancelMidCall(t *testing.T) {
+	c := newClient(t, "slow")
+	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer initCancel()
+	if _, err := mcp.Initialize(initCtx, c, "t", "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := mcp.CallTool(ctx, c, "Echo", json.RawMessage(`{"text":"x"}`))
+	if err == nil {
+		t.Fatal("expected ctx error (server delayed 200ms; ctx 50ms)")
+	}
+	if !strings.Contains(err.Error(), "context") {
+		t.Errorf("error doesn't surface context: %v", err)
+	}
+}
+
+func TestServerCrashFailsInFlightCalls(t *testing.T) {
+	// "crash" mode: server exits after initialize. Subsequent Calls must
+	// fail with a transport error rather than hang.
+	c := newClient(t, "crash")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := mcp.Initialize(ctx, c, "t", "1"); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+	// Give the child a moment to actually exit.
+	time.Sleep(50 * time.Millisecond)
+
+	_, err := mcp.CallTool(ctx, c, "Echo", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected transport error after server crash")
+	}
+	if !strings.Contains(err.Error(), "exited") && !strings.Contains(err.Error(), "closed") {
+		t.Errorf("error doesn't mention server exit: %v", err)
+	}
+}
+
+func TestCloseIsIdempotent(t *testing.T) {
+	c, err := Spawn(Config{Command: os.Args[0], Env: []string{"BE_MCP_SERVER=ok"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("second Close errored: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Second batch of v0.3 work, completing the MCP layer end-to-end. Stdio + HTTP transports, lazy-resolve pool with auto-respawn on dead servers, per-server YAML `allowed_tools` filter, ctx-aware notifications, and JSON-RPC response-ID validation. Two review passes during development; the post-fix state was approved by an independent reviewer.

## What's in

| Commit | What |
|---|---|
| `6be239e` | JSON-RPC core + stdio transport + protocol layer + pool foundation |
| `98085a9` | Wire MCP pool into cmd/loomcycle (stdio only, per-tenant via tool args) |
| `d9bfbda` | Review fix #1: per-name init lock; 16 MiB scanner cap; ctx-cancel surfaces in Execute; deterministic env order |
| `9341ea7` | `Caller.Healthy()` + lazy resolve in `mcpTool.Execute` + auto-respawn on dead pool entries |
| `7d1715d` | HTTP MCP transport (single POST → JSON, `Mcp-Session-Id` propagation, 404 → mark dead) |
| `24d84d8` | Wire HTTP transport + per-server `allowed_tools` filter into cmd/loomcycle |
| `5cbbec4` | Review fix #2: 30s shared MCP-init budget; teardown closer-miss log; `applyAllowedToolsFilter` unit test |
| `cc403e7` | Review follow-ups: ctx-aware `Notify` across both transports + HTTP response-ID validation |

## What's NEW for callers / operators

### Config
```yaml
mcp_servers:
  brave-search:
    transport: stdio                # or "http"
    command: npx                    # stdio: command + args + env
    args: [-y, "@modelcontextprotocol/server-brave-search"]
    env: { BRAVE_API_KEY: "${BRAVE_API_KEY}" }
    allowed_tools: [brave_web_search]   # optional: narrow what's exposed
  remote-search:
    transport: http
    url: https://mcp.example.com/v1
    headers: { Authorization: "Bearer ${LOOMCYCLE_REMOTE_TOKEN}" }
```

Each MCP tool is registered as `mcp__{server}__{tool}` so existing agent allow/deny lists with globs (e.g. `mcp__brave-search__*`) work unchanged.

### Behaviour
- Concurrent tool calls multiplex over one stdio connection per server (JSON-RPC ID demuxing).
- A crashed stdio child is respawned on the next call (Pool checks `Healthy()` on cached entries).
- HTTP MCP servers that invalidate a session (`404`) are marked dead, evicted, and respawned the same way.
- Per-server `allowed_tools` complements per-agent allowlists: server limits are config-time; agent limits are call-time.
- Startup-time MCP init shares a 30s budget across all servers — N×30s can't stack into K8s liveness territory.

## Verification

- [x] `go test -race ./...` — all 14 packages green from clean cache, **27+ MCP tests** (8 stdio, 8 HTTP, 11 pool, 1 wire-up + ID/ctx regression coverage)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go mod tidy` no diff
- [x] `go build -o bin/loomcycle ./cmd/loomcycle` clean
- [x] Smoke tested with both transports: stdio fake server (handshake + 1/1 tools registered after allowed_tools filter), HTTP example.invalid (soft-fail with DNS error)

## Two review passes, both with empirical-proof regression tests

| Round | Findings | Resolution |
|---|---|---|
| Post-foundation (commits 6be239e..98085a9) | 3 important: `p.mu` blocks across network IO; 4 MiB scanner cap; ctx-cancel masquerades as `IsError` retry | Fixed in `d9bfbda` with regression tests that fail on unfixed code |
| Post-additions (HTTP + respawn + allowed) | 1 important: serial startup ×N×30s; 2 minor (closer log, filter test) | Fixed in `5cbbec4`; deferred items addressed in `cc403e7` |

## Breaking changes

None at the HTTP API or YAML schema level. Internal interface change: `mcp.Caller.Notify` gained a `ctx context.Context` parameter; internal users updated.

## What's next (still in v0.3 plan, deferred)

- Per-session in-process mutex around continuation (concurrent POSTs to `/v1/sessions/{id}/messages` can interleave events)
- Built-in tools: Write, Edit, sandboxed Bash, HTTP, WebFetch, WebSearch
- Response KV cache (in-memory LRU)
- Python adapter
- Examples + `jobs-search-agent` rollout phases A + B

These can ship as point releases (v0.3.1, v0.3.2, …) or rolled into v0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)