### PR TITLE
feat(loop): runtime provider fallback for user_tier (v0.8.2 PR 2/2)

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -303,6 +303,55 @@ func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
 	}
 }
 
+// fallbackForRun builds the v0.8.2 PR-2 runtime-fallback policy +
+// re-resolve closure for one run. Returns zero/nil when the
+// operator has no user_tiers configured OR the resolved tier has
+// fallback_on_error=false (free-tier cost-cap semantics).
+//
+// The closure captures agentName + userTier so the loop can call
+// it on a retryable error mid-run. It walks the same path as the
+// initial resolveAgent: mark the failed (provider, model) stalled
+// in the matrix, ask the resolver for the next candidate, look up
+// the corresponding driver.
+//
+// On no-more-candidates the closure returns an error — the loop
+// then surfaces the ORIGINAL provider error to the caller (the
+// fallback path is terminal for this run).
+func (s *Server) fallbackForRun(agentName, userTier string) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
+	overlay := s.userTierOverlay(userTier)
+	if overlay == nil || !overlay.FallbackOnError {
+		return loop.FallbackPolicy{}, nil
+	}
+	policy := loop.FallbackPolicy{
+		Enabled:      true,
+		MaxAttempts:  overlay.MaxFallbackAttempts, // 0 = loop uses its own default (3)
+		UserTierName: overlay.Name,
+	}
+	reResolve := func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error) {
+		// Mark the failed pair stalled BEFORE re-resolving so the
+		// resolver's matrix walks past it. SetReachable=false on
+		// the model only, not the whole provider — other models on
+		// the same provider may still be valid.
+		if s.resolver != nil {
+			s.resolver.MarkStalled(failedProvider, failedModel, cause.Error())
+		}
+		// Re-resolve with the same agent + user_tier. The resolver's
+		// stall flag we just set excludes the failed pair; the next
+		// non-stalled candidate in the user_tier's priority is what
+		// we get back.
+		newProviderID, newModel, newEffort, err := s.resolveAgent(agentName, userTier)
+		if err != nil {
+			return nil, "", "", err
+		}
+		newProvider, err := s.providers.Get(newProviderID)
+		if err != nil {
+			return nil, "", "", err
+		}
+		return newProvider, newModel, newEffort, nil
+	}
+	return policy, reResolve
+}
+
 // convertConfigCandidates translates the config-package representation
 // of per-agent tier candidates into the resolver-package representation.
 // Keeping the resolver package free of internal/config imports avoids
@@ -519,6 +568,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 
 	heartbeat := s.makeHeartbeat(runID)
 
+	fbPolicy, fbReResolve := s.fallbackForRun(effectiveAgentName, in.UserTier)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
 		Model:           model,
@@ -534,6 +584,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       effectiveAgentName,
 		UserTier:        in.UserTier,
+		FallbackPolicy:  fbPolicy,
+		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
 	s.finishRunWithCancel(ctx, runCtx, runID, res, runErr)
@@ -1016,6 +1068,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// minutes → presumed dead). Cheap (~10–100 calls per run).
 	heartbeat := s.makeHeartbeat(runID)
 
+	fbPolicy, fbReResolve := s.fallbackForRun(req.Agent, req.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
 		Model:           model,
@@ -1030,6 +1083,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       req.Agent,
 		UserTier:        req.UserTier,
+		FallbackPolicy:  fbPolicy,
+		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
 	if runErr != nil {
@@ -1289,6 +1344,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 	})
+	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
 		Model:           model,
@@ -1304,6 +1360,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       sess.Agent,
 		UserTier:        body.UserTier,
+		FallbackPolicy:  fbPolicy,
+		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
 	if runErr != nil {
@@ -1757,6 +1815,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 
+	fbPolicy, fbReResolve := s.fallbackForRun(name, parentTier)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
 		Provider:        provider,
 		Model:           model,
@@ -1771,6 +1830,8 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       name,
 		UserTier:        parentTier,
+		FallbackPolicy:  fbPolicy,
+		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
 	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr)

--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -1,0 +1,427 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// tieredProvider is a fakeProvider variant whose ID is configurable.
+// The fallback tests need two distinct providers with different IDs
+// so we can assert the EventProviderFallback payload carries the
+// correct new_provider name.
+type tieredProvider struct {
+	id        string
+	mu        sync.Mutex
+	responses [][]providers.Event
+	errors    []error // returned by Call() at the same index; nil → use responses[idx]
+	calls     int
+}
+
+func (p *tieredProvider) ID() string                                       { return p.id }
+func (p *tieredProvider) Probe(_ context.Context) error                    { return nil }
+func (p *tieredProvider) ListModels(_ context.Context) ([]string, error)   { return []string{"m"}, nil }
+func (p *tieredProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *tieredProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	idx := p.calls
+	p.calls++
+	if idx < len(p.errors) && p.errors[idx] != nil {
+		return nil, p.errors[idx]
+	}
+	if idx >= len(p.responses) {
+		return nil, fmt.Errorf("no scripted response at idx=%d for %s", idx, p.id)
+	}
+	ch := make(chan providers.Event, len(p.responses[idx]))
+	for _, ev := range p.responses[idx] {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// successResponse returns the canonical "model said hi and stopped"
+// event sequence — used as the terminal response after a fallback
+// switches to the new provider.
+func successResponse() []providers.Event {
+	return []providers.Event{
+		{Type: providers.EventText, Text: "hi from new provider"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1, Model: "m"}},
+	}
+}
+
+// TestFallback_429SwitchesProviderAndEmitsEvent — the headline case:
+// first Call returns "anthropic 429: rate limit", policy enables
+// fallback, ReResolve returns a new provider; the next iteration
+// succeeds against the new provider. EventProviderFallback carries
+// the correct failed/new provider names.
+func TestFallback_429SwitchesProviderAndEmitsEvent(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 429: rate limit exceeded")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+
+	var events []providers.Event
+	var mu sync.Mutex
+
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "claude-sonnet-4-6",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			UserTierName: "medium",
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "", nil
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v (expected success after fallback)", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var fbEvent *providers.Event
+	for i := range events {
+		if events[i].Type == providers.EventProviderFallback {
+			fbEvent = &events[i]
+			break
+		}
+	}
+	if fbEvent == nil {
+		t.Fatal("no EventProviderFallback emitted")
+	}
+	if fbEvent.Fallback == nil {
+		t.Fatal("EventProviderFallback emitted with nil Fallback payload")
+	}
+	if fbEvent.Fallback.FailedProvider != "anthropic" {
+		t.Errorf("FailedProvider = %q, want anthropic", fbEvent.Fallback.FailedProvider)
+	}
+	if fbEvent.Fallback.NewProvider != "deepseek" {
+		t.Errorf("NewProvider = %q, want deepseek", fbEvent.Fallback.NewProvider)
+	}
+	if fbEvent.Fallback.Attempt != 1 {
+		t.Errorf("Attempt = %d, want 1", fbEvent.Fallback.Attempt)
+	}
+	if fbEvent.Fallback.UserTier != "medium" {
+		t.Errorf("UserTier = %q, want medium", fbEvent.Fallback.UserTier)
+	}
+	if fbEvent.Fallback.Reason != "retryable" {
+		t.Errorf("Reason = %q, want retryable", fbEvent.Fallback.Reason)
+	}
+	if !strings.Contains(fbEvent.Fallback.CauseError, "anthropic 429") {
+		t.Errorf("CauseError = %q, want substring 'anthropic 429'", fbEvent.Fallback.CauseError)
+	}
+}
+
+// TestFallback_DisabledPolicy_PropagatesError — free tier: enabled=false
+// means a 429 returns the error to the caller, no switch attempted.
+// Pins the cost-cap semantic.
+func TestFallback_DisabledPolicy_PropagatesError(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "gemini",
+		errors: []error{fmt.Errorf("gemini 429: free tier exhausted")},
+	}
+	reResolveCalls := 0
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "gemini-2.0-flash",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:       func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: false}, // free tier
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			reResolveCalls++
+			return nil, "", "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error to propagate when fallback disabled")
+	}
+	if !strings.Contains(err.Error(), "gemini 429") {
+		t.Errorf("error = %q, want substring 'gemini 429'", err.Error())
+	}
+	if reResolveCalls != 0 {
+		t.Errorf("ReResolve called %d times; want 0 (policy disabled)", reResolveCalls)
+	}
+}
+
+// TestFallback_BudgetExhausted_PropagatesError — policy enabled, but
+// after 3 successful switches a 4th 429 should propagate. Confirms
+// MaxAttempts is the cumulative cap across providers.
+func TestFallback_BudgetExhausted_PropagatesError(t *testing.T) {
+	// Each tieredProvider returns 429 on every call so the loop
+	// keeps trying to fall back. ReResolve hands out fresh providers
+	// each time; the cap stops the cycle at attempt 3.
+	makeFailing := func(id string) *tieredProvider {
+		return &tieredProvider{
+			id:     id,
+			errors: []error{fmt.Errorf("%s 429: throttled", id)},
+		}
+	}
+	providers0 := makeFailing("anthropic")
+	providers1 := makeFailing("deepseek")
+	providers2 := makeFailing("gemini")
+	providers3 := makeFailing("ollama")
+
+	queue := []*tieredProvider{providers1, providers2, providers3}
+	reResolveCalls := 0
+
+	opts := RunOptions{
+		Provider:      providers0,
+		Model:         "m0",
+		MaxIterations: 10,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:       func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			UserTierName: "high",
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			next := queue[reResolveCalls]
+			reResolveCalls++
+			return next, "m" + next.id, "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error after budget exhausted")
+	}
+	// After the 3rd switch (now on providers3), the 4th 429 should
+	// NOT trigger another switch (budget exhausted). The original
+	// providers3 error propagates.
+	if !strings.Contains(err.Error(), "ollama 429") {
+		t.Errorf("expected ollama 429 (the final provider's error); got %v", err)
+	}
+	if reResolveCalls != 3 {
+		t.Errorf("ReResolve called %d times; want 3 (MaxAttempts cap)", reResolveCalls)
+	}
+}
+
+// TestFallback_PermanentError_PropagatesRegardlessOfPolicy — a 400 /
+// 401 / 403 must NOT trigger fallback even when policy is enabled.
+// These are configuration errors (bad payload, bad auth); cascading
+// burns through every provider's quota for no benefit.
+func TestFallback_PermanentError_PropagatesRegardlessOfPolicy(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 400: invalid request shape")},
+	}
+	reResolveCalls := 0
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "claude-sonnet-4-6",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			reResolveCalls++
+			t.Error("ReResolve was called for a 400 — should NOT happen")
+			return nil, "", "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error to propagate for permanent class")
+	}
+	if !strings.Contains(err.Error(), "anthropic 400") {
+		t.Errorf("error = %q, want substring 'anthropic 400'", err.Error())
+	}
+	if reResolveCalls != 0 {
+		t.Errorf("ReResolve called %d times; want 0 (permanent error)", reResolveCalls)
+	}
+}
+
+// TestFallback_AnthropicToOther_EmitsCacheInvalidated — when the
+// failing provider is anthropic and the new one isn't, the loop
+// must emit EventCacheInvalidated alongside EventProviderFallback.
+// Anthropic's cache_control breakpoints don't transfer; this event
+// is the signal to cost-retro tooling that downstream tokens for
+// this run are cache-cold.
+func TestFallback_AnthropicToOther_EmitsCacheInvalidated(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 503: backend unavailable")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+	var events []providers.Event
+	var mu sync.Mutex
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "claude-sonnet-4-6",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	sawCacheEvent := false
+	for _, ev := range events {
+		if ev.Type == providers.EventCacheInvalidated {
+			sawCacheEvent = true
+			if !strings.Contains(ev.Text, "deepseek") {
+				t.Errorf("cache event text = %q, want substring 'deepseek'", ev.Text)
+			}
+			break
+		}
+	}
+	if !sawCacheEvent {
+		t.Error("no EventCacheInvalidated emitted on anthropic→deepseek switch")
+	}
+}
+
+// TestFallback_NonAnthropicSwitch_NoCacheEvent — switching from
+// (e.g.) gemini to deepseek must NOT emit EventCacheInvalidated.
+// Only Anthropic has operator-controlled cache_control breakpoints
+// today; cache invalidation isn't meaningful for other providers.
+func TestFallback_NonAnthropicSwitch_NoCacheEvent(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "gemini",
+		errors: []error{fmt.Errorf("gemini 503: backend unavailable")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+	var events []providers.Event
+	var mu sync.Mutex
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "gemini-2.5-pro",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		if ev.Type == providers.EventCacheInvalidated {
+			t.Errorf("EventCacheInvalidated emitted on gemini→deepseek switch (no anthropic cache to invalidate)")
+		}
+	}
+}
+
+// TestFallback_ReResolveFailure_PropagatesOriginalError — the
+// resolver couldn't find another candidate (the user_tier's list
+// is exhausted). The loop must surface the ORIGINAL provider error
+// to the caller, not the resolver's "no candidates" error.
+// Operators read the actual provider failure; the no-candidates
+// outcome is downstream context.
+func TestFallback_ReResolveFailure_PropagatesOriginalError(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 429: throttled")},
+	}
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "claude-sonnet-4-6",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return nil, "", "", errors.New("user_tier candidate list exhausted")
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("expected error when ReResolve fails")
+	}
+	// Must surface the ORIGINAL "anthropic 429", not the resolver's
+	// "user_tier candidate list exhausted" — operator needs to see
+	// what actually broke at the provider.
+	if !strings.Contains(err.Error(), "anthropic 429") {
+		t.Errorf("error = %q, want substring 'anthropic 429' (original provider failure)", err.Error())
+	}
+}
+
+// TestFallback_StreamMidErrorTriggers — provider opens the SSE
+// stream successfully but emits an EventError mid-stream. The
+// fallback path must fire from the in-stream error too, not just
+// the Call-layer error. Models 5xx-ing mid-response is a common
+// shape that v0.8.2 needs to handle.
+func TestFallback_StreamMidErrorTriggers(t *testing.T) {
+	failing := &tieredProvider{
+		id: "anthropic",
+		responses: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "starting..."},
+				{Type: providers.EventError, Error: "anthropic 503: stream interrupted"},
+			},
+		},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "claude-sonnet-4-6",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "", nil
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v (expected fallback to handle mid-stream error)", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -9,6 +9,7 @@ package loop
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -106,14 +107,35 @@ type RunOptions struct {
 	AgentName string
 
 	// UserTier is the v0.8.2 user-facing-tier policy name applied
-	// to this run. PR 1 only plumbs the field; PR 2's runtime
-	// fallback consumes FallbackOnError + MaxFallbackAttempts via
-	// the resolver's UserTierOverlay (resolver state, not RunOptions).
-	// This field is currently informational — it appears in the
-	// agent-loop log line + on store.Run.UserTier so cost/compliance
-	// queries can facet by tier. Empty when the operator has no
-	// user_tiers configured.
+	// to this run. Informational on the loop side — appears on
+	// store.Run.UserTier + agent-loop log lines so cost/compliance
+	// queries can facet by tier. The actual fallback behaviour is
+	// driven by FallbackPolicy below (also set by the HTTP server
+	// from the operator's user_tiers yaml). Empty when no user_tier
+	// was supplied / configured.
 	UserTier string
+
+	// FallbackPolicy controls the v0.8.2 runtime fallback path —
+	// the loop switches to the next-in-queue provider when a call
+	// returns a retryable error (rate limit, 5xx, network, stream-
+	// idle). Zero value = disabled (preserves v0.7.x error-out
+	// semantics). When Enabled is true, ReResolve MUST be non-nil.
+	FallbackPolicy FallbackPolicy
+
+	// ReResolve is the runtime-fallback callback. Called when a
+	// provider call returns a retryable error AND FallbackPolicy.
+	// Enabled AND attempts < MaxAttempts. The callback marks the
+	// failed (provider, model) stalled in the resolver, picks the
+	// next-in-queue, and returns the new Provider + Model + Effort.
+	//
+	// Returning an error from ReResolve means the resolver couldn't
+	// find another candidate — the loop then surfaces the original
+	// error to the caller (no further fallback attempts on this run).
+	//
+	// Nil disables runtime fallback regardless of FallbackPolicy.
+	// Both fields are set together by the HTTP server / gRPC server
+	// when the operator's user_tier policy enables fallback.
+	ReResolve func(ctx context.Context, failedProvider, failedModel string, cause error) (provider providers.Provider, model string, effort string, err error)
 
 	// Hooks is the tool-use hook dispatcher. Optional; nil disables
 	// all hook invocation (the loop runs tool dispatch directly,
@@ -146,6 +168,168 @@ type RunOptions struct {
 	// simple; tighten in follow-ups if over-reporting becomes
 	// observable noise.
 	MarkStalled func(provider, model, reason string)
+}
+
+// FallbackPolicy controls the v0.8.2 runtime fallback path. The HTTP
+// server builds this from cfg.UserTiers[req.user_tier]; the gRPC
+// server does the same. Zero value disables fallback (preserves
+// v0.7.x error-out semantics).
+//
+// Per-tier policy split: free tiers ship with Enabled=false (a 429
+// becomes a hard error so cost caps hold); paid tiers ship with
+// Enabled=true and MaxAttempts=3 (the cumulative cap across providers
+// — a run that climbs Anthropic → DeepSeek → Gemini consumes all 3).
+type FallbackPolicy struct {
+	// Enabled gates the fallback path. False = ReResolve is never
+	// consulted, errors propagate as in v0.7.x.
+	Enabled bool
+
+	// MaxAttempts is the cumulative cap on provider switches per
+	// run. The original provider doesn't count — only the SWITCHES.
+	// A run that successfully cascaded Anthropic → DeepSeek (1
+	// switch) → Gemini (2 switches) consumed 2 attempts; the 3rd
+	// would be allowed when MaxAttempts >= 3. Zero falls back to
+	// the package default of 3.
+	MaxAttempts int
+
+	// UserTierName is the operator-declared tier name that
+	// authorised this fallback policy. Informational — appears on
+	// the EventProviderFallback payload so log + UI consumers can
+	// attribute the switch to a specific tier.
+	UserTierName string
+}
+
+// defaultMaxFallbackAttempts is the cumulative cap when the operator
+// yaml leaves MaxAttempts at 0. Three attempts gets a run from a
+// stalled Anthropic through two more providers — enough to recover
+// from a single-provider outage without consuming dozens of attempts
+// against a deeper backbone-wide issue.
+const defaultMaxFallbackAttempts = 3
+
+// fallbackOutcome enumerates what tryProviderFallback decided after
+// classifying the error and consulting policy + budget.
+type fallbackOutcome int
+
+const (
+	// fallbackOutcomeNotEligible — the error class wasn't retryable,
+	// the policy was disabled, or the budget was exhausted. Caller
+	// propagates the original error via the existing error path.
+	fallbackOutcomeNotEligible fallbackOutcome = iota
+
+	// fallbackOutcomeSwitched — the loop's opts.Provider /
+	// opts.Model / opts.Effort were swapped in place. Caller
+	// re-runs the current iteration body against the new provider
+	// (typically via `continue` on the outer loop).
+	fallbackOutcomeSwitched
+
+	// fallbackOutcomeReResolveFailed — fallback was eligible AND the
+	// caller invoked ReResolve, but no replacement candidate was
+	// available (resolver exhausted the user_tier's candidate list).
+	// Caller propagates the original error (the fallback path is
+	// terminal for this run).
+	fallbackOutcomeReResolveFailed
+)
+
+// tryProviderFallback classifies the error, consults the run's
+// FallbackPolicy + cumulative attempts counter, and (if all three
+// permit) calls ReResolve to swap to the next provider. On success
+// it mutates *opts in place — caller continues the iteration body
+// against the new provider as if nothing happened.
+//
+// The mutation is intentional: opts is a value-receiver in Run, so
+// the swap is local to this loop invocation. The caller of Run
+// passed providers + initial state and doesn't re-read them.
+//
+// Emits EventProviderFallback on every successful switch. Emits
+// EventCacheInvalidated when an Anthropic provider is swapped out
+// (the only provider with operator-controlled cache_control
+// breakpoints today; gemini-implicit-cache and others don't surface
+// a knob, so swap-away isn't a meaningful invalidation event).
+func tryProviderFallback(
+	ctx context.Context,
+	opts *RunOptions,
+	attempts *int,
+	cause error,
+	emit func(providers.Event),
+) fallbackOutcome {
+	if !opts.FallbackPolicy.Enabled || opts.ReResolve == nil {
+		return fallbackOutcomeNotEligible
+	}
+	cls := providers.ClassifyError(cause)
+	if cls != providers.ErrorClassRetryable {
+		return fallbackOutcomeNotEligible
+	}
+	maxAttempts := opts.FallbackPolicy.MaxAttempts
+	if maxAttempts <= 0 {
+		maxAttempts = defaultMaxFallbackAttempts
+	}
+	if *attempts >= maxAttempts {
+		return fallbackOutcomeNotEligible
+	}
+	// Ctx already cancelled? Don't fall back — caller signalled
+	// abandon, classify would have caught explicit ctx.Canceled but
+	// race-stops can have the loop here with a fresh-looking error.
+	if ctx.Err() != nil {
+		return fallbackOutcomeNotEligible
+	}
+
+	failedProvider := opts.Provider.ID()
+	failedModel := opts.Model
+	newProvider, newModel, newEffort, rerr := opts.ReResolve(ctx, failedProvider, failedModel, cause)
+	if rerr != nil {
+		return fallbackOutcomeReResolveFailed
+	}
+
+	*attempts++
+
+	emit(providers.Event{
+		Type: providers.EventProviderFallback,
+		Fallback: &providers.FallbackInfo{
+			FailedProvider: failedProvider,
+			FailedModel:    failedModel,
+			NewProvider:    newProvider.ID(),
+			NewModel:       newModel,
+			Attempt:        *attempts,
+			UserTier:       opts.FallbackPolicy.UserTierName,
+			Reason:         cls.String(),
+			CauseError:     truncateError(cause),
+		},
+	})
+
+	// Cache-loss event when switching AWAY from Anthropic. The
+	// cache_control breakpoints in the system block (and on system_
+	// prompt segments) are Anthropic-specific; no other provider
+	// carries the equivalent state today. A switch FROM anthropic
+	// means downstream iterations on the new provider get cache-
+	// cold rates. Switches INTO anthropic don't emit this event —
+	// the new provider has no cache to begin with, and Anthropic's
+	// implicit cache will warm naturally.
+	if failedProvider == "anthropic" && newProvider.ID() != "anthropic" {
+		emit(providers.Event{
+			Type: providers.EventCacheInvalidated,
+			Text: fmt.Sprintf("Anthropic cache_control breakpoints lost on switch to %s; this run's downstream iterations will be cache-cold", newProvider.ID()),
+		})
+	}
+
+	opts.Provider = newProvider
+	opts.Model = newModel
+	opts.Effort = newEffort
+	return fallbackOutcomeSwitched
+}
+
+// truncateError clips long error strings to 200 chars so a peer's
+// 9 KB HTML 500 page doesn't flood the SSE wire on EventProviderFallback.
+// Same shape as the lazy-MCP resolver's summariseErr in v0.8.1.
+func truncateError(err error) string {
+	if err == nil {
+		return ""
+	}
+	s := err.Error()
+	const maxLen = 200
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "…(truncated)"
 }
 
 // RunResult is the terminal state after a Run.
@@ -203,7 +387,15 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	var totalUsage providers.Usage
 	var finalText string
 	var stopReason string
+	// fallbackAttempts counts cumulative v0.8.2 provider switches per
+	// run. tryProviderFallback bumps it on each successful switch;
+	// the FallbackPolicy.MaxAttempts cap (default 3) is enforced
+	// there. A fallback "consumes" one iter slot from the outer loop
+	// — we don't decrement iter, because a deliberate switch should
+	// still count toward MaxIterations as work the run did.
+	var fallbackAttempts int
 
+outerLoop:
 	for iter := 0; iter < opts.MaxIterations; iter++ {
 		// Heartbeat fires at the top of each iteration. Cheap path —
 		// implementations are expected to be ~one UPDATE. Failures
@@ -236,6 +428,17 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 			// not provider faults — don't pollute the matrix.
 			if opts.MarkStalled != nil && ctx.Err() == nil {
 				opts.MarkStalled(opts.Provider.ID(), opts.Model, err.Error())
+			}
+			// v0.8.2: when the run carries a fallback policy and the
+			// error class is retryable, swap to the next provider
+			// and re-run this iteration. tryProviderFallback emits
+			// EventProviderFallback (+ EventCacheInvalidated when
+			// switching away from anthropic) and mutates opts in
+			// place. Outcome==Switched → continue the outer loop
+			// without surfacing the error. Other outcomes fall
+			// through to the original error path.
+			if tryProviderFallback(ctx, &opts, &fallbackAttempts, err, emit) == fallbackOutcomeSwitched {
+				continue outerLoop
 			}
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})
 			return RunResult{Iterations: iter}, err
@@ -291,6 +494,19 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 				// shouldn't pollute the matrix.
 				if opts.MarkStalled != nil && ctx.Err() == nil {
 					opts.MarkStalled(opts.Provider.ID(), opts.Model, ev.Error)
+				}
+				// v0.8.2: classify the RAW provider error string
+				// (e.g. "anthropic 503: backend unavailable") for
+				// the fallback decision. The classifier's status-
+				// prefix regex needs the bare "<name> <code>:"
+				// shape, which the streamErr wrap below would
+				// obscure. The wrap is reserved for the FINAL
+				// return value when fallback isn't eligible.
+				rawErr := errors.New(ev.Error)
+				if tryProviderFallback(ctx, &opts, &fallbackAttempts, rawErr, emit) == fallbackOutcomeSwitched {
+					for range ch {
+					}
+					continue outerLoop
 				}
 				emit(ev)
 				return RunResult{Iterations: iter}, fmt.Errorf("provider error: %s", ev.Error)

--- a/internal/providers/errclass.go
+++ b/internal/providers/errclass.go
@@ -1,0 +1,162 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ErrorClass categorises a provider call's terminal error so the loop's
+// v0.8.2 runtime-fallback path can decide whether to switch to the
+// next provider in the user_tier's candidate list.
+//
+// The classification is intentionally coarse — three buckets — because
+// the policy decision the loop makes is binary (fallback or propagate)
+// plus a "cancellation" carve-out for caller-initiated tear-downs that
+// shouldn't trigger any retry shape.
+type ErrorClass int
+
+const (
+	// ErrorClassUnknown — couldn't classify; loop treats as non-
+	// retryable (safer to surface than to silently cascade).
+	ErrorClassUnknown ErrorClass = iota
+
+	// ErrorClassRetryable — transient provider-side issue that may
+	// resolve on a fresh attempt against a different provider. Covers:
+	//
+	//   - HTTP 429 (rate limit — the headline "free-tier exhausted"
+	//     case; or paid-tier burst)
+	//   - HTTP 500/502/503/504 (provider-side outage)
+	//   - Network errors (DNS, connection refused, TCP reset)
+	//   - Stream-idle deadline (v0.8.1's per-byte idle timeout firing
+	//     because the provider stalled mid-stream)
+	//
+	// Loop policy: if FallbackPolicy.Enabled and attempts <
+	// MaxAttempts, ReResolve to the next provider and continue.
+	ErrorClassRetryable
+
+	// ErrorClassPermanent — the request is bad in a way that would
+	// fail identically against any other provider. Covers:
+	//
+	//   - HTTP 400 (bad request — payload-shape issue)
+	//   - HTTP 401/403 (auth — operator config; cascading would burn
+	//     through every provider's quota for no benefit)
+	//   - HTTP 422 (semantic validation — same as 400)
+	//
+	// Loop policy: surface to caller regardless of FallbackPolicy.
+	ErrorClassPermanent
+
+	// ErrorClassCancelled — context.Canceled or a context.Cause that
+	// wraps it. Caller-initiated tear-down (HTTP client disconnect,
+	// cancel API hit). Loop policy: NEVER retry; the caller signalled
+	// abandon. Distinct from Permanent so the loop can emit the
+	// matching stop reason ("cancelled" vs "error") without parsing
+	// the error message.
+	ErrorClassCancelled
+
+	// ErrorClassDeadlineExceeded — context.DeadlineExceeded on the
+	// ROOT ctx (not the v0.8.1 idle-body wrap, which becomes a
+	// retryable stream-read error). Loop policy: surface; the
+	// caller's deadline cap has been hit and switching providers
+	// won't extend it. Distinct from Permanent so callers see a
+	// "deadline_exceeded" stop reason.
+	ErrorClassDeadlineExceeded
+)
+
+// String returns a human-readable label for log + event payloads.
+func (c ErrorClass) String() string {
+	switch c {
+	case ErrorClassRetryable:
+		return "retryable"
+	case ErrorClassPermanent:
+		return "permanent"
+	case ErrorClassCancelled:
+		return "cancelled"
+	case ErrorClassDeadlineExceeded:
+		return "deadline_exceeded"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassifyError inspects err and returns its bucket. Drivers in v0.8.2
+// still format their errors with `fmt.Errorf("anthropic %d: %s", ...)`
+// or `fmt.Errorf("http: %w", err)`; the classifier matches on those
+// shapes plus the standard errors.Is checks. A future v0.9.x can
+// replace the string-matching with typed errors (a *ProviderHTTPError
+// type that drivers return directly) — out of scope for PR 2.
+//
+// Order of checks matters: ctx-cancelled / ctx-deadline BEFORE error-
+// string matching, because the wrapped ctx errors satisfy errors.Is
+// even when buried under "http: ...".
+func ClassifyError(err error) ErrorClass {
+	if err == nil {
+		return ErrorClassUnknown
+	}
+	// Stream-idle deadline (v0.8.1 per-byte idle wrap) surfaces as
+	// "stream read: context deadline exceeded ...". errors.Is on the
+	// outer err DOES report DeadlineExceeded (the wrap chain), but
+	// we want to treat this as RETRYABLE (the provider stalled mid-
+	// stream — a different provider might be healthy), NOT as a
+	// caller-side deadline.
+	//
+	// Distinguish by the substring marker the body-wrap leaves in
+	// the error text. Pre-empt the DeadlineExceeded branch below.
+	if strings.Contains(err.Error(), "stream read: context deadline exceeded") {
+		return ErrorClassRetryable
+	}
+	if errors.Is(err, context.Canceled) {
+		return ErrorClassCancelled
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return ErrorClassDeadlineExceeded
+	}
+	// Status-coded errors: "anthropic 429: ...", "openai 500: ...",
+	// "gemini 503: ...", "deepseek 502: ...". The drivers all use the
+	// same shape — see the fmt.Errorf calls in each driver's Call().
+	if code := statusFromError(err); code != 0 {
+		switch {
+		case code == 429:
+			return ErrorClassRetryable
+		case code >= 500 && code <= 599:
+			return ErrorClassRetryable
+		case code == 400 || code == 401 || code == 403 || code == 422:
+			return ErrorClassPermanent
+		}
+		// Other 4xx (404/409/etc.) → Permanent. The agent / model id
+		// is wrong in a way another provider won't fix.
+		if code >= 400 && code <= 499 {
+			return ErrorClassPermanent
+		}
+	}
+	// Pure transport errors (`http: <wrapped>` from the drivers'
+	// non-2xx return path, or a wrapped net.Error). Retryable —
+	// another provider's transport may be healthy.
+	if strings.HasPrefix(err.Error(), "http: ") {
+		return ErrorClassRetryable
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return ErrorClassRetryable
+	}
+	return ErrorClassUnknown
+}
+
+// statusRe matches the leading "<name> <code>:" pattern the drivers
+// emit. Anchored to start-of-string so we don't false-positive on a
+// body that happens to contain the substring.
+var statusRe = regexp.MustCompile(`^[a-z][a-z0-9_-]* (\d{3}):`)
+
+// statusFromError extracts the HTTP status code from a driver-formatted
+// error, or 0 if the error doesn't match the "<name> <code>:" prefix.
+func statusFromError(err error) int {
+	match := statusRe.FindStringSubmatch(err.Error())
+	if match == nil {
+		return 0
+	}
+	code, _ := strconv.Atoi(match[1])
+	return code
+}

--- a/internal/providers/errclass_test.go
+++ b/internal/providers/errclass_test.go
@@ -1,0 +1,82 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestClassifyError_Table(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want ErrorClass
+	}{
+		// Status-code paths — the headline matrix.
+		{"anthropic 429", fmt.Errorf("anthropic 429: rate limit exceeded"), ErrorClassRetryable},
+		{"openai 429", fmt.Errorf("openai 429: throttled"), ErrorClassRetryable},
+		{"deepseek 500", fmt.Errorf("deepseek 500: internal server error"), ErrorClassRetryable},
+		{"gemini 503", fmt.Errorf("gemini 503: backend unavailable"), ErrorClassRetryable},
+		{"ollama 502", fmt.Errorf("ollama 502: bad gateway"), ErrorClassRetryable},
+		{"openai 504", fmt.Errorf("openai 504: gateway timeout"), ErrorClassRetryable},
+		// Permanent — would fail on next provider too.
+		{"anthropic 400", fmt.Errorf("anthropic 400: bad request"), ErrorClassPermanent},
+		{"openai 401", fmt.Errorf("openai 401: invalid api key"), ErrorClassPermanent},
+		{"deepseek 403", fmt.Errorf("deepseek 403: forbidden"), ErrorClassPermanent},
+		{"gemini 422", fmt.Errorf("gemini 422: unprocessable entity"), ErrorClassPermanent},
+		{"openai 404", fmt.Errorf("openai 404: model not found"), ErrorClassPermanent},
+		// Ctx-side outcomes.
+		{"ctx canceled", context.Canceled, ErrorClassCancelled},
+		{"ctx canceled wrapped", fmt.Errorf("call: %w", context.Canceled), ErrorClassCancelled},
+		{"ctx deadline exceeded", context.DeadlineExceeded, ErrorClassDeadlineExceeded},
+		// v0.8.1 stream-idle: outer ctx is fine, body-wrap canceled
+		// MID-STREAM. errors.Is reports DeadlineExceeded but we treat
+		// as Retryable — different provider may be healthy.
+		{"stream-idle", fmt.Errorf("provider error: stream read: context deadline exceeded"), ErrorClassRetryable},
+		// Transport.
+		{"http wrapped", fmt.Errorf("http: connection refused"), ErrorClassRetryable},
+		{"net.OpError wrapped", fmt.Errorf("dial: %w", &net.OpError{Op: "dial", Err: errors.New("connection refused")}), ErrorClassRetryable},
+		// Garbage in → unknown out (loop treats as non-retryable —
+		// safer to surface than silently cascade).
+		{"unknown plain", errors.New("something weird happened"), ErrorClassUnknown},
+		{"nil", nil, ErrorClassUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyError(tc.err)
+			if got != tc.want {
+				t.Errorf("ClassifyError(%v) = %s, want %s", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyError_StreamIdleHasPriorityOverDeadlineExceeded pins
+// the order-of-checks invariant: the v0.8.1 stream-idle marker MUST
+// be detected before the generic DeadlineExceeded branch fires, even
+// though the wrapped error chain satisfies errors.Is(...,
+// context.DeadlineExceeded). Without this priority, every stream-idle
+// would be misclassified as caller-deadline and lose the retry.
+func TestClassifyError_StreamIdleHasPriorityOverDeadlineExceeded(t *testing.T) {
+	wrapped := fmt.Errorf("stream read: context deadline exceeded: %w", context.DeadlineExceeded)
+	if got := ClassifyError(wrapped); got != ErrorClassRetryable {
+		t.Errorf("got %s; want retryable (stream-idle must beat ctx.DeadlineExceeded)", got)
+	}
+}
+
+func TestErrorClass_StringIsHumanReadable(t *testing.T) {
+	cases := map[ErrorClass]string{
+		ErrorClassUnknown:          "unknown",
+		ErrorClassRetryable:        "retryable",
+		ErrorClassPermanent:        "permanent",
+		ErrorClassCancelled:        "cancelled",
+		ErrorClassDeadlineExceeded: "deadline_exceeded",
+	}
+	for cls, want := range cases {
+		if got := cls.String(); got != want {
+			t.Errorf("%d.String() = %q, want %q", cls, got, want)
+		}
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -196,6 +196,28 @@ const (
 	// EventThinking and read EventDone.Reasoning; adapters that want
 	// live progress should consume both.
 	EventThinking EventType = "thinking"
+
+	// EventProviderFallback signals a v0.8.2 runtime fallback fired
+	// after a provider call returned a retryable error
+	// (ErrorClassRetryable per internal/providers/errclass.go) and
+	// the run's user_tier policy permitted the climb. The loop has
+	// already swapped to a fresh (provider, model) on the next-in-
+	// queue, re-resolved against the tier's candidate list with the
+	// failed provider marked stalled. The next iteration uses the
+	// new provider; this event is purely informational so adapters
+	// can show "switched to %s after %s 429" without a separate API
+	// call to inspect resolver state.
+	//
+	// The Fallback field carries the structured payload.
+	EventProviderFallback EventType = "provider_fallback"
+
+	// EventCacheInvalidated signals that a v0.8.2 runtime fallback
+	// dropped a provider-specific cache (most notably Anthropic's
+	// cache_control breakpoints) when switching to a different
+	// provider. The cost retro view should treat this run's
+	// downstream iterations as cache-cold for the new provider.
+	// Purely informational; the loop continues unchanged.
+	EventCacheInvalidated EventType = "cache_invalidated"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -212,6 +234,13 @@ type Event struct {
 	IsError bool `json:"is_error,omitempty"`
 	// Retry carries the retry telemetry on EventRetry. Nil otherwise.
 	Retry *RetryInfo `json:"retry,omitempty"`
+
+	// Fallback carries the structured payload on EventProviderFallback
+	// (the v0.8.2 runtime provider switch). Nil on all other event
+	// types. Adapters log/render the switch + the failing error class
+	// so cost retros can attribute downstream tokens to the new
+	// provider.
+	Fallback *FallbackInfo `json:"fallback,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -245,6 +274,43 @@ const (
 	RetryReasonHeader   = "retry-after header"
 	RetryReasonSchedule = "exponential backoff"
 )
+
+// FallbackInfo accompanies an EventProviderFallback. Carries the
+// structured switch context for log + UI rendering. Wire-stable; the
+// field names are part of the v0.8.2+ contract.
+type FallbackInfo struct {
+	// FailedProvider + FailedModel — the pair the loop just stopped
+	// using. The loop marks (FailedProvider, FailedModel) stalled in
+	// the resolver matrix before re-resolving, so subsequent agent
+	// runs in this loomcycle process skip them until the next
+	// availability probe clears the stall.
+	FailedProvider string `json:"failed_provider"`
+	FailedModel    string `json:"failed_model"`
+	// NewProvider + NewModel — the next-in-queue the resolver picked.
+	// Empty + the loop emits EventError next when the resolver could
+	// not find any non-stalled candidate (the user_tier's candidate
+	// list was exhausted).
+	NewProvider string `json:"new_provider,omitempty"`
+	NewModel    string `json:"new_model,omitempty"`
+	// Attempt is the cumulative fallback counter — 1 for the first
+	// switch after the original provider failed, 2 for the second,
+	// etc. Capped by the user_tier's MaxFallbackAttempts.
+	Attempt int `json:"attempt"`
+	// UserTier is the operator-declared tier name that authorised
+	// this fallback ("default" / "free" / "low" / "medium" / "high").
+	// Free tiers never produce this event — their FallbackOnError
+	// is false and the loop propagates the original error instead.
+	UserTier string `json:"user_tier"`
+	// Reason is the error-class label that triggered the switch
+	// ("retryable" most commonly; "deadline_exceeded" never — that
+	// shape is non-retryable). Stable wire string.
+	Reason string `json:"reason"`
+	// CauseError is the original error message (truncated to ~200
+	// chars to avoid 9 KB HTML bodies flooding the SSE wire). Useful
+	// for operator diagnostics — they see "anthropic 429: rate
+	// limit exceeded" alongside the structural switch info.
+	CauseError string `json:"cause_error,omitempty"`
+}
 
 // ToolUse is the model's request to invoke a tool.
 type ToolUse struct {


### PR DESCRIPTION
Second half of the v0.8.2 **user_tier** feature. [PR #52](https://github.com/denn-gubsky/loomcycle/pull/52) landed the resolve-time overlay + wire/store/yaml plumbing. This PR adds the **runtime fallback** path: when a provider call returns a retryable error AND the tier's `fallback_on_error: true` AND the cumulative attempt budget isn't exhausted, the loop swaps to the next-in-queue provider and continues the iteration.

## Locked decisions implemented (from PR 1's design discussion)

| # | Decision | Mechanism |
|---|---|---|
| 1 | Refuse on intersection mismatch | (Already in PR 1 — `ErrTierAgentNotAvailable`) |
| 2 | Cumulative 3-attempt budget | `FallbackPolicy.MaxAttempts` (default 3 when 0); checked in `tryProviderFallback` |
| 3 | Cache-invalidation event | `EventCacheInvalidated` emitted only on `anthropic → other` transition |
| 4 | Default tier `fallback_on_error: true` | Operator yaml; preserves v0.7.x rate-limit retry semantics |

## Error classification

Five-bucket taxonomy in `internal/providers/errclass.go`:

| Class | What triggers it | Fallback? |
|---|---|---|
| `Retryable` | 429, 500/502/503/504, network (DNS/conn refused), v0.8.1 stream-idle | **Yes** |
| `Permanent` | 400, 401, 403, 422, other 4xx | No (cascading would burn every provider's quota) |
| `Cancelled` | `context.Canceled` (wrapped or bare) | No — caller signalled abandon |
| `DeadlineExceeded` | `context.DeadlineExceeded` (NOT v0.8.1 stream-idle) | No — caller's deadline cap hit |
| `Unknown` | Anything else | No (safer to surface than silently cascade) |

The v0.8.1 stream-idle marker (`"stream read: context deadline exceeded"`) MUST be checked before the generic DeadlineExceeded branch — the wrap chain satisfies `errors.Is(..., DeadlineExceeded)` but we want Retryable semantics there. Pinned by `TestClassifyError_StreamIdleHasPriorityOverDeadlineExceeded`.

## New typed events

```go
EventProviderFallback {
  Type: "provider_fallback",
  Fallback: {
    FailedProvider, FailedModel,
    NewProvider, NewModel,
    Attempt,        // cumulative
    UserTier,       // "free" / "low" / "medium" / "high" / "default"
    Reason,         // "retryable" (always — others don't fire fallback)
    CauseError,     // truncated to 200 chars
  }
}

EventCacheInvalidated {
  Type: "cache_invalidated",
  Text: "Anthropic cache_control breakpoints lost on switch to deepseek; ...",
}
```

Both are wire-stable; adapters/SSE consumers can string-match on `Type` and read structured fields.

## Loop integration

`RunOptions` gains:
```go
FallbackPolicy struct{ Enabled bool; MaxAttempts int; UserTierName string }
ReResolve func(ctx, failedProvider, failedModel, cause) (Provider, model, effort, error)
```

`tryProviderFallback` helper classifies the error, checks policy + budget, calls ReResolve, mutates `opts.Provider/Model/Effort` in place, emits events. Wired into both error paths:

1. `ch, err := opts.Provider.Call(ctx, req)` — Call-layer error (couldn't open the stream).
2. `case providers.EventError:` — in-stream error (driver opened the stream, then 5xx mid-response). Classifies the RAW `ev.Error` before wrapping so the `<name> <code>:` status regex matches.

## HTTP server wiring

`s.fallbackForRun(agentName, userTier)` builds `FallbackPolicy` + `ReResolve` closure from `cfg.UserTiers[userTier]`. Returns zero/nil when:
- No `user_tiers` block configured, OR
- Resolved tier's `FallbackOnError: false` (free-tier cost-cap).

The closure walks the same resolution path as the initial pick: marks the failed (provider, model) stalled in the resolver matrix, re-resolves, looks up the new driver via `s.providers.Get`. Wired into all 4 `loop.Run` sites (RunOnce, handleRuns, handleMessages, runSubAgent).

## Tests

- **22 `ClassifyError` cases** covering every status code class, ctx outcomes, v0.8.1 stream-idle priority, transport errors, garbage-in.
- **9 loop integration cases**:
  1. 429 → switches; EventProviderFallback payload correct (failed/new provider names, attempt, tier, reason, cause)
  2. Disabled policy (free tier) → propagates; ReResolve never called
  3. Budget exhausted after 3 attempts → propagates final error
  4. 400 (permanent) → propagates regardless of policy; ReResolve never called
  5. anthropic → other → EventCacheInvalidated emitted
  6. gemini → other → no EventCacheInvalidated (no anthropic cache to lose)
  7. ReResolve returns error (resolver exhausted) → propagates ORIGINAL provider error
  8. In-stream EventError → fallback fires (mid-stream 5xx scenario)
  9. (8) drains the channel before `continue`

All 24 packages green; `-race` clean on loop + providers.

## What's next after this lands

- **Docs PR (#54)**: README "What's in v0.8.2" + docs/PLAN.md promotion to current + v0.8.x roadmap update (Channel → v0.8.3, LoomHelp → v0.8.4, LoomCycle MCP → v0.8.5).
- **v0.8.2 release tag** after docs PR merges.
- **jobs-search-agent migration**: extend the agent runner to pass `user_tier` per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)