### PR TITLE
feat: per-run MCP bearer tokens (${run.user_bearer})

### DIFF
--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -509,6 +509,12 @@ func (s *Server) driveStream(ctx context.Context, stream runStreamSink, in runne
 
 // runInputFromProto maps the proto request fields into the
 // runner.RunInput shared between Run and Continue.
+//
+// v0.8.x gap: RunInput.UserBearer is not yet plumbed here — the proto
+// schema has no user_bearer field. When gRPC Run/Continue leave
+// Unimplemented status, add a user_bearer proto field and a parameter
+// to this function. The HTTP wire is the only path that currently
+// carries per-run bearers.
 func runInputFromProto(
 	agent, sessionID string,
 	segments []*loomcyclepb.PromptSegment,

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -456,5 +457,121 @@ func TestSubAgent_InheritsParentCallerHostAllowlist(t *testing.T) {
 	}
 	if !sawHTTPSuccess {
 		t.Errorf("expected child's HTTP tool to reach target and capture body 'child-saw-it' in a tool_result event;\nchild transcript had %d events", len(childTranscript))
+	}
+}
+
+// bearerCapturingProvider drives a scripted event sequence per call AND
+// records the ctx-carried tools.RunIdentity(ctx).UserBearer on every
+// Call. Used by TestSubAgent_InheritsParentUserBearer to verify the
+// child run's ctx carries the parent's bearer at provider-call time.
+type bearerCapturingProvider struct {
+	calls   atomic.Int32
+	scripts [][]providers.Event
+
+	mu       sync.Mutex
+	captured []string // RunIdentity.UserBearer per Call invocation, in call order
+}
+
+func (b *bearerCapturingProvider) ID() string                    { return "bearer-capturing" }
+func (b *bearerCapturingProvider) Probe(_ context.Context) error { return nil }
+func (b *bearerCapturingProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"stub-model"}, nil
+}
+func (b *bearerCapturingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (b *bearerCapturingProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	b.mu.Lock()
+	b.captured = append(b.captured, tools.RunIdentity(ctx).UserBearer)
+	b.mu.Unlock()
+	idx := int(b.calls.Add(1)) - 1
+	var events []providers.Event
+	if idx < len(b.scripts) {
+		events = b.scripts[idx]
+	}
+	ch := make(chan providers.Event, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// TestSubAgent_InheritsParentUserBearer guards the v0.8.x invariant
+// that sub-agents see the parent run's per-run MCP bearer in their
+// own ctx — identically, NOT narrowed (unlike caller-host policy).
+// Sub-agents act on behalf of the same end-user; the same downstream
+// MCP credential applies.
+//
+// Regression guard: if someone adds narrowing logic at the sub-agent
+// dispatch site (internal/api/http/server.go around runSubAgent's
+// WithRunIdentity call), this test catches it.
+func TestSubAgent_InheritsParentUserBearer(t *testing.T) {
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		"parent": {Model: "stub-model", AllowedTools: []string{"Agent"}, SystemPrompt: "you are the parent"},
+		"child":  {Model: "stub-model", AllowedTools: []string{}, SystemPrompt: "you are the child"},
+	}
+
+	const parentBearer = "parent-bearer-xyz123456"
+
+	prov := &bearerCapturingProvider{
+		scripts: [][]providers.Event{
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_parent_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"go"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 2}},
+			},
+			{
+				{Type: providers.EventText, Text: "child done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 3, OutputTokens: 2}},
+			},
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 12, OutputTokens: 3}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent_bearer.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	body := `{"agent":"parent","user_bearer":"` + parentBearer + `","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		slurp, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, slurp)
+	}
+	// Drain the SSE body so the run completes before we assert.
+	_, _ = io.ReadAll(resp.Body)
+
+	prov.mu.Lock()
+	captured := append([]string(nil), prov.captured...)
+	prov.mu.Unlock()
+	if len(captured) < 2 {
+		t.Fatalf("expected at least 2 provider calls (parent + child), got %d", len(captured))
+	}
+	// Every Call must have seen the parent's bearer in ctx — the child
+	// just as much as the parent (identical inheritance, no narrowing).
+	for i, b := range captured {
+		if b != parentBearer {
+			t.Errorf("call #%d: ctx bearer = %q, want %q", i, b, parentBearer)
+		}
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -731,9 +731,10 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:   effectiveUserID,
-		AgentID:  agentID,
-		UserTier: in.UserTier,
+		UserID:     effectiveUserID,
+		AgentID:    agentID,
+		UserTier:   in.UserTier,
+		UserBearer: in.UserBearer, // v0.8.x: per-run MCP bearer
 	})
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
 	// Memory tool policy: agent name + per-agent scope allowlist +
@@ -1117,6 +1118,14 @@ type runRequest struct {
 	// agent overrides. See docs/PLAN.md → v0.8.2 for the full
 	// resolver overlay precedence chain.
 	UserTier string `json:"user_tier,omitempty"`
+	// UserBearer is the v0.8.x per-run MCP bearer token. Substituted
+	// into MCP HTTP header values containing ${run.user_bearer} at
+	// outbound request-build time. Charset:
+	// [A-Za-z0-9._\-+/=]{16,512} when present → 400 otherwise. Empty
+	// is backwards compat (static-bearer setups unaffected). Sub-
+	// agents inherit identically. Never persisted; never logged in
+	// full.
+	UserBearer string `json:"user_bearer,omitempty"`
 }
 
 func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
@@ -1169,6 +1178,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("unknown user_tier %q", req.UserTier), http.StatusBadRequest)
 			return
 		}
+	}
+
+	if req.UserBearer != "" && !validUserBearer(req.UserBearer) {
+		http.Error(w, `user_bearer must match [A-Za-z0-9._\-+/=]{16,512}`, http.StatusBadRequest)
+		return
 	}
 
 	providerID, model, effort, err := s.resolveAgent(req.Agent, req.UserTier)
@@ -1385,9 +1399,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// SubAgentRunner can inherit user_id and set parent_agent_id on
 	// any sub-runs it spawns.
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:   req.UserID,
-		AgentID:  agentID,
-		UserTier: req.UserTier,
+		UserID:     req.UserID,
+		AgentID:    agentID,
+		UserTier:   req.UserTier,
+		UserBearer: req.UserBearer, // v0.8.x: per-run MCP bearer
 	})
 	// Stash the caller's host policy so any sub-agents spawned by the
 	// Agent tool inherit the same allowed_hosts / WebSearchFilter
@@ -1461,6 +1476,11 @@ type messagesRequest struct {
 	// applied immediately. Empty falls through to
 	// cfg.UserTiers["default"] when user_tiers is configured.
 	UserTier string `json:"user_tier,omitempty"`
+	// UserBearer follows runRequest semantics. Per-request (not
+	// session-bound) so different continuations in the same session
+	// may carry different end-user tokens — natural for a future
+	// flow where each continuation gets a fresh short-lived bearer.
+	UserBearer string `json:"user_bearer,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -1527,6 +1547,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, fmt.Sprintf("unknown user_tier %q", body.UserTier), http.StatusBadRequest)
 			return
 		}
+	}
+	if body.UserBearer != "" && !validUserBearer(body.UserBearer) {
+		http.Error(w, `user_bearer must match [A-Za-z0-9._\-+/=]{16,512}`, http.StatusBadRequest)
+		return
 	}
 	providerID, model, effort, err := s.resolveAgent(sess.Agent, body.UserTier)
 	if err != nil {
@@ -1670,9 +1694,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:   sess.UserID,
-		AgentID:  agentID,
-		UserTier: body.UserTier,
+		UserID:     sess.UserID,
+		AgentID:    agentID,
+		UserTier:   body.UserTier,
+		UserBearer: body.UserBearer, // v0.8.x: per-run MCP bearer
 	})
 	// Sub-agents spawned by this continuation must inherit the
 	// caller-authoritative host narrowing, same as runRequest +
@@ -2190,8 +2215,9 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
 		UserID:     parentIdentity.UserID,
 		AgentID:    subAgentID,
-		UserTier:   parentIdentity.UserTier, // v0.8.2: sub-agents inherit parent's user_tier
-		AgentDefID: defID,                   // v0.8.7: surface pinned def_id via Context.self
+		UserTier:   parentIdentity.UserTier,   // v0.8.2: sub-agents inherit parent's user_tier
+		AgentDefID: defID,                     // v0.8.7: surface pinned def_id via Context.self
+		UserBearer: parentIdentity.UserBearer, // v0.8.x: bearer inherited identically (same end-user)
 	})
 	subCtx = tools.WithAgentName(subCtx, name)
 	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's
@@ -2685,6 +2711,30 @@ func validIdent(s string) bool {
 			r >= 'A' && r <= 'Z',
 			r >= '0' && r <= '9',
 			r == '_', r == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// validUserBearer reports whether s is a valid per-run MCP bearer
+// token. Charset: [A-Za-z0-9._\-+/=], length 16..512. Matches §5.1 of
+// per-run-mcp-bearer-plan: covers JWT shape (base64url + dots + maybe
+// padding) and opaque tokens. Empty is rejected here — callers that
+// want no bearer omit the field entirely (handled by an empty-check
+// before invoking this validator).
+func validUserBearer(s string) bool {
+	if len(s) < 16 || len(s) > 512 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '.', r == '_', r == '-', r == '+', r == '/', r == '=':
 			continue
 		default:
 			return false

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1577,3 +1577,70 @@ func readEvents(t *testing.T, r io.Reader) []string {
 	}
 	return types
 }
+
+// TestRunRequest_UserBearerValidation guards the v0.8.x per-run MCP
+// bearer charset and length check at the HTTP boundary. Charset:
+// [A-Za-z0-9._\-+/=], length 16..512. Empty string is accepted
+// (backwards compat — static-bearer setups omit the field).
+func TestRunRequest_UserBearerValidation(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {Model: "stub-model", AllowedTools: []string{"Read"}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn"},
+	}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	valid16 := strings.Repeat("a", 16)
+	valid512 := strings.Repeat("a", 512)
+	cases := []struct {
+		name       string
+		userBearer string
+		want400    bool
+	}{
+		{"empty_omitted_OK", "", false},
+		{"valid_16_char", valid16, false},
+		{"valid_512_char", valid512, false},
+		{"valid_jwt_shape", "eyJhbGciOi.payload-part.signature_part", false},
+		{"valid_with_slash_plus_eq", "abc+def/ghi=ABC=", false},
+		{"too_short_15", strings.Repeat("a", 15), true},
+		{"too_long_513", strings.Repeat("a", 513), true},
+		{"illegal_space", "valid_token_with space_inside", true},
+		{"illegal_exclaim", "token!!!!!!!!!!!!!!!!", true},
+		{"illegal_unicode", "тест" + strings.Repeat("a", 12), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := fmt.Sprintf(
+				`{"agent":"default","user_bearer":%q,"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+				tc.userBearer,
+			)
+			resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			defer resp.Body.Close()
+			gotBad := resp.StatusCode == http.StatusBadRequest
+			if gotBad != tc.want400 {
+				slurp, _ := io.ReadAll(resp.Body)
+				t.Errorf("status=%d want400=%v body=%s", resp.StatusCode, tc.want400, slurp)
+				return
+			}
+			if tc.want400 {
+				slurp, _ := io.ReadAll(resp.Body)
+				if !strings.Contains(string(slurp), "user_bearer") {
+					t.Errorf("400 body should mention user_bearer, got %q", slurp)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1345,6 +1345,16 @@ func expandEnv(s string) string {
 // inside YAML. Allowlist:
 //   - any LOOMCYCLE_-prefixed variable (the project's own namespace)
 //   - well-known third-party keys MCP servers commonly need
+//
+// Note on the v0.8.x ${run.user_bearer} tokens: these are intentionally
+// NOT handled here. envVarRe above requires var names matching
+// [A-Za-z_][A-Za-z0-9_]*; the "." in "run.user_bearer" structurally
+// cannot match, so those tokens survive yaml-load verbatim. Per-run
+// substitution happens at MCP outbound request time in
+// internal/tools/mcp/http/client.go Client.do(). This means a yaml
+// header value like `Bearer ${run.user_bearer:-${LOOMCYCLE_STATIC}}`
+// has its inner ${LOOMCYCLE_STATIC} resolved here, while the outer
+// ${run.user_bearer:-...} flows through to the request-time substitution.
 func expandEnvAllowed(name string) bool {
 	if strings.HasPrefix(name, "LOOMCYCLE_") {
 		return true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1365,3 +1365,52 @@ agents:
 		t.Errorf("Load: %v", err)
 	}
 }
+
+// TestExpandEnv_DoesNotTouchRunNamespace documents the load-bearing
+// invariant that ${run.user_bearer} tokens (the v0.8.x per-run MCP
+// bearer substitution syntax) flow through expandEnv unchanged.
+//
+// Why this works: envVarRe is `\$\{([A-Za-z_][A-Za-z0-9_]*)\}`. The
+// "." in "run.user_bearer" fails the [A-Za-z0-9_]* character class so
+// the regex never matches the token, and expandEnv leaves the entire
+// `${run.user_bearer...}` string verbatim. Per-run substitution then
+// happens at request-build time in internal/tools/mcp/http/client.go.
+//
+// If someone widens the regex (e.g. to support nested namespaces),
+// they MUST also explicitly skip the "run.*" namespace here or the
+// MCP HTTP transport will see pre-resolved tokens and the per-run
+// bearer flow breaks.
+func TestExpandEnv_DoesNotTouchRunNamespace(t *testing.T) {
+	cases := []struct {
+		name, in string
+	}{
+		{"bare", "${run.user_bearer}"},
+		{"with_fallback", "${run.user_bearer:-foo}"},
+		{"embedded", "Bearer ${run.user_bearer}"},
+		{"with_fallback_embedded", "Authorization: Bearer ${run.user_bearer:-static}"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandEnv(tc.in)
+			if got != tc.in {
+				t.Errorf("expandEnv(%q) = %q, want unchanged", tc.in, got)
+			}
+		})
+	}
+}
+
+// TestExpandEnv_NestedRunInsideStaticEnv documents and guards the
+// operator-facing soak-phase migration mechanic from the per-run-mcp-
+// bearer-plan: `Bearer ${run.user_bearer:-${LOOMCYCLE_STATIC_BEARER}}`
+// resolves the INNER LOOMCYCLE_ token at yaml-load (here) and leaves
+// the OUTER ${run.user_bearer:-<resolved>} verbatim for request-time
+// substitution. This composition is what lets operators ship the
+// strict per-run config behind a static fallback during rollout.
+func TestExpandEnv_NestedRunInsideStaticEnv(t *testing.T) {
+	t.Setenv("LOOMCYCLE_STATIC_BEARER", "static123")
+	got := expandEnv("Bearer ${run.user_bearer:-${LOOMCYCLE_STATIC_BEARER}}")
+	want := "Bearer ${run.user_bearer:-static123}"
+	if got != want {
+		t.Errorf("expandEnv nested:\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -141,6 +141,15 @@ type RunInput struct {
 	// See internal/api/http/server.go resolveAgent for the overlay
 	// semantics and docs/PLAN.md → v0.8.2 for the full design.
 	UserTier string
+
+	// UserBearer is the v0.8.x per-run MCP bearer token. When non-
+	// empty the HTTP MCP transport substitutes it at outbound
+	// request-build time wherever the operator's YAML header
+	// contains ${run.user_bearer}. Empty is backwards-compat:
+	// headers without ${run.*} tokens are unaffected; headers with
+	// ${run.user_bearer:-X} use fallback X; headers with bare
+	// ${run.user_bearer} drop the header and emit a WARN.
+	UserBearer string
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -224,13 +224,12 @@ func (c *Client) do(ctx context.Context, body []byte) (*http.Response, error) {
 	// The MCP server's own auth check then returns a clean 401 that
 	// the loop surfaces as a typed tool error — more debuggable than
 	// a loomcycle-side dispatch failure.
-	runBearer := tools.RunIdentity(ctx).UserBearer
+	runIdent := tools.RunIdentity(ctx)
 	for k, v := range c.headers {
-		subV, drop := substituteRunVars(v, runBearer)
+		subV, drop := substituteRunVars(v, runIdent.UserBearer)
 		if drop {
-			ident := tools.RunIdentity(ctx)
 			log.Printf("mcp http: ${run.user_bearer} unresolved for header %q on %q (agent_id=%s, bearer=%s); dropping header",
-				k, c.url, ident.AgentID, tokenPrefix(runBearer))
+				k, c.url, runIdent.AgentID, tokenPrefix(runIdent.UserBearer))
 			continue
 		}
 		req.Header.Set(k, subV)

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -18,12 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
 
@@ -212,8 +214,26 @@ func (c *Client) do(ctx context.Context, body []byte) (*http.Response, error) {
 	// per-request whether to reply JSON or SSE based on what the response
 	// shape is; we must accept both.
 	req.Header.Set("Accept", "application/json, text/event-stream")
+	// v0.8.x per-run MCP bearer: substitute ${run.user_bearer} (and
+	// the ${run.user_bearer:-FALLBACK} POSIX form) at request-build
+	// time. The Client is shared across runs (see pool.go's contract),
+	// so substitution MUST be per-request — never against c.headers
+	// in-place. drop=true means a bare ${run.user_bearer} survived
+	// without a fallback because ctx carried no bearer; we drop the
+	// header rather than send a literal placeholder downstream.
+	// The MCP server's own auth check then returns a clean 401 that
+	// the loop surfaces as a typed tool error — more debuggable than
+	// a loomcycle-side dispatch failure.
+	runBearer := tools.RunIdentity(ctx).UserBearer
 	for k, v := range c.headers {
-		req.Header.Set(k, v)
+		subV, drop := substituteRunVars(v, runBearer)
+		if drop {
+			ident := tools.RunIdentity(ctx)
+			log.Printf("mcp http: ${run.user_bearer} unresolved for header %q on %q (agent_id=%s, bearer=%s); dropping header",
+				k, c.url, ident.AgentID, tokenPrefix(runBearer))
+			continue
+		}
+		req.Header.Set(k, subV)
 	}
 	c.sessMu.Lock()
 	sid := c.sessionID

--- a/internal/tools/mcp/http/client_test.go
+++ b/internal/tools/mcp/http/client_test.go
@@ -1,10 +1,12 @@
 package http
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
 
@@ -541,5 +544,182 @@ func TestCloseIsIdempotent(t *testing.T) {
 	}
 	if err := c.Close(); err != nil {
 		t.Errorf("second Close errored: %v", err)
+	}
+}
+
+// recordingHeaderServer is a fake MCP HTTP server that records every
+// inbound request's headers (keyed by request count) and replies with
+// a minimal MCP-valid response. Used by the v0.8.x per-run bearer
+// tests below. Always tools/call-shaped: the test calls mcp.CallTool
+// directly without a full Initialize handshake (Initialize is
+// covered elsewhere; we exercise the header substitution path only).
+type recordingHeaderServer struct {
+	mu       sync.Mutex
+	requests []http.Header
+}
+
+func (r *recordingHeaderServer) handler(w http.ResponseWriter, req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	var probe struct {
+		ID     *int64          `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	_ = json.Unmarshal(body, &probe)
+
+	r.mu.Lock()
+	r.requests = append(r.requests, req.Header.Clone())
+	r.mu.Unlock()
+
+	if probe.ID == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	writeJSON(w, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      *probe.ID,
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": "ok"}},
+		},
+	})
+}
+
+// TestMcpHttpClient_PerRunBearerSubstitution covers the happy path:
+// header value `Bearer ${run.user_bearer}` + ctx with a non-empty
+// UserBearer → outbound Authorization header has the substituted token.
+func TestMcpHttpClient_PerRunBearerSubstitution(t *testing.T) {
+	rec := &recordingHeaderServer{}
+	srv := httptest.NewServer(http.HandlerFunc(rec.handler))
+	defer srv.Close()
+
+	c, _ := New(Config{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer ${run.user_bearer}"},
+	})
+
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+		AgentID:    "a_test",
+		UserBearer: "run-token-abc123def4",
+	})
+	if _, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(rec.requests))
+	}
+	if got := rec.requests[0].Get("Authorization"); got != "Bearer run-token-abc123def4" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer run-token-abc123def4")
+	}
+}
+
+// TestMcpHttpClient_ConcurrentRunsSendDistinctBearers is the regression
+// guard for the per-run state bleed risk: two goroutines share the same
+// Client (single instance, single c.headers) but each carries its own
+// ctx-borne bearer. The fake server must see one request with bearer
+// AAA and one with bearer BBB, never crossed and never with a literal
+// "${run.*}" placeholder.
+func TestMcpHttpClient_ConcurrentRunsSendDistinctBearers(t *testing.T) {
+	rec := &recordingHeaderServer{}
+	srv := httptest.NewServer(http.HandlerFunc(rec.handler))
+	defer srv.Close()
+
+	c, _ := New(Config{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer ${run.user_bearer}"},
+	})
+
+	const bearerA = "tokenAAA1234567890aa"
+	const bearerB = "tokenBBB1234567890bb"
+	var wg sync.WaitGroup
+	wg.Add(2)
+	call := func(b string) {
+		defer wg.Done()
+		ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+			AgentID:    "a_" + b[:4],
+			UserBearer: b,
+		})
+		if _, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`)); err != nil {
+			t.Errorf("CallTool(%s): %v", b, err)
+		}
+	}
+	go call(bearerA)
+	go call(bearerB)
+	wg.Wait()
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.requests) != 2 {
+		t.Fatalf("got %d requests, want 2", len(rec.requests))
+	}
+	sawA, sawB := false, false
+	for i, h := range rec.requests {
+		auth := h.Get("Authorization")
+		if strings.Contains(auth, "${run.") {
+			t.Errorf("request #%d Authorization = %q contains unresolved placeholder", i, auth)
+		}
+		switch auth {
+		case "Bearer " + bearerA:
+			sawA = true
+		case "Bearer " + bearerB:
+			sawB = true
+		default:
+			t.Errorf("request #%d Authorization = %q matches neither bearer", i, auth)
+		}
+	}
+	if !sawA || !sawB {
+		t.Errorf("expected both bearers present, sawA=%v sawB=%v", sawA, sawB)
+	}
+}
+
+// TestMcpHttpClient_MissingBearerDropsHeader covers the strict-phase
+// failure mode: header value `Bearer ${run.user_bearer}` (no fallback)
+// + ctx with empty UserBearer → header is DROPPED, NOT shipped as
+// literal placeholder. A WARN log line is emitted with the agent_id
+// and triage-safe bearer prefix.
+func TestMcpHttpClient_MissingBearerDropsHeader(t *testing.T) {
+	rec := &recordingHeaderServer{}
+	srv := httptest.NewServer(http.HandlerFunc(rec.handler))
+	defer srv.Close()
+
+	// Capture log output so we can assert the WARN line shape.
+	var logBuf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(prev)
+
+	c, _ := New(Config{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer ${run.user_bearer}"},
+	})
+
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{
+		AgentID: "a_test",
+		// UserBearer left empty intentionally.
+	})
+	if _, err := mcp.CallTool(ctx, c, "search", json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.requests) != 1 {
+		t.Fatalf("got %d requests, want 1", len(rec.requests))
+	}
+	if got := rec.requests[0].Get("Authorization"); got != "" {
+		t.Errorf("Authorization = %q, want empty (header dropped)", got)
+	}
+
+	logLine := logBuf.String()
+	if !strings.Contains(logLine, "${run.user_bearer} unresolved") {
+		t.Errorf("WARN log missing expected phrase, got: %q", logLine)
+	}
+	if !strings.Contains(logLine, "a_test") {
+		t.Errorf("WARN log missing agent_id, got: %q", logLine)
+	}
+	if !strings.Contains(logLine, "bearer=(empty)") {
+		t.Errorf("WARN log should report bearer=(empty), got: %q", logLine)
 	}
 }

--- a/internal/tools/mcp/http/client_test.go
+++ b/internal/tools/mcp/http/client_test.go
@@ -716,6 +716,9 @@ func TestMcpHttpClient_MissingBearerDropsHeader(t *testing.T) {
 	if !strings.Contains(logLine, "${run.user_bearer} unresolved") {
 		t.Errorf("WARN log missing expected phrase, got: %q", logLine)
 	}
+	if !strings.Contains(logLine, "Authorization") {
+		t.Errorf("WARN log missing header name (Authorization), got: %q", logLine)
+	}
 	if !strings.Contains(logLine, "a_test") {
 		t.Errorf("WARN log missing agent_id, got: %q", logLine)
 	}

--- a/internal/tools/mcp/http/substitute.go
+++ b/internal/tools/mcp/http/substitute.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	"regexp"
+	"strings"
+)
+
+// runBearerRe matches the v0.8.x per-run MCP bearer template tokens
+// in a header value. Two forms supported:
+//
+//	${run.user_bearer}              — strict (no fallback)
+//	${run.user_bearer:-FALLBACK}    — POSIX-style default
+//
+// The lazy `.*?` for the fallback group is safe because expandEnv
+// (internal/config/config.go) has already resolved any inner
+// ${LOOMCYCLE_*} at yaml-load time. No nested `}` remains at request
+// time; bearer tokens themselves cannot contain `}` per the
+// [A-Za-z0-9._\-+/=]{16,512} charset validated at the HTTP boundary.
+var runBearerRe = regexp.MustCompile(`\$\{run\.user_bearer(?::-(.*?))?\}`)
+
+// substituteRunVars replaces ${run.user_bearer} and
+// ${run.user_bearer:-FALLBACK} tokens in s with bearer (or the
+// fallback when bearer is empty). It is a pure function — concurrent
+// callers may invoke it on the same s without coordination.
+//
+// drop is true iff a bare ${run.user_bearer} token (no fallback)
+// remained unresolved because bearer was empty. The caller (typically
+// Client.do) should drop the entire header in that case rather than
+// send a literal "${run.user_bearer}" placeholder downstream.
+//
+// Behaviour matrix:
+//
+//	s contains                          bearer=""        bearer="X"
+//	-----------------------------------------------------------------
+//	(no ${run.*} token)                 (s, false)       (s, false)
+//	${run.user_bearer}                  ("", true)       ("X", false)
+//	${run.user_bearer:-FB}              ("FB", false)    ("X", false)
+//	mixed bare + fallback               (mixed, true)    ("X...X", false)
+func substituteRunVars(s, bearer string) (string, bool) {
+	drop := false
+	out := runBearerRe.ReplaceAllStringFunc(s, func(m string) string {
+		if bearer != "" {
+			return bearer
+		}
+		// bearer empty — use the fallback if the token had one.
+		if i := strings.Index(m, ":-"); i >= 0 {
+			// Strip the trailing "}" to recover the fallback text.
+			return m[i+2 : len(m)-1]
+		}
+		// Bare token, no fallback → caller drops the header.
+		drop = true
+		return ""
+	})
+	return out, drop
+}
+
+// tokenPrefix returns a triage-safe 4-char prefix + ellipsis for a
+// bearer-shaped string, or "(empty)" for the empty string. Used only
+// on WARN paths; never invoked on the happy path. Satisfies CLAUDE.md
+// rule 4: bearer tokens never appear in logs in full.
+func tokenPrefix(s string) string {
+	if s == "" {
+		return "(empty)"
+	}
+	if len(s) <= 4 {
+		return s + "…"
+	}
+	return s[:4] + "…"
+}

--- a/internal/tools/mcp/http/substitute_test.go
+++ b/internal/tools/mcp/http/substitute_test.go
@@ -1,0 +1,102 @@
+package http
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSubstituteRunVars_BearerPresent(t *testing.T) {
+	got, drop := substituteRunVars("Bearer ${run.user_bearer}", "tok123abc")
+	if got != "Bearer tok123abc" {
+		t.Errorf("got = %q, want %q", got, "Bearer tok123abc")
+	}
+	if drop {
+		t.Errorf("drop = true, want false")
+	}
+}
+
+func TestSubstituteRunVars_FallbackUsed(t *testing.T) {
+	got, drop := substituteRunVars("Bearer ${run.user_bearer:-static-fallback}", "")
+	if got != "Bearer static-fallback" {
+		t.Errorf("got = %q, want %q", got, "Bearer static-fallback")
+	}
+	if drop {
+		t.Errorf("drop = true, want false")
+	}
+}
+
+func TestSubstituteRunVars_BearerWinsOverFallback(t *testing.T) {
+	got, drop := substituteRunVars("Bearer ${run.user_bearer:-static-fallback}", "real-token")
+	if got != "Bearer real-token" {
+		t.Errorf("got = %q, want %q", got, "Bearer real-token")
+	}
+	if drop {
+		t.Errorf("drop = true, want false")
+	}
+}
+
+func TestSubstituteRunVars_NoBearerNoFallback(t *testing.T) {
+	got, drop := substituteRunVars("Bearer ${run.user_bearer}", "")
+	if !drop {
+		t.Errorf("drop = false, want true (bare token with empty bearer)")
+	}
+	// got value is irrelevant when drop=true (caller discards the header),
+	// but for hygiene the literal "${...}" placeholder must not survive
+	// — otherwise a caller that ignores drop would ship the placeholder
+	// downstream.
+	if strings.Contains(got, "${run.") {
+		t.Errorf("got = %q, must not contain unresolved placeholder", got)
+	}
+}
+
+func TestSubstituteRunVars_MultipleOccurrences(t *testing.T) {
+	got, drop := substituteRunVars("${run.user_bearer}:${run.user_bearer}", "abc")
+	if got != "abc:abc" {
+		t.Errorf("got = %q, want %q", got, "abc:abc")
+	}
+	if drop {
+		t.Errorf("drop = true, want false")
+	}
+}
+
+func TestSubstituteRunVars_NoToken(t *testing.T) {
+	// Pure no-op when value contains no ${run.*} template.
+	got, drop := substituteRunVars("Bearer static-value", "any-bearer")
+	if got != "Bearer static-value" {
+		t.Errorf("got = %q, want unchanged", got)
+	}
+	if drop {
+		t.Errorf("drop = true, want false")
+	}
+}
+
+// TestSubstituteRunVars_MixedBareAndFallback covers the edge case where
+// one header value contains both a bare and a fallback-bearing token.
+// Empty bearer: the bare one drops the header (per loomcycle plan §3),
+// the fallback resolves, drop is true.
+func TestSubstituteRunVars_MixedBareAndFallback(t *testing.T) {
+	got, drop := substituteRunVars("${run.user_bearer}|${run.user_bearer:-fb}", "")
+	if !drop {
+		t.Errorf("drop = false, want true (at least one bare token unresolved)")
+	}
+	if strings.Contains(got, "${run.") {
+		t.Errorf("got = %q, must not contain unresolved placeholder", got)
+	}
+}
+
+func TestTokenPrefix(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", "(empty)"},
+		{"abc", "abc…"},
+		{"abcd", "abcd…"},
+		{"abcdefgh", "abcd…"},
+		{"eyJhbGciOiJIUzI1NiJ9.payload.sig", "eyJh…"},
+	}
+	for _, tc := range cases {
+		if got := tokenPrefix(tc.in); got != tc.want {
+			t.Errorf("tokenPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/tools/mcp/http/substitute_test.go
+++ b/internal/tools/mcp/http/substitute_test.go
@@ -82,6 +82,12 @@ func TestSubstituteRunVars_MixedBareAndFallback(t *testing.T) {
 	if strings.Contains(got, "${run.") {
 		t.Errorf("got = %q, must not contain unresolved placeholder", got)
 	}
+	// Pin the full expected shape: bare token → empty, fallback → "fb".
+	// Without this, the test would pass even if the fallback branch were
+	// silently broken (returning empty too).
+	if got != "|fb" {
+		t.Errorf("got = %q, want %q (bare-token empty + fallback resolved)", got, "|fb")
+	}
 }
 
 func TestTokenPrefix(t *testing.T) {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -178,6 +178,13 @@ type RunIdentityValue struct {
 	// can identify "which version of myself am I running" without a
 	// store roundtrip.
 	AgentDefID string
+	// UserBearer is the v0.8.x per-run MCP bearer token supplied by
+	// the caller on the run request (wire field "user_bearer"). The
+	// HTTP MCP transport substitutes it into header values containing
+	// ${run.user_bearer} at outbound request-build time. Sub-agents
+	// inherit it identically (NOT narrowed — they act on behalf of
+	// the same end-user). Never persisted; never logged in full.
+	UserBearer string
 }
 
 // WithRunIdentity attaches the current run's identity to ctx. The


### PR DESCRIPTION
## Summary

- Adds `user_bearer` field to `runRequest` + `messagesRequest`; plumbs through `tools.RunIdentityValue` so sub-agents inherit identically (NOT narrowed).
- HTTP MCP transport now substitutes `${run.user_bearer}` and `${run.user_bearer:-FALLBACK}` in operator-configured `mcp_servers.*.headers` at outbound request-build time. Missing bearer + no fallback → drop the header + WARN (downstream MCP returns clean 401).
- Two commits structured so the JSA team can branch off `72ff9bb` for J-1/J-2 in parallel — Phase 2 lands the substitution layer on top.

## Why

JSA's `/api/mcp` authenticates per-end-user via Bearer tokens, but `mcp_servers.headers` is operator-static. Every run today authenticates as the operator (`denn`), not the actual end-user (e.g. `diana`). End-users see operator-scoped data or 401 depending on JSA's token resolution. This change closes that gap.

Design doc: `jobs-search-agent/doc/per-run-mcp-bearer-plan.md` on `feature-per-run-bearer-plan` (L-1 through L-6).

## Operator migration

| Phase | `Authorization` yaml | Behavior |
|---|---|---|
| Before this PR | `Bearer ${LOOMCYCLE_STATIC_BEARER}` | Static-bearer, unchanged |
| Soak (during rollout) | `Bearer ${run.user_bearer:-${LOOMCYCLE_STATIC_BEARER}}` | Per-run when supplied; static fallback otherwise |
| After verified | `Bearer ${run.user_bearer}` | Strict per-run; missing → drop header → JSA 401 |

The nested-substitution composition works because `expandEnv`'s existing regex `\$\{([A-Za-z_][A-Za-z0-9_]*)\}` structurally cannot match `${run.*}` (the `.` breaks the char class). Inner `${LOOMCYCLE_*}` resolves at yaml-load; outer `${run.user_bearer:-<resolved>}` flows to request time.

## Test plan

Automated (`go test -race ./...` clean):
- [x] `TestSubstituteRunVars_*` × 7 cases (pure function)
- [x] `TestTokenPrefix` (WARN-log token sanitization)
- [x] `TestMcpHttpClient_PerRunBearerSubstitution` (happy path)
- [x] `TestMcpHttpClient_ConcurrentRunsSendDistinctBearers` (R-2 per-run state bleed guard)
- [x] `TestMcpHttpClient_MissingBearerDropsHeader` (drop + WARN log shape)
- [x] `TestRunRequest_UserBearerValidation` × 10 cases (charset/length at HTTP boundary)
- [x] `TestSubAgent_InheritsParentUserBearer` (regression guard against future narrowing)
- [x] `TestExpandEnv_DoesNotTouchRunNamespace` × 4 cases (invariant guard)
- [x] `TestExpandEnv_NestedRunInsideStaticEnv` (soak-phase composition guard)

Manual end-to-end (post-merge, against `denn@claude-vm.local`):
- [ ] Deploy linux/amd64 binary; restart `systemctl --user loomcycle`
- [ ] Soak-phase yaml + `user_bearer` supplied → JSA returns user-scoped data
- [ ] Soak-phase yaml without `user_bearer` → static fallback works
- [ ] Strict-phase yaml without `user_bearer` → WARN logged + JSA returns 401 (not 500)
- [ ] `journalctl -u loomcycle | grep -i bearer` shows only `tokenPrefix` form; no full bearers
- [ ] Two concurrent runs with distinct `user_bearer`s — JSA logs show each MCP call with the correct bearer

## Out of scope

- gRPC `Run`/`Continue` proto fields (RPCs are still `Unimplemented`; gap noted in `runInputFromProto`)
- General `${run.*}` namespace beyond `user_bearer`
- stdio MCP transport (no headers to substitute)
- Token persistence to store

## JSA-side checkpoint

`72ff9bb` (Phase 1) is safe for the JSA team to branch off for J-1 / J-2 work — the wire field is live behind backwards compat (empty `user_bearer` = today's behavior). The MCP substitution in `7596f59` (Phase 2) only activates when operator yaml references `${run.user_bearer}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)