### PR TITLE
feat(ts): hook management methods + HookNotFoundError (PR C of 4, stacked on #142)

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -2,12 +2,13 @@
  * LoomcycleClient — the single public class exported by
  * @loomcycle/client. Speaks HTTP+SSE to a running loomcycle sidecar.
  *
- * v0.8.18: full Python-adapter parity. 24 methods total — 23 async
- * (run streaming, continuation, agent metadata, transcript, health,
- * users, pause/resume/state, snapshot lifecycle capture / list /
- * get / restore / delete, memory admin, interruption listing +
- * resolve) plus one synchronous helper (exportSnapshotURL builds a
- * URL string without issuing a request).
+ * hooks-connector PR C: full Python-adapter parity + hook management.
+ * 27 methods total — 26 async (run streaming, continuation, agent
+ * metadata, transcript, health, users, pause/resume/state, snapshot
+ * lifecycle capture / list / get / restore / delete, memory admin,
+ * interruption listing + resolve, hook registration / list / delete)
+ * plus one synchronous helper (exportSnapshotURL builds a URL string
+ * without issuing a request).
  *
  * Construction:
  *
@@ -40,15 +41,19 @@ import type {
   ContinueOptions,
   CreateSnapshotOptions,
   HealthResponse,
+  Hook,
   InterruptListResponse,
   InterruptStatus,
   ListAgentsResponse,
+  ListHooksResponse,
   ListUsersResponse,
   MemoryEntriesResponse,
   MemoryEntryResponse,
   MemoryScopeIDsResponse,
   MemoryScopesResponse,
   PauseResult,
+  RegisterHookOptions,
+  RegisterHookResponse,
   ResolveInterruptOptions,
   ResumeResult,
   RunOptions,
@@ -421,6 +426,57 @@ export class LoomcycleClient {
         answer: opts.answer,
         resolved_by: opts.resolvedBy ?? "client",
       },
+      opts,
+    );
+  }
+
+  // ---- Hook management (hooks-connector series, PR C) ----
+
+  /** Register a pre- or post-tool webhook. The callback_url must be
+   *  an http:// or https:// endpoint the CONSUMER runs — loomcycle
+   *  POSTs PreHookCall / PostHookCall payloads to it. This method
+   *  manages registration only; the receiver is the consumer's own
+   *  HTTP framework (Express, Next.js, etc.).
+   *
+   *  Re-registering the same (owner, name) replaces the prior entry
+   *  with a fresh id (idempotent app-restart contract).
+   *
+   *  Raises InvalidArgumentError on 400 (bad URL / phase / missing
+   *  required fields). */
+  async registerHook(
+    opts: RegisterHookOptions & { signal?: AbortSignal },
+  ): Promise<RegisterHookResponse> {
+    const body: Record<string, unknown> = {
+      owner: opts.owner,
+      name: opts.name,
+      phase: opts.phase,
+      callback_url: opts.callbackUrl,
+    };
+    if (opts.agents !== undefined) body.agents = opts.agents;
+    if (opts.tools !== undefined) body.tools = opts.tools;
+    if (opts.failMode !== undefined) body.fail_mode = opts.failMode;
+    if (opts.timeoutMs !== undefined && opts.timeoutMs > 0) {
+      body.timeout_ms = opts.timeoutMs;
+    }
+    return postJSON<RegisterHookResponse>(this.ctx, "/v1/hooks", body, opts);
+  }
+
+  /** List every currently-registered hook. Returns the array
+   *  unwrapped (the wire envelope is `{hooks: [...]}` — we strip
+   *  the envelope to match listUserAgents). In-memory only — empty
+   *  after a loomcycle restart. */
+  async listHooks(opts?: { signal?: AbortSignal }): Promise<Hook[]> {
+    const resp = await jsonFetch<ListHooksResponse>(this.ctx, "/v1/hooks", opts);
+    return resp.hooks ?? [];
+  }
+
+  /** Delete a registered hook by id. Raises HookNotFoundError on
+   *  404. Returns void on success (the HTTP 200 body `{deleted: id}`
+   *  is dropped — callers already know the id they passed). */
+  async deleteHook(id: string, opts?: { signal?: AbortSignal }): Promise<void> {
+    await deleteRequest(
+      this.ctx,
+      `/v1/hooks/${encodeURIComponent(id)}`,
       opts,
     );
   }

--- a/adapters/ts/src/errors.ts
+++ b/adapters/ts/src/errors.ts
@@ -144,3 +144,14 @@ export class SnapshotVersionError extends LoomcycleError {
     this.name = "SnapshotVersionError";
   }
 }
+
+/** HookNotFoundError — raised by deleteHook when no hook has the
+ *  supplied id (HTTP 404 with "hook" in the body). Extends
+ *  NotFoundError so consumers catching the broader category get this
+ *  one too. */
+export class HookNotFoundError extends NotFoundError {
+  constructor(message: string, opts?: { status?: number; bodyText?: string }) {
+    super(message, opts);
+    this.name = "HookNotFoundError";
+  }
+}

--- a/adapters/ts/src/fetch-helpers.ts
+++ b/adapters/ts/src/fetch-helpers.ts
@@ -16,6 +16,7 @@ import {
   AlreadyPausingError,
   AuthError,
   BackpressureError,
+  HookNotFoundError,
   InvalidArgumentError,
   LoomcycleError,
   NotFoundError,
@@ -136,9 +137,9 @@ export async function deleteRequest(
  *   401         → AuthError
  *   404 + "snapshot"   → SnapshotNotFoundError ────────┐
  *   404 + "session"    → SessionNotFoundError          │  All extend
- *   404 + "agent"      → AgentNotFoundError            │  NotFoundError —
- *   404 + (other)      → NotFoundError (base)          │  callers can
- *                                                      │  catch any 404
+ *   404 + "hook"       → HookNotFoundError             │  NotFoundError —
+ *   404 + "agent"      → AgentNotFoundError            │  callers can
+ *   404 + (other)      → NotFoundError (base)          │  catch any 404
  *                                                      │  with one
  *                                                      │  instanceof.
  *   409 + "already_pausing" / "already paused" → AlreadyPausingError
@@ -190,12 +191,16 @@ export async function raiseFromResponse(resp: Response): Promise<never> {
       // Priority: most-specific keyword wins.
       // - "snapshot" → SnapshotNotFoundError
       // - "session"  → SessionNotFoundError
+      // - "hook"     → HookNotFoundError (must precede "agent" — the
+      //                hooks 404 body is `no hook with id "..."`,
+      //                doesn't mention "agent")
       // - "agent" or "agent_id" → AgentNotFoundError
       // - otherwise → NotFoundError (base) — e.g. memory rows, interrupts,
       //   or any future 404-returning endpoint that doesn't fit the
       //   existing keyword set.
       if (bodyLower.includes("snapshot")) throw new SnapshotNotFoundError(msg, opts);
       if (bodyLower.includes("session")) throw new SessionNotFoundError(msg, opts);
+      if (bodyLower.includes("hook")) throw new HookNotFoundError(msg, opts);
       if (bodyLower.includes("agent")) throw new AgentNotFoundError(msg, opts);
       throw new NotFoundError(msg, opts);
     case 409:

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -110,6 +110,19 @@ export type {
   InterruptRow,
   InterruptStatus,
   ResolveInterruptOptions,
+  // Hook management (PR C)
+  Hook,
+  HookFailMode,
+  HookPhase,
+  HookToolCall,
+  HookToolResult,
+  ListHooksResponse,
+  PostHookCall,
+  PostHookResult,
+  PreHookCall,
+  PreHookResult,
+  RegisterHookOptions,
+  RegisterHookResponse,
 } from "./types.js";
 
 export {
@@ -118,6 +131,7 @@ export {
   AlreadyPausingError,
   AuthError,
   BackpressureError,
+  HookNotFoundError,
   NotFoundError,
   InvalidArgumentError,
   LoomcycleError,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -342,3 +342,133 @@ export interface ResolveInterruptOptions {
    *  for v0.9.x future kinds. */
   kind?: string;
 }
+
+// ---- Hook management (hooks-connector series, PR C) ----
+//
+// Hook *registration* is a client concern surfaced here. Hook
+// *callback delivery* is server-side: loomcycle POSTs PreHookCall /
+// PostHookCall payloads to the consumer's registered callback_url —
+// that endpoint is whatever web framework JobEmber / the consumer
+// runs. The TS adapter exports the PreHookCall / PostHookCall /
+// PreHookResult / PostHookResult shapes so consumers can type their
+// receiver code identically to the server's wire emit, but the adapter
+// itself never runs them — it only manages the registration.
+
+export type HookPhase = "pre" | "post";
+
+export type HookFailMode = "open" | "closed";
+
+/** Hook is the full descriptor returned by listHooks. The id +
+ *  registered_at are loomcycle-assigned; the rest mirrors what was
+ *  POSTed to registerHook. Field names use snake_case to match the
+ *  Go server's JSON output. */
+export interface Hook {
+  id: string;
+  owner: string;
+  name: string;
+  phase: HookPhase;
+  agents: string[];
+  tools: string[];
+  callback_url: string;
+  fail_mode: HookFailMode;
+  timeout_ms: number;
+  registered_at: string; // ISO 8601
+}
+
+/** RegisterHookOptions uses camelCase (JS norm for method parameters)
+ *  and is translated to snake_case in the request body — same split as
+ *  RunOptions / CreateSnapshotOptions. */
+export interface RegisterHookOptions {
+  /** App UID; (owner, name) is the identity tuple. Re-registering the
+   *  same pair replaces the prior entry with a fresh id. */
+  owner: string;
+  name: string;
+  phase: HookPhase;
+  /** Agent name globs (exact match or trailing-* prefix). Empty list
+   *  matches every agent (equivalent to ["*"]). */
+  agents?: string[];
+  /** Tool name globs (same syntax). Empty matches every tool. */
+  tools?: string[];
+  /** http:// or https:// URL loomcycle POSTs PreHookCall /
+   *  PostHookCall payloads to. */
+  callbackUrl: string;
+  /** "open" (default) — webhook errors pass through. "closed" — webhook
+   *  errors fail the tool call with IsError=true. */
+  failMode?: HookFailMode;
+  /** Per-call timeout. 0 / omitted = registry default (5 s). */
+  timeoutMs?: number;
+}
+
+export interface RegisterHookResponse {
+  /** Loomcycle-assigned id. Use it on deleteHook. */
+  id: string;
+}
+
+export interface ListHooksResponse {
+  hooks: Hook[];
+}
+
+// ---- Hook callback payloads ----
+//
+// These describe what the consumer's callback_url endpoint RECEIVES
+// from loomcycle. The adapter doesn't post these — the operator's
+// hooks.Dispatcher does. Exposed here so consumers can type their
+// receiver code (e.g. an Express handler, a Next.js route) against
+// the same shapes the server emits.
+
+export interface HookToolCall {
+  id: string;
+  name: string;
+  /** Raw JSON the model produced; consumers parse as needed. */
+  input: unknown;
+}
+
+export interface HookToolResult {
+  text: string;
+  is_error?: boolean;
+}
+
+export interface PreHookCall {
+  phase: "pre";
+  owner: string;
+  hook_name: string;
+  agent: string;
+  user_id?: string;
+  agent_id?: string;
+  tool_call: HookToolCall;
+}
+
+/** Response a Pre webhook returns. All fields optional; empty body
+ *  means "pass through unchanged". See the server-side docs for the
+ *  allow_hosts confused-deputy hazard before populating it. */
+export interface PreHookResult {
+  /** Rewrite the tool input. Tool runs with this instead of the
+   *  model's original payload. */
+  input?: unknown;
+  /** Short-circuit the call: model sees this synthetic result. When
+   *  set, allow_hosts is dropped (deny wins; we do not let a denied
+   *  hook contribute hostnames to peers in the chain). */
+  deny?: HookToolResult;
+  /** Per-call host approvals. Only takes effect when the registering
+   *  owner is in the operator yaml's hooks.permit_host_widen.owners.
+   *  Read the SECURITY note in internal/hooks/types.go before using —
+   *  this is a confused-deputy attack surface. */
+  allow_hosts?: string[];
+}
+
+export interface PostHookCall {
+  phase: "post";
+  owner: string;
+  hook_name: string;
+  agent: string;
+  user_id?: string;
+  agent_id?: string;
+  tool_call: HookToolCall;
+  tool_result: HookToolResult;
+}
+
+/** Response a Post webhook returns. When result is omitted the tool
+ *  result passes through unchanged. */
+export interface PostHookResult {
+  result?: HookToolResult;
+}

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -494,3 +494,126 @@ describe("interruption", () => {
     ).rejects.toMatchObject({ name: "NotFoundError", status: 404 });
   });
 });
+
+describe("hook management", () => {
+  it("registerHook POSTs the snake_case body shape", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ id: "hook_abc" }),
+    ]);
+    const resp = await client.registerHook({
+      owner: "jobs-search-web",
+      name: "scan",
+      phase: "pre",
+      tools: ["WebFetch"],
+      callbackUrl: "https://callback.local/h",
+      failMode: "closed",
+      timeoutMs: 2500,
+    });
+    expect(resp.id).toBe("hook_abc");
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe("http://test-loomcycle:8787/v1/hooks");
+    expect(call[1]!.method).toBe("POST");
+    const body = JSON.parse(call[1]!.body as string);
+    expect(body).toEqual({
+      owner: "jobs-search-web",
+      name: "scan",
+      phase: "pre",
+      tools: ["WebFetch"],
+      callback_url: "https://callback.local/h",
+      fail_mode: "closed",
+      timeout_ms: 2500,
+    });
+  });
+
+  it("registerHook omits optional fields when not set", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({ id: "hook_min" }),
+    ]);
+    await client.registerHook({
+      owner: "x",
+      name: "y",
+      phase: "post",
+      callbackUrl: "https://e.test/h",
+    });
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    // Omitted: agents, tools, fail_mode (defaults at server), timeout_ms.
+    expect(body).toEqual({
+      owner: "x",
+      name: "y",
+      phase: "post",
+      callback_url: "https://e.test/h",
+    });
+  });
+
+  it("registerHook on 400 raises InvalidArgumentError", async () => {
+    const { client } = makeClient([
+      errorResponse(400, "invalid_registration: callback_url required"),
+    ]);
+    await expect(
+      client.registerHook({
+        owner: "x",
+        name: "y",
+        phase: "pre",
+        callbackUrl: "",
+      }),
+    ).rejects.toMatchObject({ name: "InvalidArgumentError", status: 400 });
+  });
+
+  it("listHooks unwraps the envelope and returns the array", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        hooks: [
+          {
+            id: "hook_a",
+            owner: "x",
+            name: "y",
+            phase: "pre",
+            agents: ["*"],
+            tools: ["WebFetch"],
+            callback_url: "https://e.test/h",
+            fail_mode: "open",
+            timeout_ms: 0,
+            registered_at: "2026-05-19T11:00:00Z",
+          },
+        ],
+      }),
+    ]);
+    const hooks = await client.listHooks();
+    expect(hooks).toHaveLength(1);
+    expect(hooks[0]!.id).toBe("hook_a");
+    expect(fetchMock.mock.calls[0]![0]).toBe("http://test-loomcycle:8787/v1/hooks");
+    expect(fetchMock.mock.calls[0]![1]!.method).toBe("GET");
+  });
+
+  it("deleteHook DELETEs the encoded id and returns void", async () => {
+    const { client, fetchMock } = makeClient([noContentResponse()]);
+    await client.deleteHook("hook_with spaces");
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/hooks/hook_with%20spaces",
+    );
+    expect(fetchMock.mock.calls[0]![1]!.method).toBe("DELETE");
+  });
+
+  it("deleteHook on 404 raises HookNotFoundError", async () => {
+    const { client } = makeClient([
+      errorResponse(404, `no hook with id "hook_gone"`),
+    ]);
+    await expect(client.deleteHook("hook_gone")).rejects.toMatchObject({
+      name: "HookNotFoundError",
+      status: 404,
+    });
+  });
+
+  // Regression: the 404 dispatch in fetch-helpers.ts puts "hook" BEFORE
+  // "agent" in the keyword priority. Without the new branch, the hook
+  // 404 body — which doesn't say "agent" — would fall through to
+  // NotFoundError (base); this test pins the typed-error class.
+  it("deleteHook 404 with mixed-case keyword still routes to HookNotFoundError", async () => {
+    const { client } = makeClient([
+      errorResponse(404, "No HOOK with id matches"),
+    ]);
+    await expect(client.deleteHook("hook_x")).rejects.toMatchObject({
+      name: "HookNotFoundError",
+    });
+  });
+});

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -616,4 +616,19 @@ describe("hook management", () => {
       name: "HookNotFoundError",
     });
   });
+
+  // Priority guard: when the 404 body contains BOTH "hook" and "agent"
+  // (e.g. a hook id like "hook_agent_scan"), the "hook" check must
+  // still win. Hook IDs containing "agent" are not unusual — anyone
+  // registering a hook for an agent-related concern would name it
+  // that way. Pins the keyword-ordering invariant in raiseFromResponse.
+  it("deleteHook 404 with body containing both 'hook' and 'agent' routes to HookNotFoundError", async () => {
+    const { client } = makeClient([
+      errorResponse(404, `no hook with id "hook_agent_scan"`),
+    ]);
+    await expect(client.deleteHook("hook_agent_scan")).rejects.toMatchObject({
+      name: "HookNotFoundError",
+      status: 404,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

PR C of the 4-PR hooks-connector series. Brings the TS adapter to parity with the existing HTTP \`/v1/hooks\` surface (and PR B's gRPC + MCP additions).

Stacked on **#142** (TS adapter docs) — not on **#143** (PR A) — because PR C is a TS-only concern that talks to the HTTP wire (unchanged by PR A's Go-side refactor). JobEmber is the immediate beneficiary: their Node.js stack can manage Pre/PostTool hook registrations via the TS adapter instead of hand-rolling HTTP calls.

## What changed

- **\`src/types.ts\`** — \`HookPhase\` / \`HookFailMode\` string-literal unions, \`Hook\` descriptor, \`RegisterHookOptions\` / \`RegisterHookResponse\` / \`ListHooksResponse\`, plus the callback payload shapes (\`PreHookCall\` / \`PreHookResult\` / \`PostHookCall\` / \`PostHookResult\` / \`HookToolCall\` / \`HookToolResult\`).
- **\`src/errors.ts\`** — \`HookNotFoundError extends NotFoundError\`.
- **\`src/fetch-helpers.ts\`** — 404 dispatch adds \`"hook"\` keyword check BEFORE \`"agent"\` so hook 404 bodies (\`no hook with id "..."\`) don't misclassify into \`AgentNotFoundError\`.
- **\`src/client.ts\`** — 3 new methods: \`registerHook\` / \`listHooks\` / \`deleteHook\`. Method count docstring bumped from 24 → 27.
- **\`src/index.ts\`** — re-export the new types + \`HookNotFoundError\`.

## Test plan

- [x] \`cd adapters/ts && npm run build && npm test\` — 70/70 pass.
- New tests:
  - \`registerHook POSTs the snake_case body shape\`
  - \`registerHook omits optional fields when not set\`
  - \`registerHook on 400 raises InvalidArgumentError\`
  - \`listHooks unwraps the envelope and returns the array\`
  - \`deleteHook DELETEs the encoded id and returns void\`
  - \`deleteHook on 404 raises HookNotFoundError\`
  - \`deleteHook 404 with mixed-case keyword still routes to HookNotFoundError\` (regression guard for the 404 keyword priority)

🤖 Generated with [Claude Code](https://claude.com/claude-code)