### PR TITLE
feat(ui): Introspection surface — Library + Channels + per-agent sub-views

### DIFF
--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -1,0 +1,88 @@
+// library_admin.go — v0.9.x Introspection: bearer-authed read-only
+// enumeration of every name declared in each substrate (AgentDef,
+// SkillDef, MCPServerDef). Drives the Web UI's `/ui/library` tab.
+//
+// These three handlers are the missing complement to the existing
+// `POST /v1/_*` op-dispatched substrate endpoints. The op-dispatch
+// endpoints can list VERSIONS of a single name (`{op:"list", name:X}`),
+// but they cannot enumerate the set of declared names. The store
+// already exposes `*ListNames` helpers for snapshot + admin code
+// paths; these handlers wire those to bearer-authed GET endpoints.
+//
+// Read-only + bearer-authed. The same `authMiddleware` guards every
+// `/v1/_*` route — operator trust posture is identical to the
+// substrate write endpoints.
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// handleListAgentDefNames serves GET /v1/_agentdef/names.
+// Returns `{names: [AgentDefNameSummary, ...]}` ordered by name ASC.
+// Empty store returns `{names: []}` — never `null` — so adapter
+// consumers can `.length` without a null-check.
+func (s *Server) handleListAgentDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.AgentDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []store.AgentDefNameSummary{}
+	}
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
+// handleListSkillDefNames serves GET /v1/_skilldef/names.
+func (s *Server) handleListSkillDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.SkillDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []store.SkillDefNameSummary{}
+	}
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
+// handleListMCPServerDefNames serves GET /v1/_mcpserverdef/names.
+func (s *Server) handleListMCPServerDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.MCPServerDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []store.MCPServerDefNameSummary{}
+	}
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
+// handleAgentChannels serves GET /v1/agents/{agent_name}/channels.
+// Returns every channel_cursors row for (scope=agent, scope_id={agent_name}),
+// ordered by channel ASC. Drives the v0.9.x Web UI's per-agent
+// "channels this agent is subscribed to" sub-tab.
+func (s *Server) handleAgentChannels(w http.ResponseWriter, r *http.Request) {
+	agentName := r.PathValue("agent_name")
+	if !validIdent(agentName) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_agent_name", `agent_name must match [A-Za-z0-9_-]{1,128}`)
+		return
+	}
+	rows, err := s.store.ChannelListCursorsForScope(r.Context(), store.MemoryScopeAgent, agentName)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	writeJSONOK(w, map[string]any{"channels": rows})
+}
+
+// writeJSONOK is a one-line helper for read-only 200 responses.
+func writeJSONOK(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -1,0 +1,302 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// libraryFixture builds a Server with an in-memory sqlite store, no
+// pre-existing rows in any substrate. Each test seeds its own data
+// then exercises the read-only library endpoints.
+func libraryFixture(t *testing.T) (*Server, store.Store, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Env: config.Env{
+			AuthToken:             "test-token",
+			ChannelsMaxValueBytes: 64 * 1024,
+			ChannelsLongPollCapMS: 1000,
+		},
+	}
+	hookReg := hooks.NewRegistry()
+	srv := &Server{
+		cfg:            cfg,
+		store:          s,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+	return srv, s, func() { _ = s.Close() }
+}
+
+// TestLibrary_AgentDefNames_EmptyStore covers the cold-start case —
+// freshly-created store, no agent defs, endpoint returns `{names: []}`
+// not `{names: null}`. Wire shape matters for the TS adapter consumer.
+func TestLibrary_AgentDefNames_EmptyStore(t *testing.T) {
+	srv, _, cleanup := libraryFixture(t)
+	defer cleanup()
+
+	req := authedRequest("GET", "/v1/_agentdef/names", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.AgentDefNameSummary `json:"names"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Must be an empty slice, never null — the TS adapter's
+	// resp.names.length check would NPE on null.
+	if resp.Names == nil {
+		t.Errorf("Names is null, want [] for empty store")
+	}
+	if len(resp.Names) != 0 {
+		t.Errorf("Names = %d entries, want 0", len(resp.Names))
+	}
+}
+
+// TestLibrary_AgentDefNames_AfterSeed verifies the endpoint returns
+// every declared name + the active_def_id pointer + version counts
+// after a few definitions have been written.
+func TestLibrary_AgentDefNames_AfterSeed(t *testing.T) {
+	srv, s, cleanup := libraryFixture(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	// Two agents: researcher with two versions (v1 retired, v2 active);
+	// summariser with one version (v1 active).
+	r1, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_researcher_v1", Name: "researcher", Version: 1,
+		Definition: []byte(`{"system":"hi"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r1
+	r2, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_researcher_v2", Name: "researcher", Version: 2,
+		ParentDefID: "def_researcher_v1",
+		Definition:  []byte(`{"system":"hi v2"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = r2
+	_ = s.AgentDefSetRetired(ctx, "def_researcher_v1", true)
+	_ = s.AgentDefSetActive(ctx, "researcher", "def_researcher_v2", "")
+	sum1, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_summariser_v1", Name: "summariser", Version: 1,
+		Definition: []byte(`{"system":"sum"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = sum1
+	_ = s.AgentDefSetActive(ctx, "summariser", "def_summariser_v1", "")
+
+	req := authedRequest("GET", "/v1/_agentdef/names", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.AgentDefNameSummary `json:"names"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byName := map[string]store.AgentDefNameSummary{}
+	for _, n := range resp.Names {
+		byName[n.Name] = n
+	}
+	r, ok := byName["researcher"]
+	if !ok {
+		t.Fatalf("researcher not in response: %+v", resp.Names)
+	}
+	if r.VersionCount != 2 || r.LatestVersion != 2 || r.ActiveDefID != "def_researcher_v2" {
+		t.Errorf("researcher summary wrong: %+v", r)
+	}
+	sm, ok := byName["summariser"]
+	if !ok {
+		t.Fatalf("summariser not in response: %+v", resp.Names)
+	}
+	if sm.VersionCount != 1 || sm.ActiveDefID != "def_summariser_v1" {
+		t.Errorf("summariser summary wrong: %+v", sm)
+	}
+}
+
+// TestLibrary_SkillDefNames_AfterSeed mirrors the AgentDef happy path
+// for the skill substrate.
+func TestLibrary_SkillDefNames_AfterSeed(t *testing.T) {
+	srv, s, cleanup := libraryFixture(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	_, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID: "sdef_voice_v1", Name: "voice-applier", Version: 1,
+		Definition: []byte(`{"body":"speak crisply"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = s.SkillDefSetActive(ctx, "voice-applier", "sdef_voice_v1", "")
+
+	req := authedRequest("GET", "/v1/_skilldef/names", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.SkillDefNameSummary `json:"names"`
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Names) != 1 || resp.Names[0].Name != "voice-applier" {
+		t.Errorf("Names = %+v, want one voice-applier entry", resp.Names)
+	}
+}
+
+// TestLibrary_MCPServerDefNames_AfterSeed mirrors the AgentDef happy
+// path for the MCPServerDef substrate.
+func TestLibrary_MCPServerDefNames_AfterSeed(t *testing.T) {
+	srv, s, cleanup := libraryFixture(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	_, err := s.MCPServerDefCreate(ctx, store.MCPServerDefRow{
+		DefID: "mdef_n8n_v1", Name: "n8n-mailgun", Version: 1,
+		Definition: []byte(`{"transport":"streamable-http","url":"https://x/mcp"}`),
+		CreatedAt:  time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = s.MCPServerDefSetActive(ctx, "n8n-mailgun", "mdef_n8n_v1", "")
+
+	req := authedRequest("GET", "/v1/_mcpserverdef/names", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.MCPServerDefNameSummary `json:"names"`
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Names) != 1 || resp.Names[0].Name != "n8n-mailgun" {
+		t.Errorf("Names = %+v, want one n8n-mailgun entry", resp.Names)
+	}
+}
+
+// TestLibrary_RequiresBearer guards the auth middleware wiring on
+// every new route — one assertion across all four endpoints.
+func TestLibrary_RequiresBearer(t *testing.T) {
+	srv, _, cleanup := libraryFixture(t)
+	defer cleanup()
+
+	for _, path := range []string{
+		"/v1/_agentdef/names",
+		"/v1/_skilldef/names",
+		"/v1/_mcpserverdef/names",
+		"/v1/agents/alice/channels",
+	} {
+		req := httptest.NewRequest("GET", path, nil) // no Authorization header
+		rec := httptest.NewRecorder()
+		srv.Mux().ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Errorf("path %q: status = %d, want 401", path, rec.Code)
+		}
+	}
+}
+
+// TestAgentChannels_HappyPath publishes + acks on two channels under
+// scope=agent/scope_id=alice, then verifies the endpoint returns both
+// cursor rows (alphabetised by channel) with non-empty cursor strings.
+func TestAgentChannels_HappyPath(t *testing.T) {
+	srv, s, cleanup := libraryFixture(t)
+	defer cleanup()
+	ctx := t.Context()
+
+	for _, ch := range []string{"team-updates", "findings"} {
+		_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: ch, Scope: store.MemoryScopeAgent, ScopeID: "alice",
+			Payload: []byte(`{}`),
+		}, 0)
+		time.Sleep(time.Microsecond)
+		_, next, _ := s.ChannelSubscribe(ctx, ch, store.MemoryScopeAgent, "alice", "", 1)
+		_ = s.ChannelAck(ctx, ch, store.MemoryScopeAgent, "alice", next)
+	}
+
+	req := authedRequest("GET", "/v1/agents/alice/channels", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Channels []store.ChannelCursorEntry `json:"channels"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Channels) != 2 {
+		t.Fatalf("Channels = %d, want 2: %+v", len(resp.Channels), resp.Channels)
+	}
+	// Channel ASC ordering: "findings" before "team-updates".
+	if resp.Channels[0].Channel != "findings" || resp.Channels[1].Channel != "team-updates" {
+		t.Errorf("ordering wrong: %+v", resp.Channels)
+	}
+	for _, c := range resp.Channels {
+		if c.Cursor == "" {
+			t.Errorf("channel %q has empty cursor", c.Channel)
+		}
+		if c.ScopeID != "alice" || string(c.Scope) != "agent" {
+			t.Errorf("channel %q has wrong scope: %+v", c.Channel, c)
+		}
+	}
+}
+
+// TestAgentChannels_InvalidAgentName guards the validIdent check on
+// the path-derived agent_name (same pattern as the per-user channel
+// routes).
+func TestAgentChannels_InvalidAgentName(t *testing.T) {
+	srv, _, cleanup := libraryFixture(t)
+	defer cleanup()
+
+	req := authedRequest("GET", "/v1/agents/alice@bob/channels", nil)
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 (invalid_agent_name)", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "invalid_agent_name") {
+		t.Errorf("body should mention invalid_agent_name: %s", rec.Body.String())
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1436,6 +1436,16 @@ func (s *Server) Mux() http.Handler {
 	// admin-only (no per-agent surface). Same dispatch shape as the
 	// other two substrate admin endpoints.
 	mux.Handle("POST /v1/_mcpserverdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateMCPServerDef))))
+	// v0.9.x Introspection — bearer-authed read-only enumeration of
+	// declared names per substrate. The companion to the op-dispatched
+	// substrate write endpoints; drives the Web UI's /ui/library tab.
+	mux.Handle("GET /v1/_agentdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListAgentDefNames))))
+	mux.Handle("GET /v1/_skilldef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListSkillDefNames))))
+	mux.Handle("GET /v1/_mcpserverdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMCPServerDefNames))))
+	// v0.9.x Introspection — channels an agent has cursored on
+	// (scope=agent, scope_id={agent_name}). Drives the Web UI's
+	// per-agent "channels this agent is subscribed to" sub-tab.
+	mux.Handle("GET /v1/agents/{agent_name}/channels", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleAgentChannels))))
 	// v0.8.15.3 HTTP MCP transport — Streamable HTTP endpoint that
 	// dispatches the same 20 MCP tools as the stdio MCP server.
 	// POST is the JSON-RPC frame transport; DELETE terminates a

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2797,6 +2797,33 @@ func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scop
 	return cursor, nil
 }
 
+// ChannelListCursorsForScope — see store.Store doc. v0.9.x introspection.
+func (s *Store) ChannelListCursorsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT channel, scope, scope_id, cursor, updated_at
+		 FROM channel_cursors
+		 WHERE scope = $1 AND scope_id = $2
+		 ORDER BY channel ASC`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list channel cursors: %w", err)
+	}
+	defer rows.Close()
+	out := []store.ChannelCursorEntry{}
+	for rows.Next() {
+		var entry store.ChannelCursorEntry
+		var scopeStr string
+		if err := rows.Scan(&entry.Channel, &scopeStr, &entry.ScopeID, &entry.Cursor, &entry.UpdatedAt); err != nil {
+			return nil, err
+		}
+		entry.Scope = store.MemoryScope(scopeStr)
+		entry.UpdatedAt = entry.UpdatedAt.UTC()
+		out = append(out, entry)
+	}
+	return out, rows.Err()
+}
+
 // ChannelSweepExpired drops every expired channel_messages row.
 func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 	tag, err := s.pool.Exec(ctx,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -2710,6 +2710,35 @@ func (s *Store) ChannelCommittedCursor(ctx context.Context, channel string, scop
 	return cursor, nil
 }
 
+// ChannelListCursorsForScope — see store.Store doc. v0.9.x
+// introspection. Ordered by channel ASC for deterministic UI render.
+func (s *Store) ChannelListCursorsForScope(ctx context.Context, scope store.MemoryScope, scopeID string) ([]store.ChannelCursorEntry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT channel, scope, scope_id, cursor, updated_at
+		 FROM channel_cursors
+		 WHERE scope = ? AND scope_id = ?
+		 ORDER BY channel ASC`,
+		string(scope), scopeID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []store.ChannelCursorEntry{}
+	for rows.Next() {
+		var entry store.ChannelCursorEntry
+		var scopeStr string
+		var updatedNanos int64
+		if err := rows.Scan(&entry.Channel, &scopeStr, &entry.ScopeID, &entry.Cursor, &updatedNanos); err != nil {
+			return nil, err
+		}
+		entry.Scope = store.MemoryScope(scopeStr)
+		entry.UpdatedAt = time.Unix(0, updatedNanos).UTC()
+		out = append(out, entry)
+	}
+	return out, rows.Err()
+}
+
 // ChannelSweepExpired deletes every expired row. Mirror of MemorySweep.
 func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 	res, err := s.db.ExecContext(ctx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -770,6 +770,16 @@ type Store interface {
 	// when callers omit fromCursor — "pick up where I left off".
 	ChannelCommittedCursor(ctx context.Context, channel string, scope MemoryScope, scopeID string) (string, error)
 
+	// ChannelListCursorsForScope returns every channel_cursors row
+	// matching (scope, scope_id). v0.9.x introspection — drives the
+	// Web UI's "channels this agent has subscribed to" view via the
+	// admin endpoint at GET /v1/agents/{name}/channels (scope=agent)
+	// and the equivalent per-user path. Empty slice when the
+	// (scope, scope_id) tuple has no cursors. Returns the full set so
+	// the UI can render "all channels this agent has ack'd on"
+	// without N+1 per-channel queries.
+	ChannelListCursorsForScope(ctx context.Context, scope MemoryScope, scopeID string) ([]ChannelCursorEntry, error)
+
 	// ChannelSweepExpired deletes every channel_messages row whose
 	// expires_at has passed. Returns the deleted row count for the
 	// sweeper's log line. Safe under concurrent sweepers; mirrors

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -127,6 +127,7 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelCursorAdvancesAcrossSubscribes", testChannelCursorAdvancesAcrossSubscribes},
 		{"ChannelAckIsIdempotent", testChannelAckIsIdempotent},
 		{"ChannelAckRejectsCursorRegression", testChannelAckRejectsCursorRegression},
+		{"ChannelListCursorsForScopeReturnsOnlyMatchingTuple", testChannelListCursorsForScope},
 		{"ChannelTTLFilteredAtRead", testChannelTTLFilteredAtRead},
 		{"ChannelSweepReapsExpired", testChannelSweepReapsExpired},
 		{"ChannelMaxMessagesTrimsOldest", testChannelMaxMessagesTrimsOldest},
@@ -2237,6 +2238,79 @@ func testChannelAckRejectsCursorRegression(t *testing.T, s store.Store) {
 	err = s.ChannelAck(ctx, "ch", store.MemoryScopeAgent, "x", cur1)
 	if !errors.Is(err, store.ErrChannelCursorRegression) {
 		t.Errorf("got %v, want ErrChannelCursorRegression", err)
+	}
+}
+
+// testChannelListCursorsForScope pins the v0.9.x introspection contract:
+// the method returns every cursor row matching (scope, scope_id),
+// ordered by channel ASC, and rows for a different scope_id MUST NOT
+// leak.
+func testChannelListCursorsForScope(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// Seed two distinct (scope, scope_id) tuples with cursors on two
+	// channels each. Then verify per-tuple isolation + ordering.
+	for _, ch := range []string{"channel-a", "channel-b"} {
+		_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: ch, Scope: store.MemoryScopeAgent, ScopeID: "alice",
+			Payload: json.RawMessage(`{}`),
+		}, 0)
+		time.Sleep(time.Microsecond)
+		_, _, _ = s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: ch, Scope: store.MemoryScopeAgent, ScopeID: "bob",
+			Payload: json.RawMessage(`{}`),
+		}, 0)
+	}
+	// Alice acks both channels; bob acks only channel-a.
+	for _, ch := range []string{"channel-a", "channel-b"} {
+		_, next, _ := s.ChannelSubscribe(ctx, ch, store.MemoryScopeAgent, "alice", "", 1)
+		if next != "" {
+			_ = s.ChannelAck(ctx, ch, store.MemoryScopeAgent, "alice", next)
+		}
+	}
+	_, next, _ := s.ChannelSubscribe(ctx, "channel-a", store.MemoryScopeAgent, "bob", "", 1)
+	if next != "" {
+		_ = s.ChannelAck(ctx, "channel-a", store.MemoryScopeAgent, "bob", next)
+	}
+
+	// Alice's view: two rows, ordered ASC.
+	aliceRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeAgent, "alice")
+	if err != nil {
+		t.Fatalf("alice list: %v", err)
+	}
+	if len(aliceRows) != 2 {
+		t.Fatalf("alice rows = %d, want 2: %+v", len(aliceRows), aliceRows)
+	}
+	if aliceRows[0].Channel != "channel-a" || aliceRows[1].Channel != "channel-b" {
+		t.Errorf("alice ordering wrong: %+v", aliceRows)
+	}
+	for _, r := range aliceRows {
+		if r.ScopeID != "alice" || r.Scope != store.MemoryScopeAgent {
+			t.Errorf("alice row has wrong scope/scope_id: %+v", r)
+		}
+		if r.Cursor == "" {
+			t.Errorf("alice row %q has empty cursor", r.Channel)
+		}
+		if r.UpdatedAt.IsZero() {
+			t.Errorf("alice row %q has zero UpdatedAt", r.Channel)
+		}
+	}
+
+	// Bob's view: one row (channel-a only).
+	bobRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeAgent, "bob")
+	if err != nil {
+		t.Fatalf("bob list: %v", err)
+	}
+	if len(bobRows) != 1 || bobRows[0].Channel != "channel-a" {
+		t.Errorf("bob rows = %+v, want one channel-a row", bobRows)
+	}
+
+	// Mismatched scope: scope=user, scope_id=alice. No rows.
+	userRows, err := s.ChannelListCursorsForScope(ctx, store.MemoryScopeUser, "alice")
+	if err != nil {
+		t.Fatalf("user-scope list: %v", err)
+	}
+	if len(userRows) != 0 {
+		t.Errorf("scope=user/alice rows = %+v, want 0 (must not leak agent-scope rows)", userRows)
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -736,3 +736,137 @@ export async function getMetricsSummary(
   );
   return asMetricsResult(r);
 }
+
+// ---- v0.9.x Introspection — Library + Channels + Agent sub-views ----
+
+// Substrate name summary — same shape across AgentDef / SkillDef /
+// MCPServerDef. Returned by the three GET /v1/_*/names endpoints.
+export interface DefNameSummary {
+  name: string;
+  version_count: number;
+  active_def_id?: string;
+  latest_version: number;
+  last_updated: string;
+}
+
+export interface DefNamesResponse {
+  names: DefNameSummary[];
+}
+
+// Substrate row — what `op:list` returns inside its `versions: []`
+// array. Same fields across AgentDef / SkillDef / MCPServerDef so the
+// UI's lineage tree can render any of them with one component.
+export interface DefRow {
+  def_id: string;
+  name: string;
+  version: number;
+  parent_def_id?: string;
+  description?: string;
+  retired?: boolean;
+  bootstrapped_from_static?: boolean;
+  content_sha256?: string;
+  created_at: string;
+  created_by_agent_id?: string;
+  created_by_run_id?: string;
+  definition?: unknown;
+}
+
+export interface DefListByNameResponse {
+  name: string;
+  versions: DefRow[];
+}
+
+export interface ChannelDescriptor {
+  name: string;
+  scope?: string;
+  semantic?: string;
+  publisher?: string;
+  period?: string;
+  default_ttl?: number;
+  max_messages?: number;
+  message_count: number;
+  oldest_visible_at?: string;
+  newest_visible_at?: string;
+}
+
+export interface ListChannelsResponse {
+  channels: ChannelDescriptor[];
+}
+
+export interface ChannelMessageItem {
+  id: string;
+  value: unknown;
+  published_at: string;
+}
+
+export interface ChannelPeekResponse {
+  channel: string;
+  messages: ChannelMessageItem[];
+}
+
+export interface ChannelCursorEntry {
+  channel: string;
+  scope: string;
+  scope_id: string;
+  cursor: string;
+  updated_at: string;
+}
+
+export interface AgentChannelsResponse {
+  channels: ChannelCursorEntry[];
+}
+
+// ---- Library fetchers ----
+
+export function listAgentDefNames(): Promise<DefNamesResponse> {
+  return jsonFetch<DefNamesResponse>("/v1/_agentdef/names");
+}
+
+export function listSkillDefNames(): Promise<DefNamesResponse> {
+  return jsonFetch<DefNamesResponse>("/v1/_skilldef/names");
+}
+
+export function listMcpServerDefNames(): Promise<DefNamesResponse> {
+  return jsonFetch<DefNamesResponse>("/v1/_mcpserverdef/names");
+}
+
+// listDefVersionsByName uses the existing op-discriminated POST
+// endpoint with `{op:"list", name}` to retrieve every version of one
+// declared name. Used by the Library UI when an operator clicks into
+// a name to inspect its lineage.
+export function listDefVersionsByName(
+  kind: "agentdef" | "skilldef" | "mcpserverdef",
+  name: string,
+): Promise<DefListByNameResponse> {
+  return jsonFetch<DefListByNameResponse>(`/v1/_${kind}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ op: "list", name }),
+  });
+}
+
+// ---- Channel fetchers ----
+
+export function listChannels(): Promise<ListChannelsResponse> {
+  return jsonFetch<ListChannelsResponse>("/v1/_channels");
+}
+
+export function peekChannel(
+  name: string,
+  opts: { maxMessages?: number; fromCursor?: string } = {},
+): Promise<ChannelPeekResponse> {
+  const q = new URLSearchParams();
+  if (opts.maxMessages !== undefined)
+    q.set("max_messages", String(opts.maxMessages));
+  if (opts.fromCursor) q.set("from_cursor", opts.fromCursor);
+  const qs = q.toString();
+  return jsonFetch<ChannelPeekResponse>(
+    `/v1/_channels/${encodeURIComponent(name)}/peek${qs ? "?" + qs : ""}`,
+  );
+}
+
+export function listAgentChannels(agentName: string): Promise<AgentChannelsResponse> {
+  return jsonFetch<AgentChannelsResponse>(
+    `/v1/agents/${encodeURIComponent(agentName)}/channels`,
+  );
+}

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -13,6 +13,13 @@ import {
 import Breadcrumbs, { type BreadcrumbAncestor } from "./Breadcrumbs";
 import TerminalTranscript from "./TerminalTranscript";
 import ViewToggle, { useViewMode } from "./ViewToggle";
+import {
+  AgentTabStrip,
+  ChannelsTab,
+  InterruptsTab,
+  MemoryTab,
+  useAgentTab,
+} from "./AgentDetailTabs";
 
 // AgentDetailPane renders one agent's status header + the
 // scrollable event-card stream. Takes agentId as a prop so it can
@@ -130,6 +137,9 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
   const renderedEvents = useMemo(() => coalesceText(events.filter(visible)), [events]);
   const awaited = useMemo(() => deriveAwaitedState(events), [events]);
   const [viewMode, setViewMode] = useViewMode();
+  // v0.9.x — sub-tab strip above the transcript. Default "transcript"
+  // shows the existing event-card stream + view toggle.
+  const [activeTab, setActiveTab] = useAgentTab();
 
   return (
     <div className="agent-detail">
@@ -189,17 +199,25 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
       ) : (
         <div className="empty">loading…</div>
       )}
-      <ViewToggle mode={viewMode} onChange={setViewMode} />
-      {viewMode === "panels" ? (
-        <div className="events">
-          {renderedEvents.map((ev) => (
-            <EventCard key={ev.seq} row={ev} />
-          ))}
-          <div ref={tailRef} />
-        </div>
-      ) : (
-        <TerminalTranscript events={events} />
+      <AgentTabStrip tab={activeTab} onChange={setActiveTab} />
+      {activeTab === "transcript" && (
+        <>
+          <ViewToggle mode={viewMode} onChange={setViewMode} />
+          {viewMode === "panels" ? (
+            <div className="events">
+              {renderedEvents.map((ev) => (
+                <EventCard key={ev.seq} row={ev} />
+              ))}
+              <div ref={tailRef} />
+            </div>
+          ) : (
+            <TerminalTranscript events={events} />
+          )}
+        </>
       )}
+      {activeTab === "memory" && <MemoryTab agentName={agent?.agent ?? ""} />}
+      {activeTab === "interrupts" && <InterruptsTab runID={agent?.run_id ?? ""} />}
+      {activeTab === "channels" && <ChannelsTab agentName={agent?.agent ?? ""} />}
     </div>
   );
 }

--- a/web/src/components/AgentDetailTabs.tsx
+++ b/web/src/components/AgentDetailTabs.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  ChannelCursorEntry,
+  InterruptRow,
+  MemoryEntry,
+  listAgentChannels,
+  listMemoryEntries,
+  listRunInterrupts,
+} from "../api";
+
+// AgentDetailTabs is the per-agent sub-tab strip + the three new
+// scoped-view components (Memory / Interrupts / Channels) that
+// hang off the existing AgentDetailPane. The default tab is
+// "transcript" — when active, AgentDetailPane renders its existing
+// event list as before. The other three tabs are read-only views
+// over data scoped to the current agent.
+
+export type AgentTab = "transcript" | "memory" | "interrupts" | "channels";
+
+// useAgentTab persists the active sub-tab in the URL search param
+// `?tab=` so deep-links + refreshes preserve the operator's choice.
+// Default = "transcript" (param absent or any unrecognised value).
+export function useAgentTab(): [AgentTab, (t: AgentTab) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const raw = searchParams.get("tab");
+  const tab: AgentTab =
+    raw === "memory" || raw === "interrupts" || raw === "channels" ? raw : "transcript";
+  const set = (t: AgentTab) => {
+    const next = new URLSearchParams(searchParams);
+    if (t === "transcript") {
+      next.delete("tab");
+    } else {
+      next.set("tab", t);
+    }
+    setSearchParams(next, { replace: true });
+  };
+  return [tab, set];
+}
+
+export interface AgentTabStripProps {
+  tab: AgentTab;
+  onChange: (t: AgentTab) => void;
+}
+
+export function AgentTabStrip({ tab, onChange }: AgentTabStripProps) {
+  return (
+    <div className="agent-tabs" role="tablist" aria-label="agent detail tabs">
+      <TabBtn label="transcript" tab="transcript" current={tab} onChange={onChange} />
+      <TabBtn label="memory" tab="memory" current={tab} onChange={onChange} />
+      <TabBtn label="interrupts" tab="interrupts" current={tab} onChange={onChange} />
+      <TabBtn label="channels" tab="channels" current={tab} onChange={onChange} />
+    </div>
+  );
+}
+
+function TabBtn({
+  label,
+  tab,
+  current,
+  onChange,
+}: {
+  label: string;
+  tab: AgentTab;
+  current: AgentTab;
+  onChange: (t: AgentTab) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={tab === current}
+      className={tab === current ? "agent-tab agent-tab-active" : "agent-tab"}
+      onClick={() => onChange(tab)}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ---- Memory tab: scope=agent, scope_id=agent.agent (the agent name) ----
+
+const MEMORY_LIMIT = 100;
+
+export function MemoryTab({ agentName }: { agentName: string }) {
+  const [entries, setEntries] = useState<MemoryEntry[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!agentName) return;
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    listMemoryEntries("agent", agentName, undefined, MEMORY_LIMIT)
+      .then((r) => {
+        if (cancelled) return;
+        setEntries(r.entries ?? []);
+        setLoading(false);
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setErr(e.message);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentName]);
+
+  if (!agentName) {
+    return <div className="empty-state">Agent name unknown — cannot scope memory query.</div>;
+  }
+  if (err) {
+    return <div className="error-banner">Failed to load memory: {err}</div>;
+  }
+  if (loading) {
+    return <div className="loading-indicator">loading memory entries…</div>;
+  }
+  if (entries.length === 0) {
+    return (
+      <div className="empty-state">
+        No memory entries in <code className="mono">scope=agent / scope_id={agentName}</code>.
+      </div>
+    );
+  }
+  return (
+    <div className="agent-tab-body">
+      <div className="agent-tab-meta">
+        <span>scope=agent</span>
+        <span>scope_id={agentName}</span>
+        <span>{entries.length} entries</span>
+      </div>
+      <ul className="memory-entry-list">
+        {entries.map((e) => (
+          <li key={e.key} className="memory-entry">
+            <div className="memory-entry-key mono">{e.key}</div>
+            <pre className="memory-entry-value mono">
+              {tryPretty(e.value)}
+            </pre>
+            <div className="memory-entry-meta">
+              updated {new Date(e.updated_at).toLocaleString()}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {entries.length >= MEMORY_LIMIT && (
+        <div className="agent-tab-note">
+          Showing first {MEMORY_LIMIT} entries. For the full picker (search +
+          edit), open <a href="/ui/memory">memory</a>.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Interrupts tab: scoped to the run_id of the agent ----
+
+export function InterruptsTab({ runID }: { runID: string }) {
+  const [interrupts, setInterrupts] = useState<InterruptRow[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!runID) return;
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    // Status=all returns pending + resolved + cancelled so the
+    // operator sees the whole interrupt history for this run.
+    listRunInterrupts(runID, "all")
+      .then((r) => {
+        if (cancelled) return;
+        setInterrupts(r.interrupts ?? []);
+        setLoading(false);
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setErr(e.message);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [runID]);
+
+  if (!runID) {
+    return <div className="empty-state">Run id unknown — cannot scope interrupt query.</div>;
+  }
+  if (err) {
+    return <div className="error-banner">Failed to load interrupts: {err}</div>;
+  }
+  if (loading) {
+    return <div className="loading-indicator">loading interrupts…</div>;
+  }
+  if (interrupts.length === 0) {
+    return (
+      <div className="empty-state">
+        No interrupts on run <code className="mono">{runID}</code>.
+      </div>
+    );
+  }
+  return (
+    <div className="agent-tab-body">
+      <div className="agent-tab-meta">
+        <span>run_id={runID}</span>
+        <span>{interrupts.length} interrupts</span>
+      </div>
+      <ul className="interrupt-list">
+        {interrupts.map((it) => (
+          <li key={it.interrupt_id} className={`interrupt-row interrupt-${it.status}`}>
+            <div className="interrupt-header">
+              <span className={`pill ${it.status}`}>{it.status}</span>
+              <span className="interrupt-kind mono">{it.kind}</span>
+              <span className="interrupt-id mono">{it.interrupt_id}</span>
+            </div>
+            {it.question && <div className="interrupt-question">{it.question}</div>}
+            {it.answer && (
+              <div className="interrupt-answer">
+                <span className="agent-tab-meta-key">answer:</span> {it.answer}
+              </div>
+            )}
+            <div className="agent-tab-meta">
+              <span>created {new Date(it.created_at).toLocaleString()}</span>
+              {it.resolved_at && (
+                <span>resolved {new Date(it.resolved_at).toLocaleString()}</span>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className="agent-tab-note">
+        To resolve a pending interrupt, open <a href="/ui/interrupts">interrupts</a>.
+      </div>
+    </div>
+  );
+}
+
+// ---- Channels tab: scope=agent cursors for this agent name ----
+
+export function ChannelsTab({ agentName }: { agentName: string }) {
+  const [channels, setChannels] = useState<ChannelCursorEntry[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!agentName) return;
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    listAgentChannels(agentName)
+      .then((r) => {
+        if (cancelled) return;
+        setChannels(r.channels ?? []);
+        setLoading(false);
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setErr(e.message);
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentName]);
+
+  if (!agentName) {
+    return <div className="empty-state">Agent name unknown — cannot scope channel query.</div>;
+  }
+  if (err) {
+    return <div className="error-banner">Failed to load channels: {err}</div>;
+  }
+  if (loading) {
+    return <div className="loading-indicator">loading channels…</div>;
+  }
+  if (channels.length === 0) {
+    return (
+      <div className="empty-state">
+        Agent <code className="mono">{agentName}</code> has no channel cursors.
+      </div>
+    );
+  }
+  return (
+    <div className="agent-tab-body">
+      <div className="agent-tab-meta">
+        <span>scope=agent</span>
+        <span>scope_id={agentName}</span>
+        <span>{channels.length} channels</span>
+      </div>
+      <ul className="channel-cursor-list">
+        {channels.map((c) => (
+          <li key={c.channel} className="channel-cursor-row">
+            <div className="channel-cursor-name mono">{c.channel}</div>
+            <div className="channel-cursor-meta">
+              <span className="mono" title={c.cursor}>
+                cursor: {shortCursor(c.cursor)}
+              </span>
+              <span>updated {new Date(c.updated_at).toLocaleString()}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className="agent-tab-note">
+        To inspect channel content + recent messages, open{" "}
+        <a href="/ui/channels">channels</a>.
+      </div>
+    </div>
+  );
+}
+
+function shortCursor(cur: string): string {
+  // cur_<16hex>_<msg_id>. Show the first 18 chars (cur_ + visible_at
+  // hex) for a compact display; full cursor available via tooltip.
+  if (cur.length <= 18) return cur;
+  return cur.slice(0, 18) + "…";
+}
+
+function tryPretty(value: unknown): string {
+  if (typeof value === "string") {
+    // Many memory values are JSON-encoded strings; try to parse so
+    // the operator sees structure rather than a quoted blob.
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -81,6 +81,8 @@ export default function Layout() {
         </div>
         <nav className="nav-tabs">
           <NavLink to="/agents">runs</NavLink>
+          <NavLink to="/library/agents">library</NavLink>
+          <NavLink to="/channels">channels</NavLink>
           <NavLink to="/interrupts">interrupts</NavLink>
           <NavLink to="/memory">memory</NavLink>
           <NavLink to="/snapshots">snapshots</NavLink>

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  DefNameSummary,
+  DefRow,
+  listDefVersionsByName,
+} from "../api";
+import Splitter from "./Splitter";
+import LineageTree, { buildLineageTree } from "./LineageTree";
+
+// LineagePanel is the shared shape that backs each Library sub-tab
+// (Agents / Skills / MCP Servers). Left pane lists declared NAMES
+// supplied by the parent page; right pane shows the lineage tree
+// for the selected name + the selected version's definition JSON.
+//
+// Polling cadence: name list refresh is owned by the parent (Library
+// page calls listAgentDefNames / listSkillDefNames / etc.); version
+// lineage refreshes on selection change.
+
+export interface LineagePanelProps {
+  // Substrate kind used in the listDefVersionsByName API call.
+  kind: "agentdef" | "skilldef" | "mcpserverdef";
+  // Human-readable label for the empty-state copy.
+  kindLabel: string;
+  // List of declared names — fetched by the parent so the polling
+  // strategy stays uniform with other admin pages.
+  names: DefNameSummary[];
+  // Storage key for the Splitter's persisted width (per sub-tab so
+  // the operator can size them independently).
+  splitterStorageKey: string;
+  // Kind-specific renderer for the version's Definition JSON shape.
+  // Used by Agents (system_prompt + allowed_tools) / Skills (body) /
+  // MCP Servers (url + headers + discovered_tools).
+  renderDefinition: (row: DefRow) => React.ReactNode;
+}
+
+export default function LineagePanel({
+  kind,
+  kindLabel,
+  names,
+  splitterStorageKey,
+  renderDefinition,
+}: LineagePanelProps) {
+  const [selectedName, setSelectedName] = useState<string>(() =>
+    names.length > 0 ? names[0]!.name : "",
+  );
+  const [versions, setVersions] = useState<DefRow[]>([]);
+  const [versionsErr, setVersionsErr] = useState<string | null>(null);
+  const [versionsLoading, setVersionsLoading] = useState(false);
+  const [selectedDefID, setSelectedDefID] = useState<string>("");
+
+  // When the names list updates and the currently-selected name is
+  // gone (renamed / retired tree), fall back to the first available.
+  useEffect(() => {
+    if (selectedName && names.find((n) => n.name === selectedName)) return;
+    setSelectedName(names.length > 0 ? names[0]!.name : "");
+  }, [names, selectedName]);
+
+  // Fetch the lineage for the selected name. Selecting a different
+  // name resets the selectedDefID + clears the previous lineage.
+  useEffect(() => {
+    if (!selectedName) {
+      setVersions([]);
+      setSelectedDefID("");
+      return;
+    }
+    let cancelled = false;
+    setVersionsLoading(true);
+    setVersionsErr(null);
+    listDefVersionsByName(kind, selectedName)
+      .then((r) => {
+        if (cancelled) return;
+        setVersions(r.versions ?? []);
+        setVersionsLoading(false);
+        // Pre-select the active version if available, else the
+        // highest-version (most recent) row.
+        const summary = names.find((n) => n.name === selectedName);
+        if (summary?.active_def_id) {
+          setSelectedDefID(summary.active_def_id);
+        } else if (r.versions && r.versions.length > 0) {
+          const top = [...r.versions].sort((a, b) => b.version - a.version)[0]!;
+          setSelectedDefID(top.def_id);
+        } else {
+          setSelectedDefID("");
+        }
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setVersionsErr(e.message);
+        setVersionsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, selectedName, names]);
+
+  const tree = useMemo(() => buildLineageTree(versions), [versions]);
+  const activeDefID = useMemo(
+    () => names.find((n) => n.name === selectedName)?.active_def_id ?? "",
+    [names, selectedName],
+  );
+  const selectedRow = useMemo(
+    () => versions.find((v) => v.def_id === selectedDefID),
+    [versions, selectedDefID],
+  );
+
+  if (names.length === 0) {
+    return (
+      <div className="empty-state">
+        No {kindLabel} declared yet. Use the substrate admin API
+        (POST /v1/_{kind}) to create one.
+      </div>
+    );
+  }
+
+  return (
+    <Splitter
+      storageKey={splitterStorageKey}
+      defaultLeftWidth={320}
+      minLeftWidth={220}
+      minRightWidth={320}
+    >
+      <NameList
+        names={names}
+        selectedName={selectedName}
+        onSelect={setSelectedName}
+      />
+      <div className="lineage-right">
+        <div className="lineage-header">
+          <h3>{selectedName}</h3>
+          {versionsLoading && <span className="loading-indicator">loading…</span>}
+        </div>
+        {versionsErr && (
+          <div className="error-banner">Failed to load: {versionsErr}</div>
+        )}
+        <LineageTree
+          tree={tree}
+          activeDefID={activeDefID}
+          selectedDefID={selectedDefID}
+          onSelect={setSelectedDefID}
+        />
+        {selectedRow && (
+          <div className="lineage-detail">
+            <div className="lineage-detail-header">
+              <span className="mono">{selectedRow.def_id}</span>
+              {selectedRow.parent_def_id && (
+                <span className="lineage-detail-meta">
+                  ← {selectedRow.parent_def_id}
+                </span>
+              )}
+              <span className="lineage-detail-meta">
+                created {new Date(selectedRow.created_at).toLocaleString()}
+              </span>
+              {selectedRow.content_sha256 && (
+                <span className="mono lineage-detail-meta" title={selectedRow.content_sha256}>
+                  {shortenSHA(selectedRow.content_sha256)}
+                </span>
+              )}
+            </div>
+            {renderDefinition(selectedRow)}
+          </div>
+        )}
+      </div>
+    </Splitter>
+  );
+}
+
+function NameList({
+  names,
+  selectedName,
+  onSelect,
+}: {
+  names: DefNameSummary[];
+  selectedName: string;
+  onSelect: (name: string) => void;
+}) {
+  return (
+    <ul className="lineage-name-list">
+      {names.map((n) => (
+        <li
+          key={n.name}
+          className={
+            n.name === selectedName
+              ? "lineage-name-row lineage-name-selected"
+              : "lineage-name-row"
+          }
+        >
+          <button
+            type="button"
+            className="lineage-name-button"
+            onClick={() => onSelect(n.name)}
+          >
+            <span className="lineage-name-label">{n.name}</span>
+            <span className="lineage-name-versions">
+              {n.version_count} version{n.version_count === 1 ? "" : "s"}
+            </span>
+            {n.active_def_id ? (
+              <span className="def-chip def-chip-active">v{n.latest_version} ★</span>
+            ) : (
+              <span className="def-chip def-chip-no-active">no active</span>
+            )}
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function shortenSHA(s: string): string {
+  // `sha256:64hex` → `sha256:8hex…` for compact display; hover for full.
+  if (s.length <= 18) return s;
+  return s.slice(0, 14) + "…";
+}

--- a/web/src/components/LineageTree.tsx
+++ b/web/src/components/LineageTree.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DefRow } from "../api";
+
+// LineageTree renders parent → child substrate versions as a nested
+// <ul>. Mirror of AgentsTree.tsx but generalised over the substrate
+// DefRow shape (def_id / parent_def_id / version / retired /
+// bootstrapped_from_static). One component backs the Agent / Skill /
+// MCP Server sub-tabs in the Library view.
+//
+// Expand state is per-component (Map<def_id, boolean>); default-true
+// for v1 — operators inspecting lineage usually want the full chain
+// visible. Selected row is highlighted; clicking fires onSelect.
+
+export interface LineageNode {
+  row: DefRow;
+  children: LineageNode[];
+}
+
+// buildLineageTree groups rows into parent → child nodes via
+// parent_def_id. Roots are rows whose parent_def_id is empty OR
+// missing from the input set (defensive against partial pages).
+// Returned roots are sorted by version ASC so v1 sits at the top.
+export function buildLineageTree(rows: DefRow[]): LineageNode[] {
+  const byID = new Map<string, LineageNode>();
+  rows.forEach((r) => byID.set(r.def_id, { row: r, children: [] }));
+  const roots: LineageNode[] = [];
+  rows.forEach((r) => {
+    const node = byID.get(r.def_id)!;
+    if (r.parent_def_id && byID.has(r.parent_def_id)) {
+      byID.get(r.parent_def_id)!.children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  const sortByVersionAsc = (nodes: LineageNode[]) => {
+    nodes.sort((a, b) => a.row.version - b.row.version);
+    nodes.forEach((n) => sortByVersionAsc(n.children));
+  };
+  sortByVersionAsc(roots);
+  return roots;
+}
+
+export interface LineageTreeProps {
+  tree: LineageNode[];
+  // Highlight + click callback. activeDefID — the row stored in the
+  // *_def_active overlay; gets the "active ★" chip. selectedDefID —
+  // the currently-clicked row (independent of active).
+  activeDefID?: string;
+  selectedDefID?: string;
+  onSelect?: (defID: string) => void;
+}
+
+export default function LineageTree({
+  tree,
+  activeDefID,
+  selectedDefID,
+  onSelect,
+}: LineageTreeProps) {
+  const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
+
+  // Auto-expand ancestors of the selected node so a deep-link / fresh
+  // click never leaves the selection buried under a collapsed parent.
+  useEffect(() => {
+    if (!selectedDefID) return;
+    const ancestors = collectAncestors(tree, selectedDefID);
+    if (ancestors.length === 0) return;
+    setExpanded((prev) => {
+      let mutated = false;
+      const next = new Map(prev);
+      for (const id of ancestors) {
+        if (next.get(id) === false) {
+          next.set(id, true);
+          mutated = true;
+        }
+      }
+      return mutated ? next : prev;
+    });
+  }, [tree, selectedDefID]);
+
+  const toggleExpanded = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Map(prev);
+      // Default-expanded: missing key OR true is expanded; only an
+      // explicit false collapses. So clicking flips the local state.
+      const currentExpanded = next.get(id) !== false;
+      next.set(id, !currentExpanded);
+      return next;
+    });
+  }, []);
+
+  return (
+    <ul className="lineage-tree" role="tree">
+      {tree.map((node) => (
+        <LineageNodeRow
+          key={node.row.def_id}
+          node={node}
+          depth={0}
+          expanded={expanded}
+          toggleExpanded={toggleExpanded}
+          activeDefID={activeDefID}
+          selectedDefID={selectedDefID}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function LineageNodeRow({
+  node,
+  depth,
+  expanded,
+  toggleExpanded,
+  activeDefID,
+  selectedDefID,
+  onSelect,
+}: {
+  node: LineageNode;
+  depth: number;
+  expanded: Map<string, boolean>;
+  toggleExpanded: (id: string) => void;
+  activeDefID?: string;
+  selectedDefID?: string;
+  onSelect?: (defID: string) => void;
+}) {
+  const isExpanded = expanded.get(node.row.def_id) !== false;
+  const hasChildren = node.children.length > 0;
+  const isActive = node.row.def_id === activeDefID;
+  const isSelected = node.row.def_id === selectedDefID;
+  const row = node.row;
+
+  return (
+    <li className={isSelected ? "lineage-row lineage-row-selected" : "lineage-row"}>
+      <div className="lineage-row-line" style={{ paddingLeft: `${depth * 16}px` }}>
+        {hasChildren ? (
+          <button
+            type="button"
+            className="lineage-caret"
+            onClick={() => toggleExpanded(row.def_id)}
+            aria-label={isExpanded ? "Collapse" : "Expand"}
+          >
+            {isExpanded ? "▾" : "▸"}
+          </button>
+        ) : (
+          <span className="lineage-caret lineage-caret-empty">·</span>
+        )}
+        <button
+          type="button"
+          className="lineage-row-button"
+          onClick={() => onSelect?.(row.def_id)}
+        >
+          <span className="lineage-version">v{row.version}</span>
+          {isActive && <span className="def-chip def-chip-active">active ★</span>}
+          {row.retired && <span className="def-chip def-chip-retired">retired</span>}
+          {row.bootstrapped_from_static && (
+            <span className="def-chip def-chip-bootstrap">bootstrapped</span>
+          )}
+          <span className="lineage-defid mono">{shortDefID(row.def_id)}</span>
+        </button>
+      </div>
+      {isExpanded && hasChildren && (
+        <ul role="group">
+          {node.children.map((child) => (
+            <LineageNodeRow
+              key={child.row.def_id}
+              node={child}
+              depth={depth + 1}
+              expanded={expanded}
+              toggleExpanded={toggleExpanded}
+              activeDefID={activeDefID}
+              selectedDefID={selectedDefID}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function collectAncestors(tree: LineageNode[], targetID: string): string[] {
+  const ancestors: string[] = [];
+  function walk(nodes: LineageNode[], path: string[]): boolean {
+    for (const node of nodes) {
+      if (node.row.def_id === targetID) {
+        ancestors.push(...path);
+        return true;
+      }
+      if (walk(node.children, [...path, node.row.def_id])) return true;
+    }
+    return false;
+  }
+  walk(tree, []);
+  return ancestors;
+}
+
+function shortDefID(defID: string): string {
+  // def_<24hex> → def_xxxxxxxx (8 chars after prefix). Substrate UI
+  // doesn't need the full 24; full id available via tooltip in caller.
+  if (defID.length <= 12) return defID;
+  return defID.slice(0, 12) + "…";
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,6 +8,8 @@ import InterruptInbox from "./pages/InterruptInbox";
 import SnapshotsView from "./pages/SnapshotsView";
 import AuditView from "./pages/AuditView";
 import ActivityMonitor from "./pages/ActivityMonitor";
+import LibraryView from "./pages/LibraryView";
+import ChannelsView from "./pages/ChannelsView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
 
@@ -26,6 +28,13 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route index element={<Navigate to="/agents" replace />} />
           <Route path="agents" element={<AgentsView />} />
           <Route path="agents/:agentId" element={<AgentIdRedirect />} />
+          <Route path="library" element={<LibraryView />}>
+            <Route index element={<Navigate to="/library/agents" replace />} />
+          </Route>
+          <Route path="library/agents" element={<LibraryView />} />
+          <Route path="library/skills" element={<LibraryView />} />
+          <Route path="library/mcp-servers" element={<LibraryView />} />
+          <Route path="channels" element={<ChannelsView />} />
           <Route path="memory" element={<MemoryView />} />
           <Route path="interrupts" element={<InterruptInbox />} />
           <Route path="snapshots" element={<SnapshotsView />} />

--- a/web/src/pages/ChannelsView.tsx
+++ b/web/src/pages/ChannelsView.tsx
@@ -1,0 +1,253 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  ChannelDescriptor,
+  ChannelMessageItem,
+  listChannels,
+  peekChannel,
+} from "../api";
+import Splitter from "../components/Splitter";
+
+// ChannelsView is the v0.9.x Introspection surface for operator-
+// declared channels. Three things together:
+//
+//   1. Aggregate stats per channel (message_count, oldest/newest
+//      visible_at) — what's flowing where.
+//   2. Per-scope filtering (system / global / user / agent) — so
+//      operators can narrow to e.g. only _system/* channels.
+//   3. Per-channel message peek — non-destructive read of recent
+//      messages so operators can verify content shape without
+//      hooking up a subscriber.
+
+const REFRESH_MS = 10_000;
+
+export default function ChannelsView() {
+  const [channels, setChannels] = useState<ChannelDescriptor[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [filter, setFilter] = useState<FilterKind>("all");
+  const [selectedName, setSelectedName] = useState<string>("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchOnce = async () => {
+      try {
+        const r = await listChannels();
+        if (cancelled) return;
+        setChannels(r.channels ?? []);
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchOnce();
+    const t = setInterval(fetchOnce, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const visible = useMemo(() => filterChannels(channels, filter), [channels, filter]);
+
+  // Default-select the first visible row when nothing is selected, so
+  // the right pane has content from page load.
+  useEffect(() => {
+    if (selectedName && visible.find((c) => c.name === selectedName)) return;
+    setSelectedName(visible.length > 0 ? visible[0]!.name : "");
+  }, [visible, selectedName]);
+
+  const selected = useMemo(
+    () => channels.find((c) => c.name === selectedName),
+    [channels, selectedName],
+  );
+
+  return (
+    <div className="channels-view">
+      <div className="channels-toolbar">
+        <FilterChips current={filter} onChange={setFilter} />
+        <span className="channels-count">{visible.length} channels</span>
+      </div>
+      {err && <div className="error-banner">Failed to load channels: {err}</div>}
+      <Splitter
+        storageKey="loomcycle.channels.split"
+        defaultLeftWidth={420}
+        minLeftWidth={300}
+        minRightWidth={360}
+      >
+        <ChannelsList
+          channels={visible}
+          selectedName={selectedName}
+          onSelect={setSelectedName}
+        />
+        {selected ? (
+          <ChannelDetail channel={selected} />
+        ) : (
+          <div className="empty-state">Select a channel to inspect.</div>
+        )}
+      </Splitter>
+    </div>
+  );
+}
+
+type FilterKind = "all" | "system" | "global" | "user" | "agent";
+
+function FilterChips({
+  current,
+  onChange,
+}: {
+  current: FilterKind;
+  onChange: (f: FilterKind) => void;
+}) {
+  const opts: { kind: FilterKind; label: string }[] = [
+    { kind: "all", label: "all" },
+    { kind: "system", label: "_system/*" },
+    { kind: "global", label: "global" },
+    { kind: "user", label: "user" },
+    { kind: "agent", label: "agent" },
+  ];
+  return (
+    <div className="filter-chips">
+      {opts.map((o) => (
+        <button
+          key={o.kind}
+          type="button"
+          className={
+            o.kind === current ? "filter-chip filter-chip-active" : "filter-chip"
+          }
+          onClick={() => onChange(o.kind)}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function filterChannels(channels: ChannelDescriptor[], f: FilterKind): ChannelDescriptor[] {
+  if (f === "all") return channels;
+  if (f === "system") return channels.filter((c) => c.name.startsWith("_system/"));
+  return channels.filter((c) => c.scope === f);
+}
+
+function ChannelsList({
+  channels,
+  selectedName,
+  onSelect,
+}: {
+  channels: ChannelDescriptor[];
+  selectedName: string;
+  onSelect: (name: string) => void;
+}) {
+  if (channels.length === 0) {
+    return (
+      <div className="empty-state">No channels match the current filter.</div>
+    );
+  }
+  return (
+    <ul className="channels-list">
+      {channels.map((c) => (
+        <li
+          key={c.name}
+          className={
+            c.name === selectedName ? "channel-row channel-row-selected" : "channel-row"
+          }
+        >
+          <button
+            type="button"
+            className="channel-row-button"
+            onClick={() => onSelect(c.name)}
+          >
+            <span className="channel-name">{c.name}</span>
+            <span className="channel-meta">
+              {c.scope && <span className="channel-scope">{c.scope}</span>}
+              {c.semantic && <span className="channel-semantic">{c.semantic}</span>}
+              <span className="channel-count">
+                {c.message_count} msg{c.message_count === 1 ? "" : "s"}
+              </span>
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ChannelDetail({ channel }: { channel: ChannelDescriptor }) {
+  // Peek is only well-defined for scope=global channels via this
+  // endpoint. We attempt the peek and gracefully show an empty state
+  // with an explanation when the channel uses a different scope.
+  const [messages, setMessages] = useState<ChannelMessageItem[]>([]);
+  const [peekErr, setPeekErr] = useState<string | null>(null);
+  const [peekLoading, setPeekLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setPeekLoading(true);
+    setPeekErr(null);
+    peekChannel(channel.name, { maxMessages: 20 })
+      .then((r) => {
+        if (cancelled) return;
+        setMessages(r.messages ?? []);
+        setPeekLoading(false);
+      })
+      .catch((e: Error) => {
+        if (cancelled) return;
+        setPeekErr(e.message);
+        setPeekLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [channel.name]);
+
+  return (
+    <div className="channel-detail">
+      <div className="channel-detail-header">
+        <h3>{channel.name}</h3>
+        <div className="channel-detail-meta">
+          {channel.scope && <span>scope={channel.scope}</span>}
+          {channel.semantic && <span>semantic={channel.semantic}</span>}
+          {channel.publisher && <span>publisher={channel.publisher}</span>}
+          {channel.period && <span>period={channel.period}</span>}
+          {channel.default_ttl !== undefined && channel.default_ttl > 0 && (
+            <span>ttl={channel.default_ttl}s</span>
+          )}
+          {channel.max_messages !== undefined && channel.max_messages > 0 && (
+            <span>max={channel.max_messages}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="channel-detail-section">
+        <h4>Recent messages (peek, scope=global)</h4>
+        {peekLoading && <div className="loading-indicator">loading…</div>}
+        {peekErr && (
+          <div className="error-banner">
+            Peek failed: {peekErr}
+            <div className="error-banner-hint">
+              Peek through this endpoint addresses scope=global. For
+              scope=user / scope=agent channels, peek via the
+              per-user / per-agent route.
+            </div>
+          </div>
+        )}
+        {!peekErr && messages.length === 0 && !peekLoading && (
+          <div className="empty-state">No messages in scope=global.</div>
+        )}
+        {messages.length > 0 && (
+          <ul className="channel-messages">
+            {messages.map((m) => (
+              <li key={m.id} className="channel-message">
+                <div className="channel-message-meta mono">
+                  {m.id} · {new Date(m.published_at).toLocaleString()}
+                </div>
+                <pre className="channel-message-value mono">
+                  {JSON.stringify(m.value, null, 2)}
+                </pre>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/LibraryView.tsx
+++ b/web/src/pages/LibraryView.tsx
@@ -1,0 +1,290 @@
+import { useEffect, useState } from "react";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
+import {
+  DefNameSummary,
+  DefRow,
+  listAgentDefNames,
+  listMcpServerDefNames,
+  listSkillDefNames,
+} from "../api";
+import LineagePanel from "../components/LineagePanel";
+
+// LibraryView is the v0.9.x Introspection surface — three sub-tabs
+// over the AgentDef / SkillDef / MCPServerDef substrates. Each
+// sub-tab uses the shared LineagePanel (list-left + lineage-right
+// Splitter) with a substrate-specific definition renderer.
+//
+// Polling cadence: 10 s for the name list. Lineage trees per name
+// refresh on selection.
+
+const REFRESH_MS = 10_000;
+
+export default function LibraryView() {
+  // Three independent name lists. Polled in parallel from one effect.
+  const [agents, setAgents] = useState<DefNameSummary[]>([]);
+  const [skills, setSkills] = useState<DefNameSummary[]>([]);
+  const [mcps, setMcps] = useState<DefNameSummary[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchAll = async () => {
+      try {
+        const [a, s, m] = await Promise.all([
+          listAgentDefNames(),
+          listSkillDefNames(),
+          listMcpServerDefNames(),
+        ]);
+        if (cancelled) return;
+        setAgents(a.names ?? []);
+        setSkills(s.names ?? []);
+        setMcps(m.names ?? []);
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchAll();
+    const t = setInterval(fetchAll, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, []);
+
+  const loc = useLocation();
+  const path = loc.pathname;
+  const sub = (() => {
+    if (path.startsWith("/library/skills")) return "skills";
+    if (path.startsWith("/library/mcp-servers")) return "mcp-servers";
+    return "agents";
+  })();
+
+  return (
+    <div className="library-view">
+      <div className="library-subtabs">
+        <NavLink to="/library/agents" end className={subtabClass}>
+          Agents <span className="library-subtab-count">{agents.length}</span>
+        </NavLink>
+        <NavLink to="/library/skills" end className={subtabClass}>
+          Skills <span className="library-subtab-count">{skills.length}</span>
+        </NavLink>
+        <NavLink to="/library/mcp-servers" end className={subtabClass}>
+          MCP Servers <span className="library-subtab-count">{mcps.length}</span>
+        </NavLink>
+      </div>
+      {err && <div className="error-banner">Failed to load library: {err}</div>}
+      <div className="library-content">
+        {sub === "agents" && (
+          <LineagePanel
+            kind="agentdef"
+            kindLabel="agents"
+            names={agents}
+            splitterStorageKey="loomcycle.library.agents.split"
+            renderDefinition={renderAgentDefinition}
+          />
+        )}
+        {sub === "skills" && (
+          <LineagePanel
+            kind="skilldef"
+            kindLabel="skills"
+            names={skills}
+            splitterStorageKey="loomcycle.library.skills.split"
+            renderDefinition={renderSkillDefinition}
+          />
+        )}
+        {sub === "mcp-servers" && (
+          <LineagePanel
+            kind="mcpserverdef"
+            kindLabel="MCP servers"
+            names={mcps}
+            splitterStorageKey="loomcycle.library.mcp.split"
+            renderDefinition={renderMcpDefinition}
+          />
+        )}
+      </div>
+      <Outlet />
+    </div>
+  );
+}
+
+const subtabClass = ({ isActive }: { isActive: boolean }) =>
+  isActive ? "library-subtab library-subtab-active" : "library-subtab";
+
+// ---- Substrate-specific Definition renderers ----
+
+interface AgentDefBody {
+  system_prompt?: string;
+  allowed_tools?: string[];
+  description?: string;
+  tier?: string;
+  provider?: string;
+  model?: string;
+  effort?: string;
+  max_tokens?: number;
+  max_iterations?: number;
+  skills?: string[];
+}
+
+function renderAgentDefinition(row: DefRow) {
+  const body = (row.definition as AgentDefBody) ?? {};
+  return (
+    <div className="def-body">
+      {body.description && (
+        <div className="def-field">
+          <span className="def-field-label">description</span>
+          <span>{body.description}</span>
+        </div>
+      )}
+      {body.system_prompt && (
+        <div className="def-field def-field-prompt">
+          <span className="def-field-label">system_prompt</span>
+          <pre className="def-prompt mono">{body.system_prompt}</pre>
+        </div>
+      )}
+      {body.allowed_tools && body.allowed_tools.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">allowed_tools</span>
+          <div className="def-pill-row">
+            {body.allowed_tools.map((t) => (
+              <span key={t} className="def-pill mono">{t}</span>
+            ))}
+          </div>
+        </div>
+      )}
+      {body.skills && body.skills.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">skills</span>
+          <div className="def-pill-row">
+            {body.skills.map((s) => (
+              <span key={s} className="def-pill mono">{s}</span>
+            ))}
+          </div>
+        </div>
+      )}
+      <DefMetaRow
+        items={[
+          ["tier", body.tier],
+          ["provider", body.provider],
+          ["model", body.model],
+          ["effort", body.effort],
+          ["max_tokens", body.max_tokens?.toString()],
+          ["max_iterations", body.max_iterations?.toString()],
+        ]}
+      />
+    </div>
+  );
+}
+
+interface SkillDefBody {
+  body?: string;
+  description?: string;
+  allowed_tools?: string[];
+}
+
+function renderSkillDefinition(row: DefRow) {
+  const body = (row.definition as SkillDefBody) ?? {};
+  return (
+    <div className="def-body">
+      {body.description && (
+        <div className="def-field">
+          <span className="def-field-label">description</span>
+          <span>{body.description}</span>
+        </div>
+      )}
+      {body.body && (
+        <div className="def-field def-field-prompt">
+          <span className="def-field-label">body</span>
+          <pre className="def-prompt mono">{body.body}</pre>
+        </div>
+      )}
+      {body.allowed_tools && body.allowed_tools.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">allowed_tools</span>
+          <div className="def-pill-row">
+            {body.allowed_tools.map((t) => (
+              <span key={t} className="def-pill mono">{t}</span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface MCPServerDefBody {
+  transport?: string;
+  url?: string;
+  description?: string;
+  headers?: Record<string, string>;
+  discovered_tools?: string[];
+}
+
+function renderMcpDefinition(row: DefRow) {
+  const body = (row.definition as MCPServerDefBody) ?? {};
+  return (
+    <div className="def-body">
+      {body.description && (
+        <div className="def-field">
+          <span className="def-field-label">description</span>
+          <span>{body.description}</span>
+        </div>
+      )}
+      <DefMetaRow
+        items={[
+          ["transport", body.transport],
+          ["url", body.url],
+        ]}
+      />
+      {body.headers && Object.keys(body.headers).length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">headers</span>
+          <pre className="def-prompt mono">
+            {Object.entries(body.headers)
+              .map(([k, v]) => `${k}: ${maskHeaderValue(k, v)}`)
+              .join("\n")}
+          </pre>
+        </div>
+      )}
+      {body.discovered_tools && body.discovered_tools.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">
+            discovered_tools ({body.discovered_tools.length})
+          </span>
+          <div className="def-pill-row">
+            {body.discovered_tools.map((t) => (
+              <span key={t} className="def-pill mono">{t}</span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DefMetaRow({ items }: { items: [string, string | undefined][] }) {
+  const present = items.filter(([, v]) => v !== undefined && v !== "");
+  if (present.length === 0) return null;
+  return (
+    <div className="def-meta-row">
+      {present.map(([k, v]) => (
+        <span key={k} className="def-meta-item">
+          <span className="def-meta-key mono">{k}</span>
+          <span className="def-meta-value mono">{v}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// maskHeaderValue redacts the value of Authorization-shaped headers
+// so a bearer token or API key in an MCP server registration's
+// headers map doesn't get displayed in plaintext.
+function maskHeaderValue(key: string, value: string): string {
+  const k = key.toLowerCase();
+  if (k === "authorization" || k.includes("token") || k.includes("api-key") || k.includes("apikey")) {
+    if (value.length <= 12) return "•".repeat(value.length);
+    return value.slice(0, 4) + "…" + "•".repeat(8);
+  }
+  return value;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2400,3 +2400,146 @@ pre {
   white-space: pre-wrap;
   word-break: break-all;
 }
+
+/* ---- v0.9.x AgentDetailPane sub-tabs (Transcript/Memory/Interrupts/Channels) ---- */
+.agent-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin: 0 0 8px 0;
+}
+.agent-tab {
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-soft);
+  padding: 6px 14px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.agent-tab:hover {
+  color: var(--fg);
+}
+.agent-tab-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.agent-tab-body {
+  padding: 8px 0;
+  overflow-y: auto;
+}
+.agent-tab-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--fg-soft);
+  font-family: var(--mono);
+  margin-bottom: 12px;
+}
+.agent-tab-meta-key {
+  color: var(--fg-soft);
+}
+.agent-tab-note {
+  font-size: 11px;
+  color: var(--fg-soft);
+  font-style: italic;
+  margin-top: 12px;
+}
+.agent-tab-note a {
+  color: var(--accent);
+}
+
+/* Memory tab: per-key entry rows */
+.memory-entry-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.memory-entry {
+  margin-bottom: 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: var(--bg-soft);
+}
+.memory-entry-key {
+  font-size: 12px;
+  color: var(--fg);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.memory-entry-value {
+  font-size: 11px;
+  margin: 0 0 4px 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.memory-entry-meta {
+  font-size: 10px;
+  color: var(--fg-soft);
+}
+
+/* Interrupts tab */
+.interrupt-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.interrupt-row {
+  margin-bottom: 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: var(--bg-soft);
+}
+.interrupt-header {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  margin-bottom: 6px;
+}
+.interrupt-kind {
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.interrupt-id {
+  font-size: 10px;
+  color: var(--fg-soft);
+  margin-left: auto;
+}
+.interrupt-question {
+  font-size: 13px;
+  margin-bottom: 4px;
+}
+.interrupt-answer {
+  font-size: 12px;
+  margin-bottom: 4px;
+  font-family: var(--mono);
+}
+
+/* Channels tab */
+.channel-cursor-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.channel-cursor-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.channel-cursor-name {
+  font-size: 13px;
+  font-weight: 500;
+}
+.channel-cursor-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1977,3 +1977,426 @@ pre {
   color: var(--fg);
   font-variant-numeric: tabular-nums;
 }
+
+/* ---- v0.9.x Introspection: Library + Channels + Lineage ---- */
+
+/* Generic monospace utility — many new components use className="mono"
+   for IDs / paths / cursor tokens. */
+.mono {
+  font-family: var(--mono);
+}
+.empty-state {
+  color: var(--fg-soft);
+  padding: 32px 16px;
+  text-align: center;
+}
+.error-banner {
+  background: rgba(255, 93, 104, 0.1);
+  border: 1px solid var(--failed);
+  color: var(--failed);
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin: 8px 0;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.error-banner-hint {
+  margin-top: 4px;
+  color: var(--fg-soft);
+  font-style: italic;
+}
+.loading-indicator {
+  color: var(--fg-soft);
+  font-size: 12px;
+  margin-left: 8px;
+}
+
+/* ---- Library page (top-level) ---- */
+.library-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.library-subtabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.library-subtab {
+  padding: 10px 16px;
+  color: var(--fg-soft);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  font-size: 13px;
+}
+.library-subtab:hover {
+  color: var(--fg);
+}
+.library-subtab-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+.library-subtab-count {
+  margin-left: 6px;
+  color: var(--fg-soft);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.library-content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* ---- LineagePanel: list-left, lineage-right ---- */
+.lineage-name-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  height: 100%;
+}
+.lineage-name-row {
+  border-bottom: 1px solid var(--border);
+}
+.lineage-name-row.lineage-name-selected {
+  background: rgba(91, 157, 255, 0.12);
+}
+.lineage-name-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+.lineage-name-button:hover {
+  background: var(--bg-soft);
+}
+.lineage-name-label {
+  font-weight: 500;
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.lineage-name-versions {
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.lineage-right {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  padding: 12px 16px;
+}
+.lineage-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.lineage-header h3 {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 16px;
+}
+
+/* ---- LineageTree: indented <ul> rows ---- */
+.lineage-tree,
+.lineage-tree ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.lineage-row {
+  margin: 0;
+}
+.lineage-row-line {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 4px;
+}
+.lineage-row.lineage-row-selected > .lineage-row-line {
+  background: rgba(91, 157, 255, 0.18);
+  border-radius: 3px;
+}
+.lineage-caret {
+  background: transparent;
+  border: 0;
+  color: var(--fg-soft);
+  cursor: pointer;
+  width: 16px;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+.lineage-caret:hover {
+  color: var(--fg);
+}
+.lineage-caret-empty {
+  cursor: default;
+  user-select: none;
+}
+.lineage-row-button {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 13px;
+}
+.lineage-version {
+  font-family: var(--mono);
+  font-weight: 500;
+}
+.lineage-defid {
+  font-size: 11px;
+  color: var(--fg-soft);
+  margin-left: 4px;
+}
+
+/* ---- Lineage detail (version body) ---- */
+.lineage-detail {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+.lineage-detail-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 12px;
+  margin-bottom: 12px;
+}
+.lineage-detail-meta {
+  color: var(--fg-soft);
+}
+.def-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.def-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.def-field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-soft);
+}
+.def-prompt {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-size: 12px;
+  white-space: pre-wrap;
+  max-height: 320px;
+  overflow-y: auto;
+  margin: 0;
+}
+.def-pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+.def-pill {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2px 8px;
+  font-size: 11px;
+}
+.def-meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.def-meta-item {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+  font-size: 12px;
+}
+.def-meta-key {
+  color: var(--fg-soft);
+  font-size: 11px;
+}
+.def-meta-value {
+  color: var(--fg);
+}
+
+/* ---- Definition chips (active / retired / bootstrapped) ---- */
+.def-chip {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  text-transform: lowercase;
+  letter-spacing: 0.03em;
+}
+.def-chip-active {
+  background: rgba(78, 201, 176, 0.15);
+  color: var(--completed);
+  border: 1px solid var(--completed);
+}
+.def-chip-retired {
+  background: rgba(176, 139, 208, 0.15);
+  color: var(--cancelled);
+  border: 1px solid var(--cancelled);
+}
+.def-chip-bootstrap {
+  background: rgba(240, 160, 64, 0.15);
+  color: var(--running);
+  border: 1px solid var(--running);
+}
+.def-chip-no-active {
+  background: rgba(255, 93, 104, 0.1);
+  color: var(--failed);
+  border: 1px solid var(--failed);
+}
+
+/* ---- Channels page ---- */
+.channels-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.channels-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.channels-count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-soft);
+}
+.filter-chips {
+  display: flex;
+  gap: 6px;
+}
+.filter-chip {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg-soft);
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.filter-chip:hover {
+  color: var(--fg);
+}
+.filter-chip-active {
+  background: rgba(91, 157, 255, 0.18);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.channels-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow-y: auto;
+}
+.channel-row {
+  border-bottom: 1px solid var(--border);
+}
+.channel-row.channel-row-selected {
+  background: rgba(91, 157, 255, 0.12);
+}
+.channel-row-button {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  padding: 10px 14px;
+  cursor: pointer;
+}
+.channel-row-button:hover {
+  background: var(--bg-soft);
+}
+.channel-name {
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.channel-meta {
+  display: flex;
+  gap: 8px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.channel-scope,
+.channel-semantic,
+.channel-count {
+  font-family: var(--mono);
+}
+.channel-detail {
+  padding: 16px;
+  overflow-y: auto;
+  height: 100%;
+}
+.channel-detail-header h3 {
+  margin: 0 0 6px 0;
+  font-family: var(--mono);
+}
+.channel-detail-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--fg-soft);
+  font-family: var(--mono);
+  margin-bottom: 16px;
+}
+.channel-detail-section h4 {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-soft);
+  margin: 12px 0 8px 0;
+}
+.channel-messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.channel-message {
+  margin-bottom: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px 10px;
+  background: var(--bg-soft);
+}
+.channel-message-meta {
+  font-size: 10px;
+  color: var(--fg-soft);
+  margin-bottom: 4px;
+}
+.channel-message-value {
+  font-size: 11px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}


### PR DESCRIPTION
## Summary

The v0.9.x substrate work (AgentDef / SkillDef / MCPServerDef) plus the Channel CRUD wire-API made the loomcycle store the **source of truth** for what's provisioned in the runtime. This PR makes that state visible in the Web UI.

- **New `/library` tab** with sub-tabs `Agents | Skills | MCP Servers`. Each sub-tab: list-left (declared names with active-version chip + version count) → lineage-right (indented `<ul>` tree showing parent_def_id chains with active/retired/bootstrapped chips). Click a version → see the body JSON rendered with kind-specific formatters (system_prompt+allowed_tools for Agents, body for Skills, transport+url+headers+discovered_tools for MCP Servers; Authorization-shaped headers masked).
- **New `/channels` tab**: filter chip-row (`all | _system/* | global | user | agent`) + list of operator-declared channels with aggregate stats (message_count, oldest/newest visible_at) + per-channel 20-message peek.
- **Per-agent sub-tabs** on the existing Agent detail pane: `Transcript | Memory | Interrupts | Channels`. Transcript is unchanged; the three new tabs are read-only scoped views — memory at `scope=agent / scope_id={agent.agent}`, interrupts on `run_id={agent.run_id}`, channels at `scope=agent` cursors for `{agent.agent}`. Sub-tab state in URL via `?tab=`.
- **Augment, don't replace** — operator-wide `/memory` and `/interrupts` tabs stay; the new agent sub-tabs are a focused alternative when you're looking at one agent.

Read-only across the board. Polling cadence: 10s for Library + Channels (matching the existing admin pages); the agent sub-tabs fetch on activation (no auto-refresh).

## Why

The substrate primitives are now the deployment surface. Without a visualization, the operator's answer to *"did `denngubsky/jobs-search-agent#69` boot-push the right agent definitions? Is `voice-applier` on the version I promoted? Did n8n self-register that MCP server?"* is "shell into the VM and SELECT from the substrate tables." This PR collapses that to one bearer-authed UI session.

## What

Four commits, each independently buildable + reviewable:

1. **`feat(store): ChannelListCursorsForScope for v0.9.x introspection`** — one new store method enumerating channel_cursors rows by (scope, scope_id). Implementations in SQLite + Postgres + a `ChannelListCursorsForScopeReturnsOnlyMatchingTuple` contract test pinning per-tuple isolation + ordering + scope-mismatch safety.

2. **`feat(http): bearer-authed library + agent-channels endpoints`** — four new GET endpoints:
   - `GET /v1/_agentdef/names`
   - `GET /v1/_skilldef/names`
   - `GET /v1/_mcpserverdef/names`
   - `GET /v1/agents/{name}/channels`
   
   Plus 7 regression tests covering happy paths (with seeded substrate rows), empty-store `[]` vs `null` invariant, bearer-required guard on all four routes, agent-name `validIdent` check.

3. **`feat(ui): Library tab + Channels tab`** — `LibraryView`, `LineagePanel`, `LineageTree`, `ChannelsView`, router + nav-bar entries, ~250 LOC of new CSS. The `LineagePanel` is substrate-agnostic — `kind` prop + `renderDefinition` callback so one component backs all three Library sub-tabs.

4. **`feat(ui): Agent detail pane sub-tabs — Memory / Interrupts / Channels`** — `AgentDetailTabs.tsx` with `useAgentTab` URL-state hook, `AgentTabStrip` component, and the three new tab components. `AgentDetailPane.tsx` patched to wire the strip above the existing view-toggle.

## Tested

- `go test ./...` — full pass.
- `cd web && npm run build` — clean tsc + vite. Bundle: 313kB → 320kB gzipped.
- Contract test `ChannelListCursorsForScopeReturnsOnlyMatchingTuple` pins per-(scope, scope_id) isolation + channel ASC ordering + scope-mismatch safety.
- 7 HTTP regression tests (`library_admin_test.go`) for the new endpoints.
- Manual binary smoke skipped (unrelated sqlite migrate I/O error on the smoke db path — does not reflect on this PR's changes).

## Notes for review

- **No SSE-driven auto-refresh** — polling stays at the existing 3–10s cadences. Aligns with the rest of the admin pages; SSE channels for substrate changes is a v0.10 follow-up.
- **No edit-from-UI** — pure read-only view. Create / fork / promote / retire still go through the substrate tools / admin endpoints. Edit-from-UI is a bigger surface (form validation, confirmation flows) and deserves its own RFC.
- **MCP Server header masking** — Authorization-shaped headers (key contains "authorization" / "token" / "api-key") are rendered as `xxx…••••••••`. Other headers pass through verbatim. Operators inspecting the registration's headers shouldn't see bearer tokens in plaintext.
- **Empty-store `[]` not `null`** — the three names endpoints explicitly coerce nil → `[]` so adapter consumers can `.length` without a null-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)