### PR TITLE
docs(plan): restore tool-use hooks (PreToolUse/PostToolUse) to v1.0 outline

### DIFF
--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -91,6 +91,16 @@ This is the "MCP-configurable" axis: instead of writing YAML and POSTing JSON, a
 
 What's not yet decided: stdio vs HTTP transport (probably both), method naming (resources vs tools), whether MCP clients can register new agents at runtime or only spawn from operator-defined ones, handling of long-lived run streams across MCP's request/response shape.
 
+#### Tool-use hooks (PreToolUse / PostToolUse)
+
+Operator-supplied middleware around tool dispatch. The agent loop calls `PreToolUse` before invoking any tool — given the tool name, the model's input, the agent identity, and the request context, the hook can rewrite the input, deny the call (returning a synthetic `tool_result`), audit it, or annotate it with metadata (e.g. a trace span ID). After the tool runs, `PostToolUse` sees the result and can rewrite it. The canonical use case for the post-hook is wrapping untrusted content from `WebFetch` / `HTTP` / MCP results in a trust-boundary marker so a downstream LLM treats the payload as data rather than instructions — the v0.2 plan called this the "untrusted-content wrap."
+
+Hooks are the seam for cross-cutting concerns the runtime currently has no first-class place for: per-tool quotas, audit logs that capture every tool call before the policy layer touches it, content-sanitization passes, OTEL spans tied to tool invocations, soft-deny patterns ("you tried to fetch X; here's a redacted version instead"). Today every one of these would have to be bolted into the dispatcher; hooks let them be operator-pluggable without forking the runtime. The pre/post split mirrors the same pattern in Claude Code's hooks system, so operators porting policy code between the two have one mental model.
+
+This was originally a v0.2 plan item, deferred at v0.4 because no consumer required it, and resurfaces alongside the v1.0 observability work — many of the items in *High-load runtime work* below (OTEL spans, per-tool quotas, audit) want hooks as their wiring point.
+
+What's not yet decided: hook composition order (single chain vs typed phases), how hooks express denial vs annotation, whether hooks see the post-policy-narrowing input or the raw model input, whether hooks can short-circuit the loop entirely, and the wire shape — Go interface (compile-time, in-process), HTTP webhook (operator-supplied service), or MCP-callable (agentic hook driving agentic policy). RFC at pickup.
+
 ### High-load runtime work
 
 These are cross-cutting capacity items. Not a single feature; collectively they take the runtime from "single-tenant comfortable on a 4–8 GiB VPS" to "10k concurrent agents per replica."


### PR DESCRIPTION
## Summary

Restores the **Tool-use hooks (PreToolUse / PostToolUse)** roadmap entry to the public \`docs/PLAN.md\`. The feature has been on the internal plan since v0.2 (\`doc-internal/PLAN.md:352-354\`), got deferred at v0.4 (line 690), and survived only as a one-liner in the internal v1.0 list (line 845) — it never made it into the public roadmap when v0.5.0 promoted the v1.0 outline to a public doc.

This is a **doc-only PR** — no code changes, no commitment to a v1.0 ship date for hooks itself. It just makes the public roadmap match the internal plan record so the feature isn't silently dropped.

## What the new section covers

Same outline-shape as the neighbouring primitives (Memory, Channel, LoomHelp, LoomCycle MCP):

- **Elevator** — \`PreToolUse\` rewrites/denies/audits before dispatch; \`PostToolUse\` rewrites tool results (canonical case: wrapping untrusted \`WebFetch\` / \`HTTP\` / MCP content as a trust-boundary marker — the v0.2 plan's "untrusted-content wrap")
- **Why now** — names the cross-cutting concerns the runtime has no place for today: per-tool quotas, OTEL spans, audit, content sanitization, soft-deny patterns. Notes that several **High-load runtime work** items listed below (OTEL spans, per-tool quotas, audit) want hooks as their wiring point.
- **History** — v0.2 plan → deferred at v0.4 → resurfaces in v1.0 alongside observability.
- **Open questions** — hook composition order, denial vs annotation, post-policy vs raw input, short-circuit semantics, wire shape (Go interface / HTTP webhook / MCP-callable).
- **Cross-reference** — pre/post split mirrors Claude Code's hook pattern, so operators porting policy between the two have one mental model.

## Test plan

- [x] Markdown renders cleanly on GitHub (verified via diff preview)
- [x] No code or test changes — \`go test ./...\` not required
- [x] Existing \`Decision principles\` section already permits operator-extension primitives; no governance change needed

## Out of scope

- Detailed API design (Go interface signature, HTTP webhook contract, MCP method shape) — explicitly left for the RFC-at-pickup pattern documented in the *How to contribute to v1.0* section.
- v1.0 ship date for hooks. The roadmap as a whole sequences observability ahead of hooks; this PR doesn't change that.
- Code scaffolding (\`internal/loop/hooks.go\`). The internal plan reserves that path; nothing lands until the RFC is signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)