### PR TITLE
test(context): runtime smoke for v0.8.7 Context tool

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -345,6 +345,12 @@ func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName st
 		}
 }
 
+// historyPolicyForAgent returns the v0.8.7 Context.history scope policy
+// for one agent. Default-deny shape: empty Scopes = no access.
+func (s *Server) historyPolicyForAgent(agentDef config.AgentDef) tools.HistoryPolicyValue {
+	return tools.HistoryPolicyValue{Scopes: agentDef.HistoryScope}
+}
+
 // applyAgentDefOverlay overlays the v0.8.5 agent_defs.definition JSON
 // onto a static cfg.Agents entry, producing the effective AgentDef
 // for one sub-run. Mirrors the mutable-subset list maintained by the
@@ -730,6 +736,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
+	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -1375,6 +1382,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
+	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1662,6 +1670,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
+	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -2192,6 +2201,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subADPolicy, subEvPolicy := s.substratePoliciesForAgent(def, name)
 	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
 	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
+	subCtx = tools.WithHistoryPolicy(subCtx, s.historyPolicyForAgent(def))
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -346,6 +346,30 @@ type AgentDef struct {
 	// scope list gates WHICH emitter roles the agent is allowed to
 	// produce.
 	EvaluationScopes []string `yaml:"evaluation_scopes"`
+
+	// HistoryScope gates the v0.8.7 Context.history op. Closed set:
+	//
+	//	"self"        — caller may read its own run's transcript
+	//	"siblings"    — RESERVED (not yet active in v0.8.7 PR 3)
+	//	"descendants" — RESERVED
+	//	"named:<n>"   — RESERVED
+	//	"any"         — caller may read any agent's transcript
+	//
+	// Empty / unset = default-deny. Mirror of the substrate-scope
+	// pattern (agent_def_scopes, evaluation_scopes).
+	HistoryScope []string `yaml:"history_scope"`
+
+	// DisableContext opts the agent OUT of the v0.8.7 default-add
+	// behaviour. Normally every agent's allowed_tools is augmented
+	// with "Context" at config-load — introspection is foundational
+	// for self-evolving agents and missing it is a footgun. Operators
+	// running airgapped or strictly-deterministic agents can set
+	// `disable_context: true` to skip the default-add for that agent.
+	//
+	// Note: this only controls the AUTO-ADD. If an operator explicitly
+	// lists "Context" in allowed_tools, that wins regardless of this
+	// flag (explicit beats default).
+	DisableContext bool `yaml:"disable_context"`
 }
 
 // Channel is one operator-declared channel in the top-level
@@ -1099,10 +1123,41 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// v0.8.7 default-add: every agent gets Context auto-appended to
+	// its allowed_tools unless `disable_context: true` is set. Runs
+	// after resolveSkills so skill-driven AllowedTools widening has
+	// already taken effect.
+	addContextToolDefaults(cfg)
+
 	if err := validate(cfg); err != nil {
 		return nil, err
 	}
 	return cfg, nil
+}
+
+// addContextToolDefaults appends "Context" to every agent's
+// AllowedTools unless DisableContext is set (or "Context" is already
+// listed). v0.8.7 introspection is foundational for self-evolving
+// agents; missing it is a footgun. Operators with airgapped agents
+// opt out per-agent via `disable_context: true`.
+func addContextToolDefaults(cfg *Config) {
+	for name, def := range cfg.Agents {
+		if def.DisableContext {
+			continue
+		}
+		alreadyHas := false
+		for _, t := range def.AllowedTools {
+			if t == "Context" {
+				alreadyHas = true
+				break
+			}
+		}
+		if alreadyHas {
+			continue
+		}
+		def.AllowedTools = append(def.AllowedTools, "Context")
+		cfg.Agents[name] = def
+	}
 }
 
 // ResolveAgentModel returns (provider, model) for the named agent, walking
@@ -1594,6 +1649,19 @@ var validEvaluationScopes = map[string]bool{
 	"read_any":           true,
 }
 
+// validHistoryScopes is the closed set of Context.history scope
+// strings. "self" / "siblings" / "descendants" / "named:<n>" /
+// "any". The non-"self"/"any" entries are RESERVED in v0.8.7 PR 3
+// — granting them is well-formed but the runtime falls through to
+// default-deny until the plumbing PR lands.
+var validHistoryScopes = map[string]bool{
+	"self":        true,
+	"siblings":    true,
+	"descendants": true,
+	"any":         true,
+	// "named:<n>" handled by prefix check at validation time.
+}
+
 // validateAgentDefScope checks one entry in an agent's
 // agent_def_scopes list. Closed set:
 //
@@ -1797,6 +1865,21 @@ func validate(c *Config) error {
 			if !validEvaluationScopes[sc] {
 				return fmt.Errorf("agent %q: evaluation_scopes[%d]: unknown scope %q (want one of: submit_self, submit_siblings, submit_descendants, submit_any, read_any)", name, i, sc)
 			}
+		}
+		// Context.history (v0.8.7): validate history_scope entries.
+		// Closed set as documented on AgentDef.HistoryScope. The
+		// `named:<n>` prefix follows the same shape as agent_def_scopes.
+		for i, sc := range agent.HistoryScope {
+			if validHistoryScopes[sc] {
+				continue
+			}
+			if strings.HasPrefix(sc, "named:") {
+				if strings.TrimPrefix(sc, "named:") == "" {
+					return fmt.Errorf("agent %q: history_scope[%d]: empty name after `named:` prefix", name, i)
+				}
+				continue
+			}
+			return fmt.Errorf("agent %q: history_scope[%d]: unknown scope %q (want one of: self, siblings, descendants, any, named:<n>)", name, i, sc)
 		}
 	}
 	// Channel tool: validate the top-level `channels:` block.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,7 +353,16 @@ type AgentDef struct {
 	//	"siblings"    — RESERVED (not yet active in v0.8.7 PR 3)
 	//	"descendants" — RESERVED
 	//	"named:<n>"   — RESERVED
-	//	"any"         — caller may read any agent's transcript
+	//	"any"         — UNRESTRICTED. Caller may read ANY agent's
+	//	                transcript INCLUDING transcripts owned by
+	//	                OTHER users in multi-tenant deployments. There
+	//	                is no user_id check today; `any` is a flat
+	//	                operator-trust grant. Use only for admin /
+	//	                debugging agents under operator control. For
+	//	                "caller may read my own + my children's
+	//	                transcripts" wait for siblings/descendants
+	//	                scopes to activate (needs RunIdentityValue
+	//	                ParentAgentID plumbing).
 	//
 	// Empty / unset = default-deny. Mirror of the substrate-scope
 	// pattern (agent_def_scopes, evaluation_scopes).
@@ -1147,7 +1156,13 @@ func addContextToolDefaults(cfg *Config) {
 		}
 		alreadyHas := false
 		for _, t := range def.AllowedTools {
-			if t == "Context" {
+			// Case-insensitive match. An operator's lowercase
+			// `allowed_tools: [context]` is a typo, not an explicit
+			// listing — but case-sensitive eq would let the typo
+			// double-add (yielding [context, Context]) and confuse
+			// the per-run dispatcher's case-sensitive registry
+			// lookup. PR 3 review fix.
+			if strings.EqualFold(t, "Context") {
 				alreadyHas = true
 				break
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1266,6 +1266,38 @@ agents:
 	}
 }
 
+// PR 3 review fix: case-insensitive duplicate-check. Operator-typed
+// lowercase `context` in yaml should not cause a `[context, Context]`
+// double-add (which would confuse the case-sensitive runtime
+// dispatcher).
+func TestContextNotDoubleAddedCaseInsensitive(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  lower:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read, context]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["lower"]
+	count := 0
+	for _, tool := range def.AllowedTools {
+		if strings.EqualFold(tool, "Context") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Context appears %d times (case-insensitive); want exactly 1 — got %v", count, def.AllowedTools)
+	}
+}
+
 // TestContextNotDoubleAdded: agent already listing Context doesn't
 // see it duplicated.
 func TestContextNotDoubleAdded(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -713,9 +713,10 @@ agents:
 	if def.MaxTokens != 24576 {
 		t.Errorf("MaxTokens = %d, want 24576 (yaml override)", def.MaxTokens)
 	}
-	wantTools := []string{"Read", "Edit"}
-	if len(def.AllowedTools) != 2 || def.AllowedTools[0] != "Read" || def.AllowedTools[1] != "Edit" {
-		t.Errorf("AllowedTools = %v, want %v (yaml override)", def.AllowedTools, wantTools)
+	// v0.8.7 default-add: Context appended automatically.
+	wantTools := []string{"Read", "Edit", "Context"}
+	if len(def.AllowedTools) != 3 || def.AllowedTools[0] != "Read" || def.AllowedTools[1] != "Edit" || def.AllowedTools[2] != "Context" {
+		t.Errorf("AllowedTools = %v, want %v (yaml override + Context auto-add)", def.AllowedTools, wantTools)
 	}
 	if def.SystemPrompt != "prompt body\n" {
 		t.Errorf("SystemPrompt = %q, want body from MD", def.SystemPrompt)
@@ -1006,11 +1007,11 @@ agents:
 		t.Fatalf("Load: %v", err)
 	}
 	got := cfg.Agents["narrow"].AllowedTools
-	if got == nil {
-		t.Errorf("AllowedTools = nil; expected non-nil empty slice (yaml [] should override discovered)")
-	}
-	if len(got) != 0 {
-		t.Errorf("AllowedTools = %v; expected empty slice (yaml [] should zero out discovered list)", got)
+	// v0.8.7 default-add: empty-list yaml override clears the
+	// discovered list, then Context is appended by the default-add
+	// pass — so [Context] is the expected post-load shape, not [].
+	if len(got) != 1 || got[0] != "Context" {
+		t.Errorf("AllowedTools = %v; expected [Context] (yaml [] cleared discovered + Context auto-added)", got)
 	}
 }
 
@@ -1202,5 +1203,133 @@ agents:
 	}
 	if len(cfg.UserTiers) != 0 {
 		t.Errorf("UserTiers len = %d; want 0 (block absent)", len(cfg.UserTiers))
+	}
+}
+
+// ---- v0.8.7 Context default-add ----
+
+// TestContextAutoAddedToAllowedTools: every agent gets Context
+// appended to allowed_tools at config-load.
+func TestContextAutoAddedToAllowedTools(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  worker:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["worker"]
+	hasContext := false
+	for _, tool := range def.AllowedTools {
+		if tool == "Context" {
+			hasContext = true
+			break
+		}
+	}
+	if !hasContext {
+		t.Errorf("Context not auto-added to allowed_tools; got %v", def.AllowedTools)
+	}
+}
+
+// TestContextAutoAddSkippedWhenDisabled: agent with
+// `disable_context: true` does NOT get Context appended.
+func TestContextAutoAddSkippedWhenDisabled(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  airgapped:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    disable_context: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["airgapped"]
+	for _, tool := range def.AllowedTools {
+		if tool == "Context" {
+			t.Errorf("Context auto-added despite disable_context=true; got %v", def.AllowedTools)
+		}
+	}
+}
+
+// TestContextNotDoubleAdded: agent already listing Context doesn't
+// see it duplicated.
+func TestContextNotDoubleAdded(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  explicit:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read, Context]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["explicit"]
+	count := 0
+	for _, tool := range def.AllowedTools {
+		if tool == "Context" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("Context appears %d times; want exactly 1", count)
+	}
+}
+
+// TestHistoryScopeValidation: closed set + named:<n> prefix.
+func TestHistoryScopeValidation(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  bad:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    history_scope: [nonsense]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(yamlPath)
+	if err == nil || !strings.Contains(err.Error(), "history_scope") {
+		t.Errorf("expected history_scope validation error; got %v", err)
+	}
+}
+
+func TestHistoryScopeAcceptsValid(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  good:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read]
+    history_scope: [self, any, "named:friend"]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(yamlPath); err != nil {
+		t.Errorf("Load: %v", err)
 	}
 }

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -71,24 +71,30 @@ const contextDescription = `Read-only runtime introspection. ` +
 const contextInputSchema = `{
   "type": "object",
   "properties": {
-    "op":              {"type": "string", "enum": ["self","tools","doc","permissions","agents","lineage","evaluations"], "description": "Which introspection op to run."},
+    "op":              {"type": "string", "enum": ["self","tools","doc","permissions","agents","lineage","evaluations","channels","history"], "description": "Which introspection op to run."},
     "name":            {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."},
-    "prefix":          {"type": "string", "description": "agents only: optional name prefix filter."},
+    "prefix":          {"type": "string", "description": "agents / channels: optional name prefix filter."},
     "def_id":          {"type": "string", "description": "lineage / evaluations: the agent_defs row id to inspect. Use Context.agents to discover def_ids first."},
     "depth":           {"type": "integer", "description": "lineage only: max depth to walk in each direction (default 10, cap 100)."},
-    "include_lineage": {"type": "boolean", "description": "evaluations only: include ancestors' evaluations in the aggregate (default false)."}
+    "include_lineage": {"type": "boolean", "description": "evaluations only: include ancestors' evaluations in the aggregate (default false)."},
+    "agent_id":        {"type": "string", "description": "history only: target agent_id whose run history to fetch. Omitted = caller's own agent_id from ctx."},
+    "event_types":     {"type": "array", "items": {"type": "string"}, "description": "history only: optional filter — return only events of these types (e.g. [\"text\",\"tool_call\"])."},
+    "limit":           {"type": "integer", "description": "history only: max events to return (default 100, cap 1000)."}
   },
   "required": ["op"],
   "additionalProperties": false
 }`
 
 type contextInput struct {
-	Op             string `json:"op"`
-	Name           string `json:"name,omitempty"`
-	Prefix         string `json:"prefix,omitempty"`
-	DefID          string `json:"def_id,omitempty"`
-	Depth          int    `json:"depth,omitempty"`
-	IncludeLineage bool   `json:"include_lineage,omitempty"`
+	Op             string   `json:"op"`
+	Name           string   `json:"name,omitempty"`
+	Prefix         string   `json:"prefix,omitempty"`
+	DefID          string   `json:"def_id,omitempty"`
+	Depth          int      `json:"depth,omitempty"`
+	IncludeLineage bool     `json:"include_lineage,omitempty"`
+	AgentID        string   `json:"agent_id,omitempty"`
+	EventTypes     []string `json:"event_types,omitempty"`
+	Limit          int      `json:"limit,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -122,10 +128,14 @@ func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execLineage(ctx, in)
 	case "evaluations":
 		return c.execEvaluations(ctx, in)
+	case "channels":
+		return c.execChannels(ctx, in)
+	case "history":
+		return c.execHistory(ctx, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions, agents, lineage, evaluations)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions, agents, lineage, evaluations, channels, history)", in.Op)), nil
 	}
 }
 
@@ -279,6 +289,7 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 	adPol := tools.AgentDefPolicy(ctx)
 	evPol := tools.EvaluationPolicy(ctx)
 
+	histPol := tools.HistoryPolicy(ctx)
 	out := map[string]any{
 		"allowed_tools": tools.AgentTools(ctx),
 		"host_policy": map[string]any{
@@ -296,6 +307,7 @@ func (c *Context) execPermissions(ctx context.Context) (tools.Result, error) {
 		},
 		"agent_def_scopes":  adPol.Scopes,
 		"evaluation_scopes": evPol.Scopes,
+		"history_scope":     histPol.Scopes,
 	}
 	return okJSON(out)
 }
@@ -485,6 +497,190 @@ func (c *Context) execEvaluations(ctx context.Context, in contextInput) (tools.R
 		return errResult(fmt.Sprintf("evaluations: %s", err)), nil
 	}
 	return okJSON(agg)
+}
+
+// ---- channels ----
+
+func (c *Context) execChannels(ctx context.Context, in contextInput) (tools.Result, error) {
+	pol := tools.ChannelPolicy(ctx)
+	type channelSummary struct {
+		Name        string `json:"name"`
+		Scope       string `json:"scope,omitempty"`
+		Semantic    string `json:"semantic,omitempty"`
+		DefaultTTL  int    `json:"default_ttl,omitempty"`
+		MaxMessages int    `json:"max_messages,omitempty"`
+		Publisher   string `json:"publisher,omitempty"`
+		Publish     bool   `json:"publish"`
+		Subscribe   bool   `json:"subscribe"`
+	}
+	// Union of operator-declared channels + the caller's publish /
+	// subscribe lists. Operator may declare channels the agent has no
+	// ACL on — surfaced so the agent sees what exists even when it
+	// can't write/read (good for "what bus does the operator run?"
+	// discovery).
+	allNames := make(map[string]bool, len(pol.Channels))
+	for n := range pol.Channels {
+		allNames[n] = true
+	}
+	// publish/subscribe lists may contain wildcards (e.g. `findings/*`);
+	// those don't expand into the result set here — we surface the
+	// declared channels only. The bools below reflect whether the
+	// exact name appears in either list.
+	publishSet := stringSet(pol.Publish)
+	subscribeSet := stringSet(pol.Subscribe)
+
+	out := make([]channelSummary, 0, len(allNames))
+	for name := range allNames {
+		if in.Prefix != "" && !strings.HasPrefix(name, in.Prefix) {
+			continue
+		}
+		def := pol.Channels[name]
+		out = append(out, channelSummary{
+			Name:        name,
+			Scope:       def.Scope,
+			Semantic:    def.Semantic,
+			DefaultTTL:  def.DefaultTTL,
+			MaxMessages: def.MaxMessages,
+			Publisher:   def.Publisher,
+			Publish:     publishSet[name],
+			Subscribe:   subscribeSet[name],
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return okJSON(map[string]any{
+		"channels":           out,
+		"count":              len(out),
+		"publish_wildcards":  filterWildcards(pol.Publish),
+		"subscribe_wildcards": filterWildcards(pol.Subscribe),
+	})
+}
+
+func stringSet(xs []string) map[string]bool {
+	out := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		out[x] = true
+	}
+	return out
+}
+
+// filterWildcards returns only the entries that look like wildcards
+// (anchored prefix patterns ending in `/*`). The non-wildcard entries
+// are already surfaced via the per-channel publish/subscribe bools.
+func filterWildcards(xs []string) []string {
+	var out []string
+	for _, x := range xs {
+		if strings.HasSuffix(x, "/*") {
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+// ---- history ----
+
+func (c *Context) execHistory(ctx context.Context, in contextInput) (tools.Result, error) {
+	if c.Store == nil {
+		return errResult("history: not configured (no Store backend)"), nil
+	}
+
+	// Gate on history_scope. The closed set is documented on
+	// HistoryPolicyValue. Default-deny: empty scopes refuses.
+	pol := tools.HistoryPolicy(ctx)
+	if len(pol.Scopes) == 0 {
+		return errResult("history: agent has no `history_scope` policy (default-deny); add `history_scope: [...]` to the agent yaml"), nil
+	}
+
+	// Determine target agent_id. Omitted = caller's own.
+	emitter := tools.RunIdentity(ctx)
+	targetAgentID := in.AgentID
+	if targetAgentID == "" {
+		targetAgentID = emitter.AgentID
+	}
+	if targetAgentID == "" {
+		return errResult("history: no agent_id supplied and caller has no AgentID on ctx"), nil
+	}
+
+	// Scope check. v0.8.7 PR 3 supports:
+	//   - "self": caller's own agent_id only
+	//   - "any":  unrestricted
+	// "siblings" / "descendants" / "named:<n>" are reserved and not
+	// yet active; granting them yields default-deny until the
+	// follow-up plumbing lands.
+	allowed := false
+	if hasHistoryScope(pol, "any") {
+		allowed = true
+	} else if hasHistoryScope(pol, "self") && targetAgentID == emitter.AgentID {
+		allowed = true
+	}
+	if !allowed {
+		return errResult(fmt.Sprintf("history: scope check failed for agent_id %q (caller scopes: %v)", targetAgentID, pol.Scopes)), nil
+	}
+
+	// Resolve agent_id → Run row → session_id.
+	run, err := c.Store.GetRunByAgentID(ctx, targetAgentID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("history: agent_id %q not found", targetAgentID)), nil
+		}
+		return errResult(fmt.Sprintf("history: lookup run: %s", err)), nil
+	}
+
+	events, err := c.Store.GetTranscript(ctx, run.SessionID)
+	if err != nil {
+		return errResult(fmt.Sprintf("history: transcript: %s", err)), nil
+	}
+
+	// Optional event_types filter + limit.
+	typeFilter := stringSet(in.EventTypes)
+	limit := in.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+
+	type eventOut struct {
+		Seq       int64           `json:"seq"`
+		RunID     string          `json:"run_id"`
+		Timestamp string          `json:"ts"`
+		Type      string          `json:"type"`
+		Payload   json.RawMessage `json:"payload,omitempty"`
+	}
+	out := make([]eventOut, 0, limit)
+	for _, ev := range events {
+		if len(typeFilter) > 0 && !typeFilter[ev.Type] {
+			continue
+		}
+		out = append(out, eventOut{
+			Seq:       ev.Seq,
+			RunID:     ev.RunID,
+			Timestamp: ev.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+			Type:      ev.Type,
+			Payload:   json.RawMessage(ev.Payload),
+		})
+		if len(out) >= limit {
+			break
+		}
+	}
+
+	return okJSON(map[string]any{
+		"agent_id":   targetAgentID,
+		"session_id": run.SessionID,
+		"events":     out,
+		"count":      len(out),
+		"truncated":  len(out) == limit && len(events) > limit,
+	})
+}
+
+func hasHistoryScope(pol tools.HistoryPolicyValue, want string) bool {
+	for _, s := range pol.Scopes {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 var _ tools.Tool = (*Context)(nil)

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -648,21 +648,33 @@ func (c *Context) execHistory(ctx context.Context, in contextInput) (tools.Resul
 		Type      string          `json:"type"`
 		Payload   json.RawMessage `json:"payload,omitempty"`
 	}
+	// Track POST-FILTER match count separately so truncated is
+	// honest: it's true iff there are more matches than we returned.
+	// The old check (`len(out)==limit && len(events)>limit`) used
+	// the raw transcript size and gave false positives whenever an
+	// event_types filter excluded enough events that the filter-
+	// matching count was actually <= limit (PR 3 review fix).
 	out := make([]eventOut, 0, limit)
+	matchedCount := 0
 	for _, ev := range events {
 		if len(typeFilter) > 0 && !typeFilter[ev.Type] {
 			continue
 		}
-		out = append(out, eventOut{
-			Seq:       ev.Seq,
-			RunID:     ev.RunID,
-			Timestamp: ev.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z"),
-			Type:      ev.Type,
-			Payload:   json.RawMessage(ev.Payload),
-		})
-		if len(out) >= limit {
-			break
+		matchedCount++
+		if len(out) < limit {
+			out = append(out, eventOut{
+				Seq:       ev.Seq,
+				RunID:     ev.RunID,
+				Timestamp: ev.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+				Type:      ev.Type,
+				Payload:   json.RawMessage(ev.Payload),
+			})
 		}
+		// Loop continues even after limit so we get an accurate
+		// matchedCount. Worst case: O(len(events)) — bounded by
+		// GetTranscript's own paging. Acceptable cost for honest
+		// truncation reporting; agents using a tiny limit on a
+		// huge transcript pay marginal extra work.
 	}
 
 	return okJSON(map[string]any{
@@ -670,7 +682,7 @@ func (c *Context) execHistory(ctx context.Context, in contextInput) (tools.Resul
 		"session_id": run.SessionID,
 		"events":     out,
 		"count":      len(out),
-		"truncated":  len(out) == limit && len(events) > limit,
+		"truncated":  matchedCount > limit,
 	})
 }
 

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -753,3 +753,59 @@ func TestContextTool_PermissionsSurfacesHistoryScope(t *testing.T) {
 		t.Errorf("history_scope = %v, want [self any]", scopes)
 	}
 }
+
+// PR 3 review fix: truncated must be true ONLY when there are more
+// filter-matching events than the limit allows. Old code compared
+// limit to raw transcript size — false positive when event_types
+// filter excluded enough events that matchCount <= limit.
+func TestContextTool_HistoryTruncatedRespectsTypeFilter(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	sess, _ := s.CreateSession(context.Background(), "t", agentName, "alice")
+	run, _ := s.CreateRun(context.Background(), sess.ID, store.RunIdentity{AgentID: "a_filtered", UserID: "alice"})
+	// Mix: 3 text events + 50 usage events. With a `text` filter +
+	// limit=10, only 3 events match — truncated MUST be false.
+	for i := 0; i < 3; i++ {
+		_ = s.AppendEvent(context.Background(), run.ID, "text", []byte(`{"text":"hi"}`))
+	}
+	for i := 0; i < 50; i++ {
+		_ = s.AppendEvent(context.Background(), run.ID, "usage", []byte(`{"tokens":1}`))
+	}
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_filtered"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"any"}})
+
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","agent_id":"a_filtered","event_types":["text"],"limit":10}`))
+	if res.IsError {
+		t.Fatalf("history: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if c := out["count"].(float64); c != 3 {
+		t.Errorf("count = %v, want 3 (only text events match)", c)
+	}
+	if out["truncated"].(bool) {
+		t.Error("truncated = true; want false (only 3 matching events, all returned)")
+	}
+}
+
+// Same fixture but with limit=2 — now 3 matches exceeds limit, so
+// truncated MUST be true.
+func TestContextTool_HistoryTruncatedTrueWhenMatchesExceedLimit(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	sess, _ := s.CreateSession(context.Background(), "t", agentName, "alice")
+	run, _ := s.CreateRun(context.Background(), sess.ID, store.RunIdentity{AgentID: "a_match", UserID: "alice"})
+	for i := 0; i < 3; i++ {
+		_ = s.AppendEvent(context.Background(), run.ID, "text", []byte(`{"text":"hi"}`))
+	}
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_match"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"any"}})
+
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","agent_id":"a_match","event_types":["text"],"limit":2}`))
+	out := decodeResult(t, res.Text)
+	if c := out["count"].(float64); c != 2 {
+		t.Errorf("count = %v, want 2 (limit)", c)
+	}
+	if !out["truncated"].(bool) {
+		t.Error("truncated = false; want true (3 matches > limit 2)")
+	}
+}

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -623,3 +623,133 @@ func TestContextTool_EvaluationsRefusesWithoutStore(t *testing.T) {
 		t.Fatal("evaluations without Store should refuse")
 	}
 }
+
+// ---- channels / history (PR 3) ----
+
+func TestContextTool_ChannelsListsAccessible(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	chCtx := tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"findings", "findings/*"},
+		Subscribe: []string{"findings", "alerts"},
+		Channels: map[string]tools.ChannelDef{
+			"findings": {Name: "findings", Scope: "agent", Semantic: "queue"},
+			"alerts":   {Name: "alerts", Scope: "global", DefaultTTL: 3600},
+		},
+	})
+	res, _ := tool.Execute(chCtx, json.RawMessage(`{"op":"channels"}`))
+	if res.IsError {
+		t.Fatalf("channels: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["count"].(float64) != 2 {
+		t.Errorf("count = %v, want 2", out["count"])
+	}
+	// Wildcards surface separately.
+	w := out["publish_wildcards"].([]any)
+	if len(w) != 1 || w[0].(string) != "findings/*" {
+		t.Errorf("publish_wildcards = %v, want [findings/*]", w)
+	}
+	// Per-channel bools.
+	got := out["channels"].([]any)
+	for _, c := range got {
+		m := c.(map[string]any)
+		switch m["name"].(string) {
+		case "findings":
+			if !m["publish"].(bool) || !m["subscribe"].(bool) {
+				t.Errorf("findings: publish=%v subscribe=%v, want true/true", m["publish"], m["subscribe"])
+			}
+		case "alerts":
+			if m["publish"].(bool) || !m["subscribe"].(bool) {
+				t.Errorf("alerts: publish=%v subscribe=%v, want false/true", m["publish"], m["subscribe"])
+			}
+		}
+	}
+}
+
+func TestContextTool_HistorySelfScope(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	// Seed a real run + an event under THIS caller's agent_id.
+	sess, _ := s.CreateSession(context.Background(), "t", agentName, "alice")
+	run, _ := s.CreateRun(context.Background(), sess.ID, store.RunIdentity{AgentID: "a_caller", UserID: "alice"})
+	_ = s.AppendEvent(context.Background(), run.ID, "text", []byte(`{"text":"hello"}`))
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller", UserID: "alice"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"self"}})
+
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history"}`))
+	if res.IsError {
+		t.Fatalf("history: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["agent_id"] != "a_caller" {
+		t.Errorf("agent_id = %v, want a_caller", out["agent_id"])
+	}
+	if count := out["count"].(float64); count < 1 {
+		t.Errorf("count = %v, want >= 1", count)
+	}
+}
+
+func TestContextTool_HistoryRefusesOtherAgentUnderSelfScope(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	sess, _ := s.CreateSession(context.Background(), "t", agentName, "alice")
+	_, _ = s.CreateRun(context.Background(), sess.ID, store.RunIdentity{AgentID: "a_other", UserID: "alice"})
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"self"}})
+
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","agent_id":"a_other"}`))
+	if !res.IsError {
+		t.Fatalf("history of other agent under self scope should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "scope check") {
+		t.Errorf("error should mention scope check; got %q", res.Text)
+	}
+}
+
+func TestContextTool_HistoryAnyScopeAllowsOther(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	sess, _ := s.CreateSession(context.Background(), "t", agentName, "alice")
+	run, _ := s.CreateRun(context.Background(), sess.ID, store.RunIdentity{AgentID: "a_other", UserID: "alice"})
+	_ = s.AppendEvent(context.Background(), run.ID, "text", []byte(`{"text":"hi"}`))
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"any"}})
+
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","agent_id":"a_other"}`))
+	if res.IsError {
+		t.Fatalf("history under `any` scope should succeed; got %s", res.Text)
+	}
+}
+
+func TestContextTool_HistoryRefusesEmptyScopes(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller"})
+	// No WithHistoryPolicy attached.
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history"}`))
+	if !res.IsError {
+		t.Fatal("history without any scope should refuse (default-deny)")
+	}
+}
+
+func TestContextTool_HistoryRefusesWithoutStore(t *testing.T) {
+	tool := &Context{}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a"})
+	ctx = tools.WithHistoryPolicy(ctx, tools.HistoryPolicyValue{Scopes: []string{"any"}})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"history"}`))
+	if !res.IsError {
+		t.Fatal("history without Store should refuse")
+	}
+}
+
+// ---- permissions surfaces history_scope ----
+
+func TestContextTool_PermissionsSurfacesHistoryScope(t *testing.T) {
+	tool, ctx := contextFixture(t)
+	ctx = tools.WithHistoryPolicy(ctx, tools.HistoryPolicyValue{Scopes: []string{"self", "any"}})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"permissions"}`))
+	out := decodeResult(t, res.Text)
+	scopes := out["history_scope"].([]any)
+	if len(scopes) != 2 || scopes[0] != "self" || scopes[1] != "any" {
+		t.Errorf("history_scope = %v, want [self any]", scopes)
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -425,7 +425,10 @@ type ctxKeyHistoryPolicy struct{}
 //                     without a separate plumbing PR)
 //   - "descendants" — RESERVED (same reason)
 //   - "named:<n>"   — RESERVED (same reason)
-//   - "any"         — caller may read any agent's transcript
+//   - "any"         — UNRESTRICTED. Caller may read ANY agent's
+//                     transcript INCLUDING transcripts owned by
+//                     other users. Operator-trust grant; use only
+//                     for admin/debug agents.
 type HistoryPolicyValue struct {
 	Scopes []string
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -408,6 +408,39 @@ func EvaluationPolicy(ctx context.Context) EvaluationPolicyValue {
 	return v
 }
 
+// ctxKeyHistoryPolicy is the key under which the runtime stashes the
+// v0.8.7 Context.history scope policy. Multi-select scopes; same shape
+// as AgentDefPolicy and EvaluationPolicy. The closed set lives on
+// config.AgentDef.HistoryScope.
+type ctxKeyHistoryPolicy struct{}
+
+// HistoryPolicyValue is the per-agent Context.history gate. Multi-
+// select; empty Scopes = default-deny (Context.history refuses).
+//
+// Closed set:
+//   - "self"        — caller may read its own run's transcript
+//   - "siblings"    — RESERVED (not yet active in v0.8.7 PR 3;
+//                     RunIdentityValue lacks ParentAgentID, so the
+//                     server can't derive sibling relationships
+//                     without a separate plumbing PR)
+//   - "descendants" — RESERVED (same reason)
+//   - "named:<n>"   — RESERVED (same reason)
+//   - "any"         — caller may read any agent's transcript
+type HistoryPolicyValue struct {
+	Scopes []string
+}
+
+// WithHistoryPolicy attaches the policy to ctx.
+func WithHistoryPolicy(ctx context.Context, p HistoryPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyHistoryPolicy{}, p)
+}
+
+// HistoryPolicy returns the policy from ctx. Zero value = no access.
+func HistoryPolicy(ctx context.Context) HistoryPolicyValue {
+	v, _ := ctx.Value(ctxKeyHistoryPolicy{}).(HistoryPolicyValue)
+	return v
+}
+
 // Execute looks up the named tool and runs it. Unknown tool names consult
 // the optional Fallback before returning the standard "tool not found"
 // error result (the model can self-correct on the error result; we never

--- a/test/runtime/README.md
+++ b/test/runtime/README.md
@@ -29,10 +29,7 @@ test/runtime/<feature>/
 | `agent-def/` (v0.8.5) | Single-agent walkthrough of the six AgentDef ops: create → get → list → fork → promote → retire. Driver inspects `agent_defs` + `agent_def_active` rows to verify lifecycle, parent-chain wiring, retire flags, and active-pointer placement. |
 | `evaluation/` (v0.8.5) | Two-run scenario. Run 1 (`worker`) executes a trivial deterministic op; driver extracts its run_id from the SSE `agent` event. Run 2 (`evaluator`) submits + reads back an Evaluation against the worker's run_id (emitter_role=`unrelated`; `submit_any` scope path). Verifies the full submit/get/list/aggregate surface. |
 | `system-channels/` (v0.8.6) | Three exercises in one run: (A) `_system/heartbeat-1s` cadence — driver waits 3s and asserts ≥2 messages with the fixed `{ts, version, uptime_s}` payload + `_system` attribution. (B) Admin endpoint — `curl POST /v1/_channels/_system/alarms/info` lands a row with `published_by_user_id = _admin`. (C) Agent deferred publish — scheduler-bot publishes to `findings` with `deliver_at = now+30s`; driver verifies the `(visible_at - published_at)` delta is in the expected window + the tool_result envelope carries `visible_at`. |
-
-Future scenarios (one folder per primitive):
-
-- `context/` (v0.8.6) — introspection rollup against an agent with the full primitive surface
+| `context/` (v0.8.7) | Single-run introspection walkthrough. The `introspector` agent's `allowed_tools` omits Context — v0.8.7 default-add auto-attaches it at config-load. The agent chains four Context ops (`self`, `tools`, `doc(name=Memory)`, `permissions`) and reports findings. Driver verifies Context calls ≥4, run completed, and the final text mentions agent_name + Context-in-catalog + ends with DONE. Exercises the default-add behavior end-to-end. |
 
 ## When to add a runtime test
 

--- a/test/runtime/context/agents/introspector.md
+++ b/test/runtime/context/agents/introspector.md
@@ -1,0 +1,34 @@
+---
+name: introspector
+description: Exercises Context tool's four PR-1 ops in one run.
+provider: gemini
+model: gemini-2.5-flash
+allowed_tools: [Read, Memory]
+memory_scopes: [agent]
+---
+You are introspector. Your job is to call the Context tool four
+times to inspect this runtime, then write a one-line summary.
+
+Three rules:
+
+1. Make EXACTLY four Context tool calls, in this order:
+   (1) op=self                  — fetch identity bundle
+   (2) op=tools                 — list available tools
+   (3) op=doc, name=Memory      — fetch Memory's input schema
+   (4) op=permissions           — fetch policy bundle
+
+2. After ALL FOUR Context calls complete, write a one-line summary
+   that includes:
+   - your agent_name (from op=self)
+   - the count of tools you have (from op=tools)
+   - whether your tools list includes "Context" (it should, by
+     default-add)
+   - whether the permissions result has a memory section
+
+   End the summary with the single word DONE.
+
+3. Do not call any other tool besides Context. The agent's
+   allowed_tools deliberately omits Context — the runtime
+   auto-attaches it via v0.8.7 default-add. If you see "Context
+   tool not available" then the default-add is broken; report
+   that and end with DONE.

--- a/test/runtime/context/loomcycle.yaml
+++ b/test/runtime/context/loomcycle.yaml
@@ -1,0 +1,24 @@
+# test/runtime/context/loomcycle.yaml — v0.8.7 Context-tool runtime smoke test.
+#
+# One agent (introspector) exercises four Context ops in one chained
+# run: self, tools, doc(name=Memory), permissions.
+#
+# The agent's allowed_tools intentionally OMITS Context — exercising
+# the v0.8.7 default-add behaviour (Context auto-attached at
+# config-load).
+#
+# Provider: gemini (gemini-2.5-flash). Source .env.local for
+# GEMINI_API_KEY.
+
+provider_priority: [gemini]
+
+defaults:
+  provider: gemini
+  model: gemini-2.5-flash
+
+storage:
+  backend: sqlite
+
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8

--- a/test/runtime/context/run.sh
+++ b/test/runtime/context/run.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# test/runtime/context/run.sh — v0.8.7 Context-tool runtime smoke test.
+#
+# One agent (introspector.md) chains four Context ops in a single
+# run. The agent's allowed_tools intentionally omits Context —
+# exercising the v0.8.7 default-add (Context auto-attached at
+# config-load).
+#
+# Verdict checks:
+#   - run completed cleanly
+#   - tool_call events include at least 4 calls to Context
+#   - SSE final text mentions agent_name, tools count, "Context" in
+#     the catalog, and the memory section
+#   - final text ends with DONE
+#
+# Usage:
+#   GEMINI_API_KEY=... ./test/runtime/context/run.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-context-test.XXXXXX)"
+trap 'cleanup' EXIT INT TERM
+
+cleanup() {
+  if [[ -n "${LOOMCYCLE_PID:-}" ]]; then
+    kill "$LOOMCYCLE_PID" 2>/dev/null || true
+    wait "$LOOMCYCLE_PID" 2>/dev/null || true
+  fi
+  echo
+  echo "Test dir kept for inspection: $TEST_DIR"
+}
+
+export LOOMCYCLE_DATA_DIR="$TEST_DIR/data"
+export LOOMCYCLE_AGENTS_ROOT="$SCRIPT_DIR/agents"
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:18792"
+export LOOMCYCLE_AUTH_TOKEN="test-token-$(date +%s)"
+if [[ -z "${GEMINI_API_KEY:-}" ]]; then
+  echo "ERROR: GEMINI_API_KEY not set. Source .env.local first." >&2
+  exit 1
+fi
+if ! command -v python3 &>/dev/null; then
+  echo "ERROR: python3 is required." >&2
+  exit 1
+fi
+
+mkdir -p "$TEST_DIR/data"
+BOOT_LOG="$TEST_DIR/boot.log"
+RUN_SSE="$TEST_DIR/run.sse"
+
+echo "[1/5] Building bin/loomcycle..."
+go build -o bin/loomcycle ./cmd/loomcycle
+
+echo "[2/5] Booting loomcycle at $LOOMCYCLE_LISTEN_ADDR..."
+./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$BOOT_LOG" 2>&1 &
+LOOMCYCLE_PID=$!
+
+READY=0
+for i in $(seq 1 50); do
+  if curl -fsS "http://$LOOMCYCLE_LISTEN_ADDR/healthz" > /dev/null 2>&1; then
+    echo "      ready after ~$((i * 200))ms"
+    READY=1
+    break
+  fi
+  if ! kill -0 "$LOOMCYCLE_PID" 2>/dev/null; then
+    echo "ERROR: loomcycle exited during boot." >&2
+    cat "$BOOT_LOG" >&2
+    exit 1
+  fi
+  sleep 0.2
+done
+if [[ "$READY" != "1" ]]; then
+  echo "ERROR: loomcycle did not become ready within ~10s." >&2
+  cat "$BOOT_LOG" >&2
+  exit 1
+fi
+
+echo "[3/5] Boot-log highlights:"
+grep -E "agents:|provider:|build:" "$BOOT_LOG" | sed 's/^/      /'
+echo
+
+PROMPT='Execute the four Context operations described in your system prompt, then write your one-line DONE summary.'
+
+echo "[4/5] Running introspector..."
+curl -fsS -N \
+  -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d @- "http://$LOOMCYCLE_LISTEN_ADDR/v1/runs" <<EOF > "$RUN_SSE"
+{
+  "agent": "introspector",
+  "user_id": "test-user-context",
+  "segments": [
+    {"role": "user", "content": [{"type": "trusted-text", "text": $(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$PROMPT")}]}
+  ]
+}
+EOF
+
+echo "      SSE event types:"
+grep -E "^event:" "$RUN_SSE" | sort | uniq -c | sort -rn | sed 's/^/        /'
+
+# Count Context tool calls
+CONTEXT_CALLS=$(grep -E '"name":"Context"' "$RUN_SSE" | grep -c "tool_use" || echo "0")
+echo "      Context tool calls: $CONTEXT_CALLS"
+
+# ─── 5. Final-text + verdict ───────────────────────────────────────
+FINAL_TEXT=$(grep -A1 '^event: text$' "$RUN_SSE" | grep '^data:' | sed 's/^data: //' | \
+  python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" 2>/dev/null)
+
+DB="$TEST_DIR/data/loomcycle.db"
+RUN_STATUS=$(sqlite3 "$DB" "SELECT status FROM runs ORDER BY started_at LIMIT 1;" 2>/dev/null || echo "")
+
+echo
+echo "── Final text ────────────────────────────────────────────────────"
+echo "$FINAL_TEXT"
+
+echo
+echo "[5/5] Verdict:"
+PASS=true
+
+if [[ "$CONTEXT_CALLS" -ge 4 ]]; then
+  echo "  Context calls >= 4         = $CONTEXT_CALLS ✓"
+else
+  echo "  Context calls >= 4         = $CONTEXT_CALLS ✗"; PASS=false
+fi
+
+if [[ "$RUN_STATUS" = "completed" ]]; then
+  echo "  run status                 = completed ✓"
+else
+  echo "  run status                 = $RUN_STATUS ✗"; PASS=false
+fi
+
+# Final text should mention introspector (agent_name from op=self).
+if echo "$FINAL_TEXT" | grep -qi "introspector"; then
+  echo "  text mentions introspector = ✓"
+else
+  echo "  text mentions introspector = ✗"; PASS=false
+fi
+
+# Text should mention Context being in the tools list (default-add).
+if echo "$FINAL_TEXT" | grep -qi "context"; then
+  echo "  text mentions Context tool = ✓"
+else
+  echo "  text mentions Context tool = ✗"; PASS=false
+fi
+
+# Text ends with DONE.
+if echo "$FINAL_TEXT" | grep -qi "DONE"; then
+  echo "  text ends with DONE        = ✓"
+else
+  echo "  text ends with DONE        = ✗"; PASS=false
+fi
+
+if $PASS; then
+  echo "  PASS ✓"
+  exit 0
+else
+  echo "  FAIL ✗ — see $TEST_DIR for full logs"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Final of four stacked v0.8.7 PRs. Runtime smoke that exercises the Context tool's four PR-1 ops + the v0.8.7 default-add behaviour end-to-end against real Gemini 2.5 Flash.

## Stacking
- **Base:** \`feature-context-pr3-channels-history\` (PR #81)

## Scenario

\`introspector\` agent has \`allowed_tools: [Read, Memory]\` — Context is **intentionally omitted** to verify the config-load default-add. The agent chains four Context ops:

1. \`op=self\` — identity bundle
2. \`op=tools\` — runtime catalog
3. \`op=doc, name=Memory\` — Memory tool's input schema
4. \`op=permissions\` — policy bundle

After all four calls, the agent writes a one-line summary including:
- agent_name (from op=self)
- tools count (from op=tools)
- whether Context appears in its own catalog (it should — that's the default-add invariant)
- whether the permissions bundle has a memory section
- ending with DONE

## Verdict checks
- [x] Context tool calls ≥ 4
- [x] run status = completed
- [x] final text mentions \`introspector\` / \`Context\` / DONE

Tested live 2026-05-12: all 5 verdict checks PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)