### PR TITLE
fix(substrate): unblock HTTP-admin AgentDef/SkillDef create with allowed_tools

### DIFF
--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -130,6 +130,19 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 		AgentID: substrateAdminAgentID,
 	})
 	ctx = tools.WithAgentName(ctx, substrateAdminAgentName)
+	// AgentTools wildcard: substrate admin = operator trust. Without
+	// this, AgentDef.create / SkillDef.create with a non-empty
+	// allowed_tools overlay refuse with "caller's effective
+	// allowed_tools not on ctx (runtime misconfiguration)" because
+	// the create-time ceiling check (assertAllowedToolsSubset against
+	// callerTools) treats a nil callerTools as "unknown ceiling →
+	// refuse". For operator-trust paths the operator is the security
+	// boundary (bearer-authed /v1/_*), so attach a wildcard ceiling
+	// the subset check recognises. Regular per-run contexts continue
+	// to set WithAgentTools to the agent's actual allowed_tools list,
+	// so the capability-escalation guard for in-loop AgentDef calls
+	// is unchanged.
+	ctx = tools.WithAgentTools(ctx, []string{"*"})
 	// Memory: full scope access. QuotaBytes=0 falls back to the
 	// global default (LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES).
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -139,6 +139,58 @@ func TestSubstrateAdmin_AgentDef_MaxIterationsThreadsThrough(t *testing.T) {
 	}
 }
 
+// HTTP-admin AgentDef.create with a non-empty allowed_tools list
+// MUST succeed. Before the substrateAdminCtx wildcard fix, the
+// in-process tool refused with "caller's effective allowed_tools
+// not on ctx" because the admin context didn't set WithAgentTools,
+// blocking containerised callers (JobEmber) from registering their
+// agents at boot. Pin the contract so the regression has teeth.
+func TestSubstrateAdmin_AgentDef_CreateWithAllowedToolsSucceeds(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	body := `{"op":"create","name":"cv-adapter","overlay":{"system_prompt":"adapt the CV","allowed_tools":["Read","Write","WebFetch"]}}`
+	resp := postAdmin(t, ts, "/v1/_agentdef", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["name"] != "cv-adapter" {
+		t.Errorf("name = %v, want cv-adapter", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+}
+
+// Mirror test for SkillDef — same gap, same fix. Skills with their
+// own allowed_tools (e.g. position-relevance-filtering carries
+// mcp__jobs__matchUserLocations) must register over HTTP admin.
+func TestSubstrateAdmin_SkillDef_CreateWithAllowedToolsSucceeds(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	body := `{"op":"create","name":"position-relevance-filtering","overlay":{"body":"Evaluate postings.","allowed_tools":["Read","WebFetch"]}}`
+	resp := postAdmin(t, ts, "/v1/_skilldef", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["name"] != "position-relevance-filtering" {
+		t.Errorf("name = %v, want position-relevance-filtering", out["name"])
+	}
+}
+
 func TestSubstrateAdmin_RejectsMalformedBody(t *testing.T) {
 	ts := substrateAdminFixture(t)
 	defer ts.Close()

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -593,7 +593,20 @@ func (a *AgentDef) resolveAllowedToolsRoot(ctx context.Context, name string, par
 // also appears in `root`. Empty proposed = empty subset = OK (narrowing
 // to zero tools is allowed). Empty root = no permitted tools — proposed
 // must also be empty.
+//
+// Wildcard: a root containing "*" accepts any proposed list. Used by
+// the substrate-admin HTTP context (substrateAdminCtx) where the
+// operator's bearer-auth is the security boundary, not a per-agent
+// allowed_tools ceiling. Lineage roots (the v1 row's actual tool
+// list) never contain "*" — they're real tool names persisted by an
+// earlier `create`, so the fork narrowing check at lines 305 / 328
+// is unaffected.
 func assertAllowedToolsSubset(proposed, root []string) error {
+	for _, t := range root {
+		if t == "*" {
+			return nil
+		}
+	}
 	rootSet := make(map[string]bool, len(root))
 	for _, t := range root {
 		rootSet[t] = true

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -265,6 +265,26 @@ func TestAgentDefTool_CreateRefusedOnAllowedToolsWidening(t *testing.T) {
 	}
 }
 
+// Wildcard caller tools — used by the substrate-admin HTTP context
+// (substrateAdminCtx in internal/api/http/substrate_admin.go) so the
+// operator can register agents whose allowed_tools the operator
+// chooses, without first listing every per-tool name as their own
+// callerTools list. assertAllowedToolsSubset short-circuits on a
+// "*" entry in root.
+func TestAgentDefTool_CreateWithWildcardCallerToolsAllowsAnyOverlay(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	wildCtx := tools.WithAgentTools(ctx, []string{"*"})
+
+	// Operator picks a broad allowed_tools list — every entry should
+	// pass even though "*" alone is the caller's ceiling.
+	res, _ := tool.Execute(wildCtx, json.RawMessage(`{"op":"create","name":"opagent","overlay":{"allowed_tools":["Read","Write","WebFetch","Bash"]}}`))
+	if res.IsError {
+		t.Fatalf("create with wildcard ctx + arbitrary allowed_tools should pass; got %s", res.Text)
+	}
+}
+
 // Missing AgentTools(ctx) — runtime misconfiguration. With a
 // non-empty overlay AllowedTools, refuse rather than silently
 // allow the wider value.


### PR DESCRIPTION
## Summary

Containerised callers (JobEmber) that push agent + skill definitions to loomcycle at boot via `POST /v1/_agentdef` / `POST /v1/_skilldef` were blocked on first deploy: the in-process tool refused every `create` whose overlay declared `allowed_tools` with

```
create: caller's effective allowed_tools not on ctx (runtime misconfiguration);
refuse rather than risk silent widening
```

**Root cause:** [`substrateAdminCtx`](internal/api/http/substrate_admin.go) stamps the operator-trust context with `WithAgentDefPolicy` / `WithChannelPolicy` / etc., but not with `WithAgentTools`. The `AgentDef.create` capability-escalation guard at [agentdef.go:181](internal/tools/builtin/agentdef.go#L181) treats a `nil` `callerTools` as *"unknown ceiling — refuse"* — correct for per-run contexts where missing `callerTools` is a runtime misconfiguration, but wrong for HTTP-admin where the operator's bearer auth IS the security boundary.

## Fix

- `substrateAdminCtx` now attaches `WithAgentTools(ctx, []string{"*"})` — wildcard sentinel meaning "no per-tool ceiling, operator trust".
- `assertAllowedToolsSubset` short-circuits when `root` contains `"*"`.

Lineage roots never contain `"*"` (they're real tool names persisted by an earlier `create`), so the fork-narrowing check at `agentdef.go:305` / `skilldef.go:328` is unaffected — forks still narrow against the real v1 tool list, never widen.

Regular per-run contexts continue to attach `WithAgentTools(ctx, agent.AllowedTools)` (real tool names, no wildcard), so the in-loop capability-escalation guard for nested `AgentDef.create` calls is unchanged.

## Tests

- `TestAgentDefTool_CreateWithWildcardCallerToolsAllowsAnyOverlay` — unit test pinning the wildcard-passes contract.
- `TestSubstrateAdmin_AgentDef_CreateWithAllowedToolsSucceeds` — end-to-end HTTP test, AgentDef.
- `TestSubstrateAdmin_SkillDef_CreateWithAllowedToolsSucceeds` — end-to-end HTTP test, SkillDef.

Existing regression coverage still passes:
- `TestAgentDefTool_CreateRefusedOnAllowedToolsWidening` — narrow `callerTools` still narrow.
- `TestAgentDefTool_CreateRefusedWhenCallerToolsMissing` — `nil` `callerTools` still refuses.

## Test plan

- [x] `go test ./internal/tools/builtin/ ./internal/api/http/` — green.
- [x] `go test ./...` — green; no regressions across the whole tree.
- [x] `gofmt -l internal/` — clean.
- [x] `go vet ./...` — clean.
- [ ] Manual: build the CLI, point it at a fresh sqlite store, POST `/v1/_agentdef` with `{"op":"create","name":"x","overlay":{"system_prompt":"hi","allowed_tools":["Read","Write"]}}` — expect 200 instead of 422.

## Downstream

[denn-gubsky/jobs-search-agent#69](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent/pulls/69) (the JobEmber agent-registry boot sync) is gated on this fix landing. The JobEmber side documents the precondition in `doc/loomcycle-integration.md` under *Required preconditions → substrate-admin tools ceiling*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)