### PR TITLE
fix(ollama+ui): coalesce per-token text deltas — backend driver + UI

### DIFF
--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -410,6 +410,31 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	// at end-of-stream without buffering the user's view of progress.
 	var textBuf strings.Builder
 
+	// coalesceBuf batches consecutive content deltas into phrase-sized
+	// EventText emissions. Ollama (both local /api/chat and ollama.com
+	// cloud) streams one token per chunk — pre-fix the events table
+	// recorded one row per token, the SSE wire emitted one frame per
+	// token, and the Web UI rendered one card per token. Mirrors the
+	// openai driver's 64-byte coalesce (PR #28); we land it separately
+	// here because deepseek-v4-pro served via the ollama-cloud
+	// subscription path goes through THIS driver, not the openai/deepseek
+	// pair, so PR #28's fix didn't reach it.
+	//
+	// Flush points: ≥64 bytes accumulated, newline in the current
+	// delta (preserve paragraph breaks), before any tool_call emission
+	// (preserves the "text precedes tool_call" ordering loop.go expects),
+	// and end-of-stream / scanner-error / done frame.
+	var coalesceBuf strings.Builder
+	const textCoalesceMin = 64
+	flushText := func() bool {
+		if coalesceBuf.Len() == 0 {
+			return true
+		}
+		s := coalesceBuf.String()
+		coalesceBuf.Reset()
+		return send(providers.Event{Type: providers.EventText, Text: s})
+	}
+
 	for scanner.Scan() {
 		line := bytes.TrimSpace(scanner.Bytes())
 		if len(line) == 0 {
@@ -430,7 +455,18 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 		if c.Message.Content != "" {
 			textBuf.WriteString(c.Message.Content)
-			if !send(providers.Event{Type: providers.EventText, Text: c.Message.Content}) {
+			coalesceBuf.WriteString(c.Message.Content)
+			if coalesceBuf.Len() >= textCoalesceMin || strings.ContainsRune(c.Message.Content, '\n') {
+				if !flushText() {
+					return
+				}
+			}
+		}
+		if len(c.Message.ToolCalls) > 0 {
+			// Flush buffered text BEFORE tool_call emissions so the loop's
+			// "text precedes tool_call within an iteration" invariant holds
+			// (loop.go:629 prepends iterText into the assistant block).
+			if !flushText() {
 				return
 			}
 		}
@@ -465,7 +501,19 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		// Flush any buffered text before the error event so bytes the
+		// wire delivered aren't silently dropped on mid-stream read
+		// failure. Mirrors the openai driver's same-position flush.
+		_ = flushText()
 		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
+		return
+	}
+
+	// End-of-stream flush. Covers the common case where the final
+	// content delta brought the buffer to <64 bytes and contained no
+	// newline (e.g. a short final sentence). Without this, that tail
+	// would be silently dropped.
+	if !flushText() {
 		return
 	}
 

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -601,3 +601,104 @@ func TestDriver_NonOKErrorUsesProviderID(t *testing.T) {
 		t.Errorf("err = %q, want prefix \"ollama-local 503:\"", err.Error())
 	}
 }
+
+// Regression: Ollama (both local /api/chat and ollama.com cloud) streams
+// one token per chunk. Pre-fix the driver emitted one EventText per
+// chunk, producing one events-table row per token and one Web UI card
+// per token (job-searcher r_935214273f141fb9 on 2026-05-17 logged 317
+// text events for a single run). The driver now coalesces consecutive
+// content deltas into ≥64-byte EventText emissions; this test asserts
+// that 14 single-token deltas (~70 chars total) emit ≤2 EventText
+// events instead of 14, and that the joined text is byte-identical to
+// the wire content.
+func TestStreamCoalescesPerTokenContentDeltas(t *testing.T) {
+	tokens := []string{
+		"Now", " let", " me", " load", " the", " relevance",
+		"-filter", "ing", " skill", " and", " then", " start",
+		" searching", ".",
+	}
+	var frames []string
+	for _, tok := range tokens {
+		frames = append(frames,
+			`{"model":"llama3.1","message":{"role":"assistant","content":`+jsonString(tok)+`},"done":false}`+"\n",
+		)
+	}
+	frames = append(frames,
+		`{"model":"llama3.1","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":14}`+"\n",
+	)
+
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), providers.Request{Model: "llama3.1"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var joined strings.Builder
+	textCount := 0
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			textCount++
+			joined.WriteString(ev.Text)
+		}
+	}
+
+	want := strings.Join(tokens, "")
+	if joined.String() != want {
+		t.Errorf("joined text = %q, want %q", joined.String(), want)
+	}
+	// 14 tokens × ~5 chars = ~70 chars total. With a 64-byte threshold
+	// the buffer should flush exactly once during the stream (when it
+	// crosses 64) and once more at end-of-stream for the tail. So
+	// textCount ∈ {1, 2}; anything ≥3 means the coalesce regressed.
+	if textCount > 2 {
+		t.Errorf("EventText count = %d, want ≤2 (coalesce regressed; pre-fix would emit %d)", textCount, len(tokens))
+	}
+	if textCount < 1 {
+		t.Errorf("EventText count = %d, want ≥1 (text was silently dropped)", textCount)
+	}
+}
+
+// Regression: a newline in a content delta must force a flush so
+// paragraph breaks survive coalescing. Without this, a 60-byte buffer
+// would swallow the newline boundary and concatenate two paragraphs
+// into one EventText.
+func TestStreamCoalesceFlushesOnNewline(t *testing.T) {
+	frames := []string{
+		`{"model":"x","message":{"role":"assistant","content":"first paragraph\n"},"done":false}` + "\n",
+		`{"model":"x","message":{"role":"assistant","content":"second paragraph"},"done":true,"done_reason":"stop","prompt_eval_count":1,"eval_count":2}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), providers.Request{Model: "x"})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var events []string
+	for ev := range ch {
+		if ev.Type == providers.EventText {
+			events = append(events, ev.Text)
+		}
+	}
+	if len(events) != 2 {
+		t.Fatalf("EventText count = %d, want 2 (newline must split); got events %#v", len(events), events)
+	}
+	if events[0] != "first paragraph\n" {
+		t.Errorf("event[0] = %q, want %q (newline-bearing delta should flush including the newline)", events[0], "first paragraph\n")
+	}
+	if events[1] != "second paragraph" {
+		t.Errorf("event[1] = %q, want %q (post-newline delta should land in a fresh buffer flushed at end-of-stream)", events[1], "second paragraph")
+	}
+}
+
+// jsonString quotes a string as a JSON literal — handy for building
+// stream frames inline above without dragging in encoding/json
+// just to write a token.
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/web/src/pages/AgentDetail.tsx
+++ b/web/src/pages/AgentDetail.tsx
@@ -55,7 +55,7 @@ export default function AgentDetail() {
     }
   }, [events.length, agent?.status]);
 
-  const renderedEvents = useMemo(() => events.filter(visible), [events]);
+  const renderedEvents = useMemo(() => coalesceText(events.filter(visible)), [events]);
 
   if (!agentId) {
     return <div className="empty">Missing agent id in URL.</div>;
@@ -132,6 +132,42 @@ export default function AgentDetail() {
 function visible(ev: TranscriptEvent): boolean {
   const t = ev.event?.type ?? ev.type;
   return t !== "started" && t !== "usage" && t !== "session" && t !== "agent" && t !== "user_input";
+}
+
+// coalesceText folds runs of consecutive `text` (and `thinking`) events
+// into a single merged event for rendering. Providers that stream one
+// token per delta (DeepSeek, Ollama Cloud) used to produce hundreds of
+// single-token cards per run — illegible in the operator dashboard.
+// The backend now coalesces at the driver level (PR addressing
+// r_935214273f141fb9 on 2026-05-17), but the UI keeps its own pass for
+// two reasons: (1) historical transcripts persisted pre-fix still
+// contain per-token rows that we want to render compactly, (2) the
+// driver's 64-byte threshold still produces ~phrase-sized chunks
+// which look better as one paragraph than as many cards.
+//
+// The merged event reuses the FIRST input event's seq (React key) and
+// ts_ns (timestamp label). text is concatenated in order, preserving
+// whitespace exactly as the provider wrote it. Only consecutive
+// same-type events merge; a tool_call between two text events is a
+// hard boundary.
+function coalesceText(events: TranscriptEvent[]): TranscriptEvent[] {
+  const out: TranscriptEvent[] = [];
+  for (const ev of events) {
+    const last = out[out.length - 1];
+    const kind = ev.event?.type ?? ev.type;
+    const lastKind = last ? (last.event?.type ?? last.type) : "";
+    if (last && (kind === "text" || kind === "thinking") && kind === lastKind) {
+      // Append text to the existing merged event. Clone rather than
+      // mutate so React's reference equality picks up the change.
+      out[out.length - 1] = {
+        ...last,
+        event: { ...last.event, text: (last.event?.text ?? "") + (ev.event?.text ?? "") },
+      };
+    } else {
+      out.push(ev);
+    }
+  }
+  return out;
 }
 
 // EventCard renders one transcript row as a collapsed panel by


### PR DESCRIPTION
## Summary

- **Backend (`internal/providers/ollama/driver.go`):** coalesce consecutive `message.content` deltas into ≥64-byte `EventText` chunks (mirrors PR #28's openai-driver fix that this driver was missed by).
- **Web UI (`web/src/pages/AgentDetail.tsx`):** fold consecutive `text`/`thinking` events into one merged card before render.

## Why

The `deepseek-v4-pro` model served through the `ollama` provider (Ollama Cloud subscription path) was producing one events-table row per token — empirically observed on 2026-05-17 in run `r_935214273f141fb9` (317 text events for a single run, average payload 30 bytes ≈ one word each). Sampling 5 recent `model LIKE 'deepseek%'` runs showed the pattern is consistent (317–1904 text events per run, all averaging ~30 bytes).

PR #28 (May 9) fixed the same issue for the openai driver, but the ollama driver was missed. The `deepseek-v4-pro` runs go through `provider: ollama` (not `provider: deepseek`) because the operator yaml lists the Ollama Cloud subscription path first for cost-floor routing — confirmed by every recent tool_call having an `lc-*-*` synth ID (loop.go:587 synthesises these specifically because "Ollama doesn't issue tool_call IDs").

The events-table chunking translates downstream into one SSE frame per token and one `<EventCard>` per token on the Web UI — illegible on the operator dashboard. The UI-side merge handles both the new compact backend stream and historical pre-fix transcripts that still contain per-token rows.

## What changed

### `internal/providers/ollama/driver.go`

Add a `coalesceBuf` separate from the existing `textBuf` (which serves a different purpose: qwen3 tool-call-as-text recovery at end-of-stream). Flush points mirror the openai driver:

- ≥64 bytes accumulated
- newline in the current delta (preserve paragraph breaks)
- before any `tool_call` emission within a frame (preserve the "text precedes tool_call" ordering loop.go:629 expects)
- end-of-stream / scanner-error

### `web/src/pages/AgentDetail.tsx`

`coalesceText()` folds runs of consecutive same-type `text`/`thinking` events into one merged event for rendering. Reuses the first input event's `seq` (React key stability) and `ts_ns` (timestamp label). Concatenates `text` in order, preserving whitespace exactly. `tool_call` between two text events is a hard boundary.

Kept on the UI side even after backend coalesce lands so that historical transcripts persisted pre-fix still render compactly.

## Test plan

- [x] `TestStreamCoalescesPerTokenContentDeltas` — 14 single-token deltas must emit ≤2 `EventText` events. Verified to **fail on the unfixed driver** (count=14) and pass after the fix (count≤2).
- [x] `TestStreamCoalesceFlushesOnNewline` — paragraph break in delta must split into two `EventText` events.
- [x] `go test ./...` — full Go suite passes clean.
- [x] `npx tsc --noEmit` — Web UI type-check clean.
- [x] `npx vite build` — production UI bundle builds clean (46 modules, 250 KB JS).
- [x] `go build ./cmd/loomcycle` — full binary builds clean.

## Operational notes (separate from this PR)

The latest job-searcher runs on the dev machine also hit ollama-local **header timeouts** on `denn-desktop.local:11434` — `qwen3-coder:30b-a3b-q4_K_M` is 17 GB and its cold-load exceeds the 60s default `LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS`. Recommended operator workarounds (no code change in this PR):

- Set `LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=180000` in the loomcycle daemon env.
- Pre-warm on denn-desktop: `ollama run qwen3-coder:30b-a3b-q4_K_M ""` (and `ollama run qwen3:14b ""` for the text-manipulation tier).

If the global env-var bump turns out to be too coarse, a follow-up could expose per-provider header-timeout overrides via yaml (`providers.ollama-local.header_timeout_ms`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)