### PR TITLE
ci: publish @loomcycle/client to npm on v* tag

### DIFF
--- a/.github/workflows/publish-ts-adapter.yml
+++ b/.github/workflows/publish-ts-adapter.yml
@@ -8,6 +8,14 @@ name: Publish @loomcycle/client to npm
 # doesn't match the tag. Tagging without bumping package.json fails
 # loudly without touching npm.
 #
+# Auth: npm Trusted Publisher (OIDC) — no NPM_TOKEN secret required.
+# Configure the trust relationship at
+# https://www.npmjs.com/package/@loomcycle/client/access by adding a
+# GitHub Actions trusted publisher with repository
+# `denn-gubsky/loomcycle` and workflow filename `publish-ts-adapter.yml`.
+# `id-token: write` below is the permission setup-node needs to mint
+# the OIDC token that npm exchanges for a short-lived publish token.
+#
 # Inputs reaching `run` steps are limited to GITHUB_REF_NAME (from a
 # git tag — git rejects metacharacters in ref names) and constants.
 # Per the GitHub workflow-injection guide we route the tag through
@@ -19,6 +27,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
@@ -66,9 +75,14 @@ jobs:
 
       - name: Publish
         working-directory: adapters/ts
-        # --access public required for scoped packages on the npmjs
-        # free tier. The NPM_TOKEN secret needs publish permission
-        # on the @loomcycle scope.
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # --access public is required for scoped packages.
+        # --provenance is free with OIDC trusted publishing: npm
+        # embeds an SLSA-style build attestation in the published
+        # tarball, surfaced as a green "Provenance" badge on the
+        # package page that links back to this workflow run. Worth
+        # ~zero effort for verifiable supply-chain origin.
+        #
+        # No NODE_AUTH_TOKEN env — setup-node negotiates the OIDC
+        # handshake against npmjs.com using the id-token permission
+        # granted above.
+        run: npm publish --access public --provenance

--- a/.github/workflows/publish-ts-adapter.yml
+++ b/.github/workflows/publish-ts-adapter.yml
@@ -1,0 +1,74 @@
+name: Publish @loomcycle/client to npm
+
+# Triggered on annotated tags matching the loomcycle release pattern.
+# The Go binary's release tags use v0.8.x; this workflow piggy-backs
+# on the same tag so the TS adapter version stays in lockstep.
+#
+# Safety: the workflow refuses to publish if package.json's version
+# doesn't match the tag. Tagging without bumping package.json fails
+# loudly without touching npm.
+#
+# Inputs reaching `run` steps are limited to GITHUB_REF_NAME (from a
+# git tag — git rejects metacharacters in ref names) and constants.
+# Per the GitHub workflow-injection guide we route the tag through
+# `env:` rather than direct template expansion as defence in depth.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish @loomcycle/client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
+          cache-dependency-path: adapters/ts/package-lock.json
+
+      - name: Verify package version matches tag
+        working-directory: adapters/ts
+        # Refuse to publish when package.json hasn't been bumped to
+        # match the release tag. Strip leading `v` because npm tags
+        # don't carry it; git tags do.
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PKG_VER=$(node -p "require('./package.json').version")
+          TAG_VER="${TAG_REF#v}"
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::error::package.json version ($PKG_VER) does not match tag ($TAG_VER)"
+            echo "Bump adapters/ts/package.json to $TAG_VER and re-tag, or fix the tag."
+            exit 1
+          fi
+          echo "::notice::Publishing @loomcycle/client@$PKG_VER (tag $TAG_REF)"
+
+      - name: Install
+        working-directory: adapters/ts
+        run: npm ci
+
+      - name: Build
+        working-directory: adapters/ts
+        run: npm run build
+
+      - name: Test
+        working-directory: adapters/ts
+        run: npm test
+
+      - name: Publish
+        working-directory: adapters/ts
+        # --access public required for scoped packages on the npmjs
+        # free tier. The NPM_TOKEN secret needs publish permission
+        # on the @loomcycle scope.
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Automates the npm publish step so tagging the Go release also publishes the matching \`@loomcycle/client\` version. Today this is a manual \`npm publish\` after each release; nothing stops the operator from forgetting, and JobEmber's migration is now coupled to TS adapter releases.

## Safety gates

- **Trigger restricted**: \`tags: ['v*']\` only — branch pushes never fire the workflow.
- **Version match gate**: refuses to publish if \`adapters/ts/package.json\`'s \`version\` doesn't equal \`\${TAG#v}\`. Tagging without bumping package.json fails loudly without touching npm.
- **CI before publish**: \`npm ci && npm run build && npm test\` all run before \`npm publish\`. A broken build can't ship.
- **Injection defence**: \`GITHUB_REF_NAME\` is routed through \`env:\` to a shell variable before interpolation. Tags can't carry shell metacharacters (git rejects them in ref names) so this is defence in depth per the [GitHub Actions workflow-injection guide](https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/).

## Setup needed (one-time)

Add an \`NPM_TOKEN\` repository secret with publish permission on the \`@loomcycle\` scope. Generated via the npm automation token flow:

\`\`\`
npm token create --otp <2fa-code>  # if 2FA enforced
# pick "Automation" type so the token works in CI without OTP
\`\`\`

Paste the token into the GitHub repo settings → Secrets and variables → Actions → New secret → \`NPM_TOKEN\`.

## Operator runbook for a release

1. Bump \`adapters/ts/package.json\` \`version\` to match the upcoming tag.
2. Bump anything else (Python adapter version, Go embed assets, etc.) the release needs.
3. \`git tag -a v0.8.X -m "v0.8.X — ..." && git push origin v0.8.X\`.
4. The workflow runs version check → install → build → test → publish.

If the version check fails (forgot to bump package.json before tagging), the workflow exits without publishing. Fix package.json + amend the commit + re-tag with \`git tag -f\` + \`git push --force origin v0.8.X\`.

## Out of scope (could ship later as separate workflows)

- Python package publish to PyPI on tag.
- GitHub Release notes generation.

## Test plan

- [x] YAML validates (\`python3 -c 'import yaml; yaml.safe_load(...)'\`).
- [x] Trigger constrained to tags only — branch pushes can't fire the publish step.
- [x] Version mismatch path verified by reading the shell flow: \`PKG_VER\` from \`node -p\`, \`TAG_VER\` from \`\${TAG_REF#v}\`, exit 1 on inequality.
- [ ] First real publish happens on the next \`v0.8.X\` tag — observable in the Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)