### PR TITLE
feat(v0.8.0): Memory tool — persistent agent-scoped storage + Web UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,29 @@ LOOMCYCLE_DATA_DIR=./data
 # they're loaded with the same trust as inline `system_prompt:`. Do
 # not point this at a directory writable by untrusted users.
 # LOOMCYCLE_SKILLS_ROOT=/srv/loomcycle/skills
+
+# ─── Memory tool (v0.8.0+) ───────────────────────────────────────────
+#
+# The Memory tool exposes persistent agent-scoped key/value storage to
+# the model (get / set / delete / list / incr). Storage rides the
+# existing Store backend (sqlite default, postgres opt-in).
+#
+# Per-agent yaml gates which scopes an agent may use:
+#   memory_scopes: [agent, user]          # required; empty = no Memory
+#   memory_quota_bytes: 5_000_000         # optional override; 0 = use default
+#
+# Per-write cap on the value payload (set / incr). Default 64 KB
+# (65536). 0 disables. Refuses obvious abuse like "stash an entire
+# transcript in one row".
+# LOOMCYCLE_MEMORY_MAX_VALUE_BYTES=65536
+
+# Default per-(scope, scope_id) byte cap. Default 1 MB (1048576).
+# 0 disables. Per-agent yaml memory_quota_bytes overrides this.
+# LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES=1048576
+
+# TTL reaper goroutine cadence — periodic DELETE of expired rows.
+# Default 15 minutes. 0 disables (operators with an external reaper,
+# or dev/test runs that don't want background work, can opt out).
+# Read paths filter expired entries even when the reaper is off, so
+# agents never see stale values regardless.
+# LOOMCYCLE_MEMORY_SWEEP_MS=900000

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -167,6 +167,15 @@ func main() {
 		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
 		&builtin.SkillTool{Set: skillSet},
 	}
+	// Memory tool — wired post-store so it can grab the live Store
+	// reference. Registered unconditionally; access is gated per-agent
+	// via memory_scopes yaml + the Memory.Store==nil branch when the
+	// runtime hasn't configured a store backend.
+	memoryTool := &builtin.Memory{
+		MaxValueBytes:     cfg.Env.MemoryMaxValueBytes,
+		DefaultQuotaBytes: cfg.Env.MemoryMaxScopeBytes,
+	}
+	allTools = append(allTools, memoryTool)
 
 	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
 	// in loomcycle.yaml, parse the OpenAPI spec and register one tool
@@ -306,6 +315,11 @@ func main() {
 		log.Fatalf("store: %v", err)
 	}
 	defer storeCloser()
+	// Memory tool depends on the Store; wire the live backend in now
+	// that the adapter is open. This keeps the per-agent registration
+	// at boot (allTools assembled once) and the tool's nil-Store
+	// fallback for operators running without a configured store.
+	memoryTool.Store = storeIface
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
 
 	// Build the model-resolution matrix (resolve.Resolver). Providers
@@ -345,6 +359,17 @@ func main() {
 		go sweeper.Run(bgCtx)
 	} else {
 		log.Printf("heartbeat: sweeper disabled (LOOMCYCLE_HEARTBEAT_SWEEPER=0 or no Store)")
+	}
+
+	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.
+	// The store also filters expired entries at read time, so this
+	// goroutine only matters for keeping the table small over the
+	// long haul.
+	if cfg.Env.MemorySweepInterval > 0 && storeIface != nil {
+		go runMemorySweeper(bgCtx, storeIface, cfg.Env.MemorySweepInterval)
+		log.Printf("memory: sweeper interval=%s", cfg.Env.MemorySweepInterval)
+	} else {
+		log.Printf("memory: sweeper disabled (LOOMCYCLE_MEMORY_SWEEP_MS=0 or no Store)")
 	}
 
 	// Session-lock map GC. Defaults: prune entries idle ≥ 10 min, on
@@ -674,6 +699,30 @@ func convertTiers(in map[string][]config.TierCandidate) map[string][]resolve.Can
 		out[tier] = conv
 	}
 	return out
+}
+
+// runMemorySweeper periodically deletes Memory rows whose TTL has
+// expired. Read paths in the store filter expired rows out anyway so
+// agents never see stale values; the sweeper just keeps the table
+// bounded over time.
+func runMemorySweeper(ctx context.Context, s store.Store, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			swept, err := s.MemorySweep(ctx)
+			if err != nil {
+				log.Printf("memory sweep: %v", err)
+				continue
+			}
+			if swept > 0 {
+				log.Printf("memory sweep: deleted %d expired row(s)", swept)
+			}
+		}
+	}
 }
 
 // spawnStdioMCP starts a stdio MCP child for one server entry. Env keys are

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -203,13 +203,17 @@ For usage: see [README](../README.md). For the architecture: see [ARCHITECTURE.m
 
 Sequenced 2026-05-09. Each point release ships one focused framework primitive — the v1.0 capstone (LoomCycle MCP) needs them in this order because the MCP server's surface is built FROM these primitives. Detailed design (API schemas, storage shapes, retention semantics) lives in feature-branch RFCs at implementation time; the outlines below capture the shape but not the wire.
 
-### v0.8.0 — Memory tool
+### v0.8.0 — Memory tool *(in development)*
 
-Agent-scoped persistent storage. Backs self-improving agents — an agent can write a fact, a learned heuristic, a counter, or a per-user preference, and read it back on the next invocation. Scope variants (per-agent vs per-session vs per-user vs per-tenant) and retention semantics (TTL, size caps, eviction policy) shape the storage backend, which goes on the existing Postgres `Store` adapter (sqlite for dev, postgres for prod) — no new infra.
+**Status: in development on `feature-memory-tool` branch (2026-05-09).** Five-op surface (`get` / `set` / `delete` / `list` / `incr`) over a `memory` table on both SQLite and Postgres. Agent and user scopes ship; session and tenant scopes are forward-compatible (yaml accepts new scope strings without a wire change). TTL is in seconds; per-write 64 KB and per-(scope, scope_id) 1 MB defaults are operator-overridable, with per-agent `memory_quota_bytes` for production tuning.
+
+Agents are stateless across runs today. Memory closes the gap with persistent storage that survives across runs and sessions — a place to write down learned facts, counters, per-user preferences, summaries of long conversations, or notes for an agent's future self. The yaml gate is double-keyed: `Memory` must be in `allowed_tools`, AND the agent must declare `memory_scopes: [...]` to actually pick which scopes it can touch.
 
 **Sequenced first** because Channel and LoomHelp both expect Memory to exist (Memory underpins the "agents that learn" use case Channel routing makes interesting; LoomHelp surfaces a memory-snapshot view in its introspection output).
 
-What's not yet decided: API shape (key/value vs append-log vs both), TTL semantics, encryption-at-rest, cross-agent read permission model, schema versioning for stored values, structured-JSON values (queryable) vs opaque blobs (simpler). RFC at pickup.
+**Locked decisions** (RFC under doc-internal): scopes = `agent` + `user`; values = JSON (validated at write); ops = `get` / `set` / `delete` / `list` / **`incr`** (atomic counter); TTL = seconds; encryption-at-rest deferred to v0.9.x cluster work; no automatic eviction (quota exceeded → write fails with `quota_exceeded`); ACL = agent's `memory_scopes` is the floor.
+
+For the full surface and yaml shape, see [TOOLS.md → Memory tool](TOOLS.md#the-memory-tool--persistent-agent-scoped-storage-v080).
 
 ### v0.8.1 — Channel tool
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -45,6 +45,7 @@ Each built-in is registered into the dispatcher at process startup but **refuses
 | `Bash`      | `LOOMCYCLE_BASH_ENABLED=1` + `LOOMCYCLE_BASH_CWD=...` |
 | `Agent`     | Always registered (server-internal); per-agent `allowed_tools` controls who can spawn. |
 | `Skill`     | `LOOMCYCLE_SKILLS_ROOT=/path/to/skills` (or skills inlined per-agent via YAML `skills:` list) |
+| `Memory`    | Storage backend (SQLite default; Postgres opt-in) + per-agent `memory_scopes:` allowlist. |
 
 Bash has additional warnings: it is **not a true sandbox** even when enabled. Run loomcycle inside a container or VM if Bash is exposed to untrusted prompts. See `internal/tools/builtin/bash.go` for the full warning.
 
@@ -261,6 +262,86 @@ Constraint: each skill's frontmatter declares its own `allowed-tools`; this list
 The `Skill` built-in is registered when `LOOMCYCLE_SKILLS_ROOT` is set; the model can call it with `{"name": "voice-applier"}` to load a skill mid-conversation. In v0.4.0 the tool returns "unknown skill" — full Approach B implementation is v1.0 work. The hook is in place so prompts that reference the dynamic Skill tool can be authored today; they degrade gracefully (the tool reports the skill isn't available, the model continues without).
 
 References: `internal/skills/`, `internal/tools/builtin/skill.go`.
+
+## The `Memory` tool — persistent agent-scoped storage (v0.8.0)
+
+The `Memory` built-in gives agents a place to write down state that survives across runs and sessions. Five operations behind one tool, discriminated by an `op` field: **`get`**, **`set`**, **`delete`**, **`list`**, **`incr`**.
+
+### Wire shape
+
+```jsonc
+{
+  "op":     "get" | "set" | "delete" | "list" | "incr",
+  "scope":  "agent" | "user",
+  "key":    "string",     // get/set/delete/incr
+  "value":  any,          // set
+  "delta":  number,       // incr (default 1, may be negative)
+  "ttl":    number,       // set/incr — seconds; absent = no expiry
+  "prefix": "string",     // list filter
+  "limit":  number        // list cap (default 100, max 1000)
+}
+```
+
+Result shapes:
+
+```jsonc
+get    → { "value": <stored> | null, "expires_at": "RFC3339" | null }
+set    → { "ok": true }
+incr   → { "value": <new int> }
+delete → { "deleted": true | false }
+list   → { "entries": [{"key", "value", "expires_at"}], "truncated": bool }
+```
+
+### Scopes
+
+Two scopes ship in v0.8.0:
+
+- **`agent`** — keyed by the yaml-declared agent name. Cross-run, **shared across users.** Use for: per-agent counters, learned heuristics, summaries the agent wants its future self to read.
+- **`user`** — keyed by the run's `user_id`. Cross-agent, **per end-user.** Use for: voice/preferences, per-user notes, anything you want every agent that's allowed to read the user scope to see.
+
+`session` and `tenant` scopes are forward-compatible (the yaml allowlist accepts new scope strings without a wire-protocol change) but not implemented in v0.8.0.
+
+`scope_id` is **always** resolved server-side. The model picks the scope; loomcycle picks the scope_id. A model-supplied scope_id would let one user's agent run read another user's keys.
+
+### Per-agent yaml policy
+
+```yaml
+agents:
+  cv-adapter:
+    allowed_tools: [Memory, Read, Write]
+    memory_scopes: [agent, user]            # which scopes this agent may use
+    memory_quota_bytes: 5_000_000           # per-(scope, scope_id) override (default 1 MB)
+```
+
+`memory_scopes` is a default-deny allowlist. An agent with `Memory` in `allowed_tools` but no `memory_scopes` sees a refusal on every Memory call.
+
+`memory_quota_bytes` overrides the global `LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES` for this agent only. Use higher caps for memory-heavy agents; lower for noisy agents you want kept in check.
+
+### Operator env vars
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `LOOMCYCLE_MEMORY_MAX_VALUE_BYTES` | `65536` | Per-write cap on the `value` payload. 0 disables. |
+| `LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES` | `1048576` | Default per-(scope, scope_id) cap. 0 disables. |
+| `LOOMCYCLE_MEMORY_SWEEP_MS` | `900000` (15 min) | TTL reaper goroutine cadence. 0 disables. |
+
+### Atomic increment
+
+`op: "incr"` is the counter primitive. If the key doesn't exist (or the existing value has already expired), the row is created starting from `0 + delta`. If the existing value isn't a JSON number, the call is refused with `wrong_type`. Optional `ttl` resets the expiry on every increment.
+
+### TTL semantics
+
+`ttl: 3600` on a `set` makes the row expire in one hour. Reads filter expired rows out **before** the sweeper runs them — agents never see stale values, even on a slow sweep cadence. The sweep goroutine just keeps the table bounded over the long haul.
+
+### What's NOT in v0.8.0
+
+- Cross-tenant sharing (no `tenant` scope yet).
+- Append-log primitive — agents wanting an event stream write `events/<timestamp>` keys + `list` with prefix.
+- Automatic eviction / LRU — quota exceeded → the write fails with `quota_exceeded`. Agents call `delete` explicitly.
+- Encryption-at-rest — disk encryption is operator-config-wide, not Memory-specific. Revisit alongside v0.9.x HA work.
+- Server-side schema validation — values are JSON; agents own their schemas.
+
+References: `internal/store/store.go` (interface), `internal/store/sqlite/sqlite.go` + `internal/store/postgres/postgres.go` (adapters), `internal/tools/builtin/memory.go` (tool).
 
 ## LocalAPI tools — OpenAPI gateway (scaffolded; not the v0.4 integration vehicle)
 

--- a/internal/api/http/memory.go
+++ b/internal/api/http/memory.go
@@ -1,0 +1,199 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Memory admin endpoints — drive the v0.8.0 Web UI Memory page. All
+// three are read-only operator views; the /v1/_memory namespace
+// matches the existing /v1/_users / /v1/_resolver convention for
+// admin / introspection routes.
+//
+// Wire shape mirrors the store types directly. Bearer auth is
+// applied at the mux layer (recoveryMiddleware → authMiddleware).
+//
+// Routes:
+//   GET /v1/_memory/scopes
+//     → list scope kinds the operator can browse (constant set —
+//       agent + user; forward-compatible for new scope kinds when
+//       they ship).
+//   GET /v1/_memory/scopes/{scope}
+//     → list scope_ids under one scope, with summary stats.
+//   GET /v1/_memory/scopes/{scope}/{scope_id}/keys?prefix=&limit=
+//     → list keys + values for one (scope, scope_id) tuple.
+//   GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key}
+//     → one entry. (Used by the UI's deep-link / refresh path; the
+//       list response already includes the value, so this is mostly
+//       for direct API consumers.)
+
+type memoryScopesResponse struct {
+	Scopes []memoryScopeKind `json:"scopes"`
+}
+
+type memoryScopeKind struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type memoryScopeIDsResponse struct {
+	Scope    string                       `json:"scope"`
+	ScopeIDs []store.MemoryScopeIDSummary `json:"scope_ids"`
+}
+
+type memoryEntriesResponse struct {
+	Scope     string              `json:"scope"`
+	ScopeID   string              `json:"scope_id"`
+	Entries   []store.MemoryEntry `json:"entries"`
+	Truncated bool                `json:"truncated"`
+}
+
+type memoryEntryResponse struct {
+	Scope   string            `json:"scope"`
+	ScopeID string            `json:"scope_id"`
+	Entry   store.MemoryEntry `json:"entry"`
+}
+
+// handleListMemoryScopes serves GET /v1/_memory/scopes. Returns the
+// operator-browsable scope kinds. v0.8.0 is `agent` + `user`; future
+// versions extend this list.
+func (s *Server) handleListMemoryScopes(w http.ResponseWriter, _ *http.Request) {
+	resp := memoryScopesResponse{
+		Scopes: []memoryScopeKind{
+			{Name: "agent", Description: "Per-yaml-agent keyspace, shared across users"},
+			{Name: "user", Description: "Per-user keyspace, shared across agents"},
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleListMemoryScopeIDs serves GET /v1/_memory/scopes/{scope}.
+func (s *Server) handleListMemoryScopeIDs(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; Memory admin requires a persistent store")
+		return
+	}
+	scope := r.PathValue("scope")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user")
+		return
+	}
+	rows, err := s.store.MemoryListScopeIDs(r.Context(), store.MemoryScope(scope))
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if rows == nil {
+		// JSON-encode an empty array rather than null so the UI can
+		// `.map` without a guard.
+		rows = []store.MemoryScopeIDSummary{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(memoryScopeIDsResponse{Scope: scope, ScopeIDs: rows})
+}
+
+// handleListMemoryEntries serves
+// GET /v1/_memory/scopes/{scope}/{scope_id}/keys?prefix=&limit=.
+func (s *Server) handleListMemoryEntries(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; Memory admin requires a persistent store")
+		return
+	}
+	scope := r.PathValue("scope")
+	scopeID := r.PathValue("scope_id")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user")
+		return
+	}
+	if strings.TrimSpace(scopeID) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_scope_id", "scope_id is required")
+		return
+	}
+	prefix := r.URL.Query().Get("prefix")
+	limit := 200
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	entries, truncated, err := s.store.MemoryList(r.Context(), store.MemoryScope(scope), scopeID, prefix, limit)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []store.MemoryEntry{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(memoryEntriesResponse{
+		Scope:     scope,
+		ScopeID:   scopeID,
+		Entries:   entries,
+		Truncated: truncated,
+	})
+}
+
+// handleGetMemoryEntry serves
+// GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key}.
+func (s *Server) handleGetMemoryEntry(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; Memory admin requires a persistent store")
+		return
+	}
+	scope := r.PathValue("scope")
+	scopeID := r.PathValue("scope_id")
+	key := r.PathValue("key")
+	if !validAdminMemoryScope(scope) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_scope",
+			"scope must be one of: agent, user")
+		return
+	}
+	if strings.TrimSpace(scopeID) == "" || strings.TrimSpace(key) == "" {
+		writeJSONError(w, http.StatusBadRequest, "missing_path",
+			"scope_id and key are required")
+		return
+	}
+	entry, err := s.store.MemoryGet(r.Context(), store.MemoryScope(scope), scopeID, key)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			writeJSONError(w, http.StatusNotFound, "not_found",
+				"no entry at "+scope+"/"+scopeID+"/"+key)
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(memoryEntryResponse{
+		Scope:   scope,
+		ScopeID: scopeID,
+		Entry:   entry,
+	})
+}
+
+// validAdminMemoryScope mirrors the closed scope set the runtime
+// accepts. Distinct from the agent yaml allowlist (which is per-
+// agent + caller-side); this is the admin-side gate so the UI can't
+// poke a never-shipped scope into the store.
+func validAdminMemoryScope(s string) bool {
+	switch s {
+	case "agent", "user":
+		return true
+	}
+	return false
+}

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -186,6 +186,32 @@ func TestHandleGetMemoryEntry_RoundTrip(t *testing.T) {
 	}
 }
 
+// Memory keys often contain `/` (e.g. `events/2026-05-09`). The mux
+// pattern uses {key...} so the multi-segment path resolves correctly;
+// a plain {key} would 404 these silently. Exercise the route through
+// the full Mux() so the pattern matching is part of the test.
+func TestHandleGetMemoryEntry_MultiSegmentKey(t *testing.T) {
+	s := memoryAdminFixture(t)
+	if err := s.store.MemorySet(t.Context(), store.MemoryScopeAgent, "qa-agent",
+		"events/2026-05-09T10:00", []byte(`"first event"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	s.Mux().ServeHTTP(rec, httptest.NewRequest(
+		"GET", "/v1/_memory/scopes/agent/qa-agent/keys/events/2026-05-09T10:00", nil,
+	))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryEntryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if string(resp.Entry.Value) != `"first event"` {
+		t.Errorf("value = %s", resp.Entry.Value)
+	}
+}
+
 func TestHandleGetMemoryEntry_NotFound(t *testing.T) {
 	s := memoryAdminFixture(t)
 	req := httptest.NewRequest("GET", "/v1/_memory/scopes/agent/qa-agent/keys/missing", nil)

--- a/internal/api/http/memory_test.go
+++ b/internal/api/http/memory_test.go
@@ -1,0 +1,221 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// memoryAdminFixture wires just enough of Server to exercise the
+// /v1/_memory/* handlers with an in-memory SQLite backend pre-loaded
+// with rows under both scopes.
+func memoryAdminFixture(t *testing.T) *Server {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	ctx := t.Context()
+	for _, k := range []string{"voice", "tone"} {
+		if err := st.MemorySet(ctx, store.MemoryScopeUser, "alice", k, []byte(`"`+k+`-value"`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := st.MemorySet(ctx, store.MemoryScopeUser, "bob", "voice", []byte(`"bob-voice"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.MemorySet(ctx, store.MemoryScopeAgent, "qa-agent", "warnings", []byte(`5`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	hookReg := hooks.NewRegistry()
+	return &Server{
+		cfg:            cfg,
+		store:          st,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+}
+
+func TestHandleListMemoryScopes_ReturnsConstantSet(t *testing.T) {
+	s := memoryAdminFixture(t)
+	rec := httptest.NewRecorder()
+	s.handleListMemoryScopes(rec, httptest.NewRequest("GET", "/v1/_memory/scopes", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryScopesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Scopes) != 2 {
+		t.Errorf("scopes len = %d, want 2", len(resp.Scopes))
+	}
+	got := map[string]bool{}
+	for _, sc := range resp.Scopes {
+		got[sc.Name] = true
+		if sc.Description == "" {
+			t.Errorf("scope %q missing description", sc.Name)
+		}
+	}
+	if !got["agent"] || !got["user"] {
+		t.Errorf("missing scopes in response: %v", resp.Scopes)
+	}
+}
+
+func TestHandleListMemoryScopeIDs_FiltersByScope(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/user", nil)
+	req.SetPathValue("scope", "user")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryScopeIDs(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryScopeIDsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Scope != "user" {
+		t.Errorf("scope = %q", resp.Scope)
+	}
+	got := map[string]int{}
+	for _, sc := range resp.ScopeIDs {
+		got[sc.ScopeID] = sc.KeyCount
+	}
+	if got["alice"] != 2 || got["bob"] != 1 {
+		t.Errorf("scope_ids: %v, want alice=2 bob=1", got)
+	}
+	if _, ok := got["qa-agent"]; ok {
+		t.Errorf("agent-scope row leaked into user listing: %v", got)
+	}
+}
+
+func TestHandleListMemoryScopeIDs_RejectsUnknownScope(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/tenant", nil)
+	req.SetPathValue("scope", "tenant")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryScopeIDs(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleListMemoryEntries_ReturnsKeysAndValues(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/user/alice/keys", nil)
+	req.SetPathValue("scope", "user")
+	req.SetPathValue("scope_id", "alice")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryEntries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryEntriesResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(resp.Entries))
+	}
+	if resp.Truncated {
+		t.Errorf("unexpected truncation")
+	}
+	keys := map[string]string{}
+	for _, e := range resp.Entries {
+		keys[e.Key] = string(e.Value)
+	}
+	if keys["voice"] != `"voice-value"` || keys["tone"] != `"tone-value"` {
+		t.Errorf("entries: %v", keys)
+	}
+}
+
+func TestHandleListMemoryEntries_PrefixFilter(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/user/alice/keys?prefix=voi", nil)
+	req.SetPathValue("scope", "user")
+	req.SetPathValue("scope_id", "alice")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryEntries(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp memoryEntriesResponse
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Entries) != 1 || resp.Entries[0].Key != "voice" {
+		t.Errorf("prefix filter returned %v, want [voice]", resp.Entries)
+	}
+}
+
+func TestHandleGetMemoryEntry_RoundTrip(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/agent/qa-agent/keys/warnings", nil)
+	req.SetPathValue("scope", "agent")
+	req.SetPathValue("scope_id", "qa-agent")
+	req.SetPathValue("key", "warnings")
+	rec := httptest.NewRecorder()
+	s.handleGetMemoryEntry(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp memoryEntryResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if string(resp.Entry.Value) != `5` {
+		t.Errorf("value = %s, want 5", resp.Entry.Value)
+	}
+	if resp.Scope != "agent" || resp.ScopeID != "qa-agent" {
+		t.Errorf("response (scope, scope_id) = (%q, %q)", resp.Scope, resp.ScopeID)
+	}
+}
+
+func TestHandleGetMemoryEntry_NotFound(t *testing.T) {
+	s := memoryAdminFixture(t)
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/agent/qa-agent/keys/missing", nil)
+	req.SetPathValue("scope", "agent")
+	req.SetPathValue("scope_id", "qa-agent")
+	req.SetPathValue("key", "missing")
+	rec := httptest.NewRecorder()
+	s.handleGetMemoryEntry(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleListMemoryEntries_StoreUnavailable(t *testing.T) {
+	cfg := &config.Config{}
+	hookReg := hooks.NewRegistry()
+	s := &Server{
+		cfg:            cfg,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+	req := httptest.NewRequest("GET", "/v1/_memory/scopes/user/alice/keys", nil)
+	req.SetPathValue("scope", "user")
+	req.SetPathValue("scope_id", "alice")
+	rec := httptest.NewRecorder()
+	s.handleListMemoryEntries(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -560,7 +560,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_memory/scopes", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryScopes))))
 	mux.Handle("GET /v1/_memory/scopes/{scope}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryScopeIDs))))
 	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryEntries))))
-	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetMemoryEntry))))
+	// {key...} catches multi-segment keys — Memory keys frequently use
+	// `/`-prefixed paths (e.g. `events/2026-05-09T10:00`) and a
+	// single-segment {key} would 404 on those.
+	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key...}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetMemoryEntry))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the
@@ -1054,12 +1057,18 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	allowedTools := filterTools(s.tools, agentDef.AllowedTools, body.AllowedTools)
+	var hostPolicy tools.HostPolicyValue
 	if body.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
 		if body.AllowedHosts != nil {
 			caller = *body.AllowedHosts
 		}
 		allowedTools = builtin.NarrowHosts(allowedTools, caller, body.WebSearchFilter, s.cfg.Env.HTTPCallerAuthoritative)
+		hostPolicy = tools.HostPolicyValue{
+			AllowedHosts:    caller,
+			HasList:         body.AllowedHosts != nil,
+			WebSearchFilter: body.WebSearchFilter,
+		}
 	}
 	dispatcher := tools.NewDispatcher(allowedTools)
 
@@ -1156,6 +1165,13 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		UserID:  sess.UserID,
 		AgentID: agentID,
 	})
+	// Sub-agents spawned by this continuation must inherit the
+	// caller-authoritative host narrowing, same as runRequest +
+	// handleRuns. Without this, a sub-agent runs against the
+	// operator's static allowlist instead of the caller's narrowed
+	// list — the production failure mode 9677b85 fixed for top-level
+	// runs and this continuation path was missing the same fix.
+	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
 	loopCtx = tools.WithAgentName(loopCtx, sess.Agent)
 	loopCtx = tools.WithMemoryPolicy(loopCtx, tools.MemoryPolicyValue{
 		AllowedScopes: agentDef.MemoryScopes,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -554,6 +554,13 @@ func (s *Server) Mux() http.Handler {
 	// user_ids that have runs in the store. Bearer-authed; drives
 	// the Web UI's run-list user dropdown.
 	mux.Handle("GET /v1/_users", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUsers))))
+	// v0.8.0 Memory admin — read-only browsing of stored Memory rows.
+	// Drives the Web UI's Memory page. Bearer-authed; same admin
+	// posture as /v1/_users / /v1/_resolver.
+	mux.Handle("GET /v1/_memory/scopes", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryScopes))))
+	mux.Handle("GET /v1/_memory/scopes/{scope}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryScopeIDs))))
+	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryEntries))))
+	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetMemoryEntry))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -433,6 +433,16 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		AgentID: agentID,
 	})
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
+	// Memory tool policy: agent name + per-agent scope allowlist +
+	// per-agent quota override. The Memory tool reads these from ctx
+	// at call time to refuse out-of-policy operations and resolve
+	// scope_id (yaml agent name for `agent` scope, user_id for
+	// `user` scope).
+	loopCtx = tools.WithAgentName(loopCtx, effectiveAgentName)
+	loopCtx = tools.WithMemoryPolicy(loopCtx, tools.MemoryPolicyValue{
+		AllowedScopes: agentDef.MemoryScopes,
+		QuotaBytes:    agentDef.MemoryQuotaBytes,
+	})
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -891,6 +901,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Agent tool inherit the same allowed_hosts / WebSearchFilter
 	// narrowing the parent received.
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
+	loopCtx = tools.WithAgentName(loopCtx, req.Agent)
+	loopCtx = tools.WithMemoryPolicy(loopCtx, tools.MemoryPolicyValue{
+		AllowedScopes: agentDef.MemoryScopes,
+		QuotaBytes:    agentDef.MemoryQuotaBytes,
+	})
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1133,6 +1148,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:  sess.UserID,
 		AgentID: agentID,
+	})
+	loopCtx = tools.WithAgentName(loopCtx, sess.Agent)
+	loopCtx = tools.WithMemoryPolicy(loopCtx, tools.MemoryPolicyValue{
+		AllowedScopes: agentDef.MemoryScopes,
+		QuotaBytes:    agentDef.MemoryQuotaBytes,
 	})
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -1577,6 +1597,18 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
 		UserID:  parentIdentity.UserID,
 		AgentID: subAgentID,
+	})
+	subCtx = tools.WithAgentName(subCtx, name)
+	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's
+	// memory_scopes do NOT cascade. This matches the existing
+	// `allowed_tools` model: a child's surface is its own yaml's
+	// authority. Cross-agent state-sharing is what the `user` scope
+	// is for; sub-agents that share state with their parent simply
+	// both list `user` (or `agent` keyed by a shared name) in their
+	// memory_scopes.
+	subCtx = tools.WithMemoryPolicy(subCtx, tools.MemoryPolicyValue{
+		AllowedScopes: def.MemoryScopes,
+		QuotaBytes:    def.MemoryQuotaBytes,
 	})
 
 	subHeartbeat := s.makeHeartbeat(subRunID)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,21 @@ type AgentDef struct {
 	// to a specific subset of providers (e.g. CV generator that
 	// must stay on Anthropic for sensitive paths).
 	Models map[string][]TierCandidate `yaml:"models"`
+
+	// MemoryScopes is the v0.8.0 Memory tool scope allowlist. Empty
+	// = no Memory access (the default-deny invariant — even if
+	// `Memory` is in AllowedTools, agents without an explicit
+	// memory_scopes list see refused calls). Currently accepts
+	// "agent" and "user"; forward-compatible for "session" / "tenant"
+	// when those scopes ship.
+	MemoryScopes []string `yaml:"memory_scopes"`
+
+	// MemoryQuotaBytes overrides the global per-(scope, scope_id)
+	// byte cap (LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES) for this agent.
+	// 0 = use the global default. Set higher for agents that
+	// legitimately maintain large state (cv-adapter); set lower for
+	// noisy agents you want to keep on a tight leash.
+	MemoryQuotaBytes int `yaml:"memory_quota_bytes"`
 }
 
 // MCPServer declares one MCP server. Transport "stdio" or "http".
@@ -394,6 +409,26 @@ type Env struct {
 	// timeouts on the affected network paths. Set to 0 to disable.
 	// Env: LOOMCYCLE_SSE_KEEPALIVE_MS.
 	SSEKeepaliveInterval time.Duration
+
+	// MemoryMaxValueBytes caps a single Memory.set / Memory.incr
+	// payload. Default 65536 (64 KB) — generous for a JSON document
+	// agents would actually persist; refuses obvious abuse like
+	// "stash an entire transcript here." Set to 0 to disable.
+	// Env: LOOMCYCLE_MEMORY_MAX_VALUE_BYTES.
+	MemoryMaxValueBytes int
+
+	// MemoryMaxScopeBytes is the default per-(scope, scope_id) byte
+	// cap. Per-agent yaml `memory_quota_bytes` overrides this.
+	// Default 1048576 (1 MB). Set to 0 to disable.
+	// Env: LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES.
+	MemoryMaxScopeBytes int
+
+	// MemorySweepInterval is how often the TTL reaper goroutine
+	// runs MemorySweep on the store. Default 15 minutes. Set to 0
+	// to disable (operators with an external reaper, or tests that
+	// don't want background work, can opt out).
+	// Env: LOOMCYCLE_MEMORY_SWEEP_MS.
+	MemorySweepInterval time.Duration
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -573,6 +608,40 @@ func Load(path string) (*Config, error) {
 					d = maxSSE
 				}
 				cfg.Env.SSEKeepaliveInterval = d
+			}
+		}
+	}
+
+	// Memory tool defaults. Per-write 64 KB, per-scope 1 MB,
+	// 15-minute TTL sweep cadence. Negative values are treated as
+	// "disable" (matches the SSE keepalive convention above).
+	cfg.Env.MemoryMaxValueBytes = 64 * 1024
+	if v := os.Getenv("LOOMCYCLE_MEMORY_MAX_VALUE_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.MemoryMaxValueBytes = 0
+			} else {
+				cfg.Env.MemoryMaxValueBytes = n
+			}
+		}
+	}
+	cfg.Env.MemoryMaxScopeBytes = 1024 * 1024
+	if v := os.Getenv("LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.MemoryMaxScopeBytes = 0
+			} else {
+				cfg.Env.MemoryMaxScopeBytes = n
+			}
+		}
+	}
+	cfg.Env.MemorySweepInterval = 15 * time.Minute
+	if v := os.Getenv("LOOMCYCLE_MEMORY_SWEEP_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.MemorySweepInterval = 0
+			} else {
+				cfg.Env.MemorySweepInterval = time.Duration(n) * time.Millisecond
 			}
 		}
 	}
@@ -845,6 +914,14 @@ var validEffortLevels = map[string]bool{
 	"high":   true,
 }
 
+// validMemoryScopes is the closed set of Memory tool scope names
+// accepted in agent yaml. v0.8.0 ships agent + user; future versions
+// may add session / tenant.
+var validMemoryScopes = map[string]bool{
+	"agent": true,
+	"user":  true,
+}
+
 func validate(c *Config) error {
 	if c.Concurrency.MaxConcurrentRuns < 1 {
 		return fmt.Errorf("concurrency.max_concurrent_runs must be >= 1")
@@ -916,6 +993,17 @@ func validate(c *Config) error {
 					return fmt.Errorf("agent %q: models.%s[%d]: model is required", name, tierName, i)
 				}
 			}
+		}
+		// Memory tool: validate memory_scopes are known scope strings.
+		// Empty memory_scopes is fine (it just means no Memory access);
+		// non-empty must be a subset of {agent, user} for v0.8.0.
+		for i, sc := range agent.MemoryScopes {
+			if !validMemoryScopes[sc] {
+				return fmt.Errorf("agent %q: memory_scopes[%d]: unknown scope %q (want one of: agent, user)", name, i, sc)
+			}
+		}
+		if agent.MemoryQuotaBytes < 0 {
+			return fmt.Errorf("agent %q: memory_quota_bytes must be >= 0", name)
 		}
 	}
 	for name, srv := range c.MCPServers {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -445,6 +445,99 @@ agents:
 	}
 }
 
+// v0.8.0 Memory tool: yaml memory_scopes must validate against the
+// closed set {agent, user}. An unknown scope is a config-load error
+// — silent drop would let a typoed `memmory_scopes: [agnet]` produce
+// an agent that calls Memory.set with no policy applied at runtime.
+func TestMemoryScopesValidation(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  bad:
+    model: claude-sonnet-4-6
+    memory_scopes: [agent, tenant]
+`), 0o600)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected error for unknown memory scope")
+	}
+	if !strings.Contains(err.Error(), "tenant") {
+		t.Errorf("error should name the offending scope: %v", err)
+	}
+}
+
+func TestMemoryScopesAccepted(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  ok:
+    model: claude-sonnet-4-6
+    allowed_tools: [Memory]
+    memory_scopes: [agent, user]
+    memory_quota_bytes: 5000000
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["ok"]
+	if len(def.MemoryScopes) != 2 || def.MemoryScopes[0] != "agent" || def.MemoryScopes[1] != "user" {
+		t.Errorf("MemoryScopes round-trip: %v", def.MemoryScopes)
+	}
+	if def.MemoryQuotaBytes != 5_000_000 {
+		t.Errorf("MemoryQuotaBytes = %d", def.MemoryQuotaBytes)
+	}
+}
+
+func TestMemoryEnvDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  default: { model: claude-sonnet-4-6 }
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Env.MemoryMaxValueBytes != 64*1024 {
+		t.Errorf("MemoryMaxValueBytes default = %d, want 65536", cfg.Env.MemoryMaxValueBytes)
+	}
+	if cfg.Env.MemoryMaxScopeBytes != 1024*1024 {
+		t.Errorf("MemoryMaxScopeBytes default = %d, want 1048576", cfg.Env.MemoryMaxScopeBytes)
+	}
+	if cfg.Env.MemorySweepInterval == 0 {
+		t.Errorf("MemorySweepInterval default should be non-zero")
+	}
+}
+
+func TestMemoryEnvDisable(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  default: { model: claude-sonnet-4-6 }
+`), 0o600)
+	t.Setenv("LOOMCYCLE_MEMORY_MAX_VALUE_BYTES", "0")
+	t.Setenv("LOOMCYCLE_MEMORY_SWEEP_MS", "-1")
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Env.MemoryMaxValueBytes != 0 {
+		t.Errorf("0 should disable; got %d", cfg.Env.MemoryMaxValueBytes)
+	}
+	if cfg.Env.MemorySweepInterval != 0 {
+		t.Errorf("negative should disable; got %v", cfg.Env.MemorySweepInterval)
+	}
+}
+
 // Absolute path bypasses configDir resolution. Used when the operator
 // stages prompts somewhere outside the YAML's directory.
 func TestSystemPromptFileAbsolutePath(t *testing.T) {

--- a/internal/store/postgres/migrations/0002_memory.down.sql
+++ b/internal/store/postgres/migrations/0002_memory.down.sql
@@ -1,0 +1,3 @@
+-- 0002_memory.down.sql — drop the v0.8.0 Memory storage.
+
+DROP TABLE IF EXISTS memory;

--- a/internal/store/postgres/migrations/0002_memory.up.sql
+++ b/internal/store/postgres/migrations/0002_memory.up.sql
@@ -1,0 +1,23 @@
+-- 0002_memory.up.sql — v0.8.0 Memory tool storage.
+--
+-- One row per (scope, scope_id, key). value is JSONB so list/get can
+-- round-trip the stored shape and a future query primitive can use the
+-- @> / -> operators without a migration. expires_at is the TTL anchor;
+-- NULL means "no expiry".
+--
+-- The PRIMARY KEY (scope, scope_id, key) doubles as the lookup index
+-- for get/incr/delete. The partial expires_at index keeps the sweep
+-- DELETE cheap (small index, only the rows that actually have a TTL).
+
+CREATE TABLE memory (
+    scope       TEXT        NOT NULL,
+    scope_id    TEXT        NOT NULL,
+    key         TEXT        NOT NULL,
+    value       JSONB       NOT NULL,
+    expires_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (scope, scope_id, key)
+);
+
+CREATE INDEX memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -605,9 +605,23 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 }
 
 // MemoryIncrement is the atomic counter primitive. We do the parse +
-// add in a single transaction with `FOR UPDATE` row-locking; the
-// existing-value parse is JSON-side because JSONB stores the value as
-// the parsed shape, not as text.
+// add in a single transaction. `SELECT ... FOR UPDATE` correctly
+// serialises increments on an EXISTING row, but does NOT block when
+// the row is absent (no row to lock) — two concurrent first-
+// increments of the same key would both see ErrNoRows, both compute
+// `delta`, and both INSERT. The unique constraint serialises the
+// writes (one INSERT wins, the other falls into ON CONFLICT DO
+// UPDATE), but EXCLUDED.value is the SECOND transaction's `delta`
+// rather than `first_result + delta`, losing the first's contribution.
+//
+// Fix: take a transaction-scoped advisory lock keyed by the
+// (scope, scope_id, key) hash before SELECT-ing. This serialises
+// every increment on the same key — the FIRST winner does its
+// SELECT (NoRows → INSERT delta), commits, releases the advisory
+// lock; the SECOND now does its SELECT (sees value=delta → INSERT
+// 2*delta via ON CONFLICT DO UPDATE). Different keys hash to
+// different lock IDs and don't contend. Verified by a 100-goroutine
+// regression test in storetest (all 100 increments must land).
 func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
@@ -615,14 +629,20 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		string(scope)+":"+scopeID+":"+key,
+	); err != nil {
+		return 0, fmt.Errorf("memory incr lock: %w", err)
+	}
+
 	var (
 		valueText []byte
 		expiresAt *time.Time
 	)
 	err = tx.QueryRow(ctx,
 		`SELECT value::text, expires_at FROM memory
-		 WHERE scope = $1 AND scope_id = $2 AND key = $3
-		 FOR UPDATE`,
+		 WHERE scope = $1 AND scope_id = $2 AND key = $3`,
 		string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
 

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -15,8 +15,10 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -473,6 +475,238 @@ func (s *Store) Close() error {
 // future SQLite-to-Postgres data migration tool. Not part of the Store
 // interface — this is package-internal access for the runtime layer.
 func (s *Store) Pool() *pgxpool.Pool { return s.pool }
+
+// MemorySet upserts a Memory row. The value column is JSONB; we cast
+// the input bytes to ::jsonb in the query so the database validates
+// the JSON shape (an invalid payload surfaces as a SQL error rather
+// than a silently-stored bad row).
+func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
+	now := time.Now().UTC()
+	var expiresAt any
+	if ttl > 0 {
+		expiresAt = now.Add(ttl)
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO memory (scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+		 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+		    value = EXCLUDED.value,
+		    expires_at = EXCLUDED.expires_at,
+		    updated_at = EXCLUDED.updated_at`,
+		string(scope), scopeID, key, string(value), expiresAt, now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("memory set: %w", err)
+	}
+	return nil
+}
+
+// MemoryGet returns one entry. Expired rows are surfaced as
+// ErrNotFound (the WHERE clause filters them out so the caller never
+// sees a stale value, even if the sweeper is behind).
+func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
+	var (
+		valueText []byte
+		expiresAt *time.Time
+		createdAt time.Time
+		updatedAt time.Time
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT value::text, expires_at, created_at, updated_at
+		 FROM memory
+		 WHERE scope = $1 AND scope_id = $2 AND key = $3
+		   AND (expires_at IS NULL OR expires_at > NOW())`,
+		string(scope), scopeID, key,
+	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
+	}
+	if err != nil {
+		return store.MemoryEntry{}, fmt.Errorf("memory get: %w", err)
+	}
+	out := store.MemoryEntry{
+		Key:       key,
+		Value:     json.RawMessage(valueText),
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+	if expiresAt != nil {
+		out.ExpiresAt = *expiresAt
+	}
+	return out, nil
+}
+
+// MemoryDelete removes a row. The boolean reports whether a row was
+// actually present. Both branches are non-error.
+func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM memory WHERE scope = $1 AND scope_id = $2 AND key = $3`,
+		string(scope), scopeID, key,
+	)
+	if err != nil {
+		return false, fmt.Errorf("memory delete: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// MemoryList enumerates entries for a (scope, scopeID), filtered by
+// prefix and capped at limit. The query fetches limit+1 rows so we
+// can report truncated == true without a separate COUNT(*).
+func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	pattern := escapeLikePrefix(prefix) + "%"
+	rows, err := s.pool.Query(ctx,
+		`SELECT key, value::text, expires_at, created_at, updated_at
+		 FROM memory
+		 WHERE scope = $1 AND scope_id = $2 AND key LIKE $3 ESCAPE '\'
+		   AND (expires_at IS NULL OR expires_at > NOW())
+		 ORDER BY key ASC
+		 LIMIT $4`,
+		string(scope), scopeID, pattern, limit+1,
+	)
+	if err != nil {
+		return nil, false, fmt.Errorf("memory list: %w", err)
+	}
+	defer rows.Close()
+	var out []store.MemoryEntry
+	for rows.Next() {
+		var (
+			key       string
+			valueText []byte
+			expiresAt *time.Time
+			createdAt time.Time
+			updatedAt time.Time
+		)
+		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt); err != nil {
+			return nil, false, fmt.Errorf("memory list scan: %w", err)
+		}
+		entry := store.MemoryEntry{
+			Key:       key,
+			Value:     json.RawMessage(valueText),
+			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
+		}
+		if expiresAt != nil {
+			entry.ExpiresAt = *expiresAt
+		}
+		out = append(out, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, fmt.Errorf("memory list iter: %w", err)
+	}
+	truncated := false
+	if len(out) > limit {
+		out = out[:limit]
+		truncated = true
+	}
+	return out, truncated, nil
+}
+
+// MemoryIncrement is the atomic counter primitive. We do the parse +
+// add in a single transaction with `FOR UPDATE` row-locking; the
+// existing-value parse is JSON-side because JSONB stores the value as
+// the parsed shape, not as text.
+func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("memory incr begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var (
+		valueText []byte
+		expiresAt *time.Time
+	)
+	err = tx.QueryRow(ctx,
+		`SELECT value::text, expires_at FROM memory
+		 WHERE scope = $1 AND scope_id = $2 AND key = $3
+		 FOR UPDATE`,
+		string(scope), scopeID, key,
+	).Scan(&valueText, &expiresAt)
+
+	now := time.Now().UTC()
+	rowExists := !errors.Is(err, pgx.ErrNoRows)
+	if rowExists && err != nil {
+		return 0, fmt.Errorf("memory incr select: %w", err)
+	}
+	if rowExists && expiresAt != nil && now.After(*expiresAt) {
+		// Treat expired as missing — increment from zero rather than
+		// the stale value.
+		rowExists = false
+	}
+
+	var current int64
+	if rowExists {
+		text := strings.TrimSpace(string(valueText))
+		n, parseErr := strconv.ParseInt(text, 10, 64)
+		if parseErr != nil {
+			var f float64
+			if jsonErr := json.Unmarshal([]byte(text), &f); jsonErr != nil {
+				return 0, store.ErrMemoryWrongType
+			}
+			if f != float64(int64(f)) {
+				return 0, store.ErrMemoryWrongType
+			}
+			n = int64(f)
+		}
+		current = n
+	}
+	next := current + delta
+	nextText := strconv.FormatInt(next, 10)
+
+	var newExpires any
+	switch {
+	case ttl > 0:
+		newExpires = now.Add(ttl)
+	case rowExists && expiresAt != nil:
+		newExpires = *expiresAt // preserve existing expiry
+	}
+
+	if _, err := tx.Exec(ctx,
+		`INSERT INTO memory (scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+		 ON CONFLICT (scope, scope_id, key) DO UPDATE SET
+		    value = EXCLUDED.value,
+		    expires_at = EXCLUDED.expires_at,
+		    updated_at = EXCLUDED.updated_at`,
+		string(scope), scopeID, key, nextText, newExpires, now, now,
+	); err != nil {
+		return 0, fmt.Errorf("memory incr write: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("memory incr commit: %w", err)
+	}
+	return next, nil
+}
+
+// MemorySweep deletes every Memory row whose expires_at has passed.
+// Single atomic DELETE so concurrent sweepers race correctly.
+func (s *Store) MemorySweep(ctx context.Context) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM memory WHERE expires_at IS NOT NULL AND expires_at <= NOW()`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("memory sweep: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// escapeLikePrefix neutralises the LIKE wildcards in `prefix` so an
+// agent searching for "events_2026" doesn't get treated as
+// "events" + any-char + "2026". Backslash is the ESCAPE clause.
+func escapeLikePrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	)
+	return r.Replace(prefix)
+}
 
 // ---- helpers ----
 

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -681,6 +681,40 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	return next, nil
 }
 
+// MemoryListScopeIDs returns distinct scope_ids under scope with
+// summary stats. octet_length(value::text) is used for the bytes
+// estimate — JSONB has no LENGTH() in the SQLite sense; the textual
+// representation is what an operator cares about anyway. Capped at
+// 200 rows ordered by updated_at DESC.
+func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			scope_id,
+			COUNT(*)                                                          AS key_count,
+			COALESCE(SUM(octet_length(key) + octet_length(value::text)), 0)   AS bytes,
+			MAX(updated_at)                                                   AS updated_at
+		FROM memory
+		WHERE scope = $1 AND (expires_at IS NULL OR expires_at > NOW())
+		GROUP BY scope_id
+		ORDER BY updated_at DESC
+		LIMIT 200`,
+		string(scope),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("memory list scope ids: %w", err)
+	}
+	defer rows.Close()
+	var out []store.MemoryScopeIDSummary
+	for rows.Next() {
+		var summary store.MemoryScopeIDSummary
+		if err := rows.Scan(&summary.ScopeID, &summary.KeyCount, &summary.Bytes, &summary.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("memory list scope ids scan: %w", err)
+		}
+		out = append(out, summary)
+	}
+	return out, rows.Err()
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 // Single atomic DELETE so concurrent sweepers race correctly.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -702,18 +702,37 @@ func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID
 // arithmetic + write in an IMMEDIATE transaction (a write lock at
 // the BEGIN). Concurrent increments serialise on the lock; the
 // loop is contention-free in the absence of writes.
+//
+// modernc/sqlite's database/sql driver does NOT translate
+// `sql.LevelSerializable` to `BEGIN IMMEDIATE` — it only honors
+// `_txlock=immediate` in the DSN (which would affect every
+// transaction, including read paths where DEFERRED is preferred).
+// We therefore pin a connection from the pool and issue
+// `BEGIN IMMEDIATE` / `COMMIT` raw, scoping the lock-on-BEGIN
+// behaviour to this one operation. Verified by a 100-goroutine
+// regression test in storetest (counter must hit exactly 100).
 func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	conn, err := s.db.Conn(ctx)
 	if err != nil {
 		return 0, err
 	}
-	defer func() { _ = tx.Rollback() }()
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return 0, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
 
 	var (
 		valueText sql.NullString
 		expiresAt sql.NullInt64
 	)
-	err = tx.QueryRowContext(ctx,
+	err = conn.QueryRowContext(ctx,
 		`SELECT value, expires_at FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
 		string(scope), scopeID, key,
 	).Scan(&valueText, &expiresAt)
@@ -758,7 +777,7 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 		newExpires = expiresAt.Int64 // preserve existing expiry
 	}
 
-	_, err = tx.ExecContext(ctx,
+	_, err = conn.ExecContext(ctx,
 		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
@@ -770,9 +789,10 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	if err != nil {
 		return 0, err
 	}
-	if err := tx.Commit(); err != nil {
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 		return 0, err
 	}
+	committed = true
 	return next, nil
 }
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -776,6 +776,43 @@ func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, sc
 	return next, nil
 }
 
+// MemoryListScopeIDs returns distinct scope_ids under scope with
+// summary stats. Excludes expired rows so operators see live state
+// only. Capped at 200 rows ordered by updated_at DESC.
+func (s *Store) MemoryListScopeIDs(ctx context.Context, scope store.MemoryScope) ([]store.MemoryScopeIDSummary, error) {
+	nowNs := time.Now().UnixNano()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			scope_id,
+			COUNT(*)                                              AS key_count,
+			COALESCE(SUM(LENGTH(key) + LENGTH(value)), 0)          AS bytes,
+			MAX(updated_at)                                        AS updated_at
+		FROM memory
+		WHERE scope = ? AND (expires_at IS NULL OR expires_at > ?)
+		GROUP BY scope_id
+		ORDER BY updated_at DESC
+		LIMIT 200`,
+		string(scope), nowNs,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.MemoryScopeIDSummary
+	for rows.Next() {
+		var (
+			summary   store.MemoryScopeIDSummary
+			updatedNs int64
+		)
+		if err := rows.Scan(&summary.ScopeID, &summary.KeyCount, &summary.Bytes, &updatedNs); err != nil {
+			return nil, err
+		}
+		summary.UpdatedAt = time.Unix(0, updatedNs).UTC()
+		out = append(out, summary)
+	}
+	return out, rows.Err()
+}
+
 // MemorySweep deletes every Memory row whose expires_at has passed.
 func (s *Store) MemorySweep(ctx context.Context) (int, error) {
 	res, err := s.db.ExecContext(ctx,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -8,8 +8,10 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -96,6 +98,20 @@ func (s *Store) migrate(ctx context.Context) error {
 			payload    BLOB NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS events_by_session ON events(session_id, seq)`,
+		// v0.8 Memory tool. PRIMARY KEY (scope, scope_id, key) gives
+		// the natural lookup index; the partial expires_at index keeps
+		// the sweeper's DELETE cheap (no full-table scan).
+		`CREATE TABLE IF NOT EXISTS memory (
+			scope       TEXT NOT NULL,
+			scope_id    TEXT NOT NULL,
+			key         TEXT NOT NULL,
+			value       TEXT NOT NULL,
+			expires_at  INTEGER,
+			created_at  INTEGER NOT NULL,
+			updated_at  INTEGER NOT NULL,
+			PRIMARY KEY (scope, scope_id, key)
+		)`,
+		`CREATE INDEX IF NOT EXISTS memory_by_expires_at ON memory(expires_at) WHERE expires_at IS NOT NULL`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -544,6 +560,251 @@ func (s *Store) SweepStaleRuns(ctx context.Context, cutoff time.Time) (int, erro
 		return 0, nil
 	}
 	return int(n), nil
+}
+
+// MemorySet upserts a Memory row. ttl > 0 sets expires_at = now+ttl;
+// ttl <= 0 clears the column to NULL (no expiry).
+//
+// Stored as JSON text in a TEXT column — SQLite has no native JSON
+// type beyond what JSON1 functions consume; the tool layer is the
+// source of truth for shape validation. (We also use the textual
+// representation for the JSON-number parse in MemoryIncrement.)
+func (s *Store) MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error {
+	now := time.Now().UnixNano()
+	var expiresAt any
+	if ttl > 0 {
+		expiresAt = time.Now().Add(ttl).UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
+		    value = excluded.value,
+		    expires_at = excluded.expires_at,
+		    updated_at = excluded.updated_at`,
+		string(scope), scopeID, key, string(value), expiresAt, now, now,
+	)
+	return err
+}
+
+// MemoryGet returns the entry or *ErrNotFound. Expired rows are
+// surfaced as ErrNotFound regardless of whether the sweeper has
+// reaped them yet.
+func (s *Store) MemoryGet(ctx context.Context, scope store.MemoryScope, scopeID, key string) (store.MemoryEntry, error) {
+	var (
+		valueText string
+		expiresAt sql.NullInt64
+		createdAt int64
+		updatedAt int64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT value, expires_at, created_at, updated_at
+		 FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
+		string(scope), scopeID, key,
+	).Scan(&valueText, &expiresAt, &createdAt, &updatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
+	}
+	if err != nil {
+		return store.MemoryEntry{}, err
+	}
+	if expiresAt.Valid && time.Now().UnixNano() > expiresAt.Int64 {
+		return store.MemoryEntry{}, &store.ErrNotFound{Kind: "memory", ID: key}
+	}
+	out := store.MemoryEntry{
+		Key:       key,
+		Value:     json.RawMessage(valueText),
+		CreatedAt: time.Unix(0, createdAt),
+		UpdatedAt: time.Unix(0, updatedAt),
+	}
+	if expiresAt.Valid {
+		out.ExpiresAt = time.Unix(0, expiresAt.Int64)
+	}
+	return out, nil
+}
+
+// MemoryDelete removes a row. Returns whether a row was actually
+// deleted; both outcomes are non-error.
+func (s *Store) MemoryDelete(ctx context.Context, scope store.MemoryScope, scopeID, key string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
+		string(scope), scopeID, key,
+	)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, nil
+	}
+	return n > 0, nil
+}
+
+// MemoryList enumerates entries for a (scope, scopeID), filtered by
+// prefix and capped at limit rows. Expired rows are filtered in the
+// WHERE clause so callers never see them. truncated == true when the
+// underlying query found at least limit+1 rows.
+func (s *Store) MemoryList(ctx context.Context, scope store.MemoryScope, scopeID, prefix string, limit int) ([]store.MemoryEntry, bool, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	nowNs := time.Now().UnixNano()
+	// Fetch limit+1 to detect truncation without a separate COUNT(*).
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT key, value, expires_at, created_at, updated_at
+		 FROM memory
+		 WHERE scope = ? AND scope_id = ? AND key LIKE ? ESCAPE '\'
+		   AND (expires_at IS NULL OR expires_at > ?)
+		 ORDER BY key ASC
+		 LIMIT ?`,
+		string(scope), scopeID, escapeLikePrefix(prefix)+"%", nowNs, limit+1,
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	defer rows.Close()
+	var out []store.MemoryEntry
+	for rows.Next() {
+		var (
+			key       string
+			valueText string
+			expiresAt sql.NullInt64
+			createdAt int64
+			updatedAt int64
+		)
+		if err := rows.Scan(&key, &valueText, &expiresAt, &createdAt, &updatedAt); err != nil {
+			return nil, false, err
+		}
+		entry := store.MemoryEntry{
+			Key:       key,
+			Value:     json.RawMessage(valueText),
+			CreatedAt: time.Unix(0, createdAt),
+			UpdatedAt: time.Unix(0, updatedAt),
+		}
+		if expiresAt.Valid {
+			entry.ExpiresAt = time.Unix(0, expiresAt.Int64)
+		}
+		out = append(out, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, false, err
+	}
+	truncated := false
+	if len(out) > limit {
+		out = out[:limit]
+		truncated = true
+	}
+	return out, truncated, nil
+}
+
+// MemoryIncrement is the atomic counter primitive. SQLite has no
+// native compare-and-set on JSON values, so we wrap the read +
+// arithmetic + write in an IMMEDIATE transaction (a write lock at
+// the BEGIN). Concurrent increments serialise on the lock; the
+// loop is contention-free in the absence of writes.
+func (s *Store) MemoryIncrement(ctx context.Context, scope store.MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var (
+		valueText sql.NullString
+		expiresAt sql.NullInt64
+	)
+	err = tx.QueryRowContext(ctx,
+		`SELECT value, expires_at FROM memory WHERE scope = ? AND scope_id = ? AND key = ?`,
+		string(scope), scopeID, key,
+	).Scan(&valueText, &expiresAt)
+	now := time.Now()
+	nowNs := now.UnixNano()
+
+	var current int64
+	rowExists := !errors.Is(err, sql.ErrNoRows)
+	if rowExists && err != nil {
+		return 0, err
+	}
+	// Treat expired rows as missing — increment from zero rather than
+	// the stale value.
+	if rowExists && expiresAt.Valid && nowNs > expiresAt.Int64 {
+		rowExists = false
+	}
+	if rowExists {
+		text := strings.TrimSpace(valueText.String)
+		n, parseErr := strconv.ParseInt(text, 10, 64)
+		if parseErr != nil {
+			// Fall back to JSON parse: covers floats expressed as
+			// integers ("3.0") which strconv rejects but JSON allows.
+			var f float64
+			if jsonErr := json.Unmarshal([]byte(text), &f); jsonErr != nil {
+				return 0, store.ErrMemoryWrongType
+			}
+			if f != float64(int64(f)) {
+				return 0, store.ErrMemoryWrongType
+			}
+			n = int64(f)
+		}
+		current = n
+	}
+	next := current + delta
+	nextText := strconv.FormatInt(next, 10)
+
+	var newExpires any
+	switch {
+	case ttl > 0:
+		newExpires = now.Add(ttl).UnixNano()
+	case rowExists && expiresAt.Valid:
+		newExpires = expiresAt.Int64 // preserve existing expiry
+	}
+
+	_, err = tx.ExecContext(ctx,
+		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(scope, scope_id, key) DO UPDATE SET
+		    value = excluded.value,
+		    expires_at = excluded.expires_at,
+		    updated_at = excluded.updated_at`,
+		string(scope), scopeID, key, nextText, newExpires, nowNs, nowNs,
+	)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return next, nil
+}
+
+// MemorySweep deletes every Memory row whose expires_at has passed.
+func (s *Store) MemorySweep(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM memory WHERE expires_at IS NOT NULL AND expires_at <= ?`,
+		time.Now().UnixNano(),
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, nil
+	}
+	return int(n), nil
+}
+
+// escapeLikePrefix escapes the LIKE wildcards in `prefix` so an agent
+// passing "events_2026" doesn't get treated as "events" + any-char +
+// "2026". The ESCAPE clause in the LIKE statement uses backslash.
+func escapeLikePrefix(prefix string) string {
+	if prefix == "" {
+		return ""
+	}
+	r := strings.NewReplacer(
+		`\`, `\\`,
+		`%`, `\%`,
+		`_`, `\_`,
+	)
+	return r.Replace(prefix)
 }
 
 // nilIfEmpty returns nil when s is empty so the SQL driver writes NULL

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -273,6 +273,13 @@ type Store interface {
 	// DELETE).
 	MemorySweep(ctx context.Context) (int, error)
 
+	// MemoryListScopeIDs returns one row per distinct scope_id under
+	// the given scope, with summary stats (key count, total bytes,
+	// most recent updated_at). Drives the v0.8.0 Web UI's Memory
+	// page picker. Expired rows are excluded — operators see live
+	// state only. Capped at 200 rows ordered by updated_at DESC.
+	MemoryListScopeIDs(ctx context.Context, scope MemoryScope) ([]MemoryScopeIDSummary, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -302,6 +309,17 @@ type MemoryEntry struct {
 	ExpiresAt time.Time       `json:"expires_at,omitempty"`
 	CreatedAt time.Time       `json:"created_at"`
 	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// MemoryScopeIDSummary is one row of MemoryListScopeIDs' output.
+// KeyCount is the live key count (expired rows excluded). Bytes is
+// the sum of key+value bytes — gives operators a quick "how full is
+// this scope" view in the UI.
+type MemoryScopeIDSummary struct {
+	ScopeID   string    `json:"scope_id"`
+	KeyCount  int       `json:"key_count"`
+	Bytes     int       `json:"bytes"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // ErrMemoryWrongType is returned by MemoryIncrement when the existing

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ package store
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 )
 
@@ -230,9 +231,103 @@ type Store interface {
 	// Used by internal/heartbeat for the periodic sweep goroutine.
 	SweepStaleRuns(ctx context.Context, cutoff time.Time) (int, error)
 
+	// MemorySet writes a Memory entry. ttl > 0 sets an expiry; ttl <= 0
+	// stores with no expiry (the row's expires_at column is NULL). The
+	// row is upserted on the (scope, scopeID, key) primary key —
+	// re-writes overwrite the value and bump updated_at. Implementations
+	// are responsible for surfacing wire-level constraints (max value
+	// bytes, scope quota) as ErrMemoryQuotaExceeded — the tool layer
+	// trusts the store's verdict.
+	MemorySet(ctx context.Context, scope MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
+
+	// MemoryGet reads one entry. Returns *ErrNotFound for both "key
+	// missing" and "key expired" — callers don't need to distinguish.
+	// Implementations MUST treat an entry whose expires_at is in the
+	// past as missing (returns ErrNotFound) regardless of whether the
+	// sweeper has reaped it yet — the sweeper is best-effort.
+	MemoryGet(ctx context.Context, scope MemoryScope, scopeID, key string) (MemoryEntry, error)
+
+	// MemoryDelete removes an entry. Returns true when a row was
+	// actually deleted, false when the key didn't exist (or had
+	// already expired). Both are non-error paths.
+	MemoryDelete(ctx context.Context, scope MemoryScope, scopeID, key string) (bool, error)
+
+	// MemoryList returns entries for the (scope, scopeID) tuple whose
+	// key starts with prefix. An empty prefix returns every key in the
+	// scope. Capped at limit rows; if more rows would match, callers
+	// see truncated == true. Expired rows are filtered out — callers
+	// never see them.
+	MemoryList(ctx context.Context, scope MemoryScope, scopeID, prefix string, limit int) (entries []MemoryEntry, truncated bool, err error)
+
+	// MemoryIncrement is an atomic add over the JSON-number value at
+	// (scope, scopeID, key). If the key doesn't exist, it's created
+	// with the delta as the value. If the existing value isn't a
+	// JSON number, returns ErrMemoryWrongType. Optional ttl sets (or
+	// resets, on a re-incr) the expiry; ttl <= 0 keeps the existing
+	// expiry untouched (or no expiry on a fresh row).
+	MemoryIncrement(ctx context.Context, scope MemoryScope, scopeID, key string, delta int64, ttl time.Duration) (int64, error)
+
+	// MemorySweep deletes every Memory row whose expires_at has passed.
+	// Returns the row count deleted. Safe to run from a periodic
+	// goroutine; idempotent under concurrent sweepers (single atomic
+	// DELETE).
+	MemorySweep(ctx context.Context) (int, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
+
+// MemoryScope is the addressing axis for a Memory row. v0.8.0 ships
+// `agent` and `user`; the type is forward-compatible for adding
+// `session` / `tenant` later — a new scope value is a yaml + adapter
+// allowlist update, not a wire-protocol change.
+type MemoryScope string
+
+const (
+	// MemoryScopeAgent — keyed by yaml agent name. Cross-run state for
+	// one agent type (counters, summaries, learned facts).
+	MemoryScopeAgent MemoryScope = "agent"
+	// MemoryScopeUser — keyed by user_id. Per-end-user state shared
+	// across every agent that's allowed to read the `user` scope.
+	MemoryScopeUser MemoryScope = "user"
+)
+
+// MemoryEntry is one row in the memory table. ExpiresAt is zero when
+// the row has no expiry. CreatedAt and UpdatedAt are the row's
+// lifecycle timestamps; UpdatedAt advances on overwrite or
+// MemoryIncrement.
+type MemoryEntry struct {
+	Key       string          `json:"key"`
+	Value     json.RawMessage `json:"value"`
+	ExpiresAt time.Time       `json:"expires_at,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// ErrMemoryWrongType is returned by MemoryIncrement when the existing
+// value at the target key is not a JSON number. Callers (the Memory
+// tool) surface this as a typed tool-result error.
+var ErrMemoryWrongType = &MemoryError{Code: "wrong_type", Msg: "memory: existing value is not a JSON number"}
+
+// ErrMemoryQuotaExceeded is returned by MemorySet / MemoryIncrement
+// when the write would push the (scope, scopeID) tuple past its
+// configured byte cap. The caller should drop or replace existing
+// keys; loomcycle does not auto-evict.
+var ErrMemoryQuotaExceeded = &MemoryError{Code: "quota_exceeded", Msg: "memory: scope quota exceeded"}
+
+// ErrMemoryValueTooLarge is returned when a single value exceeds the
+// per-write byte cap (LOOMCYCLE_MEMORY_MAX_VALUE_BYTES).
+var ErrMemoryValueTooLarge = &MemoryError{Code: "value_too_large", Msg: "memory: value exceeds max bytes"}
+
+// MemoryError is a typed error so the Memory tool can surface a
+// stable error code to the agent. The Code is wire-stable; the Msg
+// is human-readable and may evolve.
+type MemoryError struct {
+	Code string
+	Msg  string
+}
+
+func (e *MemoryError) Error() string { return e.Msg }
 
 // ErrNotFound is returned when a session or run ID isn't in the store.
 type ErrNotFound struct {

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -24,6 +24,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -77,6 +80,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryIncrementOnExpiredKey", testMemoryIncrementOnExpiredKey},
 		{"MemoryScopeIsolation", testMemoryScopeIsolation},
 		{"MemoryListScopeIDs", testMemoryListScopeIDs},
+		{"MemoryIncrementIsAtomicUnderConcurrency", testMemoryIncrementIsAtomicUnderConcurrency},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -940,6 +944,53 @@ func testMemoryListScopeIDs(t *testing.T, s store.Store) {
 			t.Errorf("expired-only scope_id %q should not appear", u.ScopeID)
 		}
 	}
+}
+
+// testMemoryIncrementIsAtomicUnderConcurrency is a regression test
+// for two adapter-level bugs caught in v0.8.0 review:
+//
+//   - SQLite's BeginTx(nil) gives a DEFERRED transaction, not the
+//     IMMEDIATE the increment loop assumes. Two concurrent increments
+//     on the same key both see the old value and both write the same
+//     "next" value, losing one update.
+//   - Postgres's SELECT FOR UPDATE on a non-existent row does NOT
+//     block the second transaction (there's no row to lock). Both
+//     transactions see ErrNoRows, both INSERT (one wins outright,
+//     the second's ON CONFLICT DO UPDATE overwrites the first's
+//     value with delta — losing the first's contribution).
+//
+// 100 concurrent +1 increments must produce exactly 100. A failing
+// adapter shows a final value < 100 (number of lost updates).
+func testMemoryIncrementIsAtomicUnderConcurrency(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const N = 100
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "counter", 1, 0)
+		}()
+	}
+	wg.Wait()
+
+	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "counter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strconv.Itoa(N)
+	if string(got.Value) != want {
+		t.Errorf("concurrent increments: counter = %s, want %s (%d lost updates)",
+			got.Value, want, N-mustParseInt(string(got.Value)))
+	}
+}
+
+func mustParseInt(s string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // intToKey is a tiny helper for testMemoryListTruncation — keeps the

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -76,6 +76,7 @@ func Run(t *testing.T, factory Factory) {
 		{"MemoryIncrementOnNonNumberFails", testMemoryIncrementOnNonNumberFails},
 		{"MemoryIncrementOnExpiredKey", testMemoryIncrementOnExpiredKey},
 		{"MemoryScopeIsolation", testMemoryScopeIsolation},
+		{"MemoryListScopeIDs", testMemoryListScopeIDs},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -890,6 +891,54 @@ func testMemoryScopeIsolation(t *testing.T, s store.Store) {
 	list, _, _ := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "", 100)
 	if len(list) != 1 {
 		t.Errorf("alice-scope list returned %d rows, want 1", len(list))
+	}
+}
+
+func testMemoryListScopeIDs(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// alice: 2 keys; bob: 1 key; qa-agent: 1 key.
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "voice", json.RawMessage(`"a1"`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "tone", json.RawMessage(`"a2"`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "bob", "voice", json.RawMessage(`"b1"`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa-agent", "warnings", json.RawMessage(`5`), 0)
+
+	users, err := s.MemoryListScopeIDs(ctx, store.MemoryScopeUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]int{}
+	for _, u := range users {
+		got[u.ScopeID] = u.KeyCount
+		if u.UpdatedAt.IsZero() {
+			t.Errorf("%s.UpdatedAt is zero", u.ScopeID)
+		}
+		if u.Bytes <= 0 {
+			t.Errorf("%s.Bytes = %d, want > 0", u.ScopeID, u.Bytes)
+		}
+	}
+	if got["alice"] != 2 || got["bob"] != 1 {
+		t.Errorf("user-scope summary: %v, want alice=2 bob=1", got)
+	}
+	if _, ok := got["qa-agent"]; ok {
+		t.Errorf("user-scope listing should not include agent-scope rows: %v", got)
+	}
+
+	agents, err := s.MemoryListScopeIDs(ctx, store.MemoryScopeAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(agents) != 1 || agents[0].ScopeID != "qa-agent" {
+		t.Errorf("agent-scope summary: %+v", agents)
+	}
+
+	// Expired rows must not surface in the summary.
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "transient", "k", json.RawMessage(`1`), 30*time.Millisecond)
+	time.Sleep(60 * time.Millisecond)
+	users2, _ := s.MemoryListScopeIDs(ctx, store.MemoryScopeUser)
+	for _, u := range users2 {
+		if u.ScopeID == "transient" {
+			t.Errorf("expired-only scope_id %q should not appear", u.ScopeID)
+		}
 	}
 }
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -22,6 +22,7 @@ package storetest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -62,6 +63,19 @@ func Run(t *testing.T, factory Factory) {
 		{"FinishRunCancelledTerminal", testFinishRunCancelledTerminal},
 		{"TranscriptOrderedAcrossRuns", testTranscriptOrderedAcrossRuns},
 		{"SweepStaleRuns", testSweepStaleRuns},
+		{"MemorySetGetRoundTrip", testMemorySetGetRoundTrip},
+		{"MemoryGetNotFound", testMemoryGetNotFound},
+		{"MemoryOverwriteUpdatesValue", testMemoryOverwriteUpdatesValue},
+		{"MemoryDelete", testMemoryDelete},
+		{"MemoryListPrefix", testMemoryListPrefix},
+		{"MemoryListTruncation", testMemoryListTruncation},
+		{"MemoryTTLExpiry", testMemoryTTLExpiry},
+		{"MemorySweepReapsExpired", testMemorySweepReapsExpired},
+		{"MemoryIncrementOnNewKey", testMemoryIncrementOnNewKey},
+		{"MemoryIncrementOnExistingNumber", testMemoryIncrementOnExistingNumber},
+		{"MemoryIncrementOnNonNumberFails", testMemoryIncrementOnNonNumberFails},
+		{"MemoryIncrementOnExpiredKey", testMemoryIncrementOnExpiredKey},
+		{"MemoryScopeIsolation", testMemoryScopeIsolation},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -595,4 +609,296 @@ func testTranscriptOrderedAcrossRuns(t *testing.T, s store.Store) {
 	if transcript[2].RunID != runB.ID || transcript[3].RunID != runB.ID {
 		t.Errorf("last two events should belong to runB")
 	}
+}
+
+// ----- Memory contract -----
+//
+// These tests exercise the v0.8.0 Memory tool's storage surface.
+// Both backends implement identical semantics, so the suite runs
+// unchanged against SQLite (TEXT-as-JSON column) and Postgres (JSONB).
+
+func testMemorySetGetRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	value := json.RawMessage(`{"style":"concise","tone":"friendly"}`)
+	if err := s.MemorySet(ctx, store.MemoryScopeUser, "alice", "voice", value, 0); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.MemoryGet(ctx, store.MemoryScopeUser, "alice", "voice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Key != "voice" {
+		t.Errorf("key = %q, want voice", got.Key)
+	}
+	// Compare by parsed shape — JSONB may reorder keys / drop whitespace.
+	var a, b map[string]any
+	if err := json.Unmarshal(value, &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(got.Value, &b); err != nil {
+		t.Fatalf("stored value not valid JSON: %v", err)
+	}
+	if a["style"] != b["style"] || a["tone"] != b["tone"] {
+		t.Errorf("value round-trip diverged: stored=%v got=%v", a, b)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Error("created_at / updated_at must be set on a fresh write")
+	}
+	if !got.ExpiresAt.IsZero() {
+		t.Errorf("expires_at should be zero for ttl=0; got %v", got.ExpiresAt)
+	}
+}
+
+func testMemoryGetNotFound(t *testing.T, s store.Store) {
+	_, err := s.MemoryGet(context.Background(), store.MemoryScopeAgent, "qa-agent", "missing")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
+	}
+}
+
+func testMemoryOverwriteUpdatesValue(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v1"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	first, _ := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "summary")
+	time.Sleep(2 * time.Millisecond)
+	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "summary", json.RawMessage(`"v2"`), 0); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "summary")
+	if string(second.Value) == string(first.Value) {
+		t.Error("overwrite did not change the stored value")
+	}
+	if !second.UpdatedAt.After(first.UpdatedAt) {
+		t.Errorf("updated_at not advanced: first=%v second=%v", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
+func testMemoryDelete(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u1", "k", json.RawMessage(`1`), 0)
+
+	deleted, err := s.MemoryDelete(ctx, store.MemoryScopeUser, "u1", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deleted {
+		t.Error("expected deleted=true on a present key")
+	}
+	deleted, err = s.MemoryDelete(ctx, store.MemoryScopeUser, "u1", "k")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted {
+		t.Error("expected deleted=false on a missing key")
+	}
+}
+
+func testMemoryListPrefix(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for k, v := range map[string]string{
+		"events/2026-05-09T10:00": `"a"`,
+		"events/2026-05-09T11:00": `"b"`,
+		"events/2026-05-10T09:00": `"c"`,
+		"prefs/voice":             `"d"`,
+		"prefs/timezone":          `"e"`,
+	} {
+		if err := s.MemorySet(ctx, store.MemoryScopeUser, "alice", k, json.RawMessage(v), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, truncated, err := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "events/", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if truncated {
+		t.Errorf("truncated unexpectedly")
+	}
+	if len(got) != 3 {
+		t.Errorf("len = %d, want 3 (events/* only)", len(got))
+	}
+	for _, e := range got {
+		if len(e.Key) < len("events/") || e.Key[:len("events/")] != "events/" {
+			t.Errorf("non-prefix-matching key in result: %q", e.Key)
+		}
+	}
+	// Empty prefix returns everything in the scope.
+	all, _, err := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "", 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 5 {
+		t.Errorf("empty prefix len = %d, want 5", len(all))
+	}
+}
+
+func testMemoryListTruncation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "key/"+intToKey(i), json.RawMessage(`1`), 0)
+	}
+	got, truncated, err := s.MemoryList(ctx, store.MemoryScopeAgent, "qa", "key/", 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !truncated {
+		t.Error("truncated should be true when more rows exist than limit")
+	}
+	if len(got) != 3 {
+		t.Errorf("len = %d, want 3", len(got))
+	}
+}
+
+func testMemoryTTLExpiry(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// 50 ms TTL — short enough for a test, long enough to survive the
+	// initial Get on a slow CI runner.
+	if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "warning", json.RawMessage(`"hi"`), 50*time.Millisecond); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "warning")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ExpiresAt.IsZero() {
+		t.Error("expires_at should be set when ttl > 0")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	_, err = s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "warning")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("expired key should return ErrNotFound, got %v", err)
+	}
+
+	// MemoryList must filter expired entries even before the sweeper
+	// runs.
+	listed, _, err := s.MemoryList(ctx, store.MemoryScopeAgent, "qa", "warning", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listed) != 0 {
+		t.Errorf("MemoryList returned expired row(s): %d", len(listed))
+	}
+}
+
+func testMemorySweepReapsExpired(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u", "transient", json.RawMessage(`1`), 30*time.Millisecond)
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "u", "permanent", json.RawMessage(`1`), 0)
+
+	time.Sleep(60 * time.Millisecond)
+	deleted, err := s.MemorySweep(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted < 1 {
+		t.Errorf("MemorySweep reaped %d, want >=1", deleted)
+	}
+	// Idempotent: second sweep right after is a no-op.
+	deleted2, err := s.MemorySweep(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted2 != 0 {
+		t.Errorf("second sweep reaped %d, want 0", deleted2)
+	}
+	// Permanent row must survive.
+	if _, err := s.MemoryGet(ctx, store.MemoryScopeUser, "u", "permanent"); err != nil {
+		t.Errorf("permanent row was reaped: %v", err)
+	}
+}
+
+func testMemoryIncrementOnNewKey(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "warnings", 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("incr on new key = %d, want 1", got)
+	}
+	got, err = s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "warnings", 5, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 6 {
+		t.Errorf("incr by 5 on existing 1 = %d, want 6", got)
+	}
+}
+
+func testMemoryIncrementOnExistingNumber(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "n", json.RawMessage(`42`), 0)
+	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "n", -10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 32 {
+		t.Errorf("incr by -10 on 42 = %d, want 32", got)
+	}
+}
+
+func testMemoryIncrementOnNonNumberFails(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "obj", json.RawMessage(`{"hello":"world"}`), 0)
+	_, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "obj", 1, 0)
+	if !errors.Is(err, store.ErrMemoryWrongType) {
+		t.Errorf("got %v, want ErrMemoryWrongType", err)
+	}
+}
+
+func testMemoryIncrementOnExpiredKey(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "k", json.RawMessage(`100`), 30*time.Millisecond)
+	time.Sleep(60 * time.Millisecond)
+	got, err := s.MemoryIncrement(ctx, store.MemoryScopeAgent, "qa", "k", 1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Errorf("incr on expired key should restart from 0; got %d, want 1", got)
+	}
+}
+
+func testMemoryScopeIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "alice", "secret", json.RawMessage(`"alice-secret"`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeUser, "bob", "secret", json.RawMessage(`"bob-secret"`), 0)
+	_ = s.MemorySet(ctx, store.MemoryScopeAgent, "qa", "secret", json.RawMessage(`"qa-secret"`), 0)
+
+	a, err := s.MemoryGet(ctx, store.MemoryScopeUser, "alice", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.MemoryGet(ctx, store.MemoryScopeUser, "bob", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	q, err := s.MemoryGet(ctx, store.MemoryScopeAgent, "qa", "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a.Value) == string(b.Value) || string(a.Value) == string(q.Value) {
+		t.Errorf("scope isolation broken: alice=%s bob=%s qa=%s", a.Value, b.Value, q.Value)
+	}
+
+	// Listing one (scope, scopeID) must not surface another's keys.
+	list, _, _ := s.MemoryList(ctx, store.MemoryScopeUser, "alice", "", 100)
+	if len(list) != 1 {
+		t.Errorf("alice-scope list returned %d rows, want 1", len(list))
+	}
+}
+
+// intToKey is a tiny helper for testMemoryListTruncation — keeps the
+// keys lex-sortable so the prefix LIKE behaves predictably.
+func intToKey(i int) string {
+	const digits = "0123456789"
+	if i < 10 {
+		return string(digits[i])
+	}
+	return string(digits[i/10]) + string(digits[i%10])
 }

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -301,17 +301,24 @@ func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeI
 	// the worst case; in practice scopes hold a handful of summary
 	// keys. If we ever need to scale this, we'll add a cached
 	// per-(scope, scope_id) byte counter via a SQL trigger.
+	//
+	// We treat truncation (>1000 keys in scope) as a quota refusal:
+	// undercounting would let a thousand-tiny-key agent slip past the
+	// cap silently. An agent that hits this limit should `delete`
+	// rows before writing more, or operators should bump the quota.
 	const listCap = 1000
-	entries, _, err := m.Store.MemoryList(ctx, scope, scopeID, "", listCap)
+	entries, truncated, err := m.Store.MemoryList(ctx, scope, scopeID, "", listCap)
 	if err != nil {
 		return fmt.Errorf("quota check: %w", err)
 	}
+	if truncated {
+		return fmt.Errorf("Memory.set: scope %q has more than %d keys; quota check cannot run accurately — delete unused keys first",
+			scope, listCap)
+	}
 	used := 0
-	keyExists := false
 	for _, e := range entries {
 		used += len(e.Key) + len(e.Value)
 		if e.Key == key {
-			keyExists = true
 			// Subtract the existing row's bytes — we'll re-add
 			// the new size below to compute the post-write total.
 			used -= len(e.Key) + len(e.Value)
@@ -319,7 +326,6 @@ func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeI
 	}
 	projected := used + len(key) + addBytes
 	if projected > quota {
-		_ = keyExists
 		return fmt.Errorf("Memory.set: scope %q quota %d bytes would be exceeded by this write (current=%d, after=%d)",
 			scope, quota, used, projected)
 	}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -1,0 +1,365 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Memory is the v0.8.0 built-in tool that exposes persistent
+// agent-scoped key/value storage to the model.
+//
+// Five operations, discriminated by the `op` field:
+//
+//	get     — read one entry by key
+//	set     — write/overwrite one entry, optional TTL (seconds)
+//	delete  — remove one entry; returns whether it existed
+//	list    — enumerate keys with an optional prefix filter
+//	incr    — atomic add over a JSON-number value (counter primitive)
+//
+// scope_id is RESOLVED SERVER-SIDE based on the agent's run context —
+// the model picks the SCOPE (agent vs user); loomcycle picks the
+// SCOPE_ID:
+//
+//   - scope=agent → yaml agent name from tools.AgentName(ctx)
+//   - scope=user  → user_id from tools.RunIdentity(ctx)
+//
+// This split is non-negotiable: a model-supplied scope_id would let
+// one user's agent run read another user's keys.
+//
+// Quota enforcement happens at write time (set / incr). The agent's
+// per-yaml `memory_quota_bytes` overrides the global default; both
+// land via tools.MemoryPolicy(ctx).
+type Memory struct {
+	// Store is the persistence backend. Required; nil disables the
+	// tool entirely (every call returns an is_error tool_result with
+	// a "Memory not configured" message — operators see one clear
+	// failure rather than panics).
+	Store store.Store
+
+	// MaxValueBytes caps a single write's value size (the Set / Incr
+	// payload). 0 = no per-write cap. Sourced from
+	// LOOMCYCLE_MEMORY_MAX_VALUE_BYTES.
+	MaxValueBytes int
+
+	// DefaultQuotaBytes is the per-(scope, scope_id) byte cap when
+	// the agent yaml doesn't override it. 0 = no cap. Sourced from
+	// LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES.
+	DefaultQuotaBytes int
+}
+
+const memoryDescription = `Persistent key/value storage scoped to this agent or end-user. ` +
+	`Survives across runs and sessions. Use for: counters, summaries, voice/preferences, ` +
+	`learned facts, notes for your future self. ` +
+	`Operations: get, set, delete, list, incr. ` +
+	`Scope is "agent" (this agent's keyspace, shared across users) or "user" (this end-user's keyspace, shared across agents). ` +
+	`Values are JSON. Optional TTL is in seconds.`
+
+const memoryInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":     {"type": "string", "enum": ["get","set","delete","list","incr"], "description": "Which operation to perform."},
+    "scope":  {"type": "string", "enum": ["agent","user"], "description": "Which keyspace: this agent's (cross-run, cross-user) or this user's (cross-agent)."},
+    "key":    {"type": "string", "description": "The entry's key. Required for get / set / delete / incr."},
+    "value":  {"description": "The JSON value to store. Required for set."},
+    "delta":  {"type": "integer", "description": "Increment delta for incr (default 1, may be negative)."},
+    "ttl":    {"type": "integer", "description": "Optional time-to-live in seconds. Applies to set and incr; 0 means no expiry."},
+    "prefix": {"type": "string", "description": "Optional key prefix filter for list."},
+    "limit":  {"type": "integer", "description": "Maximum entries to return for list (default 100)."}
+  },
+  "required": ["op","scope"],
+  "additionalProperties": false
+}`
+
+type memoryInput struct {
+	Op     string          `json:"op"`
+	Scope  string          `json:"scope"`
+	Key    string          `json:"key,omitempty"`
+	Value  json.RawMessage `json:"value,omitempty"`
+	Delta  *int64          `json:"delta,omitempty"`
+	TTL    int64           `json:"ttl,omitempty"`
+	Prefix string          `json:"prefix,omitempty"`
+	Limit  int             `json:"limit,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (m *Memory) Name() string { return "Memory" }
+
+// Description implements tools.Tool.
+func (m *Memory) Description() string { return memoryDescription }
+
+// InputSchema implements tools.Tool.
+func (m *Memory) InputSchema() json.RawMessage { return json.RawMessage(memoryInputSchema) }
+
+// Execute implements tools.Tool. The full request → result mapping
+// lives here; helpers below normalise scope/scope_id and surface
+// errors as model-readable tool_results.
+func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if m.Store == nil {
+		return errResult("Memory tool: not configured (no Store backend — set LOOMCYCLE_STORAGE_BACKEND or remove Memory from the agent's allowed_tools)"), nil
+	}
+	var in memoryInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	scope, scopeID, err := m.resolveScope(ctx, in.Scope)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	switch in.Op {
+	case "get":
+		return m.execGet(ctx, scope, scopeID, in)
+	case "set":
+		return m.execSet(ctx, scope, scopeID, in)
+	case "delete":
+		return m.execDelete(ctx, scope, scopeID, in)
+	case "list":
+		return m.execList(ctx, scope, scopeID, in)
+	case "incr":
+		return m.execIncr(ctx, scope, scopeID, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr)", in.Op)), nil
+	}
+}
+
+// resolveScope validates the requested scope against the agent's
+// MemoryPolicy and resolves scope_id from ctx. Returns a typed scope
+// + the runtime-supplied scope_id, or a refusal error suitable for
+// surfacing as a tool_result.
+func (m *Memory) resolveScope(ctx context.Context, requested string) (store.MemoryScope, string, error) {
+	policy := tools.MemoryPolicy(ctx)
+	if requested == "" {
+		return "", "", fmt.Errorf("missing required field: scope")
+	}
+	if !contains(policy.AllowedScopes, requested) {
+		if len(policy.AllowedScopes) == 0 {
+			return "", "", fmt.Errorf("Memory tool: this agent has no memory_scopes configured — add `memory_scopes: [agent]` (or [user], or both) to the agent yaml")
+		}
+		return "", "", fmt.Errorf("Memory tool: scope %q not in this agent's memory_scopes %v", requested, policy.AllowedScopes)
+	}
+
+	switch store.MemoryScope(requested) {
+	case store.MemoryScopeAgent:
+		name := tools.AgentName(ctx)
+		if name == "" {
+			return "", "", fmt.Errorf("Memory tool: scope=agent requires a yaml-declared agent (no agent name on the run context)")
+		}
+		return store.MemoryScopeAgent, name, nil
+	case store.MemoryScopeUser:
+		ident := tools.RunIdentity(ctx)
+		if ident.UserID == "" {
+			return "", "", fmt.Errorf("Memory tool: scope=user requires a user_id on the run (caller must supply user_id when starting the run)")
+		}
+		return store.MemoryScopeUser, ident.UserID, nil
+	default:
+		return "", "", fmt.Errorf("Memory tool: unknown scope %q (only agent / user are supported in v0.8.0)", requested)
+	}
+}
+
+func (m *Memory) execGet(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if in.Key == "" {
+		return errResult("get: missing required field: key"), nil
+	}
+	entry, err := m.Store.MemoryGet(ctx, scope, scopeID, in.Key)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return okJSON(map[string]any{"value": nil, "expires_at": nil})
+		}
+		return errResult(fmt.Sprintf("get: %s", err)), nil
+	}
+	return okJSON(map[string]any{
+		"value":      entry.Value,
+		"expires_at": expiresAtRFC3339(entry.ExpiresAt),
+	})
+}
+
+func (m *Memory) execSet(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if in.Key == "" {
+		return errResult("set: missing required field: key"), nil
+	}
+	if len(in.Value) == 0 {
+		return errResult("set: missing required field: value"), nil
+	}
+	if !json.Valid(in.Value) {
+		return errResult("set: value is not valid JSON"), nil
+	}
+	if m.MaxValueBytes > 0 && len(in.Value) > m.MaxValueBytes {
+		return errResult(fmt.Sprintf("set: value (%d bytes) exceeds max %d bytes", len(in.Value), m.MaxValueBytes)), nil
+	}
+	if err := m.checkQuota(ctx, scope, scopeID, in.Key, len(in.Value)); err != nil {
+		return errResult(err.Error()), nil
+	}
+	ttl := time.Duration(in.TTL) * time.Second
+	if err := m.Store.MemorySet(ctx, scope, scopeID, in.Key, in.Value, ttl); err != nil {
+		return errResult(fmt.Sprintf("set: %s", err)), nil
+	}
+	return okJSON(map[string]any{"ok": true})
+}
+
+func (m *Memory) execDelete(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if in.Key == "" {
+		return errResult("delete: missing required field: key"), nil
+	}
+	deleted, err := m.Store.MemoryDelete(ctx, scope, scopeID, in.Key)
+	if err != nil {
+		return errResult(fmt.Sprintf("delete: %s", err)), nil
+	}
+	return okJSON(map[string]any{"deleted": deleted})
+}
+
+func (m *Memory) execList(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		// Hard cap to keep one tool_result from blowing past a
+		// model's context window. Operators who really want more
+		// should paginate via the prefix.
+		limit = 1000
+	}
+	entries, truncated, err := m.Store.MemoryList(ctx, scope, scopeID, in.Prefix, limit)
+	if err != nil {
+		return errResult(fmt.Sprintf("list: %s", err)), nil
+	}
+	out := make([]map[string]any, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, map[string]any{
+			"key":        e.Key,
+			"value":      e.Value,
+			"expires_at": expiresAtRFC3339(e.ExpiresAt),
+		})
+	}
+	return okJSON(map[string]any{
+		"entries":   out,
+		"truncated": truncated,
+	})
+}
+
+func (m *Memory) execIncr(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if in.Key == "" {
+		return errResult("incr: missing required field: key"), nil
+	}
+	delta := int64(1)
+	if in.Delta != nil {
+		delta = *in.Delta
+	}
+	// Quota check is approximate for incr — the on-disk value's text
+	// representation is bounded by 20 bytes (max int64 width). Charge
+	// 32 bytes for safety; a counter row is negligible relative to
+	// any sane scope cap.
+	if err := m.checkQuota(ctx, scope, scopeID, in.Key, 32); err != nil {
+		return errResult(err.Error()), nil
+	}
+	ttl := time.Duration(in.TTL) * time.Second
+	next, err := m.Store.MemoryIncrement(ctx, scope, scopeID, in.Key, delta, ttl)
+	if err != nil {
+		if errors.Is(err, store.ErrMemoryWrongType) {
+			return errResult("incr: existing value is not a JSON number — use set with a number, or delete first"), nil
+		}
+		return errResult(fmt.Sprintf("incr: %s", err)), nil
+	}
+	return okJSON(map[string]any{"value": next})
+}
+
+// checkQuota verifies that adding `addBytes` to the (scope, scopeID)
+// keyspace would not exceed the per-agent quota (or global default).
+// Existing-key writes are charged the *additional* bytes only — we
+// look up the current row, subtract its size, and compare.
+//
+// Returns nil when the write is permitted. Returns
+// store.ErrMemoryQuotaExceeded (wrapped) when not.
+//
+// 0 quota = "no cap" (matches the env var convention for "feature
+// disabled"). The check short-circuits then.
+func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeID, key string, addBytes int) error {
+	policy := tools.MemoryPolicy(ctx)
+	quota := policy.QuotaBytes
+	if quota <= 0 {
+		quota = m.DefaultQuotaBytes
+	}
+	if quota <= 0 {
+		return nil
+	}
+
+	// Sum existing bytes (key + value) across the whole scope. The
+	// list call is expected to be small for a well-behaved agent — a
+	// noisy agent that writes thousands of keys hits the quota cap
+	// long before this loop becomes an issue.
+	//
+	// For a scope of 1 MB at 64 KB/value that's at most ~16 rows in
+	// the worst case; in practice scopes hold a handful of summary
+	// keys. If we ever need to scale this, we'll add a cached
+	// per-(scope, scope_id) byte counter via a SQL trigger.
+	const listCap = 1000
+	entries, _, err := m.Store.MemoryList(ctx, scope, scopeID, "", listCap)
+	if err != nil {
+		return fmt.Errorf("quota check: %w", err)
+	}
+	used := 0
+	keyExists := false
+	for _, e := range entries {
+		used += len(e.Key) + len(e.Value)
+		if e.Key == key {
+			keyExists = true
+			// Subtract the existing row's bytes — we'll re-add
+			// the new size below to compute the post-write total.
+			used -= len(e.Key) + len(e.Value)
+		}
+	}
+	projected := used + len(key) + addBytes
+	if projected > quota {
+		_ = keyExists
+		return fmt.Errorf("Memory.set: scope %q quota %d bytes would be exceeded by this write (current=%d, after=%d)",
+			scope, quota, used, projected)
+	}
+	return nil
+}
+
+// okJSON marshals v as the tool_result text. JSON marshalling is
+// expected to succeed (every code path constructs a map with safe
+// values); on failure we surface the error as a tool_result so the
+// model sees a coherent message rather than a panic.
+func okJSON(v any) (tools.Result, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return errResult(fmt.Sprintf("encode result: %s", err)), nil
+	}
+	return tools.Result{Text: string(b)}, nil
+}
+
+func errResult(msg string) tools.Result {
+	return tools.Result{IsError: true, Text: msg}
+}
+
+// expiresAtRFC3339 returns nil for the zero time and an RFC3339 string
+// otherwise. The wire shape is stable across set/get/list — operators
+// debugging a Memory issue see consistent timestamps.
+func expiresAtRFC3339(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func contains(haystack []string, needle string) bool {
+	needle = strings.TrimSpace(needle)
+	for _, s := range haystack {
+		if strings.TrimSpace(s) == needle {
+			return true
+		}
+	}
+	return false
+}
+
+var _ tools.Tool = (*Memory)(nil)

--- a/internal/tools/builtin/memory_test.go
+++ b/internal/tools/builtin/memory_test.go
@@ -1,0 +1,284 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// memoryFixture builds a Memory tool backed by a SQLite store and
+// returns a ctx pre-populated with a sensible run identity. Tests
+// override per-call ctx values (policy, agent name, user_id) when
+// they want to exercise specific gates.
+func memoryFixture(t *testing.T) (*Memory, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	tool := &Memory{
+		Store:             s,
+		MaxValueBytes:     65536,
+		DefaultQuotaBytes: 1 << 20,
+	}
+	ctx := tools.WithAgentName(context.Background(), "qa-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", AgentID: "a_test"})
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user"},
+		QuotaBytes:    0,
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func TestMemoryTool_SetGetDeleteRoundTrip(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"user","key":"voice","value":{"style":"concise"}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("set is_error: %s", res.Text)
+	}
+
+	res, err = tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"user","key":"voice"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("get is_error: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"style":"concise"`) {
+		t.Errorf("get result missing stored value: %s", res.Text)
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"delete","scope":"user","key":"voice"}`))
+	if !strings.Contains(res.Text, `"deleted":true`) {
+		t.Errorf("delete result: %s", res.Text)
+	}
+}
+
+func TestMemoryTool_GetMissingReturnsNullValue(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","key":"absent"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Errorf("get on missing key should not be an error; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"value":null`) {
+		t.Errorf("expected value:null for missing key, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_IncrementCounter(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	for i, want := range []string{`"value":1`, `"value":2`, `"value":7`} {
+		input := `{"op":"incr","scope":"agent","key":"warnings"}`
+		if i == 2 {
+			input = `{"op":"incr","scope":"agent","key":"warnings","delta":5}`
+		}
+		res, _ := tool.Execute(ctx, json.RawMessage(input))
+		if res.IsError {
+			t.Fatalf("incr[%d] is_error: %s", i, res.Text)
+		}
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("incr[%d] result %s, want %s", i, res.Text, want)
+		}
+	}
+}
+
+func TestMemoryTool_IncrementWrongType(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	_, _ = tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"agent","key":"obj","value":{"hello":"world"}}`))
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"incr","scope":"agent","key":"obj"}`))
+	if !res.IsError {
+		t.Errorf("incr on object should be is_error; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "JSON number") {
+		t.Errorf("expected wrong-type error, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_ListPrefix(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	for _, k := range []string{"events/1", "events/2", "prefs/x"} {
+		_, _ = tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"agent","key":"`+k+`","value":1}`))
+	}
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list","scope":"agent","prefix":"events/"}`))
+	if res.IsError {
+		t.Fatalf("list is_error: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"events/1"`) || !strings.Contains(res.Text, `"events/2"`) {
+		t.Errorf("list missing expected keys: %s", res.Text)
+	}
+	if strings.Contains(res.Text, `"prefs/x"`) {
+		t.Errorf("list returned non-prefix-matching key: %s", res.Text)
+	}
+}
+
+func TestMemoryTool_ScopeNotInPolicyRefused(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	// Override policy: only allow agent scope.
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"agent"}})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"user","key":"x","value":1}`))
+	if !res.IsError {
+		t.Fatalf("write to disallowed scope should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "memory_scopes") {
+		t.Errorf("expected diagnostic mentioning memory_scopes, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_NoPolicyMeansNoAccess(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	// Strip policy entirely — agent has Memory in allowed_tools but
+	// no memory_scopes — this simulates the "tool granted but no
+	// scopes configured" misconfiguration.
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","key":"x"}`))
+	if !res.IsError {
+		t.Errorf("expected refusal on empty memory_scopes; got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_AgentScopeRequiresAgentName(t *testing.T) {
+	tool, _, cleanup := memoryFixture(t)
+	defer cleanup()
+	// Build a fresh ctx WITHOUT an agent name.
+	ctx := tools.WithMemoryPolicy(context.Background(), tools.MemoryPolicyValue{AllowedScopes: []string{"agent"}})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","key":"x"}`))
+	if !res.IsError {
+		t.Errorf("missing agent name should be a refusal; got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_UserScopeRequiresUserID(t *testing.T) {
+	tool, _, cleanup := memoryFixture(t)
+	defer cleanup()
+	ctx := tools.WithAgentName(context.Background(), "qa-agent")
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{AllowedScopes: []string{"user"}})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"user","key":"x"}`))
+	if !res.IsError {
+		t.Errorf("missing user_id should be a refusal; got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_ScopeIsolation(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	// Set under user=alice's user-scope.
+	_, _ = tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"user","key":"secret","value":"alice-only"}`))
+	// Switch to user=bob.
+	ctxBob := tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "bob", AgentID: "a_b"})
+	res, _ := tool.Execute(ctxBob, json.RawMessage(`{"op":"get","scope":"user","key":"secret"}`))
+	if res.IsError {
+		t.Fatalf("get is_error: %s", res.Text)
+	}
+	if strings.Contains(res.Text, "alice-only") {
+		t.Errorf("user-scope leaked across user_ids: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"value":null`) {
+		t.Errorf("bob should see no value for alice's key, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_ValueTooLarge(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.MaxValueBytes = 16
+
+	big := strings.Repeat("a", 100)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"agent","key":"k","value":"`+big+`"}`))
+	if !res.IsError {
+		t.Errorf("oversized write should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "max") {
+		t.Errorf("expected size error, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_QuotaEnforcement(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	// Tighten the per-scope quota via policy override. 64 bytes is
+	// enough for one small value but not two.
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent"},
+		QuotaBytes:    64,
+	})
+
+	// First write fits.
+	value := json.RawMessage(`"` + strings.Repeat("a", 30) + `"`)
+	in1 := mustMarshal(t, map[string]any{"op": "set", "scope": "agent", "key": "k1", "value": value})
+	if res, _ := tool.Execute(ctx, in1); res.IsError {
+		t.Fatalf("first write should fit: %s", res.Text)
+	}
+	// Second write blows the cap.
+	in2 := mustMarshal(t, map[string]any{"op": "set", "scope": "agent", "key": "k2", "value": value})
+	res, _ := tool.Execute(ctx, in2)
+	if !res.IsError {
+		t.Errorf("second write should be quota-refused; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "quota") {
+		t.Errorf("expected quota error, got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_UnknownOp(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"clear","scope":"agent"}`))
+	if !res.IsError {
+		t.Errorf("unknown op should be is_error; got %s", res.Text)
+	}
+}
+
+func TestMemoryTool_NoStore(t *testing.T) {
+	tool := &Memory{}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"get","scope":"agent","key":"x"}`))
+	if !res.IsError {
+		t.Errorf("nil-store call should be is_error")
+	}
+	if !strings.Contains(res.Text, "not configured") {
+		t.Errorf("expected 'not configured' diagnostic, got %s", res.Text)
+	}
+}
+
+// Compile-time guard: every store the test fixture uses satisfies
+// store.Store. (Just a smoke check; the SQLite adapter is well-tested
+// already.)
+var _ store.Store = (*sqlite.Store)(nil)
+
+// mustMarshal is a tiny helper for building input JSON in tests.
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -160,6 +160,60 @@ func RunIdentity(ctx context.Context) RunIdentityValue {
 	return v
 }
 
+// ctxKeyAgentName is the context key under which the runtime stores the
+// yaml-declared agent name (e.g. "qa-agent", "company-researcher"). The
+// Memory tool reads this to resolve the `agent` scope_id; other future
+// tools that need to namespace state by agent can use it the same way.
+type ctxKeyAgentName struct{}
+
+// WithAgentName attaches the agent's yaml-declared name to ctx.
+// loop.Run threads opts.AgentName through, but ctx-level access lets
+// tools read it without plumbing the value through every Execute
+// signature. Empty string is acceptable — tools that need the value
+// must validate.
+func WithAgentName(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentName{}, name)
+}
+
+// AgentName returns the yaml-declared agent name from ctx, or empty
+// string if not attached.
+func AgentName(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyAgentName{}).(string)
+	return v
+}
+
+// ctxKeyMemoryPolicy is the context key for the per-agent Memory tool
+// policy (allowed scopes + scope-byte quota override). Set by the HTTP
+// server from the agent's yaml definition; read by the Memory tool to
+// gate writes and surface "scope not allowed" refusals to the model.
+type ctxKeyMemoryPolicy struct{}
+
+// MemoryPolicyValue is the per-agent Memory access policy.
+//
+//   - AllowedScopes is the yaml `memory_scopes` allowlist; an empty
+//     slice means the agent has NO Memory access (the tool itself
+//     must already be in allowed_tools for the agent to even call it,
+//     but the scope allowlist is a second gate that lets operators
+//     grant Memory:read-only on `user` while withholding `agent`).
+//   - QuotaBytes is the yaml `memory_quota_bytes` override; 0 falls
+//     back to the global LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES default.
+type MemoryPolicyValue struct {
+	AllowedScopes []string
+	QuotaBytes    int
+}
+
+// WithMemoryPolicy attaches the agent's resolved Memory policy to ctx.
+func WithMemoryPolicy(ctx context.Context, p MemoryPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyMemoryPolicy{}, p)
+}
+
+// MemoryPolicy returns the agent's Memory policy from ctx. Zero value
+// (empty AllowedScopes, QuotaBytes=0) means "no Memory access".
+func MemoryPolicy(ctx context.Context) MemoryPolicyValue {
+	v, _ := ctx.Value(ctxKeyMemoryPolicy{}).(MemoryPolicyValue)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names return an
 // error result (the model can self-correct) rather than a hard error.
 func (d *Dispatcher) Execute(ctx context.Context, name string, input json.RawMessage) Result {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -130,6 +130,87 @@ export function getTranscript(sessionId: string): Promise<TranscriptResponse> {
   return jsonFetch<TranscriptResponse>(`/v1/sessions/${encodeURIComponent(sessionId)}/transcript`);
 }
 
+// v0.8.0 Memory admin types — mirrors internal/api/http/memory.go.
+
+export interface MemoryScopeKind {
+  name: string;
+  description: string;
+}
+
+export interface MemoryScopesResponse {
+  scopes: MemoryScopeKind[];
+}
+
+export interface MemoryScopeIDSummary {
+  scope_id: string;
+  key_count: number;
+  bytes: number;
+  updated_at: string;
+}
+
+export interface MemoryScopeIDsResponse {
+  scope: string;
+  scope_ids: MemoryScopeIDSummary[];
+}
+
+// MemoryEntry mirrors store.MemoryEntry. value is a parsed JSON value
+// (the server stored it as JSONB on Postgres, TEXT-as-JSON on SQLite,
+// and re-parsed it on the way out — `unknown` here so the UI can
+// pretty-print whatever shape the agent wrote).
+export interface MemoryEntry {
+  key: string;
+  value: unknown;
+  expires_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MemoryEntriesResponse {
+  scope: string;
+  scope_id: string;
+  entries: MemoryEntry[];
+  truncated: boolean;
+}
+
+export interface MemoryEntryResponse {
+  scope: string;
+  scope_id: string;
+  entry: MemoryEntry;
+}
+
+export function listMemoryScopes(): Promise<MemoryScopesResponse> {
+  return jsonFetch<MemoryScopesResponse>("/v1/_memory/scopes");
+}
+
+export function listMemoryScopeIDs(scope: string): Promise<MemoryScopeIDsResponse> {
+  return jsonFetch<MemoryScopeIDsResponse>(`/v1/_memory/scopes/${encodeURIComponent(scope)}`);
+}
+
+export function listMemoryEntries(
+  scope: string,
+  scopeID: string,
+  prefix?: string,
+  limit?: number,
+): Promise<MemoryEntriesResponse> {
+  const params = new URLSearchParams();
+  if (prefix) params.set("prefix", prefix);
+  if (limit) params.set("limit", String(limit));
+  const qs = params.toString();
+  return jsonFetch<MemoryEntriesResponse>(
+    `/v1/_memory/scopes/${encodeURIComponent(scope)}/${encodeURIComponent(scopeID)}/keys${qs ? "?" + qs : ""}`,
+  );
+}
+
+export function getMemoryEntry(
+  scope: string,
+  scopeID: string,
+  key: string,
+): Promise<MemoryEntryResponse> {
+  return jsonFetch<MemoryEntryResponse>(
+    `/v1/_memory/scopes/${encodeURIComponent(scope)}/${encodeURIComponent(scopeID)}/keys/${encodeURIComponent(key)}`,
+  );
+}
+
 export async function cancelAgent(agentId: string, reason?: string): Promise<unknown> {
   const resp = await fetch(`/v1/agents/${encodeURIComponent(agentId)}/cancel`, {
     method: "POST",

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -53,8 +53,12 @@ export default function Layout() {
       <header className="topbar">
         <div className="brand">
           <Link to="/">loomcycle</Link>
-          <span className="version">v0.7.3</span>
+          <span className="version">v0.8.0</span>
         </div>
+        <nav className="nav-tabs">
+          <Link to="/">runs</Link>
+          <Link to="/memory">memory</Link>
+        </nav>
         <div className="user-picker">
           {usersErr && <span className="picker-err" title={usersErr}>users unavailable</span>}
           {!showManual && (

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import "./styles.css";
 import RunList from "./pages/RunList";
 import AgentDetail from "./pages/AgentDetail";
+import MemoryView from "./pages/MemoryView";
 import Layout from "./components/Layout";
 
 // Mounted at /ui/ in production; the BrowserRouter basename matches
@@ -15,6 +16,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         <Route path="/" element={<Layout />}>
           <Route index element={<RunList />} />
           <Route path="agents/:agentId" element={<AgentDetail />} />
+          <Route path="memory" element={<MemoryView />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Route>
       </Routes>

--- a/web/src/pages/MemoryView.tsx
+++ b/web/src/pages/MemoryView.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  MemoryEntry,
+  MemoryScopeIDSummary,
+  MemoryScopeKind,
+  listMemoryEntries,
+  listMemoryScopeIDs,
+  listMemoryScopes,
+} from "../api";
+
+// MemoryView — operator browse-only view over the v0.8.0 Memory tool's
+// stored rows.
+//
+// Three-pane layout:
+//   left   : scope picker (agent / user) + scope_id list under the
+//            chosen scope, with key counts.
+//   middle : key list for the selected (scope, scope_id), with a
+//            prefix filter input.
+//   right  : the selected entry's value pretty-printed JSON, plus
+//            timestamps and TTL.
+//
+// Polling, not SSE — Memory rows are slow-changing (counters tick on
+// the order of one-per-iteration; preferences barely change). 5 s
+// refresh is plenty to feel live without hammering the store.
+const REFRESH_MS = 5_000;
+
+export default function MemoryView() {
+  const [scopes, setScopes] = useState<MemoryScopeKind[]>([]);
+  const [scope, setScope] = useState<string>("");
+  const [scopeIDs, setScopeIDs] = useState<MemoryScopeIDSummary[]>([]);
+  const [scopeID, setScopeID] = useState<string>("");
+  const [entries, setEntries] = useState<MemoryEntry[]>([]);
+  const [truncated, setTruncated] = useState(false);
+  const [selectedKey, setSelectedKey] = useState<string>("");
+  const [prefix, setPrefix] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+
+  // Bootstrap: fetch the (constant) scope list once on mount, default
+  // the selection to "agent" so the page lands on actual data.
+  useEffect(() => {
+    let cancelled = false;
+    listMemoryScopes()
+      .then((resp) => {
+        if (cancelled) return;
+        setScopes(resp.scopes ?? []);
+        if (resp.scopes && resp.scopes.length > 0 && !scope) {
+          setScope(resp.scopes[0].name);
+        }
+      })
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+    // scope intentionally omitted — only run on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Poll scope_ids under the selected scope.
+  useEffect(() => {
+    if (!scope) return;
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const resp = await listMemoryScopeIDs(scope);
+        if (cancelled) return;
+        setScopeIDs(resp.scope_ids ?? []);
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchOnce();
+    const t = setInterval(fetchOnce, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [scope]);
+
+  // When the scope changes, blow away the scope_id selection so the
+  // user always picks fresh under the new scope.
+  useEffect(() => {
+    setScopeID("");
+    setSelectedKey("");
+    setEntries([]);
+    setPrefix("");
+  }, [scope]);
+
+  // Poll entries under the selected (scope, scope_id, prefix). Debounce
+  // the prefix input by piggy-backing on the polling clock — typing
+  // doesn't fire a request per keystroke; the next tick picks up the
+  // new prefix.
+  useEffect(() => {
+    if (!scope || !scopeID) {
+      setEntries([]);
+      setTruncated(false);
+      return;
+    }
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const resp = await listMemoryEntries(scope, scopeID, prefix || undefined, 200);
+        if (cancelled) return;
+        setEntries(resp.entries ?? []);
+        setTruncated(resp.truncated);
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchOnce();
+    const t = setInterval(fetchOnce, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [scope, scopeID, prefix]);
+
+  // Resolve the currently selected entry from the in-memory list — no
+  // separate fetch required because the list response already carries
+  // the value. (Drops one round-trip and one source of staleness.)
+  const selectedEntry = useMemo(() => {
+    if (!selectedKey) return null;
+    return entries.find((e) => e.key === selectedKey) ?? null;
+  }, [entries, selectedKey]);
+
+  return (
+    <div className="memory-view">
+      <div className="memory-pane scopes-pane">
+        <div className="pane-header">scopes</div>
+        <div className="scope-tabs">
+          {scopes.map((sc) => (
+            <button
+              key={sc.name}
+              className={sc.name === scope ? "on" : ""}
+              onClick={() => setScope(sc.name)}
+              title={sc.description}
+            >
+              {sc.name}
+            </button>
+          ))}
+        </div>
+        <div className="pane-header sub">{scope || "—"} ids</div>
+        <ul className="scope-id-list">
+          {scopeIDs.length === 0 && (
+            <li className="empty-row">no rows under {scope}</li>
+          )}
+          {scopeIDs.map((row) => (
+            <li
+              key={row.scope_id}
+              className={row.scope_id === scopeID ? "on" : ""}
+              onClick={() => {
+                setScopeID(row.scope_id);
+                setSelectedKey("");
+              }}
+            >
+              <code>{row.scope_id}</code>
+              <span className="meta">
+                {row.key_count} key{row.key_count === 1 ? "" : "s"} · {formatBytes(row.bytes)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="memory-pane keys-pane">
+        <div className="pane-header">
+          keys {scopeID && <code>{scope}/{scopeID}</code>}
+        </div>
+        {scopeID && (
+          <input
+            type="text"
+            className="prefix-input"
+            placeholder="filter by prefix…"
+            value={prefix}
+            onChange={(e) => setPrefix(e.target.value)}
+          />
+        )}
+        <ul className="key-list">
+          {!scopeID && <li className="empty-row">pick a scope_id to see its keys</li>}
+          {scopeID && entries.length === 0 && <li className="empty-row">no keys</li>}
+          {entries.map((e) => (
+            <li
+              key={e.key}
+              className={e.key === selectedKey ? "on" : ""}
+              onClick={() => setSelectedKey(e.key)}
+            >
+              <code>{e.key}</code>
+              {e.expires_at && <span className="ttl-flag" title={`expires ${e.expires_at}`}>ttl</span>}
+            </li>
+          ))}
+          {truncated && (
+            <li className="empty-row">… more keys hidden (raise limit or refine prefix)</li>
+          )}
+        </ul>
+      </div>
+      <div className="memory-pane detail-pane">
+        <div className="pane-header">value</div>
+        {!selectedEntry && <div className="empty">pick a key to inspect its value.</div>}
+        {selectedEntry && (
+          <div className="entry-detail">
+            <div className="entry-meta">
+              <div><span>key</span><code>{selectedEntry.key}</code></div>
+              <div><span>created</span><code>{selectedEntry.created_at}</code></div>
+              <div><span>updated</span><code>{selectedEntry.updated_at}</code></div>
+              {selectedEntry.expires_at && (
+                <div><span>expires</span><code>{selectedEntry.expires_at}</code></div>
+              )}
+            </div>
+            <pre className="entry-value">{prettyJSON(selectedEntry.value)}</pre>
+          </div>
+        )}
+      </div>
+      {err && <div className="err memory-err">{err}</div>}
+    </div>
+  );
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function prettyJSON(v: unknown): string {
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -393,3 +393,206 @@ pre {
 .ev-error .kind { color: var(--failed); }
 .ev-retry { border-left-color: var(--running); }
 .ev-done { border-left-color: var(--fg-soft); }
+
+/* v0.8.0 nav tabs (top bar between brand and user picker). */
+.nav-tabs {
+  display: flex;
+  gap: 4px;
+  margin-left: 24px;
+}
+.nav-tabs a {
+  color: var(--fg-soft);
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+.nav-tabs a:hover {
+  background: var(--bg-soft-2);
+  color: var(--fg);
+  text-decoration: none;
+}
+
+/* v0.8.0 Memory page — three-pane layout. */
+.memory-view {
+  display: grid;
+  grid-template-columns: 280px 320px 1fr;
+  gap: 12px;
+  padding: 12px;
+  height: 100%;
+  min-height: 0;
+}
+.memory-pane {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.memory-pane .pane-header {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-soft);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.memory-pane .pane-header.sub {
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft-2);
+}
+.memory-pane .pane-header code {
+  color: var(--fg);
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.scope-tabs {
+  display: flex;
+  padding: 8px;
+  gap: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.scope-tabs button {
+  flex: 1;
+  background: var(--bg);
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.scope-tabs button.on {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+.scope-id-list,
+.key-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow: auto;
+  flex: 1;
+  min-height: 0;
+}
+.scope-id-list li,
+.key-list li {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 8px;
+}
+.scope-id-list li:hover,
+.key-list li:hover {
+  background: var(--bg-soft-2);
+}
+.scope-id-list li.on,
+.key-list li.on {
+  background: var(--bg-soft-2);
+  border-left: 3px solid var(--accent);
+  padding-left: 9px;
+}
+.scope-id-list li .meta {
+  color: var(--fg-soft);
+  font-size: 11px;
+  font-family: var(--mono);
+}
+.scope-id-list li code,
+.key-list li code {
+  font-size: 12px;
+  word-break: break-all;
+}
+.empty-row {
+  color: var(--fg-soft);
+  padding: 16px 12px !important;
+  cursor: default !important;
+  font-style: italic;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+.empty-row:hover {
+  background: transparent !important;
+}
+.prefix-input {
+  margin: 8px 12px;
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.ttl-flag {
+  background: var(--running);
+  color: white;
+  font-size: 10px;
+  text-transform: uppercase;
+  padding: 1px 4px;
+  border-radius: 2px;
+  letter-spacing: 0.04em;
+}
+.entry-detail {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+.entry-meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 4px 12px;
+  font-size: 12px;
+}
+.entry-meta div {
+  display: contents;
+}
+.entry-meta div span {
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+  align-self: center;
+}
+.entry-meta div code {
+  font-size: 12px;
+  word-break: break-all;
+}
+.entry-value {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 12px;
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12px;
+  flex: 1;
+  overflow: auto;
+  margin: 0;
+}
+.detail-pane .empty {
+  padding: 24px;
+  color: var(--fg-soft);
+  font-style: italic;
+}
+.memory-err {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  background: var(--failed);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  max-width: 400px;
+}


### PR DESCRIPTION
## Summary

- **New built-in `Memory` tool** with five ops (`get` / `set` / `delete` / `list` / `incr`) over a `memory` table on both SQLite and Postgres adapters.
- **Two scopes** — `agent` (yaml-keyed; cross-run, shared across users) and `user` (user_id-keyed; cross-agent, per end-user). `scope_id` is server-resolved from the run context — the model picks the SCOPE, the runtime picks the SCOPE_ID.
- **Per-agent yaml gate** — `memory_scopes: [agent, user]` allowlist plus optional `memory_quota_bytes` override. Default-deny: `Memory` in `allowed_tools` is necessary but not sufficient; agents without `memory_scopes` see refusals.
- **Web UI** — new `/memory` route with a three-pane browser (scope picker → scope_id list with byte totals → keys with prefix filter → entry detail with pretty-printed JSON + TTL).
- **Admin API** — four read-only `/v1/_memory/*` routes driving the UI; bearer-authed via the existing middleware, same posture as `/v1/_users` / `/v1/_resolver`.

## What was tested

### Automated

- **Store contract** — 14 new cases in `internal/store/storetest/contract.go` (CRUD, TTL expiry, sweep, scope isolation, prefix list, truncation, atomic increment, wrong-type increment, expired-key increment from zero, scope_id summary). Green on both SQLite (in-memory) and Postgres (containerised fixture). Race detector green.
- **Concurrency regression** — 100-goroutine concurrent-increment test catches lost-update bugs found during code review (see fix commits below). Final counter must hit exactly 100 — was 12/100 on SQLite and 91/100 on Postgres before fixes; 100/100 after.
- **Memory tool** — 14 unit tests in `internal/tools/builtin/memory_test.go` covering happy paths, scope refusals, scope isolation across users, value-too-large, quota breach, wrong-type incr, missing-store fallback, unknown-op rejection.
- **Admin endpoints** — 9 handler tests in `internal/api/http/memory_test.go` (constant scope list, scope_ids filtered by scope, unknown-scope 400, list keys with values, prefix filter, get-by-key round trip, **multi-segment key route** regression, 404, store-unavailable 503).
- **Config validation** — 4 tests covering `memory_scopes` allowlist, accepted shape with quota, env defaults, env disable behavior.

### Manual / observational

- `make build-ui` — React bundle builds cleanly (246 KB / 78 KB gzipped).
- `go test ./...` — full suite green; `gofmt -l .`, `go vet ./...` clean.
- `go test -race` — green on `internal/store/...`, `internal/tools/builtin/...`, `internal/api/http/...`.

## Code review pre-merge

A `code-reviewer` pass found **2 critical** + **3 important** issues, all fixed in the last two commits:

| # | Severity | What | Fix |
|---|---|---|---|
| 1 | Critical | SQLite `MemoryIncrement` used `BeginTx(nil)` (DEFERRED), allowing lost updates between SELECT and INSERT | Pin a connection + raw `BEGIN IMMEDIATE` / `COMMIT` (modernc/sqlite doesn't translate `LevelSerializable` → IMMEDIATE) |
| 2 | Critical | Postgres `SELECT ... FOR UPDATE` doesn't lock absent rows, so two concurrent first-increments both saw NoRows and both INSERT'd `delta` (lost update on the second) | Take `pg_advisory_xact_lock(hashtextextended(key, 0))` at the top of the increment txn |
| 3 | Important | `checkQuota` silently truncated at 1000 keys, letting writes through that should be refused | Treat `truncated == true` as a `quota_exceeded` refusal |
| 4 | Important | Admin route `/v1/_memory/.../keys/{key}` couldn't reach keys with `/` (e.g. `events/2026-05-09`) | Use Go 1.22+ `{key...}` multi-segment wildcard; regression test added |
| 5 | Pre-existing | `handleMessages` (continuation path) missed `tools.WithHostPolicy` on its loop ctx — sub-agents from continuations fell back to the operator's static allowlist | Attach the policy alongside the new Memory ctx values, matching `handleRuns` / `RunOnce` (the same fix `9677b85` made for top-level runs) |

All marked items confirmed fixed by re-running the regression tests.

## Commit list (9 commits)

```
b2a9c12 fix: review follow-ups — quota truncation, multi-segment keys, host policy
cccc7fe fix(store): atomic Memory increments under concurrency on both backends
0ac4376 feat(ui): Memory page — three-pane browser over stored Memory rows
85f649c feat(api): /v1/_memory admin endpoints — list scopes, scope_ids, keys
7988065 docs(memory): TOOLS.md section, PLAN.md v0.8.0 status, env example
348420c feat(runtime): wire Memory tool into main + per-agent policy onto loop ctx
49bcee9 feat(config): per-agent memory_scopes / memory_quota_bytes + env defaults
8666f56 feat(tools): Memory built-in — get/set/delete/list/incr with scope policy
2a539ec feat(store): Memory CRUD + atomic increment + TTL sweep on both backends
```

## Locked design decisions (from `doc-internal/rfcs/memory-tool.md`)

| Decision | Resolution |
|---|---|
| Scopes | `agent` + `user` only — forward-compatible for `session` / `tenant` |
| Value model | JSON, validated at write |
| Ops | `get`/`set`/`delete`/`list`/`incr` (atomic counter) |
| TTL | Seconds; expired rows filtered at read time, not just by sweeper |
| Encryption-at-rest | Deferred to v0.9.x cluster work |
| Quotas | 64 KB/value, 1 MB/scope global; per-agent yaml override |
| Eviction | None automatic; quota exceeded → write fails with `quota_exceeded` |

## Verification (after merge, on `main`)

- `make build-ui && go build -o bin/loomcycle ./cmd/loomcycle`
- Run with a config granting an agent `Memory` + `memory_scopes: [agent, user]`
- Browser: `/ui/memory?token=...` — verify the three-pane browser loads
- Curl: exercise the `/v1/_memory/scopes` admin endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)