### PR TITLE
feat: auto-resolve build identity from runtime/debug

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -4,11 +4,12 @@
 //
 //	loomcycle --config loomcycle.yaml
 //
-// Build identification: the buildCommit and buildTime vars are populated
-// at link time via -ldflags so a running binary can identify itself.
-// Without ldflags injection they default to "unknown" — useful signal
-// when an operator is debugging "is this the binary I just built?".
-// See loomcycle.sh for the canonical build invocation.
+// Build identification: the buildVersion / buildCommit / buildTime vars
+// are resolved automatically from Go's VCS stamp (embedded by `go build`
+// since 1.18) and from the module's tagged version when present. A
+// release script may still override any of them via -ldflags to inject
+// explicit values, but the unattached default works for `go build`,
+// `go install`, and CI without any wrapper tooling.
 package main
 
 import (
@@ -22,6 +23,8 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -61,19 +64,96 @@ import (
 	mcpstdio "github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
 )
 
-// Build identification — overridden at link time via:
+// Build identification. Empty defaults are resolved at main()-entry
+// from Go's VCS stamp via runtime/debug.ReadBuildInfo() — no external
+// tooling required. ldflags overrides still win:
 //
-//	go build -ldflags "-X main.buildCommit=$(git rev-parse --short HEAD) \
+//	go build -ldflags "-X main.buildVersion=v0.8.14 \
+//	                   -X main.buildCommit=$(git rev-parse --short HEAD) \
 //	                   -X main.buildTime=$(date -u +%Y-%m-%dT%H:%M:%SZ)" ...
 //
-// Defaults make a forgotten -ldflags invocation visible at runtime
-// rather than silently shipping an unidentifiable binary.
+// Resolution precedence per var: ldflags override → runtime/debug →
+// "unknown". A binary built outside a VCS-aware context (e.g. `go run`
+// from an unpacked tarball) ends up with "unknown" — visible signal
+// that the operator should rebuild from a real checkout.
 var (
-	buildCommit = "unknown"
-	buildTime   = "unknown"
+	buildVersion = ""
+	buildCommit  = ""
+	buildTime    = ""
 )
 
+// resolveBuildInfo reads Go's automatically-embedded VCS stamp and
+// returns (version, commit, time). commit gets a "-dirty" suffix when
+// the working tree was modified at build time. Empty strings mean the
+// corresponding info wasn't available (binary built without VCS — e.g.
+// `go test` by default does not embed VCS info, but `go build` and
+// `go install` do).
+func resolveBuildInfo() (version, commit, builtAt string) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", "", ""
+	}
+	var rev string
+	var dirty bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.time":
+			builtAt = s.Value
+		case "vcs.modified":
+			dirty = s.Value == "true"
+		}
+	}
+	return formatBuildInfo(info.Main.Version, rev, builtAt, dirty)
+}
+
+// formatBuildInfo normalises the raw VCS-stamp fields into the display
+// shape used by --version and startup logs. Split out from
+// resolveBuildInfo so it can be exhaustively unit-tested without
+// depending on whether the test binary itself had VCS info embedded.
+func formatBuildInfo(mainVersion, rev, builtAt string, dirty bool) (version, commit, ts string) {
+	version = mainVersion
+	if version == "(devel)" || version == "" {
+		// `go build` from a local checkout reports "(devel)"; surface a
+		// shorter form so operators can tell a release binary from a
+		// developer build at a glance.
+		version = "devel"
+	}
+	if len(rev) > 12 {
+		rev = rev[:12]
+	}
+	if dirty && rev != "" {
+		rev += "-dirty"
+	}
+	return version, rev, builtAt
+}
+
 func main() {
+	// Resolve build identifiers FIRST so subcommands (validate / agents
+	// / health / migrate) and --version see the same auto-resolved
+	// values. ldflags overrides win — release scripts that explicitly
+	// set buildVersion/buildCommit/buildTime get exactly those.
+	autoVersion, autoCommit, autoTime := resolveBuildInfo()
+	if buildVersion == "" {
+		buildVersion = autoVersion
+	}
+	if buildCommit == "" {
+		buildCommit = autoCommit
+	}
+	if buildTime == "" {
+		buildTime = autoTime
+	}
+	if buildVersion == "" {
+		buildVersion = "unknown"
+	}
+	if buildCommit == "" {
+		buildCommit = "unknown"
+	}
+	if buildTime == "" {
+		buildTime = "unknown"
+	}
+
 	// Subcommand dispatch BEFORE flag parsing — let `loomcycle
 	// validate ...` flow into the CLI surface without colliding with
 	// the server's own --config flag.
@@ -103,7 +183,8 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Printf("loomcycle commit=%s built=%s\n", buildCommit, buildTime)
+		fmt.Printf("loomcycle version=%s commit=%s built=%s go=%s\n",
+			buildVersion, buildCommit, buildTime, runtime.Version())
 		return
 	}
 
@@ -111,7 +192,7 @@ func main() {
 	// binary spots it immediately — before any "but my code says X"
 	// debugging spiral. Critical when development cycle is "git pull
 	// && restart" without a rebuild step in between.
-	log.Printf("loomcycle build: commit=%s time=%s", buildCommit, buildTime)
+	log.Printf("loomcycle build: version=%s commit=%s time=%s", buildVersion, buildCommit, buildTime)
 
 	cfg, err := config.Load(*cfgPath)
 	if err != nil {

--- a/cmd/loomcycle/main_test.go
+++ b/cmd/loomcycle/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
@@ -55,5 +56,118 @@ func TestApplyAllowedToolsFilter(t *testing.T) {
 				t.Errorf("got %v, want %v", gotNames, tc.want)
 			}
 		})
+	}
+}
+
+// TestFormatBuildInfo exhaustively covers the version/commit display
+// normalisation. Driving the pure formatter with synthetic inputs
+// avoids any dependency on whether the test binary itself was built
+// with VCS stamping (`go test` doesn't embed VCS info by default).
+func TestFormatBuildInfo(t *testing.T) {
+	cases := []struct {
+		name        string
+		mainVersion string
+		rev         string
+		builtAt     string
+		dirty       bool
+		wantVersion string
+		wantCommit  string
+		wantTS      string
+	}{
+		{
+			name:        "release_tag_clean",
+			mainVersion: "v0.8.14",
+			rev:         "7c2ca2e1f592abcd",
+			builtAt:     "2026-05-13T18:04:43Z",
+			wantVersion: "v0.8.14",
+			wantCommit:  "7c2ca2e1f592", // truncated to 12
+			wantTS:      "2026-05-13T18:04:43Z",
+		},
+		{
+			name:        "pseudo_version_dirty",
+			mainVersion: "v0.8.14-0.20260513180443-7c2ca2e1f592",
+			rev:         "7c2ca2e1f592abcd",
+			builtAt:     "2026-05-13T18:04:43Z",
+			dirty:       true,
+			wantVersion: "v0.8.14-0.20260513180443-7c2ca2e1f592",
+			wantCommit:  "7c2ca2e1f592-dirty",
+			wantTS:      "2026-05-13T18:04:43Z",
+		},
+		{
+			name:        "devel_marker_normalised",
+			mainVersion: "(devel)",
+			rev:         "abc123def456",
+			wantVersion: "devel",
+			wantCommit:  "abc123def456",
+		},
+		{
+			name:        "empty_main_version_normalised",
+			mainVersion: "",
+			rev:         "abc123",
+			wantVersion: "devel",
+			wantCommit:  "abc123",
+		},
+		{
+			name:        "short_rev_dirty",
+			mainVersion: "v0.8.14",
+			rev:         "abc",
+			dirty:       true,
+			wantVersion: "v0.8.14",
+			wantCommit:  "abc-dirty",
+		},
+		{
+			name:        "empty_rev_dirty_no_suffix",
+			mainVersion: "v0.8.14",
+			rev:         "",
+			dirty:       true,
+			wantVersion: "v0.8.14",
+			wantCommit:  "", // no "-dirty" appended to an empty rev
+		},
+		{
+			name:        "exactly_12_char_rev_untruncated",
+			mainVersion: "v0.8.14",
+			rev:         "abcdef012345", // exactly 12 chars
+			wantVersion: "v0.8.14",
+			wantCommit:  "abcdef012345",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotV, gotC, gotT := formatBuildInfo(tc.mainVersion, tc.rev, tc.builtAt, tc.dirty)
+			if gotV != tc.wantVersion {
+				t.Errorf("version: got %q want %q", gotV, tc.wantVersion)
+			}
+			if gotC != tc.wantCommit {
+				t.Errorf("commit: got %q want %q", gotC, tc.wantCommit)
+			}
+			if gotT != tc.wantTS {
+				t.Errorf("ts: got %q want %q", gotT, tc.wantTS)
+			}
+		})
+	}
+}
+
+// TestResolveBuildInfo_DoesNotPanic is a smoke test for the
+// runtime/debug.ReadBuildInfo() integration. The exact returned values
+// depend on the build mode — `go test` typically doesn't stamp VCS
+// info, while `go build` does — so we only assert the helper returns
+// without panicking and that any non-empty commit obeys the formatter's
+// shape contract (≤12 hex chars, possibly "-dirty" suffix).
+func TestResolveBuildInfo_DoesNotPanic(t *testing.T) {
+	_, commit, _ := resolveBuildInfo()
+	if commit == "" {
+		t.Logf("commit empty (no VCS info embedded in test binary — expected for go test)")
+		return
+	}
+	bare := strings.TrimSuffix(commit, "-dirty")
+	if len(bare) > 12 {
+		t.Errorf("commit %q exceeds 12-char truncation", commit)
+	}
+	for _, r := range bare {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')
+		if !isHex {
+			t.Errorf("commit %q contains non-hex char %q", commit, r)
+			break
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces forgotten-ldflags-default \"unknown\" with auto-resolved version/commit/time from Go's embedded VCS stamp.
- New \`--version\` shape: \`loomcycle version=<v> commit=<c> built=<t> go=<g>\`.
- ldflags overrides still win for release scripts that want explicit values.

## Why

Today's deploy used \`-X main.gitCommit=...\` (wrong variable name — the var is \`buildCommit\`) and silently shipped \`commit=unknown\` to the VM. That class of mistake is the whole motivation for unattached versioning: the binary should be able to identify itself even when nobody remembered to pass the right ldflags.

\`runtime/debug.ReadBuildInfo()\` has provided this since Go 1.18; we just weren't reading it.

## How

\`resolveBuildInfo()\` walks \`info.Settings\` for \`vcs.revision\`, \`vcs.time\`, \`vcs.modified\`, and reads \`info.Main.Version\` for the module's tagged version (or a pseudo-version like \`v0.8.14-0.YYYYMMDD-HASH\` when past the last tag). Formatter logic (12-char truncation, \`-dirty\` suffix, \`(devel)\` normalisation) is split into \`formatBuildInfo()\` so it can be exhaustively unit-tested.

Resolution precedence per identifier:
1. ldflags-injected value (release-script override)
2. \`runtime/debug\` (auto, unattached)
3. \`\"unknown\"\` (final fallback — visible signal if both above failed)

## Test plan

Automated:
- [x] \`TestFormatBuildInfo\` — 7 cases (release tag, pseudo-version dirty, (devel) normalisation, empty version, short rev dirty, empty rev dirty, exactly-12-char untruncated)
- [x] \`TestResolveBuildInfo_DoesNotPanic\` — smoke test handling the \`go test\` no-VCS case
- [x] \`go test ./...\` clean

Manual:
- [x] \`go build -o bin/lc ./cmd/loomcycle && ./bin/lc --version\` produces a useful pseudo-version with commit + dirty marker
- [ ] Post-merge: redeploy to VM, confirm \`journalctl -u loomcycle\` shows the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)