### PR TITLE
feat(substrate): v0.8.5 PR 2 — config + resolver plumbing

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -72,6 +72,15 @@ type Agent struct {
 	// Channels is the v0.8.4 Channel-tool ACL. Empty Publish /
 	// Subscribe = no access on that side.
 	Channels AgentChannelACL
+	// AgentDefScopes is the v0.8.5 AgentDef-tool capability gate.
+	// Closed set: "self" / "descendants" / "named:<name>" / "any".
+	// Empty = default-deny.
+	AgentDefScopes []string
+	// EvaluationScopes is the v0.8.5 Evaluation-tool capability gate.
+	// Closed set: "submit_self" / "submit_siblings" /
+	// "submit_descendants" / "submit_any" / "read_any". Empty =
+	// default-deny.
+	EvaluationScopes []string
 	// Path is the absolute path of the source MD, kept for diagnostic
 	// logging (skills/loader.go follows the same convention).
 	Path string
@@ -211,6 +220,8 @@ type frontmatter struct {
 	MemoryScopes     []string                   `yaml:"memory_scopes"`
 	MemoryQuotaBytes int                        `yaml:"memory_quota_bytes"`
 	Channels         AgentChannelACL            `yaml:"channels"`
+	AgentDefScopes   []string                   `yaml:"agent_def_scopes"`
+	EvaluationScopes []string                   `yaml:"evaluation_scopes"`
 	SystemPromptFile string                     `yaml:"system_prompt_file"`
 	// SystemPrompt as an inline frontmatter field is intentionally
 	// NOT supported. The body of the MD is the prompt; if you want a
@@ -271,6 +282,8 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.MemoryScopes = fm.MemoryScopes
 	a.MemoryQuotaBytes = fm.MemoryQuotaBytes
 	a.Channels = fm.Channels
+	a.AgentDefScopes = fm.AgentDefScopes
+	a.EvaluationScopes = fm.EvaluationScopes
 	a.SystemPromptFile = fm.SystemPromptFile
 	a.SystemPrompt = body
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -304,6 +304,22 @@ func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
 	}
 }
 
+// substratePoliciesForAgent returns the v0.8.5 AgentDef +
+// Evaluation policies for one agent. Mirrors channelPolicyForAgent's
+// shape. selfName is the resolved agent name as seen by the ctx
+// chain (== tools.AgentName at attach time); stamped onto the
+// AgentDef policy so the tool's "self" scope check is robust to
+// any future ctx-stack mutations.
+func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName string) (tools.AgentDefPolicyValue, tools.EvaluationPolicyValue) {
+	return tools.AgentDefPolicyValue{
+			Scopes:   agentDef.AgentDefScopes,
+			SelfName: selfName,
+		},
+		tools.EvaluationPolicyValue{
+			Scopes: agentDef.EvaluationScopes,
+		}
+}
+
 // channelPolicyForAgent builds the v0.8.4 Channel-tool policy from
 // the agent yaml + the top-level `channels:` block. Returns a value
 // suitable for tools.WithChannelPolicy. The Channels map is a copy
@@ -592,6 +608,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -1091,6 +1110,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1375,6 +1397,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -1870,6 +1895,13 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	// subEmit above). Channel-tool publishes from inside the sub
 	// surface on the sub's SSE stream, not the parent's.
 	subCtx = tools.WithEventEmitter(subCtx, subEmit)
+	// Sub-agent's substrate policies come from ITS OWN yaml — same
+	// shape as Memory/Channel. selfName is the sub's name so the
+	// "self" scope resolves to the sub-agent's identity, not the
+	// parent's.
+	subADPolicy, subEvPolicy := s.substratePoliciesForAgent(def, name)
+	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
+	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -305,6 +305,46 @@ type AgentDef struct {
 	// operator-yaml is the floor; the model can never enlarge its
 	// own access. Sub-agents inherit the parent's ACL via ctx.
 	Channels AgentChannelACL `yaml:"channels"`
+
+	// AgentDefScopes is the v0.8.5 AgentDef tool capability gate.
+	// Default-deny when empty. Mirrors MemoryScopes' shape — having
+	// AgentDef in allowed_tools is necessary but not sufficient; this
+	// list narrows which mutation paths the agent can take. Closed
+	// set:
+	//
+	//   - "self"         → may fork/promote/retire its OWN name
+	//                       (== tools.AgentName(ctx))
+	//   - "descendants"  → may operate on any def whose lineage chain
+	//                       traces back to a def the agent created
+	//   - "named:<name>" → may operate on the specified single name
+	//                       (multi-entry: "named:foo" + "named:bar")
+	//   - "any"          → unrestricted (operator-blessed orchestrator
+	//                       privilege)
+	//
+	// "any" is intentionally a single string ("any") rather than a
+	// wildcard pattern so the model never authors mass-mutation
+	// access via a templated string.
+	AgentDefScopes []string `yaml:"agent_def_scopes"`
+
+	// EvaluationScopes is the v0.8.5 Evaluation tool capability gate.
+	// Multi-select; default-deny when empty. Closed set:
+	//
+	//   - "submit_self"        → may emit evaluations against own runs
+	//   - "submit_siblings"    → may emit evaluations against sibling
+	//                             runs (same parent_agent_id)
+	//   - "submit_descendants" → may emit evaluations against the
+	//                             agent's spawn-tree descendants
+	//   - "submit_any"         → unrestricted submit (operator
+	//                             override; emitter_role = "unrelated"
+	//                             when the agent has no kinship)
+	//   - "read_any"           → may call list/aggregate ops against
+	//                             any def or run
+	//
+	// Emitter role is derived server-side from the emitter's ctx vs
+	// the target run's identity; the model never supplies it. The
+	// scope list gates WHICH emitter roles the agent is allowed to
+	// produce.
+	EvaluationScopes []string `yaml:"evaluation_scopes"`
 }
 
 // Channel is one operator-declared channel in the top-level
@@ -1091,6 +1131,8 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 			Publish:   d.Channels.Publish,
 			Subscribe: d.Channels.Subscribe,
 		},
+		AgentDefScopes:   d.AgentDefScopes,
+		EvaluationScopes: d.EvaluationScopes,
 	}
 	if len(d.Models) > 0 {
 		def.Models = make(map[string][]TierCandidate, len(d.Models))
@@ -1178,6 +1220,12 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.Channels.Subscribe != nil {
 		out.Channels.Subscribe = override.Channels.Subscribe
+	}
+	if override.AgentDefScopes != nil {
+		out.AgentDefScopes = override.AgentDefScopes
+	}
+	if override.EvaluationScopes != nil {
+		out.EvaluationScopes = override.EvaluationScopes
 	}
 	return out
 }
@@ -1379,6 +1427,43 @@ var validChannelSemantics = map[string]bool{
 	"broadcast": true,
 }
 
+// validEvaluationScopes is the closed set of Evaluation-tool scope
+// strings. See AgentDef.EvaluationScopes docstring for the meaning
+// of each.
+var validEvaluationScopes = map[string]bool{
+	"submit_self":        true,
+	"submit_siblings":    true,
+	"submit_descendants": true,
+	"submit_any":         true,
+	"read_any":           true,
+}
+
+// validateAgentDefScope checks one entry in an agent's
+// agent_def_scopes list. Closed set:
+//
+//   - "self"
+//   - "descendants"
+//   - "any"
+//   - "named:<name>" where <name> is non-empty
+//
+// The "named:" prefix is the only stringly-typed exception — keeps
+// the yaml authoring ergonomic. Empty name in "named:" is rejected
+// at config-load.
+func validateAgentDefScope(sc string) error {
+	switch sc {
+	case "self", "descendants", "any":
+		return nil
+	}
+	if strings.HasPrefix(sc, "named:") {
+		ref := strings.TrimPrefix(sc, "named:")
+		if ref == "" {
+			return fmt.Errorf("agent_def_scopes: \"named:\" requires a non-empty name (e.g. \"named:coder\")")
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown scope %q (want one of: self, descendants, any, or \"named:<name>\")", sc)
+}
+
 // validateAgentChannelEntry checks one publish/subscribe entry on
 // an AgentDef.Channels list. Exact match → must reference a declared
 // channel. Trailing "/*" wildcard → must match at least one declared
@@ -1541,6 +1626,20 @@ func validate(c *Config) error {
 		for i, ch := range agent.Channels.Subscribe {
 			if err := validateAgentChannelEntry(c.Channels, ch); err != nil {
 				return fmt.Errorf("agent %q: channels.subscribe[%d]: %w", name, i, err)
+			}
+		}
+		// AgentDef tool (v0.8.5): validate agent_def_scopes entries.
+		// Closed set: "self" / "descendants" / "named:<name>" / "any".
+		for i, sc := range agent.AgentDefScopes {
+			if err := validateAgentDefScope(sc); err != nil {
+				return fmt.Errorf("agent %q: agent_def_scopes[%d]: %w", name, i, err)
+			}
+		}
+		// Evaluation tool (v0.8.5): validate evaluation_scopes entries.
+		// Closed set as documented on AgentDef.EvaluationScopes.
+		for i, sc := range agent.EvaluationScopes {
+			if !validEvaluationScopes[sc] {
+				return fmt.Errorf("agent %q: evaluation_scopes[%d]: unknown scope %q (want one of: submit_self, submit_siblings, submit_descendants, submit_any, read_any)", name, i, sc)
 			}
 		}
 	}

--- a/internal/store/postgres/migrations/0006_agent_defs.down.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.down.sql
@@ -1,0 +1,7 @@
+-- 0006_agent_defs.down.sql — drop the v0.8.5 substrate def-storage.
+-- Order matters: agent_def_active references agent_defs.
+DROP INDEX IF EXISTS agent_defs_by_run;
+DROP INDEX IF EXISTS agent_defs_by_parent;
+DROP INDEX IF EXISTS agent_defs_by_name;
+DROP TABLE IF EXISTS agent_def_active;
+DROP TABLE IF EXISTS agent_defs;

--- a/internal/store/postgres/migrations/0006_agent_defs.up.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.up.sql
@@ -1,5 +1,13 @@
 -- 0006_agent_defs.up.sql — v0.8.5 Self-Evolution Substrate storage.
 --
+-- (No 0005 — that slot was reserved for a v0.8.4 follow-up that
+-- shipped inline in 0004 instead. The gap is intentional; golang-
+-- migrate applies migrations in numeric order and does not require
+-- sequential numbering. Future cherry-picks MUST NOT fill the gap
+-- on a deployed database — golang-migrate refuses to apply a
+-- migration with a number lower than the database's current version.
+-- Use 0009+ for any new migration.)
+--
 -- Two tables. agent_defs is the append-only versioned-definition
 -- layer (operator-blessed static MDs remain the immutable root in
 -- cfg.Agents; this is the DERIVED layer of agent-authored versions).

--- a/internal/store/postgres/migrations/0006_agent_defs.up.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.up.sql
@@ -1,0 +1,46 @@
+-- 0006_agent_defs.up.sql — v0.8.5 Self-Evolution Substrate storage.
+--
+-- Two tables. agent_defs is the append-only versioned-definition
+-- layer (operator-blessed static MDs remain the immutable root in
+-- cfg.Agents; this is the DERIVED layer of agent-authored versions).
+-- agent_def_active is the per-name "which version is current"
+-- pointer.
+--
+-- Why two tables and not is_active BOOL on agent_defs:
+--   - Partial-unique indexes for "one active per name" diverge
+--     between SQLite and Postgres syntax.
+--   - Promote/rollback is a one-row UPDATE here, vs a two-row
+--     UPDATE flipping the flag. Symmetric.
+--   - Per-tenant active pointers (future v0.9.x) extend the PK to
+--     (tenant_id, name); the agent_defs rows stay tenant-agnostic.
+--
+-- definition is JSONB so a future "find forks similar to this one"
+-- query can use @> operators without a migration. Description is
+-- free-text "why I made this" — capped in the application layer
+-- (LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES, default 8 KB).
+
+CREATE TABLE agent_defs (
+    def_id                    TEXT        PRIMARY KEY,
+    name                      TEXT        NOT NULL,
+    version                   INTEGER     NOT NULL,
+    parent_def_id             TEXT        REFERENCES agent_defs(def_id),
+    definition                JSONB       NOT NULL,
+    description               TEXT,
+    created_at                TIMESTAMPTZ NOT NULL,
+    created_by_agent_id       TEXT,
+    created_by_run_id         TEXT,
+    retired                   BOOLEAN     NOT NULL DEFAULT FALSE,
+    bootstrapped_from_static  BOOLEAN     NOT NULL DEFAULT FALSE,
+    UNIQUE(name, version)
+);
+
+CREATE INDEX agent_defs_by_name   ON agent_defs(name, version DESC);
+CREATE INDEX agent_defs_by_parent ON agent_defs(parent_def_id) WHERE parent_def_id IS NOT NULL;
+CREATE INDEX agent_defs_by_run    ON agent_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL;
+
+CREATE TABLE agent_def_active (
+    name                  TEXT        PRIMARY KEY,
+    def_id                TEXT        NOT NULL REFERENCES agent_defs(def_id),
+    promoted_at           TIMESTAMPTZ NOT NULL,
+    promoted_by_agent_id  TEXT
+);

--- a/internal/store/postgres/migrations/0007_runs_agent_def.down.sql
+++ b/internal/store/postgres/migrations/0007_runs_agent_def.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS runs_by_agent_def;
+ALTER TABLE runs DROP COLUMN IF EXISTS agent_def_id;

--- a/internal/store/postgres/migrations/0007_runs_agent_def.up.sql
+++ b/internal/store/postgres/migrations/0007_runs_agent_def.up.sql
@@ -1,0 +1,12 @@
+-- 0007_runs_agent_def.up.sql — v0.8.5 runs.agent_def_id audit column.
+--
+-- NULL = "this run resolved against the static cfg.Agents fallback,
+-- no DB-versioned definition." That distinguishes static-resolved
+-- runs from DB-resolved runs without a separate flag column. Cost
+-- retros + experiment audits facet on this.
+--
+-- Additive ALTER on an existing table; no row lock in Postgres ≥ 11
+-- because the new column has no DEFAULT (NULL is free).
+
+ALTER TABLE runs ADD COLUMN agent_def_id TEXT;
+CREATE INDEX runs_by_agent_def ON runs(agent_def_id) WHERE agent_def_id IS NOT NULL;

--- a/internal/store/postgres/migrations/0008_evaluations.down.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS evaluations_by_emitter;
+DROP INDEX IF EXISTS evaluations_by_def;
+DROP INDEX IF EXISTS evaluations_by_run;
+DROP TABLE IF EXISTS evaluations;

--- a/internal/store/postgres/migrations/0008_evaluations.up.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.up.sql
@@ -16,6 +16,13 @@
 -- (operator chooses; substrate is range-agnostic). Dimensions are
 -- arbitrary named axes; judgement is free-form JSON. All capped at
 -- the application layer (LOOMCYCLE_EVALUATION_MAX_* env vars).
+--
+-- NO foreign keys on run_id or def_id: evaluations are an immutable
+-- audit log and must survive any future run/def pruning. Referential
+-- integrity is enforced at the application layer (EvaluationSubmit
+-- validates run_id exists before inserting). A RESTRICT FK would
+-- block legitimate admin pruning workflows; CASCADE would silently
+-- delete audit data. Mirrors the SQLite schema in sqlite.go.
 
 CREATE TABLE evaluations (
     eval_id            TEXT             PRIMARY KEY,

--- a/internal/store/postgres/migrations/0008_evaluations.up.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.up.sql
@@ -1,0 +1,36 @@
+-- 0008_evaluations.up.sql — v0.8.5 Self-Evolution Substrate evals.
+--
+-- Pure-insert table; agents call EvaluationSubmit per scored run.
+-- def_id is denormalised from runs.agent_def_id at submit time —
+-- captures which version the run actually targeted at the moment
+-- the eval landed, robust to later promote / retire ops.
+--
+-- emitter_role is server-derived from ctx + run identity (the
+-- store does NOT compute it; the tool layer stamps it before
+-- handing the row off). Closed set: 'self' / 'sibling' / 'parent' /
+-- 'external' / 'unrelated'. Future v0.9.x experiments can add new
+-- role strings without a schema change.
+--
+-- Score is REAL (Postgres DOUBLE PRECISION) — the RL convention
+-- range [-1, 1] OR [0, 1] is enforced in the application layer
+-- (operator chooses; substrate is range-agnostic). Dimensions are
+-- arbitrary named axes; judgement is free-form JSON. All capped at
+-- the application layer (LOOMCYCLE_EVALUATION_MAX_* env vars).
+
+CREATE TABLE evaluations (
+    eval_id            TEXT             PRIMARY KEY,
+    run_id             TEXT             NOT NULL,
+    def_id             TEXT,
+    score              DOUBLE PRECISION NOT NULL,
+    dimensions         JSONB,
+    judgement          JSONB,
+    rationale          TEXT,
+    emitter_role       TEXT             NOT NULL,
+    emitter_agent_id   TEXT,
+    emitter_run_id     TEXT,
+    created_at         TIMESTAMPTZ      NOT NULL
+);
+
+CREATE INDEX evaluations_by_run     ON evaluations(run_id);
+CREATE INDEX evaluations_by_def     ON evaluations(def_id) WHERE def_id IS NOT NULL;
+CREATE INDEX evaluations_by_emitter ON evaluations(emitter_agent_id) WHERE emitter_agent_id IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1442,6 +1442,14 @@ func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded
 	return out
 }
 
+// statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
+// Latest is set here as vals[len-1]: callers MUST append in
+// created_at ASC order so the last element is the newest. For the
+// top-level Score axis the caller currently overwrites Latest after
+// returning (the input slice for that axis is built differently); for
+// the Dimensions and ByEmitterRole axes the value set here stands.
+// Mirrors the SQLite implementation in sqlite.go — duplicated
+// intentionally; extract to a shared package if a third backend lands.
 func statsOf(vals []float64) store.ScoreStats {
 	if len(vals) == 0 {
 		return store.ScoreStats{}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -14,10 +14,12 @@ package postgres
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -960,6 +962,513 @@ func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("channel sweep: %w", err)
 	}
 	return int(tag.RowsAffected()), nil
+}
+
+// ---- v0.8.5 Self-Evolution Substrate ----
+//
+// Postgres mirror of the SQLite implementation. Version-allocation
+// lock uses pg_advisory_xact_lock(hashtextextended('agent_def:' || name, 0))
+// inside the tx so concurrent forks against the same name serialise
+// without locking the whole table. The aggregation kernel
+// (computeAggregate / statsOf) is shared with sqlite.
+
+// AgentDefCreate allocates the next version for row.Name under a
+// per-name advisory lock and inserts. Validates parent_def_id.
+func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (store.AgentDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def: def_id + name required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Per-name advisory lock — serialises version allocation against
+	// concurrent forks of the SAME name. Different names proceed in
+	// parallel. The hash is deterministic so the same name always
+	// hashes to the same lock key.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"agent_def:"+row.Name,
+	); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create lock: %w", err)
+	}
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM agent_defs WHERE def_id = $1`, row.ParentDefID).Scan(&n); err != nil {
+			return store.AgentDefRow{}, fmt.Errorf("agent_def create parent check: %w", err)
+		}
+		if n == 0 {
+			return store.AgentDefRow{}, store.ErrAgentDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM agent_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create max version: %w", err)
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now().UTC()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11)`,
+		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
+		string(row.Definition), nullableString(row.Description),
+		row.CreatedAt,
+		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
+		row.Retired, row.BootstrappedFromStatic,
+	); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def insert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def commit: %w", err)
+	}
+	return row, nil
+}
+
+// AgentDefGet returns one row by def_id.
+func (s *Store) AgentDefGet(ctx context.Context, defID string) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.pool.QueryRow(ctx, agentDefSelect+` WHERE def_id = $1`, defID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return row, err
+}
+
+// AgentDefGetByNameVersion returns one row by (name, version).
+func (s *Store) AgentDefGetByNameVersion(ctx context.Context, name string, version int) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.pool.QueryRow(ctx, agentDefSelect+` WHERE name = $1 AND version = $2`, name, version))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+// AgentDefListByName returns rows for one name, version DESC.
+func (s *Store) AgentDefListByName(ctx context.Context, name string) ([]store.AgentDefRow, error) {
+	rows, err := s.pool.Query(ctx, agentDefSelect+` WHERE name = $1 ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list by name: %w", err)
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListChildren returns immediate children.
+func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([]store.AgentDefRow, error) {
+	rows, err := s.pool.Query(ctx, agentDefSelect+` WHERE parent_def_id = $1 ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list children: %w", err)
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListNames returns one summary per distinct name.
+func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM agent_defs d
+		LEFT JOIN agent_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list names: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.AgentDefNameSummary
+	for rows.Next() {
+		var s store.AgentDefNameSummary
+		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &s.LastUpdated, &s.ActiveDefID); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
+func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	var rowName string
+	err := s.pool.QueryRow(ctx, `SELECT name FROM agent_defs WHERE def_id = $1`, defID).Scan(&rowName)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	if err != nil {
+		return fmt.Errorf("agent_def_active check: %w", err)
+	}
+	if rowName != name {
+		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (name) DO UPDATE SET
+		    def_id               = EXCLUDED.def_id,
+		    promoted_at          = EXCLUDED.promoted_at,
+		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
+		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("agent_def_active upsert: %w", err)
+	}
+	return nil
+}
+
+// AgentDefGetActive returns the active row for name. *ErrNotFound
+// when no pointer exists.
+func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+	var defID string
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM agent_def_active WHERE name = $1`, name).Scan(&defID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
+	}
+	if err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def_active lookup: %w", err)
+	}
+	return s.AgentDefGet(ctx, defID)
+}
+
+// AgentDefSetRetired flips the retired flag.
+func (s *Store) AgentDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	tag, err := s.pool.Exec(ctx, `UPDATE agent_defs SET retired = $1 WHERE def_id = $2`, retired, defID)
+	if err != nil {
+		return fmt.Errorf("agent_def set retired: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return nil
+}
+
+const agentDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition::text,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM agent_defs`
+
+func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
+	var (
+		out        store.AgentDefRow
+		definition string
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&out.CreatedAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&out.Retired, &out.BootstrappedFromStatic,
+	)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	return out, nil
+}
+
+func (s *Store) scanAgentDefRows(rows pgx.Rows) ([]store.AgentDefRow, error) {
+	var out []store.AgentDefRow
+	for rows.Next() {
+		var (
+			r          store.AgentDefRow
+			definition string
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&r.CreatedAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&r.Retired, &r.BootstrappedFromStatic,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- Evaluation ----
+
+func (s *Store) EvaluationSubmit(ctx context.Context, row store.EvaluationRow) (store.EvaluationRow, error) {
+	if row.EvalID == "" || row.RunID == "" || row.EmitterRole == "" {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation: eval_id, run_id, emitter_role required")
+	}
+	row.CreatedAt = time.Now().UTC()
+	var dimsJSON, judgementJSON any
+	if len(row.Dimensions) > 0 {
+		b, err := json.Marshal(row.Dimensions)
+		if err != nil {
+			return store.EvaluationRow{}, fmt.Errorf("evaluation: marshal dimensions: %w", err)
+		}
+		dimsJSON = string(b)
+	}
+	if len(row.Judgement) > 0 {
+		judgementJSON = string(row.Judgement)
+	}
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO evaluations (
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11)`,
+		row.EvalID, row.RunID, nullableString(row.DefID), row.Score,
+		dimsJSON, judgementJSON, nullableString(row.Rationale),
+		row.EmitterRole, nullableString(row.EmitterAgentID), nullableString(row.EmitterRunID),
+		row.CreatedAt,
+	); err != nil {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation submit: %w", err)
+	}
+	return row, nil
+}
+
+func (s *Store) EvaluationGet(ctx context.Context, evalID string) (store.EvaluationRow, error) {
+	row, err := s.scanEvaluation(s.pool.QueryRow(ctx, evaluationSelect+` WHERE eval_id = $1`, evalID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.EvaluationRow{}, &store.ErrNotFound{Kind: "evaluation", ID: evalID}
+	}
+	return row, err
+}
+
+func (s *Store) EvaluationListForRun(ctx context.Context, runID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE run_id = $1 ORDER BY created_at DESC LIMIT $2`, runID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation list for run: %w", err)
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+func (s *Store) EvaluationListForDef(ctx context.Context, defID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE def_id = $1 ORDER BY created_at DESC LIMIT $2`, defID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation list for def: %w", err)
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+func (s *Store) EvaluationAggregate(ctx context.Context, defID string, opts store.AggregateOpts) (store.AggregateResult, error) {
+	defIDs := []string{defID}
+	if opts.IncludeLineage {
+		ancestors, err := s.walkAncestors(ctx, defID)
+		if err != nil {
+			return store.AggregateResult{}, err
+		}
+		defIDs = append(defIDs, ancestors...)
+	}
+	if len(defIDs) > 1000 {
+		defIDs = defIDs[:1000]
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE def_id = ANY($1) ORDER BY created_at ASC`, defIDs)
+	if err != nil {
+		return store.AggregateResult{}, fmt.Errorf("evaluation aggregate: %w", err)
+	}
+	defer rows.Close()
+	evals, err := s.scanEvaluationRows(rows)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	return computeAggregate(defID, evals, opts.IncludeLineage), nil
+}
+
+func (s *Store) walkAncestors(ctx context.Context, defID string) ([]string, error) {
+	var ancestors []string
+	seen := map[string]bool{defID: true}
+	cur := defID
+	for i := 0; i < 100; i++ {
+		var parent sql.NullString
+		err := s.pool.QueryRow(ctx, `SELECT parent_def_id FROM agent_defs WHERE def_id = $1`, cur).Scan(&parent)
+		if errors.Is(err, pgx.ErrNoRows) || !parent.Valid || parent.String == "" {
+			return ancestors, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if seen[parent.String] {
+			return ancestors, nil
+		}
+		seen[parent.String] = true
+		ancestors = append(ancestors, parent.String)
+		cur = parent.String
+	}
+	return ancestors, nil
+}
+
+const evaluationSelect = `SELECT
+	eval_id, run_id,
+	COALESCE(def_id, ''),
+	score,
+	COALESCE(dimensions::text, ''),
+	COALESCE(judgement::text, ''),
+	COALESCE(rationale, ''),
+	emitter_role,
+	COALESCE(emitter_agent_id, ''),
+	COALESCE(emitter_run_id, ''),
+	created_at
+FROM evaluations`
+
+func (s *Store) scanEvaluation(row pgx.Row) (store.EvaluationRow, error) {
+	var (
+		out                   store.EvaluationRow
+		dimensions, judgement string
+	)
+	if err := row.Scan(
+		&out.EvalID, &out.RunID, &out.DefID, &out.Score,
+		&dimensions, &judgement, &out.Rationale,
+		&out.EmitterRole, &out.EmitterAgentID, &out.EmitterRunID,
+		&out.CreatedAt,
+	); err != nil {
+		return store.EvaluationRow{}, err
+	}
+	if dimensions != "" {
+		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+	}
+	if judgement != "" {
+		out.Judgement = json.RawMessage(judgement)
+	}
+	return out, nil
+}
+
+func (s *Store) scanEvaluationRows(rows pgx.Rows) ([]store.EvaluationRow, error) {
+	var out []store.EvaluationRow
+	for rows.Next() {
+		var (
+			r                     store.EvaluationRow
+			dimensions, judgement string
+		)
+		if err := rows.Scan(
+			&r.EvalID, &r.RunID, &r.DefID, &r.Score,
+			&dimensions, &judgement, &r.Rationale,
+			&r.EmitterRole, &r.EmitterAgentID, &r.EmitterRunID,
+			&r.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if dimensions != "" {
+			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+		}
+		if judgement != "" {
+			r.Judgement = json.RawMessage(judgement)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// nullableString returns sql.NullString-equivalent for pgx Exec args.
+// pgx accepts `nil` for NULL; empty strings stay as empty NOT NULL —
+// but our columns are TEXT NULL so we pass nil to mean NULL.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// computeAggregate + statsOf are defined in the sqlite adapter and
+// live in package store_sqlite. To avoid duplicating the aggregation
+// kernel, we redeclare it here as well — the two packages don't
+// share a parent except `store`, and putting the kernel in `store`
+// would force `store` to know about ScoreStats math. Leaving these
+// here for now; if a third backend lands we'll extract a helper
+// package.
+//
+// (Below copies are intentionally identical to sqlite's bodies.)
+
+func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded bool) store.AggregateResult {
+	out := store.AggregateResult{
+		DefID:           defID,
+		Count:           len(evals),
+		LineageIncluded: lineageIncluded,
+	}
+	if len(evals) == 0 {
+		return out
+	}
+	scores := make([]float64, len(evals))
+	dimAcc := map[string][]float64{}
+	roleAcc := map[string][]float64{}
+	for i, e := range evals {
+		scores[i] = e.Score
+		for k, v := range e.Dimensions {
+			dimAcc[k] = append(dimAcc[k], v)
+		}
+		roleAcc[e.EmitterRole] = append(roleAcc[e.EmitterRole], e.Score)
+	}
+	out.Score = statsOf(scores)
+	out.Score.Latest = evals[len(evals)-1].Score
+	if len(dimAcc) > 0 {
+		out.Dimensions = make(map[string]store.ScoreStats, len(dimAcc))
+		for k, v := range dimAcc {
+			out.Dimensions[k] = statsOf(v)
+		}
+	}
+	if len(roleAcc) > 0 {
+		out.ByEmitterRole = make(map[string]store.ScoreStats, len(roleAcc))
+		for k, v := range roleAcc {
+			out.ByEmitterRole[k] = statsOf(v)
+		}
+	}
+	return out
+}
+
+func statsOf(vals []float64) store.ScoreStats {
+	if len(vals) == 0 {
+		return store.ScoreStats{}
+	}
+	out := store.ScoreStats{Count: len(vals), Min: vals[0], Max: vals[0]}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+		if v < out.Min {
+			out.Min = v
+		}
+		if v > out.Max {
+			out.Max = v
+		}
+	}
+	out.Mean = sum / float64(len(vals))
+	out.Latest = vals[len(vals)-1]
+	sorted := make([]float64, len(vals))
+	copy(sorted, vals)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		out.Median = sorted[mid]
+	} else {
+		out.Median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return out
 }
 
 // escapeLikePrefix neutralises the LIKE wildcards in `prefix` so an

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -136,6 +137,54 @@ func (s *Store) migrate(ctx context.Context) error {
 			updated_at INTEGER NOT NULL,
 			PRIMARY KEY (channel, scope, scope_id)
 		)`,
+		// v0.8.5 Self-Evolution Substrate — see
+		// internal/store/postgres/migrations/0006_agent_defs.up.sql for
+		// the full design rationale. SQLite mirrors the shape; INTEGER
+		// boolean (0/1) instead of Postgres BOOLEAN, unix-nano INTEGER
+		// timestamps instead of TIMESTAMPTZ, TEXT JSON instead of JSONB.
+		`CREATE TABLE IF NOT EXISTS agent_defs (
+			def_id                    TEXT    PRIMARY KEY,
+			name                      TEXT    NOT NULL,
+			version                   INTEGER NOT NULL,
+			parent_def_id             TEXT    REFERENCES agent_defs(def_id),
+			definition                TEXT    NOT NULL,
+			description               TEXT,
+			created_at                INTEGER NOT NULL,
+			created_by_agent_id       TEXT,
+			created_by_run_id         TEXT,
+			retired                   INTEGER NOT NULL DEFAULT 0,
+			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(name, version)
+		)`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_name   ON agent_defs(name, version DESC)`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_parent ON agent_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_run    ON agent_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS agent_def_active (
+			name                  TEXT    PRIMARY KEY,
+			def_id                TEXT    NOT NULL REFERENCES agent_defs(def_id),
+			promoted_at           INTEGER NOT NULL,
+			promoted_by_agent_id  TEXT
+		)`,
+		// v0.8.5 evaluations table. emitter_role is server-derived in
+		// the tool layer; the store stores the string verbatim. Score
+		// is REAL (Go float64). Dimensions + Judgement are JSON-as-TEXT
+		// (sqlite has no JSONB).
+		`CREATE TABLE IF NOT EXISTS evaluations (
+			eval_id            TEXT    PRIMARY KEY,
+			run_id             TEXT    NOT NULL,
+			def_id             TEXT,
+			score              REAL    NOT NULL,
+			dimensions         TEXT,
+			judgement          TEXT,
+			rationale          TEXT,
+			emitter_role       TEXT    NOT NULL,
+			emitter_agent_id   TEXT,
+			emitter_run_id     TEXT,
+			created_at         INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_run     ON evaluations(run_id)`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_def     ON evaluations(def_id) WHERE def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_emitter ON evaluations(emitter_agent_id) WHERE emitter_agent_id IS NOT NULL`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -158,6 +207,12 @@ func (s *Store) migrate(ctx context.Context) error {
 		// new rows carry the name of the user_tier policy applied at
 		// run creation. Compliance + cost-retro queries facet on this.
 		`ALTER TABLE runs ADD COLUMN user_tier TEXT`,
+		// v0.8.5: agent_def_id audit column. NULL = the run resolved
+		// against the static cfg.Agents fallback (no DB-versioned def).
+		// Non-NULL = the run targeted a specific (name, version) row
+		// in agent_defs. Distinguishes static-resolved from DB-resolved
+		// runs without a separate flag.
+		`ALTER TABLE runs ADD COLUMN agent_def_id TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -181,6 +236,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS runs_by_parent_agent_id ON runs(parent_agent_id) WHERE parent_agent_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS runs_by_user_active     ON runs(user_id, status) WHERE user_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS sessions_by_user        ON sessions(user_id)     WHERE user_id IS NOT NULL`,
+		// v0.8.5: facets cost retros + experiment audits by which
+		// agent_def_id the run actually ran against. Partial index
+		// keeps it small — only DB-resolved runs have a non-NULL value.
+		`CREATE INDEX IF NOT EXISTS runs_by_agent_def       ON runs(agent_def_id)    WHERE agent_def_id IS NOT NULL`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -1115,6 +1174,571 @@ func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return int(n), nil
+}
+
+// ---- v0.8.5 Self-Evolution Substrate ----
+//
+// AgentDef methods. Append-only. Version is allocated under a
+// per-name lock (BEGIN IMMEDIATE in sqlite — coarse but correct for
+// single-writer WAL, mirrors MemoryIncrement's pattern).
+
+// AgentDefCreate allocates the next version for row.Name under a
+// per-name lock and inserts. The caller supplies row.DefID (UUID/
+// ULID-ish opaque string). Validates parent_def_id when set.
+//
+// SQLite concurrency: uses the same BEGIN IMMEDIATE + pinned-conn
+// pattern as MemoryIncrement — pinning the connection scopes the
+// write lock to this one transaction, and IMMEDIATE means concurrent
+// writers see SQLITE_BUSY at BEGIN time (database/sql retries) rather
+// than upgrade-deadlocking mid-tx. Without this, two concurrent
+// AgentDefCreate calls against the same name both start a DEFERRED
+// tx, both SELECT MAX(version) (returning the same value), then both
+// try to INSERT with the same version — one succeeds, one fails on
+// the UNIQUE(name, version) constraint.
+func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (store.AgentDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def: def_id + name required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_defs WHERE def_id = ?`, row.ParentDefID).Scan(&n); err != nil {
+			return store.AgentDefRow{}, err
+		}
+		if n == 0 {
+			return store.AgentDefRow{}, store.ErrAgentDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT MAX(version) FROM agent_defs WHERE name = ?`, row.Name,
+	).Scan(&maxVer); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO agent_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
+		string(row.Definition), nilIfEmpty(row.Description),
+		row.CreatedAt.UnixNano(),
+		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
+		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
+	); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	committed = true
+	return row, nil
+}
+
+// AgentDefGet returns one row by def_id.
+func (s *Store) AgentDefGet(ctx context.Context, defID string) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.db.QueryRowContext(ctx, agentDefSelect+` WHERE def_id = ?`, defID))
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return row, err
+}
+
+// AgentDefGetByNameVersion returns one row by (name, version).
+func (s *Store) AgentDefGetByNameVersion(ctx context.Context, name string, version int) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.db.QueryRowContext(ctx, agentDefSelect+` WHERE name = ? AND version = ?`, name, version))
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+// AgentDefListByName returns rows for one name, version DESC.
+func (s *Store) AgentDefListByName(ctx context.Context, name string) ([]store.AgentDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, agentDefSelect+` WHERE name = ? ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListChildren returns immediate children (parent_def_id == arg).
+func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([]store.AgentDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, agentDefSelect+` WHERE parent_def_id = ? ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListNames returns one summary row per distinct name. Joins
+// agent_def_active to surface the active def_id when one exists.
+func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM agent_defs d
+		LEFT JOIN agent_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.AgentDefNameSummary
+	for rows.Next() {
+		var s store.AgentDefNameSummary
+		var updatedAt int64
+		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &updatedAt, &s.ActiveDefID); err != nil {
+			return nil, err
+		}
+		s.LastUpdated = time.Unix(0, updatedAt)
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
+func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	// Validate def_id exists + matches name (defence-in-depth; the
+	// FK isn't enforced without foreign_keys PRAGMA).
+	var rowName string
+	err := s.db.QueryRowContext(ctx, `SELECT name FROM agent_defs WHERE def_id = ?`, defID).Scan(&rowName)
+	if err == sql.ErrNoRows {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	if err != nil {
+		return err
+	}
+	if rowName != name {
+		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+		    def_id               = excluded.def_id,
+		    promoted_at          = excluded.promoted_at,
+		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+	)
+	return err
+}
+
+// AgentDefGetActive returns the active row for name. *ErrNotFound
+// when no pointer exists — caller falls through to cfg.Agents.
+func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+	var defID string
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM agent_def_active WHERE name = ?`, name).Scan(&defID)
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
+	}
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	return s.AgentDefGet(ctx, defID)
+}
+
+// AgentDefSetRetired flips the `retired` flag on one row. The row
+// stays visible in lineage queries.
+func (s *Store) AgentDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE agent_defs SET retired = ? WHERE def_id = ?`,
+		boolToInt(retired), defID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return nil
+}
+
+// agentDefSelect is the column list shared by every read. Kept in
+// one place so column additions (a future tenant_id, similarity_score,
+// ...) need only a single touch-point.
+const agentDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM agent_defs`
+
+func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
+	var (
+		out        store.AgentDefRow
+		definition string
+		createdAt  int64
+		retired    int
+		bootstrap  int
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&createdAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&retired, &bootstrap,
+	)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	out.CreatedAt = time.Unix(0, createdAt)
+	out.Retired = retired != 0
+	out.BootstrappedFromStatic = bootstrap != 0
+	return out, nil
+}
+
+func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
+	var out []store.AgentDefRow
+	for rows.Next() {
+		var (
+			r          store.AgentDefRow
+			definition string
+			createdAt  int64
+			retired    int
+			bootstrap  int
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&createdAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&retired, &bootstrap,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdAt)
+		r.Retired = retired != 0
+		r.BootstrappedFromStatic = bootstrap != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- Evaluation (pure-insert, no concurrency lock) ----
+
+// EvaluationSubmit inserts one evaluation row. CreatedAt set by store.
+func (s *Store) EvaluationSubmit(ctx context.Context, row store.EvaluationRow) (store.EvaluationRow, error) {
+	if row.EvalID == "" || row.RunID == "" || row.EmitterRole == "" {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation: eval_id, run_id, emitter_role required")
+	}
+	row.CreatedAt = time.Now()
+	var dimsJSON, judgementJSON sql.NullString
+	if len(row.Dimensions) > 0 {
+		b, err := json.Marshal(row.Dimensions)
+		if err != nil {
+			return store.EvaluationRow{}, fmt.Errorf("evaluation: marshal dimensions: %w", err)
+		}
+		dimsJSON = sql.NullString{String: string(b), Valid: true}
+	}
+	if len(row.Judgement) > 0 {
+		judgementJSON = sql.NullString{String: string(row.Judgement), Valid: true}
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO evaluations (
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.EvalID, row.RunID, nilIfEmpty(row.DefID), row.Score,
+		dimsJSON, judgementJSON, nilIfEmpty(row.Rationale),
+		row.EmitterRole, nilIfEmpty(row.EmitterAgentID), nilIfEmpty(row.EmitterRunID),
+		row.CreatedAt.UnixNano(),
+	)
+	if err != nil {
+		return store.EvaluationRow{}, err
+	}
+	return row, nil
+}
+
+// EvaluationGet returns one row by eval_id.
+func (s *Store) EvaluationGet(ctx context.Context, evalID string) (store.EvaluationRow, error) {
+	row, err := s.scanEvaluation(s.db.QueryRowContext(ctx, evaluationSelect+` WHERE eval_id = ?`, evalID))
+	if err == sql.ErrNoRows {
+		return store.EvaluationRow{}, &store.ErrNotFound{Kind: "evaluation", ID: evalID}
+	}
+	return row, err
+}
+
+// EvaluationListForRun returns evals targeting one run.
+func (s *Store) EvaluationListForRun(ctx context.Context, runID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, evaluationSelect+` WHERE run_id = ? ORDER BY created_at DESC LIMIT ?`, runID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+// EvaluationListForDef returns evals targeting one def.
+func (s *Store) EvaluationListForDef(ctx context.Context, defID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, evaluationSelect+` WHERE def_id = ? ORDER BY created_at DESC LIMIT ?`, defID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+// EvaluationAggregate computes the score+dimension+by-role aggregates
+// for a def_id. When opts.IncludeLineage is true, walks parent_def_id
+// chain depth-first and includes ancestors.
+func (s *Store) EvaluationAggregate(ctx context.Context, defID string, opts store.AggregateOpts) (store.AggregateResult, error) {
+	defIDs := []string{defID}
+	if opts.IncludeLineage {
+		ancestors, err := s.walkAncestors(ctx, defID)
+		if err != nil {
+			return store.AggregateResult{}, err
+		}
+		defIDs = append(defIDs, ancestors...)
+	}
+
+	// Build the IN list. Limit defensively at 1000 ancestors so a
+	// pathological lineage can't blow query parser limits — the
+	// aggregator caller is responsible for not building megacycles.
+	if len(defIDs) > 1000 {
+		defIDs = defIDs[:1000]
+	}
+	placeholders := make([]string, len(defIDs))
+	args := make([]any, len(defIDs))
+	for i, id := range defIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	q := evaluationSelect + ` WHERE def_id IN (` + strings.Join(placeholders, ",") + `) ORDER BY created_at ASC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	defer rows.Close()
+	evals, err := s.scanEvaluationRows(rows)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	return computeAggregate(defID, evals, opts.IncludeLineage), nil
+}
+
+// walkAncestors returns the parent_def_id chain for defID (NOT
+// including defID itself). Depth-first, bounded at 100 hops to
+// protect against the (impossible-by-construction-but-let's-be-safe)
+// case of a cycle. Empty when defID has no parent.
+func (s *Store) walkAncestors(ctx context.Context, defID string) ([]string, error) {
+	var ancestors []string
+	seen := map[string]bool{defID: true}
+	cur := defID
+	for i := 0; i < 100; i++ {
+		var parent sql.NullString
+		err := s.db.QueryRowContext(ctx, `SELECT parent_def_id FROM agent_defs WHERE def_id = ?`, cur).Scan(&parent)
+		if err == sql.ErrNoRows || !parent.Valid || parent.String == "" {
+			return ancestors, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if seen[parent.String] {
+			return ancestors, nil // cycle guard
+		}
+		seen[parent.String] = true
+		ancestors = append(ancestors, parent.String)
+		cur = parent.String
+	}
+	return ancestors, nil
+}
+
+const evaluationSelect = `SELECT
+	eval_id, run_id,
+	COALESCE(def_id, ''),
+	score,
+	COALESCE(dimensions, ''),
+	COALESCE(judgement, ''),
+	COALESCE(rationale, ''),
+	emitter_role,
+	COALESCE(emitter_agent_id, ''),
+	COALESCE(emitter_run_id, ''),
+	created_at
+FROM evaluations`
+
+func (s *Store) scanEvaluation(row *sql.Row) (store.EvaluationRow, error) {
+	var (
+		out                   store.EvaluationRow
+		dimensions, judgement string
+		createdAt             int64
+	)
+	if err := row.Scan(
+		&out.EvalID, &out.RunID, &out.DefID, &out.Score,
+		&dimensions, &judgement, &out.Rationale,
+		&out.EmitterRole, &out.EmitterAgentID, &out.EmitterRunID,
+		&createdAt,
+	); err != nil {
+		return store.EvaluationRow{}, err
+	}
+	if dimensions != "" {
+		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+	}
+	if judgement != "" {
+		out.Judgement = json.RawMessage(judgement)
+	}
+	out.CreatedAt = time.Unix(0, createdAt)
+	return out, nil
+}
+
+func (s *Store) scanEvaluationRows(rows *sql.Rows) ([]store.EvaluationRow, error) {
+	var out []store.EvaluationRow
+	for rows.Next() {
+		var (
+			r                     store.EvaluationRow
+			dimensions, judgement string
+			createdAt             int64
+		)
+		if err := rows.Scan(
+			&r.EvalID, &r.RunID, &r.DefID, &r.Score,
+			&dimensions, &judgement, &r.Rationale,
+			&r.EmitterRole, &r.EmitterAgentID, &r.EmitterRunID,
+			&createdAt,
+		); err != nil {
+			return nil, err
+		}
+		if dimensions != "" {
+			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+		}
+		if judgement != "" {
+			r.Judgement = json.RawMessage(judgement)
+		}
+		r.CreatedAt = time.Unix(0, createdAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// computeAggregate is the pure-Go aggregation kernel — shared by
+// sqlite + postgres adapters. Given a flat list of evaluations,
+// produce summary stats. Empty input → zero-valued AggregateResult
+// with Count=0 (well-defined "no evaluations yet").
+func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded bool) store.AggregateResult {
+	out := store.AggregateResult{
+		DefID:           defID,
+		Count:           len(evals),
+		LineageIncluded: lineageIncluded,
+	}
+	if len(evals) == 0 {
+		return out
+	}
+
+	scores := make([]float64, len(evals))
+	dimAcc := map[string][]float64{}
+	roleAcc := map[string][]float64{}
+	for i, e := range evals {
+		scores[i] = e.Score
+		for k, v := range e.Dimensions {
+			dimAcc[k] = append(dimAcc[k], v)
+		}
+		roleAcc[e.EmitterRole] = append(roleAcc[e.EmitterRole], e.Score)
+	}
+	out.Score = statsOf(scores)
+	out.Score.Latest = evals[len(evals)-1].Score // evals is ASC by created_at
+
+	if len(dimAcc) > 0 {
+		out.Dimensions = make(map[string]store.ScoreStats, len(dimAcc))
+		for k, v := range dimAcc {
+			out.Dimensions[k] = statsOf(v)
+		}
+	}
+	if len(roleAcc) > 0 {
+		out.ByEmitterRole = make(map[string]store.ScoreStats, len(roleAcc))
+		for k, v := range roleAcc {
+			out.ByEmitterRole[k] = statsOf(v)
+		}
+	}
+	return out
+}
+
+// statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
+// Latest is filled by the caller (per-axis stat needs the original
+// ordering, which we lose when sorting for the median).
+func statsOf(vals []float64) store.ScoreStats {
+	if len(vals) == 0 {
+		return store.ScoreStats{}
+	}
+	out := store.ScoreStats{Count: len(vals), Min: vals[0], Max: vals[0]}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+		if v < out.Min {
+			out.Min = v
+		}
+		if v > out.Max {
+			out.Max = v
+		}
+	}
+	out.Mean = sum / float64(len(vals))
+	out.Latest = vals[len(vals)-1] // overwritten by caller for the top-level Score; ok for dim/role
+
+	// Median — sort a copy to avoid mutating caller's slice.
+	sorted := make([]float64, len(vals))
+	copy(sorted, vals)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		out.Median = sorted[mid]
+	} else {
+		out.Median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return out
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // escapeLikePrefix escapes the LIKE wildcards in `prefix` so an agent

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -169,6 +169,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// the tool layer; the store stores the string verbatim. Score
 		// is REAL (Go float64). Dimensions + Judgement are JSON-as-TEXT
 		// (sqlite has no JSONB).
+		//
+		// NO foreign keys on run_id or def_id: evaluations are an
+		// immutable audit log and must survive any future run/def
+		// pruning. Referential integrity is enforced at the
+		// application layer. A RESTRICT FK would block legitimate
+		// admin pruning workflows; CASCADE would silently delete
+		// audit data. Mirrors the postgres migration 0008.
 		`CREATE TABLE IF NOT EXISTS evaluations (
 			eval_id            TEXT    PRIMARY KEY,
 			run_id             TEXT    NOT NULL,
@@ -1701,8 +1708,11 @@ func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded
 }
 
 // statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
-// Latest is filled by the caller (per-axis stat needs the original
-// ordering, which we lose when sorting for the median).
+// Latest is set here as vals[len-1]: callers MUST append in
+// created_at ASC order so the last element is the newest. For the
+// top-level Score axis the caller currently overwrites Latest after
+// returning (the input slice for that axis is built differently); for
+// the Dimensions and ByEmitterRole axes the value set here stands.
 func statsOf(vals []float64) store.ScoreStats {
 	if len(vals) == 0 {
 		return store.ScoreStats{}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -371,6 +371,102 @@ type Store interface {
 	// from cur_0 without disturbing the consumer's position.
 	ChannelPeek(ctx context.Context, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
 
+	// ---- v0.8.5 Self-Evolution Substrate ----
+	//
+	// `AgentDef` is the agent-authored agent-definition versioning
+	// layer. Static `<name>.md` files remain the operator-blessed
+	// root; the database holds the derived layer of agent-created
+	// versions. Append-only. version is server-allocated under a
+	// per-name lock so concurrent forks against the same parent each
+	// get a distinct, monotonic version with no gaps.
+
+	// AgentDefCreate inserts a fresh row. The caller passes the row
+	// shape; the store allocates Version under the per-name lock,
+	// sets CreatedAt server-side, validates the parent (if any), and
+	// returns the persisted row. The DefID is caller-generated to
+	// support deterministic-ID workflows (test fixtures, externally-
+	// authored bootstrap rows).
+	//
+	// Errors:
+	//   - parent_def_id supplied but not found → ErrAgentDefParentNotFound
+	//   - name + version already exists (deterministic ID collision) → wraps the underlying constraint error
+	AgentDefCreate(ctx context.Context, row AgentDefRow) (AgentDefRow, error)
+
+	// AgentDefGet returns a single row by def_id. Returns *ErrNotFound
+	// when the row doesn't exist.
+	AgentDefGet(ctx context.Context, defID string) (AgentDefRow, error)
+
+	// AgentDefGetByNameVersion returns one row by (name, version).
+	// Useful for friendly lookups in the admin API. Returns
+	// *ErrNotFound on miss.
+	AgentDefGetByNameVersion(ctx context.Context, name string, version int) (AgentDefRow, error)
+
+	// AgentDefListByName returns every row for one name, ordered by
+	// version DESC. Empty slice (not nil) when the name has no rows.
+	// Retired rows are included; the caller filters as needed.
+	AgentDefListByName(ctx context.Context, name string) ([]AgentDefRow, error)
+
+	// AgentDefListChildren returns the immediate-children rows
+	// (parent_def_id == argument). One hop only — callers that need
+	// the full descendant tree walk iteratively.
+	AgentDefListChildren(ctx context.Context, parentDefID string) ([]AgentDefRow, error)
+
+	// AgentDefListNames returns one summary row per distinct name.
+	// Drives the admin API's name-list endpoint. count is the per-
+	// name version count; active_def_id is the agent_def_active
+	// pointer (empty when no row is promoted).
+	AgentDefListNames(ctx context.Context) ([]AgentDefNameSummary, error)
+
+	// AgentDefSetActive UPSERTs the agent_def_active pointer for
+	// `name` to `defID`. promotedByAgentID is the agent_id that
+	// performed the promotion (may be empty for admin API calls).
+	// Idempotent: promote A → promote B → promote A leaves the
+	// pointer at A with the latest promoted_at.
+	AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
+
+	// AgentDefGetActive returns the currently-active row for `name`
+	// — the (name, version) pointed at by agent_def_active. Returns
+	// *ErrNotFound when no active pointer exists (the caller falls
+	// through to cfg.Agents — the static fallback path).
+	AgentDefGetActive(ctx context.Context, name string) (AgentDefRow, error)
+
+	// AgentDefSetRetired flips the `retired` flag on one row. The
+	// row stays visible in lineage queries with the flag exposed;
+	// the resolver skips retired rows when picking the next default
+	// for runs that don't pin def_id.
+	AgentDefSetRetired(ctx context.Context, defID string, retired bool) error
+
+	// ---- Evaluation ----
+	//
+	// `Evaluation` is the score-attached-to-(run, def) primitive.
+	// Pure-insert (no per-row mutation), so no concurrency lock is
+	// needed. EvalID is caller-generated.
+
+	// EvaluationSubmit inserts a row. The caller stamps EmitterRole
+	// (derived server-side from ctx + run identity in the tool
+	// layer; the store does not interpret). CreatedAt is set by the
+	// store. Returns the persisted row.
+	EvaluationSubmit(ctx context.Context, row EvaluationRow) (EvaluationRow, error)
+
+	// EvaluationGet returns one row by eval_id. *ErrNotFound on miss.
+	EvaluationGet(ctx context.Context, evalID string) (EvaluationRow, error)
+
+	// EvaluationListForRun returns evaluations targeting a run,
+	// newest first. limit ≤ 0 falls through to a sane default.
+	EvaluationListForRun(ctx context.Context, runID string, limit int) ([]EvaluationRow, error)
+
+	// EvaluationListForDef returns evaluations targeting one def
+	// (denormalised def_id column). Same ordering + limit semantics
+	// as ListForRun.
+	EvaluationListForDef(ctx context.Context, defID string, limit int) ([]EvaluationRow, error)
+
+	// EvaluationAggregate computes summary statistics for a def_id.
+	// When opts.IncludeLineage is true, recursively walks parent_def_id
+	// and includes evaluations of every ancestor (depth-first;
+	// retired ancestors included). The returned LineageIncluded flag
+	// echoes the option for caller-side assertion.
+	EvaluationAggregate(ctx context.Context, defID string, opts AggregateOpts) (AggregateResult, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -486,6 +582,142 @@ type ChannelError struct {
 }
 
 func (e *ChannelError) Error() string { return e.Msg }
+
+// ---- v0.8.5 Self-Evolution Substrate types ----
+
+// AgentDefRow is one row in the agent_defs table. The Definition
+// field carries the JSON-encoded AgentDef body verbatim — the store
+// does NOT depend on internal/config (dep direction would invert),
+// so callers at the tool / HTTP layer unmarshal into the concrete
+// shape they need.
+//
+// Identity:
+//   - DefID is the canonical handle (caller-generated UUID/ULID;
+//     stable across renames). Use it for run pins and lineage edges.
+//   - (Name, Version) is the human-friendly identifier. Version is
+//     server-allocated, monotonic per Name with no gaps.
+//
+// Lineage:
+//   - ParentDefID empty = no parent (top of a lineage, typically
+//     bootstrapped from a static MD with BootstrappedFromStatic=true).
+//   - Children query: AgentDefListChildren(parentDefID).
+//
+// Provenance:
+//   - CreatedByAgentID + CreatedByRunID stamp the agent that called
+//     AgentDef.create/fork at runtime. Empty for the static-bootstrap
+//     row (its "creator" is the operator's MD file, not an agent).
+type AgentDefRow struct {
+	DefID                  string          `json:"def_id"`
+	Name                   string          `json:"name"`
+	Version                int             `json:"version"`
+	ParentDefID            string          `json:"parent_def_id,omitempty"`
+	Definition             json.RawMessage `json:"definition"`
+	Description            string          `json:"description,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	CreatedByAgentID       string          `json:"created_by_agent_id,omitempty"`
+	CreatedByRunID         string          `json:"created_by_run_id,omitempty"`
+	Retired                bool            `json:"retired"`
+	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
+}
+
+// AgentDefNameSummary is one entry of AgentDefListNames' output.
+// count is the version count; ActiveDefID is the agent_def_active
+// pointer (empty when no row is promoted under this name).
+type AgentDefNameSummary struct {
+	Name          string    `json:"name"`
+	VersionCount  int       `json:"version_count"`
+	ActiveDefID   string    `json:"active_def_id,omitempty"`
+	LatestVersion int       `json:"latest_version"`
+	LastUpdated   time.Time `json:"last_updated"`
+}
+
+// EvaluationRow is one row in the evaluations table.
+//
+// DefID is denormalised from runs.agent_def_id at submit time —
+// captures which version of the agent the run actually ran against.
+// Empty for static-resolved runs (where the agent body came from
+// cfg.Agents, not the database).
+//
+// Score is the required scalar (RL lingua franca). Dimensions are
+// optional named axes for multi-fitness; nil = no dimensions.
+// Judgement is a free-form structured payload; nil = absent.
+// Rationale is natural-language reasoning for explainability + audit.
+//
+// EmitterRole is derived server-side from the emitter's ctx vs the
+// target run's identity (parent / sibling / self / external /
+// unrelated). The model NEVER supplies it.
+type EvaluationRow struct {
+	EvalID         string             `json:"eval_id"`
+	RunID          string             `json:"run_id"`
+	DefID          string             `json:"def_id,omitempty"`
+	Score          float64            `json:"score"`
+	Dimensions     map[string]float64 `json:"dimensions,omitempty"`
+	Judgement      json.RawMessage    `json:"judgement,omitempty"`
+	Rationale      string             `json:"rationale,omitempty"`
+	EmitterRole    string             `json:"emitter_role"`
+	EmitterAgentID string             `json:"emitter_agent_id,omitempty"`
+	EmitterRunID   string             `json:"emitter_run_id,omitempty"`
+	CreatedAt      time.Time          `json:"created_at"`
+}
+
+// AggregateOpts is the parameter struct for EvaluationAggregate.
+type AggregateOpts struct {
+	// IncludeLineage walks parent_def_id chain depth-first and
+	// includes ancestors' evaluations in the aggregate. Retired
+	// ancestors are included; the caller can filter post-hoc.
+	IncludeLineage bool
+}
+
+// AggregateResult is the output of EvaluationAggregate.
+//
+// Count is the total evaluation row count contributing to the
+// statistics (post-lineage-walk when IncludeLineage is true).
+// Score aggregates the scalar field. Dimensions is keyed by the
+// dimension name the evaluations supplied (only dimensions present
+// in at least one row appear). ByEmitterRole breaks aggregates by
+// role string. LineageIncluded echoes the option for caller-side
+// assertion.
+type AggregateResult struct {
+	DefID           string                `json:"def_id"`
+	Count           int                   `json:"count"`
+	Score           ScoreStats            `json:"score"`
+	Dimensions      map[string]ScoreStats `json:"dimensions,omitempty"`
+	ByEmitterRole   map[string]ScoreStats `json:"by_emitter_role,omitempty"`
+	LineageIncluded bool                  `json:"lineage_included"`
+}
+
+// ScoreStats is the summary-stats bundle used inside AggregateResult.
+// All fields zero when Count is zero (an empty aggregate is a
+// well-defined "no evaluations submitted yet" response, NOT an error).
+type ScoreStats struct {
+	Mean   float64 `json:"mean"`
+	Median float64 `json:"median"`
+	Min    float64 `json:"min"`
+	Max    float64 `json:"max"`
+	Latest float64 `json:"latest"`
+	Count  int     `json:"count"`
+}
+
+// ErrAgentDefParentNotFound is returned by AgentDefCreate when the
+// caller supplied a parent_def_id that doesn't exist. Distinct from
+// ErrNotFound so the tool layer can surface "your fork parent
+// vanished" with a clean code.
+var ErrAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "agent_def: parent_def_id does not exist"}
+
+// ErrAgentDefImmutable is returned by store-layer assertions if
+// someone tries to UPDATE an agent_defs row's definition column.
+// Append-only invariant. The adapter's contract test pins this.
+var ErrAgentDefImmutable = &SubstrateError{Code: "immutable", Msg: "agent_def: rows are append-only; create a new version"}
+
+// SubstrateError envelopes substrate-specific errors so the tool
+// layer can pattern-match on Code. Mirror of MemoryError /
+// ChannelError shape.
+type SubstrateError struct {
+	Code string
+	Msg  string
+}
+
+func (e *SubstrateError) Error() string { return e.Msg }
 
 // ErrNotFound is returned when a session or run ID isn't in the store.
 type ErrNotFound struct {

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,6 +93,15 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelScopeIsolation", testChannelScopeIsolation},
 		{"ChannelPeekDoesNotConsume", testChannelPeekDoesNotConsume},
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
+		{"AgentDefCreateAndGet", testAgentDefCreateAndGet},
+		{"AgentDefVersionMonotonicUnderContention", testAgentDefVersionMonotonicUnderContention},
+		{"AgentDefParallelForksDistinctVersions", testAgentDefParallelForksDistinctVersions},
+		{"AgentDefAppendOnlyDefinition", testAgentDefAppendOnlyDefinition},
+		{"AgentDefActivePointerIdempotent", testAgentDefActivePointerIdempotent},
+		{"AgentDefRetireReversible", testAgentDefRetireReversible},
+		{"AgentDefStaticFallback", testAgentDefStaticFallback},
+		{"EvaluationSubmitAndAggregate", testEvaluationSubmitAndAggregate},
+		{"EvaluationAggregateWithLineage", testEvaluationAggregateWithLineage},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1294,5 +1304,317 @@ func testChannelReplayFromCursorZero(t *testing.T, s store.Store) {
 	msgs, _, _ = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
 	if len(msgs) != 3 {
 		t.Errorf("replay: got %d, want 3 (cur_0 must ignore committed cursor)", len(msgs))
+	}
+}
+
+// ---- v0.8.5 Self-Evolution Substrate contract ----
+
+// mkDef returns a minimal AgentDefRow suitable for create tests.
+// def_id is caller-supplied; the store doesn't generate it.
+func mkDef(id, name string, parent string) store.AgentDefRow {
+	return store.AgentDefRow{
+		DefID:       id,
+		Name:        name,
+		ParentDefID: parent,
+		Definition:  json.RawMessage(`{"model":"x","system_prompt":"p"}`),
+		Description: "test row",
+	}
+}
+
+func testAgentDefCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.AgentDefCreate(ctx, mkDef("d-1", "alpha", ""))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Version != 1 {
+		t.Errorf("first version = %d, want 1", row.Version)
+	}
+	got, err := s.AgentDefGet(ctx, "d-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "alpha" || got.Version != 1 {
+		t.Errorf("got %+v", got)
+	}
+	// Created-at populated.
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at not populated")
+	}
+}
+
+func testAgentDefVersionMonotonicUnderContention(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const G = 50 // 50 goroutines × 5 inserts = 250 unique versions
+	const Per = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, G*Per)
+	for g := 0; g < G; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < Per; i++ {
+				id := fmt.Sprintf("d-%d-%d", g, i)
+				_, err := s.AgentDefCreate(ctx, mkDef(id, "raceagent", ""))
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("create error: %v", err)
+	}
+	rows, err := s.AgentDefListByName(ctx, "raceagent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != G*Per {
+		t.Fatalf("got %d versions, want %d", len(rows), G*Per)
+	}
+	// rows is version DESC. Check strictly monotonic and no gaps.
+	versions := make(map[int]bool, len(rows))
+	for _, r := range rows {
+		if versions[r.Version] {
+			t.Errorf("duplicate version %d", r.Version)
+		}
+		versions[r.Version] = true
+	}
+	for v := 1; v <= G*Per; v++ {
+		if !versions[v] {
+			t.Errorf("missing version %d", v)
+		}
+	}
+}
+
+func testAgentDefParallelForksDistinctVersions(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	parent, err := s.AgentDefCreate(ctx, mkDef("p-1", "forkparent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const N = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := s.AgentDefCreate(ctx, mkDef(fmt.Sprintf("f-%d", i), "forkparent", parent.DefID))
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("fork: %v", err)
+	}
+	children, err := s.AgentDefListChildren(ctx, parent.DefID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != N {
+		t.Errorf("got %d children, want %d", len(children), N)
+	}
+	versions := make(map[int]bool)
+	for _, c := range children {
+		if versions[c.Version] {
+			t.Errorf("duplicate child version %d", c.Version)
+		}
+		versions[c.Version] = true
+		if c.ParentDefID != parent.DefID {
+			t.Errorf("child %s has wrong parent: %s", c.DefID, c.ParentDefID)
+		}
+	}
+}
+
+func testAgentDefAppendOnlyDefinition(t *testing.T, s store.Store) {
+	// The store's adapter has NO UPDATE statement on the definition
+	// column. This test verifies the row content is byte-identical
+	// after a get-set-get cycle would have applied if the store
+	// permitted mutation. There's no public API to mutate, so the
+	// only failure mode is "the implementation grew an UPDATE
+	// path" — caught by code review more than this test, but the
+	// test pins the contract for any future adapter.
+	ctx := context.Background()
+	original := mkDef("immutable-1", "frozen", "")
+	original.Definition = json.RawMessage(`{"v":"original"}`)
+	row, err := s.AgentDefCreate(ctx, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.AgentDefGet(ctx, row.DefID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Definition) != `{"v":"original"}` {
+		t.Errorf("definition: got %s, want original", got.Definition)
+	}
+}
+
+func testAgentDefActivePointerIdempotent(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	a, err := s.AgentDefCreate(ctx, mkDef("a", "promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.AgentDefCreate(ctx, mkDef("b", "promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", b.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.AgentDefGetActive(ctx, "promo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DefID != a.DefID {
+		t.Errorf("active = %s, want %s", got.DefID, a.DefID)
+	}
+}
+
+func testAgentDefRetireReversible(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.AgentDefCreate(ctx, mkDef("r-1", "retireagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetRetired(ctx, row.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.AgentDefGet(ctx, row.DefID)
+	if !got.Retired {
+		t.Error("retire(true) didn't stick")
+	}
+	if err := s.AgentDefSetRetired(ctx, row.DefID, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.AgentDefGet(ctx, row.DefID)
+	if got.Retired {
+		t.Error("retire(false) didn't reverse")
+	}
+	// Retired rows still appear in lineage queries.
+	rows, _ := s.AgentDefListByName(ctx, "retireagent")
+	if len(rows) != 1 {
+		t.Errorf("list after retire toggle: got %d, want 1", len(rows))
+	}
+}
+
+func testAgentDefStaticFallback(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, err := s.AgentDefGetActive(ctx, "no-such-name")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v, want *ErrNotFound", err)
+	}
+}
+
+func testEvaluationSubmitAndAggregate(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	def, err := s.AgentDefCreate(ctx, mkDef("eval-d", "evalagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Submit 5 evals with known scores.
+	scores := []float64{0.1, 0.3, 0.5, 0.7, 0.9}
+	for i, sc := range scores {
+		_, err := s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID:      fmt.Sprintf("ev-%d", i),
+			RunID:       fmt.Sprintf("r-%d", i),
+			DefID:       def.DefID,
+			Score:       sc,
+			EmitterRole: "self",
+			Dimensions:  map[string]float64{"correctness": sc},
+		})
+		if err != nil {
+			t.Fatalf("submit %d: %v", i, err)
+		}
+		time.Sleep(time.Microsecond) // ensure created_at ordering
+	}
+	agg, err := s.EvaluationAggregate(ctx, def.DefID, store.AggregateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 5 {
+		t.Errorf("count = %d, want 5", agg.Count)
+	}
+	if agg.Score.Mean < 0.49 || agg.Score.Mean > 0.51 {
+		t.Errorf("mean = %f, want ~0.5", agg.Score.Mean)
+	}
+	if agg.Score.Min != 0.1 {
+		t.Errorf("min = %f", agg.Score.Min)
+	}
+	if agg.Score.Max != 0.9 {
+		t.Errorf("max = %f", agg.Score.Max)
+	}
+	if agg.Score.Median != 0.5 {
+		t.Errorf("median = %f, want 0.5", agg.Score.Median)
+	}
+	if agg.Score.Latest != 0.9 {
+		t.Errorf("latest = %f, want 0.9 (newest)", agg.Score.Latest)
+	}
+	// Dimensions captured.
+	corr, ok := agg.Dimensions["correctness"]
+	if !ok {
+		t.Fatal("no correctness dimension in aggregate")
+	}
+	if corr.Mean < 0.49 || corr.Mean > 0.51 {
+		t.Errorf("correctness mean = %f", corr.Mean)
+	}
+}
+
+func testEvaluationAggregateWithLineage(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	root, err := s.AgentDefCreate(ctx, mkDef("ln-root", "lineageagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := s.AgentDefCreate(ctx, mkDef("ln-child", "lineageagent", root.DefID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2 evals on root, 3 evals on child.
+	for i := 0; i < 2; i++ {
+		_, _ = s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID: fmt.Sprintf("rt-%d", i), RunID: fmt.Sprintf("r-rt-%d", i),
+			DefID: root.DefID, Score: 0.5, EmitterRole: "external",
+		})
+	}
+	for i := 0; i < 3; i++ {
+		_, _ = s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID: fmt.Sprintf("ch-%d", i), RunID: fmt.Sprintf("r-ch-%d", i),
+			DefID: child.DefID, Score: 1.0, EmitterRole: "external",
+		})
+	}
+	// Without lineage: only child's 3.
+	agg, err := s.EvaluationAggregate(ctx, child.DefID, store.AggregateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 3 {
+		t.Errorf("no-lineage count = %d, want 3", agg.Count)
+	}
+	// With lineage: 3 + 2 = 5.
+	agg, err = s.EvaluationAggregate(ctx, child.DefID, store.AggregateOpts{IncludeLineage: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 5 {
+		t.Errorf("with-lineage count = %d, want 5", agg.Count)
+	}
+	if !agg.LineageIncluded {
+		t.Error("LineageIncluded flag not set")
 	}
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -339,6 +339,63 @@ func EventEmitter(ctx context.Context) EventEmitterFunc {
 	return func(providers.Event) {}
 }
 
+// ctxKeyAgentDefPolicy carries the v0.8.5 AgentDef-tool capability
+// gate. Mirrors MemoryPolicy / ChannelPolicy shape.
+type ctxKeyAgentDefPolicy struct{}
+
+// AgentDefPolicyValue is the per-agent AgentDef-tool access policy.
+//
+//   - Scopes is the operator-yaml agent_def_scopes list. Closed set:
+//     "self" / "descendants" / "any" / "named:<name>". Empty =
+//     default-deny.
+//
+// Auxiliary identity fields stamped server-side at ctx-attach so the
+// AgentDef tool can resolve self / siblings / descendants without
+// re-reading ctx values that may have been overwritten by sub-agent
+// chains:
+//
+//   - SelfName is the yaml agent name (== tools.AgentName(ctx) at
+//     attach time). Used for the "self" scope check.
+type AgentDefPolicyValue struct {
+	Scopes   []string
+	SelfName string
+}
+
+// WithAgentDefPolicy attaches the policy to ctx.
+func WithAgentDefPolicy(ctx context.Context, p AgentDefPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentDefPolicy{}, p)
+}
+
+// AgentDefPolicy returns the policy from ctx. Zero value = no
+// access (default-deny — the tool refuses every mutation op until
+// scopes are explicitly granted via yaml).
+func AgentDefPolicy(ctx context.Context) AgentDefPolicyValue {
+	v, _ := ctx.Value(ctxKeyAgentDefPolicy{}).(AgentDefPolicyValue)
+	return v
+}
+
+// ctxKeyEvaluationPolicy carries the v0.8.5 Evaluation-tool gate.
+type ctxKeyEvaluationPolicy struct{}
+
+// EvaluationPolicyValue is the per-agent Evaluation policy.
+// Multi-select scopes; default-deny when Scopes is empty. See
+// config.AgentDef.EvaluationScopes docstring for the closed set.
+type EvaluationPolicyValue struct {
+	Scopes []string
+}
+
+// WithEvaluationPolicy attaches the policy to ctx.
+func WithEvaluationPolicy(ctx context.Context, p EvaluationPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyEvaluationPolicy{}, p)
+}
+
+// EvaluationPolicy returns the policy from ctx. Zero value =
+// no access.
+func EvaluationPolicy(ctx context.Context) EvaluationPolicyValue {
+	v, _ := ctx.Value(ctxKeyEvaluationPolicy{}).(EvaluationPolicyValue)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names consult
 // the optional Fallback before returning the standard "tool not found"
 // error result (the model can self-correct on the error result; we never


### PR DESCRIPTION
## Summary

PR 2 of seven in the **Self-Evolution Substrate (v0.8.5)** sequence. Wires the v0.8.5 capability gates into config + the ctx chain. **Stacked on PR 1** ([feature-substrate-pr1-storage](https://github.com/denn-gubsky/loomcycle/pull/65)); when PR 1 merges, GitHub auto-rebases this PR's base to main.

No tool surface yet — PRs 3 + 4 introduce the AgentDef and Evaluation built-in tools that consume these policies. ~200 LOC.

## What changes

**`config.AgentDef` gains two yaml fields:**
- `agent_def_scopes: []string` — AgentDef-tool capability gate. Closed set: `"self"` / `"descendants"` / `"any"` / `"named:<name>"`. Empty = default-deny.
- `evaluation_scopes: []string` — Evaluation-tool capability gate. Multi-select: `submit_self` / `submit_siblings` / `submit_descendants` / `submit_any` / `read_any`. Empty = default-deny.

**`internal/tools/tool.go` ctx-key plumbing** (mirror of `WithMemoryPolicy` / `WithChannelPolicy` / `WithEventEmitter`):

```go
type AgentDefPolicyValue struct { Scopes []string; SelfName string }
type EvaluationPolicyValue struct { Scopes []string }
WithAgentDefPolicy / AgentDefPolicy
WithEvaluationPolicy / EvaluationPolicy
```

`SelfName` on `AgentDefPolicyValue` is stamped server-side at ctx-attach time (= `tools.AgentName(ctx)` at attach moment). Carried separately so the "self" scope check is robust to any future ctx-stack reshape.

**`internal/api/http/server.go`**: new `substratePoliciesForAgent` helper threads the policies into all 4 ctx-attach sites + sub-agent path:

- `handleRuns` (top-level POST /v1/runs)
- `runRequest` path
- `messagesContinuation` (POST /v1/sessions/{id}/messages)
- `runSubAgent` (Agent-tool spawn)

Sub-agent inherits the CHILD's yaml policies (not the parent's — same pattern as Memory and Channel), with `selfName` = the sub-agent's name.

**`internal/agents/loader.go`**: frontmatter loader gains both new fields so MD-discovered agents can declare scopes directly without going through yaml override.

**`config.validate()`**: per-agent validation:
- `validateAgentDefScope` enforces the closed set including the `"named:<name>"` prefix-typed entries (rejects empty name after `named:`)
- `validEvaluationScopes` is a flat map check
- Bad entries fail at config-load with pointed errors

**`mergeAgentDef`**: yaml-overrides-MD precedence applied to both new fields (mirror of `Channels.Publish/Subscribe` handling).

## What does NOT change

- No tool surface — PRs 3 + 4 wire the AgentDef + Evaluation tools.
- No `resolveAgent` signature change — the DB-backed resolution path (`AgentDefGetActive` → `cfg.Agents` fallback) lands in PR 5 alongside sub-agent pinning.
- No `runs.agent_def_id` population — also PR 5.

This PR scope is deliberately contained: just the policies + ctx plumbing so PRs 3 + 4 can consume `AgentDefPolicy(ctx)` / `EvaluationPolicy(ctx)` immediately.

## Test plan

- [x] `go test ./...` clean (no regressions).
- [x] `gofmt -l` clean.
- [x] Binary builds clean.
- [x] Validation rejects bad scope entries at config-load (manual eyeball; will get a dedicated config_test.go subtest in PR 3 where the AgentDef tool starts depending on the policy).
- [ ] Operator eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)