### PR TITLE
v0.3.4: build identifier + system_prompt_file + private-host allowlist + caller-authoritative mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,30 @@ LOOMCYCLE_DATA_DIR=./data
 # Entry "example.com" matches "example.com" and "api.example.com" but
 # not "evilexample.com". Private IPs (RFC1918, loopback, link-local incl.
 # 169.254.169.254) are HARD-blocked at connect regardless of allowlist.
+# Loopback aliases on the list (localhost, 127.0.0.1, ::1, *.localhost)
+# are silently stripped at startup — use LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST
+# below to permit specific loopback hosts.
 # LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.anthropic.com,api.brave.com,linkedin.com
+
+# Private-host exception. Hosts here may resolve to private IPs at
+# dial time — used to permit agent callbacks to a localhost-bound
+# application API. Suffix-matched the same way as the main allowlist.
+# Each entry must ALSO be on LOOMCYCLE_HTTP_HOST_ALLOWLIST (or be
+# carried per-call when LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1) to be
+# reachable; this var only lifts the IP-private rejection.
+# LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST=localhost,127.0.0.1
+
+# Caller-authoritative mode for HTTP/WebFetch host allowlist.
+# When unset (default): caller's per-request allowed_hosts can ONLY
+# narrow the operator's static list. Trust model: operator owns the
+# host policy; caller fine-tunes per-call.
+# When =1: caller's allowed_hosts is the SOLE policy. Operator's
+# static list becomes a fallback for runs that don't carry their own
+# list. Trust model: caller (the application server) owns the host
+# policy; operator's list is just a default. Use when the application
+# manages a dynamic list of allowed hosts that changes faster than
+# loomcycle restarts. IP-level guard at dial still applies.
+# LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1
 
 # WebSearch tool — Brave Search API key. 2k/month free tier.
 # BRAVE_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,41 @@
-# Provider keys (only the providers you'll use need to be set)
+# loomcycle .env — copy to .env.local and fill in.
+# loomcycle.sh sources this file before starting the binary.
+
+# ─── Provider keys (only the ones you'll use need to be set) ──────────
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 OLLAMA_BASE_URL=http://localhost:11434
 
-# Sidecar listen + auth
+# ─── Sidecar listen + auth ────────────────────────────────────────────
 LOOMCYCLE_LISTEN_ADDR=127.0.0.1:8787
-LOOMCYCLE_AUTH_TOKEN=change-me
+# Bearer token /v1 routes require. Empty = dev-mode unauthenticated;
+# loomcycle prints a WARNING at startup so this is hard to forget.
+LOOMCYCLE_AUTH_TOKEN=
 
-# Storage
+# ─── Storage ──────────────────────────────────────────────────────────
 LOOMCYCLE_DATA_DIR=./data
 
-# Sandbox root for the built-in Read tool. The Read tool rejects every call
-# while this is unset (no silent open-everything default).
+# ─── Built-in tool sandboxes (each tool refuses every call until set) ─
+#
+# Read tool — agents may read files inside this directory only.
+# Symlinks resolved before the sandbox check (no symlink-escape).
 # LOOMCYCLE_READ_ROOT=/srv/loomcycle/files
+
+# Write + Edit tools — same shape as Read. Atomic tempfile + rename.
+# LOOMCYCLE_WRITE_ROOT=/srv/loomcycle/scratch
+
+# HTTP + WebFetch tools — comma-separated suffix-match host allowlist.
+# Entry "example.com" matches "example.com" and "api.example.com" but
+# not "evilexample.com". Private IPs (RFC1918, loopback, link-local incl.
+# 169.254.169.254) are HARD-blocked at connect regardless of allowlist.
+# LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.anthropic.com,api.brave.com,linkedin.com
+
+# WebSearch tool — Brave Search API key. 2k/month free tier.
+# BRAVE_API_KEY=
+
+# Bash tool — explicitly opt-in. NOT a true sandbox: cwd-restricted,
+# env-scrubbed (only PATH leaks), output-bounded (1 MiB), time-capped
+# (30s default, 5min max). Run loomcycle inside a container if you
+# expose Bash to untrusted prompts.
+# LOOMCYCLE_BASH_ENABLED=1
+# LOOMCYCLE_BASH_CWD=/srv/loomcycle/scratch

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -3,6 +3,12 @@
 // Usage:
 //
 //	loomcycle --config loomcycle.yaml
+//
+// Build identification: the buildCommit and buildTime vars are populated
+// at link time via -ldflags so a running binary can identify itself.
+// Without ldflags injection they default to "unknown" — useful signal
+// when an operator is debugging "is this the binary I just built?".
+// See loomcycle.sh for the canonical build invocation.
 package main
 
 import (
@@ -34,9 +40,33 @@ import (
 	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
 )
 
+// Build identification — overridden at link time via:
+//
+//	go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD) \
+//	                   -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" ...
+//
+// Defaults make a forgotten -ldflags invocation visible at runtime
+// rather than silently shipping an unidentifiable binary.
+var (
+	buildCommit = "unknown"
+	buildTime   = "unknown"
+)
+
 func main() {
 	cfgPath := flag.String("config", "loomcycle.yaml", "path to config YAML")
+	showVersion := flag.Bool("version", false, "print build identifier and exit")
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Printf("loomcycle commit=%s built=%s\n", buildCommit, buildTime)
+		return
+	}
+
+	// Identify ourselves first thing so an operator running a stale
+	// binary spots it immediately — before any "but my code says X"
+	// debugging spiral. Critical when development cycle is "git pull
+	// && restart" without a rebuild step in between.
+	log.Printf("loomcycle build: commit=%s time=%s", buildCommit, buildTime)
 
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -86,7 +86,16 @@ func main() {
 	// log a note for any that's still disabled — that way the model sees
 	// a clear "tool refused" error instead of a confusing "unknown tool",
 	// and operators see at startup which tools they've configured.
-	httpTool := &builtin.HTTP{HostAllowlist: cfg.Env.HTTPHostAllowlist}
+	// Strip loopback aliases (localhost, 127.0.0.1, etc.) from the
+	// operator's static allowlist. Belt-and-braces — the IP-level
+	// guard at dial time also rejects loopback, but stripping here
+	// means loopback never appears in the tool's effective list and
+	// operators don't get fooled by seeing "localhost" listed.
+	staticHosts := builtin.StripLocalhostAliases(cfg.Env.HTTPHostAllowlist)
+	httpTool := &builtin.HTTP{
+		HostAllowlist:        staticHosts,
+		PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,
+	}
 	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},
 		&builtin.Write{Root: cfg.Env.WriteRoot},
@@ -102,8 +111,14 @@ func main() {
 	if cfg.Env.WriteRoot == "" {
 		log.Printf("note: Write + Edit tools are registered but disabled — set LOOMCYCLE_WRITE_ROOT to enable")
 	}
-	if len(cfg.Env.HTTPHostAllowlist) == 0 {
-		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable")
+	if len(staticHosts) == 0 && !cfg.Env.HTTPCallerAuthoritative {
+		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable (or LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1 to delegate the allowlist to the caller)")
+	}
+	if cfg.Env.HTTPCallerAuthoritative {
+		log.Printf("note: HTTP_CALLER_AUTHORITATIVE=1 — caller's allowed_hosts is the sole policy; operator's static list is fallback only")
+	}
+	if len(cfg.Env.HTTPPrivateHostAllowlist) > 0 {
+		log.Printf("note: HTTP_PRIVATE_HOST_ALLOWLIST=%v — these hosts may resolve to private IPs (e.g. localhost callbacks)", cfg.Env.HTTPPrivateHostAllowlist)
 	}
 	if cfg.Env.BraveAPIKey == "" {
 		log.Printf("note: WebSearch tool is registered but disabled — set BRAVE_API_KEY to enable")

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -254,11 +254,17 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 
 	// Filter tools by agent allowlist + caller request.
 	allowedTools := filterTools(s.tools, agentDef.AllowedTools, req.AllowedTools)
-	// Per-run host narrowing for HTTP/WebFetch/WebSearch. nil pointer
-	// = no narrowing. Empty slice = deny-all (network tools refuse).
-	// Non-empty = intersected with the operator's static allowlist.
-	if req.AllowedHosts != nil {
-		allowedTools = builtin.NarrowHosts(allowedTools, *req.AllowedHosts, req.WebSearchFilter)
+	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
+	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
+	// doc comment. In caller-authoritative mode we ALWAYS call so the
+	// nil-fallback-to-operator path works; in default mode we only
+	// call when the caller actually supplied a list.
+	if req.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
+		var caller []string
+		if req.AllowedHosts != nil {
+			caller = *req.AllowedHosts
+		}
+		allowedTools = builtin.NarrowHosts(allowedTools, caller, req.WebSearchFilter, s.cfg.Env.HTTPCallerAuthoritative)
 	}
 	dispatcher := tools.NewDispatcher(allowedTools)
 
@@ -444,8 +450,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	allowedTools := filterTools(s.tools, agentDef.AllowedTools, body.AllowedTools)
-	if body.AllowedHosts != nil {
-		allowedTools = builtin.NarrowHosts(allowedTools, *body.AllowedHosts, body.WebSearchFilter)
+	if body.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
+		var caller []string
+		if body.AllowedHosts != nil {
+			caller = *body.AllowedHosts
+		}
+		allowedTools = builtin.NarrowHosts(allowedTools, caller, body.WebSearchFilter, s.cfg.Env.HTTPCallerAuthoritative)
 	}
 	dispatcher := tools.NewDispatcher(allowedTools)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -295,6 +295,19 @@ func getenvDefault(name, dflt string) string {
 // Errors:
 //   - both SystemPrompt and SystemPromptFile set on the same agent
 //   - SystemPromptFile points at a missing or unreadable file
+//
+// SECURITY: the YAML config is treated as fully trusted operator
+// input. SystemPromptFile values may use "../" relative paths that
+// escape configDir, and os.ReadFile follows symlinks — both are
+// intentional. This is fine when the operator owns the YAML (typical
+// deployment: a sysadmin checks the file in alongside the binary).
+//
+// If you ever load YAML from a less-trusted source — multi-tenant
+// control plane, GitOps from PR branches, shared file shares — you
+// MUST clamp paths to configDir (reject relative segments containing
+// ".." after Clean) and open with O_NOFOLLOW. The current code makes
+// neither check; an attacker who can write YAML can read any file
+// the loomcycle process can.
 func resolveSystemPromptFiles(cfg *Config, configPath string) error {
 	configDir, err := filepath.Abs(filepath.Dir(configPath))
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -38,10 +39,19 @@ type ModelRef struct {
 
 // AgentDef is one agent the API can address by name.
 type AgentDef struct {
-	Provider     string   `yaml:"provider"` // optional override of Defaults
-	Model        string   `yaml:"model"`    // alias or full model ID
-	SystemPrompt string   `yaml:"system_prompt"`
-	AllowedTools []string `yaml:"allowed_tools"`
+	Provider string `yaml:"provider"` // optional override of Defaults
+	Model    string `yaml:"model"`    // alias or full model ID
+	// SystemPrompt is the agent's system prompt as an inline YAML
+	// string. Mutually exclusive with SystemPromptFile.
+	SystemPrompt string `yaml:"system_prompt"`
+	// SystemPromptFile points at a file whose contents become
+	// SystemPrompt. Resolved relative to the YAML config file's
+	// directory (so "agents/qa.md" works regardless of cwd). Useful
+	// for prompts that don't fit inline — long .md files with
+	// frontmatter, etc. The frontmatter is loaded verbatim; if you
+	// want to strip it, use SystemPrompt + a preprocessor.
+	SystemPromptFile string   `yaml:"system_prompt_file"`
+	AllowedTools     []string `yaml:"allowed_tools"`
 }
 
 // MCPServer declares one MCP server. Transport "stdio" or "http".
@@ -107,7 +117,22 @@ type Env struct {
 	// calls. Suffix-matched: an entry "example.com" matches both
 	// "example.com" and "api.example.com". RFC1918, loopback, and
 	// link-local addresses are HARD-blocked regardless of allowlist.
+	// Loopback aliases (localhost, 127.0.0.1, ::1, *.localhost) are
+	// stripped at startup — use HTTPPrivateHostAllowlist below to
+	// permit specific loopback hosts at the IP layer.
 	HTTPHostAllowlist []string
+	// HTTPPrivateHostAllowlist names hosts whose resolved private IPs
+	// are allowed at dial time. Suffix-matched. Use to permit agent
+	// callbacks to a localhost-bound application API. Default empty
+	// (no exception). Example: "localhost,127.0.0.1".
+	HTTPPrivateHostAllowlist []string
+	// HTTPCallerAuthoritative flips the per-request allowed_hosts
+	// trust model: when true, caller's list is the sole policy
+	// (operator's HTTPHostAllowlist becomes a fallback for runs that
+	// don't carry their own list). When false (default), caller can
+	// only narrow operator's list, never widen. Operator opts in once
+	// via LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1.
+	HTTPCallerAuthoritative bool
 	// BraveAPIKey enables the WebSearch tool. Empty = WebSearch refuses
 	// every call. Lives at https://api.search.brave.com/.
 	BraveAPIKey string
@@ -147,21 +172,29 @@ func Load(path string) (*Config, error) {
 		if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)
 		}
+		// Resolve any agent's system_prompt_file → system_prompt. Done
+		// here so the rest of the runtime sees a uniform AgentDef
+		// regardless of which form the operator wrote.
+		if err := resolveSystemPromptFiles(cfg, path); err != nil {
+			return nil, err
+		}
 	}
 
 	cfg.Env = Env{
-		AnthropicAPIKey:   os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:      os.Getenv("OPENAI_API_KEY"),
-		OllamaBaseURL:     getenvDefault("OLLAMA_BASE_URL", "http://localhost:11434"),
-		ListenAddr:        getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
-		AuthToken:         os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
-		DataDir:           getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
-		ReadRoot:          os.Getenv("LOOMCYCLE_READ_ROOT"),
-		WriteRoot:         os.Getenv("LOOMCYCLE_WRITE_ROOT"),
-		HTTPHostAllowlist: splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
-		BraveAPIKey:       os.Getenv("BRAVE_API_KEY"),
-		BashEnabled:       os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
-		BashCwd:           os.Getenv("LOOMCYCLE_BASH_CWD"),
+		AnthropicAPIKey:          os.Getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:             os.Getenv("OPENAI_API_KEY"),
+		OllamaBaseURL:            getenvDefault("OLLAMA_BASE_URL", "http://localhost:11434"),
+		ListenAddr:               getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
+		AuthToken:                os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
+		DataDir:                  getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
+		ReadRoot:                 os.Getenv("LOOMCYCLE_READ_ROOT"),
+		WriteRoot:                os.Getenv("LOOMCYCLE_WRITE_ROOT"),
+		HTTPHostAllowlist:        splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
+		HTTPPrivateHostAllowlist: splitCSV(os.Getenv("LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST")),
+		HTTPCallerAuthoritative:  os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
+		BraveAPIKey:              os.Getenv("BRAVE_API_KEY"),
+		BashEnabled:              os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
+		BashCwd:                  os.Getenv("LOOMCYCLE_BASH_CWD"),
 	}
 
 	if err := validate(cfg); err != nil {
@@ -252,6 +285,42 @@ func getenvDefault(name, dflt string) string {
 		return v
 	}
 	return dflt
+}
+
+// resolveSystemPromptFiles populates each agent's SystemPrompt from
+// SystemPromptFile when set. Relative paths are resolved against the
+// YAML config file's directory so the operator's "agents/qa.md" works
+// regardless of the process's cwd.
+//
+// Errors:
+//   - both SystemPrompt and SystemPromptFile set on the same agent
+//   - SystemPromptFile points at a missing or unreadable file
+func resolveSystemPromptFiles(cfg *Config, configPath string) error {
+	configDir, err := filepath.Abs(filepath.Dir(configPath))
+	if err != nil {
+		return fmt.Errorf("config dir: %w", err)
+	}
+	for name, def := range cfg.Agents {
+		if def.SystemPromptFile == "" {
+			continue
+		}
+		if def.SystemPrompt != "" {
+			return fmt.Errorf("agent %q: system_prompt and system_prompt_file are mutually exclusive", name)
+		}
+		p := def.SystemPromptFile
+		if !filepath.IsAbs(p) {
+			p = filepath.Join(configDir, p)
+		}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("agent %q: read system_prompt_file %s: %w", name, p, err)
+		}
+		def.SystemPrompt = string(body)
+		// SystemPromptFile is preserved on the struct — no harm, and
+		// surfaces the source path for anyone debugging the config.
+		cfg.Agents[name] = def
+	}
+	return nil
 }
 
 // splitCSV trims whitespace and drops empties from a comma-separated env value.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -127,3 +127,90 @@ mcp_servers:
 		t.Fatal("expected validation error for missing url")
 	}
 }
+
+// system_prompt_file populates SystemPrompt from disk. Path resolves
+// relative to the YAML config file's directory so the operator's
+// "agents/qa.md" works regardless of cwd.
+func TestSystemPromptFileLoaded(t *testing.T) {
+	tmp := t.TempDir()
+	promptDir := filepath.Join(tmp, "prompts")
+	if err := os.MkdirAll(promptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(promptDir, "qa.md"), []byte("You are QA."), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  qa: { model: claude-sonnet-4-6, system_prompt_file: prompts/qa.md }
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["qa"].SystemPrompt; got != "You are QA." {
+		t.Errorf("SystemPrompt = %q, want %q", got, "You are QA.")
+	}
+}
+
+func TestSystemPromptFileAndInlineMutuallyExclusive(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "p.md"), []byte("body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  bad:
+    model: claude-sonnet-4-6
+    system_prompt: "inline"
+    system_prompt_file: p.md
+`), 0o600)
+	_, err := Load(yamlPath)
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("expected mutual-exclusion error, got %v", err)
+	}
+}
+
+func TestSystemPromptFileMissingErrors(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  bad: { model: claude-sonnet-4-6, system_prompt_file: nope.md }
+`), 0o600)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected error for missing prompt file")
+	}
+}
+
+// Absolute path bypasses configDir resolution. Used when the operator
+// stages prompts somewhere outside the YAML's directory.
+func TestSystemPromptFileAbsolutePath(t *testing.T) {
+	tmp := t.TempDir()
+	otherDir := t.TempDir()
+	abs := filepath.Join(otherDir, "prompt.md")
+	if err := os.WriteFile(abs, []byte("absolute body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  qa: { model: claude-sonnet-4-6, system_prompt_file: `+abs+` }
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Agents["qa"].SystemPrompt != "absolute body" {
+		t.Errorf("absolute path not resolved correctly")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,7 +34,10 @@ func TestLoadExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveAgentModel: %v", err)
 	}
-	if provider != "anthropic" || model != "claude-opus-4-7" {
+	// Example's `default` agent uses `model: smart`, which resolves
+	// via the models alias to anthropic/claude-sonnet-4-6. If you
+	// change the example's smart alias, update this assertion.
+	if provider != "anthropic" || model != "claude-sonnet-4-6" {
 		t.Errorf("resolved (%s, %s)", provider, model)
 	}
 }

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -48,6 +48,14 @@ type HTTP struct {
 	// flip this to true so they can hit httptest.NewServer (loopback).
 	// Production never sets this to true.
 	AllowPrivateIPs bool
+	// PrivateHostAllowlist is the suffix-matched list of hostnames
+	// allowed to resolve to private IPs at dial time. Default empty
+	// (no exception — every private resolution refused). Operator
+	// opts specific hosts in via LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST.
+	// Use case: agents calling back to a localhost-bound application
+	// API. Hostname is checked BEFORE DNS so dial-time still validates
+	// the resolved IP against this same list.
+	PrivateHostAllowlist []string
 }
 
 func (h *HTTP) Name() string { return "HTTP" }
@@ -207,12 +215,20 @@ func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn,
 	if err != nil {
 		return nil, err
 	}
+	// PrivateHostAllowlist: hostname-side opt-in to the private-IP
+	// block. If host is on the list, dial-layer private-IP rejection
+	// is skipped for THIS dial. Distinct from AllowPrivateIPs (which
+	// is the global tests-only flag); this one is operator-opt-in
+	// scoped to specific hostnames so e.g. localhost can be reached
+	// without disabling the SSRF block for the rest of the universe.
+	hostExempt := hostAllowed(host, h.PrivateHostAllowlist)
+
 	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
 	if err != nil {
 		return nil, err
 	}
 	candidates := ips
-	if !h.AllowPrivateIPs {
+	if !h.AllowPrivateIPs && !hostExempt {
 		candidates = candidates[:0]
 		for _, ip := range ips {
 			if !isPrivateIP(ip.IP) {
@@ -226,7 +242,7 @@ func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn,
 	d := net.Dialer{
 		Timeout: 10 * time.Second,
 		Control: func(network, address string, c syscall.RawConn) error {
-			if h.AllowPrivateIPs {
+			if h.AllowPrivateIPs || hostExempt {
 				return nil
 			}
 			ip, _, _ := net.SplitHostPort(address)

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -55,6 +55,12 @@ type HTTP struct {
 	// Use case: agents calling back to a localhost-bound application
 	// API. Hostname is checked BEFORE DNS so dial-time still validates
 	// the resolved IP against this same list.
+	//
+	// Matching is suffix-string against the URL's literal hostname,
+	// not against resolved IPs. Listing "localhost" does NOT permit
+	// a URL written as "http://127.0.0.1/" — operators wanting both
+	// must list both literally. Same applies to IPv4 vs IPv6 loopback:
+	// "127.0.0.1" doesn't cover "::1".
 	PrivateHostAllowlist []string
 }
 

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -104,6 +104,80 @@ func TestHTTPDialContextRefusesAllPrivateResolution(t *testing.T) {
 	}
 }
 
+// PrivateHostAllowlist: hosts on the list bypass the IP-private check
+// at dial time. Use case: agent calling back to localhost-bound app
+// API. Must NOT also disable the check for other hosts.
+//
+// We use httptest.NewServer (loopback) — when "localhost" is in the
+// PrivateHostAllowlist, the dial proceeds. When it's NOT, the dial
+// is blocked by the standard private-IP rejection.
+func TestHTTPPrivateHostAllowlistPermitsListedHost(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok via localhost")
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	h := &HTTP{
+		HostAllowlist:        []string{host},
+		PrivateHostAllowlist: []string{host},
+		// AllowPrivateIPs stays false — we're testing the per-host
+		// exception, not the global tests-only flag.
+	}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("listed private host should be reachable; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "ok via localhost") {
+		t.Errorf("body missing: %q", res.Text)
+	}
+}
+
+// Inverse: a host NOT in PrivateHostAllowlist resolving to private IP
+// is still refused. The exception is scoped to listed hosts only.
+func TestHTTPPrivateHostAllowlistDoesNotLeakToOtherHosts(t *testing.T) {
+	h := &HTTP{
+		HostAllowlist:        []string{"localhost", "127.0.0.1"},
+		PrivateHostAllowlist: []string{"my-app"}, // arbitrary unrelated host
+	}
+	// Dial localhost — NOT in PrivateHostAllowlist. Should be refused
+	// the same way as without the exception list.
+	_, err := h.dialContext(context.Background(), "tcp", "localhost:1")
+	if err == nil {
+		t.Fatal("expected refusal for unlisted private host")
+	}
+	if !strings.Contains(err.Error(), "no public addresses") {
+		t.Errorf("expected 'no public addresses' error, got %v", err)
+	}
+}
+
+// Suffix-match parity: PrivateHostAllowlist uses the same suffix
+// matching as HostAllowlist. Listing "myapp.local" permits
+// "api.myapp.local" too, anchored at a dot boundary.
+func TestHTTPPrivateHostAllowlistSuffixMatch(t *testing.T) {
+	cases := []struct {
+		host  string
+		list  []string
+		match bool
+	}{
+		{"myapp.local", []string{"myapp.local"}, true},
+		{"api.myapp.local", []string{"myapp.local"}, true},
+		{"evilmyapp.local", []string{"myapp.local"}, false},
+		{"myapp.local.evil", []string{"myapp.local"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := hostAllowed(tc.host, tc.list); got != tc.match {
+				t.Errorf("hostAllowed(%q, %v) = %v, want %v", tc.host, tc.list, got, tc.match)
+			}
+		})
+	}
+}
+
 func TestIsPrivateIP(t *testing.T) {
 	cases := []struct {
 		ip      string

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -137,6 +137,37 @@ func TestHTTPPrivateHostAllowlistPermitsListedHost(t *testing.T) {
 	}
 }
 
+// Asymmetric companion to TestHTTPPrivateHostAllowlistPermitsListedHost.
+// The earlier test puts the SAME entry on both HostAllowlist and
+// PrivateHostAllowlist — could pass for the wrong reason if the dial
+// path mistakenly consulted HostAllowlist. Here HostAllowlist is the
+// only thing letting the URL through layer-1; PrivateHostAllowlist
+// has a non-matching entry. The dial layer should still reject the
+// private IP because the exemption doesn't apply to this host.
+func TestHTTPPrivateHostAllowlistAsymmetricLists(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "should not be reached")
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	h := &HTTP{
+		HostAllowlist:        []string{host},                  // 127.0.0.1 — passes layer 1
+		PrivateHostAllowlist: []string{"some.unrelated.host"}, // does NOT match host
+	}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected refusal — host not in PrivateHostAllowlist; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "no public addresses") {
+		t.Errorf("expected 'no public addresses' rejection (private-IP guard fires); got %q", res.Text)
+	}
+}
+
 // Inverse: a host NOT in PrivateHostAllowlist resolving to private IP
 // is still refused. The exception is scoped to listed hosts only.
 func TestHTTPPrivateHostAllowlistDoesNotLeakToOtherHosts(t *testing.T) {

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -1,38 +1,74 @@
 package builtin
 
 import (
+	"strings"
+
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // NarrowHosts returns a copy of the tool slice where every HTTP,
 // WebFetch, and WebSearch instance is value-copied with its host
-// allowlist intersected against callerAllowed. Other tools pass
-// through unchanged.
+// allowlist resolved per callerAllowed and the policy mode. Other
+// tools pass through unchanged.
 //
-// The intersection is suffix-anchored via hostAllowed (entry
-// "example.com" matches "example.com" and "api.example.com").
-// Callers can SHRINK the operator's static allowlist this way; they
-// cannot widen it, because every entry in callerAllowed is checked
-// against the operator list before being kept.
+// Two policy modes (callerAuthoritative selects):
 //
-// Important: when an operator-level allowlist is empty (HTTP's
-// HostAllowlist is nil/empty), that's already a deny-all signal at
-// the HTTP layer. Narrowing must preserve it — the caller cannot
-// supply allowed_hosts:["evil.com"] and bypass the operator's
-// deny-all default. intersectHosts enforces this.
+// MODE INTERSECT (callerAuthoritative=false, today's default):
 //
-// callerAllowed semantics, set at the HTTP layer:
-//   - nil          — no narrowing; pass tools through untouched.
-//   - []           — deny all; the wrapped tools have an empty
-//     allowlist and refuse every call.
-//   - [hosts...]   — intersect with the operator's list.
+//	The operator's static list is the floor. Caller can SHRINK,
+//	never widen. Empty operator list = deny-all (caller cannot lift
+//	it; this was the BLOCKING fix from feature-tools review). Suffix
+//	matching means caller "api.example.com" passes operator
+//	"example.com" but caller "example.com" is rejected if operator
+//	only has "api.example.com".
+//	  - callerAllowed nil    → no narrowing; pass tools through.
+//	  - callerAllowed []     → deny-all (empty intersection).
+//	  - callerAllowed [hosts] → intersect with operator's list.
+//
+// MODE CALLER_AUTHORITATIVE (callerAuthoritative=true, opt-in via
+// LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1):
+//
+//	Trust-the-caller: caller's list replaces operator's. IP-level
+//	guard at dial time still blocks RFC1918/loopback/etc.; this
+//	flag only controls hostname policy.
+//	  - callerAllowed nil    → fall back to operator's static list (option iii)
+//	  - callerAllowed []     → fall back to operator's static list (option iii)
+//	  - callerAllowed [hosts] → use caller's list as the sole policy.
+//
+// Loopback aliases (localhost, 127.0.0.1, ::1, *.localhost, etc.)
+// are stripped from caller's list before either mode evaluates.
+// Operator's list is stripped at config-load time. The IP-level
+// connect guard is the actual security gate; the strip is
+// belt-and-braces so no operator/caller can confuse themselves into
+// thinking "localhost" is a valid allowlist entry.
 //
 // wsFilterMode applies only to WebSearch:
-//   - WebSearchFilterDrop (default when callerAllowed is non-nil)
-//     drops Brave results whose host isn't in the intersected list.
+//   - WebSearchFilterDrop (default when narrowing applies) drops
+//     Brave results whose host isn't in the effective list.
 //   - WebSearchFilterKeep returns Brave's results unchanged; the
 //     caller filters downstream.
-func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string) []tools.Tool {
+func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string, callerAuthoritative bool) []tools.Tool {
+	// Strip loopback aliases from caller's list before any mode logic.
+	// nil stays nil (the "no narrowing" signal); a list with only
+	// loopback aliases shrinks to an empty list (deny-all in INTERSECT,
+	// fall-back-to-operator in CALLER_AUTHORITATIVE).
+	if callerAllowed != nil {
+		callerAllowed = StripLocalhostAliases(callerAllowed)
+	}
+
+	if callerAuthoritative {
+		// Option (iii): nil OR empty → fall back to operator's static.
+		// Pass tools through unchanged so each tool's existing
+		// HostAllowlist (already loopback-stripped at startup) applies.
+		if len(callerAllowed) == 0 {
+			return in
+		}
+		// Caller's list is the sole authority — REPLACE every tool's
+		// HostAllowlist with it. No intersection with operator.
+		return replaceHostsInTools(in, callerAllowed, wsFilterMode)
+	}
+
+	// MODE INTERSECT: today's default.
 	if callerAllowed == nil {
 		return in
 	}
@@ -79,6 +115,41 @@ func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string) [
 	return out
 }
 
+// replaceHostsInTools is the caller-authoritative-mode helper: it
+// value-copies HTTP/WebFetch/WebSearch instances with HostAllowlist
+// directly REPLACED by hosts (no intersection). Other tools pass
+// through. hosts is assumed already loopback-stripped.
+func replaceHostsInTools(in []tools.Tool, hosts []string, wsFilterMode string) []tools.Tool {
+	out := make([]tools.Tool, 0, len(in))
+	for _, t := range in {
+		switch v := t.(type) {
+		case *HTTP:
+			h := *v
+			h.HostAllowlist = append([]string(nil), hosts...)
+			out = append(out, &h)
+		case *WebFetch:
+			wf := *v
+			if wf.HTTP != nil {
+				h := *wf.HTTP
+				h.HostAllowlist = append([]string(nil), hosts...)
+				wf.HTTP = &h
+			}
+			out = append(out, &wf)
+		case *WebSearch:
+			ws := *v
+			ws.AllowedHosts = append([]string(nil), hosts...)
+			ws.FilterMode = wsFilterMode
+			if ws.FilterMode == "" {
+				ws.FilterMode = WebSearchFilterDrop
+			}
+			out = append(out, &ws)
+		default:
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // narrowHTTP value-copies an HTTP and replaces its allowlist with the
 // intersection. All other config (timeouts, byte caps, AllowPrivateIPs)
 // carries over unchanged.
@@ -86,6 +157,40 @@ func narrowHTTP(orig *HTTP, callerAllowed []string) *HTTP {
 	narrowed := *orig
 	narrowed.HostAllowlist = intersectHosts(orig.HostAllowlist, callerAllowed)
 	return &narrowed
+}
+
+// StripLocalhostAliases drops loopback-aliasing entries from a host
+// allowlist. Belt-and-braces: the IP-level connect guard rejects
+// loopback IPs at dial time too, but stripping at allowlist-parse
+// time means operators never see "localhost" in their effective list
+// and falsely conclude it's reachable through the main allowlist.
+//
+// What's stripped (case-insensitive, trailing dot ignored):
+//   - "localhost" and any host whose final label is "localhost"
+//     (RFC 6761 reserves the entire .localhost TLD as loopback)
+//   - "127.0.0.1", "0.0.0.0" — IPv4 loopback / unspecified
+//   - "::1", "[::]", "[::1]" — IPv6 loopback / unspecified literals
+//
+// Does NOT apply to LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST — that env
+// var's whole purpose is to permit specific loopback hosts, so the
+// strip would be self-defeating.
+func StripLocalhostAliases(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]string, 0, len(in))
+	for _, h := range in {
+		n := strings.ToLower(strings.TrimSuffix(h, "."))
+		if n == "localhost" || strings.HasSuffix(n, ".localhost") {
+			continue
+		}
+		switch n {
+		case "127.0.0.1", "0.0.0.0", "::1", "[::]", "[::1]":
+			continue
+		}
+		out = append(out, h)
+	}
+	return out
 }
 
 // intersectHosts returns the entries from callerAllowed that are

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -1,6 +1,7 @@
 package builtin
 
 import (
+	"net"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -180,7 +181,15 @@ func StripLocalhostAliases(in []string) []string {
 	}
 	out := make([]string, 0, len(in))
 	for _, h := range in {
-		n := strings.ToLower(strings.TrimSuffix(h, "."))
+		// Try host:port split first so "localhost:3000" or "[::1]:443"
+		// also trip the strip. net.SplitHostPort succeeds on
+		// well-formed host:port strings; on failure we fall back to
+		// the bare-string path (allowlist entries usually omit ports).
+		hostPart := h
+		if hp, _, err := net.SplitHostPort(h); err == nil {
+			hostPart = hp
+		}
+		n := strings.ToLower(strings.TrimSuffix(hostPart, "."))
 		if n == "localhost" || strings.HasSuffix(n, ".localhost") {
 			continue
 		}

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -16,7 +16,7 @@ func TestNarrowHostsNilPassThrough(t *testing.T) {
 		&HTTP{HostAllowlist: []string{"a.example"}},
 		&Read{Root: "/x"},
 	}
-	out := NarrowHosts(original, nil, "")
+	out := NarrowHosts(original, nil, "", false)
 	if len(out) != 2 {
 		t.Fatalf("len = %d, want 2", len(out))
 	}
@@ -33,7 +33,7 @@ func TestNarrowHostsCannotWidenOperatorList(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"allowed.example"}}
 	caller := []string{"allowed.example", "EVIL.example"}
 
-	out := NarrowHosts([]tools.Tool{op}, caller, "")
+	out := NarrowHosts([]tools.Tool{op}, caller, "", false)
 	wrapped, ok := out[0].(*HTTP)
 	if !ok {
 		t.Fatalf("expected *HTTP, got %T", out[0])
@@ -58,7 +58,7 @@ func TestNarrowHostsWebFetchInheritsNarrowing(t *testing.T) {
 	wf := &WebFetch{HTTP: innerOrig}
 	caller := []string{"a.example"}
 
-	out := NarrowHosts([]tools.Tool{wf}, caller, "")
+	out := NarrowHosts([]tools.Tool{wf}, caller, "", false)
 	wrapped, ok := out[0].(*WebFetch)
 	if !ok {
 		t.Fatalf("expected *WebFetch, got %T", out[0])
@@ -85,7 +85,7 @@ func TestNarrowHostsWebFetchInheritsNarrowing(t *testing.T) {
 func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
 	httpTool := &HTTP{HostAllowlist: []string{"x.example", "y.example"}}
 	ws := &WebSearch{APIKey: "k"}
-	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, "")
+	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, "", false)
 	// out[0] is the wrapped HTTP, out[1] is the wrapped WebSearch.
 	wrapped := out[1].(*WebSearch)
 	if wrapped == ws {
@@ -102,7 +102,7 @@ func TestNarrowHostsWebSearchDropDefault(t *testing.T) {
 func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
 	httpTool := &HTTP{HostAllowlist: []string{"x.example"}}
 	ws := &WebSearch{APIKey: "k"}
-	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, WebSearchFilterKeep)
+	out := NarrowHosts([]tools.Tool{httpTool, ws}, []string{"x.example"}, WebSearchFilterKeep, false)
 	wrapped := out[1].(*WebSearch)
 	if wrapped.FilterMode != WebSearchFilterKeep {
 		t.Errorf("FilterMode = %q, want %q", wrapped.FilterMode, WebSearchFilterKeep)
@@ -116,7 +116,7 @@ func TestNarrowHostsWebSearchKeepExplicit(t *testing.T) {
 // so this is the right answer.
 func TestNarrowHostsWebSearchWithoutHTTPGetsEmpty(t *testing.T) {
 	ws := &WebSearch{APIKey: "k"}
-	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "")
+	out := NarrowHosts([]tools.Tool{ws}, []string{"x.example"}, "", false)
 	wrapped := out[0].(*WebSearch)
 	if len(wrapped.AllowedHosts) != 0 {
 		t.Errorf("WebSearch with no HTTP floor must produce empty allowed list; got %v", wrapped.AllowedHosts)
@@ -127,7 +127,7 @@ func TestNarrowHostsWebSearchWithoutHTTPGetsEmpty(t *testing.T) {
 // an empty allowlist; the existing HTTP refusal path takes over.
 func TestNarrowHostsEmptyCallerDeniesAll(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"a.example"}}
-	out := NarrowHosts([]tools.Tool{op}, []string{}, "")
+	out := NarrowHosts([]tools.Tool{op}, []string{}, "", false)
 	wrapped := out[0].(*HTTP)
 	if len(wrapped.HostAllowlist) != 0 {
 		t.Errorf("empty caller should produce empty allowlist; got %v", wrapped.HostAllowlist)
@@ -139,7 +139,7 @@ func TestNarrowHostsLeavesUnrelatedToolsAlone(t *testing.T) {
 	r := &Read{Root: "/x"}
 	w := &Write{Root: "/x"}
 	b := &Bash{Enabled: true, Cwd: "/x"}
-	out := NarrowHosts([]tools.Tool{r, w, b}, []string{"x.example"}, "")
+	out := NarrowHosts([]tools.Tool{r, w, b}, []string{"x.example"}, "", false)
 	if len(out) != 3 {
 		t.Fatalf("len = %d, want 3", len(out))
 	}
@@ -159,9 +159,135 @@ func TestNarrowHostsLeavesUnrelatedToolsAlone(t *testing.T) {
 // `append([]string(nil), caller...)` makes this test fail.
 func TestNarrowHostsOperatorEmptyForcesDenyAll(t *testing.T) {
 	op := &HTTP{HostAllowlist: nil} // operator has not set an allowlist
-	out := NarrowHosts([]tools.Tool{op}, []string{"evil.example", "anywhere.example"}, "")
+	out := NarrowHosts([]tools.Tool{op}, []string{"evil.example", "anywhere.example"}, "", false)
 	wrapped := out[0].(*HTTP)
 	if len(wrapped.HostAllowlist) != 0 {
 		t.Errorf("operator deny-all must override caller; got allowlist %v, want empty", wrapped.HostAllowlist)
+	}
+}
+
+// ─── StripLocalhostAliases ────────────────────────────────────────────
+
+func TestStripLocalhostAliases(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, nil},
+		{"empty", []string{}, []string{}},
+		{
+			"strips literal localhost",
+			[]string{"localhost", "example.com"},
+			[]string{"example.com"},
+		},
+		{
+			"strips *.localhost (RFC 6761)",
+			[]string{"api.localhost", "service.localhost", "example.com"},
+			[]string{"example.com"},
+		},
+		{
+			"case-insensitive + trailing dot",
+			[]string{"LOCALHOST", "Example.com.", "Localhost."},
+			[]string{"Example.com."},
+		},
+		{
+			"strips IPv4 + IPv6 loopback literals",
+			[]string{"127.0.0.1", "::1", "[::1]", "0.0.0.0", "[::]", "good.example"},
+			[]string{"good.example"},
+		},
+		{
+			"keeps non-loopback IP literals",
+			[]string{"8.8.8.8", "1.1.1.1"},
+			[]string{"8.8.8.8", "1.1.1.1"},
+		},
+		{
+			"preserves original casing in output",
+			[]string{"Example.COM", "ApI.example.com"},
+			[]string{"Example.COM", "ApI.example.com"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripLocalhostAliases(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("StripLocalhostAliases(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// ─── Caller-authoritative mode + iii fallback ─────────────────────────
+
+// CALLER_AUTHORITATIVE + caller has hosts → caller's list replaces
+// operator's HostAllowlist on every network tool. Operator's list is
+// NOT intersected.
+func TestNarrowHostsAuthoritativeReplacesOperator(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	caller := []string{"caller-wide.example", "another.example"}
+	out := NarrowHosts([]tools.Tool{op}, caller, "", true)
+	wrapped := out[0].(*HTTP)
+	got := append([]string(nil), wrapped.HostAllowlist...)
+	sort.Strings(got)
+	want := []string{"another.example", "caller-wide.example"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("authoritative replace = %v, want %v (operator's list ignored)", got, want)
+	}
+}
+
+// CALLER_AUTHORITATIVE + caller is nil → option (iii): fall back to
+// operator's static list. Tools pass through unchanged so each one's
+// existing HostAllowlist applies.
+func TestNarrowHostsAuthoritativeNilFallsBackToOperator(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	out := NarrowHosts([]tools.Tool{op}, nil, "", true)
+	if out[0] != op {
+		t.Errorf("nil caller in authoritative mode should pass through (operator's list applies); got wrapped instance")
+	}
+}
+
+// CALLER_AUTHORITATIVE + caller is empty → also falls back to
+// operator (the user's option (iii) explicit choice — different from
+// INTERSECT mode where empty caller means deny-all).
+func TestNarrowHostsAuthoritativeEmptyFallsBackToOperator(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	out := NarrowHosts([]tools.Tool{op}, []string{}, "", true)
+	if out[0] != op {
+		t.Errorf("empty caller in authoritative mode should pass through; got wrapped instance")
+	}
+}
+
+// Localhost-strip applies in BOTH modes. Caller passing localhost
+// aliases sees them removed before policy evaluation.
+func TestNarrowHostsStripsLocalhostFromCallerInAuthoritativeMode(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"some.example"}}
+	caller := []string{"localhost", "127.0.0.1", "real.example"}
+	out := NarrowHosts([]tools.Tool{op}, caller, "", true)
+	wrapped := out[0].(*HTTP)
+	if !reflect.DeepEqual(wrapped.HostAllowlist, []string{"real.example"}) {
+		t.Errorf("authoritative mode should strip localhost from caller; got %v", wrapped.HostAllowlist)
+	}
+}
+
+func TestNarrowHostsStripsLocalhostFromCallerInIntersectMode(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"localhost", "example.com"}} // operator should have stripped at startup, but if it didn't:
+	caller := []string{"localhost", "127.0.0.1", "example.com"}
+	out := NarrowHosts([]tools.Tool{op}, caller, "", false)
+	wrapped := out[0].(*HTTP)
+	got := append([]string(nil), wrapped.HostAllowlist...)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, []string{"example.com"}) {
+		t.Errorf("intersect mode should strip localhost from caller; got %v", got)
+	}
+}
+
+// In authoritative mode + caller-only-loopback (becomes empty after
+// strip), behaviour equals empty-caller → fall back to operator.
+func TestNarrowHostsAuthoritativeAllLoopbackBecomesFallback(t *testing.T) {
+	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	caller := []string{"localhost", "127.0.0.1"} // all stripped
+	out := NarrowHosts([]tools.Tool{op}, caller, "", true)
+	if out[0] != op {
+		t.Errorf("caller of only-loopback in authoritative mode should fall back to operator; got wrapped instance")
 	}
 }

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -206,6 +206,16 @@ func TestStripLocalhostAliases(t *testing.T) {
 			[]string{"Example.COM", "ApI.example.com"},
 			[]string{"Example.COM", "ApI.example.com"},
 		},
+		{
+			"strips loopback host:port",
+			[]string{"localhost:3000", "127.0.0.1:8080", "[::1]:443", "good.example:443"},
+			[]string{"good.example:443"},
+		},
+		{
+			"strips *.localhost:port",
+			[]string{"api.localhost:9000", "service.localhost:80"},
+			[]string{},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -221,17 +231,41 @@ func TestStripLocalhostAliases(t *testing.T) {
 
 // CALLER_AUTHORITATIVE + caller has hosts → caller's list replaces
 // operator's HostAllowlist on every network tool. Operator's list is
-// NOT intersected.
+// NOT intersected. Order assertion is exact (no sort) so a future
+// internal sort/dedupe inside replaceHostsInTools would surface as a
+// test failure — caller-supplied order is part of the contract.
 func TestNarrowHostsAuthoritativeReplacesOperator(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
 	caller := []string{"caller-wide.example", "another.example"}
 	out := NarrowHosts([]tools.Tool{op}, caller, "", true)
 	wrapped := out[0].(*HTTP)
-	got := append([]string(nil), wrapped.HostAllowlist...)
-	sort.Strings(got)
-	want := []string{"another.example", "caller-wide.example"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("authoritative replace = %v, want %v (operator's list ignored)", got, want)
+	if !reflect.DeepEqual(wrapped.HostAllowlist, caller) {
+		t.Errorf("authoritative replace = %v, want %v exactly (caller's order preserved)", wrapped.HostAllowlist, caller)
+	}
+	// Operator's instance must be untouched.
+	if !reflect.DeepEqual(op.HostAllowlist, []string{"operator-only.example"}) {
+		t.Errorf("operator instance mutated: %v", op.HostAllowlist)
+	}
+}
+
+// assertOperatorFallback checks the semantic invariant of option (iii):
+// the wrapped tool's HostAllowlist matches the operator's, AND the
+// operator's instance was NOT mutated. Catches both "tool dropped
+// the operator's list" regressions AND "tool mutated operator's
+// shared slice" regressions. Doesn't depend on the implementation
+// detail of "is the same pointer returned".
+func assertOperatorFallback(t *testing.T, out tools.Tool, op *HTTP, originalOpHosts []string) {
+	t.Helper()
+	wrapped, ok := out.(*HTTP)
+	if !ok {
+		t.Fatalf("expected *HTTP, got %T", out)
+	}
+	if !reflect.DeepEqual(wrapped.HostAllowlist, op.HostAllowlist) {
+		t.Errorf("wrapped HostAllowlist = %v, want operator's %v", wrapped.HostAllowlist, op.HostAllowlist)
+	}
+	// Operator instance must not have been mutated.
+	if !reflect.DeepEqual(op.HostAllowlist, originalOpHosts) {
+		t.Errorf("operator instance mutated: HostAllowlist now %v, was %v", op.HostAllowlist, originalOpHosts)
 	}
 }
 
@@ -240,10 +274,9 @@ func TestNarrowHostsAuthoritativeReplacesOperator(t *testing.T) {
 // existing HostAllowlist applies.
 func TestNarrowHostsAuthoritativeNilFallsBackToOperator(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	originalHosts := append([]string(nil), op.HostAllowlist...)
 	out := NarrowHosts([]tools.Tool{op}, nil, "", true)
-	if out[0] != op {
-		t.Errorf("nil caller in authoritative mode should pass through (operator's list applies); got wrapped instance")
-	}
+	assertOperatorFallback(t, out[0], op, originalHosts)
 }
 
 // CALLER_AUTHORITATIVE + caller is empty → also falls back to
@@ -251,10 +284,9 @@ func TestNarrowHostsAuthoritativeNilFallsBackToOperator(t *testing.T) {
 // INTERSECT mode where empty caller means deny-all).
 func TestNarrowHostsAuthoritativeEmptyFallsBackToOperator(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	originalHosts := append([]string(nil), op.HostAllowlist...)
 	out := NarrowHosts([]tools.Tool{op}, []string{}, "", true)
-	if out[0] != op {
-		t.Errorf("empty caller in authoritative mode should pass through; got wrapped instance")
-	}
+	assertOperatorFallback(t, out[0], op, originalHosts)
 }
 
 // Localhost-strip applies in BOTH modes. Caller passing localhost
@@ -285,9 +317,8 @@ func TestNarrowHostsStripsLocalhostFromCallerInIntersectMode(t *testing.T) {
 // strip), behaviour equals empty-caller → fall back to operator.
 func TestNarrowHostsAuthoritativeAllLoopbackBecomesFallback(t *testing.T) {
 	op := &HTTP{HostAllowlist: []string{"operator-only.example"}}
+	originalHosts := append([]string(nil), op.HostAllowlist...)
 	caller := []string{"localhost", "127.0.0.1"} // all stripped
 	out := NarrowHosts([]tools.Tool{op}, caller, "", true)
-	if out[0] != op {
-		t.Errorf("caller of only-loopback in authoritative mode should fall back to operator; got wrapped instance")
-	}
+	assertOperatorFallback(t, out[0], op, originalHosts)
 }

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -1,24 +1,147 @@
-# loomcycle.example.yaml
-# Routing, agent definitions, and MCP servers.
-# Secrets stay in .env (referenced via ${VAR} interpolation below).
+# loomcycle.example.yaml — comprehensive example with every tool exercised.
+#
+# Copy this to ~/.config/loomcycle/loomcycle.yaml (or wherever your
+# `loomcycle --config` flag points) and edit the agents to your needs.
+#
+# Two-layer policy model (see docs/TOOLS.md):
+#   1. Operator-side env: each built-in is registered but DISABLED until
+#      its env var is set. .env.example documents these.
+#   2. Per-agent allowed_tools below: anchored allowlist (default-deny).
+#      An agent with no allowed_tools sees ZERO tools at the dispatcher.
+#
+# YAML interpolation: ${VAR} is allowed but RESTRICTED — only LOOMCYCLE_*
+# names plus a small list of well-known third-party tokens (BRAVE_API_KEY,
+# GITHUB_TOKEN, SLACK_BOT_TOKEN, PG_DSN, REDIS_URL). Other ${VAR} tokens
+# are passed through verbatim. This blocks a malicious YAML in a shared-
+# config setup from exfiltrating, say, ANTHROPIC_API_KEY into an MCP
+# server URL.
 
+# ─── Default routing for agents that don't specify their own ──────────
 defaults:
   provider: anthropic
   model: claude-sonnet-4-6
 
+# ─── Model aliases ────────────────────────────────────────────────────
+# Agents reference these names via `model: <alias>`. The alias resolves
+# to (provider, real_model_id). Cleaner than repeating model strings,
+# and makes "swap haiku→sonnet for cv-adapter" a one-line YAML change.
 models:
   cheap:  { provider: anthropic, model: claude-haiku-4-5 }
-  smart:  { provider: anthropic, model: claude-opus-4-7 }
+  smart:  { provider: anthropic, model: claude-sonnet-4-6 }
+  best:   { provider: anthropic, model: claude-opus-4-7 }
   gpt:    { provider: openai,    model: gpt-4o-mini }
+  gpt-4:  { provider: openai,    model: gpt-4o }
   local:  { provider: ollama,    model: llama3.1:8b }     # tool-tuned model
 
+# ─── Agents ───────────────────────────────────────────────────────────
+# Each agent is addressed by name in POST /v1/runs's "agent" field.
+# allowed_tools is the ANCHORED allowlist — anything not on the list is
+# invisible to that agent's runs. Glob `mcp__server__*` exposes every
+# tool from one MCP server.
 agents:
+
+  # The minimum-viable agent: smart model, system prompt, no tools.
+  # Reaches no resources outside the model. Safe for prompts that only
+  # need text generation (Q&A bots, classifiers, summarisers).
   default:
     model: smart
     system_prompt: "You are a helpful assistant."
-    allowed_tools: [Read]
+    allowed_tools: []
 
+  # Filesystem-only agent: can read/write/edit files but cannot reach
+  # the network. Good for code-review or doc-editing flows where the
+  # operator has staged inputs into LOOMCYCLE_WRITE_ROOT.
+  file-editor:
+    model: smart
+    system_prompt: "You edit files in the configured sandbox. Never speculate about files you haven't read."
+    allowed_tools: [Read, Write, Edit]
+
+  # Research agent: can search the web and fetch pages. Cannot touch
+  # the filesystem. Default WebSearch filter is "drop" — the model
+  # only sees URLs it can actually fetch via WebFetch (the per-request
+  # allowed_hosts narrows further if the caller supplies it).
+  researcher:
+    model: smart
+    system_prompt: "You do focused web research. Cite every claim with a URL."
+    allowed_tools: [WebSearch, WebFetch]
+
+  # Power agent: full tool surface. Should only be used when the
+  # operator has containerised loomcycle (Bash is NOT a true sandbox).
+  # Keep `Bash` off this list unless you really need it.
+  power-user:
+    model: best
+    system_prompt: "You have broad access. Do the minimum work needed."
+    allowed_tools: [Read, Write, Edit, WebSearch, WebFetch]
+    # Add Bash only if loomcycle runs inside a container/VM:
+    # allowed_tools: [Read, Write, Edit, WebSearch, WebFetch, Bash]
+
+  # MCP-backed agent: glob exposes every tool the brave-search MCP
+  # server registers, alongside built-in WebFetch for the deep-dive.
+  # The mcp_servers.brave-search block below declares the server.
+  brave-researcher:
+    model: smart
+    allowed_tools: ["mcp__brave-search__*", WebFetch]
+    system_prompt: "Search via Brave, fetch top results, synthesise."
+
+  # Cheap classifier: haiku model, no tools, system prompt does
+  # all the heavy lifting. Good for routing/triage where you'd
+  # otherwise pay sonnet rates per call.
+  classifier:
+    model: cheap
+    system_prompt: |
+      Classify each input into exactly one of: bug, feature, question, spam.
+      Output ONLY the label, no explanation.
+    allowed_tools: []
+
+# ─── MCP servers ──────────────────────────────────────────────────────
+# Declared servers spawn at startup (stdio) or are dialed per-call
+# (http). Their tools register as `mcp__{server}__{tool}` after
+# tools/list discovery. Operator-level allowed_tools narrows what the
+# server exposes BEFORE any agent's allowed_tools is consulted.
+mcp_servers:
+
+  # ─ Stdio MCP server (subprocess) ────────────────────────────────────
+  brave-search:
+    transport: stdio
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-brave-search"]
+    env:
+      # ${BRAVE_API_KEY} expands from the parent process env (loomcycle.sh
+      # sources .env.local before exec). Falls through verbatim if the
+      # var is unset — the MCP server will then refuse to start, which
+      # surfaces as a startup log line and the server is skipped.
+      BRAVE_API_KEY: "${BRAVE_API_KEY}"
+    pool_size: 2
+    # Operator-level filter: only this subset of the server's tools is
+    # registered AT ALL. Useful when an MCP server advertises 20 tools
+    # but you only want the model to see 2.
+    allowed_tools: [brave_web_search]
+
+  # ─ HTTP MCP server (per-call dial) ──────────────────────────────────
+  # Use HTTP transport when the MCP server runs as a separate service
+  # (own process, own container, own host). loomcycle dials it per
+  # tool-call and 404s mark the server dead until next discovery.
+  # jobs-ingest:
+  #   transport: http
+  #   url: http://localhost:3000/mcp/ingest
+  #   headers:
+  #     Authorization: "Bearer ${LOOMCYCLE_AUTH_TOKEN}"
+
+# ─── Concurrency ──────────────────────────────────────────────────────
+# Caps total in-flight runs across all agents. Bursts above the cap
+# queue up to max_queue_depth for queue_timeout_ms before returning
+# HTTP 429 with code:"backpressure".
 concurrency:
-  max_concurrent_runs: 8
-  max_queue_depth: 16
-  queue_timeout_ms: 30000
+  max_concurrent_runs: 8       # ~1 GiB RSS per run on a typical Sonnet config
+  max_queue_depth: 16          # short burst absorption
+  queue_timeout_ms: 30000      # 30s — caller-side timeout should match
+
+# ─── Cache ────────────────────────────────────────────────────────────
+# Two layers: the response_kv (loomcycle's own normalised-request KV)
+# and native (provider-side cache_control on Anthropic system blocks).
+cache:
+  response_kv:
+    backend: memory            # "memory" | "redis" (redis adapter v0.4)
+    ttl: 5m
+  native:
+    enabled: true              # honour Anthropic cache_control hints

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -48,6 +48,14 @@ agents:
     system_prompt: "You are a helpful assistant."
     allowed_tools: []
 
+  # Loads the system prompt from a file relative to this YAML's
+  # directory. Mutually exclusive with system_prompt. Useful when the
+  # prompt is long enough to be uncomfortable to inline.
+  # docs-from-file:
+  #   model: smart
+  #   system_prompt_file: prompts/docs-agent.md
+  #   allowed_tools: [WebFetch]
+
   # Filesystem-only agent: can read/write/edit files but cannot reach
   # the network. Good for code-review or doc-editing flows where the
   # operator has staged inputs into LOOMCYCLE_WRITE_ROOT.

--- a/loomcycle.sh
+++ b/loomcycle.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# loomcycle.sh — rebuild + restart the loomcycle sidecar with stamped build metadata.
+#
+# Usage:
+#   ./loomcycle.sh               # rebuild + start, sourcing .env.local
+#   ./loomcycle.sh --config X    # override config path (default ~/.config/loomcycle/loomcycle.yaml)
+#   ./loomcycle.sh --no-build    # skip the rebuild (use existing bin/loomcycle)
+#   ./loomcycle.sh --version     # build then print build identifier and exit
+#
+# Why this exists: `git pull && bin/loomcycle ...` runs the OLD binary.
+# This script makes "fresh source → fresh binary" the default. Build
+# metadata (commit + UTC time) is injected via -ldflags so a running
+# loomcycle can identify itself at startup.
+
+set -euo pipefail
+
+# ─── Locate ourselves regardless of the caller's pwd ──────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ─── Defaults (override via flags or environment) ─────────────────────
+CONFIG="${LOOMCYCLE_CONFIG:-$HOME/.config/loomcycle/loomcycle.yaml}"
+ENV_FILE="${LOOMCYCLE_ENV_FILE:-.env.local}"
+BIN="bin/loomcycle"
+DO_BUILD=1
+SHOW_VERSION=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --config)     CONFIG="$2"; shift 2 ;;
+    --no-build)   DO_BUILD=0; shift ;;
+    --version)    SHOW_VERSION=1; shift ;;
+    -h|--help)    sed -n '1,12p' "$0"; exit 0 ;;
+    *)            echo "loomcycle.sh: unknown flag '$1'" >&2; exit 2 ;;
+  esac
+done
+
+# ─── 1. Rebuild with stamped commit + time ────────────────────────────
+if [[ $DO_BUILD -eq 1 ]]; then
+  COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+  # Append "-dirty" if the working tree has uncommitted changes — tells
+  # the operator the binary doesn't match a clean commit they could
+  # check out.
+  if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+    COMMIT="${COMMIT}-dirty"
+  fi
+  BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  echo "loomcycle.sh: building commit=$COMMIT time=$BUILD_TIME"
+  go build \
+    -ldflags "-X main.buildCommit=${COMMIT} -X main.buildTime=${BUILD_TIME}" \
+    -o "$BIN" \
+    ./cmd/loomcycle
+fi
+
+if [[ $SHOW_VERSION -eq 1 ]]; then
+  exec "$BIN" --version
+fi
+
+# ─── 2. Source .env.local before exec so loomcycle inherits the vars ──
+if [[ -f "$ENV_FILE" ]]; then
+  echo "loomcycle.sh: sourcing $ENV_FILE"
+  # `set -a` exports every assignment without needing each line to use
+  # `export`. `set +a` switches it back off so we don't unintentionally
+  # export later script-locals.
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+else
+  echo "loomcycle.sh: no $ENV_FILE found (ok for first run; copy from .env.example)" >&2
+fi
+
+# ─── 3. Stop any prior loomcycle instance ─────────────────────────────
+# This is the design choice you might want to tune — see
+# stop_prior_instance() below. Default behaviour: send SIGTERM to any
+# loomcycle process started from THIS bin path, wait briefly for it to
+# release the port, fall back to SIGKILL if it stuck around.
+stop_prior_instance() {
+  # Match by exact binary path so we never kill an unrelated process
+  # that happens to be on the same port. `pgrep -f` matches the full
+  # command line.
+  local target_bin
+  target_bin="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+
+  local pids
+  pids="$(pgrep -f "$target_bin" || true)"
+  if [[ -z "$pids" ]]; then
+    return 0
+  fi
+
+  echo "loomcycle.sh: stopping prior instance(s): $pids"
+  # SIGTERM first — loomcycle catches it and shuts down cleanly
+  # (releases the port, flushes the store).
+  # shellcheck disable=SC2086
+  kill -TERM $pids 2>/dev/null || true
+
+  # Wait up to 5s for graceful exit.
+  local i
+  for i in $(seq 1 10); do
+    if ! pgrep -f "$target_bin" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.5
+  done
+
+  echo "loomcycle.sh: prior instance didn't exit; sending SIGKILL" >&2
+  # shellcheck disable=SC2086
+  kill -KILL $pids 2>/dev/null || true
+  sleep 0.5
+}
+
+stop_prior_instance
+
+# ─── 4. Exec the binary so signals (Ctrl+C) reach loomcycle directly ──
+echo "loomcycle.sh: starting $BIN --config $CONFIG"
+exec "$BIN" --config "$CONFIG"

--- a/loomcycle.sh
+++ b/loomcycle.sh
@@ -71,25 +71,44 @@ else
   echo "loomcycle.sh: no $ENV_FILE found (ok for first run; copy from .env.example)" >&2
 fi
 
-# ─── 3. Stop any prior loomcycle instance ─────────────────────────────
-# This is the design choice you might want to tune — see
-# stop_prior_instance() below. Default behaviour: send SIGTERM to any
-# loomcycle process started from THIS bin path, wait briefly for it to
-# release the port, fall back to SIGKILL if it stuck around.
+# ─── 3. Stop any prior instance bound to the loomcycle port ───────────
+# Match by listen port (LOOMCYCLE_LISTEN_ADDR's :port suffix). Catches
+# any prior loomcycle regardless of which checkout / binary path it
+# was started from — useful when you have multiple working trees open
+# and the script in one of them needs to clear whatever's on the port.
+#
+# Trade-off accepted: this WILL kill an unrelated process listening on
+# the same port (e.g. `python -m http.server 8787`). LOOMCYCLE_LISTEN_ADDR
+# defaults to 127.0.0.1:8787; bind to a less-conventional port if the
+# blast radius is a concern.
+#
+# `lsof -sTCP:LISTEN` filters to listening sockets only, so a TCP
+# client connected to that port from elsewhere on the box is NOT a
+# match. That keeps innocent clients alive.
 stop_prior_instance() {
-  # Match by exact binary path so we never kill an unrelated process
-  # that happens to be on the same port. `pgrep -f` matches the full
-  # command line.
-  local target_bin
-  target_bin="$(cd "$(dirname "$BIN")" && pwd)/$(basename "$BIN")"
+  local addr="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
+  # Strip everything up to and including the last ':' to get the port.
+  # Works for "127.0.0.1:8787", "[::1]:8787", and ":8787".
+  local port="${addr##*:}"
+  if [[ -z "$port" || "$port" == "$addr" ]]; then
+    echo "loomcycle.sh: cannot extract port from LOOMCYCLE_LISTEN_ADDR='$addr'; skipping prior-instance stop" >&2
+    return 0
+  fi
+
+  # Need lsof. Skip cleanly on systems without it rather than failing
+  # the whole start (the bind itself will surface the conflict if any).
+  if ! command -v lsof >/dev/null 2>&1; then
+    echo "loomcycle.sh: lsof not found; skipping prior-instance stop" >&2
+    return 0
+  fi
 
   local pids
-  pids="$(pgrep -f "$target_bin" || true)"
+  pids="$(lsof -ti tcp:"$port" -sTCP:LISTEN 2>/dev/null || true)"
   if [[ -z "$pids" ]]; then
     return 0
   fi
 
-  echo "loomcycle.sh: stopping prior instance(s): $pids"
+  echo "loomcycle.sh: stopping process(es) listening on port $port: $pids"
   # SIGTERM first — loomcycle catches it and shuts down cleanly
   # (releases the port, flushes the store).
   # shellcheck disable=SC2086
@@ -98,15 +117,18 @@ stop_prior_instance() {
   # Wait up to 5s for graceful exit.
   local i
   for i in $(seq 1 10); do
-    if ! pgrep -f "$target_bin" >/dev/null 2>&1; then
+    if [[ -z "$(lsof -ti tcp:"$port" -sTCP:LISTEN 2>/dev/null)" ]]; then
       return 0
     fi
     sleep 0.5
   done
 
-  echo "loomcycle.sh: prior instance didn't exit; sending SIGKILL" >&2
-  # shellcheck disable=SC2086
-  kill -KILL $pids 2>/dev/null || true
+  echo "loomcycle.sh: process didn't exit on SIGTERM; sending SIGKILL" >&2
+  pids="$(lsof -ti tcp:"$port" -sTCP:LISTEN 2>/dev/null || true)"
+  if [[ -n "$pids" ]]; then
+    # shellcheck disable=SC2086
+    kill -KILL $pids 2>/dev/null || true
+  fi
   sleep 0.5
 }
 


### PR DESCRIPTION
## Summary

Operational ergonomics release surfaced during jobs-search-agent integration. Each change closes a real friction point that bit during dogfooding. All opt-in; defaults stay v0.3.3 behaviour.

### Build identifier + loomcycle.sh dev workflow

- buildCommit and buildTime injected at link time via -ldflags. Logged on the first line of startup output (and via --version flag). Solves "is the running binary current?" — operators running git pull && bin/loomcycle would otherwise silently use the OLD binary.
- loomcycle.sh: rebuild + source .env.local + stop-prior-listener + exec the binary. Stops prior instances by listen-port match (lsof -ti tcp:PORT -sTCP:LISTEN), which catches any prior loomcycle regardless of which checkout started it. SIGTERM with 5s grace, SIGKILL fallback.
- Comprehensive loomcycle.example.yaml with six agent archetypes.

### system_prompt_file on AgentDef

- New YAML field. Loads prompt from disk relative to YAML config's directory. Mutually exclusive with system_prompt.
- Frees jobs-search-agent's loomcycle config from inlining 360 lines of agent prompts; can reference .claude/agents/*.md directly.
- SECURITY block in the resolver doc documents the operator-trusts-YAML threat model + what to add (path clamp + O_NOFOLLOW) if the assumption ever stops holding.

### LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST

- Suffix-matched hostname list whose private-IP resolution is permitted at dial time.
- Distinct from AllowPrivateIPs (the global tests-only flag) — this is operator-opt-in scoped to specific hostnames.
- Use case: agents calling back to a localhost-bound application API without disabling SSRF block for the rest of the universe.
- Listed hosts must ALSO be on the main HostAllowlist to be reachable.
- Doc-comment explicitly notes the IP-literal-vs-hostname semantics: listing localhost does NOT permit URL http://127.0.0.1/ — operators wanting both must list both literally.

### LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1

Flips the per-request allowed_hosts trust model (option iii from design discussion):
- Caller has hosts: caller's list REPLACES operator's list.
- Caller is nil OR empty: fall back to operator's static list (NOT deny-all — explicit operator-trusts-caller fallback).

Use case: applications with a dynamic service registry that grows faster than loomcycle restarts. IP-level guard at dial still applies.

### StripLocalhostAliases helper

Removes localhost, *.localhost (RFC 6761), 127.0.0.1, ::1, 0.0.0.0, [::], [::1] from any host allowlist. Also handles host:port forms (localhost:3000, [::1]:443).

Belt-and-braces: the IP-level guard is the actual SSRF defense; the strip just keeps allowlists from confusing operators about reachability. Applied to operator's static list at startup AND caller's per-request list.

## Review

Two independent code-review passes:
- Pass 1: 2 IMPORTANT + 4 NIT findings. All addressed in fix-up commit e1641f6.
- Pass 2: APPROVED, ship-ready. All six items resolved correctly. Empirical claims verified by reviewer performing reverts directly. Only two optional NITs about helper API documentation.

## Test plan

- [x] go test -race ./... clean
- [x] gofmt -l . empty, go vet ./... clean
- [x] First review pass — agent (2 IMPORTANT + 4 NIT)
- [x] Fix-up commit — e1641f6
- [x] Second review pass — agent (APPROVED, recommends merge)
- [x] Empirical proof for every load-bearing wire-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)