### PR TITLE
feat(store): add interrupts table + 8 Store methods (PR 1/5 of v0.8.16 Interruption tool)

### DIFF
--- a/internal/store/postgres/migrations/0011_interrupts.down.sql
+++ b/internal/store/postgres/migrations/0011_interrupts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS interrupts;

--- a/internal/store/postgres/migrations/0011_interrupts.up.sql
+++ b/internal/store/postgres/migrations/0011_interrupts.up.sql
@@ -1,0 +1,54 @@
+-- 0011_interrupts.up.sql — v0.8.16 Interruption tool.
+--
+-- Agents call Interruption.ask / .notify / .cancel; pending rows
+-- block the run until resolved by a human (via Web UI), an external
+-- MCP-server delivery surface, or a timeout / cancel. The kind column
+-- is the closed-enum future-proofing for v0.9.x pause / wait_until /
+-- approval — v0.8.16 writes only kind='question'.
+--
+-- user_id / agent_id / agent_name are denormalised from the run row
+-- at create time (NOT joined on read) so the GET /v1/users/{id}/
+-- interrupts listing query never needs a JOIN against runs. Same
+-- denormalisation pattern as runs.user_id and channel_messages.run_id.
+--
+-- NO foreign key on run_id: interrupts must survive any future run
+-- pruning, same reasoning as evaluations. Referential integrity is
+-- enforced at the application layer (InterruptCreate validates the
+-- run exists before inserting). RESTRICT FK would block legitimate
+-- admin pruning; CASCADE would silently delete audit data.
+--
+-- answer_meta is the kind-discriminated structured-response slot:
+-- v0.8.16 question writes either NULL or empty JSON; future approval
+-- writes {approved: bool, reason?: string}. The agent-visible result
+-- is the scalar `answer` field — `answer_meta` is for the resolver's
+-- structured payload that doesn't fit a single string.
+
+CREATE TABLE interrupts (
+    interrupt_id    TEXT             PRIMARY KEY,
+    run_id          TEXT             NOT NULL,
+    kind            TEXT             NOT NULL DEFAULT 'question',
+    status          TEXT             NOT NULL DEFAULT 'pending',
+    question        TEXT,
+    options         JSONB,
+    context_data    TEXT,
+    priority        TEXT             NOT NULL DEFAULT 'normal',
+    answer          TEXT,
+    answer_meta     JSONB,
+    created_at      TIMESTAMPTZ      NOT NULL,
+    expires_at      TIMESTAMPTZ,
+    resolved_at     TIMESTAMPTZ,
+    resolved_by     TEXT,
+    user_id         TEXT,
+    agent_id        TEXT,
+    agent_name      TEXT
+);
+
+-- Primary access patterns:
+--   1. "Is this run blocked on a pending interrupt?"  → (run_id, status)
+--   2. "What does this user need to answer?"          → (user_id, status)
+--   3. "Sweeper: what timeouts have fired?"           → (expires_at, status)
+
+CREATE INDEX interrupts_by_run_status  ON interrupts(run_id, status);
+CREATE INDEX interrupts_by_user_status ON interrupts(user_id, status) WHERE user_id IS NOT NULL;
+CREATE INDEX interrupts_by_expires     ON interrupts(expires_at)
+    WHERE expires_at IS NOT NULL AND status = 'pending';

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -757,6 +757,299 @@ func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
 	return int(tag.RowsAffected()), nil
 }
 
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// nullableTimePtr returns a *time.Time pointing at t when non-zero,
+// nil otherwise. Postgres expires_at / resolved_at are nullable
+// TIMESTAMPTZ; pgx writes SQL NULL on nil pointers.
+func nullableTimePtr(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+
+// nullableStringArg returns the string when non-empty, nil otherwise
+// (writes SQL NULL via pgx).
+func nullableStringArg(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// nullableJSONArg returns the raw JSON as a string when non-empty,
+// nil otherwise. Postgres column type is JSONB; pgx-side we send TEXT
+// + cast via the ::jsonb in the INSERT/UPDATE query.
+func nullableJSONArg(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return string(b)
+}
+
+func (s *Store) InterruptCreate(ctx context.Context, r store.InterruptRow) (string, error) {
+	if r.InterruptID == "" {
+		return "", fmt.Errorf("interrupts: interrupt_id required")
+	}
+	if r.RunID == "" {
+		return "", fmt.Errorf("interrupts: run_id required")
+	}
+	if r.Kind == "" {
+		r.Kind = store.InterruptKindQuestion
+	}
+	if r.Status == "" {
+		r.Status = store.InterruptStatusPending
+	}
+	if r.Priority == "" {
+		r.Priority = store.InterruptPriorityNormal
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO interrupts (
+			interrupt_id, run_id, kind, status,
+			question, options, context_data, priority,
+			answer, answer_meta,
+			created_at, expires_at, resolved_at, resolved_by,
+			user_id, agent_id, agent_name
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6::jsonb, $7, $8,
+			$9, $10::jsonb,
+			$11, $12, NULL, $13,
+			$14, $15, $16
+		)
+	`,
+		r.InterruptID, r.RunID, r.Kind, r.Status,
+		nullableStringArg(r.Question), nullableJSONArg(r.Options), nullableStringArg(r.ContextData), r.Priority,
+		nullableStringArg(r.Answer), nullableJSONArg(r.AnswerMeta),
+		createdAt, nullableTimePtr(r.ExpiresAt), nullableStringArg(r.ResolvedBy),
+		nullableStringArg(r.UserID), nullableStringArg(r.AgentID), nullableStringArg(r.AgentName),
+	)
+	if err != nil {
+		return "", fmt.Errorf("interrupts: create: %w", err)
+	}
+	return r.InterruptID, nil
+}
+
+func (s *Store) InterruptGet(ctx context.Context, interruptID string) (store.InterruptRow, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options::text, context_data, priority,
+		       answer, answer_meta::text,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE interrupt_id = $1
+	`, interruptID)
+	r, err := s.scanInterruptRow(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.InterruptRow{}, &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+	}
+	if err != nil {
+		return store.InterruptRow{}, fmt.Errorf("interrupts: get: %w", err)
+	}
+	return r, nil
+}
+
+// pgRowScanner abstracts pgx.Row / pgx.Rows for scanInterruptRow.
+type pgRowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (s *Store) scanInterruptRow(row pgRowScanner) (store.InterruptRow, error) {
+	var r store.InterruptRow
+	var question, options, contextData, answer, answerMeta, resolvedBy, userID, agentID, agentName *string
+	var expiresAt, resolvedAt *time.Time
+	if err := row.Scan(
+		&r.InterruptID, &r.RunID, &r.Kind, &r.Status,
+		&question, &options, &contextData, &r.Priority,
+		&answer, &answerMeta,
+		&r.CreatedAt, &expiresAt, &resolvedAt, &resolvedBy,
+		&userID, &agentID, &agentName,
+	); err != nil {
+		return store.InterruptRow{}, err
+	}
+	if question != nil {
+		r.Question = *question
+	}
+	if contextData != nil {
+		r.ContextData = *contextData
+	}
+	if answer != nil {
+		r.Answer = *answer
+	}
+	if resolvedBy != nil {
+		r.ResolvedBy = *resolvedBy
+	}
+	if userID != nil {
+		r.UserID = *userID
+	}
+	if agentID != nil {
+		r.AgentID = *agentID
+	}
+	if agentName != nil {
+		r.AgentName = *agentName
+	}
+	if options != nil && *options != "" {
+		r.Options = json.RawMessage(*options)
+	}
+	if answerMeta != nil && *answerMeta != "" {
+		r.AnswerMeta = json.RawMessage(*answerMeta)
+	}
+	if expiresAt != nil {
+		r.ExpiresAt = *expiresAt
+	}
+	if resolvedAt != nil {
+		r.ResolvedAt = *resolvedAt
+	}
+	return r, nil
+}
+
+func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    answer      = $2,
+		    answer_meta = $3::jsonb,
+		    resolved_at = $4,
+		    resolved_by = $5
+		WHERE interrupt_id = $6 AND status = $7
+	`,
+		store.InterruptStatusResolved,
+		answer, nullableJSONArg(answerMeta),
+		time.Now(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: resolve: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var existing string
+		err := s.pool.QueryRow(ctx, `SELECT status FROM interrupts WHERE interrupt_id = $1`, interruptID).Scan(&existing)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: resolve probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
+	switch status {
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+		// ok
+	default:
+		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    resolved_at = $2,
+		    resolved_by = $3
+		WHERE interrupt_id = $4 AND status = $5
+	`,
+		status,
+		time.Now(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: finish: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var existing string
+		err := s.pool.QueryRow(ctx, `SELECT status FROM interrupts WHERE interrupt_id = $1`, interruptID).Scan(&existing)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: finish probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "run_id", runID, statusFilter)
+}
+
+func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "user_id", userID, statusFilter)
+}
+
+func (s *Store) interruptList(ctx context.Context, col, val, statusFilter string) ([]store.InterruptRow, error) {
+	if col != "run_id" && col != "user_id" {
+		return nil, fmt.Errorf("interrupts: list: unknown filter column %q", col)
+	}
+	q := `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options::text, context_data, priority,
+		       answer, answer_meta::text,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE ` + col + ` = $1`
+	args := []any{val}
+	if statusFilter != "" {
+		q += ` AND status = $2`
+		args = append(args, statusFilter)
+	}
+	q += ` ORDER BY created_at DESC LIMIT 200`
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := s.scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) InterruptCountPendingByRun(ctx context.Context, runID string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM interrupts WHERE run_id = $1 AND status = $2
+	`, runID, store.InterruptStatusPending).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: count pending: %w", err)
+	}
+	return n, nil
+}
+
+func (s *Store) InterruptSweepExpired(ctx context.Context) (int, error) {
+	now := time.Now()
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    resolved_at = $2,
+		    resolved_by = $3
+		WHERE status = $4 AND expires_at IS NOT NULL AND expires_at < $5
+	`,
+		store.InterruptStatusTimedOut,
+		now, store.InterruptResolvedByTimeout,
+		store.InterruptStatusPending, now,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: sweep: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Close releases the connection pool. Idempotent.
 func (s *Store) Close() error {
 	s.closeOnce.Do(func() {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -244,6 +244,34 @@ func (s *Store) migrate(ctx context.Context) error {
 			expires_at  INTEGER NOT NULL DEFAULT 0,
 			description TEXT
 		)`,
+		// v0.8.16 Interruption tool. Agents call Interruption.ask /
+		// .notify / .cancel; pending rows block the run until resolved.
+		// kind is the closed-enum future-proofing for v0.9.x pause /
+		// wait_until / approval — v0.8.16 writes only kind='question'.
+		// user_id / agent_id / agent_name denormalised from the run
+		// row so listing queries never need a JOIN. Timestamps as
+		// INTEGER (unix-nano) per existing sqlite pattern. No FK on
+		// run_id (same reasoning as evaluations — immutable audit log
+		// must survive any future run pruning).
+		`CREATE TABLE IF NOT EXISTS interrupts (
+			interrupt_id    TEXT    PRIMARY KEY,
+			run_id          TEXT    NOT NULL,
+			kind            TEXT    NOT NULL DEFAULT 'question',
+			status          TEXT    NOT NULL DEFAULT 'pending',
+			question        TEXT,
+			options         TEXT,
+			context_data    TEXT,
+			priority        TEXT    NOT NULL DEFAULT 'normal',
+			answer          TEXT,
+			answer_meta     TEXT,
+			created_at      INTEGER NOT NULL,
+			expires_at      INTEGER,
+			resolved_at     INTEGER,
+			resolved_by     TEXT,
+			user_id         TEXT,
+			agent_id        TEXT,
+			agent_name      TEXT
+		)`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -320,6 +348,17 @@ func (s *Store) migrate(ctx context.Context) error {
 		// (DELETE WHERE expires_at < now() AND expires_at > 0) and the
 		// per-Get expiry filter. Partial: only TTL-bearing rows.
 		`CREATE INDEX IF NOT EXISTS dynamic_agents_by_expires_at ON dynamic_agents(expires_at) WHERE expires_at > 0`,
+		// v0.8.16 Interruption tool indexes.
+		//   * by_run_status drives "is this run blocked?" + listing.
+		//   * by_user_status drives the Web UI inbox view (the
+		//     denormalised user_id column makes this a single-table
+		//     scan, no JOIN against runs).
+		//   * by_expires_pending drives the timeout sweeper.
+		// Partial on by_user / by_expires so the index stays small
+		// when the bulk of rows are resolved/terminal.
+		`CREATE INDEX IF NOT EXISTS interrupts_by_run_status  ON interrupts(run_id, status)`,
+		`CREATE INDEX IF NOT EXISTS interrupts_by_user_status ON interrupts(user_id, status) WHERE user_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS interrupts_by_expires     ON interrupts(expires_at) WHERE expires_at IS NOT NULL AND status = 'pending'`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -2246,6 +2285,332 @@ func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
 	`, time.Now().UnixNano())
 	if err != nil {
 		return 0, fmt.Errorf("dynamic_agents: sweep: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// nanosOrNull returns NULL when t is zero, unix-nanos otherwise. The
+// zero-time → NULL contract is documented on InterruptRow.ExpiresAt.
+func nanosOrNull(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UnixNano()
+}
+
+// nullableNanos scans an INTEGER-or-NULL column into a time. NULL
+// becomes time.Time{} (zero value).
+func nullableNanos(ns sql.NullInt64) time.Time {
+	if !ns.Valid || ns.Int64 == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns.Int64)
+}
+
+// nullableString scans a TEXT-or-NULL column into a string. NULL
+// becomes "" — matches how the upper layer treats absent values.
+func nullableString(ns sql.NullString) string {
+	if !ns.Valid {
+		return ""
+	}
+	return ns.String
+}
+
+// nullableRawJSON scans a TEXT-or-NULL column holding JSON. NULL
+// returns nil, not the JSON null literal; callers distinguish via
+// `len(...) == 0`.
+func nullableRawJSON(ns sql.NullString) json.RawMessage {
+	if !ns.Valid || ns.String == "" {
+		return nil
+	}
+	return json.RawMessage(ns.String)
+}
+
+func (s *Store) InterruptCreate(ctx context.Context, r store.InterruptRow) (string, error) {
+	if r.InterruptID == "" {
+		return "", fmt.Errorf("interrupts: interrupt_id required")
+	}
+	if r.RunID == "" {
+		return "", fmt.Errorf("interrupts: run_id required")
+	}
+	if r.Kind == "" {
+		r.Kind = store.InterruptKindQuestion
+	}
+	if r.Status == "" {
+		r.Status = store.InterruptStatusPending
+	}
+	if r.Priority == "" {
+		r.Priority = store.InterruptPriorityNormal
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	// Question/options/context_data are NULLed when empty so the
+	// column distinguishes "not set" from "empty string". Same
+	// pattern as channel_messages payload.
+	var question, contextData, answer, resolvedBy any
+	if r.Question != "" {
+		question = r.Question
+	}
+	if r.ContextData != "" {
+		contextData = r.ContextData
+	}
+	if r.Answer != "" {
+		answer = r.Answer
+	}
+	if r.ResolvedBy != "" {
+		resolvedBy = r.ResolvedBy
+	}
+	var options, answerMeta any
+	if len(r.Options) > 0 {
+		options = string(r.Options)
+	}
+	if len(r.AnswerMeta) > 0 {
+		answerMeta = string(r.AnswerMeta)
+	}
+	var userID, agentID, agentName any
+	if r.UserID != "" {
+		userID = r.UserID
+	}
+	if r.AgentID != "" {
+		agentID = r.AgentID
+	}
+	if r.AgentName != "" {
+		agentName = r.AgentName
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO interrupts (
+			interrupt_id, run_id, kind, status,
+			question, options, context_data, priority,
+			answer, answer_meta,
+			created_at, expires_at, resolved_at, resolved_by,
+			user_id, agent_id, agent_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
+	`,
+		r.InterruptID, r.RunID, r.Kind, r.Status,
+		question, options, contextData, r.Priority,
+		answer, answerMeta,
+		createdAt.UnixNano(), nanosOrNull(r.ExpiresAt), resolvedBy,
+		userID, agentID, agentName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("interrupts: create: %w", err)
+	}
+	return r.InterruptID, nil
+}
+
+func (s *Store) InterruptGet(ctx context.Context, interruptID string) (store.InterruptRow, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options, context_data, priority,
+		       answer, answer_meta,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE interrupt_id = ?
+	`, interruptID)
+	r, err := scanInterruptRow(row)
+	if err == sql.ErrNoRows {
+		return store.InterruptRow{}, &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+	}
+	if err != nil {
+		return store.InterruptRow{}, fmt.Errorf("interrupts: get: %w", err)
+	}
+	return r, nil
+}
+
+// rowScanner abstracts *sql.Row / *sql.Rows so scanInterruptRow works
+// for both Get (single row) and List (loop). Same trick used by other
+// adapter helpers.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanInterruptRow(row rowScanner) (store.InterruptRow, error) {
+	var r store.InterruptRow
+	var question, contextData, answer, resolvedBy, userID, agentID, agentName sql.NullString
+	var options, answerMeta sql.NullString
+	var createdAtNS int64
+	var expiresAtNS, resolvedAtNS sql.NullInt64
+	if err := row.Scan(
+		&r.InterruptID, &r.RunID, &r.Kind, &r.Status,
+		&question, &options, &contextData, &r.Priority,
+		&answer, &answerMeta,
+		&createdAtNS, &expiresAtNS, &resolvedAtNS, &resolvedBy,
+		&userID, &agentID, &agentName,
+	); err != nil {
+		return store.InterruptRow{}, err
+	}
+	r.Question = nullableString(question)
+	r.ContextData = nullableString(contextData)
+	r.Answer = nullableString(answer)
+	r.ResolvedBy = nullableString(resolvedBy)
+	r.UserID = nullableString(userID)
+	r.AgentID = nullableString(agentID)
+	r.AgentName = nullableString(agentName)
+	r.Options = nullableRawJSON(options)
+	r.AnswerMeta = nullableRawJSON(answerMeta)
+	r.CreatedAt = time.Unix(0, createdAtNS)
+	r.ExpiresAt = nullableNanos(expiresAtNS)
+	r.ResolvedAt = nullableNanos(resolvedAtNS)
+	return r, nil
+}
+
+func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error {
+	var meta any
+	if len(answerMeta) > 0 {
+		meta = string(answerMeta)
+	}
+	// Gated by status='pending' so the resolve loses cleanly when
+	// another resolver / sweeper has already finalised the row.
+	// RowsAffected==0 distinguishes "row missing" (still 0 affected)
+	// from "row already terminal" (also 0 affected) — we resolve the
+	// ambiguity with a follow-up SELECT.
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    answer      = ?,
+		    answer_meta = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE interrupt_id = ? AND status = ?
+	`,
+		store.InterruptStatusResolved,
+		answer, meta,
+		time.Now().UnixNano(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: resolve: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Disambiguate: not-found vs already-terminal.
+		var existing string
+		err := s.db.QueryRowContext(ctx, `SELECT status FROM interrupts WHERE interrupt_id = ?`, interruptID).Scan(&existing)
+		if err == sql.ErrNoRows {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: resolve probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
+	switch status {
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+		// ok
+	default:
+		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE interrupt_id = ? AND status = ?
+	`,
+		status,
+		time.Now().UnixNano(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: finish: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		var existing string
+		err := s.db.QueryRowContext(ctx, `SELECT status FROM interrupts WHERE interrupt_id = ?`, interruptID).Scan(&existing)
+		if err == sql.ErrNoRows {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: finish probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "run_id", runID, statusFilter)
+}
+
+func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "user_id", userID, statusFilter)
+}
+
+// interruptList is the shared SELECT body for ListByRun / ListByUser.
+// `col` is the indexed filter column; we never embed user input here,
+// so a static switch keeps the query parameter-binding safe.
+func (s *Store) interruptList(ctx context.Context, col, val, statusFilter string) ([]store.InterruptRow, error) {
+	if col != "run_id" && col != "user_id" {
+		return nil, fmt.Errorf("interrupts: list: unknown filter column %q", col)
+	}
+	q := `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options, context_data, priority,
+		       answer, answer_meta,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE ` + col + ` = ?`
+	args := []any{val}
+	if statusFilter != "" {
+		q += ` AND status = ?`
+		args = append(args, statusFilter)
+	}
+	q += ` ORDER BY created_at DESC LIMIT 200`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) InterruptCountPendingByRun(ctx context.Context, runID string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM interrupts WHERE run_id = ? AND status = ?
+	`, runID, store.InterruptStatusPending).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: count pending: %w", err)
+	}
+	return n, nil
+}
+
+func (s *Store) InterruptSweepExpired(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE status = ? AND expires_at IS NOT NULL AND expires_at < ?
+	`,
+		store.InterruptStatusTimedOut,
+		time.Now().UnixNano(), store.InterruptResolvedByTimeout,
+		store.InterruptStatusPending, time.Now().UnixNano(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: sweep: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	return int(n), nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -625,6 +625,68 @@ type Store interface {
 	// sweepers (single atomic DELETE).
 	DynamicAgentSweep(ctx context.Context) (int, error)
 
+	// ---- Interruption (v0.8.16) -------------------------------------
+	//
+	// Durable row that survives process restart + drives the listing
+	// APIs. The tool-layer waiter (channels.Bus key) carries the
+	// in-process wake; the row carries the state.
+	//
+	// kind is a closed enum owned by loomcycle. v0.8.16 writes only
+	// "question". Future kinds (pause / wait_until / approval) are
+	// additive enum values on the same column; the schema does not
+	// need to change. See doc-internal/rfcs/interruption-tool.md §8.
+
+	// InterruptCreate inserts a fresh interrupt row in status=pending.
+	// The caller pre-generates row.InterruptID via MintInterruptID.
+	// CreatedAt is set by the store. Returns the persisted ID. On
+	// row.ExpiresAt zero-value, no expiry is recorded (NULL column).
+	InterruptCreate(ctx context.Context, row InterruptRow) (string, error)
+
+	// InterruptGet returns one row by interrupt_id. *ErrNotFound on
+	// miss (Kind: "interrupt").
+	InterruptGet(ctx context.Context, interruptID string) (InterruptRow, error)
+
+	// InterruptResolve transitions a pending interrupt to status=
+	// resolved with the supplied answer + answer_meta. Sets
+	// resolved_at = now() server-side. Returns ErrInterruptAlreadyTerminal
+	// when the row was already in a terminal state (resolved /
+	// timed_out / cancelled) — the UPDATE is gated by status='pending'.
+	// answerMeta may be nil; the column then writes SQL NULL.
+	InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error
+
+	// InterruptFinish transitions a pending interrupt to a terminal
+	// status WITHOUT an answer (used for timeout sweeper + agent-side
+	// cancel). status must be one of: "timed_out" / "cancelled".
+	// resolvedBy is recorded for audit. Returns
+	// ErrInterruptAlreadyTerminal on a non-pending row.
+	InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error
+
+	// InterruptListByRun returns interrupts for the given run_id,
+	// newest first. statusFilter is one of: ""="all",
+	// "pending" / "resolved" / "timed_out" / "cancelled".
+	// Capped at 200 rows.
+	InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]InterruptRow, error)
+
+	// InterruptListByUser returns interrupts owned by user_id,
+	// newest first. statusFilter same shape as ListByRun. The
+	// denormalised user_id column drives this query without a JOIN
+	// against runs. Capped at 200 rows.
+	InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]InterruptRow, error)
+
+	// InterruptCountPendingByRun returns the count of status=pending
+	// interrupts for the given run_id. Drives max_pending enforcement
+	// at the tool layer (the count check is a single round trip; the
+	// subsequent InterruptCreate is a separate transaction — operators
+	// SHOULD treat max_pending as advisory, not a hard concurrency
+	// guard. See rfcs/interruption-tool.md §6).
+	InterruptCountPendingByRun(ctx context.Context, runID string) (int, error)
+
+	// InterruptSweepExpired marks every status=pending interrupt
+	// whose expires_at < now as timed_out. Returns the count
+	// transitioned. Safe to run from a periodic goroutine;
+	// idempotent under concurrent sweepers (single atomic UPDATE).
+	InterruptSweepExpired(ctx context.Context) (int, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -947,6 +1009,85 @@ var ErrAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "
 // someone tries to UPDATE an agent_defs row's definition column.
 // Append-only invariant. The adapter's contract test pins this.
 var ErrAgentDefImmutable = &SubstrateError{Code: "immutable", Msg: "agent_def: rows are append-only; create a new version"}
+
+// ---- Interruption (v0.8.16) -----------------------------------------
+
+// Interrupt kind / status / resolved-by enum values. v0.8.16 only
+// uses kind=question; future values land here as additive enum
+// extensions.
+const (
+	InterruptKindQuestion = "question"
+
+	InterruptStatusPending   = "pending"
+	InterruptStatusResolved  = "resolved"
+	InterruptStatusTimedOut  = "timed_out"
+	InterruptStatusCancelled = "cancelled"
+
+	InterruptPriorityLow    = "low"
+	InterruptPriorityNormal = "normal"
+	InterruptPriorityHigh   = "high"
+
+	// ResolvedBy attribution values. The set is open at the type
+	// level (TEXT column) but semantically closed — these are the
+	// values loomcycle itself writes. External admin tooling may
+	// invent its own (e.g. "claude_code") and that's allowed.
+	InterruptResolvedByWebUI       = "webui"
+	InterruptResolvedByMCP         = "mcp"
+	InterruptResolvedByCLI         = "cli"
+	InterruptResolvedByAPI         = "api"
+	InterruptResolvedByTimeout     = "timeout"
+	InterruptResolvedByAgentCancel = "agent_cancel"
+)
+
+// MintInterruptID returns a fresh interrupt_id that's monotonic-by-
+// create-time AND globally unique. Format:
+// "intr_<16-hex unixNanos><8-hex rand>" — 24 hex chars after the
+// prefix. Mirrors MintChannelMessageID / MintSampleID; same lex-
+// sortable invariant through year 2262.
+func MintInterruptID(t time.Time) string {
+	var buf [4]byte
+	_, _ = rand.Read(buf[:])
+	return fmt.Sprintf("intr_%016x%s", uint64(t.UnixNano()), hex.EncodeToString(buf[:]))
+}
+
+// InterruptRow is one row in the `interrupts` table. Caller supplies
+// InterruptID + RunID + Kind + (kind-specific fields); the store
+// fills CreatedAt and (on resolve / finish) ResolvedAt + ResolvedBy.
+//
+// user_id / agent_id / agent_name are denormalised at create time
+// from the run identity so listing queries don't need a JOIN. The
+// caller MUST stamp them — the store never JOINs.
+//
+// Options and AnswerMeta are JSON-encoded blobs. For kind=question,
+// Options is a JSON array of strings (NULL = free-text). AnswerMeta
+// is kind-discriminated extra resolve data (NULL for v0.8.16
+// question — the scalar Answer field carries everything).
+type InterruptRow struct {
+	InterruptID string          `json:"interrupt_id"`
+	RunID       string          `json:"run_id"`
+	Kind        string          `json:"kind"`
+	Status      string          `json:"status"`
+	Question    string          `json:"question,omitempty"`
+	Options     json.RawMessage `json:"options,omitempty"`
+	ContextData string          `json:"context_data,omitempty"`
+	Priority    string          `json:"priority"`
+	Answer      string          `json:"answer,omitempty"`
+	AnswerMeta  json.RawMessage `json:"answer_meta,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	ExpiresAt   time.Time       `json:"expires_at,omitempty"` // zero = no expiry
+	ResolvedAt  time.Time       `json:"resolved_at,omitempty"`
+	ResolvedBy  string          `json:"resolved_by,omitempty"`
+	UserID      string          `json:"user_id,omitempty"`
+	AgentID     string          `json:"agent_id,omitempty"`
+	AgentName   string          `json:"agent_name,omitempty"`
+}
+
+// ErrInterruptAlreadyTerminal is returned by InterruptResolve /
+// InterruptFinish when the row is already in a terminal status
+// (resolved / timed_out / cancelled). Distinct from ErrNotFound:
+// the row exists, but the resolve / finish race lost. The tool
+// layer maps this to HTTP 409 Conflict.
+var ErrInterruptAlreadyTerminal = &SubstrateError{Code: "already_terminal", Msg: "interrupt: already resolved, timed out, or cancelled"}
 
 // SubstrateError envelopes substrate-specific errors so the tool
 // layer can pattern-match on Code. Mirror of MemoryError /

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -121,6 +121,19 @@ func Run(t *testing.T, factory Factory) {
 		{"MetricsRunSummaryWithSamples", testMetricsRunSummaryWithSamples},
 		{"MetricsRunSummaryInFlight", testMetricsRunSummaryInFlight},
 		{"MetricsRunSummaryNotFound", testMetricsRunSummaryNotFound},
+		// v0.8.16 Interruption tool storage layer
+		{"InterruptCreateAndGet", testInterruptCreateAndGet},
+		{"InterruptGetNotFound", testInterruptGetNotFound},
+		{"InterruptResolveSetsStatusAndFields", testInterruptResolveSetsStatusAndFields},
+		{"InterruptResolveRejectsAlreadyTerminal", testInterruptResolveRejectsAlreadyTerminal},
+		{"InterruptResolveRoundTripsAnswerMeta", testInterruptResolveRoundTripsAnswerMeta},
+		{"InterruptFinishSetsTimedOut", testInterruptFinishSetsTimedOut},
+		{"InterruptFinishRejectsAlreadyTerminal", testInterruptFinishRejectsAlreadyTerminal},
+		{"InterruptListByRunFiltersByStatus", testInterruptListByRunFiltersByStatus},
+		{"InterruptListByUserFiltersByStatus", testInterruptListByUserFiltersByStatus},
+		{"InterruptCountPendingByRunIsAccurateUnderConcurrency", testInterruptCountPendingByRunIsAccurateUnderConcurrency},
+		{"InterruptSweepExpiredMarksOnlyExpiredPending", testInterruptSweepExpiredMarksOnlyExpiredPending},
+		{"InterruptIDIsMonotonicByTime", testInterruptIDIsMonotonicByTime},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2177,5 +2190,363 @@ func testMetricsRunSummaryNotFound(t *testing.T, s store.Store) {
 	}
 	if nf != nil && nf.Kind != "run" {
 		t.Errorf("Kind = %q, want run", nf.Kind)
+	}
+}
+
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// makeRunForInterrupt creates a session + run with given identity
+// fields. Returns the run_id. Helper so each interruption test
+// doesn't repeat the boilerplate.
+func makeRunForInterrupt(t *testing.T, s store.Store, userID, agentID, agentName string) (sessID, runID string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := s.CreateSession(ctx, "t", agentName, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: agentID,
+		UserID:  userID,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return sess.ID, run.ID
+}
+
+func testInterruptCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_1", "batch-processor")
+
+	id := store.MintInterruptID(time.Now())
+	row := store.InterruptRow{
+		InterruptID: id,
+		RunID:       runID,
+		Kind:        store.InterruptKindQuestion,
+		Question:    "Proceed with delete?",
+		Options:     json.RawMessage(`["Yes","No"]`),
+		ContextData: "47 records pending",
+		Priority:    store.InterruptPriorityNormal,
+		UserID:      "u_alice",
+		AgentID:     "a_intr_1",
+		AgentName:   "batch-processor",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	}
+	got, err := s.InterruptCreate(ctx, row)
+	if err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+	if got != id {
+		t.Errorf("returned id = %q, want %q", got, id)
+	}
+
+	r, err := s.InterruptGet(ctx, id)
+	if err != nil {
+		t.Fatalf("InterruptGet: %v", err)
+	}
+	if r.Status != store.InterruptStatusPending {
+		t.Errorf("Status = %q, want pending", r.Status)
+	}
+	if r.Question != "Proceed with delete?" {
+		t.Errorf("Question = %q", r.Question)
+	}
+	if string(r.Options) == "" || string(r.Options) == "null" {
+		t.Errorf("Options round-trip empty: %q", string(r.Options))
+	}
+	if r.UserID != "u_alice" {
+		t.Errorf("UserID = %q, want u_alice (denormalised at create)", r.UserID)
+	}
+	if r.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt round-tripped zero; want non-zero")
+	}
+}
+
+func testInterruptGetNotFound(t *testing.T, s store.Store) {
+	_, err := s.InterruptGet(context.Background(), "intr_doesnotexist")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
+	}
+	if nf != nil && nf.Kind != "interrupt" {
+		t.Errorf("Kind = %q, want interrupt", nf.Kind)
+	}
+}
+
+func testInterruptResolveSetsStatusAndFields(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_r", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	if _, err := s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", Priority: store.InterruptPriorityNormal,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatalf("InterruptResolve: %v", err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if r.Status != store.InterruptStatusResolved {
+		t.Errorf("Status = %q, want resolved", r.Status)
+	}
+	if r.Answer != "Yes" {
+		t.Errorf("Answer = %q, want Yes", r.Answer)
+	}
+	if r.ResolvedBy != store.InterruptResolvedByWebUI {
+		t.Errorf("ResolvedBy = %q", r.ResolvedBy)
+	}
+	if r.ResolvedAt.IsZero() {
+		t.Error("ResolvedAt is zero; want set")
+	}
+}
+
+func testInterruptResolveRejectsAlreadyTerminal(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_dup", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Second resolve must fail with ErrInterruptAlreadyTerminal.
+	err := s.InterruptResolve(ctx, id, "No", store.InterruptResolvedByWebUI, nil)
+	if !errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+		t.Errorf("got %v, want ErrInterruptAlreadyTerminal", err)
+	}
+}
+
+func testInterruptResolveRoundTripsAnswerMeta(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_meta", "approver")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Approve delete?", CreatedAt: time.Now(),
+	})
+	meta := json.RawMessage(`{"approved":true,"reason":"verified manually"}`)
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, meta); err != nil {
+		t.Fatal(err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if len(r.AnswerMeta) == 0 {
+		t.Fatal("AnswerMeta round-tripped empty")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(r.AnswerMeta, &decoded); err != nil {
+		t.Fatalf("AnswerMeta unmarshal: %v (raw %q)", err, string(r.AnswerMeta))
+	}
+	if decoded["approved"] != true || decoded["reason"] != "verified manually" {
+		t.Errorf("AnswerMeta decoded = %+v", decoded)
+	}
+}
+
+func testInterruptFinishSetsTimedOut(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_fin", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	if err := s.InterruptFinish(ctx, id, store.InterruptStatusTimedOut, store.InterruptResolvedByTimeout); err != nil {
+		t.Fatalf("InterruptFinish: %v", err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if r.Status != store.InterruptStatusTimedOut {
+		t.Errorf("Status = %q, want timed_out", r.Status)
+	}
+	if r.Answer != "" {
+		t.Errorf("Answer = %q on timeout path; want empty", r.Answer)
+	}
+}
+
+func testInterruptFinishRejectsAlreadyTerminal(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_fin_dup", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	_ = s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil)
+	err := s.InterruptFinish(ctx, id, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+	if !errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+		t.Errorf("got %v, want ErrInterruptAlreadyTerminal", err)
+	}
+}
+
+func testInterruptListByRunFiltersByStatus(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_list", "batch")
+
+	// Three interrupts: one pending, one resolved, one cancelled.
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id1, RunID: runID, UserID: "u_alice", Question: "Q1", CreatedAt: time.Now()})
+	id2 := store.MintInterruptID(time.Now().Add(time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id2, RunID: runID, UserID: "u_alice", Question: "Q2", CreatedAt: time.Now().Add(time.Millisecond)})
+	_ = s.InterruptResolve(ctx, id2, "ok", store.InterruptResolvedByWebUI, nil)
+	id3 := store.MintInterruptID(time.Now().Add(2 * time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id3, RunID: runID, UserID: "u_alice", Question: "Q3", CreatedAt: time.Now().Add(2 * time.Millisecond)})
+	_ = s.InterruptFinish(ctx, id3, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+
+	all, err := s.InterruptListByRun(ctx, runID, "")
+	if err != nil {
+		t.Fatalf("List all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("list-all returned %d rows, want 3", len(all))
+	}
+
+	pending, _ := s.InterruptListByRun(ctx, runID, store.InterruptStatusPending)
+	if len(pending) != 1 || pending[0].InterruptID != id1 {
+		t.Errorf("pending filter returned %d rows; want 1 (id=%s)", len(pending), id1)
+	}
+}
+
+func testInterruptListByUserFiltersByStatus(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runA := makeRunForInterrupt(t, s, "u_bob", "a_intr_ub_1", "agent-a")
+	_, runB := makeRunForInterrupt(t, s, "u_bob", "a_intr_ub_2", "agent-b")
+	_, runC := makeRunForInterrupt(t, s, "u_other", "a_intr_uo_1", "agent-c")
+
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id1, RunID: runA, UserID: "u_bob", Question: "Q from A", CreatedAt: time.Now()})
+	id2 := store.MintInterruptID(time.Now().Add(time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id2, RunID: runB, UserID: "u_bob", Question: "Q from B", CreatedAt: time.Now().Add(time.Millisecond)})
+	// Unrelated user — must not appear in u_bob's listing.
+	id3 := store.MintInterruptID(time.Now().Add(2 * time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id3, RunID: runC, UserID: "u_other", Question: "Q from C", CreatedAt: time.Now().Add(2 * time.Millisecond)})
+
+	rows, err := s.InterruptListByUser(ctx, "u_bob", store.InterruptStatusPending)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows for u_bob, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.UserID != "u_bob" {
+			t.Errorf("listing leaked row from %q", r.UserID)
+		}
+	}
+}
+
+func testInterruptCountPendingByRunIsAccurateUnderConcurrency(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_count", "batch")
+
+	const N = 20
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := store.MintInterruptID(time.Now())
+			_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+				InterruptID: id, RunID: runID, UserID: "u_alice",
+				Question: "Q?", CreatedAt: time.Now(),
+			})
+		}(i)
+	}
+	wg.Wait()
+	n, err := s.InterruptCountPendingByRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("InterruptCountPendingByRun: %v", err)
+	}
+	if n != N {
+		t.Errorf("count = %d, want %d under parallel inserts", n, N)
+	}
+}
+
+func testInterruptSweepExpiredMarksOnlyExpiredPending(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_sweep", "batch")
+
+	// Row 1: expired pending — should be swept.
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id1, RunID: runID, UserID: "u_alice", Question: "Q1",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	})
+	// Row 2: future expiry — must NOT be swept.
+	id2 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id2, RunID: runID, UserID: "u_alice", Question: "Q2",
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+	// Row 3: no expiry — must NOT be swept.
+	id3 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id3, RunID: runID, UserID: "u_alice", Question: "Q3",
+		CreatedAt: time.Now(),
+		// ExpiresAt zero → no expiry
+	})
+	// Row 4: expired but already resolved — must NOT change status.
+	id4 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id4, RunID: runID, UserID: "u_alice", Question: "Q4",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	})
+	_ = s.InterruptResolve(ctx, id4, "answered before expiry", store.InterruptResolvedByWebUI, nil)
+
+	n, err := s.InterruptSweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("InterruptSweepExpired: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("swept %d rows, want 1", n)
+	}
+	r1, _ := s.InterruptGet(ctx, id1)
+	if r1.Status != store.InterruptStatusTimedOut {
+		t.Errorf("Row1 status = %q, want timed_out", r1.Status)
+	}
+	if r1.ResolvedBy != store.InterruptResolvedByTimeout {
+		t.Errorf("Row1 ResolvedBy = %q, want timeout", r1.ResolvedBy)
+	}
+	r2, _ := s.InterruptGet(ctx, id2)
+	if r2.Status != store.InterruptStatusPending {
+		t.Errorf("Row2 status = %q, want pending (future expiry)", r2.Status)
+	}
+	r3, _ := s.InterruptGet(ctx, id3)
+	if r3.Status != store.InterruptStatusPending {
+		t.Errorf("Row3 status = %q, want pending (no expiry)", r3.Status)
+	}
+	r4, _ := s.InterruptGet(ctx, id4)
+	if r4.Status != store.InterruptStatusResolved {
+		t.Errorf("Row4 status = %q, want resolved (must not re-finalise)", r4.Status)
+	}
+}
+
+func testInterruptIDIsMonotonicByTime(t *testing.T, s store.Store) {
+	// Pure unit-style check on the MintInterruptID format — IDs minted
+	// later in time must lex-compare greater than earlier IDs. The
+	// `interrupts_by_run_status` index orders by created_at internally,
+	// but ID monotonicity is the operator-debugging-eyeball property
+	// described on MintInterruptID's docstring.
+	t1 := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Microsecond)
+	id1 := store.MintInterruptID(t1)
+	id2 := store.MintInterruptID(t2)
+	if !(id1 < id2) {
+		t.Errorf("MintInterruptID not monotonic by time: %s ≥ %s (t1=%v t2=%v)", id1, id2, t1, t2)
+	}
+	const wantLen = len("intr_") + 16 + 8
+	if len(id1) != wantLen {
+		t.Errorf("id length = %d, want %d", len(id1), wantLen)
 	}
 }


### PR DESCRIPTION
## Summary

PR 1 of 5 for the **v0.8.16 Interruption tool**. Pure storage foundation — no user-visible behaviour change, but every subsequent PR depends on this contract.

- New `interrupts` table (migration 0011, both sqlite + postgres)
- 8 new methods on the `Store` interface + their adapter implementations
- 12 cross-backend contract tests (sqlite + postgres)
- `MintInterruptID` helper + typed enum constants + `ErrInterruptAlreadyTerminal` sentinel

**+1,225 lines, 6 files.**

## Why \"Interruption\", not \"Question\"?

The parked v0.8.16 design (`docs/PLAN.md:523`) was generalized following the 2026-05-16 LangChain comparison RFC (`doc-internal/rfcs/langchain-comparison.md`, Tier B candidate #4). Same v0.8.16 ops (`ask`/`notify`/`cancel`), but namespace + schema generalized via a closed-enum `kind` discriminator so future kinds (`pause`, `wait_until`, `approval`) slot in additively without reopening the design. The schema generalization is **free** in PR 1 — one column with a default value.

Full design rationale lives in `doc-internal/rfcs/interruption-tool.md` (gitignored, internal-only). The 5-PR sequence + load-bearing-invariant test map is documented there.

## Schema

`interrupts` table — 17 columns including the `kind` discriminator:

| Column | Type | Purpose |
|---|---|---|
| `interrupt_id` | TEXT PK | `\"intr_<16hex><8hex>\"` |
| `run_id` | TEXT NOT NULL | which run is blocked |
| `kind` | TEXT DEFAULT 'question' | **closed enum** — v0.8.16 writes only `question` |
| `status` | TEXT DEFAULT 'pending' | `pending`/`resolved`/`timed_out`/`cancelled` |
| `question`, `options`, `context_data`, `priority` | kind=question payload |
| `answer`, `answer_meta` | resolve payload (kind-discriminated) |
| `created_at`, `expires_at`, `resolved_at`, `resolved_by` | lifecycle timestamps |
| `user_id`, `agent_id`, `agent_name` | **denormalised at create time** so listing queries skip the JOIN against runs |

Three indexes: `by_run_status`, `by_user_status` (partial WHERE user_id IS NOT NULL), `by_expires` (partial WHERE expires_at IS NOT NULL AND status = 'pending').

**No FK on run_id** — same reasoning as evaluations (immutable audit log must survive any future run pruning).

## Test plan

12 contract subtests under `TestStoreContract`, all green on sqlite:

- `InterruptCreateAndGet` — basic round-trip including JSONB Options + denormalised user_id
- `InterruptGetNotFound` — \\*ErrNotFound{Kind: \"interrupt\"} contract
- `InterruptResolveSetsStatusAndFields` — Status, Answer, ResolvedBy, ResolvedAt all populated
- `InterruptResolveRejectsAlreadyTerminal` — second resolve returns ErrInterruptAlreadyTerminal (load-bearing invariant for HTTP 409)
- `InterruptResolveRoundTripsAnswerMeta` — JSONB payload column survives the round-trip with structure preserved
- `InterruptFinishSetsTimedOut` — terminal transition without an answer
- `InterruptFinishRejectsAlreadyTerminal` — same guard as Resolve
- `InterruptListByRunFiltersByStatus` — status filter narrows
- `InterruptListByUserFiltersByStatus` — denormalised user_id keeps cross-user rows out
- `InterruptCountPendingByRunIsAccurateUnderConcurrency` — 20 parallel inserts, count == 20
- `InterruptSweepExpiredMarksOnlyExpiredPending` — sweeper doesn't touch future-expiry / no-expiry / already-resolved rows
- `InterruptIDIsMonotonicByTime` — MintInterruptID format check

Postgres backend builds clean; full contract run gated by `LOOMCYCLE_TEST_PG_DSN` per existing pattern.

## CI gates

- [x] `go test ./...` clean across all packages
- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean
- [x] Live binary creates the table at startup (sqlite3 `.indexes interrupts` + `PRAGMA table_info(interrupts)` confirmed)

## Out of scope for PR 1

PR 2: the Interruption tool itself (tool dispatch + bus.Wait blocking + heartbeat ticker + webui backend + resolve endpoint)
PR 3: consumer-MCP backend + LoomCycle MCP meta-tool (`interruption_resolve`)
PR 4: Web UI `/ui/interrupts` route + run-detail banner
PR 5: docs (TOOLS.md, help topic, sample yaml, REVISIONS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)