### PR TITLE
chore(ts): bump @loomcycle/client to 0.8.20

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.1.0-alpha.0",
+  "version": "0.8.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.1.0-alpha.0",
+      "version": "0.8.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.8.19",
+  "version": "0.8.20",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 27 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin, interruption resolve, and hook management.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Tiny version-bump PR ahead of the v0.8.20 git tag. Required for the new \`publish-ts-adapter\` workflow's version-match gate (\`package.json.version\` must equal the tag).

## Why skip v0.8.19 on the Go side

\`@loomcycle/client@0.8.19\` was already published to npm in mid-stream when PR #150's content shipped. A \`v0.8.19\` git tag would trigger the publish workflow into a \`npm publish\` "version already exists" rejection. Tagging \`v0.8.20\` lets the workflow run cleanly.

## v0.8.20 release window (for the GitHub release notes when tagging)

PRs #148–#154 accumulate into v0.8.20:

| PR | Summary |
|---|---|
| #148 | re-bundle missing v0.8.18 PRs to main |
| #149 | TS adapter docs — hooks reference + migration guide |
| #150 | TS adapter server-parity additions for JobEmber |
| #151 | Web UI refactor — split view + breadcrumbs + expand/collapse + filter-race fix + terminal view |
| #152 | channels: reorder scheduler AfterFunc (race-detector flake fix) |
| #153 | gRPC + Python adapter — per-run policy fields + Event host_widening |
| #154 | CI publish-ts-adapter workflow with npm OIDC trusted publisher + provenance |

## Tests

- [x] \`npm run build\` clean
- [x] \`npm test\` — 78/78 pass at the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)