### PR TITLE
docs: mark v0.5.5 + v0.6.0 shipped; surface DeepSeek + provider-routing intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ It exists to replace bundled-binary agent SDKs that cold-start in 20–30 s, lea
 ## Why this approach
 
 - **Pure HTTP loop.** No vendor binary spawned per call. The runtime is one Go process, ~16 MB compiled, single static binary. Cold-start is the kernel's exec time.
-- **Provider-agnostic.** Anthropic Messages, OpenAI Chat Completions, Ollama `/api/chat` — all three drivers normalize to one `Event` channel the loop drains. Capability flags expose provider-specific extras (Anthropic `cache_control`, OpenAI parallel tool calls).
+- **Provider-agnostic.** Four drivers — Anthropic Messages, OpenAI Chat Completions, DeepSeek (OpenAI-compatible), Ollama `/api/chat` — all normalize to one `Event` channel the loop drains. Capability flags expose provider-specific extras (Anthropic `cache_control`, OpenAI / DeepSeek parallel tool calls).
+- **Per-agent provider routing.** YAML `provider:` field per agent lets a consumer mix backends by data sensitivity: Anthropic for user-sensitive paths, DeepSeek for high-volume public-data work, Ollama (local llama) for offline / cost-floor scenarios. Same wire surface, different cost / privacy posture per agent.
 - **Default-deny tool policy.** Every built-in is disabled until env-configured. Every agent gets zero tools until `allowed_tools` is set in YAML. Two layers must say "yes" before a tool reaches the model.
 - **Native cache placement.** When the provider supports it (Anthropic), system blocks marked `cacheable: true` carry `cache_control` on the wire — you keep cache reads on the stable preamble even when the rest of the conversation churns.
-- **Observable everywhere.** Every text chunk, tool call, tool result, usage update, and retry is an SSE event. Nothing happens silently.
+- **Two wire surfaces.** HTTP+SSE (default) and gRPC (opt-in via `LOOMCYCLE_GRPC_ADDR`). Both share the same store, cancel registry, runner, and concurrency semaphore — picking one is a wire-format decision, not a feature decision. A cancel issued via gRPC reaches a run started via HTTP and vice versa.
+- **Observable everywhere.** Every text chunk, tool call, tool result, usage update, and retry is an SSE / gRPC event. Nothing happens silently.
 
 ## Quick start
 
@@ -55,7 +57,27 @@ curl -N http://127.0.0.1:8787/v1/runs \
   }'
 ```
 
-## What's in v0.5.0 (`feature-postgres` branch)
+## What's in v0.6.0
+
+| Surface             | Status |
+|---------------------|--------|
+| **DeepSeek provider** | ✅ Wraps the OpenAI driver with the DeepSeek base URL pre-baked. Per-agent yaml: `provider: deepseek`. Set `DEEPSEEK_API_KEY`; optional `DEEPSEEK_BASE_URL` for self-hosted OpenAI-compatible mirrors (vLLM, etc.). |
+| **OpenAI `Usage.Model` fix** | ✅ Driver now captures the wire-resolved model alias from the streamed chunk envelope, so `runs.model` populates for every OpenAI-compatible run (OpenAI itself, DeepSeek, vLLM). Same regression class as the v0.4 anthropic fix; latent until the DeepSeek live test surfaced it. |
+| **Ollama live integration tests** | ✅ Three tests (probe, chat, tool call) gated by `OLLAMA_TEST_BASE_URL`. Validated against qwen3:14b on RTX 5080 (16GB VRAM) end-to-end as the offline / cost-floor backend. |
+| **Constant-time bearer compare** | ✅ New `internal/auth.CompareBearer` (sha256+CTC) replaces raw `subtle.ConstantTimeCompare` on both HTTP and gRPC. Closes a length-leak side channel that the stdlib documents but doesn't fix. |
+
+**Provider routing intent (jobs-search-agent first):** Anthropic for user-sensitive paths · DeepSeek for high-volume public data · Ollama (local llama) for offline / cost floor · OpenAI for general use / prototyping. See [`docs/PLAN.md`](docs/PLAN.md#v060--current) for the full rationale and the v0.7+ rollout plan.
+
+## What's in v0.5.5
+
+| Surface             | Status |
+|---------------------|--------|
+| **gRPC server**      | ✅ Opt-in via `LOOMCYCLE_GRPC_ADDR`. All seven RPCs mirror the HTTP+SSE surface 1:1 (`Run`, `Continue`, `GetAgent`, `CancelAgent`, `ListUserAgents`, `GetTranscript`, `Health`). Coexists with HTTP — same store, same cancel registry, same semaphore. See [`docs/GRPC.md`](docs/GRPC.md). |
+| **Python adapter**   | ✅ `pip install loomcycle`. Async `LoomcycleClient` over `grpc.aio` covering all seven RPCs. PEP-561 `py.typed`. |
+| **`internal/runner/`** | ✅ Wire-agnostic seam — HTTP server satisfies `runner.Runner`, gRPC server delegates to the same instance. |
+| **Synthetic registration frames** | ✅ Wire-stable `session` + `agent` frame pair at the head of every Run/Continue stream so adapters capture `(agent_id, run_id, session_id, parent_agent_id)` without re-decoding the transcript. |
+
+## What's in v0.5.0
 
 | Surface             | Status |
 |---------------------|--------|
@@ -72,7 +94,7 @@ The bulk of v0.5.0 is operational: backbone you'll need before scaling past one 
 
 | Surface             | Status |
 |---------------------|--------|
-| **Providers**       | Anthropic ✅ · OpenAI ✅ · Ollama ✅ (tool-tuned models only) |
+| **Providers**       | Anthropic ✅ · OpenAI ✅ · Ollama ✅ (tool-tuned models only). DeepSeek added in v0.6.0. |
 | **Built-in tools**  | Read · Write · Edit · HTTP · WebFetch · WebSearch · Bash · **Agent** · **Skill** |
 | **MCP transports**  | stdio (pooled, auto-respawn) · HTTP (Streamable, SSE-aware) |
 | **MCP startup retry** | Exponential backoff handshake on boot — handles peer-still-starting races |
@@ -101,6 +123,7 @@ The bulk of v0.5.0 is operational: backbone you'll need before scaling past one 
                   │  Agent loop ──── Provider drivers            │
                   │     │              ├─ Anthropic   ✅         │
                   │     │              ├─ OpenAI      ✅         │
+                  │     │              ├─ DeepSeek    ✅         │
                   │     │              └─ Ollama      ✅         │
                   │     ▼                                        │
                   │  Tool dispatcher                             │
@@ -121,7 +144,7 @@ Most-used knobs (full list in `.env.example` + `loomcycle.example.yaml`):
 
 | Env / YAML | What it does |
 |---|---|
-| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OLLAMA_BASE_URL` | Provider credentials. Set what you'll use; unset keys disable the corresponding driver. |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `DEEPSEEK_API_KEY` / `OLLAMA_BASE_URL` | Provider credentials. Set what you'll use; unset keys disable the corresponding driver. `DEEPSEEK_BASE_URL` overrides the public DeepSeek endpoint for self-hosted OpenAI-compatible mirrors. |
 | `LOOMCYCLE_AUTH_TOKEN` | Bearer token required on every `/v1/*` request. Empty = dev-mode unauthenticated (warning logged). |
 | `LOOMCYCLE_LISTEN_ADDR` | Default `127.0.0.1:8787`. |
 | `LOOMCYCLE_DATA_DIR` | SQLite store location. Default `./data`. |
@@ -136,8 +159,8 @@ Most-used knobs (full list in `.env.example` + `loomcycle.example.yaml`):
 
 ## Adapters
 
-- **TypeScript** — `npm install @loomcycle/client` → see `adapters/ts/`. Used by `jobs-search-agent`.
-- **Python** — deferred to v1.x.
+- **TypeScript** — `npm install @loomcycle/client` → see `adapters/ts/`. HTTP+SSE. Used by `jobs-search-agent`.
+- **Python** — `pip install loomcycle` → see `adapters/python/`. Async over `grpc.aio`; covers all seven RPCs. Shipped in v0.5.5.
 
 ## Security
 
@@ -154,7 +177,7 @@ Most-used knobs (full list in `.env.example` + `loomcycle.example.yaml`):
 - `docs/TOOLS.md` — the two-layer default-deny model end-to-end, every built-in tool, MCP / LocalAPI integrations, per-request narrowing.
 - `docs/POSTGRES.md` — operator guide for the v0.5.0 Postgres backend: configuration, migrations, sqlite→postgres data migration runbook, concurrency benchmark.
 - `docs/GRPC.md` — operator guide for the v0.5.5 gRPC surface: enablement, wire-shape parity with HTTP+SSE, error mapping, TLS / coexistence recipes, Python adapter quick-start.
-- `docs/PLAN.md` — public roadmap. v0.4.0 + v0.5.0 status; v0.5.5 / v0.6.0 / v1.0 outlines.
+- `docs/PLAN.md` — public roadmap. v0.4.0 / v0.5.0 / v0.5.5 / v0.6.0 shipped status; v0.7+ near-term + v1.0 outline.
 - `CLAUDE.md` — project guide for agents working in this repo (Claude Code).
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ This document describes the v0.4.0 runtime end-to-end. v0.4.0 ships the MCP-inte
 `loomcycle` is a single Go binary (`bin/loomcycle` from `cmd/loomcycle/`) that:
 
 1. Owns the LLM **tool-use loop** end-to-end (model → tool_use → tool_result → model). No vendor SDK in the loop, no bundled binary.
-2. Talks to **providers** over their public HTTP APIs — Anthropic Messages, OpenAI Chat Completions, Ollama `/api/chat`.
+2. Talks to **providers** over their public HTTP APIs — Anthropic Messages, OpenAI Chat Completions, DeepSeek (OpenAI-compatible Chat Completions at a different base URL), Ollama `/api/chat`.
 3. Dispatches tool calls to **built-in tools**, **MCP servers** (stdio + HTTP), **LocalAPI gateways** (OpenAPI → tool-per-operation), or **sub-agents** (the `Agent` built-in).
 4. Streams every event back to callers as **SSE** over a small HTTP API (`/v1/runs`, `/v1/sessions/{id}/messages`, `/v1/agents/{agent_id}`, `/v1/users/{user_id}/agents`, `/healthz`).
 5. Persists sessions, runs, and events to a pluggable `Store` (SQLite default; Postgres + Redis adapters scaffolded for v1.0).
@@ -29,6 +29,7 @@ loomcycle/
 │   ├── providers/
 │   │   ├── anthropic/                 Messages API + native cache_control
 │   │   ├── openai/                    Chat Completions
+│   │   ├── deepseek/                  Wraps openai/ with the DeepSeek base URL pre-baked
 │   │   ├── ollama/                    /api/chat NDJSON (tool-tuned models only)
 │   │   ├── ratelimit/                 per-driver retry-after + backoff
 │   │   └── provider.go                Provider interface + Capabilities
@@ -123,13 +124,14 @@ type Event struct {
 
 Each driver translates its provider's streaming shape into the same `Event` channel. The loop is provider-agnostic. Capability flags let the loop decline to set fields the provider doesn't honour (e.g. only Anthropic gets `cache_control` placement; Ollama tool-call IDs are synthesized by the loop).
 
-Three drivers ship in v0.4.0:
+Four drivers ship as of v0.6.0:
 
 | Driver       | API                       | Notes |
 |---|---|---|
 | `anthropic` | Messages (streaming SSE)   | Native `cache_control` on system blocks marked `cacheable: true`. `message_start.message.model` plumbed into final `Usage.Model` so callers get the resolved alias for pricing. |
-| `openai`    | Chat Completions (streaming) | Index-keyed tool_call accumulator across deltas. Honours `[DONE]` sentinel. |
-| `ollama`    | `/api/chat` (NDJSON)         | Tool-tuned models only. Tool-call IDs synthesized as `lc-{iter}-{slot}` because Ollama doesn't issue them. |
+| `openai`    | Chat Completions (streaming) | Index-keyed tool_call accumulator across deltas. Honours `[DONE]` sentinel. As of v0.6.0, captures the wire-resolved `model` field from each chunk envelope so `runs.model` populates correctly (also benefits any OpenAI-compatible endpoint — DeepSeek, vLLM). |
+| `deepseek`  | Chat Completions (streaming) | Wraps the `openai` driver with `https://api.deepseek.com/v1` pre-baked and `ID()` returning `"deepseek"`. Same wire shape, retry strategy, and tool-call envelope. Operator opts in via `DEEPSEEK_API_KEY` env (optional `DEEPSEEK_BASE_URL` for self-hosted OpenAI-compatible mirrors). Distinct package so per-provider cost rollups don't conflate OpenAI and DeepSeek pricing. |
+| `ollama`    | `/api/chat` (NDJSON)         | Tool-tuned models only (qwen3+, llama3.1+, mistral-large). Tool-call IDs synthesized as `lc-{iter}-{slot}` because Ollama doesn't issue them. Recent Ollama versions emit reasoning-model output in a separate `message.thinking` field which the driver currently drops — tracked as v0.7+ work. |
 
 Each driver has rate-limit retry logic (`internal/providers/ratelimit/`) — 429s and provider 5xx-with-retry-after preserve run context across the retry; observable as `event: retry` SSE frames.
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,7 +2,41 @@
 
 This is the public roadmap. For decision history, regret notes, and per-version commit-by-commit details, see `doc-internal/PLAN.md` (gitignored).
 
-## v0.5.0 — current
+## v0.6.0 — current
+
+**Status: shipped (2026-05-08).** Tag `v0.6.0` on `main`, merged via PRs #18 + #19 + the OpenAI driver `Usage.Model` fix. Provider matrix now covers four backends: Anthropic for user-sensitive paths, DeepSeek for high-volume public-data work, Ollama (local llama) for offline / cost-floor scenarios, OpenAI for general use. Per-agent provider routing in YAML lets a consumer mix and match by data sensitivity.
+
+**What's in v0.6.0 (vs v0.5.5):**
+
+- **DeepSeek provider** (`internal/providers/deepseek/`) — thin wrapper around the existing OpenAI driver with the DeepSeek base URL pre-baked and `ID()` returning `"deepseek"`. DeepSeek's Chat Completions endpoint is OpenAI-compatible, so the wire shape, SSE framing, retry strategy, and tool-call envelope all reuse the OpenAI plumbing unchanged. Operator opts in via `DEEPSEEK_API_KEY` env; `DEEPSEEK_BASE_URL` overrides for self-hosted OpenAI-compatible mirrors (e.g. vLLM serving a DeepSeek model). Per-agent yaml: `provider: deepseek`.
+- **OpenAI driver: `Usage.Model` populated from chunk envelope.** Pre-fix, `streamEvents` extracted token counts from the streamed `usage` chunk but never captured the model field, so `runs.model` was always empty for any OpenAI-compatible endpoint (OpenAI itself, DeepSeek, vLLM, ...). Same regression class as the v0.4.0 anthropic fix; latent until the DeepSeek live test surfaced it. Now every OpenAI-compatible run records the wire-resolved alias (e.g. `deepseek-chat-v3-0324`, `gpt-4o-mini-2024-07-18`) — what the provider actually billed against, which matters for cost retros.
+- **Ollama live integration tests** (`internal/providers/ollama/live_test.go`) — three tests (probe, chat, tool call) gated by `OLLAMA_TEST_BASE_URL`. v0.4.0 shipped the Ollama driver with httptest fakes only; the live coverage validates qwen3:14b on RTX 5080 (16GB VRAM) end-to-end as the offline / cost-floor backend.
+- **`internal/auth.CompareBearer`** — sha256+CTC helper used by both HTTP and gRPC bearer-token middleware. Plain `subtle.ConstantTimeCompare` returns 0 immediately on length mismatch, leaking the expected token's length via timing; hashing both sides to a fixed-length digest before the constant-time compare closes that channel. Strengthens auth on both wire surfaces.
+
+**Provider routing intent (jobs-search-agent first):**
+
+| Sensitivity | Backend | Rationale |
+|---|---|---|
+| User-sensitive (CV / CL generation, profile-aware q&a) | **Anthropic** | Best quality + privacy posture for user data |
+| Public data (job scoring, ATS filtering, company profiling, position relevance) | **DeepSeek** | Order-of-magnitude cheaper than Anthropic for high-volume work |
+| Offline / private / cost floor | **Ollama** (local llama) | qwen3:14b on RTX-class VRAM gives DeepSeek-comparable quality at near-zero marginal cost |
+| General / new agents during development | **OpenAI** | Standard choice for prototyping; pin to a specific model to avoid drift |
+
+Architecture decision: DeepSeek is a separate `provider: deepseek` rather than `provider: openai` with a quirky base URL. Three reasons: (1) explicit yaml config documents intent, (2) per-provider `runs.model` rollups can't conflate OpenAI and DeepSeek pricing, (3) a place to absorb DeepSeek-specific quirks (reasoning_content for the reasoner model, future rate-limit header differences) without polluting the OpenAI driver.
+
+## v0.5.5 — previous
+
+**Status: shipped (2026-05-08).** Tag `v0.5.5` on `main`, merged via PR #16. Wire surface coverage: gRPC alongside HTTP+SSE, async Python adapter as a first-class consumer.
+
+**What's in v0.5.5 (vs v0.5.0):**
+
+- **gRPC server** (opt-in via `LOOMCYCLE_GRPC_ADDR`). All seven RPCs mirror the HTTP+SSE surface 1:1 — `Run`, `Continue`, `GetAgent`, `CancelAgent`, `ListUserAgents`, `GetTranscript`, `Health`. Both wires share the same store, cancel registry, runner, and concurrency semaphore — picking gRPC vs. HTTP is a wire-format decision, not a feature decision. A cancel issued via gRPC reaches a run started via HTTP and vice versa.
+- **`internal/runner/`** wire-agnostic seam. The HTTP server satisfies `runner.Runner`; the gRPC server delegates to the same instance. Compile-time guard `var _ runner.Runner = (*Server)(nil)` keeps the interface conformance honest.
+- **Python adapter** (`adapters/python/`, `pip install loomcycle`) — async `LoomcycleClient` over `grpc.aio` covering all seven RPCs. Frozen-dataclass events (`AgentEvent`, `ToolUse`, `Usage`, `Retry`); typed exceptions over `grpc.StatusCode` codes; PEP-561 `py.typed` marker. Promotes the Python adapter from "deferred" to a shipped consumer.
+- **Synthetic registration frames.** `Run`/`Continue` server-stream emit a wire-stable `session` + `agent` frame pair before any provider event so adapters can capture `(agent_id, run_id, session_id, parent_agent_id)` without re-decoding the loop's transcript. The Python adapter swallows these into a `RunHandle`; the HTTP+SSE side-channel exposes the same data via existing event types.
+- **Operator guide:** [GRPC.md](GRPC.md) covers enablement, wire-shape parity with HTTP+SSE, synthetic-frame contract, error code mapping, TLS / coexistence recipes, Python adapter quick-start.
+
+## v0.5.0 — earlier
 
 **Status: shipped (2026-05-08).** Tag `v0.5.0` on `main`, merged via PR #15. The production-deployment unlock: Postgres `Store` adapter alongside SQLite (which stays first-class for compact installs), heartbeat sweeper + session-lock map GC, operator-facing CLI surface.
 
@@ -21,9 +55,7 @@ This is the public roadmap. For decision history, regret notes, and per-version 
 - **Cross-replica advisory locks deferred to v1.0.** Driver was multi-replica HA; for the only deployment shape today (single replica), the in-memory cancel registry works for both backends.
 - **No live cutover for sqlite→postgres** — operator stops loomcycle, runs the copy, restarts. Live cutover is v1.0.
 
-For the public-roadmap status of subsequent milestones (v0.5.5, v0.6.0, v1.0), see below.
-
-## v0.4.0 — previous
+## v0.4.0 — earlier
 
 **Status: shipped.** Tag `v0.4.0` on `main`. The runtime's MCP integration story is now production-validated against jobs-search-agent as the first real consumer.
 
@@ -50,6 +82,15 @@ For the public-roadmap status of subsequent milestones (v0.5.5, v0.6.0, v1.0), s
 - **LocalAPI MCP gateway** — code is in `internal/tools/localapi/`, parser + dispatcher wiring + unit tests all landed, registered into the dispatcher at boot when `cfg.LocalAPI.SpecPath` is non-empty. Useful for future consumers that have an OpenAPI spec and don't want to stand up an MCP server.
 
 For usage: see [README](../README.md). For the architecture: see [ARCHITECTURE.md](ARCHITECTURE.md). For tool policy: see [TOOLS.md](TOOLS.md).
+
+## v0.7+ — near-term
+
+Items already designed or scoped, ready to pick up. Distinct from the v1.0 outline below: these are bounded chunks of work with a known shape, not framework-defining primitives.
+
+- **Tool-use hooks implementation** (`PreToolUse` / `PostToolUse`). The public outline lives in [Framework primitives → Tool-use hooks](#tool-use-hooks-pretoolusepostooluse) below. Documentation restored to the roadmap in PR #17. Implementation follows once the wire shape (Go interface vs. HTTP webhook vs. MCP-callable) is decided in an RFC.
+- **`EventThinking` event type.** Recent Ollama versions surface qwen3 / deepseek-r1 reasoning output in a separate `message.thinking` field that the Ollama driver currently silently drops. Acceptable for jobs-search-agent's structured-output public-data agents, but blocks future chain-of-thought consumers and hides cost (operators pay for thinking tokens via `output_tokens` without visibility into what they bought). RFC at pickup; same event type would apply to OpenAI o1-family support when that lands.
+- **`TestBashTimeout` race-detector reliability.** The 100ms timeout in `internal/tools/builtin/bash_test.go` doesn't fire reliably under the race detector on slow CI runners (full `sleep 5` runs to completion instead of cancelling). Real timer-signal starvation, not a margin tweak. Likely needs a refactor of `Bash.Execute()`'s timeout machinery to use `exec.CommandContext` rather than a separate timer goroutine.
+- **jobs-search-agent provider routing rollout.** v0.6.0 ships the per-agent `provider:` knob and three first-class backends (Anthropic / DeepSeek / Ollama). The consumer-side flip happens in `jobs-search-agent`'s agent yaml: public-data agents (ATS filtering, position relevance, company profiling) move to `provider: deepseek`; CV / CL generation stays on `provider: anthropic`. Validation: cost rollups by `runs.model` should show DeepSeek dominating volume while Anthropic dominates spend.
 
 ## v1.0 — planned
 
@@ -149,10 +190,6 @@ The cookbook in v1.0 will expand this into a full set: development sandbox, sing
 ### Web monitoring frontend
 
 A small frontend on top of the SQLite/Postgres event stream — see runs, drill into transcripts, view token + cost rollups. Not a chat UI; this is operator-facing monitoring. Distinct from the LoomCycle MCP, which is for external orchestration.
-
-### Python adapter
-
-`pip install loomcycle`. Thin client over the HTTP+SSE API, equivalent to the TS adapter at `adapters/ts/`. Deferred until a Python-first downstream consumer materializes.
 
 ## Decision principles
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -287,20 +287,23 @@ References: `internal/tools/localapi/`, `cmd/loomcycle/main.go` (registration), 
 
 ## Provider × tool matrix
 
-What works with what:
+What works with what (DeepSeek added in v0.6.0; behaviour identical to OpenAI for tool dispatch since it shares the driver):
 
-|              | Anthropic | OpenAI | Ollama (tool-tuned) |
-|---|:---:|:---:|:---:|
-| `Read` / `Write` / `Edit`  | ✅ | ✅ | ✅ |
-| `HTTP` / `WebFetch`        | ✅ | ✅ | ✅ |
-| `WebSearch`                | ✅ | ✅ | ✅ |
-| `Bash`                     | ✅ | ✅ | ✅ |
-| `Agent` (sub-agents)       | ✅ | ✅ | ✅ |
-| `Skill` (Approach A)       | ✅ | ✅ | ✅ |
-| `LocalAPI` (OpenAPI gateway) | ⏳ | ⏳ | ⏳ | (scaffolded — for future OpenAPI-without-MCP-server consumers) |
-| MCP tools (stdio + HTTP)   | ✅ | ✅ | ✅ |
-| Native cache_control       | ✅ | ❌ | ❌ |
-| Parallel tool calls        | ✅ | ✅ | depends on model |
-| Streaming text + tool_use  | ✅ | ✅ | ✅ |
+|              | Anthropic | OpenAI | DeepSeek | Ollama (tool-tuned) |
+|---|:---:|:---:|:---:|:---:|
+| `Read` / `Write` / `Edit`  | ✅ | ✅ | ✅ | ✅ |
+| `HTTP` / `WebFetch`        | ✅ | ✅ | ✅ | ✅ |
+| `WebSearch`                | ✅ | ✅ | ✅ | ✅ |
+| `Bash`                     | ✅ | ✅ | ✅ | ✅ |
+| `Agent` (sub-agents)       | ✅ | ✅ | ✅ | ✅ |
+| `Skill` (Approach A)       | ✅ | ✅ | ✅ | ✅ |
+| `LocalAPI` (OpenAPI gateway) | ⏳ | ⏳ | ⏳ | ⏳ | (scaffolded — for future OpenAPI-without-MCP-server consumers) |
+| MCP tools (stdio + HTTP)   | ✅ | ✅ | ✅ | ✅ |
+| Native cache_control       | ✅ | ❌ | ❌ | ❌ |
+| Parallel tool calls        | ✅ | ✅ | ✅ | depends on model |
+| Streaming text + tool_use  | ✅ | ✅ | ✅ | ✅ |
+| `Usage.Model` populated    | ✅ | ✅ (v0.6.0+) | ✅ | ✅ |
 
-Ollama caveat: tool calling only works on **tool-tuned** models (Llama 3.1 instruct variants, Qwen2.5-Instruct, Mistral Nemo Instruct). Non-tool-tuned models will hallucinate tool names instead of calling them. Tool_use IDs are synthesized by the loop because Ollama doesn't issue them.
+Ollama caveat: tool calling only works on **tool-tuned** models (qwen3+, Llama 3.1 instruct variants, Qwen2.5-Instruct, Mistral Nemo Instruct). Non-tool-tuned models will silently drop the `tools` field instead of calling them — Ollama's behaviour, not the driver's. Tool_use IDs are synthesized by the loop because Ollama doesn't issue them.
+
+DeepSeek caveat: the v0.6.0 driver wraps the OpenAI driver, so it inherits OpenAI's behaviour exactly. The `deepseek-reasoner` model emits `reasoning_content` separately from `content`; the driver doesn't yet surface that (tracked as v0.7+ alongside the parallel Ollama `message.thinking` gap).


### PR DESCRIPTION
## Summary

Docs catch-up after the v0.5.5 (gRPC + Python adapter, PR #16) and v0.6.0 (DeepSeek + OpenAI \`Usage.Model\` fix + Ollama live tests, PRs #17/#18/#19) rapid-fire merges. Public roadmap, README provider matrix, ARCHITECTURE provider list, and TOOLS provider × tool matrix were all stale.

## What's in this PR

### \`docs/PLAN.md\`
- **New v0.6.0 section** as \"current\" — DeepSeek provider, OpenAI \`Usage.Model\` fix, Ollama live tests, \`internal/auth.CompareBearer\`. Includes the per-agent provider-routing intent table:

  | Sensitivity | Backend |
  |---|---|
  | User-sensitive | Anthropic |
  | Public data | DeepSeek |
  | Offline / floor | Ollama |
  | General / dev | OpenAI |

- **New v0.5.5 section** as \"previous\" — gRPC server, Python adapter, runner extraction, synthetic registration frames, \`GRPC.md\` operator guide.
- **New v0.7+ near-term section** between v0.6.0 and the v1.0 outline. Bounded chunks with known shape, distinct from v1.0 framework-defining primitives:
  - Tool-use hooks implementation (docs already restored to v1.0 outline via PR #17)
  - \`EventThinking\` event type (closes the qwen3 / deepseek-r1 reasoning-content gap)
  - \`TestBashTimeout\` reliability under race detector
  - jobs-search-agent provider-routing rollout
- Demoted v0.5.0 + v0.4.0 to \"earlier\". Removed the stale \"Python adapter — Deferred\" stub from v1.0 (shipped in v0.5.5).

### \`README.md\`
- Provider matrix bumped to four (Anthropic / OpenAI / DeepSeek / Ollama) in the \"Why this approach\" paragraph + architecture diagram.
- New \"What's in v0.6.0\" + \"What's in v0.5.5\" tables ahead of the existing v0.5.0 + v0.4.0 tables.
- Per-agent provider routing called out as a first-class feature (was implicit).
- gRPC documented as the second wire surface alongside HTTP+SSE.
- Config cheatsheet: \`DEEPSEEK_API_KEY\` + \`DEEPSEEK_BASE_URL\`.
- Adapters section: Python ✅ shipped (was ⏳ deferred); mentions \`grpc.aio\` + the seven RPCs.

### \`docs/ARCHITECTURE.md\`
- \`internal/providers/deepseek/\` added to the repo-layout tree.
- Provider driver table expanded from 3 to 4 rows. v0.6.0 OpenAI \`Usage.Model\` fix called out; Ollama \`message.thinking\` gap noted as v0.7+.

### \`docs/TOOLS.md\`
- Provider × tool matrix gains a DeepSeek column. All tool rows ✅ since DeepSeek inherits the OpenAI driver; native \`cache_control\` ❌.
- New \"Usage.Model populated\" row documenting the v0.6.0 fix.
- DeepSeek caveat paragraph mirroring the Ollama one (deepseek-reasoner \`reasoning_content\` gap = v0.7+ work parallel to Ollama \`message.thinking\`).

## Test plan

- [x] \`go build ./...\` clean (docs-only PR but verified nothing else regressed)
- [x] \`go vet ./...\` clean
- [x] Cross-references resolve (links to GRPC.md, POSTGRES.md, PLAN.md, internal source paths)
- [x] Provider matrix consistent across files (README diagram, ARCHITECTURE table, TOOLS matrix all show same 4 providers)

## Out of scope

- Tagging \`v0.6.0\` on \`main\`. Mirror the v0.5.0 pattern: ship docs first, tag after.
- jobs-search-agent's actual yaml flips (consumer-side, separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)