### PR TITLE
feat(v0.8.15): LoomCycle MCP server — Connector abstraction + stdio MCP + 20 tools

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -729,7 +729,8 @@ func main() {
 		grpcAdapter := loomgrpc.New(loomgrpc.Config{
 			Store:       storeIface,
 			CancelReg:   srv.CancelRegistry(),
-			Runner:      srv, // *http.Server satisfies runner.Runner
+			Connector:   srv, // v0.8.15: *http.Server satisfies connector.Connector
+			Runner:      srv, // *http.Server satisfies runner.Runner (streaming)
 			AuthToken:   cfg.Env.AuthToken,
 			BuildCommit: buildCommit,
 			BuildTime:   buildTime,

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -56,6 +56,7 @@ import (
 
 	loomgrpc "github.com/denn-gubsky/loomcycle/internal/api/grpc"
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	lcmcp "github.com/denn-gubsky/loomcycle/internal/api/mcp"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	"github.com/denn-gubsky/loomcycle/internal/tools/localapi"
@@ -162,6 +163,16 @@ func main() {
 	// the known subcommands, hand off to internal/cli and exit.
 	// Otherwise fall through to the server entry point (preserves
 	// backwards compat: `loomcycle --config foo.yaml` still works).
+	//
+	// The `mcp` subcommand is a special case (v0.8.15+): it starts
+	// the SAME server setup as the default flow, plus a stdio MCP
+	// listener reading os.Stdin / writing os.Stdout. CRITICAL: in
+	// mcp mode, no code may write to os.Stdout outside the MCP loop
+	// — stdout is the JSON-RPC wire. The stdlib `log` package
+	// defaults to os.Stderr (so log lines are safe); any future
+	// `fmt.Println` / direct os.Stdout writes elsewhere in the
+	// binary would corrupt the protocol.
+	mcpMode := false
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "validate":
@@ -172,6 +183,11 @@ func main() {
 			os.Exit(cli.RunHealth(os.Args[2:], os.Stdout, os.Stderr))
 		case "migrate":
 			os.Exit(cli.RunMigrate(os.Args[2:], os.Stdout, os.Stderr))
+		case "mcp":
+			mcpMode = true
+			// Strip "mcp" from os.Args so flag.Parse() below sees
+			// the remaining flags (--config etc.) at index 1+.
+			os.Args = append([]string{os.Args[0]}, os.Args[2:]...)
 		case "help", "-h", "--help":
 			cli.PrintHelp(os.Stdout)
 			return
@@ -696,6 +712,46 @@ func main() {
 		sessionGCMaxIdle = 10 * time.Minute
 	}
 	go srv.RunSessionLockGC(bgCtx, sessionGCInterval, sessionGCMaxIdle)
+
+	// v0.8.15: LoomCycle MCP — when launched via `loomcycle mcp --config Y`,
+	// expose the runtime as an MCP server over stdio alongside the HTTP
+	// listener. Per the RFC, both surfaces run together; the HTTP server
+	// keeps serving /healthz, /v1/*, and the Web UI while MCP clients
+	// (Claude Code first) drive the same business logic through
+	// Connector dispatch.
+	//
+	// The dynamic-agent TTL sweeper runs in BOTH default and mcp modes:
+	// the dynamic_agents table is shared. operators who never use the
+	// `register_agent` MCP tool simply have an empty table the sweeper
+	// passes over with zero rows deleted.
+	if cfg.Env.DynamicAgentSweepInterval > 0 {
+		lcmcp.RunDynamicAgentSweeper(bgCtx, storeIface, cfg.Env.DynamicAgentSweepInterval, log.Printf)
+		log.Printf("dynamic_agents: sweeper enabled (interval=%s)", cfg.Env.DynamicAgentSweepInterval)
+	}
+	if mcpMode {
+		mcpSrv := lcmcp.New(lcmcp.Config{
+			Connector:     srv, // *http.Server satisfies connector.Connector
+			Runner:        srv, // *http.Server satisfies runner.Runner (streaming)
+			Store:         storeIface,
+			Logf:          log.Printf, // log goes to stderr; never stdout (stdout is the JSON-RPC wire)
+			ServerName:    "loomcycle",
+			ServerVersion: buildVersion,
+		})
+		// Run the MCP stdio loop in a goroutine. When stdin closes
+		// (Claude Code disconnects), Serve returns; we log and let
+		// the HTTP listener keep serving until the process is sent
+		// a signal. Operators who want MCP-disconnect = process-exit
+		// can wrap loomcycle in a supervisor that watches for the
+		// log line.
+		go func() {
+			log.Printf("mcp: stdio server starting (20 tools registered)")
+			if err := mcpSrv.Serve(bgCtx, os.Stdin, os.Stdout); err != nil {
+				log.Printf("mcp: serve ended: %v", err)
+			} else {
+				log.Printf("mcp: stdio closed; HTTP listener continues")
+			}
+		}()
+	}
 	log.Printf("session-lock GC: interval=%s max_idle=%s", sessionGCInterval, sessionGCMaxIdle)
 
 	// Periodic probe loop: re-runs the resolver's reachability +

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -31,6 +31,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
@@ -38,18 +39,33 @@ import (
 )
 
 // Server implements loomcyclepb.LoomcycleServer. The metadata RPCs
-// (Health, GetAgent, CancelAgent, ListUserAgents, GetTranscript) read
-// from the same Store + cancel.Registry the HTTP server uses; the
-// streaming RPCs (Run, Continue) delegate to a runner.Runner — in
+// dispatch through the connector.Connector interface (v0.8.15+) — in
 // production this is the *internal/api/http.Server instance from
-// main.go, so a cancel issued via gRPC reaches a run started via
-// HTTP and vice versa.
+// main.go, so a cancel/get/list issued via gRPC reaches the same
+// business logic the HTTP /v1/* endpoints use. The streaming RPCs
+// (Run, Continue) keep using runner.Runner directly because Connector
+// only exposes a blocking SpawnRun — gRPC streaming needs the
+// callback-driven runner.RunOnce path.
+//
+// Future proto method additions (gRPC equivalents of the remaining
+// Connector methods — RegisterAgent, ListAgents, Memory, Channel,
+// AgentDef, Evaluation, Context, Pause/Snapshot) slot into the
+// Connector dispatch pattern mechanically.
 type Server struct {
 	loomcyclepb.UnimplementedLoomcycleServer
 
 	store     store.Store
 	cancelReg *cancel.Registry
-	runner    runner.Runner
+	// connector is the v0.8.15+ canonical operation surface. Used by
+	// the unary metadata RPCs (GetAgent, CancelAgent). May be nil for
+	// older callers that didn't supply one; the affected handlers
+	// fall back to the legacy direct-store + cancelReg path.
+	connector connector.Connector
+	// runner is the wire-agnostic loop driver used by Run + Continue
+	// streaming RPCs. Connector.SpawnRun is blocking-only; gRPC
+	// streaming needs the callback-driven runner.RunOnce path so this
+	// field stays alongside connector.
+	runner runner.Runner
 
 	// authToken is the bearer token clients must present in the
 	// `authorization` gRPC metadata header. Empty means open-mode
@@ -72,9 +88,15 @@ type Server struct {
 type Config struct {
 	Store     store.Store
 	CancelReg *cancel.Registry
-	// Runner is the wire-agnostic loop driver. *internal/api/http.Server
-	// satisfies it. May be nil — Run + Continue then return
-	// codes.Unimplemented (useful for tests that don't need streaming).
+	// Connector is the v0.8.15+ operation surface that unary metadata
+	// RPCs dispatch through. *internal/api/http.Server satisfies it.
+	// Optional — when nil, GetAgent/CancelAgent fall back to direct
+	// store+cancelReg paths (preserves backwards compatibility).
+	Connector connector.Connector
+	// Runner is the wire-agnostic loop driver for the streaming RPCs.
+	// *internal/api/http.Server also satisfies it. May be nil — Run +
+	// Continue then return codes.Unimplemented (useful for tests that
+	// don't need streaming).
 	Runner      runner.Runner
 	AuthToken   string
 	BuildCommit string
@@ -87,6 +109,7 @@ func New(cfg Config) *Server {
 	return &Server{
 		store:       cfg.Store,
 		cancelReg:   cfg.CancelReg,
+		connector:   cfg.Connector,
 		runner:      cfg.Runner,
 		authToken:   cfg.AuthToken,
 		buildCommit: cfg.BuildCommit,
@@ -165,16 +188,39 @@ func (s *Server) CancelAgent(ctx context.Context, req *loomcyclepb.CancelAgentRe
 	}
 	agentID := req.GetAgentId()
 
+	// v0.8.15+ dispatch through Connector. The Connector method
+	// already handles both "live in registry" (cascade-cancel) and
+	// "in store but already ended" (idempotent no-op) paths — we just
+	// translate its result into proto + gRPC status codes here.
+	if s.connector != nil {
+		res, err := s.connector.CancelRun(ctx, agentID, req.GetReason())
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				return nil, status.Errorf(codes.NotFound, "no run found for agent_id %q", agentID)
+			}
+			return nil, status.Errorf(codes.Internal, "connector: %v", err)
+		}
+		// Cancelled=true means this call initiated the cancel (live in
+		// registry); AlreadyEnded=true means the run was already
+		// terminated. Both succeed; cancelled_count = 1+cascade on the
+		// active path, 0 on the idempotent path.
+		if res.Cancelled {
+			return &loomcyclepb.CancelAgentResponse{
+				CancelledCount: int32(1 + res.CascadeCount),
+			}, nil
+		}
+		return &loomcyclepb.CancelAgentResponse{CancelledCount: 0}, nil
+	}
+
+	// Legacy direct path (preserves backwards compat when no
+	// Connector was supplied — e.g., older callers, some tests).
 	res, ok := s.cancelReg.Cancel(agentID, req.GetReason())
 	if ok {
-		// The cascade walk captured this agent + every descendant; the
-		// proto's cancelled_count reports the total.
 		return &loomcyclepb.CancelAgentResponse{
 			CancelledCount: int32(1 + len(res.Cascaded)),
 		}, nil
 	}
-
-	// Not in registry — either already terminated or never existed.
 	if s.store == nil {
 		return nil, status.Errorf(codes.NotFound, "no live or terminated run for %q (no store configured)", agentID)
 	}
@@ -185,10 +231,6 @@ func (s *Server) CancelAgent(ctx context.Context, req *loomcyclepb.CancelAgentRe
 		}
 		return nil, status.Errorf(codes.Internal, "store: %v", err)
 	}
-	// Idempotent: agent exists in the store but is no longer live —
-	// cancelled_count = 0 signals "this call did not initiate the
-	// cancel" but the RPC succeeds (mirrors HTTP's 200 with
-	// cancelled=false).
 	return &loomcyclepb.CancelAgentResponse{CancelledCount: 0}, nil
 }
 

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -2,9 +2,11 @@ package grpc
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -579,6 +582,129 @@ func startTestServerWithRunner(t *testing.T, r runner.Runner) (loomcyclepb.Loomc
 		grpcSrv.GracefulStop()
 	}
 	return loomcyclepb.NewLoomcycleClient(conn), cleanup
+}
+
+// mockConnector is a minimal connector.Connector for the gRPC
+// dispatch-through-connector regression test. Every method records
+// it was called; only the methods exercised by the test (CancelRun)
+// return meaningful results — the rest return zero values, which is
+// fine because the test only calls CancelAgent.
+type mockConnector struct {
+	cancelCalls atomic.Int32
+	lastAgentID atomic.Value // string
+	lastReason  atomic.Value // string
+	cancelOK    atomic.Bool  // controls return value
+	cascade     atomic.Int32 // CascadeCount returned
+}
+
+func (m *mockConnector) CancelRun(_ context.Context, agentID, reason string) (connector.CancelRunResult, error) {
+	m.cancelCalls.Add(1)
+	m.lastAgentID.Store(agentID)
+	m.lastReason.Store(reason)
+	if !m.cancelOK.Load() {
+		return connector.CancelRunResult{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	return connector.CancelRunResult{
+		Cancelled:    true,
+		CascadeCount: int(m.cascade.Load()),
+	}, nil
+}
+
+// Every other Connector method returns a zero value — the dispatch
+// test only exercises CancelRun. Keeping them in one block so adding
+// a new Connector method forces a compile failure here (which is the
+// signal we want: "look at me, I'm new").
+func (m *mockConnector) SpawnRun(context.Context, connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+	return connector.SpawnRunResult{}, nil
+}
+func (m *mockConnector) GetRun(context.Context, string) (connector.Run, error) {
+	return connector.Run{}, nil
+}
+func (m *mockConnector) ListRuns(context.Context, connector.ListRunsFilter) ([]connector.Run, error) {
+	return nil, nil
+}
+func (m *mockConnector) RegisterAgent(context.Context, connector.RegisterAgentRequest) (connector.AgentDescriptor, error) {
+	return connector.AgentDescriptor{}, nil
+}
+func (m *mockConnector) UnregisterAgent(context.Context, string) error { return nil }
+func (m *mockConnector) ListAgents(context.Context, bool) ([]connector.AgentDescriptor, error) {
+	return nil, nil
+}
+func (m *mockConnector) Memory(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) Channel(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) AgentDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) Evaluation(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) Context(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) PauseRuntime(context.Context, int) (connector.PauseResult, error) {
+	return connector.PauseResult{}, nil
+}
+func (m *mockConnector) ResumeRuntime(context.Context) (connector.ResumeResult, error) {
+	return connector.ResumeResult{}, nil
+}
+func (m *mockConnector) GetRuntimeState(context.Context) (connector.RuntimeState, error) {
+	return connector.RuntimeState{}, nil
+}
+func (m *mockConnector) CreateSnapshot(context.Context, connector.CreateSnapshotRequest) (connector.SnapshotDescriptor, error) {
+	return connector.SnapshotDescriptor{}, nil
+}
+func (m *mockConnector) ListSnapshots(context.Context) ([]connector.SnapshotDescriptor, error) {
+	return nil, nil
+}
+func (m *mockConnector) ExportSnapshot(context.Context, string) (connector.ExportSnapshotResult, error) {
+	return connector.ExportSnapshotResult{}, nil
+}
+func (m *mockConnector) RestoreSnapshot(context.Context, connector.RestoreSnapshotRequest) (connector.RestoreSnapshotResult, error) {
+	return connector.RestoreSnapshotResult{}, nil
+}
+func (m *mockConnector) DeleteSnapshot(context.Context, string) error { return nil }
+
+// TestGrpcServer_CancelAgent_DispatchesThroughConnector is the v0.8.15
+// regression guard: when the gRPC Server is wired with a Connector,
+// CancelAgent dispatches through s.connector.CancelRun rather than the
+// legacy direct cancelReg+store path. Verifies the architectural
+// commitment: gRPC CONSUMES Connector.
+func TestGrpcServer_CancelAgent_DispatchesThroughConnector(t *testing.T) {
+	mc := &mockConnector{}
+	mc.cancelOK.Store(true)
+	mc.cascade.Store(3) // pretend 3 sub-agents got cascaded
+
+	adapter := New(Config{
+		Store:     newTestStore(t),
+		CancelReg: cancel.NewRegistry(),
+		Connector: mc,
+	})
+
+	resp, err := adapter.CancelAgent(context.Background(), &loomcyclepb.CancelAgentRequest{
+		AgentId: "a_test123",
+		Reason:  "user requested",
+	})
+	if err != nil {
+		t.Fatalf("CancelAgent: %v", err)
+	}
+
+	if mc.cancelCalls.Load() != 1 {
+		t.Errorf("Connector.CancelRun called %d times, want 1", mc.cancelCalls.Load())
+	}
+	if got := mc.lastAgentID.Load(); got != "a_test123" {
+		t.Errorf("Connector saw agent_id %q, want %q", got, "a_test123")
+	}
+	if got := mc.lastReason.Load(); got != "user requested" {
+		t.Errorf("Connector saw reason %q, want %q", got, "user requested")
+	}
+	// CascadeCount=3 from the mock → proto cancelled_count = 1+3 = 4.
+	if resp.GetCancelledCount() != 4 {
+		t.Errorf("CancelledCount=%d, want 4 (1 root + 3 cascade)", resp.GetCancelledCount())
+	}
 }
 
 // drain reads every Event from a Run/Continue stream until EOF or

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -1,0 +1,532 @@
+// Package http — v0.8.15 Connector interface implementation.
+//
+// The HTTP Server is the canonical connector.Connector implementation.
+// Other wire transports (MCP, gRPC, future CLI) CONSUME the Connector
+// rather than re-implementing business logic.
+//
+// Methods in this file are organised by Connector method group:
+//   1. Run lifecycle: SpawnRun, CancelRun, GetRun, ListRuns
+//   2. Agent management: RegisterAgent, UnregisterAgent, ListAgents
+//   3. Builtin tool wrappers: Memory, Channel, AgentDef, Evaluation, Context
+//   4. Pause/Resume/Snapshot: MOCKED in v0.8.15 (see RFC)
+
+package http
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Compile-time assertion that *Server satisfies connector.Connector.
+// Adding new methods to the Connector interface forces a compile
+// failure here until they're implemented — exactly the signal we want.
+var _ connector.Connector = (*Server)(nil)
+
+// --- 1. Run lifecycle ---
+
+// SpawnRun translates a connector.SpawnRunRequest into a runner.RunInput
+// and drives RunOnce. The blocking shape matches the Connector contract;
+// transports that want streaming (MCP notifications, gRPC stream) hold a
+// runner.Runner field separately and use it directly for that path.
+func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+	in := runner.RunInput{
+		Agent:           req.Agent,
+		SessionID:       req.SessionID,
+		TenantID:        req.TenantID,
+		Segments:        req.Segments,
+		AllowedTools:    req.AllowedTools,
+		AllowedHosts:    req.AllowedHosts,
+		WebSearchFilter: req.WebSearchFilter,
+		UserID:          req.UserID,
+		AgentID:         req.AgentID,
+		UserTier:        req.UserTier,
+		UserBearer:      req.UserBearer,
+	}
+
+	// Capture: the OnRegistered callback gives us the resolved IDs;
+	// OnEvent accumulates text deltas + the final usage/stop_reason.
+	var (
+		regAgentID, regRunID, regSessionID string
+		finalText                          string
+		finalUsage                         *providers.Usage
+		finalStopReason                    string
+		lastErrorMsg                       string
+	)
+	cb := runner.RunCallbacks{
+		OnRegistered: func(agentID, runID, sessionID, _ string) {
+			regAgentID, regRunID, regSessionID = agentID, runID, sessionID
+		},
+		OnEvent: func(ev providers.Event) {
+			switch ev.Type {
+			case providers.EventText:
+				finalText += ev.Text
+			case providers.EventUsage:
+				if ev.Usage != nil {
+					u := *ev.Usage
+					finalUsage = &u
+				}
+			case providers.EventDone:
+				finalStopReason = ev.StopReason
+				if ev.Usage != nil && finalUsage == nil {
+					u := *ev.Usage
+					finalUsage = &u
+				}
+			case providers.EventError:
+				if ev.Error != "" {
+					lastErrorMsg = ev.Error
+				}
+			}
+		},
+	}
+
+	runErr := s.RunOnce(ctx, in, cb)
+
+	result := connector.SpawnRunResult{
+		AgentID:    regAgentID,
+		RunID:      regRunID,
+		SessionID:  regSessionID,
+		Status:     string(store.RunCompleted),
+		StopReason: finalStopReason,
+		FinalText:  finalText,
+		Usage:      finalUsage,
+	}
+	switch {
+	case runErr != nil && errors.Is(runErr, context.Canceled):
+		result.Status = string(store.RunCancelled)
+		result.Error = runErr.Error()
+	case runErr != nil:
+		result.Status = string(store.RunFailed)
+		result.Error = runErr.Error()
+	case lastErrorMsg != "":
+		// Loop emitted an error event but didn't return a Go error
+		// (rare — current loop returns errors via the err path; this
+		// is belt-and-suspenders for any future event-only error path).
+		result.Status = string(store.RunFailed)
+		result.Error = lastErrorMsg
+	}
+	return result, nil
+}
+
+// CancelRun looks up the run by agent_id and triggers cancellation
+// via the in-memory cancel registry. The registry's Cancel handles
+// the BFS cascade to sub-agents internally.
+func (s *Server) CancelRun(ctx context.Context, agentID, reason string) (connector.CancelRunResult, error) {
+	if agentID == "" {
+		return connector.CancelRunResult{}, fmt.Errorf("agent_id required")
+	}
+	res, ok := s.cancelReg.Cancel(agentID, reason)
+	if !ok {
+		// Run may already have completed. Check the store to
+		// distinguish "never existed" from "already ended".
+		if s.store != nil {
+			if _, err := s.store.GetRunByAgentID(ctx, agentID); err == nil {
+				return connector.CancelRunResult{AlreadyEnded: true}, nil
+			}
+		}
+		return connector.CancelRunResult{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	return connector.CancelRunResult{
+		Cancelled:    res.Cancelled,
+		CascadeCount: len(res.Cascaded),
+	}, nil
+}
+
+// GetRun returns a status snapshot for one tracked agent_id. Maps the
+// store's persistence-layer Run shape onto the connector's wire shape.
+func (s *Server) GetRun(ctx context.Context, agentID string) (connector.Run, error) {
+	if s.store == nil {
+		return connector.Run{}, fmt.Errorf("get_run requires persistence (no Store configured)")
+	}
+	r, err := s.store.GetRunByAgentID(ctx, agentID)
+	if err != nil {
+		return connector.Run{}, err
+	}
+	return storeRunToConnector(r), nil
+}
+
+// ListRuns enumerates runs. Today only the UserID filter has an
+// optimised store path (ListActiveRunsByUser); other combinations
+// fall through to a broader query that the storetest contract suite
+// already exercises.
+func (s *Server) ListRuns(ctx context.Context, filter connector.ListRunsFilter) ([]connector.Run, error) {
+	if s.store == nil {
+		return nil, fmt.Errorf("list_runs requires persistence (no Store configured)")
+	}
+	limit := filter.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	var rows []store.Run
+	if filter.UserID != "" {
+		rs, err := s.store.ListActiveRunsByUser(ctx, filter.UserID, store.RunStatus(filter.Status))
+		if err != nil {
+			return nil, err
+		}
+		rows = rs
+	} else {
+		// No optimised non-user query exists today; fall through to a
+		// scan via storetest semantics. For v0.8.15 we require a UserID
+		// filter; callers omitting it get an explicit error so they
+		// don't accidentally walk the entire runs table.
+		return nil, fmt.Errorf("list_runs without user_id is not supported in v0.8.15; supply user_id in filter")
+	}
+	out := make([]connector.Run, 0, len(rows))
+	for i, r := range rows {
+		if i >= limit {
+			break
+		}
+		out = append(out, storeRunToConnector(r))
+	}
+	return out, nil
+}
+
+func storeRunToConnector(r store.Run) connector.Run {
+	usage := &providers.Usage{
+		InputTokens:         r.InputTokens,
+		OutputTokens:        r.OutputTokens,
+		CacheCreationTokens: r.CacheCreationTokens,
+		CacheReadTokens:     r.CacheReadTokens,
+		Model:               r.Model,
+	}
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 && usage.Model == "" {
+		usage = nil
+	}
+	out := connector.Run{
+		AgentID:       r.AgentID,
+		RunID:         r.ID,
+		SessionID:     r.SessionID,
+		UserID:        r.UserID,
+		Agent:         r.Agent,
+		ParentAgentID: r.ParentAgentID,
+		Status:        string(r.Status),
+		StartedAt:     r.StartedAt,
+		StopReason:    r.StopReason,
+		Usage:         usage,
+		Error:         r.ErrorMsg,
+	}
+	if !r.CompletedAt.IsZero() {
+		ct := r.CompletedAt
+		out.CompletedAt = &ct
+	}
+	return out
+}
+
+// --- 2. Agent management ---
+
+// RegisterAgent persists a dynamic agent in store.dynamic_agents.
+// Privileged tools (Bash/Write/Edit) are stripped unless the operator
+// has set LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1. Collisions with
+// static agents (from yaml / discovery) are rejected.
+func (s *Server) RegisterAgent(ctx context.Context, req connector.RegisterAgentRequest) (connector.AgentDescriptor, error) {
+	if !validDynamicAgentName(req.Name) {
+		return connector.AgentDescriptor{}, fmt.Errorf("invalid agent name %q: must match [A-Za-z0-9_-]{1,64}", req.Name)
+	}
+	if req.SystemPrompt == "" {
+		return connector.AgentDescriptor{}, fmt.Errorf("system_prompt required")
+	}
+	if len(req.SystemPrompt) > 64*1024 {
+		return connector.AgentDescriptor{}, fmt.Errorf("system_prompt exceeds 64KB cap")
+	}
+	if len(req.AllowedTools) == 0 {
+		return connector.AgentDescriptor{}, fmt.Errorf("allowed_tools required (default-deny model)")
+	}
+	if _, collides := s.cfg.Agents[req.Name]; collides {
+		return connector.AgentDescriptor{}, fmt.Errorf("agent %q is statically defined in yaml; cannot register over it", req.Name)
+	}
+	if s.store == nil {
+		return connector.AgentDescriptor{}, fmt.Errorf("register_agent requires persistence (no Store configured)")
+	}
+
+	allowedTools := stripPrivilegedTools(req.AllowedTools, s.cfg.Env.MCPAllowPrivilegedTools)
+
+	def := config.AgentDef{
+		SystemPrompt: req.SystemPrompt,
+		AllowedTools: allowedTools,
+		Tier:         req.Tier,
+		Provider:     req.Provider,
+		Model:        req.Model,
+		Effort:       req.Effort,
+		MaxTokens:    req.MaxTokens,
+		MemoryScopes: req.MemoryScopes,
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return connector.AgentDescriptor{}, fmt.Errorf("marshal agent def: %w", err)
+	}
+
+	createdAt := time.Now().UTC()
+	expiresAt := computeExpiresAt(createdAt, req.TTLSeconds, s.cfg.Env.DynamicAgentDefaultTTLSeconds)
+
+	row := store.DynamicAgent{
+		Name:        req.Name,
+		Definition:  defJSON,
+		CreatedAt:   createdAt,
+		ExpiresAt:   expiresAt,
+		Description: req.Description,
+	}
+	if err := s.store.DynamicAgentUpsert(ctx, row); err != nil {
+		return connector.AgentDescriptor{}, err
+	}
+
+	desc := connector.AgentDescriptor{
+		Name:         req.Name,
+		Source:       "dynamic",
+		AllowedTools: allowedTools,
+		Tier:         req.Tier,
+		Provider:     req.Provider,
+		Model:        req.Model,
+		Description:  req.Description,
+		CreatedAt:    &createdAt,
+	}
+	if !expiresAt.IsZero() {
+		desc.ExpiresAt = &expiresAt
+	}
+	return desc, nil
+}
+
+// UnregisterAgent removes a dynamic agent. Refuses to operate on
+// static (yaml-defined) agents — those need a yaml edit and restart.
+func (s *Server) UnregisterAgent(ctx context.Context, name string) error {
+	if _, isStatic := s.cfg.Agents[name]; isStatic {
+		return fmt.Errorf("agent %q is statically defined in yaml; cannot unregister", name)
+	}
+	if s.store == nil {
+		return fmt.Errorf("unregister_agent requires persistence (no Store configured)")
+	}
+	_, err := s.store.DynamicAgentDelete(ctx, name)
+	return err
+}
+
+// ListAgents merges static (cfg.Agents) and dynamic (store) agent
+// descriptors. includeDynamic=false omits the dynamic set entirely.
+func (s *Server) ListAgents(ctx context.Context, includeDynamic bool) ([]connector.AgentDescriptor, error) {
+	out := make([]connector.AgentDescriptor, 0, len(s.cfg.Agents)+8)
+	for name, def := range s.cfg.Agents {
+		out = append(out, connector.AgentDescriptor{
+			Name:         name,
+			Source:       "static",
+			AllowedTools: append([]string(nil), def.AllowedTools...),
+			Tier:         def.Tier,
+			Provider:     def.Provider,
+			Model:        def.Model,
+		})
+	}
+	if includeDynamic && s.store != nil {
+		dyn, err := s.store.DynamicAgentList(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, row := range dyn {
+			var def config.AgentDef
+			_ = json.Unmarshal(row.Definition, &def) // best-effort; we still surface name/description on parse failure
+			desc := connector.AgentDescriptor{
+				Name:         row.Name,
+				Source:       "dynamic",
+				AllowedTools: def.AllowedTools,
+				Tier:         def.Tier,
+				Provider:     def.Provider,
+				Model:        def.Model,
+				Description:  row.Description,
+			}
+			c := row.CreatedAt
+			desc.CreatedAt = &c
+			if !row.ExpiresAt.IsZero() {
+				e := row.ExpiresAt
+				desc.ExpiresAt = &e
+			}
+			out = append(out, desc)
+		}
+	}
+	return out, nil
+}
+
+// --- 3. Builtin tool wrappers ---
+
+func (s *Server) Memory(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "Memory", input)
+}
+
+func (s *Server) Channel(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "Channel", input)
+}
+
+func (s *Server) AgentDef(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "AgentDef", input)
+}
+
+func (s *Server) Evaluation(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "Evaluation", input)
+}
+
+func (s *Server) Context(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "Context", input)
+}
+
+// dispatchBuiltin is the shared lookup-and-execute path for the five
+// builtin wrappers. tools.Result {Text, IsError} maps directly onto
+// connector.ToolResult; the transport adapter (MCP) then wraps both
+// fields into its wire shape (content[].text + isError).
+//
+// Go-error return path is reserved for "tool not registered" /
+// "internal failure" — distinct from IsError which is a normal tool
+// outcome the model is allowed to see and self-correct from.
+func (s *Server) dispatchBuiltin(ctx context.Context, name string, input json.RawMessage) (connector.ToolResult, error) {
+	var tool tools.Tool
+	for _, t := range s.tools {
+		if t.Name() == name {
+			tool = t
+			break
+		}
+	}
+	if tool == nil {
+		return connector.ToolResult{}, fmt.Errorf("builtin tool %q not registered (operator disabled it via allowed_tools or yaml)", name)
+	}
+	res, err := tool.Execute(ctx, input)
+	if err != nil {
+		return connector.ToolResult{}, err
+	}
+	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
+// --- 4. Pause/Resume/Snapshot (MOCKED in v0.8.15) ---
+//
+// Wire shapes stable; real implementations land in v0.8.16+ per
+// doc-internal/rfcs/pause-resume-snapshot.md.
+
+const previewNote = "Pause/Resume/Snapshot implementation pending in v0.8.16+; wire shape is stable. See doc-internal/rfcs/pause-resume-snapshot.md."
+
+func (s *Server) PauseRuntime(_ context.Context, _ int) (connector.PauseResult, error) {
+	return connector.PauseResult{
+		Status:        "paused",
+		FeatureStatus: "preview",
+		Note:          previewNote,
+	}, nil
+}
+
+func (s *Server) ResumeRuntime(_ context.Context) (connector.ResumeResult, error) {
+	return connector.ResumeResult{
+		Status:        "running",
+		FeatureStatus: "preview",
+		Note:          previewNote,
+	}, nil
+}
+
+func (s *Server) GetRuntimeState(_ context.Context) (connector.RuntimeState, error) {
+	return connector.RuntimeState{
+		Status:        "running",
+		FeatureStatus: "preview",
+	}, nil
+}
+
+func (s *Server) CreateSnapshot(_ context.Context, _ connector.CreateSnapshotRequest) (connector.SnapshotDescriptor, error) {
+	return connector.SnapshotDescriptor{
+		SnapshotID:    mintPreviewSnapshotID(),
+		CreatedAt:     time.Now().UTC(),
+		FormatVersion: "preview",
+		FeatureStatus: "preview",
+	}, nil
+}
+
+func (s *Server) ListSnapshots(_ context.Context) ([]connector.SnapshotDescriptor, error) {
+	// Mocks don't persist — list is always empty in v0.8.15.
+	return []connector.SnapshotDescriptor{}, nil
+}
+
+func (s *Server) ExportSnapshot(_ context.Context, snapshotID string) (connector.ExportSnapshotResult, error) {
+	return connector.ExportSnapshotResult{
+		SnapshotID:    snapshotID,
+		FeatureStatus: "preview",
+	}, fmt.Errorf("export_snapshot: %s", previewNote)
+}
+
+func (s *Server) RestoreSnapshot(_ context.Context, _ connector.RestoreSnapshotRequest) (connector.RestoreSnapshotResult, error) {
+	return connector.RestoreSnapshotResult{
+		Restored:      map[string]int{},
+		FeatureStatus: "preview",
+	}, fmt.Errorf("restore_snapshot: %s", previewNote)
+}
+
+func (s *Server) DeleteSnapshot(_ context.Context, _ string) error {
+	return fmt.Errorf("delete_snapshot: %s", previewNote)
+}
+
+// --- Helpers ---
+
+// validDynamicAgentName matches [A-Za-z0-9_-]{1,64}. Stricter than
+// general identifiers because agent names appear in log lines, yaml
+// errors, and `mcp__loomcycle__spawn_run` parameters.
+func validDynamicAgentName(s string) bool {
+	if s == "" || len(s) > 64 {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z',
+			r >= 'A' && r <= 'Z',
+			r >= '0' && r <= '9',
+			r == '_', r == '-':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// stripPrivilegedTools removes Bash/Write/Edit from the requested
+// allowed_tools when the operator hasn't opted into privileged-tool
+// dynamic registration. Default-deny matches v0.8.7 / v0.8.8 pattern.
+func stripPrivilegedTools(requested []string, allowPrivileged bool) []string {
+	if allowPrivileged {
+		return append([]string(nil), requested...)
+	}
+	out := make([]string, 0, len(requested))
+	for _, t := range requested {
+		switch t {
+		case "Bash", "Write", "Edit":
+			continue
+		default:
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// computeExpiresAt resolves the effective TTL for a register_agent
+// request. TTLSeconds < 0 means "no expiry" (return zero-value
+// time.Time, which the store treats as 'epoch' = no expiry). 0 falls
+// back to the env default. Positive values are used directly.
+func computeExpiresAt(now time.Time, ttlSeconds, defaultTTLSeconds int) time.Time {
+	if ttlSeconds < 0 {
+		return time.Time{}
+	}
+	if ttlSeconds == 0 {
+		ttlSeconds = defaultTTLSeconds
+	}
+	if ttlSeconds <= 0 {
+		// defaultTTLSeconds also unset or non-positive → no expiry.
+		return time.Time{}
+	}
+	return now.Add(time.Duration(ttlSeconds) * time.Second)
+}
+
+// mintPreviewSnapshotID produces a snap_preview_<8hex> identifier.
+// Real snapshot IDs in v0.8.16+ will use a different prefix
+// (snap_<time><rand>) so callers can distinguish preview-only IDs.
+func mintPreviewSnapshotID() string {
+	var b [4]byte
+	_, _ = rand.Read(b[:])
+	return "snap_preview_" + hex.EncodeToString(b[:])
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -613,6 +613,20 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 	agentDef, ok := s.cfg.Agents[effectiveAgentName]
 	if !ok {
+		// v0.8.15: fall back to dynamic agents registered at runtime
+		// via mcp__loomcycle__register_agent. TTL-expired rows are
+		// filtered server-side by DynamicAgentGet so we never see them.
+		if s.store != nil {
+			if row, derr := s.store.DynamicAgentGet(ctx, effectiveAgentName); derr == nil {
+				var def config.AgentDef
+				if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
+					agentDef = def
+					ok = true
+				}
+			}
+		}
+	}
+	if !ok {
 		return fmt.Errorf("%w: %s", runner.ErrUnknownAgent, effectiveAgentName)
 	}
 	providerID, model, effort, err := s.resolveAgent(effectiveAgentName, in.UserTier)

--- a/internal/api/mcp/agent_sweeper.go
+++ b/internal/api/mcp/agent_sweeper.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"context"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// RunDynamicAgentSweeper starts a periodic goroutine that deletes
+// expired rows from the dynamic_agents table. Designed to be wired
+// from cmd/loomcycle/main.go alongside other sweepers (memory,
+// channel, metrics).
+//
+// interval=0 disables the sweeper (the operator may prefer to manage
+// retention out-of-band, or operate at low registration volume where
+// expired rows have negligible cost). DynamicAgentGet always filters
+// expired rows at read time, so functional correctness is preserved
+// either way — disabling only forgoes the storage-reclamation.
+//
+// Returns immediately after starting the goroutine. The goroutine
+// exits when ctx is done.
+func RunDynamicAgentSweeper(ctx context.Context, st store.Store, interval time.Duration, logf func(string, ...any)) {
+	if interval <= 0 || st == nil {
+		return
+	}
+	if logf == nil {
+		logf = defaultLogf
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				n, err := st.DynamicAgentSweep(ctx)
+				if err != nil {
+					logf("dynamic_agents sweep: %v", err)
+					continue
+				}
+				if n > 0 {
+					logf("dynamic_agents: swept %d expired", n)
+				}
+			}
+		}
+	}()
+}

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -1,0 +1,104 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Operator-trust constants. The stdio MCP server runs in the operator's
+// process — when Claude Code (or any other MCP orchestrator) spawns
+// `loomcycle mcp ...`, the operator IS the launcher and has full process
+// authority. Builtin tools (Memory, Channel, AgentDef, Evaluation,
+// Context) gate on per-agent ACLs that don't exist for MCP-direct
+// callers — there's no yaml agent definition behind a `tools/call`
+// invocation. We synthesise a permissive policy that mirrors operator
+// access, with a stable synthetic agent name so memory/channel ops that
+// require `scope_id` derivation (scope=agent) have a deterministic key.
+//
+// This is intentionally distinct from sub-agent runs spawned via
+// `spawn_run` — those carry the requested agent's real policies because
+// they go through RunOnce, which builds ctx from cfg.Agents. The
+// operatorCtx path applies ONLY to direct builtin-tool dispatch from
+// the MCP wire.
+const (
+	// operatorAgentName is the synthetic agent name attached to ctx
+	// for MCP-direct builtin invocations. Memory ops with scope=agent
+	// use this as the scope_id; Channel ops similarly. Distinct from
+	// realistic user agent names so operator-direct memory doesn't
+	// collide with any production agent's keys.
+	operatorAgentName = "mcp-operator"
+
+	// operatorUserID + operatorAgentID populate the synthetic
+	// RunIdentityValue. memory scope=user resolves to this; the
+	// AgentDefPolicy's SelfName matches operatorAgentName.
+	operatorUserID  = "mcp-operator"
+	operatorAgentID = "a_mcp-operator"
+)
+
+// operatorCtx enriches the supplied ctx with the policy values required
+// for MCP-direct builtin-tool invocations. Without these, every call to
+// Memory / Channel / AgentDef / Evaluation / Context fails with
+// default-deny refusals because the underlying tools check per-agent
+// policy from ctx and find zero values.
+//
+// Use this for the 5 builtin-wrapper handlers ONLY. Do NOT use it for
+// run-lifecycle handlers (spawn_run / cancel_run / etc.) — those go
+// through RunOnce which builds the right ctx for each agent from
+// cfg.Agents.
+func operatorCtx(ctx context.Context) context.Context {
+	// Identity. Synthetic but consistent — repeated MCP calls share
+	// the same scope_id for scope=agent memory and the same UserID
+	// for scope=user. Operators can audit by querying memory rows
+	// where scope_id = "mcp-operator".
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		UserID:  operatorUserID,
+		AgentID: operatorAgentID,
+	})
+	ctx = tools.WithAgentName(ctx, operatorAgentName)
+
+	// Memory: full scope access. QuotaBytes=0 falls back to the
+	// global default (LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES) — operators
+	// who want a tighter cap on MCP-direct writes can set the env.
+	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
+		AllowedScopes: []string{"agent", "user", "global"},
+	})
+
+	// Channel: open ACL. "*" wildcard matches every channel name.
+	// Channels map is left nil — the tool falls back to defaults
+	// (TTL=0, max_messages=0=unbounded, scope=agent) for channels
+	// not in operator yaml. Operators wanting fine-grained MCP
+	// channel control should declare the channels in `channels:`
+	// (which populates ChannelPolicy.Channels per-run, but for
+	// MCP-direct we synthesise — see channel.go for the resolve).
+	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"*"},
+		Subscribe: []string{"*"},
+	})
+
+	// AgentDef: "any" scope — operators may mutate any def. SelfName
+	// matches the synthetic agent name so the (rarely used) "self"
+	// scope check still resolves correctly if an operator later
+	// narrows the policy in code.
+	ctx = tools.WithAgentDefPolicy(ctx, tools.AgentDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: operatorAgentName,
+	})
+
+	// Evaluation: all 4 valid scope values. submit_any + read_any
+	// are the load-bearing ones; submit_self + submit_descendants
+	// are included for completeness in case an operator wants the
+	// "self" path explicitly.
+	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{
+		Scopes: []string{"submit_self", "submit_descendants", "submit_any", "read_any"},
+	})
+
+	// Context.history: "any" — read every agent's transcript. This
+	// is the operator-trust grant the policy comment describes as
+	// "admin/debug only" — exactly the MCP operator's role.
+	ctx = tools.WithHistoryPolicy(ctx, tools.HistoryPolicyValue{
+		Scopes: []string{"any"},
+	})
+
+	return ctx
+}

--- a/internal/api/mcp/context_test.go
+++ b/internal/api/mcp/context_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestOperatorCtx_AttachesAllRequiredPolicies pins the load-bearing
+// invariant: operatorCtx must enrich ctx with every policy value the
+// builtin tools (Memory, Channel, AgentDef, Evaluation, Context) check
+// at Execute time. Without all 5 attaches, the corresponding MCP
+// wrapper handler returns "no scope configured" tool errors on every
+// call — the v0.8.15 launch bug found in code review.
+//
+// If a future tool grows a new policy value, add the attach to
+// operatorCtx and the assertion here in the same change.
+func TestOperatorCtx_AttachesAllRequiredPolicies(t *testing.T) {
+	ctx := operatorCtx(context.Background())
+
+	// RunIdentity: scope=user memory ops derive scope_id from
+	// UserID; scope=agent ops use AgentID via tools.AgentName.
+	rid := tools.RunIdentity(ctx)
+	if rid.UserID == "" {
+		t.Errorf("RunIdentity.UserID is empty; scope=user memory ops would fail")
+	}
+	if rid.AgentID == "" {
+		t.Errorf("RunIdentity.AgentID is empty")
+	}
+
+	// AgentName: scope=agent memory ops use this as scope_id.
+	if name := tools.AgentName(ctx); name == "" {
+		t.Errorf("tools.AgentName(ctx) is empty; scope=agent ops would fail")
+	}
+
+	// MemoryPolicy: empty AllowedScopes ⇒ every memory op fails.
+	mp := tools.MemoryPolicy(ctx)
+	if len(mp.AllowedScopes) == 0 {
+		t.Errorf("MemoryPolicy.AllowedScopes empty; all Memory ops would fail")
+	}
+	wantMemScopes := map[string]bool{"agent": false, "user": false, "global": false}
+	for _, s := range mp.AllowedScopes {
+		if _, ok := wantMemScopes[s]; ok {
+			wantMemScopes[s] = true
+		}
+	}
+	for scope, present := range wantMemScopes {
+		if !present {
+			t.Errorf("MemoryPolicy.AllowedScopes missing %q", scope)
+		}
+	}
+
+	// ChannelPolicy: empty Publish/Subscribe ⇒ all channel ops fail.
+	cp := tools.ChannelPolicy(ctx)
+	if len(cp.Publish) == 0 {
+		t.Errorf("ChannelPolicy.Publish empty; publish ops would fail")
+	}
+	if len(cp.Subscribe) == 0 {
+		t.Errorf("ChannelPolicy.Subscribe empty; subscribe/peek/ack would fail")
+	}
+
+	// AgentDefPolicy: empty Scopes ⇒ every mutation op fails.
+	ap := tools.AgentDefPolicy(ctx)
+	if len(ap.Scopes) == 0 {
+		t.Errorf("AgentDefPolicy.Scopes empty; all AgentDef ops would fail")
+	}
+	if ap.SelfName == "" {
+		t.Errorf("AgentDefPolicy.SelfName empty; `self` scope check would always fail")
+	}
+
+	// EvaluationPolicy: needs submit_any + read_any for full operator access.
+	ep := tools.EvaluationPolicy(ctx)
+	wantEvalScopes := map[string]bool{"submit_any": false, "read_any": false}
+	for _, s := range ep.Scopes {
+		if _, ok := wantEvalScopes[s]; ok {
+			wantEvalScopes[s] = true
+		}
+	}
+	for scope, present := range wantEvalScopes {
+		if !present {
+			t.Errorf("EvaluationPolicy.Scopes missing %q (operator-direct evaluation ops would fail)", scope)
+		}
+	}
+
+	// HistoryPolicy: empty Scopes ⇒ Context.history refuses.
+	hp := tools.HistoryPolicy(ctx)
+	if len(hp.Scopes) == 0 {
+		t.Errorf("HistoryPolicy.Scopes empty; Context.history would refuse")
+	}
+}
+
+// TestOperatorCtx_PreservesParentValues ensures operatorCtx layers on
+// top of an existing ctx rather than replacing it — values attached
+// upstream (e.g., cancellation, request ID) survive.
+func TestOperatorCtx_PreservesParentValues(t *testing.T) {
+	type customKey struct{}
+	parent := context.WithValue(context.Background(), customKey{}, "parent-marker")
+	enriched := operatorCtx(parent)
+	if got, _ := enriched.Value(customKey{}).(string); got != "parent-marker" {
+		t.Errorf("operatorCtx dropped parent ctx value; got %q want %q", got, "parent-marker")
+	}
+}

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -1,0 +1,433 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// toolHandler is the uniform signature every dispatch entry follows.
+// Returns the MCP CallToolResult directly (not raw JSON) so the server
+// can marshal it once.
+type toolHandler func(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error)
+
+var handlersByName = map[string]toolHandler{
+	// Run lifecycle
+	"spawn_run":  handleSpawnRun,
+	"cancel_run": handleCancelRun,
+	"get_run":    handleGetRun,
+	"list_runs":  handleListRuns,
+
+	// Agent management
+	"register_agent":   handleRegisterAgent,
+	"unregister_agent": handleUnregisterAgent,
+	"list_agents":      handleListAgents,
+
+	// Builtin wrappers
+	"memory": wrapBuiltin("memory", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.Memory(ctx, in)
+	}),
+	"channel": wrapBuiltin("channel", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.Channel(ctx, in)
+	}),
+	"agentdef": wrapBuiltin("agentdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.AgentDef(ctx, in)
+	}),
+	"evaluation": wrapBuiltin("evaluation", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.Evaluation(ctx, in)
+	}),
+	"context": wrapBuiltin("context", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.Context(ctx, in)
+	}),
+
+	// Pause/Resume (PREVIEW mocks in v0.8.15)
+	"pause_runtime":     handlePauseRuntime,
+	"resume_runtime":    handleResumeRuntime,
+	"get_runtime_state": handleGetRuntimeState,
+
+	// Snapshot (PREVIEW mocks in v0.8.15)
+	"create_snapshot":  handleCreateSnapshot,
+	"list_snapshots":   handleListSnapshots,
+	"export_snapshot":  handleExportSnapshot,
+	"restore_snapshot": handleRestoreSnapshot,
+	"delete_snapshot":  handleDeleteSnapshot,
+}
+
+func toolHandlerByName(name string) (toolHandler, bool) {
+	h, ok := handlersByName[name]
+	return h, ok
+}
+
+// --- Run lifecycle handlers ---
+
+// handleSpawnRun has two code paths:
+//
+//  1. Streaming (session opted into runEvents AND a Runner is wired):
+//     drive runner.RunOnce directly with an OnEvent that emits
+//     notifications/loomcycle/run_event for each provider event.
+//     Capture the final text + usage + IDs in a closure for the
+//     tool/call result.
+//
+//  2. Blocking (no opt-in, or no Runner): call Connector.SpawnRun
+//     and return its result. No streaming.
+//
+// Both paths produce the same final tool/call response shape — the
+// adapter on the orchestrator side can branch on the response if it
+// cares about which path was taken.
+func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("spawn_run: no connector wired")
+	}
+	var req connector.SpawnRunRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return toolErr("invalid spawn_run arguments: " + err.Error()), nil
+	}
+	if req.Agent == "" && req.SessionID == "" {
+		return toolErr("spawn_run: either agent or session_id must be supplied"), nil
+	}
+
+	useStreaming := env.session != nil && env.session.RunEventsEnabled() && env.runner != nil
+	var result connector.SpawnRunResult
+	var err error
+	if useStreaming {
+		result, err = spawnRunStreaming(ctx, env, req)
+	} else {
+		result, err = env.connector.SpawnRun(ctx, req)
+	}
+	if err != nil {
+		return toolErr("spawn_run: " + err.Error()), nil
+	}
+	return toolResultJSON(result), nil
+}
+
+// spawnRunStreaming drives the runner directly and emits per-event
+// notifications. The final connector.SpawnRunResult is assembled
+// from the captured callback state — identical shape to
+// Connector.SpawnRun, so the tool/call response matches across both
+// code paths.
+func spawnRunStreaming(ctx context.Context, env *handlerEnv, req connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+	in := runner.RunInput{
+		Agent:           req.Agent,
+		SessionID:       req.SessionID,
+		TenantID:        req.TenantID,
+		Segments:        req.Segments,
+		AllowedTools:    req.AllowedTools,
+		AllowedHosts:    req.AllowedHosts,
+		WebSearchFilter: req.WebSearchFilter,
+		UserID:          req.UserID,
+		AgentID:         req.AgentID,
+		UserTier:        req.UserTier,
+		UserBearer:      req.UserBearer,
+	}
+
+	var (
+		regAgentID, regRunID, regSessionID string
+		finalText                          string
+		finalUsage                         *providers.Usage
+		finalStopReason                    string
+	)
+	cb := runner.RunCallbacks{
+		OnRegistered: func(agentID, runID, sessionID, _ string) {
+			regAgentID, regRunID, regSessionID = agentID, runID, sessionID
+		},
+		OnEvent: func(ev providers.Event) {
+			// Emit the notification BEFORE accumulating state — keeps
+			// the wire order matching event timestamps.
+			env.notify("notifications/loomcycle/run_event", runEventPayload{
+				RunID:   regRunID,
+				AgentID: regAgentID,
+				Event:   ev,
+			})
+			switch ev.Type {
+			case providers.EventText:
+				finalText += ev.Text
+			case providers.EventUsage:
+				if ev.Usage != nil {
+					u := *ev.Usage
+					finalUsage = &u
+				}
+			case providers.EventDone:
+				finalStopReason = ev.StopReason
+				if ev.Usage != nil && finalUsage == nil {
+					u := *ev.Usage
+					finalUsage = &u
+				}
+			}
+		},
+	}
+
+	runErr := env.runner.RunOnce(ctx, in, cb)
+
+	result := connector.SpawnRunResult{
+		AgentID:    regAgentID,
+		RunID:      regRunID,
+		SessionID:  regSessionID,
+		Status:     "completed",
+		StopReason: finalStopReason,
+		FinalText:  finalText,
+		Usage:      finalUsage,
+	}
+	switch {
+	case runErr != nil && errors.Is(runErr, context.Canceled):
+		result.Status = "cancelled"
+		result.Error = runErr.Error()
+	case runErr != nil:
+		result.Status = "failed"
+		result.Error = runErr.Error()
+	}
+	return result, nil
+}
+
+func handleCancelRun(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		AgentID string `json:"agent_id"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid cancel_run arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.CancelRun(ctx, p.AgentID, p.Reason)
+	if err != nil {
+		return toolErr("cancel_run: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleGetRun(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		AgentID string `json:"agent_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid get_run arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.GetRun(ctx, p.AgentID)
+	if err != nil {
+		return toolErr("get_run: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleListRuns(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var f connector.ListRunsFilter
+	if err := json.Unmarshal(args, &f); err != nil {
+		return toolErr("invalid list_runs arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.ListRuns(ctx, f)
+	if err != nil {
+		return toolErr("list_runs: " + err.Error()), nil
+	}
+	return toolResultJSON(struct {
+		Runs []connector.Run `json:"runs"`
+	}{Runs: res}), nil
+}
+
+// --- Agent management handlers ---
+
+func handleRegisterAgent(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var req connector.RegisterAgentRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return toolErr("invalid register_agent arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.RegisterAgent(ctx, req)
+	if err != nil {
+		return toolErr("register_agent: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleUnregisterAgent(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid unregister_agent arguments: " + err.Error()), nil
+	}
+	if err := env.connector.UnregisterAgent(ctx, p.Name); err != nil {
+		return toolErr("unregister_agent: " + err.Error()), nil
+	}
+	return toolResultJSON(map[string]any{"unregistered": true, "name": p.Name}), nil
+}
+
+func handleListAgents(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		IncludeDynamic *bool `json:"include_dynamic"`
+	}
+	_ = json.Unmarshal(args, &p) // best-effort; defaults to true below
+	includeDyn := true
+	if p.IncludeDynamic != nil {
+		includeDyn = *p.IncludeDynamic
+	}
+	agents, err := env.connector.ListAgents(ctx, includeDyn)
+	if err != nil {
+		return toolErr("list_agents: " + err.Error()), nil
+	}
+	return toolResultJSON(struct {
+		Agents []connector.AgentDescriptor `json:"agents"`
+	}{Agents: agents}), nil
+}
+
+// --- Builtin wrappers (memory/channel/agentdef/evaluation/context) ---
+
+// wrapBuiltin returns a handler that dispatches to one Connector
+// builtin method. The connector returns ToolResult{Text, IsError};
+// we map that 1:1 to the MCP tool/call response (content[].text +
+// isError).
+func wrapBuiltin(toolName string, call func(connector.Connector, context.Context, json.RawMessage) (connector.ToolResult, error)) toolHandler {
+	return func(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+		if env.connector == nil {
+			return nil, fmt.Errorf("%s: no connector wired", toolName)
+		}
+		res, err := call(env.connector, ctx, args)
+		if err != nil {
+			return toolErr(toolName + ": " + err.Error()), nil
+		}
+		return &loommcp.CallToolResult{
+			Content: []loommcp.ContentBlock{{Type: "text", Text: res.Text}},
+			IsError: res.IsError,
+		}, nil
+	}
+}
+
+// --- Pause/Resume/Snapshot handlers (PREVIEW mocks in v0.8.15) ---
+
+func handlePauseRuntime(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		TimeoutMS int `json:"timeout_ms"`
+	}
+	_ = json.Unmarshal(args, &p)
+	res, err := env.connector.PauseRuntime(ctx, p.TimeoutMS)
+	if err != nil {
+		return toolErr("pause_runtime: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleResumeRuntime(ctx context.Context, env *handlerEnv, _ json.RawMessage) (*loommcp.CallToolResult, error) {
+	res, err := env.connector.ResumeRuntime(ctx)
+	if err != nil {
+		return toolErr("resume_runtime: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleGetRuntimeState(ctx context.Context, env *handlerEnv, _ json.RawMessage) (*loommcp.CallToolResult, error) {
+	res, err := env.connector.GetRuntimeState(ctx)
+	if err != nil {
+		return toolErr("get_runtime_state: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleCreateSnapshot(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var req connector.CreateSnapshotRequest
+	_ = json.Unmarshal(args, &req)
+	res, err := env.connector.CreateSnapshot(ctx, req)
+	if err != nil {
+		return toolErr("create_snapshot: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleListSnapshots(ctx context.Context, env *handlerEnv, _ json.RawMessage) (*loommcp.CallToolResult, error) {
+	res, err := env.connector.ListSnapshots(ctx)
+	if err != nil {
+		return toolErr("list_snapshots: " + err.Error()), nil
+	}
+	return toolResultJSON(struct {
+		Snapshots []connector.SnapshotDescriptor `json:"snapshots"`
+	}{Snapshots: res}), nil
+}
+
+func handleExportSnapshot(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		SnapshotID string `json:"snapshot_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid export_snapshot arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.ExportSnapshot(ctx, p.SnapshotID)
+	if err != nil {
+		// v0.8.15 mock returns (result, err) — surface as tool error.
+		return toolErrWith(err.Error(), res), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleRestoreSnapshot(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var req connector.RestoreSnapshotRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return toolErr("invalid restore_snapshot arguments: " + err.Error()), nil
+	}
+	res, err := env.connector.RestoreSnapshot(ctx, req)
+	if err != nil {
+		return toolErrWith(err.Error(), res), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+func handleDeleteSnapshot(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		SnapshotID string `json:"snapshot_id"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid delete_snapshot arguments: " + err.Error()), nil
+	}
+	if err := env.connector.DeleteSnapshot(ctx, p.SnapshotID); err != nil {
+		return toolErr("delete_snapshot: " + err.Error()), nil
+	}
+	return toolResultJSON(map[string]any{"deleted": true, "snapshot_id": p.SnapshotID}), nil
+}
+
+// --- Helpers ---
+
+// runEventPayload is the wire shape for notifications/loomcycle/run_event.
+type runEventPayload struct {
+	RunID   string          `json:"run_id"`
+	AgentID string          `json:"agent_id"`
+	Event   providers.Event `json:"event"`
+}
+
+// toolResultJSON marshals v as JSON and wraps it in a non-error MCP
+// CallToolResult with a single text content block.
+func toolResultJSON(v any) *loommcp.CallToolResult {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		// Internal failure — surface as tool error rather than panic.
+		return toolErr("marshal result: " + err.Error())
+	}
+	return &loommcp.CallToolResult{
+		Content: []loommcp.ContentBlock{{Type: "text", Text: string(raw)}},
+	}
+}
+
+// toolErr returns an MCP tool/call response with isError=true and a
+// single text content block carrying the error message. Distinct from
+// the JSON-RPC -32603 error path: tool errors are a normal tool
+// outcome the orchestrator surfaces to the user; -32603 is an
+// internal-server-error path.
+func toolErr(msg string) *loommcp.CallToolResult {
+	return &loommcp.CallToolResult{
+		Content: []loommcp.ContentBlock{{Type: "text", Text: msg}},
+		IsError: true,
+	}
+}
+
+// toolErrWith returns an MCP tool error with structured content.
+// Used for the v0.8.15 Pause/Snapshot mocks that surface
+// feature_status=preview placeholder data alongside the error.
+func toolErrWith(msg string, payload any) *loommcp.CallToolResult {
+	raw, _ := json.Marshal(payload)
+	return &loommcp.CallToolResult{
+		Content: []loommcp.ContentBlock{
+			{Type: "text", Text: msg},
+			{Type: "text", Text: string(raw)},
+		},
+		IsError: true,
+	}
+}

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -278,12 +278,19 @@ func handleListAgents(ctx context.Context, env *handlerEnv, args json.RawMessage
 // builtin method. The connector returns ToolResult{Text, IsError};
 // we map that 1:1 to the MCP tool/call response (content[].text +
 // isError).
+//
+// CRITICAL: enrich ctx with operatorCtx() BEFORE calling the Connector.
+// The underlying tools (Memory/Channel/AgentDef/Evaluation/Context)
+// gate every op on per-agent policy values from ctx. Without enrichment,
+// MCP-direct callers see "no scope configured" errors on every call —
+// the policies are missing from a bare bgCtx. See internal/api/mcp/
+// context.go for the policy synthesis rationale.
 func wrapBuiltin(toolName string, call func(connector.Connector, context.Context, json.RawMessage) (connector.ToolResult, error)) toolHandler {
 	return func(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
 		if env.connector == nil {
 			return nil, fmt.Errorf("%s: no connector wired", toolName)
 		}
-		res, err := call(env.connector, ctx, args)
+		res, err := call(env.connector, operatorCtx(ctx), args)
 		if err != nil {
 			return toolErr(toolName + ": " + err.Error()), nil
 		}

--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -153,7 +153,13 @@ func (s *Server) handleFrame(ctx context.Context, frame []byte, stdout io.Writer
 		ID *int64 `json:"id"`
 	}
 	if err := json.Unmarshal(frame, &probe); err != nil {
+		// Malformed frame — emit a best-effort -32700 with id=0 (the
+		// "unknown id" convention) so the client gets SOME response
+		// instead of waiting forever for a request that never resolves.
+		// Without this, a single bad frame from a buggy client stalls
+		// the session permanently.
 		s.cfg.Logf("mcp: decode probe: %v", err)
+		s.writeError(stdout, 0, -32700, "parse error: "+err.Error())
 		return
 	}
 	if probe.ID == nil {

--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -1,0 +1,363 @@
+// Package mcp implements loomcycle as an MCP (Model Context Protocol)
+// server. This is the v0.8.15 capstone: external orchestrators
+// (Claude Code via stdio, future HTTP-MCP service consumers) drive
+// loomcycle through standard MCP — alternate front-end to /v1/*.
+//
+// The server CONSUMES the connector.Connector interface and the
+// runner.Runner interface from internal/runner. All business logic
+// lives in the canonical Connector implementation (*lchttp.Server);
+// this package is purely a wire-translation layer.
+//
+// Transport: stdio in v0.8.15. HTTP Streamable transport lands in
+// v0.8.15.x; the dispatch handlers don't change for HTTP — only the
+// read/write loop wraps an http.Handler instead of os.Stdin/Stdout.
+//
+// Architecture:
+//
+//	stdin →  serve() reads JSON-RPC frames line-by-line
+//	    →  routeRequest() dispatches by method:
+//	         - initialize / initialized / tools/list / tools/call
+//	    →  toolHandlers[name](ctx, sess, args) returns *mcp.CallToolResult
+//	    →  writeFrame() emits the JSON-RPC response to stdout
+//	stdout ← notifications/loomcycle/run_event during long-running
+//	         tools/call invocations (when session opted in via
+//	         initialize.capabilities.loomcycle.runEvents=true)
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// Config configures the MCP server.
+type Config struct {
+	// Connector is the canonical business-logic surface. Required —
+	// every tool handler dispatches through it.
+	Connector connector.Connector
+	// Runner is the callback-driven loop driver used when the client
+	// opts into run-event streaming (Connector.SpawnRun is blocking-
+	// only; streaming needs OnEvent callbacks). May be nil; without
+	// it, spawn_run still works but ignores the runEvents capability.
+	Runner runner.Runner
+	// Store is needed for the dynamic-agent TTL sweeper (started by
+	// the caller via main.go's worker block). The MCP server itself
+	// doesn't write to Store directly — Connector handles that.
+	Store store.Store
+	// Logf is the log sink. nil → standard library log.Printf.
+	Logf func(format string, v ...any)
+	// ServerName / ServerVersion are surfaced in the initialize
+	// response so adapters can log which loomcycle they're talking
+	// to. Empty fallbacks are fine.
+	ServerName    string
+	ServerVersion string
+}
+
+// Server reads MCP JSON-RPC frames from stdin and writes responses +
+// notifications to stdout. One Server per stdio connection (so one
+// per loomcycle-as-MCP process). HTTP transport (v0.8.15.x) will
+// instantiate one Server per HTTP connection.
+type Server struct {
+	cfg Config
+
+	// session carries per-connection state — capability flags etc.
+	// For stdio there's exactly one session for the process lifetime;
+	// initialized as not-yet-handshaked.
+	session *Session
+
+	// writeMu serialises writes to stdout — JSON-RPC frames must be
+	// emitted atomically (one frame per line). Tool handlers and the
+	// notification path both acquire this before writing.
+	writeMu sync.Mutex
+}
+
+// New constructs an MCP Server. Caller drives it by calling Serve.
+func New(cfg Config) *Server {
+	if cfg.Logf == nil {
+		cfg.Logf = defaultLogf
+	}
+	if cfg.ServerName == "" {
+		cfg.ServerName = "loomcycle"
+	}
+	return &Server{
+		cfg:     cfg,
+		session: NewSession(),
+	}
+}
+
+// Serve runs the read-dispatch-write loop until stdin closes or
+// ctx is done. Returns nil on clean stdin EOF; non-nil on read /
+// write errors. Each line on stdin is one JSON-RPC frame (per MCP's
+// stdio framing — newline-delimited JSON, no header).
+//
+// Frames are dispatched SEQUENTIALLY per the MCP initialization
+// contract: initialize must complete before any tool call, and the
+// initialized notification must arrive before other requests are
+// honored. Serialising the entire dispatch satisfies this without
+// per-method gating. Concurrent tools/call (long-running spawn_run
+// vs short list_runs on the same connection) is a v0.8.15.x or v0.9.x
+// optimisation; the writeMu is retained for the notification path
+// where in-flight spawn_run emits notifications while reading the
+// next frame is desired — but those notifications come from the
+// handler goroutine, which is the same goroutine that's dispatching.
+//
+// In practice MCP clients (Claude Code first) send one request at a
+// time and wait for the response, so sequential dispatch matches
+// real-world usage.
+func (s *Server) Serve(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+	scanner := bufio.NewScanner(stdin)
+	// MCP messages can be large (tool inputs, agent system prompts).
+	// Default 64 KB is too small. Use 4 MB ceiling — matches the HTTP
+	// server's effective request-size budget.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+
+	for scanner.Scan() {
+		// Copy the line — scanner reuses its buffer on next Scan().
+		line := append([]byte(nil), scanner.Bytes()...)
+		if len(line) == 0 {
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		s.handleFrame(ctx, line, stdout)
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("mcp: read stdin: %w", err)
+	}
+	return nil
+}
+
+// handleFrame decodes one inbound JSON-RPC frame and dispatches to
+// the appropriate handler. Requests get a response written back to
+// stdout; notifications (no id) get logged + handled but emit no
+// response.
+func (s *Server) handleFrame(ctx context.Context, frame []byte, stdout io.Writer) {
+	// JSON-RPC servers see Requests (id present) and Notifications
+	// (no id). Probe for id presence the same way DecodeFrame does
+	// for the client side.
+	var probe struct {
+		ID *int64 `json:"id"`
+	}
+	if err := json.Unmarshal(frame, &probe); err != nil {
+		s.cfg.Logf("mcp: decode probe: %v", err)
+		return
+	}
+	if probe.ID == nil {
+		// Notification — no response. We handle "initialized" + log
+		// the rest. (MCP defines a few client-to-server notifications
+		// — most loomcycle can safely ignore.)
+		var n loommcp.Notification
+		if err := json.Unmarshal(frame, &n); err != nil {
+			s.cfg.Logf("mcp: decode notification: %v", err)
+			return
+		}
+		if n.Method == "notifications/initialized" {
+			s.session.MarkInitialized()
+		}
+		return
+	}
+
+	// Request — must respond.
+	var req loommcp.Request
+	if err := json.Unmarshal(frame, &req); err != nil {
+		s.writeError(stdout, *probe.ID, -32700, "parse error: "+err.Error())
+		return
+	}
+	if req.JSONRPC != "2.0" {
+		s.writeError(stdout, req.ID, -32600, "invalid request: jsonrpc must be \"2.0\"")
+		return
+	}
+
+	switch req.Method {
+	case "initialize":
+		s.handleInitialize(stdout, req)
+	case "tools/list":
+		s.handleToolsList(stdout, req)
+	case "tools/call":
+		s.handleToolsCall(ctx, stdout, req)
+	default:
+		// MCP -32601 = method not found. Adapters log this and fall
+		// through; we don't need to enumerate every spec method we
+		// don't yet implement (sampling, elicitation, etc.).
+		s.writeError(stdout, req.ID, -32601, "method not found: "+req.Method)
+	}
+}
+
+// handleInitialize captures the client's capabilities (most
+// importantly: did they opt into run-event notifications?) and
+// returns our serverInfo + capabilities + protocolVersion.
+func (s *Server) handleInitialize(stdout io.Writer, req loommcp.Request) {
+	var params struct {
+		ProtocolVersion string          `json:"protocolVersion"`
+		Capabilities    json.RawMessage `json:"capabilities"`
+		ClientInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"clientInfo"`
+	}
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeError(stdout, req.ID, -32602, "invalid initialize params: "+err.Error())
+		return
+	}
+
+	// Parse our v0.8.15-specific capability nesting:
+	// capabilities.loomcycle.runEvents = true | false
+	var caps struct {
+		Loomcycle struct {
+			RunEvents bool `json:"runEvents"`
+		} `json:"loomcycle"`
+	}
+	_ = json.Unmarshal(params.Capabilities, &caps) // best-effort; default false
+	s.session.SetRunEventsEnabled(caps.Loomcycle.RunEvents)
+	s.session.SetClientInfo(params.ClientInfo.Name, params.ClientInfo.Version)
+
+	result := struct {
+		ProtocolVersion string         `json:"protocolVersion"`
+		Capabilities    map[string]any `json:"capabilities"`
+		ServerInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+	}{
+		ProtocolVersion: loommcp.ProtocolVersion,
+		Capabilities: map[string]any{
+			"tools": map[string]any{},
+			// Server-side advertised capabilities. Mirrors what we
+			// expect from the client side too.
+			"loomcycle": map[string]any{
+				"runEvents": true,
+			},
+		},
+	}
+	result.ServerInfo.Name = s.cfg.ServerName
+	result.ServerInfo.Version = s.cfg.ServerVersion
+
+	s.writeResult(stdout, req.ID, result)
+}
+
+// handleToolsList returns the static tool descriptor catalogue.
+func (s *Server) handleToolsList(stdout io.Writer, req loommcp.Request) {
+	descs := toolDescriptors()
+	result := loommcp.ToolsListResult{Tools: descs}
+	s.writeResult(stdout, req.ID, result)
+}
+
+// handleToolsCall is the dispatch for every loomcycle__<tool>
+// invocation. Each tool handler returns a *loommcp.CallToolResult
+// shaped result; we marshal it as the JSON-RPC response.
+func (s *Server) handleToolsCall(ctx context.Context, stdout io.Writer, req loommcp.Request) {
+	var params loommcp.CallToolParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeError(stdout, req.ID, -32602, "invalid tools/call params: "+err.Error())
+		return
+	}
+
+	handler, ok := toolHandlerByName(params.Name)
+	if !ok {
+		s.writeError(stdout, req.ID, -32601, "unknown tool: "+params.Name)
+		return
+	}
+
+	res, err := handler(ctx, &handlerEnv{
+		connector: s.cfg.Connector,
+		runner:    s.cfg.Runner,
+		session:   s.session,
+		notify:    s.makeNotifier(stdout, req.ID),
+		logf:      s.cfg.Logf,
+	}, params.Arguments)
+	if err != nil {
+		// Handler returned a Go error (internal failure, not a
+		// tool-error). MCP -32603 = internal error.
+		s.writeError(stdout, req.ID, -32603, err.Error())
+		return
+	}
+	s.writeResult(stdout, req.ID, res)
+}
+
+// writeResult emits a JSON-RPC 2.0 success response.
+func (s *Server) writeResult(stdout io.Writer, id int64, result any) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		s.writeError(stdout, id, -32603, "marshal result: "+err.Error())
+		return
+	}
+	frame := loommcp.Response{JSONRPC: "2.0", ID: id, Result: raw}
+	s.writeFrame(stdout, frame)
+}
+
+// writeError emits a JSON-RPC 2.0 error response.
+func (s *Server) writeError(stdout io.Writer, id int64, code int, message string) {
+	frame := loommcp.Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &loommcp.Error{Code: code, Message: message},
+	}
+	s.writeFrame(stdout, frame)
+}
+
+// writeFrame serialises and writes one JSON-RPC frame. Holds writeMu
+// so concurrent goroutines (request handlers + notification emitters)
+// can't interleave bytes.
+func (s *Server) writeFrame(stdout io.Writer, v any) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		s.cfg.Logf("mcp: marshal frame: %v", err)
+		return
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	if _, err := stdout.Write(raw); err != nil {
+		s.cfg.Logf("mcp: write stdout: %v", err)
+		return
+	}
+	if _, err := stdout.Write([]byte("\n")); err != nil {
+		s.cfg.Logf("mcp: write newline: %v", err)
+	}
+}
+
+// makeNotifier returns a notifier closure that handlers can call to
+// emit notifications/loomcycle/run_event during a long-running
+// tools/call. Captures stdout + writeMu via the Server reference.
+func (s *Server) makeNotifier(stdout io.Writer, _ int64) NotifyFunc {
+	return func(method string, params any) {
+		n, err := loommcp.NewNotification(method, params)
+		if err != nil {
+			s.cfg.Logf("mcp: notify build: %v", err)
+			return
+		}
+		s.writeFrame(stdout, n)
+	}
+}
+
+// NotifyFunc is the signature passed to handlers for emitting
+// server-to-client notifications during long-running calls.
+type NotifyFunc func(method string, params any)
+
+// handlerEnv carries the things every tool handler needs. Passing
+// one struct keeps handler signatures uniform (matters because we
+// register them by name in a map).
+type handlerEnv struct {
+	connector connector.Connector
+	runner    runner.Runner
+	session   *Session
+	notify    NotifyFunc
+	logf      func(format string, v ...any)
+}
+
+func defaultLogf(format string, v ...any) {
+	log.Printf("mcp: "+format, v...)
+}

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -1,0 +1,415 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// mockConnector implements every Connector method as a no-op except
+// the ones explicitly exercised. Lets tests focus on what they care
+// about without faking unrelated surfaces.
+type mockConnector struct {
+	spawnReq     atomic.Value // connector.SpawnRunRequest (last)
+	spawnResult  connector.SpawnRunResult
+	spawnErr     error
+	regCalls     atomic.Int32
+	regResult    connector.AgentDescriptor
+	pauseResult  connector.PauseResult
+	listCallback func()
+}
+
+func (m *mockConnector) SpawnRun(_ context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+	m.spawnReq.Store(r)
+	return m.spawnResult, m.spawnErr
+}
+func (m *mockConnector) CancelRun(_ context.Context, _, _ string) (connector.CancelRunResult, error) {
+	return connector.CancelRunResult{Cancelled: true}, nil
+}
+func (m *mockConnector) GetRun(_ context.Context, _ string) (connector.Run, error) {
+	return connector.Run{}, nil
+}
+func (m *mockConnector) ListRuns(_ context.Context, _ connector.ListRunsFilter) ([]connector.Run, error) {
+	if m.listCallback != nil {
+		m.listCallback()
+	}
+	return nil, nil
+}
+func (m *mockConnector) RegisterAgent(_ context.Context, _ connector.RegisterAgentRequest) (connector.AgentDescriptor, error) {
+	m.regCalls.Add(1)
+	return m.regResult, nil
+}
+func (m *mockConnector) UnregisterAgent(_ context.Context, _ string) error { return nil }
+func (m *mockConnector) ListAgents(_ context.Context, _ bool) ([]connector.AgentDescriptor, error) {
+	return nil, nil
+}
+func (m *mockConnector) Memory(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{Text: `{"ok":true}`}, nil
+}
+func (m *mockConnector) Channel(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) AgentDef(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) Evaluation(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) Context(_ context.Context, _ json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+func (m *mockConnector) PauseRuntime(_ context.Context, _ int) (connector.PauseResult, error) {
+	return m.pauseResult, nil
+}
+func (m *mockConnector) ResumeRuntime(_ context.Context) (connector.ResumeResult, error) {
+	return connector.ResumeResult{}, nil
+}
+func (m *mockConnector) GetRuntimeState(_ context.Context) (connector.RuntimeState, error) {
+	return connector.RuntimeState{}, nil
+}
+func (m *mockConnector) CreateSnapshot(_ context.Context, _ connector.CreateSnapshotRequest) (connector.SnapshotDescriptor, error) {
+	return connector.SnapshotDescriptor{}, nil
+}
+func (m *mockConnector) ListSnapshots(_ context.Context) ([]connector.SnapshotDescriptor, error) {
+	return nil, nil
+}
+func (m *mockConnector) ExportSnapshot(_ context.Context, _ string) (connector.ExportSnapshotResult, error) {
+	return connector.ExportSnapshotResult{}, errors.New("not implemented")
+}
+func (m *mockConnector) RestoreSnapshot(_ context.Context, _ connector.RestoreSnapshotRequest) (connector.RestoreSnapshotResult, error) {
+	return connector.RestoreSnapshotResult{}, errors.New("not implemented")
+}
+func (m *mockConnector) DeleteSnapshot(_ context.Context, _ string) error {
+	return errors.New("not implemented")
+}
+
+// driveServer runs the server against the given input lines and
+// returns the response frames (one per request). Notifications are
+// captured separately.
+func driveServer(t *testing.T, srv *Server, input string) (responses []loommcp.Response, notifications []loommcp.Notification) {
+	t.Helper()
+	stdout := &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Serve(ctx, strings.NewReader(input), stdout); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if line == "" {
+			continue
+		}
+		// Probe by presence of "id" — responses have one, notifications don't.
+		var probe struct {
+			ID *int64 `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			t.Logf("skip undecodable line: %s", line)
+			continue
+		}
+		if probe.ID != nil {
+			var r loommcp.Response
+			if err := json.Unmarshal([]byte(line), &r); err == nil {
+				responses = append(responses, r)
+			}
+		} else {
+			var n loommcp.Notification
+			if err := json.Unmarshal([]byte(line), &n); err == nil {
+				notifications = append(notifications, n)
+			}
+		}
+	}
+	return
+}
+
+func TestServer_Handshake(t *testing.T) {
+	srv := New(Config{
+		Connector:     &mockConnector{},
+		Logf:          func(string, ...any) {},
+		ServerName:    "loomcycle-test",
+		ServerVersion: "v0.8.15-test",
+	})
+	in := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"claude-code","version":"1.0"}}}` + "\n"
+	resps, notifs := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if len(notifs) != 0 {
+		t.Errorf("got %d unexpected notifications", len(notifs))
+	}
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if result.ProtocolVersion != loommcp.ProtocolVersion {
+		t.Errorf("protocolVersion = %q, want %q", result.ProtocolVersion, loommcp.ProtocolVersion)
+	}
+	if result.ServerInfo.Name != "loomcycle-test" {
+		t.Errorf("serverInfo.name = %q, want %q", result.ServerInfo.Name, "loomcycle-test")
+	}
+}
+
+func TestServer_ToolsList_Returns20Tools(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	var result loommcp.ToolsListResult
+	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(result.Tools) != 20 {
+		t.Errorf("got %d tools, want 20", len(result.Tools))
+	}
+	names := map[string]bool{}
+	for _, td := range result.Tools {
+		names[td.Name] = true
+	}
+	// Spot-check a few across categories.
+	for _, want := range []string{"spawn_run", "register_agent", "memory", "pause_runtime", "create_snapshot"} {
+		if !names[want] {
+			t.Errorf("missing tool %q in tools/list", want)
+		}
+	}
+}
+
+func TestServer_SpawnRun_BlockingPath(t *testing.T) {
+	mc := &mockConnector{
+		spawnResult: connector.SpawnRunResult{
+			AgentID:   "a_x",
+			RunID:     "r_x",
+			SessionID: "s_x",
+			Status:    "completed",
+			FinalText: "hello world",
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	// No runEvents capability → blocking path via Connector.SpawnRun.
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+	}, "\n") + "\n"
+	resps, notifs := driveServer(t, srv, in)
+	if len(resps) != 2 {
+		t.Fatalf("got %d responses, want 2 (init + spawn_run)", len(resps))
+	}
+	if len(notifs) != 0 {
+		t.Errorf("blocking path emitted %d notifications, want 0", len(notifs))
+	}
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.Agent != "qa-agent" {
+		t.Errorf("Connector saw agent=%q, want %q", stored.Agent, "qa-agent")
+	}
+	// Inspect the spawn_run tool result payload.
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	if callRes.IsError {
+		t.Fatalf("expected non-error spawn_run result, got isError=true: %v", callRes.Content)
+	}
+	if len(callRes.Content) != 1 {
+		t.Fatalf("got %d content blocks, want 1", len(callRes.Content))
+	}
+	var inner connector.SpawnRunResult
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if inner.AgentID != "a_x" || inner.FinalText != "hello world" {
+		t.Errorf("inner = %+v, want AgentID=a_x FinalText=\"hello world\"", inner)
+	}
+}
+
+// fakeRunner implements runner.Runner: on RunOnce, fires
+// OnRegistered then a scripted event sequence on OnEvent.
+type fakeRunner struct {
+	agentID, runID, sessionID string
+	events                    []providers.Event
+}
+
+func (f *fakeRunner) RunOnce(_ context.Context, _ runner.RunInput, cb runner.RunCallbacks) error {
+	if cb.OnRegistered != nil {
+		cb.OnRegistered(f.agentID, f.runID, f.sessionID, "")
+	}
+	for _, ev := range f.events {
+		if cb.OnEvent != nil {
+			cb.OnEvent(ev)
+		}
+	}
+	return nil
+}
+
+func TestServer_SpawnRun_StreamingPath(t *testing.T) {
+	usage := &providers.Usage{InputTokens: 10, OutputTokens: 4, Model: "stub"}
+	fr := &fakeRunner{
+		agentID:   "a_s",
+		runID:     "r_s",
+		sessionID: "s_s",
+		events: []providers.Event{
+			{Type: providers.EventStarted},
+			{Type: providers.EventText, Text: "hi "},
+			{Type: providers.EventText, Text: "there"},
+			{Type: providers.EventUsage, Usage: usage},
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		},
+	}
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Runner: fr, Logf: func(string, ...any) {}})
+
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"loomcycle":{"runEvents":true}},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+	}, "\n") + "\n"
+	resps, notifs := driveServer(t, srv, in)
+	if len(resps) != 2 {
+		t.Fatalf("got %d responses, want 2", len(resps))
+	}
+	// 5 events → 5 notifications.
+	if len(notifs) != 5 {
+		t.Errorf("got %d notifications, want 5 (one per fake event)", len(notifs))
+	}
+	for _, n := range notifs {
+		if n.Method != "notifications/loomcycle/run_event" {
+			t.Errorf("notification method = %q, want %q", n.Method, "notifications/loomcycle/run_event")
+		}
+	}
+	// Final result should have FinalText accumulated from the two
+	// text events and the usage attached.
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	var inner connector.SpawnRunResult
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if inner.FinalText != "hi there" {
+		t.Errorf("FinalText = %q, want %q", inner.FinalText, "hi there")
+	}
+	if inner.AgentID != "a_s" {
+		t.Errorf("AgentID = %q, want %q", inner.AgentID, "a_s")
+	}
+	if inner.Status != "completed" {
+		t.Errorf("Status = %q, want %q", inner.Status, "completed")
+	}
+}
+
+func TestServer_RegisterAgent_DispatchesThroughConnector(t *testing.T) {
+	mc := &mockConnector{
+		regResult: connector.AgentDescriptor{Name: "x", Source: "dynamic"},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"register_agent","arguments":{"name":"x","system_prompt":"p","allowed_tools":["Memory"]}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if mc.regCalls.Load() != 1 {
+		t.Errorf("Connector.RegisterAgent called %d times, want 1", mc.regCalls.Load())
+	}
+}
+
+func TestServer_UnknownTool_Returns32601(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nonexistent","arguments":{}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error == nil {
+		t.Fatal("expected error response")
+	}
+	if resps[0].Error.Code != -32601 {
+		t.Errorf("error code = %d, want -32601", resps[0].Error.Code)
+	}
+}
+
+func TestServer_PauseRuntime_ReturnsPreviewShape(t *testing.T) {
+	mc := &mockConnector{
+		pauseResult: connector.PauseResult{
+			Status:        "paused",
+			FeatureStatus: "preview",
+			Note:          "v0.8.15 mock",
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pause_runtime","arguments":{}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[0].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if callRes.IsError {
+		t.Errorf("pause_runtime should NOT be a tool error in v0.8.15 (mocks return success with feature_status=preview)")
+	}
+	var inner connector.PauseResult
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if inner.FeatureStatus != "preview" {
+		t.Errorf("feature_status = %q, want %q", inner.FeatureStatus, "preview")
+	}
+}
+
+func TestServer_ConcurrentToolsCall_NoFrameInterleave(t *testing.T) {
+	// 5 concurrent list_runs calls; each handler blocks briefly to
+	// raise the chance of interleave. We assert: each output line
+	// parses as a valid JSON-RPC frame (no torn lines), and the IDs
+	// 1..5 are all present.
+	var listCalls atomic.Int32
+	mc := &mockConnector{}
+	mc.listCallback = func() {
+		listCalls.Add(1)
+		time.Sleep(5 * time.Millisecond)
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+
+	var sb strings.Builder
+	for i := 1; i <= 5; i++ {
+		sb.WriteString(`{"jsonrpc":"2.0","id":`)
+		sb.WriteString(string(rune('0' + i)))
+		sb.WriteString(`,"method":"tools/call","params":{"name":"list_runs","arguments":{"user_id":"u_a"}}}` + "\n")
+	}
+	resps, _ := driveServer(t, srv, sb.String())
+	if len(resps) != 5 {
+		t.Fatalf("got %d responses, want 5", len(resps))
+	}
+	seen := map[int64]bool{}
+	for _, r := range resps {
+		seen[r.ID] = true
+	}
+	for i := int64(1); i <= 5; i++ {
+		if !seen[i] {
+			t.Errorf("missing response id=%d", i)
+		}
+	}
+	if listCalls.Load() != 5 {
+		t.Errorf("Connector.ListRuns called %d times, want 5", listCalls.Load())
+	}
+}
+
+// helper to satisfy io.Reader vs strings.NewReader type contract in
+// case Go's stdlib evolves; kept as a guard.
+var _ io.Reader = strings.NewReader("")
+var _ sync.Locker = (*sync.Mutex)(nil)

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -312,6 +312,77 @@ func TestServer_SpawnRun_StreamingPath(t *testing.T) {
 	}
 }
 
+// TestServer_SpawnRun_NotificationsArriveBeforeResponse pins the
+// wire-ordering invariant: every notifications/loomcycle/run_event
+// for a streaming spawn_run lands on stdout BEFORE the final
+// tools/call response. Without this guarantee, MCP orchestrators
+// rendering live agent output would see the run complete and only
+// then receive the event stream — useless for live progress UIs.
+//
+// Distinct from TestServer_SpawnRun_StreamingPath above (which only
+// counts notifications). This test re-runs the same fixture but
+// captures stdout in order to assert positional invariants.
+func TestServer_SpawnRun_NotificationsArriveBeforeResponse(t *testing.T) {
+	fr := &fakeRunner{
+		agentID:   "a_o",
+		runID:     "r_o",
+		sessionID: "s_o",
+		events: []providers.Event{
+			{Type: providers.EventStarted},
+			{Type: providers.EventText, Text: "hello"},
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		},
+	}
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Runner: fr, Logf: func(string, ...any) {}})
+
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"loomcycle":{"runEvents":true}},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa-agent","segments":[]}}}`,
+	}, "\n") + "\n"
+
+	stdout := &bytes.Buffer{}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Serve(ctx, strings.NewReader(in), stdout); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+
+	// Walk stdout lines in order. Track:
+	//   - index of the spawn_run response (id=2)
+	//   - indexes of all run_event notifications
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	var spawnRespIdx int = -1
+	var notifIdxs []int
+	for i, line := range lines {
+		var probe struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal([]byte(line), &probe); err != nil {
+			t.Fatalf("undecodable line %d: %s", i, line)
+		}
+		if probe.ID != nil && *probe.ID == 2 {
+			spawnRespIdx = i
+		}
+		if probe.ID == nil && probe.Method == "notifications/loomcycle/run_event" {
+			notifIdxs = append(notifIdxs, i)
+		}
+	}
+	if spawnRespIdx < 0 {
+		t.Fatalf("spawn_run response (id=2) not found in stdout:\n%s", stdout.String())
+	}
+	if len(notifIdxs) == 0 {
+		t.Fatal("no run_event notifications observed")
+	}
+	for _, ni := range notifIdxs {
+		if ni >= spawnRespIdx {
+			t.Errorf("notification at line %d came at-or-after spawn response at line %d; ordering invariant broken",
+				ni, spawnRespIdx)
+		}
+	}
+}
+
 func TestServer_RegisterAgent_DispatchesThroughConnector(t *testing.T) {
 	mc := &mockConnector{
 		regResult: connector.AgentDescriptor{Name: "x", Source: "dynamic"},
@@ -372,11 +443,15 @@ func TestServer_PauseRuntime_ReturnsPreviewShape(t *testing.T) {
 	}
 }
 
-func TestServer_ConcurrentToolsCall_NoFrameInterleave(t *testing.T) {
-	// 5 concurrent list_runs calls; each handler blocks briefly to
-	// raise the chance of interleave. We assert: each output line
-	// parses as a valid JSON-RPC frame (no torn lines), and the IDs
-	// 1..5 are all present.
+// TestServer_SequentialDispatch_AllResponsesPresent pins the property
+// that 5 back-to-back requests on a single stdio connection each
+// receive a response with the correct id. Frame dispatch is sequential
+// (see Server.Serve doc); this test doesn't exercise concurrent goroutine
+// safety — that's an explicit v0.9.x non-goal. If the dispatch loop is
+// ever made concurrent (per-request goroutines), this test would still
+// pass but the writeMu would become load-bearing; in that future,
+// extend the test to assert no torn frames on stdout.
+func TestServer_SequentialDispatch_AllResponsesPresent(t *testing.T) {
 	var listCalls atomic.Int32
 	mc := &mockConnector{}
 	mc.listCallback = func() {

--- a/internal/api/mcp/sessions.go
+++ b/internal/api/mcp/sessions.go
@@ -1,0 +1,63 @@
+package mcp
+
+import "sync/atomic"
+
+// Session carries per-connection MCP state. For stdio there's exactly
+// one Session per loomcycle-mcp process; HTTP transport (v0.8.15.x)
+// will create one Session per HTTP connection.
+//
+// Fields are read/written by both the main read-dispatch loop and
+// the per-request goroutines; access is via atomics so concurrent
+// reads after initialize don't need a mutex on the hot path.
+type Session struct {
+	// initialized flips true after the client sent
+	// notifications/initialized following its initialize call.
+	// Currently informational — we don't refuse tool calls before
+	// it (some clients fire tools/list immediately after the
+	// initialize response without sending the initialized
+	// notification first).
+	initialized atomic.Bool
+
+	// runEventsEnabled is true when the client opted into
+	// notifications/loomcycle/run_event via
+	// initialize.capabilities.loomcycle.runEvents=true. Read by
+	// spawn_run to decide which code path to take.
+	runEventsEnabled atomic.Bool
+
+	// clientName / clientVersion captured from the initialize
+	// client_info block. Logged at handshake; not otherwise
+	// load-bearing.
+	clientName    atomic.Value // string
+	clientVersion atomic.Value // string
+}
+
+// NewSession returns a fresh Session in the pre-handshake state.
+func NewSession() *Session { return &Session{} }
+
+func (s *Session) MarkInitialized()           { s.initialized.Store(true) }
+func (s *Session) IsInitialized() bool        { return s.initialized.Load() }
+func (s *Session) SetRunEventsEnabled(v bool) { s.runEventsEnabled.Store(v) }
+func (s *Session) RunEventsEnabled() bool     { return s.runEventsEnabled.Load() }
+
+// SetClientInfo records the client's name/version (captured from
+// initialize.clientInfo). Best-effort logging input.
+func (s *Session) SetClientInfo(name, version string) {
+	if name != "" {
+		s.clientName.Store(name)
+	}
+	if version != "" {
+		s.clientVersion.Store(version)
+	}
+}
+
+// ClientName returns the client's name or "" if not set.
+func (s *Session) ClientName() string {
+	v, _ := s.clientName.Load().(string)
+	return v
+}
+
+// ClientVersion returns the client's version or "" if not set.
+func (s *Session) ClientVersion() string {
+	v, _ := s.clientVersion.Load().(string)
+	return v
+}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -20,23 +20,26 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		// --- Run lifecycle ---
 		{
 			Name:        "spawn_run",
-			Description: "Spawn an agent run. Blocks until completion; final text + usage returned. When the session opted into runEvents via initialize.capabilities.loomcycle.runEvents=true, intermediate events stream as notifications/loomcycle/run_event during the call.",
+			Description: "Spawn an agent run. Blocks until completion; final text + usage returned. When the session opted into runEvents via initialize.capabilities.loomcycle.runEvents=true, intermediate events stream as notifications/loomcycle/run_event during the call. Exactly one of `agent` (fresh run against a registered agent) or `session_id` (continuation of an existing session) must be supplied.",
 			InputSchema: rawJSON(`{
 				"type": "object",
-				"required": ["agent", "segments"],
 				"properties": {
-					"agent":            {"type": "string", "description": "Registered agent name (static or dynamic)."},
-					"segments":         {"type": "array",  "description": "Prompt segments (matches /v1/runs segments field)."},
-					"session_id":       {"type": "string", "description": "Optional — set to continue an existing session."},
+					"agent":            {"type": "string", "description": "Registered agent name. Required for fresh runs; ignored for continuations (session's stored agent is authoritative)."},
+					"segments":         {"type": "array",  "description": "Prompt segments. Typically required for fresh runs; continuations may omit when the caller has nothing new to add."},
+					"session_id":       {"type": "string", "description": "Set to continue an existing session. When set, agent is ignored."},
 					"tenant_id":        {"type": "string"},
 					"user_id":          {"type": "string"},
 					"agent_id":         {"type": "string", "description": "Optional caller-supplied tracking handle."},
 					"user_tier":        {"type": "string"},
 					"user_bearer":      {"type": "string", "description": "Per-run MCP bearer (substituted into ${run.user_bearer} in mcp_servers.*.headers)."},
 					"allowed_tools":    {"type": "array", "items": {"type": "string"}},
-					"allowed_hosts":    {"type": "array", "items": {"type": "string"}},
+					"allowed_hosts":    {"type": "array", "items": {"type": "string"}, "description": "OMIT for no narrowing (operator's static allowlist applies). Pass empty array [] to DENY ALL outbound HTTP. Pass non-empty array to intersect with operator's list."},
 					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]}
-				}
+				},
+				"anyOf": [
+					{"required": ["agent"]},
+					{"required": ["session_id"]}
+				]
 			}`),
 		},
 		{

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"encoding/json"
+
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// toolDescriptors returns the v0.8.15 catalogue of 20 MCP tools.
+// Each descriptor carries name + description + input schema; the
+// schemas are intentionally minimal — full input validation lives
+// at the connector layer (or, for builtin wrappers, at the
+// underlying tool's discriminated-op schema).
+//
+// Naming convention: flat `verb_noun` for actions; single-word for
+// builtin wrappers (memory, channel, agentdef, evaluation, context)
+// whose inner `op` field already discriminates the operation.
+func toolDescriptors() []loommcp.ToolDescriptor {
+	return []loommcp.ToolDescriptor{
+		// --- Run lifecycle ---
+		{
+			Name:        "spawn_run",
+			Description: "Spawn an agent run. Blocks until completion; final text + usage returned. When the session opted into runEvents via initialize.capabilities.loomcycle.runEvents=true, intermediate events stream as notifications/loomcycle/run_event during the call.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["agent", "segments"],
+				"properties": {
+					"agent":            {"type": "string", "description": "Registered agent name (static or dynamic)."},
+					"segments":         {"type": "array",  "description": "Prompt segments (matches /v1/runs segments field)."},
+					"session_id":       {"type": "string", "description": "Optional — set to continue an existing session."},
+					"tenant_id":        {"type": "string"},
+					"user_id":          {"type": "string"},
+					"agent_id":         {"type": "string", "description": "Optional caller-supplied tracking handle."},
+					"user_tier":        {"type": "string"},
+					"user_bearer":      {"type": "string", "description": "Per-run MCP bearer (substituted into ${run.user_bearer} in mcp_servers.*.headers)."},
+					"allowed_tools":    {"type": "array", "items": {"type": "string"}},
+					"allowed_hosts":    {"type": "array", "items": {"type": "string"}},
+					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]}
+				}
+			}`),
+		},
+		{
+			Name:        "cancel_run",
+			Description: "Cancel a running agent by agent_id. Cascades to sub-agents. Idempotent.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["agent_id"],
+				"properties": {
+					"agent_id": {"type": "string"},
+					"reason":   {"type": "string"}
+				}
+			}`),
+		},
+		{
+			Name:        "get_run",
+			Description: "Return the latest status snapshot for a tracked agent_id.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["agent_id"],
+				"properties": {"agent_id": {"type": "string"}}
+			}`),
+		},
+		{
+			Name:        "list_runs",
+			Description: "Enumerate runs. user_id filter is required in v0.8.15.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["user_id"],
+				"properties": {
+					"user_id": {"type": "string"},
+					"status":  {"type": "string", "enum": ["running", "completed", "failed", "cancelled"]},
+					"limit":   {"type": "integer", "minimum": 1, "maximum": 200}
+				}
+			}`),
+		},
+
+		// --- Agent management ---
+		{
+			Name:        "register_agent",
+			Description: "Register a dynamic agent at runtime. Survives until TTL expires or unregister_agent is called. Bash/Write/Edit are stripped from allowed_tools unless the operator set LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["name", "system_prompt", "allowed_tools"],
+				"properties": {
+					"name":          {"type": "string", "pattern": "^[A-Za-z0-9_-]{1,64}$"},
+					"system_prompt": {"type": "string", "maxLength": 65536},
+					"allowed_tools": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+					"tier":          {"type": "string"},
+					"provider":      {"type": "string"},
+					"model":         {"type": "string"},
+					"effort":        {"type": "string", "enum": ["minimal", "low", "medium", "high"]},
+					"max_tokens":    {"type": "integer", "minimum": 1},
+					"memory_scopes": {"type": "array", "items": {"type": "string"}},
+					"description":   {"type": "string"},
+					"ttl_seconds":   {"type": "integer", "description": "TTL in seconds. 0 = env default (24h). -1 = no expiry."}
+				}
+			}`),
+		},
+		{
+			Name:        "unregister_agent",
+			Description: "Remove a dynamic agent. Cannot unregister static (yaml-defined) agents. Idempotent on missing names.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["name"],
+				"properties": {"name": {"type": "string"}}
+			}`),
+		},
+		{
+			Name:        "list_agents",
+			Description: "List all agents — static (from yaml) and dynamic (TTL-active rows from dynamic_agents).",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"properties": {
+					"include_dynamic": {"type": "boolean", "default": true}
+				}
+			}`),
+		},
+
+		// --- Builtin wrappers ---
+		// Each delegates 1:1 to the underlying builtin tool's
+		// discriminated-op input schema. We don't restate the inner
+		// schema here — the loomcycle agent loop already validates it.
+		{
+			Name:        "memory",
+			Description: "Memory tool ops (get/set/delete/list/incr). Pass-through to the underlying Memory builtin.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "channel",
+			Description: "Channel tool ops (publish/subscribe/ack/peek/list_channels). Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "agentdef",
+			Description: "AgentDef tool ops (create/fork/get/list/promote/retire). Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "evaluation",
+			Description: "Evaluation tool ops (submit/get/list_for_run/list_for_def/aggregate). Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "context",
+			Description: "Context tool ops (self/tools/doc/permissions/agents/lineage/evaluations/channels/history/help). Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+
+		// --- Pause/Resume (PREVIEW in v0.8.15) ---
+		{
+			Name:        "pause_runtime",
+			Description: "PREVIEW (v0.8.15): wire shape stable; real implementation in v0.8.16+. Currently returns placeholder data — does NOT actually pause the runtime.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"properties": {"timeout_ms": {"type": "integer", "default": 30000}}
+			}`),
+		},
+		{
+			Name:        "resume_runtime",
+			Description: "PREVIEW (v0.8.15): wire shape stable; real implementation in v0.8.16+. Currently a no-op.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "get_runtime_state",
+			Description: "PREVIEW (v0.8.15): always returns {status: running, feature_status: preview} in v0.8.15.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+
+		// --- Snapshot (PREVIEW in v0.8.15) ---
+		{
+			Name:        "create_snapshot",
+			Description: "PREVIEW (v0.8.15): wire shape stable; returns a placeholder snapshot_id with feature_status=preview. Does NOT write a snapshot.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"properties": {
+					"include_history": {"type": "boolean"},
+					"since_ts":        {"type": "string", "format": "date-time"},
+					"description":     {"type": "string"}
+				}
+			}`),
+		},
+		{
+			Name:        "list_snapshots",
+			Description: "PREVIEW (v0.8.15): always returns an empty list (mocks don't persist).",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "export_snapshot",
+			Description: "PREVIEW (v0.8.15): not implemented; returns a tool error.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["snapshot_id"],
+				"properties": {"snapshot_id": {"type": "string"}}
+			}`),
+		},
+		{
+			Name:        "restore_snapshot",
+			Description: "PREVIEW (v0.8.15): not implemented; returns a tool error.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"oneOf": [
+					{"required": ["snapshot_id"]},
+					{"required": ["file_path"]}
+				],
+				"properties": {
+					"snapshot_id": {"type": "string"},
+					"file_path":   {"type": "string"}
+				}
+			}`),
+		},
+		{
+			Name:        "delete_snapshot",
+			Description: "PREVIEW (v0.8.15): not implemented; returns a tool error.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["snapshot_id"],
+				"properties": {"snapshot_id": {"type": "string"}}
+			}`),
+		},
+	}
+}
+
+func rawJSON(s string) json.RawMessage { return json.RawMessage(s) }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,11 +5,16 @@
 //	loomcycle health [--target <url>]               — ping a running instance
 //	loomcycle migrate up|down|status [--config Y]   — run Postgres schema migrations
 //	loomcycle migrate sqlite-to-postgres            — copy data between adapters
+//	loomcycle mcp [--config <yaml>]                 — run as MCP server (stdio, v0.8.15+)
 //
 // Each subcommand exposes a Run* function returning an exit code so the
 // caller (cmd/loomcycle/main.go) can `os.Exit(rc)` cleanly. Stdout/
 // stderr are passed in so tests can assert on the produced output
 // without race-driving the global os.Stdout.
+//
+// Note: `mcp` is special — it's handled directly in main.go (not via
+// a Run* function here) because it reuses the full server boot path.
+// PrintHelp still lists it for discoverability.
 //
 // Design intent: these are thin wrappers around existing internal
 // packages. No business logic lives here — validate calls config.Load
@@ -43,6 +48,9 @@ func PrintHelp(w io.Writer) {
 	fmt.Fprintln(w, "  migrate status  [--config <y>]   show current schema version + dirty flag")
 	fmt.Fprintln(w, "  migrate sqlite-to-postgres --src <path> --dst <dsn>")
 	fmt.Fprintln(w, "                                   copy SQLite data into Postgres")
+	fmt.Fprintln(w, "  mcp [--config <yaml>]            run as MCP server over stdio (v0.8.15+)")
+	fmt.Fprintln(w, "                                   exposes 20 tools; consumed by Claude Code,")
+	fmt.Fprintln(w, "                                   custom MCP orchestrators, etc.")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "Run any subcommand with -h for its own flags.")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -709,6 +709,30 @@ type Env struct {
 	// LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS.
 	MetricsSweepInterval time.Duration
 
+	// MCPAllowPrivilegedTools — v0.8.15. When true, dynamically-
+	// registered agents may include Bash/Write/Edit in their
+	// allowed_tools. Default false: those three are stripped from
+	// any register_agent request, matching the v0.8.7/v0.8.8
+	// default-deny pattern for new tool surfaces. Env:
+	// LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS.
+	MCPAllowPrivilegedTools bool
+
+	// DynamicAgentDefaultTTLSeconds — v0.8.15. TTL applied to
+	// dynamic agents registered via mcp__loomcycle__register_agent
+	// when the caller omits ttl_seconds. Default 86400 (24h).
+	// Set to 0 to deny all default-TTL registrations (callers
+	// MUST supply an explicit ttl_seconds). Env:
+	// LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS.
+	DynamicAgentDefaultTTLSeconds int
+
+	// DynamicAgentSweepInterval — v0.8.15. Cadence for the
+	// dynamic_agents TTL sweeper. Default 15 minutes. 0 disables
+	// the sweeper (expired rows linger; DynamicAgentGet still
+	// filters them out at read time so functional correctness is
+	// preserved, but the table grows unbounded). Env:
+	// LOOMCYCLE_DYNAMIC_AGENT_SWEEP_INTERVAL_MS.
+	DynamicAgentSweepInterval time.Duration
+
 	// ToolParallelism caps how many tool_calls from a single
 	// assistant turn run concurrently. Default 8. Set to 1 to
 	// force serial dispatch (debug / determinism). Field 0
@@ -1159,6 +1183,25 @@ func Load(path string) (*Config, error) {
 				cfg.Env.MetricsSweepInterval = 0
 			} else {
 				cfg.Env.MetricsSweepInterval = time.Duration(n) * time.Millisecond
+			}
+		}
+	}
+
+	// v0.8.15 LoomCycle MCP: dynamic agent registration policy.
+	cfg.Env.MCPAllowPrivilegedTools = os.Getenv("LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS") == "1"
+	cfg.Env.DynamicAgentDefaultTTLSeconds = 86400 // 24h
+	if v := os.Getenv("LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.Env.DynamicAgentDefaultTTLSeconds = n
+		}
+	}
+	cfg.Env.DynamicAgentSweepInterval = 15 * time.Minute
+	if v := os.Getenv("LOOMCYCLE_DYNAMIC_AGENT_SWEEP_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				cfg.Env.DynamicAgentSweepInterval = 0
+			} else {
+				cfg.Env.DynamicAgentSweepInterval = time.Duration(n) * time.Millisecond
 			}
 		}
 	}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -1,0 +1,113 @@
+// Package connector defines the abstract operation surface that every
+// wire transport (HTTP, gRPC, MCP, future CLI) translates into. The
+// Connector interface is the single canonical contract; transport
+// adapters become thin wire-translation layers over it.
+//
+// Implementations and consumers:
+//
+//   - internal/api/http.Server     IMPLEMENTS  Connector (canonical;
+//     existing handlers compose into the interface)
+//   - internal/api/mcp.Server      CONSUMES    Connector (each
+//     tools/call handler dispatches to a Connector method)
+//   - internal/api/grpc.Server     CONSUMES    Connector (each proto
+//     handler dispatches to a Connector method)
+//   - adapters/ts (TypeScript)     MIRRORS     the operation surface
+//     in TypeScript over HTTP wire
+//   - future adapters/python       MIRRORS     same in Python
+//   - future internal/api/cli      CONSUMES    Connector (`loomcycle run`)
+//
+// The MCP / gRPC / CLI servers hold a connector.Connector field and
+// never make HTTP round-trips; they call methods directly on the
+// underlying HTTP server (which holds the business logic). Adding a
+// new wire surface is mechanical: implement input/output translation
+// for each Connector method, no business logic duplication.
+//
+// Evolution policy: the interface is ADDITIVE going forward through
+// v0.8.x. Adding methods is safe; changing signatures is a semver
+// break and requires a v0.9.x bump.
+package connector
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Connector is the operation surface every wire transport exposes.
+// See package doc for the architectural rationale.
+//
+// v0.8.15 mock policy: PauseRuntime / ResumeRuntime / GetRuntimeState /
+// CreateSnapshot / ListSnapshots / ExportSnapshot / RestoreSnapshot /
+// DeleteSnapshot return placeholder responses with FeatureStatus="preview".
+// Wire shapes are stable; real implementations land in v0.8.16+.
+type Connector interface {
+	// --- Run lifecycle ---
+
+	// SpawnRun is the alternate front-end to POST /v1/runs. Blocks
+	// until the run completes (or fails); use Notify-style streaming
+	// at the transport layer for live progress (e.g., MCP
+	// notifications/loomcycle/run_event). Returns the final result
+	// (text, stop_reason, usage) along with the assigned IDs.
+	SpawnRun(ctx context.Context, req SpawnRunRequest) (SpawnRunResult, error)
+
+	// CancelRun mirrors POST /v1/agents/{agent_id}/cancel. Cascades
+	// to sub-agent runs spawned by this run. Idempotent.
+	CancelRun(ctx context.Context, agentID, reason string) (CancelRunResult, error)
+
+	// GetRun returns the latest status snapshot for a tracked
+	// agent_id. Mirrors GET /v1/agents/{agent_id}.
+	GetRun(ctx context.Context, agentID string) (Run, error)
+
+	// ListRuns enumerates runs matching the filter. Mirrors
+	// GET /v1/runs (with optional user_id / status filters).
+	ListRuns(ctx context.Context, filter ListRunsFilter) ([]Run, error)
+
+	// --- Agent management ---
+
+	// RegisterAgent adds a dynamic agent that survives until its TTL
+	// expires (or until UnregisterAgent is called). Returns the
+	// effective AgentDescriptor — note allowed_tools may have been
+	// stripped if Bash/Write/Edit were requested without the
+	// LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS opt-in.
+	RegisterAgent(ctx context.Context, req RegisterAgentRequest) (AgentDescriptor, error)
+
+	// UnregisterAgent removes a dynamic agent immediately. Returns
+	// nil if the agent didn't exist (idempotent). Cannot unregister
+	// static agents declared in YAML — that returns an error.
+	UnregisterAgent(ctx context.Context, name string) error
+
+	// ListAgents returns all known agents — both static (from
+	// cfg.Agents / discovery) and dynamic (TTL-active rows from
+	// dynamic_agents). includeDynamic=false returns only static.
+	ListAgents(ctx context.Context, includeDynamic bool) ([]AgentDescriptor, error)
+
+	// --- Builtin tool invocations ---
+	//
+	// Each builtin's discriminated-op input shape stays the authority
+	// for inner-op validation. The connector passes raw JSON through
+	// to tool.Execute; transport adapters just route inputs+outputs.
+	// Operator-level ctx is built by the transport (full memory
+	// scopes, full channel ACL, full evaluation policy).
+
+	Memory(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+	Channel(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+	AgentDef(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+	Evaluation(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+	Context(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+
+	// --- Pause/Resume/Snapshot (MOCKED in v0.8.15) ---
+	//
+	// Wire shapes are stable; real implementations land in v0.8.16+
+	// per doc-internal/rfcs/pause-resume-snapshot.md (RFC locked
+	// 2026-05-12). Mock responses include FeatureStatus="preview" so
+	// adapters can detect the stub state without surprise.
+
+	PauseRuntime(ctx context.Context, timeoutMS int) (PauseResult, error)
+	ResumeRuntime(ctx context.Context) (ResumeResult, error)
+	GetRuntimeState(ctx context.Context) (RuntimeState, error)
+
+	CreateSnapshot(ctx context.Context, req CreateSnapshotRequest) (SnapshotDescriptor, error)
+	ListSnapshots(ctx context.Context) ([]SnapshotDescriptor, error)
+	ExportSnapshot(ctx context.Context, snapshotID string) (ExportSnapshotResult, error)
+	RestoreSnapshot(ctx context.Context, req RestoreSnapshotRequest) (RestoreSnapshotResult, error)
+	DeleteSnapshot(ctx context.Context, snapshotID string) error
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -91,9 +91,15 @@ type Connector interface {
 	// Operator-level ctx is the responsibility of the TRANSPORT adapter
 	// (MCP / gRPC / future CLI), NOT the connector. The connector is
 	// intentionally policy-agnostic — the caller attaches the right
-	// memory_scopes / channel ACL / evaluation policy on ctx before
-	// calling. See operatorCtx helpers in each transport for the
-	// pattern.
+	// memory_scopes / channel ACL / evaluation / agent_def / history
+	// policy on ctx BEFORE calling, otherwise the underlying tools
+	// return default-deny refusals (every op fails).
+	//
+	// See internal/api/mcp/context.go (operatorCtx) for the MCP
+	// transport's policy-enrichment helper. Future gRPC/CLI transports
+	// that surface builtin tools directly will need their own
+	// equivalent — the gRPC server today only exposes run-lifecycle
+	// RPCs through Connector, so the issue doesn't arise there.
 
 	Memory(ctx context.Context, input json.RawMessage) (ToolResult, error)
 	Channel(ctx context.Context, input json.RawMessage) (ToolResult, error)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -84,15 +84,22 @@ type Connector interface {
 	//
 	// Each builtin's discriminated-op input shape stays the authority
 	// for inner-op validation. The connector passes raw JSON through
-	// to tool.Execute; transport adapters just route inputs+outputs.
-	// Operator-level ctx is built by the transport (full memory
-	// scopes, full channel ACL, full evaluation policy).
+	// to tool.Execute; the result Text is the model-facing payload
+	// (typically JSON for builtin tools). Transport adapters wrap
+	// (text, is_error) in their wire-shape (e.g. MCP's content+isError).
+	//
+	// Operator-level ctx is the responsibility of the TRANSPORT adapter
+	// (MCP / gRPC / future CLI), NOT the connector. The connector is
+	// intentionally policy-agnostic — the caller attaches the right
+	// memory_scopes / channel ACL / evaluation policy on ctx before
+	// calling. See operatorCtx helpers in each transport for the
+	// pattern.
 
-	Memory(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
-	Channel(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
-	AgentDef(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
-	Evaluation(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
-	Context(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+	Memory(ctx context.Context, input json.RawMessage) (ToolResult, error)
+	Channel(ctx context.Context, input json.RawMessage) (ToolResult, error)
+	AgentDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+	Evaluation(ctx context.Context, input json.RawMessage) (ToolResult, error)
+	Context(ctx context.Context, input json.RawMessage) (ToolResult, error)
 
 	// --- Pause/Resume/Snapshot (MOCKED in v0.8.15) ---
 	//

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -1,0 +1,221 @@
+package connector
+
+import (
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// --- Run lifecycle types ---
+
+// SpawnRunRequest is the input to SpawnRun. Mirrors the union of
+// HTTP runRequest + runner.RunInput + gRPC RunRequest. Field
+// semantics match POST /v1/runs (when SessionID is empty) and
+// POST /v1/sessions/{id}/messages (when SessionID is non-empty).
+type SpawnRunRequest struct {
+	// Agent is the registered agent name. Required for fresh runs;
+	// ignored for continuations (session's stored agent is the
+	// source of truth).
+	Agent string `json:"agent"`
+
+	// SessionID — empty starts a fresh session+run; non-empty
+	// continues an existing session and creates a new run inside it.
+	SessionID string `json:"session_id,omitempty"`
+
+	// TenantID is recorded on a fresh session. Ignored for continuations.
+	TenantID string `json:"tenant_id,omitempty"`
+
+	// Segments is the call's input prompt content. The caller does
+	// NOT prepend the agent's system_prompt — the runner does that.
+	Segments []loop.PromptSegment `json:"segments"`
+
+	// AllowedTools narrows the agent's tool surface for this call.
+	// Empty = use the agent's full configured allowlist.
+	AllowedTools []string `json:"allowed_tools,omitempty"`
+
+	// AllowedHosts narrows HTTP / WebFetch / WebSearch host policy.
+	// nil = no narrowing; &[]string{} = deny-all; &[]string{"foo"} =
+	// intersection with operator's static list.
+	AllowedHosts *[]string `json:"allowed_hosts,omitempty"`
+
+	// WebSearchFilter is "drop" or "keep". Ignored when AllowedHosts is nil.
+	WebSearchFilter string `json:"web_search_filter,omitempty"`
+
+	// UserID binds the run to a user. Optional for fresh runs;
+	// ignored for continuations (inherited from the session).
+	UserID string `json:"user_id,omitempty"`
+
+	// AgentID is the caller-supplied tracking handle. Optional;
+	// the runner generates one when empty and returns it in result.
+	AgentID string `json:"agent_id,omitempty"`
+
+	// UserTier is the v0.8.2 user-facing-tier policy name. Empty
+	// falls through to cfg.UserTiers["default"] when configured.
+	UserTier string `json:"user_tier,omitempty"`
+
+	// UserBearer is the v0.8.14 per-run MCP bearer token. Substituted
+	// into MCP HTTP header values containing ${run.user_bearer}.
+	UserBearer string `json:"user_bearer,omitempty"`
+}
+
+// SpawnRunResult is the final outcome of a SpawnRun call (returned
+// only after the run completes — use streaming notifications at the
+// transport layer for live progress).
+type SpawnRunResult struct {
+	AgentID    string           `json:"agent_id"`
+	RunID      string           `json:"run_id"`
+	SessionID  string           `json:"session_id"`
+	Status     string           `json:"status"` // "completed" | "failed" | "cancelled"
+	StopReason string           `json:"stop_reason,omitempty"`
+	FinalText  string           `json:"final_text,omitempty"`
+	Usage      *providers.Usage `json:"usage,omitempty"`
+	Error      string           `json:"error,omitempty"`
+}
+
+// CancelRunResult reports the outcome of CancelRun.
+type CancelRunResult struct {
+	Cancelled     bool `json:"cancelled"`
+	CascadeCount  int  `json:"cascade_count"` // sub-runs also cancelled
+	AlreadyEnded  bool `json:"already_ended"` // run had already completed/failed
+}
+
+// Run is the status snapshot returned by GetRun / ListRuns. Distinct
+// from store.Run — this is the wire shape (no internal-only fields).
+type Run struct {
+	AgentID       string           `json:"agent_id"`
+	RunID         string           `json:"run_id"`
+	SessionID     string           `json:"session_id"`
+	UserID        string           `json:"user_id,omitempty"`
+	Agent         string           `json:"agent"`
+	ParentAgentID string           `json:"parent_agent_id,omitempty"`
+	Status        string           `json:"status"` // "running" | "completed" | "failed" | "cancelled"
+	StartedAt     time.Time        `json:"started_at"`
+	CompletedAt   *time.Time       `json:"completed_at,omitempty"`
+	StopReason    string           `json:"stop_reason,omitempty"`
+	Usage         *providers.Usage `json:"usage,omitempty"`
+	Error         string           `json:"error,omitempty"`
+}
+
+// ListRunsFilter selects which runs ListRuns returns. Empty fields
+// mean "no filter on this dimension". Multiple non-empty fields are
+// AND-combined.
+type ListRunsFilter struct {
+	UserID string `json:"user_id,omitempty"`
+	Status string `json:"status,omitempty"`
+	Limit  int    `json:"limit,omitempty"` // 0 = adapter default
+}
+
+// --- Agent management types ---
+
+// RegisterAgentRequest is the input to RegisterAgent. Mirrors a
+// subset of config.AgentDef sufficient for runtime-registered agents.
+type RegisterAgentRequest struct {
+	Name         string   `json:"name"`
+	SystemPrompt string   `json:"system_prompt"`
+	AllowedTools []string `json:"allowed_tools"`
+	Tier         string   `json:"tier,omitempty"`
+	Provider     string   `json:"provider,omitempty"`
+	Model        string   `json:"model,omitempty"`
+	Effort       string   `json:"effort,omitempty"` // "minimal" | "low" | "medium" | "high"
+	MaxTokens    int      `json:"max_tokens,omitempty"`
+	MemoryScopes []string `json:"memory_scopes,omitempty"`
+	Description  string   `json:"description,omitempty"`
+
+	// TTLSeconds is how long this dynamic agent should live. When
+	// 0, falls back to LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS
+	// (default 24h). A value of -1 means "no expiry" (operator
+	// must explicitly UnregisterAgent).
+	TTLSeconds int `json:"ttl_seconds,omitempty"`
+}
+
+// AgentDescriptor is the public-facing view of an agent (static or
+// dynamic). Distinct from config.AgentDef — this omits operator
+// secrets like the resolved API key path.
+type AgentDescriptor struct {
+	Name         string     `json:"name"`
+	Source       string     `json:"source"` // "static" | "dynamic"
+	AllowedTools []string   `json:"allowed_tools"`
+	Tier         string     `json:"tier,omitempty"`
+	Provider     string     `json:"provider,omitempty"`
+	Model        string     `json:"model,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"` // dynamic only
+	CreatedAt    *time.Time `json:"created_at,omitempty"` // dynamic only
+}
+
+// --- Pause/Resume/Snapshot types (mocked in v0.8.15) ---
+//
+// All include FeatureStatus="preview" in v0.8.15 responses to signal
+// the stub state. Real implementations in v0.8.16+ leave the field
+// empty (or set "stable") and populate the meaningful fields.
+
+// PauseResult reports the outcome of PauseRuntime.
+type PauseResult struct {
+	Status              string `json:"status"`                        // "paused"
+	DurationMS          int64  `json:"duration_ms"`                   // time taken to reach paused state
+	ForceCancelledCount int    `json:"force_cancelled_count"`         // non-idempotent tool calls force-cancelled
+	FeatureStatus       string `json:"feature_status,omitempty"`      // "preview" in v0.8.15
+	Note                string `json:"note,omitempty"`                // human-readable feature-status explanation
+}
+
+// ResumeResult reports the outcome of ResumeRuntime.
+type ResumeResult struct {
+	Status           string `json:"status"`                   // "running"
+	ResumedRunCount  int    `json:"resumed_run_count"`        // paused runs resumed
+	FeatureStatus    string `json:"feature_status,omitempty"`
+	Note             string `json:"note,omitempty"`
+}
+
+// RuntimeState is the response shape for GetRuntimeState.
+type RuntimeState struct {
+	Status          string     `json:"status"` // "running" | "pausing" | "paused" | "resuming" | "restoring"
+	PausedAt        *time.Time `json:"paused_at,omitempty"`
+	PausedRunCount  int        `json:"paused_run_count"`
+	SnapshotsCount  int        `json:"snapshots_count"`
+	FeatureStatus   string     `json:"feature_status,omitempty"`
+}
+
+// CreateSnapshotRequest is the input to CreateSnapshot.
+type CreateSnapshotRequest struct {
+	IncludeHistory bool       `json:"include_history,omitempty"`
+	SinceTS        *time.Time `json:"since_ts,omitempty"`
+	Description    string     `json:"description,omitempty"`
+}
+
+// SnapshotDescriptor is the response shape for CreateSnapshot /
+// elements of ListSnapshots.
+type SnapshotDescriptor struct {
+	SnapshotID      string     `json:"snapshot_id"`
+	CreatedAt       time.Time  `json:"created_at"`
+	SizeBytes       int64      `json:"size_bytes"`
+	IncludesHistory bool       `json:"includes_history"`
+	SinceTS         *time.Time `json:"since_ts,omitempty"`
+	Description     string     `json:"description,omitempty"`
+	FormatVersion   string     `json:"format_version"`
+	FeatureStatus   string     `json:"feature_status,omitempty"`
+}
+
+// ExportSnapshotResult is the response shape for ExportSnapshot.
+type ExportSnapshotResult struct {
+	SnapshotID    string `json:"snapshot_id"`
+	FilePath      string `json:"file_path"` // absolute path on the loomcycle host
+	Checksum      string `json:"checksum"`  // "sha256:..."
+	SizeBytes     int64  `json:"size_bytes"`
+	FeatureStatus string `json:"feature_status,omitempty"`
+}
+
+// RestoreSnapshotRequest is the input to RestoreSnapshot — exactly
+// one of SnapshotID (restore from same-instance snapshot) or
+// FilePath (load from disk) must be non-empty.
+type RestoreSnapshotRequest struct {
+	SnapshotID string `json:"snapshot_id,omitempty"`
+	FilePath   string `json:"file_path,omitempty"`
+}
+
+// RestoreSnapshotResult is the response shape for RestoreSnapshot.
+type RestoreSnapshotResult struct {
+	Restored      map[string]int `json:"restored"` // section name → row count
+	FormatMigrations []string    `json:"format_migrations,omitempty"`
+	FeatureStatus    string      `json:"feature_status,omitempty"`
+}

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -7,6 +7,19 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
+// ToolResult is the output of a builtin-tool invocation through the
+// Connector. Mirrors tools.Result but lives in the connector package
+// so transport adapters don't need to depend on internal/tools.
+//
+// Text is the model-facing payload (typically JSON for builtin tools).
+// IsError signals a failed execution — the MCP wire layer maps this
+// to `{"isError": true}` in the tool/call response so the orchestrator
+// can render it differently.
+type ToolResult struct {
+	Text    string `json:"text"`
+	IsError bool   `json:"is_error,omitempty"`
+}
+
 // --- Run lifecycle types ---
 
 // SpawnRunRequest is the input to SpawnRun. Mirrors the union of

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -88,9 +88,9 @@ type SpawnRunResult struct {
 
 // CancelRunResult reports the outcome of CancelRun.
 type CancelRunResult struct {
-	Cancelled     bool `json:"cancelled"`
-	CascadeCount  int  `json:"cascade_count"` // sub-runs also cancelled
-	AlreadyEnded  bool `json:"already_ended"` // run had already completed/failed
+	Cancelled    bool `json:"cancelled"`
+	CascadeCount int  `json:"cascade_count"` // sub-runs also cancelled
+	AlreadyEnded bool `json:"already_ended"` // run had already completed/failed
 }
 
 // Run is the status snapshot returned by GetRun / ListRuns. Distinct
@@ -165,28 +165,28 @@ type AgentDescriptor struct {
 
 // PauseResult reports the outcome of PauseRuntime.
 type PauseResult struct {
-	Status              string `json:"status"`                        // "paused"
-	DurationMS          int64  `json:"duration_ms"`                   // time taken to reach paused state
-	ForceCancelledCount int    `json:"force_cancelled_count"`         // non-idempotent tool calls force-cancelled
-	FeatureStatus       string `json:"feature_status,omitempty"`      // "preview" in v0.8.15
-	Note                string `json:"note,omitempty"`                // human-readable feature-status explanation
+	Status              string `json:"status"`                   // "paused"
+	DurationMS          int64  `json:"duration_ms"`              // time taken to reach paused state
+	ForceCancelledCount int    `json:"force_cancelled_count"`    // non-idempotent tool calls force-cancelled
+	FeatureStatus       string `json:"feature_status,omitempty"` // "preview" in v0.8.15
+	Note                string `json:"note,omitempty"`           // human-readable feature-status explanation
 }
 
 // ResumeResult reports the outcome of ResumeRuntime.
 type ResumeResult struct {
-	Status           string `json:"status"`                   // "running"
-	ResumedRunCount  int    `json:"resumed_run_count"`        // paused runs resumed
-	FeatureStatus    string `json:"feature_status,omitempty"`
-	Note             string `json:"note,omitempty"`
+	Status          string `json:"status"`            // "running"
+	ResumedRunCount int    `json:"resumed_run_count"` // paused runs resumed
+	FeatureStatus   string `json:"feature_status,omitempty"`
+	Note            string `json:"note,omitempty"`
 }
 
 // RuntimeState is the response shape for GetRuntimeState.
 type RuntimeState struct {
-	Status          string     `json:"status"` // "running" | "pausing" | "paused" | "resuming" | "restoring"
-	PausedAt        *time.Time `json:"paused_at,omitempty"`
-	PausedRunCount  int        `json:"paused_run_count"`
-	SnapshotsCount  int        `json:"snapshots_count"`
-	FeatureStatus   string     `json:"feature_status,omitempty"`
+	Status         string     `json:"status"` // "running" | "pausing" | "paused" | "resuming" | "restoring"
+	PausedAt       *time.Time `json:"paused_at,omitempty"`
+	PausedRunCount int        `json:"paused_run_count"`
+	SnapshotsCount int        `json:"snapshots_count"`
+	FeatureStatus  string     `json:"feature_status,omitempty"`
 }
 
 // CreateSnapshotRequest is the input to CreateSnapshot.
@@ -228,7 +228,7 @@ type RestoreSnapshotRequest struct {
 
 // RestoreSnapshotResult is the response shape for RestoreSnapshot.
 type RestoreSnapshotResult struct {
-	Restored      map[string]int `json:"restored"` // section name → row count
-	FormatMigrations []string    `json:"format_migrations,omitempty"`
-	FeatureStatus    string      `json:"feature_status,omitempty"`
+	Restored         map[string]int `json:"restored"` // section name → row count
+	FormatMigrations []string       `json:"format_migrations,omitempty"`
+	FeatureStatus    string         `json:"feature_status,omitempty"`
 }

--- a/internal/store/postgres/migrations/0010_dynamic_agents.down.sql
+++ b/internal/store/postgres/migrations/0010_dynamic_agents.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS dynamic_agents_by_expires_at;
+DROP TABLE IF EXISTS dynamic_agents;

--- a/internal/store/postgres/migrations/0010_dynamic_agents.up.sql
+++ b/internal/store/postgres/migrations/0010_dynamic_agents.up.sql
@@ -1,0 +1,24 @@
+-- v0.8.15 LoomCycle MCP: dynamic_agents — runtime-registered agents
+-- from `mcp__loomcycle__register_agent`. Survive restart until TTL
+-- expiry (or explicit unregister). The `definition` column holds the
+-- JSON-encoded config.AgentDef body verbatim (the store doesn't depend
+-- on internal/config; same pattern as v0.8.5 agent_defs).
+--
+-- expires_at = epoch (1970-01-01 UTC) means "no expiry" (operator
+-- must explicitly unregister). Non-default values are filtered at
+-- read time so callers never see expired rows.
+
+CREATE TABLE IF NOT EXISTS dynamic_agents (
+    name        TEXT        PRIMARY KEY,
+    definition  JSONB       NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL DEFAULT 'epoch',
+    description TEXT
+);
+
+-- Partial index: only TTL-bearing rows (the typical case). The full-table
+-- scan for "no expiry" rows is fine since list operations are bounded
+-- at 200 rows.
+CREATE INDEX IF NOT EXISTS dynamic_agents_by_expires_at
+    ON dynamic_agents(expires_at)
+    WHERE expires_at > 'epoch';

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -649,6 +649,112 @@ func (s *Store) MetricsSweep(ctx context.Context, cutoff time.Time) (int, error)
 	return int(tag.RowsAffected()), nil
 }
 
+// --- v0.8.15 dynamic_agents (LoomCycle MCP runtime registration) ---
+
+func (s *Store) DynamicAgentUpsert(ctx context.Context, a store.DynamicAgent) error {
+	if a.Name == "" {
+		return fmt.Errorf("dynamic_agents: name required")
+	}
+	if len(a.Definition) == 0 {
+		return fmt.Errorf("dynamic_agents: definition required")
+	}
+	createdAt := a.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	// Postgres expires_at column defaults to 'epoch' for "no expiry".
+	expiresAt := a.ExpiresAt
+	if expiresAt.IsZero() {
+		expiresAt = time.Unix(0, 0).UTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO dynamic_agents (name, definition, created_at, expires_at, description)
+		VALUES ($1, $2::jsonb, $3, $4, $5)
+		ON CONFLICT (name) DO UPDATE SET
+			definition  = EXCLUDED.definition,
+			created_at  = EXCLUDED.created_at,
+			expires_at  = EXCLUDED.expires_at,
+			description = EXCLUDED.description
+	`, a.Name, string(a.Definition), createdAt, expiresAt, a.Description)
+	if err != nil {
+		return fmt.Errorf("dynamic_agents: upsert: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT name, definition::text, created_at, expires_at, COALESCE(description, '')
+		FROM dynamic_agents
+		WHERE name = $1 AND (expires_at = 'epoch' OR expires_at > $2)
+	`, name, time.Now())
+
+	var a store.DynamicAgent
+	var defStr string
+	if err := row.Scan(&a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
+		}
+		return store.DynamicAgent{}, fmt.Errorf("dynamic_agents: get: %w", err)
+	}
+	a.Definition = []byte(defStr)
+	// Normalise the "no expiry" marker back to zero-value Time so
+	// callers (and the connector layer) see a consistent shape across
+	// SQLite (0 unix-ns) and Postgres ('epoch').
+	if a.ExpiresAt.Unix() == 0 {
+		a.ExpiresAt = time.Time{}
+	}
+	return a, nil
+}
+
+func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT name, definition::text, created_at, expires_at, COALESCE(description, '')
+		FROM dynamic_agents
+		WHERE expires_at = 'epoch' OR expires_at > $1
+		ORDER BY created_at DESC
+		LIMIT 200
+	`, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("dynamic_agents: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.DynamicAgent{}
+	for rows.Next() {
+		var a store.DynamicAgent
+		var defStr string
+		if err := rows.Scan(&a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
+			return nil, fmt.Errorf("dynamic_agents: list scan: %w", err)
+		}
+		a.Definition = []byte(defStr)
+		if a.ExpiresAt.Unix() == 0 {
+			a.ExpiresAt = time.Time{}
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) DynamicAgentDelete(ctx context.Context, name string) (bool, error) {
+	tag, err := s.pool.Exec(ctx, `DELETE FROM dynamic_agents WHERE name = $1`, name)
+	if err != nil {
+		return false, fmt.Errorf("dynamic_agents: delete: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM dynamic_agents
+		WHERE expires_at > 'epoch' AND expires_at < $1
+	`, time.Now())
+	if err != nil {
+		return 0, fmt.Errorf("dynamic_agents: sweep: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Close releases the connection pool. Idempotent.
 func (s *Store) Close() error {
 	s.closeOnce.Do(func() {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -230,6 +230,20 @@ func (s *Store) migrate(ctx context.Context) error {
 		// below (defensive: future column additions via ALTER TABLE
 		// would otherwise risk the upgrade-path bug that hit
 		// channel_messages_by_visible in v0.8.6).
+
+		// v0.8.15 LoomCycle MCP: dynamic_agents — runtime-registered
+		// agents from `mcp__loomcycle__register_agent`. Survive restart
+		// until TTL expiry (or explicit unregister). definition holds
+		// the JSON-encoded config.AgentDef body verbatim (the store
+		// doesn't depend on internal/config; same pattern as v0.8.5
+		// agent_defs). expires_at = 0 means "no expiry".
+		`CREATE TABLE IF NOT EXISTS dynamic_agents (
+			name        TEXT PRIMARY KEY,
+			definition  BLOB    NOT NULL,
+			created_at  INTEGER NOT NULL,
+			expires_at  INTEGER NOT NULL DEFAULT 0,
+			description TEXT
+		)`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -302,6 +316,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		// path for /v1/_metrics/samples (window scan) and the
 		// sweep DELETE WHERE sampled_at < cutoff.
 		`CREATE INDEX IF NOT EXISTS process_samples_by_sampled_at ON process_samples(sampled_at)`,
+		// v0.8.15 dynamic_agents_by_expires_at. Drives the sweeper
+		// (DELETE WHERE expires_at < now() AND expires_at > 0) and the
+		// per-Get expiry filter. Partial: only TTL-bearing rows.
+		`CREATE INDEX IF NOT EXISTS dynamic_agents_by_expires_at ON dynamic_agents(expires_at) WHERE expires_at > 0`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -2122,6 +2140,110 @@ func (s *Store) MetricsSweep(ctx context.Context, cutoff time.Time) (int, error)
 	res, err := s.db.ExecContext(ctx, `DELETE FROM process_samples WHERE sampled_at < ?`, cutoff.UnixNano())
 	if err != nil {
 		return 0, fmt.Errorf("metrics: sweep: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// --- v0.8.15 dynamic_agents (LoomCycle MCP runtime registration) ---
+
+func (s *Store) DynamicAgentUpsert(ctx context.Context, a store.DynamicAgent) error {
+	if a.Name == "" {
+		return fmt.Errorf("dynamic_agents: name required")
+	}
+	if len(a.Definition) == 0 {
+		return fmt.Errorf("dynamic_agents: definition required")
+	}
+	createdAt := a.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	var expiresAtNS int64
+	if !a.ExpiresAt.IsZero() {
+		expiresAtNS = a.ExpiresAt.UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO dynamic_agents (name, definition, created_at, expires_at, description)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+			definition  = excluded.definition,
+			created_at  = excluded.created_at,
+			expires_at  = excluded.expires_at,
+			description = excluded.description
+	`, a.Name, a.Definition, createdAt.UnixNano(), expiresAtNS, a.Description)
+	if err != nil {
+		return fmt.Errorf("dynamic_agents: upsert: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT name, definition, created_at, expires_at, COALESCE(description, '')
+		FROM dynamic_agents
+		WHERE name = ? AND (expires_at = 0 OR expires_at > ?)
+	`, name, time.Now().UnixNano())
+
+	var a store.DynamicAgent
+	var createdAtNS, expiresAtNS int64
+	if err := row.Scan(&a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
+		if err == sql.ErrNoRows {
+			return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
+		}
+		return store.DynamicAgent{}, fmt.Errorf("dynamic_agents: get: %w", err)
+	}
+	a.CreatedAt = time.Unix(0, createdAtNS)
+	if expiresAtNS > 0 {
+		a.ExpiresAt = time.Unix(0, expiresAtNS)
+	}
+	return a, nil
+}
+
+func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT name, definition, created_at, expires_at, COALESCE(description, '')
+		FROM dynamic_agents
+		WHERE expires_at = 0 OR expires_at > ?
+		ORDER BY created_at DESC
+		LIMIT 200
+	`, time.Now().UnixNano())
+	if err != nil {
+		return nil, fmt.Errorf("dynamic_agents: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.DynamicAgent{}
+	for rows.Next() {
+		var a store.DynamicAgent
+		var createdAtNS, expiresAtNS int64
+		if err := rows.Scan(&a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
+			return nil, fmt.Errorf("dynamic_agents: list scan: %w", err)
+		}
+		a.CreatedAt = time.Unix(0, createdAtNS)
+		if expiresAtNS > 0 {
+			a.ExpiresAt = time.Unix(0, expiresAtNS)
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) DynamicAgentDelete(ctx context.Context, name string) (bool, error) {
+	res, err := s.db.ExecContext(ctx, `DELETE FROM dynamic_agents WHERE name = ?`, name)
+	if err != nil {
+		return false, fmt.Errorf("dynamic_agents: delete: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n > 0, nil
+}
+
+func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		DELETE FROM dynamic_agents
+		WHERE expires_at > 0 AND expires_at < ?
+	`, time.Now().UnixNano())
+	if err != nil {
+		return 0, fmt.Errorf("dynamic_agents: sweep: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	return int(n), nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -589,6 +589,34 @@ type Store interface {
 	// the count deleted. Idempotent under concurrent sweepers.
 	MetricsSweep(ctx context.Context, cutoff time.Time) (int, error)
 
+	// DynamicAgentUpsert writes a dynamic agent row. The (name)
+	// column is the primary key — re-upserting the same name
+	// overwrites the definition and resets expires_at. expiresAt is
+	// zero-valued to mean "no expiry" (operator must explicitly
+	// DynamicAgentDelete). v0.8.15+.
+	DynamicAgentUpsert(ctx context.Context, agent DynamicAgent) error
+
+	// DynamicAgentGet reads one dynamic agent. Returns *ErrNotFound
+	// for both "row missing" and "row expired" — callers don't need
+	// to distinguish. Expired rows are filtered server-side
+	// regardless of whether the sweeper has reaped them yet.
+	DynamicAgentGet(ctx context.Context, name string) (DynamicAgent, error)
+
+	// DynamicAgentList enumerates non-expired dynamic agents.
+	// Capped at 200 rows ordered by created_at DESC.
+	DynamicAgentList(ctx context.Context) ([]DynamicAgent, error)
+
+	// DynamicAgentDelete removes one dynamic agent. Returns true
+	// when a row was actually deleted, false when the name didn't
+	// exist (or had already expired). Both are non-error paths.
+	DynamicAgentDelete(ctx context.Context, name string) (bool, error)
+
+	// DynamicAgentSweep deletes every dynamic_agents row whose
+	// expires_at has passed. Returns the row count deleted. Safe to
+	// run from a periodic goroutine; idempotent under concurrent
+	// sweepers (single atomic DELETE).
+	DynamicAgentSweep(ctx context.Context) (int, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -767,6 +795,23 @@ type MetricsRunWindow struct {
 	PeakRSSBytes  int64     `json:"peak_rss_bytes"`
 	MeanRSSBytes  int64     `json:"mean_rss_bytes"`
 	MaxCPUPctX100 int       `json:"max_cpu_pct_x100"`
+}
+
+// DynamicAgent is one row in the dynamic_agents table. Holds the JSON-
+// encoded AgentDef body verbatim (the store doesn't depend on
+// internal/config — dep direction would invert; the v0.8.5 AgentDefRow
+// uses the same pattern). v0.8.15 LoomCycle MCP adds runtime
+// registration via `mcp__loomcycle__register_agent`.
+//
+// ExpiresAt is zero when the agent has no TTL (operator must
+// explicitly unregister); non-zero rows are filtered by
+// DynamicAgentGet / DynamicAgentList when expires_at < now().
+type DynamicAgent struct {
+	Name        string    `json:"name"`         // primary key; charset [A-Za-z0-9_-]{1,64}
+	Definition  []byte    `json:"definition"`   // JSON-encoded config.AgentDef body
+	CreatedAt   time.Time `json:"created_at"`
+	ExpiresAt   time.Time `json:"expires_at,omitempty"` // zero = no expiry
+	Description string    `json:"description,omitempty"`
 }
 
 // ---- v0.8.5 Self-Evolution Substrate types ----

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -807,8 +807,8 @@ type MetricsRunWindow struct {
 // explicitly unregister); non-zero rows are filtered by
 // DynamicAgentGet / DynamicAgentList when expires_at < now().
 type DynamicAgent struct {
-	Name        string    `json:"name"`         // primary key; charset [A-Za-z0-9_-]{1,64}
-	Definition  []byte    `json:"definition"`   // JSON-encoded config.AgentDef body
+	Name        string    `json:"name"`       // primary key; charset [A-Za-z0-9_-]{1,64}
+	Definition  []byte    `json:"definition"` // JSON-encoded config.AgentDef body
 	CreatedAt   time.Time `json:"created_at"`
 	ExpiresAt   time.Time `json:"expires_at,omitempty"` // zero = no expiry
 	Description string    `json:"description,omitempty"`

--- a/loomcycle-mcp.sh
+++ b/loomcycle-mcp.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# loomcycle-mcp.sh — launch loomcycle in stdio MCP mode with .env.local sourced.
+#
+# Usage (typically invoked by an MCP client, not by hand):
+#   ./loomcycle-mcp.sh                 # uses default config
+#   LOOMCYCLE_CONFIG=/path/to.yaml ./loomcycle-mcp.sh
+#
+# Why this exists: the bare `bin/loomcycle mcp ...` inherits whatever env
+# the MCP client (e.g. Claude Code) hands it — typically empty of the
+# LOOMCYCLE_* / BRAVE_API_KEY / LOOMCYCLE_JOBS_SEARCH_API_TOKEN vars that
+# loomcycle.yaml's `${...}` placeholders expect. With those unset, the
+# aggregator's upstream pool handshakes fail (brave-search exits, jobs
+# redirects to /login) and the stdio server never converges to ready.
+# This wrapper sources .env.local first so every spawn gets the full env.
+#
+# Compare with loomcycle.sh, which does the same env-sourcing but runs the
+# HTTP+SSE server and rebuilds. MCP mode is per-invocation stdio — no
+# rebuild and no port-stop logic; let signals (EOF on stdin) end the run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+CONFIG="${LOOMCYCLE_CONFIG:-$HOME/.config/loomcycle/loomcycle.yaml}"
+ENV_FILE="${LOOMCYCLE_ENV_FILE:-.env.local}"
+BIN="${LOOMCYCLE_BIN:-bin/loomcycle}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "loomcycle-mcp.sh: binary not found or not executable: $BIN" >&2
+  echo "loomcycle-mcp.sh: run ./loomcycle.sh --no-build=0 first, or set LOOMCYCLE_BIN" >&2
+  exit 127
+fi
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+else
+  echo "loomcycle-mcp.sh: $ENV_FILE missing — upstream MCP handshakes will likely fail" >&2
+fi
+
+exec "$BIN" mcp --config "$CONFIG"


### PR DESCRIPTION
## Status

**Ready for review.** All phases of v0.8.15 land on this branch. Pause/Resume/Snapshot ship as PREVIEW-mocked wire shapes per the locked RFC; real implementations defer to v0.8.16+.

Per the locked RFC at \`doc-internal/rfcs/loomcycle-mcp.md\` (gitignored, locally available).

**Smoke test completed 2026-05-14** — loomcycle is connected to Claude Code via the wrapper pattern below; all 20 tools registered; upstream MCP servers (brave-search, jobs) converge correctly.

## What ships

| Layer | Status | Test count |
|---|---|---|
| **Connector abstraction** (the architectural anchor) | ✅ 20-method Go interface + types | (no tests; compile-time interface assertions) |
| **dynamic_agents storage** | ✅ SQLite + Postgres + 5 Store methods + sweeper helper | covered by storetest contract suite |
| **HTTP server satisfies Connector** | ✅ All 20 methods implemented in \`connector_impl.go\` | existing http tests pass clean |
| **gRPC server dispatches through Connector** | ✅ CancelAgent now goes through Connector.CancelRun | +1 dispatch-through-connector test |
| **MCP server (stdio)** | ✅ Full 20-tool surface + streaming via notifications | +8 mcp/server_test.go tests |
| **\`loomcycle mcp\` subcommand + wrapper** | ✅ Subcommand dispatch + \`loomcycle-mcp.sh\` env-loading wrapper | manual smoke test verified |

## Operator integration recipe (CORRECTED)

**Claude Code's MCP discovery only honors specific sources.** The accepted ones:
- \`~/.claude.json\` (via \`claude mcp add\`)
- Project-root \`.mcp.json\`
- Plugin manifests

\`~/.claude/mcp.json\` is **NOT** a discovered location — earlier drafts of this PR incorrectly recommended it. The correct shape is:

\`\`\`json
// .mcp.json at the project root (or wherever your team's config lives)
{
  \"mcpServers\": {
    \"loomcycle\": {
      \"command\": \"/Users/denn/work/loomcycle/loomcycle-mcp.sh\"
    }
  }
}
\`\`\`

Or via \`claude mcp add loomcycle /path/to/loomcycle-mcp.sh\` (writes to \`~/.claude.json\`).

The wrapper script (\`loomcycle-mcp.sh\` at the repo root, committed in this PR) sources \`.env.local\` before exec so the binary inherits the project-specific keys (BRAVE_API_KEY, LOOMCYCLE_JOBS_SEARCH_API_TOKEN, etc.) that \`loomcycle.yaml\`'s \`${...}\` placeholders expect.

## Sharp edges to know about

| Edge | Why | Mitigation in v0.8.15 | Fix in v0.8.16 |
|---|---|---|---|
| **Boot-time upstream MCP init blocks stdio readiness** | The pool aggregator holds back stdio responses until every declared upstream handshakes. With exponential backoff (~32s budget per upstream), Claude Code's MCP timeout fires before loomcycle replies if any upstream wedges. | The wrapper script sources \`.env.local\` so upstreams succeed quickly. | Make upstream MCP init non-blocking when running as \`mcp\` subcommand, or add \`--skip-upstream-mcp\` flag. |
| **HTTP listener binds 127.0.0.1:8787 in \`mcp\` mode** | The subcommand starts BOTH the HTTP listener AND the MCP stdio loop. Operators running the \`loomcycle.sh\` daemon AND having Claude Code spawn \`loomcycle mcp\` simultaneously will collide on the port. | Run one or the other, not both. | Add \`LOOMCYCLE_HTTP_DISABLE=1\` / \`--no-http\` for pure-stdio mode. |
| **Upstream MCP tools don't bubble up to the parent client** | This is intended behavior, not a bug. loomcycle exposes 20 meta-tools (spawn_run, register_agent, memory, etc.); the upstream brave-search / jobs / etc. are for agents running INSIDE loomcycle to call, not for the parent orchestrator. | None needed — operator just needs to know what they'll see in Claude Code's tool list. | n/a |

## 7 commits, ~3000 LOC

| Commit | Phase | LOC |
|---|---|---|
| \`7108c87\` | 2+3: \`internal/connector/\` + \`dynamic_agents\` storage | 633 |
| \`df564fc\` | 4: HTTP server implements Connector + dynamic-agent fallback in RunOnce | 617 |
| \`43862d6\` | gofmt struct alignment | 44 |
| \`c7438cf\` | 5: gRPC server holds Connector field; CancelAgent dispatches through it | 187 |
| \`f28a2ef\` | 6: \`internal/api/mcp/\` server + handlers + tests | 1546 |
| \`b3474f9\` | 7: \`loomcycle mcp\` subcommand in main.go + PrintHelp | 64 |
| \`ca3f55f\` | \`loomcycle-mcp.sh\` wrapper for MCP-client env-loading | 44 |

## Key architectural decisions

1. **\`Connector\` is the single contract.** HTTP server is the canonical implementation; MCP, gRPC, future CLI all CONSUME it via direct method dispatch (no HTTP round-trips).

2. **MCP server streaming via notifications.** When the client opts in via \`initialize.capabilities.loomcycle.runEvents=true\`, spawn_run dispatches through Runner.RunOnce directly and emits \`notifications/loomcycle/run_event\` per provider event. Non-opt-in clients get the blocking-only path. Both produce identical final \`SpawnRunResult\` shape.

3. **Pause/Resume/Snapshot mocked.** All 8 methods are implemented as stubs returning \`FeatureStatus: \"preview\"\`. Wire shape is stable so v0.8.16+ real impls swap in behind the same Connector signatures without breaking changes.

4. **Dynamic agents = DB-persisted with TTL.** New \`dynamic_agents\` table (SQLite + Postgres migration 0010). Privileged tools (Bash/Write/Edit) stripped unless \`LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1\`. Collisions with static (yaml) agents are rejected. TTL sweeper runs in both default and \`mcp\` modes.

## Verification

- ✅ \`go build ./...\` clean
- ✅ \`go test -race ./...\` clean across all 41 packages
- ✅ \`gofmt -l .\` clean (only files I touched)
- ✅ Compile-time interface assertion: \`var _ connector.Connector = (*Server)(nil)\` in \`connector_impl.go\` prevents drift
- ✅ MCP server unit tests cover handshake, tools/list (20 tools), spawn_run blocking + streaming, register_agent dispatch, unknown tool, pause_runtime mock shape, concurrent tools/call (sequential dispatch)
- ✅ gRPC regression test: \`TestGrpcServer_CancelAgent_DispatchesThroughConnector\` proves the new dispatch path
- ✅ **Manual smoke test (2026-05-14)**: \`loomcycle mcp\` via \`loomcycle-mcp.sh\` wrapper, connected to Claude Code via project-root \`.mcp.json\`, upstream MCP servers converge (brave-search 1/2, jobs 17/17), 20 native tools registered, \`pause_runtime\` returns preview shape correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)