### PR TITLE
feat(webui): add orange creature favicon

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>loomcycle</title>
   </head>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img">
+  <title>Loomcycle</title>
+  <rect width="32" height="32" rx="6" fill="#FAF8F3"/>
+  <path d="M 16 5 C 25 5, 28 12, 28 20 C 28 27, 23 29, 16 29 C 9 29, 4 27, 4 20 C 4 12, 7 5, 16 5 Z"
+        fill="#E8923D" stroke="#1A1A2E" stroke-width="2" stroke-linejoin="round"/>
+  <ellipse cx="11" cy="15" rx="2.3" ry="3" fill="#1A1A2E"/>
+  <ellipse cx="21" cy="15" rx="2.3" ry="3" fill="#1A1A2E"/>
+  <circle cx="10.3" cy="13.8" r="1" fill="#FAF8F3"/>
+  <circle cx="20.3" cy="13.8" r="1" fill="#FAF8F3"/>
+  <path d="M 11 22 Q 16 26 21 22" stroke="#1A1A2E" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Add a favicon for the loomcycle Web UI.

## What changed

- `web/public/favicon.svg` (new) — the creature mark from the internal brand asset at `~/work/loomcycle-internal/web/favicon.svg`, recoloured with body fill `#3D8EE8` → `#E8923D` (orange — perfect colour-wheel inverse of the original blue, preserving saturation/lightness). Everything else (paths, coordinates, eye and mouth strokes, background) is byte-identical to source — the diff is a single hex value.
- `web/index.html` — adds `<link rel="icon" type="image/svg+xml" href="/favicon.svg" />`.

## Build mechanics

Vite serves static assets from `web/public/`; on `npm run build` the favicon lands in `internal/webui/dist/` and is picked up by `//go:embed all:dist` in `internal/webui/webui.go`. The binary serves it at `/ui/favicon.svg`. Vite's `base: "/ui/"` config rewrites the `/favicon.svg` href in `index.html` to `/ui/favicon.svg` in the production build automatically.

## Test plan

- [x] `npx vite build` — production bundle builds clean; `internal/webui/dist/index.html` contains `href="/ui/favicon.svg"`.
- [x] `go build ./cmd/loomcycle` — full binary builds.
- [x] `strings ./bin/loomcycle | grep E8923D` — the orange colour appears exactly once in the compiled binary (the embedded SVG payload).
- [ ] Visual check at `/ui` after binary deploy — tab icon shows the orange creature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)