### PR TITLE
feat(web): Activity Monitor tab with live charts

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1135,14 +1135,23 @@ func recoveryMiddleware(next http.Handler) http.Handler {
 
 // healthzResponse mirrors the gRPC HealthResponse shape so adapters
 // switching between the two transports decode the same JSON keys.
+//
 // uptime_seconds is computed at request time (not cached) so a long-
 // running process surfaces its real uptime, not the moment New() ran.
+//
+// v0.8.21 also adds `metrics_enabled` so the Web UI's Activity
+// Monitor can render its "metrics are off, set
+// LOOMCYCLE_METRICS_ENABLED=1" empty state without first probing
+// /v1/_metrics and getting a 503. metricsSampler is constructed in
+// main.go only when cfg.Env.MetricsEnabled is true, so its nil-ness
+// is the single source of truth — no separate field on Server.
 type healthzResponse struct {
-	OK            bool   `json:"ok"`
-	Version       string `json:"version,omitempty"`
-	Commit        string `json:"commit,omitempty"`
-	Built         string `json:"built,omitempty"`
-	UptimeSeconds int64  `json:"uptime_seconds,omitempty"`
+	OK             bool   `json:"ok"`
+	Version        string `json:"version,omitempty"`
+	Commit         string `json:"commit,omitempty"`
+	Built          string `json:"built,omitempty"`
+	UptimeSeconds  int64  `json:"uptime_seconds,omitempty"`
+	MetricsEnabled bool   `json:"metrics_enabled"`
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -1155,11 +1164,12 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 		uptime = int64(time.Since(s.startedAt).Seconds())
 	}
 	resp := healthzResponse{
-		OK:            true,
-		Version:       s.buildVersion,
-		Commit:        s.buildCommit,
-		Built:         s.buildTime,
-		UptimeSeconds: uptime,
+		OK:             true,
+		Version:        s.buildVersion,
+		Commit:         s.buildCommit,
+		Built:          s.buildTime,
+		UptimeSeconds:  uptime,
+		MetricsEnabled: s.metricsSampler != nil,
 	}
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -198,6 +198,24 @@ func TestHealthz(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("status = %d", resp.StatusCode)
 	}
+	// v0.8.21: response is JSON {ok, metrics_enabled}. metrics
+	// sampler isn't wired in this test, so metrics_enabled must
+	// be false — the Activity Monitor UI keys off this flag to
+	// render its "metrics off" empty state immediately, without
+	// probing /v1/_metrics and getting 503.
+	var body struct {
+		OK             bool `json:"ok"`
+		MetricsEnabled bool `json:"metrics_enabled"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Errorf("ok = %v, want true", body.OK)
+	}
+	if body.MetricsEnabled {
+		t.Errorf("metrics_enabled = %v, want false (sampler not wired in test)", body.MetricsEnabled)
+	}
 }
 
 func TestAuthRequired(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -232,6 +232,7 @@ const (
 // filter on this dimension":
 //   - Type == ""  → all event types
 //   - From / To zero-value time.Time → unbounded on that side
+//
 // Use From + To together for a window; either alone is supported.
 type EventFilter struct {
 	Type string

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -146,6 +146,44 @@ async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return resp.json() as Promise<T>;
 }
 
+// jsonFetchAllowing is a sibling of jsonFetch that does NOT throw on
+// the status codes in `allow` — instead it returns a discriminated
+// {ok:false, status, body} so the caller can branch. Used by the
+// metrics helpers: the /v1/_metrics/* endpoints return 503 when the
+// server-side sampler is off (LOOMCYCLE_METRICS_ENABLED unset), and
+// the Activity Monitor wants to render an instructional empty
+// state instead of surfacing the 503 as a thrown error.
+async function jsonFetchAllowing<T>(
+  path: string,
+  allow: number[],
+  init?: RequestInit,
+): Promise<{ ok: true; data: T } | { ok: false; status: number; body: any }> {
+  const resp = await fetch(baseURL + path, {
+    credentials: "same-origin",
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(init?.headers ?? {}),
+    },
+  });
+  if (resp.ok) {
+    return { ok: true, data: (await resp.json()) as T };
+  }
+  if (allow.includes(resp.status)) {
+    // Best-effort JSON decode; the server's 503 carries an
+    // enable_hint string in the body for the metrics path.
+    let body: any = null;
+    try {
+      body = await resp.json();
+    } catch {
+      // non-JSON body — leave as null
+    }
+    return { ok: false, status: resp.status, body };
+  }
+  const text = await resp.text();
+  throw new Error(`${resp.status} ${resp.statusText}: ${text.slice(0, 200)}`);
+}
+
 export function listAgents(userId: string, status?: string): Promise<ListAgentsResponse> {
   const q = status ? `?status=${encodeURIComponent(status)}` : "";
   return jsonFetch<ListAgentsResponse>(`/v1/users/${encodeURIComponent(userId)}/agents${q}`);
@@ -489,4 +527,102 @@ export async function resolveInterrupt(
     throw new Error(`${resp.status} ${resp.statusText}: ${body.slice(0, 200)}`);
   }
   return resp.json();
+}
+
+// --- v0.8.21 Process-resource metrics ---
+//
+// ProcessSample mirrors the server's ProcessSample row. Optional
+// system_* fields are populated only when LOOMCYCLE_METRICS_COLLECT_SYSTEM=1
+// — null/undefined on installs where the operator didn't opt in.
+// The UI detects system-availability by inspecting the first
+// non-null row.
+export interface ProcessSample {
+  sampled_at: string;
+  active_runs: number;
+  queued_runs: number;
+  loomcycle_rss_bytes: number;
+  loomcycle_heap_alloc_bytes: number;
+  loomcycle_heap_inuse_bytes: number;
+  loomcycle_num_goroutines: number;
+  loomcycle_cpu_pct_x100: number;
+  system_cpu_pct_x100?: number | null;
+  system_mem_used_mb?: number | null;
+  system_mem_available_mb?: number | null;
+}
+
+export interface SamplesResponse {
+  samples: ProcessSample[];
+  next_cursor?: string;
+}
+
+export interface SummaryBucket {
+  at: string;
+  mean_rss_bytes: number;
+  max_rss_bytes: number;
+  p95_cpu_pct_x100: number;
+  active_runs_max: number;
+  sample_count: number;
+}
+
+export interface SummaryResponse {
+  period: "1h" | "24h" | "7d";
+  buckets: SummaryBucket[];
+}
+
+// MetricsResult is the typed-disabled discriminated union returned
+// by the metrics helpers. The page's render branch reads this:
+//   if (r.disabled) → show MetricsDisabledEmpty with enableHint
+//   else            → render charts from r.data
+//
+// We deliberately don't throw on 503 — the disabled state is a
+// LEGITIMATE runtime mode, not an error.
+export type MetricsResult<T> =
+  | { disabled: false; data: T }
+  | { disabled: true; enableHint: string };
+
+const DEFAULT_METRICS_DISABLED_HINT =
+  "set LOOMCYCLE_METRICS_ENABLED=1 and restart loomcycle";
+
+function asMetricsResult<T>(
+  r: { ok: true; data: T } | { ok: false; status: number; body: any },
+): MetricsResult<T> {
+  if (r.ok) return { disabled: false, data: r.data };
+  const hint =
+    (r.body && typeof r.body.enable_hint === "string"
+      ? r.body.enable_hint
+      : null) ?? DEFAULT_METRICS_DISABLED_HINT;
+  return { disabled: true, enableHint: hint };
+}
+
+export interface MetricsSamplesParams {
+  since?: string;
+  until?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export async function getMetricsSamples(
+  params: MetricsSamplesParams = {},
+): Promise<MetricsResult<SamplesResponse>> {
+  const q = new URLSearchParams();
+  if (params.since) q.set("since", params.since);
+  if (params.until) q.set("until", params.until);
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  if (params.cursor) q.set("cursor", params.cursor);
+  const qs = q.toString();
+  const r = await jsonFetchAllowing<SamplesResponse>(
+    `/v1/_metrics/samples${qs ? "?" + qs : ""}`,
+    [503],
+  );
+  return asMetricsResult(r);
+}
+
+export async function getMetricsSummary(
+  period: "1h" | "24h" | "7d",
+): Promise<MetricsResult<SummaryResponse>> {
+  const r = await jsonFetchAllowing<SummaryResponse>(
+    `/v1/_metrics/summary?period=${encodeURIComponent(period)}`,
+    [503],
+  );
+  return asMetricsResult(r);
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -18,18 +18,20 @@ export function listUsers(): Promise<ListUsersResponse> {
   return jsonFetch<ListUsersResponse>("/v1/_users");
 }
 
-// HealthResponse mirrors handleHealthz on the server. Extended in
-// v0.8.21 to surface buildVersion / buildCommit / buildTime so the
-// Web UI can render the real running version instead of a hard-coded
-// string. Older binaries (<= v0.8.20) return just {"ok":true} —
-// the version field is missing on those responses; callers must
-// tolerate undefined.
+// HealthResponse mirrors handleHealthz on the server. v0.8.21 added
+// build identifiers (version/commit/built/uptime_seconds) so the UI
+// topbar can show the real running version, plus metrics_enabled so
+// the Activity Monitor can render its "metrics off" empty state on
+// mount without probing /v1/_metrics and getting 503. Pre-v0.8.21
+// servers return just {"ok":true}; the new fields are undefined on
+// those responses, which the UI treats accordingly.
 export interface HealthResponse {
   ok: boolean;
   version?: string;
   commit?: string;
   built?: string;
   uptime_seconds?: number;
+  metrics_enabled?: boolean;
 }
 
 export function getHealth(): Promise<HealthResponse> {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -85,6 +85,7 @@ export default function Layout() {
           <NavLink to="/memory">memory</NavLink>
           <NavLink to="/snapshots">snapshots</NavLink>
           <NavLink to="/audit">audit</NavLink>
+          <NavLink to="/activity">activity</NavLink>
         </nav>
         <PauseControls />
         <div className="user-picker">

--- a/web/src/components/activity/ActivityToolbar.tsx
+++ b/web/src/components/activity/ActivityToolbar.tsx
@@ -1,0 +1,96 @@
+// ActivityToolbar — top-of-page controls for the Activity Monitor.
+// Owns no state of its own; the page passes current values + setters.
+// Layout is one wrapped flex row so the toolbar collapses cleanly
+// on narrow viewports.
+
+export type ActivityMode = "live" | "1h" | "24h" | "7d";
+
+export interface ActivityToolbarProps {
+  mode: ActivityMode;
+  onModeChange: (m: ActivityMode) => void;
+  autoRefresh: boolean;
+  onAutoRefreshChange: (v: boolean) => void;
+  // Whether the system overlay toggle is available (server is
+  // sending non-null system_* fields). The toggle is rendered
+  // disabled when this is false.
+  systemAvailable: boolean;
+  showSystem: boolean;
+  onShowSystemChange: (v: boolean) => void;
+  showAdvanced: boolean;
+  onShowAdvancedChange: (v: boolean) => void;
+  // Optional status text shown to the right (e.g. "loading…",
+  // "paused", "last update 3 s ago"). Free-form.
+  statusText?: string;
+}
+
+const MODES: ActivityMode[] = ["live", "1h", "24h", "7d"];
+
+export default function ActivityToolbar({
+  mode,
+  onModeChange,
+  autoRefresh,
+  onAutoRefreshChange,
+  systemAvailable,
+  showSystem,
+  onShowSystemChange,
+  showAdvanced,
+  onShowAdvancedChange,
+  statusText,
+}: ActivityToolbarProps) {
+  return (
+    <div className="activity-toolbar">
+      <div className="activity-toolbar-group">
+        <span className="activity-toolbar-label">window</span>
+        <div className="mode-tabs">
+          {MODES.map((m) => (
+            <button
+              key={m}
+              type="button"
+              className={`mode-tab ${m === mode ? "on" : ""}`}
+              onClick={() => onModeChange(m)}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className={`toggle ${autoRefresh ? "on" : ""}`}
+        onClick={() => onAutoRefreshChange(!autoRefresh)}
+        title={autoRefresh ? "auto-refresh on — click to pause" : "auto-refresh paused — click to resume"}
+      >
+        {autoRefresh ? "⏸ pause" : "▶ resume"}
+      </button>
+
+      <button
+        type="button"
+        className={`toggle ${showSystem ? "on" : ""} ${!systemAvailable ? "disabled" : ""}`}
+        onClick={() => {
+          if (!systemAvailable) return;
+          onShowSystemChange(!showSystem);
+        }}
+        disabled={!systemAvailable}
+        title={
+          systemAvailable
+            ? "show host CPU + memory overlay"
+            : "set LOOMCYCLE_METRICS_COLLECT_SYSTEM=1 on the server to enable"
+        }
+      >
+        system overlay
+      </button>
+
+      <button
+        type="button"
+        className={`toggle ${showAdvanced ? "on" : ""}`}
+        onClick={() => onShowAdvancedChange(!showAdvanced)}
+        title="show diagnostic charts (goroutines, heap, system memory)"
+      >
+        advanced
+      </button>
+
+      {statusText && <span className="activity-toolbar-status">{statusText}</span>}
+    </div>
+  );
+}

--- a/web/src/components/activity/ChartCard.tsx
+++ b/web/src/components/activity/ChartCard.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from "react";
+
+// ChartCard wraps one chart with a uniform header (title +
+// current-value badge) and optional legend strip below the chart.
+// The Activity Monitor renders one ChartCard per metric; this
+// keeps all card layouts uniform without each chart having to
+// duplicate header markup.
+
+export interface LegendEntry {
+  label: string;
+  color: string;
+}
+
+export interface ChartCardProps {
+  title: string;
+  // The freshest scalar value (e.g. "342 MB", "12 runs"). Rendered
+  // in the mono accent color. Optional — some cards (e.g. queue
+  // depth) carry a derived "current" that's clearer in the chart
+  // than as a single number.
+  currentValue?: string;
+  legend?: LegendEntry[];
+  children: ReactNode;
+}
+
+export default function ChartCard({ title, currentValue, legend, children }: ChartCardProps) {
+  return (
+    <div className="chart-card">
+      <div className="chart-card-header">
+        <span className="chart-card-title">{title}</span>
+        {currentValue !== undefined && (
+          <span className="chart-card-current">{currentValue}</span>
+        )}
+      </div>
+      <div className="chart-card-body">{children}</div>
+      {legend && legend.length > 0 && (
+        <div className="chart-card-legend">
+          {legend.map((e) => (
+            <span key={e.label} className="legend-entry">
+              <span className="legend-swatch" style={{ background: e.color }} />
+              {e.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/activity/LineChart.tsx
+++ b/web/src/components/activity/LineChart.tsx
@@ -1,0 +1,465 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+// LineChart — hand-rolled SVG time series chart used by the
+// Activity Monitor tab. Zero dependencies. Supports:
+//   - multiple series (line OR stacked-area, mixed in one chart)
+//   - dual-axis (yAxis: "left" | "right" per series)
+//   - automatic gap detection (a path breaks if two adjacent
+//     points are > gapThresholdMs apart, so idle-gated sampling
+//     doesn't draw a straight line across hours of no data)
+//   - hover tooltip snapped to the nearest X point
+//   - responsive resize via ResizeObserver (the SVG uses a fixed
+//     viewBox matched to measured width, so labels stay crisp)
+//
+// Why hand-rolled instead of recharts/uplot: loomcycle keeps its
+// web/ deps minimal (3 runtime packages today). The chart shape we
+// need is uniform across the 6 Activity-Monitor cards; a 200-LOC
+// component beats a 80KB dep we'd have to theme. If we ever add a
+// chart type that doesn't fit this shape (e.g. a heatmap), the
+// trade-off shifts.
+
+export interface SeriesPoint {
+  t: number; // milliseconds since epoch
+  y: number; // value at t; in raw units (caller pre-scales if needed)
+}
+
+export interface Series {
+  label: string;
+  color: string;
+  points: SeriesPoint[];
+  // "left" (default) or "right". Two-axis charts use one of each.
+  yAxis?: "left" | "right";
+  // true → render as filled area (stacks on previous fill series).
+  // false/undefined → line only.
+  fill?: boolean;
+}
+
+export interface LineChartProps {
+  series: Series[];
+  // Override the auto-computed domain (e.g. CPU% always 0..100).
+  yLeftDomain?: [number, number];
+  yRightDomain?: [number, number];
+  // Formatters for axis-tick labels and tooltip values.
+  yLeftFormat?: (v: number) => string;
+  yRightFormat?: (v: number) => string;
+  // X-tick label formatter (default: HH:MM:SS for live, M/D HH:MM
+  // for longer windows — caller picks via the formatter passed in).
+  xFormat?: (t: number) => string;
+  // Visual height of the chart in pixels.
+  height?: number;
+  // Gap threshold in ms — adjacent points farther apart than this
+  // produce a path break (no straight line bridging the gap).
+  // Default 30s matches the sampler's worst-case idle gap.
+  gapThresholdMs?: number;
+}
+
+const PAD_LEFT = 56;
+const PAD_RIGHT = 56;
+const PAD_TOP = 8;
+const PAD_BOTTOM = 24;
+
+export default function LineChart({
+  series,
+  yLeftDomain,
+  yRightDomain,
+  yLeftFormat = formatNumber,
+  yRightFormat = formatNumber,
+  xFormat = formatTimeHMS,
+  height = 180,
+  gapThresholdMs = 30_000,
+}: LineChartProps) {
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState(600);
+  const [hover, setHover] = useState<{ x: number; t: number } | null>(null);
+
+  // ResizeObserver gives us the actual rendered width. The SVG
+  // viewBox is set to match so paths render 1:1 with the container.
+  useEffect(() => {
+    if (!wrapRef.current) return;
+    const el = wrapRef.current;
+    const ro = new ResizeObserver(() => {
+      setWidth(el.clientWidth || 600);
+    });
+    ro.observe(el);
+    setWidth(el.clientWidth || 600);
+    return () => ro.disconnect();
+  }, []);
+
+  // Domains: X from full point set; Y from each axis's series.
+  const xDomain = useMemo(() => computeXDomain(series), [series]);
+  const computedLeft = useMemo(() => computeYDomain(series, "left"), [series]);
+  const computedRight = useMemo(() => computeYDomain(series, "right"), [series]);
+  const leftDom = yLeftDomain ?? computedLeft;
+  const rightDom = yRightDomain ?? computedRight;
+
+  const plotW = Math.max(20, width - PAD_LEFT - PAD_RIGHT);
+  const plotH = Math.max(20, height - PAD_TOP - PAD_BOTTOM);
+
+  const xScale = (t: number) =>
+    PAD_LEFT + ((t - xDomain[0]) / Math.max(1, xDomain[1] - xDomain[0])) * plotW;
+  const yScaleLeft = (v: number) =>
+    PAD_TOP + plotH - ((v - leftDom[0]) / Math.max(1e-9, leftDom[1] - leftDom[0])) * plotH;
+  const yScaleRight = (v: number) =>
+    PAD_TOP + plotH - ((v - rightDom[0]) / Math.max(1e-9, rightDom[1] - rightDom[0])) * plotH;
+
+  // For stacked areas: the running baseline. Each fill series adds
+  // on top of the prior fill series' values at the SAME index. We
+  // assume all stacked series share an X grid (the Queue Depth
+  // chart's active+queued series are computed from the same sample
+  // list, so this holds in practice). Non-stacked series don't
+  // touch this state.
+  const stackedBaseline = useMemo(() => buildStackedBaseline(series), [series]);
+
+  const xTicks = useMemo(() => makeXTicks(xDomain, plotW), [xDomain, plotW]);
+  const yLeftTicks = useMemo(() => makeYTicks(leftDom), [leftDom]);
+  const yRightTicks = useMemo(() => makeYTicks(rightDom), [rightDom]);
+
+  const hasAnyPoints = series.some((s) => s.points.length > 0);
+
+  // onMouseMove: find the closest X point across all series.
+  const onMove = (e: React.MouseEvent<SVGSVGElement>) => {
+    if (!hasAnyPoints) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = e.clientX - rect.left;
+    if (px < PAD_LEFT || px > PAD_LEFT + plotW) {
+      setHover(null);
+      return;
+    }
+    // Use the union of all series' X points and pick the closest.
+    let bestT = xDomain[0];
+    let bestDist = Infinity;
+    for (const s of series) {
+      for (const p of s.points) {
+        const d = Math.abs(xScale(p.t) - px);
+        if (d < bestDist) {
+          bestDist = d;
+          bestT = p.t;
+        }
+      }
+    }
+    setHover({ x: xScale(bestT), t: bestT });
+  };
+
+  const hoverValuesByT = (t: number) =>
+    series.map((s) => {
+      const p = s.points.find((pp) => pp.t === t);
+      return { label: s.label, color: s.color, value: p?.y, yAxis: s.yAxis ?? "left" };
+    });
+
+  return (
+    <div className="line-chart-wrap" ref={wrapRef} style={{ position: "relative" }}>
+      <svg
+        className="line-chart"
+        viewBox={`0 0 ${width} ${height}`}
+        preserveAspectRatio="none"
+        onMouseMove={onMove}
+        onMouseLeave={() => setHover(null)}
+      >
+        {/* horizontal grid lines on the LEFT axis ticks */}
+        {yLeftTicks.map((t, i) => (
+          <line
+            key={`gh-${i}`}
+            x1={PAD_LEFT}
+            x2={PAD_LEFT + plotW}
+            y1={yScaleLeft(t)}
+            y2={yScaleLeft(t)}
+            stroke="#2a2e3a"
+            strokeOpacity={0.5}
+          />
+        ))}
+
+        {/* axis lines */}
+        <line x1={PAD_LEFT} x2={PAD_LEFT} y1={PAD_TOP} y2={PAD_TOP + plotH} stroke="#2a2e3a" />
+        <line
+          x1={PAD_LEFT + plotW}
+          x2={PAD_LEFT + plotW}
+          y1={PAD_TOP}
+          y2={PAD_TOP + plotH}
+          stroke="#2a2e3a"
+        />
+        <line
+          x1={PAD_LEFT}
+          x2={PAD_LEFT + plotW}
+          y1={PAD_TOP + plotH}
+          y2={PAD_TOP + plotH}
+          stroke="#2a2e3a"
+        />
+
+        {/* axis tick labels */}
+        {yLeftTicks.map((t, i) => (
+          <text
+            key={`yl-${i}`}
+            x={PAD_LEFT - 6}
+            y={yScaleLeft(t) + 3}
+            textAnchor="end"
+            fontSize="10"
+            fill="#9aa0ad"
+            fontFamily="ui-monospace, monospace"
+          >
+            {yLeftFormat(t)}
+          </text>
+        ))}
+        {rightDom[0] !== rightDom[1] &&
+          yRightTicks.map((t, i) => (
+            <text
+              key={`yr-${i}`}
+              x={PAD_LEFT + plotW + 6}
+              y={yScaleRight(t) + 3}
+              textAnchor="start"
+              fontSize="10"
+              fill="#9aa0ad"
+              fontFamily="ui-monospace, monospace"
+            >
+              {yRightFormat(t)}
+            </text>
+          ))}
+        {xTicks.map((t, i) => (
+          <text
+            key={`x-${i}`}
+            x={xScale(t)}
+            y={PAD_TOP + plotH + 14}
+            textAnchor="middle"
+            fontSize="10"
+            fill="#9aa0ad"
+            fontFamily="ui-monospace, monospace"
+          >
+            {xFormat(t)}
+          </text>
+        ))}
+
+        {/* series — areas drawn first (under lines), lines on top */}
+        {series.map((s, si) => {
+          if (!s.fill) return null;
+          const baseline = stackedBaseline[si];
+          const path = buildAreaPath(s.points, baseline, xScale, yScaleLeft, gapThresholdMs);
+          return (
+            <path
+              key={`area-${si}`}
+              d={path}
+              fill={s.color}
+              fillOpacity={0.25}
+              stroke={s.color}
+              strokeWidth={1}
+            />
+          );
+        })}
+        {series.map((s, si) => {
+          if (s.fill) return null;
+          const yScale = (s.yAxis ?? "left") === "right" ? yScaleRight : yScaleLeft;
+          const path = buildLinePath(s.points, xScale, yScale, gapThresholdMs);
+          return (
+            <path
+              key={`line-${si}`}
+              d={path}
+              fill="none"
+              stroke={s.color}
+              strokeWidth={1.5}
+            />
+          );
+        })}
+
+        {/* hover crosshair */}
+        {hover && (
+          <line
+            x1={hover.x}
+            x2={hover.x}
+            y1={PAD_TOP}
+            y2={PAD_TOP + plotH}
+            stroke="#9aa0ad"
+            strokeOpacity={0.4}
+            strokeDasharray="3 3"
+          />
+        )}
+      </svg>
+
+      {/* tooltip */}
+      {hover && (
+        <div
+          className="line-chart-tooltip"
+          style={{
+            position: "absolute",
+            left:
+              hover.x + 140 > width
+                ? `${hover.x - 140}px`
+                : `${hover.x + 8}px`,
+            top: `${PAD_TOP + 4}px`,
+            pointerEvents: "none",
+          }}
+        >
+          <div className="tt-time">{xFormat(hover.t)}</div>
+          {hoverValuesByT(hover.t).map((v) => (
+            <div key={v.label} className="tt-row">
+              <span className="tt-swatch" style={{ background: v.color }} />
+              <span className="tt-label">{v.label}</span>
+              <span className="tt-value">
+                {v.value === undefined
+                  ? "—"
+                  : v.yAxis === "right"
+                    ? yRightFormat(v.value)
+                    : yLeftFormat(v.value)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!hasAnyPoints && (
+        <div className="line-chart-empty">awaiting first sample…</div>
+      )}
+    </div>
+  );
+}
+
+// --- helpers --------------------------------------------------------
+
+function computeXDomain(series: Series[]): [number, number] {
+  let lo = Infinity;
+  let hi = -Infinity;
+  for (const s of series) {
+    for (const p of s.points) {
+      if (p.t < lo) lo = p.t;
+      if (p.t > hi) hi = p.t;
+    }
+  }
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) {
+    const now = Date.now();
+    return [now - 60_000, now];
+  }
+  if (lo === hi) return [lo - 60_000, hi];
+  return [lo, hi];
+}
+
+function computeYDomain(series: Series[], axis: "left" | "right"): [number, number] {
+  let lo = Infinity;
+  let hi = -Infinity;
+  // Stacked-area handling: sum same-X values on left axis when
+  // multiple fill series exist, so the y-domain encloses the stack.
+  const stackedAt: Map<number, number> = new Map();
+  for (const s of series) {
+    if ((s.yAxis ?? "left") !== axis) continue;
+    for (const p of s.points) {
+      if (s.fill && axis === "left") {
+        stackedAt.set(p.t, (stackedAt.get(p.t) ?? 0) + p.y);
+      } else {
+        if (p.y < lo) lo = p.y;
+        if (p.y > hi) hi = p.y;
+      }
+    }
+  }
+  for (const v of stackedAt.values()) {
+    if (v < lo) lo = v;
+    if (v > hi) hi = v;
+  }
+  if (!Number.isFinite(lo) || !Number.isFinite(hi)) return [0, 1];
+  if (lo === hi) return [Math.min(0, lo), hi + 1];
+  // Pad the top by 8% so the line doesn't kiss the axis.
+  const span = hi - lo;
+  return [Math.min(0, lo), hi + span * 0.08];
+}
+
+// buildStackedBaseline returns, for each series index, the cumulative
+// baseline (sum of all PRIOR fill series' values at each X point).
+// Non-fill series get an empty map. Used by buildAreaPath as the
+// lower edge of the polygon.
+function buildStackedBaseline(series: Series[]): Map<number, number>[] {
+  const out: Map<number, number>[] = [];
+  const running: Map<number, number> = new Map();
+  for (const s of series) {
+    if (!s.fill) {
+      out.push(new Map());
+      continue;
+    }
+    // Snapshot the current running totals as THIS series' baseline.
+    out.push(new Map(running));
+    for (const p of s.points) {
+      running.set(p.t, (running.get(p.t) ?? 0) + p.y);
+    }
+  }
+  return out;
+}
+
+function buildLinePath(
+  points: SeriesPoint[],
+  xScale: (t: number) => number,
+  yScale: (v: number) => number,
+  gapMs: number,
+): string {
+  if (points.length === 0) return "";
+  const sorted = [...points].sort((a, b) => a.t - b.t);
+  let d = "";
+  let lastT = -Infinity;
+  for (const p of sorted) {
+    const cmd = lastT === -Infinity || p.t - lastT > gapMs ? "M" : "L";
+    d += `${cmd}${xScale(p.t).toFixed(1)},${yScale(p.y).toFixed(1)} `;
+    lastT = p.t;
+  }
+  return d.trim();
+}
+
+function buildAreaPath(
+  points: SeriesPoint[],
+  baseline: Map<number, number>,
+  xScale: (t: number) => number,
+  yScale: (v: number) => number,
+  gapMs: number,
+): string {
+  if (points.length === 0) return "";
+  const sorted = [...points].sort((a, b) => a.t - b.t);
+  // Build the path in segments split by gaps; each segment is a
+  // closed polygon (top edge → bottom edge reversed).
+  let d = "";
+  let segStart = 0;
+  const closeSegment = (start: number, end: number) => {
+    const top: string[] = [];
+    const bottom: string[] = [];
+    for (let i = start; i <= end; i++) {
+      const p = sorted[i];
+      const base = baseline.get(p.t) ?? 0;
+      const yTop = yScale(base + p.y);
+      const yBot = yScale(base);
+      top.push(`${xScale(p.t).toFixed(1)},${yTop.toFixed(1)}`);
+      bottom.push(`${xScale(p.t).toFixed(1)},${yBot.toFixed(1)}`);
+    }
+    bottom.reverse();
+    d += `M${top[0]} L${top.slice(1).join(" L")} L${bottom.join(" L")} Z `;
+  };
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i].t - sorted[i - 1].t > gapMs) {
+      closeSegment(segStart, i - 1);
+      segStart = i;
+    }
+  }
+  closeSegment(segStart, sorted.length - 1);
+  return d.trim();
+}
+
+function makeXTicks(domain: [number, number], plotW: number): number[] {
+  const targetCount = Math.max(2, Math.min(6, Math.floor(plotW / 100)));
+  const out: number[] = [];
+  for (let i = 0; i < targetCount; i++) {
+    out.push(domain[0] + ((domain[1] - domain[0]) * i) / (targetCount - 1));
+  }
+  return out;
+}
+
+function makeYTicks(domain: [number, number]): number[] {
+  const ticks = 4;
+  const out: number[] = [];
+  for (let i = 0; i <= ticks; i++) {
+    out.push(domain[0] + ((domain[1] - domain[0]) * i) / ticks);
+  }
+  return out;
+}
+
+function formatNumber(v: number): string {
+  if (Math.abs(v) >= 1000) return v.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  if (Math.abs(v) >= 10) return v.toFixed(0);
+  if (Math.abs(v) >= 1) return v.toFixed(1);
+  return v.toFixed(2);
+}
+
+function formatTimeHMS(t: number): string {
+  const d = new Date(t);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}

--- a/web/src/components/activity/MetricsDisabledEmpty.tsx
+++ b/web/src/components/activity/MetricsDisabledEmpty.tsx
@@ -1,0 +1,26 @@
+// MetricsDisabledEmpty — rendered when the server says metrics are
+// off (either /healthz reports metrics_enabled: false on mount, or
+// any /v1/_metrics request returns 503 with a typed-disabled
+// result). Operator-facing copy explains how to turn it on.
+
+export interface MetricsDisabledEmptyProps {
+  enableHint: string;
+}
+
+export default function MetricsDisabledEmpty({ enableHint }: MetricsDisabledEmptyProps) {
+  return (
+    <div className="metrics-disabled">
+      <div className="metrics-disabled-title">process sampler is off</div>
+      <p className="metrics-disabled-body">
+        loomcycle isn&apos;t collecting CPU / memory / agent-load samples on this
+        deployment. To turn it on,{" "}
+        <code>{enableHint}</code>.
+      </p>
+      <p className="metrics-disabled-body">
+        For host-wide CPU + memory (the dashed second line on the CPU chart,
+        and the system-memory card), also set{" "}
+        <code>LOOMCYCLE_METRICS_COLLECT_SYSTEM=1</code>.
+      </p>
+    </div>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -7,6 +7,7 @@ import MemoryView from "./pages/MemoryView";
 import InterruptInbox from "./pages/InterruptInbox";
 import SnapshotsView from "./pages/SnapshotsView";
 import AuditView from "./pages/AuditView";
+import ActivityMonitor from "./pages/ActivityMonitor";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
 
@@ -29,6 +30,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="interrupts" element={<InterruptInbox />} />
           <Route path="snapshots" element={<SnapshotsView />} />
           <Route path="audit" element={<AuditView />} />
+          <Route path="activity" element={<ActivityMonitor />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />
         </Route>
       </Routes>

--- a/web/src/pages/ActivityMonitor.tsx
+++ b/web/src/pages/ActivityMonitor.tsx
@@ -45,6 +45,11 @@ const C_QUEUED = "#5b9dff";     // accent (top of stack)
 const C_ACTIVE = "#f0a040";     // --running (bottom of stack)
 const C_CPU_PROCESS = "#5b9dff";
 const C_CPU_SYSTEM = "#9aa0ad"; // --fg-soft, dashed via opacity
+const C_GOROUTINES = "#6ee7a3";   // await-running green
+const C_HEAP_ALLOC = "#5b9dff";   // accent
+const C_HEAP_INUSE = "#c9a8ff";   // await-interrupted violet
+const C_SYSMEM_USED = "#ffb766";  // await-channel orange
+const C_SYSMEM_AVAIL = "#6ee7a3"; // await-running green
 
 function readLSBool(key: string, fallback: boolean): boolean {
   const v = localStorage.getItem(key);
@@ -199,6 +204,27 @@ export default function ActivityMonitor() {
           <MemoryVsAgentsCard samples={samples} buckets={summary} mode={mode} />
           <CPUCard samples={samples} buckets={summary} mode={mode} showSystem={showSystem && systemAvailable} />
           <QueueDepthCard samples={samples} buckets={summary} mode={mode} />
+          {/* Diagnostic cards are live-mode only — the summary
+              endpoint doesn't bucket goroutines / heap / system
+              memory, so window modes can't render them. */}
+          {showAdvanced && mode === "live" && (
+            <>
+              <GoroutinesCard samples={samples} />
+              <HeapCard samples={samples} />
+              <SystemMemoryCard samples={samples} />
+            </>
+          )}
+          {showAdvanced && mode !== "live" && (
+            <div className="chart-card advanced-window-note">
+              <div className="chart-card-title">advanced diagnostics</div>
+              <p>
+                Goroutines, heap breakdown, and system memory are only available
+                in <strong>live</strong> mode — the summary endpoint aggregates
+                only memory, CPU, and agent counts. Switch the window to
+                <code> live </code> to see them.
+              </p>
+            </div>
+          )}
         </div>
       )}
     </div>
@@ -366,6 +392,128 @@ function QueueDepthCard({ samples, buckets, mode }: CardProps) {
       />
     </ChartCard>
   );
+}
+
+// --- diagnostic cards (advanced toggle) ----------------------------
+
+function GoroutinesCard({ samples }: { samples: ProcessSample[] }) {
+  const series: Series[] = [
+    {
+      label: "goroutines",
+      color: C_GOROUTINES,
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: s.loomcycle_num_goroutines })),
+    },
+  ];
+  const cur = latestPoint(series[0].points)?.y;
+  return (
+    <ChartCard
+      title="goroutines"
+      currentValue={cur != null ? cur.toLocaleString() : undefined}
+      legend={[{ label: "go runtime goroutine count", color: C_GOROUTINES }]}
+    >
+      <LineChart
+        series={series}
+        yLeftFormat={(v) => v.toFixed(0)}
+        xFormat={xFormatForMode("live")}
+      />
+    </ChartCard>
+  );
+}
+
+function HeapCard({ samples }: { samples: ProcessSample[] }) {
+  const series: Series[] = [
+    {
+      label: "heap alloc",
+      color: C_HEAP_ALLOC,
+      points: samples.map((s) => ({
+        t: tsMs(s.sampled_at),
+        y: bytesToMB(s.loomcycle_heap_alloc_bytes),
+      })),
+    },
+    {
+      label: "heap inuse",
+      color: C_HEAP_INUSE,
+      points: samples.map((s) => ({
+        t: tsMs(s.sampled_at),
+        y: bytesToMB(s.loomcycle_heap_inuse_bytes),
+      })),
+    },
+  ];
+  const allocNow = latestPoint(series[0].points)?.y;
+  const inuseNow = latestPoint(series[1].points)?.y;
+  return (
+    <ChartCard
+      title="go heap"
+      currentValue={
+        allocNow != null && inuseNow != null
+          ? `${formatMB(allocNow)} alloc / ${formatMB(inuseNow)} inuse`
+          : undefined
+      }
+      legend={[
+        { label: "heap alloc (MB)", color: C_HEAP_ALLOC },
+        { label: "heap inuse (MB)", color: C_HEAP_INUSE },
+      ]}
+    >
+      <LineChart
+        series={series}
+        yLeftFormat={(v) => `${v.toFixed(0)} MB`}
+        xFormat={xFormatForMode("live")}
+      />
+    </ChartCard>
+  );
+}
+
+function SystemMemoryCard({ samples }: { samples: ProcessSample[] }) {
+  // Auto-suppress: if no sample has a non-null system_mem_used_mb,
+  // we render nothing instead of a perpetually-empty card. (The
+  // page suppresses too, but defending here keeps the card
+  // self-contained if reused.)
+  const hasData = samples.some((s) => s.system_mem_used_mb != null);
+  if (!hasData) return null;
+
+  const series: Series[] = [
+    {
+      label: "used",
+      color: C_SYSMEM_USED,
+      points: samples
+        .filter((s) => s.system_mem_used_mb != null)
+        .map((s) => ({ t: tsMs(s.sampled_at), y: s.system_mem_used_mb as number })),
+    },
+    {
+      label: "available",
+      color: C_SYSMEM_AVAIL,
+      points: samples
+        .filter((s) => s.system_mem_available_mb != null)
+        .map((s) => ({ t: tsMs(s.sampled_at), y: s.system_mem_available_mb as number })),
+    },
+  ];
+  const usedNow = latestPoint(series[0].points)?.y;
+  const availNow = latestPoint(series[1].points)?.y;
+  return (
+    <ChartCard
+      title="system memory"
+      currentValue={
+        usedNow != null && availNow != null
+          ? `${formatMBFromMB(usedNow)} used / ${formatMBFromMB(availNow)} free`
+          : undefined
+      }
+      legend={[
+        { label: "used (MB)", color: C_SYSMEM_USED },
+        { label: "available (MB)", color: C_SYSMEM_AVAIL },
+      ]}
+    >
+      <LineChart
+        series={series}
+        yLeftFormat={(v) => `${v.toFixed(0)} MB`}
+        xFormat={xFormatForMode("live")}
+      />
+    </ChartCard>
+  );
+}
+
+function formatMBFromMB(v: number): string {
+  if (v >= 1024) return `${(v / 1024).toFixed(2)} GB`;
+  return `${v.toFixed(0)} MB`;
 }
 
 // --- formatting helpers --------------------------------------------

--- a/web/src/pages/ActivityMonitor.tsx
+++ b/web/src/pages/ActivityMonitor.tsx
@@ -1,0 +1,404 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ProcessSample,
+  SummaryBucket,
+  getHealth,
+  getMetricsSamples,
+  getMetricsSummary,
+} from "../api";
+import ActivityToolbar, { type ActivityMode } from "../components/activity/ActivityToolbar";
+import ChartCard from "../components/activity/ChartCard";
+import LineChart, { type Series } from "../components/activity/LineChart";
+import MetricsDisabledEmpty from "../components/activity/MetricsDisabledEmpty";
+
+// ActivityMonitor — operator-facing live charts of CPU, memory,
+// agent load, and (optionally) host metrics. Backed by the v0.8.11
+// process-resource metrics sampler.
+//
+// Layout:
+//   ┌─ ActivityToolbar (mode | pause | system | advanced) ─┐
+//   │ MetricsDisabledEmpty  *or*  chart grid               │
+//   └──────────────────────────────────────────────────────┘
+//
+// Three primary charts ship in this commit (memory+agents,
+// CPU, queue depth). The 'advanced' toggle exposes diagnostic
+// charts in the next commit; right now the toggle is wired but
+// only the primaries render.
+
+const LIVE_WINDOW_MS = 15 * 60 * 1000; // 15 min live window
+const LIVE_POLL_MS = 5000;
+const SUMMARY_POLL_MS = 30_000;
+
+// localStorage keys — keep all activity preferences under one
+// namespace prefix so they're easy to clear in DevTools.
+const LS_MODE = "loomcycle.activity.mode";
+const LS_AUTOREFRESH = "loomcycle.activity.autoRefresh";
+const LS_SHOW_SYSTEM = "loomcycle.activity.showSystem";
+const LS_SHOW_ADVANCED = "loomcycle.activity.showAdvanced";
+
+// Series colors — pulled from the existing palette + the v0.8.21
+// awaited-state chip palette to stay consistent with the rest of
+// the UI.
+const C_MEMORY = "#5b9dff";     // --accent
+const C_AGENTS = "#ffb766";     // await-channel orange
+const C_QUEUED = "#5b9dff";     // accent (top of stack)
+const C_ACTIVE = "#f0a040";     // --running (bottom of stack)
+const C_CPU_PROCESS = "#5b9dff";
+const C_CPU_SYSTEM = "#9aa0ad"; // --fg-soft, dashed via opacity
+
+function readLSBool(key: string, fallback: boolean): boolean {
+  const v = localStorage.getItem(key);
+  if (v === "1") return true;
+  if (v === "0") return false;
+  return fallback;
+}
+
+function readLSMode(fallback: ActivityMode): ActivityMode {
+  const v = localStorage.getItem(LS_MODE);
+  if (v === "live" || v === "1h" || v === "24h" || v === "7d") return v;
+  return fallback;
+}
+
+export default function ActivityMonitor() {
+  // Preference state — initialised from localStorage so a reload
+  // lands the operator on the same view.
+  const [mode, setMode] = useState<ActivityMode>(() => readLSMode("live"));
+  const [autoRefresh, setAutoRefresh] = useState<boolean>(() => readLSBool(LS_AUTOREFRESH, true));
+  const [showSystem, setShowSystem] = useState<boolean>(() => readLSBool(LS_SHOW_SYSTEM, false));
+  const [showAdvanced, setShowAdvanced] = useState<boolean>(() => readLSBool(LS_SHOW_ADVANCED, false));
+
+  // Data state.
+  const [samples, setSamples] = useState<ProcessSample[]>([]);
+  const [summary, setSummary] = useState<SummaryBucket[]>([]);
+  const [disabled, setDisabled] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
+
+  // On mount, probe /healthz so we can render the disabled empty
+  // state BEFORE making a metrics request that would 503. This is
+  // also why the helper /healthz now ships metrics_enabled.
+  useEffect(() => {
+    let cancelled = false;
+    getHealth()
+      .then((h) => {
+        if (cancelled) return;
+        if (h.metrics_enabled === false) {
+          setDisabled("set LOOMCYCLE_METRICS_ENABLED=1 and restart loomcycle");
+        }
+      })
+      .catch(() => {
+        // Health probe failing is a different problem; the metrics
+        // fetch below will surface its own error.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Persist preferences on change.
+  useEffect(() => localStorage.setItem(LS_MODE, mode), [mode]);
+  useEffect(() => localStorage.setItem(LS_AUTOREFRESH, autoRefresh ? "1" : "0"), [autoRefresh]);
+  useEffect(() => localStorage.setItem(LS_SHOW_SYSTEM, showSystem ? "1" : "0"), [showSystem]);
+  useEffect(() => localStorage.setItem(LS_SHOW_ADVANCED, showAdvanced ? "1" : "0"), [showAdvanced]);
+
+  // Polling lifecycle. One useEffect keyed on [mode, autoRefresh].
+  // On mode change we drop the prior data so the chart doesn't
+  // briefly render samples against the wrong X domain.
+  useEffect(() => {
+    setSamples([]);
+    setSummary([]);
+    setErr(null);
+    if (!autoRefresh) return;
+    if (disabled) return; // already known disabled — skip polling
+
+    let cancelled = false;
+    const tick = async () => {
+      setLoading(true);
+      try {
+        if (mode === "live") {
+          const since = new Date(Date.now() - LIVE_WINDOW_MS).toISOString();
+          const r = await getMetricsSamples({ since, limit: 200 });
+          if (cancelled) return;
+          if (r.disabled) {
+            setDisabled(r.enableHint);
+          } else {
+            setSamples(r.data.samples);
+            setLastUpdated(Date.now());
+          }
+        } else {
+          const r = await getMetricsSummary(mode);
+          if (cancelled) return;
+          if (r.disabled) {
+            setDisabled(r.enableHint);
+          } else {
+            setSummary(r.data.buckets);
+            setLastUpdated(Date.now());
+          }
+        }
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    tick();
+    const id = setInterval(tick, mode === "live" ? LIVE_POLL_MS : SUMMARY_POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [mode, autoRefresh, disabled]);
+
+  // Detect whether the server is shipping system_* fields. The
+  // sampler may be enabled but COLLECT_SYSTEM may not be — the
+  // toggle is rendered disabled when this is false.
+  const systemAvailable = useMemo(() => {
+    if (mode === "live") {
+      return samples.some((s) => s.system_cpu_pct_x100 != null);
+    }
+    // Summary buckets don't carry system_* separately; we'd need a
+    // probe sample. For window modes, fall back to the live samples
+    // we accumulated (none, on first window-mode load). Treat as
+    // unavailable until the user toggles to live and back —
+    // pragmatic; the toggle's tooltip explains.
+    return false;
+  }, [mode, samples]);
+
+  const statusText = useMemo(() => {
+    if (disabled) return undefined;
+    if (loading && lastUpdated === null) return "loading…";
+    if (!autoRefresh) return "paused";
+    if (lastUpdated == null) return undefined;
+    const ageS = Math.round((Date.now() - lastUpdated) / 1000);
+    return `updated ${ageS}s ago`;
+  }, [disabled, loading, lastUpdated, autoRefresh]);
+
+  return (
+    <div className="activity-view">
+      <ActivityToolbar
+        mode={mode}
+        onModeChange={setMode}
+        autoRefresh={autoRefresh}
+        onAutoRefreshChange={setAutoRefresh}
+        systemAvailable={systemAvailable}
+        showSystem={showSystem}
+        onShowSystemChange={setShowSystem}
+        showAdvanced={showAdvanced}
+        onShowAdvancedChange={setShowAdvanced}
+        statusText={statusText}
+      />
+
+      {err && !disabled && <div className="err">{err}</div>}
+
+      {disabled ? (
+        <MetricsDisabledEmpty enableHint={disabled} />
+      ) : (
+        <div className="activity-grid">
+          <MemoryVsAgentsCard samples={samples} buckets={summary} mode={mode} />
+          <CPUCard samples={samples} buckets={summary} mode={mode} showSystem={showSystem && systemAvailable} />
+          <QueueDepthCard samples={samples} buckets={summary} mode={mode} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Chart cards ----------------------------------------------------
+
+interface CardProps {
+  samples: ProcessSample[];
+  buckets: SummaryBucket[];
+  mode: ActivityMode;
+}
+
+function MemoryVsAgentsCard({ samples, buckets, mode }: CardProps) {
+  const memSeries: Series[] = [];
+  const agentSeries: Series[] = [];
+  if (mode === "live") {
+    memSeries.push({
+      label: "memory",
+      color: C_MEMORY,
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: bytesToMB(s.loomcycle_rss_bytes) })),
+    });
+    agentSeries.push({
+      label: "active agents",
+      color: C_AGENTS,
+      yAxis: "right",
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: s.active_runs })),
+    });
+  } else {
+    memSeries.push({
+      label: "memory (mean)",
+      color: C_MEMORY,
+      points: buckets.map((b) => ({ t: tsMs(b.at), y: bytesToMB(b.mean_rss_bytes) })),
+    });
+    agentSeries.push({
+      label: "active agents (max)",
+      color: C_AGENTS,
+      yAxis: "right",
+      points: buckets.map((b) => ({ t: tsMs(b.at), y: b.active_runs_max })),
+    });
+  }
+  const current = latestPoint(memSeries[0]?.points)?.y;
+  const currentAgents = latestPoint(agentSeries[0]?.points)?.y;
+  return (
+    <ChartCard
+      title="memory vs running agents"
+      currentValue={
+        current != null && currentAgents != null
+          ? `${formatMB(current)} · ${currentAgents} run${currentAgents === 1 ? "" : "s"}`
+          : undefined
+      }
+      legend={[
+        { label: "memory (MB, left axis)", color: C_MEMORY },
+        { label: "active agents (count, right axis)", color: C_AGENTS },
+      ]}
+    >
+      <LineChart
+        series={[...memSeries, ...agentSeries]}
+        yLeftFormat={(v) => `${v.toFixed(0)} MB`}
+        yRightFormat={(v) => v.toFixed(0)}
+        xFormat={xFormatForMode(mode)}
+      />
+    </ChartCard>
+  );
+}
+
+function CPUCard({
+  samples,
+  buckets,
+  mode,
+  showSystem,
+}: CardProps & { showSystem: boolean }) {
+  const series: Series[] = [];
+  if (mode === "live") {
+    series.push({
+      label: "process CPU",
+      color: C_CPU_PROCESS,
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: s.loomcycle_cpu_pct_x100 / 100 })),
+    });
+    if (showSystem) {
+      series.push({
+        label: "system CPU",
+        color: C_CPU_SYSTEM,
+        points: samples
+          .filter((s) => s.system_cpu_pct_x100 != null)
+          .map((s) => ({ t: tsMs(s.sampled_at), y: (s.system_cpu_pct_x100 as number) / 100 })),
+      });
+    }
+  } else {
+    series.push({
+      label: "process CPU (p95)",
+      color: C_CPU_PROCESS,
+      points: buckets.map((b) => ({ t: tsMs(b.at), y: b.p95_cpu_pct_x100 / 100 })),
+    });
+    // System CPU isn't bucketed by the summary endpoint, so the
+    // overlay is live-only in window modes.
+  }
+  const cur = latestPoint(series[0]?.points)?.y;
+  return (
+    <ChartCard
+      title="CPU load"
+      currentValue={cur != null ? `${cur.toFixed(1)}%` : undefined}
+      legend={[
+        { label: "process CPU %", color: C_CPU_PROCESS },
+        ...(showSystem ? [{ label: "system CPU %", color: C_CPU_SYSTEM }] : []),
+      ]}
+    >
+      <LineChart
+        series={series}
+        yLeftDomain={[0, 100]}
+        yLeftFormat={(v) => `${v.toFixed(0)}%`}
+        xFormat={xFormatForMode(mode)}
+      />
+    </ChartCard>
+  );
+}
+
+function QueueDepthCard({ samples, buckets, mode }: CardProps) {
+  // Stacked area: active on the bottom, queued on top.
+  // Summary endpoint doesn't carry queued_runs separately — only
+  // active_runs_max — so the window-mode chart degrades to one
+  // band (active only).
+  const series: Series[] = [];
+  if (mode === "live") {
+    series.push({
+      label: "active",
+      color: C_ACTIVE,
+      fill: true,
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: s.active_runs })),
+    });
+    series.push({
+      label: "queued",
+      color: C_QUEUED,
+      fill: true,
+      points: samples.map((s) => ({ t: tsMs(s.sampled_at), y: s.queued_runs })),
+    });
+  } else {
+    series.push({
+      label: "active (max per bucket)",
+      color: C_ACTIVE,
+      fill: true,
+      points: buckets.map((b) => ({ t: tsMs(b.at), y: b.active_runs_max })),
+    });
+  }
+  const totalNow =
+    (latestPoint(series[0]?.points)?.y ?? 0) + (latestPoint(series[1]?.points)?.y ?? 0);
+  return (
+    <ChartCard
+      title="queue depth"
+      currentValue={`${totalNow} total`}
+      legend={
+        mode === "live"
+          ? [
+              { label: "active runs", color: C_ACTIVE },
+              { label: "queued runs", color: C_QUEUED },
+            ]
+          : [{ label: "active runs (max)", color: C_ACTIVE }]
+      }
+    >
+      <LineChart
+        series={series}
+        yLeftFormat={(v) => v.toFixed(0)}
+        xFormat={xFormatForMode(mode)}
+      />
+    </ChartCard>
+  );
+}
+
+// --- formatting helpers --------------------------------------------
+
+function tsMs(s: string): number {
+  return Date.parse(s);
+}
+
+function bytesToMB(b: number): number {
+  return b / (1024 * 1024);
+}
+
+function formatMB(v: number): string {
+  if (v >= 1024) return `${(v / 1024).toFixed(2)} GB`;
+  return `${v.toFixed(0)} MB`;
+}
+
+function latestPoint(points: { t: number; y: number }[] | undefined) {
+  if (!points || points.length === 0) return undefined;
+  return points.reduce((a, b) => (a.t > b.t ? a : b));
+}
+
+function xFormatForMode(mode: ActivityMode) {
+  return (t: number) => {
+    const d = new Date(t);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    if (mode === "live" || mode === "1h") {
+      return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+    }
+    if (mode === "24h") {
+      return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+    // 7d
+    return `${d.getMonth() + 1}/${d.getDate()} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1559,3 +1559,62 @@ pre {
   color: white;
   border-color: var(--accent);
 }
+
+/* v0.8.21 Activity Monitor — LineChart. Hand-rolled SVG; the
+ * component owns its sizing via ResizeObserver and a matching
+ * viewBox. CSS handles the tooltip overlay + empty state. */
+.line-chart-wrap {
+  width: 100%;
+  position: relative;
+}
+.line-chart {
+  width: 100%;
+  display: block;
+}
+.line-chart-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-soft);
+  font-size: 12px;
+  font-style: italic;
+  pointer-events: none;
+}
+.line-chart-tooltip {
+  background: rgba(15, 17, 21, 0.96);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  min-width: 140px;
+}
+.line-chart-tooltip .tt-time {
+  color: var(--fg-soft);
+  margin-bottom: 4px;
+}
+.line-chart-tooltip .tt-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  line-height: 1.5;
+}
+.line-chart-tooltip .tt-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.line-chart-tooltip .tt-label {
+  flex: 1;
+  color: var(--fg-soft);
+}
+.line-chart-tooltip .tt-value {
+  color: var(--fg);
+  font-variant-numeric: tabular-nums;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1391,10 +1391,31 @@ pre {
   height: 100%;
   min-height: 0;
 }
+
+/* v0.8.21 Activity Monitor — page layout, toolbar, chart cards.
+ * Three primary charts ship in this commit; diagnostic charts
+ * land in the next one behind the `advanced` toolbar toggle. */
+.activity-view {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 100%;
+  min-height: 0;
+}
 .audit-toolbar {
   display: flex;
   flex-direction: column;
   gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.activity-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
   padding: 10px 12px;
   background: var(--bg-soft);
   border: 1px solid var(--border);
@@ -1558,6 +1579,166 @@ pre {
   background: var(--accent);
   color: white;
   border-color: var(--accent);
+}
+
+.activity-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.activity-toolbar-label {
+  color: var(--fg-soft);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.mode-tabs {
+  display: flex;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.mode-tab {
+  background: transparent;
+  color: var(--fg-soft);
+  border: none;
+  padding: 4px 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+}
+.mode-tab:last-child { border-right: none; }
+.mode-tab.on {
+  background: var(--accent);
+  color: white;
+}
+.mode-tab:hover:not(.on) {
+  background: var(--bg-soft-2);
+  color: var(--fg);
+}
+.toggle {
+  background: var(--bg);
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: var(--mono);
+  cursor: pointer;
+}
+.toggle.on {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.toggle:hover:not(:disabled):not(.disabled) {
+  background: var(--bg-soft-2);
+  color: var(--fg);
+}
+.toggle.on:hover {
+  background: var(--accent);
+  color: white;
+}
+.toggle:disabled,
+.toggle.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.activity-toolbar-status {
+  margin-left: auto;
+  color: var(--fg-soft);
+  font-size: 11px;
+  font-family: var(--mono);
+}
+
+.activity-grid {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+  gap: 12px;
+  padding-bottom: 12px;
+}
+
+.chart-card {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 220px;
+}
+.chart-card-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.chart-card-title {
+  font-size: 13px;
+  color: var(--fg);
+  font-weight: 600;
+}
+.chart-card-current {
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--accent);
+  font-variant-numeric: tabular-nums;
+}
+.chart-card-body {
+  flex: 1;
+  min-height: 180px;
+  position: relative;
+}
+.chart-card-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.legend-entry {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.legend-swatch {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+}
+
+.metrics-disabled {
+  padding: 40px 24px;
+  text-align: center;
+  background: var(--bg-soft);
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--fg-soft);
+}
+.metrics-disabled-title {
+  font-size: 16px;
+  color: var(--fg);
+  margin-bottom: 10px;
+}
+.metrics-disabled-body {
+  max-width: 540px;
+  margin: 6px auto;
+  line-height: 1.6;
+}
+.metrics-disabled code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-family: var(--mono);
+  color: var(--fg);
 }
 
 /* v0.8.21 Activity Monitor — LineChart. Hand-rolled SVG; the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1741,6 +1741,28 @@ pre {
   color: var(--fg);
 }
 
+/* Note card rendered when 'advanced' is on but mode != live —
+ * diagnostic series aren't bucketed by the summary endpoint. */
+.advanced-window-note {
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 6px;
+}
+.advanced-window-note p {
+  color: var(--fg-soft);
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 0;
+}
+.advanced-window-note code {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 6px;
+  font-family: var(--mono);
+  color: var(--fg);
+}
+
 /* v0.8.21 Activity Monitor — LineChart. Hand-rolled SVG; the
  * component owns its sizing via ResizeObserver and a matching
  * viewBox. CSS handles the tooltip overlay + empty state. */


### PR DESCRIPTION
## Summary

Adds a new `/ui/activity` tab that surfaces the v0.8.11 process-resource sampler's data as live charts. The data was already collected; this PR is the operator-facing consumer.

**Five commits, each independently reviewable:**

1. **feat(api): expose `metrics_enabled` on `/healthz`** — five-line server delta. Lets the UI render the "sampler off" empty state on mount instead of probing `/v1/_metrics/*` and getting 503.
2. **feat(web): TS types + helpers for `/v1/_metrics` endpoints** — `getMetricsSamples`, `getMetricsSummary`, and a new `jsonFetchAllowing` sibling that returns a typed-disabled `MetricsResult` instead of throwing on 503.
3. **feat(web): hand-rolled SVG `LineChart` component** — ~360 LOC; multi-series, dual-axis, stacked-area, gap detection, hover crosshair + tooltip, responsive via `ResizeObserver`. Zero new deps.
4. **feat(web): Activity Monitor tab with primary charts** — three primary cards (memory vs running agents, CPU load with optional system overlay, queue depth as a stacked area). Toolbar with window selector (live / 1h / 24h / 7d), pause, system overlay, advanced toggles. localStorage persistence for all preferences.
5. **feat(web): diagnostic charts behind the 'advanced' toggle** — goroutines, Go heap (alloc vs inuse), system memory. Live-mode only (summary endpoint doesn't bucket these); window modes show an explanatory note card instead.

## Why hand-rolled SVG, not a chart library

Loomcycle's `web/` carries three runtime deps today (react, react-dom, react-router-dom). Adding `recharts` (~80 kB) or even `uplot` (~45 kB) is a meaningful philosophical shift, and once charting libs land they tend to metastasize (axes, tooltips, legends, theme glue). With six chart cards of uniform shape (time-on-X, one or two scalar series), a ~360-LOC custom component beats a library we'd have to theme against the dark palette. CSS uses existing palette variables — no new colours.

## What the operator sees

**Sampler off** → instructional empty state: "process sampler is off. To turn it on, set `LOOMCYCLE_METRICS_ENABLED=1` and restart loomcycle."

**Sampler on, idle** → toolbar + empty chart cards with "awaiting first sample…" overlay.

**Sampler on, under load** → live charts populate within 5 s. Memory vs running-agents card answers the headline correlation question (does memory grow with load, or leak?). Queue depth's stacked area surfaces semaphore backpressure at a glance.

**Window modes** → hits `/v1/_metrics/summary?period=1h|24h|7d`, repolling every 30 s. Charts re-key on mode switch, prior data dropped so we never render across a domain change.

## Test plan

- [x] `go test ./...` clean
- [x] `npm run build` clean (+1 new chart card module, ~16 kB JS / +3 kB CSS gzipped vs main)
- [x] `loomcycle --version` and `--config` startup behaviour unchanged
- [x] `TestHealthz` now asserts `metrics_enabled: false` in the no-sampler test wiring
- [ ] Manual: boot WITHOUT `LOOMCYCLE_METRICS_ENABLED` → visit `/ui/activity` → MetricsDisabledEmpty renders immediately (DevTools Network shows no `/v1/_metrics/*` request)
- [ ] Manual: boot with `LOOMCYCLE_METRICS_ENABLED=1`, run some agents, watch the three primary charts populate within 5 s
- [ ] Manual: pause → polling stops, last snapshot stays on screen; resume → polling resumes
- [ ] Manual: switch live → 24h → DevTools Network shows `/samples` polling stops, `/summary?period=24h` fires every 30 s
- [ ] Manual: enable `LOOMCYCLE_METRICS_COLLECT_SYSTEM=1` → system-overlay toggle becomes interactive, system CPU line appears on the CPU card, system-memory diagnostic card appears under advanced
- [ ] Manual: enable advanced → three diagnostic cards appear in live mode; switching to 1h shows the explanatory note card instead
- [ ] Manual: resize 1600 → 600 px → grid collapses 2 → 1 columns without overlapping the topbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)