### PR TITLE
feat(context): v0.8.7 PR 2 — agents / lineage / evaluations ops

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -250,8 +250,11 @@ func main() {
 	// other registration (MCP + localapi) so doc/tools ops reflect the
 	// complete catalog. Including Context itself in the catalog is
 	// intentional — agents introspecting "what tools do I have" should
-	// see Context, and `doc(name="Context")` should work.
-	contextTool := &builtin.Context{}
+	// see Context, and `doc(name="Context")` should work. Cfg + Store
+	// power the v0.8.7 PR 2 substrate-coupled ops (agents / lineage /
+	// evaluations); Store is late-bound below alongside the other
+	// substrate tools.
+	contextTool := &builtin.Context{Cfg: cfg}
 	allTools = append(allTools, contextTool)
 
 	// Local API MCP gateway (v0.4.0+). When `local_api.spec` is set
@@ -420,6 +423,7 @@ func main() {
 	channelTool.Store = storeIface
 	agentDefTool.Store = storeIface
 	evaluationTool.Store = storeIface
+	contextTool.Store = storeIface
 	// Back-fill Context tool's catalog with the FINAL allTools slice
 	// (including MCP-served tools registered above) so doc/tools ops
 	// reflect the complete runtime catalog. Must happen AFTER every

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -317,6 +318,12 @@ func (c *Context) execAgents(ctx context.Context, in contextInput) (tools.Result
 		Provider     string `json:"provider,omitempty"`
 		ActiveDefID  string `json:"active_def_id,omitempty"`
 		AllowedTools int    `json:"allowed_tools_count"`
+		// Error surfaces a per-name lookup failure (e.g. DB connection
+		// drop while resolving ActiveDefID). Empty when the lookup
+		// succeeded or the name has no DB row (the NotFound case
+		// silently omits ActiveDefID rather than reporting an error —
+		// not-yet-forked is the common "no active def" state).
+		Error string `json:"error,omitempty"`
 	}
 	names := make([]string, 0, len(c.Cfg.Agents))
 	for n := range c.Cfg.Agents {
@@ -338,9 +345,11 @@ func (c *Context) execAgents(ctx context.Context, in contextInput) (tools.Result
 			AllowedTools: len(def.AllowedTools),
 		}
 		// Active def_id from the v0.8.5 substrate. Best-effort — if
-		// Store is nil or no active row, we omit the field. Errors
-		// other than ErrNotFound are logged inline as part of a
-		// per-name `error` key rather than failing the whole op.
+		// Store is nil or no active row, we omit the field. Non-
+		// NotFound errors are unusual but possible (e.g. DB connection
+		// drop mid-call); surface them as a per-name `error` key + log
+		// so operators see the partial failure without losing the rest
+		// of the catalog. PR 2 review fix.
 		if c.Store != nil {
 			row, err := c.Store.AgentDefGetActive(ctx, name)
 			if err == nil {
@@ -348,11 +357,8 @@ func (c *Context) execAgents(ctx context.Context, in contextInput) (tools.Result
 			} else {
 				var nf *store.ErrNotFound
 				if !errors.As(err, &nf) {
-					// Non-NotFound errors are unusual — surface them
-					// so operators see the per-name failure without
-					// losing the rest of the catalog.
-					// (We don't fail the whole op for one bad lookup.)
-					_ = err
+					s.Error = err.Error()
+					log.Printf("context agents: AgentDefGetActive(%q): %v", name, err)
 				}
 			}
 		}
@@ -422,14 +428,17 @@ func (c *Context) execLineage(ctx context.Context, in contextInput) (tools.Resul
 		cur = parent
 	}
 
-	// Walk descendants breadth-first via AgentDefListChildren.
-	type level struct {
-		rows  []store.AgentDefRow
-		level int
-	}
+	// Walk descendants breadth-first via AgentDefListChildren. Cap
+	// the TOTAL node count (not just depth) so a high-fan-out lineage
+	// doesn't produce a multi-megabyte JSON blob — depth alone could
+	// still blow up under heavy fork branching (PR 2 review fix).
+	// On overflow we stop the BFS, set truncated=true, and return
+	// whatever was collected so far.
+	const maxDescendants = 500
 	var descendants []defSummary
+	truncated := false
 	frontier := []store.AgentDefRow{root}
-	for d := 1; d <= depth && len(frontier) > 0; d++ {
+	for d := 1; d <= depth && len(frontier) > 0 && !truncated; d++ {
 		var next []store.AgentDefRow
 		for _, r := range frontier {
 			children, err := c.Store.AgentDefListChildren(ctx, r.DefID)
@@ -437,8 +446,15 @@ func (c *Context) execLineage(ctx context.Context, in contextInput) (tools.Resul
 				return errResult(fmt.Sprintf("lineage: walk descendants: %s", err)), nil
 			}
 			for _, ch := range children {
+				if len(descendants) >= maxDescendants {
+					truncated = true
+					break
+				}
 				descendants = append(descendants, toSummary(ch))
 				next = append(next, ch)
+			}
+			if truncated {
+				break
 			}
 		}
 		frontier = next
@@ -449,6 +465,7 @@ func (c *Context) execLineage(ctx context.Context, in contextInput) (tools.Resul
 		"ancestors":   ancestors,
 		"descendants": descendants,
 		"depth":       depth,
+		"truncated":   truncated,
 	})
 }
 

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -3,10 +3,13 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -40,11 +43,26 @@ type Context struct {
 	// The HTTP server constructs this per-run via filterTools+narrowing
 	// and passes it through; Context just reports it. Required.
 	Tools []tools.Tool
+
+	// Cfg is the operator config. Used by the `agents` op to enumerate
+	// declared agents and surface metadata (name, description, tier,
+	// allowed-tools shape). nil = `agents` op refuses with a clear
+	// "not configured" error.
+	Cfg *config.Config
+
+	// Store is the persistence backend, used by the substrate-coupled
+	// ops (`agents` for active-def lookup, `lineage` for parent/child
+	// walks, `evaluations` for aggregate). nil = those ops refuse with
+	// a clear "not configured" error; the storage-agnostic ops (self /
+	// tools / doc / permissions) still work.
+	Store store.Store
 }
 
 const contextDescription = `Read-only runtime introspection. ` +
-	`Answers "what tools do I have? who am I? what permissions apply to me?". ` +
-	`Operations: self, tools, doc, permissions (more ops in later versions). ` +
+	`Answers "what tools do I have? who am I? what permissions apply to me? ` +
+	`what other agents exist? what's my def's lineage and evaluation history?". ` +
+	`Operations: self, tools, doc, permissions, agents, lineage, evaluations ` +
+	`(more ops in later versions). ` +
 	`Always safe to call — no side effects, no storage writes, no network calls. ` +
 	`Useful for self-evolving agents that build their own task plans and want to inspect ` +
 	`their environment before deciding what to do.`
@@ -52,16 +70,24 @@ const contextDescription = `Read-only runtime introspection. ` +
 const contextInputSchema = `{
   "type": "object",
   "properties": {
-    "op":   {"type": "string", "enum": ["self","tools","doc","permissions"], "description": "Which introspection op to run."},
-    "name": {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."}
+    "op":              {"type": "string", "enum": ["self","tools","doc","permissions","agents","lineage","evaluations"], "description": "Which introspection op to run."},
+    "name":            {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."},
+    "prefix":          {"type": "string", "description": "agents only: optional name prefix filter."},
+    "def_id":          {"type": "string", "description": "lineage / evaluations: the agent_defs row id to inspect. Use Context.agents to discover def_ids first."},
+    "depth":           {"type": "integer", "description": "lineage only: max depth to walk in each direction (default 10, cap 100)."},
+    "include_lineage": {"type": "boolean", "description": "evaluations only: include ancestors' evaluations in the aggregate (default false)."}
   },
   "required": ["op"],
   "additionalProperties": false
 }`
 
 type contextInput struct {
-	Op   string `json:"op"`
-	Name string `json:"name,omitempty"`
+	Op             string `json:"op"`
+	Name           string `json:"name,omitempty"`
+	Prefix         string `json:"prefix,omitempty"`
+	DefID          string `json:"def_id,omitempty"`
+	Depth          int    `json:"depth,omitempty"`
+	IncludeLineage bool   `json:"include_lineage,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -89,10 +115,16 @@ func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execDoc(ctx, in)
 	case "permissions":
 		return c.execPermissions(ctx)
+	case "agents":
+		return c.execAgents(ctx, in)
+	case "lineage":
+		return c.execLineage(ctx, in)
+	case "evaluations":
+		return c.execEvaluations(ctx, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions, agents, lineage, evaluations)", in.Op)), nil
 	}
 }
 
@@ -265,6 +297,177 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 		"evaluation_scopes": evPol.Scopes,
 	}
 	return okJSON(out)
+}
+
+// ---- agents ----
+
+func (c *Context) execAgents(ctx context.Context, in contextInput) (tools.Result, error) {
+	if c.Cfg == nil {
+		return errResult("agents: not configured (no Cfg)"), nil
+	}
+	type agentSummary struct {
+		Name string `json:"name"`
+		// config.AgentDef has no Description field today — the
+		// MD-frontmatter description lives on agents.Agent (loader) and
+		// doesn't get propagated into cfg.Agents. Omitted from this op
+		// pending a follow-up that threads it through (low priority;
+		// agents already know their own description from their prompt).
+		Tier         string `json:"tier,omitempty"`
+		Model        string `json:"model,omitempty"`
+		Provider     string `json:"provider,omitempty"`
+		ActiveDefID  string `json:"active_def_id,omitempty"`
+		AllowedTools int    `json:"allowed_tools_count"`
+	}
+	names := make([]string, 0, len(c.Cfg.Agents))
+	for n := range c.Cfg.Agents {
+		if in.Prefix != "" && !strings.HasPrefix(n, in.Prefix) {
+			continue
+		}
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	out := make([]agentSummary, 0, len(names))
+	for _, name := range names {
+		def := c.Cfg.Agents[name]
+		s := agentSummary{
+			Name:         name,
+			Tier:         def.Tier,
+			Model:        def.Model,
+			Provider:     def.Provider,
+			AllowedTools: len(def.AllowedTools),
+		}
+		// Active def_id from the v0.8.5 substrate. Best-effort — if
+		// Store is nil or no active row, we omit the field. Errors
+		// other than ErrNotFound are logged inline as part of a
+		// per-name `error` key rather than failing the whole op.
+		if c.Store != nil {
+			row, err := c.Store.AgentDefGetActive(ctx, name)
+			if err == nil {
+				s.ActiveDefID = row.DefID
+			} else {
+				var nf *store.ErrNotFound
+				if !errors.As(err, &nf) {
+					// Non-NotFound errors are unusual — surface them
+					// so operators see the per-name failure without
+					// losing the rest of the catalog.
+					// (We don't fail the whole op for one bad lookup.)
+					_ = err
+				}
+			}
+		}
+		out = append(out, s)
+	}
+	return okJSON(map[string]any{"agents": out, "count": len(out)})
+}
+
+// ---- lineage ----
+
+func (c *Context) execLineage(ctx context.Context, in contextInput) (tools.Result, error) {
+	if c.Store == nil {
+		return errResult("lineage: not configured (no Store backend)"), nil
+	}
+	if in.DefID == "" {
+		return errResult("lineage: missing required field: def_id (use Context.agents to discover def_ids)"), nil
+	}
+	depth := in.Depth
+	if depth <= 0 {
+		depth = 10
+	}
+	if depth > 100 {
+		depth = 100
+	}
+
+	root, err := c.Store.AgentDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("lineage: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("lineage: %s", err)), nil
+	}
+
+	type defSummary struct {
+		DefID       string `json:"def_id"`
+		Name        string `json:"name"`
+		Version     int    `json:"version"`
+		ParentDefID string `json:"parent_def_id,omitempty"`
+		Retired     bool   `json:"retired"`
+		Description string `json:"description,omitempty"`
+	}
+	toSummary := func(row store.AgentDefRow) defSummary {
+		return defSummary{
+			DefID:       row.DefID,
+			Name:        row.Name,
+			Version:     row.Version,
+			ParentDefID: row.ParentDefID,
+			Retired:     row.Retired,
+			Description: row.Description,
+		}
+	}
+
+	// Walk ancestors via parent_def_id chain.
+	ancestors := make([]defSummary, 0, depth)
+	cur := root
+	for i := 0; i < depth && cur.ParentDefID != ""; i++ {
+		parent, err := c.Store.AgentDefGet(ctx, cur.ParentDefID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				break // chain ended at a row that's been deleted
+			}
+			return errResult(fmt.Sprintf("lineage: walk ancestors: %s", err)), nil
+		}
+		ancestors = append(ancestors, toSummary(parent))
+		cur = parent
+	}
+
+	// Walk descendants breadth-first via AgentDefListChildren.
+	type level struct {
+		rows  []store.AgentDefRow
+		level int
+	}
+	var descendants []defSummary
+	frontier := []store.AgentDefRow{root}
+	for d := 1; d <= depth && len(frontier) > 0; d++ {
+		var next []store.AgentDefRow
+		for _, r := range frontier {
+			children, err := c.Store.AgentDefListChildren(ctx, r.DefID)
+			if err != nil {
+				return errResult(fmt.Sprintf("lineage: walk descendants: %s", err)), nil
+			}
+			for _, ch := range children {
+				descendants = append(descendants, toSummary(ch))
+				next = append(next, ch)
+			}
+		}
+		frontier = next
+	}
+
+	return okJSON(map[string]any{
+		"root":        toSummary(root),
+		"ancestors":   ancestors,
+		"descendants": descendants,
+		"depth":       depth,
+	})
+}
+
+// ---- evaluations ----
+
+func (c *Context) execEvaluations(ctx context.Context, in contextInput) (tools.Result, error) {
+	if c.Store == nil {
+		return errResult("evaluations: not configured (no Store backend)"), nil
+	}
+	if in.DefID == "" {
+		return errResult("evaluations: missing required field: def_id (use Context.agents to discover def_ids)"), nil
+	}
+	agg, err := c.Store.EvaluationAggregate(ctx, in.DefID, store.AggregateOpts{
+		IncludeLineage: in.IncludeLineage,
+	})
+	if err != nil {
+		return errResult(fmt.Sprintf("evaluations: %s", err)), nil
+	}
+	return okJSON(agg)
 }
 
 var _ tools.Tool = (*Context)(nil)

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -517,6 +518,52 @@ func TestContextTool_LineageUnknownDefID(t *testing.T) {
 	}
 	if !strings.Contains(res.Text, "not found") {
 		t.Errorf("error should mention not found; got %q", res.Text)
+	}
+}
+
+// PR 2 review fix: lineage BFS caps total node count (not just
+// depth) so a high-fan-out lineage doesn't blow up the response.
+// Seed > maxDescendants children and verify truncated=true.
+func TestContextTool_LineageTruncatesAtNodeCap(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+	suffix := strings.ReplaceAll(t.Name(), "/", "_")
+
+	root, _ := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:      "def_root_" + suffix,
+		Name:       "fanout_" + suffix,
+		Definition: json.RawMessage(`{}`),
+	})
+	// Create > 500 children (the maxDescendants cap). Just barely
+	// over the cap is enough to trigger truncation.
+	for i := 0; i < 510; i++ {
+		_, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+			DefID:       fmt.Sprintf("def_child_%d_%s", i, suffix),
+			Name:        "fanout_" + suffix,
+			ParentDefID: root.DefID,
+			Definition:  json.RawMessage(`{}`),
+		})
+		if err != nil {
+			t.Fatalf("seed child %d: %v", i, err)
+		}
+	}
+
+	tool := &Context{Cfg: &config.Config{}, Store: s}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"lineage","def_id":"`+root.DefID+`"}`))
+	if res.IsError {
+		t.Fatalf("lineage: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	desc := out["descendants"].([]any)
+	if len(desc) > 500 {
+		t.Errorf("descendants len = %d, want <= 500 (the cap)", len(desc))
+	}
+	if !out["truncated"].(bool) {
+		t.Error("truncated should be true when cap hit")
 	}
 }
 

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -306,5 +309,270 @@ func TestContextTool_MalformedJSON(t *testing.T) {
 	res, _ := tool.Execute(ctx, json.RawMessage(`{not json`))
 	if !res.IsError {
 		t.Fatal("malformed JSON should error")
+	}
+}
+
+// ---- agents / lineage / evaluations fixtures + tests (PR 2) ----
+
+// substrateFixture builds a Context tool with Cfg + an in-memory
+// sqlite store seeded with two agent_defs rows (a v1 + a v2-child)
+// for a per-test unique name, and one Evaluation row against v2.
+//
+// The `:memory:` sqlite DSN uses `cache=shared`, so every Open returns
+// the same physical database within one test process — subtests share
+// state. Defeating that requires either a per-test file:: DSN or
+// per-test unique keys. We pick unique keys (per t.Name()) so the
+// fixture remains race-clean across subtests without filesystem
+// shenanigans.
+func substrateFixture(t *testing.T) (*Context, store.Store, context.Context, string, string, string) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	// `:memory:` with cache=shared persists for the lifetime of any
+	// open connection — without explicit Close, later tests that
+	// reopen `:memory:` see stale rows. Registering the close on
+	// t.Cleanup ensures the connection pool drains at test exit.
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := context.Background()
+
+	// Per-test unique IDs so subtests don't collide on the shared
+	// in-memory DB. t.Name() is unique per subtest.
+	suffix := strings.ReplaceAll(t.Name(), "/", "_")
+	suffix = strings.ReplaceAll(suffix, "TestContextTool_", "")
+	agentName := "researcher_" + suffix
+	v1ID := "def_v1_" + suffix
+	v2ID := "def_v2_" + suffix
+
+	v1, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:      v1ID,
+		Name:       agentName,
+		Definition: json.RawMessage(`{"system_prompt":"v1"}`),
+	})
+	if err != nil {
+		t.Fatalf("AgentDefCreate v1: %v", err)
+	}
+	v2, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:       v2ID,
+		Name:        agentName,
+		ParentDefID: v1.DefID,
+		Definition:  json.RawMessage(`{"system_prompt":"v2"}`),
+		Description: "experimental",
+	})
+	if err != nil {
+		t.Fatalf("AgentDefCreate v2: %v", err)
+	}
+	if err := s.AgentDefSetActive(ctx, agentName, v2.DefID, ""); err != nil {
+		t.Fatalf("AgentDefSetActive: %v", err)
+	}
+
+	sess, _ := s.CreateSession(ctx, "t", agentName, "alice")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_eval", AgentDefID: v2.DefID})
+	_, _ = s.EvaluationSubmit(ctx, store.EvaluationRow{
+		EvalID:      "eval_" + suffix,
+		RunID:       run.ID,
+		DefID:       v2.DefID,
+		Score:       0.8,
+		EmitterRole: "self",
+	})
+
+	cfg := &config.Config{
+		Agents: map[string]config.AgentDef{
+			agentName: {
+				Tier:         "low",
+				Provider:     "anthropic",
+				Model:        "claude-haiku-4-5",
+				AllowedTools: []string{"Read", "Context"},
+			},
+			"qa_" + suffix: {
+				Tier:         "middle",
+				AllowedTools: []string{"Read"},
+			},
+		},
+	}
+	tool := &Context{
+		Tools: []tools.Tool{
+			&fakeTool{NameVal: "Read", DescVal: "Read a file", SchemaVal: `{}`},
+			&fakeTool{NameVal: "Context", DescVal: "Introspect", SchemaVal: `{}`},
+		},
+		Cfg:   cfg,
+		Store: s,
+	}
+	runCtx := tools.WithAgentName(context.Background(), agentName)
+	runCtx = tools.WithRunIdentity(runCtx, tools.RunIdentityValue{AgentID: "a_test", UserID: "alice"})
+	runCtx = tools.WithAgentTools(runCtx, []string{"Read", "Context"})
+	return tool, s, runCtx, agentName, v1.DefID, v2.DefID
+}
+
+// ---- agents ----
+
+func TestContextTool_AgentsListsAll(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"agents"}`))
+	if res.IsError {
+		t.Fatalf("agents: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["count"].(float64) != 2 {
+		t.Errorf("count = %v, want 2 (researcher + qa)", out["count"])
+	}
+	got := out["agents"].([]any)
+	// Sorted alphabetically; qa_ prefix sorts before researcher_.
+	first := got[0].(map[string]any)
+	if !strings.HasPrefix(first["name"].(string), "qa_") {
+		t.Errorf("first agent = %q, want qa_* prefix", first["name"])
+	}
+}
+
+func TestContextTool_AgentsPrefixFilter(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"agents","prefix":"researcher_"}`))
+	out := decodeResult(t, res.Text)
+	if out["count"].(float64) != 1 {
+		t.Errorf("prefix=researcher_ count = %v, want 1", out["count"])
+	}
+	first := out["agents"].([]any)[0].(map[string]any)
+	if !strings.HasPrefix(first["name"].(string), "researcher_") {
+		t.Errorf("name = %q, want researcher_ prefix", first["name"])
+	}
+}
+
+func TestContextTool_AgentsIncludesActiveDefID(t *testing.T) {
+	tool, _, ctx, _, _, v2ID := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"agents","prefix":"researcher_"}`))
+	out := decodeResult(t, res.Text)
+	first := out["agents"].([]any)[0].(map[string]any)
+	if first["active_def_id"] != v2ID {
+		t.Errorf("active_def_id = %v, want %s", first["active_def_id"], v2ID)
+	}
+}
+
+func TestContextTool_AgentsRefusesWithoutCfg(t *testing.T) {
+	tool := &Context{} // no Cfg
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"agents"}`))
+	if !res.IsError {
+		t.Fatal("agents without Cfg should refuse")
+	}
+}
+
+// ---- lineage ----
+
+func TestContextTool_LineageWalksAncestorsAndDescendants(t *testing.T) {
+	tool, _, ctx, _, v1ID, v2ID := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"lineage","def_id":"`+v1ID+`"}`))
+	if res.IsError {
+		t.Fatalf("lineage: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	root := out["root"].(map[string]any)
+	if root["def_id"] != v1ID {
+		t.Errorf("root.def_id = %v, want %s", root["def_id"], v1ID)
+	}
+	// v1 has no ancestors (it's the root).
+	if anc := out["ancestors"]; anc != nil {
+		if a, _ := anc.([]any); len(a) != 0 {
+			t.Errorf("ancestors = %v, want []", a)
+		}
+	}
+	// v1 has one descendant: v2.
+	desc := out["descendants"].([]any)
+	if len(desc) != 1 {
+		t.Fatalf("descendants len = %d, want 1", len(desc))
+	}
+	if d := desc[0].(map[string]any); d["def_id"] != v2ID {
+		t.Errorf("descendant.def_id = %v, want %s", d["def_id"], v2ID)
+	}
+}
+
+func TestContextTool_LineageFromChildShowsAncestor(t *testing.T) {
+	tool, _, ctx, _, v1ID, v2ID := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"lineage","def_id":"`+v2ID+`"}`))
+	out := decodeResult(t, res.Text)
+	anc := out["ancestors"].([]any)
+	if len(anc) != 1 {
+		t.Fatalf("ancestors len = %d, want 1", len(anc))
+	}
+	if a := anc[0].(map[string]any); a["def_id"] != v1ID {
+		t.Errorf("ancestor.def_id = %v, want %s", a["def_id"], v1ID)
+	}
+}
+
+func TestContextTool_LineageMissingDefID(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"lineage"}`))
+	if !res.IsError {
+		t.Fatal("lineage without def_id should refuse")
+	}
+	if !strings.Contains(res.Text, "def_id") {
+		t.Errorf("error should mention def_id; got %q", res.Text)
+	}
+}
+
+func TestContextTool_LineageUnknownDefID(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"lineage","def_id":"def_nope_does_not_exist"}`))
+	if !res.IsError {
+		t.Fatal("lineage for unknown def_id should refuse")
+	}
+	if !strings.Contains(res.Text, "not found") {
+		t.Errorf("error should mention not found; got %q", res.Text)
+	}
+}
+
+func TestContextTool_LineageRefusesWithoutStore(t *testing.T) {
+	tool := &Context{Cfg: &config.Config{}} // no Store
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"lineage","def_id":"x"}`))
+	if !res.IsError {
+		t.Fatal("lineage without Store should refuse")
+	}
+}
+
+// ---- evaluations ----
+
+func TestContextTool_EvaluationsAggregate(t *testing.T) {
+	tool, _, ctx, _, _, v2ID := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"evaluations","def_id":"`+v2ID+`"}`))
+	if res.IsError {
+		t.Fatalf("evaluations: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["def_id"] != v2ID {
+		t.Errorf("def_id = %v, want %s", out["def_id"], v2ID)
+	}
+	if out["count"].(float64) != 1 {
+		t.Errorf("count = %v, want 1", out["count"])
+	}
+	score := out["score"].(map[string]any)
+	if score["mean"].(float64) != 0.8 {
+		t.Errorf("mean = %v, want 0.8", score["mean"])
+	}
+}
+
+func TestContextTool_EvaluationsEmptyDef(t *testing.T) {
+	tool, _, ctx, _, v1ID, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"evaluations","def_id":"`+v1ID+`"}`))
+	if res.IsError {
+		t.Fatalf("evaluations: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["count"].(float64) != 0 {
+		t.Errorf("count = %v, want 0 (no evaluations for v1)", out["count"])
+	}
+}
+
+func TestContextTool_EvaluationsMissingDefID(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"evaluations"}`))
+	if !res.IsError {
+		t.Fatal("evaluations without def_id should refuse")
+	}
+}
+
+func TestContextTool_EvaluationsRefusesWithoutStore(t *testing.T) {
+	tool := &Context{Cfg: &config.Config{}} // no Store
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"evaluations","def_id":"x"}`))
+	if !res.IsError {
+		t.Fatal("evaluations without Store should refuse")
 	}
 }


### PR DESCRIPTION
## Summary
Second of four stacked v0.8.7 PRs. Wires the Context tool to the v0.8.5 substrate (AgentDef + Evaluation stores) so agents can discover their environment's other agents, walk a definition's lineage, and read aggregate scores.

## Stacking
- **Base:** \`feature-context-pr1-self-tools\` (PR #79)
- **PR 3** (next) — channels/history ops + default-add + \`disable_context\` opt-out.
- **PR 4** — runtime smoke at \`test/runtime/context/\`.

## New ops

| op | input | returns |
|---|---|---|
| \`agents\` | \`prefix?\` | list of operator-declared agents (\`name\`, \`tier\`, \`model\`, \`provider\`, \`allowed_tools_count\`, \`active_def_id\` when Store wired). Sorted by name. |
| \`lineage\` | \`def_id\`, \`depth?\` (default 10, cap 100) | \`{root, ancestors[], descendants[]}\` — ancestors via \`parent_def_id\` chain, descendants via \`AgentDefListChildren\` BFS. |
| \`evaluations\` | \`def_id\`, \`include_lineage?\` | the v0.8.5 \`EvaluationAggregate\` output (mean/median/min/max/latest + per-dimension + per-emitter-role breakdowns). |

## Deferred — caller's-default for def_id

The PLAN.md sketch says \`def_id?\` (defaults to caller's). Today \`RunIdentityValue\` doesn't carry \`AgentDefID\`; plumbing that through is a separate small change. For v0.8.7 PR 2 the def_id is required — agents call \`Context.agents\` first to discover their own def_id, then call \`lineage\` / \`evaluations\` explicitly. Follow-up improvement, not a blocker.

## Wiring

\`Context\` struct gains \`Cfg\` (operator config — used by \`agents\` op) + \`Store\` (substrate backend — used by all three ops). \`main.go\`:
- Construct with \`Cfg: cfg\` at registration time.
- Late-bind \`contextTool.Store = storeIface\` alongside the other substrate tools.

## Test plan
- [x] 13 new unit tests covering each op (happy path, prefix filter, active-def-id surfacing, missing-input refusals, no-Cfg/no-Store refusals)
- [x] Per-test unique IDs (\`t.Name()\`-derived suffixes) to avoid the cache=shared sqlite in-memory DB persisting rows across subtests
- [x] \`t.Cleanup\` registered on the fixture's Store so the connection pool drains at test exit — without this, the shared in-memory cache survives Context tests and pollutes the Memory test suite that runs later in the same package
- [x] \`go test ./...\` green
- [x] \`go build ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)