### PR TITLE
fix(ci): gofmt clean across v0.9.0 + max_iterations files

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -54,13 +54,13 @@ import (
 // returns these instead of config.AgentDef directly so the
 // dependency arrow stays config → agents (config converts on merge).
 type Agent struct {
-	Name             string
-	Description      string
-	Provider         string
-	Model            string
-	Tier             string
-	Effort           string
-	MaxTokens        int
+	Name        string
+	Description string
+	Provider    string
+	Model       string
+	Tier        string
+	Effort      string
+	MaxTokens   int
 	// MaxIterations caps the agent loop at this many provider calls
 	// before terminating with stop_reason="max_iterations". 0 means
 	// use the loop default (16). Set higher for discovery-style

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1841,7 +1841,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Segments:        req.Segments,
 		OnEvent:         emit,
 		OnHeartbeat:     heartbeat,
-		MaxTokens:       agentDef.MaxTokens, // 0 → driver default
+		MaxTokens:       agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:   agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
@@ -2145,7 +2145,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		PriorMessages:   priorMessages,
 		OnEvent:         emit,
 		OnHeartbeat:     heartbeat,
-		MaxTokens:       agentDef.MaxTokens, // 0 → driver default
+		MaxTokens:       agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:   agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
@@ -2693,7 +2693,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		Segments:        segs,
 		OnEvent:         subEmit,
 		OnHeartbeat:     subHeartbeat,
-		MaxTokens:       def.MaxTokens, // 0 → driver default
+		MaxTokens:       def.MaxTokens,     // 0 → driver default
 		MaxIterations:   def.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),

--- a/internal/providers/gemini/embedder.go
+++ b/internal/providers/gemini/embedder.go
@@ -35,8 +35,9 @@ import (
 // with `:batchEmbedContents` action suffix.
 //
 // Known models + dimensions:
-//   text-embedding-004      → 768
-//   gemini-embedding-001    → 3072 (when released)
+//
+//	text-embedding-004      → 768
+//	gemini-embedding-001    → 3072 (when released)
 //
 // We don't ship a `dimensions` param; Gemini's API allows it on some
 // models but the matrix is small and the default is the typical

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -1897,9 +1897,9 @@ func testMemoryEmbedSearchTopK(t *testing.T, s store.Store) {
 		key string
 		vec []float32
 	}{
-		{"row1", floats32(1, 0, 0, 0)},                          // aligned with query
-		{"row2", floats32(0.7071, 0.7071, 0, 0)},                // 45° off
-		{"row3", floats32(0, 1, 0, 0)},                          // 90° off
+		{"row1", floats32(1, 0, 0, 0)},           // aligned with query
+		{"row2", floats32(0.7071, 0.7071, 0, 0)}, // 45° off
+		{"row3", floats32(0, 1, 0, 0)},           // 90° off
 	}
 	for _, r := range rows {
 		if err := s.MemorySet(ctx, store.MemoryScopeAgent, "qa", r.key, json.RawMessage(`"x"`), 0); err != nil {

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -582,11 +582,11 @@ func (a *AgentDef) bootstrapStatic(ctx context.Context, name string, static conf
 // mirrors the mutable subset of config.AgentDef — keeps the DB
 // layer config-agnostic.
 type mergedDef struct {
-	Provider         string                            `json:"provider,omitempty"`
-	Model            string                            `json:"model,omitempty"`
-	Tier             string                            `json:"tier,omitempty"`
-	Effort           string                            `json:"effort,omitempty"`
-	MaxTokens        int                               `json:"max_tokens,omitempty"`
+	Provider  string `json:"provider,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Tier      string `json:"tier,omitempty"`
+	Effort    string `json:"effort,omitempty"`
+	MaxTokens int    `json:"max_tokens,omitempty"`
 	// MaxIterations caps the loop at N provider calls before
 	// terminating with stop_reason="max_iterations". 0 = use the
 	// loop default (16). Set higher for discovery-style forks

--- a/internal/tools/builtin/grep.go
+++ b/internal/tools/builtin/grep.go
@@ -74,7 +74,7 @@ type grepInput struct {
 	Multiline       bool   `json:"multiline,omitempty"`
 	HeadLimit       int    `json:"head_limit,omitempty"`
 	After           int    `json:"-A,omitempty"`
-	Before           int    `json:"-B,omitempty"`
+	Before          int    `json:"-B,omitempty"`
 	Context         int    `json:"-C,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

CI on \`main\` failed after PR #167 merged with three files unformatted under \`gofmt\`. PR #168's merge bumped the count to six. This PR runs \`gofmt -w\` across the affected files. Pure whitespace; no behavioural changes.

## Affected files

| File | Came in via |
|---|---|
| \`internal/agents/loader.go\` | PR #168 |
| \`internal/api/http/server.go\` | PR #167 + PR #168 |
| \`internal/providers/gemini/embedder.go\` | PR #167 |
| \`internal/store/storetest/contract.go\` | PR #167 |
| \`internal/tools/builtin/agentdef.go\` | PR #168 (propagation work) |
| \`internal/tools/builtin/grep.go\` | v0.8.24 leftover |

## Why now

Required before tagging v0.9.0 — the goreleaser workflow runs \`make ci-checks\` which includes the gofmt gate. Without this fix the release build refuses to start.

## Test

- \`gofmt -l .\` clean.
- \`go build ./...\` clean.
- \`go vet ./...\` clean.
- \`go test ./...\` clean (no behavioural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)