### PR TITLE
feat(config): discover agents from a directory of MD files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,44 @@ LOOMCYCLE_DATA_DIR=./data
 # not point this at a directory writable by untrusted users.
 # LOOMCYCLE_SKILLS_ROOT=/srv/loomcycle/skills
 
+# ─── Agent directory discovery (v0.8.x+) ─────────────────────────────
+#
+# Directory of flat `<name>.md` files. When set, loomcycle parses each
+# file's YAML frontmatter as the base AgentDef and the body (after the
+# closing `---`) as the system prompt. The yaml `agents:` map remains
+# OPTIONAL and acts as an override layer — yaml entries with the same
+# name override per-field. Operators get a single source of truth in
+# the MD with targeted per-environment tweaks in yaml when needed.
+#
+# Why: synchronising the yaml `agents:` block with the MDs referenced
+# from `system_prompt_file` is recurring operational pain (every
+# dev↔main branch divergence breaks loomcycle on the deploy box).
+#
+# Frontmatter contract — these top-level keys are read by loomcycle
+# (Claude Code ignores unknown keys, so the same MD drives both):
+#   name                  # string; must equal filename sans .md
+#   description           # string; informational
+#   tools                 # string "A, B, C" OR list [A, B, C]
+#   allowed_tools         # list — wins when both `tools` and this set
+#   provider              # string; e.g. anthropic / openai / deepseek
+#   model                 # string; alias or full model ID
+#   tier                  # one of low / middle / high
+#   models                # map<tier-name, [{provider, model}, ...]>
+#   effort                # one of low / medium / high
+#   max_tokens            # int; per-iteration output cap
+#   skills                # list of skill names (LOOMCYCLE_SKILLS_ROOT)
+#   memory_scopes         # list — subset of {agent, user}
+#   memory_quota_bytes    # int; per-agent override
+#   providers             # list — per-agent ProviderPriority override
+#   system_prompt_file    # string; alternative to body
+#
+# Validation rules (Pin XOR Tier, Effort domain, MemoryScopes domain,
+# etc.) run unchanged on the merged map. A typo'd key is silently
+# dropped to zero today — keep that in mind when an agent doesn't
+# behave as expected.
+#
+# LOOMCYCLE_AGENTS_ROOT=/srv/loomcycle/agents
+
 # ─── Memory tool (v0.8.0+) ───────────────────────────────────────────
 #
 # The Memory tool exposes persistent agent-scoped key/value storage to

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -156,6 +156,14 @@ func main() {
 	if cfg.Env.SkillsRoot != "" {
 		log.Printf("skills: loaded %d from %s", len(skillSet.Names()), cfg.Env.SkillsRoot)
 	}
+	if cfg.Env.AgentsRoot != "" {
+		// Agents-from-MD discovery happened inside config.Load (must run
+		// before resolveSystemPromptFiles so the merged map flows through
+		// the existing pipeline). Log the count post-merge so operators
+		// see the final cfg.Agents size, which may include yaml-only
+		// entries on top of the discovered ones.
+		log.Printf("agents: discovered from %s — total in cfg.Agents (after yaml merge): %d", cfg.Env.AgentsRoot, len(cfg.Agents))
+	}
 
 	allTools := []tools.Tool{
 		&builtin.Read{Root: cfg.Env.ReadRoot},

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -1,0 +1,328 @@
+// Package agents loads `<name>.md` files from a directory into a
+// name→Agent registry that the config layer merges into the yaml
+// `agents:` map at load time.
+//
+// Wire model:
+//
+//  1. Operator points LOOMCYCLE_AGENTS_ROOT at a directory of flat
+//     `<name>.md` files. Each file's YAML frontmatter is the agent's
+//     base config; the body (after the closing `---`) is the system
+//     prompt.
+//  2. The yaml `agents:` map remains an OPTIONAL override layer. When
+//     a yaml entry exists with the same name, its non-zero fields
+//     replace the discovered ones (per-field shallow merge).
+//  3. The merged AgentDef goes through the existing
+//     resolveSystemPromptFiles → resolveSkills → validate pipeline.
+//     No special-case handling at the runtime layer.
+//
+// File format mirrors Claude Code's agent files so a single MD can
+// drive both Claude Code and loomcycle. Standard Claude Code keys
+// (name / description / tools / model) are honoured. Loomcycle-
+// specific keys (tier / models / effort / max_tokens / skills /
+// memory_scopes / memory_quota_bytes / providers / allowed_tools /
+// system_prompt_file / provider) sit alongside them at the top level.
+// Claude Code ignores keys it doesn't know, so MDs stay forward-
+// compatible across both consumers.
+//
+// Tool-list shape: Claude Code emits `tools: A, B, C` (comma-string).
+// Loomcycle's yaml prefers `allowed_tools: [A, B, C]` (list). Both
+// are accepted on read; if both are present in one file, the list
+// form wins (loomcycle is the consumer that cares about precision).
+//
+// SECURITY: this package only parses + exposes metadata. Validation
+// (Pin XOR Tier, Effort domain, MemoryScopes domain, etc.) and
+// skill-subset enforcement (skill.allowed-tools ⊆ agent.allowed_tools)
+// happen at the config layer post-merge, against the existing rules.
+package agents
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Agent is one parsed `<name>.md`.
+//
+// Field set is structurally a superset of config.AgentDef: every
+// AgentDef field has a counterpart here, plus a Description field
+// (Claude Code metadata; loomcycle currently ignores it at runtime
+// but keeps it for a future agents-listing surface). The loader
+// returns these instead of config.AgentDef directly so the
+// dependency arrow stays config → agents (config converts on merge).
+type Agent struct {
+	Name             string
+	Description      string
+	Provider         string
+	Model            string
+	Tier             string
+	Effort           string
+	MaxTokens        int
+	AllowedTools     []string
+	Skills           []string
+	SystemPrompt     string
+	SystemPromptFile string
+	Providers        []string
+	Models           map[string][]TierCandidate
+	MemoryScopes     []string
+	MemoryQuotaBytes int
+	// Path is the absolute path of the source MD, kept for diagnostic
+	// logging (skills/loader.go follows the same convention).
+	Path string
+}
+
+// TierCandidate mirrors config.TierCandidate's shape locally so this
+// package doesn't import config (which would create a cycle:
+// config → agents → config). The merger in config converts these to
+// config.TierCandidate when populating AgentDef.Models.
+type TierCandidate struct {
+	Provider string `yaml:"provider"`
+	Model    string `yaml:"model"`
+}
+
+// Set is a name→Agent registry.
+type Set struct {
+	agents map[string]*Agent
+}
+
+// Get returns the named agent, or (nil, false) if absent. Safe on a
+// nil receiver so callers can do `set.Get(name)` without checking
+// AgentsRoot first.
+func (s *Set) Get(name string) (*Agent, bool) {
+	if s == nil {
+		return nil, false
+	}
+	a, ok := s.agents[name]
+	return a, ok
+}
+
+// Names returns all loaded agent names sorted lexicographically.
+// Used by the diagnostic startup log.
+func (s *Set) Names() []string {
+	if s == nil {
+		return nil
+	}
+	out := make([]string, 0, len(s.agents))
+	for n := range s.agents {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// LoadSet walks root, parses every `<name>.md`, and returns the
+// populated registry. Empty root returns a non-nil empty Set so
+// callers can always Get; a missing root directory is an error
+// (almost certainly an operator misconfiguration of LOOMCYCLE_AGENTS_ROOT).
+//
+// Subdirectories under root are skipped silently — they may be
+// auxiliary content (per-agent fixtures, prompt fragments operators
+// stage alongside the MDs). Files not ending in `.md` are also
+// skipped silently for the same reason.
+func LoadSet(root string) (*Set, error) {
+	set := &Set{agents: map[string]*Agent{}}
+	if root == "" {
+		return set, nil
+	}
+	st, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("agents root %s: %w", root, err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("agents root %s: not a directory", root)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read agents root %s: %w", root, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		fileName := e.Name()
+		if !strings.HasSuffix(fileName, ".md") {
+			continue
+		}
+		name := strings.TrimSuffix(fileName, ".md")
+		// Reject names that could escape the root if a future caller
+		// constructs a path from them. Belt-and-braces — ReadDir doesn't
+		// return entries with "/" in the name, but nothing stops a
+		// creative filename, so we sanity-check.
+		if strings.ContainsAny(name, "/\\") || name == "" || name == "." || name == ".." {
+			return nil, fmt.Errorf("invalid agent file name %q under %s", fileName, root)
+		}
+		path := filepath.Join(root, fileName)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		a, err := parseAgent(raw)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		a.Path = path
+		// The filename (sans .md) is the canonical address. If the
+		// frontmatter declares a different name, that's drift the
+		// operator should notice and fix; refusing to load is loud
+		// and unambiguous (mirrors the skills loader's check).
+		if a.Name != "" && a.Name != name {
+			return nil, fmt.Errorf("agent %s: frontmatter name %q != filename %q", path, a.Name, name)
+		}
+		a.Name = name
+		set.agents[name] = a
+	}
+	return set, nil
+}
+
+// frontmatter is the strict-ish set of YAML keys we read from an MD.
+//
+// Tools field accepts a string OR a list, modelled as `any` and
+// post-processed in parseAgent. Loomcycle's `allowed_tools` (yaml
+// list) takes precedence over `tools` (Claude Code's comma-string)
+// when both are set; that mirrors the design call we made: yaml
+// shape is the precise one, comma-string is the legacy/Claude Code
+// shape we tolerate so MDs stay portable.
+type frontmatter struct {
+	Name             string                     `yaml:"name"`
+	Description      string                     `yaml:"description"`
+	Tools            any                        `yaml:"tools"`         // Claude Code shape — string OR []string
+	AllowedTools     []string                   `yaml:"allowed_tools"` // loomcycle's preferred shape
+	Provider         string                     `yaml:"provider"`
+	Model            string                     `yaml:"model"`
+	Tier             string                     `yaml:"tier"`
+	Effort           string                     `yaml:"effort"`
+	MaxTokens        int                        `yaml:"max_tokens"`
+	Skills           []string                   `yaml:"skills"`
+	Providers        []string                   `yaml:"providers"`
+	Models           map[string][]TierCandidate `yaml:"models"`
+	MemoryScopes     []string                   `yaml:"memory_scopes"`
+	MemoryQuotaBytes int                        `yaml:"memory_quota_bytes"`
+	SystemPromptFile string                     `yaml:"system_prompt_file"`
+	// SystemPrompt as an inline frontmatter field is intentionally
+	// NOT supported. The body of the MD is the prompt; if you want a
+	// pointer to a different file, use system_prompt_file.
+}
+
+// parseAgent splits raw bytes into frontmatter + body. The frontmatter
+// is delimited by leading "---\n" and a closing "---" line; everything
+// after the closing line is the body and becomes Agent.SystemPrompt.
+//
+// An MD without a leading "---\n" is treated as body-only: name will
+// fall back to the filename at the LoadSet layer, and AllowedTools /
+// model / etc. all stay zero. This tolerates ad-hoc MD files that
+// haven't been written with frontmatter yet.
+func parseAgent(raw []byte) (*Agent, error) {
+	a := &Agent{}
+	text := string(raw)
+	// Normalise CRLF to LF for the line-based delimiter scan.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+
+	if !strings.HasPrefix(text, "---\n") {
+		a.SystemPrompt = text
+		return a, nil
+	}
+	rest := text[len("---\n"):]
+	// Closing delimiter is a line that is exactly "---". We accept
+	// either "\n---\n..." or a trailing "\n---" with no body.
+	endIdx := strings.Index(rest, "\n---\n")
+	bodyOffset := -1
+	if endIdx >= 0 {
+		bodyOffset = endIdx + len("\n---\n")
+	} else if strings.HasSuffix(rest, "\n---") {
+		endIdx = len(rest) - len("\n---")
+		bodyOffset = len(rest)
+	} else {
+		return nil, fmt.Errorf("frontmatter has no closing ---")
+	}
+	fmYAML := rest[:endIdx]
+	body := ""
+	if bodyOffset < len(rest) {
+		body = rest[bodyOffset:]
+	}
+	var fm frontmatter
+	if err := yaml.Unmarshal([]byte(fmYAML), &fm); err != nil {
+		return nil, fmt.Errorf("parse frontmatter: %w", err)
+	}
+
+	a.Name = fm.Name
+	a.Description = fm.Description
+	a.Provider = fm.Provider
+	a.Model = fm.Model
+	a.Tier = fm.Tier
+	a.Effort = fm.Effort
+	a.MaxTokens = fm.MaxTokens
+	a.Skills = fm.Skills
+	a.Providers = fm.Providers
+	a.Models = fm.Models
+	a.MemoryScopes = fm.MemoryScopes
+	a.MemoryQuotaBytes = fm.MemoryQuotaBytes
+	a.SystemPromptFile = fm.SystemPromptFile
+	a.SystemPrompt = body
+
+	// Tool-list precedence: yaml list (allowed_tools) wins when set;
+	// otherwise fall back to the Claude Code comma-string (tools).
+	// Both empty → AllowedTools stays nil (default-deny — matches the
+	// existing semantics that an agent without allowed_tools sees no
+	// tools).
+	if len(fm.AllowedTools) > 0 {
+		a.AllowedTools = fm.AllowedTools
+	} else if fm.Tools != nil {
+		toolsList, err := coerceToolsField(fm.Tools)
+		if err != nil {
+			return nil, fmt.Errorf("tools: %w", err)
+		}
+		a.AllowedTools = toolsList
+	}
+
+	return a, nil
+}
+
+// coerceToolsField accepts Claude Code's comma-string OR an explicit
+// YAML list and normalises to []string. Returns an error for unsupported
+// shapes (numbers, maps, etc.) so a typo'd value gets caught at config-
+// load rather than silently dropping to nil.
+func coerceToolsField(v any) ([]string, error) {
+	switch t := v.(type) {
+	case string:
+		return ParseToolList(t), nil
+	case []any:
+		out := make([]string, 0, len(t))
+		for i, el := range t {
+			s, ok := el.(string)
+			if !ok {
+				return nil, fmt.Errorf("element %d is %T, want string", i, el)
+			}
+			s = strings.TrimSpace(s)
+			if s != "" {
+				out = append(out, s)
+			}
+		}
+		return out, nil
+	case nil:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("expected string or list, got %T", v)
+	}
+}
+
+// ParseToolList splits a comma-separated tool string ("A, B, C") into
+// a trimmed []string. Empty input → empty slice (NOT nil; that
+// distinction matters in the merge layer where a non-nil empty list
+// signals "explicit empty, override discovered" vs nil "absent").
+//
+// Exported because the same comma-vs-list duality appears in MCP
+// server allowed_tools fields and would benefit from one canonical
+// implementation; future callers can reuse this without copy-pasting.
+func ParseToolList(s string) []string {
+	out := []string{}
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}

--- a/internal/agents/loader_test.go
+++ b/internal/agents/loader_test.go
@@ -361,3 +361,25 @@ body
 		t.Errorf("error %q should mention 'tools'", err.Error())
 	}
 }
+
+// TestParseAgent_ToolsRejectsMapElement: a list containing a YAML map
+// (a realistic typo when an operator confuses `models:` block syntax
+// with `tools:`) must error rather than silently dropping the bad
+// element. The rejection happens in the []any branch of coerceToolsField
+// when the element type assertion to string fails.
+func TestParseAgent_ToolsRejectsMapElement(t *testing.T) {
+	_, err := parseAgent([]byte(`---
+name: bad-mixed
+tools:
+  - { provider: foo, model: bar }
+  - "Read"
+---
+body
+`))
+	if err == nil {
+		t.Fatal("expected error for map element in tools list, got nil")
+	}
+	if !strings.Contains(err.Error(), "tools") {
+		t.Errorf("error %q should mention 'tools'", err.Error())
+	}
+}

--- a/internal/agents/loader_test.go
+++ b/internal/agents/loader_test.go
@@ -1,0 +1,363 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeFile creates a file under dir with the given name + content. Helper for
+// the table-driven tests so the surrounding signal-to-noise stays high.
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestLoadSet_HappyPath: two MDs with rich frontmatter resolve cleanly into
+// a populated Set with the expected fields and body. Pins the canonical
+// frontmatter contract: comma-string `tools` parses, `model` survives,
+// `description` stored, body becomes SystemPrompt, name from filename.
+func TestLoadSet_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "ats-filter.md", `---
+name: ats-filter
+description: Relevance filter
+tools: Read, mcp__jobs__getAgentContext, Skill
+model: haiku
+tier: low
+max_tokens: 24576
+skills: [position-relevance-filtering]
+memory_scopes: [agent]
+---
+You are an ATS-filter agent.
+`)
+	writeFile(t, dir, "cv-adapter.md", `---
+name: cv-adapter
+description: CV adapter
+allowed_tools: [Read, mcp__jobs__patchApplication]
+provider: anthropic
+model: claude-sonnet-4-6
+---
+Body for cv-adapter.
+`)
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	names := set.Names()
+	want := []string{"ats-filter", "cv-adapter"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("Names() = %v, want %v", names, want)
+	}
+
+	a, ok := set.Get("ats-filter")
+	if !ok {
+		t.Fatal("ats-filter not found")
+	}
+	if a.Description != "Relevance filter" {
+		t.Errorf("Description = %q, want %q", a.Description, "Relevance filter")
+	}
+	if a.Model != "haiku" {
+		t.Errorf("Model = %q, want haiku", a.Model)
+	}
+	if a.Tier != "low" {
+		t.Errorf("Tier = %q, want low", a.Tier)
+	}
+	if a.MaxTokens != 24576 {
+		t.Errorf("MaxTokens = %d, want 24576", a.MaxTokens)
+	}
+	wantTools := []string{"Read", "mcp__jobs__getAgentContext", "Skill"}
+	if !reflect.DeepEqual(a.AllowedTools, wantTools) {
+		t.Errorf("AllowedTools = %v, want %v", a.AllowedTools, wantTools)
+	}
+	if !reflect.DeepEqual(a.Skills, []string{"position-relevance-filtering"}) {
+		t.Errorf("Skills = %v, want [position-relevance-filtering]", a.Skills)
+	}
+	if !reflect.DeepEqual(a.MemoryScopes, []string{"agent"}) {
+		t.Errorf("MemoryScopes = %v, want [agent]", a.MemoryScopes)
+	}
+	if a.SystemPrompt != "You are an ATS-filter agent.\n" {
+		t.Errorf("SystemPrompt = %q, want body", a.SystemPrompt)
+	}
+
+	b, ok := set.Get("cv-adapter")
+	if !ok {
+		t.Fatal("cv-adapter not found")
+	}
+	if b.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want anthropic", b.Provider)
+	}
+	if b.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model = %q, want claude-sonnet-4-6", b.Model)
+	}
+	wantBT := []string{"Read", "mcp__jobs__patchApplication"}
+	if !reflect.DeepEqual(b.AllowedTools, wantBT) {
+		t.Errorf("AllowedTools = %v, want %v", b.AllowedTools, wantBT)
+	}
+}
+
+// TestLoadSet_EmptyRoot: an unset/blank root returns a non-nil empty Set so
+// callers can always Get() without nil-checking. Mirrors the skills loader's
+// contract for the AGENTS_ROOT-not-set deployment.
+func TestLoadSet_EmptyRoot(t *testing.T) {
+	set, err := LoadSet("")
+	if err != nil {
+		t.Fatalf("LoadSet(\"\"): %v", err)
+	}
+	if set == nil {
+		t.Fatal("LoadSet(\"\") returned nil Set")
+	}
+	if got := len(set.Names()); got != 0 {
+		t.Errorf("Names() len = %d, want 0", got)
+	}
+	if _, ok := set.Get("anything"); ok {
+		t.Errorf("Get on empty Set returned ok=true")
+	}
+}
+
+// TestLoadSet_NonexistentRoot: a missing directory is an error (almost
+// certainly an operator misconfiguration of LOOMCYCLE_AGENTS_ROOT).
+func TestLoadSet_NonexistentRoot(t *testing.T) {
+	_, err := LoadSet("/nonexistent/path/that/should/never/exist/loomcycle-test")
+	if err == nil {
+		t.Fatal("expected error for nonexistent root, got nil")
+	}
+}
+
+// TestLoadSet_FrontmatterParseError: malformed YAML in the frontmatter
+// surfaces as a wrapped error citing the file path. Operators get a
+// pointer to the broken file rather than a generic parse error.
+func TestLoadSet_FrontmatterParseError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "broken.md", `---
+name: broken
+tools: [unclosed list
+---
+body
+`)
+	_, err := LoadSet(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "broken.md") {
+		t.Errorf("error %q does not cite path 'broken.md'", err.Error())
+	}
+}
+
+// TestLoadSet_NoClosingDelimiter: a frontmatter that opens with --- but
+// never closes is an error, matching skills-loader behaviour.
+func TestLoadSet_NoClosingDelimiter(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "incomplete.md", `---
+name: incomplete
+no closing delim here
+`)
+	_, err := LoadSet(dir)
+	if err == nil {
+		t.Fatal("expected error for missing closing ---, got nil")
+	}
+	if !strings.Contains(err.Error(), "no closing") {
+		t.Errorf("error %q does not mention 'no closing'", err.Error())
+	}
+}
+
+// TestLoadSet_BodyOnly: a file without leading --- is treated as body-only.
+// The agent ends up with name from the filename, all other fields zero,
+// and the entire content as SystemPrompt. Tolerates ad-hoc MDs that
+// haven't been written with frontmatter yet.
+func TestLoadSet_BodyOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "simple.md", "Just a plain prompt body, no frontmatter.\n")
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	a, ok := set.Get("simple")
+	if !ok {
+		t.Fatal("simple not found")
+	}
+	if a.Name != "simple" {
+		t.Errorf("Name = %q, want simple", a.Name)
+	}
+	if a.SystemPrompt != "Just a plain prompt body, no frontmatter.\n" {
+		t.Errorf("SystemPrompt = %q, want full content", a.SystemPrompt)
+	}
+	if len(a.AllowedTools) != 0 || a.Model != "" || a.Tier != "" {
+		t.Errorf("expected zero values for non-name fields, got tools=%v model=%q tier=%q",
+			a.AllowedTools, a.Model, a.Tier)
+	}
+}
+
+// TestParseToolList_CommaString: the standalone helper that splits Claude
+// Code's comma-string tool field. Critical because operators copy MDs
+// straight from .claude/agents/ where this format is the norm.
+func TestParseToolList_CommaString(t *testing.T) {
+	got := ParseToolList("Read, mcp__foo__bar, Skill")
+	want := []string{"Read", "mcp__foo__bar", "Skill"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ParseToolList = %v, want %v", got, want)
+	}
+	// Whitespace-only input → empty slice (not nil — the merge layer
+	// distinguishes those).
+	got = ParseToolList("   ,  ,  ")
+	if len(got) != 0 {
+		t.Errorf("ParseToolList of whitespace-only = %v, want empty", got)
+	}
+	// Empty input → empty slice.
+	got = ParseToolList("")
+	if got == nil {
+		t.Errorf("ParseToolList(\"\") = nil, want empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("ParseToolList(\"\") len = %d, want 0", len(got))
+	}
+}
+
+// TestLoadSet_AllowedToolsWinsOverTools: when an MD has BOTH the loomcycle
+// `allowed_tools:` list AND the Claude Code `tools:` comma-string, the
+// list form wins (loomcycle is the consumer that demands precision).
+// This pins the documented precedence rule.
+func TestLoadSet_AllowedToolsWinsOverTools(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "dual.md", `---
+name: dual
+tools: A, B, C
+allowed_tools: [X, Y]
+---
+body
+`)
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	a, ok := set.Get("dual")
+	if !ok {
+		t.Fatal("dual not found")
+	}
+	want := []string{"X", "Y"}
+	if !reflect.DeepEqual(a.AllowedTools, want) {
+		t.Errorf("AllowedTools = %v, want %v (allowed_tools should win)", a.AllowedTools, want)
+	}
+}
+
+// TestLoadSet_FilenameNameMismatch: a frontmatter `name:` that disagrees
+// with the filename is operator drift and refusal-to-load is the right
+// surface (mirrors skills-loader behaviour). Loud errors here prevent
+// "wait, why doesn't agent X load when its file is right there?"
+// debugging spirals.
+func TestLoadSet_FilenameNameMismatch(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "actual-name.md", `---
+name: different-name
+---
+body
+`)
+	_, err := LoadSet(dir)
+	if err == nil {
+		t.Fatal("expected error for name/filename mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "different-name") || !strings.Contains(err.Error(), "actual-name") {
+		t.Errorf("error %q should cite both names", err.Error())
+	}
+}
+
+// TestLoadSet_SubdirAndNonMDIgnored: subdirectories under root and files
+// without a .md extension are skipped silently. Operators stage auxiliary
+// content (fixtures, fragments, a `.git` directory) alongside the MDs;
+// those should not produce spurious agents or errors.
+func TestLoadSet_SubdirAndNonMDIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "real.md", `---
+name: real
+---
+ok
+`)
+	// A subdirectory with a stray .md inside (we don't recurse).
+	if err := os.Mkdir(filepath.Join(dir, "fixtures"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeFile(t, filepath.Join(dir, "fixtures"), "buried.md", "ignored")
+	// A non-md file at root.
+	writeFile(t, dir, "README.txt", "not an agent")
+	// A dot-file the loader shouldn't try to parse.
+	writeFile(t, dir, ".DS_Store", "macos noise")
+
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	names := set.Names()
+	if !reflect.DeepEqual(names, []string{"real"}) {
+		t.Errorf("Names() = %v, want [real]", names)
+	}
+}
+
+// TestLoadSet_EmptyBody: a file with frontmatter but no body parses
+// cleanly with an empty SystemPrompt. Useful for agents whose prompt
+// is fully bundled from a system_prompt_file or from skills.
+func TestLoadSet_EmptyBody(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "empty.md", `---
+name: empty
+tools: Read
+---`)
+	set, err := LoadSet(dir)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	a, ok := set.Get("empty")
+	if !ok {
+		t.Fatal("empty not found")
+	}
+	if a.SystemPrompt != "" {
+		t.Errorf("SystemPrompt = %q, want empty", a.SystemPrompt)
+	}
+	if !reflect.DeepEqual(a.AllowedTools, []string{"Read"}) {
+		t.Errorf("AllowedTools = %v, want [Read]", a.AllowedTools)
+	}
+}
+
+// TestParseAgent_ToolsAsYAMLList: when the Claude Code `tools:` field is
+// itself a YAML list (some MDs in the wild do this even though the
+// canonical Claude Code shape is a comma-string), it should also be
+// accepted. Same outcome as if `allowed_tools` had been used — but
+// `allowed_tools` still wins if both are present.
+func TestParseAgent_ToolsAsYAMLList(t *testing.T) {
+	a, err := parseAgent([]byte(`---
+name: yaml-list
+tools: [A, B, C]
+---
+body
+`))
+	if err != nil {
+		t.Fatalf("parseAgent: %v", err)
+	}
+	want := []string{"A", "B", "C"}
+	if !reflect.DeepEqual(a.AllowedTools, want) {
+		t.Errorf("AllowedTools = %v, want %v", a.AllowedTools, want)
+	}
+}
+
+// TestParseAgent_ToolsRejectsBadType: a non-string non-list `tools:` value
+// (number, map, etc.) is operator-typo territory — surface a clear error
+// rather than silently dropping to nil.
+func TestParseAgent_ToolsRejectsBadType(t *testing.T) {
+	_, err := parseAgent([]byte(`---
+name: bad
+tools: 42
+---
+body
+`))
+	if err == nil {
+		t.Fatal("expected error for numeric tools, got nil")
+	}
+	if !strings.Contains(err.Error(), "tools") {
+		t.Errorf("error %q should mention 'tools'", err.Error())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -478,23 +478,32 @@ func Load(path string) (*Config, error) {
 		if abs, err := filepath.Abs(filepath.Dir(path)); err == nil {
 			cfg.configDir = abs
 		}
-		// Discover MD-defined agents BEFORE resolveSystemPromptFiles so
-		// the file-resolution pass sees a merged map. We read the env
-		// var inline here because the full Env struct is populated later
-		// in this function — re-shuffling that order would risk subtler
-		// regressions for one early reader. The book-keeping copy onto
-		// cfg.Env.AgentsRoot lands in the env-block below.
-		if root := os.Getenv("LOOMCYCLE_AGENTS_ROOT"); root != "" {
-			if err := discoverAgents(cfg, root); err != nil {
-				return nil, err
-			}
-		}
-		// Resolve any agent's system_prompt_file → system_prompt. Done
-		// here so the rest of the runtime sees a uniform AgentDef
-		// regardless of which form the operator wrote.
-		if err := resolveSystemPromptFiles(cfg, path); err != nil {
+	}
+	// Discover MD-defined agents BEFORE resolveSystemPromptFiles so
+	// the file-resolution pass sees a merged map. We read the env var
+	// inline here because the full Env struct is populated later in
+	// this function — re-shuffling that order would risk subtler
+	// regressions for one early reader. The book-keeping copy onto
+	// cfg.Env.AgentsRoot lands in the env-block below.
+	//
+	// Discovery runs OUTSIDE the `if path != ""` guard so the
+	// MDs-as-sole-source-of-truth deployment works (operator sets
+	// LOOMCYCLE_AGENTS_ROOT and omits the yaml entirely; cfg.Agents
+	// is populated purely from MDs).
+	if root := os.Getenv("LOOMCYCLE_AGENTS_ROOT"); root != "" {
+		if err := discoverAgents(cfg, root); err != nil {
 			return nil, err
 		}
+	}
+	// Resolve any agent's system_prompt_file → system_prompt (for both
+	// yaml-declared and discovered agents that set the field). Also
+	// outside the path-guard for the MDs-only path. With path == "",
+	// configDir is empty → relative paths resolve against cwd; absolute
+	// paths still work; this matches the documented semantic ("relative
+	// paths resolve against the YAML config file's directory" reduces
+	// to "the process's cwd" when there is no YAML).
+	if err := resolveSystemPromptFiles(cfg, path); err != nil {
+		return nil, err
 	}
 
 	cfg.Env = Env{
@@ -868,13 +877,21 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	if override.Model != "" {
 		out.Model = override.Model
 	}
+	// Either prompt-source override clears the OTHER source on the
+	// merged struct. Without this, a discovered MD that sets
+	// system_prompt_file in its frontmatter merging with a yaml
+	// override that sets inline system_prompt (or vice versa) would
+	// produce both fields populated and trip resolveSystemPromptFiles'
+	// mutual-exclusion check downstream — making yaml overrides for
+	// the prompt source unusable. The yaml override is the explicit
+	// "use this prompt source instead" signal, regardless of which
+	// shape it takes.
 	if override.SystemPrompt != "" {
 		out.SystemPrompt = override.SystemPrompt
+		out.SystemPromptFile = ""
 	}
 	if override.SystemPromptFile != "" {
 		out.SystemPromptFile = override.SystemPromptFile
-		// File pointer wins over inline body; otherwise
-		// resolveSystemPromptFiles errors on "both set".
 		out.SystemPrompt = ""
 	}
 	if override.AllowedTools != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/denn-gubsky/loomcycle/internal/agents"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
 )
@@ -336,6 +337,23 @@ type Env struct {
 	// reference them). Sourced from LOOMCYCLE_SKILLS_ROOT.
 	SkillsRoot string
 
+	// AgentsRoot points at a directory of flat `<name>.md` files.
+	// Each file's YAML frontmatter is parsed as an AgentDef base; the
+	// body becomes SystemPrompt. When set, discovered agents seed
+	// cfg.Agents BEFORE the yaml `agents:` block; yaml entries with
+	// matching names override per-field (mergeAgentDef in this file).
+	// Empty AgentsRoot leaves cfg.Agents to the yaml-only path —
+	// today's behaviour.
+	//
+	// Why this exists: synchronising the yaml `agents:` block with
+	// the .claude/agents/<name>.md files referenced from
+	// system_prompt_file is recurring operational pain (every dev↔main
+	// branch divergence breaks loomcycle on the deploy box). The
+	// directory becomes the single source of truth in normal
+	// operation; yaml entries shrink to per-environment overrides.
+	// Sourced from LOOMCYCLE_AGENTS_ROOT.
+	AgentsRoot string
+
 	// HeartbeatSweeperEnabled controls the v0.5.0 stale-run sweeper.
 	// When true (default), a goroutine periodically marks runs whose
 	// heartbeat hasn't advanced in HeartbeatStaleAfter as failed —
@@ -460,6 +478,17 @@ func Load(path string) (*Config, error) {
 		if abs, err := filepath.Abs(filepath.Dir(path)); err == nil {
 			cfg.configDir = abs
 		}
+		// Discover MD-defined agents BEFORE resolveSystemPromptFiles so
+		// the file-resolution pass sees a merged map. We read the env
+		// var inline here because the full Env struct is populated later
+		// in this function — re-shuffling that order would risk subtler
+		// regressions for one early reader. The book-keeping copy onto
+		// cfg.Env.AgentsRoot lands in the env-block below.
+		if root := os.Getenv("LOOMCYCLE_AGENTS_ROOT"); root != "" {
+			if err := discoverAgents(cfg, root); err != nil {
+				return nil, err
+			}
+		}
 		// Resolve any agent's system_prompt_file → system_prompt. Done
 		// here so the rest of the runtime sees a uniform AgentDef
 		// regardless of which form the operator wrote.
@@ -488,6 +517,7 @@ func Load(path string) (*Config, error) {
 		BashEnabled:              os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
 		BashCwd:                  os.Getenv("LOOMCYCLE_BASH_CWD"),
 		SkillsRoot:               os.Getenv("LOOMCYCLE_SKILLS_ROOT"),
+		AgentsRoot:               os.Getenv("LOOMCYCLE_AGENTS_ROOT"),
 		// Sweeper / GC defaults — populated above zero only if the
 		// env var below was set. The fallbacks are applied in
 		// cmd/loomcycle/main.go where the goroutines are started.
@@ -741,6 +771,140 @@ func getenvDefault(name, dflt string) string {
 		return v
 	}
 	return dflt
+}
+
+// discoverAgents walks LOOMCYCLE_AGENTS_ROOT, parses each `<name>.md`
+// frontmatter as an AgentDef base, and merges the result into
+// cfg.Agents — yaml entries override per-field on conflict.
+//
+// Resolution-order constraint: this runs AFTER yaml.Unmarshal but
+// BEFORE resolveSystemPromptFiles. The latter needs to see the merged
+// map so a yaml `system_prompt_file` for a same-named MD agent works
+// (yaml's pointer wins over MD's body — see mergeAgentDef's special
+// case). resolveSkills runs later and also operates on the merged map.
+//
+// Discovered AgentDefs use the same field set as yaml-defined ones; no
+// new validation rules are introduced here. validate() runs unchanged
+// over the merged set, so a merge that produces both Pin and Tier
+// (e.g. MD `model: haiku` + yaml override `tier: low`) gets caught by
+// the existing post-load check.
+func discoverAgents(cfg *Config, root string) error {
+	set, err := agents.LoadSet(root)
+	if err != nil {
+		return fmt.Errorf("agents discovery: %w", err)
+	}
+	if cfg.Agents == nil {
+		cfg.Agents = make(map[string]AgentDef)
+	}
+	for _, name := range set.Names() {
+		discovered, _ := set.Get(name)
+		base := agentFromDiscovered(discovered)
+		// yaml-as-override: if cfg.Agents[name] already exists from
+		// the yaml unmarshal, the yaml fields beat the discovered
+		// ones for any non-zero override slot.
+		yamlEntry, hasYaml := cfg.Agents[name]
+		if hasYaml {
+			cfg.Agents[name] = mergeAgentDef(base, yamlEntry)
+		} else {
+			cfg.Agents[name] = base
+		}
+	}
+	return nil
+}
+
+// agentFromDiscovered converts the agents-package shape (which can't
+// import config without creating a cycle) to AgentDef. Field-for-field
+// passthrough except Models, where the local TierCandidate type is
+// converted to config.TierCandidate.
+func agentFromDiscovered(d *agents.Agent) AgentDef {
+	def := AgentDef{
+		Provider:         d.Provider,
+		Model:            d.Model,
+		SystemPrompt:     d.SystemPrompt,
+		SystemPromptFile: d.SystemPromptFile,
+		AllowedTools:     d.AllowedTools,
+		Skills:           d.Skills,
+		MaxTokens:        d.MaxTokens,
+		Tier:             d.Tier,
+		Effort:           d.Effort,
+		Providers:        d.Providers,
+		MemoryScopes:     d.MemoryScopes,
+		MemoryQuotaBytes: d.MemoryQuotaBytes,
+	}
+	if len(d.Models) > 0 {
+		def.Models = make(map[string][]TierCandidate, len(d.Models))
+		for tier, cands := range d.Models {
+			out := make([]TierCandidate, 0, len(cands))
+			for _, c := range cands {
+				out = append(out, TierCandidate{Provider: c.Provider, Model: c.Model})
+			}
+			def.Models[tier] = out
+		}
+	}
+	return def
+}
+
+// mergeAgentDef returns base with override's non-zero fields applied
+// on top. Per-field shallow merge: each AgentDef field is replaced
+// independently when the override's value is non-zero, otherwise
+// base's value carries through.
+//
+// Slices/maps: yaml.Unmarshal produces nil for absent keys and
+// non-nil-empty for explicit empty entries (`allowed_tools: []`).
+// We treat nil as "absent in yaml — keep discovered" and non-nil as
+// "explicit override — take yaml". This lets ops zero-out a list by
+// writing the empty form in yaml.
+//
+// Special case: SystemPromptFile in the yaml override clears the
+// discovered SystemPrompt. Otherwise resolveSystemPromptFiles would
+// load the file's contents and concatenate alongside the MD body,
+// confusing the prompt with two sources. The yaml SystemPromptFile
+// is the explicit "use this file instead of the MD body" signal.
+func mergeAgentDef(base, override AgentDef) AgentDef {
+	out := base
+	if override.Provider != "" {
+		out.Provider = override.Provider
+	}
+	if override.Model != "" {
+		out.Model = override.Model
+	}
+	if override.SystemPrompt != "" {
+		out.SystemPrompt = override.SystemPrompt
+	}
+	if override.SystemPromptFile != "" {
+		out.SystemPromptFile = override.SystemPromptFile
+		// File pointer wins over inline body; otherwise
+		// resolveSystemPromptFiles errors on "both set".
+		out.SystemPrompt = ""
+	}
+	if override.AllowedTools != nil {
+		out.AllowedTools = override.AllowedTools
+	}
+	if override.Skills != nil {
+		out.Skills = override.Skills
+	}
+	if override.MaxTokens != 0 {
+		out.MaxTokens = override.MaxTokens
+	}
+	if override.Tier != "" {
+		out.Tier = override.Tier
+	}
+	if override.Effort != "" {
+		out.Effort = override.Effort
+	}
+	if override.Providers != nil {
+		out.Providers = override.Providers
+	}
+	if override.Models != nil {
+		out.Models = override.Models
+	}
+	if override.MemoryScopes != nil {
+		out.MemoryScopes = override.MemoryScopes
+	}
+	if override.MemoryQuotaBytes != 0 {
+		out.MemoryQuotaBytes = override.MemoryQuotaBytes
+	}
+	return out
 }
 
 // resolveSystemPromptFiles populates each agent's SystemPrompt from

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -561,3 +561,284 @@ agents:
 		t.Errorf("absolute path not resolved correctly")
 	}
 }
+
+// ─── Agent directory discovery (LOOMCYCLE_AGENTS_ROOT) ─────────────
+//
+// These tests cover the v0.8.x feature: discovering agents from a
+// directory of <name>.md files and merging with the yaml `agents:`
+// map. The yaml-as-override-layer contract is the load-bearing one;
+// every test here pins one slice of it.
+
+// writeAgentMD is a small helper to keep the test bodies focused on
+// the merge/precedence assertions rather than file plumbing.
+func writeAgentMD(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// TestDiscoverAgents_DiscoveryAndYAMLMerge: an MD provides the base
+// AgentDef; a yaml entry with the same name overrides per-field
+// (allowed_tools changes, tier added, model from MD survives because
+// yaml leaves it zero). Headline scenario for the operator pain this
+// feature solves — single source of truth in the MD with targeted
+// per-environment overrides in yaml.
+func TestDiscoverAgents_DiscoveryAndYAMLMerge(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "foo", `---
+name: foo
+description: Foo agent
+tools: Read, mcp__jobs__getAgentContext
+tier: low
+max_tokens: 4096
+---
+prompt body
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  foo:
+    max_tokens: 24576
+    allowed_tools: [Read, Edit]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["foo"]
+	if def.Tier != "low" {
+		t.Errorf("Tier = %q, want low (from MD; yaml didn't override)", def.Tier)
+	}
+	if def.MaxTokens != 24576 {
+		t.Errorf("MaxTokens = %d, want 24576 (yaml override)", def.MaxTokens)
+	}
+	wantTools := []string{"Read", "Edit"}
+	if len(def.AllowedTools) != 2 || def.AllowedTools[0] != "Read" || def.AllowedTools[1] != "Edit" {
+		t.Errorf("AllowedTools = %v, want %v (yaml override)", def.AllowedTools, wantTools)
+	}
+	if def.SystemPrompt != "prompt body\n" {
+		t.Errorf("SystemPrompt = %q, want body from MD", def.SystemPrompt)
+	}
+}
+
+// TestDiscoverAgents_DiscoveryOnly: AGENTS_ROOT set, yaml has no
+// `agents:` block at all. All agents come from the MDs, validation
+// passes. The deployment shape an operator using "MDs as sole source
+// of truth" should be able to ship.
+func TestDiscoverAgents_DiscoveryOnly(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "alpha", `---
+name: alpha
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+---
+alpha body
+`)
+	writeAgentMD(t, agentsDir, "beta", `---
+name: beta
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read, Edit]
+---
+beta body
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := len(cfg.Agents); got != 2 {
+		t.Fatalf("len(cfg.Agents) = %d, want 2", got)
+	}
+	if cfg.Agents["alpha"].SystemPrompt != "alpha body\n" {
+		t.Errorf("alpha SystemPrompt = %q", cfg.Agents["alpha"].SystemPrompt)
+	}
+	if cfg.Agents["beta"].SystemPrompt != "beta body\n" {
+		t.Errorf("beta SystemPrompt = %q", cfg.Agents["beta"].SystemPrompt)
+	}
+}
+
+// TestDiscoverAgents_YAMLOnlyRegression: AGENTS_ROOT unset. The
+// existing yaml-only deployment continues to work unchanged. Critical
+// regression guard — the discovery feature must NEVER change behaviour
+// for operators who haven't opted in.
+func TestDiscoverAgents_YAMLOnlyRegression(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  qa:
+    model: claude-sonnet-4-6
+    system_prompt: "You are QA."
+    allowed_tools: [Read]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly clear in case parent shell exported it.
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", "")
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Agents["qa"].SystemPrompt != "You are QA." {
+		t.Errorf("yaml-only path broke: SystemPrompt = %q", cfg.Agents["qa"].SystemPrompt)
+	}
+}
+
+// TestDiscoverAgents_MergePinAndTierConflict: an MD pins Provider+Model;
+// a yaml override adds Tier without clearing the pin. The merger
+// produces an AgentDef with both Pin and Tier set; validate()'s
+// existing Pin XOR Tier rule catches it. Confirms validation runs
+// uniformly over the merged map (not just over yaml-only fields).
+func TestDiscoverAgents_MergePinAndTierConflict(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "conflict", `---
+name: conflict
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+---
+body
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  conflict:
+    tier: low
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected validation error for Pin+Tier on merged agent, got nil")
+	}
+	if !strings.Contains(err.Error(), "tier") || !strings.Contains(err.Error(), "conflict") {
+		t.Errorf("error %q should cite both 'tier' and the agent name", err.Error())
+	}
+}
+
+// TestDiscoverAgents_YAMLSystemPromptFileWins: when the MD provides a
+// body AND the yaml override sets system_prompt_file, the file wins.
+// The merger clears the discovered SystemPrompt so resolveSystemPromptFiles
+// doesn't trip the "both inline + file set" mutual-exclusion check.
+// Operator semantic: yaml's pointer-to-file is the explicit override.
+func TestDiscoverAgents_YAMLSystemPromptFileWins(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "doc", `---
+name: doc
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+---
+discovered body that should be overridden
+`)
+	if err := os.WriteFile(filepath.Join(tmp, "override.md"), []byte("the override prompt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  doc:
+    system_prompt_file: override.md
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["doc"].SystemPrompt; got != "the override prompt" {
+		t.Errorf("SystemPrompt = %q, want yaml-override-file content", got)
+	}
+}
+
+// TestDiscoverAgents_DiscoveredSkillsBundleCorrectly: an MD names a
+// skill in its frontmatter; SKILLS_ROOT is set and the skill is
+// available; resolveSkills runs over the merged map and bundles the
+// body. Confirms ordering — discovery happens before
+// resolveSystemPromptFiles + resolveSkills, so the discovered prompt
+// + the skill body both feed into the same downstream pipeline.
+func TestDiscoverAgents_DiscoveredSkillsBundleCorrectly(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skillsDir := filepath.Join(tmp, "skills")
+	if err := os.MkdirAll(filepath.Join(skillsDir, "helper"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillsDir, "helper", "SKILL.md"), []byte(`---
+name: helper
+description: a helper
+---
+SKILL HELPER BODY`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "uses-skill", `---
+name: uses-skill
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+skills: [helper]
+---
+agent prompt body`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+	t.Setenv("LOOMCYCLE_SKILLS_ROOT", skillsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	prompt := cfg.Agents["uses-skill"].SystemPrompt
+	if !strings.Contains(prompt, "agent prompt body") {
+		t.Errorf("merged prompt missing agent body: %q", prompt)
+	}
+	if !strings.Contains(prompt, "SKILL HELPER BODY") {
+		t.Errorf("merged prompt missing skill body: %q", prompt)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -842,3 +842,126 @@ defaults: { provider: anthropic, model: claude-sonnet-4-6 }
 		t.Errorf("merged prompt missing skill body: %q", prompt)
 	}
 }
+
+// TestDiscoverAgents_NoYAMLPath: AGENTS_ROOT set, Load called with
+// path="" (env-only mode, no yaml). The discovery + system-prompt-file
+// resolution passes must run regardless of yaml presence — without
+// this the headline "MDs as sole source of truth" deployment shape
+// would silently load zero agents (the original Load wrapped both
+// passes in `if path != ""`). Regression guard for the critical bug
+// the code review caught at PR #49 review time.
+func TestDiscoverAgents_NoYAMLPath(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "solo", `---
+name: solo
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+---
+solo body
+`)
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\"): %v", err)
+	}
+	if got := len(cfg.Agents); got != 1 {
+		t.Fatalf("Agents count = %d, want 1 (env-only deployment should still discover)", got)
+	}
+	if cfg.Agents["solo"].SystemPrompt != "solo body\n" {
+		t.Errorf("SystemPrompt = %q, want body from MD", cfg.Agents["solo"].SystemPrompt)
+	}
+}
+
+// TestDiscoverAgents_EmptyYAMLListClearsDiscovered: the merger's
+// nil-vs-empty-slice contract — yaml `allowed_tools: []` actively
+// zero-outs a discovered list, vs yaml omitting the field entirely
+// (which keeps discovered). Pins gopkg.in/yaml.v3's nil/non-nil-empty
+// distinction so a future yaml lib upgrade that breaks this surfaces
+// as a test failure instead of silently leaving agents with the wrong
+// tool set.
+func TestDiscoverAgents_EmptyYAMLListClearsDiscovered(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "narrow", `---
+name: narrow
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read, Edit, mcp__jobs__getAgentContext]
+---
+body
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  narrow:
+    allowed_tools: []
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Agents["narrow"].AllowedTools
+	if got == nil {
+		t.Errorf("AllowedTools = nil; expected non-nil empty slice (yaml [] should override discovered)")
+	}
+	if len(got) != 0 {
+		t.Errorf("AllowedTools = %v; expected empty slice (yaml [] should zero out discovered list)", got)
+	}
+}
+
+// TestDiscoverAgents_YAMLInlinePromptOverridesMDFile: covers the
+// inverse of TestDiscoverAgents_YAMLSystemPromptFileWins. MD has
+// system_prompt_file in its frontmatter; yaml override sets inline
+// system_prompt. Without the merger clearing the OTHER source on
+// each prompt-source override, both fields end up populated and
+// resolveSystemPromptFiles' mutual-exclusion check fires.
+func TestDiscoverAgents_YAMLInlinePromptOverridesMDFile(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "from-file.md"), []byte("from-file body"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	writeAgentMD(t, agentsDir, "doc", `---
+name: doc
+provider: anthropic
+model: claude-sonnet-4-6
+allowed_tools: [Read]
+system_prompt_file: from-file.md
+---
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  doc:
+    system_prompt: "yaml override prompt"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v (the merger should have cleared SystemPromptFile when yaml set inline SystemPrompt)", err)
+	}
+	if got := cfg.Agents["doc"].SystemPrompt; got != "yaml override prompt" {
+		t.Errorf("SystemPrompt = %q, want yaml override", got)
+	}
+}


### PR DESCRIPTION
## Summary

Eliminate the synchronisation pain between yaml `agents:` entries and Claude Code `.md` files. Loomcycle now scans a directory of `<name>.md` files (`LOOMCYCLE_AGENTS_ROOT`), parses each frontmatter as the base AgentDef, and uses the body as the system prompt. The yaml `agents:` map remains an optional override layer for environment-specific tweaks.

Single source of truth in normal operation; per-deployment overrides when needed.

## Why

Two-source-of-truth has been recurring operational pain:

- 2026-05-09 VM bring-up: 4 agent files existed in dev branch but not main → loomcycle restart loop until the workspace was switched to dev.
- Broader pattern: yaml entries pointing at `system_prompt_file` paths that don't exist, or MDs without matching yaml entries, both fail in different ways.

The frontmatter and yaml are the same shape of information, asked twice. This PR collapses it.

## Design (user-confirmed)

| Question | Answer |
|---|---|
| Yaml `agents:` role | **Override layer.** MDs are the base; yaml entries override per-agent fields when present. All MDs are enabled by default. Mixed-mode and yaml-only deployments stay supported. |
| Frontmatter shape | **Flat top-level keys.** Loomcycle-specific fields (`tier`, `models`, `skills`, `max_tokens`, `memory_scopes`, …) live alongside Claude Code's standard keys (`name`, `description`, `tools`, `model`). Claude Code ignores unknown frontmatter keys, so MDs stay portable across both consumers. |
| Tool list shape | Both `tools: A, B, C` (Claude Code's comma-string) AND `allowed_tools: [A, B, C]` (loomcycle's yaml list) are accepted. When both present, `allowed_tools` wins. |
| Discovery | All `<name>.md` files in the directory are enabled. To disable one, move the file out. |

## What

### New surface

- **`internal/agents/loader.go`** — `LoadSet(root)`, `Set.Get`, `Set.Names`, `ParseToolList(s)`. Mirrors `internal/skills/loader.go` shape: same delimiter rules, same body-only fallback, same name-validation reject set.
- **`Env.AgentsRoot`** in `internal/config/config.go` — sourced from `LOOMCYCLE_AGENTS_ROOT`.
- **`config.discoverAgents(cfg, root)`** — walks the directory, converts each `agents.Agent` to `config.AgentDef`, merges with yaml entries.
- **`config.mergeAgentDef(base, override)`** — per-field shallow merge with yaml-overrides-discovered semantics. `nil` slice = absent (keep discovered); non-nil = explicit override (replace). Special case: yaml `system_prompt_file` clears discovered `system_prompt` (body) so `resolveSystemPromptFiles`' "both set" check doesn't fire.

### Resolution order

```
config.Load(path)
├─ defaults populated
├─ if path != "":
│   ├─ os.ReadFile + expandEnv + yaml.Unmarshal
│   ├─ stash configDir
│   ├─ NEW: read LOOMCYCLE_AGENTS_ROOT inline
│   │   if set: discoverAgents(cfg, root)
│   │     └─ agents.LoadSet(root)
│   │     └─ for each: cfg.Agents = mergeAgentDef(discovered, yaml)
│   └─ resolveSystemPromptFiles (sees merged map)
├─ Env struct loading (fills cfg.Env.AgentsRoot for observability)
├─ resolveSkills (sees merged map)
├─ validate (covers all merged agents — Pin XOR Tier rule catches MD/yaml conflicts)
└─ return
```

The env var is read inline because the env-block populates later in Load(); restructuring that order would risk subtler regressions for one early reader.

### Operator changes

- New env var: `LOOMCYCLE_AGENTS_ROOT=/srv/loomcycle/agents`.
- New boot log line: `agents: discovered from <root> — total in cfg.Agents (after yaml merge): N`.
- `.env.example` documents the canonical frontmatter key list (mitigation for the typo'd-key silent-zero risk).

## Out of scope (deferred)

- No yaml↔MD bidirectional sync; no MD generation tool; no `loomcycle agents lint` subcommand; no SIGHUP hot-reload.
- No nested-directory layout — flat `<name>.md` only, matches Claude Code convention.
- No strict-frontmatter enforcement (`yaml.KnownFields(true)`); typo'd keys silently zero today. Follow-up PR would also tighten the skills loader.
- No parallel jobs-search-agent migration — per CLAUDE.md cross-repo discipline, lands in loomcycle first; jobs-search-agent migration follows on a separate branch.

## Test plan

- [x] `internal/agents/loader_test.go` — 13 unit tests (happy path, missing/nonexistent root, malformed frontmatter, no-closing-delim, body-only, comma-string tools, `allowed_tools` wins, filename/name mismatch, subdir + non-md skip, empty body, YAML-list tools, tools rejects bad type).
- [x] `internal/config/config_test.go` — 6 cross-cutting tests (discovery + yaml merge, discovery only, yaml-only regression guard, Pin+Tier validation post-merge, `system_prompt_file` overrides discovered body, discovered skills bundle correctly).
- [x] `go test ./...` — all 25 packages green.
- [x] `go test -race ./internal/agents/ ./internal/config/` — clean.
- [x] Manual: `loomcycle validate <yaml>` with `LOOMCYCLE_AGENTS_ROOT` set → discovered agent appears in summary. Boot log emits the new line.
- [ ] Manual end-to-end: real agent run via the discovered agent (deferred to next session, paired with the jobs-search-agent migration).

## Risks

- **Typo'd frontmatter key silently drops to zero.** A misspelled `provdier:` parses as `Provider=""`, looks like "operator forgot to set it". Mitigation: documented key list in `.env.example`. Strict mode is a follow-up PR (would also affect skills).
- **AGENTS_ROOT set but empty dir** → empty Set, no error. If yaml also has zero `agents:`, validate() may pass with zero agents → API-time "unknown agent" error when a request arrives. Recommendation: keep silent-empty (consistent with `SkillsRoot=""`); the runtime error is loud enough.
- **Filename collisions across cases** (`foo.md` vs `Foo.md`) — distinct on Linux, same on macOS/Windows. Loader treats them as distinct names; same caveat exists for skills today.
- **Body containing `---` separators** — parser uses first `\n---\n` after the opening. An MD with nested frontmatter triggers early body cutoff. Document but don't fix; matches skills behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)