### PR TITLE
chore(ts): bump @loomcycle/client to 0.9.0 for v0.9.0 release

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.8.20",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.8.20",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.8.23",
-  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 29 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin, interruption resolve, hook management, and v0.8.22 substrate admin (agentDef + skillDef).",
+  "version": "0.9.0",
+  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 29 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, and v0.8.22 substrate admin (agentDef + skillDef).",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

v0.9.0 npm-publish workflow (run [26223670781](https://github.com/denn-gubsky/loomcycle/actions/runs/26223670781)) failed:

\`\`\`
##[error]package.json version (0.8.23) does not match tag (0.9.0)
Bump adapters/ts/package.json to 0.9.0 and re-tag, or fix the tag.
\`\`\`

This PR bumps the TS adapter to 0.9.0 + refreshes the description to mention the v0.9.0 Vector Memory admin endpoints the adapter forwards.

## Plan after merge

1. Merge this PR
2. Delete the existing \`v0.9.0\` tag (npm publish failed; the release was incomplete anyway)
3. Re-tag \`v0.9.0\` at the new main tip
4. Push the tag — re-fires goreleaser + npm publish; both should succeed

## Test

- \`npm install\` regenerates lockfile to 0.9.0
- \`npm run build\` clean (TypeScript compiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)