### PR TITLE
fix(resolver): substrate-registered agents must resolve via /v1/runs

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -451,8 +451,9 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 }
 
 // lookupAgent returns the AgentDef for a registered agent name,
-// consulting static cfg.Agents first and then v0.8.15 dynamic_agents.
-// Returns (zero AgentDef, false) when neither source has the name.
+// consulting static cfg.Agents first, then the v0.8.15 dynamic_agents
+// table, then the v0.8.22 substrate registry (agent_def_active +
+// agent_defs). Returns (zero AgentDef, false) when no source has it.
 //
 // Centralizing the lookup here is the antidote to the v0.8.15
 // regression where each entry point (RunOnce / handleRuns / handle
@@ -465,6 +466,15 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 // TTL filtering happens server-side in store.DynamicAgentGet, so a
 // row whose expires_at has passed surfaces as derr (not found).
 // Malformed Definition JSON also falls through to (zero, false).
+//
+// Substrate fallback (v0.8.22+): agents registered via POST
+// /v1/_agentdef land in `agent_defs` + `agent_def_active`, NOT in
+// dynamic_agents. Without the third tier here those agents are
+// invisible to /v1/runs even though `list` / `verify` / `get`
+// confirm they exist — a "registered but unknown" paradox surfaced
+// by the JobEmber boot-sync (PR #69 downstream) which only writes
+// to the substrate. Same JSON shape (mergedDef <:> mutable subset
+// of config.AgentDef), so json.Unmarshal slots in cleanly.
 func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef, bool) {
 	if def, ok := s.cfg.Agents[name]; ok {
 		return def, true
@@ -472,15 +482,70 @@ func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef,
 	if s.store == nil {
 		return config.AgentDef{}, false
 	}
-	row, err := s.store.DynamicAgentGet(ctx, name)
+	if row, err := s.store.DynamicAgentGet(ctx, name); err == nil {
+		var def config.AgentDef
+		if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
+			return def, true
+		}
+	}
+	activeRow, err := s.store.AgentDefGetActive(ctx, name)
 	if err != nil {
 		return config.AgentDef{}, false
 	}
-	var def config.AgentDef
-	if uerr := json.Unmarshal(row.Definition, &def); uerr != nil {
+	var sd substrateAgentDef
+	if uerr := json.Unmarshal(activeRow.Definition, &sd); uerr != nil {
 		return config.AgentDef{}, false
 	}
-	return def, true
+	return sd.toConfigDef(), true
+}
+
+// substrateAgentDef mirrors the JSON shape `AgentDef.create` persists
+// in agent_defs.definition (snake_case via the json struct tags on
+// mergedDef in internal/tools/builtin/agentdef.go). Unmarshalling
+// substrate JSON directly into config.AgentDef silently drops every
+// field because config.AgentDef carries only yaml tags — json.Unmarshal
+// then matches Go field names ("SystemPrompt", "AllowedTools", …) and
+// none of the snake_case keys land. This local struct + toConfigDef
+// adapter is the seam that converts the substrate's JSON shape to
+// the in-process config.AgentDef the rest of the runtime expects.
+//
+// Kept in sync with mergedDef (same field set, same json tags). The
+// TestLookupAgent_FallsThroughToSubstrate test pins a representative
+// subset — a future field added to mergedDef without a matching
+// addition here would silently drop on resolve, mirroring the bug
+// this struct exists to fix.
+type substrateAgentDef struct {
+	Provider         string                            `json:"provider,omitempty"`
+	Model            string                            `json:"model,omitempty"`
+	Tier             string                            `json:"tier,omitempty"`
+	Effort           string                            `json:"effort,omitempty"`
+	MaxTokens        int                               `json:"max_tokens,omitempty"`
+	MaxIterations    int                               `json:"max_iterations,omitempty"`
+	SystemPrompt     string                            `json:"system_prompt,omitempty"`
+	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
+	Skills           []string                          `json:"skills,omitempty"`
+	Providers        []string                          `json:"providers,omitempty"`
+	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
+	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
+	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+}
+
+func (s substrateAgentDef) toConfigDef() config.AgentDef {
+	return config.AgentDef{
+		Provider:         s.Provider,
+		Model:            s.Model,
+		Tier:             s.Tier,
+		Effort:           s.Effort,
+		MaxTokens:        s.MaxTokens,
+		MaxIterations:    s.MaxIterations,
+		SystemPrompt:     s.SystemPrompt,
+		AllowedTools:     s.AllowedTools,
+		Skills:           s.Skills,
+		Providers:        s.Providers,
+		Models:           s.Models,
+		MemoryScopes:     s.MemoryScopes,
+		MemoryQuotaBytes: s.MemoryQuotaBytes,
+	}
 }
 
 // resolveAgentDef mirrors resolveAgent but takes a caller-supplied

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -1660,5 +1661,117 @@ func TestRunRequest_UserBearerValidation(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestLookupAgent_FallsThroughToSubstrate pins the v0.8.22 fall-through:
+// agents registered via the substrate (POST /v1/_agentdef → agent_defs +
+// agent_def_active) must be resolvable by `lookupAgent` even though
+// the historical `dynamic_agents` path is empty. Without the third
+// tier in lookupAgent, JobEmber-style callers that only push through
+// the substrate get an "unknown agent" 400 on /v1/runs even though
+// `agentDef({op:"list"})` confirms the row exists.
+func TestLookupAgent_FallsThroughToSubstrate(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{
+		// Empty cfg.Agents — the substrate is the only registry.
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ctx := context.Background()
+
+	// Insert directly into agent_defs + agent_def_active, mirroring
+	// what /v1/_agentdef create+promote does.
+	defJSON, _ := json.Marshal(map[string]any{
+		"system_prompt": "be brief",
+		"allowed_tools": []string{"Read"},
+		"model":         "stub-model",
+	})
+	row := store.AgentDefRow{
+		DefID:      "def_test_substrate",
+		Name:       "substrate-only-agent",
+		Definition: defJSON,
+	}
+	if _, err := st.AgentDefCreate(ctx, row); err != nil {
+		t.Fatalf("AgentDefCreate: %v", err)
+	}
+	if err := st.AgentDefSetActive(ctx, "substrate-only-agent", "def_test_substrate", "a_test"); err != nil {
+		t.Fatalf("AgentDefSetActive: %v", err)
+	}
+
+	// Before this PR, lookupAgent only consulted dynamic_agents (empty)
+	// and returned (zero, false). After this PR it falls through to
+	// AgentDefGetActive and resolves.
+	def, ok := srv.lookupAgent(ctx, "substrate-only-agent")
+	if !ok {
+		t.Fatal("lookupAgent returned ok=false; expected substrate fall-through to resolve the agent")
+	}
+	if def.SystemPrompt != "be brief" {
+		t.Errorf("SystemPrompt = %q, want %q", def.SystemPrompt, "be brief")
+	}
+	if len(def.AllowedTools) != 1 || def.AllowedTools[0] != "Read" {
+		t.Errorf("AllowedTools = %v, want [Read]", def.AllowedTools)
+	}
+}
+
+// TestLookupAgent_DynamicAgentsStillWins preserves backwards
+// compatibility: the legacy RegisterAgent → DynamicAgentUpsert path
+// must keep resolving. If a name happens to exist in BOTH dynamic_agents
+// AND agent_def_active, dynamic_agents wins (older code path; would
+// only happen during a transition where both paths get used).
+func TestLookupAgent_DynamicAgentsStillWins(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ctx := context.Background()
+
+	// The legacy RegisterAgent path stores json.Marshal(config.AgentDef{...})
+	// which, because config.AgentDef has no json tags, serializes with
+	// Go field names (PascalCase). Mirror that exactly so the
+	// dynamic-path branch unmarshals correctly.
+	dynDefJSON, _ := json.Marshal(config.AgentDef{
+		SystemPrompt: "dynamic wins",
+		AllowedTools: []string{"Bash"},
+	})
+	if err := st.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		Name:       "shared-name",
+		Definition: dynDefJSON,
+		CreatedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("DynamicAgentUpsert: %v", err)
+	}
+	substrateDefJSON, _ := json.Marshal(map[string]any{
+		"system_prompt": "substrate loses tie",
+		"allowed_tools": []string{"Read"},
+	})
+	if _, err := st.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:      "def_shared",
+		Name:       "shared-name",
+		Definition: substrateDefJSON,
+	}); err != nil {
+		t.Fatalf("AgentDefCreate: %v", err)
+	}
+	if err := st.AgentDefSetActive(ctx, "shared-name", "def_shared", "a_test"); err != nil {
+		t.Fatalf("AgentDefSetActive: %v", err)
+	}
+
+	def, ok := srv.lookupAgent(ctx, "shared-name")
+	if !ok {
+		t.Fatal("lookupAgent returned ok=false; want ok=true")
+	}
+	if def.SystemPrompt != "dynamic wins" {
+		t.Errorf("SystemPrompt = %q, want %q (dynamic_agents must beat substrate when both have a row)", def.SystemPrompt, "dynamic wins")
 	}
 }


### PR DESCRIPTION
## Summary

Agents registered through the v0.8.22 substrate (`POST /v1/_agentdef create + promote` → `agent_defs` + `agent_def_active` tables) were invisible to `/v1/runs` even though every substrate query op (`list`, `get`, `verify`) confirmed the row existed. The two registries were wired up to the same write-side surface (`RegisterAgent` vs `AgentDef.create`) but landed in different tables, and only the legacy `dynamic_agents` path was reachable from the run dispatcher.

**Symptom downstream:** JobEmber's agent-registry boot sync pushed all 23 agents + 3 skills via `AgentDef.create` with `promote: true`; the rows were present and the active pointer was set, but the very next `/v1/runs` invocation returned `400 unknown agent`. `agentdef.list` returned `versions: 1` *in the same session* where `/v1/runs` said *"unknown agent ats-filter"* — the paradox this fix resolves.

## Root cause

`lookupAgent` in [`internal/api/http/server.go`](internal/api/http/server.go) consulted only `cfg.Agents` → `DynamicAgentGet`. The substrate's `agent_def_active` pointer was never read by the resolver, so substrate writes accumulated rows nobody could resolve.

## Fix

Two coordinated changes in `lookupAgent`:

1. **Add a third tier**: when `cfg.Agents` and `DynamicAgentGet` both miss, fall through to `s.store.AgentDefGetActive(ctx, name)`. The dynamic_agents path stays first so any caller still using the legacy `RegisterAgent` path keeps working unchanged.

2. **Translate the JSON shape**: `AgentDef.create` persists `mergedDef`-shaped JSON (snake_case via `json` struct tags on [`internal/tools/builtin/agentdef.go`](internal/tools/builtin/agentdef.go)). `config.AgentDef` has only `yaml` tags, so `json.Unmarshal` directly into `config.AgentDef` silently drops every snake_case field. New `substrateAgentDef` local struct mirrors `mergedDef`'s JSON shape and `toConfigDef` projects to the runtime type the rest of the dispatcher expects. A *kept-in-sync* comment + the new test pin the field set.

## Tests

- `TestLookupAgent_FallsThroughToSubstrate` — directly inserts a row via `AgentDefCreate` + `AgentDefSetActive` (mirroring what the substrate-admin happy-path tests already exercise on the write side), asserts `lookupAgent` resolves it with `SystemPrompt` + `AllowedTools` round-tripped.
- `TestLookupAgent_DynamicAgentsStillWins` — when a name has rows in BOTH `dynamic_agents` and `agent_def_active` (transition state), `dynamic_agents` wins. Pins the precedence so a future refactor that flips the order would trigger a deliberate test update.

## Test plan

- [x] `go test ./internal/api/http/ -run TestLookupAgent` — both new tests green.
- [x] `go test ./...` — full tree green, no regressions.
- [x] `gofmt -l internal/` — clean.
- [x] `go vet ./...` — clean.
- [ ] Manual end-to-end (next deploy): JobEmber agent-registry boot sync registers definitions on first boot, subsequent `/v1/runs` for `ats-filter` / `job-search-batch` / `cv-adapter` resolves to the substrate row instead of 400-ing.

## Downstream

[denn-gubsky/jobs-search-agent#71](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent/pulls/71) (merged) was the JobEmber-side boot-sync that exposed this gap in production. JobEmber needs no further changes — once this resolver fix ships, JobEmber's pre-existing `/v1/_agentdef create` flow becomes effective end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)