### PR TITLE
v0.3.1: provider rate-limit retry (preserve context across 429)

### DIFF
--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -88,6 +89,11 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		ParseHeader: ratelimit.AnthropicRetryAfter,
 	}, attempt)
 	if err != nil {
+		// ctx errors aren't HTTP errors — propagate as-is so the loop's
+		// errors.Is(ctx.Err()) checks aren't masked by the "http:" prefix.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("http: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
 )
 
 const (
@@ -55,22 +56,37 @@ func (d *Driver) Capabilities() providers.Capabilities {
 
 // Call sends the request and returns a channel of Events. The channel is
 // closed when the stream ends (clean or error). Cancel ctx to abort.
+//
+// 429 retry: if Anthropic rate-limits the request, ratelimit.Do honours
+// the Retry-After header (or the exponential fallback) and re-sends the
+// same body bytes — preserving the full conversation history, tool
+// definitions, system blocks, and cache_control breakpoints. The agent
+// loop sees no failure on a transient rate-limit; it just observes a
+// longer round-trip.
 func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
 	body, err := buildRequestBody(req)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/v1/messages", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
+	attempt := func(ctx context.Context) (*http.Response, error) {
+		// Build a fresh request each attempt — http.Request.Body is
+		// consumed by Do, so a single Reader can't be reused.
+		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("x-api-key", d.apiKey)
+		req.Header.Set("anthropic-version", apiVersion)
+		return d.http.Do(req)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
-	httpReq.Header.Set("x-api-key", d.apiKey)
-	httpReq.Header.Set("anthropic-version", apiVersion)
 
-	resp, err := d.http.Do(httpReq)
+	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+		Provider:    "anthropic",
+		ParseHeader: ratelimit.AnthropicRetryAfter,
+	}, attempt)
 	if err != nil {
 		return nil, fmt.Errorf("http: %w", err)
 	}

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
@@ -241,6 +242,67 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	// is preserved.
 	if !bytes.Equal(bodies[0], bodies[1]) {
 		t.Errorf("retry sent different body:\n  call 1: %s\n  call 2: %s", string(bodies[0]), string(bodies[1]))
+	}
+}
+
+// Integration regression: a 429 mid-loop must not bubble out as an EventError.
+// The retry happens inside the driver's Call(); the loop sees only the
+// recovered 200 response. Run() should return cleanly with end_turn and the
+// caller's OnEvent must NOT observe any error event.
+//
+// This is the load-bearing guarantee of v0.3.1: a transient rate limit
+// preserves the run's context. The driver-level test verifies the body
+// is re-sent; this loop-level test verifies the agent loop is unaffected.
+func TestRetryOn429IsInvisibleToLoop(t *testing.T) {
+	var callNum int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callNum++
+		n := callNum
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"recovered after 429\"}}\n\n")
+		fmt.Fprint(w, "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n")
+		fmt.Fprint(w, "event: message_stop\ndata: {}\n\n")
+	}))
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+
+	var observedEvents []providers.EventType
+	res, err := loop.Run(context.Background(), loop.RunOptions{
+		Provider: d,
+		Model:    "claude-sonnet-4-6",
+		Segments: []loop.PromptSegment{
+			{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: "hi"}}},
+		},
+		OnEvent: func(ev providers.Event) {
+			observedEvents = append(observedEvents, ev.Type)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run returned error after 429-then-200: %v", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+	for _, evType := range observedEvents {
+		if evType == providers.EventError {
+			t.Errorf("loop emitted EventError despite driver-level retry recovery")
+		}
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if callNum != 2 {
+		t.Errorf("server got %d calls, want 2 (driver should have retried)", callNum)
 	}
 }
 

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -1,6 +1,7 @@
 package anthropic
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -174,6 +176,72 @@ func isStreamEventsRunning(t *testing.T) bool {
 	buf := make([]byte, 64*1024)
 	n := runtime.Stack(buf, true)
 	return strings.Contains(string(buf[:n]), ".streamEvents(")
+}
+
+// Regression: a 429 from Anthropic must trigger a retry, not fail the run.
+// The driver's retry-wrapper re-sends the exact same body bytes — preserving
+// the full conversation context (messages, tools, system, cache_control)
+// across the rate limit. We assert the second request carries the same
+// body the first one did, AND the second request's stream is what the
+// caller eventually consumes.
+func TestRetryOn429PreservesContext(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		callNum int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		callNum++
+		bodies = append(bodies, body)
+		n := callNum
+		mu.Unlock()
+
+		if n == 1 {
+			// First call: 429 with a 0-second retry-after so the test runs fast.
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))
+			return
+		}
+		// Second call: stream a normal response.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"recovered\"}}\n\n")
+		fmt.Fprint(w, "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n")
+		fmt.Fprint(w, "event: message_stop\ndata: {}\n\n")
+	}))
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "claude-sonnet-4-6",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var text strings.Builder
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			text.WriteString(ev.Text)
+		}
+	}
+	if text.String() != "recovered" {
+		t.Errorf("text = %q, want %q (second-call stream not delivered)", text.String(), "recovered")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if callNum != 2 {
+		t.Fatalf("server got %d calls, want 2 (no retry)", callNum)
+	}
+	// Body bytes must be identical across attempts — that's how context
+	// is preserved.
+	if !bytes.Equal(bodies[0], bodies[1]) {
+		t.Errorf("retry sent different body:\n  call 1: %s\n  call 2: %s", string(bodies[0]), string(bodies[1]))
+	}
 }
 
 func TestRequestBodyShape(t *testing.T) {

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
 )
 
 const (
@@ -65,20 +66,29 @@ func (d *Driver) Capabilities() providers.Capabilities {
 
 // Call sends the chat request and streams Events. The goroutine that reads
 // the response closes the channel when the stream ends.
+// 429 retry: Ollama OSS doesn't rate-limit (no 429 expected on a local
+// server). Ollama Cloud may emit a standard Retry-After; we handle it
+// defensively. Same body-bytes-preserved retry as the cloud providers.
 func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
 	body, err := buildRequestBody(req)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/api/chat", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
+	attempt := func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/api/chat", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/x-ndjson")
+		return d.http.Do(req)
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "application/x-ndjson")
 
-	resp, err := d.http.Do(httpReq)
+	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+		Provider:    "ollama",
+		ParseHeader: ratelimit.OllamaRetryAfter,
+	}, attempt)
 	if err != nil {
 		return nil, fmt.Errorf("http: %w", err)
 	}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -90,6 +91,9 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		ParseHeader: ratelimit.OllamaRetryAfter,
 	}, attempt)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("http: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -1,6 +1,7 @@
 package ollama
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -256,6 +258,60 @@ func TestNon200Status(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "404") {
 		t.Errorf("error doesn't mention status code: %v", err)
+	}
+}
+
+// Regression: Ollama Cloud may emit a 429 with Retry-After. The driver
+// retries with the same body. (Ollama OSS doesn't 429, but the wrap is
+// shared transport-level code so we exercise it here defensively.)
+func TestRetryOn429PreservesContext(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		callNum int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		callNum++
+		bodies = append(bodies, body)
+		n := callNum
+		mu.Unlock()
+
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"error":"too many requests"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"model":"llama3.1","message":{"role":"assistant","content":"recovered"},"done":false}`+"\n")
+		fmt.Fprint(w, `{"model":"llama3.1","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`+"\n")
+	}))
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var text strings.Builder
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			text.WriteString(ev.Text)
+		}
+	}
+	if text.String() != "recovered" {
+		t.Errorf("text = %q, want %q", text.String(), "recovered")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if callNum != 2 {
+		t.Fatalf("server got %d calls, want 2", callNum)
+	}
+	if !bytes.Equal(bodies[0], bodies[1]) {
+		t.Errorf("retry body differs from original")
 	}
 }
 

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
 )
 
 const (
@@ -60,23 +61,35 @@ func (d *Driver) Capabilities() providers.Capabilities {
 
 // Call sends the request and returns a channel of Events. The goroutine that
 // reads the response closes the channel when the stream ends.
+//
+// 429 retry: ratelimit.Do honours OpenAI's Retry-After header when present;
+// otherwise it reads the bigger of x-ratelimit-reset-{requests,tokens}
+// (relative durations like "120ms" or "12.5s") so we wait for the more
+// constrained bucket. The same body bytes are re-sent — full conversation
+// context preserved across the rate limit.
 func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
 	body, err := buildRequestBody(req)
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("new request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
-	if d.apiKey != "" {
-		httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+	attempt := func(ctx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		if d.apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+d.apiKey)
+		}
+		return d.http.Do(req)
 	}
 
-	resp, err := d.http.Do(httpReq)
+	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+		Provider:    "openai",
+		ParseHeader: ratelimit.OpenAIRetryAfter,
+	}, attempt)
 	if err != nil {
 		return nil, fmt.Errorf("http: %w", err)
 	}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -91,6 +92,9 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		ParseHeader: ratelimit.OpenAIRetryAfter,
 	}, attempt)
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
 		return nil, fmt.Errorf("http: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -284,6 +286,64 @@ func isStreamEventsRunning(t *testing.T) bool {
 	buf := make([]byte, 64*1024)
 	n := runtime.Stack(buf, true)
 	return strings.Contains(string(buf[:n]), ".streamEvents(")
+}
+
+// Regression: OpenAI 429 with x-ratelimit-reset-* headers (no Retry-After)
+// triggers a retry that re-sends the same body. Specifically tests the
+// header-fallback path: Retry-After absent, x-ratelimit-reset-tokens=0s.
+func TestRetryOn429PreservesContext(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		callNum int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		callNum++
+		bodies = append(bodies, body)
+		n := callNum
+		mu.Unlock()
+
+		if n == 1 {
+			// 429 — no Retry-After, but x-ratelimit-reset-tokens=0s
+			// exercises the OpenAI parser fallback path.
+			w.Header().Set("X-Ratelimit-Reset-Requests", "100ms")
+			w.Header().Set("X-Ratelimit-Reset-Tokens", "0s")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"error":{"type":"rate_limit_exceeded","message":"slow down"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"recovered"}}]}`+"\n\n")
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{Model: "gpt-4o-mini"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var text strings.Builder
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			text.WriteString(ev.Text)
+		}
+	}
+	if text.String() != "recovered" {
+		t.Errorf("text = %q, want %q", text.String(), "recovered")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if callNum != 2 {
+		t.Fatalf("server got %d calls, want 2", callNum)
+	}
+	if !bytes.Equal(bodies[0], bodies[1]) {
+		t.Errorf("retry body differs from original")
+	}
 }
 
 func TestNon200Status(t *testing.T) {

--- a/internal/providers/ratelimit/backoff.go
+++ b/internal/providers/ratelimit/backoff.go
@@ -1,0 +1,197 @@
+// Package ratelimit provides shared 429-retry handling for provider drivers.
+//
+// Why a shared helper: each provider (Anthropic, OpenAI, Ollama) returns 429
+// with different headers, but the response is the same shape for our
+// purposes — drain body, sleep some duration, retry the exact same request.
+// The helper owns the loop + sleep + ctx logic; per-provider parsers in
+// headers.go know how to read each provider's retry-after signal.
+//
+// Why retrying inside the driver matters: without it, a 429 surfaces as an
+// EventError, the loop's run terminates with status=failed, and the agent's
+// conversation context is lost. Retrying preserves the entire request
+// (messages, tools, system blocks, cache breakpoints) by virtue of holding
+// the marshalled body bytes outside the retry loop and re-sending them.
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+// ParseFn extracts a retry-after duration from response headers. Returns
+// (delay, ok) where ok=false means no retry-after-equivalent header was
+// found and the caller should fall back to the exponential schedule.
+type ParseFn func(http.Header) (time.Duration, bool)
+
+// Config configures the retry behaviour. All fields except ParseHeader
+// have sensible defaults applied by Do.
+type Config struct {
+	// ParseHeader extracts a retry-after wait from response headers.
+	// Required.
+	ParseHeader ParseFn
+
+	// Provider is a label included in retry logs. Optional.
+	Provider string
+
+	// MaxAttempts is the maximum number of attempts (including the first).
+	// Default: 5.
+	MaxAttempts int
+
+	// MaxTotalWait caps the total time spent waiting across all retries.
+	// Once exceeded, the last 429 response is returned without further
+	// retry. Default: 5 minutes.
+	MaxTotalWait time.Duration
+
+	// Schedule is the fallback delay schedule used when ParseHeader
+	// returns ok=false. Indexed by attempt number (0 = first retry).
+	// Default: 10s, 20s, 40s, 60s, 120s.
+	Schedule []time.Duration
+
+	// Jitter is the fraction (0..1) of the computed delay to randomise
+	// per retry. Default: 0.2 (±20%). Set to 0 in tests for determinism.
+	Jitter float64
+
+	// OnRetry is called before each sleep with diagnostic info. The
+	// default writes a structured log line via the standard logger.
+	OnRetry func(provider string, attempt int, wait time.Duration, reason string)
+
+	// rng is for tests to inject a deterministic source. nil = global rand.
+	rng *rand.Rand
+}
+
+// Default schedule applied when no Retry-After header is parsed.
+var defaultSchedule = []time.Duration{
+	10 * time.Second,
+	20 * time.Second,
+	40 * time.Second,
+	60 * time.Second,
+	120 * time.Second,
+}
+
+func (c *Config) applyDefaults() {
+	if c.MaxAttempts <= 0 {
+		c.MaxAttempts = 5
+	}
+	if c.MaxTotalWait <= 0 {
+		c.MaxTotalWait = 5 * time.Minute
+	}
+	if len(c.Schedule) == 0 {
+		c.Schedule = defaultSchedule
+	}
+	if c.Jitter < 0 {
+		c.Jitter = 0
+	}
+	if c.OnRetry == nil {
+		c.OnRetry = defaultOnRetry
+	}
+}
+
+func defaultOnRetry(provider string, attempt int, wait time.Duration, reason string) {
+	log.Printf(`{"event":"rate_limit_retry","provider":%q,"attempt":%d,"wait":%q,"reason":%q}`,
+		provider, attempt, wait.String(), reason)
+}
+
+// Reason strings passed to OnRetry.
+const (
+	ReasonHeader   = "retry-after header"
+	ReasonSchedule = "exponential backoff"
+)
+
+// Do calls attempt repeatedly until it returns a non-429 response or the
+// retry budget is exhausted. The returned response is the first non-429 (on
+// success) or the last 429 (on budget exhaustion); in both cases its body
+// has NOT been read — caller owns it.
+//
+// Bodies of intermediate 429 responses are drained + closed by Do so the
+// underlying TCP connection can be reused for the retry.
+//
+// ctx propagates into each attempt and into the inter-attempt sleep; a
+// cancelled ctx breaks out of the sleep immediately and returns ctx.Err().
+//
+// Network errors from attempt are returned immediately without retry; this
+// helper is specifically for HTTP 429, not for arbitrary transient failures.
+func Do(ctx context.Context, cfg Config, attempt func(ctx context.Context) (*http.Response, error)) (*http.Response, error) {
+	if cfg.ParseHeader == nil {
+		return nil, errors.New("ratelimit: ParseHeader is required")
+	}
+	cfg.applyDefaults()
+
+	var totalWait time.Duration
+	var lastResp *http.Response
+
+	for i := 0; i < cfg.MaxAttempts; i++ {
+		resp, err := attempt(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+		lastResp = resp
+
+		// Last attempt — return the 429 with its body intact so the caller
+		// can read the error message.
+		if i+1 >= cfg.MaxAttempts {
+			break
+		}
+
+		// Compute wait
+		wait, fromHeader := cfg.ParseHeader(resp.Header)
+		reason := ReasonHeader
+		if !fromHeader {
+			reason = ReasonSchedule
+			idx := i
+			if idx >= len(cfg.Schedule) {
+				idx = len(cfg.Schedule) - 1
+			}
+			wait = cfg.Schedule[idx]
+		}
+		wait = applyJitter(wait, cfg.Jitter, cfg.rng)
+
+		// Total-wait budget guard.
+		if totalWait+wait > cfg.MaxTotalWait {
+			break
+		}
+
+		// Drain + close so the connection is reusable for the retry.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		cfg.OnRetry(cfg.Provider, i+1, wait, reason)
+
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+		totalWait += wait
+	}
+	// Budget exhausted; return the last 429 untouched (body intact for
+	// caller's normal error path).
+	return lastResp, nil
+}
+
+// applyJitter returns d ± frac×d. With frac=0 returns d unchanged. With
+// rng==nil uses the global rand.
+func applyJitter(d time.Duration, frac float64, rng *rand.Rand) time.Duration {
+	if frac <= 0 {
+		return d
+	}
+	delta := float64(d) * frac
+	var off float64
+	if rng != nil {
+		off = rng.Float64()*2*delta - delta
+	} else {
+		off = rand.Float64()*2*delta - delta
+	}
+	out := time.Duration(float64(d) + off)
+	if out < 0 {
+		return 0
+	}
+	return out
+}

--- a/internal/providers/ratelimit/backoff.go
+++ b/internal/providers/ratelimit/backoff.go
@@ -107,8 +107,10 @@ const (
 // success) or the last 429 (on budget exhaustion); in both cases its body
 // has NOT been read — caller owns it.
 //
-// Bodies of intermediate 429 responses are drained + closed by Do so the
-// underlying TCP connection can be reused for the retry.
+// Bodies of intermediate 429 responses (i.e. those followed by another
+// retry) are drained + closed by Do so the underlying TCP connection can
+// be reused. The body of the final 429 (returned on budget exhaustion) is
+// preserved so the caller can read the error message.
 //
 // ctx propagates into each attempt and into the inter-attempt sleep; a
 // cancelled ctx breaks out of the sleep immediately and returns ctx.Err().
@@ -164,9 +166,14 @@ func Do(ctx context.Context, cfg Config, attempt func(ctx context.Context) (*htt
 
 		cfg.OnRetry(cfg.Provider, i+1, wait, reason)
 
+		// time.NewTimer + defer Stop instead of time.After so a ctx-cancel
+		// during the wait doesn't leak the underlying timer until expiry.
+		// Trivial at 5min max wait but the canonical pattern.
+		t := time.NewTimer(wait)
 		select {
-		case <-time.After(wait):
+		case <-t.C:
 		case <-ctx.Done():
+			t.Stop()
 			return nil, ctx.Err()
 		}
 		totalWait += wait

--- a/internal/providers/ratelimit/backoff_test.go
+++ b/internal/providers/ratelimit/backoff_test.go
@@ -1,0 +1,248 @@
+package ratelimit
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeResp builds a minimal *http.Response usable in tests.
+func fakeResp(status int, headers map[string]string, body string) *http.Response {
+	h := http.Header{}
+	for k, v := range headers {
+		h.Set(k, v)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     h,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestNonZeroAttemptReturnsImmediately(t *testing.T) {
+	calls := atomic.Int32{}
+	resp, err := Do(context.Background(), Config{
+		ParseHeader: AnthropicRetryAfter,
+		Jitter:      0,
+	}, func(ctx context.Context) (*http.Response, error) {
+		calls.Add(1)
+		return fakeResp(200, nil, "ok"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if calls.Load() != 1 {
+		t.Errorf("attempts = %d, want 1", calls.Load())
+	}
+}
+
+func TestRetriesOn429ThenSucceeds(t *testing.T) {
+	calls := atomic.Int32{}
+	cfg := Config{
+		ParseHeader:  AnthropicRetryAfter,
+		MaxAttempts:  3,
+		Schedule:     []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+		Jitter:       0,
+		Provider:     "test",
+		MaxTotalWait: time.Second,
+		OnRetry:      func(string, int, time.Duration, string) {},
+	}
+
+	resp, err := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			// 429 with no Retry-After → exp schedule kicks in
+			return fakeResp(429, nil, "rate limited"), nil
+		}
+		return fakeResp(200, nil, "ok"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("final status = %d", resp.StatusCode)
+	}
+	if calls.Load() != 3 {
+		t.Errorf("attempts = %d, want 3", calls.Load())
+	}
+}
+
+func TestRetryAfterHeaderHonored(t *testing.T) {
+	var observedWaits []time.Duration
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		MaxAttempts: 2,
+		Jitter:      0,
+		OnRetry: func(_ string, _ int, wait time.Duration, _ string) {
+			observedWaits = append(observedWaits, wait)
+		},
+	}
+	calls := atomic.Int32{}
+	_, err := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return fakeResp(429, map[string]string{"Retry-After": "0"}, ""), nil
+		}
+		return fakeResp(200, nil, "ok"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observedWaits) != 1 || observedWaits[0] != 0 {
+		t.Errorf("observed waits %v, want [0s] (Retry-After: 0 honored)", observedWaits)
+	}
+}
+
+func TestExpScheduleUsedWhenNoHeader(t *testing.T) {
+	var observedReason string
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		MaxAttempts: 2,
+		Schedule:    []time.Duration{0},
+		Jitter:      0,
+		OnRetry: func(_ string, _ int, _ time.Duration, reason string) {
+			observedReason = reason
+		},
+	}
+	calls := atomic.Int32{}
+	_, _ = Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return fakeResp(429, nil, ""), nil // no Retry-After
+		}
+		return fakeResp(200, nil, ""), nil
+	})
+	if observedReason != ReasonSchedule {
+		t.Errorf("reason = %q, want %q", observedReason, ReasonSchedule)
+	}
+}
+
+func TestCtxCancelDuringWait(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		MaxAttempts: 3,
+		Schedule:    []time.Duration{500 * time.Millisecond},
+		Jitter:      0,
+		OnRetry: func(string, int, time.Duration, string) {
+			// Cancel the moment we enter the sleep.
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				cancel()
+			}()
+		},
+	}
+	_, err := Do(ctx, cfg, func(ctx context.Context) (*http.Response, error) {
+		return fakeResp(429, nil, ""), nil
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err = %v, want context.Canceled", err)
+	}
+}
+
+func TestBudgetExhaustionReturnsLast429(t *testing.T) {
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		MaxAttempts: 2,
+		Schedule:    []time.Duration{1 * time.Millisecond},
+		Jitter:      0,
+		OnRetry:     func(string, int, time.Duration, string) {},
+	}
+	calls := atomic.Int32{}
+	resp, err := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		calls.Add(1)
+		return fakeResp(429, nil, "still busy"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 429 {
+		t.Errorf("expected 429 on exhaustion, got %d", resp.StatusCode)
+	}
+	if calls.Load() != 2 {
+		t.Errorf("attempts = %d, want 2", calls.Load())
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "still busy" {
+		t.Errorf("body = %q (caller should still see error message)", string(body))
+	}
+}
+
+func TestMaxTotalWaitGuardStopsRetries(t *testing.T) {
+	cfg := Config{
+		ParseHeader:  AnthropicRetryAfter,
+		MaxAttempts:  10,
+		MaxTotalWait: 5 * time.Millisecond,
+		// Each retry asks for 100ms; second retry would push over budget.
+		Schedule: []time.Duration{100 * time.Millisecond},
+		Jitter:   0,
+		OnRetry:  func(string, int, time.Duration, string) {},
+	}
+	calls := atomic.Int32{}
+	resp, _ := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		calls.Add(1)
+		return fakeResp(429, nil, ""), nil
+	})
+	// Should attempt exactly once: the budget guard fires before the first
+	// sleep because 100ms > 5ms remaining.
+	if calls.Load() != 1 {
+		t.Errorf("attempts = %d, want 1 (budget guard should block first retry)", calls.Load())
+	}
+	if resp.StatusCode != 429 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+}
+
+func TestPropagatesAttemptError(t *testing.T) {
+	myErr := errors.New("network down")
+	_, err := Do(context.Background(), Config{
+		ParseHeader: AnthropicRetryAfter,
+		Jitter:      0,
+	}, func(ctx context.Context) (*http.Response, error) {
+		return nil, myErr
+	})
+	if !errors.Is(err, myErr) {
+		t.Errorf("err = %v, want network down", err)
+	}
+}
+
+func TestParseHeaderRequired(t *testing.T) {
+	_, err := Do(context.Background(), Config{}, func(ctx context.Context) (*http.Response, error) {
+		return fakeResp(200, nil, ""), nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "ParseHeader") {
+		t.Errorf("err = %v, want ParseHeader required", err)
+	}
+}
+
+func TestJitterIsBoundedAndDeterministic(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	d := 100 * time.Millisecond
+	got := applyJitter(d, 0.2, rng)
+	if got < 80*time.Millisecond || got > 120*time.Millisecond {
+		t.Errorf("jittered = %v, want within ±20%% of 100ms", got)
+	}
+	// Same seed produces same value (determinism for tests).
+	rng2 := rand.New(rand.NewSource(42))
+	got2 := applyJitter(d, 0.2, rng2)
+	if got != got2 {
+		t.Errorf("jitter not deterministic with same seed: %v vs %v", got, got2)
+	}
+}
+
+func TestJitterZeroIsIdentity(t *testing.T) {
+	d := 100 * time.Millisecond
+	got := applyJitter(d, 0, nil)
+	if got != d {
+		t.Errorf("jitter=0 changed duration: %v", got)
+	}
+}

--- a/internal/providers/ratelimit/headers.go
+++ b/internal/providers/ratelimit/headers.go
@@ -1,0 +1,63 @@
+package ratelimit
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// AnthropicRetryAfter parses Anthropic Messages API rate-limit headers.
+// Anthropic always emits `retry-after` (integer seconds) on 429 per the
+// public docs. The richer `anthropic-ratelimit-*-reset` headers are RFC 3339
+// timestamps useful for proactive throttling but redundant on 429.
+func AnthropicRetryAfter(h http.Header) (time.Duration, bool) {
+	return parseRetryAfterSeconds(h.Get("Retry-After"))
+}
+
+// OpenAIRetryAfter parses OpenAI Chat Completions rate-limit headers.
+//
+// OpenAI's Retry-After is sometimes present (seconds) but not guaranteed.
+// On every response (200 or 429) they emit relative durations like "120ms"
+// or "12.5s" in `x-ratelimit-reset-requests` and `x-ratelimit-reset-tokens`
+// telling you when each bucket refills. We try Retry-After first, then take
+// the larger of the two reset windows so we wait for the more constrained
+// bucket.
+func OpenAIRetryAfter(h http.Header) (time.Duration, bool) {
+	if d, ok := parseRetryAfterSeconds(h.Get("Retry-After")); ok {
+		return d, true
+	}
+	var max time.Duration
+	for _, k := range []string{"X-Ratelimit-Reset-Requests", "X-Ratelimit-Reset-Tokens"} {
+		if v := h.Get(k); v != "" {
+			if d, err := time.ParseDuration(v); err == nil && d > max {
+				max = d
+			}
+		}
+	}
+	if max > 0 {
+		return max, true
+	}
+	return 0, false
+}
+
+// OllamaRetryAfter parses Ollama rate-limit headers. The OSS server
+// doesn't 429 in practice, but Ollama Cloud may emit a standard Retry-After.
+// Defensive: same shape as Anthropic.
+func OllamaRetryAfter(h http.Header) (time.Duration, bool) {
+	return parseRetryAfterSeconds(h.Get("Retry-After"))
+}
+
+// parseRetryAfterSeconds parses an HTTP Retry-After header in seconds form.
+// HTTP also allows HTTP-date form (RFC 7231); we don't support it because
+// none of the three providers use it. Returns (0, false) on missing /
+// malformed.
+func parseRetryAfterSeconds(v string) (time.Duration, bool) {
+	if v == "" {
+		return 0, false
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs < 0 {
+		return 0, false
+	}
+	return time.Duration(secs) * time.Second, true
+}

--- a/internal/providers/ratelimit/headers.go
+++ b/internal/providers/ratelimit/headers.go
@@ -19,23 +19,33 @@ func AnthropicRetryAfter(h http.Header) (time.Duration, bool) {
 // OpenAI's Retry-After is sometimes present (seconds) but not guaranteed.
 // On every response (200 or 429) they emit relative durations like "120ms"
 // or "12.5s" in `x-ratelimit-reset-requests` and `x-ratelimit-reset-tokens`
-// telling you when each bucket refills. We try Retry-After first, then take
-// the larger of the two reset windows so we wait for the more constrained
-// bucket.
+// telling you when each bucket refills.
+//
+// When Retry-After is missing and we have both reset values, we take the
+// MIN of the non-zero ones rather than the max. Reasoning: a 429 means at
+// least one bucket emptied, but we don't know which. Picking the max
+// always succeeds on the first retry but over-waits when the empty bucket
+// was the smaller one. Picking the min is responsive: if we guessed
+// right, we retry at the perfect moment; if wrong, we 429 again and the
+// next retry sleeps the *real* needed wait. Total wall-clock wait is
+// the same as max in the wrong-guess case but we use one extra attempt
+// budget — cheap (we have 5 attempts).
 func OpenAIRetryAfter(h http.Header) (time.Duration, bool) {
 	if d, ok := parseRetryAfterSeconds(h.Get("Retry-After")); ok {
 		return d, true
 	}
-	var max time.Duration
+	var min time.Duration
 	for _, k := range []string{"X-Ratelimit-Reset-Requests", "X-Ratelimit-Reset-Tokens"} {
 		if v := h.Get(k); v != "" {
-			if d, err := time.ParseDuration(v); err == nil && d > max {
-				max = d
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				if min == 0 || d < min {
+					min = d
+				}
 			}
 		}
 	}
-	if max > 0 {
-		return max, true
+	if min > 0 {
+		return min, true
 	}
 	return 0, false
 }

--- a/internal/providers/ratelimit/headers_test.go
+++ b/internal/providers/ratelimit/headers_test.go
@@ -51,15 +51,29 @@ func TestOpenAIRetryAfterPrefersRetryAfter(t *testing.T) {
 	}
 }
 
-func TestOpenAIRetryAfterFallsBackToResetTokens(t *testing.T) {
-	// No Retry-After; pick the bigger reset.
+func TestOpenAIRetryAfterFallsBackToSmallerReset(t *testing.T) {
+	// No Retry-After; pick the smaller non-zero reset (responsiveness +
+	// retry-budget trade-off; see headers.go for the full reasoning).
 	h := headers(
 		"X-Ratelimit-Reset-Requests", "100ms",
 		"X-Ratelimit-Reset-Tokens", "12.5s",
 	)
 	d, ok := OpenAIRetryAfter(h)
-	if !ok || d != 12500*time.Millisecond {
-		t.Errorf("got (%v, %v), want (12.5s, true)", d, ok)
+	if !ok || d != 100*time.Millisecond {
+		t.Errorf("got (%v, %v), want (100ms, true)", d, ok)
+	}
+}
+
+func TestOpenAIRetryAfterIgnoresZeroReset(t *testing.T) {
+	// Zero on one bucket means it's already refilled — should not be
+	// chosen as the wait. The non-zero bucket's reset is the answer.
+	h := headers(
+		"X-Ratelimit-Reset-Requests", "0s",
+		"X-Ratelimit-Reset-Tokens", "5s",
+	)
+	d, ok := OpenAIRetryAfter(h)
+	if !ok || d != 5*time.Second {
+		t.Errorf("got (%v, %v), want (5s, true) — zero bucket should be ignored", d, ok)
 	}
 }
 

--- a/internal/providers/ratelimit/headers_test.go
+++ b/internal/providers/ratelimit/headers_test.go
@@ -1,0 +1,88 @@
+package ratelimit
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func headers(kv ...string) http.Header {
+	h := http.Header{}
+	for i := 0; i+1 < len(kv); i += 2 {
+		h.Set(kv[i], kv[i+1])
+	}
+	return h
+}
+
+func TestAnthropicRetryAfter(t *testing.T) {
+	cases := []struct {
+		name string
+		h    http.Header
+		want time.Duration
+		ok   bool
+	}{
+		{"missing header", headers(), 0, false},
+		{"valid seconds", headers("Retry-After", "30"), 30 * time.Second, true},
+		{"zero seconds", headers("Retry-After", "0"), 0, true},
+		{"non-numeric", headers("Retry-After", "soon"), 0, false},
+		{"negative rejected", headers("Retry-After", "-5"), 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := AnthropicRetryAfter(tc.h)
+			if d != tc.want || ok != tc.ok {
+				t.Errorf("got (%v, %v), want (%v, %v)", d, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestOpenAIRetryAfterPrefersRetryAfter(t *testing.T) {
+	// When both Retry-After and x-ratelimit-reset-* are present, Retry-After
+	// wins (it's the canonical signal; reset-* are for proactive throttling).
+	h := headers(
+		"Retry-After", "5",
+		"X-Ratelimit-Reset-Requests", "10s",
+		"X-Ratelimit-Reset-Tokens", "20s",
+	)
+	d, ok := OpenAIRetryAfter(h)
+	if !ok || d != 5*time.Second {
+		t.Errorf("got (%v, %v), want (5s, true)", d, ok)
+	}
+}
+
+func TestOpenAIRetryAfterFallsBackToResetTokens(t *testing.T) {
+	// No Retry-After; pick the bigger reset.
+	h := headers(
+		"X-Ratelimit-Reset-Requests", "100ms",
+		"X-Ratelimit-Reset-Tokens", "12.5s",
+	)
+	d, ok := OpenAIRetryAfter(h)
+	if !ok || d != 12500*time.Millisecond {
+		t.Errorf("got (%v, %v), want (12.5s, true)", d, ok)
+	}
+}
+
+func TestOpenAIRetryAfterMissingAllReturnsFalse(t *testing.T) {
+	d, ok := OpenAIRetryAfter(headers())
+	if ok || d != 0 {
+		t.Errorf("got (%v, %v), want (0, false)", d, ok)
+	}
+}
+
+func TestOpenAIRetryAfterIgnoresMalformedDuration(t *testing.T) {
+	// "later" is not a Go duration literal; should be ignored, not panic.
+	h := headers("X-Ratelimit-Reset-Requests", "later")
+	d, ok := OpenAIRetryAfter(h)
+	if ok || d != 0 {
+		t.Errorf("got (%v, %v), want (0, false)", d, ok)
+	}
+}
+
+func TestOllamaRetryAfter(t *testing.T) {
+	h := headers("Retry-After", "15")
+	d, ok := OllamaRetryAfter(h)
+	if !ok || d != 15*time.Second {
+		t.Errorf("got (%v, %v), want (15s, true)", d, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the production-blocking issue where Anthropic Tier-1 (50 RPM) — and OpenAI's tighter limits — would surface a 429 to the agent loop, terminate the run with status=failed, and lose the entire conversation context. Now each provider driver wraps its HTTP round-trip in a shared retry helper that **re-sends the same body bytes** on 429, preserving messages + tools + system blocks + cache_control breakpoints across the rate limit. Two review passes; both approved.

## What's in

| Commit | What |
|---|---|
| `2438789` | `internal/providers/ratelimit/` package: shared retry helper + Anthropic/OpenAI/Ollama header parsers (17 unit tests) |
| `9daf055` | All three drivers wrapped: Call() now goes through ratelimit.Do (3 driver-level regression tests, body bytes asserted equal) |
| `1e75ccc` | Review fixes: MIN reset window for OpenAI; ctx-error pass-through; loop-level integration test; doc-comment correction; NewTimer+Stop |

## Per-provider behaviour

| Provider | Primary signal | Fallback | Notes |
|---|---|---|---|
| Anthropic | `Retry-After` header (always present per docs) | exp schedule | Sonnet 4.x Tier-1 = 50 RPM; trivial to hit |
| OpenAI | `Retry-After` (sometimes) | smaller of `x-ratelimit-reset-{requests,tokens}` | MIN over MAX is faster + cheap (1 wasted attempt at most) |
| Ollama | `Retry-After` (Cloud) | exp schedule | OSS doesn't 429 in practice; defensive wrap |

## Behaviour guarantees (load-bearing)

1. **Context preserved across retry** — driver re-sends identical body bytes; messages array, tool definitions, system blocks, and `cache_control` breakpoints all survive (verified by `bytes.Equal(body[0], body[1])` assertion in each driver test)
2. **Retry invisible to the loop** — `loop.Run()` sees only the recovered 200; no `EventError` emitted; run completes with `end_turn` (verified by `TestRetryOn429IsInvisibleToLoop` in anthropic package)
3. **ctx-aware sleep** — cancelled ctx breaks out of the wait immediately and returns `ctx.Err()` (not wrapped in misleading "http:" prefix)
4. **Budget caps** — 5 attempts OR 5 minutes total wait, whichever fires first; final 429 returned with body intact for caller's normal error path

## Schedule + jitter

When no `Retry-After`-equivalent header is found, fallback to **10s → 20s → 40s → 60s → 120s** with ±20% jitter. Matches the schedule called out in the spec.

## Verification

- [x] `go test -race ./...` — all 15 packages green from clean cache
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go mod tidy` no diff
- [x] Each driver's regression test verified to fail without the wrap (driver returns the 429 as a hard error)
- [x] Loop-integration test verified to fail without the wrap (Run() returns EventError)
- [x] Two code-review passes; second pass: "ready to tag v0.3.1, no regressions, no new blockers"

## Breaking changes

None at the HTTP API, YAML schema, or `mcp.Caller` interface level.

## Deferred to v0.3.2 (review-flagged, out of scope)

- `rate_limit_wait_ms` SSE event surfacing — requires `Provider.Call` interface change to expose mid-Call events; the channel doesn't exist yet during the retry sleep. The structured log line is in place today; SSE-event surface follows when the Provider interface is extended.

## Test plan

- [x] Unit tests pass (`go test -race ./...`)
- [x] Vet, gofmt, mod tidy clean
- [ ] CI workflow passes (will be visible once landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)