### PR TITLE
fix(loop): strip reasoning_content on cross-provider fallback (production bug 2026-05-13)

### DIFF
--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -425,3 +425,237 @@ func TestFallback_StreamMidErrorTriggers(t *testing.T) {
 		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
 	}
 }
+
+// recordingProvider is a tieredProvider that captures every Request
+// it receives, so cross-provider tests can assert what the new
+// provider got after a fallback (specifically: was the Reasoning
+// field stripped from prior assistant turns).
+type recordingProvider struct {
+	*tieredProvider
+	mu       sync.Mutex
+	requests []providers.Request
+}
+
+func (p *recordingProvider) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, req)
+	p.mu.Unlock()
+	return p.tieredProvider.Call(ctx, req)
+}
+
+func (p *recordingProvider) snapshotRequests() []providers.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]providers.Request, len(p.requests))
+	copy(out, p.requests)
+	return out
+}
+
+// TestFallback_ReasoningStrippedOnProviderSwitch — the regression
+// test for the 2026-05-13 production bug. A run starts on a
+// provider whose previous turn populated Message.Reasoning (here we
+// inject it via PriorMessages to simulate a continuation). The
+// initial provider 503s. Fallback to the new provider must zero the
+// Reasoning field on every assistant message before sending the
+// request, so DeepSeek-style "must be passed back" 400s can't fire.
+func TestFallback_ReasoningStrippedOnProviderSwitch(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "gemini",
+		errors: []error{fmt.Errorf("gemini 503: This model is currently experiencing high demand.")},
+	}
+	healthy := &recordingProvider{
+		tieredProvider: &tieredProvider{
+			id:        "deepseek",
+			responses: [][]providers.Event{successResponse()},
+		},
+	}
+
+	// PriorMessages carries an assistant turn with Reasoning set —
+	// simulating a continuation where the prior turn ran on a
+	// thinking-capable provider and that turn's reasoning_content
+	// lives in the transcript.
+	prior := []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "first prompt"}}},
+		{
+			Role:      "assistant",
+			Content:   []providers.ContentBlock{{Type: "text", Text: "ok"}},
+			Reasoning: "step 1: consider X\nstep 2: pick Y\nstep 3: respond Z",
+		},
+	}
+
+	var events []providers.Event
+	var mu sync.Mutex
+
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "gemini-2.5-flash",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "second prompt"}}}},
+		PriorMessages:  prior,
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-flash", "", nil
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+
+	// The recording provider should have received exactly one Call.
+	requests := healthy.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("recordingProvider got %d Calls, want 1", len(requests))
+	}
+	// Assert NO assistant message in the request carries Reasoning.
+	for i, m := range requests[0].Messages {
+		if m.Role == "assistant" && m.Reasoning != "" {
+			t.Errorf("messages[%d] (assistant) reached deepseek with Reasoning=%q — strip pass failed", i, m.Reasoning)
+		}
+	}
+
+	// Assert EventReasoningInvalidated was emitted.
+	mu.Lock()
+	defer mu.Unlock()
+	var reasoningEvent *providers.Event
+	for i := range events {
+		if events[i].Type == providers.EventReasoningInvalidated {
+			reasoningEvent = &events[i]
+			break
+		}
+	}
+	if reasoningEvent == nil {
+		t.Fatal("no EventReasoningInvalidated emitted")
+	}
+	if !strings.Contains(reasoningEvent.Text, "gemini to deepseek") {
+		t.Errorf("EventReasoningInvalidated Text = %q, expected to mention gemini→deepseek switch", reasoningEvent.Text)
+	}
+	if !strings.Contains(reasoningEvent.Text, "1 assistant turn") {
+		t.Errorf("EventReasoningInvalidated Text = %q, expected to mention 1 cleared assistant turn", reasoningEvent.Text)
+	}
+}
+
+// TestFallback_NoReasoningStrip_SameProviderFamily — guard against
+// a spurious EventReasoningInvalidated when no assistant turns had
+// non-empty Reasoning. The event should ONLY fire when something
+// was actually stripped.
+func TestFallback_NoReasoningStrip_NothingToStrip(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 429: rate limit exceeded")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+
+	// PriorMessages with assistant turns that have NO Reasoning.
+	prior := []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "first prompt"}}},
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "text", Text: "ok"}}},
+		// Reasoning field intentionally empty.
+	}
+
+	var events []providers.Event
+	var mu sync.Mutex
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "claude-sonnet-4-6",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "second prompt"}}}},
+		PriorMessages:  prior,
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		if ev.Type == providers.EventReasoningInvalidated {
+			t.Errorf("spurious EventReasoningInvalidated emitted (Text=%q); nothing should have been stripped", ev.Text)
+		}
+	}
+	// Sanity: EventProviderFallback should still fire — only the
+	// reasoning-invalidated one is suppressed.
+	saw := false
+	for _, ev := range events {
+		if ev.Type == providers.EventProviderFallback {
+			saw = true
+			break
+		}
+	}
+	if !saw {
+		t.Error("EventProviderFallback missing — fallback should still have fired")
+	}
+}
+
+// TestFallback_PartialStreamReasoning_NeverReachesMessages — the
+// in-stream error invariant: if a provider's stream begins emitting
+// before erroring, any partial iterReasoning accumulator is dropped
+// by the drain-and-continue path. The fallback's strip pass therefore
+// never needs to handle partial-accumulation; we assert via the
+// captured request that no Reasoning leaked through.
+//
+// Scenario: failing provider emits EventText then EventError mid-
+// stream. Healthy provider records the request it receives. Even
+// without any prior Reasoning in PriorMessages, the captured request
+// must have empty Reasoning on all assistant messages (there should
+// be none, since the failing turn's stream errored before EventDone).
+func TestFallback_PartialStreamReasoning_NeverReachesMessages(t *testing.T) {
+	failing := &tieredProvider{
+		id: "gemini",
+		responses: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "starting..."},
+				{Type: providers.EventError, Error: "gemini 503: stream interrupted mid-response"},
+			},
+		},
+	}
+	healthy := &recordingProvider{
+		tieredProvider: &tieredProvider{
+			id:        "deepseek",
+			responses: [][]providers.Event{successResponse()},
+		},
+	}
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "gemini-2.5-flash",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "high"},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-flash", "", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	requests := healthy.snapshotRequests()
+	if len(requests) != 1 {
+		t.Fatalf("recordingProvider got %d Calls, want 1", len(requests))
+	}
+	for i, m := range requests[0].Messages {
+		if m.Role == "assistant" && m.Reasoning != "" {
+			t.Errorf("messages[%d] reached deepseek with partial Reasoning=%q — drain-and-continue path leaked", i, m.Reasoning)
+		}
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -245,12 +245,21 @@ const (
 // (the only provider with operator-controlled cache_control
 // breakpoints today; gemini-implicit-cache and others don't surface
 // a knob, so swap-away isn't a meaningful invalidation event).
+// Emits EventReasoningInvalidated when the strip pass cleared any
+// assistant-turn Reasoning field on switching providers — see the
+// in-body comment for the cross-provider thinking-content rationale.
+//
+// `messages` is the in-flight conversation history. On a successful
+// switch, every assistant turn's Reasoning field is zeroed in place.
+// Slice-element write is required (not a range-copy) so the caller's
+// slice sees the update.
 func tryProviderFallback(
 	ctx context.Context,
 	opts *RunOptions,
 	attempts *int,
 	cause error,
 	emit func(providers.Event),
+	messages []providers.Message,
 ) fallbackOutcome {
 	if !opts.FallbackPolicy.Enabled || opts.ReResolve == nil {
 		return fallbackOutcomeNotEligible
@@ -308,6 +317,40 @@ func tryProviderFallback(
 		emit(providers.Event{
 			Type: providers.EventCacheInvalidated,
 			Text: fmt.Sprintf("Anthropic cache_control breakpoints lost on switch to %s; this run's downstream iterations will be cache-cold", newProvider.ID()),
+		})
+	}
+
+	// Reasoning strip on cross-provider switch. `Message.Reasoning`
+	// is a single string field with no provenance. The OpenAI driver
+	// (which also backs DeepSeek) echoes it back as `reasoning_content`
+	// on the wire. DeepSeek's API verifies that any echoed
+	// reasoning_content matches what IT produced and 400s on mismatch
+	// with "The reasoning_content in the thinking mode must be passed
+	// back to the API." Cross-provider echoes always fail this check
+	// because the content originated from a different provider.
+	//
+	// Production bug (2026-05-13): a tier=low run on gemini-2.5-flash
+	// fell back to deepseek-v4-flash mid-conversation after a gemini
+	// 503; the conversation carried Reasoning-populated assistant
+	// turns into the deepseek request and deepseek 400'd. Fixed by
+	// zeroing the field at fallback time so the new provider gets
+	// a clean history.
+	//
+	// Safe across all current providers: Anthropic uses content blocks
+	// for extended_thinking (not the Reasoning string field), Gemini's
+	// driver doesn't write Reasoning today, OpenAI o-series tolerates
+	// missing reasoning_content (treats as no prior thinking).
+	stripped := 0
+	for i := range messages {
+		if messages[i].Role == "assistant" && messages[i].Reasoning != "" {
+			messages[i].Reasoning = ""
+			stripped++
+		}
+	}
+	if stripped > 0 {
+		emit(providers.Event{
+			Type: providers.EventReasoningInvalidated,
+			Text: fmt.Sprintf("cleared reasoning_content from %d assistant turn(s) on switch from %s to %s; cross-provider echo would 400", stripped, failedProvider, newProvider.ID()),
 		})
 	}
 
@@ -437,7 +480,7 @@ outerLoop:
 			// place. Outcome==Switched → continue the outer loop
 			// without surfacing the error. Other outcomes fall
 			// through to the original error path.
-			if tryProviderFallback(ctx, &opts, &fallbackAttempts, err, emit) == fallbackOutcomeSwitched {
+			if tryProviderFallback(ctx, &opts, &fallbackAttempts, err, emit, messages) == fallbackOutcomeSwitched {
 				continue outerLoop
 			}
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})
@@ -503,7 +546,7 @@ outerLoop:
 				// obscure. The wrap is reserved for the FINAL
 				// return value when fallback isn't eligible.
 				rawErr := errors.New(ev.Error)
-				if tryProviderFallback(ctx, &opts, &fallbackAttempts, rawErr, emit) == fallbackOutcomeSwitched {
+				if tryProviderFallback(ctx, &opts, &fallbackAttempts, rawErr, emit, messages) == fallbackOutcomeSwitched {
 					for range ch {
 					}
 					continue outerLoop

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -219,6 +219,33 @@ const (
 	// Purely informational; the loop continues unchanged.
 	EventCacheInvalidated EventType = "cache_invalidated"
 
+	// EventReasoningInvalidated signals that a v0.8.x runtime
+	// fallback switched to a provider that must not receive
+	// reasoning_content produced by the prior provider. The loop
+	// zeroed the Reasoning field on every assistant turn in the
+	// conversation history before retrying on the new provider.
+	//
+	// Why: Message.Reasoning is a single string field with no
+	// provenance (provider.go:130). The OpenAI driver's
+	// flattenMessage unconditionally echoes it back as
+	// reasoning_content on the wire. DeepSeek's API verifies that
+	// any echoed reasoning_content matches what IT produced and
+	// 400s otherwise ("reasoning_content in the thinking mode must
+	// be passed back to the API"). Cross-provider echoes always
+	// fail this check. The strip pass at fallback time prevents
+	// the failure deterministically.
+	//
+	// Cost retros should treat this run's downstream iterations
+	// as reasoning-cold on the new provider — any benefit of the
+	// prior provider's chain-of-thought is discarded. Distinct
+	// from EventCacheInvalidated: cache and reasoning are
+	// orthogonal invalidation axes that may fire independently.
+	//
+	// The Text field carries a human-readable summary
+	// ("cleared reasoning_content from N assistant turn(s) on
+	// switch from <old> to <new>").
+	EventReasoningInvalidated EventType = "reasoning_invalidated"
+
 	// EventChannelPublish signals that the v0.8.4 Channel tool
 	// successfully appended a message to a channel. Emitted from
 	// inside the tool's Execute() via the ctx-attached event


### PR DESCRIPTION
## Summary

Fixes a production bug where mid-conversation provider fallback would 400 on the new provider because the conversation history carried thinking/reasoning content from the previous provider.

**Observed sequence (cv-batch-adapter run, 2026-05-13):**
1. Run starts on \`gemini-2.5-flash\` (anthropic transiently stalled).
2. Turn 1 succeeds. A subsequent tool call returns research data.
3. Turn 2 to gemini returns **503**: \"This model is currently experiencing high demand.\"
4. Fallback fires → \`deepseek-v4-flash\` (next candidate in \`user_tier=high.tiers.low\`).
5. DeepSeek 400: \`\"The reasoning_content in the thinking mode must be passed back to the API.\"\` — run dies unrecoverably.

## Root cause

\`Message.Reasoning\` (provider.go:130) is a single string field with no provenance. The OpenAI driver (which also backs DeepSeek, since DeepSeek is OpenAI-compatible) unconditionally echoes it back as \`reasoning_content\` in the assistant turn on the wire (\`flattenMessage\` at openai/driver.go:284). DeepSeek's API verifies that any echoed \`reasoning_content\` matches what IT produced for that turn, and 400s if it can't verify. Cross-provider echoes always fail this check.

## Fix

When \`tryProviderFallback\` successfully switches providers, walk the in-flight \`messages\` slice and zero \`Message.Reasoning\` on every assistant turn. Emit a new \`EventReasoningInvalidated\` typed event when anything was actually stripped (mirrors the existing \`EventCacheInvalidated\` pattern for Anthropic cache_control on fallback).

**Approach chosen**: C1 + C3 from the architect plan — surgical in-place strip + typed event for SSE consumers. Considered and rejected: C2 (per-message ProducedBy field across all drivers) — deferred to v1.x.

**Safe across all current providers**:
- Anthropic uses typed content blocks for \`extended_thinking\`, not the \`Reasoning\` string field → immune.
- Gemini's driver doesn't write Reasoning today → strip is a no-op unless populated upstream (e.g., PriorMessages from a continuation).
- OpenAI o-series tolerates missing \`reasoning_content\` (treats as no prior thinking).
- DeepSeek and OpenAI o-series within their own family continue to round-trip correctly — the strip only fires on fallback.

## Scope

3 files, ~50 LOC + ~200 LOC tests:

- **\`internal/providers/provider.go\`**: new \`EventReasoningInvalidated EventType\` constant with doc comment explaining the cross-provider invariant. Mirrors \`EventCacheInvalidated\`.
- **\`internal/loop/loop.go\`**: \`tryProviderFallback\` gains a \`messages []providers.Message\` parameter. Body adds an in-place strip pass after the existing \`EventProviderFallback\` + \`EventCacheInvalidated\` emits, with conditional \`EventReasoningInvalidated\` emit when \`stripped > 0\`. Two call sites updated.
- **\`internal/loop/fallback_test.go\`**: 3 regression tests using a new \`recordingProvider\` wrapper that captures the \`providers.Request\` the new provider receives.

## Tests

| Test | Asserts |
|---|---|
| \`TestFallback_ReasoningStrippedOnProviderSwitch\` | PriorMessages carries assistant turn with Reasoning. Failing provider 503s. Asserts: deepseek's captured request has empty Reasoning on all messages; \`EventReasoningInvalidated\` emitted with correct gemini→deepseek text. **Pre-fix this test fails with the exact production error** (\`messages[1] reached deepseek with Reasoning=\"step 1: ...\"\`). |
| \`TestFallback_NoReasoningStrip_NothingToStrip\` | When PriorMessages has no Reasoning set, fallback fires but \`EventReasoningInvalidated\` is NOT emitted (guards against spurious events). \`EventProviderFallback\` still emitted. |
| \`TestFallback_PartialStreamReasoning_NeverReachesMessages\` | Pin: drain-and-continue path on in-stream error doesn't stamp \`iterReasoning\` to messages, so partial reasoning never leaks. |

**Verification**:
- ✅ \`go test ./...\` — 37 packages green
- ✅ \`go test -race ./internal/loop/... ./internal/providers/...\` clean
- ✅ Regression test verified: \`git stash\` of \`loop.go\` → test fails with the exact production error mode; \`git stash pop\` → test passes.

## What's NOT in this PR

- **Per-message ProducedBy provenance field** — deferred to v1.x. No current use case requires routing reasoning round-trips across providers in the same conversation.
- **TS adapter handler for \`EventReasoningInvalidated\`** — \`@loomcycle/client\` will currently log \`[loomcycle: unknown event \"reasoning_invalidated\"]\`. Separate adapter PR.
- **Gemini driver thoughtSummary surfacing** — the bug fix is defensive regardless. When Google opens a text trace surface, that's a separate driver PR.
- **PriorMessages sanitization at Run() entry** — if a caller passes PriorMessages with mismatched-provenance Reasoning, the initial provider receives it as-is. That's a caller contract issue, not a fallback issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)