### PR TITLE
feat(connector): add hook management RPCs (PR A of 4)

### DIFF
--- a/internal/api/http/connector_impl_hooks.go
+++ b/internal/api/http/connector_impl_hooks.go
@@ -1,0 +1,70 @@
+// Package http — Connector hook-management implementation. Lives in its
+// own file (mirroring how grpc/pause_snapshot.go isolates the
+// pause/snapshot concern) so the file growing here doesn't bloat the
+// main connector_impl.go.
+
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+)
+
+// RegisterHook adapts the existing hookRegistry.Register flow to the
+// Connector interface. The transport-shape connector.RegisterHookRequest
+// is mapped to a hooks.Hook struct; the registry validates and assigns
+// an ID. hooks.ErrInvalidRegistration is wrapped as
+// connector.ErrHookInvalidRegistration so gRPC/MCP can map cleanly.
+func (s *Server) RegisterHook(_ context.Context, req connector.RegisterHookRequest) (connector.RegisterHookResponse, error) {
+	if s.hookRegistry == nil {
+		return connector.RegisterHookResponse{}, connector.ErrHookNotConfigured
+	}
+	h := &hooks.Hook{
+		Owner:       req.Owner,
+		Name:        req.Name,
+		Phase:       req.Phase,
+		Agents:      req.Agents,
+		Tools:       req.Tools,
+		CallbackURL: req.CallbackURL,
+		FailMode:    req.FailMode,
+		TimeoutMs:   req.TimeoutMs,
+	}
+	id, err := s.hookRegistry.Register(h)
+	if err != nil {
+		if errors.Is(err, hooks.ErrInvalidRegistration) {
+			return connector.RegisterHookResponse{}, fmt.Errorf("%w: %s", connector.ErrHookInvalidRegistration, err.Error())
+		}
+		return connector.RegisterHookResponse{}, err
+	}
+	return connector.RegisterHookResponse{ID: id}, nil
+}
+
+// ListHooks returns the full registry snapshot. The slice is owned by
+// the registry (List clones internally — see registry.go) so callers
+// may not mutate it but reading concurrently is safe.
+func (s *Server) ListHooks(_ context.Context) (connector.ListHooksResponse, error) {
+	if s.hookRegistry == nil {
+		return connector.ListHooksResponse{}, connector.ErrHookNotConfigured
+	}
+	return connector.ListHooksResponse{Hooks: s.hookRegistry.List()}, nil
+}
+
+// DeleteHook removes the hook with the given id. Idempotent only in the
+// sense the HTTP layer was: a second delete on the same id always
+// returns ErrHookNotFound.
+func (s *Server) DeleteHook(_ context.Context, id string) error {
+	if s.hookRegistry == nil {
+		return connector.ErrHookNotConfigured
+	}
+	if err := s.hookRegistry.Delete(id); err != nil {
+		if errors.Is(err, hooks.ErrNotFound) {
+			return fmt.Errorf("%w: %s", connector.ErrHookNotFound, id)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/api/http/hooks.go
+++ b/internal/api/http/hooks.go
@@ -6,55 +6,35 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 )
 
-// hookRegisterRequest is the wire shape POSTed to /v1/hooks. Mirrors
-// hooks.Hook minus the loomcycle-assigned fields (ID, RegisteredAt).
-type hookRegisterRequest struct {
-	Owner       string         `json:"owner"`
-	Name        string         `json:"name"`
-	Phase       hooks.Phase    `json:"phase"`
-	Agents      []string       `json:"agents"`
-	Tools       []string       `json:"tools"`
-	CallbackURL string         `json:"callback_url"`
-	FailMode    hooks.FailMode `json:"fail_mode"`
-	TimeoutMs   int            `json:"timeout_ms"`
-}
-
-// hookRegisterResponse is the wire shape returned on success. The id
-// is loomcycle-assigned; clients use it on DELETE /v1/hooks/{id}.
-type hookRegisterResponse struct {
-	ID string `json:"id"`
-}
-
-// handleRegisterHook accepts a hookRegisterRequest, registers it
-// against the in-memory registry, and returns the assigned id.
+// handleRegisterHook accepts a connector.RegisterHookRequest, registers
+// it through the Connector layer, and returns the assigned id.
 //
 // Idempotency: if the (owner, name) tuple already maps to a registered
 // hook, the prior entry is replaced in-place (preserving chain order)
 // and a fresh id is assigned. Apps re-registering on their own startup
 // don't have to worry about cascading duplicates.
+//
+// Refactored in the hooks-connector series: business logic moved to
+// Server.RegisterHook (connector_impl_hooks.go); this handler is now
+// pure wire-translation, mirroring the v0.8.18 handlePauseRuntime /
+// handleSnapshot style.
 func (s *Server) handleRegisterHook(w http.ResponseWriter, r *http.Request) {
-	var req hookRegisterRequest
+	var req connector.RegisterHookRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON: "+err.Error())
 		return
 	}
-	h := &hooks.Hook{
-		Owner:       req.Owner,
-		Name:        req.Name,
-		Phase:       req.Phase,
-		Agents:      req.Agents,
-		Tools:       req.Tools,
-		CallbackURL: req.CallbackURL,
-		FailMode:    req.FailMode,
-		TimeoutMs:   req.TimeoutMs,
-	}
-	id, err := s.hookRegistry.Register(h)
+	resp, err := s.RegisterHook(r.Context(), req)
 	if err != nil {
-		if errors.Is(err, hooks.ErrInvalidRegistration) {
+		if errors.Is(err, connector.ErrHookInvalidRegistration) {
 			writeJSONError(w, http.StatusBadRequest, "invalid_registration", err.Error())
+			return
+		}
+		if errors.Is(err, connector.ErrHookNotConfigured) {
+			writeJSONError(w, http.StatusServiceUnavailable, "hooks_not_configured", err.Error())
 			return
 		}
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
@@ -62,18 +42,25 @@ func (s *Server) handleRegisterHook(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(hookRegisterResponse{ID: id})
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleListHooks returns every currently-registered hook in
 // registration order. Useful for debug; no pagination because the
 // registry is intentionally small (operator-curated set).
-func (s *Server) handleListHooks(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleListHooks(w http.ResponseWriter, r *http.Request) {
+	resp, err := s.ListHooks(r.Context())
+	if err != nil {
+		if errors.Is(err, connector.ErrHookNotConfigured) {
+			writeJSONError(w, http.StatusServiceUnavailable, "hooks_not_configured", err.Error())
+			return
+		}
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"hooks": s.hookRegistry.List(),
-	})
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // handleDeleteHook removes the hook with the given id from the
@@ -86,9 +73,13 @@ func (s *Server) handleDeleteHook(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "missing_id", "hook id required in path")
 		return
 	}
-	if err := s.hookRegistry.Delete(id); err != nil {
-		if errors.Is(err, hooks.ErrNotFound) {
+	if err := s.DeleteHook(r.Context(), id); err != nil {
+		if errors.Is(err, connector.ErrHookNotFound) {
 			writeJSONError(w, http.StatusNotFound, "not_found", fmt.Sprintf("no hook with id %q", id))
+			return
+		}
+		if errors.Is(err, connector.ErrHookNotConfigured) {
+			writeJSONError(w, http.StatusServiceUnavailable, "hooks_not_configured", err.Error())
 			return
 		}
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())

--- a/internal/api/http/hooks_test.go
+++ b/internal/api/http/hooks_test.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 )
@@ -53,7 +55,7 @@ func TestHooksAPI_RegisterListDelete(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("Register status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	var regResp hookRegisterResponse
+	var regResp connector.RegisterHookResponse
 	if err := json.Unmarshal(rec.Body.Bytes(), &regResp); err != nil {
 		t.Fatalf("decode register response: %v", err)
 	}
@@ -111,14 +113,14 @@ func TestHooksAPI_ReplaceOnDuplicate(t *testing.T) {
 	req := httptest.NewRequest("POST", "/v1/hooks", bytes.NewReader([]byte(body("https://a/x"))))
 	rec := httptest.NewRecorder()
 	s.handleRegisterHook(rec, req)
-	var first hookRegisterResponse
+	var first connector.RegisterHookResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &first)
 
 	// Second registration, same (owner, name)
 	req = httptest.NewRequest("POST", "/v1/hooks", bytes.NewReader([]byte(body("https://b/x"))))
 	rec = httptest.NewRecorder()
 	s.handleRegisterHook(rec, req)
-	var second hookRegisterResponse
+	var second connector.RegisterHookResponse
 	_ = json.Unmarshal(rec.Body.Bytes(), &second)
 
 	if first.ID == second.ID {
@@ -155,5 +157,48 @@ func TestHooksAPI_RejectsInvalid(t *testing.T) {
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("%s: status = %d, want 400 (body=%s)", name, rec.Code, rec.Body.String())
 		}
+	}
+}
+
+// TestConnector_RegisterHook_InvalidRegistration confirms the
+// Connector-layer typed-error contract: when the registry rejects a
+// hook, the wrapped sentinel is connector.ErrHookInvalidRegistration —
+// what gRPC/MCP will errors.Is against to pick the right protocol code.
+func TestConnector_RegisterHook_InvalidRegistration(t *testing.T) {
+	s := minimalServer(t)
+	_, err := s.RegisterHook(t.Context(), connector.RegisterHookRequest{
+		// missing owner / callback_url → registry validation fails
+		Name:  "x",
+		Phase: "pre",
+	})
+	if !errors.Is(err, connector.ErrHookInvalidRegistration) {
+		t.Errorf("err = %v, want errors.Is ErrHookInvalidRegistration", err)
+	}
+}
+
+// TestConnector_DeleteHook_NotFound confirms unknown-id deletes wrap
+// connector.ErrHookNotFound. This is the seam gRPC + MCP rely on to
+// emit codes.NotFound / a 404-shaped tool_error.
+func TestConnector_DeleteHook_NotFound(t *testing.T) {
+	s := minimalServer(t)
+	err := s.DeleteHook(t.Context(), "hook_does_not_exist")
+	if !errors.Is(err, connector.ErrHookNotFound) {
+		t.Errorf("err = %v, want errors.Is ErrHookNotFound", err)
+	}
+}
+
+// TestConnector_Hooks_NotConfigured exercises the defensive nil-guard
+// for *Server values constructed without a hookRegistry (test harnesses
+// using struct literals). Production New() always wires one.
+func TestConnector_Hooks_NotConfigured(t *testing.T) {
+	s := &Server{} // no hookRegistry
+	if _, err := s.RegisterHook(t.Context(), connector.RegisterHookRequest{}); !errors.Is(err, connector.ErrHookNotConfigured) {
+		t.Errorf("RegisterHook err = %v, want ErrHookNotConfigured", err)
+	}
+	if _, err := s.ListHooks(t.Context()); !errors.Is(err, connector.ErrHookNotConfigured) {
+		t.Errorf("ListHooks err = %v, want ErrHookNotConfigured", err)
+	}
+	if err := s.DeleteHook(t.Context(), "x"); !errors.Is(err, connector.ErrHookNotConfigured) {
+		t.Errorf("DeleteHook err = %v, want ErrHookNotConfigured", err)
 	}
 }

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -161,6 +161,26 @@ type Connector interface {
 	// (409 from the HTTP layer maps to this); ErrNotFound on a
 	// missing interrupt_id; nil on success.
 	InterruptionResolve(ctx context.Context, req InterruptionResolveRequest) (InterruptionResolveResult, error)
+
+	// --- Hook management (PR A of the hooks-connector series) ---
+	//
+	// Hooks are in-memory only; registrations do not survive restarts.
+	// The callback half is HTTP-only (consumer's own web server receives
+	// the Pre/PostHookCall payloads); these Connector methods cover the
+	// registration management surface only.
+	//
+	// Typed errors:
+	//   ErrHookInvalidRegistration — bad owner/name/callback_url, etc.
+	//                                Transports: HTTP 400 / InvalidArgument.
+	//   ErrHookNotFound            — DeleteHook on unknown id.
+	//                                Transports: HTTP 404 / NotFound.
+	//   ErrHookNotConfigured       — Server has no hookRegistry wired
+	//                                (test-harness guard; not seen in
+	//                                production). Transports: Unavailable.
+
+	RegisterHook(ctx context.Context, req RegisterHookRequest) (RegisterHookResponse, error)
+	ListHooks(ctx context.Context) (ListHooksResponse, error)
+	DeleteHook(ctx context.Context, id string) error
 }
 
 // InterruptionResolveRequest is the input to Connector.InterruptionResolve.

--- a/internal/connector/errors.go
+++ b/internal/connector/errors.go
@@ -54,4 +54,23 @@ var (
 	// section's declared version isn't in the migration registry at
 	// all (corrupted snapshot or pre-history version).
 	ErrSnapshotVersionUnknown = errors.New("connector: snapshot section version unknown")
+
+	// ErrHookInvalidRegistration is returned by RegisterHook when the
+	// supplied request fails the hooks.Registry validation (missing
+	// owner/name/callback_url, unsupported phase, non-http(s) scheme).
+	// Transports map to 400 / InvalidArgument. Wrap with %w + the
+	// underlying message so the caller sees what specifically failed.
+	ErrHookInvalidRegistration = errors.New("connector: invalid hook registration")
+
+	// ErrHookNotFound is returned by DeleteHook when no hook is
+	// registered with the supplied id. Transports map to 404 / NotFound.
+	ErrHookNotFound = errors.New("connector: hook not found")
+
+	// ErrHookNotConfigured is returned by the hook methods when the
+	// Server was constructed without a hookRegistry (e.g. a test harness
+	// that builds *Server directly via struct literal). The HTTP New()
+	// constructor always wires one, so production deployments never hit
+	// this — it's a defensive guard for the gRPC/MCP code paths that
+	// dispatch through Connector and would otherwise nil-panic.
+	ErrHookNotConfigured = errors.New("connector: hook registry not configured on this server")
 )

--- a/internal/connector/hooks.go
+++ b/internal/connector/hooks.go
@@ -1,0 +1,36 @@
+package connector
+
+import "github.com/denn-gubsky/loomcycle/internal/hooks"
+
+// RegisterHookRequest is the input to Connector.RegisterHook. It mirrors
+// internal/hooks.Hook minus the loomcycle-assigned fields (ID,
+// RegisteredAt) — the same shape POST /v1/hooks consumes today.
+//
+// Lives in the connector package (not internal/api/http) so gRPC + MCP
+// transports can import it without touching the HTTP package. Imports
+// internal/hooks for the Phase / FailMode named types; the hooks
+// package has no dependency on connector, so the import direction is
+// safe.
+type RegisterHookRequest struct {
+	Owner       string         `json:"owner"`
+	Name        string         `json:"name"`
+	Phase       hooks.Phase    `json:"phase"`
+	Agents      []string       `json:"agents,omitempty"`
+	Tools       []string       `json:"tools,omitempty"`
+	CallbackURL string         `json:"callback_url"`
+	FailMode    hooks.FailMode `json:"fail_mode,omitempty"`
+	TimeoutMs   int            `json:"timeout_ms,omitempty"`
+}
+
+// RegisterHookResponse is what Connector.RegisterHook returns: the
+// loomcycle-assigned ID that callers use on DeleteHook.
+type RegisterHookResponse struct {
+	ID string `json:"id"`
+}
+
+// ListHooksResponse wraps the slice of currently-registered hooks.
+// Mirrors GET /v1/hooks. Carries the full hooks.Hook (including ID +
+// RegisteredAt) so callers can correlate with their own bookkeeping.
+type ListHooksResponse struct {
+	Hooks []*hooks.Hook `json:"hooks"`
+}


### PR DESCRIPTION
## Summary

First PR in the 4-PR hooks-connector series. Lifts the existing
\`/v1/hooks\` HTTP surface onto the \`Connector\` interface so future
PRs can expose the same operations through gRPC (PR B), MCP (PR B),
TS (PR C), and Python (PR D) without re-implementing the registry
logic.

JobEmber — loomcycle's first production consumer — uses
Pre/PostTool hooks today. With this series, JobEmber will be able
to manage hook registrations from any transport, not only HTTP.

## What changed

- **\`internal/connector/hooks.go\`** (new) — wire types:
  \`RegisterHookRequest\`, \`RegisterHookResponse\`, \`ListHooksResponse\`.
  Imports \`internal/hooks\` for the \`Phase\` and \`FailMode\` named
  types (one-way dependency — \`hooks\` has no back-reference).
- **\`internal/connector/errors.go\`** — three new typed errors:
  \`ErrHookInvalidRegistration\`, \`ErrHookNotFound\`,
  \`ErrHookNotConfigured\`. Transports use \`errors.Is\` to map to
  protocol-specific status codes (HTTP 400/404/503; gRPC
  InvalidArgument/NotFound/Unavailable; MCP IsError text).
- **\`internal/connector/connector.go\`** — three new interface
  methods on \`Connector\`: \`RegisterHook\`, \`ListHooks\`,
  \`DeleteHook\`.
- **\`internal/api/http/connector_impl_hooks.go\`** (new) — the
  canonical implementation. Wraps the existing \`hookRegistry\`
  methods + translates \`hooks.ErrInvalidRegistration\` /
  \`hooks.ErrNotFound\` to the connector-typed equivalents. Nil-guards
  \`s.hookRegistry\` (production wiring never hits this, but
  struct-literal test harnesses would nil-panic without it).
- **\`internal/api/http/hooks.go\`** — handlers now delegate to the
  Connector methods. Local \`hookRegisterRequest\` /
  \`hookRegisterResponse\` types deleted; replaced by
  \`connector.RegisterHookRequest\` / \`RegisterHookResponse\`. Wire
  JSON is byte-identical.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./internal/connector/... ./internal/api/http/... ./internal/hooks/...\` passes.
- [x] New test: \`TestConnector_RegisterHook_InvalidRegistration\`
      confirms the wrapped \`ErrHookInvalidRegistration\` sentinel
      surfaces for gRPC/MCP \`errors.Is\` checks.
- [x] New test: \`TestConnector_DeleteHook_NotFound\`.
- [x] New test: \`TestConnector_Hooks_NotConfigured\` pins the
      defensive nil-guard.
- [x] Original \`/v1/hooks\` route tests pass unchanged after the
      type rename.

## Sequencing

PR A → PR B (gRPC + MCP) || PR C (TS) — both can run in parallel
after A merges → PR D (Python; needs PR B's regenerated stubs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)