### PR TITLE
feat(ui): user picker — replace freeform user_id with a dropdown

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -540,6 +540,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("DELETE /v1/hooks/{id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDeleteHook))))
 	// v0.7.x resolver introspection — operator-only debug surface.
 	mux.Handle("GET /v1/_resolver", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResolverSnapshot))))
+	// v0.7.3+ user picker — admin-style endpoint surfacing distinct
+	// user_ids that have runs in the store. Bearer-authed; drives
+	// the Web UI's run-list user dropdown.
+	mux.Handle("GET /v1/_users", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUsers))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the

--- a/internal/api/http/users.go
+++ b/internal/api/http/users.go
@@ -1,0 +1,58 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// listUsersResponse is the wire shape of GET /v1/_users.
+type listUsersResponse struct {
+	Users []wireUserSummary `json:"users"`
+}
+
+type wireUserSummary struct {
+	UserID        string    `json:"user_id"`
+	RunningCount  int       `json:"running_count"`
+	TotalCount    int       `json:"total_count"`
+	LastStartedAt time.Time `json:"last_started_at"`
+}
+
+// handleListUsers serves GET /v1/_users — distinct user_ids with
+// summary stats. Drives the Web UI's user picker so operators can
+// see who has active runs without typing UUIDs.
+//
+// Returns 503 with `store_unavailable` when the server boots without
+// a store (test harnesses; Memory-only configs). The empty case (no
+// runs yet) returns 200 with an empty users array — the UI renders
+// "no users yet" rather than treating empty as an error.
+func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; user listing requires a persistent store")
+		return
+	}
+	users, err := s.store.ListUsers(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	resp := listUsersResponse{Users: make([]wireUserSummary, 0, len(users))}
+	for _, u := range users {
+		resp.Users = append(resp.Users, toWireUser(u))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func toWireUser(u store.UserSummary) wireUserSummary {
+	return wireUserSummary{
+		UserID:        u.UserID,
+		RunningCount:  u.RunningCount,
+		TotalCount:    u.TotalCount,
+		LastStartedAt: u.LastStartedAt,
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -319,6 +319,36 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 	return r, nil
 }
 
+// ListUsers returns one row per distinct user_id with summary stats.
+// Drives the v0.7.3 Web UI user picker. Mirrors the SQLite shape so
+// behaviour is identical across backends.
+func (s *Store) ListUsers(ctx context.Context) ([]store.UserSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			user_id,
+			COUNT(*) FILTER (WHERE status = 'running') AS running_count,
+			COUNT(*) AS total_count,
+			MAX(started_at) AS last_started_at
+		FROM runs
+		WHERE user_id IS NOT NULL AND user_id != ''
+		GROUP BY user_id
+		ORDER BY last_started_at DESC
+		LIMIT 200`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.UserSummary
+	for rows.Next() {
+		var u store.UserSummary
+		if err := rows.Scan(&u.UserID, &u.RunningCount, &u.TotalCount, &u.LastStartedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
 // ListActiveRunsByUser returns up to 100 runs for the user, ordered by
 // started_at DESC. Empty status returns all statuses; non-empty filters
 // to the exact status string. Empty userID short-circuits to no rows.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -377,6 +377,40 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 	return r, err
 }
 
+// ListUsers returns one row per distinct user_id with summary stats.
+// Drives the v0.7.3 Web UI user picker.
+//
+// SQLite COUNT(CASE WHEN ...) is the conventional shape for grouped
+// counts by category; both backends produce identical row sets.
+func (s *Store) ListUsers(ctx context.Context) ([]store.UserSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			user_id,
+			COUNT(CASE WHEN status = 'running' THEN 1 END) AS running_count,
+			COUNT(*) AS total_count,
+			MAX(started_at) AS last_started_at
+		FROM runs
+		WHERE user_id IS NOT NULL AND user_id != ''
+		GROUP BY user_id
+		ORDER BY last_started_at DESC
+		LIMIT 200`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.UserSummary
+	for rows.Next() {
+		var u store.UserSummary
+		var lastNanos int64
+		if err := rows.Scan(&u.UserID, &u.RunningCount, &u.TotalCount, &lastNanos); err != nil {
+			return nil, err
+		}
+		u.LastStartedAt = time.Unix(0, lastNanos).UTC()
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
 // ListActiveRunsByUser returns runs for userID whose status matches the
 // supplied filter. An empty status returns ALL statuses. Capped at 100
 // rows ordered by started_at DESC.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -128,6 +128,20 @@ type RunIdentity struct {
 	UserID string
 }
 
+// UserSummary is one row of ListUsers' output: distinct user_id with
+// summary stats. Drives the Web UI's user picker so operators can see
+// who has active runs and pick from a list rather than typing a UUID.
+//
+// `LastStartedAt` is the most recent run start (any status) — useful
+// for sorting by activity. `RunningCount` is the in-flight count
+// (status=="running"); `TotalCount` includes everything ever.
+type UserSummary struct {
+	UserID        string    `json:"user_id"`
+	RunningCount  int       `json:"running_count"`
+	TotalCount    int       `json:"total_count"`
+	LastStartedAt time.Time `json:"last_started_at"`
+}
+
 // Store is the persistence backend. SQLite is the default; Postgres / Redis
 // adapters slot in behind this interface in v0.4.
 //
@@ -177,6 +191,17 @@ type Store interface {
 	// ListRunsByParentAgentID returns the runs whose parent_agent_id
 	// matches the given value. Drives cascade-cancel discovery.
 	ListRunsByParentAgentID(ctx context.Context, parentAgentID string) ([]Run, error)
+
+	// ListUsers returns the distinct user_ids that have runs in the
+	// store, with summary stats per user (run counts by status, last
+	// activity). Drives the v0.7.3 Web UI's user picker so operators
+	// don't have to type a UUID. Excludes runs with empty user_id
+	// (the default for callers that don't supply identity).
+	//
+	// Capped at 200 users ordered by last_started_at DESC. A bigger
+	// list would be a UX problem anyway — the UI then needs filtering
+	// rather than dropdown.
+	ListUsers(ctx context.Context) ([]UserSummary, error)
 
 	// UpdateHeartbeat sets last_heartbeat_at on a run to the current
 	// time. Called by the loop at each iteration. No-op if the run

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -56,6 +56,7 @@ func Run(t *testing.T, factory Factory) {
 		{"GetRunByAgentIDNotFound", testGetRunByAgentIDNotFound},
 		{"GetRunByAgentIDReturnsMostRecent", testGetRunByAgentIDReturnsMostRecent},
 		{"ListActiveRunsByUser", testListActiveRunsByUser},
+		{"ListUsers", testListUsers},
 		{"ListRunsByParentAgentID", testListRunsByParentAgentID},
 		{"UpdateHeartbeat", testUpdateHeartbeat},
 		{"FinishRunCancelledTerminal", testFinishRunCancelledTerminal},
@@ -334,6 +335,65 @@ func testListActiveRunsByUser(t *testing.T, s store.Store) {
 
 	if got, _ := s.ListActiveRunsByUser(ctx, "", store.RunRunning); len(got) != 0 {
 		t.Errorf("empty userID should return no rows, got %d", len(got))
+	}
+}
+
+func testListUsers(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sessAlice, _ := s.CreateSession(ctx, "t", "a", "alice")
+	sessBob, _ := s.CreateSession(ctx, "t", "a", "bob")
+
+	// alice: 2 runs, 1 still running.
+	rA1, _ := s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice1", UserID: "alice"})
+	_, _ = s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice2", UserID: "alice"})
+	_ = s.FinishRun(ctx, rA1.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	// bob: 1 run, completed.
+	rB1, _ := s.CreateRun(ctx, sessBob.ID, store.RunIdentity{AgentID: "a_bob1", UserID: "bob"})
+	_ = s.FinishRun(ctx, rB1.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	// Empty-userID run should NOT show up in the listing — filtered
+	// by the WHERE user_id != '' clause.
+	sessAnon, _ := s.CreateSession(ctx, "t", "a", "")
+	_, _ = s.CreateRun(ctx, sessAnon.ID, store.RunIdentity{AgentID: "a_anon", UserID: ""})
+
+	users, err := s.ListUsers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Order: most-recent activity first. Last run was bob's
+	// (CreateRun ordering), then alice's. But CreateRun timestamps
+	// are nanosecond-resolution and assigned in order — bob is later
+	// than alice.
+	wantIDs := map[string]struct {
+		running int
+		total   int
+	}{
+		"alice": {running: 1, total: 2},
+		"bob":   {running: 0, total: 1},
+	}
+	if len(users) != len(wantIDs) {
+		ids := make([]string, len(users))
+		for i, u := range users {
+			ids[i] = u.UserID
+		}
+		t.Fatalf("ListUsers returned %d users, want %d (got %v)", len(users), len(wantIDs), ids)
+	}
+	for _, u := range users {
+		want, ok := wantIDs[u.UserID]
+		if !ok {
+			t.Errorf("unexpected user_id in result: %q", u.UserID)
+			continue
+		}
+		if u.RunningCount != want.running {
+			t.Errorf("%s.running = %d, want %d", u.UserID, u.RunningCount, want.running)
+		}
+		if u.TotalCount != want.total {
+			t.Errorf("%s.total = %d, want %d", u.UserID, u.TotalCount, want.total)
+		}
+		if u.LastStartedAt.IsZero() {
+			t.Errorf("%s.last_started_at is zero; should reflect a real timestamp", u.UserID)
+		}
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -3,6 +3,21 @@
 // operator visits `/ui?token=...` — fetch() includes it
 // automatically because we're same-origin. No bearer header needed.
 
+export interface UserSummary {
+  user_id: string;
+  running_count: number;
+  total_count: number;
+  last_started_at: string;
+}
+
+export interface ListUsersResponse {
+  users: UserSummary[];
+}
+
+export function listUsers(): Promise<ListUsersResponse> {
+  return jsonFetch<ListUsersResponse>("/v1/_users");
+}
+
 export interface Agent {
   agent_id: string;
   run_id: string;

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,19 +1,52 @@
 import { useEffect, useState } from "react";
-import { Link, Outlet } from "react-router-dom";
+import { Link, Outlet, useOutletContext } from "react-router-dom";
+import { UserSummary, listUsers } from "../api";
 
 const USER_ID_KEY = "loomcycle.userId";
+// Refresh the user picker every 30 s. Activity stats (running counts)
+// drift fast on busy deployments; the dropdown is rendered with the
+// most recent counts each time it opens.
+const REFRESH_MS = 30_000;
 
 export default function Layout() {
-  // user_id is required for the run-list query; we store it in
-  // localStorage so the operator doesn't have to retype it on every
-  // navigation. The bearer token is in the HttpOnly cookie set by
-  // the server's ?token=... redirect; we don't manage it here.
+  // user_id is the gating context for the run-list query. Persisted in
+  // localStorage so the operator doesn't have to re-pick on every
+  // navigation. The bearer token is in the HttpOnly cookie set by the
+  // server's ?token=... redirect; we don't manage it here.
   const [userId, setUserId] = useState<string>(() => localStorage.getItem(USER_ID_KEY) ?? "");
+  const [users, setUsers] = useState<UserSummary[]>([]);
+  const [usersErr, setUsersErr] = useState<string | null>(null);
+  const [showManual, setShowManual] = useState(false);
   const [draft, setDraft] = useState(userId);
 
   useEffect(() => {
     localStorage.setItem(USER_ID_KEY, userId);
   }, [userId]);
+
+  // Poll /v1/_users so the dropdown reflects who has active runs in
+  // near-real-time. Server response is bounded (LIMIT 200) and fast.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const resp = await listUsers();
+        if (!cancelled) {
+          setUsers(resp.users ?? []);
+          setUsersErr(null);
+        }
+      } catch (e) {
+        if (!cancelled) setUsersErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchOnce();
+    const t = setInterval(fetchOnce, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const knownUser = users.find((u) => u.user_id === userId);
 
   return (
     <div className="layout">
@@ -22,25 +55,58 @@ export default function Layout() {
           <Link to="/">loomcycle</Link>
           <span className="version">v0.7.3</span>
         </div>
-        <form
-          className="user-input"
-          onSubmit={(e) => {
-            e.preventDefault();
-            setUserId(draft.trim());
-          }}
-        >
-          <label htmlFor="user_id">user_id</label>
-          <input
-            id="user_id"
-            type="text"
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="paste a user_id…"
-          />
-          <button type="submit" disabled={draft.trim() === userId}>
-            apply
-          </button>
-        </form>
+        <div className="user-picker">
+          {usersErr && <span className="picker-err" title={usersErr}>users unavailable</span>}
+          {!showManual && (
+            <>
+              <label htmlFor="user_select">user</label>
+              <select
+                id="user_select"
+                value={knownUser ? userId : ""}
+                onChange={(e) => setUserId(e.target.value)}
+              >
+                <option value="">— pick a user —</option>
+                {users.map((u) => (
+                  <option key={u.user_id} value={u.user_id}>
+                    {u.user_id} · {u.running_count > 0 ? `${u.running_count} running` : `${u.total_count} runs`}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="manual-btn"
+                title="Type a user_id manually (e.g. for users with no runs yet)"
+                onClick={() => {
+                  setDraft(userId);
+                  setShowManual(true);
+                }}
+              >
+                ✎
+              </button>
+            </>
+          )}
+          {showManual && (
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                setUserId(draft.trim());
+                setShowManual(false);
+              }}
+            >
+              <input
+                type="text"
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="paste a user_id…"
+                autoFocus
+              />
+              <button type="submit">apply</button>
+              <button type="button" onClick={() => setShowManual(false)}>
+                cancel
+              </button>
+            </form>
+          )}
+        </div>
       </header>
       <main className="content">
         <Outlet context={{ userId }} />
@@ -50,7 +116,6 @@ export default function Layout() {
 }
 
 // Small helper: child routes import this to read userId.
-import { useOutletContext } from "react-router-dom";
 export function useUserId(): string {
   const ctx = useOutletContext<{ userId: string }>();
   return ctx.userId;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -72,16 +72,17 @@ pre {
   font-size: 12px;
   font-family: var(--mono);
 }
-.user-input {
+.user-picker {
   display: flex;
   gap: 8px;
   align-items: center;
 }
-.user-input label {
+.user-picker label {
   color: var(--fg-soft);
   font-size: 12px;
 }
-.user-input input {
+.user-picker select,
+.user-picker input {
   background: var(--bg);
   color: var(--fg);
   border: 1px solid var(--border);
@@ -89,9 +90,14 @@ pre {
   padding: 4px 8px;
   font-family: var(--mono);
   font-size: 13px;
-  width: 280px;
+  min-width: 280px;
 }
-.user-input button {
+.user-picker form {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.user-picker button {
   background: var(--accent);
   color: white;
   border: none;
@@ -99,10 +105,21 @@ pre {
   padding: 5px 12px;
   cursor: pointer;
 }
-.user-input button:disabled {
-  background: var(--border);
+.user-picker button.manual-btn {
+  background: transparent;
   color: var(--fg-soft);
-  cursor: not-allowed;
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.user-picker button.manual-btn:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}
+.picker-err {
+  color: var(--failed);
+  font-size: 11px;
+  font-style: italic;
 }
 
 .content {


### PR DESCRIPTION
v0.7.3 UI shipped with a manual user_id input — operators had to know the UUID and paste it. Real UX gap (operator question this morning: \"how do I know which user_id is currently running agents?\"). Fixes that.

## What

- **New store method \`ListUsers(ctx)\`** — returns distinct user_ids with summary stats (\`running_count\` / \`total_count\` / \`last_started_at\`). SQLite + Postgres impls; \`storetest\` contract gains a coverage test exercising multi-user / running-vs-finished / empty-userID-filter behaviour.
- **New HTTP endpoint \`GET /v1/_users\`** — bearer-authed admin surface mirroring \`/v1/_resolver\`'s shape. 503 with \`store_unavailable\` when the server boots without a store; 200 with empty \`users[]\` when the store has no runs yet.
- **Web UI** swaps the freeform input for a \`<select>\` populated from the new endpoint. Each option shows \`user_id · N running\` or \`user_id · M runs\` so the picker doubles as a quick activity view. Refreshes every 30 s.
- **Manual override** (the ✎ button) preserves the old type-it-in flow for picking a user_id that has no runs yet.

## Tests

- \`storetest/contract.go\` — \`testListUsers\` (multi-user, mixed running/finished, empty-userID filtering, count accuracy)
- \`go test -race ./...\` clean

## Out of scope

- TS adapter wrapper for \`/v1/_users\` — UI-only surface for now; the adapter gains it when an SDK consumer asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)