### PR TITLE
ci: cross-platform release via goreleaser + Homebrew tap auto-bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release (goreleaser)
+
+# Cross-platform binary builds + Homebrew formula bump, fired on
+# every `v*` tag. The TS adapter's publish-ts-adapter workflow and
+# this one BOTH trigger on `v*`; they run in parallel and don't
+# conflict (TS publishes to npm, this builds Go binaries + uploads
+# release assets + bumps the homebrew tap formula).
+#
+# Manual setup required ONCE per repo:
+#   1. Generate a fine-grained personal access token at
+#      https://github.com/settings/personal-access-tokens scoped to
+#      ONLY denn-gubsky/homebrew-loomcycle with `Contents: Read and
+#      write` permission. No other scopes.
+#   2. Add the token as a repository secret named HOMEBREW_TAP_TOKEN
+#      under Settings -> Secrets and variables -> Actions.
+#
+# That token is needed because the workflow's default GITHUB_TOKEN
+# is scoped to THIS repository (denn-gubsky/loomcycle) only; pushing
+# the formula bump to the tap repo requires cross-repo write access.
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write  # needed for goreleaser to upload release assets
+
+jobs:
+  goreleaser:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # goreleaser needs full git history for the version
+          # template + commit-date stamp.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+          cache: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Build embedded Web UI
+        # The web UI is embedded via go:embed in internal/webui/dist
+        # which `make build-ui` populates. Every cross-compiled
+        # binary ships the same UI bundle.
+        run: make build-ui
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,11 @@ __pycache__/
 *.pyc
 .pytest_cache/
 
+# goreleaser snapshot + release output. `goreleaser release --snapshot`
+# writes here for local smoke-testing; CI's release workflow also
+# uses this directory before uploading to the GitHub release.
+/dist/
+
 # v0.7.3 web UI build artefacts. The .gitkeep placeholder is the only
 # committed file under internal/webui/dist/ — `make build-ui` replaces
 # it with index.html + assets/, which we don't commit (CI runs the

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,119 @@
+# goreleaser config — cross-platform release + Homebrew tap update.
+#
+# Triggered by .github/workflows/release.yml on `v*` tag push. Builds
+# loomcycle for darwin-{arm64,amd64} + linux-{arm64,amd64}, packages
+# each as tar.gz with LICENSE + README, attaches everything to the
+# GitHub release at the tag, generates SHA256SUMS, then bumps
+# Formula/loomcycle.rb in denn-gubsky/homebrew-loomcycle with the new
+# version + per-platform sha256 values.
+#
+# The Web UI is built once before the goreleaser run (the workflow's
+# `make build-ui` step) so internal/webui/dist/ is populated for
+# go:embed across every cross-compiled binary.
+#
+# https://goreleaser.com/
+version: 2
+
+project_name: loomcycle
+
+builds:
+  - id: loomcycle
+    main: ./cmd/loomcycle
+    binary: loomcycle
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    # -s -w strips DWARF + symbol table (~30% smaller). buildVersion /
+    # buildCommit / buildTime are read by cmd/loomcycle/main.go via
+    # the auto-version fallback chain (runtime/debug VCS stamp first;
+    # these ldflags override when the operator runs `make build` from
+    # a clean tag, which goreleaser always does).
+    ldflags:
+      - -s
+      - -w
+      - -X main.buildVersion={{ .Version }}
+      - -X main.buildCommit={{ .ShortCommit }}
+      - -X main.buildTime={{ .CommitDate }}
+    # Reproducible: pin mod_timestamp so multi-platform builds at the
+    # same tag produce identical archives (only the embedded binary
+    # differs by architecture).
+    mod_timestamp: "{{ .CommitTimestamp }}"
+
+archives:
+  - id: loomcycle-binary
+    ids:
+      - loomcycle
+    # Naming mirrors what the Formula's url template expects.
+    # Lowercase OS/Arch so darwin-arm64 etc. match.
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: "SHA256SUMS"
+  algorithm: sha256
+
+# Snapshot mode is what `goreleaser release --snapshot` uses to test
+# the config locally without pushing anywhere. The tag template
+# emits {next-tag}-next + commit so local snapshot artifacts can't
+# be confused with real releases.
+snapshot:
+  version_template: "{{ incpatch .Version }}-next-{{ .ShortCommit }}"
+
+# Release notes are managed manually on the GitHub release page
+# (curated narrative). goreleaser's auto-changelog would produce a
+# raw git-log dump that adds noise on top of the hand-written notes.
+changelog:
+  disable: true
+
+release:
+  github:
+    owner: denn-gubsky
+    name: loomcycle
+  # Don't overwrite manually-curated release notes if the release
+  # was created ahead of time (the v0.8.20 release was; future tags
+  # might be too).
+  mode: keep-existing
+
+# Homebrew formula — generated AND pushed to the tap repo on each
+# tag. `directory: Formula` matches the tap's layout. The token used
+# to push is HOMEBREW_TAP_GITHUB_TOKEN (a separate fine-grained PAT
+# scoped to denn-gubsky/homebrew-loomcycle with `contents: write`);
+# the default GITHUB_TOKEN is scoped to this repo only and can't
+# write to the tap.
+brews:
+  - name: loomcycle
+    repository:
+      owner: denn-gubsky
+      name: homebrew-loomcycle
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/denn-gubsky/loomcycle"
+    description: "Agentic runtime — one Go binary owning the LLM tool-use loop"
+    license: "Apache-2.0"
+    # commit_author surfaces in the tap's git history.
+    commit_author:
+      name: goreleaser-bot
+      email: bot@goreleaser.com
+    commit_msg_template: "loomcycle {{ .Tag }} — formula bump"
+    # caveats prints on `brew install` — mirrors what we wrote
+    # by hand for v0.8.20.
+    caveats: |
+      loomcycle ships as a single Go binary that reads configuration from
+      a YAML file. Quick start:
+
+        mkdir -p ~/.config/loomcycle
+        # Drop your loomcycle.yaml into ~/.config/loomcycle/
+        # See https://github.com/denn-gubsky/loomcycle for examples.
+        loomcycle --config ~/.config/loomcycle/loomcycle.yaml
+    test: |
+      assert_match "version=", shell_output("#{bin}/loomcycle --version")


### PR DESCRIPTION
## Summary

Adds goreleaser-driven release automation triggered on every \`v*\` tag. Runs alongside the existing \`publish-ts-adapter\` workflow without conflict — they touch different artifacts (TS publishes to npm; this builds Go binaries + uploads release assets + bumps the Homebrew tap formula).

**v0.8.20 was set up manually** (4 platform tarballs + SHA256SUMS uploaded to the release page; \`Formula/loomcycle.rb\` written by hand in denn-gubsky/homebrew-loomcycle). This PR is the automation for **future tags** (v0.8.21+).

## What goreleaser does on each v* tag

1. Cross-compiles loomcycle for \`darwin-{arm64,amd64}\` and \`linux-{arm64,amd64}\` with ldflags pinning version/commit/build-time to the tag.
2. Packages each binary as \`loomcycle-<os>-<arch>.tar.gz\` bundled with \`LICENSE\` + \`README.md\`.
3. Computes \`SHA256SUMS\` and attaches everything to the GitHub release at the tag.
4. Generates \`Formula/loomcycle.rb\` from the goreleaser brews template and pushes it to \`denn-gubsky/homebrew-loomcycle\` with the new version + per-platform sha256 values.

## Key config choices

- **\`release.mode: keep-existing\`** — preserves manually-curated release notes. v0.8.20's release page was written by hand; we don't want goreleaser overwriting it on future re-runs. Narrative changelogs stay a manual step (\`gh release create\` first, then tag; or edit the release after tagging).
- **\`mod_timestamp: CommitTimestamp\`** — reproducible builds. Re-running goreleaser at the same tag produces byte-identical archives.
- **\`brews\`** is being phased out by goreleaser in favour of \`homebrew_casks\` (informational warning, still supported). Migration is a small follow-up if/when convenient.

## One-time setup needed before the next tag

1. Generate a fine-grained PAT at https://github.com/settings/personal-access-tokens scoped to **only** \`denn-gubsky/homebrew-loomcycle\` with \`Contents: Read and write\` permission. No other scopes.
2. Add it as repo secret \`HOMEBREW_TAP_TOKEN\` under Settings → Secrets and variables → Actions.

This token is needed because the workflow's default \`GITHUB_TOKEN\` is scoped to \`denn-gubsky/loomcycle\` only — cross-repo write to the tap requires a separate PAT.

## Local snapshot verification

\`\`\`bash
goreleaser release --snapshot --clean --skip=publish --skip=homebrew
\`\`\`

Produced:
- 4 cross-compiled binaries (darwin-arm64, darwin-amd64, linux-arm64, linux-amd64)
- 4 tarballs each containing \`loomcycle\` + \`LICENSE\` + \`README.md\`
- Snapshot version template working: \`0.8.21-next-<short-sha>\`
- \`SHA256SUMS\` generated

## Files

| File | Purpose |
|---|---|
| \`.goreleaser.yaml\` | Cross-platform build config + brews/tap config + reproducible build settings |
| \`.github/workflows/release.yml\` | Triggers goreleaser on \`v*\` tag; sets up Go + Node toolchains; builds embedded Web UI |
| \`.gitignore\` | \`/dist/\` (goreleaser snapshot + release output) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)