### PR TITLE
fix(v0.8.15.1): skip eager upstream MCP init in mcp mode

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -481,21 +481,36 @@ func main() {
 	// on first request), the first handshake attempt may fail with
 	// ECONNREFUSED or a 404. GetWithRetry backs off (500ms, 1s, 2s, 4s,
 	// 8s, 16s) until success or ctx exhaustion. Each retry logs.
-	mcpInitCtx, mcpInitCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	for name, srv := range cfg.MCPServers {
-		_, descs, err := mcpPool.GetWithRetry(mcpInitCtx, name, log.Printf)
-		if err != nil {
-			log.Printf("mcp[%s]: skipped — %v", name, err)
-			continue
+	//
+	// v0.8.15.1: skip the eager init entirely in `loomcycle mcp` mode.
+	// The consumer (Claude Code, custom MCP orchestrator) expects the
+	// stdio JSON-RPC loop to answer initialize / tools/list within
+	// its short discovery timeout — well under the ~32s exponential-
+	// backoff budget GetWithRetry can spend per unreachable upstream.
+	// The lazy resolver wired below handles "server wasn't in pool at
+	// boot" cleanly since v0.8.1; the first agent call that needs an
+	// mcp__<server>__<tool> tool triggers the handshake there. Server
+	// mode keeps eager init — fail-fast is correct when the operator
+	// is starting a long-lived daemon.
+	if mcpMode {
+		log.Printf("mcp mode: skipping eager upstream MCP init for %d server(s); lazy resolver will handshake on first agent call", len(cfg.MCPServers))
+	} else {
+		mcpInitCtx, mcpInitCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		for name, srv := range cfg.MCPServers {
+			_, descs, err := mcpPool.GetWithRetry(mcpInitCtx, name, log.Printf)
+			if err != nil {
+				log.Printf("mcp[%s]: skipped — %v", name, err)
+				continue
+			}
+			filtered := applyAllowedToolsFilter(descs, srv.AllowedTools)
+			for _, d := range filtered {
+				allTools = append(allTools, mcp.NewTool(mcpPool, name, d))
+			}
+			log.Printf("mcp[%s]: ready, %d/%d tools registered (transport=%s)",
+				name, len(filtered), len(descs), srv.Transport)
 		}
-		filtered := applyAllowedToolsFilter(descs, srv.AllowedTools)
-		for _, d := range filtered {
-			allTools = append(allTools, mcp.NewTool(mcpPool, name, d))
-		}
-		log.Printf("mcp[%s]: ready, %d/%d tools registered (transport=%s)",
-			name, len(filtered), len(descs), srv.Transport)
+		mcpInitCancel()
 	}
-	mcpInitCancel()
 
 	// Lazy MCP recovery — when an agent calls a tool from a server that
 	// failed initial handshake (skipped above), this resolver tries one


### PR DESCRIPTION
## Status

**PR 1 of 3** for the v0.8.15.x sharp-edge follow-ups. Smallest and most operationally urgent — fixes the issue where \`loomcycle mcp\` hangs at boot for ~32s if any upstream MCP server is misconfigured, blocking Claude Code's MCP discovery.

## Problem

The boot-time MCP pool init loop in \`cmd/loomcycle/main.go\` calls \`GetWithRetry\` on every configured upstream MCP server before answering any JSON-RPC frame on stdio. GetWithRetry's exponential backoff (500ms → 1s → 2s → 4s → 8s → 16s = ~32s per unreachable upstream) routinely exceeds Claude Code's MCP tool-discovery timeout if ANY upstream is misconfigured.

Surfaced during the v0.8.15 smoke test — operators had to either run \`loomcycle-mcp.sh\` (which sources \`.env.local\` so upstream keys resolve fast) or ensure every upstream key was already in the environment Claude Code spawns from.

## Fix

Wrap the boot-time loop in \`if !mcpMode { ... }\`. In \`mcp\` mode, skip eager init entirely; the lazy resolver (\`internal/tools/mcp/lazy.go\`, production-validated since v0.8.1) handles handshakes on the first agent call that needs each server. Server mode (long-lived daemon) keeps eager init — fail-fast is correct when starting a daemon.

12 lines net change: a guard + a log line + re-indenting the existing body.

## Verification

Tested locally with the operator's real config (2 upstreams — brave-search + jobs — neither pre-configured with env keys):

| Mode | Boot time before \`initialize\` response | Behavior |
|---|---|---|
| pre-fix \`loomcycle mcp\` | **~32s** | stdio blocked on upstream retries |
| **post-fix \`loomcycle mcp\`** | **<100ms** | stdio answers immediately; new log: \"mcp mode: skipping eager upstream MCP init for 2 server(s); lazy resolver will handshake on first agent call\" |
| \`loomcycle --config Y\` (server mode) | unchanged | Eager init runs as before; \"mcp[brave-search]: handshake failed (attempt 1)\" log still appears, confirming the guard is conditional |

## Decision recap (per RFC at \`~/work/loomcycle-internal/doc-internal/rfcs/v0.8.15.x-sharp-edges.md\`)

**A1: Automatic in mcp mode, no flag, no env var.** Eager init in server mode is correct (fail-fast). In mcp mode the only consumer is an MCP orchestrator that needs the stdio loop responsive immediately — no operator would want blocking behavior there. Automatic = zero upgrade friction.

**A2: Skip ALL upstreams (not just failing ones).** The lazy resolver handles \"server wasn't in pool at boot\" cleanly since v0.8.1. Partial eager init adds complexity for no gain.

## Not in this PR

- \`--no-http\` flag (PR 2 / v0.8.15.2)
- HTTP MCP transport (PR 3 / v0.8.15.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)