### PR TITLE
fix(config): allow "gemini" in provider_priority and tier candidates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -824,6 +824,7 @@ var validProviderIDs = map[string]bool{
 	"openai":    true,
 	"deepseek":  true,
 	"ollama":    true,
+	"gemini":    true,
 }
 
 // validTierNames is the closed set of tier names. Operators choose
@@ -856,7 +857,7 @@ func validate(c *Config) error {
 	// to its hardcoded default order).
 	for i, p := range c.ProviderPriority {
 		if !validProviderIDs[p] {
-			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/ollama)", i, p)
+			return fmt.Errorf("provider_priority[%d]: unknown provider %q (want one of anthropic/openai/deepseek/gemini/ollama)", i, p)
 		}
 	}
 	// Library-level tier definitions.


### PR DESCRIPTION
PR #37 added the Gemini driver but missed the validation set in \`internal/config/config.go\`. Operators with \`gemini\` in their \`loomcycle.yaml\` (per the v0.7.2 release docs) see startup fail with:

\`\`\`
config: provider_priority[1]: unknown provider \"gemini\"
(want one of anthropic/openai/deepseek/ollama)
\`\`\`

Two-line fix: add \`gemini\` to \`validProviderIDs\`, update the error message.

Verified \`go test -race ./...\` clean. \`loomcycle validate\` against a sample.yaml carrying \`provider: gemini\` rows now passes the provider-priority check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)