### PR TITLE
feat(hooks): per-call host-widening capability for Pre-hooks (v0.8.17)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -584,11 +584,98 @@ DELETE /v1/hooks/{id}          // remove a registration
 
 ### Trust-boundary invariants
 
-- Hooks run **after** the policy layer (`allowed_tools` / `allowed_hosts`). Hooks may narrow further or rewrite content — **never widen**.
+- Hooks run **after** the policy layer (`allowed_tools` / `allowed_hosts`). Hooks may narrow further or rewrite content. The **only** exception is the per-call host-widening capability below, which requires explicit operator opt-in.
 - Hooks **cannot** tear down the agent run. The worst they can do is short-circuit one tool call with a synthetic `IsError: true` result.
 - Webhook payloads include `agent_id` and `user_id` for correlation but **do NOT** include the agent's prompt or message history.
 
-References: `internal/hooks/`, `internal/api/http/hooks.go` (registration routes), `internal/loop/loop.go::dispatchOneTool` (chain invocation).
+### Per-call host widening (v0.8.17)
+
+A Pre-hook can grant the model permission to fetch a hostname that's *not* on the operator's static `LOOMCYCLE_HTTP_HOST_ALLOWLIST` and *not* on the runtime caller's `runRequest.allowed_hosts`. The grant is **per-tool-call** — scoped to exactly one `Execute()`, never cached server-side, never inherited by sub-agents.
+
+This solves the dynamic-discovery problem: `job-searcher` finds a job posting on a site nobody pre-enumerated; the calling service's hook checks its own per-user allowlist + reputation oracle + business rules and approves the URL on the spot.
+
+#### Opt-in (operator yaml only)
+
+```yaml
+hooks:
+  permit_host_widen:
+    owners: ["jobs-search-web"]
+```
+
+Or env: `LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS=jobs-search-web,company-research`
+
+- **Exact-string match** against `Hook.Owner`. No globs.
+- Without an entry here, ANY hook's `allow_hosts` field is silently dropped at the dispatcher (with a `hooks: pre ... dropping grant` WARN log + counter increment via `Dispatcher.Stats().HostWidenDenied`). The model and the runtime caller cannot enable this — only the operator yaml can.
+- **Caller-authoritative mode interaction**: when `LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=true`, a permitted hook STILL widens on top of the caller's authoritative list. Operator yaml is the floor for *behaviors* (including hook delegation), not just for the static host list.
+
+#### Wire shape
+
+A Pre-hook returns an optional `allow_hosts` field alongside the existing `input` / `deny`:
+
+```json
+{
+  "input": {...},
+  "deny": {"is_error": true, "text": "..."},
+  "allow_hosts": ["acme.com", ".trusted-cdn.com"]
+}
+```
+
+#### Matching semantics
+
+Intentionally **stricter** than the operator allowlist:
+
+- `"acme.com"` (no leading dot) → **exact hostname match only**. Won't widen `careers.acme.com`.
+- `".acme.com"` (leading dot) → **suffix-match** (matches `acme.com` AND any subdomain). Symmetric with the operator-list shape.
+
+This lets cautious hook authors be surgical ("approve only the literal URL the model asked about") while supporting the broader case via the leading-dot opt-in.
+
+#### Composition
+
+- Multiple permitted-owner hooks contributing `allow_hosts` in one chain → the dispatcher returns the **deduplicated UNION** (case-insensitive on hostname).
+- A `deny` anywhere in the chain **discards all prior** `allow_hosts` grants (we don't carry policy widenings into a denied call — confused-deputy hardening).
+- Order of `AllowHosts` in the outcome is first-seen across the Pre chain.
+
+#### Audit event
+
+The loop emits one `EventHostWidened` per dispatched call where widening fired:
+
+```json
+{
+  "type": "host_widened",
+  "host_widening": {
+    "tool_call_id": "lc-0-0",
+    "tool_name": "WebFetch",
+    "url": "https://acme.com/careers/123",
+    "hook_owner": "jobs-search-web",
+    "hook_name": "url-gate",
+    "hosts_added": ["acme.com"]
+  }
+}
+```
+
+Persisted to the `events` table via `makeRecordingEmit` like every other typed event. Operators audit confused-deputy patterns by joining on `tool_call_id` and comparing the requested URL's host to the granted `HostsAdded` — if they're always identical for one owner, the hook is probably echoing model input without independent validation.
+
+Aggregate counters via `Dispatcher.Stats()`:
+
+```go
+type DispatcherStats struct {
+    HostWidenPermitted int64 // grants honoured
+    HostWidenDenied    int64 // grants dropped (owner not in permit list)
+}
+```
+
+#### SECURITY — confused-deputy hazard
+
+The Pre-hook's `tool_call.input` is **model-generated and untrusted**. A naive hook that echoes `input.url`'s hostname back as `allow_hosts` literally lets the model widen its own allowlist. **Validate independently** — against the user's own preferences, a per-tenant allowlist, a domain-reputation service, your own business rules. Never trust the URL the model is asking about as authority for whether the URL should be approved.
+
+#### Known limitations (v1)
+
+1. **Redirect to a new unknown host within a single fetch** is NOT re-validated by the hook. The extras attached pre-dispatch cover the entire tool call (initial URL + all redirects), so a redirect to a hostname the hook *did* approve up-front works. But a redirect to a brand-new host nobody approved fails. Practical workaround: hooks for redirect-heavy use cases (job boards proxied through ATS trackers) should approve the likely redirect targets too.
+2. **Dial-time private-IP block is NOT bypassable.** Even if `allow_hosts` includes `localhost`, the host's resolved private IP is still blocked unless the operator separately opted in via `HTTPPrivateHostAllowlist`. This is a separate, orthogonal trust boundary — hooks widen at the hostname layer, never at the IP layer.
+3. **Sub-agents do NOT inherit a parent's widening.** Per-tool-call scope means the grant evaporates the moment Execute() returns. If a sub-agent needs the same widening, the same hook needs to be registered against the sub-agent's name (via the hook's `agents:` glob).
+4. **No server-side caching.** Every WebFetch to a hostname outside the static list triggers a fresh callback. Hooks should cache client-side if their decision is stable for the user/tenant.
+
+References: `internal/hooks/`, `internal/api/http/hooks.go` (registration routes), `internal/loop/loop.go::dispatchOneTool` (chain invocation), `internal/config/config.go::HooksConfig` (operator opt-in shape), `internal/tools/builtin/httptool.go::hostAllowedExtras` (matcher).
 
 ## The `Interruption` tool — human-in-the-loop primitive (v0.8.16)
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -141,7 +141,12 @@ type Server struct {
 // (empty if no run has started) so handler code can call its methods
 // unconditionally without nil-checking.
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
-	hookReg := hooks.NewRegistry()
+	// Hook registry is constructed with the operator-yaml host-widen
+	// permit list (cfg.Hooks.PermitHostWiden.Owners). Without an entry
+	// there, any Pre-hook's allow_hosts response is silently dropped
+	// at dispatch time. The list is frozen at construction — the only
+	// way to mutate the trust boundary is a restart with new yaml.
+	hookReg := hooks.NewRegistryWithPermissions(cfg.Hooks.PermitHostWiden.Owners)
 	s := &Server{
 		cfg:            cfg,
 		providers:      pr,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,12 @@ type Config struct {
 	// Empty (zero-value) = backend=webui implicitly.
 	Interruption InterruptionConfig `yaml:"interruption"`
 
+	// Hooks is the v0.8.17 top-level config block for the tool-use
+	// hooks subsystem. Today it only carries the host-widen
+	// permission allowlist; the existing hook-registration HTTP
+	// endpoints (POST /v1/hooks) are unchanged. See HooksConfig.
+	Hooks HooksConfig `yaml:"hooks"`
+
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
 
@@ -191,6 +197,42 @@ type StorageConfig struct {
 // callers that need to resolve relative paths declared in the config
 // (the local-api spec path, additional resource files).
 func (c *Config) ConfigDir() string { return c.configDir }
+
+// HooksConfig is the v0.8.17 top-level config block for the tool-use
+// hooks subsystem. Carries operator-side knobs that can't be set via
+// the dynamic POST /v1/hooks endpoint — they need a trust boundary
+// the registering app can't influence.
+type HooksConfig struct {
+	// PermitHostWiden lists hook owners whose Pre-hook responses are
+	// honoured when they include an `allow_hosts` field. A hook
+	// registers via POST /v1/hooks with an Owner UID; if that Owner
+	// appears here (exact string match, no globs), the dispatcher
+	// will UNION the hook's per-call allow_hosts entries into a
+	// ctx-scoped extra list that HTTP/WebFetch consult at the
+	// host-allowed gate.
+	//
+	// Without an entry here, allow_hosts from any hook is silently
+	// dropped (with a WARN log + metric increment) — preserving the
+	// "operator yaml is the trust-boundary floor" invariant
+	// (CLAUDE.md rule #8): the runtime caller and the model both
+	// cannot enable widening.
+	//
+	// Env-var equivalent: LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS
+	// (comma-separated). Env wins over yaml when both are set (same
+	// rule as storage / cache blocks).
+	PermitHostWiden HostWidenPermitConfig `yaml:"permit_host_widen"`
+}
+
+// HostWidenPermitConfig is the per-capability slice of HooksConfig
+// for the per-call host-widening capability. Kept as its own struct
+// so future widening axes (memory scopes, channel ACLs) can hang off
+// HooksConfig without flattening the namespace.
+type HostWidenPermitConfig struct {
+	// Owners is the exact-match list of registered-hook owner UIDs
+	// whose allow_hosts entries are honoured. Empty / nil = no
+	// widening permitted (default — the safe stance).
+	Owners []string `yaml:"owners"`
+}
 
 // Defaults are the fall-throughs for agents that don't specify them.
 type Defaults struct {
@@ -1071,6 +1113,17 @@ func Load(path string) (*Config, error) {
 	// Default backend is sqlite (back-compat with pre-Storage configs).
 	if cfg.Storage.Backend == "" {
 		cfg.Storage.Backend = "sqlite"
+	}
+
+	// Hooks block (v0.8.17). The env-var override APPENDS to whatever
+	// yaml already declared rather than replacing, so an operator can
+	// keep their static list in yaml and add an ops-only entry via env
+	// without rewriting the config file. Duplicates are tolerated — the
+	// registry's IsHostWidenPermitted() does set membership.
+	if v := os.Getenv("LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS"); v != "" {
+		for _, owner := range splitCSV(v) {
+			cfg.Hooks.PermitHostWiden.Owners = append(cfg.Hooks.PermitHostWiden.Owners, owner)
+		}
 	}
 
 	// gRPC server (v0.5.5+). Disabled by default; operator opts in

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"sync/atomic"
 )
 
 // Dispatcher is the front door the agent loop calls into. It looks
@@ -13,9 +14,34 @@ import (
 // after applying each hook's rewrite or short-circuit.
 //
 // One Dispatcher per server, shared across all runs.
+//
+// hostWidenPermitted / hostWidenDenied are atomic counters incremented
+// whenever a Pre-hook's allow_hosts is honoured or dropped at
+// dispatch time. Lets operators graph widening volume without
+// scraping the audit-event stream. Surfaced via Stats().
 type Dispatcher struct {
 	registry *Registry
 	client   *webhookClient
+
+	hostWidenPermitted atomic.Int64
+	hostWidenDenied    atomic.Int64
+}
+
+// DispatcherStats is a point-in-time snapshot of dispatcher counters,
+// intended for operator observability endpoints. Today only the
+// host-widen counters exist; future counters land here.
+type DispatcherStats struct {
+	HostWidenPermitted int64 // Pre-hook allow_hosts honoured (owner in permit list)
+	HostWidenDenied    int64 // Pre-hook allow_hosts dropped (owner NOT in permit list)
+}
+
+// Stats returns a snapshot of the dispatcher's counters. Cheap —
+// atomic loads only; safe to call from any goroutine.
+func (d *Dispatcher) Stats() DispatcherStats {
+	return DispatcherStats{
+		HostWidenPermitted: d.hostWidenPermitted.Load(),
+		HostWidenDenied:    d.hostWidenDenied.Load(),
+	}
 }
 
 // NewDispatcher returns a Dispatcher backed by the given registry.
@@ -44,20 +70,63 @@ type Identity struct {
 //   - Deny is non-nil when a hook short-circuited the chain. The loop
 //     MUST skip executeTool and treat Deny as the synthetic
 //     tool_result.
+//   - AllowHosts carries the UNION of per-call host grants from all
+//     permitted-owner Pre-hooks in the chain. The loop attaches this
+//     to ctx via tools.WithExtraAllowedHosts before executing the
+//     tool. Empty/nil when no hook granted anything or all granting
+//     hooks had un-permitted owners (their grants are silently
+//     dropped at the dispatcher, with a WARN log + metric increment).
+//     Also nil when the chain ended in Deny — a denied hook does NOT
+//     contribute hostnames to peers (CLAUDE.md confused-deputy
+//     guidance).
+//   - GrantingHookOwner and GrantingHookName name the LAST permitted
+//     hook in the chain that contributed to AllowHosts. Carried so
+//     the loop's audit event (host_widened) names a single
+//     attribution rather than the whole chain. When multiple
+//     permitted hooks each contributed, "last permitted to contribute"
+//     is the attribution the audit log shows; operators can correlate
+//     to the metric for the full picture.
 type PreOutcome struct {
-	Input json.RawMessage
-	Deny  *ToolResult
+	Input            json.RawMessage
+	Deny             *ToolResult
+	AllowHosts       []string
+	GrantingHookOwner string
+	GrantingHookName  string
 }
 
 // RunPre invokes the Pre chain for (agent, tool). Returns the
 // possibly-rewritten input (or a synthetic deny result if any hook
-// short-circuited).
+// short-circuited), plus any host-widening grants accumulated from
+// permitted-owner hooks in the chain.
 //
 // `originalInput` is the model's tool_use.input — passed in so the
 // dispatcher can pass the running input forward through each hook.
+//
+// AllowHosts accumulation rules:
+//   - A hook contributes to the outcome's AllowHosts only when its
+//     Owner is on the registry's host-widen permit list (operator
+//     yaml's hooks.permit_host_widen.owners). Otherwise the field is
+//     dropped with a WARN log + counter increment.
+//   - Contributions are UNION'd across all permitted hooks in the
+//     chain (de-duplicated, order-preserved by first-seen).
+//   - Deny wins: if any hook in the chain returns a non-nil Deny,
+//     RunPre returns immediately with Deny set and AllowHosts nil —
+//     no permitted hook's earlier grant carries over. A denied hook
+//     short-circuits the chain AND nukes any pending widening
+//     (confused-deputy mitigation: don't let a hook that ends in
+//     deny still influence policy via a sibling).
+//   - GrantingHook{Owner,Name} are stamped to the LAST permitted
+//     hook that contributed at least one host. Carried for the
+//     audit event so operators see a single attribution.
 func (d *Dispatcher) RunPre(ctx context.Context, ident Identity, tu ToolCall) PreOutcome {
 	hooks := d.registry.Match(ident.Agent, tu.Name, PhasePre)
 	current := tu.Input
+	var (
+		allowHosts       []string
+		allowHostsSeen   map[string]struct{} // dedup set; lazy-init
+		grantingOwner    string
+		grantingHookName string
+	)
 	for _, h := range hooks {
 		// Each hook in the chain sees the running input as it stands
 		// after upstream rewrites — that's the whole point of an
@@ -88,13 +157,81 @@ func (d *Dispatcher) RunPre(ctx context.Context, ident Identity, tu ToolCall) Pr
 		if res.Deny != nil {
 			// First non-nil deny wins. Subsequent hooks in the chain
 			// don't run — the synthetic result is what the model sees.
+			// Any AllowHosts accumulated from prior hooks is DISCARDED
+			// (we don't carry policy widenings into a denied call).
 			return PreOutcome{Deny: res.Deny}
 		}
 		if len(res.Input) > 0 {
 			current = res.Input
 		}
+		if len(res.AllowHosts) > 0 {
+			if !d.registry.IsHostWidenPermitted(h.Owner) {
+				// Operator never opted this owner in. Drop with a WARN
+				// log so operators can spot un-authorised widening
+				// attempts (e.g., a hook that started returning
+				// allow_hosts after a code update without the
+				// corresponding yaml change). Counter exposed via
+				// Stats() for graphability.
+				d.hostWidenDenied.Add(1)
+				log.Printf("hooks: pre %s/%s returned allow_hosts=%v but owner is NOT on hooks.permit_host_widen.owners; dropping grant",
+					h.Owner, h.Name, res.AllowHosts)
+				continue
+			}
+			// Permitted. Union into the accumulator (dedup on
+			// case-insensitive hostname — DNS is case-insensitive and
+			// the operator allowlist normalizes the same way).
+			if allowHostsSeen == nil {
+				allowHostsSeen = make(map[string]struct{})
+			}
+			for _, host := range res.AllowHosts {
+				key := normaliseHost(host)
+				if key == "" {
+					continue
+				}
+				if _, dup := allowHostsSeen[key]; dup {
+					continue
+				}
+				allowHostsSeen[key] = struct{}{}
+				allowHosts = append(allowHosts, key)
+			}
+			d.hostWidenPermitted.Add(1)
+			grantingOwner = h.Owner
+			grantingHookName = h.Name
+		}
 	}
-	return PreOutcome{Input: current}
+	return PreOutcome{
+		Input:             current,
+		AllowHosts:        allowHosts,
+		GrantingHookOwner: grantingOwner,
+		GrantingHookName:  grantingHookName,
+	}
+}
+
+// normaliseHost lower-cases the host entry and trims surrounding
+// whitespace. Preserves a single leading dot (suffix-match opt-in).
+// Empty / whitespace-only inputs map to "" so the caller drops them.
+func normaliseHost(h string) string {
+	// Trim spaces but NOT the leading dot — the dot is semantic.
+	for len(h) > 0 && (h[0] == ' ' || h[0] == '\t') {
+		h = h[1:]
+	}
+	for len(h) > 0 && (h[len(h)-1] == ' ' || h[len(h)-1] == '\t') {
+		h = h[:len(h)-1]
+	}
+	if h == "" || h == "." {
+		return ""
+	}
+	// ASCII lower-case (hostnames are ASCII for the alphanum range;
+	// IDNA was already resolved on the wire side before we see it).
+	out := make([]byte, len(h))
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		out[i] = c
+	}
+	return string(out)
 }
 
 // RunPost invokes the Post chain for (agent, tool). Each hook sees

--- a/internal/hooks/dispatcher.go
+++ b/internal/hooks/dispatcher.go
@@ -87,9 +87,9 @@ type Identity struct {
 //     is the attribution the audit log shows; operators can correlate
 //     to the metric for the full picture.
 type PreOutcome struct {
-	Input            json.RawMessage
-	Deny             *ToolResult
-	AllowHosts       []string
+	Input             json.RawMessage
+	Deny              *ToolResult
+	AllowHosts        []string
 	GrantingHookOwner string
 	GrantingHookName  string
 }

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -197,6 +197,224 @@ func TestDispatcher_EmptyResponseBodyIsNoOp(t *testing.T) {
 }
 
 // TestDispatcher_NoMatchIsCheap pins the empty-registry fast path:
+// TestDispatcher_PreAllowHosts_PermittedOwnerFlows: a single Pre-hook
+// whose owner is on the operator-yaml permit list returns allow_hosts;
+// the dispatcher's PreOutcome carries the grant + attribution + bumps
+// the permitted counter.
+func TestDispatcher_PreAllowHosts_PermittedOwnerFlows(t *testing.T) {
+	hook := newFakeHook(t, `{"allow_hosts":["acme.com",".trusted-cdn.com"]}`)
+	r := NewRegistryWithPermissions([]string{"jobs-search-web"})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "url-gate", Phase: PhasePre,
+		CallbackURL: hook.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if out.Deny != nil {
+		t.Fatalf("unexpected deny: %+v", out.Deny)
+	}
+	if len(out.AllowHosts) != 2 {
+		t.Fatalf("AllowHosts = %v, want 2 entries", out.AllowHosts)
+	}
+	if out.AllowHosts[0] != "acme.com" || out.AllowHosts[1] != ".trusted-cdn.com" {
+		t.Errorf("AllowHosts = %v, want [acme.com .trusted-cdn.com] (order preserved)", out.AllowHosts)
+	}
+	if out.GrantingHookOwner != "jobs-search-web" || out.GrantingHookName != "url-gate" {
+		t.Errorf("attribution = %s/%s, want jobs-search-web/url-gate",
+			out.GrantingHookOwner, out.GrantingHookName)
+	}
+	if d.Stats().HostWidenPermitted != 1 {
+		t.Errorf("Stats.HostWidenPermitted = %d, want 1", d.Stats().HostWidenPermitted)
+	}
+	if d.Stats().HostWidenDenied != 0 {
+		t.Errorf("Stats.HostWidenDenied = %d, want 0", d.Stats().HostWidenDenied)
+	}
+}
+
+// TestDispatcher_PreAllowHosts_UnpermittedOwnerDropped: a hook whose
+// owner is NOT in the permit list returns allow_hosts; the
+// dispatcher drops the grant, bumps the denied counter, but does not
+// fail the call (the tool runs with the operator-floor host policy).
+func TestDispatcher_PreAllowHosts_UnpermittedOwnerDropped(t *testing.T) {
+	hook := newFakeHook(t, `{"allow_hosts":["acme.com"]}`)
+	r := NewRegistryWithPermissions([]string{"some-other-app"}) // NOT our hook's owner
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "rogue-gate", Phase: PhasePre,
+		CallbackURL: hook.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if out.Deny != nil {
+		t.Fatalf("unexpected deny: %+v", out.Deny)
+	}
+	if len(out.AllowHosts) != 0 {
+		t.Errorf("AllowHosts = %v, want empty (owner not in permit list)", out.AllowHosts)
+	}
+	if d.Stats().HostWidenDenied != 1 {
+		t.Errorf("Stats.HostWidenDenied = %d, want 1 (un-permitted grant should bump the counter)",
+			d.Stats().HostWidenDenied)
+	}
+	if d.Stats().HostWidenPermitted != 0 {
+		t.Errorf("Stats.HostWidenPermitted = %d, want 0", d.Stats().HostWidenPermitted)
+	}
+}
+
+// TestDispatcher_PreAllowHosts_DenyDiscardsPriorGrants: a permitted
+// hook contributes allow_hosts, then a later hook denies. The
+// outcome must be a clean deny with NO leaked widening — denied
+// chains do not influence policy.
+func TestDispatcher_PreAllowHosts_DenyDiscardsPriorGrants(t *testing.T) {
+	granter := newFakeHook(t, `{"allow_hosts":["acme.com"]}`)
+	denier := newFakeHook(t, `{"deny":{"is_error":true,"text":"no"}}`)
+	r := NewRegistryWithPermissions([]string{"jobs-search-web"})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "grant", Phase: PhasePre,
+		CallbackURL: granter.srv.URL, Tools: []string{"WebFetch"},
+	})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "deny", Phase: PhasePre,
+		CallbackURL: denier.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if out.Deny == nil {
+		t.Fatal("expected deny, got pass-through")
+	}
+	if len(out.AllowHosts) != 0 {
+		t.Errorf("AllowHosts = %v, want empty (deny must discard prior widenings)", out.AllowHosts)
+	}
+}
+
+// TestDispatcher_PreAllowHosts_UnionAcrossPermittedHooks: two
+// permitted hooks each return distinct host sets; the outcome
+// contains the deduplicated UNION. Attribution names the LAST
+// contributing hook.
+func TestDispatcher_PreAllowHosts_UnionAcrossPermittedHooks(t *testing.T) {
+	hookA := newFakeHook(t, `{"allow_hosts":["acme.com","shared.example"]}`)
+	hookB := newFakeHook(t, `{"allow_hosts":["shared.example","other.example"]}`)
+	r := NewRegistryWithPermissions([]string{"jobs-search-web", "company-research"})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "A", Phase: PhasePre,
+		CallbackURL: hookA.srv.URL, Tools: []string{"WebFetch"},
+	})
+	mustRegister(t, r, &Hook{
+		Owner: "company-research", Name: "B", Phase: PhasePre,
+		CallbackURL: hookB.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if out.Deny != nil {
+		t.Fatalf("unexpected deny: %+v", out.Deny)
+	}
+	if len(out.AllowHosts) != 3 {
+		t.Fatalf("AllowHosts = %v, want 3 entries (acme.com, shared.example, other.example)",
+			out.AllowHosts)
+	}
+	// Order preserved by first-seen: acme.com (A), shared.example (A first),
+	// other.example (B).
+	want := []string{"acme.com", "shared.example", "other.example"}
+	for i, h := range want {
+		if out.AllowHosts[i] != h {
+			t.Errorf("AllowHosts[%d] = %q, want %q", i, out.AllowHosts[i], h)
+		}
+	}
+	if out.GrantingHookOwner != "company-research" || out.GrantingHookName != "B" {
+		t.Errorf("attribution = %s/%s, want company-research/B (last contributor)",
+			out.GrantingHookOwner, out.GrantingHookName)
+	}
+	if d.Stats().HostWidenPermitted != 2 {
+		t.Errorf("Stats.HostWidenPermitted = %d, want 2 (both hooks contributed)",
+			d.Stats().HostWidenPermitted)
+	}
+}
+
+// TestDispatcher_PreAllowHosts_MixedPermittedUnpermitted: a permitted
+// hook and an un-permitted hook both return allow_hosts. The outcome
+// carries ONLY the permitted hook's grant, attribution names the
+// permitted hook, and both counters bump (1 permitted, 1 denied).
+func TestDispatcher_PreAllowHosts_MixedPermittedUnpermitted(t *testing.T) {
+	permitted := newFakeHook(t, `{"allow_hosts":["acme.com"]}`)
+	rogue := newFakeHook(t, `{"allow_hosts":["evil.example"]}`)
+	r := NewRegistryWithPermissions([]string{"jobs-search-web"}) // only jobs-search-web permitted
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "good", Phase: PhasePre,
+		CallbackURL: permitted.srv.URL, Tools: []string{"WebFetch"},
+	})
+	mustRegister(t, r, &Hook{
+		Owner: "unknown-app", Name: "rogue", Phase: PhasePre,
+		CallbackURL: rogue.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if len(out.AllowHosts) != 1 || out.AllowHosts[0] != "acme.com" {
+		t.Fatalf("AllowHosts = %v, want [acme.com] only (rogue's evil.example must be dropped)",
+			out.AllowHosts)
+	}
+	if out.GrantingHookOwner != "jobs-search-web" {
+		t.Errorf("attribution owner = %q, want jobs-search-web", out.GrantingHookOwner)
+	}
+	if d.Stats().HostWidenPermitted != 1 {
+		t.Errorf("Stats.HostWidenPermitted = %d, want 1", d.Stats().HostWidenPermitted)
+	}
+	if d.Stats().HostWidenDenied != 1 {
+		t.Errorf("Stats.HostWidenDenied = %d, want 1", d.Stats().HostWidenDenied)
+	}
+}
+
+// TestDispatcher_PreAllowHosts_NormalisesCase confirms hostnames are
+// lower-cased and trimmed on entry — so a hook returning "ACME.COM "
+// dedupes against a peer returning "acme.com".
+func TestDispatcher_PreAllowHosts_NormalisesCase(t *testing.T) {
+	hookA := newFakeHook(t, `{"allow_hosts":["ACME.COM ","  empty  ",""]}`)
+	hookB := newFakeHook(t, `{"allow_hosts":["acme.com"]}`)
+	r := NewRegistryWithPermissions([]string{"jobs-search-web"})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "A", Phase: PhasePre,
+		CallbackURL: hookA.srv.URL, Tools: []string{"WebFetch"},
+	})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "B", Phase: PhasePre,
+		CallbackURL: hookB.srv.URL, Tools: []string{"WebFetch"},
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if len(out.AllowHosts) != 2 {
+		t.Fatalf("AllowHosts = %v, want 2 (acme.com + empty after norm + dup-of-acme-dropped)",
+			out.AllowHosts)
+	}
+	if out.AllowHosts[0] != "acme.com" {
+		t.Errorf("AllowHosts[0] = %q, want %q (lower-cased + trimmed)", out.AllowHosts[0], "acme.com")
+	}
+	if out.AllowHosts[1] != "empty" {
+		t.Errorf("AllowHosts[1] = %q, want %q (whitespace-only entry surfaced)",
+			out.AllowHosts[1], "empty")
+	}
+}
+
 // when no hooks match the (agent, tool) the dispatcher does no
 // network calls and returns the original input unchanged.
 func TestDispatcher_NoMatchIsCheap(t *testing.T) {

--- a/internal/hooks/dispatcher_test.go
+++ b/internal/hooks/dispatcher_test.go
@@ -267,6 +267,48 @@ func TestDispatcher_PreAllowHosts_UnpermittedOwnerDropped(t *testing.T) {
 	}
 }
 
+// TestDispatcher_PreAllowHosts_FailClosedTimeoutDiscardsPriorGrants
+// pins the symmetric case to DenyDiscardsPriorGrants: a permitted
+// hook contributes allow_hosts, then a FailClosed hook TIMES OUT and
+// the fail-mode synthesises a deny. The outcome must be a clean deny
+// with NO leaked widening — the same security property as explicit
+// deny, but driven via the error-induced fail-closed path. Without
+// this test, a future refactor that "preserves AllowHosts across
+// FailClosed denials for observability" would silently widen policy
+// for a tool call that was supposed to be aborted.
+func TestDispatcher_PreAllowHosts_FailClosedTimeoutDiscardsPriorGrants(t *testing.T) {
+	granter := newFakeHook(t, `{"allow_hosts":["acme.com"]}`)
+	slowFailClosed := newFakeHook(t, ``)
+	slowFailClosed.delay = 200 * time.Millisecond
+
+	r := NewRegistryWithPermissions([]string{"jobs-search-web"})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "grant", Phase: PhasePre,
+		CallbackURL: granter.srv.URL, Tools: []string{"WebFetch"},
+	})
+	mustRegister(t, r, &Hook{
+		Owner: "jobs-search-web", Name: "slow", Phase: PhasePre,
+		CallbackURL: slowFailClosed.srv.URL, Tools: []string{"WebFetch"},
+		FailMode: FailClosed, TimeoutMs: 50,
+	})
+	d := NewDispatcher(r, nil)
+
+	out := d.RunPre(context.Background(),
+		Identity{Agent: "a"},
+		ToolCall{ID: "t1", Name: "WebFetch", Input: json.RawMessage(`{}`)},
+	)
+	if out.Deny == nil {
+		t.Fatal("expected deny (FailClosed hook timed out), got pass-through")
+	}
+	if !out.Deny.IsError {
+		t.Errorf("deny.IsError = false, want true")
+	}
+	if len(out.AllowHosts) != 0 {
+		t.Errorf("AllowHosts = %v, want empty (FailClosed-induced deny must discard prior grants — same property as explicit deny)",
+			out.AllowHosts)
+	}
+}
+
 // TestDispatcher_PreAllowHosts_DenyDiscardsPriorGrants: a permitted
 // hook contributes allow_hosts, then a later hook denies. The
 // outcome must be a clean deny with NO leaked widening — denied

--- a/internal/hooks/registry.go
+++ b/internal/hooks/registry.go
@@ -25,11 +25,19 @@ var ErrNotFound = errors.New("hook not found")
 // Concurrency: Register / Delete take the write lock; Match takes
 // the read lock. Match is on the hot path (every tool call) so the
 // implementation favours read-heavy access patterns.
+//
+// hostWidenPermitted is an operator-yaml-derived set (loaded once at
+// New time, never mutated post-construction). The dispatcher consults
+// it via IsHostWidenPermitted() to decide whether a Pre-hook's
+// allow_hosts is honoured. Read access is lock-free — the set is
+// frozen.
 type Registry struct {
 	mu    sync.RWMutex
 	byID  map[string]*Hook    // id → hook, for DELETE / GET by id
 	byKey map[ownerName]*Hook // (owner, name) → hook, for replace-on-conflict
 	order []string            // ids in registration order; chain order in Match()
+
+	hostWidenPermitted map[string]struct{} // owner UID set; frozen post-construction
 }
 
 type ownerName struct {
@@ -37,12 +45,50 @@ type ownerName struct {
 	Name  string
 }
 
-// NewRegistry constructs an empty Registry.
+// NewRegistry constructs an empty Registry with the default policy
+// (no host-widen permissions). Use NewRegistryWithPermissions to wire
+// the operator-yaml permit list at server New time.
 func NewRegistry() *Registry {
-	return &Registry{
-		byID:  make(map[string]*Hook),
-		byKey: make(map[ownerName]*Hook),
+	return NewRegistryWithPermissions(nil)
+}
+
+// NewRegistryWithPermissions constructs a Registry with the operator's
+// host-widen permit list baked in. permitHostWidenOwners is the
+// exact-match set of registered-hook owner UIDs whose Pre-hook
+// allow_hosts is honoured at dispatch time. nil / empty = no widening
+// permitted for anyone (default-deny stance).
+//
+// The set is built once at construction and never mutated — so the
+// trust boundary is "what the operator declared at boot", not "what
+// some runtime API ended up writing." That property is load-bearing
+// for CLAUDE.md rule #8.
+func NewRegistryWithPermissions(permitHostWidenOwners []string) *Registry {
+	permit := make(map[string]struct{}, len(permitHostWidenOwners))
+	for _, owner := range permitHostWidenOwners {
+		owner = strings.TrimSpace(owner)
+		if owner == "" {
+			continue
+		}
+		permit[owner] = struct{}{}
 	}
+	return &Registry{
+		byID:               make(map[string]*Hook),
+		byKey:              make(map[ownerName]*Hook),
+		hostWidenPermitted: permit,
+	}
+}
+
+// IsHostWidenPermitted reports whether the given hook Owner is on the
+// operator-yaml permit list (exact-string match, no globs). Used by
+// the dispatcher to decide whether to honour a Pre-hook's allow_hosts
+// field. False for any owner not explicitly listed at server boot —
+// including the empty string.
+func (r *Registry) IsHostWidenPermitted(owner string) bool {
+	if r == nil || r.hostWidenPermitted == nil {
+		return false
+	}
+	_, ok := r.hostWidenPermitted[owner]
+	return ok
 }
 
 // Register adds a hook. If a hook with the same (Owner, Name) is

--- a/internal/hooks/registry_test.go
+++ b/internal/hooks/registry_test.go
@@ -232,14 +232,14 @@ func TestRegistry_HostWidenPermit_ExactMatch(t *testing.T) {
 		owner string
 		want  bool
 	}{
-		{"jobs-search-web", true},                  // exact match
-		{"company-research", true},                 // trimmed match
-		{"jobs-search-web-staging", false},         // prefix is NOT a match (no globs)
-		{"jobs-search", false},                     // partial prefix not a match
-		{"web", false},                             // suffix not a match
-		{"", false},                                // empty owner never matches
-		{"unknown", false},                         // not in list
-		{"  jobs-search-web  ", false},             // lookup doesn't trim — operator names canonicalise on registration
+		{"jobs-search-web", true},          // exact match
+		{"company-research", true},         // trimmed match
+		{"jobs-search-web-staging", false}, // prefix is NOT a match (no globs)
+		{"jobs-search", false},             // partial prefix not a match
+		{"web", false},                     // suffix not a match
+		{"", false},                        // empty owner never matches
+		{"unknown", false},                 // not in list
+		{"  jobs-search-web  ", false},     // lookup doesn't trim — operator names canonicalise on registration
 	}
 	for _, tc := range cases {
 		t.Run(tc.owner, func(t *testing.T) {

--- a/internal/hooks/registry_test.go
+++ b/internal/hooks/registry_test.go
@@ -214,3 +214,66 @@ func hookNames(hs []*Hook) []string {
 	}
 	return out
 }
+
+// TestRegistry_HostWidenPermit_ExactMatch pins the trust-boundary
+// contract: only exact-match owner UIDs in the operator yaml are
+// permitted to widen the host allowlist via Pre-hook allow_hosts.
+// Globs / prefix-matches must NOT match — the operator names each
+// app explicitly. Whitespace is trimmed so a yaml entry with
+// surrounding spaces still matches.
+func TestRegistry_HostWidenPermit_ExactMatch(t *testing.T) {
+	r := NewRegistryWithPermissions([]string{
+		"jobs-search-web",
+		"  company-research  ", // surrounding whitespace tolerated
+		"",                     // empty entry silently dropped
+	})
+
+	cases := []struct {
+		owner string
+		want  bool
+	}{
+		{"jobs-search-web", true},                  // exact match
+		{"company-research", true},                 // trimmed match
+		{"jobs-search-web-staging", false},         // prefix is NOT a match (no globs)
+		{"jobs-search", false},                     // partial prefix not a match
+		{"web", false},                             // suffix not a match
+		{"", false},                                // empty owner never matches
+		{"unknown", false},                         // not in list
+		{"  jobs-search-web  ", false},             // lookup doesn't trim — operator names canonicalise on registration
+	}
+	for _, tc := range cases {
+		t.Run(tc.owner, func(t *testing.T) {
+			got := r.IsHostWidenPermitted(tc.owner)
+			if got != tc.want {
+				t.Errorf("IsHostWidenPermitted(%q) = %v, want %v", tc.owner, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRegistry_HostWidenPermit_DefaultDeny verifies the default
+// stance: a registry constructed without a permit list (NewRegistry)
+// returns false for every owner — preserving the "operator yaml is
+// the trust-boundary floor" invariant for back-compat installs that
+// don't opt in.
+func TestRegistry_HostWidenPermit_DefaultDeny(t *testing.T) {
+	r := NewRegistry()
+	if r.IsHostWidenPermitted("any-owner") {
+		t.Error("NewRegistry() should default-deny host widening for every owner")
+	}
+	if r.IsHostWidenPermitted("") {
+		t.Error("NewRegistry() must default-deny the empty-string owner")
+	}
+}
+
+// TestRegistry_HostWidenPermit_NilReceiver pins defensive behavior:
+// a nil *Registry must return false rather than panic. The dispatcher
+// is wired with a non-nil registry by Server.New, but defensive
+// programming on a hot-path check costs nothing and removes a
+// latent crash class.
+func TestRegistry_HostWidenPermit_NilReceiver(t *testing.T) {
+	var r *Registry
+	if r.IsHostWidenPermitted("anyone") {
+		t.Error("nil receiver should return false")
+	}
+}

--- a/internal/hooks/types.go
+++ b/internal/hooks/types.go
@@ -103,18 +103,43 @@ type PreHookCall struct {
 	ToolCall ToolCall `json:"tool_call"`
 }
 
-// PreHookResult is the response a Pre webhook returns. Either field can
-// be set independently:
+// PreHookResult is the response a Pre webhook returns. Fields can be set
+// independently:
 //   - Input non-nil: the tool runs with this input instead of the model's.
 //   - Deny non-nil: the tool does NOT run. The Deny payload becomes the
 //     synthetic tool_result the model sees.
+//   - AllowHosts non-empty: hostnames the hook approves for THIS tool
+//     call (per-call scope, no server-side cache, not inherited by
+//     sub-agents). Only takes effect when the hook's owner is listed
+//     in the operator yaml's hooks.permit_host_widen.owners (or the
+//     LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS env). Un-permitted
+//     entries are dropped at the dispatcher with a WARN log + metric.
+//     Matching semantics for each entry: a literal hostname (no
+//     leading dot) is EXACT-match only ("acme.com" does not match
+//     "careers.acme.com"); a leading-dot entry (".acme.com") is
+//     suffix-match like the operator allowlist (matches "acme.com"
+//     AND any subdomain). This is intentionally stricter than the
+//     operator-list default so cautious hook authors can be surgical.
 //
-// If both are set, Deny wins (short-circuit takes precedence). If neither
-// is set (or response body is empty / 204), the call passes through
-// unchanged.
+// Precedence: if Deny is set, AllowHosts is DROPPED (deny wins; we do
+// not let a denied hook contribute hostnames to peers in the chain).
+// If both Input and AllowHosts are set, both apply — the rewritten
+// input executes against the widened policy.
+//
+// SECURITY — confused-deputy hazard: AllowHosts MUST NOT be derived
+// blindly from PreHookCall.ToolCall.Input. The URL the model wants to
+// fetch is untrusted. Hook authors must validate independently — e.g.,
+// against the user's own preferences, a per-tenant allowlist, or a
+// domain-reputation service. The audit event (host_widened) and the
+// hooks_host_widen_total metric exist so operators can detect
+// confused-deputy patterns post-hoc.
+//
+// If no field is set (or response body is empty / 204), the call
+// passes through unchanged.
 type PreHookResult struct {
-	Input json.RawMessage `json:"input,omitempty"`
-	Deny  *ToolResult     `json:"deny,omitempty"`
+	Input      json.RawMessage `json:"input,omitempty"`
+	Deny       *ToolResult     `json:"deny,omitempty"`
+	AllowHosts []string        `json:"allow_hosts,omitempty"`
 }
 
 // PostHookCall is the JSON payload sent to a Post webhook.

--- a/internal/hooks/types_test.go
+++ b/internal/hooks/types_test.go
@@ -1,0 +1,113 @@
+package hooks
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestPreHookResult_AllowHosts_RoundTrips pins the wire shape for the
+// per-call host-widening capability. The field is `allow_hosts` on the
+// JSON side and `omitempty` so existing hooks (which never set it) emit
+// byte-identical payloads.
+func TestPreHookResult_AllowHosts_RoundTrips(t *testing.T) {
+	cases := []struct {
+		name string
+		in   PreHookResult
+		want string
+	}{
+		{
+			name: "EmptyResultEmitsEmptyObject",
+			in:   PreHookResult{},
+			want: `{}`,
+		},
+		{
+			name: "AllowHostsAlone",
+			in:   PreHookResult{AllowHosts: []string{"acme.com", ".trusted-cdn.com"}},
+			want: `{"allow_hosts":["acme.com",".trusted-cdn.com"]}`,
+		},
+		{
+			name: "AllowHostsWithInputRewrite",
+			in: PreHookResult{
+				Input:      json.RawMessage(`{"url":"https://acme.com/canonical"}`),
+				AllowHosts: []string{"acme.com"},
+			},
+			want: `{"input":{"url":"https://acme.com/canonical"},"allow_hosts":["acme.com"]}`,
+		},
+		{
+			name: "AllowHostsWithDeny",
+			in: PreHookResult{
+				Deny:       &ToolResult{IsError: true, Text: "no"},
+				AllowHosts: []string{"acme.com"},
+			},
+			// Deny + AllowHosts is a valid wire shape; the dispatcher
+			// rules (deny wins, allow_hosts dropped) live above this
+			// layer. The wire contract just preserves what's sent.
+			want: `{"deny":{"text":"no","is_error":true},"allow_hosts":["acme.com"]}`,
+		},
+		{
+			name: "NilSliceOmitted",
+			// Distinct from "empty slice": nil is the "not set" sentinel,
+			// proven by the absence of the field in the marshalled output.
+			in:   PreHookResult{AllowHosts: nil},
+			want: `{}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.in)
+			if err != nil {
+				t.Fatalf("Marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("Marshal = %s\nwant %s", got, tc.want)
+			}
+			// Round-trip back to confirm Unmarshal accepts what Marshal
+			// produced (catches a typo in the json tag).
+			var rt PreHookResult
+			if err := json.Unmarshal(got, &rt); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if len(rt.AllowHosts) != len(tc.in.AllowHosts) {
+				t.Errorf("round-trip AllowHosts len = %d, want %d (%v vs %v)",
+					len(rt.AllowHosts), len(tc.in.AllowHosts), rt.AllowHosts, tc.in.AllowHosts)
+			}
+		})
+	}
+}
+
+// TestPreHookResult_AllowHosts_AcceptsEmptyArray confirms an explicit
+// empty array deserialises to an empty (non-nil) slice. This matters
+// because a hook author who writes `{"allow_hosts": []}` to express
+// "no widening this call" should be byte-equivalent to omitting the
+// field — the dispatcher treats both as no-op.
+func TestPreHookResult_AllowHosts_AcceptsEmptyArray(t *testing.T) {
+	var r PreHookResult
+	if err := json.Unmarshal([]byte(`{"allow_hosts":[]}`), &r); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if r.AllowHosts == nil {
+		t.Errorf("AllowHosts is nil; want empty non-nil slice (Go's json package decodes [] to []string{})")
+	}
+	if len(r.AllowHosts) != 0 {
+		t.Errorf("len(AllowHosts) = %d, want 0", len(r.AllowHosts))
+	}
+}
+
+// TestPreHookResult_AllowHosts_DocCommentMentionsConfusedDeputy is a
+// gentle reminder via test: the security warning on the field must
+// stay attached. If a future PR strips the doc-comment, this test still
+// passes (no code-level enforcement), but the test name signals intent
+// in a code-review diff.
+func TestPreHookResult_AllowHosts_DocCommentMentionsConfusedDeputy(t *testing.T) {
+	// Sanity: the field exists and is the right shape.
+	r := PreHookResult{AllowHosts: []string{"x"}}
+	if len(r.AllowHosts) != 1 || r.AllowHosts[0] != "x" {
+		t.Fatal("AllowHosts shape regression")
+	}
+	// The doc-comment is on the struct; we can't introspect comments at
+	// runtime. This test exists for grep-ability — a reviewer searching
+	// for confused-deputy guidance lands here and follows the trail to
+	// types.go.
+	_ = strings.Contains // keep `strings` import meaningful
+}

--- a/internal/loop/hooks_test.go
+++ b/internal/loop/hooks_test.go
@@ -209,3 +209,197 @@ func TestLoop_HooksPreDeny(t *testing.T) {
 		t.Errorf("model saw tool_result = %q, want deny synthetic text", seen)
 	}
 }
+
+// hostCheckingTool simulates the HTTP tool's host-allowed gate at the
+// loop-integration layer: it consults ctx for ExtraAllowedHosts and
+// fails when the URL's host is not in the union of operator-floor +
+// ctx-extras. Lets us prove end-to-end that a permitted Pre-hook's
+// allow_hosts flows through dispatchOneTool into the tool's ctx.
+type hostCheckingTool struct {
+	floor      []string // operator-static allowlist
+	lastInput  string
+	lastExtras []string
+}
+
+func (t *hostCheckingTool) Name() string                 { return "WebFetch" }
+func (t *hostCheckingTool) Description() string          { return "" }
+func (t *hostCheckingTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (t *hostCheckingTool) Execute(ctx context.Context, input json.RawMessage) (tools.Result, error) {
+	t.lastInput = string(input)
+	t.lastExtras = tools.ExtraAllowedHosts(ctx)
+	var args struct {
+		URL string `json:"url"`
+	}
+	_ = json.Unmarshal(input, &args)
+	// Tiny host-matcher: exact match against floor OR against extras.
+	host := args.URL
+	// Strip scheme prefix for the test's sake.
+	for _, prefix := range []string{"https://", "http://"} {
+		if strings.HasPrefix(host, prefix) {
+			host = host[len(prefix):]
+			break
+		}
+	}
+	for i := 0; i < len(host); i++ {
+		if host[i] == '/' {
+			host = host[:i]
+			break
+		}
+	}
+	for _, h := range t.floor {
+		if h == host {
+			return tools.Result{Text: "ok: " + host}, nil
+		}
+	}
+	for _, h := range t.lastExtras {
+		if h == host {
+			return tools.Result{Text: "ok via extras: " + host}, nil
+		}
+	}
+	return tools.Result{IsError: true, Text: "host not in allowlist: " + host}, nil
+}
+
+// TestLoop_HostWiden_PermittedHookApprovesUnknownHost is the end-to-end
+// integration for v0.8.17: a Pre-hook whose owner is on the operator's
+// host-widen permit list returns allow_hosts; the loop attaches them
+// to ctx; the tool sees the widening and succeeds; an
+// EventHostWidened event fires with the right payload.
+func TestLoop_HostWiden_PermittedHookApprovesUnknownHost(t *testing.T) {
+	// Webhook returns the unknown host as an allow_hosts grant.
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out := hooks.PreHookResult{AllowHosts: []string{"unknown.example"}}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer hookSrv.Close()
+
+	// Registry built with the hook's owner in the permit list.
+	reg := hooks.NewRegistryWithPermissions([]string{"jobs-search-web"})
+	if _, err := reg.Register(&hooks.Hook{
+		Owner: "jobs-search-web", Name: "url-gate", Phase: hooks.PhasePre,
+		CallbackURL: hookSrv.URL, Tools: []string{"WebFetch"},
+	}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	dispatcher := hooks.NewDispatcher(reg, nil)
+
+	prov := &scriptedProvider{toolCalls: []providers.ToolUse{
+		{ID: "call_1", Name: "WebFetch", Input: json.RawMessage(`{"url":"https://unknown.example/"}`)},
+	}}
+	tool := &hostCheckingTool{floor: []string{"only-allowed.example"}} // unknown.example NOT in floor
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	// Capture emitted events to assert on EventHostWidened.
+	var emitted []providers.Event
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 4,
+		AgentName:       "job-searcher",
+		Hooks:           dispatcher,
+		OnEvent:         func(ev providers.Event) { emitted = append(emitted, ev) },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Tool succeeded via the extras path.
+	if !strings.Contains(tool.lastInput, "unknown.example") {
+		t.Errorf("tool didn't see expected URL; got %q", tool.lastInput)
+	}
+	if len(tool.lastExtras) != 1 || tool.lastExtras[0] != "unknown.example" {
+		t.Errorf("tool ctx extras = %v, want [unknown.example]", tool.lastExtras)
+	}
+
+	// Find the EventHostWidened event in the emitted stream.
+	var wideningEvent *providers.Event
+	for i := range emitted {
+		if emitted[i].Type == providers.EventHostWidened {
+			wideningEvent = &emitted[i]
+			break
+		}
+	}
+	if wideningEvent == nil {
+		var seenTypes []providers.EventType
+		for _, e := range emitted {
+			seenTypes = append(seenTypes, e.Type)
+		}
+		t.Fatalf("EventHostWidened not emitted; saw events: %v", seenTypes)
+	}
+	if wideningEvent.HostWidening == nil {
+		t.Fatal("EventHostWidened payload (HostWidening) is nil")
+	}
+	w := wideningEvent.HostWidening
+	if w.ToolCallID != "call_1" {
+		t.Errorf("HostWidening.ToolCallID = %q, want call_1", w.ToolCallID)
+	}
+	if w.ToolName != "WebFetch" {
+		t.Errorf("HostWidening.ToolName = %q, want WebFetch", w.ToolName)
+	}
+	if w.URL != "https://unknown.example/" {
+		t.Errorf("HostWidening.URL = %q, want https://unknown.example/", w.URL)
+	}
+	if w.HookOwner != "jobs-search-web" || w.HookName != "url-gate" {
+		t.Errorf("HostWidening attribution = %s/%s, want jobs-search-web/url-gate",
+			w.HookOwner, w.HookName)
+	}
+	if len(w.HostsAdded) != 1 || w.HostsAdded[0] != "unknown.example" {
+		t.Errorf("HostWidening.HostsAdded = %v, want [unknown.example]", w.HostsAdded)
+	}
+}
+
+// TestLoop_HostWiden_UnpermittedHookHasNoEffect is the negative case:
+// same setup but the hook's owner is NOT on the permit list. The
+// dispatcher drops the grant; the tool ctx is empty; the tool fails
+// because the URL isn't in the operator floor; NO EventHostWidened
+// fires.
+func TestLoop_HostWiden_UnpermittedHookHasNoEffect(t *testing.T) {
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		out := hooks.PreHookResult{AllowHosts: []string{"unknown.example"}}
+		_ = json.NewEncoder(w).Encode(out)
+	}))
+	defer hookSrv.Close()
+
+	// Registry permits a DIFFERENT owner; our hook's owner is NOT.
+	reg := hooks.NewRegistryWithPermissions([]string{"some-other-owner"})
+	_, _ = reg.Register(&hooks.Hook{
+		Owner: "jobs-search-web", Name: "url-gate", Phase: hooks.PhasePre,
+		CallbackURL: hookSrv.URL, Tools: []string{"WebFetch"},
+	})
+
+	prov := &scriptedProvider{toolCalls: []providers.ToolUse{
+		{ID: "call_1", Name: "WebFetch", Input: json.RawMessage(`{"url":"https://unknown.example/"}`)},
+	}}
+	tool := &hostCheckingTool{floor: []string{"only-allowed.example"}}
+	disp := tools.NewDispatcher([]tools.Tool{tool})
+
+	var emitted []providers.Event
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Tools:           []tools.Tool{tool},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 4,
+		AgentName:       "job-searcher",
+		Hooks:           hooks.NewDispatcher(reg, nil),
+		OnEvent:         func(ev providers.Event) { emitted = append(emitted, ev) },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Tool was called but with no extras — the dispatcher dropped the grant.
+	if len(tool.lastExtras) != 0 {
+		t.Errorf("tool ctx extras = %v, want empty (un-permitted owner)", tool.lastExtras)
+	}
+
+	// No EventHostWidened should have fired.
+	for _, e := range emitted {
+		if e.Type == providers.EventHostWidened {
+			t.Errorf("EventHostWidened fired for un-permitted owner: %+v", e.HostWidening)
+		}
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -761,7 +761,15 @@ func dispatchOneTool(
 		if pre.Input != nil {
 			running.Input = pre.Input
 		}
-		r = executeTool(ctx, dispatcher, running)
+		// Attach any per-call host-widening grants from permitted
+		// Pre-hooks (v0.8.17). WithExtraAllowedHosts is a no-op when
+		// pre.AllowHosts is empty, so this is cost-free for the common
+		// path. The widened ctx is per-tool-call — sub-agents and the
+		// loop's next iteration see the original ctx without the
+		// extras (CLAUDE.md confused-deputy guidance: grant scope is
+		// one Execute call, no implicit propagation).
+		execCtx := tools.WithExtraAllowedHosts(ctx, pre.AllowHosts)
+		r = executeTool(execCtx, dispatcher, running)
 	}
 
 	post := hookDispatcher.RunPost(ctx, ident, hookTC, hooks.ToolResult{Text: r.Text, IsError: r.IsError})

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -735,12 +735,20 @@ func executeTool(ctx context.Context, d *tools.Dispatcher, tu providers.ToolUse)
 // O(N) over registered hooks; with no hooks registered this is a
 // nil-slice return and the function shape is identical to pre-hook
 // behaviour.
+//
+// emit is the same callback used by the loop for SSE/store emissions.
+// It's invoked here for the v0.8.17 EventHostWidened audit event,
+// fired ONCE per dispatched call that a permitted Pre-hook widened.
+// emit may be nil (some tests inject a dispatcher without one) —
+// host_widened emission is silently skipped in that case; the
+// widening itself still applies.
 func dispatchOneTool(
 	ctx context.Context,
 	dispatcher *tools.Dispatcher,
 	tu providers.ToolUse,
 	hookDispatcher *hooks.Dispatcher,
 	ident hooks.Identity,
+	emit func(providers.Event),
 ) tools.Result {
 	if hookDispatcher == nil {
 		return executeTool(ctx, dispatcher, tu)
@@ -761,6 +769,23 @@ func dispatchOneTool(
 		if pre.Input != nil {
 			running.Input = pre.Input
 		}
+		// Emit the v0.8.17 host-widened audit event BEFORE executing
+		// the tool, so the SSE stream ordering reads
+		// tool_call → host_widened → tool_result. Persisted via
+		// makeRecordingEmit so the events table carries an audit row.
+		if emit != nil && len(pre.AllowHosts) > 0 {
+			emit(providers.Event{
+				Type: providers.EventHostWidened,
+				HostWidening: &providers.HostWideningEventInfo{
+					ToolCallID: tu.ID,
+					ToolName:   tu.Name,
+					URL:        extractToolURL(running.Input),
+					HookOwner:  pre.GrantingHookOwner,
+					HookName:   pre.GrantingHookName,
+					HostsAdded: pre.AllowHosts,
+				},
+			})
+		}
 		// Attach any per-call host-widening grants from permitted
 		// Pre-hooks (v0.8.17). WithExtraAllowedHosts is a no-op when
 		// pre.AllowHosts is empty, so this is cost-free for the common
@@ -774,6 +799,24 @@ func dispatchOneTool(
 
 	post := hookDispatcher.RunPost(ctx, ident, hookTC, hooks.ToolResult{Text: r.Text, IsError: r.IsError})
 	return tools.Result{Text: post.Text, IsError: post.IsError}
+}
+
+// extractToolURL best-effort pulls a URL string out of common tool
+// input shapes (HTTP, WebFetch). Returns "" when no URL field is
+// present — the audit event still emits, with an empty URL field,
+// rather than failing the dispatch. JSON-parse failures are silent
+// for the same reason.
+func extractToolURL(input json.RawMessage) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var probe struct {
+		URL string `json:"url"`
+	}
+	if err := json.Unmarshal(input, &probe); err != nil {
+		return ""
+	}
+	return probe.URL
 }
 
 // executePendingTools runs the assistant turn's tool_calls concurrently,
@@ -835,7 +878,7 @@ func executePendingTools(
 				}}
 				return
 			}
-			r := dispatchOneTool(ctx, dispatcher, tu, hookDispatcher, hookIdent)
+			r := dispatchOneTool(ctx, dispatcher, tu, hookDispatcher, hookIdent, emit)
 			resCh <- result{idx: i, tu: tu, res: r}
 		}(i, tu)
 	}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -831,10 +831,16 @@ func extractToolURL(input json.RawMessage) string {
 // (the existing dispatcher contract); they do NOT abort the batch — the
 // other tools still run, and the model gets to see every result.
 //
-// All emit() calls happen from THIS goroutine (the caller's), reading
-// from a results channel. That preserves the existing single-writer
-// contract for emit and avoids forcing every emit implementation to be
-// thread-safe.
+// emit() concurrency: most emits (EventToolResult below) happen from
+// THIS goroutine, reading from a results channel — single-writer.
+// EXCEPTIONS (v0.8.4 EventChannel* from Channel tool's Execute;
+// v0.8.17 EventHostWidened from dispatchOneTool when a permitted
+// Pre-hook widens) are emitted from worker goroutines inside
+// dispatchOneTool. The production emit (api/http/server.go's
+// makeRecordingEmit) is mutex-protected to handle this; test-side
+// emit collectors used with ToolParallelism > 1 MUST take the same
+// precaution (a plain `func(ev) { events = append(events, ev) }`
+// would data-race on the slice).
 func executePendingTools(
 	ctx context.Context,
 	dispatcher *tools.Dispatcher,

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -313,6 +313,25 @@ const (
 	// moment. The external `_system/interrupts/resolved` channel
 	// publishes the resolve notification for non-run consumers.
 	EventInterruptionPending EventType = "interruption_pending"
+
+	// EventHostWidened is the v0.8.17 audit event emitted by the loop
+	// whenever a permitted Pre-hook's allow_hosts grant fires for a
+	// specific tool call. Emitted ONCE per dispatched tool call that
+	// the hook actually widened (not on every call — the common
+	// "no widening" path is silent).
+	//
+	// The HostWidening field carries the structured payload: the
+	// requesting tool_call_id + tool_name, the originating URL (so
+	// operators can spot confused-deputy patterns where the model's
+	// requested host equals the hook's grant), the granting
+	// hook's owner + name, and the list of hosts added.
+	//
+	// The event is purely informational — it does NOT itself widen
+	// anything; the widening already happened in the dispatcher and
+	// the ctx-extras path. Persistence is via the standard
+	// makeRecordingEmit path so the events table carries an audit
+	// row for every grant.
+	EventHostWidened EventType = "host_widened"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -350,6 +369,14 @@ type Event struct {
 	// types. Renders directly into the Web UI's modal/sidebar
 	// without a follow-up fetch.
 	Interruption *InterruptionEventInfo `json:"interruption,omitempty"`
+
+	// HostWidening carries the structured payload on EventHostWidened
+	// (v0.8.17). Nil on all other event types. Operators audit
+	// confused-deputy patterns by comparing HostWidening.URL's host
+	// to the granted HostsAdded — if they're always identical, the
+	// hook is probably echoing model input without independent
+	// validation.
+	HostWidening *HostWideningEventInfo `json:"host_widening,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -495,6 +522,43 @@ type InterruptionEventInfo struct {
 	// interruption will time out. RFC3339. Empty when no timeout
 	// was set.
 	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// HostWideningEventInfo is the structured payload on EventHostWidened
+// (v0.8.17). Emitted once per dispatched tool call that a permitted
+// Pre-hook widened. Operators correlate (ToolCallID, URL, HostsAdded)
+// to detect confused-deputy patterns where the hook is just echoing
+// the model's requested host without independent validation — those
+// cases show URL.Host == HostsAdded[0] for every event from one owner.
+type HostWideningEventInfo struct {
+	// ToolCallID is the loop-issued or provider-issued tool_use id
+	// (the same id that appears on the surrounding EventToolCall /
+	// EventToolResult). Lets a UI thread the audit row to its tool
+	// call.
+	ToolCallID string `json:"tool_call_id"`
+	// ToolName is "HTTP" / "WebFetch" / etc — whichever tool this
+	// widening applies to. Carried explicitly so an operator can
+	// filter audit logs by tool without joining to events of other
+	// types.
+	ToolName string `json:"tool_name"`
+	// URL is the originating URL the model asked the tool to fetch.
+	// Recorded verbatim (not normalised) so operators can spot
+	// patterns where a hook echoes a model-supplied URL's host.
+	// CAREFUL: the URL itself may carry tokens or sensitive query
+	// params; operators should redact in downstream log forwarders.
+	URL string `json:"url"`
+	// HookOwner is the registered hook's Owner UID — the app that
+	// the operator yaml opted in to via hooks.permit_host_widen.owners.
+	HookOwner string `json:"hook_owner"`
+	// HookName is the hook's Name (the Owner+Name identity). Same
+	// hook can register multiple Names; this discriminates the
+	// specific one that contributed.
+	HookName string `json:"hook_name"`
+	// HostsAdded is the deduplicated list of hostnames the
+	// dispatcher accumulated for THIS tool call. Matches the
+	// PreOutcome.AllowHosts value. Leading-dot entries appear here
+	// verbatim (they're semantic — suffix-match opt-in).
+	HostsAdded []string `json:"hosts_added"`
 }
 
 // ToolUse is the model's request to invoke a tool.

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -117,7 +117,14 @@ func (h *HTTP) do(ctx context.Context, method, rawURL string, headers map[string
 	if parsed.Scheme != "http" && parsed.Scheme != "https" {
 		return tools.Result{Text: "url scheme must be http or https", IsError: true}, nil
 	}
-	if !hostAllowed(parsed.Hostname(), h.HostAllowlist) {
+	if !hostAllowed(parsed.Hostname(), h.HostAllowlist) &&
+		!hostAllowedExtras(parsed.Hostname(), tools.ExtraAllowedHosts(ctx)) {
+		// Operator floor + caller-narrowed list rejected, and no
+		// permitted Pre-hook contributed a per-call grant covering
+		// this hostname either. (Trust-boundary reminder: the
+		// extras list comes ONLY from operator-opted-in hooks via
+		// the dispatcher; the model and the runtime caller cannot
+		// inject into it.)
 		return tools.Result{Text: fmt.Sprintf("host %q not in allowlist", parsed.Hostname()), IsError: true}, nil
 	}
 
@@ -157,11 +164,19 @@ func (h *HTTP) do(ctx context.Context, method, rawURL string, headers map[string
 		// this, an allowlisted host could 302 to an internal URL and
 		// the second TCP connect would happen to a non-allowlisted
 		// destination — only blocked by the IP-level guard.
+		//
+		// Per-call host-widening (v0.8.17) ALSO applies here: the
+		// extras list attached to ctx pre-dispatch covers the entire
+		// tool call including any redirects within it. KNOWN
+		// LIMITATION: the hook is not re-invoked mid-redirect, so a
+		// redirect to a brand-new hostname not approved up front
+		// will fail. Document loudly in TOOLS.md.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return errors.New("too many redirects")
 			}
-			if !hostAllowed(req.URL.Hostname(), h.HostAllowlist) {
+			if !hostAllowed(req.URL.Hostname(), h.HostAllowlist) &&
+				!hostAllowedExtras(req.URL.Hostname(), tools.ExtraAllowedHosts(ctx)) {
 				return fmt.Errorf("redirect host %q not in allowlist", req.URL.Hostname())
 			}
 			return nil
@@ -287,6 +302,52 @@ func hostAllowed(host string, allowlist []string) bool {
 			return true
 		}
 		if strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostAllowedExtras is the matcher for per-call host-widening grants
+// from permitted Pre-hooks (v0.8.17). Intentionally stricter than
+// hostAllowed:
+//
+//   - A bare entry "acme.com" matches "acme.com" ONLY (NOT
+//     "careers.acme.com"). Useful for hooks that want to approve
+//     exactly the URL the model asked about, no broader.
+//   - A leading-dot entry ".acme.com" suffix-matches: "acme.com" AND
+//     any subdomain. The leading dot is an explicit opt-in to the
+//     "operator-list-style" suffix semantics, so cautious hook
+//     authors get exact-match by default.
+//
+// Returns false on nil / empty extras (the common path) without
+// allocating.
+func hostAllowedExtras(host string, extras []string) bool {
+	if len(extras) == 0 {
+		return false
+	}
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "" {
+		return false
+	}
+	for _, entry := range extras {
+		entry = strings.ToLower(strings.TrimSuffix(entry, "."))
+		if entry == "" {
+			continue
+		}
+		if strings.HasPrefix(entry, ".") {
+			// Leading-dot: suffix-match (operator-style).
+			anchor := entry[1:]
+			if anchor == "" {
+				continue // ".  alone" isn't meaningful
+			}
+			if host == anchor || strings.HasSuffix(host, "."+anchor) {
+				return true
+			}
+			continue
+		}
+		// Bare entry: exact match only.
+		if host == entry {
 			return true
 		}
 	}

--- a/internal/tools/builtin/httptool_test.go
+++ b/internal/tools/builtin/httptool_test.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 func TestHTTPRefusesEmptyAllowlist(t *testing.T) {
@@ -342,4 +344,201 @@ func mustHost(t *testing.T, raw string) string {
 		t.Fatalf("parse url: %v", err)
 	}
 	return u.Hostname()
+}
+
+// TestHTTPAllowsHostFromCtxExtras: a host NOT in the operator's
+// allowlist but PRESENT in the ctx-attached extras (placed there by a
+// permitted Pre-hook earlier in dispatch) must succeed. This is the
+// end-to-end of the v0.8.17 per-call host-widening capability — proves
+// the gate consults ctx-extras after the static-list check fails.
+func TestHTTPAllowsHostFromCtxExtras(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok via extras")
+	}))
+	defer srv.Close()
+
+	host := mustHost(t, srv.URL)
+	// Operator's static allowlist deliberately does NOT include `host`.
+	// A throwaway entry keeps the deny-all branch out of the way so
+	// we're specifically testing the "operator-floor rejects, extras
+	// approves" branch.
+	h := &HTTP{
+		HostAllowlist:        []string{"some-other-host.example"},
+		PrivateHostAllowlist: []string{host}, // dial-layer exception so loopback succeeds
+		AllowPrivateIPs:      false,
+	}
+
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": srv.URL})
+	// Attach the host as a per-call extra (mirrors what
+	// loop.dispatchOneTool does after a permitted Pre-hook).
+	ctx := tools.WithExtraAllowedHosts(context.Background(), []string{host})
+	res, err := h.Execute(ctx, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("host in ctx-extras should be reachable; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "ok via extras") {
+		t.Errorf("response body unexpected: %q", res.Text)
+	}
+}
+
+// TestHTTPCtxExtrasEmptyDoesNotWiden: a ctx with NO extras attached
+// must NOT widen — the host stays blocked. Catches a regression where
+// a future refactor accidentally treats nil/empty extras as "allow
+// everything" (an easy reversal-of-meaning bug).
+func TestHTTPCtxExtrasEmptyDoesNotWiden(t *testing.T) {
+	h := &HTTP{HostAllowlist: []string{"only.allowed.example"}}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": "https://unknown.example/"})
+	res, err := h.Execute(context.Background(), body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected refusal — empty ctx-extras must not widen; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "not in allowlist") {
+		t.Errorf("expected 'not in allowlist' error; got %q", res.Text)
+	}
+}
+
+// TestHTTPCtxExtrasIPBlockNotBypassable: even if extras include a
+// hostname that resolves to a private IP (e.g. "localhost"), the
+// dial-time private-IP block still fires when PrivateHostAllowlist
+// does NOT opt that host in. Pins the design: a Pre-hook can widen
+// at the hostname layer, but cannot bypass the SSRF-defense at the
+// IP layer — that's a separate, orthogonal trust boundary.
+func TestHTTPCtxExtrasIPBlockNotBypassable(t *testing.T) {
+	h := &HTTP{
+		HostAllowlist: []string{"some-other-host.example"},
+		// PrivateHostAllowlist deliberately empty — no IP-layer exemption.
+	}
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": "http://localhost:1/"})
+	ctx := tools.WithExtraAllowedHosts(context.Background(), []string{"localhost"})
+	res, err := h.Execute(ctx, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("expected dial-layer refusal even with extras; got %q", res.Text)
+	}
+	// The error surface depends on resolver/dial behavior; what matters
+	// is that the call DID NOT succeed. Either "no public addresses"
+	// (private-IP guard) or a connect failure on the bogus port — both
+	// are acceptable. We just assert the request was rejected.
+	if strings.Contains(res.Text, "HTTP GET") && !strings.Contains(res.Text, "-> 4") && !strings.Contains(res.Text, "-> 5") {
+		t.Errorf("response looked like a successful round-trip; got %q", res.Text)
+	}
+}
+
+// TestHTTPRedirectConsultsCtxExtras: initial URL on the operator
+// allowlist, redirect target in the ctx-extras. CheckRedirect must
+// allow the hop because the extras attached at dispatch cover the
+// entire tool call.
+func TestHTTPRedirectConsultsCtxExtras(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "ok at redirect target")
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer source.Close()
+
+	sourceHost := mustHost(t, source.URL)
+	targetHost := mustHost(t, target.URL)
+	h := &HTTP{
+		HostAllowlist:        []string{sourceHost},
+		PrivateHostAllowlist: []string{sourceHost, targetHost},
+		AllowPrivateIPs:      false,
+	}
+
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": source.URL})
+	// Source is in the static list; target is only in the per-call extras.
+	ctx := tools.WithExtraAllowedHosts(context.Background(), []string{targetHost})
+	res, err := h.Execute(ctx, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("expected redirect to extras-approved host to succeed; got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "ok at redirect target") {
+		t.Errorf("redirect did not land at target; body = %q", res.Text)
+	}
+}
+
+// TestHTTPRedirectToUnknownHostStillBlocked: a redirect to a host
+// covered by NEITHER the static list NOR the extras still fails.
+// Pins the "extras don't blanket-approve" property — they cover
+// exactly the hostnames the hook named, no more.
+func TestHTTPRedirectToUnknownHostStillBlocked(t *testing.T) {
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://attacker.example/", http.StatusFound)
+	}))
+	defer source.Close()
+
+	sourceHost := mustHost(t, source.URL)
+	h := &HTTP{
+		HostAllowlist:   []string{sourceHost},
+		AllowPrivateIPs: true,
+	}
+
+	body, _ := json.Marshal(map[string]string{"method": "GET", "url": source.URL})
+	// Extras approve a different host than the redirect target.
+	ctx := tools.WithExtraAllowedHosts(context.Background(), []string{"acme.com"})
+	res, err := h.Execute(ctx, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Errorf("expected redirect rejection (target not in static OR extras); got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "redirect host") && !strings.Contains(res.Text, "not in allowlist") {
+		t.Errorf("expected redirect-host error; got %q", res.Text)
+	}
+}
+
+// TestHostAllowedExtras_LeadingDotSuffix unit-tests the matcher
+// semantics: dotless entries are exact-match; leading-dot entries
+// are suffix-match. This is intentionally stricter than the
+// operator allowlist's hostAllowed() which is suffix-match always.
+func TestHostAllowedExtras_LeadingDotSuffix(t *testing.T) {
+	cases := []struct {
+		host    string
+		extras  []string
+		want    bool
+		comment string
+	}{
+		// Dotless: exact match only.
+		{"acme.com", []string{"acme.com"}, true, "exact"},
+		{"careers.acme.com", []string{"acme.com"}, false, "subdomain of dotless entry should NOT match"},
+		{"acme.co", []string{"acme.com"}, false, "different host"},
+		// Leading-dot: suffix-match including the bare anchor.
+		{"acme.com", []string{".acme.com"}, true, "anchor of leading-dot matches"},
+		{"careers.acme.com", []string{".acme.com"}, true, "subdomain of leading-dot matches"},
+		{"evilacme.com", []string{".acme.com"}, false, "non-dot-boundary suffix must NOT match"},
+		// Empty / edge cases.
+		{"acme.com", []string{}, false, "empty extras"},
+		{"acme.com", nil, false, "nil extras"},
+		{"acme.com", []string{"", "."}, false, "empty + bare-dot entries are no-ops"},
+		// Trailing dot on host (FQDN form) normalised.
+		{"acme.com.", []string{"acme.com"}, true, "trailing-dot host normalises"},
+		// Case-insensitivity.
+		{"ACME.COM", []string{"acme.com"}, true, "case-insensitive host"},
+		{"acme.com", []string{"ACME.COM"}, true, "case-insensitive entry"},
+		// Empty host never matches.
+		{"", []string{"acme.com"}, false, "empty host"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.comment, func(t *testing.T) {
+			got := hostAllowedExtras(tc.host, tc.extras)
+			if got != tc.want {
+				t.Errorf("hostAllowedExtras(%q, %v) = %v, want %v (%s)",
+					tc.host, tc.extras, got, tc.want, tc.comment)
+			}
+		})
+	}
 }

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -151,6 +151,42 @@ func HostPolicy(ctx context.Context) HostPolicyValue {
 	return v
 }
 
+// ctxKeyExtraAllowedHosts is the context key for v0.8.17 per-call
+// host-widening grants from permitted Pre-hooks. Distinct from
+// HostPolicy: HostPolicy carries the caller-authoritative narrowing
+// that applies for the entire run and is inherited by sub-agents.
+// ExtraAllowedHosts is per-tool-call only — set by loop.dispatchOneTool
+// for the SINGLE Execute() call after a permitted Pre-hook returned
+// allow_hosts, then dropped when control returns to the loop.
+// Sub-agents do NOT inherit it; the v1 scope is one Execute() per
+// hook callback (CLAUDE.md confused-deputy guidance).
+type ctxKeyExtraAllowedHosts struct{}
+
+// WithExtraAllowedHosts derives a ctx with the per-call host-widening
+// grants attached. extras is the deduplicated list from the
+// dispatcher's PreOutcome.AllowHosts. Matching semantics live in the
+// enforcement-site helper (httptool.hostAllowedWithExtras): bare
+// entries are exact-match; entries with a leading dot are suffix-match.
+//
+// Calling this with a nil / empty slice is a no-op (returns the
+// input ctx unchanged) so the loop can call it unconditionally
+// without paying for an extra ctx allocation per tool call.
+func WithExtraAllowedHosts(ctx context.Context, extras []string) context.Context {
+	if len(extras) == 0 {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyExtraAllowedHosts{}, extras)
+}
+
+// ExtraAllowedHosts returns the per-call host-widening grants from
+// ctx, or nil when nothing was attached. Tools that enforce a host
+// allowlist consult this AFTER their operator-floor + caller-narrowed
+// check fails, allowing the per-call grant to widen JUST this call.
+func ExtraAllowedHosts(ctx context.Context) []string {
+	v, _ := ctx.Value(ctxKeyExtraAllowedHosts{}).([]string)
+	return v
+}
+
 // ctxKeyRunIdentity is the context key under which the runtime
 // stashes the current run's user_id and agent_id (v0.4 tracking
 // fields). Sub-agents read these via RunIdentity to inherit the

--- a/internal/tools/tool_test.go
+++ b/internal/tools/tool_test.go
@@ -100,3 +100,65 @@ func TestDispatcher_FallbackHandledFalseFallsThrough(t *testing.T) {
 		t.Errorf("expected 'tool not found: Unknown' substring; got %q", r.Text)
 	}
 }
+
+// TestExtraAllowedHosts_RoundTripsThroughCtx pins the basic ctx
+// helper contract for the v0.8.17 per-call host-widening mechanism.
+// The list is attached unmodified and retrieved unmodified — no
+// normalisation in this layer (the dispatcher already normalised
+// before calling WithExtraAllowedHosts; httptool will pattern-match
+// at the enforcement site).
+func TestExtraAllowedHosts_RoundTripsThroughCtx(t *testing.T) {
+	ctx := context.Background()
+	if got := ExtraAllowedHosts(ctx); got != nil {
+		t.Errorf("bare ctx returned %v, want nil", got)
+	}
+
+	in := []string{"acme.com", ".trusted-cdn.com"}
+	ctx2 := WithExtraAllowedHosts(ctx, in)
+	got := ExtraAllowedHosts(ctx2)
+	if len(got) != 2 || got[0] != "acme.com" || got[1] != ".trusted-cdn.com" {
+		t.Errorf("ExtraAllowedHosts = %v, want %v (unmodified)", got, in)
+	}
+
+	// Parent ctx is unaffected (Go context immutability).
+	if got := ExtraAllowedHosts(ctx); got != nil {
+		t.Errorf("parent ctx mutated; ExtraAllowedHosts now = %v", got)
+	}
+}
+
+// TestWithExtraAllowedHosts_NilEmptyIsNoOp confirms the optimization:
+// passing nil or [] returns the input ctx unchanged. This matters
+// because loop.dispatchOneTool calls WithExtraAllowedHosts on every
+// tool dispatch — the common case (no permitted hook contributed)
+// must not allocate a new ctx for nothing.
+func TestWithExtraAllowedHosts_NilEmptyIsNoOp(t *testing.T) {
+	ctx := context.Background()
+	if WithExtraAllowedHosts(ctx, nil) != ctx {
+		t.Error("nil extras: WithExtraAllowedHosts must return the input ctx unchanged")
+	}
+	if WithExtraAllowedHosts(ctx, []string{}) != ctx {
+		t.Error("empty extras: WithExtraAllowedHosts must return the input ctx unchanged")
+	}
+}
+
+// TestExtraAllowedHosts_NoLeakAcrossSiblingDerivations pins the
+// scope invariant: a ctx derived AFTER WithExtraAllowedHosts sees the
+// extras; a SIBLING derivation off the parent ctx does NOT. This is
+// the property that keeps per-tool-call grants from leaking into
+// sub-agent calls (sub-agents derive a fresh ctx from the loop's
+// pre-dispatch ctx, not from the per-call execCtx).
+func TestExtraAllowedHosts_NoLeakAcrossSiblingDerivations(t *testing.T) {
+	parent := context.Background()
+	widened := WithExtraAllowedHosts(parent, []string{"acme.com"})
+
+	// Child of widened sees the extras.
+	if got := ExtraAllowedHosts(widened); len(got) != 1 {
+		t.Errorf("widened ctx: extras = %v, want [acme.com]", got)
+	}
+
+	// Sibling of widened (derived off `parent`) does NOT see them.
+	sibling := WithExtraAllowedHosts(parent, nil) // == parent
+	if got := ExtraAllowedHosts(sibling); got != nil {
+		t.Errorf("sibling ctx (not derived from widened): extras = %v, want nil", got)
+	}
+}

--- a/loomcycle.example.yaml
+++ b/loomcycle.example.yaml
@@ -237,6 +237,34 @@ interruption:
   max_pending_per_run: 10         # operator-global cap; per-agent yaml narrows
   heartbeat_interval_ms: 30000    # during-block heartbeat cadence (sweeper-safe)
 
+# ─── Tool-use hooks (v0.7.x+; widening capability v0.8.17) ────────────
+# Hook registrations themselves are RUNTIME — apps register via
+# POST /v1/hooks. This block carries the few operator-side knobs that
+# CANNOT be set via the runtime API (so the registering app can't
+# escalate its own trust boundary).
+#
+# permit_host_widen.owners: the exact-string list of registered-hook
+# Owner UIDs whose Pre-hook `allow_hosts` response is HONOURED at
+# dispatch time. Without an entry here, any hook's allow_hosts is
+# silently dropped (with a WARN log + Dispatcher.HostWidenDenied
+# counter increment). The model and the runtime caller cannot enable
+# widening — only this yaml can. See docs/TOOLS.md "Per-call host
+# widening" for the wire shape, audit event, and known limitations.
+#
+# Env equivalent (APPENDS to whatever yaml has, not replaces):
+#   LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS=jobs-search-web,company-research
+#
+# SECURITY: the named app is trusted to make ad-hoc per-call URL
+# decisions. The hook receives the URL the model wants to fetch +
+# agent/user identity, and decides allow/deny. The hook MUST NOT
+# blindly echo the model's URL host as `allow_hosts` (that would let
+# the model widen its own allowlist — see confused-deputy notes in
+# docs/TOOLS.md). Audit the operator-yaml addition like you'd audit
+# any trust delegation.
+hooks:
+  permit_host_widen:
+    owners: []                    # e.g. ["jobs-search-web"] — empty default-denies for all owners
+
 # ─── Default routing for agents that don't specify their own ──────────
 # Used by agents that declare neither `tier:` nor an explicit
 # `provider:`+`model:` pin. v0.6.x back-compat path; tier-based agents


### PR DESCRIPTION
## Summary

Pre-hooks can now grant the model permission to fetch hostnames outside the operator's static allowlist and the caller's `runRequest.allowed_hosts`, **per tool call**, gated on explicit operator-yaml opt-in. Solves the dynamic-discovery problem for `job-searcher` / `company-explorer` agents that find URLs in search results that nobody pre-enumerated.

## Why

`jobs-search-agent` integrators kept hitting the host-allowlist wall: the operator's static list can't enumerate every job-board / company-site / ATS-tracker domain in advance, and the caller's per-run allowed_hosts only knows what was known at run-create time. The agent finds a new URL, tries to fetch, and gets blocked. Existing options (pre-enumerate everything; widen the static list; disable host policy entirely) either don't scale or degrade the security posture too far.

The trust-boundary invariant (CLAUDE.md rule #8) prevents the model from unilaterally widening. The clean solution: delegate the per-URL allow/deny decision to a **trusted out-of-band party** — the calling service's own policy webhook — and let the OPERATOR opt that webhook in via yaml. The runtime caller and the model both cannot enable widening; only operator yaml can.

## What changed

Eight commits, broken down for review:

1. **`feat(hooks/types): add AllowHosts to PreHookResult (wire shape only)`** — extend `PreHookResult` with optional `allow_hosts []string`. Doc-comment captures the load-bearing invariants (per-call scope, leading-dot suffix semantics, confused-deputy warning). No behavior change yet.
2. **`feat(hooks): operator opt-in for host-widening (PermitHostWiden.Owners)`** — new `hooks.permit_host_widen.owners` yaml block + `LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS` env. `Registry.IsHostWidenPermitted(owner)` exposes the set; default-deny stance preserved for back-compat.
3. **`feat(hooks): dispatcher accumulates allow_hosts from permitted owners`** — `RunPre` unions per-call grants from permitted hooks, drops un-permitted ones with a WARN log + counter, deny discards all prior grants. `Dispatcher.Stats()` exposes `HostWidenPermitted` / `HostWidenDenied` atomic counters.
4. **`feat(tools): WithExtraAllowedHosts ctx helper + loop wires it pre-Execute`** — ctx-scoped extras attached by `dispatchOneTool` JUST before calling Execute. Sub-agents and the next iteration see the original ctx without extras (per-call scope).
5. **`feat(httptool): consult ctx-extras at host-allowed gate + redirect`** — primary gate + CheckRedirect both consult `tools.ExtraAllowedHosts(ctx)`. New `hostAllowedExtras` matcher: dotless = exact-match, leading-dot = suffix-match (intentionally stricter than the operator allowlist).
6. **`feat(loop+providers): EventHostWidened audit event`** — typed `host_widened` event with the full payload (tool_call_id, tool_name, URL, hook_owner, hook_name, hosts_added). Persisted via `makeRecordingEmit`.
7. **`docs: per-call host widening capability + sample yaml`** — full `docs/TOOLS.md` subsection covering wire shape, semantics, audit event, counters, the four known limitations, and the confused-deputy security warning. Sample yaml shows the operator opt-in shape.
8. **`chore: gofmt struct-literal alignment in hooks package`** — purely cosmetic.

## Wire shape

```json
// Pre-hook response (new optional field):
{
  "input": {...},
  "deny": {...},
  "allow_hosts": ["acme.com", ".trusted-cdn.com"]
}
```

Matching: bare = exact-hostname, leading-dot = suffix-match.

## Operator opt-in

```yaml
hooks:
  permit_host_widen:
    owners: ["jobs-search-web"]
```

Or env: `LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS=jobs-search-web,company-research` (APPENDS to yaml).

## Trust-boundary preservation

- Operator yaml is the SOLE enabler. Model and runtime caller cannot configure widening.
- Hook author warning lives in the `PreHookResult.AllowHosts` doc-comment: "MUST NOT be derived blindly from `tool_call.input` — the URL is model-generated and untrusted. Validate independently."
- Audit event includes the requesting URL so operators detect confused-deputy patterns post-hoc.
- Aggregate counter (`hooks_host_widen_denied`) makes un-authorised widening attempts graphable without scraping events.
- Dial-time private-IP block is NOT bypassable (a hook approving `localhost` still fails at dial unless `HTTPPrivateHostAllowlist` separately opts in).
- Sub-agents do NOT inherit a parent's widening. Per-call scope, no propagation.

## Known limitations (v1)

1. **Redirect to a brand-new host not approved up-front fails.** The hook is invoked once per tool call, before Execute; redirects within the call consult the SAME ctx-extras. Documented in `docs/TOOLS.md`.
2. **No server-side cache.** Every fetch to an unknown host fires a fresh callback. Hooks should cache client-side.
3. **No sub-agent inheritance.** Per-call scope means the grant evaporates the moment Execute returns. Sub-agents needing the same widening register their own hook against the sub-agent's name.
4. **Dial-time IP block remains orthogonal.** Operator must separately opt in via `HTTPPrivateHostAllowlist` for hosts resolving to private IPs.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` empty.
- [x] `go test -race -timeout 120s ./...` green on the full tree.
- [x] **15 new unit + integration tests** across `internal/hooks/`, `internal/tools/`, `internal/tools/builtin/`, `internal/loop/`. Cover: wire shape round-trip, registry permit semantics, dispatcher accumulation (permitted/un-permitted/deny+allow/union/mixed/case-norm), ctx helper round-trip + scope isolation, httptool enforcement (allows / empty-no-widen / IP-block-unbypassable / redirect-allows / redirect-unknown-blocked), `hostAllowedExtras` matcher table (12 cases), end-to-end loop integration (permitted approves; un-permitted has no effect).
- [x] Sample yaml loads cleanly: `./bin/loomcycle --config loomcycle.example.yaml --version` boots.

## File touches

```
 docs/TOOLS.md                           |  91 ++++++++++++-
 internal/api/http/server.go             |   7 +-
 internal/config/config.go               |  53 ++++++++
 internal/hooks/dispatcher.go            | 148 ++++++++++++++++++-
 internal/hooks/dispatcher_test.go       | 218 ++++++++++++++++++++++++++++++++
 internal/hooks/registry.go              |  52 +++++++-
 internal/hooks/registry_test.go         |  63 +++++++++
 internal/hooks/types.go                 |  39 +++++-
 internal/hooks/types_test.go            | 113 +++++++++++++++++
 internal/loop/hooks_test.go             | 194 ++++++++++++++++++++++++++++
 internal/loop/loop.go                   |  55 +++++++-
 internal/providers/provider.go          |  64 ++++++++++
 internal/tools/builtin/httptool.go      |  65 +++++++++-
 internal/tools/builtin/httptool_test.go | 199 +++++++++++++++++++++++++++++
 internal/tools/tool.go                  |  36 ++++++
 internal/tools/tool_test.go             |  62 +++++++++
 loomcycle.example.yaml                  |  28 ++++
 17 files changed, ~1480 insertions, ~21 deletions
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)