### PR TITLE
feat(ui): show agent names in the runs list (and fix wire shape drift)

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1625,9 +1625,15 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 // from the original SSE stream and surfacing it here keeps things
 // debug-friendly.
 type agentResponse struct {
-	AgentID         string             `json:"agent_id"`
-	RunID           string             `json:"run_id"`
-	SessionID       string             `json:"session_id"`
+	AgentID   string `json:"agent_id"`
+	RunID     string `json:"run_id"`
+	SessionID string `json:"session_id"`
+	// Agent is the YAML-declared agent name (e.g. "qa-agent",
+	// "company-researcher"). Surfaced from the parent session via
+	// SQL JOIN so consumers don't have to fetch the session row
+	// separately. Empty when the session row is missing (manual
+	// pruning / very-old data).
+	Agent           string             `json:"agent,omitempty"`
 	UserID          string             `json:"user_id,omitempty"`
 	ParentAgentID   string             `json:"parent_agent_id,omitempty"`
 	Status          store.RunStatus    `json:"status"`
@@ -1659,6 +1665,7 @@ func runToAgentResponse(r store.Run, live bool) agentResponse {
 		AgentID:       r.AgentID,
 		RunID:         r.ID,
 		SessionID:     r.SessionID,
+		Agent:         r.Agent,
 		UserID:        r.UserID,
 		ParentAgentID: r.ParentAgentID,
 		Status:        r.Status,

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -303,11 +303,13 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
 	}
 	row := s.pool.QueryRow(ctx,
-		`SELECT id, session_id, status, started_at, completed_at, stop_reason,
-		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-		        model, error,
-		        agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at
-		 FROM runs WHERE agent_id = $1 ORDER BY started_at DESC LIMIT 1`, agentID,
+		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+		        r.model, r.error,
+		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
+		        s.agent
+		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
 	)
 	r, err := scanRun(row)
 	if err != nil {
@@ -363,20 +365,24 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 	)
 	if status == "" {
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, session_id, status, started_at, completed_at, stop_reason,
-			        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-			        model, error,
-			        agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at
-			 FROM runs WHERE user_id = $1
-			 ORDER BY started_at DESC LIMIT $2`, userID, limit)
+			`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+			        r.model, r.error,
+			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
+			        s.agent
+			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+			 WHERE r.user_id = $1
+			 ORDER BY r.started_at DESC LIMIT $2`, userID, limit)
 	} else {
 		rows, err = s.pool.Query(ctx,
-			`SELECT id, session_id, status, started_at, completed_at, stop_reason,
-			        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-			        model, error,
-			        agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at
-			 FROM runs WHERE user_id = $1 AND status = $2
-			 ORDER BY started_at DESC LIMIT $3`, userID, string(status), limit)
+			`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+			        r.model, r.error,
+			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
+			        s.agent
+			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+			 WHERE r.user_id = $1 AND r.status = $2
+			 ORDER BY r.started_at DESC LIMIT $3`, userID, string(status), limit)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("list active runs: %w", err)
@@ -393,12 +399,14 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		return nil, nil
 	}
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, session_id, status, started_at, completed_at, stop_reason,
-		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-		        model, error,
-		        agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at
-		 FROM runs WHERE parent_agent_id = $1
-		 ORDER BY started_at ASC`, parentAgentID,
+		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+		        r.model, r.error,
+		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
+		        s.agent
+		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+		 WHERE r.parent_agent_id = $1
+		 ORDER BY r.started_at ASC`, parentAgentID,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list runs by parent: %w", err)
@@ -477,6 +485,10 @@ type rowScanner interface {
 
 // scanRun reads one run row from pgx into a store.Run, converting
 // nullable columns through pointer-string scratch variables.
+//
+// Trailing column is `s.agent` from the LEFT JOIN onto sessions —
+// surfaces the human-readable agent name (yaml-declared, e.g.
+// "qa-agent") on every Run without a separate session lookup.
 func scanRun(r rowScanner) (store.Run, error) {
 	var (
 		out store.Run
@@ -489,6 +501,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 
 		agentID, parentAgentID, parentRunID, userID *string
 		lastHeartbeatAt                             *time.Time
+		sessAgent                                   *string
 
 		statusStr string
 	)
@@ -497,6 +510,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&out.InputTokens, &out.OutputTokens, &out.CacheCreationTokens, &out.CacheReadTokens,
 		&model, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
+		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
 	}
@@ -528,6 +542,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	if lastHeartbeatAt != nil {
 		out.LastHeartbeatAt = *lastHeartbeatAt
+	}
+	if sessAgent != nil {
+		out.Agent = *sessAgent
 	}
 	return out, nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -299,12 +299,19 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 
 // scanRun decodes one row from a runs SELECT into a store.Run. The
 // SELECT column list MUST match the order in runColumns below.
+//
+// The trailing `agent` column comes from a LEFT JOIN onto sessions
+// — sessions.agent is the YAML-declared agent name. NULL when the
+// session row is missing (the JOIN drops the agent name silently
+// rather than failing the read; the rest of the run row is still
+// useful).
 func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var r store.Run
 	var startedNs, completedNs sql.NullInt64
 	var lastHbNs sql.NullInt64
 	var stopReason, model, errMsg sql.NullString
 	var agentID, parentAgentID, parentRunID, userID sql.NullString
+	var sessAgent sql.NullString
 	var status string
 	if err := scanner.Scan(
 		&r.ID, &r.SessionID, &status, &startedNs, &completedNs,
@@ -312,6 +319,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&r.InputTokens, &r.OutputTokens, &r.CacheCreationTokens, &r.CacheReadTokens,
 		&model, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
+		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
 	}
@@ -346,16 +354,30 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	if userID.Valid {
 		r.UserID = userID.String
 	}
+	if sessAgent.Valid {
+		r.Agent = sessAgent.String
+	}
 	return r, nil
 }
 
 // runColumns is the canonical SELECT column list paired with scanRun.
 // Centralised so a future column addition is a one-line change.
-const runColumns = `id, session_id, status, started_at, completed_at,
-		stop_reason,
-		input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-		model, error,
-		agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at`
+//
+// The `r.` / `s.` qualifiers + the trailing JOIN clause are required
+// because of the sessions.agent column (denormalised onto Run.Agent
+// at read time so callers don't have to fetch the session row
+// separately). All callers MUST use `runFromTable` to reference the
+// table (with its alias) so the qualifiers resolve.
+const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
+		r.stop_reason,
+		r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+		r.model, r.error,
+		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
+		s.agent`
+
+// runFromTable is the canonical FROM clause paired with runColumns.
+// Provides the `r` and `s` aliases that the column list references.
+const runFromTable = `runs r LEFT JOIN sessions s ON r.session_id = s.id`
 
 // GetRunByAgentID returns the most recently started run carrying the
 // given agent_id, or *store.ErrNotFound. Multiple historical runs may
@@ -367,7 +389,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
 	}
 	row := s.db.QueryRowContext(ctx,
-		`SELECT `+runColumns+` FROM runs WHERE agent_id = ? ORDER BY started_at DESC LIMIT 1`,
+		`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.agent_id = ? ORDER BY r.started_at DESC LIMIT 1`,
 		agentID,
 	)
 	r, err := scanRun(row)
@@ -422,12 +444,12 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 	var err error
 	if status == "" {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT `+runColumns+` FROM runs WHERE user_id = ? ORDER BY started_at DESC LIMIT 100`,
+			`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.user_id = ? ORDER BY r.started_at DESC LIMIT 100`,
 			userID,
 		)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
-			`SELECT `+runColumns+` FROM runs WHERE user_id = ? AND status = ? ORDER BY started_at DESC LIMIT 100`,
+			`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.user_id = ? AND r.status = ? ORDER BY r.started_at DESC LIMIT 100`,
 			userID, string(status),
 		)
 	}
@@ -456,7 +478,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		return nil, nil
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+runColumns+` FROM runs WHERE parent_agent_id = ? ORDER BY started_at ASC`,
+		`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.parent_agent_id = ? ORDER BY r.started_at ASC`,
 		parentAgentID,
 	)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -45,8 +45,13 @@ const (
 
 // Run is one execution within a session.
 type Run struct {
-	ID                  string    `json:"id"`
-	SessionID           string    `json:"session_id"`
+	ID        string `json:"id"`
+	SessionID string `json:"session_id"`
+	// Agent is the YAML-declared agent name (e.g. "qa-agent",
+	// "company-researcher"). Read from the parent session via SQL JOIN
+	// at read time — NOT a column on the runs table. Empty when the
+	// JOIN can't resolve (e.g. a session row was manually pruned).
+	Agent               string    `json:"agent,omitempty"`
 	Status              RunStatus `json:"status"`
 	StartedAt           time.Time `json:"started_at"`
 	CompletedAt         time.Time `json:"completed_at,omitempty"`

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -18,23 +18,34 @@ export function listUsers(): Promise<ListUsersResponse> {
   return jsonFetch<ListUsersResponse>("/v1/_users");
 }
 
+// Agent mirrors agentResponse on the server (internal/api/http/server.go).
+// Field names use snake_case to match the wire shape; renaming any of
+// them is a wire change, not a UI change.
 export interface Agent {
   agent_id: string;
   run_id: string;
   session_id: string;
+  // agent is the YAML-declared agent name ("qa-agent",
+  // "company-researcher") — what the operator wants to see in lists.
+  // Empty when loomcycle's parser didn't see a session row (legacy
+  // rows pre-dating the agent column on the JOIN).
+  agent: string;
   parent_agent_id: string | null;
-  agent_type: string;
   user_id: string;
   status: "running" | "completed" | "failed" | "cancelled";
-  model: string;
   started_at: string;
   completed_at: string | null;
-  duration_ms: number | null;
+  stop_reason: string | null;
   error: string | null;
-  input_tokens: number | null;
-  output_tokens: number | null;
-  cache_read_tokens: number | null;
-  cache_creation_tokens: number | null;
+  usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_tokens?: number;
+    cache_read_tokens?: number;
+    model?: string;
+  };
+  last_heartbeat_at: string | null;
+  live: boolean;
 }
 
 export interface ListAgentsResponse {

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -70,7 +70,7 @@ export default function AgentDetail() {
         <div className="agent-header">
           <div className="line1">
             <span className={`pill ${agent.status}`}>{agent.status}</span>
-            <strong>{agent.agent_type}</strong>
+            <strong>{agent.agent || "(unknown agent)"}</strong>
             <code className="agent-id">{agent.agent_id}</code>
             {agent.status === "running" && (
               <button
@@ -92,7 +92,7 @@ export default function AgentDetail() {
             )}
           </div>
           <div className="line2">
-            <span>{agent.model || "—"}</span>
+            <span>{agent.usage?.model || "—"}</span>
             <span>user: {agent.user_id || "—"}</span>
             {agent.parent_agent_id && (
               <span>
@@ -103,10 +103,12 @@ export default function AgentDetail() {
               </span>
             )}
             <span>
-              tokens: {agent.input_tokens ?? "?"} in / {agent.output_tokens ?? "?"} out
-              {agent.cache_read_tokens ? `, ${agent.cache_read_tokens} cache-read` : ""}
+              tokens: {agent.usage?.input_tokens ?? "?"} in / {agent.usage?.output_tokens ?? "?"} out
+              {agent.usage?.cache_read_tokens ? `, ${agent.usage.cache_read_tokens} cache-read` : ""}
             </span>
-            {agent.duration_ms != null && <span>{(agent.duration_ms / 1000).toFixed(1)}s</span>}
+            {agent.completed_at && (
+              <span>{durationLabel(agent.started_at, agent.completed_at)}</span>
+            )}
           </div>
           {agent.error && <div className="agent-err">error: {agent.error}</div>}
         </div>
@@ -300,4 +302,14 @@ function formatTime(ns: number): string {
   if (!ns) return "";
   const ms = Math.floor(ns / 1_000_000);
   return new Date(ms).toLocaleTimeString();
+}
+
+function durationLabel(startedAt: string, completedAt: string): string {
+  const a = new Date(startedAt).getTime();
+  const b = new Date(completedAt).getTime();
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return "";
+  const ms = b - a;
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60_000)}m ${Math.round((ms % 60_000) / 1000)}s`;
 }

--- a/web/src/pages/RunList.tsx
+++ b/web/src/pages/RunList.tsx
@@ -128,10 +128,10 @@ function RunNode({ node, depth }: { node: TreeNode; depth: number }) {
       <div className="row">
         <span className={`pill ${a.status}`}>{a.status}</span>
         <Link to={`/agents/${a.agent_id}`} className="agent-link">
-          <strong>{a.agent_type}</strong>
+          <strong>{a.agent || "(unknown agent)"}</strong>
           <code className="agent-id">{a.agent_id.slice(0, 12)}…</code>
         </Link>
-        <span className="model">{a.model || "—"}</span>
+        <span className="model">{a.usage?.model || "—"}</span>
         <span className="time">{relativeTime(a.started_at)}</span>
         {a.error && <span className="error-flag" title={a.error}>error</span>}
       </div>


### PR DESCRIPTION
Operator question: \"runs list shows agent_id (UUID) and a status pill, but no human-readable agent name like 'qa-agent' or 'company-researcher' — how do I know what agent each row represents?\"

## Diagnosis

The wire response from \`/v1/users/{user_id}/agents\` and \`/v1/agents/{agent_id}\` carried only \`agent_id\` (the UUID). The human-readable name lives on the **session** row (\`sessions.agent\`), not the run row. The TypeScript \`Agent\` interface had an \`agent_type\` field that NEVER existed on the wire — undefined at runtime, which is why nothing showed.

Also discovered broader wire-shape drift in the same interface: flat \`model\` / \`input_tokens\` / \`output_tokens\` / \`duration_ms\` etc., but the server's \`agentResponse\` puts these under a nested \`usage: {...}\` field with no \`duration_ms\` at all. Fixed everything in one pass.

## Changes

### Backend

- **\`store.Run\`** gains \`Agent\` field, denormalised from \`sessions\` via SQL JOIN at read time (same pattern as the existing \`UserID\` denorm).
- **SQLite + Postgres**: \`scanRun\` + every SELECT updated to \`runs r LEFT JOIN sessions s ON r.session_id = s.id\` with \`s.agent\` as the trailing column. Centralised in \`runColumns\` + new \`runFromTable\` constants for SQLite.
- **\`agentResponse\` JSON** gains the \`agent\` field; \`runToAgentResponse\` populates it.

### Frontend

- **\`Agent\` interface** rewritten to match the actual wire shape: \`agent\` (the new field), \`usage: {...}\` nested struct, \`live\` flag, \`last_heartbeat_at\`. Drops the never-existed \`agent_type\` / \`model\` / \`input_tokens\` / \`output_tokens\` / \`duration_ms\` / \`cache_read_tokens\` flat fields.
- **RunList** renders \`a.agent\` (with \"(unknown agent)\" fallback for legacy rows) instead of the undefined \`a.agent_type\`.
- **AgentDetail** header reads from the new shape: \`agent\` for the bold name, \`usage.*\` for the metadata line, computed duration from \`started_at\` / \`completed_at\`.

\`\`\`
go test -race ./...     # clean
npm run build           # 242 KB / 77 KB gzipped
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)