### PR TITLE
fix: record model on streaming Usage so runs.model populates

### DIFF
--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -104,7 +104,15 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out)
+	// Thread req.Model into the stream parser so the message_delta
+	// handler can stamp it onto the Usage event. Anthropic's
+	// streaming usage object doesn't carry the model field; without
+	// this plumbing, every providers.Usage on the wire has Model="",
+	// the loop's totalUsage.Model stays empty, and the runs table's
+	// `model` column never populates. Cost incident 2026-05-06: with
+	// no model recorded per run, we couldn't verify which agent
+	// runs called which model — investigation depended on guesses.
+	go streamEvents(ctx, resp.Body, out, req.Model)
 	return out, nil
 }
 
@@ -225,7 +233,7 @@ type sseFrame struct {
 	data  []byte
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, model string) {
 	defer body.Close()
 	defer close(out)
 
@@ -254,7 +262,7 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		if len(line) == 0 {
 			// dispatch frame
 			if frame.event != "" || len(frame.data) > 0 {
-				if !processFrame(frame, &current, &stopReason, &usage, send) {
+				if !processFrame(frame, &current, &stopReason, &usage, send, model) {
 					return
 				}
 			}
@@ -290,6 +298,7 @@ func processFrame(
 	stopReason *string,
 	usage **providers.Usage,
 	send func(providers.Event) bool,
+	model string,
 ) bool {
 	switch f.event {
 	case "content_block_start":
@@ -372,11 +381,15 @@ func processFrame(
 			*stopReason = ev.Delta.StopReason
 		}
 		// usage in message_delta is final cumulative; it overwrites.
+		// Stamp the model from the request — Anthropic's streaming
+		// usage object doesn't carry it, so we plumb it through from
+		// driver.Call (see comment at the streamEvents call site).
 		*usage = &providers.Usage{
 			InputTokens:         ev.Usage.InputTokens,
 			OutputTokens:        ev.Usage.OutputTokens,
 			CacheCreationTokens: ev.Usage.CacheCreationTokens,
 			CacheReadTokens:     ev.Usage.CacheReadTokens,
+			Model:               model,
 		}
 
 	case "error":

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -466,3 +466,57 @@ func TestBuildRequestBody_MaxTokensOverride(t *testing.T) {
 		t.Errorf("override max_tokens: got %d, want 16384", parsed.MaxTokens)
 	}
 }
+
+// TestStreamingUsage_PopulatesModel verifies that the providers.Usage
+// emitted on EventDone carries the model field from the request.
+//
+// Anthropic's streaming `message_delta` event includes token counts
+// but NOT the model identifier. The driver plumbs req.Model through
+// to the usage parser so downstream stores (loomcycle's runs.model
+// column, jobs-search-web's agent_runs.model) get the ground truth.
+//
+// Cost incident 2026-05-06: with no model recorded per loomcycle run,
+// it was impossible to verify which agents called which models from
+// DB queries alone. Investigation required guesswork. This test
+// pins the invariant: Usage.Model on EventDone equals req.Model.
+//
+// Revert the streamEvents `model` parameter or the Usage.Model
+// assignment in processFrame's message_delta case to fail this test.
+func TestStreamingUsage_PopulatesModel(t *testing.T) {
+	const requestedModel = "claude-haiku-4-5-20251001"
+
+	srv := fakeStream(t, []string{
+		"event: content_block_delta\ndata: {\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n",
+		"event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":42,\"output_tokens\":7}}\n\n",
+		"event: message_stop\ndata: {}\n\n",
+	})
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    requestedModel,
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var done *providers.Event
+	for ev := range ch {
+		if ev.Type == providers.EventDone {
+			cp := ev
+			done = &cp
+		}
+	}
+	if done == nil || done.Usage == nil {
+		t.Fatalf("expected an EventDone with Usage; got done=%v", done)
+	}
+	if done.Usage.Model != requestedModel {
+		t.Errorf("Usage.Model = %q, want %q (Anthropic streaming usage doesn't carry model — driver should stamp it from req.Model)",
+			done.Usage.Model, requestedModel)
+	}
+	// Also assert tokens to confirm the parse path is otherwise intact.
+	if done.Usage.InputTokens != 42 || done.Usage.OutputTokens != 7 {
+		t.Errorf("Usage tokens: input=%d output=%d, want 42/7", done.Usage.InputTokens, done.Usage.OutputTokens)
+	}
+}


### PR DESCRIPTION
## Summary

The streaming \`message_delta\` handler builds the final cumulative \`providers.Usage\` from the wire's usage object — but Anthropic's streaming usage doesn't carry the model identifier. So every \`runs.model\` row in the DB has been empty, even though \`req.Model\` is sent on every call.

This PR plumbs \`req.Model\` from \`driver.Call\` → \`streamEvents\` → \`processFrame\` and stamps it onto Usage in the message_delta case. Three small changes; one new test pinning the invariant.

## Why this matters

Cost incident 2026-05-06: when investigating which models were called during specific time windows, every loomcycle run reported \`model = ""\`. Post-incident accounting had to guess from \`session.agent\` + \`sample.yaml\`'s per-agent model assignment. No ground truth.

After this PR, queries like:

\`\`\`sql
SELECT model, COUNT(*), SUM(input_tokens), SUM(output_tokens)
FROM runs
WHERE started_at > strftime('%s','now','-1 day') * 1000000000
GROUP BY model;
\`\`\`

return real per-model breakdowns. Combined with the price table in jobs-search-web's \`src/lib/pricing.ts\`, this gives ground-truth cost-per-model for retrospectives.

## Test plan

- [x] \`go test -count=1 ./...\` — all 18 packages pass
- [x] New \`TestStreamingUsage_PopulatesModel\` asserts \`ev.Usage.Model\` equals \`req.Model\` on EventDone
- [x] Reverting the plumbing makes the test fail with \`Usage.Model = ""\` vs the requested model

🤖 Generated with [Claude Code](https://claude.com/claude-code)