### PR TITLE
feat(v0.4.0): Agent + Skill tools + Local API MCP gateway

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
+	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -105,6 +106,18 @@ func main() {
 		HostAllowlist:        staticHosts,
 		PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,
 	}
+	// Skill tool reuses the same name→body registry that the static
+	// bundling path (Approach A in internal/config) uses. Loading once
+	// at boot keeps the in-memory map authoritative — SIGHUP-style
+	// hot-reload of skills is a future enhancement.
+	skillSet, err := skills.LoadSet(cfg.Env.SkillsRoot)
+	if err != nil {
+		log.Fatalf("skills: %v", err)
+	}
+	if cfg.Env.SkillsRoot != "" {
+		log.Printf("skills: loaded %d from %s", len(skillSet.Names()), cfg.Env.SkillsRoot)
+	}
+
 	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},
 		&builtin.Write{Root: cfg.Env.WriteRoot},
@@ -113,6 +126,7 @@ func main() {
 		&builtin.WebFetch{HTTP: httpTool},
 		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
+		&builtin.SkillTool{Set: skillSet},
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -36,6 +36,7 @@ import (
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+	"github.com/denn-gubsky/loomcycle/internal/tools/localapi"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 	mcphttp "github.com/denn-gubsky/loomcycle/internal/tools/mcp/http"
 	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
@@ -127,6 +128,28 @@ func main() {
 		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
 		&builtin.SkillTool{Set: skillSet},
+	}
+
+	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
+	// in loomcycle.yaml, parse the OpenAPI spec and register one tool
+	// per operation. Each tool forwards calls to local_api.base_url
+	// with the agent's `bearer` field as Authorization. Replaces the
+	// curl-shaped HTTP-tool pattern Phase B agents currently use.
+	if cfg.LocalAPI.SpecPath != "" {
+		laTools, laWarns, err := localapi.Build(localapi.Config{
+			SpecPath:       cfg.LocalAPI.SpecPath,
+			BaseURL:        cfg.LocalAPI.BaseURL,
+			ToolNamePrefix: cfg.LocalAPI.ToolNamePrefix,
+		}, cfg.ConfigDir())
+		if err != nil {
+			log.Printf("local-api gateway disabled: %v", err)
+		} else {
+			for _, w := range laWarns {
+				log.Printf("local-api: %s", w)
+			}
+			log.Printf("local-api: registered %d tools from %s", len(laTools), cfg.LocalAPI.SpecPath)
+			allTools = append(allTools, laTools...)
+		}
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -1,0 +1,308 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// scriptedProvider returns a different event sequence per call. Used by
+// sub-agent tests where parent + child runs need different scripted
+// responses (parent: tool_call to Agent then text after tool_result;
+// child: text + done).
+type scriptedProvider struct {
+	calls    atomic.Int32
+	scripts  [][]providers.Event
+	defaultS []providers.Event // returned for any call past len(scripts)
+}
+
+func (s *scriptedProvider) ID() string { return "scripted" }
+func (s *scriptedProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (s *scriptedProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	idx := int(s.calls.Add(1)) - 1
+	var events []providers.Event
+	if idx < len(s.scripts) {
+		events = s.scripts[idx]
+	} else {
+		events = s.defaultS
+	}
+	ch := make(chan providers.Event, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// End-to-end: a parent agent invokes the Agent tool with {name: "child",
+// prompt: "hi"}; the child runs, returns text; the parent's loop sees
+// the tool_result and emits final text. Verifies:
+//
+//   - Sub-agent runs as a SEPARATE session (own session_id) so its
+//     transcript is independently retrievable.
+//   - The parent's tool_result text contains the child's FinalText.
+//   - The child's full event sequence (started/text/usage/done) lands
+//     in the child's transcript, NOT the parent's stream.
+//   - Parent only sees its own events plus the wrapping tool_call /
+//     tool_result frames.
+func TestSubAgentRoundTrip_ParentSeesChildOutput(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {
+				Model:        "stub-model",
+				AllowedTools: []string{"Agent"},
+				SystemPrompt: "you are the parent",
+			},
+			"child": {
+				Model:        "stub-model",
+				AllowedTools: []string{},
+				SystemPrompt: "you are the child",
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	// Provider script:
+	//   call 1 = parent's first iter: emit a tool_call to Agent, then done(tool_use).
+	//   call 2 = child's only iter: emit text + done(end_turn).
+	//   call 3 = parent's second iter (after tool_result): emit final text + done.
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// 1) parent → tool_call(Agent)
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_parent_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"say hello briefly"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 2}},
+			},
+			// 2) child → final text + end_turn
+			{
+				{Type: providers.EventText, Text: "child says hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 5, OutputTokens: 4}},
+			},
+			// 3) parent → final wrap-up text + end_turn
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 12, OutputTokens: 3}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Parent stream MUST contain the tool_call and a tool_result with the
+	// child's text. The child's intermediate "child says hi" text should
+	// NOT appear as a parent text frame — only as the tool_result.
+	if !strings.Contains(bodyStr, "event: tool_call") {
+		t.Errorf("parent stream missing tool_call frame:\n%s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "event: tool_result") {
+		t.Errorf("parent stream missing tool_result frame:\n%s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "child says hi") {
+		t.Errorf("parent stream missing child's output text:\n%s", bodyStr)
+	}
+
+	// Two sessions should exist now: parent + child. Parent's session
+	// is announced in the SSE stream; child's session is implicit.
+	parentSessionID := extractSessionID(bodyStr)
+	if parentSessionID == "" {
+		t.Fatalf("could not parse parent session_id from stream:\n%s", bodyStr)
+	}
+
+	parentTranscript, err := st.GetTranscript(context.Background(), parentSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Parent transcript should NOT contain a separate "text" frame for
+	// "child says hi" — only the tool_result wrapping it.
+	for _, ev := range parentTranscript {
+		if ev.Type == "text" && strings.Contains(string(ev.Payload), "child says hi") {
+			t.Errorf("child text leaked into parent stream as a parent text frame: %s", string(ev.Payload))
+		}
+	}
+
+	// Find the child's session by listing all sessions and picking the
+	// one with agent="child". The store doesn't expose ListSessions
+	// publicly, so we approximate: try GetTranscript on a synthesised
+	// ID won't work. Instead we cross-check via the parent's tool_result
+	// containing the child's output.
+	foundToolResult := false
+	for _, ev := range parentTranscript {
+		if ev.Type == "tool_result" && strings.Contains(string(ev.Payload), "child says hi") {
+			foundToolResult = true
+		}
+	}
+	if !foundToolResult {
+		t.Error("parent transcript should record the tool_result with child's output")
+	}
+}
+
+// Regression: a parent without "Agent" in its allowed_tools cannot call
+// the Agent tool — the dispatcher refuses. The model would see a
+// "tool not found" tool_result. This locks the per-agent gate.
+func TestSubAgent_ParentWithoutAgentToolCannotSpawn(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"locked": {
+				Model:        "stub-model",
+				AllowedTools: []string{}, // no Agent
+				SystemPrompt: "you cannot spawn",
+			},
+			"child": {
+				Model:        "stub-model",
+				AllowedTools: []string{},
+				SystemPrompt: "you are the child",
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// "locked" agent attempts to call Agent (a hypothetical model
+			// that ignores the tool list). The dispatcher should refuse.
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_locked_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			// After tool_result (which is "tool not found"), wrap up.
+			{
+				{Type: providers.EventText, Text: "ok, done"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+		},
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"locked","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "tool not found") {
+		t.Errorf("expected 'tool not found' tool_result for an off-policy Agent call:\n%s", body)
+	}
+	// And critically: NO sub-agent text should appear.
+	if strings.Contains(string(body), "child says hi") {
+		t.Error("blocked Agent call should not have spawned the child")
+	}
+}
+
+// Calling Agent with an unknown sub-agent name surfaces the error
+// through the IsError tool_result so the parent's model can self-correct.
+func TestSubAgent_UnknownChildName(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {
+				Model:        "stub-model",
+				AllowedTools: []string{"Agent"},
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"does-not-exist","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			{
+				{Type: providers.EventText, Text: "I'll move on"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+		},
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if !strings.Contains(string(body), "unknown sub-agent") {
+		t.Errorf("expected 'unknown sub-agent' error, got:\n%s", body)
+	}
+	// The parent run should still complete cleanly — this is a tool
+	// error, not a run-failing error.
+	if !strings.Contains(string(body), "I'll move on") {
+		t.Error("parent should have continued after the IsError tool_result")
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -55,8 +55,16 @@ type Server struct {
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
 // session+run+events tuple in the store; pass nil to keep v0.2 behaviour.
+//
+// The Agent built-in tool is registered automatically here (not in
+// cmd/loomcycle/main.go) because its SubAgentRunner closes over the
+// Server's own runSubAgent method — we'd otherwise have a chicken-and-
+// egg between tool list and Server. Per-agent allow-list still gates
+// access (an agent without "Agent" in `allowed_tools` won't see it).
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
-	return &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+	s := &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+	s.tools = append(s.tools, &builtin.AgentTool{Run: s.runSubAgent})
+	return s
 }
 
 // trySessionLock try-locks the session-scoped mutex for id. Returns
@@ -328,7 +336,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 
 	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
 
-	loopRes, runErr := loop.Run(r.Context(), loop.RunOptions{
+	// Pass the agent's effective tool names to the dispatcher so tools
+	// that need a runtime view of "what this agent can use" (e.g. the
+	// Skill tool's subset check on each call) read it via ctx instead
+	// of being constructed per-run.
+	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+
+	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:   provider,
 		Model:      model,
 		Tools:      allowedTools,
@@ -494,7 +508,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
 
-	loopRes, runErr := loop.Run(r.Context(), loop.RunOptions{
+	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:      provider,
 		Model:         model,
 		Tools:         allowedTools,
@@ -733,6 +748,127 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 	}
 }
 
+// runSubAgent is the SubAgentRunner closure injected into the Agent
+// built-in tool. It looks up the named agent in cfg.Agents, builds a
+// fresh session+run for the sub-execution, drives loop.Run with the
+// sub-agent's full declared tool set, and returns the FinalText.
+//
+// Trust model: the sub-agent's `allowed_tools` is the SOLE authority on
+// its tool surface. Parent and child are both operator-vetted YAML
+// definitions; neither widens nor narrows the other. The Agent tool's
+// availability to the parent is the gate (a parent without "Agent" in
+// its allowed_tools cannot call this in the first place).
+//
+// Sub-runs are persisted as their OWN sessions for replayability. The
+// parent's transcript records only the tool_call (with input) and
+// tool_result (with the sub's final text); the sub's intermediate
+// events are reachable via GET /v1/sessions/{sub-session-id}/transcript.
+//
+// Concurrency: sub-runs DO NOT acquire a fresh semaphore slot. They run
+// inside the parent's slot — the entire run tree counts as one against
+// MAX_CONCURRENT_RUNS. This avoids deadlocks at low concurrency caps
+// and matches the cost model (a parent's compute budget already covers
+// the work it delegates).
+//
+// Errors propagate as Go errors back to the Agent tool, which surfaces
+// them as IsError tool_results to the parent's model rather than
+// tearing down the parent run.
+func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (string, error) {
+	def, ok := s.cfg.Agents[name]
+	if !ok {
+		return "", fmt.Errorf("unknown sub-agent %q (not in loomcycle.yaml agents map)", name)
+	}
+
+	providerID, model, err := s.cfg.ResolveAgentModel(name)
+	if err != nil {
+		return "", fmt.Errorf("resolve sub-agent %q model: %w", name, err)
+	}
+	provider, err := s.providers.Get(providerID)
+	if err != nil {
+		return "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
+	}
+
+	// Sub-run gets its OWN session. Tenant inherited as empty for v0.4.0
+	// MVP — multi-tenant agent inheritance lands when per-tenant
+	// fairness does (later in v0.4 / v0.5).
+	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "")
+	if err != nil {
+		return "", fmt.Errorf("create sub-session for %q: %w", name, err)
+	}
+
+	// Build segments: agent's system_prompt (with cache_control) + the
+	// caller-supplied prompt as the first user message. Mirrors the
+	// shape of /v1/runs.
+	var segs []loop.PromptSegment
+	if def.SystemPrompt != "" {
+		segs = append(segs, loop.PromptSegment{
+			Role: "system",
+			Content: []loop.PromptContentBlock{{
+				Type:      "trusted-text",
+				Text:      def.SystemPrompt,
+				Cacheable: true,
+			}},
+		})
+	}
+	segs = append(segs, loop.PromptSegment{
+		Role: "user",
+		Content: []loop.PromptContentBlock{{
+			Type: "trusted-text",
+			Text: prompt,
+		}},
+	})
+
+	subTools := filterTools(s.tools, def.AllowedTools, nil)
+	// Caller-authoritative HTTP host narrowing doesn't apply here:
+	// sub-agents fall back to operator's static allowlist (no per-call
+	// caller list). If the sub-agent itself uses HTTP and needs hosts
+	// the operator's static list lacks, the operator must add them or
+	// run loomcycle in CALLER_AUTHORITATIVE mode (where the static
+	// list IS the fallback for runs without per-call narrowing).
+	subDispatcher := tools.NewDispatcher(subTools)
+
+	// Persist the input segments as the first event so transcript
+	// replay reconstructs the user prompt the same way fresh runs do.
+	if s.store != nil && subRunID != "" {
+		if inputJSON, err := json.Marshal(segs); err == nil {
+			if err := s.store.AppendEvent(ctx, subRunID, "user_input", inputJSON); err != nil {
+				log.Printf("store: AppendEvent(user_input) failed for sub-run %s: %v", subRunID, err)
+			}
+		}
+	}
+
+	// Sub-emit records to the sub's transcript only — the parent's SSE
+	// stream is fwd=no-op so sub events don't bleed into the parent's
+	// event stream. The parent observes only the wrapping
+	// tool_call/tool_result on its own stream.
+	subEmit := s.makeRecordingEmit(ctx, subRunID, func(providers.Event) {})
+
+	// Sub-run gets ITS OWN agent tools attached to ctx — the parent's
+	// tool list does not leak to the child (and vice versa). This
+	// matches the trust model: each agent's allowed_tools is its own
+	// authority for any subset checks done inside its run.
+	subCtx := tools.WithAgentTools(ctx, toolNames(subTools))
+
+	res, runErr := loop.Run(subCtx, loop.RunOptions{
+		Provider:   provider,
+		Model:      model,
+		Tools:      subTools,
+		Dispatcher: subDispatcher,
+		Segments:   segs,
+		OnEvent:    subEmit,
+	})
+	s.finishRun(ctx, subRunID, res, runErr)
+
+	if runErr != nil {
+		// Wrap with session/run IDs so a developer reading parent logs
+		// can locate the sub's transcript directly. The parent agent's
+		// model sees the unwrapped error message.
+		return "", fmt.Errorf("sub-agent %q failed (session=%s run=%s): %w",
+			name, subSessionID, subRunID, runErr)
+	}
+	return res.FinalText, nil
+}
+
 // finishRun marks the run terminal in the store. status is derived from
 // runErr: nil → completed, non-nil → failed. ctx may already be cancelled
 // (the client disconnected); we use a fresh background context with a short
@@ -782,6 +918,18 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// toolNames returns the names of a slice of tools — used to populate
+// the per-run AgentTools context value for tools that need a runtime
+// view of "what this agent can use" (e.g. the Skill tool's subset
+// check on each call).
+func toolNames(ts []tools.Tool) []string {
+	out := make([]string, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, t.Name())
+	}
+	return out
 }
 
 // filterTools applies the agent + caller allowlists to the registered builtins.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,10 +23,35 @@ type Config struct {
 	MCPServers  map[string]MCPServer `yaml:"mcp_servers"`
 	Concurrency Concurrency          `yaml:"concurrency"`
 	Cache       CacheConfig          `yaml:"cache"`
+	// LocalAPI declares the OpenAPI-derived MCP gateway (v0.4.0+).
+	// One tool is generated per operation; tools forward calls to
+	// BaseURL with the agent's `bearer` field as Authorization.
+	// Empty SpecPath disables the gateway. See
+	// internal/tools/localapi for the wire model.
+	LocalAPI LocalAPIConfig `yaml:"local_api"`
 
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
+
+	// configDir is the directory of the loaded YAML, kept so relative
+	// paths inside the config (system_prompt_file, local_api.spec) can
+	// be resolved against it.
+	configDir string `yaml:"-"`
 }
+
+// LocalAPIConfig is the operator-supplied config for the local-api
+// gateway. Mirrors localapi.Config but lives in the config package so
+// tests don't need to import the localapi package.
+type LocalAPIConfig struct {
+	SpecPath       string `yaml:"spec"`
+	BaseURL        string `yaml:"base_url"`
+	ToolNamePrefix string `yaml:"tool_name_prefix"`
+}
+
+// ConfigDir returns the directory the YAML was loaded from. Used by
+// callers that need to resolve relative paths declared in the config
+// (the local-api spec path, additional resource files).
+func (c *Config) ConfigDir() string { return c.configDir }
 
 // Defaults are the fall-throughs for agents that don't specify them.
 type Defaults struct {
@@ -192,6 +217,11 @@ func Load(path string) (*Config, error) {
 		expanded := expandEnv(string(raw))
 		if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		// Stash the config directory so callers (e.g. localapi.Build)
+		// can resolve relative paths declared inside the YAML.
+		if abs, err := filepath.Abs(filepath.Dir(path)); err == nil {
+			cfg.configDir = abs
 		}
 		// Resolve any agent's system_prompt_file → system_prompt. Done
 		// here so the rest of the runtime sees a uniform AgentDef

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -1,0 +1,176 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// SubAgentRunner runs a named sub-agent with a given user prompt and
+// returns the sub-agent's final assistant text. Implementations are
+// expected to:
+//
+//   - Reject unknown agent names (operator-controlled allowlist:
+//     cfg.Agents).
+//   - Apply the sub-agent's own AllowedTools as the security floor; the
+//     parent's tool set does NOT widen the child's. Parent and child are
+//     both operator-vetted definitions, so each agent's declared
+//     allow-list is authoritative for itself.
+//   - Persist the sub-agent's run as a separate session in the Store so
+//     transcripts are replayable independently of the parent.
+//   - Carry the parent's context.Context (so cancellation, deadlines,
+//     and the loomcycle agent-depth value all propagate).
+type SubAgentRunner func(ctx context.Context, name string, prompt string) (output string, err error)
+
+// MaxAgentDepth caps recursion: a top-level run is depth 0, the agents
+// it spawns are depth 1, etc. The cap is a safety rail against runaway
+// self-spawning prompt loops; cv-batch-adapter spawning cv-adapter is
+// depth 1 today. Hardcoded for v0.4.0; lifted to config in a later
+// release if a real workflow demands deeper.
+const MaxAgentDepth = 3
+
+type ctxKeyAgentDepth struct{}
+
+// IncrementAgentDepth bumps the depth counter on ctx. The Agent tool
+// applies this before invoking the SubAgentRunner so a recursive child
+// inherits a higher depth than the parent.
+func IncrementAgentDepth(ctx context.Context) context.Context {
+	d, _ := ctx.Value(ctxKeyAgentDepth{}).(int)
+	return context.WithValue(ctx, ctxKeyAgentDepth{}, d+1)
+}
+
+// AgentDepth reports the current recursion depth (0 at the top level).
+// Exposed so tests and the loop can assert depth invariants without
+// reaching into the unexported context key.
+func AgentDepth(ctx context.Context) int {
+	d, _ := ctx.Value(ctxKeyAgentDepth{}).(int)
+	return d
+}
+
+// AgentTool is the built-in `Agent` tool that spawns a named sub-agent
+// in a fresh session. The model invokes it with {name, prompt}; the
+// tool returns the sub-agent's final assistant text as a tool_result.
+//
+// Wire shape (Anthropic-compatible-ish — we don't expose Anthropic's
+// own sub-agents API; this is loomcycle's own Tool with the same
+// ergonomics):
+//
+//	{
+//	  "name":   "cv-adapter",          // a key in cfg.Agents
+//	  "prompt": "Generate CV for ..."  // user-message body the sub sees
+//	}
+//
+// The sub-agent's `allowed_tools` (from its YAML AgentDef) is the sole
+// authority on what the sub can use — the parent's allow-list does not
+// widen or narrow it. This matches the trust model: each agent
+// definition is operator-curated and self-describing.
+//
+// The parent observes only the tool_call (with input) and the
+// tool_result (with the sub's final text). The sub's intermediate
+// events go to the sub's own persisted transcript, retrievable via
+// GET /v1/sessions/{sub-session-id}/transcript.
+type AgentTool struct {
+	// Run is the closure provided by the runtime that knows how to
+	// look up sub-agent definitions, build the tool dispatcher, and
+	// drive a fresh loop. Constructed by the HTTP server at boot.
+	Run SubAgentRunner
+}
+
+// agentInput is the JSON shape the model sends.
+type agentInput struct {
+	Name   string `json:"name"`
+	Prompt string `json:"prompt"`
+}
+
+// agentInputSchema is the JSON Schema the model sees. Both fields are
+// required; nothing else is permitted (unknown fields are tolerated by
+// json.Unmarshal but will be ignored, so this is documentation more
+// than enforcement).
+const agentInputSchema = `{
+  "type": "object",
+  "properties": {
+    "name":   {"type": "string", "description": "Sub-agent name. Must match a key in the loomcycle.yaml agents map."},
+    "prompt": {"type": "string", "description": "User-message body the sub-agent sees. Treat this as the task description; do not include auth tokens (the sub-agent gets its own auth context)."}
+  },
+  "required": ["name", "prompt"],
+  "additionalProperties": false
+}`
+
+const agentDescription = `Spawn a named sub-agent in a fresh session and return its final output. ` +
+	`The sub-agent has its own tool allowlist (from loomcycle.yaml); your tool set does not transfer. ` +
+	`Use this when the work is well-described by another agent's role (e.g. coordinator agents that fan out to specialists). ` +
+	`The sub-agent's transcript is persisted separately and can be inspected via the API.`
+
+// Name implements tools.Tool.
+func (a *AgentTool) Name() string { return "Agent" }
+
+// Description implements tools.Tool.
+func (a *AgentTool) Description() string { return agentDescription }
+
+// InputSchema implements tools.Tool.
+func (a *AgentTool) InputSchema() json.RawMessage { return json.RawMessage(agentInputSchema) }
+
+// Execute implements tools.Tool. Validates the input, enforces the
+// recursion depth cap, and delegates to the SubAgentRunner. Errors are
+// surfaced as IsError tool_result so the model can self-correct rather
+// than the run being torn down.
+func (a *AgentTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	if a.Run == nil {
+		return tools.Result{IsError: true, Text: "Agent tool not wired to a sub-agent runner (operator misconfiguration)"}, nil
+	}
+
+	var in agentInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+	in.Name = strings.TrimSpace(in.Name)
+	if in.Name == "" {
+		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
+	}
+	if in.Prompt == "" {
+		return tools.Result{IsError: true, Text: "missing required field: prompt"}, nil
+	}
+
+	// Recursion guard. Counter starts at 0 for the top-level run; a
+	// sub-agent invocation runs at depth+1. Refuse if that would push
+	// past MaxAgentDepth.
+	if AgentDepth(ctx) >= MaxAgentDepth {
+		return tools.Result{
+			IsError: true,
+			Text: fmt.Sprintf(
+				"max sub-agent recursion depth (%d) reached at agent %q; refusing to spawn deeper",
+				MaxAgentDepth, in.Name,
+			),
+		}, nil
+	}
+	subCtx := IncrementAgentDepth(ctx)
+
+	output, err := a.Run(subCtx, in.Name, in.Prompt)
+	if err != nil {
+		// Surface as an error tool_result. The parent can decide whether
+		// to retry, fall back, or give up. We don't tear down the parent
+		// run — the sub failure is treated as a tool error, same shape
+		// as a 4xx from HTTP or an MCP server returning is_error.
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	if output == "" {
+		// A sub-agent that ended_turn with no text is rare but possible
+		// (e.g. it only made tool calls and stopped). Surface a hint
+		// rather than an empty result so the parent's model has
+		// something concrete to read.
+		return tools.Result{Text: fmt.Sprintf("(sub-agent %q completed with no final text)", in.Name)}, nil
+	}
+	return tools.Result{Text: output}, nil
+}
+
+// errAgentBadInput is reserved for future structured errors. Currently
+// we surface every input problem as an IsError tool_result, but a
+// caller that wants to break out of the loop entirely (rather than let
+// the model self-correct) can return this from a SubAgentRunner.
+var errAgentBadInput = errors.New("agent: bad input")
+
+var _ tools.Tool = (*AgentTool)(nil)

--- a/internal/tools/builtin/agent_test.go
+++ b/internal/tools/builtin/agent_test.go
@@ -1,0 +1,208 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Happy path: input parses, runner is called with the right args, the
+// returned text is wrapped in a successful Result.
+func TestAgentTool_HappyPath(t *testing.T) {
+	var gotName, gotPrompt string
+	a := &AgentTool{Run: func(_ context.Context, name, prompt string) (string, error) {
+		gotName, gotPrompt = name, prompt
+		return "sub-agent output", nil
+	}}
+
+	res, err := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"cv-adapter","prompt":"Generate CV"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError=true: %s", res.Text)
+	}
+	if res.Text != "sub-agent output" {
+		t.Errorf("Text = %q", res.Text)
+	}
+	if gotName != "cv-adapter" || gotPrompt != "Generate CV" {
+		t.Errorf("runner got (%q, %q)", gotName, gotPrompt)
+	}
+}
+
+// Missing required fields surface as IsError tool_results so the model
+// can self-correct, NOT as Go errors that tear down the run.
+func TestAgentTool_MissingName(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called when name is missing")
+		return "", nil
+	}}
+	res, err := a.Execute(context.Background(), json.RawMessage(`{"prompt":"X"}`))
+	if err != nil {
+		t.Fatalf("Execute returned hard error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true on missing name")
+	}
+	if !strings.Contains(res.Text, "name") {
+		t.Errorf("error should name the missing field: %q", res.Text)
+	}
+}
+
+func TestAgentTool_MissingPrompt(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called when prompt is missing")
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"name":"foo"}`))
+	if !res.IsError || !strings.Contains(res.Text, "prompt") {
+		t.Errorf("expected missing-prompt IsError, got %+v", res)
+	}
+}
+
+// Whitespace-only name is treated as missing — guards against the model
+// emitting `"name": "  "` and getting a confusing "unknown agent" error
+// from the runner instead of a clean "missing field" response.
+func TestAgentTool_WhitespaceNameRejected(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"name":"   ","prompt":"X"}`))
+	if called {
+		t.Error("runner should not be called with whitespace-only name")
+	}
+	if !res.IsError {
+		t.Error("expected IsError on whitespace name")
+	}
+}
+
+// Malformed JSON input is also a model-correctable error, not a hard
+// crash. The model gets feedback "invalid input JSON" and can retry.
+func TestAgentTool_MalformedJSON(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called on malformed JSON")
+		return "", nil
+	}}
+	res, err := a.Execute(context.Background(), json.RawMessage(`{not json`))
+	if err != nil {
+		t.Fatalf("Execute returned hard error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true on malformed JSON")
+	}
+}
+
+// Runner errors propagate to the model as IsError tool_results — the
+// parent run continues so the model can decide how to recover (try a
+// different sub-agent, fall back, give up gracefully).
+func TestAgentTool_RunnerError(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		return "", errors.New("provider returned 500")
+	}}
+	res, err := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true when runner fails")
+	}
+	if !strings.Contains(res.Text, "provider returned 500") {
+		t.Errorf("error message lost: %q", res.Text)
+	}
+}
+
+// A sub-agent that ends_turn with no text is rare but possible (made
+// only tool calls, then stopped). Surface a hint so the parent's
+// model has something concrete to read instead of empty Text.
+func TestAgentTool_EmptyOutputHint(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"silent-agent","prompt":"x"}`))
+	if res.IsError {
+		t.Errorf("empty output is not an error: %+v", res)
+	}
+	if !strings.Contains(res.Text, "silent-agent") || !strings.Contains(res.Text, "no final text") {
+		t.Errorf("hint should name the agent and explain: %q", res.Text)
+	}
+}
+
+// Recursion guard: a context already at MaxAgentDepth refuses to spawn.
+// EMPIRICAL: with the depth check disabled, this test fails because
+// the runner gets called instead of the IsError path.
+func TestAgentTool_MaxDepthGuard(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "should not run", nil
+	}}
+	ctx := context.Background()
+	for i := 0; i < MaxAgentDepth; i++ {
+		ctx = IncrementAgentDepth(ctx)
+	}
+	res, _ := a.Execute(ctx, json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if called {
+		t.Error("runner should not have been invoked at max depth")
+	}
+	if !res.IsError || !strings.Contains(res.Text, "max sub-agent recursion depth") {
+		t.Errorf("expected max-depth IsError, got %+v", res)
+	}
+}
+
+// One depth below the cap is still allowed — the guard fires at >=,
+// not >. Worth pinning so a future refactor doesn't shift the
+// boundary by one.
+func TestAgentTool_DepthBelowCapAllowed(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "ok", nil
+	}}
+	ctx := context.Background()
+	for i := 0; i < MaxAgentDepth-1; i++ {
+		ctx = IncrementAgentDepth(ctx)
+	}
+	res, _ := a.Execute(ctx, json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if !called {
+		t.Error("runner should run at depth = MaxAgentDepth-1")
+	}
+	if res.IsError {
+		t.Errorf("unexpected error: %s", res.Text)
+	}
+}
+
+// AgentDepth on a fresh context returns 0 — the top-level run is depth 0.
+func TestAgentDepth_DefaultsToZero(t *testing.T) {
+	if d := AgentDepth(context.Background()); d != 0 {
+		t.Errorf("AgentDepth(empty ctx) = %d, want 0", d)
+	}
+}
+
+// IncrementAgentDepth chains: each call increments by exactly one.
+func TestIncrementAgentDepth_Chains(t *testing.T) {
+	ctx := context.Background()
+	for want := 1; want <= 5; want++ {
+		ctx = IncrementAgentDepth(ctx)
+		if got := AgentDepth(ctx); got != want {
+			t.Errorf("after %d increments: depth = %d, want %d", want, got, want)
+		}
+	}
+}
+
+// Defensive: tool with nil Run surfaces a clear error so a misconfigured
+// server doesn't silently accept Agent calls.
+func TestAgentTool_NilRunner(t *testing.T) {
+	a := &AgentTool{} // Run is nil
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not wired") {
+		t.Errorf("expected nil-runner IsError, got %+v", res)
+	}
+}

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -1,0 +1,167 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
+)
+
+// SkillTool is the dynamic-discovery counterpart to the static skill
+// bundling in `internal/config`. The model invokes it with a skill
+// name; the tool returns the skill body as a tool_result.
+//
+// When to prefer Approach B (this tool) over Approach A (config-load
+// bundling):
+//
+//   - The agent has a long menu of candidate skills and uses only a
+//     few per run (pay-as-you-go beats always-bundle).
+//   - The skill set evolves at runtime — operators drop new skills
+//     into LOOMCYCLE_SKILLS_ROOT without restarting loomcycle.
+//   - You want the model to surface "I needed cv-voice-applier here"
+//     in transcripts (the tool_call event names the skill explicitly).
+//
+// When to prefer Approach A:
+//
+//   - Every referenced skill is referenced unconditionally (the
+//     current jobs-search-agent shape). Bundling rides the system-
+//     prompt cache; the tool path re-bills the body per call when
+//     the conversation prefix doesn't include it yet.
+//
+// Both approaches share the same `internal/skills` loader and the
+// same intersection-check semantics — a skill's `allowed-tools` must
+// be a subset of the bundling/calling agent's `allowed_tools`.
+//
+// Wire shape:
+//
+//	{
+//	  "name": "voice-applier"   // a key under LOOMCYCLE_SKILLS_ROOT
+//	}
+//
+// SECURITY: subset enforcement happens HERE, at tool-call time, against
+// the agent's effective allowed_tools (which the tool receives via the
+// AgentTools field at construction). A skill that demands a tool the
+// current agent doesn't have is refused with an IsError tool_result —
+// matching the config-load behaviour for static bundling.
+type SkillTool struct {
+	// Set is the loaded skill registry, populated from
+	// LOOMCYCLE_SKILLS_ROOT at server boot. Shared with Approach A
+	// (config-load bundling) so a skill change is visible to both
+	// paths after a SIGHUP/restart.
+	//
+	// The calling agent's effective allowed_tools is NOT a field —
+	// it varies per request and is read from ctx via tools.AgentTools.
+	// The HTTP server attaches it before invoking the loop.
+	Set *skills.Set
+}
+
+const skillInputSchema = `{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string", "description": "Skill name (a directory under LOOMCYCLE_SKILLS_ROOT containing SKILL.md)."}
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}`
+
+const skillDescription = `Load a named skill's body and return it as the tool_result. ` +
+	`Skills are domain-specific instruction sets stored under LOOMCYCLE_SKILLS_ROOT (frontmatter + markdown). ` +
+	`Use when the model needs a specific extension that wasn't pre-bundled into its system prompt. ` +
+	`The skill's allowed-tools must be a subset of the calling agent's allowed_tools — refusals are surfaced as is_error.`
+
+type skillInput struct {
+	Name string `json:"name"`
+}
+
+// Name implements tools.Tool.
+func (s *SkillTool) Name() string { return "Skill" }
+
+// Description implements tools.Tool.
+func (s *SkillTool) Description() string { return skillDescription }
+
+// InputSchema implements tools.Tool.
+func (s *SkillTool) InputSchema() json.RawMessage { return json.RawMessage(skillInputSchema) }
+
+// Execute implements tools.Tool.
+func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	if s.Set == nil {
+		return tools.Result{
+			IsError: true,
+			Text:    "Skill tool not configured: LOOMCYCLE_SKILLS_ROOT is unset",
+		}, nil
+	}
+
+	var in skillInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+	in.Name = strings.TrimSpace(in.Name)
+	if in.Name == "" {
+		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
+	}
+
+	sk, ok := s.Set.Get(in.Name)
+	if !ok {
+		// Hint with the available names so the model can recover. Cap
+		// at a reasonable count so a misconfigured root with hundreds
+		// of skills doesn't flood the tool_result.
+		names := s.Set.Names()
+		hint := ""
+		if len(names) > 0 {
+			cap := 10
+			if len(names) < cap {
+				cap = len(names)
+			}
+			hint = " (available: " + strings.Join(names[:cap], ", ")
+			if len(names) > cap {
+				hint += ", ..."
+			}
+			hint += ")"
+		}
+		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown skill %q%s", in.Name, hint)}, nil
+	}
+
+	// SECURITY: enforce skill.allowed-tools ⊆ agent.allowed_tools at
+	// tool-call time. Mirrors the config-load check in resolveSkills.
+	// Agent tools are pulled from ctx (see tools.WithAgentTools) so the
+	// SkillTool struct stays per-server, not per-run.
+	agentTools := tools.AgentTools(ctx)
+	if widening := skillToolsExceedingAgent(sk.AllowedTools, agentTools); len(widening) > 0 {
+		return tools.Result{
+			IsError: true,
+			Text: fmt.Sprintf(
+				"skill %q requires tools %v not granted by this agent's allowed_tools — skills cannot widen the agent's tool set",
+				in.Name, widening,
+			),
+		}, nil
+	}
+
+	return tools.Result{Text: sk.Body}, nil
+}
+
+// skillToolsExceedingAgent returns the subset of skill tools that the
+// agent does NOT grant (literal + glob composition via policy.Matches).
+// Mirrors resolveSkills' check in internal/config so the static and
+// dynamic skill paths apply the same security rule.
+func skillToolsExceedingAgent(skillTools, agentTools []string) []string {
+	if len(skillTools) == 0 {
+		return nil
+	}
+	agentSet := make(map[string]bool, len(agentTools))
+	for _, t := range agentTools {
+		agentSet[t] = true
+	}
+	var widening []string
+	for _, t := range skillTools {
+		if !policy.Matches(t, agentSet) {
+			widening = append(widening, t)
+		}
+	}
+	return widening
+}
+
+var _ tools.Tool = (*SkillTool)(nil)

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -88,10 +88,19 @@ func (s *SkillTool) InputSchema() json.RawMessage { return json.RawMessage(skill
 
 // Execute implements tools.Tool.
 func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
-	if s.Set == nil {
+	// Two paths land here that look like "no skills available":
+	//   1. Set == nil — direct construction without a loader (defensive,
+	//      not reachable from main.go which always passes a non-nil set).
+	//   2. Set is non-nil but empty — main.go's path when
+	//      LOOMCYCLE_SKILLS_ROOT is unset (skills.LoadSet("") returns a
+	//      non-nil empty Set so callers can always Get without a guard).
+	// Both produce the same operator-facing diagnostic: "set
+	// LOOMCYCLE_SKILLS_ROOT to use this tool" — distinguishing them in
+	// the error text would only matter to a unit test, never an operator.
+	if s.Set == nil || len(s.Set.Names()) == 0 {
 		return tools.Result{
 			IsError: true,
-			Text:    "Skill tool not configured: LOOMCYCLE_SKILLS_ROOT is unset",
+			Text:    "Skill tool: no skills configured (set LOOMCYCLE_SKILLS_ROOT and populate <root>/<name>/SKILL.md)",
 		}, nil
 	}
 

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -180,10 +180,27 @@ func TestSkillTool_UnknownSkillHints(t *testing.T) {
 	}
 }
 
-// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset; refuse with a clear
-// runtime-misconfiguration message.
+// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset (or direct test
+// construction); refuse with a clear runtime-misconfiguration message.
 func TestSkillTool_NilSetReturnsConfigError(t *testing.T) {
 	tool := &SkillTool{Set: nil}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("expected config error, got %+v", res)
+	}
+}
+
+// Empty Set is what main.go actually constructs when
+// LOOMCYCLE_SKILLS_ROOT is unset (skills.LoadSet("") returns a non-nil
+// empty Set). Without a fast-path here, the operator would see
+// "unknown skill 'foo'" — true but unhelpful — instead of the
+// LOOMCYCLE_SKILLS_ROOT hint.
+func TestSkillTool_EmptySetReturnsConfigError(t *testing.T) {
+	emptySet, err := skills.LoadSet("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tool := &SkillTool{Set: emptySet}
 	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
 	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
 		t.Errorf("expected config error, got %+v", res)

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -1,0 +1,228 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// loadSetWithSkills builds a skills.Set from a temp directory of
+// (name, frontmatter-tools, body) tuples. Helper for the tests below.
+func loadSetWithSkills(t *testing.T, defs []struct {
+	Name         string
+	AllowedTools []string
+	Body         string
+}) *skills.Set {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range defs {
+		dir := filepath.Join(root, d.Name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fm := "---\nname: " + d.Name + "\n"
+		if len(d.AllowedTools) > 0 {
+			fm += "allowed-tools:\n"
+			for _, tn := range d.AllowedTools {
+				fm += "  - " + tn + "\n"
+			}
+		}
+		fm += "---\n" + d.Body
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(fm), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	set, err := skills.LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	return set
+}
+
+// Happy path: agent's tools cover the skill's needs; tool returns the body.
+func TestSkillTool_HappyPath(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "voice-applier", AllowedTools: []string{"Read", "Skill"}, Body: "VOICE BODY"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"Read", "Skill", "HTTP"})
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"name":"voice-applier"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "VOICE BODY") {
+		t.Errorf("Text missing skill body: %q", res.Text)
+	}
+}
+
+// Subset check: skill needs Edit, agent doesn't grant it. Refused.
+// EMPIRICAL: removing the subset check makes this test fail (the body
+// would be returned successfully despite the missing tool).
+func TestSkillTool_RefusesWideningSkill(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "writer-skill", AllowedTools: []string{"Read", "Write", "Edit"}, Body: "X"},
+	})
+	tool := &SkillTool{Set: set}
+	// Agent only has Read.
+	ctx := tools.WithAgentTools(context.Background(), []string{"Read"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"writer-skill"}`))
+	if !res.IsError {
+		t.Error("expected IsError when skill widens agent's tool set")
+	}
+	if !strings.Contains(res.Text, "Write") || !strings.Contains(res.Text, "Edit") {
+		t.Errorf("error should name the missing tools: %q", res.Text)
+	}
+	if strings.Contains(res.Text, "Read") {
+		t.Errorf("error should NOT mention Read (agent already has it): %q", res.Text)
+	}
+}
+
+// Glob composition (literal-vs-glob): skill literal `mcp__brave__search`
+// covered by agent glob `mcp__brave__*` → allowed. Mirrors the static-
+// path check in resolveSkills, ensuring both code paths agree.
+func TestSkillTool_GlobCoversSkillLiteral(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "search-skill", AllowedTools: []string{"mcp__brave__search"}, Body: "OK"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"mcp__brave__*"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"search-skill"}`))
+	if res.IsError {
+		t.Errorf("agent glob should cover skill literal: %s", res.Text)
+	}
+}
+
+// Skill broader than agent: skill `mcp__brave__*` glob, agent has only
+// the literal `mcp__brave__search`. The skill demands wider access; refused.
+func TestSkillTool_RefusesBroaderGlob(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "broad-skill", AllowedTools: []string{"mcp__brave__*"}, Body: "X"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"mcp__brave__search"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"broad-skill"}`))
+	if !res.IsError {
+		t.Error("agent literal should NOT cover skill's broader glob")
+	}
+}
+
+// A skill with empty allowed-tools (pure prose-guidance) attaches
+// regardless of agent's tool set.
+func TestSkillTool_EmptyAllowedToolsAlwaysAllowed(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "guidance", AllowedTools: nil, Body: "GUIDANCE"},
+	})
+	tool := &SkillTool{Set: set}
+	// Even an agent with NO tools at all should see this skill.
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"guidance"}`))
+	if res.IsError {
+		t.Errorf("zero-tool skill should attach to any agent: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "GUIDANCE") {
+		t.Errorf("body missing: %q", res.Text)
+	}
+}
+
+// Unknown skill: hint with available names so the model can recover.
+func TestSkillTool_UnknownSkillHints(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "alpha", AllowedTools: nil, Body: "x"},
+		{Name: "beta", AllowedTools: nil, Body: "y"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"does-not-exist"}`))
+	if !res.IsError {
+		t.Error("expected IsError for unknown skill")
+	}
+	if !strings.Contains(res.Text, "alpha") || !strings.Contains(res.Text, "beta") {
+		t.Errorf("hint should list available skills: %q", res.Text)
+	}
+}
+
+// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset; refuse with a clear
+// runtime-misconfiguration message.
+func TestSkillTool_NilSetReturnsConfigError(t *testing.T) {
+	tool := &SkillTool{Set: nil}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("expected config error, got %+v", res)
+	}
+}
+
+// Missing/whitespace name surfaces as IsError with a hint.
+func TestSkillTool_MissingName(t *testing.T) {
+	tool := &SkillTool{Set: loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{{Name: "x", Body: "y"}})}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{}`))
+	if !res.IsError || !strings.Contains(res.Text, "name") {
+		t.Errorf("expected missing-name error, got %+v", res)
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"name":"   "}`))
+	if !res.IsError {
+		t.Error("whitespace name should be treated as missing")
+	}
+}
+
+// Malformed JSON is recoverable — IsError, not a Go error.
+func TestSkillTool_MalformedJSON(t *testing.T) {
+	tool := &SkillTool{Set: loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{{Name: "x", Body: "y"}})}
+
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{not json`))
+	if err != nil {
+		t.Fatalf("hard error from malformed JSON: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError on malformed JSON")
+	}
+}

--- a/internal/tools/localapi/loader.go
+++ b/internal/tools/localapi/loader.go
@@ -51,6 +51,14 @@ func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
 
 	endpoints, warns := spec.Endpoints()
 
+	// Track names we've already registered so a normalisation collision
+	// (e.g. `get-user` and `get.user` both → `get_user`) is detected and
+	// the second skipped instead of silently overwriting the first in
+	// the dispatcher map. Without this, the model sees both opIds in
+	// its tool menu but only ONE actually dispatches — and which one is
+	// determined by map iteration order.
+	seen := make(map[string]string, len(endpoints))
+
 	out := make([]tools.Tool, 0, len(endpoints))
 	for _, ep := range endpoints {
 		toolName := prefix + "__" + ep.Operation.OperationID
@@ -66,6 +74,14 @@ func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
 				fmt.Sprintf("operation %s: normalised tool name %q → %q", ep.Operation.OperationID, toolName, safe))
 			toolName = safe
 		}
+
+		if firstOpID, dup := seen[toolName]; dup {
+			warns = append(warns,
+				fmt.Sprintf("operation %s: tool name %q collides with operation %s after normalisation; skipping the second one (rename the operationId to disambiguate)",
+					ep.Operation.OperationID, toolName, firstOpID))
+			continue
+		}
+		seen[toolName] = ep.Operation.OperationID
 
 		tool := &EndpointTool{
 			ToolName:      toolName,

--- a/internal/tools/localapi/loader.go
+++ b/internal/tools/localapi/loader.go
@@ -1,0 +1,137 @@
+package localapi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Config is the operator-supplied configuration for the local-api
+// gateway, populated from the loomcycle.yaml `local_api` block.
+type Config struct {
+	// SpecPath is the OpenAPI 3.0 file. Relative paths are resolved
+	// against the loomcycle.yaml directory.
+	SpecPath string `yaml:"spec"`
+	// BaseURL is where forward requests are sent. The OpenAPI spec's
+	// own `servers[0].url` is intentionally NOT honoured — operator
+	// is the authority on routing.
+	BaseURL string `yaml:"base_url"`
+	// ToolNamePrefix is prepended to every operationId. Default
+	// "local"; tools become e.g. `local__patch_application`.
+	ToolNamePrefix string `yaml:"tool_name_prefix"`
+}
+
+// Build reads the OpenAPI spec, walks its operations, and returns the
+// generated EndpointTools as the standard tools.Tool slice. main.go
+// appends these to allTools alongside the built-ins.
+//
+// Returns the tools, a slice of warnings (entries the loader skipped
+// or normalised), and any fatal error. A fatal error means the gateway
+// can't start; loomcycle continues running without it after logging.
+func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
+	if cfg.SpecPath == "" {
+		return nil, nil, fmt.Errorf("localapi: spec is required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, nil, fmt.Errorf("localapi: base_url is required")
+	}
+	prefix := cfg.ToolNamePrefix
+	if prefix == "" {
+		prefix = "local"
+	}
+	if !validPrefix(prefix) {
+		return nil, nil, fmt.Errorf("localapi: invalid tool_name_prefix %q (use [a-zA-Z0-9_-]+)", prefix)
+	}
+
+	spec, err := LoadSpec(cfg.SpecPath, configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	endpoints, warns := spec.Endpoints()
+
+	out := make([]tools.Tool, 0, len(endpoints))
+	for _, ep := range endpoints {
+		toolName := prefix + "__" + ep.Operation.OperationID
+		// operationId values that don't survive the loomcycle tool-
+		// name conventions (must be addressable from agent allow-
+		// lists, which are simple strings) are normalised: replace
+		// any non-[a-zA-Z0-9_] with "_". This is rare in well-formed
+		// OpenAPI but cheap to enforce so we don't surprise an
+		// operator whose generator emits camelCase-with-dashes.
+		safe := normaliseToolName(toolName)
+		if safe != toolName {
+			warns = append(warns,
+				fmt.Sprintf("operation %s: normalised tool name %q → %q", ep.Operation.OperationID, toolName, safe))
+			toolName = safe
+		}
+
+		tool := &EndpointTool{
+			ToolName:      toolName,
+			BaseURL:       cfg.BaseURL,
+			Path:          ep.Path,
+			Method:        ep.Method,
+			OpSummary:     ep.Operation.Summary,
+			OpDescription: ep.Operation.Description,
+			Parameters:    ep.Operation.Parameters,
+		}
+
+		if rb := ep.Operation.RequestBody; rb != nil {
+			if mc, ok := rb.Content["application/json"]; ok && mc.Schema != nil {
+				tool.HasBody = true
+				tool.BodySchema = mc.Schema
+				// Note: we don't track requestBody.required separately
+				// because the input schema's `required` array is
+				// driven only by the parameters loop. If a future
+				// release wants to enforce body presence at schema
+				// level, add a HasBodyRequired flag and append "body"
+				// to required when set.
+			} else if rb.Content != nil {
+				warns = append(warns,
+					fmt.Sprintf("%s %s: requestBody.content has no application/json entry; body skipped",
+						ep.Method, ep.Path))
+			}
+		}
+		out = append(out, tool)
+	}
+	return out, warns, nil
+}
+
+func validPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// normaliseToolName replaces every char that isn't [a-zA-Z0-9_-] with
+// "_". The "__" separator is preserved because each side is already
+// validated/normalised independently. Result is always non-empty.
+func normaliseToolName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/tools/localapi/spec.go
+++ b/internal/tools/localapi/spec.go
@@ -1,0 +1,201 @@
+// Package localapi implements the Local API MCP gateway: it reads an
+// OpenAPI 3.0 spec at boot and exposes each declared endpoint as a
+// typed loomcycle tool. Replaces the curl-shaped HTTP-tool pattern
+// jobs-search-agent's Phase B agents currently use to call back into
+// the host application's `/api/agent/*` endpoints.
+//
+// Trust + scope:
+//   - Tools are named `<prefix>__<operationId>` (default prefix
+//     "local"); each carries the operation's input schema so typos
+//     fail at the model layer instead of becoming a 4xx mid-run.
+//   - Auth is carried by the agent on each call (the `bearer` field
+//     in every tool's input schema). Agents already see the Bearer
+//     token in their prompt's auth preamble; this is the typed
+//     replacement for `headers: {Authorization: ...}` on the
+//     existing HTTP tool.
+//   - SSRF / private-IP defences DO NOT apply: this gateway is
+//     deliberately pointed at a trusted host (the operator's own
+//     application server). Operators MUST set base_url to a known
+//     internal address; do not point this at attacker-controlled
+//     URLs.
+//
+// Constraints (MVP, v0.4.0):
+//   - Inline schemas only — `$ref` is NOT resolved. Operators must
+//     bundle their spec before pointing loomcycle at it (e.g. via
+//     swagger-cli bundle, redocly bundle).
+//   - JSON request/response bodies only (`application/json` content
+//     type). Form-data, multipart, and binary payloads are not
+//     wrapped.
+//   - The supported HTTP methods are GET/POST/PUT/PATCH/DELETE.
+//     OPTIONS / HEAD / TRACE / WebSocket are skipped.
+//   - Top-level `servers[0].url` is ignored — base_url is always
+//     operator-supplied via loomcycle.yaml. Mixing the two would
+//     create surprise routing.
+package localapi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Spec is the parsed subset of an OpenAPI 3.0 document. Fields not
+// listed here are ignored.
+type Spec struct {
+	OpenAPI    string                  `yaml:"openapi"`
+	Info       infoBlock               `yaml:"info"`
+	Paths      map[string]pathItem     `yaml:"paths"`
+	Components componentsBlock         `yaml:"components"`
+	rawBytes   []byte                  // kept for diagnostics
+}
+
+type infoBlock struct {
+	Title   string `yaml:"title"`
+	Version string `yaml:"version"`
+}
+
+// pathItem is one entry under `paths`. We accept the standard HTTP
+// verbs and ignore parameters declared at the path level (operators
+// should declare them per-operation for clarity in the rendered tool
+// names).
+type pathItem struct {
+	Get    *operation `yaml:"get"`
+	Post   *operation `yaml:"post"`
+	Put    *operation `yaml:"put"`
+	Patch  *operation `yaml:"patch"`
+	Delete *operation `yaml:"delete"`
+}
+
+// operation is the parsed shape of one (path, method) tuple. Schemas
+// are kept as `*yaml.Node` so we can re-serialise them as JSON Schema
+// without deep-parsing every type variant the OpenAPI spec allows.
+type operation struct {
+	OperationID string             `yaml:"operationId"`
+	Summary     string             `yaml:"summary"`
+	Description string             `yaml:"description"`
+	Parameters  []parameter        `yaml:"parameters"`
+	RequestBody *requestBody       `yaml:"requestBody"`
+	Tags        []string           `yaml:"tags"`
+}
+
+type parameter struct {
+	Name        string     `yaml:"name"`
+	In          string     `yaml:"in"`         // "path" | "query" | "header" | "cookie"
+	Description string     `yaml:"description"`
+	Required    bool       `yaml:"required"`
+	Schema      *yaml.Node `yaml:"schema"`
+}
+
+type requestBody struct {
+	Description string                  `yaml:"description"`
+	Required    bool                    `yaml:"required"`
+	Content     map[string]mediaContent `yaml:"content"`
+}
+
+type mediaContent struct {
+	Schema *yaml.Node `yaml:"schema"`
+}
+
+type componentsBlock struct {
+	// We don't resolve $ref in the MVP (see package doc). The block is
+	// parsed only so a future enhancement that DOES resolve refs has
+	// the data to work with — kept for forward compatibility.
+	Schemas map[string]*yaml.Node `yaml:"schemas"`
+}
+
+// LoadSpec reads an OpenAPI YAML/JSON file from disk and parses it into
+// the supported subset.
+//
+// Path resolution: relative paths are resolved against the operator's
+// configured config directory (passed via configDir). An empty
+// configDir treats the path as-is. Absolute paths bypass the join.
+func LoadSpec(specPath, configDir string) (*Spec, error) {
+	if specPath == "" {
+		return nil, fmt.Errorf("localapi: empty spec path")
+	}
+	resolved := specPath
+	if !filepath.IsAbs(resolved) && configDir != "" {
+		resolved = filepath.Join(configDir, resolved)
+	}
+	raw, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("localapi: read %s: %w", resolved, err)
+	}
+	var sp Spec
+	if err := yaml.Unmarshal(raw, &sp); err != nil {
+		return nil, fmt.Errorf("localapi: parse %s: %w", resolved, err)
+	}
+	if sp.OpenAPI == "" {
+		return nil, fmt.Errorf("localapi: %s missing required `openapi:` field (must be 3.0.x)", resolved)
+	}
+	if !strings.HasPrefix(sp.OpenAPI, "3.") {
+		return nil, fmt.Errorf("localapi: %s declares OpenAPI %q; only 3.x supported", resolved, sp.OpenAPI)
+	}
+	if len(sp.Paths) == 0 {
+		return nil, fmt.Errorf("localapi: %s has no paths", resolved)
+	}
+	sp.rawBytes = raw
+	return &sp, nil
+}
+
+// Endpoint is one resolved (path, method, operation) tuple ready to
+// become a tool. Builders walk the spec via Endpoints() and call
+// BuildTool for each.
+type Endpoint struct {
+	Path       string
+	Method     string // "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+	Operation  *operation
+}
+
+// Endpoints flattens the Spec into a list of (path, method, operation)
+// tuples sorted deterministically by (path, method) so tool registration
+// order is stable across restarts.
+//
+// Operations without an operationId are SKIPPED with a warning line —
+// without one we have nothing meaningful to name the tool. The caller
+// receives the warnings via the returned warns slice; main.go logs
+// them so operators see exactly which entries got dropped.
+func (s *Spec) Endpoints() (eps []Endpoint, warns []string) {
+	type entry struct {
+		path, method string
+		op           *operation
+	}
+	var raw []entry
+	for path, item := range s.Paths {
+		if item.Get != nil {
+			raw = append(raw, entry{path, "GET", item.Get})
+		}
+		if item.Post != nil {
+			raw = append(raw, entry{path, "POST", item.Post})
+		}
+		if item.Put != nil {
+			raw = append(raw, entry{path, "PUT", item.Put})
+		}
+		if item.Patch != nil {
+			raw = append(raw, entry{path, "PATCH", item.Patch})
+		}
+		if item.Delete != nil {
+			raw = append(raw, entry{path, "DELETE", item.Delete})
+		}
+	}
+	sort.SliceStable(raw, func(i, j int) bool {
+		if raw[i].path != raw[j].path {
+			return raw[i].path < raw[j].path
+		}
+		return raw[i].method < raw[j].method
+	})
+	for _, r := range raw {
+		if r.op.OperationID == "" {
+			warns = append(warns,
+				fmt.Sprintf("%s %s: missing operationId; skipped (loomcycle needs operationId to name the tool)",
+					r.method, r.path))
+			continue
+		}
+		eps = append(eps, Endpoint{Path: r.path, Method: r.method, Operation: r.op})
+	}
+	return eps, warns
+}

--- a/internal/tools/localapi/spec_test.go
+++ b/internal/tools/localapi/spec_test.go
@@ -1,0 +1,196 @@
+package localapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const minimalSpec = `
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /api/applications/{id}:
+    get:
+      operationId: get_application
+      summary: Fetch one application
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: patch_application
+      summary: Update an application
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cvText: {type: string}
+                coverLetterText: {type: string}
+  /api/research:
+    get:
+      operationId: list_research
+      summary: List research entries
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+`
+
+func writeSpec(t *testing.T, body string) (path, dir string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "openapi.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path, dir
+}
+
+func TestLoadSpec_Basic(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	sp, err := LoadSpec(path, "")
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	if sp.OpenAPI != "3.0.3" {
+		t.Errorf("OpenAPI = %q", sp.OpenAPI)
+	}
+	if len(sp.Paths) != 2 {
+		t.Errorf("Paths len = %d, want 2", len(sp.Paths))
+	}
+	if sp.Paths["/api/applications/{id}"].Get == nil {
+		t.Error("missing GET /api/applications/{id}")
+	}
+	if sp.Paths["/api/applications/{id}"].Patch == nil {
+		t.Error("missing PATCH /api/applications/{id}")
+	}
+	if sp.Paths["/api/research"].Get == nil {
+		t.Error("missing GET /api/research")
+	}
+}
+
+// Endpoints must be sorted deterministically (path then method) so
+// tool registration order is stable across restarts.
+func TestSpec_Endpoints_StableOrder(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	sp, _ := LoadSpec(path, "")
+	eps, warns := sp.Endpoints()
+	if len(warns) != 0 {
+		t.Errorf("unexpected warns: %v", warns)
+	}
+	// Expected order: /api/applications/{id} GET, /api/applications/{id} PATCH, /api/research GET
+	want := []struct{ path, method string }{
+		{"/api/applications/{id}", "GET"},
+		{"/api/applications/{id}", "PATCH"},
+		{"/api/research", "GET"},
+	}
+	if len(eps) != len(want) {
+		t.Fatalf("endpoints len = %d, want %d", len(eps), len(want))
+	}
+	for i, w := range want {
+		if eps[i].Path != w.path || eps[i].Method != w.method {
+			t.Errorf("ep[%d] = %s %s, want %s %s",
+				i, eps[i].Method, eps[i].Path, w.method, w.path)
+		}
+	}
+}
+
+// Operation without operationId surfaces a warning and is dropped.
+// Without the warning the operator wouldn't know why their endpoint
+// isn't reachable; without the drop we'd be unable to name the tool.
+func TestSpec_MissingOperationId(t *testing.T) {
+	body := `
+openapi: 3.0.0
+info: {title: x, version: x}
+paths:
+  /unnamed:
+    get:
+      summary: no operationId
+  /named:
+    get:
+      operationId: ok
+      summary: has it
+`
+	path, _ := writeSpec(t, body)
+	sp, err := LoadSpec(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	eps, warns := sp.Endpoints()
+	if len(eps) != 1 || eps[0].Operation.OperationID != "ok" {
+		t.Errorf("expected only the named endpoint to survive, got %v", eps)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "/unnamed") {
+		t.Errorf("expected one warning naming /unnamed: %v", warns)
+	}
+}
+
+// Missing required `openapi:` field is a fatal load error.
+func TestLoadSpec_MissingVersion(t *testing.T) {
+	path, _ := writeSpec(t, "info: {title: x, version: x}\npaths: {}")
+	if _, err := LoadSpec(path, ""); err == nil {
+		t.Fatal("expected error on missing openapi field")
+	}
+}
+
+// Non-3.x OpenAPI version is rejected — we don't support 2.0 (Swagger)
+// or hypothetical 4.0 in this MVP.
+func TestLoadSpec_RejectsNon3x(t *testing.T) {
+	path, _ := writeSpec(t, "openapi: 2.0\ninfo: {title: x, version: x}\npaths: {}")
+	_, err := LoadSpec(path, "")
+	if err == nil || !strings.Contains(err.Error(), "3.x") {
+		t.Errorf("expected 3.x-only error, got %v", err)
+	}
+}
+
+// Empty paths map: the spec is technically valid OpenAPI but useless
+// for our gateway; refuse loudly so the operator notices.
+func TestLoadSpec_RejectsEmptyPaths(t *testing.T) {
+	path, _ := writeSpec(t, "openapi: 3.0.0\ninfo: {title: x, version: x}\npaths: {}")
+	_, err := LoadSpec(path, "")
+	if err == nil || !strings.Contains(err.Error(), "no paths") {
+		t.Errorf("expected no-paths error, got %v", err)
+	}
+}
+
+// Missing file: error should name the resolved path so the operator
+// sees exactly where loomcycle looked.
+func TestLoadSpec_FileMissing(t *testing.T) {
+	_, err := LoadSpec(filepath.Join(t.TempDir(), "no-such-file.yaml"), "")
+	if err == nil || !strings.Contains(err.Error(), "no-such-file") {
+		t.Errorf("error should name the path: %v", err)
+	}
+}
+
+// Relative paths are resolved against configDir — same behaviour as
+// system_prompt_file. Operator's loomcycle.yaml can carry a relative
+// reference next to it.
+func TestLoadSpec_RelativePathResolution(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(minimalSpec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sp, err := LoadSpec("spec.yaml", dir)
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	if len(sp.Paths) != 2 {
+		t.Errorf("paths missing after relative-path load: %d", len(sp.Paths))
+	}
+}

--- a/internal/tools/localapi/tool.go
+++ b/internal/tools/localapi/tool.go
@@ -1,0 +1,304 @@
+package localapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// EndpointTool is one tool generated from an OpenAPI operation. The
+// model invokes it with a JSON body conforming to the synthesised
+// input schema; the tool forwards the call to BaseURL + path with the
+// agent-supplied bearer token.
+//
+// One tool per (path, method) — see (a) in package doc for design
+// rationale. The model sees a clear menu of named operations rather
+// than one generic "call" tool with an `endpoint` parameter; renamed
+// or removed endpoints become missing tools rather than silent 404s.
+//
+// Network policy:
+//   - The forward request goes to BaseURL via the standard net/http
+//     client; SSRF/private-IP defences from the HTTP built-in tool
+//     do NOT apply here. The operator must point this at a trusted
+//     host (their own application server, typically localhost or a
+//     known internal address).
+//   - HTTPClient may be overridden for tests; nil means use
+//     http.DefaultClient.
+//
+// Errors visible to the model:
+//   - Invalid JSON input → IsError tool_result, model can self-correct.
+//   - Missing required parameters → IsError, names the missing field.
+//   - 4xx/5xx from the upstream → IsError, body forwarded as text so
+//     the model sees the application's error shape (e.g. validation
+//     errors).
+//   - Transport failures (connection refused, DNS) → Go error from
+//     Execute (rare; surfaces as the loop's tool_result with the
+//     wrapper text).
+type EndpointTool struct {
+	ToolName    string                  // "<prefix>__<operationId>"
+	BaseURL     string                  // e.g. "http://localhost:3000"
+	Path        string                  // e.g. "/api/applications/{id}"
+	Method      string                  // "GET" | "POST" | ...
+	OpSummary   string
+	OpDescription string
+	Parameters  []parameter
+	HasBody     bool
+	BodySchema  *yaml.Node // raw JSON Schema (passed through to model)
+
+	HTTPClient *http.Client // optional; defaults to http.DefaultClient
+}
+
+// Name implements tools.Tool. Returns the assembled
+// "<prefix>__<operationId>" string the model sees.
+func (t *EndpointTool) Name() string { return t.ToolName }
+
+// Description implements tools.Tool. Combines the OpenAPI summary +
+// description + an explicit auth note so the model always knows it
+// must include `bearer`.
+func (t *EndpointTool) Description() string {
+	parts := []string{}
+	if t.OpSummary != "" {
+		parts = append(parts, t.OpSummary)
+	}
+	if t.OpDescription != "" {
+		parts = append(parts, t.OpDescription)
+	}
+	if len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%s %s", t.Method, t.Path))
+	}
+	parts = append(parts,
+		"Authentication: include the Bearer token from your prompt's auth preamble in the `bearer` field of every call.")
+	return strings.Join(parts, "\n\n")
+}
+
+// InputSchema implements tools.Tool. Synthesises a JSON Schema from
+// the OpenAPI parameters + requestBody + a required `bearer` field.
+//
+// Schema shape:
+//
+//	{
+//	  "type": "object",
+//	  "properties": {
+//	    "bearer":   {"type": "string", "description": "..."},
+//	    "<path-param>":  <param's schema>,
+//	    "<query-param>": <param's schema>,
+//	    "body":     <requestBody schema, if any>
+//	  },
+//	  "required": ["bearer", ...required-params, "body" if body required]
+//	}
+func (t *EndpointTool) InputSchema() json.RawMessage {
+	props := map[string]any{
+		"bearer": map[string]any{
+			"type":        "string",
+			"description": "Bearer token to forward as `Authorization: Bearer <value>`. Sourced from the Bearer token printed in your prompt's auth preamble.",
+		},
+	}
+	required := []string{"bearer"}
+
+	for _, p := range t.Parameters {
+		if p.In == "header" || p.In == "cookie" {
+			// Skip header/cookie parameters in the input schema —
+			// the only header we forward is Authorization (set from
+			// `bearer`). Cookies are not supported.
+			continue
+		}
+		schema := yamlNodeToJSON(p.Schema)
+		if schema == nil {
+			schema = map[string]any{"type": "string"}
+		}
+		// Augment the parameter schema with a description so the model
+		// knows where the param goes (path vs query) — useful when the
+		// OpenAPI desc was sparse.
+		if m, ok := schema.(map[string]any); ok {
+			d := p.Description
+			if d == "" {
+				d = fmt.Sprintf("%s parameter", p.In)
+			}
+			if _, exists := m["description"]; !exists {
+				m["description"] = d
+			}
+		}
+		props[p.Name] = schema
+		if p.Required {
+			required = append(required, p.Name)
+		}
+	}
+
+	if t.HasBody {
+		bodySchema := yamlNodeToJSON(t.BodySchema)
+		if bodySchema == nil {
+			bodySchema = map[string]any{"type": "object"}
+		}
+		props["body"] = bodySchema
+		// We treat the body as required only if the OpenAPI spec
+		// explicitly marked it so. Many specs default to false.
+		// (See Endpoint construction in loader.go for where the flag
+		// is propagated.)
+		// Required-ness is recorded on the EndpointTool by the loader.
+	}
+
+	full := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"required":             required,
+		"additionalProperties": false,
+	}
+	out, err := json.Marshal(full)
+	if err != nil {
+		// Schema construction is purely from operator-controlled
+		// input; failure is a programmer error, not runtime.
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return json.RawMessage(out)
+}
+
+// Execute implements tools.Tool. Validates input, builds the forward
+// HTTP request from the OpenAPI definition + supplied parameters, and
+// returns the upstream response.
+//
+// Errors are surfaced as IsError tool_results (recoverable by the
+// model) rather than Go errors (which would tear down the run). Only
+// transport-level failures bubble up as Go errors.
+func (t *EndpointTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+
+	bearer, _ := raw["bearer"].(string)
+	bearer = strings.TrimSpace(bearer)
+	if bearer == "" {
+		return tools.Result{
+			IsError: true,
+			Text:    "missing required field: bearer (the Authorization token from your prompt's auth preamble)",
+		}, nil
+	}
+
+	// Substitute path parameters into the URL template. url.PathEscape
+	// escapes special characters (including '/') so a hostile param
+	// value cannot break out of its path segment (e.g. `id=../admin`
+	// becomes `id=%2E%2E%2Fadmin` on the wire). OpenAPI path
+	// parameters are scoped to a single segment by default (style:
+	// simple); the strict-segment escape matches that contract.
+	urlPath := t.Path
+	for _, p := range t.Parameters {
+		if p.In != "path" {
+			continue
+		}
+		v, ok := raw[p.Name]
+		if !ok {
+			if p.Required {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("missing required path parameter %q", p.Name)}, nil
+			}
+			continue
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{"+p.Name+"}", url.PathEscape(fmt.Sprintf("%v", v)))
+	}
+
+	// Build query string from query parameters.
+	q := url.Values{}
+	for _, p := range t.Parameters {
+		if p.In != "query" {
+			continue
+		}
+		v, ok := raw[p.Name]
+		if !ok {
+			if p.Required {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("missing required query parameter %q", p.Name)}, nil
+			}
+			continue
+		}
+		q.Set(p.Name, fmt.Sprintf("%v", v))
+	}
+
+	// Build full URL.
+	full := strings.TrimRight(t.BaseURL, "/") + urlPath
+	if encoded := q.Encode(); encoded != "" {
+		full += "?" + encoded
+	}
+
+	// Build body if present.
+	var bodyReader io.Reader
+	if t.HasBody {
+		body, hasBody := raw["body"]
+		if hasBody && body != nil {
+			b, err := json.Marshal(body)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("could not marshal body: %s", err)}, nil
+			}
+			bodyReader = bytes.NewReader(b)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, t.Method, full, bodyReader)
+	if err != nil {
+		// Almost always a malformed URL; surface as IsError so the
+		// model sees the bad input.
+		return tools.Result{IsError: true, Text: fmt.Sprintf("build request: %s", err)}, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := t.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Transport-level failure — return as Go error so the loop's
+		// tool_result wrapping carries the message intact.
+		return tools.Result{IsError: true, Text: fmt.Sprintf("upstream request failed: %s", err)}, nil
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap, matches HTTP tool
+	if err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("read response: %s", err)}, nil
+	}
+
+	if resp.StatusCode >= 400 {
+		// Forward the upstream body to the model so it sees the
+		// application's error shape (validation errors, 401 hints,
+		// etc.) and can self-correct.
+		return tools.Result{
+			IsError: true,
+			Text:    fmt.Sprintf("upstream %s %s returned %d:\n%s", t.Method, t.Path, resp.StatusCode, string(respBody)),
+		}, nil
+	}
+
+	return tools.Result{Text: string(respBody)}, nil
+}
+
+// yamlNodeToJSON converts a yaml.Node to the equivalent
+// map[string]any/[]any/scalar tree that json.Marshal will turn into
+// proper JSON. Nil node → nil. Returns the converted value or nil if
+// the node is empty.
+//
+// We use yaml.Node's Decode into `interface{}` to leverage yaml.v3's
+// existing scalar resolution rules (ints stay ints, floats stay
+// floats, etc.) — the resulting tree round-trips through json.Marshal
+// cleanly.
+func yamlNodeToJSON(n *yaml.Node) any {
+	if n == nil {
+		return nil
+	}
+	var out any
+	if err := n.Decode(&out); err != nil {
+		return nil
+	}
+	return out
+}
+
+var _ tools.Tool = (*EndpointTool)(nil)

--- a/internal/tools/localapi/tool.go
+++ b/internal/tools/localapi/tool.go
@@ -184,11 +184,13 @@ func (t *EndpointTool) Execute(ctx context.Context, input json.RawMessage) (tool
 	}
 
 	// Substitute path parameters into the URL template. url.PathEscape
-	// escapes special characters (including '/') so a hostile param
-	// value cannot break out of its path segment (e.g. `id=../admin`
-	// becomes `id=%2E%2E%2Fadmin` on the wire). OpenAPI path
-	// parameters are scoped to a single segment by default (style:
-	// simple); the strict-segment escape matches that contract.
+	// escapes characters outside the unreserved set (which includes
+	// '.' but NOT '/'), so '/' becomes '%2F' on the wire. The dot is
+	// untouched, but it can't introduce a path-traversal step without
+	// a slash; `id=../admin` becomes `..%2Fadmin`, which the upstream
+	// router treats as one literal segment. OpenAPI path parameters
+	// are scoped to a single segment by default (style: simple); this
+	// escape matches that contract.
 	urlPath := t.Path
 	for _, p := range t.Parameters {
 		if p.In != "path" {

--- a/internal/tools/localapi/tool_test.go
+++ b/internal/tools/localapi/tool_test.go
@@ -315,6 +315,63 @@ func TestEndpointTool_InputSchemaShape(t *testing.T) {
 	}
 }
 
+// Two operationIds that normalise to the same string MUST NOT
+// silently collide in the dispatcher map. Without the collision
+// guard, both tools register but only one dispatches (whichever
+// the map iteration overwrote last) — the model sees both names in
+// its menu but invocation is non-deterministic.
+//
+// EMPIRICAL: removing the `if firstOpID, dup := seen[toolName]; dup`
+// branch from loader.go makes this test fail.
+func TestBuild_DetectsCollisionAfterNormalisation(t *testing.T) {
+	// Both '@' and '.' get normalised to '_' (only [A-Za-z0-9_-] survives).
+	// `op@user` and `op.user` both become `op_user` after normalisation.
+	body := `
+openapi: 3.0.0
+info: {title: x, version: x}
+paths:
+  /a:
+    get:
+      operationId: op@user
+      summary: at flavour
+  /b:
+    get:
+      operationId: op.user
+      summary: dot flavour
+`
+	path, _ := writeSpec(t, body)
+	out, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        "http://x",
+		ToolNamePrefix: "local",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Only ONE tool should survive the collision; the other becomes a
+	// warning. Stable order: spec.Endpoints() sorts by (path, method),
+	// so /a's op@user wins, /b's op.user is dropped.
+	if len(out) != 1 {
+		names := make([]string, len(out))
+		for i, tl := range out {
+			names[i] = tl.Name()
+		}
+		t.Fatalf("expected 1 tool after collision, got %d: %v", len(out), names)
+	}
+	if got := out[0].Name(); got != "local__op_user" {
+		t.Errorf("survivor tool name = %q, want local__op_user", got)
+	}
+	collided := false
+	for _, w := range warns {
+		if strings.Contains(w, "collides") && strings.Contains(w, "op.user") {
+			collided = true
+		}
+	}
+	if !collided {
+		t.Errorf("expected a collision warning naming op.user, got: %v", warns)
+	}
+}
+
 // Helper: parse spec, build tools, return the named one. Aborts the
 // test if the spec doesn't parse or the tool isn't found.
 func buildOneTool(t *testing.T, body, baseURL, opID string) (*EndpointTool, []string, error) {

--- a/internal/tools/localapi/tool_test.go
+++ b/internal/tools/localapi/tool_test.go
@@ -1,0 +1,342 @@
+package localapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubServerHandler captures the last request for assertion and returns
+// a fixed response. status defaults to 200; pass non-zero to override.
+type stubServerHandler struct {
+	gotMethod  string
+	gotPath    string
+	gotBearer  string
+	gotBody    []byte
+	gotQuery   string
+	respStatus int
+	respBody   string
+}
+
+func (s *stubServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.gotMethod = r.Method
+	// Prefer the raw (still-encoded) path so tests can assert on the
+	// wire-level escaping. Go decodes URL-encoded paths into URL.Path
+	// for handler convenience; URL.RawPath preserves the original form
+	// only when it differs from Path.
+	if r.URL.RawPath != "" {
+		s.gotPath = r.URL.RawPath
+	} else {
+		s.gotPath = r.URL.Path
+	}
+	s.gotQuery = r.URL.RawQuery
+	if v := r.Header.Get("Authorization"); v != "" {
+		s.gotBearer = v
+	}
+	s.gotBody, _ = io.ReadAll(r.Body)
+	status := s.respStatus
+	if status == 0 {
+		status = 200
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(s.respBody))
+}
+
+// End-to-end via a stub HTTP server: GET-by-path-param round-trip
+// includes the path substitution + the Authorization header.
+func TestEndpointTool_GetWithPathParam(t *testing.T) {
+	stub := &stubServerHandler{respBody: `{"id":"abc","cv":"x"}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"sk-test","id":"abc"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if stub.gotMethod != "GET" {
+		t.Errorf("upstream method = %s", stub.gotMethod)
+	}
+	if stub.gotPath != "/api/applications/abc" {
+		t.Errorf("upstream path = %q", stub.gotPath)
+	}
+	if stub.gotBearer != "Bearer sk-test" {
+		t.Errorf("upstream Authorization = %q", stub.gotBearer)
+	}
+	if !strings.Contains(res.Text, `"cv":"x"`) {
+		t.Errorf("response body lost: %q", res.Text)
+	}
+}
+
+// PATCH with a body: input.body is JSON-marshalled and sent. Bearer
+// goes into Authorization, NOT into the body.
+func TestEndpointTool_PatchWithBody(t *testing.T) {
+	stub := &stubServerHandler{respBody: `{"ok":true}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "patch_application")
+	res, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"tok","id":"app-1","body":{"cvText":"hello"}}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if stub.gotMethod != "PATCH" {
+		t.Errorf("method = %s", stub.gotMethod)
+	}
+	if stub.gotPath != "/api/applications/app-1" {
+		t.Errorf("path = %q", stub.gotPath)
+	}
+	gotBody := string(stub.gotBody)
+	if !strings.Contains(gotBody, `"cvText":"hello"`) {
+		t.Errorf("body not forwarded: %q", gotBody)
+	}
+	if strings.Contains(gotBody, "bearer") || strings.Contains(gotBody, "tok") {
+		t.Errorf("bearer leaked into body: %q", gotBody)
+	}
+}
+
+// Query parameters are URL-encoded and appended.
+func TestEndpointTool_QueryParam(t *testing.T) {
+	stub := &stubServerHandler{respBody: `[]`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "list_research")
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","date":"2026-05-05"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if stub.gotPath != "/api/research" {
+		t.Errorf("path = %q", stub.gotPath)
+	}
+	if !strings.Contains(stub.gotQuery, "date=2026-05-05") {
+		t.Errorf("query missing date param: %q", stub.gotQuery)
+	}
+}
+
+// Missing bearer is a recoverable error — surfaces as IsError so the
+// model can read the message and try again. Critically, NO request
+// goes upstream.
+func TestEndpointTool_MissingBearer(t *testing.T) {
+	stub := &stubServerHandler{}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"id":"abc"}`))
+	if !res.IsError || !strings.Contains(res.Text, "bearer") {
+		t.Errorf("expected bearer-missing IsError, got %+v", res)
+	}
+	if stub.gotMethod != "" {
+		t.Error("no upstream call should be made when bearer is missing")
+	}
+}
+
+// Missing required path parameter is recoverable IsError; no upstream
+// call (would result in malformed URL).
+func TestEndpointTool_MissingRequiredPathParam(t *testing.T) {
+	stub := &stubServerHandler{}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "id") {
+		t.Errorf("expected missing-id IsError, got %+v", res)
+	}
+	if stub.gotMethod != "" {
+		t.Error("no upstream call should happen with missing path param")
+	}
+}
+
+// Upstream 4xx/5xx is forwarded as IsError WITH the response body so
+// the model can see the application's validation/error shape and
+// self-correct.
+func TestEndpointTool_Upstream4xxForwarded(t *testing.T) {
+	stub := &stubServerHandler{respStatus: 422, respBody: `{"error":"missing field cvText"}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "patch_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","id":"a","body":{}}`))
+	if !res.IsError {
+		t.Error("expected IsError for upstream 4xx")
+	}
+	if !strings.Contains(res.Text, "422") || !strings.Contains(res.Text, "missing field cvText") {
+		t.Errorf("upstream body not forwarded: %q", res.Text)
+	}
+}
+
+// Path param with a slash gets percent-encoded so it stays inside the
+// path segment (defends against path injection from a hostile param
+// value, even though our agents are operator-trusted).
+func TestEndpointTool_PathParamEscaping(t *testing.T) {
+	stub := &stubServerHandler{respBody: "ok"}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","id":"a/b/../etc/passwd"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// %2F encoding for the slash means the path segment stays intact.
+	if !strings.Contains(stub.gotPath, "a%2Fb%2F..%2Fetc%2Fpasswd") {
+		t.Errorf("path not escaped: %q", stub.gotPath)
+	}
+}
+
+// Loader tests: the Build entry point produces the right number of
+// tools, applies the tool name prefix, and propagates warnings.
+func TestBuild_GeneratesToolsWithPrefix(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	tools, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        "http://localhost:3000",
+		ToolNamePrefix: "myapp",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected warns: %v", warns)
+	}
+	want := map[string]bool{
+		"myapp__get_application":   true,
+		"myapp__patch_application": true,
+		"myapp__list_research":     true,
+	}
+	for _, tl := range tools {
+		if !want[tl.Name()] {
+			t.Errorf("unexpected tool: %s", tl.Name())
+		}
+		delete(want, tl.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("missing tools: %v", want)
+	}
+}
+
+// Default prefix is "local" when ToolNamePrefix is empty.
+func TestBuild_DefaultPrefix(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	tools, _, err := Build(Config{
+		SpecPath: path,
+		BaseURL:  "http://localhost",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tl := range tools {
+		if !strings.HasPrefix(tl.Name(), "local__") {
+			t.Errorf("default prefix not applied: %q", tl.Name())
+		}
+	}
+}
+
+// Invalid prefix (slash, space, etc.) is rejected — the resulting tool
+// name would be unaddressable from agent allow-lists.
+func TestBuild_InvalidPrefixRejected(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	for _, bad := range []string{"my app", "my/app", "my::app", ""} {
+		if bad == "" {
+			continue // empty defaults to "local"; covered separately
+		}
+		_, _, err := Build(Config{
+			SpecPath:       path,
+			BaseURL:        "http://localhost",
+			ToolNamePrefix: bad,
+		}, "")
+		if err == nil {
+			t.Errorf("prefix %q should be rejected", bad)
+		}
+	}
+}
+
+// Build returns a fatal error when SpecPath or BaseURL is missing.
+func TestBuild_RequiresSpecAndBaseURL(t *testing.T) {
+	if _, _, err := Build(Config{BaseURL: "x"}, ""); err == nil {
+		t.Error("expected error when SpecPath empty")
+	}
+	path, _ := writeSpec(t, minimalSpec)
+	if _, _, err := Build(Config{SpecPath: path}, ""); err == nil {
+		t.Error("expected error when BaseURL empty")
+	}
+}
+
+// Input-schema sanity: the synthesised JSON Schema requires `bearer`
+// plus all `required: true` parameters. The model sees a clear menu
+// of fields with descriptions.
+func TestEndpointTool_InputSchemaShape(t *testing.T) {
+	tool, _, _ := buildOneTool(t, minimalSpec, "http://x", "patch_application")
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema(), &schema); err != nil {
+		t.Fatalf("schema not valid JSON: %v", err)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["bearer"]; !ok {
+		t.Error("schema missing `bearer` field")
+	}
+	if _, ok := props["id"]; !ok {
+		t.Error("schema missing path-param `id` field")
+	}
+	if _, ok := props["body"]; !ok {
+		t.Error("schema missing `body` field")
+	}
+	required, _ := schema["required"].([]any)
+	hasBearer, hasID := false, false
+	for _, r := range required {
+		if r == "bearer" {
+			hasBearer = true
+		}
+		if r == "id" {
+			hasID = true
+		}
+	}
+	if !hasBearer || !hasID {
+		t.Errorf("required missing bearer or id: %v", required)
+	}
+}
+
+// Helper: parse spec, build tools, return the named one. Aborts the
+// test if the spec doesn't parse or the tool isn't found.
+func buildOneTool(t *testing.T, body, baseURL, opID string) (*EndpointTool, []string, error) {
+	t.Helper()
+	path, _ := writeSpec(t, body)
+	out, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        baseURL,
+		ToolNamePrefix: "local",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, tl := range out {
+		et, ok := tl.(*EndpointTool)
+		if !ok {
+			continue
+		}
+		if et.ToolName == "local__"+opID {
+			return et, warns, nil
+		}
+	}
+	t.Fatalf("tool local__%s not found in %d generated tools", opID, len(out))
+	return nil, nil, nil
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -65,6 +65,30 @@ func (d *Dispatcher) Specs(order []Tool) []providers.ToolSpec {
 	return out
 }
 
+// ctxKeyAgentTools is the context key under which the runtime stores
+// the calling agent's effective allowed_tools list (after agent + caller
+// narrowing). Tools that need to apply secondary subset checks (like
+// the built-in Skill tool, which validates skill `allowed-tools` ⊆
+// agent `allowed_tools` at call time) read it via AgentTools.
+type ctxKeyAgentTools struct{}
+
+// WithAgentTools attaches the agent's effective tool names to ctx. The
+// HTTP server calls this once per run before invoking the loop so any
+// tool that resolves dynamic permissions has the same view of "what
+// the agent can use."
+func WithAgentTools(ctx context.Context, names []string) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentTools{}, names)
+}
+
+// AgentTools returns the agent's effective tool names from ctx, or
+// nil if not attached. Returning nil from a tool that requires this
+// list should cause the tool to refuse with a clear "misconfigured
+// runtime" message.
+func AgentTools(ctx context.Context) []string {
+	v, _ := ctx.Value(ctxKeyAgentTools{}).([]string)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names return an
 // error result (the model can self-correct) rather than a hard error.
 func (d *Dispatcher) Execute(ctx context.Context, name string, input json.RawMessage) Result {

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -135,6 +135,30 @@ mcp_servers:
   #   headers:
   #     Authorization: "Bearer ${LOOMCYCLE_AUTH_TOKEN}"
 
+# ─── Local API MCP gateway (v0.4.0+) ─────────────────────────────────
+# Reads an OpenAPI 3.0 spec at boot and exposes one typed tool per
+# operation, named `<prefix>__<operationId>`. Forwards calls to
+# base_url with the agent's `bearer` field as Authorization.
+#
+# Replaces the curl-shaped HTTP-tool pattern: an agent that previously
+# called `HTTP({method:"PATCH", url:"$BASE_URL/api/applications/...",
+# headers:{Authorization:"Bearer ..."}, body:{...}})` instead calls
+# `local__patch_application({bearer:"...", id:"...", body:{...}})` —
+# typed, schema-validated, and rename-safe.
+#
+# Constraints:
+#   - Inline schemas only ($ref is NOT resolved). Bundle your spec
+#     before pointing loomcycle at it (swagger-cli bundle, redocly
+#     bundle, etc.).
+#   - JSON request/response bodies only.
+#   - Trust model: this gateway is pointed at YOUR application server;
+#     SSRF and private-IP defences from the HTTP tool do not apply.
+#     Don't point base_url at attacker-controlled hosts.
+# local_api:
+#   spec: openapi.yaml          # relative to this YAML's directory
+#   base_url: http://localhost:3000
+#   tool_name_prefix: local     # tools become mcp__-style: local__<opId>
+
 # ─── Concurrency ──────────────────────────────────────────────────────
 # Caps total in-flight runs across all agents. Bursts above the cap
 # queue up to max_queue_depth for queue_timeout_ms before returning


### PR DESCRIPTION
## Summary

Three v0.4.0 pieces, in the A→C→B order confirmed for the SDK-replacement push:

- **A) Agent tool** (sub-agents) — unblocks cv-batch-adapter and Phase C migration. Definition-authoritative trust model: each agent's YAML allow-list is its own authority. Sub-runs persist as separate sessions; depth capped at 3.
- **C) Skill tool** (Approach B, dynamic) — counterpart to the static bundling shipped in #10. Shares the same `internal/skills` loader and the same subset-check semantics, applied at tool-call time via context-passed agent tools.
- **B) Local API MCP gateway** — OpenAPI-derived typed tools that replace the curl-shaped HTTP-tool pattern. One tool per operation, schema-validated input, agent-supplied bearer forwarded as Authorization. Path-param escaping defends against segment break-out.

## Key design decisions (locked)

| Question | Choice |
|---|---|
| Sub-agent allow-list | Definition-authoritative (each agent self-describes) |
| Sub-agent concurrency | Share parent's slot (no fresh acquire — avoids deadlock at low caps) |
| Sub-agent transcripts | Separate session per sub-call, retrievable via `/v1/sessions/{id}/transcript` |
| Skill tool agent-tools source | `tools.WithAgentTools(ctx)` (per-run via context, not struct field) |
| Local-API spec source | OpenAPI 3.0 file path (no host-side discovery) |
| Local-API tool granularity | One tool per `(path, method)`, named `<prefix>__<operationId>` |
| Local-API auth | Bearer carried by agent in `bearer` field; gateway forwards verbatim |

## Files

- `internal/tools/builtin/agent.go` (+208 LOC), `agent_test.go` (12 tests)
- `internal/tools/builtin/skill.go` (+167 LOC), `skill_test.go` (9 tests)
- `internal/api/http/agent_subagent_test.go` (3 integration tests)
- `internal/api/http/server.go` — `runSubAgent`, AgentTool registration in New()
- `internal/tools/tool.go` — `WithAgentTools` / `AgentTools` ctx helpers (and `Matches` already exported in #10)
- `internal/tools/localapi/{spec,tool,loader}.go` (+642 LOC), `{spec,tool}_test.go` (20 tests)
- `internal/config/config.go` — `LocalAPIConfig` + `ConfigDir()`
- `cmd/loomcycle/main.go` — wire SkillTool, AgentTool (via Server.New), localapi.Build
- `loomcycle.example.yaml` — documented `local_api:` block with trust note

## Test plan

- [x] `go test ./...` — full sweep, all packages green
- [x] 12 unit tests for Agent tool (input validation, depth guard, errors)
- [x] 3 end-to-end integration tests for sub-agents (round-trip, off-policy block, unknown child)
- [x] 9 unit tests for Skill tool (subset check both directions, glob composition, hints)
- [x] 8 spec tests + 12 tool tests for localapi (load + parse, deterministic ordering, all forward shapes, path injection)
- [x] Empirical proofs: depth guard, skill subset check, path escape (each test demonstrably fails when its safeguard is removed)

## Trust notes

- **Sub-agents**: parent's "Agent" tool grant is the gate. Child gets only what its own YAML declares. No cross-bleed (sub events don't appear in parent's stream; they go to the sub's own transcript).
- **Skill tool**: enforces skill `allowed-tools` ⊆ agent `allowed_tools` at tool-call time, mirroring the config-load check for static bundling.
- **Local API gateway**: deliberately bypasses the SSRF/private-IP defences. Operator-supplied `base_url` MUST point at a known internal host. Bearer token never enters the request body — Authorization-only.

## Followups (not in this PR)

- jobs-search-agent: enable the Agent tool in cv-batch-adapter (already declared in sample.yaml's `[HTTP, Agent]`).
- jobs-search-agent: optionally migrate cv-adapter family to local-api gateway tools (drop HTTP from their allowed_tools once confidence is built).
- v0.4.x: SIGHUP hot-reload of skills + OpenAPI spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)