### PR TITLE
feat(mcp): consumer-MCP backend + LoomCycle MCP interruption_resolve (PR 3/5)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -387,6 +387,7 @@ func main() {
 	// Slack notifier).
 	interruptionTool := &builtin.Interruption{
 		Bus:               channelBus,
+		Backend:           cfg.Interruption.Backend,
 		DefaultTimeout:    time.Duration(cfg.Interruption.DefaultTimeoutMS) * time.Millisecond,
 		MaxTimeout:        time.Duration(cfg.Interruption.MaxTimeoutMS) * time.Millisecond,
 		HeartbeatInterval: time.Duration(cfg.Interruption.HeartbeatIntervalMS) * time.Millisecond,

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -667,6 +667,9 @@ func (m *mockConnector) RestoreSnapshot(context.Context, connector.RestoreSnapsh
 	return connector.RestoreSnapshotResult{}, nil
 }
 func (m *mockConnector) DeleteSnapshot(context.Context, string) error { return nil }
+func (m *mockConnector) InterruptionResolve(context.Context, connector.InterruptionResolveRequest) (connector.InterruptionResolveResult, error) {
+	return connector.InterruptionResolveResult{}, nil
+}
 
 // TestGrpcServer_CancelAgent_DispatchesThroughConnector is the v0.8.15
 // regression guard: when the gRPC Server is wired with a Connector,

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -460,6 +461,95 @@ func (s *Server) RestoreSnapshot(_ context.Context, _ connector.RestoreSnapshotR
 
 func (s *Server) DeleteSnapshot(_ context.Context, _ string) error {
 	return fmt.Errorf("delete_snapshot: %s", previewNote)
+}
+
+// --- Interruption (v0.8.16) ---
+
+// InterruptionResolve implements connector.Connector. It mirrors the
+// HTTP resolve endpoint's logic without round-tripping through HTTP:
+// validate row + answer, transition status, fire bus.Notify,
+// publish to _system/interrupts/resolved.
+//
+// Used by the LoomCycle MCP server's `interruption_resolve` meta-tool
+// so external orchestrators (Claude Code, custom dashboards) can act
+// as the answerer without speaking HTTP to loomcycle.
+func (s *Server) InterruptionResolve(ctx context.Context, req connector.InterruptionResolveRequest) (connector.InterruptionResolveResult, error) {
+	if s.store == nil {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: store not configured")
+	}
+	kind := req.Kind
+	if kind == "" {
+		kind = store.InterruptKindQuestion
+	}
+	if kind != store.InterruptKindQuestion {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: unsupported kind %q (v0.8.16 supports: question)", kind)
+	}
+	resolvedBy := req.ResolvedBy
+	if resolvedBy == "" {
+		resolvedBy = store.InterruptResolvedByMCP
+	}
+
+	row, err := s.store.InterruptGet(ctx, req.InterruptID)
+	if err != nil {
+		return connector.InterruptionResolveResult{}, err
+	}
+	if row.RunID != req.RunID {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: interrupt %q does not belong to run %q", req.InterruptID, req.RunID)
+	}
+	if row.Status != store.InterruptStatusPending {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: already %s", row.Status)
+	}
+	if !row.ExpiresAt.IsZero() && row.ExpiresAt.Before(time.Now()) {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: expired")
+	}
+
+	// Option-list validation. Same shape as the HTTP handler.
+	if len(row.Options) > 0 {
+		var opts []string
+		if err := json.Unmarshal(row.Options, &opts); err == nil && len(opts) > 0 {
+			ok := false
+			for _, o := range opts {
+				if o == req.Answer {
+					ok = true
+					break
+				}
+			}
+			if !ok {
+				return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: answer %q is not in declared options %v", req.Answer, opts)
+			}
+		}
+	} else if req.Answer == "" {
+		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: answer required for free-text interrupts")
+	}
+
+	if err := s.store.InterruptResolve(ctx, req.InterruptID, req.Answer, resolvedBy, nil); err != nil {
+		return connector.InterruptionResolveResult{}, err
+	}
+	if s.interruptionBus != nil {
+		s.interruptionBus.Notify("intr:" + req.InterruptID)
+	}
+	if s.systemPublisher != nil && row.UserID != "" {
+		payload, _ := json.Marshal(map[string]any{
+			"interrupt_id": req.InterruptID,
+			"run_id":       req.RunID,
+			"kind":         row.Kind,
+			"status":       store.InterruptStatusResolved,
+			"answer":       req.Answer,
+			"resolved_by":  resolvedBy,
+		})
+		_, _ = s.systemPublisher.PublishNow(
+			ctx,
+			"_system/interrupts/resolved",
+			store.MemoryScopeUser, row.UserID,
+			payload, channels.SystemPublisherUserID, 0, 0,
+		)
+	}
+
+	return connector.InterruptionResolveResult{
+		InterruptID: req.InterruptID,
+		Status:      store.InterruptStatusResolved,
+		ResolvedAt:  time.Now().UTC().Format(time.RFC3339Nano),
+	}, nil
 }
 
 // --- Helpers ---

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -860,6 +860,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
 	loopCtx = tools.WithRunID(loopCtx, runID)
+	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
 
 	heartbeat := s.makeHeartbeat(runID)
 
@@ -1562,6 +1563,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
 	loopCtx = tools.WithRunID(loopCtx, runID)
+	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
 
 	// Heartbeat hook: each loop iteration updates last_heartbeat_at so a
 	// future sweeper can detect crashed processes (no heartbeat for > N
@@ -1864,6 +1866,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithHistoryPolicy(loopCtx, s.historyPolicyForAgent(agentDef))
 	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
 	loopCtx = tools.WithRunID(loopCtx, run.ID)
+	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:        provider,
@@ -2400,6 +2403,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subCtx = tools.WithHistoryPolicy(subCtx, s.historyPolicyForAgent(def))
 	subCtx = tools.WithInterruptionPolicy(subCtx, s.interruptionPolicyForAgent(def))
 	subCtx = tools.WithRunID(subCtx, subRunID)
+	subCtx = tools.WithDispatcher(subCtx, subDispatcher)
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -57,6 +57,9 @@ var handlersByName = map[string]toolHandler{
 	"export_snapshot":  handleExportSnapshot,
 	"restore_snapshot": handleRestoreSnapshot,
 	"delete_snapshot":  handleDeleteSnapshot,
+
+	// Interruption (v0.8.16) — 21st meta-tool
+	"interruption_resolve": handleInterruptionResolve,
 }
 
 func toolHandlerByName(name string) (toolHandler, bool) {
@@ -437,4 +440,28 @@ func toolErrWith(msg string, payload any) *loommcp.CallToolResult {
 		},
 		IsError: true,
 	}
+}
+
+// --- Interruption (v0.8.16) ---
+
+// handleInterruptionResolve is the 21st LoomCycle MCP meta-tool. Lets
+// an external orchestrator (Claude Code etc.) resolve a pending
+// interrupt without speaking HTTP to loomcycle directly. Wraps
+// connector.InterruptionResolve.
+func handleInterruptionResolve(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("interruption_resolve: no connector wired")
+	}
+	var req connector.InterruptionResolveRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return toolErr("invalid interruption_resolve arguments: " + err.Error()), nil
+	}
+	if req.RunID == "" || req.InterruptID == "" {
+		return toolErr("interruption_resolve: run_id and interrupt_id are required"), nil
+	}
+	res, err := env.connector.InterruptionResolve(ctx, req)
+	if err != nil {
+		return toolErr("interruption_resolve: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
 }

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -90,6 +90,10 @@ func (m *httpMockConnector) DeleteSnapshot(context.Context, string) error {
 	return errors.New("not implemented")
 }
 
+func (m *httpMockConnector) InterruptionResolve(context.Context, connector.InterruptionResolveRequest) (connector.InterruptionResolveResult, error) {
+	return connector.InterruptionResolveResult{}, errors.New("not implemented")
+}
+
 // httpTestServer wires an HTTPHandler against the mock connector and
 // returns an httptest.Server speaking the loomcycle MCP transport over
 // real HTTP. Test bodies POST to ts.URL + "/" (the test server has no

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -95,6 +95,10 @@ func (m *mockConnector) DeleteSnapshot(_ context.Context, _ string) error {
 	return errors.New("not implemented")
 }
 
+func (m *mockConnector) InterruptionResolve(_ context.Context, _ connector.InterruptionResolveRequest) (connector.InterruptionResolveResult, error) {
+	return connector.InterruptionResolveResult{}, errors.New("not implemented")
+}
+
 // driveServer runs the server against the given input lines and
 // returns the response frames (one per request). Notifications are
 // captured separately.
@@ -165,7 +169,7 @@ func TestServer_Handshake(t *testing.T) {
 	}
 }
 
-func TestServer_ToolsList_Returns20Tools(t *testing.T) {
+func TestServer_ToolsList_Returns21Tools(t *testing.T) {
 	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
 	in := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n"
 	resps, _ := driveServer(t, srv, in)
@@ -176,15 +180,15 @@ func TestServer_ToolsList_Returns20Tools(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 20 {
-		t.Errorf("got %d tools, want 20", len(result.Tools))
+	if len(result.Tools) != 21 {
+		t.Errorf("got %d tools, want 21 (v0.8.16 adds interruption_resolve)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
-	// Spot-check a few across categories.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "pause_runtime", "create_snapshot"} {
+	// Spot-check a few across categories — including the v0.8.16 addition.
+	for _, want := range []string{"spawn_run", "register_agent", "memory", "pause_runtime", "create_snapshot", "interruption_resolve"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -220,6 +220,22 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 				"properties": {"snapshot_id": {"type": "string"}}
 			}`),
 		},
+		// --- Interruption (v0.8.16) — the 21st meta-tool ---
+		{
+			Name: "interruption_resolve",
+			Description: "Resolve a pending Interruption.ask from outside the agent loop. Lets an external orchestrator (Claude Code, custom dashboard) act as the human answerer when the operator yaml configures `interruption.backend: mcp_server:...` or when the orchestrator wants to take over the webui default. Writes the answer, wakes the blocked agent loop, publishes _system/interrupts/resolved for downstream consumers. Returns 409-equivalent error on already-resolved / timed-out / cancelled rows.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["run_id", "interrupt_id", "answer"],
+				"properties": {
+					"run_id":       {"type": "string", "description": "The run that owns the pending interrupt."},
+					"interrupt_id": {"type": "string", "description": "The intr_... id surfaced via _system/interrupts/pending or EventInterruptionPending."},
+					"kind":         {"type": "string", "enum": ["question"], "description": "Discriminator. v0.8.16 supports only 'question'. Optional; defaults to 'question'."},
+					"answer":       {"type": "string", "description": "The human's answer. When the original ask declared options, MUST be one of them (server-side validated)."},
+					"resolved_by":  {"type": "string", "description": "Audit attribution for who resolved it (free-form). Defaults to 'mcp' when surfaced via this tool."}
+				}
+			}`),
+		},
 	}
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -123,4 +123,41 @@ type Connector interface {
 	ExportSnapshot(ctx context.Context, snapshotID string) (ExportSnapshotResult, error)
 	RestoreSnapshot(ctx context.Context, req RestoreSnapshotRequest) (RestoreSnapshotResult, error)
 	DeleteSnapshot(ctx context.Context, snapshotID string) error
+
+	// --- Interruption (v0.8.16) ---
+
+	// InterruptionResolve writes a resolution to a pending interrupt
+	// row + wakes any blocked Interruption.ask waiter via the bus.
+	// The LoomCycle MCP server's `interruption_resolve` meta-tool
+	// surfaces this on its 21st tool slot so external orchestrators
+	// (Claude Code, custom dashboards) can act as the answerer.
+	//
+	// The req payload is `kind`-discriminated; v0.8.16 supports only
+	// kind=question with {answer, resolved_by?}. Future kinds slot
+	// in as additional discriminator branches in the server-side
+	// validator (closed enum: see doc-internal/rfcs/interruption-tool.md
+	// §8).
+	//
+	// Returns ErrInterruptAlreadyTerminal-equivalent on conflict
+	// (409 from the HTTP layer maps to this); ErrNotFound on a
+	// missing interrupt_id; nil on success.
+	InterruptionResolve(ctx context.Context, req InterruptionResolveRequest) (InterruptionResolveResult, error)
+}
+
+// InterruptionResolveRequest is the input to Connector.InterruptionResolve.
+type InterruptionResolveRequest struct {
+	RunID         string `json:"run_id"`
+	InterruptID   string `json:"interrupt_id"`
+	Kind          string `json:"kind"`           // "question" in v0.8.16; future: "pause" / "wait_until" / "approval"
+	Answer        string `json:"answer"`         // for kind=question
+	ResolvedBy    string `json:"resolved_by"`    // operator attribution; default "mcp" when surfaced via LoomCycle MCP
+}
+
+// InterruptionResolveResult is what the resolve op returns. The
+// terminal status is always "resolved" on success; failure modes
+// surface as Go errors (typed where useful).
+type InterruptionResolveResult struct {
+	InterruptID string `json:"interrupt_id"`
+	Status      string `json:"status"`
+	ResolvedAt  string `json:"resolved_at"` // RFC3339Nano
 }

--- a/internal/tools/builtin/interruption.go
+++ b/internal/tools/builtin/interruption.go
@@ -86,6 +86,24 @@ type Interruption struct {
 	// own lower cap) but cannot exceed this. 0 = unbounded.
 	// Sourced from LOOMCYCLE_INTERRUPTION_MAX_PENDING_PER_RUN.
 	MaxPendingPerRun int
+
+	// Backend selects the delivery surface. Valid values:
+	//   - ""      / "webui" — default; agent loop blocks on bus.Wait;
+	//                          humans answer via /ui/interrupts → POST
+	//                          .../resolve.
+	//   - "mcp_server:<name>" — instead of bus.Wait, the tool calls
+	//                          the consumer's `mcp__<name>__ask` tool
+	//                          via the per-run Dispatcher (recovered
+	//                          from ctx). The consumer is responsible
+	//                          for blocking until the human answers;
+	//                          its tool result becomes the answer.
+	//   - "cli"               — local-dev only; treated as webui from
+	//                          the tool's POV (a separate process
+	//                          consumes `_system/interrupts/pending`
+	//                          and posts the resolve endpoint).
+	//
+	// Sourced from cfg.Interruption.Backend at boot.
+	Backend string
 }
 
 const interruptionDescription = `Human-in-the-loop primitive (v0.8.16). ` +
@@ -282,6 +300,17 @@ func (it *Interruption) execAsk(ctx context.Context, policy tools.InterruptionPo
 		)
 	}
 
+	// Backend selection:
+	//   - mcp_server:<name> → call the consumer's MCP tool directly
+	//     via the per-run Dispatcher. The consumer's tool blocks
+	//     until the human answers; we just write the row, dispatch,
+	//     persist the answer, return.
+	//   - webui / cli / "" → block on bus.Wait. The resolve handler
+	//     (or the cli answerer) writes the row + notifies.
+	if mcpName, ok := mcpServerFromBackend(it.Backend); ok {
+		return it.execAskViaMCP(ctx, id, mcpName, in, optsJSON, expiresAt, timeout)
+	}
+
 	// Block on the bus. Heartbeat ticker fires in a sibling goroutine
 	// so the run stays alive across long waits.
 	if err := it.blockWithHeartbeat(ctx, id, timeout); err != nil {
@@ -299,6 +328,97 @@ func (it *Interruption) execAsk(ctx context.Context, policy tools.InterruptionPo
 		return errResult(fmt.Sprintf("ask: post-resolve read: %s", err)), nil
 	}
 	return it.toolResultForStatus(final), nil
+}
+
+// execAskViaMCP is the consumer-MCP delivery path. Calls the named
+// MCP server's `ask` tool via the per-run Dispatcher; the consumer
+// blocks on its own (HTTP round-trip from loomcycle → consumer →
+// human → consumer → loomcycle). Result becomes the answer.
+//
+// On success we finalise the row as resolved + return the answer to
+// the agent. On dispatch error (consumer down, etc.) we mark the
+// row cancelled (audit attribution = "agent_cancel" since the agent
+// triggered the dispatch but couldn't complete it).
+func (it *Interruption) execAskViaMCP(ctx context.Context, interruptID, mcpName string, in interruptionInput, _ json.RawMessage, _ time.Time, timeout time.Duration) (tools.Result, error) {
+	disp := tools.DispatcherFromCtx(ctx)
+	if disp == nil {
+		// No dispatcher → fall back to webui path. Operator misconfig
+		// (yaml says mcp_server but server registration absent),
+		// surfaces clearly as a tool error rather than silently
+		// blocking.
+		_ = it.Store.InterruptFinish(ctx, interruptID, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+		return errResult(fmt.Sprintf(
+			"ask: backend mcp_server:%s configured but no dispatcher attached to ctx (server wiring bug)",
+			mcpName,
+		)), nil
+	}
+	toolName := "mcp__" + mcpName + "__ask"
+
+	// Build the args payload — the consumer's tool decides its own
+	// schema, but we forward the agent-supplied question+options+
+	// context unchanged so the consumer can render them faithfully.
+	argMap := map[string]any{
+		"question":     in.Question,
+		"interrupt_id": interruptID,
+	}
+	if len(in.Options) > 0 {
+		argMap["options"] = in.Options
+	}
+	if in.Context != "" {
+		argMap["context"] = in.Context
+	}
+	if timeout > 0 {
+		argMap["timeout_ms"] = int(timeout / time.Millisecond)
+	}
+	args, _ := json.Marshal(argMap)
+
+	// Apply timeout to the dispatch ctx so a hung consumer doesn't
+	// pin the run forever.
+	callCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		callCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	res := disp.Execute(callCtx, toolName, args)
+	if res.IsError {
+		// Consumer surfaced an error tool result — treat as a
+		// failed delivery, mark cancelled.
+		_ = it.Store.InterruptFinish(context.WithoutCancel(ctx), interruptID, store.InterruptStatusCancelled, store.InterruptResolvedByAgentCancel)
+		return res, nil
+	}
+
+	// Consumer returned a successful tool result. The result text is
+	// the human's answer (typically free-text JSON). Persist it +
+	// return it to the agent.
+	if err := it.Store.InterruptResolve(context.WithoutCancel(ctx), interruptID, res.Text, store.InterruptResolvedByMCP, nil); err != nil {
+		// Resolve write failed but the consumer already collected
+		// the answer. Surface as is_error so the agent doesn't see
+		// a phantom-success answer that doesn't match storage.
+		return errResult(fmt.Sprintf("ask: persist answer from mcp_server:%s: %s", mcpName, err)), nil
+	}
+
+	out, _ := json.Marshal(map[string]any{
+		"interrupt_id": interruptID,
+		"answer":       res.Text,
+		"resolved_at":  time.Now().UTC().Format(time.RFC3339Nano),
+		"resolved_by":  store.InterruptResolvedByMCP,
+	})
+	return tools.Result{Text: string(out)}, nil
+}
+
+// mcpServerFromBackend parses "mcp_server:<name>" into (<name>, true).
+// Returns ("", false) for any other backend value.
+func mcpServerFromBackend(backend string) (string, bool) {
+	const prefix = "mcp_server:"
+	if strings.HasPrefix(backend, prefix) {
+		name := backend[len(prefix):]
+		if name != "" {
+			return name, true
+		}
+	}
+	return "", false
 }
 
 // execNotify is fire-and-forget — no blocking. Writes a row with

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -355,6 +355,34 @@ func InterruptionPolicy(ctx context.Context) InterruptionPolicyValue {
 	return v
 }
 
+// ctxKeyDispatcher is the context key carrying the run's tool
+// dispatcher (v0.8.16). The Interruption tool's mcp_server delivery
+// backend uses this to call the consumer's `mcp__<name>__ask` tool
+// without re-implementing dispatch + retry + bearer substitution.
+//
+// Nil-safe — the helper Dispatcher(ctx) returns nil when no
+// dispatcher is attached; the Interruption tool falls back to its
+// webui code path when the operator config requests
+// mcp_server:<name> but no dispatcher is available.
+type ctxKeyDispatcher struct{}
+
+// WithDispatcher attaches the run's Dispatcher to ctx. Called at run
+// start in the HTTP server (same locations as WithRunID /
+// WithRunIdentity).
+func WithDispatcher(ctx context.Context, d *Dispatcher) context.Context {
+	if d == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyDispatcher{}, d)
+}
+
+// DispatcherFromCtx returns the run's Dispatcher from ctx, or nil
+// when none was attached.
+func DispatcherFromCtx(ctx context.Context) *Dispatcher {
+	v, _ := ctx.Value(ctxKeyDispatcher{}).(*Dispatcher)
+	return v
+}
+
 // ctxKeyRunID is the context key under which the runtime stores
 // the current run's store row ID. The Interruption tool uses this
 // at create time to associate the interrupt row with the run for


### PR DESCRIPTION
**Stacked on PR #120** — review after PRs 1+2 land.

## Summary

PR 3 of 5 for v0.8.16. Adds the two non-default delivery surfaces.

+339 / -5, 11 files.

## What ships

- **Consumer-MCP delivery** — `interruption.backend: mcp_server:<name>` routes through the per-run Dispatcher to call `mcp__<name>__ask`. Inherits `${run.user_bearer}` substitution + ACL for free.
- **Dispatcher in ctx** — new `tools.WithDispatcher` / `tools.DispatcherFromCtx` attached at all 4 ctx-attach sites.
- **21st LoomCycle MCP meta-tool**: `interruption_resolve`. Lets an external orchestrator (Claude Code) act as the answerer.
- **Connector.InterruptionResolve** + request/result types. Implementation on `*Server` mirrors the HTTP resolve handler's logic (validate row + ownership + expiry + options → write → bus.Notify → publish `_system/interrupts/resolved`).
- **Backend field** on the Interruption tool struct, plumbed from `cfg.Interruption.Backend` at boot.

## Tests

- gRPC + 2 MCP mockConnectors gain `InterruptionResolve` method (interface compliance)
- `TestServer_ToolsList_Returns20Tools` → `Returns21Tools`; spot-check list now includes `interruption_resolve`
- All v0.8.x existing tests pass unchanged

## Verification

- [x] `go test ./...` clean
- [x] `gofmt -l .` empty
- [x] `go vet ./...` clean

## Out of scope

PR 4: Web UI `/ui/interrupts` route
PR 5: Documentation (TOOLS.md, help topic, sample yaml, REVISIONS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)