### PR TITLE
chore(ts): bump @loomcycle/client to 0.9.1 for v0.9.1 release

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.9.0",
-  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 29 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, and v0.8.22 substrate admin (agentDef + skillDef).",
+  "version": "0.9.1",
+  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 29 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, and v0.8.22 substrate admin (agentDef + skillDef). v0.9.1 adds typed UserInputPayload + SystemPromptPayload for the transcript event sidecar.",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary

v0.9.1 will tag PR #171 (transcript first-cycle events) on top of v0.9.0. The TS adapter gained typed payloads for the new transcript event sidecar (`UserInputPayload` + `SystemPromptPayload`), so we bump 0.9.0 → 0.9.1 alongside the upstream tag.

Without this bump, the npm-publish workflow's version-match gate would refuse with `package.json version (0.9.0) does not match tag (0.9.1)` — same failure mode as v0.9.0's first attempt.

## Test

- `npm install` regenerates lockfile to 0.9.1
- `npm run build` clean (TypeScript compiles)
- Existing vitest suite still passes (adapter surface is additive)

## Plan after merge

1. Merge this PR
2. Tag v0.9.1 at main tip → fires goreleaser + npm publish in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)