### PR TITLE
fix(ui): wire transcript event payloads + collapse-expand event panels

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -41,7 +41,11 @@ export interface ListAgentsResponse {
   agents: Agent[];
 }
 
-export interface TranscriptEvent {
+// EventPayload mirrors providers.Event on the server side. Carried
+// inside `TranscriptEvent.event` (the wire shape from
+// /v1/sessions/{id}/transcript wraps each row with seq/run_id/ts_ns
+// plus the embedded event).
+export interface EventPayload {
   type: string;
   text?: string;
   tool_use?: { id: string; name: string; input: unknown };
@@ -57,19 +61,29 @@ export interface TranscriptEvent {
     model?: string;
   };
   error?: string;
-  // Loomcycle stamps event arrival as event_id + created_at on the
-  // wire when the consumer asks for replay. For live streams these
-  // can be absent; treat as optional in the UI.
-  event_id?: string;
-  created_at?: string;
+  retry?: { provider?: string; attempt?: number; wait_ms?: number; reason?: string };
+}
+
+// TranscriptEvent is one persisted row from
+// /v1/sessions/{id}/transcript. The server wraps each providers.Event
+// in {seq, run_id, ts_ns, type, event:{...}} — the type field at the
+// top level mirrors event.type so consumers can filter without
+// digging into the payload, but the actual content lives under
+// `event`.
+export interface TranscriptEvent {
+  seq: number;
+  run_id: string;
+  ts_ns: number;
+  type: string;
+  event: EventPayload;
 }
 
 export interface TranscriptResponse {
   session: {
     id: string;
     user_id: string;
-    agent_type: string;
-    started_at: string;
+    agent: string;
+    created_at: string;
   };
   events: TranscriptEvent[];
 }

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link, useParams } from "react-router-dom";
-import { Agent, TranscriptEvent, cancelAgent, getAgent, getTranscript } from "../api";
+import { Agent, EventPayload, TranscriptEvent, cancelAgent, getAgent, getTranscript } from "../api";
 
 // Auto-refresh cadence for live runs. Static runs (completed /
 // failed / cancelled) skip polling.
@@ -33,7 +33,6 @@ export default function AgentDetail() {
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
       } finally {
-        // Schedule next fetch only when status is still running.
         if (!cancelled) {
           if (agent?.status === "running" || agent === null) {
             timer = window.setTimeout(fetchOnce, REFRESH_MS);
@@ -115,8 +114,8 @@ export default function AgentDetail() {
         <div className="empty">loading…</div>
       )}
       <div className="events">
-        {renderedEvents.map((ev, i) => (
-          <EventCard key={i} ev={ev} />
+        {renderedEvents.map((ev) => (
+          <EventCard key={ev.seq} row={ev} />
         ))}
         <div ref={tailRef} />
       </div>
@@ -125,71 +124,180 @@ export default function AgentDetail() {
 }
 
 // visible filters out events that are noise on the operator dashboard
-// (started — purely a marker; usage — folded into the header).
+// (started — purely a marker; usage — folded into the header;
+// session/agent — side-channel ID announcements; user_input — the
+// initial prompt, separately rendered in v0.8).
 function visible(ev: TranscriptEvent): boolean {
-  return ev.type !== "started" && ev.type !== "usage" && ev.type !== "session" && ev.type !== "agent";
+  const t = ev.event?.type ?? ev.type;
+  return t !== "started" && t !== "usage" && t !== "session" && t !== "agent" && t !== "user_input";
 }
 
-function EventCard({ ev }: { ev: TranscriptEvent }) {
+// EventCard renders one transcript row as a collapsed panel by
+// default — first-line summary + a "▶" affordance — that expands on
+// click to show the full text / inputs / outputs / tool params.
+// Operators scrolling a long transcript see the shape of the run
+// without a wall of text; clicking dives into a specific event.
+function EventCard({ row }: { row: TranscriptEvent }) {
+  const [open, setOpen] = useState(false);
+  const ev = row.event ?? ({ type: row.type } as EventPayload);
+  const kind = ev.type ?? row.type;
+
+  const summary = summaryFor(ev);
+  const detail = detailFor(ev);
+
+  const toggle = () => setOpen((v) => !v);
+
+  return (
+    <div
+      className={`ev ev-${kind} ${ev.is_error ? "err" : ""} ${open ? "open" : ""}`}
+      onClick={toggle}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggle();
+        }
+      }}
+    >
+      <div className="ev-header">
+        <span className="caret">{open ? "▼" : "▶"}</span>
+        <span className="kind">{labelFor(ev)}</span>
+        {!open && <span className="summary">{summary}</span>}
+        {row.ts_ns > 0 && <span className="ts">{formatTime(row.ts_ns)}</span>}
+      </div>
+      {open && <div className="ev-detail">{detail}</div>}
+    </div>
+  );
+}
+
+// labelFor is the small uppercase tag on the left side of each card.
+// Tool calls embed the tool name to reduce the click-to-discover
+// distance for "what tool was this".
+function labelFor(ev: EventPayload): string {
+  switch (ev.type) {
+    case "tool_call":
+      return `tool_call · ${ev.tool_use?.name ?? "?"}`;
+    case "tool_result":
+      return ev.is_error ? "tool_result · error" : "tool_result";
+    case "done":
+      return `done · ${ev.stop_reason ?? "?"}`;
+    case "retry":
+      return `retry · ${ev.retry?.reason ?? ""}`.trim();
+    default:
+      return ev.type ?? "?";
+  }
+}
+
+// summaryFor is the one-line preview shown when the card is
+// collapsed. Keeps the transcript scannable; full content opens on
+// click.
+function summaryFor(ev: EventPayload): string {
   switch (ev.type) {
     case "text":
-      return (
-        <div className="ev ev-text">
-          <span className="kind">text</span>
-          <pre>{ev.text}</pre>
-        </div>
-      );
     case "thinking":
-      return (
-        <div className="ev ev-thinking">
-          <span className="kind">thinking</span>
-          <pre>{ev.text}</pre>
-        </div>
-      );
+      return firstLine(ev.text ?? "", 200);
+    case "tool_call": {
+      const args = ev.tool_use?.input;
+      if (!args) return "(no args)";
+      const json = typeof args === "string" ? args : JSON.stringify(args);
+      return firstLine(json, 200);
+    }
+    case "tool_result":
+      return firstLine(ev.text ?? "", 200);
+    case "error":
+      return firstLine(ev.error ?? "", 200);
+    case "retry": {
+      const r = ev.retry ?? {};
+      return `${r.provider ?? "?"} attempt ${r.attempt ?? "?"} · wait ${r.wait_ms ?? "?"}ms`;
+    }
+    case "done":
+      return ev.usage
+        ? `${ev.usage.input_tokens ?? 0} in / ${ev.usage.output_tokens ?? 0} out${
+            ev.usage.model ? ` · ${ev.usage.model}` : ""
+          }`
+        : "";
+    default:
+      return "";
+  }
+}
+
+// detailFor is the full content shown when the card is expanded.
+// Returns React nodes so each event type can format its payload how
+// it wants (raw text, pretty-printed JSON, etc).
+function detailFor(ev: EventPayload): ReactNode {
+  switch (ev.type) {
+    case "text":
+    case "thinking":
+      return <pre className="full-text">{ev.text ?? ""}</pre>;
     case "tool_call":
       return (
-        <div className="ev ev-tool-call">
-          <span className="kind">tool_call</span>
-          <div className="tool">
-            <strong>{ev.tool_use?.name}</strong>
-            <pre>{ev.tool_use ? JSON.stringify(ev.tool_use.input, null, 2) : ""}</pre>
+        <div className="tool-detail">
+          <div className="tool-meta">
+            <span>name:</span> <code>{ev.tool_use?.name ?? "?"}</code>
+            {ev.tool_use?.id && (
+              <>
+                {" · "}
+                <span>id:</span> <code>{ev.tool_use.id}</code>
+              </>
+            )}
+          </div>
+          <div className="tool-params">
+            <span>input:</span>
+            <pre className="full-text">{prettyJSON(ev.tool_use?.input)}</pre>
           </div>
         </div>
       );
     case "tool_result":
-      return (
-        <div className={`ev ev-tool-result ${ev.is_error ? "err" : ""}`}>
-          <span className="kind">tool_result{ev.is_error ? " (error)" : ""}</span>
-          <pre>{ev.text}</pre>
-        </div>
-      );
+      return <pre className="full-text">{ev.text ?? ""}</pre>;
     case "error":
-      return (
-        <div className="ev ev-error">
-          <span className="kind">error</span>
-          <pre>{ev.error}</pre>
-        </div>
-      );
+      return <pre className="full-text">{ev.error ?? ""}</pre>;
     case "retry":
       return (
-        <div className="ev ev-retry">
-          <span className="kind">retry</span>
-          <pre>rate-limited; sleeping…</pre>
-        </div>
+        <pre className="full-text">
+          {JSON.stringify(ev.retry ?? {}, null, 2)}
+        </pre>
       );
     case "done":
       return (
-        <div className="ev ev-done">
-          <span className="kind">done</span>
-          <pre>stop_reason: {ev.stop_reason ?? "?"}</pre>
+        <div>
+          <div>stop_reason: {ev.stop_reason ?? "?"}</div>
+          {ev.reasoning && (
+            <div>
+              <strong>reasoning trace:</strong>
+              <pre className="full-text">{ev.reasoning}</pre>
+            </div>
+          )}
+          {ev.usage && (
+            <pre className="full-text">{JSON.stringify(ev.usage, null, 2)}</pre>
+          )}
         </div>
       );
     default:
-      return (
-        <div className="ev ev-unknown">
-          <span className="kind">{ev.type}</span>
-          <pre>{JSON.stringify(ev, null, 2)}</pre>
-        </div>
-      );
+      return <pre className="full-text">{JSON.stringify(ev, null, 2)}</pre>;
   }
+}
+
+function firstLine(s: string, max: number): string {
+  if (!s) return "";
+  const nl = s.indexOf("\n");
+  let line = nl >= 0 ? s.slice(0, nl) : s;
+  if (line.length > max) line = line.slice(0, max) + "…";
+  return line;
+}
+
+function prettyJSON(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+function formatTime(ns: number): string {
+  if (!ns) return "";
+  const ms = Math.floor(ns / 1_000_000);
+  return new Date(ms).toLocaleTimeString();
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -295,35 +295,101 @@ pre {
 .events {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 .ev {
   background: var(--bg-soft);
   border: 1px solid var(--border);
   border-left-width: 3px;
   border-radius: 3px;
-  padding: 8px 12px;
+  cursor: pointer;
+  transition: background 80ms ease;
 }
-.ev .kind {
-  display: inline-block;
-  font-size: 10px;
+.ev:hover {
+  background: var(--bg-soft-2);
+}
+.ev.open {
+  background: var(--bg-soft-2);
+}
+.ev-header {
+  display: grid;
+  grid-template-columns: 14px 180px 1fr 80px;
+  gap: 10px;
+  align-items: center;
+  padding: 6px 12px;
+}
+.ev-header .caret {
+  color: var(--fg-soft);
+  font-size: 9px;
+  user-select: none;
+}
+.ev-header .kind {
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.04em;
+  color: var(--fg-soft);
+  font-family: var(--mono);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.ev-header .summary {
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ev-header .ts {
+  color: var(--fg-soft);
+  font-size: 11px;
+  font-family: var(--mono);
+  text-align: right;
+}
+.ev-detail {
+  padding: 6px 12px 10px 36px;
+  border-top: 1px dashed var(--border);
+}
+.ev-detail .full-text {
+  margin: 4px 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 8px 10px;
+  font-family: var(--mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 600px;
+  overflow: auto;
+}
+.tool-detail .tool-meta {
+  font-family: var(--mono);
+  font-size: 12px;
   color: var(--fg-soft);
   margin-bottom: 4px;
+}
+.tool-detail .tool-meta code {
+  color: var(--fg);
+}
+.tool-detail .tool-params span {
   font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 .ev-text { border-left-color: #6b8caf; }
-.ev-thinking { border-left-color: #b08bd0; background: var(--bg-soft-2); }
-.ev-thinking pre { color: var(--fg-soft); font-style: italic; }
-.ev-tool-call { border-left-color: var(--accent); }
-.ev-tool-call .tool strong {
-  color: var(--accent);
-  font-family: var(--mono);
-}
-.ev-tool-result { border-left-color: var(--completed); }
-.ev-tool-result.err { border-left-color: var(--failed); }
+.ev-thinking { border-left-color: #b08bd0; }
+.ev-thinking .summary,
+.ev-thinking .full-text { color: var(--fg-soft); font-style: italic; }
+.ev-tool_call { border-left-color: var(--accent); }
+.ev-tool_call .kind { color: var(--accent); }
+.ev-tool_result { border-left-color: var(--completed); }
+.ev-tool_result.err { border-left-color: var(--failed); }
+.ev-tool_result.err .kind { color: var(--failed); }
 .ev-error { border-left-color: var(--failed); background: rgba(255, 93, 104, 0.05); }
+.ev-error .kind { color: var(--failed); }
 .ev-retry { border-left-color: var(--running); }
 .ev-done { border-left-color: var(--fg-soft); }
-.ev-unknown { border-left-color: var(--fg-soft); opacity: 0.7; }


### PR DESCRIPTION
Two fixes for the v0.7.3 agent-detail view, both flagged by operator question after running the UI against completed jobs-search-agent runs.

## 1. Empty cards (the bug)

The transcript endpoint wraps each persisted event as \`{seq, run_id, ts_ns, type, event:{...}}\` — the actual content (text, tool_use, etc.) lives under the nested \`event:\` field. The frontend was reading \`ev.text\` / \`ev.tool_use\` directly off the top level — all undefined — so cards rendered the type label and nothing else.

Fixed by introducing two types in \`api.ts\`: \`EventPayload\` (mirrors \`providers.Event\`) and \`TranscriptEvent\` (the wrapper row), and updating \`AgentDetail.tsx\` to read from \`row.event\` consistently.

## 2. Wall-of-text → collapsed-by-default panels (the feature)

Long completed runs produced screens of raw text. New collapse/expand pattern:

- **Default**: each event renders as a one-line summary card (first line of text truncated to 200 chars; tool name + args preview; usage tokens for \`done\`; etc.).
- **Click** (or Enter/Space — keyboard accessible) toggles to the full payload: pretty-printed JSON for \`tool_call\` inputs, full text for \`text\` / \`thinking\` / \`tool_result\`, the structured usage breakdown for \`done\`, etc.

Operators scrolling a long transcript see the SHAPE of the run — what tool was called, what came back — without scrolling through every line. Clicking dives into a specific event when they want the detail.

## Visual polish

- Tool calls show the tool name in the kind label (\`tool_call · search_web\`) so the operator doesn't have to expand to know which tool fired.
- Each card surfaces the wall-clock timestamp on the right (formatted from \`ts_ns\`).
- Errored tool_results flagged in the kind label (\`tool_result · error\`) and tinted red.
- Hover and open states have distinct background tints so the interactive affordance is obvious.

## Out of scope

- Rendering the seeded prompt as a regular event card (\`user_input\` type is filtered out today; can become a special header section in v0.8 if operators ask).
- Search / filter within a transcript (planned for v0.8 alongside the SSE live-stream).

\`\`\`
go test -race ./...     # clean
npm run build           # 241 KB / 77 KB gzipped
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)