### PR TITLE
chore: gofmt main (Go 1.19+ doc-comment normalization)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -28,8 +28,10 @@ import (
 	"time"
 
 	lchttp "github.com/denn-gubsky/loomcycle/internal/api/http"
+	"github.com/denn-gubsky/loomcycle/internal/cli"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/heartbeat"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
 	"github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
@@ -37,8 +39,6 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
-	"github.com/denn-gubsky/loomcycle/internal/cli"
-	"github.com/denn-gubsky/loomcycle/internal/heartbeat"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -568,10 +568,10 @@ func buildResolver(cfg *config.Config, pr *providerResolver) *resolve.Resolver {
 // context.Background for startup) bounds the total wait.
 func runResolveProbeOnce(ctx context.Context, r *resolve.Resolver, pr *providerResolver, cfg *config.Config) {
 	type probeJob struct {
-		id        string                 // provider id
-		excluded  bool                   // operator opted out
-		exclReason string                // why excluded; surfaced in LastError
-		provider  providers.Provider     // nil when excluded
+		id         string             // provider id
+		excluded   bool               // operator opted out
+		exclReason string             // why excluded; surfaced in LastError
+		provider   providers.Provider // nil when excluded
 	}
 
 	jobs := []probeJob{

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -70,8 +70,8 @@ type Server struct {
 
 // Config carries the server's construction-time inputs.
 type Config struct {
-	Store       store.Store
-	CancelReg   *cancel.Registry
+	Store     store.Store
+	CancelReg *cancel.Registry
 	// Runner is the wire-agnostic loop driver. *internal/api/http.Server
 	// satisfies it. May be nil — Run + Continue then return
 	// codes.Unimplemented (useful for tests that don't need streaming).
@@ -426,7 +426,7 @@ func (s *Server) Continue(req *loomcyclepb.ContinueRequest, stream loomcyclepb.L
 	if req.GetSessionId() == "" {
 		return status.Error(codes.InvalidArgument, "session_id is required for Continue")
 	}
-	in := runInputFromProto(/*agent=*/ "", req.GetSessionId(), req.GetSegments(),
+	in := runInputFromProto( /*agent=*/ "", req.GetSessionId(), req.GetSegments(),
 		req.GetAllowedTools(), req.GetAllowedHosts(), req.GetWebSearchFilter(),
 		/*userID=*/ "", req.GetAgentId())
 	return s.driveStream(stream.Context(), stream, in)
@@ -645,4 +645,3 @@ func mapRunnerErr(err error) error {
 		return status.Errorf(codes.Internal, "runner: %v", err)
 	}
 }
-

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -30,8 +30,8 @@ type scriptedProvider struct {
 	defaultS []providers.Event // returned for any call past len(scripts)
 }
 
-func (s *scriptedProvider) ID() string                            { return "scripted" }
-func (s *scriptedProvider) Probe(_ context.Context) error          { return nil }
+func (s *scriptedProvider) ID() string                    { return "scripted" }
+func (s *scriptedProvider) Probe(_ context.Context) error { return nil }
 func (s *scriptedProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"scripted-model"}, nil
 }

--- a/internal/api/http/agent_tracking_test.go
+++ b/internal/api/http/agent_tracking_test.go
@@ -23,13 +23,13 @@ import (
 // ctx is cancelled. Used by cancel tests to give an external cancel
 // request time to fire before the loop's response stream completes.
 type pausableProvider struct {
-	release    chan struct{}
-	ctxFired   atomic.Bool
-	finalText  string
+	release   chan struct{}
+	ctxFired  atomic.Bool
+	finalText string
 }
 
-func (p *pausableProvider) ID() string                            { return "pausable" }
-func (p *pausableProvider) Probe(_ context.Context) error          { return nil }
+func (p *pausableProvider) ID() string                    { return "pausable" }
+func (p *pausableProvider) Probe(_ context.Context) error { return nil }
 func (p *pausableProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"pausable-model"}, nil
 }

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -31,8 +31,8 @@ type stubProvider struct {
 	preEvents []providers.Event
 }
 
-func (s *stubProvider) ID() string                            { return "stub" }
-func (s *stubProvider) Probe(_ context.Context) error          { return nil }
+func (s *stubProvider) ID() string                    { return "stub" }
+func (s *stubProvider) Probe(_ context.Context) error { return nil }
 func (s *stubProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"stub-model"}, nil
 }
@@ -1275,8 +1275,8 @@ type callableProvider struct {
 	mu       sync.Mutex
 }
 
-func (c *callableProvider) ID() string                            { return "stub" }
-func (c *callableProvider) Probe(_ context.Context) error          { return nil }
+func (c *callableProvider) ID() string                    { return "stub" }
+func (c *callableProvider) Probe(_ context.Context) error { return nil }
 func (c *callableProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"stub-model"}, nil
 }

--- a/internal/cancel/registry.go
+++ b/internal/cancel/registry.go
@@ -21,36 +21,36 @@
 //
 // Lifecycle:
 //
-//   ┌────────────────────────────────────────────────────────────────┐
-//   │ HTTP req in →  Server creates session+run → Register(agentID)  │
-//   │                          │                                     │
-//   │                          ▼                                     │
-//   │              ┌─ loop.Run(runCtx) ──────────────┐                │
-//   │              │  (subloops inherit runCtx —     │                │
-//   │              │   parent cancel cascades)       │                │
-//   │              └─────────────────────────────────┘                │
-//   │                          │                                     │
-//   │                          ▼                                     │
-//   │              FinishRun (writes terminal status)                 │
-//   │                          │                                     │
-//   │                          ▼                                     │
-//   │              Deregister(agentID)  ← `defer` so even panics      │
-//   │                                     deregister cleanly         │
-//   └────────────────────────────────────────────────────────────────┘
+//	┌────────────────────────────────────────────────────────────────┐
+//	│ HTTP req in →  Server creates session+run → Register(agentID)  │
+//	│                          │                                     │
+//	│                          ▼                                     │
+//	│              ┌─ loop.Run(runCtx) ──────────────┐                │
+//	│              │  (subloops inherit runCtx —     │                │
+//	│              │   parent cancel cascades)       │                │
+//	│              └─────────────────────────────────┘                │
+//	│                          │                                     │
+//	│                          ▼                                     │
+//	│              FinishRun (writes terminal status)                 │
+//	│                          │                                     │
+//	│                          ▼                                     │
+//	│              Deregister(agentID)  ← `defer` so even panics      │
+//	│                                     deregister cleanly         │
+//	└────────────────────────────────────────────────────────────────┘
 //
 // Cancel from a separate request:
 //
-//   POST /v1/agents/<id>/cancel
-//   ↓
-//   Registry.Cancel("a_id", "user_clicked_stop")
-//   ↓
-//   1. cancelFn(ErrCancelledByAPI) — runCtx becomes cancelled with cause
-//   2. Walk children: each direct child's cancelFn fires too
-//      (recursively descends because each child's cancelFn ALSO triggers
-//      ITS subtree's ctx cascade)
-//   3. Loop iterations exit on next ctx check; FinishRun sees the cause
-//      and writes RunCancelled (rather than RunFailed) via the cause-
-//      aware logic in server.finishRun.
+//	POST /v1/agents/<id>/cancel
+//	↓
+//	Registry.Cancel("a_id", "user_clicked_stop")
+//	↓
+//	1. cancelFn(ErrCancelledByAPI) — runCtx becomes cancelled with cause
+//	2. Walk children: each direct child's cancelFn fires too
+//	   (recursively descends because each child's cancelFn ALSO triggers
+//	   ITS subtree's ctx cascade)
+//	3. Loop iterations exit on next ctx check; FinishRun sees the cause
+//	   and writes RunCancelled (rather than RunFailed) via the cause-
+//	   aware logic in server.finishRun.
 package cancel
 
 import (

--- a/internal/cli/migrate_sqlite.go
+++ b/internal/cli/migrate_sqlite.go
@@ -213,12 +213,12 @@ func copyRuns(ctx context.Context, src *sql.DB, dst *pgxpool.Pool, stdout io.Wri
 	count := 0
 	for rows.Next() {
 		var (
-			id, sessionID, status                                    string
-			startedAtNs                                              int64
-			completedAtNs, lastHeartbeatAtNs                         *int64
-			stopReason, model, errMsg                                *string
+			id, sessionID, status                                     string
+			startedAtNs                                               int64
+			completedAtNs, lastHeartbeatAtNs                          *int64
+			stopReason, model, errMsg                                 *string
 			inputTokens, outputTokens, cacheCreationTokens, cacheRead int64
-			agentID, parentAgentID, parentRunID, userID              *string
+			agentID, parentAgentID, parentRunID, userID               *string
 		)
 		if err := rows.Scan(
 			&id, &sessionID, &status, &startedAtNs, &completedAtNs, &stopReason,
@@ -284,11 +284,11 @@ func copyEvents(ctx context.Context, src *sql.DB, dst *pgxpool.Pool, stdout io.W
 	defer rows.Close()
 
 	type ev struct {
-		seq                  int64
-		sessionID, runID     string
-		ts                   time.Time
-		typ                  string
-		payload              []byte
+		seq              int64
+		sessionID, runID string
+		ts               time.Time
+		typ              string
+		payload          []byte
 	}
 	batch := make([]ev, 0, batchSize)
 	count := 0
@@ -444,9 +444,9 @@ func digestSqliteTranscript(ctx context.Context, db *sql.DB, sessionID string) (
 	h := sha256.New()
 	for rows.Next() {
 		var (
-			seq          int64
-			runID, typ   string
-			payload      []byte
+			seq        int64
+			runID, typ string
+			payload    []byte
 		)
 		if err := rows.Scan(&seq, &runID, &typ, &payload); err != nil {
 			return "", err
@@ -490,6 +490,9 @@ type stringWriter struct {
 	buf []byte
 }
 
-func (w *stringWriter) Write(p []byte) (int, error)        { w.buf = append(w.buf, p...); return len(p), nil }
-func (w *stringWriter) WriteString(s string) (int, error)  { w.buf = append(w.buf, s...); return len(s), nil }
-func (w *stringWriter) String() string                     { return string(w.buf) }
+func (w *stringWriter) Write(p []byte) (int, error) { w.buf = append(w.buf, p...); return len(p), nil }
+func (w *stringWriter) WriteString(s string) (int, error) {
+	w.buf = append(w.buf, s...)
+	return len(s), nil
+}
+func (w *stringWriter) String() string { return string(w.buf) }

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -19,8 +19,8 @@ type fakeProvider struct {
 	calls     []providers.Request
 }
 
-func (f *fakeProvider) ID() string                            { return "fake" }
-func (f *fakeProvider) Probe(_ context.Context) error          { return nil }
+func (f *fakeProvider) ID() string                    { return "fake" }
+func (f *fakeProvider) Probe(_ context.Context) error { return nil }
 func (f *fakeProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"fake-model"}, nil
 }
@@ -323,8 +323,8 @@ type erroringProvider struct {
 	err error
 }
 
-func (e *erroringProvider) ID() string                            { return "erroring" }
-func (e *erroringProvider) Probe(_ context.Context) error          { return nil }
+func (e *erroringProvider) ID() string                    { return "erroring" }
+func (e *erroringProvider) Probe(_ context.Context) error { return nil }
 func (e *erroringProvider) ListModels(_ context.Context) ([]string, error) {
 	return []string{"fake-model"}, nil
 }

--- a/internal/providers/ollama/tool_text_recovery_test.go
+++ b/internal/providers/ollama/tool_text_recovery_test.go
@@ -208,7 +208,7 @@ func TestToolTextRecovery_DisabledWhenNoToolsRequested(t *testing.T) {
 
 	d := New(srv.URL, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
-		Model:    "qwen3:14b",
+		Model: "qwen3:14b",
 		// Tools intentionally empty — recovery must NOT fire.
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
 	})

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -4,14 +4,14 @@
 //
 // Wire model (Approach A in doc-internal/skills-design.md):
 //
-//   1. Operator points LOOMCYCLE_SKILLS_ROOT at a directory containing
-//      one subdirectory per skill, each with a SKILL.md file.
-//   2. Each agent's YAML lists `skills: [name1, name2]`. At config-load,
-//      the named skill bodies are concatenated onto the agent's
-//      system_prompt.
-//   3. The bundled body lands inside the cacheable system block at the
-//      provider layer, so subsequent runs replay the skill at
-//      cache-read rates.
+//  1. Operator points LOOMCYCLE_SKILLS_ROOT at a directory containing
+//     one subdirectory per skill, each with a SKILL.md file.
+//  2. Each agent's YAML lists `skills: [name1, name2]`. At config-load,
+//     the named skill bodies are concatenated onto the agent's
+//     system_prompt.
+//  3. The bundled body lands inside the cacheable system block at the
+//     provider layer, so subsequent runs replay the skill at
+//     cache-read rates.
 //
 // Approach A trades cache effectiveness for static behaviour: the
 // bundled set is fixed at config-load. Dynamic discovery (Approach B —

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -147,8 +147,8 @@ func (s *Store) CreateSession(ctx context.Context, tenantID, agent, userID strin
 // GetSession returns the row by ID or *store.ErrNotFound.
 func (s *Store) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
 	var (
-		out      store.Session
-		userID   *string
+		out       store.Session
+		userID    *string
 		createdAt time.Time
 	)
 	row := s.pool.QueryRow(ctx,
@@ -451,14 +451,14 @@ func scanRun(r rowScanner) (store.Run, error) {
 	var (
 		out store.Run
 
-		started time.Time
-		completed *time.Time
+		started    time.Time
+		completed  *time.Time
 		stopReason *string
-		model *string
-		errMsg *string
+		model      *string
+		errMsg     *string
 
 		agentID, parentAgentID, parentRunID, userID *string
-		lastHeartbeatAt *time.Time
+		lastHeartbeatAt                             *time.Time
 
 		statusStr string
 	)

--- a/internal/store/storetest/bench.go
+++ b/internal/store/storetest/bench.go
@@ -97,9 +97,9 @@ func RunConcurrencyBench(tb testing.TB, s store.Store, cfg BenchmarkConfig) Benc
 	var latMu sync.Mutex
 
 	var (
-		wg            sync.WaitGroup
-		errCount      atomic.Uint64
-		eventsTotal   atomic.Uint64
+		wg          sync.WaitGroup
+		errCount    atomic.Uint64
+		eventsTotal atomic.Uint64
 	)
 	wg.Add(cfg.Concurrency)
 	wallStart := time.Now()

--- a/internal/tools/localapi/spec.go
+++ b/internal/tools/localapi/spec.go
@@ -46,11 +46,11 @@ import (
 // Spec is the parsed subset of an OpenAPI 3.0 document. Fields not
 // listed here are ignored.
 type Spec struct {
-	OpenAPI    string                  `yaml:"openapi"`
-	Info       infoBlock               `yaml:"info"`
-	Paths      map[string]pathItem     `yaml:"paths"`
-	Components componentsBlock         `yaml:"components"`
-	rawBytes   []byte                  // kept for diagnostics
+	OpenAPI    string              `yaml:"openapi"`
+	Info       infoBlock           `yaml:"info"`
+	Paths      map[string]pathItem `yaml:"paths"`
+	Components componentsBlock     `yaml:"components"`
+	rawBytes   []byte              // kept for diagnostics
 }
 
 type infoBlock struct {
@@ -74,17 +74,17 @@ type pathItem struct {
 // are kept as `*yaml.Node` so we can re-serialise them as JSON Schema
 // without deep-parsing every type variant the OpenAPI spec allows.
 type operation struct {
-	OperationID string             `yaml:"operationId"`
-	Summary     string             `yaml:"summary"`
-	Description string             `yaml:"description"`
-	Parameters  []parameter        `yaml:"parameters"`
-	RequestBody *requestBody       `yaml:"requestBody"`
-	Tags        []string           `yaml:"tags"`
+	OperationID string       `yaml:"operationId"`
+	Summary     string       `yaml:"summary"`
+	Description string       `yaml:"description"`
+	Parameters  []parameter  `yaml:"parameters"`
+	RequestBody *requestBody `yaml:"requestBody"`
+	Tags        []string     `yaml:"tags"`
 }
 
 type parameter struct {
 	Name        string     `yaml:"name"`
-	In          string     `yaml:"in"`         // "path" | "query" | "header" | "cookie"
+	In          string     `yaml:"in"` // "path" | "query" | "header" | "cookie"
 	Description string     `yaml:"description"`
 	Required    bool       `yaml:"required"`
 	Schema      *yaml.Node `yaml:"schema"`
@@ -146,9 +146,9 @@ func LoadSpec(specPath, configDir string) (*Spec, error) {
 // become a tool. Builders walk the spec via Endpoints() and call
 // BuildTool for each.
 type Endpoint struct {
-	Path       string
-	Method     string // "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
-	Operation  *operation
+	Path      string
+	Method    string // "GET" | "POST" | "PUT" | "PATCH" | "DELETE"
+	Operation *operation
 }
 
 // Endpoints flattens the Spec into a list of (path, method, operation)

--- a/internal/tools/localapi/tool.go
+++ b/internal/tools/localapi/tool.go
@@ -44,15 +44,15 @@ import (
 //     Execute (rare; surfaces as the loop's tool_result with the
 //     wrapper text).
 type EndpointTool struct {
-	ToolName    string                  // "<prefix>__<operationId>"
-	BaseURL     string                  // e.g. "http://localhost:3000"
-	Path        string                  // e.g. "/api/applications/{id}"
-	Method      string                  // "GET" | "POST" | ...
-	OpSummary   string
+	ToolName      string // "<prefix>__<operationId>"
+	BaseURL       string // e.g. "http://localhost:3000"
+	Path          string // e.g. "/api/applications/{id}"
+	Method        string // "GET" | "POST" | ...
+	OpSummary     string
 	OpDescription string
-	Parameters  []parameter
-	HasBody     bool
-	BodySchema  *yaml.Node // raw JSON Schema (passed through to model)
+	Parameters    []parameter
+	HasBody       bool
+	BodySchema    *yaml.Node // raw JSON Schema (passed through to model)
 
 	HTTPClient *http.Client // optional; defaults to http.DefaultClient
 }

--- a/internal/tools/mcp/http/client_test.go
+++ b/internal/tools/mcp/http/client_test.go
@@ -285,8 +285,9 @@ func TestHeadersForwarded(t *testing.T) {
 //
 // Regression for the 2026-05-07 jobs-search-agent /api/mcp decode
 // failure:
-//   mcp http: decode response: invalid character 'e' looking for
-//   beginning of value (body: event: message\ndata: {...})
+//
+//	mcp http: decode response: invalid character 'e' looking for
+//	beginning of value (body: event: message\ndata: {...})
 func TestSSEResponseDecoded(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var probe struct {


### PR DESCRIPTION
## Why

CI's gofmt step has been rejecting every PR for some time because 15 files on \`main\` carry the pre-Go-1.19 indented-doc-comment style (\`//   text\`) that gofmt now normalises to tab-indented (\`//\\ttext\`).

## What

Ran \`gofmt -w .\` on the whole tree. Pure whitespace deltas — no behaviour change, no semantic edits, no identifier renames. Verified \`gofmt -l .\` is empty after the commit, and the full test suite (\`go test ./...\` and \`go test -race ./...\`) stays green.

Unblocks CI for #28, #29, #30 and any future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)