### PR TITLE
fix(ts): add repository field to package.json for npm provenance verification

### DIFF
--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -4,6 +4,15 @@
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 27 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin, interruption resolve, and hook management.",
   "license": "Apache-2.0",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/denn-gubsky/loomcycle.git",
+    "directory": "adapters/ts"
+  },
+  "homepage": "https://github.com/denn-gubsky/loomcycle/tree/main/adapters/ts#readme",
+  "bugs": {
+    "url": "https://github.com/denn-gubsky/loomcycle/issues"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Second v0.8.20 publish failure — but now we're past OIDC and at the provenance-verification stage. Different (and more informative) error:

\`\`\`
422 Unprocessable Entity - PUT https://registry.npmjs.org/@loomcycle/client
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match
"https://github.com/denn-gubsky/loomcycle" from provenance
\`\`\`

**Root cause**: npm cross-checks the package.json \`repository.url\` field against the GitHub repo URL embedded in the sigstore provenance bundle. The attestation says "this tarball was built in \`denn-gubsky/loomcycle\`"; the package.json has no \`repository\` field; npm rejects with 422 before accepting the tarball.

This is supply-chain protection working as intended — a provenance attestation has to verifiably match the package's claimed source. The fix is purely metadata: declare \`repository\` (+ \`homepage\` and \`bugs\` as cheap wins since they surface on the npm package page).

## Diff

\`\`\`json
"repository": {
  "type": "git",
  "url": "git+https://github.com/denn-gubsky/loomcycle.git",
  "directory": "adapters/ts"
},
"homepage": "https://github.com/denn-gubsky/loomcycle/tree/main/adapters/ts#readme",
"bugs": {
  "url": "https://github.com/denn-gubsky/loomcycle/issues"
}
\`\`\`

\`directory: "adapters/ts"\` declares the subpath since the npm package is a subdirectory of the GitHub repo. Surfaces correctly on the npm package page and lets tools like Snyk/Renovate locate the source.

## Tests

- [x] \`npm install\` clean (no lockfile drift)
- [x] \`npm run build\` clean
- [x] \`npm test\` — 78/78 pass

## Next step after merge

Re-point the \`v0.8.20\` tag at the post-fix HEAD (third retag — should be the last one). The publish workflow then runs against a package.json that satisfies the provenance cross-check, and \`@loomcycle/client@0.8.20\` finally lands on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)