### PR TITLE
test(channels): runtime smoke test + test/runtime/<feature>/ pattern

### DIFF
--- a/test/runtime/README.md
+++ b/test/runtime/README.md
@@ -1,0 +1,38 @@
+# Runtime tests
+
+Per-feature end-to-end smoke tests that drive a real loomcycle binary against a real LLM provider through the HTTP+SSE wire. Distinct from the Go unit tests under `internal/` — those validate the code; these validate the wire.
+
+Each subdirectory under `test/runtime/<feature>/` is one self-contained scenario:
+
+```
+test/runtime/<feature>/
+├── agents/<name>.md      # one MD per agent (frontmatter + body)
+├── loomcycle.yaml        # operator config for THIS test
+└── run.sh                # driver — builds the binary, boots it, drives the runs, inspects
+```
+
+## Conventions
+
+- **Self-contained.** Each `run.sh` builds the binary, opens a fresh sqlite DB under `$(mktemp -d)`, boots loomcycle on a non-default port, and tears down on exit. No collisions with a running production loomcycle on the same host.
+- **Boot log + SSE streams kept on disk** at the printed `$TEST_DIR` path so failures are debuggable without re-running.
+- **Verdict is the last thing printed** — `PASS ✓` or `FAIL ✗`. Scripts exit non-zero on failure.
+- **Env vars sourced from the operator's shell.** Scripts don't read `.env.local` themselves; the operator runs `set -a; source .env.local; set +a; ./run.sh`. Keeps secrets out of any tracked file.
+- **Agents are MD-discovered** (the v0.8.1 `LOOMCYCLE_AGENTS_ROOT` mechanism). The yaml file declares operator-owned state (channels, MCP servers, user_tiers, …) but never the agents themselves — agents are the test's data.
+
+## Current scenarios
+
+| Feature | Scenario |
+|---|---|
+| `channels/` | Two-agent canonical handoff: researcher publishes 3 findings to a user-scoped queue; analyst subscribes and produces a structured report. Verifies the Channel tool's publish/subscribe/auto-ack path through real DeepSeek tool calls. |
+
+Future scenarios (one folder per primitive):
+
+- `memory/` — set/get/incr round-trip across two runs of the same agent
+- `user-tier/` — runtime fallback on a 429 from the primary provider in a tier's candidate list
+- `agent-def/` (v0.8.5) — fork → spawn → retire lifecycle
+- `evaluation/` (v0.8.5) — sibling-emitter evaluation of a forked variant
+- `context/` (v0.8.6) — introspection rollup against an agent with the full primitive surface
+
+## When to add a runtime test
+
+Anything that's hard to fake with httptest fakes — provider tool-call quirks, multi-run cursor/state interactions, ACL gating against a real model that may try to bypass it, sub-agent ctx inheritance under real spawn paths. Unit tests should still cover everything they can; these scripts cover what the unit tests can't.

--- a/test/runtime/channels/agents/analyst.md
+++ b/test/runtime/channels/agents/analyst.md
@@ -1,0 +1,29 @@
+---
+name: analyst
+description: Drains the `findings` channel and summarises what it sees. v0.8.4 Channel-tool runtime smoke-test agent.
+provider: deepseek
+model: deepseek-v4-pro
+allowed_tools: [Channel]
+channels:
+  publish: []
+  subscribe: [findings]
+---
+You are an analyst agent. Your job is to drain the `findings` channel
+and report what was published.
+
+Call the `Channel` tool exactly once with `op=subscribe`,
+`channel=findings`, and `max_messages=10`. The tool returns a JSON
+object with a `messages` array — each entry has an `id`, a `value`
+(the finding), and a `published_at` timestamp.
+
+After the subscribe call, write a single concise plaintext report:
+
+  - First line: "ANALYST REPORT".
+  - One bullet per message, formatted as `- <topic>: <note>` using the
+    `topic` and `note` fields from the message's `value`.
+  - Final line: "TOTAL: <count>" where <count> is the number of
+    messages received.
+
+If `messages` is empty, write only `ANALYST REPORT` and `TOTAL: 0`.
+Do not subscribe again. Do not call any other tool. End your response
+with the single word DONE.

--- a/test/runtime/channels/agents/researcher.md
+++ b/test/runtime/channels/agents/researcher.md
@@ -1,0 +1,33 @@
+---
+name: researcher
+description: Publishes structured findings to the `findings` channel. v0.8.4 Channel-tool runtime smoke-test agent.
+provider: deepseek
+model: deepseek-v4-pro
+allowed_tools: [Channel]
+channels:
+  publish: [findings]
+  subscribe: []
+---
+You are a research agent. Your job is to publish exactly three short
+findings about the city of Tokyo to the `findings` channel and then
+stop.
+
+Use the `Channel` tool with `op=publish` and `channel=findings`. The
+`value` field must be a JSON object with two keys: `topic` (a short
+string like "population") and `note` (one sentence). Example:
+
+```
+{
+  "op": "publish",
+  "channel": "findings",
+  "value": {
+    "topic": "population",
+    "note": "Tokyo metropolitan area has roughly 37 million residents."
+  }
+}
+```
+
+Pick three distinct topics (e.g. population, geography, transport),
+publish one finding for each topic, then end your response with the
+single word DONE so the caller knows you're finished. Do not call any
+other tool. Do not publish more than three findings.

--- a/test/runtime/channels/loomcycle.yaml
+++ b/test/runtime/channels/loomcycle.yaml
@@ -1,0 +1,42 @@
+# test/runtime/channels/loomcycle.yaml — v0.8.4 Channel-tool runtime smoke test.
+#
+# Two test agents (./agents/{researcher,analyst}.md) talking through a
+# user-scoped `findings` channel. See ./run.sh for the driver.
+#
+# Provider: deepseek. Set DEEPSEEK_API_KEY in your shell (or source
+# .env.local) before invoking the driver.
+
+# DeepSeek-only provider routing. Other agents not declared here
+# resolve through cfg.Defaults below.
+provider_priority: [deepseek]
+
+defaults:
+  provider: deepseek
+  model: deepseek-v4-pro
+
+# ─── Channels (v0.8.4) ──────────────────────────────────────────────
+# One user-scoped queue. user-scope means cursor_id = user_id, so the
+# researcher's writes and the analyst's reads share the same row set
+# when both runs carry the same user_id on the HTTP request body.
+channels:
+  findings:
+    scope: user
+    default_ttl: 3600       # 1 hour
+    max_messages: 100
+    semantic: queue
+
+# ─── Agents from MD discovery ──────────────────────────────────────
+# run.sh sets LOOMCYCLE_AGENTS_ROOT to ./agents/ (alongside this
+# file). No yaml `agents:` block — agents come purely from the MD
+# frontmatter under that directory.
+
+# ─── Storage ───────────────────────────────────────────────────────
+# Local sqlite, isolated path so the test doesn't touch any existing
+# data dir.
+storage:
+  backend: sqlite
+
+# ─── Concurrency ───────────────────────────────────────────────────
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8

--- a/test/runtime/channels/run.sh
+++ b/test/runtime/channels/run.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# test/runtime/channels/run.sh — v0.8.4 Channel-tool runtime smoke test.
+#
+# Boots loomcycle with the two test agents in this directory's
+# `agents/` subdir, declares a user-scoped `findings` queue via the
+# colocated `loomcycle.yaml`, drives one researcher run (publishes
+# 3 findings) followed by one analyst run (drains + reports), and
+# inspects the resulting sqlite tables.
+#
+# This is the FIRST of a growing family of per-tool runtime tests
+# under `test/runtime/<feature>/`. The pattern:
+#   - `agents/<name>.md` per agent (frontmatter + body)
+#   - `loomcycle.yaml`  per-test operator config (channels, MCP, etc.)
+#   - `run.sh`          driver — builds, boots, drives, inspects
+#
+# Usage (run from anywhere; the script self-roots to repo root):
+#   DEEPSEEK_API_KEY=... ./test/runtime/channels/run.sh
+# OR (if .env.local has the key):
+#   set -a; source .env.local; set +a; ./test/runtime/channels/run.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+# ─── Test isolation ─────────────────────────────────────────────────
+# Fresh data dir + token + port so this test never collides with a
+# running production loomcycle. /tmp prefix is auto-cleaned on reboot.
+TEST_DIR="$(mktemp -d -t loomcycle-channels-test.XXXXXX)"
+trap 'cleanup' EXIT INT TERM
+
+cleanup() {
+  if [[ -n "${LOOMCYCLE_PID:-}" ]]; then
+    kill "$LOOMCYCLE_PID" 2>/dev/null || true
+    wait "$LOOMCYCLE_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "Test dir kept for inspection: $TEST_DIR"
+}
+
+export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
+export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18787"
+export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
+# Forward whatever DEEPSEEK_API_KEY the operator has in their shell.
+if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
+  echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first:" >&2
+  echo "  set -a; source .env.local; set +a" >&2
+  exit 1
+fi
+
+mkdir -p "$TEST_DIR/data"
+BOOT_LOG="$TEST_DIR/boot.log"
+RESEARCHER_SSE="$TEST_DIR/researcher.sse"
+ANALYST_SSE="$TEST_DIR/analyst.sse"
+
+# ─── 1. Build fresh binary ──────────────────────────────────────────
+echo "[1/6] Building bin/loomcycle..."
+go build -o bin/loomcycle ./cmd/loomcycle
+
+# ─── 2. Boot loomcycle in background ────────────────────────────────
+echo "[2/6] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loomcycle.yaml)..."
+./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
+LOOMCYCLE_PID=$!
+
+# Wait up to 10 s for /healthz to respond.
+for i in $(seq 1 50); do
+  if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
+    echo "      ready after ~$((i * 200))ms"
+    break
+  fi
+  if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
+    echo "ERROR: loomcycle exited during boot. Boot log:" >&2
+    cat "$BOOT_LOG" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+# ─── 3. Surface the boot log lines that matter ──────────────────────
+echo "[3/6] Boot-log highlights (channels + agents):"
+grep -E "channels:|agents:|skills:" "$BOOT_LOG" | sed 's/^/      /'
+echo
+
+# ─── 4. Run the researcher ──────────────────────────────────────────
+USER_ID="test-user-channels"
+echo "[4/6] Running researcher (publishes 3 findings)..."
+curl -fsS -N \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF > "$RESEARCHER_SSE"
+{
+  "agent": "researcher",
+  "user_id": "$USER_ID",
+  "segments": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "trusted-text", "text": "Publish your three Tokyo findings now."}
+      ]
+    }
+  ]
+}
+EOF
+
+# Quick summary of what happened on the researcher's side.
+echo "      Researcher SSE event types:"
+grep -E "^event:" "$RESEARCHER_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# ─── 5. Run the analyst ─────────────────────────────────────────────
+echo "[5/6] Running analyst (drains + reports)..."
+curl -fsS -N \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF > "$ANALYST_SSE"
+{
+  "agent": "analyst",
+  "user_id": "$USER_ID",
+  "segments": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "trusted-text", "text": "Drain the findings channel and report."}
+      ]
+    }
+  ]
+}
+EOF
+
+echo "      Analyst SSE event types:"
+grep -E "^event:" "$ANALYST_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# ─── 6. Inspect storage ─────────────────────────────────────────────
+DB="$TEST_DIR/data/loomcycle.db"
+echo "[6/6] Storage inspection ($DB):"
+if [[ -f "$DB" ]]; then
+  echo "      channel_messages rows:"
+  sqlite3 "$DB" "SELECT id, channel, scope, scope_id, length(payload) AS payload_bytes, published_at FROM channel_messages ORDER BY id;" | sed 's/^/        /'
+  echo "      channel_cursors rows:"
+  sqlite3 "$DB" "SELECT channel, scope, scope_id, cursor, updated_at FROM channel_cursors;" | sed 's/^/        /'
+  echo "      runs rows:"
+  sqlite3 "$DB" "SELECT id, session_id, status, stop_reason, model FROM runs ORDER BY started_at;" | sed 's/^/        /'
+else
+  echo "      WARNING: $DB not found"
+fi
+
+# ─── Final report ───────────────────────────────────────────────────
+echo
+echo "── Researcher's final text output ────────────────────────────────"
+# Extract `text` deltas from the SSE stream. The shape is:
+#   event: text
+#   data: {"text":"..."}
+grep -A1 '^event: text$' "$RESEARCHER_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" || true
+echo
+echo
+echo "── Analyst's final text output ───────────────────────────────────"
+grep -A1 '^event: text$' "$ANALYST_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" || true
+echo
+echo
+echo "── Verdict ───────────────────────────────────────────────────────"
+PUBLISHED=$(sqlite3 "$DB" "SELECT COUNT(*) FROM channel_messages WHERE channel='findings';" 2>/dev/null || echo 0)
+CURSORS=$(sqlite3 "$DB" "SELECT COUNT(*) FROM channel_cursors WHERE channel='findings';" 2>/dev/null || echo 0)
+echo "  channel_messages count: $PUBLISHED (expect 3)"
+echo "  channel_cursors count:  $CURSORS (expect 1 — analyst's committed cursor)"
+if [[ "$PUBLISHED" == "3" && "$CURSORS" == "1" ]]; then
+  echo "  PASS ✓"
+  exit 0
+else
+  echo "  FAIL ✗ — see $TEST_DIR for full logs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds the **first end-to-end runtime smoke test** for the v0.8.4 Channel tool — drives a real `bin/loomcycle` against real DeepSeek over HTTP+SSE, verifies the storage end state in sqlite, prints PASS/FAIL.
- Establishes **`test/runtime/<feature>/`** as the convention for per-tool runtime tests going forward. Future framework primitives (Memory live-flow, user_tier failover, v0.8.5 AgentDef + Evaluation, v0.8.6 Context) each get a sibling folder with the same shape: `agents/` MDs + `loomcycle.yaml` + `run.sh`.
- `test/runtime/README.md` documents the convention + the queue of future scenarios.

## Why a separate runtime test layer

Go unit tests under `internal/` validate the **code**; these scripts validate the **wire**. They exercise the parts of the system unit tests deliberately can't:

- Provider tool-call quirks against actual LLMs (DeepSeek, Anthropic, …).
- Multi-run cursor / state interactions across separate `POST /v1/runs` calls.
- ACL gates against a model that may try to bypass them.
- Sub-agent ctx inheritance under real spawn paths.

A Go in-process test would have to fake either the HTTP layer or the LLM driver — exactly what this test layer is for.

## Layout

```
test/runtime/
├── README.md
└── channels/                       # the v0.8.4 scenario
    ├── agents/researcher.md        # frontmatter wires Channel + channels.publish=[findings]
    ├── agents/analyst.md           # frontmatter wires Channel + channels.subscribe=[findings]
    ├── loomcycle.yaml              # declares the `findings` user-scoped queue
    └── run.sh                      # build → boot → drive → inspect → PASS/FAIL
```

The driver is self-contained:

1. Builds `bin/loomcycle` from current source.
2. Spins up an isolated instance — fresh `DATA_DIR` under `$(mktemp -d)`, random `AUTH_TOKEN`, non-default port 18787.
3. Surfaces the boot log lines that matter (agents-discovered count, channels-configured line, sweeper interval).
4. POSTs two `/v1/runs` back-to-back: researcher publishes 3 findings, analyst drains + reports.
5. Inspects `channel_messages` + `channel_cursors` directly via sqlite3.
6. Prints both agents' final text + PASS/FAIL.

## Verified PASS

Boot log → 2 agents discovered, 1 channel configured, sweeper at 15m. Researcher emits 3 `tool_call` + 3 `tool_result` events and "DONE". Analyst's single `subscribe` returns all 3, the structured report is correct, `channel_messages` has 3 rows, `channel_cursors` shows the auto-commit advanced to the last delivered id.

Observed message IDs also confirm the `msg_<16-hex unixNanos><8-hex rand>` format: 3 publishes within ~110 µs, lex-order matches publish-order.

## Why DeepSeek for the test provider

Cheap, fast on tool calls, **provider-agnosticism check** (DeepSeek wraps the OpenAI driver, so a passing test transitively validates the OpenAI tool-use path too). Anthropic Haiku works equally well; operators with different keys swap two lines in the agent MDs.

## Why MD-discovered agents (not yaml-declared)

The test exercises the v0.8.1 `LOOMCYCLE_AGENTS_ROOT` mechanism on top of the v0.8.4 Channel ACL — two primitives validated in one test for free.

## Why bash + curl

Mirrors how real consumers (`jobs-search-agent`, the TS adapter) talk to loomcycle. No new test framework dependencies; just `go build` + `curl` + `sqlite3` + `python3` for the SSE delta extractor.

## Future scenarios (next folders)

| Folder | Scenario |
|---|---|
| `memory/` | set/get/incr round-trip across two runs of the same agent |
| `user-tier/` | Runtime fallback on a 429 from the primary provider in a tier's candidate list |
| `agent-def/` (v0.8.5) | fork → spawn → retire lifecycle |
| `evaluation/` (v0.8.5) | sibling-emitter evaluation of a forked variant |
| `context/` (v0.8.6) | introspection rollup against an agent with the full primitive surface |

## Test plan

- [x] Driver script runs cleanly against current main (`feature-channel-tool` merged).
- [x] PASS verdict observed on a real DeepSeek-backed run.
- [x] No tracked file references `.env.local` contents.
- [x] Test isolation verified — runs on port 18787 with its own DATA_DIR; doesn't touch any existing loomcycle instance.
- [ ] Operator eyeball pass on the `test/runtime/<feature>/` convention before we adopt it for the next primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)