### PR TITLE
fix(bench): structural grader extracts JSON from prose; relax low-03 cap

### DIFF
--- a/bench/cases/low/03-multi-turn-search-and-ingest.yaml
+++ b/bench/cases/low/03-multi-turn-search-and-ingest.yaml
@@ -31,7 +31,7 @@ expected:
   structural:
     schema: |
       {"type":"object","required":["search_count","ingest_count"],"properties":{
-        "search_count":{"type":"integer","minimum":1,"maximum":2},
+        "search_count":{"type":"integer","minimum":1,"maximum":5},
         "ingest_count":{"type":"integer","minimum":1,"maximum":1},
         "first_company":{"type":"string"}
       }}
@@ -39,7 +39,7 @@ expected:
     tool_calls:
       - name: "mcp__brave-search__brave_web_search"
         min_calls: 1
-        max_calls: 2
+        max_calls: 5
       - name: "mcp__jobs__postSearchIngest"
         args_must_include:
           has_body: true

--- a/bench/internal/grader/structural.go
+++ b/bench/internal/grader/structural.go
@@ -95,17 +95,27 @@ func failAxis(reason string) AxisResult {
 //
 // Anything else in the schema is silently ignored — keep the
 // validator small and predictable.
+//
+// Response-text discipline:
+//   - First we strip outer whitespace + leading/trailing ``` fences.
+//   - If the result starts with `{` or `[`, validate it directly.
+//   - Otherwise extract the largest balanced `{...}` / `[...]` block
+//     and validate that. This handles the common "model leads with
+//     prose / 'I have called the tool...' before emitting the JSON"
+//     case — production agents can strip prose, so capability rank
+//     shouldn't fail on it. Cases that REQUIRE bare-JSON output
+//     (e.g., production injection-judge's downstream parser) can use
+//     `must_not_match` regex to flag pre-JSON narration as a separate
+//     structural sub-check.
 func validateJSONAgainstSchema(textBody, schemaJSON string) (bool, string) {
-	// Strip leading/trailing whitespace and optional code fences so the
-	// validator is forgiving about presentation. A case that wants to
-	// REJECT fences should use must_not_match alongside the schema.
 	text := strings.TrimSpace(textBody)
 	text = stripCodeFences(text)
-	if !looksLikeJSON(text) {
-		return false, "final text is not a JSON object/array (first char: " + firstChar(text) + ")"
+	jsonPart, ok := extractJSONBlock(text)
+	if !ok {
+		return false, "no JSON object or array found in response (first char: " + firstChar(text) + ")"
 	}
 	var value any
-	if err := json.Unmarshal([]byte(text), &value); err != nil {
+	if err := json.Unmarshal([]byte(jsonPart), &value); err != nil {
 		return false, "json parse: " + err.Error()
 	}
 	var schema map[string]any
@@ -118,11 +128,73 @@ func validateJSONAgainstSchema(textBody, schemaJSON string) (bool, string) {
 	return true, ""
 }
 
-func looksLikeJSON(s string) bool {
-	s = strings.TrimSpace(s)
-	return strings.HasPrefix(s, "{") || strings.HasPrefix(s, "[")
+// extractJSONBlock finds and returns the largest balanced {...} or
+// [...] substring in s. Returns ("", false) when no balanced block
+// exists.
+//
+// Implementation: walk s with a depth counter, tracking whether we're
+// inside a JSON string (to ignore brace/bracket chars within strings).
+// We seek the FIRST opening brace/bracket, then find its matching
+// close. This is good enough for the bench's use case — cases produce
+// one top-level JSON value preceded/followed by at most narration.
+//
+// Not a full JSON parser; just a balanced-delimiter scanner. The
+// json.Unmarshal call downstream is what enforces well-formedness.
+func extractJSONBlock(s string) (string, bool) {
+	first := -1
+	var open, close byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '{' {
+			first, open, close = i, '{', '}'
+			break
+		}
+		if c == '[' {
+			first, open, close = i, '[', ']'
+			break
+		}
+	}
+	if first < 0 {
+		return "", false
+	}
+	depth := 0
+	inString := false
+	escape := false
+	for i := first; i < len(s); i++ {
+		c := s[i]
+		if escape {
+			escape = false
+			continue
+		}
+		if inString {
+			if c == '\\' {
+				escape = true
+				continue
+			}
+			if c == '"' {
+				inString = false
+			}
+			continue
+		}
+		if c == '"' {
+			inString = true
+			continue
+		}
+		if c == open {
+			depth++
+		} else if c == close {
+			depth--
+			if depth == 0 {
+				return s[first : i+1], true
+			}
+		}
+	}
+	return "", false
 }
 
+// firstChar returns a short description of the leading character for
+// diagnostic messages. Exported (lowercase-helper) for the no-JSON
+// branch of validateJSONAgainstSchema.
 func firstChar(s string) string {
 	s = strings.TrimSpace(s)
 	if s == "" {

--- a/bench/internal/grader/structural_test.go
+++ b/bench/internal/grader/structural_test.go
@@ -117,3 +117,72 @@ func contains(ss []string, sub string) bool {
 	}
 	return false
 }
+
+// TestStructural_ExtractsJSONAfterProse — Sweep #4 surfaced the
+// pattern where models lead with narration like "I have called the
+// tool...\n{...}". The bench should extract the JSON object and
+// validate THAT against the schema, not reject on the first 'I' char.
+//
+// Cases that require bare-JSON output can use must_not_match to
+// flag pre-JSON prose as a separate structural sub-check.
+func TestStructural_ExtractsJSONAfterProse(t *testing.T) {
+	text := `I have called the tool successfully. Here is the result:
+
+{"verdicts": [{"index": 0, "safe": true, "score": 0.0, "reason": "ok"}]}`
+	exp := cases.Structural{
+		Schema: `{"type":"object","required":["verdicts"],"properties":{
+			"verdicts":{"type":"array","items":{"type":"object",
+			"required":["index","safe","score","reason"]}}}}`,
+	}
+	r := Structural(text, exp)
+	if !r.Pass {
+		t.Fatalf("expected pass after extraction; reasons: %v", r.Reasons)
+	}
+}
+
+// TestStructural_ExtractsNestedJSONWithBracesInStrings — verifies
+// the extractor correctly accounts for `{` / `}` inside JSON strings
+// (a regex-based extractor would get this wrong).
+func TestStructural_ExtractsNestedJSONWithBracesInStrings(t *testing.T) {
+	text := `Output below.\n\n{"note": "value with {braces} inside the string", "n": 1}`
+	exp := cases.Structural{
+		Schema: `{"type":"object","required":["note","n"],"properties":{
+			"note":{"type":"string"},"n":{"type":"integer"}}}`,
+	}
+	r := Structural(text, exp)
+	if !r.Pass {
+		t.Fatalf("expected pass; reasons: %v", r.Reasons)
+	}
+}
+
+// TestStructural_BareProseIsStillRejected — when the response has
+// no JSON at all, structural should still fail with a clear message.
+func TestStructural_BareProseIsStillRejected(t *testing.T) {
+	text := "The model decided not to produce a JSON output."
+	exp := cases.Structural{
+		Schema: `{"type":"object","required":["x"]}`,
+	}
+	r := Structural(text, exp)
+	if r.Pass {
+		t.Fatal("expected fail when no JSON block present")
+	}
+	if !contains(r.Reasons, "no JSON object or array found") {
+		t.Errorf("expected diagnostic about missing JSON; got %v", r.Reasons)
+	}
+}
+
+// TestStructural_MustNotMatchStillCatchesPreJSONNarration — cases
+// that need bare-JSON output (e.g., production injection-judge's
+// downstream parser) can use must_not_match to fail on prose-before-
+// JSON even though the schema now extracts and passes.
+func TestStructural_MustNotMatchStillCatchesPreJSONNarration(t *testing.T) {
+	text := "I have called the tool successfully:\n{\"x\": 1}"
+	exp := cases.Structural{
+		MustNotMatch: `(?im)^I have called|^Here is`,
+		Schema:       `{"type":"object","required":["x"]}`,
+	}
+	r := Structural(text, exp)
+	if r.Pass {
+		t.Fatal("expected must_not_match to flag the 'I have called' preamble")
+	}
+}


### PR DESCRIPTION
## Summary

Two bench-strictness fixes uncovered by Sweep #4 (post-MCP-schema rewrite validation, recorded in operator-side research doc). Both are bench-side improvements that affect ~17 of 30 still-failing rows on that sweep — capability gaps that turned out to be the bench grading on formatting, not on actual task performance.

## Why

After Sweep #4 corrected the bench cases against real MCP schemas, all 6 models hit **functional 16/16** — the prior "third-party tool-use weakness" conclusion was 100% bench bug. But structural was still 9-11/16 because:

1. **Issue A** — Sonnet's `mid-04-tool-routing` had SEM=1.00 (perfect content) but structural=FAIL because the response started with "I have called both tools..." before the JSON. The validator required the first non-whitespace char to be `{` or `[`. 17 of 30 still-failing rows were this exact pattern across all models.
2. **Issue B** — `low-03-multi-turn-search-and-ingest` schema capped `search_count: max=2`. All 6 models called `brave_web_search` 3 times (legitimate re-search behavior). Schema rejected legitimate behavior.

## What

**Fix A** — new `extractJSONBlock` helper in `bench/internal/grader/structural.go`:
- Walks the response with a depth counter, tracking JSON-string state (braces in string values don't count toward depth).
- Returns the largest balanced `{...}` / `[...]` substring.
- Falls back to "no JSON found" with a clear diagnostic when truly empty.
- Cases that REQUIRE bare JSON (production injection-judge's downstream parser) can use existing `must_not_match` regex to flag pre-JSON prose as a separate sub-check.

**Fix B** — `low-03-multi-turn-search-and-ingest.yaml`:
- Schema `search_count` max 2 → 5.
- Functional `brave_web_search` max_calls 2 → 5.

## Test plan

- [x] 4 new unit tests in `structural_test.go` covering prose-before-JSON extraction, brace-aware scanner, no-JSON fallback, must_not_match still works for bare-JSON discipline.
- [x] `go test ./bench/...` — all 10 structural tests + suite clean.
- [x] `go test ./...` — full repo, no regressions.
- [ ] Operator: Sweep #5a (haiku + sonnet baseline) — verify both approach CAPABLE on all 16 cases with the strictness fixes applied.

## Impact on prior research

The bench-strictness disclaimer at the end of Sweep #4's section in the operator-side `model-capability-sweeps.md`:

> "Until these are fixed, the cases that universally fail (low-03, low-04, mid-01, mid-04, mid-06) **cannot be interpreted as model capability gaps**."

…is now resolved. Sweep #5 (planned) will produce the first clean cross-family capability signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)