### PR TITLE
chore(ts): bump @loomcycle/client to 0.9.2 for v0.9.2 release

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.12.0",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.12.0",
+      "version": "0.9.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.13.1",
+  "version": "0.9.2",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 36 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates — with debug-mode synthetic open/close meta-frames + client-side parentAgentId filter), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel — admin scope=global + per-user scope=user surfaces), v0.9.x content_sha256 (AgentDefVerifyResult + SkillDefVerifyResult types for the bundle-vs-deployed comparison workflow), v0.9.1 transcript first-cycle (SystemPromptPayload + UserInputPayload), and v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult — register HTTP/Streamable-HTTP MCP servers at runtime without yaml edits).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Restores the binary-tag-to-adapter-version lockstep that `publish-ts-adapter.yml` enforces. Every prior release tagged binary `vX.Y.Z` and published the TS adapter at npm version `X.Y.Z`; PRs #177 / #180 / #181 broke that pattern by bumping the adapter to 0.12.0 / 0.13.0 / 0.13.1 inside feature branches. None of those versions reached npm (branch-local only), so collapsing back to 0.9.2 is the first published version since 0.9.1 — not a downgrade.

## v0.9.2 covers

| PR | Change |
|---|---|
| #177 | MCPServerDef substrate (dynamic MCP server registration) |
| #178 | substrate-admin tools-ceiling wildcard for AgentDef/SkillDef create |
| #179 | loomcycle.sh lenient .env.local sourcing |
| #180 | Channel CRUD wire-API (publish/subscribe/peek/ack — admin + per-user) |
| #181 | n8n polish — debug-mode stream meta-events + client-side parentAgentId filter |
| #182 | loomcycle.sh trap-protected restore of strict mode |

## Test plan

- [x] `cd adapters/ts && npm install` regenerates package-lock.json with 0.9.2.
- [x] `cd adapters/ts && npm run build && npm test` — 110 vitest cases green at 0.9.2.
- [ ] Merge this, tag `v0.9.2`, push tag — goreleaser builds binaries + publish-ts-adapter.yml publishes the npm package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)