### PR TITLE
fix(sqlite): move channel_messages_by_visible index past addColumns (v0.8.6 upgrade path)

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -135,7 +135,14 @@ func (s *Store) migrate(ctx context.Context) error {
 			PRIMARY KEY (channel, scope, scope_id, id)
 		)`,
 		`CREATE INDEX IF NOT EXISTS channel_messages_by_expires_at ON channel_messages(expires_at) WHERE expires_at IS NOT NULL`,
-		`CREATE INDEX IF NOT EXISTS channel_messages_by_visible ON channel_messages(channel, scope, scope_id, visible_at, id)`,
+		// NOTE: channel_messages_by_visible is created in `addIndexes`
+		// below, AFTER the `addColumns` block adds the visible_at
+		// column. On a fresh deploy the CREATE TABLE above already
+		// declares visible_at so the index could be created here too;
+		// on an UPGRADE from v0.8.4/v0.8.5 (channel_messages exists
+		// without visible_at), the CREATE TABLE IF NOT EXISTS is a
+		// no-op and creating the index here would fail with
+		// "no such column: visible_at". Keep the index in addIndexes.
 		`CREATE TABLE IF NOT EXISTS channel_cursors (
 			channel    TEXT    NOT NULL,
 			scope      TEXT    NOT NULL,
@@ -260,6 +267,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// agent_def_id the run actually ran against. Partial index
 		// keeps it small — only DB-resolved runs have a non-NULL value.
 		`CREATE INDEX IF NOT EXISTS runs_by_agent_def       ON runs(agent_def_id)    WHERE agent_def_id IS NOT NULL`,
+		// v0.8.6 channel_messages_by_visible — runs in addIndexes
+		// (NOT the earlier `stmts` loop) so the visible_at column
+		// added by addColumns above is guaranteed to exist when this
+		// index is created. Required for the upgrade path
+		// v0.8.4/v0.8.5 → v0.8.6+ (channel_messages table exists
+		// from v0.8.4 without visible_at).
+		`CREATE INDEX IF NOT EXISTS channel_messages_by_visible ON channel_messages(channel, scope, scope_id, visible_at, id)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -80,6 +80,121 @@ func TestCreateSession_EmptyUserIDIsNullInDB(t *testing.T) {
 	}
 }
 
+// TestMigrate_UpgradeFromV084ChannelMessages — regression test for
+// the v0.8.6 migration ordering bug surfaced 2026-05-13 during the
+// v0.8.9 deploy. Setup: hand-create a v0.8.4 channel_messages schema
+// (no visible_at, no published_by_user_id) directly via sql.DB,
+// then invoke migrate() and verify both columns + the index exist.
+//
+// Pre-fix, this test FAILS with:
+//
+//	migrate: SQL logic error: no such column: visible_at (1)
+//
+// because `CREATE INDEX channel_messages_by_visible` ran inside the
+// first `stmts` loop (before the `addColumns` ALTER block) and tried
+// to reference a column that didn't exist yet on an upgrade path.
+//
+// The fix moves the index creation into `addIndexes` (which runs
+// AFTER `addColumns`). On a fresh deploy the order doesn't matter
+// (CREATE TABLE declared visible_at); on an upgrade it's required.
+func TestMigrate_UpgradeFromV084ChannelMessages(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "v084.db")
+
+	// Open a raw sql.DB and create the v0.8.4 channel_messages
+	// schema (channel_messages without the v0.8.6 columns; the
+	// expires_at index from v0.8.4). Close and reopen via the
+	// loomcycle store path — that re-runs migrate(), which must
+	// successfully upgrade.
+	{
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("initial open: %v", err)
+		}
+		// Drop the v0.8.6 columns + index to simulate the
+		// pre-v0.8.6 schema state. SQLite doesn't support DROP
+		// COLUMN before 3.35; modernc/sqlite is recent enough,
+		// but the portable way (and the one that mirrors how a
+		// real pre-v0.8.6 deploy looks) is to drop the table and
+		// rebuild it without the columns.
+		stmts := []string{
+			`DROP INDEX IF EXISTS channel_messages_by_visible`,
+			`DROP TABLE channel_messages`,
+			`CREATE TABLE channel_messages (
+				id           TEXT    NOT NULL,
+				channel      TEXT    NOT NULL,
+				scope        TEXT    NOT NULL,
+				scope_id     TEXT    NOT NULL,
+				payload      TEXT    NOT NULL,
+				published_at INTEGER NOT NULL,
+				expires_at   INTEGER,
+				PRIMARY KEY (channel, scope, scope_id, id)
+			)`,
+			`CREATE INDEX channel_messages_by_expires_at ON channel_messages(expires_at) WHERE expires_at IS NOT NULL`,
+			// Insert one pre-v0.8.6 row to ensure the data
+			// fixup (UPDATE ... SET visible_at = published_at)
+			// also runs correctly on upgrade.
+			`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at)
+			   VALUES ('msg_legacy_001', 'findings', 'agent', 'researcher', '{}', 1000, NULL)`,
+		}
+		ctx := context.Background()
+		for _, q := range stmts {
+			if _, err := s.db.ExecContext(ctx, q); err != nil {
+				t.Fatalf("setup pre-v0.8.6 schema: %q: %v", q, err)
+			}
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Re-open. migrate() must successfully add visible_at +
+	// published_by_user_id, create the by_visible index, and
+	// backfill visible_at from published_at on the legacy row.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("upgrade open: %v (this is the v0.8.6 migration order bug if the message mentions `no such column: visible_at`)", err)
+	}
+	defer s.Close()
+
+	ctx := context.Background()
+	// 1. visible_at column exists.
+	var hasVisibleAt int
+	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('channel_messages') WHERE name = 'visible_at'`)
+	if err := row.Scan(&hasVisibleAt); err != nil {
+		t.Fatal(err)
+	}
+	if hasVisibleAt != 1 {
+		t.Error("visible_at column not added by migration")
+	}
+	// 2. published_by_user_id column exists.
+	var hasPublishedBy int
+	row = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_table_info('channel_messages') WHERE name = 'published_by_user_id'`)
+	if err := row.Scan(&hasPublishedBy); err != nil {
+		t.Fatal(err)
+	}
+	if hasPublishedBy != 1 {
+		t.Error("published_by_user_id column not added by migration")
+	}
+	// 3. channel_messages_by_visible index exists.
+	var hasIndex int
+	row = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'channel_messages_by_visible'`)
+	if err := row.Scan(&hasIndex); err != nil {
+		t.Fatal(err)
+	}
+	if hasIndex != 1 {
+		t.Error("channel_messages_by_visible index not created by migration")
+	}
+	// 4. Backfill ran: legacy row's visible_at = published_at.
+	var visibleAt int64
+	row = s.db.QueryRowContext(ctx, `SELECT visible_at FROM channel_messages WHERE id = 'msg_legacy_001'`)
+	if err := row.Scan(&visibleAt); err != nil {
+		t.Fatal(err)
+	}
+	if visibleAt != 1000 {
+		t.Errorf("pre-v0.8.6 row visible_at not backfilled from published_at; got %d, want 1000", visibleAt)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(path)


### PR DESCRIPTION
## Summary

**Production-blocking** — the v0.8.6 sqlite migration crashes when upgrading from a pre-v0.8.6 schema, with `SQL logic error: no such column: visible_at`. Bit production on 2026-05-13 during the v0.8.9 deploy.

## Root cause

In `internal/store/sqlite/sqlite.go migrate()`:

- The first `stmts` loop creates `CREATE TABLE IF NOT EXISTS channel_messages (... visible_at ...)` AND `CREATE INDEX channel_messages_by_visible ON channel_messages(..., visible_at, id)`.
- The second `addColumns` loop runs `ALTER TABLE channel_messages ADD COLUMN visible_at ...` (idempotent on \"duplicate column name\").

On a **fresh deploy**, the CREATE TABLE declares `visible_at` so the index works. On an **upgrade** from v0.8.4 / v0.8.5 (channel_messages already exists from migration 0004 without `visible_at`), `CREATE TABLE IF NOT EXISTS` is a no-op — but the index creation in the same loop tries to reference `visible_at` BEFORE the ALTER block adds it. Fails.

CI never caught this because every test run uses a fresh DB.

## Fix

Move the `channel_messages_by_visible` CREATE INDEX into `addIndexes` (which runs AFTER `addColumns`). One-line move; comments at both the old and new sites explain why. Postgres is unaffected — migration `0005_channel_visible_at.up.sql` already orders ALTER → CREATE INDEX correctly inside a single golang-migrate transaction.

## Regression test

`TestMigrate_UpgradeFromV084ChannelMessages` in `internal/store/sqlite/sqlite_test.go`:

1. Opens a fresh sqlite DB.
2. Hand-builds a v0.8.4 schema for `channel_messages` (no `visible_at`, no `published_by_user_id`).
3. Inserts one legacy row.
4. Closes + re-opens, which invokes `migrate()`.
5. Verifies post-migration state: both columns added, `channel_messages_by_visible` index exists, legacy row's `visible_at` backfilled from `published_at`.

**Pre-fix this test fails** with the exact production error: `migrate: SQL logic error: no such column: visible_at (1)`. **Post-fix all four assertions pass.** Verified by `git stash` + re-run (test fails) then `git stash pop` + re-run (passes).

## Test plan

- [x] `go test ./internal/store/sqlite/...` — new regression test + 4 pre-existing tests pass
- [x] `go test ./...` — full suite green
- [x] Verified test fails on unfixed code (`git stash` of `sqlite.go`, re-run shows the exact production error)

## Production impact

This blocks the v0.8.9 deploy on every existing sqlite-backed loomcycle instance that's been running v0.8.4 or v0.8.5. Once this PR lands, I'll tag v0.8.10 and retry the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)