### PR TITLE
test(builtin): fix race in TestInterruption_EmitsPendingSSEEvent

### DIFF
--- a/internal/tools/builtin/interruption_test.go
+++ b/internal/tools/builtin/interruption_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -318,9 +319,18 @@ func TestInterruption_EmitsPendingSSEEvent(t *testing.T) {
 	tool, ctx, _, cleanup := interruptionFixture(t)
 	defer cleanup()
 
-	var events []providers.Event
+	// The emitter fires from the goroutine that calls tool.Execute below;
+	// the assertion loop runs from the test goroutine. Both touch the
+	// `events` slice, so guard it with a mutex — without this, -race
+	// flags the unsynchronised slice access (CI run 25993107457).
+	var (
+		eventsMu sync.Mutex
+		events   []providers.Event
+	)
 	ctx = tools.WithEventEmitter(ctx, func(e providers.Event) {
+		eventsMu.Lock()
 		events = append(events, e)
+		eventsMu.Unlock()
 	})
 
 	resCh := make(chan tools.Result, 1)
@@ -330,9 +340,15 @@ func TestInterruption_EmitsPendingSSEEvent(t *testing.T) {
 	}()
 	time.Sleep(50 * time.Millisecond)
 
+	// Snapshot under the lock so the iteration below operates on a
+	// stable slice header that won't race with further emitter writes.
+	eventsMu.Lock()
+	snapshot := append([]providers.Event(nil), events...)
+	eventsMu.Unlock()
+
 	// At least one EventInterruptionPending must have fired.
 	found := false
-	for _, e := range events {
+	for _, e := range snapshot {
 		if e.Type == providers.EventInterruptionPending && e.Interruption != nil {
 			found = true
 			if e.Interruption.Question != "Hi?" {


### PR DESCRIPTION
## Summary

Fix the data race in \`TestInterruption_EmitsPendingSSEEvent\` that has kept CI red on \`main\` since the Interruption tool landed (PR #120).

## Symptom

\`go test -race\` flags an unsynchronised access to a local \`events\` slice in the test:

\`\`\`
WARNING: DATA RACE
Read at 0x... by goroutine 444:
  interruption_test.go:341 (assertion loop iterating events)
Previous write at 0x... by goroutine 447:
  interruption_test.go:328 → interruption.go:270 (execAsk appending via EventEmitter)
--- FAIL: TestInterruption_EmitsPendingSSEEvent (0.20s)
    testing.go:1712: race detected during execution of test
FAIL  github.com/denn-gubsky/loomcycle/internal/tools/builtin  16.093s
\`\`\`

Reproduced on CI runs 25993107457 (PR #124 merge) and 25993420245 (PR #125 merge).

## Why it raced

The test installs an EventEmitter that appends to a local \`events\` slice. The emitter fires from inside the goroutine running \`tool.Execute(...)\` (line 327), while the assertion loop reads the same slice from the test goroutine (line 335). The intervening \`time.Sleep(50ms)\` is intended to wait for events to arrive but is not a memory-synchronisation primitive — Go's race detector correctly flags every full-suite run.

## Fix

Guard the slice with a \`sync.Mutex\`:

- The emitter takes the lock to append.
- The assertion takes the lock once to copy a stable snapshot, then iterates the snapshot lock-free (so the loop body's calls into the test \`t\` don't deadlock against a still-emitting goroutine).

The 50 ms wait stays — its job is "give the emitter time to fire" (event-arrival latency), not memory visibility. Memory visibility now comes from the mutex.

## Test plan

- [x] \`gofmt -l internal/tools/builtin/interruption_test.go\` — clean.
- [x] \`go vet ./internal/tools/builtin/...\` — clean.
- [x] \`go test -race ./internal/tools/builtin/... -run TestInterruption_EmitsPendingSSEEvent -count=10\` — 10/10 pass.
- [x] \`go test -race ./internal/tools/builtin/...\` — full package clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)