### PR TITLE
feat(snapshot): export/restore + per-section migrations (PR 3 of 5, stacked on #130)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -867,6 +867,15 @@ func main() {
 	if probeInterval <= 0 {
 		probeInterval = 15 * time.Minute
 	}
+	// v0.8.17: register the force-probe callback. The snapshot restore
+	// handler (POST /v1/_snapshots/{id}/restore) calls
+	// resolver.ForceProbe(ctx) to refresh the matrix before the
+	// operator can call Resume — the pause-resume-snapshot RFC says
+	// the resolver state is excluded from snapshots, so a fresh probe
+	// closes the gap.
+	resolver.SetForceProbeCallback(func(ctx context.Context) {
+		runResolveProbeOnce(ctx, resolver, pr, cfg)
+	})
 	go runResolveProbeLoop(bgCtx, resolver, pr, cfg, probeInterval)
 	log.Printf("resolve probe: interval=%s", probeInterval)
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1024,6 +1024,12 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_snapshots", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListSnapshots))))
 	mux.Handle("GET /v1/_snapshots/{id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetSnapshot))))
 	mux.Handle("DELETE /v1/_snapshots/{id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDeleteSnapshot))))
+	// v0.8.17 PR 3: restore + export. /restore consumes the
+	// envelope (looked up by {id} or supplied inline); /export
+	// returns the canonical JSON with a Content-Disposition header
+	// for `curl -O`.
+	mux.Handle("POST /v1/_snapshots/{id}/restore", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRestoreSnapshot))))
+	mux.Handle("GET /v1/_snapshots/{id}/export", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleExportSnapshot))))
 	// v0.8.16 Interruption tool. resolve is the human-side answer
 	// submit; the two list endpoints drive the Web UI (run-scoped
 	// audit + user-scoped inbox).

--- a/internal/api/http/snapshots.go
+++ b/internal/api/http/snapshots.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -317,10 +318,30 @@ func (s *Server) handleExportSnapshot(w http.ResponseWriter, r *http.Request) {
 	// so CLI consumers using `curl -O` save it under the snapshot's
 	// id. The bytes are already canonical (Capture stored them via
 	// json.Marshal); no re-marshal needed.
+	//
+	// Sanitize the id before splicing into the header value: snapshot
+	// IDs from mintID are clean ("snap_<ms>_<hex>") but the id here is
+	// a path param under operator control, and trusting it would
+	// permit header injection / response-splitting via embedded
+	// quotes, CR, or LF. Replace those with '_' rather than rejecting
+	// so a misuse still gets the body (just with a sanitized filename).
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Disposition", `attachment; filename="`+id+`.json"`)
+	w.Header().Set("Content-Disposition", `attachment; filename="`+sanitizeSnapshotFilename(id)+`.json"`)
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(row.JSONContent)
+}
+
+// sanitizeSnapshotFilename strips characters that would break the
+// Content-Disposition header value (double quote, CR, LF) and replaces
+// them with '_'. mintID-produced ids never trip this in practice; it's
+// defense-in-depth against operator-supplied or future-format ids.
+func sanitizeSnapshotFilename(id string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '"' || r == '\r' || r == '\n' {
+			return '_'
+		}
+		return r
+	}, id)
 }
 
 // channelConfigForSnapshot translates cfg.Channels (operator-yaml

--- a/internal/api/http/snapshots.go
+++ b/internal/api/http/snapshots.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/snapshot"
+	"github.com/denn-gubsky/loomcycle/internal/snapshot/migrations"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -197,6 +198,129 @@ func (s *Server) handleDeleteSnapshot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// snapshotRestoreRequest is the body of POST /v1/_snapshots/{id}/restore.
+type snapshotRestoreRequest struct {
+	// IncludeHistory toggles restoring the optional
+	// interaction_history section. Default false (the running-state
+	// restore most operators want).
+	IncludeHistory bool `json:"include_history,omitempty"`
+	// JSON, when set, overrides the {id} path — restore from the
+	// supplied envelope rather than looking up by id. Used by the
+	// CLI's `loomcycle snapshot restore <file.json>` flow which
+	// posts the envelope directly without persisting first.
+	JSON json.RawMessage `json:"json,omitempty"`
+}
+
+// snapshotRestoreResponse mirrors snapshot.RestoreResult for the wire.
+type snapshotRestoreResponse struct {
+	AgentDefsRestored          int      `json:"agent_defs_restored"`
+	AgentDefActiveRestored     int      `json:"agent_def_active_restored"`
+	MemoryRestored             int      `json:"memory_restored"`
+	ChannelMessagesRestored    int      `json:"channel_messages_restored"`
+	ChannelCursorsRestored     int      `json:"channel_cursors_restored"`
+	EvaluationsRestored        int      `json:"evaluations_restored"`
+	PausedRunsRestored         int      `json:"paused_runs_restored"`
+	SynthesizedSessions        int      `json:"synthesized_sessions"`
+	TranscriptEventsRestored   int      `json:"transcript_events_restored"`
+	InteractionHistoryRestored int      `json:"interaction_history_restored"`
+	Warnings                   []string `json:"warnings,omitempty"`
+}
+
+func (s *Server) handleRestoreSnapshot(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	var req snapshotRestoreRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && err.Error() != "EOF" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON object (or empty)")
+		return
+	}
+
+	// Resolve the envelope bytes — either the supplied JSON or
+	// fetch by id.
+	var rawBytes []byte
+	if len(req.JSON) > 0 {
+		rawBytes = req.JSON
+	} else {
+		row, err := s.store.SnapshotGet(r.Context(), id)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				writeJSONError(w, http.StatusNotFound, "snapshot_not_found", "no snapshot with id "+id)
+				return
+			}
+			writeJSONError(w, http.StatusInternalServerError, "get_failed", err.Error())
+			return
+		}
+		rawBytes = row.JSONContent
+	}
+
+	// Restore — passes ForceProbe so the resolver matrix is
+	// refreshed before this returns. Operators can call Resume
+	// immediately after a successful restore without waiting for
+	// the periodic probe.
+	opts := snapshot.RestoreOptions{
+		IncludeHistory: req.IncludeHistory,
+	}
+	if s.resolver != nil {
+		opts.ForceProbe = s.resolver.ForceProbe
+	}
+	result, err := snapshot.Restore(r.Context(), s.store, rawBytes, opts)
+	if err != nil {
+		// Migration / version errors map to 422 (semantically valid
+		// JSON, semantically invalid state). The error message
+		// carries the section + version strings so operators see
+		// what to do.
+		var tooNew *migrations.ErrSnapshotVersionTooNew
+		var unknown *migrations.ErrUnknownSectionVersion
+		switch {
+		case errors.As(err, &tooNew):
+			writeJSONError(w, http.StatusUnprocessableEntity, "snapshot_version_too_new", err.Error())
+			return
+		case errors.As(err, &unknown):
+			writeJSONError(w, http.StatusUnprocessableEntity, "snapshot_version_unknown", err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "restore_failed", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, snapshotRestoreResponse{
+		AgentDefsRestored:          result.AgentDefsRestored,
+		AgentDefActiveRestored:     result.AgentDefActiveRestored,
+		MemoryRestored:             result.MemoryRestored,
+		ChannelMessagesRestored:    result.ChannelMessagesRestored,
+		ChannelCursorsRestored:     result.ChannelCursorsRestored,
+		EvaluationsRestored:        result.EvaluationsRestored,
+		PausedRunsRestored:         result.PausedRunsRestored,
+		SynthesizedSessions:        result.SynthesizedSessions,
+		TranscriptEventsRestored:   result.TranscriptEventsRestored,
+		InteractionHistoryRestored: result.InteractionHistoryRestored,
+		Warnings:                   result.Warnings,
+	})
+}
+
+func (s *Server) handleExportSnapshot(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	row, err := s.store.SnapshotGet(r.Context(), id)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			writeJSONError(w, http.StatusNotFound, "snapshot_not_found", "no snapshot with id "+id)
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "get_failed", err.Error())
+		return
+	}
+	// Serve the raw JSON content with a Content-Disposition header
+	// so CLI consumers using `curl -O` save it under the snapshot's
+	// id. The bytes are already canonical (Capture stored them via
+	// json.Marshal); no re-marshal needed.
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+id+`.json"`)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(row.JSONContent)
 }
 
 // channelConfigForSnapshot translates cfg.Channels (operator-yaml

--- a/internal/api/http/snapshots_test.go
+++ b/internal/api/http/snapshots_test.go
@@ -298,6 +298,160 @@ func TestDeleteSnapshot_Idempotent(t *testing.T) {
 	}
 }
 
+// TestRestoreSnapshot_FromStoredID — POST /v1/_snapshots/{id}/restore
+// looks up the snapshot by id and restores it. Returns 200 +
+// per-section restored counts.
+func TestRestoreSnapshot_FromStoredID(t *testing.T) {
+	srv, st, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+
+	// Seed some state, capture.
+	ctx := httptest.NewRequest("POST", "/", nil).Context()
+	_ = st.MemorySet(ctx, store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0)
+
+	createRec := httptest.NewRecorder()
+	srv.handleCreateSnapshot(createRec, httptest.NewRequest("POST", "/v1/_snapshots", http.NoBody))
+	var created snapshotCreateResponse
+	_ = json.Unmarshal(createRec.Body.Bytes(), &created)
+
+	// Restore by id.
+	req := httptest.NewRequest("POST", "/v1/_snapshots/"+created.ID+"/restore", http.NoBody)
+	req.SetPathValue("id", created.ID)
+	rec := httptest.NewRecorder()
+	srv.handleRestoreSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp snapshotRestoreResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	// MemoryRestored may be 1 OR 0 depending on whether the second
+	// (re-)insert succeeded (it shouldn't — the row already exists,
+	// ON CONFLICT DO NOTHING means INSERT counts as a no-op). The
+	// counter semantics are "INSERT-attempts that didn't error"; SQLite's
+	// driver returns nil err on ON CONFLICT IGNORE, so counter goes up
+	// even on no-op. Test for "≥ 0 and no error" rather than exact 1.
+	if resp.MemoryRestored < 0 {
+		t.Errorf("MemoryRestored = %d, want >= 0", resp.MemoryRestored)
+	}
+}
+
+// TestRestoreSnapshot_NotFound — restore with unknown id returns 404.
+func TestRestoreSnapshot_NotFound(t *testing.T) {
+	srv, _, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+	req := httptest.NewRequest("POST", "/v1/_snapshots/snap_no_such/restore", http.NoBody)
+	req.SetPathValue("id", "snap_no_such")
+	rec := httptest.NewRecorder()
+	srv.handleRestoreSnapshot(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestRestoreSnapshot_FromInlineJSON — restore can accept the envelope
+// inline via the {"json": ...} body, bypassing the id lookup. Used by
+// the CLI for `loomcycle snapshot restore <file.json>`.
+func TestRestoreSnapshot_FromInlineJSON(t *testing.T) {
+	srv, _, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+
+	envelope := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"memory": {
+				"version": "1.0",
+				"entries": [
+					{"scope":"agent","scope_id":"a","key":"k","value":"v","created_at":"2026-05-18T00:00:00Z","updated_at":"2026-05-18T00:00:00Z","embedding":null}
+				]
+			}
+		}
+	}`)
+	reqBody, _ := json.Marshal(map[string]any{"json": json.RawMessage(envelope)})
+	req := httptest.NewRequest("POST", "/v1/_snapshots/ignored/restore", bytes.NewReader(reqBody))
+	req.SetPathValue("id", "ignored")
+	rec := httptest.NewRecorder()
+	srv.handleRestoreSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp snapshotRestoreResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.MemoryRestored != 1 {
+		t.Errorf("MemoryRestored = %d, want 1", resp.MemoryRestored)
+	}
+}
+
+// TestRestoreSnapshot_RejectsNewerVersion — section version newer
+// than reader → 422 Unprocessable Entity with version_too_new code.
+func TestRestoreSnapshot_RejectsNewerVersion(t *testing.T) {
+	srv, _, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+	envelope := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"memory": {"version": "9.99", "entries": []}
+		}
+	}`)
+	reqBody, _ := json.Marshal(map[string]any{"json": json.RawMessage(envelope)})
+	req := httptest.NewRequest("POST", "/v1/_snapshots/x/restore", bytes.NewReader(reqBody))
+	req.SetPathValue("id", "x")
+	rec := httptest.NewRecorder()
+	srv.handleRestoreSnapshot(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Errorf("status = %d, want 422", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "version_too_new") {
+		t.Errorf("body missing version_too_new code: %s", rec.Body.String())
+	}
+}
+
+// TestExportSnapshot_DownloadHeader — GET /v1/_snapshots/{id}/export
+// returns the JSON content with Content-Disposition: attachment.
+func TestExportSnapshot_DownloadHeader(t *testing.T) {
+	srv, _, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+
+	// Create one first.
+	createRec := httptest.NewRecorder()
+	srv.handleCreateSnapshot(createRec, httptest.NewRequest("POST", "/v1/_snapshots", http.NoBody))
+	var created snapshotCreateResponse
+	_ = json.Unmarshal(createRec.Body.Bytes(), &created)
+
+	req := httptest.NewRequest("GET", "/v1/_snapshots/"+created.ID+"/export", nil)
+	req.SetPathValue("id", created.ID)
+	rec := httptest.NewRecorder()
+	srv.handleExportSnapshot(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") {
+		t.Errorf("Content-Disposition = %q, want attachment", cd)
+	}
+	if !strings.Contains(rec.Header().Get("Content-Disposition"), created.ID+".json") {
+		t.Errorf("filename hint missing: %q", rec.Header().Get("Content-Disposition"))
+	}
+	// Body must be valid JSON.
+	var env map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &env); err != nil {
+		t.Errorf("body not valid JSON: %v", err)
+	}
+}
+
+// TestExportSnapshot_NotFound — export with unknown id → 404.
+func TestExportSnapshot_NotFound(t *testing.T) {
+	srv, _, cleanup := minimalServerWithSnapshotStore(t)
+	defer cleanup()
+	req := httptest.NewRequest("GET", "/v1/_snapshots/snap_no_such/export", nil)
+	req.SetPathValue("id", "snap_no_such")
+	rec := httptest.NewRecorder()
+	srv.handleExportSnapshot(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
 // TestCreateSnapshot_ChannelConfigCarriedThrough — operator yaml's
 // Channels map flows into the snapshot envelope's channels.config.
 func TestCreateSnapshot_ChannelConfigCarriedThrough(t *testing.T) {

--- a/internal/api/http/snapshots_test.go
+++ b/internal/api/http/snapshots_test.go
@@ -324,14 +324,14 @@ func TestRestoreSnapshot_FromStoredID(t *testing.T) {
 	}
 	var resp snapshotRestoreResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
-	// MemoryRestored may be 1 OR 0 depending on whether the second
-	// (re-)insert succeeded (it shouldn't — the row already exists,
-	// ON CONFLICT DO NOTHING means INSERT counts as a no-op). The
-	// counter semantics are "INSERT-attempts that didn't error"; SQLite's
-	// driver returns nil err on ON CONFLICT IGNORE, so counter goes up
-	// even on no-op. Test for "≥ 0 and no error" rather than exact 1.
-	if resp.MemoryRestored < 0 {
-		t.Errorf("MemoryRestored = %d, want >= 0", resp.MemoryRestored)
+	// Capture-then-restore against the SAME store: the existing row
+	// hits ON CONFLICT DO NOTHING and reports rows_affected=0, so the
+	// PR #131 (bool, error) contract gives MemoryRestored = 0 even
+	// though the section had 1 entry. Compare to TestRestoreSnapshot_
+	// FromInlineJSON below which restores against a fresh row not
+	// previously present → MemoryRestored = 1.
+	if resp.MemoryRestored != 0 {
+		t.Errorf("MemoryRestored = %d, want 0 (row already exists in same store)", resp.MemoryRestored)
 	}
 }
 

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -19,6 +19,7 @@
 package resolve
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -176,6 +177,16 @@ type Resolver struct {
 	// outer map is treated as not-yet-probed (effectively unavailable
 	// in PR 1's stub-probe world).
 	matrix map[string]*Availability
+
+	// forceProbe is the v0.8.17 hook the periodic probe loop sets so
+	// out-of-band callers (POST /v1/_snapshots/{id}/restore handler)
+	// can request an immediate matrix refresh. main.go's
+	// runResolveProbeLoop sets this to a closure that triggers
+	// runResolveProbeOnce; tests + callers that don't set it just
+	// see ForceProbe() return immediately. Lock-free via mu —
+	// SetForceProbeCallback writes under the write lock; ForceProbe
+	// reads under the read lock.
+	forceProbe func(ctx context.Context)
 }
 
 // Availability is the resolver's view of one provider's reachability
@@ -681,4 +692,38 @@ func (r *Resolver) Snapshot() map[string]Availability {
 		}
 	}
 	return out
+}
+
+// SetForceProbeCallback installs the closure ForceProbe invokes.
+// Used by cmd/loomcycle/main.go to wire the probe loop's
+// runResolveProbeOnce as the immediate-probe trigger. Callers that
+// don't set this see ForceProbe() return immediately (matrix stays
+// stale until the next periodic sweep).
+func (r *Resolver) SetForceProbeCallback(fn func(ctx context.Context)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.forceProbe = fn
+}
+
+// ForceProbe triggers an immediate refresh of the resolver matrix.
+// Called by the snapshot restore handler so the resolver's view of
+// provider availability is populated before the operator calls
+// Resume — the pause-resume-snapshot RFC excludes the resolver
+// state from snapshots (re-probe on restore).
+//
+// Blocking: returns when the underlying probe completes. Operator
+// behind a slow / unreachable provider sees the restore response
+// wait briefly (~3-5s in the worst case); main.go's probe loop has
+// per-provider timeouts that bound this.
+//
+// No-op when SetForceProbeCallback hasn't been called (tests, or
+// runtime configurations without a probe loop).
+func (r *Resolver) ForceProbe(ctx context.Context) {
+	r.mu.RLock()
+	fn := r.forceProbe
+	r.mu.RUnlock()
+	if fn == nil {
+		return
+	}
+	fn(ctx)
 }

--- a/internal/resolve/matrix_test.go
+++ b/internal/resolve/matrix_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"context"
 	"errors"
 	"testing"
 )
@@ -782,5 +783,55 @@ func TestResolve_OllamaLocalAndOllamaAreDistinct(t *testing.T) {
 	}
 	if dec.Provider != "ollama-local" || dec.Model != "gemma4:9b" {
 		t.Errorf("post-stall resolve = %+v; want ollama-local/gemma4:9b (proves the two are distinct)", dec)
+	}
+}
+
+// TestForceProbe_NoCallbackIsNoOp pins the nil-safe contract: a
+// resolver without SetForceProbeCallback called returns immediately
+// from ForceProbe rather than panicking. Tests + simple consumers
+// can call ForceProbe unconditionally.
+func TestForceProbe_NoCallbackIsNoOp(t *testing.T) {
+	r := NewResolver(nil, nil)
+	// Must not panic. No assertion on side effects — the contract is
+	// just "safe to call."
+	r.ForceProbe(context.Background())
+}
+
+// TestForceProbe_InvokesRegisteredCallback — when a callback is
+// registered, ForceProbe calls it with the supplied ctx.
+func TestForceProbe_InvokesRegisteredCallback(t *testing.T) {
+	r := NewResolver(nil, nil)
+	called := false
+	var receivedCtx context.Context
+	r.SetForceProbeCallback(func(ctx context.Context) {
+		called = true
+		receivedCtx = ctx
+	})
+
+	ctx := context.WithValue(context.Background(), struct{ k int }{1}, "test")
+	r.ForceProbe(ctx)
+	if !called {
+		t.Error("callback not invoked")
+	}
+	if receivedCtx == nil {
+		t.Error("callback got nil ctx")
+	}
+}
+
+// TestForceProbe_ReplacingCallbackUsesLatest — SetForceProbeCallback
+// replaces any prior registration. The latest fn is what ForceProbe
+// invokes.
+func TestForceProbe_ReplacingCallbackUsesLatest(t *testing.T) {
+	r := NewResolver(nil, nil)
+	old := 0
+	new := 0
+	r.SetForceProbeCallback(func(ctx context.Context) { old++ })
+	r.SetForceProbeCallback(func(ctx context.Context) { new++ })
+	r.ForceProbe(context.Background())
+	if old != 0 {
+		t.Errorf("old callback called %d times; expected 0 (should have been replaced)", old)
+	}
+	if new != 1 {
+		t.Errorf("new callback called %d times; expected 1", new)
 	}
 }

--- a/internal/snapshot/export.go
+++ b/internal/snapshot/export.go
@@ -1,0 +1,52 @@
+package snapshot
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Export serialises a snapshot envelope to canonical JSON bytes
+// suitable for writing to disk + restoring on a different host.
+// Wrapper around json.Marshal that documents the wire-export contract.
+//
+// The canonical form is:
+//   - Compact (no indentation; smallest wire payload)
+//   - UTF-8 encoded
+//   - Stable field ordering per the Envelope struct's field
+//     declaration order (Go's encoding/json honours this)
+//
+// Operators wanting a pretty-printed export for human inspection
+// can pipe through `jq` or set up their own ExportPretty wrapper —
+// the canonical form is what the restore path consumes, so keep it
+// minimal.
+//
+// Export does NOT include an envelope-level checksum or signature.
+// That's left to the transport layer: HTTP responses include
+// Content-Length; the snapshots table stores byte_size; operators
+// transferring snapshot files between hosts use external tools
+// (sha256sum, signed transfer) when integrity matters.
+func Export(env *Envelope) ([]byte, error) {
+	if env == nil {
+		return nil, fmt.Errorf("snapshot export: nil envelope")
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot export: marshal: %w", err)
+	}
+	return b, nil
+}
+
+// ExportPretty produces indented JSON for human inspection. Used by
+// the CLI's `loomcycle snapshot get --pretty` flag. NOT used by
+// Restore — restoration parses canonical JSON via Export's output
+// shape.
+func ExportPretty(env *Envelope) ([]byte, error) {
+	if env == nil {
+		return nil, fmt.Errorf("snapshot export pretty: nil envelope")
+	}
+	b, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("snapshot export pretty: marshal: %w", err)
+	}
+	return b, nil
+}

--- a/internal/snapshot/migrations/registry.go
+++ b/internal/snapshot/migrations/registry.go
@@ -1,0 +1,170 @@
+// Package migrations holds per-section cross-version migrators for
+// the v0.8.17 snapshot envelope. The locked design (see
+// doc-internal/rfcs/pause-resume-snapshot.md § "Format migration
+// rule") evolves each section's schema independently: bumping the
+// outer envelope's schema_version is reserved for structurally
+// breaking changes; per-section sub-schema changes use version
+// strings keyed in this registry.
+//
+// Today every section is at "1.0" so the registry's Get() returns
+// identity migrators for the matching case (no transformation
+// needed). The framework is in place so when a section bumps to
+// "1.1" (e.g., adding a required field), the new migrator from
+// "1.0" → "1.1" lands here without touching the snapshot package
+// itself.
+package migrations
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// CurrentVersion is the reader's declared section version. Each
+// section uses the same string today; future per-section divergence
+// is allowed (the registry is per-section).
+const CurrentVersion = "1.0"
+
+// Section names — wire-stable strings used as keys in
+// Envelope.Sections JSON. Mirrored from snapshot.Envelope's struct
+// tags; we redeclare here to avoid an import cycle (migrations
+// imported by snapshot/restore.go, NOT the other way around).
+const (
+	SectionAgentDefs          = "agent_defs"
+	SectionAgentDefActive     = "agent_def_active"
+	SectionMemory             = "memory"
+	SectionChannels           = "channels"
+	SectionEvaluations        = "evaluations"
+	SectionPausedRuns         = "paused_runs"
+	SectionInteractionHistory = "interaction_history"
+)
+
+// Migrator transforms a section's raw JSON bytes from one version
+// to the next. Identity migrators (fromVersion == toVersion) pass
+// through unchanged. A migrator chain (e.g. "0.9" → "1.0" → "1.1")
+// is applied in sequence by Migrate().
+type Migrator func(raw json.RawMessage) (json.RawMessage, error)
+
+// ErrSnapshotVersionTooNew is returned by Migrate when a section's
+// declared version is newer than the reader's CurrentVersion.
+// Operators get the section name + both version strings so they
+// can decide to upgrade the reader or capture a fresh snapshot
+// from the source instance.
+type ErrSnapshotVersionTooNew struct {
+	Section         string
+	SnapshotVersion string
+	ReaderVersion   string
+}
+
+func (e *ErrSnapshotVersionTooNew) Error() string {
+	return fmt.Sprintf("snapshot: section %q is version %s but reader supports %s — upgrade loomcycle or re-capture from source",
+		e.Section, e.SnapshotVersion, e.ReaderVersion)
+}
+
+// ErrUnknownSectionVersion is returned when a section's version
+// string isn't in the migration registry at all (not even as an
+// older known version). Distinguishes a corrupted / hand-edited
+// snapshot from a forward-version situation.
+type ErrUnknownSectionVersion struct {
+	Section string
+	Version string
+}
+
+func (e *ErrUnknownSectionVersion) Error() string {
+	return fmt.Sprintf("snapshot: section %q has unknown version %q — corrupted snapshot or unsupported source",
+		e.Section, e.Version)
+}
+
+// registry is the per-section map of from-version → migrator. Each
+// section's entry produces the version listed in CurrentVersion when
+// chained from oldest known version forward. v0.8.17 ships with
+// only "1.0" entries (identity migrators) — the framework's first
+// real use will be a "1.1" addition when a section's required-field
+// shape changes.
+//
+// IMPORTANT: when adding a new version (e.g. "1.1"), register the
+// "1.0" → "1.1" migrator AND bump CurrentVersion to "1.1". The
+// registry walks from the snapshot's declared version forward to
+// CurrentVersion; intermediate versions need their own migrators
+// in the chain.
+var registry = map[string]map[string]Migrator{
+	SectionAgentDefs:          {"1.0": identityMigrator},
+	SectionAgentDefActive:     {"1.0": identityMigrator},
+	SectionMemory:             {"1.0": identityMigrator},
+	SectionChannels:           {"1.0": identityMigrator},
+	SectionEvaluations:        {"1.0": identityMigrator},
+	SectionPausedRuns:         {"1.0": identityMigrator},
+	SectionInteractionHistory: {"1.0": identityMigrator},
+}
+
+// identityMigrator is the no-op migrator. Used when fromVersion ==
+// CurrentVersion (the common case in v0.8.17).
+func identityMigrator(raw json.RawMessage) (json.RawMessage, error) {
+	return raw, nil
+}
+
+// Migrate transforms a section's raw JSON from snapshotVersion up to
+// CurrentVersion. Returns:
+//   - The raw unchanged when snapshotVersion == CurrentVersion.
+//   - *ErrSnapshotVersionTooNew when snapshotVersion > CurrentVersion.
+//   - *ErrUnknownSectionVersion when snapshotVersion isn't registered.
+//   - The migrated raw + nil when one or more migrators ran cleanly.
+//
+// The walk is deterministic and version-string-based; today every
+// section has only "1.0" so the only valid input is "1.0". Future
+// additions (e.g. "1.1") chain forward from older versions.
+func Migrate(section, snapshotVersion string, raw json.RawMessage) (json.RawMessage, error) {
+	sectionRegistry, ok := registry[section]
+	if !ok {
+		return nil, &ErrUnknownSectionVersion{Section: section, Version: snapshotVersion}
+	}
+	// Same version → identity. Cheap and common.
+	if snapshotVersion == CurrentVersion {
+		mig, ok := sectionRegistry[snapshotVersion]
+		if !ok {
+			return nil, &ErrUnknownSectionVersion{Section: section, Version: snapshotVersion}
+		}
+		return mig(raw)
+	}
+	// Newer than reader → operator-actionable error.
+	if compareVersions(snapshotVersion, CurrentVersion) > 0 {
+		return nil, &ErrSnapshotVersionTooNew{
+			Section:         section,
+			SnapshotVersion: snapshotVersion,
+			ReaderVersion:   CurrentVersion,
+		}
+	}
+	// Older known version → would walk migrator chain. v0.8.17 has
+	// only "1.0" so this branch is unreachable today; ship the
+	// framework with a clear "not implemented" so a future schema
+	// change can land its migrator without changing the dispatch
+	// logic.
+	if _, ok := sectionRegistry[snapshotVersion]; !ok {
+		return nil, &ErrUnknownSectionVersion{Section: section, Version: snapshotVersion}
+	}
+	// When a real migration chain exists, walk it here: iterate
+	// from snapshotVersion forward to CurrentVersion, applying each
+	// registered migrator in sequence.
+	return nil, fmt.Errorf("snapshot: section %q version %q is older than current %q but no migration chain registered yet",
+		section, snapshotVersion, CurrentVersion)
+}
+
+// compareVersions does a lexicographic compare on dot-separated
+// numeric version strings. Returns -1, 0, or +1. Treats malformed
+// versions as equal to the empty string (sorts below everything).
+//
+// v0.8.17 uses simple "<major>.<minor>" strings; this comparator
+// will need extending if we ever introduce "<major>.<minor>.<patch>"
+// or pre-release suffixes. Documented limitation rather than a bug.
+func compareVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	// Cheap path: lexicographic for the simple <int>.<int> shape.
+	// "1.0" < "1.1" < "1.10" lex-fails ("1.10" < "1.1" lex) but
+	// we're well below that scale today; revisit when a section
+	// passes v1.9.
+	if a < b {
+		return -1
+	}
+	return 1
+}

--- a/internal/snapshot/migrations/registry.go
+++ b/internal/snapshot/migrations/registry.go
@@ -17,6 +17,8 @@ package migrations
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 )
 
 // CurrentVersion is the reader's declared section version. Each
@@ -148,23 +150,41 @@ func Migrate(section, snapshotVersion string, raw json.RawMessage) (json.RawMess
 		section, snapshotVersion, CurrentVersion)
 }
 
-// compareVersions does a lexicographic compare on dot-separated
-// numeric version strings. Returns -1, 0, or +1. Treats malformed
-// versions as equal to the empty string (sorts below everything).
+// compareVersions does a numeric per-component compare on
+// dot-separated version strings. Returns -1, 0, or +1.
 //
-// v0.8.17 uses simple "<major>.<minor>" strings; this comparator
-// will need extending if we ever introduce "<major>.<minor>.<patch>"
-// or pre-release suffixes. Documented limitation rather than a bug.
+// Components that fail to parse as int compare as 0 (e.g. "1.x" vs
+// "1.0" tie on the second component, which is the cautious behaviour
+// — we don't want a malformed version to silently sort above or
+// below a real one and flip the ErrSnapshotVersionTooNew gate).
+//
+// Per-component numeric ordering matters: lexicographic "1.10" <
+// "1.9" would make a reader at v1.10 wrongly reject a valid older
+// snapshot at v1.9 as "too new" once minor versions reach 10.
 func compareVersions(a, b string) int {
 	if a == b {
 		return 0
 	}
-	// Cheap path: lexicographic for the simple <int>.<int> shape.
-	// "1.0" < "1.1" < "1.10" lex-fails ("1.10" < "1.1" lex) but
-	// we're well below that scale today; revisit when a section
-	// passes v1.9.
-	if a < b {
-		return -1
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	n := len(aParts)
+	if len(bParts) > n {
+		n = len(bParts)
 	}
-	return 1
+	for i := 0; i < n; i++ {
+		var ax, bx int
+		if i < len(aParts) {
+			ax, _ = strconv.Atoi(aParts[i])
+		}
+		if i < len(bParts) {
+			bx, _ = strconv.Atoi(bParts[i])
+		}
+		if ax < bx {
+			return -1
+		}
+		if ax > bx {
+			return 1
+		}
+	}
+	return 0
 }

--- a/internal/snapshot/migrations/registry_test.go
+++ b/internal/snapshot/migrations/registry_test.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -74,9 +75,6 @@ func TestMigrate_UnknownSectionReturnsTypedError(t *testing.T) {
 // pre-history snapshot from a version we never supported."
 func TestMigrate_UnknownVersionForKnownSectionRejected(t *testing.T) {
 	_, err := Migrate(SectionMemory, "0.1", json.RawMessage(`{}`))
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
 	// "0.1" < "1.0" so we go down the "older known version" branch,
 	// which today (no registered migrators for "0.1") surfaces as
 	// either *ErrUnknownSectionVersion or the "not implemented"
@@ -99,7 +97,7 @@ func TestErrSnapshotVersionTooNew_MessageContent(t *testing.T) {
 	}
 	msg := err.Error()
 	for _, want := range []string{"memory", "2.0", "1.0", "upgrade"} {
-		if !contains(msg, want) {
+		if !strings.Contains(msg, want) {
 			t.Errorf("error message %q missing %q", msg, want)
 		}
 	}
@@ -112,24 +110,9 @@ func TestErrUnknownSectionVersion_MessageContent(t *testing.T) {
 	err := &ErrUnknownSectionVersion{Section: "memory", Version: "9.99"}
 	msg := err.Error()
 	for _, want := range []string{"memory", "9.99", "corrupted"} {
-		if !contains(msg, want) {
+		if !strings.Contains(msg, want) {
 			t.Errorf("error message %q missing %q", msg, want)
 		}
 	}
 }
 
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && (haystack == needle ||
-		len(haystack) > len(needle) && (haystack[:len(needle)] == needle ||
-			haystack[len(haystack)-len(needle):] == needle ||
-			indexOf(haystack, needle) >= 0))
-}
-
-func indexOf(haystack, needle string) int {
-	for i := 0; i+len(needle) <= len(haystack); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return i
-		}
-	}
-	return -1
-}

--- a/internal/snapshot/migrations/registry_test.go
+++ b/internal/snapshot/migrations/registry_test.go
@@ -1,0 +1,135 @@
+package migrations
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+// TestMigrate_SameVersionIdentity — the common path: snapshot's
+// section version equals CurrentVersion, migrator returns raw bytes
+// unchanged.
+func TestMigrate_SameVersionIdentity(t *testing.T) {
+	for _, section := range []string{
+		SectionAgentDefs, SectionAgentDefActive, SectionMemory,
+		SectionChannels, SectionEvaluations, SectionPausedRuns,
+		SectionInteractionHistory,
+	} {
+		t.Run(section, func(t *testing.T) {
+			input := json.RawMessage(`{"version":"1.0","entries":[{"x":1}]}`)
+			got, err := Migrate(section, "1.0", input)
+			if err != nil {
+				t.Fatalf("Migrate(%s, 1.0): %v", section, err)
+			}
+			if string(got) != string(input) {
+				t.Errorf("identity migrator modified bytes:\n got: %s\nwant: %s", got, input)
+			}
+		})
+	}
+}
+
+// TestMigrate_NewerVersionRejected — section version newer than the
+// reader's CurrentVersion returns *ErrSnapshotVersionTooNew with
+// both version strings + section name.
+func TestMigrate_NewerVersionRejected(t *testing.T) {
+	_, err := Migrate(SectionMemory, "9.99", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error on newer version, got nil")
+	}
+	var tooNew *ErrSnapshotVersionTooNew
+	if !errors.As(err, &tooNew) {
+		t.Errorf("err = %v, want *ErrSnapshotVersionTooNew", err)
+	}
+	if tooNew.Section != SectionMemory {
+		t.Errorf("Section = %q, want %q", tooNew.Section, SectionMemory)
+	}
+	if tooNew.SnapshotVersion != "9.99" {
+		t.Errorf("SnapshotVersion = %q, want %q", tooNew.SnapshotVersion, "9.99")
+	}
+	if tooNew.ReaderVersion != CurrentVersion {
+		t.Errorf("ReaderVersion = %q, want %q", tooNew.ReaderVersion, CurrentVersion)
+	}
+}
+
+// TestMigrate_UnknownSectionReturnsTypedError — section name not
+// in the registry returns *ErrUnknownSectionVersion (distinct from
+// version-too-new so callers can branch).
+func TestMigrate_UnknownSectionReturnsTypedError(t *testing.T) {
+	_, err := Migrate("not_a_section", "1.0", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error on unknown section, got nil")
+	}
+	var unknown *ErrUnknownSectionVersion
+	if !errors.As(err, &unknown) {
+		t.Errorf("err = %v, want *ErrUnknownSectionVersion", err)
+	}
+	if unknown.Section != "not_a_section" {
+		t.Errorf("Section = %q", unknown.Section)
+	}
+}
+
+// TestMigrate_UnknownVersionForKnownSectionRejected — section is
+// registered but the snapshot's version string isn't in its map.
+// Different from "newer than current" — this is "corrupted or
+// pre-history snapshot from a version we never supported."
+func TestMigrate_UnknownVersionForKnownSectionRejected(t *testing.T) {
+	_, err := Migrate(SectionMemory, "0.1", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// "0.1" < "1.0" so we go down the "older known version" branch,
+	// which today (no registered migrators for "0.1") surfaces as
+	// either *ErrUnknownSectionVersion or the "not implemented"
+	// error. Both are acceptable signals to the operator; just
+	// verify it's NOT silently accepted.
+	if err == nil {
+		t.Fatal("missing-version-in-registry must fail")
+	}
+}
+
+// TestErrSnapshotVersionTooNew_MessageContent — error message must
+// name the section, both versions, and suggest a remediation. This
+// is the operator's first contact with the failure mode; clarity
+// matters.
+func TestErrSnapshotVersionTooNew_MessageContent(t *testing.T) {
+	err := &ErrSnapshotVersionTooNew{
+		Section:         "memory",
+		SnapshotVersion: "2.0",
+		ReaderVersion:   "1.0",
+	}
+	msg := err.Error()
+	for _, want := range []string{"memory", "2.0", "1.0", "upgrade"} {
+		if !contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+// TestErrUnknownSectionVersion_MessageContent — error message names
+// the section + version, with a "corrupted snapshot or unsupported
+// source" hint that helps operators diagnose.
+func TestErrUnknownSectionVersion_MessageContent(t *testing.T) {
+	err := &ErrUnknownSectionVersion{Section: "memory", Version: "9.99"}
+	msg := err.Error()
+	for _, want := range []string{"memory", "9.99", "corrupted"} {
+		if !contains(msg, want) {
+			t.Errorf("error message %q missing %q", msg, want)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle ||
+		len(haystack) > len(needle) && (haystack[:len(needle)] == needle ||
+			haystack[len(haystack)-len(needle):] == needle ||
+			indexOf(haystack, needle) >= 0))
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -1,0 +1,406 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/snapshot/migrations"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// RestoreOptions controls the Restore() behaviour.
+type RestoreOptions struct {
+	// IncludeHistory toggles restoring the optional
+	// interaction_history section. False (default) skips it even
+	// when present in the envelope — operators often want
+	// running-state restore only (paused runs + their transcripts +
+	// Memory + Channels + AgentDefs + Evaluations) without
+	// pollution from archived sessions.
+	IncludeHistory bool
+
+	// ForceProbe, when non-nil, is called by Restore after section
+	// writes complete. The pause-resume-snapshot RFC says the
+	// resolver matrix is excluded from snapshots — restore triggers
+	// an immediate probe so the matrix is populated before the
+	// operator calls Resume. Pass nil to skip.
+	ForceProbe func(ctx context.Context)
+}
+
+// RestoreResult is the operator-facing summary of a Restore() call.
+// Warnings carry every non-fatal anomaly the restore encountered:
+// synthesized sessions, dropped expired rows, skipped sections, etc.
+// Operators read warnings to decide whether the restore is "clean
+// enough" to call Resume.
+type RestoreResult struct {
+	AgentDefsRestored          int      `json:"agent_defs_restored"`
+	AgentDefActiveRestored     int      `json:"agent_def_active_restored"`
+	MemoryRestored             int      `json:"memory_restored"`
+	ChannelMessagesRestored    int      `json:"channel_messages_restored"`
+	ChannelCursorsRestored     int      `json:"channel_cursors_restored"`
+	EvaluationsRestored        int      `json:"evaluations_restored"`
+	PausedRunsRestored         int      `json:"paused_runs_restored"`
+	SynthesizedSessions        int      `json:"synthesized_sessions"`
+	TranscriptEventsRestored   int      `json:"transcript_events_restored"`
+	InteractionHistoryRestored int      `json:"interaction_history_restored"`
+	Warnings                   []string `json:"warnings,omitempty"`
+}
+
+// Restore reads a canonical JSON envelope (Export's output shape),
+// migrates each section per the migrations registry, and writes
+// rows back into the store via the SnapshotRestore* methods. The
+// restore order matches the section FK dependency graph:
+//
+//	agent_defs        → agent_def_active (FK: name → agent_defs.def_id)
+//	(sessions synth)  → paused_runs       (FK: session_id → sessions.id)
+//	                  → transcript events (FK: run_id    → runs.id)
+//	channels.messages, .cursors
+//	evaluations       (no FKs)
+//	interaction_history (optional)
+//
+// Idempotent: a second Restore call on the same envelope is a clean
+// no-op (every SnapshotRestore* method uses ON CONFLICT DO NOTHING /
+// INSERT OR IGNORE).
+//
+// Critical correctness detail (the architect's catch in PR 3
+// planning): the snapshot's paused_runs section references
+// session_id values, but sessions are NOT a captured section.
+// Restore synthesizes a minimal session row per paused run with
+// ID = "snap_sess_" + run.ID — deterministic so a re-run produces
+// the same synthetic ID. RestoreResult.SynthesizedSessions counts
+// these for operator visibility.
+//
+// Returns *migrations.ErrSnapshotVersionTooNew when any section's
+// version is newer than the reader's CurrentVersion. Returns
+// *migrations.ErrUnknownSectionVersion for corrupted / unsupported
+// snapshots. Both errors carry the section + version strings for
+// operator-actionable messaging.
+func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions) (RestoreResult, error) {
+	if s == nil {
+		return RestoreResult{}, fmt.Errorf("snapshot restore: nil store")
+	}
+	if len(raw) == 0 {
+		return RestoreResult{}, fmt.Errorf("snapshot restore: empty input")
+	}
+
+	// Stage 1: deserialise the outer envelope to discover sections
+	// and their declared versions. We deserialise via a deferred
+	// map[string]json.RawMessage rather than directly into Envelope
+	// so each section's raw bytes can pass through Migrate() before
+	// being typed-decoded — that's the migration mechanism's hook.
+	var outer struct {
+		SchemaVersion int                        `json:"schema_version"`
+		CreatedAt     time.Time                  `json:"created_at"`
+		Sections      map[string]json.RawMessage `json:"sections"`
+	}
+	if err := json.Unmarshal(raw, &outer); err != nil {
+		return RestoreResult{}, fmt.Errorf("snapshot restore: parse envelope: %w", err)
+	}
+	if outer.SchemaVersion > SchemaVersion {
+		return RestoreResult{}, fmt.Errorf("snapshot restore: envelope schema_version %d is newer than reader %d", outer.SchemaVersion, SchemaVersion)
+	}
+
+	result := RestoreResult{}
+
+	// Stage 2: per-section migration + decode + insert. Order
+	// matters for FK reasons (agent_defs before agent_def_active;
+	// sessions before paused_runs).
+
+	// agent_defs
+	if rawSection, ok := outer.Sections[migrations.SectionAgentDefs]; ok {
+		var sec AgentDefsSection
+		if err := decodeWithMigration(migrations.SectionAgentDefs, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			if err := s.SnapshotRestoreAgentDef(ctx, store.AgentDefRow{
+				DefID:                  e.DefID,
+				Name:                   e.Name,
+				Version:                e.Version,
+				ParentDefID:            e.ParentDefID,
+				Definition:             e.Definition,
+				Description:            e.Description,
+				CreatedAt:              e.CreatedAt,
+				CreatedByAgentID:       e.CreatedByAgentID,
+				CreatedByRunID:         e.CreatedByRunID,
+				Retired:                e.Retired,
+				BootstrappedFromStatic: e.BootstrappedFromStatic,
+			}); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("agent_def %s: %v", e.DefID, err))
+				continue
+			}
+			result.AgentDefsRestored++
+		}
+	}
+
+	// agent_def_active (after agent_defs for FK)
+	if rawSection, ok := outer.Sections[migrations.SectionAgentDefActive]; ok {
+		var sec AgentDefActiveSection
+		if err := decodeWithMigration(migrations.SectionAgentDefActive, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			if err := s.SnapshotRestoreAgentDefActive(ctx, store.AgentDefActiveEntry{
+				Name:              e.Name,
+				DefID:             e.DefID,
+				PromotedAt:        e.PromotedAt,
+				PromotedByAgentID: e.PromotedByAgentID,
+			}); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("agent_def_active %s: %v", e.Name, err))
+				continue
+			}
+			result.AgentDefActiveRestored++
+		}
+	}
+
+	// memory (no FK; embedding field carried but Phase 1 always
+	// null; Phase 2 will populate)
+	if rawSection, ok := outer.Sections[migrations.SectionMemory]; ok {
+		var sec MemorySection
+		if err := decodeWithMigration(migrations.SectionMemory, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			var expires time.Time
+			if e.ExpiresAt != nil {
+				expires = *e.ExpiresAt
+			}
+			entry := store.MemorySnapshotEntry{
+				Scope:   store.MemoryScope(e.Scope),
+				ScopeID: e.ScopeID,
+				MemoryEntry: store.MemoryEntry{
+					Key:       e.Key,
+					Value:     e.Value,
+					ExpiresAt: expires,
+					CreatedAt: e.CreatedAt,
+					UpdatedAt: e.UpdatedAt,
+				},
+			}
+			if err := s.SnapshotRestoreMemory(ctx, entry); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("memory %s/%s/%s: %v", e.Scope, e.ScopeID, e.Key, err))
+				continue
+			}
+			result.MemoryRestored++
+		}
+		// Phase 2 will check e.Embedding != nil and populate the
+		// memory_embeddings table. Phase 1 silently drops the field
+		// (snapshots have it as null on every row anyway).
+	}
+
+	// channels (config + messages + cursors). Config is operator-
+	// yaml-side; restore doesn't write it back into a table — the
+	// operator on the restoring host reconciles against their own
+	// yaml. Messages + cursors get raw inserts.
+	if rawSection, ok := outer.Sections[migrations.SectionChannels]; ok {
+		var sec ChannelsSection
+		if err := decodeWithMigration(migrations.SectionChannels, rawSection, &sec); err != nil {
+			return result, err
+		}
+		if len(sec.Config) > 0 {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("channels.config: %d declared channels in snapshot; reconcile against operator yaml on the restoring host", len(sec.Config)))
+		}
+		for _, m := range sec.Messages {
+			var expires, visible time.Time
+			if m.ExpiresAt != nil {
+				expires = *m.ExpiresAt
+			}
+			if m.VisibleAt != nil {
+				visible = *m.VisibleAt
+			}
+			if err := s.SnapshotRestoreChannelMessage(ctx, store.ChannelMessage{
+				ID:                m.ID,
+				Channel:           m.Channel,
+				Scope:             store.MemoryScope(m.Scope),
+				ScopeID:           m.ScopeID,
+				Payload:           m.Payload,
+				PublishedAt:       m.PublishedAt,
+				ExpiresAt:         expires,
+				VisibleAt:         visible,
+				PublishedByUserID: m.PublishedByUserID,
+			}); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("channel_message %s: %v", m.ID, err))
+				continue
+			}
+			result.ChannelMessagesRestored++
+		}
+		for _, c := range sec.Cursors {
+			if err := s.SnapshotRestoreChannelCursor(ctx, store.ChannelCursorEntry{
+				Channel:   c.Channel,
+				Scope:     store.MemoryScope(c.Scope),
+				ScopeID:   c.ScopeID,
+				Cursor:    c.Cursor,
+				UpdatedAt: c.UpdatedAt,
+			}); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("channel_cursor %s/%s/%s: %v", c.Channel, c.Scope, c.ScopeID, err))
+				continue
+			}
+			result.ChannelCursorsRestored++
+		}
+	}
+
+	// evaluations (no FK enforced — runs.agent_def_id is
+	// denormalised at submit time; runs may not even exist on the
+	// restoring host)
+	if rawSection, ok := outer.Sections[migrations.SectionEvaluations]; ok {
+		var sec EvaluationsSection
+		if err := decodeWithMigration(migrations.SectionEvaluations, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			if err := s.SnapshotRestoreEvaluation(ctx, store.EvaluationRow{
+				EvalID:         e.EvalID,
+				RunID:          e.RunID,
+				DefID:          e.DefID,
+				Score:          e.Score,
+				Dimensions:     e.Dimensions,
+				Judgement:      e.Judgement,
+				Rationale:      e.Rationale,
+				EmitterRole:    e.EmitterRole,
+				EmitterAgentID: e.EmitterAgentID,
+				EmitterRunID:   e.EmitterRunID,
+				CreatedAt:      e.CreatedAt,
+			}); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("evaluation %s: %v", e.EvalID, err))
+				continue
+			}
+			result.EvaluationsRestored++
+		}
+	}
+
+	// paused_runs (after sessions are synthesized — FK on session_id)
+	if rawSection, ok := outer.Sections[migrations.SectionPausedRuns]; ok {
+		var sec PausedRunsSection
+		if err := decodeWithMigration(migrations.SectionPausedRuns, rawSection, &sec); err != nil {
+			return result, err
+		}
+		for _, e := range sec.Entries {
+			// Critical: synthesize a session row for this run BEFORE
+			// inserting the run. The pause-resume-snapshot RFC
+			// doesn't capture sessions (architect's catch); without
+			// this step, every restore errors with FK violation on
+			// runs.session_id.
+			synthesizedID := "snap_sess_" + e.RunID
+			sessionID := e.SessionID
+			if sessionID == "" {
+				sessionID = synthesizedID
+			}
+			synthSession := store.Session{
+				ID:        sessionID,
+				TenantID:  "",
+				Agent:     e.Agent,
+				CreatedAt: e.StartedAt,
+				UserID:    e.UserID,
+			}
+			if err := s.SnapshotRestoreSession(ctx, synthSession); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("synthesized session %s: %v", sessionID, err))
+				continue
+			}
+			// The architect's blueprint flagged this as the load-
+			// bearing correctness detail — count synthesized
+			// sessions explicitly for operator visibility.
+			if e.SessionID == "" || e.SessionID == synthesizedID {
+				result.SynthesizedSessions++
+			}
+
+			runRow := store.Run{
+				ID:            e.RunID,
+				SessionID:     sessionID,
+				Status:        store.RunRunning, // resume sets terminal status on completion
+				StartedAt:     e.StartedAt,
+				Model:         e.Model,
+				AgentID:       e.AgentID,
+				ParentAgentID: e.ParentAgentID,
+				UserID:        e.UserID,
+				UserTier:      e.UserTier,
+				AgentDefID:    e.AgentDefID,
+				PauseState:    e.PauseState,
+			}
+			if err := s.SnapshotRestoreRun(ctx, runRow); err != nil {
+				result.Warnings = append(result.Warnings, fmt.Sprintf("paused_run %s: %v", e.RunID, err))
+				continue
+			}
+			result.PausedRunsRestored++
+
+			// Transcript events for the run.
+			for _, te := range e.TranscriptEvents {
+				if err := s.SnapshotRestoreEvent(ctx, store.Event{
+					Seq:       te.Seq,
+					SessionID: sessionID,
+					RunID:     e.RunID,
+					Timestamp: time.Unix(0, te.TsNs),
+					Type:      te.Type,
+					Payload:   te.Payload,
+				}); err != nil {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("transcript event run=%s seq=%d: %v", e.RunID, te.Seq, err))
+					continue
+				}
+				result.TranscriptEventsRestored++
+			}
+		}
+	}
+
+	// interaction_history (optional, opt-in via RestoreOptions)
+	if opts.IncludeHistory {
+		if rawSection, ok := outer.Sections[migrations.SectionInteractionHistory]; ok {
+			var sec InteractionHistorySection
+			if err := decodeWithMigration(migrations.SectionInteractionHistory, rawSection, &sec); err != nil {
+				return result, err
+			}
+			// Phase 1 limitation: snapshot.Capture's interaction_history
+			// section is a stub (always empty events). When PR 3.x
+			// or 1.5 adds the store-side bulk event reader and the
+			// snapshot package populates this section, the restore
+			// path here writes events back. Today there's nothing
+			// to write, but we leave the loop in place for forward
+			// compatibility.
+			result.InteractionHistoryRestored = len(sec.Events)
+			if len(sec.Events) > 0 {
+				result.Warnings = append(result.Warnings,
+					"interaction_history events in envelope: Phase 1 restore does not write these back yet; see snapshot.go captureInteractionHistory")
+			}
+		}
+	} else if _, ok := outer.Sections[migrations.SectionInteractionHistory]; ok {
+		result.Warnings = append(result.Warnings,
+			"interaction_history section present in snapshot but RestoreOptions.IncludeHistory=false; skipped")
+	}
+
+	// Stage 3: trigger an immediate resolver probe so the matrix is
+	// populated before the operator calls Resume. Done last so any
+	// errors above are returned before the resolver work.
+	if opts.ForceProbe != nil {
+		opts.ForceProbe(ctx)
+	}
+
+	return result, nil
+}
+
+// decodeWithMigration runs the raw section bytes through the
+// per-section migration registry then JSON-decodes into the typed
+// destination. Returns the migration error verbatim (operator gets
+// the version + section + suggested action).
+func decodeWithMigration(section string, raw json.RawMessage, dst any) error {
+	// Peek at the section's version. The section wrapper has
+	// {"version": "1.0", ...} as its outer shape.
+	var versioned struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &versioned); err != nil {
+		return fmt.Errorf("snapshot section %s: parse version: %w", section, err)
+	}
+	if versioned.Version == "" {
+		// Tolerant default — pre-versioned sections (corrupted /
+		// hand-written) get current-version semantics. Future-strict
+		// readers may flip this to refuse.
+		versioned.Version = migrations.CurrentVersion
+	}
+	migrated, err := migrations.Migrate(section, versioned.Version, raw)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(migrated, dst); err != nil {
+		return fmt.Errorf("snapshot section %s: decode migrated bytes: %w", section, err)
+	}
+	return nil
+}

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -114,7 +114,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			return result, err
 		}
 		for _, e := range sec.Entries {
-			if err := s.SnapshotRestoreAgentDef(ctx, store.AgentDefRow{
+			inserted, err := s.SnapshotRestoreAgentDef(ctx, store.AgentDefRow{
 				DefID:                  e.DefID,
 				Name:                   e.Name,
 				Version:                e.Version,
@@ -126,11 +126,14 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				CreatedByRunID:         e.CreatedByRunID,
 				Retired:                e.Retired,
 				BootstrappedFromStatic: e.BootstrappedFromStatic,
-			}); err != nil {
+			})
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("agent_def %s: %v", e.DefID, err))
 				continue
 			}
-			result.AgentDefsRestored++
+			if inserted {
+				result.AgentDefsRestored++
+			}
 		}
 	}
 
@@ -141,16 +144,19 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			return result, err
 		}
 		for _, e := range sec.Entries {
-			if err := s.SnapshotRestoreAgentDefActive(ctx, store.AgentDefActiveEntry{
+			inserted, err := s.SnapshotRestoreAgentDefActive(ctx, store.AgentDefActiveEntry{
 				Name:              e.Name,
 				DefID:             e.DefID,
 				PromotedAt:        e.PromotedAt,
 				PromotedByAgentID: e.PromotedByAgentID,
-			}); err != nil {
+			})
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("agent_def_active %s: %v", e.Name, err))
 				continue
 			}
-			result.AgentDefActiveRestored++
+			if inserted {
+				result.AgentDefActiveRestored++
+			}
 		}
 	}
 
@@ -177,11 +183,14 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 					UpdatedAt: e.UpdatedAt,
 				},
 			}
-			if err := s.SnapshotRestoreMemory(ctx, entry); err != nil {
+			inserted, err := s.SnapshotRestoreMemory(ctx, entry)
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("memory %s/%s/%s: %v", e.Scope, e.ScopeID, e.Key, err))
 				continue
 			}
-			result.MemoryRestored++
+			if inserted {
+				result.MemoryRestored++
+			}
 		}
 		// Phase 2 will check e.Embedding != nil and populate the
 		// memory_embeddings table. Phase 1 silently drops the field
@@ -209,7 +218,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			if m.VisibleAt != nil {
 				visible = *m.VisibleAt
 			}
-			if err := s.SnapshotRestoreChannelMessage(ctx, store.ChannelMessage{
+			inserted, err := s.SnapshotRestoreChannelMessage(ctx, store.ChannelMessage{
 				ID:                m.ID,
 				Channel:           m.Channel,
 				Scope:             store.MemoryScope(m.Scope),
@@ -219,24 +228,30 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				ExpiresAt:         expires,
 				VisibleAt:         visible,
 				PublishedByUserID: m.PublishedByUserID,
-			}); err != nil {
+			})
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("channel_message %s: %v", m.ID, err))
 				continue
 			}
-			result.ChannelMessagesRestored++
+			if inserted {
+				result.ChannelMessagesRestored++
+			}
 		}
 		for _, c := range sec.Cursors {
-			if err := s.SnapshotRestoreChannelCursor(ctx, store.ChannelCursorEntry{
+			inserted, err := s.SnapshotRestoreChannelCursor(ctx, store.ChannelCursorEntry{
 				Channel:   c.Channel,
 				Scope:     store.MemoryScope(c.Scope),
 				ScopeID:   c.ScopeID,
 				Cursor:    c.Cursor,
 				UpdatedAt: c.UpdatedAt,
-			}); err != nil {
+			})
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("channel_cursor %s/%s/%s: %v", c.Channel, c.Scope, c.ScopeID, err))
 				continue
 			}
-			result.ChannelCursorsRestored++
+			if inserted {
+				result.ChannelCursorsRestored++
+			}
 		}
 	}
 
@@ -249,7 +264,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 			return result, err
 		}
 		for _, e := range sec.Entries {
-			if err := s.SnapshotRestoreEvaluation(ctx, store.EvaluationRow{
+			inserted, err := s.SnapshotRestoreEvaluation(ctx, store.EvaluationRow{
 				EvalID:         e.EvalID,
 				RunID:          e.RunID,
 				DefID:          e.DefID,
@@ -261,11 +276,14 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				EmitterAgentID: e.EmitterAgentID,
 				EmitterRunID:   e.EmitterRunID,
 				CreatedAt:      e.CreatedAt,
-			}); err != nil {
+			})
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("evaluation %s: %v", e.EvalID, err))
 				continue
 			}
-			result.EvaluationsRestored++
+			if inserted {
+				result.EvaluationsRestored++
+			}
 		}
 	}
 
@@ -293,14 +311,18 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				CreatedAt: e.StartedAt,
 				UserID:    e.UserID,
 			}
-			if err := s.SnapshotRestoreSession(ctx, synthSession); err != nil {
+			sessInserted, err := s.SnapshotRestoreSession(ctx, synthSession)
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("synthesized session %s: %v", sessionID, err))
 				continue
 			}
 			// The architect's blueprint flagged this as the load-
 			// bearing correctness detail — count synthesized
-			// sessions explicitly for operator visibility.
-			if e.SessionID == "" || e.SessionID == synthesizedID {
+			// sessions explicitly for operator visibility. Only
+			// count when an INSERT actually happened so a re-restore
+			// reads as "0 synthesized" rather than re-reporting
+			// the first restore's count.
+			if sessInserted && (e.SessionID == "" || e.SessionID == synthesizedID) {
 				result.SynthesizedSessions++
 			}
 
@@ -317,26 +339,32 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				AgentDefID:    e.AgentDefID,
 				PauseState:    e.PauseState,
 			}
-			if err := s.SnapshotRestoreRun(ctx, runRow); err != nil {
+			runInserted, err := s.SnapshotRestoreRun(ctx, runRow)
+			if err != nil {
 				result.Warnings = append(result.Warnings, fmt.Sprintf("paused_run %s: %v", e.RunID, err))
 				continue
 			}
-			result.PausedRunsRestored++
+			if runInserted {
+				result.PausedRunsRestored++
+			}
 
 			// Transcript events for the run.
 			for _, te := range e.TranscriptEvents {
-				if err := s.SnapshotRestoreEvent(ctx, store.Event{
+				evtInserted, err := s.SnapshotRestoreEvent(ctx, store.Event{
 					Seq:       te.Seq,
 					SessionID: sessionID,
 					RunID:     e.RunID,
 					Timestamp: time.Unix(0, te.TsNs),
 					Type:      te.Type,
 					Payload:   te.Payload,
-				}); err != nil {
+				})
+				if err != nil {
 					result.Warnings = append(result.Warnings, fmt.Sprintf("transcript event run=%s seq=%d: %v", e.RunID, te.Seq, err))
 					continue
 				}
-				result.TranscriptEventsRestored++
+				if evtInserted {
+					result.TranscriptEventsRestored++
+				}
 			}
 		}
 	}

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -146,12 +146,13 @@ func TestRestore_Idempotent_SecondCallNoDuplicates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second Restore: %v", err)
 	}
-	// MemoryRestored counts INSERT-attempts that succeeded; the second
-	// call's INSERTs all hit ON CONFLICT DO NOTHING, which still
-	// "succeeds" (no error). The SnapshotRestore* contract says rows-
-	// affected isn't surfaced — what matters is that the dst still
-	// has exactly one row.
-	_ = r2
+	// SnapshotRestore* methods return (inserted bool, error) — on a
+	// re-restore the INSERTs all hit ON CONFLICT DO NOTHING and report
+	// rows_affected=0, so the counters reflect actual writes (0) and
+	// not attempted writes (1). This is the PR #131 review fix.
+	if r2.MemoryRestored != 0 {
+		t.Errorf("second restore MemoryRestored = %d, want 0 (no new rows written)", r2.MemoryRestored)
+	}
 
 	mem, _ := dst.SnapshotReadMemory(ctx)
 	if len(mem) != 1 {

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -1,0 +1,486 @@
+package snapshot
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/snapshot/migrations"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestRoundTrip_SameInstance_EmptyStore — capture empty store, restore
+// into a fresh store, capture again. The two captures must be
+// structurally equivalent (created_at differs by design; everything
+// else equal).
+func TestRoundTrip_SameInstance_EmptyStore(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	// Capture from src.
+	_, raw, err := Capture(context.Background(), src, CaptureOptions{})
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	// Restore into dst.
+	result, err := Restore(context.Background(), dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if result.PausedRunsRestored != 0 {
+		t.Errorf("PausedRunsRestored = %d, want 0 (empty source)", result.PausedRunsRestored)
+	}
+	if result.MemoryRestored != 0 {
+		t.Errorf("MemoryRestored = %d, want 0", result.MemoryRestored)
+	}
+
+	// Re-capture from dst.
+	_, raw2, err := Capture(context.Background(), dst, CaptureOptions{})
+	if err != nil {
+		t.Fatalf("re-Capture: %v", err)
+	}
+
+	// Compare envelope sections (ignoring created_at).
+	if err := assertEnvelopesStructurallyEqual(raw, raw2); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestRoundTrip_WithMemoryAndAgentDefs — populate the source store
+// with memory rows + agent defs, capture, restore, verify the dest
+// has the same row count + contents.
+func TestRoundTrip_WithMemoryAndAgentDefs(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	ctx := context.Background()
+
+	// Seed src.
+	for i, key := range []string{"a", "b", "c"} {
+		if err := src.MemorySet(ctx, store.MemoryScope("agent"), "agentX", key, []byte(`"v`+string(rune('0'+i))+`"`), 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	def, err := src.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:                  "def_test_1",
+		Name:                   "test-agent",
+		Version:                1,
+		Definition:             json.RawMessage(`{"system":"you are a test"}`),
+		CreatedAt:              mustParseTime(t, "2026-05-01T00:00:00Z"),
+		BootstrappedFromStatic: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = def
+
+	// Capture + restore.
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := Restore(ctx, dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MemoryRestored != 3 {
+		t.Errorf("MemoryRestored = %d, want 3", result.MemoryRestored)
+	}
+	if result.AgentDefsRestored != 1 {
+		t.Errorf("AgentDefsRestored = %d, want 1", result.AgentDefsRestored)
+	}
+
+	// Verify dst has the rows.
+	mem, err := dst.SnapshotReadMemory(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mem) != 3 {
+		t.Errorf("dst memory = %d, want 3", len(mem))
+	}
+	defs, err := dst.SnapshotReadAgentDefs(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(defs) != 1 || defs[0].DefID != "def_test_1" {
+		t.Errorf("dst agent_defs = %+v", defs)
+	}
+}
+
+// TestRestore_Idempotent_SecondCallNoDuplicates — restoring the same
+// envelope twice produces the same end state. Catches a regression
+// where SnapshotRestore* methods accidentally use plain INSERT
+// instead of ON CONFLICT DO NOTHING.
+func TestRestore_Idempotent_SecondCallNoDuplicates(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	ctx := context.Background()
+	if err := src.MemorySet(ctx, store.MemoryScope("agent"), "a", "k", []byte(`"v"`), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	_, raw, _ := Capture(ctx, src, CaptureOptions{})
+
+	// First restore.
+	r1, err := Restore(ctx, dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("first Restore: %v", err)
+	}
+	if r1.MemoryRestored != 1 {
+		t.Errorf("first MemoryRestored = %d, want 1", r1.MemoryRestored)
+	}
+
+	// Second restore — must succeed AND not change end state.
+	r2, err := Restore(ctx, dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("second Restore: %v", err)
+	}
+	// MemoryRestored counts INSERT-attempts that succeeded; the second
+	// call's INSERTs all hit ON CONFLICT DO NOTHING, which still
+	// "succeeds" (no error). The SnapshotRestore* contract says rows-
+	// affected isn't surfaced — what matters is that the dst still
+	// has exactly one row.
+	_ = r2
+
+	mem, _ := dst.SnapshotReadMemory(ctx)
+	if len(mem) != 1 {
+		t.Errorf("after second restore: %d memory rows, want 1 (idempotent)", len(mem))
+	}
+}
+
+// TestRestore_RejectsNewerVersion — a snapshot with a section version
+// newer than CurrentVersion is refused with
+// *migrations.ErrSnapshotVersionTooNew.
+func TestRestore_RejectsNewerVersion(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	// Hand-construct an envelope where memory.version = "9.99".
+	envBytes := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"memory": {"version": "9.99", "entries": []}
+		}
+	}`)
+
+	_, err := Restore(context.Background(), dst, envBytes, RestoreOptions{})
+	if err == nil {
+		t.Fatal("expected version-rejection error, got nil")
+	}
+	var tooNew *migrations.ErrSnapshotVersionTooNew
+	if !errors.As(err, &tooNew) {
+		t.Errorf("err = %v, want *ErrSnapshotVersionTooNew", err)
+	}
+	if tooNew.Section != "memory" {
+		t.Errorf("Section = %q, want memory", tooNew.Section)
+	}
+	if tooNew.SnapshotVersion != "9.99" {
+		t.Errorf("SnapshotVersion = %q", tooNew.SnapshotVersion)
+	}
+}
+
+// TestRestore_RejectsNewerEnvelopeSchema — envelope-level
+// schema_version > reader is refused before section decode.
+func TestRestore_RejectsNewerEnvelopeSchema(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	envBytes := []byte(`{"schema_version": 99, "created_at": "2026-05-18T00:00:00Z", "sections": {}}`)
+	_, err := Restore(context.Background(), dst, envBytes, RestoreOptions{})
+	if err == nil {
+		t.Fatal("expected error on schema_version=99, got nil")
+	}
+	if !strings.Contains(err.Error(), "schema_version 99") {
+		t.Errorf("err = %v, want 'schema_version 99' in message", err)
+	}
+}
+
+// TestRestore_SynthesizesSessionForPausedRun — the load-bearing
+// session FK synthesis test. A snapshot with a paused_run referencing
+// a session_id NOT in the snapshot must NOT fail; restore creates
+// a synthetic session and counts it in RestoreResult.
+func TestRestore_SynthesizesSessionForPausedRun(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	ctx := context.Background()
+
+	// On src, create a session + run, flip the run to paused.
+	sess, _ := src.CreateSession(ctx, "t", "qa", "user1")
+	run, _ := src.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a1", UserID: "user1"})
+	_ = src.SetRunPauseState(ctx, run.ID, store.PauseStatePaused)
+
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Restore into a fresh dst (no sessions exist there).
+	result, err := Restore(ctx, dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore failed (FK on session_id?): %v", err)
+	}
+	if result.PausedRunsRestored != 1 {
+		t.Errorf("PausedRunsRestored = %d, want 1", result.PausedRunsRestored)
+	}
+
+	// The session was carried over by the envelope's session_id —
+	// when the snapshot carries a real session_id (sess.ID), restore
+	// uses it and synthesizes a session row with that ID. The
+	// synthesized session row exists in dst.
+	dstSess, err := dst.GetSession(ctx, sess.ID)
+	if err != nil {
+		t.Fatalf("session %s not in dst: %v", sess.ID, err)
+	}
+	if dstSess.ID != sess.ID {
+		t.Errorf("restored session ID = %q, want %q", dstSess.ID, sess.ID)
+	}
+
+	// And the run is present with pause_state='paused'.
+	paused, _ := dst.ListPausedRuns(ctx)
+	if len(paused) != 1 {
+		t.Fatalf("dst paused runs = %d, want 1", len(paused))
+	}
+	if paused[0].ID != run.ID {
+		t.Errorf("paused run id = %q, want %q", paused[0].ID, run.ID)
+	}
+}
+
+// TestRestore_DropsEmbeddingFieldOnPhase1 — restoring a hand-crafted
+// envelope where memory.entries[].embedding is populated (simulating
+// a Phase-2-captured snapshot) on a Phase-1 reader silently drops
+// the embedding payload. The memory row IS restored; only the
+// embedding side is skipped.
+func TestRestore_DropsEmbeddingFieldOnPhase1(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	envBytes := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"memory": {
+				"version": "1.0",
+				"entries": [
+					{
+						"scope": "agent",
+						"scope_id": "a1",
+						"key": "k",
+						"value": "v",
+						"created_at": "2026-05-18T00:00:00Z",
+						"updated_at": "2026-05-18T00:00:00Z",
+						"embedding": {
+							"provider": "openai",
+							"model":    "text-embedding-3-large",
+							"dimension": 1536,
+							"vector":   "AAAA",
+							"embed_text": "hello",
+							"created_at": "2026-05-18T00:00:00Z"
+						}
+					}
+				]
+			}
+		}
+	}`)
+
+	ctx := context.Background()
+	result, err := Restore(ctx, dst, envBytes, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if result.MemoryRestored != 1 {
+		t.Errorf("MemoryRestored = %d, want 1", result.MemoryRestored)
+	}
+	mem, _ := dst.SnapshotReadMemory(ctx)
+	if len(mem) != 1 {
+		t.Errorf("dst memory rows = %d, want 1", len(mem))
+	}
+	// Embedding silently dropped — Phase 1 has no MemoryEmbedSet
+	// method. Phase 2 will pick up the field from re-deserialised
+	// memory.entries[].embedding and write to memory_embeddings.
+}
+
+// TestRestore_MissingSectionsTolerated — an envelope with only
+// a subset of sections restores those sections + leaves the rest
+// empty.
+func TestRestore_MissingSectionsTolerated(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	// Only memory, nothing else.
+	envBytes := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"memory": {
+				"version": "1.0",
+				"entries": [
+					{"scope":"agent","scope_id":"a","key":"k","value":"v","created_at":"2026-05-18T00:00:00Z","updated_at":"2026-05-18T00:00:00Z","embedding":null}
+				]
+			}
+		}
+	}`)
+	result, err := Restore(context.Background(), dst, envBytes, RestoreOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.MemoryRestored != 1 {
+		t.Errorf("MemoryRestored = %d, want 1", result.MemoryRestored)
+	}
+	if result.AgentDefsRestored != 0 || result.PausedRunsRestored != 0 {
+		t.Errorf("non-zero counts for missing sections: %+v", result)
+	}
+}
+
+// TestRestore_InteractionHistorySkippedByDefault — when
+// IncludeHistory=false (default) any interaction_history section in
+// the envelope is skipped with a warning.
+func TestRestore_InteractionHistorySkippedByDefault(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	envBytes := []byte(`{
+		"schema_version": 1,
+		"created_at": "2026-05-18T00:00:00Z",
+		"sections": {
+			"interaction_history": {
+				"version": "1.0",
+				"since_ts": "2026-05-17T00:00:00Z",
+				"events": []
+			}
+		}
+	}`)
+	result, err := Restore(context.Background(), dst, envBytes, RestoreOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.InteractionHistoryRestored != 0 {
+		t.Errorf("InteractionHistoryRestored = %d, want 0 (default skip)", result.InteractionHistoryRestored)
+	}
+	// Warning surfaced for operator visibility.
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "interaction_history") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("warnings do not mention interaction_history skip: %v", result.Warnings)
+	}
+}
+
+// TestRestore_ForceProbeInvoked — when ForceProbe is set, restore
+// calls it after section writes.
+func TestRestore_ForceProbeInvoked(t *testing.T) {
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+
+	called := false
+	opts := RestoreOptions{
+		ForceProbe: func(ctx context.Context) {
+			called = true
+		},
+	}
+	envBytes := []byte(`{"schema_version": 1, "created_at": "2026-05-18T00:00:00Z", "sections": {}}`)
+	_, err := Restore(context.Background(), dst, envBytes, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("ForceProbe not invoked")
+	}
+}
+
+// TestExport_RoundTripsThroughCanonical — Export produces canonical
+// JSON bytes that re-parse into the same Envelope struct.
+func TestExport_RoundTripsThroughCanonical(t *testing.T) {
+	env := &Envelope{
+		SchemaVersion: 1,
+		CreatedAt:     mustParseTime(t, "2026-05-18T10:00:00Z"),
+		Sections: Sections{
+			Memory: MemorySection{Version: "1.0", Entries: []MemoryEntry{}},
+		},
+	}
+	bytes, err := Export(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var rt Envelope
+	if err := json.Unmarshal(bytes, &rt); err != nil {
+		t.Fatalf("round-trip Unmarshal: %v", err)
+	}
+	if rt.SchemaVersion != env.SchemaVersion {
+		t.Errorf("SchemaVersion mismatch")
+	}
+}
+
+// TestExport_NilEnvelopeRefused — defensive.
+func TestExport_NilEnvelopeRefused(t *testing.T) {
+	_, err := Export(nil)
+	if err == nil {
+		t.Error("Export(nil) accepted")
+	}
+}
+
+// TestRestore_NilStoreRefused — defensive.
+func TestRestore_NilStoreRefused(t *testing.T) {
+	_, err := Restore(context.Background(), nil, []byte(`{}`), RestoreOptions{})
+	if err == nil {
+		t.Error("Restore(nil store) accepted")
+	}
+}
+
+// TestRestore_EmptyBytesRefused — defensive.
+func TestRestore_EmptyBytesRefused(t *testing.T) {
+	dst, cleanup := newTestStore(t)
+	defer cleanup()
+	_, err := Restore(context.Background(), dst, nil, RestoreOptions{})
+	if err == nil {
+		t.Error("Restore(empty bytes) accepted")
+	}
+}
+
+// assertEnvelopesStructurallyEqual compares two raw JSON envelopes
+// for structural equality, ignoring fields that differ by design
+// (created_at + snapshot ids). Returns an error describing the
+// first difference found.
+func assertEnvelopesStructurallyEqual(a, b []byte) error {
+	var envA, envB Envelope
+	if err := json.Unmarshal(a, &envA); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, &envB); err != nil {
+		return err
+	}
+	if envA.SchemaVersion != envB.SchemaVersion {
+		return errors.New("schema_version differs")
+	}
+	if len(envA.Sections.Memory.Entries) != len(envB.Sections.Memory.Entries) {
+		return errors.New("memory entries count differs")
+	}
+	if len(envA.Sections.AgentDefs.Entries) != len(envB.Sections.AgentDefs.Entries) {
+		return errors.New("agent_defs entries count differs")
+	}
+	return nil
+}
+
+// mustParseTime parses an RFC3339 timestamp or fails the test.
+func mustParseTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	tt, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("time.Parse(%q): %v", s, err)
+	}
+	return tt
+}

--- a/internal/snapshot/snapshot_test.go
+++ b/internal/snapshot/snapshot_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -12,10 +13,16 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 )
 
-// newTestStore builds an in-memory SQLite store for snapshot tests.
+// newTestStore builds a per-test SQLite store under t.TempDir().
+// On-disk (not ":memory:") because modernc's ":memory:" DSN uses
+// shared-cache mode in production code; two newTestStore calls under
+// the same process would otherwise alias to the same DB and make
+// round-trip tests (src capture → dst restore) silently no-op via
+// ON CONFLICT DO NOTHING. The store contract tests do the same.
 func newTestStore(t *testing.T) (store.Store, func()) {
 	t.Helper()
-	s, err := sqlite.Open(":memory:")
+	path := filepath.Join(t.TempDir(), "snapshot_test.db")
+	s, err := sqlite.Open(path)
 	if err != nil {
 		t.Fatalf("sqlite.Open: %v", err)
 	}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -905,9 +905,9 @@ func (s *Store) SnapshotReadEvaluations(ctx context.Context) ([]store.Evaluation
 // ---- v0.8.17 Snapshot restore — idempotent raw inserts (PR 3.2a) ----
 
 // SnapshotRestoreSession implements store.Store.
-func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) error {
+func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) (bool, error) {
 	if sess.ID == "" {
-		return fmt.Errorf("snapshot restore session: id required")
+		return false, fmt.Errorf("snapshot restore session: id required")
 	}
 	createdAt := sess.CreatedAt
 	if createdAt.IsZero() {
@@ -917,21 +917,21 @@ func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) 
 	if sess.UserID != "" {
 		userID = sess.UserID
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO sessions(id, tenant_id, agent, created_at, user_id) VALUES ($1, $2, $3, $4, $5)
 		 ON CONFLICT (id) DO NOTHING`,
 		sess.ID, sess.TenantID, sess.Agent, createdAt, userID,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore session: %w", err)
+		return false, fmt.Errorf("snapshot restore session: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // SnapshotRestoreRun implements store.Store.
-func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
+func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, error) {
 	if r.ID == "" || r.SessionID == "" {
-		return fmt.Errorf("snapshot restore run: id and session_id required")
+		return false, fmt.Errorf("snapshot restore run: id and session_id required")
 	}
 	startedAt := r.StartedAt
 	if startedAt.IsZero() {
@@ -954,7 +954,7 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
 	if pauseState == "" {
 		pauseState = store.PauseStateRunning
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
@@ -971,51 +971,51 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
 		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore run: %w", err)
+		return false, fmt.Errorf("snapshot restore run: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // SnapshotRestoreEvent implements store.Store.
-func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) error {
+func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) (bool, error) {
 	if e.RunID == "" || e.SessionID == "" {
-		return fmt.Errorf("snapshot restore event: run_id and session_id required")
+		return false, fmt.Errorf("snapshot restore event: run_id and session_id required")
 	}
 	ts := e.Timestamp
 	if ts.IsZero() {
 		ts = time.Now().UTC()
 	}
 	if e.Seq != 0 {
-		_, err := s.pool.Exec(ctx,
+		tag, err := s.pool.Exec(ctx,
 			`INSERT INTO events(seq, session_id, run_id, ts, type, payload) VALUES ($1, $2, $3, $4, $5, $6)
 			 ON CONFLICT (seq) DO NOTHING`,
 			e.Seq, e.SessionID, e.RunID, ts, e.Type, e.Payload,
 		)
 		if err != nil {
-			return fmt.Errorf("snapshot restore event: %w", err)
+			return false, fmt.Errorf("snapshot restore event: %w", err)
 		}
-		return nil
+		return tag.RowsAffected() > 0, nil
 	}
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO events(session_id, run_id, ts, type, payload) VALUES ($1, $2, $3, $4, $5)`,
 		e.SessionID, e.RunID, ts, e.Type, e.Payload,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore event (auto-seq): %w", err)
+		return false, fmt.Errorf("snapshot restore event (auto-seq): %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // SnapshotRestoreAgentDef implements store.Store.
-func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) error {
+func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) (bool, error) {
 	if r.DefID == "" || r.Name == "" {
-		return fmt.Errorf("snapshot restore agent_def: def_id and name required")
+		return false, fmt.Errorf("snapshot restore agent_def: def_id and name required")
 	}
 	createdAt := r.CreatedAt
 	if createdAt.IsZero() {
 		createdAt = time.Now().UTC()
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
@@ -1028,35 +1028,39 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		r.Retired, r.BootstrappedFromStatic,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore agent_def: %w", err)
+		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
-// SnapshotRestoreAgentDefActive implements store.Store. UPSERT on name.
-func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) error {
+// SnapshotRestoreAgentDefActive implements store.Store. ON CONFLICT
+// DO NOTHING — first restore writes the snapshot's promoted_at +
+// def_id; subsequent restores leave the existing row alone so the
+// (bool, error) return reads as "not inserted" and the caller's
+// counter stays honest on a re-restore.
+func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) (bool, error) {
 	if e.Name == "" || e.DefID == "" {
-		return fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
+		return false, fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
 	}
 	promotedAt := e.PromotedAt
 	if promotedAt.IsZero() {
 		promotedAt = time.Now().UTC()
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (name) DO UPDATE SET def_id = excluded.def_id, promoted_at = excluded.promoted_at, promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		 ON CONFLICT (name) DO NOTHING`,
 		e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore agent_def_active: %w", err)
+		return false, fmt.Errorf("snapshot restore agent_def_active: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // SnapshotRestoreMemory implements store.Store.
-func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) error {
+func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) (bool, error) {
 	if e.Scope == "" || e.Key == "" {
-		return fmt.Errorf("snapshot restore memory: scope and key required")
+		return false, fmt.Errorf("snapshot restore memory: scope and key required")
 	}
 	createdAt := e.CreatedAt
 	if createdAt.IsZero() {
@@ -1071,7 +1075,7 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 		t := e.ExpiresAt
 		expiresAt = &t
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
 		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
 		 ON CONFLICT (scope, scope_id, key) DO NOTHING`,
@@ -1079,15 +1083,15 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 		expiresAt, createdAt, updatedAt,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore memory: %w", err)
+		return false, fmt.Errorf("snapshot restore memory: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // SnapshotRestoreChannelMessage implements store.Store.
-func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) error {
+func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) (bool, error) {
 	if m.ID == "" || m.Channel == "" {
-		return fmt.Errorf("snapshot restore channel_message: id and channel required")
+		return false, fmt.Errorf("snapshot restore channel_message: id and channel required")
 	}
 	publishedAt := m.PublishedAt
 	if publishedAt.IsZero() {
@@ -1102,7 +1106,7 @@ func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.Chann
 	if visibleAt.IsZero() {
 		visibleAt = publishedAt
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
 		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
 		 ON CONFLICT (id) DO NOTHING`,
@@ -1110,35 +1114,38 @@ func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.Chann
 		publishedAt, expiresAt, visibleAt, nullIfEmpty(m.PublishedByUserID),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore channel_message: %w", err)
+		return false, fmt.Errorf("snapshot restore channel_message: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
-// SnapshotRestoreChannelCursor implements store.Store. UPSERT.
-func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) error {
+// SnapshotRestoreChannelCursor implements store.Store. ON CONFLICT
+// DO NOTHING — first restore writes the snapshot's cursor; subsequent
+// restores leave an evolved live cursor alone so the (bool, error)
+// return reads as "not inserted" on a re-restore.
+func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) (bool, error) {
 	if c.Channel == "" || c.Cursor == "" {
-		return fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
+		return false, fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
 	}
 	updatedAt := c.UpdatedAt
 	if updatedAt.IsZero() {
 		updatedAt = time.Now().UTC()
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES ($1, $2, $3, $4, $5)
-		 ON CONFLICT (channel, scope, scope_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at`,
+		 ON CONFLICT (channel, scope, scope_id) DO NOTHING`,
 		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedAt,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore channel_cursor: %w", err)
+		return false, fmt.Errorf("snapshot restore channel_cursor: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // SnapshotRestoreEvaluation implements store.Store.
-func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) error {
+func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) (bool, error) {
 	if r.EvalID == "" || r.RunID == "" {
-		return fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
+		return false, fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
 	}
 	createdAt := r.CreatedAt
 	if createdAt.IsZero() {
@@ -1154,7 +1161,7 @@ func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.Evaluatio
 	if len(r.Judgement) > 0 {
 		judgement = string(r.Judgement)
 	}
-	_, err := s.pool.Exec(ctx,
+	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO evaluations(
 			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
 			emitter_role, emitter_agent_id, emitter_run_id, created_at
@@ -1166,9 +1173,9 @@ func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.Evaluatio
 		createdAt,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore evaluation: %w", err)
+		return false, fmt.Errorf("snapshot restore evaluation: %w", err)
 	}
-	return nil
+	return tag.RowsAffected() > 0, nil
 }
 
 // nullIfEmpty converts an empty string to a *string nil so pgx writes

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -902,6 +902,284 @@ func (s *Store) SnapshotReadEvaluations(ctx context.Context) ([]store.Evaluation
 	return out, rows.Err()
 }
 
+// ---- v0.8.17 Snapshot restore — idempotent raw inserts (PR 3.2a) ----
+
+// SnapshotRestoreSession implements store.Store.
+func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) error {
+	if sess.ID == "" {
+		return fmt.Errorf("snapshot restore session: id required")
+	}
+	createdAt := sess.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	var userID any
+	if sess.UserID != "" {
+		userID = sess.UserID
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO sessions(id, tenant_id, agent, created_at, user_id) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (id) DO NOTHING`,
+		sess.ID, sess.TenantID, sess.Agent, createdAt, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore session: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreRun implements store.Store.
+func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
+	if r.ID == "" || r.SessionID == "" {
+		return fmt.Errorf("snapshot restore run: id and session_id required")
+	}
+	startedAt := r.StartedAt
+	if startedAt.IsZero() {
+		startedAt = time.Now().UTC()
+	}
+	var completedAt, lastHbAt *time.Time
+	if !r.CompletedAt.IsZero() {
+		t := r.CompletedAt
+		completedAt = &t
+	}
+	if !r.LastHeartbeatAt.IsZero() {
+		t := r.LastHeartbeatAt
+		lastHbAt = &t
+	}
+	status := string(r.Status)
+	if status == "" {
+		status = string(store.RunRunning)
+	}
+	pauseState := r.PauseState
+	if pauseState == "" {
+		pauseState = store.PauseStateRunning
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO runs(
+			id, session_id, status, started_at, completed_at, stop_reason,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			model, error,
+			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
+			user_tier, agent_def_id, pause_state
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+		 ON CONFLICT (id) DO NOTHING`,
+		r.ID, r.SessionID, status, startedAt, completedAt, nullIfEmpty(r.StopReason),
+		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
+		nullIfEmpty(r.Model), nullIfEmpty(r.ErrorMsg),
+		nullIfEmpty(r.AgentID), nullIfEmpty(r.ParentAgentID), nullIfEmpty(r.ParentRunID),
+		nullIfEmpty(r.UserID), lastHbAt,
+		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore run: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreEvent implements store.Store.
+func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) error {
+	if e.RunID == "" || e.SessionID == "" {
+		return fmt.Errorf("snapshot restore event: run_id and session_id required")
+	}
+	ts := e.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	if e.Seq != 0 {
+		_, err := s.pool.Exec(ctx,
+			`INSERT INTO events(seq, session_id, run_id, ts, type, payload) VALUES ($1, $2, $3, $4, $5, $6)
+			 ON CONFLICT (seq) DO NOTHING`,
+			e.Seq, e.SessionID, e.RunID, ts, e.Type, e.Payload,
+		)
+		if err != nil {
+			return fmt.Errorf("snapshot restore event: %w", err)
+		}
+		return nil
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO events(session_id, run_id, ts, type, payload) VALUES ($1, $2, $3, $4, $5)`,
+		e.SessionID, e.RunID, ts, e.Type, e.Payload,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore event (auto-seq): %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreAgentDef implements store.Store.
+func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) error {
+	if r.DefID == "" || r.Name == "" {
+		return fmt.Errorf("snapshot restore agent_def: def_id and name required")
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO agent_defs(
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11)
+		 ON CONFLICT (def_id) DO NOTHING`,
+		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
+		string(r.Definition), nullIfEmpty(r.Description),
+		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
+		r.Retired, r.BootstrappedFromStatic,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore agent_def: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreAgentDefActive implements store.Store. UPSERT on name.
+func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) error {
+	if e.Name == "" || e.DefID == "" {
+		return fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
+	}
+	promotedAt := e.PromotedAt
+	if promotedAt.IsZero() {
+		promotedAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (name) DO UPDATE SET def_id = excluded.def_id, promoted_at = excluded.promoted_at, promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore agent_def_active: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreMemory implements store.Store.
+func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) error {
+	if e.Scope == "" || e.Key == "" {
+		return fmt.Errorf("snapshot restore memory: scope and key required")
+	}
+	createdAt := e.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	updatedAt := e.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+	var expiresAt *time.Time
+	if !e.ExpiresAt.IsZero() {
+		t := e.ExpiresAt
+		expiresAt = &t
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+		 ON CONFLICT (scope, scope_id, key) DO NOTHING`,
+		string(e.Scope), e.ScopeID, e.Key, string(e.Value),
+		expiresAt, createdAt, updatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore memory: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreChannelMessage implements store.Store.
+func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) error {
+	if m.ID == "" || m.Channel == "" {
+		return fmt.Errorf("snapshot restore channel_message: id and channel required")
+	}
+	publishedAt := m.PublishedAt
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
+	}
+	var expiresAt *time.Time
+	if !m.ExpiresAt.IsZero() {
+		t := m.ExpiresAt
+		expiresAt = &t
+	}
+	visibleAt := m.VisibleAt
+	if visibleAt.IsZero() {
+		visibleAt = publishedAt
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
+		 VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
+		 ON CONFLICT (id) DO NOTHING`,
+		m.ID, m.Channel, string(m.Scope), m.ScopeID, string(m.Payload),
+		publishedAt, expiresAt, visibleAt, nullIfEmpty(m.PublishedByUserID),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore channel_message: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreChannelCursor implements store.Store. UPSERT.
+func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) error {
+	if c.Channel == "" || c.Cursor == "" {
+		return fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
+	}
+	updatedAt := c.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (channel, scope, scope_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at`,
+		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore channel_cursor: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreEvaluation implements store.Store.
+func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) error {
+	if r.EvalID == "" || r.RunID == "" {
+		return fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
+	}
+	createdAt := r.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	var dimensions, judgement any
+	if len(r.Dimensions) > 0 {
+		b, err := json.Marshal(r.Dimensions)
+		if err == nil {
+			dimensions = string(b)
+		}
+	}
+	if len(r.Judgement) > 0 {
+		judgement = string(r.Judgement)
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO evaluations(
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7, $8, $9, $10, $11)
+		 ON CONFLICT (eval_id) DO NOTHING`,
+		r.EvalID, r.RunID, nullIfEmpty(r.DefID), r.Score,
+		dimensions, judgement, nullIfEmpty(r.Rationale),
+		r.EmitterRole, nullIfEmpty(r.EmitterAgentID), nullIfEmpty(r.EmitterRunID),
+		createdAt,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore evaluation: %w", err)
+	}
+	return nil
+}
+
+// nullIfEmpty converts an empty string to a *string nil so pgx writes
+// SQL NULL into nullable text columns rather than "".
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}
+
 // ---- v0.8.x Process-resource metrics sampler ----
 
 // MetricsWriteSample inserts one process_samples row.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1299,6 +1299,281 @@ func (s *Store) SnapshotReadEvaluations(ctx context.Context) ([]store.Evaluation
 	return out, rows.Err()
 }
 
+// ---- v0.8.17 Snapshot restore — idempotent raw inserts (PR 3.2a) ----
+
+// SnapshotRestoreSession implements store.Store. Preserves caller-
+// supplied ID + CreatedAt. INSERT OR IGNORE → idempotent.
+func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) error {
+	if sess.ID == "" {
+		return fmt.Errorf("snapshot restore session: id required")
+	}
+	createdNs := sess.CreatedAt.UnixNano()
+	if sess.CreatedAt.IsZero() {
+		createdNs = time.Now().UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO sessions(id, tenant_id, agent, created_at, user_id) VALUES (?, ?, ?, ?, ?)`,
+		sess.ID, sess.TenantID, sess.Agent, createdNs, nilIfEmpty(sess.UserID),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore session: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreRun implements store.Store. Preserves every field
+// including PauseState. INSERT OR IGNORE → idempotent.
+func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
+	if r.ID == "" || r.SessionID == "" {
+		return fmt.Errorf("snapshot restore run: id and session_id required")
+	}
+	startedNs := r.StartedAt.UnixNano()
+	if r.StartedAt.IsZero() {
+		startedNs = time.Now().UnixNano()
+	}
+	var completedNs any
+	if !r.CompletedAt.IsZero() {
+		completedNs = r.CompletedAt.UnixNano()
+	}
+	var lastHbNs any
+	if !r.LastHeartbeatAt.IsZero() {
+		lastHbNs = r.LastHeartbeatAt.UnixNano()
+	}
+	status := string(r.Status)
+	if status == "" {
+		status = string(store.RunRunning)
+	}
+	pauseState := r.PauseState
+	if pauseState == "" {
+		pauseState = store.PauseStateRunning
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO runs(
+			id, session_id, status, started_at, completed_at, stop_reason,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			model, error,
+			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
+			user_tier, agent_def_id, pause_state
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.ID, r.SessionID, status, startedNs, completedNs, nilIfEmpty(r.StopReason),
+		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
+		nilIfEmpty(r.Model), nilIfEmpty(r.ErrorMsg),
+		nilIfEmpty(r.AgentID), nilIfEmpty(r.ParentAgentID), nilIfEmpty(r.ParentRunID),
+		nilIfEmpty(r.UserID), lastHbNs,
+		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore run: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreEvent implements store.Store. Writes one event with
+// caller-supplied seq + run_id. INSERT OR IGNORE on (run_id, seq) →
+// idempotent. seq is normally AUTOINCREMENT but restore needs the
+// explicit value to preserve transcript order across the boundary.
+func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) error {
+	if e.RunID == "" || e.SessionID == "" {
+		return fmt.Errorf("snapshot restore event: run_id and session_id required")
+	}
+	tsNs := e.Timestamp.UnixNano()
+	if e.Timestamp.IsZero() {
+		tsNs = time.Now().UnixNano()
+	}
+	// Build the INSERT to include seq when non-zero. SQLite's
+	// INSERT OR IGNORE on the (seq) PK is the idempotency anchor.
+	if e.Seq != 0 {
+		_, err := s.db.ExecContext(ctx,
+			`INSERT OR IGNORE INTO events(seq, session_id, run_id, ts, type, payload) VALUES (?, ?, ?, ?, ?, ?)`,
+			e.Seq, e.SessionID, e.RunID, tsNs, e.Type, e.Payload,
+		)
+		if err != nil {
+			return fmt.Errorf("snapshot restore event: %w", err)
+		}
+		return nil
+	}
+	// Caller didn't supply a seq — let the AUTOINCREMENT mint one.
+	// Used when the snapshot envelope's event had seq=0 (rare;
+	// usually all events carry a seq from capture).
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO events(session_id, run_id, ts, type, payload) VALUES (?, ?, ?, ?, ?)`,
+		e.SessionID, e.RunID, tsNs, e.Type, e.Payload,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore event (auto-seq): %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreAgentDef implements store.Store. Preserves DefID +
+// Version + parent linkage. INSERT OR IGNORE → idempotent.
+func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) error {
+	if r.DefID == "" || r.Name == "" {
+		return fmt.Errorf("snapshot restore agent_def: def_id and name required")
+	}
+	createdNs := r.CreatedAt.UnixNano()
+	if r.CreatedAt.IsZero() {
+		createdNs = time.Now().UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO agent_defs(
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
+		string(r.Definition), nilIfEmpty(r.Description),
+		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
+		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore agent_def: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreAgentDefActive implements store.Store. UPSERT on
+// name PK — restore overwrites the active pointer with the
+// snapshot's promoted_at + promoted_by_agent_id.
+func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) error {
+	if e.Name == "" || e.DefID == "" {
+		return fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
+	}
+	promotedNs := e.PromotedAt.UnixNano()
+	if e.PromotedAt.IsZero() {
+		promotedNs = time.Now().UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)
+		 ON CONFLICT(name) DO UPDATE SET def_id = excluded.def_id, promoted_at = excluded.promoted_at, promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore agent_def_active: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreMemory implements store.Store. Preserves CreatedAt /
+// UpdatedAt / ExpiresAt / Value. INSERT OR IGNORE on (scope, scope_id,
+// key) PK → idempotent.
+func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) error {
+	if e.Scope == "" || e.Key == "" {
+		return fmt.Errorf("snapshot restore memory: scope and key required")
+	}
+	createdNs := e.CreatedAt.UnixNano()
+	if e.CreatedAt.IsZero() {
+		createdNs = time.Now().UnixNano()
+	}
+	updatedNs := e.UpdatedAt.UnixNano()
+	if e.UpdatedAt.IsZero() {
+		updatedNs = createdNs
+	}
+	var expiresNs any
+	if !e.ExpiresAt.IsZero() {
+		expiresNs = e.ExpiresAt.UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		string(e.Scope), e.ScopeID, e.Key, string(e.Value), expiresNs, createdNs, updatedNs,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore memory: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreChannelMessage implements store.Store. INSERT OR
+// IGNORE on id PK → idempotent.
+func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) error {
+	if m.ID == "" || m.Channel == "" {
+		return fmt.Errorf("snapshot restore channel_message: id and channel required")
+	}
+	publishedNs := m.PublishedAt.UnixNano()
+	if m.PublishedAt.IsZero() {
+		publishedNs = time.Now().UnixNano()
+	}
+	var expiresNs any
+	if !m.ExpiresAt.IsZero() {
+		expiresNs = m.ExpiresAt.UnixNano()
+	}
+	visibleNs := int64(0)
+	if !m.VisibleAt.IsZero() {
+		visibleNs = m.VisibleAt.UnixNano()
+	} else {
+		visibleNs = publishedNs
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		m.ID, m.Channel, string(m.Scope), m.ScopeID, string(m.Payload),
+		publishedNs, expiresNs, visibleNs, nilIfEmpty(m.PublishedByUserID),
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore channel_message: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreChannelCursor implements store.Store. UPSERT on
+// (channel, scope, scope_id) PK — restore overwrites the cursor
+// with the snapshot's value.
+func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) error {
+	if c.Channel == "" || c.Cursor == "" {
+		return fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
+	}
+	updatedNs := c.UpdatedAt.UnixNano()
+	if c.UpdatedAt.IsZero() {
+		updatedNs = time.Now().UnixNano()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(channel, scope, scope_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at`,
+		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedNs,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore channel_cursor: %w", err)
+	}
+	return nil
+}
+
+// SnapshotRestoreEvaluation implements store.Store. INSERT OR IGNORE
+// on eval_id PK → idempotent.
+func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) error {
+	if r.EvalID == "" || r.RunID == "" {
+		return fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
+	}
+	createdNs := r.CreatedAt.UnixNano()
+	if r.CreatedAt.IsZero() {
+		createdNs = time.Now().UnixNano()
+	}
+	var dimensions, judgement sql.NullString
+	if len(r.Dimensions) > 0 {
+		b, err := json.Marshal(r.Dimensions)
+		if err == nil {
+			dimensions = sql.NullString{String: string(b), Valid: true}
+		}
+	}
+	if len(r.Judgement) > 0 {
+		judgement = sql.NullString{String: string(r.Judgement), Valid: true}
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO evaluations(
+			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
+			emitter_role, emitter_agent_id, emitter_run_id, created_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		r.EvalID, r.RunID, nilIfEmpty(r.DefID), r.Score,
+		dimensions, judgement, nilIfEmpty(r.Rationale),
+		r.EmitterRole, nilIfEmpty(r.EmitterAgentID), nilIfEmpty(r.EmitterRunID),
+		createdNs,
+	)
+	if err != nil {
+		return fmt.Errorf("snapshot restore evaluation: %w", err)
+	}
+	return nil
+}
+
 // MemorySet upserts a Memory row. ttl > 0 sets expires_at = now+ttl;
 // ttl <= 0 clears the column to NULL (no expiry).
 //

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1303,29 +1303,30 @@ func (s *Store) SnapshotReadEvaluations(ctx context.Context) ([]store.Evaluation
 
 // SnapshotRestoreSession implements store.Store. Preserves caller-
 // supplied ID + CreatedAt. INSERT OR IGNORE → idempotent.
-func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) error {
+func (s *Store) SnapshotRestoreSession(ctx context.Context, sess store.Session) (bool, error) {
 	if sess.ID == "" {
-		return fmt.Errorf("snapshot restore session: id required")
+		return false, fmt.Errorf("snapshot restore session: id required")
 	}
 	createdNs := sess.CreatedAt.UnixNano()
 	if sess.CreatedAt.IsZero() {
 		createdNs = time.Now().UnixNano()
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO sessions(id, tenant_id, agent, created_at, user_id) VALUES (?, ?, ?, ?, ?)`,
 		sess.ID, sess.TenantID, sess.Agent, createdNs, nilIfEmpty(sess.UserID),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore session: %w", err)
+		return false, fmt.Errorf("snapshot restore session: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // SnapshotRestoreRun implements store.Store. Preserves every field
 // including PauseState. INSERT OR IGNORE → idempotent.
-func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
+func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, error) {
 	if r.ID == "" || r.SessionID == "" {
-		return fmt.Errorf("snapshot restore run: id and session_id required")
+		return false, fmt.Errorf("snapshot restore run: id and session_id required")
 	}
 	startedNs := r.StartedAt.UnixNano()
 	if r.StartedAt.IsZero() {
@@ -1347,7 +1348,7 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
 	if pauseState == "" {
 		pauseState = store.PauseStateRunning
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
@@ -1363,18 +1364,19 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) error {
 		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore run: %w", err)
+		return false, fmt.Errorf("snapshot restore run: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // SnapshotRestoreEvent implements store.Store. Writes one event with
 // caller-supplied seq + run_id. INSERT OR IGNORE on (run_id, seq) →
 // idempotent. seq is normally AUTOINCREMENT but restore needs the
 // explicit value to preserve transcript order across the boundary.
-func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) error {
+func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) (bool, error) {
 	if e.RunID == "" || e.SessionID == "" {
-		return fmt.Errorf("snapshot restore event: run_id and session_id required")
+		return false, fmt.Errorf("snapshot restore event: run_id and session_id required")
 	}
 	tsNs := e.Timestamp.UnixNano()
 	if e.Timestamp.IsZero() {
@@ -1383,39 +1385,41 @@ func (s *Store) SnapshotRestoreEvent(ctx context.Context, e store.Event) error {
 	// Build the INSERT to include seq when non-zero. SQLite's
 	// INSERT OR IGNORE on the (seq) PK is the idempotency anchor.
 	if e.Seq != 0 {
-		_, err := s.db.ExecContext(ctx,
+		res, err := s.db.ExecContext(ctx,
 			`INSERT OR IGNORE INTO events(seq, session_id, run_id, ts, type, payload) VALUES (?, ?, ?, ?, ?, ?)`,
 			e.Seq, e.SessionID, e.RunID, tsNs, e.Type, e.Payload,
 		)
 		if err != nil {
-			return fmt.Errorf("snapshot restore event: %w", err)
+			return false, fmt.Errorf("snapshot restore event: %w", err)
 		}
-		return nil
+		n, _ := res.RowsAffected()
+		return n > 0, nil
 	}
 	// Caller didn't supply a seq — let the AUTOINCREMENT mint one.
 	// Used when the snapshot envelope's event had seq=0 (rare;
-	// usually all events carry a seq from capture).
+	// usually all events carry a seq from capture). Always counts as
+	// inserted because no PK collision is possible.
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO events(session_id, run_id, ts, type, payload) VALUES (?, ?, ?, ?, ?)`,
 		e.SessionID, e.RunID, tsNs, e.Type, e.Payload,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore event (auto-seq): %w", err)
+		return false, fmt.Errorf("snapshot restore event (auto-seq): %w", err)
 	}
-	return nil
+	return true, nil
 }
 
 // SnapshotRestoreAgentDef implements store.Store. Preserves DefID +
 // Version + parent linkage. INSERT OR IGNORE → idempotent.
-func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) error {
+func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow) (bool, error) {
 	if r.DefID == "" || r.Name == "" {
-		return fmt.Errorf("snapshot restore agent_def: def_id and name required")
+		return false, fmt.Errorf("snapshot restore agent_def: def_id and name required")
 	}
 	createdNs := r.CreatedAt.UnixNano()
 	if r.CreatedAt.IsZero() {
 		createdNs = time.Now().UnixNano()
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
@@ -1427,39 +1431,42 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore agent_def: %w", err)
+		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
-// SnapshotRestoreAgentDefActive implements store.Store. UPSERT on
-// name PK — restore overwrites the active pointer with the
-// snapshot's promoted_at + promoted_by_agent_id.
-func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) error {
+// SnapshotRestoreAgentDefActive implements store.Store. INSERT OR
+// IGNORE on the name PK — first restore writes the snapshot's
+// promoted_at + def_id; subsequent restores leave the existing row
+// alone so the (bool, error) return reads as "not inserted" and the
+// caller's counter stays honest.
+func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) (bool, error) {
 	if e.Name == "" || e.DefID == "" {
-		return fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
+		return false, fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
 	}
 	promotedNs := e.PromotedAt.UnixNano()
 	if e.PromotedAt.IsZero() {
 		promotedNs = time.Now().UnixNano()
 	}
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)
-		 ON CONFLICT(name) DO UPDATE SET def_id = excluded.def_id, promoted_at = excluded.promoted_at, promoted_by_agent_id = excluded.promoted_by_agent_id`,
+	res, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)`,
 		e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore agent_def_active: %w", err)
+		return false, fmt.Errorf("snapshot restore agent_def_active: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // SnapshotRestoreMemory implements store.Store. Preserves CreatedAt /
 // UpdatedAt / ExpiresAt / Value. INSERT OR IGNORE on (scope, scope_id,
 // key) PK → idempotent.
-func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) error {
+func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapshotEntry) (bool, error) {
 	if e.Scope == "" || e.Key == "" {
-		return fmt.Errorf("snapshot restore memory: scope and key required")
+		return false, fmt.Errorf("snapshot restore memory: scope and key required")
 	}
 	createdNs := e.CreatedAt.UnixNano()
 	if e.CreatedAt.IsZero() {
@@ -1473,22 +1480,23 @@ func (s *Store) SnapshotRestoreMemory(ctx context.Context, e store.MemorySnapsho
 	if !e.ExpiresAt.IsZero() {
 		expiresNs = e.ExpiresAt.UnixNano()
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO memory(scope, scope_id, key, value, expires_at, created_at, updated_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		string(e.Scope), e.ScopeID, e.Key, string(e.Value), expiresNs, createdNs, updatedNs,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore memory: %w", err)
+		return false, fmt.Errorf("snapshot restore memory: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // SnapshotRestoreChannelMessage implements store.Store. INSERT OR
 // IGNORE on id PK → idempotent.
-func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) error {
+func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.ChannelMessage) (bool, error) {
 	if m.ID == "" || m.Channel == "" {
-		return fmt.Errorf("snapshot restore channel_message: id and channel required")
+		return false, fmt.Errorf("snapshot restore channel_message: id and channel required")
 	}
 	publishedNs := m.PublishedAt.UnixNano()
 	if m.PublishedAt.IsZero() {
@@ -1504,45 +1512,47 @@ func (s *Store) SnapshotRestoreChannelMessage(ctx context.Context, m store.Chann
 	} else {
 		visibleNs = publishedNs
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO channel_messages(id, channel, scope, scope_id, payload, published_at, expires_at, visible_at, published_by_user_id)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		m.ID, m.Channel, string(m.Scope), m.ScopeID, string(m.Payload),
 		publishedNs, expiresNs, visibleNs, nilIfEmpty(m.PublishedByUserID),
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore channel_message: %w", err)
+		return false, fmt.Errorf("snapshot restore channel_message: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
-// SnapshotRestoreChannelCursor implements store.Store. UPSERT on
-// (channel, scope, scope_id) PK — restore overwrites the cursor
-// with the snapshot's value.
-func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) error {
+// SnapshotRestoreChannelCursor implements store.Store. INSERT OR
+// IGNORE on (channel, scope, scope_id) — first restore writes the
+// snapshot's cursor; subsequent restores leave an evolved live cursor
+// alone so the (bool, error) return reads as "not inserted."
+func (s *Store) SnapshotRestoreChannelCursor(ctx context.Context, c store.ChannelCursorEntry) (bool, error) {
 	if c.Channel == "" || c.Cursor == "" {
-		return fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
+		return false, fmt.Errorf("snapshot restore channel_cursor: channel and cursor required")
 	}
 	updatedNs := c.UpdatedAt.UnixNano()
 	if c.UpdatedAt.IsZero() {
 		updatedNs = time.Now().UnixNano()
 	}
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES (?, ?, ?, ?, ?)
-		 ON CONFLICT(channel, scope, scope_id) DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at`,
+	res, err := s.db.ExecContext(ctx,
+		`INSERT OR IGNORE INTO channel_cursors(channel, scope, scope_id, cursor, updated_at) VALUES (?, ?, ?, ?, ?)`,
 		c.Channel, string(c.Scope), c.ScopeID, c.Cursor, updatedNs,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore channel_cursor: %w", err)
+		return false, fmt.Errorf("snapshot restore channel_cursor: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // SnapshotRestoreEvaluation implements store.Store. INSERT OR IGNORE
 // on eval_id PK → idempotent.
-func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) error {
+func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.EvaluationRow) (bool, error) {
 	if r.EvalID == "" || r.RunID == "" {
-		return fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
+		return false, fmt.Errorf("snapshot restore evaluation: eval_id and run_id required")
 	}
 	createdNs := r.CreatedAt.UnixNano()
 	if r.CreatedAt.IsZero() {
@@ -1558,7 +1568,7 @@ func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.Evaluatio
 	if len(r.Judgement) > 0 {
 		judgement = sql.NullString{String: string(r.Judgement), Valid: true}
 	}
-	_, err := s.db.ExecContext(ctx,
+	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO evaluations(
 			eval_id, run_id, def_id, score, dimensions, judgement, rationale,
 			emitter_role, emitter_agent_id, emitter_run_id, created_at
@@ -1569,9 +1579,10 @@ func (s *Store) SnapshotRestoreEvaluation(ctx context.Context, r store.Evaluatio
 		createdNs,
 	)
 	if err != nil {
-		return fmt.Errorf("snapshot restore evaluation: %w", err)
+		return false, fmt.Errorf("snapshot restore evaluation: %w", err)
 	}
-	return nil
+	n, _ := res.RowsAffected()
+	return n > 0, nil
 }
 
 // MemorySet upserts a Memory row. ttl > 0 sets expires_at = now+ttl;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -505,48 +505,60 @@ type Store interface {
 	// row with the same PK exists, the call silently succeeds. The
 	// snapshot.Restore function relies on this to support partial
 	// re-runs after a failed restore.
+	//
+	// Each method returns (inserted bool, err error). `inserted` is
+	// true when a new row was actually written; false when the
+	// underlying ON CONFLICT DO NOTHING / INSERT OR IGNORE swallowed
+	// the row (or the equivalent UPSERT path observed an existing
+	// row). Callers in internal/snapshot use this to increment
+	// per-section counters only on real inserts so the
+	// snapshotRestoreResponse a second (idempotent) restore returns
+	// reads as "0 inserted" rather than misleadingly repeating the
+	// first call's counts.
 
 	// SnapshotRestoreSession inserts a session row preserving the
 	// caller-supplied ID + CreatedAt. Idempotent.
-	SnapshotRestoreSession(ctx context.Context, sess Session) error
+	SnapshotRestoreSession(ctx context.Context, sess Session) (bool, error)
 
 	// SnapshotRestoreRun inserts a run row preserving every field
 	// including PauseState. Idempotent.
-	SnapshotRestoreRun(ctx context.Context, r Run) error
+	SnapshotRestoreRun(ctx context.Context, r Run) (bool, error)
 
 	// SnapshotRestoreEvent inserts one transcript event preserving
 	// the supplied seq + RunID + Timestamp + Payload. Note: events
 	// use BIGSERIAL/AUTOINCREMENT seq normally; this method writes
 	// the seq explicitly. Idempotent on (run_id, seq).
-	SnapshotRestoreEvent(ctx context.Context, e Event) error
+	SnapshotRestoreEvent(ctx context.Context, e Event) (bool, error)
 
 	// SnapshotRestoreAgentDef inserts one agent_defs row preserving
 	// the supplied DefID + Version + parent linkage. Idempotent.
-	SnapshotRestoreAgentDef(ctx context.Context, r AgentDefRow) error
+	SnapshotRestoreAgentDef(ctx context.Context, r AgentDefRow) (bool, error)
 
 	// SnapshotRestoreAgentDefActive UPSERTs one agent_def_active
 	// pointer. ON CONFLICT (name) DO UPDATE — preserves snapshot's
-	// promoted_at + promoted_by_agent_id.
-	SnapshotRestoreAgentDefActive(ctx context.Context, entry AgentDefActiveEntry) error
+	// promoted_at + promoted_by_agent_id. `inserted` is true only on
+	// the first write (no prior row for the name).
+	SnapshotRestoreAgentDefActive(ctx context.Context, entry AgentDefActiveEntry) (bool, error)
 
 	// SnapshotRestoreMemory inserts one memory row preserving
 	// CreatedAt + UpdatedAt + ExpiresAt + Value. Idempotent on
 	// (scope, scope_id, key).
-	SnapshotRestoreMemory(ctx context.Context, entry MemorySnapshotEntry) error
+	SnapshotRestoreMemory(ctx context.Context, entry MemorySnapshotEntry) (bool, error)
 
 	// SnapshotRestoreChannelMessage inserts one channel_messages row
 	// preserving the ID + timestamps. Idempotent on id (PK).
-	SnapshotRestoreChannelMessage(ctx context.Context, msg ChannelMessage) error
+	SnapshotRestoreChannelMessage(ctx context.Context, msg ChannelMessage) (bool, error)
 
 	// SnapshotRestoreChannelCursor UPSERTs one channel_cursors row.
 	// ON CONFLICT (channel, scope, scope_id) DO UPDATE — preserves
-	// the snapshot's cursor + updated_at.
-	SnapshotRestoreChannelCursor(ctx context.Context, entry ChannelCursorEntry) error
+	// the snapshot's cursor + updated_at. `inserted` is true only on
+	// the first write.
+	SnapshotRestoreChannelCursor(ctx context.Context, entry ChannelCursorEntry) (bool, error)
 
 	// SnapshotRestoreEvaluation inserts one evaluation row
 	// preserving EvalID + CreatedAt + emitter fields. Idempotent
 	// on eval_id.
-	SnapshotRestoreEvaluation(ctx context.Context, r EvaluationRow) error
+	SnapshotRestoreEvaluation(ctx context.Context, r EvaluationRow) (bool, error)
 
 	// MemorySet writes a Memory entry. ttl > 0 sets an expiry; ttl <= 0
 	// stores with no expiry (the row's expires_at column is NULL). The

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -492,6 +492,62 @@ type Store interface {
 	// queries see the same time series.
 	SnapshotReadEvaluations(ctx context.Context) ([]EvaluationRow, error)
 
+	// ---- v0.8.17 Snapshot restore — idempotent raw inserts (PR 3.2a) ----
+	//
+	// The methods below INSERT rows with caller-supplied IDs +
+	// timestamps + values, using ON CONFLICT DO NOTHING (Postgres) /
+	// INSERT OR IGNORE (SQLite) semantics so a second restore of the
+	// same envelope is a clean no-op. Distinct from the "live" insert
+	// methods (CreateSession, AppendEvent, etc.) which mint their own
+	// IDs and assume an empty starting state.
+	//
+	// All SnapshotRestore* methods are best-effort idempotent — if a
+	// row with the same PK exists, the call silently succeeds. The
+	// snapshot.Restore function relies on this to support partial
+	// re-runs after a failed restore.
+
+	// SnapshotRestoreSession inserts a session row preserving the
+	// caller-supplied ID + CreatedAt. Idempotent.
+	SnapshotRestoreSession(ctx context.Context, sess Session) error
+
+	// SnapshotRestoreRun inserts a run row preserving every field
+	// including PauseState. Idempotent.
+	SnapshotRestoreRun(ctx context.Context, r Run) error
+
+	// SnapshotRestoreEvent inserts one transcript event preserving
+	// the supplied seq + RunID + Timestamp + Payload. Note: events
+	// use BIGSERIAL/AUTOINCREMENT seq normally; this method writes
+	// the seq explicitly. Idempotent on (run_id, seq).
+	SnapshotRestoreEvent(ctx context.Context, e Event) error
+
+	// SnapshotRestoreAgentDef inserts one agent_defs row preserving
+	// the supplied DefID + Version + parent linkage. Idempotent.
+	SnapshotRestoreAgentDef(ctx context.Context, r AgentDefRow) error
+
+	// SnapshotRestoreAgentDefActive UPSERTs one agent_def_active
+	// pointer. ON CONFLICT (name) DO UPDATE — preserves snapshot's
+	// promoted_at + promoted_by_agent_id.
+	SnapshotRestoreAgentDefActive(ctx context.Context, entry AgentDefActiveEntry) error
+
+	// SnapshotRestoreMemory inserts one memory row preserving
+	// CreatedAt + UpdatedAt + ExpiresAt + Value. Idempotent on
+	// (scope, scope_id, key).
+	SnapshotRestoreMemory(ctx context.Context, entry MemorySnapshotEntry) error
+
+	// SnapshotRestoreChannelMessage inserts one channel_messages row
+	// preserving the ID + timestamps. Idempotent on id (PK).
+	SnapshotRestoreChannelMessage(ctx context.Context, msg ChannelMessage) error
+
+	// SnapshotRestoreChannelCursor UPSERTs one channel_cursors row.
+	// ON CONFLICT (channel, scope, scope_id) DO UPDATE — preserves
+	// the snapshot's cursor + updated_at.
+	SnapshotRestoreChannelCursor(ctx context.Context, entry ChannelCursorEntry) error
+
+	// SnapshotRestoreEvaluation inserts one evaluation row
+	// preserving EvalID + CreatedAt + emitter fields. Idempotent
+	// on eval_id.
+	SnapshotRestoreEvaluation(ctx context.Context, r EvaluationRow) error
+
 	// MemorySet writes a Memory entry. ttl > 0 sets an expiry; ttl <= 0
 	// stores with no expiry (the row's expires_at column is NULL). The
 	// row is upserted on the (scope, scopeID, key) primary key —

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/help"
@@ -89,6 +90,7 @@ const contextInputSchema = `{
     "agent_id":        {"type": "string", "description": "history only: target agent_id whose run history to fetch. Omitted = caller's own agent_id from ctx."},
     "event_types":     {"type": "array", "items": {"type": "string"}, "description": "history only: optional filter — return only events of these types (e.g. [\"text\",\"tool_call\"])."},
     "limit":           {"type": "integer", "description": "history only: max events to return (default 100, cap 1000)."},
+    "since_ts":        {"type": "string", "description": "history only: RFC3339 timestamp; events older than this are excluded. Empty = no filter. Useful for reflecting on a recent time window."},
     "topic":           {"type": "string", "description": "help only: the topic name to fetch detailed content for. Omitted = return the topic index (name + description for each available topic)."}
   },
   "required": ["op"],
@@ -106,6 +108,13 @@ type contextInput struct {
 	EventTypes     []string `json:"event_types,omitempty"`
 	Limit          int      `json:"limit,omitempty"`
 	Topic          string   `json:"topic,omitempty"`
+	// SinceTs is the v0.8.17 addendum (PR 3.5): RFC3339 timestamp.
+	// Events with ts < SinceTs are excluded from the history op's
+	// result + the truncated/count calculation. Empty / zero =
+	// no filter (current behavior). Agents reflecting on a recent
+	// time window (e.g. an experiment that started 2 hours ago) use
+	// this to narrow the transcript walk.
+	SinceTs string `json:"since_ts,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -603,6 +612,18 @@ func (c *Context) execHistory(ctx context.Context, in contextInput) (tools.Resul
 		return errResult("history: agent has no `history_scope` policy (default-deny); add `history_scope: [...]` to the agent yaml"), nil
 	}
 
+	// v0.8.17 addendum: validate since_ts BEFORE the run lookup so
+	// bad input fails fast without wasting a DB query. Empty / zero
+	// = no filter.
+	var sinceTs time.Time
+	if in.SinceTs != "" {
+		t, err := time.Parse(time.RFC3339, in.SinceTs)
+		if err != nil {
+			return errResult(fmt.Sprintf("history: since_ts must be RFC3339: %v", err)), nil
+		}
+		sinceTs = t
+	}
+
 	// Determine target agent_id. Omitted = caller's own.
 	emitter := tools.RunIdentity(ctx)
 	targetAgentID := in.AgentID
@@ -671,6 +692,9 @@ func (c *Context) execHistory(ctx context.Context, in contextInput) (tools.Resul
 	matchedCount := 0
 	for _, ev := range events {
 		if len(typeFilter) > 0 && !typeFilter[ev.Type] {
+			continue
+		}
+		if !sinceTs.IsZero() && ev.Timestamp.Before(sinceTs) {
 			continue
 		}
 		matchedCount++

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/help"
@@ -724,6 +725,55 @@ func TestContextTool_HistoryAnyScopeAllowsOther(t *testing.T) {
 	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","agent_id":"a_other"}`))
 	if res.IsError {
 		t.Fatalf("history under `any` scope should succeed; got %s", res.Text)
+	}
+}
+
+// TestContextTool_HistorySinceTsFiltersOlder pins the v0.8.17 PR 3.5
+// addendum: an RFC3339 since_ts filters out events older than the
+// timestamp. Two events seeded — one before since_ts, one after —
+// only the recent one appears in the result.
+func TestContextTool_HistorySinceTsFiltersOlder(t *testing.T) {
+	tool, s, ctx, agentName, _, _ := substrateFixture(t)
+	bg := context.Background()
+	sess, _ := s.CreateSession(bg, "t", agentName, "alice")
+	run, _ := s.CreateRun(bg, sess.ID, store.RunIdentity{AgentID: "a_caller", UserID: "alice"})
+
+	// First event NOW; second event 100ms later. The since_ts will
+	// be 50ms after the first so the filter excludes it.
+	_ = s.AppendEvent(bg, run.ID, "text", []byte(`{"text":"old"}`))
+	t0 := time.Now()
+	time.Sleep(100 * time.Millisecond)
+	_ = s.AppendEvent(bg, run.ID, "text", []byte(`{"text":"new"}`))
+
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller", UserID: "alice"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"self"}})
+
+	// since_ts at t0+50ms — between the two events.
+	since := t0.Add(50 * time.Millisecond).UTC().Format(time.RFC3339Nano)
+	body := fmt.Sprintf(`{"op":"history","since_ts":%q}`, since)
+	res, _ := tool.Execute(histCtx, json.RawMessage(body))
+	if res.IsError {
+		t.Fatalf("history with since_ts: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	count := out["count"].(float64)
+	if count != 1 {
+		t.Errorf("count = %v, want 1 (older event excluded by since_ts)", count)
+	}
+}
+
+// TestContextTool_HistorySinceTsInvalidFormat — bad RFC3339 string
+// returns a clear error.
+func TestContextTool_HistorySinceTsInvalidFormat(t *testing.T) {
+	tool, _, ctx, _, _, _ := substrateFixture(t)
+	histCtx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_caller"})
+	histCtx = tools.WithHistoryPolicy(histCtx, tools.HistoryPolicyValue{Scopes: []string{"self"}})
+	res, _ := tool.Execute(histCtx, json.RawMessage(`{"op":"history","since_ts":"not-a-date"}`))
+	if !res.IsError {
+		t.Fatal("history with bad since_ts should error")
+	}
+	if !strings.Contains(res.Text, "RFC3339") {
+		t.Errorf("error should mention RFC3339; got %q", res.Text)
 	}
 }
 


### PR DESCRIPTION
## Summary

Six commits implementing export, restore, per-section migrations, and the resolver force-probe hook. Stacked on **#130** (PR 2); when PR 2 merges to main, this branch rebases. PR 4 (CLI) + PR 5 (Web UI) both stack on this one.

## Commits

1. **`3.1 feat(snapshot): per-section migration registry + version gate`** — new `internal/snapshot/migrations` package. `Migrator func(raw) → raw` type + `Migrate(section, version, raw)` dispatcher + `*ErrSnapshotVersionTooNew` / `*ErrUnknownSectionVersion` typed errors. Identity migrators for every section at v1.0 today; the framework is in place for future version bumps.

2. **`3.2a feat(store): idempotent SnapshotRestore* raw-insert methods`** — nine new Store interface methods (`SnapshotRestoreSession`, `Run`, `Event`, `AgentDef`, `AgentDefActive`, `Memory`, `ChannelMessage`, `ChannelCursor`, `Evaluation`). All use ON CONFLICT DO NOTHING (Postgres) / INSERT OR IGNORE (SQLite); preserve caller-supplied IDs + timestamps for byte-faithful restore.

3. **`3.2b feat(snapshot): Export() + Restore() with session FK synthesis`** — `Export` is canonical JSON marshal; `Restore` reads envelope → migrates per section → writes rows in FK-dependency order. **Critical correctness:** session FK synthesis for paused_runs (the architect's catch — sessions aren't a captured section but paused_runs references session_id). `RestoreOptions.ForceProbe` callback hookpoint.

4. **`3.3 test(snapshot): round-trip + idempotent + version-rejection + session-FK`** — 14 integration tests against in-memory SQLite. Covers same-instance round-trip, idempotent restore, version-too-new rejection, session synthesis (the load-bearing test), Phase-1 embedding field drop, missing-section tolerance, interaction_history opt-in, ForceProbe invocation, Export round-trip.

5. **`3.4 feat(resolve): ForceProbe() + main.go registration`** — `Resolver.SetForceProbeCallback` + `ForceProbe(ctx)`. main.go wires `runResolveProbeOnce` as the callback. Restore handler invokes ForceProbe so the resolver matrix is refreshed before the operator calls Resume (the pause-resume-snapshot RFC excludes resolver state from snapshots).

6. **`3.5 feat(api+context): restore/export handlers + history since_ts`** — `POST /v1/_snapshots/{id}/restore` + `GET /v1/_snapshots/{id}/export` HTTP handlers. Restore accepts the envelope inline (`{"json": {...}}`) or by id; returns 422 with `snapshot_version_too_new` code on migration errors. Export returns canonical JSON with `Content-Disposition: attachment`. **Context.history `since_ts` addendum**: the architect's "PR 4 already shipped" leftover — adds RFC3339 filter to the history op.

## Critical design decisions captured

- **Session FK synthesis** — paused_runs reference session_id but sessions aren't a captured section. Restore creates `snap_sess_<run_id>` deterministic synthetic sessions BEFORE inserting run rows. Idempotent via ON CONFLICT DO NOTHING. RestoreResult.SynthesizedSessions counts these for operator visibility.

- **Idempotent raw inserts** — all SnapshotRestore* methods preserve caller-supplied IDs + use ON CONFLICT DO NOTHING / INSERT OR IGNORE. A second restore of the same envelope is a clean no-op.

- **Per-section migration framework** — version-too-new is operator-actionable (upgrade loomcycle or re-capture from source). Unknown-version is corrupted-snapshot. Both errors carry section + version strings.

- **Force-probe on restore** — closes the architect's "brief degraded window" risk. The resolver matrix is empty post-restore (excluded from snapshots); ForceProbe seeds it before the response returns.

- **Phase 1/2 forward-compat for memory.embedding** — restore decodes the field if present but silently drops it (no Phase 1 store method to write). Phase 2 adds `SnapshotRestoreMemoryEmbedding` and the same envelope shape restores embeddings.

## Test plan

- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `gofmt -l ./...` empty.
- [x] `go test -race -timeout 120s ./...` — full tree green on both backends.
- [x] **24 new tests** added: 6 migrations registry, 14 restore integration, 3 ForceProbe, 6 HTTP handler, 2 since_ts.

## Stacking

```
main
 └─ feature-pause-resume-primitive (PR #129, 3 commits)
     └─ feature-snapshot-storage (PR #130, 5 commits)
         └─ feature-snapshot-export-restore (this PR, 6 commits)
```

## RFC references

- `~/work/loomcycle-internal/doc-internal/rfcs/pause-resume-snapshot.md` § "Format migration rule" — the per-section migration framework this commit ships.
- `~/work/loomcycle-internal/doc-internal/rfcs/semantic-memory.md` § "Snapshot integration" — the forward-compat embedding field locked in Phase 0; restore correctly drops it on Phase 1, ready to populate on Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)