### PR TITLE
feat(metrics): v0.8.x process-resource sampler + /v1/_metrics/* API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,3 +203,45 @@ LOOMCYCLE_DATA_DIR=./data
 # defaults are tuned for direct internet egress.
 # LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
 # LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000
+
+# ─── Process-resource metrics sampler (v0.8.x+) ──────────────────────
+#
+# Built-in CPU + memory sampler that runs as a background goroutine
+# while at least one agent run is active and persists samples to a
+# new `process_samples` table for capacity-planning. Sleep-when-idle:
+# no DB writes, no /proc reads when nothing is running.
+#
+# Default OFF in v0.8.x — set =1 to enable. Default-on planned for
+# v0.9.x once production-validated.
+# LOOMCYCLE_METRICS_ENABLED=1
+#
+# Sample cadence in milliseconds. Default 5 s (5000). Values below
+# 1 s are clamped up to 1 s — prevents accidental write-storms from
+# a typo'd 50 vs 5000. Storage estimate at defaults: ~210 MB/week
+# for a continuously-active deployment (5 s × 86 400 × 7 ≈ 121 K
+# rows × ~250 bytes each).
+# LOOMCYCLE_METRICS_SAMPLE_INTERVAL_MS=5000
+#
+# Retention in days. Default 7. Set 0 to disable automatic cleanup
+# (table grows unbounded). Lower this on slow disks or
+# storage-constrained deployments.
+# LOOMCYCLE_METRICS_RETENTION_DAYS=7
+#
+# Optional: also read /proc/stat + /proc/meminfo for SYSTEM-wide
+# CPU% + memory (not just loomcycle's process). Linux only;
+# silently ignored on macOS/Windows. Useful when correlating
+# loomcycle's behaviour with host pressure (e.g. ZFS ARC eating
+# RAM in a TrueNAS-hosted VM).
+# LOOMCYCLE_METRICS_COLLECT_SYSTEM=1
+#
+# Sweeper cadence (cleanup goroutine) in milliseconds. Default
+# 15 min. Set 0 to disable. Bounded retention requires BOTH a
+# non-zero retention AND non-zero sweep interval.
+# LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS=900000
+#
+# Public API (bearer-authed):
+#   GET /v1/_metrics/samples?since=<RFC3339>&until=<RFC3339>&limit=N
+#   GET /v1/_metrics/runs/{run_id}    — peak/mean RSS + max CPU%
+#                                       for samples in the run window
+#   GET /v1/_metrics/summary?period=1h|24h|7d
+#                                     — aggregated buckets

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/heartbeat"
 	"github.com/denn-gubsky/loomcycle/internal/help"
+	"github.com/denn-gubsky/loomcycle/internal/metrics"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/providers/anthropic"
 	"github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
@@ -561,6 +562,35 @@ func main() {
 	} else if storeIface != nil {
 		log.Printf("channels: sweeper disabled (LOOMCYCLE_CHANNELS_SWEEP_MS=0)")
 	}
+
+	// v0.8.x process-resource metrics sampler. Default OFF;
+	// operator opts in via LOOMCYCLE_METRICS_ENABLED=1. When
+	// enabled, samples loomcycle's CPU + memory usage at
+	// cfg.Env.MetricsSampleInterval cadence while at least one
+	// agent run is active (the semaphore's Stats() is the idle
+	// gate — no DB write, no /proc read while idle).
+	if cfg.Env.MetricsEnabled && storeIface != nil {
+		metricsSampler := metrics.New(storeIface, sem, metrics.Config{
+			Interval:      cfg.Env.MetricsSampleInterval,
+			CollectSystem: cfg.Env.MetricsCollectSystem,
+		})
+		go metricsSampler.Run(bgCtx)
+		srv.SetMetricsSampler(metricsSampler)
+		log.Printf("metrics: sampler enabled (interval=%s, system=%v)",
+			cfg.Env.MetricsSampleInterval, cfg.Env.MetricsCollectSystem)
+		if cfg.Env.MetricsSweepInterval > 0 && cfg.Env.MetricsRetentionDays > 0 {
+			go runMetricsSweeper(bgCtx, storeIface,
+				cfg.Env.MetricsRetentionDays, cfg.Env.MetricsSweepInterval)
+			log.Printf("metrics: sweeper enabled (retention=%dd, interval=%s)",
+				cfg.Env.MetricsRetentionDays, cfg.Env.MetricsSweepInterval)
+		} else {
+			log.Printf("metrics: sweeper disabled (retention=0 or sweep interval=0)")
+		}
+	} else if cfg.Env.MetricsEnabled {
+		log.Printf("metrics: sampler disabled (no Store backend)")
+	} else {
+		log.Printf("metrics: sampler disabled (LOOMCYCLE_METRICS_ENABLED=0)")
+	}
 	// Boot summary of operator-declared channels. Mirrors the
 	// "user_tiers: configured N — ..." line shape so operators see
 	// the framework-primitive state at startup.
@@ -972,6 +1002,32 @@ func runChannelsSweeper(ctx context.Context, s store.Store, interval time.Durati
 			}
 			if swept > 0 {
 				log.Printf("channels sweep: deleted %d expired row(s)", swept)
+			}
+		}
+	}
+}
+
+// runMetricsSweeper is the v0.8.x mirror of runChannelsSweeper for
+// the process_samples table. Deletes rows whose sampled_at <
+// (now - retentionDays). The retention guarantee is bounded-time,
+// not bounded-rows; operators on slow disks should set
+// MetricsRetentionDays to a smaller value if disk pressure shows up.
+func runMetricsSweeper(ctx context.Context, s store.Store, retentionDays int, interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			cutoff := time.Now().Add(-time.Duration(retentionDays) * 24 * time.Hour)
+			swept, err := s.MetricsSweep(ctx, cutoff)
+			if err != nil {
+				log.Printf("metrics sweep: %v", err)
+				continue
+			}
+			if swept > 0 {
+				log.Printf("metrics sweep: deleted %d expired row(s)", swept)
 			}
 		}
 	}

--- a/internal/api/http/metrics_handlers.go
+++ b/internal/api/http/metrics_handlers.go
@@ -1,0 +1,271 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// metricsEndpointsEnabled returns true when the metrics sampler is
+// wired AND the store backend is non-nil. False sends a 503 with
+// a one-line operator-facing explanation.
+func (s *Server) metricsEndpointsEnabled() bool {
+	return s.metricsSampler != nil && s.store != nil
+}
+
+// writeMetricsDisabled emits the standard 503 envelope when the
+// metrics endpoints are queried in a deployment where they're not
+// enabled. The body's `enable_hint` points operators at the env var
+// so the failure mode is self-explanatory.
+func writeMetricsDisabled(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error":       "metrics sampler not enabled",
+		"enable_hint": "set LOOMCYCLE_METRICS_ENABLED=1 and restart loomcycle",
+	})
+}
+
+// handleMetricsSamples implements `GET /v1/_metrics/samples` —
+// raw process_samples rows within a time window.
+//
+// Query params:
+//   - since   RFC3339, required
+//   - until   RFC3339, optional (defaults to now)
+//   - limit   int 1..1000, optional (default 200)
+//   - cursor  opaque, optional (from a previous response's next_cursor)
+func (s *Server) handleMetricsSamples(w http.ResponseWriter, r *http.Request) {
+	if !s.metricsEndpointsEnabled() {
+		writeMetricsDisabled(w)
+		return
+	}
+	q := r.URL.Query()
+	sinceStr := q.Get("since")
+	if sinceStr == "" {
+		http.Error(w, `{"error":"missing required query param: since (RFC3339)"}`, http.StatusBadRequest)
+		return
+	}
+	since, err := time.Parse(time.RFC3339, sinceStr)
+	if err != nil {
+		http.Error(w, `{"error":"invalid since: must be RFC3339"}`, http.StatusBadRequest)
+		return
+	}
+	until := time.Now().UTC()
+	if v := q.Get("until"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			http.Error(w, `{"error":"invalid until: must be RFC3339"}`, http.StatusBadRequest)
+			return
+		}
+		until = t
+	}
+	limit := 0
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			http.Error(w, `{"error":"invalid limit: must be positive integer (1..1000)"}`, http.StatusBadRequest)
+			return
+		}
+		limit = n
+	}
+	cursor := q.Get("cursor")
+
+	samples, nextCursor, err := s.store.MetricsSampleWindow(r.Context(), since, until, limit, cursor)
+	if err != nil {
+		http.Error(w, `{"error":"failed to query samples"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"samples":     samples,
+		"next_cursor": nextCursor,
+	})
+}
+
+// handleMetricsRunSummary implements `GET /v1/_metrics/runs/{run_id}` —
+// peak / mean RSS + max CPU% from samples overlapping the run's
+// [started_at, COALESCE(completed_at, now)] window.
+//
+// 404 when the run_id doesn't exist. 200 with SampleCount=0 when
+// the run exists but had no overlapping samples (in-flight run
+// that hasn't ticked yet, or metrics disabled during the run).
+func (s *Server) handleMetricsRunSummary(w http.ResponseWriter, r *http.Request) {
+	if !s.metricsEndpointsEnabled() {
+		writeMetricsDisabled(w)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if runID == "" {
+		http.Error(w, `{"error":"missing run_id"}`, http.StatusBadRequest)
+		return
+	}
+	summary, err := s.store.MetricsRunSummary(r.Context(), runID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			http.Error(w, `{"error":"run not found"}`, http.StatusNotFound)
+			return
+		}
+		http.Error(w, `{"error":"failed to compute run summary"}`, http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(summary)
+}
+
+// metricsSummaryBucket is one aggregated time bucket in the
+// /v1/_metrics/summary response.
+type metricsSummaryBucket struct {
+	At             time.Time `json:"at"`
+	MeanRSSBytes   int64     `json:"mean_rss_bytes"`
+	MaxRSSBytes    int64     `json:"max_rss_bytes"`
+	P95CPUPctX100  int       `json:"p95_cpu_pct_x100"`
+	ActiveRunsMax  int       `json:"active_runs_max"`
+	SampleCount    int       `json:"sample_count"`
+}
+
+// handleMetricsSummary implements `GET /v1/_metrics/summary` —
+// aggregated buckets over a fixed period.
+//
+// Query params:
+//   - period: "1h" | "24h" | "7d" (default "1h")
+//
+// The handler fetches samples from MetricsSampleWindow and
+// aggregates in-process. For v0.8.x scale (≤2016 rows / 7-day
+// period at default 5s interval) this is sub-millisecond. A
+// dedicated SQL GROUP BY path can replace this in v0.9.x when
+// load justifies it.
+func (s *Server) handleMetricsSummary(w http.ResponseWriter, r *http.Request) {
+	if !s.metricsEndpointsEnabled() {
+		writeMetricsDisabled(w)
+		return
+	}
+	period := r.URL.Query().Get("period")
+	if period == "" {
+		period = "1h"
+	}
+	var (
+		windowDur  time.Duration
+		bucketSize time.Duration
+	)
+	switch period {
+	case "1h":
+		windowDur, bucketSize = 1*time.Hour, 5*time.Minute
+	case "24h":
+		windowDur, bucketSize = 24*time.Hour, 1*time.Hour
+	case "7d":
+		windowDur, bucketSize = 7*24*time.Hour, 6*time.Hour
+	default:
+		http.Error(w, `{"error":"invalid period: must be 1h | 24h | 7d"}`, http.StatusBadRequest)
+		return
+	}
+
+	now := time.Now().UTC()
+	since := now.Add(-windowDur)
+	// Fetch ALL samples in the window. Cap of 1000 per page is
+	// applied by the store; loop to drain if more.
+	var all []store.ProcessSample
+	cursor := ""
+	for {
+		batch, next, err := s.store.MetricsSampleWindow(r.Context(), since, now, 1000, cursor)
+		if err != nil {
+			http.Error(w, `{"error":"failed to query samples"}`, http.StatusInternalServerError)
+			return
+		}
+		all = append(all, batch...)
+		if next == "" {
+			break
+		}
+		cursor = next
+		// Safety: cap total rows fetched at 100k to prevent a
+		// runaway query from consuming all memory.
+		if len(all) >= 100000 {
+			break
+		}
+	}
+
+	buckets := summariseIntoBuckets(all, since, now, bucketSize)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"period":  period,
+		"buckets": buckets,
+	})
+}
+
+// summariseIntoBuckets groups samples into fixed-size time buckets
+// and computes per-bucket aggregates: mean/max RSS, max active_runs,
+// p95 CPU%, and sample count.
+//
+// Empty buckets (no samples in their window) are still emitted with
+// zero-valued fields so a consumer plotting a timeline sees the
+// gaps explicitly.
+func summariseIntoBuckets(samples []store.ProcessSample, since, until time.Time, bucketSize time.Duration) []metricsSummaryBucket {
+	numBuckets := int(until.Sub(since) / bucketSize)
+	if numBuckets <= 0 {
+		numBuckets = 1
+	}
+	type bucketAgg struct {
+		rssSum   int64
+		rssMax   int64
+		runsMax  int
+		cpuList  []int
+		count    int
+	}
+	aggs := make([]bucketAgg, numBuckets)
+	for _, s := range samples {
+		idx := int(s.SampledAt.Sub(since) / bucketSize)
+		if idx < 0 || idx >= numBuckets {
+			continue
+		}
+		aggs[idx].rssSum += s.LoomcycleRSSBytes
+		if s.LoomcycleRSSBytes > aggs[idx].rssMax {
+			aggs[idx].rssMax = s.LoomcycleRSSBytes
+		}
+		if s.ActiveRuns > aggs[idx].runsMax {
+			aggs[idx].runsMax = s.ActiveRuns
+		}
+		aggs[idx].cpuList = append(aggs[idx].cpuList, s.LoomcycleCPUPctX100)
+		aggs[idx].count++
+	}
+	out := make([]metricsSummaryBucket, numBuckets)
+	for i := 0; i < numBuckets; i++ {
+		bucket := metricsSummaryBucket{
+			At:            since.Add(time.Duration(i) * bucketSize),
+			SampleCount:   aggs[i].count,
+			MaxRSSBytes:   aggs[i].rssMax,
+			ActiveRunsMax: aggs[i].runsMax,
+		}
+		if aggs[i].count > 0 {
+			bucket.MeanRSSBytes = aggs[i].rssSum / int64(aggs[i].count)
+			bucket.P95CPUPctX100 = percentile(aggs[i].cpuList, 95)
+		}
+		out[i] = bucket
+	}
+	return out
+}
+
+// percentile returns the p-th percentile of a slice of ints
+// (rounded to the nearest sample). Used for p95 CPU% in the
+// summary buckets. Empty slice → 0.
+func percentile(values []int, p int) int {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := make([]int, len(values))
+	copy(sorted, values)
+	sort.Ints(sorted)
+	// Nearest-rank percentile: index = ceil(p/100 * n) - 1.
+	idx := (p*len(sorted) + 99) / 100
+	if idx > 0 {
+		idx--
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}

--- a/internal/api/http/metrics_handlers_test.go
+++ b/internal/api/http/metrics_handlers_test.go
@@ -1,0 +1,255 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/metrics"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// metricsFixture wires a Server with a real sqlite store + an
+// optionally-attached metrics sampler. Returns the server, the
+// store (so tests can pre-seed rows), and a cleanup func.
+func metricsFixture(t *testing.T, attachSampler bool) (*Server, store.Store) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// Server only needs the store + sampler for the metrics
+	// endpoints; the rest of the Server fields are unused. We set
+	// `store` directly via the struct rather than calling New(),
+	// because New() requires a fully-wired provider resolver etc.
+	srv := &Server{store: st}
+	if attachSampler {
+		srv.metricsSampler = metrics.New(st, concurrency.New(8, 16, time.Second), metrics.Config{
+			Interval: time.Second,
+		})
+	}
+	return srv, st
+}
+
+// TestMetricsEndpoints_DisabledReturns503 — no sampler wired, all
+// three endpoints return 503 with the standard envelope.
+func TestMetricsEndpoints_DisabledReturns503(t *testing.T) {
+	srv, _ := metricsFixture(t, false)
+	cases := []struct {
+		name string
+		path string
+		fn   http.HandlerFunc
+		// some handlers need PathValue
+		pathValues map[string]string
+	}{
+		{"samples", "/v1/_metrics/samples?since=2026-05-13T00:00:00Z", srv.handleMetricsSamples, nil},
+		{"run", "/v1/_metrics/runs/r_nope", srv.handleMetricsRunSummary, map[string]string{"run_id": "r_nope"}},
+		{"summary", "/v1/_metrics/summary?period=1h", srv.handleMetricsSummary, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tc.path, nil)
+			for k, v := range tc.pathValues {
+				req.SetPathValue(k, v)
+			}
+			rec := httptest.NewRecorder()
+			tc.fn(rec, req)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Errorf("status = %d, want 503; body=%s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestHandleMetricsSamples_RoundTrip — sampler attached, store
+// pre-loaded with 3 samples. GET returns them in time order with
+// next_cursor empty.
+func TestHandleMetricsSamples_RoundTrip(t *testing.T) {
+	srv, st := metricsFixture(t, true)
+	ctx := t.Context()
+	base := time.Now().UTC().Add(-1 * time.Minute).Truncate(time.Millisecond)
+	for i := 0; i < 3; i++ {
+		sa := store.ProcessSample{
+			SampleID:           store.MintSampleID(base.Add(time.Duration(i) * time.Second)),
+			SampledAt:          base.Add(time.Duration(i) * time.Second),
+			ActiveRuns:         1,
+			QueuedRuns:         0,
+			LoomcycleRSSBytes:  int64(100+i) << 20,
+			LoomcycleHeapAlloc: 50 << 20,
+		}
+		if err := st.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatal(err)
+		}
+	}
+	req := httptest.NewRequest("GET", "/v1/_metrics/samples?since="+base.Add(-1*time.Second).Format(time.RFC3339), nil)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsSamples(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Samples    []store.ProcessSample `json:"samples"`
+		NextCursor string                `json:"next_cursor"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Samples) != 3 {
+		t.Errorf("got %d samples, want 3", len(resp.Samples))
+	}
+	if resp.NextCursor != "" {
+		t.Errorf("next_cursor = %q, want empty", resp.NextCursor)
+	}
+}
+
+// TestHandleMetricsSamples_MissingSince — 400 with helpful error.
+func TestHandleMetricsSamples_MissingSince(t *testing.T) {
+	srv, _ := metricsFixture(t, true)
+	req := httptest.NewRequest("GET", "/v1/_metrics/samples", nil)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsSamples(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHandleMetricsRunSummary_NotFound — unknown run_id → 404.
+func TestHandleMetricsRunSummary_NotFound(t *testing.T) {
+	srv, _ := metricsFixture(t, true)
+	req := httptest.NewRequest("GET", "/v1/_metrics/runs/r_nope", nil)
+	req.SetPathValue("run_id", "r_nope")
+	rec := httptest.NewRecorder()
+	srv.handleMetricsRunSummary(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleMetricsRunSummary_HappyPath — a run + 2 overlapping
+// samples → 200 with non-zero peak + count.
+func TestHandleMetricsRunSummary_HappyPath(t *testing.T) {
+	srv, st := metricsFixture(t, true)
+	ctx := t.Context()
+	sess, _ := st.CreateSession(ctx, "t", "default", "")
+	run, _ := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_test"})
+	time.Sleep(2 * time.Millisecond)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for i, rss := range []int64{100 << 20, 150 << 20} {
+		sa := store.ProcessSample{
+			SampleID:          store.MintSampleID(now.Add(time.Duration(i) * time.Millisecond)),
+			SampledAt:         now.Add(time.Duration(i) * time.Millisecond),
+			ActiveRuns:        1,
+			LoomcycleRSSBytes: rss,
+		}
+		if err := st.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Millisecond)
+	if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest("GET", "/v1/_metrics/runs/"+run.ID, nil)
+	req.SetPathValue("run_id", run.ID)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsRunSummary(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got store.MetricsRunWindow
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.SampleCount != 2 {
+		t.Errorf("SampleCount = %d, want 2", got.SampleCount)
+	}
+	if got.PeakRSSBytes != 150<<20 {
+		t.Errorf("PeakRSSBytes = %d, want %d", got.PeakRSSBytes, int64(150<<20))
+	}
+}
+
+// TestHandleMetricsSummary_Period1h — 12 samples spread over an
+// hour at 5-min intervals → 12 buckets (one per 5-min span)
+// with sample_count=1 each.
+func TestHandleMetricsSummary_Period1h(t *testing.T) {
+	srv, st := metricsFixture(t, true)
+	ctx := t.Context()
+	now := time.Now().UTC()
+	for i := 0; i < 12; i++ {
+		sampleTime := now.Add(-time.Duration(i+1) * 5 * time.Minute)
+		sa := store.ProcessSample{
+			SampleID:            store.MintSampleID(sampleTime),
+			SampledAt:           sampleTime,
+			ActiveRuns:          1 + i%3,
+			LoomcycleRSSBytes:   int64(100+i) << 20,
+			LoomcycleCPUPctX100: 1000 + i*100,
+		}
+		if err := st.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatal(err)
+		}
+	}
+	req := httptest.NewRequest("GET", "/v1/_metrics/summary?period=1h", nil)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsSummary(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Period  string                 `json:"period"`
+		Buckets []metricsSummaryBucket `json:"buckets"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Period != "1h" {
+		t.Errorf("period = %q, want 1h", resp.Period)
+	}
+	if len(resp.Buckets) != 12 {
+		t.Errorf("got %d buckets, want 12 (5-min bucket × 1h)", len(resp.Buckets))
+	}
+	// At least one bucket should have a non-zero sample count.
+	total := 0
+	for _, b := range resp.Buckets {
+		total += b.SampleCount
+	}
+	if total == 0 {
+		t.Error("no bucket recorded any samples")
+	}
+}
+
+// TestHandleMetricsSummary_InvalidPeriod — 400 on unknown period.
+func TestHandleMetricsSummary_InvalidPeriod(t *testing.T) {
+	srv, _ := metricsFixture(t, true)
+	req := httptest.NewRequest("GET", "/v1/_metrics/summary?period=42h", nil)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsSummary(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestPercentile — sanity-check the helper used by summary.
+func TestPercentile_Nearest(t *testing.T) {
+	cases := []struct {
+		in   []int
+		p    int
+		want int
+	}{
+		{nil, 95, 0},
+		{[]int{100}, 95, 100},
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 95, 10},
+		{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 50, 5},
+	}
+	for _, tc := range cases {
+		got := percentile(tc.in, tc.p)
+		if got != tc.want {
+			t.Errorf("percentile(%v, %d) = %d, want %d", tc.in, tc.p, got, tc.want)
+		}
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/metrics"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
@@ -100,6 +101,12 @@ type Server struct {
 	// admin endpoint. Nil = endpoint refuses every request with a
 	// "system publisher not wired" 503. Set via SetSystemPublisher.
 	systemPublisher channels.SystemPublisher
+
+	// metricsSampler is the v0.8.x process-resource sampler.
+	// Nil = the /v1/_metrics/* endpoints return 503. Set via
+	// SetMetricsSampler from main.go after the sampler is
+	// constructed.
+	metricsSampler *metrics.Sampler
 }
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
@@ -141,6 +148,13 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 // cmd/loomcycle/main.go after the MCP pool is built.
 func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
 	s.mcpFallback = fn
+}
+
+// SetMetricsSampler installs the v0.8.x metrics sampler so the
+// /v1/_metrics/* endpoints have a backing object. Nil is the
+// default — endpoints return 503 until this is called.
+func (s *Server) SetMetricsSampler(m *metrics.Sampler) {
+	s.metricsSampler = m
 }
 
 // SetSystemPublisher installs the v0.8.6 system-channels publisher.
@@ -864,6 +878,12 @@ func (s *Server) Mux() http.Handler {
 	// here. Future verbs (GET to peek, etc.) can use the same path
 	// with different methods.
 	mux.Handle("POST /v1/_channels/{name...}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSystemChannelPublish))))
+	// v0.8.x process-resource metrics sampler endpoints. All
+	// bearer-authed. Return 503 when metricsSampler is nil
+	// (LOOMCYCLE_METRICS_ENABLED=0 deployment).
+	mux.Handle("GET /v1/_metrics/samples", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSamples))))
+	mux.Handle("GET /v1/_metrics/runs/{run_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsRunSummary))))
+	mux.Handle("GET /v1/_metrics/summary", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSummary))))
 	// v0.8.0 Memory admin — read-only browsing of stored Memory rows.
 	// Drives the Web UI's Memory page. Bearer-authed; same admin
 	// posture as /v1/_users / /v1/_resolver.

--- a/internal/cancel/registry.go
+++ b/internal/cancel/registry.go
@@ -275,6 +275,24 @@ func (r *Registry) Count() int {
 	return len(r.entries)
 }
 
+// ListAll returns a snapshot of every live entry regardless of
+// user or parent. General-purpose accessor for diagnostics and
+// future cross-cutting consumers (the v0.8.x metrics sampler
+// already gates on `concurrency.Semaphore.Stats()` for its
+// active-runs count; this method exists for richer per-agent
+// snapshots a future PR may need). The caller MUST NOT mutate
+// the returned slice; treat as read-only. O(n) under RLock; cheap
+// for typical run counts (≤ MaxConcurrentRuns).
+func (r *Registry) ListAll() []Entry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Entry, 0, len(r.entries))
+	for _, e := range r.entries {
+		out = append(out, e)
+	}
+	return out
+}
+
 // cancelWithReason wraps the API-cancel sentinel with a human reason
 // so context.Cause carries both. errors.Is(cause, ErrCancelledByAPI)
 // continues to identify the cancel as API-originated; cause.Error()

--- a/internal/cancel/registry_test.go
+++ b/internal/cancel/registry_test.go
@@ -284,3 +284,59 @@ func TestRegistry_Register_RejectsEmptyInputs(t *testing.T) {
 		t.Error("expected error on nil cancelFn")
 	}
 }
+
+// TestRegistry_ListAll returns a snapshot of every live entry,
+// regardless of user. Deregistered entries vanish from the snapshot.
+func TestRegistry_ListAll(t *testing.T) {
+	r := NewRegistry()
+	_, c1, _ := makeCancellable()
+	_, c2, _ := makeCancellable()
+	_, c3, _ := makeCancellable()
+
+	if err := r.Register(Entry{AgentID: "a_1", RunID: "r_1", UserID: "alice"}, c1); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(Entry{AgentID: "a_2", RunID: "r_2", UserID: "bob"}, c2); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Register(Entry{AgentID: "a_3", RunID: "r_3", UserID: "alice"}, c3); err != nil {
+		t.Fatal(err)
+	}
+
+	got := r.ListAll()
+	if len(got) != 3 {
+		t.Fatalf("len(ListAll()) = %d, want 3", len(got))
+	}
+	seen := map[string]bool{}
+	for _, e := range got {
+		seen[e.AgentID] = true
+	}
+	for _, want := range []string{"a_1", "a_2", "a_3"} {
+		if !seen[want] {
+			t.Errorf("ListAll() missing agent %q", want)
+		}
+	}
+
+	// Deregister one and confirm the snapshot reflects the change.
+	r.Deregister("a_2")
+	got = r.ListAll()
+	if len(got) != 2 {
+		t.Errorf("after Deregister, len(ListAll()) = %d, want 2", len(got))
+	}
+	for _, e := range got {
+		if e.AgentID == "a_2" {
+			t.Errorf("deregistered a_2 still in ListAll()")
+		}
+	}
+}
+
+// TestRegistry_ListAll_Empty returns a non-nil empty slice on a
+// fresh registry. (Some callers may iterate via range; a nil slice
+// also iterates safely, but documenting the contract.)
+func TestRegistry_ListAll_Empty(t *testing.T) {
+	r := NewRegistry()
+	got := r.ListAll()
+	if len(got) != 0 {
+		t.Errorf("fresh registry returned %d entries, want 0", len(got))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -658,6 +658,37 @@ type Env struct {
 	// day. Env: LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS.
 	ResolveProbeInterval time.Duration
 
+	// ---- v0.8.x process-resource metrics sampler (opt-in) ----
+
+	// MetricsEnabled enables the periodic process_samples
+	// recorder. Default OFF in v0.8.x (operator opts in via
+	// LOOMCYCLE_METRICS_ENABLED=1). Flip to default-on in v0.9.x
+	// once production-validated. When false, the sampler goroutine
+	// is not started at all — zero runtime overhead.
+	MetricsEnabled bool
+	// MetricsSampleInterval is the tick rate. Default 5s.
+	// Values below 1s are rejected at config-load (preventing
+	// accidental write-storms). Env:
+	// LOOMCYCLE_METRICS_SAMPLE_INTERVAL_MS.
+	MetricsSampleInterval time.Duration
+	// MetricsRetentionDays is how many days of process_samples
+	// rows the periodic sweeper keeps. Default 7. Cleared rows
+	// are gone. 0 means "no automatic cleanup" (operator must
+	// prune manually, or the table grows unbounded). Env:
+	// LOOMCYCLE_METRICS_RETENTION_DAYS.
+	MetricsRetentionDays int
+	// MetricsCollectSystem enables /proc/stat + /proc/meminfo
+	// reads for system-wide CPU% + memory usage in addition to
+	// loomcycle's own RSS. Linux only; silently ignored on other
+	// platforms. Env: LOOMCYCLE_METRICS_COLLECT_SYSTEM.
+	MetricsCollectSystem bool
+	// MetricsSweepInterval is the sweeper cadence for
+	// process_samples. Default 15 minutes. 0 disables the
+	// sweeper (combine with MetricsRetentionDays=0 if you
+	// want unbounded retention). Env:
+	// LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS.
+	MetricsSweepInterval time.Duration
+
 	// ToolParallelism caps how many tool_calls from a single
 	// assistant turn run concurrently. Default 8. Set to 1 to
 	// force serial dispatch (debug / determinism). Field 0
@@ -1070,6 +1101,40 @@ func Load(path string) (*Config, error) {
 				cfg.Env.ChannelsMaxPendingDeferred = 0
 			} else {
 				cfg.Env.ChannelsMaxPendingDeferred = n
+			}
+		}
+	}
+
+	// v0.8.x process-resource metrics sampler. Default OFF; operator
+	// opts in via LOOMCYCLE_METRICS_ENABLED=1.
+	cfg.Env.MetricsEnabled = os.Getenv("LOOMCYCLE_METRICS_ENABLED") == "1"
+	cfg.Env.MetricsSampleInterval = 5 * time.Second
+	if v := os.Getenv("LOOMCYCLE_METRICS_SAMPLE_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			d := time.Duration(n) * time.Millisecond
+			// Floor 1s to prevent accidental write-storms from a
+			// typo'd value like 50 (interpreted as 50ms not 5s).
+			const minInterval = 1 * time.Second
+			if d < minInterval {
+				d = minInterval
+			}
+			cfg.Env.MetricsSampleInterval = d
+		}
+	}
+	cfg.Env.MetricsRetentionDays = 7
+	if v := os.Getenv("LOOMCYCLE_METRICS_RETENTION_DAYS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Env.MetricsRetentionDays = n
+		}
+	}
+	cfg.Env.MetricsCollectSystem = os.Getenv("LOOMCYCLE_METRICS_COLLECT_SYSTEM") == "1"
+	cfg.Env.MetricsSweepInterval = 15 * time.Minute
+	if v := os.Getenv("LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.MetricsSweepInterval = 0
+			} else {
+				cfg.Env.MetricsSweepInterval = time.Duration(n) * time.Millisecond
 			}
 		}
 	}

--- a/internal/metrics/proc_linux.go
+++ b/internal/metrics/proc_linux.go
@@ -1,0 +1,297 @@
+//go:build linux
+
+// Package metrics — Linux-specific /proc readers for the
+// process-resource sampler.
+//
+// What's read:
+//   - /proc/self/status   → VmRSS line for process resident set size
+//   - /proc/self/stat     → utime + stime fields for cumulative CPU
+//     ticks; delta-from-previous / wall-clock-delta → CPU%
+//   - /proc/stat          → first line; system-wide CPU delta
+//     (only when collectSystem=true)
+//   - /proc/meminfo       → MemTotal + MemAvailable
+//     (only when collectSystem=true)
+//
+// All reads are <50 µs on a healthy host; total per-tick cost
+// dominates by the sampler's 5-second interval. Parse errors are
+// surfaced as the function's error return — the sampler treats
+// them as soft failures (log once, continue).
+package metrics
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// ProcMetricsAvailable is true on Linux; the sampler can populate
+// RSS + CPU fields.
+const ProcMetricsAvailable = true
+
+// USER_HZ — number of jiffies per second on every Linux target
+// loomcycle targets. Hard-coded rather than sysconf'd; if a future
+// kernel breaks this we revisit.
+const userHZ = 100
+
+// procMetrics is one tick's worth of per-process + (optionally)
+// system-wide measurements.
+type procMetrics struct {
+	rssBytes             int64
+	cpuPctX100           int
+	systemCPUPctX100     *int
+	systemMemUsedMB      *int
+	systemMemAvailableMB *int
+}
+
+// cpuSnapshot is the previous-tick state required to compute
+// delta-CPU% on the next tick. The sampler carries this across
+// invocations.
+type cpuSnapshot struct {
+	at            time.Time
+	procTicks     uint64 // utime + stime of our process
+	systemTotal   uint64 // /proc/stat: sum of all CPU jiffies
+	systemIdle    uint64 // /proc/stat: idle jiffies
+	systemPopulated bool
+}
+
+// readProcMetrics samples /proc once. Returns the new metrics and
+// the snapshot to pass into the NEXT call. On first call (prev is
+// zero-valued), the delta-based CPU fields return 0 — the second
+// call onward produces real CPU% numbers.
+//
+// Errors are NEVER fatal — the sampler treats them as soft
+// failures so a hardened-container `/proc` shape doesn't kill the
+// runtime.
+func readProcMetrics(collectSystem bool, prev cpuSnapshot) (procMetrics, cpuSnapshot, error) {
+	now := time.Now()
+	out := procMetrics{}
+	next := cpuSnapshot{at: now}
+
+	// 1. /proc/self/status — VmRSS line.
+	if rss, err := readProcSelfStatusVmRSS(); err != nil {
+		return out, prev, fmt.Errorf("read /proc/self/status: %w", err)
+	} else {
+		out.rssBytes = rss
+	}
+
+	// 2. /proc/self/stat — utime + stime cumulative ticks.
+	curProcTicks, err := readProcSelfStatTicks()
+	if err != nil {
+		return out, prev, fmt.Errorf("read /proc/self/stat: %w", err)
+	}
+	next.procTicks = curProcTicks
+	if !prev.at.IsZero() && curProcTicks >= prev.procTicks {
+		wall := now.Sub(prev.at).Seconds()
+		if wall > 0 {
+			deltaTicks := float64(curProcTicks - prev.procTicks)
+			pct := (deltaTicks / float64(userHZ)) / wall * 100.0
+			out.cpuPctX100 = int(pct * 100.0)
+		}
+	}
+
+	// 3. Optionally /proc/stat for system CPU.
+	if collectSystem {
+		total, idle, err := readProcStatCPU0()
+		if err == nil {
+			next.systemTotal = total
+			next.systemIdle = idle
+			next.systemPopulated = true
+			if prev.systemPopulated && total >= prev.systemTotal && idle >= prev.systemIdle {
+				deltaTotal := total - prev.systemTotal
+				deltaIdle := idle - prev.systemIdle
+				if deltaTotal > 0 {
+					usedJiffies := deltaTotal - deltaIdle
+					pct := float64(usedJiffies) / float64(deltaTotal) * 100.0
+					v := int(pct * 100.0)
+					out.systemCPUPctX100 = &v
+				}
+			}
+		}
+		// /proc/meminfo — MemTotal + MemAvailable.
+		if total, available, err := readProcMeminfo(); err == nil {
+			tot := int(total / 1024 / 1024)
+			avail := int(available / 1024 / 1024)
+			used := tot - avail
+			out.systemMemUsedMB = &used
+			out.systemMemAvailableMB = &avail
+		}
+	}
+
+	return out, next, nil
+}
+
+// readProcSelfStatusVmRSS scans /proc/self/status for the VmRSS:
+// line and returns the value in bytes. Format example:
+//
+//	VmRSS:	   45200 kB
+//
+// (whitespace varies; the kernel writes a single value in kB).
+func readProcSelfStatusVmRSS() (int64, error) {
+	data, err := readFile("/proc/self/status")
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/self/status: %w", err)
+	}
+	return parseVmRSS(data)
+}
+
+func parseVmRSS(data []byte) (int64, error) {
+	prefix := []byte("VmRSS:")
+	idx := bytes.Index(data, prefix)
+	if idx < 0 {
+		return 0, fmt.Errorf("VmRSS line not found in /proc/self/status")
+	}
+	// After the prefix, skip whitespace and find the numeric value.
+	rest := data[idx+len(prefix):]
+	// Trim leading whitespace.
+	start := 0
+	for start < len(rest) && (rest[start] == ' ' || rest[start] == '\t') {
+		start++
+	}
+	end := start
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if start == end {
+		return 0, fmt.Errorf("VmRSS line malformed: no numeric value after `VmRSS:`")
+	}
+	kb, err := strconv.ParseInt(string(rest[start:end]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse VmRSS value %q: %w", string(rest[start:end]), err)
+	}
+	return kb * 1024, nil
+}
+
+// readProcSelfStatTicks parses utime (field 14) + stime (field 15)
+// from /proc/self/stat. The file is a single line of
+// space-separated fields. Field indexing is 1-based per `man 5
+// proc`; field 2 is `comm` in parens which may contain spaces, so
+// we find the closing `)` and split the rest.
+func readProcSelfStatTicks() (uint64, error) {
+	data, err := readFile("/proc/self/stat")
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/self/stat: %w", err)
+	}
+	return parseSelfStatTicks(data)
+}
+
+func parseSelfStatTicks(data []byte) (uint64, error) {
+	closeIdx := bytes.LastIndexByte(data, ')')
+	if closeIdx < 0 || closeIdx+1 >= len(data) {
+		return 0, fmt.Errorf("/proc/self/stat: closing `)` of comm not found")
+	}
+	tail := data[closeIdx+1:]
+	// Now fields 3.. are space-separated. utime is field 14
+	// overall, which is the (14 - 2) = 12th field of `tail` after
+	// trimming the leading space. Iterate counting fields.
+	fields := bytes.Fields(tail)
+	// fields[0] = field 3 (state). utime is field 14 → index 11.
+	// stime is field 15 → index 12.
+	if len(fields) < 13 {
+		return 0, fmt.Errorf("/proc/self/stat: not enough fields after comm (%d)", len(fields))
+	}
+	utime, err := strconv.ParseUint(string(fields[11]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse utime %q: %w", string(fields[11]), err)
+	}
+	stime, err := strconv.ParseUint(string(fields[12]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse stime %q: %w", string(fields[12]), err)
+	}
+	return utime + stime, nil
+}
+
+// readProcStatCPU0 parses the first "cpu " line of /proc/stat,
+// returning (total jiffies, idle jiffies). The line format is:
+//
+//	cpu user nice system idle iowait irq softirq steal guest guest_nice
+//
+// Total is the sum of all the numeric fields; idle is the 4th
+// numeric (after the "cpu" label).
+func readProcStatCPU0() (uint64, uint64, error) {
+	data, err := readFile("/proc/stat")
+	if err != nil {
+		return 0, 0, fmt.Errorf("read /proc/stat: %w", err)
+	}
+	return parseProcStatCPU0(data)
+}
+
+func parseProcStatCPU0(data []byte) (uint64, uint64, error) {
+	nl := bytes.IndexByte(data, '\n')
+	if nl < 0 {
+		nl = len(data)
+	}
+	first := data[:nl]
+	fields := bytes.Fields(first)
+	if len(fields) < 5 || !bytes.Equal(fields[0], []byte("cpu")) {
+		return 0, 0, fmt.Errorf("/proc/stat: expected `cpu ...` on first line")
+	}
+	var total, idle uint64
+	for i := 1; i < len(fields); i++ {
+		v, err := strconv.ParseUint(string(fields[i]), 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("parse /proc/stat cpu field %d (%q): %w", i, string(fields[i]), err)
+		}
+		total += v
+		if i == 4 { // idle is the 4th numeric field
+			idle = v
+		}
+	}
+	return total, idle, nil
+}
+
+// readProcMeminfo returns (MemTotal, MemAvailable) in bytes.
+func readProcMeminfo() (int64, int64, error) {
+	data, err := readFile("/proc/meminfo")
+	if err != nil {
+		return 0, 0, fmt.Errorf("read /proc/meminfo: %w", err)
+	}
+	return parseProcMeminfo(data)
+}
+
+func parseProcMeminfo(data []byte) (int64, int64, error) {
+	total, err := parseMeminfoField(data, "MemTotal:")
+	if err != nil {
+		return 0, 0, err
+	}
+	avail, err := parseMeminfoField(data, "MemAvailable:")
+	if err != nil {
+		return 0, 0, err
+	}
+	return total * 1024, avail * 1024, nil
+}
+
+func parseMeminfoField(data []byte, prefix string) (int64, error) {
+	idx := bytes.Index(data, []byte(prefix))
+	if idx < 0 {
+		return 0, fmt.Errorf("/proc/meminfo: %s not found", prefix)
+	}
+	rest := data[idx+len(prefix):]
+	start := 0
+	for start < len(rest) && (rest[start] == ' ' || rest[start] == '\t') {
+		start++
+	}
+	end := start
+	for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+		end++
+	}
+	if start == end {
+		return 0, fmt.Errorf("/proc/meminfo: no numeric after %s", prefix)
+	}
+	kb, err := strconv.ParseInt(string(rest[start:end]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s value %q: %w", prefix, string(rest[start:end]), err)
+	}
+	return kb, nil
+}
+
+// readFile is the test-injectable file reader. Tests override it
+// to feed parsers fixture bytes; production calls os.ReadFile.
+// Returns the raw OS error on failure so operator logs surface
+// the actual cause (e.g. "permission denied" on a hardened
+// container) rather than a downstream parse error like "VmRSS
+// line not found in /proc/self/status".
+var readFile = func(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/internal/metrics/proc_linux_test.go
+++ b/internal/metrics/proc_linux_test.go
@@ -1,0 +1,186 @@
+//go:build linux
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+)
+
+// Fixtures embedded as constants so the tests run anywhere, not
+// just on a machine whose /proc happens to have the right shape.
+
+const sampleStatusVmRSS = `Name:	loomcycle
+Umask:	0022
+State:	S (sleeping)
+Tgid:	12345
+VmPeak:	   53288 kB
+VmSize:	   48192 kB
+VmLck:	       0 kB
+VmRSS:	   45200 kB
+VmData:	   12000 kB
+Threads:	13
+`
+
+const sampleStatusNoVmRSS = `Name:	loomcycle
+State:	S (sleeping)
+VmSize:	   48192 kB
+`
+
+const sampleSelfStat = `12345 (loomcycle) S 1 12345 12345 0 -1 4194304 1234 0 0 0 250 100 0 0 20 0 13 0 12345678 48000000 5650 18446744073709551615 1 1 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0`
+
+const sampleProcStat = `cpu  100 50 200 4000 30 0 20 0 0 0
+cpu0 25 12 50 1000 7 0 5 0 0 0
+intr 12345 0 0 0
+`
+
+const sampleMeminfo = `MemTotal:        8073648 kB
+MemFree:          170380 kB
+MemAvailable:     145392 kB
+Buffers:            3100 kB
+Cached:           159644 kB
+`
+
+func TestParseVmRSS_HappyPath(t *testing.T) {
+	got, err := parseVmRSS([]byte(sampleStatusVmRSS))
+	if err != nil {
+		t.Fatalf("parseVmRSS: %v", err)
+	}
+	want := int64(45200) * 1024
+	if got != want {
+		t.Errorf("VmRSS = %d bytes, want %d", got, want)
+	}
+}
+
+func TestParseVmRSS_MalformedNoVmRSSLine(t *testing.T) {
+	_, err := parseVmRSS([]byte(sampleStatusNoVmRSS))
+	if err == nil {
+		t.Fatal("expected error when VmRSS missing")
+	}
+	if !strings.Contains(err.Error(), "VmRSS line not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParseSelfStatTicks_HappyPath(t *testing.T) {
+	// utime field 14 = "250", stime field 15 = "100" in fixture.
+	// Total = 350.
+	got, err := parseSelfStatTicks([]byte(sampleSelfStat))
+	if err != nil {
+		t.Fatalf("parseSelfStatTicks: %v", err)
+	}
+	if got != 350 {
+		t.Errorf("ticks = %d, want 350", got)
+	}
+}
+
+func TestParseProcStatCPU0_HappyPath(t *testing.T) {
+	total, idle, err := parseProcStatCPU0([]byte(sampleProcStat))
+	if err != nil {
+		t.Fatalf("parseProcStatCPU0: %v", err)
+	}
+	wantTotal := uint64(100 + 50 + 200 + 4000 + 30 + 0 + 20 + 0 + 0 + 0)
+	if total != wantTotal {
+		t.Errorf("total = %d, want %d", total, wantTotal)
+	}
+	if idle != 4000 {
+		t.Errorf("idle = %d, want 4000", idle)
+	}
+}
+
+func TestParseProcStatCPU0_Malformed(t *testing.T) {
+	_, _, err := parseProcStatCPU0([]byte("not the right shape\n"))
+	if err == nil {
+		t.Fatal("expected error on malformed /proc/stat")
+	}
+}
+
+func TestParseProcMeminfo_HappyPath(t *testing.T) {
+	total, avail, err := parseProcMeminfo([]byte(sampleMeminfo))
+	if err != nil {
+		t.Fatalf("parseProcMeminfo: %v", err)
+	}
+	wantTotal := int64(8073648) * 1024
+	wantAvail := int64(145392) * 1024
+	if total != wantTotal {
+		t.Errorf("MemTotal = %d, want %d", total, wantTotal)
+	}
+	if avail != wantAvail {
+		t.Errorf("MemAvailable = %d, want %d", avail, wantAvail)
+	}
+}
+
+func TestReadProcMetrics_DeltaCPU(t *testing.T) {
+	// Mock the file-reader so two sequential calls return two
+	// different /proc/self/stat snapshots — second has +50 ticks
+	// at +1 wall-clock second → CPU% ≈ 50.0 (50%×100 = 5000 in
+	// cpuPctX100 units).
+	defer restoreReadFile()
+	calls := 0
+	readFile = func(path string) ([]byte, error) {
+		switch path {
+		case "/proc/self/status":
+			return []byte(sampleStatusVmRSS), nil
+		case "/proc/self/stat":
+			calls++
+			if calls == 1 {
+				return []byte(sampleSelfStat), nil // utime+stime = 350
+			}
+			// Second call: utime field 14 = "350" (+100), stime field 15 = "100" (unchanged)
+			// total = 450 → delta 100 ticks
+			return []byte(`12345 (loomcycle) S 1 12345 12345 0 -1 4194304 1234 0 0 0 350 100 0 0 20 0 13 0 12345678 48000000 5650 18446744073709551615 1 1 0 0 0 0 0 0 0 0 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0`), nil
+		}
+		return nil, nil
+	}
+	// First call — populates `prev`, returns 0 CPU%.
+	m1, snap1, err := readProcMetrics(false, cpuSnapshot{})
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if m1.rssBytes == 0 {
+		t.Errorf("RSS not populated on first call: %d", m1.rssBytes)
+	}
+	if m1.cpuPctX100 != 0 {
+		t.Errorf("CPU should be 0 on first call (no prev); got %d", m1.cpuPctX100)
+	}
+	// Backdate snapshot by 1 second to simulate a 1 sec gap.
+	snap1.at = snap1.at.Add(-1_000_000_000) // -1s in nanoseconds
+	// Second call. Delta = 450 - 350 = 100 ticks. Wall = ~1s.
+	// CPU% = 100 ticks / 100 hz / 1s × 100 = 100%. ×100 = 10000.
+	m2, _, err := readProcMetrics(false, snap1)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	// Allow ±10% margin for timing slop.
+	if m2.cpuPctX100 < 9000 || m2.cpuPctX100 > 11000 {
+		t.Errorf("CPU%%×100 = %d, want ~10000 (delta 100 ticks / 1 sec)", m2.cpuPctX100)
+	}
+}
+
+func restoreReadFile() {
+	readFile = func(path string) ([]byte, error) {
+		return nil, nil
+	}
+}
+
+// TestReadProcMetrics_SurfacesOSError — a permission error from
+// the OS (e.g. hardened container blocking /proc) must surface as
+// the real OS error in the sampler log, not as a misleading parse
+// error like "VmRSS line not found".
+func TestReadProcMetrics_SurfacesOSError(t *testing.T) {
+	defer restoreReadFile()
+	readFile = func(path string) ([]byte, error) {
+		return nil, &mockOSError{msg: "permission denied"}
+	}
+	_, _, err := readProcMetrics(false, cpuSnapshot{})
+	if err == nil {
+		t.Fatal("expected error from readProcMetrics when /proc unreadable")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error message %q does not mention real OS cause", err.Error())
+	}
+}
+
+type mockOSError struct{ msg string }
+
+func (e *mockOSError) Error() string { return e.msg }

--- a/internal/metrics/proc_other.go
+++ b/internal/metrics/proc_other.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+// Package metrics — non-Linux stub for /proc/* readers.
+//
+// loomcycle's metrics sampler reads process RSS + CPU% from
+// /proc/self/status and /proc/self/stat (Linux-specific kernel
+// interfaces). On macOS / Windows / FreeBSD, those paths don't
+// exist; this build-tagged stub returns zero values so the sampler
+// still records the platform-independent fields (active_runs,
+// goroutine count, Go heap metrics).
+package metrics
+
+import "time"
+
+// ProcMetricsAvailable advertises whether per-process /proc-based
+// metrics will be populated on this platform. Build-tag-split:
+// true on Linux, false everywhere else.
+const ProcMetricsAvailable = false
+
+// procMetrics is the per-tick output of readProcMetrics. Empty on
+// non-Linux platforms.
+type procMetrics struct {
+	rssBytes             int64
+	cpuPctX100           int
+	systemCPUPctX100     *int
+	systemMemUsedMB      *int
+	systemMemAvailableMB *int
+}
+
+// cpuSnapshot is the previous-tick state needed for delta-CPU%
+// computation. Empty on non-Linux.
+type cpuSnapshot struct {
+	at time.Time
+}
+
+// readProcMetrics returns zero metrics on non-Linux platforms.
+// The caller (sampler) still writes a row with the
+// platform-independent fields populated — RSS/CPU columns just
+// land as 0 / NULL.
+func readProcMetrics(_ bool, prev cpuSnapshot) (procMetrics, cpuSnapshot, error) {
+	return procMetrics{}, prev, nil
+}

--- a/internal/metrics/sampler.go
+++ b/internal/metrics/sampler.go
@@ -1,0 +1,158 @@
+// Package metrics implements the v0.8.x process-resource sampler:
+// a background goroutine that periodically captures loomcycle's
+// own CPU + memory usage (and optionally system-wide CPU/mem)
+// WHILE at least one agent run is active, and writes a row to the
+// process_samples table for later correlation with run records.
+//
+// When no agent runs are active, the sampler skips the tick — no
+// /proc reads, no DB writes — so the idle-runtime cost is the
+// per-interval call to sem.Stats().
+//
+// The HTTP API at /v1/_metrics/* reads the persisted samples.
+package metrics
+
+import (
+	"context"
+	"log"
+	"runtime"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Config tunes the sampler. Operators set via env vars; the
+// Run() loop reads from the Sampler.cfg snapshot.
+type Config struct {
+	// Interval is the tick rate. Default 5s when zero; the
+	// config-load layer rejects values below 1s to prevent
+	// accidental write-storms.
+	Interval time.Duration
+	// CollectSystem enables /proc/stat + /proc/meminfo reads
+	// (Linux only; ignored silently on other platforms).
+	CollectSystem bool
+	// Logf is the log sink. nil → log.Printf.
+	Logf func(string, ...any)
+}
+
+// Sampler is the background-worker handle. Construct via New;
+// drive via Run(ctx).
+type Sampler struct {
+	cfg     Config
+	store   store.Store
+	sem     *concurrency.Semaphore
+	prevCPU cpuSnapshot
+	// failures is the consecutive-write-error counter. Sampler
+	// logs loudly on the first failure, then every 10th to avoid
+	// log flood on a wedged disk / Postgres pool.
+	failures int
+}
+
+// New constructs a Sampler. The store may be nil (writes will be
+// skipped with a single warning), but the semaphore must not be —
+// it's the idle gate.
+func New(st store.Store, sem *concurrency.Semaphore, cfg Config) *Sampler {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 5 * time.Second
+	}
+	if cfg.Logf == nil {
+		cfg.Logf = log.Printf
+	}
+	return &Sampler{cfg: cfg, store: st, sem: sem}
+}
+
+// Run blocks until ctx is done, sampling once per cfg.Interval
+// while at least one agent run is active.
+func (s *Sampler) Run(ctx context.Context) {
+	t := time.NewTicker(s.cfg.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			_ = s.sampleOnce(ctx, now)
+		}
+	}
+}
+
+// sampleOnce performs one tick of the sampler loop. Extracted
+// from Run for deterministic unit tests. Returns an error from
+// the store write path (if any); the caller logs + continues
+// (errors are NOT fatal — a transient store outage shouldn't
+// crash loomcycle).
+func (s *Sampler) sampleOnce(ctx context.Context, now time.Time) error {
+	// 1. Idle gate. If nothing is running AND nothing is queued,
+	//    skip — no /proc read, no DB write.
+	active, queued := 0, 0
+	if s.sem != nil {
+		active, queued = s.sem.Stats()
+	}
+	if active == 0 && queued == 0 {
+		return nil
+	}
+
+	// 2. Always-cheap measurements (Go heap + goroutines).
+	var rt runtime.MemStats
+	runtime.ReadMemStats(&rt)
+	sample := store.ProcessSample{
+		SampleID:            store.MintSampleID(now),
+		SampledAt:           now.UTC(),
+		ActiveRuns:          active,
+		QueuedRuns:          queued,
+		LoomcycleHeapAlloc:  int64(rt.HeapAlloc),
+		LoomcycleHeapInuse:  int64(rt.HeapInuse),
+		LoomcycleGoroutines: runtime.NumGoroutine(),
+	}
+
+	// 3. Linux-only /proc reads (RSS + per-process CPU + optional
+	//    system-wide). Errors here are soft — we still write the
+	//    row with the cheap fields, leaving RSS/CPU as zero.
+	if ProcMetricsAvailable {
+		pm, nextSnap, err := readProcMetrics(s.cfg.CollectSystem, s.prevCPU)
+		if err != nil {
+			// Log once-per-N to avoid spam on hardened-container
+			// /proc shapes.
+			if s.failures == 0 {
+				s.cfg.Logf("metrics: /proc read failed: %v (continuing with zero RSS/CPU)", err)
+			}
+			// /proc soft failures count toward the same backoff
+			// budget as store-write failures.
+			s.failures++
+		} else {
+			sample.LoomcycleRSSBytes = pm.rssBytes
+			sample.LoomcycleCPUPctX100 = pm.cpuPctX100
+			sample.SystemCPUPctX100 = pm.systemCPUPctX100
+			sample.SystemMemUsedMB = pm.systemMemUsedMB
+			sample.SystemMemAvailableMB = pm.systemMemAvailableMB
+			s.prevCPU = nextSnap
+		}
+	}
+
+	// 4. Persist. Soft-failure on store outage.
+	if s.store == nil {
+		return nil
+	}
+	if err := s.store.MetricsWriteSample(ctx, sample); err != nil {
+		s.recordFailure(err)
+		return err
+	}
+	// Successful write resets the failure counter — the sampler
+	// is back to a healthy state.
+	if s.failures > 0 {
+		s.cfg.Logf("metrics: write recovered after %d consecutive failures", s.failures)
+		s.failures = 0
+	}
+	return nil
+}
+
+// recordFailure increments the failure counter and emits a log
+// line at first failure and every 10th thereafter — preventing
+// log floods on a wedged disk or disconnected Postgres pool while
+// still surfacing the problem at startup.
+func (s *Sampler) recordFailure(err error) {
+	s.failures++
+	if s.failures == 1 || s.failures%10 == 0 {
+		s.cfg.Logf("metrics: write failed (consecutive=%d): %v", s.failures, err)
+	}
+}

--- a/internal/metrics/sampler_test.go
+++ b/internal/metrics/sampler_test.go
@@ -1,0 +1,183 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// fakeStore is a store.Store that ONLY implements the metrics
+// methods. Unused methods inherit from the embedded interface; the
+// interface is nil at construction, so any non-metrics call panics
+// with a nil-pointer dereference. That's the desired test fence —
+// if the sampler accidentally starts calling MemoryGet (etc.), the
+// test will fail loudly rather than silently succeed.
+//
+// This pattern is robust against future Store interface additions:
+// new methods that the sampler doesn't call require no test
+// changes at all.
+type fakeStore struct {
+	store.Store // intentionally nil — unused methods nil-panic
+
+	writes     []store.ProcessSample
+	writeError error
+}
+
+func (f *fakeStore) MetricsWriteSample(_ context.Context, s store.ProcessSample) error {
+	if f.writeError != nil {
+		return f.writeError
+	}
+	f.writes = append(f.writes, s)
+	return nil
+}
+
+func (f *fakeStore) MetricsSampleWindow(context.Context, time.Time, time.Time, int, string) ([]store.ProcessSample, string, error) {
+	return nil, "", nil
+}
+
+func (f *fakeStore) MetricsRunSummary(context.Context, string) (store.MetricsRunWindow, error) {
+	return store.MetricsRunWindow{}, nil
+}
+
+func (f *fakeStore) MetricsSweep(context.Context, time.Time) (int, error) {
+	return 0, nil
+}
+
+// TestSampler_SkipsWhenIdle: no active runs → no write.
+func TestSampler_SkipsWhenIdle(t *testing.T) {
+	fs := &fakeStore{}
+	sem := concurrency.New(8, 16, time.Second)
+	s := New(fs, sem, Config{Interval: time.Second})
+	if err := s.sampleOnce(context.Background(), time.Now()); err != nil {
+		t.Fatalf("sampleOnce: %v", err)
+	}
+	if len(fs.writes) != 0 {
+		t.Errorf("got %d writes, want 0 (idle)", len(fs.writes))
+	}
+}
+
+// TestSampler_WritesWhenActive: at least one active run → one
+// write with the correct active_runs/queued_runs fields.
+func TestSampler_WritesWhenActive(t *testing.T) {
+	fs := &fakeStore{}
+	sem := concurrency.New(8, 16, time.Second)
+	// Acquire 2 slots to drive active=2.
+	ctx := context.Background()
+	rel1, err := sem.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel1()
+	rel2, err := sem.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel2()
+	s := New(fs, sem, Config{Interval: time.Second})
+	now := time.Now()
+	if err := s.sampleOnce(ctx, now); err != nil {
+		t.Fatalf("sampleOnce: %v", err)
+	}
+	if len(fs.writes) != 1 {
+		t.Fatalf("got %d writes, want 1", len(fs.writes))
+	}
+	got := fs.writes[0]
+	if got.ActiveRuns != 2 {
+		t.Errorf("active_runs = %d, want 2", got.ActiveRuns)
+	}
+	if got.QueuedRuns != 0 {
+		t.Errorf("queued_runs = %d, want 0", got.QueuedRuns)
+	}
+	if got.SampleID == "" {
+		t.Error("SampleID empty")
+	}
+	if got.LoomcycleGoroutines <= 0 {
+		t.Errorf("goroutines = %d, want > 0", got.LoomcycleGoroutines)
+	}
+	if got.LoomcycleHeapAlloc <= 0 {
+		t.Errorf("heap_alloc = %d, want > 0", got.LoomcycleHeapAlloc)
+	}
+}
+
+// TestSampler_GracefulStoreError: store returns error → sampler
+// logs + counts the failure, doesn't panic. Subsequent ticks
+// still attempt.
+func TestSampler_GracefulStoreError(t *testing.T) {
+	fs := &fakeStore{writeError: errors.New("simulated DB outage")}
+	sem := concurrency.New(8, 16, time.Second)
+	ctx := context.Background()
+	rel, _ := sem.Acquire(ctx)
+	defer rel()
+	logs := 0
+	s := New(fs, sem, Config{
+		Interval: time.Second,
+		Logf:     func(string, ...any) { logs++ },
+	})
+	if err := s.sampleOnce(ctx, time.Now()); err == nil {
+		t.Fatal("expected error from sampleOnce, got nil")
+	}
+	if s.failures != 1 {
+		t.Errorf("failures = %d after first error, want 1", s.failures)
+	}
+	if logs != 1 {
+		t.Errorf("log count = %d after first error, want 1 (loud-on-first)", logs)
+	}
+	// Subsequent failures up to N=9 should NOT log (rate-limit).
+	for i := 0; i < 8; i++ {
+		_ = s.sampleOnce(ctx, time.Now())
+	}
+	if logs != 1 {
+		t.Errorf("log count = %d after 9 errors, want still 1 (rate-limited)", logs)
+	}
+	// 10th failure logs again.
+	_ = s.sampleOnce(ctx, time.Now())
+	if logs != 2 {
+		t.Errorf("log count = %d after 10 errors, want 2", logs)
+	}
+}
+
+// TestSampler_NilStore: sampler with no store wired (e.g., metrics
+// enabled but DB initialisation deferred). Must not panic; no
+// writes.
+func TestSampler_NilStore(t *testing.T) {
+	sem := concurrency.New(8, 16, time.Second)
+	ctx := context.Background()
+	rel, _ := sem.Acquire(ctx)
+	defer rel()
+	s := New(nil, sem, Config{Interval: time.Second})
+	if err := s.sampleOnce(ctx, time.Now()); err != nil {
+		t.Errorf("nil-store sampleOnce returned err: %v", err)
+	}
+}
+
+// TestSampler_RecoveryResetsCounter: a successful write after a
+// failure run resets the failure counter.
+func TestSampler_RecoveryResetsCounter(t *testing.T) {
+	fs := &fakeStore{writeError: errors.New("transient")}
+	sem := concurrency.New(8, 16, time.Second)
+	ctx := context.Background()
+	rel, _ := sem.Acquire(ctx)
+	defer rel()
+	s := New(fs, sem, Config{
+		Interval: time.Second,
+		Logf:     func(string, ...any) {},
+	})
+	// Two failures.
+	_ = s.sampleOnce(ctx, time.Now())
+	_ = s.sampleOnce(ctx, time.Now())
+	if s.failures != 2 {
+		t.Errorf("failures = %d, want 2", s.failures)
+	}
+	// Clear the simulated outage.
+	fs.writeError = nil
+	if err := s.sampleOnce(ctx, time.Now()); err != nil {
+		t.Fatalf("post-recovery sampleOnce returned err: %v", err)
+	}
+	if s.failures != 0 {
+		t.Errorf("failures = %d after recovery, want 0", s.failures)
+	}
+}

--- a/internal/store/postgres/migrations/0009_process_samples.down.sql
+++ b/internal/store/postgres/migrations/0009_process_samples.down.sql
@@ -1,0 +1,2 @@
+-- 0009_process_samples.down.sql — drop the v0.8.x metrics sampler table.
+DROP TABLE IF EXISTS process_samples;

--- a/internal/store/postgres/migrations/0009_process_samples.up.sql
+++ b/internal/store/postgres/migrations/0009_process_samples.up.sql
@@ -1,0 +1,37 @@
+-- 0009_process_samples.up.sql — v0.8.x process-resource metrics sampler.
+--
+-- New table for periodic process-resource samples (RSS, Go heap,
+-- goroutine count, CPU%) captured while at least one agent run is
+-- active. Time-series shape — one row per sample tick; populated
+-- by internal/metrics/sampler.go.
+--
+-- The Linux-only fields (loomcycle_rss_bytes, loomcycle_cpu_pct_x100)
+-- store 0 on non-Linux platforms (build-tag-split in the sampler).
+-- system_* columns are NULLable; only populated when the operator
+-- sets LOOMCYCLE_METRICS_COLLECT_SYSTEM=1.
+--
+-- No foreign keys to `runs` — this is a time-series; correlation
+-- with a specific run is done at query time via the API endpoint
+-- (`GET /v1/_metrics/runs/{run_id}`) which joins on the
+-- (started_at, completed_at) window of the runs row.
+--
+-- Index: process_samples_by_sampled_at drives BOTH the window-scan
+-- read path (`/v1/_metrics/samples?since&until`) AND the sweeper
+-- DELETE (rows older than retention cutoff).
+
+CREATE TABLE process_samples (
+    sample_id                  TEXT        PRIMARY KEY,
+    sampled_at                 TIMESTAMPTZ NOT NULL,
+    active_runs                INTEGER     NOT NULL,
+    queued_runs                INTEGER     NOT NULL,
+    loomcycle_rss_bytes        BIGINT      NOT NULL DEFAULT 0,
+    loomcycle_heap_alloc_bytes BIGINT      NOT NULL DEFAULT 0,
+    loomcycle_heap_inuse_bytes BIGINT      NOT NULL DEFAULT 0,
+    loomcycle_num_goroutines   INTEGER     NOT NULL DEFAULT 0,
+    loomcycle_cpu_pct_x100     INTEGER     NOT NULL DEFAULT 0,
+    system_cpu_pct_x100        INTEGER,
+    system_mem_used_mb         INTEGER,
+    system_mem_available_mb    INTEGER
+);
+
+CREATE INDEX process_samples_by_sampled_at ON process_samples(sampled_at);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -498,6 +498,157 @@ func (s *Store) SweepStaleRuns(ctx context.Context, cutoff time.Time) (int, erro
 	return int(tag.RowsAffected()), nil
 }
 
+// ---- v0.8.x Process-resource metrics sampler ----
+
+// MetricsWriteSample inserts one process_samples row.
+func (s *Store) MetricsWriteSample(ctx context.Context, sample store.ProcessSample) error {
+	var sysCPU, sysMemUsed, sysMemAvail any
+	if sample.SystemCPUPctX100 != nil {
+		sysCPU = *sample.SystemCPUPctX100
+	}
+	if sample.SystemMemUsedMB != nil {
+		sysMemUsed = *sample.SystemMemUsedMB
+	}
+	if sample.SystemMemAvailableMB != nil {
+		sysMemAvail = *sample.SystemMemAvailableMB
+	}
+	_, err := s.pool.Exec(ctx, `INSERT INTO process_samples(
+		sample_id, sampled_at, active_runs, queued_runs,
+		loomcycle_rss_bytes, loomcycle_heap_alloc_bytes, loomcycle_heap_inuse_bytes,
+		loomcycle_num_goroutines, loomcycle_cpu_pct_x100,
+		system_cpu_pct_x100, system_mem_used_mb, system_mem_available_mb
+	) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		sample.SampleID, sample.SampledAt, sample.ActiveRuns, sample.QueuedRuns,
+		sample.LoomcycleRSSBytes, sample.LoomcycleHeapAlloc, sample.LoomcycleHeapInuse,
+		sample.LoomcycleGoroutines, sample.LoomcycleCPUPctX100,
+		sysCPU, sysMemUsed, sysMemAvail,
+	)
+	if err != nil {
+		return fmt.Errorf("metrics: write sample: %w", err)
+	}
+	return nil
+}
+
+// MetricsSampleWindow returns samples in [since, until] ordered by
+// sampled_at ASC then sample_id ASC. Pagination via the last
+// sample_id seen.
+func (s *Store) MetricsSampleWindow(ctx context.Context, since, until time.Time, limit int, cursor string) ([]store.ProcessSample, string, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	q := `SELECT sample_id, sampled_at, active_runs, queued_runs,
+	             loomcycle_rss_bytes, loomcycle_heap_alloc_bytes, loomcycle_heap_inuse_bytes,
+	             loomcycle_num_goroutines, loomcycle_cpu_pct_x100,
+	             system_cpu_pct_x100, system_mem_used_mb, system_mem_available_mb
+	      FROM process_samples
+	      WHERE sampled_at BETWEEN $1 AND $2`
+	args := []any{since, until}
+	if cursor != "" {
+		q += ` AND sample_id > $3`
+		args = append(args, cursor)
+	}
+	q += ` ORDER BY sampled_at ASC, sample_id ASC LIMIT $` + fmt.Sprint(len(args)+1)
+	args = append(args, limit+1)
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("metrics: query window: %w", err)
+	}
+	defer rows.Close()
+	out := make([]store.ProcessSample, 0, limit)
+	for rows.Next() {
+		var (
+			rec                          store.ProcessSample
+			sysCPU, sysMemU, sysMemAvail *int
+		)
+		if err := rows.Scan(
+			&rec.SampleID, &rec.SampledAt, &rec.ActiveRuns, &rec.QueuedRuns,
+			&rec.LoomcycleRSSBytes, &rec.LoomcycleHeapAlloc, &rec.LoomcycleHeapInuse,
+			&rec.LoomcycleGoroutines, &rec.LoomcycleCPUPctX100,
+			&sysCPU, &sysMemU, &sysMemAvail,
+		); err != nil {
+			return nil, "", fmt.Errorf("metrics: scan sample: %w", err)
+		}
+		rec.SystemCPUPctX100 = sysCPU
+		rec.SystemMemUsedMB = sysMemU
+		rec.SystemMemAvailableMB = sysMemAvail
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("metrics: iterate samples: %w", err)
+	}
+	nextCursor := ""
+	if len(out) > limit {
+		out = out[:limit]
+		nextCursor = out[len(out)-1].SampleID
+	}
+	return out, nextCursor, nil
+}
+
+// MetricsRunSummary aggregates samples overlapping the run's window.
+func (s *Store) MetricsRunSummary(ctx context.Context, runID string) (store.MetricsRunWindow, error) {
+	var (
+		startedAt   time.Time
+		completedAt *time.Time
+	)
+	row := s.pool.QueryRow(ctx, `SELECT started_at, completed_at FROM runs WHERE id = $1`, runID)
+	if err := row.Scan(&startedAt, &completedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return store.MetricsRunWindow{}, &store.ErrNotFound{Kind: "run", ID: runID}
+		}
+		return store.MetricsRunWindow{}, fmt.Errorf("metrics: read run %s: %w", runID, err)
+	}
+	upper := time.Now().UTC()
+	if completedAt != nil {
+		upper = *completedAt
+	}
+	var (
+		sampleCount   int
+		peakRSS       *int64
+		meanRSS       *float64
+		maxCPUPctX100 *int
+	)
+	row = s.pool.QueryRow(ctx, `SELECT
+		COUNT(*),
+		MAX(loomcycle_rss_bytes),
+		AVG(loomcycle_rss_bytes),
+		MAX(loomcycle_cpu_pct_x100)
+	FROM process_samples
+	WHERE sampled_at BETWEEN $1 AND $2`, startedAt, upper)
+	if err := row.Scan(&sampleCount, &peakRSS, &meanRSS, &maxCPUPctX100); err != nil {
+		return store.MetricsRunWindow{}, fmt.Errorf("metrics: aggregate run %s: %w", runID, err)
+	}
+	out := store.MetricsRunWindow{
+		RunID:       runID,
+		StartedAt:   startedAt,
+		SampleCount: sampleCount,
+	}
+	if completedAt != nil {
+		out.CompletedAt = *completedAt
+	}
+	if peakRSS != nil {
+		out.PeakRSSBytes = *peakRSS
+	}
+	if meanRSS != nil {
+		out.MeanRSSBytes = int64(*meanRSS)
+	}
+	if maxCPUPctX100 != nil {
+		out.MaxCPUPctX100 = *maxCPUPctX100
+	}
+	return out, nil
+}
+
+// MetricsSweep deletes samples with sampled_at < cutoff.
+func (s *Store) MetricsSweep(ctx context.Context, cutoff time.Time) (int, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM process_samples WHERE sampled_at < $1`, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("metrics: sweep: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Close releases the connection pool. Idempotent.
 func (s *Store) Close() error {
 	s.closeOnce.Do(func() {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -206,6 +206,30 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS evaluations_by_run     ON evaluations(run_id)`,
 		`CREATE INDEX IF NOT EXISTS evaluations_by_def     ON evaluations(def_id) WHERE def_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS evaluations_by_emitter ON evaluations(emitter_agent_id) WHERE emitter_agent_id IS NOT NULL`,
+		// v0.8.x Process-resource metrics sampler. process_samples
+		// is a time-series table: one row per sample tick while
+		// at least one agent run is active. NULLable system_* fields
+		// are populated only when LOOMCYCLE_METRICS_COLLECT_SYSTEM=1.
+		// See internal/metrics/sampler.go for the write path and
+		// the API endpoints under /v1/_metrics/* for read paths.
+		`CREATE TABLE IF NOT EXISTS process_samples (
+			sample_id                  TEXT    PRIMARY KEY,
+			sampled_at                 INTEGER NOT NULL,
+			active_runs                INTEGER NOT NULL,
+			queued_runs                INTEGER NOT NULL,
+			loomcycle_rss_bytes        INTEGER NOT NULL DEFAULT 0,
+			loomcycle_heap_alloc_bytes INTEGER NOT NULL DEFAULT 0,
+			loomcycle_heap_inuse_bytes INTEGER NOT NULL DEFAULT 0,
+			loomcycle_num_goroutines   INTEGER NOT NULL DEFAULT 0,
+			loomcycle_cpu_pct_x100     INTEGER NOT NULL DEFAULT 0,
+			system_cpu_pct_x100        INTEGER,
+			system_mem_used_mb         INTEGER,
+			system_mem_available_mb    INTEGER
+		)`,
+		// NOTE: process_samples_by_sampled_at is created in `addIndexes`
+		// below (defensive: future column additions via ALTER TABLE
+		// would otherwise risk the upgrade-path bug that hit
+		// channel_messages_by_visible in v0.8.6).
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -274,6 +298,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		// v0.8.4/v0.8.5 → v0.8.6+ (channel_messages table exists
 		// from v0.8.4 without visible_at).
 		`CREATE INDEX IF NOT EXISTS channel_messages_by_visible ON channel_messages(channel, scope, scope_id, visible_at, id)`,
+		// v0.8.x process_samples_by_sampled_at. Drives the read
+		// path for /v1/_metrics/samples (window scan) and the
+		// sweep DELETE WHERE sampled_at < cutoff.
+		`CREATE INDEX IF NOT EXISTS process_samples_by_sampled_at ON process_samples(sampled_at)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -1920,6 +1948,183 @@ func nilIfEmpty(s string) any {
 		return nil
 	}
 	return s
+}
+
+// ---- v0.8.x Process-resource metrics sampler ----
+
+// MetricsWriteSample inserts one process_samples row. Nullable
+// system_* fields are stored as NULL when their pointer is nil.
+func (s *Store) MetricsWriteSample(ctx context.Context, sample store.ProcessSample) error {
+	var (
+		sysCPU, sysMemUsed, sysMemAvail sql.NullInt64
+	)
+	if sample.SystemCPUPctX100 != nil {
+		sysCPU = sql.NullInt64{Valid: true, Int64: int64(*sample.SystemCPUPctX100)}
+	}
+	if sample.SystemMemUsedMB != nil {
+		sysMemUsed = sql.NullInt64{Valid: true, Int64: int64(*sample.SystemMemUsedMB)}
+	}
+	if sample.SystemMemAvailableMB != nil {
+		sysMemAvail = sql.NullInt64{Valid: true, Int64: int64(*sample.SystemMemAvailableMB)}
+	}
+	_, err := s.db.ExecContext(ctx, `INSERT INTO process_samples(
+		sample_id, sampled_at, active_runs, queued_runs,
+		loomcycle_rss_bytes, loomcycle_heap_alloc_bytes, loomcycle_heap_inuse_bytes,
+		loomcycle_num_goroutines, loomcycle_cpu_pct_x100,
+		system_cpu_pct_x100, system_mem_used_mb, system_mem_available_mb
+	) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)`,
+		sample.SampleID, sample.SampledAt.UnixNano(), sample.ActiveRuns, sample.QueuedRuns,
+		sample.LoomcycleRSSBytes, sample.LoomcycleHeapAlloc, sample.LoomcycleHeapInuse,
+		sample.LoomcycleGoroutines, sample.LoomcycleCPUPctX100,
+		sysCPU, sysMemUsed, sysMemAvail,
+	)
+	if err != nil {
+		return fmt.Errorf("metrics: write sample: %w", err)
+	}
+	return nil
+}
+
+// MetricsSampleWindow returns samples in [since, until] ordered by
+// sampled_at ASC then sample_id ASC. Cursor is the sample_id of the
+// last row from the previous page (empty = from start). limit ≤ 0
+// → 200, capped at 1000.
+func (s *Store) MetricsSampleWindow(ctx context.Context, since, until time.Time, limit int, cursor string) ([]store.ProcessSample, string, error) {
+	if limit <= 0 {
+		limit = 200
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	// Use sampled_at as the primary order key; sample_id as
+	// tie-breaker. Cursor is just the last seen sample_id since
+	// MintSampleID encodes sampled_at in its prefix — strictly
+	// monotonic per ns.
+	args := []any{since.UnixNano(), until.UnixNano()}
+	q := `SELECT sample_id, sampled_at, active_runs, queued_runs,
+	             loomcycle_rss_bytes, loomcycle_heap_alloc_bytes, loomcycle_heap_inuse_bytes,
+	             loomcycle_num_goroutines, loomcycle_cpu_pct_x100,
+	             system_cpu_pct_x100, system_mem_used_mb, system_mem_available_mb
+	      FROM process_samples
+	      WHERE sampled_at BETWEEN ? AND ?`
+	if cursor != "" {
+		q += ` AND sample_id > ?`
+		args = append(args, cursor)
+	}
+	q += ` ORDER BY sampled_at ASC, sample_id ASC LIMIT ?`
+	args = append(args, limit+1) // fetch one extra to detect next page
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("metrics: query window: %w", err)
+	}
+	defer rows.Close()
+	out := make([]store.ProcessSample, 0, limit)
+	for rows.Next() {
+		var (
+			rec                          store.ProcessSample
+			sampledAtNs                  int64
+			sysCPU, sysMemU, sysMemAvail sql.NullInt64
+		)
+		if err := rows.Scan(
+			&rec.SampleID, &sampledAtNs, &rec.ActiveRuns, &rec.QueuedRuns,
+			&rec.LoomcycleRSSBytes, &rec.LoomcycleHeapAlloc, &rec.LoomcycleHeapInuse,
+			&rec.LoomcycleGoroutines, &rec.LoomcycleCPUPctX100,
+			&sysCPU, &sysMemU, &sysMemAvail,
+		); err != nil {
+			return nil, "", fmt.Errorf("metrics: scan sample: %w", err)
+		}
+		rec.SampledAt = time.Unix(0, sampledAtNs).UTC()
+		if sysCPU.Valid {
+			v := int(sysCPU.Int64)
+			rec.SystemCPUPctX100 = &v
+		}
+		if sysMemU.Valid {
+			v := int(sysMemU.Int64)
+			rec.SystemMemUsedMB = &v
+		}
+		if sysMemAvail.Valid {
+			v := int(sysMemAvail.Int64)
+			rec.SystemMemAvailableMB = &v
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("metrics: iterate samples: %w", err)
+	}
+	nextCursor := ""
+	if len(out) > limit {
+		// We fetched limit+1; the (limit+1)-th row is the marker
+		// for "more available." Truncate and return its predecessor
+		// as the cursor.
+		out = out[:limit]
+		nextCursor = out[len(out)-1].SampleID
+	}
+	return out, nextCursor, nil
+}
+
+// MetricsRunSummary aggregates process_samples whose sampled_at
+// overlaps the run's [started_at, COALESCE(completed_at, now)]
+// window. Returns *ErrNotFound when the run row doesn't exist.
+func (s *Store) MetricsRunSummary(ctx context.Context, runID string) (store.MetricsRunWindow, error) {
+	var (
+		startedAtNs   int64
+		completedAtNs sql.NullInt64
+	)
+	row := s.db.QueryRowContext(ctx, `SELECT started_at, completed_at FROM runs WHERE id = ?`, runID)
+	if err := row.Scan(&startedAtNs, &completedAtNs); err != nil {
+		if err == sql.ErrNoRows {
+			return store.MetricsRunWindow{}, &store.ErrNotFound{Kind: "run", ID: runID}
+		}
+		return store.MetricsRunWindow{}, fmt.Errorf("metrics: read run %s: %w", runID, err)
+	}
+	upper := time.Now().UnixNano()
+	if completedAtNs.Valid {
+		upper = completedAtNs.Int64
+	}
+	var (
+		sampleCount   int
+		peakRSS       sql.NullInt64
+		meanRSS       sql.NullFloat64
+		maxCPUPctX100 sql.NullInt64
+	)
+	row = s.db.QueryRowContext(ctx, `SELECT
+		COUNT(*),
+		MAX(loomcycle_rss_bytes),
+		AVG(loomcycle_rss_bytes),
+		MAX(loomcycle_cpu_pct_x100)
+	FROM process_samples
+	WHERE sampled_at BETWEEN ? AND ?`, startedAtNs, upper)
+	if err := row.Scan(&sampleCount, &peakRSS, &meanRSS, &maxCPUPctX100); err != nil {
+		return store.MetricsRunWindow{}, fmt.Errorf("metrics: aggregate run %s: %w", runID, err)
+	}
+	out := store.MetricsRunWindow{
+		RunID:       runID,
+		StartedAt:   time.Unix(0, startedAtNs).UTC(),
+		SampleCount: sampleCount,
+	}
+	if completedAtNs.Valid {
+		out.CompletedAt = time.Unix(0, completedAtNs.Int64).UTC()
+	}
+	if peakRSS.Valid {
+		out.PeakRSSBytes = peakRSS.Int64
+	}
+	if meanRSS.Valid {
+		out.MeanRSSBytes = int64(meanRSS.Float64)
+	}
+	if maxCPUPctX100.Valid {
+		out.MaxCPUPctX100 = int(maxCPUPctX100.Int64)
+	}
+	return out, nil
+}
+
+// MetricsSweep deletes samples with sampled_at < cutoff. Returns
+// the count deleted.
+func (s *Store) MetricsSweep(ctx context.Context, cutoff time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM process_samples WHERE sampled_at < ?`, cutoff.UnixNano())
+	if err != nil {
+		return 0, fmt.Errorf("metrics: sweep: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
 }
 
 // Close closes the underlying *sql.DB. Idempotent.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -560,6 +560,35 @@ type Store interface {
 	// echoes the option for caller-side assertion.
 	EvaluationAggregate(ctx context.Context, defID string, opts AggregateOpts) (AggregateResult, error)
 
+	// ---- Metrics sampler (v0.8.x) -------------------------------------
+
+	// MetricsWriteSample persists one process_samples row. The caller
+	// pre-generates SampleID via MintSampleID. SampledAt must be set;
+	// the store does not stamp time on its own (the sampler decides
+	// when "now" is — important for unit tests with deterministic
+	// clocks).
+	MetricsWriteSample(ctx context.Context, s ProcessSample) error
+
+	// MetricsSampleWindow returns samples whose sampled_at falls in
+	// [since, until] (inclusive both ends). Returns up to `limit`
+	// rows (≤ 0 → 200 default; cap 1000). Cursor is an opaque token
+	// from a previous call's nextCursor (empty = from start of
+	// window). Returns nextCursor empty when no more rows.
+	MetricsSampleWindow(ctx context.Context, since, until time.Time, limit int, cursor string) (samples []ProcessSample, nextCursor string, err error)
+
+	// MetricsRunSummary returns peak/mean RSS + max CPU% from
+	// process_samples rows whose sampled_at overlaps the run's
+	// [started_at, COALESCE(completed_at, now())] window. Returns
+	// MetricsRunWindow with zero SampleCount + zero values when no
+	// samples overlap (in-flight run with metrics disabled, or a
+	// freshly-started run that hasn't ticked yet). *ErrNotFound when
+	// the run_id itself doesn't exist.
+	MetricsRunSummary(ctx context.Context, runID string) (MetricsRunWindow, error)
+
+	// MetricsSweep deletes samples whose sampled_at < cutoff. Returns
+	// the count deleted. Idempotent under concurrent sweepers.
+	MetricsSweep(ctx context.Context, cutoff time.Time) (int, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -689,6 +718,56 @@ type ChannelError struct {
 }
 
 func (e *ChannelError) Error() string { return e.Msg }
+
+// ---- v0.8.x Process-resource metrics sampler types ----
+
+// MintSampleID returns a fresh process_samples row id. Format:
+// "smp_<16-hex unixNanos><8-hex rand>" — sortable lexicographically
+// by sample time within the resolution of a single nanosecond.
+// Mirrors MintChannelMessageID; same trade-offs documented there.
+func MintSampleID(t time.Time) string {
+	var buf [4]byte
+	_, _ = rand.Read(buf[:])
+	return fmt.Sprintf("smp_%016x%s", uint64(t.UnixNano()), hex.EncodeToString(buf[:]))
+}
+
+// ProcessSample is one row in the process_samples table. Captured
+// by the metrics sampler when at least one agent run is active.
+// Linux-only fields (RSS, CPU%) are 0 on non-Linux platforms; the
+// sampler's build-tag-split readers handle the gating.
+//
+// System-wide fields are pointer-typed because they may be NULL —
+// they're only populated when LOOMCYCLE_METRICS_COLLECT_SYSTEM=1
+// AND the platform is Linux.
+type ProcessSample struct {
+	SampleID             string    `json:"sample_id"` // "smp_<16hex><8hex>"
+	SampledAt            time.Time `json:"sampled_at"`
+	ActiveRuns           int       `json:"active_runs"`
+	QueuedRuns           int       `json:"queued_runs"`
+	LoomcycleRSSBytes    int64     `json:"loomcycle_rss_bytes"` // 0 on non-Linux
+	LoomcycleHeapAlloc   int64     `json:"loomcycle_heap_alloc_bytes"`
+	LoomcycleHeapInuse   int64     `json:"loomcycle_heap_inuse_bytes"`
+	LoomcycleGoroutines  int       `json:"loomcycle_num_goroutines"`
+	LoomcycleCPUPctX100  int       `json:"loomcycle_cpu_pct_x100"` // 0 on non-Linux; %×100
+	SystemCPUPctX100     *int      `json:"system_cpu_pct_x100,omitempty"`
+	SystemMemUsedMB      *int      `json:"system_mem_used_mb,omitempty"`
+	SystemMemAvailableMB *int      `json:"system_mem_available_mb,omitempty"`
+}
+
+// MetricsRunWindow is the result of MetricsRunSummary — peak/mean
+// RSS + max CPU% from process_samples whose sampled_at overlaps the
+// run's lifetime window. SampleCount=0 means no overlapping samples
+// (in-flight run with no ticks yet, or metrics disabled when the
+// run executed).
+type MetricsRunWindow struct {
+	RunID         string    `json:"run_id"`
+	StartedAt     time.Time `json:"started_at"`
+	CompletedAt   time.Time `json:"completed_at,omitempty"` // zero when in-flight
+	SampleCount   int       `json:"sample_count"`
+	PeakRSSBytes  int64     `json:"peak_rss_bytes"`
+	MeanRSSBytes  int64     `json:"mean_rss_bytes"`
+	MaxCPUPctX100 int       `json:"max_cpu_pct_x100"`
+}
 
 // ---- v0.8.5 Self-Evolution Substrate types ----
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -112,6 +112,13 @@ func Run(t *testing.T, factory Factory) {
 		{"AgentDefStaticFallback", testAgentDefStaticFallback},
 		{"EvaluationSubmitAndAggregate", testEvaluationSubmitAndAggregate},
 		{"EvaluationAggregateWithLineage", testEvaluationAggregateWithLineage},
+		// v0.8.x Process-resource metrics sampler
+		{"MetricsWriteAndQuery", testMetricsWriteAndQuery},
+		{"MetricsSweep", testMetricsSweep},
+		{"MetricsRunSummaryEmpty", testMetricsRunSummaryEmpty},
+		{"MetricsRunSummaryWithSamples", testMetricsRunSummaryWithSamples},
+		{"MetricsRunSummaryInFlight", testMetricsRunSummaryInFlight},
+		{"MetricsRunSummaryNotFound", testMetricsRunSummaryNotFound},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1908,5 +1915,204 @@ func testEvaluationAggregateWithLineage(t *testing.T, s store.Store) {
 	}
 	if !agg.LineageIncluded {
 		t.Error("LineageIncluded flag not set")
+	}
+}
+
+// ---- v0.8.x Process-resource metrics sampler ----
+
+// metricsMakeSample builds a ProcessSample for tests. Caller may
+// adjust fields before passing to MetricsWriteSample.
+func metricsMakeSample(t *testing.T, sampledAt time.Time, active, queued int, rss int64) store.ProcessSample {
+	t.Helper()
+	return store.ProcessSample{
+		SampleID:            store.MintSampleID(sampledAt),
+		SampledAt:           sampledAt,
+		ActiveRuns:          active,
+		QueuedRuns:          queued,
+		LoomcycleRSSBytes:   rss,
+		LoomcycleHeapAlloc:  rss / 2,
+		LoomcycleHeapInuse:  rss / 3,
+		LoomcycleGoroutines: 50,
+		LoomcycleCPUPctX100: 1234,
+	}
+}
+
+func testMetricsWriteAndQuery(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Microsecond)
+	samples := []store.ProcessSample{
+		metricsMakeSample(t, base.Add(-3*time.Second), 1, 0, 100<<20),
+		metricsMakeSample(t, base.Add(-2*time.Second), 2, 1, 110<<20),
+		metricsMakeSample(t, base.Add(-1*time.Second), 3, 0, 95<<20),
+	}
+	for _, sa := range samples {
+		if err := s.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatalf("MetricsWriteSample: %v", err)
+		}
+	}
+	got, nextCursor, err := s.MetricsSampleWindow(ctx, base.Add(-10*time.Second), base, 0, "")
+	if err != nil {
+		t.Fatalf("MetricsSampleWindow: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d samples, want 3", len(got))
+	}
+	if nextCursor != "" {
+		t.Errorf("nextCursor = %q, want empty (only 3 rows ≤ default limit 200)", nextCursor)
+	}
+	// Ordering: sampled_at ASC.
+	for i := 1; i < len(got); i++ {
+		if !got[i].SampledAt.After(got[i-1].SampledAt) && !got[i].SampledAt.Equal(got[i-1].SampledAt) {
+			t.Errorf("sample %d at %v not >= sample %d at %v", i, got[i].SampledAt, i-1, got[i-1].SampledAt)
+		}
+	}
+	// Field round-trip on the first sample.
+	if got[0].ActiveRuns != 1 || got[0].QueuedRuns != 0 || got[0].LoomcycleRSSBytes != 100<<20 {
+		t.Errorf("sample[0] round-trip failed: %+v", got[0])
+	}
+}
+
+func testMetricsSweep(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	base := time.Now().UTC().Truncate(time.Microsecond)
+	// Two old samples, one fresh sample.
+	old1 := metricsMakeSample(t, base.Add(-10*time.Minute), 1, 0, 50<<20)
+	old2 := metricsMakeSample(t, base.Add(-5*time.Minute), 1, 0, 60<<20)
+	fresh := metricsMakeSample(t, base.Add(-30*time.Second), 1, 0, 70<<20)
+	for _, sa := range []store.ProcessSample{old1, old2, fresh} {
+		if err := s.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatalf("MetricsWriteSample: %v", err)
+		}
+	}
+	// Cutoff = 2 minutes ago. Should delete the two older samples.
+	deleted, err := s.MetricsSweep(ctx, base.Add(-2*time.Minute))
+	if err != nil {
+		t.Fatalf("MetricsSweep: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted %d, want 2", deleted)
+	}
+	// The fresh sample survives.
+	got, _, err := s.MetricsSampleWindow(ctx, base.Add(-1*time.Hour), base, 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("post-sweep window len = %d, want 1", len(got))
+	}
+	// Second sweep with the same cutoff is idempotent (0 deleted).
+	deleted2, err := s.MetricsSweep(ctx, base.Add(-2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deleted2 != 0 {
+		t.Errorf("second sweep deleted %d, want 0", deleted2)
+	}
+}
+
+func testMetricsRunSummaryEmpty(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_metric_empty"})
+	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "x"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	// No samples written; summary should return zero-valued window
+	// (not an error) with SampleCount=0.
+	summary, err := s.MetricsRunSummary(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("MetricsRunSummary on run with no samples: %v", err)
+	}
+	if summary.SampleCount != 0 {
+		t.Errorf("SampleCount = %d, want 0", summary.SampleCount)
+	}
+	if summary.PeakRSSBytes != 0 || summary.MeanRSSBytes != 0 || summary.MaxCPUPctX100 != 0 {
+		t.Errorf("expected zero-valued metrics, got %+v", summary)
+	}
+	if summary.RunID != run.ID {
+		t.Errorf("RunID = %q, want %q", summary.RunID, run.ID)
+	}
+}
+
+func testMetricsRunSummaryWithSamples(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_metric_with"})
+	// Wait one ms so the samples fall strictly after started_at.
+	// (Postgres TIMESTAMPTZ has microsecond resolution; sqlite is
+	// nanosecond. Both are fine here.)
+	time.Sleep(2 * time.Millisecond)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	// Three samples in this run's window, descending RSS.
+	for i, rss := range []int64{120 << 20, 200 << 20, 150 << 20} {
+		_ = i
+		sa := metricsMakeSample(t, now.Add(time.Duration(i)*time.Millisecond), 1, 0, rss)
+		sa.LoomcycleCPUPctX100 = 1000 + (i+1)*500 // 1500, 2000, 2500
+		if err := s.MetricsWriteSample(ctx, sa); err != nil {
+			t.Fatal(err)
+		}
+	}
+	time.Sleep(2 * time.Millisecond)
+	// Finish the run AFTER the samples so the window covers them.
+	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "x"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	summary, err := s.MetricsRunSummary(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("MetricsRunSummary: %v", err)
+	}
+	if summary.SampleCount != 3 {
+		t.Errorf("SampleCount = %d, want 3", summary.SampleCount)
+	}
+	// Peak should match the largest of the three.
+	if summary.PeakRSSBytes != 200<<20 {
+		t.Errorf("PeakRSSBytes = %d, want %d", summary.PeakRSSBytes, int64(200<<20))
+	}
+	if summary.MaxCPUPctX100 != 2500 {
+		t.Errorf("MaxCPUPctX100 = %d, want 2500", summary.MaxCPUPctX100)
+	}
+	// Mean is approximately (120+200+150)/3 = ~156 MB.
+	if summary.MeanRSSBytes < 150<<20 || summary.MeanRSSBytes > 170<<20 {
+		t.Errorf("MeanRSSBytes = %d, want ~157 MB", summary.MeanRSSBytes)
+	}
+}
+
+func testMetricsRunSummaryInFlight(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_metric_inflight"})
+	time.Sleep(2 * time.Millisecond)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	sa := metricsMakeSample(t, now, 1, 0, 80<<20)
+	if err := s.MetricsWriteSample(ctx, sa); err != nil {
+		t.Fatal(err)
+	}
+	// Run NOT finished — completed_at is NULL. Summary must still
+	// pick up the sample by using COALESCE(completed_at, now) as
+	// the upper bound.
+	summary, err := s.MetricsRunSummary(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("MetricsRunSummary on in-flight run: %v", err)
+	}
+	if summary.SampleCount != 1 {
+		t.Errorf("SampleCount = %d, want 1", summary.SampleCount)
+	}
+	if summary.PeakRSSBytes != 80<<20 {
+		t.Errorf("PeakRSSBytes = %d, want %d", summary.PeakRSSBytes, int64(80<<20))
+	}
+	// CompletedAt should be the zero value on in-flight runs.
+	if !summary.CompletedAt.IsZero() {
+		t.Errorf("CompletedAt = %v, want zero (run is in-flight)", summary.CompletedAt)
+	}
+}
+
+func testMetricsRunSummaryNotFound(t *testing.T, s store.Store) {
+	_, err := s.MetricsRunSummary(context.Background(), "r_does_not_exist")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
+	}
+	if nf != nil && nf.Kind != "run" {
+		t.Errorf("Kind = %q, want run", nf.Kind)
 	}
 }


### PR DESCRIPTION
## Summary

Built-in periodic CPU + memory sampler. While at least one agent run is active, samples loomcycle's process RSS, Go heap, goroutine count, CPU%, and optionally system-wide CPU + memory to a new \`process_samples\` table. Idle-gate on \`semaphore.Stats()\` — zero DB writes and zero \`/proc\` reads when nothing is running.

Closes the capacity-planning gap surfaced 2026-05-13: today's only signal is ad-hoc shell scripts (\`/tmp/loomcycle-watch.sh\` on the deployed VM). With this PR, operators can:

- See per-tick RSS / heap / CPU / goroutine count for any time window
- Correlate physical resource consumption with specific run lifetimes via the run-summary endpoint
- Aggregate into 1h / 24h / 7d buckets for trend analysis

## What ships

- **\`internal/metrics/\`** — sampler core (\`sampler.go\`) + Linux \`/proc\` readers (\`proc_linux.go\`, build tag \`linux\`) + non-Linux stubs (\`proc_other.go\`). Soft failures on \`/proc\` parse errors or store outages; consecutive-failure rate-limited logging.
- **Store interface** — \`ProcessSample\` + \`MetricsRunWindow\` types, 4 new methods (\`MetricsWriteSample\`, \`MetricsSampleWindow\`, \`MetricsRunSummary\`, \`MetricsSweep\`). \`MintSampleID\` helper mirrors \`MintChannelMessageID\`.
- **Storage** — sqlite \`CREATE TABLE\` in \`stmts\` + index in \`addIndexes\` (defensive against future column ALTERs, per the v0.8.6 lesson). Postgres migration \`0009_process_samples\`.
- **HTTP API** (bearer-authed): \`GET /v1/_metrics/samples\` (windowed list with cursor pagination), \`GET /v1/_metrics/runs/{run_id}\` (peak/mean RSS + max CPU% for samples overlapping the run's lifetime, computed via SQL — no denormalized columns on \`runs\`), \`GET /v1/_metrics/summary\` (1h/24h/7d aggregated buckets, in-Go aggregation acceptable at v0.8.x scale).
- **Config** — 5 new \`LOOMCYCLE_METRICS_*\` env vars. **Default OFF in v0.8.x**; operator opts in via \`LOOMCYCLE_METRICS_ENABLED=1\`. 5s sample interval / 7-day retention defaults (~210 MB/week sqlite, ~290 MB max).
- **\`cancel.Registry.ListAll()\`** — general-purpose accessor for future cross-cutting consumers (the sampler itself uses \`Semaphore.Stats()\` for its active-runs gate; \`ListAll\` is a separate forward-compat addition with its own test coverage).

## Key design decisions (locked in plan)

- **No denormalized \`runs.peak_rss\` / \`runs.cpu_ms\` columns** — \`MetricsRunSummary\` computes via JOIN at API time. Avoids a hot-table UPDATE per sample tick AND avoids an unbounded in-memory \`runID → peak\` map in the sampler.
- **No \`agents_json\` snapshot per sample row** — leaner rows (~250 bytes). Operators correlate WHICH agents were active via the time-window JOIN with the \`runs\` table.
- **Linux-only RSS + CPU** via build-tag-split (\`proc_linux.go\` / \`proc_other.go\`). On macOS / Windows dev workstations the sampler still records the platform-independent fields (active_runs, goroutine count, Go heap) — just leaves RSS/CPU as 0.
- **Default-off in v0.8.x.** Sampler not even started without explicit opt-in. Plan: flip to default-on in v0.9.x once production-validated.

## Tests (28 new)

| Where | Count | What |
|---|---|---|
| \`storetest/contract.go\` | 6 | write+query round-trip, sweep idempotency, run-summary empty / with-samples / in-flight (\`completed_at IS NULL\`) / not-found. Auto-runs on both sqlite + postgres. |
| \`internal/metrics/sampler_test.go\` | 5 | idle skip, write on active, graceful store error (with rate-limited log), nil store, recovery counter reset. Uses embedded-Store-interface fake — forward-compat against future Store additions. |
| \`internal/metrics/proc_linux_test.go\` | 8 | fixture-based parser tests for VmRSS, /proc/self/stat utime+stime, /proc/stat CPU totals, /proc/meminfo, delta CPU%. Tests run in CI via Linux cross-build. |
| \`internal/api/http/metrics_handlers_test.go\` | 9 | 503-when-disabled, samples round-trip + cursor, run-summary 404 + happy path, summary period bucketing (1h), invalid period, percentile helper, validation errors. |
| \`internal/cancel/registry_test.go\` | 2 | \`ListAll\` populated + after-deregister + empty registry. |

## Test plan

- [x] \`go test ./...\` — 37 packages green
- [x] \`go test -race ./internal/store/sqlite/... ./internal/metrics/... ./internal/api/http/... ./internal/cancel/... ./internal/config/...\` clean
- [x] \`GOOS=linux GOARCH=amd64 go build\` and \`GOOS=darwin go build\` both clean (build tags verified)
- [x] Code review via feature-dev:code-reviewer — 3 HIGH findings addressed:
  - \`limit=0\` now correctly rejected (was silently 200)
  - \`readFile\` propagates OS errors (was masking permission errors as parse errors)
  - \`cancel.Registry.ListAll\` doc-comment fixed + test coverage added
- [ ] Human review
- [ ] Manual end-to-end on the VM after merge (build linux/amd64, scp, set \`LOOMCYCLE_METRICS_ENABLED=1\`, restart, curl \`/v1/_metrics/samples\` while a real agent run is active)

## Operator notes

When this lands and you flip \`LOOMCYCLE_METRICS_ENABLED=1\` on the VM:
- Boot log shows: \`metrics: sampler enabled (interval=5s, system=false)\`
- During an active agent run: rows accumulate at ~12/min
- Disk growth: ~30 MB/day at default settings, ~210 MB/week steady state
- Sweeper kicks in every 15 min; with \`RETENTION_DAYS=7\` keeps a rolling 7-day window
- HTTP API endpoints become available immediately for dashboards / curl

🤖 Generated with [Claude Code](https://claude.com/claude-code)