### PR TITLE
fix(resolver): set SystemPromptBase for runtime-resolved agents

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -485,6 +485,7 @@ func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef,
 	if row, err := s.store.DynamicAgentGet(ctx, name); err == nil {
 		var def config.AgentDef
 		if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
+			normalizeSystemPromptBase(&def)
 			return def, true
 		}
 	}
@@ -496,7 +497,30 @@ func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef,
 	if uerr := json.Unmarshal(activeRow.Definition, &sd); uerr != nil {
 		return config.AgentDef{}, false
 	}
-	return sd.toConfigDef(), true
+	def := sd.toConfigDef()
+	normalizeSystemPromptBase(&def)
+	return def, true
+}
+
+// normalizeSystemPromptBase fills the SystemPromptBase invariant for
+// runtime-resolved agents. resolveSkills (config-load) sets this for
+// statically yaml-defined agents — it's the pre-skill-bake copy of
+// SystemPrompt used by resolveSkillBodiesForRun to rebuild the
+// effective prompt when DB-active SkillDef rows are present. Agents
+// resolved at runtime from dynamic_agents or the v0.8.22 substrate
+// never go through resolveSkills, so SystemPromptBase stays empty
+// even though their SystemPrompt IS the base (no skill body has been
+// pre-appended). Without this normalisation, resolveSkillBodiesForRun's
+// rebuild starts from "" and concatenates the skill body — replacing
+// the agent's actual instructions entirely. Symptom: an agent like
+// ats-filter that declares skills: ["position-relevance-filtering"]
+// loses its own body at run time, with only the skill text reaching
+// the model — the agent never sees its "call mcp__jobs__getAgentContext
+// first" instructions.
+func normalizeSystemPromptBase(def *config.AgentDef) {
+	if def.SystemPromptBase == "" {
+		def.SystemPromptBase = def.SystemPrompt
+	}
 }
 
 // substrateAgentDef mirrors the JSON shape `AgentDef.create` persists

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1775,3 +1775,106 @@ func TestLookupAgent_DynamicAgentsStillWins(t *testing.T) {
 		t.Errorf("SystemPrompt = %q, want %q (dynamic_agents must beat substrate when both have a row)", def.SystemPrompt, "dynamic wins")
 	}
 }
+
+// TestLookupAgent_SystemPromptBaseSetFromSubstrate pins the v0.8.22
+// SystemPromptBase normalisation invariant: an agent resolved from the
+// substrate (agent_def_active) MUST have SystemPromptBase populated to
+// equal SystemPrompt at lookup time. Without this, resolveSkillBodiesForRun
+// rebuilds from an empty base and the agent's own body is silently
+// dropped when any skill bundles in — only the skill text reaches the
+// model. Repro of the production bug: ats-filter (which declares
+// skills: ["position-relevance-filtering"]) stopped knowing to call
+// mcp__jobs__getAgentContext because its body was replaced by the skill.
+func TestLookupAgent_SystemPromptBaseSetFromSubstrate(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ctx := context.Background()
+
+	const agentBody = "You are ats-filter. First call mcp__jobs__getAgentContext, then score."
+	defJSON, _ := json.Marshal(map[string]any{
+		"system_prompt": agentBody,
+		"allowed_tools": []string{"mcp__jobs__getAgentContext", "Skill"},
+		"skills":        []string{"position-relevance-filtering"},
+	})
+	if _, err := st.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_substrate_ats", Name: "ats-filter", Definition: defJSON,
+	}); err != nil {
+		t.Fatalf("AgentDefCreate: %v", err)
+	}
+	if err := st.AgentDefSetActive(ctx, "ats-filter", "def_substrate_ats", "a_test"); err != nil {
+		t.Fatalf("AgentDefSetActive: %v", err)
+	}
+
+	def, ok := srv.lookupAgent(ctx, "ats-filter")
+	if !ok {
+		t.Fatal("lookupAgent returned ok=false")
+	}
+	if def.SystemPrompt != agentBody {
+		t.Errorf("SystemPrompt = %q, want agent body", def.SystemPrompt)
+	}
+	// THE invariant this test exists to pin.
+	if def.SystemPromptBase != agentBody {
+		t.Errorf("SystemPromptBase = %q, want it set to SystemPrompt %q so resolveSkillBodiesForRun rebuilds from the agent's actual body, not an empty string", def.SystemPromptBase, agentBody)
+	}
+}
+
+// TestLookupAgent_SystemPromptBaseSetFromDynamic mirrors the substrate
+// invariant for the legacy dynamic_agents path. Same gap, same fix.
+// Documented as defensive because the bug never surfaced in production
+// — historical dynamic_agents callers didn't declare skills: — but
+// the invariant should hold uniformly across both runtime paths.
+func TestLookupAgent_SystemPromptBaseSetFromDynamic(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ctx := context.Background()
+
+	const agentBody = "You are a legacy dynamic agent. Body must survive."
+	defJSON, _ := json.Marshal(config.AgentDef{
+		SystemPrompt: agentBody,
+		AllowedTools: []string{"Skill"},
+		Skills:       []string{"some-skill"},
+	})
+	if err := st.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		Name: "legacy-with-skills", Definition: defJSON, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("DynamicAgentUpsert: %v", err)
+	}
+
+	def, ok := srv.lookupAgent(ctx, "legacy-with-skills")
+	if !ok {
+		t.Fatal("lookupAgent returned ok=false")
+	}
+	if def.SystemPromptBase != agentBody {
+		t.Errorf("SystemPromptBase = %q, want %q", def.SystemPromptBase, agentBody)
+	}
+}
+
+// TestLookupAgent_PreservesNonEmptySystemPromptBase confirms the
+// normalisation is non-destructive: when an upstream caller already
+// populated SystemPromptBase (the static-cfg path via resolveSkills),
+// the normaliser MUST NOT overwrite it. Pins the "fill only when empty"
+// semantic so a future refactor that flips the order doesn't silently
+// regress the static-config invariant.
+func TestLookupAgent_PreservesNonEmptySystemPromptBase(t *testing.T) {
+	d := &config.AgentDef{SystemPrompt: "rebuilt prompt", SystemPromptBase: "original base"}
+	normalizeSystemPromptBase(d)
+	if d.SystemPromptBase != "original base" {
+		t.Errorf("SystemPromptBase overwritten: got %q, want %q", d.SystemPromptBase, "original base")
+	}
+}


### PR DESCRIPTION
## Symptom — JobEmber production today

`ats-filter` (registered via the v0.8.22 substrate with `skills: [position-relevance-filtering]`) was losing its own body at every run. The model received only the skill's scoring rules, not the agent's *"call `mcp__jobs__getAgentContext` first, then score, then output one JSON object"* instructions. Result: it tried to score postings without loading the candidate context, producing wrong verdicts.

The substrate row was correct — verified by direct SQLite read of `agent_defs.definition`: SystemPrompt = the actual ATS body. The corruption was happening at run time, not at storage time.

## Root cause

`resolveSkillBodiesForRun` ([server.go:731](internal/api/http/server.go#L731)) rebuilds the effective SystemPrompt from `SystemPromptBase` + each active skill body when any DB-active SkillDef row is present:

```go
rebuilt.SystemPrompt = agentDef.SystemPromptBase    // ← empty for runtime-resolved agents
for _, skillName := range agentDef.Skills {
    body, _ := activeBodies[skillName]
    if rebuilt.SystemPrompt != "" {
        rebuilt.SystemPrompt += "\n\n---\n\n"
    }
    rebuilt.SystemPrompt += body
}
```

`SystemPromptBase` is the pre-skill-bake copy of SystemPrompt. For statically-yaml-defined agents, `resolveSkills` at config-load sets `SystemPromptBase = SystemPrompt` before any skill body is appended. But agents resolved at runtime — `dynamic_agents` (v0.8.15) and the v0.8.22 substrate (added by [#184](https://github.com/denn-gubsky/loomcycle/pull/184)) — never go through `resolveSkills`. Their `SystemPromptBase` stays empty even though their `SystemPrompt` IS the base (no skill body pre-appended).

So the rebuild starts from `""`, skips the separator (empty-check), and assigns just the skill body. The agent's own body is silently dropped.

## Fix

New `normalizeSystemPromptBase` helper, applied to both runtime branches in `lookupAgent` right after the json.Unmarshal:

```go
func normalizeSystemPromptBase(def *config.AgentDef) {
    if def.SystemPromptBase == "" {
        def.SystemPromptBase = def.SystemPrompt
    }
}
```

Idempotent on the static-cfg path — `resolveSkills` already pre-set the base there, and the empty-check short-circuits the assignment.

## Tests

- `TestLookupAgent_SystemPromptBaseSetFromSubstrate` — substrate agent declares `skills: [...]`; after `lookupAgent` SystemPromptBase MUST equal the agent body. Direct repro of the production bug.
- `TestLookupAgent_SystemPromptBaseSetFromDynamic` — same invariant for the legacy `dynamic_agents` path. Defensive — no production failure there (callers historically didn't combine `dynamic_agents` + `skills:`) but the invariant should hold uniformly across both runtime paths.
- `TestLookupAgent_PreservesNonEmptySystemPromptBase` — normaliser must not overwrite an already-set base. Pins the "fill only when empty" semantic so a future refactor doesn't regress the static-cfg path.

## Test plan

- [x] `go test ./internal/api/http/ -run TestLookupAgent` — 5/5 pass (2 from #184 + 3 new).
- [x] `go test ./...` — full tree green.
- [x] `gofmt -l internal/` + `go vet ./...` clean.

## Downstream

Once this ships, JobEmber's substrate-registered agents that declare `skills: [...]` (currently `ai-detector`, `ats-filter`, `cv-adapter`, `cv-rewriter`, `job-scorer`, `job-searcher`) get their own body back at run time. No JobEmber-side changes required — the substrate rows are already correct; only the runtime resolver was dropping them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)