### PR TITLE
v0.3.2: SSE retry telemetry + per-session continuation mutex

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -62,6 +62,11 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 // (release, true) on success and (nil, false) if another caller already
 // holds it — in which case the caller should respond 409 / session_busy.
 // id must be non-empty; an empty id is a programmer error and panics.
+//
+// Callers MUST validate the session exists in the store before calling
+// this — sessionLocks entries are never GC'd, so taking a lock on an
+// unknown id would leak permanently and is a vector for an unbounded
+// memory DoS.
 func (s *Server) trySessionLock(id string) (release func(), ok bool) {
 	if id == "" {
 		panic("trySessionLock: empty session id")
@@ -72,6 +77,18 @@ func (s *Server) trySessionLock(id string) (release func(), ok bool) {
 		return nil, false
 	}
 	return mu.Unlock, true
+}
+
+// lockedSessionCount returns the number of entries in sessionLocks.
+// Test-only: used to assert the DoS fix (unknown IDs must not grow
+// the table). sync.Map exposes no Len, so we range.
+func (s *Server) lockedSessionCount() int {
+	n := 0
+	s.sessionLocks.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
 }
 
 // Mux returns the http.Handler ready to be served.
@@ -175,7 +192,24 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// existing session, serialize at the session level so two concurrent
 	// POSTs can't replay overlapping transcripts. Fresh runs (empty
 	// SessionID) skip this — they have no prior history to corrupt.
+	//
+	// CRITICAL: validate the session exists BEFORE taking the lock.
+	// Otherwise an attacker can spam unknown IDs and each LoadOrStore
+	// grows sessionLocks permanently (entries are never GC'd at v0.3.2).
 	if req.SessionID != "" {
+		if s.store == nil {
+			http.Error(w, "session_id requires persistence (Store not configured)", http.StatusBadRequest)
+			return
+		}
+		if _, err := s.store.GetSession(r.Context(), req.SessionID); err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 		releaseSess, ok := s.trySessionLock(req.SessionID)
 		if !ok {
 			w.Header().Set("Content-Type", "application/json")
@@ -304,6 +338,26 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var body messagesRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Validate the session exists BEFORE taking the per-session lock.
+	// Otherwise an attacker can spam unknown IDs and each LoadOrStore
+	// grows sessionLocks permanently (entries are never GC'd at v0.3.2).
+	sess, err := s.store.GetSession(r.Context(), id)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	// Per-session continuation lock: take the lock before transcript
 	// replay so two concurrent POSTs to the same session can't read
 	// half-written history. Fast-fail with 409 since the alternative —
@@ -317,23 +371,6 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer releaseSess()
-
-	var body messagesRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	sess, err := s.store.GetSession(r.Context(), id)
-	if err != nil {
-		var nf *store.ErrNotFound
-		if errors.As(err, &nf) {
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 
 	// Resolve provider+model from the session's stored agent so the
 	// continuation runs against the same model as the original session.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
@@ -38,12 +39,39 @@ type Server struct {
 	tools     []tools.Tool
 	sem       *concurrency.Semaphore
 	store     store.Store // optional; nil means "don't persist"
+
+	// sessionLocks maps session IDs to *sync.Mutex. A continuation POST
+	// (handleMessages, or handleRuns with a non-empty SessionID) try-locks
+	// the session before replaying transcript + running. Concurrent POSTs
+	// to the same session fast-fail with 409, since the alternative is to
+	// leave a second SSE stream waiting indefinitely behind the first —
+	// and a partial-transcript replay would corrupt history.
+	//
+	// Entries accumulate; never deleted. ~32 B per session is acceptable
+	// for v0.3.2; periodic GC is a future cleanup.
+	sessionLocks sync.Map
 }
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
 // session+run+events tuple in the store; pass nil to keep v0.2 behaviour.
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
 	return &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+}
+
+// trySessionLock try-locks the session-scoped mutex for id. Returns
+// (release, true) on success and (nil, false) if another caller already
+// holds it — in which case the caller should respond 409 / session_busy.
+// id must be non-empty; an empty id is a programmer error and panics.
+func (s *Server) trySessionLock(id string) (release func(), ok bool) {
+	if id == "" {
+		panic("trySessionLock: empty session id")
+	}
+	v, _ := s.sessionLocks.LoadOrStore(id, &sync.Mutex{})
+	mu := v.(*sync.Mutex)
+	if !mu.TryLock() {
+		return nil, false
+	}
+	return mu.Unlock, true
 }
 
 // Mux returns the http.Handler ready to be served.
@@ -141,6 +169,21 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	// Per-session continuation lock: when the caller is resuming an
+	// existing session, serialize at the session level so two concurrent
+	// POSTs can't replay overlapping transcripts. Fresh runs (empty
+	// SessionID) skip this — they have no prior history to corrupt.
+	if req.SessionID != "" {
+		releaseSess, ok := s.trySessionLock(req.SessionID)
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			fmt.Fprintf(w, `{"code":"session_busy","error":"another request is in flight on session %q"}`, req.SessionID)
+			return
+		}
+		defer releaseSess()
 	}
 
 	// Acquire concurrency slot first so backpressure is reported as 429
@@ -260,6 +303,21 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session id is required", http.StatusBadRequest)
 		return
 	}
+
+	// Per-session continuation lock: take the lock before transcript
+	// replay so two concurrent POSTs to the same session can't read
+	// half-written history. Fast-fail with 409 since the alternative —
+	// blocking on an SSE handler — would hold an HTTP connection open
+	// for the full length of the in-flight run.
+	releaseSess, ok := s.trySessionLock(id)
+	if !ok {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprintf(w, `{"code":"session_busy","error":"another request is in flight on session %q"}`, id)
+		return
+	}
+	defer releaseSess()
+
 	var body messagesRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -22,13 +22,24 @@ import (
 )
 
 // stubProvider replays a fixed event sequence, ignoring the request entirely.
-type stubProvider struct{ events []providers.Event }
+// If preEvents are set and req.OnEvent is non-nil, they are fired
+// synchronously through the OnEvent callback before the channel events —
+// simulating a driver that emitted EventRetry during a 429 sleep.
+type stubProvider struct {
+	events    []providers.Event
+	preEvents []providers.Event
+}
 
 func (s *stubProvider) ID() string { return "stub" }
 func (s *stubProvider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{Streaming: true}
 }
-func (s *stubProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+func (s *stubProvider) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	if req.OnEvent != nil {
+		for _, ev := range s.preEvents {
+			req.OnEvent(ev)
+		}
+	}
 	ch := make(chan providers.Event, len(s.events))
 	for _, ev := range s.events {
 		ch <- ev
@@ -84,6 +95,87 @@ func TestHandleRunsSSE(t *testing.T) {
 		if got[i] != w {
 			t.Errorf("frame %d: got %q want %q", i, got[i], w)
 		}
+	}
+}
+
+// v0.3.2 end-to-end: a driver that fires EventRetry through req.OnEvent
+// (as our drivers do during a 429 sleep) must surface as `event: retry`
+// over SSE, ahead of the main response events. Adapter UIs read this to
+// show "waiting on rate limit" live.
+func TestHandleRunsSSEEmitsRetryFrame(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model", AllowedTools: []string{"Read"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	provider := &stubProvider{
+		preEvents: []providers.Event{{
+			Type: providers.EventRetry,
+			Retry: &providers.RetryInfo{
+				Provider: "stub",
+				Attempt:  1,
+				WaitMs:   12345,
+				Reason:   "retry-after header",
+			},
+		}},
+		events: []providers.Event{
+			{Type: providers.EventText, Text: "hi"},
+			{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+		},
+	}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, nil)
+
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	frames := readFrames(t, resp.Body)
+
+	// Must see a retry frame somewhere in the stream, with the full payload
+	// the adapter UI needs.
+	var retry *sseFrame
+	for i := range frames {
+		if frames[i].Event == "retry" {
+			retry = &frames[i]
+			break
+		}
+	}
+	if retry == nil {
+		var types []string
+		for _, f := range frames {
+			types = append(types, f.Event)
+		}
+		t.Fatalf("no retry frame in stream, got events: %v", types)
+	}
+	r, ok := retry.Data["retry"].(map[string]any)
+	if !ok {
+		t.Fatalf("retry frame has no .retry object: %#v", retry.Data)
+	}
+	if r["provider"] != "stub" {
+		t.Errorf("retry.provider = %v, want stub", r["provider"])
+	}
+	if r["attempt"].(float64) != 1 {
+		t.Errorf("retry.attempt = %v, want 1", r["attempt"])
+	}
+	if r["wait_ms"].(float64) != 12345 {
+		t.Errorf("retry.wait_ms = %v, want 12345", r["wait_ms"])
+	}
+	if r["reason"] != "retry-after header" {
+		t.Errorf("retry.reason = %v, want 'retry-after header'", r["reason"])
 	}
 }
 
@@ -758,6 +850,45 @@ func extractSessionID(body string) string {
 }
 
 // readEvents parses SSE frames and returns the event-type per frame in order.
+// sseFrame is one parsed SSE frame: event type + decoded JSON data.
+type sseFrame struct {
+	Event string
+	Data  map[string]any
+}
+
+func readFrames(t *testing.T, r io.Reader) []sseFrame {
+	t.Helper()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var frames []sseFrame
+	var current sseFrame
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if current.Event != "" {
+				frames = append(frames, current)
+				current = sseFrame{}
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			current.Event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		}
+		if strings.HasPrefix(line, "data:") {
+			payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+			_ = json.Unmarshal([]byte(payload), &current.Data)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner: %v", err)
+	}
+	if current.Event != "" {
+		frames = append(frames, current)
+	}
+	return frames
+}
+
 func readEvents(t *testing.T, r io.Reader) []string {
 	t.Helper()
 	scanner := bufio.NewScanner(r)

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -626,6 +626,314 @@ func TestMessagesEndpointReplaysAndContinues(t *testing.T) {
 	}
 }
 
+// v0.3.2: two concurrent POSTs to the same session must serialize at the
+// session level. The second is fast-failed with 409 / session_busy
+// because blocking on an open SSE handler would hold the second HTTP
+// connection for the full duration of the first run, and a second
+// transcript replay overlapping the first would corrupt history.
+func TestPerSessionLockRejectsConcurrentMessages(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	// Provider is non-blocking by default; the test swaps in a blocking
+	// implementation after the seed call completes.
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		ch := make(chan providers.Event, 2)
+		ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		close(ch)
+		return ch, nil
+	}
+
+	st, _ := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Seed: a fresh run to obtain a session id. Non-blocking.
+	resp0, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body0, _ := io.ReadAll(resp0.Body)
+	resp0.Body.Close()
+	sessionID := extractSessionID(string(body0))
+	if sessionID == "" {
+		t.Fatalf("no session id from seed call:\n%s", string(body0))
+	}
+
+	// Now swap in a blocking provider that holds until release2 is closed.
+	release2 := make(chan struct{})
+	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		ch := make(chan providers.Event, 2)
+		go func() {
+			defer close(ch)
+			<-release2
+			ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+			ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		}()
+		return ch, nil
+	}
+
+	// Fire two concurrent POSTs to the same session.
+	type result struct {
+		status int
+		body   string
+	}
+	first := make(chan result, 1)
+	go func() {
+		resp, err := http.Post(ts.URL+"/v1/sessions/"+sessionID+"/messages", "application/json", strings.NewReader(
+			`{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"q1"}]}]}`,
+		))
+		if err != nil {
+			first <- result{status: -1, body: err.Error()}
+			return
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		first <- result{status: resp.StatusCode, body: string(b)}
+	}()
+
+	// Spin until the provider has actually been entered by the first
+	// request (otherwise the second can race ahead before the lock is held).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		provider.mu.Lock()
+		n := len(provider.requests)
+		provider.mu.Unlock()
+		if n >= 2 { // seed + first continuation
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first continuation never reached the provider")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Second continuation while the first is mid-call.
+	resp2, err := http.Post(ts.URL+"/v1/sessions/"+sessionID+"/messages", "application/json", strings.NewReader(
+		`{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"q2"}]}]}`,
+	))
+	if err != nil {
+		close(release2)
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusConflict {
+		close(release2)
+		<-first
+		t.Fatalf("second status = %d, want 409; body=%s", resp2.StatusCode, string(body2))
+	}
+	if !strings.Contains(string(body2), `"code":"session_busy"`) {
+		close(release2)
+		<-first
+		t.Fatalf("second body missing session_busy code: %s", string(body2))
+	}
+
+	// Let the first complete, then verify a follow-up succeeds (lock released).
+	close(release2)
+	got := <-first
+	if got.status != 200 {
+		t.Fatalf("first call failed: status=%d body=%s", got.status, got.body)
+	}
+
+	resp3, err := http.Post(ts.URL+"/v1/sessions/"+sessionID+"/messages", "application/json", strings.NewReader(
+		`{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"q3"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp3.Body.Close()
+	if resp3.StatusCode != 200 {
+		b, _ := io.ReadAll(resp3.Body)
+		t.Fatalf("post-release status = %d, body=%s", resp3.StatusCode, string(b))
+	}
+}
+
+// v0.3.2: the per-session lock must be scoped per-session, not global.
+// Two concurrent POSTs to DIFFERENT sessions must both succeed.
+func TestPerSessionLockDoesNotAffectOtherSessions(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+		ch := make(chan providers.Event, 2)
+		ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		close(ch)
+		return ch, nil
+	}
+
+	st, _ := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Two fresh runs → two distinct session IDs.
+	mkSession := func() string {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return extractSessionID(string(b))
+	}
+	s1, s2 := mkSession(), mkSession()
+	if s1 == "" || s2 == "" || s1 == s2 {
+		t.Fatalf("bad session ids: %q %q", s1, s2)
+	}
+
+	// Concurrent continuation on each — both must succeed.
+	var wg sync.WaitGroup
+	results := make([]int, 2)
+	for i, sid := range []string{s1, s2} {
+		wg.Add(1)
+		go func(i int, sid string) {
+			defer wg.Done()
+			resp, err := http.Post(ts.URL+"/v1/sessions/"+sid+"/messages", "application/json", strings.NewReader(
+				`{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+			))
+			if err != nil {
+				results[i] = -1
+				return
+			}
+			defer resp.Body.Close()
+			io.Copy(io.Discard, resp.Body)
+			results[i] = resp.StatusCode
+		}(i, sid)
+	}
+	wg.Wait()
+	for i, st := range results {
+		if st != 200 {
+			t.Errorf("session %d status = %d, want 200", i, st)
+		}
+	}
+}
+
+// v0.3.2: handleRuns also takes the lock when SessionID is set.
+// Reusing an explicit SessionID concurrently must fast-fail with 409.
+func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	release := make(chan struct{})
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+		idx := len(provider.requests) - 1
+		ch := make(chan providers.Event, 2)
+		go func() {
+			defer close(ch)
+			if idx == 1 {
+				<-release
+			}
+			ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+			ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		}()
+		return ch, nil
+	}
+
+	st, _ := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Seed.
+	resp0, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body0, _ := io.ReadAll(resp0.Body)
+	resp0.Body.Close()
+	sessionID := extractSessionID(string(body0))
+	if sessionID == "" {
+		t.Fatalf("no session id from seed:\n%s", string(body0))
+	}
+
+	// Concurrent /v1/runs reusing the same session_id: first blocks; second 409s.
+	first := make(chan int, 1)
+	go func() {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","session_id":"`+sessionID+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"q1"}]}]}`,
+		))
+		if err != nil {
+			first <- -1
+			return
+		}
+		defer resp.Body.Close()
+		io.Copy(io.Discard, resp.Body)
+		first <- resp.StatusCode
+	}()
+
+	// Wait until provider entered (idx==1 means seed + first).
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		provider.mu.Lock()
+		n := len(provider.requests)
+		provider.mu.Unlock()
+		if n >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first run never reached provider")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	resp2, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","session_id":"`+sessionID+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"q2"}]}]}`,
+	))
+	if err != nil {
+		close(release)
+		t.Fatal(err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+
+	if resp2.StatusCode != http.StatusConflict {
+		close(release)
+		<-first
+		t.Fatalf("second status = %d, want 409; body=%s", resp2.StatusCode, string(body2))
+	}
+	if !strings.Contains(string(body2), `"code":"session_busy"`) {
+		close(release)
+		<-first
+		t.Fatalf("second body missing session_busy: %s", string(body2))
+	}
+	close(release)
+	if got := <-first; got != 200 {
+		t.Errorf("first status = %d, want 200", got)
+	}
+}
+
 // callableProvider lets a test inject a Call function. Reuses stubProvider's
 // ID/Capabilities trivially.
 type callableProvider struct {

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -672,8 +672,15 @@ func TestPerSessionLockRejectsConcurrentMessages(t *testing.T) {
 	}
 
 	// Now swap in a blocking provider that holds until release2 is closed.
+	// Signal entry via a closed channel so the test waits deterministically
+	// rather than spinning on a length read.
 	release2 := make(chan struct{})
+	entered := make(chan struct{}, 1)
 	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
 		ch := make(chan providers.Event, 2)
 		go func() {
 			defer close(ch)
@@ -703,20 +710,13 @@ func TestPerSessionLockRejectsConcurrentMessages(t *testing.T) {
 		first <- result{status: resp.StatusCode, body: string(b)}
 	}()
 
-	// Spin until the provider has actually been entered by the first
-	// request (otherwise the second can race ahead before the lock is held).
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		provider.mu.Lock()
-		n := len(provider.requests)
-		provider.mu.Unlock()
-		if n >= 2 { // seed + first continuation
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("first continuation never reached the provider")
-		}
-		time.Sleep(2 * time.Millisecond)
+	// Wait deterministically for the first request to enter the provider
+	// (and thus hold the session lock).
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		close(release2)
+		t.Fatal("first continuation never reached the provider")
 	}
 
 	// Second continuation while the first is mid-call.
@@ -831,6 +831,61 @@ func TestPerSessionLockDoesNotAffectOtherSessions(t *testing.T) {
 	}
 }
 
+// v0.3.2 review fix: unknown session IDs must NOT grow sessionLocks.
+// Previously trySessionLock ran before existence validation, so a caller
+// spamming /v1/sessions/<random>/messages or /v1/runs with an unknown
+// session_id could leak a *sync.Mutex per request indefinitely.
+func TestUnknownSessionIDDoesNotGrowLockTable(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	st, _ := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	defer st.Close()
+
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Hammer /messages with 50 unknown ids.
+	for i := 0; i < 50; i++ {
+		resp, err := http.Post(ts.URL+"/v1/sessions/s_unknown_"+fmt.Sprint(i)+"/messages", "application/json", strings.NewReader(
+			`{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("messages unknown #%d: status = %d, want 404", i, resp.StatusCode)
+		}
+	}
+
+	// Hammer /runs with 50 unknown session_ids.
+	for i := 0; i < 50; i++ {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","session_id":"s_unknown_runs_`+fmt.Sprint(i)+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusNotFound {
+			t.Fatalf("runs unknown #%d: status = %d, want 404", i, resp.StatusCode)
+		}
+	}
+
+	if got := srv.lockedSessionCount(); got != 0 {
+		t.Fatalf("sessionLocks grew to %d entries from 100 unknown-id requests; want 0", got)
+	}
+}
+
 // v0.3.2: handleRuns also takes the lock when SessionID is set.
 // Reusing an explicit SessionID concurrently must fast-fail with 409.
 func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
@@ -841,14 +896,25 @@ func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
 		},
 		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
 	}
+	// Gate which call blocks by inspecting the request itself rather than
+	// reading provider.requests' length racily. Calls whose user message
+	// contains "BLOCK_HERE" hold until release is closed; everything else
+	// completes immediately. entered signals first blocking entry.
 	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
 	provider := &callableProvider{}
-	provider.call = func(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
-		idx := len(provider.requests) - 1
+	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		shouldBlock := requestContains(req, "BLOCK_HERE")
+		if shouldBlock {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+		}
 		ch := make(chan providers.Event, 2)
 		go func() {
 			defer close(ch)
-			if idx == 1 {
+			if shouldBlock {
 				<-release
 			}
 			ch <- providers.Event{Type: providers.EventText, Text: "ok"}
@@ -882,7 +948,7 @@ func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
 	first := make(chan int, 1)
 	go func() {
 		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
-			`{"agent":"default","session_id":"`+sessionID+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"q1"}]}]}`,
+			`{"agent":"default","session_id":"`+sessionID+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"q1 BLOCK_HERE"}]}]}`,
 		))
 		if err != nil {
 			first <- -1
@@ -893,19 +959,12 @@ func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
 		first <- resp.StatusCode
 	}()
 
-	// Wait until provider entered (idx==1 means seed + first).
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		provider.mu.Lock()
-		n := len(provider.requests)
-		provider.mu.Unlock()
-		if n >= 2 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("first run never reached provider")
-		}
-		time.Sleep(2 * time.Millisecond)
+	// Wait deterministically for the blocking call to enter the provider.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		close(release)
+		t.Fatal("first run never reached provider")
 	}
 
 	resp2, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
@@ -956,6 +1015,21 @@ func (c *callableProvider) Call(ctx context.Context, req providers.Request) (<-c
 func containsText(blocks []providers.ContentBlock, want string) bool {
 	for _, b := range blocks {
 		if b.Type == "text" && strings.Contains(b.Text, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// requestContains scans the request's user messages for a marker string.
+// Tests use this to gate per-call behaviour deterministically (instead of
+// reading provider.requests' length, which races with concurrent appends).
+func requestContains(req providers.Request, marker string) bool {
+	for _, m := range req.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		if containsText(m.Content, marker) {
 			return true
 		}
 	}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -99,6 +99,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 			System:   system,
 			Messages: messages,
 			Tools:    toolSpecs,
+			// OnEvent lets the driver fire pre-channel events (currently
+			// EventRetry during a 429 sleep) directly to the same caller
+			// hook the loop uses for response events. Without this hop
+			// the retry would be invisible to SSE consumers.
+			OnEvent: emit,
 		}
 		ch, err := opts.Provider.Call(ctx, req)
 		if err != nil {

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -87,6 +87,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	resp, err := ratelimit.Do(ctx, ratelimit.Config{
 		Provider:    "anthropic",
 		ParseHeader: ratelimit.AnthropicRetryAfter,
+		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
 		// ctx errors aren't HTTP errors — propagate as-is so the loop's

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -306,6 +306,73 @@ func TestRetryOn429IsInvisibleToLoop(t *testing.T) {
 	}
 }
 
+// v0.3.2: a 429 must surface a typed EventRetry to the loop's OnEvent
+// hook, with provider/attempt/wait_ms/reason populated. This is the full
+// pipeline: driver 429 → ratelimit Config.OnEvent → req.OnEvent (loop's
+// emit) → opts.OnEvent (caller). The caller (e.g. the SSE handler) needs
+// the WaitMs to render "waiting on rate limit" UI.
+func TestRetryEmitsTypedEventToLoop(t *testing.T) {
+	var callNum int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callNum++
+		n := callNum
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, "event: content_block_delta\ndata: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n")
+		fmt.Fprint(w, "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\n")
+		fmt.Fprint(w, "event: message_stop\ndata: {}\n\n")
+	}))
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+
+	var retryEvents []providers.Event
+	_, err := loop.Run(context.Background(), loop.RunOptions{
+		Provider: d,
+		Model:    "claude-sonnet-4-6",
+		Segments: []loop.PromptSegment{
+			{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: "hi"}}},
+		},
+		OnEvent: func(ev providers.Event) {
+			if ev.Type == providers.EventRetry {
+				retryEvents = append(retryEvents, ev)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(retryEvents) != 1 {
+		t.Fatalf("got %d retry events, want 1 (one 429 → one retry)", len(retryEvents))
+	}
+	r := retryEvents[0].Retry
+	if r == nil {
+		t.Fatal("EventRetry.Retry is nil")
+	}
+	if r.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic", r.Provider)
+	}
+	if r.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", r.Attempt)
+	}
+	// Retry-After: 0 honoured.
+	if r.WaitMs != 0 {
+		t.Errorf("WaitMs = %d, want 0", r.WaitMs)
+	}
+	if r.Reason == "" {
+		t.Errorf("Reason is empty, want non-empty")
+	}
+}
+
 func TestRequestBodyShape(t *testing.T) {
 	// Verify the request marshalling: cache_control on Cacheable system block,
 	// proper tool_use / tool_result encoding.

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -89,6 +89,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	resp, err := ratelimit.Do(ctx, ratelimit.Config{
 		Provider:    "ollama",
 		ParseHeader: ratelimit.OllamaRetryAfter,
+		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -315,6 +315,66 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}
 }
 
+// v0.3.2: a 429 must fire EventRetry through req.OnEvent. Proves the
+// driver wires req.OnEvent into ratelimit.Config.OnEvent — without
+// that line, the EventRetry never reaches the caller.
+func TestRetryEmitsEventToRequestOnEvent(t *testing.T) {
+	var callNum int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callNum++
+		n := callNum
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"error":"too many requests"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `{"model":"llama3.1","message":{"role":"assistant","content":"ok"},"done":false}`+"\n")
+		fmt.Fprint(w, `{"model":"llama3.1","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":1}`+"\n")
+	}))
+	defer srv.Close()
+
+	var retries []providers.Event
+	var rmu sync.Mutex
+	d := New(srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model: "llama3.1",
+		OnEvent: func(ev providers.Event) {
+			rmu.Lock()
+			defer rmu.Unlock()
+			if ev.Type == providers.EventRetry {
+				retries = append(retries, ev)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	rmu.Lock()
+	defer rmu.Unlock()
+	if len(retries) != 1 {
+		t.Fatalf("got %d retry events, want 1", len(retries))
+	}
+	r := retries[0].Retry
+	if r == nil {
+		t.Fatal("Retry payload missing")
+	}
+	if r.Provider != "ollama" {
+		t.Errorf("Provider = %q, want ollama", r.Provider)
+	}
+	if r.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", r.Attempt)
+	}
+}
+
 func TestStopReasonWithoutToolCalls(t *testing.T) {
 	// done_reason "length" should map to max_tokens.
 	frames := []string{

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -90,6 +90,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	resp, err := ratelimit.Do(ctx, ratelimit.Config{
 		Provider:    "openai",
 		ParseHeader: ratelimit.OpenAIRetryAfter,
+		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -346,6 +346,68 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}
 }
 
+// v0.3.2: a 429 must fire EventRetry through req.OnEvent so the loop's
+// SSE consumer sees retry telemetry live during the sleep. This proves
+// the driver wires req.OnEvent into ratelimit.Config.OnEvent — without
+// that line, the EventRetry never reaches the caller.
+func TestRetryEmitsEventToRequestOnEvent(t *testing.T) {
+	var callNum int
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		callNum++
+		n := callNum
+		mu.Unlock()
+		if n == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(429)
+			w.Write([]byte(`{"error":{"type":"rate_limit_exceeded","message":"slow down"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(200)
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{"content":"ok"}}]}`+"\n\n")
+		fmt.Fprint(w, `data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`+"\n\n")
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	var retries []providers.Event
+	var rmu sync.Mutex
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model: "gpt-4o-mini",
+		OnEvent: func(ev providers.Event) {
+			rmu.Lock()
+			defer rmu.Unlock()
+			if ev.Type == providers.EventRetry {
+				retries = append(retries, ev)
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	rmu.Lock()
+	defer rmu.Unlock()
+	if len(retries) != 1 {
+		t.Fatalf("got %d retry events, want 1", len(retries))
+	}
+	r := retries[0].Retry
+	if r == nil {
+		t.Fatal("Retry payload missing")
+	}
+	if r.Provider != "openai" {
+		t.Errorf("Provider = %q, want openai", r.Provider)
+	}
+	if r.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", r.Attempt)
+	}
+}
+
 func TestNon200Status(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -39,6 +39,14 @@ type Request struct {
 	MaxTokens   int            `json:"max_tokens,omitempty"`
 	Temperature *float64       `json:"temperature,omitempty"`
 	Stream      bool           `json:"stream"`
+
+	// OnEvent, when set, is called for events that occur BEFORE the
+	// response channel exists — most importantly, EventRetry frames
+	// fired during a 429 retry sleep. Optional; the loop populates this
+	// from RunOptions.OnEvent so adapter consumers see retry telemetry
+	// live on the same SSE stream as the main response. Marshalling
+	// callers should ignore (json:"-").
+	OnEvent func(Event) `json:"-"`
 }
 
 // Message is one turn in the conversation.
@@ -85,6 +93,12 @@ const (
 	EventUsage      EventType = "usage"
 	EventDone       EventType = "done"
 	EventError      EventType = "error"
+	// EventRetry signals that a provider returned 429 and the driver is
+	// about to sleep before retrying. Surfaced live during the retry sleep
+	// (not after) so adapter consumers can show "waiting on rate limit"
+	// to end users. The retry itself is invisible to the agent loop —
+	// EventRetry is purely informational.
+	EventRetry EventType = "retry"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -99,10 +113,20 @@ type Event struct {
 	// persist+replay round-trip matters because a continuation that lost
 	// the flag would re-feed the model a successful-looking result.
 	IsError bool `json:"is_error,omitempty"`
+	// Retry carries the retry telemetry on EventRetry. Nil otherwise.
+	Retry *RetryInfo `json:"retry,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
 	StopReason string `json:"stop_reason,omitempty"`
+}
+
+// RetryInfo accompanies an EventRetry. Each field is set every time.
+type RetryInfo struct {
+	Provider string `json:"provider"`
+	Attempt  int    `json:"attempt"`
+	WaitMs   int64  `json:"wait_ms"`
+	Reason   string `json:"reason"` // "retry-after header" | "exponential backoff"
 }
 
 // ToolUse is the model's request to invoke a tool.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -46,6 +46,12 @@ type Request struct {
 	// from RunOptions.OnEvent so adapter consumers see retry telemetry
 	// live on the same SSE stream as the main response. Marshalling
 	// callers should ignore (json:"-").
+	//
+	// Callback contract: the driver invokes OnEvent synchronously from
+	// inside Call() (before the response channel exists). The callback
+	// MUST NOT block — the driver is mid-retry-sleep and a slow callback
+	// extends the rate-limit wait. SSE writes are fine; do not perform
+	// network IO from here.
 	OnEvent func(Event) `json:"-"`
 }
 
@@ -126,8 +132,19 @@ type RetryInfo struct {
 	Provider string `json:"provider"`
 	Attempt  int    `json:"attempt"`
 	WaitMs   int64  `json:"wait_ms"`
-	Reason   string `json:"reason"` // "retry-after header" | "exponential backoff"
+	// Reason is one of the RetryReason* constants below. It's a
+	// stable wire string — adapters string-match against it.
+	Reason string `json:"reason"`
 }
+
+// RetryReason* are the values of RetryInfo.Reason. They're declared on
+// the providers package (not on ratelimit) because they're part of the
+// wire contract — adapters and SSE consumers depend on these strings.
+// Do not change without bumping a major version.
+const (
+	RetryReasonHeader   = "retry-after header"
+	RetryReasonSchedule = "exponential backoff"
+)
 
 // ToolUse is the model's request to invoke a tool.
 type ToolUse struct {

--- a/internal/providers/ratelimit/backoff.go
+++ b/internal/providers/ratelimit/backoff.go
@@ -21,6 +21,8 @@ import (
 	"math/rand"
 	"net/http"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
 // ParseFn extracts a retry-after duration from response headers. Returns
@@ -59,6 +61,12 @@ type Config struct {
 	// OnRetry is called before each sleep with diagnostic info. The
 	// default writes a structured log line via the standard logger.
 	OnRetry func(provider string, attempt int, wait time.Duration, reason string)
+
+	// OnEvent, when set, is called after OnRetry with a typed
+	// providers.EventRetry. Drivers wire req.OnEvent here so adapter
+	// consumers see retry telemetry on the same SSE stream as the main
+	// response. Optional.
+	OnEvent func(providers.Event)
 
 	// rng is for tests to inject a deterministic source. nil = global rand.
 	rng *rand.Rand
@@ -165,6 +173,17 @@ func Do(ctx context.Context, cfg Config, attempt func(ctx context.Context) (*htt
 		_ = resp.Body.Close()
 
 		cfg.OnRetry(cfg.Provider, i+1, wait, reason)
+		if cfg.OnEvent != nil {
+			cfg.OnEvent(providers.Event{
+				Type: providers.EventRetry,
+				Retry: &providers.RetryInfo{
+					Provider: cfg.Provider,
+					Attempt:  i + 1,
+					WaitMs:   wait.Milliseconds(),
+					Reason:   reason,
+				},
+			})
+		}
 
 		// time.NewTimer + defer Stop instead of time.After so a ctx-cancel
 		// during the wait doesn't leak the underlying timer until expiry.

--- a/internal/providers/ratelimit/backoff.go
+++ b/internal/providers/ratelimit/backoff.go
@@ -104,10 +104,12 @@ func defaultOnRetry(provider string, attempt int, wait time.Duration, reason str
 		provider, attempt, wait.String(), reason)
 }
 
-// Reason strings passed to OnRetry.
+// Reason strings passed to OnRetry. These re-export the canonical
+// constants from the providers package — the wire contract lives
+// there because RetryInfo.Reason is part of the SSE shape.
 const (
-	ReasonHeader   = "retry-after header"
-	ReasonSchedule = "exponential backoff"
+	ReasonHeader   = providers.RetryReasonHeader
+	ReasonSchedule = providers.RetryReasonSchedule
 )
 
 // Do calls attempt repeatedly until it returns a non-429 response or the

--- a/internal/providers/ratelimit/backoff_test.go
+++ b/internal/providers/ratelimit/backoff_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
 // fakeResp builds a minimal *http.Response usable in tests.
@@ -236,6 +238,76 @@ func TestJitterIsBoundedAndDeterministic(t *testing.T) {
 	got2 := applyJitter(d, 0.2, rng2)
 	if got != got2 {
 		t.Errorf("jitter not deterministic with same seed: %v vs %v", got, got2)
+	}
+}
+
+func TestOnEventFiresWithRetryInfo(t *testing.T) {
+	var events []providers.Event
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		Provider:    "test-provider",
+		MaxAttempts: 3,
+		Schedule:    []time.Duration{1 * time.Millisecond, 1 * time.Millisecond},
+		Jitter:      0,
+		OnRetry:     func(string, int, time.Duration, string) {},
+		OnEvent:     func(e providers.Event) { events = append(events, e) },
+	}
+	calls := atomic.Int32{}
+	_, err := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		n := calls.Add(1)
+		if n < 3 {
+			return fakeResp(429, map[string]string{"Retry-After": "0"}, ""), nil
+		}
+		return fakeResp(200, nil, "ok"), nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("got %d events, want 2 (one per retry sleep)", len(events))
+	}
+	for i, ev := range events {
+		if ev.Type != providers.EventRetry {
+			t.Errorf("event[%d].Type = %q, want %q", i, ev.Type, providers.EventRetry)
+		}
+		if ev.Retry == nil {
+			t.Fatalf("event[%d].Retry is nil", i)
+		}
+		if ev.Retry.Provider != "test-provider" {
+			t.Errorf("event[%d].Retry.Provider = %q, want test-provider", i, ev.Retry.Provider)
+		}
+		if ev.Retry.Attempt != i+1 {
+			t.Errorf("event[%d].Retry.Attempt = %d, want %d", i, ev.Retry.Attempt, i+1)
+		}
+		if ev.Retry.Reason != ReasonHeader {
+			t.Errorf("event[%d].Retry.Reason = %q, want %q", i, ev.Retry.Reason, ReasonHeader)
+		}
+		// Retry-After: 0 → wait 0ms.
+		if ev.Retry.WaitMs != 0 {
+			t.Errorf("event[%d].Retry.WaitMs = %d, want 0", i, ev.Retry.WaitMs)
+		}
+	}
+}
+
+func TestOnEventNotCalledWhenNotSet(t *testing.T) {
+	// Smoke check: Config.OnEvent==nil must not panic in Do().
+	cfg := Config{
+		ParseHeader: AnthropicRetryAfter,
+		MaxAttempts: 2,
+		Schedule:    []time.Duration{1 * time.Millisecond},
+		Jitter:      0,
+		OnRetry:     func(string, int, time.Duration, string) {},
+	}
+	calls := atomic.Int32{}
+	_, err := Do(context.Background(), cfg, func(ctx context.Context) (*http.Response, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return fakeResp(429, nil, ""), nil
+		}
+		return fakeResp(200, nil, ""), nil
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **rate_limit_wait_ms SSE event** — surfaces 429-retry telemetry (event: retry, data: {provider, attempt, wait_ms, reason}) live during the retry sleep, so adapter UIs can render "waiting on rate limit" instead of only seeing the retry after the fact in logs. Adds providers.Request.OnEvent + providers.EventRetry + providers.RetryInfo.
- **Per-session continuation mutex** — protects against concurrent POSTs to the same session corrupting replayTranscript. Concurrent attempt returns HTTP 409 with code:session_busy. Lock keyed by validated-session-id only (DoS-safe — unknown ids 404 before the lock table touches them).

## Review

Two independent code-review passes returned clean. Three IMPORTANT findings from the first pass were addressed in 7b2a5c1:
1. DoS via lock-table growth — fixed by validating session existence before trySessionLock.
2. Test race / idx-via-len gating — replaced with deterministic entered chan struct{} + per-call marker matching.
3. Per-driver wiring uncovered — added TestRetryEmitsEventToRequestOnEvent in openai + ollama drivers (anthropic already had loop-level coverage).

Empirical proof for every load-bearing change: revert one line, observe the right test fail, restore.

## Test plan

- [x] go test ./... clean
- [x] go test -race ./... clean
- [x] gofmt -l . empty, go vet ./... clean
- [x] First review pass — agent
- [x] Fix-up commit — 7b2a5c1
- [x] Second review pass — agent (verified the empirical-proof claim itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)