### PR TITLE
feat(substrate): v0.8.5 PR 5 — sub-agent pinning via def_id (forward port to main)

### DIFF
--- a/internal/api/http/agent_def_overlay_test.go
+++ b/internal/api/http/agent_def_overlay_test.go
@@ -1,0 +1,167 @@
+package http
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// applyAgentDefOverlay is the helper that merges an agent_defs row's
+// JSON definition over a static cfg.Agents entry for one sub-run.
+// These tests pin the merge semantics described in the v0.8.5 PR 5 RFC:
+//   - non-empty / non-zero fields override the static base
+//   - nil slices / maps / zero ints leave the base untouched
+//   - explicit Model pin clears static Tier (and vice versa) so the
+//     Pin XOR Tier invariant survives the overlay
+//   - substrate policy fields (agent_def_scopes, evaluation_scopes)
+//     are NOT in the merge surface — they stay with the static yaml.
+
+func TestApplyAgentDefOverlay_Empty(t *testing.T) {
+	base := config.AgentDef{
+		Provider:     "anthropic",
+		Model:        "claude-haiku-4-5",
+		SystemPrompt: "you are a helpful agent",
+		AllowedTools: []string{"Read", "Write"},
+	}
+	got := applyAgentDefOverlay(base, json.RawMessage{})
+	if !reflect.DeepEqual(got, base) {
+		t.Errorf("empty overlay should not modify base; got %+v", got)
+	}
+}
+
+func TestApplyAgentDefOverlay_SystemPromptAndAllowedTools(t *testing.T) {
+	base := config.AgentDef{
+		Provider:     "anthropic",
+		Model:        "claude-haiku-4-5",
+		SystemPrompt: "static prompt",
+		AllowedTools: []string{"Read", "Write"},
+	}
+	def := json.RawMessage(`{
+		"system_prompt": "forked prompt",
+		"allowed_tools": ["Read"]
+	}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.SystemPrompt != "forked prompt" {
+		t.Errorf("system_prompt = %q, want forked prompt", got.SystemPrompt)
+	}
+	if !reflect.DeepEqual(got.AllowedTools, []string{"Read"}) {
+		t.Errorf("allowed_tools = %v, want [Read]", got.AllowedTools)
+	}
+	// Untouched: provider, model.
+	if got.Provider != "anthropic" || got.Model != "claude-haiku-4-5" {
+		t.Errorf("untouched fields drifted: %+v", got)
+	}
+}
+
+func TestApplyAgentDefOverlay_TierOverridesStaticModelPin(t *testing.T) {
+	// Static had an explicit model pin; fork moves to tier-driven
+	// resolution. Pin XOR Tier — the overlay must clear Model.
+	base := config.AgentDef{
+		Provider: "anthropic",
+		Model:    "claude-haiku-4-5",
+	}
+	def := json.RawMessage(`{"tier": "low"}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.Tier != "low" {
+		t.Errorf("tier = %q, want low", got.Tier)
+	}
+	if got.Model != "" {
+		t.Errorf("model should clear when tier set; got %q", got.Model)
+	}
+}
+
+func TestApplyAgentDefOverlay_BothModelAndTier_PrefersModel(t *testing.T) {
+	// Defensive: a row that somehow carries both model AND tier (which
+	// AgentDef.create rejects) must collapse to one choice rather than
+	// passing the invariant violation through to the resolver. Prefer
+	// the more specific intent (Model wins, Tier cleared).
+	base := config.AgentDef{Provider: "anthropic"}
+	def := json.RawMessage(`{"model": "claude-haiku-4-5", "tier": "low"}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.Model != "claude-haiku-4-5" {
+		t.Errorf("model = %q, want claude-haiku-4-5", got.Model)
+	}
+	if got.Tier != "" {
+		t.Errorf("tier should clear when model also set; got %q", got.Tier)
+	}
+}
+
+func TestApplyAgentDefOverlay_ModelOverridesStaticTier(t *testing.T) {
+	// Mirror: static was tier-driven; fork pins a specific model.
+	base := config.AgentDef{
+		Provider: "anthropic",
+		Tier:     "low",
+	}
+	def := json.RawMessage(`{"model": "claude-haiku-4-5"}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.Model != "claude-haiku-4-5" {
+		t.Errorf("model = %q, want claude-haiku-4-5", got.Model)
+	}
+	if got.Tier != "" {
+		t.Errorf("tier should clear when model pinned; got %q", got.Tier)
+	}
+}
+
+func TestApplyAgentDefOverlay_MaxTokens(t *testing.T) {
+	base := config.AgentDef{MaxTokens: 8192}
+	def := json.RawMessage(`{"max_tokens": 24576}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.MaxTokens != 24576 {
+		t.Errorf("max_tokens = %d, want 24576", got.MaxTokens)
+	}
+	// Zero max_tokens in overlay must NOT zero the base — zero means
+	// "absent" in the overlay protocol, not "explicit zero".
+	got = applyAgentDefOverlay(base, json.RawMessage(`{"max_tokens": 0}`))
+	if got.MaxTokens != 8192 {
+		t.Errorf("absent max_tokens should keep base; got %d", got.MaxTokens)
+	}
+}
+
+func TestApplyAgentDefOverlay_MalformedJSONReturnsBase(t *testing.T) {
+	base := config.AgentDef{Model: "claude-haiku-4-5"}
+	got := applyAgentDefOverlay(base, json.RawMessage(`{not json`))
+	if got.Model != "claude-haiku-4-5" {
+		t.Errorf("malformed JSON should fall back to base; got %+v", got)
+	}
+}
+
+func TestApplyAgentDefOverlay_SubstratePolicyFieldsNotMerged(t *testing.T) {
+	// agent_def_scopes / evaluation_scopes live on the static yaml
+	// only. A row's Definition JSON may contain other keys, but the
+	// overlay must not import them — those are the operator's
+	// substrate-capability gate and not subject to fork-time mutation.
+	base := config.AgentDef{
+		AgentDefScopes:   []string{"any"},
+		EvaluationScopes: []string{"submit_self", "read_any"},
+	}
+	def := json.RawMessage(`{
+		"agent_def_scopes": ["fork_self"],
+		"evaluation_scopes": ["submit_any"]
+	}`)
+	got := applyAgentDefOverlay(base, def)
+	if !reflect.DeepEqual(got.AgentDefScopes, []string{"any"}) {
+		t.Errorf("AgentDefScopes drifted: %v", got.AgentDefScopes)
+	}
+	if !reflect.DeepEqual(got.EvaluationScopes, []string{"submit_self", "read_any"}) {
+		t.Errorf("EvaluationScopes drifted: %v", got.EvaluationScopes)
+	}
+}
+
+func TestApplyAgentDefOverlay_NilSlicesKeepBase(t *testing.T) {
+	// Absent slice keys in JSON decode to nil, which the overlay must
+	// treat as "keep base", not "zero out base".
+	base := config.AgentDef{
+		AllowedTools: []string{"Read", "Write"},
+		Skills:       []string{"position-relevance"},
+	}
+	def := json.RawMessage(`{"system_prompt": "new prompt"}`)
+	got := applyAgentDefOverlay(base, def)
+	if !reflect.DeepEqual(got.AllowedTools, base.AllowedTools) {
+		t.Errorf("AllowedTools drifted on partial overlay: %v", got.AllowedTools)
+	}
+	if !reflect.DeepEqual(got.Skills, base.Skills) {
+		t.Errorf("Skills drifted on partial overlay: %v", got.Skills)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -229,7 +229,17 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 	if !ok {
 		return "", "", "", fmt.Errorf("%w: %s", runner.ErrUnknownAgent, agentName)
 	}
+	return s.resolveAgentDef(def, agentName, userTier)
+}
 
+// resolveAgentDef mirrors resolveAgent but takes a caller-supplied
+// AgentDef instead of looking it up in cfg.Agents. Used by the
+// v0.8.5 sub-agent path when an overlay has already produced an
+// effective def whose Provider/Model/Tier/Effort differ from the
+// static yaml. Without this, a forked sub-agent runs against the
+// static model — silently defeating the whole point of def_id
+// pinning.
+func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string) (providerID, model, effort string, err error) {
 	hasPin := def.Provider != "" || def.Model != ""
 	hasTier := def.Tier != ""
 
@@ -259,11 +269,12 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 		return dec.Provider, dec.Model, dec.Effort, nil
 	}
 
-	// Pin path (or fallback to defaults): use the v0.6.x logic.
+	// Pin path (or fallback to defaults): use the v0.6.x logic against
+	// the caller-supplied def, NOT the static cfg.Agents entry.
 	if !hasPin && s.cfg.Defaults.Model == "" {
 		return "", "", "", fmt.Errorf("%w: agent %q has no pin, no tier, and no defaults", runner.ErrInvalidArgument, agentName)
 	}
-	providerID, model, err = s.cfg.ResolveAgentModel(agentName)
+	providerID, model, err = s.cfg.ResolveAgentDefModel(agentName, def)
 	if err != nil {
 		return "", "", "", fmt.Errorf("%w: %v", runner.ErrInvalidArgument, err)
 	}
@@ -318,6 +329,99 @@ func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName st
 		tools.EvaluationPolicyValue{
 			Scopes: agentDef.EvaluationScopes,
 		}
+}
+
+// applyAgentDefOverlay overlays the v0.8.5 agent_defs.definition JSON
+// onto a static cfg.Agents entry, producing the effective AgentDef
+// for one sub-run. Mirrors the mutable-subset list maintained by the
+// AgentDef tool's `mergedDef`: provider, model, tier, effort,
+// max_tokens, system_prompt, allowed_tools, skills, providers, models,
+// memory_scopes, memory_quota_bytes. Substrate policy fields
+// (agent_def_scopes, evaluation_scopes) are NOT overlaid — they stay
+// with the static yaml so the operator's substrate-capability gate
+// can't be widened by a fork. AllowedTools narrowing is enforced at
+// AgentDef.create/fork time (the tool refuses widening); here we
+// simply trust the persisted row.
+//
+// Malformed JSON returns the base unchanged — the AgentDef tool's
+// schema ensures rows are well-formed, so this is defensive only.
+func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) config.AgentDef {
+	if len(definition) == 0 {
+		return base
+	}
+	// Decode into a partial AgentDef-shaped struct. Using
+	// config.AgentDef directly would pull substrate policy fields
+	// into the merge by accident; an inline anonymous struct keeps
+	// the overlay surface explicit.
+	var ov struct {
+		Provider         string                            `json:"provider,omitempty"`
+		Model            string                            `json:"model,omitempty"`
+		Tier             string                            `json:"tier,omitempty"`
+		Effort           string                            `json:"effort,omitempty"`
+		MaxTokens        int                               `json:"max_tokens,omitempty"`
+		SystemPrompt     string                            `json:"system_prompt,omitempty"`
+		AllowedTools     []string                          `json:"allowed_tools,omitempty"`
+		Skills           []string                          `json:"skills,omitempty"`
+		Providers        []string                          `json:"providers,omitempty"`
+		Models           map[string][]config.TierCandidate `json:"models,omitempty"`
+		MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
+		MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+	}
+	if err := json.Unmarshal(definition, &ov); err != nil {
+		log.Printf("agent_def overlay: malformed definition JSON, falling back to static: %v", err)
+		return base
+	}
+	out := base
+	if ov.Provider != "" {
+		out.Provider = ov.Provider
+	}
+	// Pin XOR Tier defensive resolution. AgentDef.create/fork rejects
+	// rows that set both, but a row written via direct SQL or migrated
+	// from a future schema variant could carry both. When both are set
+	// in the overlay, prefer Model (the more specific intent) and
+	// drop Tier — matches what the resolver does when given a pin.
+	switch {
+	case ov.Model != "" && ov.Tier != "":
+		out.Model = ov.Model
+		out.Tier = ""
+	case ov.Model != "":
+		out.Model = ov.Model
+		// Explicit model pin clears any static tier so the resolver
+		// takes the pin path, not the tier path.
+		out.Tier = ""
+	case ov.Tier != "":
+		out.Tier = ov.Tier
+		// Mirror image: explicit tier clears any static model pin.
+		out.Model = ""
+	}
+	if ov.Effort != "" {
+		out.Effort = ov.Effort
+	}
+	if ov.MaxTokens != 0 {
+		out.MaxTokens = ov.MaxTokens
+	}
+	if ov.SystemPrompt != "" {
+		out.SystemPrompt = ov.SystemPrompt
+	}
+	if ov.AllowedTools != nil {
+		out.AllowedTools = ov.AllowedTools
+	}
+	if ov.Skills != nil {
+		out.Skills = ov.Skills
+	}
+	if ov.Providers != nil {
+		out.Providers = ov.Providers
+	}
+	if ov.Models != nil {
+		out.Models = ov.Models
+	}
+	if ov.MemoryScopes != nil {
+		out.MemoryScopes = ov.MemoryScopes
+	}
+	if ov.MemoryQuotaBytes != 0 {
+		out.MemoryQuotaBytes = ov.MemoryQuotaBytes
+	}
+	return out
 }
 
 // channelPolicyForAgent builds the v0.8.4 Channel-tool policy from
@@ -1729,10 +1833,33 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 // Errors propagate as Go errors back to the Agent tool, which surfaces
 // them as IsError tool_results to the parent's model rather than
 // tearing down the parent run.
-func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (string, error) {
+func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, defID string) (string, error) {
 	def, ok := s.cfg.Agents[name]
 	if !ok {
 		return "", fmt.Errorf("unknown sub-agent %q (not in loomcycle.yaml agents map)", name)
+	}
+
+	// v0.8.5 substrate: when defID is set, overlay the named def's
+	// mutable fields (system_prompt, allowed_tools, model, tier,
+	// effort, max_tokens, memory_scopes, etc.) over the static
+	// cfg.Agents entry for this single sub-run. Name mismatch is a
+	// hard refuse — pinning across names would let a parent bypass
+	// the operator's static agent boundary.
+	if defID != "" {
+		if s.store == nil {
+			return "", fmt.Errorf("Agent tool: def_id pinning requires a configured store backend")
+		}
+		row, err := s.store.AgentDefGet(ctx, defID)
+		if err != nil {
+			return "", fmt.Errorf("Agent tool: def_id %q lookup failed: %w", defID, err)
+		}
+		if row.Name != name {
+			return "", fmt.Errorf("Agent tool: def_id %q is for agent %q, not %q (cross-name pinning refused)", defID, row.Name, name)
+		}
+		if row.Retired {
+			return "", fmt.Errorf("Agent tool: def_id %q is retired", defID)
+		}
+		def = applyAgentDefOverlay(def, row.Definition)
 	}
 
 	// v0.8.2: inherit parent's user_tier via ctx. The Agent built-in
@@ -1741,7 +1868,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 	// policy + fallback posture applied to the whole sub-run tree.
 	parentTier := tools.RunIdentity(ctx).UserTier
 
-	providerID, model, effort, err := s.resolveAgent(name, parentTier)
+	// Route through resolveAgentDef so an overlay's Model/Tier/Provider/
+	// Effort actually take effect. resolveAgent re-reads cfg.Agents and
+	// would silently discard the fork's values.
+	providerID, model, effort, err := s.resolveAgentDef(def, name, parentTier)
 	if err != nil {
 		return "", fmt.Errorf("resolve sub-agent %q model: %w", name, err)
 	}
@@ -1771,8 +1901,9 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string) (s
 		// works via parent_agent_id alone; ParentRunID is informational
 		// for transcript stitching and can be filled in by a future
 		// refactor that threads parent run.ID through ctx.
-		UserID:   parentIdentity.UserID,
-		UserTier: parentIdentity.UserTier, // v0.8.2: same user_tier across the sub-run tree
+		UserID:     parentIdentity.UserID,
+		UserTier:   parentIdentity.UserTier, // v0.8.2: same user_tier across the sub-run tree
+		AgentDefID: defID,                   // v0.8.5: pin defID on the sub-run for evaluation denormalisation
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "", parentIdentity.UserID, subIdentity)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1060,6 +1060,15 @@ func (c *Config) ResolveAgentModel(agent string) (provider string, model string,
 	if !ok {
 		return "", "", fmt.Errorf("unknown agent %q", agent)
 	}
+	return c.ResolveAgentDefModel(agent, def)
+}
+
+// ResolveAgentDefModel mirrors ResolveAgentModel but resolves against
+// a caller-supplied AgentDef instead of looking it up in c.Agents.
+// Used by the sub-agent path when an overlay has already produced an
+// effective def whose Provider/Model differ from the static yaml.
+// Same alias-expansion + defaults-fallback rules as ResolveAgentModel.
+func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider string, model string, err error) {
 	model = def.Model
 	provider = def.Provider
 

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -192,14 +192,15 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	if _, err := s.pool.Exec(ctx,
 		`INSERT INTO runs (
 			id, session_id, status, started_at,
-			agent_id, parent_agent_id, parent_run_id, user_id, user_tier
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+			agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
 		id, sessionID, string(store.RunRunning), now,
 		nullableText(identity.AgentID),
 		nullableText(identity.ParentAgentID),
 		nullableText(identity.ParentRunID),
 		nullableText(identity.UserID),
 		nullableText(identity.UserTier),
+		nullableText(identity.AgentDefID),
 	); err != nil {
 		return store.Run{}, fmt.Errorf("create run: %w", err)
 	}
@@ -213,6 +214,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		ParentRunID:   identity.ParentRunID,
 		UserID:        identity.UserID,
 		UserTier:      identity.UserTier,
+		AgentDefID:    identity.AgentDefID,
 	}, nil
 }
 
@@ -313,6 +315,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+		        r.agent_def_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
@@ -337,6 +340,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+		        r.agent_def_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.id = $1`, runID,
@@ -399,6 +403,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+			        r.agent_def_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1
@@ -409,6 +414,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+			        r.agent_def_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1 AND r.status = $2
@@ -433,6 +439,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+		        r.agent_def_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.parent_agent_id = $1
@@ -1544,6 +1551,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		errMsg     *string
 
 		agentID, parentAgentID, parentRunID, userID, userTier *string
+		agentDefID                                            *string
 		lastHeartbeatAt                                       *time.Time
 		sessAgent                                             *string
 
@@ -1555,6 +1563,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&model, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
+		&agentDefID,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -1590,6 +1599,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	if userTier != nil {
 		out.UserTier = *userTier
+	}
+	if agentDefID != nil {
+		out.AgentDefID = *agentDefID
 	}
 	if sessAgent != nil {
 		out.Agent = *sessAgent

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -312,14 +312,15 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	id := newID("r_")
 	now := time.Now()
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
 		nilIfEmpty(identity.ParentRunID),
 		nilIfEmpty(identity.UserID),
 		nilIfEmpty(identity.UserTier),
+		nilIfEmpty(identity.AgentDefID),
 	)
 	if err != nil {
 		return store.Run{}, err
@@ -334,6 +335,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		ParentRunID:   identity.ParentRunID,
 		UserID:        identity.UserID,
 		UserTier:      identity.UserTier,
+		AgentDefID:    identity.AgentDefID,
 	}, nil
 }
 
@@ -423,6 +425,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var lastHbNs sql.NullInt64
 	var stopReason, model, errMsg sql.NullString
 	var agentID, parentAgentID, parentRunID, userID, userTier sql.NullString
+	var agentDefID sql.NullString
 	var sessAgent sql.NullString
 	var status string
 	if err := scanner.Scan(
@@ -432,6 +435,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&model, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
+		&agentDefID,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -470,6 +474,9 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	if userTier.Valid {
 		r.UserTier = userTier.String
 	}
+	if agentDefID.Valid {
+		r.AgentDefID = agentDefID.String
+	}
 	if sessAgent.Valid {
 		r.Agent = sessAgent.String
 	}
@@ -490,6 +497,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.model, r.error,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
+		r.agent_def_id,
 		s.agent`
 
 // runFromTable is the canonical FROM clause paired with runColumns.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -123,6 +123,14 @@ type Run struct {
 	// define a user_tiers block at all. Lets compliance / cost
 	// retrospective queries facet by tier without grepping logs.
 	UserTier string `json:"user_tier,omitempty"`
+
+	// AgentDefID is the v0.8.5 substrate audit column — populated
+	// when the parent's Agent tool call pinned a specific def_id, or
+	// when an admin path resolves through agent_def_active. Empty =
+	// the run resolved through static cfg.Agents only. The
+	// Evaluation tool's submit op reads this to denormalise def_id
+	// onto each evaluation row at write time.
+	AgentDefID string `json:"agent_def_id,omitempty"`
 }
 
 // Event is one streamed datum, persisted append-only. Payload is the JSON
@@ -172,6 +180,12 @@ type RunIdentity struct {
 	// creation. Empty when the request didn't carry user_tier (back-
 	// compat) or the operator's yaml has no user_tiers block.
 	UserTier string
+	// AgentDefID pins this run to a specific agent_defs row (v0.8.5).
+	// Empty = the run resolved through static cfg.Agents only; non-
+	// empty = parent called Agent tool with a def_id. Persisted as
+	// runs.agent_def_id so the Evaluation tool can denormalise it
+	// into evaluations.def_id at submit time.
+	AgentDefID string
 }
 
 // UserSummary is one row of ListUsers' output: distinct user_id with

--- a/internal/tools/builtin/agent.go
+++ b/internal/tools/builtin/agent.go
@@ -20,11 +20,18 @@ import (
 //     parent's tool set does NOT widen the child's. Parent and child are
 //     both operator-vetted definitions, so each agent's declared
 //     allow-list is authoritative for itself.
+//   - When defID is non-empty, resolve the sub-agent against the
+//     agent_defs row at that id (v0.8.5 substrate). The row's Name MUST
+//     match the requested name — cross-name pinning is refused. The
+//     def's mutable fields (system_prompt, allowed_tools, model, tier,
+//     etc.) override the static cfg.Agents entry for this sub-run. The
+//     pinned defID is also persisted on the sub-run row so evaluations
+//     denormalise correctly.
 //   - Persist the sub-agent's run as a separate session in the Store so
 //     transcripts are replayable independently of the parent.
 //   - Carry the parent's context.Context (so cancellation, deadlines,
 //     and the loomcycle agent-depth value all propagate).
-type SubAgentRunner func(ctx context.Context, name string, prompt string) (output string, err error)
+type SubAgentRunner func(ctx context.Context, name string, prompt string, defID string) (output string, err error)
 
 // MaxAgentDepth caps recursion: a top-level run is depth 0, the agents
 // it spawns are depth 1, etc. The cap is a safety rail against runaway
@@ -84,17 +91,24 @@ type AgentTool struct {
 type agentInput struct {
 	Name   string `json:"name"`
 	Prompt string `json:"prompt"`
+	// DefID is optional (v0.8.5). When set, the sub-agent runs against
+	// this specific agent_defs row instead of the currently-active
+	// pointer / static cfg.Agents fallback. The row's name must match
+	// `Name` — cross-name def pinning is refused. Empty = standard
+	// active-or-static resolution.
+	DefID string `json:"def_id,omitempty"`
 }
 
-// agentInputSchema is the JSON Schema the model sees. Both fields are
-// required; nothing else is permitted (unknown fields are tolerated by
-// json.Unmarshal but will be ignored, so this is documentation more
-// than enforcement).
+// agentInputSchema is the JSON Schema the model sees. name + prompt are
+// required; def_id is optional. additionalProperties:false enforces the
+// exact shape (operator-vetted parents can't accidentally smuggle in
+// undocumented fields).
 const agentInputSchema = `{
   "type": "object",
   "properties": {
     "name":   {"type": "string", "description": "Sub-agent name. Must match a key in the loomcycle.yaml agents map."},
-    "prompt": {"type": "string", "description": "User-message body the sub-agent sees. Treat this as the task description; do not include auth tokens (the sub-agent gets its own auth context)."}
+    "prompt": {"type": "string", "description": "User-message body the sub-agent sees. Treat this as the task description; do not include auth tokens (the sub-agent gets its own auth context)."},
+    "def_id": {"type": "string", "description": "Optional. Pin this sub-run to a specific agent_defs row id (returned by AgentDef.create or AgentDef.fork). The row's name must match the 'name' field. Empty = use the currently-active version (or static cfg.Agents)."}
   },
   "required": ["name", "prompt"],
   "additionalProperties": false
@@ -149,7 +163,7 @@ func (a *AgentTool) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	}
 	subCtx := IncrementAgentDepth(ctx)
 
-	output, err := a.Run(subCtx, in.Name, in.Prompt)
+	output, err := a.Run(subCtx, in.Name, in.Prompt, in.DefID)
 	if err != nil {
 		// Surface as an error tool_result. The parent can decide whether
 		// to retry, fall back, or give up. We don't tear down the parent

--- a/internal/tools/builtin/agent_test.go
+++ b/internal/tools/builtin/agent_test.go
@@ -12,7 +12,7 @@ import (
 // returned text is wrapped in a successful Result.
 func TestAgentTool_HappyPath(t *testing.T) {
 	var gotName, gotPrompt string
-	a := &AgentTool{Run: func(_ context.Context, name, prompt string) (string, error) {
+	a := &AgentTool{Run: func(_ context.Context, name, prompt, _ string) (string, error) {
 		gotName, gotPrompt = name, prompt
 		return "sub-agent output", nil
 	}}
@@ -36,7 +36,7 @@ func TestAgentTool_HappyPath(t *testing.T) {
 // Missing required fields surface as IsError tool_results so the model
 // can self-correct, NOT as Go errors that tear down the run.
 func TestAgentTool_MissingName(t *testing.T) {
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		t.Fatal("runner should not be called when name is missing")
 		return "", nil
 	}}
@@ -53,7 +53,7 @@ func TestAgentTool_MissingName(t *testing.T) {
 }
 
 func TestAgentTool_MissingPrompt(t *testing.T) {
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		t.Fatal("runner should not be called when prompt is missing")
 		return "", nil
 	}}
@@ -68,7 +68,7 @@ func TestAgentTool_MissingPrompt(t *testing.T) {
 // from the runner instead of a clean "missing field" response.
 func TestAgentTool_WhitespaceNameRejected(t *testing.T) {
 	called := false
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		called = true
 		return "", nil
 	}}
@@ -84,7 +84,7 @@ func TestAgentTool_WhitespaceNameRejected(t *testing.T) {
 // Malformed JSON input is also a model-correctable error, not a hard
 // crash. The model gets feedback "invalid input JSON" and can retry.
 func TestAgentTool_MalformedJSON(t *testing.T) {
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		t.Fatal("runner should not be called on malformed JSON")
 		return "", nil
 	}}
@@ -101,7 +101,7 @@ func TestAgentTool_MalformedJSON(t *testing.T) {
 // parent run continues so the model can decide how to recover (try a
 // different sub-agent, fall back, give up gracefully).
 func TestAgentTool_RunnerError(t *testing.T) {
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		return "", errors.New("provider returned 500")
 	}}
 	res, err := a.Execute(context.Background(),
@@ -121,7 +121,7 @@ func TestAgentTool_RunnerError(t *testing.T) {
 // only tool calls, then stopped). Surface a hint so the parent's
 // model has something concrete to read instead of empty Text.
 func TestAgentTool_EmptyOutputHint(t *testing.T) {
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		return "", nil
 	}}
 	res, _ := a.Execute(context.Background(),
@@ -139,7 +139,7 @@ func TestAgentTool_EmptyOutputHint(t *testing.T) {
 // the runner gets called instead of the IsError path.
 func TestAgentTool_MaxDepthGuard(t *testing.T) {
 	called := false
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		called = true
 		return "should not run", nil
 	}}
@@ -161,7 +161,7 @@ func TestAgentTool_MaxDepthGuard(t *testing.T) {
 // boundary by one.
 func TestAgentTool_DepthBelowCapAllowed(t *testing.T) {
 	called := false
-	a := &AgentTool{Run: func(context.Context, string, string) (string, error) {
+	a := &AgentTool{Run: func(context.Context, string, string, string) (string, error) {
 		called = true
 		return "ok", nil
 	}}
@@ -204,5 +204,42 @@ func TestAgentTool_NilRunner(t *testing.T) {
 		json.RawMessage(`{"name":"x","prompt":"y"}`))
 	if !res.IsError || !strings.Contains(res.Text, "not wired") {
 		t.Errorf("expected nil-runner IsError, got %+v", res)
+	}
+}
+
+// v0.8.5 PR 5: optional def_id pins this sub-run to a specific
+// agent_defs row. Test only that the tool propagates the field
+// through to the runner — actual lookup + overlay is wired in the
+// HTTP server's runSubAgent and tested at that layer.
+func TestAgentTool_DefIDPassthrough(t *testing.T) {
+	var gotDef string
+	a := &AgentTool{Run: func(_ context.Context, _, _, defID string) (string, error) {
+		gotDef = defID
+		return "ok", nil
+	}}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y","def_id":"def_abc"}`))
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Text)
+	}
+	if gotDef != "def_abc" {
+		t.Errorf("def_id passthrough lost: %q", gotDef)
+	}
+}
+
+// Backwards-compat: omitting def_id leaves it empty (zero-value).
+func TestAgentTool_DefIDOmittedDefaultsEmpty(t *testing.T) {
+	var gotDef string
+	a := &AgentTool{Run: func(_ context.Context, _, _, defID string) (string, error) {
+		gotDef = defID
+		return "ok", nil
+	}}
+	res, _ := a.Execute(context.Background(),
+		json.RawMessage(`{"name":"x","prompt":"y"}`))
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Text)
+	}
+	if gotDef != "" {
+		t.Errorf("def_id should default empty, got %q", gotDef)
 	}
 }

--- a/internal/tools/builtin/evaluation.go
+++ b/internal/tools/builtin/evaluation.go
@@ -189,7 +189,7 @@ func (e *Evaluation) execSubmit(ctx context.Context, policy tools.EvaluationPoli
 	row := store.EvaluationRow{
 		EvalID:         mintEvalID(),
 		RunID:          in.RunID,
-		DefID:          "", // denormalised from target run; populated below if available
+		DefID:          target.AgentDefID, // denormalised from target run (v0.8.5 PR 5)
 		Score:          *in.Score,
 		Dimensions:     in.Dimensions,
 		Judgement:      in.Judgement,
@@ -197,12 +197,6 @@ func (e *Evaluation) execSubmit(ctx context.Context, policy tools.EvaluationPoli
 		EmitterRole:    role,
 		EmitterAgentID: emitter.AgentID,
 	}
-	// Capture target run's agent_def_id when present so def_id-keyed
-	// aggregates work. PR 5 wires runs.agent_def_id population; for
-	// PR 4 the column may be empty, which is fine — aggregates on
-	// def_id just won't find these rows.
-	// (The Run struct doesn't currently expose agent_def_id;
-	// future PR can plumb it. For now leave empty.)
 
 	saved, err := e.Store.EvaluationSubmit(ctx, row)
 	if err != nil {


### PR DESCRIPTION
## Why this exists

PR #69 was approved and merged — but its base was \`feature-substrate-pr4-evaluation-tool\`, and that branch was already absorbed into main via PR #68's merge before PR #69 landed. The merge therefore went into a now-orphan feature branch, **not** into main. This PR forward-ports that content as a fresh commit on top of main so v0.8.5 can be tagged with the full substrate.

This is a pure cherry-pick of \`eeef348\` (the PR #69 squash-merge commit) onto current main — no new code, just relocation.

## Content (unchanged from PR #69)

- \`Agent\` tool input gains optional \`def_id\` field (\`additionalProperties:false\` stays); cross-name pinning + retired-row pinning refused at the runtime.
- \`runSubAgent\` overlays the row's \`Definition\` JSON onto the static \`cfg.Agents\` entry via \`applyAgentDefOverlay\`, with substrate-policy fields (\`agent_def_scopes\`, \`evaluation_scopes\`) deliberately NOT in the merge surface so a fork can't widen its own substrate gate. Pin XOR Tier invariant preserved.
- \`runSubAgent\` resolves through \`resolveAgentDef\` (introduced in PR #69's review-fix commit) so the overlay's Model/Tier/Provider/Effort actually take effect; previously \`resolveAgent\` re-read \`cfg.Agents\` and silently discarded those fields.
- \`store.RunIdentity.AgentDefID\` + \`store.Run.AgentDefID\` plumbed through both adapters' CreateRun + scanRun + every SELECT column list.
- \`Evaluation.submit\` now denormalises \`target.AgentDefID\` into \`EvaluationRow.DefID\` at write time (resolves PR-4's TODO).
- 8 unit tests in \`agent_def_overlay_test.go\` pin the overlay semantics + 2 new \`Agent\` tool tests for the \`def_id\` pass-through.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (sqlite + postgres + tools + http)
- [x] Cherry-pick applied without conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)