### PR TITLE
feat(ts): 23 new methods + Vitest test suite (PR 5b of 5c, stacked on #140)

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -9,10 +9,1439 @@
       "version": "0.1.0-alpha.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "typescript": "^5.6.0"
+        "typescript": "^5.6.0",
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -27,6 +1456,194 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -18,10 +18,13 @@
   ],
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
-    "typescript": "^5.6.0"
+    "typescript": "^5.6.0",
+    "vitest": "^3.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -103,6 +103,7 @@ export class LoomcycleClient {
       {
         segments: opts.segments,
         allowed_tools: opts.allowedTools,
+        ...(opts.agentId ? { agent_id: opts.agentId } : {}),
       },
       opts.signal,
     );
@@ -250,13 +251,13 @@ export class LoomcycleClient {
     );
   }
 
-  /** URL of the snapshot's canonical envelope. Operators can curl
-   *  this directly or piping into a file (the response has a
-   *  Content-Disposition header). When the client has an
-   *  authToken set, callers add `?token=...` query-param manually
-   *  if the server enforces it on this route — the default
-   *  loomcycle binding accepts Authorization header on all
-   *  bearer-authed routes. */
+  /** Returns the URL of the snapshot's canonical envelope —
+   *  synchronous and side-effect-free; does NOT issue an HTTP
+   *  request. The endpoint is bearer-authed like every other
+   *  `/v1/_snapshots/*` route, so callers must attach the same
+   *  `Authorization: Bearer <token>` header when fetching this
+   *  URL (e.g. `curl -H "Authorization: Bearer $TOKEN" ...`).
+   *  There is no token query-param fallback. */
   exportSnapshotURL(snapshotId: string): string {
     return `${this.ctx.baseUrl}/v1/_snapshots/${encodeURIComponent(snapshotId)}/export`;
   }
@@ -348,7 +349,11 @@ export class LoomcycleClient {
   ): Promise<MemoryEntriesResponse> {
     const params = new URLSearchParams();
     if (opts?.prefix) params.set("prefix", opts.prefix);
-    if (opts?.limit) params.set("limit", String(opts.limit));
+    // Guard against `limit: 0` (falsy but valid-looking) and negatives —
+    // both would either send `limit=0` (server treats as default but the
+    // semantic is unclear) or `limit=-N` (server rejects). Only send the
+    // param when the caller passed a meaningful positive number.
+    if (opts?.limit && opts.limit > 0) params.set("limit", String(opts.limit));
     const qs = params.toString();
     const path = `/v1/_memory/scopes/${encodeURIComponent(scope)}/${encodeURIComponent(scopeID)}/keys${qs ? "?" + qs : ""}`;
     return jsonFetch<MemoryEntriesResponse>(this.ctx, path, opts);

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -2,10 +2,10 @@
  * LoomcycleClient — the single public class exported by
  * @loomcycle/client. Speaks HTTP+SSE to a running loomcycle sidecar.
  *
- * PR 5a foundation: hosts the existing runStreaming() with
- * byte-identical behavior. PR 5b adds the remaining 21 methods
- * (continueSession + agent metadata + pause/snapshot + memory +
- * interrupts) on top.
+ * v0.8.18: full Python-adapter parity. 22 methods covering run
+ * streaming, agent metadata, transcript, pause/resume/state,
+ * snapshot lifecycle (capture / list / get / export / restore /
+ * delete), memory admin, interruption resolve, and health.
  *
  * Construction:
  *
@@ -14,18 +14,49 @@
  *     authToken: "...",                  // or process.env.LOOMCYCLE_AUTH_TOKEN
  *   });
  *
- * Streaming methods return AsyncIterable<AgentEvent>; non-streaming
- * methods return Promise<T>. Non-2xx responses throw typed errors
- * from errors.ts via fetch-helpers.ts:raiseFromResponse.
+ * Streaming methods (`runStreaming`, `continueSession`) return
+ * AsyncIterable<AgentEvent>; non-streaming methods return
+ * Promise<T>. Non-2xx responses throw typed errors from errors.ts
+ * via fetch-helpers.ts:raiseFromResponse — see README.md for the
+ * full mapping table.
  */
 
 import type { _FetchContext } from "./fetch-helpers.js";
-import { raiseFromResponse } from "./fetch-helpers.js";
+import {
+  deleteRequest,
+  jsonFetch,
+  postJSON,
+  raiseFromResponse,
+} from "./fetch-helpers.js";
 import { parseSSE } from "./stream.js";
 import type {
+  Agent,
   AgentEvent,
+  AgentStatus,
+  CancelAgentResult,
   ClientOptions,
+  ContinueOptions,
+  CreateSnapshotOptions,
+  HealthResponse,
+  InterruptListResponse,
+  InterruptStatus,
+  ListAgentsResponse,
+  ListUsersResponse,
+  MemoryEntriesResponse,
+  MemoryEntryResponse,
+  MemoryScopeIDsResponse,
+  MemoryScopesResponse,
+  PauseResult,
+  ResolveInterruptOptions,
+  ResumeResult,
   RunOptions,
+  RuntimeStateResponse,
+  SnapshotCreateResponse,
+  SnapshotDescriptor,
+  SnapshotEnvelope,
+  SnapshotListResponse,
+  SnapshotRestoreResponse,
+  TranscriptResponse,
 } from "./types.js";
 
 export class LoomcycleClient {
@@ -39,20 +70,363 @@ export class LoomcycleClient {
     };
   }
 
+  // ---- Run lifecycle ----
+
   /**
    * Run an agent and stream events. Returns AsyncIterable<AgentEvent>;
    * the iterator completes when the server closes the SSE stream.
    *
    * Errors during the run surface as `{ type: "error", error }` events;
    * only transport / HTTP-level failures throw — and those throw typed
-   * errors from errors.ts (e.g. AuthError for 401, BackpressureError
-   * for 429).
-   *
-   * The wire shape is unchanged from v0.1.0-alpha.0: same request
-   * body, same SSE frame parsing. jobs-search-agent's existing
-   * runStreaming usage continues to work without changes.
+   * errors (e.g. AuthError for 401, BackpressureError for 429).
    */
   async *runStreaming(opts: RunOptions): AsyncIterable<AgentEvent> {
+    yield* this.streamSSE("/v1/runs", {
+      agent: opts.agent,
+      segments: opts.segments,
+      allowed_tools: opts.allowedTools,
+    }, opts.signal);
+  }
+
+  /**
+   * Continue an existing session with a new run. The session's prior
+   * transcript is replayed into the model's context server-side;
+   * this iterator yields only the NEW events from the continuation.
+   *
+   * Raises SessionNotFoundError when sessionId is unknown,
+   * SessionBusyError when another request is in flight on the same
+   * session.
+   */
+  async *continueSession(opts: ContinueOptions): AsyncIterable<AgentEvent> {
+    yield* this.streamSSE(
+      `/v1/sessions/${encodeURIComponent(opts.sessionId)}/messages`,
+      {
+        segments: opts.segments,
+        allowed_tools: opts.allowedTools,
+      },
+      opts.signal,
+    );
+  }
+
+  // ---- Agent metadata ----
+
+  /** Read one agent's status + usage stats. Raises AgentNotFoundError
+   *  when the agent_id is unknown. */
+  async getAgent(agentId: string, opts?: { signal?: AbortSignal }): Promise<Agent> {
+    return jsonFetch<Agent>(this.ctx, `/v1/agents/${encodeURIComponent(agentId)}`, opts);
+  }
+
+  /** Cancel a live agent (cascades to children via parent_agent_id).
+   *  Returns count of agents cancelled. Idempotent — already-terminated
+   *  agents return 0. */
+  async cancelAgent(
+    agentId: string,
+    opts?: { reason?: string; signal?: AbortSignal },
+  ): Promise<CancelAgentResult> {
+    const resp = await postJSON<{ cancelled_count: number }>(
+      this.ctx,
+      `/v1/agents/${encodeURIComponent(agentId)}/cancel`,
+      { reason: opts?.reason ?? "" },
+      opts,
+    );
+    return { cancelledCount: resp.cancelled_count };
+  }
+
+  /** List a user's recent agent runs, optionally filtered by status. */
+  async listUserAgents(
+    userId: string,
+    opts?: { status?: AgentStatus; signal?: AbortSignal },
+  ): Promise<Agent[]> {
+    const q = opts?.status ? `?status=${encodeURIComponent(opts.status)}` : "";
+    const resp = await jsonFetch<ListAgentsResponse>(
+      this.ctx,
+      `/v1/users/${encodeURIComponent(userId)}/agents${q}`,
+      opts,
+    );
+    return resp.agents ?? [];
+  }
+
+  /** Read the full event log for a session. Each entry has seq,
+   *  run_id, ts_ns, type, event (the providers.Event payload). */
+  async getTranscript(
+    sessionId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<TranscriptResponse> {
+    return jsonFetch<TranscriptResponse>(
+      this.ctx,
+      `/v1/sessions/${encodeURIComponent(sessionId)}/transcript`,
+      opts,
+    );
+  }
+
+  /** Liveness probe. Unauthenticated. Returns build info + uptime.
+   *  Hits /healthz, not /v1/. */
+  async health(opts?: { signal?: AbortSignal }): Promise<HealthResponse> {
+    return jsonFetch<HealthResponse>(this.ctx, "/healthz", opts);
+  }
+
+  /** Admin: list known users with running-count summary. Drives the
+   *  Web UI's user picker; operators with bearer auth can call too. */
+  async listUsers(opts?: { signal?: AbortSignal }): Promise<ListUsersResponse> {
+    return jsonFetch<ListUsersResponse>(this.ctx, "/v1/_users", opts);
+  }
+
+  // ---- v0.8.17/8.18 Pause / Resume / State ----
+
+  /** Quiesce the runtime. Idempotent tools cancel immediately;
+   *  non-idempotent + external tools get a grace window then
+   *  force-cancel. Raises AlreadyPausingError on 409,
+   *  PauseNotConfiguredError on 503. */
+  async pauseRuntime(opts?: {
+    timeoutMs?: number;
+    signal?: AbortSignal;
+  }): Promise<PauseResult> {
+    const body =
+      opts?.timeoutMs && opts.timeoutMs > 0
+        ? { timeout_ms: opts.timeoutMs }
+        : undefined;
+    return postJSON<PauseResult>(this.ctx, "/v1/_pause", body, opts);
+  }
+
+  /** Release the runtime quiesce. Raises NotPausedError on 409. */
+  async resumeRuntime(opts?: { signal?: AbortSignal }): Promise<ResumeResult> {
+    return postJSON<ResumeResult>(this.ctx, "/v1/_resume", undefined, opts);
+  }
+
+  /** Current runtime state. Cheap query — atomic state + a
+   *  bounded snapshots count. */
+  async getRuntimeState(opts?: {
+    signal?: AbortSignal;
+  }): Promise<RuntimeStateResponse> {
+    return jsonFetch<RuntimeStateResponse>(this.ctx, "/v1/_state", opts);
+  }
+
+  // ---- Snapshot lifecycle ----
+
+  /** Capture running-state into a per-section-semver JSON envelope.
+   *  Raises SnapshotTooLargeError on 413 when the envelope exceeds
+   *  LOOMCYCLE_SNAPSHOT_MAX_BYTES (default 512 MiB). */
+  async createSnapshot(
+    opts?: CreateSnapshotOptions & { signal?: AbortSignal },
+  ): Promise<SnapshotCreateResponse> {
+    const body: Record<string, unknown> = {};
+    if (opts?.label) body.label = opts.label;
+    if (opts?.includeHistory) body.include_history = true;
+    if (opts?.includeHistorySince)
+      body.include_history_since = opts.includeHistorySince;
+    if (opts?.maxBytes && opts.maxBytes > 0) body.max_bytes = opts.maxBytes;
+    return postJSON<SnapshotCreateResponse>(this.ctx, "/v1/_snapshots", body, opts);
+  }
+
+  /** List captured snapshots (most-recent first). Capped at 200
+   *  server-side; the limit param defaults to 200 too. */
+  async listSnapshots(opts?: {
+    limit?: number;
+    labelContains?: string;
+    signal?: AbortSignal;
+  }): Promise<SnapshotDescriptor[]> {
+    const params = new URLSearchParams();
+    if (opts?.limit && opts.limit > 0) params.set("limit", String(opts.limit));
+    if (opts?.labelContains)
+      params.set("label_contains", opts.labelContains);
+    const qs = params.toString();
+    const path = qs ? `/v1/_snapshots?${qs}` : "/v1/_snapshots";
+    const resp = await jsonFetch<SnapshotListResponse>(this.ctx, path, opts);
+    return resp.entries ?? [];
+  }
+
+  /** Fetch the full snapshot envelope including JSON content.
+   *  Distinct from exportSnapshot (which is operator-facing
+   *  "where did this land on the host" semantics with a download
+   *  URL). Raises SnapshotNotFoundError on 404. */
+  async getSnapshot(
+    snapshotId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<SnapshotEnvelope> {
+    return jsonFetch<SnapshotEnvelope>(
+      this.ctx,
+      `/v1/_snapshots/${encodeURIComponent(snapshotId)}`,
+      opts,
+    );
+  }
+
+  /** URL of the snapshot's canonical envelope. Operators can curl
+   *  this directly or piping into a file (the response has a
+   *  Content-Disposition header). When the client has an
+   *  authToken set, callers add `?token=...` query-param manually
+   *  if the server enforces it on this route — the default
+   *  loomcycle binding accepts Authorization header on all
+   *  bearer-authed routes. */
+  exportSnapshotURL(snapshotId: string): string {
+    return `${this.ctx.baseUrl}/v1/_snapshots/${encodeURIComponent(snapshotId)}/export`;
+  }
+
+  /** Restore from a same-instance snapshot id OR an inline
+   *  envelope JSON. Idempotent: ON CONFLICT DO NOTHING per row;
+   *  the returned counters reflect rows actually written.
+   *  Raises SnapshotVersionError on 422 when a section's
+   *  declared version is newer than the reader supports. */
+  async restoreSnapshot(opts: {
+    snapshotId?: string;
+    /** Pass a parsed JSON object (e.g. `getSnapshot.json_content` or
+     *  the result of JSON.parse on an exported envelope). */
+    json?: unknown;
+    includeHistory?: boolean;
+    signal?: AbortSignal;
+  }): Promise<SnapshotRestoreResponse> {
+    if (!opts.snapshotId && opts.json === undefined) {
+      // Client-side validation — match Python adapter's
+      // InvalidArgumentError pattern but the typed-error layer
+      // lives in errors.ts; for a thrown plain error here the
+      // method's catchers just see the message.
+      throw new Error(
+        "restoreSnapshot: pass snapshotId or json (one is required)",
+      );
+    }
+    if (opts.snapshotId && opts.json !== undefined) {
+      throw new Error(
+        "restoreSnapshot: pass only one of snapshotId or json",
+      );
+    }
+    // When json is supplied the id path-segment is ignored
+    // server-side; we use a placeholder "inline" segment to keep
+    // the URL well-formed.
+    const id = opts.snapshotId ?? "inline";
+    const body: Record<string, unknown> = {};
+    if (opts.includeHistory) body.include_history = true;
+    if (opts.json !== undefined) body.json = opts.json;
+    return postJSON<SnapshotRestoreResponse>(
+      this.ctx,
+      `/v1/_snapshots/${encodeURIComponent(id)}/restore`,
+      body,
+      opts,
+    );
+  }
+
+  /** Delete a snapshot. Idempotent — succeeds whether or not the
+   *  row existed (server returns 204 in both cases). */
+  async deleteSnapshot(
+    snapshotId: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<void> {
+    await deleteRequest(
+      this.ctx,
+      `/v1/_snapshots/${encodeURIComponent(snapshotId)}`,
+      opts,
+    );
+  }
+
+  // ---- Memory admin ----
+
+  /** List the kinds of memory scopes the server knows about
+   *  (agent, user — or whatever the operator yaml declares). */
+  async listMemoryScopes(opts?: {
+    signal?: AbortSignal;
+  }): Promise<MemoryScopesResponse> {
+    return jsonFetch<MemoryScopesResponse>(this.ctx, "/v1/_memory/scopes", opts);
+  }
+
+  /** List the scope_ids that have at least one memory row under
+   *  a given scope. */
+  async listMemoryScopeIDs(
+    scope: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MemoryScopeIDsResponse> {
+    return jsonFetch<MemoryScopeIDsResponse>(
+      this.ctx,
+      `/v1/_memory/scopes/${encodeURIComponent(scope)}`,
+      opts,
+    );
+  }
+
+  /** List memory entries under a (scope, scope_id) tuple.
+   *  Optional prefix narrows by key prefix. */
+  async listMemoryEntries(
+    scope: string,
+    scopeID: string,
+    opts?: { prefix?: string; limit?: number; signal?: AbortSignal },
+  ): Promise<MemoryEntriesResponse> {
+    const params = new URLSearchParams();
+    if (opts?.prefix) params.set("prefix", opts.prefix);
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    const qs = params.toString();
+    const path = `/v1/_memory/scopes/${encodeURIComponent(scope)}/${encodeURIComponent(scopeID)}/keys${qs ? "?" + qs : ""}`;
+    return jsonFetch<MemoryEntriesResponse>(this.ctx, path, opts);
+  }
+
+  /** Read a single memory entry by (scope, scope_id, key). */
+  async getMemoryEntry(
+    scope: string,
+    scopeID: string,
+    key: string,
+    opts?: { signal?: AbortSignal },
+  ): Promise<MemoryEntryResponse> {
+    return jsonFetch<MemoryEntryResponse>(
+      this.ctx,
+      `/v1/_memory/scopes/${encodeURIComponent(scope)}/${encodeURIComponent(scopeID)}/keys/${encodeURIComponent(key)}`,
+      opts,
+    );
+  }
+
+  // ---- Interruption ----
+
+  /** List interrupts addressable to a user_id. Default filter is
+   *  status=pending. */
+  async listUserInterrupts(
+    userId: string,
+    opts?: { status?: InterruptStatus; signal?: AbortSignal },
+  ): Promise<InterruptListResponse> {
+    const status = opts?.status ?? "pending";
+    return jsonFetch<InterruptListResponse>(
+      this.ctx,
+      `/v1/users/${encodeURIComponent(userId)}/interrupts?status=${encodeURIComponent(status)}`,
+      opts,
+    );
+  }
+
+  /** List interrupts emitted by a specific run. */
+  async listRunInterrupts(
+    runId: string,
+    opts?: { status?: InterruptStatus; signal?: AbortSignal },
+  ): Promise<InterruptListResponse> {
+    const status = opts?.status ?? "pending";
+    return jsonFetch<InterruptListResponse>(
+      this.ctx,
+      `/v1/runs/${encodeURIComponent(runId)}/interrupts?status=${encodeURIComponent(status)}`,
+      opts,
+    );
+  }
+
+  /** Resolve a pending Interruption.ask from outside the agent
+   *  loop. Lets a TS-side dashboard or service act as the human
+   *  answerer when operator yaml configures the consumer-MCP
+   *  backend. */
+  async resolveInterrupt(
+    runId: string,
+    interruptId: string,
+    opts: ResolveInterruptOptions & { signal?: AbortSignal },
+  ): Promise<unknown> {
+    return postJSON<unknown>(
+      this.ctx,
+      `/v1/runs/${encodeURIComponent(runId)}/interrupts/${encodeURIComponent(interruptId)}/resolve`,
+      {
+        kind: opts.kind ?? "question",
+        answer: opts.answer,
+        resolved_by: opts.resolvedBy ?? "client",
+      },
+      opts,
+    );
+  }
+
+  // ---- Internal helpers ----
+
+  /** Shared SSE POST → stream-of-AgentEvent path. Used by
+   *  runStreaming + continueSession. */
+  private async *streamSSE(
+    path: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): AsyncIterable<AgentEvent> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
       // Accept BOTH text/event-stream (the success path) AND
@@ -65,23 +439,17 @@ export class LoomcycleClient {
     };
     if (this.ctx.authToken) headers.Authorization = `Bearer ${this.ctx.authToken}`;
 
-    const resp = await this.ctx.fetchImpl(`${this.ctx.baseUrl}/v1/runs`, {
+    const resp = await this.ctx.fetchImpl(this.ctx.baseUrl + path, {
       method: "POST",
       headers,
-      body: JSON.stringify({
-        agent: opts.agent,
-        segments: opts.segments,
-        allowed_tools: opts.allowedTools,
-      }),
-      signal: opts.signal,
+      body: JSON.stringify(body),
+      signal,
     });
 
     if (!resp.ok) {
       await raiseFromResponse(resp);
     }
     if (!resp.body) {
-      // Defensive — the spec guarantees a body on streaming endpoints
-      // but typing is conservative.
       throw new Error("loomcycle: response has no body");
     }
 

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -1,45 +1,115 @@
 /**
  * @loomcycle/client — TypeScript client for the loomcycle sidecar.
  *
- * Public surface (v0.8.18 — Python-adapter parity in progress):
+ * Public surface (v0.8.18 — Python-adapter parity):
  *
  *   class LoomcycleClient
  *     constructor(opts: ClientOptions)
- *     runStreaming(opts: RunOptions): AsyncIterable<AgentEvent>
- *     // ...21 more methods land in PR 5b
  *
- *   Errors (typed subclasses of LoomcycleError):
+ *     // Run lifecycle (SSE streams)
+ *     runStreaming(opts: RunOptions): AsyncIterable<AgentEvent>
+ *     continueSession(opts: ContinueOptions): AsyncIterable<AgentEvent>
+ *
+ *     // Agent metadata
+ *     getAgent(agentId): Promise<Agent>
+ *     cancelAgent(agentId, opts?): Promise<CancelAgentResult>
+ *     listUserAgents(userId, opts?): Promise<Agent[]>
+ *     getTranscript(sessionId): Promise<TranscriptResponse>
+ *     health(): Promise<HealthResponse>
+ *     listUsers(): Promise<ListUsersResponse>
+ *
+ *     // Pause / Resume / State (v0.8.17/8.18)
+ *     pauseRuntime(opts?): Promise<PauseResult>
+ *     resumeRuntime(): Promise<ResumeResult>
+ *     getRuntimeState(): Promise<RuntimeStateResponse>
+ *
+ *     // Snapshot lifecycle (v0.8.17/8.18)
+ *     createSnapshot(opts?): Promise<SnapshotCreateResponse>
+ *     listSnapshots(opts?): Promise<SnapshotDescriptor[]>
+ *     getSnapshot(id): Promise<SnapshotEnvelope>
+ *     exportSnapshotURL(id): string  (synchronous; returns a URL)
+ *     restoreSnapshot(opts): Promise<SnapshotRestoreResponse>
+ *     deleteSnapshot(id): Promise<void>
+ *
+ *     // Memory admin
+ *     listMemoryScopes(): Promise<MemoryScopesResponse>
+ *     listMemoryScopeIDs(scope): Promise<MemoryScopeIDsResponse>
+ *     listMemoryEntries(scope, scopeID, opts?): Promise<MemoryEntriesResponse>
+ *     getMemoryEntry(scope, scopeID, key): Promise<MemoryEntryResponse>
+ *
+ *     // Interruption (v0.8.16)
+ *     listUserInterrupts(userId, opts?): Promise<InterruptListResponse>
+ *     listRunInterrupts(runId, opts?): Promise<InterruptListResponse>
+ *     resolveInterrupt(runId, interruptId, opts): Promise<unknown>
+ *
+ *   Errors (typed subclasses of LoomcycleError; see README for the
+ *   full HTTP-status → typed-error mapping table):
  *     LoomcycleError, AgentNotFoundError, SessionNotFoundError,
  *     SessionBusyError, AgentIDInUseError, BackpressureError,
  *     AuthError, UnavailableError, InvalidArgumentError,
- *     PauseNotConfiguredError, AlreadyPausingError, NotPausedError,
- *     SnapshotNotFoundError, SnapshotTooLargeError,
- *     SnapshotVersionError
- *
- *   Types (wire shapes):
- *     AgentEvent, EventType, ToolUse, Usage, PromptContent,
- *     PromptSegment, RunOptions, ClientOptions
+ *     PauseNotConfiguredError (subclass of UnavailableError),
+ *     AlreadyPausingError, NotPausedError, SnapshotNotFoundError,
+ *     SnapshotTooLargeError, SnapshotVersionError
  *
  * Transport: HTTP+SSE. Auth: Bearer token via the Authorization
  * header. Designed for Node ≥18 (engines pinned); Bun/Deno likely
  * work but untested. Browser support is not a target (use the
  * Web UI for browser-side operator control).
  *
- * See `adapters/ts/README.md` for usage examples and the full
- * API table.
+ * See `adapters/ts/README.md` for usage examples.
  */
 
 export { LoomcycleClient } from "./client.js";
 
 export type {
+  // Run lifecycle
   AgentEvent,
   ClientOptions,
+  ContinueOptions,
   EventType,
   PromptContent,
   PromptSegment,
   RunOptions,
   ToolUse,
   Usage,
+  // Agent metadata
+  Agent,
+  AgentStatus,
+  AgentUsage,
+  CancelAgentResult,
+  ListAgentsResponse,
+  // Transcript
+  TranscriptEvent,
+  TranscriptResponse,
+  // Health + Users
+  HealthResponse,
+  ListUsersResponse,
+  UserSummary,
+  // Pause / Resume / State
+  PauseResult,
+  ResumeResult,
+  RuntimeStateResponse,
+  RuntimeStateStatus,
+  // Snapshot
+  CreateSnapshotOptions,
+  SnapshotCreateResponse,
+  SnapshotDescriptor,
+  SnapshotEnvelope,
+  SnapshotListResponse,
+  SnapshotRestoreResponse,
+  // Memory
+  MemoryEntriesResponse,
+  MemoryEntry,
+  MemoryEntryResponse,
+  MemoryScopeIDsResponse,
+  MemoryScopeIDSummary,
+  MemoryScopeKind,
+  MemoryScopesResponse,
+  // Interruption
+  InterruptListResponse,
+  InterruptRow,
+  InterruptStatus,
+  ResolveInterruptOptions,
 } from "./types.js";
 
 export {

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -63,6 +63,13 @@ export interface ContinueOptions {
   sessionId: string;
   segments: PromptSegment[];
   allowedTools?: string[];
+  /** Pin the continuation to a specific running agent_id.
+   *  Optional — when set, the server validates that the agent is
+   *  live for this session before accepting; rejects with
+   *  AgentNotFoundError / SessionBusyError otherwise. Mirrors
+   *  Python adapter's ContinueOptions.agent_id (the Python field
+   *  is snake_case; the wire field server-side is `agent_id`). */
+  agentId?: string;
   signal?: AbortSignal;
 }
 

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -6,13 +6,9 @@
  * Public API method *parameters* use camelCase (JS norm); see
  * `client.ts` for the input shapes (RunOptions, CreateSnapshotOptions,
  * etc.) — those are translated to snake_case in the request body.
- *
- * PR 5a foundation: Run lifecycle + Prompt + Event types only. PR 5b
- * adds the agent / transcript / pause / snapshot / memory / interrupt
- * types when the methods that need them land.
  */
 
-// ---- Run lifecycle (existing, unchanged) ----
+// ---- Run lifecycle ----
 
 export type EventType =
   | "started"
@@ -55,10 +51,16 @@ export interface PromptSegment {
   content: PromptContent[];
 }
 
-// ---- Client input shapes ----
-
 export interface RunOptions {
   agent: string;
+  segments: PromptSegment[];
+  allowedTools?: string[];
+  signal?: AbortSignal;
+}
+
+export interface ContinueOptions {
+  /** Required — the session to continue. */
+  sessionId: string;
   segments: PromptSegment[];
   allowedTools?: string[];
   signal?: AbortSignal;
@@ -80,4 +82,256 @@ export interface ClientOptions {
    *  Useful for testing (vi.fn()) or for runtimes that ship their
    *  own fetch (e.g. node-fetch on older Node). */
   fetch?: typeof fetch;
+}
+
+// ---- Agent metadata ----
+
+export type AgentStatus = "running" | "completed" | "failed" | "cancelled";
+
+export interface AgentUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_tokens?: number;
+  cache_read_tokens?: number;
+  model?: string;
+}
+
+export interface Agent {
+  agent_id: string;
+  run_id: string;
+  session_id: string;
+  agent: string;
+  parent_agent_id: string | null;
+  user_id: string;
+  status: AgentStatus;
+  started_at: string;
+  completed_at: string | null;
+  stop_reason: string | null;
+  error: string | null;
+  usage: AgentUsage;
+  last_heartbeat_at: string | null;
+  live: boolean;
+}
+
+export interface ListAgentsResponse {
+  agents: Agent[];
+}
+
+export interface CancelAgentResult {
+  /** Number of agents marked cancelled (root + descendants reached
+   *  via parent_agent_id cascade). 0 when the agent had already
+   *  terminated; the call still succeeds (idempotent contract). */
+  cancelledCount: number;
+}
+
+// ---- Transcript ----
+
+/** TranscriptEvent — one persisted store.Event from
+ *  GET /v1/sessions/{id}/transcript. The server wraps each
+ *  providers.Event in {seq, run_id, ts_ns, type, event:{...}}. */
+export interface TranscriptEvent {
+  seq: number;
+  run_id: string;
+  ts_ns: number;
+  type: string;
+  event: unknown;
+}
+
+export interface TranscriptResponse {
+  session: {
+    id: string;
+    user_id: string;
+    agent: string;
+    created_at: string;
+  };
+  events: TranscriptEvent[];
+}
+
+// ---- Health ----
+
+export interface HealthResponse {
+  ok: boolean;
+  commit?: string;
+  built?: string;
+  uptime_seconds?: number;
+  version?: string;
+}
+
+// ---- Admin: users list ----
+
+export interface UserSummary {
+  user_id: string;
+  running_count: number;
+  total_count: number;
+  last_started_at: string;
+}
+
+export interface ListUsersResponse {
+  users: UserSummary[];
+}
+
+// ---- Pause / Resume / State (v0.8.17 wire shape, v0.8.18 real impls) ----
+
+export type RuntimeStateStatus = "running" | "pausing" | "paused";
+
+export interface PauseResult {
+  state: string; // "paused"
+  duration_ms: number;
+  force_cancelled_count: number;
+  paused_runs_count: number;
+  warnings?: string[];
+}
+
+export interface ResumeResult {
+  state: string; // "running"
+  resumed_runs_count: number;
+  warnings?: string[];
+}
+
+export interface RuntimeStateResponse {
+  state: RuntimeStateStatus;
+  paused_runs_count: number;
+}
+
+// ---- Snapshot ----
+
+export interface SnapshotDescriptor {
+  id: string;
+  created_at: string;
+  label?: string;
+  schema_version: number;
+  byte_size: number;
+}
+
+export interface SnapshotListResponse {
+  entries: SnapshotDescriptor[];
+}
+
+export interface SnapshotCreateResponse {
+  id: string;
+  created_at: string;
+  label?: string;
+  schema_version: number;
+  byte_size: number;
+}
+
+/** Full envelope returned by GET /v1/_snapshots/{id}. json_content
+ *  carries the canonical envelope as a parsed JSON object — pipe
+ *  it directly into restoreSnapshot's `json` field. */
+export interface SnapshotEnvelope {
+  id: string;
+  created_at: string;
+  label?: string;
+  schema_version: number;
+  byte_size: number;
+  json_content: unknown;
+}
+
+export interface CreateSnapshotOptions {
+  /** Free-text marker stored on the snapshots.label column. */
+  label?: string;
+  /** Capture the optional interaction_history section (large; opt-in). */
+  includeHistory?: boolean;
+  /** RFC3339 timestamp; only honoured when `includeHistory` is true. */
+  includeHistorySince?: string;
+  /** Override the operator's LOOMCYCLE_SNAPSHOT_MAX_BYTES cap. 0 = default. */
+  maxBytes?: number;
+}
+
+export interface SnapshotRestoreResponse {
+  agent_defs_restored?: number;
+  agent_def_active_restored?: number;
+  memory_restored?: number;
+  channel_messages_restored?: number;
+  channel_cursors_restored?: number;
+  evaluations_restored?: number;
+  paused_runs_restored?: number;
+  synthesized_sessions?: number;
+  transcript_events_restored?: number;
+  interaction_history_restored?: number;
+  warnings?: string[];
+}
+
+// ---- Memory admin ----
+
+export interface MemoryScopeKind {
+  name: string;
+  description: string;
+}
+
+export interface MemoryScopesResponse {
+  scopes: MemoryScopeKind[];
+}
+
+export interface MemoryScopeIDSummary {
+  scope_id: string;
+  key_count: number;
+  bytes: number;
+  updated_at: string;
+}
+
+export interface MemoryScopeIDsResponse {
+  scope: string;
+  scope_ids: MemoryScopeIDSummary[];
+}
+
+export interface MemoryEntry {
+  key: string;
+  value: unknown;
+  expires_at?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MemoryEntriesResponse {
+  scope: string;
+  scope_id: string;
+  entries: MemoryEntry[];
+  truncated: boolean;
+}
+
+export interface MemoryEntryResponse {
+  scope: string;
+  scope_id: string;
+  entry: MemoryEntry;
+}
+
+// ---- Interruption ----
+
+export type InterruptStatus = "pending" | "answered" | "cancelled" | "expired";
+
+export interface InterruptRow {
+  interrupt_id: string;
+  run_id: string;
+  kind: string;
+  status: InterruptStatus;
+  question?: string;
+  options?: string[];
+  context_data?: string;
+  priority: string;
+  answer?: string;
+  created_at: string;
+  expires_at?: string;
+  resolved_at?: string;
+  resolved_by?: string;
+  user_id?: string;
+  agent_id?: string;
+  agent_name?: string;
+}
+
+export interface InterruptListResponse {
+  interrupts: InterruptRow[];
+  total: number;
+}
+
+export interface ResolveInterruptOptions {
+  /** The human's answer. When the original ask declared options,
+   *  MUST be one of them (server-side validated). */
+  answer: string;
+  /** Audit attribution for who resolved it (free-form). Defaults
+   *  server-side to "client" when omitted. */
+  resolvedBy?: string;
+  /** Discriminator. v0.8.16 supports only "question"; reserved
+   *  for v0.9.x future kinds. */
+  kind?: string;
 }

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -1,0 +1,475 @@
+/**
+ * LoomcycleClient method-level tests. One block per method group;
+ * each block asserts (a) the request URL + headers + body are
+ * correct, (b) the response is unwrapped into the documented
+ * surface shape.
+ *
+ * The fetch mock is supplied via constructor; no global fetch
+ * monkey-patching. Auth header is asserted on the first test in
+ * each block (consistent across methods).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  errorResponse,
+  jsonResponse,
+  makeClient,
+  noContentResponse,
+  sseResponse,
+} from "./helpers.js";
+
+describe("runStreaming", () => {
+  it("POSTs to /v1/runs with bearer + SSE Accept + yields parsed events", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse([
+        'event: started\ndata: {"type":"started"}\n\n',
+        'event: text\ndata: {"type":"text","text":"hi"}\n\n',
+        'event: done\ndata: {"type":"done","stop_reason":"end_turn"}\n\n',
+      ]),
+    ]);
+
+    const events = [];
+    for await (const ev of client.runStreaming({
+      agent: "qa-agent",
+      segments: [{ role: "user", content: [{ type: "trusted-text", text: "hi" }] }],
+      allowedTools: ["Read"],
+    })) {
+      events.push(ev);
+    }
+
+    expect(events.length).toBe(3);
+    expect(events[0]!.type).toBe("started");
+    expect(events[2]!.stop_reason).toBe("end_turn");
+
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe("http://test-loomcycle:8787/v1/runs");
+    expect(call[1]!.method).toBe("POST");
+    const headers = call[1]!.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-bearer");
+    expect(headers["Accept"]).toBe("text/event-stream");
+    const body = JSON.parse(call[1]!.body as string);
+    expect(body).toEqual({
+      agent: "qa-agent",
+      segments: [{ role: "user", content: [{ type: "trusted-text", text: "hi" }] }],
+      allowed_tools: ["Read"],
+    });
+  });
+
+  it("throws AuthError on 401 before yielding any events", async () => {
+    const { AuthError } = await import("../src/errors.js");
+    const { client } = makeClient([errorResponse(401, "invalid token")]);
+    let caught: unknown;
+    try {
+      for await (const _ of client.runStreaming({ agent: "x", segments: [] })) {
+        // unreachable
+      }
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as { status: number }).status).toBe(401);
+  });
+
+  it("throws BackpressureError on 429", async () => {
+    const { BackpressureError } = await import("../src/errors.js");
+    const { client } = makeClient([errorResponse(429, "queue full")]);
+    let caught: unknown;
+    try {
+      for await (const _ of client.runStreaming({ agent: "x", segments: [] })) {}
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(BackpressureError);
+  });
+});
+
+describe("continueSession", () => {
+  it("POSTs to /v1/sessions/{id}/messages with body shape", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse(['event: text\ndata: {"type":"text","text":"hi"}\n\n']),
+    ]);
+    const events = [];
+    for await (const ev of client.continueSession({
+      sessionId: "sess-1",
+      segments: [{ role: "user", content: [{ type: "trusted-text", text: "again" }] }],
+    })) {
+      events.push(ev);
+    }
+    expect(events.length).toBe(1);
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/sessions/sess-1/messages",
+    );
+  });
+
+  it("encodes session_id in the URL path", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse([]),
+    ]);
+    const it = client.continueSession({
+      sessionId: "sess with spaces",
+      segments: [],
+    });
+    await it[Symbol.asyncIterator]().next();
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/sessions/sess%20with%20spaces/messages",
+    );
+  });
+});
+
+describe("getAgent / cancelAgent / listUserAgents", () => {
+  it("getAgent GETs /v1/agents/{id} and returns the parsed body", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        agent_id: "a1",
+        run_id: "r1",
+        session_id: "s1",
+        agent: "qa",
+        parent_agent_id: null,
+        user_id: "u1",
+        status: "running",
+        started_at: "2026-05-19T00:00:00Z",
+        completed_at: null,
+        stop_reason: null,
+        error: null,
+        usage: { input_tokens: 100, output_tokens: 50 },
+        last_heartbeat_at: null,
+        live: true,
+      }),
+    ]);
+
+    const agent = await client.getAgent("a1");
+    expect(agent.agent_id).toBe("a1");
+    expect(agent.status).toBe("running");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/agents/a1",
+    );
+    expect(fetchMock.mock.calls[0]![1]!.method).toBe("GET");
+  });
+
+  it("getAgent throws AgentNotFoundError on 404", async () => {
+    const { AgentNotFoundError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(404, "no run found for agent_id"),
+    ]);
+    await expect(client.getAgent("a-missing")).rejects.toBeInstanceOf(
+      AgentNotFoundError,
+    );
+  });
+
+  it("cancelAgent POSTs reason + returns cancelledCount", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ cancelled_count: 3 }),
+    ]);
+    const result = await client.cancelAgent("a1", { reason: "user requested" });
+    expect(result.cancelledCount).toBe(3);
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({ reason: "user requested" });
+  });
+
+  it("listUserAgents filters by status query param", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ agents: [] }),
+    ]);
+    await client.listUserAgents("u1", { status: "running" });
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/users/u1/agents?status=running",
+    );
+  });
+});
+
+describe("getTranscript / health / listUsers", () => {
+  it("getTranscript GETs /v1/sessions/{id}/transcript", async () => {
+    const { client } = makeClient([
+      jsonResponse({
+        session: { id: "s1", user_id: "u1", agent: "qa", created_at: "2026-05-19T00:00:00Z" },
+        events: [],
+      }),
+    ]);
+    const t = await client.getTranscript("s1");
+    expect(t.session.id).toBe("s1");
+    expect(t.events).toEqual([]);
+  });
+
+  it("health hits /healthz (no /v1 prefix)", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ ok: true, commit: "abc", built: "2026-05-19", uptime_seconds: 42 }),
+    ]);
+    const h = await client.health();
+    expect(h.ok).toBe(true);
+    expect(fetchMock.mock.calls[0]![0]).toBe("http://test-loomcycle:8787/healthz");
+  });
+
+  it("listUsers returns the users array shape", async () => {
+    const { client } = makeClient([
+      jsonResponse({
+        users: [
+          { user_id: "u1", running_count: 1, total_count: 5, last_started_at: "2026-05-19T00:00:00Z" },
+        ],
+      }),
+    ]);
+    const r = await client.listUsers();
+    expect(r.users.length).toBe(1);
+    expect(r.users[0]!.user_id).toBe("u1");
+  });
+});
+
+describe("pauseRuntime / resumeRuntime / getRuntimeState", () => {
+  it("pauseRuntime POSTs /v1/_pause with optional timeout_ms", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        state: "paused",
+        duration_ms: 42,
+        force_cancelled_count: 1,
+        paused_runs_count: 2,
+      }),
+    ]);
+    const r = await client.pauseRuntime({ timeoutMs: 5000 });
+    expect(r.state).toBe("paused");
+    expect(r.paused_runs_count).toBe(2);
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({ timeout_ms: 5000 });
+  });
+
+  it("pauseRuntime without timeoutMs sends no body", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ state: "paused", duration_ms: 0, force_cancelled_count: 0, paused_runs_count: 0 }),
+    ]);
+    await client.pauseRuntime();
+    expect(fetchMock.mock.calls[0]![1]!.body).toBeUndefined();
+  });
+
+  it("pauseRuntime throws AlreadyPausingError on 409", async () => {
+    const { AlreadyPausingError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(409, "already_pausing: runtime is already paused"),
+    ]);
+    await expect(client.pauseRuntime()).rejects.toBeInstanceOf(AlreadyPausingError);
+  });
+
+  it("pauseRuntime throws PauseNotConfiguredError on 503", async () => {
+    const { PauseNotConfiguredError, UnavailableError } = await import(
+      "../src/errors.js"
+    );
+    const { client } = makeClient([
+      errorResponse(503, "pause manager not configured on this server"),
+    ]);
+    let caught: unknown;
+    try {
+      await client.pauseRuntime();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(PauseNotConfiguredError);
+    // back-compat: PauseNotConfiguredError is-a UnavailableError
+    expect(caught).toBeInstanceOf(UnavailableError);
+  });
+
+  it("resumeRuntime throws NotPausedError on 409", async () => {
+    const { NotPausedError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(409, "not_paused: runtime is not paused"),
+    ]);
+    await expect(client.resumeRuntime()).rejects.toBeInstanceOf(NotPausedError);
+  });
+
+  it("getRuntimeState GETs /v1/_state", async () => {
+    const { client } = makeClient([
+      jsonResponse({ state: "paused", paused_runs_count: 3 }),
+    ]);
+    const s = await client.getRuntimeState();
+    expect(s.state).toBe("paused");
+    expect(s.paused_runs_count).toBe(3);
+  });
+});
+
+describe("snapshot lifecycle", () => {
+  it("createSnapshot POSTs label + flags", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        id: "snap_abc",
+        created_at: "2026-05-19T00:00:00Z",
+        label: "before-deploy",
+        schema_version: 1,
+        byte_size: 1024,
+      }),
+    ]);
+    const r = await client.createSnapshot({
+      label: "before-deploy",
+      includeHistory: true,
+      includeHistorySince: "2026-05-01T00:00:00Z",
+      maxBytes: 1048576,
+    });
+    expect(r.id).toBe("snap_abc");
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({
+      label: "before-deploy",
+      include_history: true,
+      include_history_since: "2026-05-01T00:00:00Z",
+      max_bytes: 1048576,
+    });
+  });
+
+  it("createSnapshot throws SnapshotTooLargeError on 413", async () => {
+    const { SnapshotTooLargeError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(413, "snapshot exceeds size cap"),
+    ]);
+    await expect(client.createSnapshot()).rejects.toBeInstanceOf(
+      SnapshotTooLargeError,
+    );
+  });
+
+  it("listSnapshots GETs with limit + label_contains params", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ entries: [{ id: "snap_a", created_at: "x", schema_version: 1, byte_size: 1 }] }),
+    ]);
+    const r = await client.listSnapshots({ limit: 10, labelContains: "prod" });
+    expect(r.length).toBe(1);
+    expect(fetchMock.mock.calls[0]![0]).toContain("limit=10");
+    expect(fetchMock.mock.calls[0]![0]).toContain("label_contains=prod");
+  });
+
+  it("getSnapshot returns the full envelope including json_content", async () => {
+    const { client } = makeClient([
+      jsonResponse({
+        id: "snap_x",
+        created_at: "x",
+        schema_version: 1,
+        byte_size: 100,
+        json_content: { sections: { memory: { version: "1.0", entries: [] } } },
+      }),
+    ]);
+    const env = await client.getSnapshot("snap_x");
+    expect(env.id).toBe("snap_x");
+    expect((env.json_content as { sections: unknown }).sections).toBeDefined();
+  });
+
+  it("getSnapshot throws SnapshotNotFoundError on 404", async () => {
+    const { SnapshotNotFoundError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(404, "no snapshot with id snap_nope"),
+    ]);
+    await expect(client.getSnapshot("snap_nope")).rejects.toBeInstanceOf(
+      SnapshotNotFoundError,
+    );
+  });
+
+  it("exportSnapshotURL returns the URL synchronously (no fetch)", () => {
+    const { client, fetchMock } = makeClient([]);
+    const url = client.exportSnapshotURL("snap_abc");
+    expect(url).toBe("http://test-loomcycle:8787/v1/_snapshots/snap_abc/export");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("restoreSnapshot with snapshotId posts to /v1/_snapshots/{id}/restore", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ memory_restored: 3, paused_runs_restored: 1 }),
+    ]);
+    const r = await client.restoreSnapshot({ snapshotId: "snap_xyz" });
+    expect(r.memory_restored).toBe(3);
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/_snapshots/snap_xyz/restore",
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({});
+  });
+
+  it("restoreSnapshot with inline json uses 'inline' path segment + json body", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ memory_restored: 0 }),
+    ]);
+    const envelope = { schema_version: 1, sections: {} };
+    await client.restoreSnapshot({ json: envelope, includeHistory: true });
+    expect(fetchMock.mock.calls[0]![0]).toContain("/v1/_snapshots/inline/restore");
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({ include_history: true, json: envelope });
+  });
+
+  it("restoreSnapshot requires snapshotId or json (not both, not neither)", async () => {
+    const { client } = makeClient([]);
+    await expect(client.restoreSnapshot({})).rejects.toThrow(/snapshotId or json/);
+    await expect(
+      client.restoreSnapshot({ snapshotId: "x", json: {} }),
+    ).rejects.toThrow(/only one/);
+  });
+
+  it("restoreSnapshot throws SnapshotVersionError on 422", async () => {
+    const { SnapshotVersionError } = await import("../src/errors.js");
+    const { client } = makeClient([
+      errorResponse(422, "snapshot section version newer than reader supports"),
+    ]);
+    await expect(
+      client.restoreSnapshot({ snapshotId: "x" }),
+    ).rejects.toBeInstanceOf(SnapshotVersionError);
+  });
+
+  it("deleteSnapshot DELETEs and returns void on 204", async () => {
+    const { client, fetchMock } = makeClient([noContentResponse()]);
+    await client.deleteSnapshot("snap_x");
+    expect(fetchMock.mock.calls[0]![1]!.method).toBe("DELETE");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/_snapshots/snap_x",
+    );
+  });
+});
+
+describe("memory admin", () => {
+  it("listMemoryScopes GETs the scopes index", async () => {
+    const { client } = makeClient([
+      jsonResponse({ scopes: [{ name: "agent", description: "..." }] }),
+    ]);
+    const r = await client.listMemoryScopes();
+    expect(r.scopes.length).toBe(1);
+  });
+
+  it("listMemoryEntries encodes prefix + limit", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ scope: "agent", scope_id: "a1", entries: [], truncated: false }),
+    ]);
+    await client.listMemoryEntries("agent", "a1", { prefix: "events/", limit: 50 });
+    const url = fetchMock.mock.calls[0]![0];
+    expect(url).toContain("/v1/_memory/scopes/agent/a1/keys");
+    expect(url).toContain("prefix=events%2F");
+    expect(url).toContain("limit=50");
+  });
+
+  it("getMemoryEntry encodes path segments", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ scope: "agent", scope_id: "a1", entry: { key: "k", value: 1, created_at: "x", updated_at: "x" } }),
+    ]);
+    await client.getMemoryEntry("agent", "a1", "events/2026");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/_memory/scopes/agent/a1/keys/events%2F2026",
+    );
+  });
+});
+
+describe("interruption", () => {
+  it("listUserInterrupts defaults to status=pending", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ interrupts: [], total: 0 }),
+    ]);
+    await client.listUserInterrupts("u1");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/users/u1/interrupts?status=pending",
+    );
+  });
+
+  it("resolveInterrupt posts the kind+answer+resolvedBy body", async () => {
+    const { client, fetchMock } = makeClient([jsonResponse({ ok: true })]);
+    await client.resolveInterrupt("r1", "intr_xyz", {
+      answer: "yes",
+      resolvedBy: "operator-dashboard",
+    });
+    const url = fetchMock.mock.calls[0]![0];
+    expect(url).toBe(
+      "http://test-loomcycle:8787/v1/runs/r1/interrupts/intr_xyz/resolve",
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body).toEqual({
+      kind: "question",
+      answer: "yes",
+      resolved_by: "operator-dashboard",
+    });
+  });
+});

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -46,7 +46,7 @@ describe("runStreaming", () => {
     expect(call[1]!.method).toBe("POST");
     const headers = call[1]!.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer test-bearer");
-    expect(headers["Accept"]).toBe("text/event-stream");
+    expect(headers["Accept"]).toBe("text/event-stream, application/json");
     const body = JSON.parse(call[1]!.body as string);
     expect(body).toEqual({
       agent: "qa-agent",
@@ -471,5 +471,26 @@ describe("interruption", () => {
       answer: "yes",
       resolved_by: "operator-dashboard",
     });
+  });
+
+  // Regression: PR #141 review surfaced that 404 on the interrupt
+  // routes had no test coverage. The new NotFoundError base ensures
+  // an interrupt 404 (which doesn't mention "agent" in the body)
+  // falls through to NotFoundError, not AgentNotFoundError.
+  it("listRunInterrupts on 404 raises NotFoundError (not AgentNotFoundError)", async () => {
+    const { client } = makeClient([errorResponse(404, "run not found")]);
+    await expect(client.listRunInterrupts("missing-run")).rejects.toMatchObject({
+      name: "NotFoundError",
+      status: 404,
+    });
+  });
+
+  it("resolveInterrupt on 404 raises NotFoundError when interrupt is unknown", async () => {
+    const { client } = makeClient([
+      errorResponse(404, "interrupt not found"),
+    ]);
+    await expect(
+      client.resolveInterrupt("r1", "intr_gone", { answer: "yes" }),
+    ).rejects.toMatchObject({ name: "NotFoundError", status: 404 });
   });
 });

--- a/adapters/ts/tests/errors.test.ts
+++ b/adapters/ts/tests/errors.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for fetch-helpers.ts:raiseFromResponse — the single source
+ * of truth for HTTP status + body-text → typed-error dispatch.
+ *
+ * Mirrors the Python adapter's test_errors.py pattern: synthesize
+ * a Response with a specific (status, body) combination and assert
+ * the right typed error class is thrown.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  AgentIDInUseError,
+  AgentNotFoundError,
+  AlreadyPausingError,
+  AuthError,
+  BackpressureError,
+  InvalidArgumentError,
+  LoomcycleError,
+  NotPausedError,
+  PauseNotConfiguredError,
+  SessionBusyError,
+  SessionNotFoundError,
+  SnapshotNotFoundError,
+  SnapshotTooLargeError,
+  SnapshotVersionError,
+  UnavailableError,
+} from "../src/errors.js";
+import { raiseFromResponse } from "../src/fetch-helpers.js";
+
+async function expectErrorFor(status: number, body: string) {
+  const resp = new Response(body, { status });
+  try {
+    await raiseFromResponse(resp);
+    throw new Error("expected raiseFromResponse to throw");
+  } catch (e) {
+    return e;
+  }
+}
+
+describe("raiseFromResponse — status + body-text → typed error", () => {
+  it("400 → InvalidArgumentError", async () => {
+    expect(await expectErrorFor(400, "bad timeout")).toBeInstanceOf(
+      InvalidArgumentError,
+    );
+  });
+
+  it("401 → AuthError", async () => {
+    expect(await expectErrorFor(401, "invalid token")).toBeInstanceOf(AuthError);
+  });
+
+  it("404 + 'snapshot' → SnapshotNotFoundError", async () => {
+    expect(
+      await expectErrorFor(404, "no snapshot with id snap_xyz"),
+    ).toBeInstanceOf(SnapshotNotFoundError);
+  });
+
+  it("404 + 'session' → SessionNotFoundError", async () => {
+    expect(
+      await expectErrorFor(404, "session not found"),
+    ).toBeInstanceOf(SessionNotFoundError);
+  });
+
+  it("404 (other) → AgentNotFoundError (catch-all)", async () => {
+    expect(
+      await expectErrorFor(404, "no run found for agent_id ax"),
+    ).toBeInstanceOf(AgentNotFoundError);
+  });
+
+  it("404 + both 'snapshot' AND 'session' → SnapshotNotFoundError (priority)", async () => {
+    // Documented priority: "snapshot" wins over "session" wins over agent
+    expect(
+      await expectErrorFor(
+        404,
+        "no snapshot with id snap_sess_foo (session reference incidental)",
+      ),
+    ).toBeInstanceOf(SnapshotNotFoundError);
+  });
+
+  it("409 + 'already_pausing' → AlreadyPausingError", async () => {
+    expect(
+      await expectErrorFor(409, "already_pausing: runtime is already pausing"),
+    ).toBeInstanceOf(AlreadyPausingError);
+  });
+
+  it("409 + 'already paused' → AlreadyPausingError", async () => {
+    expect(
+      await expectErrorFor(409, "runtime already paused"),
+    ).toBeInstanceOf(AlreadyPausingError);
+  });
+
+  it("409 + 'not_paused' → NotPausedError", async () => {
+    expect(
+      await expectErrorFor(409, "not_paused: cannot resume"),
+    ).toBeInstanceOf(NotPausedError);
+  });
+
+  it("409 + 'session' → SessionBusyError", async () => {
+    expect(
+      await expectErrorFor(409, "session busy: another request in flight"),
+    ).toBeInstanceOf(SessionBusyError);
+  });
+
+  it("409 + 'agent_id' → AgentIDInUseError", async () => {
+    expect(
+      await expectErrorFor(409, "agent_id in use"),
+    ).toBeInstanceOf(AgentIDInUseError);
+  });
+
+  it("409 (other) → LoomcycleError (base)", async () => {
+    const e = await expectErrorFor(409, "some other conflict");
+    expect(e).toBeInstanceOf(LoomcycleError);
+    expect(e instanceof AlreadyPausingError).toBe(false);
+  });
+
+  it("413 → SnapshotTooLargeError", async () => {
+    expect(
+      await expectErrorFor(413, "snapshot exceeds size cap"),
+    ).toBeInstanceOf(SnapshotTooLargeError);
+  });
+
+  it("422 → SnapshotVersionError", async () => {
+    expect(
+      await expectErrorFor(422, "snapshot section version too new"),
+    ).toBeInstanceOf(SnapshotVersionError);
+  });
+
+  it("429 → BackpressureError", async () => {
+    expect(await expectErrorFor(429, "queue full")).toBeInstanceOf(
+      BackpressureError,
+    );
+  });
+
+  it("503 + 'pause manager not configured' → PauseNotConfiguredError", async () => {
+    const e = await expectErrorFor(
+      503,
+      "pause manager not configured on this server",
+    );
+    expect(e).toBeInstanceOf(PauseNotConfiguredError);
+    // back-compat: PauseNotConfiguredError IS-A UnavailableError
+    expect(e).toBeInstanceOf(UnavailableError);
+  });
+
+  it("503 (other) → UnavailableError (not the more specific PauseNotConfiguredError)", async () => {
+    const e = await expectErrorFor(503, "service unavailable");
+    expect(e).toBeInstanceOf(UnavailableError);
+    expect(e instanceof PauseNotConfiguredError).toBe(false);
+  });
+
+  it("500 → LoomcycleError (base) — unknown server error", async () => {
+    expect(await expectErrorFor(500, "boom")).toBeInstanceOf(LoomcycleError);
+  });
+
+  it("error carries status + truncated bodyText", async () => {
+    const e = (await expectErrorFor(401, "invalid token")) as AuthError;
+    expect(e.status).toBe(401);
+    expect(e.bodyText).toBe("invalid token");
+  });
+
+  it("LoomcycleError.bodyText is truncated to 1024 chars", async () => {
+    const longBody = "x".repeat(5000);
+    const e = (await expectErrorFor(500, longBody)) as LoomcycleError;
+    expect(e.bodyText?.length).toBe(1024);
+  });
+
+  it("empty body falls back to a status-text message", async () => {
+    const resp = new Response("", { status: 401 });
+    let caught: unknown;
+    try {
+      await raiseFromResponse(resp);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    // empty body → message comes from status + statusText
+    expect((caught as Error).message).toMatch(/401/);
+  });
+});

--- a/adapters/ts/tests/helpers.ts
+++ b/adapters/ts/tests/helpers.ts
@@ -1,0 +1,104 @@
+/**
+ * Test helpers for vitest-based unit tests against LoomcycleClient.
+ *
+ * The pattern: build a `vi.fn()` fetch mock that returns canned
+ * Response objects, instantiate LoomcycleClient with `fetch: mock`,
+ * call a method, assert on the recorded calls + the unwrapped
+ * response.
+ *
+ * Helpers here keep the per-test boilerplate small.
+ */
+
+import { vi, type Mock } from "vitest";
+import { LoomcycleClient } from "../src/client.js";
+
+/**
+ * makeClient builds a LoomcycleClient with a captured fetch mock.
+ * The mock is preloaded with a Response factory queue; each call
+ * pops the next factory and uses it to build the Response.
+ *
+ * Returns: the client + the fetch mock + a `queue.push()` to enqueue
+ * additional responses for chained-call tests.
+ */
+export function makeClient(
+  responses: Array<(req: Request) => Response> = [],
+): { client: LoomcycleClient; fetchMock: Mock; queue: typeof responses } {
+  const queue = [...responses];
+  const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+    const req = new Request(url, init as RequestInit);
+    if (queue.length === 0) {
+      throw new Error(
+        `fetch mock: no more responses queued for ${init?.method ?? "GET"} ${url}`,
+      );
+    }
+    const factory = queue.shift()!;
+    return factory(req);
+  });
+  const client = new LoomcycleClient({
+    baseUrl: "http://test-loomcycle:8787",
+    authToken: "test-bearer",
+    fetch: fetchMock as unknown as typeof fetch,
+  });
+  return { client, fetchMock, queue };
+}
+
+/** jsonResponse builds a Response factory that returns `body` as
+ *  JSON with status 200 (or `status` if supplied). */
+export function jsonResponse(
+  body: unknown,
+  status = 200,
+): (req: Request) => Response {
+  return () =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+}
+
+/** errorResponse builds a Response with non-2xx status + plain text
+ *  body. Used to drive the typed-error dispatch in
+ *  fetch-helpers.ts:raiseFromResponse. */
+export function errorResponse(
+  status: number,
+  bodyText: string,
+): (req: Request) => Response {
+  return () =>
+    new Response(bodyText, { status, statusText: defaultStatusText(status) });
+}
+
+/** noContentResponse builds a 204 No Content. */
+export function noContentResponse(): (req: Request) => Response {
+  return () => new Response(null, { status: 204 });
+}
+
+/** sseResponse builds a Response with a ReadableStream body that
+ *  emits the given SSE frames. Use for runStreaming /
+ *  continueSession tests. */
+export function sseResponse(frames: string[]): (req: Request) => Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      for (const f of frames) controller.enqueue(encoder.encode(f));
+      controller.close();
+    },
+  });
+  return () =>
+    new Response(body, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+}
+
+function defaultStatusText(status: number): string {
+  switch (status) {
+    case 400: return "Bad Request";
+    case 401: return "Unauthorized";
+    case 404: return "Not Found";
+    case 409: return "Conflict";
+    case 413: return "Payload Too Large";
+    case 422: return "Unprocessable Entity";
+    case 429: return "Too Many Requests";
+    case 503: return "Service Unavailable";
+    default: return "";
+  }
+}

--- a/adapters/ts/tests/stream.test.ts
+++ b/adapters/ts/tests/stream.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for src/stream.ts:parseSSE — the SSE frame parser shared
+ * by runStreaming + continueSession.
+ *
+ * Drives synthetic chunked byte input through the parser and
+ * asserts the right AgentEvents come out in order.
+ */
+
+import { describe, expect, it } from "vitest";
+import { parseSSE } from "../src/stream.js";
+
+/** streamFromChunks builds a ReadableStream that emits each
+ *  string as a separate chunk. Lets us test chunk-boundary
+ *  handling in parseSSE (the parser must tolerate splits
+ *  mid-line, mid-frame, etc.). */
+function streamFromChunks(chunks: string[]): ReadableStreamDefaultReader<Uint8Array> {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return stream.getReader();
+}
+
+describe("parseSSE", () => {
+  it("parses 3 well-formed frames into 3 events in order", async () => {
+    const reader = streamFromChunks([
+      'event: started\ndata: {"type":"started"}\n\n',
+      'event: text\ndata: {"type":"text","text":"hi"}\n\n',
+      'event: done\ndata: {"type":"done","stop_reason":"end_turn"}\n\n',
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(3);
+    expect(out[0]!.type).toBe("started");
+    expect(out[1]!.text).toBe("hi");
+    expect(out[2]!.stop_reason).toBe("end_turn");
+  });
+
+  it("handles chunk boundaries mid-frame", async () => {
+    // Same 1 frame split across many tiny chunks.
+    const reader = streamFromChunks([
+      "event: tex",
+      "t\ndata: {",
+      '"type":"text"',
+      ',"text":"hello"',
+      "}\n\n",
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(1);
+    expect(out[0]!.text).toBe("hello");
+  });
+
+  it("handles \\r\\n line endings", async () => {
+    const reader = streamFromChunks([
+      'event: text\r\ndata: {"type":"text","text":"crlf"}\r\n\r\n',
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(1);
+    expect(out[0]!.text).toBe("crlf");
+  });
+
+  it("drops frames with malformed JSON without throwing", async () => {
+    const reader = streamFromChunks([
+      'event: bad\ndata: { not json\n\n',
+      'event: text\ndata: {"type":"text","text":"ok"}\n\n',
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(1);
+    expect(out[0]!.text).toBe("ok");
+  });
+
+  it("emits the trailing frame even without a final blank line", async () => {
+    const reader = streamFromChunks([
+      'event: text\ndata: {"type":"text","text":"last"}\n',
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(1);
+    expect(out[0]!.text).toBe("last");
+  });
+
+  it("ignores frames with only event: and no data:", async () => {
+    const reader = streamFromChunks([
+      "event: heartbeat\n\n",
+      'event: text\ndata: {"type":"text","text":"after-heartbeat"}\n\n',
+    ]);
+    const out = [];
+    for await (const ev of parseSSE(reader)) out.push(ev);
+    expect(out.length).toBe(1);
+    expect(out[0]!.text).toBe("after-heartbeat");
+  });
+});

--- a/adapters/ts/vitest.config.ts
+++ b/adapters/ts/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+// Vitest configuration — minimal. The TS adapter targets Node (per
+// engines >= 18), so we use the node environment rather than jsdom.
+// Tests live alongside src/ under tests/, mocking `fetch` via vi.fn().
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

v0.8.18 TS adapter PR 2 of 3. Adds 23 new methods on top of PR 5a's foundation. Total now **24 public methods** (was 1 in v0.1.0-alpha.0) — full Python-adapter parity plus the Web UI's admin/memory/interrupt surface.

### Methods
- **Run lifecycle**: + \`continueSession\` (runStreaming preserved byte-identical from PR 5a)
- **Metadata**: \`getAgent\`, \`cancelAgent\`, \`listUserAgents\`, \`getTranscript\`, \`health\`, \`listUsers\`
- **Pause/Resume/State**: \`pauseRuntime\`, \`resumeRuntime\`, \`getRuntimeState\`
- **Snapshots**: \`createSnapshot\`, \`listSnapshots\`, \`getSnapshot\`, \`exportSnapshotURL\` (sync), \`restoreSnapshot\`, \`deleteSnapshot\`
- **Memory admin**: \`listMemoryScopes\`, \`listMemoryScopeIDs\`, \`listMemoryEntries\`, \`getMemoryEntry\`
- **Interruption**: \`listUserInterrupts\`, \`listRunInterrupts\`, \`resolveInterrupt\`

Every method accepts an optional \`signal?: AbortSignal\`.

### Tests
- Vitest ^3.0 added to devDeps; \`npm test\` runs \`vitest run\`.
- **61 test cases / 3 files / all green in 933ms**:
  - \`client.test.ts\` (34) — method-level request/response shape + typed-error dispatch
  - \`errors.test.ts\` (21) — every (status, body) combination through \`raiseFromResponse\`, including the documented NOT_FOUND priority + PauseNotConfiguredError IS-A UnavailableError back-compat
  - \`stream.test.ts\` (6) — \`parseSSE\` boundary cases (chunk splits, \\r\\n, malformed JSON, trailing frames)

### Test plan
- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean; \`dist/\` contains only \`src/\` output (tests not published)
- [x] \`npm test\` — 61/61 pass

Stacked on #140. PR 5c bumps version + expands README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)