### PR TITLE
test(user-tier): runtime smoke test — resolve-time tier-walk past stalled candidate

### DIFF
--- a/test/runtime/channels/run.sh
+++ b/test/runtime/channels/run.sh
@@ -49,6 +49,14 @@ if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
   echo "  set -a; source .env.local; set +a" >&2
   exit 1
 fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required for SSE delta extraction." >&2
+  exit 1
+fi
+if ! command -v sqlite3 &>/dev/null; then
+  echo "ERROR: sqlite3 CLI is required for storage inspection." >&2
+  exit 1
+fi
 
 mkdir -p "$TEST_DIR/data"
 BOOT_LOG="$TEST_DIR/boot.log"
@@ -65,9 +73,11 @@ echo "[2/6] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loo
 LOOMCYCLE_PID=$!
 
 # Wait up to 10 s for /healthz to respond.
+READY=0
 for i in $(seq 1 50); do
   if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
     echo "      ready after ~$((i * 200))ms"
+    READY=1
     break
   fi
   if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
@@ -77,6 +87,14 @@ for i in $(seq 1 50); do
   fi
   sleep 0.2
 done
+
+if [[ "$READY" != "1" ]]; then
+  # Boot taking longer than 10 s (cold-start probes on a slow
+  # network). Fail loudly so the cause is visible.
+  echo "ERROR: loomcycle did not become ready within ~10 s. Boot log so far:" >&2
+  cat "$BOOT_LOG" >&2
+  exit 1
+fi
 
 # ─── 3. Surface the boot log lines that matter ──────────────────────
 echo "[3/6] Boot-log highlights (channels + agents):"

--- a/test/runtime/memory/run.sh
+++ b/test/runtime/memory/run.sh
@@ -42,6 +42,14 @@ if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
   echo "  set -a; source .env.local; set +a" >&2
   exit 1
 fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required for SSE delta extraction." >&2
+  exit 1
+fi
+if ! command -v sqlite3 &>/dev/null; then
+  echo "ERROR: sqlite3 CLI is required for storage inspection." >&2
+  exit 1
+fi
 
 mkdir -p "$TEST_DIR/data"
 BOOT_LOG="$TEST_DIR/boot.log"
@@ -58,9 +66,11 @@ echo "[2/6] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loo
 ./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
 LOOMCYCLE_PID=$!
 
+READY=0
 for i in $(seq 1 50); do
   if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
     echo "      ready after ~$((i * 200))ms"
+    READY=1
     break
   fi
   if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
@@ -70,6 +80,14 @@ for i in $(seq 1 50); do
   fi
   sleep 0.2
 done
+
+if [[ "$READY" != "1" ]]; then
+  # Boot taking longer than 10 s (cold-start probes on a slow
+  # network). Fail loudly so the cause is visible.
+  echo "ERROR: loomcycle did not become ready within ~10 s. Boot log so far:" >&2
+  cat "$BOOT_LOG" >&2
+  exit 1
+fi
 
 echo "[3/6] Boot-log highlights:"
 grep -E "memory:|agents:|skills:" "$BOOT_LOG" | sed 's/^/      /'

--- a/test/runtime/user-tier/agents/greeter.md
+++ b/test/runtime/user-tier/agents/greeter.md
@@ -1,0 +1,10 @@
+---
+name: greeter
+description: One-turn greeter for the v0.8.2 user_tier runtime-fallback test. No tools.
+allowed_tools: []
+---
+You are a greeter. When the user sends any message, reply with the
+single sentence "Hello from the fallback provider." and stop.
+
+Do not call any tools. Do not produce more than one sentence. Always
+end your reply with the exact word "DONE" on a new line.

--- a/test/runtime/user-tier/loomcycle.yaml
+++ b/test/runtime/user-tier/loomcycle.yaml
@@ -1,0 +1,69 @@
+# test/runtime/user-tier/loomcycle.yaml — v0.8.2 user_tier runtime-fallback test.
+#
+# Drives a run with `user_tier: low` whose primary provider (deepseek)
+# is forced to fail at the network layer (DEEPSEEK_BASE_URL points at
+# an unreachable address — see run.sh). The v0.8.2 fallback path
+# kicks in, swaps to anthropic, and the run completes against the
+# fallback provider.
+#
+# Validates:
+#   - error classifier marks a network-refused error as Retryable
+#   - loop calls ReResolve via the user_tier candidate list
+#   - resolver picks the next provider (anthropic) and dispatches
+#   - SSE stream surfaces event: provider_fallback with FallbackInfo
+#   - run.user_tier marker persists
+#
+# Requires DEEPSEEK_API_KEY (any non-empty value — the unreachable URL
+# means auth is never tried) AND ANTHROPIC_API_KEY. run.sh exits
+# cleanly with a clear message if either is missing.
+
+# Both providers configured so the resolver can dispatch to either.
+provider_priority: [deepseek, anthropic]
+
+# ─── User tiers (v0.8.2) ────────────────────────────────────────────
+# `low` is the tier the test driver passes on POST /v1/runs. Primary
+# is deepseek (broken URL → fails); fallback is anthropic (real).
+# fallback_on_error: true is the gate — without it the broken-primary
+# error propagates straight to the client and no switch happens.
+user_tiers:
+  default:
+    # Used only by runs that don't carry a user_tier. Mirrors `low`
+    # so this config is interpretable for ad-hoc curl calls.
+    provider_priority: [deepseek, anthropic]
+    tiers:
+      low:
+        - { provider: deepseek,  model: deepseek-v4-pro }
+        - { provider: anthropic, model: claude-haiku-4-5-20251001 }
+    fallback_on_error: true
+    max_fallback_attempts: 3
+
+  low:
+    provider_priority: [deepseek, anthropic]
+    tiers:
+      low:
+        - { provider: deepseek,  model: deepseek-v4-pro }
+        - { provider: anthropic, model: claude-haiku-4-5-20251001 }
+    fallback_on_error: true
+    max_fallback_attempts: 3
+
+# ─── Agents from MD discovery ──────────────────────────────────────
+# run.sh sets LOOMCYCLE_AGENTS_ROOT to ./agents/. The single test
+# agent (greeter.md) declares tier: low and no provider pin — so
+# resolution walks the candidate list above.
+
+# Inject tier: low on the agent via the yaml override layer.
+# The MD itself stays provider-agnostic so this yaml is the only
+# place the tier dependency lives.
+agents:
+  greeter:
+    tier: low
+    effort: low
+
+# ─── Storage ───────────────────────────────────────────────────────
+storage:
+  backend: sqlite
+
+# ─── Concurrency ───────────────────────────────────────────────────
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8

--- a/test/runtime/user-tier/loomcycle.yaml
+++ b/test/runtime/user-tier/loomcycle.yaml
@@ -1,17 +1,26 @@
-# test/runtime/user-tier/loomcycle.yaml — v0.8.2 user_tier runtime-fallback test.
+# test/runtime/user-tier/loomcycle.yaml — v0.8.2 user_tier resolve-time
+# tier-walk test.
 #
 # Drives a run with `user_tier: low` whose primary provider (deepseek)
-# is forced to fail at the network layer (DEEPSEEK_BASE_URL points at
-# an unreachable address — see run.sh). The v0.8.2 fallback path
-# kicks in, swaps to anthropic, and the run completes against the
-# fallback provider.
+# is unreachable (DEEPSEEK_BASE_URL points at port 1 — see run.sh).
+# Boot probe marks deepseek unreachable in the matrix; at run-start,
+# the resolver walks the tier's candidate list, skips deepseek, and
+# dispatches to the next candidate (anthropic). Run completes
+# against the fallback provider.
 #
 # Validates:
-#   - error classifier marks a network-refused error as Retryable
-#   - loop calls ReResolve via the user_tier candidate list
-#   - resolver picks the next provider (anthropic) and dispatches
-#   - SSE stream surfaces event: provider_fallback with FallbackInfo
-#   - run.user_tier marker persists
+#   - boot probe marks deepseek unreachable
+#   - resolver walks the user_tier candidate list and skips stalled
+#     candidates at resolve-time
+#   - run dispatches to the next candidate (claude-haiku-4-5-20251001)
+#   - runs.user_tier marker persists for cost retros and compliance
+#
+# Does NOT validate the mid-run fallback path (v0.8.2 PR #53 — error
+# classifier + ReResolve from inside the loop after a 5xx mid-call).
+# That path is unit-tested in internal/loop/fallback_test.go.
+# Exercising it from a runtime test would require a fake HTTP server
+# that probes 200 on /v1/models but 503 on /v1/chat/completions —
+# out of scope for this smoke. See run.sh's docstring for details.
 #
 # Requires DEEPSEEK_API_KEY (any non-empty value — the unreachable URL
 # means auth is never tried) AND ANTHROPIC_API_KEY. run.sh exits

--- a/test/runtime/user-tier/run.sh
+++ b/test/runtime/user-tier/run.sh
@@ -67,6 +67,15 @@ if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
   echo "  AND ANTHROPIC_API_KEY (fallback, must succeed)." >&2
   exit 1
 fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required for SSE delta extraction." >&2
+  echo "  Install python3 or add to PATH." >&2
+  exit 1
+fi
+if ! command -v sqlite3 &>/dev/null; then
+  echo "ERROR: sqlite3 CLI is required for storage inspection." >&2
+  exit 1
+fi
 
 export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
 export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
@@ -100,9 +109,11 @@ echo "      DEEPSEEK_BASE_URL=$DEEPSEEK_BASE_URL  (deliberately unreachable)"
 ./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
 LOOMCYCLE_PID=$!
 
+READY=0
 for i in $(seq 1 50); do
   if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
     echo "      ready after ~$((i * 200))ms"
+    READY=1
     break
   fi
   if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
@@ -112,6 +123,18 @@ for i in $(seq 1 50); do
   fi
   sleep 0.2
 done
+
+if [[ "$READY" != "1" ]]; then
+  # Falling through the readiness loop without the curl ever
+  # succeeding AND without the process dying means loomcycle is
+  # still booting (cold-start probes are real network calls; on a
+  # slow connection they can exceed 10 s). Fail loudly so a
+  # contributor sees the actual cause instead of an opaque
+  # ECONNREFUSED later in the script.
+  echo "ERROR: loomcycle did not become ready within ~10 s. Boot log so far:" >&2
+  cat "$BOOT_LOG" >&2
+  exit 1
+fi
 
 echo "[3/5] Boot-log highlights:"
 grep -E "user_tiers:|agents:|providers" "$BOOT_LOG" | sed 's/^/      /' || true
@@ -173,9 +196,15 @@ echo
 echo "── Verdict ───────────────────────────────────────────────────────"
 PASS=true
 
-# Check 1: boot probe marked deepseek unreachable (this is the
+# Check 1: boot probe marked deepseek UNREACHABLE (this is the
 # precondition for the tier walk to skip it at run-start).
-PROBE_LINE=$(grep -E "resolve probe: deepseek (unreachable|excluded)" "$BOOT_LOG" | head -1)
+#
+# Match only "unreachable", NOT "excluded". The two come from
+# different code paths: "unreachable" = probe attempted but failed
+# (the path we're verifying); "excluded" = operator opted out at
+# config time (a different scenario this test isn't designed to
+# cover). Matching both would silently accept the wrong failure mode.
+PROBE_LINE=$(grep -E "resolve probe: deepseek unreachable" "$BOOT_LOG" | head -1)
 echo "  Probe marked deepseek bad:      $(if [[ -n "$PROBE_LINE" ]]; then echo "yes"; else echo "no"; PASS=false; fi)"
 if [[ -n "$PROBE_LINE" ]]; then
   echo "    └─ $PROBE_LINE"

--- a/test/runtime/user-tier/run.sh
+++ b/test/runtime/user-tier/run.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# test/runtime/user-tier/run.sh — v0.8.2 user_tier resolve-time
+# tier-walk smoke test.
+#
+# Drives one /v1/runs with user_tier=low. The tier's candidate list
+# is [deepseek, anthropic]. DEEPSEEK_BASE_URL is overridden to
+# http://127.0.0.1:1, so:
+#
+#   1. At boot, the resolver probes /v1/models on each provider.
+#      The deepseek probe fails with `connect: connection refused`
+#      → matrix marks deepseek unreachable.
+#   2. At run-start, the resolver walks the user_tier's candidate
+#      list. deepseek is skipped (unreachable in matrix); anthropic
+#      is healthy → resolver returns claude-haiku-4-5-20251001.
+#   3. The run completes against the fallback provider.
+#
+# This validates the RESOLVE-TIME tier-walk path of v0.8.2: the
+# user_tier overlay correctly walks past stalled candidates and
+# picks the next healthy one. The runs.user_tier marker persists
+# for cost retros and compliance.
+#
+# Note: the MID-RUN fallback path (v0.8.2 PR #53 — error
+# classifier + ReResolve from inside the loop) is exercised by the
+# Go unit tests in internal/loop/fallback_test.go. Exercising it
+# from a runtime test would require a fake HTTP server that probes
+# 200 on /v1/models but 503 on /v1/chat/completions — out of scope
+# for this smoke (the boot-probe path is the simpler shape that
+# operators actually hit).
+#
+# Same `test/runtime/<feature>/` convention as channels/ and memory/.
+#
+# Usage:
+#   DEEPSEEK_API_KEY=... ANTHROPIC_API_KEY=... ./test/runtime/user-tier/run.sh
+# OR:
+#   set -a; source .env.local; set +a; ./test/runtime/user-tier/run.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-user-tier-test.XXXXXX)"
+trap 'cleanup' EXIT INT TERM
+
+cleanup() {
+  if [[ -n "${LOOMCYCLE_PID:-}" ]]; then
+    kill "$LOOMCYCLE_PID" 2>/dev/null || true
+    wait "$LOOMCYCLE_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "Test dir kept for inspection: $TEST_DIR"
+}
+
+# ─── Env requirements ───────────────────────────────────────────────
+# Need BOTH keys: DeepSeek for the primary registration (the
+# unreachable URL means auth is never tried, but the registration
+# check is DEEPSEEK_API_KEY != ""), Anthropic for the fallback to
+# actually succeed.
+if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
+  echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first." >&2
+  exit 1
+fi
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+  echo "ERROR: ANTHROPIC_API_KEY not set — required for the fallback step." >&2
+  echo "  This test needs BOTH DEEPSEEK_API_KEY (primary, will fail by design)" >&2
+  echo "  AND ANTHROPIC_API_KEY (fallback, must succeed)." >&2
+  exit 1
+fi
+
+export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
+export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18789"   # +1 vs memory test
+export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
+
+# THE KEY KNOB. Point the DeepSeek driver at an unreachable address.
+# Port 1 is reserved + nothing listens on it on macOS or Linux by
+# default, so the dial fails immediately with ECONNREFUSED.
+# v0.8.2's errclass classifies wrapped net.OpError as Retryable →
+# fallback fires.
+export DEEPSEEK_BASE_URL="http://127.0.0.1:1"
+
+# Shorten the per-stream header timeout so the deepseek call fails
+# quickly (the connect attempt itself is sub-millisecond on the
+# loopback, but make sure we don't sit idle).
+export LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=5000
+
+mkdir -p "$TEST_DIR/data"
+BOOT_LOG="$TEST_DIR/boot.log"
+RUN_SSE="$TEST_DIR/run.sse"
+USER_ID="test-user-fallback"
+
+# ─── 1. Build fresh binary ──────────────────────────────────────────
+echo "[1/5] Building bin/loomcycle..."
+go build -o bin/loomcycle ./cmd/loomcycle
+
+# ─── 2. Boot loomcycle ──────────────────────────────────────────────
+echo "[2/5] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loomcycle.yaml)..."
+echo "      DEEPSEEK_BASE_URL=$DEEPSEEK_BASE_URL  (deliberately unreachable)"
+./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
+LOOMCYCLE_PID=$!
+
+for i in $(seq 1 50); do
+  if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
+    echo "      ready after ~$((i * 200))ms"
+    break
+  fi
+  if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
+    echo "ERROR: loomcycle exited during boot. Boot log:" >&2
+    cat "$BOOT_LOG" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+echo "[3/5] Boot-log highlights:"
+grep -E "user_tiers:|agents:|providers" "$BOOT_LOG" | sed 's/^/      /' || true
+echo
+
+# ─── 4. Drive a single run with user_tier=low ──────────────────────
+echo "[4/5] Running greeter with user_tier=low (primary deepseek fails → fallback to anthropic)..."
+# Drop `-f` (no auto-bail on 4xx/5xx) so the response body lands in
+# RUN_SSE for inspection even on error. Capture status separately.
+RUN_HTTP_STATUS=$(curl -sS -N -w '%{http_code}' -o "$RUN_SSE" \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF
+{
+  "agent": "greeter",
+  "user_id": "$USER_ID",
+  "user_tier": "low",
+  "segments": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "trusted-text", "text": "say hello"}
+      ]
+    }
+  ]
+}
+EOF
+)
+echo "      HTTP status: $RUN_HTTP_STATUS"
+if [[ "$RUN_HTTP_STATUS" != "200" ]]; then
+  echo "      Response body:"
+  head -50 "$RUN_SSE" | sed 's/^/        /'
+fi
+
+echo "      Run SSE event types:"
+grep -E "^event:" "$RUN_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# ─── 5. Verdict ────────────────────────────────────────────────────
+DB="$TEST_DIR/data/loomcycle.db"
+echo "[5/5] Storage inspection ($DB):"
+if [[ -f "$DB" ]]; then
+  echo "      runs rows (note: user_tier marker, model = fallback provider):"
+  sqlite3 "$DB" "SELECT id, status, stop_reason, model, user_tier FROM runs ORDER BY started_at;" | sed 's/^/        /'
+else
+  echo "      WARNING: $DB not found"
+fi
+
+echo
+echo "── Run final text ────────────────────────────────────────────────"
+grep -A1 '^event: text$' "$RUN_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" || true
+echo
+
+echo
+echo "── Verdict ───────────────────────────────────────────────────────"
+PASS=true
+
+# Check 1: boot probe marked deepseek unreachable (this is the
+# precondition for the tier walk to skip it at run-start).
+PROBE_LINE=$(grep -E "resolve probe: deepseek (unreachable|excluded)" "$BOOT_LOG" | head -1)
+echo "  Probe marked deepseek bad:      $(if [[ -n "$PROBE_LINE" ]]; then echo "yes"; else echo "no"; PASS=false; fi)"
+if [[ -n "$PROBE_LINE" ]]; then
+  echo "    └─ $PROBE_LINE"
+fi
+
+# Check 2: run completed (not failed/cancelled).
+RUN_STATUS=$(sqlite3 "$DB" "SELECT status FROM runs;" 2>/dev/null | head -1)
+RUN_MODEL=$(sqlite3 "$DB" "SELECT model FROM runs;" 2>/dev/null | head -1)
+RUN_TIER=$(sqlite3 "$DB" "SELECT user_tier FROM runs;" 2>/dev/null | head -1)
+echo "  Run status:                     $RUN_STATUS (expect completed)"
+[[ "$RUN_STATUS" == "completed" ]] || PASS=false
+
+# Check 3: model used = fallback target = claude-haiku-4-5-20251001
+# (the tier's SECOND candidate, picked after deepseek was skipped).
+echo "  Run model (= fallback target):  $RUN_MODEL (expect claude-haiku-4-5-20251001)"
+[[ "$RUN_MODEL" == "claude-haiku-4-5-20251001" ]] || PASS=false
+
+# Check 4: runs.user_tier marker stamped (v0.8.2 audit column).
+echo "  Run user_tier marker:           $RUN_TIER (expect low)"
+[[ "$RUN_TIER" == "low" ]] || PASS=false
+
+# Check 5: final text contains "Hello" — proves the fallback provider
+# actually executed, not just that it was resolved.
+FINAL_TEXT=$(grep -A1 '^event: text$' "$RUN_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" 2>/dev/null)
+if echo "$FINAL_TEXT" | grep -qi 'hello'; then
+  echo "  Final text contains 'Hello':    yes"
+else
+  echo "  Final text contains 'Hello':    no"
+  PASS=false
+fi
+
+if $PASS; then
+  echo "  PASS ✓"
+  exit 0
+else
+  echo "  FAIL ✗ — see $TEST_DIR for full logs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- **Third runtime-test scenario** under `test/runtime/<feature>/` (after channels + memory). Validates the v0.8.2 user_tier overlay's resolve-time tier-walk: when the primary provider in a tier's candidate list is unreachable at boot probe, the resolver skips it at run-start and dispatches to the next candidate.
- Establishes that **`runs.user_tier` persists** for cost-retro / compliance queries — the v0.8.2 PR #52 audit-marker column working under real wire conditions.

## Test shape

- **Agent** (`greeter.md`): no tools, tier: low. Replies with a fixed greeting + DONE.
- **Yaml** (`loomcycle.yaml`): user_tier `low` declared with candidates `[deepseek, anthropic]`. Both providers registered (DEEPSEEK_API_KEY for the registration check, ANTHROPIC_API_KEY for the fallback to succeed).
- **The trick**: `DEEPSEEK_BASE_URL=http://127.0.0.1:1` (port 1, definitively unreachable). The boot probe gets `connect: connection refused` → matrix marks deepseek unreachable → subsequent runs skip it cleanly.

## Verified PASS

```
Boot-log highlights:
  resolve probe: deepseek unreachable (...dial tcp 127.0.0.1:1: connect: connection refused)
  user_tiers: configured 2 — default / low
  agents: discovered ... 1

Run SSE event types:
  2 event: text
  1 event: usage / started / session / done / agent

Storage:
  runs row: completed | end_turn | claude-haiku-4-5-20251001 | low

Verdict:
  Probe marked deepseek bad:      yes
  Run status:                     completed
  Run model (= fallback target):  claude-haiku-4-5-20251001
  Run user_tier marker:           low
  Final text contains 'Hello':    yes
  PASS ✓
```

## What this validates (and what it doesn't)

**Validates** — the v0.8.2 resolve-time tier-walk path:
1. Boot probe correctly marks the broken primary unreachable.
2. Resolver walks the user_tier's candidate list and skips stalled candidates.
3. Run dispatches to the second candidate (anthropic / claude-haiku-4-5-20251001).
4. `runs.user_tier` persists for cost-retro / compliance queries.
5. The fallback provider actually executes (not just that it was resolved).

**Doesn't validate** — the mid-run fallback path (v0.8.2 PR #53): error classifier + `ReResolve` from inside the loop after a 5xx mid-call. That path is unit-tested extensively in `internal/loop/fallback_test.go` (9 cases covering retryable / permanent / cancel / deadline / regression / cumulative budget). Exercising it from a runtime test would require a fake HTTP server that probes 200 on `/v1/models` but 503 on `/v1/chat/completions` — a real test fixture out of scope for this smoke. The boot-probe path is the simpler shape that operators actually hit when a provider is genuinely down.

## Requirements

Both keys must be set in the operator's shell before running:

- `DEEPSEEK_API_KEY` — any non-empty value. The unreachable URL means auth is never tried, but the registration check is `DEEPSEEK_API_KEY != ""`.
- `ANTHROPIC_API_KEY` — the fallback target. The run must succeed against this provider.

Driver exits cleanly with a clear message if either is missing.

## Layout

```
test/runtime/user-tier/
├── agents/greeter.md       # tier: low, allowed_tools: []
├── loomcycle.yaml          # user_tier `low` = [deepseek, anthropic]
└── run.sh                  # self-contained driver
```

Mirrors `channels/` + `memory/`. Different port (18789) so all three runtime tests can run side-by-side without collision.

## Test plan

- [x] PASS verdict on a real boot-probe-marks-stalled + run-against-fallback scenario.
- [x] Both keys required; clear error when either is missing.
- [x] Different port (18789) — no collision with channels (18787) or memory (18788).
- [x] `runs.user_tier` audit column persists correctly.
- [ ] Operator eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)