### PR TITLE
fix(ci): gofmt -w on 7 files flagged by main CI

### DIFF
--- a/bench/cmd/lc-bench/judge.go
+++ b/bench/cmd/lc-bench/judge.go
@@ -284,10 +284,10 @@ type consensusJudge struct {
 
 func (c *consensusJudge) Score(ctx context.Context, prompt string) (int, string, error) {
 	type result struct {
-		idx     int
-		score   int
-		notes   string
-		err     error
+		idx   int
+		score int
+		notes string
+		err   error
 	}
 	out := make(chan result, len(c.judges))
 	for i, j := range c.judges {

--- a/bench/internal/cases/cases.go
+++ b/bench/internal/cases/cases.go
@@ -19,7 +19,7 @@ import (
 // no derived state lives here.
 type Case struct {
 	ID           string   `yaml:"id"`
-	Tier         string   `yaml:"tier"`     // "low" | "middle"
+	Tier         string   `yaml:"tier"` // "low" | "middle"
 	Description  string   `yaml:"description"`
 	AllowedTools []string `yaml:"allowed_tools"`
 	MaxTurns     int      `yaml:"max_turns"`

--- a/bench/internal/grader/functional.go
+++ b/bench/internal/grader/functional.go
@@ -14,10 +14,10 @@ import (
 //
 //   - tool name (exact)
 //   - argument shape: args_must_include map with these keys:
-//       "<field>": <value>        — exact field == value
-//       "<field>_contains": substr — field contains substring
-//       "has_<field>": true       — field present, any value
-//       "<field>_is_object": true — field is a non-empty object
+//     "<field>": <value>        — exact field == value
+//     "<field>_contains": substr — field contains substring
+//     "has_<field>": true       — field present, any value
+//     "<field>_is_object": true — field is a non-empty object
 //   - min/max call count for the named tool
 //
 // Plus case-level OrderStrict (calls must appear in declared order)

--- a/bench/internal/grader/grader.go
+++ b/bench/internal/grader/grader.go
@@ -22,8 +22,8 @@ type Result struct {
 // judge's 0..100 rating divided by 100.
 type AxisResult struct {
 	Pass    bool     `json:"pass"`
-	Score   float64  `json:"score"`              // 0..1
-	Reasons []string `json:"reasons,omitempty"`   // human-readable diagnostics
+	Score   float64  `json:"score"`             // 0..1
+	Reasons []string `json:"reasons,omitempty"` // human-readable diagnostics
 }
 
 // Passed reports whether the overall (case, run) is a success — all

--- a/bench/internal/report/report.go
+++ b/bench/internal/report/report.go
@@ -19,15 +19,15 @@ import (
 
 // CaseOutcome is one (provider, model, tier, case) row.
 type CaseOutcome struct {
-	Provider   string         `json:"provider"`
-	Model      string         `json:"model"`
-	Tier       string         `json:"tier"`
-	CaseID     string         `json:"case_id"`
-	Status     string         `json:"status"`     // run status: "completed" | "failed" | "cancelled"
-	Result     grader.Result  `json:"result"`
-	CostUSD    float64        `json:"cost_usd"`
-	DurationMS int64          `json:"duration_ms"`
-	Error      string         `json:"error,omitempty"`
+	Provider   string        `json:"provider"`
+	Model      string        `json:"model"`
+	Tier       string        `json:"tier"`
+	CaseID     string        `json:"case_id"`
+	Status     string        `json:"status"` // run status: "completed" | "failed" | "cancelled"
+	Result     grader.Result `json:"result"`
+	CostUSD    float64       `json:"cost_usd"`
+	DurationMS int64         `json:"duration_ms"`
+	Error      string        `json:"error,omitempty"`
 }
 
 // ModelSummary is the rolled-up verdict for one (provider, model)
@@ -57,10 +57,10 @@ type ModelSummary struct {
 // per-model summaries side by side so consumers can either inspect
 // individual cases or skip to the bottom-line verdict.
 type Matrix struct {
-	GeneratedAt time.Time      `json:"generated_at"`
+	GeneratedAt  time.Time      `json:"generated_at"`
 	BenchVersion string         `json:"bench_version"`
-	Outcomes    []CaseOutcome  `json:"outcomes"`
-	Summaries   []ModelSummary `json:"summaries"`
+	Outcomes     []CaseOutcome  `json:"outcomes"`
+	Summaries    []ModelSummary `json:"summaries"`
 }
 
 // Verdict thresholds (per the plan):
@@ -283,9 +283,9 @@ func writeSpeedRanking(w io.Writer, m Matrix) {
 // produces a working result on this battery".
 func writeCostPerPassRanking(w io.Writer, rows []costPerPassRow) {
 	type costRow struct {
-		s        ModelSummary
-		costPP   float64
-		avgSec   float64
+		s      ModelSummary
+		costPP float64
+		avgSec float64
 	}
 	cr := make([]costRow, 0, len(rows))
 	for _, r := range rows {

--- a/bench/internal/runner/runner.go
+++ b/bench/internal/runner/runner.go
@@ -122,10 +122,10 @@ func (c *Client) Initialize(ctx context.Context) error {
 		JSONRPC string `json:"jsonrpc"`
 		ID      int64  `json:"id"`
 		Result  struct {
-			ProtocolVersion string                 `json:"protocolVersion"`
-			ServerInfo      ServerInfo             `json:"serverInfo"`
-			Capabilities    map[string]any         `json:"capabilities"`
-			Instructions    string                 `json:"instructions,omitempty"`
+			ProtocolVersion string         `json:"protocolVersion"`
+			ServerInfo      ServerInfo     `json:"serverInfo"`
+			Capabilities    map[string]any `json:"capabilities"`
+			Instructions    string         `json:"instructions,omitempty"`
 		} `json:"result"`
 		Error *jsonRPCError `json:"error,omitempty"`
 	}
@@ -281,15 +281,15 @@ func UserTextSegment(text string) PromptSegment {
 // (graded structurally + semantically) and the captured event trace
 // (graded functionally). Status mirrors connector.SpawnRunResult.Status.
 type RunResult struct {
-	AgentID    string         `json:"agent_id"`
-	RunID      string         `json:"run_id"`
-	SessionID  string         `json:"session_id"`
-	Status     string         `json:"status"` // "completed" | "failed" | "cancelled"
-	StopReason string         `json:"stop_reason"`
-	FinalText  string         `json:"final_text"`
-	Usage      *UsageInfo     `json:"usage,omitempty"`
+	AgentID    string          `json:"agent_id"`
+	RunID      string          `json:"run_id"`
+	SessionID  string          `json:"session_id"`
+	Status     string          `json:"status"` // "completed" | "failed" | "cancelled"
+	StopReason string          `json:"stop_reason"`
+	FinalText  string          `json:"final_text"`
+	Usage      *UsageInfo      `json:"usage,omitempty"`
 	Events     []ProviderEvent `json:"events,omitempty"`
-	Error      string         `json:"error,omitempty"`
+	Error      string          `json:"error,omitempty"`
 }
 
 // UsageInfo mirrors providers.Usage on the wire (input/output token

--- a/internal/providers/deepseek/driver_test.go
+++ b/internal/providers/deepseek/driver_test.go
@@ -138,8 +138,9 @@ func TestDriver_CapabilitiesMostlyMatchOpenAI(t *testing.T) {
 
 // TestIsThinkingModel covers the per-model affordance the driver
 // uses internally for thinking-class decisions. Naming convention:
-//   thinking-class: deepseek-v4-pro, deepseek-reasoner, deepseek-r1
-//   non-thinking:   deepseek-chat, deepseek-v4-flash, deepseek-v3.2
+//
+//	thinking-class: deepseek-v4-pro, deepseek-reasoner, deepseek-r1
+//	non-thinking:   deepseek-chat, deepseek-v4-flash, deepseek-v3.2
 func TestIsThinkingModel(t *testing.T) {
 	cases := []struct {
 		model string


### PR DESCRIPTION
## Summary

`gofmt` check started failing on main. Pure cosmetic alignment fixes across 7 files.

## Why now

6 of the 7 files have been carrying the misalignment since PR #106 (initial bench harness, 2026-05-14). CI either wasn't enforcing the check before, or the alignment rules drifted slightly with the Go 1.26 toolchain. The 7th file (`internal/providers/deepseek/driver_test.go`) is from PR #111 where I added the `IsThinkingModel` test fixture table — my alignment mistake.

## Changes

Applied `gofmt -w` on:

- `bench/cmd/lc-bench/judge.go`
- `bench/internal/cases/cases.go`
- `bench/internal/grader/functional.go`
- `bench/internal/grader/grader.go`
- `bench/internal/report/report.go`
- `bench/internal/runner/runner.go`
- `internal/providers/deepseek/driver_test.go`

Diff stats: ~80 LOC of column-shifted alignment. Zero semantic changes — struct tag spacing and doc-comment indentation only.

## Test plan

- [x] `gofmt -l bench/ internal/` returns empty
- [x] `go build ./...` clean
- [x] `go test ./...` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)