### PR TITLE
feat(context): v0.8.7 PR 1 — Context tool (self/tools/doc/permissions)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -245,6 +245,15 @@ func main() {
 	}
 	allTools = append(allTools, evaluationTool)
 
+	// Context tool (v0.8.7). Read-only runtime introspection. The Tools
+	// field is back-filled with the FULL allTools slice after every
+	// other registration (MCP + localapi) so doc/tools ops reflect the
+	// complete catalog. Including Context itself in the catalog is
+	// intentional — agents introspecting "what tools do I have" should
+	// see Context, and `doc(name="Context")` should work.
+	contextTool := &builtin.Context{}
+	allTools = append(allTools, contextTool)
+
 	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
 	// in loomcycle.yaml, parse the OpenAPI spec and register one tool
 	// per operation. Each tool forwards calls to local_api.base_url
@@ -411,6 +420,12 @@ func main() {
 	channelTool.Store = storeIface
 	agentDefTool.Store = storeIface
 	evaluationTool.Store = storeIface
+	// Back-fill Context tool's catalog with the FINAL allTools slice
+	// (including MCP-served tools registered above) so doc/tools ops
+	// reflect the complete runtime catalog. Must happen AFTER every
+	// allTools = append(...) line above.
+	contextTool.Tools = allTools
+
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
 	srv.SetMCPFallback(mcpLazyResolver.Resolve)
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2158,9 +2158,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// parent_agent_id (= subAgentID).
 	subCtx := tools.WithAgentTools(subRunCtx, toolNames(subTools))
 	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
-		UserID:   parentIdentity.UserID,
-		AgentID:  subAgentID,
-		UserTier: parentIdentity.UserTier, // v0.8.2: sub-agents inherit parent's user_tier
+		UserID:     parentIdentity.UserID,
+		AgentID:    subAgentID,
+		UserTier:   parentIdentity.UserTier, // v0.8.2: sub-agents inherit parent's user_tier
+		AgentDefID: defID,                   // v0.8.7: surface pinned def_id via Context.self
 	})
 	subCtx = tools.WithAgentName(subCtx, name)
 	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -1,0 +1,269 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Context is the v0.8.7 built-in tool that lets an agent introspect
+// its own runtime — what tools it has, what its identity / lineage
+// looks like, what evaluations exist for its definition, what channels
+// it can reach. Read-only; no mutations, no side effects beyond reads.
+//
+// Discriminated `op` field (same shape as Memory / Channel) lets
+// agents narrow the output instead of paying for a kitchen-sink dump
+// on every call.
+//
+// Nine ops total — PR 1 ships four of them:
+//
+//	self        — identity bundle (agent name, run/agent ids, user, tier)
+//	tools       — post-filter tool catalog
+//	doc         — detailed schema/docstring for one tool by name
+//	permissions — gates that apply to the caller (tool ACL, host policy, scopes)
+//
+// PR 2 adds:  agents / lineage / evaluations
+// PR 3 adds:  channels / history + default-add + opt-out
+//
+// All op results are deterministic and side-effect-free. Calling
+// Context never modifies anything in storage or in-process state.
+//
+// scope_id is NOT relevant here — Context reads from ctx, not from
+// per-scope buckets. No model-supplied identifiers route to storage
+// reads, so there's no cross-user-leak surface.
+type Context struct {
+	// Tools is the FULL post-filter tool list available to THIS run.
+	// The HTTP server constructs this per-run via filterTools+narrowing
+	// and passes it through; Context just reports it. Required.
+	Tools []tools.Tool
+}
+
+const contextDescription = `Read-only runtime introspection. ` +
+	`Answers "what tools do I have? who am I? what permissions apply to me?". ` +
+	`Operations: self, tools, doc, permissions (more ops in later versions). ` +
+	`Always safe to call — no side effects, no storage writes, no network calls. ` +
+	`Useful for self-evolving agents that build their own task plans and want to inspect ` +
+	`their environment before deciding what to do.`
+
+const contextInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":   {"type": "string", "enum": ["self","tools","doc","permissions"], "description": "Which introspection op to run."},
+    "name": {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."}
+  },
+  "required": ["op"],
+  "additionalProperties": false
+}`
+
+type contextInput struct {
+	Op   string `json:"op"`
+	Name string `json:"name,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (c *Context) Name() string { return "Context" }
+
+// Description implements tools.Tool.
+func (c *Context) Description() string { return contextDescription }
+
+// InputSchema implements tools.Tool.
+func (c *Context) InputSchema() json.RawMessage { return json.RawMessage(contextInputSchema) }
+
+// Execute implements tools.Tool. Dispatch off `op`; everything is
+// read-only so there's no scope resolution / quota / cursor path.
+func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	var in contextInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	switch in.Op {
+	case "self":
+		return c.execSelf(ctx)
+	case "tools":
+		return c.execTools(ctx)
+	case "doc":
+		return c.execDoc(ctx, in)
+	case "permissions":
+		return c.execPermissions(ctx)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions)", in.Op)), nil
+	}
+}
+
+// ---- self ----
+
+func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
+	ident := tools.RunIdentity(ctx)
+	out := map[string]any{
+		"agent_name": tools.AgentName(ctx),
+		"agent_id":   ident.AgentID,
+		"user_id":    ident.UserID,
+		"user_tier":  ident.UserTier,
+	}
+	return okJSON(out)
+}
+
+// ---- tools ----
+
+func (c *Context) execTools(ctx context.Context) (tools.Result, error) {
+	// The agent's effective tool name list is attached to ctx by
+	// the server at run start (tools.WithAgentTools). Filter c.Tools
+	// against it so the result reflects THIS run's allowlist
+	// (post-narrowing) — c.Tools is the runtime-wide catalog, the
+	// ctx list is the per-run subset.
+	allowed := tools.AgentTools(ctx)
+	allowSet := make(map[string]bool, len(allowed))
+	for _, n := range allowed {
+		allowSet[n] = true
+	}
+
+	type toolSummary struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		// SideEffectClass is a hint to the model about what calling
+		// the tool can do. Closed set (v0.8.7):
+		//
+		//	"pure"        — no side effects (Read, WebFetch, WebSearch,
+		//	                Memory.get/list, Channel.peek, AgentDef.get/list,
+		//	                Evaluation.get/aggregate, Context.*)
+		//	"state"       — mutates loomcycle-managed state (Memory.set/incr/
+		//	                delete, Channel.publish/subscribe/ack,
+		//	                AgentDef.create/fork/promote/retire,
+		//	                Evaluation.submit)
+		//	"network"     — outbound HTTP/HTTPS (HTTP, WebFetch, WebSearch)
+		//	"filesystem"  — reads/writes the runtime's filesystem (Read,
+		//	                Write, Edit)
+		//	"privileged"  — executes arbitrary code on the host (Bash, Agent)
+		//	"unknown"     — MCP-served tool; class isn't introspectable
+		//	                without operator metadata. Defaults here.
+		//
+		// One tool may legitimately be in multiple classes — the field
+		// is a single string by design (the model wants a quick filter,
+		// not a fine-grained taxonomy). When in doubt, pick the
+		// strongest class.
+		SideEffectClass string `json:"side_effect_class"`
+	}
+	out := make([]toolSummary, 0, len(c.Tools))
+	for _, t := range c.Tools {
+		name := t.Name()
+		// When the ctx-attached list is present (production path), use
+		// it as the floor; when absent (test fixtures, unwired test
+		// harnesses) fall back to showing everything in c.Tools so
+		// Context is still useful in unit tests.
+		if len(allowSet) > 0 && !allowSet[name] {
+			continue
+		}
+		out = append(out, toolSummary{
+			Name:            name,
+			Description:     t.Description(),
+			SideEffectClass: sideEffectClassFor(name),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return okJSON(map[string]any{"tools": out, "count": len(out)})
+}
+
+// sideEffectClassFor maps the closed-set classifier to a tool name.
+// MCP tools (prefixed `mcp__`) fall through to "unknown" — the class
+// depends on the server's contract and we don't have operator metadata
+// to introspect. Built-ins are listed by canonical name.
+func sideEffectClassFor(name string) string {
+	switch name {
+	// Pure reads (no state mutation, no network beyond reading a URL).
+	case "Read":
+		return "filesystem"
+	case "WebFetch", "WebSearch", "HTTP":
+		return "network"
+	// State mutations.
+	case "Write", "Edit":
+		return "filesystem"
+	case "Bash", "Agent":
+		return "privileged"
+	case "Memory", "Channel", "AgentDef", "Evaluation":
+		// These have op-discriminated surfaces; some ops are pure
+		// (get/list/peek) and some are state (set/publish/create).
+		// Without per-op classification we conservatively pick "state"
+		// — operators reading the catalog see "this might mutate."
+		return "state"
+	case "Context", "Skill":
+		return "pure"
+	}
+	if strings.HasPrefix(name, "mcp__") {
+		return "unknown"
+	}
+	return "unknown"
+}
+
+// ---- doc ----
+
+func (c *Context) execDoc(ctx context.Context, in contextInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("doc: missing required field: name"), nil
+	}
+	allowed := tools.AgentTools(ctx)
+	allowSet := make(map[string]bool, len(allowed))
+	for _, n := range allowed {
+		allowSet[n] = true
+	}
+	for _, t := range c.Tools {
+		if t.Name() != in.Name {
+			continue
+		}
+		if len(allowSet) > 0 && !allowSet[in.Name] {
+			// Tool exists in the runtime catalog but isn't in THIS
+			// run's effective list. Refuse with a clear message
+			// rather than leaking the docs of a tool the agent
+			// can't actually call.
+			return errResult(fmt.Sprintf("doc: tool %q is not in this agent's allowed_tools", in.Name)), nil
+		}
+		schema := t.InputSchema()
+		return okJSON(map[string]any{
+			"name":              t.Name(),
+			"description":       t.Description(),
+			"input_schema":      json.RawMessage(schema),
+			"side_effect_class": sideEffectClassFor(t.Name()),
+		})
+	}
+	return errResult(fmt.Sprintf("doc: tool %q not found (use op=tools to list available)", in.Name)), nil
+}
+
+// ---- permissions ----
+
+func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
+	// Surface the per-run policy bundles that gate the agent's
+	// behaviour. The model can compare its intended actions to these
+	// gates before attempting them (avoids "tool refused" surprises).
+	hostPol := tools.HostPolicy(ctx)
+	memPol := tools.MemoryPolicy(ctx)
+	chPol := tools.ChannelPolicy(ctx)
+	adPol := tools.AgentDefPolicy(ctx)
+	evPol := tools.EvaluationPolicy(ctx)
+
+	out := map[string]any{
+		"allowed_tools": tools.AgentTools(ctx),
+		"host_policy": map[string]any{
+			"has_list":          hostPol.HasList,
+			"allowed_hosts":     hostPol.AllowedHosts,
+			"web_search_filter": hostPol.WebSearchFilter,
+		},
+		"memory": map[string]any{
+			"allowed_scopes": memPol.AllowedScopes,
+			"quota_bytes":    memPol.QuotaBytes,
+		},
+		"channels": map[string]any{
+			"publish":   chPol.Publish,
+			"subscribe": chPol.Subscribe,
+		},
+		"agent_def_scopes":  adPol.Scopes,
+		"evaluation_scopes": evPol.Scopes,
+	}
+	return okJSON(out)
+}
+
+var _ tools.Tool = (*Context)(nil)

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -101,10 +101,11 @@ func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 	ident := tools.RunIdentity(ctx)
 	out := map[string]any{
-		"agent_name": tools.AgentName(ctx),
-		"agent_id":   ident.AgentID,
-		"user_id":    ident.UserID,
-		"user_tier":  ident.UserTier,
+		"agent_name":   tools.AgentName(ctx),
+		"agent_id":     ident.AgentID,
+		"user_id":      ident.UserID,
+		"user_tier":    ident.UserTier,
+		"agent_def_id": ident.AgentDefID,
 	}
 	return okJSON(out)
 }

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -38,9 +38,10 @@ func contextFixture(t *testing.T) (*Context, context.Context) {
 	}
 	ctx := tools.WithAgentName(context.Background(), "researcher")
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
-		AgentID:  "a_test",
-		UserID:   "alice",
-		UserTier: "medium",
+		AgentID:    "a_test",
+		UserID:     "alice",
+		UserTier:   "medium",
+		AgentDefID: "def_abc",
 	})
 	ctx = tools.WithAgentTools(ctx, []string{"Read", "Memory", "Context", "mcp__jobs__patchApp"})
 	return tool, ctx
@@ -66,6 +67,27 @@ func TestContextTool_SelfReturnsIdentity(t *testing.T) {
 	}
 	if out["user_tier"] != "medium" {
 		t.Errorf("user_tier = %v, want medium", out["user_tier"])
+	}
+	// v0.8.7 PR 1 review fix: agent_def_id surfaced from RunIdentity.
+	if out["agent_def_id"] != "def_abc" {
+		t.Errorf("agent_def_id = %v, want def_abc", out["agent_def_id"])
+	}
+}
+
+// PR 1 review fix: empty AgentDefID (static-resolved run, no pin)
+// surfaces as empty string, not as a missing key.
+func TestContextTool_SelfEmptyAgentDefIDStillSurfaced(t *testing.T) {
+	tool := &Context{}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+		AgentID: "a_static",
+	})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
+	out := decodeResult(t, res.Text)
+	if _, ok := out["agent_def_id"]; !ok {
+		t.Error("agent_def_id key missing — should be present (empty string) for static runs")
+	}
+	if out["agent_def_id"] != "" {
+		t.Errorf("agent_def_id = %v, want empty string", out["agent_def_id"])
 	}
 }
 

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -1,0 +1,288 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// fakeTool is a minimal tools.Tool used for the Context tool's
+// catalog tests. Name + Description + InputSchema are caller-supplied;
+// Execute is a no-op (Context never calls Execute on its catalog).
+type fakeTool struct {
+	NameVal   string
+	DescVal   string
+	SchemaVal string
+}
+
+func (f *fakeTool) Name() string                 { return f.NameVal }
+func (f *fakeTool) Description() string          { return f.DescVal }
+func (f *fakeTool) InputSchema() json.RawMessage { return json.RawMessage(f.SchemaVal) }
+func (f *fakeTool) Execute(context.Context, json.RawMessage) (tools.Result, error) {
+	return tools.Result{}, nil
+}
+
+func contextFixture(t *testing.T) (*Context, context.Context) {
+	t.Helper()
+	tool := &Context{
+		Tools: []tools.Tool{
+			&fakeTool{NameVal: "Read", DescVal: "Read a file", SchemaVal: `{"type":"object"}`},
+			&fakeTool{NameVal: "Memory", DescVal: "Persistent KV", SchemaVal: `{"type":"object"}`},
+			&fakeTool{NameVal: "Context", DescVal: "Introspect", SchemaVal: `{"type":"object"}`},
+			&fakeTool{NameVal: "Bash", DescVal: "Run shell", SchemaVal: `{"type":"object"}`},
+			&fakeTool{NameVal: "mcp__jobs__patchApp", DescVal: "MCP", SchemaVal: `{"type":"object"}`},
+		},
+	}
+	ctx := tools.WithAgentName(context.Background(), "researcher")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		AgentID:  "a_test",
+		UserID:   "alice",
+		UserTier: "medium",
+	})
+	ctx = tools.WithAgentTools(ctx, []string{"Read", "Memory", "Context", "mcp__jobs__patchApp"})
+	return tool, ctx
+}
+
+// ---- self ----
+
+func TestContextTool_SelfReturnsIdentity(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
+	if res.IsError {
+		t.Fatalf("self: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["agent_name"] != "researcher" {
+		t.Errorf("agent_name = %v, want researcher", out["agent_name"])
+	}
+	if out["agent_id"] != "a_test" {
+		t.Errorf("agent_id = %v, want a_test", out["agent_id"])
+	}
+	if out["user_id"] != "alice" {
+		t.Errorf("user_id = %v, want alice", out["user_id"])
+	}
+	if out["user_tier"] != "medium" {
+		t.Errorf("user_tier = %v, want medium", out["user_tier"])
+	}
+}
+
+func TestContextTool_SelfWithEmptyCtxReturnsZeros(t *testing.T) {
+	tool := &Context{}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"self"}`))
+	if res.IsError {
+		t.Fatalf("self: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["agent_name"] != "" {
+		t.Errorf("agent_name = %v, want empty", out["agent_name"])
+	}
+}
+
+// ---- tools ----
+
+func TestContextTool_ToolsFiltersByAgentToolsList(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"tools"}`))
+	if res.IsError {
+		t.Fatalf("tools: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	// 4 of the 5 fake tools are in AgentTools (Bash is excluded).
+	if out["count"].(float64) != 4 {
+		t.Errorf("count = %v, want 4 (Bash excluded by ctx allowlist)", out["count"])
+	}
+	got := out["tools"].([]any)
+	gotNames := map[string]bool{}
+	for _, e := range got {
+		gotNames[e.(map[string]any)["name"].(string)] = true
+	}
+	if gotNames["Bash"] {
+		t.Error("Bash should be filtered out (not in AgentTools ctx)")
+	}
+	if !gotNames["Read"] || !gotNames["Memory"] || !gotNames["Context"] || !gotNames["mcp__jobs__patchApp"] {
+		t.Errorf("missing expected tool in catalog: %v", gotNames)
+	}
+}
+
+func TestContextTool_ToolsSortedByName(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"tools"}`))
+	out := decodeResult(t, res.Text)
+	got := out["tools"].([]any)
+	var prev string
+	for _, e := range got {
+		name := e.(map[string]any)["name"].(string)
+		if prev != "" && name < prev {
+			t.Errorf("tools not sorted: %q after %q", name, prev)
+		}
+		prev = name
+	}
+}
+
+func TestContextTool_ToolsSideEffectClass(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"tools"}`))
+	out := decodeResult(t, res.Text)
+	classes := map[string]string{}
+	for _, e := range out["tools"].([]any) {
+		m := e.(map[string]any)
+		classes[m["name"].(string)] = m["side_effect_class"].(string)
+	}
+	if classes["Read"] != "filesystem" {
+		t.Errorf("Read class = %q, want filesystem", classes["Read"])
+	}
+	if classes["Memory"] != "state" {
+		t.Errorf("Memory class = %q, want state", classes["Memory"])
+	}
+	if classes["Context"] != "pure" {
+		t.Errorf("Context class = %q, want pure", classes["Context"])
+	}
+	if classes["mcp__jobs__patchApp"] != "unknown" {
+		t.Errorf("mcp__ class = %q, want unknown", classes["mcp__jobs__patchApp"])
+	}
+}
+
+func TestContextTool_ToolsWithoutCtxShowsAll(t *testing.T) {
+	// No WithAgentTools attached → fallback shows the full c.Tools
+	// catalog. Useful for unit tests and dev introspection.
+	tool := &Context{Tools: []tools.Tool{
+		&fakeTool{NameVal: "Read", DescVal: "x", SchemaVal: `{}`},
+		&fakeTool{NameVal: "Bash", DescVal: "x", SchemaVal: `{}`},
+	}}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"tools"}`))
+	out := decodeResult(t, res.Text)
+	if out["count"].(float64) != 2 {
+		t.Errorf("count = %v, want 2 (no ctx filter)", out["count"])
+	}
+}
+
+// ---- doc ----
+
+func TestContextTool_DocReturnsFullSchema(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"doc","name":"Read"}`))
+	if res.IsError {
+		t.Fatalf("doc: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["name"] != "Read" {
+		t.Errorf("name = %v, want Read", out["name"])
+	}
+	if out["description"] != "Read a file" {
+		t.Errorf("description = %v, want \"Read a file\"", out["description"])
+	}
+	if out["input_schema"] == nil {
+		t.Error("input_schema missing")
+	}
+}
+
+func TestContextTool_DocMissingName(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"doc"}`))
+	if !res.IsError {
+		t.Fatalf("doc without name should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "name") {
+		t.Errorf("error should mention name; got %q", res.Text)
+	}
+}
+
+func TestContextTool_DocUnknownTool(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"doc","name":"Nonexistent"}`))
+	if !res.IsError {
+		t.Fatalf("doc for unknown tool should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "not found") {
+		t.Errorf("error should mention not found; got %q", res.Text)
+	}
+}
+
+func TestContextTool_DocOutsideAllowlist(t *testing.T) {
+	// Tool exists in the catalog but isn't in the ctx allowlist.
+	// Should refuse rather than leak the docs.
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"doc","name":"Bash"}`))
+	if !res.IsError {
+		t.Fatalf("doc for out-of-allowlist tool should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "allowed_tools") {
+		t.Errorf("error should mention allowed_tools; got %q", res.Text)
+	}
+}
+
+// ---- permissions ----
+
+func TestContextTool_PermissionsBundle(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	// Attach a host policy + memory policy so they appear in the output.
+	ctx = tools.WithHostPolicy(ctx, tools.HostPolicyValue{
+		AllowedHosts: []string{"api.example.com"},
+		HasList:      true,
+	})
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user"},
+		QuotaBytes:    1024,
+	})
+	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"findings"},
+		Subscribe: []string{"findings"},
+	})
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"self"},
+		SelfName: "researcher",
+	})
+	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{
+		Scopes: []string{"submit_self", "read_any"},
+	})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"permissions"}`))
+	if res.IsError {
+		t.Fatalf("permissions: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if got := out["allowed_tools"].([]any); len(got) != 4 {
+		t.Errorf("allowed_tools len = %d, want 4", len(got))
+	}
+	if hp := out["host_policy"].(map[string]any); hp["has_list"].(bool) != true {
+		t.Error("host_policy.has_list != true")
+	}
+	if mem := out["memory"].(map[string]any); mem["quota_bytes"].(float64) != 1024 {
+		t.Errorf("memory.quota_bytes = %v, want 1024", mem["quota_bytes"])
+	}
+	if ch := out["channels"].(map[string]any); len(ch["publish"].([]any)) != 1 {
+		t.Errorf("channels.publish len = %d, want 1", len(ch["publish"].([]any)))
+	}
+	if adScopes := out["agent_def_scopes"].([]any); adScopes[0] != "self" {
+		t.Errorf("agent_def_scopes[0] = %v, want self", adScopes[0])
+	}
+}
+
+// ---- dispatch ----
+
+func TestContextTool_UnknownOp(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"frob"}`))
+	if !res.IsError {
+		t.Fatalf("unknown op should refuse; got %s", res.Text)
+	}
+}
+
+func TestContextTool_MissingOp(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{}`))
+	if !res.IsError {
+		t.Fatalf("missing op should refuse; got %s", res.Text)
+	}
+}
+
+func TestContextTool_MalformedJSON(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{not json`))
+	if !res.IsError {
+		t.Fatal("malformed JSON should error")
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -170,6 +170,14 @@ type RunIdentityValue struct {
 	// Empty when the operator has no user_tiers block or the caller
 	// didn't pass user_tier.
 	UserTier string
+	// AgentDefID is the v0.8.5 substrate def_id pinned to THIS run
+	// (when set via the Agent tool's def_id parameter or when the
+	// resolver picked a non-static active def at run start). Empty
+	// for static-only runs (where the agent body came from
+	// cfg.Agents alone). The Context.self op surfaces it so agents
+	// can identify "which version of myself am I running" without a
+	// store roundtrip.
+	AgentDefID string
 }
 
 // WithRunIdentity attaches the current run's identity to ctx. The


### PR DESCRIPTION
## Summary
First of four stacked v0.8.7 PRs implementing the **Context** tool — read-only runtime introspection. This PR ships the four storage-agnostic ops (\`self\`, \`tools\`, \`doc\`, \`permissions\`) that depend only on ctx-attached values; no migrations, no goroutines, no network calls.

## Stacking
- **Base:** \`main\`
- **PR 2** (next) — substrate-coupled ops (\`agents\`, \`lineage\`, \`evaluations\`) wiring to v0.8.5 store methods.
- **PR 3** — channels/history ops + default-add behaviour (auto-attach to every agent's \`allowed_tools\`, opt out via \`disable_context: true\`).
- **PR 4** — runtime smoke at \`test/runtime/context/\` (agent introspects itself end-to-end via Gemini).

## Operations

| op | input | returns |
|---|---|---|
| \`self\` | — | \`agent_name\`, \`agent_id\`, \`user_id\`, \`user_tier\` from \`tools.RunIdentity(ctx)\` + \`tools.AgentName(ctx)\` |
| \`tools\` | — | post-filter tool catalog (\`name\`, \`description\`, \`side_effect_class\`) sorted by name. Filters against \`tools.AgentTools(ctx)\` so the agent sees its effective allowlist, not the runtime-wide catalog. |
| \`doc\` | \`name\` | input_schema + description for the named tool. Refuses for tools outside the allowlist (no leak of unavailable docs). |
| \`permissions\` | — | bundle of every policy ctx-key: \`allowed_tools\`, \`host_policy\`, \`memory\`, \`channels\`, \`agent_def_scopes\`, \`evaluation_scopes\`. |

## side_effect_class taxonomy

Closed set on the \`tools\` op:

- \`pure\` — Context, Skill
- \`state\` — Memory, Channel, AgentDef, Evaluation (op-discriminated; conservatively classed as state since some ops mutate)
- \`network\` — HTTP, WebFetch, WebSearch
- \`filesystem\` — Read, Write, Edit
- \`privileged\` — Bash, Agent
- \`unknown\` — \`mcp__*\` (operator metadata required to introspect)

Lets models filter their candidate actions by side-effect posture before committing.

## Wiring

Registered as the final builtin before MCP / localapi appends:

\`\`\`go
contextTool := &builtin.Context{}
allTools = append(allTools, contextTool)
\`\`\`

After every other \`allTools = append(...)\` (including MCP), back-fill the catalog:

\`\`\`go
contextTool.Tools = allTools  // includes Context itself — self-introspection works
\`\`\`

## Test plan
- [x] 14 unit tests in \`context_test.go\`: every op + side-effect-class mapping + allowlist filter + ctx-empty fallback + unknown/missing op refusals + docs-outside-allowlist refusal.
- [x] \`go test ./...\` green
- [x] \`go build ./...\` clean
- [x] \`gofmt -l .\` empty

## What this PR does NOT do (intentional split)

- No substrate-coupled ops (\`agents\`, \`lineage\`, \`evaluations\`) — PR 2.
- No \`channels\` / \`history\` ops — PR 3.
- No default-add behaviour or \`disable_context\` yaml — PR 3.
- No runtime test — PR 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)