### PR TITLE
fix(ci): build-ui uses npm ci so goreleaser releases from a clean tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PG_DSN := postgres://$(PG_USER):$(PG_PASSWORD)@127.0.0.1:$(PG_PORT)/$(PG_DATABAS
 help:
 	@echo "loomcycle dev targets:"
 	@echo "  build       — go build ./..."
-	@echo "  build-ui    — npm install + npm build for web/ (output → internal/webui/dist/)"
+	@echo "  build-ui    — npm ci + npm build for web/ (output → internal/webui/dist/)"
 	@echo "  build-all   — build-ui + build (produces a binary with the latest UI embedded)"
 	@echo "  test        — go test ./... (Postgres tests skip without LOOMCYCLE_TEST_PG_DSN)"
 	@echo "  test-pg     — go test ./... with LOOMCYCLE_TEST_PG_DSN set against the local fixture"
@@ -46,8 +46,13 @@ build-ui:
 	# the .gitkeep placeholder is restored so go:embed always has at
 	# least one matching file (a fresh checkout without npm-build still
 	# compiles Go).
+	#
+	# `npm ci` (not `npm install`) so the lock file is treated as
+	# authoritative AND is never mutated. The release.yml goreleaser
+	# job fails on a dirty working tree; `npm install` would touch
+	# web/package-lock.json on any silent drift and break the release.
 	rm -rf internal/webui/dist/*
-	cd web && npm install --silent && npm run build
+	cd web && npm ci --silent && npm run build
 	touch internal/webui/dist/.gitkeep
 
 build-all: build-ui build

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -22,6 +22,12 @@ This is the public roadmap. For decision history, regret notes, and per-version 
 
 **Tests:** ~25 new tests across Go (+10), TS (+7), Python (+5), plus 3 regression/refactor updates to existing tests. Full sweep clean.
 
+**Release artifacts:**
+
+- **Binary (goreleaser → Homebrew tap):** v0.8.23 tag — release.yml re-fired after the v0.8.23 initial-tag-attempt hit `git is in a dirty state` (Makefile's `npm install` mutated `web/package-lock.json` before goreleaser ran; fixed by switching to `npm ci`).
+- **TypeScript adapter (`@loomcycle/client@0.8.23`):** published to npm on the v0.8.23 tag.
+- **Python adapter (`loomcycle==0.7.0`):** **NOT** on PyPI as of v0.8.23. The PyPI Trusted Publisher needs configuration at pypi.org; until then the Python adapter ships from source via `pip install "git+https://github.com/denn-gubsky/loomcycle@python-v0.7.0#subdirectory=adapters/python"`. The `python-v0.7.0` tag still exists for source installs even though the PyPI publish failed. Operator action: configure Trusted Publisher at pypi.org/manage/account/publishing/ then re-run the failed `Publish loomcycle to PyPI` job from the Actions tab.
+
 **Out of scope:** Exposing `Memory` / `Channel` / `Evaluation` / `Context` on HTTP/gRPC/adapters (they have MCP meta-tools today; same gap AgentDef had before this PR). Convenience wrappers (`forkSkillDef`, `promoteSkillDef`) on the adapters — single op-discriminated method per tool keeps the wire surface minimal.
 
 ## v0.8.22 — earlier


### PR DESCRIPTION
## Summary

The v0.8.23 binary release failed with goreleaser's `git is in a dirty state` check. Root cause: `make build-ui` ran `npm install --silent`, which mutated `web/package-lock.json` even on a clean checkout (npm's silent drift). goreleaser correctly refused to release because the binary would carry uncommitted changes.

**Fix:** `Makefile:50` now uses `npm ci` instead of `npm install`. `npm ci` treats the lock file as authoritative and refuses to mutate it; stale-lock-vs-package.json drift produces a loud non-zero exit, which is the right loud-fail behaviour for a release pipeline.

Also updates `docs/PLAN.md` with the v0.8.23 release-artifact status:
- Binary release: pending — will succeed after merge + retag of v0.8.23.
- TS npm `@loomcycle/client@0.8.23`: shipped on the first tag-push attempt.
- PyPI `loomcycle==0.7.0`: failed (Trusted Publisher unconfigured); Python adapter ships from source via the `python-v0.7.0` tag until the publisher is configured.

## After merge

1. Delete the existing `v0.8.23` tag locally + on remote.
2. Re-tag `v0.8.23` on the new merge commit.
3. Push → `release.yml` fires cleanly; `publish-ts-adapter.yml` no-ops (npm refuses re-publish of 0.8.23, which is the intended idempotent-re-tag posture).
4. Homebrew tap auto-bumps.

The `python-v0.7.0` tag stays in place for source installs; PyPI publish is deferred per operator decision.

## Test plan

- [x] `make build-ui` locally on a clean tree leaves `web/package-lock.json` untouched
- [x] `go build ./... && go test ./...` clean
- [ ] After merge: retag v0.8.23, watch release.yml succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)