### PR TITLE
v0.3.5: localhost-strip honours PrivateHostAllowlist exemption

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -91,7 +91,16 @@ func main() {
 	// guard at dial time also rejects loopback, but stripping here
 	// means loopback never appears in the tool's effective list and
 	// operators don't get fooled by seeing "localhost" listed.
-	staticHosts := builtin.StripLocalhostAliases(cfg.Env.HTTPHostAllowlist)
+	//
+	// PrivateHostAllowlist acts as the exemption: if the operator
+	// has explicitly opted in to a loopback host via that env var,
+	// it survives the strip on the main allowlist too. This is what
+	// lets a single "localhost" entry mean "agents may reach this
+	// loopback host AND the IP-private check is lifted for it".
+	staticHosts := builtin.StripLocalhostAliases(
+		cfg.Env.HTTPHostAllowlist,
+		cfg.Env.HTTPPrivateHostAllowlist,
+	)
 	httpTool := &builtin.HTTP{
 		HostAllowlist:        staticHosts,
 		PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -53,8 +53,15 @@ func NarrowHosts(in []tools.Tool, callerAllowed []string, wsFilterMode string, c
 	// nil stays nil (the "no narrowing" signal); a list with only
 	// loopback aliases shrinks to an empty list (deny-all in INTERSECT,
 	// fall-back-to-operator in CALLER_AUTHORITATIVE).
+	//
+	// Exception: if the operator has explicitly opted in to specific
+	// loopback hosts via HTTP.PrivateHostAllowlist, those entries are
+	// preserved through the strip. Without this, jobs-search-agent's
+	// Phase B "agents call back to localhost" pattern fails — the
+	// caller-supplied "localhost" gets stripped and the dial layer
+	// has nothing to reach. See tests for exact semantics.
 	if callerAllowed != nil {
-		callerAllowed = StripLocalhostAliases(callerAllowed)
+		callerAllowed = StripLocalhostAliases(callerAllowed, findHTTPPrivateAllowlist(in))
 	}
 
 	if callerAuthoritative {
@@ -161,24 +168,34 @@ func narrowHTTP(orig *HTTP, callerAllowed []string) *HTTP {
 }
 
 // StripLocalhostAliases drops loopback-aliasing entries from a host
-// allowlist. Belt-and-braces: the IP-level connect guard rejects
-// loopback IPs at dial time too, but stripping at allowlist-parse
-// time means operators never see "localhost" in their effective list
-// and falsely conclude it's reachable through the main allowlist.
+// allowlist UNLESS they're also on `exempt` (typically the operator's
+// LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST — "operator has explicitly
+// opted in to these private hosts"). Belt-and-braces: the IP-level
+// connect guard rejects loopback IPs at dial time too, but stripping
+// at allowlist-parse time means operators don't accidentally see
+// "localhost" in their effective list and falsely conclude it's
+// reachable through the main allowlist.
 //
-// What's stripped (case-insensitive, trailing dot ignored):
+// Exempt semantics: when `exempt` contains "localhost", a caller-
+// supplied "localhost" survives the strip; the IP-private check is
+// already lifted for that host by the same env var (PrivateHostAllowlist).
+// This is what makes localhost callbacks (jobs-search-agent's Phase B
+// pattern) work without disabling the SSRF defenses for the rest
+// of the universe.
+//
+// What's stripped when not on exempt (case-insensitive, trailing dot ignored):
 //   - "localhost" and any host whose final label is "localhost"
 //     (RFC 6761 reserves the entire .localhost TLD as loopback)
 //   - "127.0.0.1", "0.0.0.0" — IPv4 loopback / unspecified
 //   - "::1", "[::]", "[::1]" — IPv6 loopback / unspecified literals
 //
-// Does NOT apply to LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST — that env
-// var's whole purpose is to permit specific loopback hosts, so the
-// strip would be self-defeating.
-func StripLocalhostAliases(in []string) []string {
+// Pass `nil` for exempt to get the original strip-everything-loopback
+// behaviour (config-load-time strip when no PrivateHostAllowlist is set).
+func StripLocalhostAliases(in []string, exempt []string) []string {
 	if len(in) == 0 {
 		return in
 	}
+	exemptSet := normaliseExempt(exempt)
 	out := make([]string, 0, len(in))
 	for _, h := range in {
 		// Try host:port split first so "localhost:3000" or "[::1]:443"
@@ -190,6 +207,10 @@ func StripLocalhostAliases(in []string) []string {
 			hostPart = hp
 		}
 		n := strings.ToLower(strings.TrimSuffix(hostPart, "."))
+		if exemptSet[n] {
+			out = append(out, h)
+			continue
+		}
 		if n == "localhost" || strings.HasSuffix(n, ".localhost") {
 			continue
 		}
@@ -198,6 +219,37 @@ func StripLocalhostAliases(in []string) []string {
 			continue
 		}
 		out = append(out, h)
+	}
+	return out
+}
+
+// findHTTPPrivateAllowlist scans the run's tool slice for an HTTP tool
+// and returns its PrivateHostAllowlist. Used by NarrowHosts to find
+// the operator's "loopback exemption" list at per-call narrowing time.
+// Returns nil when no HTTP tool is in the run (no exemption applies).
+func findHTTPPrivateAllowlist(in []tools.Tool) []string {
+	for _, t := range in {
+		if h, ok := t.(*HTTP); ok {
+			return h.PrivateHostAllowlist
+		}
+	}
+	return nil
+}
+
+// normaliseExempt lower-cases and trims each entry of the exempt list
+// so the strip's match logic can compare against the same shape it
+// produces from the input.
+func normaliseExempt(exempt []string) map[string]bool {
+	if len(exempt) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(exempt))
+	for _, e := range exempt {
+		hostPart := e
+		if hp, _, err := net.SplitHostPort(e); err == nil {
+			hostPart = hp
+		}
+		out[strings.ToLower(strings.TrimSuffix(hostPart, "."))] = true
 	}
 	return out
 }

--- a/internal/tools/builtin/narrowing.go
+++ b/internal/tools/builtin/narrowing.go
@@ -227,10 +227,21 @@ func StripLocalhostAliases(in []string, exempt []string) []string {
 // and returns its PrivateHostAllowlist. Used by NarrowHosts to find
 // the operator's "loopback exemption" list at per-call narrowing time.
 // Returns nil when no HTTP tool is in the run (no exemption applies).
+//
+// Also unwraps *WebFetch — that tool wraps an inner *HTTP and an
+// agent allowed only WebFetch (no standalone HTTP) would otherwise
+// lose the exemption even though the same configured PrivateHostAllowlist
+// applies. Returns the first match; in the standard config there is
+// exactly one shared HTTP instance, so the order doesn't matter.
 func findHTTPPrivateAllowlist(in []tools.Tool) []string {
 	for _, t := range in {
-		if h, ok := t.(*HTTP); ok {
-			return h.PrivateHostAllowlist
+		switch v := t.(type) {
+		case *HTTP:
+			return v.PrivateHostAllowlist
+		case *WebFetch:
+			if v.HTTP != nil {
+				return v.HTTP.PrivateHostAllowlist
+			}
 		}
 	}
 	return nil

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -219,11 +219,115 @@ func TestStripLocalhostAliases(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := StripLocalhostAliases(tc.in)
+			got := StripLocalhostAliases(tc.in, nil)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("StripLocalhostAliases(%v) = %v, want %v", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// Exempt parameter: entries listed there survive the strip even if
+// they're loopback. Use case: operator opts in to localhost callbacks
+// via LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST; without this exemption,
+// caller-supplied "localhost" gets stripped and Phase B agents fail.
+func TestStripLocalhostAliasesExempt(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     []string
+		exempt []string
+		want   []string
+	}{
+		{
+			"localhost on exempt survives",
+			[]string{"localhost", "127.0.0.1", "real.example"},
+			[]string{"localhost"},
+			[]string{"localhost", "real.example"},
+		},
+		{
+			"both loopbacks on exempt survive",
+			[]string{"localhost", "127.0.0.1", "::1", "real.example"},
+			[]string{"localhost", "127.0.0.1", "::1"},
+			[]string{"localhost", "127.0.0.1", "::1", "real.example"},
+		},
+		{
+			"exempt is case-insensitive",
+			[]string{"LocalHost", "real.example"},
+			[]string{"localhost"},
+			[]string{"LocalHost", "real.example"},
+		},
+		{
+			"exempt with trailing dot still matches",
+			[]string{"localhost.", "real.example"},
+			[]string{"localhost"},
+			[]string{"localhost.", "real.example"},
+		},
+		{
+			"exempt only protects what's listed; non-exempt loopback still stripped",
+			[]string{"localhost", "127.0.0.1"},
+			[]string{"localhost"},
+			[]string{"localhost"},
+		},
+		{
+			"empty exempt is identical to nil exempt",
+			[]string{"localhost", "real.example"},
+			[]string{},
+			[]string{"real.example"},
+		},
+		{
+			"exempt that doesn't appear in input is a no-op",
+			[]string{"localhost", "real.example"},
+			[]string{"127.0.0.1"},
+			[]string{"real.example"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripLocalhostAliases(tc.in, tc.exempt)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("StripLocalhostAliases(%v, exempt=%v) = %v, want %v", tc.in, tc.exempt, got, tc.want)
+			}
+		})
+	}
+}
+
+// End-to-end Phase B semantics: caller supplies allowed_hosts:
+// ["localhost", "127.0.0.1"], operator has PrivateHostAllowlist with
+// the same entries, CALLER_AUTHORITATIVE=true. Result: the wrapped
+// HTTP tool gets HostAllowlist=["localhost","127.0.0.1"] (preserved
+// through the strip) — making jobs-search-agent's localhost callback
+// reachable.
+func TestNarrowHostsPhaseBLocalhostCallback(t *testing.T) {
+	httpTool := &HTTP{
+		HostAllowlist:        nil, // operator opts out of static list
+		PrivateHostAllowlist: []string{"localhost", "127.0.0.1"},
+	}
+	caller := []string{"localhost", "127.0.0.1"}
+	out := NarrowHosts([]tools.Tool{httpTool}, caller, "", true)
+	wrapped := out[0].(*HTTP)
+	got := append([]string(nil), wrapped.HostAllowlist...)
+	sort.Strings(got)
+	want := []string{"127.0.0.1", "localhost"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Phase B localhost callback: got HostAllowlist=%v, want %v", got, want)
+	}
+}
+
+// Inverse: same setup but operator did NOT set PrivateHostAllowlist.
+// Caller's loopback entries get stripped; in CALLER_AUTHORITATIVE mode
+// that empties the caller list which falls back to operator's static
+// (also empty) → effectively deny-all. This is the v0.3.4 default
+// behaviour we want to preserve when the operator hasn't opted in.
+func TestNarrowHostsLocalhostStrippedWhenNoPrivateAllowlist(t *testing.T) {
+	httpTool := &HTTP{
+		HostAllowlist:        nil,
+		PrivateHostAllowlist: nil, // operator did NOT opt in
+	}
+	caller := []string{"localhost", "127.0.0.1"}
+	out := NarrowHosts([]tools.Tool{httpTool}, caller, "", true)
+	wrapped := out[0].(*HTTP)
+	if len(wrapped.HostAllowlist) != 0 {
+		t.Errorf("without PrivateHostAllowlist, all loopback should strip and fall back to operator's empty list; got %v", wrapped.HostAllowlist)
 	}
 }
 

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -313,6 +313,29 @@ func TestNarrowHostsPhaseBLocalhostCallback(t *testing.T) {
 	}
 }
 
+// Reviewer-flagged edge case: agent allowed WebFetch but NOT a
+// standalone HTTP. WebFetch wraps an inner *HTTP that carries the
+// same operator-configured PrivateHostAllowlist. Without unwrapping
+// *WebFetch, findHTTPPrivateAllowlist would return nil and Phase B's
+// promise breaks for that agent shape (caller-supplied "localhost"
+// gets stripped even though the operator opted in).
+func TestNarrowHostsWebFetchOnlyHonoursPrivateAllowlist(t *testing.T) {
+	innerHTTP := &HTTP{
+		HostAllowlist:        nil,
+		PrivateHostAllowlist: []string{"localhost"},
+	}
+	wf := &WebFetch{HTTP: innerHTTP}
+	caller := []string{"localhost"}
+	out := NarrowHosts([]tools.Tool{wf}, caller, "", true)
+	wrapped := out[0].(*WebFetch)
+	if wrapped.HTTP == nil {
+		t.Fatal("wrapped WebFetch lost its HTTP backend")
+	}
+	if !reflect.DeepEqual(wrapped.HTTP.HostAllowlist, []string{"localhost"}) {
+		t.Errorf("WebFetch-only run should preserve operator-exempt localhost; got %v", wrapped.HTTP.HostAllowlist)
+	}
+}
+
 // Inverse: same setup but operator did NOT set PrivateHostAllowlist.
 // Caller's loopback entries get stripped; in CALLER_AUTHORITATIVE mode
 // that empties the caller list which falls back to operator's static


### PR DESCRIPTION
Phase B integration testing on jobs-search-agent surfaced this: localhost callbacks fail when caller-supplied allowed_hosts:[localhost,127.0.0.1] gets stripped before reaching the dial layer.

## Fix

StripLocalhostAliases gains an exempt parameter. Loopback entries also on exempt survive the strip. NarrowHosts forwards HTTP.PrivateHostAllowlist (or WebFetch's inner HTTP) as exempt via a new findHTTPPrivateAllowlist helper. cmd/loomcycle/main.go does the same for the static-list strip at config-load time.

Net effect: setting LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST=localhost now lifts BOTH the IP-private check at dial AND the hostname-strip at allowlist-parse — operators get one consistent opt-in.

## Review

One review pass (independent reviewer agent) — 1 IMPORTANT finding (WebFetch-only agents missed the exemption because findHTTPPrivateAllowlist only matched *HTTP). Addressed in 25c647b with a regression test that fails on the original implementation.

## Tests

- 7 sub-cases for the exempt parameter (case insensitivity, trailing dots, partial overlap, no-op when exempt doesn't match input)
- TestNarrowHostsPhaseBLocalhostCallback: end-to-end Phase B scenario
- TestNarrowHostsLocalhostStrippedWhenNoPrivateAllowlist: inverse — without operator opt-in, v0.3.4 deny-by-strip behaviour preserved
- TestNarrowHostsWebFetchOnlyHonoursPrivateAllowlist: WebFetch unwrap regression
- All existing tests still pass (existing call sites updated to pass nil for the new parameter)

go test -race ./... clean. gofmt + vet clean.