### PR TITLE
fix(openai): preserve reasoning_content across iterations for DeepSeek thinking-mode

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1124,6 +1124,13 @@ func replayTranscript(events []store.Event) []providers.Message {
 	var asstText strings.Builder
 	var asstTools []providers.ContentBlock
 	var pendingToolResults []providers.ContentBlock
+	// asstReasoning carries reasoning_content captured from the
+	// iteration's "done" event so the rebuilt assistant Message can
+	// echo it back to the API on continuation. Required by DeepSeek
+	// V4 Pro / deepseek-reasoner — without it, the next request 400s
+	// with "reasoning_content in the thinking mode must be passed
+	// back". Empty for non-thinking models.
+	var asstReasoning string
 
 	flushAssistant := func() {
 		if asstText.Len() == 0 && len(asstTools) == 0 {
@@ -1134,9 +1141,14 @@ func replayTranscript(events []store.Event) []providers.Message {
 			content = append(content, providers.ContentBlock{Type: "text", Text: asstText.String()})
 		}
 		content = append(content, asstTools...)
-		messages = append(messages, providers.Message{Role: "assistant", Content: content})
+		messages = append(messages, providers.Message{
+			Role:      "assistant",
+			Content:   content,
+			Reasoning: asstReasoning,
+		})
 		asstText.Reset()
 		asstTools = nil
+		asstReasoning = ""
 	}
 	flushPendingTools := func() {
 		if len(pendingToolResults) == 0 {
@@ -1207,8 +1219,20 @@ func replayTranscript(events []store.Event) []providers.Message {
 			// same boundary belong to one user message, and the next text
 			// or tool_call event will close this user turn.
 		case "done":
-			// End-of-run boundary — only used when the final iteration was
-			// purely textual (no tool_results to carry over).
+			// Capture reasoning_content (if present) BEFORE the flush
+			// so the rebuilt assistant Message carries it. Mid-
+			// conversation, this done event also marks the end of
+			// the iteration's assistant turn — done arrives in the
+			// stream BEFORE tool_result events, so the flush here
+			// commits the assistant Message with reasoning attached.
+			var pe providers.Event
+			if err := json.Unmarshal(ev.Payload, &pe); err == nil {
+				asstReasoning = pe.Reasoning
+			}
+			// End-of-run boundary — used both mid-conversation (the
+			// per-iteration assistant turn closes here) and at the
+			// very end (final iteration with purely textual output,
+			// no tool_results to carry over).
 			flushAssistant()
 			flushPendingTools()
 		}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -200,6 +200,13 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 		var iterText string
 		var iterStop string
 		var iterUsage *providers.Usage
+		// iterReasoning holds the accumulated reasoning_content from
+		// thinking-mode models (DeepSeek V4 Pro / deepseek-reasoner).
+		// Stamped onto the assistant Message we append below so the
+		// next iteration's request body echoes it back to the API
+		// per DeepSeek's roundtrip contract. Empty for non-thinking
+		// providers.
+		var iterReasoning string
 
 		for ev := range ch {
 			switch ev.Type {
@@ -227,6 +234,7 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 			case providers.EventDone:
 				iterStop = ev.StopReason
 				iterUsage = ev.Usage
+				iterReasoning = ev.Reasoning
 			case providers.EventError:
 				// Resolver stall feedback for in-stream errors:
 				// driver opened the SSE/NDJSON stream successfully
@@ -249,7 +257,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 				assistantBlocks...,
 			)
 		}
-		messages = append(messages, providers.Message{Role: "assistant", Content: assistantBlocks})
+		messages = append(messages, providers.Message{
+			Role:      "assistant",
+			Content:   assistantBlocks,
+			Reasoning: iterReasoning,
+		})
 
 		if iterUsage != nil {
 			totalUsage.InputTokens += iterUsage.InputTokens

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -166,6 +166,11 @@ type wireMessage struct {
 	Name       string         `json:"name,omitempty"`
 	ToolCallID string         `json:"tool_call_id,omitempty"`
 	ToolCalls  []wireToolCall `json:"tool_calls,omitempty"`
+	// ReasoningContent is the per-turn reasoning trace DeepSeek V4 Pro
+	// (and deepseek-reasoner) require operators to echo back on
+	// subsequent assistant-history turns. omitempty keeps it off the
+	// wire for non-thinking models / non-DeepSeek endpoints.
+	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
 type wireToolCall struct {
@@ -262,7 +267,18 @@ func flattenMessage(m providers.Message) []wireMessage {
 				})
 			}
 		}
-		return []wireMessage{{Role: "assistant", Content: text.String(), ToolCalls: calls}}
+		// Echo back reasoning_content if the message carries one
+		// (DeepSeek V4 Pro / deepseek-reasoner contract — sending the
+		// assistant turn back without it 400s with "reasoning_content
+		// in the thinking mode must be passed back"). omitempty keeps
+		// the field off the wire for non-thinking models / non-DeepSeek
+		// endpoints; vanilla OpenAI ignores unknown fields anyway.
+		return []wireMessage{{
+			Role:             "assistant",
+			Content:          text.String(),
+			ToolCalls:        calls,
+			ReasoningContent: m.Reasoning,
+		}}
 	}
 
 	// user role: split tool_result blocks into their own messages.
@@ -305,6 +321,12 @@ func flattenMessage(m providers.Message) []wireMessage {
 type chunkDelta struct {
 	Content   string             `json:"content"`
 	ToolCalls []chunkToolCallDel `json:"tool_calls"`
+	// ReasoningContent streams alongside Content for thinking-mode
+	// models (DeepSeek V4 Pro, deepseek-reasoner). The deltas
+	// concatenate into the per-turn reasoning trace, which the
+	// driver surfaces on EventDone.Reasoning so the loop can echo
+	// it back on the next iteration.
+	ReasoningContent string `json:"reasoning_content"`
 }
 
 type chunkToolCallDel struct {
@@ -378,6 +400,15 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	// some OpenAI-compatible servers omit usage on cancelled
 	// streams).
 	var model string
+	// reasoningBuf accumulates `delta.reasoning_content` chunks for
+	// thinking-mode models (DeepSeek V4 Pro / deepseek-reasoner).
+	// Surfaced on EventDone.Reasoning so the loop can stamp it onto
+	// the assistant Message it appends to the conversation history.
+	// The next iteration's request body then echoes it back via
+	// wireMessage.ReasoningContent — DeepSeek's API requires this or
+	// it 400s with "reasoning_content in the thinking mode must be
+	// passed back". Empty for non-thinking models.
+	var reasoningBuf strings.Builder
 
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -398,6 +429,14 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 
 		for _, ch := range c.Choices {
+			if ch.Delta.ReasoningContent != "" {
+				// Internal accumulator only — reasoning isn't an
+				// EventText event today (would surface as model
+				// "speech" to adapters that just stream text). Kept
+				// inside the driver until the v0.7.x EventThinking
+				// follow-up exposes it as a typed event.
+				reasoningBuf.WriteString(ch.Delta.ReasoningContent)
+			}
 			if ch.Delta.Content != "" {
 				if !send(providers.Event{Type: providers.EventText, Text: ch.Delta.Content}) {
 					return
@@ -468,7 +507,12 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 	}
 
-	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
+	send(providers.Event{
+		Type:       providers.EventDone,
+		StopReason: stopReason,
+		Usage:      usage,
+		Reasoning:  reasoningBuf.String(),
+	})
 }
 
 // mapStopReason translates OpenAI's finish_reason vocabulary into our shared

--- a/internal/providers/openai/reasoning_test.go
+++ b/internal/providers/openai/reasoning_test.go
@@ -1,0 +1,126 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Three tests pin the reasoning_content roundtrip — the contract
+// DeepSeek V4 Pro / deepseek-reasoner enforces with a 400:
+//
+//   "The `reasoning_content` in the thinking mode must be passed
+//    back to the API."
+//
+// Capture: streaming reasoning_content deltas accumulate into
+// EventDone.Reasoning.
+// Replay: an assistant Message carrying Reasoning emits the
+// `reasoning_content` field on the next request body.
+// No-thinking: vanilla streams without reasoning_content stay clean
+// (the field is omitted from EventDone and from the wire body).
+
+func TestReasoning_CaptureAccumulatesAcrossDeltas(t *testing.T) {
+	// Mimics DeepSeek V4 Pro: reasoning_content streams in chunks
+	// alongside content. The driver should accumulate both into
+	// the per-iteration buffers — content into EventText events,
+	// reasoning into the internal accumulator surfaced on
+	// EventDone.Reasoning.
+	frames := []string{
+		`data: {"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"reasoning_content":"Let me think... "}}]}` + "\n\n",
+		`data: {"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"reasoning_content":"the answer is 42."}}]}` + "\n\n",
+		`data: {"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{"content":"42"}}]}` + "\n\n",
+		`data: {"model":"deepseek-v4-pro","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		`data: {"model":"deepseek-v4-pro","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5}}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "deepseek-v4-pro",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var done providers.Event
+	for ev := range ch {
+		if ev.Type == providers.EventDone {
+			done = ev
+		}
+	}
+	want := "Let me think... the answer is 42."
+	if done.Reasoning != want {
+		t.Errorf("EventDone.Reasoning = %q, want %q", done.Reasoning, want)
+	}
+}
+
+func TestReasoning_ReplayedToWireOnAssistantMessage(t *testing.T) {
+	// An assistant Message with Reasoning set should serialise the
+	// `reasoning_content` field in its wire form. Catches the
+	// regression where the buildRequestBody helper drops the field
+	// — exactly the bug that 400'd against DeepSeek in production.
+	body, err := buildRequestBody(providers.Request{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+			{
+				Role:      "assistant",
+				Content:   []providers.ContentBlock{{Type: "text", Text: "42"}},
+				Reasoning: "Let me think... the answer is 42.",
+			},
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "explain"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var w struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	// messages[0] = user, messages[1] = assistant, messages[2] = user
+	asst := w.Messages[1]
+	if asst["role"] != "assistant" {
+		t.Fatalf("messages[1].role = %v, want assistant", asst["role"])
+	}
+	got, ok := asst["reasoning_content"].(string)
+	if !ok {
+		t.Fatalf("messages[1].reasoning_content missing or wrong type, body: %s", body)
+	}
+	if got != "Let me think... the answer is 42." {
+		t.Errorf("reasoning_content = %q, want %q", got, "Let me think... the answer is 42.")
+	}
+}
+
+func TestReasoning_OmittedWhenAssistantHasNoReasoning(t *testing.T) {
+	// Non-thinking models never set Reasoning on their assistant
+	// turns. The wire body must omit reasoning_content entirely
+	// (omitempty) — a present empty-string field would still be
+	// echoed, and some strict OpenAI-compatible endpoints might
+	// reject the unknown empty field.
+	body, err := buildRequestBody(providers.Request{
+		Model: "gpt-5.4",
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+			{Role: "assistant", Content: []providers.ContentBlock{{Type: "text", Text: "hello"}}},
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "again"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var w struct {
+		Messages []map[string]any `json:"messages"`
+	}
+	_ = json.Unmarshal(body, &w)
+	asst := w.Messages[1]
+	if _, has := asst["reasoning_content"]; has {
+		t.Errorf("assistant message without Reasoning should omit reasoning_content from wire, got %v", asst["reasoning_content"])
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -115,6 +115,19 @@ type Request struct {
 type Message struct {
 	Role    string         `json:"role"` // "user" | "assistant"
 	Content []ContentBlock `json:"content"`
+
+	// Reasoning carries the assistant turn's reasoning trace when the
+	// provider's model emits one. DeepSeek V4 Pro and the deepseek-
+	// reasoner family return `reasoning_content` alongside `content`
+	// when thinking mode is on; the API requires that string to be
+	// echoed back on subsequent turns or the next request 400s with
+	// "reasoning_content in the thinking mode must be passed back."
+	//
+	// Empty for non-thinking models / non-DeepSeek providers; the
+	// `omitempty` keeps it out of the wire body for everyone else
+	// (vanilla OpenAI ignores unknown fields anyway, but no point
+	// sending bytes that mean nothing).
+	Reasoning string `json:"reasoning_content,omitempty"`
 }
 
 // ContentBlock is one piece of message content. Type discriminates the union.
@@ -181,6 +194,15 @@ type Event struct {
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
 	StopReason string `json:"stop_reason,omitempty"`
+
+	// Reasoning carries the assistant turn's accumulated reasoning
+	// trace (DeepSeek V4 Pro / deepseek-reasoner). Set on EventDone
+	// when the response stream included `reasoning_content` deltas.
+	// The loop reads this and stamps it onto the assistant Message
+	// it appends to the conversation history so the next iteration
+	// echoes it back to the API per DeepSeek's contract. Empty for
+	// non-thinking models.
+	Reasoning string `json:"reasoning,omitempty"`
 }
 
 // RetryInfo accompanies an EventRetry. Each field is set every time.


### PR DESCRIPTION
## Summary

DeepSeek V4 Pro / deepseek-reasoner emit \`reasoning_content\` in their assistant response when thinking mode is on. DeepSeek's API requires that field to be **echoed back** on subsequent turns, or the next request 400s with:

> The \`reasoning_content\` in the thinking mode must be passed back to the API.

The OpenAI driver (which the DeepSeek wrapper delegates to) was capturing \`content\` and \`tool_calls\` in conversation history but dropping \`reasoning_content\`. Multi-iteration agents (anything with tools) hitting DeepSeek V4 Pro therefore failed on the second iteration.

Empirical surface from production: a tier:middle agent (qa-agent in the operator's case) resolved to deepseek-v4-pro, made one tool call, then 400'd on the iteration-2 request.

## Fix

Five-touch surgical fix:

| File | Change |
|---|---|
| \`internal/providers/provider.go\` | \`Message\` gains \`Reasoning string\` (json: \`reasoning_content,omitempty\`). \`Event\` gains \`Reasoning\` on \`EventDone\`. Both carry the per-turn reasoning trace through the loop. |
| \`internal/providers/openai/driver.go\` | \`chunkDelta.ReasoningContent\` to capture deltas; \`streamEvents\` accumulates into a buffer surfaced on \`EventDone.Reasoning\`; \`flattenMessage\` wires \`Message.Reasoning\` to wire \`reasoning_content\` on assistant turns. |
| \`internal/loop/loop.go\` | Loop captures \`EventDone.Reasoning\`, stamps it onto the assistant Message appended to \`messages[]\` for the next iteration's request. |
| \`internal/api/http/server.go\` (replayTranscript) | Continuation path: extracts \`Reasoning\` from persisted \`done\` events so resumed sessions also echo \`reasoning_content\` correctly. |
| \`internal/providers/openai/reasoning_test.go\` (new) | 3 tests pin the contract: multi-delta capture, wire replay, omitempty correctness for non-thinking models. |

## Backward compat

- **Non-thinking models** (gpt-5.4-mini, deepseek-v4-flash, every Anthropic model): never set \`Reasoning\` on the wire. \`omitempty\` on both struct tags keeps the field off the wire body for those paths.
- **Vanilla OpenAI**: ignores unknown fields. If a future OpenAI o-series model uses the same \`reasoning_content\` shape (likely), this code already handles it.
- **Anthropic**: uses a different thinking-block shape (signed blocks, separate content type). This change doesn't touch that path; an Anthropic equivalent is a future PR if needed.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` clean (35 packages)
- [x] 3 new reasoning round-trip tests pass — capture, replay, omitempty
- [ ] **Operator manual verification:**
  1. Restart loomcycle with this binary.
  2. Trigger qa-agent (or any tier:middle agent that lands on deepseek-v4-pro and uses at least one tool call).
  3. Confirm the request completes without the \`reasoning_content must be passed back\` 400.

## Out of scope

- **\`EventThinking\` event type** to surface reasoning to adapters (the \"output side\" of the v0.7.x roadmap entry). This PR keeps reasoning internal to the driver/loop/transcript — adapters don't see it. A separate PR can elevate the field to a typed event for chain-of-thought-aware UIs.
- **Anthropic thinking-block preservation.** Anthropic's API tolerates dropped thinking blocks (it doesn't 400 like DeepSeek does), so the priority gap was only on DeepSeek. Worth a follow-up to symmetrize.
- **DeepSeek wrapper error attribution.** Today errors from the inner OpenAI driver surface as \"openai 400\" even when the resolved provider is DeepSeek — small UX issue, fix in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)