### PR TITLE
fix(gemini): sanitize tool schemas + propagate ToolName on tool_result + runtime tests on Gemini

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -719,9 +719,15 @@ func executePendingTools(
 		})
 		// Place by index so the message we hand back to the model
 		// stays in tool_call order regardless of finish order.
+		// ToolName is set for the benefit of providers that
+		// correlate tool_use ↔ tool_result by NAME rather than by
+		// id — Gemini's functionResponse and Ollama's tool messages
+		// both require the name. Anthropic / OpenAI / DeepSeek use
+		// the id only and ignore the redundant name field.
 		results[r.idx] = providers.ContentBlock{
 			Type:      "tool_result",
 			ToolUseID: r.tu.ID,
+			ToolName:  r.tu.Name,
 			Text:      r.res.Text,
 			IsError:   r.res.IsError,
 		}

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -253,7 +253,7 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 			decls = append(decls, wireFunctionDecl{
 				Name:        t.Name,
 				Description: t.Description,
-				Parameters:  t.InputSchema,
+				Parameters:  sanitizeGeminiSchema(t.InputSchema),
 			})
 		}
 		w.Tools = []wireTool{{FunctionDeclarations: decls}}
@@ -580,4 +580,60 @@ func (d *Driver) fetchModels(ctx context.Context) ([]string, error) {
 		}
 	}
 	return out, nil
+}
+
+// sanitizeGeminiSchema strips JSON-Schema fields that Gemini's
+// function_declarations.parameters does not accept. Gemini takes
+// an OpenAPI-3.0 subset; full JSON Schema features like
+// additionalProperties, $schema, $ref, oneOf, anyOf, etc. produce
+// a 400 INVALID_ARGUMENT.
+//
+// The Channel and Memory built-in tools both ship schemas with
+// `"additionalProperties": false` (a JSON Schema best-practice
+// that's silently accepted by Anthropic / OpenAI / DeepSeek /
+// Ollama drivers). The other built-in tools don't use it today
+// but might in the future. This helper makes the Gemini driver
+// tolerant of any tool schema that happens to use the rejected
+// fields — operators don't have to know which tools are
+// Gemini-compatible.
+//
+// Best-effort: on parse failure (malformed schema), returns the
+// original bytes so Gemini surfaces a clear 400 rather than the
+// driver swallowing the problem.
+func sanitizeGeminiSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var parsed any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return raw
+	}
+	stripGeminiUnsupported(parsed)
+	out, err := json.Marshal(parsed)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// stripGeminiUnsupported walks a parsed JSON value and removes
+// the field names Gemini rejects. Recurses into nested objects
+// (e.g., properties.*.additionalProperties on nested schemas)
+// and arrays (e.g., enum value validation lists).
+func stripGeminiUnsupported(node any) {
+	switch n := node.(type) {
+	case map[string]any:
+		// The vocabulary Gemini doesn't accept. Add more here if
+		// future tool schemas trip the API.
+		delete(n, "additionalProperties")
+		delete(n, "$schema")
+		delete(n, "$id")
+		for _, v := range n {
+			stripGeminiUnsupported(v)
+		}
+	case []any:
+		for _, item := range n {
+			stripGeminiUnsupported(item)
+		}
+	}
 }

--- a/internal/providers/gemini/driver_test.go
+++ b/internal/providers/gemini/driver_test.go
@@ -339,3 +339,74 @@ func TestProbe_PropagatesError(t *testing.T) {
 		t.Fatal("Probe with 401 didn't surface an error")
 	}
 }
+
+// TestSanitizeGeminiSchema_StripsAdditionalProperties pins the v0.8.4
+// follow-up fix: Gemini's function_declarations.parameters rejects
+// JSON Schema's additionalProperties (and $schema / $id). The Channel
+// + Memory built-in tools both ship schemas with these fields, which
+// every other driver (Anthropic / OpenAI / DeepSeek / Ollama)
+// accepts silently. Without the sanitizer, every tool call against
+// Gemini returns 400 INVALID_ARGUMENT.
+func TestSanitizeGeminiSchema_StripsAdditionalProperties(t *testing.T) {
+	in := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"op":{"type":"string","enum":["get","set"]},
+			"value":{"type":"object","additionalProperties":false}
+		},
+		"required":["op"],
+		"additionalProperties":false,
+		"$schema":"https://json-schema.org/draft/2020-12/schema",
+		"$id":"channel-input"
+	}`)
+	got := sanitizeGeminiSchema(in)
+	gotStr := string(got)
+
+	// All three offending fields must be stripped from both the
+	// root schema AND any nested object schema. Without recursion,
+	// the inner "value.additionalProperties" would survive and the
+	// API still rejects.
+	if strings.Contains(gotStr, "additionalProperties") {
+		t.Errorf("additionalProperties not stripped: %s", gotStr)
+	}
+	if strings.Contains(gotStr, "$schema") {
+		t.Errorf("$schema not stripped: %s", gotStr)
+	}
+	if strings.Contains(gotStr, "$id") {
+		t.Errorf("$id not stripped: %s", gotStr)
+	}
+	// Allowed fields must survive.
+	if !strings.Contains(gotStr, `"properties"`) {
+		t.Errorf("properties missing from sanitized output: %s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"required"`) {
+		t.Errorf("required missing from sanitized output: %s", gotStr)
+	}
+	if !strings.Contains(gotStr, `"enum"`) {
+		t.Errorf("enum missing from sanitized output: %s", gotStr)
+	}
+}
+
+// TestSanitizeGeminiSchema_PreservesOnMalformedInput pins the best-
+// effort contract: if the schema is somehow malformed JSON (shouldn't
+// happen at runtime since the loop builds it from validated tool
+// specs), the sanitizer returns the input verbatim so Gemini surfaces
+// a clear 400 rather than the driver silently swallowing the problem.
+func TestSanitizeGeminiSchema_PreservesOnMalformedInput(t *testing.T) {
+	in := json.RawMessage(`not json`)
+	got := sanitizeGeminiSchema(in)
+	if string(got) != "not json" {
+		t.Errorf("malformed input not preserved: got %q", string(got))
+	}
+}
+
+// TestSanitizeGeminiSchema_EmptyInputPassthrough — zero-length
+// schemas (rare; would mean a tool with no parameters) pass through
+// unchanged.
+func TestSanitizeGeminiSchema_EmptyInputPassthrough(t *testing.T) {
+	in := json.RawMessage(``)
+	got := sanitizeGeminiSchema(in)
+	if len(got) != 0 {
+		t.Errorf("empty input not preserved: got %d bytes", len(got))
+	}
+}

--- a/test/runtime/channels/agents/analyst.md
+++ b/test/runtime/channels/agents/analyst.md
@@ -1,8 +1,8 @@
 ---
 name: analyst
 description: Drains the `findings` channel and summarises what it sees. v0.8.4 Channel-tool runtime smoke-test agent.
-provider: deepseek
-model: deepseek-v4-pro
+provider: gemini
+model: gemini-2.5-flash
 allowed_tools: [Channel]
 channels:
   publish: []

--- a/test/runtime/channels/agents/researcher.md
+++ b/test/runtime/channels/agents/researcher.md
@@ -1,8 +1,8 @@
 ---
 name: researcher
 description: Publishes structured findings to the `findings` channel. v0.8.4 Channel-tool runtime smoke-test agent.
-provider: deepseek
-model: deepseek-v4-pro
+provider: gemini
+model: gemini-2.5-flash
 allowed_tools: [Channel]
 channels:
   publish: [findings]

--- a/test/runtime/channels/loomcycle.yaml
+++ b/test/runtime/channels/loomcycle.yaml
@@ -3,16 +3,16 @@
 # Two test agents (./agents/{researcher,analyst}.md) talking through a
 # user-scoped `findings` channel. See ./run.sh for the driver.
 #
-# Provider: deepseek. Set DEEPSEEK_API_KEY in your shell (or source
-# .env.local) before invoking the driver.
+# Provider: gemini (gemini-2.5-flash). Set GEMINI_API_KEY in your
+# shell (or source .env.local) before invoking the driver.
 
-# DeepSeek-only provider routing. Other agents not declared here
+# Gemini-only provider routing. Other agents not declared here
 # resolve through cfg.Defaults below.
-provider_priority: [deepseek]
+provider_priority: [gemini]
 
 defaults:
-  provider: deepseek
-  model: deepseek-v4-pro
+  provider: gemini
+  model: gemini-2.5-flash
 
 # ─── Channels (v0.8.4) ──────────────────────────────────────────────
 # One user-scoped queue. user-scope means cursor_id = user_id, so the

--- a/test/runtime/channels/run.sh
+++ b/test/runtime/channels/run.sh
@@ -43,9 +43,9 @@ export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
 export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
 export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18787"
 export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
-# Forward whatever DEEPSEEK_API_KEY the operator has in their shell.
-if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
-  echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first:" >&2
+# Forward whatever GEMINI_API_KEY the operator has in their shell.
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY not set. Source .env.local first:" >&2
   echo "  set -a; source .env.local; set +a" >&2
   exit 1
 fi

--- a/test/runtime/memory/agents/memorybot.md
+++ b/test/runtime/memory/agents/memorybot.md
@@ -1,8 +1,8 @@
 ---
 name: memorybot
 description: Two-run Memory smoke test agent. Writes on the first call, reads on the second.
-provider: deepseek
-model: deepseek-v4-pro
+provider: gemini
+model: gemini-2.5-flash
 allowed_tools: [Memory]
 memory_scopes: [agent, user]
 ---

--- a/test/runtime/memory/loomcycle.yaml
+++ b/test/runtime/memory/loomcycle.yaml
@@ -5,14 +5,14 @@
 # is expected to persist across the run boundary — that's the whole
 # point of Memory.
 #
-# Provider: deepseek. Set DEEPSEEK_API_KEY in your shell (or source
-# .env.local) before invoking the driver.
+# Provider: gemini (gemini-2.5-flash). Set GEMINI_API_KEY in your
+# shell (or source .env.local) before invoking the driver.
 
-provider_priority: [deepseek]
+provider_priority: [gemini]
 
 defaults:
-  provider: deepseek
-  model: deepseek-v4-pro
+  provider: gemini
+  model: gemini-2.5-flash
 
 # ─── Agents from MD discovery ──────────────────────────────────────
 # run.sh sets LOOMCYCLE_AGENTS_ROOT to ./agents/ (alongside this

--- a/test/runtime/memory/run.sh
+++ b/test/runtime/memory/run.sh
@@ -37,8 +37,8 @@ export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
 export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
 export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18788"   # +1 vs channels test
 export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
-if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
-  echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first:" >&2
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY not set. Source .env.local first:" >&2
   echo "  set -a; source .env.local; set +a" >&2
   exit 1
 fi

--- a/test/runtime/user-tier/loomcycle.yaml
+++ b/test/runtime/user-tier/loomcycle.yaml
@@ -5,14 +5,14 @@
 # is unreachable (DEEPSEEK_BASE_URL points at port 1 — see run.sh).
 # Boot probe marks deepseek unreachable in the matrix; at run-start,
 # the resolver walks the tier's candidate list, skips deepseek, and
-# dispatches to the next candidate (anthropic). Run completes
-# against the fallback provider.
+# dispatches to the next candidate (gemini). Run completes against
+# the fallback provider.
 #
 # Validates:
 #   - boot probe marks deepseek unreachable
 #   - resolver walks the user_tier candidate list and skips stalled
 #     candidates at resolve-time
-#   - run dispatches to the next candidate (claude-haiku-4-5-20251001)
+#   - run dispatches to the next candidate (gemini-2.5-flash)
 #   - runs.user_tier marker persists for cost retros and compliance
 #
 # Does NOT validate the mid-run fallback path (v0.8.2 PR #53 — error
@@ -23,35 +23,35 @@
 # out of scope for this smoke. See run.sh's docstring for details.
 #
 # Requires DEEPSEEK_API_KEY (any non-empty value — the unreachable URL
-# means auth is never tried) AND ANTHROPIC_API_KEY. run.sh exits
+# means auth is never tried) AND GEMINI_API_KEY. run.sh exits
 # cleanly with a clear message if either is missing.
 
 # Both providers configured so the resolver can dispatch to either.
-provider_priority: [deepseek, anthropic]
+provider_priority: [deepseek, gemini]
 
 # ─── User tiers (v0.8.2) ────────────────────────────────────────────
 # `low` is the tier the test driver passes on POST /v1/runs. Primary
-# is deepseek (broken URL → fails); fallback is anthropic (real).
+# is deepseek (broken URL → fails); fallback is gemini (real).
 # fallback_on_error: true is the gate — without it the broken-primary
 # error propagates straight to the client and no switch happens.
 user_tiers:
   default:
     # Used only by runs that don't carry a user_tier. Mirrors `low`
     # so this config is interpretable for ad-hoc curl calls.
-    provider_priority: [deepseek, anthropic]
+    provider_priority: [deepseek, gemini]
     tiers:
       low:
-        - { provider: deepseek,  model: deepseek-v4-pro }
-        - { provider: anthropic, model: claude-haiku-4-5-20251001 }
+        - { provider: deepseek, model: deepseek-v4-pro }
+        - { provider: gemini,   model: gemini-2.5-flash }
     fallback_on_error: true
     max_fallback_attempts: 3
 
   low:
-    provider_priority: [deepseek, anthropic]
+    provider_priority: [deepseek, gemini]
     tiers:
       low:
-        - { provider: deepseek,  model: deepseek-v4-pro }
-        - { provider: anthropic, model: claude-haiku-4-5-20251001 }
+        - { provider: deepseek, model: deepseek-v4-pro }
+        - { provider: gemini,   model: gemini-2.5-flash }
     fallback_on_error: true
     max_fallback_attempts: 3
 

--- a/test/runtime/user-tier/run.sh
+++ b/test/runtime/user-tier/run.sh
@@ -3,15 +3,15 @@
 # tier-walk smoke test.
 #
 # Drives one /v1/runs with user_tier=low. The tier's candidate list
-# is [deepseek, anthropic]. DEEPSEEK_BASE_URL is overridden to
+# is [deepseek, gemini]. DEEPSEEK_BASE_URL is overridden to
 # http://127.0.0.1:1, so:
 #
 #   1. At boot, the resolver probes /v1/models on each provider.
 #      The deepseek probe fails with `connect: connection refused`
 #      → matrix marks deepseek unreachable.
 #   2. At run-start, the resolver walks the user_tier's candidate
-#      list. deepseek is skipped (unreachable in matrix); anthropic
-#      is healthy → resolver returns claude-haiku-4-5-20251001.
+#      list. deepseek is skipped (unreachable in matrix); gemini
+#      is healthy → resolver returns gemini-2.5-flash.
 #   3. The run completes against the fallback provider.
 #
 # This validates the RESOLVE-TIME tier-walk path of v0.8.2: the
@@ -30,7 +30,7 @@
 # Same `test/runtime/<feature>/` convention as channels/ and memory/.
 #
 # Usage:
-#   DEEPSEEK_API_KEY=... ANTHROPIC_API_KEY=... ./test/runtime/user-tier/run.sh
+#   DEEPSEEK_API_KEY=... GEMINI_API_KEY=... ./test/runtime/user-tier/run.sh
 # OR:
 #   set -a; source .env.local; set +a; ./test/runtime/user-tier/run.sh
 
@@ -55,16 +55,16 @@ cleanup() {
 # ─── Env requirements ───────────────────────────────────────────────
 # Need BOTH keys: DeepSeek for the primary registration (the
 # unreachable URL means auth is never tried, but the registration
-# check is DEEPSEEK_API_KEY != ""), Anthropic for the fallback to
+# check is DEEPSEEK_API_KEY != ""), Gemini for the fallback to
 # actually succeed.
 if [[ -z "${DEEPSEEK_API_KEY:-}" ]]; then
   echo "ERROR: DEEPSEEK_API_KEY not set. Source .env.local first." >&2
   exit 1
 fi
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-  echo "ERROR: ANTHROPIC_API_KEY not set — required for the fallback step." >&2
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY not set — required for the fallback step." >&2
   echo "  This test needs BOTH DEEPSEEK_API_KEY (primary, will fail by design)" >&2
-  echo "  AND ANTHROPIC_API_KEY (fallback, must succeed)." >&2
+  echo "  AND GEMINI_API_KEY (fallback, must succeed)." >&2
   exit 1
 fi
 if ! command -v python3 &>/dev/null; then
@@ -141,7 +141,7 @@ grep -E "user_tiers:|agents:|providers" "$BOOT_LOG" | sed 's/^/      /' || true
 echo
 
 # ─── 4. Drive a single run with user_tier=low ──────────────────────
-echo "[4/5] Running greeter with user_tier=low (primary deepseek fails → fallback to anthropic)..."
+echo "[4/5] Running greeter with user_tier=low (primary deepseek fails → fallback to gemini)..."
 # Drop `-f` (no auto-bail on 4xx/5xx) so the response body lands in
 # RUN_SSE for inspection even on error. Capture status separately.
 RUN_HTTP_STATUS=$(curl -sS -N -w '%{http_code}' -o "$RUN_SSE" \
@@ -219,8 +219,8 @@ echo "  Run status:                     $RUN_STATUS (expect completed)"
 
 # Check 3: model used = fallback target = claude-haiku-4-5-20251001
 # (the tier's SECOND candidate, picked after deepseek was skipped).
-echo "  Run model (= fallback target):  $RUN_MODEL (expect claude-haiku-4-5-20251001)"
-[[ "$RUN_MODEL" == "claude-haiku-4-5-20251001" ]] || PASS=false
+echo "  Run model (= fallback target):  $RUN_MODEL (expect gemini-2.5-flash)"
+[[ "$RUN_MODEL" == "gemini-2.5-flash" ]] || PASS=false
 
 # Check 4: runs.user_tier marker stamped (v0.8.2 audit column).
 echo "  Run user_tier marker:           $RUN_TIER (expect low)"


### PR DESCRIPTION
## Summary

Two real Gemini-driver bugs surfaced while re-running the `test/runtime/<feature>/` suite against `gemini-2.5-flash`. Both fixed in this PR. Plus the runtime tests are swapped to Gemini so the suite now validates against Anthropic, DeepSeek (mid-run unit-test path), AND Gemini end-to-end through the SSE wire.

The two bugs compound — fixing only one wouldn't restore Gemini support. Found via runtime testing, not unit tests, because the unit tests use httptest fakes that don't enforce Gemini's OpenAPI-subset validation.

**Bonus:** the `event: channel_publish` / `event: channel_delivery` typed audit events from PR #61 got their first real wire test in this run. They surface correctly on the SSE stream during both the channels and the user-tier scenarios.

## BUG #1 (CRITICAL) — Gemini rejects `additionalProperties`

`gemini/driver.go` passed each tool's `InputSchema` (a `json.RawMessage`) verbatim into `function_declarations.parameters`. Gemini's API accepts an **OpenAPI 3.0 subset**, NOT full JSON Schema. The `additionalProperties: false` field that the Channel + Memory built-in tools both include produces:

```
gemini 400: Invalid JSON payload received. Unknown name "additionalProperties"
  at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

Every other driver (Anthropic / OpenAI / DeepSeek / Ollama) silently accepts the field. The Channel and Memory tools have shipped since v0.8.0 / v0.8.4 respectively without anyone noticing — Gemini-with-tools has been broken from day one.

**Fix:** new `sanitizeGeminiSchema` helper. Recursively walks the parsed schema and strips:

- `additionalProperties`
- `$schema`
- `$id`

Applied at the one site in `buildRequestBody` where `t.InputSchema` becomes `wireFunctionDecl.Parameters`. Best-effort: malformed input passes through verbatim so Gemini surfaces a clear 400 rather than the driver swallowing the problem.

Three new unit tests in `gemini/driver_test.go`:

- `TestSanitizeGeminiSchema_StripsAdditionalProperties` — root + nested object schemas; verifies `properties` / `required` / `enum` survive.
- `TestSanitizeGeminiSchema_PreservesOnMalformedInput`.
- `TestSanitizeGeminiSchema_EmptyInputPassthrough`.

## BUG #2 (HIGH) — `ToolName` not propagated on `tool_result`

The loop's `tool_result` `ContentBlock` construction at `internal/loop/loop.go:723` set `ToolUseID` but not `ToolName`. Anthropic / OpenAI / DeepSeek correlate tool_use ↔ tool_result by **ID** (the redundant name is ignored). Gemini and Ollama do NOT issue tool_call IDs and correlate by **NAME** instead.

Gemini returned:

```
gemini 400: GenerateContentRequest.contents[2].parts[0].function_response.name:
  Name cannot be empty.
```

The result: every multi-turn tool-using flow against Gemini died on the model-callback turn (the FIRST publish/subscribe worked because Gemini received the tool_call; the second turn — where the model reads the result and replies — failed because `function_response.name` was empty).

**Fix:** one-line — add `ToolName: r.tu.Name` to the result `ContentBlock` build. The matching tool_use block already sets `ToolName`, so the loop had the data; we just weren't propagating it.

## The two bugs compound

Without bug #1 fixed, every Gemini tool call returns 400 before the model even sees the schema.

With bug #1 fixed but not #2: the first tool call succeeds; the second turn (model reads result) dies with the empty-name 400. Channels test would show 1/3 publishes; memory test would die on the second set; user-tier would never get there because the run still fails.

Both fixes together: full runtime suite passes.

## Runtime test swap to Gemini

| File | Change |
|---|---|
| `test/runtime/channels/agents/{researcher,analyst}.md` | `provider: gemini, model: gemini-2.5-flash` |
| `test/runtime/channels/loomcycle.yaml` | Same swap; `provider_priority: [gemini]` |
| `test/runtime/channels/run.sh` | `GEMINI_API_KEY` env check |
| `test/runtime/memory/{memorybot.md, loomcycle.yaml, run.sh}` | Same shape |
| `test/runtime/user-tier/loomcycle.yaml` | Tier candidates become `[deepseek (broken), gemini / gemini-2.5-flash]` |
| `test/runtime/user-tier/run.sh` | `GEMINI_API_KEY` instead of `ANTHROPIC_API_KEY`; expected model = `gemini-2.5-flash` |

Picked `gemini-2.5-flash` (not 2.0) because the latter's free tier returned `limit: 0` for input tokens on this project — probably exhausted from earlier testing. 2.5-flash worked cleanly.

## Verified PASS on all three scenarios

| Test | Result |
|---|---|
| `test/runtime/channels/` | 3 publishes + 3 deliveries + 3 channel_messages rows; both runs `completed/end_turn/gemini-2.5-flash` |
| `test/runtime/memory/` | Cross-run state persistence + atomic `run_count → 2`; both runs `completed` |
| `test/runtime/user-tier/` | Boot probe marks deepseek unreachable; resolver picks `gemini-2.5-flash`; `runs.user_tier=low` persists |

Plus the **typed audit events from PR #61** fire correctly on the wire:
- Channels run shows `event: channel_publish` (3) + `event: channel_delivery` (3) frames.
- First time those event types have been wire-tested end-to-end.

## Test plan

- [x] `go test ./...` clean (3 new gemini tests; 0 regressions).
- [x] `go test -race` clean on loop, gemini driver, tools/builtin.
- [x] `gofmt -l` clean.
- [x] All 3 runtime tests PASS end-to-end against `gemini-2.5-flash`.
- [x] Channels typed audit events visible on the SSE stream.
- [ ] Operator eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)