### PR TITLE
feat(substrate): v0.8.5 PR 3 — AgentDef built-in tool

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -220,6 +220,16 @@ func main() {
 	}
 	allTools = append(allTools, channelTool)
 
+	// AgentDef tool (v0.8.5). Per-agent default-deny via
+	// agent_def_scopes yaml; the tool itself is registered globally
+	// and the policy gate runs inside Execute.
+	agentDefTool := &builtin.AgentDef{
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
+		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
+	}
+	allTools = append(allTools, agentDefTool)
+
 	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
 	// in loomcycle.yaml, parse the OpenAPI spec and register one tool
 	// per operation. Each tool forwards calls to local_api.base_url
@@ -384,6 +394,7 @@ func main() {
 	// fallback for operators running without a configured store.
 	memoryTool.Store = storeIface
 	channelTool.Store = storeIface
+	agentDefTool.Store = storeIface
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
 	srv.SetMCPFallback(mcpLazyResolver.Resolve)
 

--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -72,6 +72,15 @@ type Agent struct {
 	// Channels is the v0.8.4 Channel-tool ACL. Empty Publish /
 	// Subscribe = no access on that side.
 	Channels AgentChannelACL
+	// AgentDefScopes is the v0.8.5 AgentDef-tool capability gate.
+	// Closed set: "self" / "descendants" / "named:<name>" / "any".
+	// Empty = default-deny.
+	AgentDefScopes []string
+	// EvaluationScopes is the v0.8.5 Evaluation-tool capability gate.
+	// Closed set: "submit_self" / "submit_siblings" /
+	// "submit_descendants" / "submit_any" / "read_any". Empty =
+	// default-deny.
+	EvaluationScopes []string
 	// Path is the absolute path of the source MD, kept for diagnostic
 	// logging (skills/loader.go follows the same convention).
 	Path string
@@ -211,6 +220,8 @@ type frontmatter struct {
 	MemoryScopes     []string                   `yaml:"memory_scopes"`
 	MemoryQuotaBytes int                        `yaml:"memory_quota_bytes"`
 	Channels         AgentChannelACL            `yaml:"channels"`
+	AgentDefScopes   []string                   `yaml:"agent_def_scopes"`
+	EvaluationScopes []string                   `yaml:"evaluation_scopes"`
 	SystemPromptFile string                     `yaml:"system_prompt_file"`
 	// SystemPrompt as an inline frontmatter field is intentionally
 	// NOT supported. The body of the MD is the prompt; if you want a
@@ -271,6 +282,8 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.MemoryScopes = fm.MemoryScopes
 	a.MemoryQuotaBytes = fm.MemoryQuotaBytes
 	a.Channels = fm.Channels
+	a.AgentDefScopes = fm.AgentDefScopes
+	a.EvaluationScopes = fm.EvaluationScopes
 	a.SystemPromptFile = fm.SystemPromptFile
 	a.SystemPrompt = body
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -304,6 +304,22 @@ func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
 	}
 }
 
+// substratePoliciesForAgent returns the v0.8.5 AgentDef +
+// Evaluation policies for one agent. Mirrors channelPolicyForAgent's
+// shape. selfName is the resolved agent name as seen by the ctx
+// chain (== tools.AgentName at attach time); stamped onto the
+// AgentDef policy so the tool's "self" scope check is robust to
+// any future ctx-stack mutations.
+func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName string) (tools.AgentDefPolicyValue, tools.EvaluationPolicyValue) {
+	return tools.AgentDefPolicyValue{
+			Scopes:   agentDef.AgentDefScopes,
+			SelfName: selfName,
+		},
+		tools.EvaluationPolicyValue{
+			Scopes: agentDef.EvaluationScopes,
+		}
+}
+
 // channelPolicyForAgent builds the v0.8.4 Channel-tool policy from
 // the agent yaml + the top-level `channels:` block. Returns a value
 // suitable for tools.WithChannelPolicy. The Channels map is a copy
@@ -592,6 +608,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -1091,6 +1110,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1375,6 +1397,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	})
 	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
+	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
+	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
+	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -1870,6 +1895,13 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	// subEmit above). Channel-tool publishes from inside the sub
 	// surface on the sub's SSE stream, not the parent's.
 	subCtx = tools.WithEventEmitter(subCtx, subEmit)
+	// Sub-agent's substrate policies come from ITS OWN yaml — same
+	// shape as Memory/Channel. selfName is the sub's name so the
+	// "self" scope resolves to the sub-agent's identity, not the
+	// parent's.
+	subADPolicy, subEvPolicy := s.substratePoliciesForAgent(def, name)
+	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
+	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -305,6 +305,46 @@ type AgentDef struct {
 	// operator-yaml is the floor; the model can never enlarge its
 	// own access. Sub-agents inherit the parent's ACL via ctx.
 	Channels AgentChannelACL `yaml:"channels"`
+
+	// AgentDefScopes is the v0.8.5 AgentDef tool capability gate.
+	// Default-deny when empty. Mirrors MemoryScopes' shape — having
+	// AgentDef in allowed_tools is necessary but not sufficient; this
+	// list narrows which mutation paths the agent can take. Closed
+	// set:
+	//
+	//   - "self"         → may fork/promote/retire its OWN name
+	//                       (== tools.AgentName(ctx))
+	//   - "descendants"  → may operate on any def whose lineage chain
+	//                       traces back to a def the agent created
+	//   - "named:<name>" → may operate on the specified single name
+	//                       (multi-entry: "named:foo" + "named:bar")
+	//   - "any"          → unrestricted (operator-blessed orchestrator
+	//                       privilege)
+	//
+	// "any" is intentionally a single string ("any") rather than a
+	// wildcard pattern so the model never authors mass-mutation
+	// access via a templated string.
+	AgentDefScopes []string `yaml:"agent_def_scopes"`
+
+	// EvaluationScopes is the v0.8.5 Evaluation tool capability gate.
+	// Multi-select; default-deny when empty. Closed set:
+	//
+	//   - "submit_self"        → may emit evaluations against own runs
+	//   - "submit_siblings"    → may emit evaluations against sibling
+	//                             runs (same parent_agent_id)
+	//   - "submit_descendants" → may emit evaluations against the
+	//                             agent's spawn-tree descendants
+	//   - "submit_any"         → unrestricted submit (operator
+	//                             override; emitter_role = "unrelated"
+	//                             when the agent has no kinship)
+	//   - "read_any"           → may call list/aggregate ops against
+	//                             any def or run
+	//
+	// Emitter role is derived server-side from the emitter's ctx vs
+	// the target run's identity; the model never supplies it. The
+	// scope list gates WHICH emitter roles the agent is allowed to
+	// produce.
+	EvaluationScopes []string `yaml:"evaluation_scopes"`
 }
 
 // Channel is one operator-declared channel in the top-level
@@ -1091,6 +1131,8 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 			Publish:   d.Channels.Publish,
 			Subscribe: d.Channels.Subscribe,
 		},
+		AgentDefScopes:   d.AgentDefScopes,
+		EvaluationScopes: d.EvaluationScopes,
 	}
 	if len(d.Models) > 0 {
 		def.Models = make(map[string][]TierCandidate, len(d.Models))
@@ -1178,6 +1220,12 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.Channels.Subscribe != nil {
 		out.Channels.Subscribe = override.Channels.Subscribe
+	}
+	if override.AgentDefScopes != nil {
+		out.AgentDefScopes = override.AgentDefScopes
+	}
+	if override.EvaluationScopes != nil {
+		out.EvaluationScopes = override.EvaluationScopes
 	}
 	return out
 }
@@ -1379,6 +1427,43 @@ var validChannelSemantics = map[string]bool{
 	"broadcast": true,
 }
 
+// validEvaluationScopes is the closed set of Evaluation-tool scope
+// strings. See AgentDef.EvaluationScopes docstring for the meaning
+// of each.
+var validEvaluationScopes = map[string]bool{
+	"submit_self":        true,
+	"submit_siblings":    true,
+	"submit_descendants": true,
+	"submit_any":         true,
+	"read_any":           true,
+}
+
+// validateAgentDefScope checks one entry in an agent's
+// agent_def_scopes list. Closed set:
+//
+//   - "self"
+//   - "descendants"
+//   - "any"
+//   - "named:<name>" where <name> is non-empty
+//
+// The "named:" prefix is the only stringly-typed exception — keeps
+// the yaml authoring ergonomic. Empty name in "named:" is rejected
+// at config-load.
+func validateAgentDefScope(sc string) error {
+	switch sc {
+	case "self", "descendants", "any":
+		return nil
+	}
+	if strings.HasPrefix(sc, "named:") {
+		ref := strings.TrimPrefix(sc, "named:")
+		if ref == "" {
+			return fmt.Errorf("agent_def_scopes: \"named:\" requires a non-empty name (e.g. \"named:coder\")")
+		}
+		return nil
+	}
+	return fmt.Errorf("unknown scope %q (want one of: self, descendants, any, or \"named:<name>\")", sc)
+}
+
 // validateAgentChannelEntry checks one publish/subscribe entry on
 // an AgentDef.Channels list. Exact match → must reference a declared
 // channel. Trailing "/*" wildcard → must match at least one declared
@@ -1541,6 +1626,20 @@ func validate(c *Config) error {
 		for i, ch := range agent.Channels.Subscribe {
 			if err := validateAgentChannelEntry(c.Channels, ch); err != nil {
 				return fmt.Errorf("agent %q: channels.subscribe[%d]: %w", name, i, err)
+			}
+		}
+		// AgentDef tool (v0.8.5): validate agent_def_scopes entries.
+		// Closed set: "self" / "descendants" / "named:<name>" / "any".
+		for i, sc := range agent.AgentDefScopes {
+			if err := validateAgentDefScope(sc); err != nil {
+				return fmt.Errorf("agent %q: agent_def_scopes[%d]: %w", name, i, err)
+			}
+		}
+		// Evaluation tool (v0.8.5): validate evaluation_scopes entries.
+		// Closed set as documented on AgentDef.EvaluationScopes.
+		for i, sc := range agent.EvaluationScopes {
+			if !validEvaluationScopes[sc] {
+				return fmt.Errorf("agent %q: evaluation_scopes[%d]: unknown scope %q (want one of: submit_self, submit_siblings, submit_descendants, submit_any, read_any)", name, i, sc)
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -656,6 +656,30 @@ type Env struct {
 	// Env: LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS.
 	ChannelsLongPollCapMS int
 
+	// AgentDefMaxDefinitionBytes caps a single AgentDef.create or
+	// AgentDef.fork's serialised definition JSON (v0.8.5). Default
+	// 131072 (128 KB). 0 disables. Mirrors MemoryMaxValueBytes's
+	// negative-as-disable convention.
+	// Env: LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES.
+	AgentDefMaxDefinitionBytes int
+
+	// AgentDefMaxDescriptionBytes caps the free-text description
+	// field on AgentDef.create / fork (v0.8.5). Default 8192 (8 KB).
+	// 0 disables.
+	// Env: LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES.
+	AgentDefMaxDescriptionBytes int
+
+	// EvaluationMaxJudgementBytes caps the structured-judgement JSON
+	// on Evaluation.submit (v0.8.5). Default 32768 (32 KB). 0 disables.
+	// Env: LOOMCYCLE_EVALUATION_MAX_JUDGEMENT_BYTES.
+	EvaluationMaxJudgementBytes int
+
+	// EvaluationMaxRationaleBytes caps the natural-language rationale
+	// text on Evaluation.submit (v0.8.5). Default 8192 (8 KB).
+	// 0 disables.
+	// Env: LOOMCYCLE_EVALUATION_MAX_RATIONALE_BYTES.
+	EvaluationMaxRationaleBytes int
+
 	// ProviderHeaderTimeout is the per-attempt cap on time-to-first-
 	// byte for streaming provider HTTP calls (set on each driver's
 	// http.Transport.ResponseHeaderTimeout). Default 60s — generous
@@ -951,6 +975,49 @@ func Load(path string) (*Config, error) {
 				cfg.Env.ChannelsLongPollCapMS = 0
 			} else {
 				cfg.Env.ChannelsLongPollCapMS = n
+			}
+		}
+	}
+
+	// v0.8.5 substrate caps. Same negative-as-disable convention as
+	// Memory + Channel sibling caps.
+	cfg.Env.AgentDefMaxDefinitionBytes = 131072
+	if v := os.Getenv("LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.AgentDefMaxDefinitionBytes = 0
+			} else {
+				cfg.Env.AgentDefMaxDefinitionBytes = n
+			}
+		}
+	}
+	cfg.Env.AgentDefMaxDescriptionBytes = 8192
+	if v := os.Getenv("LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.AgentDefMaxDescriptionBytes = 0
+			} else {
+				cfg.Env.AgentDefMaxDescriptionBytes = n
+			}
+		}
+	}
+	cfg.Env.EvaluationMaxJudgementBytes = 32768
+	if v := os.Getenv("LOOMCYCLE_EVALUATION_MAX_JUDGEMENT_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.EvaluationMaxJudgementBytes = 0
+			} else {
+				cfg.Env.EvaluationMaxJudgementBytes = n
+			}
+		}
+	}
+	cfg.Env.EvaluationMaxRationaleBytes = 8192
+	if v := os.Getenv("LOOMCYCLE_EVALUATION_MAX_RATIONALE_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.EvaluationMaxRationaleBytes = 0
+			} else {
+				cfg.Env.EvaluationMaxRationaleBytes = n
 			}
 		}
 	}

--- a/internal/store/postgres/migrations/0006_agent_defs.down.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.down.sql
@@ -1,0 +1,7 @@
+-- 0006_agent_defs.down.sql — drop the v0.8.5 substrate def-storage.
+-- Order matters: agent_def_active references agent_defs.
+DROP INDEX IF EXISTS agent_defs_by_run;
+DROP INDEX IF EXISTS agent_defs_by_parent;
+DROP INDEX IF EXISTS agent_defs_by_name;
+DROP TABLE IF EXISTS agent_def_active;
+DROP TABLE IF EXISTS agent_defs;

--- a/internal/store/postgres/migrations/0006_agent_defs.up.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.up.sql
@@ -1,5 +1,13 @@
 -- 0006_agent_defs.up.sql — v0.8.5 Self-Evolution Substrate storage.
 --
+-- (No 0005 — that slot was reserved for a v0.8.4 follow-up that
+-- shipped inline in 0004 instead. The gap is intentional; golang-
+-- migrate applies migrations in numeric order and does not require
+-- sequential numbering. Future cherry-picks MUST NOT fill the gap
+-- on a deployed database — golang-migrate refuses to apply a
+-- migration with a number lower than the database's current version.
+-- Use 0009+ for any new migration.)
+--
 -- Two tables. agent_defs is the append-only versioned-definition
 -- layer (operator-blessed static MDs remain the immutable root in
 -- cfg.Agents; this is the DERIVED layer of agent-authored versions).

--- a/internal/store/postgres/migrations/0006_agent_defs.up.sql
+++ b/internal/store/postgres/migrations/0006_agent_defs.up.sql
@@ -1,0 +1,46 @@
+-- 0006_agent_defs.up.sql — v0.8.5 Self-Evolution Substrate storage.
+--
+-- Two tables. agent_defs is the append-only versioned-definition
+-- layer (operator-blessed static MDs remain the immutable root in
+-- cfg.Agents; this is the DERIVED layer of agent-authored versions).
+-- agent_def_active is the per-name "which version is current"
+-- pointer.
+--
+-- Why two tables and not is_active BOOL on agent_defs:
+--   - Partial-unique indexes for "one active per name" diverge
+--     between SQLite and Postgres syntax.
+--   - Promote/rollback is a one-row UPDATE here, vs a two-row
+--     UPDATE flipping the flag. Symmetric.
+--   - Per-tenant active pointers (future v0.9.x) extend the PK to
+--     (tenant_id, name); the agent_defs rows stay tenant-agnostic.
+--
+-- definition is JSONB so a future "find forks similar to this one"
+-- query can use @> operators without a migration. Description is
+-- free-text "why I made this" — capped in the application layer
+-- (LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES, default 8 KB).
+
+CREATE TABLE agent_defs (
+    def_id                    TEXT        PRIMARY KEY,
+    name                      TEXT        NOT NULL,
+    version                   INTEGER     NOT NULL,
+    parent_def_id             TEXT        REFERENCES agent_defs(def_id),
+    definition                JSONB       NOT NULL,
+    description               TEXT,
+    created_at                TIMESTAMPTZ NOT NULL,
+    created_by_agent_id       TEXT,
+    created_by_run_id         TEXT,
+    retired                   BOOLEAN     NOT NULL DEFAULT FALSE,
+    bootstrapped_from_static  BOOLEAN     NOT NULL DEFAULT FALSE,
+    UNIQUE(name, version)
+);
+
+CREATE INDEX agent_defs_by_name   ON agent_defs(name, version DESC);
+CREATE INDEX agent_defs_by_parent ON agent_defs(parent_def_id) WHERE parent_def_id IS NOT NULL;
+CREATE INDEX agent_defs_by_run    ON agent_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL;
+
+CREATE TABLE agent_def_active (
+    name                  TEXT        PRIMARY KEY,
+    def_id                TEXT        NOT NULL REFERENCES agent_defs(def_id),
+    promoted_at           TIMESTAMPTZ NOT NULL,
+    promoted_by_agent_id  TEXT
+);

--- a/internal/store/postgres/migrations/0007_runs_agent_def.down.sql
+++ b/internal/store/postgres/migrations/0007_runs_agent_def.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS runs_by_agent_def;
+ALTER TABLE runs DROP COLUMN IF EXISTS agent_def_id;

--- a/internal/store/postgres/migrations/0007_runs_agent_def.up.sql
+++ b/internal/store/postgres/migrations/0007_runs_agent_def.up.sql
@@ -1,0 +1,12 @@
+-- 0007_runs_agent_def.up.sql — v0.8.5 runs.agent_def_id audit column.
+--
+-- NULL = "this run resolved against the static cfg.Agents fallback,
+-- no DB-versioned definition." That distinguishes static-resolved
+-- runs from DB-resolved runs without a separate flag column. Cost
+-- retros + experiment audits facet on this.
+--
+-- Additive ALTER on an existing table; no row lock in Postgres ≥ 11
+-- because the new column has no DEFAULT (NULL is free).
+
+ALTER TABLE runs ADD COLUMN agent_def_id TEXT;
+CREATE INDEX runs_by_agent_def ON runs(agent_def_id) WHERE agent_def_id IS NOT NULL;

--- a/internal/store/postgres/migrations/0008_evaluations.down.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS evaluations_by_emitter;
+DROP INDEX IF EXISTS evaluations_by_def;
+DROP INDEX IF EXISTS evaluations_by_run;
+DROP TABLE IF EXISTS evaluations;

--- a/internal/store/postgres/migrations/0008_evaluations.up.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.up.sql
@@ -16,6 +16,13 @@
 -- (operator chooses; substrate is range-agnostic). Dimensions are
 -- arbitrary named axes; judgement is free-form JSON. All capped at
 -- the application layer (LOOMCYCLE_EVALUATION_MAX_* env vars).
+--
+-- NO foreign keys on run_id or def_id: evaluations are an immutable
+-- audit log and must survive any future run/def pruning. Referential
+-- integrity is enforced at the application layer (EvaluationSubmit
+-- validates run_id exists before inserting). A RESTRICT FK would
+-- block legitimate admin pruning workflows; CASCADE would silently
+-- delete audit data. Mirrors the SQLite schema in sqlite.go.
 
 CREATE TABLE evaluations (
     eval_id            TEXT             PRIMARY KEY,

--- a/internal/store/postgres/migrations/0008_evaluations.up.sql
+++ b/internal/store/postgres/migrations/0008_evaluations.up.sql
@@ -1,0 +1,36 @@
+-- 0008_evaluations.up.sql — v0.8.5 Self-Evolution Substrate evals.
+--
+-- Pure-insert table; agents call EvaluationSubmit per scored run.
+-- def_id is denormalised from runs.agent_def_id at submit time —
+-- captures which version the run actually targeted at the moment
+-- the eval landed, robust to later promote / retire ops.
+--
+-- emitter_role is server-derived from ctx + run identity (the
+-- store does NOT compute it; the tool layer stamps it before
+-- handing the row off). Closed set: 'self' / 'sibling' / 'parent' /
+-- 'external' / 'unrelated'. Future v0.9.x experiments can add new
+-- role strings without a schema change.
+--
+-- Score is REAL (Postgres DOUBLE PRECISION) — the RL convention
+-- range [-1, 1] OR [0, 1] is enforced in the application layer
+-- (operator chooses; substrate is range-agnostic). Dimensions are
+-- arbitrary named axes; judgement is free-form JSON. All capped at
+-- the application layer (LOOMCYCLE_EVALUATION_MAX_* env vars).
+
+CREATE TABLE evaluations (
+    eval_id            TEXT             PRIMARY KEY,
+    run_id             TEXT             NOT NULL,
+    def_id             TEXT,
+    score              DOUBLE PRECISION NOT NULL,
+    dimensions         JSONB,
+    judgement          JSONB,
+    rationale          TEXT,
+    emitter_role       TEXT             NOT NULL,
+    emitter_agent_id   TEXT,
+    emitter_run_id     TEXT,
+    created_at         TIMESTAMPTZ      NOT NULL
+);
+
+CREATE INDEX evaluations_by_run     ON evaluations(run_id);
+CREATE INDEX evaluations_by_def     ON evaluations(def_id) WHERE def_id IS NOT NULL;
+CREATE INDEX evaluations_by_emitter ON evaluations(emitter_agent_id) WHERE emitter_agent_id IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1442,6 +1442,14 @@ func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded
 	return out
 }
 
+// statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
+// Latest is set here as vals[len-1]: callers MUST append in
+// created_at ASC order so the last element is the newest. For the
+// top-level Score axis the caller currently overwrites Latest after
+// returning (the input slice for that axis is built differently); for
+// the Dimensions and ByEmitterRole axes the value set here stands.
+// Mirrors the SQLite implementation in sqlite.go — duplicated
+// intentionally; extract to a shared package if a third backend lands.
 func statsOf(vals []float64) store.ScoreStats {
 	if len(vals) == 0 {
 		return store.ScoreStats{}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -14,10 +14,12 @@ package postgres
 import (
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -960,6 +962,513 @@ func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 		return 0, fmt.Errorf("channel sweep: %w", err)
 	}
 	return int(tag.RowsAffected()), nil
+}
+
+// ---- v0.8.5 Self-Evolution Substrate ----
+//
+// Postgres mirror of the SQLite implementation. Version-allocation
+// lock uses pg_advisory_xact_lock(hashtextextended('agent_def:' || name, 0))
+// inside the tx so concurrent forks against the same name serialise
+// without locking the whole table. The aggregation kernel
+// (computeAggregate / statsOf) is shared with sqlite.
+
+// AgentDefCreate allocates the next version for row.Name under a
+// per-name advisory lock and inserts. Validates parent_def_id.
+func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (store.AgentDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def: def_id + name required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Per-name advisory lock — serialises version allocation against
+	// concurrent forks of the SAME name. Different names proceed in
+	// parallel. The hash is deterministic so the same name always
+	// hashes to the same lock key.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"agent_def:"+row.Name,
+	); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create lock: %w", err)
+	}
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM agent_defs WHERE def_id = $1`, row.ParentDefID).Scan(&n); err != nil {
+			return store.AgentDefRow{}, fmt.Errorf("agent_def create parent check: %w", err)
+		}
+		if n == 0 {
+			return store.AgentDefRow{}, store.ErrAgentDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM agent_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def create max version: %w", err)
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now().UTC()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO agent_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11)`,
+		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
+		string(row.Definition), nullableString(row.Description),
+		row.CreatedAt,
+		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
+		row.Retired, row.BootstrappedFromStatic,
+	); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def insert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def commit: %w", err)
+	}
+	return row, nil
+}
+
+// AgentDefGet returns one row by def_id.
+func (s *Store) AgentDefGet(ctx context.Context, defID string) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.pool.QueryRow(ctx, agentDefSelect+` WHERE def_id = $1`, defID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return row, err
+}
+
+// AgentDefGetByNameVersion returns one row by (name, version).
+func (s *Store) AgentDefGetByNameVersion(ctx context.Context, name string, version int) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.pool.QueryRow(ctx, agentDefSelect+` WHERE name = $1 AND version = $2`, name, version))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+// AgentDefListByName returns rows for one name, version DESC.
+func (s *Store) AgentDefListByName(ctx context.Context, name string) ([]store.AgentDefRow, error) {
+	rows, err := s.pool.Query(ctx, agentDefSelect+` WHERE name = $1 ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list by name: %w", err)
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListChildren returns immediate children.
+func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([]store.AgentDefRow, error) {
+	rows, err := s.pool.Query(ctx, agentDefSelect+` WHERE parent_def_id = $1 ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list children: %w", err)
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListNames returns one summary per distinct name.
+func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM agent_defs d
+		LEFT JOIN agent_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, fmt.Errorf("agent_def list names: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.AgentDefNameSummary
+	for rows.Next() {
+		var s store.AgentDefNameSummary
+		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &s.LastUpdated, &s.ActiveDefID); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
+func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	var rowName string
+	err := s.pool.QueryRow(ctx, `SELECT name FROM agent_defs WHERE def_id = $1`, defID).Scan(&rowName)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	if err != nil {
+		return fmt.Errorf("agent_def_active check: %w", err)
+	}
+	if rowName != name {
+		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (name) DO UPDATE SET
+		    def_id               = EXCLUDED.def_id,
+		    promoted_at          = EXCLUDED.promoted_at,
+		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
+		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("agent_def_active upsert: %w", err)
+	}
+	return nil
+}
+
+// AgentDefGetActive returns the active row for name. *ErrNotFound
+// when no pointer exists.
+func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+	var defID string
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM agent_def_active WHERE name = $1`, name).Scan(&defID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
+	}
+	if err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def_active lookup: %w", err)
+	}
+	return s.AgentDefGet(ctx, defID)
+}
+
+// AgentDefSetRetired flips the retired flag.
+func (s *Store) AgentDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	tag, err := s.pool.Exec(ctx, `UPDATE agent_defs SET retired = $1 WHERE def_id = $2`, retired, defID)
+	if err != nil {
+		return fmt.Errorf("agent_def set retired: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return nil
+}
+
+const agentDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition::text,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM agent_defs`
+
+func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
+	var (
+		out        store.AgentDefRow
+		definition string
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&out.CreatedAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&out.Retired, &out.BootstrappedFromStatic,
+	)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	return out, nil
+}
+
+func (s *Store) scanAgentDefRows(rows pgx.Rows) ([]store.AgentDefRow, error) {
+	var out []store.AgentDefRow
+	for rows.Next() {
+		var (
+			r          store.AgentDefRow
+			definition string
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&r.CreatedAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&r.Retired, &r.BootstrappedFromStatic,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- Evaluation ----
+
+func (s *Store) EvaluationSubmit(ctx context.Context, row store.EvaluationRow) (store.EvaluationRow, error) {
+	if row.EvalID == "" || row.RunID == "" || row.EmitterRole == "" {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation: eval_id, run_id, emitter_role required")
+	}
+	row.CreatedAt = time.Now().UTC()
+	var dimsJSON, judgementJSON any
+	if len(row.Dimensions) > 0 {
+		b, err := json.Marshal(row.Dimensions)
+		if err != nil {
+			return store.EvaluationRow{}, fmt.Errorf("evaluation: marshal dimensions: %w", err)
+		}
+		dimsJSON = string(b)
+	}
+	if len(row.Judgement) > 0 {
+		judgementJSON = string(row.Judgement)
+	}
+	if _, err := s.pool.Exec(ctx, `
+		INSERT INTO evaluations (
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11)`,
+		row.EvalID, row.RunID, nullableString(row.DefID), row.Score,
+		dimsJSON, judgementJSON, nullableString(row.Rationale),
+		row.EmitterRole, nullableString(row.EmitterAgentID), nullableString(row.EmitterRunID),
+		row.CreatedAt,
+	); err != nil {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation submit: %w", err)
+	}
+	return row, nil
+}
+
+func (s *Store) EvaluationGet(ctx context.Context, evalID string) (store.EvaluationRow, error) {
+	row, err := s.scanEvaluation(s.pool.QueryRow(ctx, evaluationSelect+` WHERE eval_id = $1`, evalID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.EvaluationRow{}, &store.ErrNotFound{Kind: "evaluation", ID: evalID}
+	}
+	return row, err
+}
+
+func (s *Store) EvaluationListForRun(ctx context.Context, runID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE run_id = $1 ORDER BY created_at DESC LIMIT $2`, runID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation list for run: %w", err)
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+func (s *Store) EvaluationListForDef(ctx context.Context, defID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE def_id = $1 ORDER BY created_at DESC LIMIT $2`, defID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("evaluation list for def: %w", err)
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+func (s *Store) EvaluationAggregate(ctx context.Context, defID string, opts store.AggregateOpts) (store.AggregateResult, error) {
+	defIDs := []string{defID}
+	if opts.IncludeLineage {
+		ancestors, err := s.walkAncestors(ctx, defID)
+		if err != nil {
+			return store.AggregateResult{}, err
+		}
+		defIDs = append(defIDs, ancestors...)
+	}
+	if len(defIDs) > 1000 {
+		defIDs = defIDs[:1000]
+	}
+	rows, err := s.pool.Query(ctx, evaluationSelect+` WHERE def_id = ANY($1) ORDER BY created_at ASC`, defIDs)
+	if err != nil {
+		return store.AggregateResult{}, fmt.Errorf("evaluation aggregate: %w", err)
+	}
+	defer rows.Close()
+	evals, err := s.scanEvaluationRows(rows)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	return computeAggregate(defID, evals, opts.IncludeLineage), nil
+}
+
+func (s *Store) walkAncestors(ctx context.Context, defID string) ([]string, error) {
+	var ancestors []string
+	seen := map[string]bool{defID: true}
+	cur := defID
+	for i := 0; i < 100; i++ {
+		var parent sql.NullString
+		err := s.pool.QueryRow(ctx, `SELECT parent_def_id FROM agent_defs WHERE def_id = $1`, cur).Scan(&parent)
+		if errors.Is(err, pgx.ErrNoRows) || !parent.Valid || parent.String == "" {
+			return ancestors, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if seen[parent.String] {
+			return ancestors, nil
+		}
+		seen[parent.String] = true
+		ancestors = append(ancestors, parent.String)
+		cur = parent.String
+	}
+	return ancestors, nil
+}
+
+const evaluationSelect = `SELECT
+	eval_id, run_id,
+	COALESCE(def_id, ''),
+	score,
+	COALESCE(dimensions::text, ''),
+	COALESCE(judgement::text, ''),
+	COALESCE(rationale, ''),
+	emitter_role,
+	COALESCE(emitter_agent_id, ''),
+	COALESCE(emitter_run_id, ''),
+	created_at
+FROM evaluations`
+
+func (s *Store) scanEvaluation(row pgx.Row) (store.EvaluationRow, error) {
+	var (
+		out                   store.EvaluationRow
+		dimensions, judgement string
+	)
+	if err := row.Scan(
+		&out.EvalID, &out.RunID, &out.DefID, &out.Score,
+		&dimensions, &judgement, &out.Rationale,
+		&out.EmitterRole, &out.EmitterAgentID, &out.EmitterRunID,
+		&out.CreatedAt,
+	); err != nil {
+		return store.EvaluationRow{}, err
+	}
+	if dimensions != "" {
+		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+	}
+	if judgement != "" {
+		out.Judgement = json.RawMessage(judgement)
+	}
+	return out, nil
+}
+
+func (s *Store) scanEvaluationRows(rows pgx.Rows) ([]store.EvaluationRow, error) {
+	var out []store.EvaluationRow
+	for rows.Next() {
+		var (
+			r                     store.EvaluationRow
+			dimensions, judgement string
+		)
+		if err := rows.Scan(
+			&r.EvalID, &r.RunID, &r.DefID, &r.Score,
+			&dimensions, &judgement, &r.Rationale,
+			&r.EmitterRole, &r.EmitterAgentID, &r.EmitterRunID,
+			&r.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if dimensions != "" {
+			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+		}
+		if judgement != "" {
+			r.Judgement = json.RawMessage(judgement)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// nullableString returns sql.NullString-equivalent for pgx Exec args.
+// pgx accepts `nil` for NULL; empty strings stay as empty NOT NULL —
+// but our columns are TEXT NULL so we pass nil to mean NULL.
+func nullableString(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// computeAggregate + statsOf are defined in the sqlite adapter and
+// live in package store_sqlite. To avoid duplicating the aggregation
+// kernel, we redeclare it here as well — the two packages don't
+// share a parent except `store`, and putting the kernel in `store`
+// would force `store` to know about ScoreStats math. Leaving these
+// here for now; if a third backend lands we'll extract a helper
+// package.
+//
+// (Below copies are intentionally identical to sqlite's bodies.)
+
+func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded bool) store.AggregateResult {
+	out := store.AggregateResult{
+		DefID:           defID,
+		Count:           len(evals),
+		LineageIncluded: lineageIncluded,
+	}
+	if len(evals) == 0 {
+		return out
+	}
+	scores := make([]float64, len(evals))
+	dimAcc := map[string][]float64{}
+	roleAcc := map[string][]float64{}
+	for i, e := range evals {
+		scores[i] = e.Score
+		for k, v := range e.Dimensions {
+			dimAcc[k] = append(dimAcc[k], v)
+		}
+		roleAcc[e.EmitterRole] = append(roleAcc[e.EmitterRole], e.Score)
+	}
+	out.Score = statsOf(scores)
+	out.Score.Latest = evals[len(evals)-1].Score
+	if len(dimAcc) > 0 {
+		out.Dimensions = make(map[string]store.ScoreStats, len(dimAcc))
+		for k, v := range dimAcc {
+			out.Dimensions[k] = statsOf(v)
+		}
+	}
+	if len(roleAcc) > 0 {
+		out.ByEmitterRole = make(map[string]store.ScoreStats, len(roleAcc))
+		for k, v := range roleAcc {
+			out.ByEmitterRole[k] = statsOf(v)
+		}
+	}
+	return out
+}
+
+func statsOf(vals []float64) store.ScoreStats {
+	if len(vals) == 0 {
+		return store.ScoreStats{}
+	}
+	out := store.ScoreStats{Count: len(vals), Min: vals[0], Max: vals[0]}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+		if v < out.Min {
+			out.Min = v
+		}
+		if v > out.Max {
+			out.Max = v
+		}
+	}
+	out.Mean = sum / float64(len(vals))
+	out.Latest = vals[len(vals)-1]
+	sorted := make([]float64, len(vals))
+	copy(sorted, vals)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		out.Median = sorted[mid]
+	} else {
+		out.Median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return out
 }
 
 // escapeLikePrefix neutralises the LIKE wildcards in `prefix` so an

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -136,6 +137,54 @@ func (s *Store) migrate(ctx context.Context) error {
 			updated_at INTEGER NOT NULL,
 			PRIMARY KEY (channel, scope, scope_id)
 		)`,
+		// v0.8.5 Self-Evolution Substrate — see
+		// internal/store/postgres/migrations/0006_agent_defs.up.sql for
+		// the full design rationale. SQLite mirrors the shape; INTEGER
+		// boolean (0/1) instead of Postgres BOOLEAN, unix-nano INTEGER
+		// timestamps instead of TIMESTAMPTZ, TEXT JSON instead of JSONB.
+		`CREATE TABLE IF NOT EXISTS agent_defs (
+			def_id                    TEXT    PRIMARY KEY,
+			name                      TEXT    NOT NULL,
+			version                   INTEGER NOT NULL,
+			parent_def_id             TEXT    REFERENCES agent_defs(def_id),
+			definition                TEXT    NOT NULL,
+			description               TEXT,
+			created_at                INTEGER NOT NULL,
+			created_by_agent_id       TEXT,
+			created_by_run_id         TEXT,
+			retired                   INTEGER NOT NULL DEFAULT 0,
+			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(name, version)
+		)`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_name   ON agent_defs(name, version DESC)`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_parent ON agent_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS agent_defs_by_run    ON agent_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS agent_def_active (
+			name                  TEXT    PRIMARY KEY,
+			def_id                TEXT    NOT NULL REFERENCES agent_defs(def_id),
+			promoted_at           INTEGER NOT NULL,
+			promoted_by_agent_id  TEXT
+		)`,
+		// v0.8.5 evaluations table. emitter_role is server-derived in
+		// the tool layer; the store stores the string verbatim. Score
+		// is REAL (Go float64). Dimensions + Judgement are JSON-as-TEXT
+		// (sqlite has no JSONB).
+		`CREATE TABLE IF NOT EXISTS evaluations (
+			eval_id            TEXT    PRIMARY KEY,
+			run_id             TEXT    NOT NULL,
+			def_id             TEXT,
+			score              REAL    NOT NULL,
+			dimensions         TEXT,
+			judgement          TEXT,
+			rationale          TEXT,
+			emitter_role       TEXT    NOT NULL,
+			emitter_agent_id   TEXT,
+			emitter_run_id     TEXT,
+			created_at         INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_run     ON evaluations(run_id)`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_def     ON evaluations(def_id) WHERE def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS evaluations_by_emitter ON evaluations(emitter_agent_id) WHERE emitter_agent_id IS NOT NULL`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -158,6 +207,12 @@ func (s *Store) migrate(ctx context.Context) error {
 		// new rows carry the name of the user_tier policy applied at
 		// run creation. Compliance + cost-retro queries facet on this.
 		`ALTER TABLE runs ADD COLUMN user_tier TEXT`,
+		// v0.8.5: agent_def_id audit column. NULL = the run resolved
+		// against the static cfg.Agents fallback (no DB-versioned def).
+		// Non-NULL = the run targeted a specific (name, version) row
+		// in agent_defs. Distinguishes static-resolved from DB-resolved
+		// runs without a separate flag.
+		`ALTER TABLE runs ADD COLUMN agent_def_id TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -181,6 +236,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS runs_by_parent_agent_id ON runs(parent_agent_id) WHERE parent_agent_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS runs_by_user_active     ON runs(user_id, status) WHERE user_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS sessions_by_user        ON sessions(user_id)     WHERE user_id IS NOT NULL`,
+		// v0.8.5: facets cost retros + experiment audits by which
+		// agent_def_id the run actually ran against. Partial index
+		// keeps it small — only DB-resolved runs have a non-NULL value.
+		`CREATE INDEX IF NOT EXISTS runs_by_agent_def       ON runs(agent_def_id)    WHERE agent_def_id IS NOT NULL`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -1115,6 +1174,571 @@ func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 		return 0, nil
 	}
 	return int(n), nil
+}
+
+// ---- v0.8.5 Self-Evolution Substrate ----
+//
+// AgentDef methods. Append-only. Version is allocated under a
+// per-name lock (BEGIN IMMEDIATE in sqlite — coarse but correct for
+// single-writer WAL, mirrors MemoryIncrement's pattern).
+
+// AgentDefCreate allocates the next version for row.Name under a
+// per-name lock and inserts. The caller supplies row.DefID (UUID/
+// ULID-ish opaque string). Validates parent_def_id when set.
+//
+// SQLite concurrency: uses the same BEGIN IMMEDIATE + pinned-conn
+// pattern as MemoryIncrement — pinning the connection scopes the
+// write lock to this one transaction, and IMMEDIATE means concurrent
+// writers see SQLITE_BUSY at BEGIN time (database/sql retries) rather
+// than upgrade-deadlocking mid-tx. Without this, two concurrent
+// AgentDefCreate calls against the same name both start a DEFERRED
+// tx, both SELECT MAX(version) (returning the same value), then both
+// try to INSERT with the same version — one succeeds, one fails on
+// the UNIQUE(name, version) constraint.
+func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (store.AgentDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.AgentDefRow{}, fmt.Errorf("agent_def: def_id + name required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM agent_defs WHERE def_id = ?`, row.ParentDefID).Scan(&n); err != nil {
+			return store.AgentDefRow{}, err
+		}
+		if n == 0 {
+			return store.AgentDefRow{}, store.ErrAgentDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT MAX(version) FROM agent_defs WHERE name = ?`, row.Name,
+	).Scan(&maxVer); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO agent_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
+		string(row.Definition), nilIfEmpty(row.Description),
+		row.CreatedAt.UnixNano(),
+		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
+		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
+	); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return store.AgentDefRow{}, err
+	}
+	committed = true
+	return row, nil
+}
+
+// AgentDefGet returns one row by def_id.
+func (s *Store) AgentDefGet(ctx context.Context, defID string) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.db.QueryRowContext(ctx, agentDefSelect+` WHERE def_id = ?`, defID))
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return row, err
+}
+
+// AgentDefGetByNameVersion returns one row by (name, version).
+func (s *Store) AgentDefGetByNameVersion(ctx context.Context, name string, version int) (store.AgentDefRow, error) {
+	row, err := s.scanAgentDef(s.db.QueryRowContext(ctx, agentDefSelect+` WHERE name = ? AND version = ?`, name, version))
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+// AgentDefListByName returns rows for one name, version DESC.
+func (s *Store) AgentDefListByName(ctx context.Context, name string) ([]store.AgentDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, agentDefSelect+` WHERE name = ? ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListChildren returns immediate children (parent_def_id == arg).
+func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([]store.AgentDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, agentDefSelect+` WHERE parent_def_id = ? ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanAgentDefRows(rows)
+}
+
+// AgentDefListNames returns one summary row per distinct name. Joins
+// agent_def_active to surface the active def_id when one exists.
+func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM agent_defs d
+		LEFT JOIN agent_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.AgentDefNameSummary
+	for rows.Next() {
+		var s store.AgentDefNameSummary
+		var updatedAt int64
+		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &updatedAt, &s.ActiveDefID); err != nil {
+			return nil, err
+		}
+		s.LastUpdated = time.Unix(0, updatedAt)
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
+func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	// Validate def_id exists + matches name (defence-in-depth; the
+	// FK isn't enforced without foreign_keys PRAGMA).
+	var rowName string
+	err := s.db.QueryRowContext(ctx, `SELECT name FROM agent_defs WHERE def_id = ?`, defID).Scan(&rowName)
+	if err == sql.ErrNoRows {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	if err != nil {
+		return err
+	}
+	if rowName != name {
+		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+		    def_id               = excluded.def_id,
+		    promoted_at          = excluded.promoted_at,
+		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+	)
+	return err
+}
+
+// AgentDefGetActive returns the active row for name. *ErrNotFound
+// when no pointer exists — caller falls through to cfg.Agents.
+func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+	var defID string
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM agent_def_active WHERE name = ?`, name).Scan(&defID)
+	if err == sql.ErrNoRows {
+		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
+	}
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	return s.AgentDefGet(ctx, defID)
+}
+
+// AgentDefSetRetired flips the `retired` flag on one row. The row
+// stays visible in lineage queries.
+func (s *Store) AgentDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE agent_defs SET retired = ? WHERE def_id = ?`,
+		boolToInt(retired), defID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
+	}
+	return nil
+}
+
+// agentDefSelect is the column list shared by every read. Kept in
+// one place so column additions (a future tenant_id, similarity_score,
+// ...) need only a single touch-point.
+const agentDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM agent_defs`
+
+func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
+	var (
+		out        store.AgentDefRow
+		definition string
+		createdAt  int64
+		retired    int
+		bootstrap  int
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&createdAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&retired, &bootstrap,
+	)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	out.CreatedAt = time.Unix(0, createdAt)
+	out.Retired = retired != 0
+	out.BootstrappedFromStatic = bootstrap != 0
+	return out, nil
+}
+
+func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
+	var out []store.AgentDefRow
+	for rows.Next() {
+		var (
+			r          store.AgentDefRow
+			definition string
+			createdAt  int64
+			retired    int
+			bootstrap  int
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&createdAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&retired, &bootstrap,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdAt)
+		r.Retired = retired != 0
+		r.BootstrappedFromStatic = bootstrap != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- Evaluation (pure-insert, no concurrency lock) ----
+
+// EvaluationSubmit inserts one evaluation row. CreatedAt set by store.
+func (s *Store) EvaluationSubmit(ctx context.Context, row store.EvaluationRow) (store.EvaluationRow, error) {
+	if row.EvalID == "" || row.RunID == "" || row.EmitterRole == "" {
+		return store.EvaluationRow{}, fmt.Errorf("evaluation: eval_id, run_id, emitter_role required")
+	}
+	row.CreatedAt = time.Now()
+	var dimsJSON, judgementJSON sql.NullString
+	if len(row.Dimensions) > 0 {
+		b, err := json.Marshal(row.Dimensions)
+		if err != nil {
+			return store.EvaluationRow{}, fmt.Errorf("evaluation: marshal dimensions: %w", err)
+		}
+		dimsJSON = sql.NullString{String: string(b), Valid: true}
+	}
+	if len(row.Judgement) > 0 {
+		judgementJSON = sql.NullString{String: string(row.Judgement), Valid: true}
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO evaluations (
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.EvalID, row.RunID, nilIfEmpty(row.DefID), row.Score,
+		dimsJSON, judgementJSON, nilIfEmpty(row.Rationale),
+		row.EmitterRole, nilIfEmpty(row.EmitterAgentID), nilIfEmpty(row.EmitterRunID),
+		row.CreatedAt.UnixNano(),
+	)
+	if err != nil {
+		return store.EvaluationRow{}, err
+	}
+	return row, nil
+}
+
+// EvaluationGet returns one row by eval_id.
+func (s *Store) EvaluationGet(ctx context.Context, evalID string) (store.EvaluationRow, error) {
+	row, err := s.scanEvaluation(s.db.QueryRowContext(ctx, evaluationSelect+` WHERE eval_id = ?`, evalID))
+	if err == sql.ErrNoRows {
+		return store.EvaluationRow{}, &store.ErrNotFound{Kind: "evaluation", ID: evalID}
+	}
+	return row, err
+}
+
+// EvaluationListForRun returns evals targeting one run.
+func (s *Store) EvaluationListForRun(ctx context.Context, runID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, evaluationSelect+` WHERE run_id = ? ORDER BY created_at DESC LIMIT ?`, runID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+// EvaluationListForDef returns evals targeting one def.
+func (s *Store) EvaluationListForDef(ctx context.Context, defID string, limit int) ([]store.EvaluationRow, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, evaluationSelect+` WHERE def_id = ? ORDER BY created_at DESC LIMIT ?`, defID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanEvaluationRows(rows)
+}
+
+// EvaluationAggregate computes the score+dimension+by-role aggregates
+// for a def_id. When opts.IncludeLineage is true, walks parent_def_id
+// chain depth-first and includes ancestors.
+func (s *Store) EvaluationAggregate(ctx context.Context, defID string, opts store.AggregateOpts) (store.AggregateResult, error) {
+	defIDs := []string{defID}
+	if opts.IncludeLineage {
+		ancestors, err := s.walkAncestors(ctx, defID)
+		if err != nil {
+			return store.AggregateResult{}, err
+		}
+		defIDs = append(defIDs, ancestors...)
+	}
+
+	// Build the IN list. Limit defensively at 1000 ancestors so a
+	// pathological lineage can't blow query parser limits — the
+	// aggregator caller is responsible for not building megacycles.
+	if len(defIDs) > 1000 {
+		defIDs = defIDs[:1000]
+	}
+	placeholders := make([]string, len(defIDs))
+	args := make([]any, len(defIDs))
+	for i, id := range defIDs {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	q := evaluationSelect + ` WHERE def_id IN (` + strings.Join(placeholders, ",") + `) ORDER BY created_at ASC`
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	defer rows.Close()
+	evals, err := s.scanEvaluationRows(rows)
+	if err != nil {
+		return store.AggregateResult{}, err
+	}
+	return computeAggregate(defID, evals, opts.IncludeLineage), nil
+}
+
+// walkAncestors returns the parent_def_id chain for defID (NOT
+// including defID itself). Depth-first, bounded at 100 hops to
+// protect against the (impossible-by-construction-but-let's-be-safe)
+// case of a cycle. Empty when defID has no parent.
+func (s *Store) walkAncestors(ctx context.Context, defID string) ([]string, error) {
+	var ancestors []string
+	seen := map[string]bool{defID: true}
+	cur := defID
+	for i := 0; i < 100; i++ {
+		var parent sql.NullString
+		err := s.db.QueryRowContext(ctx, `SELECT parent_def_id FROM agent_defs WHERE def_id = ?`, cur).Scan(&parent)
+		if err == sql.ErrNoRows || !parent.Valid || parent.String == "" {
+			return ancestors, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		if seen[parent.String] {
+			return ancestors, nil // cycle guard
+		}
+		seen[parent.String] = true
+		ancestors = append(ancestors, parent.String)
+		cur = parent.String
+	}
+	return ancestors, nil
+}
+
+const evaluationSelect = `SELECT
+	eval_id, run_id,
+	COALESCE(def_id, ''),
+	score,
+	COALESCE(dimensions, ''),
+	COALESCE(judgement, ''),
+	COALESCE(rationale, ''),
+	emitter_role,
+	COALESCE(emitter_agent_id, ''),
+	COALESCE(emitter_run_id, ''),
+	created_at
+FROM evaluations`
+
+func (s *Store) scanEvaluation(row *sql.Row) (store.EvaluationRow, error) {
+	var (
+		out                   store.EvaluationRow
+		dimensions, judgement string
+		createdAt             int64
+	)
+	if err := row.Scan(
+		&out.EvalID, &out.RunID, &out.DefID, &out.Score,
+		&dimensions, &judgement, &out.Rationale,
+		&out.EmitterRole, &out.EmitterAgentID, &out.EmitterRunID,
+		&createdAt,
+	); err != nil {
+		return store.EvaluationRow{}, err
+	}
+	if dimensions != "" {
+		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+	}
+	if judgement != "" {
+		out.Judgement = json.RawMessage(judgement)
+	}
+	out.CreatedAt = time.Unix(0, createdAt)
+	return out, nil
+}
+
+func (s *Store) scanEvaluationRows(rows *sql.Rows) ([]store.EvaluationRow, error) {
+	var out []store.EvaluationRow
+	for rows.Next() {
+		var (
+			r                     store.EvaluationRow
+			dimensions, judgement string
+			createdAt             int64
+		)
+		if err := rows.Scan(
+			&r.EvalID, &r.RunID, &r.DefID, &r.Score,
+			&dimensions, &judgement, &r.Rationale,
+			&r.EmitterRole, &r.EmitterAgentID, &r.EmitterRunID,
+			&createdAt,
+		); err != nil {
+			return nil, err
+		}
+		if dimensions != "" {
+			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+		}
+		if judgement != "" {
+			r.Judgement = json.RawMessage(judgement)
+		}
+		r.CreatedAt = time.Unix(0, createdAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// computeAggregate is the pure-Go aggregation kernel — shared by
+// sqlite + postgres adapters. Given a flat list of evaluations,
+// produce summary stats. Empty input → zero-valued AggregateResult
+// with Count=0 (well-defined "no evaluations yet").
+func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded bool) store.AggregateResult {
+	out := store.AggregateResult{
+		DefID:           defID,
+		Count:           len(evals),
+		LineageIncluded: lineageIncluded,
+	}
+	if len(evals) == 0 {
+		return out
+	}
+
+	scores := make([]float64, len(evals))
+	dimAcc := map[string][]float64{}
+	roleAcc := map[string][]float64{}
+	for i, e := range evals {
+		scores[i] = e.Score
+		for k, v := range e.Dimensions {
+			dimAcc[k] = append(dimAcc[k], v)
+		}
+		roleAcc[e.EmitterRole] = append(roleAcc[e.EmitterRole], e.Score)
+	}
+	out.Score = statsOf(scores)
+	out.Score.Latest = evals[len(evals)-1].Score // evals is ASC by created_at
+
+	if len(dimAcc) > 0 {
+		out.Dimensions = make(map[string]store.ScoreStats, len(dimAcc))
+		for k, v := range dimAcc {
+			out.Dimensions[k] = statsOf(v)
+		}
+	}
+	if len(roleAcc) > 0 {
+		out.ByEmitterRole = make(map[string]store.ScoreStats, len(roleAcc))
+		for k, v := range roleAcc {
+			out.ByEmitterRole[k] = statsOf(v)
+		}
+	}
+	return out
+}
+
+// statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
+// Latest is filled by the caller (per-axis stat needs the original
+// ordering, which we lose when sorting for the median).
+func statsOf(vals []float64) store.ScoreStats {
+	if len(vals) == 0 {
+		return store.ScoreStats{}
+	}
+	out := store.ScoreStats{Count: len(vals), Min: vals[0], Max: vals[0]}
+	sum := 0.0
+	for _, v := range vals {
+		sum += v
+		if v < out.Min {
+			out.Min = v
+		}
+		if v > out.Max {
+			out.Max = v
+		}
+	}
+	out.Mean = sum / float64(len(vals))
+	out.Latest = vals[len(vals)-1] // overwritten by caller for the top-level Score; ok for dim/role
+
+	// Median — sort a copy to avoid mutating caller's slice.
+	sorted := make([]float64, len(vals))
+	copy(sorted, vals)
+	sort.Float64s(sorted)
+	mid := len(sorted) / 2
+	if len(sorted)%2 == 1 {
+		out.Median = sorted[mid]
+	} else {
+		out.Median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+	return out
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // escapeLikePrefix escapes the LIKE wildcards in `prefix` so an agent

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -169,6 +169,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// the tool layer; the store stores the string verbatim. Score
 		// is REAL (Go float64). Dimensions + Judgement are JSON-as-TEXT
 		// (sqlite has no JSONB).
+		//
+		// NO foreign keys on run_id or def_id: evaluations are an
+		// immutable audit log and must survive any future run/def
+		// pruning. Referential integrity is enforced at the
+		// application layer. A RESTRICT FK would block legitimate
+		// admin pruning workflows; CASCADE would silently delete
+		// audit data. Mirrors the postgres migration 0008.
 		`CREATE TABLE IF NOT EXISTS evaluations (
 			eval_id            TEXT    PRIMARY KEY,
 			run_id             TEXT    NOT NULL,
@@ -1701,8 +1708,11 @@ func computeAggregate(defID string, evals []store.EvaluationRow, lineageIncluded
 }
 
 // statsOf computes Mean/Median/Min/Max/Count for a non-empty slice.
-// Latest is filled by the caller (per-axis stat needs the original
-// ordering, which we lose when sorting for the median).
+// Latest is set here as vals[len-1]: callers MUST append in
+// created_at ASC order so the last element is the newest. For the
+// top-level Score axis the caller currently overwrites Latest after
+// returning (the input slice for that axis is built differently); for
+// the Dimensions and ByEmitterRole axes the value set here stands.
 func statsOf(vals []float64) store.ScoreStats {
 	if len(vals) == 0 {
 		return store.ScoreStats{}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -371,6 +371,102 @@ type Store interface {
 	// from cur_0 without disturbing the consumer's position.
 	ChannelPeek(ctx context.Context, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
 
+	// ---- v0.8.5 Self-Evolution Substrate ----
+	//
+	// `AgentDef` is the agent-authored agent-definition versioning
+	// layer. Static `<name>.md` files remain the operator-blessed
+	// root; the database holds the derived layer of agent-created
+	// versions. Append-only. version is server-allocated under a
+	// per-name lock so concurrent forks against the same parent each
+	// get a distinct, monotonic version with no gaps.
+
+	// AgentDefCreate inserts a fresh row. The caller passes the row
+	// shape; the store allocates Version under the per-name lock,
+	// sets CreatedAt server-side, validates the parent (if any), and
+	// returns the persisted row. The DefID is caller-generated to
+	// support deterministic-ID workflows (test fixtures, externally-
+	// authored bootstrap rows).
+	//
+	// Errors:
+	//   - parent_def_id supplied but not found → ErrAgentDefParentNotFound
+	//   - name + version already exists (deterministic ID collision) → wraps the underlying constraint error
+	AgentDefCreate(ctx context.Context, row AgentDefRow) (AgentDefRow, error)
+
+	// AgentDefGet returns a single row by def_id. Returns *ErrNotFound
+	// when the row doesn't exist.
+	AgentDefGet(ctx context.Context, defID string) (AgentDefRow, error)
+
+	// AgentDefGetByNameVersion returns one row by (name, version).
+	// Useful for friendly lookups in the admin API. Returns
+	// *ErrNotFound on miss.
+	AgentDefGetByNameVersion(ctx context.Context, name string, version int) (AgentDefRow, error)
+
+	// AgentDefListByName returns every row for one name, ordered by
+	// version DESC. Empty slice (not nil) when the name has no rows.
+	// Retired rows are included; the caller filters as needed.
+	AgentDefListByName(ctx context.Context, name string) ([]AgentDefRow, error)
+
+	// AgentDefListChildren returns the immediate-children rows
+	// (parent_def_id == argument). One hop only — callers that need
+	// the full descendant tree walk iteratively.
+	AgentDefListChildren(ctx context.Context, parentDefID string) ([]AgentDefRow, error)
+
+	// AgentDefListNames returns one summary row per distinct name.
+	// Drives the admin API's name-list endpoint. count is the per-
+	// name version count; active_def_id is the agent_def_active
+	// pointer (empty when no row is promoted).
+	AgentDefListNames(ctx context.Context) ([]AgentDefNameSummary, error)
+
+	// AgentDefSetActive UPSERTs the agent_def_active pointer for
+	// `name` to `defID`. promotedByAgentID is the agent_id that
+	// performed the promotion (may be empty for admin API calls).
+	// Idempotent: promote A → promote B → promote A leaves the
+	// pointer at A with the latest promoted_at.
+	AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
+
+	// AgentDefGetActive returns the currently-active row for `name`
+	// — the (name, version) pointed at by agent_def_active. Returns
+	// *ErrNotFound when no active pointer exists (the caller falls
+	// through to cfg.Agents — the static fallback path).
+	AgentDefGetActive(ctx context.Context, name string) (AgentDefRow, error)
+
+	// AgentDefSetRetired flips the `retired` flag on one row. The
+	// row stays visible in lineage queries with the flag exposed;
+	// the resolver skips retired rows when picking the next default
+	// for runs that don't pin def_id.
+	AgentDefSetRetired(ctx context.Context, defID string, retired bool) error
+
+	// ---- Evaluation ----
+	//
+	// `Evaluation` is the score-attached-to-(run, def) primitive.
+	// Pure-insert (no per-row mutation), so no concurrency lock is
+	// needed. EvalID is caller-generated.
+
+	// EvaluationSubmit inserts a row. The caller stamps EmitterRole
+	// (derived server-side from ctx + run identity in the tool
+	// layer; the store does not interpret). CreatedAt is set by the
+	// store. Returns the persisted row.
+	EvaluationSubmit(ctx context.Context, row EvaluationRow) (EvaluationRow, error)
+
+	// EvaluationGet returns one row by eval_id. *ErrNotFound on miss.
+	EvaluationGet(ctx context.Context, evalID string) (EvaluationRow, error)
+
+	// EvaluationListForRun returns evaluations targeting a run,
+	// newest first. limit ≤ 0 falls through to a sane default.
+	EvaluationListForRun(ctx context.Context, runID string, limit int) ([]EvaluationRow, error)
+
+	// EvaluationListForDef returns evaluations targeting one def
+	// (denormalised def_id column). Same ordering + limit semantics
+	// as ListForRun.
+	EvaluationListForDef(ctx context.Context, defID string, limit int) ([]EvaluationRow, error)
+
+	// EvaluationAggregate computes summary statistics for a def_id.
+	// When opts.IncludeLineage is true, recursively walks parent_def_id
+	// and includes evaluations of every ancestor (depth-first;
+	// retired ancestors included). The returned LineageIncluded flag
+	// echoes the option for caller-side assertion.
+	EvaluationAggregate(ctx context.Context, defID string, opts AggregateOpts) (AggregateResult, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -486,6 +582,142 @@ type ChannelError struct {
 }
 
 func (e *ChannelError) Error() string { return e.Msg }
+
+// ---- v0.8.5 Self-Evolution Substrate types ----
+
+// AgentDefRow is one row in the agent_defs table. The Definition
+// field carries the JSON-encoded AgentDef body verbatim — the store
+// does NOT depend on internal/config (dep direction would invert),
+// so callers at the tool / HTTP layer unmarshal into the concrete
+// shape they need.
+//
+// Identity:
+//   - DefID is the canonical handle (caller-generated UUID/ULID;
+//     stable across renames). Use it for run pins and lineage edges.
+//   - (Name, Version) is the human-friendly identifier. Version is
+//     server-allocated, monotonic per Name with no gaps.
+//
+// Lineage:
+//   - ParentDefID empty = no parent (top of a lineage, typically
+//     bootstrapped from a static MD with BootstrappedFromStatic=true).
+//   - Children query: AgentDefListChildren(parentDefID).
+//
+// Provenance:
+//   - CreatedByAgentID + CreatedByRunID stamp the agent that called
+//     AgentDef.create/fork at runtime. Empty for the static-bootstrap
+//     row (its "creator" is the operator's MD file, not an agent).
+type AgentDefRow struct {
+	DefID                  string          `json:"def_id"`
+	Name                   string          `json:"name"`
+	Version                int             `json:"version"`
+	ParentDefID            string          `json:"parent_def_id,omitempty"`
+	Definition             json.RawMessage `json:"definition"`
+	Description            string          `json:"description,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	CreatedByAgentID       string          `json:"created_by_agent_id,omitempty"`
+	CreatedByRunID         string          `json:"created_by_run_id,omitempty"`
+	Retired                bool            `json:"retired"`
+	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
+}
+
+// AgentDefNameSummary is one entry of AgentDefListNames' output.
+// count is the version count; ActiveDefID is the agent_def_active
+// pointer (empty when no row is promoted under this name).
+type AgentDefNameSummary struct {
+	Name          string    `json:"name"`
+	VersionCount  int       `json:"version_count"`
+	ActiveDefID   string    `json:"active_def_id,omitempty"`
+	LatestVersion int       `json:"latest_version"`
+	LastUpdated   time.Time `json:"last_updated"`
+}
+
+// EvaluationRow is one row in the evaluations table.
+//
+// DefID is denormalised from runs.agent_def_id at submit time —
+// captures which version of the agent the run actually ran against.
+// Empty for static-resolved runs (where the agent body came from
+// cfg.Agents, not the database).
+//
+// Score is the required scalar (RL lingua franca). Dimensions are
+// optional named axes for multi-fitness; nil = no dimensions.
+// Judgement is a free-form structured payload; nil = absent.
+// Rationale is natural-language reasoning for explainability + audit.
+//
+// EmitterRole is derived server-side from the emitter's ctx vs the
+// target run's identity (parent / sibling / self / external /
+// unrelated). The model NEVER supplies it.
+type EvaluationRow struct {
+	EvalID         string             `json:"eval_id"`
+	RunID          string             `json:"run_id"`
+	DefID          string             `json:"def_id,omitempty"`
+	Score          float64            `json:"score"`
+	Dimensions     map[string]float64 `json:"dimensions,omitempty"`
+	Judgement      json.RawMessage    `json:"judgement,omitempty"`
+	Rationale      string             `json:"rationale,omitempty"`
+	EmitterRole    string             `json:"emitter_role"`
+	EmitterAgentID string             `json:"emitter_agent_id,omitempty"`
+	EmitterRunID   string             `json:"emitter_run_id,omitempty"`
+	CreatedAt      time.Time          `json:"created_at"`
+}
+
+// AggregateOpts is the parameter struct for EvaluationAggregate.
+type AggregateOpts struct {
+	// IncludeLineage walks parent_def_id chain depth-first and
+	// includes ancestors' evaluations in the aggregate. Retired
+	// ancestors are included; the caller can filter post-hoc.
+	IncludeLineage bool
+}
+
+// AggregateResult is the output of EvaluationAggregate.
+//
+// Count is the total evaluation row count contributing to the
+// statistics (post-lineage-walk when IncludeLineage is true).
+// Score aggregates the scalar field. Dimensions is keyed by the
+// dimension name the evaluations supplied (only dimensions present
+// in at least one row appear). ByEmitterRole breaks aggregates by
+// role string. LineageIncluded echoes the option for caller-side
+// assertion.
+type AggregateResult struct {
+	DefID           string                `json:"def_id"`
+	Count           int                   `json:"count"`
+	Score           ScoreStats            `json:"score"`
+	Dimensions      map[string]ScoreStats `json:"dimensions,omitempty"`
+	ByEmitterRole   map[string]ScoreStats `json:"by_emitter_role,omitempty"`
+	LineageIncluded bool                  `json:"lineage_included"`
+}
+
+// ScoreStats is the summary-stats bundle used inside AggregateResult.
+// All fields zero when Count is zero (an empty aggregate is a
+// well-defined "no evaluations submitted yet" response, NOT an error).
+type ScoreStats struct {
+	Mean   float64 `json:"mean"`
+	Median float64 `json:"median"`
+	Min    float64 `json:"min"`
+	Max    float64 `json:"max"`
+	Latest float64 `json:"latest"`
+	Count  int     `json:"count"`
+}
+
+// ErrAgentDefParentNotFound is returned by AgentDefCreate when the
+// caller supplied a parent_def_id that doesn't exist. Distinct from
+// ErrNotFound so the tool layer can surface "your fork parent
+// vanished" with a clean code.
+var ErrAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "agent_def: parent_def_id does not exist"}
+
+// ErrAgentDefImmutable is returned by store-layer assertions if
+// someone tries to UPDATE an agent_defs row's definition column.
+// Append-only invariant. The adapter's contract test pins this.
+var ErrAgentDefImmutable = &SubstrateError{Code: "immutable", Msg: "agent_def: rows are append-only; create a new version"}
+
+// SubstrateError envelopes substrate-specific errors so the tool
+// layer can pattern-match on Code. Mirror of MemoryError /
+// ChannelError shape.
+type SubstrateError struct {
+	Code string
+	Msg  string
+}
+
+func (e *SubstrateError) Error() string { return e.Msg }
 
 // ErrNotFound is returned when a session or run ID isn't in the store.
 type ErrNotFound struct {

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,6 +93,15 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelScopeIsolation", testChannelScopeIsolation},
 		{"ChannelPeekDoesNotConsume", testChannelPeekDoesNotConsume},
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
+		{"AgentDefCreateAndGet", testAgentDefCreateAndGet},
+		{"AgentDefVersionMonotonicUnderContention", testAgentDefVersionMonotonicUnderContention},
+		{"AgentDefParallelForksDistinctVersions", testAgentDefParallelForksDistinctVersions},
+		{"AgentDefAppendOnlyDefinition", testAgentDefAppendOnlyDefinition},
+		{"AgentDefActivePointerIdempotent", testAgentDefActivePointerIdempotent},
+		{"AgentDefRetireReversible", testAgentDefRetireReversible},
+		{"AgentDefStaticFallback", testAgentDefStaticFallback},
+		{"EvaluationSubmitAndAggregate", testEvaluationSubmitAndAggregate},
+		{"EvaluationAggregateWithLineage", testEvaluationAggregateWithLineage},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1294,5 +1304,317 @@ func testChannelReplayFromCursorZero(t *testing.T, s store.Store) {
 	msgs, _, _ = s.ChannelSubscribe(ctx, "ch", store.MemoryScopeAgent, "x", "cur_0", 10)
 	if len(msgs) != 3 {
 		t.Errorf("replay: got %d, want 3 (cur_0 must ignore committed cursor)", len(msgs))
+	}
+}
+
+// ---- v0.8.5 Self-Evolution Substrate contract ----
+
+// mkDef returns a minimal AgentDefRow suitable for create tests.
+// def_id is caller-supplied; the store doesn't generate it.
+func mkDef(id, name string, parent string) store.AgentDefRow {
+	return store.AgentDefRow{
+		DefID:       id,
+		Name:        name,
+		ParentDefID: parent,
+		Definition:  json.RawMessage(`{"model":"x","system_prompt":"p"}`),
+		Description: "test row",
+	}
+}
+
+func testAgentDefCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.AgentDefCreate(ctx, mkDef("d-1", "alpha", ""))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Version != 1 {
+		t.Errorf("first version = %d, want 1", row.Version)
+	}
+	got, err := s.AgentDefGet(ctx, "d-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "alpha" || got.Version != 1 {
+		t.Errorf("got %+v", got)
+	}
+	// Created-at populated.
+	if got.CreatedAt.IsZero() {
+		t.Error("created_at not populated")
+	}
+}
+
+func testAgentDefVersionMonotonicUnderContention(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const G = 50 // 50 goroutines × 5 inserts = 250 unique versions
+	const Per = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, G*Per)
+	for g := 0; g < G; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < Per; i++ {
+				id := fmt.Sprintf("d-%d-%d", g, i)
+				_, err := s.AgentDefCreate(ctx, mkDef(id, "raceagent", ""))
+				if err != nil {
+					errs <- err
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("create error: %v", err)
+	}
+	rows, err := s.AgentDefListByName(ctx, "raceagent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != G*Per {
+		t.Fatalf("got %d versions, want %d", len(rows), G*Per)
+	}
+	// rows is version DESC. Check strictly monotonic and no gaps.
+	versions := make(map[int]bool, len(rows))
+	for _, r := range rows {
+		if versions[r.Version] {
+			t.Errorf("duplicate version %d", r.Version)
+		}
+		versions[r.Version] = true
+	}
+	for v := 1; v <= G*Per; v++ {
+		if !versions[v] {
+			t.Errorf("missing version %d", v)
+		}
+	}
+}
+
+func testAgentDefParallelForksDistinctVersions(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	parent, err := s.AgentDefCreate(ctx, mkDef("p-1", "forkparent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const N = 10
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := s.AgentDefCreate(ctx, mkDef(fmt.Sprintf("f-%d", i), "forkparent", parent.DefID))
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("fork: %v", err)
+	}
+	children, err := s.AgentDefListChildren(ctx, parent.DefID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != N {
+		t.Errorf("got %d children, want %d", len(children), N)
+	}
+	versions := make(map[int]bool)
+	for _, c := range children {
+		if versions[c.Version] {
+			t.Errorf("duplicate child version %d", c.Version)
+		}
+		versions[c.Version] = true
+		if c.ParentDefID != parent.DefID {
+			t.Errorf("child %s has wrong parent: %s", c.DefID, c.ParentDefID)
+		}
+	}
+}
+
+func testAgentDefAppendOnlyDefinition(t *testing.T, s store.Store) {
+	// The store's adapter has NO UPDATE statement on the definition
+	// column. This test verifies the row content is byte-identical
+	// after a get-set-get cycle would have applied if the store
+	// permitted mutation. There's no public API to mutate, so the
+	// only failure mode is "the implementation grew an UPDATE
+	// path" — caught by code review more than this test, but the
+	// test pins the contract for any future adapter.
+	ctx := context.Background()
+	original := mkDef("immutable-1", "frozen", "")
+	original.Definition = json.RawMessage(`{"v":"original"}`)
+	row, err := s.AgentDefCreate(ctx, original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.AgentDefGet(ctx, row.DefID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Definition) != `{"v":"original"}` {
+		t.Errorf("definition: got %s, want original", got.Definition)
+	}
+}
+
+func testAgentDefActivePointerIdempotent(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	a, err := s.AgentDefCreate(ctx, mkDef("a", "promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := s.AgentDefCreate(ctx, mkDef("b", "promo", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", b.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.AgentDefGetActive(ctx, "promo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DefID != a.DefID {
+		t.Errorf("active = %s, want %s", got.DefID, a.DefID)
+	}
+}
+
+func testAgentDefRetireReversible(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.AgentDefCreate(ctx, mkDef("r-1", "retireagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AgentDefSetRetired(ctx, row.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.AgentDefGet(ctx, row.DefID)
+	if !got.Retired {
+		t.Error("retire(true) didn't stick")
+	}
+	if err := s.AgentDefSetRetired(ctx, row.DefID, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.AgentDefGet(ctx, row.DefID)
+	if got.Retired {
+		t.Error("retire(false) didn't reverse")
+	}
+	// Retired rows still appear in lineage queries.
+	rows, _ := s.AgentDefListByName(ctx, "retireagent")
+	if len(rows) != 1 {
+		t.Errorf("list after retire toggle: got %d, want 1", len(rows))
+	}
+}
+
+func testAgentDefStaticFallback(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, err := s.AgentDefGetActive(ctx, "no-such-name")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v, want *ErrNotFound", err)
+	}
+}
+
+func testEvaluationSubmitAndAggregate(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	def, err := s.AgentDefCreate(ctx, mkDef("eval-d", "evalagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Submit 5 evals with known scores.
+	scores := []float64{0.1, 0.3, 0.5, 0.7, 0.9}
+	for i, sc := range scores {
+		_, err := s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID:      fmt.Sprintf("ev-%d", i),
+			RunID:       fmt.Sprintf("r-%d", i),
+			DefID:       def.DefID,
+			Score:       sc,
+			EmitterRole: "self",
+			Dimensions:  map[string]float64{"correctness": sc},
+		})
+		if err != nil {
+			t.Fatalf("submit %d: %v", i, err)
+		}
+		time.Sleep(time.Microsecond) // ensure created_at ordering
+	}
+	agg, err := s.EvaluationAggregate(ctx, def.DefID, store.AggregateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 5 {
+		t.Errorf("count = %d, want 5", agg.Count)
+	}
+	if agg.Score.Mean < 0.49 || agg.Score.Mean > 0.51 {
+		t.Errorf("mean = %f, want ~0.5", agg.Score.Mean)
+	}
+	if agg.Score.Min != 0.1 {
+		t.Errorf("min = %f", agg.Score.Min)
+	}
+	if agg.Score.Max != 0.9 {
+		t.Errorf("max = %f", agg.Score.Max)
+	}
+	if agg.Score.Median != 0.5 {
+		t.Errorf("median = %f, want 0.5", agg.Score.Median)
+	}
+	if agg.Score.Latest != 0.9 {
+		t.Errorf("latest = %f, want 0.9 (newest)", agg.Score.Latest)
+	}
+	// Dimensions captured.
+	corr, ok := agg.Dimensions["correctness"]
+	if !ok {
+		t.Fatal("no correctness dimension in aggregate")
+	}
+	if corr.Mean < 0.49 || corr.Mean > 0.51 {
+		t.Errorf("correctness mean = %f", corr.Mean)
+	}
+}
+
+func testEvaluationAggregateWithLineage(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	root, err := s.AgentDefCreate(ctx, mkDef("ln-root", "lineageagent", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	child, err := s.AgentDefCreate(ctx, mkDef("ln-child", "lineageagent", root.DefID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// 2 evals on root, 3 evals on child.
+	for i := 0; i < 2; i++ {
+		_, _ = s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID: fmt.Sprintf("rt-%d", i), RunID: fmt.Sprintf("r-rt-%d", i),
+			DefID: root.DefID, Score: 0.5, EmitterRole: "external",
+		})
+	}
+	for i := 0; i < 3; i++ {
+		_, _ = s.EvaluationSubmit(ctx, store.EvaluationRow{
+			EvalID: fmt.Sprintf("ch-%d", i), RunID: fmt.Sprintf("r-ch-%d", i),
+			DefID: child.DefID, Score: 1.0, EmitterRole: "external",
+		})
+	}
+	// Without lineage: only child's 3.
+	agg, err := s.EvaluationAggregate(ctx, child.DefID, store.AggregateOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 3 {
+		t.Errorf("no-lineage count = %d, want 3", agg.Count)
+	}
+	// With lineage: 3 + 2 = 5.
+	agg, err = s.EvaluationAggregate(ctx, child.DefID, store.AggregateOpts{IncludeLineage: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if agg.Count != 5 {
+		t.Errorf("with-lineage count = %d, want 5", agg.Count)
+	}
+	if !agg.LineageIncluded {
+		t.Error("LineageIncluded flag not set")
 	}
 }

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -159,6 +159,25 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 	if err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
+	// AllowedTools ceiling on `create`: the caller's own effective
+	// allowed_tools is the ceiling for any new agent it mints. Without
+	// this check an agent with narrow allowed_tools could call
+	// `create` with overlay.allowed_tools = [the entire universe] and
+	// then spawn the resulting agent — a capability-escalation path.
+	// Mirror of the subset check in `fork`.
+	//
+	// AgentTools(ctx) returns nil in test contexts; we refuse to
+	// create with a non-empty AllowedTools overlay when the ceiling
+	// is unknown rather than silently allowing widening.
+	callerTools := tools.AgentTools(ctx)
+	if len(def.AllowedTools) > 0 {
+		if callerTools == nil {
+			return errResult("create: caller's effective allowed_tools not on ctx (runtime misconfiguration); refuse rather than risk silent widening"), nil
+		}
+		if err := assertAllowedToolsSubset(def.AllowedTools, callerTools); err != nil {
+			return errResult(fmt.Sprintf("create: %s", err)), nil
+		}
+	}
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
@@ -239,12 +258,25 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 			if !ok {
 				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static cfg.Agents entry", in.Name)), nil
 			}
-			bootstrap, err := a.bootstrapStatic(ctx, in.Name, static)
-			if err != nil {
-				return errResult(fmt.Sprintf("fork: bootstrap static: %s", err)), nil
+			bootstrap, berr := a.bootstrapStatic(ctx, in.Name, static)
+			if berr != nil {
+				// A concurrent first-fork may have already bootstrapped
+				// v1 between our AgentDefGetActive check and our own
+				// bootstrap insert. The store's per-name lock guarantees
+				// monotonic versions but our caller has no way to know
+				// "another goroutine just won v1." Re-read the active
+				// pointer once before propagating the error — if it's
+				// now set, use that as our parent instead of failing.
+				if row2, gerr := a.Store.AgentDefGetActive(ctx, in.Name); gerr == nil {
+					parent = row2
+					parentDefID = row2.DefID
+				} else {
+					return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+				}
+			} else {
+				parent = bootstrap
+				parentDefID = bootstrap.DefID
 			}
-			parent = bootstrap
-			parentDefID = bootstrap.DefID
 		}
 	}
 
@@ -407,11 +439,17 @@ func (a *AgentDef) checkScopeForName(policy tools.AgentDefPolicyValue, name, _ s
 				return nil
 			}
 		case "descendants":
-			// v0.8.5 simplification: descendants is treated as "any"
-			// inside the agent's spawn tree, which the tool can't
-			// efficiently verify without walking the lineage against
-			// every check. For now, accept on "descendants" present —
-			// a future PR can tighten this with a lineage-walk gate.
+			// KNOWN GAP (TODO v0.9.x): `descendants` is intended to
+			// permit mutation of agents in the calling agent's spawn
+			// tree. Today the tool has no efficient way to verify
+			// lineage against every check (cfg.Agents is the static
+			// boundary; a DB-only descendant tree is N AgentDefGet
+			// round-trips deep). For v0.8.5 we accept on "descendants"
+			// present, which makes the scope behaviourally equivalent
+			// to "any". Operators wanting strict descendant gating
+			// must grant `named:<child>` per child instead. See
+			// TestAgentDefTool_DescendantsScopeIsCurrentlyEquivalentToAny
+			// for the pinned-but-undesired current behaviour.
 			return nil
 		default:
 			if strings.HasPrefix(sc, "named:") {
@@ -467,17 +505,28 @@ func (a *AgentDef) resolveAllowedToolsRoot(ctx context.Context, name string, par
 	if static, ok := a.Cfg.Agents[name]; ok {
 		return static.AllowedTools, nil
 	}
-	// Walk parent chain to the v1 row.
+	// Walk parent chain to the v1 row. Hard cap at 100 hops as a
+	// defense against cyclic / corrupt lineage. If we exhaust the cap
+	// without reaching the root (ParentDefID still non-empty), refuse
+	// rather than treat the mid-chain row as the ceiling — using a
+	// non-root row would silently weaken the AllowedTools security
+	// invariant for sufficiently deep or cyclic chains.
 	cur := parent
-	for i := 0; i < 100; i++ {
+	const maxHops = 100
+	reachedRoot := false
+	for i := 0; i < maxHops; i++ {
 		if cur.ParentDefID == "" {
-			break // cur is the root
+			reachedRoot = true
+			break
 		}
 		next, err := a.Store.AgentDefGet(ctx, cur.ParentDefID)
 		if err != nil {
 			return nil, err
 		}
 		cur = next
+	}
+	if !reachedRoot {
+		return nil, fmt.Errorf("lineage depth exceeds %d hops — possible cycle or corrupt chain for name %q (last def_id walked: %q)", maxHops, name, cur.DefID)
 	}
 	var rootDef mergedDef
 	if err := json.Unmarshal(cur.Definition, &rootDef); err != nil {

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -1,0 +1,639 @@
+package builtin
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// AgentDef is the v0.8.5 built-in tool that lets agents author, fork,
+// promote, retire, and inspect agent definitions at runtime. Static
+// `<name>.md` files remain the operator-blessed root; this tool
+// produces the DERIVED layer of agent-authored versions.
+//
+// Six operations dispatched off the `op` field:
+//
+//	create   — declare a brand-new agent name with a v1 definition.
+//	           Refused if `name` matches a static cfg.Agents entry
+//	           (operators expect their MDs to be ground truth).
+//	fork     — make a new version from an existing parent (DB-resolved
+//	           by def_id, or by-name from the active pointer). Default
+//	           does NOT auto-promote — orchestrators promote
+//	           explicitly after evaluation.
+//	get      — fetch one row by def_id.
+//	list     — list versions for a name, version DESC.
+//	retire   — flip the retired flag on a def. Row stays visible in
+//	           lineage; resolver skips retired when picking active.
+//	promote  — set the active pointer for a name to a specific def_id.
+//
+// AllowedTools enforcement: forks may NARROW but NEVER widen. The
+// operator-blessed root (static cfg.Agents[name].AllowedTools if it
+// exists, else the v1 row's AllowedTools) is the permanent capability
+// ceiling. A fork that tries to add a tool not in the root is
+// rejected with a typed error.
+//
+// Server-stamped fields: created_at, created_by_agent_id (from
+// tools.RunIdentity), created_by_run_id (from ctx). The model
+// NEVER supplies these.
+type AgentDef struct {
+	// Store is the persistence backend. Required.
+	Store store.Store
+
+	// Cfg is the loaded operator config. Used to resolve the
+	// operator-blessed root (cfg.Agents[name]) for AllowedTools
+	// ceiling enforcement and to refuse `create` over a static name.
+	Cfg *config.Config
+
+	// MaxDefinitionBytes caps the serialised definition JSON
+	// (LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES). 0 = no cap.
+	MaxDefinitionBytes int
+
+	// MaxDescriptionBytes caps the description field
+	// (LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES). 0 = no cap.
+	MaxDescriptionBytes int
+}
+
+const agentDefDescription = `Author, fork, promote, retire, and inspect agent definitions at runtime. ` +
+	`Static <name>.md files remain the operator's immutable ground truth; this tool ` +
+	`produces the DERIVED layer of agent-authored versions. AllowedTools may be NARROWED ` +
+	`on forks but never WIDENED — operator-blessed root is the permanent capability ceiling. ` +
+	`Operations: create, fork, get, list, retire, promote.`
+
+const agentDefInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":            {"type": "string", "enum": ["create","fork","get","list","retire","promote"], "description": "Operation to perform."},
+    "name":          {"type": "string", "description": "Agent name (required for create/fork/list)."},
+    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire/promote)."},
+    "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name)."},
+    "overlay": {
+      "type": "object",
+      "description": "Mutable subset of AgentDef for create/fork. Immutable / server-set fields (def_id, version, parent_def_id, created_*, bootstrapped_from_static) are silently ignored if supplied.",
+      "additionalProperties": true
+    },
+    "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
+    "promote":       {"type": "boolean", "description": "create defaults true, fork defaults false. When true, sets the active pointer for the name to the new def."},
+    "retired":       {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."}
+  },
+  "required": ["op"]
+}`
+
+type agentDefInput struct {
+	Op          string          `json:"op"`
+	Name        string          `json:"name,omitempty"`
+	DefID       string          `json:"def_id,omitempty"`
+	ParentDefID string          `json:"parent_def_id,omitempty"`
+	Overlay     json.RawMessage `json:"overlay,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Promote     *bool           `json:"promote,omitempty"`
+	Retired     *bool           `json:"retired,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (a *AgentDef) Name() string { return "AgentDef" }
+
+// Description implements tools.Tool.
+func (a *AgentDef) Description() string { return agentDefDescription }
+
+// InputSchema implements tools.Tool.
+func (a *AgentDef) InputSchema() json.RawMessage { return json.RawMessage(agentDefInputSchema) }
+
+// Execute implements tools.Tool.
+func (a *AgentDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if a.Store == nil {
+		return errResult("AgentDef tool: not configured (no Store backend)"), nil
+	}
+	if a.Cfg == nil {
+		return errResult("AgentDef tool: not configured (no Config — operator-blessed root unavailable)"), nil
+	}
+	var in agentDefInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	policy := tools.AgentDefPolicy(ctx)
+
+	switch in.Op {
+	case "create":
+		return a.execCreate(ctx, policy, in)
+	case "fork":
+		return a.execFork(ctx, policy, in)
+	case "get":
+		return a.execGet(ctx, policy, in)
+	case "list":
+		return a.execList(ctx, policy, in)
+	case "retire":
+		return a.execRetire(ctx, policy, in)
+	case "promote":
+		return a.execPromote(ctx, policy, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire, promote)", in.Op)), nil
+	}
+}
+
+// ---- create ----
+
+func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("create: missing required field: name"), nil
+	}
+	if err := a.checkScopeForName(policy, in.Name, ""); err != nil {
+		return errResult(err.Error()), nil
+	}
+	// Static-name-replace refusal — operator-blessed MD is ground truth.
+	// Anyone wanting to evolve a static agent must fork, not create.
+	if _, ok := a.Cfg.Agents[in.Name]; ok {
+		return errResult(fmt.Sprintf("create: name %q matches a static cfg.Agents entry — use `fork` to derive a new version", in.Name)), nil
+	}
+
+	def, err := a.buildDefinition(ctx, in.Name, "", in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
+	}
+	if a.MaxDefinitionBytes > 0 && len(defJSON) > a.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("create: definition (%d bytes) exceeds max %d", len(defJSON), a.MaxDefinitionBytes)), nil
+	}
+	if a.MaxDescriptionBytes > 0 && len(in.Description) > a.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.AgentDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+		// CreatedByRunID stays empty here — there's no run_id on
+		// RunIdentityValue today; carried via the run ctx separately.
+	}
+	created, err := a.Store.AgentDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := a.Store.AgentDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
+		}
+	}
+	return okJSON(rowResponse(created, promote))
+}
+
+// ---- fork ----
+
+func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("fork: missing required field: name"), nil
+	}
+
+	// Resolve the parent. Three paths:
+	//   1. parent_def_id supplied → pin
+	//   2. parent_def_id empty + active pointer exists → use it
+	//   3. neither → name must have a static MD; bootstrap v1
+	//      snapshot as the parent
+	parentDefID := in.ParentDefID
+	var parent store.AgentDefRow
+	if parentDefID != "" {
+		row, err := a.Store.AgentDefGet(ctx, parentDefID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: parent_def_id %q not found", parentDefID)), nil
+			}
+			return errResult(fmt.Sprintf("fork: %s", err)), nil
+		}
+		if row.Name != in.Name {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
+		}
+		parent = row
+	} else {
+		// Try the active pointer first.
+		row, err := a.Store.AgentDefGetActive(ctx, in.Name)
+		if err == nil {
+			parent = row
+			parentDefID = row.DefID
+		} else {
+			var nf *store.ErrNotFound
+			if !errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: %s", err)), nil
+			}
+			// No active pointer → must bootstrap from static MD.
+			static, ok := a.Cfg.Agents[in.Name]
+			if !ok {
+				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static cfg.Agents entry", in.Name)), nil
+			}
+			bootstrap, err := a.bootstrapStatic(ctx, in.Name, static)
+			if err != nil {
+				return errResult(fmt.Sprintf("fork: bootstrap static: %s", err)), nil
+			}
+			parent = bootstrap
+			parentDefID = bootstrap.DefID
+		}
+	}
+
+	if err := a.checkScopeForName(policy, in.Name, parentDefID); err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	def, err := a.buildDefinition(ctx, in.Name, string(parent.Definition), in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	// AllowedTools ceiling enforcement — fork may narrow, never widen.
+	root, err := a.resolveAllowedToolsRoot(ctx, in.Name, parent)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: resolve root: %s", err)), nil
+	}
+	if err := assertAllowedToolsSubset(def.AllowedTools, root); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
+	}
+	if a.MaxDefinitionBytes > 0 && len(defJSON) > a.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("fork: definition (%d bytes) exceeds max %d", len(defJSON), a.MaxDefinitionBytes)), nil
+	}
+	if a.MaxDescriptionBytes > 0 && len(in.Description) > a.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.AgentDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		ParentDefID:      parentDefID,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := a.Store.AgentDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	promote := false
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := a.Store.AgentDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
+		}
+	}
+	return okJSON(rowResponse(created, promote))
+}
+
+// ---- get / list ----
+
+func (a *AgentDef) execGet(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("get: missing required field: def_id"), nil
+	}
+	row, err := a.Store.AgentDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("get: %s", err)), nil
+	}
+	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
+		return errResult(err.Error()), nil
+	}
+	return okJSON(rowResponse(row, false))
+}
+
+func (a *AgentDef) execList(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("list: missing required field: name"), nil
+	}
+	if err := a.checkScopeForName(policy, in.Name, ""); err != nil {
+		return errResult(err.Error()), nil
+	}
+	rows, err := a.Store.AgentDefListByName(ctx, in.Name)
+	if err != nil {
+		return errResult(fmt.Sprintf("list: %s", err)), nil
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, rowResponseMap(r))
+	}
+	return okJSON(map[string]any{"name": in.Name, "versions": out})
+}
+
+// ---- retire / promote ----
+
+func (a *AgentDef) execRetire(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("retire: missing required field: def_id"), nil
+	}
+	if in.Retired == nil {
+		return errResult("retire: missing required field: retired (true|false)"), nil
+	}
+	row, err := a.Store.AgentDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if err := a.Store.AgentDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+}
+
+func (a *AgentDef) execPromote(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("promote: missing required field: def_id"), nil
+	}
+	row, err := a.Store.AgentDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("promote: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("promote: %s", err)), nil
+	}
+	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
+		return errResult(err.Error()), nil
+	}
+	ident := tools.RunIdentity(ctx)
+	if err := a.Store.AgentDefSetActive(ctx, row.Name, row.DefID, ident.AgentID); err != nil {
+		return errResult(fmt.Sprintf("promote: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": row.DefID, "name": row.Name, "promoted": true})
+}
+
+// ---- helpers ----
+
+// checkScopeForName enforces the agent's agent_def_scopes against a
+// proposed (name, def_id) target. Default-deny when policy.Scopes
+// is empty. The def_id arg is used for "descendants" path
+// (currently treated as "any" since lineage-walk on every check is
+// too expensive — flagged TODO; refines in v0.9.x).
+func (a *AgentDef) checkScopeForName(policy tools.AgentDefPolicyValue, name, _ string) error {
+	if len(policy.Scopes) == 0 {
+		return fmt.Errorf("AgentDef tool: agent has no agent_def_scopes (default-deny); add `agent_def_scopes: [...]` to the agent yaml")
+	}
+	for _, sc := range policy.Scopes {
+		switch sc {
+		case "any":
+			return nil
+		case "self":
+			if name == policy.SelfName {
+				return nil
+			}
+		case "descendants":
+			// v0.8.5 simplification: descendants is treated as "any"
+			// inside the agent's spawn tree, which the tool can't
+			// efficiently verify without walking the lineage against
+			// every check. For now, accept on "descendants" present —
+			// a future PR can tighten this with a lineage-walk gate.
+			return nil
+		default:
+			if strings.HasPrefix(sc, "named:") {
+				if strings.TrimPrefix(sc, "named:") == name {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf("AgentDef tool: name %q not in this agent's agent_def_scopes (%v)", name, policy.Scopes)
+}
+
+// buildDefinition takes the base definition (parent's JSON for fork;
+// the static cfg.Agents entry for create; empty for create-of-new-
+// name), applies the overlay, and returns the merged AgentDef.
+//
+// Immutable + server-set fields (def_id, version, parent_def_id,
+// created_*, bootstrapped_from_static) are SILENTLY DROPPED from the
+// overlay — the model can supply them; we ignore. The tool layer
+// stamps them server-side.
+//
+// Returns a config.AgentDef shape but as a generic JSON-decodable
+// map so the store layer doesn't need the config import.
+func (a *AgentDef) buildDefinition(ctx context.Context, name, parentJSON string, overlay json.RawMessage) (mergedDef, error) {
+	base := mergedDef{}
+	if parentJSON != "" {
+		if err := json.Unmarshal([]byte(parentJSON), &base); err != nil {
+			return mergedDef{}, fmt.Errorf("parse parent definition: %w", err)
+		}
+	} else if static, ok := a.Cfg.Agents[name]; ok {
+		// Create-with-static-name path is REFUSED in execCreate; this
+		// branch handles fork's bootstrap-from-static when there's no
+		// parent JSON yet but a static entry exists.
+		base = staticToMergedDef(static)
+	}
+
+	if len(overlay) > 0 {
+		var ov mergedDef
+		if err := json.Unmarshal(overlay, &ov); err != nil {
+			return mergedDef{}, fmt.Errorf("parse overlay: %w", err)
+		}
+		base.applyOverlay(ov)
+	}
+	return base, nil
+}
+
+// resolveAllowedToolsRoot returns the operator-blessed AllowedTools
+// ceiling for a name + parent chain. For names with a static MD,
+// that's cfg.Agents[name].AllowedTools — the operator's permanent
+// authority. For names that exist only in DB (created via `create`),
+// it's the v1 row's AllowedTools (the root of the DB-only lineage).
+func (a *AgentDef) resolveAllowedToolsRoot(ctx context.Context, name string, parent store.AgentDefRow) ([]string, error) {
+	if static, ok := a.Cfg.Agents[name]; ok {
+		return static.AllowedTools, nil
+	}
+	// Walk parent chain to the v1 row.
+	cur := parent
+	for i := 0; i < 100; i++ {
+		if cur.ParentDefID == "" {
+			break // cur is the root
+		}
+		next, err := a.Store.AgentDefGet(ctx, cur.ParentDefID)
+		if err != nil {
+			return nil, err
+		}
+		cur = next
+	}
+	var rootDef mergedDef
+	if err := json.Unmarshal(cur.Definition, &rootDef); err != nil {
+		return nil, fmt.Errorf("parse root definition: %w", err)
+	}
+	return rootDef.AllowedTools, nil
+}
+
+// assertAllowedToolsSubset returns nil iff every tool in `proposed`
+// also appears in `root`. Empty proposed = empty subset = OK (narrowing
+// to zero tools is allowed). Empty root = no permitted tools — proposed
+// must also be empty.
+func assertAllowedToolsSubset(proposed, root []string) error {
+	rootSet := make(map[string]bool, len(root))
+	for _, t := range root {
+		rootSet[t] = true
+	}
+	for _, t := range proposed {
+		if !rootSet[t] {
+			return fmt.Errorf("AllowedTools cannot widen — %q is not in the operator-blessed root %v", t, root)
+		}
+	}
+	return nil
+}
+
+// bootstrapStatic snapshots the cfg.Agents[name] static MD into a v1
+// DB row with bootstrapped_from_static=TRUE. Called by fork when no
+// parent exists yet but the name has a static entry. The snapshot is
+// the immortal lineage root.
+func (a *AgentDef) bootstrapStatic(ctx context.Context, name string, static config.AgentDef) (store.AgentDefRow, error) {
+	def := staticToMergedDef(static)
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return store.AgentDefRow{}, fmt.Errorf("marshal: %w", err)
+	}
+	ident := tools.RunIdentity(ctx)
+	row := store.AgentDefRow{
+		DefID:                  mintDefID(),
+		Name:                   name,
+		Definition:             defJSON,
+		Description:            "bootstrapped from static cfg.Agents",
+		CreatedByAgentID:       ident.AgentID,
+		BootstrappedFromStatic: true,
+	}
+	created, err := a.Store.AgentDefCreate(ctx, row)
+	if err != nil {
+		return store.AgentDefRow{}, err
+	}
+	return created, nil
+}
+
+// mergedDef is the JSON shape stored in agent_defs.definition. It
+// mirrors the mutable subset of config.AgentDef — keeps the DB
+// layer config-agnostic.
+type mergedDef struct {
+	Provider         string                            `json:"provider,omitempty"`
+	Model            string                            `json:"model,omitempty"`
+	Tier             string                            `json:"tier,omitempty"`
+	Effort           string                            `json:"effort,omitempty"`
+	MaxTokens        int                               `json:"max_tokens,omitempty"`
+	SystemPrompt     string                            `json:"system_prompt,omitempty"`
+	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
+	Skills           []string                          `json:"skills,omitempty"`
+	Providers        []string                          `json:"providers,omitempty"`
+	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
+	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
+	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+	Description      string                            `json:"description,omitempty"`
+}
+
+func (d *mergedDef) applyOverlay(ov mergedDef) {
+	if ov.Provider != "" {
+		d.Provider = ov.Provider
+	}
+	if ov.Model != "" {
+		d.Model = ov.Model
+	}
+	if ov.Tier != "" {
+		d.Tier = ov.Tier
+	}
+	if ov.Effort != "" {
+		d.Effort = ov.Effort
+	}
+	if ov.MaxTokens != 0 {
+		d.MaxTokens = ov.MaxTokens
+	}
+	if ov.SystemPrompt != "" {
+		d.SystemPrompt = ov.SystemPrompt
+	}
+	if ov.AllowedTools != nil {
+		d.AllowedTools = ov.AllowedTools
+	}
+	if ov.Skills != nil {
+		d.Skills = ov.Skills
+	}
+	if ov.Providers != nil {
+		d.Providers = ov.Providers
+	}
+	if ov.Models != nil {
+		d.Models = ov.Models
+	}
+	if ov.MemoryScopes != nil {
+		d.MemoryScopes = ov.MemoryScopes
+	}
+	if ov.MemoryQuotaBytes != 0 {
+		d.MemoryQuotaBytes = ov.MemoryQuotaBytes
+	}
+	if ov.Description != "" {
+		d.Description = ov.Description
+	}
+}
+
+func staticToMergedDef(s config.AgentDef) mergedDef {
+	return mergedDef{
+		Provider:         s.Provider,
+		Model:            s.Model,
+		Tier:             s.Tier,
+		Effort:           s.Effort,
+		MaxTokens:        s.MaxTokens,
+		SystemPrompt:     s.SystemPrompt,
+		AllowedTools:     s.AllowedTools,
+		Skills:           s.Skills,
+		Providers:        s.Providers,
+		Models:           s.Models,
+		MemoryScopes:     s.MemoryScopes,
+		MemoryQuotaBytes: s.MemoryQuotaBytes,
+	}
+}
+
+// rowResponse + rowResponseMap shape the tool's reply envelope. Both
+// use the same fields so consumers can parse with one shape.
+func rowResponse(row store.AgentDefRow, promoted bool) map[string]any {
+	m := rowResponseMap(row)
+	m["promoted"] = promoted
+	return m
+}
+
+func rowResponseMap(row store.AgentDefRow) map[string]any {
+	return map[string]any{
+		"def_id":                   row.DefID,
+		"name":                     row.Name,
+		"version":                  row.Version,
+		"parent_def_id":            row.ParentDefID,
+		"description":              row.Description,
+		"created_at":               row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		"created_by_agent_id":      row.CreatedByAgentID,
+		"retired":                  row.Retired,
+		"bootstrapped_from_static": row.BootstrappedFromStatic,
+	}
+}
+
+// mintDefID returns a fresh opaque ID for a new row. 16 hex chars
+// = 64 bits entropy — matches the existing newID pattern in
+// internal/store/sqlite/sqlite.go. Format: "def_<hex>".
+func mintDefID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "def_" + hex.EncodeToString(b[:])
+}

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -237,3 +237,80 @@ func TestAgentDefTool_RetireRoundTrip(t *testing.T) {
 		t.Error("retire(false) didn't reverse")
 	}
 }
+
+// Capability-escalation guard on `create`: an agent with narrow
+// allowed_tools cannot mint a new agent with a wider tool surface
+// than its own. The caller's effective AgentTools(ctx) is the
+// ceiling. Mirror of the subset check in `fork`.
+func TestAgentDefTool_CreateRefusedOnAllowedToolsWidening(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Caller's effective tools is [Read, AgentDef] only.
+	narrowCtx := tools.WithAgentTools(ctx, []string{"Read", "AgentDef"})
+
+	// Overlay tries to add Write — wider than the caller's surface.
+	res, _ := tool.Execute(narrowCtx, json.RawMessage(`{"op":"create","name":"newagent","overlay":{"allowed_tools":["Read","Write"]}}`))
+	if !res.IsError {
+		t.Fatalf("create with wider allowed_tools should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "AllowedTools cannot widen") {
+		t.Errorf("error should mention AllowedTools widening; got %s", res.Text)
+	}
+
+	// Same overlay but subset of caller's tools is fine.
+	res, _ = tool.Execute(narrowCtx, json.RawMessage(`{"op":"create","name":"newagent2","overlay":{"allowed_tools":["Read"]}}`))
+	if res.IsError {
+		t.Fatalf("create with narrowed allowed_tools should pass; got %s", res.Text)
+	}
+}
+
+// Missing AgentTools(ctx) — runtime misconfiguration. With a
+// non-empty overlay AllowedTools, refuse rather than silently
+// allow the wider value.
+func TestAgentDefTool_CreateRefusedWhenCallerToolsMissing(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// ctx does NOT have AgentTools attached. Overlay sets allowed_tools.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"newagent","overlay":{"allowed_tools":["Read"]}}`))
+	if !res.IsError {
+		t.Fatalf("create with no AgentTools(ctx) + AllowedTools overlay should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "not on ctx") {
+		t.Errorf("error should mention missing ctx tools; got %s", res.Text)
+	}
+
+	// Create WITHOUT allowed_tools overlay should still pass (no
+	// widening risk when the def doesn't declare its own tools).
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"toolless"}`))
+	if res.IsError {
+		t.Fatalf("create with no allowed_tools overlay should pass even without ctx tools; got %s", res.Text)
+	}
+}
+
+// Documents the v0.8.5 gap: the `descendants` scope is behaviourally
+// equivalent to `any` because the tool does not walk the lineage
+// graph on every check. This pins the current (undesired) behaviour
+// so future tightening triggers a deliberate test update rather than
+// silently changing the runtime contract.
+func TestAgentDefTool_DescendantsScopeIsCurrentlyEquivalentToAny(t *testing.T) {
+	tool, _, cleanup := agentDefFixture(t)
+	defer cleanup()
+	// Build a ctx with ONLY `descendants` scope (no `any`, no `named:foo`).
+	ctx := tools.WithAgentName(context.Background(), "alpha")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"descendants"},
+		SelfName: "alpha",
+	})
+	ctx = tools.WithAgentTools(ctx, []string{"Read"})
+
+	// Mutate a totally unrelated name (would-be cross-tree).
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"completely-unrelated"}`))
+	if res.IsError {
+		t.Fatalf("descendants scope currently accepts unrelated names by design (v0.8.5 gap); got %s", res.Text)
+	}
+	// When this test starts failing, descendants has been tightened —
+	// update the test and the inline comment in checkScopeForName.
+}

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -1,0 +1,239 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// agentDefFixture builds an AgentDef tool over in-memory SQLite +
+// a stub Config with one "static" agent. Returns a ctx with a
+// permissive policy (scopes=[any]); per-test code overrides for
+// scope-specific cases.
+func agentDefFixture(t *testing.T) (*AgentDef, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Agents: map[string]config.AgentDef{
+			"researcher": {
+				Provider:     "anthropic",
+				Model:        "claude-haiku-4-5",
+				SystemPrompt: "operator-blessed root prompt",
+				AllowedTools: []string{"Read", "WebFetch", "AgentDef"},
+			},
+		},
+	}
+	tool := &AgentDef{
+		Store:               s,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  131072,
+		MaxDescriptionBytes: 8192,
+	}
+	ctx := tools.WithAgentName(context.Background(), "researcher")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: "researcher",
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func TestAgentDefTool_CreateRefusedOverStaticName(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// "researcher" exists in cfg.Agents → create must refuse.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"researcher","overlay":{"system_prompt":"new"}}`))
+	if !res.IsError {
+		t.Fatalf("create over static name should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "static cfg.Agents") {
+		t.Errorf("refusal should mention static; got %s", res.Text)
+	}
+}
+
+func TestAgentDefTool_CreateNewName(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"reviewer","overlay":{"provider":"openai","system_prompt":"new agent"},"description":"reviewer for code"}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["name"] != "reviewer" {
+		t.Errorf("name = %v, want reviewer", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("create default promote = false; want true")
+	}
+}
+
+func TestAgentDefTool_ForkInheritsParent(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Fork "researcher" (static MD bootstrap). Default promote=false.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"researcher","overlay":{"system_prompt":"forked prompt"}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["promoted"].(bool) != false {
+		t.Errorf("fork default promote = true; want false")
+	}
+	if out["parent_def_id"] == "" {
+		t.Error("fork must record parent_def_id")
+	}
+	// list should now have 2 entries (v1 static bootstrap + v2 fork).
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"researcher"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	out = decodeResult(t, res.Text)
+	versions := out["versions"].([]any)
+	if len(versions) != 2 {
+		t.Errorf("after fork: got %d versions, want 2 (bootstrap v1 + fork v2)", len(versions))
+	}
+}
+
+func TestAgentDefTool_ForkAllowedToolsCannotWiden(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Static root has [Read, WebFetch, AgentDef]. Try to fork adding "Write".
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"researcher","overlay":{"allowed_tools":["Read","WebFetch","Write"]}}`))
+	if !res.IsError {
+		t.Fatalf("fork widening allowed_tools should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "AllowedTools cannot widen") {
+		t.Errorf("refusal should mention widening; got %s", res.Text)
+	}
+}
+
+func TestAgentDefTool_ForkAllowedToolsCanNarrow(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"researcher","overlay":{"allowed_tools":["Read"]}}`))
+	if res.IsError {
+		t.Fatalf("fork narrowing should succeed; got %s", res.Text)
+	}
+}
+
+func TestAgentDefTool_NoScopesIsDefaultDeny(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   nil,
+		SelfName: "researcher",
+	})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"newbot"}`))
+	if !res.IsError {
+		t.Fatalf("no scopes = default-deny; want refusal, got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "default-deny") {
+		t.Errorf("refusal should mention default-deny; got %s", res.Text)
+	}
+}
+
+func TestAgentDefTool_SelfScopeOnlyOwnName(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"self"},
+		SelfName: "researcher",
+	})
+	// Own name → ok.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"researcher"}`))
+	if res.IsError {
+		t.Errorf("self scope on own name should succeed; got %s", res.Text)
+	}
+	// Other name → refused.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"otheragent"}`))
+	if !res.IsError {
+		t.Fatalf("self scope on different name should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "agent_def_scopes") {
+		t.Errorf("refusal should mention agent_def_scopes; got %s", res.Text)
+	}
+}
+
+func TestAgentDefTool_NamedScope(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"named:reviewer"},
+		SelfName: "orchestrator",
+	})
+	// "reviewer" → ok.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"reviewer"}`))
+	if res.IsError {
+		t.Errorf("named:reviewer on reviewer should succeed; got %s", res.Text)
+	}
+	// "coder" → refused.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"coder"}`))
+	if !res.IsError {
+		t.Fatalf("named:reviewer on coder should refuse")
+	}
+}
+
+func TestAgentDefTool_PromoteAndGet(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Create with promote=false, then explicit promote.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"reviewer","promote":false}`))
+	if res.IsError {
+		t.Fatal(res.Text)
+	}
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"promote","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("promote: %s", res.Text)
+	}
+	// Get back the row.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["name"] != "reviewer" {
+		t.Error("get returned wrong row")
+	}
+}
+
+func TestAgentDefTool_RetireRoundTrip(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"retiretest"}`))
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if res.IsError {
+		t.Fatalf("retire: %s", res.Text)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if !decodeResult(t, res.Text)["retired"].(bool) {
+		t.Error("retire(true) didn't stick")
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":false}`))
+	if res.IsError {
+		t.Fatal(res.Text)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if decodeResult(t, res.Text)["retired"].(bool) {
+		t.Error("retire(false) didn't reverse")
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -339,6 +339,63 @@ func EventEmitter(ctx context.Context) EventEmitterFunc {
 	return func(providers.Event) {}
 }
 
+// ctxKeyAgentDefPolicy carries the v0.8.5 AgentDef-tool capability
+// gate. Mirrors MemoryPolicy / ChannelPolicy shape.
+type ctxKeyAgentDefPolicy struct{}
+
+// AgentDefPolicyValue is the per-agent AgentDef-tool access policy.
+//
+//   - Scopes is the operator-yaml agent_def_scopes list. Closed set:
+//     "self" / "descendants" / "any" / "named:<name>". Empty =
+//     default-deny.
+//
+// Auxiliary identity fields stamped server-side at ctx-attach so the
+// AgentDef tool can resolve self / siblings / descendants without
+// re-reading ctx values that may have been overwritten by sub-agent
+// chains:
+//
+//   - SelfName is the yaml agent name (== tools.AgentName(ctx) at
+//     attach time). Used for the "self" scope check.
+type AgentDefPolicyValue struct {
+	Scopes   []string
+	SelfName string
+}
+
+// WithAgentDefPolicy attaches the policy to ctx.
+func WithAgentDefPolicy(ctx context.Context, p AgentDefPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyAgentDefPolicy{}, p)
+}
+
+// AgentDefPolicy returns the policy from ctx. Zero value = no
+// access (default-deny — the tool refuses every mutation op until
+// scopes are explicitly granted via yaml).
+func AgentDefPolicy(ctx context.Context) AgentDefPolicyValue {
+	v, _ := ctx.Value(ctxKeyAgentDefPolicy{}).(AgentDefPolicyValue)
+	return v
+}
+
+// ctxKeyEvaluationPolicy carries the v0.8.5 Evaluation-tool gate.
+type ctxKeyEvaluationPolicy struct{}
+
+// EvaluationPolicyValue is the per-agent Evaluation policy.
+// Multi-select scopes; default-deny when Scopes is empty. See
+// config.AgentDef.EvaluationScopes docstring for the closed set.
+type EvaluationPolicyValue struct {
+	Scopes []string
+}
+
+// WithEvaluationPolicy attaches the policy to ctx.
+func WithEvaluationPolicy(ctx context.Context, p EvaluationPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyEvaluationPolicy{}, p)
+}
+
+// EvaluationPolicy returns the policy from ctx. Zero value =
+// no access.
+func EvaluationPolicy(ctx context.Context) EvaluationPolicyValue {
+	v, _ := ctx.Value(ctxKeyEvaluationPolicy{}).(EvaluationPolicyValue)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names consult
 // the optional Fallback before returning the standard "tool not found"
 // error result (the model can self-correct on the error result; we never


### PR DESCRIPTION
## Summary

PR 3 of seven in the **Self-Evolution Substrate (v0.8.5)** sequence. Adds the `AgentDef` built-in tool — agents can author, fork, promote, retire, and inspect agent definitions at runtime. **Stacked on PR 2** (config + resolver plumbing).

Static `<name>.md` files remain the operator-blessed root; this tool produces the DERIVED layer of agent-authored versions. ~960 LOC including 10 unit tests.

## Six operations

| Op | What |
|---|---|
| `create` | Declare a brand-new agent name with a v1 definition. **Refused** if `name` matches a static `cfg.Agents` entry — operators expect their MDs to be ground truth. |
| `fork` | New version from an existing parent. Parent resolved in order: explicit `parent_def_id` → active pointer for the name → **bootstrap-from-static** (snapshots the static MD as v1 with `bootstrapped_from_static=TRUE`; the snapshot is the immortal lineage root). Default `promote=false`. |
| `get` | Fetch one row by `def_id`. |
| `list` | List versions for a name, version DESC. |
| `retire` | Flip the retired flag. Row stays visible in lineage; resolver skips retired when picking active. |
| `promote` | Set the active pointer to a specific `def_id`. |

## AllowedTools ceiling enforcement

Forks may **NARROW** but **NEVER widen**. The operator-blessed root (`cfg.Agents[name].AllowedTools` when present, else the v1 row's `AllowedTools`) is the permanent capability ceiling. An agent with `AgentDef` access cannot escalate by forking. Pinned by the cannot-widen + can-narrow test pair.

## Server-stamped fields

- `created_at` (server time)
- `created_by_agent_id` (from `tools.RunIdentity`)
- `def_id`, `version`, `parent_def_id`, `bootstrapped_from_static`

Model NEVER supplies these. Immutable fields in the overlay are silently dropped at `buildDefinition` time.

## Capability gates

Read from `tools.AgentDefPolicy(ctx)` (introduced in PR 2):

- `"any"` — unrestricted
- `"self"` — only the agent's own name (`== policy.SelfName`)
- `"named:<name>"` — only the named entry
- `"descendants"` — accepted but currently treated as "any"; full lineage-walk gate is a v0.9.x refinement (noted in the helper's docstring)

**Default-deny when scopes is empty.**

## New env vars

| Env | Default |
|---|---|
| `LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES` | 128 KB |
| `LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES` | 8 KB |
| `LOOMCYCLE_EVALUATION_MAX_JUDGEMENT_BYTES` | 32 KB (PR 4) |
| `LOOMCYCLE_EVALUATION_MAX_RATIONALE_BYTES` | 8 KB (PR 4) |

All have negative-as-disable semantics (mirrors Memory + Channel sibling caps).

## Tool registration

Wired in `cmd/loomcycle/main.go` alongside the existing Memory + Channel + Skill tools. The tool is registered **globally**; per-agent default-deny remains via the ctx-policy gate.

## Test coverage (10 new subtests)

- `CreateRefusedOverStaticName` — static MD is inviolate
- `CreateNewName` — default `promote=true`, version 1
- `ForkInheritsParent` — default `promote=false`; v1 bootstrap + v2 fork yields 2 list entries
- `ForkAllowedToolsCannotWiden` / `ForkAllowedToolsCanNarrow` — ceiling enforcement
- `NoScopesIsDefaultDeny`
- `SelfScopeOnlyOwnName` / `NamedScope`
- `PromoteAndGet`
- `RetireRoundTrip` — retire(true)/(false) reversible

## Test plan

- [x] `go test ./...` clean (10 new tests pass).
- [x] `gofmt -l` clean.
- [x] Binary builds clean.
- [x] AllowedTools ceiling enforced both directions (widening refused, narrowing accepted).
- [x] Default-deny when `agent_def_scopes` is empty.
- [ ] Operator eyeball pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)