### PR TITLE
feat(web): version + tabs + copy + audit-view UI polish

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"runtime/debug"
 	"sort"
@@ -122,6 +123,15 @@ func formatBuildInfo(mainVersion, rev, builtAt string, dirty bool) (version, com
 		// developer build at a glance.
 		version = "devel"
 	}
+	// Go's module proxy synthesises a "pseudo-version" for a commit
+	// that has no semver tag yet. Shape:
+	//   vX.Y.Z-0.YYYYMMDDHHMMSS-abcdef012345
+	// (the "0." form means "before any vX.Y.Z tag"). Operators want
+	// to see the meaningful base ("v0.8.21"), not the 40-char
+	// timestamped suffix that's redundant with `commit` + `built`
+	// fields. Strip it. Real prerelease tags like "v0.8.14-rc1" are
+	// left alone — the regex only matches the precise pseudo shape.
+	version = stripPseudoVersionSuffix(version)
 	if len(rev) > 12 {
 		rev = rev[:12]
 	}
@@ -129,6 +139,26 @@ func formatBuildInfo(mainVersion, rev, builtAt string, dirty bool) (version, com
 		rev += "-dirty"
 	}
 	return version, rev, builtAt
+}
+
+// pseudoVersionRE matches Go's auto-synthesised pseudo-versions:
+//
+//	vMAJOR.MINOR.PATCH-0.YYYYMMDDHHMMSS-<12+ hex>
+//
+// (Go also emits a leading "0." for the pre-tag case; the v2-style
+// post-tag pseudo-version is "<base>-<n>.YYYYMMDDHHMMSS-…" but our
+// repo is sub-v2 so the 0.-prefixed form is the only one we see.)
+// `(\+\w+)?` tolerates Go's module-level "+dirty" suffix that gets
+// appended to the pseudo-version when the working tree has uncommitted
+// changes — the version field still reports a clean semver, the
+// dirty signal is preserved on the separate commit field.
+var pseudoVersionRE = regexp.MustCompile(`^(v\d+\.\d+\.\d+)-0\.\d{14}-[0-9a-f]+(?:\+\w+)?$`)
+
+func stripPseudoVersionSuffix(v string) string {
+	if m := pseudoVersionRE.FindStringSubmatch(v); m != nil {
+		return m[1]
+	}
+	return v
 }
 
 func main() {

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -629,6 +629,11 @@ func main() {
 	contextTool.Tools = allTools
 
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
+	// Surface the resolved build identifiers via /healthz so the Web UI
+	// can render the running binary's real version instead of a stale
+	// hard-coded string. Mirrors what gRPC's Health RPC has reported
+	// since v0.5.5; HTTP only adopted this in v0.8.21.
+	srv.SetBuildInfo(buildVersion, buildCommit, buildTime)
 	srv.SetMCPFallback(mcpLazyResolver.Resolve)
 
 	// v0.8.6 SystemPublisher — backs the POST /v1/_channels/_system/...

--- a/cmd/loomcycle/main_test.go
+++ b/cmd/loomcycle/main_test.go
@@ -84,14 +84,52 @@ func TestFormatBuildInfo(t *testing.T) {
 			wantTS:      "2026-05-13T18:04:43Z",
 		},
 		{
-			name:        "pseudo_version_dirty",
+			// Go pseudo-versions get stripped to their semver base —
+			// the timestamped suffix is redundant with the separate
+			// commit + built fields. Operators want "v0.8.14" in the
+			// topbar, not "v0.8.14-0.20260513180443-7c2ca2e1f592".
+			name:        "pseudo_version_stripped_dirty",
 			mainVersion: "v0.8.14-0.20260513180443-7c2ca2e1f592",
 			rev:         "7c2ca2e1f592abcd",
 			builtAt:     "2026-05-13T18:04:43Z",
 			dirty:       true,
-			wantVersion: "v0.8.14-0.20260513180443-7c2ca2e1f592",
+			wantVersion: "v0.8.14",
 			wantCommit:  "7c2ca2e1f592-dirty",
 			wantTS:      "2026-05-13T18:04:43Z",
+		},
+		{
+			name:        "pseudo_version_stripped_clean",
+			mainVersion: "v0.8.21-0.20260520061001-1107844c6cf7",
+			rev:         "1107844c6cf7",
+			builtAt:     "2026-05-20T06:10:01Z",
+			wantVersion: "v0.8.21",
+			wantCommit:  "1107844c6cf7",
+			wantTS:      "2026-05-20T06:10:01Z",
+		},
+		{
+			// `go build` on a dirty working tree appends "+dirty" to
+			// the synthesised Main.Version. The strip must tolerate
+			// this suffix — the "-dirty" signal still surfaces via
+			// commit (driven by the separate vcs.modified setting).
+			name:        "pseudo_version_with_plus_dirty_stripped",
+			mainVersion: "v0.8.21-0.20260520061001-1107844c6cf7+dirty",
+			rev:         "1107844c6cf7",
+			builtAt:     "2026-05-20T06:10:01Z",
+			dirty:       true,
+			wantVersion: "v0.8.21",
+			wantCommit:  "1107844c6cf7-dirty",
+			wantTS:      "2026-05-20T06:10:01Z",
+		},
+		{
+			// Real semver prerelease tags must NOT be stripped. The
+			// pseudo-version regex is intentionally narrow (requires
+			// the literal "-0.<14 digits>-<hex>" tail) so legitimate
+			// suffixes like "-rc1" pass through unchanged.
+			name:        "real_prerelease_tag_preserved",
+			mainVersion: "v0.8.14-rc1",
+			rev:         "abcdef012345",
+			wantVersion: "v0.8.14-rc1",
+			wantCommit:  "abcdef012345",
 		},
 		{
 			name:        "devel_marker_normalised",

--- a/internal/api/http/awaited_state.go
+++ b/internal/api/http/awaited_state.go
@@ -1,0 +1,120 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// AwaitedState constants — the wire string values returned in the
+// agent response's `awaited_state` field. Kept in one place so the
+// derivation and the test asserts can't drift apart.
+const (
+	awaitedStateChannel     = "channel"
+	awaitedStateInterrupted = "interrupted"
+)
+
+// payloadToolCall mirrors providers.Event's persisted JSON shape
+// for tool_call rows — we decode only what the awaited-state
+// derivation needs (tool name + first-level input dispatch fields).
+// Input is decoded twice: once as a Channel.subscribe input, once
+// as an Interruption input. Both unmarshals are cheap on a small
+// JSON object.
+type payloadToolCall struct {
+	ToolUse struct {
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	} `json:"tool_use"`
+}
+
+type channelInput struct {
+	Op      string `json:"op"`
+	Channel string `json:"channel"`
+}
+
+type interruptionInput struct {
+	Op   string `json:"op"`
+	Kind string `json:"kind"`
+}
+
+// deriveAwaitedState inspects the latest event of a running agent
+// and returns (state, on) describing what (if anything) the agent
+// is blocked on:
+//
+//	state="channel"     on=<channel name>   — open Channel.subscribe
+//	state="interrupted" on=<kind|op>        — open Interruption.ask
+//	state=""            on=""               — agent is making progress
+//
+// Why "last event" suffices: the loomcycle loop is synchronous from
+// the goroutine's view — between a tool_call and its matching
+// tool_result, NO other events emit. So "the last event is a
+// tool_call to X" is equivalent to "X is currently executing."
+// This collapses what the client-side derivation needs (walking
+// unresolved tool_uses) into a single row lookup.
+func deriveAwaitedState(ev store.Event) (state, on string) {
+	if ev.Type != "tool_call" {
+		return "", ""
+	}
+	var p payloadToolCall
+	if err := json.Unmarshal(ev.Payload, &p); err != nil {
+		return "", ""
+	}
+	switch p.ToolUse.Name {
+	case "Channel":
+		var ci channelInput
+		if err := json.Unmarshal(p.ToolUse.Input, &ci); err != nil {
+			return "", ""
+		}
+		if ci.Op == "subscribe" {
+			return awaitedStateChannel, ci.Channel
+		}
+	case "Interruption":
+		var ii interruptionInput
+		if err := json.Unmarshal(p.ToolUse.Input, &ii); err != nil {
+			return "", ""
+		}
+		// v0.8.16 always emits kind="question" for "ask"; future
+		// kinds will land verbatim. For non-ask ops the
+		// Interruption tool doesn't block, so we ignore them.
+		if ii.Op == "ask" {
+			kind := ii.Kind
+			if kind == "" {
+				kind = "question"
+			}
+			return awaitedStateInterrupted, kind
+		}
+	}
+	return "", ""
+}
+
+// fillAwaitedStateForRunning enriches a slice of agentResponse with
+// the awaited_state / awaited_on fields by issuing a GetLastEventForRun
+// per running entry. Non-running rows are skipped. ErrNotFound
+// (run has no events yet) is silently treated as "no awaited state"
+// — common immediately after a CreateRun. Other store errors are
+// logged but don't fail the request (the chip tint is a UI nicety,
+// not a correctness signal).
+func fillAwaitedStateForRunning(ctx context.Context, st store.Store, items []agentResponse) {
+	for i, item := range items {
+		if item.Status != store.RunRunning {
+			continue
+		}
+		ev, err := st.GetLastEventForRun(ctx, item.RunID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				continue
+			}
+			log.Printf("awaited_state: GetLastEventForRun(%s) failed: %v", item.RunID, err)
+			continue
+		}
+		state, on := deriveAwaitedState(ev)
+		if state != "" {
+			items[i].AwaitedState = state
+			items[i].AwaitedOn = on
+		}
+	}
+}

--- a/internal/api/http/awaited_state_test.go
+++ b/internal/api/http/awaited_state_test.go
@@ -1,0 +1,104 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func TestDeriveAwaitedState(t *testing.T) {
+	cases := []struct {
+		name      string
+		ev        store.Event
+		wantState string
+		wantOn    string
+	}{
+		{
+			name:      "non_tool_call_event_yields_running",
+			ev:        store.Event{Type: "text", Payload: []byte(`{"type":"text","text":"hi"}`)},
+			wantState: "",
+		},
+		{
+			name: "channel_subscribe_yields_channel_state_with_name",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_1","name":"Channel","input":{"op":"subscribe","channel":"findings"}}
+				}`),
+			},
+			wantState: "channel",
+			wantOn:    "findings",
+		},
+		{
+			name: "channel_publish_does_not_block_yields_running",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_1","name":"Channel","input":{"op":"publish","channel":"findings"}}
+				}`),
+			},
+			wantState: "",
+		},
+		{
+			name: "interruption_ask_yields_interrupted_state_kind_default_question",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_2","name":"Interruption","input":{"op":"ask","question":"continue?"}}
+				}`),
+			},
+			wantState: "interrupted",
+			wantOn:    "question",
+		},
+		{
+			name: "interruption_ask_with_explicit_kind",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_3","name":"Interruption","input":{"op":"ask","kind":"approval"}}
+				}`),
+			},
+			wantState: "interrupted",
+			wantOn:    "approval",
+		},
+		{
+			name: "interruption_notify_does_not_block_yields_running",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_4","name":"Interruption","input":{"op":"notify","message":"hi"}}
+				}`),
+			},
+			wantState: "",
+		},
+		{
+			name: "other_tool_call_yields_running",
+			ev: store.Event{
+				Type: "tool_call",
+				Payload: []byte(`{
+					"type":"tool_call",
+					"tool_use":{"id":"tu_5","name":"Read","input":{"path":"/tmp/x"}}
+				}`),
+			},
+			wantState: "",
+		},
+		{
+			name:      "malformed_payload_degrades_to_running",
+			ev:        store.Event{Type: "tool_call", Payload: []byte(`{not json`)},
+			wantState: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotS, gotO := deriveAwaitedState(tc.ev)
+			if gotS != tc.wantState || gotO != tc.wantOn {
+				t.Errorf("got (%q,%q), want (%q,%q)", gotS, gotO, tc.wantState, tc.wantOn)
+			}
+		})
+	}
+}

--- a/internal/api/http/events_audit.go
+++ b/internal/api/http/events_audit.go
@@ -1,0 +1,126 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// listEventsResponse is the wire shape of GET /v1/_events.
+//
+// `total` is the unbounded match count for the filter — pagination
+// UIs need it to render "page N of M". `events` is the limit-bounded
+// slice for the requested window.
+type listEventsResponse struct {
+	Events []wireEvent `json:"events"`
+	Total  int64       `json:"total"`
+	Limit  int         `json:"limit"`
+	Offset int         `json:"offset"`
+}
+
+// wireEvent decouples the on-the-wire shape from the store row. We
+// keep payload as raw json.RawMessage so the UI can re-decode it the
+// same way the transcript endpoint does, without server-side
+// re-marshalling.
+type wireEvent struct {
+	Seq       int64           `json:"seq"`
+	SessionID string          `json:"session_id"`
+	RunID     string          `json:"run_id"`
+	Timestamp time.Time       `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// handleListEvents serves GET /v1/_events?type=X&from=Y&to=Z&limit=N&offset=M
+// — paginated cross-session event log for the v0.8.21 Audit view.
+// Bearer-authed admin surface.
+//
+// Filter params (all optional):
+//
+//	type=tool_call      exact match on event.type
+//	from=RFC3339        ts >= from
+//	to=RFC3339          ts <= to
+//	limit=50            page size (clamped to 1..500, default 50)
+//	offset=0            page offset (default 0)
+//
+// Returns 503 when the server boots without a store.
+func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; event audit requires a persistent store")
+		return
+	}
+	q := r.URL.Query()
+
+	var filter store.EventFilter
+	filter.Type = q.Get("type")
+
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"from must be RFC3339: "+err.Error())
+			return
+		}
+		filter.From = t
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"to must be RFC3339: "+err.Error())
+			return
+		}
+		filter.To = t
+	}
+
+	limit := 50
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"limit must be a positive integer")
+			return
+		}
+		limit = n
+	}
+	offset := 0
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"offset must be a non-negative integer")
+			return
+		}
+		offset = n
+	}
+
+	events, total, err := s.store.ListEvents(r.Context(), filter, limit, offset)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+
+	resp := listEventsResponse{
+		Events: make([]wireEvent, 0, len(events)),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	}
+	for _, ev := range events {
+		resp.Events = append(resp.Events, wireEvent{
+			Seq:       ev.Seq,
+			SessionID: ev.SessionID,
+			RunID:     ev.RunID,
+			Timestamp: ev.Timestamp,
+			Type:      ev.Type,
+			Payload:   json.RawMessage(ev.Payload),
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -133,6 +133,19 @@ type Server struct {
 	// Nil = POST /v1/_mcp returns 503. Set via SetMCPHTTPHandler from
 	// main.go after the handler is constructed.
 	mcpHTTPHandler http.Handler
+
+	// Build identifiers surfaced via /healthz so the Web UI topbar
+	// can display the running binary's version instead of a stale
+	// hard-coded string. Set via SetBuildInfo from cmd/loomcycle/main.go
+	// after the buildVersion / buildCommit / buildTime vars have been
+	// resolved (ldflags overrides → runtime/debug VCS stamp → "unknown").
+	// Empty values render as "unknown" on /healthz.
+	buildVersion string
+	buildCommit  string
+	buildTime    string
+	// startedAt records process start so /healthz can report uptime
+	// in seconds. Set in New().
+	startedAt time.Time
 }
 
 // New constructs a Server. If st is non-nil, every run is recorded as a
@@ -164,9 +177,21 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		sessionLocks:   runner.NewSessionLockMap(),
 		hookRegistry:   hookReg,
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		startedAt:      time.Now(),
 	}
 	s.tools = append(s.tools, &builtin.AgentTool{Run: s.runSubAgent})
 	return s
+}
+
+// SetBuildInfo records the binary's identification triple. Called from
+// cmd/loomcycle/main.go after the buildVersion/buildCommit/buildTime
+// vars are resolved. The values flow through /healthz so the Web UI
+// can render a real version label instead of a hard-coded string that
+// drifts every release.
+func (s *Server) SetBuildInfo(version, commit, builtAt string) {
+	s.buildVersion = version
+	s.buildCommit = commit
+	s.buildTime = builtAt
 }
 
 // SetMCPFallback installs the optional MCP lazy-resolution fallback.
@@ -1104,9 +1129,35 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 
 // --- handlers ---
 
+// healthzResponse mirrors the gRPC HealthResponse shape so adapters
+// switching between the two transports decode the same JSON keys.
+// uptime_seconds is computed at request time (not cached) so a long-
+// running process surfaces its real uptime, not the moment New() ran.
+type healthzResponse struct {
+	OK            bool   `json:"ok"`
+	Version       string `json:"version,omitempty"`
+	Commit        string `json:"commit,omitempty"`
+	Built         string `json:"built,omitempty"`
+	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
+}
+
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	w.Write([]byte(`{"ok":true}`))
+	// Compute uptime relative to startedAt. The fallback to time.Time{}
+	// case is for *Server values constructed via struct literal in
+	// tests — uptime would otherwise be ~negative-epoch.
+	var uptime int64
+	if !s.startedAt.IsZero() {
+		uptime = int64(time.Since(s.startedAt).Seconds())
+	}
+	resp := healthzResponse{
+		OK:            true,
+		Version:       s.buildVersion,
+		Commit:        s.buildCommit,
+		Built:         s.buildTime,
+		UptimeSeconds: uptime,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 // systemChannelPublishRequest is the body shape for the v0.8.6

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2578,6 +2578,16 @@ type agentResponse struct {
 	Usage           agentResponseUsage `json:"usage"`
 	LastHeartbeatAt *time.Time         `json:"last_heartbeat_at,omitempty"`
 	Live            bool               `json:"live"`
+	// v0.8.21 awaited-state surface — what the running agent is
+	// currently blocked on. Empty for non-running rows AND for
+	// running rows where the agent is making progress (no
+	// unresolved Channel.subscribe / Interruption.ask). Two-field
+	// shape avoids encoding a parser into the wire:
+	//   AwaitedState = "" | "channel" | "interrupted"
+	//   AwaitedOn    = channel name (when state=channel) or
+	//                  interruption kind (when state=interrupted)
+	AwaitedState string `json:"awaited_state,omitempty"`
+	AwaitedOn    string `json:"awaited_on,omitempty"`
 }
 
 type agentResponseUsage struct {
@@ -2671,7 +2681,13 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_, live := s.cancelReg.Get(agentID)
-	writeJSON(w, http.StatusOK, runToAgentResponse(run, live))
+	resp := runToAgentResponse(run, live)
+	if resp.Status == store.RunRunning {
+		single := []agentResponse{resp}
+		fillAwaitedStateForRunning(r.Context(), s.store, single)
+		resp = single[0]
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 // cancelRequest is the (optional) JSON body for POST /v1/agents/{id}/cancel.
@@ -2777,6 +2793,7 @@ func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
 		_, live := s.cancelReg.Get(run.AgentID)
 		out = append(out, runToAgentResponse(run, live))
 	}
+	fillAwaitedStateForRunning(r.Context(), s.store, out)
 	writeJSON(w, http.StatusOK, map[string]any{"agents": out})
 }
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1048,6 +1048,10 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_metrics/samples", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSamples))))
 	mux.Handle("GET /v1/_metrics/runs/{run_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsRunSummary))))
 	mux.Handle("GET /v1/_metrics/summary", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSummary))))
+	// v0.8.21 audit view — paginated cross-session event log with
+	// optional type + date-range filter. Drives the Web UI's
+	// /ui/audit page. Bearer-authed admin surface.
+	mux.Handle("GET /v1/_events", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListEvents))))
 	// v0.8.15.3 HTTP MCP transport — Streamable HTTP endpoint that
 	// dispatches the same 20 MCP tools as the stdio MCP server.
 	// POST is the JSON-RPC frame transport; DELETE terminates a

--- a/internal/store/postgres/migrations/0014_events_audit_index.down.sql
+++ b/internal/store/postgres/migrations/0014_events_audit_index.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS events_by_type_ts;
+DROP INDEX IF EXISTS events_by_ts;

--- a/internal/store/postgres/migrations/0014_events_audit_index.up.sql
+++ b/internal/store/postgres/migrations/0014_events_audit_index.up.sql
@@ -1,0 +1,25 @@
+-- 0014_events_audit_index.up.sql — v0.8.21 Audit view tab.
+--
+-- The Web UI's new /ui/audit page queries events across all
+-- sessions, filtered by event type and date range, paginated by
+-- limit + offset. The existing `events_by_session (session_id,
+-- seq)` index serves session-scoped queries; cross-session reads
+-- table-scan without help. Two new indexes:
+--
+-- events_by_ts            — covers the common "show me everything
+--                           since timestamp X" view with descending
+--                           ts ordering. PK seq is monotonically
+--                           increasing alongside ts (events insert
+--                           in order) so this is the audit-view
+--                           default sort.
+--
+-- events_by_type_ts       — covers type-filtered queries
+--                           ("show me only tool_call events since X").
+--                           Composite (type, ts DESC) supports both
+--                           the equality + range scan in one B-tree.
+--
+-- No DOWN counterpart drops the indexes — they're additive and
+-- cheap to keep. If a future reader runs the down migration, they
+-- explicitly want the indexes gone.
+CREATE INDEX IF NOT EXISTS events_by_ts ON events(ts DESC);
+CREATE INDEX IF NOT EXISTS events_by_type_ts ON events(type, ts DESC);

--- a/internal/store/postgres/migrations/0015_events_by_run_seq_index.down.sql
+++ b/internal/store/postgres/migrations/0015_events_by_run_seq_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS events_by_run_seq;

--- a/internal/store/postgres/migrations/0015_events_by_run_seq_index.up.sql
+++ b/internal/store/postgres/migrations/0015_events_by_run_seq_index.up.sql
@@ -1,0 +1,13 @@
+-- 0015_events_by_run_seq_index.up.sql — v0.8.21 awaited-state tree tint.
+--
+-- The Web UI's left agents-tree panel needs the most-recent event
+-- per running run to derive what each agent is currently blocked
+-- on (Channel.subscribe long-poll → orange; Interruption.ask →
+-- violet; otherwise green). The list-agents handler invokes
+-- GetLastEventForRun once per running row.
+--
+-- Without this index the (run_id, ORDER BY seq DESC LIMIT 1)
+-- subquery scans every event the run has emitted; for chatty
+-- agents this is hundreds of rows per call, repeated for every
+-- agent in the polling fan-out.
+CREATE INDEX IF NOT EXISTS events_by_run_seq ON events(run_id, seq DESC);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -306,6 +306,80 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 	return out, nil
 }
 
+// ListEvents serves the v0.8.21 /v1/_events audit endpoint. Same
+// filter semantics as the SQLite adapter; uses $N placeholders and
+// numeric args. Index hint: events_by_ts / events_by_type_ts (added
+// in migration 0014).
+func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit, offset int) ([]store.Event, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var (
+		conds []string
+		args  []any
+		i     = 1
+	)
+	if filter.Type != "" {
+		conds = append(conds, fmt.Sprintf("type = $%d", i))
+		args = append(args, filter.Type)
+		i++
+	}
+	if !filter.From.IsZero() {
+		conds = append(conds, fmt.Sprintf("ts >= $%d", i))
+		args = append(args, filter.From)
+		i++
+	}
+	if !filter.To.IsZero() {
+		conds = append(conds, fmt.Sprintf("ts <= $%d", i))
+		args = append(args, filter.To)
+		i++
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	var total int64
+	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM events "+where, args...).Scan(&total); err != nil {
+		return nil, 0, fmt.Errorf("count events: %w", err)
+	}
+
+	args = append(args, limit, offset)
+	rows, err := s.pool.Query(ctx,
+		"SELECT seq, session_id, run_id, ts, type, payload FROM events "+where+
+			fmt.Sprintf(" ORDER BY ts DESC, seq DESC LIMIT $%d OFFSET $%d", i, i+1),
+		args...,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("query events: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]store.Event, 0, limit)
+	for rows.Next() {
+		var (
+			ev store.Event
+			ts time.Time
+		)
+		if err := rows.Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload); err != nil {
+			return nil, 0, fmt.Errorf("scan event: %w", err)
+		}
+		ev.Timestamp = ts
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iter events: %w", err)
+	}
+	return out, total, nil
+}
+
 // GetRunByAgentID returns the most recently started run with the given
 // agent_id. Empty agentID short-circuits to ErrNotFound (callers don't
 // have to pre-check, matching SQLite adapter behaviour).

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -306,6 +306,28 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 	return out, nil
 }
 
+// GetLastEventForRun returns the latest event by seq for the given
+// run. Index hint: events_by_run_seq (added in migration 0015).
+func (s *Store) GetLastEventForRun(ctx context.Context, runID string) (store.Event, error) {
+	var (
+		ev store.Event
+		ts time.Time
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT seq, session_id, run_id, ts, type, payload
+		 FROM events WHERE run_id = $1 ORDER BY seq DESC LIMIT 1`,
+		runID,
+	).Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.Event{}, &store.ErrNotFound{Kind: "event", ID: runID}
+	}
+	if err != nil {
+		return store.Event{}, fmt.Errorf("get last event for run: %w", err)
+	}
+	ev.Timestamp = ts
+	return ev, nil
+}
+
 // ListEvents serves the v0.8.21 /v1/_events audit endpoint. Same
 // filter semantics as the SQLite adapter; uses $N placeholders and
 // numeric args. Index hint: events_by_ts / events_by_type_ts (added

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -99,6 +99,12 @@ func (s *Store) migrate(ctx context.Context) error {
 			payload    BLOB NOT NULL
 		)`,
 		`CREATE INDEX IF NOT EXISTS events_by_session ON events(session_id, seq)`,
+		// v0.8.21 audit view — cross-session queries by ts (descending)
+		// and ts-with-type-equality. Mirrors the postgres
+		// 0014_events_audit_index migration; both stores need the
+		// indexes to avoid full-table scans on busy installs.
+		`CREATE INDEX IF NOT EXISTS events_by_ts ON events(ts DESC)`,
+		`CREATE INDEX IF NOT EXISTS events_by_type_ts ON events(type, ts DESC)`,
 		// v0.8 Memory tool. PRIMARY KEY (scope, scope_id, key) gives
 		// the natural lookup index; the partial expires_at index keeps
 		// the sweeper's DELETE cheap (no full-table scan).
@@ -561,6 +567,75 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 		out = append(out, ev)
 	}
 	return out, rows.Err()
+}
+
+// ListEvents serves the v0.8.21 audit view's cross-session query.
+// Filter clauses are conditionally appended so unset dimensions don't
+// constrain the index lookup. Total is computed via a sibling COUNT(*)
+// over the same WHERE clause so pagination UIs can show "page N of M"
+// without a separate API call.
+func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit, offset int) ([]store.Event, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500 // cap to keep memory bounded
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var (
+		conds []string
+		args  []any
+	)
+	if filter.Type != "" {
+		conds = append(conds, "type = ?")
+		args = append(args, filter.Type)
+	}
+	if !filter.From.IsZero() {
+		conds = append(conds, "ts >= ?")
+		args = append(args, filter.From.UnixNano())
+	}
+	if !filter.To.IsZero() {
+		conds = append(conds, "ts <= ?")
+		args = append(args, filter.To.UnixNano())
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	// COUNT(*) first — same WHERE, but separate to avoid window-fn
+	// complexity on SQLite. Cheap because the WHERE narrows via the
+	// new indexes.
+	var total int64
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events "+where, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	args = append(args, limit, offset)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT seq, session_id, run_id, ts, type, payload FROM events "+where+
+			" ORDER BY ts DESC, seq DESC LIMIT ? OFFSET ?",
+		args...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	out := make([]store.Event, 0, limit)
+	for rows.Next() {
+		var ev store.Event
+		var ts int64
+		if err := rows.Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload); err != nil {
+			return nil, 0, err
+		}
+		ev.Timestamp = time.Unix(0, ts)
+		out = append(out, ev)
+	}
+	return out, total, rows.Err()
 }
 
 // scanRun decodes one row from a runs SELECT into a store.Run. The

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -105,6 +105,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		// indexes to avoid full-table scans on busy installs.
 		`CREATE INDEX IF NOT EXISTS events_by_ts ON events(ts DESC)`,
 		`CREATE INDEX IF NOT EXISTS events_by_type_ts ON events(type, ts DESC)`,
+		// v0.8.21 awaited-state derivation needs the last event per
+		// run cheaply for every running agent — (run_id, seq DESC)
+		// is the covering shape.
+		`CREATE INDEX IF NOT EXISTS events_by_run_seq ON events(run_id, seq DESC)`,
 		// v0.8 Memory tool. PRIMARY KEY (scope, scope_id, key) gives
 		// the natural lookup index; the partial expires_at index keeps
 		// the sweeper's DELETE cheap (no full-table scan).
@@ -567,6 +571,31 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 		out = append(out, ev)
 	}
 	return out, rows.Err()
+}
+
+// GetLastEventForRun returns the latest event by seq for the given
+// run. Indexed by events.run_id under the existing schema; the
+// composite (session_id, seq) index doesn't cover this query, but
+// SQLite's automatic indexing on the run_id column is sufficient
+// for the typical N<20 running-agents case.
+func (s *Store) GetLastEventForRun(ctx context.Context, runID string) (store.Event, error) {
+	var (
+		ev store.Event
+		ts int64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT seq, session_id, run_id, ts, type, payload
+		 FROM events WHERE run_id = ? ORDER BY seq DESC LIMIT 1`,
+		runID,
+	).Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Event{}, &store.ErrNotFound{Kind: "event", ID: runID}
+	}
+	if err != nil {
+		return store.Event{}, err
+	}
+	ev.Timestamp = time.Unix(0, ts)
+	return ev, nil
 }
 
 // ListEvents serves the v0.8.21 audit view's cross-session query.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -360,6 +360,15 @@ type Store interface {
 	// follow-up if scale demands.
 	ListEvents(ctx context.Context, filter EventFilter, limit, offset int) ([]Event, int64, error)
 
+	// GetLastEventForRun returns the highest-seq event recorded for
+	// the given run. v0.8.21 introduces this so the list-agents
+	// endpoint can derive "awaited state" (channel/interrupted/
+	// running) cheaply from one row per running agent — without
+	// pulling the full transcript. Returns *ErrNotFound{Kind:"event"}
+	// when the run has no events yet (just-created, hasn't streamed
+	// anything).
+	GetLastEventForRun(ctx context.Context, runID string) (Event, error)
+
 	// GetRunByAgentID returns the most recently started run carrying
 	// the given agent_id. Returns *ErrNotFound when no such row.
 	// Used by the GET /v1/agents/{agent_id} and cancel endpoints to

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -228,6 +228,17 @@ const (
 	PauseStatePaused  = "paused"  // loop reached the boundary and persisted; awaiting resume
 )
 
+// EventFilter narrows a ListEvents query. Zero values mean "no
+// filter on this dimension":
+//   - Type == ""  → all event types
+//   - From / To zero-value time.Time → unbounded on that side
+// Use From + To together for a window; either alone is supported.
+type EventFilter struct {
+	Type string
+	From time.Time
+	To   time.Time
+}
+
 // Event is one streamed datum, persisted append-only. Payload is the JSON
 // representation of the loop's providers.Event so we never lose typed
 // fields when reading back; the API package re-decodes it on replay.
@@ -338,6 +349,16 @@ type Store interface {
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.
 	GetTranscript(ctx context.Context, sessionID string) ([]Event, error)
+
+	// ListEvents returns events across all sessions matching the
+	// filter, ordered by ts DESC (newest first). Used by the v0.8.21
+	// /v1/_events audit endpoint. Returns the rows AND the total
+	// match count (for pagination UIs that show "page N of M");
+	// total is an unbounded COUNT(*) over the same filter — bounded
+	// by indexes events_by_ts / events_by_type_ts. Pagination is
+	// offset-based for simplicity; cursor-based pagination is a
+	// follow-up if scale demands.
+	ListEvents(ctx context.Context, filter EventFilter, limit, offset int) ([]Event, int64, error)
 
 	// GetRunByAgentID returns the most recently started run carrying
 	// the given agent_id. Returns *ErrNotFound when no such row.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -162,6 +162,9 @@ func Run(t *testing.T, factory Factory) {
 		// v0.8.21 audit-view cross-session event listing.
 		{"ListEventsFilterByTypeAndRange", testListEventsFilterByTypeAndRange},
 		{"ListEventsPaginationAndTotal", testListEventsPaginationAndTotal},
+		// v0.8.21 awaited-state derivation needs last-event-per-run.
+		{"GetLastEventForRunEmpty", testGetLastEventForRunEmpty},
+		{"GetLastEventForRunReturnsHighestSeq", testGetLastEventForRunReturnsHighestSeq},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3272,6 +3275,82 @@ func testListEventsFilterByTypeAndRange(t *testing.T, s store.Store) {
 	if total3 != 1 || len(got3) != 1 || got3[0].Type != "tool_call" {
 		t.Errorf("type+to mismatch: total=%d got=%v", total3, got3)
 	}
+}
+
+// testGetLastEventForRunEmpty confirms a freshly-created run with no
+// events yet yields ErrNotFound{Kind:"event"}. The list-agents
+// handler treats this as "no awaited state" — common immediately
+// after a run is registered.
+func testGetLastEventForRunEmpty(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_empty"})
+
+	_, err := s.GetLastEventForRun(ctx, run.ID)
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Fatalf("got %v (%T), want *ErrNotFound", err, err)
+	}
+	if nf.Kind != "event" {
+		t.Errorf("Kind = %q, want event", nf.Kind)
+	}
+}
+
+// testGetLastEventForRunReturnsHighestSeq writes a sequence of
+// events and asserts the lookup returns the LATEST one (highest
+// seq), with the correct session/run/type/payload round-tripped.
+func testGetLastEventForRunReturnsHighestSeq(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_last"})
+
+	for _, p := range []struct{ typ, body string }{
+		{"text", `{"text":"hi"}`},
+		{"tool_call", `{"tool_use":{"id":"tu_1","name":"Read"}}`},
+		{"tool_call", `{"tool_use":{"id":"tu_2","name":"Channel","input":{"op":"subscribe","channel":"findings"}}}`},
+	} {
+		if err := s.AppendEvent(ctx, run.ID, p.typ, []byte(p.body)); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	ev, err := s.GetLastEventForRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.Type != "tool_call" {
+		t.Errorf("Type = %q, want tool_call (latest)", ev.Type)
+	}
+	if ev.SessionID != sess.ID || ev.RunID != run.ID {
+		t.Errorf("session/run id mismatch: %+v", ev)
+	}
+	if !contains(string(ev.Payload), "Channel") {
+		t.Errorf("payload should be the Channel.subscribe row, got %s", string(ev.Payload))
+	}
+
+	// Adding an event on a DIFFERENT run must not leak into this one.
+	other, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_other"})
+	if err := s.AppendEvent(ctx, other.ID, "text", []byte(`{"text":"other"}`)); err != nil {
+		t.Fatal(err)
+	}
+	ev2, err := s.GetLastEventForRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev2.RunID != run.ID || ev2.Type != "tool_call" {
+		t.Errorf("scope leak: got %+v", ev2)
+	}
+}
+
+// contains is a local helper to avoid pulling strings.Contains in
+// a test-only file — keeps the contract package import-light.
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // testListEventsPaginationAndTotal confirms limit + offset slice the

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -159,6 +159,9 @@ func Run(t *testing.T, factory Factory) {
 		{"InterruptCountPendingByRunIsAccurateUnderConcurrency", testInterruptCountPendingByRunIsAccurateUnderConcurrency},
 		{"InterruptSweepExpiredMarksOnlyExpiredPending", testInterruptSweepExpiredMarksOnlyExpiredPending},
 		{"InterruptIDIsMonotonicByTime", testInterruptIDIsMonotonicByTime},
+		// v0.8.21 audit-view cross-session event listing.
+		{"ListEventsFilterByTypeAndRange", testListEventsFilterByTypeAndRange},
+		{"ListEventsPaginationAndTotal", testListEventsPaginationAndTotal},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -3199,5 +3202,126 @@ func testInterruptIDIsMonotonicByTime(t *testing.T, s store.Store) {
 	const wantLen = len("intr_") + 16 + 8
 	if len(id1) != wantLen {
 		t.Errorf("id length = %d, want %d", len(id1), wantLen)
+	}
+}
+
+// testListEventsFilterByTypeAndRange confirms the audit query honors
+// both the type and from/to dimensions: only the union of matching
+// rows is returned, and total reflects that union (not the table).
+func testListEventsFilterByTypeAndRange(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_audit"})
+
+	// Append a known sequence across multiple event types.
+	for _, p := range []struct{ typ, body string }{
+		{"text", `{"text":"hello"}`},
+		{"tool_call", `{"tool":"Read"}`},
+		{"text", `{"text":"world"}`},
+		{"tool_result", `{"tool_use_id":"tu_1"}`},
+		{"text", `{"text":"again"}`},
+	} {
+		if err := s.AppendEvent(ctx, run.ID, p.typ, []byte(p.body)); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	// Filter by type only.
+	got, total, err := s.ListEvents(ctx, store.EventFilter{Type: "text"}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Errorf("type=text total = %d, want 3", total)
+	}
+	if len(got) != 3 {
+		t.Errorf("type=text len(got) = %d, want 3", len(got))
+	}
+	for _, ev := range got {
+		if ev.Type != "text" {
+			t.Errorf("filter leaked non-text event: %q", ev.Type)
+		}
+		if ev.SessionID != sess.ID || ev.RunID != run.ID {
+			t.Errorf("event missing session/run id: %+v", ev)
+		}
+	}
+
+	// Order is ts DESC (newest first) — "again" was appended last.
+	if got[0].Type != "text" {
+		t.Fatalf("expected newest text first")
+	}
+
+	// Date range that excludes everything → empty + total=0.
+	farFuture := time.Now().Add(24 * time.Hour)
+	_, total2, err := s.ListEvents(ctx, store.EventFilter{From: farFuture}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total2 != 0 {
+		t.Errorf("future-only filter total = %d, want 0", total2)
+	}
+
+	// Combined type + to in the future → all matching texts.
+	got3, total3, err := s.ListEvents(ctx, store.EventFilter{
+		Type: "tool_call",
+		To:   farFuture,
+	}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total3 != 1 || len(got3) != 1 || got3[0].Type != "tool_call" {
+		t.Errorf("type+to mismatch: total=%d got=%v", total3, got3)
+	}
+}
+
+// testListEventsPaginationAndTotal confirms limit + offset slice the
+// matching window correctly and total is the unbounded match count
+// regardless of pagination.
+func testListEventsPaginationAndTotal(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_page"})
+
+	const N = 7
+	for i := 0; i < N; i++ {
+		if err := s.AppendEvent(ctx, run.ID, "text", []byte(`{}`)); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+	}
+
+	page1, total, err := s.ListEvents(ctx, store.EventFilter{Type: "text"}, 3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != N {
+		t.Errorf("total = %d, want %d", total, N)
+	}
+	if len(page1) != 3 {
+		t.Errorf("page1 len = %d, want 3", len(page1))
+	}
+
+	page2, _, err := s.ListEvents(ctx, store.EventFilter{Type: "text"}, 3, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 3 {
+		t.Errorf("page2 len = %d, want 3", len(page2))
+	}
+
+	page3, _, err := s.ListEvents(ctx, store.EventFilter{Type: "text"}, 3, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page3) != 1 {
+		t.Errorf("page3 len = %d, want 1", len(page3))
+	}
+
+	// Pages must not overlap on seq.
+	seen := map[int64]bool{}
+	for _, ev := range append(append(page1, page2...), page3...) {
+		if seen[ev.Seq] {
+			t.Errorf("seq %d appeared in two pages", ev.Seq)
+		}
+		seen[ev.Seq] = true
 	}
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -66,6 +66,13 @@ export interface Agent {
   };
   last_heartbeat_at: string | null;
   live: boolean;
+  // v0.8.21 awaited-state surface. Empty/absent for non-running
+  // runs AND for running runs making normal progress. When set,
+  // `awaited_state` is "channel" (open Channel.subscribe) or
+  // "interrupted" (open Interruption.ask), and `awaited_on` carries
+  // the channel name or interruption kind respectively.
+  awaited_state?: "channel" | "interrupted" | "";
+  awaited_on?: string;
 }
 
 export interface ListAgentsResponse {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -421,6 +421,45 @@ async function postJSON<T>(path: string, body: string | undefined): Promise<T> {
   return resp.json() as Promise<T>;
 }
 
+// AuditEvent mirrors wireEvent in internal/api/http/events_audit.go.
+// Payload is left as `unknown` because event payloads vary by type
+// (text / tool_call / tool_result / usage / done / …); the audit
+// view stringifies + pretty-prints them rather than decoding.
+export interface AuditEvent {
+  seq: number;
+  session_id: string;
+  run_id: string;
+  timestamp: string;
+  type: string;
+  payload: unknown;
+}
+
+export interface ListEventsResponse {
+  events: AuditEvent[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface ListEventsParams {
+  type?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export function listEvents(params: ListEventsParams = {}): Promise<ListEventsResponse> {
+  const q = new URLSearchParams();
+  if (params.type) q.set("type", params.type);
+  if (params.from) q.set("from", params.from);
+  if (params.to) q.set("to", params.to);
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  if (params.offset !== undefined) q.set("offset", String(params.offset));
+  const qs = q.toString();
+  return jsonFetch<ListEventsResponse>(`/v1/_events${qs ? "?" + qs : ""}`);
+}
+
 export async function resolveInterrupt(
   runID: string,
   interruptID: string,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -18,6 +18,26 @@ export function listUsers(): Promise<ListUsersResponse> {
   return jsonFetch<ListUsersResponse>("/v1/_users");
 }
 
+// HealthResponse mirrors handleHealthz on the server. Extended in
+// v0.8.21 to surface buildVersion / buildCommit / buildTime so the
+// Web UI can render the real running version instead of a hard-coded
+// string. Older binaries (<= v0.8.20) return just {"ok":true} —
+// the version field is missing on those responses; callers must
+// tolerate undefined.
+export interface HealthResponse {
+  ok: boolean;
+  version?: string;
+  commit?: string;
+  built?: string;
+  uptime_seconds?: number;
+}
+
+export function getHealth(): Promise<HealthResponse> {
+  // /healthz isn't under /v1/ — it's unauthenticated and lives at
+  // the root mux per the server's pattern.
+  return jsonFetch<HealthResponse>("/healthz");
+}
+
 // Agent mirrors agentResponse on the server (internal/api/http/server.go).
 // Field names use snake_case to match the wire shape; renaming any of
 // them is a wire change, not a UI change.

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -119,6 +119,7 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
   }, [ancestors, agent?.parent_agent_id, parentAgent]);
 
   const renderedEvents = useMemo(() => coalesceText(events.filter(visible)), [events]);
+  const awaited = useMemo(() => deriveAwaitedState(events), [events]);
   const [viewMode, setViewMode] = useViewMode();
 
   return (
@@ -150,6 +151,11 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
               </button>
             )}
           </div>
+          {agent.status === "running" && (
+            <div className="line-await">
+              <AwaitChip state={awaited} />
+            </div>
+          )}
           <div className="line2">
             <span>{agent.usage?.model || "—"}</span>
             <span>user: {agent.user_id || "—"}</span>
@@ -196,6 +202,84 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
 function visible(ev: TranscriptEvent): boolean {
   const t = ev.event?.type ?? ev.type;
   return t !== "started" && t !== "usage" && t !== "session" && t !== "agent" && t !== "user_input";
+}
+
+// AwaitedState is what the agent is currently blocked on (or
+// "running" if it's actively making progress / waiting on a
+// provider response, which we can't distinguish from real CPU
+// work from outside the loop).
+type AwaitedState =
+  | { kind: "running" }
+  | { kind: "channel"; channel: string }
+  | { kind: "interrupted"; op: string };
+
+// deriveAwaitedState walks the transcript and identifies the last
+// tool_call that hasn't received a matching tool_result. If that
+// open call is a Channel.subscribe or an Interruption.ask, the
+// agent is blocked on a long-poll; otherwise it's "running".
+//
+// Why look at unresolved tool_calls (not a server-side flag): the
+// loomcycle loop doesn't currently surface "I'm inside a tool that
+// is blocking on i/o" anywhere — the only signal is the absence of
+// a tool_result for the most recent tool_call. The events stream
+// already carries that signal; computing it client-side keeps the
+// wire shape stable and avoids a server roundtrip. Note this is
+// best-effort: if the operator filters events somehow, the
+// derivation degrades to "running".
+function deriveAwaitedState(events: TranscriptEvent[]): AwaitedState {
+  const settledIDs = new Set<string>();
+  for (const row of events) {
+    const ev = row.event ?? ({ type: row.type } as EventPayload);
+    if (ev.type === "tool_result" && ev.tool_use_id) {
+      settledIDs.add(ev.tool_use_id);
+    }
+  }
+  // Walk from newest to oldest looking for an unresolved tool_call.
+  for (let i = events.length - 1; i >= 0; i--) {
+    const row = events[i];
+    const ev = row.event ?? ({ type: row.type } as EventPayload);
+    if (ev.type !== "tool_call" || !ev.tool_use) continue;
+    if (settledIDs.has(ev.tool_use.id)) continue;
+    const input = (ev.tool_use.input ?? {}) as Record<string, unknown>;
+    if (ev.tool_use.name === "Channel" && input.op === "subscribe") {
+      const channel = typeof input.channel === "string" ? input.channel : "?";
+      return { kind: "channel", channel };
+    }
+    if (ev.tool_use.name === "Interruption") {
+      const op = typeof input.op === "string" ? input.op : "";
+      // v0.8.16 emits kind="question" for every blocking ask, but
+      // call sites may set kind explicitly in future versions —
+      // prefer it when present, fall back to a human-friendly
+      // mapping of op.
+      const kind = typeof input.kind === "string" ? input.kind : op === "ask" ? "question" : op;
+      return { kind: "interrupted", op: kind || "?" };
+    }
+    // First unresolved tool_call is neither Channel nor Interruption
+    // — agent is doing normal tool work. Stop walking; no blocking
+    // state.
+    return { kind: "running" };
+  }
+  return { kind: "running" };
+}
+
+// AwaitChip renders one of three pills next to a running agent's
+// status. Colour comes from CSS class — see styles.css .await-chip.*.
+function AwaitChip({ state }: { state: AwaitedState }) {
+  if (state.kind === "channel") {
+    return (
+      <span className="await-chip await-chip-channel">
+        channel <code>{state.channel}</code>
+      </span>
+    );
+  }
+  if (state.kind === "interrupted") {
+    return (
+      <span className="await-chip await-chip-interrupted">
+        interrupted: <code>{state.op}</code>
+      </span>
+    );
+  }
+  return <span className="await-chip await-chip-running">running</span>;
 }
 
 // coalesceText folds runs of consecutive `text` (and `thinking`) events

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { Agent, EventPayload, TranscriptEvent, cancelAgent, getAgent, getTranscript } from "../api";
 import Breadcrumbs, { type BreadcrumbAncestor } from "./Breadcrumbs";
@@ -241,6 +241,11 @@ function coalesceText(events: TranscriptEvent[]): TranscriptEvent[] {
 // without a wall of text; clicking dives into a specific event.
 function EventCard({ row }: { row: TranscriptEvent }) {
   const [open, setOpen] = useState(false);
+  // copyState shows feedback after click: idle → copied → idle.
+  // "error" fires when the clipboard API is blocked (insecure
+  // origin, no document focus, etc.) so the operator sees that
+  // copy didn't happen instead of silently swallowing.
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
   const ev = row.event ?? ({ type: row.type } as EventPayload);
   const kind = ev.type ?? row.type;
 
@@ -248,6 +253,19 @@ function EventCard({ row }: { row: TranscriptEvent }) {
   const detail = detailFor(ev);
 
   const toggle = () => setOpen((v) => !v);
+
+  const copyPayload = async (e: ReactMouseEvent) => {
+    e.stopPropagation(); // don't collapse the card on copy click
+    const text = textPayloadFor(ev);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 1200);
+    } catch {
+      setCopyState("error");
+      window.setTimeout(() => setCopyState("idle"), 1500);
+    }
+  };
 
   return (
     <div
@@ -268,9 +286,61 @@ function EventCard({ row }: { row: TranscriptEvent }) {
         {!open && <span className="summary">{summary}</span>}
         {row.ts_ns > 0 && <span className="ts">{formatTime(row.ts_ns)}</span>}
       </div>
-      {open && <div className="ev-detail">{detail}</div>}
+      {open && (
+        <div className="ev-detail">
+          <button
+            type="button"
+            className={`copy-btn copy-state-${copyState}`}
+            onClick={copyPayload}
+            aria-label="Copy event content to clipboard"
+            title={
+              copyState === "copied"
+                ? "copied"
+                : copyState === "error"
+                  ? "copy failed (clipboard blocked)"
+                  : "copy to clipboard"
+            }
+          >
+            {copyState === "copied" ? "✓ copied" : copyState === "error" ? "✗" : "⧉ copy"}
+          </button>
+          {detail}
+        </div>
+      )}
     </div>
   );
+}
+
+// textPayloadFor produces the plain-text representation copied to
+// the clipboard when the operator hits the copy button on an
+// expanded EventCard. Each branch mirrors detailFor's React render
+// but in flat text — keeps tool input/result/usage/etc. captured
+// without leaking React's escape-sequence artifacts.
+function textPayloadFor(ev: EventPayload): string {
+  switch (ev.type) {
+    case "text":
+    case "thinking":
+      return ev.text ?? "";
+    case "tool_call": {
+      const t = ev.tool_use;
+      const head = `tool: ${t?.name ?? "?"}${t?.id ? `  id: ${t.id}` : ""}`;
+      const input = `input:\n${prettyJSON(t?.input)}`;
+      return `${head}\n${input}`;
+    }
+    case "tool_result":
+      return ev.text ?? "";
+    case "error":
+      return ev.error ?? "";
+    case "retry":
+      return JSON.stringify(ev.retry ?? {}, null, 2);
+    case "done": {
+      const lines = [`stop_reason: ${ev.stop_reason ?? "?"}`];
+      if (ev.reasoning) lines.push("", "reasoning:", ev.reasoning);
+      if (ev.usage) lines.push("", "usage:", JSON.stringify(ev.usage, null, 2));
+      return lines.join("\n");
+    }
+    default:
+      return JSON.stringify(ev, null, 2);
+  }
 }
 
 // labelFor is the small uppercase tag on the left side of each card.

--- a/web/src/components/AgentsTree.tsx
+++ b/web/src/components/AgentsTree.tsx
@@ -152,7 +152,7 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
   const expanded = expandedMap.get(a.agent_id) !== false;
   const isSelected = selectedId === a.agent_id;
   return (
-    <li className={`node depth-${depth} status-${a.status} ${isSelected ? "selected" : ""}`}>
+    <li className={`node depth-${depth} status-${a.status} ${awaitClass(a.awaited_state, a.status)} ${isSelected ? "selected" : ""}`}>
       <div className="row">
         <button
           type="button"
@@ -206,4 +206,17 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
       )}
     </li>
   );
+}
+
+// awaitClass maps a row to one of three tint classes. The server
+// only emits awaited_state for the channel / interrupted cases;
+// every other running row falls through to await-running (so the
+// whole running-status set is visually distinguishable in the
+// tree). Terminal rows (completed / failed / cancelled) return no
+// extra class — they keep the existing status-* styling.
+function awaitClass(state: Agent["awaited_state"] | undefined, status: Agent["status"]): string {
+  if (state === "channel") return "await-channel";
+  if (state === "interrupted") return "await-interrupted";
+  if (status === "running") return "await-running";
+  return "";
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -84,6 +84,7 @@ export default function Layout() {
           <NavLink to="/interrupts">interrupts</NavLink>
           <NavLink to="/memory">memory</NavLink>
           <NavLink to="/snapshots">snapshots</NavLink>
+          <NavLink to="/audit">audit</NavLink>
         </nav>
         <PauseControls />
         <div className="user-picker">

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { Link, Outlet, useOutletContext } from "react-router-dom";
-import { UserSummary, listUsers } from "../api";
+import { Link, NavLink, Outlet, useOutletContext } from "react-router-dom";
+import { UserSummary, getHealth, listUsers } from "../api";
 import PauseControls from "./PauseControls";
 
 const USER_ID_KEY = "loomcycle.userId";
@@ -19,10 +19,31 @@ export default function Layout() {
   const [usersErr, setUsersErr] = useState<string | null>(null);
   const [showManual, setShowManual] = useState(false);
   const [draft, setDraft] = useState(userId);
+  // Fetched from /healthz once on mount. Falls back to the static
+  // shipped version on failure (offline server or pre-v0.8.21 binary
+  // that only returns {"ok":true}). Undefined while in-flight.
+  const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {
     localStorage.setItem(USER_ID_KEY, userId);
   }, [userId]);
+
+  // Fetch the running binary's version once on mount. Not polled —
+  // the version doesn't change without a process restart, at which
+  // point the UI bundle is likely reloaded too.
+  useEffect(() => {
+    let cancelled = false;
+    getHealth()
+      .then((h) => {
+        if (!cancelled) setVersion(h.version || "unknown");
+      })
+      .catch(() => {
+        if (!cancelled) setVersion("offline");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Poll /v1/_users so the dropdown reflects who has active runs in
   // near-real-time. Server response is bounded (LIMIT 200) and fast.
@@ -54,13 +75,15 @@ export default function Layout() {
       <header className="topbar">
         <div className="brand">
           <Link to="/">loomcycle</Link>
-          <span className="version">v0.8.17</span>
+          <span className="version">
+            {version === null ? "…" : version}
+          </span>
         </div>
         <nav className="nav-tabs">
-          <Link to="/">runs</Link>
-          <Link to="/interrupts">interrupts</Link>
-          <Link to="/memory">memory</Link>
-          <Link to="/snapshots">snapshots</Link>
+          <NavLink to="/" end>runs</NavLink>
+          <NavLink to="/interrupts">interrupts</NavLink>
+          <NavLink to="/memory">memory</NavLink>
+          <NavLink to="/snapshots">snapshots</NavLink>
         </nav>
         <PauseControls />
         <div className="user-picker">

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -80,7 +80,7 @@ export default function Layout() {
           </span>
         </div>
         <nav className="nav-tabs">
-          <NavLink to="/" end>runs</NavLink>
+          <NavLink to="/agents">runs</NavLink>
           <NavLink to="/interrupts">interrupts</NavLink>
           <NavLink to="/memory">memory</NavLink>
           <NavLink to="/snapshots">snapshots</NavLink>

--- a/web/src/components/Splitter.tsx
+++ b/web/src/components/Splitter.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+// Splitter wraps two children with a draggable vertical handle
+// between them. The left pane's width is owned in state and (when
+// `storageKey` is set) persisted to localStorage so the operator's
+// layout choice survives reloads.
+//
+// Implementation notes:
+//   - CSS Grid with three columns: [left] [handle] [right]. Grid
+//     keeps the right pane on a fluid `1fr` regardless of the
+//     window width, while the left pane snaps to the dragged size.
+//   - Drag uses window-level pointermove + pointerup so the user
+//     can drag PAST the handle bounds without losing tracking
+//     (common UX pitfall when the listener lives on the handle
+//     element). The container ref provides the origin for the
+//     fractional clientX calculation.
+//   - min/max clamps so the user can't drag a pane into oblivion
+//     or off-screen.
+
+export interface SplitterProps {
+  children: [ReactNode, ReactNode];
+  // Initial left-pane width in px. Used until the user drags or a
+  // persisted value is restored from localStorage.
+  defaultLeftWidth?: number;
+  // Lower bound for the left pane in px. Pane content has its own
+  // overflow:auto so it survives squeezing, but a too-narrow pane
+  // is unusable.
+  minLeftWidth?: number;
+  // Upper bound for the left pane in px. Prevents the operator from
+  // dragging the right pane to zero by accident.
+  minRightWidth?: number;
+  // localStorage key for persistence. Omit to make the split
+  // ephemeral (resets on every page mount).
+  storageKey?: string;
+  // Extra class on the outer wrapper (the parent .agents-view /
+  // .memory-view rules expect a specific class; this lets the
+  // caller keep those selectors intact).
+  className?: string;
+}
+
+const HANDLE_WIDTH = 6;
+
+export default function Splitter({
+  children,
+  defaultLeftWidth = 380,
+  minLeftWidth = 180,
+  minRightWidth = 240,
+  storageKey,
+  className,
+}: SplitterProps) {
+  const [leftWidth, setLeftWidth] = useState<number>(() => {
+    if (storageKey) {
+      const stored = localStorage.getItem(storageKey);
+      const n = stored ? parseInt(stored, 10) : NaN;
+      if (Number.isFinite(n) && n >= minLeftWidth) return n;
+    }
+    return defaultLeftWidth;
+  });
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  // Persist on every settled width. Debouncing isn't needed — drag
+  // already produces a single final settle via pointerup.
+  useEffect(() => {
+    if (!storageKey || dragging) return;
+    localStorage.setItem(storageKey, String(Math.round(leftWidth)));
+  }, [storageKey, leftWidth, dragging]);
+
+  const onPointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    setDragging(true);
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!dragging || !containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const raw = e.clientX - rect.left;
+      const maxAllowed = rect.width - minRightWidth - HANDLE_WIDTH;
+      const clamped = Math.max(minLeftWidth, Math.min(raw, maxAllowed));
+      setLeftWidth(clamped);
+    },
+    [dragging, minLeftWidth, minRightWidth],
+  );
+
+  const onPointerUp = useCallback((e: React.PointerEvent) => {
+    setDragging(false);
+    try {
+      (e.target as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {
+      // Pointer was already released (e.g. capture lost from a
+      // browser-internal gesture). Safe to ignore.
+    }
+  }, []);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`splitter ${className ?? ""} ${dragging ? "dragging" : ""}`}
+      style={{
+        gridTemplateColumns: `${leftWidth}px ${HANDLE_WIDTH}px 1fr`,
+      }}
+    >
+      <div className="splitter-pane splitter-left">{children[0]}</div>
+      <div
+        className="splitter-handle"
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuenow={Math.round(leftWidth)}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+      />
+      <div className="splitter-pane splitter-right">{children[1]}</div>
+    </div>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -6,6 +6,7 @@ import AgentsView from "./pages/AgentsView";
 import MemoryView from "./pages/MemoryView";
 import InterruptInbox from "./pages/InterruptInbox";
 import SnapshotsView from "./pages/SnapshotsView";
+import AuditView from "./pages/AuditView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
 
@@ -27,6 +28,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="memory" element={<MemoryView />} />
           <Route path="interrupts" element={<InterruptInbox />} />
           <Route path="snapshots" element={<SnapshotsView />} />
+          <Route path="audit" element={<AuditView />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />
         </Route>
       </Routes>

--- a/web/src/pages/AgentsView.tsx
+++ b/web/src/pages/AgentsView.tsx
@@ -6,6 +6,7 @@ import AgentsTreePanel, { type StatusFilter } from "../components/AgentsTreePane
 import AgentDetailPane from "../components/AgentDetailPane";
 import type { BreadcrumbAncestor } from "../components/Breadcrumbs";
 import { buildTree } from "../components/AgentsTree";
+import Splitter from "../components/Splitter";
 
 // AgentsView is the v0.8.20 split-view replacement for the
 // sequential RunList → AgentDetail navigation. Two side-by-side
@@ -121,7 +122,13 @@ export default function AgentsView() {
   }
 
   return (
-    <div className="agents-view">
+    <Splitter
+      className="agents-view"
+      defaultLeftWidth={420}
+      minLeftWidth={260}
+      minRightWidth={320}
+      storageKey="loomcycle.split.agents"
+    >
       <div className="left">
         <AgentsTreePanel
           agents={agents}
@@ -148,6 +155,6 @@ export default function AgentsView() {
           </div>
         )}
       </div>
-    </div>
+    </Splitter>
   );
 }

--- a/web/src/pages/AuditView.tsx
+++ b/web/src/pages/AuditView.tsx
@@ -1,0 +1,296 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AuditEvent, ListEventsResponse, listEvents } from "../api";
+
+// AuditView — v0.8.21 cross-session event log.
+//
+// Why a separate view (not "the transcript page, but bigger"): the
+// per-session transcript answers "what did THIS run do?". Audit
+// answers "across every run, what tool calls happened in the last
+// hour?" or "show me every `error` event yesterday." Different
+// query shape; different UI primitives (filter toolbar, pagination,
+// no agent-tree hierarchy).
+//
+// Pagination is offset-based (server clamps limit to 500) — fine for
+// the audit-view scale we have today. Cursor-based pagination is a
+// future migration if event tables grow into millions.
+
+const PAGE_SIZE = 50;
+
+// Well-known event types loomcycle emits. The dropdown lists these
+// for discoverability; the user can also type a free-form value (the
+// server filters on exact string match).
+const COMMON_TYPES = [
+  "text",
+  "thinking",
+  "tool_call",
+  "tool_result",
+  "usage",
+  "done",
+  "error",
+  "started",
+  "retry",
+  "cache_invalidated",
+  "reasoning_invalidated",
+  "fallback_suppressed",
+  "interrupt_raised",
+  "interrupt_resolved",
+];
+
+// toRFC3339 converts an <input type="datetime-local"> value (which is
+// "YYYY-MM-DDTHH:MM" in local time) to the RFC3339 the server expects.
+// Empty in → empty out (the caller skips the param entirely).
+function toRFC3339(local: string): string {
+  if (!local) return "";
+  const d = new Date(local);
+  if (isNaN(d.getTime())) return "";
+  return d.toISOString();
+}
+
+export default function AuditView() {
+  const [filterType, setFilterType] = useState<string>("");
+  const [from, setFrom] = useState<string>("");
+  const [to, setTo] = useState<string>("");
+  const [offset, setOffset] = useState<number>(0);
+  const [resp, setResp] = useState<ListEventsResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<number>>(new Set());
+
+  const params = useMemo(
+    () => ({
+      type: filterType || undefined,
+      from: toRFC3339(from) || undefined,
+      to: toRFC3339(to) || undefined,
+      limit: PAGE_SIZE,
+      offset,
+    }),
+    [filterType, from, to, offset],
+  );
+
+  const fetchPage = useCallback(async () => {
+    setLoading(true);
+    try {
+      const r = await listEvents(params);
+      setResp(r);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [params]);
+
+  useEffect(() => {
+    fetchPage();
+  }, [fetchPage]);
+
+  // Reset offset to 0 whenever a filter dimension changes — paging
+  // into "page 4 of the old result set" makes no sense once the set
+  // itself moves.
+  useEffect(() => {
+    setOffset(0);
+  }, [filterType, from, to]);
+
+  const total = resp?.total ?? 0;
+  const events = resp?.events ?? [];
+  const page = Math.floor(offset / PAGE_SIZE) + 1;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="audit-view">
+      <div className="audit-toolbar">
+        <div className="audit-toolbar-row">
+          <label>
+            type
+            <input
+              list="audit-event-types"
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              placeholder="(any)"
+            />
+            <datalist id="audit-event-types">
+              {COMMON_TYPES.map((t) => (
+                <option key={t} value={t} />
+              ))}
+            </datalist>
+          </label>
+          <label>
+            from
+            <input
+              type="datetime-local"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+            />
+          </label>
+          <label>
+            to
+            <input
+              type="datetime-local"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => {
+              setFilterType("");
+              setFrom("");
+              setTo("");
+            }}
+            className="audit-clear"
+            disabled={!filterType && !from && !to}
+          >
+            clear
+          </button>
+          <button type="button" onClick={fetchPage} className="audit-refresh">
+            ↻ refresh
+          </button>
+        </div>
+        <div className="audit-status">
+          {loading ? (
+            <span className="spin">loading…</span>
+          ) : (
+            <span>
+              {total.toLocaleString()} event{total === 1 ? "" : "s"} · page {page} of {totalPages}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {err && <div className="err">{err}</div>}
+
+      <div className="audit-table">
+        <div className="audit-row audit-head">
+          <div>time</div>
+          <div>type</div>
+          <div>session / run</div>
+          <div>payload</div>
+        </div>
+        {events.length === 0 && !loading && (
+          <div className="empty">no events match the current filter.</div>
+        )}
+        {events.map((ev) => (
+          <AuditRow
+            key={ev.seq}
+            ev={ev}
+            expanded={expanded.has(ev.seq)}
+            onToggle={() =>
+              setExpanded((prev) => {
+                const next = new Set(prev);
+                if (next.has(ev.seq)) next.delete(ev.seq);
+                else next.add(ev.seq);
+                return next;
+              })
+            }
+          />
+        ))}
+      </div>
+
+      <div className="audit-pager">
+        <button
+          type="button"
+          disabled={offset === 0}
+          onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+        >
+          ← prev
+        </button>
+        <span>
+          page {page} of {totalPages}
+        </span>
+        <button
+          type="button"
+          disabled={offset + PAGE_SIZE >= total}
+          onClick={() => setOffset(offset + PAGE_SIZE)}
+        >
+          next →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function AuditRow({
+  ev,
+  expanded,
+  onToggle,
+}: {
+  ev: AuditEvent;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const preview = useMemo(() => {
+    try {
+      const s = JSON.stringify(ev.payload);
+      return s.length > 120 ? s.slice(0, 120) + "…" : s;
+    } catch {
+      return "(unprintable)";
+    }
+  }, [ev.payload]);
+
+  const pretty = useMemo(() => {
+    try {
+      return JSON.stringify(ev.payload, null, 2);
+    } catch {
+      return String(ev.payload);
+    }
+  }, [ev.payload]);
+
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+  const copy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(pretty);
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 1200);
+    } catch {
+      setCopyState("error");
+      setTimeout(() => setCopyState("idle"), 1500);
+    }
+  };
+
+  return (
+    <>
+      <div className={`audit-row ${expanded ? "expanded" : ""}`} onClick={onToggle}>
+        <div title={ev.timestamp}>{new Date(ev.timestamp).toLocaleString()}</div>
+        <div>
+          <span className={`audit-type type-${ev.type}`}>{ev.type}</span>
+        </div>
+        <div className="audit-ids">
+          <span title={ev.session_id}>{ev.session_id.slice(0, 12)}…</span>
+          <span className="muted"> / </span>
+          <span title={ev.run_id}>{ev.run_id.slice(0, 12)}…</span>
+        </div>
+        <div className="audit-preview">{preview}</div>
+      </div>
+      {expanded && (
+        <div className="audit-detail">
+          <button
+            type="button"
+            className={`copy-btn ${
+              copyState === "copied"
+                ? "copy-state-copied"
+                : copyState === "error"
+                ? "copy-state-error"
+                : ""
+            }`}
+            onClick={copy}
+          >
+            {copyState === "copied" ? "✓ copied" : copyState === "error" ? "✗" : "⧉ copy"}
+          </button>
+          <div className="audit-detail-meta">
+            <span>
+              <strong>seq</strong> {ev.seq}
+            </span>
+            <span>
+              <strong>session_id</strong> {ev.session_id}
+            </span>
+            <span>
+              <strong>run_id</strong> {ev.run_id}
+            </span>
+          </div>
+          <pre className="audit-detail-payload">{pretty}</pre>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/pages/AuditView.tsx
+++ b/web/src/pages/AuditView.tsx
@@ -18,7 +18,14 @@ const PAGE_SIZE = 50;
 
 // Well-known event types loomcycle emits. The dropdown lists these
 // for discoverability; the user can also type a free-form value (the
-// server filters on exact string match).
+// server filters on exact string match). Kept in sync with
+// internal/providers/provider.go EventType constants.
+//
+// Note on "hook calls": hooks are dispatched synchronously by the
+// loop and do not emit a dedicated `hook_*` event type. Their
+// audit footprint is the side-effects they produce — most notably
+// `host_widened` when a Pre-hook grants `allow_hosts`. Filter on
+// `host_widened` to see all hook-driven URL widenings.
 const COMMON_TYPES = [
   "text",
   "thinking",
@@ -29,11 +36,14 @@ const COMMON_TYPES = [
   "error",
   "started",
   "retry",
+  "provider_fallback",
+  "fallback_suppressed",
   "cache_invalidated",
   "reasoning_invalidated",
-  "fallback_suppressed",
-  "interrupt_raised",
-  "interrupt_resolved",
+  "host_widened",
+  "channel_publish",
+  "channel_delivery",
+  "interruption_pending",
 ];
 
 // toRFC3339 converts an <input type="datetime-local"> value (which is

--- a/web/src/pages/MemoryView.tsx
+++ b/web/src/pages/MemoryView.tsx
@@ -7,6 +7,7 @@ import {
   listMemoryScopeIDs,
   listMemoryScopes,
 } from "../api";
+import Splitter from "../components/Splitter";
 
 // MemoryView — operator browse-only view over the v0.8.0 Memory tool's
 // stored rows.
@@ -125,7 +126,15 @@ export default function MemoryView() {
   }, [entries, selectedKey]);
 
   return (
-    <div className="memory-view">
+    <div className="memory-view-wrapper">
+    {err && <div className="err memory-err">{err}</div>}
+    <Splitter
+      className="memory-view"
+      defaultLeftWidth={280}
+      minLeftWidth={200}
+      minRightWidth={460}
+      storageKey="loomcycle.split.memory.outer"
+    >
       <div className="memory-pane scopes-pane">
         <div className="pane-header">scopes</div>
         <div className="scope-tabs">
@@ -162,6 +171,13 @@ export default function MemoryView() {
           ))}
         </ul>
       </div>
+      <Splitter
+        className="memory-view-inner"
+        defaultLeftWidth={320}
+        minLeftWidth={220}
+        minRightWidth={320}
+        storageKey="loomcycle.split.memory.inner"
+      >
       <div className="memory-pane keys-pane">
         <div className="pane-header">
           keys {scopeID && <code>{scope}/{scopeID}</code>}
@@ -210,7 +226,8 @@ export default function MemoryView() {
           </div>
         )}
       </div>
-      {err && <div className="err memory-err">{err}</div>}
+      </Splitter>
+    </Splitter>
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1249,3 +1249,180 @@ pre {
 .snapshots-table .muted {
   color: var(--fg-soft);
 }
+
+/* v0.8.21 Audit view — cross-session paginated event log. */
+.audit-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+}
+.audit-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.audit-toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+.audit-toolbar label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--fg-soft);
+  font-size: 12px;
+}
+.audit-toolbar input {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 4px 8px;
+  border-radius: 3px;
+  font-family: var(--mono);
+  font-size: 12px;
+  min-width: 140px;
+}
+.audit-toolbar button {
+  background: var(--bg-soft-2);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+}
+.audit-toolbar button:hover:not(:disabled) {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.audit-toolbar button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.audit-status {
+  color: var(--fg-soft);
+  font-size: 12px;
+}
+
+.audit-table {
+  flex: 1;
+  overflow: auto;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  min-height: 0;
+}
+.audit-row {
+  display: grid;
+  grid-template-columns: 180px 160px 220px 1fr;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  font-family: var(--mono);
+  cursor: pointer;
+  align-items: center;
+}
+.audit-row:hover {
+  background: var(--bg-soft-2);
+}
+.audit-row.expanded {
+  background: var(--bg-soft-2);
+  border-bottom: none;
+}
+.audit-row.audit-head {
+  background: var(--bg);
+  color: var(--fg-soft);
+  font-weight: 600;
+  cursor: default;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+.audit-row.audit-head:hover {
+  background: var(--bg);
+}
+.audit-type {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+}
+.audit-ids .muted {
+  color: var(--fg-soft);
+}
+.audit-preview {
+  color: var(--fg-soft);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.audit-detail {
+  position: relative;
+  padding: 10px 14px 14px 14px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.audit-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: var(--fg-soft);
+  margin-bottom: 8px;
+}
+.audit-detail-meta strong {
+  color: var(--fg);
+  margin-right: 4px;
+}
+.audit-detail-payload {
+  margin: 0;
+  padding: 10px 12px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  max-height: 400px;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--fg);
+}
+
+.audit-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 8px;
+  color: var(--fg-soft);
+  font-size: 12px;
+}
+.audit-pager button {
+  background: var(--bg-soft);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  padding: 4px 12px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+.audit-pager button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.audit-pager button:hover:not(:disabled) {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -569,6 +569,39 @@ pre {
 .ev-detail {
   padding: 6px 12px 10px 36px;
   border-top: 1px dashed var(--border);
+  position: relative;
+}
+/* Copy-to-clipboard button anchored top-right in every expanded
+ * EventCard. The card's onClick toggles open/closed, so the button
+ * uses e.stopPropagation() (in the React handler) to suppress that.
+ * State flips between idle / copied / error briefly. */
+.copy-btn {
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  background: var(--bg-soft);
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 3px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 80ms ease, border-color 80ms ease, background 80ms ease;
+  z-index: 1;
+}
+.copy-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: var(--bg);
+}
+.copy-btn.copy-state-copied {
+  color: var(--completed);
+  border-color: var(--completed);
+}
+.copy-btn.copy-state-error {
+  color: var(--failed);
+  border-color: var(--failed);
 }
 .ev-detail .full-text {
   margin: 4px 0;
@@ -614,21 +647,37 @@ pre {
 .ev-done { border-left-color: var(--fg-soft); }
 
 /* v0.8.0 nav tabs (top bar between brand and user picker). */
+/* Topbar nav rendered as proper tabs. NavLink from react-router-dom
+ * adds .active to the matching link; we use that to draw an
+ * underline indicator on the current tab. */
 .nav-tabs {
   display: flex;
-  gap: 4px;
+  gap: 0;
   margin-left: 24px;
+  align-self: stretch;
+  align-items: flex-end;
 }
 .nav-tabs a {
   color: var(--fg-soft);
-  padding: 4px 10px;
-  border-radius: 4px;
+  padding: 8px 14px 9px;
   font-size: 13px;
+  /* Reserve the underline space on inactive tabs so the layout
+   * doesn't shift when the active tab gains its 2px border. */
+  border-bottom: 2px solid transparent;
+  /* Offset so the underline sits on the topbar's own bottom border,
+   * not above it. */
+  margin-bottom: -1px;
+  transition: color 80ms ease, border-color 80ms ease, background 80ms ease;
 }
 .nav-tabs a:hover {
-  background: var(--bg-soft-2);
   color: var(--fg);
+  background: var(--bg-soft-2);
   text-decoration: none;
+}
+.nav-tabs a.active {
+  color: var(--fg);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
 }
 
 /* v0.8.0 Memory page — three-pane layout. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -271,14 +271,14 @@ pre {
  * available height of the .content area; each has its own
  * internal scroll so headers stay sticky. */
 .agents-view {
-  display: grid;
-  grid-template-columns: 420px 1fr;
-  gap: 12px;
+  /* Layout (grid-template-columns + gap) comes from .splitter. The
+   * old static rules are retained for any non-splitter consumer
+   * that still expects the visual styling. */
   height: 100%;
   min-height: 0;
 }
-.agents-view > .left,
-.agents-view > .right {
+.agents-view .left,
+.agents-view .right {
   background: var(--bg-soft);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -286,6 +286,7 @@ pre {
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+  flex: 1;
 }
 .agents-tree-panel {
   display: flex;
@@ -303,13 +304,13 @@ pre {
   padding: 8px 10px;
   min-height: 0;
 }
-.agents-view > .right > .agent-detail {
+.agents-view .right > .agent-detail {
   flex: 1;
   overflow: auto;
   min-height: 0;
   padding: 0 14px 14px;
 }
-.agents-view > .right > .empty {
+.agents-view .right > .empty {
   flex: 1;
   display: flex;
   align-items: center;
@@ -481,6 +482,12 @@ pre {
   align-items: center;
   gap: 12px;
 }
+.agent-header .line-await {
+  margin-top: 6px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 .agent-header .line2 {
   margin-top: 6px;
   display: flex;
@@ -488,6 +495,43 @@ pre {
   gap: 16px;
   font-size: 12px;
   color: var(--fg-soft);
+}
+
+/* v0.8.21 awaited-state chip — small pill that says what the
+ * running agent is blocked on (a Channel.subscribe long-poll, a
+ * pending Interruption, or none → plain "running"). Colours follow
+ * the operator's mental model: green = healthy/active, orange =
+ * waiting on inter-agent comms, violet = waiting on a human. */
+.await-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-family: var(--mono);
+  line-height: 1.4;
+  border: 1px solid transparent;
+}
+.await-chip code {
+  font-size: 11px;
+  background: transparent;
+  color: inherit;
+}
+.await-chip-running {
+  background: #1a3a26;
+  color: #6ee7a3;
+  border-color: #2a5a3a;
+}
+.await-chip-channel {
+  background: #3a2a14;
+  color: #ffb766;
+  border-color: #5a3a1e;
+}
+.await-chip-interrupted {
+  background: #2a1f3a;
+  color: #c9a8ff;
+  border-color: #46347a;
 }
 .cancel-btn {
   background: var(--failed);
@@ -681,11 +725,27 @@ pre {
 }
 
 /* v0.8.0 Memory page — three-pane layout. */
-.memory-view {
-  display: grid;
-  grid-template-columns: 280px 320px 1fr;
-  gap: 12px;
+.memory-view-wrapper {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
   padding: 12px;
+  gap: 8px;
+}
+.memory-view-wrapper > .err {
+  flex-shrink: 0;
+}
+.memory-view {
+  /* Layout owned by .splitter (display:grid, grid-template-columns
+   * via inline style). The previous static three-column grid is
+   * replaced by an outer + inner Splitter so each gutter is
+   * draggable. Pane styling (.memory-pane) still applies. */
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+}
+.memory-view-inner {
   height: 100%;
   min-height: 0;
 }
@@ -1248,6 +1308,53 @@ pre {
 }
 .snapshots-table .muted {
   color: var(--fg-soft);
+}
+
+/* v0.8.21 Splitter — draggable resizable two-pane container used by
+ * Runs and Memory views. Owner: web/src/components/Splitter.tsx.
+ * Layout is grid (left / handle / right); the inline style sets the
+ * left column width, handle is fixed 6px, right grows. */
+.splitter {
+  display: grid;
+  gap: 0;
+  height: 100%;
+  min-height: 0;
+}
+.splitter.dragging {
+  /* Suppress text-select highlighting during a drag — without this
+   * the user's mouse sweep grabs the pane content as a selection. */
+  user-select: none;
+  cursor: col-resize;
+}
+.splitter > .splitter-pane {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.splitter > .splitter-handle {
+  background: transparent;
+  cursor: col-resize;
+  position: relative;
+  z-index: 1;
+}
+.splitter > .splitter-handle::before {
+  /* Thin centred line that becomes visible on hover/drag — the
+   * 6px handle has 1px of visible vibe and 5px of forgiving hit
+   * area. */
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2px;
+  width: 2px;
+  background: var(--border);
+  transition: background 80ms ease;
+}
+.splitter > .splitter-handle:hover::before,
+.splitter.dragging > .splitter-handle::before {
+  background: var(--accent);
 }
 
 /* v0.8.21 Audit view — cross-session paginated event log. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -497,6 +497,32 @@ pre {
   color: var(--fg-soft);
 }
 
+/* v0.8.21 awaited-state row tint — applied to running rows in the
+ * agents tree so the operator can scan the tree and see at a glance
+ * which agents are progressing vs. blocked. Colours mirror the
+ * detail-pane chip (.await-chip-*) using lower-alpha fills so the
+ * tint never overpowers the row content. The `.row` selector keeps
+ * children rows (.children) un-tinted — only the immediate row
+ * paints, since children inherit their own state via their own
+ * tint class. */
+.node.await-running > .row {
+  background-color: rgba(110, 231, 163, 0.08);
+  border-left: 3px solid #2a5a3a;
+}
+.node.await-channel > .row {
+  background-color: rgba(255, 183, 102, 0.12);
+  border-left: 3px solid #b97a30;
+}
+.node.await-interrupted > .row {
+  background-color: rgba(201, 168, 255, 0.13);
+  border-left: 3px solid #6b50b8;
+}
+/* Selected outranks the tint border so the operator can still tell
+ * which row is currently open in the detail pane. */
+.node.selected > .row {
+  border-left-color: var(--accent);
+}
+
 /* v0.8.21 awaited-state chip — small pill that says what the
  * running agent is blocked on (a Channel.subscribe long-poll, a
  * pending Interruption, or none → plain "running"). Colours follow


### PR DESCRIPTION
## Summary

Four Web-UI polish items, one PR:

1. **Dynamic version** — topbar now reads from `/healthz` (which now returns `{version, commit, built, uptime_seconds}`) instead of a hard-coded `v0.8.17`.
2. **Proper tabs** — `runs / interrupts / memory / snapshots / audit` use `NavLink` with an active underline indicator instead of plain links.
3. **Copy button on EventCards** — every expanded event panel gets a `⧉ copy` button (clipboard access was previously impossible without manually scraping the DOM).
4. **Audit view** — new `/ui/audit` page: cross-session paginated event log with type + date-range filter, served by new `GET /v1/_events?type=…&from=…&to=…&limit=…&offset=…`.

## What changed

### Build-info plumbing
- `Server.SetBuildInfo(version, commit, built)` + `startedAt time.Time` on the `Server` struct.
- `handleHealthz` extended to emit JSON when build info is set; falls back to plain `ok` when called without (test harness compatibility).

### New storage interface
- `store.Store.ListEvents(ctx, EventFilter{Type, From, To}, limit, offset)` returns `(events, total, err)`. Implemented in both SQLite + Postgres adapters with `ORDER BY ts DESC, seq DESC` so identical-timestamp appends still order deterministically.
- Two contract tests cover filter semantics and pagination/total invariants.

### Indexes (migration 0014)
- `events_by_ts (ts DESC)` and `events_by_type_ts (type, ts DESC)`. Both bounded — `events_by_session` (the pre-existing index) still serves single-session reads.

### HTTP
- `GET /v1/_events` — bearer-authed admin endpoint with the same posture as `/v1/_users`, `/v1/_metrics/*`, etc.

### Web UI
- New `AuditView.tsx` with filter toolbar (combobox-style type input seeded with known event names + free-form override; from/to `datetime-local`), paginated table (50/page), per-row expand-with-payload + copy button.
- Topbar version label fetched once on mount; falls back to `offline` if `/healthz` is unreachable.
- `.nav-tabs a.active` underline indicator via `NavLink`.

## Test plan

- [x] `go test ./...` — clean (SQLite contract tests for ListEvents pass; Postgres covered by shared contract suite)
- [x] `cd web && npm run build` — clean (tsc + vite)
- [x] `go build -o bin/loomcycle ./cmd/loomcycle` — clean
- [ ] Manual: `/healthz` returns `{version, commit, built, uptime_seconds}` on the live binary
- [ ] Manual: topbar shows the actual version string
- [ ] Manual: nav tabs render an underline on the active route
- [ ] Manual: expand an event in `/ui/agents`, click `⧉ copy`, paste into a text editor — payload arrives
- [ ] Manual: `/ui/audit` lists events; filter by `type=tool_call` works; from/to pickers narrow correctly; pagination prev/next works

🤖 Generated with [Claude Code](https://claude.com/claude-code)