### PR TITLE
fix(store): persist resolved model at CreateRun — UI shows it mid-flight

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -755,7 +755,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -1400,7 +1400,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier}
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier, Model: model}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -1739,6 +1739,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AgentID:  agentID,
 		UserID:   sess.UserID,
 		UserTier: body.UserTier,
+		Model:    model,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -2224,6 +2225,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		UserID:     parentIdentity.UserID,
 		UserTier:   parentIdentity.UserTier, // v0.8.2: same user_tier across the sub-run tree
 		AgentDefID: defID,                   // v0.8.5: pin defID on the sub-run for evaluation denormalisation
+		Model:      model,                   // resolved model — written at create so the UI sees it during the run
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "", parentIdentity.UserID, subIdentity)
 	if err != nil {

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -192,8 +192,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	if _, err := s.pool.Exec(ctx,
 		`INSERT INTO runs (
 			id, session_id, status, started_at,
-			agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+			agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		id, sessionID, string(store.RunRunning), now,
 		nullableText(identity.AgentID),
 		nullableText(identity.ParentAgentID),
@@ -201,6 +201,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nullableText(identity.UserID),
 		nullableText(identity.UserTier),
 		nullableText(identity.AgentDefID),
+		nullableText(identity.Model),
 	); err != nil {
 		return store.Run{}, fmt.Errorf("create run: %w", err)
 	}
@@ -215,6 +216,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		UserID:        identity.UserID,
 		UserTier:      identity.UserTier,
 		AgentDefID:    identity.AgentDefID,
+		Model:         identity.Model,
 	}, nil
 }
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -402,8 +402,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	id := newID("r_")
 	now := time.Now()
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
@@ -411,6 +411,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nilIfEmpty(identity.UserID),
 		nilIfEmpty(identity.UserTier),
 		nilIfEmpty(identity.AgentDefID),
+		nilIfEmpty(identity.Model),
 	)
 	if err != nil {
 		return store.Run{}, err
@@ -426,6 +427,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		UserID:        identity.UserID,
 		UserTier:      identity.UserTier,
 		AgentDefID:    identity.AgentDefID,
+		Model:         identity.Model,
 	}, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -257,6 +257,14 @@ type RunIdentity struct {
 	// runs.agent_def_id so the Evaluation tool can denormalise it
 	// into evaluations.def_id at submit time.
 	AgentDefID string
+	// Model is the resolved (provider, model) decision applied at
+	// run creation — written to runs.model immediately so the row is
+	// queryable mid-flight, not just after FinishRun. Empty = unknown
+	// at creation time (back-compat with callers that haven't been
+	// updated yet). FinishRun overwrites this with the final model
+	// recorded by the loop, which may differ if cross-provider
+	// fallback fired mid-run.
+	Model string
 }
 
 // UserSummary is one row of ListUsers' output: distinct user_id with

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -58,6 +58,8 @@ func Run(t *testing.T, factory Factory) {
 		{"GetTranscriptEmpty", testGetTranscriptEmpty},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
+		{"CreateRunModelVisibleMidFlight", testCreateRunModelVisibleMidFlight},
+		{"CreateRunModelEmptyStaysEmpty", testCreateRunModelEmptyStaysEmpty},
 		{"GetRunByAgentIDNotFound", testGetRunByAgentIDNotFound},
 		{"GetRunByAgentIDReturnsMostRecent", testGetRunByAgentIDReturnsMostRecent},
 		{"ListActiveRunsByUser", testListActiveRunsByUser},
@@ -326,6 +328,67 @@ func testCreateRunIdentityRoundTrip(t *testing.T, s store.Store) {
 	}
 	if got.AgentID != "a_top" || got.UserID != "user-1" {
 		t.Errorf("identity not preserved through GetRunByAgentID: %+v", got)
+	}
+}
+
+// testCreateRunModelVisibleMidFlight pins the v0.8.x contract added
+// after the Web UI started showing "—" for the model column on every
+// running run: CreateRun must persist RunIdentity.Model so a SELECT
+// against the row returns the resolved model BEFORE FinishRun. The
+// previous shape (model written only at FinishRun) made the running
+// UI useless for diagnosing tier resolution mid-flight.
+func testCreateRunModelVisibleMidFlight(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_midflight",
+		UserID:  "user-1",
+		Model:   "claude-sonnet-4-6",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Model != "claude-sonnet-4-6" {
+		t.Errorf("CreateRun returned Model=%q; want claude-sonnet-4-6", run.Model)
+	}
+
+	// Critical: read back BEFORE FinishRun. The bug shape this guards
+	// against is a backend that accepts Model on the struct but doesn't
+	// write it to the row until FinishRun.
+	got, err := s.GetRunByAgentID(ctx, "a_midflight")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != store.RunRunning {
+		t.Fatalf("expected status=running before FinishRun, got %q", got.Status)
+	}
+	if got.Model != "claude-sonnet-4-6" {
+		t.Errorf("GetRunByAgentID returned Model=%q on a still-running row; want claude-sonnet-4-6", got.Model)
+	}
+}
+
+// testCreateRunModelEmptyStaysEmpty: a CreateRun without Model must
+// leave the column unset (NULL / empty). Back-compat with older
+// callers and with sub-agent paths where the model is filled in later.
+func testCreateRunModelEmptyStaysEmpty(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_nomodel",
+		UserID:  "user-1",
+		// Model deliberately empty
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Model != "" {
+		t.Errorf("CreateRun returned Model=%q on empty input; want empty", run.Model)
+	}
+	got, _ := s.GetRunByAgentID(ctx, "a_nomodel")
+	if got.Model != "" {
+		t.Errorf("read-back Model=%q on empty input; want empty", got.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Persists the resolver-decided model into `runs.model` at **CreateRun** instead of only at FinishRun, so the column is non-null on running rows.
- Fixes the Web UI showing `—` for the model column on every in-flight run (it reads `usage.model`, which mirrors `runs.model`).
- 5 files, +83 / -6 lines. No wire-protocol change. No new env vars.

## Why

The model is fully known at run creation: `resolveAgent` / `resolveAgentDef` returns `(providerID, model, effort)` several lines before `CreateRun` runs. But `RunIdentity` had no `Model` field, so the column was inserted as `NULL` and only got filled in by `FinishRun`'s final UPDATE. Net effect: the Web UI's runs list was useless for diagnosing tier resolution at exactly the moment operators most needed it — \"what's it running on right now?\".

## What changed

- **`internal/store/store.go`** — `RunIdentity.Model string`. Zero-value preserves pre-v0.8.x shape for callers that haven't been updated.
- **`internal/store/sqlite/sqlite.go`** + **`internal/store/postgres/postgres.go`** — `CreateRun` INSERT extended with the new column. Both adapters mirrored.
- **`internal/api/http/server.go`** — all four `RunIdentity` construction sites pass the resolved model:
  - `RunOnce` (the agent-runner entry)
  - `handleRuns` (POST `/v1/runs`)
  - `handleMessages` (continuation on existing session)
  - `runSubAgent` (Agent tool spawn — sub-agents now also show their model)

FinishRun is unchanged; it continues to overwrite `Model` with the loop's final `EventUsage.Model`, so mid-run cross-provider fallback is reflected at completion. Mid-flight display is the *initial* resolution, not the *live* one — that's acceptable for v0.8.x because cross-provider fallback is the exceptional path. If the operator wants live updates through fallback, that's a follow-up (extra UPDATE in `tryProviderFallback`).

## Tests

Two new cases in the cross-backend `storetest` contract suite (so they exercise both sqlite and postgres):

| Test | Asserts |
|---|---|
| `CreateRunModelVisibleMidFlight` | `GetRunByAgentID` returns the supplied `Model` BEFORE `FinishRun`, on a `status=running` row. This is the load-bearing assertion: the bug shape (Model in struct but not in row until completion) would fail this. |
| `CreateRunModelEmptyStaysEmpty` | Back-compat — empty `Model` in stays empty out. |

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` clean across all packages (sqlite + postgres backends both green on the new cases)
- [x] Confirmed the bug shape: reverted the sqlite UPDATE adding `model` to the INSERT — `CreateRunModelVisibleMidFlight` goes red. Reverted.
- [ ] **Live verify after merge**: trigger a long-running agent (`employer-profiler`), refresh the Web UI runs list mid-flight, confirm the model column shows the resolved value (e.g. `deepseek-v4-pro`) instead of `—`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)