### PR TITLE
feat(providers): replace Client.Timeout with header+idle stream timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,29 @@ LOOMCYCLE_DATA_DIR=./data
 # Read paths filter expired entries even when the reaper is off, so
 # agents never see stale values regardless.
 # LOOMCYCLE_MEMORY_SWEEP_MS=900000
+
+# ─── Provider streaming timeouts (v0.8.x+) ──────────────────────────
+#
+# Replaced the old wall-clock `http.Client.Timeout = 5 min` with a
+# pair of finer-grained ceilings:
+#
+#   - HEADER_TIMEOUT: per-attempt cap on time-to-first-byte. Set on
+#     each provider driver's http.Transport.ResponseHeaderTimeout.
+#     Generous default (60 s) accommodates cold-start cloud endpoints
+#     and warming Ollama models without leaving a stalled pre-stream
+#     connection open forever. Bump if you see "stream read: context
+#     deadline exceeded" errors during the FIRST few seconds of a
+#     run (rare).
+#   - IDLE_TIMEOUT: max gap between body bytes during a streaming
+#     response. The driver wraps resp.Body and resets a timer on
+#     every Read; if the timer fires (no bytes for this long), the
+#     request context is cancelled. Default 90 s. Bump if you see
+#     mid-stream "context deadline exceeded" errors on long final
+#     turns where the model is provably still emitting (e.g. a
+#     reasoning model with extended thinking pauses).
+#
+# Operators on networks with high TLS handshake latency or aggressive
+# NAT idle timeouts may want to bump HEADER_TIMEOUT to 90 000 ms; the
+# defaults are tuned for direct internet egress.
+# LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
+# LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -38,6 +38,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/gemini"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -513,29 +514,33 @@ type providerResolver struct {
 
 func newProviderResolver(cfg *config.Config) *providerResolver {
 	pr := &providerResolver{}
+	streamOpts := streamhttp.Options{
+		HeaderTimeout: cfg.Env.ProviderHeaderTimeout,
+		IdleTimeout:   cfg.Env.ProviderIdleTimeout,
+	}
 	if cfg.Env.AnthropicAPIKey != "" {
-		pr.anthropic = anthropic.New(cfg.Env.AnthropicAPIKey, "", nil)
+		pr.anthropic = anthropic.New(cfg.Env.AnthropicAPIKey, "", streamOpts, nil)
 	}
 	if cfg.Env.OpenAIAPIKey != "" {
-		pr.openai = openai.New(cfg.Env.OpenAIAPIKey, "", nil)
+		pr.openai = openai.New(cfg.Env.OpenAIAPIKey, "", streamOpts, nil)
 	}
 	// Ollama has no API key — wire it up if a base URL is configured (the
 	// loader defaults this to http://localhost:11434 so it's effectively
 	// always-on; users disable it by setting OLLAMA_BASE_URL=disabled).
 	if cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled" {
-		pr.ollama = ollama.New(cfg.Env.OllamaBaseURL, nil)
+		pr.ollama = ollama.New(cfg.Env.OllamaBaseURL, streamOpts, nil)
 	}
 	// DeepSeek opts in via DEEPSEEK_API_KEY. Optional DEEPSEEK_BASE_URL
 	// overrides the public endpoint for self-hosted OpenAI-compatible
 	// mirrors. Same on/off semantics as Anthropic + OpenAI.
 	if cfg.Env.DeepSeekAPIKey != "" {
-		pr.deepseek = deepseek.New(cfg.Env.DeepSeekAPIKey, cfg.Env.DeepSeekBaseURL, nil)
+		pr.deepseek = deepseek.New(cfg.Env.DeepSeekAPIKey, cfg.Env.DeepSeekBaseURL, streamOpts, nil)
 	}
 	// Gemini opts in via GEMINI_API_KEY. Optional GEMINI_BASE_URL
 	// points at a Vertex AI Gemini endpoint instead of the public
 	// generativelanguage.googleapis.com surface.
 	if cfg.Env.GeminiAPIKey != "" {
-		pr.gemini = gemini.New(cfg.Env.GeminiAPIKey, cfg.Env.GeminiBaseURL, nil)
+		pr.gemini = gemini.New(cfg.Env.GeminiAPIKey, cfg.Env.GeminiBaseURL, streamOpts, nil)
 	}
 	return pr
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -429,6 +429,32 @@ type Env struct {
 	// don't want background work, can opt out).
 	// Env: LOOMCYCLE_MEMORY_SWEEP_MS.
 	MemorySweepInterval time.Duration
+
+	// ProviderHeaderTimeout is the per-attempt cap on time-to-first-
+	// byte for streaming provider HTTP calls (set on each driver's
+	// http.Transport.ResponseHeaderTimeout). Default 60s — generous
+	// enough for cold-start cloud endpoints and warming Ollama models
+	// without leaving a stalled pre-stream connection open forever.
+	// Env: LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS.
+	ProviderHeaderTimeout time.Duration
+
+	// ProviderIdleTimeout is the maximum gap allowed between body
+	// bytes during a streaming provider response. The driver wraps
+	// resp.Body with streamhttp.WrapBody and resets a timer on every
+	// Read; if the timer fires (no bytes for this long), the request
+	// context is cancelled. Default 90s — long enough to ride out
+	// reasoning-model thinking pauses, short enough to drop a truly
+	// stalled stream before the agent's heartbeat sweeper notices.
+	//
+	// Why this exists: the previous implementation used
+	// http.Client.Timeout = 5min as a wall-clock cap on the entire
+	// request. For long final-turn responses (e.g. job-searcher
+	// emitting a 25-position ingest payload) the cap fired mid-stream
+	// even when the model was actively producing tokens. The
+	// header-timeout + per-byte idle pair lets long *productive*
+	// streams complete while still killing genuinely stalled ones.
+	// Env: LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS.
+	ProviderIdleTimeout time.Duration
 }
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
@@ -643,6 +669,24 @@ func Load(path string) (*Config, error) {
 			} else {
 				cfg.Env.MemorySweepInterval = time.Duration(n) * time.Millisecond
 			}
+		}
+	}
+
+	// Provider streaming timeouts. Defaults match streamhttp.Default*.
+	// Negative or zero values are NOT treated as "disable" — there's no
+	// safe interpretation of "stream forever" given the agent loop's
+	// liveness assumptions. Operators bumping these should pick a real
+	// number; bad input falls through to the default.
+	cfg.Env.ProviderHeaderTimeout = 60 * time.Second
+	if v := os.Getenv("LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.ProviderHeaderTimeout = time.Duration(n) * time.Millisecond
+		}
+	}
+	cfg.Env.ProviderIdleTimeout = 90 * time.Second
+	if v := os.Getenv("LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.ProviderIdleTimeout = time.Duration(n) * time.Millisecond
 		}
 	}
 

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -17,30 +17,35 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 const (
 	defaultBaseURL = "https://api.anthropic.com"
 	apiVersion     = "2023-06-01"
-	defaultTimeout = 5 * time.Minute
 )
 
 // Driver is the Anthropic Messages API implementation of providers.Provider.
 type Driver struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey      string
+	baseURL     string
+	http        *http.Client
+	idleTimeout time.Duration
 }
 
 // New constructs a Driver. baseURL may be empty for the default endpoint.
-func New(apiKey, baseURL string, httpClient *http.Client) *Driver {
+// streamOpts controls the per-stream timeouts; zero values resolve to
+// streamhttp.Default*. When httpClient is nil, a fresh streaming client
+// honoring streamOpts.HeaderTimeout is built.
+func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
+	streamOpts = streamOpts.Resolve()
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: defaultTimeout}
+		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
 }
 
 func (d *Driver) ID() string { return "anthropic" }
@@ -71,10 +76,17 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	attempt := func(ctx context.Context) (*http.Response, error) {
+	// streamCtx is a cancellable child of ctx. Its cancel is passed to
+	// streamhttp.WrapBody so an idle body read can interrupt the
+	// in-flight HTTP request. The streaming goroutine releases the ctx
+	// via deferred cancel; the wrap may have called cancel earlier
+	// (idempotent).
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
+	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// Build a fresh request each attempt — http.Request.Body is
 		// consumed by Do, so a single Reader can't be reused.
-		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/v1/messages", bytes.NewReader(body))
+		req, err := http.NewRequestWithContext(attemptCtx, "POST", d.baseURL+"/v1/messages", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -85,12 +97,13 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return d.http.Do(req)
 	}
 
-	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+	resp, err := ratelimit.Do(streamCtx, ratelimit.Config{
 		Provider:    "anthropic",
 		ParseHeader: ratelimit.AnthropicRetryAfter,
 		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
+		cancelStream()
 		// ctx errors aren't HTTP errors — propagate as-is so the loop's
 		// errors.Is(ctx.Err()) checks aren't masked by the "http:" prefix.
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -100,12 +113,18 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
+		cancelStream()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("anthropic %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
+	resp.Body = streamhttp.WrapBody(resp.Body, d.idleTimeout, cancelStream)
+
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out)
+	go func() {
+		defer cancelStream()
+		streamEvents(streamCtx, resp.Body, out)
+	}()
 	return out, nil
 }
 

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeStream serves a canned SSE script as one Anthropic Messages response.
@@ -52,7 +53,7 @@ func TestStreamTextThenStop(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "claude-sonnet-4-6",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -102,7 +103,7 @@ func TestStreamUsageCarriesModel(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "claude-haiku-4-5",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -140,7 +141,7 @@ func TestStreamToolUse(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{Model: "x"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -195,7 +196,7 @@ func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(ctx, providers.Request{Model: "x"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -258,7 +259,7 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "claude-sonnet-4-6",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -318,7 +319,7 @@ func TestRetryOn429IsInvisibleToLoop(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 
 	var observedEvents []providers.EventType
 	res, err := loop.Run(context.Background(), loop.RunOptions{
@@ -376,7 +377,7 @@ func TestRetryEmitsTypedEventToLoop(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 
 	var retryEvents []providers.Event
 	_, err := loop.Run(context.Background(), loop.RunOptions{
@@ -427,7 +428,7 @@ func TestRequestBodyShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "claude-sonnet-4-6",
 		System: []providers.ContentBlock{

--- a/internal/providers/anthropic/probe_test.go
+++ b/internal/providers/anthropic/probe_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeModelsServer serves a canned /v1/models response. Asserts the
@@ -42,7 +43,7 @@ func TestListModels_HappyPath(t *testing.T) {
 	srv := fakeModelsServer(t, http.StatusOK, body)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
@@ -59,7 +60,7 @@ func TestProbe_HappyPath(t *testing.T) {
 	srv := fakeModelsServer(t, http.StatusOK, `{"data": [{"id": "claude-opus-4-7"}]}`)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestProbe_AuthFailure(t *testing.T) {
 		`{"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}}`)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	err := d.Probe(context.Background())
 	if err == nil {
 		t.Fatal("Probe should error on 401")
@@ -92,7 +93,7 @@ func TestProbe_NetworkFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err == nil {
 		t.Fatal("Probe should error on dropped connection")
 	}

--- a/internal/providers/anthropic/thinking_test.go
+++ b/internal/providers/anthropic/thinking_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // TestStreamThinking_EmitsLiveEventThinking pins the v0.7.x
@@ -36,7 +37,7 @@ func TestStreamThinking_EmitsLiveEventThinking(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "claude-opus-4-7",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "what is 6 times 7"}}}},
@@ -89,7 +90,7 @@ func TestStreamThinking_NotEmittedOnPlainTextStream(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "claude-haiku-4-5",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // defaultBaseURL is DeepSeek's OpenAI-compatible Chat Completions
@@ -47,12 +48,13 @@ type Driver struct {
 // New constructs a Driver. baseURL may be empty for the public
 // DeepSeek endpoint, or set to a self-hosted OpenAI-compatible mirror
 // (e.g. an internal vLLM serving a DeepSeek model). httpClient may be
-// nil to use the OpenAI driver's default.
-func New(apiKey, baseURL string, httpClient *http.Client) *Driver {
+// nil to use the OpenAI driver's default. streamOpts is forwarded to
+// the inner driver — see openai.New for semantics.
+func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	return &Driver{inner: openai.New(apiKey, baseURL, httpClient)}
+	return &Driver{inner: openai.New(apiKey, baseURL, streamOpts, httpClient)}
 }
 
 // ID returns "deepseek" so the provider resolver in cmd/loomcycle

--- a/internal/providers/deepseek/driver_test.go
+++ b/internal/providers/deepseek/driver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeStream serves a canned SSE script, mirroring the OpenAI
@@ -38,14 +39,14 @@ func TestDriver_IDIsDeepseek(t *testing.T) {
 	// The whole point of the wrapper: a distinct ID so the
 	// provider resolver dispatches `provider: deepseek` to this
 	// driver and per-run cost accounting keys on it correctly.
-	d := New("test-key", "", nil)
+	d := New("test-key", "", streamhttp.Options{}, nil)
 	if got := d.ID(); got != "deepseek" {
 		t.Fatalf("ID() = %q, want %q", got, "deepseek")
 	}
 }
 
 func TestDriver_DefaultBaseURLIsDeepseek(t *testing.T) {
-	// New("", "", nil) must NOT fall through to api.openai.com.
+	// New("", "", streamhttp.Options{}, nil) must NOT fall through to api.openai.com.
 	// Verify by stubbing the OpenAI default URL — if the wrapper
 	// forgot to pre-bake the DeepSeek base, the request would
 	// flow to OpenAI. Easiest check: call with an empty base URL
@@ -64,7 +65,7 @@ func TestDriver_DefaultBaseURLIsDeepseek(t *testing.T) {
 			),
 		}, nil
 	})
-	d := New("test-key", "", &http.Client{Transport: rt})
+	d := New("test-key", "", streamhttp.Options{}, &http.Client{Transport: rt})
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "deepseek-chat",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -92,7 +93,7 @@ func TestDriver_CustomBaseURLOverridesDefault(t *testing.T) {
 	})
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "deepseek-chat",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -118,7 +119,7 @@ func TestDriver_CapabilitiesMatchOpenAI(t *testing.T) {
 	// pins the assumption so a future change to OpenAI's flags
 	// surfaces here as a deliberate decision rather than silent
 	// drift.
-	d := New("test-key", "", nil)
+	d := New("test-key", "", streamhttp.Options{}, nil)
 	caps := d.Capabilities()
 	if caps.NativePromptCache {
 		t.Errorf("NativePromptCache = true, want false (DeepSeek auto-caches; no caller knob)")

--- a/internal/providers/deepseek/live_test.go
+++ b/internal/providers/deepseek/live_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 func TestLive_DeepSeekChatCompletion(t *testing.T) {
@@ -31,7 +32,7 @@ func TestLive_DeepSeekChatCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	d := New(key, "", nil)
+	d := New(key, "", streamhttp.Options{}, nil)
 
 	ch, err := d.Call(ctx, providers.Request{
 		Model: "deepseek-chat",
@@ -102,7 +103,7 @@ func TestLive_DeepSeekToolCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	d := New(key, "", nil)
+	d := New(key, "", streamhttp.Options{}, nil)
 
 	ch, err := d.Call(ctx, providers.Request{
 		Model: "deepseek-chat",

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -42,33 +42,37 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 const (
 	defaultBaseURL = "https://generativelanguage.googleapis.com/v1beta"
-	defaultTimeout = 5 * time.Minute
 )
 
 // Driver speaks Gemini's generateContent API.
 type Driver struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey      string
+	baseURL     string
+	http        *http.Client
+	idleTimeout time.Duration
 }
 
 // New constructs a Driver. baseURL may be empty for the default
 // endpoint, or set to a self-hosted Vertex AI Gemini gateway. The
 // trailing path "/v1beta" is included in the default — operator
-// overrides should match that pattern.
-func New(apiKey, baseURL string, httpClient *http.Client) *Driver {
+// overrides should match that pattern. streamOpts controls per-stream
+// timeouts (zero = streamhttp defaults). When httpClient is nil, a
+// fresh streaming client honoring streamOpts.HeaderTimeout is built.
+func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	streamOpts = streamOpts.Resolve()
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: defaultTimeout}
+		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
 }
 
 func (d *Driver) ID() string { return "gemini" }
@@ -103,9 +107,11 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
 	url := d.baseURL + "/models/" + req.Model + ":streamGenerateContent?alt=sse"
-	attempt := func(ctx context.Context) (*http.Response, error) {
-		httpReq, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	attempt := func(attemptCtx context.Context) (*http.Response, error) {
+		httpReq, err := http.NewRequestWithContext(attemptCtx, "POST", url, bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -117,12 +123,13 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return d.http.Do(httpReq)
 	}
 
-	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+	resp, err := ratelimit.Do(streamCtx, ratelimit.Config{
 		Provider:    "gemini",
 		ParseHeader: ratelimit.OpenAIRetryAfter, // Gemini uses the same header shape
 		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
+		cancelStream()
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
@@ -130,12 +137,18 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
+		cancelStream()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("gemini %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
+	resp.Body = streamhttp.WrapBody(resp.Body, d.idleTimeout, cancelStream)
+
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out, req.Model)
+	go func() {
+		defer cancelStream()
+		streamEvents(streamCtx, resp.Body, out, req.Model)
+	}()
 	return out, nil
 }
 

--- a/internal/providers/gemini/driver_test.go
+++ b/internal/providers/gemini/driver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeStream serves a canned SSE script as one streamGenerateContent
@@ -51,7 +52,7 @@ func TestStreamTextThenStop(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "gemini-2.0-flash",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -97,7 +98,7 @@ func TestStreamFunctionCall(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model: "gemini-2.0-flash",
 		Tools: []providers.ToolSpec{
@@ -156,7 +157,7 @@ func TestRequestShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	temp := 0.5
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:       "gemini-2.5-flash",
@@ -310,7 +311,7 @@ func TestListModels_StripsModelsPrefix(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
@@ -333,7 +334,7 @@ func TestProbe_PropagatesError(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("bad-key", srv.URL, nil)
+	d := New("bad-key", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err == nil {
 		t.Fatal("Probe with 401 didn't surface an error")
 	}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -28,29 +28,36 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 const (
 	defaultBaseURL = "http://localhost:11434"
-	defaultTimeout = 10 * time.Minute // local generation can be slow
 )
 
 // Driver speaks Ollama's /api/chat. No API key — local trust model.
 type Driver struct {
-	baseURL string
-	http    *http.Client
+	baseURL     string
+	http        *http.Client
+	idleTimeout time.Duration
 }
 
-// New constructs a Driver. baseURL may be empty for the default localhost endpoint.
-func New(baseURL string, httpClient *http.Client) *Driver {
+// New constructs a Driver. baseURL may be empty for the default localhost
+// endpoint. streamOpts controls per-stream timeouts. Local generation
+// can be very slow on first-token (model warmup, large context); callers
+// passing zero values get the streamhttp defaults — usually fine, but
+// operators on cold-start sensitive deployments may want to bump
+// HeaderTimeout via LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_SECONDS.
+func New(baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	streamOpts = streamOpts.Resolve()
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: defaultTimeout}
+		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{baseURL: baseURL, http: httpClient}
+	return &Driver{baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
 }
 
 func (d *Driver) ID() string { return "ollama" }
@@ -85,8 +92,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	attempt := func(ctx context.Context) (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/api/chat", bytes.NewReader(body))
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
+	attempt := func(attemptCtx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(attemptCtx, "POST", d.baseURL+"/api/chat", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -95,12 +104,13 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return d.http.Do(req)
 	}
 
-	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+	resp, err := ratelimit.Do(streamCtx, ratelimit.Config{
 		Provider:    "ollama",
 		ParseHeader: ratelimit.OllamaRetryAfter,
 		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
+		cancelStream()
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
@@ -108,12 +118,18 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
+		cancelStream()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("ollama %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
+	resp.Body = streamhttp.WrapBody(resp.Body, d.idleTimeout, cancelStream)
+
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out, len(req.Tools) > 0)
+	go func() {
+		defer cancelStream()
+		streamEvents(streamCtx, resp.Body, out, len(req.Tools) > 0)
+	}()
 	return out, nil
 }
 

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeStream serves a canned NDJSON script as one /api/chat response.
@@ -44,7 +45,7 @@ func TestStreamTextThenStop(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "llama3.1",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -88,7 +89,7 @@ func TestStreamToolCallOnFinalFrame(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 
 	var toolCall *providers.ToolUse
@@ -130,7 +131,7 @@ func TestStreamToolCallOnNonFinalFrame(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 
 	var toolCalls int
@@ -160,7 +161,7 @@ func TestRequestBodyShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	temp := 0.7
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:       "llama3.1",
@@ -223,7 +224,7 @@ func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(ctx, providers.Request{Model: "llama3.1"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -251,7 +252,7 @@ func TestNon200Status(t *testing.T) {
 		fmt.Fprint(w, `{"error":"model not found"}`)
 	}))
 	defer srv.Close()
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(context.Background(), providers.Request{Model: "nope"})
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -291,7 +292,7 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -341,7 +342,7 @@ func TestRetryEmitsEventToRequestOnEvent(t *testing.T) {
 
 	var retries []providers.Event
 	var rmu sync.Mutex
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "llama3.1",
 		OnEvent: func(ev providers.Event) {
@@ -382,7 +383,7 @@ func TestStopReasonWithoutToolCalls(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
 	var stop string
 	for ev := range ch {

--- a/internal/providers/ollama/effort_test.go
+++ b/internal/providers/ollama/effort_test.go
@@ -2,6 +2,7 @@ package ollama
 
 import (
 	"testing"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // Ollama doesn't translate effort — it has no operator-controlled
@@ -14,7 +15,7 @@ func TestCapabilities_SupportsEffortIsFalse(t *testing.T) {
 	// when an agent declares effort on an Ollama-resolved run.
 	// Operators see clearly that the hint was discarded rather
 	// than silently believing the agent thought hard.
-	d := New("http://localhost:11434", nil)
+	d := New("http://localhost:11434", streamhttp.Options{}, nil)
 	if d.Capabilities().SupportsEffort {
 		t.Error("Ollama driver must report SupportsEffort=false (no thinking-budget knob today)")
 	}

--- a/internal/providers/ollama/live_test.go
+++ b/internal/providers/ollama/live_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // liveBaseURL returns the test Ollama address from the env, or
@@ -110,7 +111,7 @@ func TestLive_OllamaChatCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	d := New(baseURL, nil)
+	d := New(baseURL, streamhttp.Options{}, nil)
 
 	// MaxTokens=512 gives reasoning models (qwen3, deepseek-r1, etc.)
 	// budget for the <think>...</think> block AND the actual answer.
@@ -191,7 +192,7 @@ func TestLive_OllamaToolCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	d := New(baseURL, nil)
+	d := New(baseURL, streamhttp.Options{}, nil)
 
 	ch, err := d.Call(ctx, providers.Request{
 		Model: model,

--- a/internal/providers/ollama/markdown_tool_test.go
+++ b/internal/providers/ollama/markdown_tool_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // Tests for the v0.7.x Ollama markdown-form tool-call parser
@@ -161,7 +162,7 @@ func TestStreamMarkdownFormToolCall(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "hermes3:latest",
 		Tools: []providers.ToolSpec{{Name: "search_web", InputSchema: json.RawMessage(`{}`)}},

--- a/internal/providers/ollama/probe_test.go
+++ b/internal/providers/ollama/probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeTagsServer serves a canned /api/tags response. Ollama doesn't
@@ -32,7 +33,7 @@ func TestListModels_HappyPath(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, body)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
@@ -49,7 +50,7 @@ func TestListModels_NoModelsPulled(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, `{"models": []}`)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels (empty): %v", err)
@@ -63,7 +64,7 @@ func TestProbe_HappyPath(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, `{"models": []}`)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestProbe_ServerDown(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusInternalServerError, "ollama: server error")
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err == nil {
 		t.Fatal("Probe should error on 500")
 	}

--- a/internal/providers/ollama/thinking_test.go
+++ b/internal/providers/ollama/thinking_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // TestStreamThinking_EmitsLiveEventThinking pins the v0.7.x
@@ -28,7 +29,7 @@ func TestStreamThinking_EmitsLiveEventThinking(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "what is 6 times 7"}}}},
@@ -76,7 +77,7 @@ func TestStreamThinking_NotEmittedOnNonThinkingModel(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "llama3.1",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},

--- a/internal/providers/ollama/tool_text_recovery_test.go
+++ b/internal/providers/ollama/tool_text_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // Five tests pin the qwen3 tool-call-as-text recovery contract:
@@ -35,7 +36,7 @@ func TestToolTextRecovery_SynthesizesCallFromText(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "qwen3:14b",
 		Tools: []providers.ToolSpec{{Name: "mcp__jobs__getApplication", InputSchema: json.RawMessage(`{}`)}},
@@ -88,7 +89,7 @@ func TestToolTextRecovery_SynthesizesArrayOfCalls(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "a"}, {Name: "b"}},
@@ -115,7 +116,7 @@ func TestToolTextRecovery_StripsMarkdownFence(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -142,7 +143,7 @@ func TestToolTextRecovery_DoesNotFalsePositiveOnProse(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -178,7 +179,7 @@ func TestToolTextRecovery_NoSynthWhenStructuredCallAlreadyEmitted(t *testing.T) 
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -206,7 +207,7 @@ func TestToolTextRecovery_DisabledWhenNoToolsRequested(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, nil)
+	d := New(srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model: "qwen3:14b",
 		// Tools intentionally empty — recovery must NOT fire.

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -21,31 +21,36 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ratelimit"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 const (
 	defaultBaseURL = "https://api.openai.com/v1"
-	defaultTimeout = 5 * time.Minute
 )
 
 // Driver speaks Chat Completions.
 type Driver struct {
-	apiKey  string
-	baseURL string
-	http    *http.Client
+	apiKey      string
+	baseURL     string
+	http        *http.Client
+	idleTimeout time.Duration
 }
 
 // New constructs a Driver. baseURL may be empty for the default endpoint, or
 // set to any OpenAI-compatible base (e.g. "http://localhost:8000/v1" for vLLM).
-func New(apiKey, baseURL string, httpClient *http.Client) *Driver {
+// streamOpts controls per-stream timeouts (zero = streamhttp defaults). When
+// httpClient is nil, a fresh streaming client honoring streamOpts.HeaderTimeout
+// is built.
+func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
 	baseURL = strings.TrimRight(baseURL, "/")
+	streamOpts = streamOpts.Resolve()
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: defaultTimeout}
+		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
 }
 
 func (d *Driver) ID() string { return "openai" }
@@ -81,8 +86,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return nil, fmt.Errorf("build request: %w", err)
 	}
 
-	attempt := func(ctx context.Context) (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, "POST", d.baseURL+"/chat/completions", bytes.NewReader(body))
+	streamCtx, cancelStream := context.WithCancel(ctx)
+
+	attempt := func(attemptCtx context.Context) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(attemptCtx, "POST", d.baseURL+"/chat/completions", bytes.NewReader(body))
 		if err != nil {
 			return nil, err
 		}
@@ -94,12 +101,13 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		return d.http.Do(req)
 	}
 
-	resp, err := ratelimit.Do(ctx, ratelimit.Config{
+	resp, err := ratelimit.Do(streamCtx, ratelimit.Config{
 		Provider:    "openai",
 		ParseHeader: ratelimit.OpenAIRetryAfter,
 		OnEvent:     req.OnEvent,
 	}, attempt)
 	if err != nil {
+		cancelStream()
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
@@ -107,12 +115,18 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	}
 	if resp.StatusCode != http.StatusOK {
 		defer resp.Body.Close()
+		cancelStream()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, fmt.Errorf("openai %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
+	resp.Body = streamhttp.WrapBody(resp.Body, d.idleTimeout, cancelStream)
+
 	out := make(chan providers.Event, 16)
-	go streamEvents(ctx, resp.Body, out)
+	go func() {
+		defer cancelStream()
+		streamEvents(streamCtx, resp.Body, out)
+	}()
 	return out, nil
 }
 

--- a/internal/providers/openai/driver_test.go
+++ b/internal/providers/openai/driver_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeStream serves a canned SSE script as one Chat Completions response.
@@ -76,7 +77,7 @@ func TestStreamTextCoalescing_BatchesPerTokenDeltas(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "gpt-5.4-mini",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
@@ -124,7 +125,7 @@ func TestStreamTextCoalescing_FlushesOnNewline(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "gpt-5.4-mini",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
@@ -179,7 +180,7 @@ func TestStreamTextCoalescing_FlushesBeforeToolCall(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "gpt-5.4-mini",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -238,7 +239,7 @@ func TestStreamTextThenStop(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "gpt-4o-mini",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -296,7 +297,7 @@ func TestStreamUsage_PopulatesModel(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "deepseek-chat",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "x"}}}},
@@ -333,7 +334,7 @@ func TestStreamToolCallAccumulation(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "gpt-4o-mini"})
 
 	var toolCall *providers.ToolUse
@@ -376,7 +377,7 @@ func TestStreamMultipleToolCalls(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
 
 	var got []providers.ToolUse
@@ -411,7 +412,7 @@ func TestStreamToolCallNonContiguousIndices(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
 
 	var got []providers.ToolUse
@@ -442,7 +443,7 @@ func TestRequestBodyShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "gpt-4o-mini",
 		System: []providers.ContentBlock{
@@ -504,7 +505,7 @@ func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(ctx, providers.Request{Model: "x"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -560,7 +561,7 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{Model: "gpt-4o-mini"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -612,7 +613,7 @@ func TestRetryEmitsEventToRequestOnEvent(t *testing.T) {
 
 	var retries []providers.Event
 	var rmu sync.Mutex
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "gpt-4o-mini",
 		OnEvent: func(ev providers.Event) {
@@ -652,7 +653,7 @@ func TestNon200Status(t *testing.T) {
 		fmt.Fprint(w, `{"error":{"message":"invalid api key"}}`)
 	}))
 	defer srv.Close()
-	d := New("bad-key", srv.URL, nil)
+	d := New("bad-key", srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(context.Background(), providers.Request{Model: "x"})
 	if err == nil {
 		t.Fatal("expected error on 401")

--- a/internal/providers/openai/effort_test.go
+++ b/internal/providers/openai/effort_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // OpenAI effort translation is much simpler than Anthropic's: pass
@@ -84,7 +85,7 @@ func TestCapabilities_SupportsEffortIsTrue(t *testing.T) {
 	// edit can't quietly flip it to false (which would make the
 	// loop log "effort dropped" on every OpenAI run, misleading
 	// operators about what the driver actually does).
-	d := New("test-key", "", nil)
+	d := New("test-key", "", streamhttp.Options{}, nil)
 	if !d.Capabilities().SupportsEffort {
 		t.Error("OpenAI driver must report SupportsEffort=true")
 	}

--- a/internal/providers/openai/probe_test.go
+++ b/internal/providers/openai/probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // fakeModelsServer serves a canned /models response.
@@ -35,7 +36,7 @@ func TestListModels_HappyPath(t *testing.T) {
 	srv := fakeModelsServer(t, http.StatusOK, body)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
@@ -59,7 +60,7 @@ func TestListModels_DeepSeekShape(t *testing.T) {
 	srv := fakeModelsServer(t, http.StatusOK, body)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels (DeepSeek shape): %v", err)
@@ -74,7 +75,7 @@ func TestProbe_AuthFailure(t *testing.T) {
 		`{"error": {"message": "Incorrect API key", "type": "invalid_request_error"}}`)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err == nil {
 		t.Fatal("Probe should error on 401")
 	}

--- a/internal/providers/openai/reasoning_test.go
+++ b/internal/providers/openai/reasoning_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
 // Three tests pin the reasoning_content roundtrip — the contract
@@ -38,7 +39,7 @@ func TestReasoning_EmitsLiveEventThinking(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "deepseek-v4-pro",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -91,7 +92,7 @@ func TestReasoning_CaptureAccumulatesAcrossDeltas(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New("test-key", srv.URL, nil)
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "deepseek-v4-pro",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},

--- a/internal/providers/streamhttp/streamhttp.go
+++ b/internal/providers/streamhttp/streamhttp.go
@@ -1,0 +1,170 @@
+// Package streamhttp provides HTTP client + body-wrapping utilities for
+// long-running streaming responses (LLM SSE streams). It replaces the
+// "http.Client.Timeout = 5 * time.Minute" wall-clock pattern with two
+// finer timeouts:
+//
+//   - ResponseHeaderTimeout, set on the Transport: caps time-to-first-byte.
+//     The model has this long to start emitting after we POST.
+//   - Per-byte idle timeout, applied to the response body via WrapBody:
+//     caps stalls *between* body bytes. Long but actively-emitting streams
+//     are allowed to run as long as they keep producing — only stalled
+//     streams get killed.
+//
+// Why the change: a single Client.Timeout cancels the entire request,
+// including the body read. For long final turns where the model is
+// streaming a large structured response (e.g. job-searcher building a
+// 25-position ingest payload), the wall-clock timeout fires mid-stream
+// and the agent run fails. Per-byte idle is the right shape — it
+// distinguishes "model is generating, just slowly" from "model has
+// stopped emitting and we should give up."
+package streamhttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Default timeout values applied when Options is zero.
+const (
+	// DefaultHeaderTimeout is generous because cold-start LLM endpoints
+	// (Anthropic during a regional load spike, Ollama warming a 70b
+	// model) can legitimately take 30+ seconds to deliver headers.
+	DefaultHeaderTimeout = 60 * time.Second
+
+	// DefaultIdleTimeout is the gap-between-body-bytes ceiling. With
+	// reasoning-model thinking blocks (Anthropic extended thinking,
+	// DeepSeek-R1 chain-of-thought), pauses of 30-60 seconds between
+	// tokens are normal. 90 seconds gives a safety margin without
+	// keeping a fully-stalled connection forever.
+	DefaultIdleTimeout = 90 * time.Second
+)
+
+// Options configures the timeouts a driver applies to its provider HTTP
+// calls. A zero field falls back to the matching Default*. Driver
+// constructors should resolve the defaults at New() time so the Driver
+// struct holds the real value (no surprise behaviour change if a future
+// caller mutates this constant).
+type Options struct {
+	HeaderTimeout time.Duration
+	IdleTimeout   time.Duration
+}
+
+// Resolve returns a copy with zero fields replaced by their defaults.
+// Drivers call this once in New() so subsequent Call()s see concrete values.
+func (o Options) Resolve() Options {
+	if o.HeaderTimeout <= 0 {
+		o.HeaderTimeout = DefaultHeaderTimeout
+	}
+	if o.IdleTimeout <= 0 {
+		o.IdleTimeout = DefaultIdleTimeout
+	}
+	return o
+}
+
+// NewClient returns an *http.Client suitable for LLM streaming. The
+// client has NO Timeout (would cap mid-stream); the Transport carries
+// ResponseHeaderTimeout. Per-byte idle detection on the response body
+// is the caller's job — wrap resp.Body with WrapBody in each Call().
+//
+// We build a fresh Transport rather than cloning http.DefaultTransport.
+// Sharing the default pool across drivers means one stalled connection
+// (e.g. a hung Anthropic session) can starve another driver's reuse —
+// observed in production. A per-driver Transport keeps the failure
+// domains separate.
+func NewClient(headerTimeout time.Duration) *http.Client {
+	if headerTimeout <= 0 {
+		headerTimeout = DefaultHeaderTimeout
+	}
+	return &http.Client{
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: headerTimeout,
+			// Defaults from http.DefaultTransport for the rest:
+			Proxy:                 http.ProxyFromEnvironment,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		},
+	}
+}
+
+// WrapBody wraps an HTTP response body so that it cancels the request's
+// context after idleTimeout elapses without a Read returning bytes.
+// Each Read with n>0 resets the timer; Close stops the timer and is
+// idempotent.
+//
+// Use this in driver Call() implementations:
+//
+//	ctx, cancel := context.WithCancel(parentCtx)
+//	req, _ := http.NewRequestWithContext(ctx, ...)
+//	resp, err := client.Do(req)
+//	if err != nil {
+//	    cancel()
+//	    return nil, err
+//	}
+//	resp.Body = streamhttp.WrapBody(resp.Body, idleTimeout, cancel)
+//	// ... read resp.Body in the SSE loop. defer resp.Body.Close().
+//	// defer cancel() at the top of Call() is the standard ctx cleanup.
+//
+// On idle, cancel() fires; the next Read on the underlying body returns
+// context.Canceled (or wraps it via net/http). The SSE parser surfaces
+// this as the existing "stream read: context deadline exceeded" error
+// shape, so callers don't need to handle a new error type.
+//
+// There's a small race window: if a Read is in flight when the timer
+// fires, cancel() runs even though bytes were arriving. The
+// consequence is a spurious cancel right at the idle threshold — rare,
+// benign, and the loop will retry the request via the regular
+// rate-limit / retry path.
+func WrapBody(rc io.ReadCloser, idleTimeout time.Duration, cancel context.CancelFunc) io.ReadCloser {
+	if idleTimeout <= 0 {
+		idleTimeout = DefaultIdleTimeout
+	}
+	return &idleReadCloser{
+		rc:     rc,
+		idle:   idleTimeout,
+		cancel: cancel,
+		timer:  time.AfterFunc(idleTimeout, cancel),
+	}
+}
+
+// idleReadCloser is the WrapBody implementation. The timer is created
+// in WrapBody (so we don't need a separate Start step) and torn down
+// in Close. Concurrent Close vs Read is allowed; the mutex makes Close
+// idempotent and prevents a double Stop on the timer.
+type idleReadCloser struct {
+	rc     io.ReadCloser
+	idle   time.Duration
+	cancel context.CancelFunc
+	timer  *time.Timer
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func (i *idleReadCloser) Read(p []byte) (int, error) {
+	n, err := i.rc.Read(p)
+	if n > 0 {
+		// Reset returns false when the timer was already fired/stopped;
+		// we don't care — if it already fired, cancel() ran and the next
+		// Read will see the context error. If it was stopped (Close),
+		// we're shutting down anyway.
+		i.timer.Reset(i.idle)
+	}
+	return n, err
+}
+
+func (i *idleReadCloser) Close() error {
+	i.mu.Lock()
+	if i.closed {
+		i.mu.Unlock()
+		return nil
+	}
+	i.closed = true
+	i.mu.Unlock()
+	i.timer.Stop()
+	return i.rc.Close()
+}

--- a/internal/providers/streamhttp/streamhttp_test.go
+++ b/internal/providers/streamhttp/streamhttp_test.go
@@ -1,0 +1,191 @@
+package streamhttp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowReader emits one byte at the given interval, up to total bytes.
+// Used to model "stream that's slow but progressing" vs "stalled stream".
+type slowReader struct {
+	interval time.Duration
+	total    int
+	emitted  int
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.emitted >= s.total {
+		return 0, io.EOF
+	}
+	time.Sleep(s.interval)
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = byte('a' + s.emitted%26)
+	s.emitted++
+	return 1, nil
+}
+
+func (s *slowReader) Close() error { return nil }
+
+// stalledReader blocks forever (until Close).
+type stalledReader struct {
+	closed atomic.Bool
+}
+
+func (s *stalledReader) Read(p []byte) (int, error) {
+	for !s.closed.Load() {
+		time.Sleep(10 * time.Millisecond)
+	}
+	return 0, io.ErrClosedPipe
+}
+
+func (s *stalledReader) Close() error {
+	s.closed.Store(true)
+	return nil
+}
+
+// TestWrapBody_StalledStreamFiresCancel verifies that a body which
+// produces no Read'd bytes within idleTimeout triggers cancel(). This
+// is the headline case — the regression we're guarding against.
+func TestWrapBody_StalledStreamFiresCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	stall := &stalledReader{}
+	body := WrapBody(stall, 50*time.Millisecond, cancel)
+	defer body.Close()
+
+	// Read in a separate goroutine so we can assert ctx fires.
+	readDone := make(chan struct{})
+	go func() {
+		defer close(readDone)
+		// Read will block until the underlying reader returns; once cancel
+		// fires, our wrapper doesn't immediately interrupt the Read (the
+		// underlying reader has to notice). For this test we just confirm
+		// the context was cancelled within the idle window.
+		_, _ = body.Read(make([]byte, 1))
+	}()
+
+	select {
+	case <-ctx.Done():
+		// Expected — timer fired and called cancel.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("expected ctx to be cancelled by idle timer; ctx still active")
+	}
+	// Unblock the read goroutine for clean shutdown.
+	stall.Close()
+	<-readDone
+}
+
+// TestWrapBody_ActiveStreamSurvives verifies that a stream that keeps
+// producing bytes (every 30ms, well under the 100ms idle limit) is NOT
+// killed by the idle timer. This is the case the old Client.Timeout
+// got wrong: it killed slow-but-active streams at 5 min wall-clock.
+func TestWrapBody_ActiveStreamSurvives(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := WrapBody(&slowReader{interval: 30 * time.Millisecond, total: 20}, 100*time.Millisecond, cancel)
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 20 {
+		t.Errorf("expected 20 bytes, got %d (%q)", len(got), string(got))
+	}
+	// ctx should NOT have been cancelled by the idle timer.
+	select {
+	case <-ctx.Done():
+		t.Errorf("idle timer fired on an active stream: %v", ctx.Err())
+	default:
+		// Expected — active stream survived.
+	}
+}
+
+// TestWrapBody_CloseIsIdempotent verifies Close can be called multiple
+// times without panicking on double timer.Stop(). The driver code
+// often has both an explicit Close path and a defer Close path.
+func TestWrapBody_CloseIsIdempotent(t *testing.T) {
+	_, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := WrapBody(io.NopCloser(strings.NewReader("hello")), 1*time.Second, cancel)
+	if err := body.Close(); err != nil {
+		t.Errorf("first Close failed: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Errorf("second Close failed: %v", err)
+	}
+}
+
+// TestWrapBody_CloseStopsTimer verifies that closing the body before
+// the idle timer fires prevents a spurious cancel() afterward. Without
+// this guarantee, a normally-completed stream that gets Close()d would
+// still cancel the parent context if the idle timer happened to fire
+// during shutdown.
+func TestWrapBody_CloseStopsTimer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body := WrapBody(io.NopCloser(strings.NewReader("ok")), 30*time.Millisecond, cancel)
+
+	// Read a byte, then immediately close.
+	buf := make([]byte, 1)
+	_, _ = body.Read(buf)
+	if err := body.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	// Wait past the original idle timeout. ctx must remain non-cancelled
+	// because Close stopped the timer.
+	time.Sleep(80 * time.Millisecond)
+	select {
+	case <-ctx.Done():
+		t.Errorf("ctx was cancelled after Close — timer was not stopped")
+	default:
+		// Expected — closing the body cleaned up the timer.
+	}
+}
+
+// TestNewClient_NoWallclockTimeout sanity-checks that we did NOT set
+// http.Client.Timeout (which would re-introduce the bug we're fixing).
+// The streaming path relies entirely on Transport.ResponseHeaderTimeout
+// + the body-wrap idle detection.
+func TestNewClient_NoWallclockTimeout(t *testing.T) {
+	c := NewClient(60 * time.Second)
+	if c.Timeout != 0 {
+		t.Errorf("http.Client.Timeout=%v; expected 0 (would kill long streams)", c.Timeout)
+	}
+}
+
+// TestOptions_Resolve fills zero fields with defaults; explicit values
+// pass through.
+func TestOptions_Resolve(t *testing.T) {
+	got := Options{}.Resolve()
+	if got.HeaderTimeout != DefaultHeaderTimeout {
+		t.Errorf("HeaderTimeout=%v; want %v", got.HeaderTimeout, DefaultHeaderTimeout)
+	}
+	if got.IdleTimeout != DefaultIdleTimeout {
+		t.Errorf("IdleTimeout=%v; want %v", got.IdleTimeout, DefaultIdleTimeout)
+	}
+
+	got = Options{HeaderTimeout: 5 * time.Second, IdleTimeout: 7 * time.Second}.Resolve()
+	if got.HeaderTimeout != 5*time.Second {
+		t.Errorf("HeaderTimeout=%v; want 5s", got.HeaderTimeout)
+	}
+	if got.IdleTimeout != 7*time.Second {
+		t.Errorf("IdleTimeout=%v; want 7s", got.IdleTimeout)
+	}
+}
+
+// Ensure errors.Is wires through cleanly for the cancellation case
+// (sanity check used elsewhere in this codebase).
+var _ = errors.Is


### PR DESCRIPTION
## Summary

The 5-min wall-clock `http.Client.Timeout` was killing long final-turn streaming responses while the model was actively producing tokens. Replace with header-timeout + per-byte idle pair so productive streams complete and only genuinely-stalled streams get cut.

## Why

Observed on 2026-05-09: a `job-searcher` run on the VM hit `provider error: stream read: context deadline exceeded` at exactly 659 s. The agent had done 53 WebSearch + 14 WebFetch + 8 HTTP + 2 mcp tool calls, then started its final compile-the-candidate-set turn. The model was still emitting tokens when the wall-clock cap fired mid-stream. Same error class also explains earlier `cv-adapter` failures.

`http.Client.Timeout` is documented to cover the whole request including the body read — so streaming responses that legitimately take >5 min get killed even when the connection is healthy. The right shape for SSE is two narrower windows:
- **Time-to-first-byte** (header receipt) → `Transport.ResponseHeaderTimeout`
- **Stalled stream** (gap between body bytes) → custom body wrap that resets a timer on each Read, cancels ctx on idle

## What

New package `internal/providers/streamhttp`:
- `NewClient(headerTimeout)` — `*http.Client` with `Transport.ResponseHeaderTimeout` set; **no** `Client.Timeout`.
- `WrapBody(rc, idleTimeout, cancel)` — `io.ReadCloser` that resets a timer on each Read with `n>0`; on idle, calls `cancel()`. Idempotent `Close` stops the timer.

All five drivers (anthropic / openai / deepseek / gemini / ollama) updated:
- `New()` takes a new `streamhttp.Options` arg before the existing `httpClient`. Zero values resolve to defaults via `Options.Resolve()`.
- `Call()` derives a cancellable `streamCtx` child of `ctx`, passes its cancel to `WrapBody`, and runs the streaming goroutine with deferred cancel for cleanup.
- All error paths (build error, ratelimit failure, non-2xx) call `cancelStream()` before returning.

Operator-tunable via env (defaults match `streamhttp.Default*`):
```
LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000
```

## Test plan

- [x] `go test ./...` — all 22 packages green
- [x] `go test -race ./internal/providers/streamhttp/ ./internal/providers/anthropic/ ./internal/providers/openai/` clean
- [x] streamhttp unit tests cover: stalled stream cancels ctx, active stream survives idle window, Close stops timer, Close idempotent, NewClient has no Client.Timeout
- [ ] Manual smoke against the VM (cross-build, scp, restart loomcycle, run a long agent end-to-end)

## Notes

- No wire-protocol change — this is a runtime-only loomcycle change. jobs-search-agent picks it up on the next dependency bump.
- A spurious-cancel race exists at the idle threshold (timer fires while a Read is in flight returning bytes). Documented in WrapBody's docstring; consequence is benign (the loop's existing 429/retry path handles it as a transient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)