### PR TITLE
feat(grpc): 9 RPC methods for pause/snapshot (PR 2 of 4, stacked on #136)

### DIFF
--- a/internal/api/grpc/loomcyclepb/loomcycle.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle.pb.go
@@ -1473,6 +1473,1128 @@ func (x *HealthResponse) GetUptimeSeconds() int64 {
 	return 0
 }
 
+type PauseRuntimeRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Wait-for-non-idempotent-tools cap, in milliseconds. 0 falls
+	// through to LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS (default 30 s).
+	// Clamped server-side at pause.MaxPauseTimeout (5 min).
+	TimeoutMs     int32 `protobuf:"varint,1,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *PauseRuntimeRequest) Reset() {
+	*x = PauseRuntimeRequest{}
+	mi := &file_loomcycle_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PauseRuntimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PauseRuntimeRequest) ProtoMessage() {}
+
+func (x *PauseRuntimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PauseRuntimeRequest.ProtoReflect.Descriptor instead.
+func (*PauseRuntimeRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *PauseRuntimeRequest) GetTimeoutMs() int32 {
+	if x != nil {
+		return x.TimeoutMs
+	}
+	return 0
+}
+
+type PauseRuntimeResponse struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	Status              string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"` // "paused"
+	DurationMs          int64                  `protobuf:"varint,2,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	ForceCancelledCount int32                  `protobuf:"varint,3,opt,name=force_cancelled_count,json=forceCancelledCount,proto3" json:"force_cancelled_count,omitempty"`
+	PausedRunsCount     int32                  `protobuf:"varint,4,opt,name=paused_runs_count,json=pausedRunsCount,proto3" json:"paused_runs_count,omitempty"`
+	Warnings            []string               `protobuf:"bytes,5,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *PauseRuntimeResponse) Reset() {
+	*x = PauseRuntimeResponse{}
+	mi := &file_loomcycle_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PauseRuntimeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PauseRuntimeResponse) ProtoMessage() {}
+
+func (x *PauseRuntimeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PauseRuntimeResponse.ProtoReflect.Descriptor instead.
+func (*PauseRuntimeResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *PauseRuntimeResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *PauseRuntimeResponse) GetDurationMs() int64 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *PauseRuntimeResponse) GetForceCancelledCount() int32 {
+	if x != nil {
+		return x.ForceCancelledCount
+	}
+	return 0
+}
+
+func (x *PauseRuntimeResponse) GetPausedRunsCount() int32 {
+	if x != nil {
+		return x.PausedRunsCount
+	}
+	return 0
+}
+
+func (x *PauseRuntimeResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
+type ResumeRuntimeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ResumeRuntimeRequest) Reset() {
+	*x = ResumeRuntimeRequest{}
+	mi := &file_loomcycle_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeRuntimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeRuntimeRequest) ProtoMessage() {}
+
+func (x *ResumeRuntimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeRuntimeRequest.ProtoReflect.Descriptor instead.
+func (*ResumeRuntimeRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{23}
+}
+
+type ResumeRuntimeResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Status          string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"` // "running"
+	ResumedRunCount int32                  `protobuf:"varint,2,opt,name=resumed_run_count,json=resumedRunCount,proto3" json:"resumed_run_count,omitempty"`
+	Warnings        []string               `protobuf:"bytes,3,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ResumeRuntimeResponse) Reset() {
+	*x = ResumeRuntimeResponse{}
+	mi := &file_loomcycle_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ResumeRuntimeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ResumeRuntimeResponse) ProtoMessage() {}
+
+func (x *ResumeRuntimeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ResumeRuntimeResponse.ProtoReflect.Descriptor instead.
+func (*ResumeRuntimeResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *ResumeRuntimeResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *ResumeRuntimeResponse) GetResumedRunCount() int32 {
+	if x != nil {
+		return x.ResumedRunCount
+	}
+	return 0
+}
+
+func (x *ResumeRuntimeResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
+type GetRuntimeStateRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRuntimeStateRequest) Reset() {
+	*x = GetRuntimeStateRequest{}
+	mi := &file_loomcycle_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRuntimeStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRuntimeStateRequest) ProtoMessage() {}
+
+func (x *GetRuntimeStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRuntimeStateRequest.ProtoReflect.Descriptor instead.
+func (*GetRuntimeStateRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{25}
+}
+
+type RuntimeStateResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Status         string                 `protobuf:"bytes,1,opt,name=status,proto3" json:"status,omitempty"` // "running" | "pausing" | "paused"
+	PausedAt       *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=paused_at,json=pausedAt,proto3" json:"paused_at,omitempty"`
+	PausedRunCount int32                  `protobuf:"varint,3,opt,name=paused_run_count,json=pausedRunCount,proto3" json:"paused_run_count,omitempty"`
+	SnapshotsCount int32                  `protobuf:"varint,4,opt,name=snapshots_count,json=snapshotsCount,proto3" json:"snapshots_count,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RuntimeStateResponse) Reset() {
+	*x = RuntimeStateResponse{}
+	mi := &file_loomcycle_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RuntimeStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RuntimeStateResponse) ProtoMessage() {}
+
+func (x *RuntimeStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RuntimeStateResponse.ProtoReflect.Descriptor instead.
+func (*RuntimeStateResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *RuntimeStateResponse) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *RuntimeStateResponse) GetPausedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.PausedAt
+	}
+	return nil
+}
+
+func (x *RuntimeStateResponse) GetPausedRunCount() int32 {
+	if x != nil {
+		return x.PausedRunCount
+	}
+	return 0
+}
+
+func (x *RuntimeStateResponse) GetSnapshotsCount() int32 {
+	if x != nil {
+		return x.SnapshotsCount
+	}
+	return 0
+}
+
+type CreateSnapshotRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	IncludeHistory bool                   `protobuf:"varint,1,opt,name=include_history,json=includeHistory,proto3" json:"include_history,omitempty"`
+	SinceTs        *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=since_ts,json=sinceTs,proto3" json:"since_ts,omitempty"`
+	Description    string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	// Override LOOMCYCLE_SNAPSHOT_MAX_BYTES for this call. 0 = default.
+	MaxBytes      int64 `protobuf:"varint,4,opt,name=max_bytes,json=maxBytes,proto3" json:"max_bytes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateSnapshotRequest) Reset() {
+	*x = CreateSnapshotRequest{}
+	mi := &file_loomcycle_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateSnapshotRequest) ProtoMessage() {}
+
+func (x *CreateSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*CreateSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *CreateSnapshotRequest) GetIncludeHistory() bool {
+	if x != nil {
+		return x.IncludeHistory
+	}
+	return false
+}
+
+func (x *CreateSnapshotRequest) GetSinceTs() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SinceTs
+	}
+	return nil
+}
+
+func (x *CreateSnapshotRequest) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *CreateSnapshotRequest) GetMaxBytes() int64 {
+	if x != nil {
+		return x.MaxBytes
+	}
+	return 0
+}
+
+// SnapshotDescriptor is the metadata-only view used by CreateSnapshot
+// + ListSnapshots. The full JSON envelope lives in GetSnapshot /
+// ExportSnapshot responses.
+type SnapshotDescriptor struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId      string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	CreatedAt       *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	SizeBytes       int64                  `protobuf:"varint,3,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	IncludesHistory bool                   `protobuf:"varint,4,opt,name=includes_history,json=includesHistory,proto3" json:"includes_history,omitempty"`
+	SinceTs         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=since_ts,json=sinceTs,proto3" json:"since_ts,omitempty"`
+	Description     string                 `protobuf:"bytes,6,opt,name=description,proto3" json:"description,omitempty"`
+	FormatVersion   string                 `protobuf:"bytes,7,opt,name=format_version,json=formatVersion,proto3" json:"format_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *SnapshotDescriptor) Reset() {
+	*x = SnapshotDescriptor{}
+	mi := &file_loomcycle_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotDescriptor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotDescriptor) ProtoMessage() {}
+
+func (x *SnapshotDescriptor) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotDescriptor.ProtoReflect.Descriptor instead.
+func (*SnapshotDescriptor) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *SnapshotDescriptor) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *SnapshotDescriptor) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *SnapshotDescriptor) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *SnapshotDescriptor) GetIncludesHistory() bool {
+	if x != nil {
+		return x.IncludesHistory
+	}
+	return false
+}
+
+func (x *SnapshotDescriptor) GetSinceTs() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SinceTs
+	}
+	return nil
+}
+
+func (x *SnapshotDescriptor) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *SnapshotDescriptor) GetFormatVersion() string {
+	if x != nil {
+		return x.FormatVersion
+	}
+	return ""
+}
+
+type ListSnapshotsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSnapshotsRequest) Reset() {
+	*x = ListSnapshotsRequest{}
+	mi := &file_loomcycle_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSnapshotsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSnapshotsRequest) ProtoMessage() {}
+
+func (x *ListSnapshotsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSnapshotsRequest.ProtoReflect.Descriptor instead.
+func (*ListSnapshotsRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{29}
+}
+
+type ListSnapshotsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Snapshots     []*SnapshotDescriptor  `protobuf:"bytes,1,rep,name=snapshots,proto3" json:"snapshots,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListSnapshotsResponse) Reset() {
+	*x = ListSnapshotsResponse{}
+	mi := &file_loomcycle_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListSnapshotsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListSnapshotsResponse) ProtoMessage() {}
+
+func (x *ListSnapshotsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListSnapshotsResponse.ProtoReflect.Descriptor instead.
+func (*ListSnapshotsResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *ListSnapshotsResponse) GetSnapshots() []*SnapshotDescriptor {
+	if x != nil {
+		return x.Snapshots
+	}
+	return nil
+}
+
+type GetSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetSnapshotRequest) Reset() {
+	*x = GetSnapshotRequest{}
+	mi := &file_loomcycle_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetSnapshotRequest) ProtoMessage() {}
+
+func (x *GetSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*GetSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *GetSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+// SnapshotEnvelope carries the full row including JSON content.
+// Distinct from ExportSnapshotResponse, which is operator-facing
+// "where did this land on the host" semantics.
+type SnapshotEnvelope struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	Description   string                 `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
+	FormatVersion string                 `protobuf:"bytes,4,opt,name=format_version,json=formatVersion,proto3" json:"format_version,omitempty"`
+	SizeBytes     int64                  `protobuf:"varint,5,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	// Canonical envelope bytes.
+	JsonContent   []byte `protobuf:"bytes,6,opt,name=json_content,json=jsonContent,proto3" json:"json_content,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SnapshotEnvelope) Reset() {
+	*x = SnapshotEnvelope{}
+	mi := &file_loomcycle_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SnapshotEnvelope) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SnapshotEnvelope) ProtoMessage() {}
+
+func (x *SnapshotEnvelope) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SnapshotEnvelope.ProtoReflect.Descriptor instead.
+func (*SnapshotEnvelope) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *SnapshotEnvelope) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *SnapshotEnvelope) GetCreatedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *SnapshotEnvelope) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *SnapshotEnvelope) GetFormatVersion() string {
+	if x != nil {
+		return x.FormatVersion
+	}
+	return ""
+}
+
+func (x *SnapshotEnvelope) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *SnapshotEnvelope) GetJsonContent() []byte {
+	if x != nil {
+		return x.JsonContent
+	}
+	return nil
+}
+
+type ExportSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExportSnapshotRequest) Reset() {
+	*x = ExportSnapshotRequest{}
+	mi := &file_loomcycle_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExportSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportSnapshotRequest) ProtoMessage() {}
+
+func (x *ExportSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*ExportSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *ExportSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type ExportSnapshotResponse struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	// file_path + checksum are populated when a transport materialises
+	// the export to disk first (CLI's --out flag). Otherwise empty —
+	// raw_json carries the canonical bytes directly.
+	FilePath      string `protobuf:"bytes,2,opt,name=file_path,json=filePath,proto3" json:"file_path,omitempty"`
+	Checksum      string `protobuf:"bytes,3,opt,name=checksum,proto3" json:"checksum,omitempty"`
+	SizeBytes     int64  `protobuf:"varint,4,opt,name=size_bytes,json=sizeBytes,proto3" json:"size_bytes,omitempty"`
+	RawJson       []byte `protobuf:"bytes,5,opt,name=raw_json,json=rawJson,proto3" json:"raw_json,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ExportSnapshotResponse) Reset() {
+	*x = ExportSnapshotResponse{}
+	mi := &file_loomcycle_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ExportSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ExportSnapshotResponse) ProtoMessage() {}
+
+func (x *ExportSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ExportSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*ExportSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ExportSnapshotResponse) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *ExportSnapshotResponse) GetFilePath() string {
+	if x != nil {
+		return x.FilePath
+	}
+	return ""
+}
+
+func (x *ExportSnapshotResponse) GetChecksum() string {
+	if x != nil {
+		return x.Checksum
+	}
+	return ""
+}
+
+func (x *ExportSnapshotResponse) GetSizeBytes() int64 {
+	if x != nil {
+		return x.SizeBytes
+	}
+	return 0
+}
+
+func (x *ExportSnapshotResponse) GetRawJson() []byte {
+	if x != nil {
+		return x.RawJson
+	}
+	return nil
+}
+
+type RestoreSnapshotRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exactly one of snapshot_id (same-instance lookup) or raw_json
+	// (cross-instance restore from inline bytes) must be non-empty.
+	// file_path restore is intentionally not supported on the gRPC
+	// surface — supply raw_json inline (CLI reads the file client-side).
+	SnapshotId     string `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	RawJson        []byte `protobuf:"bytes,2,opt,name=raw_json,json=rawJson,proto3" json:"raw_json,omitempty"`
+	IncludeHistory bool   `protobuf:"varint,3,opt,name=include_history,json=includeHistory,proto3" json:"include_history,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *RestoreSnapshotRequest) Reset() {
+	*x = RestoreSnapshotRequest{}
+	mi := &file_loomcycle_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSnapshotRequest) ProtoMessage() {}
+
+func (x *RestoreSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*RestoreSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *RestoreSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+func (x *RestoreSnapshotRequest) GetRawJson() []byte {
+	if x != nil {
+		return x.RawJson
+	}
+	return nil
+}
+
+func (x *RestoreSnapshotRequest) GetIncludeHistory() bool {
+	if x != nil {
+		return x.IncludeHistory
+	}
+	return false
+}
+
+type RestoreSnapshotResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Per-section counters. Reflect rows actually written
+	// (ON CONFLICT DO NOTHING — a re-restore reports 0 even though
+	// every per-row INSERT "succeeded").
+	AgentDefsRestored       int32 `protobuf:"varint,1,opt,name=agent_defs_restored,json=agentDefsRestored,proto3" json:"agent_defs_restored,omitempty"`
+	AgentDefActiveRestored  int32 `protobuf:"varint,2,opt,name=agent_def_active_restored,json=agentDefActiveRestored,proto3" json:"agent_def_active_restored,omitempty"`
+	MemoryRestored          int32 `protobuf:"varint,3,opt,name=memory_restored,json=memoryRestored,proto3" json:"memory_restored,omitempty"`
+	ChannelMessagesRestored int32 `protobuf:"varint,4,opt,name=channel_messages_restored,json=channelMessagesRestored,proto3" json:"channel_messages_restored,omitempty"`
+	ChannelCursorsRestored  int32 `protobuf:"varint,5,opt,name=channel_cursors_restored,json=channelCursorsRestored,proto3" json:"channel_cursors_restored,omitempty"`
+	EvaluationsRestored     int32 `protobuf:"varint,6,opt,name=evaluations_restored,json=evaluationsRestored,proto3" json:"evaluations_restored,omitempty"`
+	PausedRunsRestored      int32 `protobuf:"varint,7,opt,name=paused_runs_restored,json=pausedRunsRestored,proto3" json:"paused_runs_restored,omitempty"`
+	// Sessions synthesized for cross-instance restore (paused_runs
+	// reference session_ids; restore creates snap_sess_<run_id>
+	// entries deterministically when needed).
+	SynthesizedSessions        int32    `protobuf:"varint,8,opt,name=synthesized_sessions,json=synthesizedSessions,proto3" json:"synthesized_sessions,omitempty"`
+	TranscriptEventsRestored   int32    `protobuf:"varint,9,opt,name=transcript_events_restored,json=transcriptEventsRestored,proto3" json:"transcript_events_restored,omitempty"`
+	InteractionHistoryRestored int32    `protobuf:"varint,10,opt,name=interaction_history_restored,json=interactionHistoryRestored,proto3" json:"interaction_history_restored,omitempty"`
+	Warnings                   []string `protobuf:"bytes,11,rep,name=warnings,proto3" json:"warnings,omitempty"`
+	FormatMigrations           []string `protobuf:"bytes,12,rep,name=format_migrations,json=formatMigrations,proto3" json:"format_migrations,omitempty"`
+	unknownFields              protoimpl.UnknownFields
+	sizeCache                  protoimpl.SizeCache
+}
+
+func (x *RestoreSnapshotResponse) Reset() {
+	*x = RestoreSnapshotResponse{}
+	mi := &file_loomcycle_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RestoreSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RestoreSnapshotResponse) ProtoMessage() {}
+
+func (x *RestoreSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RestoreSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*RestoreSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *RestoreSnapshotResponse) GetAgentDefsRestored() int32 {
+	if x != nil {
+		return x.AgentDefsRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetAgentDefActiveRestored() int32 {
+	if x != nil {
+		return x.AgentDefActiveRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetMemoryRestored() int32 {
+	if x != nil {
+		return x.MemoryRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetChannelMessagesRestored() int32 {
+	if x != nil {
+		return x.ChannelMessagesRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetChannelCursorsRestored() int32 {
+	if x != nil {
+		return x.ChannelCursorsRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetEvaluationsRestored() int32 {
+	if x != nil {
+		return x.EvaluationsRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetPausedRunsRestored() int32 {
+	if x != nil {
+		return x.PausedRunsRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetSynthesizedSessions() int32 {
+	if x != nil {
+		return x.SynthesizedSessions
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetTranscriptEventsRestored() int32 {
+	if x != nil {
+		return x.TranscriptEventsRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetInteractionHistoryRestored() int32 {
+	if x != nil {
+		return x.InteractionHistoryRestored
+	}
+	return 0
+}
+
+func (x *RestoreSnapshotResponse) GetWarnings() []string {
+	if x != nil {
+		return x.Warnings
+	}
+	return nil
+}
+
+func (x *RestoreSnapshotResponse) GetFormatMigrations() []string {
+	if x != nil {
+		return x.FormatMigrations
+	}
+	return nil
+}
+
+type DeleteSnapshotRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	SnapshotId    string                 `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSnapshotRequest) Reset() {
+	*x = DeleteSnapshotRequest{}
+	mi := &file_loomcycle_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSnapshotRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSnapshotRequest) ProtoMessage() {}
+
+func (x *DeleteSnapshotRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSnapshotRequest.ProtoReflect.Descriptor instead.
+func (*DeleteSnapshotRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *DeleteSnapshotRequest) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
+type DeleteSnapshotResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Always true — DELETE is idempotent (returns ok whether or not
+	// the row existed; mirrors HTTP DELETE /v1/_snapshots/{id} = 204).
+	Deleted       bool   `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	SnapshotId    string `protobuf:"bytes,2,opt,name=snapshot_id,json=snapshotId,proto3" json:"snapshot_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DeleteSnapshotResponse) Reset() {
+	*x = DeleteSnapshotResponse{}
+	mi := &file_loomcycle_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeleteSnapshotResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteSnapshotResponse) ProtoMessage() {}
+
+func (x *DeleteSnapshotResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteSnapshotResponse.ProtoReflect.Descriptor instead.
+func (*DeleteSnapshotResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *DeleteSnapshotResponse) GetDeleted() bool {
+	if x != nil {
+		return x.Deleted
+	}
+	return false
+}
+
+func (x *DeleteSnapshotResponse) GetSnapshotId() string {
+	if x != nil {
+		return x.SnapshotId
+	}
+	return ""
+}
+
 var File_loomcycle_proto protoreflect.FileDescriptor
 
 const file_loomcycle_proto_rawDesc = "" +
@@ -1587,7 +2709,98 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\x02ok\x18\x01 \x01(\bR\x02ok\x12\x16\n" +
 	"\x06commit\x18\x02 \x01(\tR\x06commit\x12\x14\n" +
 	"\x05built\x18\x03 \x01(\tR\x05built\x12%\n" +
-	"\x0euptime_seconds\x18\x04 \x01(\x03R\ruptimeSeconds2\x8a\x04\n" +
+	"\x0euptime_seconds\x18\x04 \x01(\x03R\ruptimeSeconds\"4\n" +
+	"\x13PauseRuntimeRequest\x12\x1d\n" +
+	"\n" +
+	"timeout_ms\x18\x01 \x01(\x05R\ttimeoutMs\"\xcb\x01\n" +
+	"\x14PauseRuntimeResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1f\n" +
+	"\vduration_ms\x18\x02 \x01(\x03R\n" +
+	"durationMs\x122\n" +
+	"\x15force_cancelled_count\x18\x03 \x01(\x05R\x13forceCancelledCount\x12*\n" +
+	"\x11paused_runs_count\x18\x04 \x01(\x05R\x0fpausedRunsCount\x12\x1a\n" +
+	"\bwarnings\x18\x05 \x03(\tR\bwarnings\"\x16\n" +
+	"\x14ResumeRuntimeRequest\"w\n" +
+	"\x15ResumeRuntimeResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x12*\n" +
+	"\x11resumed_run_count\x18\x02 \x01(\x05R\x0fresumedRunCount\x12\x1a\n" +
+	"\bwarnings\x18\x03 \x03(\tR\bwarnings\"\x18\n" +
+	"\x16GetRuntimeStateRequest\"\xba\x01\n" +
+	"\x14RuntimeStateResponse\x12\x16\n" +
+	"\x06status\x18\x01 \x01(\tR\x06status\x127\n" +
+	"\tpaused_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\bpausedAt\x12(\n" +
+	"\x10paused_run_count\x18\x03 \x01(\x05R\x0epausedRunCount\x12'\n" +
+	"\x0fsnapshots_count\x18\x04 \x01(\x05R\x0esnapshotsCount\"\xb6\x01\n" +
+	"\x15CreateSnapshotRequest\x12'\n" +
+	"\x0finclude_history\x18\x01 \x01(\bR\x0eincludeHistory\x125\n" +
+	"\bsince_ts\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\asinceTs\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x12\x1b\n" +
+	"\tmax_bytes\x18\x04 \x01(\x03R\bmaxBytes\"\xba\x02\n" +
+	"\x12SnapshotDescriptor\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x129\n" +
+	"\n" +
+	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x03 \x01(\x03R\tsizeBytes\x12)\n" +
+	"\x10includes_history\x18\x04 \x01(\bR\x0fincludesHistory\x125\n" +
+	"\bsince_ts\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\asinceTs\x12 \n" +
+	"\vdescription\x18\x06 \x01(\tR\vdescription\x12%\n" +
+	"\x0eformat_version\x18\a \x01(\tR\rformatVersion\"\x16\n" +
+	"\x14ListSnapshotsRequest\"W\n" +
+	"\x15ListSnapshotsResponse\x12>\n" +
+	"\tsnapshots\x18\x01 \x03(\v2 .loomcycle.v1.SnapshotDescriptorR\tsnapshots\"5\n" +
+	"\x12GetSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"\xf9\x01\n" +
+	"\x10SnapshotEnvelope\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x129\n" +
+	"\n" +
+	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12 \n" +
+	"\vdescription\x18\x03 \x01(\tR\vdescription\x12%\n" +
+	"\x0eformat_version\x18\x04 \x01(\tR\rformatVersion\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x05 \x01(\x03R\tsizeBytes\x12!\n" +
+	"\fjson_content\x18\x06 \x01(\fR\vjsonContent\"8\n" +
+	"\x15ExportSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"\xac\x01\n" +
+	"\x16ExportSnapshotResponse\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x12\x1b\n" +
+	"\tfile_path\x18\x02 \x01(\tR\bfilePath\x12\x1a\n" +
+	"\bchecksum\x18\x03 \x01(\tR\bchecksum\x12\x1d\n" +
+	"\n" +
+	"size_bytes\x18\x04 \x01(\x03R\tsizeBytes\x12\x19\n" +
+	"\braw_json\x18\x05 \x01(\fR\arawJson\"}\n" +
+	"\x16RestoreSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\x12\x19\n" +
+	"\braw_json\x18\x02 \x01(\fR\arawJson\x12'\n" +
+	"\x0finclude_history\x18\x03 \x01(\bR\x0eincludeHistory\"\x84\x05\n" +
+	"\x17RestoreSnapshotResponse\x12.\n" +
+	"\x13agent_defs_restored\x18\x01 \x01(\x05R\x11agentDefsRestored\x129\n" +
+	"\x19agent_def_active_restored\x18\x02 \x01(\x05R\x16agentDefActiveRestored\x12'\n" +
+	"\x0fmemory_restored\x18\x03 \x01(\x05R\x0ememoryRestored\x12:\n" +
+	"\x19channel_messages_restored\x18\x04 \x01(\x05R\x17channelMessagesRestored\x128\n" +
+	"\x18channel_cursors_restored\x18\x05 \x01(\x05R\x16channelCursorsRestored\x121\n" +
+	"\x14evaluations_restored\x18\x06 \x01(\x05R\x13evaluationsRestored\x120\n" +
+	"\x14paused_runs_restored\x18\a \x01(\x05R\x12pausedRunsRestored\x121\n" +
+	"\x14synthesized_sessions\x18\b \x01(\x05R\x13synthesizedSessions\x12<\n" +
+	"\x1atranscript_events_restored\x18\t \x01(\x05R\x18transcriptEventsRestored\x12@\n" +
+	"\x1cinteraction_history_restored\x18\n" +
+	" \x01(\x05R\x1ainteractionHistoryRestored\x12\x1a\n" +
+	"\bwarnings\x18\v \x03(\tR\bwarnings\x12+\n" +
+	"\x11format_migrations\x18\f \x03(\tR\x10formatMigrations\"8\n" +
+	"\x15DeleteSnapshotRequest\x12\x1f\n" +
+	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
+	"snapshotId\"S\n" +
+	"\x16DeleteSnapshotResponse\x12\x18\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\x12\x1f\n" +
+	"\vsnapshot_id\x18\x02 \x01(\tR\n" +
+	"snapshotId2\xb6\n" +
+	"\n" +
 	"\tLoomcycle\x126\n" +
 	"\x03Run\x12\x18.loomcycle.v1.RunRequest\x1a\x13.loomcycle.v1.Event0\x01\x12@\n" +
 	"\bContinue\x12\x1d.loomcycle.v1.ContinueRequest\x1a\x13.loomcycle.v1.Event0\x01\x12M\n" +
@@ -1595,7 +2808,16 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\bGetAgent\x12\x1d.loomcycle.v1.GetAgentRequest\x1a\x13.loomcycle.v1.Agent\x12R\n" +
 	"\vCancelAgent\x12 .loomcycle.v1.CancelAgentRequest\x1a!.loomcycle.v1.CancelAgentResponse\x12[\n" +
 	"\x0eListUserAgents\x12#.loomcycle.v1.ListUserAgentsRequest\x1a$.loomcycle.v1.ListUserAgentsResponse\x12C\n" +
-	"\x06Health\x12\x1b.loomcycle.v1.HealthRequest\x1a\x1c.loomcycle.v1.HealthResponseBLZJgithub.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb;loomcyclepbb\x06proto3"
+	"\x06Health\x12\x1b.loomcycle.v1.HealthRequest\x1a\x1c.loomcycle.v1.HealthResponse\x12U\n" +
+	"\fPauseRuntime\x12!.loomcycle.v1.PauseRuntimeRequest\x1a\".loomcycle.v1.PauseRuntimeResponse\x12X\n" +
+	"\rResumeRuntime\x12\".loomcycle.v1.ResumeRuntimeRequest\x1a#.loomcycle.v1.ResumeRuntimeResponse\x12[\n" +
+	"\x0fGetRuntimeState\x12$.loomcycle.v1.GetRuntimeStateRequest\x1a\".loomcycle.v1.RuntimeStateResponse\x12W\n" +
+	"\x0eCreateSnapshot\x12#.loomcycle.v1.CreateSnapshotRequest\x1a .loomcycle.v1.SnapshotDescriptor\x12X\n" +
+	"\rListSnapshots\x12\".loomcycle.v1.ListSnapshotsRequest\x1a#.loomcycle.v1.ListSnapshotsResponse\x12O\n" +
+	"\vGetSnapshot\x12 .loomcycle.v1.GetSnapshotRequest\x1a\x1e.loomcycle.v1.SnapshotEnvelope\x12[\n" +
+	"\x0eExportSnapshot\x12#.loomcycle.v1.ExportSnapshotRequest\x1a$.loomcycle.v1.ExportSnapshotResponse\x12^\n" +
+	"\x0fRestoreSnapshot\x12$.loomcycle.v1.RestoreSnapshotRequest\x1a%.loomcycle.v1.RestoreSnapshotResponse\x12[\n" +
+	"\x0eDeleteSnapshot\x12#.loomcycle.v1.DeleteSnapshotRequest\x1a$.loomcycle.v1.DeleteSnapshotResponseBLZJgithub.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb;loomcyclepbb\x06proto3"
 
 var (
 	file_loomcycle_proto_rawDescOnce sync.Once
@@ -1609,30 +2831,48 @@ func file_loomcycle_proto_rawDescGZIP() []byte {
 	return file_loomcycle_proto_rawDescData
 }
 
-var file_loomcycle_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_loomcycle_proto_msgTypes = make([]protoimpl.MessageInfo, 39)
 var file_loomcycle_proto_goTypes = []any{
-	(*RunRequest)(nil),             // 0: loomcycle.v1.RunRequest
-	(*ContinueRequest)(nil),        // 1: loomcycle.v1.ContinueRequest
-	(*HostAllowlist)(nil),          // 2: loomcycle.v1.HostAllowlist
-	(*PromptSegment)(nil),          // 3: loomcycle.v1.PromptSegment
-	(*PromptContentBlock)(nil),     // 4: loomcycle.v1.PromptContentBlock
-	(*Event)(nil),                  // 5: loomcycle.v1.Event
-	(*ToolUse)(nil),                // 6: loomcycle.v1.ToolUse
-	(*Usage)(nil),                  // 7: loomcycle.v1.Usage
-	(*Retry)(nil),                  // 8: loomcycle.v1.Retry
-	(*GetTranscriptRequest)(nil),   // 9: loomcycle.v1.GetTranscriptRequest
-	(*Transcript)(nil),             // 10: loomcycle.v1.Transcript
-	(*TranscriptEvent)(nil),        // 11: loomcycle.v1.TranscriptEvent
-	(*GetAgentRequest)(nil),        // 12: loomcycle.v1.GetAgentRequest
-	(*Agent)(nil),                  // 13: loomcycle.v1.Agent
-	(*AgentUsage)(nil),             // 14: loomcycle.v1.AgentUsage
-	(*CancelAgentRequest)(nil),     // 15: loomcycle.v1.CancelAgentRequest
-	(*CancelAgentResponse)(nil),    // 16: loomcycle.v1.CancelAgentResponse
-	(*ListUserAgentsRequest)(nil),  // 17: loomcycle.v1.ListUserAgentsRequest
-	(*ListUserAgentsResponse)(nil), // 18: loomcycle.v1.ListUserAgentsResponse
-	(*HealthRequest)(nil),          // 19: loomcycle.v1.HealthRequest
-	(*HealthResponse)(nil),         // 20: loomcycle.v1.HealthResponse
-	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
+	(*RunRequest)(nil),              // 0: loomcycle.v1.RunRequest
+	(*ContinueRequest)(nil),         // 1: loomcycle.v1.ContinueRequest
+	(*HostAllowlist)(nil),           // 2: loomcycle.v1.HostAllowlist
+	(*PromptSegment)(nil),           // 3: loomcycle.v1.PromptSegment
+	(*PromptContentBlock)(nil),      // 4: loomcycle.v1.PromptContentBlock
+	(*Event)(nil),                   // 5: loomcycle.v1.Event
+	(*ToolUse)(nil),                 // 6: loomcycle.v1.ToolUse
+	(*Usage)(nil),                   // 7: loomcycle.v1.Usage
+	(*Retry)(nil),                   // 8: loomcycle.v1.Retry
+	(*GetTranscriptRequest)(nil),    // 9: loomcycle.v1.GetTranscriptRequest
+	(*Transcript)(nil),              // 10: loomcycle.v1.Transcript
+	(*TranscriptEvent)(nil),         // 11: loomcycle.v1.TranscriptEvent
+	(*GetAgentRequest)(nil),         // 12: loomcycle.v1.GetAgentRequest
+	(*Agent)(nil),                   // 13: loomcycle.v1.Agent
+	(*AgentUsage)(nil),              // 14: loomcycle.v1.AgentUsage
+	(*CancelAgentRequest)(nil),      // 15: loomcycle.v1.CancelAgentRequest
+	(*CancelAgentResponse)(nil),     // 16: loomcycle.v1.CancelAgentResponse
+	(*ListUserAgentsRequest)(nil),   // 17: loomcycle.v1.ListUserAgentsRequest
+	(*ListUserAgentsResponse)(nil),  // 18: loomcycle.v1.ListUserAgentsResponse
+	(*HealthRequest)(nil),           // 19: loomcycle.v1.HealthRequest
+	(*HealthResponse)(nil),          // 20: loomcycle.v1.HealthResponse
+	(*PauseRuntimeRequest)(nil),     // 21: loomcycle.v1.PauseRuntimeRequest
+	(*PauseRuntimeResponse)(nil),    // 22: loomcycle.v1.PauseRuntimeResponse
+	(*ResumeRuntimeRequest)(nil),    // 23: loomcycle.v1.ResumeRuntimeRequest
+	(*ResumeRuntimeResponse)(nil),   // 24: loomcycle.v1.ResumeRuntimeResponse
+	(*GetRuntimeStateRequest)(nil),  // 25: loomcycle.v1.GetRuntimeStateRequest
+	(*RuntimeStateResponse)(nil),    // 26: loomcycle.v1.RuntimeStateResponse
+	(*CreateSnapshotRequest)(nil),   // 27: loomcycle.v1.CreateSnapshotRequest
+	(*SnapshotDescriptor)(nil),      // 28: loomcycle.v1.SnapshotDescriptor
+	(*ListSnapshotsRequest)(nil),    // 29: loomcycle.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),   // 30: loomcycle.v1.ListSnapshotsResponse
+	(*GetSnapshotRequest)(nil),      // 31: loomcycle.v1.GetSnapshotRequest
+	(*SnapshotEnvelope)(nil),        // 32: loomcycle.v1.SnapshotEnvelope
+	(*ExportSnapshotRequest)(nil),   // 33: loomcycle.v1.ExportSnapshotRequest
+	(*ExportSnapshotResponse)(nil),  // 34: loomcycle.v1.ExportSnapshotResponse
+	(*RestoreSnapshotRequest)(nil),  // 35: loomcycle.v1.RestoreSnapshotRequest
+	(*RestoreSnapshotResponse)(nil), // 36: loomcycle.v1.RestoreSnapshotResponse
+	(*DeleteSnapshotRequest)(nil),   // 37: loomcycle.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),  // 38: loomcycle.v1.DeleteSnapshotResponse
+	(*timestamppb.Timestamp)(nil),   // 39: google.protobuf.Timestamp
 }
 var file_loomcycle_proto_depIdxs = []int32{
 	3,  // 0: loomcycle.v1.RunRequest.segments:type_name -> loomcycle.v1.PromptSegment
@@ -1644,31 +2884,55 @@ var file_loomcycle_proto_depIdxs = []int32{
 	7,  // 6: loomcycle.v1.Event.usage:type_name -> loomcycle.v1.Usage
 	8,  // 7: loomcycle.v1.Event.retry:type_name -> loomcycle.v1.Retry
 	11, // 8: loomcycle.v1.Transcript.events:type_name -> loomcycle.v1.TranscriptEvent
-	21, // 9: loomcycle.v1.TranscriptEvent.ts:type_name -> google.protobuf.Timestamp
-	21, // 10: loomcycle.v1.Agent.started_at:type_name -> google.protobuf.Timestamp
-	21, // 11: loomcycle.v1.Agent.completed_at:type_name -> google.protobuf.Timestamp
+	39, // 9: loomcycle.v1.TranscriptEvent.ts:type_name -> google.protobuf.Timestamp
+	39, // 10: loomcycle.v1.Agent.started_at:type_name -> google.protobuf.Timestamp
+	39, // 11: loomcycle.v1.Agent.completed_at:type_name -> google.protobuf.Timestamp
 	14, // 12: loomcycle.v1.Agent.usage:type_name -> loomcycle.v1.AgentUsage
-	21, // 13: loomcycle.v1.Agent.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	39, // 13: loomcycle.v1.Agent.last_heartbeat_at:type_name -> google.protobuf.Timestamp
 	13, // 14: loomcycle.v1.ListUserAgentsResponse.agents:type_name -> loomcycle.v1.Agent
-	0,  // 15: loomcycle.v1.Loomcycle.Run:input_type -> loomcycle.v1.RunRequest
-	1,  // 16: loomcycle.v1.Loomcycle.Continue:input_type -> loomcycle.v1.ContinueRequest
-	9,  // 17: loomcycle.v1.Loomcycle.GetTranscript:input_type -> loomcycle.v1.GetTranscriptRequest
-	12, // 18: loomcycle.v1.Loomcycle.GetAgent:input_type -> loomcycle.v1.GetAgentRequest
-	15, // 19: loomcycle.v1.Loomcycle.CancelAgent:input_type -> loomcycle.v1.CancelAgentRequest
-	17, // 20: loomcycle.v1.Loomcycle.ListUserAgents:input_type -> loomcycle.v1.ListUserAgentsRequest
-	19, // 21: loomcycle.v1.Loomcycle.Health:input_type -> loomcycle.v1.HealthRequest
-	5,  // 22: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
-	5,  // 23: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
-	10, // 24: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
-	13, // 25: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
-	16, // 26: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
-	18, // 27: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
-	20, // 28: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
-	22, // [22:29] is the sub-list for method output_type
-	15, // [15:22] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	39, // 15: loomcycle.v1.RuntimeStateResponse.paused_at:type_name -> google.protobuf.Timestamp
+	39, // 16: loomcycle.v1.CreateSnapshotRequest.since_ts:type_name -> google.protobuf.Timestamp
+	39, // 17: loomcycle.v1.SnapshotDescriptor.created_at:type_name -> google.protobuf.Timestamp
+	39, // 18: loomcycle.v1.SnapshotDescriptor.since_ts:type_name -> google.protobuf.Timestamp
+	28, // 19: loomcycle.v1.ListSnapshotsResponse.snapshots:type_name -> loomcycle.v1.SnapshotDescriptor
+	39, // 20: loomcycle.v1.SnapshotEnvelope.created_at:type_name -> google.protobuf.Timestamp
+	0,  // 21: loomcycle.v1.Loomcycle.Run:input_type -> loomcycle.v1.RunRequest
+	1,  // 22: loomcycle.v1.Loomcycle.Continue:input_type -> loomcycle.v1.ContinueRequest
+	9,  // 23: loomcycle.v1.Loomcycle.GetTranscript:input_type -> loomcycle.v1.GetTranscriptRequest
+	12, // 24: loomcycle.v1.Loomcycle.GetAgent:input_type -> loomcycle.v1.GetAgentRequest
+	15, // 25: loomcycle.v1.Loomcycle.CancelAgent:input_type -> loomcycle.v1.CancelAgentRequest
+	17, // 26: loomcycle.v1.Loomcycle.ListUserAgents:input_type -> loomcycle.v1.ListUserAgentsRequest
+	19, // 27: loomcycle.v1.Loomcycle.Health:input_type -> loomcycle.v1.HealthRequest
+	21, // 28: loomcycle.v1.Loomcycle.PauseRuntime:input_type -> loomcycle.v1.PauseRuntimeRequest
+	23, // 29: loomcycle.v1.Loomcycle.ResumeRuntime:input_type -> loomcycle.v1.ResumeRuntimeRequest
+	25, // 30: loomcycle.v1.Loomcycle.GetRuntimeState:input_type -> loomcycle.v1.GetRuntimeStateRequest
+	27, // 31: loomcycle.v1.Loomcycle.CreateSnapshot:input_type -> loomcycle.v1.CreateSnapshotRequest
+	29, // 32: loomcycle.v1.Loomcycle.ListSnapshots:input_type -> loomcycle.v1.ListSnapshotsRequest
+	31, // 33: loomcycle.v1.Loomcycle.GetSnapshot:input_type -> loomcycle.v1.GetSnapshotRequest
+	33, // 34: loomcycle.v1.Loomcycle.ExportSnapshot:input_type -> loomcycle.v1.ExportSnapshotRequest
+	35, // 35: loomcycle.v1.Loomcycle.RestoreSnapshot:input_type -> loomcycle.v1.RestoreSnapshotRequest
+	37, // 36: loomcycle.v1.Loomcycle.DeleteSnapshot:input_type -> loomcycle.v1.DeleteSnapshotRequest
+	5,  // 37: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
+	5,  // 38: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
+	10, // 39: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
+	13, // 40: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
+	16, // 41: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
+	18, // 42: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
+	20, // 43: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
+	22, // 44: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
+	24, // 45: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
+	26, // 46: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
+	28, // 47: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
+	30, // 48: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
+	32, // 49: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
+	34, // 50: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
+	36, // 51: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
+	38, // 52: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
+	37, // [37:53] is the sub-list for method output_type
+	21, // [21:37] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_loomcycle_proto_init() }
@@ -1682,7 +2946,7 @@ func file_loomcycle_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loomcycle_proto_rawDesc), len(file_loomcycle_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   21,
+			NumMessages:   39,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/grpc/loomcyclepb/loomcycle.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle.pb.go
@@ -1477,8 +1477,12 @@ type PauseRuntimeRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Wait-for-non-idempotent-tools cap, in milliseconds. 0 falls
 	// through to LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS (default 30 s).
-	// Clamped server-side at pause.MaxPauseTimeout (5 min).
-	TimeoutMs     int32 `protobuf:"varint,1,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
+	// Clamped server-side at pause.MaxPauseTimeout (5 min). int64
+	// for consistency with every other _ms field in this proto
+	// (duration_ms in PauseRuntimeResponse, wait_ms in Retry) —
+	// server clamping makes the larger range unobservable but the
+	// type matches.
+	TimeoutMs     int64 `protobuf:"varint,1,opt,name=timeout_ms,json=timeoutMs,proto3" json:"timeout_ms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1513,7 +1517,7 @@ func (*PauseRuntimeRequest) Descriptor() ([]byte, []int) {
 	return file_loomcycle_proto_rawDescGZIP(), []int{21}
 }
 
-func (x *PauseRuntimeRequest) GetTimeoutMs() int32 {
+func (x *PauseRuntimeRequest) GetTimeoutMs() int64 {
 	if x != nil {
 		return x.TimeoutMs
 	}
@@ -2712,7 +2716,7 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\x0euptime_seconds\x18\x04 \x01(\x03R\ruptimeSeconds\"4\n" +
 	"\x13PauseRuntimeRequest\x12\x1d\n" +
 	"\n" +
-	"timeout_ms\x18\x01 \x01(\x05R\ttimeoutMs\"\xcb\x01\n" +
+	"timeout_ms\x18\x01 \x01(\x03R\ttimeoutMs\"\xcb\x01\n" +
 	"\x14PauseRuntimeResponse\x12\x16\n" +
 	"\x06status\x18\x01 \x01(\tR\x06status\x12\x1f\n" +
 	"\vduration_ms\x18\x02 \x01(\x03R\n" +

--- a/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
@@ -38,13 +38,22 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Loomcycle_Run_FullMethodName            = "/loomcycle.v1.Loomcycle/Run"
-	Loomcycle_Continue_FullMethodName       = "/loomcycle.v1.Loomcycle/Continue"
-	Loomcycle_GetTranscript_FullMethodName  = "/loomcycle.v1.Loomcycle/GetTranscript"
-	Loomcycle_GetAgent_FullMethodName       = "/loomcycle.v1.Loomcycle/GetAgent"
-	Loomcycle_CancelAgent_FullMethodName    = "/loomcycle.v1.Loomcycle/CancelAgent"
-	Loomcycle_ListUserAgents_FullMethodName = "/loomcycle.v1.Loomcycle/ListUserAgents"
-	Loomcycle_Health_FullMethodName         = "/loomcycle.v1.Loomcycle/Health"
+	Loomcycle_Run_FullMethodName             = "/loomcycle.v1.Loomcycle/Run"
+	Loomcycle_Continue_FullMethodName        = "/loomcycle.v1.Loomcycle/Continue"
+	Loomcycle_GetTranscript_FullMethodName   = "/loomcycle.v1.Loomcycle/GetTranscript"
+	Loomcycle_GetAgent_FullMethodName        = "/loomcycle.v1.Loomcycle/GetAgent"
+	Loomcycle_CancelAgent_FullMethodName     = "/loomcycle.v1.Loomcycle/CancelAgent"
+	Loomcycle_ListUserAgents_FullMethodName  = "/loomcycle.v1.Loomcycle/ListUserAgents"
+	Loomcycle_Health_FullMethodName          = "/loomcycle.v1.Loomcycle/Health"
+	Loomcycle_PauseRuntime_FullMethodName    = "/loomcycle.v1.Loomcycle/PauseRuntime"
+	Loomcycle_ResumeRuntime_FullMethodName   = "/loomcycle.v1.Loomcycle/ResumeRuntime"
+	Loomcycle_GetRuntimeState_FullMethodName = "/loomcycle.v1.Loomcycle/GetRuntimeState"
+	Loomcycle_CreateSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/CreateSnapshot"
+	Loomcycle_ListSnapshots_FullMethodName   = "/loomcycle.v1.Loomcycle/ListSnapshots"
+	Loomcycle_GetSnapshot_FullMethodName     = "/loomcycle.v1.Loomcycle/GetSnapshot"
+	Loomcycle_ExportSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/ExportSnapshot"
+	Loomcycle_RestoreSnapshot_FullMethodName = "/loomcycle.v1.Loomcycle/RestoreSnapshot"
+	Loomcycle_DeleteSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/DeleteSnapshot"
 )
 
 // LoomcycleClient is the client API for Loomcycle service.
@@ -90,6 +99,61 @@ type LoomcycleClient interface {
 	// Mirrors GET /healthz (which is unauthenticated on the HTTP side;
 	// the gRPC equivalent stays unauthenticated for parity).
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
+	// PauseRuntime quiesces the runtime. Idempotent tools cancel
+	// immediately; non-idempotent + external tools get a grace window
+	// (default 30 s; max 5 min) then force-cancel. Returns 409-equivalent
+	// when the runtime is already pausing or paused.
+	//
+	// Mirrors POST /v1/_pause.
+	PauseRuntime(ctx context.Context, in *PauseRuntimeRequest, opts ...grpc.CallOption) (*PauseRuntimeResponse, error)
+	// ResumeRuntime releases the quiesce. Paused runs re-enter their
+	// loops. Returns 409-equivalent when the runtime is not paused.
+	//
+	// Mirrors POST /v1/_resume.
+	ResumeRuntime(ctx context.Context, in *ResumeRuntimeRequest, opts ...grpc.CallOption) (*ResumeRuntimeResponse, error)
+	// GetRuntimeState returns the current quiesce state for dashboards.
+	//
+	// Mirrors GET /v1/_state.
+	GetRuntimeState(ctx context.Context, in *GetRuntimeStateRequest, opts ...grpc.CallOption) (*RuntimeStateResponse, error)
+	// CreateSnapshot captures running-state into a per-section-semver
+	// JSON envelope (agent_defs, agent_def_active, memory, channels,
+	// evaluations, paused_runs, optional interaction_history). Returns
+	// 413-equivalent when the serialised envelope exceeds the configured
+	// cap (LOOMCYCLE_SNAPSHOT_MAX_BYTES; default 512 MiB).
+	//
+	// Mirrors POST /v1/_snapshots.
+	CreateSnapshot(ctx context.Context, in *CreateSnapshotRequest, opts ...grpc.CallOption) (*SnapshotDescriptor, error)
+	// ListSnapshots returns metadata for the most-recent snapshots
+	// (capped at 200). The JSON envelope itself is not included; use
+	// GetSnapshot / ExportSnapshot to fetch.
+	//
+	// Mirrors GET /v1/_snapshots.
+	ListSnapshots(ctx context.Context, in *ListSnapshotsRequest, opts ...grpc.CallOption) (*ListSnapshotsResponse, error)
+	// GetSnapshot returns the full envelope including JSON content.
+	// Distinct from ExportSnapshot, which is operator-facing "where did
+	// this land on the host" semantics.
+	//
+	// Mirrors GET /v1/_snapshots/{id}.
+	GetSnapshot(ctx context.Context, in *GetSnapshotRequest, opts ...grpc.CallOption) (*SnapshotEnvelope, error)
+	// ExportSnapshot returns canonical envelope bytes (raw_json) for a
+	// snapshot id. Transports that stream large exports use raw_json
+	// directly; file_path / checksum stay empty unless materialised.
+	//
+	// Mirrors GET /v1/_snapshots/{id}/export.
+	ExportSnapshot(ctx context.Context, in *ExportSnapshotRequest, opts ...grpc.CallOption) (*ExportSnapshotResponse, error)
+	// RestoreSnapshot restores from a same-instance snapshot_id OR
+	// cross-instance raw_json. Idempotent: ON CONFLICT DO NOTHING per
+	// row. Counters in the response reflect rows actually written.
+	// Returns 422-equivalent on snapshot version newer than reader
+	// supports.
+	//
+	// Mirrors POST /v1/_snapshots/{id}/restore.
+	RestoreSnapshot(ctx context.Context, in *RestoreSnapshotRequest, opts ...grpc.CallOption) (*RestoreSnapshotResponse, error)
+	// DeleteSnapshot removes a snapshot. Idempotent — succeeds whether
+	// or not the row existed.
+	//
+	// Mirrors DELETE /v1/_snapshots/{id}.
+	DeleteSnapshot(ctx context.Context, in *DeleteSnapshotRequest, opts ...grpc.CallOption) (*DeleteSnapshotResponse, error)
 }
 
 type loomcycleClient struct {
@@ -188,6 +252,96 @@ func (c *loomcycleClient) Health(ctx context.Context, in *HealthRequest, opts ..
 	return out, nil
 }
 
+func (c *loomcycleClient) PauseRuntime(ctx context.Context, in *PauseRuntimeRequest, opts ...grpc.CallOption) (*PauseRuntimeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PauseRuntimeResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_PauseRuntime_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) ResumeRuntime(ctx context.Context, in *ResumeRuntimeRequest, opts ...grpc.CallOption) (*ResumeRuntimeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ResumeRuntimeResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_ResumeRuntime_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) GetRuntimeState(ctx context.Context, in *GetRuntimeStateRequest, opts ...grpc.CallOption) (*RuntimeStateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RuntimeStateResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_GetRuntimeState_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) CreateSnapshot(ctx context.Context, in *CreateSnapshotRequest, opts ...grpc.CallOption) (*SnapshotDescriptor, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SnapshotDescriptor)
+	err := c.cc.Invoke(ctx, Loomcycle_CreateSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) ListSnapshots(ctx context.Context, in *ListSnapshotsRequest, opts ...grpc.CallOption) (*ListSnapshotsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListSnapshotsResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_ListSnapshots_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) GetSnapshot(ctx context.Context, in *GetSnapshotRequest, opts ...grpc.CallOption) (*SnapshotEnvelope, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SnapshotEnvelope)
+	err := c.cc.Invoke(ctx, Loomcycle_GetSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) ExportSnapshot(ctx context.Context, in *ExportSnapshotRequest, opts ...grpc.CallOption) (*ExportSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ExportSnapshotResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_ExportSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) RestoreSnapshot(ctx context.Context, in *RestoreSnapshotRequest, opts ...grpc.CallOption) (*RestoreSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RestoreSnapshotResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_RestoreSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) DeleteSnapshot(ctx context.Context, in *DeleteSnapshotRequest, opts ...grpc.CallOption) (*DeleteSnapshotResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeleteSnapshotResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_DeleteSnapshot_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // LoomcycleServer is the server API for Loomcycle service.
 // All implementations must embed UnimplementedLoomcycleServer
 // for forward compatibility.
@@ -231,6 +385,61 @@ type LoomcycleServer interface {
 	// Mirrors GET /healthz (which is unauthenticated on the HTTP side;
 	// the gRPC equivalent stays unauthenticated for parity).
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
+	// PauseRuntime quiesces the runtime. Idempotent tools cancel
+	// immediately; non-idempotent + external tools get a grace window
+	// (default 30 s; max 5 min) then force-cancel. Returns 409-equivalent
+	// when the runtime is already pausing or paused.
+	//
+	// Mirrors POST /v1/_pause.
+	PauseRuntime(context.Context, *PauseRuntimeRequest) (*PauseRuntimeResponse, error)
+	// ResumeRuntime releases the quiesce. Paused runs re-enter their
+	// loops. Returns 409-equivalent when the runtime is not paused.
+	//
+	// Mirrors POST /v1/_resume.
+	ResumeRuntime(context.Context, *ResumeRuntimeRequest) (*ResumeRuntimeResponse, error)
+	// GetRuntimeState returns the current quiesce state for dashboards.
+	//
+	// Mirrors GET /v1/_state.
+	GetRuntimeState(context.Context, *GetRuntimeStateRequest) (*RuntimeStateResponse, error)
+	// CreateSnapshot captures running-state into a per-section-semver
+	// JSON envelope (agent_defs, agent_def_active, memory, channels,
+	// evaluations, paused_runs, optional interaction_history). Returns
+	// 413-equivalent when the serialised envelope exceeds the configured
+	// cap (LOOMCYCLE_SNAPSHOT_MAX_BYTES; default 512 MiB).
+	//
+	// Mirrors POST /v1/_snapshots.
+	CreateSnapshot(context.Context, *CreateSnapshotRequest) (*SnapshotDescriptor, error)
+	// ListSnapshots returns metadata for the most-recent snapshots
+	// (capped at 200). The JSON envelope itself is not included; use
+	// GetSnapshot / ExportSnapshot to fetch.
+	//
+	// Mirrors GET /v1/_snapshots.
+	ListSnapshots(context.Context, *ListSnapshotsRequest) (*ListSnapshotsResponse, error)
+	// GetSnapshot returns the full envelope including JSON content.
+	// Distinct from ExportSnapshot, which is operator-facing "where did
+	// this land on the host" semantics.
+	//
+	// Mirrors GET /v1/_snapshots/{id}.
+	GetSnapshot(context.Context, *GetSnapshotRequest) (*SnapshotEnvelope, error)
+	// ExportSnapshot returns canonical envelope bytes (raw_json) for a
+	// snapshot id. Transports that stream large exports use raw_json
+	// directly; file_path / checksum stay empty unless materialised.
+	//
+	// Mirrors GET /v1/_snapshots/{id}/export.
+	ExportSnapshot(context.Context, *ExportSnapshotRequest) (*ExportSnapshotResponse, error)
+	// RestoreSnapshot restores from a same-instance snapshot_id OR
+	// cross-instance raw_json. Idempotent: ON CONFLICT DO NOTHING per
+	// row. Counters in the response reflect rows actually written.
+	// Returns 422-equivalent on snapshot version newer than reader
+	// supports.
+	//
+	// Mirrors POST /v1/_snapshots/{id}/restore.
+	RestoreSnapshot(context.Context, *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error)
+	// DeleteSnapshot removes a snapshot. Idempotent — succeeds whether
+	// or not the row existed.
+	//
+	// Mirrors DELETE /v1/_snapshots/{id}.
+	DeleteSnapshot(context.Context, *DeleteSnapshotRequest) (*DeleteSnapshotResponse, error)
 	mustEmbedUnimplementedLoomcycleServer()
 }
 
@@ -261,6 +470,33 @@ func (UnimplementedLoomcycleServer) ListUserAgents(context.Context, *ListUserAge
 }
 func (UnimplementedLoomcycleServer) Health(context.Context, *HealthRequest) (*HealthResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Health not implemented")
+}
+func (UnimplementedLoomcycleServer) PauseRuntime(context.Context, *PauseRuntimeRequest) (*PauseRuntimeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method PauseRuntime not implemented")
+}
+func (UnimplementedLoomcycleServer) ResumeRuntime(context.Context, *ResumeRuntimeRequest) (*ResumeRuntimeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ResumeRuntime not implemented")
+}
+func (UnimplementedLoomcycleServer) GetRuntimeState(context.Context, *GetRuntimeStateRequest) (*RuntimeStateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetRuntimeState not implemented")
+}
+func (UnimplementedLoomcycleServer) CreateSnapshot(context.Context, *CreateSnapshotRequest) (*SnapshotDescriptor, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateSnapshot not implemented")
+}
+func (UnimplementedLoomcycleServer) ListSnapshots(context.Context, *ListSnapshotsRequest) (*ListSnapshotsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListSnapshots not implemented")
+}
+func (UnimplementedLoomcycleServer) GetSnapshot(context.Context, *GetSnapshotRequest) (*SnapshotEnvelope, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetSnapshot not implemented")
+}
+func (UnimplementedLoomcycleServer) ExportSnapshot(context.Context, *ExportSnapshotRequest) (*ExportSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ExportSnapshot not implemented")
+}
+func (UnimplementedLoomcycleServer) RestoreSnapshot(context.Context, *RestoreSnapshotRequest) (*RestoreSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RestoreSnapshot not implemented")
+}
+func (UnimplementedLoomcycleServer) DeleteSnapshot(context.Context, *DeleteSnapshotRequest) (*DeleteSnapshotResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeleteSnapshot not implemented")
 }
 func (UnimplementedLoomcycleServer) mustEmbedUnimplementedLoomcycleServer() {}
 func (UnimplementedLoomcycleServer) testEmbeddedByValue()                   {}
@@ -395,6 +631,168 @@ func _Loomcycle_Health_Handler(srv interface{}, ctx context.Context, dec func(in
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Loomcycle_PauseRuntime_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PauseRuntimeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).PauseRuntime(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_PauseRuntime_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).PauseRuntime(ctx, req.(*PauseRuntimeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_ResumeRuntime_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ResumeRuntimeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).ResumeRuntime(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_ResumeRuntime_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).ResumeRuntime(ctx, req.(*ResumeRuntimeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_GetRuntimeState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetRuntimeStateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).GetRuntimeState(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_GetRuntimeState_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).GetRuntimeState(ctx, req.(*GetRuntimeStateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_CreateSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).CreateSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_CreateSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).CreateSnapshot(ctx, req.(*CreateSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_ListSnapshots_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListSnapshotsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).ListSnapshots(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_ListSnapshots_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).ListSnapshots(ctx, req.(*ListSnapshotsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_GetSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).GetSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_GetSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).GetSnapshot(ctx, req.(*GetSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_ExportSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ExportSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).ExportSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_ExportSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).ExportSnapshot(ctx, req.(*ExportSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_RestoreSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RestoreSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).RestoreSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_RestoreSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).RestoreSnapshot(ctx, req.(*RestoreSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_DeleteSnapshot_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteSnapshotRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).DeleteSnapshot(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_DeleteSnapshot_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).DeleteSnapshot(ctx, req.(*DeleteSnapshotRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // Loomcycle_ServiceDesc is the grpc.ServiceDesc for Loomcycle service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -421,6 +819,42 @@ var Loomcycle_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Health",
 			Handler:    _Loomcycle_Health_Handler,
+		},
+		{
+			MethodName: "PauseRuntime",
+			Handler:    _Loomcycle_PauseRuntime_Handler,
+		},
+		{
+			MethodName: "ResumeRuntime",
+			Handler:    _Loomcycle_ResumeRuntime_Handler,
+		},
+		{
+			MethodName: "GetRuntimeState",
+			Handler:    _Loomcycle_GetRuntimeState_Handler,
+		},
+		{
+			MethodName: "CreateSnapshot",
+			Handler:    _Loomcycle_CreateSnapshot_Handler,
+		},
+		{
+			MethodName: "ListSnapshots",
+			Handler:    _Loomcycle_ListSnapshots_Handler,
+		},
+		{
+			MethodName: "GetSnapshot",
+			Handler:    _Loomcycle_GetSnapshot_Handler,
+		},
+		{
+			MethodName: "ExportSnapshot",
+			Handler:    _Loomcycle_ExportSnapshot_Handler,
+		},
+		{
+			MethodName: "RestoreSnapshot",
+			Handler:    _Loomcycle_RestoreSnapshot_Handler,
+		},
+		{
+			MethodName: "DeleteSnapshot",
+			Handler:    _Loomcycle_DeleteSnapshot_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/internal/api/grpc/pause_snapshot.go
+++ b/internal/api/grpc/pause_snapshot.go
@@ -1,0 +1,236 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// v0.8.18 gRPC surface for Pause/Resume/Snapshot. Every handler is a
+// thin translation between the proto wire shape and the Connector
+// interface — same pattern as CancelAgent. Typed errors from the
+// Connector (see internal/connector/errors.go) map to gRPC status
+// codes via translatePauseSnapshotError.
+
+// PauseRuntime — mirrors POST /v1/_pause.
+func (s *Server) PauseRuntime(ctx context.Context, req *loomcyclepb.PauseRuntimeRequest) (*loomcyclepb.PauseRuntimeResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	res, err := s.connector.PauseRuntime(ctx, int(req.GetTimeoutMs()))
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.PauseRuntimeResponse{
+		Status:              res.Status,
+		DurationMs:          res.DurationMS,
+		ForceCancelledCount: int32(res.ForceCancelledCount),
+		PausedRunsCount:     int32(res.PausedRunsCount),
+		Warnings:            res.Warnings,
+	}, nil
+}
+
+// ResumeRuntime — mirrors POST /v1/_resume.
+func (s *Server) ResumeRuntime(ctx context.Context, _ *loomcyclepb.ResumeRuntimeRequest) (*loomcyclepb.ResumeRuntimeResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	res, err := s.connector.ResumeRuntime(ctx)
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.ResumeRuntimeResponse{
+		Status:          res.Status,
+		ResumedRunCount: int32(res.ResumedRunCount),
+		Warnings:        res.Warnings,
+	}, nil
+}
+
+// GetRuntimeState — mirrors GET /v1/_state.
+func (s *Server) GetRuntimeState(ctx context.Context, _ *loomcyclepb.GetRuntimeStateRequest) (*loomcyclepb.RuntimeStateResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	res, err := s.connector.GetRuntimeState(ctx)
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	out := &loomcyclepb.RuntimeStateResponse{
+		Status:         res.Status,
+		PausedRunCount: int32(res.PausedRunCount),
+		SnapshotsCount: int32(res.SnapshotsCount),
+	}
+	if res.PausedAt != nil {
+		out.PausedAt = timestamppb.New(*res.PausedAt)
+	}
+	return out, nil
+}
+
+// CreateSnapshot — mirrors POST /v1/_snapshots.
+func (s *Server) CreateSnapshot(ctx context.Context, req *loomcyclepb.CreateSnapshotRequest) (*loomcyclepb.SnapshotDescriptor, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	in := connector.CreateSnapshotRequest{
+		IncludeHistory: req.GetIncludeHistory(),
+		Description:    req.GetDescription(),
+		MaxBytes:       req.GetMaxBytes(),
+	}
+	if req.GetSinceTs() != nil {
+		t := req.GetSinceTs().AsTime()
+		in.SinceTS = &t
+	}
+	desc, err := s.connector.CreateSnapshot(ctx, in)
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return descriptorToProto(desc), nil
+}
+
+// ListSnapshots — mirrors GET /v1/_snapshots.
+func (s *Server) ListSnapshots(ctx context.Context, _ *loomcyclepb.ListSnapshotsRequest) (*loomcyclepb.ListSnapshotsResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	list, err := s.connector.ListSnapshots(ctx)
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	out := &loomcyclepb.ListSnapshotsResponse{
+		Snapshots: make([]*loomcyclepb.SnapshotDescriptor, 0, len(list)),
+	}
+	for _, d := range list {
+		out.Snapshots = append(out.Snapshots, descriptorToProto(d))
+	}
+	return out, nil
+}
+
+// GetSnapshot — mirrors GET /v1/_snapshots/{id}. Returns the full
+// envelope including JSON content (v0.8.18+).
+func (s *Server) GetSnapshot(ctx context.Context, req *loomcyclepb.GetSnapshotRequest) (*loomcyclepb.SnapshotEnvelope, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	env, err := s.connector.GetSnapshot(ctx, req.GetSnapshotId())
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.SnapshotEnvelope{
+		SnapshotId:    env.SnapshotID,
+		CreatedAt:     timestamppb.New(env.CreatedAt),
+		Description:   env.Description,
+		FormatVersion: env.FormatVersion,
+		SizeBytes:     env.SizeBytes,
+		JsonContent:   env.JSONContent,
+	}, nil
+}
+
+// ExportSnapshot — mirrors GET /v1/_snapshots/{id}/export. Returns
+// canonical envelope bytes in raw_json.
+func (s *Server) ExportSnapshot(ctx context.Context, req *loomcyclepb.ExportSnapshotRequest) (*loomcyclepb.ExportSnapshotResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	out, err := s.connector.ExportSnapshot(ctx, req.GetSnapshotId())
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.ExportSnapshotResponse{
+		SnapshotId: out.SnapshotID,
+		FilePath:   out.FilePath,
+		Checksum:   out.Checksum,
+		SizeBytes:  out.SizeBytes,
+		RawJson:    out.RawJSON,
+	}, nil
+}
+
+// RestoreSnapshot — mirrors POST /v1/_snapshots/{id}/restore.
+func (s *Server) RestoreSnapshot(ctx context.Context, req *loomcyclepb.RestoreSnapshotRequest) (*loomcyclepb.RestoreSnapshotResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	in := connector.RestoreSnapshotRequest{
+		SnapshotID:     req.GetSnapshotId(),
+		RawJSON:        req.GetRawJson(),
+		IncludeHistory: req.GetIncludeHistory(),
+	}
+	res, err := s.connector.RestoreSnapshot(ctx, in)
+	if err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.RestoreSnapshotResponse{
+		AgentDefsRestored:          int32(res.AgentDefsRestored),
+		AgentDefActiveRestored:     int32(res.AgentDefActiveRestored),
+		MemoryRestored:             int32(res.MemoryRestored),
+		ChannelMessagesRestored:    int32(res.ChannelMessagesRestored),
+		ChannelCursorsRestored:     int32(res.ChannelCursorsRestored),
+		EvaluationsRestored:        int32(res.EvaluationsRestored),
+		PausedRunsRestored:         int32(res.PausedRunsRestored),
+		SynthesizedSessions:        int32(res.SynthesizedSessions),
+		TranscriptEventsRestored:   int32(res.TranscriptEventsRestored),
+		InteractionHistoryRestored: int32(res.InteractionHistoryRestored),
+		Warnings:                   res.Warnings,
+		FormatMigrations:           res.FormatMigrations,
+	}, nil
+}
+
+// DeleteSnapshot — mirrors DELETE /v1/_snapshots/{id}. Idempotent.
+func (s *Server) DeleteSnapshot(ctx context.Context, req *loomcyclepb.DeleteSnapshotRequest) (*loomcyclepb.DeleteSnapshotResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	if err := s.connector.DeleteSnapshot(ctx, req.GetSnapshotId()); err != nil {
+		return nil, translatePauseSnapshotError(err)
+	}
+	return &loomcyclepb.DeleteSnapshotResponse{
+		Deleted:    true,
+		SnapshotId: req.GetSnapshotId(),
+	}, nil
+}
+
+// descriptorToProto converts a connector.SnapshotDescriptor into the
+// proto wire shape. Reused by CreateSnapshot + ListSnapshots.
+func descriptorToProto(d connector.SnapshotDescriptor) *loomcyclepb.SnapshotDescriptor {
+	out := &loomcyclepb.SnapshotDescriptor{
+		SnapshotId:      d.SnapshotID,
+		CreatedAt:       timestamppb.New(d.CreatedAt),
+		SizeBytes:       d.SizeBytes,
+		IncludesHistory: d.IncludesHistory,
+		Description:     d.Description,
+		FormatVersion:   d.FormatVersion,
+	}
+	if d.SinceTS != nil {
+		out.SinceTs = timestamppb.New(*d.SinceTS)
+	}
+	return out
+}
+
+// translatePauseSnapshotError maps Connector typed errors to gRPC
+// status codes. See connector/errors.go for the canonical taxonomy.
+// Unknown errors map to Internal with the underlying message.
+func translatePauseSnapshotError(err error) error {
+	switch {
+	case errors.Is(err, connector.ErrPauseNotConfigured):
+		return status.Error(codes.Unavailable, err.Error())
+	case errors.Is(err, connector.ErrAlreadyPausing):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, connector.ErrNotPaused):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, connector.ErrSnapshotNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, connector.ErrSnapshotTooLarge):
+		return status.Error(codes.ResourceExhausted, err.Error())
+	case errors.Is(err, connector.ErrSnapshotVersionTooNew):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, connector.ErrSnapshotVersionUnknown):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	default:
+		return status.Errorf(codes.Internal, "%v", err)
+	}
+}

--- a/internal/api/grpc/pause_snapshot_test.go
+++ b/internal/api/grpc/pause_snapshot_test.go
@@ -1,0 +1,436 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	googlegrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// v0.8.18 gRPC pause/snapshot tests. The wire shape is covered by the
+// HTTP handler tests + the Connector impl tests in
+// internal/api/http/connector_impl_pause_snapshot_test.go. These tests
+// assert (a) the gRPC handlers dispatch through s.connector, (b) the
+// proto wire shape round-trips field values correctly, (c) typed
+// errors translate to the expected gRPC status codes.
+
+// pauseSnapshotMock is a programmable Connector stub purpose-built
+// for these tests. Each method returns whatever the test stages.
+// Unrelated Connector methods are inherited from the existing
+// mockConnector via embedding.
+type pauseSnapshotMock struct {
+	mockConnector
+
+	pauseResult         connector.PauseResult
+	pauseErr            error
+	resumeResult        connector.ResumeResult
+	resumeErr           error
+	stateResult         connector.RuntimeState
+	stateErr            error
+	createSnapshotResp  connector.SnapshotDescriptor
+	createSnapshotErr   error
+	listSnapshotsResp   []connector.SnapshotDescriptor
+	getSnapshotResp     connector.SnapshotEnvelope
+	getSnapshotErr      error
+	exportSnapshotResp  connector.ExportSnapshotResult
+	exportSnapshotErr   error
+	restoreSnapshotResp connector.RestoreSnapshotResult
+	restoreSnapshotErr  error
+	deleteErr           error
+
+	lastCreateReq  connector.CreateSnapshotRequest
+	lastRestoreReq connector.RestoreSnapshotRequest
+	lastDeleteID   string
+	lastGetID      string
+	lastExportID   string
+	lastPauseMS    int
+}
+
+func (m *pauseSnapshotMock) PauseRuntime(_ context.Context, timeoutMS int) (connector.PauseResult, error) {
+	m.lastPauseMS = timeoutMS
+	return m.pauseResult, m.pauseErr
+}
+func (m *pauseSnapshotMock) ResumeRuntime(context.Context) (connector.ResumeResult, error) {
+	return m.resumeResult, m.resumeErr
+}
+func (m *pauseSnapshotMock) GetRuntimeState(context.Context) (connector.RuntimeState, error) {
+	return m.stateResult, m.stateErr
+}
+func (m *pauseSnapshotMock) CreateSnapshot(_ context.Context, req connector.CreateSnapshotRequest) (connector.SnapshotDescriptor, error) {
+	m.lastCreateReq = req
+	return m.createSnapshotResp, m.createSnapshotErr
+}
+func (m *pauseSnapshotMock) ListSnapshots(context.Context) ([]connector.SnapshotDescriptor, error) {
+	return m.listSnapshotsResp, nil
+}
+func (m *pauseSnapshotMock) GetSnapshot(_ context.Context, id string) (connector.SnapshotEnvelope, error) {
+	m.lastGetID = id
+	return m.getSnapshotResp, m.getSnapshotErr
+}
+func (m *pauseSnapshotMock) ExportSnapshot(_ context.Context, id string) (connector.ExportSnapshotResult, error) {
+	m.lastExportID = id
+	return m.exportSnapshotResp, m.exportSnapshotErr
+}
+func (m *pauseSnapshotMock) RestoreSnapshot(_ context.Context, req connector.RestoreSnapshotRequest) (connector.RestoreSnapshotResult, error) {
+	m.lastRestoreReq = req
+	return m.restoreSnapshotResp, m.restoreSnapshotErr
+}
+func (m *pauseSnapshotMock) DeleteSnapshot(_ context.Context, id string) error {
+	m.lastDeleteID = id
+	return m.deleteErr
+}
+
+// startTestServerWithConnector mirrors startTestServer but wires the
+// supplied Connector. Returns a connected client + the cleanup.
+func startTestServerWithConnector(t *testing.T, mc connector.Connector) (loomcyclepb.LoomcycleClient, func()) {
+	t.Helper()
+	adapter := New(Config{
+		Store:     newTestStore(t),
+		CancelReg: cancel.NewRegistry(),
+		Connector: mc,
+	})
+	grpcSrv := googlegrpc.NewServer()
+	loomcyclepb.RegisterLoomcycleServer(grpcSrv, adapter)
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	go func() { _ = grpcSrv.Serve(lis) }()
+	conn, err := googlegrpc.NewClient(lis.Addr().String(),
+		googlegrpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := loomcyclepb.NewLoomcycleClient(conn)
+	return client, func() {
+		_ = conn.Close()
+		grpcSrv.GracefulStop()
+	}
+}
+
+// --- PauseRuntime ---
+
+func TestGrpcPauseRuntime_HappyPath(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		pauseResult: connector.PauseResult{
+			Status:              "paused",
+			DurationMS:          42,
+			ForceCancelledCount: 1,
+			PausedRunsCount:     2,
+			Warnings:            []string{"flaky-tool"},
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.PauseRuntime(context.Background(), &loomcyclepb.PauseRuntimeRequest{TimeoutMs: 5000})
+	if err != nil {
+		t.Fatalf("PauseRuntime: %v", err)
+	}
+	if resp.GetStatus() != "paused" {
+		t.Errorf("status = %q, want paused", resp.GetStatus())
+	}
+	if resp.GetDurationMs() != 42 {
+		t.Errorf("duration_ms = %d, want 42", resp.GetDurationMs())
+	}
+	if resp.GetPausedRunsCount() != 2 {
+		t.Errorf("paused_runs_count = %d, want 2", resp.GetPausedRunsCount())
+	}
+	if got := mc.lastPauseMS; got != 5000 {
+		t.Errorf("Connector saw timeout_ms = %d, want 5000", got)
+	}
+}
+
+func TestGrpcPauseRuntime_AlreadyPausing(t *testing.T) {
+	mc := &pauseSnapshotMock{pauseErr: connector.ErrAlreadyPausing}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.PauseRuntime(context.Background(), &loomcyclepb.PauseRuntimeRequest{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func TestGrpcPauseRuntime_NotConfigured(t *testing.T) {
+	mc := &pauseSnapshotMock{pauseErr: connector.ErrPauseNotConfigured}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.PauseRuntime(context.Background(), &loomcyclepb.PauseRuntimeRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %v, want Unavailable", status.Code(err))
+	}
+}
+
+func TestGrpcResumeRuntime_NotPaused(t *testing.T) {
+	mc := &pauseSnapshotMock{resumeErr: connector.ErrNotPaused}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.ResumeRuntime(context.Background(), &loomcyclepb.ResumeRuntimeRequest{})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func TestGrpcResumeRuntime_HappyPath(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		resumeResult: connector.ResumeResult{
+			Status:          "running",
+			ResumedRunCount: 5,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ResumeRuntime(context.Background(), &loomcyclepb.ResumeRuntimeRequest{})
+	if err != nil {
+		t.Fatalf("ResumeRuntime: %v", err)
+	}
+	if resp.GetStatus() != "running" {
+		t.Errorf("status = %q, want running", resp.GetStatus())
+	}
+	if resp.GetResumedRunCount() != 5 {
+		t.Errorf("resumed_run_count = %d, want 5", resp.GetResumedRunCount())
+	}
+}
+
+func TestGrpcGetRuntimeState(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		stateResult: connector.RuntimeState{
+			Status:         "paused",
+			PausedRunCount: 3,
+			SnapshotsCount: 7,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.GetRuntimeState(context.Background(), &loomcyclepb.GetRuntimeStateRequest{})
+	if err != nil {
+		t.Fatalf("GetRuntimeState: %v", err)
+	}
+	if resp.GetStatus() != "paused" {
+		t.Errorf("status = %q, want paused", resp.GetStatus())
+	}
+	if resp.GetPausedRunCount() != 3 {
+		t.Errorf("paused_run_count = %d, want 3", resp.GetPausedRunCount())
+	}
+	if resp.GetSnapshotsCount() != 7 {
+		t.Errorf("snapshots_count = %d, want 7", resp.GetSnapshotsCount())
+	}
+}
+
+// --- Snapshot lifecycle ---
+
+func TestGrpcCreateSnapshot_HappyPath(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		createSnapshotResp: connector.SnapshotDescriptor{
+			SnapshotID:    "snap_xyz",
+			CreatedAt:     time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+			SizeBytes:     1024,
+			Description:   "test",
+			FormatVersion: "1",
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.CreateSnapshot(context.Background(), &loomcyclepb.CreateSnapshotRequest{
+		Description: "test",
+	})
+	if err != nil {
+		t.Fatalf("CreateSnapshot: %v", err)
+	}
+	if resp.GetSnapshotId() != "snap_xyz" {
+		t.Errorf("snapshot_id = %q, want snap_xyz", resp.GetSnapshotId())
+	}
+	if mc.lastCreateReq.Description != "test" {
+		t.Errorf("Connector saw Description = %q, want test", mc.lastCreateReq.Description)
+	}
+}
+
+func TestGrpcCreateSnapshot_TooLarge(t *testing.T) {
+	mc := &pauseSnapshotMock{createSnapshotErr: connector.ErrSnapshotTooLarge}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.CreateSnapshot(context.Background(), &loomcyclepb.CreateSnapshotRequest{})
+	if status.Code(err) != codes.ResourceExhausted {
+		t.Errorf("code = %v, want ResourceExhausted", status.Code(err))
+	}
+}
+
+func TestGrpcListSnapshots(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		listSnapshotsResp: []connector.SnapshotDescriptor{
+			{SnapshotID: "snap_a", CreatedAt: time.Now()},
+			{SnapshotID: "snap_b", CreatedAt: time.Now()},
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ListSnapshots(context.Background(), &loomcyclepb.ListSnapshotsRequest{})
+	if err != nil {
+		t.Fatalf("ListSnapshots: %v", err)
+	}
+	if len(resp.GetSnapshots()) != 2 {
+		t.Errorf("len(snapshots) = %d, want 2", len(resp.GetSnapshots()))
+	}
+}
+
+func TestGrpcGetSnapshot_HappyPath(t *testing.T) {
+	envelope := json.RawMessage(`{"schema_version":1,"sections":{}}`)
+	mc := &pauseSnapshotMock{
+		getSnapshotResp: connector.SnapshotEnvelope{
+			SnapshotID:    "snap_xyz",
+			CreatedAt:     time.Now(),
+			Description:   "test",
+			FormatVersion: "1",
+			SizeBytes:     int64(len(envelope)),
+			JSONContent:   envelope,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.GetSnapshot(context.Background(), &loomcyclepb.GetSnapshotRequest{SnapshotId: "snap_xyz"})
+	if err != nil {
+		t.Fatalf("GetSnapshot: %v", err)
+	}
+	if resp.GetSnapshotId() != "snap_xyz" {
+		t.Errorf("snapshot_id = %q, want snap_xyz", resp.GetSnapshotId())
+	}
+	if string(resp.GetJsonContent()) != string(envelope) {
+		t.Errorf("json_content round-trip mismatch")
+	}
+	if mc.lastGetID != "snap_xyz" {
+		t.Errorf("Connector saw id = %q, want snap_xyz", mc.lastGetID)
+	}
+}
+
+func TestGrpcGetSnapshot_NotFound(t *testing.T) {
+	mc := &pauseSnapshotMock{getSnapshotErr: connector.ErrSnapshotNotFound}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.GetSnapshot(context.Background(), &loomcyclepb.GetSnapshotRequest{SnapshotId: "x"})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestGrpcExportSnapshot_HappyPath(t *testing.T) {
+	envelope := []byte(`{"schema_version":1,"sections":{}}`)
+	mc := &pauseSnapshotMock{
+		exportSnapshotResp: connector.ExportSnapshotResult{
+			SnapshotID: "snap_xyz",
+			SizeBytes:  int64(len(envelope)),
+			RawJSON:    envelope,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ExportSnapshot(context.Background(), &loomcyclepb.ExportSnapshotRequest{SnapshotId: "snap_xyz"})
+	if err != nil {
+		t.Fatalf("ExportSnapshot: %v", err)
+	}
+	if string(resp.GetRawJson()) != string(envelope) {
+		t.Errorf("raw_json round-trip mismatch")
+	}
+}
+
+func TestGrpcExportSnapshot_NotFound(t *testing.T) {
+	mc := &pauseSnapshotMock{exportSnapshotErr: connector.ErrSnapshotNotFound}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.ExportSnapshot(context.Background(), &loomcyclepb.ExportSnapshotRequest{SnapshotId: "x"})
+	if status.Code(err) != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", status.Code(err))
+	}
+}
+
+func TestGrpcRestoreSnapshot_HappyPath(t *testing.T) {
+	mc := &pauseSnapshotMock{
+		restoreSnapshotResp: connector.RestoreSnapshotResult{
+			MemoryRestored:     3,
+			PausedRunsRestored: 1,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.RestoreSnapshot(context.Background(), &loomcyclepb.RestoreSnapshotRequest{
+		SnapshotId: "snap_xyz",
+	})
+	if err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	if resp.GetMemoryRestored() != 3 {
+		t.Errorf("memory_restored = %d, want 3", resp.GetMemoryRestored())
+	}
+	if resp.GetPausedRunsRestored() != 1 {
+		t.Errorf("paused_runs_restored = %d, want 1", resp.GetPausedRunsRestored())
+	}
+	if mc.lastRestoreReq.SnapshotID != "snap_xyz" {
+		t.Errorf("Connector saw SnapshotID = %q, want snap_xyz", mc.lastRestoreReq.SnapshotID)
+	}
+}
+
+func TestGrpcRestoreSnapshot_VersionTooNew(t *testing.T) {
+	mc := &pauseSnapshotMock{restoreSnapshotErr: connector.ErrSnapshotVersionTooNew}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.RestoreSnapshot(context.Background(), &loomcyclepb.RestoreSnapshotRequest{SnapshotId: "x"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", status.Code(err))
+	}
+}
+
+func TestGrpcDeleteSnapshot_Idempotent(t *testing.T) {
+	mc := &pauseSnapshotMock{}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.DeleteSnapshot(context.Background(), &loomcyclepb.DeleteSnapshotRequest{SnapshotId: "snap_xyz"})
+	if err != nil {
+		t.Fatalf("DeleteSnapshot: %v", err)
+	}
+	if !resp.GetDeleted() {
+		t.Error("deleted = false, want true (idempotent contract)")
+	}
+	if mc.lastDeleteID != "snap_xyz" {
+		t.Errorf("Connector saw id = %q, want snap_xyz", mc.lastDeleteID)
+	}
+}
+
+// --- Connector wiring guard ---
+
+// TestGrpcPauseRuntime_NoConnectorReturnsUnavailable pins that a
+// gRPC server constructed without a Connector (legacy test config)
+// returns codes.Unavailable rather than panicking — matches the
+// HTTP connector layer's "pause manager not configured" posture.
+func TestGrpcPauseRuntime_NoConnectorReturnsUnavailable(t *testing.T) {
+	client, _, _, cleanup := startTestServer(t, "")
+	defer cleanup()
+
+	_, err := client.PauseRuntime(context.Background(), &loomcyclepb.PauseRuntimeRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %v, want Unavailable", status.Code(err))
+	}
+}

--- a/internal/api/grpc/pause_snapshot_test.go
+++ b/internal/api/grpc/pause_snapshot_test.go
@@ -40,6 +40,7 @@ type pauseSnapshotMock struct {
 	createSnapshotResp  connector.SnapshotDescriptor
 	createSnapshotErr   error
 	listSnapshotsResp   []connector.SnapshotDescriptor
+	listSnapshotsErr    error
 	getSnapshotResp     connector.SnapshotEnvelope
 	getSnapshotErr      error
 	exportSnapshotResp  connector.ExportSnapshotResult
@@ -71,7 +72,7 @@ func (m *pauseSnapshotMock) CreateSnapshot(_ context.Context, req connector.Crea
 	return m.createSnapshotResp, m.createSnapshotErr
 }
 func (m *pauseSnapshotMock) ListSnapshots(context.Context) ([]connector.SnapshotDescriptor, error) {
-	return m.listSnapshotsResp, nil
+	return m.listSnapshotsResp, m.listSnapshotsErr
 }
 func (m *pauseSnapshotMock) GetSnapshot(_ context.Context, id string) (connector.SnapshotEnvelope, error) {
 	m.lastGetID = id
@@ -230,6 +231,41 @@ func TestGrpcGetRuntimeState(t *testing.T) {
 	if resp.GetSnapshotsCount() != 7 {
 		t.Errorf("snapshots_count = %d, want 7", resp.GetSnapshotsCount())
 	}
+	// PausedAt is nil on the mock — the handler's nil-guard at
+	// pause_snapshot.go (if res.PausedAt != nil) means the proto
+	// PausedAt field stays unset; assert that explicitly.
+	if resp.GetPausedAt() != nil {
+		t.Errorf("paused_at = %v, want nil when connector RuntimeState.PausedAt is nil", resp.GetPausedAt())
+	}
+}
+
+// TestGrpcGetRuntimeState_Paused exercises the non-nil PausedAt
+// branch in GetRuntimeState. Without this, the nil-guard at
+// pause_snapshot.go:69 was tested only on the nil side; the dereference +
+// timestamppb.New path was dead code from the test's perspective.
+func TestGrpcGetRuntimeState_Paused(t *testing.T) {
+	pausedAt := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	mc := &pauseSnapshotMock{
+		stateResult: connector.RuntimeState{
+			Status:         "paused",
+			PausedAt:       &pausedAt,
+			PausedRunCount: 1,
+			SnapshotsCount: 1,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.GetRuntimeState(context.Background(), &loomcyclepb.GetRuntimeStateRequest{})
+	if err != nil {
+		t.Fatalf("GetRuntimeState: %v", err)
+	}
+	if resp.GetPausedAt() == nil {
+		t.Fatal("paused_at = nil, want non-nil Timestamp")
+	}
+	if got := resp.GetPausedAt().AsTime().UTC(); !got.Equal(pausedAt) {
+		t.Errorf("paused_at = %v, want %v", got, pausedAt)
+	}
 }
 
 // --- Snapshot lifecycle ---
@@ -288,6 +324,23 @@ func TestGrpcListSnapshots(t *testing.T) {
 	}
 	if len(resp.GetSnapshots()) != 2 {
 		t.Errorf("len(snapshots) = %d, want 2", len(resp.GetSnapshots()))
+	}
+}
+
+// TestGrpcListSnapshots_PauseNotConfigured pins that typed
+// connector errors flow through ListSnapshots's
+// translatePauseSnapshotError. Without this, the error path was
+// untested — the mock previously hardcoded nil for the error
+// return so the translatePauseSnapshotError branch in
+// pause_snapshot.go was dead code from the test's perspective.
+func TestGrpcListSnapshots_PauseNotConfigured(t *testing.T) {
+	mc := &pauseSnapshotMock{listSnapshotsErr: connector.ErrPauseNotConfigured}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	_, err := client.ListSnapshots(context.Background(), &loomcyclepb.ListSnapshotsRequest{})
+	if status.Code(err) != codes.Unavailable {
+		t.Errorf("code = %v, want Unavailable", status.Code(err))
 	}
 }
 

--- a/proto/loomcycle.proto
+++ b/proto/loomcycle.proto
@@ -384,8 +384,12 @@ message HealthResponse {
 message PauseRuntimeRequest {
   // Wait-for-non-idempotent-tools cap, in milliseconds. 0 falls
   // through to LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS (default 30 s).
-  // Clamped server-side at pause.MaxPauseTimeout (5 min).
-  int32 timeout_ms = 1;
+  // Clamped server-side at pause.MaxPauseTimeout (5 min). int64
+  // for consistency with every other _ms field in this proto
+  // (duration_ms in PauseRuntimeResponse, wait_ms in Retry) —
+  // server clamping makes the larger range unobservable but the
+  // type matches.
+  int64 timeout_ms = 1;
 }
 
 message PauseRuntimeResponse {

--- a/proto/loomcycle.proto
+++ b/proto/loomcycle.proto
@@ -74,6 +74,83 @@ service Loomcycle {
   // Mirrors GET /healthz (which is unauthenticated on the HTTP side;
   // the gRPC equivalent stays unauthenticated for parity).
   rpc Health(HealthRequest) returns (HealthResponse);
+
+  // ----- v0.8.17 Pause / Resume / Snapshot (real impls in v0.8.18) -----
+  //
+  // Runtime-wide quiesce + cross-version-portable JSON snapshot. Wire
+  // shapes mirror the connector.Connector method signatures. Typed
+  // errors from internal/connector/errors.go map to gRPC codes:
+  //   ErrPauseNotConfigured     → Unavailable (503-equivalent)
+  //   ErrAlreadyPausing         → FailedPrecondition (409-equivalent)
+  //   ErrNotPaused              → FailedPrecondition (409-equivalent)
+  //   ErrSnapshotNotFound       → NotFound (404-equivalent)
+  //   ErrSnapshotTooLarge       → ResourceExhausted (413-equivalent)
+  //   ErrSnapshotVersionTooNew  → FailedPrecondition (422-equivalent)
+  //   ErrSnapshotVersionUnknown → FailedPrecondition (422-equivalent)
+
+  // PauseRuntime quiesces the runtime. Idempotent tools cancel
+  // immediately; non-idempotent + external tools get a grace window
+  // (default 30 s; max 5 min) then force-cancel. Returns 409-equivalent
+  // when the runtime is already pausing or paused.
+  //
+  // Mirrors POST /v1/_pause.
+  rpc PauseRuntime(PauseRuntimeRequest) returns (PauseRuntimeResponse);
+
+  // ResumeRuntime releases the quiesce. Paused runs re-enter their
+  // loops. Returns 409-equivalent when the runtime is not paused.
+  //
+  // Mirrors POST /v1/_resume.
+  rpc ResumeRuntime(ResumeRuntimeRequest) returns (ResumeRuntimeResponse);
+
+  // GetRuntimeState returns the current quiesce state for dashboards.
+  //
+  // Mirrors GET /v1/_state.
+  rpc GetRuntimeState(GetRuntimeStateRequest) returns (RuntimeStateResponse);
+
+  // CreateSnapshot captures running-state into a per-section-semver
+  // JSON envelope (agent_defs, agent_def_active, memory, channels,
+  // evaluations, paused_runs, optional interaction_history). Returns
+  // 413-equivalent when the serialised envelope exceeds the configured
+  // cap (LOOMCYCLE_SNAPSHOT_MAX_BYTES; default 512 MiB).
+  //
+  // Mirrors POST /v1/_snapshots.
+  rpc CreateSnapshot(CreateSnapshotRequest) returns (SnapshotDescriptor);
+
+  // ListSnapshots returns metadata for the most-recent snapshots
+  // (capped at 200). The JSON envelope itself is not included; use
+  // GetSnapshot / ExportSnapshot to fetch.
+  //
+  // Mirrors GET /v1/_snapshots.
+  rpc ListSnapshots(ListSnapshotsRequest) returns (ListSnapshotsResponse);
+
+  // GetSnapshot returns the full envelope including JSON content.
+  // Distinct from ExportSnapshot, which is operator-facing "where did
+  // this land on the host" semantics.
+  //
+  // Mirrors GET /v1/_snapshots/{id}.
+  rpc GetSnapshot(GetSnapshotRequest) returns (SnapshotEnvelope);
+
+  // ExportSnapshot returns canonical envelope bytes (raw_json) for a
+  // snapshot id. Transports that stream large exports use raw_json
+  // directly; file_path / checksum stay empty unless materialised.
+  //
+  // Mirrors GET /v1/_snapshots/{id}/export.
+  rpc ExportSnapshot(ExportSnapshotRequest) returns (ExportSnapshotResponse);
+
+  // RestoreSnapshot restores from a same-instance snapshot_id OR
+  // cross-instance raw_json. Idempotent: ON CONFLICT DO NOTHING per
+  // row. Counters in the response reflect rows actually written.
+  // Returns 422-equivalent on snapshot version newer than reader
+  // supports.
+  //
+  // Mirrors POST /v1/_snapshots/{id}/restore.
+  rpc RestoreSnapshot(RestoreSnapshotRequest) returns (RestoreSnapshotResponse);
+
+  // DeleteSnapshot removes a snapshot. Idempotent — succeeds whether
+  // or not the row existed.
+  //
+  // Mirrors DELETE /v1/_snapshots/{id}.
+  rpc DeleteSnapshot(DeleteSnapshotRequest) returns (DeleteSnapshotResponse);
 }
 
 // ========================
@@ -298,4 +375,145 @@ message HealthResponse {
   string built = 3;
   // Uptime in seconds since process start.
   int64 uptime_seconds = 4;
+}
+
+// ========================
+// Pause / Resume / State (v0.8.17 primitives; gRPC surface v0.8.18)
+// ========================
+
+message PauseRuntimeRequest {
+  // Wait-for-non-idempotent-tools cap, in milliseconds. 0 falls
+  // through to LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS (default 30 s).
+  // Clamped server-side at pause.MaxPauseTimeout (5 min).
+  int32 timeout_ms = 1;
+}
+
+message PauseRuntimeResponse {
+  string status = 1;              // "paused"
+  int64 duration_ms = 2;
+  int32 force_cancelled_count = 3;
+  int32 paused_runs_count = 4;
+  repeated string warnings = 5;
+}
+
+message ResumeRuntimeRequest {}
+
+message ResumeRuntimeResponse {
+  string status = 1;              // "running"
+  int32 resumed_run_count = 2;
+  repeated string warnings = 3;
+}
+
+message GetRuntimeStateRequest {}
+
+message RuntimeStateResponse {
+  string status = 1;              // "running" | "pausing" | "paused"
+  google.protobuf.Timestamp paused_at = 2;
+  int32 paused_run_count = 3;
+  int32 snapshots_count = 4;
+}
+
+// ========================
+// Snapshot (v0.8.17 primitives; gRPC surface v0.8.18)
+// ========================
+
+message CreateSnapshotRequest {
+  bool include_history = 1;
+  google.protobuf.Timestamp since_ts = 2;
+  string description = 3;
+  // Override LOOMCYCLE_SNAPSHOT_MAX_BYTES for this call. 0 = default.
+  int64 max_bytes = 4;
+}
+
+// SnapshotDescriptor is the metadata-only view used by CreateSnapshot
+// + ListSnapshots. The full JSON envelope lives in GetSnapshot /
+// ExportSnapshot responses.
+message SnapshotDescriptor {
+  string snapshot_id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  int64 size_bytes = 3;
+  bool includes_history = 4;
+  google.protobuf.Timestamp since_ts = 5;
+  string description = 6;
+  string format_version = 7;
+}
+
+message ListSnapshotsRequest {}
+
+message ListSnapshotsResponse {
+  repeated SnapshotDescriptor snapshots = 1;
+}
+
+message GetSnapshotRequest {
+  string snapshot_id = 1;
+}
+
+// SnapshotEnvelope carries the full row including JSON content.
+// Distinct from ExportSnapshotResponse, which is operator-facing
+// "where did this land on the host" semantics.
+message SnapshotEnvelope {
+  string snapshot_id = 1;
+  google.protobuf.Timestamp created_at = 2;
+  string description = 3;
+  string format_version = 4;
+  int64 size_bytes = 5;
+  // Canonical envelope bytes.
+  bytes json_content = 6;
+}
+
+message ExportSnapshotRequest {
+  string snapshot_id = 1;
+}
+
+message ExportSnapshotResponse {
+  string snapshot_id = 1;
+  // file_path + checksum are populated when a transport materialises
+  // the export to disk first (CLI's --out flag). Otherwise empty —
+  // raw_json carries the canonical bytes directly.
+  string file_path = 2;
+  string checksum = 3;
+  int64 size_bytes = 4;
+  bytes raw_json = 5;
+}
+
+message RestoreSnapshotRequest {
+  // Exactly one of snapshot_id (same-instance lookup) or raw_json
+  // (cross-instance restore from inline bytes) must be non-empty.
+  // file_path restore is intentionally not supported on the gRPC
+  // surface — supply raw_json inline (CLI reads the file client-side).
+  string snapshot_id = 1;
+  bytes raw_json = 2;
+  bool include_history = 3;
+}
+
+message RestoreSnapshotResponse {
+  // Per-section counters. Reflect rows actually written
+  // (ON CONFLICT DO NOTHING — a re-restore reports 0 even though
+  // every per-row INSERT "succeeded").
+  int32 agent_defs_restored = 1;
+  int32 agent_def_active_restored = 2;
+  int32 memory_restored = 3;
+  int32 channel_messages_restored = 4;
+  int32 channel_cursors_restored = 5;
+  int32 evaluations_restored = 6;
+  int32 paused_runs_restored = 7;
+  // Sessions synthesized for cross-instance restore (paused_runs
+  // reference session_ids; restore creates snap_sess_<run_id>
+  // entries deterministically when needed).
+  int32 synthesized_sessions = 8;
+  int32 transcript_events_restored = 9;
+  int32 interaction_history_restored = 10;
+  repeated string warnings = 11;
+  repeated string format_migrations = 12;
+}
+
+message DeleteSnapshotRequest {
+  string snapshot_id = 1;
+}
+
+message DeleteSnapshotResponse {
+  // Always true — DELETE is idempotent (returns ok whether or not
+  // the row existed; mirrors HTTP DELETE /v1/_snapshots/{id} = 204).
+  bool deleted = 1;
+  string snapshot_id = 2;
 }


### PR DESCRIPTION
## Summary

v0.8.18 PR 2 — gRPC catch-up for v0.8.17 Pause/Resume/Snapshot. Previously the gRPC surface only had run lifecycle + agent management + health (7 RPCs). This PR adds 9 RPCs so any gRPC client (including the production Python adapter) can drive the same surface.

### Changes
- **Proto** (\`proto/loomcycle.proto\`): 9 new RPCs + 13 new message types.
- **Generated stubs**: \`make proto\` clean regen.
- **Handlers** (\`internal/api/grpc/pause_snapshot.go\`): each dispatches \`s.connector.X(...)\` + translates typed Connector errors to gRPC status codes.
- **Tests** (\`internal/api/grpc/pause_snapshot_test.go\`, 17 cases): happy paths, error-code translation, wire round-trip, idempotent delete, no-connector fallback.

Stacked on #136 (which provides the real Connector impls). Without #136, the gRPC handlers would dispatch to mocked Connector responses.

## Test plan
- [x] \`make proto\` clean
- [x] \`go test ./internal/api/grpc/...\` clean (36 tests total)
- [x] Full \`go test ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)