### PR TITLE
feat(ts-adapter): n8n polish — debug toggle + parentAgentId filter + JSDoc

### DIFF
--- a/adapters/ts/README.md
+++ b/adapters/ts/README.md
@@ -17,6 +17,7 @@ TypeScript client for the [loomcycle](https://github.com/denn-gubsky/loomcycle) 
 - **`streamUserRunStates`** (v0.9.x) — SSE stream of run state transitions scoped to one `user_id`. Yields `{ kind: "open" | "event", payload }` items until the connection closes (30-min server cap). The primary substrate hook for orchestration UIs that need to react when an agent run completes / fails / cancels.
 - **Content signatures** (v0.9.x) — every `agent_defs` / `skill_defs` row now carries a deterministic `content_sha256`. Combined with the `verify` op and the `loomcycle hash agent|skill` CLI subcommand, this gives Docker-bundled operators a one-call answer to *"is what I have in my image identical to what's deployed?"* — see [Content signatures](#content-signatures-v09x) below for the end-to-end workflow.
 - **Transcript first-cycle types** (v0.9.1) — `UserInputPayload` + `SystemPromptPayload` typed interfaces for the two new transcript events that surface "what the agent actually received" (the resolved system prompt + the caller's segments) as the first frames of every run.
+- **n8n polish — `debug` toggle + `parentAgentId` filter** (v0.13.0) — opt-in synthetic `stream_open` / `stream_close` frames on `runStreaming` / `continueSession` / `streamUserRunStates` plus a client-side `parentAgentId` filter on `listUserAgents` + `streamUserRunStates`. Default behaviour is unchanged for existing callers; both knobs are off until set. See [Patterns](#patterns) for when to reach for them.
 
 ## Install
 
@@ -420,6 +421,80 @@ try {
   }
 }
 ```
+
+## Patterns
+
+A short field guide for the common consumer shapes — when to use which method, what each one costs, and how the v0.9.x polish hooks (`debug`, `parentAgentId`) fit in.
+
+### Sync vs async run consumption
+
+`runStreaming` and `continueSession` are **sync**: the iterator stays alive for the FULL duration of the run. Use them when:
+
+- You have a single agent run and want to render its output progressively (UI streaming, CLI tail-like display).
+- The caller can hold a connection per active run without worker-thread starvation.
+
+For async fire-and-forget patterns (the n8n trigger node's model), use `streamUserRunStates` instead:
+
+```ts
+// Don't do this in an n8n worker — blocks the worker for the full run:
+for await (const ev of client.runStreaming({ agent: "long-task", segments })) { ... }
+
+// Do this instead — kick off the run, get back a tracking ID, and watch run-state transitions:
+const seedRun = await runOnce(...);  // your one-shot dispatch
+for await (const item of client.streamUserRunStates(userId, {
+  statuses: ["completed", "failed", "cancelled"],
+})) {
+  if (item.kind === "event" && item.payload.agent_id === seedRun.agentId) {
+    // fire downstream workflow, persist to DB, etc.
+    break;
+  }
+}
+```
+
+`streamUserRunStates` holds ONE connection per user regardless of how many concurrent runs that user has. Server-enforced 30-minute timeout; reconnect on close.
+
+### `debug: true` — synthetic open/close frames
+
+All three streaming methods (`runStreaming`, `continueSession`, `streamUserRunStates`) accept `debug?: boolean`. Default off; behaviour is exactly the pre-v0.9.x shape.
+
+When `debug: true`:
+- `runStreaming` / `continueSession` brackets the real events with `{ type: "_meta", meta_subtype: "stream_open" | "stream_close", meta_reason }` frames. The leading-underscore type signals "client-synthesized; never on the wire." The `meta_reason` is `"eof"` on clean close or an error class name (e.g. `"AuthError"`) when the inner iterator threw mid-stream.
+- `streamUserRunStates` yields an extra `{ kind: "close", payload: { reason } }` item on stream end (in addition to the existing `kind: "open" | "event"` frames).
+
+```ts
+for await (const ev of client.runStreaming({ agent: "qa", segments, debug: true })) {
+  if (ev.type === "_meta") {
+    console.log(`[stream ${ev.meta_subtype}] reason=${ev.meta_reason}`);
+    continue;
+  }
+  // ... handle real events
+}
+```
+
+Use case: n8n trigger nodes that surface "stream re-opened / closed" log entries to the operator without inferring from event timing. Non-n8n consumers don't need to know the toggle exists.
+
+### `parentAgentId` — client-side narrowing
+
+`listUserAgents(userId, { parentAgentId })` and `streamUserRunStates(userId, { parentAgentId })` apply a client-side filter on the run's `parent_agent_id`. The server still returns / streams the full set; the adapter trims before yielding.
+
+```ts
+// All sub-runs spawned by a specific parent (one-shot snapshot)
+const subRuns = await client.listUserAgents(userId, {
+  parentAgentId: "ag_parent_abc",
+  status: "running",
+});
+
+// Same shape, but as a live stream
+for await (const item of client.streamUserRunStates(userId, {
+  parentAgentId: "ag_parent_abc",
+  statuses: ["completed", "failed"],
+})) {
+  // Only events whose payload.parent_agent_id === "ag_parent_abc"
+  // (open and close frames always pass through).
+}
+```
+
+**Cost note:** because the filter is client-side, the server doesn't shed any load. If the result set is large enough that you care about server-side narrowing, raise an issue — server-side `?parent_agent_id=` is a planned addition.
 
 ## Why HTTP, not gRPC
 

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.13.0",
-  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 36 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel — admin scope=global + per-user scope=user surfaces), v0.9.x content_sha256 (AgentDefVerifyResult + SkillDefVerifyResult types for the bundle-vs-deployed comparison workflow), v0.9.1 transcript first-cycle (SystemPromptPayload + UserInputPayload), and v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult — register HTTP/Streamable-HTTP MCP servers at runtime without yaml edits).",
+  "version": "0.13.1",
+  "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 36 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates — with debug-mode synthetic open/close meta-frames + client-side parentAgentId filter), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel — admin scope=global + per-user scope=user surfaces), v0.9.x content_sha256 (AgentDefVerifyResult + SkillDefVerifyResult types for the bundle-vs-deployed comparison workflow), v0.9.1 transcript first-cycle (SystemPromptPayload + UserInputPayload), and v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult — register HTTP/Streamable-HTTP MCP servers at runtime without yaml edits).",
   "license": "Apache-2.0",
   "type": "module",
   "repository": {

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -99,6 +99,19 @@ export class LoomcycleClient {
    * Errors during the run surface as `{ type: "error", error }` events;
    * only transport / HTTP-level failures throw — and those throw typed
    * errors (e.g. AuthError for 401, BackpressureError for 429).
+   *
+   * **Blocking semantics.** This iterator is alive for the FULL
+   * duration of the run — typically seconds, occasionally minutes for
+   * long tool chains. Callers that need fire-and-forget completion
+   * notifications (n8n's worker model, dashboards that don't want to
+   * hold a connection per active run) should subscribe to
+   * {@link LoomcycleClient.streamUserRunStates} instead, which yields
+   * one terminal-state frame per completed run without holding the
+   * run's stream open.
+   *
+   * v0.9.x — pass `opts.debug = true` to emit synthetic
+   * `{ type: "_meta", meta_subtype: "stream_open" | "stream_close" }`
+   * events around the real frames. Silent (default) when omitted.
    */
   async *runStreaming(opts: RunOptions): AsyncIterable<AgentEvent> {
     // Build the body conditionally so omitted fields stay off the wire.
@@ -122,7 +135,7 @@ export class LoomcycleClient {
     if (opts.agentId !== undefined) body.agent_id = opts.agentId;
     if (opts.userTier !== undefined) body.user_tier = opts.userTier;
     if (opts.userBearer !== undefined) body.user_bearer = opts.userBearer;
-    yield* this.streamSSE("/v1/runs", body, opts.signal);
+    yield* this.streamSSE("/v1/runs", body, opts.signal, opts.debug);
   }
 
   /**
@@ -133,6 +146,14 @@ export class LoomcycleClient {
    * Raises SessionNotFoundError when sessionId is unknown,
    * SessionBusyError when another request is in flight on the same
    * session.
+   *
+   * **Blocking semantics.** Same as {@link LoomcycleClient.runStreaming} —
+   * the iterator stays alive for the duration of the new run. For
+   * async fire-and-forget completion patterns, see
+   * {@link LoomcycleClient.streamUserRunStates}.
+   *
+   * v0.9.x — pass `opts.debug = true` for synthetic
+   * `_meta` open/close events.
    */
   async *continueSession(opts: ContinueOptions): AsyncIterable<AgentEvent> {
     const body: Record<string, unknown> = {
@@ -150,6 +171,7 @@ export class LoomcycleClient {
       `/v1/sessions/${encodeURIComponent(opts.sessionId)}/messages`,
       body,
       opts.signal,
+      opts.debug,
     );
   }
 
@@ -177,10 +199,20 @@ export class LoomcycleClient {
     return { cancelledCount: resp.cancelled_count };
   }
 
-  /** List a user's recent agent runs, optionally filtered by status. */
+  /** List a user's recent agent runs, optionally filtered by status.
+   *
+   *  v0.9.x — `parentAgentId` narrows the result CLIENT-SIDE to runs
+   *  whose `parent_agent_id` matches. The server still returns the
+   *  full set (server-side `?parent_agent_id=` filter is a future
+   *  request); the adapter trims before returning. Useful for the
+   *  n8n trigger pattern "show me all sub-runs spawned by parent X." */
   async listUserAgents(
     userId: string,
-    opts?: { status?: AgentStatus; signal?: AbortSignal },
+    opts?: {
+      status?: AgentStatus;
+      parentAgentId?: string;
+      signal?: AbortSignal;
+    },
   ): Promise<Agent[]> {
     const q = opts?.status ? `?status=${encodeURIComponent(opts.status)}` : "";
     const resp = await jsonFetch<ListAgentsResponse>(
@@ -188,7 +220,11 @@ export class LoomcycleClient {
       `/v1/users/${encodeURIComponent(userId)}/agents${q}`,
       opts,
     );
-    return resp.agents ?? [];
+    const all = resp.agents ?? [];
+    if (opts?.parentAgentId !== undefined && opts.parentAgentId !== "") {
+      return all.filter((a) => a.parent_agent_id === opts.parentAgentId);
+    }
+    return all;
   }
 
   /** Read the full event log for a session. Each entry has seq,
@@ -589,11 +625,18 @@ export class LoomcycleClient {
   // ---- Internal helpers ----
 
   /** Shared SSE POST → stream-of-AgentEvent path. Used by
-   *  runStreaming + continueSession. */
+   *  runStreaming + continueSession.
+   *
+   *  When `debug` is true, the iterator yields a synthetic
+   *  `{ type: "_meta", meta_subtype: "stream_open" }` before any real
+   *  events AND a `{ type: "_meta", meta_subtype: "stream_close",
+   *  meta_reason }` on EOF / abort / error. The default is silent
+   *  (matches pre-v0.9.x behaviour). */
   private async *streamSSE(
     path: string,
     body: Record<string, unknown>,
     signal?: AbortSignal,
+    debug?: boolean,
   ): AsyncIterable<AgentEvent> {
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -621,7 +664,40 @@ export class LoomcycleClient {
       throw new Error("loomcycle: response has no body");
     }
 
-    yield* parseSSE(resp.body.getReader());
+    if (!debug) {
+      // Silent default — pre-v0.9.x shape.
+      yield* parseSSE(resp.body.getReader());
+      return;
+    }
+
+    // Debug shape: synthetic open + close around the real stream.
+    // `meta_reason` distinguishes normal EOF from caller-side abort
+    // or a typed-error throw mid-stream. The close frame is emitted
+    // in `finally` so it fires regardless of how the inner iterator
+    // exited.
+    yield { type: "_meta", meta_subtype: "stream_open", meta_reason: "open" };
+    let closeReason = "eof";
+    try {
+      yield* parseSSE(resp.body.getReader());
+    } catch (e) {
+      // Capture the error type for the close frame, then re-throw so
+      // typed-error handling at the consumer site still works.
+      closeReason =
+        e && typeof e === "object" && "name" in e
+          ? String((e as { name: string }).name)
+          : "error";
+      yield {
+        type: "_meta",
+        meta_subtype: "stream_close",
+        meta_reason: closeReason,
+      };
+      throw e;
+    }
+    yield {
+      type: "_meta",
+      meta_subtype: "stream_close",
+      meta_reason: closeReason,
+    };
   }
 
   // ---- v0.9.x n8n RFC Phase 0 ----
@@ -745,7 +821,18 @@ export class LoomcycleClient {
    *  Callers running indefinitely should reconnect on close.
    *
    *  Errors during the stream throw — they do NOT surface as items.
-   *  Pass an AbortSignal to terminate cleanly from the consumer side. */
+   *  Pass an AbortSignal to terminate cleanly from the consumer side.
+   *
+   *  v0.9.x options:
+   *  - `parentAgentId` — client-side filter: only `kind: "event"`
+   *    items whose payload's `parent_agent_id` matches are yielded.
+   *    The server still streams every matching event; the adapter
+   *    filters before yielding. Empty/omitted = no filter.
+   *  - `debug` — when true, an additional `{ kind: "close", payload:
+   *    { reason } }` item is yielded when the stream ends (EOF,
+   *    abort, or pre-yield error). Useful for n8n nodes that surface
+   *    "stream re-opened / closed" log entries without inferring
+   *    from timing. Default false. */
   async *streamUserRunStates(
     userId: string,
     opts?: StreamUserRunStatesOptions,
@@ -782,7 +869,39 @@ export class LoomcycleClient {
       throw new Error("loomcycle: streamUserRunStates response has no body");
     }
 
-    yield* parseRunStateSSE(resp.body.getReader());
+    const parentFilter = opts?.parentAgentId ?? "";
+    const debug = opts?.debug === true;
+
+    let closeReason = "eof";
+    try {
+      for await (const item of parseRunStateSSE(resp.body.getReader())) {
+        // Client-side parent_agent_id filter. Pre-v1 the server has no
+        // ?parent_agent_id= query param; n8n-style consumers that need
+        // a narrow view get a smaller iterator at the cost of
+        // unchanged server load. See StreamUserRunStatesOptions for
+        // the trade-off note.
+        if (
+          parentFilter !== "" &&
+          item.kind === "event" &&
+          item.payload.parent_agent_id !== parentFilter
+        ) {
+          continue;
+        }
+        yield item;
+      }
+    } catch (e) {
+      closeReason =
+        e && typeof e === "object" && "name" in e
+          ? String((e as { name: string }).name)
+          : "error";
+      if (debug) {
+        yield { kind: "close", payload: { reason: closeReason } };
+      }
+      throw e;
+    }
+    if (debug) {
+      yield { kind: "close", payload: { reason: closeReason } };
+    }
   }
 }
 

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -671,11 +671,16 @@ export class LoomcycleClient {
     }
 
     // Debug shape: synthetic open + close around the real stream.
-    // `meta_reason` distinguishes normal EOF from caller-side abort
-    // or a typed-error throw mid-stream. The close frame is emitted
-    // in `finally` so it fires regardless of how the inner iterator
-    // exited.
-    yield { type: "_meta", meta_subtype: "stream_open", meta_reason: "open" };
+    // The open frame carries no meta_reason — the frame itself IS the
+    // signal. The close frame's meta_reason distinguishes normal EOF
+    // from caller-side abort or a typed-error throw mid-stream.
+    //
+    // Close is emitted on both paths via try/catch/throw: success path
+    // emits AFTER the try block; error path emits INSIDE the catch
+    // before re-throwing. NOT a try/finally — the duplication is
+    // intentional so the close-then-throw ordering is explicit and
+    // a refactor adding `finally` doesn't accidentally double-emit.
+    yield { type: "_meta", meta_subtype: "stream_open" };
     let closeReason = "eof";
     try {
       yield* parseSSE(resp.body.getReader());

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -140,6 +140,7 @@ export type {
   ChannelDescriptor,
   ListChannelsResponse,
   RunStateEvent,
+  RunStateStreamClose,
   RunStateStreamItem,
   RunStateStreamOpen,
   StreamUserRunStatesOptions,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -28,7 +28,12 @@ export type EventType =
   // doesn't carry `type` server-side; parseSSE backfills it from the SSE
   // event-name so the consumer sees a well-formed AgentEvent).
   | "session"
-  | "agent";
+  | "agent"
+  // v0.9.x — client-synthesized lifecycle events emitted ONLY when the
+  // streaming caller passes `debug: true`. Never originate from the
+  // server. The leading underscore signals "synthetic, not on the wire."
+  // Consumers that opt out (default) never see this `type`.
+  | "_meta";
 
 export interface ToolUse {
   id: string;
@@ -98,6 +103,13 @@ export interface AgentEvent {
   run_id?: string;
   session_id?: string;
   parent_agent_id?: string | null;
+  // v0.9.x — client-synthesized observability fields, populated only on
+  // events of `type: "_meta"`. Subtype distinguishes connection
+  // lifecycle frames; reason is the cause (HTTP status, "abort",
+  // "eof", typed-error name). All other event types leave them
+  // undefined.
+  meta_subtype?: "stream_open" | "stream_close";
+  meta_reason?: string;
 }
 
 export type PromptContent =
@@ -154,6 +166,14 @@ export interface RunOptions {
    *  (static-bearer setups unaffected). Sub-agents inherit identically.
    *  Never persisted; never logged in full. */
   userBearer?: string;
+  /** Opt-in observability: when true, the iterator emits client-
+   *  synthesized `{ type: "_meta", meta_subtype: "stream_open" | "stream_close" }`
+   *  events around the real event stream. `meta_reason` carries the
+   *  trigger ("eof", "abort", or an error class name). Default is
+   *  false — existing consumers see no behaviour change. Useful for
+   *  n8n nodes that want to surface "stream re-opened" / "stream
+   *  closed" log entries without inferring from event timing. */
+  debug?: boolean;
   signal?: AbortSignal;
 }
 
@@ -183,6 +203,8 @@ export interface ContinueOptions {
    *  so different continuations in the same session may carry
    *  different end-user tokens. */
   userBearer?: string;
+  /** Opt-in observability: see {@link RunOptions.debug}. Same shape. */
+  debug?: boolean;
   signal?: AbortSignal;
 }
 
@@ -802,7 +824,10 @@ export interface RunStateStreamOpen {
  *  the connection before any real events flow. */
 export type RunStateStreamItem =
   | { kind: "open"; payload: RunStateStreamOpen }
-  | { kind: "event"; payload: RunStateEvent };
+  | { kind: "event"; payload: RunStateEvent }
+  // v0.9.x — emitted ONLY when StreamUserRunStatesOptions.debug=true.
+  // Never on the wire; synthesized client-side at stream-close time.
+  | { kind: "close"; payload: RunStateStreamClose };
 
 /** Optional filter for {@link LoomcycleClient.streamUserRunStates}. */
 export interface StreamUserRunStatesOptions {
@@ -810,7 +835,28 @@ export interface StreamUserRunStatesOptions {
   statuses?: string[];
   /** Filter to one agent name. Empty means any. */
   agent?: string;
+  /** v0.9.x — client-side filter on the run's parent_agent_id.
+   *  Useful for "show me only the sub-runs spawned by agent X."
+   *  The filter is applied AFTER the SSE frame is parsed, so this
+   *  shrinks what your callback sees but doesn't reduce server-side
+   *  load. Server-side filtering is a separate (future) request.
+   *  Pass the empty string to opt out (default). */
+  parentAgentId?: string;
+  /** v0.9.x — opt-in observability: when true, the iterator emits a
+   *  client-synthesized `{ kind: "open", payload: { ... reason: "..." } }`
+   *  before any real frames AND a `{ kind: "close", payload: { reason } }`
+   *  on stream EOF / abort / error. Reason carries the cause
+   *  ("eof", "abort", or an error class name). Default false leaves
+   *  behaviour identical to v0.9.x earlier. */
+  debug?: boolean;
   signal?: AbortSignal;
+}
+
+/** v0.9.x — close-event payload emitted only under
+ *  {@link StreamUserRunStatesOptions.debug}. Synthetic; never on the
+ *  wire. */
+export interface RunStateStreamClose {
+  reason: string;
 }
 
 // ---- v0.9.x content_sha256 verify op (AgentDef + SkillDef) ----

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -104,10 +104,12 @@ export interface AgentEvent {
   session_id?: string;
   parent_agent_id?: string | null;
   // v0.9.x — client-synthesized observability fields, populated only on
-  // events of `type: "_meta"`. Subtype distinguishes connection
-  // lifecycle frames; reason is the cause (HTTP status, "abort",
-  // "eof", typed-error name). All other event types leave them
-  // undefined.
+  // events of `type: "_meta"`. `meta_subtype` is always set on a
+  // _meta event (distinguishes open from close). `meta_reason` is set
+  // ONLY on stream_close frames — carrying the cause ("eof" on clean
+  // close, "AbortError"/"AuthError"/etc on a typed-error throw). The
+  // stream_open frame leaves meta_reason undefined — the frame itself
+  // is the signal that the stream just opened.
   meta_subtype?: "stream_open" | "stream_close";
   meta_reason?: string;
 }
@@ -842,12 +844,14 @@ export interface StreamUserRunStatesOptions {
    *  load. Server-side filtering is a separate (future) request.
    *  Pass the empty string to opt out (default). */
   parentAgentId?: string;
-  /** v0.9.x — opt-in observability: when true, the iterator emits a
-   *  client-synthesized `{ kind: "open", payload: { ... reason: "..." } }`
-   *  before any real frames AND a `{ kind: "close", payload: { reason } }`
-   *  on stream EOF / abort / error. Reason carries the cause
-   *  ("eof", "abort", or an error class name). Default false leaves
-   *  behaviour identical to v0.9.x earlier. */
+  /** v0.9.x — opt-in observability: when true, the iterator yields a
+   *  client-synthesized `{ kind: "close", payload: { reason } }` item
+   *  when the stream ends (EOF, abort, or error). `reason` carries
+   *  the cause ("eof" on clean close or an error class name like
+   *  "AbortError" / "AuthError"). The opening `kind: "open"` frame
+   *  that always appears first is server-emitted, not synthetic;
+   *  `debug` has no effect on it. Default false leaves behaviour
+   *  identical to v0.9.x earlier. */
   debug?: boolean;
   signal?: AbortSignal;
 }

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -1039,3 +1039,187 @@ describe("v0.9.x Channel CRUD — publish / subscribe / peek / ack", () => {
     );
   });
 });
+
+describe("v0.9.x n8n polish — debug toggle + parentAgentId filter", () => {
+  it("runStreaming yields no _meta events when debug is omitted (default)", async () => {
+    const { client } = makeClient([
+      sseResponse([
+        'event: text\ndata: {"type":"text","text":"hi"}\n\n',
+        'event: done\ndata: {"type":"done"}\n\n',
+      ]),
+    ]);
+    const types: string[] = [];
+    for await (const ev of client.runStreaming({
+      agent: "qa",
+      segments: [],
+    })) {
+      types.push(ev.type);
+    }
+    expect(types).toEqual(["text", "done"]);
+  });
+
+  it("runStreaming with debug:true brackets the real events with synthetic _meta open + close", async () => {
+    const { client } = makeClient([
+      sseResponse([
+        'event: text\ndata: {"type":"text","text":"hi"}\n\n',
+        'event: done\ndata: {"type":"done"}\n\n',
+      ]),
+    ]);
+    const events = [];
+    for await (const ev of client.runStreaming({
+      agent: "qa",
+      segments: [],
+      debug: true,
+    })) {
+      events.push(ev);
+    }
+    expect(events.length).toBe(4);
+    expect(events[0]!.type).toBe("_meta");
+    expect(events[0]!.meta_subtype).toBe("stream_open");
+    expect(events[1]!.type).toBe("text");
+    expect(events[2]!.type).toBe("done");
+    expect(events[3]!.type).toBe("_meta");
+    expect(events[3]!.meta_subtype).toBe("stream_close");
+    expect(events[3]!.meta_reason).toBe("eof");
+  });
+
+  it("continueSession debug:true wraps the inner stream too", async () => {
+    const { client } = makeClient([
+      sseResponse(['event: done\ndata: {"type":"done"}\n\n']),
+    ]);
+    const events = [];
+    for await (const ev of client.continueSession({
+      sessionId: "s1",
+      segments: [],
+      debug: true,
+    })) {
+      events.push(ev);
+    }
+    expect(events.map((e) => e.type)).toEqual([
+      "_meta",
+      "done",
+      "_meta",
+    ]);
+    expect(events[0]!.meta_subtype).toBe("stream_open");
+    expect(events[2]!.meta_subtype).toBe("stream_close");
+  });
+
+  it("streamUserRunStates with debug:true yields a kind=close item on EOF", async () => {
+    const { client } = makeClient([
+      sseResponse([
+        `event: run_state\ndata: ${JSON.stringify({
+          run_id: "r1",
+          agent_id: "ag1",
+          agent: "x",
+          user_id: "u",
+          status: "running",
+          ts: "2026-05-22T00:00:00Z",
+        })}\n\n`,
+      ]),
+    ]);
+    const kinds = [];
+    for await (const item of client.streamUserRunStates("u", { debug: true })) {
+      kinds.push(item.kind);
+    }
+    expect(kinds).toEqual(["event", "close"]);
+  });
+
+  it("streamUserRunStates without debug yields no close item", async () => {
+    const { client } = makeClient([
+      sseResponse([
+        `event: run_state\ndata: ${JSON.stringify({
+          run_id: "r1",
+          agent_id: "ag1",
+          agent: "x",
+          user_id: "u",
+          status: "running",
+          ts: "2026-05-22T00:00:00Z",
+        })}\n\n`,
+      ]),
+    ]);
+    const kinds = [];
+    for await (const item of client.streamUserRunStates("u")) {
+      kinds.push(item.kind);
+    }
+    expect(kinds).toEqual(["event"]);
+  });
+
+  it("streamUserRunStates parentAgentId filters out events whose parent_agent_id differs", async () => {
+    const { client } = makeClient([
+      sseResponse([
+        `event: stream_open\ndata: ${JSON.stringify({
+          user_id: "u",
+          filter_status: null,
+          filter_agent: "",
+          keepalive_interval: 25,
+        })}\n\n`,
+        // Two events with different parent_agent_ids.
+        `event: run_state\ndata: ${JSON.stringify({
+          run_id: "r1",
+          agent_id: "ag1",
+          agent: "x",
+          user_id: "u",
+          parent_agent_id: "parent_target",
+          status: "completed",
+          ts: "2026-05-22T00:00:00Z",
+        })}\n\n`,
+        `event: run_state\ndata: ${JSON.stringify({
+          run_id: "r2",
+          agent_id: "ag2",
+          agent: "x",
+          user_id: "u",
+          parent_agent_id: "parent_other",
+          status: "completed",
+          ts: "2026-05-22T00:00:01Z",
+        })}\n\n`,
+      ]),
+    ]);
+    const items = [];
+    for await (const item of client.streamUserRunStates("u", {
+      parentAgentId: "parent_target",
+    })) {
+      items.push(item);
+    }
+    // open frame always yielded, then only the event with the matching
+    // parent — the second event is filtered out client-side.
+    expect(items.length).toBe(2);
+    expect(items[0]!.kind).toBe("open");
+    expect(items[1]!.kind).toBe("event");
+    expect(items[1]!.kind === "event" && items[1]!.payload.run_id).toBe("r1");
+  });
+
+  it("listUserAgents parentAgentId narrows the result client-side", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        agents: [
+          { agent_id: "a1", run_id: "r1", session_id: "s1", agent: "x", parent_agent_id: "parent_target", status: "running", started_at: "2026-05-22T00:00:00Z" },
+          { agent_id: "a2", run_id: "r2", session_id: "s2", agent: "x", parent_agent_id: "parent_other", status: "running", started_at: "2026-05-22T00:00:01Z" },
+          { agent_id: "a3", run_id: "r3", session_id: "s3", agent: "x", parent_agent_id: "parent_target", status: "running", started_at: "2026-05-22T00:00:02Z" },
+        ],
+      }),
+    ]);
+    const out = await client.listUserAgents("u", {
+      parentAgentId: "parent_target",
+    });
+    expect(out.length).toBe(2);
+    expect(out.map((a) => a.agent_id).sort()).toEqual(["a1", "a3"]);
+    // Server-side: no query param for parent (filter is client-side).
+    expect(fetchMock.mock.calls[0]![0]).toBe(
+      "http://test-loomcycle:8787/v1/users/u/agents",
+    );
+  });
+
+  it("listUserAgents returns all agents when parentAgentId is omitted or empty string", async () => {
+    const seed = [
+      { agent_id: "a1", run_id: "r1", session_id: "s1", agent: "x", parent_agent_id: "p", status: "running", started_at: "2026-05-22T00:00:00Z" },
+      { agent_id: "a2", run_id: "r2", session_id: "s2", agent: "x", parent_agent_id: null, status: "running", started_at: "2026-05-22T00:00:01Z" },
+    ];
+    const omitted = makeClient([jsonResponse({ agents: seed })]);
+    expect((await omitted.client.listUserAgents("u")).length).toBe(2);
+
+    const empty = makeClient([jsonResponse({ agents: seed })]);
+    expect(
+      (await empty.client.listUserAgents("u", { parentAgentId: "" })).length,
+    ).toBe(2);
+  });
+});

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -1222,4 +1222,105 @@ describe("v0.9.x n8n polish — debug toggle + parentAgentId filter", () => {
       (await empty.client.listUserAgents("u", { parentAgentId: "" })).length,
     ).toBe(2);
   });
+
+  // Defensive: when the dataset contains a row with parent_agent_id === null
+  // AND the filter is a non-null string, the null row MUST be excluded.
+  // JS `null === "parent_target"` is false at runtime, but a future
+  // refactor that uses == or a different comparator could regress this.
+  it("listUserAgents excludes parent_agent_id=null rows when filter is set to a non-null string", async () => {
+    const { client } = makeClient([
+      jsonResponse({
+        agents: [
+          { agent_id: "match",  run_id: "r1", session_id: "s1", agent: "x", parent_agent_id: "parent_target", status: "running", started_at: "2026-05-22T00:00:00Z" },
+          { agent_id: "null_p", run_id: "r2", session_id: "s2", agent: "x", parent_agent_id: null,             status: "running", started_at: "2026-05-22T00:00:01Z" },
+          { agent_id: "other",  run_id: "r3", session_id: "s3", agent: "x", parent_agent_id: "parent_other",  status: "running", started_at: "2026-05-22T00:00:02Z" },
+        ],
+      }),
+    ]);
+    const out = await client.listUserAgents("u", {
+      parentAgentId: "parent_target",
+    });
+    // Only the "match" row should survive. The null-parent row must
+    // NOT silently match the "parent_target" filter.
+    expect(out.map((a) => a.agent_id)).toEqual(["match"]);
+  });
+
+  // Stream-side error with debug:true: the close frame fires (with
+  // meta_reason set to the error class name) before the error
+  // propagates to the consumer's try/catch. Simulates the abort path
+  // by building an SSE response whose stream errors on first read.
+  it("runStreaming debug:true yields a stream_close frame before re-throwing on stream-side error", async () => {
+    const failingStream = new ReadableStream({
+      start(controller) {
+        const err = new DOMException("aborted by signal", "AbortError");
+        controller.error(err);
+      },
+    });
+    const failingResponse = () =>
+      new Response(failingStream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+
+    const { client } = makeClient([failingResponse]);
+    const events: Array<{ type: string; meta_subtype?: string; meta_reason?: string }> = [];
+    let caught: unknown;
+    try {
+      for await (const ev of client.runStreaming({
+        agent: "qa",
+        segments: [],
+        debug: true,
+      })) {
+        events.push({
+          type: ev.type,
+          meta_subtype: ev.meta_subtype,
+          meta_reason: ev.meta_reason,
+        });
+      }
+    } catch (e) {
+      caught = e;
+    }
+    // Two synthetic frames before the throw — open then close
+    // (with meta_reason captured from the inner error's `.name`).
+    expect(events.length).toBe(2);
+    expect(events[0]!.meta_subtype).toBe("stream_open");
+    expect(events[1]!.meta_subtype).toBe("stream_close");
+    expect(events[1]!.meta_reason).toBe("AbortError");
+    // The original error still surfaces to the consumer.
+    expect((caught as Error | undefined)?.name).toBe("AbortError");
+  });
+
+  // streamUserRunStates analogue: a close item with reason set to the
+  // error class name fires before the stream-side throw propagates.
+  it("streamUserRunStates debug:true yields a kind=close item with error reason before re-throwing", async () => {
+    const failingStream = new ReadableStream({
+      start(controller) {
+        const err = new DOMException("aborted by signal", "AbortError");
+        controller.error(err);
+      },
+    });
+    const failingResponse = () =>
+      new Response(failingStream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+
+    const { client } = makeClient([failingResponse]);
+    const items: Array<{ kind: string; reason?: string }> = [];
+    let caught: unknown;
+    try {
+      for await (const item of client.streamUserRunStates("u", { debug: true })) {
+        items.push({
+          kind: item.kind,
+          reason: item.kind === "close" ? item.payload.reason : undefined,
+        });
+      }
+    } catch (e) {
+      caught = e;
+    }
+    expect(items.length).toBe(1);
+    expect(items[0]!.kind).toBe("close");
+    expect(items[0]!.reason).toBe("AbortError");
+    expect((caught as Error | undefined)?.name).toBe("AbortError");
+  });
 });


### PR DESCRIPTION
## Summary

- Closes the final two items the n8n-nodes-loomcycle designer flagged at lines 254–255 of `~/work/n8n-nodes-loomcycle/docs/IMPLEMENTATION_PLAN.md`:
  - *"Surface reconnect events to operator? Recommend silent + debug-mode toggle."* — new `opts.debug: boolean` on `runStreaming`, `continueSession`, `streamUserRunStates`. Off by default; when true, the iterator emits synthetic `stream_open` / `stream_close` frames around the real events with a `meta_reason` field carrying the trigger ("eof", "abort", or an error class name).
  - *"`parent_agent_id` filter — adapter doesn't expose today; client-side filter is fine for v1."* — new `parentAgentId` option on `listUserAgents` and `streamUserRunStates`. Applied as a client-side post-filter; the server still returns / streams the full set. Cost is documented.
- JSDoc additions on the three streaming methods documenting their blocking semantics + pointing at `streamUserRunStates` as the fire-and-forget alternative for n8n-style worker models.
- New "Patterns" section in `adapters/ts/README.md` codifying the choice between `runStreaming`/`continueSession` (sync) vs `streamUserRunStates` (async) + the consumer pattern for the new debug/parentAgentId knobs.

## Why

The n8n-nodes-loomcycle Phase 2.3 trigger nodes (`RunCompleted`, `ChannelMessage`) want operator-facing observability hooks for "stream re-opened / closed" log entries without inferring from event timing — but only when n8n is debugging. The default-off `debug` flag gives that hook without changing behaviour for existing consumers.

The `parentAgentId` filter is the n8n-side answer to "show me only the sub-runs spawned by parent X" — a common pattern in multi-agent workflows where an n8n trigger spawns a parent agent that fans out to children. The server doesn't (yet) support `?parent_agent_id=` as a query parameter; the IMPLEMENTATION_PLAN's guidance is "client-side filter is fine for v1," which this PR follows verbatim.

The JSDoc + Patterns section closes the doc gap the same plan flagged earlier (line 160-161): "drainRunStream blocks execute() until completion. Correct for sync action; long runs block n8n's worker. Document; direct operators to the RunCompleted trigger (2.3) for async patterns." The adapter's `runStreaming` isn't called `drainRunStream`, but the blocking concern is the same — and the README's new Patterns section makes the sync-vs-async choice explicit.

## What

Two commits:

1. **`feat(ts-adapter): debug-mode stream meta-events + client-side parentAgentId filter`** — code + types + 8 vitest cases. The shape:
   - `EventType` union grows `"_meta"`; `AgentEvent` grows optional `meta_subtype` + `meta_reason` populated only on meta events.
   - `RunStateStreamItem` union grows `{kind: "close", payload: RunStateStreamClose}`; the new `RunStateStreamClose` type is exported.
   - `RunOptions`, `ContinueOptions`, `StreamUserRunStatesOptions` each gain `debug?: boolean`.
   - `StreamUserRunStatesOptions` gains `parentAgentId?: string`; `listUserAgents`'s inline opts grows the same field.
   - `streamSSE` private helper threads `debug` through; emits synthetic open + close frames around the real stream when set, including on the error-thrown path (close frame fires THEN the error re-throws).
   - `streamUserRunStates` wraps `parseRunStateSSE` in its own loop to apply the `parentAgentId` filter on `kind: "event"` items (open + close frames always pass through unfiltered).

2. **`docs(ts-adapter): Patterns section + blocking-streaming guidance + What's-new bullet`** — README only. New Patterns section, "What's new since v0.8.18" bullet, JSDoc additions on the three streaming methods (those are in commit 1 but the README codifies the between-methods choice).

`@loomcycle/client` bumped to v0.13.0. Method count unchanged at 32 (this PR adds options, not methods).

## Tested

- `cd adapters/ts && npm run build` — clean tsc.
- `cd adapters/ts && npm test` — 99 tests pass (91 → 99; 8 new cases in `tests/client.test.ts`).
- Test coverage:
  - `runStreaming` default emits no `_meta` frames.
  - `runStreaming` `debug: true` brackets the real events with `_meta` open + close (`meta_reason: "eof"` on clean close).
  - `continueSession` `debug: true` wraps the inner stream same way.
  - `streamUserRunStates` `debug: true` yields a `kind: "close"` item on EOF; default does not.
  - `streamUserRunStates` `parentAgentId` filters out events whose `parent_agent_id` differs (open frame still passes).
  - `listUserAgents` `parentAgentId` narrows the result client-side; no server-side query param added.
  - `listUserAgents` returns the full set when `parentAgentId` is empty string or omitted.

## Notes for review

- The synthetic `_meta` events deliberately use a leading-underscore type so they can never collide with a server-emitted event name. The JSDoc on `EventType` calls out the "client-synthesized; never on the wire" contract.
- I considered making `parentAgentId` a server-side filter (adding `?parent_agent_id=` to `GET /v1/users/{user_id}/agents` and the SSE stream) but the n8n plan explicitly says "client-side filter is fine for v1." Keeping the adapter additive lets us land this now; a server-side filter is a single follow-up commit if usage proves we need it.
- This PR branches from main (before PR #180's Channel CRUD lands). package.json bumps to 0.13.0 same as #180. If #180 merges first, this branch rebases with a trivial version-bump conflict (resolve to 0.13.0 keeping description from #180 and merging the n8n-polish description from this PR; net version becomes 0.13.0 or 0.13.1 depending on how we want to sequence). Either way the code diffs don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)