### PR TITLE
feat(tools): Interruption tool with webui backend + bus.Wait blocking (PR 2/5)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -377,6 +377,23 @@ func main() {
 	}
 	allTools = append(allTools, evaluationTool)
 
+	// Interruption tool (v0.8.16) — human-in-the-loop primitive. Three
+	// ops (ask / notify / cancel) gated by per-agent
+	// `interruption: {enabled, kinds, max_pending}` yaml. The tool
+	// blocks via channels.Bus, so it reuses the same bus instance the
+	// Channel tool's long-poll subscribe uses. SystemPublisher (set
+	// below alongside Store) carries the external `_system/interrupts/
+	// pending` / `resolved` signal for non-run consumers (Web UI inbox,
+	// Slack notifier).
+	interruptionTool := &builtin.Interruption{
+		Bus:               channelBus,
+		DefaultTimeout:    time.Duration(cfg.Interruption.DefaultTimeoutMS) * time.Millisecond,
+		MaxTimeout:        time.Duration(cfg.Interruption.MaxTimeoutMS) * time.Millisecond,
+		HeartbeatInterval: time.Duration(cfg.Interruption.HeartbeatIntervalMS) * time.Millisecond,
+		MaxPendingPerRun:  cfg.Interruption.MaxPendingPerRun,
+	}
+	allTools = append(allTools, interruptionTool)
+
 	// Context tool (v0.8.7). Read-only runtime introspection. The Tools
 	// field is back-filled with the FULL allTools slice after every
 	// other registration (MCP + localapi) so doc/tools ops reflect the
@@ -571,6 +588,7 @@ func main() {
 	agentDefTool.Store = storeIface
 	evaluationTool.Store = storeIface
 	contextTool.Store = storeIface
+	interruptionTool.Store = storeIface
 	// Back-fill Context tool's catalog with the FINAL allTools slice
 	// (including MCP-served tools registered above) so doc/tools ops
 	// reflect the complete runtime catalog. Must happen AFTER every
@@ -591,6 +609,15 @@ func main() {
 		Scheduler: channelScheduler,
 	}
 	srv.SetSystemPublisher(sysPublisher)
+	// Wire the SystemPublisher onto the Interruption tool too — same
+	// instance, so _system/interrupts/* publishes from inside the
+	// tool wake the same Channel long-poll subscribers.
+	interruptionTool.SystemPublisher = sysPublisher
+	// v0.8.16 — wire the same Bus to the server so the resolve
+	// handler can wake the blocked tool's bus.Wait via the
+	// "intr:<id>" key. Without this the resolve writes the row but
+	// the tool re-checks storage only when its own timer fires.
+	srv.SetInterruptionBus(channelBus)
 
 	// v0.8.6 heartbeat runner — one goroutine per `_system/heartbeat-*`
 	// (or any other `publisher: system` + `period:` channel) declared

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -108,6 +108,15 @@ type Server struct {
 	// constructed.
 	metricsSampler *metrics.Sampler
 
+	// interruptionBus is the v0.8.16 in-process notification bus used
+	// by the resolve handler to wake the blocked Interruption tool.
+	// Same instance as the Channel tool's Bus — re-using one Bus per
+	// process keeps wake-up paths uniform. Nil = resolve handler
+	// still writes the row (the bus.Wait timer will fire once the
+	// row's expires_at passes) but in-process wakeup is skipped. Set
+	// via SetInterruptionBus from main.go.
+	interruptionBus *channels.Bus
+
 	// mcpHTTPHandler is the v0.8.15.3 HTTP MCP transport (alternate
 	// front-end to the stdio MCP server). Typed as http.Handler — NOT
 	// *lcmcp.HTTPHandler — so this package does NOT import
@@ -185,6 +194,13 @@ func (s *Server) SetMCPHTTPHandler(h http.Handler) {
 // after the Store is open + the Bus/Scheduler are constructed.
 func (s *Server) SetSystemPublisher(p channels.SystemPublisher) {
 	s.systemPublisher = p
+}
+
+// SetInterruptionBus wires the v0.8.16 in-process notification bus
+// used by the Interruption-resolve HTTP handler to wake the blocked
+// tool. Same Bus instance the Channel tool uses.
+func (s *Server) SetInterruptionBus(b *channels.Bus) {
+	s.interruptionBus = b
 }
 
 // newDispatcher centralises Dispatcher construction so the three call
@@ -436,6 +452,18 @@ func (s *Server) substratePoliciesForAgent(agentDef config.AgentDef, selfName st
 // for one agent. Default-deny shape: empty Scopes = no access.
 func (s *Server) historyPolicyForAgent(agentDef config.AgentDef) tools.HistoryPolicyValue {
 	return tools.HistoryPolicyValue{Scopes: agentDef.HistoryScope}
+}
+
+// interruptionPolicyForAgent maps the agent's yaml ACL into the
+// runtime policy struct the Interruption tool reads via ctx.
+// Default-deny: absent block in yaml → Enabled=false → tool returns
+// is_error on every op.
+func (s *Server) interruptionPolicyForAgent(agentDef config.AgentDef) tools.InterruptionPolicyValue {
+	return tools.InterruptionPolicyValue{
+		Enabled:    agentDef.Interruption.Enabled,
+		Kinds:      agentDef.Interruption.Kinds,
+		MaxPending: agentDef.Interruption.MaxPending,
+	}
 }
 
 // applyAgentDefOverlay overlays the v0.8.5 agent_defs.definition JSON
@@ -830,6 +858,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
+	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
+	loopCtx = tools.WithRunID(loopCtx, runID)
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -981,6 +1011,12 @@ func (s *Server) Mux() http.Handler {
 	// `/`-prefixed paths (e.g. `events/2026-05-09T10:00`) and a
 	// single-segment {key} would 404 on those.
 	mux.Handle("GET /v1/_memory/scopes/{scope}/{scope_id}/keys/{key...}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetMemoryEntry))))
+	// v0.8.16 Interruption tool. resolve is the human-side answer
+	// submit; the two list endpoints drive the Web UI (run-scoped
+	// audit + user-scoped inbox).
+	mux.Handle("POST /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResolveInterrupt))))
+	mux.Handle("GET /v1/runs/{run_id}/interrupts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListRunInterrupts))))
+	mux.Handle("GET /v1/users/{user_id}/interrupts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUserInterrupts))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the
@@ -1524,6 +1560,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
+	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
+	loopCtx = tools.WithRunID(loopCtx, runID)
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1824,6 +1862,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
 	loopCtx = tools.WithEvaluationPolicy(loopCtx, evPolicy)
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
+	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
+	loopCtx = tools.WithRunID(loopCtx, run.ID)
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -2358,6 +2398,8 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subCtx = tools.WithAgentDefPolicy(subCtx, subADPolicy)
 	subCtx = tools.WithEvaluationPolicy(subCtx, subEvPolicy)
 	subCtx = tools.WithHistoryPolicy(subCtx, s.historyPolicyForAgent(def))
+	subCtx = tools.WithInterruptionPolicy(subCtx, s.interruptionPolicyForAgent(def))
+	subCtx = tools.WithRunID(subCtx, subRunID)
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 
@@ -2629,6 +2671,219 @@ func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
 		out = append(out, runToAgentResponse(run, live))
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"agents": out})
+}
+
+// ---- Interruption (v0.8.16) ---------------------------------------
+
+// resolveInterruptRequest is the JSON body for the resolve endpoint.
+// kind-discriminated: v0.8.16 supports only kind="question"; future
+// kinds (pause/wait_until/approval) parse different fields.
+type resolveInterruptRequest struct {
+	Kind       string `json:"kind"`
+	Answer     string `json:"answer"`
+	ResolvedBy string `json:"resolved_by,omitempty"`
+}
+
+// handleResolveInterrupt accepts a human's answer to a pending
+// interruption + wakes the blocked tool. The path captures
+// {run_id, interrupt_id}; the body carries the kind-discriminated
+// payload. 422 on invalid answer, 409 on already-terminal, 410 on
+// expired-but-not-yet-swept.
+func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "interrupts require persistence (Store not configured)", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	interruptID := r.PathValue("interrupt_id")
+	if !validIdent(runID) || !validIdent(interruptID) {
+		http.Error(w, "run_id / interrupt_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+
+	var req resolveInterruptRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid JSON body: %v", err), http.StatusBadRequest)
+		return
+	}
+	if req.Kind == "" {
+		req.Kind = store.InterruptKindQuestion
+	}
+	if req.Kind != store.InterruptKindQuestion {
+		// v0.8.16 supports only "question". Future kinds add their
+		// own validators here; the closed-enum contract means the
+		// resolve handler is the gate, not the model or the
+		// caller.
+		http.Error(w, fmt.Sprintf("unsupported kind %q (v0.8.16 supports: question)", req.Kind), http.StatusUnprocessableEntity)
+		return
+	}
+	if req.ResolvedBy == "" {
+		// Authoritative attribution: cookie session (Web UI) writes
+		// "webui"; bearer-only API calls write "api". The Web UI
+		// resolve flow runs through the same handler.
+		if hasSessionCookie(r) {
+			req.ResolvedBy = store.InterruptResolvedByWebUI
+		} else {
+			req.ResolvedBy = store.InterruptResolvedByAPI
+		}
+	}
+
+	// Validate the answer against the stored row's options + expiry.
+	row, err := s.store.InterruptGet(r.Context(), interruptID)
+	var nf *store.ErrNotFound
+	if errors.As(err, &nf) {
+		http.Error(w, "interrupt not found", http.StatusNotFound)
+		return
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if row.RunID != runID {
+		// Defensive: the URL path's run_id must match the stored
+		// row's run_id. Prevents one user's resolve from being
+		// retargeted at another run's interrupt by URL manipulation.
+		http.Error(w, "interrupt does not belong to that run", http.StatusNotFound)
+		return
+	}
+	if row.Status != store.InterruptStatusPending {
+		if row.Status == store.InterruptStatusTimedOut && !row.ExpiresAt.IsZero() && row.ExpiresAt.Before(time.Now()) {
+			http.Error(w, "interrupt expired", http.StatusGone)
+			return
+		}
+		http.Error(w, fmt.Sprintf("interrupt already %s", row.Status), http.StatusConflict)
+		return
+	}
+	if !row.ExpiresAt.IsZero() && row.ExpiresAt.Before(time.Now()) {
+		http.Error(w, "interrupt expired", http.StatusGone)
+		return
+	}
+
+	// Option-list validation: when the original ask declared
+	// options, the answer must be one of them. Free-text answers
+	// (no options) accept any non-empty string.
+	if len(row.Options) > 0 {
+		var opts []string
+		if err := json.Unmarshal(row.Options, &opts); err == nil && len(opts) > 0 {
+			ok := false
+			for _, o := range opts {
+				if o == req.Answer {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				http.Error(w, fmt.Sprintf("answer %q is not one of the declared options: %v", req.Answer, opts), http.StatusUnprocessableEntity)
+				return
+			}
+		}
+	} else if req.Answer == "" {
+		http.Error(w, "answer is required for free-text interrupts", http.StatusUnprocessableEntity)
+		return
+	}
+
+	if err := s.store.InterruptResolve(r.Context(), interruptID, req.Answer, req.ResolvedBy, nil); err != nil {
+		if errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+			http.Error(w, "interrupt already resolved, timed out, or cancelled", http.StatusConflict)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Wake the blocked tool. Bus.Notify is best-effort — if no
+	// waiter, it's a no-op. If we crash before Notify fires, the
+	// next bus.Wait cycle exits via timeout and the storage row
+	// is the source of truth.
+	if s.interruptionBus != nil {
+		s.interruptionBus.Notify("intr:" + interruptID)
+	}
+
+	// Publish the external `_system/interrupts/resolved` signal so
+	// non-run Channel subscribers (dashboards, Slack bots) see the
+	// terminal state. Best-effort.
+	if s.systemPublisher != nil && row.UserID != "" {
+		payload, _ := json.Marshal(map[string]any{
+			"interrupt_id": interruptID,
+			"run_id":       runID,
+			"kind":         row.Kind,
+			"status":       store.InterruptStatusResolved,
+			"answer":       req.Answer,
+			"resolved_by":  req.ResolvedBy,
+		})
+		_, _ = s.systemPublisher.PublishNow(
+			r.Context(),
+			"_system/interrupts/resolved",
+			store.MemoryScopeUser, row.UserID,
+			payload, channels.SystemPublisherUserID, 0, 0,
+		)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"interrupt_id": interruptID,
+		"status":       store.InterruptStatusResolved,
+		"resolved_at":  time.Now().UTC().Format(time.RFC3339Nano),
+	})
+}
+
+// handleListRunInterrupts serves GET /v1/runs/{run_id}/interrupts.
+// Capped at 200 rows by the store; ordering is created_at DESC.
+func (s *Server) handleListRunInterrupts(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "interrupts require persistence", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	statusFilter := r.URL.Query().Get("status")
+	if statusFilter == "all" {
+		statusFilter = ""
+	}
+	rows, err := s.store.InterruptListByRun(r.Context(), runID, statusFilter)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"interrupts": rows, "total": len(rows)})
+}
+
+// handleListUserInterrupts serves GET /v1/users/{user_id}/interrupts.
+// Drives the Web UI inbox view. Same status filter as the run-scoped
+// variant; defaults to pending (most useful view for "what do I need
+// to answer?").
+func (s *Server) handleListUserInterrupts(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "interrupts require persistence", http.StatusServiceUnavailable)
+		return
+	}
+	userID := r.PathValue("user_id")
+	if !validIdent(userID) {
+		http.Error(w, "user_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	statusFilter := r.URL.Query().Get("status")
+	if statusFilter == "" {
+		statusFilter = store.InterruptStatusPending
+	}
+	if statusFilter == "all" {
+		statusFilter = ""
+	}
+	rows, err := s.store.InterruptListByUser(r.Context(), userID, statusFilter)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"interrupts": rows, "total": len(rows)})
+}
+
+// hasSessionCookie returns true when the request carries the
+// Web UI session cookie — drives the resolved_by attribution.
+func hasSessionCookie(r *http.Request) bool {
+	c, err := r.Cookie("loomcycle_session")
+	return err == nil && c != nil && c.Value != ""
 }
 
 // writeJSON is a small helper for the new endpoints that avoids

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,12 @@ type Config struct {
 	// plus a new "global" scope for cross-tenant fan-out streams.
 	Channels map[string]Channel `yaml:"channels"`
 
+	// Interruption is the v0.8.16 top-level config block for the
+	// Interruption tool. Operator picks the delivery backend
+	// (webui / mcp_server:<name> / cli) and the env-cap defaults.
+	// Empty (zero-value) = backend=webui implicitly.
+	Interruption InterruptionConfig `yaml:"interruption"`
+
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
 
@@ -107,6 +113,48 @@ type LocalAPIConfig struct {
 	SpecPath       string `yaml:"spec"`
 	BaseURL        string `yaml:"base_url"`
 	ToolNamePrefix string `yaml:"tool_name_prefix"`
+}
+
+// InterruptionConfig is the v0.8.16 top-level config block for the
+// Interruption tool. Operator selects which delivery surface the
+// "ask" op uses for human input, plus the timeout / heartbeat env
+// caps. Most fields have env-var equivalents (see Env.Interruption*)
+// for ops who prefer env over yaml; env wins where both are set.
+type InterruptionConfig struct {
+	// Backend selects the delivery surface. Valid values:
+	//   - "webui"             (default) — humans answer via /ui/interrupts
+	//   - "mcp_server:<name>" — loomcycle calls <name>'s MCP server
+	//                            tool (e.g. mcp__myconsumer__ask)
+	//   - "cli"               — local-dev only; a separate process
+	//                            (loomcycle-interrupt-cli) subscribes
+	//                            to _system/interrupts/pending and
+	//                            resolves via the HTTP endpoint
+	// Empty = webui.
+	Backend string `yaml:"backend"`
+
+	// DefaultTimeoutMS is the timeout applied when an ask doesn't
+	// pass timeout_ms. 0 = no timeout (interruption sits pending
+	// indefinitely; operators relying on long-running questions
+	// SHOULD set a sweeper-friendly value).
+	DefaultTimeoutMS int `yaml:"default_timeout_ms"`
+
+	// MaxTimeoutMS is the hard ceiling. timeout_ms above this is
+	// clamped down. 0 = no ceiling. Useful for capping
+	// model-passed timeouts so the model can't pin a run open for
+	// arbitrary time.
+	MaxTimeoutMS int `yaml:"max_timeout_ms"`
+
+	// MaxPendingPerRun caps simultaneous pending interrupts on one
+	// run. 0 = no cap (operator trusts agent yaml's max_pending
+	// alone). Per-agent yaml may narrow further.
+	MaxPendingPerRun int `yaml:"max_pending_per_run"`
+
+	// HeartbeatIntervalMS governs the during-block heartbeat
+	// ticker. 0 = use the 30-second default. Tighter intervals
+	// shorten the post-crash detection window (the sweeper sees
+	// missed heartbeats sooner) at the cost of more DB write
+	// traffic.
+	HeartbeatIntervalMS int `yaml:"heartbeat_interval_ms"`
 }
 
 // StorageConfig selects the Store backend and its connection settings.
@@ -379,6 +427,34 @@ type AgentDef struct {
 	// lists "Context" in allowed_tools, that wins regardless of this
 	// flag (explicit beats default).
 	DisableContext bool `yaml:"disable_context"`
+
+	// Interruption is the v0.8.16 Interruption tool ACL. Default-
+	// deny: an absent block means Enabled is false and every
+	// Interruption op returns is_error with a clear refusal.
+	// Mirror of the substrate-ACL pattern (memory_scopes,
+	// agent_def_scopes, evaluation_scopes) — operator-yaml is the
+	// floor; the model can never enlarge its own access.
+	Interruption AgentInterruptionACL `yaml:"interruption"`
+}
+
+// AgentInterruptionACL is the per-agent v0.8.16 Interruption tool
+// gate. Three fields:
+//
+//   - Enabled gates the tool entirely. False (default) → every op
+//     returns is_error with a "not enabled" refusal.
+//   - Kinds is the allowlist of interrupt kinds this agent may
+//     create. v0.8.16 supports only "question". Empty (when
+//     Enabled=true) defaults to ["question"]. Future "pause" /
+//     "wait_until" / "approval" kinds land here as additive opt-ins
+//     without a yaml shape change.
+//   - MaxPending caps simultaneous pending interrupts on a single
+//     run. 0 = use the operator's global default
+//     (LOOMCYCLE_INTERRUPTION_MAX_PENDING_PER_RUN). The lower of
+//     the agent and operator caps wins.
+type AgentInterruptionACL struct {
+	Enabled    bool     `yaml:"enabled"`
+	Kinds      []string `yaml:"kinds"`
+	MaxPending int      `yaml:"max_pending"`
 }
 
 // Channel is one operator-declared channel in the top-level

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -294,6 +294,25 @@ const (
 	// subscribe that returns 100 messages, expect 100
 	// EventChannelDelivery events emitted in order.
 	EventChannelDelivery EventType = "channel_delivery"
+
+	// EventInterruptionPending signals that the v0.8.16 Interruption
+	// tool just created a pending interrupt and the agent's loop is
+	// about to block on a human (or other delivery surface) resolve.
+	// Emitted from inside the tool's Execute() via the ctx-attached
+	// event emitter (tools.EventEmitter). The Interruption field
+	// carries the structured payload — interrupt_id, kind, question,
+	// options, priority, expires_at — enough for the Web UI to render
+	// without a separate fetch.
+	//
+	// Only `ask` ops emit this event; `notify` (fire-and-forget) and
+	// `cancel` (terminating) don't block, so SSE consumers don't see
+	// a corresponding "pending" event. There is intentionally NO
+	// EventInterruptionResolved sibling event on the run's SSE stream
+	// because the run is BLOCKED inside the Interruption tool when
+	// the resolve arrives — there's no SSE writer pumping at that
+	// moment. The external `_system/interrupts/resolved` channel
+	// publishes the resolve notification for non-run consumers.
+	EventInterruptionPending EventType = "interruption_pending"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -325,6 +344,12 @@ type Event struct {
 	// channel-activity dashboards can filter on Type and key the
 	// row by (channel, message_id) without two parsers.
 	Channel *ChannelEventInfo `json:"channel,omitempty"`
+
+	// Interruption carries the structured payload on
+	// EventInterruptionPending (v0.8.16). Nil on all other event
+	// types. Renders directly into the Web UI's modal/sidebar
+	// without a follow-up fetch.
+	Interruption *InterruptionEventInfo `json:"interruption,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -439,6 +464,37 @@ type ChannelEventInfo struct {
 	// MessageID of THIS event (since delivery events fire per
 	// message in order). Empty on EventChannelPublish.
 	Cursor string `json:"cursor,omitempty"`
+}
+
+// InterruptionEventInfo is the structured payload on
+// EventInterruptionPending (v0.8.16). Carries enough for the Web UI
+// or external dashboard to render the question without a follow-up
+// fetch of the interrupt row.
+type InterruptionEventInfo struct {
+	// InterruptID is the row's primary key. Same shape as the
+	// minter: "intr_<16hex unixNanos><8hex rand>".
+	InterruptID string `json:"interrupt_id"`
+	// Kind is the discriminator. v0.8.16 emits only "question";
+	// future "pause" / "wait_until" / "approval" land as additive
+	// values.
+	Kind string `json:"kind"`
+	// Question is the prompt text for kind=question. Empty for
+	// future non-question kinds.
+	Question string `json:"question,omitempty"`
+	// Options is the JSON-encoded array of option strings for
+	// kind=question (NULL/empty = free-text answer). Verbatim from
+	// the interrupt row; the Web UI parses it.
+	Options json.RawMessage `json:"options,omitempty"`
+	// Context is the optional hint string the agent provides ("47
+	// records pending"). Empty when the agent didn't pass context.
+	Context string `json:"context,omitempty"`
+	// Priority is "low" / "normal" / "high" — informational, drives
+	// UI badge styling.
+	Priority string `json:"priority"`
+	// ExpiresAt is the absolute UTC timestamp at which the
+	// interruption will time out. RFC3339. Empty when no timeout
+	// was set.
+	ExpiresAt string `json:"expires_at,omitempty"`
 }
 
 // ToolUse is the model's request to invoke a tool.

--- a/internal/store/postgres/migrations/0011_interrupts.down.sql
+++ b/internal/store/postgres/migrations/0011_interrupts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS interrupts;

--- a/internal/store/postgres/migrations/0011_interrupts.up.sql
+++ b/internal/store/postgres/migrations/0011_interrupts.up.sql
@@ -1,0 +1,54 @@
+-- 0011_interrupts.up.sql — v0.8.16 Interruption tool.
+--
+-- Agents call Interruption.ask / .notify / .cancel; pending rows
+-- block the run until resolved by a human (via Web UI), an external
+-- MCP-server delivery surface, or a timeout / cancel. The kind column
+-- is the closed-enum future-proofing for v0.9.x pause / wait_until /
+-- approval — v0.8.16 writes only kind='question'.
+--
+-- user_id / agent_id / agent_name are denormalised from the run row
+-- at create time (NOT joined on read) so the GET /v1/users/{id}/
+-- interrupts listing query never needs a JOIN against runs. Same
+-- denormalisation pattern as runs.user_id and channel_messages.run_id.
+--
+-- NO foreign key on run_id: interrupts must survive any future run
+-- pruning, same reasoning as evaluations. Referential integrity is
+-- enforced at the application layer (InterruptCreate validates the
+-- run exists before inserting). RESTRICT FK would block legitimate
+-- admin pruning; CASCADE would silently delete audit data.
+--
+-- answer_meta is the kind-discriminated structured-response slot:
+-- v0.8.16 question writes either NULL or empty JSON; future approval
+-- writes {approved: bool, reason?: string}. The agent-visible result
+-- is the scalar `answer` field — `answer_meta` is for the resolver's
+-- structured payload that doesn't fit a single string.
+
+CREATE TABLE interrupts (
+    interrupt_id    TEXT             PRIMARY KEY,
+    run_id          TEXT             NOT NULL,
+    kind            TEXT             NOT NULL DEFAULT 'question',
+    status          TEXT             NOT NULL DEFAULT 'pending',
+    question        TEXT,
+    options         JSONB,
+    context_data    TEXT,
+    priority        TEXT             NOT NULL DEFAULT 'normal',
+    answer          TEXT,
+    answer_meta     JSONB,
+    created_at      TIMESTAMPTZ      NOT NULL,
+    expires_at      TIMESTAMPTZ,
+    resolved_at     TIMESTAMPTZ,
+    resolved_by     TEXT,
+    user_id         TEXT,
+    agent_id        TEXT,
+    agent_name      TEXT
+);
+
+-- Primary access patterns:
+--   1. "Is this run blocked on a pending interrupt?"  → (run_id, status)
+--   2. "What does this user need to answer?"          → (user_id, status)
+--   3. "Sweeper: what timeouts have fired?"           → (expires_at, status)
+
+CREATE INDEX interrupts_by_run_status  ON interrupts(run_id, status);
+CREATE INDEX interrupts_by_user_status ON interrupts(user_id, status) WHERE user_id IS NOT NULL;
+CREATE INDEX interrupts_by_expires     ON interrupts(expires_at)
+    WHERE expires_at IS NOT NULL AND status = 'pending';

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -757,6 +757,299 @@ func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
 	return int(tag.RowsAffected()), nil
 }
 
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// nullableTimePtr returns a *time.Time pointing at t when non-zero,
+// nil otherwise. Postgres expires_at / resolved_at are nullable
+// TIMESTAMPTZ; pgx writes SQL NULL on nil pointers.
+func nullableTimePtr(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t
+}
+
+// nullableStringArg returns the string when non-empty, nil otherwise
+// (writes SQL NULL via pgx).
+func nullableStringArg(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
+// nullableJSONArg returns the raw JSON as a string when non-empty,
+// nil otherwise. Postgres column type is JSONB; pgx-side we send TEXT
+// + cast via the ::jsonb in the INSERT/UPDATE query.
+func nullableJSONArg(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return string(b)
+}
+
+func (s *Store) InterruptCreate(ctx context.Context, r store.InterruptRow) (string, error) {
+	if r.InterruptID == "" {
+		return "", fmt.Errorf("interrupts: interrupt_id required")
+	}
+	if r.RunID == "" {
+		return "", fmt.Errorf("interrupts: run_id required")
+	}
+	if r.Kind == "" {
+		r.Kind = store.InterruptKindQuestion
+	}
+	if r.Status == "" {
+		r.Status = store.InterruptStatusPending
+	}
+	if r.Priority == "" {
+		r.Priority = store.InterruptPriorityNormal
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO interrupts (
+			interrupt_id, run_id, kind, status,
+			question, options, context_data, priority,
+			answer, answer_meta,
+			created_at, expires_at, resolved_at, resolved_by,
+			user_id, agent_id, agent_name
+		) VALUES (
+			$1, $2, $3, $4,
+			$5, $6::jsonb, $7, $8,
+			$9, $10::jsonb,
+			$11, $12, NULL, $13,
+			$14, $15, $16
+		)
+	`,
+		r.InterruptID, r.RunID, r.Kind, r.Status,
+		nullableStringArg(r.Question), nullableJSONArg(r.Options), nullableStringArg(r.ContextData), r.Priority,
+		nullableStringArg(r.Answer), nullableJSONArg(r.AnswerMeta),
+		createdAt, nullableTimePtr(r.ExpiresAt), nullableStringArg(r.ResolvedBy),
+		nullableStringArg(r.UserID), nullableStringArg(r.AgentID), nullableStringArg(r.AgentName),
+	)
+	if err != nil {
+		return "", fmt.Errorf("interrupts: create: %w", err)
+	}
+	return r.InterruptID, nil
+}
+
+func (s *Store) InterruptGet(ctx context.Context, interruptID string) (store.InterruptRow, error) {
+	row := s.pool.QueryRow(ctx, `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options::text, context_data, priority,
+		       answer, answer_meta::text,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE interrupt_id = $1
+	`, interruptID)
+	r, err := s.scanInterruptRow(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.InterruptRow{}, &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+	}
+	if err != nil {
+		return store.InterruptRow{}, fmt.Errorf("interrupts: get: %w", err)
+	}
+	return r, nil
+}
+
+// pgRowScanner abstracts pgx.Row / pgx.Rows for scanInterruptRow.
+type pgRowScanner interface {
+	Scan(dest ...any) error
+}
+
+func (s *Store) scanInterruptRow(row pgRowScanner) (store.InterruptRow, error) {
+	var r store.InterruptRow
+	var question, options, contextData, answer, answerMeta, resolvedBy, userID, agentID, agentName *string
+	var expiresAt, resolvedAt *time.Time
+	if err := row.Scan(
+		&r.InterruptID, &r.RunID, &r.Kind, &r.Status,
+		&question, &options, &contextData, &r.Priority,
+		&answer, &answerMeta,
+		&r.CreatedAt, &expiresAt, &resolvedAt, &resolvedBy,
+		&userID, &agentID, &agentName,
+	); err != nil {
+		return store.InterruptRow{}, err
+	}
+	if question != nil {
+		r.Question = *question
+	}
+	if contextData != nil {
+		r.ContextData = *contextData
+	}
+	if answer != nil {
+		r.Answer = *answer
+	}
+	if resolvedBy != nil {
+		r.ResolvedBy = *resolvedBy
+	}
+	if userID != nil {
+		r.UserID = *userID
+	}
+	if agentID != nil {
+		r.AgentID = *agentID
+	}
+	if agentName != nil {
+		r.AgentName = *agentName
+	}
+	if options != nil && *options != "" {
+		r.Options = json.RawMessage(*options)
+	}
+	if answerMeta != nil && *answerMeta != "" {
+		r.AnswerMeta = json.RawMessage(*answerMeta)
+	}
+	if expiresAt != nil {
+		r.ExpiresAt = *expiresAt
+	}
+	if resolvedAt != nil {
+		r.ResolvedAt = *resolvedAt
+	}
+	return r, nil
+}
+
+func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error {
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    answer      = $2,
+		    answer_meta = $3::jsonb,
+		    resolved_at = $4,
+		    resolved_by = $5
+		WHERE interrupt_id = $6 AND status = $7
+	`,
+		store.InterruptStatusResolved,
+		answer, nullableJSONArg(answerMeta),
+		time.Now(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: resolve: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var existing string
+		err := s.pool.QueryRow(ctx, `SELECT status FROM interrupts WHERE interrupt_id = $1`, interruptID).Scan(&existing)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: resolve probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
+	switch status {
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+		// ok
+	default:
+		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    resolved_at = $2,
+		    resolved_by = $3
+		WHERE interrupt_id = $4 AND status = $5
+	`,
+		status,
+		time.Now(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: finish: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		var existing string
+		err := s.pool.QueryRow(ctx, `SELECT status FROM interrupts WHERE interrupt_id = $1`, interruptID).Scan(&existing)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: finish probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "run_id", runID, statusFilter)
+}
+
+func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "user_id", userID, statusFilter)
+}
+
+func (s *Store) interruptList(ctx context.Context, col, val, statusFilter string) ([]store.InterruptRow, error) {
+	if col != "run_id" && col != "user_id" {
+		return nil, fmt.Errorf("interrupts: list: unknown filter column %q", col)
+	}
+	q := `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options::text, context_data, priority,
+		       answer, answer_meta::text,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE ` + col + ` = $1`
+	args := []any{val}
+	if statusFilter != "" {
+		q += ` AND status = $2`
+		args = append(args, statusFilter)
+	}
+	q += ` ORDER BY created_at DESC LIMIT 200`
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := s.scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) InterruptCountPendingByRun(ctx context.Context, runID string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM interrupts WHERE run_id = $1 AND status = $2
+	`, runID, store.InterruptStatusPending).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: count pending: %w", err)
+	}
+	return n, nil
+}
+
+func (s *Store) InterruptSweepExpired(ctx context.Context) (int, error) {
+	now := time.Now()
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE interrupts
+		SET status      = $1,
+		    resolved_at = $2,
+		    resolved_by = $3
+		WHERE status = $4 AND expires_at IS NOT NULL AND expires_at < $5
+	`,
+		store.InterruptStatusTimedOut,
+		now, store.InterruptResolvedByTimeout,
+		store.InterruptStatusPending, now,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: sweep: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // Close releases the connection pool. Idempotent.
 func (s *Store) Close() error {
 	s.closeOnce.Do(func() {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -244,6 +244,34 @@ func (s *Store) migrate(ctx context.Context) error {
 			expires_at  INTEGER NOT NULL DEFAULT 0,
 			description TEXT
 		)`,
+		// v0.8.16 Interruption tool. Agents call Interruption.ask /
+		// .notify / .cancel; pending rows block the run until resolved.
+		// kind is the closed-enum future-proofing for v0.9.x pause /
+		// wait_until / approval — v0.8.16 writes only kind='question'.
+		// user_id / agent_id / agent_name denormalised from the run
+		// row so listing queries never need a JOIN. Timestamps as
+		// INTEGER (unix-nano) per existing sqlite pattern. No FK on
+		// run_id (same reasoning as evaluations — immutable audit log
+		// must survive any future run pruning).
+		`CREATE TABLE IF NOT EXISTS interrupts (
+			interrupt_id    TEXT    PRIMARY KEY,
+			run_id          TEXT    NOT NULL,
+			kind            TEXT    NOT NULL DEFAULT 'question',
+			status          TEXT    NOT NULL DEFAULT 'pending',
+			question        TEXT,
+			options         TEXT,
+			context_data    TEXT,
+			priority        TEXT    NOT NULL DEFAULT 'normal',
+			answer          TEXT,
+			answer_meta     TEXT,
+			created_at      INTEGER NOT NULL,
+			expires_at      INTEGER,
+			resolved_at     INTEGER,
+			resolved_by     TEXT,
+			user_id         TEXT,
+			agent_id        TEXT,
+			agent_name      TEXT
+		)`,
 	}
 	for _, q := range stmts {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -320,6 +348,17 @@ func (s *Store) migrate(ctx context.Context) error {
 		// (DELETE WHERE expires_at < now() AND expires_at > 0) and the
 		// per-Get expiry filter. Partial: only TTL-bearing rows.
 		`CREATE INDEX IF NOT EXISTS dynamic_agents_by_expires_at ON dynamic_agents(expires_at) WHERE expires_at > 0`,
+		// v0.8.16 Interruption tool indexes.
+		//   * by_run_status drives "is this run blocked?" + listing.
+		//   * by_user_status drives the Web UI inbox view (the
+		//     denormalised user_id column makes this a single-table
+		//     scan, no JOIN against runs).
+		//   * by_expires_pending drives the timeout sweeper.
+		// Partial on by_user / by_expires so the index stays small
+		// when the bulk of rows are resolved/terminal.
+		`CREATE INDEX IF NOT EXISTS interrupts_by_run_status  ON interrupts(run_id, status)`,
+		`CREATE INDEX IF NOT EXISTS interrupts_by_user_status ON interrupts(user_id, status) WHERE user_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS interrupts_by_expires     ON interrupts(expires_at) WHERE expires_at IS NOT NULL AND status = 'pending'`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -2246,6 +2285,332 @@ func (s *Store) DynamicAgentSweep(ctx context.Context) (int, error) {
 	`, time.Now().UnixNano())
 	if err != nil {
 		return 0, fmt.Errorf("dynamic_agents: sweep: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return int(n), nil
+}
+
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// nanosOrNull returns NULL when t is zero, unix-nanos otherwise. The
+// zero-time → NULL contract is documented on InterruptRow.ExpiresAt.
+func nanosOrNull(t time.Time) any {
+	if t.IsZero() {
+		return nil
+	}
+	return t.UnixNano()
+}
+
+// nullableNanos scans an INTEGER-or-NULL column into a time. NULL
+// becomes time.Time{} (zero value).
+func nullableNanos(ns sql.NullInt64) time.Time {
+	if !ns.Valid || ns.Int64 == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns.Int64)
+}
+
+// nullableString scans a TEXT-or-NULL column into a string. NULL
+// becomes "" — matches how the upper layer treats absent values.
+func nullableString(ns sql.NullString) string {
+	if !ns.Valid {
+		return ""
+	}
+	return ns.String
+}
+
+// nullableRawJSON scans a TEXT-or-NULL column holding JSON. NULL
+// returns nil, not the JSON null literal; callers distinguish via
+// `len(...) == 0`.
+func nullableRawJSON(ns sql.NullString) json.RawMessage {
+	if !ns.Valid || ns.String == "" {
+		return nil
+	}
+	return json.RawMessage(ns.String)
+}
+
+func (s *Store) InterruptCreate(ctx context.Context, r store.InterruptRow) (string, error) {
+	if r.InterruptID == "" {
+		return "", fmt.Errorf("interrupts: interrupt_id required")
+	}
+	if r.RunID == "" {
+		return "", fmt.Errorf("interrupts: run_id required")
+	}
+	if r.Kind == "" {
+		r.Kind = store.InterruptKindQuestion
+	}
+	if r.Status == "" {
+		r.Status = store.InterruptStatusPending
+	}
+	if r.Priority == "" {
+		r.Priority = store.InterruptPriorityNormal
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now()
+	}
+	// Question/options/context_data are NULLed when empty so the
+	// column distinguishes "not set" from "empty string". Same
+	// pattern as channel_messages payload.
+	var question, contextData, answer, resolvedBy any
+	if r.Question != "" {
+		question = r.Question
+	}
+	if r.ContextData != "" {
+		contextData = r.ContextData
+	}
+	if r.Answer != "" {
+		answer = r.Answer
+	}
+	if r.ResolvedBy != "" {
+		resolvedBy = r.ResolvedBy
+	}
+	var options, answerMeta any
+	if len(r.Options) > 0 {
+		options = string(r.Options)
+	}
+	if len(r.AnswerMeta) > 0 {
+		answerMeta = string(r.AnswerMeta)
+	}
+	var userID, agentID, agentName any
+	if r.UserID != "" {
+		userID = r.UserID
+	}
+	if r.AgentID != "" {
+		agentID = r.AgentID
+	}
+	if r.AgentName != "" {
+		agentName = r.AgentName
+	}
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO interrupts (
+			interrupt_id, run_id, kind, status,
+			question, options, context_data, priority,
+			answer, answer_meta,
+			created_at, expires_at, resolved_at, resolved_by,
+			user_id, agent_id, agent_name
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?)
+	`,
+		r.InterruptID, r.RunID, r.Kind, r.Status,
+		question, options, contextData, r.Priority,
+		answer, answerMeta,
+		createdAt.UnixNano(), nanosOrNull(r.ExpiresAt), resolvedBy,
+		userID, agentID, agentName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("interrupts: create: %w", err)
+	}
+	return r.InterruptID, nil
+}
+
+func (s *Store) InterruptGet(ctx context.Context, interruptID string) (store.InterruptRow, error) {
+	row := s.db.QueryRowContext(ctx, `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options, context_data, priority,
+		       answer, answer_meta,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE interrupt_id = ?
+	`, interruptID)
+	r, err := scanInterruptRow(row)
+	if err == sql.ErrNoRows {
+		return store.InterruptRow{}, &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+	}
+	if err != nil {
+		return store.InterruptRow{}, fmt.Errorf("interrupts: get: %w", err)
+	}
+	return r, nil
+}
+
+// rowScanner abstracts *sql.Row / *sql.Rows so scanInterruptRow works
+// for both Get (single row) and List (loop). Same trick used by other
+// adapter helpers.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanInterruptRow(row rowScanner) (store.InterruptRow, error) {
+	var r store.InterruptRow
+	var question, contextData, answer, resolvedBy, userID, agentID, agentName sql.NullString
+	var options, answerMeta sql.NullString
+	var createdAtNS int64
+	var expiresAtNS, resolvedAtNS sql.NullInt64
+	if err := row.Scan(
+		&r.InterruptID, &r.RunID, &r.Kind, &r.Status,
+		&question, &options, &contextData, &r.Priority,
+		&answer, &answerMeta,
+		&createdAtNS, &expiresAtNS, &resolvedAtNS, &resolvedBy,
+		&userID, &agentID, &agentName,
+	); err != nil {
+		return store.InterruptRow{}, err
+	}
+	r.Question = nullableString(question)
+	r.ContextData = nullableString(contextData)
+	r.Answer = nullableString(answer)
+	r.ResolvedBy = nullableString(resolvedBy)
+	r.UserID = nullableString(userID)
+	r.AgentID = nullableString(agentID)
+	r.AgentName = nullableString(agentName)
+	r.Options = nullableRawJSON(options)
+	r.AnswerMeta = nullableRawJSON(answerMeta)
+	r.CreatedAt = time.Unix(0, createdAtNS)
+	r.ExpiresAt = nullableNanos(expiresAtNS)
+	r.ResolvedAt = nullableNanos(resolvedAtNS)
+	return r, nil
+}
+
+func (s *Store) InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error {
+	var meta any
+	if len(answerMeta) > 0 {
+		meta = string(answerMeta)
+	}
+	// Gated by status='pending' so the resolve loses cleanly when
+	// another resolver / sweeper has already finalised the row.
+	// RowsAffected==0 distinguishes "row missing" (still 0 affected)
+	// from "row already terminal" (also 0 affected) — we resolve the
+	// ambiguity with a follow-up SELECT.
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    answer      = ?,
+		    answer_meta = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE interrupt_id = ? AND status = ?
+	`,
+		store.InterruptStatusResolved,
+		answer, meta,
+		time.Now().UnixNano(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: resolve: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Disambiguate: not-found vs already-terminal.
+		var existing string
+		err := s.db.QueryRowContext(ctx, `SELECT status FROM interrupts WHERE interrupt_id = ?`, interruptID).Scan(&existing)
+		if err == sql.ErrNoRows {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: resolve probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error {
+	switch status {
+	case store.InterruptStatusTimedOut, store.InterruptStatusCancelled:
+		// ok
+	default:
+		return fmt.Errorf("interrupts: finish: invalid terminal status %q", status)
+	}
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE interrupt_id = ? AND status = ?
+	`,
+		status,
+		time.Now().UnixNano(), resolvedBy,
+		interruptID, store.InterruptStatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("interrupts: finish: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		var existing string
+		err := s.db.QueryRowContext(ctx, `SELECT status FROM interrupts WHERE interrupt_id = ?`, interruptID).Scan(&existing)
+		if err == sql.ErrNoRows {
+			return &store.ErrNotFound{Kind: "interrupt", ID: interruptID}
+		}
+		if err != nil {
+			return fmt.Errorf("interrupts: finish probe: %w", err)
+		}
+		return store.ErrInterruptAlreadyTerminal
+	}
+	return nil
+}
+
+func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "run_id", runID, statusFilter)
+}
+
+func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
+	return s.interruptList(ctx, "user_id", userID, statusFilter)
+}
+
+// interruptList is the shared SELECT body for ListByRun / ListByUser.
+// `col` is the indexed filter column; we never embed user input here,
+// so a static switch keeps the query parameter-binding safe.
+func (s *Store) interruptList(ctx context.Context, col, val, statusFilter string) ([]store.InterruptRow, error) {
+	if col != "run_id" && col != "user_id" {
+		return nil, fmt.Errorf("interrupts: list: unknown filter column %q", col)
+	}
+	q := `
+		SELECT interrupt_id, run_id, kind, status,
+		       question, options, context_data, priority,
+		       answer, answer_meta,
+		       created_at, expires_at, resolved_at, resolved_by,
+		       user_id, agent_id, agent_name
+		FROM interrupts
+		WHERE ` + col + ` = ?`
+	args := []any{val}
+	if statusFilter != "" {
+		q += ` AND status = ?`
+		args = append(args, statusFilter)
+	}
+	q += ` ORDER BY created_at DESC LIMIT 200`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) InterruptCountPendingByRun(ctx context.Context, runID string) (int, error) {
+	var n int
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM interrupts WHERE run_id = ? AND status = ?
+	`, runID, store.InterruptStatusPending).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: count pending: %w", err)
+	}
+	return n, nil
+}
+
+func (s *Store) InterruptSweepExpired(ctx context.Context) (int, error) {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE interrupts
+		SET status      = ?,
+		    resolved_at = ?,
+		    resolved_by = ?
+		WHERE status = ? AND expires_at IS NOT NULL AND expires_at < ?
+	`,
+		store.InterruptStatusTimedOut,
+		time.Now().UnixNano(), store.InterruptResolvedByTimeout,
+		store.InterruptStatusPending, time.Now().UnixNano(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("interrupts: sweep: %w", err)
 	}
 	n, _ := res.RowsAffected()
 	return int(n), nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -625,6 +625,68 @@ type Store interface {
 	// sweepers (single atomic DELETE).
 	DynamicAgentSweep(ctx context.Context) (int, error)
 
+	// ---- Interruption (v0.8.16) -------------------------------------
+	//
+	// Durable row that survives process restart + drives the listing
+	// APIs. The tool-layer waiter (channels.Bus key) carries the
+	// in-process wake; the row carries the state.
+	//
+	// kind is a closed enum owned by loomcycle. v0.8.16 writes only
+	// "question". Future kinds (pause / wait_until / approval) are
+	// additive enum values on the same column; the schema does not
+	// need to change. See doc-internal/rfcs/interruption-tool.md §8.
+
+	// InterruptCreate inserts a fresh interrupt row in status=pending.
+	// The caller pre-generates row.InterruptID via MintInterruptID.
+	// CreatedAt is set by the store. Returns the persisted ID. On
+	// row.ExpiresAt zero-value, no expiry is recorded (NULL column).
+	InterruptCreate(ctx context.Context, row InterruptRow) (string, error)
+
+	// InterruptGet returns one row by interrupt_id. *ErrNotFound on
+	// miss (Kind: "interrupt").
+	InterruptGet(ctx context.Context, interruptID string) (InterruptRow, error)
+
+	// InterruptResolve transitions a pending interrupt to status=
+	// resolved with the supplied answer + answer_meta. Sets
+	// resolved_at = now() server-side. Returns ErrInterruptAlreadyTerminal
+	// when the row was already in a terminal state (resolved /
+	// timed_out / cancelled) — the UPDATE is gated by status='pending'.
+	// answerMeta may be nil; the column then writes SQL NULL.
+	InterruptResolve(ctx context.Context, interruptID, answer, resolvedBy string, answerMeta json.RawMessage) error
+
+	// InterruptFinish transitions a pending interrupt to a terminal
+	// status WITHOUT an answer (used for timeout sweeper + agent-side
+	// cancel). status must be one of: "timed_out" / "cancelled".
+	// resolvedBy is recorded for audit. Returns
+	// ErrInterruptAlreadyTerminal on a non-pending row.
+	InterruptFinish(ctx context.Context, interruptID, status, resolvedBy string) error
+
+	// InterruptListByRun returns interrupts for the given run_id,
+	// newest first. statusFilter is one of: ""="all",
+	// "pending" / "resolved" / "timed_out" / "cancelled".
+	// Capped at 200 rows.
+	InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]InterruptRow, error)
+
+	// InterruptListByUser returns interrupts owned by user_id,
+	// newest first. statusFilter same shape as ListByRun. The
+	// denormalised user_id column drives this query without a JOIN
+	// against runs. Capped at 200 rows.
+	InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]InterruptRow, error)
+
+	// InterruptCountPendingByRun returns the count of status=pending
+	// interrupts for the given run_id. Drives max_pending enforcement
+	// at the tool layer (the count check is a single round trip; the
+	// subsequent InterruptCreate is a separate transaction — operators
+	// SHOULD treat max_pending as advisory, not a hard concurrency
+	// guard. See rfcs/interruption-tool.md §6).
+	InterruptCountPendingByRun(ctx context.Context, runID string) (int, error)
+
+	// InterruptSweepExpired marks every status=pending interrupt
+	// whose expires_at < now as timed_out. Returns the count
+	// transitioned. Safe to run from a periodic goroutine;
+	// idempotent under concurrent sweepers (single atomic UPDATE).
+	InterruptSweepExpired(ctx context.Context) (int, error)
+
 	// Close releases backend resources. Idempotent.
 	Close() error
 }
@@ -947,6 +1009,85 @@ var ErrAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "
 // someone tries to UPDATE an agent_defs row's definition column.
 // Append-only invariant. The adapter's contract test pins this.
 var ErrAgentDefImmutable = &SubstrateError{Code: "immutable", Msg: "agent_def: rows are append-only; create a new version"}
+
+// ---- Interruption (v0.8.16) -----------------------------------------
+
+// Interrupt kind / status / resolved-by enum values. v0.8.16 only
+// uses kind=question; future values land here as additive enum
+// extensions.
+const (
+	InterruptKindQuestion = "question"
+
+	InterruptStatusPending   = "pending"
+	InterruptStatusResolved  = "resolved"
+	InterruptStatusTimedOut  = "timed_out"
+	InterruptStatusCancelled = "cancelled"
+
+	InterruptPriorityLow    = "low"
+	InterruptPriorityNormal = "normal"
+	InterruptPriorityHigh   = "high"
+
+	// ResolvedBy attribution values. The set is open at the type
+	// level (TEXT column) but semantically closed — these are the
+	// values loomcycle itself writes. External admin tooling may
+	// invent its own (e.g. "claude_code") and that's allowed.
+	InterruptResolvedByWebUI       = "webui"
+	InterruptResolvedByMCP         = "mcp"
+	InterruptResolvedByCLI         = "cli"
+	InterruptResolvedByAPI         = "api"
+	InterruptResolvedByTimeout     = "timeout"
+	InterruptResolvedByAgentCancel = "agent_cancel"
+)
+
+// MintInterruptID returns a fresh interrupt_id that's monotonic-by-
+// create-time AND globally unique. Format:
+// "intr_<16-hex unixNanos><8-hex rand>" — 24 hex chars after the
+// prefix. Mirrors MintChannelMessageID / MintSampleID; same lex-
+// sortable invariant through year 2262.
+func MintInterruptID(t time.Time) string {
+	var buf [4]byte
+	_, _ = rand.Read(buf[:])
+	return fmt.Sprintf("intr_%016x%s", uint64(t.UnixNano()), hex.EncodeToString(buf[:]))
+}
+
+// InterruptRow is one row in the `interrupts` table. Caller supplies
+// InterruptID + RunID + Kind + (kind-specific fields); the store
+// fills CreatedAt and (on resolve / finish) ResolvedAt + ResolvedBy.
+//
+// user_id / agent_id / agent_name are denormalised at create time
+// from the run identity so listing queries don't need a JOIN. The
+// caller MUST stamp them — the store never JOINs.
+//
+// Options and AnswerMeta are JSON-encoded blobs. For kind=question,
+// Options is a JSON array of strings (NULL = free-text). AnswerMeta
+// is kind-discriminated extra resolve data (NULL for v0.8.16
+// question — the scalar Answer field carries everything).
+type InterruptRow struct {
+	InterruptID string          `json:"interrupt_id"`
+	RunID       string          `json:"run_id"`
+	Kind        string          `json:"kind"`
+	Status      string          `json:"status"`
+	Question    string          `json:"question,omitempty"`
+	Options     json.RawMessage `json:"options,omitempty"`
+	ContextData string          `json:"context_data,omitempty"`
+	Priority    string          `json:"priority"`
+	Answer      string          `json:"answer,omitempty"`
+	AnswerMeta  json.RawMessage `json:"answer_meta,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	ExpiresAt   time.Time       `json:"expires_at,omitempty"` // zero = no expiry
+	ResolvedAt  time.Time       `json:"resolved_at,omitempty"`
+	ResolvedBy  string          `json:"resolved_by,omitempty"`
+	UserID      string          `json:"user_id,omitempty"`
+	AgentID     string          `json:"agent_id,omitempty"`
+	AgentName   string          `json:"agent_name,omitempty"`
+}
+
+// ErrInterruptAlreadyTerminal is returned by InterruptResolve /
+// InterruptFinish when the row is already in a terminal status
+// (resolved / timed_out / cancelled). Distinct from ErrNotFound:
+// the row exists, but the resolve / finish race lost. The tool
+// layer maps this to HTTP 409 Conflict.
+var ErrInterruptAlreadyTerminal = &SubstrateError{Code: "already_terminal", Msg: "interrupt: already resolved, timed out, or cancelled"}
 
 // SubstrateError envelopes substrate-specific errors so the tool
 // layer can pattern-match on Code. Mirror of MemoryError /

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -121,6 +121,19 @@ func Run(t *testing.T, factory Factory) {
 		{"MetricsRunSummaryWithSamples", testMetricsRunSummaryWithSamples},
 		{"MetricsRunSummaryInFlight", testMetricsRunSummaryInFlight},
 		{"MetricsRunSummaryNotFound", testMetricsRunSummaryNotFound},
+		// v0.8.16 Interruption tool storage layer
+		{"InterruptCreateAndGet", testInterruptCreateAndGet},
+		{"InterruptGetNotFound", testInterruptGetNotFound},
+		{"InterruptResolveSetsStatusAndFields", testInterruptResolveSetsStatusAndFields},
+		{"InterruptResolveRejectsAlreadyTerminal", testInterruptResolveRejectsAlreadyTerminal},
+		{"InterruptResolveRoundTripsAnswerMeta", testInterruptResolveRoundTripsAnswerMeta},
+		{"InterruptFinishSetsTimedOut", testInterruptFinishSetsTimedOut},
+		{"InterruptFinishRejectsAlreadyTerminal", testInterruptFinishRejectsAlreadyTerminal},
+		{"InterruptListByRunFiltersByStatus", testInterruptListByRunFiltersByStatus},
+		{"InterruptListByUserFiltersByStatus", testInterruptListByUserFiltersByStatus},
+		{"InterruptCountPendingByRunIsAccurateUnderConcurrency", testInterruptCountPendingByRunIsAccurateUnderConcurrency},
+		{"InterruptSweepExpiredMarksOnlyExpiredPending", testInterruptSweepExpiredMarksOnlyExpiredPending},
+		{"InterruptIDIsMonotonicByTime", testInterruptIDIsMonotonicByTime},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2177,5 +2190,363 @@ func testMetricsRunSummaryNotFound(t *testing.T, s store.Store) {
 	}
 	if nf != nil && nf.Kind != "run" {
 		t.Errorf("Kind = %q, want run", nf.Kind)
+	}
+}
+
+// ---- Interruption (v0.8.16) ----------------------------------------
+
+// makeRunForInterrupt creates a session + run with given identity
+// fields. Returns the run_id. Helper so each interruption test
+// doesn't repeat the boilerplate.
+func makeRunForInterrupt(t *testing.T, s store.Store, userID, agentID, agentName string) (sessID, runID string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := s.CreateSession(ctx, "t", agentName, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: agentID,
+		UserID:  userID,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return sess.ID, run.ID
+}
+
+func testInterruptCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_1", "batch-processor")
+
+	id := store.MintInterruptID(time.Now())
+	row := store.InterruptRow{
+		InterruptID: id,
+		RunID:       runID,
+		Kind:        store.InterruptKindQuestion,
+		Question:    "Proceed with delete?",
+		Options:     json.RawMessage(`["Yes","No"]`),
+		ContextData: "47 records pending",
+		Priority:    store.InterruptPriorityNormal,
+		UserID:      "u_alice",
+		AgentID:     "a_intr_1",
+		AgentName:   "batch-processor",
+		CreatedAt:   time.Now(),
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	}
+	got, err := s.InterruptCreate(ctx, row)
+	if err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+	if got != id {
+		t.Errorf("returned id = %q, want %q", got, id)
+	}
+
+	r, err := s.InterruptGet(ctx, id)
+	if err != nil {
+		t.Fatalf("InterruptGet: %v", err)
+	}
+	if r.Status != store.InterruptStatusPending {
+		t.Errorf("Status = %q, want pending", r.Status)
+	}
+	if r.Question != "Proceed with delete?" {
+		t.Errorf("Question = %q", r.Question)
+	}
+	if string(r.Options) == "" || string(r.Options) == "null" {
+		t.Errorf("Options round-trip empty: %q", string(r.Options))
+	}
+	if r.UserID != "u_alice" {
+		t.Errorf("UserID = %q, want u_alice (denormalised at create)", r.UserID)
+	}
+	if r.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt round-tripped zero; want non-zero")
+	}
+}
+
+func testInterruptGetNotFound(t *testing.T, s store.Store) {
+	_, err := s.InterruptGet(context.Background(), "intr_doesnotexist")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
+	}
+	if nf != nil && nf.Kind != "interrupt" {
+		t.Errorf("Kind = %q, want interrupt", nf.Kind)
+	}
+}
+
+func testInterruptResolveSetsStatusAndFields(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_r", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	if _, err := s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", Priority: store.InterruptPriorityNormal,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatalf("InterruptResolve: %v", err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if r.Status != store.InterruptStatusResolved {
+		t.Errorf("Status = %q, want resolved", r.Status)
+	}
+	if r.Answer != "Yes" {
+		t.Errorf("Answer = %q, want Yes", r.Answer)
+	}
+	if r.ResolvedBy != store.InterruptResolvedByWebUI {
+		t.Errorf("ResolvedBy = %q", r.ResolvedBy)
+	}
+	if r.ResolvedAt.IsZero() {
+		t.Error("ResolvedAt is zero; want set")
+	}
+}
+
+func testInterruptResolveRejectsAlreadyTerminal(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_dup", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatal(err)
+	}
+	// Second resolve must fail with ErrInterruptAlreadyTerminal.
+	err := s.InterruptResolve(ctx, id, "No", store.InterruptResolvedByWebUI, nil)
+	if !errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+		t.Errorf("got %v, want ErrInterruptAlreadyTerminal", err)
+	}
+}
+
+func testInterruptResolveRoundTripsAnswerMeta(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_meta", "approver")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Approve delete?", CreatedAt: time.Now(),
+	})
+	meta := json.RawMessage(`{"approved":true,"reason":"verified manually"}`)
+	if err := s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, meta); err != nil {
+		t.Fatal(err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if len(r.AnswerMeta) == 0 {
+		t.Fatal("AnswerMeta round-tripped empty")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(r.AnswerMeta, &decoded); err != nil {
+		t.Fatalf("AnswerMeta unmarshal: %v (raw %q)", err, string(r.AnswerMeta))
+	}
+	if decoded["approved"] != true || decoded["reason"] != "verified manually" {
+		t.Errorf("AnswerMeta decoded = %+v", decoded)
+	}
+}
+
+func testInterruptFinishSetsTimedOut(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_fin", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	if err := s.InterruptFinish(ctx, id, store.InterruptStatusTimedOut, store.InterruptResolvedByTimeout); err != nil {
+		t.Fatalf("InterruptFinish: %v", err)
+	}
+	r, _ := s.InterruptGet(ctx, id)
+	if r.Status != store.InterruptStatusTimedOut {
+		t.Errorf("Status = %q, want timed_out", r.Status)
+	}
+	if r.Answer != "" {
+		t.Errorf("Answer = %q on timeout path; want empty", r.Answer)
+	}
+}
+
+func testInterruptFinishRejectsAlreadyTerminal(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_fin_dup", "batch")
+
+	id := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "u_alice",
+		Question: "Q?", CreatedAt: time.Now(),
+	})
+	_ = s.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil)
+	err := s.InterruptFinish(ctx, id, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+	if !errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+		t.Errorf("got %v, want ErrInterruptAlreadyTerminal", err)
+	}
+}
+
+func testInterruptListByRunFiltersByStatus(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_list", "batch")
+
+	// Three interrupts: one pending, one resolved, one cancelled.
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id1, RunID: runID, UserID: "u_alice", Question: "Q1", CreatedAt: time.Now()})
+	id2 := store.MintInterruptID(time.Now().Add(time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id2, RunID: runID, UserID: "u_alice", Question: "Q2", CreatedAt: time.Now().Add(time.Millisecond)})
+	_ = s.InterruptResolve(ctx, id2, "ok", store.InterruptResolvedByWebUI, nil)
+	id3 := store.MintInterruptID(time.Now().Add(2 * time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id3, RunID: runID, UserID: "u_alice", Question: "Q3", CreatedAt: time.Now().Add(2 * time.Millisecond)})
+	_ = s.InterruptFinish(ctx, id3, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+
+	all, err := s.InterruptListByRun(ctx, runID, "")
+	if err != nil {
+		t.Fatalf("List all: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("list-all returned %d rows, want 3", len(all))
+	}
+
+	pending, _ := s.InterruptListByRun(ctx, runID, store.InterruptStatusPending)
+	if len(pending) != 1 || pending[0].InterruptID != id1 {
+		t.Errorf("pending filter returned %d rows; want 1 (id=%s)", len(pending), id1)
+	}
+}
+
+func testInterruptListByUserFiltersByStatus(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runA := makeRunForInterrupt(t, s, "u_bob", "a_intr_ub_1", "agent-a")
+	_, runB := makeRunForInterrupt(t, s, "u_bob", "a_intr_ub_2", "agent-b")
+	_, runC := makeRunForInterrupt(t, s, "u_other", "a_intr_uo_1", "agent-c")
+
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id1, RunID: runA, UserID: "u_bob", Question: "Q from A", CreatedAt: time.Now()})
+	id2 := store.MintInterruptID(time.Now().Add(time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id2, RunID: runB, UserID: "u_bob", Question: "Q from B", CreatedAt: time.Now().Add(time.Millisecond)})
+	// Unrelated user — must not appear in u_bob's listing.
+	id3 := store.MintInterruptID(time.Now().Add(2 * time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id3, RunID: runC, UserID: "u_other", Question: "Q from C", CreatedAt: time.Now().Add(2 * time.Millisecond)})
+
+	rows, err := s.InterruptListByUser(ctx, "u_bob", store.InterruptStatusPending)
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows for u_bob, want 2", len(rows))
+	}
+	for _, r := range rows {
+		if r.UserID != "u_bob" {
+			t.Errorf("listing leaked row from %q", r.UserID)
+		}
+	}
+}
+
+func testInterruptCountPendingByRunIsAccurateUnderConcurrency(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_count", "batch")
+
+	const N = 20
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := store.MintInterruptID(time.Now())
+			_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+				InterruptID: id, RunID: runID, UserID: "u_alice",
+				Question: "Q?", CreatedAt: time.Now(),
+			})
+		}(i)
+	}
+	wg.Wait()
+	n, err := s.InterruptCountPendingByRun(ctx, runID)
+	if err != nil {
+		t.Fatalf("InterruptCountPendingByRun: %v", err)
+	}
+	if n != N {
+		t.Errorf("count = %d, want %d under parallel inserts", n, N)
+	}
+}
+
+func testInterruptSweepExpiredMarksOnlyExpiredPending(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_sweep", "batch")
+
+	// Row 1: expired pending — should be swept.
+	id1 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id1, RunID: runID, UserID: "u_alice", Question: "Q1",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	})
+	// Row 2: future expiry — must NOT be swept.
+	id2 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id2, RunID: runID, UserID: "u_alice", Question: "Q2",
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+	// Row 3: no expiry — must NOT be swept.
+	id3 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id3, RunID: runID, UserID: "u_alice", Question: "Q3",
+		CreatedAt: time.Now(),
+		// ExpiresAt zero → no expiry
+	})
+	// Row 4: expired but already resolved — must NOT change status.
+	id4 := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id4, RunID: runID, UserID: "u_alice", Question: "Q4",
+		CreatedAt: time.Now().Add(-2 * time.Hour),
+		ExpiresAt: time.Now().Add(-1 * time.Hour),
+	})
+	_ = s.InterruptResolve(ctx, id4, "answered before expiry", store.InterruptResolvedByWebUI, nil)
+
+	n, err := s.InterruptSweepExpired(ctx)
+	if err != nil {
+		t.Fatalf("InterruptSweepExpired: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("swept %d rows, want 1", n)
+	}
+	r1, _ := s.InterruptGet(ctx, id1)
+	if r1.Status != store.InterruptStatusTimedOut {
+		t.Errorf("Row1 status = %q, want timed_out", r1.Status)
+	}
+	if r1.ResolvedBy != store.InterruptResolvedByTimeout {
+		t.Errorf("Row1 ResolvedBy = %q, want timeout", r1.ResolvedBy)
+	}
+	r2, _ := s.InterruptGet(ctx, id2)
+	if r2.Status != store.InterruptStatusPending {
+		t.Errorf("Row2 status = %q, want pending (future expiry)", r2.Status)
+	}
+	r3, _ := s.InterruptGet(ctx, id3)
+	if r3.Status != store.InterruptStatusPending {
+		t.Errorf("Row3 status = %q, want pending (no expiry)", r3.Status)
+	}
+	r4, _ := s.InterruptGet(ctx, id4)
+	if r4.Status != store.InterruptStatusResolved {
+		t.Errorf("Row4 status = %q, want resolved (must not re-finalise)", r4.Status)
+	}
+}
+
+func testInterruptIDIsMonotonicByTime(t *testing.T, s store.Store) {
+	// Pure unit-style check on the MintInterruptID format — IDs minted
+	// later in time must lex-compare greater than earlier IDs. The
+	// `interrupts_by_run_status` index orders by created_at internally,
+	// but ID monotonicity is the operator-debugging-eyeball property
+	// described on MintInterruptID's docstring.
+	t1 := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(time.Microsecond)
+	id1 := store.MintInterruptID(t1)
+	id2 := store.MintInterruptID(t2)
+	if !(id1 < id2) {
+		t.Errorf("MintInterruptID not monotonic by time: %s ≥ %s (t1=%v t2=%v)", id1, id2, t1, t2)
+	}
+	const wantLen = len("intr_") + 16 + 8
+	if len(id1) != wantLen {
+		t.Errorf("id length = %d, want %d", len(id1), wantLen)
 	}
 }

--- a/internal/tools/builtin/interruption.go
+++ b/internal/tools/builtin/interruption.go
@@ -1,0 +1,617 @@
+// Package builtin's Interruption tool — v0.8.16.
+//
+// Human-in-the-loop primitive. Three ops on a single discriminated
+// `op` field, matching Memory / Channel / AgentDef / Evaluation /
+// Context:
+//
+//   - ask     — surface a question to a human; agent loop blocks
+//     until answered, timed out, or cancelled.
+//   - notify  — fire-and-forget message (no answer expected).
+//   - cancel  — agent unblocks a previously-asked question (e.g.
+//     it figured the answer out on its own).
+//
+// `ask` is the load-bearing op — it blocks the loop via
+// channels.Bus.Wait on a dedicated bus key ("intr:<id>"). The Web UI
+// (the v0.8.16 default delivery surface) resolves via
+// POST /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve, which
+// writes the resolved row + calls bus.Notify; this Execute wakes,
+// reads the answer, returns it as the tool result, and the loop's
+// next iteration uses the human's input.
+//
+// A dedicated heartbeat ticker fires opts.OnHeartbeat at a
+// configurable interval (default 30s) while the call is blocked.
+// Without this, a question that waits an hour gets swept as a
+// crashed run by the v0.5.0 heartbeat sweeper (default StaleAfter
+// 10 minutes, calibrated for tool-dispatch durations).
+//
+// Future-kinds (pause / wait_until / approval) slot in additively
+// on the same `kind` enum column without reopening this tool — see
+// doc-internal/rfcs/interruption-tool.md §8.
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Interruption is the v0.8.16 human-in-the-loop tool.
+type Interruption struct {
+	// Store is the persistence backend. Required.
+	Store store.Store
+
+	// Bus is the in-process notification bus. Required — ask blocks
+	// on bus.Wait, the HTTP resolve endpoint calls bus.Notify.
+	// Without it, ask polls storage every Wait timeout, which would
+	// make resolves visibly laggy.
+	Bus *channels.Bus
+
+	// SystemPublisher publishes to the `_system/interrupts/pending`
+	// and `_system/interrupts/resolved` channels (operator-declared
+	// per the v0.8.6 system-channels pattern). Optional — when nil,
+	// the tool still functions but external Channel subscribers
+	// (Web UI, Slack bot, etc.) won't see pub/sub signals. The
+	// in-process bus.Notify path still works.
+	SystemPublisher channels.SystemPublisher
+
+	// The heartbeat-during-block path uses Store.UpdateHeartbeat
+	// directly (run id recovered from ctx). No injected closure.
+
+	// DefaultTimeout is the timeout applied when an `ask` doesn't
+	// pass timeout_ms. 0 = no timeout (the interruption sits
+	// pending indefinitely). Sourced from
+	// LOOMCYCLE_INTERRUPTION_DEFAULT_TIMEOUT_MS at boot.
+	DefaultTimeout time.Duration
+
+	// MaxTimeout is the hard ceiling. timeout_ms above this is
+	// clamped down to MaxTimeout. 0 = no ceiling. Sourced from
+	// LOOMCYCLE_INTERRUPTION_MAX_TIMEOUT_MS.
+	MaxTimeout time.Duration
+
+	// HeartbeatInterval governs the ticker cadence. 0 = use the
+	// 30-second default. Sourced from
+	// LOOMCYCLE_INTERRUPTION_HEARTBEAT_INTERVAL_MS.
+	HeartbeatInterval time.Duration
+
+	// MaxPendingPerRun is the operator-global cap on simultaneous
+	// pending interruptions per run. Agent yaml may NARROW (set its
+	// own lower cap) but cannot exceed this. 0 = unbounded.
+	// Sourced from LOOMCYCLE_INTERRUPTION_MAX_PENDING_PER_RUN.
+	MaxPendingPerRun int
+}
+
+const interruptionDescription = `Human-in-the-loop primitive (v0.8.16). ` +
+	`ask: surface a question to a human; agent loop blocks until answered, timed out, or cancelled. ` +
+	`notify: fire-and-forget message (no answer expected). ` +
+	`cancel: agent unblocks a previously-asked question that it answered itself. ` +
+	`Delivery surface is operator-selected (webui / mcp_server / cli); the tool interface is identical across them.`
+
+const interruptionInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":              {"type": "string", "enum": ["ask","notify","cancel"], "description": "Which operation to perform."},
+    "question":        {"type": "string", "description": "ask only: the question text shown to the human."},
+    "options":         {"type": "array",  "items": {"type": "string"}, "description": "ask only (optional): a fixed list of allowed answers. When set, the resolve endpoint refuses any answer not in this list. Absent or empty = free-text answer."},
+    "context":         {"type": "string", "description": "ask only (optional): a short hint for the answerer (e.g. \"47 records pending\")."},
+    "timeout_ms":      {"type": "integer", "description": "ask only (optional): how long to block before giving up. Absent = operator default; capped by operator max."},
+    "priority":        {"type": "string", "enum": ["low","normal","high"], "description": "ask/notify (optional): informational badge for the UI. Default normal."},
+    "message":         {"type": "string", "description": "notify only: the message text."},
+    "interruption_id": {"type": "string", "description": "cancel only: the interrupt_id returned by a prior ask."}
+  },
+  "required": ["op"],
+  "additionalProperties": false
+}`
+
+type interruptionInput struct {
+	Op             string   `json:"op"`
+	Question       string   `json:"question,omitempty"`
+	Options        []string `json:"options,omitempty"`
+	Context        string   `json:"context,omitempty"`
+	TimeoutMS      int      `json:"timeout_ms,omitempty"`
+	Priority       string   `json:"priority,omitempty"`
+	Message        string   `json:"message,omitempty"`
+	InterruptionID string   `json:"interruption_id,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (it *Interruption) Name() string { return "Interruption" }
+
+// Description implements tools.Tool.
+func (it *Interruption) Description() string { return interruptionDescription }
+
+// InputSchema implements tools.Tool.
+func (it *Interruption) InputSchema() json.RawMessage {
+	return json.RawMessage(interruptionInputSchema)
+}
+
+// Execute implements tools.Tool. Dispatches off `op`; ACL gate
+// shared across all ops.
+func (it *Interruption) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if it.Store == nil {
+		return errResult("Interruption tool: not configured (no Store backend)"), nil
+	}
+	if it.Bus == nil {
+		return errResult("Interruption tool: not configured (no Bus — blocking ask cannot wake on resolve)"), nil
+	}
+	var in interruptionInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+
+	policy := tools.InterruptionPolicy(ctx)
+	if !policy.Enabled {
+		return errResult(
+			"Interruption tool: not enabled for this agent — add `interruption: { enabled: true }` to the agent yaml",
+		), nil
+	}
+
+	switch in.Op {
+	case "ask":
+		return it.execAsk(ctx, policy, in)
+	case "notify":
+		return it.execNotify(ctx, policy, in)
+	case "cancel":
+		return it.execCancel(ctx, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: ask, notify, cancel)", in.Op)), nil
+	}
+}
+
+// execAsk creates a pending interrupt row, emits the SSE event,
+// publishes to _system/interrupts/pending, blocks on Bus.Wait with
+// a heartbeat ticker, then reads the resolved row + returns the
+// answer as the tool result.
+func (it *Interruption) execAsk(ctx context.Context, policy tools.InterruptionPolicyValue, in interruptionInput) (tools.Result, error) {
+	if in.Question == "" {
+		return errResult("ask: missing required field: question"), nil
+	}
+	if !kindAllowed("question", policy.Kinds) {
+		return errResult("ask: kind 'question' is not in this agent's allowed kinds (interruption.kinds yaml)"), nil
+	}
+	priority := normalizePriority(in.Priority)
+
+	ident := tools.RunIdentity(ctx)
+	runID := tools.RunID(ctx)
+	if runID == "" {
+		return errResult("Interruption tool: run id missing from ctx (server wiring bug — please report)"), nil
+	}
+
+	// max_pending check. Agent yaml MAY narrow below the global; we
+	// honour the smaller of the two (0 on either side = "no cap on
+	// that axis"). Per-run, not per-user — see RFC §6 Q5.
+	cap := effectiveMaxPending(policy.MaxPending, it.MaxPendingPerRun)
+	if cap > 0 {
+		n, err := it.Store.InterruptCountPendingByRun(ctx, runID)
+		if err != nil {
+			return errResult(fmt.Sprintf("ask: storage error counting pending: %s", err)), nil
+		}
+		if n >= cap {
+			return errResult(fmt.Sprintf(
+				"ask: max_pending (%d) already reached for this run — wait for one of the %d pending interruptions to resolve or cancel",
+				cap, n,
+			)), nil
+		}
+	}
+
+	// Compute the effective timeout. Caller value clamped to
+	// [0, MaxTimeout]; absent → DefaultTimeout.
+	timeout := it.resolveTimeout(in.TimeoutMS)
+
+	id := store.MintInterruptID(time.Now())
+	now := time.Now()
+	var expiresAt time.Time
+	if timeout > 0 {
+		expiresAt = now.Add(timeout)
+	}
+	var optsJSON json.RawMessage
+	if len(in.Options) > 0 {
+		b, err := json.Marshal(in.Options)
+		if err != nil {
+			return errResult(fmt.Sprintf("ask: marshal options: %s", err)), nil
+		}
+		optsJSON = b
+	}
+	row := store.InterruptRow{
+		InterruptID: id,
+		RunID:       runID,
+		Kind:        store.InterruptKindQuestion,
+		Status:      store.InterruptStatusPending,
+		Question:    in.Question,
+		Options:     optsJSON,
+		ContextData: in.Context,
+		Priority:    priority,
+		CreatedAt:   now,
+		ExpiresAt:   expiresAt,
+		UserID:      ident.UserID,
+		AgentID:     ident.AgentID,
+		// AgentName isn't directly on RunIdentity; ctx carries it via
+		// the policy / loop wiring. Empty is fine — listing queries
+		// gracefully fall back without it.
+	}
+	if _, err := it.Store.InterruptCreate(ctx, row); err != nil {
+		return errResult(fmt.Sprintf("ask: storage error: %s", err)), nil
+	}
+
+	// Emit the SSE event for the run's own stream — Web UI consumers
+	// already have an open connection and use this for real-time
+	// modal rendering without a follow-up GET.
+	tools.EventEmitter(ctx)(providers.Event{
+		Type: providers.EventInterruptionPending,
+		Interruption: &providers.InterruptionEventInfo{
+			InterruptID: id,
+			Kind:        store.InterruptKindQuestion,
+			Question:    in.Question,
+			Options:     optsJSON,
+			Context:     in.Context,
+			Priority:    priority,
+			ExpiresAt:   rfc3339OrEmpty(expiresAt),
+		},
+	})
+
+	// Publish to _system/interrupts/pending so non-run subscribers
+	// (Web UI inbox view, Slack notifier, etc.) learn about it via
+	// the Channel substrate rather than an SSE event they don't see.
+	if it.SystemPublisher != nil && ident.UserID != "" {
+		payload, _ := json.Marshal(map[string]any{
+			"interrupt_id": id,
+			"run_id":       runID,
+			"kind":         store.InterruptKindQuestion,
+			"question":     in.Question,
+			"options":      json.RawMessage(optsJSON),
+			"priority":     priority,
+			"expires_at":   rfc3339OrEmpty(expiresAt),
+			"agent_id":     ident.AgentID,
+		})
+		_, _ = it.SystemPublisher.PublishNow(
+			ctx,
+			"_system/interrupts/pending",
+			store.MemoryScopeUser, ident.UserID,
+			payload, channels.SystemPublisherUserID,
+			0, // maxMessages — operator yaml configures
+			0, // defaultTTL — operator yaml configures
+		)
+	}
+
+	// Block on the bus. Heartbeat ticker fires in a sibling goroutine
+	// so the run stays alive across long waits.
+	if err := it.blockWithHeartbeat(ctx, id, timeout); err != nil {
+		// ctx-cancelled OR timeout fired AFTER bus.Wait returned but
+		// before we could read the row. Recover the terminal status
+		// from storage; "still pending" → finalise it ourselves and
+		// report cancel/timeout.
+		return it.finaliseUnresolved(ctx, id, err)
+	}
+
+	// Wake path: bus.Notify fired. Re-read the row to get the
+	// resolved answer (the resolve handler wrote it before Notify).
+	final, err := it.Store.InterruptGet(ctx, id)
+	if err != nil {
+		return errResult(fmt.Sprintf("ask: post-resolve read: %s", err)), nil
+	}
+	return it.toolResultForStatus(final), nil
+}
+
+// execNotify is fire-and-forget — no blocking. Writes a row with
+// status=resolved immediately (since the notify carries no answer
+// to wait for); the Web UI / dashboards still surface it via the
+// system channel publish.
+func (it *Interruption) execNotify(ctx context.Context, policy tools.InterruptionPolicyValue, in interruptionInput) (tools.Result, error) {
+	if in.Message == "" {
+		return errResult("notify: missing required field: message"), nil
+	}
+	if !kindAllowed("question", policy.Kinds) {
+		// Same gate as ask — operator opts into question-shaped
+		// interactions, which includes notify (a degenerate ask).
+		return errResult("notify: kind 'question' is not in this agent's allowed kinds"), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	runID := tools.RunID(ctx)
+	if runID == "" {
+		return errResult("Interruption tool: run id missing from ctx"), nil
+	}
+
+	priority := normalizePriority(in.Priority)
+	id := store.MintInterruptID(time.Now())
+	now := time.Now()
+	row := store.InterruptRow{
+		InterruptID: id,
+		RunID:       runID,
+		Kind:        store.InterruptKindQuestion,
+		// Status starts pending then immediately transitions to
+		// resolved via InterruptFinish below — keeps the row's
+		// status enum honest (every row passes through pending).
+		Status:    store.InterruptStatusPending,
+		Question:  in.Message,
+		Priority:  priority,
+		CreatedAt: now,
+		UserID:    ident.UserID,
+		AgentID:   ident.AgentID,
+	}
+	if _, err := it.Store.InterruptCreate(ctx, row); err != nil {
+		return errResult(fmt.Sprintf("notify: storage error: %s", err)), nil
+	}
+	// notify is treated as cancelled (no human response) for the
+	// terminal-status enum.  resolved_by = "agent_cancel" preserves
+	// audit attribution.
+	if err := it.Store.InterruptFinish(ctx, id, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel); err != nil {
+		return errResult(fmt.Sprintf("notify: finish: %s", err)), nil
+	}
+
+	if it.SystemPublisher != nil && ident.UserID != "" {
+		payload, _ := json.Marshal(map[string]any{
+			"interrupt_id": id,
+			"run_id":       runID,
+			"kind":         store.InterruptKindQuestion,
+			"message":      in.Message,
+			"priority":     priority,
+			"notify":       true,
+			"agent_id":     ident.AgentID,
+		})
+		_, _ = it.SystemPublisher.PublishNow(
+			ctx,
+			"_system/interrupts/pending",
+			store.MemoryScopeUser, ident.UserID,
+			payload, channels.SystemPublisherUserID, 0, 0,
+		)
+	}
+
+	out, _ := json.Marshal(map[string]any{
+		"interrupt_id": id,
+		"status":       "delivered",
+		"created_at":   now.UTC().Format(time.RFC3339Nano),
+	})
+	return tools.Result{Text: string(out)}, nil
+}
+
+// execCancel transitions a pending interrupt to status=cancelled.
+// Agent-side path — distinct from human "I don't want to answer"
+// which the resolve endpoint maps to a 200 with no answer (out of
+// scope for v0.8.16).
+func (it *Interruption) execCancel(ctx context.Context, in interruptionInput) (tools.Result, error) {
+	if in.InterruptionID == "" {
+		return errResult("cancel: missing required field: interruption_id"), nil
+	}
+	err := it.Store.InterruptFinish(
+		ctx,
+		in.InterruptionID,
+		store.InterruptStatusCancelled,
+		store.InterruptResolvedByAgentCancel,
+	)
+	var nf *store.ErrNotFound
+	if errors.As(err, &nf) {
+		return errResult(fmt.Sprintf("cancel: interruption_id %q not found", in.InterruptionID)), nil
+	}
+	wasPending := true
+	if err != nil {
+		if errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+			wasPending = false
+		} else {
+			return errResult(fmt.Sprintf("cancel: storage error: %s", err)), nil
+		}
+	}
+	// If the row was already cancelled / timed_out / resolved, the
+	// tool reports was_pending: false. The bus.Notify still fires —
+	// any concurrent ask waiter wakes and sees the terminal status.
+	// (For race-safety; harmless when no waiter exists.)
+	it.Bus.Notify("intr:" + in.InterruptionID)
+
+	out, _ := json.Marshal(map[string]any{
+		"interrupt_id": in.InterruptionID,
+		"status":       store.InterruptStatusCancelled,
+		"was_pending":  wasPending,
+	})
+	return tools.Result{Text: string(out)}, nil
+}
+
+// blockWithHeartbeat is the load-bearing wait: bus.Wait blocks the
+// loop's tool dispatch goroutine until the resolve endpoint calls
+// bus.Notify. A sibling goroutine fires the run's heartbeat
+// callback every HeartbeatInterval so the sweeper doesn't mark the
+// run as dead.
+//
+// On clean resolve, returns nil. On timeout fired BY bus.Wait
+// itself, returns a sentinel error indicating timeout; on ctx
+// cancel, returns ctx.Err(). The caller distinguishes via errors.Is
+// and calls InterruptFinish accordingly.
+func (it *Interruption) blockWithHeartbeat(ctx context.Context, interruptID string, timeout time.Duration) error {
+	// bus.Wait with timeout=0 returns immediately (the bus contract).
+	// For "no operator timeout" we pass a very large duration so the
+	// timeout branch never fires; ctx is still respected.
+	waitTimeout := timeout
+	if waitTimeout <= 0 {
+		// 100 years — effectively no timeout. ctx still trumps.
+		waitTimeout = 100 * 365 * 24 * time.Hour
+	}
+
+	// Heartbeat ticker. Calls Store.UpdateHeartbeat(runID) directly
+	// at HeartbeatInterval cadence so the v0.5.0 sweeper doesn't mark
+	// this run as dead while the loop's per-iteration heartbeat is
+	// suspended inside our blocking wait. The DB write uses a ctx
+	// that survives the loop's eventual ctx-cancel so a heartbeat in
+	// flight at cancel time still commits cleanly (cheaper than a
+	// failed DB call's retry storm).
+	runID := tools.RunID(ctx)
+	done := make(chan struct{})
+	if runID != "" {
+		interval := it.HeartbeatInterval
+		if interval <= 0 {
+			interval = 30 * time.Second
+		}
+		ticker := time.NewTicker(interval)
+		go func() {
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					hbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+					_ = it.Store.UpdateHeartbeat(hbCtx, runID)
+					cancel()
+				case <-done:
+					return
+				}
+			}
+		}()
+	}
+	defer close(done)
+
+	woke := it.Bus.Wait(ctx, "intr:"+interruptID, waitTimeout)
+	if woke {
+		return nil
+	}
+	// Distinguish ctx-cancel from timeout. Bus.Wait collapses both
+	// to "false"; ctx.Err() is the deterministic discriminator.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return errInterruptionTimeout
+}
+
+// finaliseUnresolved handles the bus.Wait-returned-false path.
+// Reads the storage row to recover the row state; transitions to
+// timed_out or cancelled depending on cause; returns the tool
+// result. Two race shapes to handle:
+//
+//  1. bus.Wait returned false due to ctx cancel → run is being
+//     torn down. Finish the row as cancelled (resolved_by =
+//     agent_cancel, semantically "run abandoned").
+//  2. bus.Wait returned false due to timer → mark timed_out. The
+//     sweeper handles process-crashed rows; this path handles the
+//     "still running, but Tom-and-Jerry'd by the timer" case.
+//
+// In both cases the row may ALREADY have been finalised by another
+// thread (the sweeper, the resolve endpoint racing with the
+// timeout, etc.). InterruptFinish returns ErrInterruptAlreadyTerminal
+// in that case — read the row and report whatever's in storage.
+func (it *Interruption) finaliseUnresolved(ctx context.Context, interruptID string, cause error) (tools.Result, error) {
+	var status, resolvedBy string
+	if errors.Is(cause, errInterruptionTimeout) {
+		status = store.InterruptStatusTimedOut
+		resolvedBy = store.InterruptResolvedByTimeout
+	} else {
+		// ctx cancel + everything else → cancelled (agent-side
+		// abandonment, surfaces as cancellation in the audit log).
+		status = store.InterruptStatusCancelled
+		resolvedBy = store.InterruptResolvedByAgentCancel
+	}
+	// Best-effort finalise. The follow-up read is authoritative.
+	// Use a fresh ctx for the storage write so ctx-cancel-after-
+	// wait doesn't sabotage the finalise.
+	bg := context.WithoutCancel(ctx)
+	_ = it.Store.InterruptFinish(bg, interruptID, status, resolvedBy)
+
+	row, err := it.Store.InterruptGet(bg, interruptID)
+	if err != nil {
+		return errResult(fmt.Sprintf("ask: post-block read: %s", err)), nil
+	}
+	return it.toolResultForStatus(row), nil
+}
+
+// toolResultForStatus produces the tool result for whatever the
+// final row state is.
+func (it *Interruption) toolResultForStatus(row store.InterruptRow) tools.Result {
+	switch row.Status {
+	case store.InterruptStatusResolved:
+		out, _ := json.Marshal(map[string]any{
+			"interrupt_id": row.InterruptID,
+			"answer":       row.Answer,
+			"resolved_at":  rfc3339OrEmpty(row.ResolvedAt),
+			"resolved_by":  row.ResolvedBy,
+		})
+		return tools.Result{Text: string(out)}
+	case store.InterruptStatusTimedOut:
+		return tools.Result{
+			IsError: true,
+			Text:    fmt.Sprintf("interruption timed_out (id=%s) — no answer received in the allotted window", row.InterruptID),
+		}
+	case store.InterruptStatusCancelled:
+		return tools.Result{
+			IsError: true,
+			Text:    fmt.Sprintf("interruption cancelled (id=%s, resolved_by=%s)", row.InterruptID, row.ResolvedBy),
+		}
+	default:
+		// Pending — should never happen after finalise. Surface as
+		// an explicit error so the operator can investigate.
+		return tools.Result{
+			IsError: true,
+			Text:    fmt.Sprintf("interruption in unexpected state %q after block (id=%s)", row.Status, row.InterruptID),
+		}
+	}
+}
+
+// resolveTimeout clamps the caller's timeout_ms to [0, MaxTimeout]
+// and substitutes DefaultTimeout when absent (0).
+func (it *Interruption) resolveTimeout(reqMS int) time.Duration {
+	if reqMS <= 0 {
+		return it.DefaultTimeout
+	}
+	t := time.Duration(reqMS) * time.Millisecond
+	if it.MaxTimeout > 0 && t > it.MaxTimeout {
+		return it.MaxTimeout
+	}
+	return t
+}
+
+// --- helpers ---------------------------------------------------------
+
+// errInterruptionTimeout is the sentinel returned by
+// blockWithHeartbeat when bus.Wait fires its own timer (vs ctx
+// being cancelled). Internal — never surfaces to the model.
+var errInterruptionTimeout = fmt.Errorf("interruption: blocking wait timed out")
+
+func kindAllowed(kind string, kinds []string) bool {
+	if len(kinds) == 0 {
+		// Empty allowlist defaults to ["question"] — the only
+		// v0.8.16 kind. Future expansions land here as opt-in.
+		return kind == store.InterruptKindQuestion
+	}
+	for _, k := range kinds {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizePriority(p string) string {
+	switch strings.ToLower(p) {
+	case store.InterruptPriorityLow:
+		return store.InterruptPriorityLow
+	case store.InterruptPriorityHigh:
+		return store.InterruptPriorityHigh
+	default:
+		return store.InterruptPriorityNormal
+	}
+}
+
+func effectiveMaxPending(perAgent, perOperator int) int {
+	switch {
+	case perAgent <= 0 && perOperator <= 0:
+		return 0
+	case perAgent <= 0:
+		return perOperator
+	case perOperator <= 0:
+		return perAgent
+	case perAgent < perOperator:
+		return perAgent
+	default:
+		return perOperator
+	}
+}
+
+func rfc3339OrEmpty(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/tools/builtin/interruption_test.go
+++ b/internal/tools/builtin/interruption_test.go
@@ -1,0 +1,414 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// interruptionFixture builds an Interruption tool backed by a
+// SQLite store + a real channels.Bus, with a ctx pre-populated with
+// a run row + a permissive policy (Enabled=true, kinds=question).
+// Tests override individual ctx values where they want to exercise
+// specific gates.
+func interruptionFixture(t *testing.T) (*Interruption, context.Context, string, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	ctx := context.Background()
+	sess, err := s.CreateSession(ctx, "t", "qa-agent", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "a_test",
+		UserID:  "alice",
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	tool := &Interruption{
+		Store:             s,
+		Bus:               channels.NewBus(),
+		DefaultTimeout:    0, // no implicit timeout
+		MaxTimeout:        time.Minute,
+		HeartbeatInterval: 0, // ticker disabled by default in tests (RunID empty would also disable)
+	}
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", AgentID: "a_test"})
+	ctx = tools.WithRunID(ctx, run.ID)
+	ctx = tools.WithInterruptionPolicy(ctx, tools.InterruptionPolicyValue{Enabled: true})
+	return tool, ctx, run.ID, func() { _ = s.Close() }
+}
+
+func TestInterruption_DefaultDeny(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+	// Strip the permissive policy → default-deny.
+	ctx = tools.WithInterruptionPolicy(ctx, tools.InterruptionPolicyValue{Enabled: false})
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"hi?"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected is_error=true on default-deny, got result: %+v", res)
+	}
+	if !strings.Contains(res.Text, "not enabled") {
+		t.Errorf("expected refusal message; got %q", res.Text)
+	}
+}
+
+func TestInterruption_AskBlockUntilResolve(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// Kick off ask in a goroutine — it blocks on bus.Wait.
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		res, err := tool.Execute(ctx, json.RawMessage(`{
+			"op":"ask",
+			"question":"Proceed with delete?",
+			"options":["Yes","No"],
+			"timeout_ms":5000
+		}`))
+		if err != nil {
+			t.Errorf("Execute: %v", err)
+		}
+		resCh <- res
+	}()
+
+	// Wait briefly so the create + bus.Wait runs.
+	time.Sleep(50 * time.Millisecond)
+
+	// Find the pending row + resolve it (simulating the HTTP
+	// resolve handler doing the work).
+	pending, err := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending interrupt, got %d", len(pending))
+	}
+	id := pending[0].InterruptID
+	if err := tool.Store.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	tool.Bus.Notify("intr:" + id)
+
+	select {
+	case res := <-resCh:
+		if res.IsError {
+			t.Fatalf("expected non-error result; got %+v", res)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+			t.Fatalf("result not JSON: %v (raw %q)", err, res.Text)
+		}
+		if out["answer"] != "Yes" {
+			t.Errorf("answer=%v, want Yes", out["answer"])
+		}
+		if out["resolved_by"] != store.InterruptResolvedByWebUI {
+			t.Errorf("resolved_by=%v", out["resolved_by"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not wake after resolve")
+	}
+}
+
+func TestInterruption_AskTimeout(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// 50 ms timeout; no resolve will come.
+	start := time.Now()
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"Hi?","timeout_ms":50}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected is_error=true on timeout; got %+v", res)
+	}
+	if !strings.Contains(res.Text, "timed_out") {
+		t.Errorf("expected timed_out marker; got %q", res.Text)
+	}
+	if d := time.Since(start); d < 50*time.Millisecond || d > 2*time.Second {
+		t.Errorf("timeout fired at %v (expected ~50ms)", d)
+	}
+
+	// Storage row should be finalised with status=timed_out.
+	rows, _ := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusTimedOut)
+	if len(rows) != 1 {
+		t.Errorf("expected 1 timed_out row, got %d", len(rows))
+	}
+}
+
+func TestInterruption_AskCtxCancelMidBlock(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(ctx)
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"Hi?","timeout_ms":5000}`))
+		resCh <- res
+	}()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case res := <-resCh:
+		if !res.IsError {
+			t.Errorf("expected is_error on ctx cancel; got %+v", res)
+		}
+		if !strings.Contains(res.Text, "cancelled") {
+			t.Errorf("expected cancelled marker; got %q", res.Text)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not return after ctx cancel")
+	}
+}
+
+func TestInterruption_NotifyIsFireAndForget(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	start := time.Now()
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"notify","message":"All done.","priority":"low"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := time.Since(start); d > 500*time.Millisecond {
+		t.Errorf("notify blocked for %v; expected near-instant", d)
+	}
+	if res.IsError {
+		t.Errorf("notify returned error: %+v", res)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Text), &out)
+	if out["status"] != "delivered" {
+		t.Errorf("status=%v, want delivered", out["status"])
+	}
+}
+
+func TestInterruption_Cancel(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// Kick off ask, then cancel it from another op call.
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"Hi?","timeout_ms":5000}`))
+		resCh <- res
+	}()
+	time.Sleep(30 * time.Millisecond)
+
+	pending, _ := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(pending))
+	}
+	id := pending[0].InterruptID
+
+	// Agent-side cancel — should transition the row + notify the
+	// blocked waiter to return promptly.
+	cres, err := tool.Execute(ctx, json.RawMessage(`{
+		"op":"cancel",
+		"interruption_id":"`+id+`"
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cres.IsError {
+		t.Errorf("cancel returned error: %+v", cres)
+	}
+
+	select {
+	case res := <-resCh:
+		if !res.IsError {
+			t.Errorf("expected ask to return is_error after cancel; got %+v", res)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not unblock after cancel op")
+	}
+}
+
+func TestInterruption_OptionsRejectInvalidAnswerAtResolveLayer(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// This test runs purely against the tool's create path + the
+	// storage layer's validation isn't tested here (that's the
+	// HTTP handler's job). What we DO assert: the options list
+	// makes it into the stored row so the resolve handler can
+	// validate against it.
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		res, _ := tool.Execute(ctx, json.RawMessage(`{
+			"op":"ask",
+			"question":"Yes or no?",
+			"options":["Yes","No"],
+			"timeout_ms":2000
+		}`))
+		resCh <- res
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	pending, _ := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending, got %d", len(pending))
+	}
+	if string(pending[0].Options) == "" || string(pending[0].Options) == "null" {
+		t.Errorf("options not persisted: %q", string(pending[0].Options))
+	}
+	var opts []string
+	if err := json.Unmarshal(pending[0].Options, &opts); err != nil || len(opts) != 2 || opts[0] != "Yes" {
+		t.Errorf("options round-trip wrong: %v %v", opts, err)
+	}
+	// Clean up by cancelling the pending row.
+	_ = tool.Store.InterruptFinish(ctx, pending[0].InterruptID, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+	tool.Bus.Notify("intr:" + pending[0].InterruptID)
+	<-resCh
+}
+
+func TestInterruption_MaxPendingEnforced(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+	// Cap at 1 pending per run.
+	ctx = tools.WithInterruptionPolicy(ctx, tools.InterruptionPolicyValue{Enabled: true, MaxPending: 1})
+
+	// First ask — creates pending row + blocks. Run in goroutine.
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		r, _ := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"first","timeout_ms":2000}`))
+		resCh <- r
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Second ask — should refuse with max_pending error.
+	r2, err := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"second","timeout_ms":2000}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r2.IsError {
+		t.Errorf("expected is_error on second ask; got %+v", r2)
+	}
+	if !strings.Contains(r2.Text, "max_pending") {
+		t.Errorf("expected max_pending refusal; got %q", r2.Text)
+	}
+	// Clean up — cancel the first.
+	pending, _ := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	for _, p := range pending {
+		_ = tool.Store.InterruptFinish(ctx, p.InterruptID, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+		tool.Bus.Notify("intr:" + p.InterruptID)
+	}
+	<-resCh
+}
+
+func TestInterruption_EmitsPendingSSEEvent(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	var events []providers.Event
+	ctx = tools.WithEventEmitter(ctx, func(e providers.Event) {
+		events = append(events, e)
+	})
+
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		r, _ := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"Hi?","timeout_ms":2000}`))
+		resCh <- r
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// At least one EventInterruptionPending must have fired.
+	found := false
+	for _, e := range events {
+		if e.Type == providers.EventInterruptionPending && e.Interruption != nil {
+			found = true
+			if e.Interruption.Question != "Hi?" {
+				t.Errorf("event Question=%q, want Hi?", e.Interruption.Question)
+			}
+			if e.Interruption.Kind != store.InterruptKindQuestion {
+				t.Errorf("event Kind=%q, want question", e.Interruption.Kind)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("EventInterruptionPending not emitted")
+	}
+	// Cleanup.
+	pending, _ := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	for _, p := range pending {
+		_ = tool.Store.InterruptFinish(ctx, p.InterruptID, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+		tool.Bus.Notify("intr:" + p.InterruptID)
+	}
+	<-resCh
+}
+
+func TestInterruption_RunIDMissingFromCtx(t *testing.T) {
+	tool, _, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+	// Build a ctx with policy but NO RunID — should surface a clear
+	// "server wiring bug" error instead of silently creating
+	// dangling rows.
+	ctx := context.Background()
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", AgentID: "a_test"})
+	ctx = tools.WithInterruptionPolicy(ctx, tools.InterruptionPolicyValue{Enabled: true})
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"ask","question":"Hi?"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected is_error on missing RunID; got %+v", res)
+	}
+	if !strings.Contains(res.Text, "run id missing") {
+		t.Errorf("expected run-id error; got %q", res.Text)
+	}
+}
+
+func TestInterruption_StoreAlreadyTerminalNotPanic(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// Cancel against an already-terminal row returns a non-error
+	// tool result with was_pending=false.
+	id := store.MintInterruptID(time.Now())
+	if _, err := tool.Store.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: tools.RunID(ctx), UserID: "alice", AgentID: "a_test",
+		Question: "Hi?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = tool.Store.InterruptFinish(ctx, id, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"cancel","interruption_id":"`+id+`"}`))
+	if res.IsError {
+		t.Errorf("cancel of already-terminal should NOT be is_error; got %+v", res)
+	}
+	var out map[string]any
+	_ = json.Unmarshal([]byte(res.Text), &out)
+	if out["was_pending"] != false {
+		t.Errorf("expected was_pending=false; got %v", out["was_pending"])
+	}
+}
+
+// Ensure errors.Is / errors.As behave on the new ErrInterruptAlreadyTerminal
+// sentinel — surfaces in cancel-of-already-cancelled path.
+func TestStoreSentinelErrCheck(t *testing.T) {
+	err := store.ErrInterruptAlreadyTerminal
+	if !errors.Is(err, store.ErrInterruptAlreadyTerminal) {
+		t.Error("errors.Is failed on direct sentinel")
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -316,6 +316,69 @@ func ChannelPolicy(ctx context.Context) ChannelPolicyValue {
 	return v
 }
 
+// InterruptionPolicyValue is the per-agent Interruption access
+// policy (v0.8.16). Default-deny: an absent block means Enabled is
+// false and every Interruption op returns is_error with a clear
+// "not enabled" message.
+//
+//   - Enabled gates the tool entirely. False → tool returns is_error
+//     on every op.
+//   - Kinds is the allowlist of interrupt kinds this agent may
+//     create. v0.8.16 supports only "question"; future "pause" /
+//     "wait_until" / "approval" will land here as additive opt-ins.
+//     Empty means default (["question"]) when Enabled=true.
+//   - MaxPending caps the number of pending interrupts this run may
+//     hold simultaneously. 0 = use the operator's global default
+//     (LOOMCYCLE_INTERRUPTION_MAX_PENDING_PER_RUN).
+type InterruptionPolicyValue struct {
+	Enabled    bool
+	Kinds      []string
+	MaxPending int
+}
+
+type ctxKeyInterruptionPolicy struct{}
+
+// WithInterruptionPolicy attaches the agent's resolved Interruption
+// policy to ctx. The HTTP server's RunOnce / handleRuns wraps the
+// loop ctx with this so any Interruption.Execute downstream can
+// recover the policy in one call.
+func WithInterruptionPolicy(ctx context.Context, p InterruptionPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyInterruptionPolicy{}, p)
+}
+
+// InterruptionPolicy returns the agent's Interruption policy from
+// ctx. Zero value (Enabled=false) means "not enabled" — the tool
+// surfaces this as a clear refusal so operators see one explicit
+// failure instead of a stack trace.
+func InterruptionPolicy(ctx context.Context) InterruptionPolicyValue {
+	v, _ := ctx.Value(ctxKeyInterruptionPolicy{}).(InterruptionPolicyValue)
+	return v
+}
+
+// ctxKeyRunID is the context key under which the runtime stores
+// the current run's store row ID. The Interruption tool uses this
+// at create time to associate the interrupt row with the run for
+// listing and ACL purposes — the model never supplies it, so it
+// must travel via ctx alongside RunIdentity (which carries the
+// agent-facing IDs; run.ID is operator-facing and stays out of the
+// model's view).
+type ctxKeyRunID struct{}
+
+// WithRunID attaches the run's store row ID to ctx. Same call site
+// as WithRunIdentity (HTTP handler at run start).
+func WithRunID(ctx context.Context, runID string) context.Context {
+	if runID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyRunID{}, runID)
+}
+
+// RunID returns the run row ID from ctx, or "" when unset.
+func RunID(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyRunID{}).(string)
+	return v
+}
+
 // ctxKeyEventEmitter is the context key for the v0.8.4 typed-audit-
 // event emitter. The loop's OnEvent callback is attached at run
 // start; tools that want to surface structured wire events (e.g.


### PR DESCRIPTION
**Stacked on PR #119** — review after PR 1 lands.

## Summary

PR 2 of 5 for v0.8.16 Interruption tool. The tool itself plus the webui delivery backend. PR 1 supplied the storage layer; this PR makes it usable end-to-end.

+1,508 lines, 7 files (2 new).

## What ships

- `internal/tools/builtin/interruption.go` — the tool with 3 ops (ask/notify/cancel). Discriminated-`op` shape matching Memory/Channel/AgentDef/etc.
- **Blocking semantic**: `ask` blocks on `channels.Bus.Wait` with the key `intr:<id>`. Dedicated heartbeat ticker fires `Store.UpdateHeartbeat` every 30s (configurable) while blocked, so the v0.5.0 sweeper doesn't reap a long-pending run.
- **New ACL**: per-agent `interruption: {enabled, kinds, max_pending}` yaml struct. Default-deny. v0.8.16 only kind is `question`; future `pause`/`wait_until`/`approval` slot in additively.
- **Top-level config**: `interruption:` block (backend / default_timeout_ms / max_timeout_ms / max_pending_per_run / heartbeat_interval_ms).
- **New ctx carriers**: `tools.InterruptionPolicyValue` + `tools.RunID`, attached at all 4 ctx-attach sites (RunOnce / handleRuns / handleMessages / runSubAgent) so sub-agents inherit.
- **New SSE event**: `providers.EventInterruptionPending` + `InterruptionEventInfo` payload for Web UI real-time render.
- **HTTP handlers**:
  - `POST /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve`
  - `GET  /v1/runs/{run_id}/interrupts`
  - `GET  /v1/users/{user_id}/interrupts`
- Server-side option validation (422 on out-of-list), expiry (410 Gone), already-terminal (409 Conflict), webui-vs-api attribution of `resolved_by`.

## Test coverage

11 new tool tests + 1 sentinel-error test. All green. Covers default-deny, block-until-resolve, timeout path, ctx-cancel-mid-block, notify fire-and-forget, cancel, options persistence, max_pending enforcement, SSE emission, missing-RunID guard, already-terminal idempotence.

## Verification

- [x] `go test ./...` clean across all packages
- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean

## Out of scope (deferred to later PRs)

PR 3: `mcp_server:<name>` delivery backend + LoomCycle MCP meta-tool
PR 4: Web UI `/ui/interrupts` route
PR 5: Documentation (TOOLS.md, help topic, sample yaml, REVISIONS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)