### PR TITLE
fix(loomcycle.sh): trap-protected restore of strict mode around .env.local sourcing

### DIFF
--- a/loomcycle.sh
+++ b/loomcycle.sh
@@ -61,23 +61,31 @@ fi
 if [[ -f "$ENV_FILE" ]]; then
   echo "loomcycle.sh: sourcing $ENV_FILE"
   # `set -a` exports every assignment without needing each line to use
-  # `export`. `set +a` switches it back off so we don't unintentionally
-  # export later script-locals.
+  # `export`. `set +a` after the source switches it back off so we
+  # don't unintentionally export later script-locals.
   #
   # `set +u` while sourcing: dotenv files commonly reference upstream
   # vars (e.g. `FOO="${UPSTREAM_VAR}/x"`) that aren't required for the
   # script itself but are kept for parity across machines. Under `set -u`
   # any such expansion against an unset upstream var aborts the script
   # before loomcycle starts — even when loomcycle itself doesn't need
-  # that var. Restore `set -u` immediately after; the binary's own
-  # required-config validation still surfaces actually-missing vars
-  # with a clear log line.
+  # that var. The binary's own required-config validation still
+  # surfaces actually-missing vars with a clear log line.
+  #
+  # Save-then-restore via `$-` instead of unconditional `set -u`: if a
+  # future invocation runs loomcycle.sh with `-u` explicitly off (or
+  # a wrapper unsets it), we don't want to reintroduce strict-undefined
+  # checking that the caller deliberately disabled. `$-` carries the
+  # currently-enabled shell options as letter flags; we restore only
+  # what was set going in.
+  _loomcycle_saved_opts="$-"
   set -a
   set +u
   # shellcheck disable=SC1090
   source "$ENV_FILE"
-  set -u
+  [[ "$_loomcycle_saved_opts" == *u* ]] && set -u
   set +a
+  unset _loomcycle_saved_opts
 else
   echo "loomcycle.sh: no $ENV_FILE found (ok for first run; copy from .env.example)" >&2
 fi


### PR DESCRIPTION
## Summary

Code-review followup against #179 (merged). The original fix wrapped `source "\$ENV_FILE"` in `set +u` / `set -u` to tolerate undefined-var expansion in dotenv files. The unconditional `set -u` after the source assumed the caller was running with strict-undefined enabled — fine today, fragile if a future wrapper / refactor / EXIT trap ever flips the option for its own reasons.

This commit replaces the unconditional restore with the defensive `$-`-saved-options pattern: capture which options were enabled before the source, restore exactly those.

## Why

The reviewer for #179 flagged this as HIGH-85: practical risk low because `exec "\$BIN"` immediately follows and there are no EXIT traps today, but the pattern is fragile if EXIT traps are ever added. Upgrading from latent to fixed costs 4 lines and zero behaviour change for the existing case.

## What

One file (`loomcycle.sh`), +14 / -6 lines. Replaces:

```bash
set -a
set +u
source "\$ENV_FILE"
set -u
set +a
```

with:

```bash
_loomcycle_saved_opts="\$-"
set -a
set +u
source "\$ENV_FILE"
[[ "\$_loomcycle_saved_opts" == *u* ]] && set -u
set +a
unset _loomcycle_saved_opts
```

`\$-` is the bash built-in carrying the currently-enabled options as letter flags (e.g. `ehuBc` means `e`, `h`, `u`, `B`, `c` are on). The post-source `set -u` now fires only if `u` was in the saved set.

## Tested

Standalone smoke confirming the save/restore semantics:

```bash
\$ bash -c 'set -euo pipefail; echo "before: \$-"; \\
    _saved="\$-"; set -a; set +u; echo "during: \$-"; \\
    source <(echo "FOO=\\\${UNSET_VAR_TEST}/x"); \\
    [[ "\$_saved" == *u* ]] && set -u; set +a; echo "after: \$-"'
before: ehuBc   # u is set
during: aehBc   # a is set, u is not (relaxed for sourcing)
after:  ehuBc   # u is restored, a is cleared
```

End-to-end smoke also confirms the user-facing path that prompted #179 originally still works:

```bash
\$ echo 'FOO="\${UNSET_UPSTREAM_VAR}/x"' > /tmp/.env.smoke
\$ LOOMCYCLE_ENV_FILE=/tmp/.env.smoke timeout 3 ./loomcycle.sh --no-build
loomcycle.sh: sourcing /tmp/.env.smoke
loomcycle.sh: starting bin/loomcycle ...
2026/05/22 14:34:01 loomcycle build: version=...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)