### PR TITLE
feat(v0.4.0): agent tracking + cancel API (user_id, agent_id, cascade)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
+	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -105,6 +106,18 @@ func main() {
 		HostAllowlist:        staticHosts,
 		PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,
 	}
+	// Skill tool reuses the same name→body registry that the static
+	// bundling path (Approach A in internal/config) uses. Loading once
+	// at boot keeps the in-memory map authoritative — SIGHUP-style
+	// hot-reload of skills is a future enhancement.
+	skillSet, err := skills.LoadSet(cfg.Env.SkillsRoot)
+	if err != nil {
+		log.Fatalf("skills: %v", err)
+	}
+	if cfg.Env.SkillsRoot != "" {
+		log.Printf("skills: loaded %d from %s", len(skillSet.Names()), cfg.Env.SkillsRoot)
+	}
+
 	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},
 		&builtin.Write{Root: cfg.Env.WriteRoot},
@@ -113,6 +126,7 @@ func main() {
 		&builtin.WebFetch{HTTP: httpTool},
 		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
+		&builtin.SkillTool{Set: skillSet},
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -36,6 +36,7 @@ import (
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+	"github.com/denn-gubsky/loomcycle/internal/tools/localapi"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 	mcphttp "github.com/denn-gubsky/loomcycle/internal/tools/mcp/http"
 	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
@@ -127,6 +128,28 @@ func main() {
 		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
 		&builtin.SkillTool{Set: skillSet},
+	}
+
+	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
+	// in loomcycle.yaml, parse the OpenAPI spec and register one tool
+	// per operation. Each tool forwards calls to local_api.base_url
+	// with the agent's `bearer` field as Authorization. Replaces the
+	// curl-shaped HTTP-tool pattern Phase B agents currently use.
+	if cfg.LocalAPI.SpecPath != "" {
+		laTools, laWarns, err := localapi.Build(localapi.Config{
+			SpecPath:       cfg.LocalAPI.SpecPath,
+			BaseURL:        cfg.LocalAPI.BaseURL,
+			ToolNamePrefix: cfg.LocalAPI.ToolNamePrefix,
+		}, cfg.ConfigDir())
+		if err != nil {
+			log.Printf("local-api gateway disabled: %v", err)
+		} else {
+			for _, w := range laWarns {
+				log.Printf("local-api: %s", w)
+			}
+			log.Printf("local-api: registered %d tools from %s", len(laTools), cfg.LocalAPI.SpecPath)
+			allTools = append(allTools, laTools...)
+		}
 	}
 	if cfg.Env.ReadRoot == "" {
 		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -1,0 +1,308 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// scriptedProvider returns a different event sequence per call. Used by
+// sub-agent tests where parent + child runs need different scripted
+// responses (parent: tool_call to Agent then text after tool_result;
+// child: text + done).
+type scriptedProvider struct {
+	calls    atomic.Int32
+	scripts  [][]providers.Event
+	defaultS []providers.Event // returned for any call past len(scripts)
+}
+
+func (s *scriptedProvider) ID() string { return "scripted" }
+func (s *scriptedProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (s *scriptedProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	idx := int(s.calls.Add(1)) - 1
+	var events []providers.Event
+	if idx < len(s.scripts) {
+		events = s.scripts[idx]
+	} else {
+		events = s.defaultS
+	}
+	ch := make(chan providers.Event, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// End-to-end: a parent agent invokes the Agent tool with {name: "child",
+// prompt: "hi"}; the child runs, returns text; the parent's loop sees
+// the tool_result and emits final text. Verifies:
+//
+//   - Sub-agent runs as a SEPARATE session (own session_id) so its
+//     transcript is independently retrievable.
+//   - The parent's tool_result text contains the child's FinalText.
+//   - The child's full event sequence (started/text/usage/done) lands
+//     in the child's transcript, NOT the parent's stream.
+//   - Parent only sees its own events plus the wrapping tool_call /
+//     tool_result frames.
+func TestSubAgentRoundTrip_ParentSeesChildOutput(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {
+				Model:        "stub-model",
+				AllowedTools: []string{"Agent"},
+				SystemPrompt: "you are the parent",
+			},
+			"child": {
+				Model:        "stub-model",
+				AllowedTools: []string{},
+				SystemPrompt: "you are the child",
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	// Provider script:
+	//   call 1 = parent's first iter: emit a tool_call to Agent, then done(tool_use).
+	//   call 2 = child's only iter: emit text + done(end_turn).
+	//   call 3 = parent's second iter (after tool_result): emit final text + done.
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// 1) parent → tool_call(Agent)
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_parent_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"say hello briefly"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 2}},
+			},
+			// 2) child → final text + end_turn
+			{
+				{Type: providers.EventText, Text: "child says hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 5, OutputTokens: 4}},
+			},
+			// 3) parent → final wrap-up text + end_turn
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 12, OutputTokens: 3}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// Parent stream MUST contain the tool_call and a tool_result with the
+	// child's text. The child's intermediate "child says hi" text should
+	// NOT appear as a parent text frame — only as the tool_result.
+	if !strings.Contains(bodyStr, "event: tool_call") {
+		t.Errorf("parent stream missing tool_call frame:\n%s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "event: tool_result") {
+		t.Errorf("parent stream missing tool_result frame:\n%s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "child says hi") {
+		t.Errorf("parent stream missing child's output text:\n%s", bodyStr)
+	}
+
+	// Two sessions should exist now: parent + child. Parent's session
+	// is announced in the SSE stream; child's session is implicit.
+	parentSessionID := extractSessionID(bodyStr)
+	if parentSessionID == "" {
+		t.Fatalf("could not parse parent session_id from stream:\n%s", bodyStr)
+	}
+
+	parentTranscript, err := st.GetTranscript(context.Background(), parentSessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Parent transcript should NOT contain a separate "text" frame for
+	// "child says hi" — only the tool_result wrapping it.
+	for _, ev := range parentTranscript {
+		if ev.Type == "text" && strings.Contains(string(ev.Payload), "child says hi") {
+			t.Errorf("child text leaked into parent stream as a parent text frame: %s", string(ev.Payload))
+		}
+	}
+
+	// Find the child's session by listing all sessions and picking the
+	// one with agent="child". The store doesn't expose ListSessions
+	// publicly, so we approximate: try GetTranscript on a synthesised
+	// ID won't work. Instead we cross-check via the parent's tool_result
+	// containing the child's output.
+	foundToolResult := false
+	for _, ev := range parentTranscript {
+		if ev.Type == "tool_result" && strings.Contains(string(ev.Payload), "child says hi") {
+			foundToolResult = true
+		}
+	}
+	if !foundToolResult {
+		t.Error("parent transcript should record the tool_result with child's output")
+	}
+}
+
+// Regression: a parent without "Agent" in its allowed_tools cannot call
+// the Agent tool — the dispatcher refuses. The model would see a
+// "tool not found" tool_result. This locks the per-agent gate.
+func TestSubAgent_ParentWithoutAgentToolCannotSpawn(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"locked": {
+				Model:        "stub-model",
+				AllowedTools: []string{}, // no Agent
+				SystemPrompt: "you cannot spawn",
+			},
+			"child": {
+				Model:        "stub-model",
+				AllowedTools: []string{},
+				SystemPrompt: "you are the child",
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// "locked" agent attempts to call Agent (a hypothetical model
+			// that ignores the tool list). The dispatcher should refuse.
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_locked_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			// After tool_result (which is "tool not found"), wrap up.
+			{
+				{Type: providers.EventText, Text: "ok, done"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+		},
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"locked","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "tool not found") {
+		t.Errorf("expected 'tool not found' tool_result for an off-policy Agent call:\n%s", body)
+	}
+	// And critically: NO sub-agent text should appear.
+	if strings.Contains(string(body), "child says hi") {
+		t.Error("blocked Agent call should not have spawned the child")
+	}
+}
+
+// Calling Agent with an unknown sub-agent name surfaces the error
+// through the IsError tool_result so the parent's model can self-correct.
+func TestSubAgent_UnknownChildName(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {
+				Model:        "stub-model",
+				AllowedTools: []string{"Agent"},
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"does-not-exist","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			{
+				{Type: providers.EventText, Text: "I'll move on"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+		},
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if !strings.Contains(string(body), "unknown sub-agent") {
+		t.Errorf("expected 'unknown sub-agent' error, got:\n%s", body)
+	}
+	// The parent run should still complete cleanly — this is a tool
+	// error, not a run-failing error.
+	if !strings.Contains(string(body), "I'll move on") {
+		t.Error("parent should have continued after the IsError tool_result")
+	}
+}

--- a/internal/api/http/agent_tracking_test.go
+++ b/internal/api/http/agent_tracking_test.go
@@ -249,6 +249,87 @@ func TestRuns_RejectsDuplicateActiveAgentID(t *testing.T) {
 	close(prov.release)
 }
 
+// REGRESSION: a 409 from the duplicate-active path MUST NOT leave the
+// just-created run row at status=running. The handler creates a
+// session+run BEFORE registering with the cancel registry; a registry
+// collision was previously orphaning that row at status=running for
+// the heartbeat sweeper to clean up later — polluting
+// ListActiveRunsByUser in the meantime.
+//
+// EMPIRICAL: removing the s.finishRunFailedReason call on the ErrInUse
+// branch of handleRuns regresses this test (the row stays at running).
+func TestRuns_DuplicateActiveAgentID_DoesNotLeakRunningRow(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &pausableProvider{release: make(chan struct{}), finalText: "ok"}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// First run: kick off and wait for registry presence.
+	go func() {
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","user_id":"alice","agent_id":"a_dup_leak","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	waitForRegistry(t, srv, "a_dup_leak", 2*time.Second)
+
+	// Second run with same agent_id → 409.
+	resp2, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","user_id":"alice","agent_id":"a_dup_leak","segments":[{"role":"user","content":[{"type":"trusted-text","text":"y"}]}]}`,
+	))
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 409 {
+		t.Fatalf("status = %d, want 409", resp2.StatusCode)
+	}
+
+	// At this point Alice should have exactly ONE running row (the
+	// first one) — NOT two. The second run's row, created before the
+	// registry collision was detected, must have been transitioned
+	// to status=failed.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		runs, _ := srv.store.ListActiveRunsByUser(context.Background(), "alice", "")
+		failedCount := 0
+		runningCount := 0
+		for _, r := range runs {
+			switch r.Status {
+			case "running":
+				runningCount++
+			case "failed":
+				failedCount++
+			}
+		}
+		// We expect: 1 running (the live first run) + 1 failed (the
+		// 409-rejected second). If we see 2 running, the leak is back.
+		if runningCount == 1 && failedCount == 1 {
+			break
+		}
+		if runningCount > 1 {
+			t.Fatalf("BLOCKING: %d running rows for alice, expected 1 (the 409 leaked a row)", runningCount)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Sanity: there should be at least one failed row with the
+	// "agent_id collision" reason.
+	allRuns, _ := srv.store.ListActiveRunsByUser(context.Background(), "alice", "failed")
+	foundCollision := false
+	for _, r := range allRuns {
+		if strings.Contains(r.ErrorMsg, "agent_id collision") {
+			foundCollision = true
+		}
+	}
+	if !foundCollision {
+		t.Errorf("expected a failed row with 'agent_id collision' error, got: %+v", allRuns)
+	}
+
+	close(prov.release)
+}
+
 // Cancelling a running run via POST /v1/agents/{id}/cancel writes
 // status=cancelled (NOT failed) in the store. The cause-aware path
 // in finishRunWithCancel discriminates API-cancel from client-disconnect.

--- a/internal/api/http/agent_tracking_test.go
+++ b/internal/api/http/agent_tracking_test.go
@@ -1,0 +1,669 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// pausableProvider blocks inside Call() until release is signalled OR
+// ctx is cancelled. Used by cancel tests to give an external cancel
+// request time to fire before the loop's response stream completes.
+type pausableProvider struct {
+	release    chan struct{}
+	ctxFired   atomic.Bool
+	finalText  string
+}
+
+func (p *pausableProvider) ID() string { return "pausable" }
+func (p *pausableProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *pausableProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event, 4)
+	go func() {
+		defer close(ch)
+		select {
+		case <-p.release:
+			// Released — emit a normal completion.
+			ch <- providers.Event{Type: providers.EventText, Text: p.finalText}
+			ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+		case <-ctx.Done():
+			// Cancelled — record so tests can assert and emit nothing
+			// further. The driver's normal contract is to close the
+			// channel; the loop sees zero events and treats it as the
+			// iteration ending without text or done.
+			p.ctxFired.Store(true)
+		}
+	}()
+	return ch, nil
+}
+
+// makeServer builds a Server with a fresh sqlite store, semaphore, and
+// stub provider — the common boilerplate every test below shares.
+func makeServer(t *testing.T, prov providers.Provider, cfg *config.Config) (*Server, string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "tracking.db")
+	st, err := storesqlite.Open(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(8, 8, time.Second), st)
+	return srv, dbPath
+}
+
+func makeBaseConfig() *config.Config {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model", AllowedTools: []string{}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 8, MaxQueueDepth: 8, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	return cfg
+}
+
+// extractAgentID parses the SSE body for the v0.4 `event: agent` frame
+// and returns the agent_id field. Tests use this to discover the
+// generated id when the request didn't supply one.
+func extractAgentID(body string) string {
+	const marker = "event: agent\ndata: "
+	i := strings.Index(body, marker)
+	if i < 0 {
+		return ""
+	}
+	tail := body[i+len(marker):]
+	end := strings.Index(tail, "\n")
+	if end < 0 {
+		return ""
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(tail[:end]), &payload); err != nil {
+		return ""
+	}
+	if v, ok := payload["agent_id"].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// POST /v1/runs with a caller-supplied agent_id announces it in the
+// event: agent SSE frame so the caller can confirm it round-tripped
+// (and so adapter UIs can wire UI tracking from a single source).
+func TestRuns_AcceptsAgentID_AnnouncesInAgentEvent(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","user_id":"alice","agent_id":"a_caller","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	got := extractAgentID(string(body))
+	if got != "a_caller" {
+		t.Errorf("event:agent did not announce caller's agent_id: got %q, want a_caller\nbody:\n%s", got, body)
+	}
+}
+
+// When agent_id is omitted, loomcycle generates one and announces it.
+func TestRuns_GeneratesAgentIDWhenOmitted(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := extractAgentID(string(body))
+	if !strings.HasPrefix(got, "a_") {
+		t.Errorf("generated agent_id should be a_-prefixed, got %q", got)
+	}
+	if len(got) != 18 {
+		t.Errorf("generated agent_id length = %d, want 18 (a_ + 16 hex)", len(got))
+	}
+}
+
+// Invalid charset on user_id or agent_id is a 400 — guards against
+// malformed input reaching SQL queries or registry keys.
+func TestRuns_RejectsInvalidIdent(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	for _, badField := range []string{
+		`"user_id":"has space"`,
+		`"agent_id":"has/slash"`,
+		`"user_id":"` + strings.Repeat("a", 200) + `"`,
+	} {
+		body := `{"agent":"default",` + badField + `,"segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+		if resp.StatusCode != 400 {
+			t.Errorf("body %s → status %d, want 400", badField, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}
+
+// Two concurrent runs with the same agent_id: the second 409s. Locks
+// in the registry's ErrInUse semantics at the HTTP layer.
+//
+// EMPIRICAL: removing the `if errors.Is(regErr, cancel.ErrInUse)`
+// branch in handleRuns sends both runs through; the second would either
+// crash on the registry's silent overwrite or run normally — either
+// way this test fails.
+func TestRuns_RejectsDuplicateActiveAgentID(t *testing.T) {
+	cfg := makeBaseConfig()
+	// Pausable provider so the first run holds the registry slot for
+	// the duration of the test.
+	prov := &pausableProvider{
+		release:   make(chan struct{}),
+		finalText: "ok",
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// First run: kick off but DON'T release. We poll for the run to
+	// appear in the registry to avoid racing the request.
+	go func() {
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","agent_id":"a_dup","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	// Wait until the registry has the entry.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, ok := srv.cancelReg.Get("a_dup"); ok {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if _, ok := srv.cancelReg.Get("a_dup"); !ok {
+		t.Fatal("first run did not register within the deadline")
+	}
+
+	// Second run with the same agent_id should 409.
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","agent_id":"a_dup","segments":[{"role":"user","content":[{"type":"trusted-text","text":"y"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 409 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 409\nbody: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "agent_id_in_use") {
+		t.Errorf("expected agent_id_in_use code, got: %s", body)
+	}
+
+	// Release the first run so the test exits cleanly.
+	close(prov.release)
+}
+
+// Cancelling a running run via POST /v1/agents/{id}/cancel writes
+// status=cancelled (NOT failed) in the store. The cause-aware path
+// in finishRunWithCancel discriminates API-cancel from client-disconnect.
+//
+// EMPIRICAL: reverting finishRunWithCancel to call finishRun directly
+// (skipping the cause check) makes this test fail — the run would land
+// at status=failed (because runErr is ctx.Canceled) instead of cancelled.
+func TestCancel_RunningRun_WritesCancelledStatus(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &pausableProvider{release: make(chan struct{})}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Kick off a slow run.
+	go func() {
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"default","user_id":"u","agent_id":"a_x","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	waitForRegistry(t, srv, "a_x", 2*time.Second)
+
+	// Cancel.
+	cancelResp, err := http.Post(ts.URL+"/v1/agents/a_x/cancel", "application/json",
+		strings.NewReader(`{"reason":"user_clicked_stop"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != 200 {
+		body, _ := io.ReadAll(cancelResp.Body)
+		t.Fatalf("cancel status = %d\nbody: %s", cancelResp.StatusCode, body)
+	}
+
+	// Wait for the run to terminate. Polling the registry isn't a
+	// good synchronization point — Cancel deletes the entry IMMEDIATELY
+	// (before the run goroutine has finalized the DB row). Instead we
+	// poll the DB directly until status leaves "running", then assert
+	// the terminal status. The deadline is generous because on the
+	// loaded test runner the goroutine schedule can stretch.
+	deadline := time.Now().Add(2 * time.Second)
+	var run = struct {
+		Status     string
+		StopReason string
+	}{}
+	for time.Now().Before(deadline) {
+		got, err := srv.store.GetRunByAgentID(context.Background(), "a_x")
+		if err == nil && got.Status != "running" {
+			run.Status = string(got.Status)
+			run.StopReason = got.StopReason
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if run.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled (cause-aware path didn't fire)", run.Status)
+	}
+	if !strings.Contains(run.StopReason, "user_clicked_stop") {
+		t.Errorf("stop_reason = %q, want it to contain user_clicked_stop", run.StopReason)
+	}
+}
+
+// Cancel of an unknown agent_id (never seen) returns 404.
+func TestCancel_UnknownAgentID_404(t *testing.T) {
+	cfg := makeBaseConfig()
+	srv, _ := makeServer(t, &scriptedProvider{}, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, _ := http.Post(ts.URL+"/v1/agents/a_nope/cancel", "application/json", strings.NewReader(`{}`))
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404\nbody: %s", resp.StatusCode, body)
+	}
+}
+
+// Cancel of a finished run is idempotent: returns 200 with cancelled=false
+// and the existing terminal status. Lets retrying clients converge.
+func TestCancel_AlreadyFinished_Idempotent(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Run completes immediately.
+	resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","agent_id":"a_done","user_id":"u","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Cancel after termination.
+	cancelResp, _ := http.Post(ts.URL+"/v1/agents/a_done/cancel", "application/json", strings.NewReader(`{}`))
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != 200 {
+		body, _ := io.ReadAll(cancelResp.Body)
+		t.Errorf("status = %d, want 200 idempotent\nbody: %s", cancelResp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(cancelResp.Body)
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["cancelled"] != false {
+		t.Errorf("cancelled = %v, want false (already terminated)", got["cancelled"])
+	}
+	if got["status"] != "completed" {
+		t.Errorf("status echo = %v, want completed", got["status"])
+	}
+}
+
+// GET /v1/agents/{id} returns the run's current status and surfaces
+// the live flag indicating registry presence.
+func TestGetAgent_ReturnsCurrentStatus(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 5}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","agent_id":"a_get","user_id":"alice","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// After completion, GET returns the terminal record.
+	getResp, _ := http.Get(ts.URL + "/v1/agents/a_get")
+	defer getResp.Body.Close()
+	if getResp.StatusCode != 200 {
+		body, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("status = %d\nbody: %s", getResp.StatusCode, body)
+	}
+	var doc agentResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.AgentID != "a_get" {
+		t.Errorf("agent_id = %q", doc.AgentID)
+	}
+	if doc.UserID != "alice" {
+		t.Errorf("user_id = %q (denormalisation not working)", doc.UserID)
+	}
+	if doc.Status != "completed" {
+		t.Errorf("status = %q, want completed", doc.Status)
+	}
+	if doc.Live {
+		t.Errorf("live = true after termination, should be false")
+	}
+}
+
+// GET /v1/users/{user_id}/agents lists active runs for the user only,
+// filters out other users.
+func TestListUserAgents_FiltersByUserAndStatus(t *testing.T) {
+	cfg := makeBaseConfig()
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// alice's first run completes
+			{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+			// bob's run completes
+			{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+			// alice's second run completes
+			{
+				{Type: providers.EventText, Text: "ok"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	for _, body := range []string{
+		`{"agent":"default","user_id":"alice","agent_id":"a_a1","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		`{"agent":"default","user_id":"bob","agent_id":"a_b1","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		`{"agent":"default","user_id":"alice","agent_id":"a_a2","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	} {
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	// All-statuses for alice — should see exactly her two completed runs.
+	getResp, _ := http.Get(ts.URL + "/v1/users/alice/agents?status=all")
+	defer getResp.Body.Close()
+	var listDoc struct {
+		Agents []agentResponse `json:"agents"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&listDoc); err != nil {
+		t.Fatal(err)
+	}
+	if len(listDoc.Agents) != 2 {
+		t.Fatalf("got %d agents for alice, want 2", len(listDoc.Agents))
+	}
+	for _, a := range listDoc.Agents {
+		if a.UserID != "alice" {
+			t.Errorf("non-alice agent leaked: %+v", a)
+		}
+	}
+}
+
+// Cancel cascades to a sub-agent at the HTTP level: parent's runCtx
+// propagates to the sub-loop AND the registry walk explicitly cancels
+// the sub.
+//
+// The cascade MECHANISM is fully proven at the registry unit level by
+// TestRegistry_Cancel_CascadesTree (parent + 2 children + grandchild,
+// every cancelFn fires, full cascaded list). The HTTP-level integration
+// version of the test below is skipped because reliably orchestrating
+// "parent up + child up + neither completes" with the current
+// scriptedProvider requires a more sophisticated multi-channel stub
+// than the codebase has today, and the cascade behaviour is not
+// expected to differ at the HTTP layer (it's a thin wrapper over
+// Registry.Cancel).
+//
+// Re-enable once the test infrastructure has a per-script-entry pause
+// channel; until then, rely on the unit-level cascade test plus
+// TestSubAgent_InheritsUserID_GeneratesFreshAgentID (which proves the
+// sub registers correctly, the prerequisite for cascade).
+func TestCancel_CascadesToSubAgent(t *testing.T) {
+	t.Skip("see comment above — cascade is unit-tested by TestRegistry_Cancel_CascadesTree")
+	cfg := makeBaseConfig()
+	cfg.Agents["parent"] = config.AgentDef{
+		Model: "stub-model", AllowedTools: []string{"Agent"},
+	}
+	cfg.Agents["child"] = config.AgentDef{
+		Model: "stub-model", AllowedTools: []string{},
+	}
+	// Provider script: parent emits one tool_call to spawn child;
+	// child blocks indefinitely on a pausable provider released by
+	// the test (or by ctx cancel). Parent uses scriptedProvider, but
+	// since sub-runs go through providers.Get(...) for the SAME
+	// ProviderResolver, we use a routing provider that switches
+	// behaviour by request.
+	scripted := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// parent iter 1: tool_call to Agent
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_p_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{}},
+			},
+			// child iter 1: blocks until ctx cancel — emit nothing,
+			// done with stop_reason from ctx cancel
+			{}, // empty events causes the loop to see ctx cancel via done channel close
+		},
+	}
+	srv, _ := makeServer(t, scripted, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Kick off parent — pausable behaviour comes from the empty
+	// child script forcing the loop to wait for events that never
+	// arrive (until ctx fires).
+	go func() {
+		resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"parent","user_id":"u","agent_id":"a_parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+		))
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	waitForRegistry(t, srv, "a_parent", 2*time.Second)
+
+	// Wait for the sub-agent to register too. It will have a
+	// loomcycle-generated agent_id; we find it via ListChildren.
+	deadline := time.Now().Add(2 * time.Second)
+	var subAgentID string
+	for time.Now().Before(deadline) {
+		children := srv.cancelReg.ListChildren("a_parent")
+		if len(children) == 1 {
+			subAgentID = children[0].AgentID
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if subAgentID == "" {
+		t.Skip("sub-agent did not register within deadline; the empty-script approach may not exercise the sub-loop reliably on this platform")
+	}
+
+	cancelResp, _ := http.Post(ts.URL+"/v1/agents/a_parent/cancel", "application/json",
+		strings.NewReader(`{"reason":"shutdown"}`))
+	defer cancelResp.Body.Close()
+	if cancelResp.StatusCode != 200 {
+		t.Fatalf("cancel status = %d", cancelResp.StatusCode)
+	}
+	var cr cancelResponse
+	_ = json.NewDecoder(cancelResp.Body).Decode(&cr)
+	if !cr.Cancelled {
+		t.Errorf("cancelled = false, want true")
+	}
+	cascaded := false
+	for _, c := range cr.Cascaded {
+		if c == subAgentID {
+			cascaded = true
+		}
+	}
+	if !cascaded {
+		t.Errorf("expected sub %s in cascaded list, got %v", subAgentID, cr.Cascaded)
+	}
+}
+
+// Sub-agent inherits user_id and gets a fresh agent_id with
+// parent_agent_id pointing at the parent.
+func TestSubAgent_InheritsUserID_GeneratesFreshAgentID(t *testing.T) {
+	cfg := makeBaseConfig()
+	cfg.Agents["parent"] = config.AgentDef{
+		Model: "stub-model", AllowedTools: []string{"Agent"},
+	}
+	cfg.Agents["child"] = config.AgentDef{
+		Model: "stub-model", AllowedTools: []string{},
+	}
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// parent: tool_call to spawn child
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"x"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			// child runs to completion
+			{
+				{Type: providers.EventText, Text: "child output"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+			// parent post-tool-result: text + done
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+			},
+		},
+	}
+	srv, _ := makeServer(t, prov, cfg)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, _ := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","user_id":"alice","agent_id":"a_parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`,
+	))
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	// Find the sub-run via parent_agent_id lookup in the store.
+	subs, err := srv.store.ListRunsByParentAgentID(context.Background(), "a_parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("got %d sub-runs, want 1", len(subs))
+	}
+	sub := subs[0]
+	if sub.UserID != "alice" {
+		t.Errorf("sub user_id = %q, want alice (inheritance broken)", sub.UserID)
+	}
+	if !strings.HasPrefix(sub.AgentID, "a_") {
+		t.Errorf("sub agent_id should be a_-prefixed, got %q", sub.AgentID)
+	}
+	if sub.AgentID == "a_parent" {
+		t.Errorf("sub agent_id MUST be distinct from parent (got same: %q)", sub.AgentID)
+	}
+	if sub.ParentAgentID != "a_parent" {
+		t.Errorf("sub parent_agent_id = %q, want a_parent", sub.ParentAgentID)
+	}
+}
+
+// waitForRegistry polls the cancel registry until the agent_id appears
+// or the deadline passes. Used by tests that need to synchronise on
+// the goroutine running an HTTP request.
+func waitForRegistry(t *testing.T, srv *Server, agentID string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if _, ok := srv.cancelReg.Get(agentID); ok {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("agent_id %q did not register within %s", agentID, within)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -55,8 +55,16 @@ type Server struct {
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
 // session+run+events tuple in the store; pass nil to keep v0.2 behaviour.
+//
+// The Agent built-in tool is registered automatically here (not in
+// cmd/loomcycle/main.go) because its SubAgentRunner closes over the
+// Server's own runSubAgent method — we'd otherwise have a chicken-and-
+// egg between tool list and Server. Per-agent allow-list still gates
+// access (an agent without "Agent" in `allowed_tools` won't see it).
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
-	return &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+	s := &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+	s.tools = append(s.tools, &builtin.AgentTool{Run: s.runSubAgent})
+	return s
 }
 
 // trySessionLock try-locks the session-scoped mutex for id. Returns
@@ -328,7 +336,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 
 	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
 
-	loopRes, runErr := loop.Run(r.Context(), loop.RunOptions{
+	// Pass the agent's effective tool names to the dispatcher so tools
+	// that need a runtime view of "what this agent can use" (e.g. the
+	// Skill tool's subset check on each call) read it via ctx instead
+	// of being constructed per-run.
+	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+
+	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:   provider,
 		Model:      model,
 		Tools:      allowedTools,
@@ -494,7 +508,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
 
-	loopRes, runErr := loop.Run(r.Context(), loop.RunOptions{
+	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:      provider,
 		Model:         model,
 		Tools:         allowedTools,
@@ -733,6 +748,127 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 	}
 }
 
+// runSubAgent is the SubAgentRunner closure injected into the Agent
+// built-in tool. It looks up the named agent in cfg.Agents, builds a
+// fresh session+run for the sub-execution, drives loop.Run with the
+// sub-agent's full declared tool set, and returns the FinalText.
+//
+// Trust model: the sub-agent's `allowed_tools` is the SOLE authority on
+// its tool surface. Parent and child are both operator-vetted YAML
+// definitions; neither widens nor narrows the other. The Agent tool's
+// availability to the parent is the gate (a parent without "Agent" in
+// its allowed_tools cannot call this in the first place).
+//
+// Sub-runs are persisted as their OWN sessions for replayability. The
+// parent's transcript records only the tool_call (with input) and
+// tool_result (with the sub's final text); the sub's intermediate
+// events are reachable via GET /v1/sessions/{sub-session-id}/transcript.
+//
+// Concurrency: sub-runs DO NOT acquire a fresh semaphore slot. They run
+// inside the parent's slot — the entire run tree counts as one against
+// MAX_CONCURRENT_RUNS. This avoids deadlocks at low concurrency caps
+// and matches the cost model (a parent's compute budget already covers
+// the work it delegates).
+//
+// Errors propagate as Go errors back to the Agent tool, which surfaces
+// them as IsError tool_results to the parent's model rather than
+// tearing down the parent run.
+func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (string, error) {
+	def, ok := s.cfg.Agents[name]
+	if !ok {
+		return "", fmt.Errorf("unknown sub-agent %q (not in loomcycle.yaml agents map)", name)
+	}
+
+	providerID, model, err := s.cfg.ResolveAgentModel(name)
+	if err != nil {
+		return "", fmt.Errorf("resolve sub-agent %q model: %w", name, err)
+	}
+	provider, err := s.providers.Get(providerID)
+	if err != nil {
+		return "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
+	}
+
+	// Sub-run gets its OWN session. Tenant inherited as empty for v0.4.0
+	// MVP — multi-tenant agent inheritance lands when per-tenant
+	// fairness does (later in v0.4 / v0.5).
+	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "")
+	if err != nil {
+		return "", fmt.Errorf("create sub-session for %q: %w", name, err)
+	}
+
+	// Build segments: agent's system_prompt (with cache_control) + the
+	// caller-supplied prompt as the first user message. Mirrors the
+	// shape of /v1/runs.
+	var segs []loop.PromptSegment
+	if def.SystemPrompt != "" {
+		segs = append(segs, loop.PromptSegment{
+			Role: "system",
+			Content: []loop.PromptContentBlock{{
+				Type:      "trusted-text",
+				Text:      def.SystemPrompt,
+				Cacheable: true,
+			}},
+		})
+	}
+	segs = append(segs, loop.PromptSegment{
+		Role: "user",
+		Content: []loop.PromptContentBlock{{
+			Type: "trusted-text",
+			Text: prompt,
+		}},
+	})
+
+	subTools := filterTools(s.tools, def.AllowedTools, nil)
+	// Caller-authoritative HTTP host narrowing doesn't apply here:
+	// sub-agents fall back to operator's static allowlist (no per-call
+	// caller list). If the sub-agent itself uses HTTP and needs hosts
+	// the operator's static list lacks, the operator must add them or
+	// run loomcycle in CALLER_AUTHORITATIVE mode (where the static
+	// list IS the fallback for runs without per-call narrowing).
+	subDispatcher := tools.NewDispatcher(subTools)
+
+	// Persist the input segments as the first event so transcript
+	// replay reconstructs the user prompt the same way fresh runs do.
+	if s.store != nil && subRunID != "" {
+		if inputJSON, err := json.Marshal(segs); err == nil {
+			if err := s.store.AppendEvent(ctx, subRunID, "user_input", inputJSON); err != nil {
+				log.Printf("store: AppendEvent(user_input) failed for sub-run %s: %v", subRunID, err)
+			}
+		}
+	}
+
+	// Sub-emit records to the sub's transcript only — the parent's SSE
+	// stream is fwd=no-op so sub events don't bleed into the parent's
+	// event stream. The parent observes only the wrapping
+	// tool_call/tool_result on its own stream.
+	subEmit := s.makeRecordingEmit(ctx, subRunID, func(providers.Event) {})
+
+	// Sub-run gets ITS OWN agent tools attached to ctx — the parent's
+	// tool list does not leak to the child (and vice versa). This
+	// matches the trust model: each agent's allowed_tools is its own
+	// authority for any subset checks done inside its run.
+	subCtx := tools.WithAgentTools(ctx, toolNames(subTools))
+
+	res, runErr := loop.Run(subCtx, loop.RunOptions{
+		Provider:   provider,
+		Model:      model,
+		Tools:      subTools,
+		Dispatcher: subDispatcher,
+		Segments:   segs,
+		OnEvent:    subEmit,
+	})
+	s.finishRun(ctx, subRunID, res, runErr)
+
+	if runErr != nil {
+		// Wrap with session/run IDs so a developer reading parent logs
+		// can locate the sub's transcript directly. The parent agent's
+		// model sees the unwrapped error message.
+		return "", fmt.Errorf("sub-agent %q failed (session=%s run=%s): %w",
+			name, subSessionID, subRunID, runErr)
+	}
+	return res.FinalText, nil
+}
+
 // finishRun marks the run terminal in the store. status is derived from
 // runErr: nil → completed, non-nil → failed. ctx may already be cancelled
 // (the client disconnected); we use a fresh background context with a short
@@ -782,6 +918,18 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// toolNames returns the names of a slice of tools — used to populate
+// the per-run AgentTools context value for tools that need a runtime
+// view of "what this agent can use" (e.g. the Skill tool's subset
+// check on each call).
+func toolNames(ts []tools.Tool) []string {
+	out := make([]string, 0, len(ts))
+	for _, t := range ts {
+		out = append(out, t.Name())
+	}
+	return out
 }
 
 // filterTools applies the agent + caller allowlists to the registered builtins.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -6,7 +6,9 @@ package http
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/subtle"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
@@ -41,6 +44,12 @@ type Server struct {
 	sem       *concurrency.Semaphore
 	store     store.Store // optional; nil means "don't persist"
 
+	// cancelReg holds the in-memory map of agent_id → cancelFn so the
+	// cancel API can tear down a still-running loop from a different
+	// HTTP request. Always non-nil after New(); empty on startup. See
+	// internal/cancel/registry.go for the trust model.
+	cancelReg *cancel.Registry
+
 	// sessionLocks maps session IDs to *sync.Mutex. A continuation POST
 	// (handleMessages, or handleRuns with a non-empty SessionID) try-locks
 	// the session before replaying transcript + running. Concurrent POSTs
@@ -61,8 +70,19 @@ type Server struct {
 // Server's own runSubAgent method — we'd otherwise have a chicken-and-
 // egg between tool list and Server. Per-agent allow-list still gates
 // access (an agent without "Agent" in `allowed_tools` won't see it).
+//
+// The cancel registry is also constructed here. It's always present
+// (empty if no run has started) so handler code can call its methods
+// unconditionally without nil-checking.
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
-	s := &Server{cfg: cfg, providers: pr, tools: builtinTools, sem: sem, store: st}
+	s := &Server{
+		cfg:       cfg,
+		providers: pr,
+		tools:     builtinTools,
+		sem:       sem,
+		store:     st,
+		cancelReg: cancel.NewRegistry(),
+	}
 	s.tools = append(s.tools, &builtin.AgentTool{Run: s.runSubAgent})
 	return s
 }
@@ -112,6 +132,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("POST /v1/runs", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRuns))))
 	mux.Handle("GET /v1/sessions/{id}/transcript", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleTranscript))))
 	mux.Handle("POST /v1/sessions/{id}/messages", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMessages))))
+	// v0.4 tracking + cancel API.
+	mux.Handle("GET /v1/agents/{agent_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetAgent))))
+	mux.Handle("POST /v1/agents/{agent_id}/cancel", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCancelAgent))))
+	mux.Handle("GET /v1/users/{user_id}/agents", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUserAgents))))
 	return mux
 }
 
@@ -173,6 +197,17 @@ type runRequest struct {
 	// SSE event so the caller can address subsequent calls to it.
 	SessionID string `json:"session_id,omitempty"`
 	TenantID  string `json:"tenant_id,omitempty"`
+	// UserID binds the run to a user (v0.4+). Optional. Charset:
+	// [A-Za-z0-9_-]{1,128}. Empty leaves the run unbound (legacy v0.3
+	// behaviour). Sub-agent runs spawned from this run inherit it.
+	UserID string `json:"user_id,omitempty"`
+	// AgentID is a caller-supplied tracking handle (v0.4+). Optional;
+	// when omitted, loomcycle generates one and announces it in the
+	// `event: agent` SSE frame. Charset: [A-Za-z0-9_-]{1,128}. Distinct
+	// from SessionID — agent_id addresses a single run for status/cancel,
+	// session_id addresses the conversation thread for transcript
+	// continuation.
+	AgentID string `json:"agent_id,omitempty"`
 }
 
 func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
@@ -194,6 +229,19 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Agent == "" {
 		http.Error(w, `agent is required`, http.StatusBadRequest)
+		return
+	}
+
+	// Validate the v0.4 tracking fields. user_id is optional; an empty
+	// agent_id triggers server-side generation. Both, when supplied,
+	// must satisfy the [A-Za-z0-9_-]{1,128} charset so they're safe to
+	// use as URL path segments and registry keys.
+	if req.UserID != "" && !validIdent(req.UserID) {
+		http.Error(w, `user_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
+		return
+	}
+	if req.AgentID != "" && !validIdent(req.AgentID) {
+		http.Error(w, `agent_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
 		return
 	}
 
@@ -288,11 +336,22 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		}}, req.Segments...)
 	}
 
+	// Resolve the run's agent_id: the caller's value when supplied,
+	// otherwise a fresh server-generated one. We need this BEFORE
+	// session/run creation so we can write it to the row in one shot,
+	// AND BEFORE registering the cancel entry so a cancel arriving
+	// between Register and the loop's first ctx-check finds the entry.
+	agentID := req.AgentID
+	if agentID == "" {
+		agentID = newAgentID()
+	}
+
 	// Persistence: resolve or create a session, create a run, route every
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID)
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID}
+	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
 		if errors.As(sessErr, &nf) {
@@ -302,6 +361,32 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, sessErr.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Derive the loop ctx with a cancel-cause function. The HTTP request
+	// ctx remains the parent so client-disconnect still tears down. We
+	// register the cancelFn under agent_id so an external cancel API
+	// call can fire it.
+	runCtx, cancelFn := context.WithCancelCause(r.Context())
+	defer cancelFn(nil) // ensure ctx leaks don't survive the handler
+
+	regErr := s.cancelReg.Register(cancel.Entry{
+		AgentID:   agentID,
+		RunID:     runID,
+		SessionID: sessionID,
+		UserID:    req.UserID,
+		StartedAt: time.Now(),
+	}, cancelFn)
+	if errors.Is(regErr, cancel.ErrInUse) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
+		return
+	}
+	if regErr != nil {
+		http.Error(w, regErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer s.cancelReg.Deregister(agentID)
 
 	// If we're persisting, record the caller's input segments as the first
 	// event in the run. The loop never emits the caller's input itself, so
@@ -333,6 +418,16 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			Text: sessionID,
 		})
 	}
+	// New v0.4 side-channel: announce the agent_id (and run_id) so the
+	// caller can address cancel/status without knowing the loomcycle-
+	// internal session/run IDs. parent_agent_id is null for top-level
+	// runs; sub-agents emit it via runSubAgent's own side-channel work.
+	stream.sendRaw("agent", map[string]any{
+		"agent_id":        agentID,
+		"run_id":          runID,
+		"session_id":      sessionID,
+		"parent_agent_id": nil,
+	})
 
 	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
 
@@ -340,21 +435,34 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// that need a runtime view of "what this agent can use" (e.g. the
 	// Skill tool's subset check on each call) read it via ctx instead
 	// of being constructed per-run.
-	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// Stash the run's identity so the Agent built-in tool's
+	// SubAgentRunner can inherit user_id and set parent_agent_id on
+	// any sub-runs it spawns.
+	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
+		UserID:  req.UserID,
+		AgentID: agentID,
+	})
+
+	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
+	// future sweeper can detect crashed processes (no heartbeat for > N
+	// minutes → presumed dead). Cheap (~10–100 calls per run).
+	heartbeat := s.makeHeartbeat(runID)
 
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
-		Provider:   provider,
-		Model:      model,
-		Tools:      allowedTools,
-		Dispatcher: dispatcher,
-		Segments:   req.Segments,
-		OnEvent:    emit,
+		Provider:    provider,
+		Model:       model,
+		Tools:       allowedTools,
+		Dispatcher:  dispatcher,
+		Segments:    req.Segments,
+		OnEvent:     emit,
+		OnHeartbeat: heartbeat,
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}
 
-	s.finishRun(r.Context(), runID, loopRes, runErr)
+	s.finishRunWithCancel(r.Context(), runCtx, runID, loopRes, runErr)
 }
 
 // messagesRequest is the JSON body for POST /v1/sessions/{id}/messages. It
@@ -370,6 +478,12 @@ type messagesRequest struct {
 	// request alone, no session state to chase.
 	AllowedHosts    *[]string `json:"allowed_hosts,omitempty"`
 	WebSearchFilter string    `json:"web_search_filter,omitempty"`
+	// AgentID is a fresh tracking handle for the new run created by
+	// this continuation (v0.4+). Same charset rules as runRequest.
+	// UserID is NOT accepted here — continuation runs inherit the
+	// session's user_id (set at original creation); allowing a
+	// different user_id mid-session would be confusing.
+	AgentID string `json:"agent_id,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -485,12 +599,52 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		}}, segments...)
 	}
 
-	// Create a new run inside the existing session.
-	run, err := s.store.CreateRun(r.Context(), id)
+	// Validate any caller-supplied agent_id and reserve one for the new
+	// run (sub-fresh per continuation; never inherited from the prior
+	// run since "the run" is what agent_id addresses).
+	if body.AgentID != "" && !validIdent(body.AgentID) {
+		http.Error(w, `agent_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
+		return
+	}
+	agentID := body.AgentID
+	if agentID == "" {
+		agentID = newAgentID()
+	}
+
+	// Create a new run inside the existing session. user_id is
+	// inherited from the session (set at original creation).
+	run, err := s.store.CreateRun(r.Context(), id, store.RunIdentity{
+		AgentID: agentID,
+		UserID:  sess.UserID,
+	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	// Derive a runCtx with cancel-cause and register in the cancel
+	// registry. Same shape as handleRuns.
+	runCtx, cancelFn := context.WithCancelCause(r.Context())
+	defer cancelFn(nil)
+	regErr := s.cancelReg.Register(cancel.Entry{
+		AgentID:   agentID,
+		RunID:     run.ID,
+		SessionID: id,
+		UserID:    sess.UserID,
+		StartedAt: time.Now(),
+	}, cancelFn)
+	if errors.Is(regErr, cancel.ErrInUse) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
+		return
+	}
+	if regErr != nil {
+		http.Error(w, regErr.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer s.cancelReg.Deregister(agentID)
+
 	// Persist the new user input segments so a future replay sees them.
 	if inputJSON, err := json.Marshal(body.Segments); err == nil {
 		if err := s.store.AppendEvent(r.Context(), run.ID, "user_input", inputJSON); err != nil {
@@ -505,10 +659,21 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	stream.start()
 	stream.send(providers.Event{Type: "session", Text: id})
+	stream.sendRaw("agent", map[string]any{
+		"agent_id":        agentID,
+		"run_id":          run.ID,
+		"session_id":      id,
+		"parent_agent_id": nil,
+	})
 
 	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
+	heartbeat := s.makeHeartbeat(run.ID)
 
-	loopCtx := tools.WithAgentTools(r.Context(), toolNames(allowedTools))
+	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
+		UserID:  sess.UserID,
+		AgentID: agentID,
+	})
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:      provider,
 		Model:         model,
@@ -517,12 +682,13 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Segments:      segments,
 		PriorMessages: priorMessages,
 		OnEvent:       emit,
+		OnHeartbeat:   heartbeat,
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}
 
-	s.finishRun(r.Context(), run.ID, loopRes, runErr)
+	s.finishRunWithCancel(r.Context(), runCtx, run.ID, loopRes, runErr)
 }
 
 // replayTranscript walks the persisted events of a session and reconstructs
@@ -705,7 +871,14 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 // openOrCreateSessionAndRun resolves the session (creating one if the caller
 // didn't pass an ID), then creates a run inside it. Returns ("", "", nil) when
 // no store is configured — the caller treats both empty IDs as "skip persistence".
-func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSessionID, agent, tenantID string) (string, string, error) {
+//
+// userID is forwarded into the new session row (empty when the caller didn't
+// supply one). identity carries the v0.4 tracking fields for the new run; for
+// continuation requests on an existing session, the run inherits the session's
+// user_id automatically via the denormalised UserID on RunIdentity (caller is
+// responsible for setting that when continuing — typically copied from
+// GetSession).
+func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSessionID, agent, tenantID, userID string, identity store.RunIdentity) (string, string, error) {
 	if s.store == nil {
 		return "", "", nil
 	}
@@ -717,12 +890,18 @@ func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSession
 			return "", "", err
 		}
 	} else {
-		sess, err = s.store.CreateSession(ctx, tenantID, agent)
+		sess, err = s.store.CreateSession(ctx, tenantID, agent, userID)
 		if err != nil {
 			return "", "", err
 		}
 	}
-	run, err := s.store.CreateRun(ctx, sess.ID)
+	// Denormalise session.UserID onto the new run if the caller didn't
+	// supply one (cv-rewriter etc. always have one path; continuation
+	// inherits via the session lookup).
+	if identity.UserID == "" {
+		identity.UserID = sess.UserID
+	}
+	run, err := s.store.CreateRun(ctx, sess.ID, identity)
 	if err != nil {
 		return "", "", err
 	}
@@ -788,12 +967,56 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 		return "", fmt.Errorf("provider for sub-agent %q: %w", name, err)
 	}
 
+	// Read parent's identity from ctx to inherit user_id and pin
+	// parent_agent_id on the sub-run. tools.RunIdentity returns zero
+	// value if the parent didn't set it — sub-agents spawned from
+	// callers that didn't supply user_id naturally inherit empty.
+	parentIdentity := tools.RunIdentity(ctx)
+
+	// Generate a fresh agent_id for the sub-run. Always generated;
+	// callers can't override (the sub is loomcycle-controlled).
+	subAgentID := newAgentID()
+
 	// Sub-run gets its OWN session. Tenant inherited as empty for v0.4.0
 	// MVP — multi-tenant agent inheritance lands when per-tenant
 	// fairness does (later in v0.4 / v0.5).
-	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "")
+	subIdentity := store.RunIdentity{
+		AgentID:       subAgentID,
+		ParentAgentID: parentIdentity.AgentID,
+		// ParentRunID is left empty here — we don't have the parent's
+		// run.ID handy without an extra registry lookup. Cascade
+		// works via parent_agent_id alone; ParentRunID is informational
+		// for transcript stitching and can be filled in by a future
+		// refactor that threads parent run.ID through ctx.
+		UserID: parentIdentity.UserID,
+	}
+	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "", parentIdentity.UserID, subIdentity)
 	if err != nil {
 		return "", fmt.Errorf("create sub-session for %q: %w", name, err)
+	}
+
+	// Register the sub-run in the cancel registry so a parent-cancel
+	// can cascade through. Sub uses parent's runCtx (passed in via
+	// ctx) — a parent ctx-cancel already tears down the sub-loop, but
+	// the registry entry lets the cascade walk in Cancel() find this
+	// sub explicitly (belt-and-braces against grandchild races).
+	subRunCtx, subCancelFn := context.WithCancelCause(ctx)
+	defer subCancelFn(nil)
+	regErr := s.cancelReg.Register(cancel.Entry{
+		AgentID:       subAgentID,
+		RunID:         subRunID,
+		SessionID:     subSessionID,
+		UserID:        parentIdentity.UserID,
+		ParentAgentID: parentIdentity.AgentID,
+		StartedAt:     time.Now(),
+	}, subCancelFn)
+	if regErr != nil {
+		// A duplicate-active collision is essentially impossible here
+		// (subAgentID is freshly generated); log and continue without
+		// registering rather than fail the run for a registry hiccup.
+		log.Printf("cancel registry: sub-agent register failed (%s): %v", subAgentID, regErr)
+	} else {
+		defer s.cancelReg.Deregister(subAgentID)
 	}
 
 	// Build segments: agent's system_prompt (with cache_control) + the
@@ -847,26 +1070,345 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	// tool list does not leak to the child (and vice versa). This
 	// matches the trust model: each agent's allowed_tools is its own
 	// authority for any subset checks done inside its run.
-	subCtx := tools.WithAgentTools(ctx, toolNames(subTools))
+	//
+	// The sub's run identity is also threaded through ctx so a
+	// recursive Agent tool call from this sub picks up the right
+	// parent_agent_id (= subAgentID).
+	subCtx := tools.WithAgentTools(subRunCtx, toolNames(subTools))
+	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
+		UserID:  parentIdentity.UserID,
+		AgentID: subAgentID,
+	})
+
+	subHeartbeat := s.makeHeartbeat(subRunID)
 
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
-		Provider:   provider,
-		Model:      model,
-		Tools:      subTools,
-		Dispatcher: subDispatcher,
-		Segments:   segs,
-		OnEvent:    subEmit,
+		Provider:    provider,
+		Model:       model,
+		Tools:       subTools,
+		Dispatcher:  subDispatcher,
+		Segments:    segs,
+		OnEvent:     subEmit,
+		OnHeartbeat: subHeartbeat,
 	})
-	s.finishRun(ctx, subRunID, res, runErr)
+	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr)
 
 	if runErr != nil {
 		// Wrap with session/run IDs so a developer reading parent logs
 		// can locate the sub's transcript directly. The parent agent's
-		// model sees the unwrapped error message.
-		return "", fmt.Errorf("sub-agent %q failed (session=%s run=%s): %w",
-			name, subSessionID, subRunID, runErr)
+		// model sees the unwrapped error message. agent_id is the v0.4
+		// addressable handle, so include it too — the easiest hint for
+		// "GET /v1/agents/<this>" debugging.
+		return "", fmt.Errorf("sub-agent %q failed (agent=%s session=%s run=%s): %w",
+			name, subAgentID, subSessionID, subRunID, runErr)
 	}
-	return res.FinalText, nil
+	// Surface the sub agent_id to the parent agent's transcript by
+	// prefixing the tool_result text. Parent caller's model sees this
+	// and can echo it to the UI. Cheap; unblocks future "cancel only
+	// the sub" UX.
+	return fmt.Sprintf("[sub-agent agent_id=%s]\n%s", subAgentID, res.FinalText), nil
+}
+
+// agentResponse is the JSON shape returned by GET /v1/agents/{id} and
+// each entry in GET /v1/users/{user_id}/agents. Mirrors store.Run plus
+// a flag distinguishing live (still in the cancel registry) from
+// terminated.
+//
+// The response intentionally avoids exposing internal fields like
+// loomcycle's session_id when the caller didn't already know it; we
+// include it because the same caller almost always has the session_id
+// from the original SSE stream and surfacing it here keeps things
+// debug-friendly.
+type agentResponse struct {
+	AgentID         string             `json:"agent_id"`
+	RunID           string             `json:"run_id"`
+	SessionID       string             `json:"session_id"`
+	UserID          string             `json:"user_id,omitempty"`
+	ParentAgentID   string             `json:"parent_agent_id,omitempty"`
+	Status          store.RunStatus    `json:"status"`
+	StartedAt       time.Time          `json:"started_at"`
+	CompletedAt     *time.Time         `json:"completed_at,omitempty"`
+	StopReason      string             `json:"stop_reason,omitempty"`
+	Error           string             `json:"error,omitempty"`
+	Usage           agentResponseUsage `json:"usage"`
+	LastHeartbeatAt *time.Time         `json:"last_heartbeat_at,omitempty"`
+	Live            bool               `json:"live"`
+}
+
+type agentResponseUsage struct {
+	InputTokens         int    `json:"input_tokens"`
+	OutputTokens        int    `json:"output_tokens"`
+	CacheCreationTokens int    `json:"cache_creation_tokens,omitempty"`
+	CacheReadTokens     int    `json:"cache_read_tokens,omitempty"`
+	Model               string `json:"model,omitempty"`
+}
+
+// runToAgentResponse converts a store.Run into the API response shape.
+// `live` indicates whether the cancel registry still has an entry —
+// distinguishes "running and cancellable" from "running per the row but
+// the registry doesn't know about it" (which can happen after a process
+// restart). The HTTP layer surfaces this flag so the UI can decide
+// whether to offer a Cancel button.
+func runToAgentResponse(r store.Run, live bool) agentResponse {
+	resp := agentResponse{
+		AgentID:       r.AgentID,
+		RunID:         r.ID,
+		SessionID:     r.SessionID,
+		UserID:        r.UserID,
+		ParentAgentID: r.ParentAgentID,
+		Status:        r.Status,
+		StartedAt:     r.StartedAt,
+		StopReason:    r.StopReason,
+		Error:         r.ErrorMsg,
+		Usage: agentResponseUsage{
+			InputTokens:         r.InputTokens,
+			OutputTokens:        r.OutputTokens,
+			CacheCreationTokens: r.CacheCreationTokens,
+			CacheReadTokens:     r.CacheReadTokens,
+			Model:               r.Model,
+		},
+		Live: live,
+	}
+	if !r.CompletedAt.IsZero() {
+		t := r.CompletedAt
+		resp.CompletedAt = &t
+	}
+	if !r.LastHeartbeatAt.IsZero() {
+		t := r.LastHeartbeatAt
+		resp.LastHeartbeatAt = &t
+	}
+	return resp
+}
+
+// handleGetAgent serves GET /v1/agents/{agent_id}. Returns the most
+// recent run carrying the agent_id, with its current status. 404 when
+// neither the registry nor the store knows the id.
+func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("agent_id")
+	if !validIdent(agentID) {
+		http.Error(w, `agent_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
+		return
+	}
+	if s.store == nil {
+		// Without persistence we can only answer "live in registry" —
+		// no historical runs to query. Surface that as a 404 with a
+		// distinct code so the caller can tell.
+		if _, ok := s.cancelReg.Get(agentID); !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no live run for %q (no store configured)"}`, agentID)
+			return
+		}
+		// Live but unpersisted — return a minimal-shape response.
+		entry, _ := s.cancelReg.Get(agentID)
+		writeJSON(w, http.StatusOK, agentResponse{
+			AgentID:   agentID,
+			RunID:     entry.RunID,
+			SessionID: entry.SessionID,
+			UserID:    entry.UserID,
+			Status:    store.RunRunning,
+			StartedAt: entry.StartedAt,
+			Live:      true,
+		})
+		return
+	}
+	run, err := s.store.GetRunByAgentID(r.Context(), agentID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no run found for agent_id %q"}`, agentID)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, live := s.cancelReg.Get(agentID)
+	writeJSON(w, http.StatusOK, runToAgentResponse(run, live))
+}
+
+// cancelRequest is the (optional) JSON body for POST /v1/agents/{id}/cancel.
+type cancelRequest struct {
+	Reason string `json:"reason,omitempty"`
+}
+
+// cancelResponse is the JSON shape returned by the cancel endpoint.
+type cancelResponse struct {
+	Cancelled bool     `json:"cancelled"`
+	AgentID   string   `json:"agent_id"`
+	Cascaded  []string `json:"cascaded,omitempty"`
+	Status    string   `json:"status,omitempty"` // present on idempotent re-cancel of a terminated run
+	Reason    string   `json:"reason,omitempty"`
+}
+
+// handleCancelAgent serves POST /v1/agents/{agent_id}/cancel. Cancels
+// the in-flight run (and cascading children); idempotent — a second
+// cancel of a terminated run returns 200 with the prior status rather
+// than 404.
+func (s *Server) handleCancelAgent(w http.ResponseWriter, r *http.Request) {
+	agentID := r.PathValue("agent_id")
+	if !validIdent(agentID) {
+		http.Error(w, `agent_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
+		return
+	}
+
+	var body cancelRequest
+	if r.ContentLength > 0 {
+		// Best-effort decode — empty body is fine.
+		_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<10)).Decode(&body)
+	}
+
+	res, ok := s.cancelReg.Cancel(agentID, body.Reason)
+	if ok {
+		writeJSON(w, http.StatusOK, cancelResponse{
+			Cancelled: true,
+			AgentID:   agentID,
+			Cascaded:  res.Cascaded,
+			Reason:    res.Reason,
+		})
+		return
+	}
+
+	// Not in registry — either already terminated, or never existed.
+	// Distinguish via the store: a row exists → terminated (idempotent
+	// 200); no row → 404.
+	if s.store == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no live or terminated run for %q (no store configured)"}`, agentID)
+		return
+	}
+	run, err := s.store.GetRunByAgentID(r.Context(), agentID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no run found for agent_id %q"}`, agentID)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	// Idempotent: surface the existing terminal status. cancelled=false
+	// signals "this call did not initiate the cancel" but is still 200.
+	writeJSON(w, http.StatusOK, cancelResponse{
+		Cancelled: false,
+		AgentID:   agentID,
+		Status:    string(run.Status),
+	})
+}
+
+// handleListUserAgents serves GET /v1/users/{user_id}/agents?status=running.
+// Returns at most 100 runs ordered by started_at DESC.
+func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("user_id")
+	if !validIdent(userID) {
+		http.Error(w, `user_id must match [A-Za-z0-9_-]{1,128}`, http.StatusBadRequest)
+		return
+	}
+	if s.store == nil {
+		http.Error(w, "list-by-user requires persistence (Store not configured)", http.StatusNotFound)
+		return
+	}
+	statusFilter := store.RunStatus(r.URL.Query().Get("status"))
+	// Default to running — the most useful view for "what's in flight
+	// for me?". Pass status=all to override.
+	if statusFilter == "" {
+		statusFilter = store.RunRunning
+	}
+	if statusFilter == "all" {
+		statusFilter = ""
+	}
+	runs, err := s.store.ListActiveRunsByUser(r.Context(), userID, statusFilter)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out := make([]agentResponse, 0, len(runs))
+	for _, run := range runs {
+		_, live := s.cancelReg.Get(run.AgentID)
+		out = append(out, runToAgentResponse(run, live))
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"agents": out})
+}
+
+// writeJSON is a small helper for the new endpoints that avoids
+// repeating the Content-Type + WriteHeader + Encode dance.
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		log.Printf("writeJSON encode failed: %v", err)
+	}
+}
+
+// makeHeartbeat returns a callback the loop fires at each iteration.
+// It updates runs.last_heartbeat_at via a fire-and-forget background
+// context (the loop's ctx may be cancelled mid-write; the heartbeat
+// shouldn't gate on it).
+//
+// nil store or runID makes this a no-op so v0.2 callers stay
+// hands-off.
+func (s *Server) makeHeartbeat(runID string) func() {
+	if s.store == nil || runID == "" {
+		return nil
+	}
+	return func() {
+		bg, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		if err := s.store.UpdateHeartbeat(bg, runID); err != nil {
+			// Log only — never fail the run on a heartbeat hiccup.
+			log.Printf("store: UpdateHeartbeat(%s) failed: %v", runID, err)
+		}
+	}
+}
+
+// finishRunWithCancel is the cause-aware version of finishRun. It
+// inspects context.Cause(runCtx) to discriminate API-cancel
+// (cancel.ErrCancelledByAPI sentinel attached) from client-disconnect
+// (plain ctx.Canceled, no cause) and other errors. API-cancel writes
+// status=cancelled with the reason; everything else falls through to
+// finishRun's existing failed/completed logic.
+//
+// runCtx is the per-run ctx derived from the HTTP request ctx via
+// context.WithCancelCause. ctx (the first arg) is the outer ctx used
+// only by finishRun for its store write — passing both keeps the
+// background-write fallback in finishRun reusable for both code paths.
+func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context, runID string, res loop.RunResult, runErr error) {
+	if cause := context.Cause(runCtx); errors.Is(cause, cancel.ErrCancelledByAPI) {
+		// API-cancel terminal write. Reason text comes from the
+		// optional wrapper; falls back to the sentinel string.
+		reason := cancel.ReasonFromCause(cause)
+		if reason == "" {
+			reason = "cancelled by api"
+		}
+		s.finishRunCancelled(ctx, runID, res, reason)
+		return
+	}
+	s.finishRun(ctx, runID, res, runErr)
+}
+
+// finishRunCancelled writes the terminal cancelled status with the
+// supplied reason. Mirrors finishRun's structure (background ctx with
+// 5s timeout) so the store write isn't lost when runCtx is cancelled.
+func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.RunResult, reason string) {
+	if s.store == nil || runID == "" {
+		return
+	}
+	bg, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFn()
+	usage := store.Usage{
+		InputTokens:         res.Usage.InputTokens,
+		OutputTokens:        res.Usage.OutputTokens,
+		CacheCreationTokens: res.Usage.CacheCreationTokens,
+		CacheReadTokens:     res.Usage.CacheReadTokens,
+		Model:               res.Usage.Model,
+	}
+	if err := s.store.FinishRun(bg, runID, store.RunCancelled, reason, usage, ""); err != nil {
+		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
+	}
 }
 
 // finishRun marks the run terminal in the store. status is derived from
@@ -918,6 +1460,38 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// validIdent reports whether s is a valid user_id or agent_id. Charset
+// matches the spec: [A-Za-z0-9_-] with length 1..128. Used to refuse
+// malformed input at the HTTP boundary so SQL queries and registry
+// keys stay sane (no embedded slashes that could confuse URL routing,
+// no whitespace that could land in a stop_reason field).
+func validIdent(s string) bool {
+	if s == "" || len(s) > 128 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// newAgentID produces a fresh agent_id when the caller didn't supply
+// one (or when sub-agents need their own). Same shape as session/run
+// IDs: short prefix + 16 hex chars (8 random bytes = 64 bits of entropy).
+func newAgentID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "a_" + hex.EncodeToString(b[:])
 }
 
 // toolNames returns the names of a slice of tools — used to populate

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -377,12 +377,21 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		StartedAt: time.Now(),
 	}, cancelFn)
 	if errors.Is(regErr, cancel.ErrInUse) {
+		// We've already created the session+run row in the store
+		// (session creation is unavoidable to satisfy the FK on
+		// runs). Leaving the run at status=running would orphan it
+		// permanently — the heartbeat sweeper (when it lands) would
+		// eventually catch it, but in the meantime it pollutes
+		// ListActiveRunsByUser. Mark it failed with a clear reason
+		// so the row is terminal from this exit path.
+		s.finishRunFailedReason(runID, "agent_id collision; run never started")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
 		return
 	}
 	if regErr != nil {
+		s.finishRunFailedReason(runID, "registry register failed: "+regErr.Error())
 		http.Error(w, regErr.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -634,12 +643,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		StartedAt: time.Now(),
 	}, cancelFn)
 	if errors.Is(regErr, cancel.ErrInUse) {
+		// Same orphan-row mitigation as handleRuns — the run was
+		// already inserted at status=running.
+		s.finishRunFailedReason(run.ID, "agent_id collision; run never started")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
 		return
 	}
 	if regErr != nil {
+		s.finishRunFailedReason(run.ID, "registry register failed: "+regErr.Error())
 		http.Error(w, regErr.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1191,16 +1204,16 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.store == nil {
 		// Without persistence we can only answer "live in registry" —
-		// no historical runs to query. Surface that as a 404 with a
-		// distinct code so the caller can tell.
-		if _, ok := s.cancelReg.Get(agentID); !ok {
+		// no historical runs to query. ONE Get call so a concurrent
+		// Deregister between a check and a read doesn't return a
+		// half-populated entry.
+		entry, ok := s.cancelReg.Get(agentID)
+		if !ok {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no live run for %q (no store configured)"}`, agentID)
 			return
 		}
-		// Live but unpersisted — return a minimal-shape response.
-		entry, _ := s.cancelReg.Get(agentID)
 		writeJSON(w, http.StatusOK, agentResponse{
 			AgentID:   agentID,
 			RunID:     entry.RunID,
@@ -1390,9 +1403,36 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 	s.finishRun(ctx, runID, res, runErr)
 }
 
+// finishRunFailedReason marks a run terminal with status=failed and
+// the supplied error string, no usage. Used by the BLOCKING-fix paths
+// where we created a run row but bailed before the loop ran (e.g.
+// agent_id collision in the registry). Without this, those rows
+// orphan at status=running and pollute ListActiveRunsByUser.
+//
+// Mirrors finishRun's structure: fresh background ctx with 5s timeout
+// so the write isn't lost when the request ctx is already torn down.
+func (s *Server) finishRunFailedReason(runID, reason string) {
+	if s.store == nil || runID == "" {
+		return
+	}
+	bg, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelFn()
+	if err := s.store.FinishRun(bg, runID, store.RunFailed, "", store.Usage{}, reason); err != nil {
+		log.Printf("store: FinishRun(failed reason=%q) failed (run=%s): %v", reason, runID, err)
+	}
+}
+
 // finishRunCancelled writes the terminal cancelled status with the
 // supplied reason. Mirrors finishRun's structure (background ctx with
 // 5s timeout) so the store write isn't lost when runCtx is cancelled.
+//
+// Note: the ctx parameter is intentionally ignored — the function
+// always uses a fresh background ctx because at the call site BOTH
+// the request ctx and the runCtx are typically already cancelled.
+// The parameter is kept for signature parity with finishRun so the
+// two are interchangeable at the call site (finishRunWithCancel
+// dispatches to one or the other), but it's a no-op input. If you
+// add real ctx propagation here, audit every caller.
 func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.RunResult, reason string) {
 	if s.store == nil || runID == "" {
 		return

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -86,9 +86,11 @@ func TestHandleRunsSSE(t *testing.T) {
 		t.Errorf("content-type = %q", ct)
 	}
 
-	// Read SSE frames; expect started, text, usage, done.
+	// Read SSE frames. v0.4 announces agent_id in a side-channel
+	// "agent" frame before the loop emits its first model event;
+	// agent → started → text → usage → done.
 	got := readEvents(t, resp.Body)
-	wantTypes := []string{"started", "text", "usage", "done"}
+	wantTypes := []string{"agent", "started", "text", "usage", "done"}
 	if len(got) != len(wantTypes) {
 		t.Fatalf("got %d frames %v, want %d %v", len(got), got, len(wantTypes), wantTypes)
 	}

--- a/internal/api/http/sse.go
+++ b/internal/api/http/sse.go
@@ -64,6 +64,29 @@ func (s *sse) send(ev providers.Event) {
 	s.flush()
 }
 
+// sendRaw emits an SSE frame with a custom event name and a JSON-
+// marshalled payload. Used for side-channel events that don't fit the
+// `providers.Event` shape — currently the v0.4 `event: agent` frame
+// that announces the run's agent_id alongside the existing
+// `event: session` frame.
+//
+// data may be any json-marshalable value; on marshal failure we log
+// and silently drop (the run is still happening; an SSE-side hiccup
+// shouldn't tear down the response). The caller is responsible for
+// keeping the data shape stable since adapters parse it.
+func (s *sse) sendRaw(eventName string, data any) {
+	if s.closed {
+		return
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		log.Printf("sse: sendRaw marshal failed for %q: %v", eventName, err)
+		return
+	}
+	fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", eventName, payload)
+	s.flush()
+}
+
 func (s *sse) flush() {
 	if s.flusher != nil {
 		s.flusher.Flush()

--- a/internal/api/http/sse.go
+++ b/internal/api/http/sse.go
@@ -15,7 +15,6 @@ import (
 type sse struct {
 	w       http.ResponseWriter
 	flusher http.Flusher
-	closed  bool
 }
 
 // newSSE returns an sse and a boolean indicating whether the writer supports
@@ -40,9 +39,6 @@ func (s *sse) start() {
 }
 
 func (s *sse) send(ev providers.Event) {
-	if s.closed {
-		return
-	}
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		// Marshal can fail for unencodable values in ev.Payload-style fields.
@@ -75,9 +71,6 @@ func (s *sse) send(ev providers.Event) {
 // shouldn't tear down the response). The caller is responsible for
 // keeping the data shape stable since adapters parse it.
 func (s *sse) sendRaw(eventName string, data any) {
-	if s.closed {
-		return
-	}
 	payload, err := json.Marshal(data)
 	if err != nil {
 		log.Printf("sse: sendRaw marshal failed for %q: %v", eventName, err)

--- a/internal/cancel/registry.go
+++ b/internal/cancel/registry.go
@@ -1,0 +1,308 @@
+// Package cancel implements the in-memory registry that maps an
+// agent_id to a context.CancelCauseFunc, so an external HTTP request
+// can cancel a still-running loop.
+//
+// Why in-memory: the registry holds a goroutine-safe mapping that
+// vanishes when the loomcycle process exits. Persistent recording
+// (status=running rows in the store) is the durable source of truth;
+// the registry is the live-cancellation surface bolted on top. A
+// process restart loses the cancelFns but leaves the DB intact, which
+// is the correct shape — the runs they referenced were torn down by
+// the same restart.
+//
+// Trust + scope:
+//   - Bearer-only at the HTTP layer (matches the existing pattern).
+//     Per-user authorization is the host application's responsibility.
+//   - agent_id uniqueness is ENFORCED here, not at the DB level —
+//     historical rows can share an agent_id (a caller may legitimately
+//     reuse it after the previous run terminated). Two simultaneously
+//     active runs sharing one agent_id is a programming error and is
+//     refused via ErrInUse.
+//
+// Lifecycle:
+//
+//   ┌────────────────────────────────────────────────────────────────┐
+//   │ HTTP req in →  Server creates session+run → Register(agentID)  │
+//   │                          │                                     │
+//   │                          ▼                                     │
+//   │              ┌─ loop.Run(runCtx) ──────────────┐                │
+//   │              │  (subloops inherit runCtx —     │                │
+//   │              │   parent cancel cascades)       │                │
+//   │              └─────────────────────────────────┘                │
+//   │                          │                                     │
+//   │                          ▼                                     │
+//   │              FinishRun (writes terminal status)                 │
+//   │                          │                                     │
+//   │                          ▼                                     │
+//   │              Deregister(agentID)  ← `defer` so even panics      │
+//   │                                     deregister cleanly         │
+//   └────────────────────────────────────────────────────────────────┘
+//
+// Cancel from a separate request:
+//
+//   POST /v1/agents/<id>/cancel
+//   ↓
+//   Registry.Cancel("a_id", "user_clicked_stop")
+//   ↓
+//   1. cancelFn(ErrCancelledByAPI) — runCtx becomes cancelled with cause
+//   2. Walk children: each direct child's cancelFn fires too
+//      (recursively descends because each child's cancelFn ALSO triggers
+//      ITS subtree's ctx cascade)
+//   3. Loop iterations exit on next ctx check; FinishRun sees the cause
+//      and writes RunCancelled (rather than RunFailed) via the cause-
+//      aware logic in server.finishRun.
+package cancel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrCancelledByAPI is the cause attached to runCtx when the cancel
+// API is invoked. The HTTP server's finishRun checks this via
+// `errors.Is(context.Cause(runCtx), ErrCancelledByAPI)` and writes
+// status=cancelled rather than the default failed.
+//
+// Distinguishing API-cancel from client-disconnect (which produces
+// context.Canceled with no cause) matters: the former is a deliberate
+// terminal state worth recording; the latter is a transport hiccup
+// that should still mark the run as failed (or completed if the loop
+// happened to finish first).
+var ErrCancelledByAPI = errors.New("cancelled by api")
+
+// ErrInUse is returned by Register when an agent_id is already mapped
+// to a still-active run. The HTTP layer surfaces this as a 409.
+var ErrInUse = errors.New("agent_id already registered")
+
+// Entry is one row in the registry — the live cancel handle plus the
+// metadata needed for cascade lookups and observability.
+type Entry struct {
+	AgentID       string
+	RunID         string
+	SessionID     string
+	UserID        string
+	ParentAgentID string
+	StartedAt     time.Time
+	cancelFn      context.CancelCauseFunc
+}
+
+// CancelResult is what Cancel returns: whether the cancel actually
+// fired, the reason text recorded, and the agent_ids of every direct
+// or transitive child that was cancelled as part of the cascade.
+//
+// Idempotency: a Cancel of an already-deregistered agent_id returns
+// {Cancelled: false, Cascaded: nil} — the caller's HTTP response
+// becomes "already terminated" with whatever status the store records.
+type CancelResult struct {
+	Cancelled bool
+	Reason    string
+	Cascaded  []string
+}
+
+// Registry maps agent_id → live cancel handle. Safe for concurrent
+// use by the HTTP handler goroutines AND the run goroutines that
+// deregister on completion.
+type Registry struct {
+	mu      sync.RWMutex
+	entries map[string]Entry
+}
+
+// NewRegistry returns an empty registry. The HTTP server constructs
+// one at boot and threads it through every handler that creates a run.
+func NewRegistry() *Registry {
+	return &Registry{entries: make(map[string]Entry)}
+}
+
+// Register adds an agent_id → entry mapping. Returns ErrInUse if the
+// agent_id is already mapped to an active run. The caller MUST call
+// Deregister when the run terminates (typically via `defer` so even
+// panics clean up).
+//
+// The cancelFn passed in must be the result of context.WithCancelCause
+// — Cancel invokes it with ErrCancelledByAPI as the cause.
+func (r *Registry) Register(e Entry, cancelFn context.CancelCauseFunc) error {
+	if e.AgentID == "" {
+		return errors.New("registry: agent_id is required")
+	}
+	if cancelFn == nil {
+		return errors.New("registry: cancelFn is required")
+	}
+	e.cancelFn = cancelFn
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.entries[e.AgentID]; exists {
+		return ErrInUse
+	}
+	r.entries[e.AgentID] = e
+	return nil
+}
+
+// Deregister removes an agent_id from the registry. Idempotent — a
+// deregister of an unknown id is a no-op (typically the run was
+// already cancelled and the cancel path removed the entry).
+func (r *Registry) Deregister(agentID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.entries, agentID)
+}
+
+// Get returns the entry for an agent_id, or zero value + false. Used
+// by the GET /v1/agents/{agent_id} endpoint to determine "is this run
+// still in flight?" — when present, the answer is yes (the live entry
+// has not been deregistered). When absent, the endpoint falls back to
+// the store to surface the terminal status.
+func (r *Registry) Get(agentID string) (Entry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.entries[agentID]
+	return e, ok
+}
+
+// Cancel invokes the cancelFn for agentID and recursively cancels
+// every direct child (an entry whose ParentAgentID equals one of the
+// already-cancelled ids). The reason is attached as the cancel-cause
+// argument so the HTTP server's finishRun can record it as
+// runs.stop_reason.
+//
+// Idempotent: a second Cancel for an already-cancelled agentID returns
+// (CancelResult{Cancelled: false}, false). The caller can map this to
+// either "200 already done" or "404 unknown" by checking the store.
+//
+// Concurrency note: the cascade walk takes a single read-lock-then-
+// release-then-fire pattern (snapshot under RLock, then call
+// cancelFns outside the lock). Holding the lock while invoking
+// cancelFns would deadlock if a cancelFn synchronously triggers
+// Deregister via run goroutine cleanup.
+func (r *Registry) Cancel(agentID, reason string) (CancelResult, bool) {
+	cause := ErrCancelledByAPI
+	if reason != "" {
+		// Wrap the sentinel so context.Cause carries both the type
+		// (errors.Is(..., ErrCancelledByAPI) still works) and the
+		// human reason.
+		cause = &cancelWithReason{reason: reason}
+	}
+
+	// Snapshot and fire the requested entry under lock.
+	r.mu.Lock()
+	root, ok := r.entries[agentID]
+	if !ok {
+		r.mu.Unlock()
+		return CancelResult{}, false
+	}
+	delete(r.entries, agentID)
+	r.mu.Unlock()
+	root.cancelFn(cause)
+
+	// Walk children. We iterate over a snapshot so we never hold the
+	// lock while invoking cancelFns. New children registered during
+	// the cascade are correctly cancelled because the parent's
+	// cancelFn already cancelled their parent's runCtx, which they
+	// inherit via runSubAgent's ctx threading; the registry walk is a
+	// belt-and-braces measure for grandchildren whose parent already
+	// deregistered.
+	cascaded := []string{}
+	queue := []string{agentID}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+
+		r.mu.Lock()
+		var children []Entry
+		for id, e := range r.entries {
+			if e.ParentAgentID == parent {
+				children = append(children, e)
+				delete(r.entries, id)
+			}
+		}
+		r.mu.Unlock()
+
+		for _, c := range children {
+			c.cancelFn(cause)
+			cascaded = append(cascaded, c.AgentID)
+			queue = append(queue, c.AgentID)
+		}
+	}
+
+	return CancelResult{Cancelled: true, Reason: reason, Cascaded: cascaded}, true
+}
+
+// ListByUser returns a snapshot of every entry whose UserID matches.
+// Used by GET /v1/users/{user_id}/agents to surface what's running
+// for a user (the store has the terminal-state info; the registry
+// has the live in-flight info — together they let the UI reason
+// about both).
+func (r *Registry) ListByUser(userID string) []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if userID == "" {
+		return nil
+	}
+	var out []Entry
+	for _, e := range r.entries {
+		if e.UserID == userID {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// ListChildren returns direct children of an agent_id from the live
+// registry. Recursion is the caller's job (Cancel does this internally
+// via its queue walk). Exposed for tests and possible future
+// "list-tree" endpoints.
+func (r *Registry) ListChildren(parentAgentID string) []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if parentAgentID == "" {
+		return nil
+	}
+	var out []Entry
+	for _, e := range r.entries {
+		if e.ParentAgentID == parentAgentID {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// Count returns the number of live entries. Test-only helper; not
+// part of the public lifecycle.
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}
+
+// cancelWithReason wraps the API-cancel sentinel with a human reason
+// so context.Cause carries both. errors.Is(cause, ErrCancelledByAPI)
+// continues to identify the cancel as API-originated; cause.Error()
+// surfaces the operator-facing reason for inclusion in stop_reason.
+type cancelWithReason struct {
+	reason string
+}
+
+func (c *cancelWithReason) Error() string { return "cancelled by api: " + c.reason }
+func (c *cancelWithReason) Is(target error) bool {
+	return target == ErrCancelledByAPI
+}
+
+// Reason returns the reason text. The HTTP server's finishRun uses
+// this to populate runs.stop_reason when the cause is API-cancel.
+func (c *cancelWithReason) Reason() string { return c.reason }
+
+// ReasonFromCause extracts the reason text from a context.Cause value
+// produced by Cancel. Returns "" for non-API causes (e.g. plain
+// context.Canceled from client-disconnect, or a sentinel without a
+// reason wrapper).
+func ReasonFromCause(cause error) string {
+	if cause == nil {
+		return ""
+	}
+	var withReason *cancelWithReason
+	if errors.As(cause, &withReason) {
+		return withReason.reason
+	}
+	return ""
+}

--- a/internal/cancel/registry_test.go
+++ b/internal/cancel/registry_test.go
@@ -1,0 +1,286 @@
+package cancel
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// makeCancellable returns a (ctx, cancelFn) pair plus a boolean
+// pointer that flips to true the moment cancelFn is called. Lets
+// tests assert "the cancel actually fired" without racing on the
+// goroutine that observes ctx.
+func makeCancellable() (context.Context, context.CancelCauseFunc, *atomic.Bool) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	fired := &atomic.Bool{}
+	wrapped := func(cause error) {
+		fired.Store(true)
+		cancel(cause)
+	}
+	return ctx, wrapped, fired
+}
+
+// Happy path: register an entry, look it up, deregister.
+func TestRegistry_Register_Get_Deregister(t *testing.T) {
+	r := NewRegistry()
+	_, cancelFn, _ := makeCancellable()
+	e := Entry{AgentID: "a_1", RunID: "r_1", UserID: "u_1", StartedAt: time.Now()}
+
+	if err := r.Register(e, cancelFn); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	got, ok := r.Get("a_1")
+	if !ok {
+		t.Fatal("Get returned ok=false for registered agent")
+	}
+	if got.RunID != "r_1" || got.UserID != "u_1" {
+		t.Errorf("Get returned wrong entry: %+v", got)
+	}
+
+	r.Deregister("a_1")
+	if _, ok := r.Get("a_1"); ok {
+		t.Error("Get should miss after Deregister")
+	}
+}
+
+// Two simultaneous registrations of the same agent_id is a
+// programming error → ErrInUse. The second cancelFn is NOT registered.
+//
+// EMPIRICAL: removing the `if _, exists` guard in Register lets the
+// second registration overwrite the first; the first cancelFn would
+// be lost (cancel of agent_1 would fire only the second's cancelFn).
+func TestRegistry_DuplicateActive_Conflict(t *testing.T) {
+	r := NewRegistry()
+	_, c1, fired1 := makeCancellable()
+	_, c2, fired2 := makeCancellable()
+
+	if err := r.Register(Entry{AgentID: "a_dup", RunID: "r_1"}, c1); err != nil {
+		t.Fatal(err)
+	}
+	err := r.Register(Entry{AgentID: "a_dup", RunID: "r_2"}, c2)
+	if !errors.Is(err, ErrInUse) {
+		t.Fatalf("second Register: got %v, want ErrInUse", err)
+	}
+
+	// Cancel — only the first should fire.
+	r.Cancel("a_dup", "")
+	if !fired1.Load() {
+		t.Error("first cancelFn did not fire")
+	}
+	if fired2.Load() {
+		t.Error("second cancelFn fired despite Register failure")
+	}
+}
+
+// After deregistering, the same agent_id can be registered again.
+// This is the legitimate "caller reused agent_id after termination"
+// case — historical rows in the DB share the id, but only one is
+// active at a time.
+func TestRegistry_Deregister_AllowsReuse(t *testing.T) {
+	r := NewRegistry()
+	_, c1, _ := makeCancellable()
+	_, c2, fired2 := makeCancellable()
+
+	if err := r.Register(Entry{AgentID: "a_reuse"}, c1); err != nil {
+		t.Fatal(err)
+	}
+	r.Deregister("a_reuse")
+	if err := r.Register(Entry{AgentID: "a_reuse"}, c2); err != nil {
+		t.Errorf("re-register after Deregister should succeed: %v", err)
+	}
+	r.Cancel("a_reuse", "")
+	if !fired2.Load() {
+		t.Error("second cancelFn should fire after re-register + cancel")
+	}
+}
+
+// Cancel without a reason produces a context.Cause that is exactly
+// ErrCancelledByAPI (so errors.Is matches). This is what server.finishRun
+// uses to discriminate API-cancel from client-disconnect.
+//
+// EMPIRICAL: changing the cause in Cancel from ErrCancelledByAPI to
+// any other sentinel makes errors.Is(..., ErrCancelledByAPI) return
+// false — finishRun would write status=failed instead of cancelled.
+func TestRegistry_Cancel_WithoutReason_AttachesAPICause(t *testing.T) {
+	r := NewRegistry()
+	ctx, cancelFn, _ := makeCancellable()
+	_ = r.Register(Entry{AgentID: "a_x"}, cancelFn)
+
+	r.Cancel("a_x", "")
+	cause := context.Cause(ctx)
+	if !errors.Is(cause, ErrCancelledByAPI) {
+		t.Errorf("cause = %v; should match ErrCancelledByAPI via errors.Is", cause)
+	}
+}
+
+// Cancel with a reason wraps the cause but keeps errors.Is matching
+// AND surfaces the reason via ReasonFromCause. The HTTP server uses
+// the latter to populate runs.stop_reason.
+func TestRegistry_Cancel_WithReason_PreservesIsAndReason(t *testing.T) {
+	r := NewRegistry()
+	ctx, cancelFn, _ := makeCancellable()
+	_ = r.Register(Entry{AgentID: "a_x"}, cancelFn)
+
+	r.Cancel("a_x", "user_clicked_stop")
+	cause := context.Cause(ctx)
+	if !errors.Is(cause, ErrCancelledByAPI) {
+		t.Errorf("errors.Is should still match the sentinel: cause=%v", cause)
+	}
+	if got := ReasonFromCause(cause); got != "user_clicked_stop" {
+		t.Errorf("ReasonFromCause = %q, want user_clicked_stop", got)
+	}
+}
+
+// Cancel of an unknown agent_id returns ok=false (not an error).
+// The HTTP layer maps this to "look in the store for terminal state"
+// rather than 404 unconditionally — a recently-finished run might have
+// already deregistered.
+func TestRegistry_Cancel_UnknownAgent_OkFalse(t *testing.T) {
+	r := NewRegistry()
+	res, ok := r.Cancel("a_does_not_exist", "")
+	if ok {
+		t.Errorf("ok = true for unknown agent_id, got result %+v", res)
+	}
+}
+
+// Cascade: parent + 2 direct children + 1 grandchild. Cancel parent;
+// every cancelFn in the tree fires; cascaded list contains all
+// non-root agent_ids.
+//
+// EMPIRICAL: removing the recursive walk (the `for len(queue) > 0`
+// loop body) leaves the grandchild's cancelFn unfired and absent
+// from cascaded.
+func TestRegistry_Cancel_CascadesTree(t *testing.T) {
+	r := NewRegistry()
+	_, parentCancel, parentFired := makeCancellable()
+	_, child1Cancel, child1Fired := makeCancellable()
+	_, child2Cancel, child2Fired := makeCancellable()
+	_, grandCancel, grandFired := makeCancellable()
+
+	_ = r.Register(Entry{AgentID: "a_parent"}, parentCancel)
+	_ = r.Register(Entry{AgentID: "a_child1", ParentAgentID: "a_parent"}, child1Cancel)
+	_ = r.Register(Entry{AgentID: "a_child2", ParentAgentID: "a_parent"}, child2Cancel)
+	_ = r.Register(Entry{AgentID: "a_grand", ParentAgentID: "a_child1"}, grandCancel)
+
+	res, ok := r.Cancel("a_parent", "shutdown")
+	if !ok {
+		t.Fatal("Cancel returned ok=false for known parent")
+	}
+	if !parentFired.Load() || !child1Fired.Load() || !child2Fired.Load() || !grandFired.Load() {
+		t.Errorf("not every cancelFn fired: parent=%v c1=%v c2=%v gc=%v",
+			parentFired.Load(), child1Fired.Load(), child2Fired.Load(), grandFired.Load())
+	}
+	wantCascaded := map[string]bool{"a_child1": true, "a_child2": true, "a_grand": true}
+	if len(res.Cascaded) != 3 {
+		t.Errorf("cascaded len = %d (want 3): %v", len(res.Cascaded), res.Cascaded)
+	}
+	for _, id := range res.Cascaded {
+		if !wantCascaded[id] {
+			t.Errorf("unexpected cascaded id: %s", id)
+		}
+		delete(wantCascaded, id)
+	}
+	if len(wantCascaded) > 0 {
+		t.Errorf("missing from cascaded: %v", wantCascaded)
+	}
+
+	// Registry should be empty now (cascade deregistered all).
+	if r.Count() != 0 {
+		t.Errorf("registry not drained after cascade: %d entries left", r.Count())
+	}
+}
+
+// Concurrent Cancels of the same agent_id: exactly one returns
+// (ok=true), all others return (ok=false). The cancelFn fires
+// exactly once. This guards the idempotency claim in the docs.
+func TestRegistry_Cancel_ConcurrentIsIdempotent(t *testing.T) {
+	r := NewRegistry()
+	var fireCount atomic.Int32
+	_, cancelFn, _ := makeCancellable()
+	wrapped := func(cause error) {
+		fireCount.Add(1)
+		cancelFn(cause)
+	}
+	_ = r.Register(Entry{AgentID: "a_c"}, wrapped)
+
+	const N = 20
+	var wg sync.WaitGroup
+	var oks atomic.Int32
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, ok := r.Cancel("a_c", ""); ok {
+				oks.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := oks.Load(); got != 1 {
+		t.Errorf("ok count = %d, want exactly 1", got)
+	}
+	if got := fireCount.Load(); got != 1 {
+		t.Errorf("cancelFn fired %d times, want 1", got)
+	}
+}
+
+// ListByUser returns only entries with the matching UserID.
+func TestRegistry_ListByUser(t *testing.T) {
+	r := NewRegistry()
+	_, c1, _ := makeCancellable()
+	_, c2, _ := makeCancellable()
+	_, c3, _ := makeCancellable()
+
+	_ = r.Register(Entry{AgentID: "a_a1", UserID: "alice"}, c1)
+	_ = r.Register(Entry{AgentID: "a_a2", UserID: "alice"}, c2)
+	_ = r.Register(Entry{AgentID: "a_b1", UserID: "bob"}, c3)
+
+	alices := r.ListByUser("alice")
+	if len(alices) != 2 {
+		t.Errorf("alice has %d entries, want 2", len(alices))
+	}
+	for _, e := range alices {
+		if e.UserID != "alice" {
+			t.Errorf("non-alice entry leaked: %+v", e)
+		}
+	}
+
+	if got := r.ListByUser(""); got != nil {
+		t.Errorf("empty userID should return nil, got %d", len(got))
+	}
+}
+
+// ListChildren returns direct children only — parity with the SQL
+// ListRunsByParentAgentID. Recursion is the caller's job.
+func TestRegistry_ListChildren_DirectOnly(t *testing.T) {
+	r := NewRegistry()
+	_, c1, _ := makeCancellable()
+	_, c2, _ := makeCancellable()
+	_, c3, _ := makeCancellable()
+	_ = r.Register(Entry{AgentID: "a_p"}, c1)
+	_ = r.Register(Entry{AgentID: "a_c1", ParentAgentID: "a_p"}, c2)
+	_ = r.Register(Entry{AgentID: "a_gc", ParentAgentID: "a_c1"}, c3)
+
+	got := r.ListChildren("a_p")
+	if len(got) != 1 || got[0].AgentID != "a_c1" {
+		t.Errorf("ListChildren(a_p) = %+v, want only [a_c1]", got)
+	}
+}
+
+// Empty agent_id is a programming error in Register — refused with a
+// descriptive error rather than silently storing under "".
+func TestRegistry_Register_RejectsEmptyInputs(t *testing.T) {
+	r := NewRegistry()
+	_, cancelFn, _ := makeCancellable()
+
+	if err := r.Register(Entry{AgentID: ""}, cancelFn); err == nil {
+		t.Error("expected error on empty AgentID")
+	}
+	if err := r.Register(Entry{AgentID: "a_x"}, nil); err == nil {
+		t.Error("expected error on nil cancelFn")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,10 +23,35 @@ type Config struct {
 	MCPServers  map[string]MCPServer `yaml:"mcp_servers"`
 	Concurrency Concurrency          `yaml:"concurrency"`
 	Cache       CacheConfig          `yaml:"cache"`
+	// LocalAPI declares the OpenAPI-derived MCP gateway (v0.4.0+).
+	// One tool is generated per operation; tools forward calls to
+	// BaseURL with the agent's `bearer` field as Authorization.
+	// Empty SpecPath disables the gateway. See
+	// internal/tools/localapi for the wire model.
+	LocalAPI LocalAPIConfig `yaml:"local_api"`
 
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
+
+	// configDir is the directory of the loaded YAML, kept so relative
+	// paths inside the config (system_prompt_file, local_api.spec) can
+	// be resolved against it.
+	configDir string `yaml:"-"`
 }
+
+// LocalAPIConfig is the operator-supplied config for the local-api
+// gateway. Mirrors localapi.Config but lives in the config package so
+// tests don't need to import the localapi package.
+type LocalAPIConfig struct {
+	SpecPath       string `yaml:"spec"`
+	BaseURL        string `yaml:"base_url"`
+	ToolNamePrefix string `yaml:"tool_name_prefix"`
+}
+
+// ConfigDir returns the directory the YAML was loaded from. Used by
+// callers that need to resolve relative paths declared in the config
+// (the local-api spec path, additional resource files).
+func (c *Config) ConfigDir() string { return c.configDir }
 
 // Defaults are the fall-throughs for agents that don't specify them.
 type Defaults struct {
@@ -192,6 +217,11 @@ func Load(path string) (*Config, error) {
 		expanded := expandEnv(string(raw))
 		if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
 			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		// Stash the config directory so callers (e.g. localapi.Build)
+		// can resolve relative paths declared inside the YAML.
+		if abs, err := filepath.Abs(filepath.Dir(path)); err == nil {
+			cfg.configDir = abs
 		}
 		// Resolve any agent's system_prompt_file → system_prompt. Done
 		// here so the rest of the runtime sees a uniform AgentDef

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -50,6 +50,15 @@ type RunOptions struct {
 	// caller's new Segments. Used by the continuation endpoint to replay
 	// a session's prior turns. Empty for a fresh run (the v0.2 case).
 	PriorMessages []providers.Message
+
+	// OnHeartbeat fires once at the start of each iteration (after the
+	// previous iteration's events have all drained). The HTTP server
+	// uses this to update runs.last_heartbeat_at — foundation for the
+	// v0.4.x sweeper that detects crashed runs by stale heartbeats.
+	// Optional; nil disables. Called from the loop goroutine,
+	// synchronously, so implementations should be cheap (single
+	// UPDATE) and tolerate ctx cancellation gracefully.
+	OnHeartbeat func()
 }
 
 // RunResult is the terminal state after a Run.
@@ -94,6 +103,14 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	var stopReason string
 
 	for iter := 0; iter < opts.MaxIterations; iter++ {
+		// Heartbeat fires at the top of each iteration. Cheap path —
+		// implementations are expected to be ~one UPDATE. Failures
+		// should NOT propagate (a sweeper in the future is the
+		// authoritative path; a missed heartbeat just means we have
+		// to wait for the sweeper to catch up).
+		if opts.OnHeartbeat != nil {
+			opts.OnHeartbeat()
+		}
 		req := providers.Request{
 			Model:    opts.Model,
 			System:   system,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -56,6 +57,13 @@ func Open(path string) (*Store, error) {
 
 // migrate creates the schema if needed. Idempotent. v0.3 schema is fixed; if
 // we add columns post-1.0 we'll add a versioned migration table.
+//
+// The two phases below are separated because:
+//   - Phase 1 (CREATE) is unconditionally idempotent (IF NOT EXISTS).
+//   - Phase 2 (ALTER ADD COLUMN) is NOT idempotent in SQLite — re-running
+//     the same ADD on an existing column returns "duplicate column name".
+//     We swallow exactly that error so a second startup is a no-op without
+//     introducing a versioned migrations table for v0.4.
 func (s *Store) migrate(ctx context.Context) error {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS sessions (
@@ -94,30 +102,74 @@ func (s *Store) migrate(ctx context.Context) error {
 			return fmt.Errorf("migrate: %w", err)
 		}
 	}
+
+	// v0.4 additive columns + indexes for tracking + cancel.
+	//
+	// Order matters only in that ALTER must precede the partial indexes
+	// that reference the new columns.
+	addColumns := []string{
+		`ALTER TABLE sessions ADD COLUMN user_id TEXT`,
+		`ALTER TABLE runs ADD COLUMN agent_id TEXT`,
+		`ALTER TABLE runs ADD COLUMN parent_agent_id TEXT`,
+		`ALTER TABLE runs ADD COLUMN parent_run_id TEXT`,
+		`ALTER TABLE runs ADD COLUMN user_id TEXT`,
+		`ALTER TABLE runs ADD COLUMN last_heartbeat_at INTEGER`,
+	}
+	for _, q := range addColumns {
+		if _, err := s.db.ExecContext(ctx, q); err != nil {
+			// SQLite returns errors of the form "duplicate column name: X"
+			// when the column already exists. Match on substring rather
+			// than introspecting the schema with PRAGMA table_info — the
+			// substring check is well-defined for modernc/sqlite and
+			// cheaper.
+			if strings.Contains(err.Error(), "duplicate column name") {
+				continue
+			}
+			return fmt.Errorf("migrate add column: %w", err)
+		}
+	}
+
+	addIndexes := []string{
+		// Drives the hot lookup paths for the cancel/get endpoints.
+		// Partial indexes (WHERE ... IS NOT NULL) keep the index small —
+		// the vast majority of historical rows have no agent_id.
+		`CREATE INDEX IF NOT EXISTS runs_by_agent_id        ON runs(agent_id)        WHERE agent_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS runs_by_parent_agent_id ON runs(parent_agent_id) WHERE parent_agent_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS runs_by_user_active     ON runs(user_id, status) WHERE user_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS sessions_by_user        ON sessions(user_id)     WHERE user_id IS NOT NULL`,
+	}
+	for _, q := range addIndexes {
+		if _, err := s.db.ExecContext(ctx, q); err != nil {
+			return fmt.Errorf("migrate add index: %w", err)
+		}
+	}
 	return nil
 }
 
 // CreateSession inserts a new session with a generated ID and returns it.
-func (s *Store) CreateSession(ctx context.Context, tenantID, agent string) (store.Session, error) {
+// userID may be empty (e.g. legacy callers); the column accepts NULL via the
+// pointer-conversion below so empty doesn't shadow as "" on read.
+func (s *Store) CreateSession(ctx context.Context, tenantID, agent, userID string) (store.Session, error) {
 	id := newID("s_")
 	now := time.Now()
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO sessions(id, tenant_id, agent, created_at) VALUES (?, ?, ?, ?)`,
-		id, tenantID, agent, now.UnixNano(),
+		`INSERT INTO sessions(id, tenant_id, agent, created_at, user_id) VALUES (?, ?, ?, ?, ?)`,
+		id, tenantID, agent, now.UnixNano(), nilIfEmpty(userID),
 	)
 	if err != nil {
 		return store.Session{}, err
 	}
-	return store.Session{ID: id, TenantID: tenantID, Agent: agent, CreatedAt: now}, nil
+	return store.Session{ID: id, TenantID: tenantID, Agent: agent, CreatedAt: now, UserID: userID}, nil
 }
 
 // GetSession returns session metadata or *store.ErrNotFound.
 func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
 	var sess store.Session
 	var createdNs int64
+	var userID sql.NullString
 	err := s.db.QueryRowContext(ctx,
-		`SELECT id, tenant_id, agent, created_at FROM sessions WHERE id = ?`, sessionID,
-	).Scan(&sess.ID, &sess.TenantID, &sess.Agent, &createdNs)
+		`SELECT id, tenant_id, agent, created_at, user_id FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&sess.ID, &sess.TenantID, &sess.Agent, &createdNs, &userID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
 	}
@@ -125,11 +177,16 @@ func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session
 		return store.Session{}, err
 	}
 	sess.CreatedAt = time.Unix(0, createdNs)
+	if userID.Valid {
+		sess.UserID = userID.String
+	}
 	return sess, nil
 }
 
-// CreateRun starts a new run inside an existing session.
-func (s *Store) CreateRun(ctx context.Context, sessionID string) (store.Run, error) {
+// CreateRun starts a new run inside an existing session. The caller may
+// supply identity fields (agent_id, parent linkage, denormalised user_id)
+// for v0.4+ tracking; an empty RunIdentity behaves as v0.3 did.
+func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.RunIdentity) (store.Run, error) {
 	// Verify the session exists so a missing ID surfaces as ErrNotFound,
 	// not a foreign-key error.
 	if _, err := s.GetSession(ctx, sessionID); err != nil {
@@ -138,17 +195,26 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string) (store.Run, err
 	id := newID("r_")
 	now := time.Now()
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at) VALUES (?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
+		nilIfEmpty(identity.AgentID),
+		nilIfEmpty(identity.ParentAgentID),
+		nilIfEmpty(identity.ParentRunID),
+		nilIfEmpty(identity.UserID),
 	)
 	if err != nil {
 		return store.Run{}, err
 	}
 	return store.Run{
-		ID:        id,
-		SessionID: sessionID,
-		Status:    store.RunRunning,
-		StartedAt: now,
+		ID:            id,
+		SessionID:     sessionID,
+		Status:        store.RunRunning,
+		StartedAt:     now,
+		AgentID:       identity.AgentID,
+		ParentAgentID: identity.ParentAgentID,
+		ParentRunID:   identity.ParentRunID,
+		UserID:        identity.UserID,
 	}, nil
 }
 
@@ -222,6 +288,173 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 		out = append(out, ev)
 	}
 	return out, rows.Err()
+}
+
+// scanRun decodes one row from a runs SELECT into a store.Run. The
+// SELECT column list MUST match the order in runColumns below.
+func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
+	var r store.Run
+	var startedNs, completedNs sql.NullInt64
+	var lastHbNs sql.NullInt64
+	var stopReason, model, errMsg sql.NullString
+	var agentID, parentAgentID, parentRunID, userID sql.NullString
+	var status string
+	if err := scanner.Scan(
+		&r.ID, &r.SessionID, &status, &startedNs, &completedNs,
+		&stopReason,
+		&r.InputTokens, &r.OutputTokens, &r.CacheCreationTokens, &r.CacheReadTokens,
+		&model, &errMsg,
+		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
+	); err != nil {
+		return store.Run{}, err
+	}
+	r.Status = store.RunStatus(status)
+	if startedNs.Valid {
+		r.StartedAt = time.Unix(0, startedNs.Int64)
+	}
+	if completedNs.Valid {
+		r.CompletedAt = time.Unix(0, completedNs.Int64)
+	}
+	if lastHbNs.Valid {
+		r.LastHeartbeatAt = time.Unix(0, lastHbNs.Int64)
+	}
+	if stopReason.Valid {
+		r.StopReason = stopReason.String
+	}
+	if model.Valid {
+		r.Model = model.String
+	}
+	if errMsg.Valid {
+		r.ErrorMsg = errMsg.String
+	}
+	if agentID.Valid {
+		r.AgentID = agentID.String
+	}
+	if parentAgentID.Valid {
+		r.ParentAgentID = parentAgentID.String
+	}
+	if parentRunID.Valid {
+		r.ParentRunID = parentRunID.String
+	}
+	if userID.Valid {
+		r.UserID = userID.String
+	}
+	return r, nil
+}
+
+// runColumns is the canonical SELECT column list paired with scanRun.
+// Centralised so a future column addition is a one-line change.
+const runColumns = `id, session_id, status, started_at, completed_at,
+		stop_reason,
+		input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+		model, error,
+		agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at`
+
+// GetRunByAgentID returns the most recently started run carrying the
+// given agent_id, or *store.ErrNotFound. Multiple historical runs may
+// share an agent_id (a caller reused it after the first terminated);
+// we surface the latest, which is the one any cancel/status caller
+// would mean.
+func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run, error) {
+	if agentID == "" {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+runColumns+` FROM runs WHERE agent_id = ? ORDER BY started_at DESC LIMIT 1`,
+		agentID,
+	)
+	r, err := scanRun(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	return r, err
+}
+
+// ListActiveRunsByUser returns runs for userID whose status matches the
+// supplied filter. An empty status returns ALL statuses. Capped at 100
+// rows ordered by started_at DESC.
+func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status store.RunStatus) ([]store.Run, error) {
+	if userID == "" {
+		return nil, nil
+	}
+	var rows *sql.Rows
+	var err error
+	if status == "" {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT `+runColumns+` FROM runs WHERE user_id = ? ORDER BY started_at DESC LIMIT 100`,
+			userID,
+		)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT `+runColumns+` FROM runs WHERE user_id = ? AND status = ? ORDER BY started_at DESC LIMIT 100`,
+			userID, string(status),
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.Run
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ListRunsByParentAgentID returns the runs whose parent_agent_id
+// matches. Drives cascade-cancel discovery (every direct child of a
+// parent agent_id). Recursion (grandchildren) is the caller's job —
+// keeps this query simple and lets the cancel handler walk the tree
+// however it wants.
+func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID string) ([]store.Run, error) {
+	if parentAgentID == "" {
+		return nil, nil
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+runColumns+` FROM runs WHERE parent_agent_id = ? ORDER BY started_at ASC`,
+		parentAgentID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.Run
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// UpdateHeartbeat sets last_heartbeat_at to the current time. No-op for
+// runs that aren't currently running (the WHERE guard prevents a slow
+// hb update from un-finishing a terminal run that just got cancelled).
+func (s *Store) UpdateHeartbeat(ctx context.Context, runID string) error {
+	if runID == "" {
+		return nil
+	}
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE runs SET last_heartbeat_at = ? WHERE id = ? AND status = ?`,
+		time.Now().UnixNano(), runID, string(store.RunRunning),
+	)
+	return err
+}
+
+// nilIfEmpty returns nil when s is empty so the SQL driver writes NULL
+// rather than an empty string. Callers should prefer NULL for "no
+// value" so that COUNT(column) and IS NULL queries behave correctly.
+func nilIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 // Close closes the underlying *sql.DB. Idempotent.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -139,6 +139,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS sessions_by_user        ON sessions(user_id)     WHERE user_id IS NOT NULL`,
 	}
 	for _, q := range addIndexes {
+		// Note the asymmetry vs addColumns above: indexes use
+		// `CREATE INDEX IF NOT EXISTS` which is unconditionally
+		// idempotent, so we don't need to swallow "duplicate"
+		// errors. If you ADD a non-IF-NOT-EXISTS statement here for
+		// some reason, do NOT copy the column-loop's substring guard —
+		// you'd silently suppress real schema errors. Keep the
+		// idempotent shape consistent across all index DDL.
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
 			return fmt.Errorf("migrate add index: %w", err)
 		}

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
@@ -26,7 +27,7 @@ func TestCreateAndGetSession(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
 
-	sess, err := s.CreateSession(ctx, "tenant-a", "default")
+	sess, err := s.CreateSession(ctx, "tenant-a", "default", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,9 +62,9 @@ func TestGetSessionNotFound(t *testing.T) {
 func TestRunLifecycle(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	sess, _ := s.CreateSession(ctx, "t", "default")
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
 
-	run, err := s.CreateRun(ctx, sess.ID)
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +130,7 @@ func TestAppendEventOnUnknownRun(t *testing.T) {
 
 func TestCreateRunOnUnknownSession(t *testing.T) {
 	s := newTestStore(t)
-	_, err := s.CreateRun(context.Background(), "s_nope")
+	_, err := s.CreateRun(context.Background(), "s_nope", store.RunIdentity{})
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
@@ -143,8 +144,8 @@ func TestCreateRunOnUnknownSession(t *testing.T) {
 func TestFinishRunIdempotent(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	sess, _ := s.CreateSession(ctx, "t", "default")
-	run, _ := s.CreateRun(ctx, sess.ID)
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{})
 
 	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
 		t.Fatal(err)
@@ -160,13 +161,285 @@ func TestFinishRunIdempotent(t *testing.T) {
 func TestGetTranscriptEmpty(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
-	sess, _ := s.CreateSession(ctx, "t", "default")
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
 	transcript, err := s.GetTranscript(ctx, sess.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if len(transcript) != 0 {
 		t.Errorf("len = %d, want 0", len(transcript))
+	}
+}
+
+// v0.4 tracking + cancel field tests.
+//
+// All of the new columns are nullable additive ALTERs, so older code paths
+// (CreateSession with empty userID, CreateRun with zero RunIdentity) keep
+// working. The tests below verify the new fields round-trip, the new query
+// methods return what's expected, and the heartbeat update has the
+// status='running' guard the comments claim.
+
+// Idempotent migration: opening the same DB twice MUST NOT error. The
+// "duplicate column name" tolerance in migrate() is the only thing that
+// makes this safe.
+//
+// EMPIRICAL: removing the strings.Contains "duplicate column name" guard
+// from the addColumns loop in sqlite.go makes the second Open() error.
+func TestMigrate_AddsColumnsIdempotently(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+	s1, err := Open(path)
+	if err != nil {
+		t.Fatalf("first Open: %v", err)
+	}
+	if err := s1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	s2, err := Open(path)
+	if err != nil {
+		t.Fatalf("second Open should not error after schema is already in place: %v", err)
+	}
+	defer s2.Close()
+}
+
+// CreateSession with a non-empty userID round-trips through GetSession.
+// Empty userID stores NULL — verified via a direct sql query so we're sure
+// the column is actually NULL and not "" (matters for IS NOT NULL filters
+// on the indexes).
+func TestCreateSession_UserIDRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	sess, err := s.CreateSession(ctx, "tenant-x", "agent-x", "user-42")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess.UserID != "user-42" {
+		t.Errorf("CreateSession returned UserID %q, want user-42", sess.UserID)
+	}
+	got, err := s.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UserID != "user-42" {
+		t.Errorf("GetSession UserID = %q, want user-42", got.UserID)
+	}
+
+	// Empty userID writes NULL.
+	emptySess, _ := s.CreateSession(ctx, "t", "a", "")
+	var nullCheck *string
+	row := s.db.QueryRowContext(ctx, `SELECT user_id FROM sessions WHERE id = ?`, emptySess.ID)
+	if err := row.Scan(&nullCheck); err != nil {
+		t.Fatal(err)
+	}
+	if nullCheck != nil {
+		t.Errorf("empty userID should write NULL, got %q", *nullCheck)
+	}
+}
+
+// All v0.4 RunIdentity fields round-trip via CreateRun → GetRunByAgentID.
+func TestCreateRun_IdentityRoundTrip(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	identity := store.RunIdentity{
+		AgentID:       "a_top",
+		ParentAgentID: "a_grandparent",
+		ParentRunID:   "r_grandparent",
+		UserID:        "user-1",
+	}
+	run, err := s.CreateRun(ctx, sess.ID, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.AgentID != "a_top" || run.UserID != "user-1" || run.ParentAgentID != "a_grandparent" || run.ParentRunID != "r_grandparent" {
+		t.Errorf("CreateRun did not return the supplied identity: %+v", run)
+	}
+
+	got, err := s.GetRunByAgentID(ctx, "a_top")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != run.ID {
+		t.Errorf("GetRunByAgentID returned wrong run: got %s, want %s", got.ID, run.ID)
+	}
+	if got.AgentID != "a_top" || got.UserID != "user-1" {
+		t.Errorf("identity not preserved through GetRunByAgentID: %+v", got)
+	}
+}
+
+// GetRunByAgentID returns ErrNotFound for unknown ids, including the
+// empty string (a convenient guard so callers don't need to pre-check).
+func TestGetRunByAgentID_NotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for _, id := range []string{"a_does_not_exist", ""} {
+		_, err := s.GetRunByAgentID(ctx, id)
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			t.Errorf("agent_id %q: got %v (%T), want *store.ErrNotFound", id, err, err)
+		}
+	}
+}
+
+// When a single agent_id is reused across runs (after the first
+// terminated), GetRunByAgentID returns the MOST RECENT — that's the
+// one any cancel/status caller would mean.
+func TestGetRunByAgentID_ReturnsMostRecent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+
+	older, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_reused", UserID: "u"})
+	_ = s.FinishRun(ctx, older.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	// Tiny gap so started_at differs.
+	time.Sleep(2 * time.Millisecond)
+	newer, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_reused", UserID: "u"})
+
+	got, err := s.GetRunByAgentID(ctx, "a_reused")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != newer.ID {
+		t.Errorf("got run %s, want most-recent %s (older was %s)", got.ID, newer.ID, older.ID)
+	}
+}
+
+// ListActiveRunsByUser filters on (user_id, status). Empty status
+// returns ALL statuses for that user.
+func TestListActiveRunsByUser(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "alice")
+
+	r1, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_1", UserID: "alice"})
+	r2, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_2", UserID: "alice"})
+	_, _ = s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_other", UserID: "bob"})
+	_ = s.FinishRun(ctx, r1.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	// Only running for alice.
+	active, err := s.ListActiveRunsByUser(ctx, "alice", store.RunRunning)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(active) != 1 || active[0].ID != r2.ID {
+		ids := make([]string, len(active))
+		for i, r := range active {
+			ids[i] = r.ID
+		}
+		t.Errorf("running for alice: got %v, want [%s]", ids, r2.ID)
+	}
+
+	// All statuses for alice.
+	all, _ := s.ListActiveRunsByUser(ctx, "alice", "")
+	if len(all) != 2 {
+		t.Errorf("all for alice: got %d, want 2", len(all))
+	}
+
+	// Bob's runs shouldn't leak into alice's results.
+	for _, r := range all {
+		if r.UserID == "bob" {
+			t.Errorf("bob's run leaked into alice's list: %s", r.ID)
+		}
+	}
+
+	// Empty userID returns nil — guards against a misconfigured caller.
+	if got, _ := s.ListActiveRunsByUser(ctx, "", store.RunRunning); got != nil {
+		t.Errorf("empty userID should return nil, got %d rows", len(got))
+	}
+}
+
+// ListRunsByParentAgentID returns direct children only — recursion to
+// grandchildren is the caller's responsibility (keeps the SQL simple).
+func TestListRunsByParentAgentID(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+
+	c1, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_child1", ParentAgentID: "a_parent", UserID: "u"})
+	c2, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_child2", ParentAgentID: "a_parent", UserID: "u"})
+	// A grandchild that should NOT appear.
+	_, _ = s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_gc", ParentAgentID: "a_child1", UserID: "u"})
+
+	got, err := s.ListRunsByParentAgentID(ctx, "a_parent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2 (direct children only)", len(got))
+	}
+	ids := map[string]bool{got[0].ID: true, got[1].ID: true}
+	if !ids[c1.ID] || !ids[c2.ID] {
+		t.Errorf("expected children %s and %s, got %+v", c1.ID, c2.ID, got)
+	}
+}
+
+// UpdateHeartbeat advances last_heartbeat_at on running runs. After the
+// run finishes, the WHERE status='running' guard makes UpdateHeartbeat a
+// no-op so a slow-arriving heartbeat can't un-finalise a terminal run.
+//
+// EMPIRICAL: removing the AND status = ? from UpdateHeartbeat lets the
+// post-finish heartbeat clobber last_heartbeat_at; this test's "after
+// finish" assertion would then fail.
+func TestUpdateHeartbeat(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_hb", UserID: "u"})
+
+	if err := s.UpdateHeartbeat(ctx, run.ID); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := s.GetRunByAgentID(ctx, "a_hb")
+	if first.LastHeartbeatAt.IsZero() {
+		t.Fatal("first heartbeat should be non-zero")
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	_ = s.UpdateHeartbeat(ctx, run.ID)
+	second, _ := s.GetRunByAgentID(ctx, "a_hb")
+	if !second.LastHeartbeatAt.After(first.LastHeartbeatAt) {
+		t.Errorf("heartbeat not monotonic: first=%v second=%v", first.LastHeartbeatAt, second.LastHeartbeatAt)
+	}
+
+	// Finish the run, then try another heartbeat — must be a no-op.
+	_ = s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+	final, _ := s.GetRunByAgentID(ctx, "a_hb")
+	time.Sleep(2 * time.Millisecond)
+	_ = s.UpdateHeartbeat(ctx, run.ID)
+	afterFinish, _ := s.GetRunByAgentID(ctx, "a_hb")
+	if !afterFinish.LastHeartbeatAt.Equal(final.LastHeartbeatAt) {
+		t.Errorf("heartbeat advanced after run terminal: %v vs %v",
+			afterFinish.LastHeartbeatAt, final.LastHeartbeatAt)
+	}
+}
+
+// FinishRun honors RunCancelled and the status='running' guard prevents
+// a stale completed write from overwriting a cancellation.
+func TestFinishRun_CancelledTerminal(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_x", UserID: "u"})
+
+	if err := s.FinishRun(ctx, run.ID, store.RunCancelled, "user_clicked_stop", store.Usage{}, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.GetRunByAgentID(ctx, "a_x")
+	if got.Status != store.RunCancelled {
+		t.Errorf("status = %q, want cancelled", got.Status)
+	}
+	if got.StopReason != "user_clicked_stop" {
+		t.Errorf("stop_reason = %q", got.StopReason)
+	}
+
+	// Late-arriving completed must be a no-op (status='running' guard).
+	_ = s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+	again, _ := s.GetRunByAgentID(ctx, "a_x")
+	if again.Status != store.RunCancelled {
+		t.Errorf("late completed should not overwrite cancelled, got %q", again.Status)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -26,6 +26,10 @@ type Session struct {
 	TenantID  string    `json:"tenant_id"`
 	Agent     string    `json:"agent"`
 	CreatedAt time.Time `json:"created_at"`
+	// UserID binds the session to a user (v0.4+). Empty for legacy
+	// rows that pre-date the column. Caller-supplied at session
+	// creation; sub-agent sessions inherit the parent's value.
+	UserID string `json:"user_id,omitempty"`
 }
 
 // RunStatus is the terminal state of a run, or "running" while it's still in
@@ -53,6 +57,30 @@ type Run struct {
 	CacheReadTokens     int       `json:"cache_read_input_tokens,omitempty"`
 	Model               string    `json:"model,omitempty"`
 	ErrorMsg            string    `json:"error,omitempty"`
+
+	// v0.4 tracking + cancel fields. All optional/nullable for
+	// back-compat with rows created before the columns landed.
+
+	// AgentID is the caller-supplied (or loomcycle-generated)
+	// tracking handle. Distinct from SessionID — agent_id is
+	// per-run, session_id is per-conversation-thread. Used as the
+	// addressable identifier for the cancel/get/list endpoints.
+	AgentID string `json:"agent_id,omitempty"`
+	// ParentAgentID is set on sub-agent runs to the spawning
+	// agent's AgentID. Drives cascade-cancel.
+	ParentAgentID string `json:"parent_agent_id,omitempty"`
+	// ParentRunID is the direct parent run for sub-agent runs.
+	// Useful for transcript stitching.
+	ParentRunID string `json:"parent_run_id,omitempty"`
+	// UserID is denormalised from the session for fast cancel/list
+	// lookups without a session join. Set at run creation; never
+	// mutated.
+	UserID string `json:"user_id,omitempty"`
+	// LastHeartbeatAt is updated by the loop at each iteration so
+	// a future sweeper can detect crashed runs (no heartbeat for
+	// > N minutes → presumed dead). Zero-time means no heartbeat
+	// yet (run never reached its first iteration).
+	LastHeartbeatAt time.Time `json:"last_heartbeat_at,omitempty"`
 }
 
 // Event is one streamed datum, persisted append-only. Payload is the JSON
@@ -77,14 +105,38 @@ type Usage struct {
 	Model               string
 }
 
+// RunIdentity carries the v0.4 tracking fields a CreateRun caller can
+// supply. Zero-value fields mean "no value" — implementations must
+// store them as NULL (or empty string for TEXT columns) so historical
+// rows remain queryable.
+type RunIdentity struct {
+	// AgentID is the caller-supplied tracking handle, or
+	// loomcycle-generated for top-level runs without a caller value
+	// and for sub-agent runs (which always get a fresh ID).
+	AgentID string
+	// ParentAgentID is set only on sub-agent runs (the spawning
+	// agent's AgentID).
+	ParentAgentID string
+	// ParentRunID is the direct parent run row's ID. Set with
+	// ParentAgentID on sub-agent runs.
+	ParentRunID string
+	// UserID is denormalised from the session at run creation for
+	// fast lookups without a session join. Callers SHOULD pass the
+	// session's user_id here; the implementation does not enforce
+	// consistency (cheaper to trust the caller than to JOIN on
+	// every CreateRun).
+	UserID string
+}
+
 // Store is the persistence backend. SQLite is the default; Postgres / Redis
 // adapters slot in behind this interface in v0.4.
 //
 // All methods take ctx. Implementations must honour ctx cancellation for
 // long-running queries (transcript replay especially).
 type Store interface {
-	// CreateSession creates a new session with a generated ID.
-	CreateSession(ctx context.Context, tenantID, agent string) (Session, error)
+	// CreateSession creates a new session with a generated ID. userID
+	// may be empty for v0.3 back-compat callers.
+	CreateSession(ctx context.Context, tenantID, agent, userID string) (Session, error)
 
 	// GetSession returns the session metadata. Returns ErrNotFound if
 	// the ID doesn't exist.
@@ -92,7 +144,9 @@ type Store interface {
 
 	// CreateRun starts a new run within an existing session, in
 	// status "running". Returns ErrNotFound if sessionID doesn't exist.
-	CreateRun(ctx context.Context, sessionID string) (Run, error)
+	// identity carries the v0.4 tracking fields; pass a zero value to
+	// behave as v0.3.
+	CreateRun(ctx context.Context, sessionID string, identity RunIdentity) (Run, error)
 
 	// AppendEvent persists one event for a run. Implementations should be
 	// safe to call from the loop's goroutine on the hot path; bulk-insert
@@ -107,6 +161,27 @@ type Store interface {
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.
 	GetTranscript(ctx context.Context, sessionID string) ([]Event, error)
+
+	// GetRunByAgentID returns the most recently started run carrying
+	// the given agent_id. Returns *ErrNotFound when no such row.
+	// Used by the GET /v1/agents/{agent_id} and cancel endpoints to
+	// resolve the API-facing handle to a Run.
+	GetRunByAgentID(ctx context.Context, agentID string) (Run, error)
+
+	// ListActiveRunsByUser returns runs for userID whose status matches
+	// the supplied filter. An empty status returns ALL statuses
+	// (caller can filter further). Results are bounded — 100 rows max,
+	// ordered by started_at DESC.
+	ListActiveRunsByUser(ctx context.Context, userID string, status RunStatus) ([]Run, error)
+
+	// ListRunsByParentAgentID returns the runs whose parent_agent_id
+	// matches the given value. Drives cascade-cancel discovery.
+	ListRunsByParentAgentID(ctx context.Context, parentAgentID string) ([]Run, error)
+
+	// UpdateHeartbeat sets last_heartbeat_at on a run to the current
+	// time. Called by the loop at each iteration. No-op if the run
+	// is not running (terminal runs don't accept heartbeats).
+	UpdateHeartbeat(ctx context.Context, runID string) error
 
 	// Close releases backend resources. Idempotent.
 	Close() error

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -1,0 +1,176 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// SubAgentRunner runs a named sub-agent with a given user prompt and
+// returns the sub-agent's final assistant text. Implementations are
+// expected to:
+//
+//   - Reject unknown agent names (operator-controlled allowlist:
+//     cfg.Agents).
+//   - Apply the sub-agent's own AllowedTools as the security floor; the
+//     parent's tool set does NOT widen the child's. Parent and child are
+//     both operator-vetted definitions, so each agent's declared
+//     allow-list is authoritative for itself.
+//   - Persist the sub-agent's run as a separate session in the Store so
+//     transcripts are replayable independently of the parent.
+//   - Carry the parent's context.Context (so cancellation, deadlines,
+//     and the loomcycle agent-depth value all propagate).
+type SubAgentRunner func(ctx context.Context, name string, prompt string) (output string, err error)
+
+// MaxAgentDepth caps recursion: a top-level run is depth 0, the agents
+// it spawns are depth 1, etc. The cap is a safety rail against runaway
+// self-spawning prompt loops; cv-batch-adapter spawning cv-adapter is
+// depth 1 today. Hardcoded for v0.4.0; lifted to config in a later
+// release if a real workflow demands deeper.
+const MaxAgentDepth = 3
+
+type ctxKeyAgentDepth struct{}
+
+// IncrementAgentDepth bumps the depth counter on ctx. The Agent tool
+// applies this before invoking the SubAgentRunner so a recursive child
+// inherits a higher depth than the parent.
+func IncrementAgentDepth(ctx context.Context) context.Context {
+	d, _ := ctx.Value(ctxKeyAgentDepth{}).(int)
+	return context.WithValue(ctx, ctxKeyAgentDepth{}, d+1)
+}
+
+// AgentDepth reports the current recursion depth (0 at the top level).
+// Exposed so tests and the loop can assert depth invariants without
+// reaching into the unexported context key.
+func AgentDepth(ctx context.Context) int {
+	d, _ := ctx.Value(ctxKeyAgentDepth{}).(int)
+	return d
+}
+
+// AgentTool is the built-in `Agent` tool that spawns a named sub-agent
+// in a fresh session. The model invokes it with {name, prompt}; the
+// tool returns the sub-agent's final assistant text as a tool_result.
+//
+// Wire shape (Anthropic-compatible-ish — we don't expose Anthropic's
+// own sub-agents API; this is loomcycle's own Tool with the same
+// ergonomics):
+//
+//	{
+//	  "name":   "cv-adapter",          // a key in cfg.Agents
+//	  "prompt": "Generate CV for ..."  // user-message body the sub sees
+//	}
+//
+// The sub-agent's `allowed_tools` (from its YAML AgentDef) is the sole
+// authority on what the sub can use — the parent's allow-list does not
+// widen or narrow it. This matches the trust model: each agent
+// definition is operator-curated and self-describing.
+//
+// The parent observes only the tool_call (with input) and the
+// tool_result (with the sub's final text). The sub's intermediate
+// events go to the sub's own persisted transcript, retrievable via
+// GET /v1/sessions/{sub-session-id}/transcript.
+type AgentTool struct {
+	// Run is the closure provided by the runtime that knows how to
+	// look up sub-agent definitions, build the tool dispatcher, and
+	// drive a fresh loop. Constructed by the HTTP server at boot.
+	Run SubAgentRunner
+}
+
+// agentInput is the JSON shape the model sends.
+type agentInput struct {
+	Name   string `json:"name"`
+	Prompt string `json:"prompt"`
+}
+
+// agentInputSchema is the JSON Schema the model sees. Both fields are
+// required; nothing else is permitted (unknown fields are tolerated by
+// json.Unmarshal but will be ignored, so this is documentation more
+// than enforcement).
+const agentInputSchema = `{
+  "type": "object",
+  "properties": {
+    "name":   {"type": "string", "description": "Sub-agent name. Must match a key in the loomcycle.yaml agents map."},
+    "prompt": {"type": "string", "description": "User-message body the sub-agent sees. Treat this as the task description; do not include auth tokens (the sub-agent gets its own auth context)."}
+  },
+  "required": ["name", "prompt"],
+  "additionalProperties": false
+}`
+
+const agentDescription = `Spawn a named sub-agent in a fresh session and return its final output. ` +
+	`The sub-agent has its own tool allowlist (from loomcycle.yaml); your tool set does not transfer. ` +
+	`Use this when the work is well-described by another agent's role (e.g. coordinator agents that fan out to specialists). ` +
+	`The sub-agent's transcript is persisted separately and can be inspected via the API.`
+
+// Name implements tools.Tool.
+func (a *AgentTool) Name() string { return "Agent" }
+
+// Description implements tools.Tool.
+func (a *AgentTool) Description() string { return agentDescription }
+
+// InputSchema implements tools.Tool.
+func (a *AgentTool) InputSchema() json.RawMessage { return json.RawMessage(agentInputSchema) }
+
+// Execute implements tools.Tool. Validates the input, enforces the
+// recursion depth cap, and delegates to the SubAgentRunner. Errors are
+// surfaced as IsError tool_result so the model can self-correct rather
+// than the run being torn down.
+func (a *AgentTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	if a.Run == nil {
+		return tools.Result{IsError: true, Text: "Agent tool not wired to a sub-agent runner (operator misconfiguration)"}, nil
+	}
+
+	var in agentInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+	in.Name = strings.TrimSpace(in.Name)
+	if in.Name == "" {
+		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
+	}
+	if in.Prompt == "" {
+		return tools.Result{IsError: true, Text: "missing required field: prompt"}, nil
+	}
+
+	// Recursion guard. Counter starts at 0 for the top-level run; a
+	// sub-agent invocation runs at depth+1. Refuse if that would push
+	// past MaxAgentDepth.
+	if AgentDepth(ctx) >= MaxAgentDepth {
+		return tools.Result{
+			IsError: true,
+			Text: fmt.Sprintf(
+				"max sub-agent recursion depth (%d) reached at agent %q; refusing to spawn deeper",
+				MaxAgentDepth, in.Name,
+			),
+		}, nil
+	}
+	subCtx := IncrementAgentDepth(ctx)
+
+	output, err := a.Run(subCtx, in.Name, in.Prompt)
+	if err != nil {
+		// Surface as an error tool_result. The parent can decide whether
+		// to retry, fall back, or give up. We don't tear down the parent
+		// run — the sub failure is treated as a tool error, same shape
+		// as a 4xx from HTTP or an MCP server returning is_error.
+		return tools.Result{IsError: true, Text: err.Error()}, nil
+	}
+	if output == "" {
+		// A sub-agent that ended_turn with no text is rare but possible
+		// (e.g. it only made tool calls and stopped). Surface a hint
+		// rather than an empty result so the parent's model has
+		// something concrete to read.
+		return tools.Result{Text: fmt.Sprintf("(sub-agent %q completed with no final text)", in.Name)}, nil
+	}
+	return tools.Result{Text: output}, nil
+}
+
+// errAgentBadInput is reserved for future structured errors. Currently
+// we surface every input problem as an IsError tool_result, but a
+// caller that wants to break out of the loop entirely (rather than let
+// the model self-correct) can return this from a SubAgentRunner.
+var errAgentBadInput = errors.New("agent: bad input")
+
+var _ tools.Tool = (*AgentTool)(nil)

--- a/internal/tools/builtin/agent_test.go
+++ b/internal/tools/builtin/agent_test.go
@@ -1,0 +1,208 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Happy path: input parses, runner is called with the right args, the
+// returned text is wrapped in a successful Result.
+func TestAgentTool_HappyPath(t *testing.T) {
+	var gotName, gotPrompt string
+	a := &AgentTool{Run: func(_ context.Context, name, prompt string) (string, error) {
+		gotName, gotPrompt = name, prompt
+		return "sub-agent output", nil
+	}}
+
+	res, err := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"cv-adapter","prompt":"Generate CV"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError=true: %s", res.Text)
+	}
+	if res.Text != "sub-agent output" {
+		t.Errorf("Text = %q", res.Text)
+	}
+	if gotName != "cv-adapter" || gotPrompt != "Generate CV" {
+		t.Errorf("runner got (%q, %q)", gotName, gotPrompt)
+	}
+}
+
+// Missing required fields surface as IsError tool_results so the model
+// can self-correct, NOT as Go errors that tear down the run.
+func TestAgentTool_MissingName(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called when name is missing")
+		return "", nil
+	}}
+	res, err := a.Execute(context.Background(), json.RawMessage(`{"prompt":"X"}`))
+	if err != nil {
+		t.Fatalf("Execute returned hard error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true on missing name")
+	}
+	if !strings.Contains(res.Text, "name") {
+		t.Errorf("error should name the missing field: %q", res.Text)
+	}
+}
+
+func TestAgentTool_MissingPrompt(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called when prompt is missing")
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"name":"foo"}`))
+	if !res.IsError || !strings.Contains(res.Text, "prompt") {
+		t.Errorf("expected missing-prompt IsError, got %+v", res)
+	}
+}
+
+// Whitespace-only name is treated as missing — guards against the model
+// emitting `"name": "  "` and getting a confusing "unknown agent" error
+// from the runner instead of a clean "missing field" response.
+func TestAgentTool_WhitespaceNameRejected(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(), json.RawMessage(`{"name":"   ","prompt":"X"}`))
+	if called {
+		t.Error("runner should not be called with whitespace-only name")
+	}
+	if !res.IsError {
+		t.Error("expected IsError on whitespace name")
+	}
+}
+
+// Malformed JSON input is also a model-correctable error, not a hard
+// crash. The model gets feedback "invalid input JSON" and can retry.
+func TestAgentTool_MalformedJSON(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		t.Fatal("runner should not be called on malformed JSON")
+		return "", nil
+	}}
+	res, err := a.Execute(context.Background(), json.RawMessage(`{not json`))
+	if err != nil {
+		t.Fatalf("Execute returned hard error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true on malformed JSON")
+	}
+}
+
+// Runner errors propagate to the model as IsError tool_results — the
+// parent run continues so the model can decide how to recover (try a
+// different sub-agent, fall back, give up gracefully).
+func TestAgentTool_RunnerError(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		return "", errors.New("provider returned 500")
+	}}
+	res, err := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError=true when runner fails")
+	}
+	if !strings.Contains(res.Text, "provider returned 500") {
+		t.Errorf("error message lost: %q", res.Text)
+	}
+}
+
+// A sub-agent that ends_turn with no text is rare but possible (made
+// only tool calls, then stopped). Surface a hint so the parent's
+// model has something concrete to read instead of empty Text.
+func TestAgentTool_EmptyOutputHint(t *testing.T) {
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		return "", nil
+	}}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"silent-agent","prompt":"x"}`))
+	if res.IsError {
+		t.Errorf("empty output is not an error: %+v", res)
+	}
+	if !strings.Contains(res.Text, "silent-agent") || !strings.Contains(res.Text, "no final text") {
+		t.Errorf("hint should name the agent and explain: %q", res.Text)
+	}
+}
+
+// Recursion guard: a context already at MaxAgentDepth refuses to spawn.
+// EMPIRICAL: with the depth check disabled, this test fails because
+// the runner gets called instead of the IsError path.
+func TestAgentTool_MaxDepthGuard(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "should not run", nil
+	}}
+	ctx := context.Background()
+	for i := 0; i < MaxAgentDepth; i++ {
+		ctx = IncrementAgentDepth(ctx)
+	}
+	res, _ := a.Execute(ctx, json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if called {
+		t.Error("runner should not have been invoked at max depth")
+	}
+	if !res.IsError || !strings.Contains(res.Text, "max sub-agent recursion depth") {
+		t.Errorf("expected max-depth IsError, got %+v", res)
+	}
+}
+
+// One depth below the cap is still allowed — the guard fires at >=,
+// not >. Worth pinning so a future refactor doesn't shift the
+// boundary by one.
+func TestAgentTool_DepthBelowCapAllowed(t *testing.T) {
+	called := false
+	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+		called = true
+		return "ok", nil
+	}}
+	ctx := context.Background()
+	for i := 0; i < MaxAgentDepth-1; i++ {
+		ctx = IncrementAgentDepth(ctx)
+	}
+	res, _ := a.Execute(ctx, json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if !called {
+		t.Error("runner should run at depth = MaxAgentDepth-1")
+	}
+	if res.IsError {
+		t.Errorf("unexpected error: %s", res.Text)
+	}
+}
+
+// AgentDepth on a fresh context returns 0 — the top-level run is depth 0.
+func TestAgentDepth_DefaultsToZero(t *testing.T) {
+	if d := AgentDepth(context.Background()); d != 0 {
+		t.Errorf("AgentDepth(empty ctx) = %d, want 0", d)
+	}
+}
+
+// IncrementAgentDepth chains: each call increments by exactly one.
+func TestIncrementAgentDepth_Chains(t *testing.T) {
+	ctx := context.Background()
+	for want := 1; want <= 5; want++ {
+		ctx = IncrementAgentDepth(ctx)
+		if got := AgentDepth(ctx); got != want {
+			t.Errorf("after %d increments: depth = %d, want %d", want, got, want)
+		}
+	}
+}
+
+// Defensive: tool with nil Run surfaces a clear error so a misconfigured
+// server doesn't silently accept Agent calls.
+func TestAgentTool_NilRunner(t *testing.T) {
+	a := &AgentTool{} // Run is nil
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not wired") {
+		t.Errorf("expected nil-runner IsError, got %+v", res)
+	}
+}

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -1,0 +1,167 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
+)
+
+// SkillTool is the dynamic-discovery counterpart to the static skill
+// bundling in `internal/config`. The model invokes it with a skill
+// name; the tool returns the skill body as a tool_result.
+//
+// When to prefer Approach B (this tool) over Approach A (config-load
+// bundling):
+//
+//   - The agent has a long menu of candidate skills and uses only a
+//     few per run (pay-as-you-go beats always-bundle).
+//   - The skill set evolves at runtime — operators drop new skills
+//     into LOOMCYCLE_SKILLS_ROOT without restarting loomcycle.
+//   - You want the model to surface "I needed cv-voice-applier here"
+//     in transcripts (the tool_call event names the skill explicitly).
+//
+// When to prefer Approach A:
+//
+//   - Every referenced skill is referenced unconditionally (the
+//     current jobs-search-agent shape). Bundling rides the system-
+//     prompt cache; the tool path re-bills the body per call when
+//     the conversation prefix doesn't include it yet.
+//
+// Both approaches share the same `internal/skills` loader and the
+// same intersection-check semantics — a skill's `allowed-tools` must
+// be a subset of the bundling/calling agent's `allowed_tools`.
+//
+// Wire shape:
+//
+//	{
+//	  "name": "voice-applier"   // a key under LOOMCYCLE_SKILLS_ROOT
+//	}
+//
+// SECURITY: subset enforcement happens HERE, at tool-call time, against
+// the agent's effective allowed_tools (which the tool receives via the
+// AgentTools field at construction). A skill that demands a tool the
+// current agent doesn't have is refused with an IsError tool_result —
+// matching the config-load behaviour for static bundling.
+type SkillTool struct {
+	// Set is the loaded skill registry, populated from
+	// LOOMCYCLE_SKILLS_ROOT at server boot. Shared with Approach A
+	// (config-load bundling) so a skill change is visible to both
+	// paths after a SIGHUP/restart.
+	//
+	// The calling agent's effective allowed_tools is NOT a field —
+	// it varies per request and is read from ctx via tools.AgentTools.
+	// The HTTP server attaches it before invoking the loop.
+	Set *skills.Set
+}
+
+const skillInputSchema = `{
+  "type": "object",
+  "properties": {
+    "name": {"type": "string", "description": "Skill name (a directory under LOOMCYCLE_SKILLS_ROOT containing SKILL.md)."}
+  },
+  "required": ["name"],
+  "additionalProperties": false
+}`
+
+const skillDescription = `Load a named skill's body and return it as the tool_result. ` +
+	`Skills are domain-specific instruction sets stored under LOOMCYCLE_SKILLS_ROOT (frontmatter + markdown). ` +
+	`Use when the model needs a specific extension that wasn't pre-bundled into its system prompt. ` +
+	`The skill's allowed-tools must be a subset of the calling agent's allowed_tools — refusals are surfaced as is_error.`
+
+type skillInput struct {
+	Name string `json:"name"`
+}
+
+// Name implements tools.Tool.
+func (s *SkillTool) Name() string { return "Skill" }
+
+// Description implements tools.Tool.
+func (s *SkillTool) Description() string { return skillDescription }
+
+// InputSchema implements tools.Tool.
+func (s *SkillTool) InputSchema() json.RawMessage { return json.RawMessage(skillInputSchema) }
+
+// Execute implements tools.Tool.
+func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	if s.Set == nil {
+		return tools.Result{
+			IsError: true,
+			Text:    "Skill tool not configured: LOOMCYCLE_SKILLS_ROOT is unset",
+		}, nil
+	}
+
+	var in skillInput
+	if err := json.Unmarshal(input, &in); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+	in.Name = strings.TrimSpace(in.Name)
+	if in.Name == "" {
+		return tools.Result{IsError: true, Text: "missing required field: name"}, nil
+	}
+
+	sk, ok := s.Set.Get(in.Name)
+	if !ok {
+		// Hint with the available names so the model can recover. Cap
+		// at a reasonable count so a misconfigured root with hundreds
+		// of skills doesn't flood the tool_result.
+		names := s.Set.Names()
+		hint := ""
+		if len(names) > 0 {
+			cap := 10
+			if len(names) < cap {
+				cap = len(names)
+			}
+			hint = " (available: " + strings.Join(names[:cap], ", ")
+			if len(names) > cap {
+				hint += ", ..."
+			}
+			hint += ")"
+		}
+		return tools.Result{IsError: true, Text: fmt.Sprintf("unknown skill %q%s", in.Name, hint)}, nil
+	}
+
+	// SECURITY: enforce skill.allowed-tools ⊆ agent.allowed_tools at
+	// tool-call time. Mirrors the config-load check in resolveSkills.
+	// Agent tools are pulled from ctx (see tools.WithAgentTools) so the
+	// SkillTool struct stays per-server, not per-run.
+	agentTools := tools.AgentTools(ctx)
+	if widening := skillToolsExceedingAgent(sk.AllowedTools, agentTools); len(widening) > 0 {
+		return tools.Result{
+			IsError: true,
+			Text: fmt.Sprintf(
+				"skill %q requires tools %v not granted by this agent's allowed_tools — skills cannot widen the agent's tool set",
+				in.Name, widening,
+			),
+		}, nil
+	}
+
+	return tools.Result{Text: sk.Body}, nil
+}
+
+// skillToolsExceedingAgent returns the subset of skill tools that the
+// agent does NOT grant (literal + glob composition via policy.Matches).
+// Mirrors resolveSkills' check in internal/config so the static and
+// dynamic skill paths apply the same security rule.
+func skillToolsExceedingAgent(skillTools, agentTools []string) []string {
+	if len(skillTools) == 0 {
+		return nil
+	}
+	agentSet := make(map[string]bool, len(agentTools))
+	for _, t := range agentTools {
+		agentSet[t] = true
+	}
+	var widening []string
+	for _, t := range skillTools {
+		if !policy.Matches(t, agentSet) {
+			widening = append(widening, t)
+		}
+	}
+	return widening
+}
+
+var _ tools.Tool = (*SkillTool)(nil)

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -88,10 +88,19 @@ func (s *SkillTool) InputSchema() json.RawMessage { return json.RawMessage(skill
 
 // Execute implements tools.Tool.
 func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
-	if s.Set == nil {
+	// Two paths land here that look like "no skills available":
+	//   1. Set == nil — direct construction without a loader (defensive,
+	//      not reachable from main.go which always passes a non-nil set).
+	//   2. Set is non-nil but empty — main.go's path when
+	//      LOOMCYCLE_SKILLS_ROOT is unset (skills.LoadSet("") returns a
+	//      non-nil empty Set so callers can always Get without a guard).
+	// Both produce the same operator-facing diagnostic: "set
+	// LOOMCYCLE_SKILLS_ROOT to use this tool" — distinguishing them in
+	// the error text would only matter to a unit test, never an operator.
+	if s.Set == nil || len(s.Set.Names()) == 0 {
 		return tools.Result{
 			IsError: true,
-			Text:    "Skill tool not configured: LOOMCYCLE_SKILLS_ROOT is unset",
+			Text:    "Skill tool: no skills configured (set LOOMCYCLE_SKILLS_ROOT and populate <root>/<name>/SKILL.md)",
 		}, nil
 	}
 

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -180,10 +180,27 @@ func TestSkillTool_UnknownSkillHints(t *testing.T) {
 	}
 }
 
-// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset; refuse with a clear
-// runtime-misconfiguration message.
+// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset (or direct test
+// construction); refuse with a clear runtime-misconfiguration message.
 func TestSkillTool_NilSetReturnsConfigError(t *testing.T) {
 	tool := &SkillTool{Set: nil}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("expected config error, got %+v", res)
+	}
+}
+
+// Empty Set is what main.go actually constructs when
+// LOOMCYCLE_SKILLS_ROOT is unset (skills.LoadSet("") returns a non-nil
+// empty Set). Without a fast-path here, the operator would see
+// "unknown skill 'foo'" — true but unhelpful — instead of the
+// LOOMCYCLE_SKILLS_ROOT hint.
+func TestSkillTool_EmptySetReturnsConfigError(t *testing.T) {
+	emptySet, err := skills.LoadSet("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tool := &SkillTool{Set: emptySet}
 	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
 	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
 		t.Errorf("expected config error, got %+v", res)

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -1,0 +1,228 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// loadSetWithSkills builds a skills.Set from a temp directory of
+// (name, frontmatter-tools, body) tuples. Helper for the tests below.
+func loadSetWithSkills(t *testing.T, defs []struct {
+	Name         string
+	AllowedTools []string
+	Body         string
+}) *skills.Set {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range defs {
+		dir := filepath.Join(root, d.Name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fm := "---\nname: " + d.Name + "\n"
+		if len(d.AllowedTools) > 0 {
+			fm += "allowed-tools:\n"
+			for _, tn := range d.AllowedTools {
+				fm += "  - " + tn + "\n"
+			}
+		}
+		fm += "---\n" + d.Body
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(fm), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	set, err := skills.LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	return set
+}
+
+// Happy path: agent's tools cover the skill's needs; tool returns the body.
+func TestSkillTool_HappyPath(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "voice-applier", AllowedTools: []string{"Read", "Skill"}, Body: "VOICE BODY"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"Read", "Skill", "HTTP"})
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"name":"voice-applier"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "VOICE BODY") {
+		t.Errorf("Text missing skill body: %q", res.Text)
+	}
+}
+
+// Subset check: skill needs Edit, agent doesn't grant it. Refused.
+// EMPIRICAL: removing the subset check makes this test fail (the body
+// would be returned successfully despite the missing tool).
+func TestSkillTool_RefusesWideningSkill(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "writer-skill", AllowedTools: []string{"Read", "Write", "Edit"}, Body: "X"},
+	})
+	tool := &SkillTool{Set: set}
+	// Agent only has Read.
+	ctx := tools.WithAgentTools(context.Background(), []string{"Read"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"writer-skill"}`))
+	if !res.IsError {
+		t.Error("expected IsError when skill widens agent's tool set")
+	}
+	if !strings.Contains(res.Text, "Write") || !strings.Contains(res.Text, "Edit") {
+		t.Errorf("error should name the missing tools: %q", res.Text)
+	}
+	if strings.Contains(res.Text, "Read") {
+		t.Errorf("error should NOT mention Read (agent already has it): %q", res.Text)
+	}
+}
+
+// Glob composition (literal-vs-glob): skill literal `mcp__brave__search`
+// covered by agent glob `mcp__brave__*` → allowed. Mirrors the static-
+// path check in resolveSkills, ensuring both code paths agree.
+func TestSkillTool_GlobCoversSkillLiteral(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "search-skill", AllowedTools: []string{"mcp__brave__search"}, Body: "OK"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"mcp__brave__*"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"search-skill"}`))
+	if res.IsError {
+		t.Errorf("agent glob should cover skill literal: %s", res.Text)
+	}
+}
+
+// Skill broader than agent: skill `mcp__brave__*` glob, agent has only
+// the literal `mcp__brave__search`. The skill demands wider access; refused.
+func TestSkillTool_RefusesBroaderGlob(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "broad-skill", AllowedTools: []string{"mcp__brave__*"}, Body: "X"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), []string{"mcp__brave__search"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"broad-skill"}`))
+	if !res.IsError {
+		t.Error("agent literal should NOT cover skill's broader glob")
+	}
+}
+
+// A skill with empty allowed-tools (pure prose-guidance) attaches
+// regardless of agent's tool set.
+func TestSkillTool_EmptyAllowedToolsAlwaysAllowed(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "guidance", AllowedTools: nil, Body: "GUIDANCE"},
+	})
+	tool := &SkillTool{Set: set}
+	// Even an agent with NO tools at all should see this skill.
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"guidance"}`))
+	if res.IsError {
+		t.Errorf("zero-tool skill should attach to any agent: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "GUIDANCE") {
+		t.Errorf("body missing: %q", res.Text)
+	}
+}
+
+// Unknown skill: hint with available names so the model can recover.
+func TestSkillTool_UnknownSkillHints(t *testing.T) {
+	set := loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{
+		{Name: "alpha", AllowedTools: nil, Body: "x"},
+		{Name: "beta", AllowedTools: nil, Body: "y"},
+	})
+	tool := &SkillTool{Set: set}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"name":"does-not-exist"}`))
+	if !res.IsError {
+		t.Error("expected IsError for unknown skill")
+	}
+	if !strings.Contains(res.Text, "alpha") || !strings.Contains(res.Text, "beta") {
+		t.Errorf("hint should list available skills: %q", res.Text)
+	}
+}
+
+// Nil Set means LOOMCYCLE_SKILLS_ROOT is unset; refuse with a clear
+// runtime-misconfiguration message.
+func TestSkillTool_NilSetReturnsConfigError(t *testing.T) {
+	tool := &SkillTool{Set: nil}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("expected config error, got %+v", res)
+	}
+}
+
+// Missing/whitespace name surfaces as IsError with a hint.
+func TestSkillTool_MissingName(t *testing.T) {
+	tool := &SkillTool{Set: loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{{Name: "x", Body: "y"}})}
+	ctx := tools.WithAgentTools(context.Background(), nil)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{}`))
+	if !res.IsError || !strings.Contains(res.Text, "name") {
+		t.Errorf("expected missing-name error, got %+v", res)
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"name":"   "}`))
+	if !res.IsError {
+		t.Error("whitespace name should be treated as missing")
+	}
+}
+
+// Malformed JSON is recoverable — IsError, not a Go error.
+func TestSkillTool_MalformedJSON(t *testing.T) {
+	tool := &SkillTool{Set: loadSetWithSkills(t, []struct {
+		Name         string
+		AllowedTools []string
+		Body         string
+	}{{Name: "x", Body: "y"}})}
+
+	res, err := tool.Execute(context.Background(), json.RawMessage(`{not json`))
+	if err != nil {
+		t.Fatalf("hard error from malformed JSON: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError on malformed JSON")
+	}
+}

--- a/internal/tools/localapi/loader.go
+++ b/internal/tools/localapi/loader.go
@@ -51,6 +51,14 @@ func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
 
 	endpoints, warns := spec.Endpoints()
 
+	// Track names we've already registered so a normalisation collision
+	// (e.g. `get-user` and `get.user` both → `get_user`) is detected and
+	// the second skipped instead of silently overwriting the first in
+	// the dispatcher map. Without this, the model sees both opIds in
+	// its tool menu but only ONE actually dispatches — and which one is
+	// determined by map iteration order.
+	seen := make(map[string]string, len(endpoints))
+
 	out := make([]tools.Tool, 0, len(endpoints))
 	for _, ep := range endpoints {
 		toolName := prefix + "__" + ep.Operation.OperationID
@@ -66,6 +74,14 @@ func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
 				fmt.Sprintf("operation %s: normalised tool name %q → %q", ep.Operation.OperationID, toolName, safe))
 			toolName = safe
 		}
+
+		if firstOpID, dup := seen[toolName]; dup {
+			warns = append(warns,
+				fmt.Sprintf("operation %s: tool name %q collides with operation %s after normalisation; skipping the second one (rename the operationId to disambiguate)",
+					ep.Operation.OperationID, toolName, firstOpID))
+			continue
+		}
+		seen[toolName] = ep.Operation.OperationID
 
 		tool := &EndpointTool{
 			ToolName:      toolName,

--- a/internal/tools/localapi/loader.go
+++ b/internal/tools/localapi/loader.go
@@ -1,0 +1,137 @@
+package localapi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Config is the operator-supplied configuration for the local-api
+// gateway, populated from the loomcycle.yaml `local_api` block.
+type Config struct {
+	// SpecPath is the OpenAPI 3.0 file. Relative paths are resolved
+	// against the loomcycle.yaml directory.
+	SpecPath string `yaml:"spec"`
+	// BaseURL is where forward requests are sent. The OpenAPI spec's
+	// own `servers[0].url` is intentionally NOT honoured — operator
+	// is the authority on routing.
+	BaseURL string `yaml:"base_url"`
+	// ToolNamePrefix is prepended to every operationId. Default
+	// "local"; tools become e.g. `local__patch_application`.
+	ToolNamePrefix string `yaml:"tool_name_prefix"`
+}
+
+// Build reads the OpenAPI spec, walks its operations, and returns the
+// generated EndpointTools as the standard tools.Tool slice. main.go
+// appends these to allTools alongside the built-ins.
+//
+// Returns the tools, a slice of warnings (entries the loader skipped
+// or normalised), and any fatal error. A fatal error means the gateway
+// can't start; loomcycle continues running without it after logging.
+func Build(cfg Config, configDir string) ([]tools.Tool, []string, error) {
+	if cfg.SpecPath == "" {
+		return nil, nil, fmt.Errorf("localapi: spec is required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, nil, fmt.Errorf("localapi: base_url is required")
+	}
+	prefix := cfg.ToolNamePrefix
+	if prefix == "" {
+		prefix = "local"
+	}
+	if !validPrefix(prefix) {
+		return nil, nil, fmt.Errorf("localapi: invalid tool_name_prefix %q (use [a-zA-Z0-9_-]+)", prefix)
+	}
+
+	spec, err := LoadSpec(cfg.SpecPath, configDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	endpoints, warns := spec.Endpoints()
+
+	out := make([]tools.Tool, 0, len(endpoints))
+	for _, ep := range endpoints {
+		toolName := prefix + "__" + ep.Operation.OperationID
+		// operationId values that don't survive the loomcycle tool-
+		// name conventions (must be addressable from agent allow-
+		// lists, which are simple strings) are normalised: replace
+		// any non-[a-zA-Z0-9_] with "_". This is rare in well-formed
+		// OpenAPI but cheap to enforce so we don't surprise an
+		// operator whose generator emits camelCase-with-dashes.
+		safe := normaliseToolName(toolName)
+		if safe != toolName {
+			warns = append(warns,
+				fmt.Sprintf("operation %s: normalised tool name %q → %q", ep.Operation.OperationID, toolName, safe))
+			toolName = safe
+		}
+
+		tool := &EndpointTool{
+			ToolName:      toolName,
+			BaseURL:       cfg.BaseURL,
+			Path:          ep.Path,
+			Method:        ep.Method,
+			OpSummary:     ep.Operation.Summary,
+			OpDescription: ep.Operation.Description,
+			Parameters:    ep.Operation.Parameters,
+		}
+
+		if rb := ep.Operation.RequestBody; rb != nil {
+			if mc, ok := rb.Content["application/json"]; ok && mc.Schema != nil {
+				tool.HasBody = true
+				tool.BodySchema = mc.Schema
+				// Note: we don't track requestBody.required separately
+				// because the input schema's `required` array is
+				// driven only by the parameters loop. If a future
+				// release wants to enforce body presence at schema
+				// level, add a HasBodyRequired flag and append "body"
+				// to required when set.
+			} else if rb.Content != nil {
+				warns = append(warns,
+					fmt.Sprintf("%s %s: requestBody.content has no application/json entry; body skipped",
+						ep.Method, ep.Path))
+			}
+		}
+		out = append(out, tool)
+	}
+	return out, warns, nil
+}
+
+func validPrefix(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// normaliseToolName replaces every char that isn't [a-zA-Z0-9_-] with
+// "_". The "__" separator is preserved because each side is already
+// validated/normalised independently. Result is always non-empty.
+func normaliseToolName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}

--- a/internal/tools/localapi/spec.go
+++ b/internal/tools/localapi/spec.go
@@ -1,0 +1,201 @@
+// Package localapi implements the Local API MCP gateway: it reads an
+// OpenAPI 3.0 spec at boot and exposes each declared endpoint as a
+// typed loomcycle tool. Replaces the curl-shaped HTTP-tool pattern
+// jobs-search-agent's Phase B agents currently use to call back into
+// the host application's `/api/agent/*` endpoints.
+//
+// Trust + scope:
+//   - Tools are named `<prefix>__<operationId>` (default prefix
+//     "local"); each carries the operation's input schema so typos
+//     fail at the model layer instead of becoming a 4xx mid-run.
+//   - Auth is carried by the agent on each call (the `bearer` field
+//     in every tool's input schema). Agents already see the Bearer
+//     token in their prompt's auth preamble; this is the typed
+//     replacement for `headers: {Authorization: ...}` on the
+//     existing HTTP tool.
+//   - SSRF / private-IP defences DO NOT apply: this gateway is
+//     deliberately pointed at a trusted host (the operator's own
+//     application server). Operators MUST set base_url to a known
+//     internal address; do not point this at attacker-controlled
+//     URLs.
+//
+// Constraints (MVP, v0.4.0):
+//   - Inline schemas only — `$ref` is NOT resolved. Operators must
+//     bundle their spec before pointing loomcycle at it (e.g. via
+//     swagger-cli bundle, redocly bundle).
+//   - JSON request/response bodies only (`application/json` content
+//     type). Form-data, multipart, and binary payloads are not
+//     wrapped.
+//   - The supported HTTP methods are GET/POST/PUT/PATCH/DELETE.
+//     OPTIONS / HEAD / TRACE / WebSocket are skipped.
+//   - Top-level `servers[0].url` is ignored — base_url is always
+//     operator-supplied via loomcycle.yaml. Mixing the two would
+//     create surprise routing.
+package localapi
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Spec is the parsed subset of an OpenAPI 3.0 document. Fields not
+// listed here are ignored.
+type Spec struct {
+	OpenAPI    string                  `yaml:"openapi"`
+	Info       infoBlock               `yaml:"info"`
+	Paths      map[string]pathItem     `yaml:"paths"`
+	Components componentsBlock         `yaml:"components"`
+	rawBytes   []byte                  // kept for diagnostics
+}
+
+type infoBlock struct {
+	Title   string `yaml:"title"`
+	Version string `yaml:"version"`
+}
+
+// pathItem is one entry under `paths`. We accept the standard HTTP
+// verbs and ignore parameters declared at the path level (operators
+// should declare them per-operation for clarity in the rendered tool
+// names).
+type pathItem struct {
+	Get    *operation `yaml:"get"`
+	Post   *operation `yaml:"post"`
+	Put    *operation `yaml:"put"`
+	Patch  *operation `yaml:"patch"`
+	Delete *operation `yaml:"delete"`
+}
+
+// operation is the parsed shape of one (path, method) tuple. Schemas
+// are kept as `*yaml.Node` so we can re-serialise them as JSON Schema
+// without deep-parsing every type variant the OpenAPI spec allows.
+type operation struct {
+	OperationID string             `yaml:"operationId"`
+	Summary     string             `yaml:"summary"`
+	Description string             `yaml:"description"`
+	Parameters  []parameter        `yaml:"parameters"`
+	RequestBody *requestBody       `yaml:"requestBody"`
+	Tags        []string           `yaml:"tags"`
+}
+
+type parameter struct {
+	Name        string     `yaml:"name"`
+	In          string     `yaml:"in"`         // "path" | "query" | "header" | "cookie"
+	Description string     `yaml:"description"`
+	Required    bool       `yaml:"required"`
+	Schema      *yaml.Node `yaml:"schema"`
+}
+
+type requestBody struct {
+	Description string                  `yaml:"description"`
+	Required    bool                    `yaml:"required"`
+	Content     map[string]mediaContent `yaml:"content"`
+}
+
+type mediaContent struct {
+	Schema *yaml.Node `yaml:"schema"`
+}
+
+type componentsBlock struct {
+	// We don't resolve $ref in the MVP (see package doc). The block is
+	// parsed only so a future enhancement that DOES resolve refs has
+	// the data to work with — kept for forward compatibility.
+	Schemas map[string]*yaml.Node `yaml:"schemas"`
+}
+
+// LoadSpec reads an OpenAPI YAML/JSON file from disk and parses it into
+// the supported subset.
+//
+// Path resolution: relative paths are resolved against the operator's
+// configured config directory (passed via configDir). An empty
+// configDir treats the path as-is. Absolute paths bypass the join.
+func LoadSpec(specPath, configDir string) (*Spec, error) {
+	if specPath == "" {
+		return nil, fmt.Errorf("localapi: empty spec path")
+	}
+	resolved := specPath
+	if !filepath.IsAbs(resolved) && configDir != "" {
+		resolved = filepath.Join(configDir, resolved)
+	}
+	raw, err := os.ReadFile(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("localapi: read %s: %w", resolved, err)
+	}
+	var sp Spec
+	if err := yaml.Unmarshal(raw, &sp); err != nil {
+		return nil, fmt.Errorf("localapi: parse %s: %w", resolved, err)
+	}
+	if sp.OpenAPI == "" {
+		return nil, fmt.Errorf("localapi: %s missing required `openapi:` field (must be 3.0.x)", resolved)
+	}
+	if !strings.HasPrefix(sp.OpenAPI, "3.") {
+		return nil, fmt.Errorf("localapi: %s declares OpenAPI %q; only 3.x supported", resolved, sp.OpenAPI)
+	}
+	if len(sp.Paths) == 0 {
+		return nil, fmt.Errorf("localapi: %s has no paths", resolved)
+	}
+	sp.rawBytes = raw
+	return &sp, nil
+}
+
+// Endpoint is one resolved (path, method, operation) tuple ready to
+// become a tool. Builders walk the spec via Endpoints() and call
+// BuildTool for each.
+type Endpoint struct {
+	Path       string
+	Method     string // "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+	Operation  *operation
+}
+
+// Endpoints flattens the Spec into a list of (path, method, operation)
+// tuples sorted deterministically by (path, method) so tool registration
+// order is stable across restarts.
+//
+// Operations without an operationId are SKIPPED with a warning line —
+// without one we have nothing meaningful to name the tool. The caller
+// receives the warnings via the returned warns slice; main.go logs
+// them so operators see exactly which entries got dropped.
+func (s *Spec) Endpoints() (eps []Endpoint, warns []string) {
+	type entry struct {
+		path, method string
+		op           *operation
+	}
+	var raw []entry
+	for path, item := range s.Paths {
+		if item.Get != nil {
+			raw = append(raw, entry{path, "GET", item.Get})
+		}
+		if item.Post != nil {
+			raw = append(raw, entry{path, "POST", item.Post})
+		}
+		if item.Put != nil {
+			raw = append(raw, entry{path, "PUT", item.Put})
+		}
+		if item.Patch != nil {
+			raw = append(raw, entry{path, "PATCH", item.Patch})
+		}
+		if item.Delete != nil {
+			raw = append(raw, entry{path, "DELETE", item.Delete})
+		}
+	}
+	sort.SliceStable(raw, func(i, j int) bool {
+		if raw[i].path != raw[j].path {
+			return raw[i].path < raw[j].path
+		}
+		return raw[i].method < raw[j].method
+	})
+	for _, r := range raw {
+		if r.op.OperationID == "" {
+			warns = append(warns,
+				fmt.Sprintf("%s %s: missing operationId; skipped (loomcycle needs operationId to name the tool)",
+					r.method, r.path))
+			continue
+		}
+		eps = append(eps, Endpoint{Path: r.path, Method: r.method, Operation: r.op})
+	}
+	return eps, warns
+}

--- a/internal/tools/localapi/spec_test.go
+++ b/internal/tools/localapi/spec_test.go
@@ -1,0 +1,196 @@
+package localapi
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const minimalSpec = `
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /api/applications/{id}:
+    get:
+      operationId: get_application
+      summary: Fetch one application
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: patch_application
+      summary: Update an application
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                cvText: {type: string}
+                coverLetterText: {type: string}
+  /api/research:
+    get:
+      operationId: list_research
+      summary: List research entries
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+`
+
+func writeSpec(t *testing.T, body string) (path, dir string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "openapi.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path, dir
+}
+
+func TestLoadSpec_Basic(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	sp, err := LoadSpec(path, "")
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	if sp.OpenAPI != "3.0.3" {
+		t.Errorf("OpenAPI = %q", sp.OpenAPI)
+	}
+	if len(sp.Paths) != 2 {
+		t.Errorf("Paths len = %d, want 2", len(sp.Paths))
+	}
+	if sp.Paths["/api/applications/{id}"].Get == nil {
+		t.Error("missing GET /api/applications/{id}")
+	}
+	if sp.Paths["/api/applications/{id}"].Patch == nil {
+		t.Error("missing PATCH /api/applications/{id}")
+	}
+	if sp.Paths["/api/research"].Get == nil {
+		t.Error("missing GET /api/research")
+	}
+}
+
+// Endpoints must be sorted deterministically (path then method) so
+// tool registration order is stable across restarts.
+func TestSpec_Endpoints_StableOrder(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	sp, _ := LoadSpec(path, "")
+	eps, warns := sp.Endpoints()
+	if len(warns) != 0 {
+		t.Errorf("unexpected warns: %v", warns)
+	}
+	// Expected order: /api/applications/{id} GET, /api/applications/{id} PATCH, /api/research GET
+	want := []struct{ path, method string }{
+		{"/api/applications/{id}", "GET"},
+		{"/api/applications/{id}", "PATCH"},
+		{"/api/research", "GET"},
+	}
+	if len(eps) != len(want) {
+		t.Fatalf("endpoints len = %d, want %d", len(eps), len(want))
+	}
+	for i, w := range want {
+		if eps[i].Path != w.path || eps[i].Method != w.method {
+			t.Errorf("ep[%d] = %s %s, want %s %s",
+				i, eps[i].Method, eps[i].Path, w.method, w.path)
+		}
+	}
+}
+
+// Operation without operationId surfaces a warning and is dropped.
+// Without the warning the operator wouldn't know why their endpoint
+// isn't reachable; without the drop we'd be unable to name the tool.
+func TestSpec_MissingOperationId(t *testing.T) {
+	body := `
+openapi: 3.0.0
+info: {title: x, version: x}
+paths:
+  /unnamed:
+    get:
+      summary: no operationId
+  /named:
+    get:
+      operationId: ok
+      summary: has it
+`
+	path, _ := writeSpec(t, body)
+	sp, err := LoadSpec(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	eps, warns := sp.Endpoints()
+	if len(eps) != 1 || eps[0].Operation.OperationID != "ok" {
+		t.Errorf("expected only the named endpoint to survive, got %v", eps)
+	}
+	if len(warns) != 1 || !strings.Contains(warns[0], "/unnamed") {
+		t.Errorf("expected one warning naming /unnamed: %v", warns)
+	}
+}
+
+// Missing required `openapi:` field is a fatal load error.
+func TestLoadSpec_MissingVersion(t *testing.T) {
+	path, _ := writeSpec(t, "info: {title: x, version: x}\npaths: {}")
+	if _, err := LoadSpec(path, ""); err == nil {
+		t.Fatal("expected error on missing openapi field")
+	}
+}
+
+// Non-3.x OpenAPI version is rejected — we don't support 2.0 (Swagger)
+// or hypothetical 4.0 in this MVP.
+func TestLoadSpec_RejectsNon3x(t *testing.T) {
+	path, _ := writeSpec(t, "openapi: 2.0\ninfo: {title: x, version: x}\npaths: {}")
+	_, err := LoadSpec(path, "")
+	if err == nil || !strings.Contains(err.Error(), "3.x") {
+		t.Errorf("expected 3.x-only error, got %v", err)
+	}
+}
+
+// Empty paths map: the spec is technically valid OpenAPI but useless
+// for our gateway; refuse loudly so the operator notices.
+func TestLoadSpec_RejectsEmptyPaths(t *testing.T) {
+	path, _ := writeSpec(t, "openapi: 3.0.0\ninfo: {title: x, version: x}\npaths: {}")
+	_, err := LoadSpec(path, "")
+	if err == nil || !strings.Contains(err.Error(), "no paths") {
+		t.Errorf("expected no-paths error, got %v", err)
+	}
+}
+
+// Missing file: error should name the resolved path so the operator
+// sees exactly where loomcycle looked.
+func TestLoadSpec_FileMissing(t *testing.T) {
+	_, err := LoadSpec(filepath.Join(t.TempDir(), "no-such-file.yaml"), "")
+	if err == nil || !strings.Contains(err.Error(), "no-such-file") {
+		t.Errorf("error should name the path: %v", err)
+	}
+}
+
+// Relative paths are resolved against configDir — same behaviour as
+// system_prompt_file. Operator's loomcycle.yaml can carry a relative
+// reference next to it.
+func TestLoadSpec_RelativePathResolution(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "spec.yaml"), []byte(minimalSpec), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sp, err := LoadSpec("spec.yaml", dir)
+	if err != nil {
+		t.Fatalf("LoadSpec: %v", err)
+	}
+	if len(sp.Paths) != 2 {
+		t.Errorf("paths missing after relative-path load: %d", len(sp.Paths))
+	}
+}

--- a/internal/tools/localapi/tool.go
+++ b/internal/tools/localapi/tool.go
@@ -1,0 +1,304 @@
+package localapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// EndpointTool is one tool generated from an OpenAPI operation. The
+// model invokes it with a JSON body conforming to the synthesised
+// input schema; the tool forwards the call to BaseURL + path with the
+// agent-supplied bearer token.
+//
+// One tool per (path, method) — see (a) in package doc for design
+// rationale. The model sees a clear menu of named operations rather
+// than one generic "call" tool with an `endpoint` parameter; renamed
+// or removed endpoints become missing tools rather than silent 404s.
+//
+// Network policy:
+//   - The forward request goes to BaseURL via the standard net/http
+//     client; SSRF/private-IP defences from the HTTP built-in tool
+//     do NOT apply here. The operator must point this at a trusted
+//     host (their own application server, typically localhost or a
+//     known internal address).
+//   - HTTPClient may be overridden for tests; nil means use
+//     http.DefaultClient.
+//
+// Errors visible to the model:
+//   - Invalid JSON input → IsError tool_result, model can self-correct.
+//   - Missing required parameters → IsError, names the missing field.
+//   - 4xx/5xx from the upstream → IsError, body forwarded as text so
+//     the model sees the application's error shape (e.g. validation
+//     errors).
+//   - Transport failures (connection refused, DNS) → Go error from
+//     Execute (rare; surfaces as the loop's tool_result with the
+//     wrapper text).
+type EndpointTool struct {
+	ToolName    string                  // "<prefix>__<operationId>"
+	BaseURL     string                  // e.g. "http://localhost:3000"
+	Path        string                  // e.g. "/api/applications/{id}"
+	Method      string                  // "GET" | "POST" | ...
+	OpSummary   string
+	OpDescription string
+	Parameters  []parameter
+	HasBody     bool
+	BodySchema  *yaml.Node // raw JSON Schema (passed through to model)
+
+	HTTPClient *http.Client // optional; defaults to http.DefaultClient
+}
+
+// Name implements tools.Tool. Returns the assembled
+// "<prefix>__<operationId>" string the model sees.
+func (t *EndpointTool) Name() string { return t.ToolName }
+
+// Description implements tools.Tool. Combines the OpenAPI summary +
+// description + an explicit auth note so the model always knows it
+// must include `bearer`.
+func (t *EndpointTool) Description() string {
+	parts := []string{}
+	if t.OpSummary != "" {
+		parts = append(parts, t.OpSummary)
+	}
+	if t.OpDescription != "" {
+		parts = append(parts, t.OpDescription)
+	}
+	if len(parts) == 0 {
+		parts = append(parts, fmt.Sprintf("%s %s", t.Method, t.Path))
+	}
+	parts = append(parts,
+		"Authentication: include the Bearer token from your prompt's auth preamble in the `bearer` field of every call.")
+	return strings.Join(parts, "\n\n")
+}
+
+// InputSchema implements tools.Tool. Synthesises a JSON Schema from
+// the OpenAPI parameters + requestBody + a required `bearer` field.
+//
+// Schema shape:
+//
+//	{
+//	  "type": "object",
+//	  "properties": {
+//	    "bearer":   {"type": "string", "description": "..."},
+//	    "<path-param>":  <param's schema>,
+//	    "<query-param>": <param's schema>,
+//	    "body":     <requestBody schema, if any>
+//	  },
+//	  "required": ["bearer", ...required-params, "body" if body required]
+//	}
+func (t *EndpointTool) InputSchema() json.RawMessage {
+	props := map[string]any{
+		"bearer": map[string]any{
+			"type":        "string",
+			"description": "Bearer token to forward as `Authorization: Bearer <value>`. Sourced from the Bearer token printed in your prompt's auth preamble.",
+		},
+	}
+	required := []string{"bearer"}
+
+	for _, p := range t.Parameters {
+		if p.In == "header" || p.In == "cookie" {
+			// Skip header/cookie parameters in the input schema —
+			// the only header we forward is Authorization (set from
+			// `bearer`). Cookies are not supported.
+			continue
+		}
+		schema := yamlNodeToJSON(p.Schema)
+		if schema == nil {
+			schema = map[string]any{"type": "string"}
+		}
+		// Augment the parameter schema with a description so the model
+		// knows where the param goes (path vs query) — useful when the
+		// OpenAPI desc was sparse.
+		if m, ok := schema.(map[string]any); ok {
+			d := p.Description
+			if d == "" {
+				d = fmt.Sprintf("%s parameter", p.In)
+			}
+			if _, exists := m["description"]; !exists {
+				m["description"] = d
+			}
+		}
+		props[p.Name] = schema
+		if p.Required {
+			required = append(required, p.Name)
+		}
+	}
+
+	if t.HasBody {
+		bodySchema := yamlNodeToJSON(t.BodySchema)
+		if bodySchema == nil {
+			bodySchema = map[string]any{"type": "object"}
+		}
+		props["body"] = bodySchema
+		// We treat the body as required only if the OpenAPI spec
+		// explicitly marked it so. Many specs default to false.
+		// (See Endpoint construction in loader.go for where the flag
+		// is propagated.)
+		// Required-ness is recorded on the EndpointTool by the loader.
+	}
+
+	full := map[string]any{
+		"type":                 "object",
+		"properties":           props,
+		"required":             required,
+		"additionalProperties": false,
+	}
+	out, err := json.Marshal(full)
+	if err != nil {
+		// Schema construction is purely from operator-controlled
+		// input; failure is a programmer error, not runtime.
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return json.RawMessage(out)
+}
+
+// Execute implements tools.Tool. Validates input, builds the forward
+// HTTP request from the OpenAPI definition + supplied parameters, and
+// returns the upstream response.
+//
+// Errors are surfaced as IsError tool_results (recoverable by the
+// model) rather than Go errors (which would tear down the run). Only
+// transport-level failures bubble up as Go errors.
+func (t *EndpointTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("invalid input JSON: %s", err)}, nil
+	}
+
+	bearer, _ := raw["bearer"].(string)
+	bearer = strings.TrimSpace(bearer)
+	if bearer == "" {
+		return tools.Result{
+			IsError: true,
+			Text:    "missing required field: bearer (the Authorization token from your prompt's auth preamble)",
+		}, nil
+	}
+
+	// Substitute path parameters into the URL template. url.PathEscape
+	// escapes special characters (including '/') so a hostile param
+	// value cannot break out of its path segment (e.g. `id=../admin`
+	// becomes `id=%2E%2E%2Fadmin` on the wire). OpenAPI path
+	// parameters are scoped to a single segment by default (style:
+	// simple); the strict-segment escape matches that contract.
+	urlPath := t.Path
+	for _, p := range t.Parameters {
+		if p.In != "path" {
+			continue
+		}
+		v, ok := raw[p.Name]
+		if !ok {
+			if p.Required {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("missing required path parameter %q", p.Name)}, nil
+			}
+			continue
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{"+p.Name+"}", url.PathEscape(fmt.Sprintf("%v", v)))
+	}
+
+	// Build query string from query parameters.
+	q := url.Values{}
+	for _, p := range t.Parameters {
+		if p.In != "query" {
+			continue
+		}
+		v, ok := raw[p.Name]
+		if !ok {
+			if p.Required {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("missing required query parameter %q", p.Name)}, nil
+			}
+			continue
+		}
+		q.Set(p.Name, fmt.Sprintf("%v", v))
+	}
+
+	// Build full URL.
+	full := strings.TrimRight(t.BaseURL, "/") + urlPath
+	if encoded := q.Encode(); encoded != "" {
+		full += "?" + encoded
+	}
+
+	// Build body if present.
+	var bodyReader io.Reader
+	if t.HasBody {
+		body, hasBody := raw["body"]
+		if hasBody && body != nil {
+			b, err := json.Marshal(body)
+			if err != nil {
+				return tools.Result{IsError: true, Text: fmt.Sprintf("could not marshal body: %s", err)}, nil
+			}
+			bodyReader = bytes.NewReader(b)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, t.Method, full, bodyReader)
+	if err != nil {
+		// Almost always a malformed URL; surface as IsError so the
+		// model sees the bad input.
+		return tools.Result{IsError: true, Text: fmt.Sprintf("build request: %s", err)}, nil
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	if bodyReader != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := t.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Transport-level failure — return as Go error so the loop's
+		// tool_result wrapping carries the message intact.
+		return tools.Result{IsError: true, Text: fmt.Sprintf("upstream request failed: %s", err)}, nil
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap, matches HTTP tool
+	if err != nil {
+		return tools.Result{IsError: true, Text: fmt.Sprintf("read response: %s", err)}, nil
+	}
+
+	if resp.StatusCode >= 400 {
+		// Forward the upstream body to the model so it sees the
+		// application's error shape (validation errors, 401 hints,
+		// etc.) and can self-correct.
+		return tools.Result{
+			IsError: true,
+			Text:    fmt.Sprintf("upstream %s %s returned %d:\n%s", t.Method, t.Path, resp.StatusCode, string(respBody)),
+		}, nil
+	}
+
+	return tools.Result{Text: string(respBody)}, nil
+}
+
+// yamlNodeToJSON converts a yaml.Node to the equivalent
+// map[string]any/[]any/scalar tree that json.Marshal will turn into
+// proper JSON. Nil node → nil. Returns the converted value or nil if
+// the node is empty.
+//
+// We use yaml.Node's Decode into `interface{}` to leverage yaml.v3's
+// existing scalar resolution rules (ints stay ints, floats stay
+// floats, etc.) — the resulting tree round-trips through json.Marshal
+// cleanly.
+func yamlNodeToJSON(n *yaml.Node) any {
+	if n == nil {
+		return nil
+	}
+	var out any
+	if err := n.Decode(&out); err != nil {
+		return nil
+	}
+	return out
+}
+
+var _ tools.Tool = (*EndpointTool)(nil)

--- a/internal/tools/localapi/tool.go
+++ b/internal/tools/localapi/tool.go
@@ -184,11 +184,13 @@ func (t *EndpointTool) Execute(ctx context.Context, input json.RawMessage) (tool
 	}
 
 	// Substitute path parameters into the URL template. url.PathEscape
-	// escapes special characters (including '/') so a hostile param
-	// value cannot break out of its path segment (e.g. `id=../admin`
-	// becomes `id=%2E%2E%2Fadmin` on the wire). OpenAPI path
-	// parameters are scoped to a single segment by default (style:
-	// simple); the strict-segment escape matches that contract.
+	// escapes characters outside the unreserved set (which includes
+	// '.' but NOT '/'), so '/' becomes '%2F' on the wire. The dot is
+	// untouched, but it can't introduce a path-traversal step without
+	// a slash; `id=../admin` becomes `..%2Fadmin`, which the upstream
+	// router treats as one literal segment. OpenAPI path parameters
+	// are scoped to a single segment by default (style: simple); this
+	// escape matches that contract.
 	urlPath := t.Path
 	for _, p := range t.Parameters {
 		if p.In != "path" {

--- a/internal/tools/localapi/tool_test.go
+++ b/internal/tools/localapi/tool_test.go
@@ -315,6 +315,63 @@ func TestEndpointTool_InputSchemaShape(t *testing.T) {
 	}
 }
 
+// Two operationIds that normalise to the same string MUST NOT
+// silently collide in the dispatcher map. Without the collision
+// guard, both tools register but only one dispatches (whichever
+// the map iteration overwrote last) — the model sees both names in
+// its menu but invocation is non-deterministic.
+//
+// EMPIRICAL: removing the `if firstOpID, dup := seen[toolName]; dup`
+// branch from loader.go makes this test fail.
+func TestBuild_DetectsCollisionAfterNormalisation(t *testing.T) {
+	// Both '@' and '.' get normalised to '_' (only [A-Za-z0-9_-] survives).
+	// `op@user` and `op.user` both become `op_user` after normalisation.
+	body := `
+openapi: 3.0.0
+info: {title: x, version: x}
+paths:
+  /a:
+    get:
+      operationId: op@user
+      summary: at flavour
+  /b:
+    get:
+      operationId: op.user
+      summary: dot flavour
+`
+	path, _ := writeSpec(t, body)
+	out, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        "http://x",
+		ToolNamePrefix: "local",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Only ONE tool should survive the collision; the other becomes a
+	// warning. Stable order: spec.Endpoints() sorts by (path, method),
+	// so /a's op@user wins, /b's op.user is dropped.
+	if len(out) != 1 {
+		names := make([]string, len(out))
+		for i, tl := range out {
+			names[i] = tl.Name()
+		}
+		t.Fatalf("expected 1 tool after collision, got %d: %v", len(out), names)
+	}
+	if got := out[0].Name(); got != "local__op_user" {
+		t.Errorf("survivor tool name = %q, want local__op_user", got)
+	}
+	collided := false
+	for _, w := range warns {
+		if strings.Contains(w, "collides") && strings.Contains(w, "op.user") {
+			collided = true
+		}
+	}
+	if !collided {
+		t.Errorf("expected a collision warning naming op.user, got: %v", warns)
+	}
+}
+
 // Helper: parse spec, build tools, return the named one. Aborts the
 // test if the spec doesn't parse or the tool isn't found.
 func buildOneTool(t *testing.T, body, baseURL, opID string) (*EndpointTool, []string, error) {

--- a/internal/tools/localapi/tool_test.go
+++ b/internal/tools/localapi/tool_test.go
@@ -1,0 +1,342 @@
+package localapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubServerHandler captures the last request for assertion and returns
+// a fixed response. status defaults to 200; pass non-zero to override.
+type stubServerHandler struct {
+	gotMethod  string
+	gotPath    string
+	gotBearer  string
+	gotBody    []byte
+	gotQuery   string
+	respStatus int
+	respBody   string
+}
+
+func (s *stubServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.gotMethod = r.Method
+	// Prefer the raw (still-encoded) path so tests can assert on the
+	// wire-level escaping. Go decodes URL-encoded paths into URL.Path
+	// for handler convenience; URL.RawPath preserves the original form
+	// only when it differs from Path.
+	if r.URL.RawPath != "" {
+		s.gotPath = r.URL.RawPath
+	} else {
+		s.gotPath = r.URL.Path
+	}
+	s.gotQuery = r.URL.RawQuery
+	if v := r.Header.Get("Authorization"); v != "" {
+		s.gotBearer = v
+	}
+	s.gotBody, _ = io.ReadAll(r.Body)
+	status := s.respStatus
+	if status == 0 {
+		status = 200
+	}
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(s.respBody))
+}
+
+// End-to-end via a stub HTTP server: GET-by-path-param round-trip
+// includes the path substitution + the Authorization header.
+func TestEndpointTool_GetWithPathParam(t *testing.T) {
+	stub := &stubServerHandler{respBody: `{"id":"abc","cv":"x"}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"sk-test","id":"abc"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if stub.gotMethod != "GET" {
+		t.Errorf("upstream method = %s", stub.gotMethod)
+	}
+	if stub.gotPath != "/api/applications/abc" {
+		t.Errorf("upstream path = %q", stub.gotPath)
+	}
+	if stub.gotBearer != "Bearer sk-test" {
+		t.Errorf("upstream Authorization = %q", stub.gotBearer)
+	}
+	if !strings.Contains(res.Text, `"cv":"x"`) {
+		t.Errorf("response body lost: %q", res.Text)
+	}
+}
+
+// PATCH with a body: input.body is JSON-marshalled and sent. Bearer
+// goes into Authorization, NOT into the body.
+func TestEndpointTool_PatchWithBody(t *testing.T) {
+	stub := &stubServerHandler{respBody: `{"ok":true}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "patch_application")
+	res, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"tok","id":"app-1","body":{"cvText":"hello"}}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.IsError {
+		t.Errorf("expected success, got IsError: %s", res.Text)
+	}
+	if stub.gotMethod != "PATCH" {
+		t.Errorf("method = %s", stub.gotMethod)
+	}
+	if stub.gotPath != "/api/applications/app-1" {
+		t.Errorf("path = %q", stub.gotPath)
+	}
+	gotBody := string(stub.gotBody)
+	if !strings.Contains(gotBody, `"cvText":"hello"`) {
+		t.Errorf("body not forwarded: %q", gotBody)
+	}
+	if strings.Contains(gotBody, "bearer") || strings.Contains(gotBody, "tok") {
+		t.Errorf("bearer leaked into body: %q", gotBody)
+	}
+}
+
+// Query parameters are URL-encoded and appended.
+func TestEndpointTool_QueryParam(t *testing.T) {
+	stub := &stubServerHandler{respBody: `[]`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "list_research")
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","date":"2026-05-05"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if stub.gotPath != "/api/research" {
+		t.Errorf("path = %q", stub.gotPath)
+	}
+	if !strings.Contains(stub.gotQuery, "date=2026-05-05") {
+		t.Errorf("query missing date param: %q", stub.gotQuery)
+	}
+}
+
+// Missing bearer is a recoverable error — surfaces as IsError so the
+// model can read the message and try again. Critically, NO request
+// goes upstream.
+func TestEndpointTool_MissingBearer(t *testing.T) {
+	stub := &stubServerHandler{}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"id":"abc"}`))
+	if !res.IsError || !strings.Contains(res.Text, "bearer") {
+		t.Errorf("expected bearer-missing IsError, got %+v", res)
+	}
+	if stub.gotMethod != "" {
+		t.Error("no upstream call should be made when bearer is missing")
+	}
+}
+
+// Missing required path parameter is recoverable IsError; no upstream
+// call (would result in malformed URL).
+func TestEndpointTool_MissingRequiredPathParam(t *testing.T) {
+	stub := &stubServerHandler{}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x"}`))
+	if !res.IsError || !strings.Contains(res.Text, "id") {
+		t.Errorf("expected missing-id IsError, got %+v", res)
+	}
+	if stub.gotMethod != "" {
+		t.Error("no upstream call should happen with missing path param")
+	}
+}
+
+// Upstream 4xx/5xx is forwarded as IsError WITH the response body so
+// the model can see the application's validation/error shape and
+// self-correct.
+func TestEndpointTool_Upstream4xxForwarded(t *testing.T) {
+	stub := &stubServerHandler{respStatus: 422, respBody: `{"error":"missing field cvText"}`}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "patch_application")
+	res, _ := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","id":"a","body":{}}`))
+	if !res.IsError {
+		t.Error("expected IsError for upstream 4xx")
+	}
+	if !strings.Contains(res.Text, "422") || !strings.Contains(res.Text, "missing field cvText") {
+		t.Errorf("upstream body not forwarded: %q", res.Text)
+	}
+}
+
+// Path param with a slash gets percent-encoded so it stays inside the
+// path segment (defends against path injection from a hostile param
+// value, even though our agents are operator-trusted).
+func TestEndpointTool_PathParamEscaping(t *testing.T) {
+	stub := &stubServerHandler{respBody: "ok"}
+	ts := httptest.NewServer(stub)
+	defer ts.Close()
+
+	tool, _, _ := buildOneTool(t, minimalSpec, ts.URL, "get_application")
+	_, err := tool.Execute(context.Background(),
+		json.RawMessage(`{"bearer":"x","id":"a/b/../etc/passwd"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// %2F encoding for the slash means the path segment stays intact.
+	if !strings.Contains(stub.gotPath, "a%2Fb%2F..%2Fetc%2Fpasswd") {
+		t.Errorf("path not escaped: %q", stub.gotPath)
+	}
+}
+
+// Loader tests: the Build entry point produces the right number of
+// tools, applies the tool name prefix, and propagates warnings.
+func TestBuild_GeneratesToolsWithPrefix(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	tools, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        "http://localhost:3000",
+		ToolNamePrefix: "myapp",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("unexpected warns: %v", warns)
+	}
+	want := map[string]bool{
+		"myapp__get_application":   true,
+		"myapp__patch_application": true,
+		"myapp__list_research":     true,
+	}
+	for _, tl := range tools {
+		if !want[tl.Name()] {
+			t.Errorf("unexpected tool: %s", tl.Name())
+		}
+		delete(want, tl.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("missing tools: %v", want)
+	}
+}
+
+// Default prefix is "local" when ToolNamePrefix is empty.
+func TestBuild_DefaultPrefix(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	tools, _, err := Build(Config{
+		SpecPath: path,
+		BaseURL:  "http://localhost",
+	}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tl := range tools {
+		if !strings.HasPrefix(tl.Name(), "local__") {
+			t.Errorf("default prefix not applied: %q", tl.Name())
+		}
+	}
+}
+
+// Invalid prefix (slash, space, etc.) is rejected — the resulting tool
+// name would be unaddressable from agent allow-lists.
+func TestBuild_InvalidPrefixRejected(t *testing.T) {
+	path, _ := writeSpec(t, minimalSpec)
+	for _, bad := range []string{"my app", "my/app", "my::app", ""} {
+		if bad == "" {
+			continue // empty defaults to "local"; covered separately
+		}
+		_, _, err := Build(Config{
+			SpecPath:       path,
+			BaseURL:        "http://localhost",
+			ToolNamePrefix: bad,
+		}, "")
+		if err == nil {
+			t.Errorf("prefix %q should be rejected", bad)
+		}
+	}
+}
+
+// Build returns a fatal error when SpecPath or BaseURL is missing.
+func TestBuild_RequiresSpecAndBaseURL(t *testing.T) {
+	if _, _, err := Build(Config{BaseURL: "x"}, ""); err == nil {
+		t.Error("expected error when SpecPath empty")
+	}
+	path, _ := writeSpec(t, minimalSpec)
+	if _, _, err := Build(Config{SpecPath: path}, ""); err == nil {
+		t.Error("expected error when BaseURL empty")
+	}
+}
+
+// Input-schema sanity: the synthesised JSON Schema requires `bearer`
+// plus all `required: true` parameters. The model sees a clear menu
+// of fields with descriptions.
+func TestEndpointTool_InputSchemaShape(t *testing.T) {
+	tool, _, _ := buildOneTool(t, minimalSpec, "http://x", "patch_application")
+	var schema map[string]any
+	if err := json.Unmarshal(tool.InputSchema(), &schema); err != nil {
+		t.Fatalf("schema not valid JSON: %v", err)
+	}
+	props, _ := schema["properties"].(map[string]any)
+	if _, ok := props["bearer"]; !ok {
+		t.Error("schema missing `bearer` field")
+	}
+	if _, ok := props["id"]; !ok {
+		t.Error("schema missing path-param `id` field")
+	}
+	if _, ok := props["body"]; !ok {
+		t.Error("schema missing `body` field")
+	}
+	required, _ := schema["required"].([]any)
+	hasBearer, hasID := false, false
+	for _, r := range required {
+		if r == "bearer" {
+			hasBearer = true
+		}
+		if r == "id" {
+			hasID = true
+		}
+	}
+	if !hasBearer || !hasID {
+		t.Errorf("required missing bearer or id: %v", required)
+	}
+}
+
+// Helper: parse spec, build tools, return the named one. Aborts the
+// test if the spec doesn't parse or the tool isn't found.
+func buildOneTool(t *testing.T, body, baseURL, opID string) (*EndpointTool, []string, error) {
+	t.Helper()
+	path, _ := writeSpec(t, body)
+	out, warns, err := Build(Config{
+		SpecPath:       path,
+		BaseURL:        baseURL,
+		ToolNamePrefix: "local",
+	}, "")
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	for _, tl := range out {
+		et, ok := tl.(*EndpointTool)
+		if !ok {
+			continue
+		}
+		if et.ToolName == "local__"+opID {
+			return et, warns, nil
+		}
+	}
+	t.Fatalf("tool local__%s not found in %d generated tools", opID, len(out))
+	return nil, nil, nil
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -65,6 +65,30 @@ func (d *Dispatcher) Specs(order []Tool) []providers.ToolSpec {
 	return out
 }
 
+// ctxKeyAgentTools is the context key under which the runtime stores
+// the calling agent's effective allowed_tools list (after agent + caller
+// narrowing). Tools that need to apply secondary subset checks (like
+// the built-in Skill tool, which validates skill `allowed-tools` ⊆
+// agent `allowed_tools` at call time) read it via AgentTools.
+type ctxKeyAgentTools struct{}
+
+// WithAgentTools attaches the agent's effective tool names to ctx. The
+// HTTP server calls this once per run before invoking the loop so any
+// tool that resolves dynamic permissions has the same view of "what
+// the agent can use."
+func WithAgentTools(ctx context.Context, names []string) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentTools{}, names)
+}
+
+// AgentTools returns the agent's effective tool names from ctx, or
+// nil if not attached. Returning nil from a tool that requires this
+// list should cause the tool to refuse with a clear "misconfigured
+// runtime" message.
+func AgentTools(ctx context.Context) []string {
+	v, _ := ctx.Value(ctxKeyAgentTools{}).([]string)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names return an
 // error result (the model can self-correct) rather than a hard error.
 func (d *Dispatcher) Execute(ctx context.Context, name string, input json.RawMessage) Result {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -89,6 +89,38 @@ func AgentTools(ctx context.Context) []string {
 	return v
 }
 
+// ctxKeyRunIdentity is the context key under which the runtime
+// stashes the current run's user_id and agent_id (v0.4 tracking
+// fields). Sub-agents read these via RunIdentity to inherit the
+// parent's user_id and to know whose agent_id is their parent.
+type ctxKeyRunIdentity struct{}
+
+// RunIdentityValue is the shape stored in ctx by WithRunIdentity. The
+// "Value" suffix avoids a naming collision with store.RunIdentity
+// (which is the persistence-layer struct with more fields).
+type RunIdentityValue struct {
+	UserID  string
+	AgentID string
+}
+
+// WithRunIdentity attaches the current run's identity to ctx. The
+// HTTP server calls this once per run before invoking the loop so the
+// AgentTool's SubAgentRunner can read it back via RunIdentity and
+// thread userID/parentAgentID through to the new sub-agent's session
+// + run records.
+func WithRunIdentity(ctx context.Context, ident RunIdentityValue) context.Context {
+	return context.WithValue(ctx, ctxKeyRunIdentity{}, ident)
+}
+
+// RunIdentity returns the current run's identity from ctx, or zero
+// value if not attached. The HTTP server's runSubAgent uses the
+// AgentID as the new sub-run's parent_agent_id and the UserID for
+// inheritance into the sub-agent's session.
+func RunIdentity(ctx context.Context) RunIdentityValue {
+	v, _ := ctx.Value(ctxKeyRunIdentity{}).(RunIdentityValue)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names return an
 // error result (the model can self-correct) rather than a hard error.
 func (d *Dispatcher) Execute(ctx context.Context, name string, input json.RawMessage) Result {

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -135,6 +135,30 @@ mcp_servers:
   #   headers:
   #     Authorization: "Bearer ${LOOMCYCLE_AUTH_TOKEN}"
 
+# ─── Local API MCP gateway (v0.4.0+) ─────────────────────────────────
+# Reads an OpenAPI 3.0 spec at boot and exposes one typed tool per
+# operation, named `<prefix>__<operationId>`. Forwards calls to
+# base_url with the agent's `bearer` field as Authorization.
+#
+# Replaces the curl-shaped HTTP-tool pattern: an agent that previously
+# called `HTTP({method:"PATCH", url:"$BASE_URL/api/applications/...",
+# headers:{Authorization:"Bearer ..."}, body:{...}})` instead calls
+# `local__patch_application({bearer:"...", id:"...", body:{...}})` —
+# typed, schema-validated, and rename-safe.
+#
+# Constraints:
+#   - Inline schemas only ($ref is NOT resolved). Bundle your spec
+#     before pointing loomcycle at it (swagger-cli bundle, redocly
+#     bundle, etc.).
+#   - JSON request/response bodies only.
+#   - Trust model: this gateway is pointed at YOUR application server;
+#     SSRF and private-IP defences from the HTTP tool do not apply.
+#     Don't point base_url at attacker-controlled hosts.
+# local_api:
+#   spec: openapi.yaml          # relative to this YAML's directory
+#   base_url: http://localhost:3000
+#   tool_name_prefix: local     # tools become mcp__-style: local__<opId>
+
 # ─── Concurrency ──────────────────────────────────────────────────────
 # Caps total in-flight runs across all agents. Bursts above the cap
 # queue up to max_queue_depth for queue_timeout_ms before returning


### PR DESCRIPTION
## Summary

Adds the v0.4.0 tracking + cancel surface so jobs-search-agent's local agent_runs unreliability (rows stuck at status=running after SSE drops or process crashes) can be fixed by polling loomcycle as the source of truth.

**Stacked on PR #11** (Agent + Skill + LocalAPI). Diffable starting from `030aca8` (PR #10's merge into main).

## Trust + design (locked from the design Q&A)

| Question | Choice |
|---|---|
| Pause | Deferred to v0.4.1 |
| Process-crash recovery | Heartbeat column populated; sweeper deferred |
| Read endpoints | Both `GET /v1/agents/{agent_id}` and `GET /v1/users/{user_id}/agents` |
| Authorization | Bearer-only (existing pattern) |
| `agent_id` uniqueness | Globally unique among **active** runs only; reuse permitted post-termination |
| Idempotent cancel | Yes — second cancel returns 200 with prior status |
| SSE event for new id | Add `event: agent` (new), keep `event: session` unchanged for back-compat |
| Cancel-via-API status | `RunCancelled` (already in enum, never written before this PR) |

## API additions

- **`POST /v1/runs`** body: `user_id`, `agent_id` (both optional, charset `[A-Za-z0-9_-]{1,128}`).
- **`POST /v1/sessions/{id}/messages`** body: `agent_id` (continuation runs always get a fresh agent_id; user_id inherits from session).
- **New SSE side-channel `event: agent`**: announces `agent_id`/`run_id`/`session_id`/`parent_agent_id` after `event: session`.
- **`GET /v1/agents/{agent_id}`**: status doc with `live` flag (registry presence vs DB-only).
- **`POST /v1/agents/{agent_id}/cancel`**: cascading + idempotent; returns `cascaded[]`.
- **`GET /v1/users/{user_id}/agents?status=…`**: default `running`, `all` bypasses, any RunStatus filters.

## Schema additions (additive, all nullable)

- `sessions.user_id`
- `runs.{agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at}`
- 4 partial indexes (WHERE col IS NOT NULL)

ALTER TABLE wrapped to ignore `duplicate column name` so second startup is a no-op without a versioned-migrations table.

## Cancellation mechanism

`internal/cancel/registry.go`:
- `Register/Deregister/Cancel/Get/ListByUser/ListChildren` plus `Count` (test-only).
- `context.WithCancelCause` + `ErrCancelledByAPI` sentinel discriminates API-cancel from client-disconnect via `errors.Is(context.Cause(runCtx), cancel.ErrCancelledByAPI)`.
- Cancel cascades through children-by-parent_agent_id; idempotent under concurrent calls.
- `cancelWithReason` wrapper carries optional reason while still matching `ErrCancelledByAPI`.

`finishRunWithCancel` in server.go inspects the cause and writes `RunCancelled` (with reason) for API-cancel; `RunFailed`/`RunCompleted` for everything else. Existing `WHERE status='running'` guard prevents races.

## Sub-agent inheritance

`tools.WithRunIdentity` / `tools.RunIdentity` helpers (mirrors PR #11's `WithAgentTools`). `runSubAgent` reads parent's user_id and agent_id, generates a fresh sub agent_id, sets parent linkage on the sub-run row, and registers the sub in the cancel registry. Sub's tool_result text is prefixed with `[sub-agent agent_id=…]` so the parent's caller can echo it.

## Heartbeat foundation

`loop.RunOptions.OnHeartbeat func()` fires at each iteration; server provides a callback that does `UPDATE runs SET last_heartbeat_at = ? WHERE id = ? AND status = ?`. Sweeper deferred until soak data picks a sensible threshold.

## Test plan

- [x] 9 new sqlite tests (idempotent migration, identity round-trip, query methods, heartbeat monotonicity, cancelled terminal)
- [x] 11 cancel registry tests (duplicate active, cascade two-levels, concurrent idempotency, cause attachment with/without reason)
- [x] 10 HTTP integration tests (announce, generate, validate, 409 duplicate, cancel writes RunCancelled, idempotent re-cancel, GET status, list filter, sub-agent inheritance)
- [x] Empirical proofs for: ALTER guard, FinishRun + UpdateHeartbeat status guards, cause-aware finishRunWithCancel branch, ErrCancelledByAPI sentinel, registry duplicate-active conflict, cascade walk
- [x] Full sweep `go test ./...` green (all 18 packages)

## TS adapter

Adapter PR is on jobs-search-agent's `feature-tracking-and-cancel-adapter` branch (separate repo). Extends `LoomcycleClient` with `userId`/`agentId` on RunOptions plus `getAgent`/`cancelAgent`/`listUserAgents` methods. 12 vitest tests; type-check clean.

## Out of scope

- Pause/resume — v0.4.1
- Heartbeat sweeper — v0.4.x once we have soak data
- Per-user authorization — host application's responsibility (loomcycle is bearer-only)
- Per-user concurrency caps — separate v0.4 PR (already on the v0.4 list as "per-tenant fairness")

🤖 Generated with [Claude Code](https://claude.com/claude-code)