### PR TITLE
fix: per-agent max_tokens + WebSearch schema overshoot guard

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -466,6 +466,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Segments:    req.Segments,
 		OnEvent:     emit,
 		OnHeartbeat: heartbeat,
+		MaxTokens:   agentDef.MaxTokens, // 0 → driver default
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -696,6 +697,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		PriorMessages: priorMessages,
 		OnEvent:       emit,
 		OnHeartbeat:   heartbeat,
+		MaxTokens:     agentDef.MaxTokens, // 0 → driver default
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -1103,6 +1105,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 		Segments:    segs,
 		OnEvent:     subEmit,
 		OnHeartbeat: subHeartbeat,
+		MaxTokens:   def.MaxTokens, // 0 → driver default
 	})
 	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,6 +92,15 @@ type AgentDef struct {
 	// at config-load — a skill may only narrow, never widen, the tool
 	// set the operator granted to the agent.
 	Skills []string `yaml:"skills"`
+
+	// MaxTokens caps per-iteration assistant output. Zero = use the
+	// provider driver's default (4096 in anthropic, far below
+	// haiku-4-5's 64k ceiling). Set explicitly for agents that emit
+	// large structured output (verdict JSON for big batches, long
+	// rewrites): without it, output truncates mid-response and the
+	// caller's parser fails. Recommended values: 8192 for general
+	// use, 16384+ for batch scoring agents.
+	MaxTokens int `yaml:"max_tokens"`
 }
 
 // MCPServer declares one MCP server. Transport "stdio" or "http".

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -59,6 +59,15 @@ type RunOptions struct {
 	// synchronously, so implementations should be cheap (single
 	// UPDATE) and tolerate ctx cancellation gracefully.
 	OnHeartbeat func()
+
+	// MaxTokens caps per-iteration assistant output. Zero = let the
+	// driver pick its default (4096 in the anthropic driver, which
+	// is far below modern haiku/sonnet output ceilings of 8k–64k).
+	// Agents that emit large structured output (verdicts JSON for
+	// big batches, long-form rewrites) need to set this explicitly
+	// or they truncate mid-output. The HTTP server populates this
+	// from cfg.Agents[X].MaxTokens at request time.
+	MaxTokens int
 }
 
 // RunResult is the terminal state after a Run.
@@ -112,10 +121,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 			opts.OnHeartbeat()
 		}
 		req := providers.Request{
-			Model:    opts.Model,
-			System:   system,
-			Messages: messages,
-			Tools:    toolSpecs,
+			Model:     opts.Model,
+			System:    system,
+			Messages:  messages,
+			Tools:     toolSpecs,
+			MaxTokens: opts.MaxTokens, // 0 → driver default
 			// OnEvent lets the driver fire pre-channel events (currently
 			// EventRetry during a 429 sleep) directly to the same caller
 			// hook the loop uses for response events. Without this hop

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -149,7 +149,12 @@ type wireContentBlock struct {
 func buildRequestBody(req providers.Request) ([]byte, error) {
 	maxTokens := req.MaxTokens
 	if maxTokens == 0 {
-		maxTokens = 4096
+		// 8192 picked over the previous 4096: haiku-4-5/sonnet-4-6
+		// both support up to 64k output, and 4096 was empirically
+		// truncating verdict-batch agents (~12k chars output ≈ 4k
+		// tokens). 8k is still conservative — agents that need more
+		// can set max_tokens: NN explicitly in their YAML.
+		maxTokens = 8192
 	}
 
 	w := wireRequest{

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -416,3 +416,53 @@ func TestRequestBodyShape(t *testing.T) {
 		t.Errorf("stream flag missing:\n%s", body)
 	}
 }
+
+// TestBuildRequestBody_MaxTokensDefault verifies the driver's default
+// max_tokens. 4096 was the historical value but caused mid-output
+// truncation for batch agents (~12k chars output ≈ 4k tokens, hitting
+// the cap before the closing `}` of a verdicts JSON). Bumped to 8192
+// 2026-05-05; haiku-4-5/sonnet-4-6 both support up to 64k output so
+// 8k is still conservative. Revert this constant to fail this test.
+func TestBuildRequestBody_MaxTokensDefault(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model:    "claude-haiku-4-5",
+		System:   []providers.ContentBlock{{Type: "text", Text: "you are a test"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var parsed struct {
+		MaxTokens int `json:"max_tokens"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.MaxTokens != 8192 {
+		t.Errorf("default max_tokens: got %d, want 8192 (raised from 4096 to give batch-output agents headroom)", parsed.MaxTokens)
+	}
+}
+
+// TestBuildRequestBody_MaxTokensOverride verifies that req.MaxTokens
+// flows through to the wire request when the caller (loop.RunOptions
+// → HTTP server, populated from agentDef.MaxTokens) sets it.
+func TestBuildRequestBody_MaxTokensOverride(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model:     "claude-haiku-4-5",
+		MaxTokens: 16384,
+		System:    []providers.ContentBlock{{Type: "text", Text: "x"}},
+		Messages:  []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "y"}}}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var parsed struct {
+		MaxTokens int `json:"max_tokens"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.MaxTokens != 16384 {
+		t.Errorf("override max_tokens: got %d, want 16384", parsed.MaxTokens)
+	}
+}

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -61,11 +61,19 @@ func (s *WebSearch) Description() string {
 }
 
 func (s *WebSearch) InputSchema() json.RawMessage {
+	// max_results: model-facing cap is wide enough that overshoot
+	// (model trained on WebSearch APIs that allow up to 100) does
+	// not produce a schema-violation error round-trip; the runtime
+	// silently clamps to maxResultsHard = 25 in Execute(). Without
+	// this widening, a single overshoot like max_results=30 made
+	// the agent believe the tool itself was broken and cascade
+	// into elaborate-query retry loops (see job-searcher prod
+	// failure 2026-05-05).
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
 			"query":       {"type": "string"},
-			"max_results": {"type": "integer", "minimum": 1, "maximum": 25}
+			"max_results": {"type": "integer", "minimum": 1, "maximum": 100}
 		},
 		"required": ["query"]
 	}`)

--- a/internal/tools/builtin/websearch_live_test.go
+++ b/internal/tools/builtin/websearch_live_test.go
@@ -1,0 +1,100 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWebSearch_Live exercises the real Brave Search API through
+// loomcycle's WebSearch tool — same code path the job-searcher agent
+// hits in production. Skipped when BRAVE_API_KEY is unset so the
+// default `go test ./...` run stays hermetic.
+//
+// Run it explicitly:
+//
+//	BRAVE_API_KEY=$(grep '^BRAVE_API_KEY=' .env.local | cut -d= -f2-) \
+//	  go test -v -count=1 -run TestWebSearch_Live \
+//	  ./internal/tools/builtin/
+//
+// The `-count=1` defeats Go's test-result cache so the call actually
+// goes out to Brave each time, not just on the first run.
+func TestWebSearch_Live(t *testing.T) {
+	apiKey := strings.TrimSpace(os.Getenv("BRAVE_API_KEY"))
+	if apiKey == "" {
+		t.Skip("BRAVE_API_KEY not set; skipping live Brave call")
+	}
+
+	tool := &WebSearch{
+		APIKey:  apiKey,
+		Timeout: 20 * time.Second,
+	}
+
+	// Three queries chosen to mirror what job-searcher actually
+	// emitted in production: a plain-language one (often the most
+	// productive on Brave's free tier), one with a site: filter
+	// (the failure mode reported), and a feeds query (Wellfound
+	// is a job board the agent is supposed to crawl).
+	cases := []struct {
+		name  string
+		query string
+		max   int
+	}{
+		{"plain", "Robotics Developer remote full-time", 5},
+		{"site_filter", `site:linkedin.com/jobs "Mobile Developer" remote`, 5},
+		{"jobs_board", `Wellfound "Robotics" remote`, 5},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			input, err := json.Marshal(map[string]any{
+				"query":       c.query,
+				"max_results": c.max,
+			})
+			if err != nil {
+				t.Fatalf("marshal input: %v", err)
+			}
+
+			res, err := tool.Execute(context.Background(), input)
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+
+			t.Logf("query: %q", c.query)
+			t.Logf("isError=%v", res.IsError)
+			t.Logf("response (%d chars):\n%s", len(res.Text), res.Text)
+
+			if res.IsError {
+				// Don't fail the whole run on a single Brave hiccup —
+				// the user is investigating WHY production saw
+				// repeated empty results. Keep going so they see
+				// the pattern across all three query shapes.
+				t.Errorf("Brave returned error: %s", res.Text)
+				return
+			}
+			if strings.TrimSpace(res.Text) == "no results" {
+				t.Errorf("Brave returned 'no results' — this is the production failure mode")
+				return
+			}
+
+			// Smoke check: the rendered format is `[N] Title — URL\n   Description`.
+			// At least one numbered line should be present on a successful call.
+			if !strings.Contains(res.Text, "[1] ") {
+				t.Errorf("response missing expected `[1] ` marker — render contract drifted?")
+			}
+		})
+	}
+
+	// Header echo — Brave's response headers carry rate-limit signal
+	// (X-RateLimit-Remaining, X-RateLimit-Reset). loomcycle's WebSearch
+	// throws those away today, so we can't assert on them; the next
+	// case below would be a separate diagnostic if a per-minute cap
+	// is what the agent kept tripping. Logged here as a follow-up.
+	fmt.Println("\nTip: if all three sub-tests passed, Brave is reachable from this host with this key.")
+	fmt.Println("If only the plain query passed, the site:/quoted-string queries hit Brave's free-tier oddity")
+	fmt.Println("(operators report site: filters return zero on freemium; need pro tier for site narrowing).")
+}


### PR DESCRIPTION
## Summary
Two reliability fixes diagnosed during the 2026-05-05 jobs-search-agent production debugging session:

- **Per-agent `max_tokens` config**: the anthropic driver default of 4096 was truncating verdict-batch agents at ~12k chars output (≈ 4k tokens). Plumbed `max_tokens` through `AgentDef` YAML → `loop.RunOptions` → `providers.Request`. Driver default also bumped 4096 → 8192 so any agent that omits the field still has 2× headroom.
- **WebSearch schema cap widened 25 → 100**: models trained on WebSearch APIs that allow up to 100 results were overshooting the schema cap, getting a JSON-schema validation round-trip, and misdiagnosing it as "the tool is broken" — then producing elaborate retry queries that all returned zero results. The runtime `maxResultsHard = 25` clamp in `Execute()` still bounds the actual Brave call, so widening the schema is safe.

Adds `websearch_live_test.go` — a `BRAVE_API_KEY`-gated smoke test that hits the real Brave API with three query shapes. Useful next time an agent claims "no results"; if the live test passes from the same host, the failure is upstream in the prompt, not the key/quota/network.

## Test plan
- [x] `go test -count=1 ./...` — all 18 packages pass
- [x] New `TestBuildRequestBody_MaxTokensDefault` (asserts 8192) and `TestBuildRequestBody_MaxTokensOverride` (asserts agent-set value round-trips)
- [x] Live Brave test passed three query shapes (plain, site:filter, jobs_board)
- [ ] Operator-side: rebuild loomcycle binary, sync sample.yaml (now contains `ats-filter.max_tokens: 16384`), restart sidecar
- [ ] Verify next ATS scan completes a 10-job batch chunk to full JSON without truncation

## Notes
The companion change in jobs-search-agent (`feature-ats-filter-output-budget-and-job-searcher-syntax`, merging into `dev`) sets `ats-filter.max_tokens: 16384` in `sample.yaml`. Without rebuilding loomcycle, the YAML field is ignored and the truncation persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)