### PR TITLE
feat(skills): static skill bundling (Approach A) with tool-set intersection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,23 @@ LOOMCYCLE_DATA_DIR=./data
 # expose Bash to untrusted prompts.
 # LOOMCYCLE_BASH_ENABLED=1
 # LOOMCYCLE_BASH_CWD=/srv/loomcycle/scratch
+
+# ─── Skills (v0.4.0+) ────────────────────────────────────────────────
+#
+# Directory holding `<name>/SKILL.md` skill files (Approach A in
+# doc-internal/skills-design.md). Each agent's `skills:` YAML field
+# names skills under this root; loomcycle parses the SKILL.md
+# frontmatter, validates `allowed-tools` is a subset of the bundling
+# agent's `allowed_tools`, and concatenates the body onto the agent's
+# system_prompt at config-load. The bundled body lands inside the
+# cacheable system block, so subsequent runs replay at cache-read
+# rates.
+#
+# When unset, agents may NOT list skills (config-load fails with a
+# named error rather than silently dropping the skill body). When set
+# but empty/missing, config-load reports the unreadable directory.
+#
+# Skill bodies count as operator-authored content and are trusted —
+# they're loaded with the same trust as inline `system_prompt:`. Do
+# not point this at a directory writable by untrusted users.
+# LOOMCYCLE_SKILLS_ROOT=/srv/loomcycle/skills

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
 )
 
 // Config is the top-level YAML structure plus env-derived fields.
@@ -52,6 +55,18 @@ type AgentDef struct {
 	// want to strip it, use SystemPrompt + a preprocessor.
 	SystemPromptFile string   `yaml:"system_prompt_file"`
 	AllowedTools     []string `yaml:"allowed_tools"`
+	// Skills lists skill names (each = a subdirectory under
+	// LOOMCYCLE_SKILLS_ROOT containing SKILL.md) whose bodies are
+	// concatenated onto SystemPrompt at config-load. Approach A in
+	// doc-internal/skills-design.md: static bundling lets the skill
+	// body land inside the cacheable system block, paying the
+	// cache-write cost once per 5-min TTL.
+	//
+	// SECURITY: each named skill's allowed-tools frontmatter must be a
+	// SUBSET of this agent's AllowedTools. resolveSkills enforces this
+	// at config-load — a skill may only narrow, never widen, the tool
+	// set the operator granted to the agent.
+	Skills []string `yaml:"skills"`
 }
 
 // MCPServer declares one MCP server. Transport "stdio" or "http".
@@ -146,6 +161,12 @@ type Env struct {
 	// BashCwd is the working directory for spawned bash commands. Required
 	// when BashEnabled is true; if unset the tool refuses every call.
 	BashCwd string
+	// SkillsRoot points at a directory holding subdirectories of the
+	// shape `<name>/SKILL.md`. When unset, agents may not list skills
+	// (resolveSkills errors loudly to surface the misconfiguration —
+	// silently dropping skill bodies would defeat the prompts that
+	// reference them). Sourced from LOOMCYCLE_SKILLS_ROOT.
+	SkillsRoot string
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -195,6 +216,14 @@ func Load(path string) (*Config, error) {
 		BraveAPIKey:              os.Getenv("BRAVE_API_KEY"),
 		BashEnabled:              os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
 		BashCwd:                  os.Getenv("LOOMCYCLE_BASH_CWD"),
+		SkillsRoot:               os.Getenv("LOOMCYCLE_SKILLS_ROOT"),
+	}
+
+	// resolveSkills MUST come after env loading (it needs SkillsRoot)
+	// AND after resolveSystemPromptFiles (skill bodies append onto
+	// SystemPrompt — file-loaded prompts have to land first).
+	if err := resolveSkills(cfg); err != nil {
+		return nil, err
 	}
 
 	if err := validate(cfg); err != nil {
@@ -331,6 +360,84 @@ func resolveSystemPromptFiles(cfg *Config, configPath string) error {
 		def.SystemPrompt = string(body)
 		// SystemPromptFile is preserved on the struct — no harm, and
 		// surfaces the source path for anyone debugging the config.
+		cfg.Agents[name] = def
+	}
+	return nil
+}
+
+// resolveSkills bundles skill bodies into agent system prompts and
+// validates each skill's allowed-tools is a subset of the bundling
+// agent's allowed_tools. Static bundling — see Approach A in
+// doc-internal/skills-design.md.
+//
+// Errors:
+//   - SkillsRoot unset but an agent lists `skills:` (silent drop would
+//     produce agents whose prompts reference skills the runtime never
+//     loaded; loud failure forces the operator to fix the config)
+//   - skills root unreadable / not a directory
+//   - agent references an unknown skill name
+//   - skill demands a tool the agent doesn't grant (security invariant)
+//
+// SECURITY: the subset check uses internal/tools/policy.matches so
+// glob rules on either side compose correctly. Examples:
+//   - skill `[Read]`, agent `[Read, HTTP]` → OK (literal match)
+//   - skill `[mcp__brave__search]`, agent `[mcp__brave__*]` → OK
+//     (skill literal matched by agent glob, narrowing is fine)
+//   - skill `[mcp__brave__*]`, agent `[mcp__brave__search]` → ERROR
+//     (skill demands broader access than agent grants)
+//   - skill `[Edit]`, agent `[Read]` → ERROR (skill widens)
+func resolveSkills(cfg *Config) error {
+	// Fast-fail when skills root is unset but agents list skills. We
+	// could no-op silently, but that produces agents whose prompts
+	// reference skills the runtime never bundled — exactly the failure
+	// mode this whole feature was added to fix.
+	if cfg.Env.SkillsRoot == "" {
+		for name, def := range cfg.Agents {
+			if len(def.Skills) > 0 {
+				return fmt.Errorf("agent %q: lists skills %v but LOOMCYCLE_SKILLS_ROOT is not set", name, def.Skills)
+			}
+		}
+		return nil
+	}
+	set, err := skills.LoadSet(cfg.Env.SkillsRoot)
+	if err != nil {
+		return fmt.Errorf("load skills: %w", err)
+	}
+	for name, def := range cfg.Agents {
+		if len(def.Skills) == 0 {
+			continue
+		}
+		// Build agent rule set once per agent.
+		agentSet := make(map[string]bool, len(def.AllowedTools))
+		for _, t := range def.AllowedTools {
+			agentSet[t] = true
+		}
+		for _, skillName := range def.Skills {
+			sk, ok := set.Get(skillName)
+			if !ok {
+				return fmt.Errorf("agent %q: unknown skill %q (skills root: %s)", name, skillName, cfg.Env.SkillsRoot)
+			}
+			// SECURITY: enforce skill.allowed-tools ⊆ agent.allowed_tools.
+			var widening []string
+			for _, t := range sk.AllowedTools {
+				if !policy.Matches(t, agentSet) {
+					widening = append(widening, t)
+				}
+			}
+			if len(widening) > 0 {
+				return fmt.Errorf(
+					"agent %q: skill %q requires tools %v not granted by the agent's allowed_tools — skills may not widen the agent's tool set",
+					name, skillName, widening,
+				)
+			}
+			// Append. Use a separator only if there is already content
+			// in the system prompt; first skill on a prompt-less agent
+			// becomes the prompt without a leading "---".
+			if def.SystemPrompt != "" {
+				def.SystemPrompt += "\n\n---\n\n"
+			}
+			def.SystemPrompt += sk.Body
+		}
 		cfg.Agents[name] = def
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -191,6 +191,260 @@ agents:
 	}
 }
 
+// Skills support — Approach A.
+//
+// The bundling path is operator-driven: each agent's `skills:` YAML
+// field names skills under LOOMCYCLE_SKILLS_ROOT, and config-load
+// concatenates the parsed bodies onto SystemPrompt. The security
+// invariant is that skill `allowed-tools` ⊆ agent `allowed_tools` —
+// a skill may never widen the agent's tool set.
+
+// Happy path: agent lists two skills; both bodies land in the agent's
+// system prompt in declaration order, separated by "---" markers. The
+// agent's existing system_prompt comes first, skills append after.
+func TestSkillsBundledIntoSystemPrompt(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	for _, sk := range []struct{ name, body string }{
+		{"voice-applier", "VOICE BODY"},
+		{"cv-voice-applier", "CV VOICE BODY"},
+	} {
+		dir := filepath.Join(skillsRoot, sk.name)
+		os.MkdirAll(dir, 0o755)
+		os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+			"---\nname: "+sk.name+"\nallowed-tools:\n  - Read\n---\n"+sk.body,
+		), 0o600)
+	}
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  cv-adapter:
+    model: claude-sonnet-4-6
+    system_prompt: "You are CV adapter."
+    allowed_tools: [Read, HTTP]
+    skills: [voice-applier, cv-voice-applier]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	prompt := cfg.Agents["cv-adapter"].SystemPrompt
+	wantPrefix := "You are CV adapter."
+	if !strings.HasPrefix(prompt, wantPrefix) {
+		t.Errorf("prompt should start with the agent's own prompt: %q", prompt)
+	}
+	if !strings.Contains(prompt, "VOICE BODY") {
+		t.Error("voice-applier body missing")
+	}
+	if !strings.Contains(prompt, "CV VOICE BODY") {
+		t.Error("cv-voice-applier body missing")
+	}
+	// Order: voice-applier before cv-voice-applier (declaration order).
+	if strings.Index(prompt, "VOICE BODY") > strings.Index(prompt, "CV VOICE BODY") {
+		t.Error("skills should append in declaration order")
+	}
+}
+
+// SECURITY: a skill demanding a tool the agent doesn't have must fail
+// config-load. This is the core "skill cannot widen agent's tool set"
+// guarantee — silent acceptance would let an operator drop in a skill
+// that the agent's prompt now references but that the runtime can't
+// satisfy, leading to either tool-not-found errors mid-run or worse,
+// the model trying alternative paths to accomplish what the skill
+// prescribed.
+func TestSkillCannotWidenAgentTools(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	dir := filepath.Join(skillsRoot, "writer-skill")
+	os.MkdirAll(dir, 0o755)
+	// Skill demands Write; agent only grants Read.
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+		"---\nname: writer-skill\nallowed-tools:\n  - Read\n  - Write\n---\nbody",
+	), 0o600)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  reader:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    skills: [writer-skill]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected error when skill demands a tool the agent doesn't have")
+	}
+	if !strings.Contains(err.Error(), "Write") || !strings.Contains(err.Error(), "may not widen") {
+		t.Errorf("error should name the offending tool and explain the rule: %v", err)
+	}
+}
+
+// EMPIRICAL PROOF that the security check is load-bearing: rebuild the
+// same config with the agent ALSO granted Write, and the skill is
+// accepted. If this test starts passing while TestSkillCannotWidenAgentTools
+// still fails, the rule is being enforced.
+func TestSkillToolsAcceptedWhenAgentGrants(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	dir := filepath.Join(skillsRoot, "writer-skill")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+		"---\nname: writer-skill\nallowed-tools:\n  - Read\n  - Write\n---\nbody",
+	), 0o600)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  writer:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read, Write, Edit]
+    skills: [writer-skill]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	if _, err := Load(yamlPath); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+}
+
+// Glob handling: skill demands a literal MCP tool covered by the
+// agent's wildcard. policy.Matches handles the literal-vs-glob check.
+func TestSkillLiteralToolCoveredByAgentGlob(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	dir := filepath.Join(skillsRoot, "search-skill")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+		"---\nname: search-skill\nallowed-tools:\n  - mcp__brave__search\n---\nbody",
+	), 0o600)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  searcher:
+    model: claude-sonnet-4-6
+    allowed_tools: ["mcp__brave__*"]
+    skills: [search-skill]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	if _, err := Load(yamlPath); err != nil {
+		t.Errorf("agent glob should cover skill literal: %v", err)
+	}
+}
+
+// Reverse case: skill claims a wildcard the agent has not declared.
+// The agent's narrower-than-wildcard literals shouldn't match the
+// skill's broader glob. This is the "skill widens via glob" attempt.
+func TestSkillBroadGlobNotCoveredByAgentLiterals(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	dir := filepath.Join(skillsRoot, "broad-skill")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+		"---\nname: broad-skill\nallowed-tools:\n  - \"mcp__brave__*\"\n---\nbody",
+	), 0o600)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  narrow:
+    model: claude-sonnet-4-6
+    allowed_tools: [mcp__brave__search]
+    skills: [broad-skill]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	if _, err := Load(yamlPath); err == nil {
+		t.Fatal("agent literal should NOT cover skill's broader glob")
+	}
+}
+
+// Misconfiguration: agent lists skills but LOOMCYCLE_SKILLS_ROOT is
+// unset. Silent drop would produce an agent whose prompt references
+// a skill that was never loaded — exactly the failure mode this whole
+// feature exists to fix. Fail loudly.
+func TestSkillsListedWithoutRootErrors(t *testing.T) {
+	yamlPath := filepath.Join(t.TempDir(), "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  cv-adapter:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    skills: [voice-applier]
+`), 0o600)
+
+	// Explicitly clear the env (other tests may have set it).
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", "")
+	_, err := Load(yamlPath)
+	if err == nil || !strings.Contains(err.Error(), "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("expected LOOMCYCLE_SKILLS_ROOT-not-set error, got %v", err)
+	}
+}
+
+// Unknown skill name: surface the agent and the missing name so the
+// operator knows exactly what to fix.
+func TestUnknownSkillErrors(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	os.MkdirAll(skillsRoot, 0o755)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  cv-adapter:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    skills: [does-not-exist]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected unknown-skill error")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Errorf("error should name the missing skill: %v", err)
+	}
+}
+
+// Skills with empty allowed-tools (a body-only "guidance" skill that
+// makes no tool demands) attach to any agent regardless of the agent's
+// allowed_tools — there's nothing to intersect.
+func TestSkillWithNoToolsAttachesToAnyAgent(t *testing.T) {
+	root := t.TempDir()
+	skillsRoot := filepath.Join(root, "skills")
+	dir := filepath.Join(skillsRoot, "guidance")
+	os.MkdirAll(dir, 0o755)
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(
+		"---\nname: guidance\ndescription: just guidance\n---\nGUIDANCE BODY",
+	), 0o600)
+	yamlPath := filepath.Join(root, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  toolless:
+    model: claude-sonnet-4-6
+    allowed_tools: []
+    skills: [guidance]
+`), 0o600)
+
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsRoot)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !strings.Contains(cfg.Agents["toolless"].SystemPrompt, "GUIDANCE BODY") {
+		t.Error("guidance skill body should attach")
+	}
+}
+
 // Absolute path bypasses configDir resolution. Used when the operator
 // stages prompts somewhere outside the YAML's directory.
 func TestSystemPromptFileAbsolutePath(t *testing.T) {

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,0 +1,212 @@
+// Package skills loads .claude/skills/<name>/SKILL.md files into a
+// name→Skill registry that the config layer bundles into agent system
+// prompts at load time.
+//
+// Wire model (Approach A in doc-internal/skills-design.md):
+//
+//   1. Operator points LOOMCYCLE_SKILLS_ROOT at a directory containing
+//      one subdirectory per skill, each with a SKILL.md file.
+//   2. Each agent's YAML lists `skills: [name1, name2]`. At config-load,
+//      the named skill bodies are concatenated onto the agent's
+//      system_prompt.
+//   3. The bundled body lands inside the cacheable system block at the
+//      provider layer, so subsequent runs replay the skill at
+//      cache-read rates.
+//
+// Approach A trades cache effectiveness for static behaviour: the
+// bundled set is fixed at config-load. Dynamic discovery (Approach B —
+// a built-in Skill tool the model invokes on demand) is the v0.4.0
+// follow-on for self-developing agents that need to pick skills at
+// runtime. See PLAN.md and skills-design.md.
+//
+// SECURITY (intersection enforcement, applied by the config layer, not
+// here): a skill's `allowed-tools` frontmatter must be a subset of the
+// agent's `allowed_tools` YAML field. A skill may NEVER widen the
+// agent's tool set. The config layer (resolveSkills) refuses to load if
+// any skill demands a tool the agent doesn't grant. This package's job
+// is only to parse and expose the metadata.
+package skills
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Skill is one parsed SKILL.md.
+type Skill struct {
+	// Name is the skill's identifier — what an agent's `skills:` YAML
+	// field references. Sourced from the directory name; the
+	// frontmatter `name:` field, if present, must agree.
+	Name string
+	// Description is informational; surfaced for the dynamic Skill tool
+	// (Approach B, v0.4.0) so the model can decide which skill to load.
+	// In Approach A it is unused at runtime but kept for parity.
+	Description string
+	// AllowedTools is the skill's declared tool requirement. The config
+	// layer validates this is a subset of the bundling agent's
+	// allowed_tools. Empty = the skill needs no tools (its body is
+	// pure prompt guidance).
+	AllowedTools []string
+	// Body is the markdown after the closing frontmatter `---`. The
+	// config layer concatenates this onto the agent's system_prompt.
+	// Trailing whitespace is preserved (some skills use a final newline
+	// as their handoff signal).
+	Body string
+	// Path is the absolute path of the source SKILL.md, kept for
+	// diagnostic logging.
+	Path string
+}
+
+// Set is a name→Skill registry.
+type Set struct {
+	skills map[string]*Skill
+}
+
+// Get returns the named skill, or (nil, false) if absent. Safe on nil
+// receiver so callers can do `set.Get(name)` without checking SkillsRoot
+// first.
+func (s *Set) Get(name string) (*Skill, bool) {
+	if s == nil {
+		return nil, false
+	}
+	sk, ok := s.skills[name]
+	return sk, ok
+}
+
+// Names returns all loaded skill names sorted lexicographically. Used
+// by the diagnostic startup log.
+func (s *Set) Names() []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, 0, len(s.skills))
+	for n := range s.skills {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LoadSet walks root, parses every <name>/SKILL.md, and returns the
+// populated registry. Empty root returns a non-nil empty Set so callers
+// can always Get(); a missing root directory is an error (it almost
+// certainly means the operator misconfigured LOOMCYCLE_SKILLS_ROOT).
+//
+// Subdirectories without a SKILL.md are skipped silently — they may be
+// auxiliary content (e.g. a `references/` folder a skill body links to)
+// that operators stage alongside the skill itself.
+func LoadSet(root string) (*Set, error) {
+	set := &Set{skills: map[string]*Skill{}}
+	if root == "" {
+		return set, nil
+	}
+	st, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("skills root %s: %w", root, err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("skills root %s: not a directory", root)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read skills root %s: %w", root, err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		// Reject names that could escape the root if a future caller
+		// constructs a path from them. Belt-and-braces — ReadDir
+		// doesn't return entries with "/" in the name, but nothing
+		// stops a creative filename so we sanity-check.
+		if strings.ContainsAny(name, "/\\") || name == "." || name == ".." {
+			return nil, fmt.Errorf("invalid skill name %q under %s", name, root)
+		}
+		path := filepath.Join(root, name, "SKILL.md")
+		fi, err := os.Stat(path)
+		if err != nil || fi.IsDir() {
+			continue
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		sk, err := parseSkill(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		sk.Path = path
+		// The directory name is the canonical address. If frontmatter
+		// declares a different name, that's drift the operator should
+		// notice and fix; refusing to load is loud and unambiguous.
+		if sk.Name != "" && sk.Name != name {
+			return nil, fmt.Errorf("skill %s: frontmatter name %q != directory name %q", path, sk.Name, name)
+		}
+		sk.Name = name
+		set.skills[name] = sk
+	}
+	return set, nil
+}
+
+// frontmatter is the strict subset of YAML keys we read out of a
+// SKILL.md. Hyphenated keys match the Claude Code on-disk convention
+// (allowed-tools, not allowed_tools).
+type frontmatter struct {
+	Name         string   `yaml:"name"`
+	Description  string   `yaml:"description"`
+	AllowedTools []string `yaml:"allowed-tools"`
+}
+
+// parseSkill splits raw bytes into frontmatter + body. The frontmatter
+// is delimited by leading "---\n" and a closing "---" line; everything
+// after the closing line is the body.
+//
+// A SKILL.md without a leading "---\n" is treated as body-only — the
+// skill name will fall back to its directory at the LoadSet layer.
+// This tolerates ad-hoc skill files that haven't been written with
+// frontmatter yet.
+func parseSkill(raw []byte) (*Skill, error) {
+	sk := &Skill{}
+	text := string(raw)
+	// Normalise CRLF to LF for parsing; preserves byte semantics enough
+	// for our line-based delimiter scan.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+
+	if !strings.HasPrefix(text, "---\n") {
+		sk.Body = text
+		return sk, nil
+	}
+	rest := text[len("---\n"):]
+	// Closing delimiter is a line that is exactly "---". We accept
+	// either "\n---\n..." or a trailing "\n---" with no body.
+	endIdx := strings.Index(rest, "\n---\n")
+	bodyOffset := -1
+	if endIdx >= 0 {
+		bodyOffset = endIdx + len("\n---\n")
+	} else if strings.HasSuffix(rest, "\n---") {
+		endIdx = len(rest) - len("\n---")
+		bodyOffset = len(rest)
+	} else {
+		return nil, fmt.Errorf("frontmatter has no closing ---")
+	}
+	fmYAML := rest[:endIdx]
+	body := ""
+	if bodyOffset < len(rest) {
+		body = rest[bodyOffset:]
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(fmYAML), &fm); err != nil {
+		return nil, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	sk.Name = fm.Name
+	sk.Description = fm.Description
+	sk.AllowedTools = fm.AllowedTools
+	sk.Body = body
+	return sk, nil
+}

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -1,0 +1,202 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Happy path: a skill with full frontmatter + body parses into all
+// four fields. Verifies the directory name becomes the canonical Name
+// and the closing --- correctly demarcates the body.
+func TestLoadSet_Basic(t *testing.T) {
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "voice-applier")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "# voice-applier\n\nApply the voice rules.\n"
+	content := "---\n" +
+		"name: voice-applier\n" +
+		"description: Apply voice rules to prose.\n" +
+		"allowed-tools:\n" +
+		"  - Read\n" +
+		"  - Write\n" +
+		"  - Edit\n" +
+		"---\n\n" + body
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	set, err := LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	sk, ok := set.Get("voice-applier")
+	if !ok {
+		t.Fatalf("voice-applier not loaded; names=%v", set.Names())
+	}
+	if sk.Name != "voice-applier" {
+		t.Errorf("Name = %q", sk.Name)
+	}
+	if sk.Description != "Apply voice rules to prose." {
+		t.Errorf("Description = %q", sk.Description)
+	}
+	if len(sk.AllowedTools) != 3 || sk.AllowedTools[0] != "Read" {
+		t.Errorf("AllowedTools = %v", sk.AllowedTools)
+	}
+	if !strings.HasPrefix(sk.Body, "\n# voice-applier") {
+		t.Errorf("Body = %q (expected to start with body markdown after closing ---)", sk.Body)
+	}
+}
+
+// Empty SkillsRoot returns an empty (non-nil) Set so callers can Get()
+// without crashing. LOOMCYCLE_SKILLS_ROOT is optional; agents that
+// don't list skills should keep working.
+func TestLoadSet_EmptyRoot(t *testing.T) {
+	set, err := LoadSet("")
+	if err != nil {
+		t.Fatalf("LoadSet(\"\"): %v", err)
+	}
+	if set == nil {
+		t.Fatal("expected non-nil Set on empty root")
+	}
+	if _, ok := set.Get("anything"); ok {
+		t.Errorf("unexpected hit on empty Set")
+	}
+	if names := set.Names(); len(names) != 0 {
+		t.Errorf("Names() = %v, want []", names)
+	}
+}
+
+// Missing root directory is an error — almost certainly a misconfigured
+// LOOMCYCLE_SKILLS_ROOT, which we surface loudly.
+func TestLoadSet_MissingRoot(t *testing.T) {
+	_, err := LoadSet(filepath.Join(t.TempDir(), "no-such-dir"))
+	if err == nil {
+		t.Fatal("expected error for missing root")
+	}
+}
+
+// Drift detection: frontmatter `name:` disagreeing with the directory
+// name is the kind of silent breakage that bites operators. Refuse to
+// load, with a message that names both the file and the conflict.
+func TestLoadSet_NameMismatch(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "voice-applier")
+	os.MkdirAll(dir, 0o755)
+	content := "---\nname: cv-voice-applier\ndescription: Wrong name.\n---\nbody\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600)
+
+	_, err := LoadSet(root)
+	if err == nil || !strings.Contains(err.Error(), "frontmatter name") {
+		t.Errorf("expected frontmatter-name error, got %v", err)
+	}
+}
+
+// A SKILL.md with no frontmatter is body-only. Name falls back to the
+// directory name. AllowedTools defaults to nil (skill needs no tools).
+func TestLoadSet_NoFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "raw-skill")
+	os.MkdirAll(dir, 0o755)
+	body := "Just a plain markdown body.\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o600)
+
+	set, err := LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	sk, ok := set.Get("raw-skill")
+	if !ok {
+		t.Fatal("raw-skill not loaded")
+	}
+	if sk.Body != body {
+		t.Errorf("Body = %q", sk.Body)
+	}
+	if sk.AllowedTools != nil {
+		t.Errorf("AllowedTools = %v, want nil", sk.AllowedTools)
+	}
+}
+
+// An opening "---\n" with no closing "---" is malformed. Refuse to load
+// rather than treating the rest of the file as body — silent acceptance
+// would hide a YAML-frontmatter syntax bug.
+func TestLoadSet_UnclosedFrontmatter(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "broken")
+	os.MkdirAll(dir, 0o755)
+	content := "---\nname: broken\nno closing line below\nbody continues...\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600)
+
+	_, err := LoadSet(root)
+	if err == nil || !strings.Contains(err.Error(), "no closing") {
+		t.Errorf("expected unclosed-frontmatter error, got %v", err)
+	}
+}
+
+// Subdirectories without a SKILL.md are skipped silently. A skill may
+// stage auxiliary content (a references/ folder, a fixtures dir, etc.)
+// alongside SKILL.md without breaking discovery.
+func TestLoadSet_SkipsDirsWithoutSkillMd(t *testing.T) {
+	root := t.TempDir()
+	// Real skill
+	good := filepath.Join(root, "good-skill")
+	os.MkdirAll(good, 0o755)
+	os.WriteFile(filepath.Join(good, "SKILL.md"), []byte("body\n"), 0o600)
+	// Aux directory (no SKILL.md)
+	aux := filepath.Join(root, "auxiliary")
+	os.MkdirAll(aux, 0o755)
+	os.WriteFile(filepath.Join(aux, "README.md"), []byte("aux\n"), 0o600)
+
+	set, err := LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	if _, ok := set.Get("good-skill"); !ok {
+		t.Error("good-skill not loaded")
+	}
+	if _, ok := set.Get("auxiliary"); ok {
+		t.Error("auxiliary should not be loaded as a skill")
+	}
+}
+
+// CRLF line endings in a SKILL.md — produced when authors edit on
+// Windows or paste into editors that default to CRLF — must parse the
+// same as LF.
+func TestLoadSet_CRLFLineEndings(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "windows-skill")
+	os.MkdirAll(dir, 0o755)
+	content := "---\r\nname: windows-skill\r\nallowed-tools:\r\n  - Read\r\n---\r\nbody\r\n"
+	os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o600)
+
+	set, err := LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	sk, ok := set.Get("windows-skill")
+	if !ok {
+		t.Fatal("windows-skill not loaded")
+	}
+	if len(sk.AllowedTools) != 1 || sk.AllowedTools[0] != "Read" {
+		t.Errorf("AllowedTools = %v", sk.AllowedTools)
+	}
+	if !strings.Contains(sk.Body, "body") {
+		t.Errorf("Body = %q", sk.Body)
+	}
+}
+
+// Get() and Names() are safe on a nil receiver. The config layer holds
+// a *Set that may be nil when LOOMCYCLE_SKILLS_ROOT is unset; callers
+// shouldn't have to check before every lookup.
+func TestSet_NilSafe(t *testing.T) {
+	var s *Set
+	if _, ok := s.Get("anything"); ok {
+		t.Error("nil Get should miss")
+	}
+	if names := s.Names(); names != nil {
+		t.Errorf("nil Names = %v", names)
+	}
+}

--- a/internal/tools/policy/policy.go
+++ b/internal/tools/policy/policy.go
@@ -25,10 +25,10 @@ func Apply(available, agentAllowed, callerAllowed []string) []string {
 
 	out := make([]string, 0, len(available))
 	for _, name := range available {
-		if !matches(name, agentSet) {
+		if !Matches(name, agentSet) {
 			continue
 		}
-		if callerSet != nil && !matches(name, callerSet) {
+		if callerSet != nil && !Matches(name, callerSet) {
 			continue
 		}
 		out = append(out, name)
@@ -36,9 +36,11 @@ func Apply(available, agentAllowed, callerAllowed []string) []string {
 	return out
 }
 
-// matches checks if name is allowed by any rule in the set. Rules ending in
-// "*" match by prefix; otherwise exact match.
-func matches(name string, set map[string]bool) bool {
+// Matches checks if name is allowed by any rule in the set. Rules ending in
+// "*" match by prefix; otherwise exact match. Exported so other packages
+// (e.g. config) can perform the same subset check when validating layered
+// allowlists.
+func Matches(name string, set map[string]bool) bool {
 	if set[name] {
 		return true
 	}


### PR DESCRIPTION
## Summary

Adds `.claude/skills/<name>/SKILL.md` support to loomcycle as planned for v0.4.0 (Approach A in `doc-internal/skills-design.md`). Operator declares per-agent skills in YAML; loomcycle parses each SKILL.md, validates tool subset, concatenates the body onto the agent's system prompt at config-load. Bundled body lands inside the cacheable system block, so subsequent runs replay at cache-read rates.

## Changes

- **`internal/skills/loader.go`** — frontmatter parser + name→Skill registry. Tolerates CRLF, body-only files (frontmatter optional), and missing skill directories. Drift detection: frontmatter `name:` disagreeing with directory name fails loud.
- **`internal/config/config.go`** — `Skills []string` on AgentDef, `SkillsRoot` on Env (sourced from `LOOMCYCLE_SKILLS_ROOT`), `resolveSkills()` wired after `resolveSystemPromptFiles()`.
- **`internal/tools/policy/policy.go`** — exported `Matches` (was `matches`) so the config layer reuses the literal+glob composition logic.
- **`.env.example`** — documents `LOOMCYCLE_SKILLS_ROOT` with the trust note (skill bodies = operator-authored).

## Security invariant: skill `allowed-tools` ⊆ agent `allowed_tools`

A skill may NEVER widen the bundling agent's tool set. Glob composition handled in both directions via `policy.Matches`:

- skill `[Read]`, agent `[Read, HTTP]` → OK
- skill `[mcp__brave__search]`, agent `[mcp__brave__*]` → OK (skill literal covered by agent glob)
- skill `[mcp__brave__*]`, agent `[mcp__brave__search]` → ERROR (skill demands broader access)
- skill `[Edit]`, agent `[Read]` → ERROR (widening)

Empirically proven load-bearing: `TestSkillCannotWidenAgentTools` fails with the `widening = append(widening, t)` line disabled (no error raised when the skill widens), passes when restored.

## Test plan

- [x] `go test ./...` — full sweep, all packages green
- [x] 8 new tests in `internal/skills/loader_test.go` (frontmatter parse, CRLF, body-only, drift detection, missing root, nil-safe Set methods)
- [x] 8 new tests in `internal/config/config_test.go` (bundling order, intersection enforcement both directions, unknown skill, no-root error, body-only skill attaches anywhere)
- [x] End-to-end against jobs-search-agent's actual `.claude/skills/` (after frontmatter trim on the matching `feature-skills-config` branch): all three target agents (ai-detector, cv-adapter, cv-rewriter) load without error; bundled prompt sizes confirmed (28k–59k bytes including skill bodies)

## Approach B (dynamic Skill tool) deferred

`PLAN.md` v0.4.0 section now lists both Approach A (this PR — landing) and Approach B (dynamic Skill tool — sketched in skills-design.md). B reuses the same `internal/skills` loader; ~100 LOC on top, ships in v0.4.0 alongside sub-agents and the Local-API MCP gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)