### PR TITLE
fix(channels): reorder scheduler AfterFunc to cleanup-before-notify

### DIFF
--- a/internal/channels/scheduler.go
+++ b/internal/channels/scheduler.go
@@ -79,9 +79,19 @@ func (s *Scheduler) Schedule(channel, msgID string, visibleAt time.Time) bool {
 	}
 
 	t := time.AfterFunc(delay, func() {
-		s.bus.Notify(channel)
+		// Order matters: do the bookkeeping BEFORE calling Notify.
+		// Notify hands off to the waiting goroutine synchronously
+		// (bus.Wait returns true the moment Notify lands). If we
+		// notified first, an observer reading PendingCount() right
+		// after their Wait returned could see a stale count of 1
+		// because the Delete + Add(-1) below hadn't completed yet
+		// — the race detector exposed this as a flaky
+		// TestScheduler_FiresAtVisibleAt failure. With this order,
+		// PendingCount is post-fire by the time any subscriber
+		// observes Notify.
 		s.timers.Delete(msgID)
 		s.pendCnt.Add(-1)
+		s.bus.Notify(channel)
 	})
 	if _, loaded := s.timers.LoadOrStore(msgID, t); loaded {
 		// Race: another caller registered the same msgID between


### PR DESCRIPTION
## Summary

\`TestScheduler_FiresAtVisibleAt\` was a race-detector flake — observed on PR #151's CI but unrelated to that PR's Web UI changes (\`internal/channels\` isn't touched there). PR #151's CI passed on retry, confirming the flake.

The scheduler's single-shot timer fired in this order:

\`\`\`go
t := time.AfterFunc(delay, func() {
    s.bus.Notify(channel)    // 1
    s.timers.Delete(msgID)    // 2
    s.pendCnt.Add(-1)         // 3
})
\`\`\`

\`bus.Notify\` hands off to the waiting goroutine synchronously — \`bus.Wait\` returns the instant Notify lands. A subscriber reading \`PendingCount()\` immediately after their Wait could see stale 1 because steps 2-3 hadn't completed yet on the AfterFunc goroutine. The race detector widens scheduling enough to expose the flake; on fast machines without \`-race\` it almost never fires.

## Fix

Bookkeeping first, Notify last. No semantic change for non-test callers — the externally-visible difference is that \`PendingCount\` is guaranteed accurate relative to Notify, which is the stronger invariant test code (and any future operator dashboards) expect.

## Test plan

- [x] \`go test -race -count=20 -run TestScheduler_FiresAtVisibleAt ./internal/channels/\` — 20/20 pass under race detector.
- [x] \`go test -race -timeout 60s ./internal/channels/...\` — full package clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)