### PR TITLE
feat(sse): wire-level keepalive frames on long-lived agent streams

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -811,6 +811,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stream.start()
+	// Keep the underlying TCP/HTTP path warm during long quiet stretches
+	// (parent agent waiting on a fan-out of sub-agents, single sub-agent
+	// mid-WebFetch, etc.). Goroutine exits when r.Context() fires
+	// (handler return / client disconnect). No-op if interval == 0.
+	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)
 
 	// Announce the (possibly newly-created) session/run IDs so the caller
 	// can address continuation requests at the same session.
@@ -1072,6 +1077,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stream.start()
+	// See handleRuns for the keepalive rationale.
+	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)
 	stream.send(providers.Event{Type: "session", Text: id})
 	stream.sendRaw("agent", map[string]any{
 		"agent_id":        agentID,

--- a/internal/api/http/sse.go
+++ b/internal/api/http/sse.go
@@ -1,20 +1,29 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"sync"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
-// sse wraps an http.ResponseWriter for server-sent-events output. One sse per
-// connection. send is safe to call from the loop's goroutine — net/http
-// serializes writes to the response writer for one handler invocation.
+// sse wraps an http.ResponseWriter for server-sent-events output. One sse
+// per connection.
+//
+// Concurrency: every write to s.w goes through s.mu so the main agent-loop
+// goroutine and the optional keepalive goroutine (started by startKeepalive)
+// don't interleave bytes on the wire. net/http does NOT serialise concurrent
+// writes from multiple goroutines on a response writer — that's our job.
 type sse struct {
 	w       http.ResponseWriter
 	flusher http.Flusher
+	mu      sync.Mutex
 }
 
 // newSSE returns an sse and a boolean indicating whether the writer supports
@@ -30,12 +39,14 @@ func newSSE(w http.ResponseWriter) (*sse, bool) {
 }
 
 func (s *sse) start() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.w.Header().Set("Content-Type", "text/event-stream")
 	s.w.Header().Set("Cache-Control", "no-cache")
 	s.w.Header().Set("Connection", "keep-alive")
 	s.w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
 	s.w.WriteHeader(http.StatusOK)
-	s.flush()
+	s.flushLocked()
 }
 
 func (s *sse) send(ev providers.Event) {
@@ -52,12 +63,16 @@ func (s *sse) send(ev providers.Event) {
 			log.Printf("sse: fallback marshal failed: %v (orig: %v)", mErr, err)
 			return
 		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
 		fmt.Fprintf(s.w, "event: error\ndata: %s\n\n", fallback)
-		s.flush()
+		s.flushLocked()
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", ev.Type, payload)
-	s.flush()
+	s.flushLocked()
 }
 
 // sendRaw emits an SSE frame with a custom event name and a JSON-
@@ -76,11 +91,64 @@ func (s *sse) sendRaw(eventName string, data any) {
 		log.Printf("sse: sendRaw marshal failed for %q: %v", eventName, err)
 		return
 	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", eventName, payload)
-	s.flush()
+	s.flushLocked()
 }
 
-func (s *sse) flush() {
+// startKeepalive starts a goroutine that emits SSE comment-only frames
+// (`:keepalive\n\n`) on the configured interval until ctx fires. SSE
+// comments are required-ignored by clients per WHATWG, so they don't
+// surface as events to downstream consumers — they exist purely to
+// keep the underlying TCP/HTTP path from going idle.
+//
+// Why this matters: agent runs that fan out to sub-agents (parent +
+// company-researcher children, for example) can sit minutes between
+// real events while a child is mid-WebFetch. Networks with idle
+// connection timeouts (Tailscale, NAT routers, some reverse proxies)
+// can drop a silent stream and undici-side surfaces this as
+// `TypeError: terminated` with no diagnostic context. Periodic
+// comment frames keep bytes flowing and make this class of drops a
+// non-event.
+//
+// Safe to call once per stream after start(). No-op when the writer
+// doesn't support streaming (newSSE returned ok=false). The goroutine
+// holds no references that could outlive the request — when ctx
+// cancels (handler return, client disconnect), it exits next tick.
+func (s *sse) startKeepalive(ctx context.Context, interval time.Duration) {
+	if s.flusher == nil || interval <= 0 {
+		return
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.writeKeepalive()
+			}
+		}
+	}()
+}
+
+// writeKeepalive emits one comment-only SSE frame. Errors are
+// swallowed: a write failure means the connection is gone, in which
+// case the next real send() will surface the underlying error or the
+// handler will return on ctx done.
+func (s *sse) writeKeepalive() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, err := io.WriteString(s.w, ": keepalive\n\n"); err != nil {
+		return
+	}
+	s.flushLocked()
+}
+
+// flushLocked must be called with s.mu held.
+func (s *sse) flushLocked() {
 	if s.flusher != nil {
 		s.flusher.Flush()
 	}

--- a/internal/api/http/sse_test.go
+++ b/internal/api/http/sse_test.go
@@ -1,0 +1,173 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// captureWriter is a minimal http.ResponseWriter+Flusher for tests.
+// Tracks every write under a mutex so the keepalive goroutine and the
+// test goroutine don't race when reading the buffer.
+type captureWriter struct {
+	mu      sync.Mutex
+	hdr     http.Header
+	status  int
+	buf     bytes.Buffer
+	flushes int
+}
+
+func newCaptureWriter() *captureWriter {
+	return &captureWriter{hdr: http.Header{}}
+}
+
+func (c *captureWriter) Header() http.Header {
+	return c.hdr
+}
+func (c *captureWriter) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+func (c *captureWriter) WriteHeader(s int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.status = s
+}
+func (c *captureWriter) Flush() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.flushes++
+}
+func (c *captureWriter) Snapshot() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+func TestSSEKeepalive_EmitsCommentFramesOnIdleStream(t *testing.T) {
+	// 50 ms interval keeps the test fast but is well above the noise
+	// floor of goroutine scheduling on CI. We expect at least 2 frames
+	// over a 200 ms window.
+	w := newCaptureWriter()
+	s, ok := newSSE(w)
+	if !ok {
+		t.Fatal("captureWriter must satisfy http.Flusher")
+	}
+	s.start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.startKeepalive(ctx, 50*time.Millisecond)
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	// Give the goroutine a tick to observe ctx done and exit.
+	time.Sleep(20 * time.Millisecond)
+
+	got := w.Snapshot()
+	count := strings.Count(got, ": keepalive\n\n")
+	if count < 2 {
+		t.Errorf("keepalive frames = %d, want ≥ 2 (got payload: %q)", count, got)
+	}
+}
+
+func TestSSEKeepalive_DisabledWhenIntervalZero(t *testing.T) {
+	w := newCaptureWriter()
+	s, _ := newSSE(w)
+	s.start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s.startKeepalive(ctx, 0)
+
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+
+	if strings.Contains(w.Snapshot(), ": keepalive") {
+		t.Error("keepalive frame emitted with interval=0; should be disabled")
+	}
+}
+
+func TestSSEKeepalive_GoroutineExitsOnContextCancel(t *testing.T) {
+	// A keepalive goroutine that outlives the request would leak across
+	// streams. Verify cancelling ctx promptly stops emissions.
+	w := newCaptureWriter()
+	s, _ := newSSE(w)
+	s.start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.startKeepalive(ctx, 25*time.Millisecond)
+
+	time.Sleep(80 * time.Millisecond)
+	cancel()
+	// Wait for the goroutine to observe cancel + finish its current
+	// iteration. After this point, no new keepalive frames should append.
+	time.Sleep(50 * time.Millisecond)
+	beforeQuiet := strings.Count(w.Snapshot(), ": keepalive\n\n")
+
+	time.Sleep(120 * time.Millisecond)
+	afterQuiet := strings.Count(w.Snapshot(), ": keepalive\n\n")
+
+	if afterQuiet != beforeQuiet {
+		t.Errorf("keepalive count grew after cancel: before=%d after=%d (goroutine leaked)",
+			beforeQuiet, afterQuiet)
+	}
+}
+
+func TestSSEKeepalive_ConcurrentWritesNeverCorruptFrames(t *testing.T) {
+	// Pin the reason the sse struct now carries a mutex: with two
+	// goroutines writing to the same response writer (main agent loop
+	// + keepalive ticker), unsynchronised Fprintf calls would interleave
+	// bytes mid-frame. Run a high-rate keepalive concurrent with many
+	// real sends and verify every frame on the wire is well-formed:
+	//
+	//   - "event: <name>\ndata: <body>\n\n"  (a real event)
+	//   - ": keepalive\n\n"                  (a comment-only keepalive)
+	//
+	// Any other shape (a partial/interleaved write) fails the test.
+	w := newCaptureWriter()
+	s, _ := newSSE(w)
+	s.start()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s.startKeepalive(ctx, 1*time.Millisecond)
+
+	const sends = 500
+	for i := 0; i < sends; i++ {
+		s.send(providers.Event{Type: providers.EventText, Text: "hi"})
+	}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+
+	got := w.Snapshot()
+	// Drop the leading status-line section (start() doesn't write any
+	// SSE frame body — it just sets headers; captureWriter doesn't
+	// serialise headers to the buffer). All wire bytes are SSE frames.
+	frames := strings.Split(got, "\n\n")
+	for i, f := range frames {
+		if f == "" {
+			continue // trailing empty after the final "\n\n"
+		}
+		if strings.HasPrefix(f, ":") {
+			// comment-only keepalive frame
+			if !strings.HasPrefix(f, ": keepalive") {
+				t.Errorf("frame[%d] looks like a comment but isn't a keepalive: %q", i, f)
+			}
+			continue
+		}
+		// Real event must have an event: line then a data: line.
+		lines := strings.Split(f, "\n")
+		if len(lines) < 2 ||
+			!strings.HasPrefix(lines[0], "event:") ||
+			!strings.HasPrefix(lines[1], "data:") {
+			t.Errorf("frame[%d] malformed (interleaved write?): %q", i, f)
+		}
+	}
+}

--- a/internal/api/http/sse_test.go
+++ b/internal/api/http/sse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -49,6 +50,45 @@ func (c *captureWriter) Snapshot() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.buf.String()
+}
+
+// splittingWriter is captureWriter's evil twin: Write splits each
+// payload into byte-by-byte appends with a runtime.Gosched() between
+// every byte. Two concurrent Write calls without external
+// synchronisation will visibly interleave in the buffer — not just
+// race-detected, but observable in the wire output.
+//
+// Used by TestSSEKeepalive_ConcurrentWritesNeverCorruptFrames to
+// prove the sse.mu actually prevents interleaving without depending
+// on `-race`. The buffer access in Write is intentionally
+// unsynchronised; rely on the sse.mu in the system-under-test, not
+// on this writer, for cross-goroutine ordering.
+type splittingWriter struct {
+	hdr    http.Header
+	buf    []byte // intentionally NOT mutex-protected
+	status int
+}
+
+func newSplittingWriter() *splittingWriter {
+	return &splittingWriter{hdr: http.Header{}}
+}
+
+func (s *splittingWriter) Header() http.Header { return s.hdr }
+func (s *splittingWriter) Write(p []byte) (int, error) {
+	for _, b := range p {
+		s.buf = append(s.buf, b)
+		runtime.Gosched()
+	}
+	return len(p), nil
+}
+func (s *splittingWriter) WriteHeader(st int) { s.status = st }
+func (s *splittingWriter) Flush()              {}
+
+// SnapshotAfterQuiescing should only be called after every writer
+// goroutine has stopped (e.g. cancel + wait). Reading concurrently
+// with active Write calls would race on the unsynchronised buf.
+func (s *splittingWriter) SnapshotAfterQuiescing() string {
+	return string(s.buf)
 }
 
 func TestSSEKeepalive_EmitsCommentFramesOnIdleStream(t *testing.T) {
@@ -122,17 +162,20 @@ func TestSSEKeepalive_GoroutineExitsOnContextCancel(t *testing.T) {
 }
 
 func TestSSEKeepalive_ConcurrentWritesNeverCorruptFrames(t *testing.T) {
-	// Pin the reason the sse struct now carries a mutex: with two
+	// Pin the reason the sse struct carries a mutex: with two
 	// goroutines writing to the same response writer (main agent loop
-	// + keepalive ticker), unsynchronised Fprintf calls would interleave
-	// bytes mid-frame. Run a high-rate keepalive concurrent with many
-	// real sends and verify every frame on the wire is well-formed:
+	// + keepalive ticker), unsynchronised writes interleave bytes
+	// mid-frame. Use a writer (`splittingWriter`) that appends one
+	// byte at a time with `runtime.Gosched()` between bytes — that
+	// makes interleaving visible WITHOUT depending on `-race`. The
+	// real `http.ResponseWriter` is not thread-safe either, so this
+	// matches production conditions more closely than a mutex-guarded
+	// captureWriter.
 	//
-	//   - "event: <name>\ndata: <body>\n\n"  (a real event)
-	//   - ": keepalive\n\n"                  (a comment-only keepalive)
-	//
-	// Any other shape (a partial/interleaved write) fails the test.
-	w := newCaptureWriter()
+	// Verified the test catches the bug: temporarily removing the
+	// mutex in sse.send produces malformed frames and trips the
+	// assertions below.
+	w := newSplittingWriter()
 	s, _ := newSSE(w)
 	s.start()
 
@@ -144,12 +187,9 @@ func TestSSEKeepalive_ConcurrentWritesNeverCorruptFrames(t *testing.T) {
 		s.send(providers.Event{Type: providers.EventText, Text: "hi"})
 	}
 	cancel()
-	time.Sleep(10 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond) // give keepalive goroutine time to exit
 
-	got := w.Snapshot()
-	// Drop the leading status-line section (start() doesn't write any
-	// SSE frame body — it just sets headers; captureWriter doesn't
-	// serialise headers to the buffer). All wire bytes are SSE frames.
+	got := w.SnapshotAfterQuiescing()
 	frames := strings.Split(got, "\n\n")
 	for i, f := range frames {
 		if f == "" {

--- a/internal/api/http/sse_test.go
+++ b/internal/api/http/sse_test.go
@@ -82,7 +82,7 @@ func (s *splittingWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 func (s *splittingWriter) WriteHeader(st int) { s.status = st }
-func (s *splittingWriter) Flush()              {}
+func (s *splittingWriter) Flush()             {}
 
 // SnapshotAfterQuiescing should only be called after every writer
 // goroutine has stopped (e.g. cancel + wait). Reading concurrently

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,6 +366,22 @@ type Env struct {
 	//
 	// Env: LOOMCYCLE_TOOL_PARALLELISM.
 	ToolParallelism int
+
+	// SSEKeepaliveInterval is the cadence at which the SSE writer
+	// emits comment-only frames (`:keepalive`) on long-lived agent
+	// streams. Required-ignored by SSE clients per WHATWG so they
+	// don't surface as events; the point is to keep the underlying
+	// TCP/HTTP path from going idle. Agent runs that fan out to
+	// sub-agents can sit minutes between real events while a child
+	// is mid-WebFetch — networks with idle-connection timeouts
+	// (Tailscale, NAT routers, some reverse proxies) drop silent
+	// streams and the consumer-side undici reports the drop as
+	// `TypeError: terminated` with no diagnostic context.
+	//
+	// Default 20 s — comfortably under the typical 30-120 s idle
+	// timeouts on the affected network paths. Set to 0 to disable.
+	// Env: LOOMCYCLE_SSE_KEEPALIVE_MS.
+	SSEKeepaliveInterval time.Duration
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -515,6 +531,29 @@ func Load(path string) (*Config, error) {
 				d = maxProbe
 			}
 			cfg.Env.ResolveProbeInterval = d
+		}
+	}
+	// LOOMCYCLE_SSE_KEEPALIVE_MS sets the SSE keepalive cadence.
+	// Default 20 s; 0 disables. Floor 1 s so a misconfigured tiny
+	// value can't busy-loop the writer; ceiling 5 min so a misread
+	// (e.g. seconds vs ms) can't disable keepalive in practice.
+	cfg.Env.SSEKeepaliveInterval = 20 * time.Second
+	if v := os.Getenv("LOOMCYCLE_SSE_KEEPALIVE_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n == 0 {
+				cfg.Env.SSEKeepaliveInterval = 0
+			} else if n > 0 {
+				d := time.Duration(n) * time.Millisecond
+				const minSSE = 1 * time.Second
+				const maxSSE = 5 * time.Minute
+				if d < minSSE {
+					d = minSSE
+				}
+				if d > maxSSE {
+					d = maxSSE
+				}
+				cfg.Env.SSEKeepaliveInterval = d
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -534,15 +534,21 @@ func Load(path string) (*Config, error) {
 		}
 	}
 	// LOOMCYCLE_SSE_KEEPALIVE_MS sets the SSE keepalive cadence.
-	// Default 20 s; 0 disables. Floor 1 s so a misconfigured tiny
-	// value can't busy-loop the writer; ceiling 5 min so a misread
-	// (e.g. seconds vs ms) can't disable keepalive in practice.
+	// Default 20 s; 0 (or any value ≤ 0) disables. Floor 1 s for
+	// positive values so a misconfigured tiny value can't busy-loop
+	// the writer; ceiling 5 min so a misread (e.g. seconds vs ms)
+	// can't effectively disable keepalive in practice.
+	//
+	// Treating negative values as "disable" (same as 0) matches
+	// operator intent for the typical typo case and is consistent
+	// with the disable contract on `sse.startKeepalive` itself
+	// (interval <= 0 → no goroutine).
 	cfg.Env.SSEKeepaliveInterval = 20 * time.Second
 	if v := os.Getenv("LOOMCYCLE_SSE_KEEPALIVE_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
-			if n == 0 {
+			if n <= 0 {
 				cfg.Env.SSEKeepaliveInterval = 0
-			} else if n > 0 {
+			} else {
 				d := time.Duration(n) * time.Millisecond
 				const minSSE = 1 * time.Second
 				const maxSSE = 5 * time.Minute


### PR DESCRIPTION
## Why

Agent runs that fan out to sub-agents (e.g. \`employer-profiler\` → 3× \`company-researcher\`) can sit minutes between real SSE events while a child is mid-\`WebFetch\`. On networks with idle-connection timeouts (Tailscale, NAT routers, some reverse proxies) the silent stream gets dropped, and undici on the consumer side reports the drop as \`TypeError: terminated\` with no diagnostic context — operator sees \`Error: terminated\` in the UI with no idea what happened.

Field report 2026-05-09 from a research run on the v0.7.0 stack: parent emitted \`[tool: Agent] [tool: Agent] [tool: Agent]\` and then hit \`Error: terminated\`. Loomcycle stderr showed only an unrelated Ollama probe timeout — **no panic, no crash**. The connection died from the outside.

## What

Emit comment-only SSE frames (\`:keepalive\\n\\n\`) on a configurable cadence, default **20 s** — comfortably under the typical 30-120 s idle-timeout windows on the affected paths. SSE clients are required-ignored to drop comment frames per WHATWG, so they don't surface as events; the point is purely to keep bytes flowing on the wire.

### Implementation

- \`sse.startKeepalive(ctx, interval)\` spawns a goroutine that ticks at \`interval\` and writes \`: keepalive\\n\\n\` until \`ctx.Done()\`. Goroutine is bounded by the request context so it cannot outlive the handler.
- \`sse\` now carries a \`sync.Mutex\` because keepalive introduces a second writer goroutine. \`net/http\` does NOT serialise concurrent writes from multiple goroutines on a response writer; unsynchronised \`Fprintf\` would interleave bytes mid-frame and silently corrupt the stream. All public \`sse\` methods now acquire \`mu\` before touching the underlying writer.
- Both SSE handlers in \`server.go\` (\`handleRuns\` + \`handleMessages\`) call \`startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)\` right after \`start()\`.
- New env var \`LOOMCYCLE_SSE_KEEPALIVE_MS\`, default 20000; set to 0 to disable. Floor 1 s, ceiling 5 min.

## What was tested

Four new tests in \`sse_test.go\`:

- **EmitsCommentFramesOnIdleStream** — 50 ms interval over a 200 ms window produces ≥ 2 keepalive frames.
- **DisabledWhenIntervalZero** — \`interval=0\` writes nothing.
- **GoroutineExitsOnContextCancel** — count stays flat after \`cancel()\` (no goroutine leak across streams).
- **ConcurrentWritesNeverCorruptFrames** — 1 ms keepalive concurrent with 500 real \`send()\` calls; every wire frame is well-formed (proves the mutex prevents interleaving).

\`\`\`
go test ./...               # green
go test -race ./...         # green
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)