### PR TITLE
feat(providers): split ollama into ollama (cloud) + ollama-local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,17 @@
 # ─── Provider keys (only the ones you'll use need to be set) ──────────
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+
+# Ollama (v0.8.3 split):
+#   `ollama` provider       = hosted ollama.com, Bearer auth via OLLAMA_API_KEY.
+#   `ollama-local` provider = local-network Ollama, no auth, default
+#                             http://localhost:11434. Driven by OLLAMA_BASE_URL.
+# Existing deploys with OLLAMA_BASE_URL=http://localhost:11434 keep working
+# unchanged — they now feed `ollama-local`. To opt out of the local
+# registration entirely, set OLLAMA_BASE_URL=disabled.
 OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_API_KEY=
+# OLLAMA_CLOUD_BASE_URL=https://ollama.com   # optional override
 
 # ─── Sidecar listen + auth ────────────────────────────────────────────
 LOOMCYCLE_LISTEN_ADDR=127.0.0.1:8787

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -554,9 +554,14 @@ func openStore(cfg *config.Config) (store.Store, func(), error) {
 type providerResolver struct {
 	anthropic providers.Provider
 	openai    providers.Provider
-	ollama    providers.Provider
-	deepseek  providers.Provider
-	gemini    providers.Provider
+	// ollama = hosted ollama.com (Bearer auth via OLLAMA_API_KEY).
+	// ollamaLocal = local-network endpoint (no auth, default
+	// localhost:11434). Both wrap the same internal driver; only the
+	// providerID, auth header, and base URL differ. See v0.8.3 split.
+	ollama      providers.Provider
+	ollamaLocal providers.Provider
+	deepseek    providers.Provider
+	gemini      providers.Provider
 }
 
 func newProviderResolver(cfg *config.Config) *providerResolver {
@@ -571,11 +576,20 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 	if cfg.Env.OpenAIAPIKey != "" {
 		pr.openai = openai.New(cfg.Env.OpenAIAPIKey, "", streamOpts, nil)
 	}
-	// Ollama has no API key — wire it up if a base URL is configured (the
-	// loader defaults this to http://localhost:11434 so it's effectively
-	// always-on; users disable it by setting OLLAMA_BASE_URL=disabled).
+	// Hosted ollama.com — opts in via OLLAMA_API_KEY. Bearer-auth on the
+	// same /api/chat wire shape as local Ollama; the driver is shared,
+	// only the providerID + auth header + base URL differ.
+	// OLLAMA_CLOUD_BASE_URL overrides the public endpoint for staged
+	// rollouts or vendor mirrors.
+	if cfg.Env.OllamaAPIKey != "" {
+		pr.ollama = ollama.New("ollama", cfg.Env.OllamaAPIKey, cfg.Env.OllamaCloudBaseURL, streamOpts, nil)
+	}
+	// Local-network Ollama — no API key, local trust model. The loader
+	// defaults OLLAMA_BASE_URL to http://localhost:11434, so this is
+	// effectively always-on. Operators disable it via
+	// OLLAMA_BASE_URL=disabled (or an empty string in shell env).
 	if cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled" {
-		pr.ollama = ollama.New(cfg.Env.OllamaBaseURL, streamOpts, nil)
+		pr.ollamaLocal = ollama.New("ollama-local", "", cfg.Env.OllamaBaseURL, streamOpts, nil)
 	}
 	// DeepSeek opts in via DEEPSEEK_API_KEY. Optional DEEPSEEK_BASE_URL
 	// overrides the public endpoint for self-hosted OpenAI-compatible
@@ -606,9 +620,14 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 		return p.openai, nil
 	case "ollama":
 		if p.ollama == nil {
-			return nil, fmt.Errorf("ollama provider not configured (set OLLAMA_BASE_URL or unset OLLAMA_BASE_URL=disabled)")
+			return nil, fmt.Errorf("ollama provider not configured (set OLLAMA_API_KEY for hosted ollama.com; use provider id \"ollama-local\" for a local-network Ollama)")
 		}
 		return p.ollama, nil
+	case "ollama-local":
+		if p.ollamaLocal == nil {
+			return nil, fmt.Errorf("ollama-local provider not configured (set OLLAMA_BASE_URL, or it's been opted out via OLLAMA_BASE_URL=disabled)")
+		}
+		return p.ollamaLocal, nil
 	case "deepseek":
 		if p.deepseek == nil {
 			return nil, fmt.Errorf("deepseek provider not configured (set DEEPSEEK_API_KEY)")
@@ -673,7 +692,9 @@ func runResolveProbeOnce(ctx context.Context, r *resolve.Resolver, pr *providerR
 			exclReason: "DEEPSEEK_API_KEY not set"},
 		{id: "gemini", excluded: cfg.Env.GeminiAPIKey == "",
 			exclReason: "GEMINI_API_KEY not set"},
-		{id: "ollama", excluded: cfg.Env.OllamaBaseURL == "" || cfg.Env.OllamaBaseURL == "disabled",
+		{id: "ollama", excluded: cfg.Env.OllamaAPIKey == "",
+			exclReason: "OLLAMA_API_KEY not set"},
+		{id: "ollama-local", excluded: cfg.Env.OllamaBaseURL == "" || cfg.Env.OllamaBaseURL == "disabled",
 			exclReason: "OLLAMA_BASE_URL not configured"},
 	}
 	for i := range jobs {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ loomcycle/
 │   │   ├── anthropic/                 Messages API + native cache_control
 │   │   ├── openai/                    Chat Completions
 │   │   ├── deepseek/                  Wraps openai/ with the DeepSeek base URL pre-baked
-│   │   ├── ollama/                    /api/chat NDJSON (tool-tuned models only)
+│   │   ├── ollama/                    /api/chat NDJSON (registered as both `ollama` cloud + `ollama-local`)
 │   │   ├── ratelimit/                 per-driver retry-after + backoff
 │   │   └── provider.go                Provider interface (Call, Probe, ListModels) + Capabilities
 │   ├── resolve/                       v0.7.0 model resolution matrix (tier + effort + availability)
@@ -125,14 +125,16 @@ type Event struct {
 
 Each driver translates its provider's streaming shape into the same `Event` channel. The loop is provider-agnostic. Capability flags let the loop decline to set fields the provider doesn't honour (e.g. only Anthropic gets `cache_control` placement; Ollama tool-call IDs are synthesized by the loop).
 
-Four drivers ship as of v0.6.0:
+Six driver registrations ship as of v0.8.3 (one package per provider, except `ollama` and `ollama-local` which share the `internal/providers/ollama/` package — same wire shape, different auth header + base URL):
 
 | Driver       | API                       | Notes |
 |---|---|---|
 | `anthropic` | Messages (streaming SSE)   | Native `cache_control` on system blocks marked `cacheable: true`. `message_start.message.model` plumbed into final `Usage.Model` so callers get the resolved alias for pricing. |
 | `openai`    | Chat Completions (streaming) | Index-keyed tool_call accumulator across deltas. Honours `[DONE]` sentinel. As of v0.6.0, captures the wire-resolved `model` field from each chunk envelope so `runs.model` populates correctly (also benefits any OpenAI-compatible endpoint — DeepSeek, vLLM). |
 | `deepseek`  | Chat Completions (streaming) | Wraps the `openai` driver with `https://api.deepseek.com/v1` pre-baked and `ID()` returning `"deepseek"`. Same wire shape, retry strategy, and tool-call envelope. Operator opts in via `DEEPSEEK_API_KEY` env (optional `DEEPSEEK_BASE_URL` for self-hosted OpenAI-compatible mirrors). Distinct package so per-provider cost rollups don't conflate OpenAI and DeepSeek pricing. |
-| `ollama`    | `/api/chat` (NDJSON)         | Tool-tuned models only (qwen3+, llama3.1+, mistral-large). Tool-call IDs synthesized as `lc-{iter}-{slot}` because Ollama doesn't issue them. Recent Ollama versions emit reasoning-model output in a separate `message.thinking` field which the driver currently drops — tracked as v0.7+ work. |
+| `gemini`    | Generative Language API (streaming SSE) | v0.7.x driver. Reasoning-effort hint translated to Gemini's `thinking_config`. |
+| `ollama`    | `/api/chat` (NDJSON), Bearer auth | **Hosted ollama.com.** Opts in via `OLLAMA_API_KEY` (optional `OLLAMA_CLOUD_BASE_URL` for vendor mirrors). Same `/api/chat` wire shape as local Ollama; Bearer header on every request. Treated as a paid-cloud provider in priority queues. |
+| `ollama-local` | `/api/chat` (NDJSON), no auth | **Local-network Ollama.** Opts in via `OLLAMA_BASE_URL` (default `http://localhost:11434`; `disabled` opts out). No auth — local trust model. Tool-tuned models only (qwen3+, llama3.1+, mistral-large). Tool-call IDs synthesized as `lc-{iter}-{slot}` because Ollama doesn't issue them. Recent Ollama versions emit reasoning-model output in a separate `message.thinking` field which the driver currently drops — tracked as v0.7+ work. |
 
 Each driver has rate-limit retry logic (`internal/providers/ratelimit/`) — 429s and provider 5xx-with-retry-after preserve run context across the retry; observable as `event: retry` SSE frames.
 
@@ -161,7 +163,7 @@ Effort flow: agent yaml `effort: low|medium|high` → `Decision.Effort` → `Run
 | `anthropic` | `thinking.budget_tokens` (low → skip thinking; medium → 2048; high → 8192). Haiku always skips. Budget clamps to `max_tokens - 1024` if it would exceed `max_tokens`; drops below 1024 minimum. |
 | `openai` | `reasoning_effort` (pass-through). API rejects on non-reasoning models with 400. |
 | `deepseek` | Inherits OpenAI via the wrapper. |
-| `ollama` | `SupportsEffort=false`. Loop logs once per Run when effort is dropped. |
+| `ollama`, `ollama-local` | Both share the same driver: `SupportsEffort=false`. Loop logs once per Run when effort is dropped. |
 
 References: `internal/resolve/matrix.go`, `internal/api/http/server.go` (`resolveAgent`, `markStalledFn`), `cmd/loomcycle/main.go` (`buildResolver`, `runResolveProbeOnce`, `runResolveProbeLoop`).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -334,7 +334,23 @@ type NativeCacheConfig struct {
 type Env struct {
 	AnthropicAPIKey string
 	OpenAIAPIKey    string
-	OllamaBaseURL   string
+	// OllamaBaseURL is the local-network Ollama endpoint. Drives the
+	// `ollama-local` provider registration. Default
+	// `http://localhost:11434` keeps existing deploys unchanged across
+	// the v0.8.3 split — operators with this var set keep working with
+	// no further action. Setting `OLLAMA_BASE_URL=disabled` opts out
+	// of registering `ollama-local`.
+	OllamaBaseURL string
+	// OllamaAPIKey enables the `ollama` provider (hosted ollama.com,
+	// Bearer auth). Empty = provider not registered. Same on/off
+	// semantics as the other paid-cloud providers (Anthropic / OpenAI /
+	// DeepSeek / Gemini).
+	OllamaAPIKey string
+	// OllamaCloudBaseURL overrides the hosted ollama.com endpoint
+	// (https://ollama.com) for staged rollouts or vendor mirrors.
+	// Defaults to the public hosted endpoint; ignored when
+	// OllamaAPIKey is empty.
+	OllamaCloudBaseURL string
 	// DeepSeekAPIKey enables the `provider: deepseek` driver. Empty
 	// = provider not registered (agents that ask for it fail at
 	// resolve time, mirroring OpenAI / Anthropic behaviour).
@@ -606,6 +622,8 @@ func Load(path string) (*Config, error) {
 		AnthropicAPIKey:          os.Getenv("ANTHROPIC_API_KEY"),
 		OpenAIAPIKey:             os.Getenv("OPENAI_API_KEY"),
 		OllamaBaseURL:            getenvDefault("OLLAMA_BASE_URL", "http://localhost:11434"),
+		OllamaAPIKey:             os.Getenv("OLLAMA_API_KEY"),
+		OllamaCloudBaseURL:       getenvDefault("OLLAMA_CLOUD_BASE_URL", "https://ollama.com"),
 		DeepSeekAPIKey:           os.Getenv("DEEPSEEK_API_KEY"),
 		DeepSeekBaseURL:          os.Getenv("DEEPSEEK_BASE_URL"),
 		GeminiAPIKey:             os.Getenv("GEMINI_API_KEY"),
@@ -1184,11 +1202,12 @@ func splitCSV(s string) []string {
 // how to dispatch to. Adding a new driver requires extending this set
 // AND wiring the driver into cmd/loomcycle/main.go's resolver.
 var validProviderIDs = map[string]bool{
-	"anthropic": true,
-	"openai":    true,
-	"deepseek":  true,
-	"ollama":    true,
-	"gemini":    true,
+	"anthropic":    true,
+	"openai":       true,
+	"deepseek":     true,
+	"ollama":       true, // hosted ollama.com (Bearer auth)
+	"ollama-local": true, // local-network Ollama (no auth)
+	"gemini":       true,
 }
 
 // validTierNames is the closed set of tier names. Operators choose

--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -23,9 +23,9 @@ type tieredProvider struct {
 	calls     int
 }
 
-func (p *tieredProvider) ID() string                                       { return p.id }
-func (p *tieredProvider) Probe(_ context.Context) error                    { return nil }
-func (p *tieredProvider) ListModels(_ context.Context) ([]string, error)   { return []string{"m"}, nil }
+func (p *tieredProvider) ID() string                                     { return p.id }
+func (p *tieredProvider) Probe(_ context.Context) error                  { return nil }
+func (p *tieredProvider) ListModels(_ context.Context) ([]string, error) { return []string{"m"}, nil }
 func (p *tieredProvider) Capabilities() providers.Capabilities {
 	return providers.Capabilities{Streaming: true}
 }
@@ -148,11 +148,11 @@ func TestFallback_DisabledPolicy_PropagatesError(t *testing.T) {
 	}
 	reResolveCalls := 0
 	opts := RunOptions{
-		Provider:      failing,
-		Model:         "gemini-2.0-flash",
-		MaxIterations: 5,
-		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
-		OnEvent:       func(ev providers.Event) {},
+		Provider:       failing,
+		Model:          "gemini-2.0-flash",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
 		FallbackPolicy: FallbackPolicy{Enabled: false}, // free tier
 		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
 			reResolveCalls++

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -35,20 +35,40 @@ const (
 	defaultBaseURL = "http://localhost:11434"
 )
 
-// Driver speaks Ollama's /api/chat. No API key — local trust model.
+// Driver speaks Ollama's /api/chat. Single struct serves two registrations:
+//
+//   - providerID = "ollama"       → hosted ollama.com (Bearer auth via apiKey)
+//   - providerID = "ollama-local" → local-network Ollama (apiKey empty,
+//     local trust model)
+//
+// The wire shape is identical; only the auth header and base URL default
+// differ. main.go constructs one Driver per registration.
 type Driver struct {
+	providerID  string
+	apiKey      string // empty for ollama-local; Bearer token for hosted
 	baseURL     string
 	http        *http.Client
 	idleTimeout time.Duration
 }
 
-// New constructs a Driver. baseURL may be empty for the default localhost
-// endpoint. streamOpts controls per-stream timeouts. Local generation
-// can be very slow on first-token (model warmup, large context); callers
-// passing zero values get the streamhttp defaults — usually fine, but
-// operators on cold-start sensitive deployments may want to bump
-// HeaderTimeout via LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_SECONDS.
-func New(baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
+// New constructs a Driver.
+//
+//   - providerID names this registration (e.g. "ollama" or "ollama-local").
+//     Empty defaults to "ollama" for back-compat with any caller outside
+//     main.go's resolver wiring.
+//   - apiKey is the Bearer token for the hosted ollama.com endpoint;
+//     leave empty for local Ollama (no Authorization header is sent).
+//   - baseURL may be empty for the default localhost endpoint.
+//
+// streamOpts controls per-stream timeouts. Local generation can be very
+// slow on first-token (model warmup, large context); callers passing zero
+// values get the streamhttp defaults — usually fine, but operators on
+// cold-start sensitive deployments may want to bump HeaderTimeout via
+// LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_SECONDS.
+func New(providerID, apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http.Client) *Driver {
+	if providerID == "" {
+		providerID = "ollama"
+	}
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
@@ -57,10 +77,10 @@ func New(baseURL string, streamOpts streamhttp.Options, httpClient *http.Client)
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
+	return &Driver{providerID: providerID, apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
 }
 
-func (d *Driver) ID() string { return "ollama" }
+func (d *Driver) ID() string { return d.providerID }
 
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
@@ -101,11 +121,14 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Accept", "application/x-ndjson")
+		if d.apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+d.apiKey)
+		}
 		return d.http.Do(req)
 	}
 
 	resp, err := ratelimit.Do(streamCtx, ratelimit.Config{
-		Provider:    "ollama",
+		Provider:    d.providerID,
 		ParseHeader: ratelimit.OllamaRetryAfter,
 		OnEvent:     req.OnEvent,
 	}, attempt)
@@ -120,7 +143,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		defer resp.Body.Close()
 		cancelStream()
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return nil, fmt.Errorf("ollama %d: %s", resp.StatusCode, strings.TrimSpace(string(errBody)))
+		return nil, fmt.Errorf("%s %d: %s", d.providerID, resp.StatusCode, strings.TrimSpace(string(errBody)))
 	}
 
 	resp.Body = streamhttp.WrapBody(resp.Body, d.idleTimeout, cancelStream)
@@ -690,6 +713,9 @@ func (d *Driver) fetchTags(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, d.baseURL+"/api/tags", nil)
 	if err != nil {
 		return nil, err
+	}
+	if d.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+d.apiKey)
 	}
 	resp, err := d.http.Do(req)
 	if err != nil {

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -45,7 +45,7 @@ func TestStreamTextThenStop(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "llama3.1",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
@@ -89,7 +89,7 @@ func TestStreamToolCallOnFinalFrame(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 
 	var toolCall *providers.ToolUse
@@ -131,7 +131,7 @@ func TestStreamToolCallOnNonFinalFrame(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 
 	var toolCalls int
@@ -161,7 +161,7 @@ func TestRequestBodyShape(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	temp := 0.7
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:       "llama3.1",
@@ -224,7 +224,7 @@ func TestCancellationDoesNotLeakGoroutine(t *testing.T) {
 	defer srv.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(ctx, providers.Request{Model: "llama3.1"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -252,7 +252,7 @@ func TestNon200Status(t *testing.T) {
 		fmt.Fprint(w, `{"error":"model not found"}`)
 	}))
 	defer srv.Close()
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	_, err := d.Call(context.Background(), providers.Request{Model: "nope"})
 	if err == nil {
 		t.Fatal("expected error on 404")
@@ -292,7 +292,7 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
 	if err != nil {
 		t.Fatalf("Call: %v", err)
@@ -342,7 +342,7 @@ func TestRetryEmitsEventToRequestOnEvent(t *testing.T) {
 
 	var retries []providers.Event
 	var rmu sync.Mutex
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "llama3.1",
 		OnEvent: func(ev providers.Event) {
@@ -383,7 +383,7 @@ func TestStopReasonWithoutToolCalls(t *testing.T) {
 	}
 	srv := fakeStream(t, frames)
 	defer srv.Close()
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{Model: "x"})
 	var stop string
 	for ev := range ch {
@@ -393,5 +393,87 @@ func TestStopReasonWithoutToolCalls(t *testing.T) {
 	}
 	if stop != "max_tokens" {
 		t.Errorf("stop_reason = %q, want max_tokens", stop)
+	}
+}
+
+// TestDriver_ID_RespectsConstructorArg pins the v0.8.3 split: one
+// driver type, two registrations differentiated by providerID. The
+// empty-string default falls through to "ollama" so anything that
+// imported `ollama.New` before the signature widened keeps working.
+func TestDriver_ID_RespectsConstructorArg(t *testing.T) {
+	cases := []struct {
+		giveID string
+		wantID string
+	}{
+		{"ollama", "ollama"},
+		{"ollama-local", "ollama-local"},
+		{"", "ollama"}, // default
+	}
+	for _, tc := range cases {
+		t.Run(tc.giveID, func(t *testing.T) {
+			d := New(tc.giveID, "", "http://localhost:11434", streamhttp.Options{}, nil)
+			if got := d.ID(); got != tc.wantID {
+				t.Errorf("ID() = %q, want %q", got, tc.wantID)
+			}
+		})
+	}
+}
+
+// TestDriver_AuthHeaderEmittedOnlyWhenKeySet pins the split's auth
+// shape: the hosted ollama.com registration sends Bearer; the local
+// registration sends nothing (matches Ollama OSS's local-trust model
+// — servers in the wild rely on the absence of an auth header to
+// distinguish "loopback client" from "internet client").
+func TestDriver_AuthHeaderEmittedOnlyWhenKeySet(t *testing.T) {
+	cases := []struct {
+		name       string
+		providerID string
+		apiKey     string
+		wantHeader string // "" → expect no Authorization sent
+	}{
+		{"local: no auth", "ollama-local", "", ""},
+		{"cloud: Bearer sent", "ollama", "tok-xyz", "Bearer tok-xyz"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Get("Authorization")
+				w.Header().Set("Content-Type", "application/x-ndjson")
+				w.WriteHeader(200)
+				fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop"}`+"\n")
+			}))
+			defer srv.Close()
+			d := New(tc.providerID, tc.apiKey, srv.URL, streamhttp.Options{}, nil)
+			ch, err := d.Call(context.Background(), providers.Request{Model: "x"})
+			if err != nil {
+				t.Fatalf("Call: %v", err)
+			}
+			for range ch { // drain
+			}
+			if got != tc.wantHeader {
+				t.Errorf("Authorization header = %q, want %q", got, tc.wantHeader)
+			}
+		})
+	}
+}
+
+// TestDriver_NonOKErrorUsesProviderID pins that error messages carry
+// the provider id (not the hardcoded literal "ollama"), so the v0.8.2
+// error classifier — anchored on the "<name> <code>:" prefix — works
+// for both registrations.
+func TestDriver_NonOKErrorUsesProviderID(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(503)
+		fmt.Fprint(w, "backend unavailable")
+	}))
+	defer srv.Close()
+	d := New("ollama-local", "", srv.URL, streamhttp.Options{}, nil)
+	_, err := d.Call(context.Background(), providers.Request{Model: "x"})
+	if err == nil {
+		t.Fatal("want error, got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "ollama-local 503:") {
+		t.Errorf("err = %q, want prefix \"ollama-local 503:\"", err.Error())
 	}
 }

--- a/internal/providers/ollama/effort_test.go
+++ b/internal/providers/ollama/effort_test.go
@@ -15,7 +15,7 @@ func TestCapabilities_SupportsEffortIsFalse(t *testing.T) {
 	// when an agent declares effort on an Ollama-resolved run.
 	// Operators see clearly that the hint was discarded rather
 	// than silently believing the agent thought hard.
-	d := New("http://localhost:11434", streamhttp.Options{}, nil)
+	d := New("", "", "http://localhost:11434", streamhttp.Options{}, nil)
 	if d.Capabilities().SupportsEffort {
 		t.Error("Ollama driver must report SupportsEffort=false (no thinking-budget knob today)")
 	}

--- a/internal/providers/ollama/live_test.go
+++ b/internal/providers/ollama/live_test.go
@@ -111,7 +111,7 @@ func TestLive_OllamaChatCompletion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	d := New(baseURL, streamhttp.Options{}, nil)
+	d := New("", "", baseURL, streamhttp.Options{}, nil)
 
 	// MaxTokens=512 gives reasoning models (qwen3, deepseek-r1, etc.)
 	// budget for the <think>...</think> block AND the actual answer.
@@ -192,7 +192,7 @@ func TestLive_OllamaToolCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer cancel()
 
-	d := New(baseURL, streamhttp.Options{}, nil)
+	d := New("", "", baseURL, streamhttp.Options{}, nil)
 
 	ch, err := d.Call(ctx, providers.Request{
 		Model: model,

--- a/internal/providers/ollama/markdown_tool_test.go
+++ b/internal/providers/ollama/markdown_tool_test.go
@@ -162,7 +162,7 @@ func TestStreamMarkdownFormToolCall(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "hermes3:latest",
 		Tools: []providers.ToolSpec{{Name: "search_web", InputSchema: json.RawMessage(`{}`)}},

--- a/internal/providers/ollama/probe_test.go
+++ b/internal/providers/ollama/probe_test.go
@@ -33,7 +33,7 @@ func TestListModels_HappyPath(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, body)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels: %v", err)
@@ -50,7 +50,7 @@ func TestListModels_NoModelsPulled(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, `{"models": []}`)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	models, err := d.ListModels(context.Background())
 	if err != nil {
 		t.Fatalf("ListModels (empty): %v", err)
@@ -64,7 +64,7 @@ func TestProbe_HappyPath(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusOK, `{"models": []}`)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err != nil {
 		t.Fatalf("Probe: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestProbe_ServerDown(t *testing.T) {
 	srv := fakeTagsServer(t, http.StatusInternalServerError, "ollama: server error")
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	if err := d.Probe(context.Background()); err == nil {
 		t.Fatal("Probe should error on 500")
 	}

--- a/internal/providers/ollama/thinking_test.go
+++ b/internal/providers/ollama/thinking_test.go
@@ -29,7 +29,7 @@ func TestStreamThinking_EmitsLiveEventThinking(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "what is 6 times 7"}}}},
@@ -77,7 +77,7 @@ func TestStreamThinking_NotEmittedOnNonThinkingModel(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "llama3.1",
 		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},

--- a/internal/providers/ollama/tool_text_recovery_test.go
+++ b/internal/providers/ollama/tool_text_recovery_test.go
@@ -36,7 +36,7 @@ func TestToolTextRecovery_SynthesizesCallFromText(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, err := d.Call(context.Background(), providers.Request{
 		Model: "qwen3:14b",
 		Tools: []providers.ToolSpec{{Name: "mcp__jobs__getApplication", InputSchema: json.RawMessage(`{}`)}},
@@ -89,7 +89,7 @@ func TestToolTextRecovery_SynthesizesArrayOfCalls(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "a"}, {Name: "b"}},
@@ -116,7 +116,7 @@ func TestToolTextRecovery_StripsMarkdownFence(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -143,7 +143,7 @@ func TestToolTextRecovery_DoesNotFalsePositiveOnProse(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -179,7 +179,7 @@ func TestToolTextRecovery_NoSynthWhenStructuredCallAlreadyEmitted(t *testing.T) 
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model:    "qwen3:14b",
 		Tools:    []providers.ToolSpec{{Name: "foo"}},
@@ -207,7 +207,7 @@ func TestToolTextRecovery_DisabledWhenNoToolsRequested(t *testing.T) {
 	srv := fakeStream(t, frames)
 	defer srv.Close()
 
-	d := New(srv.URL, streamhttp.Options{}, nil)
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
 	ch, _ := d.Call(context.Background(), providers.Request{
 		Model: "qwen3:14b",
 		// Tools intentionally empty — recovery must NOT fire.

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -242,7 +242,15 @@ type ModelStatus struct {
 // defaultLibraryPriority is the cost-floor-first ordering: try the
 // cheapest reasonable backend first, escalate when stalled. Used when
 // the operator hasn't set provider_priority in yaml.
-var defaultLibraryPriority = []string{"deepseek", "ollama", "openai", "anthropic"}
+//
+// ollama-local (no auth, runs on a workstation) sits at the absolute
+// floor — when an operator has a GPU on the network there's no reason
+// to pay for the first attempt. Paid clouds escalate from cheap
+// (DeepSeek) to premium (Anthropic). Hosted ollama.com (the `ollama`
+// id since the v0.8.3 split) sits after the paid clouds because it's
+// only sensible when the operator has explicitly paid for the
+// quota — agents that want it will pin it via per-agent `providers:`.
+var defaultLibraryPriority = []string{"ollama-local", "deepseek", "openai", "anthropic", "ollama"}
 
 // NewResolver constructs a Resolver with the library-wide defaults.
 // libraryPriority and libraryTiers come from the loaded Config; pass
@@ -393,9 +401,9 @@ func (r *Resolver) resolvePin(req AgentRequest) (Decision, error) {
 // candidatesFor returns the candidate list the resolver should walk
 // for this request, applying the v0.8.2 overlay precedence:
 //
-//   per-agent Models[Tier]   (highest)
-//   user_tier overlay Tiers  (when set; v0.8.2)
-//   library Tiers            (fallback)
+//	per-agent Models[Tier]   (highest)
+//	user_tier overlay Tiers  (when set; v0.8.2)
+//	library Tiers            (fallback)
 //
 // Caller has already validated req.Tier is non-empty.
 func (r *Resolver) candidatesFor(req AgentRequest) []Candidate {
@@ -418,9 +426,9 @@ func (r *Resolver) candidatesFor(req AgentRequest) []Candidate {
 // priorityFor returns the provider-priority order the resolver should
 // walk for this request, applying the v0.8.2 overlay precedence:
 //
-//   per-agent Providers      (highest, but intersected with user_tier)
-//   user_tier ProviderPriority (when set; v0.8.2)
-//   library ProviderPriority (fallback)
+//	per-agent Providers      (highest, but intersected with user_tier)
+//	user_tier ProviderPriority (when set; v0.8.2)
+//	library ProviderPriority (fallback)
 //
 // The second return value is true when the per-agent Providers and the
 // user_tier overlay's ProviderPriority have an empty intersection.

--- a/internal/resolve/matrix_test.go
+++ b/internal/resolve/matrix_test.go
@@ -10,24 +10,24 @@ import (
 // across the tests so each one starts from the realistic operator
 // config rather than a contrived two-row table.
 func fixtureLibrary() (priority []string, tiers map[string][]Candidate) {
-	priority = []string{"deepseek", "ollama", "openai", "anthropic"}
+	priority = []string{"deepseek", "ollama-local", "openai", "anthropic"}
 	tiers = map[string][]Candidate{
 		"low": {
 			{Provider: "deepseek", Model: "deepseek-v4-flash"},
-			{Provider: "ollama", Model: "gemma4:9b"},
+			{Provider: "ollama-local", Model: "gemma4:9b"},
 			{Provider: "openai", Model: "gpt-5.4-mini"},
 			{Provider: "anthropic", Model: "claude-haiku-4-5"},
 		},
 		"middle": {
 			{Provider: "deepseek", Model: "deepseek-v4-pro"},
-			{Provider: "ollama", Model: "qwen3.6:27b"},
+			{Provider: "ollama-local", Model: "qwen3.6:27b"},
 			{Provider: "openai", Model: "gpt-5.4"},
 			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
 		},
 		"high": {
 			// DeepSeek deliberately absent at high tier per the
 			// May-2026 matrix.
-			{Provider: "ollama", Model: "kimi-k2.6"},
+			{Provider: "ollama-local", Model: "kimi-k2.6"},
 			{Provider: "openai", Model: "gpt-5.5"},
 			{Provider: "anthropic", Model: "claude-opus-4-7"},
 		},
@@ -47,7 +47,7 @@ func seedAll(t *testing.T, r *Resolver, tiers map[string][]Candidate) {
 			r.SeedModel(c.Provider, c.Model)
 		}
 	}
-	for _, providerID := range []string{"anthropic", "openai", "deepseek", "ollama"} {
+	for _, providerID := range []string{"anthropic", "openai", "deepseek", "ollama-local"} {
 		r.SetProviderReachable(providerID, true)
 	}
 }
@@ -142,7 +142,7 @@ func TestResolve_FallthroughWhenFirstCandidateStalled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if dec.Provider != "ollama" {
+	if dec.Provider != "ollama-local" {
 		t.Errorf("decision provider = %q, want ollama (fallthrough from stalled deepseek)", dec.Provider)
 	}
 }
@@ -162,7 +162,7 @@ func TestResolve_FallthroughWhenProviderUnreachable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
-	if dec.Provider != "ollama" {
+	if dec.Provider != "ollama-local" {
 		t.Errorf("decision provider = %q, want ollama (fallthrough from unreachable deepseek)", dec.Provider)
 	}
 }
@@ -245,7 +245,7 @@ func TestResolve_TierUnavailableWhenNoProviderReachable(t *testing.T) {
 	priority, tiers := fixtureLibrary()
 	r := NewResolver(priority, tiers)
 	seedAll(t, r, tiers)
-	for _, p := range []string{"anthropic", "openai", "deepseek", "ollama"} {
+	for _, p := range []string{"anthropic", "openai", "deepseek", "ollama-local"} {
 		r.SetProviderReachable(p, false)
 	}
 
@@ -377,7 +377,7 @@ func TestSetExcluded_SkipsProviderInResolution(t *testing.T) {
 	}
 	// DeepSeek is library priority's first choice for low tier;
 	// with it excluded, resolver should fall through to Ollama.
-	if dec.Provider != "ollama" {
+	if dec.Provider != "ollama-local" {
 		t.Errorf("decision provider = %q, want ollama (fallthrough from excluded deepseek)", dec.Provider)
 	}
 }
@@ -467,10 +467,10 @@ func TestSnapshot_IsACopy(t *testing.T) {
 func freeTierOverlay() *UserTierOverlay {
 	return &UserTierOverlay{
 		Name:             "free",
-		ProviderPriority: []string{"gemini", "ollama"},
+		ProviderPriority: []string{"gemini", "ollama-local"},
 		Tiers: map[string][]Candidate{
-			"low":    {{Provider: "gemini", Model: "gemini-2.0-flash"}, {Provider: "ollama", Model: "llama-local"}},
-			"middle": {{Provider: "gemini", Model: "gemini-2.0-flash"}, {Provider: "ollama", Model: "llama-local"}},
+			"low":    {{Provider: "gemini", Model: "gemini-2.0-flash"}, {Provider: "ollama-local", Model: "llama-local"}},
+			"middle": {{Provider: "gemini", Model: "gemini-2.0-flash"}, {Provider: "ollama-local", Model: "llama-local"}},
 			"high":   {{Provider: "gemini", Model: "gemini-2.5-pro"}},
 		},
 		FallbackOnError: false, // free tier doesn't cascade — cost cap
@@ -504,7 +504,7 @@ func TestResolve_UserTierOverlay_UsesUserTierPriorityWhenAgentHasNone(t *testing
 	overlay := freeTierOverlay()
 	overlay.Tiers["low"] = []Candidate{
 		{Provider: "gemini", Model: "gemini-2.0-flash"},
-		{Provider: "ollama", Model: "llama-local"},
+		{Provider: "ollama-local", Model: "llama-local"},
 	}
 	dec, err := r.Resolve(AgentRequest{
 		Name:     "any-agent",
@@ -655,5 +655,50 @@ func TestResolve_UserTierOverlay_TierFallthroughToLibrary(t *testing.T) {
 	// include anthropic (claude-opus-4-7). Resolver should pick it.
 	if dec.Provider != "anthropic" {
 		t.Errorf("Decision.Provider = %q; want anthropic (library tier filtered through user_tier priority)", dec.Provider)
+	}
+}
+
+// TestResolve_OllamaLocalAndOllamaAreDistinct pins the v0.8.3 split:
+// the resolver treats "ollama" (hosted) and "ollama-local" (local)
+// as independent priority slots. Mark hosted ollama stalled; the
+// resolver must walk on to the next slot — not silently substitute
+// the local registration just because both share the same driver
+// internally.
+func TestResolve_OllamaLocalAndOllamaAreDistinct(t *testing.T) {
+	priority := []string{"ollama", "ollama-local", "anthropic"}
+	tiers := map[string][]Candidate{
+		"low": {
+			{Provider: "ollama", Model: "kimi-k2.6"},       // hosted-only
+			{Provider: "ollama-local", Model: "gemma4:9b"}, // local-only
+			{Provider: "anthropic", Model: "claude-haiku-4-5"},
+		},
+	}
+	r := NewResolver(priority, tiers)
+	r.SeedModel("ollama", "kimi-k2.6")
+	r.SeedModel("ollama-local", "gemma4:9b")
+	r.SeedModel("anthropic", "claude-haiku-4-5")
+	r.SetProviderReachable("ollama", true)
+	r.SetProviderReachable("ollama-local", true)
+	r.SetProviderReachable("anthropic", true)
+
+	// First resolution: hosted is healthy → resolver picks it.
+	dec, err := r.Resolve(AgentRequest{Name: "any", Tier: "low"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if dec.Provider != "ollama" || dec.Model != "kimi-k2.6" {
+		t.Errorf("first resolve = %+v; want ollama/kimi-k2.6", dec)
+	}
+
+	// Mark hosted's model stalled — resolver should walk past it to
+	// the local registration. If the two ids were conflated the
+	// resolver would either return the same decision or skip BOTH.
+	r.MarkStalled("ollama", "kimi-k2.6", "503")
+	dec, err = r.Resolve(AgentRequest{Name: "any", Tier: "low"})
+	if err != nil {
+		t.Fatalf("Resolve after stall: %v", err)
+	}
+	if dec.Provider != "ollama-local" || dec.Model != "gemma4:9b" {
+		t.Errorf("post-stall resolve = %+v; want ollama-local/gemma4:9b (proves the two are distinct)", dec)
 	}
 }

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -35,24 +35,28 @@
 # and skipped; the next periodic probe revives them. PR 1 ships a
 # stub probe — providers are reachable iff their API key is set.
 provider_priority:
+  - ollama-local   # workstation GPU — absolute floor when present
   - deepseek
-  - ollama
   - openai
   - anthropic
+  - ollama         # hosted ollama.com — opt-in via OLLAMA_API_KEY
 
 tiers:
   low:
-    - { provider: deepseek,  model: deepseek-v4-flash }
-    - { provider: ollama,    model: gemma4:9b }
-    - { provider: openai,    model: gpt-5.4-mini }
-    - { provider: anthropic, model: claude-haiku-4-5 }
+    - { provider: deepseek,     model: deepseek-v4-flash }
+    - { provider: ollama-local, model: gemma4:9b }
+    - { provider: openai,       model: gpt-5.4-mini }
+    - { provider: anthropic,    model: claude-haiku-4-5 }
   middle:
-    - { provider: deepseek,  model: deepseek-v4-pro }
-    - { provider: ollama,    model: qwen3.6:27b }
-    - { provider: openai,    model: gpt-5.4 }
-    - { provider: anthropic, model: claude-sonnet-4-6 }
+    - { provider: deepseek,     model: deepseek-v4-pro }
+    - { provider: ollama-local, model: qwen3.6:27b }
+    - { provider: openai,       model: gpt-5.4 }
+    - { provider: anthropic,    model: claude-sonnet-4-6 }
   high:
     # DeepSeek absent — V4 Pro doesn't compete with Opus 4.7 / GPT-5.5.
+    # ollama-local typically can't host 600B+ kimi-k2.6 either; the
+    # `ollama` (hosted) entry covers that case for operators with a
+    # paid quota.
     - { provider: ollama,    model: kimi-k2.6 }
     - { provider: openai,    model: gpt-5.5 }
     - { provider: anthropic, model: claude-opus-4-7 }
@@ -90,7 +94,7 @@ user_tiers:
   # Same shape as the library defaults above so v0.7.x clients see no
   # behaviour change.
   default:
-    provider_priority: [deepseek, ollama, openai, anthropic]
+    provider_priority: [ollama-local, deepseek, openai, anthropic, ollama]
     # Tier-bodies (low/middle/high) omitted = inherit from library
     # `tiers:` above. Override only when this user-tier needs a
     # different candidate list than the library default.
@@ -98,15 +102,17 @@ user_tiers:
     max_fallback_attempts: 3
 
   # Free tier: cost cap — only the no-paid-key providers, no climb on
-  # 429 (would defeat the point). `fallback_on_error: false` means a
-  # 429 surfaces immediately to the client; the client can then offer
-  # an upgrade prompt.
+  # 429 (would defeat the point). ollama-local (workstation GPU, no
+  # auth) is the right shape here: no quota to exhaust, no surprise
+  # bills. `fallback_on_error: false` means an Ollama outage surfaces
+  # immediately to the client; the client can then offer an upgrade
+  # prompt.
   free:
-    provider_priority: [ollama]
+    provider_priority: [ollama-local]
     tiers:
-      low:    [{provider: ollama, model: gemma4:9b}]
-      middle: [{provider: ollama, model: qwen3.6:27b}]
-      high:   [{provider: ollama, model: qwen3.6:27b}]
+      low:    [{provider: ollama-local, model: gemma4:9b}]
+      middle: [{provider: ollama-local, model: qwen3.6:27b}]
+      high:   [{provider: ollama-local, model: qwen3.6:27b}]
     fallback_on_error: false
 
   # Low tier: cost-floor-first with one paid backstop. DeepSeek's free
@@ -151,7 +157,7 @@ models:
   best:   { provider: anthropic, model: claude-opus-4-7 }
   gpt:    { provider: openai,    model: gpt-4o-mini }
   gpt-4:  { provider: openai,    model: gpt-4o }
-  local:  { provider: ollama,    model: llama3.1:8b }     # tool-tuned model
+  local:  { provider: ollama-local, model: llama3.1:8b }  # tool-tuned model on workstation
 
 # ─── Agents ───────────────────────────────────────────────────────────
 # Each agent is addressed by name in POST /v1/runs's "agent" field.


### PR DESCRIPTION
## Summary

- Splits the single `ollama` provider registration into two: `ollama` (hosted ollama.com, Bearer auth via `OLLAMA_API_KEY`) and `ollama-local` (local-network, no auth, `OLLAMA_BASE_URL`).
- Same `/api/chat` wire shape → one driver package serves both; the constructor now takes `providerID` + `apiKey` and threads them through `ID()`, the rate-limit Config, the non-2xx error formatter, and the optional Bearer header.
- Existing deploys keep working unchanged: their `OLLAMA_BASE_URL=http://localhost:11434` now feeds `ollama-local` (no setting needs to change). Only yaml files that referenced `provider: ollama` for an actual local backend need to rename to `provider: ollama-local`.
- Targets **v0.8.3** — the v0.8.x roadmap shifts again (Channel → v0.8.4, LoomHelp → v0.8.5, LoomCycle MCP → v0.8.6). Roadmap-docs PR follows on merge.

## Why

The single `ollama` id conflated two very different operational shapes:

- **Local workstation GPU** — no auth, no quota to exhaust, treated as the absolute cost floor in resolver priority.
- **Hosted ollama.com** — Bearer auth, paid quota, behaves like Anthropic/OpenAI for `user_tier` policy purposes.

Operators couldn't express "use my workstation when it's healthy, fall through to the paid cloud" because both wore the same id. The split makes that routing intent expressible in yaml.

## Changes

### Driver (`internal/providers/ollama/driver.go`)
- `New(providerID, apiKey, baseURL, opts, client)`; empty `providerID` → `"ollama"` for back-compat.
- `Bearer` header set on `/api/chat` AND `/api/tags` (probe) when `apiKey != ""`.
- Non-2xx error message uses `providerID` so v0.8.2's classifier (anchored on `"<name> <code>:"`) works for both ids — `ollama-local 503: ...` matches the existing regex.
- 3 new tests pin the per-id behaviour:
  - `TestDriver_ID_RespectsConstructorArg`
  - `TestDriver_AuthHeaderEmittedOnlyWhenKeySet`
  - `TestDriver_NonOKErrorUsesProviderID`

### Config (`internal/config/config.go`)
- New `Env.OllamaAPIKey` (`OLLAMA_API_KEY`) + `Env.OllamaCloudBaseURL` (`OLLAMA_CLOUD_BASE_URL`, defaults `https://ollama.com`).
- Existing `Env.OllamaBaseURL` (`OLLAMA_BASE_URL`) unchanged — default still `http://localhost:11434`, still drives `ollama-local`.
- `validProviderIDs` accepts both `"ollama"` and `"ollama-local"`.

### main.go (`cmd/loomcycle/main.go`)
- `providerResolver` gains `ollamaLocal` alongside `ollama`.
- `newProviderResolver` wires both independently.
- `Get("ollama-local")` returns the local registration; `Get("ollama")`'s error message now points operators with a localhost URL to the new id.
- `runResolveProbeOnce` splits the single ollama probe job into two with distinct `exclReason` text so `/v1/_resolver` tells operators which env var is missing.

### Resolver (`internal/resolve/matrix.go`)
- `defaultLibraryPriority` becomes `[ollama-local, deepseek, openai, anthropic, ollama]`: workstation at the floor (no quota), hosted ollama after the paid clouds so operators who haven't set `OLLAMA_API_KEY` get a clean "not configured" error rather than silent traversal.
- New `TestResolve_OllamaLocalAndOllamaAreDistinct` pins that the matrix treats the two ids as independent slots — stalling one doesn't mask the other.
- Existing tests' fixture swapped `ollama` → `ollama-local` (the test models `gemma4:9b` / `qwen3.6:27b` / `kimi-k2.6` are all local-shape; mechanical rewrite preserves test intent).

### Yaml + env + architecture docs
- `loomcycle.example.yaml`: library `tiers:` candidates split between `ollama-local` (low/middle) and `ollama` (high — kimi-k2.6 can't fit on a workstation). `provider_priority` reordered. `user_tiers.default` + `user_tiers.free` use `ollama-local`. Model alias `local:` now uses `ollama-local`.
- `.env.example`: documents the split with a `Why` block explaining the back-compat semantic.
- `docs/ARCHITECTURE.md`: provider table gains an `ollama-local` row; the `ollama` row updates to "hosted, Bearer auth"; effort-translation row notes both registrations share the same driver.

### Latent cleanup
- `internal/loop/fallback_test.go` had stale gofmt drift from PR #53's `FallbackPolicy` field addition (alignment). Cleared in this PR alongside the other gofmt-touched files — same shape as PR #51.

## Back-compat

| Deployment shape | Action required |
|---|---|
| Local-only Ollama on `localhost:11434` | None. `OLLAMA_BASE_URL` keeps its meaning; the provider id flips from `ollama` to `ollama-local` in any operator yaml that explicitly named it. |
| `provider: ollama` in agent yaml pointing at local | Rename to `provider: ollama-local`. The old shape errors clearly at resolve time when `OLLAMA_API_KEY` is unset (no silent breakage). |
| Hosted ollama.com user | Set `OLLAMA_API_KEY=...` and use `provider: ollama`. Optional `OLLAMA_CLOUD_BASE_URL` for vendor mirrors. |
| Mixed local + hosted | Both vars set; both providers registered; agents pick either id explicitly or let the library priority queue try them in order. |

## Test plan

- [x] `go test ./...` clean.
- [x] `gofmt -l` clean.
- [x] Binary builds clean; `--help` loads.
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the example yaml.
- [ ] Manual smoke: boot with both env vars set; confirm `/v1/_resolver` reports both `ollama` and `ollama-local` with distinct `excluded`/`reachable` state; run a sample agent against each.
- [ ] Maintainer eyeball pass on the rename impact for jobs-search-agent's local-ollama agents (separate-repo follow-up if any reference `provider: ollama` pointing at the workstation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)