### PR TITLE
fix(ollama): synthesize EventToolCall when qwen3 emits payload as text

### DIFF
--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -114,7 +114,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out)
+	go streamEvents(ctx, resp.Body, out, len(req.Tools) > 0)
 	return out, nil
 }
 
@@ -294,7 +294,7 @@ type chunkToolCallFn struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, wantTools bool) {
 	defer body.Close()
 	defer close(out)
 
@@ -314,6 +314,7 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
 
 	var stopReason string
+	var rawDoneReason string // pre-mapStopReason; needed if we re-evaluate after recovery
 	var usage *providers.Usage
 	var model string
 	// hadToolCalls tracks whether *any* frame emitted tool_calls. Ollama may
@@ -321,6 +322,12 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	// frame with an empty tool_calls array. We must remember the earlier
 	// emission so the loop iterates instead of breaking on "end_turn".
 	var hadToolCalls bool
+	// textBuf accumulates message.content across the stream. Used only by
+	// the post-stream qwen3 tool-call-as-text recovery path (gated on
+	// wantTools && !hadToolCalls). Non-tool flows still stream text live;
+	// this buffer just mirrors what was streamed so we can re-parse it
+	// at end-of-stream without buffering the user's view of progress.
+	var textBuf strings.Builder
 
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
@@ -336,6 +343,7 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 
 		if c.Message.Content != "" {
+			textBuf.WriteString(c.Message.Content)
 			if !send(providers.Event{Type: providers.EventText, Text: c.Message.Content}) {
 				return
 			}
@@ -359,6 +367,7 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 
 		if c.Done {
+			rawDoneReason = c.DoneReason
 			stopReason = mapStopReason(c.DoneReason, hadToolCalls)
 			if c.PromptEvalCount > 0 || c.EvalCount > 0 {
 				usage = &providers.Usage{
@@ -374,7 +383,117 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		return
 	}
 
+	// qwen3 tool-call-as-text recovery. Empirically, qwen3:14b (and
+	// related Ollama-served reasoning models) sometimes lose tool-call
+	// discipline across iterations: the first iteration uses the
+	// structured `tool_calls` envelope correctly, but subsequent
+	// iterations emit the next tool call as `content` text — a JSON
+	// payload like `{"name":"foo","arguments":{...}}`. The loop then
+	// terminates with the JSON-as-text as the final assistant turn,
+	// the consumer sees a tool-call JSON dump where it expected an
+	// answer, and the run completes with garbage output.
+	//
+	// When this happens (wantTools=true, no structured tool_calls
+	// arrived, and the buffered text content parses cleanly as one
+	// or more tool-call objects), we synthesise EventToolCall events
+	// at the tail of the stream. The loop's history record retains
+	// the original streamed text (so the transcript's audit trail is
+	// honest about what the model emitted), but the synthesised tool
+	// calls let the loop iterate instead of terminating. The next
+	// iteration typically produces a clean answer.
+	//
+	// Recovery is gated on wantTools=true so non-tool flows that
+	// happen to emit JSON-shaped text (e.g. an agent whose final
+	// answer IS a JSON object — ats-filter, injection-judge) don't
+	// get false-positive tool calls synthesised.
+	if wantTools && !hadToolCalls && textBuf.Len() > 0 {
+		if recovered := tryParseToolCallsFromText(textBuf.String()); len(recovered) > 0 {
+			for _, tu := range recovered {
+				if !send(providers.Event{Type: providers.EventToolCall, ToolUse: tu}) {
+					return
+				}
+			}
+			hadToolCalls = true
+			// Recompute stopReason now that we have tool calls. Ollama's
+			// own done_reason was "stop" (the model thought it was
+			// finished); we know better.
+			stopReason = mapStopReason(rawDoneReason, true)
+		}
+	}
+
 	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
+}
+
+// tryParseToolCallsFromText attempts to parse the raw text content as
+// one or more Ollama-shaped tool-call objects:
+//
+//	{"name":"...","arguments":{...}}
+//
+// or an array of such objects. Returns the parsed ToolUse list when
+// successful, nil otherwise. Tolerates surrounding whitespace + a
+// markdown ```json fence (qwen3 sometimes wraps its output).
+//
+// A clean-parse contract — strict matching prevents false positives
+// from text that happens to look JSON-ish (e.g. an agent whose answer
+// includes a tool-call example in prose). We require the ENTIRE
+// trimmed content to deserialise into the tool-call shape; any prose
+// outside the JSON disqualifies the recovery.
+func tryParseToolCallsFromText(text string) []*providers.ToolUse {
+	s := strings.TrimSpace(text)
+	if s == "" {
+		return nil
+	}
+	// Strip a single markdown fence pair if present. qwen3's chat
+	// template sometimes wraps tool-call output in ```json ... ```.
+	if strings.HasPrefix(s, "```") {
+		// Drop the opening fence (may be ``` or ```json or ```\n).
+		if nl := strings.IndexByte(s, '\n'); nl >= 0 {
+			s = s[nl+1:]
+		} else {
+			s = strings.TrimPrefix(s, "```")
+		}
+		s = strings.TrimSuffix(strings.TrimSpace(s), "```")
+		s = strings.TrimSpace(s)
+	}
+
+	type rawCall struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+
+	// Try array first — qwen3 occasionally batches multiple calls.
+	if strings.HasPrefix(s, "[") {
+		var arr []rawCall
+		if err := json.Unmarshal([]byte(s), &arr); err == nil && len(arr) > 0 {
+			out := make([]*providers.ToolUse, 0, len(arr))
+			for _, r := range arr {
+				if r.Name == "" {
+					return nil // any malformed entry → bail; treat as prose
+				}
+				args := r.Arguments
+				if len(args) == 0 {
+					args = json.RawMessage("{}")
+				}
+				out = append(out, &providers.ToolUse{Name: r.Name, Input: args})
+			}
+			return out
+		}
+		return nil
+	}
+
+	// Try single object.
+	var r rawCall
+	if err := json.Unmarshal([]byte(s), &r); err != nil {
+		return nil
+	}
+	if r.Name == "" {
+		return nil
+	}
+	args := r.Arguments
+	if len(args) == 0 {
+		args = json.RawMessage("{}")
+	}
+	return []*providers.ToolUse{{Name: r.Name, Input: args}}
 }
 
 // mapStopReason translates Ollama's done_reason into our shared vocabulary.

--- a/internal/providers/ollama/tool_text_recovery_test.go
+++ b/internal/providers/ollama/tool_text_recovery_test.go
@@ -1,0 +1,276 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Five tests pin the qwen3 tool-call-as-text recovery contract:
+//
+//   (a) text is exact tool-call JSON + req.Tools set + no structured
+//       envelope → synthesised EventToolCall, original text events
+//       still emitted (transcript fidelity).
+//   (b) plain prose answer → no synthesis (don't false-positive).
+//   (c) JSON-ish text but doesn't match tool-call shape → no synthesis.
+//   (d) structured tool_call already emitted → no synthesis (don't
+//       double-emit even if text content also looks parseable).
+//   (e) req.Tools empty → recovery disabled (an agent whose final
+//       answer IS a JSON object — ats-filter, injection-judge —
+//       must not accidentally trip the recovery).
+
+func TestToolTextRecovery_SynthesizesCallFromText(t *testing.T) {
+	// qwen3's classic regression: emits a structured tool call on
+	// iter 1 (off-screen for this test), then in iter 2 writes the
+	// next call as content text. The driver should detect and
+	// synthesise EventToolCall so the loop iterates instead of
+	// terminating with the JSON dump as the final answer.
+	frames := []string{
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"{\"name\": \"mcp__jobs__getApplication\", \"arguments\": {\"id\": \"app-abc\"}}"},"done":false}` + "\n",
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":1000,"eval_count":50}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model: "qwen3:14b",
+		Tools: []providers.ToolSpec{{Name: "mcp__jobs__getApplication", InputSchema: json.RawMessage(`{}`)}},
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "look up app-abc"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var sawText, sawSynthCall bool
+	var done providers.Event
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventText:
+			sawText = true
+		case providers.EventToolCall:
+			sawSynthCall = true
+			if ev.ToolUse == nil || ev.ToolUse.Name != "mcp__jobs__getApplication" {
+				t.Errorf("synthesised tool_call = %+v, want name=mcp__jobs__getApplication", ev.ToolUse)
+			}
+			var args map[string]any
+			_ = json.Unmarshal(ev.ToolUse.Input, &args)
+			if args["id"] != "app-abc" {
+				t.Errorf("synthesised arguments = %v, want id=app-abc", args)
+			}
+		case providers.EventDone:
+			done = ev
+		}
+	}
+	if !sawText {
+		t.Error("expected text events to still emit (transcript fidelity)")
+	}
+	if !sawSynthCall {
+		t.Fatal("expected synthesised EventToolCall — qwen3 recovery didn't fire")
+	}
+	// stopReason should be remapped to tool_use (was 'stop' on the wire
+	// because qwen3 thought it was done; recovery knows otherwise).
+	if done.StopReason != "tool_use" {
+		t.Errorf("done.StopReason = %q, want tool_use (recovery should remap)", done.StopReason)
+	}
+}
+
+func TestToolTextRecovery_SynthesizesArrayOfCalls(t *testing.T) {
+	// qwen3 occasionally batches multiple calls into a single text
+	// block as a JSON array. Recovery should handle the array form.
+	frames := []string{
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"[{\"name\": \"a\", \"arguments\": {\"x\": 1}}, {\"name\": \"b\", \"arguments\": {\"y\": 2}}]"},"done":true,"done_reason":"stop"}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3:14b",
+		Tools:    []providers.ToolSpec{{Name: "a"}, {Name: "b"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	var calls []string
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall && ev.ToolUse != nil {
+			calls = append(calls, ev.ToolUse.Name)
+		}
+	}
+	if len(calls) != 2 || calls[0] != "a" || calls[1] != "b" {
+		t.Errorf("synthesised calls = %v, want [a b]", calls)
+	}
+}
+
+func TestToolTextRecovery_StripsMarkdownFence(t *testing.T) {
+	// qwen3's chat template sometimes wraps the tool-call JSON in a
+	// ```json ... ``` markdown fence. Recovery should strip and
+	// parse cleanly.
+	frames := []string{
+		"{\"model\":\"qwen3:14b\",\"message\":{\"role\":\"assistant\",\"content\":\"```json\\n{\\\"name\\\": \\\"foo\\\", \\\"arguments\\\": {}}\\n```\"},\"done\":true,\"done_reason\":\"stop\"}\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3:14b",
+		Tools:    []providers.ToolSpec{{Name: "foo"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	var sawSynth bool
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall && ev.ToolUse != nil && ev.ToolUse.Name == "foo" {
+			sawSynth = true
+		}
+	}
+	if !sawSynth {
+		t.Error("expected recovery to strip markdown fence and parse the inner JSON")
+	}
+}
+
+func TestToolTextRecovery_DoesNotFalsePositiveOnProse(t *testing.T) {
+	// Plain prose answer must NOT trigger the recovery — agents
+	// without tools (or with structured-JSON-output that's NOT a
+	// tool-call shape) should pass through cleanly.
+	frames := []string{
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"Here is your answer: 42."},"done":true,"done_reason":"stop"}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3:14b",
+		Tools:    []providers.ToolSpec{{Name: "foo"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	var sawSynth bool
+	var done providers.Event
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			sawSynth = true
+		}
+		if ev.Type == providers.EventDone {
+			done = ev
+		}
+	}
+	if sawSynth {
+		t.Error("recovery false-positived on plain prose")
+	}
+	// stopReason should remain "end_turn" (no recovery → no remap).
+	if done.StopReason != "end_turn" {
+		t.Errorf("done.StopReason = %q, want end_turn", done.StopReason)
+	}
+}
+
+func TestToolTextRecovery_NoSynthWhenStructuredCallAlreadyEmitted(t *testing.T) {
+	// qwen3 emits BOTH a structured envelope AND text content (the
+	// tool_call as text alongside the proper one). Don't double-emit.
+	// Recovery is gated on !hadToolCalls.
+	frames := []string{
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"","tool_calls":[{"function":{"name":"foo","arguments":{}}}]},"done":false}` + "\n",
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"{\"name\": \"foo\", \"arguments\": {}}"},"done":true,"done_reason":"stop"}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3:14b",
+		Tools:    []providers.ToolSpec{{Name: "foo"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	var toolCallCount int
+	for ev := range ch {
+		if ev.Type == providers.EventToolCall {
+			toolCallCount++
+		}
+	}
+	if toolCallCount != 1 {
+		t.Errorf("EventToolCall count = %d, want 1 (no double-emit)", toolCallCount)
+	}
+}
+
+func TestToolTextRecovery_DisabledWhenNoToolsRequested(t *testing.T) {
+	// req.Tools empty → wantTools=false → recovery disabled. An
+	// agent whose final answer IS a JSON tool-call-shaped object
+	// (vanishingly rare but possible) must not have its answer
+	// hijacked into a synthesised tool call.
+	frames := []string{
+		`{"model":"qwen3:14b","message":{"role":"assistant","content":"{\"name\": \"foo\", \"arguments\": {}}"},"done":true,"done_reason":"stop"}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New(srv.URL, nil)
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3:14b",
+		// Tools intentionally empty — recovery must NOT fire.
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	var text strings.Builder
+	var sawSynth bool
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			text.WriteString(ev.Text)
+		}
+		if ev.Type == providers.EventToolCall {
+			sawSynth = true
+		}
+	}
+	if sawSynth {
+		t.Error("recovery fired on no-tools request — must be disabled")
+	}
+	if !strings.Contains(text.String(), `"name": "foo"`) {
+		t.Errorf("text passthrough corrupted: %q", text.String())
+	}
+}
+
+// ---- Pure-function tests for the parser (no streaming infra) ----
+
+func TestTryParseToolCallsFromText_BareObject(t *testing.T) {
+	calls := tryParseToolCallsFromText(`{"name":"foo","arguments":{"x":1}}`)
+	if len(calls) != 1 || calls[0].Name != "foo" {
+		t.Errorf("parse = %+v, want one call name=foo", calls)
+	}
+}
+
+func TestTryParseToolCallsFromText_RejectsMissingName(t *testing.T) {
+	if got := tryParseToolCallsFromText(`{"arguments":{}}`); got != nil {
+		t.Errorf("parse = %v, want nil (no name field)", got)
+	}
+}
+
+func TestTryParseToolCallsFromText_RejectsArbitraryJSON(t *testing.T) {
+	// JSON that's not a tool-call shape must not parse — agents that
+	// emit structured-but-different JSON (verdicts, scores, etc.)
+	// shouldn't trip the recovery.
+	if got := tryParseToolCallsFromText(`{"verdict":"keep","score":0.8}`); got != nil {
+		t.Errorf("parse = %v, want nil (not a tool-call shape)", got)
+	}
+}
+
+func TestTryParseToolCallsFromText_RejectsTrailingProse(t *testing.T) {
+	// We require the ENTIRE trimmed content to deserialise. A
+	// tool-call JSON followed by a sentence of prose is ambiguous —
+	// don't recover.
+	if got := tryParseToolCallsFromText(`{"name":"foo","arguments":{}} and then I'll explain`); got != nil {
+		t.Errorf("parse = %v, want nil (trailing prose disqualifies)", got)
+	}
+}
+
+func TestTryParseToolCallsFromText_DefaultsEmptyArguments(t *testing.T) {
+	// Missing arguments field → default to {} so the loop doesn't
+	// fail to dispatch the tool. Same default the live path uses.
+	calls := tryParseToolCallsFromText(`{"name":"foo"}`)
+	if len(calls) != 1 {
+		t.Fatalf("parse = %+v, want one call", calls)
+	}
+	if string(calls[0].Input) != "{}" {
+		t.Errorf("default arguments = %q, want {}", string(calls[0].Input))
+	}
+}


### PR DESCRIPTION
## Summary

Closes the qwen3 tool-call-as-text gap: when an Ollama-served reasoning model loses tool-call discipline mid-conversation and emits the next call as plain text content instead of via the structured \`tool_calls\` envelope, the driver now detects the pattern at end-of-stream and synthesises an \`EventToolCall\` so the loop iterates instead of terminating with a JSON dump as the final answer.

## Empirical surface

Operator's deployed qa-agent on \`qwen3:14b\` (transcript run \`r_82f64e958b0721cd\`):

\`\`\`
events: 1 user_input + 79 text + 1 tool_call + 1 tool_result + 1 done(end_turn)
text concat: {\"name\":\"mcp__jobs__getApplication\",\"arguments\":{\"id\":\"app-...\"}}
\`\`\`

qwen3 used the proper envelope on iteration 1 (the lone \`tool_call\` event), then in iteration 2 streamed a JSON tool-call payload as 79 chunks of \`message.content\`. The Ollama driver passed those through as \`EventText\`, the loop saw text-only iteration, terminated with \`end_turn\`, and the consumer's qa-answers parser got the JSON dump where it expected a structured QA payload.

## Fix

Two-touch driver change + 11 tests.

### \`internal/providers/ollama/driver.go\`

- \`streamEvents\` gains a \`wantTools bool\` parameter (\`len(req.Tools) > 0\`).
- During streaming, \`message.content\` is mirrored into a \`textBuf\` alongside the live \`EventText\` emission — live streaming behaviour is unchanged for both tool and non-tool flows.
- At end-of-stream: if \`wantTools=true\` AND no structured envelope arrived AND the buffered text parses cleanly as a tool-call JSON object (or array), the driver synthesises \`EventToolCall\` events and remaps \`stopReason\` from \`end_turn\` → \`tool_use\` so the loop iterates.
- \`tryParseToolCallsFromText\` handles:
  - bare object: \`{\"name\":\"...\",\"arguments\":{...}}\`
  - array form: qwen3 occasionally batches multiple calls
  - \`\`\`\`json ... \`\`\`\` markdown fences (qwen3's chat template wraps sometimes)
  - missing \`arguments\` field → defaults to \`{}\`
- Strict matching: the ENTIRE trimmed content must deserialise into the tool-call shape. Trailing prose disqualifies. Recovery is gated on \`wantTools=true\` so agents whose final answer IS a JSON object (\`injection-judge\`, structured verdicts) can't false-positive.

## Test plan

- [x] \`go test ./...\` clean (35 packages); \`go vet\` clean
- [x] **6 streaming integration tests** via httptest fakes:
  - synthesis from text-shaped tool call (the qwen3 regression)
  - array form
  - markdown fence stripping
  - prose passthrough (no false-positive)
  - structured-already-emitted (no double-emit)
  - no-tools-requested (recovery disabled)
- [x] **5 parser unit tests** for \`tryParseToolCallsFromText\`: bare object, missing name (reject), arbitrary non-tool JSON (reject), trailing prose (reject), default arguments
- [ ] **Operator manual verification**:
  1. Rebuild loomcycle from this branch.
  2. Re-run the qa-agent flow that previously emitted a JSON tool-call dump as the final answer.
  3. Confirm the loop now iterates on the synthesised call, the next iteration produces a clean structured answer, and the user's UI renders correctly.

## Wire / transcript compat

- Live streaming behaviour unchanged for non-tool flows (\`wantTools=false\` → recovery branch never executes).
- Tool flows still stream text live as before; \`textBuf\` accumulation is in-memory only.
- Transcript records both the original streamed text AND the synthesised tool calls — honest audit trail of what the model emitted, while the loop recovers the right behaviour.
- The loop's existing tool-dispatch path handles synthesised \`EventToolCall\` events identically to envelope-derived ones; ID synthesis (\`lc-{iter}-{slot}\`) was already in place for Ollama.

## Out of scope

- The separate \`message.thinking\` gap (qwen3 reasoning-content surfaced via Ollama's structured thinking field) — that's a different symptom on the **output** side and stays in the v0.7.x roadmap as the \`EventThinking\` follow-up.
- Per-driver effort translation for Ollama (added in v0.7.0 PR #23 with \`SupportsEffort=false\`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)