### PR TITLE
fix(skill): better error when substrate has skills but not this name

### DIFF
--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -168,7 +168,32 @@ func (s *SkillTool) resolveSkill(ctx context.Context, name string) (string, []st
 
 	// 2. Static filesystem fallback.
 	if s.Set == nil || len(s.Set.Names()) == 0 {
-		return "", nil, "", fmt.Errorf("Skill tool: no skills configured (set LOOMCYCLE_SKILLS_ROOT and populate <root>/<name>/SKILL.md)")
+		// The static set is unset — common for registry-first operators
+		// who deliberately unset LOOMCYCLE_SKILLS_ROOT to force every
+		// skill through the substrate. The original error here pushed
+		// operators toward the static path even when their actual
+		// registry (the substrate) was healthy but missing this name.
+		// Differentiate: substrate registered some skills (just not
+		// this one) vs neither source configured at all.
+		if s.Store != nil {
+			names, lerr := s.Store.SkillDefListNames(ctx)
+			if lerr == nil && len(names) > 0 {
+				cap := 10
+				if len(names) < cap {
+					cap = len(names)
+				}
+				avail := make([]string, 0, cap)
+				for _, n := range names[:cap] {
+					avail = append(avail, n.Name)
+				}
+				more := ""
+				if len(names) > cap {
+					more = ", ..."
+				}
+				return "", nil, "", fmt.Errorf("unknown skill %q (substrate has: %s%s)", name, strings.Join(avail, ", "), more)
+			}
+		}
+		return "", nil, "", fmt.Errorf("Skill tool: no skills configured (push via POST /v1/_skilldef create, or set LOOMCYCLE_SKILLS_ROOT and populate <root>/<name>/SKILL.md for the static-MD path)")
 	}
 	sk, ok := s.Set.Get(name)
 	if !ok {

--- a/internal/tools/builtin/skill_test.go
+++ b/internal/tools/builtin/skill_test.go
@@ -295,3 +295,84 @@ func TestSkillTool_ResolvesDBActiveOverStatic(t *testing.T) {
 		t.Errorf("static-only body = %q, want STATIC BODY", res.Text)
 	}
 }
+
+// TestSkillTool_SubstrateOnlyHintsAtAvailable confirms the registry-first
+// deployment story: when LOOMCYCLE_SKILLS_ROOT is unset (Set==nil or
+// empty) BUT the substrate has skills registered, asking for an unknown
+// name returns an error that points the operator at the substrate names
+// — NOT at "set LOOMCYCLE_SKILLS_ROOT" which would be wrong guidance.
+// Mirrors the JobEmber deployment where every skill ships via
+// /v1/_skilldef create at boot.
+func TestSkillTool_SubstrateOnlyHintsAtAvailable(t *testing.T) {
+	emptySet, err := skills.LoadSet("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	// Seed two skills via SkillDef create + promote. Mirrors the
+	// substrate write path JobEmber uses on first boot.
+	ctx := tools.WithAgentTools(context.Background(), []string{"Read"})
+	dctx := tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{Scopes: []string{"any"}})
+	dctx = tools.WithRunIdentity(dctx, tools.RunIdentityValue{AgentID: "a_seed"})
+	skillDefTool := &SkillDef{Store: store, Set: emptySet}
+	for _, name := range []string{"position-relevance-filtering", "voice-applier"} {
+		body := `{"op":"create","name":"` + name + `","overlay":{"body":"body of ` + name + `"},"promote":true}`
+		res, _ := skillDefTool.Execute(dctx, json.RawMessage(body))
+		if res.IsError {
+			t.Fatalf("seed %s: %s", name, res.Text)
+		}
+	}
+
+	// Skill tool: substrate wired, no static skills. Ask for a name
+	// that ISN'T in the substrate.
+	skillTool := &SkillTool{Set: emptySet, Store: store}
+	res, _ := skillTool.Execute(ctx, json.RawMessage(`{"name":"does-not-exist"}`))
+	if !res.IsError {
+		t.Fatalf("expected IsError for unknown skill; got %+v", res)
+	}
+	// Must NOT mention LOOMCYCLE_SKILLS_ROOT — that would mislead a
+	// registry-first operator into reverting their deployment model.
+	if strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("error text leaks misleading LOOMCYCLE_SKILLS_ROOT guidance for registry-first deployment: %s", res.Text)
+	}
+	// Must surface the substrate names so the model can recover.
+	if !strings.Contains(res.Text, "position-relevance-filtering") || !strings.Contains(res.Text, "voice-applier") {
+		t.Errorf("error text should list substrate-registered skills, got: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "substrate") {
+		t.Errorf("error text should mention the substrate source, got: %s", res.Text)
+	}
+}
+
+// TestSkillTool_NoSourcesConfigured exercises the path where neither
+// the substrate nor the static set has any skills. The error message
+// should point at BOTH paths — substrate first (the modern default)
+// and the static path second (legacy).
+func TestSkillTool_NoSourcesConfigured(t *testing.T) {
+	emptySet, err := skills.LoadSet("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer store.Close()
+
+	tool := &SkillTool{Set: emptySet, Store: store}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"name":"anything"}`))
+	if !res.IsError {
+		t.Fatalf("expected IsError; got %+v", res)
+	}
+	if !strings.Contains(res.Text, "/v1/_skilldef") {
+		t.Errorf("error should point at the substrate path, got: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("error should also keep the static-path hint for legacy operators, got: %s", res.Text)
+	}
+}


### PR DESCRIPTION
## Symptom

Registry-first deployments (no `LOOMCYCLE_SKILLS_ROOT`, all skills pushed via `/v1/_skilldef`) saw a misleading error when an agent asked for a skill name that wasn't in the substrate:

```
Skill tool: no skills configured (set LOOMCYCLE_SKILLS_ROOT and populate <root>/<name>/SKILL.md)
```

The substrate WAS the configured registry — it just didn't have the requested name. Operators following the hint by re-setting `LOOMCYCLE_SKILLS_ROOT` would revert their deployment model.

Surfaced by [denn-gubsky/jobs-search-agent](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent) after the boot-sync workflow registered all three skills via `POST /v1/_skilldef` and an agent then tried to load a typo'd name.

## Fix

Three-state error in [`resolveSkill`](internal/tools/builtin/skill.go) when the static set is empty:

| Substrate has skills? | Old error | New error |
|---|---|---|
| Yes, but not this name | *"no skills configured (set LOOMCYCLE_SKILLS_ROOT…)"* | `unknown skill "X" (substrate has: a, b, c, ...)` |
| No (Store nil) or no rows | *"no skills configured (set LOOMCYCLE_SKILLS_ROOT…)"* | `no skills configured (push via POST /v1/_skilldef create, or set LOOMCYCLE_SKILLS_ROOT…)` |
| (static set non-empty path: unchanged) | unchanged | unchanged |

Mirrors the existing `TestSkillTool_UnknownSkillHints` recovery path that already lists static-set names. The "no sources" case now mentions BOTH paths so registry-first AND legacy operators get accurate guidance.

## Tests

- `TestSkillTool_SubstrateOnlyHintsAtAvailable` — substrate has names but not this one → error lists substrate names; explicitly asserts the response does NOT mention `LOOMCYCLE_SKILLS_ROOT` (that string in this branch would mislead a registry-first operator).
- `TestSkillTool_NoSourcesConfigured` — both sources empty → error mentions both `/v1/_skilldef` and `LOOMCYCLE_SKILLS_ROOT`.
- Existing `TestSkillTool_EmptySetReturnsConfigError` unchanged — the fixture leaves Store unwired, so the static-only error path still fires and still mentions `LOOMCYCLE_SKILLS_ROOT`.

No-op for legacy operators still on `LOOMCYCLE_SKILLS_ROOT`: the static hit/miss branches are unchanged. Only the "static empty" branch gains an extra check for substrate-registered names.

## Test plan

- [x] `go test ./internal/tools/builtin/ -run TestSkillTool` — 13/13 pass.
- [x] `go test ./...` — full tree green.
- [x] `gofmt -l internal/` clean; `go vet ./...` clean.

## Downstream

Companion to [#184](https://github.com/denn-gubsky/loomcycle/pull/184) (substrate agent resolution) and the corresponding JobEmber PRs ([#69](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent/pulls/69), [#71](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent/pulls/71), [#72](https://truenas-scale.taild4c2d0.ts.net:8446/denn/jobs-search-agent/pulls/72)) that complete the registry-first migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)