### PR TITLE
fix(providers): two review findings on PR #111

### DIFF
--- a/internal/providers/errclass.go
+++ b/internal/providers/errclass.go
@@ -205,10 +205,16 @@ func looksLikeDeprecatedModel(msg string) bool {
 		return false
 	}
 	lower := strings.ToLower(msg)
+	// Each pattern must be specific enough that a non-model 404
+	// (e.g., 404 NOT_FOUND for a missing fine-tune artifact whose
+	// body happens to mention a deprecated API parameter) doesn't
+	// trigger. "model is deprecated" and "model retired" anchor on
+	// the word "model"; "no longer available" / "has been deprecated"
+	// / "update your code" are common enough in retirement messages
+	// across providers but rare in unrelated 404 bodies.
 	return strings.Contains(lower, "no longer available") ||
 		strings.Contains(lower, "has been deprecated") ||
 		strings.Contains(lower, "model is deprecated") ||
 		strings.Contains(lower, "model retired") ||
-		strings.Contains(lower, "is deprecated") ||
 		strings.Contains(lower, "update your code to use")
 }

--- a/internal/providers/errclass_test.go
+++ b/internal/providers/errclass_test.go
@@ -36,6 +36,12 @@ func TestClassifyError_Table(t *testing.T) {
 		// 404 without a retirement marker stays Permanent (typo / wrong
 		// model id). False-negative on deprecation is acceptable UX.
 		{"openai 404 plain", fmt.Errorf("openai 404: not found"), ErrorClassPermanent},
+		// 404 mentioning an unrelated deprecated PARAMETER (not the
+		// model itself) must stay Permanent. The pattern set
+		// deliberately anchors on "model" or "no longer available"
+		// rather than the bare phrase "is deprecated" to avoid this
+		// false-positive (review finding on PR #111).
+		{"openai 404 parameter deprecation note", fmt.Errorf("openai 404: artifact not found; note: parameter X is deprecated, use Y"), ErrorClassPermanent},
 		// Ctx-side outcomes.
 		{"ctx canceled", context.Canceled, ErrorClassCancelled},
 		{"ctx canceled wrapped", fmt.Errorf("call: %w", context.Canceled), ErrorClassCancelled},
@@ -82,6 +88,7 @@ func TestErrorClass_StringIsHumanReadable(t *testing.T) {
 		ErrorClassPermanent:        "permanent",
 		ErrorClassCancelled:        "cancelled",
 		ErrorClassDeadlineExceeded: "deadline_exceeded",
+		ErrorClassDeprecated:       "deprecated",
 	}
 	for cls, want := range cases {
 		if got := cls.String(); got != want {


### PR DESCRIPTION
## Summary

Code review on PR #111 (just merged) surfaced two high-confidence findings. Both addressed here as a follow-up.

## Findings

### 1. `TestErrorClass_StringIsHumanReadable` missing `ErrorClassDeprecated`

The table-driven `String()` test in `internal/providers/errclass_test.go` hardcoded the original five constants. PR #111 added `ErrorClassDeprecated → "deprecated"` but the test wasn't extended. Indirect coverage existed via the `ClassifyError` table; direct coverage of the wire label `"deprecated"` did not.

`EventProviderFallback.Reason` surfaces this string to operators. Without direct test coverage, a future typo or accidental case-removal would silently break the wire label. Reviewer flagged this at 95% confidence.

**Fix**: added `ErrorClassDeprecated: "deprecated"` entry to the test map.

### 2. `looksLikeDeprecatedModel` `"is deprecated"` pattern overly broad

The bare substring `"is deprecated"` matched messages like `"Parameter X is deprecated, use Y"` — common in API lifecycle warnings that might appear in unrelated 404 response bodies (e.g., a 404 for a missing fine-tune artifact whose body carries a deprecation note about an unrelated parameter). False-positive scenario: the resolver silently re-routes instead of surfacing a clean error.

The intended-true-positive case (a model literally said to be deprecated) is already covered by `"model is deprecated"` which anchors on the word "model". The bare pattern added false-positive surface for zero additional true-positive coverage from observed exemplars. Reviewer flagged at 85% confidence.

**Fix**: removed the `"is deprecated"` line. Updated docstring to explain why patterns must anchor on "model" or provider-retirement-specific phrases. Added test fixture asserting that a parameter-deprecation note in a 404 body still classifies as `ErrorClassPermanent`.

## Test plan

- [x] `go test ./internal/providers/...` — clean, including the new false-positive guard and the new String-test entry
- [x] `go test ./...` — clean across the repo
- [x] All 5 retained deprecation patterns still match their intended exemplars (gemini retirement, anthropic "has been deprecated", openai "retired", "update your code to use", "model is deprecated")

LOC: +14 / -1 (2 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)