### PR TITLE
feat(channels): v0.8.6 PR 3 — heartbeat ticker + standard yaml

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -419,11 +419,49 @@ func main() {
 	// PR 3. Wires the same Bus + Scheduler as the agent tool so
 	// long-poll subscribers wake whether the publish came from an
 	// agent, an internal goroutine, or the admin endpoint.
-	srv.SetSystemPublisher(&channels.StorePublisher{
+	sysPublisher := &channels.StorePublisher{
 		Store:     storeIface,
 		Bus:       channelBus,
 		Scheduler: channelScheduler,
-	})
+	}
+	srv.SetSystemPublisher(sysPublisher)
+
+	// v0.8.6 heartbeat runner — one goroutine per `_system/heartbeat-*`
+	// (or any other `publisher: system` + `period:` channel) declared
+	// in operator yaml. Stops on the same context cancellation that
+	// drains the HTTP server below. Skip-on-pause semantics: when
+	// v0.8.9 pause lands, the heartbeat goroutines pause naturally
+	// because their context is the same shutdown context the rest of
+	// the system uses.
+	heartbeatChannels := make(map[string]struct {
+		Period      string
+		Publisher   string
+		DefaultTTL  int
+		MaxMessages int
+	}, len(cfg.Channels))
+	for name, ch := range cfg.Channels {
+		heartbeatChannels[name] = struct {
+			Period      string
+			Publisher   string
+			DefaultTTL  int
+			MaxMessages int
+		}{
+			Period:      ch.Period,
+			Publisher:   ch.Publisher,
+			DefaultTTL:  ch.DefaultTTL,
+			MaxMessages: ch.MaxMessages,
+		}
+	}
+	heartbeatSpecs, err := channels.LoadHeartbeatSpecs(heartbeatChannels)
+	if err != nil {
+		log.Fatalf("heartbeat specs: %v", err)
+	}
+	var heartbeatRunner *channels.HeartbeatRunner
+	if len(heartbeatSpecs) > 0 {
+		heartbeatRunner = channels.NewHeartbeatRunner(sysPublisher, buildCommit, heartbeatSpecs)
+		log.Printf("system channels: starting %d heartbeat goroutine(s)", len(heartbeatSpecs))
+		heartbeatRunner.Start(context.Background())
+	}
 
 	// Build the model-resolution matrix (resolve.Resolver). Providers
 	// without API keys are MARKED EXCLUDED so Snapshot() shows the
@@ -573,6 +611,9 @@ func main() {
 	<-sig
 	log.Println("shutting down…")
 	bgCancel() // tear down sweeper + GC goroutines first
+	if heartbeatRunner != nil {
+		heartbeatRunner.Stop()
+	}
 	if grpcSrv != nil {
 		grpcSrv.GracefulStop()
 	}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -428,11 +428,12 @@ func main() {
 
 	// v0.8.6 heartbeat runner — one goroutine per `_system/heartbeat-*`
 	// (or any other `publisher: system` + `period:` channel) declared
-	// in operator yaml. Stops on the same context cancellation that
-	// drains the HTTP server below. Skip-on-pause semantics: when
-	// v0.8.9 pause lands, the heartbeat goroutines pause naturally
-	// because their context is the same shutdown context the rest of
-	// the system uses.
+	// in operator yaml. Construction happens here; Start is deferred
+	// to AFTER bgCtx is created below so the runner observes the same
+	// shared shutdown context as the sweepers + session-lock GC.
+	// That way bgCancel() on SIGTERM tears the heartbeat goroutines
+	// down naturally, and any future v0.8.9 pause path that cancels
+	// bgCtx pauses heartbeats without a separate hook.
 	heartbeatChannels := make(map[string]struct {
 		Period      string
 		Publisher   string
@@ -459,8 +460,6 @@ func main() {
 	var heartbeatRunner *channels.HeartbeatRunner
 	if len(heartbeatSpecs) > 0 {
 		heartbeatRunner = channels.NewHeartbeatRunner(sysPublisher, buildCommit, heartbeatSpecs)
-		log.Printf("system channels: starting %d heartbeat goroutine(s)", len(heartbeatSpecs))
-		heartbeatRunner.Start(context.Background())
 	}
 
 	// Build the model-resolution matrix (resolve.Resolver). Providers
@@ -491,6 +490,14 @@ func main() {
 	// to do so in their packages.
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 	defer bgCancel()
+
+	// v0.8.6 heartbeat runner — start AFTER bgCtx is available so
+	// bgCancel() on SIGTERM (or a future pause hook) cancels the
+	// heartbeat goroutines naturally.
+	if heartbeatRunner != nil {
+		log.Printf("system channels: starting %d heartbeat goroutine(s)", len(heartbeatSpecs))
+		heartbeatRunner.Start(bgCtx)
+	}
 
 	if cfg.Env.HeartbeatSweeperEnabled && storeIface != nil {
 		sweeper := heartbeat.New(storeIface, heartbeat.Config{

--- a/internal/channels/heartbeat.go
+++ b/internal/channels/heartbeat.go
@@ -1,0 +1,174 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// HeartbeatSpec declares one cadence channel for the runner. Name is
+// the channel as declared in operator yaml (must start with `_system/`
+// for the prefix-reserved convention); Period is the parsed time.Duration
+// from yaml; DefaultTTL is the per-message TTL in seconds (0 = no TTL,
+// messages live until max_messages trims them).
+type HeartbeatSpec struct {
+	Name        string
+	Period      time.Duration
+	DefaultTTL  int
+	MaxMessages int
+}
+
+// HeartbeatPayload is the fixed minimal shape every heartbeat carries.
+// Consumers can rely on these three fields; future additive fields are
+// allowed but existing keys won't change.
+type HeartbeatPayload struct {
+	Timestamp string `json:"ts"`        // RFC3339Nano
+	Version   string `json:"version"`   // buildCommit / "unknown"
+	UptimeSec int64  `json:"uptime_s"`  // process uptime
+}
+
+// HeartbeatRunner manages one goroutine per declared `_system/*`
+// cadence channel. It publishes a fixed-shape payload at each tick
+// via the SystemPublisher; messages land with
+// `published_by_user_id = "_system"`.
+//
+// Stopping: call Stop() to cancel all tickers + drain. Safe to call
+// once; subsequent calls are no-ops.
+type HeartbeatRunner struct {
+	publisher SystemPublisher
+	specs     []HeartbeatSpec
+	version   string
+	startedAt time.Time
+
+	cancel  context.CancelFunc
+	stopped sync.Once
+	wg      sync.WaitGroup
+}
+
+// NewHeartbeatRunner constructs the runner. version is typically the
+// build commit (read from main's `buildCommit` ldflags var); empty
+// is fine and falls through to "unknown" in the published payload.
+func NewHeartbeatRunner(publisher SystemPublisher, version string, specs []HeartbeatSpec) *HeartbeatRunner {
+	if version == "" {
+		version = "unknown"
+	}
+	return &HeartbeatRunner{
+		publisher: publisher,
+		specs:     specs,
+		version:   version,
+		startedAt: time.Now(),
+	}
+}
+
+// Start launches one goroutine per spec. Returns immediately;
+// goroutines run until Stop() is called or the parent context is
+// cancelled. Each goroutine publishes the first tick AFTER one period
+// — no immediate-publish-on-start, to avoid an artificial flurry on
+// every restart.
+func (h *HeartbeatRunner) Start(parent context.Context) {
+	if len(h.specs) == 0 {
+		return
+	}
+	ctx, cancel := context.WithCancel(parent)
+	h.cancel = cancel
+	for _, spec := range h.specs {
+		if spec.Period <= 0 {
+			log.Printf("heartbeat: skip %q (non-positive period)", spec.Name)
+			continue
+		}
+		h.wg.Add(1)
+		go h.run(ctx, spec)
+	}
+}
+
+// Stop cancels all heartbeat goroutines + waits for them to drain.
+// Idempotent — safe to call multiple times.
+func (h *HeartbeatRunner) Stop() {
+	h.stopped.Do(func() {
+		if h.cancel != nil {
+			h.cancel()
+		}
+		h.wg.Wait()
+	})
+}
+
+// run is one heartbeat goroutine. Publishes at Period intervals;
+// terminates on ctx.Done. Skip-on-pause semantics: if the parent
+// context blocks Publish (e.g. v0.8.9 pause holds the system loop),
+// we just skip that tick — heartbeats represent "now," not historical
+// "then." Errors are logged + the loop continues.
+func (h *HeartbeatRunner) run(ctx context.Context, spec HeartbeatSpec) {
+	defer h.wg.Done()
+	t := time.NewTicker(spec.Period)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			payload := HeartbeatPayload{
+				Timestamp: now.UTC().Format(time.RFC3339Nano),
+				Version:   h.version,
+				UptimeSec: int64(now.Sub(h.startedAt).Seconds()),
+			}
+			body, err := json.Marshal(payload)
+			if err != nil {
+				log.Printf("heartbeat %s: marshal: %v", spec.Name, err)
+				continue
+			}
+			if _, err := h.publisher.PublishNow(ctx, spec.Name, store.MemoryScopeGlobal, "",
+				body, SystemPublisherUserID, spec.MaxMessages, spec.DefaultTTL); err != nil {
+				// ctx-cancel during publish = clean shutdown; don't
+				// noisy-log.
+				if ctx.Err() != nil {
+					return
+				}
+				log.Printf("heartbeat %s: publish: %v", spec.Name, err)
+			}
+		}
+	}
+}
+
+// LoadHeartbeatSpecs walks the operator-declared channels block and
+// returns one HeartbeatSpec per `publisher: system` + non-zero Period
+// channel. Event-driven system channels (no Period) are returned in
+// the caller's iteration order via a separate path; this helper
+// covers cadence channels only.
+//
+// Returns (specs, error) where error is non-nil for any malformed
+// duration string — the validation layer should have caught these,
+// but the helper double-checks rather than panicking.
+//
+// The cfg argument is the v0.8.6 Channel struct shape via a callback
+// to avoid importing the config package (preserves channels → config
+// dep direction).
+func LoadHeartbeatSpecs(channels map[string]struct {
+	Period      string
+	Publisher   string
+	DefaultTTL  int
+	MaxMessages int
+}) ([]HeartbeatSpec, error) {
+	var specs []HeartbeatSpec
+	for name, ch := range channels {
+		if ch.Publisher != "system" || ch.Period == "" {
+			continue
+		}
+		d, err := time.ParseDuration(ch.Period)
+		if err != nil {
+			return nil, fmt.Errorf("channel %q: parse period %q: %w", name, ch.Period, err)
+		}
+		specs = append(specs, HeartbeatSpec{
+			Name:        name,
+			Period:      d,
+			DefaultTTL:  ch.DefaultTTL,
+			MaxMessages: ch.MaxMessages,
+		})
+	}
+	return specs, nil
+}

--- a/internal/channels/heartbeat_test.go
+++ b/internal/channels/heartbeat_test.go
@@ -1,0 +1,125 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// Heartbeat runner emits the expected count of messages with the
+// fixed-shape payload over a short observation window.
+func TestHeartbeatRunner_EmitsAtCadence(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer s.Close()
+
+	pub := &StorePublisher{Store: s, Bus: NewBus()}
+	specs := []HeartbeatSpec{{
+		Name:       "_system/heartbeat-test",
+		Period:     100 * time.Millisecond,
+		DefaultTTL: 60,
+	}}
+	runner := NewHeartbeatRunner(pub, "v0.8.6-test", specs)
+	runner.Start(context.Background())
+	// 350ms = 3 expected ticks at 100ms (with some scheduler slack).
+	time.Sleep(350 * time.Millisecond)
+	runner.Stop()
+
+	msgs, _, err := s.ChannelSubscribe(context.Background(),
+		"_system/heartbeat-test", store.MemoryScopeGlobal, "", "cur_0", 100)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	if len(msgs) < 2 || len(msgs) > 5 {
+		t.Errorf("got %d heartbeats in 350ms at 100ms period, want 2..5", len(msgs))
+	}
+
+	// Verify payload shape on the first message.
+	var p HeartbeatPayload
+	if err := json.Unmarshal(msgs[0].Payload, &p); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if p.Version != "v0.8.6-test" {
+		t.Errorf("payload Version = %q, want v0.8.6-test", p.Version)
+	}
+	if p.Timestamp == "" {
+		t.Error("payload Timestamp empty")
+	}
+	if p.UptimeSec < 0 {
+		t.Errorf("payload UptimeSec = %d, want >= 0", p.UptimeSec)
+	}
+	if msgs[0].PublishedByUserID != SystemPublisherUserID {
+		t.Errorf("PublishedByUserID = %q, want %q", msgs[0].PublishedByUserID, SystemPublisherUserID)
+	}
+}
+
+// Stop is idempotent + drains all goroutines.
+func TestHeartbeatRunner_StopIdempotent(t *testing.T) {
+	s, _ := sqlite.Open(":memory:")
+	defer s.Close()
+	pub := &StorePublisher{Store: s}
+	runner := NewHeartbeatRunner(pub, "test", []HeartbeatSpec{
+		{Name: "_system/test", Period: 50 * time.Millisecond},
+	})
+	runner.Start(context.Background())
+	time.Sleep(60 * time.Millisecond)
+	runner.Stop()
+	runner.Stop() // should not panic / hang
+}
+
+// Empty specs is a no-op (no goroutines started, Stop returns immediately).
+func TestHeartbeatRunner_NoSpecsNoOp(t *testing.T) {
+	pub := &StorePublisher{}
+	runner := NewHeartbeatRunner(pub, "test", nil)
+	runner.Start(context.Background())
+	runner.Stop()
+}
+
+// LoadHeartbeatSpecs filters channels correctly: only those with
+// publisher: system AND non-empty period.
+func TestLoadHeartbeatSpecs_Filters(t *testing.T) {
+	specs, err := LoadHeartbeatSpecs(map[string]struct {
+		Period      string
+		Publisher   string
+		DefaultTTL  int
+		MaxMessages int
+	}{
+		"_system/heartbeat-1m":   {Period: "1m", Publisher: "system"},
+		"_system/heartbeat-5m":   {Period: "5m", Publisher: "system", DefaultTTL: 300},
+		"_system/runtime-state":  {Publisher: "system"}, // event-driven, no period — should be skipped
+		"_system/alarms/critical": {Publisher: ""},      // not system — should be skipped
+		"random/channel":         {Publisher: ""},
+	})
+	if err != nil {
+		t.Fatalf("LoadHeartbeatSpecs: %v", err)
+	}
+	if len(specs) != 2 {
+		t.Fatalf("got %d specs, want 2", len(specs))
+	}
+	for _, s := range specs {
+		if s.Name != "_system/heartbeat-1m" && s.Name != "_system/heartbeat-5m" {
+			t.Errorf("unexpected spec %q", s.Name)
+		}
+	}
+}
+
+// Malformed period returns an error.
+func TestLoadHeartbeatSpecs_BadPeriod(t *testing.T) {
+	_, err := LoadHeartbeatSpecs(map[string]struct {
+		Period      string
+		Publisher   string
+		DefaultTTL  int
+		MaxMessages int
+	}{
+		"_system/bad": {Period: "not-a-duration", Publisher: "system"},
+	})
+	if err == nil {
+		t.Fatal("expected error for malformed period")
+	}
+}

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -187,6 +187,37 @@ channels:
     max_messages: 1000
     semantic: broadcast
 
+  # ─── v0.8.6 System channels ────────────────────────────────────────
+  # `_system/*` prefix is reserved: only operator yaml may declare,
+  # only loomcycle's internal publisher + the admin endpoint may
+  # write (per the channel's `publisher` field). Agents may
+  # subscribe (with ACL) but never publish.
+  #
+  # Optional — uncomment the channels you want. Each one's purpose:
+  #   - heartbeat-* : cadence ticker, one message per period.
+  #                   Verifies liveness, drives dashboards.
+  #   - alarms/*    : agent or admin-endpoint publishes alert
+  #                   payloads. Severity by channel name.
+  #   - runtime-state: v0.8.9 pause/resume/restore state transitions
+  #                    (event-driven; no `period:` needed because the
+  #                    channel name is in eventDrivenSystemChannels).
+  #   - provider-events: provider fallback + cache-invalidated signals
+  #                      (v0.9.x observability sweep wires this).
+  #
+  # Cadence channels (publisher: system + period:):
+  # _system/heartbeat-1m:    { scope: global, semantic: broadcast, default_ttl: 60s,  publisher: system, period: 1m }
+  # _system/heartbeat-5m:    { scope: global, semantic: broadcast, default_ttl: 300s, publisher: system, period: 5m }
+  # _system/heartbeat-1h:    { scope: global, semantic: broadcast, default_ttl: 1h,   publisher: system, period: 1h }
+  #
+  # Alarm channels (agents publish; admin endpoint can also publish):
+  # _system/alarms/critical: { scope: global, semantic: broadcast, default_ttl: 24h, max_messages: 1000 }
+  # _system/alarms/warning:  { scope: global, semantic: broadcast, default_ttl: 6h,  max_messages: 5000 }
+  # _system/alarms/info:     { scope: global, semantic: queue,     default_ttl: 1h,  max_messages: 10000 }
+  #
+  # Event-driven channels (publisher: system without period):
+  # _system/runtime-state:   { scope: global, semantic: broadcast, default_ttl: 7d, publisher: system }
+  # _system/provider-events: { scope: global, semantic: broadcast, default_ttl: 24h, publisher: system }
+
 # ─── Default routing for agents that don't specify their own ──────────
 # Used by agents that declare neither `tier:` nor an explicit
 # `provider:`+`model:` pin. v0.6.x back-compat path; tier-based agents

--- a/test/runtime/README.md
+++ b/test/runtime/README.md
@@ -28,6 +28,7 @@ test/runtime/<feature>/
 | `user-tier/` | Runtime fallback within a tier's candidate list. Primary provider stalls (induced via a sentinel); resolver walks the tier's candidates, picks the next, completes the run. Validates `fallback_on_error` + the 3-attempt cumulative cap. |
 | `agent-def/` (v0.8.5) | Single-agent walkthrough of the six AgentDef ops: create → get → list → fork → promote → retire. Driver inspects `agent_defs` + `agent_def_active` rows to verify lifecycle, parent-chain wiring, retire flags, and active-pointer placement. |
 | `evaluation/` (v0.8.5) | Two-run scenario. Run 1 (`worker`) executes a trivial deterministic op; driver extracts its run_id from the SSE `agent` event. Run 2 (`evaluator`) submits + reads back an Evaluation against the worker's run_id (emitter_role=`unrelated`; `submit_any` scope path). Verifies the full submit/get/list/aggregate surface. |
+| `system-channels/` (v0.8.6) | Three exercises in one run: (A) `_system/heartbeat-1s` cadence — driver waits 3s and asserts ≥2 messages with the fixed `{ts, version, uptime_s}` payload + `_system` attribution. (B) Admin endpoint — `curl POST /v1/_channels/_system/alarms/info` lands a row with `published_by_user_id = _admin`. (C) Agent deferred publish — scheduler-bot publishes to `findings` with `deliver_at = now+30s`; driver verifies the `(visible_at - published_at)` delta is in the expected window + the tool_result envelope carries `visible_at`. |
 
 Future scenarios (one folder per primitive):
 

--- a/test/runtime/system-channels/agents/scheduler-bot.md
+++ b/test/runtime/system-channels/agents/scheduler-bot.md
@@ -1,0 +1,35 @@
+---
+name: scheduler-bot
+description: Channel-tool runtime test agent. Publishes to `findings` with optional deliver_at, then subscribes.
+provider: gemini
+model: gemini-2.5-flash
+allowed_tools: [Channel]
+channels:
+  publish: [findings]
+  subscribe: [findings]
+---
+You are scheduler-bot. The user message tells you exactly which
+Channel operation to execute. Three rules:
+
+1. Each operation in the user message maps to exactly one Channel
+   tool call. Don't invent operations.
+
+2. The tool returns JSON. For publish, capture `message_id` and
+   `visible_at` (when present). For subscribe, list the message
+   payloads you received.
+
+3. After ALL named operations, write a one-line summary that
+   includes:
+   - the message_id you published (if a publish op was named),
+   - the visible_at timestamp you got back (if a deferred publish),
+   - the number of messages subscribe returned.
+
+   End the summary with the single word DONE.
+
+Schema for Channel publish with deliver_at:
+
+```
+{"op":"publish","channel":"findings","value":{"k":"v"},"deliver_at":"2026-05-12T15:30:00Z"}
+```
+
+Don't use any tool other than Channel.

--- a/test/runtime/system-channels/loomcycle.yaml
+++ b/test/runtime/system-channels/loomcycle.yaml
@@ -1,0 +1,54 @@
+# test/runtime/system-channels/loomcycle.yaml — v0.8.6 system-channels runtime smoke test.
+#
+# Three exercise paths:
+#
+#   1. Heartbeat cadence: `_system/heartbeat-1s` ticks once per second.
+#      Driver waits 3s and asserts ~3 messages in the channel.
+#
+#   2. Admin endpoint: driver curls
+#      POST /v1/_channels/_system/alarms/info with a bearer.
+#      Asserts the message lands with published_by_user_id = "_admin".
+#
+#   3. Agent deferred publish: agent publishes to `findings` with
+#      deliver_at = now + 1s; immediate subscribe returns empty;
+#      after 1.2s subscribe returns the message.
+#
+# Provider: gemini (gemini-2.5-flash). Source .env.local for GEMINI_API_KEY.
+
+provider_priority: [gemini]
+
+defaults:
+  provider: gemini
+  model: gemini-2.5-flash
+
+storage:
+  backend: sqlite
+
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8
+
+# v0.8.6 — operator-declared system channels + a regular agent channel.
+channels:
+  # Cadence channel: heartbeats every 1s.
+  _system/heartbeat-1s:
+    scope: global
+    semantic: broadcast
+    default_ttl: 60
+    publisher: system
+    period: 1s
+
+  # Alarms channel: agents may publish AND admin endpoint may publish
+  # (no `publisher: system`, so the publisher field is "" = any allowed).
+  _system/alarms/info:
+    scope: global
+    semantic: queue
+    default_ttl: 3600
+    max_messages: 1000
+
+  # Regular agent channel for the deferred-publish exercise.
+  findings:
+    scope: user
+    semantic: queue
+    default_ttl: 3600
+    max_messages: 1000

--- a/test/runtime/system-channels/run.sh
+++ b/test/runtime/system-channels/run.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# test/runtime/system-channels/run.sh — v0.8.6 system-channels runtime smoke.
+#
+# Three exercises in one run:
+#
+#   [A] Heartbeat cadence — `_system/heartbeat-1s` ticks once/sec.
+#       After 3s of uptime, expect 2..4 messages in storage.
+#
+#   [B] Admin endpoint — curl publish to `_system/alarms/info`.
+#       Expect 200 + row with published_by_user_id="_admin".
+#
+#   [C] Agent deferred publish — scheduler-bot publishes to `findings`
+#       with deliver_at=now+2s. Immediate subscribe returns 0 messages;
+#       after 2.5s subscribe returns 1 message.
+#
+# Usage:
+#   GEMINI_API_KEY=... ./test/runtime/system-channels/run.sh
+# OR:
+#   set -a; source .env.local; set +a; ./test/runtime/system-channels/run.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-system-channels-test.XXXXXX)"
+trap 'cleanup' EXIT INT TERM
+
+cleanup() {
+  if [[ -n "${LOOMCYCLE_PID:-}" ]]; then
+    kill "$LOOMCYCLE_PID" 2>/dev/null || true
+    wait "$LOOMCYCLE_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "Test dir kept for inspection: $TEST_DIR"
+}
+
+export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
+export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18791"
+export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY not set. Source .env.local first:" >&2
+  echo "  set -a; source .env.local; set +a" >&2
+  exit 1
+fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required for SSE delta extraction." >&2
+  exit 1
+fi
+if ! command -v sqlite3 &>/dev/null; then
+  echo "ERROR: sqlite3 CLI is required for storage inspection." >&2
+  exit 1
+fi
+
+mkdir -p "$TEST_DIR/data"
+BOOT_LOG="$TEST_DIR/boot.log"
+USER_ID="test-user-systemch"
+
+# ─── 1. Build fresh binary ──────────────────────────────────────────
+echo "[1/7] Building bin/loomcycle..."
+go build -o bin/loomcycle ./cmd/loomcycle
+
+# ─── 2. Boot loomcycle in background ────────────────────────────────
+echo "[2/7] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR (config: $SCRIPT_DIR/loomcycle.yaml)..."
+./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
+LOOMCYCLE_PID=$!
+
+READY=0
+for i in $(seq 1 50); do
+  if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
+    echo "      ready after ~$((i * 200))ms"
+    READY=1
+    break
+  fi
+  if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
+    echo "ERROR: loomcycle exited during boot. Boot log:" >&2
+    cat "$BOOT_LOG" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+
+if [[ "$READY" != "1" ]]; then
+  echo "ERROR: loomcycle did not become ready within ~10 s. Boot log so far:" >&2
+  cat "$BOOT_LOG" >&2
+  exit 1
+fi
+
+echo "[3/7] Boot-log highlights:"
+grep -E "agents:|system channels:|heartbeat" "$BOOT_LOG" | sed 's/^/      /'
+echo
+
+# ─── 4. Exercise A: heartbeat cadence ───────────────────────────────
+# Heartbeat goroutine starts at boot — the cadence has been ticking
+# for boot-time + this wait. We measure rate (rows/s elapsed) rather
+# than absolute count to avoid coupling to boot duration.
+echo "[4/7] Exercise A — heartbeat cadence (waiting 3s for ~3 heartbeats)..."
+HEARTBEAT_START_TS=$(date +%s)
+sleep 3.2
+
+DB="$TEST_DIR/data/loomcycle.db"
+HEARTBEAT_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM channel_messages WHERE channel='_system/heartbeat-1s';" 2>/dev/null || echo "0")
+ELAPSED=$(($(date +%s) - HEARTBEAT_START_TS))
+echo "      heartbeat rows after $ELAPSED+ seconds runtime = $HEARTBEAT_COUNT (expect >=2)"
+
+# Verify one heartbeat payload's shape.
+SAMPLE=$(sqlite3 "$DB" "SELECT payload FROM channel_messages WHERE channel='_system/heartbeat-1s' LIMIT 1;" 2>/dev/null || echo "")
+echo "      sample payload: $SAMPLE"
+
+# ─── 5. Exercise B: admin endpoint publish ──────────────────────────
+echo
+echo "[5/7] Exercise B — admin endpoint publish to _system/alarms/info..."
+ADMIN_RESP=$(curl -sS -w "\nHTTP_CODE:%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"payload": {"severity": "info", "msg": "test alarm"}}' \
+  "http://$LOOMCYCLE_LISTEN_ADDR/v1/_channels/_system/alarms/info")
+echo "      admin response: $ADMIN_RESP"
+ADMIN_CODE=$(echo "$ADMIN_RESP" | grep HTTP_CODE: | sed 's/HTTP_CODE://')
+echo "      admin status: $ADMIN_CODE"
+
+ADMIN_ROW=$(sqlite3 "$DB" "SELECT published_by_user_id FROM channel_messages WHERE channel='_system/alarms/info' LIMIT 1;" 2>/dev/null || echo "")
+echo "      alarm row published_by_user_id: $ADMIN_ROW"
+
+# ─── 6. Exercise C: agent deferred publish ──────────────────────────
+# A 30-second deferral makes the visibility window observable
+# regardless of agent latency. We don't ask the agent to subscribe
+# back — direct sqlite + Store comparison is more reliable.
+echo
+echo "[6/7] Exercise C — agent deferred publish (deliver_at=now+30s)..."
+
+DELIVER_AT=$(python3 -c "
+import datetime, time
+t = datetime.datetime.utcfromtimestamp(time.time() + 30)
+print(t.strftime('%Y-%m-%dT%H:%M:%SZ'))
+")
+echo "      deliver_at = $DELIVER_AT"
+
+PROMPT="Publish exactly one message to channel \"findings\" with value {\"key\":\"deferred-test\"} and deliver_at=\"$DELIVER_AT\". Then write your one-line DONE summary including the message_id and visible_at."
+
+RUN1_SSE="$TEST_DIR/run1-publish.sse"
+curl -fsS -N \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF > "$RUN1_SSE"
+{
+  "agent": "scheduler-bot",
+  "user_id": "$USER_ID",
+  "segments": [
+    {"role": "user", "content": [{"type": "trusted-text", "text": $(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$PROMPT")}]}
+  ]
+}
+EOF
+
+# Inspect the row's visible_at vs published_at via sqlite. Both
+# stored as unix-nano INTEGER. If visible_at > published_at, the
+# deferred publish worked. We pull both for the verdict comparison.
+ROW=$(sqlite3 "$DB" "SELECT published_at, visible_at, published_by_user_id FROM channel_messages WHERE channel='findings' LIMIT 1;" 2>/dev/null)
+echo "      findings row (published_at|visible_at|user): $ROW"
+
+DEFERRED_ID=$(sqlite3 "$DB" "SELECT id FROM channel_messages WHERE channel='findings' LIMIT 1;" 2>/dev/null)
+
+# Compute visible_at - published_at in seconds. Should be ~30.
+DELTA_S=$(sqlite3 "$DB" "SELECT (visible_at - published_at) / 1000000000 FROM channel_messages WHERE channel='findings' LIMIT 1;" 2>/dev/null)
+echo "      visible_at - published_at = ${DELTA_S}s (expect ~30)"
+
+# Tool-response should have included visible_at in the JSON. The
+# tool_result wraps the inner JSON as a string, so we double-decode.
+TOOL_VISIBLE_AT=$(python3 -c "
+import json, re
+with open('$RUN1_SSE') as f:
+  for line in f:
+    if line.startswith('data: ') and '\"tool_result\"' in line:
+      try:
+        outer = json.loads(line[6:].strip())
+        inner = json.loads(outer.get('text', '{}'))
+        if 'visible_at' in inner:
+          print(inner['visible_at'])
+          break
+      except Exception:
+        continue
+")
+echo "      tool_result visible_at: $TOOL_VISIBLE_AT"
+
+# ─── 7. Storage inspection + verdict ────────────────────────────────
+echo
+echo "[7/7] Storage inspection ($DB):"
+echo "      channel_messages summary by channel:"
+sqlite3 -header -column "$DB" "SELECT channel, COUNT(*) AS n, MIN(published_by_user_id) AS sample_publisher FROM channel_messages GROUP BY channel;" | sed 's/^/        /'
+
+# ─── Verdict ───────────────────────────────────────────────────────
+echo
+echo "── Verdict ───────────────────────────────────────────────────────"
+PASS=true
+
+# A — heartbeats (lower bound only — boot adds variable head-time
+# to the count; what matters is that the ticker fired multiple times).
+if [[ "$HEARTBEAT_COUNT" -ge 2 ]]; then
+  echo "  [A] heartbeats >= 2                = $HEARTBEAT_COUNT ✓"
+else
+  echo "  [A] heartbeats >= 2                = $HEARTBEAT_COUNT ✗"; PASS=false
+fi
+
+# A — payload shape: must include "version" and "ts" and "uptime_s"
+if echo "$SAMPLE" | grep -q '"version"' && echo "$SAMPLE" | grep -q '"ts"' && echo "$SAMPLE" | grep -q '"uptime_s"'; then
+  echo "  [A] heartbeat payload has all keys = ✓"
+else
+  echo "  [A] heartbeat payload has all keys = ✗ ($SAMPLE)"; PASS=false
+fi
+
+# B — admin endpoint
+if [[ "$ADMIN_CODE" = "200" ]]; then
+  echo "  [B] admin POST status              = 200 ✓"
+else
+  echo "  [B] admin POST status              = $ADMIN_CODE ✗"; PASS=false
+fi
+if [[ "$ADMIN_ROW" = "_admin" ]]; then
+  echo "  [B] admin row published_by_user_id = _admin ✓"
+else
+  echo "  [B] admin row published_by_user_id = $ADMIN_ROW ✗"; PASS=false
+fi
+
+# C — deferred publish: visible_at must be in the future at publish
+# time. The deliver_at was 30s ahead of when the test script started
+# the agent run, but the agent took several seconds to actually
+# publish, so the realised delta is 30s minus agent latency.
+# Tolerate 15..32s (covers a busy provider taking 15s to respond).
+if [[ -n "$DELTA_S" ]] && [[ "$DELTA_S" -ge 15 ]] && [[ "$DELTA_S" -le 32 ]]; then
+  echo "  [C] visible_at - published_at      = ${DELTA_S}s ✓"
+else
+  echo "  [C] visible_at - published_at      = ${DELTA_S}s ✗ (expect 15..32)"; PASS=false
+fi
+if [[ -n "$TOOL_VISIBLE_AT" ]]; then
+  echo "  [C] tool_result has visible_at     = $TOOL_VISIBLE_AT ✓"
+else
+  echo "  [C] tool_result has visible_at     = (missing) ✗"; PASS=false
+fi
+
+if $PASS; then
+  echo "  PASS ✓"
+  exit 0
+else
+  echo "  FAIL ✗ — see $TEST_DIR for full logs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Third and final backend v0.8.6 PR. Adds:

- **\`HeartbeatRunner\`** (\`internal/channels/heartbeat.go\`) — one goroutine per \`_system/heartbeat-*\` channel; publishes \`{ts, version, uptime_s}\` at \`period:\` intervals.
- **\`LoadHeartbeatSpecs\`** filter helper — keeps the channels → config dep direction clean via a struct-callback.
- **main.go wiring** — boots the runner, drains it on SIGTERM.
- **\`loomcycle.example.yaml\`** documents the standard \`_system/*\` channel set.

## Stacking
- **Base:** \`feature-system-channels-pr2-system-publisher\` (PR #75)
- This completes the v0.8.6 backend trio. Downstream PRs (Question tool in v0.8.8, pause-state in v0.8.9) ride on top.

## Payload shape (fixed)

Every heartbeat message carries:
\`\`\`json
{
  \"ts\":        \"2026-05-12T15:30:00.123Z\",
  \"version\":   \"v0.8.6\",          // from buildCommit ldflags var
  \"uptime_s\":  3600
}
\`\`\`
Additive fields are allowed later; existing keys won't change.

## Wiring choices

- **First tick AFTER one period.** No immediate-publish-on-start — avoids an artificial flurry every time loomcycle restarts. \`time.NewTicker\` semantics; no special-case at boot.
- **Skip-on-pause by construction.** Each goroutine observes the shared shutdown context. When v0.8.9 pause lands, cancelling that context naturally pauses the goroutine; resumption is a fresh goroutine via Start. (RFC's \"heartbeats represent 'now', not historical 'then'\" — no backfill on resume.)
- **Errors logged + continued.** A transient publish failure (db timeout etc.) is logged but doesn't kill the goroutine. Clean ctx-cancel during publish drains silently.

## Standard yaml (\`loomcycle.example.yaml\`)

Commented out by default so operators uncomment what they want:

\`\`\`yaml
# Cadence channels:
# _system/heartbeat-1m: { scope: global, semantic: broadcast, default_ttl: 60s,  publisher: system, period: 1m }
# _system/heartbeat-5m: { scope: global, semantic: broadcast, default_ttl: 300s, publisher: system, period: 5m }
# _system/heartbeat-1h: { scope: global, semantic: broadcast, default_ttl: 1h,   publisher: system, period: 1h }

# Alarm channels (agents publish; admin endpoint can also publish):
# _system/alarms/critical: { scope: global, semantic: broadcast, default_ttl: 24h, max_messages: 1000 }
# _system/alarms/warning:  { scope: global, semantic: broadcast, default_ttl: 6h,  max_messages: 5000 }
# _system/alarms/info:     { scope: global, semantic: queue,     default_ttl: 1h,  max_messages: 10000 }

# Event-driven channels (publisher: system without period):
# _system/runtime-state:   { scope: global, semantic: broadcast, default_ttl: 7d,  publisher: system }
# _system/provider-events: { scope: global, semantic: broadcast, default_ttl: 24h, publisher: system }
\`\`\`

## Test plan
- [x] **TestHeartbeatRunner_EmitsAtCadence**: 100ms period × 350ms window → 2..5 messages with correct payload shape + \`_system\` attribution.
- [x] **TestHeartbeatRunner_StopIdempotent**: Stop()×N safe.
- [x] **TestHeartbeatRunner_NoSpecsNoOp**: empty specs = no goroutines started.
- [x] **TestLoadHeartbeatSpecs_Filters**: only \`publisher: system + non-empty period\` entries become specs.
- [x] **TestLoadHeartbeatSpecs_BadPeriod**: malformed duration errors.
- [x] \`go test ./...\` green (race detector clean on the channels package).
- [x] \`go build ./...\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)