### PR TITLE
feat(v0.8.15.2): --no-http flag for daemon+mcp coexistence

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -196,7 +196,28 @@ func main() {
 
 	cfgPath := flag.String("config", "loomcycle.yaml", "path to config YAML")
 	showVersion := flag.Bool("version", false, "print build identifier and exit")
+	// v0.8.15.2: suppress the HTTP listener. Useful when the daemon
+	// (`loomcycle.sh`, binds 127.0.0.1:8787 by default) is already
+	// running on the same host AND Claude Code spawns `loomcycle mcp`
+	// alongside it. Without --no-http the mcp subcommand collides on
+	// the port. Only honoured in mcp mode — in server mode it warns
+	// and starts HTTP normally so CI scripts conditionally passing the
+	// flag don't hard-fail.
+	noHTTP := flag.Bool("no-http", false, "suppress the HTTP listener (only honoured in `mcp` subcommand mode)")
 	flag.Parse()
+
+	// Resolve --no-http: takes effect only when mcpMode is true. In
+	// server mode the flag is ignored with a visible warning per RFC
+	// decision B2 — silently dropping it would be confusing; failing
+	// hard would break CI scripts that pass the flag conditionally.
+	skipHTTP := false
+	if *noHTTP {
+		if mcpMode {
+			skipHTTP = true
+		} else {
+			log.Printf("note: --no-http only takes effect in `loomcycle mcp` mode; flag ignored, HTTP listener will start normally")
+		}
+	}
 
 	if *showVersion {
 		fmt.Printf("loomcycle version=%s commit=%s built=%s go=%s\n",
@@ -783,12 +804,21 @@ func main() {
 	go runResolveProbeLoop(bgCtx, resolver, pr, cfg, probeInterval)
 	log.Printf("resolve probe: interval=%s", probeInterval)
 
-	go func() {
-		log.Printf("loomcycle listening on %s", cfg.Env.ListenAddr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("listen: %v", err)
-		}
-	}()
+	if skipHTTP {
+		// v0.8.15.2: --no-http suppresses the HTTP listener. The
+		// httpServer object stays constructed (other subsystems may
+		// hold references for routing internals); we just never call
+		// ListenAndServe. Shutdown below is a no-op on a non-listening
+		// server but we guard it anyway.
+		log.Printf("--no-http: HTTP listener suppressed; %s remains free for other processes", cfg.Env.ListenAddr)
+	} else {
+		go func() {
+			log.Printf("loomcycle listening on %s", cfg.Env.ListenAddr)
+			if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				log.Fatalf("listen: %v", err)
+			}
+		}()
+	}
 
 	// gRPC server. Optional; opt-in via LOOMCYCLE_GRPC_ADDR. Reuses
 	// the same Store + cancel registry as the HTTP server so both
@@ -841,7 +871,9 @@ func main() {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	_ = httpServer.Shutdown(ctx)
+	if !skipHTTP {
+		_ = httpServer.Shutdown(ctx)
+	}
 }
 
 // openStore resolves the operator's storage choice (sqlite default;


### PR DESCRIPTION
## Status

**PR 2 of 3** for the v0.8.15.x sharp-edge follow-ups. Stacks on top of PR #103 (merged). Smaller and quicker than PR 3 (HTTP MCP transport, coming next).

## Problem

\`loomcycle mcp --config Y\` starts BOTH the HTTP listener (127.0.0.1:8787 default) AND the stdio MCP loop. Operators running \`loomcycle.sh\` as a daemon AND having Claude Code spawn \`loomcycle mcp\` simultaneously collide on the port — one of the two fails to start.

## Fix

\`--no-http\` flag suppresses the HTTP listener. Flag only takes effect in \`mcp\` subcommand mode (per RFC decision B2). In server mode, passing the flag logs a visible warning and starts HTTP normally — protects CI scripts that conditionally add the flag.

## Behavior matrix (verified locally)

| Mode | HTTP listener | Log line |
|---|---|---|
| \`loomcycle mcp --no-http\` | **suppressed** | \`--no-http: HTTP listener suppressed; 127.0.0.1:8787 remains free for other processes\` |
| \`loomcycle --no-http\` (server) | starts | \`note: --no-http only takes effect in mcp mode; flag ignored, HTTP listener will start normally\` |
| \`loomcycle mcp\` (no flag) | starts | unchanged (\`loomcycle listening on 127.0.0.1:8787\`) |
| \`loomcycle\` (no flag) | starts | unchanged |

## Coexistence verified

Started \`loomcycle\` as daemon, then ran \`loomcycle mcp --no-http\` alongside — got a valid \`initialize\` response with zero listen errors. The two processes coexist without port collision.

## RFC decisions recap

- **B1**: flag only, no env var (CLAUDE.md \"no new env vars unless necessary\"). \`.mcp.json\` args array threading is clean.
- **B2**: silently warned in server mode (don't break CI scripts passing the flag conditionally).
- **B3**: gRPC unaffected — separate listener at \`LOOMCYCLE_GRPC_ADDR\`, not gated.

## Implementation notes

- \`httpServer\` object stays constructed regardless (subsystems hold internal references for routing); we just never call \`ListenAndServe\`.
- \`Shutdown\` at process exit guarded so we don't call it on a never-listened server.
- 39 LOC net change in one file (\`cmd/loomcycle/main.go\`).

## Not in this PR

- HTTP MCP transport (PR 3, ~440 LOC — the meaty one). I'll start that next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)