### PR TITLE
feat(transcript): persist + render system_prompt + user_input as first cycle

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2387,12 +2387,20 @@ type transcriptResponse struct {
 // transcriptEvent is one event row, with payload re-decoded into a typed
 // providers.Event so the caller doesn't have to round-trip through
 // json.RawMessage. ts is unix-nanos so it round-trips losslessly.
+//
+// v0.9.x: for event types whose payload doesn't map cleanly onto
+// providers.Event (user_input carries []loop.PromptSegment;
+// system_prompt carries {system_prompt, agent_def_id, skill_def_ids}),
+// the raw JSON is surfaced via the Payload sidecar so adapters /
+// Web UI parse it without inflating providers.Event with
+// transcript-only fields. Empty for the streaming event types.
 type transcriptEvent struct {
-	Seq   int64           `json:"seq"`
-	RunID string          `json:"run_id"`
-	TsNs  int64           `json:"ts_ns"`
-	Type  string          `json:"type"`
-	Event providers.Event `json:"event"`
+	Seq     int64           `json:"seq"`
+	RunID   string          `json:"run_id"`
+	TsNs    int64           `json:"ts_ns"`
+	Type    string          `json:"type"`
+	Event   providers.Event `json:"event"`
+	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
 func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
@@ -2429,10 +2437,21 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 			TsNs:  ev.Timestamp.UnixNano(),
 			Type:  ev.Type,
 		}
-		// Decode payload back to a typed Event. If it fails (corrupt row),
-		// surface a minimal record so the rest of the transcript still ships.
-		if err := json.Unmarshal(ev.Payload, &te.Event); err != nil {
+		// v0.9.x: payload-only event types (no fields on providers.Event)
+		// — surface the raw JSON via the Payload sidecar so the Web UI
+		// and adapter consumers can parse it directly. The Event field
+		// stays minimal (just the Type) for these.
+		switch ev.Type {
+		case "user_input", "system_prompt":
 			te.Event = providers.Event{Type: providers.EventType(ev.Type)}
+			te.Payload = append(json.RawMessage(nil), ev.Payload...)
+		default:
+			// Decode payload back to a typed Event. If it fails (corrupt
+			// row), surface a minimal record so the rest of the
+			// transcript still ships.
+			if err := json.Unmarshal(ev.Payload, &te.Event); err != nil {
+				te.Event = providers.Event{Type: providers.EventType(ev.Type)}
+			}
 		}
 		resp.Events = append(resp.Events, te)
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -540,6 +540,21 @@ func (s *Server) skillDefPolicyForAgent(agentDef config.AgentDef) tools.SkillDef
 	return tools.SkillDefPolicyValue{Scopes: agentDef.SkillDefScopes}
 }
 
+// runPromptProvenance captures the per-run metadata that fed into
+// the resolved system prompt. Used as the payload sidecar on the
+// v0.9.x `system_prompt` event so an operator inspecting the run
+// can see WHICH AgentDef row + WHICH SkillDef rows produced the
+// instructions the agent received — not just the merged text.
+//
+// SkillDefIDs maps the agent's declared skill names to the def_id
+// of the DB-active SkillDef row that supplied the skill body for
+// this specific run. Skills falling back to the static SKILL.md
+// body (no DB-active row) are NOT in this map — only DB overrides.
+// Empty map (or absent field on the wire) = pure static prompt.
+type runPromptProvenance struct {
+	SkillDefIDs map[string]string `json:"skill_def_ids,omitempty"`
+}
+
 // resolveSkillBodiesForRun rebuilds agentDef.SystemPrompt for a
 // single run with v0.8.22 SkillDef per-run resolution. For each
 // skill named in agentDef.Skills, the active SkillDef row's body
@@ -554,13 +569,19 @@ func (s *Server) skillDefPolicyForAgent(agentDef config.AgentDef) tools.SkillDef
 // Returns agentDef unchanged on any error (logged) — the run
 // continues with the static baked prompt rather than fail. The
 // agent loop is unchanged; only SystemPrompt may differ.
-func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.AgentDef) config.AgentDef {
+//
+// Second return value is the per-run provenance (skillName → active
+// SkillDef def_id) for callers emitting the v0.9.x `system_prompt`
+// transcript event. Empty when no DB-active rows were used.
+func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.AgentDef) (config.AgentDef, runPromptProvenance) {
+	var prov runPromptProvenance
 	if len(agentDef.Skills) == 0 || s.store == nil {
-		return agentDef
+		return agentDef, prov
 	}
 	// Fast pre-check: any DB-active row for any skill name?
 	anyActive := false
 	activeBodies := make(map[string]string, len(agentDef.Skills))
+	activeDefIDs := make(map[string]string, len(agentDef.Skills))
 	for _, skillName := range agentDef.Skills {
 		row, err := s.store.SkillDefGetActive(ctx, skillName)
 		if err != nil {
@@ -585,11 +606,13 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 			continue
 		}
 		activeBodies[skillName] = def.Body
+		activeDefIDs[skillName] = row.DefID
 		anyActive = true
 	}
 	if !anyActive {
-		return agentDef
+		return agentDef, prov
 	}
+	prov.SkillDefIDs = activeDefIDs
 	// Slow path: rebuild SystemPrompt from base + per-skill body.
 	rebuilt := agentDef
 	rebuilt.SystemPrompt = agentDef.SystemPromptBase
@@ -611,7 +634,46 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 		}
 		rebuilt.SystemPrompt += body
 	}
-	return rebuilt
+	return rebuilt, prov
+}
+
+// emitSystemPromptEvent persists the resolved system prompt + its
+// provenance as a `system_prompt` transcript event so an operator
+// inspecting the run can see what instructions the agent received —
+// not just the model's subsequent output. Mirror of the existing
+// `user_input` emission (which captures the caller's segments).
+// Emitted ONCE per run, right after the user_input event so the two
+// "what the agent saw" cards sort naturally at the top of the
+// transcript.
+//
+// No-op when the store isn't configured, runID is empty, or the
+// agent has no system prompt. Store errors are logged + swallowed
+// (same posture as user_input); never blocks the run.
+func (s *Server) emitSystemPromptEvent(
+	ctx context.Context,
+	runID string,
+	systemPrompt string,
+	agentDefID string,
+	prov runPromptProvenance,
+) {
+	if s.store == nil || runID == "" || systemPrompt == "" {
+		return
+	}
+	payload := map[string]any{"system_prompt": systemPrompt}
+	if agentDefID != "" {
+		payload["agent_def_id"] = agentDefID
+	}
+	if len(prov.SkillDefIDs) > 0 {
+		payload["skill_def_ids"] = prov.SkillDefIDs
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("store: marshal system_prompt event for run %s: %v", runID, err)
+		return
+	}
+	if err := s.store.AppendEvent(ctx, runID, "system_prompt", b); err != nil {
+		log.Printf("store: AppendEvent(system_prompt) failed for run %s: %v", runID, err)
+	}
 }
 
 // skillDefOverlay mirrors internal/tools/builtin.skillDefOverlay.
@@ -950,7 +1012,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies
 	// when any of the agent's skills has a DB-active row. No-op
 	// fast path when none do.
-	agentDef = s.resolveSkillBodiesForRun(ctx, agentDef)
+	agentDef, promptProv := s.resolveSkillBodiesForRun(ctx, agentDef)
 	if agentDef.SystemPrompt != "" {
 		segments = append([]loop.PromptSegment{{
 			Role: "system",
@@ -1005,6 +1067,13 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 			}
 		}
 	}
+	// v0.9.x: persist the resolved system prompt + provenance so the
+	// transcript carries WHAT the agent received, not just WHAT the
+	// model emitted. The companion Web UI rendering surfaces this as
+	// the first card on /ui run views. agent_def_id is empty here —
+	// RunInput doesn't pin a def, so the field stays unset (operators
+	// inspecting can look up the run row's AgentDefID column directly).
+	s.emitSystemPromptEvent(ctx, runID, agentDef.SystemPrompt, "", promptProv)
 
 	// ---- Caller registration callback ----
 	if cb.OnRegistered != nil {
@@ -1671,7 +1740,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	dispatcher := s.newDispatcher(allowedTools)
 
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies.
-	agentDef = s.resolveSkillBodiesForRun(r.Context(), agentDef)
+	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), agentDef)
 	// Optional system prompt from agent def.
 	if agentDef.SystemPrompt != "" {
 		req.Segments = append([]loop.PromptSegment{{
@@ -1756,6 +1825,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	// v0.9.x: persist the resolved system prompt + provenance so the
+	// Web UI surfaces it as a card on the run timeline. Mirrors the
+	// emission in RunOnce + handleMessages + runSubAgent.
+	s.emitSystemPromptEvent(r.Context(), runID, agentDef.SystemPrompt, "", promptProv)
 
 	stream, ok := newSSE(w)
 	if !ok {
@@ -2016,7 +2089,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies
 	// when any of the agent's skills has a DB-active row. No-op
 	// fast path when none do.
-	agentDef = s.resolveSkillBodiesForRun(r.Context(), agentDef)
+	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), agentDef)
 	if agentDef.SystemPrompt != "" {
 		segments = append([]loop.PromptSegment{{
 			Role: "system",
@@ -2086,6 +2159,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			log.Printf("store: AppendEvent(user_input) failed: %v", err)
 		}
 	}
+	// v0.9.x: also persist the resolved system prompt + provenance.
+	// On a continuation run, AgentDef could have been promoted to a
+	// new version between turns — emit on EVERY run so each cycle
+	// records the instructions the agent saw at THAT moment.
+	s.emitSystemPromptEvent(r.Context(), run.ID, agentDef.SystemPrompt, "", promptProv)
 
 	stream, ok := newSSE(w)
 	if !ok {
@@ -2574,7 +2652,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// sub-agents would silently keep the static baked body and
 	// SkillDef promotions never take effect for agents only spawned
 	// as sub-agents.
-	def = s.resolveSkillBodiesForRun(ctx, def)
+	def, promptProv := s.resolveSkillBodiesForRun(ctx, def)
 	// Build segments: agent's system_prompt (with cache_control) + the
 	// caller-supplied prompt as the first user message. Mirrors the
 	// shape of /v1/runs.
@@ -2624,6 +2702,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 			}
 		}
 	}
+	// v0.9.x: also persist the resolved system prompt + provenance.
+	// On sub-runs we have the explicit def_id (parameter), so the
+	// event payload includes agent_def_id — unique to this path.
+	s.emitSystemPromptEvent(ctx, subRunID, def.SystemPrompt, defID, promptProv)
 
 	// Sub-emit records to the sub's transcript only — the parent's SSE
 	// stream is fwd=no-op so sub events don't bleed into the parent's

--- a/internal/api/http/skilldef_resolution_test.go
+++ b/internal/api/http/skilldef_resolution_test.go
@@ -23,7 +23,7 @@ func TestResolveSkillBodiesForRun_NoSkillsIsNoop(t *testing.T) {
 
 	srv := &Server{store: s}
 	def := config.AgentDef{SystemPrompt: "base prompt", SystemPromptBase: "base prompt"}
-	got := srv.resolveSkillBodiesForRun(context.Background(), def)
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), def)
 	if got.SystemPrompt != "base prompt" {
 		t.Errorf("got %q, want unchanged base prompt", got.SystemPrompt)
 	}
@@ -46,7 +46,7 @@ func TestResolveSkillBodiesForRun_NoActiveRowsIsNoop(t *testing.T) {
 		SystemPrompt:     baked,
 		SystemPromptBase: "base prompt",
 	}
-	got := srv.resolveSkillBodiesForRun(context.Background(), def)
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), def)
 	if got.SystemPrompt != baked {
 		t.Errorf("no DB-active row should leave baked prompt unchanged; got %q", got.SystemPrompt)
 	}
@@ -85,7 +85,7 @@ func TestResolveSkillBodiesForRun_DBActiveOverrides(t *testing.T) {
 		SystemPrompt:     "base prompt\n\n---\n\nSTATIC BODY",
 		SystemPromptBase: "base prompt",
 	}
-	got := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
 	if !strings.Contains(got.SystemPrompt, "DB BODY") {
 		t.Errorf("DB body should be substituted into SystemPrompt; got %q", got.SystemPrompt)
 	}
@@ -130,7 +130,7 @@ func TestResolveSkillBodiesForRun_StaleRowIsIgnored(t *testing.T) {
 		SystemPrompt:     baked,
 		SystemPromptBase: "base prompt",
 	}
-	got := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
 	if got.SystemPrompt != baked {
 		t.Errorf("empty-body DB row should NOT trigger rebuild; got %q", got.SystemPrompt)
 	}
@@ -169,7 +169,7 @@ func TestResolveSkillBodiesForRun_OneSkillResolvesEvenIfAnotherIsMissing(t *test
 		SystemPrompt:     "base prompt\n\n---\n\nstatic A\n\n---\n\nstatic B",
 		SystemPromptBase: "base prompt",
 	}
-	got := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
 	if !strings.Contains(got.SystemPrompt, "DB BODY A") {
 		t.Errorf("DB body for skill-a should be substituted; got %q", got.SystemPrompt)
 	}

--- a/internal/api/http/system_prompt_event_test.go
+++ b/internal/api/http/system_prompt_event_test.go
@@ -181,6 +181,82 @@ func TestEmitSystemPromptEvent_NoOpOnEmptyInputs(t *testing.T) {
 	srv2.emitSystemPromptEvent(context.Background(), "run_test", "", "def_1", runPromptProvenance{})
 }
 
+// Pin the contract that the sub-agent path's `agent_def_id` field
+// actually lands in the persisted event payload. The two HTTP-level
+// tests above don't exercise the sub-agent code path (which would
+// require a much larger fixture — spawning the Agent tool against a
+// fake parent run). A unit-level call of `emitSystemPromptEvent` is
+// sufficient because the helper is the single source of truth for
+// the payload shape — any future refactor that drops `agentDefID`
+// at the runSubAgent emission site would leave THIS test passing
+// but the surface broken. So this test pins the helper contract;
+// the HTTP-level test pins the integration. Both are needed.
+func TestEmitSystemPromptEvent_AgentDefIDPersistedInPayload(t *testing.T) {
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// Create a session + run row so AppendEvent's FK is satisfied.
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, "t1", "test-agent", "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID:    "a_sub_test",
+		AgentDefID: "def_pinned_xyz", // mirrors the sub-agent pin
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{store: st}
+	srv.emitSystemPromptEvent(
+		ctx,
+		run.ID,
+		"You are a sub-agent fork.",
+		"def_pinned_xyz", // ← the sub-agent path's agent_def_id parameter
+		runPromptProvenance{SkillDefIDs: map[string]string{"voice": "sdf_abc123"}},
+	)
+
+	// Read the events back + assert the system_prompt row carries both
+	// the agent_def_id AND the skill_def_ids in its JSON payload.
+	transcript, err := st.GetTranscript(ctx, sess.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found *store.Event
+	for i := range transcript {
+		if transcript[i].Type == "system_prompt" {
+			found = &transcript[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("no system_prompt event in transcript; got types: %v", typeList(transcript))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(found.Payload, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if got := payload["system_prompt"]; got != "You are a sub-agent fork." {
+		t.Errorf("system_prompt mismatch: %v", got)
+	}
+	if got := payload["agent_def_id"]; got != "def_pinned_xyz" {
+		t.Errorf("agent_def_id mismatch: got %v, want def_pinned_xyz", got)
+	}
+	skills, ok := payload["skill_def_ids"].(map[string]any)
+	if !ok {
+		t.Fatalf("skill_def_ids missing or wrong shape: %v", payload["skill_def_ids"])
+	}
+	if skills["voice"] != "sdf_abc123" {
+		t.Errorf("skill_def_ids[voice] = %v, want sdf_abc123", skills["voice"])
+	}
+}
+
 // Helper: extract event types into a flat slice for error messages.
 func typeList(events []store.Event) []string {
 	out := make([]string, len(events))

--- a/internal/api/http/system_prompt_event_test.go
+++ b/internal/api/http/system_prompt_event_test.go
@@ -1,0 +1,191 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// v0.9.x — system_prompt transcript event tests. Pin the contract
+// the Web UI relies on:
+//
+//   - POST /v1/runs persists a `system_prompt` event when the agent
+//     has a SystemPrompt, alongside the existing `user_input`.
+//   - Agents WITHOUT a SystemPrompt emit NO system_prompt event
+//     (no empty payload pollution; the omitempty contract).
+//
+// Continuation (handleMessages) and sub-agent spawn paths are
+// covered by the in-process behavioural contract (same helper
+// emitSystemPromptEvent) — extending the broader test suite would
+// require wiring a real sub-agent path which is much larger and
+// out of scope for this change.
+
+func TestSystemPromptEvent_PersistedOnRunsWhenAgentHasPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"default": {
+				Model:        "stub-model",
+				SystemPrompt: "You are a careful researcher. Output JSON only.",
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 5, OutputTokens: 1}},
+	}}
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	sessionID := extractSessionID(string(body))
+	if sessionID == "" {
+		t.Fatalf("no session_id in SSE stream:\n%s", body)
+	}
+
+	transcript, err := st.GetTranscript(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the system_prompt event.
+	var sysIdx, userIdx = -1, -1
+	for i, ev := range transcript {
+		switch ev.Type {
+		case "system_prompt":
+			sysIdx = i
+		case "user_input":
+			userIdx = i
+		}
+	}
+	if sysIdx < 0 {
+		t.Fatalf("no system_prompt event in transcript; got types: %v", typeList(transcript))
+	}
+	if userIdx < 0 {
+		t.Fatalf("no user_input event in transcript; got types: %v", typeList(transcript))
+	}
+	// user_input must come before system_prompt because the
+	// existing RunOnce emits user_input first then system_prompt
+	// (mirrors the existing emission ordering in server.go).
+	if userIdx > sysIdx {
+		t.Errorf("expected user_input before system_prompt; got %d > %d", userIdx, sysIdx)
+	}
+
+	// Payload assertions.
+	var payload map[string]any
+	if err := json.Unmarshal(transcript[sysIdx].Payload, &payload); err != nil {
+		t.Fatalf("payload decode: %v", err)
+	}
+	if payload["system_prompt"] != "You are a careful researcher. Output JSON only." {
+		t.Errorf("system_prompt mismatch: %v", payload["system_prompt"])
+	}
+	// agent_def_id is empty for yaml-only agents (no DB row).
+	if v, ok := payload["agent_def_id"]; ok {
+		t.Errorf("agent_def_id should be omitted for yaml-only agent, got %v", v)
+	}
+	// No skill_def_ids when the agent has no Skills.
+	if v, ok := payload["skill_def_ids"]; ok {
+		t.Errorf("skill_def_ids should be omitted when agent has no Skills, got %v", v)
+	}
+}
+
+func TestSystemPromptEvent_NotEmittedWhenAgentHasNoPrompt(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			// SystemPrompt explicitly empty.
+			"default": {Model: "stub-model"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 5, OutputTokens: 1}},
+	}}
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: provider}, nil, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	sessionID := extractSessionID(string(body))
+
+	transcript, err := st.GetTranscript(context.Background(), sessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range transcript {
+		if ev.Type == "system_prompt" {
+			t.Errorf("agent with empty SystemPrompt should not emit system_prompt event; got %s", ev.Payload)
+		}
+	}
+}
+
+// Verify the helper handles nil store + empty runID gracefully —
+// this is the test-without-a-store path RunOnce uses.
+func TestEmitSystemPromptEvent_NoOpOnEmptyInputs(t *testing.T) {
+	// nil store.
+	srv := &Server{}
+	srv.emitSystemPromptEvent(context.Background(), "run_test", "you are X", "def_1", runPromptProvenance{})
+	// no panic = pass.
+
+	// store set but empty runID.
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv2 := &Server{store: st}
+	srv2.emitSystemPromptEvent(context.Background(), "", "you are X", "def_1", runPromptProvenance{})
+
+	// store set + runID set, but no system prompt.
+	srv2.emitSystemPromptEvent(context.Background(), "run_test", "", "def_1", runPromptProvenance{})
+}
+
+// Helper: extract event types into a flat slice for error messages.
+func typeList(events []store.Event) []string {
+	out := make([]string, len(events))
+	for i, ev := range events {
+		out[i] = ev.Type
+	}
+	return out
+}

--- a/internal/help/builtin/loomcycle.md
+++ b/internal/help/builtin/loomcycle.md
@@ -76,6 +76,27 @@ Cross-cutting topics that explain how these compose:
 - `help(topic="pause-resume-snapshot")` — runtime quiesce + portable
   JSON snapshot (operator-driven; agents don't call these directly)
 
+## Your transcript records what YOU received
+
+v0.9.x: every run persists two transcript events BEFORE the loop's
+first model call:
+
+- `user_input` — the caller's `segments` from `POST /v1/runs` /
+  `POST /v1/sessions/{id}/messages` (or from `Agent.spawn` on a
+  sub-run). Surfaced in the Web UI as the **"input · user"** card.
+- `system_prompt` — the resolved system prompt: the
+  AgentDef-derived template + AgentDef overlay (when forked) +
+  SkillDef bodies (when DB-active rows override the static
+  SKILL.md). Payload carries provenance — `agent_def_id` (when
+  pinned) + `skill_def_ids` (the active SkillDef row id per
+  resolved skill). Surfaced as the **"input · system"** card.
+
+Operators inspecting a run see exactly what instructions you saw
+at THAT moment, not just what the AgentDef template says NOW (the
+template may have been forked + promoted between runs). If an
+agent's behaviour drifts after a SkillDef promote, comparing two
+runs' `system_prompt` events shows the diff directly.
+
 ## Discovering what you have
 
 Three Context ops are your map:

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -104,18 +104,51 @@ export interface EventPayload {
   retry?: { provider?: string; attempt?: number; wait_ms?: number; reason?: string };
 }
 
+// v0.9.x — payloads for event types whose shape doesn't fit
+// providers.Event (and is carried via the `payload` sidecar on
+// TranscriptEvent rather than `event`).
+
+/** UserInputPayload mirrors the JSON of `[]loop.PromptSegment` —
+ *  what the caller supplied as `segments` on POST /v1/runs +
+ *  /v1/sessions/{id}/messages. Surfaced as the run's "user input"
+ *  card in the Web UI. */
+export interface UserInputPayload {
+  role: string; // "system" | "user"
+  content: Array<{ type: string; text?: string; cacheable?: boolean }>;
+}
+
+/** SystemPromptPayload mirrors the v0.9.x system_prompt event
+ *  payload — the resolved system prompt + provenance metadata so
+ *  operators can see WHICH AgentDef + WHICH SkillDef rows fed in. */
+export interface SystemPromptPayload {
+  system_prompt: string;
+  /** Empty for yaml-only agents (no AgentDef row). Pinned for
+   *  sub-runs spawned via the Agent tool with a def_id. */
+  agent_def_id?: string;
+  /** skillName → active SkillDef def_id. Only present for skills
+   *  whose DB-active row supplied the body; static-fallback skills
+   *  are absent. */
+  skill_def_ids?: Record<string, string>;
+}
+
 // TranscriptEvent is one persisted row from
 // /v1/sessions/{id}/transcript. The server wraps each providers.Event
 // in {seq, run_id, ts_ns, type, event:{...}} — the type field at the
 // top level mirrors event.type so consumers can filter without
 // digging into the payload, but the actual content lives under
 // `event`.
+//
+// v0.9.x: for event types whose payload doesn't fit providers.Event
+// (`user_input`, `system_prompt`), the server surfaces the raw JSON
+// via the optional `payload` field. Streaming event types
+// (text/tool_call/tool_result/done/...) leave `payload` undefined.
 export interface TranscriptEvent {
   seq: number;
   run_id: string;
   ts_ns: number;
   type: string;
   event: EventPayload;
+  payload?: UserInputPayload[] | SystemPromptPayload | unknown;
 }
 
 export interface TranscriptResponse {

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Agent, EventPayload, TranscriptEvent, cancelAgent, getAgent, getTranscript } from "../api";
+import {
+  Agent,
+  EventPayload,
+  SystemPromptPayload,
+  TranscriptEvent,
+  UserInputPayload,
+  cancelAgent,
+  getAgent,
+  getTranscript,
+} from "../api";
 import Breadcrumbs, { type BreadcrumbAncestor } from "./Breadcrumbs";
 import TerminalTranscript from "./TerminalTranscript";
 import ViewToggle, { useViewMode } from "./ViewToggle";
@@ -201,7 +210,12 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
 // initial prompt, separately rendered in v0.8).
 function visible(ev: TranscriptEvent): boolean {
   const t = ev.event?.type ?? ev.type;
-  return t !== "started" && t !== "usage" && t !== "session" && t !== "agent" && t !== "user_input";
+  // v0.9.x: user_input + system_prompt are explicitly visible now —
+  // they're the "what the agent received" cards that anchor the
+  // transcript. Before v0.9.x user_input was filtered because there
+  // was no renderer for it; the new switch branches in detailFor /
+  // summaryFor / labelFor handle both.
+  return t !== "started" && t !== "usage" && t !== "session" && t !== "agent";
 }
 
 // AwaitedState is what the agent is currently blocked on (or
@@ -333,14 +347,14 @@ function EventCard({ row }: { row: TranscriptEvent }) {
   const ev = row.event ?? ({ type: row.type } as EventPayload);
   const kind = ev.type ?? row.type;
 
-  const summary = summaryFor(ev);
-  const detail = detailFor(ev);
+  const summary = summaryFor(ev, row);
+  const detail = detailFor(ev, row);
 
   const toggle = () => setOpen((v) => !v);
 
   const copyPayload = async (e: ReactMouseEvent) => {
     e.stopPropagation(); // don't collapse the card on copy click
-    const text = textPayloadFor(ev);
+    const text = textPayloadFor(ev, row);
     try {
       await navigator.clipboard.writeText(text);
       setCopyState("copied");
@@ -366,7 +380,7 @@ function EventCard({ row }: { row: TranscriptEvent }) {
     >
       <div className="ev-header">
         <span className="caret">{open ? "▼" : "▶"}</span>
-        <span className="kind">{labelFor(ev)}</span>
+        <span className="kind">{labelFor(ev, row)}</span>
         {!open && <span className="summary">{summary}</span>}
         {row.ts_ns > 0 && <span className="ts">{formatTime(row.ts_ns)}</span>}
       </div>
@@ -399,7 +413,7 @@ function EventCard({ row }: { row: TranscriptEvent }) {
 // expanded EventCard. Each branch mirrors detailFor's React render
 // but in flat text — keeps tool input/result/usage/etc. captured
 // without leaking React's escape-sequence artifacts.
-function textPayloadFor(ev: EventPayload): string {
+function textPayloadFor(ev: EventPayload, row?: TranscriptEvent): string {
   switch (ev.type) {
     case "text":
     case "thinking":
@@ -422,6 +436,20 @@ function textPayloadFor(ev: EventPayload): string {
       if (ev.usage) lines.push("", "usage:", JSON.stringify(ev.usage, null, 2));
       return lines.join("\n");
     }
+    case "user_input": {
+      const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
+      return JSON.stringify(segs, null, 2);
+    }
+    case "system_prompt": {
+      const p = row?.payload as SystemPromptPayload | undefined;
+      if (!p) return "";
+      const lines = [p.system_prompt ?? ""];
+      if (p.agent_def_id) lines.push("", `agent_def_id: ${p.agent_def_id}`);
+      if (p.skill_def_ids) {
+        lines.push("", `skill_def_ids: ${JSON.stringify(p.skill_def_ids, null, 2)}`);
+      }
+      return lines.join("\n");
+    }
     default:
       return JSON.stringify(ev, null, 2);
   }
@@ -430,7 +458,7 @@ function textPayloadFor(ev: EventPayload): string {
 // labelFor is the small uppercase tag on the left side of each card.
 // Tool calls embed the tool name to reduce the click-to-discover
 // distance for "what tool was this".
-function labelFor(ev: EventPayload): string {
+function labelFor(ev: EventPayload, _row?: TranscriptEvent): string {
   switch (ev.type) {
     case "tool_call":
       return `tool_call · ${ev.tool_use?.name ?? "?"}`;
@@ -440,6 +468,10 @@ function labelFor(ev: EventPayload): string {
       return `done · ${ev.stop_reason ?? "?"}`;
     case "retry":
       return `retry · ${ev.retry?.reason ?? ""}`.trim();
+    case "user_input":
+      return "input · user";
+    case "system_prompt":
+      return "input · system";
     default:
       return ev.type ?? "?";
   }
@@ -448,7 +480,7 @@ function labelFor(ev: EventPayload): string {
 // summaryFor is the one-line preview shown when the card is
 // collapsed. Keeps the transcript scannable; full content opens on
 // click.
-function summaryFor(ev: EventPayload): string {
+function summaryFor(ev: EventPayload, row?: TranscriptEvent): string {
   switch (ev.type) {
     case "text":
     case "thinking":
@@ -473,6 +505,20 @@ function summaryFor(ev: EventPayload): string {
             ev.usage.model ? ` · ${ev.usage.model}` : ""
           }`
         : "";
+    case "user_input": {
+      const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
+      // Surface the first user-role content text (typical: the
+      // initial prompt the caller sent). Skip system-role segments
+      // — those usually duplicate the AgentDef prompt that the
+      // separate system_prompt card already surfaces.
+      const userSeg = segs.find((s) => s.role === "user") ?? segs[0];
+      const text = userSeg?.content?.[0]?.text ?? "";
+      return firstLine(text, 200);
+    }
+    case "system_prompt": {
+      const p = row?.payload as SystemPromptPayload | undefined;
+      return firstLine(p?.system_prompt ?? "", 200);
+    }
     default:
       return "";
   }
@@ -481,7 +527,7 @@ function summaryFor(ev: EventPayload): string {
 // detailFor is the full content shown when the card is expanded.
 // Returns React nodes so each event type can format its payload how
 // it wants (raw text, pretty-printed JSON, etc).
-function detailFor(ev: EventPayload): ReactNode {
+function detailFor(ev: EventPayload, row?: TranscriptEvent): ReactNode {
   switch (ev.type) {
     case "text":
     case "thinking":
@@ -529,6 +575,47 @@ function detailFor(ev: EventPayload): ReactNode {
           )}
         </div>
       );
+    case "user_input": {
+      const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
+      return (
+        <div className="user-input-detail">
+          {segs.map((seg, i) => (
+            <div key={i} className="user-input-segment">
+              <div className="seg-role">role: <code>{seg.role}</code></div>
+              {seg.content?.map((c, j) => (
+                <pre key={j} className="full-text">{c.text ?? JSON.stringify(c)}</pre>
+              ))}
+            </div>
+          ))}
+        </div>
+      );
+    }
+    case "system_prompt": {
+      const p = row?.payload as SystemPromptPayload | undefined;
+      if (!p) {
+        return <pre className="full-text">(no payload)</pre>;
+      }
+      return (
+        <div className="system-prompt-detail">
+          <pre className="full-text">{p.system_prompt ?? ""}</pre>
+          {(p.agent_def_id || p.skill_def_ids) && (
+            <div className="system-prompt-provenance">
+              {p.agent_def_id && (
+                <div>
+                  <span>agent_def_id:</span> <code>{p.agent_def_id}</code>
+                </div>
+              )}
+              {p.skill_def_ids && Object.keys(p.skill_def_ids).length > 0 && (
+                <div>
+                  <span>skill_def_ids:</span>
+                  <pre className="full-text">{JSON.stringify(p.skill_def_ids, null, 2)}</pre>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
     default:
       return <pre className="full-text">{JSON.stringify(ev, null, 2)}</pre>;
   }

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useRef } from "react";
-import type { EventPayload, TranscriptEvent } from "../api";
+import type {
+  EventPayload,
+  SystemPromptPayload,
+  TranscriptEvent,
+  UserInputPayload,
+} from "../api";
 
 // TerminalTranscript renders the run's events as a chronological
 // flat stream of "[hh:mm:ss.SSS] event_type | payload" lines,
@@ -138,8 +143,27 @@ function formatLine(row: TranscriptEvent): FormattedLine {
     case "session":
     case "agent":
       return { key, ts, kind, cls: "tl-meta", payload: oneLine(JSON.stringify(ev)) };
-    case "user_input":
-      return { key, ts, kind, cls: "tl-text", payload: ev.text ?? "" };
+    case "user_input": {
+      // v0.9.x: user_input's payload lives on the sidecar (the
+      // raw segments JSON) — `ev.text` is empty because the event
+      // doesn't fit providers.Event. Show the first user-role
+      // segment's text as a one-liner; expanded view lives in
+      // the panels (AgentDetailPane).
+      const segs = (row.payload as UserInputPayload[] | undefined) ?? [];
+      const userSeg = segs.find((s) => s.role === "user") ?? segs[0];
+      const text = userSeg?.content?.[0]?.text ?? "";
+      return { key, ts, kind, cls: "tl-text", payload: oneLine(text) };
+    }
+    case "system_prompt": {
+      // v0.9.x: same sidecar pattern as user_input. Surface the
+      // first line of the resolved prompt + an agent_def_id chip
+      // when present so operators eyeballing the terminal stream
+      // can correlate two runs' prompt versions at a glance.
+      const p = row.payload as SystemPromptPayload | undefined;
+      const head = p?.system_prompt ?? "";
+      const tail = p?.agent_def_id ? ` [${p.agent_def_id}]` : "";
+      return { key, ts, kind, cls: "tl-text", payload: oneLine(head) + tail };
+    }
     default:
       return { key, ts, kind, cls: "tl-other", payload: oneLine(JSON.stringify(ev)) };
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -715,6 +715,42 @@ pre {
 .ev-error .kind { color: var(--failed); }
 .ev-retry { border-left-color: var(--running); }
 .ev-done { border-left-color: var(--fg-soft); }
+/* v0.9.x — the "what the agent received" cards. Distinguish them
+   from model output (which uses cool blues / greens) so operators
+   eye-track to the run's inputs at a glance. Warm gold for the
+   system prompt; muted teal for the user input. */
+.ev-system_prompt { border-left-color: #d4a056; background: rgba(212, 160, 86, 0.04); }
+.ev-system_prompt .kind { color: #d4a056; }
+.ev-user_input { border-left-color: #5fa9a3; background: rgba(95, 169, 163, 0.04); }
+.ev-user_input .kind { color: #5fa9a3; }
+.user-input-segment { margin-bottom: 12px; }
+.user-input-segment:last-child { margin-bottom: 0; }
+.user-input-segment .seg-role {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-soft);
+  margin-bottom: 4px;
+}
+.user-input-segment .seg-role code { color: var(--fg); }
+.system-prompt-provenance {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.system-prompt-provenance span {
+  font-family: var(--mono);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.system-prompt-provenance code {
+  font-family: var(--mono);
+  color: var(--fg);
+}
 
 /* v0.8.0 nav tabs (top bar between brand and user picker). */
 /* Topbar nav rendered as proper tabs. NavLink from react-router-dom


### PR DESCRIPTION
## Summary

Surfaces "what the agent actually received" as the first two cards on every run timeline in the Web UI. Closes a debugging gap: today operators see everything FROM the model (text, thinking, tool_use, tool_result, done) but the **prompts the agent received** — both the caller's segments AND the AgentDef-resolved system prompt — were invisible after the run.

## Before / after

Before — `/ui/runs/...` opens with the model's first text frame; no record of what the agent was actually asked to do.

After — two cards at the top:

- **"input · system"** (warm gold) — the resolved system prompt after AgentDef overlay + SkillDef bodies merged in. Expandable to show `<pre>` of the prompt + a provenance footer with `agent_def_id` (when pinned) + `skill_def_ids` (active SkillDef rows per skill name).
- **"input · user"** (muted teal) — the caller's `segments` from `POST /v1/runs`. Expandable to per-segment role+content blocks.

Then the existing model timeline (started → text → tool_call → tool_result → done) carries on as before.

## 3 commits

1. **`feat(api): persist system_prompt event with provenance per run`** — adds the `system_prompt` event emission at all 4 run-creation sites (RunOnce, handleRuns, handleMessages, runSubAgent). Each emits right after the existing `user_input` event. `resolveSkillBodiesForRun` signature changes to return `(agentDef, provenance)` carrying `skillName → active SkillDef def_id` for skills whose DB-active row supplied the body. 3 regression tests (1 verified genuine by reverting the handleRuns emission → fails with `no system_prompt event in transcript`).
2. **`feat(ui): render user_input + system_prompt as the run's first cards`** — wire side: `transcriptEvent.payload` JSON sidecar for event types whose payload doesn't fit `providers.Event` (keeps the streaming event shape clean). TS adapter side: new `UserInputPayload` + `SystemPromptPayload` interfaces. AgentDetailPane: 4 switch helpers extended (labelFor / summaryFor / detailFor / textPayloadFor); `visible()` un-filters `user_input`; new CSS for the two card variants + provenance footer.
3. **`docs(context.help): mention transcript prompt visibility`** — bundled loomcycle help topic gains a paragraph explaining the two new event types so agents calling `{"op":"help","topic":"loomcycle"}` know their own behaviour can be reconstructed from the transcript.

## Provenance payload shape

```jsonc
// system_prompt event payload
{
  "system_prompt": "<resolved text>",
  "agent_def_id": "def_abc",      // omitempty (sub-runs pin via the Agent tool's def_id param)
  "skill_def_ids": {              // omitempty (only active rows)
    "voice-applier": "sdf_xyz",
    "format-output": "sdf_def"
  }
}
```

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/http/ -run TestSystemPromptEvent` — 3 cases pass (happy path, no-prompt-no-event, helper no-op)
- [x] Regression-test verified genuine: with handleRuns emission removed, `TestSystemPromptEvent_PersistedOnRunsWhenAgentHasPrompt` fails with the expected diagnostic
- [x] `go test ./...` — full repo clean
- [x] `npm run build` (TS + Vite) — clean
- [ ] Live operator check: run an agent through `/v1/runs`, GET the transcript, assert `system_prompt` event present + payload shape correct; open `/ui` and confirm the two cards anchor the run timeline
- [ ] Live operator check: fork the AgentDef + promote, kick off a new run, assert the new `agent_def_id` shows in the system_prompt event for the new run

## Wire shape

`transcriptEvent` (the `/v1/sessions/{id}/transcript` row shape) gains an optional `payload` field. Streaming event types leave it undefined; `user_input` + `system_prompt` populate it with the raw persisted JSON. Forward-compat: adapters that don't know about the field ignore it (no breakage).

## Out of scope

- Backfill for old runs (operators reading pre-v0.9.x runs see only `user_input` as a default-fallback card; no `system_prompt` will exist for those runs).
- A literal "Turn 1 / Cycle 1" visual wrapper — the cards render as flat events in seq order, which is already the right shape because they have the lowest seq numbers.
- Adapter type changes (`@loomcycle/client` / Python adapter) — adapters consume the transcript as a flexible union; new types ride through verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)