### PR TITLE
fix(ci): gofmt drift in v0.8.6 PR 1 + PR 2

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1041,7 +1041,6 @@ func (s *Server) handleSystemChannelPublish(w http.ResponseWriter, r *http.Reque
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-
 // runRequest is the JSON body shape for POST /v1/runs.
 type runRequest struct {
 	Agent        string               `json:"agent"`

--- a/internal/channels/scheduler.go
+++ b/internal/channels/scheduler.go
@@ -38,8 +38,8 @@ type Scheduler struct {
 	// alarms for the same minute).
 	MaxPending int
 
-	timers   sync.Map // msg_id (string) → *time.Timer
-	pendCnt  atomic.Int64
+	timers  sync.Map // msg_id (string) → *time.Timer
+	pendCnt atomic.Int64
 }
 
 // NewScheduler constructs a scheduler bound to the given Bus.


### PR DESCRIPTION
## Summary
CI's \`gofmt check\` step caught two trivial formatting issues introduced in the v0.8.6 system-channels work (PRs #74 and #75). Pure \`gofmt -w\` output; no behaviour change.

## Files
- \`internal/channels/scheduler.go\` — misaligned struct fields in \`Scheduler\` (\`timers   sync.Map\` had an extra space).
- \`internal/api/http/server.go\` — extra blank line between \`handleSystemChannelPublish\` and the \`runRequest\` type.

## Test plan
- [x] \`gofmt -l .\` returns empty
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)