### PR TITLE
feat(mcp): lazy retry of skipped servers on first agent call

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -306,6 +306,26 @@ func main() {
 	}
 	mcpInitCancel()
 
+	// Lazy MCP recovery — when an agent calls a tool from a server that
+	// failed initial handshake (skipped above), this resolver tries one
+	// fresh pool.Get on the agent's call path. On success the server's
+	// tools are memoised in the resolver and dispatched. Subsequent
+	// calls hit the cache without re-handshaking.
+	//
+	// Without this, an MCP peer that's down at loomcycle boot stays
+	// invisible for the lifetime of the process — operators have to
+	// notice the "skipped" log line and restart loomcycle by hand.
+	// In a server environment where peers (jobs-search-web, other MCP
+	// services) restart independently, that's recurring operational
+	// pain. See internal/tools/mcp/lazy.go for the state machine.
+	mcpServerCfgs := make(map[string]mcp.ServerCfg, len(cfg.MCPServers))
+	for name, srv := range cfg.MCPServers {
+		mcpServerCfgs[name] = mcp.ServerCfg{AllowedTools: srv.AllowedTools}
+	}
+	mcpLazyResolver := mcp.NewLazyResolver(mcpPool, mcpServerCfgs, func(server string, count int) {
+		log.Printf("mcp[%s]: lazy-registered %d tool(s) on first agent call (was skipped at boot)", server, count)
+	}, 0)
+
 	// Storage: SQLite (default, compact installs) or Postgres
 	// (production, hundreds of concurrent agents). Both adapters
 	// implement the same store.Store interface; they're tested against
@@ -321,6 +341,7 @@ func main() {
 	// fallback for operators running without a configured store.
 	memoryTool.Store = storeIface
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
+	srv.SetMCPFallback(mcpLazyResolver.Resolve)
 
 	// Build the model-resolution matrix (resolve.Resolver). Providers
 	// without API keys are MARKED EXCLUDED so Snapshot() shows the
@@ -747,22 +768,9 @@ func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {
 	})
 }
 
-// applyAllowedToolsFilter narrows a server's discovered tool descriptors
-// to the operator-permitted subset. Empty allowed = pass-through (default
-// behaviour: expose every tool the server advertises).
+// applyAllowedToolsFilter — thin wrapper over mcp.ApplyAllowedToolsFilter.
+// Lives in the mcp package so both the boot-time path here and the
+// lazy-retry path (mcp.LazyResolver) share one implementation.
 func applyAllowedToolsFilter(descs []mcp.ToolDescriptor, allowed []string) []mcp.ToolDescriptor {
-	if len(allowed) == 0 {
-		return descs
-	}
-	allowSet := make(map[string]struct{}, len(allowed))
-	for _, name := range allowed {
-		allowSet[name] = struct{}{}
-	}
-	out := make([]mcp.ToolDescriptor, 0, len(descs))
-	for _, d := range descs {
-		if _, ok := allowSet[d.Name]; ok {
-			out = append(out, d)
-		}
-	}
-	return out
+	return mcp.ApplyAllowedToolsFilter(descs, allowed)
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -82,6 +82,17 @@ type Server struct {
 	// hot path (Match returns nil, dispatchOneTool fast-paths).
 	hookRegistry   *hooks.Registry
 	hookDispatcher *hooks.Dispatcher
+
+	// mcpFallback is the optional Dispatcher fallback for lazy MCP
+	// server registration. When set, an agent's call to a tool name
+	// that's not in the per-run dispatcher's static map (typically
+	// because the MCP server failed handshake at boot and was
+	// "skipped" by main.go) gets a chance to recover via this fallback
+	// before the dispatcher returns the standard "tool not found"
+	// error. Wired in cmd/loomcycle/main.go via SetMCPFallback after
+	// the MCP pool is built; nil-safe for tests + unit harnesses
+	// that don't exercise MCP at all. See internal/tools/mcp/lazy.go.
+	mcpFallback tools.FallbackFunc
 }
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
@@ -111,6 +122,29 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 	}
 	s.tools = append(s.tools, &builtin.AgentTool{Run: s.runSubAgent})
 	return s
+}
+
+// SetMCPFallback installs the optional MCP lazy-resolution fallback.
+// Pass mcp.NewLazyResolver(...).Resolve here. Nil disables the
+// fallback (per-run dispatchers behave exactly as before — unknown
+// tool names return "tool not found" without any handshake retry).
+//
+// Mirrors the SetResolver pattern: tests that don't need lazy MCP
+// recovery can omit this call entirely. Production wires it from
+// cmd/loomcycle/main.go after the MCP pool is built.
+func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
+	s.mcpFallback = fn
+}
+
+// newDispatcher centralises Dispatcher construction so the three call
+// sites (handleRuns, handleMessages, runSubAgent) all pick up the
+// fallback automatically. With s.mcpFallback nil this is identical
+// to tools.NewDispatcher(allowedTools).
+func (s *Server) newDispatcher(allowedTools []tools.Tool) *tools.Dispatcher {
+	if s.mcpFallback == nil {
+		return tools.NewDispatcher(allowedTools)
+	}
+	return tools.NewDispatcherWithFallback(allowedTools, s.mcpFallback)
 }
 
 // SessionLocks exposes the per-session lock map so the gRPC server
@@ -356,7 +390,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 			WebSearchFilter: in.WebSearchFilter,
 		}
 	}
-	dispatcher := tools.NewDispatcher(allowedTools)
+	dispatcher := s.newDispatcher(allowedTools)
 
 	// ---- Segments: prepend agent's system prompt ----
 	segments := in.Segments
@@ -772,7 +806,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			WebSearchFilter: req.WebSearchFilter,
 		}
 	}
-	dispatcher := tools.NewDispatcher(allowedTools)
+	dispatcher := s.newDispatcher(allowedTools)
 
 	// Optional system prompt from agent def.
 	if agentDef.SystemPrompt != "" {
@@ -1070,7 +1104,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			WebSearchFilter: body.WebSearchFilter,
 		}
 	}
-	dispatcher := tools.NewDispatcher(allowedTools)
+	dispatcher := s.newDispatcher(allowedTools)
 
 	// Re-prepend the agent's system prompt — it isn't in the transcript
 	// (it's per-call configuration, not conversation content).
@@ -1590,7 +1624,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	if parentHostPolicy.HasList || s.cfg.Env.HTTPCallerAuthoritative {
 		subTools = builtin.NarrowHosts(subTools, parentHostPolicy.AllowedHosts, parentHostPolicy.WebSearchFilter, s.cfg.Env.HTTPCallerAuthoritative)
 	}
-	subDispatcher := tools.NewDispatcher(subTools)
+	subDispatcher := s.newDispatcher(subTools)
 
 	// Persist the input segments as the first event so transcript
 	// replay reconstructs the user prompt the same way fresh runs do.

--- a/internal/tools/mcp/filter.go
+++ b/internal/tools/mcp/filter.go
@@ -1,0 +1,25 @@
+package mcp
+
+// ApplyAllowedToolsFilter narrows a server's discovered tool descriptors
+// to the operator-permitted subset (yaml `mcp_servers.<name>.allowed_tools`).
+// Empty allowed = pass-through (default behaviour: expose every tool the
+// server advertises).
+//
+// Lives here so both the boot-time path in cmd/loomcycle/main.go and the
+// lazy-retry path in LazyResolver share one implementation.
+func ApplyAllowedToolsFilter(descs []ToolDescriptor, allowed []string) []ToolDescriptor {
+	if len(allowed) == 0 {
+		return descs
+	}
+	allowSet := make(map[string]struct{}, len(allowed))
+	for _, name := range allowed {
+		allowSet[name] = struct{}{}
+	}
+	out := make([]ToolDescriptor, 0, len(descs))
+	for _, d := range descs {
+		if _, ok := allowSet[d.Name]; ok {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/internal/tools/mcp/lazy.go
+++ b/internal/tools/mcp/lazy.go
@@ -1,0 +1,239 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// LazyResolver implements tools.FallbackFunc for "MCP server was skipped
+// at boot, but is now reachable" recovery.
+//
+// Why it exists. Loomcycle's startup loop in cmd/loomcycle/main.go
+// initialises every configured MCP server with a 30-second budget. If
+// a peer is slow / unreachable / broken when loomcycle boots, the
+// server's tools never get added to the global s.tools registry. Per-
+// run dispatchers then can't find them — agents see "tool not found"
+// even after the peer recovers, until loomcycle itself is restarted.
+//
+// In a server environment where peers (jobs-search-web, other MCP
+// services) restart independently of loomcycle, this is constant
+// operational pain.
+//
+// What it does. Wired as the Dispatcher's FallbackFunc, Resolve runs
+// when a tool name is missing from the static dispatcher map:
+//
+//   1. Parse the name as `mcp__<server>__<tool>`. If it's not that
+//      shape, return (zero, false) so the dispatcher emits its standard
+//      "tool not found" — preserves existing semantics for non-MCP misses.
+//   2. Look up <server> in the configured-servers set. If unknown,
+//      same fall-through (operator never declared it; the model
+//      probably hallucinated the name).
+//   3. Cache hit on the resolver's internal map? Execute the cached Tool
+//      and return.
+//   4. Cache miss: attempt one fresh pool.Get for the server (the pool
+//      handles concurrent-stampede coordination internally — the worst
+//      case is the calling goroutine waits for an in-flight init).
+//      On success, cache every tool the server exposes (after applying
+//      the operator's per-server allowed_tools filter) and dispatch the
+//      requested one. On failure, surface a clear error to the model
+//      naming the server's last-known unreachability reason.
+//
+// What it does NOT do.
+//   - Does not mutate s.tools (the global registry). Lazy-resolved
+//     tools live only in this resolver's memo. The model already knew
+//     the tool name (from its agent prompt or earlier turns); the
+//     fallback hands the call to the right Tool. Tools that need to be
+//     ADVERTISED in the spec list to a fresh model would still need
+//     boot-time registration. That's an orthogonal v1.x concern.
+//   - Does not periodically re-attempt skipped servers. Recovery
+//     happens only when an agent actually needs a tool from the
+//     server. This avoids background traffic to peers that may
+//     genuinely be down. A future background-probe loop is fine to
+//     stack on top — it would call Resolve preemptively for known
+//     server names.
+type LazyResolver struct {
+	pool         *Pool
+	serverConfig map[string]ServerCfg
+
+	// onResolve, if non-nil, is called once per server when its tools
+	// are first registered via the lazy path. Used for operator-visible
+	// "mcp[%s]: lazy-registered N tools after agent call (was skipped at
+	// boot)" log lines.
+	onResolve func(server string, count int)
+
+	// handshakeTimeout caps the per-call Get budget. The pool's own
+	// init has no internal timeout (relies on ctx); if the peer is
+	// slow but recoverable this gives a definite ceiling on how long
+	// the agent's tool call blocks. Default is 10s.
+	handshakeTimeout time.Duration
+
+	mu         sync.Mutex
+	registered map[string]map[string]tools.Tool // server → tool name → Tool
+}
+
+// ServerCfg is the subset of an MCP server's yaml config that the
+// resolver needs to reproduce boot-time tool registration faithfully.
+// Only AllowedTools today; if the boot path grows more per-server
+// knobs (e.g. per-server pool size already lives on Pool), they
+// should join here.
+type ServerCfg struct {
+	AllowedTools []string
+}
+
+// NewLazyResolver builds a resolver. configs MUST cover every server
+// the operator yaml declares — Resolve uses configs as the membership
+// check for "is this name plausibly an MCP tool we should try?". A
+// server that successfully registered at boot can still appear in
+// configs; the resolver simply won't be reached for it (its tools are
+// in the dispatcher's static map).
+//
+// onResolve is optional; pass log.Printf for production. handshakeTimeout
+// of 0 falls back to a sane default.
+func NewLazyResolver(pool *Pool, configs map[string]ServerCfg, onResolve func(string, int), handshakeTimeout time.Duration) *LazyResolver {
+	if handshakeTimeout <= 0 {
+		handshakeTimeout = 10 * time.Second
+	}
+	return &LazyResolver{
+		pool:             pool,
+		serverConfig:     configs,
+		onResolve:        onResolve,
+		handshakeTimeout: handshakeTimeout,
+		registered:       make(map[string]map[string]tools.Tool),
+	}
+}
+
+// Resolve satisfies tools.FallbackFunc. See type-level docstring for the
+// full state machine.
+func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawMessage) (tools.Result, bool) {
+	server, ok := r.parseServer(name)
+	if !ok {
+		return tools.Result{}, false
+	}
+	cfg, configured := r.serverConfig[server]
+	if !configured {
+		return tools.Result{}, false
+	}
+
+	// Cache fast path.
+	r.mu.Lock()
+	if reg, ok := r.registered[server]; ok {
+		t, hit := reg[name]
+		r.mu.Unlock()
+		if hit {
+			return executeAndWrap(ctx, t, input), true
+		}
+		// Server resolved but doesn't expose this specific tool.
+		// Definitive (handled=true) so the model sees a clear error
+		// instead of attempting another lazy-resolve cycle.
+		return tools.Result{
+			Text:    fmt.Sprintf("tool not found: %s (mcp server %q is registered but does not expose this tool name)", name, server),
+			IsError: true,
+		}, true
+	}
+	r.mu.Unlock()
+
+	// Cache miss. Attempt handshake with a per-call ceiling. The pool's
+	// internal entry/ready coordination means concurrent calls for the
+	// same server share one handshake; we just block on the same channel.
+	hsCtx, cancel := context.WithTimeout(ctx, r.handshakeTimeout)
+	defer cancel()
+	_, descs, err := r.pool.Get(hsCtx, server)
+	if err != nil {
+		return tools.Result{
+			Text:    fmt.Sprintf("tool not found: %s (mcp server %q unreachable: %v — verify the peer is healthy and retry)", name, server, summariseErr(err)),
+			IsError: true,
+		}, true
+	}
+
+	// Apply the operator's per-server filter; build the tool map.
+	filtered := ApplyAllowedToolsFilter(descs, cfg.AllowedTools)
+	toolMap := make(map[string]tools.Tool, len(filtered))
+	for _, d := range filtered {
+		t := NewTool(r.pool, server, d)
+		toolMap[t.Name()] = t
+	}
+
+	// Publish to the cache. Even if another goroutine resolved the same
+	// server while we were calling Get, overwriting is safe — the tool
+	// map is built from the same pool/descs and Tool instances are
+	// stateless wrappers. Last writer wins; no harm.
+	r.mu.Lock()
+	r.registered[server] = toolMap
+	r.mu.Unlock()
+
+	if r.onResolve != nil {
+		r.onResolve(server, len(toolMap))
+	}
+
+	t, hit := toolMap[name]
+	if !hit {
+		return tools.Result{
+			Text:    fmt.Sprintf("tool not found: %s (mcp server %q is now reachable but does not expose this tool name; check the operator's allowed_tools filter)", name, server),
+			IsError: true,
+		}, true
+	}
+	return executeAndWrap(ctx, t, input), true
+}
+
+// parseServer extracts the server segment from `mcp__<server>__<tool>`.
+// Returns ("", false) if the name doesn't match the prefix shape OR if
+// the tool segment is empty (e.g. "mcp__jobs__"). The server segment
+// itself is matched against the configured set in Resolve, so this
+// helper does no further validation beyond shape.
+func (r *LazyResolver) parseServer(name string) (string, bool) {
+	const prefix = "mcp__"
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+	rest := name[len(prefix):]
+	// Find the "__" separator between server and tool.
+	idx := strings.Index(rest, "__")
+	if idx <= 0 {
+		return "", false
+	}
+	server := rest[:idx]
+	toolName := rest[idx+2:]
+	if toolName == "" {
+		return "", false
+	}
+	// Normalise via the same helper Tool.Name() uses, so a
+	// "brave search" config (with a space) would match the
+	// "mcp__brave_search__..." names the model sees.
+	if sanitiseServerName(server) != server {
+		// Names emitted by mcpTool.Name() always go through
+		// sanitiseServerName, so an incoming `name` with non-
+		// sanitised characters can't have come from us. Reject.
+		return "", false
+	}
+	return server, true
+}
+
+// executeAndWrap runs a Tool's Execute and converts a Go error into
+// the standard error-shaped Result the dispatcher expects. Mirrors the
+// equivalent block in Dispatcher.Execute so callers of FallbackFunc
+// see the same surface as native dispatcher hits.
+func executeAndWrap(ctx context.Context, t tools.Tool, input json.RawMessage) tools.Result {
+	res, err := t.Execute(ctx, input)
+	if err != nil {
+		return tools.Result{Text: err.Error(), IsError: true}
+	}
+	return res
+}
+
+// summariseErr trims long error strings (e.g. an HTML 500-page body)
+// to a 200-char tail so the model gets a useful hint without 9 KB of
+// peer-side output appearing in tool_result.text.
+func summariseErr(err error) string {
+	s := err.Error()
+	const maxLen = 200
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…(truncated)"
+}

--- a/internal/tools/mcp/lazy_test.go
+++ b/internal/tools/mcp/lazy_test.go
@@ -1,0 +1,325 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// fakeCaller is a Caller that responds to initialize, tools/list, and
+// tools/call with canned data, configured per-server in fakeBuild.
+type fakeCaller struct {
+	server      string
+	tools       []ToolDescriptor
+	healthyFlag atomic.Bool
+}
+
+func newFakeCaller(server string, tools []ToolDescriptor) *fakeCaller {
+	c := &fakeCaller{server: server, tools: tools}
+	c.healthyFlag.Store(true)
+	return c
+}
+
+func (c *fakeCaller) Call(_ context.Context, method string, _ any) (json.RawMessage, error) {
+	switch method {
+	case "initialize":
+		body, _ := json.Marshal(map[string]any{
+			"protocolVersion": ProtocolVersion,
+			"serverInfo":      map[string]any{"name": c.server, "version": "0.1"},
+			"capabilities":    map[string]any{},
+		})
+		return body, nil
+	case "tools/list":
+		body, _ := json.Marshal(map[string]any{"tools": c.tools})
+		return body, nil
+	case "tools/call":
+		// LazyResolver doesn't directly call this in our tests — the
+		// Tool's Execute does. Return an empty content envelope so the
+		// mcpTool.Execute path completes cleanly.
+		body, _ := json.Marshal(map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": "fake-call-result"},
+			},
+		})
+		return body, nil
+	}
+	return nil, errors.New("fakeCaller: unknown method " + method)
+}
+
+func (c *fakeCaller) Notify(_ context.Context, _ string, _ any) error { return nil }
+func (c *fakeCaller) Healthy() bool                                   { return c.healthyFlag.Load() }
+
+// buildPlan is the mock build callback for NewPool. It controls
+// per-server failure ordering:
+//   - serversAlwaysFail: name → true means every build attempt errors.
+//   - serversFailOnce  : name → true means the FIRST build errors,
+//     subsequent attempts succeed (mirrors the boot-skip → recovery
+//     scenario the LazyResolver exists for).
+type buildPlan struct {
+	mu             sync.Mutex
+	failOnce       map[string]bool
+	alwaysFail     map[string]bool
+	tools          map[string][]ToolDescriptor
+	buildCallCount map[string]int
+}
+
+func (b *buildPlan) build(name string) (Caller, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buildCallCount[name]++
+	if b.alwaysFail[name] {
+		return nil, errors.New("fakeBuild: " + name + " is permanently broken")
+	}
+	if b.failOnce[name] {
+		// Clear the flag so the next attempt succeeds.
+		delete(b.failOnce, name)
+		return nil, errors.New("fakeBuild: " + name + " transient failure (will succeed next time)")
+	}
+	tools, ok := b.tools[name]
+	if !ok {
+		return nil, errors.New("fakeBuild: no tools registered for " + name)
+	}
+	return newFakeCaller(name, tools), nil
+}
+
+func (b *buildPlan) calls(name string) int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buildCallCount[name]
+}
+
+func newBuildPlan() *buildPlan {
+	return &buildPlan{
+		failOnce:       make(map[string]bool),
+		alwaysFail:     make(map[string]bool),
+		tools:          make(map[string][]ToolDescriptor),
+		buildCallCount: make(map[string]int),
+	}
+}
+
+// TestLazyResolver_NotMCPName guards against handling tool names that
+// don't match the mcp__server__tool shape — those should fall through
+// to the dispatcher's standard "tool not found", NOT take a handshake
+// detour. Without this, every miss for a built-in tool name (Read,
+// Write, etc.) would block on a useless pool.Get.
+func TestLazyResolver_NotMCPName(t *testing.T) {
+	pool := NewPool(newBuildPlan().build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	for _, name := range []string{"Read", "Write", "WebSearch", "mcp__", "mcp__jobs", "mcp__jobs__"} {
+		_, handled := r.Resolve(context.Background(), name, json.RawMessage(`{}`))
+		if handled {
+			t.Errorf("name=%q: expected handled=false (fall through), got true", name)
+		}
+	}
+}
+
+// TestLazyResolver_ServerNotConfigured covers names that LOOK like MCP
+// tool names but reference a server the operator never declared. Same
+// fall-through outcome as TestLazyResolver_NotMCPName — the model
+// likely hallucinated the name and the standard "tool not found" is
+// the right surface.
+func TestLazyResolver_ServerNotConfigured(t *testing.T) {
+	pool := NewPool(newBuildPlan().build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	_, handled := r.Resolve(context.Background(), "mcp__unknown__doSomething", json.RawMessage(`{}`))
+	if handled {
+		t.Errorf("expected handled=false for unconfigured server, got true")
+	}
+}
+
+// TestLazyResolver_FirstCallTriggersHandshakeAndDispatches is the
+// headline scenario: an agent calls a tool from a server that was
+// "skipped" at boot. LazyResolver attempts a fresh pool.Get (which
+// internally retries build), the build succeeds, the tool is
+// registered, and the call dispatches to the underlying mcpTool.
+func TestLazyResolver_FirstCallTriggersHandshakeAndDispatches(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "getAgentContext", Description: "load context", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("expected handled=true after successful lazy resolution")
+	}
+	if res.IsError {
+		t.Fatalf("expected success Result, got IsError=true: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "fake-call-result") {
+		t.Errorf("expected fake-call-result text, got %q", res.Text)
+	}
+	if got := plan.calls("jobs"); got != 1 {
+		t.Errorf("build called %d times on first lazy resolution, want 1", got)
+	}
+}
+
+// TestLazyResolver_SecondCallHitsCache verifies that successful
+// resolutions are memoised — the second call for any tool from the
+// same server must NOT trigger another handshake. Without this, every
+// tool call goes through pool.Get which serialises on the entry mutex.
+func TestLazyResolver_SecondCallHitsCache(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "patchApplication", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	for i := 0; i < 5; i++ {
+		_, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
+		if !handled {
+			t.Fatalf("iter %d: expected handled=true", i)
+		}
+	}
+	// Even the OTHER tool from the same server should now be in cache —
+	// the first resolution registered the entire server's tool map.
+	_, handled := r.Resolve(context.Background(), "mcp__jobs__patchApplication", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("expected sibling tool to be cache-resolved")
+	}
+	if got := plan.calls("jobs"); got != 1 {
+		t.Errorf("build called %d times across 6 calls, want 1 (cache miss only on the first)", got)
+	}
+}
+
+// TestLazyResolver_HandshakeFails covers the recovery path's failure
+// case: the operator declared the server, the call comes in, the pool
+// build still errors. LazyResolver must return (handled=true) with a
+// clear error to the model — falling through (handled=false) would
+// produce a generic "tool not found" with no operational signal.
+func TestLazyResolver_HandshakeFails(t *testing.T) {
+	plan := newBuildPlan()
+	plan.alwaysFail["jobs"] = true
+	pool := NewPool(plan.build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("expected handled=true on handshake failure (clear error to model)")
+	}
+	if !res.IsError {
+		t.Errorf("expected IsError=true; got success: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "unreachable") {
+		t.Errorf("expected 'unreachable' in error message; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "jobs") {
+		t.Errorf("expected server name 'jobs' in error; got %q", res.Text)
+	}
+}
+
+// TestLazyResolver_OperatorAllowedToolsFilter verifies that the per-
+// server allowed_tools yaml setting is respected on the lazy path
+// just as it would be at boot. Without this, an operator who
+// excluded "expensive_tool" from a server's discovered set would
+// suddenly see it become callable after a boot-skip recovery.
+func TestLazyResolver_OperatorAllowedToolsFilter(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "safe_tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "expensive_tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{
+		"jobs": {AllowedTools: []string{"safe_tool"}},
+	}, nil, 0)
+
+	// safe_tool resolves
+	_, handled := r.Resolve(context.Background(), "mcp__jobs__safe_tool", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("safe_tool: expected handled=true")
+	}
+	// expensive_tool is filtered out — server resolved but does not
+	// expose this tool name (per the operator's filter).
+	res, handled := r.Resolve(context.Background(), "mcp__jobs__expensive_tool", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("expensive_tool: expected handled=true (definitive 'not exposed' error)")
+	}
+	if !res.IsError {
+		t.Fatalf("expensive_tool: expected IsError=true; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "does not expose") {
+		t.Errorf("expected 'does not expose' message; got %q", res.Text)
+	}
+}
+
+// TestLazyResolver_OnResolveCallback verifies the operator-visible
+// "lazy-registered N tools" callback fires exactly once per server,
+// not on every call to a cache-hit tool.
+func TestLazyResolver_OnResolveCallback(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "alpha", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "beta", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	var (
+		mu        sync.Mutex
+		callbacks []struct {
+			server string
+			count  int
+		}
+	)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, func(server string, count int) {
+		mu.Lock()
+		defer mu.Unlock()
+		callbacks = append(callbacks, struct {
+			server string
+			count  int
+		}{server, count})
+	}, 0)
+
+	// Drive 3 calls — the callback should fire ONCE for the first one only.
+	_, _ = r.Resolve(context.Background(), "mcp__jobs__alpha", json.RawMessage(`{}`))
+	_, _ = r.Resolve(context.Background(), "mcp__jobs__beta", json.RawMessage(`{}`))
+	_, _ = r.Resolve(context.Background(), "mcp__jobs__alpha", json.RawMessage(`{}`))
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(callbacks) != 1 {
+		t.Fatalf("callback fired %d times, want 1: %+v", len(callbacks), callbacks)
+	}
+	if callbacks[0].server != "jobs" || callbacks[0].count != 2 {
+		t.Errorf("callback args = (%q, %d), want (jobs, 2)", callbacks[0].server, callbacks[0].count)
+	}
+}
+
+// TestLazyResolver_ConcurrentCallsCoalesceHandshake verifies that 50
+// goroutines hitting the same skipped server simultaneously result in
+// a single underlying build call. The pool's existing entry/ready
+// coordination handles this; the test is a regression guard against
+// future changes to LazyResolver that might bypass that coordination.
+func TestLazyResolver_ConcurrentCallsCoalesceHandshake(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+
+	const N = 50
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			_, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
+			if !handled {
+				t.Errorf("expected handled=true under concurrency")
+			}
+		}()
+	}
+	wg.Wait()
+	if got := plan.calls("jobs"); got != 1 {
+		t.Errorf("build called %d times under %d-way concurrent first-touch, want 1", got, N)
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -41,16 +41,39 @@ func Spec(t Tool) providers.ToolSpec {
 // A new Dispatcher is built per run with the run's allowed-tools list so
 // off-policy calls fail fast.
 type Dispatcher struct {
-	tools map[string]Tool
+	tools    map[string]Tool
+	fallback FallbackFunc
 }
 
-// NewDispatcher builds a dispatcher from the given tools.
+// FallbackFunc is consulted by Dispatcher.Execute when a tool name isn't
+// in the static map. It returns (Result, true) when it has a definitive
+// outcome for the call (success OR a typed error to surface to the model);
+// (zero, false) means "I don't know about this name, fall through to
+// the dispatcher's default 'tool not found' error".
+//
+// Used to implement lazy MCP server registration: a configured server
+// that failed initial handshake registers no tools at boot, but a
+// fallback can detect mcp__<server>__<tool> names, retry the handshake,
+// register the tools, and dispatch. Memoising successful resolutions
+// in the fallback avoids re-handshaking on every subsequent call.
+type FallbackFunc func(ctx context.Context, name string, input json.RawMessage) (Result, bool)
+
+// NewDispatcher builds a dispatcher from the given tools. No fallback —
+// unknown names always return "tool not found".
 func NewDispatcher(tools []Tool) *Dispatcher {
 	m := make(map[string]Tool, len(tools))
 	for _, t := range tools {
 		m[t.Name()] = t
 	}
 	return &Dispatcher{tools: m}
+}
+
+// NewDispatcherWithFallback is NewDispatcher plus a FallbackFunc consulted
+// for unknown names before returning "tool not found".
+func NewDispatcherWithFallback(tools []Tool, fallback FallbackFunc) *Dispatcher {
+	d := NewDispatcher(tools)
+	d.fallback = fallback
+	return d
 }
 
 // Specs returns the providers.ToolSpec slice for all registered tools, in the
@@ -214,16 +237,22 @@ func MemoryPolicy(ctx context.Context) MemoryPolicyValue {
 	return v
 }
 
-// Execute looks up the named tool and runs it. Unknown tool names return an
-// error result (the model can self-correct) rather than a hard error.
+// Execute looks up the named tool and runs it. Unknown tool names consult
+// the optional Fallback before returning the standard "tool not found"
+// error result (the model can self-correct on the error result; we never
+// return a hard Go error here).
 func (d *Dispatcher) Execute(ctx context.Context, name string, input json.RawMessage) Result {
-	t, ok := d.tools[name]
-	if !ok {
-		return Result{Text: fmt.Sprintf("tool not found: %s", name), IsError: true}
+	if t, ok := d.tools[name]; ok {
+		res, err := t.Execute(ctx, input)
+		if err != nil {
+			return Result{Text: err.Error(), IsError: true}
+		}
+		return res
 	}
-	res, err := t.Execute(ctx, input)
-	if err != nil {
-		return Result{Text: err.Error(), IsError: true}
+	if d.fallback != nil {
+		if res, handled := d.fallback(ctx, name, input); handled {
+			return res
+		}
 	}
-	return res
+	return Result{Text: fmt.Sprintf("tool not found: %s", name), IsError: true}
 }

--- a/internal/tools/tool_test.go
+++ b/internal/tools/tool_test.go
@@ -1,0 +1,102 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// stubTool is a tools.Tool that captures the input and returns a canned text.
+type stubTool struct {
+	name string
+}
+
+func (s *stubTool) Name() string                   { return s.name }
+func (s *stubTool) Description() string            { return "" }
+func (s *stubTool) InputSchema() json.RawMessage   { return json.RawMessage(`{"type":"object"}`) }
+func (s *stubTool) Execute(_ context.Context, in json.RawMessage) (Result, error) {
+	return Result{Text: "ran:" + s.name + ":" + string(in)}, nil
+}
+
+func TestDispatcher_NoFallback_HitReturnsToolResult(t *testing.T) {
+	d := NewDispatcher([]Tool{&stubTool{name: "Read"}})
+	r := d.Execute(context.Background(), "Read", json.RawMessage(`{}`))
+	if r.IsError {
+		t.Fatalf("hit returned IsError=true: %q", r.Text)
+	}
+	if !strings.HasPrefix(r.Text, "ran:Read:") {
+		t.Errorf("hit text = %q, want prefix ran:Read:", r.Text)
+	}
+}
+
+func TestDispatcher_NoFallback_MissReturnsToolNotFound(t *testing.T) {
+	d := NewDispatcher([]Tool{&stubTool{name: "Read"}})
+	r := d.Execute(context.Background(), "Write", json.RawMessage(`{}`))
+	if !r.IsError {
+		t.Fatalf("miss returned IsError=false: %q", r.Text)
+	}
+	if !strings.Contains(r.Text, "tool not found") {
+		t.Errorf("miss text = %q, want substring 'tool not found'", r.Text)
+	}
+}
+
+// TestDispatcher_FallbackHandlesMiss verifies the fallback is consulted on
+// a static-map miss and that its returned Result is propagated unchanged.
+// This is the core contract LazyResolver depends on.
+func TestDispatcher_FallbackHandlesMiss(t *testing.T) {
+	called := 0
+	fb := func(_ context.Context, name string, _ json.RawMessage) (Result, bool) {
+		called++
+		return Result{Text: "fallback:" + name, IsError: false}, true
+	}
+	d := NewDispatcherWithFallback([]Tool{&stubTool{name: "Read"}}, fb)
+	r := d.Execute(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
+	if r.IsError {
+		t.Fatalf("fallback returned IsError=true: %q", r.Text)
+	}
+	if r.Text != "fallback:mcp__jobs__getAgentContext" {
+		t.Errorf("fallback text = %q, want fallback:mcp__jobs__getAgentContext", r.Text)
+	}
+	if called != 1 {
+		t.Errorf("fallback called %d times, want 1", called)
+	}
+}
+
+// TestDispatcher_FallbackNotCalledOnHit guards against the fallback being
+// invoked for tools that ARE in the static map. The static map is the fast
+// path; touching the fallback would re-handshake the MCP pool unnecessarily
+// for every native tool call.
+func TestDispatcher_FallbackNotCalledOnHit(t *testing.T) {
+	called := 0
+	fb := func(_ context.Context, _ string, _ json.RawMessage) (Result, bool) {
+		called++
+		return Result{}, true
+	}
+	d := NewDispatcherWithFallback([]Tool{&stubTool{name: "Read"}}, fb)
+	r := d.Execute(context.Background(), "Read", json.RawMessage(`{}`))
+	if r.IsError {
+		t.Fatalf("hit returned IsError=true: %q", r.Text)
+	}
+	if called != 0 {
+		t.Errorf("fallback called %d times on a hit, want 0", called)
+	}
+}
+
+// TestDispatcher_FallbackHandledFalseFallsThrough verifies the (handled=false)
+// signal makes Execute return the standard "tool not found" error. The
+// LazyResolver uses this to opt out of names it can't help with (non-MCP
+// names, unconfigured server segments).
+func TestDispatcher_FallbackHandledFalseFallsThrough(t *testing.T) {
+	fb := func(_ context.Context, _ string, _ json.RawMessage) (Result, bool) {
+		return Result{Text: "should be ignored"}, false
+	}
+	d := NewDispatcherWithFallback([]Tool{&stubTool{name: "Read"}}, fb)
+	r := d.Execute(context.Background(), "Unknown", json.RawMessage(`{}`))
+	if !r.IsError {
+		t.Fatalf("expected IsError=true; got %q", r.Text)
+	}
+	if !strings.Contains(r.Text, "tool not found: Unknown") {
+		t.Errorf("expected 'tool not found: Unknown' substring; got %q", r.Text)
+	}
+}


### PR DESCRIPTION
## Summary

When an MCP server fails the boot-time handshake, loomcycle currently logs `mcp[X]: skipped` and proceeds without registering any of its tools — for the lifetime of the loomcycle process. Agents calling those tools get `tool not found`, even after the peer recovers. In a server environment where MCP peers restart independently of loomcycle, this is recurring operational pain.

This PR adds a lazy-retry path: when an agent calls `mcp__<server>__<tool>` for a server that was skipped at boot, loomcycle attempts one fresh handshake on the agent's call path. On success, the server's tools are memoised and dispatched. Subsequent calls hit the cache without re-handshaking.

## Why

Observed 2026-05-10 on the dev mac:

1. `loomcycle.sh` started; jobs-search-web's `better-sqlite3` happened to be broken (Node ABI mismatch).
2. All 6 boot-time handshake attempts to `jobs` MCP server returned 500. Server marked `skipped`.
3. Operator ran `npm rebuild better-sqlite3`, restarted Next.js. Peer healthy now.
4. Agent calls to `mcp__jobs__getAgentContext` continued to fail with `tool not found` — loomcycle had no record of those tools, no retry path on the call path.
5. Required restarting loomcycle to recover.

This is the kind of bootstrapping issue we'll keep hitting in production. Every peer restart shouldn't require a loomcycle restart.

## What

### New surface

- **`tools.FallbackFunc`**: `func(ctx, name, input) (Result, bool)` — consulted by `Dispatcher.Execute` on a static-map miss. `(handled=true)` propagates the result; `(handled=false)` falls through to the standard `tool not found` error.
- **`tools.NewDispatcherWithFallback(...)`**: same as `NewDispatcher` plus the fallback. Existing `NewDispatcher` behaviour is unchanged (nil fallback = no change).
- **`mcp.LazyResolver`** (`internal/tools/mcp/lazy.go`): implements `FallbackFunc`. Holds the pool + per-server config. On first call for a `mcp__<server>__<tool>` name where `<server>` is operator-configured, runs `pool.Get(server)`, applies `ApplyAllowedToolsFilter`, caches the resolved tool map, dispatches. On failure: typed error with the server name + last-known reason.
- **`mcp.ApplyAllowedToolsFilter`** (`internal/tools/mcp/filter.go`): moved from `cmd/loomcycle/main.go` so the boot path and the lazy path share one implementation.
- **`Server.SetMCPFallback(fn FallbackFunc)`**: optional setter. main.go wires the LazyResolver here after the MCP pool is built.

### Wire-up

- `cmd/loomcycle/main.go`: builds `LazyResolver` from `cfg.MCPServers` after the boot init loop. The boot-time `mcp[%s]: skipped` logging is unchanged. Logs `mcp[%s]: lazy-registered %d tool(s) on first agent call` when recovery happens.
- `internal/api/http/server.go`: 4 `tools.NewDispatcher` call sites → `s.newDispatcher(allowedTools)` (handleRuns, handleMessages, handleGetAgent's resume path, runSubAgent). Sub-agent dispatchers get the fallback too.

### What's intentionally NOT in scope

- **Mutating `s.tools`** on lazy success. Lazy-resolved tools live only in the resolver's memo. Tools that need to be ADVERTISED in the model's spec list (i.e. discoverable by a fresh model with no prompt-side knowledge) would still need boot-time registration. v1.x concern.
- **Periodic background re-attempt** of skipped servers. Recovery happens only when an agent needs a tool. Avoids background traffic to genuinely-down peers; can stack a probe loop on top later.

## Test plan

- [x] `go test ./...` — all 22 packages green
- [x] `go test -race ./internal/tools/ ./internal/tools/mcp/` clean
- [x] Unit tests cover: dispatcher hit/miss/fallback paths; non-mcp names fall through; unconfigured server falls through; first-call handshake + dispatch; second-call cache hit (no rebuild); handshake-fail surfaces clear error; operator `allowed_tools` filter respected; `onResolve` callback fires once per server; 50-way concurrent first-touch coalesces to one build.
- [ ] Manual: rebuild on the dev mac, deliberately break jobs-search-web at loomcycle startup, then fix the peer, then trigger an ats-filter run. Should see `mcp[jobs]: lazy-registered N tool(s) on first agent call` and the agent's call should succeed.

## Notes

- No wire-protocol change. Pure runtime improvement.
- Independent of PR #47 (streaming timeout). Either can land first.
- Documents inline in `lazy.go` what happens on a tool name that the (now-reachable) server doesn't expose: definitive `(handled=true)` error to the model citing the operator's `allowed_tools` filter as the likely cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)