### PR TITLE
fix(test): unbreak CI — SSE-stream tests race the Subscribe registration

### DIFF
--- a/internal/api/http/connector_impl_n8n_test.go
+++ b/internal/api/http/connector_impl_n8n_test.go
@@ -76,8 +76,9 @@ func TestConnector_StreamUserRunStates_VisitsMatchingEvents(t *testing.T) {
 		})
 	}()
 
-	// Wait briefly so the subscriber is registered before publishing.
-	time.Sleep(20 * time.Millisecond)
+	// Sync on actual subscription registration rather than a fixed
+	// sleep — under the race detector a 20ms sleep is unreliable.
+	waitForSubscriber(t, bus)
 
 	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})  // filtered out
 	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Status: "completed"}) // passes
@@ -114,7 +115,7 @@ func TestConnector_StreamUserRunStates_StopOnSentinel(t *testing.T) {
 			})
 	}()
 
-	time.Sleep(20 * time.Millisecond)
+	waitForSubscriber(t, bus)
 	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
 
 	select {

--- a/internal/api/http/connector_impl_n8n_test.go
+++ b/internal/api/http/connector_impl_n8n_test.go
@@ -80,7 +80,7 @@ func TestConnector_StreamUserRunStates_VisitsMatchingEvents(t *testing.T) {
 	// sleep — under the race detector a 20ms sleep is unreliable.
 	waitForSubscriber(t, bus)
 
-	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})  // filtered out
+	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})   // filtered out
 	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Status: "completed"}) // passes
 	bus.Publish(runstate.RunStateEvent{RunID: "r3", UserID: "user-b", Status: "completed"}) // wrong user
 

--- a/internal/api/http/runs_stream.go
+++ b/internal/api/http/runs_stream.go
@@ -13,8 +13,9 @@
 // publisher being a finishRun* call site we MUST NEVER stall).
 //
 // Filter shape (all optional):
-//   ?status=running,completed,failed,cancelled   — comma-separated allowlist
-//   ?agent=<name>                                 — exact-match agent name
+//
+//	?status=running,completed,failed,cancelled   — comma-separated allowlist
+//	?agent=<name>                                 — exact-match agent name
 //
 // Filters apply at the handler (not the bus) so the bus stays
 // uniform across all subscribers and the same Subscription is
@@ -72,10 +73,10 @@ func parseStreamFilter(userID string, q map[string][]string) connector.StreamUse
 // Failure modes:
 //   - missing user_id path arg     → 400 invalid_request
 //   - writer doesn't support SSE   → 500 sse_not_supported (rare; most
-//                                     test recorders DO support Flusher)
+//     test recorders DO support Flusher)
 //   - runStateBus not configured   → 503 stream_unavailable (operator
-//                                     wired loomcycle without the bus;
-//                                     defensive — main.go always wires it)
+//     wired loomcycle without the bus;
+//     defensive — main.go always wires it)
 func (s *Server) handleStreamUserAgents(w http.ResponseWriter, r *http.Request) {
 	userID := r.PathValue("user_id")
 	if userID == "" {

--- a/internal/api/http/runs_stream_test.go
+++ b/internal/api/http/runs_stream_test.go
@@ -53,6 +53,31 @@ func readSSEFrame(t *testing.T, r *bufio.Reader) (string, string, bool) {
 	}
 }
 
+// waitForSubscriber polls bus.ActiveSubscriberCount until at least
+// one subscription is registered (or until a 2s deadline fires).
+// The SSE handler emits the `stream_open` frame BEFORE the
+// Connector-dispatched StreamUserRunStates path calls bus.Subscribe —
+// so reading stream_open from the wire does NOT guarantee the
+// subscription is in place. Tests that publish events immediately
+// after open MUST sync on this; otherwise the publish races the
+// subscription and the test hangs (caught in CI under the race
+// detector — see TestStreamUserAgents_FiltersByStatus pre-fix).
+//
+// Production callers don't need this — n8n's trigger framework
+// reconnects long-running streams and continuous publishes always
+// land within milliseconds of subscription registration.
+func waitForSubscriber(t *testing.T, bus *runstate.Bus) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for bus.ActiveSubscriberCount() == 0 {
+		select {
+		case <-deadline:
+			t.Fatal("subscriber never registered within 2s — likely a regression in the handler's Subscribe path")
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+}
+
 // openStream starts an httptest.NewServer-backed SSE connection and
 // returns a bufio.Reader over the response body plus a cancel func.
 // The caller must call cancel() to clean up.
@@ -105,6 +130,7 @@ func TestStreamUserAgents_EmitsStreamOpenAndRunStateEvents(t *testing.T) {
 		t.Errorf("stream_open user_id = %v, want user-a", openPayload["user_id"])
 	}
 
+	waitForSubscriber(t, bus)
 	bus.Publish(runstate.RunStateEvent{
 		RunID: "r1", Agent: "researcher", UserID: "user-a", Status: "running",
 	})
@@ -137,6 +163,7 @@ func TestStreamUserAgents_FiltersByStatus(t *testing.T) {
 		t.Fatal("no stream_open")
 	}
 
+	waitForSubscriber(t, bus)
 	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Status: "running"})
 	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Status: "completed"})
 
@@ -165,6 +192,7 @@ func TestStreamUserAgents_FiltersByAgent(t *testing.T) {
 		t.Fatal("no stream_open")
 	}
 
+	waitForSubscriber(t, bus)
 	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-a", Agent: "reader", Status: "running"})
 	bus.Publish(runstate.RunStateEvent{RunID: "r2", UserID: "user-a", Agent: "writer", Status: "running"})
 
@@ -190,6 +218,7 @@ func TestStreamUserAgents_OtherUsersEventsNotDelivered(t *testing.T) {
 		t.Fatal("no stream_open")
 	}
 
+	waitForSubscriber(t, bus)
 	// Event for a different user.
 	bus.Publish(runstate.RunStateEvent{RunID: "r1", UserID: "user-b", Status: "running"})
 

--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -58,9 +58,9 @@ func (s *subscription) DroppedEvents() int64 {
 
 // Bus is the in-process run-state pub/sub.
 type Bus struct {
-	mu          sync.Mutex
-	byUser      map[string][]*subscription
-	bufferSize  int
+	mu         sync.Mutex
+	byUser     map[string][]*subscription
+	bufferSize int
 }
 
 // NewBus returns a fresh, empty bus. Single instance per loomcycle

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -453,12 +453,12 @@ func (a *AgentDef) execVerify(ctx context.Context, policy tools.AgentDefPolicyVa
 		if errors.As(err, &nf) {
 			// Name not promoted → no deployed version → never matches.
 			return okJSON(map[string]any{
-				"matches":         false,
-				"current_sha256":  "",
-				"current_def_id":  "",
-				"version":         0,
-				"name":            in.Name,
-				"deployed":        false,
+				"matches":        false,
+				"current_sha256": "",
+				"current_def_id": "",
+				"version":        0,
+				"name":           in.Name,
+				"deployed":       false,
 			})
 		}
 		return errResult(fmt.Sprintf("verify: %s", err)), nil


### PR DESCRIPTION
## Summary

**CI has been failing on every merge to \`main\` since PR #173** (n8n Phase 0). Three consecutive merges shipped red: #173, #174, #175. The local pre-merge runs were green because the race detector wasn't on; the post-merge GitHub Actions run uses \`-race -timeout=2m\` and was timing out at the 2-minute mark on \`TestStreamUserAgents_FiltersByStatus\`.

## Root cause

The SSE handler at \`internal/api/http/runs_stream.go\` emits the \`stream_open\` frame BEFORE the Connector-dispatched \`StreamUserRunStates\` path internally calls \`bus.Subscribe\`. The test sequence was:

1. \`openStream()\` opens the HTTP request → handler starts running
2. Read \`stream_open\` frame from the wire
3. \`bus.Publish(...)\` two events
4. Expect to read one matching event back

Step 2 reaching the client doesn't guarantee the handler goroutine has reached step 4's \`Subscribe\` call. Under \`-race\` the goroutine scheduler is slowed enough that \`Publish\` lands BEFORE \`Subscribe\` registers — the events go to no subscribers and silently vanish. The test reader then waits forever for an event that will never come.

Production callers don't hit this (they re-publish continuously and reconnect long streams), but tests publishing a single event then expecting to read it back are vulnerable.

## Fix

Synchronise on actual subscription registration via the bus's existing \`ActiveSubscriberCount\` diagnostic method. New test helper \`waitForSubscriber(t, bus)\` polls until count ≥ 1 (2s deadline). Inserted in every test that publishes immediately after stream_open:

- \`TestStreamUserAgents_EmitsStreamOpenAndRunStateEvents\`
- \`TestStreamUserAgents_FiltersByStatus\` (the one CI flagged)
- \`TestStreamUserAgents_FiltersByAgent\`
- \`TestStreamUserAgents_OtherUsersEventsNotDelivered\`

Same fix replaces the 20ms \`time.Sleep\` in the connector-level tests (\`TestConnector_StreamUserRunStates_VisitsMatchingEvents\` + \`TestConnector_StreamUserRunStates_StopOnSentinel\`) — fixed sleep was unreliable under \`-race\` for the same reason.

## Test plan

- [x] \`go test -race -timeout 5m -count=1 ./...\` — full repo clean (was hanging at \`internal/api/http\` after 2m)
- [x] \`go test -race -timeout 2m ./internal/api/http/... -run 'TestStreamUserAgents|TestConnector_StreamUserRunStates' -v\` — all 9 affected tests green

## Why not fix the production code instead

The race is structural to the test setup, not a production bug. Real-world consumers (n8n triggers, orchestration UIs) reconnect long-running streams and publish continuously — a single-event timing window is invisible. Restructuring the handler to subscribe-before-stream_open would either leak the bus through the handler or require a Connector signature change (breaking the v0.8.18 wire-shape lock). The test-layer sync is the right scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)