### PR TITLE
ci: publish loomcycle Python adapter to PyPI on python-v* tag

### DIFF
--- a/.github/workflows/publish-python-adapter.yml
+++ b/.github/workflows/publish-python-adapter.yml
@@ -1,0 +1,78 @@
+name: Publish loomcycle to PyPI
+
+# Triggered on annotated tags matching the Python-adapter release
+# pattern. The Python adapter is versioned independently of the Go
+# binary (Python at 0.6.x, Go at 0.8.x) so it uses its own tag
+# namespace — never collides with the `v*` tags consumed by the
+# Go-release + npm-publish workflow.
+#
+# Auth: PyPI Trusted Publisher (OIDC). No PYPI_API_TOKEN secret
+# needed. One-time PyPI configuration:
+#   1. Log in to https://pypi.org.
+#   2. Account settings → "Publishing".
+#   3. "Add a new pending publisher" if `loomcycle` isn't yet on
+#      PyPI; otherwise "Add a new trusted publisher" on the existing
+#      project's Publishing settings page.
+#   4. Owner: denn-gubsky, Repository: loomcycle,
+#      Workflow filename: publish-python-adapter.yml,
+#      Environment name: (blank).
+#
+# Per the GitHub workflow-injection guide, GITHUB_REF_NAME is
+# routed through `env:` rather than direct template expansion as
+# defence in depth — git rejects metacharacters in ref names so
+# this is belt-and-braces.
+on:
+  push:
+    tags:
+      - "python-v*"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish loomcycle (Python adapter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: adapters/python/pyproject.toml
+
+      - name: Verify package version matches tag
+        working-directory: adapters/python
+        env:
+          TAG_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PKG_VER=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          TAG_VER="${TAG_REF#python-v}"
+          if [ "$PKG_VER" != "$TAG_VER" ]; then
+            echo "::error::pyproject.toml version ($PKG_VER) does not match tag ($TAG_VER)"
+            echo "Bump adapters/python/pyproject.toml + loomcycle/__init__.py to $TAG_VER and re-tag, or fix the tag."
+            exit 1
+          fi
+          echo "::notice::Publishing loomcycle@$PKG_VER (tag $TAG_REF)"
+
+      - name: Install package + dev deps
+        working-directory: adapters/python
+        run: |
+          python -m pip install --upgrade pip build
+          pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: adapters/python
+        run: pytest -v
+
+      - name: Build wheel + sdist
+        working-directory: adapters/python
+        run: python -m build
+
+      - name: Publish to PyPI via OIDC trusted publisher
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: adapters/python/dist/

--- a/adapters/python/pyproject.toml
+++ b/adapters/python/pyproject.toml
@@ -9,10 +9,17 @@
 #   make -C ../.. python-proto    # regenerate _generated/*.py from proto
 #   pytest
 #
-# Publish (CI on tag):
-#   pip install build twine
-#   python -m build
-#   twine upload dist/*
+# Publish (automated, CI on tag):
+#   1. Bump `version` below + adapters/python/loomcycle/__init__.py.
+#   2. Tag with the python-v* prefix to keep Python versioning
+#      independent of the Go release tag:
+#        git tag -a python-v0.6.X -m "..."
+#        git push origin python-v0.6.X
+#   3. The .github/workflows/publish-python-adapter.yml workflow runs
+#      the version-match gate, pytest, `python -m build`, and publishes
+#      via PyPI Trusted Publisher (OIDC, no API token). One-time PyPI
+#      setup: account settings → publishing → add pending publisher
+#      for project `loomcycle` with workflow `publish-python-adapter.yml`.
 
 [build-system]
 requires = ["setuptools>=68", "wheel"]
@@ -35,7 +42,12 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Framework :: AsyncIO",
+    "Typing :: Typed",
+    "Operating System :: OS Independent",
 ]
 # grpcio floor matches the GRPC_GENERATED_VERSION baked into the
 # committed _generated/loomcycle_pb2_grpc.py stubs (1.80.0). The
@@ -58,6 +70,9 @@ dev = [
 [project.urls]
 Homepage = "https://github.com/denn-gubsky/loomcycle"
 Repository = "https://github.com/denn-gubsky/loomcycle"
+Source = "https://github.com/denn-gubsky/loomcycle/tree/main/adapters/python"
+Documentation = "https://github.com/denn-gubsky/loomcycle/tree/main/adapters/python#readme"
+Changelog = "https://github.com/denn-gubsky/loomcycle/releases"
 Issues = "https://github.com/denn-gubsky/loomcycle/issues"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary

Mirrors the npm publish workflow we built for the TS adapter (#154/#156/#157), adapted for PyPI + Python tooling. Same shape — trigger on tags, OIDC Trusted Publisher (no API token to rotate), version-match safety gate, build + test before publish.

**No version bump in this PR.** \`pyproject.toml\` stays at \`0.6.1\` (last bump in PR #153). To publish a release: bump pyproject.toml + \`__init__.py\`, tag \`python-v0.6.X\`, push.

## Key design decisions

- **Separate tag namespace (\`python-v*\`).** The Python adapter is at 0.6.x while the Go binary is at 0.8.x — a shared \`v*\` namespace would force lockstep bumps that don't reflect actual Python-side change cadence. \`python-v0.6.1\`, \`python-v0.6.2\`, etc.
- **Version-match gate** strips the \`python-v\` prefix from the tag and compares against \`pyproject.toml\`'s \`[project] version\`. Same safety net as npm: tagging without bumping fails loudly before touching PyPI.
- **PyPI Trusted Publisher (OIDC), no token.** Same OIDC flow as npm. One-time PyPI setup required (see "What you need to do on PyPI" below).
- **Tests run inside the workflow** (\`pip install -e .[dev]\` + \`pytest\`) before \`python -m build\`. A regression doesn't reach PyPI.
- **\`GITHUB_REF_NAME\` routed through \`env:\`** as defence in depth against workflow injection (git rejects metacharacters in ref names, but belt-and-braces matches the npm workflow's pattern).

## pyproject.toml polish (independent of the workflow)

- Added Project-URLs for Source / Documentation / Changelog alongside Homepage / Repository / Issues. PyPI surfaces these as separate links on the package page.
- New classifiers: Python 3.13, \`Framework :: AsyncIO\`, \`Typing :: Typed\` (matches the existing py.typed marker), \`Operating System :: OS Independent\`, \`Topic :: Software Development :: Libraries :: Python Modules\`.
- Refreshed the publish-runbook comment at the top of the file to point at the automated flow.

## What you need to do on PyPI before the first tag

1. Log in to https://pypi.org.
2. Account settings → "Publishing".
3. "Add a new pending publisher" (because \`loomcycle\` doesn't exist on PyPI yet — once it does, this becomes "Add a trusted publisher" on the project's page).
4. Fill in:
   - **PyPI Project Name**: \`loomcycle\`
   - **Owner**: \`denn-gubsky\`
   - **Repository name**: \`loomcycle\`
   - **Workflow filename**: \`publish-python-adapter.yml\`
   - **Environment name**: (blank)
5. Save.

The first tag push will then create the project AND publish in one shot.

## Local smoke verification

- [x] \`python -m build\` produces a valid wheel + sdist at 0.6.1
- [x] \`twine check dist/*\` passes both artifacts
- [x] Metadata renders correctly (\`Description-Content-Type: text/markdown\` for the README; all Project-URLs present; classifiers present)
- [x] YAML lints clean

## Out of scope (separate follow-ups if wanted)

- PyPI name-squatting protection (you could trigger the workflow now with a tag to lock the project name; not required by this PR).
- Documentation site (Sphinx/MkDocs hosted on RTD or GitHub Pages).
- Wheel-build matrix for older grpcio versions (pyproject pins \`grpcio >= 1.80.0\`; if you wanted to widen consumer support, that's a separable concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)