### PR TITLE
test(mcp/stdio): fix crash-mode race in TestServerCrashFailsInFlightCalls

### DIFF
--- a/internal/tools/mcp/stdio/client_test.go
+++ b/internal/tools/mcp/stdio/client_test.go
@@ -69,6 +69,20 @@ func runFakeServer(mode string) {
 				},
 			})
 			if mode == "crash" {
+				// Wait for the client's notifications/initialized to
+				// arrive on stdin BEFORE exiting. Without this, the
+				// client's notification write races with our exit:
+				// on macOS the pipe closes first, the client's write
+				// returns "broken pipe", and Initialize fails before
+				// the test's assertion ("server should crash after
+				// initialize, so tool_call fails with transport
+				// error") can run. The CI-passing flow needs the
+				// MCP handshake to complete cleanly first; the crash
+				// is only meaningful when measured against a
+				// subsequent operation.
+				if scanner.Scan() {
+					_ = scanner.Bytes()
+				}
 				os.Exit(1)
 			}
 		case "tools/list":


### PR DESCRIPTION
## Summary

Follow-up to PR #126. Fix a flake in \`TestServerCrashFailsInFlightCalls\` (\`internal/tools/mcp/stdio\`) where the fake server's "crash" mode raced with the MCP handshake.

## Why this isn't a no-op

Even though both PR #124 and PR #125 merge runs passed this test on CI (ubuntu-latest), it consistently fails on macOS under heavy parallel \`go test -race ./...\` load — the timing window is narrower on the slower Linux CI runners but the underlying bug is real. Fixing it now keeps the local + macOS-CI experience clean for anyone on this codebase.

## Symptom

\`\`\`
--- FAIL: TestServerCrashFailsInFlightCalls (0.01s)
    client_test.go:290: Initialize: initialized notify: write |1: broken pipe
FAIL  github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio
\`\`\`

## Why it raced

The MCP \`initialize\` handshake is two legs:

1. Client → server: \`initialize\` request.
2. Server → client: \`initialize\` response.
3. Client → server: \`notifications/initialized\` notification (one-way).

The test's fake server in "crash" mode called \`os.Exit(1)\` immediately after step 2 — so step 3's pipe write ran into a closed pipe and returned EPIPE. The test's \`t.Fatal(\"Initialize: ...\")\` fired, never reaching the actual assertion (\"the SUBSEQUENT \`CallTool\` after server death must return a transport error\").

## Fix

In crash mode, consume the \`initialized\` notification off stdin with one more \`scanner.Scan()\` before exiting. The crash semantics are preserved — the server still dies before the test's \`CallTool\` runs — it just dies AFTER the handshake completes, which is what the test was always trying to express.

## Test plan

- [x] \`go test -race ./internal/tools/mcp/stdio/... -count=20\` — 20/20 pass clean.
- [x] \`gofmt -l\` — clean.
- [x] \`go vet\` — clean.

## Out of scope (still on PR #126)

The full-suite \`go test -race ./...\` on this branch still fails on \`TestInterruption_EmitsPendingSSEEvent\` — that's the unrelated data race fixed by #126. Both PRs land their own narrow fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)