### PR TITLE
test(memory): runtime smoke test — cross-run state persistence

### DIFF
--- a/test/runtime/memory/agents/memorybot.md
+++ b/test/runtime/memory/agents/memorybot.md
@@ -1,0 +1,36 @@
+---
+name: memorybot
+description: Two-run Memory smoke test agent. Writes on the first call, reads on the second.
+provider: deepseek
+model: deepseek-v4-pro
+allowed_tools: [Memory]
+memory_scopes: [agent, user]
+---
+You are memorybot. You execute Memory operations the user describes,
+nothing else. Three rules:
+
+1. The user's message names operations. Each operation maps 1:1 to a
+   single `Memory` tool call. Do exactly what's named — no extra
+   reads, no extra writes.
+
+2. Use the `Memory` tool with the discriminated `op` field. Examples
+   below — note that `value` is a BARE JSON value (string, number,
+   etc.), NOT a string containing JSON. Pass `"value": "purple"`,
+   never `"value": "\"purple\""` (no double-encoding).
+
+   ```
+   {"op":"set","scope":"user","key":"favorite_color","value":"purple"}
+   {"op":"set","scope":"agent","key":"counter","value":0}
+   {"op":"get","scope":"user","key":"favorite_color"}
+   {"op":"incr","scope":"agent","key":"run_count","delta":1}
+   ```
+
+3. After ALL named operations complete, write a one-line plaintext
+   summary. For `set`: confirm the write (e.g. "wrote favorite_color"). For
+   `get`: include the returned value verbatim in your summary (e.g.
+   "favorite_color = purple"). For `incr`: include the returned number
+   verbatim (e.g. "run_count = 2"). End the summary with the single
+   word DONE.
+
+Do not call any tool other than Memory. Do not invent operations
+the user didn't ask for. Do not skip operations the user did ask for.

--- a/test/runtime/memory/loomcycle.yaml
+++ b/test/runtime/memory/loomcycle.yaml
@@ -1,0 +1,31 @@
+# test/runtime/memory/loomcycle.yaml — v0.8.0 Memory-tool runtime smoke test.
+#
+# One test agent (./agents/memorybot.md) called twice over the same
+# loomcycle instance + sqlite DB. Run 1 writes; run 2 reads. State
+# is expected to persist across the run boundary — that's the whole
+# point of Memory.
+#
+# Provider: deepseek. Set DEEPSEEK_API_KEY in your shell (or source
+# .env.local) before invoking the driver.
+
+provider_priority: [deepseek]
+
+defaults:
+  provider: deepseek
+  model: deepseek-v4-pro
+
+# ─── Agents from MD discovery ──────────────────────────────────────
+# run.sh sets LOOMCYCLE_AGENTS_ROOT to ./agents/ (alongside this
+# file). No yaml `agents:` block — the agent comes purely from the
+# MD frontmatter.
+
+# ─── Storage ───────────────────────────────────────────────────────
+# Local sqlite, isolated path so this test doesn't touch any
+# existing data dir.
+storage:
+  backend: sqlite
+
+# ─── Concurrency ───────────────────────────────────────────────────
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8

--- a/test/runtime/memory/run.sh
+++ b/test/runtime/memory/run.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# test/runtime/memory/run.sh — v0.8.0 Memory-tool runtime smoke test.
+#
+# One agent (./agents/memorybot.md) called twice on the same
+# loomcycle instance + sqlite DB. Run 1 writes a user-scope fact +
+# an agent-scope counter (incr). Run 2 reads them back and bumps
+# the counter again. State persistence across the run boundary —
+# the core promise of Memory — is what this validates against the
+# real wire.
+#
+# Same `test/runtime/<feature>/` convention as channels/.
+#
+# Usage:
+#   DEEPSEEK_API_KEY=... ./test/runtime/memory/run.sh
+# OR:
+#   set -a; source .env.local; set +a; ./test/runtime/memory/run.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-memory-test.XXXXXX)"
+trap 'cleanup' EXIT INT TERM
+
+cleanup() {
+  if [[ -n "${LOOMCYCLE_PID:-}" ]]; then
+    kill "$LOOMCYCLE_PID" 2>/dev/null || true
+    wait "$LOOMCYCLE_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "Test dir kept for inspection: $TEST_DIR"
+}
+
+export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
+export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18788"   # +1 vs channels test
+export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
+if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
+  echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first:" >&2
+  echo "  set -a; source .env.local; set +a" >&2
+  exit 1
+fi
+
+mkdir -p "$TEST_DIR/data"
+BOOT_LOG="$TEST_DIR/boot.log"
+RUN1_SSE="$TEST_DIR/run1.sse"
+RUN2_SSE="$TEST_DIR/run2.sse"
+USER_ID="test-user-memory"
+
+# ─── 1. Build fresh binary ──────────────────────────────────────────
+echo "[1/6] Building bin/loomcycle..."
+go build -o bin/loomcycle ./cmd/loomcycle
+
+# ─── 2. Boot loomcycle in background ────────────────────────────────
+echo "[2/6] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loomcycle.yaml)..."
+./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
+LOOMCYCLE_PID=$!
+
+for i in $(seq 1 50); do
+  if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
+    echo "      ready after ~$((i * 200))ms"
+    break
+  fi
+  if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
+    echo "ERROR: loomcycle exited during boot. Boot log:" >&2
+    cat "$BOOT_LOG" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+echo "[3/6] Boot-log highlights:"
+grep -E "memory:|agents:|skills:" "$BOOT_LOG" | sed 's/^/      /'
+echo
+
+# Helper: POST one /v1/runs with a user prompt; capture SSE to a file.
+post_run() {
+  local out_path="$1" prompt="$2"
+  curl -fsS -N \
+    -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" \
+    -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF > "$out_path"
+{
+  "agent": "memorybot",
+  "user_id": "$USER_ID",
+  "segments": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "trusted-text", "text": "$prompt"}
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# ─── 4. Run 1 — write phase ────────────────────────────────────────
+echo "[4/6] Running memorybot (run 1: write phase)..."
+post_run "$RUN1_SSE" "Do these three Memory operations in order. (1) set scope=user key=favorite_color value=purple. (2) set scope=agent key=state value=started. (3) incr scope=agent key=run_count delta=1."
+
+echo "      Run 1 SSE event types:"
+grep -E "^event:" "$RUN1_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# ─── 5. Run 2 — read phase ─────────────────────────────────────────
+echo "[5/6] Running memorybot (run 2: read phase)..."
+post_run "$RUN2_SSE" "Do these three Memory operations in order. (1) get scope=user key=favorite_color. (2) get scope=agent key=state. (3) incr scope=agent key=run_count delta=1."
+
+echo "      Run 2 SSE event types:"
+grep -E "^event:" "$RUN2_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# ─── 6. Storage inspection ─────────────────────────────────────────
+DB="$TEST_DIR/data/loomcycle.db"
+echo "[6/6] Storage inspection ($DB):"
+if [[ -f "$DB" ]]; then
+  echo "      memory rows:"
+  sqlite3 "$DB" "SELECT scope, scope_id, key, value, expires_at FROM memory ORDER BY scope, key;" | sed 's/^/        /'
+  echo "      runs rows:"
+  sqlite3 "$DB" "SELECT id, session_id, status, stop_reason, model FROM runs ORDER BY started_at;" | sed 's/^/        /'
+else
+  echo "      WARNING: $DB not found"
+fi
+
+# ─── Final report ──────────────────────────────────────────────────
+echo
+echo "── Run 1 final text ──────────────────────────────────────────────"
+grep -A1 '^event: text$' "$RUN1_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" || true
+echo
+echo
+echo "── Run 2 final text ──────────────────────────────────────────────"
+grep -A1 '^event: text$' "$RUN2_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" || true
+echo
+
+# ─── Verdict ───────────────────────────────────────────────────────
+# Expected final state in the memory table:
+#   user / test-user-memory / favorite_color = "purple"
+#   agent / memorybot / state                 = "started"
+#   agent / memorybot / run_count             = 2
+#
+# Plus: run 2's text output must mention "purple" AND "started" (proof
+# the agent SAW the persisted state — not just that the rows happen
+# to be there).
+echo
+echo "── Verdict ───────────────────────────────────────────────────────"
+PURPLE_VALUE=$(sqlite3 "$DB" "SELECT value FROM memory WHERE scope='user' AND key='favorite_color';" 2>/dev/null || echo "")
+STATE_VALUE=$(sqlite3 "$DB" "SELECT value FROM memory WHERE scope='agent' AND key='state';" 2>/dev/null || echo "")
+COUNTER_VALUE=$(sqlite3 "$DB" "SELECT value FROM memory WHERE scope='agent' AND key='run_count';" 2>/dev/null || echo "")
+RUN2_TEXT=$(grep -A1 '^event: text$' "$RUN2_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" 2>/dev/null)
+
+# Memory values are JSON-encoded; recursively json.loads until we
+# hit a non-string. This handles BOTH the canonical single-encoded
+# shape (Memory.set called with value: "purple" → stored bytes
+# "purple") AND the double-encoded shape some models emit (value:
+# "\"purple\"" → stored bytes "\"purple\""). Either is acceptable
+# storage end state — the agent saw the value and acted on it.
+unwrap_json_value() {
+  echo "$1" | python3 -c "
+import sys, json
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.exit(0)
+v = raw
+# Decode at most 3 times to bound runaway loops on malformed input.
+for _ in range(3):
+    try:
+        decoded = json.loads(v)
+    except Exception:
+        break
+    if isinstance(decoded, str):
+        v = decoded
+        continue
+    v = decoded
+    break
+print(v if isinstance(v, str) else json.dumps(v))
+"
+}
+
+PASS=true
+PURPLE_DECODED=$(unwrap_json_value "$PURPLE_VALUE")
+STATE_DECODED=$(unwrap_json_value "$STATE_VALUE")
+echo "  memory.user.favorite_color    = $PURPLE_VALUE  → decoded: $PURPLE_DECODED  (expect: purple)"
+[[ "$PURPLE_DECODED" == "purple" ]] || PASS=false
+echo "  memory.agent.state            = $STATE_VALUE  → decoded: $STATE_DECODED  (expect: started)"
+[[ "$STATE_DECODED" == "started" ]] || PASS=false
+echo "  memory.agent.run_count        = $COUNTER_VALUE (expect 2)"
+[[ "$COUNTER_VALUE" == "2" ]] || PASS=false
+
+echo "  run 2 text mentions 'purple'  → $(echo "$RUN2_TEXT" | grep -qi 'purple'  && echo yes || { echo no; PASS=false; })"
+echo "  run 2 text mentions 'started' → $(echo "$RUN2_TEXT" | grep -qi 'started' && echo yes || { echo no; PASS=false; })"
+
+if $PASS; then
+  echo "  PASS ✓"
+  exit 0
+else
+  echo "  FAIL ✗ — see $TEST_DIR for full logs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds the **second** scenario under `test/runtime/<feature>/` (after PR #58's `channels/`): one agent called twice across two `POST /v1/runs` boundaries, validating the v0.8.0 Memory tool's core promise — state persists across runs and the atomic counter survives.
- Same self-contained driver pattern as channels: fresh `DATA_DIR`, random `AUTH_TOKEN`, non-default port (18788), agents MD-discovered. Different port from channels so both tests can run side-by-side without collision.

## What it pins

Run 1 (write phase):
- `set scope=user key=favorite_color value=purple`
- `set scope=agent key=state value=started`
- `incr scope=agent key=run_count delta=1` → returns 1

Run 2 (read phase) — same agent name, same `user_id`, separate HTTP request:
- `get scope=user key=favorite_color` → must return `purple` (cross-run user-scope read)
- `get scope=agent key=state` → must return `started` (cross-run agent-scope read)
- `incr scope=agent key=run_count delta=1` → must return **2** (atomic counter monotonic across runs)

Verifier checks:
- The three memory rows have the expected decoded values.
- Run 2's text output mentions both `purple` AND `started` verbatim — proves the agent **saw** the persisted state, not just that the rows happen to be in the DB.

## Verdict on a real DeepSeek-backed run

```
memory.user.favorite_color    = "purple"  → decoded: purple
memory.agent.state            = "started"  → decoded: started
memory.agent.run_count        = 2
run 2 text mentions 'purple'  → yes
run 2 text mentions 'started' → yes
PASS ✓
```

## Verifier robustness — recursive JSON decode

A subtle finding from the first run: DeepSeek sometimes **double-encodes** string values (passing `"value": "\"purple\""` instead of `"value": "purple"`), which the Memory tool faithfully stores. The agent's system prompt now warns against this explicitly, but the verifier degrades gracefully — it `json.loads` the stored value up to three times until it hits a non-string. Either encoding shape is acceptable storage end-state; the agent still saw the value and acted on it.

## Why two HTTP requests vs one

The whole point of Memory is state across runs. A single-run test would only exercise the in-memory ctx-attach path. Two separate `POST /v1/runs` calls force the path through:

1. Run 1: `Server.handleRuns` → `WithMemoryPolicy(loopCtx, ...)` → Memory.Execute → `Store.MemorySet`
2. Storage commit, run finishes, ctx torn down
3. Run 2: fresh ctx, fresh `WithMemoryPolicy(loopCtx, ...)` for the SAME agent name → `Store.MemoryGet` → returns prior value

The agent_name scope_id resolution is the load-bearing piece — `tools.AgentName(ctx)` must return `memorybot` for both runs so the rows under `(scope=agent, scope_id=memorybot)` are visible to both.

## Layout

```
test/runtime/memory/
├── agents/memorybot.md   # Memory tool + memory_scopes: [agent, user]
├── loomcycle.yaml        # provider routing only — no channels block
└── run.sh                # boots once, drives 2 runs, inspects, verdict
```

## Relation to PR #58

This PR sits in a new sibling directory (`test/runtime/memory/`) — no overlap with PR #58 (`test/runtime/channels/`). When #58 merges, this PR rebases cleanly. The `test/runtime/README.md` (introduced in #58) already lists `memory/` as a planned scenario — this PR satisfies that entry.

## Test plan

- [x] Driver runs against current main (PR #58 branch not yet merged; this branch is off the latest main commit).
- [x] PASS verdict on a real DeepSeek run.
- [x] No `.env.local` reads in the script itself; operator sources before invoking.
- [x] Isolated port (18788) — can run concurrently with the channels test on 18787.
- [ ] Operator eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)