### PR TITLE
feat(n8n-phase0): GET /v1/_channels + GET /v1/users/{user_id}/agents/stream SSE + Connector/MCP/gRPC/TS parity

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.9.1",
-  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 29 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, and v0.8.22 substrate admin (agentDef + skillDef). v0.9.1 adds typed UserInputPayload + SystemPromptPayload for the transcript event sidecar.",
+  "version": "0.10.0",
+  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 31 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), and v0.9.x n8n Phase 0 (listChannels + streamUserRunStates). v0.9.1 adds typed UserInputPayload + SystemPromptPayload for the transcript event sidecar.",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -45,6 +45,7 @@ import type {
   InterruptListResponse,
   InterruptStatus,
   ListAgentsResponse,
+  ListChannelsResponse,
   ListHooksResponse,
   ListUsersResponse,
   MemoryEntriesResponse,
@@ -57,12 +58,14 @@ import type {
   ResolveInterruptOptions,
   ResumeResult,
   RunOptions,
+  RunStateStreamItem,
   RuntimeStateResponse,
   SnapshotCreateResponse,
   SnapshotDescriptor,
   SnapshotEnvelope,
   SnapshotListResponse,
   SnapshotRestoreResponse,
+  StreamUserRunStatesOptions,
   SubstrateToolInput,
   SubstrateToolResponse,
   TranscriptResponse,
@@ -579,5 +582,125 @@ export class LoomcycleClient {
     }
 
     yield* parseSSE(resp.body.getReader());
+  }
+
+  // ---- v0.9.x n8n RFC Phase 0 ----
+
+  /** List every operator-declared channel with aggregate stats
+   *  (message_count, oldest_visible_at, newest_visible_at).
+   *  Channels with no published messages still appear with
+   *  message_count=0. Orphaned message rows for un-declared channels
+   *  also appear (forensic visibility). Mirrors GET /v1/_channels. */
+  async listChannels(opts?: {
+    signal?: AbortSignal;
+  }): Promise<ListChannelsResponse> {
+    return await jsonFetch<ListChannelsResponse>(
+      this.ctx,
+      "/v1/_channels",
+      opts,
+    );
+  }
+
+  /** Subscribe to run state transitions for one user_id via SSE.
+   *  Yields one `{ kind: "open", ... }` item first (confirms the
+   *  connection is live), then one `{ kind: "event", ... }` per
+   *  matching state transition until the stream closes.
+   *
+   *  The stream stays open for at most 30 minutes (server-enforced).
+   *  Callers running indefinitely should reconnect on close.
+   *
+   *  Errors during the stream throw — they do NOT surface as items.
+   *  Pass an AbortSignal to terminate cleanly from the consumer side. */
+  async *streamUserRunStates(
+    userId: string,
+    opts?: StreamUserRunStatesOptions,
+  ): AsyncIterable<RunStateStreamItem> {
+    const params = new URLSearchParams();
+    if (opts?.statuses && opts.statuses.length > 0) {
+      params.set("status", opts.statuses.join(","));
+    }
+    if (opts?.agent) {
+      params.set("agent", opts.agent);
+    }
+    const qs = params.toString();
+    const path =
+      `/v1/users/${encodeURIComponent(userId)}/agents/stream` +
+      (qs ? `?${qs}` : "");
+
+    const headers: Record<string, string> = {
+      Accept: "text/event-stream",
+    };
+    if (this.ctx.authToken) {
+      headers.Authorization = `Bearer ${this.ctx.authToken}`;
+    }
+
+    const resp = await this.ctx.fetchImpl(this.ctx.baseUrl + path, {
+      method: "GET",
+      headers,
+      signal: opts?.signal,
+    });
+
+    if (!resp.ok) {
+      await raiseFromResponse(resp);
+    }
+    if (!resp.body) {
+      throw new Error("loomcycle: streamUserRunStates response has no body");
+    }
+
+    yield* parseRunStateSSE(resp.body.getReader());
+  }
+}
+
+/** Lightweight SSE parser tailored to the run-state stream. Each
+ *  frame's event name distinguishes the two kinds; data is JSON.
+ *  Comment lines (": keepalive") are ignored. */
+async function* parseRunStateSSE(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncIterable<RunStateStreamItem> {
+  const decoder = new TextDecoder("utf-8");
+  let buf = "";
+  let event = "";
+  let data = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+
+    let idx;
+    while ((idx = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, idx).replace(/\r$/, "");
+      buf = buf.slice(idx + 1);
+
+      if (line === "") {
+        if (event && data) {
+          try {
+            const parsed = JSON.parse(data) as unknown;
+            if (event === "stream_open") {
+              yield {
+                kind: "open",
+                payload: parsed as RunStateStreamItem extends { kind: "open" }
+                  ? RunStateStreamItem["payload"]
+                  : never,
+              } as RunStateStreamItem;
+            } else if (event === "run_state") {
+              yield {
+                kind: "event",
+                payload: parsed as RunStateStreamItem extends { kind: "event" }
+                  ? RunStateStreamItem["payload"]
+                  : never,
+              } as RunStateStreamItem;
+            }
+          } catch {
+            // Drop malformed frame silently — same posture as parseSSE.
+          }
+        }
+        event = "";
+        data = "";
+        continue;
+      }
+      if (line.startsWith("event:")) event = line.slice("event:".length).trim();
+      else if (line.startsWith("data:")) data = line.slice("data:".length).trim();
+    }
   }
 }

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -614,3 +614,68 @@ export type SubstrateToolResponse = unknown;
 export interface PostHookResult {
   result?: HookToolResult;
 }
+
+// ---- v0.9.x n8n RFC Phase 0 ----
+
+/** Aggregate stats for one operator-declared channel. Returned by
+ *  {@link LoomcycleClient.listChannels}. */
+export interface ChannelDescriptor {
+  name: string;
+  scope?: string;
+  semantic?: string;
+  publisher?: string;
+  period?: string;
+  default_ttl?: number;
+  max_messages?: number;
+  message_count: number;
+  /** RFC3339 — empty when count == 0. */
+  oldest_visible_at?: string;
+  newest_visible_at?: string;
+}
+
+/** Response shape for {@link LoomcycleClient.listChannels}. */
+export interface ListChannelsResponse {
+  channels: ChannelDescriptor[];
+}
+
+/** One run state transition emitted by
+ *  {@link LoomcycleClient.streamUserRunStates}. The TS field is RFC3339. */
+export interface RunStateEvent {
+  run_id: string;
+  agent_id: string;
+  agent: string;
+  user_id: string;
+  parent_agent_id?: string;
+  status: string;
+  stop_reason?: string;
+  error?: string;
+  ts: string;
+}
+
+/** Initial stream_open frame emitted before the first run_state. */
+export interface RunStateStreamOpen {
+  user_id: string;
+  filter_status: string[] | null;
+  filter_agent: string;
+  keepalive_interval: number;
+}
+
+/** Yielded by {@link LoomcycleClient.streamUserRunStates}.
+ *
+ *  The first item is always `{ kind: "open", payload: RunStateStreamOpen }`.
+ *  Subsequent items are `{ kind: "event", payload: RunStateEvent }`.
+ *
+ *  Consumers branch on `kind`; the `open` frame is useful for confirming
+ *  the connection before any real events flow. */
+export type RunStateStreamItem =
+  | { kind: "open"; payload: RunStateStreamOpen }
+  | { kind: "event"; payload: RunStateEvent };
+
+/** Optional filter for {@link LoomcycleClient.streamUserRunStates}. */
+export interface StreamUserRunStatesOptions {
+  /** Subset of states to receive. Empty means all states. */
+  statuses?: string[];
+  /** Filter to one agent name. Empty means any. */
+  agent?: string;
+  signal?: AbortSignal;
+}

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -746,3 +746,128 @@ describe("hook management", () => {
     });
   });
 });
+
+describe("v0.9.x n8n RFC Phase 0 — listChannels + streamUserRunStates", () => {
+  it("listChannels GETs /v1/_channels and returns the envelope", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        channels: [
+          {
+            name: "_system/alarms",
+            scope: "global",
+            semantic: "broadcast",
+            publisher: "system",
+            message_count: 4,
+            oldest_visible_at: "2026-05-20T10:00:00Z",
+            newest_visible_at: "2026-05-21T15:30:00Z",
+          },
+          { name: "scratch", message_count: 0 },
+        ],
+      }),
+    ]);
+    const resp = await client.listChannels();
+    expect(resp.channels).toHaveLength(2);
+    expect(resp.channels[0]?.name).toBe("_system/alarms");
+    expect(resp.channels[0]?.message_count).toBe(4);
+    expect(resp.channels[1]?.message_count).toBe(0);
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/_channels",
+    );
+    expect((fetchMock.mock.calls[0]![1]!.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-bearer",
+    );
+  });
+
+  it("streamUserRunStates yields stream_open then run_state frames", async () => {
+    const frames = [
+      `event: stream_open\ndata: ${JSON.stringify({
+        user_id: "user-a",
+        filter_status: null,
+        filter_agent: "",
+        keepalive_interval: 25,
+      })}\n\n`,
+      `event: run_state\ndata: ${JSON.stringify({
+        run_id: "r1",
+        agent_id: "ag1",
+        agent: "researcher",
+        user_id: "user-a",
+        status: "running",
+        ts: "2026-05-22T00:00:00Z",
+      })}\n\n`,
+      `event: run_state\ndata: ${JSON.stringify({
+        run_id: "r1",
+        agent_id: "ag1",
+        agent: "researcher",
+        user_id: "user-a",
+        status: "completed",
+        stop_reason: "end_turn",
+        ts: "2026-05-22T00:00:01Z",
+      })}\n\n`,
+    ];
+    const { client, fetchMock } = makeClient([sseResponse(frames)]);
+
+    const items = [];
+    for await (const item of client.streamUserRunStates("user-a")) {
+      items.push(item);
+    }
+    expect(items).toHaveLength(3);
+    expect(items[0]?.kind).toBe("open");
+    expect(items[1]?.kind).toBe("event");
+    if (items[1]?.kind === "event") {
+      expect(items[1].payload.run_id).toBe("r1");
+      expect(items[1].payload.status).toBe("running");
+    }
+    if (items[2]?.kind === "event") {
+      expect(items[2].payload.status).toBe("completed");
+      expect(items[2].payload.stop_reason).toBe("end_turn");
+    }
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/users/user-a/agents/stream",
+    );
+  });
+
+  it("streamUserRunStates encodes status + agent filters as query params", async () => {
+    const { client, fetchMock } = makeClient([sseResponse([])]);
+    const iter = client.streamUserRunStates("user-a", {
+      statuses: ["completed", "failed"],
+      agent: "writer",
+    });
+    for await (const _ of iter) {
+      // drain
+    }
+    const url = fetchMock.mock.calls[0]![0] as string;
+    expect(url).toContain("/v1/users/user-a/agents/stream?");
+    expect(url).toContain("status=completed%2Cfailed");
+    expect(url).toContain("agent=writer");
+  });
+
+  it("streamUserRunStates ignores keepalive comment lines", async () => {
+    const frames = [
+      ": keepalive\n\n",
+      `event: run_state\ndata: ${JSON.stringify({
+        run_id: "r1",
+        agent_id: "ag1",
+        agent: "x",
+        user_id: "user-a",
+        status: "running",
+        ts: "2026-05-22T00:00:00Z",
+      })}\n\n`,
+    ];
+    const { client } = makeClient([sseResponse(frames)]);
+    const items = [];
+    for await (const item of client.streamUserRunStates("user-a")) {
+      items.push(item);
+    }
+    expect(items).toHaveLength(1);
+    expect(items[0]?.kind).toBe("event");
+  });
+
+  it("streamUserRunStates raises typed error on 401", async () => {
+    const { client } = makeClient([errorResponse(401, "bad bearer")]);
+    await expect(async () => {
+      for await (const _ of client.streamUserRunStates("user-a")) {
+        // unreached
+      }
+    }).rejects.toMatchObject({ name: "AuthError", status: 401 });
+  });
+});

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
@@ -735,6 +736,15 @@ func main() {
 	// "intr:<id>" key. Without this the resolve writes the row but
 	// the tool re-checks storage only when its own timer fires.
 	srv.SetInterruptionBus(channelBus)
+
+	// v0.9.x n8n RFC Phase 0 — run-state pub/sub bus that backs the
+	// GET /v1/users/{user_id}/agents/stream SSE endpoint. One
+	// instance per process; subscribers (typically the SSE handler)
+	// register per user_id; the finishRun* paths publish state
+	// transitions. Decoupled from channelBus so a slow run-state
+	// consumer can't stall the channel notification path.
+	runStateBus := runstate.NewBus()
+	srv.SetRunStateBus(runStateBus)
 
 	// v0.8.6 heartbeat runner — one goroutine per `_system/heartbeat-*`
 	// (or any other `publisher: system` + `period:` channel) declared

--- a/internal/api/grpc/loomcyclepb/loomcycle.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle.pb.go
@@ -3309,6 +3309,377 @@ func (x *SubstrateResponse) GetIsError() bool {
 	return false
 }
 
+// ListChannelsRequest is empty — the channel list is global within
+// the loomcycle process, no per-call selectors.
+type ListChannelsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListChannelsRequest) Reset() {
+	*x = ListChannelsRequest{}
+	mi := &file_loomcycle_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListChannelsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListChannelsRequest) ProtoMessage() {}
+
+func (x *ListChannelsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListChannelsRequest.ProtoReflect.Descriptor instead.
+func (*ListChannelsRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{49}
+}
+
+type ListChannelsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Channels      []*ChannelDescriptor   `protobuf:"bytes,1,rep,name=channels,proto3" json:"channels,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListChannelsResponse) Reset() {
+	*x = ListChannelsResponse{}
+	mi := &file_loomcycle_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListChannelsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListChannelsResponse) ProtoMessage() {}
+
+func (x *ListChannelsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListChannelsResponse.ProtoReflect.Descriptor instead.
+func (*ListChannelsResponse) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ListChannelsResponse) GetChannels() []*ChannelDescriptor {
+	if x != nil {
+		return x.Channels
+	}
+	return nil
+}
+
+type ChannelDescriptor struct {
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Name         string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Scope        string                 `protobuf:"bytes,2,opt,name=scope,proto3" json:"scope,omitempty"`
+	Semantic     string                 `protobuf:"bytes,3,opt,name=semantic,proto3" json:"semantic,omitempty"`
+	Publisher    string                 `protobuf:"bytes,4,opt,name=publisher,proto3" json:"publisher,omitempty"`
+	Period       string                 `protobuf:"bytes,5,opt,name=period,proto3" json:"period,omitempty"`
+	DefaultTtl   int32                  `protobuf:"varint,6,opt,name=default_ttl,json=defaultTtl,proto3" json:"default_ttl,omitempty"`
+	MaxMessages  int32                  `protobuf:"varint,7,opt,name=max_messages,json=maxMessages,proto3" json:"max_messages,omitempty"`
+	MessageCount int64                  `protobuf:"varint,8,opt,name=message_count,json=messageCount,proto3" json:"message_count,omitempty"`
+	// RFC3339 strings — empty when count == 0.
+	OldestVisibleAt string `protobuf:"bytes,9,opt,name=oldest_visible_at,json=oldestVisibleAt,proto3" json:"oldest_visible_at,omitempty"`
+	NewestVisibleAt string `protobuf:"bytes,10,opt,name=newest_visible_at,json=newestVisibleAt,proto3" json:"newest_visible_at,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ChannelDescriptor) Reset() {
+	*x = ChannelDescriptor{}
+	mi := &file_loomcycle_proto_msgTypes[51]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ChannelDescriptor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ChannelDescriptor) ProtoMessage() {}
+
+func (x *ChannelDescriptor) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[51]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ChannelDescriptor.ProtoReflect.Descriptor instead.
+func (*ChannelDescriptor) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{51}
+}
+
+func (x *ChannelDescriptor) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetSemantic() string {
+	if x != nil {
+		return x.Semantic
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetPublisher() string {
+	if x != nil {
+		return x.Publisher
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetPeriod() string {
+	if x != nil {
+		return x.Period
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetDefaultTtl() int32 {
+	if x != nil {
+		return x.DefaultTtl
+	}
+	return 0
+}
+
+func (x *ChannelDescriptor) GetMaxMessages() int32 {
+	if x != nil {
+		return x.MaxMessages
+	}
+	return 0
+}
+
+func (x *ChannelDescriptor) GetMessageCount() int64 {
+	if x != nil {
+		return x.MessageCount
+	}
+	return 0
+}
+
+func (x *ChannelDescriptor) GetOldestVisibleAt() string {
+	if x != nil {
+		return x.OldestVisibleAt
+	}
+	return ""
+}
+
+func (x *ChannelDescriptor) GetNewestVisibleAt() string {
+	if x != nil {
+		return x.NewestVisibleAt
+	}
+	return ""
+}
+
+type StreamUserRunStatesRequest struct {
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	UserId string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	// Optional filter — empty means all transitions match.
+	Statuses []string `protobuf:"bytes,2,rep,name=statuses,proto3" json:"statuses,omitempty"`
+	// Optional filter — empty means any agent matches.
+	Agent         string `protobuf:"bytes,3,opt,name=agent,proto3" json:"agent,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StreamUserRunStatesRequest) Reset() {
+	*x = StreamUserRunStatesRequest{}
+	mi := &file_loomcycle_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StreamUserRunStatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StreamUserRunStatesRequest) ProtoMessage() {}
+
+func (x *StreamUserRunStatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StreamUserRunStatesRequest.ProtoReflect.Descriptor instead.
+func (*StreamUserRunStatesRequest) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *StreamUserRunStatesRequest) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *StreamUserRunStatesRequest) GetStatuses() []string {
+	if x != nil {
+		return x.Statuses
+	}
+	return nil
+}
+
+func (x *StreamUserRunStatesRequest) GetAgent() string {
+	if x != nil {
+		return x.Agent
+	}
+	return ""
+}
+
+// RunStateEvent mirrors the SSE wire shape from the HTTP transport.
+// TS is RFC3339 for language-portability.
+type RunStateEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	AgentId       string                 `protobuf:"bytes,2,opt,name=agent_id,json=agentId,proto3" json:"agent_id,omitempty"`
+	Agent         string                 `protobuf:"bytes,3,opt,name=agent,proto3" json:"agent,omitempty"`
+	UserId        string                 `protobuf:"bytes,4,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	ParentAgentId string                 `protobuf:"bytes,5,opt,name=parent_agent_id,json=parentAgentId,proto3" json:"parent_agent_id,omitempty"`
+	Status        string                 `protobuf:"bytes,6,opt,name=status,proto3" json:"status,omitempty"`
+	StopReason    string                 `protobuf:"bytes,7,opt,name=stop_reason,json=stopReason,proto3" json:"stop_reason,omitempty"`
+	Error         string                 `protobuf:"bytes,8,opt,name=error,proto3" json:"error,omitempty"`
+	Ts            string                 `protobuf:"bytes,9,opt,name=ts,proto3" json:"ts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RunStateEvent) Reset() {
+	*x = RunStateEvent{}
+	mi := &file_loomcycle_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RunStateEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RunStateEvent) ProtoMessage() {}
+
+func (x *RunStateEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_loomcycle_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RunStateEvent.ProtoReflect.Descriptor instead.
+func (*RunStateEvent) Descriptor() ([]byte, []int) {
+	return file_loomcycle_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *RunStateEvent) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetAgentId() string {
+	if x != nil {
+		return x.AgentId
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetAgent() string {
+	if x != nil {
+		return x.Agent
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetParentAgentId() string {
+	if x != nil {
+		return x.ParentAgentId
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetStatus() string {
+	if x != nil {
+		return x.Status
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetStopReason() string {
+	if x != nil {
+		return x.StopReason
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+func (x *RunStateEvent) GetTs() string {
+	if x != nil {
+		return x.Ts
+	}
+	return ""
+}
+
 var File_loomcycle_proto protoreflect.FileDescriptor
 
 const file_loomcycle_proto_rawDesc = "" +
@@ -3571,7 +3942,38 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\x11SubstrateResponse\x12\x1f\n" +
 	"\voutput_json\x18\x01 \x01(\fR\n" +
 	"outputJson\x12\x19\n" +
-	"\bis_error\x18\x02 \x01(\bR\aisError2\xc6\r\n" +
+	"\bis_error\x18\x02 \x01(\bR\aisError\"\x15\n" +
+	"\x13ListChannelsRequest\"S\n" +
+	"\x14ListChannelsResponse\x12;\n" +
+	"\bchannels\x18\x01 \x03(\v2\x1f.loomcycle.v1.ChannelDescriptorR\bchannels\"\xd0\x02\n" +
+	"\x11ChannelDescriptor\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
+	"\x05scope\x18\x02 \x01(\tR\x05scope\x12\x1a\n" +
+	"\bsemantic\x18\x03 \x01(\tR\bsemantic\x12\x1c\n" +
+	"\tpublisher\x18\x04 \x01(\tR\tpublisher\x12\x16\n" +
+	"\x06period\x18\x05 \x01(\tR\x06period\x12\x1f\n" +
+	"\vdefault_ttl\x18\x06 \x01(\x05R\n" +
+	"defaultTtl\x12!\n" +
+	"\fmax_messages\x18\a \x01(\x05R\vmaxMessages\x12#\n" +
+	"\rmessage_count\x18\b \x01(\x03R\fmessageCount\x12*\n" +
+	"\x11oldest_visible_at\x18\t \x01(\tR\x0foldestVisibleAt\x12*\n" +
+	"\x11newest_visible_at\x18\n" +
+	" \x01(\tR\x0fnewestVisibleAt\"g\n" +
+	"\x1aStreamUserRunStatesRequest\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x1a\n" +
+	"\bstatuses\x18\x02 \x03(\tR\bstatuses\x12\x14\n" +
+	"\x05agent\x18\x03 \x01(\tR\x05agent\"\xf7\x01\n" +
+	"\rRunStateEvent\x12\x15\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x19\n" +
+	"\bagent_id\x18\x02 \x01(\tR\aagentId\x12\x14\n" +
+	"\x05agent\x18\x03 \x01(\tR\x05agent\x12\x17\n" +
+	"\auser_id\x18\x04 \x01(\tR\x06userId\x12&\n" +
+	"\x0fparent_agent_id\x18\x05 \x01(\tR\rparentAgentId\x12\x16\n" +
+	"\x06status\x18\x06 \x01(\tR\x06status\x12\x1f\n" +
+	"\vstop_reason\x18\a \x01(\tR\n" +
+	"stopReason\x12\x14\n" +
+	"\x05error\x18\b \x01(\tR\x05error\x12\x0e\n" +
+	"\x02ts\x18\t \x01(\tR\x02ts2\xfd\x0e\n" +
 	"\tLoomcycle\x126\n" +
 	"\x03Run\x12\x18.loomcycle.v1.RunRequest\x1a\x13.loomcycle.v1.Event0\x01\x12@\n" +
 	"\bContinue\x12\x1d.loomcycle.v1.ContinueRequest\x1a\x13.loomcycle.v1.Event0\x01\x12M\n" +
@@ -3594,7 +3996,9 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\x0fRestoreSnapshot\x12$.loomcycle.v1.RestoreSnapshotRequest\x1a%.loomcycle.v1.RestoreSnapshotResponse\x12[\n" +
 	"\x0eDeleteSnapshot\x12#.loomcycle.v1.DeleteSnapshotRequest\x1a$.loomcycle.v1.DeleteSnapshotResponse\x12K\n" +
 	"\bAgentDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12K\n" +
-	"\bSkillDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponseBLZJgithub.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb;loomcyclepbb\x06proto3"
+	"\bSkillDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12U\n" +
+	"\fListChannels\x12!.loomcycle.v1.ListChannelsRequest\x1a\".loomcycle.v1.ListChannelsResponse\x12^\n" +
+	"\x13StreamUserRunStates\x12(.loomcycle.v1.StreamUserRunStatesRequest\x1a\x1b.loomcycle.v1.RunStateEvent0\x01BLZJgithub.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb;loomcyclepbb\x06proto3"
 
 var (
 	file_loomcycle_proto_rawDescOnce sync.Once
@@ -3608,58 +4012,63 @@ func file_loomcycle_proto_rawDescGZIP() []byte {
 	return file_loomcycle_proto_rawDescData
 }
 
-var file_loomcycle_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_loomcycle_proto_msgTypes = make([]protoimpl.MessageInfo, 54)
 var file_loomcycle_proto_goTypes = []any{
-	(*RunRequest)(nil),              // 0: loomcycle.v1.RunRequest
-	(*ContinueRequest)(nil),         // 1: loomcycle.v1.ContinueRequest
-	(*HostAllowlist)(nil),           // 2: loomcycle.v1.HostAllowlist
-	(*PromptSegment)(nil),           // 3: loomcycle.v1.PromptSegment
-	(*PromptContentBlock)(nil),      // 4: loomcycle.v1.PromptContentBlock
-	(*Event)(nil),                   // 5: loomcycle.v1.Event
-	(*HostWidening)(nil),            // 6: loomcycle.v1.HostWidening
-	(*ToolUse)(nil),                 // 7: loomcycle.v1.ToolUse
-	(*Usage)(nil),                   // 8: loomcycle.v1.Usage
-	(*Retry)(nil),                   // 9: loomcycle.v1.Retry
-	(*GetTranscriptRequest)(nil),    // 10: loomcycle.v1.GetTranscriptRequest
-	(*Transcript)(nil),              // 11: loomcycle.v1.Transcript
-	(*TranscriptEvent)(nil),         // 12: loomcycle.v1.TranscriptEvent
-	(*GetAgentRequest)(nil),         // 13: loomcycle.v1.GetAgentRequest
-	(*Agent)(nil),                   // 14: loomcycle.v1.Agent
-	(*AgentUsage)(nil),              // 15: loomcycle.v1.AgentUsage
-	(*CancelAgentRequest)(nil),      // 16: loomcycle.v1.CancelAgentRequest
-	(*CancelAgentResponse)(nil),     // 17: loomcycle.v1.CancelAgentResponse
-	(*ListUserAgentsRequest)(nil),   // 18: loomcycle.v1.ListUserAgentsRequest
-	(*ListUserAgentsResponse)(nil),  // 19: loomcycle.v1.ListUserAgentsResponse
-	(*HealthRequest)(nil),           // 20: loomcycle.v1.HealthRequest
-	(*HealthResponse)(nil),          // 21: loomcycle.v1.HealthResponse
-	(*RegisterHookRequest)(nil),     // 22: loomcycle.v1.RegisterHookRequest
-	(*RegisterHookResponse)(nil),    // 23: loomcycle.v1.RegisterHookResponse
-	(*ListHooksRequest)(nil),        // 24: loomcycle.v1.ListHooksRequest
-	(*Hook)(nil),                    // 25: loomcycle.v1.Hook
-	(*ListHooksResponse)(nil),       // 26: loomcycle.v1.ListHooksResponse
-	(*DeleteHookRequest)(nil),       // 27: loomcycle.v1.DeleteHookRequest
-	(*DeleteHookResponse)(nil),      // 28: loomcycle.v1.DeleteHookResponse
-	(*PauseRuntimeRequest)(nil),     // 29: loomcycle.v1.PauseRuntimeRequest
-	(*PauseRuntimeResponse)(nil),    // 30: loomcycle.v1.PauseRuntimeResponse
-	(*ResumeRuntimeRequest)(nil),    // 31: loomcycle.v1.ResumeRuntimeRequest
-	(*ResumeRuntimeResponse)(nil),   // 32: loomcycle.v1.ResumeRuntimeResponse
-	(*GetRuntimeStateRequest)(nil),  // 33: loomcycle.v1.GetRuntimeStateRequest
-	(*RuntimeStateResponse)(nil),    // 34: loomcycle.v1.RuntimeStateResponse
-	(*CreateSnapshotRequest)(nil),   // 35: loomcycle.v1.CreateSnapshotRequest
-	(*SnapshotDescriptor)(nil),      // 36: loomcycle.v1.SnapshotDescriptor
-	(*ListSnapshotsRequest)(nil),    // 37: loomcycle.v1.ListSnapshotsRequest
-	(*ListSnapshotsResponse)(nil),   // 38: loomcycle.v1.ListSnapshotsResponse
-	(*GetSnapshotRequest)(nil),      // 39: loomcycle.v1.GetSnapshotRequest
-	(*SnapshotEnvelope)(nil),        // 40: loomcycle.v1.SnapshotEnvelope
-	(*ExportSnapshotRequest)(nil),   // 41: loomcycle.v1.ExportSnapshotRequest
-	(*ExportSnapshotResponse)(nil),  // 42: loomcycle.v1.ExportSnapshotResponse
-	(*RestoreSnapshotRequest)(nil),  // 43: loomcycle.v1.RestoreSnapshotRequest
-	(*RestoreSnapshotResponse)(nil), // 44: loomcycle.v1.RestoreSnapshotResponse
-	(*DeleteSnapshotRequest)(nil),   // 45: loomcycle.v1.DeleteSnapshotRequest
-	(*DeleteSnapshotResponse)(nil),  // 46: loomcycle.v1.DeleteSnapshotResponse
-	(*SubstrateRequest)(nil),        // 47: loomcycle.v1.SubstrateRequest
-	(*SubstrateResponse)(nil),       // 48: loomcycle.v1.SubstrateResponse
-	(*timestamppb.Timestamp)(nil),   // 49: google.protobuf.Timestamp
+	(*RunRequest)(nil),                 // 0: loomcycle.v1.RunRequest
+	(*ContinueRequest)(nil),            // 1: loomcycle.v1.ContinueRequest
+	(*HostAllowlist)(nil),              // 2: loomcycle.v1.HostAllowlist
+	(*PromptSegment)(nil),              // 3: loomcycle.v1.PromptSegment
+	(*PromptContentBlock)(nil),         // 4: loomcycle.v1.PromptContentBlock
+	(*Event)(nil),                      // 5: loomcycle.v1.Event
+	(*HostWidening)(nil),               // 6: loomcycle.v1.HostWidening
+	(*ToolUse)(nil),                    // 7: loomcycle.v1.ToolUse
+	(*Usage)(nil),                      // 8: loomcycle.v1.Usage
+	(*Retry)(nil),                      // 9: loomcycle.v1.Retry
+	(*GetTranscriptRequest)(nil),       // 10: loomcycle.v1.GetTranscriptRequest
+	(*Transcript)(nil),                 // 11: loomcycle.v1.Transcript
+	(*TranscriptEvent)(nil),            // 12: loomcycle.v1.TranscriptEvent
+	(*GetAgentRequest)(nil),            // 13: loomcycle.v1.GetAgentRequest
+	(*Agent)(nil),                      // 14: loomcycle.v1.Agent
+	(*AgentUsage)(nil),                 // 15: loomcycle.v1.AgentUsage
+	(*CancelAgentRequest)(nil),         // 16: loomcycle.v1.CancelAgentRequest
+	(*CancelAgentResponse)(nil),        // 17: loomcycle.v1.CancelAgentResponse
+	(*ListUserAgentsRequest)(nil),      // 18: loomcycle.v1.ListUserAgentsRequest
+	(*ListUserAgentsResponse)(nil),     // 19: loomcycle.v1.ListUserAgentsResponse
+	(*HealthRequest)(nil),              // 20: loomcycle.v1.HealthRequest
+	(*HealthResponse)(nil),             // 21: loomcycle.v1.HealthResponse
+	(*RegisterHookRequest)(nil),        // 22: loomcycle.v1.RegisterHookRequest
+	(*RegisterHookResponse)(nil),       // 23: loomcycle.v1.RegisterHookResponse
+	(*ListHooksRequest)(nil),           // 24: loomcycle.v1.ListHooksRequest
+	(*Hook)(nil),                       // 25: loomcycle.v1.Hook
+	(*ListHooksResponse)(nil),          // 26: loomcycle.v1.ListHooksResponse
+	(*DeleteHookRequest)(nil),          // 27: loomcycle.v1.DeleteHookRequest
+	(*DeleteHookResponse)(nil),         // 28: loomcycle.v1.DeleteHookResponse
+	(*PauseRuntimeRequest)(nil),        // 29: loomcycle.v1.PauseRuntimeRequest
+	(*PauseRuntimeResponse)(nil),       // 30: loomcycle.v1.PauseRuntimeResponse
+	(*ResumeRuntimeRequest)(nil),       // 31: loomcycle.v1.ResumeRuntimeRequest
+	(*ResumeRuntimeResponse)(nil),      // 32: loomcycle.v1.ResumeRuntimeResponse
+	(*GetRuntimeStateRequest)(nil),     // 33: loomcycle.v1.GetRuntimeStateRequest
+	(*RuntimeStateResponse)(nil),       // 34: loomcycle.v1.RuntimeStateResponse
+	(*CreateSnapshotRequest)(nil),      // 35: loomcycle.v1.CreateSnapshotRequest
+	(*SnapshotDescriptor)(nil),         // 36: loomcycle.v1.SnapshotDescriptor
+	(*ListSnapshotsRequest)(nil),       // 37: loomcycle.v1.ListSnapshotsRequest
+	(*ListSnapshotsResponse)(nil),      // 38: loomcycle.v1.ListSnapshotsResponse
+	(*GetSnapshotRequest)(nil),         // 39: loomcycle.v1.GetSnapshotRequest
+	(*SnapshotEnvelope)(nil),           // 40: loomcycle.v1.SnapshotEnvelope
+	(*ExportSnapshotRequest)(nil),      // 41: loomcycle.v1.ExportSnapshotRequest
+	(*ExportSnapshotResponse)(nil),     // 42: loomcycle.v1.ExportSnapshotResponse
+	(*RestoreSnapshotRequest)(nil),     // 43: loomcycle.v1.RestoreSnapshotRequest
+	(*RestoreSnapshotResponse)(nil),    // 44: loomcycle.v1.RestoreSnapshotResponse
+	(*DeleteSnapshotRequest)(nil),      // 45: loomcycle.v1.DeleteSnapshotRequest
+	(*DeleteSnapshotResponse)(nil),     // 46: loomcycle.v1.DeleteSnapshotResponse
+	(*SubstrateRequest)(nil),           // 47: loomcycle.v1.SubstrateRequest
+	(*SubstrateResponse)(nil),          // 48: loomcycle.v1.SubstrateResponse
+	(*ListChannelsRequest)(nil),        // 49: loomcycle.v1.ListChannelsRequest
+	(*ListChannelsResponse)(nil),       // 50: loomcycle.v1.ListChannelsResponse
+	(*ChannelDescriptor)(nil),          // 51: loomcycle.v1.ChannelDescriptor
+	(*StreamUserRunStatesRequest)(nil), // 52: loomcycle.v1.StreamUserRunStatesRequest
+	(*RunStateEvent)(nil),              // 53: loomcycle.v1.RunStateEvent
+	(*timestamppb.Timestamp)(nil),      // 54: google.protobuf.Timestamp
 }
 var file_loomcycle_proto_depIdxs = []int32{
 	3,  // 0: loomcycle.v1.RunRequest.segments:type_name -> loomcycle.v1.PromptSegment
@@ -3672,67 +4081,72 @@ var file_loomcycle_proto_depIdxs = []int32{
 	9,  // 7: loomcycle.v1.Event.retry:type_name -> loomcycle.v1.Retry
 	6,  // 8: loomcycle.v1.Event.host_widening:type_name -> loomcycle.v1.HostWidening
 	12, // 9: loomcycle.v1.Transcript.events:type_name -> loomcycle.v1.TranscriptEvent
-	49, // 10: loomcycle.v1.TranscriptEvent.ts:type_name -> google.protobuf.Timestamp
-	49, // 11: loomcycle.v1.Agent.started_at:type_name -> google.protobuf.Timestamp
-	49, // 12: loomcycle.v1.Agent.completed_at:type_name -> google.protobuf.Timestamp
+	54, // 10: loomcycle.v1.TranscriptEvent.ts:type_name -> google.protobuf.Timestamp
+	54, // 11: loomcycle.v1.Agent.started_at:type_name -> google.protobuf.Timestamp
+	54, // 12: loomcycle.v1.Agent.completed_at:type_name -> google.protobuf.Timestamp
 	15, // 13: loomcycle.v1.Agent.usage:type_name -> loomcycle.v1.AgentUsage
-	49, // 14: loomcycle.v1.Agent.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	54, // 14: loomcycle.v1.Agent.last_heartbeat_at:type_name -> google.protobuf.Timestamp
 	14, // 15: loomcycle.v1.ListUserAgentsResponse.agents:type_name -> loomcycle.v1.Agent
-	49, // 16: loomcycle.v1.Hook.registered_at:type_name -> google.protobuf.Timestamp
+	54, // 16: loomcycle.v1.Hook.registered_at:type_name -> google.protobuf.Timestamp
 	25, // 17: loomcycle.v1.ListHooksResponse.hooks:type_name -> loomcycle.v1.Hook
-	49, // 18: loomcycle.v1.RuntimeStateResponse.paused_at:type_name -> google.protobuf.Timestamp
-	49, // 19: loomcycle.v1.CreateSnapshotRequest.since_ts:type_name -> google.protobuf.Timestamp
-	49, // 20: loomcycle.v1.SnapshotDescriptor.created_at:type_name -> google.protobuf.Timestamp
-	49, // 21: loomcycle.v1.SnapshotDescriptor.since_ts:type_name -> google.protobuf.Timestamp
+	54, // 18: loomcycle.v1.RuntimeStateResponse.paused_at:type_name -> google.protobuf.Timestamp
+	54, // 19: loomcycle.v1.CreateSnapshotRequest.since_ts:type_name -> google.protobuf.Timestamp
+	54, // 20: loomcycle.v1.SnapshotDescriptor.created_at:type_name -> google.protobuf.Timestamp
+	54, // 21: loomcycle.v1.SnapshotDescriptor.since_ts:type_name -> google.protobuf.Timestamp
 	36, // 22: loomcycle.v1.ListSnapshotsResponse.snapshots:type_name -> loomcycle.v1.SnapshotDescriptor
-	49, // 23: loomcycle.v1.SnapshotEnvelope.created_at:type_name -> google.protobuf.Timestamp
-	0,  // 24: loomcycle.v1.Loomcycle.Run:input_type -> loomcycle.v1.RunRequest
-	1,  // 25: loomcycle.v1.Loomcycle.Continue:input_type -> loomcycle.v1.ContinueRequest
-	10, // 26: loomcycle.v1.Loomcycle.GetTranscript:input_type -> loomcycle.v1.GetTranscriptRequest
-	13, // 27: loomcycle.v1.Loomcycle.GetAgent:input_type -> loomcycle.v1.GetAgentRequest
-	16, // 28: loomcycle.v1.Loomcycle.CancelAgent:input_type -> loomcycle.v1.CancelAgentRequest
-	18, // 29: loomcycle.v1.Loomcycle.ListUserAgents:input_type -> loomcycle.v1.ListUserAgentsRequest
-	20, // 30: loomcycle.v1.Loomcycle.Health:input_type -> loomcycle.v1.HealthRequest
-	22, // 31: loomcycle.v1.Loomcycle.RegisterHook:input_type -> loomcycle.v1.RegisterHookRequest
-	24, // 32: loomcycle.v1.Loomcycle.ListHooks:input_type -> loomcycle.v1.ListHooksRequest
-	27, // 33: loomcycle.v1.Loomcycle.DeleteHook:input_type -> loomcycle.v1.DeleteHookRequest
-	29, // 34: loomcycle.v1.Loomcycle.PauseRuntime:input_type -> loomcycle.v1.PauseRuntimeRequest
-	31, // 35: loomcycle.v1.Loomcycle.ResumeRuntime:input_type -> loomcycle.v1.ResumeRuntimeRequest
-	33, // 36: loomcycle.v1.Loomcycle.GetRuntimeState:input_type -> loomcycle.v1.GetRuntimeStateRequest
-	35, // 37: loomcycle.v1.Loomcycle.CreateSnapshot:input_type -> loomcycle.v1.CreateSnapshotRequest
-	37, // 38: loomcycle.v1.Loomcycle.ListSnapshots:input_type -> loomcycle.v1.ListSnapshotsRequest
-	39, // 39: loomcycle.v1.Loomcycle.GetSnapshot:input_type -> loomcycle.v1.GetSnapshotRequest
-	41, // 40: loomcycle.v1.Loomcycle.ExportSnapshot:input_type -> loomcycle.v1.ExportSnapshotRequest
-	43, // 41: loomcycle.v1.Loomcycle.RestoreSnapshot:input_type -> loomcycle.v1.RestoreSnapshotRequest
-	45, // 42: loomcycle.v1.Loomcycle.DeleteSnapshot:input_type -> loomcycle.v1.DeleteSnapshotRequest
-	47, // 43: loomcycle.v1.Loomcycle.AgentDef:input_type -> loomcycle.v1.SubstrateRequest
-	47, // 44: loomcycle.v1.Loomcycle.SkillDef:input_type -> loomcycle.v1.SubstrateRequest
-	5,  // 45: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
-	5,  // 46: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
-	11, // 47: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
-	14, // 48: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
-	17, // 49: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
-	19, // 50: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
-	21, // 51: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
-	23, // 52: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
-	26, // 53: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
-	28, // 54: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
-	30, // 55: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
-	32, // 56: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
-	34, // 57: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
-	36, // 58: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
-	38, // 59: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
-	40, // 60: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
-	42, // 61: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
-	44, // 62: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
-	46, // 63: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
-	48, // 64: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 65: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
-	45, // [45:66] is the sub-list for method output_type
-	24, // [24:45] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	54, // 23: loomcycle.v1.SnapshotEnvelope.created_at:type_name -> google.protobuf.Timestamp
+	51, // 24: loomcycle.v1.ListChannelsResponse.channels:type_name -> loomcycle.v1.ChannelDescriptor
+	0,  // 25: loomcycle.v1.Loomcycle.Run:input_type -> loomcycle.v1.RunRequest
+	1,  // 26: loomcycle.v1.Loomcycle.Continue:input_type -> loomcycle.v1.ContinueRequest
+	10, // 27: loomcycle.v1.Loomcycle.GetTranscript:input_type -> loomcycle.v1.GetTranscriptRequest
+	13, // 28: loomcycle.v1.Loomcycle.GetAgent:input_type -> loomcycle.v1.GetAgentRequest
+	16, // 29: loomcycle.v1.Loomcycle.CancelAgent:input_type -> loomcycle.v1.CancelAgentRequest
+	18, // 30: loomcycle.v1.Loomcycle.ListUserAgents:input_type -> loomcycle.v1.ListUserAgentsRequest
+	20, // 31: loomcycle.v1.Loomcycle.Health:input_type -> loomcycle.v1.HealthRequest
+	22, // 32: loomcycle.v1.Loomcycle.RegisterHook:input_type -> loomcycle.v1.RegisterHookRequest
+	24, // 33: loomcycle.v1.Loomcycle.ListHooks:input_type -> loomcycle.v1.ListHooksRequest
+	27, // 34: loomcycle.v1.Loomcycle.DeleteHook:input_type -> loomcycle.v1.DeleteHookRequest
+	29, // 35: loomcycle.v1.Loomcycle.PauseRuntime:input_type -> loomcycle.v1.PauseRuntimeRequest
+	31, // 36: loomcycle.v1.Loomcycle.ResumeRuntime:input_type -> loomcycle.v1.ResumeRuntimeRequest
+	33, // 37: loomcycle.v1.Loomcycle.GetRuntimeState:input_type -> loomcycle.v1.GetRuntimeStateRequest
+	35, // 38: loomcycle.v1.Loomcycle.CreateSnapshot:input_type -> loomcycle.v1.CreateSnapshotRequest
+	37, // 39: loomcycle.v1.Loomcycle.ListSnapshots:input_type -> loomcycle.v1.ListSnapshotsRequest
+	39, // 40: loomcycle.v1.Loomcycle.GetSnapshot:input_type -> loomcycle.v1.GetSnapshotRequest
+	41, // 41: loomcycle.v1.Loomcycle.ExportSnapshot:input_type -> loomcycle.v1.ExportSnapshotRequest
+	43, // 42: loomcycle.v1.Loomcycle.RestoreSnapshot:input_type -> loomcycle.v1.RestoreSnapshotRequest
+	45, // 43: loomcycle.v1.Loomcycle.DeleteSnapshot:input_type -> loomcycle.v1.DeleteSnapshotRequest
+	47, // 44: loomcycle.v1.Loomcycle.AgentDef:input_type -> loomcycle.v1.SubstrateRequest
+	47, // 45: loomcycle.v1.Loomcycle.SkillDef:input_type -> loomcycle.v1.SubstrateRequest
+	49, // 46: loomcycle.v1.Loomcycle.ListChannels:input_type -> loomcycle.v1.ListChannelsRequest
+	52, // 47: loomcycle.v1.Loomcycle.StreamUserRunStates:input_type -> loomcycle.v1.StreamUserRunStatesRequest
+	5,  // 48: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
+	5,  // 49: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
+	11, // 50: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
+	14, // 51: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
+	17, // 52: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
+	19, // 53: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
+	21, // 54: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
+	23, // 55: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
+	26, // 56: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
+	28, // 57: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
+	30, // 58: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
+	32, // 59: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
+	34, // 60: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
+	36, // 61: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
+	38, // 62: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
+	40, // 63: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
+	42, // 64: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
+	44, // 65: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
+	46, // 66: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
+	48, // 67: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 68: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
+	50, // 69: loomcycle.v1.Loomcycle.ListChannels:output_type -> loomcycle.v1.ListChannelsResponse
+	53, // 70: loomcycle.v1.Loomcycle.StreamUserRunStates:output_type -> loomcycle.v1.RunStateEvent
+	48, // [48:71] is the sub-list for method output_type
+	25, // [25:48] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_loomcycle_proto_init() }
@@ -3746,7 +4160,7 @@ func file_loomcycle_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_loomcycle_proto_rawDesc), len(file_loomcycle_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   49,
+			NumMessages:   54,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
@@ -38,27 +38,29 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Loomcycle_Run_FullMethodName             = "/loomcycle.v1.Loomcycle/Run"
-	Loomcycle_Continue_FullMethodName        = "/loomcycle.v1.Loomcycle/Continue"
-	Loomcycle_GetTranscript_FullMethodName   = "/loomcycle.v1.Loomcycle/GetTranscript"
-	Loomcycle_GetAgent_FullMethodName        = "/loomcycle.v1.Loomcycle/GetAgent"
-	Loomcycle_CancelAgent_FullMethodName     = "/loomcycle.v1.Loomcycle/CancelAgent"
-	Loomcycle_ListUserAgents_FullMethodName  = "/loomcycle.v1.Loomcycle/ListUserAgents"
-	Loomcycle_Health_FullMethodName          = "/loomcycle.v1.Loomcycle/Health"
-	Loomcycle_RegisterHook_FullMethodName    = "/loomcycle.v1.Loomcycle/RegisterHook"
-	Loomcycle_ListHooks_FullMethodName       = "/loomcycle.v1.Loomcycle/ListHooks"
-	Loomcycle_DeleteHook_FullMethodName      = "/loomcycle.v1.Loomcycle/DeleteHook"
-	Loomcycle_PauseRuntime_FullMethodName    = "/loomcycle.v1.Loomcycle/PauseRuntime"
-	Loomcycle_ResumeRuntime_FullMethodName   = "/loomcycle.v1.Loomcycle/ResumeRuntime"
-	Loomcycle_GetRuntimeState_FullMethodName = "/loomcycle.v1.Loomcycle/GetRuntimeState"
-	Loomcycle_CreateSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/CreateSnapshot"
-	Loomcycle_ListSnapshots_FullMethodName   = "/loomcycle.v1.Loomcycle/ListSnapshots"
-	Loomcycle_GetSnapshot_FullMethodName     = "/loomcycle.v1.Loomcycle/GetSnapshot"
-	Loomcycle_ExportSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/ExportSnapshot"
-	Loomcycle_RestoreSnapshot_FullMethodName = "/loomcycle.v1.Loomcycle/RestoreSnapshot"
-	Loomcycle_DeleteSnapshot_FullMethodName  = "/loomcycle.v1.Loomcycle/DeleteSnapshot"
-	Loomcycle_AgentDef_FullMethodName        = "/loomcycle.v1.Loomcycle/AgentDef"
-	Loomcycle_SkillDef_FullMethodName        = "/loomcycle.v1.Loomcycle/SkillDef"
+	Loomcycle_Run_FullMethodName                 = "/loomcycle.v1.Loomcycle/Run"
+	Loomcycle_Continue_FullMethodName            = "/loomcycle.v1.Loomcycle/Continue"
+	Loomcycle_GetTranscript_FullMethodName       = "/loomcycle.v1.Loomcycle/GetTranscript"
+	Loomcycle_GetAgent_FullMethodName            = "/loomcycle.v1.Loomcycle/GetAgent"
+	Loomcycle_CancelAgent_FullMethodName         = "/loomcycle.v1.Loomcycle/CancelAgent"
+	Loomcycle_ListUserAgents_FullMethodName      = "/loomcycle.v1.Loomcycle/ListUserAgents"
+	Loomcycle_Health_FullMethodName              = "/loomcycle.v1.Loomcycle/Health"
+	Loomcycle_RegisterHook_FullMethodName        = "/loomcycle.v1.Loomcycle/RegisterHook"
+	Loomcycle_ListHooks_FullMethodName           = "/loomcycle.v1.Loomcycle/ListHooks"
+	Loomcycle_DeleteHook_FullMethodName          = "/loomcycle.v1.Loomcycle/DeleteHook"
+	Loomcycle_PauseRuntime_FullMethodName        = "/loomcycle.v1.Loomcycle/PauseRuntime"
+	Loomcycle_ResumeRuntime_FullMethodName       = "/loomcycle.v1.Loomcycle/ResumeRuntime"
+	Loomcycle_GetRuntimeState_FullMethodName     = "/loomcycle.v1.Loomcycle/GetRuntimeState"
+	Loomcycle_CreateSnapshot_FullMethodName      = "/loomcycle.v1.Loomcycle/CreateSnapshot"
+	Loomcycle_ListSnapshots_FullMethodName       = "/loomcycle.v1.Loomcycle/ListSnapshots"
+	Loomcycle_GetSnapshot_FullMethodName         = "/loomcycle.v1.Loomcycle/GetSnapshot"
+	Loomcycle_ExportSnapshot_FullMethodName      = "/loomcycle.v1.Loomcycle/ExportSnapshot"
+	Loomcycle_RestoreSnapshot_FullMethodName     = "/loomcycle.v1.Loomcycle/RestoreSnapshot"
+	Loomcycle_DeleteSnapshot_FullMethodName      = "/loomcycle.v1.Loomcycle/DeleteSnapshot"
+	Loomcycle_AgentDef_FullMethodName            = "/loomcycle.v1.Loomcycle/AgentDef"
+	Loomcycle_SkillDef_FullMethodName            = "/loomcycle.v1.Loomcycle/SkillDef"
+	Loomcycle_ListChannels_FullMethodName        = "/loomcycle.v1.Loomcycle/ListChannels"
+	Loomcycle_StreamUserRunStates_FullMethodName = "/loomcycle.v1.Loomcycle/StreamUserRunStates"
 )
 
 // LoomcycleClient is the client API for Loomcycle service.
@@ -184,6 +186,15 @@ type LoomcycleClient interface {
 	// SkillDef dispatches to the in-process SkillDef tool. Mirrors
 	// POST /v1/_skilldef.
 	SkillDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error)
+	// ----- v0.9.x n8n RFC Phase 0 -----
+	//
+	// ListChannels mirrors GET /v1/_channels — operator-declared
+	// channels joined with runtime stats.
+	ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error)
+	// StreamUserRunStates mirrors GET /v1/users/{user_id}/agents/stream.
+	// Server-streams one RunStateEvent per matching state transition
+	// until ctx cancels or the client closes the stream.
+	StreamUserRunStates(ctx context.Context, in *StreamUserRunStatesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RunStateEvent], error)
 }
 
 type loomcycleClient struct {
@@ -422,6 +433,35 @@ func (c *loomcycleClient) SkillDef(ctx context.Context, in *SubstrateRequest, op
 	return out, nil
 }
 
+func (c *loomcycleClient) ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListChannelsResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_ListChannels_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *loomcycleClient) StreamUserRunStates(ctx context.Context, in *StreamUserRunStatesRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[RunStateEvent], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &Loomcycle_ServiceDesc.Streams[2], Loomcycle_StreamUserRunStates_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[StreamUserRunStatesRequest, RunStateEvent]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Loomcycle_StreamUserRunStatesClient = grpc.ServerStreamingClient[RunStateEvent]
+
 // LoomcycleServer is the server API for Loomcycle service.
 // All implementations must embed UnimplementedLoomcycleServer
 // for forward compatibility.
@@ -545,6 +585,15 @@ type LoomcycleServer interface {
 	// SkillDef dispatches to the in-process SkillDef tool. Mirrors
 	// POST /v1/_skilldef.
 	SkillDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error)
+	// ----- v0.9.x n8n RFC Phase 0 -----
+	//
+	// ListChannels mirrors GET /v1/_channels — operator-declared
+	// channels joined with runtime stats.
+	ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error)
+	// StreamUserRunStates mirrors GET /v1/users/{user_id}/agents/stream.
+	// Server-streams one RunStateEvent per matching state transition
+	// until ctx cancels or the client closes the stream.
+	StreamUserRunStates(*StreamUserRunStatesRequest, grpc.ServerStreamingServer[RunStateEvent]) error
 	mustEmbedUnimplementedLoomcycleServer()
 }
 
@@ -617,6 +666,12 @@ func (UnimplementedLoomcycleServer) AgentDef(context.Context, *SubstrateRequest)
 }
 func (UnimplementedLoomcycleServer) SkillDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SkillDef not implemented")
+}
+func (UnimplementedLoomcycleServer) ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListChannels not implemented")
+}
+func (UnimplementedLoomcycleServer) StreamUserRunStates(*StreamUserRunStatesRequest, grpc.ServerStreamingServer[RunStateEvent]) error {
+	return status.Error(codes.Unimplemented, "method StreamUserRunStates not implemented")
 }
 func (UnimplementedLoomcycleServer) mustEmbedUnimplementedLoomcycleServer() {}
 func (UnimplementedLoomcycleServer) testEmbeddedByValue()                   {}
@@ -1003,6 +1058,35 @@ func _Loomcycle_SkillDef_Handler(srv interface{}, ctx context.Context, dec func(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Loomcycle_ListChannels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListChannelsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).ListChannels(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_ListChannels_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).ListChannels(ctx, req.(*ListChannelsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Loomcycle_StreamUserRunStates_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StreamUserRunStatesRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(LoomcycleServer).StreamUserRunStates(m, &grpc.GenericServerStream[StreamUserRunStatesRequest, RunStateEvent]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type Loomcycle_StreamUserRunStatesServer = grpc.ServerStreamingServer[RunStateEvent]
+
 // Loomcycle_ServiceDesc is the grpc.ServiceDesc for Loomcycle service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1086,6 +1170,10 @@ var Loomcycle_ServiceDesc = grpc.ServiceDesc{
 			MethodName: "SkillDef",
 			Handler:    _Loomcycle_SkillDef_Handler,
 		},
+		{
+			MethodName: "ListChannels",
+			Handler:    _Loomcycle_ListChannels_Handler,
+		},
 	},
 	Streams: []grpc.StreamDesc{
 		{
@@ -1096,6 +1184,11 @@ var Loomcycle_ServiceDesc = grpc.ServiceDesc{
 		{
 			StreamName:    "Continue",
 			Handler:       _Loomcycle_Continue_Handler,
+			ServerStreams: true,
+		},
+		{
+			StreamName:    "StreamUserRunStates",
+			Handler:       _Loomcycle_StreamUserRunStates_Handler,
 			ServerStreams: true,
 		},
 	},

--- a/internal/api/grpc/n8n.go
+++ b/internal/api/grpc/n8n.go
@@ -1,0 +1,88 @@
+// n8n.go — gRPC handlers for the v0.9.x n8n RFC Phase 0 RPCs.
+// ListChannels is sync request/response; StreamUserRunStates is a
+// server-streamed RPC backed by the Connector's visitor-pattern.
+package grpc
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// ListChannels — mirrors GET /v1/_channels.
+func (s *Server) ListChannels(ctx context.Context, _ *loomcyclepb.ListChannelsRequest) (*loomcyclepb.ListChannelsResponse, error) {
+	if s.connector == nil {
+		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	resp, err := s.connector.ListChannels(ctx)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	out := &loomcyclepb.ListChannelsResponse{
+		Channels: make([]*loomcyclepb.ChannelDescriptor, 0, len(resp.Channels)),
+	}
+	for _, c := range resp.Channels {
+		out.Channels = append(out.Channels, &loomcyclepb.ChannelDescriptor{
+			Name:            c.Name,
+			Scope:           c.Scope,
+			Semantic:        c.Semantic,
+			Publisher:       c.Publisher,
+			Period:          c.Period,
+			DefaultTtl:      int32(c.DefaultTTL),
+			MaxMessages:     int32(c.MaxMessages),
+			MessageCount:    c.MessageCount,
+			OldestVisibleAt: c.OldestVisibleAt,
+			NewestVisibleAt: c.NewestVisibleAt,
+		})
+	}
+	return out, nil
+}
+
+// StreamUserRunStates — server-streamed RPC that mirrors
+// GET /v1/users/{user_id}/agents/stream. Yields one RunStateEvent
+// per matching state transition until ctx fires.
+func (s *Server) StreamUserRunStates(req *loomcyclepb.StreamUserRunStatesRequest, stream loomcyclepb.Loomcycle_StreamUserRunStatesServer) error {
+	if s.connector == nil {
+		return status.Error(codes.Unavailable, "connector not wired")
+	}
+	if req.GetUserId() == "" {
+		return status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	cReq := connector.StreamUserRunStatesRequest{
+		UserID:   req.GetUserId(),
+		Statuses: req.GetStatuses(),
+		Agent:    req.GetAgent(),
+	}
+
+	visit := func(evt connector.RunStateEvent) error {
+		// Translate Connector event into the proto event. Send error
+		// propagates as a non-sentinel error from the visitor; the
+		// connector loop will treat it as a real error and unwind.
+		return stream.Send(&loomcyclepb.RunStateEvent{
+			RunId:         evt.RunID,
+			AgentId:       evt.AgentID,
+			Agent:         evt.Agent,
+			UserId:        evt.UserID,
+			ParentAgentId: evt.ParentAgentID,
+			Status:        evt.Status,
+			StopReason:    evt.StopReason,
+			Error:         evt.Error,
+			Ts:            evt.TS,
+		})
+	}
+
+	err := s.connector.StreamUserRunStates(stream.Context(), cReq, visit)
+	if err != nil {
+		if errors.Is(err, connector.ErrRunStateStreamUnavailable) {
+			return status.Error(codes.Unavailable, err.Error())
+		}
+		return status.Error(codes.Internal, err.Error())
+	}
+	return nil
+}

--- a/internal/api/grpc/n8n_test.go
+++ b/internal/api/grpc/n8n_test.go
@@ -1,0 +1,118 @@
+package grpc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// n8nMock embeds mockConnector and overrides ListChannels +
+// StreamUserRunStates for the v0.9.x tests.
+type n8nMock struct {
+	mockConnector
+
+	listChannelsResp connector.ListChannelsResponse
+	listChannelsErr  error
+	streamEvents     []connector.RunStateEvent
+	streamErr        error
+	lastStreamReq    connector.StreamUserRunStatesRequest
+}
+
+func (m *n8nMock) ListChannels(context.Context) (connector.ListChannelsResponse, error) {
+	return m.listChannelsResp, m.listChannelsErr
+}
+
+func (m *n8nMock) StreamUserRunStates(_ context.Context, req connector.StreamUserRunStatesRequest, visit connector.RunStateVisitor) error {
+	m.lastStreamReq = req
+	for _, evt := range m.streamEvents {
+		if err := visit(evt); err != nil {
+			if errors.Is(err, connector.ErrStopStreaming) {
+				return nil
+			}
+			return err
+		}
+	}
+	return m.streamErr
+}
+
+func TestGrpcListChannels_HappyPath(t *testing.T) {
+	mc := &n8nMock{
+		listChannelsResp: connector.ListChannelsResponse{
+			Channels: []connector.ChannelDescriptor{
+				{Name: "alpha", MessageCount: 3, OldestVisibleAt: "2026-05-20T00:00:00Z"},
+				{Name: "beta", MessageCount: 0},
+			},
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ListChannels(context.Background(), &loomcyclepb.ListChannelsRequest{})
+	if err != nil {
+		t.Fatalf("ListChannels: %v", err)
+	}
+	if len(resp.GetChannels()) != 2 {
+		t.Fatalf("got %d channels, want 2: %+v", len(resp.GetChannels()), resp.GetChannels())
+	}
+	if resp.GetChannels()[0].GetName() != "alpha" || resp.GetChannels()[0].GetMessageCount() != 3 {
+		t.Errorf("channel[0] = %+v", resp.GetChannels()[0])
+	}
+}
+
+func TestGrpcStreamUserRunStates_StreamsAllEvents(t *testing.T) {
+	mc := &n8nMock{
+		streamEvents: []connector.RunStateEvent{
+			{RunID: "r1", UserID: "user-a", Status: "running"},
+			{RunID: "r2", UserID: "user-a", Status: "completed", StopReason: "end_turn"},
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	stream, err := client.StreamUserRunStates(context.Background(), &loomcyclepb.StreamUserRunStatesRequest{
+		UserId:   "user-a",
+		Statuses: []string{"running", "completed"},
+	})
+	if err != nil {
+		t.Fatalf("StreamUserRunStates: %v", err)
+	}
+
+	var got []*loomcyclepb.RunStateEvent
+	for {
+		evt, err := stream.Recv()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Recv: %v", err)
+		}
+		got = append(got, evt)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[0].GetRunId() != "r1" || got[1].GetStatus() != "completed" {
+		t.Errorf("events = %+v", got)
+	}
+	if mc.lastStreamReq.UserID != "user-a" || len(mc.lastStreamReq.Statuses) != 2 {
+		t.Errorf("connector req = %+v", mc.lastStreamReq)
+	}
+}
+
+func TestGrpcStreamUserRunStates_RejectsMissingUserID(t *testing.T) {
+	client, cleanup := startTestServerWithConnector(t, &n8nMock{})
+	defer cleanup()
+
+	stream, err := client.StreamUserRunStates(context.Background(), &loomcyclepb.StreamUserRunStatesRequest{})
+	if err != nil {
+		t.Fatalf("StreamUserRunStates(no user_id): %v", err)
+	}
+	_, err = stream.Recv()
+	if err == nil {
+		t.Fatal("expected error for empty user_id")
+	}
+}

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -804,6 +804,12 @@ func (m *mockConnector) ListHooks(context.Context) (connector.ListHooksResponse,
 	return connector.ListHooksResponse{}, nil
 }
 func (m *mockConnector) DeleteHook(context.Context, string) error { return nil }
+func (m *mockConnector) ListChannels(context.Context) (connector.ListChannelsResponse, error) {
+	return connector.ListChannelsResponse{}, nil
+}
+func (m *mockConnector) StreamUserRunStates(context.Context, connector.StreamUserRunStatesRequest, connector.RunStateVisitor) error {
+	return nil
+}
 
 // TestGrpcServer_CancelAgent_DispatchesThroughConnector is the v0.8.15
 // regression guard: when the gRPC Server is wired with a Connector,

--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -1,0 +1,112 @@
+// channels_admin.go — admin/list endpoints for the v0.8.4 Channel
+// surface. Phase 0 of the n8n integration RFC: GET /v1/_channels
+// returns the operator-declared channel set joined with cheap
+// aggregate stats from channel_messages, so n8n's credential-picker
+// (and any other operator dashboard) can render a channel-name
+// dropdown without re-parsing the loomcycle yaml.
+//
+// Counts + visible-at bounds come from a single SQL aggregate on
+// channel_messages; channels declared in yaml but with no messages
+// are still returned (zero counts) so the list reflects the full
+// declared surface rather than only "channels that have ever been
+// published to."
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// ChannelDescriptor is one row in the GET /v1/_channels response.
+// Mirrors the connector.ChannelDescriptor shape so the HTTP body, MCP
+// list_channels response, and gRPC ListChannels response all encode
+// the same way.
+type ChannelDescriptor struct {
+	Name            string    `json:"name"`
+	Scope           string    `json:"scope,omitempty"`
+	Semantic        string    `json:"semantic,omitempty"`
+	Publisher       string    `json:"publisher,omitempty"`
+	Period          string    `json:"period,omitempty"`
+	DefaultTTL      int       `json:"default_ttl,omitempty"`
+	MaxMessages     int       `json:"max_messages,omitempty"`
+	MessageCount    int64     `json:"message_count"`
+	OldestVisibleAt time.Time `json:"oldest_visible_at,omitempty"`
+	NewestVisibleAt time.Time `json:"newest_visible_at,omitempty"`
+}
+
+type channelsListResponse struct {
+	Channels []ChannelDescriptor `json:"channels"`
+}
+
+// handleListChannels serves GET /v1/_channels. Bearer-authed. Joins
+// the operator-declared map in cfg.Channels with the aggregate stats
+// over channel_messages. Channels declared but never published-to
+// appear with MessageCount=0. Returns 500 on store error.
+func (s *Server) handleListChannels(w http.ResponseWriter, r *http.Request) {
+	stats, err := s.store.ChannelStats(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	statsByName := make(map[string]struct {
+		Count           int64
+		OldestVisibleAt time.Time
+		NewestVisibleAt time.Time
+	}, len(stats))
+	for _, st := range stats {
+		statsByName[st.Channel] = struct {
+			Count           int64
+			OldestVisibleAt time.Time
+			NewestVisibleAt time.Time
+		}{st.MessageCount, st.OldestVisibleAt, st.NewestVisibleAt}
+	}
+
+	out := make([]ChannelDescriptor, 0, len(s.cfg.Channels))
+	for name, ch := range s.cfg.Channels {
+		desc := channelDescriptorFromConfig(name, ch)
+		if st, ok := statsByName[name]; ok {
+			desc.MessageCount = st.Count
+			desc.OldestVisibleAt = st.OldestVisibleAt
+			desc.NewestVisibleAt = st.NewestVisibleAt
+		}
+		out = append(out, desc)
+	}
+
+	// Also surface channels that have rows but are NOT in the
+	// declared yaml (shouldn't normally happen post-v0.8.4 since
+	// publish validates against the declared set; included so
+	// operators investigating orphaned rows after a yaml edit can
+	// still see them).
+	for name, st := range statsByName {
+		if _, declared := s.cfg.Channels[name]; declared {
+			continue
+		}
+		out = append(out, ChannelDescriptor{
+			Name:            name,
+			MessageCount:    st.Count,
+			OldestVisibleAt: st.OldestVisibleAt,
+			NewestVisibleAt: st.NewestVisibleAt,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(channelsListResponse{Channels: out})
+}
+
+func channelDescriptorFromConfig(name string, ch config.Channel) ChannelDescriptor {
+	return ChannelDescriptor{
+		Name:        name,
+		Scope:       ch.Scope,
+		Semantic:    ch.Semantic,
+		Publisher:   ch.Publisher,
+		Period:      ch.Period,
+		DefaultTTL:  ch.DefaultTTL,
+		MaxMessages: ch.MaxMessages,
+	}
+}

--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -15,98 +15,18 @@ package http
 import (
 	"encoding/json"
 	"net/http"
-	"sort"
-	"time"
-
-	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
-// ChannelDescriptor is one row in the GET /v1/_channels response.
-// Mirrors the connector.ChannelDescriptor shape so the HTTP body, MCP
-// list_channels response, and gRPC ListChannels response all encode
-// the same way.
-type ChannelDescriptor struct {
-	Name            string    `json:"name"`
-	Scope           string    `json:"scope,omitempty"`
-	Semantic        string    `json:"semantic,omitempty"`
-	Publisher       string    `json:"publisher,omitempty"`
-	Period          string    `json:"period,omitempty"`
-	DefaultTTL      int       `json:"default_ttl,omitempty"`
-	MaxMessages     int       `json:"max_messages,omitempty"`
-	MessageCount    int64     `json:"message_count"`
-	OldestVisibleAt time.Time `json:"oldest_visible_at,omitempty"`
-	NewestVisibleAt time.Time `json:"newest_visible_at,omitempty"`
-}
-
-type channelsListResponse struct {
-	Channels []ChannelDescriptor `json:"channels"`
-}
-
-// handleListChannels serves GET /v1/_channels. Bearer-authed. Joins
-// the operator-declared map in cfg.Channels with the aggregate stats
-// over channel_messages. Channels declared but never published-to
-// appear with MessageCount=0. Returns 500 on store error.
+// handleListChannels serves GET /v1/_channels. Bearer-authed.
+// Dispatches through the Connector (the canonical impl lives in
+// connector_impl_n8n.go) so MCP + gRPC and the HTTP handler return
+// the same shape from the same code path.
 func (s *Server) handleListChannels(w http.ResponseWriter, r *http.Request) {
-	stats, err := s.store.ChannelStats(r.Context())
+	resp, err := s.ListChannels(r.Context())
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	statsByName := make(map[string]struct {
-		Count           int64
-		OldestVisibleAt time.Time
-		NewestVisibleAt time.Time
-	}, len(stats))
-	for _, st := range stats {
-		statsByName[st.Channel] = struct {
-			Count           int64
-			OldestVisibleAt time.Time
-			NewestVisibleAt time.Time
-		}{st.MessageCount, st.OldestVisibleAt, st.NewestVisibleAt}
-	}
-
-	out := make([]ChannelDescriptor, 0, len(s.cfg.Channels))
-	for name, ch := range s.cfg.Channels {
-		desc := channelDescriptorFromConfig(name, ch)
-		if st, ok := statsByName[name]; ok {
-			desc.MessageCount = st.Count
-			desc.OldestVisibleAt = st.OldestVisibleAt
-			desc.NewestVisibleAt = st.NewestVisibleAt
-		}
-		out = append(out, desc)
-	}
-
-	// Also surface channels that have rows but are NOT in the
-	// declared yaml (shouldn't normally happen post-v0.8.4 since
-	// publish validates against the declared set; included so
-	// operators investigating orphaned rows after a yaml edit can
-	// still see them).
-	for name, st := range statsByName {
-		if _, declared := s.cfg.Channels[name]; declared {
-			continue
-		}
-		out = append(out, ChannelDescriptor{
-			Name:            name,
-			MessageCount:    st.Count,
-			OldestVisibleAt: st.OldestVisibleAt,
-			NewestVisibleAt: st.NewestVisibleAt,
-		})
-	}
-
-	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
-
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(channelsListResponse{Channels: out})
-}
-
-func channelDescriptorFromConfig(name string, ch config.Channel) ChannelDescriptor {
-	return ChannelDescriptor{
-		Name:        name,
-		Scope:       ch.Scope,
-		Semantic:    ch.Semantic,
-		Publisher:   ch.Publisher,
-		Period:      ch.Period,
-		DefaultTTL:  ch.DefaultTTL,
-		MaxMessages: ch.MaxMessages,
-	}
+	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/api/http/channels_admin_test.go
+++ b/internal/api/http/channels_admin_test.go
@@ -1,0 +1,96 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func TestListChannels_ReturnsDeclaredWithZeroCounts(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+
+	req := authedRequest("GET", "/v1/_channels", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp channelsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Channels) != 2 {
+		t.Fatalf("got %d channels, want 2 (the two declared in fixture): %+v", len(resp.Channels), resp.Channels)
+	}
+	names := map[string]ChannelDescriptor{}
+	for _, c := range resp.Channels {
+		names[c.Name] = c
+	}
+	if d, ok := names["_system/alarms/critical"]; !ok || d.MessageCount != 0 {
+		t.Errorf("_system/alarms/critical: %+v", d)
+	}
+	if d := names["_system/heartbeat-1m"]; d.Period != "1m" || d.Publisher != "system" {
+		t.Errorf("heartbeat-1m metadata wrong: %+v", d)
+	}
+}
+
+func TestListChannels_PopulatesCountsAfterPublish(t *testing.T) {
+	srv, s, cleanup := systemChannelFixture(t)
+	defer cleanup()
+
+	// Publish two messages to the declared channel via the store
+	// directly (the admin POST is exercised elsewhere).
+	for i := 0; i < 2; i++ {
+		if _, _, err := s.ChannelPublish(t.Context(), store.ChannelMessage{
+			Channel: "_system/alarms/critical",
+			Scope:   store.MemoryScopeGlobal,
+			ScopeID: "global",
+			Payload: []byte(`{"severity":"critical"}`),
+		}, 1000); err != nil {
+			t.Fatalf("ChannelPublish: %v", err)
+		}
+	}
+
+	req := authedRequest("GET", "/v1/_channels", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp channelsListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, c := range resp.Channels {
+		if c.Name == "_system/alarms/critical" {
+			if c.MessageCount != 2 {
+				t.Errorf("message_count = %d, want 2", c.MessageCount)
+			}
+			if c.OldestVisibleAt.IsZero() || c.NewestVisibleAt.IsZero() {
+				t.Errorf("visible_at bounds should be populated: %+v", c)
+			}
+			return
+		}
+	}
+	t.Fatal("alarms/critical channel not present in response")
+}
+
+func TestListChannels_RequiresBearer(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/v1/_channels", nil)
+	// no Authorization header
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}

--- a/internal/api/http/channels_admin_test.go
+++ b/internal/api/http/channels_admin_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -20,14 +21,14 @@ func TestListChannels_ReturnsDeclaredWithZeroCounts(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
-	var resp channelsListResponse
+	var resp connector.ListChannelsResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(resp.Channels) != 2 {
 		t.Fatalf("got %d channels, want 2 (the two declared in fixture): %+v", len(resp.Channels), resp.Channels)
 	}
-	names := map[string]ChannelDescriptor{}
+	names := map[string]connector.ChannelDescriptor{}
 	for _, c := range resp.Channels {
 		names[c.Name] = c
 	}
@@ -63,7 +64,7 @@ func TestListChannels_PopulatesCountsAfterPublish(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
 	}
-	var resp channelsListResponse
+	var resp connector.ListChannelsResponse
 	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
@@ -72,7 +73,7 @@ func TestListChannels_PopulatesCountsAfterPublish(t *testing.T) {
 			if c.MessageCount != 2 {
 				t.Errorf("message_count = %d, want 2", c.MessageCount)
 			}
-			if c.OldestVisibleAt.IsZero() || c.NewestVisibleAt.IsZero() {
+			if c.OldestVisibleAt == "" || c.NewestVisibleAt == "" {
 				t.Errorf("visible_at bounds should be populated: %+v", c)
 			}
 			return

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -1,0 +1,156 @@
+// connector_impl_n8n.go — Connector method bodies for the v0.9.x
+// n8n RFC Phase 0 additions (ListChannels + StreamUserRunStates).
+// Same canonical-business-logic pattern as the rest of
+// connector_impl*.go: the HTTP handlers are thin REST wrappers; the
+// real work lives here so MCP / gRPC dispatch the same code.
+package http
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+)
+
+// ListChannels returns the operator-declared channels joined with
+// runtime stats (count + oldest/newest visible_at). Mirrors what
+// handleListChannels writes to the HTTP wire — same code path
+// minus the JSON-encoder framing.
+func (s *Server) ListChannels(ctx context.Context) (connector.ListChannelsResponse, error) {
+	stats, err := s.store.ChannelStats(ctx)
+	if err != nil {
+		return connector.ListChannelsResponse{}, err
+	}
+	statsByName := make(map[string]struct {
+		Count           int64
+		OldestVisibleAt time.Time
+		NewestVisibleAt time.Time
+	}, len(stats))
+	for _, st := range stats {
+		statsByName[st.Channel] = struct {
+			Count           int64
+			OldestVisibleAt time.Time
+			NewestVisibleAt time.Time
+		}{st.MessageCount, st.OldestVisibleAt, st.NewestVisibleAt}
+	}
+
+	out := make([]connector.ChannelDescriptor, 0, len(s.cfg.Channels))
+	for name, ch := range s.cfg.Channels {
+		desc := connector.ChannelDescriptor{
+			Name:        name,
+			Scope:       ch.Scope,
+			Semantic:    ch.Semantic,
+			Publisher:   ch.Publisher,
+			Period:      ch.Period,
+			DefaultTTL:  ch.DefaultTTL,
+			MaxMessages: ch.MaxMessages,
+		}
+		if st, ok := statsByName[name]; ok {
+			desc.MessageCount = st.Count
+			if !st.OldestVisibleAt.IsZero() {
+				desc.OldestVisibleAt = st.OldestVisibleAt.UTC().Format(time.RFC3339)
+			}
+			if !st.NewestVisibleAt.IsZero() {
+				desc.NewestVisibleAt = st.NewestVisibleAt.UTC().Format(time.RFC3339)
+			}
+		}
+		out = append(out, desc)
+	}
+	// Surface orphaned message rows for channels NOT in the
+	// declared yaml — same forensic shape as the HTTP handler.
+	for name, st := range statsByName {
+		if _, declared := s.cfg.Channels[name]; declared {
+			continue
+		}
+		desc := connector.ChannelDescriptor{Name: name, MessageCount: st.Count}
+		if !st.OldestVisibleAt.IsZero() {
+			desc.OldestVisibleAt = st.OldestVisibleAt.UTC().Format(time.RFC3339)
+		}
+		if !st.NewestVisibleAt.IsZero() {
+			desc.NewestVisibleAt = st.NewestVisibleAt.UTC().Format(time.RFC3339)
+		}
+		out = append(out, desc)
+	}
+	// Deterministic order — easier on transports that snapshot the
+	// response for caching or comparison.
+	sortChannelDescriptors(out)
+	return connector.ListChannelsResponse{Channels: out}, nil
+}
+
+func sortChannelDescriptors(out []connector.ChannelDescriptor) {
+	// In-place insertion sort by Name. Channel counts are typically
+	// small (~10s); avoiding the sort package keeps the call free of
+	// heap allocations on a hot listing path.
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1].Name > out[j].Name; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+}
+
+// StreamUserRunStates subscribes to the runstate.Bus and calls visit
+// for every event matching the filter. Exits cleanly when ctx
+// cancels (returning nil) or when visit returns ErrStopStreaming.
+// Non-sentinel visit errors propagate.
+//
+// Each call holds one bus subscription for its lifetime — slow
+// visitors that don't drain in time cause drops on the subscription's
+// buffer (logged as DroppedEvents at unsubscribe).
+func (s *Server) StreamUserRunStates(ctx context.Context, req connector.StreamUserRunStatesRequest, visit connector.RunStateVisitor) error {
+	if s.runStateBus == nil {
+		return connector.ErrRunStateStreamUnavailable
+	}
+
+	statusSet := make(map[string]bool, len(req.Statuses))
+	for _, st := range req.Statuses {
+		if st != "" {
+			statusSet[st] = true
+		}
+	}
+
+	sub := s.runStateBus.Subscribe(req.UserID)
+	defer sub.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-sub.C:
+			if !ok {
+				return nil
+			}
+			if req.Agent != "" && evt.Agent != req.Agent {
+				continue
+			}
+			if len(statusSet) > 0 && !statusSet[evt.Status] {
+				continue
+			}
+			if err := visit(runStateEventToConnector(evt)); err != nil {
+				if errors.Is(err, connector.ErrStopStreaming) {
+					return nil
+				}
+				return err
+			}
+		}
+	}
+}
+
+func runStateEventToConnector(e runstate.RunStateEvent) connector.RunStateEvent {
+	ts := ""
+	if !e.TS.IsZero() {
+		ts = e.TS.UTC().Format(time.RFC3339)
+	}
+	return connector.RunStateEvent{
+		RunID:         e.RunID,
+		AgentID:       e.AgentID,
+		Agent:         e.Agent,
+		UserID:        e.UserID,
+		ParentAgentID: e.ParentAgentID,
+		Status:        e.Status,
+		StopReason:    e.StopReason,
+		Error:         e.Error,
+		TS:            ts,
+	}
+}

--- a/internal/api/http/connector_impl_n8n_test.go
+++ b/internal/api/http/connector_impl_n8n_test.go
@@ -1,0 +1,140 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func TestConnector_ListChannels_RoundtripThroughInterface(t *testing.T) {
+	srv, s, cleanup := systemChannelFixture(t)
+	defer cleanup()
+
+	// Publish into the declared channel.
+	ctx := t.Context()
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "_system/alarms/critical",
+		Scope:   store.MemoryScopeGlobal,
+		ScopeID: "global",
+		Payload: []byte(`{}`),
+	}, 1000); err != nil {
+		t.Fatalf("ChannelPublish: %v", err)
+	}
+
+	// Dispatch through the Connector interface (NOT the concrete
+	// *Server) — this is the call shape MCP / gRPC adapters use.
+	var c connector.Connector = srv
+	resp, err := c.ListChannels(ctx)
+	if err != nil {
+		t.Fatalf("ListChannels: %v", err)
+	}
+	if len(resp.Channels) == 0 {
+		t.Fatal("expected at least one channel")
+	}
+	var got connector.ChannelDescriptor
+	for _, ch := range resp.Channels {
+		if ch.Name == "_system/alarms/critical" {
+			got = ch
+			break
+		}
+	}
+	if got.Name == "" {
+		t.Fatalf("alarms/critical missing from response: %+v", resp.Channels)
+	}
+	if got.MessageCount != 1 {
+		t.Errorf("message_count = %d, want 1", got.MessageCount)
+	}
+	if _, err := time.Parse(time.RFC3339, got.OldestVisibleAt); err != nil {
+		t.Errorf("oldest_visible_at not RFC3339: %q (%v)", got.OldestVisibleAt, err)
+	}
+}
+
+func TestConnector_StreamUserRunStates_VisitsMatchingEvents(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+
+	var c connector.Connector = srv
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	received := make(chan connector.RunStateEvent, 4)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.StreamUserRunStates(ctx, connector.StreamUserRunStatesRequest{
+			UserID:   "user-a",
+			Statuses: []string{"completed"},
+		}, func(evt connector.RunStateEvent) error {
+			received <- evt
+			return nil
+		})
+	}()
+
+	// Wait briefly so the subscriber is registered before publishing.
+	time.Sleep(20 * time.Millisecond)
+
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})  // filtered out
+	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Status: "completed"}) // passes
+	bus.Publish(runstate.RunStateEvent{RunID: "r3", UserID: "user-b", Status: "completed"}) // wrong user
+
+	select {
+	case evt := <-received:
+		if evt.RunID != "r2" || evt.Status != "completed" {
+			t.Errorf("wrong event passed: %+v", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event delivered within 1s")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("StreamUserRunStates returned err: %v", err)
+	}
+}
+
+func TestConnector_StreamUserRunStates_StopOnSentinel(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+
+	var c connector.Connector = srv
+	ctx := t.Context()
+	done := make(chan error, 1)
+	go func() {
+		done <- c.StreamUserRunStates(ctx, connector.StreamUserRunStatesRequest{UserID: "user-a"},
+			func(evt connector.RunStateEvent) error {
+				return connector.ErrStopStreaming
+			})
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("expected nil on stop sentinel, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("StreamUserRunStates didn't return on sentinel")
+	}
+}
+
+func TestConnector_StreamUserRunStates_UnavailableWhenBusUnwired(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	// no SetRunStateBus call
+
+	var c connector.Connector = srv
+	err := c.StreamUserRunStates(t.Context(), connector.StreamUserRunStatesRequest{UserID: "x"}, func(connector.RunStateEvent) error { return nil })
+	if !errors.Is(err, connector.ErrRunStateStreamUnavailable) {
+		t.Errorf("expected ErrRunStateStreamUnavailable, got %v", err)
+	}
+}

--- a/internal/api/http/runs_stream.go
+++ b/internal/api/http/runs_stream.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
 )
 
 const (
@@ -43,40 +43,27 @@ const (
 	streamMaxLifetime = 30 * time.Minute
 )
 
-// runStateFilter is the per-request filter parsed from query params.
-// A zero filter matches every event.
-type runStateFilter struct {
-	statuses map[string]bool
-	agent    string
-}
-
-func parseRunStateFilter(q map[string][]string) runStateFilter {
-	f := runStateFilter{}
+// parseStreamFilter converts URL query params to a
+// connector.StreamUserRunStatesRequest. `?status=...,...` is
+// comma-decomposed; `?agent=<name>` is taken literally.
+func parseStreamFilter(userID string, q map[string][]string) connector.StreamUserRunStatesRequest {
+	out := connector.StreamUserRunStatesRequest{UserID: userID}
 	if vals := q["status"]; len(vals) > 0 && vals[0] != "" {
-		f.statuses = make(map[string]bool)
+		var statuses []string
 		for _, v := range vals {
 			for _, s := range strings.Split(v, ",") {
 				s = strings.TrimSpace(s)
 				if s != "" {
-					f.statuses[s] = true
+					statuses = append(statuses, s)
 				}
 			}
 		}
+		out.Statuses = statuses
 	}
 	if vals := q["agent"]; len(vals) > 0 {
-		f.agent = strings.TrimSpace(vals[0])
+		out.Agent = strings.TrimSpace(vals[0])
 	}
-	return f
-}
-
-func (f runStateFilter) matches(evt runstate.RunStateEvent) bool {
-	if f.agent != "" && evt.Agent != f.agent {
-		return false
-	}
-	if f.statuses != nil && !f.statuses[evt.Status] {
-		return false
-	}
-	return true
+	return out
 }
 
 // handleStreamUserAgents serves GET /v1/users/{user_id}/agents/stream.
@@ -106,59 +93,41 @@ func (s *Server) handleStreamUserAgents(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	filter := parseRunStateFilter(r.URL.Query())
+	req := parseStreamFilter(userID, r.URL.Query())
 
 	stream.start()
 
-	// Cap connection lifetime so a hung client doesn't pin a
-	// goroutine forever.
 	ctx, cancel := context.WithTimeout(r.Context(), streamMaxLifetime)
 	defer cancel()
 	stream.startKeepalive(ctx, streamKeepaliveInterval)
 
-	sub := s.runStateBus.Subscribe(userID)
-	defer sub.Close()
-
-	// Emit an initial "stream_open" frame so adapters can confirm
-	// the connection is live before any real events flow. Helpful
-	// for n8n's trigger-setup phase where the workflow waits for
-	// the credential test before arming.
+	// stream_open frame: adapters consume this to confirm the
+	// connection is live before any real events flow. Useful for
+	// n8n's trigger-setup phase where the workflow waits for the
+	// credential test before arming.
 	stream.sendRaw("stream_open", map[string]any{
 		"user_id":            userID,
-		"filter_status":      filterStatusesList(filter),
-		"filter_agent":       filter.agent,
+		"filter_status":      sortedCopy(req.Statuses),
+		"filter_agent":       req.Agent,
 		"keepalive_interval": int(streamKeepaliveInterval.Seconds()),
 	})
 
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case evt, ok := <-sub.C:
-			if !ok {
-				return
-			}
-			if !filter.matches(evt) {
-				continue
-			}
-			stream.sendRaw("run_state", evt)
-		}
-	}
-}
-
-// filterStatusesList is a stable representation of f.statuses for
-// the stream_open frame (the map iteration order is non-deterministic;
-// adapters that snapshot the open frame need stable bytes).
-func filterStatusesList(f runStateFilter) []string {
-	if len(f.statuses) == 0 {
+	visit := func(evt connector.RunStateEvent) error {
+		stream.sendRaw("run_state", evt)
 		return nil
 	}
-	out := make([]string, 0, len(f.statuses))
-	for s := range f.statuses {
-		out = append(out, s)
+	_ = s.StreamUserRunStates(ctx, req, visit)
+}
+
+// sortedCopy returns a sorted copy of statuses so the stream_open
+// frame's filter_status field is byte-stable regardless of query
+// ordering (adapters that snapshot the open frame for caching need
+// stable bytes).
+func sortedCopy(statuses []string) []string {
+	if len(statuses) == 0 {
+		return nil
 	}
-	// Tiny deterministic sort — len(statuses) is at most 5 in
-	// practice (running, completed, failed, cancelled, queued).
+	out := append([]string(nil), statuses...)
 	for i := 1; i < len(out); i++ {
 		for j := i; j > 0 && out[j-1] > out[j]; j-- {
 			out[j-1], out[j] = out[j], out[j-1]

--- a/internal/api/http/runs_stream.go
+++ b/internal/api/http/runs_stream.go
@@ -1,0 +1,168 @@
+// runs_stream.go — SSE stream of run state transitions for one user.
+// Phase 0 of the n8n integration RFC: trigger nodes in the n8n
+// community-node package need a way to fire when a loomcycle run
+// completes (or transitions to any specific state). This handler
+// opens a long-lived SSE connection scoped to one user_id and emits
+// one frame per transition.
+//
+// Transport is the existing sse.go primitives (event-stream content
+// type, keepalive comment frames every 25s so reverse proxies don't
+// drop the idle connection). The producer is the in-process
+// runstate.Bus — fanout is lock-free per subscription, slow
+// consumers drop events rather than block the publisher (the
+// publisher being a finishRun* call site we MUST NEVER stall).
+//
+// Filter shape (all optional):
+//   ?status=running,completed,failed,cancelled   — comma-separated allowlist
+//   ?agent=<name>                                 — exact-match agent name
+//
+// Filters apply at the handler (not the bus) so the bus stays
+// uniform across all subscribers and the same Subscription is
+// reusable in tests with different filters.
+package http
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+)
+
+const (
+	// streamKeepaliveInterval is the cadence of SSE comment-only
+	// frames. Picked to be under the 30s idle-timeout of common
+	// reverse proxies (nginx default, Cloudflare's free tier).
+	streamKeepaliveInterval = 25 * time.Second
+
+	// streamMaxLifetime caps any single SSE connection. Forces
+	// clients to reconnect periodically, which is the right shape
+	// for n8n's trigger framework (and lets us bound goroutine
+	// leakage if a client never sends FIN).
+	streamMaxLifetime = 30 * time.Minute
+)
+
+// runStateFilter is the per-request filter parsed from query params.
+// A zero filter matches every event.
+type runStateFilter struct {
+	statuses map[string]bool
+	agent    string
+}
+
+func parseRunStateFilter(q map[string][]string) runStateFilter {
+	f := runStateFilter{}
+	if vals := q["status"]; len(vals) > 0 && vals[0] != "" {
+		f.statuses = make(map[string]bool)
+		for _, v := range vals {
+			for _, s := range strings.Split(v, ",") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					f.statuses[s] = true
+				}
+			}
+		}
+	}
+	if vals := q["agent"]; len(vals) > 0 {
+		f.agent = strings.TrimSpace(vals[0])
+	}
+	return f
+}
+
+func (f runStateFilter) matches(evt runstate.RunStateEvent) bool {
+	if f.agent != "" && evt.Agent != f.agent {
+		return false
+	}
+	if f.statuses != nil && !f.statuses[evt.Status] {
+		return false
+	}
+	return true
+}
+
+// handleStreamUserAgents serves GET /v1/users/{user_id}/agents/stream.
+// Bearer-authed (the mux already wraps in authMiddleware).
+//
+// Failure modes:
+//   - missing user_id path arg     → 400 invalid_request
+//   - writer doesn't support SSE   → 500 sse_not_supported (rare; most
+//                                     test recorders DO support Flusher)
+//   - runStateBus not configured   → 503 stream_unavailable (operator
+//                                     wired loomcycle without the bus;
+//                                     defensive — main.go always wires it)
+func (s *Server) handleStreamUserAgents(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("user_id")
+	if userID == "" {
+		writeJSONError(w, http.StatusBadRequest, "invalid_request", "user_id path arg required")
+		return
+	}
+	if s.runStateBus == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "stream_unavailable", "run-state bus not configured")
+		return
+	}
+
+	stream, ok := newSSE(w)
+	if !ok {
+		writeJSONError(w, http.StatusInternalServerError, "sse_not_supported", "response writer does not support streaming")
+		return
+	}
+
+	filter := parseRunStateFilter(r.URL.Query())
+
+	stream.start()
+
+	// Cap connection lifetime so a hung client doesn't pin a
+	// goroutine forever.
+	ctx, cancel := context.WithTimeout(r.Context(), streamMaxLifetime)
+	defer cancel()
+	stream.startKeepalive(ctx, streamKeepaliveInterval)
+
+	sub := s.runStateBus.Subscribe(userID)
+	defer sub.Close()
+
+	// Emit an initial "stream_open" frame so adapters can confirm
+	// the connection is live before any real events flow. Helpful
+	// for n8n's trigger-setup phase where the workflow waits for
+	// the credential test before arming.
+	stream.sendRaw("stream_open", map[string]any{
+		"user_id":            userID,
+		"filter_status":      filterStatusesList(filter),
+		"filter_agent":       filter.agent,
+		"keepalive_interval": int(streamKeepaliveInterval.Seconds()),
+	})
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-sub.C:
+			if !ok {
+				return
+			}
+			if !filter.matches(evt) {
+				continue
+			}
+			stream.sendRaw("run_state", evt)
+		}
+	}
+}
+
+// filterStatusesList is a stable representation of f.statuses for
+// the stream_open frame (the map iteration order is non-deterministic;
+// adapters that snapshot the open frame need stable bytes).
+func filterStatusesList(f runStateFilter) []string {
+	if len(f.statuses) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(f.statuses))
+	for s := range f.statuses {
+		out = append(out, s)
+	}
+	// Tiny deterministic sort — len(statuses) is at most 5 in
+	// practice (running, completed, failed, cancelled, queued).
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}

--- a/internal/api/http/runs_stream_publish_test.go
+++ b/internal/api/http/runs_stream_publish_test.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// receiveAny blocks for up to 1s waiting for one event from sub.C.
+func receiveAny(t *testing.T, sub *runstate.Subscription) (runstate.RunStateEvent, bool) {
+	t.Helper()
+	select {
+	case evt, ok := <-sub.C:
+		return evt, ok
+	case <-time.After(time.Second):
+		return runstate.RunStateEvent{}, false
+	}
+}
+
+func TestFinishRun_PublishesCompletedToBus(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+	sub := bus.Subscribe("user-a")
+	defer sub.Close()
+
+	// Create a session + run row so FinishRun has something to write.
+	ctx := t.Context()
+	sess, err := srv.store.CreateSession(ctx, "tenant-a", "test-agent", "user-a")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "ag1", UserID: "user-a", Model: "test-model",
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+
+	meta := runStateMeta{RunID: run.ID, AgentID: "ag1", Agent: "test-agent", UserID: "user-a"}
+	srv.finishRun(ctx, run.ID, loop.RunResult{StopReason: "end_turn"}, nil, meta)
+
+	evt, ok := receiveAny(t, sub)
+	if !ok {
+		t.Fatal("no event delivered after finishRun")
+	}
+	if evt.Status != "completed" || evt.RunID != run.ID || evt.StopReason != "end_turn" {
+		t.Errorf("wrong event: %+v", evt)
+	}
+}
+
+func TestFinishRunFailedReason_PublishesFailedToBus(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+	sub := bus.Subscribe("user-a")
+	defer sub.Close()
+
+	ctx := t.Context()
+	sess, _ := srv.store.CreateSession(ctx, "tenant-a", "test-agent", "user-a")
+	run, _ := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "ag1", UserID: "user-a", Model: "test-model",
+	})
+
+	meta := runStateMeta{RunID: run.ID, AgentID: "ag1", Agent: "test-agent", UserID: "user-a"}
+	srv.finishRunFailedReason(run.ID, "registry collision", meta)
+
+	evt, ok := receiveAny(t, sub)
+	if !ok {
+		t.Fatal("no event delivered after finishRunFailedReason")
+	}
+	if evt.Status != "failed" || evt.Error != "registry collision" {
+		t.Errorf("wrong event: %+v", evt)
+	}
+}
+
+func TestFinishRunCancelled_PublishesCancelledToBus(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+	sub := bus.Subscribe("user-a")
+	defer sub.Close()
+
+	ctx := t.Context()
+	sess, _ := srv.store.CreateSession(ctx, "tenant-a", "test-agent", "user-a")
+	run, _ := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "ag1", UserID: "user-a", Model: "test-model",
+	})
+
+	meta := runStateMeta{RunID: run.ID, AgentID: "ag1", Agent: "test-agent", UserID: "user-a"}
+	srv.finishRunCancelled(ctx, run.ID, loop.RunResult{}, "cancelled by api", meta)
+
+	evt, ok := receiveAny(t, sub)
+	if !ok {
+		t.Fatal("no event delivered after finishRunCancelled")
+	}
+	if evt.Status != "cancelled" || evt.StopReason != "cancelled by api" {
+		t.Errorf("wrong event: %+v", evt)
+	}
+}
+
+func TestFinishRun_NoEventWhenBusUnwired(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	// Note: no SetRunStateBus call.
+
+	ctx := t.Context()
+	sess, _ := srv.store.CreateSession(ctx, "tenant-a", "test-agent", "user-a")
+	run, _ := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: "ag1", UserID: "user-a", Model: "test-model",
+	})
+	meta := runStateMeta{RunID: run.ID, AgentID: "ag1", UserID: "user-a"}
+	// Must not panic / no-op when bus is nil.
+	srv.finishRun(ctx, run.ID, loop.RunResult{StopReason: "end_turn"}, nil, meta)
+}

--- a/internal/api/http/runs_stream_test.go
+++ b/internal/api/http/runs_stream_test.go
@@ -231,24 +231,28 @@ func TestStreamUserAgents_503WhenBusUnwired(t *testing.T) {
 	}
 }
 
-func TestParseRunStateFilter_AcceptsCommaSeparated(t *testing.T) {
-	f := parseRunStateFilter(map[string][]string{"status": {"running,completed,failed"}})
-	if len(f.statuses) != 3 {
-		t.Fatalf("got %d statuses, want 3: %v", len(f.statuses), f.statuses)
+func TestParseStreamFilter_AcceptsCommaSeparated(t *testing.T) {
+	req := parseStreamFilter("user-a", map[string][]string{"status": {"running,completed,failed"}})
+	if req.UserID != "user-a" {
+		t.Errorf("user_id = %q, want user-a", req.UserID)
 	}
-	for _, s := range []string{"running", "completed", "failed"} {
-		if !f.statuses[s] {
-			t.Errorf("status %q missing", s)
+	if len(req.Statuses) != 3 {
+		t.Fatalf("got %d statuses, want 3: %v", len(req.Statuses), req.Statuses)
+	}
+	want := map[string]bool{"running": true, "completed": true, "failed": true}
+	for _, s := range req.Statuses {
+		if !want[s] {
+			t.Errorf("status %q not expected", s)
 		}
 	}
 }
 
-func TestParseRunStateFilter_MatchesEverythingWhenEmpty(t *testing.T) {
-	f := parseRunStateFilter(map[string][]string{})
-	if !f.matches(runstate.RunStateEvent{Status: "running"}) {
-		t.Error("zero filter should match")
+func TestParseStreamFilter_EmptyMeansNoFilter(t *testing.T) {
+	req := parseStreamFilter("user-a", map[string][]string{})
+	if len(req.Statuses) != 0 {
+		t.Errorf("expected empty statuses, got %v", req.Statuses)
 	}
-	if !f.matches(runstate.RunStateEvent{Status: "completed", Agent: "any"}) {
-		t.Error("zero filter should match")
+	if req.Agent != "" {
+		t.Errorf("expected empty agent, got %q", req.Agent)
 	}
 }

--- a/internal/api/http/runs_stream_test.go
+++ b/internal/api/http/runs_stream_test.go
@@ -1,0 +1,254 @@
+package http
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+)
+
+// streamFixture extends systemChannelFixture with a runstate.Bus
+// installed. Returns the server, the bus, and a cleanup func.
+func streamFixture(t *testing.T) (*Server, *runstate.Bus, func()) {
+	t.Helper()
+	srv, _, cleanup := systemChannelFixture(t)
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+	return srv, bus, cleanup
+}
+
+// readSSEFrame parses one event frame from a bufio.Reader. Returns
+// (eventName, data, ok). Blocks until a complete frame arrives or the
+// reader returns an error.
+func readSSEFrame(t *testing.T, r *bufio.Reader) (string, string, bool) {
+	t.Helper()
+	var ev, data string
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return "", "", false
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if ev != "" || data != "" {
+				return ev, data, true
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "event: ") {
+			ev = strings.TrimPrefix(line, "event: ")
+		} else if strings.HasPrefix(line, "data: ") {
+			if data != "" {
+				data += "\n"
+			}
+			data += strings.TrimPrefix(line, "data: ")
+		}
+		// `:` comment lines (keepalives) ignored
+	}
+}
+
+// openStream starts an httptest.NewServer-backed SSE connection and
+// returns a bufio.Reader over the response body plus a cancel func.
+// The caller must call cancel() to clean up.
+func openStream(t *testing.T, srv *Server, userID, queryString string) (*bufio.Reader, context.CancelFunc, *httptest.Server) {
+	t.Helper()
+	ts := httptest.NewServer(srv.Mux())
+	target := ts.URL + "/v1/users/" + userID + "/agents/stream"
+	if queryString != "" {
+		target += "?" + queryString
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	req, err := http.NewRequestWithContext(ctx, "GET", target, nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = resp.Body.Close()
+		ts.Close()
+	})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	return bufio.NewReader(resp.Body), cancel, ts
+}
+
+func TestStreamUserAgents_EmitsStreamOpenAndRunStateEvents(t *testing.T) {
+	srv, bus, cleanup := streamFixture(t)
+	defer cleanup()
+
+	reader, cancel, _ := openStream(t, srv, "user-a", "")
+	defer cancel()
+
+	ev, data, ok := readSSEFrame(t, reader)
+	if !ok {
+		t.Fatal("no stream_open frame")
+	}
+	if ev != "stream_open" {
+		t.Fatalf("first frame event = %q, want stream_open; data=%s", ev, data)
+	}
+	var openPayload map[string]any
+	if err := json.Unmarshal([]byte(data), &openPayload); err != nil {
+		t.Fatalf("stream_open decode: %v", err)
+	}
+	if openPayload["user_id"] != "user-a" {
+		t.Errorf("stream_open user_id = %v, want user-a", openPayload["user_id"])
+	}
+
+	bus.Publish(runstate.RunStateEvent{
+		RunID: "r1", Agent: "researcher", UserID: "user-a", Status: "running",
+	})
+
+	ev, data, ok = readSSEFrame(t, reader)
+	if !ok {
+		t.Fatal("no run_state frame after publish")
+	}
+	if ev != "run_state" {
+		t.Fatalf("event = %q, want run_state; data=%s", ev, data)
+	}
+	var evt runstate.RunStateEvent
+	if err := json.Unmarshal([]byte(data), &evt); err != nil {
+		t.Fatalf("run_state decode: %v", err)
+	}
+	if evt.RunID != "r1" || evt.Status != "running" || evt.Agent != "researcher" {
+		t.Errorf("wrong run_state payload: %+v", evt)
+	}
+}
+
+func TestStreamUserAgents_FiltersByStatus(t *testing.T) {
+	srv, bus, cleanup := streamFixture(t)
+	defer cleanup()
+
+	reader, cancel, _ := openStream(t, srv, "user-a", "status=completed")
+	defer cancel()
+
+	// drain stream_open
+	if _, _, ok := readSSEFrame(t, reader); !ok {
+		t.Fatal("no stream_open")
+	}
+
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
+	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Status: "completed"})
+
+	ev, data, ok := readSSEFrame(t, reader)
+	if !ok {
+		t.Fatal("no event after publishes")
+	}
+	if ev != "run_state" {
+		t.Fatalf("event = %q, want run_state", ev)
+	}
+	var evt runstate.RunStateEvent
+	_ = json.Unmarshal([]byte(data), &evt)
+	if evt.RunID != "r2" || evt.Status != "completed" {
+		t.Errorf("filter let wrong event through: %+v", evt)
+	}
+}
+
+func TestStreamUserAgents_FiltersByAgent(t *testing.T) {
+	srv, bus, cleanup := streamFixture(t)
+	defer cleanup()
+
+	reader, cancel, _ := openStream(t, srv, "user-a", "agent=writer")
+	defer cancel()
+
+	if _, _, ok := readSSEFrame(t, reader); !ok {
+		t.Fatal("no stream_open")
+	}
+
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Agent: "reader", Status: "running"})
+	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Agent: "writer", Status: "running"})
+
+	ev, data, ok := readSSEFrame(t, reader)
+	if !ok {
+		t.Fatal("no event")
+	}
+	var evt runstate.RunStateEvent
+	_ = json.Unmarshal([]byte(data), &evt)
+	if ev != "run_state" || evt.Agent != "writer" {
+		t.Errorf("agent filter wrong: ev=%q evt=%+v", ev, evt)
+	}
+}
+
+func TestStreamUserAgents_OtherUsersEventsNotDelivered(t *testing.T) {
+	srv, bus, cleanup := streamFixture(t)
+	defer cleanup()
+
+	reader, cancel, _ := openStream(t, srv, "user-a", "")
+	defer cancel()
+
+	if _, _, ok := readSSEFrame(t, reader); !ok {
+		t.Fatal("no stream_open")
+	}
+
+	// Event for a different user.
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-b", Status: "running"})
+
+	doneFrame := make(chan struct{})
+	go func() {
+		_, _, _ = readSSEFrame(t, reader)
+		close(doneFrame)
+	}()
+	select {
+	case <-doneFrame:
+		t.Error("user-a received event for user-b")
+	case <-time.After(200 * time.Millisecond):
+		// expected — no event delivered
+	}
+}
+
+func TestStreamUserAgents_RequiresBearer(t *testing.T) {
+	srv, _, cleanup := streamFixture(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/v1/users/user-a/agents/stream", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+	if rec.Code != 401 {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+}
+
+func TestStreamUserAgents_503WhenBusUnwired(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	// Note: no SetRunStateBus call.
+
+	req := authedRequest("GET", "/v1/users/user-a/agents/stream", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+	if rec.Code != 503 {
+		t.Errorf("status = %d, want 503", rec.Code)
+	}
+}
+
+func TestParseRunStateFilter_AcceptsCommaSeparated(t *testing.T) {
+	f := parseRunStateFilter(map[string][]string{"status": {"running,completed,failed"}})
+	if len(f.statuses) != 3 {
+		t.Fatalf("got %d statuses, want 3: %v", len(f.statuses), f.statuses)
+	}
+	for _, s := range []string{"running", "completed", "failed"} {
+		if !f.statuses[s] {
+			t.Errorf("status %q missing", s)
+		}
+	}
+}
+
+func TestParseRunStateFilter_MatchesEverythingWhenEmpty(t *testing.T) {
+	f := parseRunStateFilter(map[string][]string{})
+	if !f.matches(runstate.RunStateEvent{Status: "running"}) {
+		t.Error("zero filter should match")
+	}
+	if !f.matches(runstate.RunStateEvent{Status: "completed", Agent: "any"}) {
+		t.Error("zero filter should match")
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -133,6 +134,14 @@ type Server struct {
 	// row's expires_at passes) but in-process wakeup is skipped. Set
 	// via SetInterruptionBus from main.go.
 	interruptionBus *channels.Bus
+
+	// runStateBus is the v0.9.x n8n RFC Phase 0 in-process pub/sub
+	// for run state transitions. Powers GET /v1/users/{user_id}/
+	// agents/stream (SSE). Every finishRun* call site + the run-
+	// creation moment publish here; the SSE handler subscribes.
+	// Nil = the /agents/stream endpoint returns 503. Set via
+	// SetRunStateBus from main.go.
+	runStateBus *runstate.Bus
 
 	// mcpHTTPHandler is the v0.8.15.3 HTTP MCP transport (alternate
 	// front-end to the stdio MCP server). Typed as http.Handler — NOT
@@ -287,6 +296,13 @@ func (s *Server) SetSystemPublisher(p channels.SystemPublisher) {
 // tool. Same Bus instance the Channel tool uses.
 func (s *Server) SetInterruptionBus(b *channels.Bus) {
 	s.interruptionBus = b
+}
+
+// SetRunStateBus wires the v0.9.x run-state pub/sub bus that backs
+// GET /v1/users/{user_id}/agents/stream. Without this call the SSE
+// endpoint refuses with 503. Constructed once per process in main.go.
+func (s *Server) SetRunStateBus(b *runstate.Bus) {
+	s.runStateBus = b
 }
 
 // newDispatcher centralises Dispatcher construction so the three call
@@ -1049,15 +1065,25 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		UserID:    effectiveUserID,
 		StartedAt: time.Now(),
 	}, cancelFn)
+	// v0.9.x n8n RFC Phase 0: identity bundle for runstate.Bus
+	// publishes. Constructed once; passed to every finishRun* below
+	// AND used right now for the "running" transition.
+	meta := runStateMeta{
+		RunID:   runID,
+		AgentID: agentID,
+		Agent:   effectiveAgentName,
+		UserID:  effectiveUserID,
+	}
 	if errors.Is(regErr, cancel.ErrInUse) {
-		s.finishRunFailedReason(runID, "agent_id collision; run never started")
+		s.finishRunFailedReason(runID, "agent_id collision; run never started", meta)
 		return fmt.Errorf("%w: agent_id %q is already mapped to an active run", runner.ErrAgentIDInUse, agentID)
 	}
 	if regErr != nil {
-		s.finishRunFailedReason(runID, "registry register failed: "+regErr.Error())
+		s.finishRunFailedReason(runID, "registry register failed: "+regErr.Error(), meta)
 		return fmt.Errorf("%w: %v", runner.ErrInternal, regErr)
 	}
 	defer s.cancelReg.Deregister(agentID)
+	s.publishRunState(meta, "running", "", "")
 
 	// ---- Persist input segments ----
 	if s.store != nil && runID != "" {
@@ -1140,7 +1166,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
-	s.finishRunWithCancel(ctx, runCtx, runID, res, runErr)
+	s.finishRunWithCancel(ctx, runCtx, runID, res, runErr, meta)
 	return nil
 }
 
@@ -1222,6 +1248,11 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/agents/{agent_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleGetAgent))))
 	mux.Handle("POST /v1/agents/{agent_id}/cancel", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCancelAgent))))
 	mux.Handle("GET /v1/users/{user_id}/agents", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUserAgents))))
+	// v0.9.x n8n RFC Phase 0: SSE stream of run state transitions
+	// scoped to one user_id. Filters via ?status=...&agent=...
+	// Bearer-authed. Returns 503 when the runStateBus isn't wired
+	// (operator-constructed Server without SetRunStateBus).
+	mux.Handle("GET /v1/users/{user_id}/agents/stream", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleStreamUserAgents))))
 	// v0.7.x tool-use hook registration API.
 	mux.Handle("POST /v1/hooks", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRegisterHook))))
 	mux.Handle("GET /v1/hooks", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListHooks))))
@@ -1798,6 +1829,14 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		UserID:    req.UserID,
 		StartedAt: time.Now(),
 	}, cancelFn)
+	// v0.9.x: identity bundle threaded into finishRun* + the
+	// "running" transition publish below.
+	meta := runStateMeta{
+		RunID:   runID,
+		AgentID: agentID,
+		Agent:   req.Agent,
+		UserID:  req.UserID,
+	}
 	if errors.Is(regErr, cancel.ErrInUse) {
 		// We've already created the session+run row in the store
 		// (session creation is unavoidable to satisfy the FK on
@@ -1806,18 +1845,19 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		// eventually catch it, but in the meantime it pollutes
 		// ListActiveRunsByUser. Mark it failed with a clear reason
 		// so the row is terminal from this exit path.
-		s.finishRunFailedReason(runID, "agent_id collision; run never started")
+		s.finishRunFailedReason(runID, "agent_id collision; run never started", meta)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
 		return
 	}
 	if regErr != nil {
-		s.finishRunFailedReason(runID, "registry register failed: "+regErr.Error())
+		s.finishRunFailedReason(runID, "registry register failed: "+regErr.Error(), meta)
 		http.Error(w, regErr.Error(), http.StatusInternalServerError)
 		return
 	}
 	defer s.cancelReg.Deregister(agentID)
+	s.publishRunState(meta, "running", "", "")
 
 	// If we're persisting, record the caller's input segments as the first
 	// event in the run. The loop never emits the caller's input itself, so
@@ -1935,7 +1975,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}
 
-	s.finishRunWithCancel(r.Context(), runCtx, runID, loopRes, runErr)
+	s.finishRunWithCancel(r.Context(), runCtx, runID, loopRes, runErr, meta)
 }
 
 // messagesRequest is the JSON body for POST /v1/sessions/{id}/messages. It
@@ -2142,21 +2182,29 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		UserID:    sess.UserID,
 		StartedAt: time.Now(),
 	}, cancelFn)
+	// v0.9.x: per-run meta for runstate.Bus.
+	meta := runStateMeta{
+		RunID:   run.ID,
+		AgentID: agentID,
+		Agent:   sess.Agent,
+		UserID:  sess.UserID,
+	}
 	if errors.Is(regErr, cancel.ErrInUse) {
 		// Same orphan-row mitigation as handleRuns — the run was
 		// already inserted at status=running.
-		s.finishRunFailedReason(run.ID, "agent_id collision; run never started")
+		s.finishRunFailedReason(run.ID, "agent_id collision; run never started", meta)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusConflict)
 		fmt.Fprintf(w, `{"code":"agent_id_in_use","error":"agent_id %q is already mapped to an active run"}`, agentID)
 		return
 	}
 	if regErr != nil {
-		s.finishRunFailedReason(run.ID, "registry register failed: "+regErr.Error())
+		s.finishRunFailedReason(run.ID, "registry register failed: "+regErr.Error(), meta)
 		http.Error(w, regErr.Error(), http.StatusInternalServerError)
 		return
 	}
 	defer s.cancelReg.Deregister(agentID)
+	s.publishRunState(meta, "running", "", "")
 
 	// Persist the new user input segments so a future replay sees them.
 	if inputJSON, err := json.Marshal(body.Segments); err == nil {
@@ -2244,7 +2292,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}
 
-	s.finishRunWithCancel(r.Context(), runCtx, run.ID, loopRes, runErr)
+	s.finishRunWithCancel(r.Context(), runCtx, run.ID, loopRes, runErr, meta)
 }
 
 // replayTranscript walks the persisted events of a session and reconstructs
@@ -2669,6 +2717,16 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	} else {
 		defer s.cancelReg.Deregister(subAgentID)
 	}
+	// v0.9.x: sub-agent meta for runstate.Bus. ParentAgentID lets
+	// SSE subscribers see the lineage edge.
+	subMeta := runStateMeta{
+		RunID:         subRunID,
+		AgentID:       subAgentID,
+		Agent:         name,
+		UserID:        parentIdentity.UserID,
+		ParentAgentID: parentIdentity.AgentID,
+	}
+	s.publishRunState(subMeta, "running", "", "")
 
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies
 	// when any of the sub-agent's skills has a DB-active row. Same
@@ -2811,7 +2869,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		ReResolve:       fbReResolve,
 		Hooks:           s.hookDispatcher,
 	})
-	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr)
+	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr, subMeta)
 
 	if runErr != nil {
 		// Wrap with session/run IDs so a developer reading parent logs
@@ -3301,6 +3359,42 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 	}
 }
 
+// runStateMeta is the per-run identity bundle the finishRun* helpers
+// need to publish a meaningful event on the runstate.Bus. Every call
+// site (handleRuns / handleMessages / runSubAgent / connector
+// spawn_run + their collision-fail / register-fail subpaths) has the
+// fields in scope at the moment they call finishRun*; assembling the
+// struct is one line at each site.
+//
+// Zero-valued meta is safe (every finishRun* helper nil-guards on
+// s.runStateBus and publishes the event verbatim — the SSE handler's
+// filter shape tolerates empty agent / user_id).
+type runStateMeta struct {
+	RunID         string
+	AgentID       string
+	Agent         string
+	UserID        string
+	ParentAgentID string
+}
+
+// publishRunState fans out one event to the v0.9.x runstate.Bus.
+// No-op when the bus isn't wired (tests / minimal embeddings).
+func (s *Server) publishRunState(m runStateMeta, status, stopReason, errMsg string) {
+	if s.runStateBus == nil {
+		return
+	}
+	s.runStateBus.Publish(runstate.RunStateEvent{
+		RunID:         m.RunID,
+		AgentID:       m.AgentID,
+		Agent:         m.Agent,
+		UserID:        m.UserID,
+		ParentAgentID: m.ParentAgentID,
+		Status:        status,
+		StopReason:    stopReason,
+		Error:         errMsg,
+	})
+}
+
 // makeHeartbeat returns a callback the loop fires at each iteration.
 // It updates runs.last_heartbeat_at via a fire-and-forget background
 // context (the loop's ctx may be cancelled mid-write; the heartbeat
@@ -3333,7 +3427,7 @@ func (s *Server) makeHeartbeat(runID string) func() {
 // context.WithCancelCause. ctx (the first arg) is the outer ctx used
 // only by finishRun for its store write — passing both keeps the
 // background-write fallback in finishRun reusable for both code paths.
-func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context, runID string, res loop.RunResult, runErr error) {
+func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context, runID string, res loop.RunResult, runErr error, meta runStateMeta) {
 	if cause := context.Cause(runCtx); errors.Is(cause, cancel.ErrCancelledByAPI) {
 		// API-cancel terminal write. Reason text comes from the
 		// optional wrapper; falls back to the sentinel string.
@@ -3341,10 +3435,10 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 		if reason == "" {
 			reason = "cancelled by api"
 		}
-		s.finishRunCancelled(ctx, runID, res, reason)
+		s.finishRunCancelled(ctx, runID, res, reason, meta)
 		return
 	}
-	s.finishRun(ctx, runID, res, runErr)
+	s.finishRun(ctx, runID, res, runErr, meta)
 }
 
 // finishRunFailedReason marks a run terminal with status=failed and
@@ -3355,7 +3449,7 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 //
 // Mirrors finishRun's structure: fresh background ctx with 5s timeout
 // so the write isn't lost when the request ctx is already torn down.
-func (s *Server) finishRunFailedReason(runID, reason string) {
+func (s *Server) finishRunFailedReason(runID, reason string, meta runStateMeta) {
 	if s.store == nil || runID == "" {
 		return
 	}
@@ -3364,6 +3458,7 @@ func (s *Server) finishRunFailedReason(runID, reason string) {
 	if err := s.store.FinishRun(bg, runID, store.RunFailed, "", store.Usage{}, reason); err != nil {
 		log.Printf("store: FinishRun(failed reason=%q) failed (run=%s): %v", reason, runID, err)
 	}
+	s.publishRunState(meta, "failed", "", reason)
 }
 
 // finishRunCancelled writes the terminal cancelled status with the
@@ -3377,7 +3472,7 @@ func (s *Server) finishRunFailedReason(runID, reason string) {
 // two are interchangeable at the call site (finishRunWithCancel
 // dispatches to one or the other), but it's a no-op input. If you
 // add real ctx propagation here, audit every caller.
-func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.RunResult, reason string) {
+func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.RunResult, reason string, meta runStateMeta) {
 	if s.store == nil || runID == "" {
 		return
 	}
@@ -3393,13 +3488,14 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 	if err := s.store.FinishRun(bg, runID, store.RunCancelled, reason, usage, ""); err != nil {
 		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
 	}
+	s.publishRunState(meta, "cancelled", reason, "")
 }
 
 // finishRun marks the run terminal in the store. status is derived from
 // runErr: nil → completed, non-nil → failed. ctx may already be cancelled
 // (the client disconnected); we use a fresh background context with a short
 // timeout so the FinishRun write isn't lost.
-func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, runErr error) {
+func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, runErr error, meta runStateMeta) {
 	if s.store == nil || runID == "" {
 		return
 	}
@@ -3421,6 +3517,11 @@ func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, 
 	if err := s.store.FinishRun(bg, runID, status, res.StopReason, usage, errMsg); err != nil {
 		log.Printf("store: FinishRun failed (run=%s): %v", runID, err)
 	}
+	publishStatus := "completed"
+	if runErr != nil {
+		publishStatus = "failed"
+	}
+	s.publishRunState(meta, publishStatus, res.StopReason, errMsg)
 }
 
 // authMiddleware enforces LOOMCYCLE_AUTH_TOKEN bearer auth, except for /healthz which

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1244,6 +1244,11 @@ func (s *Server) Mux() http.Handler {
 	// here. Future verbs (GET to peek, etc.) can use the same path
 	// with different methods.
 	mux.Handle("POST /v1/_channels/{name...}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSystemChannelPublish))))
+	// v0.9.x n8n RFC Phase 0: list declared channels + aggregate
+	// stats (count, oldest/newest visible_at). Used by n8n's
+	// credential-picker for the channel-name dropdown; also useful
+	// for operator dashboards. Bearer-authed.
+	mux.Handle("GET /v1/_channels", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListChannels))))
 	// v0.8.x process-resource metrics sampler endpoints. All
 	// bearer-authed. Return 503 when metricsSampler is nil
 	// (LOOMCYCLE_METRICS_ENABLED=0 deployment).

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -69,6 +70,10 @@ var handlersByName = map[string]toolHandler{
 	"register_hook": handleRegisterHook,
 	"list_hooks":    handleListHooks,
 	"delete_hook":   handleDeleteHook,
+
+	// v0.9.x n8n RFC Phase 0: channel listing + run-state streaming.
+	"list_channels":          handleListChannels,
+	"stream_user_run_states": handleStreamUserRunStates,
 }
 
 func toolHandlerByName(name string) (toolHandler, bool) {
@@ -506,6 +511,97 @@ func handleListHooks(ctx context.Context, env *handlerEnv, _ json.RawMessage) (*
 		return toolErr("list_hooks: " + err.Error()), nil
 	}
 	return toolResultJSON(res), nil
+}
+
+// handleListChannels — v0.9.x n8n RFC Phase 0. Dispatches through
+// Connector.ListChannels and returns the result as a JSON tool result.
+func handleListChannels(ctx context.Context, env *handlerEnv, _ json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("list_channels: no connector wired")
+	}
+	resp, err := env.connector.ListChannels(ctx)
+	if err != nil {
+		return toolErr("list_channels: " + err.Error()), nil
+	}
+	return toolResultJSON(resp), nil
+}
+
+// streamUserRunStatesArgs is the input to the stream_user_run_states
+// meta-tool. Mirrors connector.StreamUserRunStatesRequest plus two
+// extra fields that bound the blocking-aggregate code path (the
+// streaming code path uses ctx done instead).
+type streamUserRunStatesArgs struct {
+	UserID    string   `json:"user_id"`
+	Statuses  []string `json:"statuses,omitempty"`
+	Agent     string   `json:"agent,omitempty"`
+	MaxEvents int      `json:"max_events,omitempty"`
+	TimeoutMS int      `json:"timeout_ms,omitempty"`
+}
+
+// handleStreamUserRunStates has two code paths analogous to spawn_run:
+//
+//  1. Streaming (session opted into runEvents): each matching event
+//     gets emitted as notifications/loomcycle/run_state; the tool
+//     call returns when ctx fires or MaxEvents hit, with the count
+//     of forwarded events.
+//
+//  2. Blocking (no opt-in): collects matching events into a slice
+//     until MaxEvents or TimeoutMS, then returns the slice as the
+//     tool result.
+//
+// Either way the final response is { "events": [...], "count": N }
+// so adapters can branch on whether they want streaming or polled
+// behaviour by setting the capability flag.
+func handleStreamUserRunStates(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("stream_user_run_states: no connector wired")
+	}
+	var a streamUserRunStatesArgs
+	if err := json.Unmarshal(args, &a); err != nil {
+		return toolErr("invalid stream_user_run_states arguments: " + err.Error()), nil
+	}
+	if a.UserID == "" {
+		return toolErr("stream_user_run_states: user_id is required"), nil
+	}
+	if a.MaxEvents <= 0 {
+		a.MaxEvents = 16
+	}
+	if a.TimeoutMS <= 0 {
+		a.TimeoutMS = 30000
+	}
+
+	useStreaming := env.session != nil && env.session.RunEventsEnabled()
+	collected := make([]connector.RunStateEvent, 0, a.MaxEvents)
+	var count int
+
+	streamCtx, cancel := context.WithTimeout(ctx, time.Duration(a.TimeoutMS)*time.Millisecond)
+	defer cancel()
+
+	visit := func(evt connector.RunStateEvent) error {
+		count++
+		if useStreaming {
+			env.notify("notifications/loomcycle/run_state", evt)
+		} else {
+			collected = append(collected, evt)
+		}
+		if count >= a.MaxEvents {
+			return connector.ErrStopStreaming
+		}
+		return nil
+	}
+
+	err := env.connector.StreamUserRunStates(streamCtx, connector.StreamUserRunStatesRequest{
+		UserID:   a.UserID,
+		Statuses: a.Statuses,
+		Agent:    a.Agent,
+	}, visit)
+	if err != nil {
+		return toolErr("stream_user_run_states: " + err.Error()), nil
+	}
+	return toolResultJSON(struct {
+		Events []connector.RunStateEvent `json:"events"`
+		Count  int                       `json:"count"`
+	}{Events: collected, Count: count}), nil
 }
 
 func handleDeleteHook(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -109,6 +109,14 @@ func (m *httpMockConnector) DeleteHook(context.Context, string) error {
 	return errors.New("not implemented")
 }
 
+// v0.9.x n8n RFC Phase 0 stubs.
+func (m *httpMockConnector) ListChannels(context.Context) (connector.ListChannelsResponse, error) {
+	return connector.ListChannelsResponse{}, errors.New("not implemented")
+}
+func (m *httpMockConnector) StreamUserRunStates(context.Context, connector.StreamUserRunStatesRequest, connector.RunStateVisitor) error {
+	return errors.New("not implemented")
+}
+
 // httpTestServer wires an HTTPHandler against the mock connector and
 // returns an httptest.Server speaking the loomcycle MCP transport over
 // real HTTP. Test bodies POST to ts.URL + "/" (the test server has no

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -137,6 +137,14 @@ func (m *mockConnector) InterruptionResolve(_ context.Context, _ connector.Inter
 	return connector.InterruptionResolveResult{}, errors.New("not implemented")
 }
 
+// v0.9.x n8n RFC Phase 0 stubs.
+func (m *mockConnector) ListChannels(context.Context) (connector.ListChannelsResponse, error) {
+	return connector.ListChannelsResponse{}, nil
+}
+func (m *mockConnector) StreamUserRunStates(context.Context, connector.StreamUserRunStatesRequest, connector.RunStateVisitor) error {
+	return nil
+}
+
 // driveServer runs the server against the given input lines and
 // returns the response frames (one per request). Notifications are
 // captured separately.

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -38,6 +38,13 @@ type mockConnector struct {
 	listHookHooks       []*hooks.Hook                 // return slice for ListHooks
 	deleteHookErr       error                         // return value for DeleteHook
 	lastDeleteHookID    string                        // id passed to the most recent DeleteHook call
+
+	// v0.9.x n8n RFC Phase 0 injection points.
+	listChannelsResp connector.ListChannelsResponse
+	listChannelsErr  error
+	streamEvents     []connector.RunStateEvent
+	streamErr        error
+	lastStreamReq    connector.StreamUserRunStatesRequest
 }
 
 func (m *mockConnector) SpawnRun(_ context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
@@ -137,12 +144,24 @@ func (m *mockConnector) InterruptionResolve(_ context.Context, _ connector.Inter
 	return connector.InterruptionResolveResult{}, errors.New("not implemented")
 }
 
-// v0.9.x n8n RFC Phase 0 stubs.
+// v0.9.x n8n RFC Phase 0 — overridable surface.
 func (m *mockConnector) ListChannels(context.Context) (connector.ListChannelsResponse, error) {
-	return connector.ListChannelsResponse{}, nil
+	if m.listChannelsResp.Channels != nil {
+		return m.listChannelsResp, m.listChannelsErr
+	}
+	return connector.ListChannelsResponse{}, m.listChannelsErr
 }
-func (m *mockConnector) StreamUserRunStates(context.Context, connector.StreamUserRunStatesRequest, connector.RunStateVisitor) error {
-	return nil
+func (m *mockConnector) StreamUserRunStates(_ context.Context, req connector.StreamUserRunStatesRequest, visit connector.RunStateVisitor) error {
+	m.lastStreamReq = req
+	for _, evt := range m.streamEvents {
+		if err := visit(evt); err != nil {
+			if errors.Is(err, connector.ErrStopStreaming) {
+				return nil
+			}
+			return err
+		}
+	}
+	return m.streamErr
 }
 
 // driveServer runs the server against the given input lines and
@@ -215,7 +234,7 @@ func TestServer_Handshake(t *testing.T) {
 	}
 }
 
-func TestServer_ToolsList_Returns26Tools(t *testing.T) {
+func TestServer_ToolsList_Returns28Tools(t *testing.T) {
 	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
 	in := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n"
 	resps, _ := driveServer(t, srv, in)
@@ -226,15 +245,15 @@ func TestServer_ToolsList_Returns26Tools(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 26 {
-		t.Errorf("got %d tools, want 26 (v0.8.22 adds skilldef meta-tool)", len(result.Tools))
+	if len(result.Tools) != 28 {
+		t.Errorf("got %d tools, want 28 (v0.9.x adds list_channels + stream_user_run_states)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
-	// Spot-check a few across categories — including the v0.8.16 + v0.8.18 + hook + v0.8.22 additions.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook"} {
+	// Spot-check across categories — through the v0.9.x n8n additions.
+	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}
@@ -634,6 +653,111 @@ func TestServer_ListHooks_ReturnsConnectorList(t *testing.T) {
 	}
 	if len(inner.Hooks) != 2 || inner.Hooks[0].ID != "h_1" {
 		t.Errorf("inner = %+v", inner)
+	}
+}
+
+// v0.9.x n8n RFC Phase 0 meta-tools.
+
+func TestServer_ListChannels_DispatchesToConnector(t *testing.T) {
+	mc := &mockConnector{
+		listChannelsResp: connector.ListChannelsResponse{
+			Channels: []connector.ChannelDescriptor{
+				{Name: "alpha", MessageCount: 5},
+				{Name: "beta", MessageCount: 0},
+			},
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"list_channels","arguments":{}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[0].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var inner connector.ListChannelsResponse
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if len(inner.Channels) != 2 || inner.Channels[0].Name != "alpha" {
+		t.Errorf("inner = %+v", inner)
+	}
+}
+
+func TestServer_StreamUserRunStates_BlockingPath_CollectsEvents(t *testing.T) {
+	mc := &mockConnector{
+		streamEvents: []connector.RunStateEvent{
+			{RunID: "r1", UserID: "user-a", Status: "running"},
+			{RunID: "r2", UserID: "user-a", Status: "completed"},
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"stream_user_run_states","arguments":{"user_id":"user-a","max_events":2,"timeout_ms":500}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses", len(resps))
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[0].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	var inner struct {
+		Events []connector.RunStateEvent `json:"events"`
+		Count  int                       `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if inner.Count != 2 || len(inner.Events) != 2 || inner.Events[0].RunID != "r1" {
+		t.Errorf("inner = %+v", inner)
+	}
+	if mc.lastStreamReq.UserID != "user-a" {
+		t.Errorf("connector got wrong req: %+v", mc.lastStreamReq)
+	}
+}
+
+func TestServer_StreamUserRunStates_StreamingPath_EmitsNotifications(t *testing.T) {
+	mc := &mockConnector{
+		streamEvents: []connector.RunStateEvent{
+			{RunID: "r1", UserID: "user-a", Status: "completed"},
+			{RunID: "r2", UserID: "user-a", Status: "completed"},
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	// First initialize with runEvents=true so the streaming path engages.
+	in := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{"loomcycle":{"runEvents":true}},"clientInfo":{"name":"t","version":"v"}}}` + "\n" +
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"stream_user_run_states","arguments":{"user_id":"user-a","max_events":2,"timeout_ms":500}}}` + "\n"
+	resps, notifs := driveServer(t, srv, in)
+	if len(resps) != 2 {
+		t.Fatalf("got %d responses, want 2 (initialize + tools/call)", len(resps))
+	}
+	// Expect two notifications (one per event), each with method run_state.
+	got := 0
+	for _, n := range notifs {
+		if n.Method == "notifications/loomcycle/run_state" {
+			got++
+		}
+	}
+	if got != 2 {
+		t.Errorf("got %d run_state notifications, want 2 (all %d notifs: %+v)", got, len(notifs), notifs)
+	}
+}
+
+func TestServer_StreamUserRunStates_RequiresUserID(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"stream_user_run_states","arguments":{}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses", len(resps))
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[0].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !callRes.IsError {
+		t.Error("expected IsError=true on missing user_id")
 	}
 }
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -288,6 +288,27 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 				"properties": {"id": {"type": "string"}}
 			}`),
 		},
+		// v0.9.x n8n RFC Phase 0 — channel listing + run-state streaming.
+		{
+			Name:        "list_channels",
+			Description: "List every operator-declared channel with aggregate runtime stats (message_count, oldest_visible_at, newest_visible_at). Mirrors GET /v1/_channels. No arguments.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
+			Name:        "stream_user_run_states",
+			Description: "Subscribe to run state transitions for one user_id. Returns {events: [RunStateEvent...], count}. When the session opted into capabilities.loomcycle.runEvents=true, each matching event also arrives as a notifications/loomcycle/run_state notification and the response carries an empty events array (count only). Filters: statuses (e.g. ['completed','failed']) and agent (exact name). max_events caps the response at N events; timeout_ms bounds the blocking wait.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["user_id"],
+				"properties": {
+					"user_id":    {"type": "string"},
+					"statuses":   {"type": "array", "items": {"type": "string"}},
+					"agent":      {"type": "string"},
+					"max_events": {"type": "integer", "minimum": 1, "default": 16},
+					"timeout_ms": {"type": "integer", "minimum": 100, "default": 30000}
+				}
+			}`),
+		},
 	}
 }
 

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -182,7 +182,38 @@ type Connector interface {
 	RegisterHook(ctx context.Context, req RegisterHookRequest) (RegisterHookResponse, error)
 	ListHooks(ctx context.Context) (ListHooksResponse, error)
 	DeleteHook(ctx context.Context, id string) error
+
+	// --- v0.9.x n8n RFC Phase 0 ---
+	//
+	// Two methods that surface the new HTTP endpoints (GET /v1/_channels
+	// and GET /v1/users/{user_id}/agents/stream) to MCP + gRPC. Both
+	// pure read paths; no business-logic divergence between transports.
+	//
+	// ListChannels is synchronous request/response — the operator
+	// listing of declared channels with aggregate stats.
+	//
+	// StreamUserRunStates is the streaming counterpart to the SSE
+	// endpoint. Visitor-pattern shape (callback per event) rather than
+	// channel-return so the interface stays sync-style for transports
+	// that don't natively stream (CLI's tabular output, future REST
+	// long-poll). Visitors that return ErrStopStreaming exit cleanly;
+	// other errors propagate. ctx cancel ends the stream with nil.
+	//
+	// Typed errors:
+	//   ErrRunStateStreamUnavailable — runStateBus not wired on the
+	//                                  underlying server (operator
+	//                                  embedding skipped SetRunStateBus).
+	//                                  Transports: Unavailable.
+
+	ListChannels(ctx context.Context) (ListChannelsResponse, error)
+	StreamUserRunStates(ctx context.Context, req StreamUserRunStatesRequest, visit RunStateVisitor) error
 }
+
+// RunStateVisitor is the visitor callback for StreamUserRunStates.
+// Return ErrStopStreaming to end the stream cleanly; any other
+// non-nil error aborts the stream and propagates out of
+// StreamUserRunStates.
+type RunStateVisitor func(evt RunStateEvent) error
 
 // InterruptionResolveRequest is the input to Connector.InterruptionResolve.
 type InterruptionResolveRequest struct {

--- a/internal/connector/errors.go
+++ b/internal/connector/errors.go
@@ -73,4 +73,16 @@ var (
 	// this — it's a defensive guard for the gRPC/MCP code paths that
 	// dispatch through Connector and would otherwise nil-panic.
 	ErrHookNotConfigured = errors.New("connector: hook registry not configured on this server")
+
+	// ErrRunStateStreamUnavailable is returned by StreamUserRunStates
+	// when the underlying server has no runstate.Bus wired (operator
+	// embedding skipped SetRunStateBus). Transports map to
+	// Unavailable / HTTP 503.
+	ErrRunStateStreamUnavailable = errors.New("connector: run-state stream not configured on this server")
+
+	// ErrStopStreaming is the visitor-side sentinel a RunStateVisitor
+	// returns to end the stream cleanly. StreamUserRunStates returns
+	// nil (not this sentinel) when the visitor returns it; the
+	// sentinel is the visitor's way of saying "I have what I need."
+	ErrStopStreaming = errors.New("connector: stop streaming")
 )

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -290,3 +290,53 @@ type RestoreSnapshotResult struct {
 	FormatMigrations           []string       `json:"format_migrations,omitempty"`
 	FeatureStatus              string         `json:"feature_status,omitempty"`
 }
+
+// ---- v0.9.x n8n RFC Phase 0 ----
+
+// ChannelDescriptor is one row in ListChannels. Joins the operator-
+// declared yaml channel with the runtime aggregate stats over
+// channel_messages. Channels declared with no published messages
+// still surface (MessageCount=0); rows for channels NOT declared but
+// holding orphaned messages also surface, for forensics.
+type ChannelDescriptor struct {
+	Name            string `json:"name"`
+	Scope           string `json:"scope,omitempty"`
+	Semantic        string `json:"semantic,omitempty"`
+	Publisher       string `json:"publisher,omitempty"`
+	Period          string `json:"period,omitempty"`
+	DefaultTTL      int    `json:"default_ttl,omitempty"`
+	MaxMessages     int    `json:"max_messages,omitempty"`
+	MessageCount    int64  `json:"message_count"`
+	OldestVisibleAt string `json:"oldest_visible_at,omitempty"` // RFC3339; empty when count=0
+	NewestVisibleAt string `json:"newest_visible_at,omitempty"`
+}
+
+// ListChannelsResponse is the response shape for Connector.ListChannels.
+type ListChannelsResponse struct {
+	Channels []ChannelDescriptor `json:"channels"`
+}
+
+// StreamUserRunStatesRequest is the input to Connector.StreamUserRunStates.
+// UserID is required; Statuses and Agent are optional filters that match
+// the SSE handler's ?status=...&agent=... query params.
+type StreamUserRunStatesRequest struct {
+	UserID   string   `json:"user_id"`
+	Statuses []string `json:"statuses,omitempty"`
+	Agent    string   `json:"agent,omitempty"`
+}
+
+// RunStateEvent is the payload yielded by RunStateVisitor for each
+// state transition. Mirrors runstate.RunStateEvent exactly; defined
+// here so the Connector interface doesn't depend on internal/runstate
+// (mcp / grpc adapters use only the connector package).
+type RunStateEvent struct {
+	RunID         string `json:"run_id"`
+	AgentID       string `json:"agent_id"`
+	Agent         string `json:"agent"`
+	UserID        string `json:"user_id"`
+	ParentAgentID string `json:"parent_agent_id,omitempty"`
+	Status        string `json:"status"`
+	StopReason    string `json:"stop_reason,omitempty"`
+	Error         string `json:"error,omitempty"`
+	TS            string `json:"ts"` // RFC3339
+}

--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -1,0 +1,200 @@
+// Package runstate implements an in-process pub/sub for run-state
+// transition events. The SSE handler GET /v1/users/{user_id}/agents/stream
+// subscribes; the five finishRun* paths plus the run-creation moment
+// publish.
+//
+// This package is intentionally a sibling to channels.Bus rather than
+// a reuse of it — the channels Bus is a "presence of new data" tap
+// (waiters block, get woken, re-query the store). Run-state events
+// need to carry their payload to the subscriber directly so the SSE
+// stream can emit the run_id + status delta without a follow-up DB
+// read; the natural shape is per-subscriber buffered channels.
+//
+// Cross-process delivery is OUT OF SCOPE for v0.9.x (same punt as
+// channels.Bus). Multi-replica HA work can swap the backplane for
+// Postgres LISTEN/NOTIFY or Redis pub/sub without changing the
+// Subscribe / Publish surface.
+//
+// Concurrency: Bus is safe for concurrent Publish + Subscribe calls.
+// Each subscription holds its own buffered channel; the publisher
+// fan-outs with a non-blocking send so a stalled subscriber never
+// blocks a finishRun write. Buffer overflow increments DroppedEvents
+// on the subscription and is logged at unsubscribe time.
+package runstate
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// RunStateEvent is the payload published on every run state transition.
+// Fields mirror the SSE frame the handler will emit.
+type RunStateEvent struct {
+	RunID         string    `json:"run_id"`
+	AgentID       string    `json:"agent_id"`
+	Agent         string    `json:"agent"`
+	UserID        string    `json:"user_id"`
+	ParentAgentID string    `json:"parent_agent_id,omitempty"`
+	Status        string    `json:"status"`
+	StopReason    string    `json:"stop_reason,omitempty"`
+	Error         string    `json:"error,omitempty"`
+	TS            time.Time `json:"ts"`
+}
+
+// subscription is one active subscriber's state.
+type subscription struct {
+	userID  string
+	ch      chan RunStateEvent
+	dropped int64 // atomic counter incremented on buffer overflow
+}
+
+// DroppedEvents returns the cumulative number of events that were
+// dropped because the subscriber's buffer was full. Useful for the
+// SSE handler to surface as diagnostic info on the close frame.
+func (s *subscription) DroppedEvents() int64 {
+	return atomic.LoadInt64(&s.dropped)
+}
+
+// Bus is the in-process run-state pub/sub.
+type Bus struct {
+	mu          sync.Mutex
+	byUser      map[string][]*subscription
+	bufferSize  int
+}
+
+// NewBus returns a fresh, empty bus. Single instance per loomcycle
+// process; injected into *http.Server.
+//
+// bufferSize is the per-subscription channel capacity. 64 is a
+// reasonable default — a healthy SSE consumer drains in <1ms; 64
+// covers ~64 in-flight runs between drains before the publisher
+// starts dropping for that subscriber.
+func NewBus() *Bus {
+	return &Bus{
+		byUser:     make(map[string][]*subscription),
+		bufferSize: 64,
+	}
+}
+
+// Subscription is the public handle returned by Subscribe. The
+// subscriber reads RunStateEvents from C and calls Close() when done.
+type Subscription struct {
+	bus *Bus
+	sub *subscription
+	C   <-chan RunStateEvent
+}
+
+// Close unregisters the subscription. Idempotent.
+func (s *Subscription) Close() {
+	if s == nil || s.bus == nil {
+		return
+	}
+	s.bus.unsubscribe(s.sub)
+	s.bus = nil
+}
+
+// DroppedEvents returns the cumulative number of events dropped
+// because the subscription's buffer was full. Safe to call at any
+// time, including after Close.
+func (s *Subscription) DroppedEvents() int64 {
+	if s == nil || s.sub == nil {
+		return 0
+	}
+	return s.sub.DroppedEvents()
+}
+
+// Subscribe registers a new subscriber for events on the given user
+// scope. Returns a Subscription whose C channel delivers events until
+// Close is called.
+//
+// An empty userID subscribes to ALL events (admin / operator-side
+// debugging). Used by the gRPC streaming RPC when callers pass no
+// filter. The HTTP handler always provides a concrete user_id.
+func (b *Bus) Subscribe(userID string) *Subscription {
+	sub := &subscription{
+		userID: userID,
+		ch:     make(chan RunStateEvent, b.bufferSize),
+	}
+	b.mu.Lock()
+	b.byUser[userID] = append(b.byUser[userID], sub)
+	b.mu.Unlock()
+	return &Subscription{bus: b, sub: sub, C: sub.ch}
+}
+
+// Publish fans out an event to every matching subscriber.
+//
+// "Matching" means: the subscriber's userID equals event.UserID, OR
+// the subscriber's userID is "" (subscribe-all). Non-blocking send on
+// each subscriber — a full buffer increments the subscriber's
+// DroppedEvents counter rather than blocking the publisher. This is
+// the right trade-off: a stalled SSE consumer must NEVER block a
+// finishRun write.
+//
+// Idempotent + safe to call from any goroutine, including the request
+// handler goroutine.
+func (b *Bus) Publish(evt RunStateEvent) {
+	if evt.TS.IsZero() {
+		evt.TS = time.Now().UTC()
+	}
+	b.mu.Lock()
+	// Build a snapshot of matching subscriptions while holding the
+	// lock; do the actual sends outside the lock so a slow channel
+	// doesn't serialize publishers.
+	matches := make([]*subscription, 0, len(b.byUser[evt.UserID])+len(b.byUser[""]))
+	matches = append(matches, b.byUser[evt.UserID]...)
+	if evt.UserID != "" {
+		matches = append(matches, b.byUser[""]...)
+	}
+	b.mu.Unlock()
+
+	for _, sub := range matches {
+		select {
+		case sub.ch <- evt:
+		default:
+			atomic.AddInt64(&sub.dropped, 1)
+		}
+	}
+}
+
+// unsubscribe is called by Subscription.Close. Removes the
+// subscription from the per-user slice and closes its channel so a
+// goroutine still ranging over C exits cleanly.
+func (b *Bus) unsubscribe(sub *subscription) {
+	if sub == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subs := b.byUser[sub.userID]
+	for i, s := range subs {
+		if s == sub {
+			subs[i] = subs[len(subs)-1]
+			subs = subs[:len(subs)-1]
+			break
+		}
+	}
+	if len(subs) == 0 {
+		delete(b.byUser, sub.userID)
+	} else {
+		b.byUser[sub.userID] = subs
+	}
+	// Close exactly once. Buffered sends from a concurrent Publish
+	// can race with this close; we accept losing the very last in-
+	// flight event on a closing subscription as the cost of a clean
+	// close. The drain is fine — the SSE handler is the only reader
+	// and it cancels its ctx before calling Close.
+	close(sub.ch)
+}
+
+// ActiveSubscriberCount returns the total number of active
+// subscriptions. Diagnostic / test helper.
+func (b *Bus) ActiveSubscriberCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := 0
+	for _, subs := range b.byUser {
+		n += len(subs)
+	}
+	return n
+}

--- a/internal/runstate/bus_test.go
+++ b/internal/runstate/bus_test.go
@@ -1,0 +1,197 @@
+package runstate
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBus_PublishDeliversToMatchingSubscriber(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	sub := bus.Subscribe("user-a")
+	defer sub.Close()
+
+	bus.Publish(RunStateEvent{
+		RunID: "r1", UserID: "user-a", Status: "running",
+	})
+
+	select {
+	case evt := <-sub.C:
+		if evt.RunID != "r1" || evt.Status != "running" {
+			t.Fatalf("unexpected event: %+v", evt)
+		}
+		if evt.TS.IsZero() {
+			t.Errorf("Publish should stamp TS when zero")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event not delivered within 1s")
+	}
+}
+
+func TestBus_PublishSkipsNonMatchingUser(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	a := bus.Subscribe("user-a")
+	defer a.Close()
+	b := bus.Subscribe("user-b")
+	defer b.Close()
+
+	bus.Publish(RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
+
+	select {
+	case evt := <-a.C:
+		if evt.RunID != "r1" {
+			t.Fatalf("user-a got wrong event: %+v", evt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("user-a never received its event")
+	}
+
+	select {
+	case evt := <-b.C:
+		t.Fatalf("user-b should not have received event for user-a: %+v", evt)
+	case <-time.After(50 * time.Millisecond):
+		// expected — no event for user-b
+	}
+}
+
+func TestBus_EmptyUserIDSubscribesToAll(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	all := bus.Subscribe("")
+	defer all.Close()
+
+	bus.Publish(RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
+	bus.Publish(RunStateEvent{RunID: "r2", UserID: "user-b", Status: "completed"})
+
+	var seen []string
+	timeout := time.After(time.Second)
+	for len(seen) < 2 {
+		select {
+		case evt := <-all.C:
+			seen = append(seen, evt.RunID)
+		case <-timeout:
+			t.Fatalf("only saw %v before timeout", seen)
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("expected 2 events, got %d: %v", len(seen), seen)
+	}
+}
+
+func TestBus_FanOutToMultipleSubscribersSameUser(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	a := bus.Subscribe("user-a")
+	defer a.Close()
+	a2 := bus.Subscribe("user-a")
+	defer a2.Close()
+
+	bus.Publish(RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
+
+	for i, sub := range []*Subscription{a, a2} {
+		select {
+		case evt := <-sub.C:
+			if evt.RunID != "r1" {
+				t.Errorf("subscriber %d got wrong event: %+v", i, evt)
+			}
+		case <-time.After(time.Second):
+			t.Errorf("subscriber %d never received event", i)
+		}
+	}
+}
+
+func TestBus_CloseUnregistersAndClosesChannel(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	sub := bus.Subscribe("user-a")
+	if got := bus.ActiveSubscriberCount(); got != 1 {
+		t.Fatalf("expected 1 active subscriber, got %d", got)
+	}
+	sub.Close()
+	if got := bus.ActiveSubscriberCount(); got != 0 {
+		t.Fatalf("expected 0 active subscribers after Close, got %d", got)
+	}
+	// Channel should be drained + closed.
+	if _, ok := <-sub.C; ok {
+		t.Errorf("channel should be closed after Close")
+	}
+}
+
+func TestBus_CloseIsIdempotent(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	sub := bus.Subscribe("user-a")
+	sub.Close()
+	sub.Close() // must not panic
+}
+
+func TestBus_DropOnFullBufferRatherThanBlock(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+	bus.bufferSize = 2 // tighten for the test
+	sub := bus.Subscribe("user-a")
+	defer sub.Close()
+
+	// Publish 5; only first 2 fit; rest dropped.
+	for i := 0; i < 5; i++ {
+		bus.Publish(RunStateEvent{RunID: "r", UserID: "user-a", Status: "running"})
+	}
+	if got := sub.DroppedEvents(); got != 3 {
+		t.Errorf("expected 3 dropped events, got %d", got)
+	}
+}
+
+func TestBus_ConcurrentPublishSubscribe(t *testing.T) {
+	t.Parallel()
+	bus := NewBus()
+
+	var wg sync.WaitGroup
+	const subscribers = 8
+	const eventsPer = 50
+
+	// Start subscribers; each gets its own user_id.
+	received := make([][]string, subscribers)
+	for i := 0; i < subscribers; i++ {
+		i := i
+		sub := bus.Subscribe("user-" + string(rune('a'+i)))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer sub.Close()
+			deadline := time.After(2 * time.Second)
+			for len(received[i]) < eventsPer {
+				select {
+				case evt := <-sub.C:
+					received[i] = append(received[i], evt.RunID)
+				case <-deadline:
+					return
+				}
+			}
+		}()
+	}
+
+	// Publish concurrently per user.
+	for i := 0; i < subscribers; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < eventsPer; j++ {
+				bus.Publish(RunStateEvent{
+					RunID:  string(rune('a' + i)),
+					UserID: "user-" + string(rune('a'+i)),
+					Status: "running",
+				})
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, got := range received {
+		if len(got) != eventsPer {
+			t.Errorf("subscriber %d received %d events, want %d", i, len(got), eventsPer)
+		}
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2423,6 +2423,43 @@ func (s *Store) ChannelPeek(ctx context.Context, channel string, scope store.Mem
 	return msgs, err
 }
 
+func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT channel, COUNT(*), MIN(visible_at), MAX(visible_at)
+		FROM channel_messages
+		WHERE (expires_at IS NULL OR expires_at > NOW())
+		GROUP BY channel
+		ORDER BY channel`)
+	if err != nil {
+		return nil, fmt.Errorf("channel stats query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.ChannelStats
+	for rows.Next() {
+		var (
+			name           string
+			count          int64
+			oldest, newest *time.Time
+		)
+		if err := rows.Scan(&name, &count, &oldest, &newest); err != nil {
+			return nil, fmt.Errorf("channel stats scan: %w", err)
+		}
+		st := store.ChannelStats{Channel: name, MessageCount: count}
+		if oldest != nil {
+			st.OldestVisibleAt = oldest.UTC()
+		}
+		if newest != nil {
+			st.NewestVisibleAt = newest.UTC()
+		}
+		out = append(out, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("channel stats iterate: %w", err)
+	}
+	return out, nil
+}
+
 // channelRead is the shared read body. Filters expired + invisible
 // rows at WHERE; orders by (visible_at, id) tuple so deferred
 // messages don't get skipped by subscribers that already progressed

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -2260,6 +2260,44 @@ func (s *Store) ChannelPeek(ctx context.Context, channel string, scope store.Mem
 	return msgs, err
 }
 
+func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) {
+	now := time.Now().UnixNano()
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT channel, COUNT(*), MIN(visible_at), MAX(visible_at)
+		FROM channel_messages
+		WHERE (expires_at IS NULL OR expires_at > ?)
+		GROUP BY channel
+		ORDER BY channel`, now)
+	if err != nil {
+		return nil, fmt.Errorf("channel stats query: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.ChannelStats
+	for rows.Next() {
+		var (
+			name             string
+			count            int64
+			oldestNS, newest sql.NullInt64
+		)
+		if err := rows.Scan(&name, &count, &oldestNS, &newest); err != nil {
+			return nil, fmt.Errorf("channel stats scan: %w", err)
+		}
+		st := store.ChannelStats{Channel: name, MessageCount: count}
+		if oldestNS.Valid {
+			st.OldestVisibleAt = time.Unix(0, oldestNS.Int64).UTC()
+		}
+		if newest.Valid {
+			st.NewestVisibleAt = time.Unix(0, newest.Int64).UTC()
+		}
+		out = append(out, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("channel stats iterate: %w", err)
+	}
+	return out, nil
+}
+
 // channelRead is the shared read body for Subscribe + Peek. expired-
 // at-read-time filter applies on both paths.
 //

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -770,6 +770,17 @@ type Store interface {
 	// from cur_0 without disturbing the consumer's position.
 	ChannelPeek(ctx context.Context, channel string, scope MemoryScope, scopeID, fromCursor string, limit int) ([]ChannelMessage, error)
 
+	// ChannelStats returns one row per channel that has at least one
+	// non-expired message, with the aggregate count + oldest/newest
+	// visible_at timestamps. Channels declared in operator yaml but
+	// holding no messages do NOT appear in this result — the caller
+	// joins against the declared list to surface "declared but empty"
+	// channels with zero counts.
+	//
+	// Used by the GET /v1/_channels admin listing (Phase 0 of the
+	// n8n integration RFC).
+	ChannelStats(ctx context.Context) ([]ChannelStats, error)
+
 	// ---- v0.8.5 Self-Evolution Substrate ----
 	//
 	// `AgentDef` is the agent-authored agent-definition versioning
@@ -1208,6 +1219,17 @@ type ChannelMessage struct {
 	ExpiresAt         time.Time       `json:"expires_at,omitempty"`
 	VisibleAt         time.Time       `json:"visible_at,omitempty"`
 	PublishedByUserID string          `json:"published_by_user_id,omitempty"`
+}
+
+// ChannelStats is one row in the result of ChannelStats — the
+// aggregate over channel_messages for a single channel name. Expired
+// rows are excluded from MessageCount + the visible_at bounds so the
+// admin listing reflects what subscribers would actually receive.
+type ChannelStats struct {
+	Channel         string    `json:"channel"`
+	MessageCount    int64     `json:"message_count"`
+	OldestVisibleAt time.Time `json:"oldest_visible_at,omitempty"`
+	NewestVisibleAt time.Time `json:"newest_visible_at,omitempty"`
 }
 
 // ErrChannelCursorRegression is returned by ChannelAck when a caller

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -133,6 +133,8 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelScopeIsolation", testChannelScopeIsolation},
 		{"ChannelPeekDoesNotConsume", testChannelPeekDoesNotConsume},
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
+		{"ChannelStatsAggregatesNonExpired", testChannelStatsAggregatesNonExpired},
+		{"ChannelStatsEmptyOnNoMessages", testChannelStatsEmptyOnNoMessages},
 		// v0.8.6 deferred publish (PR 1)
 		{"ChannelDeferredHiddenUntilVisible", testChannelDeferredHiddenUntilVisible},
 		{"ChannelDeferredDeliversAfterProgressedCursor", testChannelDeferredDeliversAfterProgressedCursor},
@@ -2350,6 +2352,54 @@ func testChannelPeekDoesNotConsume(t *testing.T, s store.Store) {
 	}
 	if committed != "" {
 		t.Errorf("peek advanced committed cursor to %q (must stay empty)", committed)
+	}
+}
+
+func testChannelStatsAggregatesNonExpired(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// Publish 3 to "alpha", 1 to "beta".
+	for i := 0; i < 3; i++ {
+		_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: "alpha", Scope: store.MemoryScopeAgent, ScopeID: "x",
+			Payload: json.RawMessage(`{}`),
+		}, 0)
+		time.Sleep(time.Millisecond)
+	}
+	_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "beta", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload: json.RawMessage(`{}`),
+	}, 0)
+
+	stats, err := s.ChannelStats(ctx)
+	if err != nil {
+		t.Fatalf("ChannelStats: %v", err)
+	}
+	byName := map[string]store.ChannelStats{}
+	for _, st := range stats {
+		byName[st.Channel] = st
+	}
+	if byName["alpha"].MessageCount != 3 {
+		t.Errorf("alpha count = %d, want 3", byName["alpha"].MessageCount)
+	}
+	if byName["beta"].MessageCount != 1 {
+		t.Errorf("beta count = %d, want 1", byName["beta"].MessageCount)
+	}
+	if byName["alpha"].OldestVisibleAt.After(byName["alpha"].NewestVisibleAt) {
+		t.Errorf("alpha oldest %v after newest %v", byName["alpha"].OldestVisibleAt, byName["alpha"].NewestVisibleAt)
+	}
+	if byName["alpha"].OldestVisibleAt.IsZero() {
+		t.Error("alpha oldest_visible_at should be set")
+	}
+}
+
+func testChannelStatsEmptyOnNoMessages(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	stats, err := s.ChannelStats(ctx)
+	if err != nil {
+		t.Fatalf("ChannelStats: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected empty stats, got %d rows: %+v", len(stats), stats)
 	}
 }
 

--- a/proto/loomcycle.proto
+++ b/proto/loomcycle.proto
@@ -195,6 +195,17 @@ service Loomcycle {
   // SkillDef dispatches to the in-process SkillDef tool. Mirrors
   // POST /v1/_skilldef.
   rpc SkillDef(SubstrateRequest) returns (SubstrateResponse);
+
+  // ----- v0.9.x n8n RFC Phase 0 -----
+  //
+  // ListChannels mirrors GET /v1/_channels — operator-declared
+  // channels joined with runtime stats.
+  rpc ListChannels(ListChannelsRequest) returns (ListChannelsResponse);
+
+  // StreamUserRunStates mirrors GET /v1/users/{user_id}/agents/stream.
+  // Server-streams one RunStateEvent per matching state transition
+  // until ctx cancels or the client closes the stream.
+  rpc StreamUserRunStates(StreamUserRunStatesRequest) returns (stream RunStateEvent);
 }
 
 // ========================
@@ -699,4 +710,52 @@ message SubstrateRequest {
 message SubstrateResponse {
   bytes output_json = 1;
   bool is_error = 2;
+}
+
+// ========================
+// v0.9.x n8n RFC Phase 0
+// ========================
+
+// ListChannelsRequest is empty — the channel list is global within
+// the loomcycle process, no per-call selectors.
+message ListChannelsRequest {}
+
+message ListChannelsResponse {
+  repeated ChannelDescriptor channels = 1;
+}
+
+message ChannelDescriptor {
+  string name = 1;
+  string scope = 2;
+  string semantic = 3;
+  string publisher = 4;
+  string period = 5;
+  int32 default_ttl = 6;
+  int32 max_messages = 7;
+  int64 message_count = 8;
+  // RFC3339 strings — empty when count == 0.
+  string oldest_visible_at = 9;
+  string newest_visible_at = 10;
+}
+
+message StreamUserRunStatesRequest {
+  string user_id = 1;
+  // Optional filter — empty means all transitions match.
+  repeated string statuses = 2;
+  // Optional filter — empty means any agent matches.
+  string agent = 3;
+}
+
+// RunStateEvent mirrors the SSE wire shape from the HTTP transport.
+// TS is RFC3339 for language-portability.
+message RunStateEvent {
+  string run_id = 1;
+  string agent_id = 2;
+  string agent = 3;
+  string user_id = 4;
+  string parent_agent_id = 5;
+  string status = 6;
+  string stop_reason = 7;
+  string error = 8;
+  string ts = 9;
 }


### PR DESCRIPTION
## Summary

Phase 0 of the n8n integration RFC (`~/work/loomcycle-internal/doc-internal/rfcs/n8n-comparison.md`). Adds the two new wire-API surfaces every transport now exposes:

- **`GET /v1/_channels`** — bearer-authed listing of operator-declared channels joined with aggregate stats (`message_count`, `oldest_visible_at`, `newest_visible_at`). Powers the n8n credential-picker's channel-name dropdown; useful for any operator dashboard.
- **`GET /v1/users/{user_id}/agents/stream`** — SSE stream of run state transitions scoped to one user_id. Powers the upcoming `n8n-nodes-loomcycle` trigger nodes (Run Completed / Channel Message). Filters via `?status=running,completed,...&agent=<name>`. 25s keepalive comment frames; 30-min lifetime cap.

Both surface through the canonical `connector.Connector` interface so MCP + gRPC + TS adapter dispatch the same code path:

- **Connector**: 26 → 28 methods. `StreamUserRunStates` uses a visitor-pattern callback rather than channel return so it stays sync-style for non-streaming transports.
- **MCP meta-tools**: 26 → 28. `list_channels` (sync) + `stream_user_run_states` (two modes — streams notifications when `capabilities.loomcycle.runEvents=true`, otherwise collects up to `max_events` events for `timeout_ms` and returns the slice).
- **gRPC**: `ListChannels` + `StreamUserRunStates` RPCs added to the proto. Server-streamed for the second.
- **TS adapter**: `listChannels()` + `streamUserRunStates(userId, opts)` returning `AsyncIterable<RunStateStreamItem>`. Bumped `@loomcycle/client` to v0.10.0 (minor; additive surface).

## What changed under the hood

- New `internal/runstate/` package — in-process pub/sub bus mirroring the `channels.Bus` shape but carrying payloads directly (the SSE handler needs the run_id + status delta without a follow-up DB read).
- `internal/store/Store.ChannelStats(ctx)` interface method + SQLite + Postgres implementations. Single `GROUP BY` aggregate on `channel_messages` excluding expired rows.
- The four `finishRun*` helpers in `internal/api/http/server.go` gained a `runStateMeta` parameter. 11 call sites in `handleRuns` / `handleMessages` (continuation) / `runSubAgent` updated to assemble meta from locals + publish a `running` transition right after `cancelReg.Register`. Sub-agent meta carries `ParentAgentID` so SSE subscribers see the lineage edge.
- `cmd/loomcycle/main.go`: one new line constructing `runstate.NewBus()` and wiring it via `SetRunStateBus`.

## Test plan

- [x] `go test ./...` clean (full repo pass, 200+ tests)
- [x] `go test ./internal/runstate -v` (7 tests; publish/subscribe roundtrip, cross-user isolation, drop-on-full-buffer, concurrent pub/sub)
- [x] `go test ./internal/api/http -run 'TestListChannels|TestStream|TestFinishRun|TestConnector_(ListChannels|StreamUserRunStates)' -v` (15 tests)
- [x] `go test ./internal/api/mcp -run 'TestServer_(ListChannels|StreamUserRunStates|ToolsList)' -v` (5 tests; sync + streaming-notification paths)
- [x] `go test ./internal/api/grpc -run 'TestGrpc(ListChannels|StreamUserRunStates)' -v` (3 tests; happy-path + server-streaming + missing-user_id rejection)
- [x] `cd adapters/ts && npm test` — 91 tests pass including 5 new (listChannels happy path, streaming yields open + N events, query-param encoding, keepalive-comment tolerance, 401 raises AuthError)
- [x] **Manual smoke against the binary**:
  - `./bin/loomcycle --config /tmp/loomcycle-smoke.yaml` started cleanly
  - `curl /v1/_channels` returned the two declared smoke channels with `message_count: 0`
  - `curl -N -H 'Accept: text/event-stream' /v1/users/smoke-user/agents/stream` emitted the `stream_open` frame within 100ms

## What this PR does NOT do

- Phase 1 documentation (the bundled `n8n-integration.md` help topic + the `mcp_servers.n8n-*` yaml example) — ships as a follow-up PR. The new endpoints are documented in code; the user-facing operator narrative lands in PR B.
- The community node — that's Phase 2 of the RFC, a separate `denn-gubsky/n8n-nodes-loomcycle` repo + ~2-3 weeks of work later.
- Python adapter parity — currently at 0.7.0; will catch up in a separate bump.
- Cross-process SSE delivery for multi-replica HA — same documented punt as `channels.Bus` (v0.9.x HA work will swap the backplane for Postgres LISTEN/NOTIFY or Redis pub/sub without changing the Subscribe / Publish surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)