### PR TITLE
v0.3.3: built-in tools + per-agent default-deny + per-request URL allowlist

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -87,6 +87,17 @@ func main() {
 		log.Printf("note: Bash tool is registered but disabled — set LOOMCYCLE_BASH_ENABLED=1 to enable (NOT a true sandbox; see docs)")
 	}
 
+	// Per-agent tool policy is default-deny: an agent with no allowed_tools
+	// in YAML gets ZERO tools at the dispatcher. Warn at startup so
+	// operators don't discover this only when an agent inexplicably can't
+	// do anything. We log per-agent rather than once so the operator sees
+	// which definitions are affected.
+	for name, def := range cfg.Agents {
+		if len(def.AllowedTools) == 0 {
+			log.Printf("note: agent %q has no allowed_tools — it will see zero tools (intentional default-deny; add allowed_tools to its YAML to expose tools)", name)
+		}
+	}
+
 	// MCP: spawn declared servers (stdio or http), discover their tools,
 	// register each as `mcp__{server}__{tool}` alongside the built-ins.
 	// Failures to spawn or handshake are logged and the server is skipped —

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -51,14 +51,40 @@ func main() {
 		cfg.Concurrency.MaxQueueDepth,
 		cfg.Concurrency.QueueTimeout(),
 	)
-	// The Read tool is sandboxed: it refuses every call when Root is empty.
-	// Operators must set LOOMCYCLE_READ_ROOT explicitly to enable it (no
-	// silent default — the wrong default would leak file contents).
+	// All built-in tools are SANDBOXED: each refuses every call until the
+	// operator explicitly enables it via env. We register every tool and
+	// log a note for any that's still disabled — that way the model sees
+	// a clear "tool refused" error instead of a confusing "unknown tool",
+	// and operators see at startup which tools they've configured.
+	httpTool := &builtin.HTTP{HostAllowlist: cfg.Env.HTTPHostAllowlist}
 	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},
+		&builtin.Write{Root: cfg.Env.WriteRoot},
+		&builtin.Edit{Root: cfg.Env.WriteRoot},
+		httpTool,
+		&builtin.WebFetch{HTTP: httpTool},
+		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
+		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")
+	}
+	if cfg.Env.WriteRoot == "" {
+		log.Printf("note: Write + Edit tools are registered but disabled — set LOOMCYCLE_WRITE_ROOT to enable")
+	}
+	if len(cfg.Env.HTTPHostAllowlist) == 0 {
+		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable")
+	}
+	if cfg.Env.BraveAPIKey == "" {
+		log.Printf("note: WebSearch tool is registered but disabled — set BRAVE_API_KEY to enable")
+	}
+	if cfg.Env.BashEnabled {
+		log.Printf("WARNING: Bash tool is enabled (LOOMCYCLE_BASH_ENABLED=1). This is NOT a true sandbox — run loomcycle inside a container or VM if you expose this to untrusted prompts.")
+		if cfg.Env.BashCwd == "" {
+			log.Printf("note: Bash is enabled but has no cwd; every call will refuse — set LOOMCYCLE_BASH_CWD")
+		}
+	} else {
+		log.Printf("note: Bash tool is registered but disabled — set LOOMCYCLE_BASH_ENABLED=1 to enable (NOT a true sandbox; see docs)")
 	}
 
 	// MCP: spawn declared servers (stdio or http), discover their tools,

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -126,6 +126,61 @@ Use cases:
 - Multi-step pipelines where stage 1 only reads, stage 2 also writes.
 - A web UI that exposes a "safe mode" that disables `Bash` even when the agent is normally allowed it.
 
+## Per-request URL allowlist (HTTP / WebFetch / WebSearch)
+
+The operator's `LOOMCYCLE_HTTP_HOST_ALLOWLIST` is a security floor — every host the agent might ever need to reach. For a single run, callers usually want to constrain further: this run is about scraping job listings from `linkedin.com` and `indeed.com`, that one is about reading from `bbc.co.uk`. Per-request narrowing exists for exactly this.
+
+```http
+POST /v1/runs
+{
+  "agent": "cv-adapter",
+  "allowed_hosts": ["linkedin.com", "indeed.com"],
+  "web_search_filter": "drop",       // optional; defaults to "drop"
+  "segments": [...]
+}
+```
+
+### Three-state `allowed_hosts`
+
+| Field state           | Effective allowlist                                  |
+|-----------------------|------------------------------------------------------|
+| omitted (`null`)      | Operator's full static list (no narrowing)           |
+| `[]` (empty array)    | **Deny all** — every HTTP / WebFetch call refuses    |
+| `["a.com", "b.com"]`  | Operator list ∩ caller list                          |
+
+Distinguishing `null` from `[]` matters: omitting the field means "I don't have an opinion, use the operator's list"; sending `[]` means "this run does no network calls".
+
+### Intersection-only — caller can shrink, never widen
+
+If the operator's static allowlist is `["api.linkedin.com"]` and the caller asks for `["evil.example", "api.linkedin.com"]`, the effective list is `["api.linkedin.com"]` — `evil.example` is silently dropped. The operator's policy is the floor; nothing the caller does can lift it. Suffix matching applies on both sides: `api.linkedin.com` is allowed under operator entry `linkedin.com`.
+
+### Trust boundary
+
+`allowed_hosts` MUST come from the trusted upstream caller, never from the model. The model can read its own `system` prompt and request body content but cannot construct a /v1/runs request. As long as the application calling loomcycle is the one supplying `allowed_hosts`, the threat model holds. **Don't pipe model-generated text into `allowed_hosts`** — that turns the policy into something the prompt can manipulate.
+
+### `web_search_filter` for WebSearch
+
+Brave Search returns whatever it found. With per-request narrowing in place, the model sees URLs it can't actually fetch, which wastes context tokens. Two options:
+
+| `web_search_filter` | Brave behaviour preserved | Model sees results outside `allowed_hosts`? |
+|---------------------|---------------------------|----------------------------------------------|
+| `"drop"` (default when `allowed_hosts` is set) | Yes (Brave is paid) | No — non-matching results are filtered out, indices renumber |
+| `"keep"`            | Yes                       | Yes — full result list passes through; caller filters downstream |
+
+`drop` is the default because the typical agent is already context-constrained and showing it URLs it can't follow up on is wasteful. `keep` is for callers that want to see what Brave returned before applying their own narrowing logic (e.g. a UI that displays "we found N results on these other hosts too").
+
+Filter mode is ignored when `allowed_hosts` is `null`.
+
+### Session continuation
+
+Continuations on `/v1/sessions/{id}/messages` re-supply `allowed_hosts` and `web_search_filter` per call. The list is **not** persisted on the session. This keeps "what hosts can this turn reach?" answerable from the request alone — no implicit state to chase. A continuation can change (typically narrow) the list as the conversation evolves.
+
+### What this doesn't cover
+
+- **Path-level filtering** (`example.com/api/v1/*` only) — out of scope; operators wanting that wire an HTTP MCP gateway in front.
+- **Per-host method limits** (`linkedin.com` GET-only) — same reasoning.
+- **Quota / rate limits per host** — orthogonal; belongs in a v0.4 hooks/observability story.
+
 ## What "default-deny" means in practice
 
 | Situation                                                 | Result                                |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,0 +1,155 @@
+# Tools and tool policy
+
+loomcycle exposes tools to agents through a **two-layer default-deny model**: every tool is disabled at the operator layer until env-configured, and every agent gets zero tools at the agent layer until `allowed_tools` is set in YAML. Both layers must say "yes" before a tool reaches the model.
+
+This document explains the model end-to-end and what it means for operators wiring up new agents or new tools.
+
+## The two layers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ Layer 1 — Operator (server-wide)                             │
+│   Built-ins refuse every call when their env is unset.       │
+│   MCP servers must be declared in mcp_servers in YAML, with  │
+│   optional per-server allowed_tools narrowing.               │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ (registered + enabled tools)
+                       ▼
+┌──────────────────────────────────────────────────────────────┐
+│ Layer 2 — Agent (per-run)                                    │
+│   Agent's allowed_tools in YAML lists the names exposed.     │
+│   Empty / missing list → zero tools, full stop.              │
+│   Caller's request body may further narrow (intersection).   │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ (effective tool set)
+                       ▼
+                   Dispatcher
+```
+
+Both layers are intersection-only: nothing the model sees can ever exceed what the operator allowed at layer 1, and nothing exceeds what the agent definition allowed at layer 2.
+
+## Layer 1 — operator-side: enabling tools
+
+### Built-ins
+
+Each built-in is registered into the dispatcher at process startup but **refuses every call** until its sandbox is configured via env. The model will see the tool's spec and may try to call it, but every call comes back with `{"is_error": true, "text": "<tool> is not configured ..."}`. This deliberate behaviour means the model gets a clear "not configured" signal it can self-correct from, instead of `unknown tool`.
+
+| Tool        | Enabled by                                            |
+|-------------|-------------------------------------------------------|
+| `Read`      | `LOOMCYCLE_READ_ROOT=/path/to/sandbox`                |
+| `Write`     | `LOOMCYCLE_WRITE_ROOT=/path/to/sandbox`               |
+| `Edit`      | `LOOMCYCLE_WRITE_ROOT=/path/to/sandbox` (shared)      |
+| `HTTP`      | `LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.example.com,...`   |
+| `WebFetch`  | (same allowlist as HTTP — shared backend)             |
+| `WebSearch` | `BRAVE_API_KEY=...`                                   |
+| `Bash`      | `LOOMCYCLE_BASH_ENABLED=1` + `LOOMCYCLE_BASH_CWD=...` |
+
+Bash has additional warnings: it is **not a true sandbox** even when enabled. Run loomcycle inside a container or VM if Bash is exposed to untrusted prompts. See `internal/tools/builtin/bash.go` for the full warning.
+
+Sandbox semantics (file tools):
+- Paths must resolve **inside** the sandbox root after full `EvalSymlinks` evaluation. Symlinks pointing outside the root are refused.
+- `Write` resolves the **parent** dir (target may not exist yet); `Read` and `Edit` resolve the target itself.
+- All file writes are atomic via tempfile + same-directory rename.
+
+SSRF semantics (network tools):
+- `HostAllowlist` is **suffix-anchored** at a dot boundary: an entry `example.com` matches `example.com` and `api.example.com` but not `evilexample.com`.
+- After DNS resolution, **private IPs are hard-blocked regardless of allowlist** — RFC1918, loopback, link-local (including the AWS/GCP metadata service at `169.254.169.254`), multicast, and IPv6 ULAs. This defeats DNS rebinding.
+- Redirects re-validate the destination against the same allowlist on every hop.
+
+### MCP servers
+
+MCP servers are declared in YAML under `mcp_servers`. Each server's tools are registered as `mcp__{server}__{tool}` after the server's `tools/list` discovery completes.
+
+Per-server narrowing at the operator layer:
+
+```yaml
+mcp_servers:
+  brave-search:
+    transport: stdio
+    command: npx
+    args: [-y, "@modelcontextprotocol/server-brave-search"]
+    env: { BRAVE_API_KEY: "${BRAVE_API_KEY}" }
+    # Operator-level filter: only these of the server's tools are
+    # registered AT ALL. Others are invisible to every agent.
+    allowed_tools: [brave_web_search]
+```
+
+Without `allowed_tools` on the server entry, every tool the server advertises is registered. With it, only the listed tools are registered, and the rest are dropped before any agent can ever request them.
+
+## Layer 2 — agent-side: exposing tools
+
+Each agent definition lists which tools it can access. The list is **anchored**: anything not on it is invisible.
+
+```yaml
+agents:
+  cv-adapter:
+    model: smart
+    allowed_tools:
+      - Read
+      - Edit
+      - "mcp__brave-search__*"   # glob — every brave-search tool that's registered
+    system_prompt_file: ./prompts/cv-adapter.md
+
+  ats-filter:
+    model: local
+    allowed_tools: [Read]         # only reads files
+```
+
+If you forget `allowed_tools`, the agent gets zero tools. The startup log will warn:
+
+```
+note: agent "myagent" has no allowed_tools — it will see zero tools (intentional default-deny; add allowed_tools to its YAML to expose tools)
+```
+
+This is a feature, not a bug. New agents start with no privileges; you grant them.
+
+### Glob support
+
+Entries ending in `*` match by prefix. The canonical use is exposing all tools from one MCP server: `"mcp__brave-search__*"`. Built-in names are short and unambiguous so globs aren't usually needed for them, but the same machinery applies.
+
+### Caller-side narrowing
+
+The HTTP request can carry `allowed_tools` in the body to further narrow the agent's set on a single run:
+
+```http
+POST /v1/runs
+{
+  "agent": "cv-adapter",
+  "allowed_tools": ["Read"],         // narrowing — only Read for THIS run
+  "segments": [...]
+}
+```
+
+The effective set is the **intersection**: agent allowlist ∩ caller allowlist. The caller can shrink the agent's privileges for one run; it can never widen them.
+
+Use cases:
+- Multi-step pipelines where stage 1 only reads, stage 2 also writes.
+- A web UI that exposes a "safe mode" that disables `Bash` even when the agent is normally allowed it.
+
+## What "default-deny" means in practice
+
+| Situation                                                 | Result                                |
+|-----------------------------------------------------------|---------------------------------------|
+| Operator hasn't set `LOOMCYCLE_WRITE_ROOT`                | `Write`/`Edit` calls refuse with a clear message. |
+| Agent omits `allowed_tools`                               | The model sees zero tools.            |
+| Agent includes a tool the operator hasn't enabled         | The tool is registered (visible) but every call refuses. |
+| Caller's request lists a tool the agent doesn't allow     | That tool is silently dropped from the run's set. |
+| Agent globs `mcp__foo__*` but no such server is declared  | No tools — server isn't registered.   |
+
+## Design rationale
+
+**Why register tools the operator hasn't enabled?** So the model sees `{tool} is not configured` instead of `unknown tool`. The first is a signal the model can self-correct from ("oh, I shouldn't try that here"); the second is a confusing dead end.
+
+**Why default-deny at the agent layer?** Adding a new built-in shouldn't silently grant every existing agent new privileges. With default-deny, new tools require explicit agent opt-in.
+
+**Why allow caller narrowing but not widening?** The agent definition is the trust contract between operator and the runtime; the caller is upstream code that can reduce trust for one call but not raise it. This matches the principle that policy decisions flow inward (operator → agent → caller) and trust never compounds in the other direction.
+
+## Testing the policy
+
+Unit tests in `internal/tools/policy/policy_test.go` cover the matching rules (exact, glob, intersection).
+
+Integration tests in `internal/api/http/server_test.go`:
+- `TestAgentWithNoAllowedToolsSeesZeroTools` — empty allowlist → zero tools at the dispatcher.
+- `TestAgentWithExplicitAllowSeeTool` — positive control: allow-listed tool reaches the model.
+
+Empirical proof of the security invariant: inverting the default in `filterTools` (so empty allowlist exposes every tool) makes the first test fail. The test is what stops a future refactor from accidentally inverting the policy.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
 )
 
@@ -140,6 +141,23 @@ type runRequest struct {
 	Agent        string               `json:"agent"`
 	Segments     []loop.PromptSegment `json:"segments"`
 	AllowedTools []string             `json:"allowed_tools,omitempty"`
+	// AllowedHosts narrows the HTTP/WebFetch/WebSearch host allowlist
+	// for THIS run only. nil/omitted = no narrowing (operator's static
+	// list applies). Empty array `[]` = deny all (every network call
+	// refuses). Non-empty = intersection with the operator list (caller
+	// can shrink, never widen). The pointer-to-slice shape lets us
+	// distinguish nil from empty in JSON.
+	AllowedHosts *[]string `json:"allowed_hosts,omitempty"`
+	// WebSearchFilter selects what happens to Brave search results
+	// whose URL host isn't in the intersected AllowedHosts list:
+	//   - "drop" (default when AllowedHosts is non-nil) omits non-
+	//     matching results entirely; the model only sees URLs it can
+	//     follow up on with WebFetch.
+	//   - "keep" returns Brave's full result set; the caller filters
+	//     downstream. Useful when the caller wants visibility into
+	//     what Brave found before narrowing.
+	// Ignored when AllowedHosts is nil.
+	WebSearchFilter string `json:"web_search_filter,omitempty"`
 	// SessionID is optional. When set, the new run is appended to that
 	// session (the prior transcript is NOT replayed by /v1/runs — use
 	// /v1/sessions/{id}/messages for continuation). When empty, a fresh
@@ -236,6 +254,12 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 
 	// Filter tools by agent allowlist + caller request.
 	allowedTools := filterTools(s.tools, agentDef.AllowedTools, req.AllowedTools)
+	// Per-run host narrowing for HTTP/WebFetch/WebSearch. nil pointer
+	// = no narrowing. Empty slice = deny-all (network tools refuse).
+	// Non-empty = intersected with the operator's static allowlist.
+	if req.AllowedHosts != nil {
+		allowedTools = builtin.NarrowHosts(allowedTools, *req.AllowedHosts, req.WebSearchFilter)
+	}
 	dispatcher := tools.NewDispatcher(allowedTools)
 
 	// Optional system prompt from agent def.
@@ -319,6 +343,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 type messagesRequest struct {
 	Segments     []loop.PromptSegment `json:"segments"`
 	AllowedTools []string             `json:"allowed_tools,omitempty"`
+	// AllowedHosts and WebSearchFilter mirror runRequest — see there
+	// for the full semantics. Per-call: continuations re-supply the
+	// list each time rather than inheriting from the seed call. This
+	// keeps "what hosts can this run reach?" answerable from the
+	// request alone, no session state to chase.
+	AllowedHosts    *[]string `json:"allowed_hosts,omitempty"`
+	WebSearchFilter string    `json:"web_search_filter,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -413,6 +444,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	allowedTools := filterTools(s.tools, agentDef.AllowedTools, body.AllowedTools)
+	if body.AllowedHosts != nil {
+		allowedTools = builtin.NarrowHosts(allowedTools, *body.AllowedHosts, body.WebSearchFilter)
+	}
 	dispatcher := tools.NewDispatcher(allowedTools)
 
 	// Re-prepend the agent's system prompt — it isn't in the transcript

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -993,6 +993,102 @@ func TestPerSessionLockAppliesToRunsWithSessionID(t *testing.T) {
 	}
 }
 
+// Per-agent default-deny invariant: an agent declared with no
+// allowed_tools in YAML must see ZERO tools at the dispatcher,
+// even though several built-ins are registered server-wide. The
+// model's req.Tools should be empty. This is the security floor —
+// turning off filterTools' empty-list early-return would silently
+// expose every registered tool to every agent.
+func TestAgentWithNoAllowedToolsSeesZeroTools(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			// AllowedTools omitted — default-deny.
+			"locked": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+		ch := make(chan providers.Event, 2)
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		close(ch)
+		return ch, nil
+	}
+	// Server-wide tool inventory has FakeTool registered — the agent
+	// must NOT see it because its allowed_tools is empty.
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{&fakeBuiltinTool{}}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"locked","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.requests) == 0 {
+		t.Fatal("provider was never called")
+	}
+	if got := len(provider.requests[0].Tools); got != 0 {
+		var names []string
+		for _, ts := range provider.requests[0].Tools {
+			names = append(names, ts.Name)
+		}
+		t.Errorf("agent with no allowed_tools saw %d tools (%v); want 0", got, names)
+	}
+}
+
+// Asymmetric: an agent that DOES allow a tool sees it. Pairs with the
+// previous test as the positive case — confirms the dispatcher is
+// actually plumbed (so a "0 tools" pass isn't accidentally because the
+// pipeline is broken).
+func TestAgentWithExplicitAllowSeeTool(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"open": {Model: "stub-model", AllowedTools: []string{"FakeTool"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+		ch := make(chan providers.Event, 2)
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		close(ch)
+		return ch, nil
+	}
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{&fakeBuiltinTool{}}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"open","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.requests) == 0 || len(provider.requests[0].Tools) != 1 {
+		t.Fatalf("agent with FakeTool allowed should see 1 tool; got %d", len(provider.requests[0].Tools))
+	}
+	if provider.requests[0].Tools[0].Name != "FakeTool" {
+		t.Errorf("tool name = %q, want FakeTool", provider.requests[0].Tools[0].Name)
+	}
+}
+
 // callableProvider lets a test inject a Call function. Reuses stubProvider's
 // ID/Capabilities trivially.
 type callableProvider struct {

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1245,14 +1245,20 @@ func TestPerRequestAllowedHostsNilLeavesOperatorListIntact(t *testing.T) {
 	if toolResult == "" {
 		t.Fatal("no tool_result in second call's messages")
 	}
-	// Should NOT be the empty-allowlist message — should be a dial/DNS
-	// failure, since hostAllowed accepted operator.example and we
-	// reached dialContext.
+	// Negative: should NOT be the empty-allowlist message — caller's
+	// nil allowed_hosts means no narrowing, so the operator's
+	// [operator.example] applies and the call passes hostAllowed.
 	if strings.Contains(toolResult, "empty host allowlist") {
 		t.Errorf("nil allowed_hosts should NOT trigger empty-allowlist refusal; got %q", toolResult)
 	}
-	// We don't assert exact DNS error wording — varies by resolver.
-	// The point: the call advanced past hostAllowed.
+	// Positive: the result must include "request:" — the only error
+	// path that prefix appears on (httptool.go's "request: " + err)
+	// fires AFTER hostAllowed accepts and dialContext starts dialing.
+	// Without this assertion a future regression that rejects in some
+	// other way would still pass the negative check.
+	if !strings.Contains(toolResult, "request:") {
+		t.Errorf("tool_result should contain 'request:' (proves call reached dial layer); got %q", toolResult)
+	}
 }
 
 // callableProvider lets a test inject a Call function. Reuses stubProvider's

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 )
 
 // stubProvider replays a fixed event sequence, ignoring the request entirely.
@@ -1087,6 +1088,171 @@ func TestAgentWithExplicitAllowSeeTool(t *testing.T) {
 	if provider.requests[0].Tools[0].Name != "FakeTool" {
 		t.Errorf("tool name = %q, want FakeTool", provider.requests[0].Tools[0].Name)
 	}
+}
+
+// Per-request host narrowing — empty array → deny all. The model
+// invokes HTTP; the wrapped tool's allowlist is empty, so the call
+// refuses BEFORE any DNS or dial. We inspect the tool_result text in
+// the second provider call to confirm the refusal happened with the
+// "not in allowlist" message (which only fires when the wrapped
+// allowlist is what blocked the call).
+func TestPerRequestAllowedHostsEmptyDeniesNetworkCalls(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"net": {Model: "stub-model", AllowedTools: []string{"HTTP"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		idx := len(provider.requests) - 1
+		var evs []providers.Event
+		switch idx {
+		case 0:
+			// First turn: emit a tool_call so the loop executes HTTP.
+			evs = []providers.Event{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{
+					ID: "h1", Name: "HTTP",
+					Input: json.RawMessage(`{"method":"GET","url":"https://operator.example/"}`),
+				}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			}
+		default:
+			// Second turn: just close out so the run finishes.
+			evs = []providers.Event{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			}
+		}
+		ch := make(chan providers.Event, len(evs))
+		for _, e := range evs {
+			ch <- e
+		}
+		close(ch)
+		return ch, nil
+	}
+
+	// Register a real HTTP tool with operator's allowlist permitting
+	// operator.example. Without per-request narrowing the call would
+	// attempt to dial (and fail with DNS NXDOMAIN, not a refusal).
+	httpTool := &builtin.HTTP{HostAllowlist: []string{"operator.example"}}
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{httpTool}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// allowed_hosts: [] → deny-all narrowing. The wrapped HTTP tool
+	// has an empty allowlist, so even operator.example is refused.
+	body := `{"agent":"net","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}],"allowed_hosts":[]}`
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.requests) < 2 {
+		t.Fatalf("provider got %d calls, want >=2 (tool_use + continuation)", len(provider.requests))
+	}
+	// The second call's messages must include a tool_result whose Text
+	// reflects the empty-allowlist refusal.
+	contMsgs := provider.requests[1].Messages
+	var toolResult string
+	for _, m := range contMsgs {
+		for _, c := range m.Content {
+			if c.Type == "tool_result" {
+				toolResult = c.Text
+			}
+		}
+	}
+	if toolResult == "" {
+		t.Fatalf("no tool_result in second call's messages: %s", describeMessages(contMsgs))
+	}
+	if !strings.Contains(toolResult, "empty host allowlist") && !strings.Contains(toolResult, "not in allowlist") {
+		t.Errorf("tool_result didn't show allowlist refusal: %q", toolResult)
+	}
+}
+
+// Conversely: nil allowed_hosts (omitted from request) → operator's
+// list applies. The same scenario as above but with allowed_hosts
+// missing should reach the dial layer (and fail with a DNS error,
+// distinct from the allowlist message).
+func TestPerRequestAllowedHostsNilLeavesOperatorListIntact(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"net": {Model: "stub-model", AllowedTools: []string{"HTTP"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &callableProvider{}
+	provider.call = func(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+		idx := len(provider.requests) - 1
+		var evs []providers.Event
+		switch idx {
+		case 0:
+			evs = []providers.Event{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{
+					ID: "h1", Name: "HTTP",
+					Input: json.RawMessage(`{"method":"GET","url":"https://operator.example/"}`),
+				}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			}
+		default:
+			evs = []providers.Event{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+			}
+		}
+		ch := make(chan providers.Event, len(evs))
+		for _, e := range evs {
+			ch <- e
+		}
+		close(ch)
+		return ch, nil
+	}
+
+	httpTool := &builtin.HTTP{HostAllowlist: []string{"operator.example"}}
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{httpTool}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// allowed_hosts omitted → operator's list applies; URL passes
+	// hostAllowed and proceeds to the dial (which fails with DNS).
+	body := `{"agent":"net","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	provider.mu.Lock()
+	defer provider.mu.Unlock()
+	if len(provider.requests) < 2 {
+		t.Fatalf("provider got %d calls, want >=2", len(provider.requests))
+	}
+	var toolResult string
+	for _, m := range provider.requests[1].Messages {
+		for _, c := range m.Content {
+			if c.Type == "tool_result" {
+				toolResult = c.Text
+			}
+		}
+	}
+	if toolResult == "" {
+		t.Fatal("no tool_result in second call's messages")
+	}
+	// Should NOT be the empty-allowlist message — should be a dial/DNS
+	// failure, since hostAllowed accepted operator.example and we
+	// reached dialContext.
+	if strings.Contains(toolResult, "empty host allowlist") {
+		t.Errorf("nil allowed_hosts should NOT trigger empty-allowlist refusal; got %q", toolResult)
+	}
+	// We don't assert exact DNS error wording — varies by resolver.
+	// The point: the call advanced past hostAllowed.
 }
 
 // callableProvider lets a test inject a Call function. Reuses stubProvider's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,6 +98,29 @@ type Env struct {
 	// ReadRoot is the sandbox root for the built-in Read tool. Empty by
 	// default — the tool is registered but rejects every call until set.
 	ReadRoot string
+	// WriteRoot is the sandbox root for both Write and Edit. Empty by
+	// default — both tools refuse every call until set. Same TOCTOU
+	// guarantees as ReadRoot.
+	WriteRoot string
+	// HTTPHostAllowlist is the comma-separated list of hostnames the
+	// HTTP and WebFetch tools may reach. Empty = both tools refuse all
+	// calls. Suffix-matched: an entry "example.com" matches both
+	// "example.com" and "api.example.com". RFC1918, loopback, and
+	// link-local addresses are HARD-blocked regardless of allowlist.
+	HTTPHostAllowlist []string
+	// BraveAPIKey enables the WebSearch tool. Empty = WebSearch refuses
+	// every call. Lives at https://api.search.brave.com/.
+	BraveAPIKey string
+	// BashEnabled gates the Bash tool. Defaults to false. Even when
+	// true the tool is NOT a true sandbox — it restricts cwd, scrubs
+	// env, bounds output, and times out, but cannot prevent the spawned
+	// process from reaching arbitrary files via absolute paths or making
+	// network calls. Operators wanting real isolation should run
+	// loomcycle inside a container or VM.
+	BashEnabled bool
+	// BashCwd is the working directory for spawned bash commands. Required
+	// when BashEnabled is true; if unset the tool refuses every call.
+	BashCwd string
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -127,13 +150,18 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg.Env = Env{
-		AnthropicAPIKey: os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:    os.Getenv("OPENAI_API_KEY"),
-		OllamaBaseURL:   getenvDefault("OLLAMA_BASE_URL", "http://localhost:11434"),
-		ListenAddr:      getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
-		AuthToken:       os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
-		DataDir:         getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
-		ReadRoot:        os.Getenv("LOOMCYCLE_READ_ROOT"),
+		AnthropicAPIKey:   os.Getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:      os.Getenv("OPENAI_API_KEY"),
+		OllamaBaseURL:     getenvDefault("OLLAMA_BASE_URL", "http://localhost:11434"),
+		ListenAddr:        getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
+		AuthToken:         os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
+		DataDir:           getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
+		ReadRoot:          os.Getenv("LOOMCYCLE_READ_ROOT"),
+		WriteRoot:         os.Getenv("LOOMCYCLE_WRITE_ROOT"),
+		HTTPHostAllowlist: splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
+		BraveAPIKey:       os.Getenv("BRAVE_API_KEY"),
+		BashEnabled:       os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
+		BashCwd:           os.Getenv("LOOMCYCLE_BASH_CWD"),
 	}
 
 	if err := validate(cfg); err != nil {
@@ -224,6 +252,21 @@ func getenvDefault(name, dflt string) string {
 		return v
 	}
 	return dflt
+}
+
+// splitCSV trims whitespace and drops empties from a comma-separated env value.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 func validate(c *Config) error {

--- a/internal/tools/builtin/bash.go
+++ b/internal/tools/builtin/bash.go
@@ -50,7 +50,7 @@ type Bash struct {
 
 func (b *Bash) Name() string { return "Bash" }
 func (b *Bash) Description() string {
-	return "Run a shell command in the configured cwd. Returns combined stdout+stderr."
+	return "Run a shell command in a sandboxed working directory. Returns combined stdout+stderr."
 }
 
 func (b *Bash) InputSchema() json.RawMessage {
@@ -138,8 +138,8 @@ func (b *Bash) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	if bw.truncated {
 		fmt.Fprintf(&b2, "\n[output truncated at %d bytes]", maxOut)
 	}
-	if errors := runCtx.Err(); errors != nil {
-		fmt.Fprintf(&b2, "\n[killed: %v]", errors)
+	if ctxErr := runCtx.Err(); ctxErr != nil {
+		fmt.Fprintf(&b2, "\n[killed: %v]", ctxErr)
 		return tools.Result{Text: b2.String(), IsError: true}, nil
 	}
 	if waitErr != nil {

--- a/internal/tools/builtin/bash.go
+++ b/internal/tools/builtin/bash.go
@@ -1,0 +1,201 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Bash runs a shell command. Read this comment carefully:
+//
+// **This is NOT a true sandbox.** It restricts cwd, scrubs the env, bounds
+// output, and times out — but it cannot prevent the spawned process from
+// reaching arbitrary files via absolute paths, opening sockets, spawning
+// long-running daemons that survive the timeout (we kill the process group
+// to mitigate), or escalating via setuid binaries on PATH. Operators who
+// expose Bash to untrusted prompts MUST run loomcycle inside a container,
+// VM, or other OS-level isolation.
+//
+// Why ship it at all if it's weak? Because the alternative is forcing every
+// operator to write their own MCP server for shell execution, and the
+// per-tenant container isolation that Bash really needs is the operator's
+// responsibility either way. Shipping it as opt-in (Enabled=false default)
+// + a startup warning + this comment lets the right operator wire it up
+// for their controlled environment.
+type Bash struct {
+	// Enabled gates the entire tool. False (default) refuses every call,
+	// even when Cwd is set.
+	Enabled bool
+	// Cwd is the working directory for spawned commands. Required when
+	// Enabled. Empty Cwd refuses every call.
+	Cwd string
+	// MaxOutputBytes caps stdout+stderr. Default 1 MiB.
+	MaxOutputBytes int64
+	// Timeout caps wall-clock per call. Default 30s. Hard ceiling 5min.
+	Timeout time.Duration
+	// AllowedExtraEnv is the list of env-var names passed through from
+	// the parent process beyond PATH (which is always passed through
+	// because most binaries break without it). Empty by default —
+	// only PATH leaks.
+	AllowedExtraEnv []string
+}
+
+func (b *Bash) Name() string { return "Bash" }
+func (b *Bash) Description() string {
+	return "Run a shell command in the configured cwd. Returns combined stdout+stderr."
+}
+
+func (b *Bash) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"command":         {"type": "string", "description": "Shell command to execute via /bin/sh -c."},
+			"timeout_seconds": {"type": "integer", "description": "Per-call timeout. Capped at 300s."}
+		},
+		"required": ["command"]
+	}`)
+}
+
+const (
+	bashTimeoutDefault = 30 * time.Second
+	bashTimeoutMax     = 5 * time.Minute
+	bashOutputDefault  = 1 << 20
+)
+
+func (b *Bash) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Command        string `json:"command"`
+		TimeoutSeconds int    `json:"timeout_seconds"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	if !b.Enabled {
+		return tools.Result{Text: "Bash tool is not enabled (set LOOMCYCLE_BASH_ENABLED=1); refusing", IsError: true}, nil
+	}
+	if b.Cwd == "" {
+		return tools.Result{Text: "Bash tool has no cwd configured; refusing", IsError: true}, nil
+	}
+	if args.Command == "" {
+		return tools.Result{Text: "command is required", IsError: true}, nil
+	}
+
+	cwd, err := filepath.EvalSymlinks(b.Cwd)
+	if err != nil {
+		return tools.Result{Text: "cwd: " + err.Error(), IsError: true}, nil
+	}
+
+	timeout := b.Timeout
+	if timeout == 0 {
+		timeout = bashTimeoutDefault
+	}
+	if args.TimeoutSeconds > 0 {
+		timeout = time.Duration(args.TimeoutSeconds) * time.Second
+	}
+	if timeout > bashTimeoutMax {
+		timeout = bashTimeoutMax
+	}
+
+	maxOut := b.MaxOutputBytes
+	if maxOut == 0 {
+		maxOut = bashOutputDefault
+	}
+
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(runCtx, "/bin/sh", "-c", args.Command)
+	cmd.Dir = cwd
+	cmd.Env = b.buildEnv()
+	// Capture combined output through a bounded buffer. We write to a
+	// LimitedWriter rather than reading all-at-once so a malicious command
+	// can't OOM us by producing 100 GiB of output before we read it.
+	bw := &boundedWriter{cap: maxOut}
+	cmd.Stdout = bw
+	cmd.Stderr = bw
+
+	startErr := cmd.Start()
+	if startErr != nil {
+		return tools.Result{Text: "start: " + startErr.Error(), IsError: true}, nil
+	}
+	// CommandContext sends SIGKILL on ctx cancel, so an in-flight Wait()
+	// returns with an exit error. Fork-bomb children of the immediate
+	// child may survive — consistent with "Bash is not a true sandbox".
+	// Run inside a container if that matters.
+	waitErr := cmd.Wait()
+
+	out := bw.bytes()
+	var b2 bytes.Buffer
+	b2.Write(out)
+	if bw.truncated {
+		fmt.Fprintf(&b2, "\n[output truncated at %d bytes]", maxOut)
+	}
+	if errors := runCtx.Err(); errors != nil {
+		fmt.Fprintf(&b2, "\n[killed: %v]", errors)
+		return tools.Result{Text: b2.String(), IsError: true}, nil
+	}
+	if waitErr != nil {
+		// Non-zero exit. The model often legitimately runs commands that
+		// fail (e.g. grep with no match → exit 1). Surface as IsError so
+		// the model can self-correct, but include the output so it has
+		// something to work with.
+		fmt.Fprintf(&b2, "\n[exit: %s]", waitErr.Error())
+		return tools.Result{Text: b2.String(), IsError: true}, nil
+	}
+	return tools.Result{Text: b2.String()}, nil
+}
+
+// buildEnv constructs the env passed to the child. Only PATH leaks by
+// default (most binaries are unusable without it), plus any explicitly
+// allow-listed names. Sensitive secrets like API keys never leak — the
+// model could otherwise extract them via `env`.
+func (b *Bash) buildEnv() []string {
+	out := []string{}
+	if v := os.Getenv("PATH"); v != "" {
+		out = append(out, "PATH="+v)
+	}
+	for _, name := range b.AllowedExtraEnv {
+		if v := os.Getenv(name); v != "" {
+			out = append(out, name+"="+v)
+		}
+	}
+	return out
+}
+
+// boundedWriter is an io.Writer with a hard byte cap. After cap bytes
+// are written, further writes are silently discarded and truncated is
+// set. Concurrent writes from cmd.Stdout and cmd.Stderr are serialised
+// by exec — we don't need our own mutex.
+type boundedWriter struct {
+	cap       int64
+	buf       bytes.Buffer
+	truncated bool
+}
+
+func (w *boundedWriter) Write(p []byte) (int, error) {
+	remain := w.cap - int64(w.buf.Len())
+	if remain <= 0 {
+		w.truncated = true
+		return len(p), nil
+	}
+	if int64(len(p)) > remain {
+		w.buf.Write(p[:remain])
+		w.truncated = true
+		return len(p), nil
+	}
+	w.buf.Write(p)
+	return len(p), nil
+}
+
+func (w *boundedWriter) bytes() []byte { return w.buf.Bytes() }
+
+// Compile-time assertion: boundedWriter satisfies io.Writer.
+var _ io.Writer = (*boundedWriter)(nil)

--- a/internal/tools/builtin/bash_test.go
+++ b/internal/tools/builtin/bash_test.go
@@ -1,0 +1,199 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Refusal cases: empty Enabled flag rejects every call. We test this
+// before any cwd config because Enabled is the single security gate
+// operators need to flip — a misconfigured cwd should never matter
+// when Enabled is false.
+func TestBashRefusesWhenNotEnabled(t *testing.T) {
+	b := &Bash{Cwd: "/tmp"}
+	res, err := b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "not enabled") {
+		t.Errorf("expected not-enabled refusal, got %q", res.Text)
+	}
+}
+
+func TestBashRefusesWithoutCwd(t *testing.T) {
+	b := &Bash{Enabled: true}
+	res, err := b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "no cwd") {
+		t.Errorf("expected no-cwd refusal, got %q", res.Text)
+	}
+}
+
+func TestBashRunsInsideCwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses /bin/sh; Windows tests would need cmd.exe wrapping")
+	}
+	cwd, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, "marker.txt"), []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Bash{Enabled: true, Cwd: cwd}
+	body, _ := json.Marshal(map[string]string{"command": "ls"})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "marker.txt") {
+		t.Errorf("ls did not see marker.txt; got %q", res.Text)
+	}
+}
+
+func TestBashTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{Enabled: true, Cwd: cwd, Timeout: 100 * time.Millisecond}
+	body, _ := json.Marshal(map[string]any{"command": "sleep 5"})
+
+	start := time.Now()
+	res, err := b.Execute(context.Background(), body)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected timeout error, got %q", res.Text)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("timeout did not fire in time: elapsed=%v", elapsed)
+	}
+}
+
+// Output bound: a command that produces 100KB of output should be
+// truncated when MaxOutputBytes is 1KB. The buffer cap is what
+// prevents an OOM from a malicious command.
+func TestBashTruncatesOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{Enabled: true, Cwd: cwd, MaxOutputBytes: 100}
+	// yes | head -c 5000 produces ~5KB of "y\n" repeated.
+	body, _ := json.Marshal(map[string]string{"command": "yes | head -c 5000"})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "[output truncated at 100 bytes]") {
+		t.Errorf("missing truncation marker; output len=%d, text=%q", len(res.Text), res.Text)
+	}
+}
+
+// Env scrub: ANTHROPIC_API_KEY is in the parent's env (test sets it),
+// but a Bash command's `env` output must not see it. PATH is the only
+// thing we leak by default.
+func TestBashScrubsParentEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	t.Setenv("LOOMCYCLE_SECRET_FOR_TEST", "leak-me")
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{Enabled: true, Cwd: cwd}
+	body, _ := json.Marshal(map[string]string{"command": "env"})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(res.Text, "LOOMCYCLE_SECRET_FOR_TEST") {
+		t.Errorf("parent env leaked into child: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "PATH=") {
+		t.Errorf("PATH should be inherited (most binaries need it); got %q", res.Text)
+	}
+}
+
+// Allowlisted env passthrough: explicitly allowed names DO leak.
+// Operators use this to share e.g. NODE_ENV or build-system flags.
+func TestBashAllowsExplicitlyAllowedEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	t.Setenv("LOOMCYCLE_PUBLIC_FOR_TEST", "share-me")
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{
+		Enabled:         true,
+		Cwd:             cwd,
+		AllowedExtraEnv: []string{"LOOMCYCLE_PUBLIC_FOR_TEST"},
+	}
+	body, _ := json.Marshal(map[string]string{"command": "env"})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "LOOMCYCLE_PUBLIC_FOR_TEST=share-me") {
+		t.Errorf("allow-listed env did not pass through: %q", res.Text)
+	}
+}
+
+// Non-zero exit is reported as IsError but the output is preserved so
+// the model has something to work with (e.g. grep with no match).
+func TestBashNonZeroExitSurfacesAsError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{Enabled: true, Cwd: cwd}
+	body, _ := json.Marshal(map[string]string{"command": "echo something; exit 7"})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true on non-zero exit; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "something") {
+		t.Errorf("output not preserved on error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "[exit:") {
+		t.Errorf("exit marker missing: %q", res.Text)
+	}
+}
+
+// 5-minute hard ceiling: even if the caller asks for an hour, we cap.
+func TestBashCallerTimeoutCappedAtHardCeiling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip()
+	}
+	cwd, _ := filepath.EvalSymlinks(t.TempDir())
+	b := &Bash{Enabled: true, Cwd: cwd, MaxOutputBytes: 64}
+	// timeout_seconds: 9999 → must clamp to 300s. We don't actually wait;
+	// just verify the configured timeout doesn't allow >5min via reflection
+	// of behaviour: a quick command should still complete.
+	body, _ := json.Marshal(map[string]any{"command": "echo fast", "timeout_seconds": 9999})
+	res, err := b.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Errorf("quick command failed: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "fast") {
+		t.Errorf("missing output: %q", res.Text)
+	}
+}

--- a/internal/tools/builtin/edit.go
+++ b/internal/tools/builtin/edit.go
@@ -70,24 +70,11 @@ func (e *Edit) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 		maxBytes = 1 << 20
 	}
 
-	// Resolve sandbox + target. Edit requires the file to exist, so we
-	// EvalSymlinks the target itself (Write resolved the parent because
-	// the file may be new).
-	root, err := filepath.EvalSymlinks(e.Root)
-	if err != nil {
-		return tools.Result{Text: "sandbox root: " + err.Error(), IsError: true}, nil
-	}
-	abs, err := filepath.Abs(filepath.Clean(args.Path))
-	if err != nil {
-		return tools.Result{Text: "abs path: " + err.Error(), IsError: true}, nil
-	}
-	resolved, err := filepath.EvalSymlinks(abs)
+	// Edit requires the file to exist, so we use resolveInsideRoot
+	// (Write would resolve the parent because the file may be new).
+	resolved, err := resolveInsideRoot(e.Root, args.Path)
 	if err != nil {
 		return tools.Result{Text: err.Error(), IsError: true}, nil
-	}
-	rel, err := filepath.Rel(root, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return tools.Result{Text: fmt.Sprintf("path %q escapes sandbox %q", resolved, root), IsError: true}, nil
 	}
 
 	info, err := os.Stat(resolved)

--- a/internal/tools/builtin/edit.go
+++ b/internal/tools/builtin/edit.go
@@ -1,0 +1,150 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Edit replaces text in an existing file inside the sandbox root.
+// Mirrors the Claude Code Edit semantics: by default the OldString must
+// occur EXACTLY once — ambiguity is an error so the model can supply
+// more surrounding context. ReplaceAll lifts that requirement.
+//
+// Sandbox shares Root with Write. The file must already exist; Edit
+// does not create files (callers should use Write for that). The whole
+// file is read into memory, mutated, and written back via the same
+// atomic tempfile + rename dance Write uses.
+type Edit struct {
+	// Root is the sandbox root (same one used by Write). Required.
+	Root string
+	// MaxBytes caps the file size Edit will load. Default 1 MiB.
+	MaxBytes int64
+}
+
+func (e *Edit) Name() string { return "Edit" }
+func (e *Edit) Description() string {
+	return "Replace text in an existing file inside the sandbox root."
+}
+
+func (e *Edit) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path":        {"type": "string", "description": "Absolute file path inside the sandbox root."},
+			"old_string":  {"type": "string", "description": "Exact text to replace. Must be unique unless replace_all is true."},
+			"new_string":  {"type": "string", "description": "Replacement text. Must differ from old_string."},
+			"replace_all": {"type": "boolean", "description": "Replace every occurrence instead of requiring exactly one match."}
+		},
+		"required": ["path", "old_string", "new_string"]
+	}`)
+}
+
+func (e *Edit) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path       string `json:"path"`
+		OldString  string `json:"old_string"`
+		NewString  string `json:"new_string"`
+		ReplaceAll bool   `json:"replace_all"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		return tools.Result{Text: "path is required", IsError: true}, nil
+	}
+	if args.OldString == args.NewString {
+		return tools.Result{Text: "old_string and new_string must differ", IsError: true}, nil
+	}
+	if e.Root == "" {
+		return tools.Result{Text: "Edit tool is not configured with a sandbox root; refusing to edit", IsError: true}, nil
+	}
+
+	maxBytes := e.MaxBytes
+	if maxBytes == 0 {
+		maxBytes = 1 << 20
+	}
+
+	// Resolve sandbox + target. Edit requires the file to exist, so we
+	// EvalSymlinks the target itself (Write resolved the parent because
+	// the file may be new).
+	root, err := filepath.EvalSymlinks(e.Root)
+	if err != nil {
+		return tools.Result{Text: "sandbox root: " + err.Error(), IsError: true}, nil
+	}
+	abs, err := filepath.Abs(filepath.Clean(args.Path))
+	if err != nil {
+		return tools.Result{Text: "abs path: " + err.Error(), IsError: true}, nil
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return tools.Result{Text: fmt.Sprintf("path %q escapes sandbox %q", resolved, root), IsError: true}, nil
+	}
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	if info.Size() > maxBytes {
+		return tools.Result{Text: fmt.Sprintf("file size %d exceeds limit %d", info.Size(), maxBytes), IsError: true}, nil
+	}
+
+	body, err := os.ReadFile(resolved)
+	if err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+
+	count := strings.Count(string(body), args.OldString)
+	if count == 0 {
+		return tools.Result{Text: "old_string not found in file", IsError: true}, nil
+	}
+	if count > 1 && !args.ReplaceAll {
+		return tools.Result{Text: fmt.Sprintf("old_string occurs %d times; supply more context or set replace_all=true", count), IsError: true}, nil
+	}
+
+	var replaced string
+	if args.ReplaceAll {
+		replaced = strings.ReplaceAll(string(body), args.OldString, args.NewString)
+	} else {
+		replaced = strings.Replace(string(body), args.OldString, args.NewString, 1)
+	}
+
+	parent := filepath.Dir(resolved)
+	tmp, err := os.CreateTemp(parent, ".loomcycle-edit-*")
+	if err != nil {
+		return tools.Result{Text: "create tempfile: " + err.Error(), IsError: true}, nil
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.WriteString(replaced); err != nil {
+		tmp.Close()
+		return tools.Result{Text: "write tempfile: " + err.Error(), IsError: true}, nil
+	}
+	if err := tmp.Close(); err != nil {
+		return tools.Result{Text: "close tempfile: " + err.Error(), IsError: true}, nil
+	}
+	if err := ctx.Err(); err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	if err := os.Rename(tmpName, resolved); err != nil {
+		return tools.Result{Text: "rename: " + err.Error(), IsError: true}, nil
+	}
+	return tools.Result{Text: fmt.Sprintf("edited %s (%d replacement%s)", resolved, count, plural(count))}, nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/tools/builtin/edit_test.go
+++ b/internal/tools/builtin/edit_test.go
@@ -1,0 +1,190 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEditRefusesEmptyRoot(t *testing.T) {
+	e := &Edit{}
+	res, err := e.Execute(context.Background(), json.RawMessage(`{"path":"/tmp/x","old_string":"a","new_string":"b"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "sandbox") {
+		t.Fatalf("expected sandbox-refusal error, got Text=%q IsError=%v", res.Text, res.IsError)
+	}
+}
+
+func TestEditRejectsIdenticalOldAndNew(t *testing.T) {
+	e := &Edit{Root: t.TempDir()}
+	body, _ := json.Marshal(map[string]string{"path": "/x", "old_string": "same", "new_string": "same"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected error for old==new, got %q", res.Text)
+	}
+}
+
+func TestEditOldStringNotFound(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(target, []byte("hello world"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "missing", "new_string": "x"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "not found") {
+		t.Errorf("expected not-found error, got %q", res.Text)
+	}
+}
+
+// Mirrors Claude Code's Edit semantics: ambiguous old_string is an error
+// the model can fix by widening context. Asserting it forces the model
+// to think instead of overwriting all matches by accident.
+func TestEditRejectsAmbiguousMatchWithoutReplaceAll(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(target, []byte("foo foo foo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "foo", "new_string": "bar"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "occurs 3 times") {
+		t.Errorf("expected ambiguity error mentioning count, got %q", res.Text)
+	}
+	// Confirm file untouched.
+	got, _ := os.ReadFile(target)
+	if string(got) != "foo foo foo" {
+		t.Errorf("ambiguous edit modified file: %q", string(got))
+	}
+}
+
+func TestEditSingleReplacement(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(target, []byte("hello world"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "world", "new_string": "earth"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "hello earth" {
+		t.Errorf("after edit: %q, want %q", string(got), "hello earth")
+	}
+}
+
+func TestEditReplaceAll(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(target, []byte("foo foo foo"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root}
+	body, _ := json.Marshal(map[string]any{"path": target, "old_string": "foo", "new_string": "bar", "replace_all": true})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "bar bar bar" {
+		t.Errorf("after replace_all: %q, want %q", string(got), "bar bar bar")
+	}
+	if !strings.Contains(res.Text, "3 replacements") {
+		t.Errorf("expected count in result text, got %q", res.Text)
+	}
+}
+
+func TestEditRejectsSymlinkEscape(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("CLASSIFIED"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink(secret, link); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": link, "old_string": "CLASSIFIED", "new_string": "OPEN"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("symlink to outside-sandbox file must be rejected; got %q", res.Text)
+	}
+	got, _ := os.ReadFile(secret)
+	if string(got) != "CLASSIFIED" {
+		t.Errorf("symlinked file was modified: %q", string(got))
+	}
+}
+
+func TestEditRejectsOversizedFile(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "big.txt")
+	if err := os.WriteFile(target, []byte("0123456789ABCDEF"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &Edit{Root: root, MaxBytes: 8}
+	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "0", "new_string": "X"})
+	res, err := e.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "exceeds") {
+		t.Errorf("expected size-bound error, got %q", res.Text)
+	}
+}

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -1,0 +1,265 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// HTTP performs a single outbound HTTP request and returns the response body
+// as text. Two layers of SSRF defence:
+//
+//  1. **Hostname allowlist** (HostAllowlist). Suffix-matched: an entry
+//     "example.com" matches "example.com" and "api.example.com" but not
+//     "evil-example.com". Empty allowlist refuses every call.
+//
+//  2. **IP-level block at connect time** via Dialer.Control. Even if the
+//     hostname is allowlisted, the resolved IP is rejected if it falls in
+//     RFC1918 / loopback / link-local / multicast / unspecified ranges.
+//     This defeats DNS rebinding: the allowlisted hostname can resolve to
+//     anything but we only TCP-connect to public addresses.
+//
+// Redirects re-run the allowlist check on every hop. Bodies are bounded
+// in both directions; ctx is honoured throughout via the standard request
+// context propagation.
+type HTTP struct {
+	// HostAllowlist is the suffix-matched list of permitted hostnames.
+	// Required: empty allowlist rejects every call.
+	HostAllowlist []string
+	// MaxRequestBytes caps the request body. Default 256 KiB.
+	MaxRequestBytes int64
+	// MaxResponseBytes caps the response body (truncated, not erroring).
+	// Default 256 KiB.
+	MaxResponseBytes int64
+	// Timeout is the per-request timeout. Default 30s.
+	Timeout time.Duration
+	// AllowPrivateIPs disables the IP-level block. Default false. Tests
+	// flip this to true so they can hit httptest.NewServer (loopback).
+	// Production never sets this to true.
+	AllowPrivateIPs bool
+}
+
+func (h *HTTP) Name() string { return "HTTP" }
+func (h *HTTP) Description() string {
+	return "Make an HTTP request to an allowlisted host. Returns response body as text (truncated)."
+}
+
+func (h *HTTP) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"method":  {"type": "string", "enum": ["GET","POST","PUT","PATCH","DELETE","HEAD"], "description": "HTTP method."},
+			"url":     {"type": "string", "description": "Absolute URL (scheme http/https). Host must be allowlisted."},
+			"headers": {"type": "object", "additionalProperties": {"type": "string"}},
+			"body":    {"type": "string", "description": "Request body. Required for POST/PUT/PATCH; ignored otherwise."}
+		},
+		"required": ["method", "url"]
+	}`)
+}
+
+func (h *HTTP) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Method  string            `json:"method"`
+		URL     string            `json:"url"`
+		Headers map[string]string `json:"headers"`
+		Body    string            `json:"body"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	return h.do(ctx, args.Method, args.URL, args.Headers, args.Body)
+}
+
+// do is split out so WebFetch can call it directly with GET defaults.
+func (h *HTTP) do(ctx context.Context, method, rawURL string, headers map[string]string, body string) (tools.Result, error) {
+	if len(h.HostAllowlist) == 0 {
+		return tools.Result{Text: "HTTP tool has empty host allowlist; refusing all calls", IsError: true}, nil
+	}
+	if method == "" {
+		method = "GET"
+	}
+	method = strings.ToUpper(method)
+	switch method {
+	case "GET", "POST", "PUT", "PATCH", "DELETE", "HEAD":
+	default:
+		return tools.Result{Text: "unsupported method: " + method, IsError: true}, nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return tools.Result{Text: "invalid url: " + err.Error(), IsError: true}, nil
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return tools.Result{Text: "url scheme must be http or https", IsError: true}, nil
+	}
+	if !hostAllowed(parsed.Hostname(), h.HostAllowlist) {
+		return tools.Result{Text: fmt.Sprintf("host %q not in allowlist", parsed.Hostname()), IsError: true}, nil
+	}
+
+	maxReq := h.MaxRequestBytes
+	if maxReq == 0 {
+		maxReq = 256 * 1024
+	}
+	if int64(len(body)) > maxReq {
+		return tools.Result{Text: fmt.Sprintf("request body exceeds %d bytes", maxReq), IsError: true}, nil
+	}
+	maxResp := h.MaxResponseBytes
+	if maxResp == 0 {
+		maxResp = 256 * 1024
+	}
+	timeout := h.Timeout
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(reqCtx, method, rawURL, strings.NewReader(body))
+	if err != nil {
+		return tools.Result{Text: "build request: " + err.Error(), IsError: true}, nil
+	}
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+
+	client := &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			DialContext: h.dialContext,
+		},
+		// Re-validate the destination on each redirect hop. Without
+		// this, an allowlisted host could 302 to an internal URL and
+		// the second TCP connect would happen to a non-allowlisted
+		// destination — only blocked by the IP-level guard.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			if !hostAllowed(req.URL.Hostname(), h.HostAllowlist) {
+				return fmt.Errorf("redirect host %q not in allowlist", req.URL.Hostname())
+			}
+			return nil
+		},
+	}
+
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return tools.Result{Text: "request: " + err.Error(), IsError: true}, nil
+	}
+	defer resp.Body.Close()
+
+	limited := io.LimitReader(resp.Body, maxResp+1)
+	respBody, err := io.ReadAll(limited)
+	if err != nil {
+		return tools.Result{Text: "read response: " + err.Error(), IsError: true}, nil
+	}
+	truncated := false
+	if int64(len(respBody)) > maxResp {
+		respBody = respBody[:maxResp]
+		truncated = true
+	}
+
+	var b bytes.Buffer
+	fmt.Fprintf(&b, "HTTP %s %s -> %d\n", method, rawURL, resp.StatusCode)
+	for k, v := range resp.Header {
+		fmt.Fprintf(&b, "%s: %s\n", k, strings.Join(v, ", "))
+	}
+	b.WriteString("\n")
+	b.Write(respBody)
+	if truncated {
+		fmt.Fprintf(&b, "\n[truncated at %d bytes]", maxResp)
+	}
+	return tools.Result{Text: b.String()}, nil
+}
+
+// dialContext is the connection-level SSRF guard. By the time we reach it,
+// the hostname has been DNS-resolved to a concrete address — we reject
+// the connection if the address is private. This catches DNS rebinding
+// even when the hostname passed the allowlist.
+func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if !h.AllowPrivateIPs {
+		for _, ip := range ips {
+			if isPrivateIP(ip.IP) {
+				return nil, fmt.Errorf("blocked: %s resolves to private address %s", host, ip.IP)
+			}
+		}
+	}
+	d := net.Dialer{
+		Timeout: 10 * time.Second,
+		Control: func(network, address string, c syscall.RawConn) error {
+			// Belt-and-braces: if the kernel resolves to a different IP
+			// than our LookupIP saw (rare but possible under racy DNS),
+			// the address the syscall sees is the one we'll connect to.
+			// Re-check it.
+			if h.AllowPrivateIPs {
+				return nil
+			}
+			ip, _, _ := net.SplitHostPort(address)
+			if parsed := net.ParseIP(ip); parsed != nil && isPrivateIP(parsed) {
+				return fmt.Errorf("blocked: socket-level address %s is private", ip)
+			}
+			return nil
+		},
+	}
+	return d.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+}
+
+// hostAllowed reports whether host is permitted by the allowlist.
+// Suffix match anchored on a dot boundary so "example.com" matches
+// "example.com" and "api.example.com" but not "evilexample.com".
+// Bare hostnames (no dots) match exactly only.
+func hostAllowed(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "" {
+		return false
+	}
+	for _, entry := range allowlist {
+		entry = strings.ToLower(strings.TrimSuffix(entry, "."))
+		if entry == "" {
+			continue
+		}
+		if host == entry {
+			return true
+		}
+		if strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPrivateIP returns true for any IP an SSRF attacker would want to reach:
+// loopback (127.0.0.0/8, ::1), RFC1918 private (10/8, 172.16/12, 192.168/16),
+// link-local (169.254/16, fe80::/10) — including the AWS/GCP metadata service
+// at 169.254.169.254 — multicast, and unspecified (0.0.0.0, ::).
+// IPv6 ULAs (fc00::/7) too.
+func isPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate() {
+		return true
+	}
+	return false
+}

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -184,10 +184,24 @@ func (h *HTTP) do(ctx context.Context, method, rawURL string, headers map[string
 	return tools.Result{Text: b.String()}, nil
 }
 
-// dialContext is the connection-level SSRF guard. By the time we reach it,
-// the hostname has been DNS-resolved to a concrete address — we reject
-// the connection if the address is private. This catches DNS rebinding
-// even when the hostname passed the allowlist.
+// dialContext is the connection-level SSRF guard. By the time we reach
+// it, the hostname has been DNS-resolved to a concrete address set —
+// we filter out private addresses, refuse if NONE remain, and try each
+// public address in turn until one connects (mirrors stdlib Dialer's
+// happy-eyeballs-like behaviour for dual-stack hosts).
+//
+// This shape catches two real-world cases the naive "ips[0]" approach
+// misses:
+//
+//   - Dual-stack host returns [v6, v4]; v6 unreachable on this network.
+//     Iterating across the slice lets us fall back to v4.
+//   - Public host with a misconfigured DNS record that includes a
+//     private IP alongside the real one (corp-DNS leak). We dial the
+//     public IPs and ignore the leak rather than refusing the host.
+//
+// The Control hook is a belt-and-braces re-check at the syscall layer
+// in case the kernel ends up dialing a different address than the IP
+// we passed (rare but possible if the address gets transformed).
 func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -197,20 +211,21 @@ func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn,
 	if err != nil {
 		return nil, err
 	}
+	candidates := ips
 	if !h.AllowPrivateIPs {
+		candidates = candidates[:0]
 		for _, ip := range ips {
-			if isPrivateIP(ip.IP) {
-				return nil, fmt.Errorf("blocked: %s resolves to private address %s", host, ip.IP)
+			if !isPrivateIP(ip.IP) {
+				candidates = append(candidates, ip)
 			}
+		}
+		if len(candidates) == 0 {
+			return nil, fmt.Errorf("blocked: %s has no public addresses (got %d private)", host, len(ips))
 		}
 	}
 	d := net.Dialer{
 		Timeout: 10 * time.Second,
 		Control: func(network, address string, c syscall.RawConn) error {
-			// Belt-and-braces: if the kernel resolves to a different IP
-			// than our LookupIP saw (rare but possible under racy DNS),
-			// the address the syscall sees is the one we'll connect to.
-			// Re-check it.
 			if h.AllowPrivateIPs {
 				return nil
 			}
@@ -221,7 +236,15 @@ func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn,
 			return nil
 		},
 	}
-	return d.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+	var lastErr error
+	for _, ip := range candidates {
+		conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if err == nil {
+			return conn, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 // hostAllowed reports whether host is permitted by the allowlist.

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -78,8 +78,29 @@ func TestHTTPRejectsPrivateIPDespiteAllowlist(t *testing.T) {
 	if !res.IsError {
 		t.Fatalf("expected private-IP rejection, got %q", res.Text)
 	}
-	if !strings.Contains(res.Text, "private") {
-		t.Errorf("rejection should mention private; got %q", res.Text)
+	if !strings.Contains(res.Text, "no public addresses") && !strings.Contains(res.Text, "private") {
+		t.Errorf("rejection should mention private/public; got %q", res.Text)
+	}
+}
+
+// Direct unit test on dialContext with a public-shaped hostname that
+// resolves entirely to private IPs — proves the guard is what stops
+// the dial, not the layer-1 allowlist exact-match path. Catches the
+// regression the reviewer flagged: a future refactor of hostAllowed
+// could break this without TestHTTPRejectsPrivateIPDespiteAllowlist
+// noticing, because that test relies on "localhost"-as-allowlisted.
+//
+// We don't need a custom resolver: net.DefaultResolver.LookupIPAddr
+// resolves "localhost" to loopback addresses on every standard system,
+// and "localhost" is private under our isPrivateIP rule.
+func TestHTTPDialContextRefusesAllPrivateResolution(t *testing.T) {
+	h := &HTTP{HostAllowlist: []string{"localhost"}, AllowPrivateIPs: false}
+	_, err := h.dialContext(context.Background(), "tcp", "localhost:1")
+	if err == nil {
+		t.Fatal("expected refusal; localhost should resolve only to private IPs")
+	}
+	if !strings.Contains(err.Error(), "no public addresses") {
+		t.Errorf("expected 'no public addresses' error, got %v", err)
 	}
 }
 

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -1,0 +1,219 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestHTTPRefusesEmptyAllowlist(t *testing.T) {
+	h := &HTTP{}
+	res, err := h.Execute(context.Background(), json.RawMessage(`{"method":"GET","url":"https://example.com"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "allowlist") {
+		t.Fatalf("expected allowlist refusal, got %q", res.Text)
+	}
+}
+
+func TestHTTPHostAllowlist(t *testing.T) {
+	cases := []struct {
+		host  string
+		list  []string
+		allow bool
+	}{
+		{"example.com", []string{"example.com"}, true},
+		{"api.example.com", []string{"example.com"}, true},  // suffix match
+		{"evilexample.com", []string{"example.com"}, false}, // anchored
+		{"example.com.evil", []string{"example.com"}, false},
+		{"example.com", nil, false},
+		{"", []string{"example.com"}, false},
+		{"EXAMPLE.COM", []string{"example.com"}, true}, // case-insensitive
+	}
+	for _, tc := range cases {
+		t.Run(tc.host+"/"+strings.Join(tc.list, ","), func(t *testing.T) {
+			if got := hostAllowed(tc.host, tc.list); got != tc.allow {
+				t.Errorf("hostAllowed(%q, %v) = %v, want %v", tc.host, tc.list, got, tc.allow)
+			}
+		})
+	}
+}
+
+// SSRF defence layer 1: hostname not in allowlist → refuse before any DNS
+// or TCP work. The IP guard would also catch a private resolution, but
+// catching it earlier means we never resolve attacker-controlled DNS.
+func TestHTTPRejectsNonAllowlistedHost(t *testing.T) {
+	h := &HTTP{HostAllowlist: []string{"good.example"}}
+	res, err := h.Execute(context.Background(), json.RawMessage(`{"method":"GET","url":"https://attacker.example/"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "not in allowlist") {
+		t.Errorf("expected allowlist rejection, got %q", res.Text)
+	}
+}
+
+// SSRF defence layer 2: even if the hostname IS allowlisted, an IP that
+// resolves to a private range must be refused at connect time. We test
+// this with an allowlisted hostname and a manual loopback URL — the
+// IP-level check on 127.0.0.1 should fire.
+func TestHTTPRejectsPrivateIPDespiteAllowlist(t *testing.T) {
+	// AllowPrivateIPs MUST stay false here so the test exercises the guard.
+	h := &HTTP{HostAllowlist: []string{"localhost"}}
+	body, _ := json.Marshal(map[string]string{
+		"method": "GET",
+		"url":    "http://localhost:1/", // any non-routable port; we expect rejection BEFORE the dial completes
+	})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected private-IP rejection, got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "private") {
+		t.Errorf("rejection should mention private; got %q", res.Text)
+	}
+}
+
+func TestIsPrivateIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"10.0.0.1", true},
+		{"192.168.1.1", true},
+		{"172.16.0.1", true},
+		{"169.254.169.254", true}, // EC2/GCP metadata
+		{"0.0.0.0", true},
+		{"::1", true},
+		{"fe80::1", true},
+		{"fc00::1", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+		{"2606:4700:4700::1111", false}, // Cloudflare public DNS v6
+	}
+	for _, tc := range cases {
+		t.Run(tc.ip, func(t *testing.T) {
+			if got := isPrivateIP(net.ParseIP(tc.ip)); got != tc.private {
+				t.Errorf("isPrivateIP(%s) = %v, want %v", tc.ip, got, tc.private)
+			}
+		})
+	}
+}
+
+// Successful round-trip against an allowed httptest server (loopback,
+// so AllowPrivateIPs must be set — production code never sets this).
+func TestHTTPSuccessfulRoundTrip(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "hello from server")
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	h := &HTTP{HostAllowlist: []string{host}, AllowPrivateIPs: true}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "hello from server") {
+		t.Errorf("missing body; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "-> 200") {
+		t.Errorf("missing status line; got %q", res.Text)
+	}
+}
+
+// Response truncation: a server that returns more than MaxResponseBytes
+// gets truncated and the result text says so. Without truncation, a
+// hostile server could blow the model's context window.
+func TestHTTPTruncatesLargeResponse(t *testing.T) {
+	big := strings.Repeat("x", 10_000)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, big)
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	h := &HTTP{HostAllowlist: []string{host}, AllowPrivateIPs: true, MaxResponseBytes: 100}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "[truncated at 100 bytes]") {
+		t.Errorf("missing truncation marker; got %q", res.Text)
+	}
+}
+
+// Redirect chain: if an allowed host 302s to a non-allowlisted host,
+// the redirect must be refused. This is the second SSRF surface — a
+// model could be tricked into following a redirect to an internal URL.
+func TestHTTPRefusesRedirectToNonAllowlistedHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://attacker.example/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	h := &HTTP{HostAllowlist: []string{host}, AllowPrivateIPs: true}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected redirect rejection, got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "redirect host") {
+		t.Errorf("expected redirect-host error; got %q", res.Text)
+	}
+}
+
+func TestHTTPRejectsOversizedRequestBody(t *testing.T) {
+	h := &HTTP{HostAllowlist: []string{"x.example"}, MaxRequestBytes: 8}
+	body, _ := json.Marshal(map[string]string{"method": "POST", "url": "https://x.example/", "body": "this is much more than eight bytes"})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "exceeds") {
+		t.Errorf("expected body-size rejection, got %q", res.Text)
+	}
+}
+
+func TestHTTPRejectsNonHTTPScheme(t *testing.T) {
+	h := &HTTP{HostAllowlist: []string{"example"}}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": "file:///etc/passwd"})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "scheme") {
+		t.Errorf("expected scheme rejection, got %q", res.Text)
+	}
+}
+
+func mustHost(t *testing.T, raw string) string {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	return u.Hostname()
+}

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -15,6 +15,12 @@ import (
 // cannot widen it, because every entry in callerAllowed is checked
 // against the operator list before being kept.
 //
+// Important: when an operator-level allowlist is empty (HTTP's
+// HostAllowlist is nil/empty), that's already a deny-all signal at
+// the HTTP layer. Narrowing must preserve it — the caller cannot
+// supply allowed_hosts:["evil.com"] and bypass the operator's
+// deny-all default. intersectHosts enforces this.
+//
 // callerAllowed semantics, set at the HTTP layer:
 //   - nil          — no narrowing; pass tools through untouched.
 //   - []           — deny all; the wrapped tools have an empty
@@ -30,6 +36,19 @@ func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string) [
 	if callerAllowed == nil {
 		return in
 	}
+	// Find HTTP's operator floor — used as the floor for WebSearch too,
+	// since WebFetch (which shares HTTP) is what the model actually
+	// uses to follow up on search results. Showing the model URLs it
+	// can't fetch is wasteful AND misleading. If no HTTP tool is in
+	// the run's slice, WebSearch has no floor and can only narrow as
+	// far as the caller's list.
+	var httpFloor []string
+	for _, t := range in {
+		if h, ok := t.(*HTTP); ok {
+			httpFloor = h.HostAllowlist
+			break
+		}
+	}
 	out := make([]tools.Tool, 0, len(in))
 	for _, t := range in {
 		switch v := t.(type) {
@@ -44,7 +63,10 @@ func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string) [
 			out = append(out, &wf)
 		case *WebSearch:
 			ws := *v
-			ws.AllowedHosts = intersectHosts(v.AllowedHosts, callerAllowed)
+			// WebSearch's floor is HTTP's allowlist (see comment above).
+			// If HTTP isn't in the run, the floor is nil → empty result
+			// (model can't fetch anything anyway).
+			ws.AllowedHosts = intersectHosts(httpFloor, callerAllowed)
 			ws.FilterMode = wsFilterMode
 			if ws.FilterMode == "" {
 				ws.FilterMode = WebSearchFilterDrop
@@ -67,19 +89,26 @@ func narrowHTTP(orig *HTTP, callerAllowed []string) *HTTP {
 }
 
 // intersectHosts returns the entries from callerAllowed that are
-// permitted by the operator's static list. operator==nil (operator has
-// no static list set, e.g. test config) means the caller's list passes
-// through as-is. caller==nil means no narrowing — but NarrowHosts
-// short-circuits before calling this in that case; we never reach
-// here with caller==nil.
+// permitted by the operator's static list. caller==nil means no
+// narrowing — but NarrowHosts short-circuits before calling this in
+// that case; we never reach here with caller==nil.
 //
-// The check uses hostAllowed in BOTH directions: an operator entry of
-// "example.com" allows a caller entry of "api.example.com" (more
-// specific narrowing is fine). A caller entry of "example.org" is
-// rejected if the operator only has "example.com".
+// **Empty operator list = deny-all, not "anything goes".** The HTTP
+// tool itself treats nil/empty HostAllowlist as deny-all, so we must
+// preserve that here: a caller cannot supply `allowed_hosts: ["evil"]`
+// and have it slip through just because the operator hasn't configured
+// a static allowlist yet. Callers can only ever intersect; they can
+// never override an unset operator policy.
+//
+// For non-empty operator lists: hostAllowed checks each caller entry
+// against the operator's set with suffix-anchored match. An operator
+// entry "example.com" permits a caller entry "api.example.com" (more
+// specific narrowing). A caller entry "example.com" is REJECTED if
+// the operator only has "api.example.com" — caller cannot widen.
 func intersectHosts(operator, caller []string) []string {
 	if len(operator) == 0 {
-		return append([]string(nil), caller...)
+		// Operator's deny-all stands; caller cannot lift it.
+		return []string{}
 	}
 	out := make([]string, 0, len(caller))
 	for _, c := range caller {

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -1,0 +1,91 @@
+package builtin
+
+import (
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// NarrowHosts returns a copy of the tool slice where every HTTP,
+// WebFetch, and WebSearch instance is value-copied with its host
+// allowlist intersected against callerAllowed. Other tools pass
+// through unchanged.
+//
+// The intersection is suffix-anchored via hostAllowed (entry
+// "example.com" matches "example.com" and "api.example.com").
+// Callers can SHRINK the operator's static allowlist this way; they
+// cannot widen it, because every entry in callerAllowed is checked
+// against the operator list before being kept.
+//
+// callerAllowed semantics, set at the HTTP layer:
+//   - nil          — no narrowing; pass tools through untouched.
+//   - []           — deny all; the wrapped tools have an empty
+//     allowlist and refuse every call.
+//   - [hosts...]   — intersect with the operator's list.
+//
+// wsFilterMode applies only to WebSearch:
+//   - WebSearchFilterDrop (default when callerAllowed is non-nil)
+//     drops Brave results whose host isn't in the intersected list.
+//   - WebSearchFilterKeep returns Brave's results unchanged; the
+//     caller filters downstream.
+func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string) []tools.Tool {
+	if callerAllowed == nil {
+		return in
+	}
+	out := make([]tools.Tool, 0, len(in))
+	for _, t := range in {
+		switch v := t.(type) {
+		case *HTTP:
+			out = append(out, narrowHTTP(v, callerAllowed))
+		case *WebFetch:
+			// WebFetch wraps an HTTP backend; narrow that one instead.
+			wf := *v
+			if wf.HTTP != nil {
+				wf.HTTP = narrowHTTP(wf.HTTP, callerAllowed)
+			}
+			out = append(out, &wf)
+		case *WebSearch:
+			ws := *v
+			ws.AllowedHosts = intersectHosts(v.AllowedHosts, callerAllowed)
+			ws.FilterMode = wsFilterMode
+			if ws.FilterMode == "" {
+				ws.FilterMode = WebSearchFilterDrop
+			}
+			out = append(out, &ws)
+		default:
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// narrowHTTP value-copies an HTTP and replaces its allowlist with the
+// intersection. All other config (timeouts, byte caps, AllowPrivateIPs)
+// carries over unchanged.
+func narrowHTTP(orig *HTTP, callerAllowed []string) *HTTP {
+	narrowed := *orig
+	narrowed.HostAllowlist = intersectHosts(orig.HostAllowlist, callerAllowed)
+	return &narrowed
+}
+
+// intersectHosts returns the entries from callerAllowed that are
+// permitted by the operator's static list. operator==nil (operator has
+// no static list set, e.g. test config) means the caller's list passes
+// through as-is. caller==nil means no narrowing — but NarrowHosts
+// short-circuits before calling this in that case; we never reach
+// here with caller==nil.
+//
+// The check uses hostAllowed in BOTH directions: an operator entry of
+// "example.com" allows a caller entry of "api.example.com" (more
+// specific narrowing is fine). A caller entry of "example.org" is
+// rejected if the operator only has "example.com".
+func intersectHosts(operator, caller []string) []string {
+	if len(operator) == 0 {
+		return append([]string(nil), caller...)
+	}
+	out := make([]string, 0, len(caller))
+	for _, c := range caller {
+		if hostAllowed(c, operator) {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -1,0 +1,145 @@
+package builtin
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// nil callerAllowed → no wrapping; the same instances pass through.
+// Critical for the default code path where the request omits
+// allowed_hosts entirely.
+func TestNarrowHostsNilPassThrough(t *testing.T) {
+	original := []tools.Tool{
+		&HTTP{HostAllowlist: []string{"a.example"}},
+		&Read{Root: "/x"},
+	}
+	out := NarrowHosts(original, nil, "")
+	if len(out) != 2 {
+		t.Fatalf("len = %d, want 2", len(out))
+	}
+	// Same pointers.
+	if out[0] != original[0] || out[1] != original[1] {
+		t.Errorf("nil callerAllowed should pass tools through by reference")
+	}
+}
+
+// Intersect-only invariant: caller asks for hosts not in the operator
+// list — those entries are silently dropped from the effective list.
+// Caller can SHRINK; never widen.
+func TestNarrowHostsCannotWidenOperatorList(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"allowed.example"}}
+	caller := []string{"allowed.example", "EVIL.example"}
+
+	out := NarrowHosts([]tools.Tool{op}, caller, "")
+	wrapped, ok := out[0].(*HTTP)
+	if !ok {
+		t.Fatalf("expected *HTTP, got %T", out[0])
+	}
+	got := append([]string(nil), wrapped.HostAllowlist...)
+	sort.Strings(got)
+	want := []string{"allowed.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("intersection = %v, want %v (caller cannot widen operator list)", got, want)
+	}
+	// Operator instance must be untouched (no shared-state mutation).
+	if !reflect.DeepEqual(op.HostAllowlist, []string{"allowed.example"}) {
+		t.Errorf("wrapper mutated the operator's HTTP instance: %v", op.HostAllowlist)
+	}
+}
+
+// Narrowing flows through WebFetch's HTTP backend. WebFetch wraps an
+// HTTP; the wrapper must narrow the inner HTTP without sharing state
+// with the original.
+func TestNarrowHostsWebFetchInheritsNarrowing(t *testing.T) {
+	innerOrig := &HTTP{HostAllowlist: []string{"a.example", "b.example"}}
+	wf := &WebFetch{HTTP: innerOrig}
+	caller := []string{"a.example"}
+
+	out := NarrowHosts([]tools.Tool{wf}, caller, "")
+	wrapped, ok := out[0].(*WebFetch)
+	if !ok {
+		t.Fatalf("expected *WebFetch, got %T", out[0])
+	}
+	if wrapped == wf {
+		t.Errorf("WebFetch wrapper should be a value copy, not the same pointer")
+	}
+	if wrapped.HTTP == innerOrig {
+		t.Errorf("inner HTTP should be a value copy, not the same pointer")
+	}
+	if !reflect.DeepEqual(wrapped.HTTP.HostAllowlist, []string{"a.example"}) {
+		t.Errorf("inner allowlist = %v, want [a.example]", wrapped.HTTP.HostAllowlist)
+	}
+	// Original untouched.
+	if !reflect.DeepEqual(innerOrig.HostAllowlist, []string{"a.example", "b.example"}) {
+		t.Errorf("original HTTP mutated: %v", innerOrig.HostAllowlist)
+	}
+}
+
+// WebSearch.AllowedHosts is set to the intersection; FilterMode
+// defaults to drop when AllowedHosts is being set for the first time.
+func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
+	ws := &WebSearch{APIKey: "k"}
+	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "")
+	wrapped := out[0].(*WebSearch)
+	if wrapped == ws {
+		t.Errorf("WebSearch wrapper should be a value copy")
+	}
+	if !reflect.DeepEqual(wrapped.AllowedHosts, []string{"x.example"}) {
+		t.Errorf("AllowedHosts = %v", wrapped.AllowedHosts)
+	}
+	if wrapped.FilterMode != WebSearchFilterDrop {
+		t.Errorf("FilterMode = %q, want %q (default when narrowing)", wrapped.FilterMode, WebSearchFilterDrop)
+	}
+}
+
+func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
+	ws := &WebSearch{APIKey: "k"}
+	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, WebSearchFilterKeep)
+	wrapped := out[0].(*WebSearch)
+	if wrapped.FilterMode != WebSearchFilterKeep {
+		t.Errorf("FilterMode = %q, want %q", wrapped.FilterMode, WebSearchFilterKeep)
+	}
+}
+
+// Empty caller slice (NOT nil) means deny-all. The wrapped HTTP gets
+// an empty allowlist; the existing HTTP refusal path takes over.
+func TestNarrowHostsEmptyCallerDeniesAll(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"a.example"}}
+	out := NarrowHosts([]tools.Tool{op}, []string{}, "")
+	wrapped := out[0].(*HTTP)
+	if len(wrapped.HostAllowlist) != 0 {
+		t.Errorf("empty caller should produce empty allowlist; got %v", wrapped.HostAllowlist)
+	}
+}
+
+// Non-network tools pass through untouched even when narrowing applies.
+func TestNarrowHostsLeavesUnrelatedToolsAlone(t *testing.T) {
+	r := &Read{Root: "/x"}
+	w := &Write{Root: "/x"}
+	b := &Bash{Enabled: true, Cwd: "/x"}
+	out := NarrowHosts([]tools.Tool{r, w, b}, []string{"x.example"}, "")
+	if len(out) != 3 {
+		t.Fatalf("len = %d, want 3", len(out))
+	}
+	if out[0] != r || out[1] != w || out[2] != b {
+		t.Errorf("non-network tools must pass through by reference")
+	}
+}
+
+// Operator's static list empty + caller list set → caller list passes
+// through. Useful for test configs where no operator allowlist exists
+// but the caller still wants to constrain.
+func TestNarrowHostsOperatorEmptyCallerPassesThrough(t *testing.T) {
+	op := &HTTP{HostAllowlist: nil}
+	out := NarrowHosts([]tools.Tool{op}, []string{"x.example", "y.example"}, "")
+	wrapped := out[0].(*HTTP)
+	got := append([]string(nil), wrapped.HostAllowlist...)
+	sort.Strings(got)
+	want := []string{"x.example", "y.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("with no operator list, caller list passes through; got %v", got)
+	}
+}

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -78,17 +78,21 @@ func TestNarrowHostsWebFetchInheritsNarrowing(t *testing.T) {
 	}
 }
 
-// WebSearch.AllowedHosts is set to the intersection; FilterMode
-// defaults to drop when AllowedHosts is being set for the first time.
+// WebSearch.AllowedHosts is set to (HTTP-floor ∩ caller); FilterMode
+// defaults to drop when narrowing. The HTTP tool in the run's slice
+// supplies the operator floor — this matches the actual reachability
+// (WebFetch, which shares HTTP, is what the model uses to follow up).
 func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
+	httpTool := &HTTP{HostAllowlist: []string{"x.example", "y.example"}}
 	ws := &WebSearch{APIKey: "k"}
-	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "")
-	wrapped := out[0].(*WebSearch)
+	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, "")
+	// out[0] is the wrapped HTTP, out[1] is the wrapped WebSearch.
+	wrapped := out[1].(*WebSearch)
 	if wrapped == ws {
 		t.Errorf("WebSearch wrapper should be a value copy")
 	}
 	if !reflect.DeepEqual(wrapped.AllowedHosts, []string{"x.example"}) {
-		t.Errorf("AllowedHosts = %v", wrapped.AllowedHosts)
+		t.Errorf("AllowedHosts = %v, want [x.example] (HTTP floor ∩ caller)", wrapped.AllowedHosts)
 	}
 	if wrapped.FilterMode != WebSearchFilterDrop {
 		t.Errorf("FilterMode = %q, want %q (default when narrowing)", wrapped.FilterMode, WebSearchFilterDrop)
@@ -96,11 +100,26 @@ func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
 }
 
 func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
+	httpTool := &HTTP{HostAllowlist: []string{"x.example"}}
 	ws := &WebSearch{APIKey: "k"}
-	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, WebSearchFilterKeep)
-	wrapped := out[0].(*WebSearch)
+	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, WebSearchFilterKeep)
+	wrapped := out[1].(*WebSearch)
 	if wrapped.FilterMode != WebSearchFilterKeep {
 		t.Errorf("FilterMode = %q, want %q", wrapped.FilterMode, WebSearchFilterKeep)
+	}
+}
+
+// Security parity: a WebSearch in a run with NO HTTP tool has no floor,
+// so the per-request narrowing produces an empty result list.
+// Symmetric with HTTP's deny-all default — a caller can't widen what
+// isn't there. The model couldn't fetch anything anyway (no WebFetch),
+// so this is the right answer.
+func TestNarrowHostsWebSearchWithoutHTTPGetsEmpty(t *testing.T) {
+	ws := &WebSearch{APIKey: "k"}
+	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "")
+	wrapped := out[0].(*WebSearch)
+	if len(wrapped.AllowedHosts) != 0 {
+		t.Errorf("WebSearch with no HTTP floor must produce empty allowed list; got %v", wrapped.AllowedHosts)
 	}
 }
 
@@ -129,17 +148,20 @@ func TestNarrowHostsLeavesUnrelatedToolsAlone(t *testing.T) {
 	}
 }
 
-// Operator's static list empty + caller list set → caller list passes
-// through. Useful for test configs where no operator allowlist exists
-// but the caller still wants to constrain.
-func TestNarrowHostsOperatorEmptyCallerPassesThrough(t *testing.T) {
-	op := &HTTP{HostAllowlist: nil}
-	out := NarrowHosts([]tools.Tool{op}, []string{"x.example", "y.example"}, "")
+// Critical security invariant: an operator with no static allowlist
+// (HostAllowlist nil/empty) is in deny-all mode at the HTTP layer.
+// A caller supplying allowed_hosts MUST NOT be able to override that
+// deny-all by passing arbitrary hosts. This was a real BLOCKING bug
+// in an earlier draft — intersectHosts naively returned the caller's
+// list when operator was empty, letting a request to evil.com slip
+// through any deny-all-by-default deployment. Empirical proof:
+// reverting intersectHosts' empty-operator branch back to
+// `append([]string(nil), caller...)` makes this test fail.
+func TestNarrowHostsOperatorEmptyForcesDenyAll(t *testing.T) {
+	op := &HTTP{HostAllowlist: nil} // operator has not set an allowlist
+	out := NarrowHosts([]tools.Tool{op}, []string{"evil.example", "anywhere.example"}, "")
 	wrapped := out[0].(*HTTP)
-	got := append([]string(nil), wrapped.HostAllowlist...)
-	sort.Strings(got)
-	want := []string{"x.example", "y.example"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("with no operator list, caller list passes through; got %v", got)
+	if len(wrapped.HostAllowlist) != 0 {
+		t.Errorf("operator deny-all must override caller; got allowlist %v, want empty", wrapped.HostAllowlist)
 	}
 }

--- a/internal/tools/builtin/read.go
+++ b/internal/tools/builtin/read.go
@@ -4,10 +4,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -51,28 +48,9 @@ func (r *Read) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 		return tools.Result{Text: "Read tool is not configured with a sandbox root; refusing to read", IsError: true}, nil
 	}
 
-	// Sandbox check: resolve symlinks on BOTH root AND target before the
-	// `Rel` check, then open the resolved path. This blocks the TOCTOU
-	// where target was a symlink at check time but a different file at
-	// open time, and the case where target was a symlink to outside root.
-	root, err := filepath.EvalSymlinks(r.Root)
+	resolved, err := resolveInsideRoot(r.Root, args.Path)
 	if err != nil {
-		return tools.Result{Text: "sandbox root: " + err.Error(), IsError: true}, nil
-	}
-	abs, err := filepath.Abs(filepath.Clean(args.Path))
-	if err != nil {
-		return tools.Result{Text: "abs path: " + err.Error(), IsError: true}, nil
-	}
-	resolved, err := filepath.EvalSymlinks(abs)
-	if err != nil {
-		// Not yet existing or broken symlink — surface as a normal open error.
 		return tools.Result{Text: err.Error(), IsError: true}, nil
-	}
-	rel, err := filepath.Rel(root, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		// The HasPrefix form uses the OS-specific separator so `..\foo` on
-		// Windows is caught alongside `../foo` on POSIX.
-		return tools.Result{Text: fmt.Sprintf("path %q escapes sandbox %q", resolved, root), IsError: true}, nil
 	}
 
 	maxBytes := r.MaxBytes

--- a/internal/tools/builtin/sandbox.go
+++ b/internal/tools/builtin/sandbox.go
@@ -1,0 +1,73 @@
+package builtin
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// resolveInsideRoot resolves an absolute target path and verifies it sits
+// inside root after symlink evaluation. Returns the resolved absolute
+// path on success.
+//
+// Used by Read and Edit, where the file MUST exist (otherwise EvalSymlinks
+// fails). Write uses resolveParentInsideRoot below because the file may
+// not exist yet.
+//
+// The order matters: EvalSymlinks BOTH root and target before the Rel
+// check. This blocks the TOCTOU where target was a symlink at check time
+// but a different file at open time, and the case where target is a
+// symlink to outside root.
+func resolveInsideRoot(root, target string) (resolved string, err error) {
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("sandbox root: %w", err)
+	}
+	abs, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return "", fmt.Errorf("abs path: %w", err)
+	}
+	resolved, err = filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	if err := relInsideRoot(rootResolved, resolved); err != nil {
+		return "", err
+	}
+	return resolved, nil
+}
+
+// resolveParentInsideRoot is the variant for Write: the file may not
+// exist yet, so we resolve only the parent directory and verify IT is
+// inside root, then return parent + base(target).
+func resolveParentInsideRoot(root, target string) (joined string, err error) {
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("sandbox root: %w", err)
+	}
+	abs, err := filepath.Abs(filepath.Clean(target))
+	if err != nil {
+		return "", fmt.Errorf("abs path: %w", err)
+	}
+	parentResolved, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return "", fmt.Errorf("parent dir: %w", err)
+	}
+	if err := relInsideRoot(rootResolved, parentResolved); err != nil {
+		// Reuse the absolute path in the message so the model sees what
+		// it asked for, not the resolved-parent location.
+		return "", fmt.Errorf("path %q escapes sandbox %q", abs, rootResolved)
+	}
+	return filepath.Join(parentResolved, filepath.Base(abs)), nil
+}
+
+// relInsideRoot returns nil if resolved is inside root. The HasPrefix
+// form uses the OS-specific separator so `..\foo` on Windows is caught
+// alongside `../foo` on POSIX.
+func relInsideRoot(root, resolved string) error {
+	rel, err := filepath.Rel(root, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path %q escapes sandbox %q", resolved, root)
+	}
+	return nil
+}

--- a/internal/tools/builtin/sandbox.go
+++ b/internal/tools/builtin/sandbox.go
@@ -31,7 +31,7 @@ func resolveInsideRoot(root, target string) (resolved string, err error) {
 	if err != nil {
 		return "", err
 	}
-	if err := relInsideRoot(rootResolved, resolved); err != nil {
+	if err := relInsideRoot(rootResolved, abs, resolved); err != nil {
 		return "", err
 	}
 	return resolved, nil
@@ -53,21 +53,30 @@ func resolveParentInsideRoot(root, target string) (joined string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("parent dir: %w", err)
 	}
-	if err := relInsideRoot(rootResolved, parentResolved); err != nil {
-		// Reuse the absolute path in the message so the model sees what
-		// it asked for, not the resolved-parent location.
-		return "", fmt.Errorf("path %q escapes sandbox %q", abs, rootResolved)
+	// Pass abs as both requested AND the resolved-equivalent so the
+	// error message matches the resolveInsideRoot shape: when the user
+	// path didn't redirect via symlinks (parent itself was inside root,
+	// or wholly outside), the message stays single-path.
+	parentEquivalent := filepath.Join(parentResolved, filepath.Base(abs))
+	if err := relInsideRoot(rootResolved, abs, parentEquivalent); err != nil {
+		return "", err
 	}
-	return filepath.Join(parentResolved, filepath.Base(abs)), nil
+	return parentEquivalent, nil
 }
 
-// relInsideRoot returns nil if resolved is inside root. The HasPrefix
-// form uses the OS-specific separator so `..\foo` on Windows is caught
-// alongside `../foo` on POSIX.
-func relInsideRoot(root, resolved string) error {
+// relInsideRoot returns nil if resolved is inside root. requested is the
+// caller-supplied path (pre-symlink-resolution); resolved is what we
+// actually checked. When the two differ (a symlink redirected the
+// target), the error message includes both so the model learns its
+// input was rerouted. The HasPrefix form uses the OS-specific separator
+// so `..\foo` on Windows is caught alongside `../foo` on POSIX.
+func relInsideRoot(root, requested, resolved string) error {
 	rel, err := filepath.Rel(root, resolved)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("path %q escapes sandbox %q", resolved, root)
+		if requested == resolved {
+			return fmt.Errorf("path %q escapes sandbox %q", requested, root)
+		}
+		return fmt.Errorf("path %q (resolved to %q) escapes sandbox %q", requested, resolved, root)
 	}
 	return nil
 }

--- a/internal/tools/builtin/webfetch.go
+++ b/internal/tools/builtin/webfetch.go
@@ -1,0 +1,92 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// WebFetch fetches a URL via GET and returns the response with HTML stripped
+// to plain text. It's a deliberately thin wrapper over HTTP — the only
+// reason it's a separate tool is the model surface: most agents are taught
+// to reach for WebFetch when they want a page's text and HTTP when they
+// want the raw response. Same SSRF defences (allowlist + private-IP
+// block + redirect re-validation) flow through unchanged.
+type WebFetch struct {
+	HTTP            *HTTP
+	MaxOutputBytes  int64 // optional override; default 256 KiB
+	AllowPrivateIPs bool  // tests only
+}
+
+func (f *WebFetch) Name() string        { return "WebFetch" }
+func (f *WebFetch) Description() string { return "Fetch a URL via GET and return text-extracted body." }
+
+func (f *WebFetch) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"url": {"type": "string", "description": "Absolute URL (http or https). Host must be allowlisted."}
+		},
+		"required": ["url"]
+	}`)
+}
+
+func (f *WebFetch) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	if f.HTTP == nil {
+		return tools.Result{Text: "WebFetch is not configured (HTTP backend missing)", IsError: true}, nil
+	}
+	res, err := f.HTTP.do(ctx, "GET", args.URL, nil, "")
+	if err != nil || res.IsError {
+		return res, err
+	}
+	// res.Text starts with status + headers + blank line + body. Split on
+	// the first blank line to keep only body text for extraction.
+	body := res.Text
+	if i := strings.Index(body, "\n\n"); i >= 0 {
+		body = body[i+2:]
+	}
+	out := stripHTML(body)
+	max := f.MaxOutputBytes
+	if max == 0 {
+		max = 256 * 1024
+	}
+	if int64(len(out)) > max {
+		out = out[:max] + "\n[truncated]"
+	}
+	return tools.Result{Text: out}, nil
+}
+
+// htmlTagRe matches a single HTML tag (open, close, or self-closing).
+// Naive but sufficient for the "give me the gist of this page" use
+// case the model needs. Rendering parity with a browser is explicitly
+// not a goal.
+var htmlTagRe = regexp.MustCompile(`<[^>]*>`)
+var whitespaceRe = regexp.MustCompile(`[ \t]+`)
+var manyNewlinesRe = regexp.MustCompile(`\n{3,}`)
+var scriptStyleRe = regexp.MustCompile(`(?is)<(script|style)[^>]*>.*?</(script|style)>`)
+
+// stripHTML reduces HTML to plain text. Removes script/style blocks
+// in their entirety (their contents would be noise), then strips tags.
+// Collapses runs of whitespace and three-or-more newlines.
+func stripHTML(s string) string {
+	s = scriptStyleRe.ReplaceAllString(s, "")
+	s = htmlTagRe.ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "&nbsp;", " ")
+	s = strings.ReplaceAll(s, "&amp;", "&")
+	s = strings.ReplaceAll(s, "&lt;", "<")
+	s = strings.ReplaceAll(s, "&gt;", ">")
+	s = strings.ReplaceAll(s, "&quot;", `"`)
+	s = strings.ReplaceAll(s, "&#39;", "'")
+	s = whitespaceRe.ReplaceAllString(s, " ")
+	s = manyNewlinesRe.ReplaceAllString(s, "\n\n")
+	return strings.TrimSpace(s)
+}

--- a/internal/tools/builtin/webfetch.go
+++ b/internal/tools/builtin/webfetch.go
@@ -16,9 +16,8 @@ import (
 // want the raw response. Same SSRF defences (allowlist + private-IP
 // block + redirect re-validation) flow through unchanged.
 type WebFetch struct {
-	HTTP            *HTTP
-	MaxOutputBytes  int64 // optional override; default 256 KiB
-	AllowPrivateIPs bool  // tests only
+	HTTP           *HTTP
+	MaxOutputBytes int64 // optional override; default 256 KiB
 }
 
 func (f *WebFetch) Name() string        { return "WebFetch" }

--- a/internal/tools/builtin/webfetch_test.go
+++ b/internal/tools/builtin/webfetch_test.go
@@ -84,6 +84,31 @@ func TestWebFetchExtractsTextFromHTML(t *testing.T) {
 	}
 }
 
+// Regression: WebFetch splits HTTP's response on the FIRST "\n\n" to
+// drop the headers/body separator. A body containing its own blank
+// lines must not be over-trimmed by that split — switching to
+// LastIndex would do exactly that. Both paragraphs must survive.
+func TestWebFetchPreservesBlankLinesInBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, "para1\n\npara2")
+	}))
+	defer srv.Close()
+
+	f := &WebFetch{HTTP: &HTTP{HostAllowlist: []string{mustHost(t, srv.URL)}, AllowPrivateIPs: true}}
+	body, _ := json.Marshal(map[string]string{"url": srv.URL})
+	res, err := f.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "para1") || !strings.Contains(res.Text, "para2") {
+		t.Errorf("blank-line body over-trimmed: %q", res.Text)
+	}
+}
+
 func TestStripHTML(t *testing.T) {
 	cases := []struct {
 		name  string

--- a/internal/tools/builtin/webfetch_test.go
+++ b/internal/tools/builtin/webfetch_test.go
@@ -1,0 +1,107 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWebFetchRefusesWhenHTTPMissing(t *testing.T) {
+	f := &WebFetch{}
+	res, err := f.Execute(context.Background(), json.RawMessage(`{"url":"https://example.com/"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected error when HTTP backend missing, got %q", res.Text)
+	}
+}
+
+// SSRF defence flows through unchanged: rejection happens at the HTTP
+// layer, WebFetch just surfaces it.
+func TestWebFetchInheritsAllowlist(t *testing.T) {
+	f := &WebFetch{HTTP: &HTTP{HostAllowlist: []string{"good.example"}}}
+	res, err := f.Execute(context.Background(), json.RawMessage(`{"url":"https://attacker.example/"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "allowlist") {
+		t.Errorf("expected allowlist rejection, got %q", res.Text)
+	}
+}
+
+func TestWebFetchExtractsTextFromHTML(t *testing.T) {
+	html := `<!DOCTYPE html>
+<html>
+<head>
+<title>Test</title>
+<script>var x = 1;</script>
+<style>body { color: red; }</style>
+</head>
+<body>
+<h1>Hello   World</h1>
+<p>This is a <a href="x">link</a> in a paragraph.</p>
+<p>Another&nbsp;paragraph with &amp; entities.</p>
+</body>
+</html>`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, html)
+	}))
+	defer srv.Close()
+
+	f := &WebFetch{HTTP: &HTTP{HostAllowlist: []string{mustHost(t, srv.URL)}, AllowPrivateIPs: true}}
+	body, _ := json.Marshal(map[string]string{"url": srv.URL})
+	res, err := f.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	out := res.Text
+	if strings.Contains(out, "<h1>") || strings.Contains(out, "</p>") {
+		t.Errorf("HTML tags survived stripping: %q", out)
+	}
+	if strings.Contains(out, "var x = 1") {
+		t.Errorf("script body leaked through stripping: %q", out)
+	}
+	if strings.Contains(out, "color: red") {
+		t.Errorf("style body leaked through stripping: %q", out)
+	}
+	if !strings.Contains(out, "Hello World") {
+		t.Errorf("text content missing: %q", out)
+	}
+	if !strings.Contains(out, "& entities") {
+		t.Errorf("&amp; not decoded: %q", out)
+	}
+	if !strings.Contains(out, "Another paragraph") {
+		t.Errorf("&nbsp; not decoded to space: %q", out)
+	}
+}
+
+func TestStripHTML(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text", "hello", "hello"},
+		{"single tag", "<b>hi</b>", "hi"},
+		{"script removed entirely", "before<script>evil()</script>after", "beforeafter"},
+		{"style removed entirely", "before<style>x{}</style>after", "beforeafter"},
+		{"nested tags", "<p><b><i>x</i></b></p>", "x"},
+		{"entities", "&lt;x&gt; &amp; &quot;q&quot;", `<x> & "q"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripHTML(tc.input); got != tc.want {
+				t.Errorf("stripHTML(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -1,0 +1,157 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// WebSearch is a lightweight discovery tool: query → ranked list of
+// (title, URL, snippet). The model uses it to find pages, then follows
+// up with WebFetch for actual content. Capped at 25 results and 256
+// chars per snippet so a search call can never blow the context window.
+//
+// Backend: Brave Search API at https://api.search.brave.com/.
+// Required: BRAVE_API_KEY (free tier 2k queries/month). The plan also
+// listed a DuckDuckGo HTML scraping fallback; we deferred that to a
+// later release because HTML scraping is fragile (DDG can change markup
+// any day) and would need its own test infrastructure.
+type WebSearch struct {
+	// APIKey for Brave. Required: empty key refuses every call.
+	APIKey string
+	// Endpoint overrides Brave's URL — for tests. Default uses Brave.
+	Endpoint string
+	// MaxResultsDefault is the default for max_results when unspecified.
+	// Plan default is 5. Hard ceiling 25 regardless of caller value.
+	MaxResultsDefault int
+	// Timeout per call. Default 15s.
+	Timeout time.Duration
+	// HTTPClient overrides the default. Tests inject one to control
+	// dialing; in production the default *http.Client is used.
+	HTTPClient *http.Client
+}
+
+func (s *WebSearch) Name() string { return "WebSearch" }
+func (s *WebSearch) Description() string {
+	return "Search the web (lightweight discovery). Returns titles + URLs + short snippets."
+}
+
+func (s *WebSearch) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"query":       {"type": "string"},
+			"max_results": {"type": "integer", "minimum": 1, "maximum": 25}
+		},
+		"required": ["query"]
+	}`)
+}
+
+const (
+	maxResultsHard    = 25
+	maxSnippetChars   = 256
+	defaultEndpoint   = "https://api.search.brave.com/res/v1/web/search"
+	defaultMaxResults = 5
+)
+
+func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Query      string `json:"query"`
+		MaxResults int    `json:"max_results"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	if strings.TrimSpace(args.Query) == "" {
+		return tools.Result{Text: "query is required", IsError: true}, nil
+	}
+	if s.APIKey == "" {
+		return tools.Result{Text: "WebSearch requires BRAVE_API_KEY; refusing", IsError: true}, nil
+	}
+	max := args.MaxResults
+	if max <= 0 {
+		max = s.MaxResultsDefault
+		if max <= 0 {
+			max = defaultMaxResults
+		}
+	}
+	if max > maxResultsHard {
+		max = maxResultsHard
+	}
+
+	endpoint := s.Endpoint
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+	timeout := s.Timeout
+	if timeout == 0 {
+		timeout = 15 * time.Second
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	q := url.Values{}
+	q.Set("q", args.Query)
+	q.Set("count", fmt.Sprint(max))
+	httpReq, err := http.NewRequestWithContext(reqCtx, "GET", endpoint+"?"+q.Encode(), nil)
+	if err != nil {
+		return tools.Result{Text: "build request: " + err.Error(), IsError: true}, nil
+	}
+	httpReq.Header.Set("Accept", "application/json")
+	httpReq.Header.Set("X-Subscription-Token", s.APIKey)
+
+	client := s.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: timeout}
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return tools.Result{Text: "search request: " + err.Error(), IsError: true}, nil
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return tools.Result{Text: "read search response: " + err.Error(), IsError: true}, nil
+	}
+	if resp.StatusCode != 200 {
+		return tools.Result{Text: fmt.Sprintf("brave search returned %d: %s", resp.StatusCode, string(body)), IsError: true}, nil
+	}
+
+	var parsed struct {
+		Web struct {
+			Results []struct {
+				Title       string `json:"title"`
+				URL         string `json:"url"`
+				Description string `json:"description"`
+			} `json:"results"`
+		} `json:"web"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return tools.Result{Text: "parse brave response: " + err.Error(), IsError: true}, nil
+	}
+	if len(parsed.Web.Results) == 0 {
+		return tools.Result{Text: "no results", IsError: false}, nil
+	}
+
+	var b strings.Builder
+	for i, r := range parsed.Web.Results {
+		if i >= max {
+			break
+		}
+		title := stripHTML(r.Title) // brave returns title with <strong> highlighting
+		desc := stripHTML(r.Description)
+		if len(desc) > maxSnippetChars {
+			desc = desc[:maxSnippetChars] + "…"
+		}
+		fmt.Fprintf(&b, "[%d] %s — %s\n   %s\n", i+1, title, r.URL, desc)
+	}
+	return tools.Result{Text: strings.TrimRight(b.String(), "\n")}, nil
+}

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -36,7 +36,24 @@ type WebSearch struct {
 	// HTTPClient overrides the default. Tests inject one to control
 	// dialing; in production the default *http.Client is used.
 	HTTPClient *http.Client
+	// AllowedHosts narrows the result set to URLs whose host suffix-
+	// matches one of these entries. nil = no narrowing (return what
+	// Brave returned). The per-run wrapper in narrowing.go sets this.
+	AllowedHosts []string
+	// FilterMode selects what happens to results whose URL host isn't
+	// in AllowedHosts. WebSearchFilterDrop (default when AllowedHosts
+	// is set) omits non-matching results entirely; WebSearchFilterKeep
+	// returns everything Brave returned and lets the caller filter
+	// downstream. Ignored when AllowedHosts is nil.
+	FilterMode string
 }
+
+// FilterMode constants for WebSearch.FilterMode. The wire form
+// (carried in the HTTP request body) uses these exact strings.
+const (
+	WebSearchFilterDrop = "drop"
+	WebSearchFilterKeep = "keep"
+)
 
 func (s *WebSearch) Name() string { return "WebSearch" }
 func (s *WebSearch) Description() string {
@@ -141,9 +158,29 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		return tools.Result{Text: "no results", IsError: false}, nil
 	}
 
+	// Per-run host narrowing — applied here so the filter is the LAST
+	// thing to touch the result list, after Brave's count and the
+	// hard-25 cap. Drop mode is the default when AllowedHosts is set;
+	// keep mode is opt-in for callers that want to see everything and
+	// filter downstream.
+	results := parsed.Web.Results
+	if s.AllowedHosts != nil && s.FilterMode != WebSearchFilterKeep {
+		filtered := results[:0]
+		for _, r := range results {
+			if u, err := url.Parse(r.URL); err == nil && hostAllowed(u.Hostname(), s.AllowedHosts) {
+				filtered = append(filtered, r)
+			}
+		}
+		results = filtered
+	}
+	if len(results) == 0 {
+		return tools.Result{Text: "no results"}, nil
+	}
+
 	var b strings.Builder
-	for i, r := range parsed.Web.Results {
-		if i >= max {
+	rendered := 0
+	for _, r := range results {
+		if rendered >= max {
 			break
 		}
 		title := stripHTML(r.Title) // brave returns title with <strong> highlighting
@@ -151,7 +188,8 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		if len(desc) > maxSnippetChars {
 			desc = desc[:maxSnippetChars] + "…"
 		}
-		fmt.Fprintf(&b, "[%d] %s — %s\n   %s\n", i+1, title, r.URL, desc)
+		rendered++
+		fmt.Fprintf(&b, "[%d] %s — %s\n   %s\n", rendered, title, r.URL, desc)
 	}
 	return tools.Result{Text: strings.TrimRight(b.String(), "\n")}, nil
 }

--- a/internal/tools/builtin/websearch_test.go
+++ b/internal/tools/builtin/websearch_test.go
@@ -94,6 +94,57 @@ func TestWebSearchHardMaxResultsCeiling(t *testing.T) {
 
 // Snippet truncation at 256 chars so a long Brave description can't blow
 // the model's context window.
+// Defence in depth: even if Brave returns more results than we asked
+// for (server bug or unexpected response shape), the rendering loop
+// must still cap at max. Without this clamp a misbehaving search
+// backend could blow the model's context window.
+func TestWebSearchClampsBraveOverflow(t *testing.T) {
+	// Hand-craft a response with 30 results.
+	var sb strings.Builder
+	sb.WriteString(`{"web":{"results":[`)
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `{"title":"R%d","url":"https://r%d/","description":"d"}`, i, i)
+	}
+	sb.WriteString(`]}}`)
+	resp := sb.String()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, resp)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]any{"query": "x", "max_results": 9999})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	// The rendered output should have exactly 25 lines that start with "[" —
+	// one per result.
+	count := strings.Count(res.Text, "\n[")
+	// Number of [N] markers = newline-prefixed [ + the very first one.
+	if !strings.HasPrefix(res.Text, "[") {
+		t.Fatalf("output should start with [1] marker; got %q", res.Text[:min(len(res.Text), 80)])
+	}
+	count++
+	if count != 25 {
+		t.Errorf("rendered %d result blocks, want 25 (hard cap on Brave-side overflow)", count)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
 func TestWebSearchTruncatesLongSnippet(t *testing.T) {
 	long := strings.Repeat("x", 400)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/tools/builtin/websearch_test.go
+++ b/internal/tools/builtin/websearch_test.go
@@ -181,6 +181,111 @@ func TestWebSearchSurfacesUpstreamError(t *testing.T) {
 	}
 }
 
+// Per-run host narrowing — drop mode (default when AllowedHosts is set).
+// Brave returns three results across two hosts; AllowedHosts permits
+// only one host. The other host's result must be omitted, and indices
+// must renumber so the model sees [1] not [3].
+func TestWebSearchAllowedHostsDropMode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"web":{"results":[
+			{"title":"A","url":"https://allowed.example/a","description":"da"},
+			{"title":"B","url":"https://blocked.example/b","description":"db"},
+			{"title":"C","url":"https://api.allowed.example/c","description":"dc"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{
+		APIKey:       "k",
+		Endpoint:     srv.URL,
+		AllowedHosts: []string{"allowed.example"},
+		// FilterMode unset → defaults to drop.
+	}
+	body, _ := json.Marshal(map[string]string{"query": "x"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if strings.Contains(res.Text, "blocked.example") {
+		t.Errorf("blocked host leaked into results: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowed.example/a") || !strings.Contains(res.Text, "allowed.example/c") {
+		t.Errorf("allowed hosts missing: %q", res.Text)
+	}
+	// Renumbering: only two results survive — should be [1] and [2], not [1] and [3].
+	if !strings.HasPrefix(res.Text, "[1]") {
+		t.Errorf("first result should be [1]; got prefix %q", res.Text[:min(len(res.Text), 50)])
+	}
+	if !strings.Contains(res.Text, "[2] C") {
+		t.Errorf("second result should be [2] C; got %q", res.Text)
+	}
+	if strings.Contains(res.Text, "[3]") {
+		t.Errorf("indices should renumber; saw [3] in %q", res.Text)
+	}
+}
+
+// Per-run host narrowing — keep mode (caller filters downstream).
+// Brave's full result set comes through unchanged; the model receives
+// every URL so it can reason about them. The contract: AllowedHosts
+// is informational here, NOT enforced.
+func TestWebSearchAllowedHostsKeepMode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"web":{"results":[
+			{"title":"A","url":"https://allowed.example/a","description":"da"},
+			{"title":"B","url":"https://blocked.example/b","description":"db"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{
+		APIKey:       "k",
+		Endpoint:     srv.URL,
+		AllowedHosts: []string{"allowed.example"},
+		FilterMode:   WebSearchFilterKeep,
+	}
+	body, _ := json.Marshal(map[string]string{"query": "x"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "blocked.example") {
+		t.Errorf("keep mode should return non-matching results; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowed.example") {
+		t.Errorf("matching result missing in keep mode: %q", res.Text)
+	}
+}
+
+// Edge: AllowedHosts set, drop mode, ALL Brave results filtered out.
+// Should return "no results" (matching the empty-Brave-response shape).
+func TestWebSearchAllowedHostsDropAllFiltered(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"web":{"results":[
+			{"title":"A","url":"https://blocked.example/a","description":"d"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL, AllowedHosts: []string{"only.example"}}
+	body, _ := json.Marshal(map[string]string{"query": "x"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+	if res.Text != "no results" {
+		t.Errorf("text = %q, want 'no results'", res.Text)
+	}
+}
+
 func TestWebSearchEmptyResults(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"web":{"results":[]}}`)

--- a/internal/tools/builtin/websearch_test.go
+++ b/internal/tools/builtin/websearch_test.go
@@ -1,0 +1,151 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestWebSearchRefusesWithoutAPIKey(t *testing.T) {
+	s := &WebSearch{}
+	res, err := s.Execute(context.Background(), json.RawMessage(`{"query":"x"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "BRAVE_API_KEY") {
+		t.Errorf("expected api-key refusal, got %q", res.Text)
+	}
+}
+
+func TestWebSearchRefusesEmptyQuery(t *testing.T) {
+	s := &WebSearch{APIKey: "k"}
+	res, err := s.Execute(context.Background(), json.RawMessage(`{"query":"   "}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "query") {
+		t.Errorf("expected query-required, got %q", res.Text)
+	}
+}
+
+// Plumb a fake Brave server. Verifies: token header is sent, count
+// comes from max_results, response is rendered in the documented
+// "[N] Title — URL\n   snippet" shape.
+func TestWebSearchSuccessfulQuery(t *testing.T) {
+	var seenToken, seenQuery, seenCount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenToken = r.Header.Get("X-Subscription-Token")
+		seenQuery = r.URL.Query().Get("q")
+		seenCount = r.URL.Query().Get("count")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"web":{"results":[
+			{"title":"<strong>Foo</strong>","url":"https://foo.example/","description":"about foo"},
+			{"title":"Bar","url":"https://bar.example/","description":"about bar"}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "secret123", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]any{"query": "what is foo", "max_results": 2})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %q", res.Text)
+	}
+
+	if seenToken != "secret123" {
+		t.Errorf("token header = %q, want secret123", seenToken)
+	}
+	if seenQuery != "what is foo" {
+		t.Errorf("q = %q", seenQuery)
+	}
+	if seenCount != "2" {
+		t.Errorf("count = %q, want 2", seenCount)
+	}
+
+	want := "[1] Foo — https://foo.example/\n   about foo\n[2] Bar — https://bar.example/\n   about bar"
+	if res.Text != want {
+		t.Errorf("rendered output mismatch:\n got: %q\nwant: %q", res.Text, want)
+	}
+}
+
+// Hard ceiling: caller asks for 999 results, we cap at 25.
+func TestWebSearchHardMaxResultsCeiling(t *testing.T) {
+	var seenCount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenCount = r.URL.Query().Get("count")
+		fmt.Fprint(w, `{"web":{"results":[]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]any{"query": "x", "max_results": 999})
+	_, _ = s.Execute(context.Background(), body)
+	if seenCount != "25" {
+		t.Errorf("count = %q, want 25 (hard ceiling)", seenCount)
+	}
+}
+
+// Snippet truncation at 256 chars so a long Brave description can't blow
+// the model's context window.
+func TestWebSearchTruncatesLongSnippet(t *testing.T) {
+	long := strings.Repeat("x", 400)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"web":{"results":[{"title":"T","url":"https://t/","description":%q}]}}`, long)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]string{"query": "x"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, strings.Repeat("x", 256)+"…") {
+		t.Errorf("snippet not truncated to 256 chars + ellipsis: %q", res.Text)
+	}
+}
+
+func TestWebSearchSurfacesUpstreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		fmt.Fprint(w, `{"error":"slow down"}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]string{"query": "x"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "429") {
+		t.Errorf("expected 429 surfaced, got %q", res.Text)
+	}
+}
+
+func TestWebSearchEmptyResults(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"web":{"results":[]}}`)
+	}))
+	defer srv.Close()
+
+	s := &WebSearch{APIKey: "k", Endpoint: srv.URL}
+	body, _ := json.Marshal(map[string]string{"query": "obscure"})
+	res, err := s.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("empty results should not error; got %q", res.Text)
+	}
+	if res.Text != "no results" {
+		t.Errorf("text = %q, want 'no results'", res.Text)
+	}
+}

--- a/internal/tools/builtin/write.go
+++ b/internal/tools/builtin/write.go
@@ -1,0 +1,118 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Write creates or overwrites a UTF-8 text file inside the sandbox root.
+// Writes are atomic-ish: the content lands in a tempfile in the target's
+// directory, then a single rename into place. Partial writes are never
+// observed by readers (POSIX rename is atomic on the same filesystem).
+//
+// Sandbox semantics mirror Read: empty Root rejects every call. Path
+// resolution checks the PARENT directory (the file may not exist yet),
+// then writes the new file beside the resolved parent. A symlink at the
+// target path is silently replaced by the rename, which is fine — we
+// never follow it.
+type Write struct {
+	// Root is the sandbox root. The target's parent must resolve inside
+	// Root after symlink evaluation. Required.
+	Root string
+	// MaxBytes caps the content size. Default 1 MiB.
+	MaxBytes int64
+}
+
+func (w *Write) Name() string { return "Write" }
+func (w *Write) Description() string {
+	return "Create or overwrite a text file inside the sandbox root."
+}
+
+func (w *Write) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path":    {"type": "string", "description": "Absolute file path inside the sandbox root."},
+			"content": {"type": "string", "description": "UTF-8 text to write. Replaces any existing content."}
+		},
+		"required": ["path", "content"]
+	}`)
+}
+
+func (w *Write) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		Path    string `json:"path"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return tools.Result{Text: "invalid input: " + err.Error(), IsError: true}, nil
+	}
+	if args.Path == "" {
+		return tools.Result{Text: "path is required", IsError: true}, nil
+	}
+	if w.Root == "" {
+		return tools.Result{Text: "Write tool is not configured with a sandbox root; refusing to write", IsError: true}, nil
+	}
+
+	maxBytes := w.MaxBytes
+	if maxBytes == 0 {
+		maxBytes = 1 << 20
+	}
+	if int64(len(args.Content)) > maxBytes {
+		return tools.Result{Text: fmt.Sprintf("content exceeds %d bytes (got %d)", maxBytes, len(args.Content)), IsError: true}, nil
+	}
+
+	root, err := filepath.EvalSymlinks(w.Root)
+	if err != nil {
+		return tools.Result{Text: "sandbox root: " + err.Error(), IsError: true}, nil
+	}
+	abs, err := filepath.Abs(filepath.Clean(args.Path))
+	if err != nil {
+		return tools.Result{Text: "abs path: " + err.Error(), IsError: true}, nil
+	}
+	parent := filepath.Dir(abs)
+	resolvedParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return tools.Result{Text: "parent dir: " + err.Error(), IsError: true}, nil
+	}
+	rel, err := filepath.Rel(root, resolvedParent)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return tools.Result{Text: fmt.Sprintf("path %q escapes sandbox %q", abs, root), IsError: true}, nil
+	}
+
+	target := filepath.Join(resolvedParent, filepath.Base(abs))
+
+	// Tempfile in the same directory so the rename is intra-filesystem
+	// (cross-filesystem rename is not atomic).
+	tmp, err := os.CreateTemp(resolvedParent, ".loomcycle-write-*")
+	if err != nil {
+		return tools.Result{Text: "create tempfile: " + err.Error(), IsError: true}, nil
+	}
+	tmpName := tmp.Name()
+	// On any failure path, remove the temp file. After successful rename
+	// the temp name no longer exists, so the Remove is a no-op.
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.WriteString(args.Content); err != nil {
+		tmp.Close()
+		return tools.Result{Text: "write tempfile: " + err.Error(), IsError: true}, nil
+	}
+	if err := tmp.Close(); err != nil {
+		return tools.Result{Text: "close tempfile: " + err.Error(), IsError: true}, nil
+	}
+	// Honour ctx cancellation BEFORE the visible rename so a cancelled
+	// call leaves no trace at the target.
+	if err := ctx.Err(); err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}, nil
+	}
+	if err := os.Rename(tmpName, target); err != nil {
+		return tools.Result{Text: "rename: " + err.Error(), IsError: true}, nil
+	}
+	return tools.Result{Text: fmt.Sprintf("wrote %d bytes to %s", len(args.Content), target)}, nil
+}

--- a/internal/tools/builtin/write.go
+++ b/internal/tools/builtin/write.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -68,25 +67,11 @@ func (w *Write) Execute(ctx context.Context, input json.RawMessage) (tools.Resul
 		return tools.Result{Text: fmt.Sprintf("content exceeds %d bytes (got %d)", maxBytes, len(args.Content)), IsError: true}, nil
 	}
 
-	root, err := filepath.EvalSymlinks(w.Root)
+	target, err := resolveParentInsideRoot(w.Root, args.Path)
 	if err != nil {
-		return tools.Result{Text: "sandbox root: " + err.Error(), IsError: true}, nil
+		return tools.Result{Text: err.Error(), IsError: true}, nil
 	}
-	abs, err := filepath.Abs(filepath.Clean(args.Path))
-	if err != nil {
-		return tools.Result{Text: "abs path: " + err.Error(), IsError: true}, nil
-	}
-	parent := filepath.Dir(abs)
-	resolvedParent, err := filepath.EvalSymlinks(parent)
-	if err != nil {
-		return tools.Result{Text: "parent dir: " + err.Error(), IsError: true}, nil
-	}
-	rel, err := filepath.Rel(root, resolvedParent)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return tools.Result{Text: fmt.Sprintf("path %q escapes sandbox %q", abs, root), IsError: true}, nil
-	}
-
-	target := filepath.Join(resolvedParent, filepath.Base(abs))
+	resolvedParent := filepath.Dir(target)
 
 	// Tempfile in the same directory so the rename is intra-filesystem
 	// (cross-filesystem rename is not atomic).

--- a/internal/tools/builtin/write_test.go
+++ b/internal/tools/builtin/write_test.go
@@ -1,0 +1,159 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Mirrors TestReadRefusesEmptyRoot: no Root → no writes regardless of input.
+func TestWriteRefusesEmptyRoot(t *testing.T) {
+	w := &Write{}
+	res, err := w.Execute(context.Background(), json.RawMessage(`{"path":"/tmp/x","content":"y"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "sandbox") {
+		t.Fatalf("expected sandbox-refusal error, got Text=%q IsError=%v", res.Text, res.IsError)
+	}
+}
+
+func TestWriteAllowsInsideSandbox(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "out.txt")
+
+	w := &Write{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "content": "hello world"})
+	res, err := w.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %q", res.Text)
+	}
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("file content = %q, want %q", string(got), "hello world")
+	}
+}
+
+// Same family as TestReadRejectsParentTraversal: writing above the sandbox
+// must fail. Critically, the rejection must NOT create the target file
+// (otherwise a sandbox bypass leaves observable state).
+func TestWriteRejectsParentTraversal(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parent := filepath.Dir(root)
+	probe := filepath.Join(parent, "anywhere.txt")
+
+	w := &Write{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": probe, "content": "x"})
+	res, err := w.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("traversal must be rejected; got Text=%q", res.Text)
+	}
+	if _, err := os.Stat(probe); err == nil {
+		t.Errorf("rejected write still created file at %s", probe)
+		os.Remove(probe)
+	}
+}
+
+// Same TOCTOU shape as Read's symlink test, but in the write direction:
+// a symlink whose parent directory escapes the sandbox must be rejected.
+// We construct: root/sub → outside; writing to root/sub/x.txt should fail
+// because the resolved parent is `outside`.
+func TestWriteRejectsSymlinkedParentEscape(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	outside, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "sub")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(link, "x.txt")
+
+	w := &Write{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "content": "leaked"})
+	res, err := w.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("symlinked-parent escape must be rejected; got %q", res.Text)
+	}
+	// Confirm nothing landed outside the sandbox.
+	if _, err := os.Stat(filepath.Join(outside, "x.txt")); err == nil {
+		t.Errorf("write leaked to outside-sandbox file")
+	}
+}
+
+// Atomicity: a successful write replaces an existing file in one step.
+// We can't directly observe non-atomicity in a unit test, but we can
+// verify the existing file's prior content is fully replaced (no
+// truncated/partial content survives) — that's the promise the model
+// reads as "atomic-ish".
+func TestWriteOverwritesExistingFile(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(target, []byte("OLD CONTENT THAT IS MUCH LONGER"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	w := &Write{Root: root}
+	body, _ := json.Marshal(map[string]string{"path": target, "content": "new"})
+	res, err := w.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got %q", res.Text)
+	}
+	got, _ := os.ReadFile(target)
+	if string(got) != "new" {
+		t.Errorf("after overwrite, content = %q, want %q", string(got), "new")
+	}
+}
+
+// Bound enforcement: oversized content is refused before any write happens.
+func TestWriteRefusesOversizedContent(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(root, "big.txt")
+
+	w := &Write{Root: root, MaxBytes: 8}
+	body, _ := json.Marshal(map[string]string{"path": target, "content": "this is way more than eight bytes"})
+	res, err := w.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "exceeds") {
+		t.Errorf("expected size-bound rejection, got %q", res.Text)
+	}
+	if _, err := os.Stat(target); err == nil {
+		t.Errorf("oversized rejection still created the file")
+	}
+}


### PR DESCRIPTION
## Summary

Six new built-in tools (Write, Edit, HTTP, WebFetch, WebSearch, Bash), plus the per-agent default-deny tool policy (already implemented but newly tested at the HTTP layer + documented), plus a per-request URL allowlist that lets callers narrow HTTP/WebFetch/WebSearch reachability for a single run.

### Built-in tools

All registered alongside Read; each disabled until env-configured (model sees a clear refusal, not unknown-tool):

| Tool | Sandbox | Config |
|---|---|---|
| Write | atomic tempfile+rename inside WriteRoot, 1 MiB cap | LOOMCYCLE_WRITE_ROOT |
| Edit | shares WriteRoot; Claude-Code semantics (must-be-unique unless replace_all) | LOOMCYCLE_WRITE_ROOT |
| HTTP | hostname suffix-allowlist + IP-level filter at connect (RFC1918, loopback, link-local incl. 169.254.169.254, ULAs) + redirect re-validation; happy-eyeballs across multi-IP DNS | LOOMCYCLE_HTTP_HOST_ALLOWLIST (CSV) |
| WebFetch | thin GET wrapper over HTTP, strips HTML to text; inherits all SSRF defences | uses HTTP's allowlist |
| WebSearch | Brave Search API; hard-cap 25 results / 256-char snippets | BRAVE_API_KEY |
| Bash | NOT a true sandbox (cwd-restricted, env-scrubbed, output-bounded, time-capped); explicit opt-in + startup warning telling operators to containerise | LOOMCYCLE_BASH_ENABLED=1 + LOOMCYCLE_BASH_CWD |

### Per-agent default-deny (already implemented; newly verified)

filterTools returns nil when an agent's allowed_tools is empty — an agent gets ZERO tools at the dispatcher until allowed_tools is configured. New HTTP-layer integration tests assert this invariant; empirical proof: inverting the default to "open" makes the test fail with the exact tool name leaked. Per-agent startup warning logs which definitions are affected.

### Per-request URL allowlist

Callers can narrow HTTP/WebFetch/WebSearch reachability per-run via allowed_hosts (nil/empty/values, three-state) and web_search_filter (drop/keep). Caller can shrink, never widen — operator's static allowlist is the security floor. WebSearch result-filter is post-Brave-fetch with index renumbering. WebSearch's floor mirrors HTTP's allowlist (because WebFetch — sharing HTTP — is what the model uses to follow up on results).

### Quality gates

- Three independent code-review passes total (one on the tools batch, one on docs+tests, one on the per-request allowlist commit which caught a BLOCKING bug — caller bypass of operator deny-all when operator's list was empty)
- BLOCKING fix verified by reviewer who performed the revert themselves and confirmed both deny-all regression tests fail
- go test -race ./... clean across all packages
- gofmt, go vet clean
- Empirical proof for every load-bearing wire-up — revert one line, observe specific test fail with specific message, restore

### Commits

- 6ce4a05 feat(tools): add Write, Edit, HTTP, WebFetch, WebSearch, Bash built-ins
- e809b8d fix(tools): address feature-tools review findings
- 6d030a3 nit(tools): unify sandbox-escape error wording in sandbox.go
- dca5977 docs(tools): document default-deny per-agent policy + add HTTP-layer tests
- 35f1300 feat(tools): per-request URL allowlist for HTTP/WebFetch/WebSearch
- d0d8810 fix(tools): close BLOCKING bug in per-request host narrowing

### Test plan

- [x] go test ./... clean
- [x] go test -race ./... clean
- [x] gofmt -l . empty, go vet ./... clean
- [x] First review pass — agent (4 IMPORTANT + 4 NIT)
- [x] Fix-up commits e809b8d + 6d030a3
- [x] Second review pass — agent (clean, ship-ready)
- [x] Third review pass on per-request allowlist — agent (1 BLOCKING, 2 NIT)
- [x] Fix-up commit d0d8810
- [x] Fourth review pass — agent (clean, recommend merge)

Documentation: docs/TOOLS.md is the new canonical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)