### PR TITLE
feat(loop): pin provider after first successful turn — close cross-provider mid-conversation bug class

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,38 @@ LOOMCYCLE_DATA_DIR=./data
 # LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
 # LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000
 
+# ─── Provider fallback semantics (v0.8.13+) ──────────────────────────
+#
+# Cross-provider runtime fallback (v0.8.2) climbs through the user_tier
+# candidate list on retryable errors. Mid-conversation fallback can
+# trip provider-specific transcript translation bugs (DeepSeek
+# reasoning_content, Anthropic cache_control, Gemini thoughtSignature,
+# tool_call shape differences). Each requires its own translation
+# layer; the surface area grows over time.
+#
+# When this flag is set to "1", fallback is SUPPRESSED after the run
+# has completed at least one successful turn. The initial turn can
+# still fall back (so a stale-probe initial pick doesn't kill the
+# run). Once the transcript has provider-specific state, the run
+# stays on its current provider. Same-provider rate-limit retry
+# (internal/providers/ratelimit/) still covers transient errors
+# within one provider.
+#
+# Trade: a sustained outage of a provider mid-conversation will fail
+# the run instead of cascading to a fallback. Acceptable for most
+# production deployments — provider outages are rare and clients
+# retry; mid-conversation translation bugs are subtle and silent.
+#
+# When fallback is suppressed, loomcycle emits the typed event
+# `fallback_suppressed` on the SSE wire so operators can attribute
+# the failure to the policy rather than the resolver.
+#
+# Default OFF in v0.8.x; default-on planned for v0.9.x once
+# production-validated. Recommended for any deployment running runs
+# with thinking-mode providers (DeepSeek reasoner family,
+# gemini-2.5-flash with effort hint).
+# LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1
+
 # ─── Process-resource metrics sampler (v0.8.x+) ──────────────────────
 #
 # Built-in CPU + memory sampler that runs as a background goroutine

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -503,9 +503,10 @@ func (s *Server) fallbackForRun(agentName, userTier string) (loop.FallbackPolicy
 		return loop.FallbackPolicy{}, nil
 	}
 	policy := loop.FallbackPolicy{
-		Enabled:      true,
-		MaxAttempts:  overlay.MaxFallbackAttempts, // 0 = loop uses its own default (3)
-		UserTierName: overlay.Name,
+		Enabled:         true,
+		MaxAttempts:     overlay.MaxFallbackAttempts, // 0 = loop uses its own default (3)
+		UserTierName:    overlay.Name,
+		PinAfterSuccess: s.cfg.Env.FallbackPinAfterSuccess,
 	}
 	reResolve := func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error) {
 		// Mark the failed pair stalled BEFORE re-resolving so the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -658,6 +658,26 @@ type Env struct {
 	// day. Env: LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS.
 	ResolveProbeInterval time.Duration
 
+	// FallbackPinAfterSuccess, when true, suppresses provider
+	// fallback on retryable errors AFTER the run has completed at
+	// least one successful turn (assistant message appended to
+	// the conversation history). The initial turn can still fall
+	// back — so a stale-probe initial pick survives — but once a
+	// provider has touched the transcript, the run sticks with
+	// it. Same-provider rate-limit retry (internal/providers/
+	// ratelimit/) still covers transient errors.
+	//
+	// Why: cross-provider mid-conversation fallback exposes a
+	// growing surface of provider-specific transcript translation
+	// bugs (the 2026-05-13 DeepSeek "reasoning_content must be
+	// passed back" 400 was one instance; thoughtSignature, tool_call
+	// shape, etc. are others). Pinning closes the class of bug.
+	//
+	// Default OFF in v0.8.x; plan to flip default-on in v0.9.x
+	// once production-validated. Env:
+	// LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS.
+	FallbackPinAfterSuccess bool
+
 	// ---- v0.8.x process-resource metrics sampler (opt-in) ----
 
 	// MetricsEnabled enables the periodic process_samples
@@ -997,6 +1017,10 @@ func Load(path string) (*Config, error) {
 			cfg.Env.ResolveProbeInterval = d
 		}
 	}
+	// LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS: when set to "1",
+	// suppress provider fallback after the first successful turn.
+	// Opt-in for v0.8.x; default-on planned for v0.9.x.
+	cfg.Env.FallbackPinAfterSuccess = os.Getenv("LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS") == "1"
 	// LOOMCYCLE_SSE_KEEPALIVE_MS sets the SSE keepalive cadence.
 	// Default 20 s; 0 (or any value ≤ 0) disables. Floor 1 s for
 	// positive values so a misconfigured tiny value can't busy-loop

--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // tieredProvider is a fakeProvider variant whose ID is configurable.
@@ -659,3 +661,192 @@ func TestFallback_PartialStreamReasoning_NeverReachesMessages(t *testing.T) {
 		}
 	}
 }
+
+// TestFallback_PinAfterSuccess_SuppressesFallbackOnTurnTwo —
+// headline regression for the 2026-05-13 cv-batch-adapter failure.
+// Provider A turn 1 succeeds (appends an assistant message). Turn 2
+// returns a retryable error. With PinAfterSuccess=true, the
+// fallback path MUST NOT switch providers — the original error
+// propagates, and EventFallbackSuppressed is emitted for observability.
+//
+// Without PinAfterSuccess this is the existing happy-path of
+// TestFallback_StreamMidErrorTriggers, which we don't break.
+func TestFallback_PinAfterSuccess_SuppressesFallbackOnTurnTwo(t *testing.T) {
+	failing := &tieredProvider{
+		id: "gemini",
+		responses: [][]providers.Event{
+			// Turn 1 succeeds with a tool_call. Loop appends the
+			// assistant message; firstTurnSucceeded flips true.
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu-1", Name: "Read", Input: []byte(`{"path":"x"}`)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 5, Model: "gemini-2.5-flash"}},
+			},
+		},
+		// Turn 2: scripted error — gemini 503.
+		errors: []error{nil, fmt.Errorf("gemini 503: This model is currently experiencing high demand.")},
+	}
+	healthy := &recordingProvider{
+		tieredProvider: &tieredProvider{
+			id:        "deepseek",
+			responses: [][]providers.Event{successResponse()},
+		},
+	}
+
+	var events []providers.Event
+	var mu sync.Mutex
+
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "gemini-2.5-flash",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		// A fallback-only dispatcher that returns a stub tool_result
+		// so the loop reaches a second iteration after turn 1.
+		Dispatcher: tools.NewDispatcherWithFallback(nil, func(_ context.Context, _ string, _ json.RawMessage) (tools.Result, bool) {
+			return tools.Result{Text: `{"ok":true}`}, true
+		}),
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:         true,
+			MaxAttempts:     3,
+			UserTierName:    "high",
+			PinAfterSuccess: true, // the policy under test
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-flash", "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	// Run must fail with the gemini 503 (NOT recover via fallback).
+	if err == nil {
+		t.Fatal("expected Run to fail with gemini 503; got nil (fallback fired despite PinAfterSuccess)")
+	}
+	if !strings.Contains(err.Error(), "gemini 503") {
+		t.Errorf("error = %q, want substring 'gemini 503'", err.Error())
+	}
+
+	// recordingProvider must have received ZERO calls — the
+	// fallback was suppressed.
+	if requests := healthy.snapshotRequests(); len(requests) != 0 {
+		t.Errorf("recordingProvider got %d calls, want 0 (fallback should have been suppressed)", len(requests))
+	}
+
+	// EventFallbackSuppressed must have been emitted.
+	mu.Lock()
+	defer mu.Unlock()
+	var suppressedEvent *providers.Event
+	for i := range events {
+		if events[i].Type == providers.EventFallbackSuppressed {
+			suppressedEvent = &events[i]
+			break
+		}
+	}
+	if suppressedEvent == nil {
+		t.Fatal("no EventFallbackSuppressed emitted")
+	}
+	if !strings.Contains(suppressedEvent.Text, "gemini") {
+		t.Errorf("EventFallbackSuppressed Text = %q, expected to mention the pinned gemini provider", suppressedEvent.Text)
+	}
+	// EventProviderFallback must NOT have been emitted — the
+	// suppression intercepts before the switch.
+	for _, ev := range events {
+		if ev.Type == providers.EventProviderFallback {
+			t.Errorf("EventProviderFallback emitted despite PinAfterSuccess + firstTurnSucceeded; payload=%+v", ev.Fallback)
+		}
+	}
+}
+
+// TestFallback_PinAfterSuccess_TurnOneStillFallsBack — the
+// initial-pick resilience case. With PinAfterSuccess=true, a
+// retryable error on TURN ZERO (before any assistant message has
+// been appended) MUST still fall back. This is the stale-probe
+// safety net: if the resolver picked a provider that's actually
+// stalled at request time, the run should survive the first call.
+func TestFallback_PinAfterSuccess_TurnOneStillFallsBack(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "anthropic",
+		errors: []error{fmt.Errorf("anthropic 429: rate limit exceeded")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "claude-haiku-4-5",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:       func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:         true,
+			MaxAttempts:     3,
+			UserTierName:    "high",
+			PinAfterSuccess: true,
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-flash", "", nil
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v (expected success after turn-zero fallback)", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+}
+
+// TestFallback_PinAfterSuccess_FlagOff_PreservesV082Behavior —
+// belt-and-suspenders. When PinAfterSuccess=false (the v0.8.x
+// default), the loop's behavior is identical to v0.8.2: a
+// retryable error on turn N>1 still fires fallback. Guards
+// against accidentally enabling pinning for everyone.
+func TestFallback_PinAfterSuccess_FlagOff_PreservesV082Behavior(t *testing.T) {
+	failing := &tieredProvider{
+		id: "gemini",
+		responses: [][]providers.Event{
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu-1", Name: "Read", Input: []byte(`{"path":"x"}`)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 5, Model: "gemini-2.5-flash"}},
+			},
+		},
+		errors: []error{nil, fmt.Errorf("gemini 503: high demand")},
+	}
+	healthy := &tieredProvider{
+		id:        "deepseek",
+		responses: [][]providers.Event{successResponse()},
+	}
+
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "gemini-2.5-flash",
+		MaxIterations: 5,
+		Segments:      []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		Dispatcher: tools.NewDispatcherWithFallback(nil, func(_ context.Context, _ string, _ json.RawMessage) (tools.Result, bool) {
+			return tools.Result{Text: `{"ok":true}`}, true
+		}),
+		OnEvent: func(ev providers.Event) {},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:         true,
+			MaxAttempts:     3,
+			UserTierName:    "high",
+			PinAfterSuccess: false, // explicitly off
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-flash", "", nil
+		},
+	}
+	res, err := Run(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("Run: %v (expected success — fallback should fire when flag is off)", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("StopReason = %q, want end_turn", res.StopReason)
+	}
+}
+

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -197,6 +197,33 @@ type FallbackPolicy struct {
 	// the EventProviderFallback payload so log + UI consumers can
 	// attribute the switch to a specific tier.
 	UserTierName string
+
+	// PinAfterSuccess, when true, suppresses provider fallback on
+	// retryable errors AFTER the run has completed at least one
+	// successful turn (assistant message appended to the
+	// conversation history). The initial turn can still fall back,
+	// so a stale-probe initial pick doesn't kill the run. Once a
+	// provider has touched the transcript, the run stays on it.
+	//
+	// Why: cross-provider mid-conversation fallback exposes a
+	// growing surface of provider-specific transcript translation
+	// bugs (Anthropic cache_control, DeepSeek reasoning_content +
+	// thinking-mode validation, gemini thoughtSignature, tool_call
+	// shape differences). Each requires its own translation
+	// layer. Pinning closes the entire class of bug in exchange
+	// for dropping resilience to MID-CONVERSATION provider issues —
+	// same-provider rate-limit retry (internal/providers/ratelimit/)
+	// still covers transient errors within one provider.
+	//
+	// Sourced from cfg.Env.FallbackPinAfterSuccess (env:
+	// LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS). Default OFF in v0.8.x;
+	// plan to flip default-on in v0.9.x.
+	//
+	// When pinning suppresses a fallback, the loop emits
+	// EventFallbackSuppressed so operators can attribute the
+	// failure to the policy rather than thinking the resolver
+	// misbehaved.
+	PinAfterSuccess bool
 }
 
 // defaultMaxFallbackAttempts is the cumulative cap when the operator
@@ -260,6 +287,7 @@ func tryProviderFallback(
 	cause error,
 	emit func(providers.Event),
 	messages []providers.Message,
+	firstTurnSucceeded bool,
 ) fallbackOutcome {
 	if !opts.FallbackPolicy.Enabled || opts.ReResolve == nil {
 		return fallbackOutcomeNotEligible
@@ -273,6 +301,20 @@ func tryProviderFallback(
 		maxAttempts = defaultMaxFallbackAttempts
 	}
 	if *attempts >= maxAttempts {
+		return fallbackOutcomeNotEligible
+	}
+	// PinAfterSuccess: once a turn has succeeded, the conversation
+	// transcript has provider-specific state (tool_call format,
+	// possibly reasoning content, possibly Anthropic cache_control
+	// breakpoints). Cross-provider fallback past this point opens
+	// the same class of translation bugs the v0.8.12 reasoning
+	// strip was a point fix for. Suppress and emit a typed event
+	// so operators can attribute the failure to the policy.
+	if opts.FallbackPolicy.PinAfterSuccess && firstTurnSucceeded {
+		emit(providers.Event{
+			Type: providers.EventFallbackSuppressed,
+			Text: fmt.Sprintf("fallback from %s suppressed: provider pinned after first successful turn (LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1); run will fail with cause: %s", opts.Provider.ID(), truncateError(cause)),
+		})
 		return fallbackOutcomeNotEligible
 	}
 	// Ctx already cancelled? Don't fall back — caller signalled
@@ -437,6 +479,13 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// — we don't decrement iter, because a deliberate switch should
 	// still count toward MaxIterations as work the run did.
 	var fallbackAttempts int
+	// firstTurnSucceeded flips true after the first iteration
+	// completes successfully (an assistant message has been
+	// appended to `messages`). Used by tryProviderFallback to
+	// honor RunOptions.FallbackPolicy.PinAfterSuccess — once the
+	// transcript has provider-specific state, fallback to a
+	// different provider risks cross-family translation bugs.
+	var firstTurnSucceeded bool
 
 outerLoop:
 	for iter := 0; iter < opts.MaxIterations; iter++ {
@@ -480,7 +529,7 @@ outerLoop:
 			// place. Outcome==Switched → continue the outer loop
 			// without surfacing the error. Other outcomes fall
 			// through to the original error path.
-			if tryProviderFallback(ctx, &opts, &fallbackAttempts, err, emit, messages) == fallbackOutcomeSwitched {
+			if tryProviderFallback(ctx, &opts, &fallbackAttempts, err, emit, messages, firstTurnSucceeded) == fallbackOutcomeSwitched {
 				continue outerLoop
 			}
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})
@@ -546,7 +595,7 @@ outerLoop:
 				// obscure. The wrap is reserved for the FINAL
 				// return value when fallback isn't eligible.
 				rawErr := errors.New(ev.Error)
-				if tryProviderFallback(ctx, &opts, &fallbackAttempts, rawErr, emit, messages) == fallbackOutcomeSwitched {
+				if tryProviderFallback(ctx, &opts, &fallbackAttempts, rawErr, emit, messages, firstTurnSucceeded) == fallbackOutcomeSwitched {
 					for range ch {
 					}
 					continue outerLoop
@@ -568,6 +617,11 @@ outerLoop:
 			Content:   assistantBlocks,
 			Reasoning: iterReasoning,
 		})
+		// Mark the run "past turn one." Any subsequent retryable
+		// error that would have triggered cross-provider fallback
+		// is suppressed when PinAfterSuccess is set — the
+		// transcript now has provider-specific state.
+		firstTurnSucceeded = true
 
 		if iterUsage != nil {
 			totalUsage.InputTokens += iterUsage.InputTokens

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -219,6 +219,28 @@ const (
 	// Purely informational; the loop continues unchanged.
 	EventCacheInvalidated EventType = "cache_invalidated"
 
+	// EventFallbackSuppressed signals that a retryable error would
+	// have triggered a provider fallback, but the run was already
+	// past its first successful turn AND the operator opted into
+	// "pin provider after first successful turn" semantics
+	// (`LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1`). The cause error
+	// propagates to the caller; the run fails. Purely informational.
+	//
+	// Why: cross-provider mid-conversation fallback exposes a
+	// growing surface of provider-specific transcript translation
+	// bugs (Anthropic cache_control, DeepSeek reasoning_content,
+	// gemini thoughtSignature, tool_call shape differences). Each
+	// requires its own translation layer. Pinning after first
+	// success closes the entire class of bug in exchange for
+	// dropping resilience to mid-conversation provider issues —
+	// existing same-provider rate-limit retry (internal/providers/
+	// ratelimit/) still covers transient errors within one provider.
+	//
+	// The Text field carries a human-readable summary:
+	// "fallback to <new> suppressed: provider <old> pinned after
+	// first successful turn".
+	EventFallbackSuppressed EventType = "fallback_suppressed"
+
 	// EventReasoningInvalidated signals that a v0.8.x runtime
 	// fallback switched to a provider that must not receive
 	// reasoning_content produced by the prior provider. The loop


### PR DESCRIPTION
## Summary

The cv-batch-adapter run that crashed pre-v0.8.12 with DeepSeek's \`\"reasoning_content in the thinking mode must be passed back to the API.\"\` ran AGAIN after the v0.8.12 deploy and crashed with the same error. The v0.8.12 \`Message.Reasoning\` strip targeted the wrong field — \`Message.Reasoning\` was already empty (gemini's driver doesn't write it). The actual trigger was DeepSeek's API interpreting the model + transcript shape as thinking-mode and requiring reasoning_content the previous provider never produced.

Cross-provider mid-conversation fallback exposes a growing surface of provider-specific transcript translation bugs (Anthropic cache_control, DeepSeek reasoning_content + thinking-mode validation, gemini thoughtSignature, tool_call shape differences). **Each requires its own translation layer.** Fixing them one-by-one is whack-a-mole.

This PR closes the entire class: don't fall back to a different provider mid-conversation. Once a run has touched the transcript with a provider, stay there. Resilience to the *initial provider pick* (the resolver skipping stalled providers at run start) is preserved.

## What ships

| Surface | Change |
|---|---|
| **\`FallbackPolicy.PinAfterSuccess bool\`** | New field on the existing policy struct. When true, suppresses cross-provider fallback after any turn has completed successfully. The initial turn can still fall back (stale-probe safety net). |
| **\`EventFallbackSuppressed\` typed event** | Fires when the pin policy intercepts a would-be fallback. Wire-stable for adapters; mirrors the v0.8.2 \`EventCacheInvalidated\` / v0.8.12 \`EventReasoningInvalidated\` event-on-policy pattern. Carries the cause error so operators can attribute the failure. |
| **\`LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS\` env var** | Default OFF in v0.8.x; default-on planned for v0.9.x once production-validated. Wired from \`cfg.Env\` through to \`FallbackPolicy\` via the HTTP server's \`fallbackForRun\`. |
| **Belt-and-suspenders** | v0.8.12's \`Message.Reasoning\` strip remains. When deployments opt back into mid-session fallback later, the strip still works. |

## Tests (3 new + 11 existing — 14 total)

| Test | Asserts |
|---|---|
| \`TestFallback_PinAfterSuccess_SuppressesFallbackOnTurnTwo\` | Headline. Turn 1 succeeds with tool_use; turn 2 503's; with \`PinAfterSuccess=true\`, fallback to deepseek is suppressed and \`EventFallbackSuppressed\` fires. recordingProvider gets **zero** calls. Cause error propagates. |
| \`TestFallback_PinAfterSuccess_TurnOneStillFallsBack\` | Stale-probe initial pick still survives. Retryable error on turn 0 (before any assistant message exists) still falls back. |
| \`TestFallback_PinAfterSuccess_FlagOff_PreservesV082Behavior\` | Guards against accidentally enabling pinning by default. With \`PinAfterSuccess=false\`, behavior is identical to v0.8.2. |

37 packages green; race-detector clean.

## Operator action after merge

1. Build + deploy v0.8.13 (same flow as the previous releases).
2. Add to deployed \`loomcycle.env\`:
   \`\`\`
   LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1
   \`\`\`
3. Restart loomcycle. Boot log won't show anything specific (no new boot-line); the flag takes effect on the next run.
4. Trigger a cv-batch-adapter run. If a fallback would have fired post-turn-one, you'll see an \`EventFallbackSuppressed\` SSE frame and the run will fail with the original error instead of cross-providering.

## Trade-off acknowledged

Mid-conversation provider outages now fail the run. Acceptable for production: provider outages are rare; clients retry; mid-conversation translation bugs are subtle and silent — the failure mode is much better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)