### PR TITLE
feat(loop): parallel tool dispatch within an assistant turn

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -423,17 +423,18 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	heartbeat := s.makeHeartbeat(runID)
 
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
-		Provider:      provider,
-		Model:         model,
-		Tools:         allowedTools,
-		Dispatcher:    dispatcher,
-		Segments:      segments,
-		PriorMessages: priorMessages,
-		OnEvent:       emit,
-		OnHeartbeat:   heartbeat,
-		MaxTokens:     agentDef.MaxTokens,
-		Effort:        effort,
-		MarkStalled:   s.markStalledFn(providerID, model),
+		Provider:        provider,
+		Model:           model,
+		Tools:           allowedTools,
+		Dispatcher:      dispatcher,
+		Segments:        segments,
+		PriorMessages:   priorMessages,
+		OnEvent:         emit,
+		OnHeartbeat:     heartbeat,
+		MaxTokens:       agentDef.MaxTokens,
+		Effort:          effort,
+		MarkStalled:     s.markStalledFn(providerID, model),
+		ToolParallelism: s.cfg.Env.ToolParallelism,
 	})
 	s.finishRunWithCancel(ctx, runCtx, runID, res, runErr)
 	return nil
@@ -855,16 +856,17 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	heartbeat := s.makeHeartbeat(runID)
 
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
-		Provider:    provider,
-		Model:       model,
-		Tools:       allowedTools,
-		Dispatcher:  dispatcher,
-		Segments:    req.Segments,
-		OnEvent:     emit,
-		OnHeartbeat: heartbeat,
-		MaxTokens:   agentDef.MaxTokens, // 0 → driver default
-		Effort:      effort,
-		MarkStalled: s.markStalledFn(providerID, model),
+		Provider:        provider,
+		Model:           model,
+		Tools:           allowedTools,
+		Dispatcher:      dispatcher,
+		Segments:        req.Segments,
+		OnEvent:         emit,
+		OnHeartbeat:     heartbeat,
+		MaxTokens:       agentDef.MaxTokens, // 0 → driver default
+		Effort:          effort,
+		MarkStalled:     s.markStalledFn(providerID, model),
+		ToolParallelism: s.cfg.Env.ToolParallelism,
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -1087,17 +1089,18 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AgentID: agentID,
 	})
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
-		Provider:      provider,
-		Model:         model,
-		Tools:         allowedTools,
-		Dispatcher:    dispatcher,
-		Segments:      segments,
-		PriorMessages: priorMessages,
-		OnEvent:       emit,
-		OnHeartbeat:   heartbeat,
-		MaxTokens:     agentDef.MaxTokens, // 0 → driver default
-		Effort:        effort,
-		MarkStalled:   s.markStalledFn(providerID, model),
+		Provider:        provider,
+		Model:           model,
+		Tools:           allowedTools,
+		Dispatcher:      dispatcher,
+		Segments:        segments,
+		PriorMessages:   priorMessages,
+		OnEvent:         emit,
+		OnHeartbeat:     heartbeat,
+		MaxTokens:       agentDef.MaxTokens, // 0 → driver default
+		Effort:          effort,
+		MarkStalled:     s.markStalledFn(providerID, model),
+		ToolParallelism: s.cfg.Env.ToolParallelism,
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -1531,16 +1534,17 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	subHeartbeat := s.makeHeartbeat(subRunID)
 
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
-		Provider:    provider,
-		Model:       model,
-		Tools:       subTools,
-		Dispatcher:  subDispatcher,
-		Segments:    segs,
-		OnEvent:     subEmit,
-		OnHeartbeat: subHeartbeat,
-		MaxTokens:   def.MaxTokens, // 0 → driver default
-		Effort:      effort,
-		MarkStalled: s.markStalledFn(providerID, model),
+		Provider:        provider,
+		Model:           model,
+		Tools:           subTools,
+		Dispatcher:      subDispatcher,
+		Segments:        segs,
+		OnEvent:         subEmit,
+		OnHeartbeat:     subHeartbeat,
+		MaxTokens:       def.MaxTokens, // 0 → driver default
+		Effort:          effort,
+		MarkStalled:     s.markStalledFn(providerID, model),
+		ToolParallelism: s.cfg.Env.ToolParallelism,
 	})
 	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -350,6 +350,22 @@ type Env struct {
 	// long interval can't hide a recovered provider for a full
 	// day. Env: LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS.
 	ResolveProbeInterval time.Duration
+
+	// ToolParallelism caps how many tool_calls from a single
+	// assistant turn run concurrently. Default 8. Set to 1 to
+	// force serial dispatch (debug / determinism). Field 0
+	// (unset) is treated as the default — the loop fills in 8.
+	//
+	// Bumping this matters most for agents that fan out via the
+	// `Agent` built-in tool: each Agent call spawns a sub-agent
+	// run, so a parent that emitted 3 Agent tool_calls would
+	// pre-2026-05-09 see them serialised back-to-back instead of
+	// running concurrently. The HTTP server's MAX_CONCURRENT_RUNS
+	// slot still bounds the run tree, so per-tool parallelism is
+	// an inner-loop knob that doesn't change the global ceiling.
+	//
+	// Env: LOOMCYCLE_TOOL_PARALLELISM.
+	ToolParallelism int
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -466,6 +482,19 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_SESSION_LOCK_MAX_IDLE_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.SessionLockMaxIdle = time.Duration(n) * time.Millisecond
+		}
+	}
+	// LOOMCYCLE_TOOL_PARALLELISM overrides the per-iteration
+	// tool_call concurrency cap (default 8). Floor 1, ceiling 64
+	// — anything beyond 64 would spawn a goroutine storm that
+	// outweighs realistic fan-out. Zero / negative values fall
+	// through to the default.
+	if v := os.Getenv("LOOMCYCLE_TOOL_PARALLELISM"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 64 {
+				n = 64
+			}
+			cfg.Env.ToolParallelism = n
 		}
 	}
 	// LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS overrides the default 15-min

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -79,6 +80,22 @@ type RunOptions struct {
 	// unchanged; drivers in PR 1 ignore the field entirely.
 	Effort string
 
+	// ToolParallelism caps how many tool_calls from a single
+	// assistant turn run concurrently. Zero = use the package
+	// default (8). Models like Anthropic and DeepSeek often emit
+	// 2-5 tool_calls per turn; the Agent built-in tool turns each
+	// of those into a full sub-agent run, so a serial dispatch
+	// (the pre-2026-05-09 default) was forcing fan-outs of 3
+	// sub-agents to run back-to-back instead of in parallel.
+	//
+	// Set to 1 to force serial dispatch (debug / determinism).
+	// Setting it higher than the number of pending tool_calls is
+	// harmless — the bound is never hit. Per-iteration; the loop
+	// has no global cap on aggregate concurrency across runs (the
+	// HTTP server's MAX_CONCURRENT_RUNS slot bounds the run tree
+	// already).
+	ToolParallelism int
+
 	// MarkStalled is the resolver feedback hook: the loop calls it
 	// when this iteration's provider call surfaced an error that
 	// suggests the (provider, model) pair is broken. The resolver
@@ -116,6 +133,9 @@ type RunResult struct {
 func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	if opts.MaxIterations == 0 {
 		opts.MaxIterations = 16
+	}
+	if opts.ToolParallelism <= 0 {
+		opts.ToolParallelism = 8
 	}
 	if opts.Provider == nil {
 		return RunResult{}, fmt.Errorf("loop: provider is nil")
@@ -280,23 +300,20 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 			break
 		}
 
-		// Execute pending tools and append a single user turn with all results.
-		toolResults := make([]providers.ContentBlock, 0, len(pendingTools))
-		for _, tu := range pendingTools {
-			res := executeTool(ctx, opts.Dispatcher, tu)
-			emit(providers.Event{
-				Type:    providers.EventToolResult,
-				ToolUse: &providers.ToolUse{ID: tu.ID, Name: tu.Name, Input: tu.Input},
-				Text:    res.Text,
-				IsError: res.IsError,
-			})
-			toolResults = append(toolResults, providers.ContentBlock{
-				Type:      "tool_result",
-				ToolUseID: tu.ID,
-				Text:      res.Text,
-				IsError:   res.IsError,
-			})
-		}
+		// Execute pending tools concurrently, bounded by
+		// opts.ToolParallelism, and append a single user turn with
+		// all results in tool_call order.
+		//
+		// Two ordering rules cohabit here. The MESSAGE we hand the
+		// model on the next turn lists tool_results in the same order
+		// the model emitted the tool_calls — Anthropic correlates by
+		// tool_use_id but staying stable on the wire avoids subtle
+		// surprises in cache reuse and transcript reads. The EVENTS
+		// we emit on the SSE stream go out in COMPLETION order — fast
+		// tools' results stream out first, slow ones last — because
+		// callers rendering live progress want "company 1 done" the
+		// moment company 1 is done, not after company 3 finishes too.
+		toolResults := executePendingTools(ctx, opts.Dispatcher, pendingTools, opts.ToolParallelism, emit)
 		messages = append(messages, providers.Message{Role: "user", Content: toolResults})
 	}
 
@@ -326,6 +343,94 @@ func executeTool(ctx context.Context, d *tools.Dispatcher, tu providers.ToolUse)
 		return tools.Result{Text: "no tool dispatcher", IsError: true}
 	}
 	return d.Execute(ctx, tu.Name, tu.Input)
+}
+
+// executePendingTools runs the assistant turn's tool_calls concurrently,
+// bounded by `parallelism`, and returns the tool_result content blocks in
+// the same order as `pending` (so the next turn's user message preserves
+// tool_call ordering). EventToolResult emissions happen in COMPLETION
+// order — a fast tool's result reaches the SSE consumer before a slow
+// one's, even when the slow one came first in `pending`.
+//
+// Tools share `ctx`, so a parent cancellation propagates to every
+// in-flight goroutine. Tool errors are surfaced as IsError tool_results
+// (the existing dispatcher contract); they do NOT abort the batch — the
+// other tools still run, and the model gets to see every result.
+//
+// All emit() calls happen from THIS goroutine (the caller's), reading
+// from a results channel. That preserves the existing single-writer
+// contract for emit and avoids forcing every emit implementation to be
+// thread-safe.
+func executePendingTools(
+	ctx context.Context,
+	dispatcher *tools.Dispatcher,
+	pending []providers.ToolUse,
+	parallelism int,
+	emit func(providers.Event),
+) []providers.ContentBlock {
+	if len(pending) == 0 {
+		return nil
+	}
+	if parallelism < 1 {
+		parallelism = 1
+	}
+
+	type result struct {
+		idx int
+		tu  providers.ToolUse
+		res tools.Result
+	}
+
+	resCh := make(chan result, len(pending))
+	sem := make(chan struct{}, parallelism)
+
+	var wg sync.WaitGroup
+	for i, tu := range pending {
+		wg.Add(1)
+		go func(i int, tu providers.ToolUse) {
+			defer wg.Done()
+			// Acquire the slot. ctx-aware so a parent cancellation
+			// during a saturated batch unblocks the goroutine instead
+			// of having it sit forever on a full sem channel.
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				resCh <- result{idx: i, tu: tu, res: tools.Result{
+					IsError: true,
+					Text:    "tool dispatch cancelled before slot acquired: " + ctx.Err().Error(),
+				}}
+				return
+			}
+			r := executeTool(ctx, dispatcher, tu)
+			resCh <- result{idx: i, tu: tu, res: r}
+		}(i, tu)
+	}
+	go func() {
+		wg.Wait()
+		close(resCh)
+	}()
+
+	results := make([]providers.ContentBlock, len(pending))
+	for r := range resCh {
+		// Emit in completion order so the SSE consumer sees each
+		// tool's result the moment it's done.
+		emit(providers.Event{
+			Type:    providers.EventToolResult,
+			ToolUse: &providers.ToolUse{ID: r.tu.ID, Name: r.tu.Name, Input: r.tu.Input},
+			Text:    r.res.Text,
+			IsError: r.res.IsError,
+		})
+		// Place by index so the message we hand back to the model
+		// stays in tool_call order regardless of finish order.
+		results[r.idx] = providers.ContentBlock{
+			Type:      "tool_result",
+			ToolUseID: r.tu.ID,
+			Text:      r.res.Text,
+			IsError:   r.res.IsError,
+		}
+	}
+	return results
 }
 
 // splitSegments separates "system" segments (which become provider System

--- a/internal/loop/parallel_test.go
+++ b/internal/loop/parallel_test.go
@@ -1,0 +1,303 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// slowTool sleeps for delay ms and reports its start/finish times so
+// tests can assert real concurrency from wall-clock data. ms is read
+// from input as `{"ms": <int>}`.
+type slowTool struct {
+	mu       sync.Mutex
+	starts   map[string]time.Time
+	finishes map[string]time.Time
+	maxLive  int // peak concurrent in-flight calls observed
+	live     int
+}
+
+func newSlowTool() *slowTool {
+	return &slowTool{
+		starts:   make(map[string]time.Time),
+		finishes: make(map[string]time.Time),
+	}
+}
+
+func (t *slowTool) Name() string                 { return "Slow" }
+func (t *slowTool) Description() string          { return "" }
+func (t *slowTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+
+func (t *slowTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	var args struct {
+		ID string `json:"id"`
+		MS int    `json:"ms"`
+	}
+	_ = json.Unmarshal(input, &args)
+
+	t.mu.Lock()
+	t.live++
+	if t.live > t.maxLive {
+		t.maxLive = t.live
+	}
+	t.starts[args.ID] = time.Now()
+	t.mu.Unlock()
+
+	delay := time.Duration(args.MS) * time.Millisecond
+	select {
+	case <-time.After(delay):
+	case <-ctx.Done():
+	}
+
+	t.mu.Lock()
+	t.finishes[args.ID] = time.Now()
+	t.live--
+	t.mu.Unlock()
+
+	return tools.Result{Text: "done:" + args.ID}, nil
+}
+
+// scriptedProvider drives one assistant turn with N tool_calls, then a
+// terminal end_turn turn. Caller controls how many tool_calls are
+// emitted and what their inputs are.
+type scriptedProvider struct {
+	toolCalls []providers.ToolUse
+	calls     int
+	mu        sync.Mutex
+}
+
+func (p *scriptedProvider) ID() string                                   { return "scripted" }
+func (p *scriptedProvider) Probe(_ context.Context) error                { return nil }
+func (p *scriptedProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"scripted-model"}, nil
+}
+func (p *scriptedProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *scriptedProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	turn := p.calls
+	p.calls++
+	ch := make(chan providers.Event, len(p.toolCalls)+2)
+	if turn == 0 {
+		ch <- providers.Event{Type: providers.EventText, Text: "spawning"}
+		for _, tu := range p.toolCalls {
+			tu := tu
+			ch <- providers.Event{Type: providers.EventToolCall, ToolUse: &tu}
+		}
+		ch <- providers.Event{
+			Type:       providers.EventDone,
+			StopReason: "tool_use",
+			Usage:      &providers.Usage{},
+		}
+	} else {
+		ch <- providers.Event{Type: providers.EventText, Text: "all done"}
+		ch <- providers.Event{
+			Type:       providers.EventDone,
+			StopReason: "end_turn",
+			Usage:      &providers.Usage{},
+		}
+	}
+	close(ch)
+	return ch, nil
+}
+
+func makePending(n int, delayMs int) []providers.ToolUse {
+	out := make([]providers.ToolUse, n)
+	for i := 0; i < n; i++ {
+		out[i] = providers.ToolUse{
+			ID:    "call_" + strconv.Itoa(i),
+			Name:  "Slow",
+			Input: json.RawMessage(fmt.Sprintf(`{"id":"call_%d","ms":%d}`, i, delayMs)),
+		}
+	}
+	return out
+}
+
+// TestParallelDispatch_RunsConcurrently_NotSerial pins the headline
+// behaviour: 3 tool_calls with 100 ms each must finish in roughly
+// 100 ms (not 300 ms). A serial dispatch would force ~300 ms.
+func TestParallelDispatch_RunsConcurrently_NotSerial(t *testing.T) {
+	pending := makePending(3, 100)
+	tool := newSlowTool()
+	prov := &scriptedProvider{toolCalls: pending}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	t0 := time.Now()
+	res, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 8,
+	})
+	elapsed := time.Since(t0)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("stop = %q, want end_turn", res.StopReason)
+	}
+	// Wall-clock budget: 100 ms each tool, fully parallel = ~100 ms.
+	// Allow generous slack (300 ms) to absorb scheduler noise on CI;
+	// a serial dispatch would be ≥ 300 ms even after slack.
+	if elapsed > 300*time.Millisecond {
+		t.Errorf("dispatch took %v, want < 300ms (serial would be ≥ 300ms; parallelism appears broken)", elapsed)
+	}
+	// Peak in-flight must reach 3 (all three running together at
+	// some moment); a serial dispatch would peak at 1.
+	if tool.maxLive < 3 {
+		t.Errorf("peak concurrent tools = %d, want ≥ 3 (parallel dispatch did not engage)", tool.maxLive)
+	}
+}
+
+// TestParallelDispatch_PreservesMessageOrdering pins the contract
+// that the message handed back to the model lists tool_results in
+// tool_call order, even when tools finish out of order.
+func TestParallelDispatch_PreservesMessageOrdering(t *testing.T) {
+	// Make the FIRST tool the slowest — then a serial dispatch and a
+	// parallel dispatch would both finish in the same final order
+	// (slowest first) and miss any reordering bug. Instead, make
+	// tool 0 fast, tool 1 medium, tool 2 fastest. That way completion
+	// order is [2, 0, 1] but the message must still read [0, 1, 2].
+	pending := []providers.ToolUse{
+		{ID: "call_0", Name: "Slow", Input: json.RawMessage(`{"id":"call_0","ms":50}`)},
+		{ID: "call_1", Name: "Slow", Input: json.RawMessage(`{"id":"call_1","ms":80}`)},
+		{ID: "call_2", Name: "Slow", Input: json.RawMessage(`{"id":"call_2","ms":10}`)},
+	}
+	tool := newSlowTool()
+	prov := &scriptedProvider{toolCalls: pending}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 8,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Pull the request the model received for iteration 2: its
+	// final message contains the tool_results we built. Order must
+	// match pending[].ID even though completion order was different.
+	req2 := prov.calls
+	_ = req2 // calls is incremented internally; the mutated state is what we want
+	// Deeper inspection: messages array isn't directly exposed by
+	// scripted provider; instead we verify finish-time ordering
+	// confirms our assumption (call_2 < call_0 < call_1) — the only
+	// way the test can succeed without parallel + indexed write is
+	// if both ordering-relevant code paths are correct.
+	tool.mu.Lock()
+	defer tool.mu.Unlock()
+	if !(tool.finishes["call_2"].Before(tool.finishes["call_0"]) &&
+		tool.finishes["call_0"].Before(tool.finishes["call_1"])) {
+		// If timing didn't separate as planned, the test isn't
+		// really exercising the reorder path — flag it so a
+		// flake-detective doesn't dismiss a real regression as
+		// "scheduler noise".
+		t.Skipf("scheduler did not produce the expected finish order on this run "+
+			"(call_2=%v call_0=%v call_1=%v); cannot assert reordering",
+			tool.finishes["call_2"], tool.finishes["call_0"], tool.finishes["call_1"])
+	}
+}
+
+// TestParallelDispatch_RespectsParallelismCap pins that the bound
+// is honoured: with parallelism=2 and 4 pending tools, peak
+// in-flight is exactly 2.
+func TestParallelDispatch_RespectsParallelismCap(t *testing.T) {
+	pending := makePending(4, 60)
+	tool := newSlowTool()
+	prov := &scriptedProvider{toolCalls: pending}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 2,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if tool.maxLive > 2 {
+		t.Errorf("peak concurrent tools = %d, want ≤ 2 (cap leaked)", tool.maxLive)
+	}
+	if tool.maxLive < 2 {
+		t.Errorf("peak concurrent tools = %d, want = 2 (cap underused; parallelism not engaging at all)", tool.maxLive)
+	}
+}
+
+// TestParallelDispatch_SerialFallbackWhenCapIsOne pins that
+// parallelism=1 produces strict serial behaviour — useful for debug
+// and as a back-stop for users who want deterministic ordering.
+func TestParallelDispatch_SerialFallbackWhenCapIsOne(t *testing.T) {
+	pending := makePending(3, 30)
+	tool := newSlowTool()
+	prov := &scriptedProvider{toolCalls: pending}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 1,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if tool.maxLive != 1 {
+		t.Errorf("peak concurrent tools = %d, want = 1 (serial fallback failed)", tool.maxLive)
+	}
+}
+
+// TestParallelDispatch_ContextCancelPropagates pins that a parent
+// cancellation tears down all in-flight tool goroutines, not just
+// the next one to start. Without ctx-aware semaphore acquisition,
+// goroutines waiting on a saturated cap would leak past cancel.
+func TestParallelDispatch_ContextCancelPropagates(t *testing.T) {
+	pending := makePending(8, 500)
+	tool := newSlowTool()
+	prov := &scriptedProvider{toolCalls: pending}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	t0 := time.Now()
+	_, _ = Run(ctx, RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 2,
+	})
+	elapsed := time.Since(t0)
+
+	// 8 tools × 500 ms each, parallelism 2 → ~2 s if cancel didn't
+	// propagate to in-flight tools. If cancel propagates, we should
+	// finish well under 1 s (the in-flight tools see ctx.Done() and
+	// return early via their select).
+	if elapsed > 1*time.Second {
+		t.Errorf("Run took %v after 50ms cancel; goroutines did not observe ctx.Done()", elapsed)
+	}
+}

--- a/internal/loop/parallel_test.go
+++ b/internal/loop/parallel_test.go
@@ -79,8 +79,8 @@ type scriptedProvider struct {
 	mu       sync.Mutex
 }
 
-func (p *scriptedProvider) ID() string                                   { return "scripted" }
-func (p *scriptedProvider) Probe(_ context.Context) error                { return nil }
+func (p *scriptedProvider) ID() string                    { return "scripted" }
+func (p *scriptedProvider) Probe(_ context.Context) error { return nil }
 func (p *scriptedProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"scripted-model"}, nil
 }

--- a/internal/loop/parallel_test.go
+++ b/internal/loop/parallel_test.go
@@ -70,7 +70,13 @@ func (t *slowTool) Execute(ctx context.Context, input json.RawMessage) (tools.Re
 type scriptedProvider struct {
 	toolCalls []providers.ToolUse
 	calls     int
-	mu        sync.Mutex
+	// requests captures every providers.Request the loop hands to
+	// Call(), in order. Used by TestParallelDispatch_PreservesMessageOrdering
+	// to inspect the messages array on turn 2 (the one that carries the
+	// tool_result content blocks) and assert tool_call ordering survives
+	// the parallel dispatch.
+	requests []providers.Request
+	mu       sync.Mutex
 }
 
 func (p *scriptedProvider) ID() string                                   { return "scripted" }
@@ -81,11 +87,12 @@ func (p *scriptedProvider) ListModels(_ context.Context) ([]string, error) {
 func (p *scriptedProvider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{Streaming: true}
 }
-func (p *scriptedProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+func (p *scriptedProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	turn := p.calls
 	p.calls++
+	p.requests = append(p.requests, req)
 	ch := make(chan providers.Event, len(p.toolCalls)+2)
 	if turn == 0 {
 		ch <- providers.Event{Type: providers.EventText, Text: "spawning"}
@@ -162,13 +169,15 @@ func TestParallelDispatch_RunsConcurrently_NotSerial(t *testing.T) {
 
 // TestParallelDispatch_PreservesMessageOrdering pins the contract
 // that the message handed back to the model lists tool_results in
-// tool_call order, even when tools finish out of order.
+// tool_call order, even when tools finish out of order. The
+// assertion is on the ACTUAL request the loop hands to the provider
+// on turn 2 (the one carrying the tool_result content blocks),
+// captured by scriptedProvider.requests.
 func TestParallelDispatch_PreservesMessageOrdering(t *testing.T) {
-	// Make the FIRST tool the slowest — then a serial dispatch and a
-	// parallel dispatch would both finish in the same final order
-	// (slowest first) and miss any reordering bug. Instead, make
-	// tool 0 fast, tool 1 medium, tool 2 fastest. That way completion
-	// order is [2, 0, 1] but the message must still read [0, 1, 2].
+	// Tool 0 medium, tool 1 slowest, tool 2 fastest → completion
+	// order [2, 0, 1] differs from tool_call order [0, 1, 2]. The
+	// indexed-slot write in executePendingTools must restore the
+	// original ordering before the message is appended.
 	pending := []providers.ToolUse{
 		{ID: "call_0", Name: "Slow", Input: json.RawMessage(`{"id":"call_0","ms":50}`)},
 		{ID: "call_1", Name: "Slow", Input: json.RawMessage(`{"id":"call_1","ms":80}`)},
@@ -189,27 +198,51 @@ func TestParallelDispatch_PreservesMessageOrdering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	// Pull the request the model received for iteration 2: its
-	// final message contains the tool_results we built. Order must
-	// match pending[].ID even though completion order was different.
-	req2 := prov.calls
-	_ = req2 // calls is incremented internally; the mutated state is what we want
-	// Deeper inspection: messages array isn't directly exposed by
-	// scripted provider; instead we verify finish-time ordering
-	// confirms our assumption (call_2 < call_0 < call_1) — the only
-	// way the test can succeed without parallel + indexed write is
-	// if both ordering-relevant code paths are correct.
+
+	// Sanity guard: the test only exercises the reorder path when
+	// finish times actually separate as planned. If scheduler noise
+	// produces a different finish order on this run, skip rather
+	// than report a misleading pass.
 	tool.mu.Lock()
-	defer tool.mu.Unlock()
 	if !(tool.finishes["call_2"].Before(tool.finishes["call_0"]) &&
 		tool.finishes["call_0"].Before(tool.finishes["call_1"])) {
-		// If timing didn't separate as planned, the test isn't
-		// really exercising the reorder path — flag it so a
-		// flake-detective doesn't dismiss a real regression as
-		// "scheduler noise".
-		t.Skipf("scheduler did not produce the expected finish order on this run "+
+		tool.mu.Unlock()
+		t.Skipf("scheduler did not separate finish times this run "+
 			"(call_2=%v call_0=%v call_1=%v); cannot assert reordering",
 			tool.finishes["call_2"], tool.finishes["call_0"], tool.finishes["call_1"])
+	}
+	tool.mu.Unlock()
+
+	// Pull turn 2's request — that's the one carrying the user
+	// message with all three tool_result blocks.
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	if len(prov.requests) < 2 {
+		t.Fatalf("turn 2 not captured (got %d Call invocations)", len(prov.requests))
+	}
+	turn2 := prov.requests[1]
+
+	// Find the user message containing tool_results and pull their
+	// IDs in wire order. We expect three blocks correlated to
+	// call_0/call_1/call_2 in that exact order.
+	var ids []string
+	for _, msg := range turn2.Messages {
+		for _, c := range msg.Content {
+			if c.Type == "tool_result" {
+				ids = append(ids, c.ToolUseID)
+			}
+		}
+	}
+	want := []string{"call_0", "call_1", "call_2"}
+	if len(ids) != len(want) {
+		t.Fatalf("tool_result block count = %d, want %d (got %v)", len(ids), len(want), ids)
+	}
+	for i, got := range ids {
+		if got != want[i] {
+			t.Errorf("tool_result[%d] = %q, want %q (full order %v; reorder bug — "+
+				"results slice was written in completion order, not tool_call order)",
+				i, got, want[i], ids)
+		}
 	}
 }
 


### PR DESCRIPTION
## Why

Until now, the agent loop dispatched a turn's tool_calls **serially**: one tool ran to completion before the next started (\`loop.go:285\`, \`for _, tu := range pendingTools\`). For most tools that's invisible — Read / Write / HTTP finish in milliseconds. For the \`Agent\` built-in tool, every call is a full sub-agent run; serialising 3 of them turned a fan-out into a queue.

A field run 2026-05-09 saw \`employer-profiler\` emit 3 \`Agent\` tool_calls. The expected behaviour was 3 company-researcher sub-agents running in parallel; the actual behaviour was them queued back-to-back — multiplying total wall-clock by N when it should have been bounded by the slowest sub. That's the bug.

## What

Dispatch concurrently, bounded by \`RunOptions.ToolParallelism\` (default 8). New helper \`executePendingTools\` in \`loop.go\` with two ordering rules:

- The **message** handed back to the model on the next turn lists tool_results in tool_call order. Anthropic correlates by \`tool_use_id\` but staying stable on the wire avoids subtle surprises in cache reuse and transcript reads.
- The **events** emitted on the SSE stream go out in **completion order** — fast tools' results stream out first, slow ones last. A live-progress consumer sees \"company 1 done\" the moment company 1 finishes, not after company 3 too.

\`emit()\` is still called from a single goroutine (the loop's main goroutine, draining a results channel) so the existing single-writer contract for adapter implementations is preserved — this PR doesn't require \`emit\` to be thread-safe.

Cancellation: each goroutine acquires its semaphore slot via a ctx-aware \`select\` so a parent cancellation during a saturated batch unblocks waiters instead of leaking goroutines past \`ctx.Done()\`.

### Configuration

- \`RunOptions.ToolParallelism\` (loop package) — primary knob. Zero falls through to the package default (8).
- \`Env.ToolParallelism\` (config package) — operator-facing knob. Threaded into all four \`loop.Run\` sites in \`internal/api/http/server.go\` (top-level run, sub-agent run, session continuation, \`RunOnce\`).
- \`LOOMCYCLE_TOOL_PARALLELISM\` env var. Floor 1, ceiling 64. Set to 1 to force serial dispatch for debug / determinism.

## What was tested

Five new tests in \`internal/loop/parallel_test.go\`:

- **RunsConcurrently_NotSerial** — 3 tools × 100 ms must finish in < 300 ms (a serial dispatch would be ≥ 300 ms even after scheduler slack). Asserts peak in-flight ≥ 3.
- **PreservesMessageOrdering** — tool_calls finish in \`[2,0,1]\` completion order; the message rebuilt for the next turn must still read \`[0,1,2]\`.
- **RespectsParallelismCap** — \`parallelism=2\` with 4 tools, peak in-flight is exactly 2.
- **SerialFallbackWhenCapIsOne** — \`parallelism=1\`, peak in-flight is exactly 1.
- **ContextCancelPropagates** — 8 tools × 500 ms with \`parallelism=2\`, cancel after 50 ms must finish in < 1 s (proves goroutines observe \`ctx.Done()\` rather than wait for their slot).

\`\`\`
go test ./...               # green
go test -race ./...         # green
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)