### PR TITLE
fix(ci): upgrade npm CLI before publish for Trusted Publisher OIDC

### DIFF
--- a/.github/workflows/publish-ts-adapter.yml
+++ b/.github/workflows/publish-ts-adapter.yml
@@ -43,6 +43,17 @@ jobs:
           cache: npm
           cache-dependency-path: adapters/ts/package-lock.json
 
+      - name: Upgrade npm CLI for Trusted Publisher OIDC support
+        # Trusted Publishing requires npm CLI 11.5.1+ to negotiate the
+        # GitHub Actions → npm OIDC handshake. Node 20 ships with npm
+        # 10.x, which silently falls back to looking for NODE_AUTH_TOKEN
+        # in .npmrc and emits a misleading "404 not in this registry"
+        # error from the unauthenticated PUT (npm hides scoped-package
+        # existence from anonymous callers). Pinning to npm@latest
+        # avoids tracking minor-version bumps; the action only runs on
+        # tag pushes so the version drift surface is small.
+        run: npm install -g npm@latest
+
       - name: Verify package version matches tag
         working-directory: adapters/ts
         # Refuse to publish when package.json hasn't been bumped to


### PR DESCRIPTION
## Summary

First v0.8.20 publish-workflow run failed with:

\`\`\`
404 Not Found - PUT https://registry.npmjs.org/@loomcycle/client
'@loomcycle/client@0.8.20' is not in this registry.
\`\`\`

**Root cause**: Trusted Publishing requires \`npm CLI 11.5.1+\` to negotiate the GitHub Actions → npm OIDC handshake. Node 20's bundled npm is 10.x, which doesn't have Trusted Publisher support — it silently falls back to looking for \`NODE_AUTH_TOKEN\` in \`.npmrc\` (deliberately removed when we switched to OIDC) and sends an unauthenticated PUT. npmjs.com returns 404 instead of 401 for scoped packages from anonymous callers (security through obscurity on whether private packages exist), so the error reads as "package not found" rather than the real "you're not authed."

The \`--provenance\` signing succeeding misled the log into looking healthy: provenance has been in npm 9.5+, and it signs against the GitHub OIDC id-token independently. The publish-auth path is separate.

## Fix

Add one step between \`setup-node\` and the publish:

\`\`\`yaml
- name: Upgrade npm CLI for Trusted Publisher OIDC support
  run: npm install -g npm@latest
\`\`\`

Pinning to \`@latest\` rather than a specific version because:
- The workflow only runs on \`v*\` tag pushes — small surface for drift.
- We want the newest Trusted Publishing fixes (the feature is still maturing).

## Side-channel confirmation

User confirmed Trusted Publisher config on npmjs.com is correct (\`denn-gubsky/loomcycle\` + workflow \`publish-ts-adapter.yml\` + no environment). No npm-side change needed.

## Next step after merge

\`gh run rerun 26110707652\` against the existing v0.8.20 tag re-runs the same workflow with the npm upgrade in place; OIDC handshake should succeed and \`@loomcycle/client@0.8.20\` lands on npm with provenance. No re-tagging needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)