### PR TITLE
fix(openai): coalesce per-token text deltas into 64-byte EventText chunks

### DIFF
--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -505,6 +505,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		// Flush any buffered text before the error event so bytes the
+		// wire delivered aren't silently dropped just because the read
+		// failed mid-stream. Best-effort: a send failure here is fine
+		// (the error event still surfaces the failure to the caller).
+		_ = flushText()
 		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
 		return
 	}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -410,6 +410,32 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	// passed back". Empty for non-thinking models.
 	var reasoningBuf strings.Builder
 
+	// textBuf coalesces consecutive `delta.content` chunks into
+	// reasonable-sized EventText emissions. OpenAI-compatible endpoints
+	// (especially DeepSeek) often stream one token per delta — every
+	// delta becomes an EventText becomes a render line on log-based
+	// consumers, producing the "every word on its own line" visual
+	// noise reported in the field. Anthropic's wire is naturally chunked
+	// at multi-token granularity; this brings the OpenAI path closer to
+	// that shape without adding a timer goroutine.
+	//
+	// Flush points: textCoalesceMin reached, the new chunk contains a
+	// newline (preserve formatting boundaries), end-of-stream (before
+	// tool_call emissions and EventDone). The threshold is small enough
+	// that a streaming UI still feels live (~64-char chunks ≈ a phrase
+	// per render frame); larger reduces event count more but degrades
+	// typewriter feel.
+	var textBuf strings.Builder
+	const textCoalesceMin = 64
+	flushText := func() bool {
+		if textBuf.Len() == 0 {
+			return true
+		}
+		s := textBuf.String()
+		textBuf.Reset()
+		return send(providers.Event{Type: providers.EventText, Text: s})
+	}
+
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 || !bytes.HasPrefix(line, []byte("data:")) {
@@ -438,8 +464,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 				reasoningBuf.WriteString(ch.Delta.ReasoningContent)
 			}
 			if ch.Delta.Content != "" {
-				if !send(providers.Event{Type: providers.EventText, Text: ch.Delta.Content}) {
-					return
+				textBuf.WriteString(ch.Delta.Content)
+				if textBuf.Len() >= textCoalesceMin || strings.ContainsRune(ch.Delta.Content, '\n') {
+					if !flushText() {
+						return
+					}
 				}
 			}
 			for _, tc := range ch.Delta.ToolCalls {
@@ -477,6 +506,13 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	}
 	if err := scanner.Err(); err != nil {
 		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
+		return
+	}
+
+	// Flush any text still buffered by the coalescer before tool_call /
+	// done events — preserves "text precedes tool_call" ordering and
+	// guarantees no text is dropped on stream end.
+	if !flushText() {
 		return
 	}
 

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -35,6 +35,184 @@ func fakeStream(t *testing.T, frames []string) *httptest.Server {
 	}))
 }
 
+// TestStreamTextCoalescing pins the per-delta coalescing behaviour for
+// OpenAI-compatible streams. DeepSeek (and OpenAI's gpt-5.x family)
+// often stream one token per delta; without coalescing every token
+// becomes one EventText, which line-prefix-logging consumers render as
+// one word per line. Regression vehicle for a 2026-05-09 user report
+// from a jobs-search-agent run on `deepseek-v4-pro`.
+//
+// Contract:
+//
+//   1. Many small (sub-threshold) text deltas are batched into fewer
+//      EventText emissions. Threshold is 64 bytes today.
+//   2. A delta containing '\n' flushes immediately so formatting
+//      boundaries survive coalescing.
+//   3. End-of-stream flushes any residual buffer (no dropped text).
+//   4. The concatenation of all EventText.Text values is byte-identical
+//      to the concatenation of the wire deltas — coalescing is purely
+//      a packing change, never a transformation.
+func TestStreamTextCoalescing_BatchesPerTokenDeltas(t *testing.T) {
+	// 32 single-token deltas of 3-4 bytes each (~96-128 wire bytes).
+	// Pre-fix this produces 32 EventText events; post-fix it produces
+	// at most a handful (each batch ≥ 64 bytes).
+	tokens := []string{
+		"The", " quick", " brown", " fox", " jumps",
+		" over", " the", " lazy", " dog", " near",
+		" the", " river", " where", " moss", " grows",
+		" thick", " on", " smooth", " stones", " in",
+		" the", " shallows", " and", " trout", " dart",
+		" between", " sunlight", " and", " shadow", " through",
+		" the", " current",
+	}
+	var frames []string
+	for _, tok := range tokens {
+		frames = append(frames, `data: {"choices":[{"index":0,"delta":{"content":`+jsonString(tok)+`}}]}`+"\n\n")
+	}
+	frames = append(frames,
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`+"\n\n",
+		"data: [DONE]\n\n",
+	)
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "gpt-5.4-mini",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var got strings.Builder
+	var textEvents int
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			textEvents++
+			got.WriteString(ev.Text)
+		}
+	}
+
+	// Concatenation must round-trip byte-identically.
+	want := strings.Join(tokens, "")
+	if got.String() != want {
+		t.Errorf("text round-trip = %q, want %q", got.String(), want)
+	}
+	// Coalescing target: ≤ 32 / 8 = 4× fewer events than the per-delta
+	// emission would produce. Loose bound to leave room for the natural
+	// 64-byte threshold and for the trailing partial-buffer flush.
+	if textEvents > len(tokens)/4 {
+		t.Errorf("emitted %d EventText, want fewer (~%d) — coalescing did not engage",
+			textEvents, len(tokens)/4)
+	}
+	if textEvents == 0 {
+		t.Fatal("no EventText emitted; final flush dropped the residual buffer")
+	}
+}
+
+func TestStreamTextCoalescing_FlushesOnNewline(t *testing.T) {
+	// A delta containing '\n' must flush the buffer immediately so a
+	// downstream consumer that renders line-by-line sees the newline at
+	// the same chunk boundary it arrived on.
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"line one"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"\n"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"line two"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "gpt-5.4-mini",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var events []string
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			events = append(events, ev.Text)
+		}
+	}
+	if len(events) < 2 {
+		t.Fatalf("expected at least two EventText emissions split on newline, got %d: %v",
+			len(events), events)
+	}
+	// First emission must end at the newline boundary (the '\n'
+	// either terminates the first event or is its own event — both
+	// satisfy the contract that the newline is a flush point).
+	first := events[0]
+	if !strings.HasSuffix(first, "\n") && events[1] != "\n" {
+		t.Errorf("first emission %q (or events[1] %q) did not flush at newline", first, events[1])
+	}
+	if got := strings.Join(events, ""); got != "line one\nline two" {
+		t.Errorf("text round-trip = %q, want %q", got, "line one\nline two")
+	}
+}
+
+func TestStreamTextCoalescing_FlushesBeforeToolCall(t *testing.T) {
+	// Buffered text must flush before the accumulated tool_call event
+	// at end-of-stream, preserving the contract "text precedes
+	// tool_call" that downstream consumers rely on.
+	frames := []string{
+		`data: {"choices":[{"index":0,"delta":{"content":"calling tool"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"foo","arguments":"{}"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
+		"data: [DONE]\n\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("test-key", srv.URL, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "gpt-5.4-mini",
+		Tools:    []providers.ToolSpec{{Name: "foo"}},
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var seen []providers.EventType
+	var text strings.Builder
+	for ev := range ch {
+		seen = append(seen, ev.Type)
+		if ev.Type == providers.EventText {
+			text.WriteString(ev.Text)
+		}
+	}
+	if text.String() != "calling tool" {
+		t.Errorf("text = %q, want %q", text.String(), "calling tool")
+	}
+	// Find positions: text must come before tool_call.
+	textIdx, toolIdx := -1, -1
+	for i, et := range seen {
+		if et == providers.EventText && textIdx < 0 {
+			textIdx = i
+		}
+		if et == providers.EventToolCall && toolIdx < 0 {
+			toolIdx = i
+		}
+	}
+	if textIdx < 0 || toolIdx < 0 {
+		t.Fatalf("missing event types: text=%d tool=%d (seen=%v)", textIdx, toolIdx, seen)
+	}
+	if textIdx >= toolIdx {
+		t.Errorf("event order = %v: text@%d before tool@%d expected", seen, textIdx, toolIdx)
+	}
+}
+
+// jsonString quotes s for use as a JSON string literal in the test
+// frame payloads. Avoids pulling encoding/json import drift into
+// frame construction loops.
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
 func TestStreamTextThenStop(t *testing.T) {
 	frames := []string{
 		`data: {"choices":[{"index":0,"delta":{"content":"hello "}}]}` + "\n\n",

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -155,12 +155,24 @@ func TestStreamTextCoalescing_FlushesOnNewline(t *testing.T) {
 }
 
 func TestStreamTextCoalescing_FlushesBeforeToolCall(t *testing.T) {
-	// Buffered text must flush before the accumulated tool_call event
-	// at end-of-stream, preserving the contract "text precedes
-	// tool_call" that downstream consumers rely on.
+	// Two text deltas straddling a tool_call delta. On the pre-fix
+	// driver each text delta emitted its own EventText the moment it
+	// parsed (mid-stream emission), giving 2 EventText events. On the
+	// post-fix driver, both deltas are below the 64-byte threshold and
+	// contain no newline, so they accumulate in textBuf; the post-loop
+	// flushText() before tool_call emission produces a single
+	// EventText carrying the concatenated body.
+	//
+	// The discriminator is the EventText count, NOT the ordering —
+	// ordering is satisfied either way because tool_calls only emit
+	// at end-of-stream. The count proves the coalescer engaged. A
+	// regression that drops the post-loop flushText() (or one that
+	// reverts mid-stream emission for short deltas) would push the
+	// count back to 2 and trip this test.
 	frames := []string{
-		`data: {"choices":[{"index":0,"delta":{"content":"calling tool"}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"calling "}}]}` + "\n\n",
 		`data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"foo","arguments":"{}"}}]}}]}` + "\n\n",
+		`data: {"choices":[{"index":0,"delta":{"content":"tool"}}]}` + "\n\n",
 		`data: {"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n",
 		"data: [DONE]\n\n",
 	}
@@ -178,16 +190,21 @@ func TestStreamTextCoalescing_FlushesBeforeToolCall(t *testing.T) {
 	}
 	var seen []providers.EventType
 	var text strings.Builder
+	textCount := 0
 	for ev := range ch {
 		seen = append(seen, ev.Type)
 		if ev.Type == providers.EventText {
+			textCount++
 			text.WriteString(ev.Text)
 		}
 	}
 	if text.String() != "calling tool" {
-		t.Errorf("text = %q, want %q", text.String(), "calling tool")
+		t.Errorf("text round-trip = %q, want %q (a delta was lost)", text.String(), "calling tool")
 	}
-	// Find positions: text must come before tool_call.
+	if textCount != 1 {
+		t.Errorf("EventText count = %d, want 1 (coalescer did not engage; mid-stream emit slipped through)", textCount)
+	}
+	// Sanity check on ordering — text must precede tool_call.
 	textIdx, toolIdx := -1, -1
 	for i, et := range seen {
 		if et == providers.EventText && textIdx < 0 {
@@ -197,11 +214,8 @@ func TestStreamTextCoalescing_FlushesBeforeToolCall(t *testing.T) {
 			toolIdx = i
 		}
 	}
-	if textIdx < 0 || toolIdx < 0 {
-		t.Fatalf("missing event types: text=%d tool=%d (seen=%v)", textIdx, toolIdx, seen)
-	}
-	if textIdx >= toolIdx {
-		t.Errorf("event order = %v: text@%d before tool@%d expected", seen, textIdx, toolIdx)
+	if textIdx < 0 || toolIdx < 0 || textIdx >= toolIdx {
+		t.Errorf("event order = %v: text must precede tool_call", seen)
 	}
 }
 

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -44,14 +44,14 @@ func fakeStream(t *testing.T, frames []string) *httptest.Server {
 //
 // Contract:
 //
-//   1. Many small (sub-threshold) text deltas are batched into fewer
-//      EventText emissions. Threshold is 64 bytes today.
-//   2. A delta containing '\n' flushes immediately so formatting
-//      boundaries survive coalescing.
-//   3. End-of-stream flushes any residual buffer (no dropped text).
-//   4. The concatenation of all EventText.Text values is byte-identical
-//      to the concatenation of the wire deltas — coalescing is purely
-//      a packing change, never a transformation.
+//  1. Many small (sub-threshold) text deltas are batched into fewer
+//     EventText emissions. Threshold is 64 bytes today.
+//  2. A delta containing '\n' flushes immediately so formatting
+//     boundaries survive coalescing.
+//  3. End-of-stream flushes any residual buffer (no dropped text).
+//  4. The concatenation of all EventText.Text values is byte-identical
+//     to the concatenation of the wire deltas — coalescing is purely
+//     a packing change, never a transformation.
 func TestStreamTextCoalescing_BatchesPerTokenDeltas(t *testing.T) {
 	// 32 single-token deltas of 3-4 bytes each (~96-128 wire bytes).
 	// Pre-fix this produces 32 EventText events; post-fix it produces


### PR DESCRIPTION
## Why

OpenAI-compatible providers — DeepSeek V4 Pro especially — stream **one token per delta**. The driver was emitting one \`EventText\` per delta verbatim. Line-prefix-logging consumers (e.g. jobs-search-agent's web app) render every event on its own line, so per-token deltas become per-token *lines*. A 2026-05-09 production run on \`deepseek-v4-pro\` produced output like:

\`\`\`
[ats-filter] {\"
[ats-filter] results
[ats-filter] \":[
[ats-filter] {\"
[ats-filter] url
\`\`\`

Anthropic's wire is naturally chunked at multi-token granularity, so its consumers don't see this. This brings the OpenAI path closer to that shape without adding a timer goroutine.

## What

A small \`strings.Builder\` in \`streamEvents\` accumulates \`delta.content\` chunks until any of:

- buffer reaches **64 bytes** (typewriter still feels live; ~phrase per render frame),
- the new chunk contains \`\\n\` (preserve formatting boundaries),
- **end-of-stream** (flush before tool_call emissions and EventDone).

The change is purely a packing transformation: concatenation of all \`EventText.Text\` values is byte-identical to concatenation of the wire deltas. No transformation, no drops, ordering preserved (\"text precedes tool_call\" still holds because text flushes before the accumulated tool_call block at end-of-stream).

64 was picked empirically — smaller still produces single-word events on 3–4-letter tokens; larger degrades streaming UX for adapters that render live. Threshold lives in a named \`textCoalesceMin\` const so future tuning is one line.

## What was tested

Three new regression tests in \`driver_test.go\`:

- \`TestStreamTextCoalescing_BatchesPerTokenDeltas\` — 32 small deltas must produce ≤ 8 EventText with byte-identical concatenation.
- \`TestStreamTextCoalescing_FlushesOnNewline\` — \`\\n\` in a delta forces immediate flush at the line boundary.
- \`TestStreamTextCoalescing_FlushesBeforeToolCall\` — buffered text flushes before the accumulated tool_call event.

\`\`\`
go test ./...               # green
go test -race ./...         # green
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)