### PR TITLE
feat(lookup): canonical resolver — consolidate static-vs-dynamic load paths + prevent future drift

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -786,6 +786,17 @@ func main() {
 	} else if n > 0 {
 		log.Printf("mcp_server_defs: backfilled %d rows with content_sha256", n)
 	}
+	// v0.9.x system_prompt_base backfill — fills the field that PR #186's
+	// read-side normalizer derives at runtime. Closes the on-disk data
+	// gap for legacy rows; new rows persist the field directly via the
+	// write-side mergedDef.normalize() (agentdef.go). Idempotent: a
+	// second boot after a full backfill finds zero rows missing the
+	// field. Shares the same bfCtx — bounded boot wait.
+	if n, err := storeIface.BackfillAgentDefSystemPromptBase(bfCtx); err != nil {
+		log.Printf("agent_defs: backfill system_prompt_base partial — %v (rows updated before error: %d)", err, n)
+	} else if n > 0 {
+		log.Printf("agent_defs: backfilled %d rows with system_prompt_base", n)
+	}
 	bfCancel()
 
 	// Memory tool depends on the Store; wire the live backend in now

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -634,7 +634,7 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 			log.Printf("resolveSkillBodiesForRun: SkillDefGetActive(%q) failed: %v", skillName, err)
 			continue
 		}
-		var def skillDefOverlay
+		var def lookup.SubstrateSkillDef
 		if err := json.Unmarshal(row.Definition, &def); err != nil {
 			log.Printf("resolveSkillBodiesForRun: parse %s definition: %v", row.DefID, err)
 			continue
@@ -711,16 +711,6 @@ func (s *Server) emitSystemPromptEvent(
 	if err := s.store.AppendEvent(ctx, runID, "system_prompt", b); err != nil {
 		log.Printf("store: AppendEvent(system_prompt) failed for run %s: %v", runID, err)
 	}
-}
-
-// skillDefOverlay mirrors internal/tools/builtin.skillDefOverlay.
-// Re-declared here so the api/http package doesn't import
-// tools/builtin (which would invert the existing dependency
-// direction).
-type skillDefOverlay struct {
-	Body         string   `json:"body,omitempty"`
-	Description  string   `json:"description,omitempty"`
-	AllowedTools []string `json:"allowed_tools,omitempty"`
 }
 
 // historyPolicyForAgent returns the v0.8.7 Context.history scope policy

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -615,61 +615,44 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 	if len(agentDef.Skills) == 0 || s.store == nil {
 		return agentDef, prov
 	}
-	// Fast pre-check: any DB-active row for any skill name?
-	anyActive := false
-	activeBodies := make(map[string]string, len(agentDef.Skills))
+	// Resolve each skill via the canonical lookup chain (substrate →
+	// static). lookup.Skill returns Source="substrate" when a DB-active
+	// row resolved + Source="static" when falling back to the boot
+	// SkillsRoot bundle.
+	resolutions := make(map[string]lookup.SkillResolution, len(agentDef.Skills))
 	activeDefIDs := make(map[string]string, len(agentDef.Skills))
+	anySubstrate := false
 	for _, skillName := range agentDef.Skills {
-		row, err := s.store.SkillDefGetActive(ctx, skillName)
-		if err != nil {
-			var nf *store.ErrNotFound
-			if errors.As(err, &nf) {
-				continue
-			}
-			// Degrade THIS skill to static; keep checking the rest.
-			// A transient store hiccup on one skill must not drop DB
-			// overrides for the other skills in the same run — the
-			// doc-string promise of "fall back to baked static prompt
-			// rather than fail" is per-skill, not whole-agent.
-			log.Printf("resolveSkillBodiesForRun: SkillDefGetActive(%q) failed: %v", skillName, err)
+		sr, ok := lookup.Skill(ctx, s.store, s.skillSet, skillName)
+		if !ok {
 			continue
 		}
-		var def lookup.SubstrateSkillDef
-		if err := json.Unmarshal(row.Definition, &def); err != nil {
-			log.Printf("resolveSkillBodiesForRun: parse %s definition: %v", row.DefID, err)
-			continue
+		resolutions[skillName] = sr
+		if sr.Source == "substrate" {
+			activeDefIDs[skillName] = sr.DefID
+			anySubstrate = true
 		}
-		if strings.TrimSpace(def.Body) == "" {
-			continue
-		}
-		activeBodies[skillName] = def.Body
-		activeDefIDs[skillName] = row.DefID
-		anyActive = true
 	}
-	if !anyActive {
+	// Fast path: when no substrate-active row contributed, the
+	// boot-time bake of agentDef.SystemPrompt already reflects the
+	// static skill bodies — return unchanged.
+	if !anySubstrate {
 		return agentDef, prov
 	}
 	prov.SkillDefIDs = activeDefIDs
-	// Slow path: rebuild SystemPrompt from base + per-skill body.
+	// Slow path: rebuild SystemPrompt from base + per-skill body so
+	// substrate overrides land in place of the static bake.
 	rebuilt := agentDef
 	rebuilt.SystemPrompt = agentDef.SystemPromptBase
 	for _, skillName := range agentDef.Skills {
-		body, ok := activeBodies[skillName]
-		if !ok {
-			// No DB override — fall back to the static skill body.
-			if s.skillSet == nil {
-				continue
-			}
-			sk, has := s.skillSet.Get(skillName)
-			if !has {
-				continue
-			}
-			body = sk.Body
+		sr, ok := resolutions[skillName]
+		if !ok || strings.TrimSpace(sr.Body) == "" {
+			continue
 		}
 		if rebuilt.SystemPrompt != "" {
 			rebuilt.SystemPrompt += "\n\n---\n\n"
 		}
-		rebuilt.SystemPrompt += body
+		rebuilt.SystemPrompt += sr.Body
 	}
 	return rebuilt, prov
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/metrics"
 	"github.com/denn-gubsky/loomcycle/internal/pause"
@@ -450,126 +451,25 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 	return s.resolveAgentDef(def, agentName, userTier)
 }
 
-// lookupAgent returns the AgentDef for a registered agent name,
-// consulting static cfg.Agents first, then the v0.8.15 dynamic_agents
-// table, then the v0.8.22 substrate registry (agent_def_active +
-// agent_defs). Returns (zero AgentDef, false) when no source has it.
+// lookupAgent delegates to internal/lookup.Agent — the canonical
+// agent-name resolver consolidating the static / dynamic_agents /
+// substrate lookup chain + the normalizer chain. See the lookup
+// package doc for the rationale + the "future substrate" contract.
 //
-// Centralizing the lookup here is the antidote to the v0.8.15
-// regression where each entry point (RunOnce / handleRuns / handle
-// continuation) had its own inline lookup against cfg.Agents — at
-// least two of them missed the dynamic-agent fallback, so any agent
-// registered via mcp__loomcycle__register_agent was reachable from
-// some paths and "unknown" from others. Every code path that needs
-// to resolve an agent name to a def goes through this helper.
-//
-// TTL filtering happens server-side in store.DynamicAgentGet, so a
-// row whose expires_at has passed surfaces as derr (not found).
-// Malformed Definition JSON also falls through to (zero, false).
-//
-// Substrate fallback (v0.8.22+): agents registered via POST
-// /v1/_agentdef land in `agent_defs` + `agent_def_active`, NOT in
-// dynamic_agents. Without the third tier here those agents are
-// invisible to /v1/runs even though `list` / `verify` / `get`
-// confirm they exist — a "registered but unknown" paradox surfaced
-// by the JobEmber boot-sync (PR #69 downstream) which only writes
-// to the substrate. Same JSON shape (mergedDef <:> mutable subset
-// of config.AgentDef), so json.Unmarshal slots in cleanly.
+// Centralizing the lookup at the package boundary is the antidote
+// to the v0.8.15 regression where each entry point had its own
+// inline lookup, AND the v0.9.x lookups that silently skipped the
+// boot-time normalizer chain (PRs #184 + #186). Every code path
+// that needs an agent name → def goes through here.
 func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef, bool) {
-	if def, ok := s.cfg.Agents[name]; ok {
-		return def, true
-	}
+	// nil-store guard at the boundary so the lookup package can
+	// type-assert an interface receiver. The lookup package treats
+	// "no store" identically to "store didn't have the name" — both
+	// fall through to (zero, false).
 	if s.store == nil {
-		return config.AgentDef{}, false
+		return lookup.Agent(ctx, nil, s.cfg, name)
 	}
-	if row, err := s.store.DynamicAgentGet(ctx, name); err == nil {
-		var def config.AgentDef
-		if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
-			normalizeSystemPromptBase(&def)
-			return def, true
-		}
-	}
-	activeRow, err := s.store.AgentDefGetActive(ctx, name)
-	if err != nil {
-		return config.AgentDef{}, false
-	}
-	var sd substrateAgentDef
-	if uerr := json.Unmarshal(activeRow.Definition, &sd); uerr != nil {
-		return config.AgentDef{}, false
-	}
-	def := sd.toConfigDef()
-	normalizeSystemPromptBase(&def)
-	return def, true
-}
-
-// normalizeSystemPromptBase fills the SystemPromptBase invariant for
-// runtime-resolved agents. resolveSkills (config-load) sets this for
-// statically yaml-defined agents — it's the pre-skill-bake copy of
-// SystemPrompt used by resolveSkillBodiesForRun to rebuild the
-// effective prompt when DB-active SkillDef rows are present. Agents
-// resolved at runtime from dynamic_agents or the v0.8.22 substrate
-// never go through resolveSkills, so SystemPromptBase stays empty
-// even though their SystemPrompt IS the base (no skill body has been
-// pre-appended). Without this normalisation, resolveSkillBodiesForRun's
-// rebuild starts from "" and concatenates the skill body — replacing
-// the agent's actual instructions entirely. Symptom: an agent like
-// ats-filter that declares skills: ["position-relevance-filtering"]
-// loses its own body at run time, with only the skill text reaching
-// the model — the agent never sees its "call mcp__jobs__getAgentContext
-// first" instructions.
-func normalizeSystemPromptBase(def *config.AgentDef) {
-	if def.SystemPromptBase == "" {
-		def.SystemPromptBase = def.SystemPrompt
-	}
-}
-
-// substrateAgentDef mirrors the JSON shape `AgentDef.create` persists
-// in agent_defs.definition (snake_case via the json struct tags on
-// mergedDef in internal/tools/builtin/agentdef.go). Unmarshalling
-// substrate JSON directly into config.AgentDef silently drops every
-// field because config.AgentDef carries only yaml tags — json.Unmarshal
-// then matches Go field names ("SystemPrompt", "AllowedTools", …) and
-// none of the snake_case keys land. This local struct + toConfigDef
-// adapter is the seam that converts the substrate's JSON shape to
-// the in-process config.AgentDef the rest of the runtime expects.
-//
-// Kept in sync with mergedDef (same field set, same json tags). The
-// TestLookupAgent_FallsThroughToSubstrate test pins a representative
-// subset — a future field added to mergedDef without a matching
-// addition here would silently drop on resolve, mirroring the bug
-// this struct exists to fix.
-type substrateAgentDef struct {
-	Provider         string                            `json:"provider,omitempty"`
-	Model            string                            `json:"model,omitempty"`
-	Tier             string                            `json:"tier,omitempty"`
-	Effort           string                            `json:"effort,omitempty"`
-	MaxTokens        int                               `json:"max_tokens,omitempty"`
-	MaxIterations    int                               `json:"max_iterations,omitempty"`
-	SystemPrompt     string                            `json:"system_prompt,omitempty"`
-	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
-	Skills           []string                          `json:"skills,omitempty"`
-	Providers        []string                          `json:"providers,omitempty"`
-	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
-	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
-	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
-}
-
-func (s substrateAgentDef) toConfigDef() config.AgentDef {
-	return config.AgentDef{
-		Provider:         s.Provider,
-		Model:            s.Model,
-		Tier:             s.Tier,
-		Effort:           s.Effort,
-		MaxTokens:        s.MaxTokens,
-		MaxIterations:    s.MaxIterations,
-		SystemPrompt:     s.SystemPrompt,
-		AllowedTools:     s.AllowedTools,
-		Skills:           s.Skills,
-		Providers:        s.Providers,
-		Models:           s.Models,
-		MemoryScopes:     s.MemoryScopes,
-		MemoryQuotaBytes: s.MemoryQuotaBytes,
-	}
+	return lookup.Agent(ctx, s.store, s.cfg, name)
 }
 
 // resolveAgentDef mirrors resolveAgent but takes a caller-supplied

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -1873,7 +1874,7 @@ func TestLookupAgent_SystemPromptBaseSetFromDynamic(t *testing.T) {
 // regress the static-config invariant.
 func TestLookupAgent_PreservesNonEmptySystemPromptBase(t *testing.T) {
 	d := &config.AgentDef{SystemPrompt: "rebuilt prompt", SystemPromptBase: "original base"}
-	normalizeSystemPromptBase(d)
+	lookup.NormalizeAgentDef(d)
 	if d.SystemPromptBase != "original base" {
 		t.Errorf("SystemPromptBase overwritten: got %q, want %q", d.SystemPromptBase, "original base")
 	}

--- a/internal/lookup/README.md
+++ b/internal/lookup/README.md
@@ -1,0 +1,79 @@
+# `internal/lookup`
+
+The canonical seam between loomcycle's static-yaml era and its v0.8+ dynamic substrate.
+
+## Why this package exists
+
+Loomcycle pre-v0.8 had ONE load path for `config.AgentDef`:
+
+```
+yaml → config.LoadConfig → resolveSkills / resolveAgent → cfg.Agents
+```
+
+`cfg.Agents` was the single source of truth, and `resolveSkills` applied a chain of normalizations at boot (SystemPromptBase capture, allowed-tools widening check, skill body baking).
+
+v0.8.15 added `dynamic_agents` (RegisterAgent path). v0.8.22 added the AgentDef substrate (`agent_defs` + `agent_def_active`). Both new READ paths skipped the normalizer chain. The result was a class of bugs we paid for one PR at a time:
+
+| PR | Symptom |
+|----|---------|
+| #184 | `/v1/runs` returns "unknown agent" for substrate-registered names — `lookupAgent` only consulted `cfg.Agents` + `dynamic_agents`. The fix added the third tier AND a `substrateAgentDef` adapter (because `config.AgentDef` has yaml-only tags; substrate persistence uses snake_case json — every field silently dropped on `json.Unmarshal` into `config.AgentDef`). |
+| #186 | Substrate-registered agents lost their system prompt at every skill-enabled run. `resolveSkillBodiesForRun` rebuilds `SystemPrompt = SystemPromptBase + skill bodies`, and the dynamic load path left `SystemPromptBase` empty. |
+
+This package consolidates the lookup chain + the normalizer chain + the adapter into one canonical place. The runtime contract: **a substrate-pushed AgentDef MUST produce a `config.AgentDef` byte-equivalent to the same content loaded from yaml.** Verified by `TestAgent_EquivalenceYamlVsSubstrate`.
+
+## When to use it
+
+Every code path that needs to resolve an agent / skill / MCP server NAME to its effective runtime def must go through this package:
+
+```go
+def, ok := lookup.Agent(ctx, s.store, s.cfg, name)
+sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, name)
+spec, ok := lookup.MCPServer(s.cfg, dynRegistry, name)
+```
+
+Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` etc.) — a future field added to one shape without the other fails CI.
+
+## Architectural pattern for new substrates
+
+When adding a dynamic substrate for a domain type:
+
+### 1. Read path walks the same normalizer chain as boot-time
+
+If `resolveSkills` (or the equivalent boot-time helper for your domain) sets a derived field for the static path, the dynamic resolver MUST replicate it. Add a normalizer to this package (`NormalizeAgentDef`-style) and call it on every dynamic load.
+
+### 2. Persistence uses explicit JSON tags
+
+Unmarshal targets a struct WITH json tags (the `Substrate*` adapters in this package), then convert to the runtime consumer type via a single named `ToConfigDef` method. NEVER `json.Unmarshal` directly into a yaml-only struct — Go silently no-ops on every field, and you get the bug PR #184 fixed.
+
+### 3. Equivalence tests pin the contract
+
+Add a test that loads the SAME content via yaml AND via the substrate, then asserts field-by-field equivalence. The test is the canonical "did I forget to replicate a normalizer?" check.
+
+### 4. Drift tests prevent future field-addition gaps
+
+Reflection-based audit pinning every json tag in the persistence shape against an explicit `want` set. Adding a field to the substrate's `mergedDef` (or equivalent) without adding it here AND updating the `want` set fails the test — forcing a conscious decision.
+
+## Belt-and-suspenders normalization
+
+The package implements normalization at TWO sites for the `system_prompt_base` invariant:
+
+| Site | When | Purpose |
+|------|------|---------|
+| `NormalizeAgentDef` (read-side) | Every `lookup.Agent` call | Runtime correctness floor — works on legacy rows that pre-date the write-side fix. |
+| `mergedDef.normalize()` in `agentdef.go` (write-side) | Every `AgentDef.create / fork / bootstrapStatic` | On-disk correctness floor — new rows persist the right shape. |
+| `BackfillAgentDefSystemPromptBase` (one-shot at boot) | Once per process boot | Migrates legacy rows so the on-disk data eventually converges. |
+
+The read-side normalizer is the load-bearing one — production runtime correctness depends on it, regardless of what's on disk. The write-side normalizer + backfill close the on-disk data gap so snapshot/restore round-trips are clean.
+
+## What this package does NOT do
+
+- **Mutate.** Read-only by design. Writes go through the substrate tools (`AgentDef.create` / `SkillDef.create` / `MCPServerDef.create`).
+- **Apply policy.** Allowed-tools widening checks, scope checks, etc. stay at the substrate tool layer (write-side) and the runtime dispatcher (read-side). The resolver is a pure-data shape converter.
+- **Cache.** Each call hits the store. If perf becomes a concern, add caching here behind the same interface; consumers don't need to change.
+
+## Related references
+
+- PR #184 (lookup fallthrough + JSON adapter): the symptomatic fix.
+- PR #186 (read-side normalizer): the symptomatic fix.
+- `internal/config/config.go:resolveSkills` — the boot-time normalizer this package mirrors.
+- `internal/tools/builtin/agentdef.go:mergedDef` — the substrate persistence shape; `SubstrateAgentDef` is its public mirror.

--- a/internal/lookup/README.md
+++ b/internal/lookup/README.md
@@ -23,7 +23,7 @@ This package consolidates the lookup chain + the normalizer chain + the adapter 
 
 ## When to use it
 
-Every code path that needs to resolve an agent / skill / MCP server NAME to its effective runtime def must go through this package:
+Every code path that needs to resolve an agent / skill / MCP server NAME to its effective runtime def should go through this package:
 
 ```go
 def, ok := lookup.Agent(ctx, s.store, s.cfg, name)
@@ -31,7 +31,15 @@ sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, name)
 spec, ok := lookup.MCPServer(s.cfg, dynRegistry, name)
 ```
 
-Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` etc.) — a future field added to one shape without the other fails CI.
+Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` + `TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef`) — a future field added to one shape without the other fails CI.
+
+### Coverage matrix
+
+| Resolver | Production callers | Notes |
+|----------|-------------------|-------|
+| `lookup.Agent` | `api/http/server.go:lookupAgent` (covers `/v1/runs`, `/v1/messages`, sub-agent spawn). | Drives the load-bearing static-vs-substrate equalization. |
+| `lookup.Skill` | `api/http/server.go:resolveSkillBodiesForRun` (slow-path bake). | Logs non-NotFound substrate errors as a side effect — operator gets a signal when a transient store hiccup forces a substrate→static fallback for one skill. |
+| `lookup.MCPServer` | `/ui/library/mcp-servers` GET endpoint (when added; HTTP-only call sites). | **CANNOT** replace `cmd/loomcycle/main.go`'s pool build callback — that callback needs `Command/Args/Env/PoolSize` for stdio, which `MCPServerSpec` deliberately omits because the substrate refuses stdio at the create boundary. The stdio path stays inline-in-main.go by design. |
 
 ## Architectural pattern for new substrates
 

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -1,0 +1,200 @@
+// Package lookup is the canonical seam for resolving an agent / skill
+// / MCP server NAME to its effective runtime definition. It walks the
+// multi-tier lookup chain (static cfg → dynamic_agents → substrate
+// active overlay) and applies the same normalizer chain the static
+// boot-time config-load path applies, so a name resolved at runtime
+// returns a byte-equivalent definition to one resolved at boot.
+//
+// # Why this package exists
+//
+// Loomcycle's pre-v0.8 substrate-era had ONE load path:
+//
+//	yaml → config.LoadConfig → resolveSkills / resolveAgent → cfg.Agents
+//
+// v0.8.15 added `dynamic_agents` and v0.8.22 added the AgentDef
+// substrate (`agent_defs` + `agent_def_active`). Both new read paths
+// skipped the boot-time normalizers — symptom: PR #186 ("set
+// SystemPromptBase for runtime-resolved agents") had to bolt on
+// `normalizeSystemPromptBase` at the read site after agents started
+// silently losing their instructions on every skill-enabled run. The
+// JSON-tag mismatch in PR #184 was a separate face of the same drift:
+// `config.AgentDef` carries yaml-only tags, but the substrate persists
+// snake_case JSON via `mergedDef` — every field silently dropped on
+// unmarshal until a `substrateAgentDef` adapter was added.
+//
+// This package consolidates the lookup chain + normalizer chain + the
+// adapter into one place. The runtime contract: a substrate-pushed
+// AgentDef MUST produce a config.AgentDef byte-equivalent to the same
+// content loaded from yaml. The equivalence is verified by the test
+// in agent_equivalence_test.go.
+//
+// # Architectural pattern for future substrates
+//
+// When adding a dynamic substrate for a domain type:
+//
+//  1. The read path MUST walk the same normalizer chain as the
+//     boot-time load. If `resolveSkills` (or analogue) sets a
+//     derived field for the static path, your read path must set
+//     it too. Add a normalizer to this package.
+//  2. The persistence shape uses explicit JSON tags. Unmarshal
+//     targets a struct WITH JSON tags, then convert to the runtime
+//     consumer type via a single named adapter. NEVER `json.Unmarshal`
+//     into a yaml-only struct (silently no-ops; the bug PR #184
+//     fixed for AgentDef).
+//  3. Add an equivalence test: yaml-load vs substrate-load of the
+//     same content must produce byte-equivalent runtime defs.
+//  4. Add a drift test: reflection-based audit pinning every field
+//     in the runtime consumer struct has a corresponding tag in the
+//     persistence-shape adapter, so a future field added to one
+//     without the other fails the test instead of silently dropping.
+package lookup
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// AgentStore is the subset of store.Store the agent resolver uses.
+// Declared here so tests + callers can mock without depending on the
+// full store interface.
+type AgentStore interface {
+	DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error)
+	AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error)
+}
+
+// Agent resolves an agent NAME to its effective config.AgentDef by
+// walking the lookup chain in precedence order:
+//
+//  1. static cfg.Agents (yaml-defined, pre-normalized at boot)
+//  2. dynamic_agents table (v0.8.15 RegisterAgent path)
+//  3. agent_def_active + agent_defs (v0.8.22 substrate path)
+//
+// Returns (zero, false) when no source has the name. Malformed
+// persistence JSON also returns (zero, false) — defensive against
+// future-field churn or hand-edited rows.
+//
+// Normalization: every dynamic path applies NormalizeAgentDef before
+// returning, equalizing the runtime shape with what config-load
+// would have produced for the same yaml content. Static cfg.Agents
+// entries already went through config-load's resolveSkills /
+// resolveAgent, so the cfg path returns directly without re-
+// normalizing (avoids double-baking skill bodies into SystemPrompt).
+func Agent(ctx context.Context, s AgentStore, cfg *config.Config, name string) (config.AgentDef, bool) {
+	if cfg != nil {
+		if def, ok := cfg.Agents[name]; ok {
+			return def, true
+		}
+	}
+	if s == nil {
+		return config.AgentDef{}, false
+	}
+	// Tier 2 — dynamic_agents (RegisterAgent path). Persistence uses
+	// config.AgentDef's JSON tags directly; safe to unmarshal into
+	// config.AgentDef.
+	if row, err := s.DynamicAgentGet(ctx, name); err == nil {
+		var def config.AgentDef
+		if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
+			NormalizeAgentDef(&def)
+			return def, true
+		}
+	}
+	// Tier 3 — substrate (agent_def_active overlay → agent_defs row).
+	// Persistence uses mergedDef's snake_case JSON tags; must unmarshal
+	// into a json-tagged adapter then convert.
+	activeRow, err := s.AgentDefGetActive(ctx, name)
+	if err != nil {
+		return config.AgentDef{}, false
+	}
+	var sd SubstrateAgentDef
+	if uerr := json.Unmarshal(activeRow.Definition, &sd); uerr != nil {
+		return config.AgentDef{}, false
+	}
+	def := sd.ToConfigDef()
+	NormalizeAgentDef(&def)
+	return def, true
+}
+
+// SubstrateAgentDef mirrors the JSON shape `AgentDef.create` persists
+// in `agent_defs.definition` (snake_case via the json tags on
+// `mergedDef` in internal/tools/builtin/agentdef.go). The runtime
+// consumer (`config.AgentDef`) carries ONLY yaml tags — unmarshalling
+// substrate JSON directly into it silently drops every field because
+// json.Unmarshal then matches against Go field names instead.
+//
+// This adapter + ToConfigDef is the seam. Kept in sync with
+// `mergedDef`; TestAgentDef_DriftDetection in drift_test.go pins the
+// field set so a future field added to mergedDef without a matching
+// addition here fails the build.
+type SubstrateAgentDef struct {
+	Provider      string `json:"provider,omitempty"`
+	Model         string `json:"model,omitempty"`
+	Tier          string `json:"tier,omitempty"`
+	Effort        string `json:"effort,omitempty"`
+	MaxTokens     int    `json:"max_tokens,omitempty"`
+	MaxIterations int    `json:"max_iterations,omitempty"`
+	SystemPrompt  string `json:"system_prompt,omitempty"`
+	// SystemPromptBase carries the pre-skill-bake snapshot when the
+	// substrate write path (commit 3 of this PR) persisted it.
+	// Read-side normalizers fall back to SystemPrompt when this is
+	// empty (legacy rows that pre-date the write-side fix).
+	SystemPromptBase string                            `json:"system_prompt_base,omitempty"`
+	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
+	Skills           []string                          `json:"skills,omitempty"`
+	Providers        []string                          `json:"providers,omitempty"`
+	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
+	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
+	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+}
+
+// ToConfigDef projects the substrate JSON shape onto config.AgentDef
+// for the runtime to consume. Pure data shuffling; no normalization
+// happens here (NormalizeAgentDef is called afterward by Agent).
+func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
+	return config.AgentDef{
+		Provider:         s.Provider,
+		Model:            s.Model,
+		Tier:             s.Tier,
+		Effort:           s.Effort,
+		MaxTokens:        s.MaxTokens,
+		MaxIterations:    s.MaxIterations,
+		SystemPrompt:     s.SystemPrompt,
+		SystemPromptBase: s.SystemPromptBase,
+		AllowedTools:     s.AllowedTools,
+		Skills:           s.Skills,
+		Providers:        s.Providers,
+		Models:           s.Models,
+		MemoryScopes:     s.MemoryScopes,
+		MemoryQuotaBytes: s.MemoryQuotaBytes,
+	}
+}
+
+// NormalizeAgentDef applies the boot-time normalization chain that
+// `config.LoadConfig` / `resolveSkills` applied to statically-yaml-
+// defined agents. Called by Agent() on every dynamic-load path before
+// returning, so substrate-resolved agents reach the runtime with the
+// same effective shape as yaml-resolved ones.
+//
+// Steps (each is idempotent under the static cfg path — re-applying
+// them to a static cfg.AgentDef is a no-op):
+//
+//  1. SystemPromptBase invariant — fills SystemPromptBase from
+//     SystemPrompt when empty. `resolveSkills` sets this at boot for
+//     any yaml agent that lists skills, capturing the pre-skill-bake
+//     snapshot for resolveSkillBodiesForRun to rebuild from. Agents
+//     resolved at runtime never go through resolveSkills, so without
+//     this normalization the rebuild starts from "" and concatenates
+//     the skill body — silently replacing the agent's instructions.
+//     See PR #186 for the production bug + the symptom.
+//
+// Future normalizers go here. Each MUST be idempotent under the
+// static cfg path (so re-applying to an already-normalized agent is a
+// no-op) and MUST mirror exactly what the equivalent boot-time helper
+// does for yaml-defined agents.
+func NormalizeAgentDef(def *config.AgentDef) {
+	if def.SystemPromptBase == "" {
+		def.SystemPromptBase = def.SystemPrompt
+	}
+}

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -177,19 +177,17 @@ func TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead(t *testing.T) {
 	}
 }
 
-// TestAgent_DriftDetection is the reflection-based audit pinning the
-// architectural invariant: every json-tagged field in the substrate's
-// persistence shape (mergedDef in internal/tools/builtin/agentdef.go,
-// reflected here via SubstrateAgentDef which is its public mirror)
-// must have a corresponding json tag in SubstrateAgentDef so the
-// unmarshal slot exists. A future field added to mergedDef without
-// being added here would fail this test BEFORE it ships, catching
-// the bug PR #184 fixed.
+// TestAgent_DriftDetection pins the SubstrateAgentDef field set
+// against an explicit `want` enumeration. A field added to or removed
+// from SubstrateAgentDef without updating this enumeration fails.
 //
-// This test is intentionally fragile against ADDITIONS to
-// SubstrateAgentDef — when growing the substrate persistence shape,
-// the developer MUST update this enumeration. That coupling is the
-// point: it forces a conscious decision rather than silent drift.
+// This test catches one direction of drift: changes to
+// SubstrateAgentDef. The complementary direction — a field added to
+// mergedDef in internal/tools/builtin/agentdef.go but accidentally
+// NOT mirrored in SubstrateAgentDef — is covered by
+// TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef in the
+// builtin package, where mergedDef is in-scope for reflection. Both
+// tests are needed to close the full drift loop.
 func TestAgent_DriftDetection(t *testing.T) {
 	// Expected json tags on SubstrateAgentDef as of v0.9.x. Keep in
 	// sync with mergedDef + SubstrateAgentDef field definitions.

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -1,0 +1,246 @@
+package lookup_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// stubStore is a minimal in-memory AgentStore for the equivalence
+// tests. Sufficient for unit-level coverage of the resolver chain;
+// the integration tests in api/http/server_test.go exercise the
+// real store-backed paths.
+type stubStore struct {
+	dyn  map[string]store.DynamicAgent
+	defs map[string]store.AgentDefRow // keyed by name (active)
+}
+
+func (s *stubStore) DynamicAgentGet(_ context.Context, name string) (store.DynamicAgent, error) {
+	if row, ok := s.dyn[name]; ok {
+		return row, nil
+	}
+	return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
+}
+
+func (s *stubStore) AgentDefGetActive(_ context.Context, name string) (store.AgentDefRow, error) {
+	if row, ok := s.defs[name]; ok {
+		return row, nil
+	}
+	return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
+}
+
+// TestAgent_EquivalenceYamlVsSubstrate pins the architectural contract:
+// loading the same content via the yaml path (cfg.Agents) vs the
+// substrate path (agent_defs row, decoded by lookup.Agent) MUST
+// produce byte-equivalent config.AgentDef structs after normalization.
+//
+// This catches the entire class of drift bugs PRs #184 + #186 fixed:
+// any future field added to config.AgentDef that needs a static-path
+// normalization but not a dynamic one — or vice versa — fails this
+// test. The two paths must stay in lockstep.
+func TestAgent_EquivalenceYamlVsSubstrate(t *testing.T) {
+	// Seed agent — representative of a realistic content shape:
+	// non-trivial system_prompt, allowed_tools, skills, model+tier.
+	yamlAgent := config.AgentDef{
+		Provider:         "anthropic",
+		Model:            "claude-sonnet-4-6",
+		Tier:             "smart",
+		MaxTokens:        4096,
+		MaxIterations:    32,
+		SystemPrompt:     "You are a careful researcher. Ask questions before acting.",
+		SystemPromptBase: "You are a careful researcher. Ask questions before acting.",
+		AllowedTools:     []string{"Read", "Memory", "Channel"},
+		Skills:           []string{"voice-applier"},
+		MemoryScopes:     []string{"agent", "user"},
+		MemoryQuotaBytes: 65536,
+	}
+	// Simulate boot-time normalization on the yaml side: resolveSkills
+	// would set SystemPromptBase = SystemPrompt for an agent with
+	// skills. The fixture already reflects that.
+
+	// Persist via the substrate shape (snake_case json tags via
+	// lookup.SubstrateAgentDef). This mirrors what AgentDef.create
+	// stores after the write-side normalize() of commit 3.
+	substrateShape := lookup.SubstrateAgentDef{
+		Provider:         yamlAgent.Provider,
+		Model:            yamlAgent.Model,
+		Tier:             yamlAgent.Tier,
+		MaxTokens:        yamlAgent.MaxTokens,
+		MaxIterations:    yamlAgent.MaxIterations,
+		SystemPrompt:     yamlAgent.SystemPrompt,
+		SystemPromptBase: yamlAgent.SystemPromptBase,
+		AllowedTools:     yamlAgent.AllowedTools,
+		Skills:           yamlAgent.Skills,
+		MemoryScopes:     yamlAgent.MemoryScopes,
+		MemoryQuotaBytes: yamlAgent.MemoryQuotaBytes,
+	}
+	defJSON, err := json.Marshal(substrateShape)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// Resolve via the dynamic-substrate path.
+	ss := &stubStore{
+		dyn: map[string]store.DynamicAgent{},
+		defs: map[string]store.AgentDefRow{
+			"researcher": {
+				DefID:      "def_researcher_v1",
+				Name:       "researcher",
+				Version:    1,
+				Definition: defJSON,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "researcher")
+	if !ok {
+		t.Fatal("resolver returned !ok")
+	}
+
+	// Equivalence: every field that crosses the wire must arrive intact.
+	// (HistoryScope and other yaml-only ACL fields stay at their zero
+	// value on the substrate path — that's by design; the substrate's
+	// mergedDef deliberately excludes them so a fork can't widen
+	// operator-policy fields.)
+	if resolved.Provider != yamlAgent.Provider ||
+		resolved.Model != yamlAgent.Model ||
+		resolved.Tier != yamlAgent.Tier ||
+		resolved.MaxTokens != yamlAgent.MaxTokens ||
+		resolved.MaxIterations != yamlAgent.MaxIterations {
+		t.Errorf("scalar mismatch:\n  yaml: %+v\n  resolved: %+v", yamlAgent, resolved)
+	}
+	if resolved.SystemPrompt != yamlAgent.SystemPrompt {
+		t.Errorf("SystemPrompt mismatch:\n  yaml: %q\n  resolved: %q", yamlAgent.SystemPrompt, resolved.SystemPrompt)
+	}
+	if resolved.SystemPromptBase != yamlAgent.SystemPromptBase {
+		t.Errorf("SystemPromptBase mismatch:\n  yaml: %q\n  resolved: %q", yamlAgent.SystemPromptBase, resolved.SystemPromptBase)
+	}
+	if !reflect.DeepEqual(resolved.AllowedTools, yamlAgent.AllowedTools) {
+		t.Errorf("AllowedTools mismatch:\n  yaml: %v\n  resolved: %v", yamlAgent.AllowedTools, resolved.AllowedTools)
+	}
+	if !reflect.DeepEqual(resolved.Skills, yamlAgent.Skills) {
+		t.Errorf("Skills mismatch:\n  yaml: %v\n  resolved: %v", yamlAgent.Skills, resolved.Skills)
+	}
+	if !reflect.DeepEqual(resolved.MemoryScopes, yamlAgent.MemoryScopes) {
+		t.Errorf("MemoryScopes mismatch:\n  yaml: %v\n  resolved: %v", yamlAgent.MemoryScopes, resolved.MemoryScopes)
+	}
+	if resolved.MemoryQuotaBytes != yamlAgent.MemoryQuotaBytes {
+		t.Errorf("MemoryQuotaBytes mismatch:\n  yaml: %d\n  resolved: %d", yamlAgent.MemoryQuotaBytes, resolved.MemoryQuotaBytes)
+	}
+}
+
+// TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead verifies the
+// belt-and-suspenders posture: a row persisted BEFORE the
+// commit-3 write-side normalize() (i.e., system_prompt_base missing
+// from the JSON) is still served correctly because the read-side
+// NormalizeAgentDef fills it. This is the production scenario the
+// SystemPromptBase backfill exists to close — but it must also
+// work on a row that hasn't been backfilled yet.
+func TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead(t *testing.T) {
+	// Persist WITHOUT system_prompt_base (legacy shape).
+	defJSON, err := json.Marshal(map[string]any{
+		"system_prompt": "be helpful",
+		"allowed_tools": []string{"Read"},
+		"skills":        []string{"summariser"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := &stubStore{
+		dyn: map[string]store.DynamicAgent{},
+		defs: map[string]store.AgentDefRow{
+			"legacy": {
+				DefID:      "def_legacy_v1",
+				Name:       "legacy",
+				Version:    1,
+				Definition: defJSON,
+				CreatedAt:  time.Now(),
+			},
+		},
+	}
+	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "legacy")
+	if !ok {
+		t.Fatal("resolver returned !ok")
+	}
+	if resolved.SystemPromptBase != "be helpful" {
+		t.Errorf("SystemPromptBase not filled by read-side normalizer: got %q, want %q",
+			resolved.SystemPromptBase, "be helpful")
+	}
+	if resolved.SystemPrompt != "be helpful" {
+		t.Errorf("SystemPrompt unexpectedly mutated: %q", resolved.SystemPrompt)
+	}
+}
+
+// TestAgent_DriftDetection is the reflection-based audit pinning the
+// architectural invariant: every json-tagged field in the substrate's
+// persistence shape (mergedDef in internal/tools/builtin/agentdef.go,
+// reflected here via SubstrateAgentDef which is its public mirror)
+// must have a corresponding json tag in SubstrateAgentDef so the
+// unmarshal slot exists. A future field added to mergedDef without
+// being added here would fail this test BEFORE it ships, catching
+// the bug PR #184 fixed.
+//
+// This test is intentionally fragile against ADDITIONS to
+// SubstrateAgentDef — when growing the substrate persistence shape,
+// the developer MUST update this enumeration. That coupling is the
+// point: it forces a conscious decision rather than silent drift.
+func TestAgent_DriftDetection(t *testing.T) {
+	// Expected json tags on SubstrateAgentDef as of v0.9.x. Keep in
+	// sync with mergedDef + SubstrateAgentDef field definitions.
+	// Adding a field to either WITHOUT adding it here is the bug
+	// this test is designed to catch.
+	want := map[string]bool{
+		"provider":           true,
+		"model":              true,
+		"tier":               true,
+		"effort":             true,
+		"max_tokens":         true,
+		"max_iterations":     true,
+		"system_prompt":      true,
+		"system_prompt_base": true,
+		"allowed_tools":      true,
+		"skills":             true,
+		"providers":          true,
+		"models":             true,
+		"memory_scopes":      true,
+		"memory_quota_bytes": true,
+	}
+	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateAgentDef{}))
+	for tag := range want {
+		if !have[tag] {
+			t.Errorf("SubstrateAgentDef missing json tag %q (must mirror mergedDef in internal/tools/builtin/agentdef.go)", tag)
+		}
+	}
+	for tag := range have {
+		if !want[tag] {
+			t.Errorf("SubstrateAgentDef has json tag %q not in expected set — if this field was deliberately added, update the `want` map in this test to confirm the addition was conscious", tag)
+		}
+	}
+}
+
+// jsonTagsOf walks a struct's exported fields and returns the set of
+// json tag names (the part before any "," for `,omitempty` etc.).
+func jsonTagsOf(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		// Strip ",omitempty" and similar.
+		for j, c := range tag {
+			if c == ',' {
+				tag = tag[:j]
+				break
+			}
+		}
+		out[tag] = true
+	}
+	return out
+}

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -1,0 +1,99 @@
+package lookup
+
+import (
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// MCPDynamicRegistry is the subset of mcp.DynamicRegistry the
+// MCPServer resolver consults — broken out so internal/lookup
+// doesn't import internal/tools/mcp (which would invert the existing
+// dependency direction; tools/mcp is consumed by everything else).
+type MCPDynamicRegistry interface {
+	Get(name string) (MCPServerSpec, bool)
+}
+
+// MCPServerSpec is the runtime spec for an MCP server registration.
+// Mirrors mcp.DynamicMCPServerSpec but lives in this package so the
+// lookup chain can return a uniform shape regardless of whether the
+// name came from the static yaml or the dynamic registry.
+//
+// (The static cfg.MCPServer has additional yaml-only fields like
+// `command`, `args`, `env`, `pool_size` for stdio servers; those
+// don't apply to dynamically-registered http / streamable-http
+// servers — the substrate refuses stdio at the create boundary.)
+type MCPServerSpec struct {
+	Transport string
+	URL       string
+	Headers   map[string]string
+	// Source — "static" or "dynamic". Useful for log lines + the
+	// /ui/library/mcp-servers page's badge.
+	Source string
+}
+
+// MCPServer resolves an MCP server NAME to its effective runtime
+// spec by walking the lookup chain in precedence order:
+//
+//  1. static cfg.MCPServers (yaml-defined; ground truth).
+//  2. dynamic registry (v0.9.x substrate, rehydrated from
+//     mcp_server_defs at boot + mutated by promote / retire).
+//
+// Returns (zero, false) when neither source has the name.
+//
+// Yaml takes precedence on name collisions: the substrate tool refuses
+// `create` over a yaml-occupied name, and the boot-time loader skips
+// dynamic rows whose name collides with yaml. This resolver enforces
+// the same order at the lookup boundary so future refactors that add
+// a third tier can't accidentally invert it.
+//
+// The current pool build callback in cmd/loomcycle/main.go is the
+// primary consumer; the /ui/library/mcp-servers page also calls this
+// through the bearer-authed GET endpoint to render the source badge.
+func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, name string) (MCPServerSpec, bool) {
+	if cfg != nil {
+		if srv, ok := cfg.MCPServers[name]; ok {
+			return MCPServerSpec{
+				Transport: srv.Transport,
+				URL:       srv.URL,
+				Headers:   srv.Headers,
+				Source:    "static",
+			}, true
+		}
+	}
+	if dyn != nil {
+		if spec, ok := dyn.Get(name); ok {
+			spec.Source = "dynamic"
+			return spec, true
+		}
+	}
+	return MCPServerSpec{}, false
+}
+
+// SubstrateMCPServer mirrors the JSON shape `MCPServerDef.create`
+// persists in `mcp_server_defs.definition` (snake_case json tags via
+// the `mcpServerOverlay` struct in
+// internal/tools/builtin/mcpserverdef.go).
+//
+// Symmetric across marshal + unmarshal — both ends use json tags, so
+// the "silent unmarshal drop" bug PR #184 exposed for AgentDef CAN'T
+// fire here. Defined here for the same three reasons SubstrateSkillDef
+// is defined: documentation, drift-test symmetry, and eliminating the
+// duplicate type declaration that main.go's boot-time loader
+// currently has inline.
+type SubstrateMCPServer struct {
+	Transport       string                   `json:"transport,omitempty"`
+	URL             string                   `json:"url,omitempty"`
+	Headers         map[string]string        `json:"headers,omitempty"`
+	Description     string                   `json:"description,omitempty"`
+	DiscoveredTools []SubstrateMCPServerTool `json:"discovered_tools,omitempty"`
+}
+
+// SubstrateMCPServerTool is the cached form of a single tool the
+// upstream exposed via tools/list. Mirrors `toolDescriptor` in
+// builtin/mcpserverdef.go.
+type SubstrateMCPServerTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// InputSchema is raw JSON — preserved verbatim to avoid double-
+	// parse on every introspection read.
+	InputSchema []byte `json:"input_schema,omitempty"`
+}

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -45,9 +45,17 @@ type MCPServerSpec struct {
 // the same order at the lookup boundary so future refactors that add
 // a third tier can't accidentally invert it.
 //
-// The current pool build callback in cmd/loomcycle/main.go is the
-// primary consumer; the /ui/library/mcp-servers page also calls this
-// through the bearer-authed GET endpoint to render the source badge.
+// LIMITATION (intentional): MCPServerSpec is the HTTP / streamable-http
+// subset. The stdio transport carries additional yaml-only fields
+// (Command/Args/Env/PoolSize) that this resolver deliberately omits
+// because the substrate refuses stdio at the create boundary — there's
+// no path by which a dynamic row could carry those fields. As a
+// consequence, this function cannot replace the inline pool build
+// callback in cmd/loomcycle/main.go for the stdio case; that callback
+// reads cfg.MCPServer directly to get the stdio fields. Use this
+// resolver from HTTP-only call sites: the /ui/library/mcp-servers
+// page's bearer-authed GET endpoint + any future tool that needs to
+// resolve a name → spec for an http-transport server.
 func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, name string) (MCPServerSpec, bool) {
 	if cfg != nil {
 		if srv, ok := cfg.MCPServers[name]; ok {

--- a/internal/lookup/mcpserver_test.go
+++ b/internal/lookup/mcpserver_test.go
@@ -1,0 +1,59 @@
+package lookup_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+)
+
+// TestMCPServer_DriftDetection pins the substrate-shape invariant for
+// MCPServerDef. SubstrateMCPServer and the persistence shape in
+// internal/tools/builtin/mcpserverdef.go (`mcpServerOverlay`) must
+// stay in lockstep — same field set, same json tags.
+//
+// Symmetric today (marshal + unmarshal both use json-tagged structs),
+// so the AgentDef-style "yaml-only consumer" bug PR #184 fixed CAN'T
+// fire here. Forward-looking test for future refactors that might
+// introduce an asymmetric intermediate.
+func TestMCPServer_DriftDetection(t *testing.T) {
+	want := map[string]bool{
+		"transport":        true,
+		"url":              true,
+		"headers":          true,
+		"description":      true,
+		"discovered_tools": true,
+	}
+	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateMCPServer{}))
+	for tag := range want {
+		if !have[tag] {
+			t.Errorf("SubstrateMCPServer missing json tag %q (must mirror mcpServerOverlay in internal/tools/builtin/mcpserverdef.go)", tag)
+		}
+	}
+	for tag := range have {
+		if !want[tag] {
+			t.Errorf("SubstrateMCPServer has json tag %q not in expected set — if added deliberately, update the `want` map", tag)
+		}
+	}
+}
+
+// TestSubstrateMCPServerTool_DriftDetection covers the nested
+// discovered-tools shape. Same posture as the parent struct.
+func TestSubstrateMCPServerTool_DriftDetection(t *testing.T) {
+	want := map[string]bool{
+		"name":         true,
+		"description":  true,
+		"input_schema": true,
+	}
+	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateMCPServerTool{}))
+	for tag := range want {
+		if !have[tag] {
+			t.Errorf("SubstrateMCPServerTool missing json tag %q", tag)
+		}
+	}
+	for tag := range have {
+		if !want[tag] {
+			t.Errorf("SubstrateMCPServerTool has json tag %q not in expected set", tag)
+		}
+	}
+}

--- a/internal/lookup/skill.go
+++ b/internal/lookup/skill.go
@@ -3,6 +3,8 @@ package lookup
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"log"
 
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -44,17 +46,29 @@ type SkillResolution struct {
 func Skill(ctx context.Context, s SkillStore, set *skills.Set, name string) (SkillResolution, bool) {
 	if s != nil {
 		row, err := s.SkillDefGetActive(ctx, name)
-		if err == nil {
+		switch {
+		case err == nil:
 			var sd SubstrateSkillDef
-			if uerr := json.Unmarshal(row.Definition, &sd); uerr == nil {
-				if sd.Body != "" {
-					return SkillResolution{
-						Body:         sd.Body,
-						AllowedTools: sd.AllowedTools,
-						DefID:        row.DefID,
-						Source:       "substrate",
-					}, true
-				}
+			if uerr := json.Unmarshal(row.Definition, &sd); uerr != nil {
+				// Hand-edited / corrupted row — log + fall through to
+				// static so the run can continue with the boot bake.
+				log.Printf("lookup.Skill(%q): parse %s definition failed: %v", name, row.DefID, uerr)
+			} else if sd.Body != "" {
+				return SkillResolution{
+					Body:         sd.Body,
+					AllowedTools: sd.AllowedTools,
+					DefID:        row.DefID,
+					Source:       "substrate",
+				}, true
+			}
+		default:
+			var nf *store.ErrNotFound
+			if !errors.As(err, &nf) {
+				// Transient store hiccup. Static fallback preserves
+				// correctness (the static bake still runs); the log line
+				// is the operator's signal that a substrate override was
+				// skipped this run.
+				log.Printf("lookup.Skill(%q): SkillDefGetActive failed: %v", name, err)
 			}
 		}
 	}

--- a/internal/lookup/skill.go
+++ b/internal/lookup/skill.go
@@ -1,0 +1,95 @@
+package lookup
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// SkillStore is the subset of store.Store the skill resolver uses.
+type SkillStore interface {
+	SkillDefGetActive(ctx context.Context, name string) (store.SkillDefRow, error)
+}
+
+// SkillResolution is the effective skill body + metadata returned
+// by Skill(). When the resolution came from a substrate row, DefID
+// is non-empty (the system_prompt transcript event uses this for
+// provenance — see resolveSkillBodiesForRun in api/http/server.go).
+// When the resolution came from the static set, DefID is "".
+type SkillResolution struct {
+	Body         string
+	AllowedTools []string
+	// DefID — non-empty only for substrate-resolved skills.
+	DefID string
+	// Source — "substrate" or "static". Useful for the
+	// system_prompt provenance event.
+	Source string
+}
+
+// Skill resolves a skill NAME to its effective body + allowed_tools by
+// walking the lookup chain in precedence order:
+//
+//  1. substrate (skill_def_active overlay → skill_defs row) —
+//     operator pushed via `POST /v1/_skilldef create`.
+//  2. static skill set (loaded from LOOMCYCLE_SKILLS_ROOT at boot).
+//
+// Returns (zero, false) when neither source has the name.
+//
+// This mirrors what resolveSkillBodiesForRun in api/http/server.go
+// has done inline for skill-baking at run-start. Factored here so
+// the multi-tier lookup is in one place + the SubstrateSkillDef
+// adapter has a documented home alongside the AgentDef one.
+func Skill(ctx context.Context, s SkillStore, set *skills.Set, name string) (SkillResolution, bool) {
+	if s != nil {
+		row, err := s.SkillDefGetActive(ctx, name)
+		if err == nil {
+			var sd SubstrateSkillDef
+			if uerr := json.Unmarshal(row.Definition, &sd); uerr == nil {
+				if sd.Body != "" {
+					return SkillResolution{
+						Body:         sd.Body,
+						AllowedTools: sd.AllowedTools,
+						DefID:        row.DefID,
+						Source:       "substrate",
+					}, true
+				}
+			}
+		}
+	}
+	if set != nil {
+		if sk, ok := set.Get(name); ok {
+			return SkillResolution{
+				Body:         sk.Body,
+				AllowedTools: sk.AllowedTools,
+				Source:       "static",
+			}, true
+		}
+	}
+	return SkillResolution{}, false
+}
+
+// SubstrateSkillDef mirrors the JSON shape `SkillDef.create` persists
+// in `skill_defs.definition` (snake_case json tags via the
+// `skillDefOverlay` struct in internal/tools/builtin/skilldef.go).
+//
+// Unlike the AgentDef case (where the runtime consumer config.AgentDef
+// has yaml-only tags), the existing in-package skillDefOverlay struct
+// in `internal/api/http/server.go` also uses json tags — so the
+// "silent unmarshal drop" bug PR #184 exposed CAN'T fire here today.
+// We define SubstrateSkillDef anyway to:
+//
+//  1. Document the wire shape explicitly + co-locate it with the
+//     adapter pattern for AgentDef.
+//  2. Make the drift test reflection-based audit symmetric across
+//     all three substrates — a future refactor that introduces a
+//     yaml-only intermediate struct would fail the test.
+//  3. Eliminate the duplicate type declaration between
+//     api/http/server.go's local skillDefOverlay + builtin/skilldef.go's
+//     skillDefOverlay (both were the same fields independently).
+type SubstrateSkillDef struct {
+	Body         string   `json:"body,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	AllowedTools []string `json:"allowed_tools,omitempty"`
+}

--- a/internal/lookup/skill_test.go
+++ b/internal/lookup/skill_test.go
@@ -1,0 +1,40 @@
+package lookup_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+)
+
+// TestSkill_DriftDetection pins the substrate-shape invariant for
+// SkillDef. SubstrateSkillDef and the runtime consumer (skillDefOverlay
+// in api/http/server.go before commit 2; now consumes lookup.SubstrateSkillDef
+// directly) must stay in lockstep. Adding a field to one without the
+// other would silently drop it on unmarshal.
+//
+// Unlike SubstrateAgentDef, this side is currently SYMMETRIC across
+// marshal + unmarshal (both ends use json-tagged structs), so the
+// AgentDef-style "yaml-only consumer" bug PR #184 fixed CAN'T fire
+// here today. This test is forward-looking: if a future refactor
+// introduces a yaml-only intermediate struct, the symmetry would
+// break + the equivalent of PR #184 would land for SkillDef. The
+// drift test catches that intent.
+func TestSkill_DriftDetection(t *testing.T) {
+	want := map[string]bool{
+		"body":          true,
+		"description":   true,
+		"allowed_tools": true,
+	}
+	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateSkillDef{}))
+	for tag := range want {
+		if !have[tag] {
+			t.Errorf("SubstrateSkillDef missing json tag %q (must mirror skillDefOverlay in internal/tools/builtin/skilldef.go)", tag)
+		}
+	}
+	for tag := range have {
+		if !want[tag] {
+			t.Errorf("SubstrateSkillDef has json tag %q not in expected set — if added deliberately, update the `want` map", tag)
+		}
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2595,6 +2595,74 @@ func (s *Store) BackfillAgentDefContentSHA256(ctx context.Context, signFn func(n
 	return s.backfillContentSHA256(ctx, "agent_defs", signFn)
 }
 
+// BackfillAgentDefSystemPromptBase — see store.Store doc.
+func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, error) {
+	rows, err := s.pool.Query(ctx, `SELECT def_id, definition FROM agent_defs`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill system_prompt_base read: %w", err)
+	}
+	type pending struct {
+		DefID string
+		Def   []byte
+	}
+	var todo []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.DefID, &p.Def); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("backfill system_prompt_base scan: %w", err)
+		}
+		todo = append(todo, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("backfill system_prompt_base iterate: %w", err)
+	}
+
+	n := 0
+	for _, p := range todo {
+		updated, ok, err := backfillSystemPromptBase(p.Def)
+		if err != nil {
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if _, err := s.pool.Exec(ctx,
+			`UPDATE agent_defs SET definition = $1 WHERE def_id = $2`,
+			updated, p.DefID); err != nil {
+			return n, fmt.Errorf("backfill system_prompt_base update %s: %w", p.DefID, err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// backfillSystemPromptBase is the JSON-layer transform shared by the
+// sqlite + postgres backfill methods. Returns (newDef, true, nil)
+// when the row needed a fill; (nil, false, nil) when it didn't;
+// (nil, false, err) on JSON parse failure.
+func backfillSystemPromptBase(def []byte) ([]byte, bool, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(def, &raw); err != nil {
+		return nil, false, err
+	}
+	existing, _ := raw["system_prompt_base"].(string)
+	if existing != "" {
+		return nil, false, nil
+	}
+	sp, _ := raw["system_prompt"].(string)
+	if sp == "" {
+		return nil, false, nil
+	}
+	raw["system_prompt_base"] = sp
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
 // BackfillSkillDefContentSHA256 — mirror.
 func (s *Store) BackfillSkillDefContentSHA256(ctx context.Context, signFn func(name string, def []byte) (string, error)) (int, error) {
 	return s.backfillContentSHA256(ctx, "skill_defs", signFn)

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -2623,6 +2624,12 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 	for _, p := range todo {
 		updated, ok, err := backfillSystemPromptBase(p.Def)
 		if err != nil {
+			// Hand-edited row with broken JSON — log + skip rather than
+			// abort the whole backfill. The read-side normalizer in
+			// internal/lookup will still fill SystemPromptBase at runtime,
+			// but this log line is the operator's only signal that a row
+			// was left untouched.
+			log.Printf("agent_defs: backfill system_prompt_base: def_id=%s: JSON parse failed, skipping: %v", p.DefID, err)
 			continue
 		}
 		if !ok {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -2487,6 +2487,80 @@ func (s *Store) ChannelStats(ctx context.Context) ([]store.ChannelStats, error) 
 	return out, nil
 }
 
+// BackfillAgentDefSystemPromptBase walks rows missing the
+// system_prompt_base JSON field + copies system_prompt into it. See
+// store.Store doc for the rationale (PR #186 follow-up).
+func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT def_id, definition FROM agent_defs`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill system_prompt_base read: %w", err)
+	}
+	type pending struct {
+		DefID string
+		Def   []byte
+	}
+	var todo []pending
+	for rows.Next() {
+		var p pending
+		if err := rows.Scan(&p.DefID, &p.Def); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("backfill system_prompt_base scan: %w", err)
+		}
+		todo = append(todo, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("backfill system_prompt_base iterate: %w", err)
+	}
+
+	n := 0
+	for _, p := range todo {
+		updated, ok, err := backfillSystemPromptBase(p.Def)
+		if err != nil {
+			// Hand-edited row with broken JSON — log + skip rather than
+			// abort the whole backfill.
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE agent_defs SET definition = ? WHERE def_id = ?`,
+			updated, p.DefID); err != nil {
+			return n, fmt.Errorf("backfill system_prompt_base update %s: %w", p.DefID, err)
+		}
+		n++
+	}
+	return n, nil
+}
+
+// backfillSystemPromptBase is the JSON-layer transform shared by
+// the sqlite + postgres backfill methods. Returns (newDef, true,
+// nil) when the row needed a fill; (nil, false, nil) when it didn't;
+// (nil, false, err) on JSON parse failure.
+func backfillSystemPromptBase(def []byte) ([]byte, bool, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(def, &raw); err != nil {
+		return nil, false, err
+	}
+	existing, _ := raw["system_prompt_base"].(string)
+	if existing != "" {
+		return nil, false, nil
+	}
+	sp, _ := raw["system_prompt"].(string)
+	if sp == "" {
+		// No system_prompt either — nothing to backfill from. Leave
+		// the row as-is; the read-side normalizer is a no-op too.
+		return nil, false, nil
+	}
+	raw["system_prompt_base"] = sp
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}
+
 // BackfillAgentDefContentSHA256 walks NULL/empty rows + populates the
 // column via the injected signFn. See store.Store doc for invariants.
 func (s *Store) BackfillAgentDefContentSHA256(ctx context.Context, signFn func(name string, def []byte) (string, error)) (int, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -2518,7 +2519,11 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 		updated, ok, err := backfillSystemPromptBase(p.Def)
 		if err != nil {
 			// Hand-edited row with broken JSON — log + skip rather than
-			// abort the whole backfill.
+			// abort the whole backfill. The read-side normalizer in
+			// internal/lookup will still fill SystemPromptBase at runtime,
+			// but this log line is the operator's only signal that a row
+			// was left untouched.
+			log.Printf("agent_defs: backfill system_prompt_base: def_id=%s: JSON parse failed, skipping: %v", p.DefID, err)
 			continue
 		}
 		if !ok {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -824,6 +824,29 @@ type Store interface {
 	// data problem.
 	BackfillAgentDefContentSHA256(ctx context.Context, signFn func(name string, def []byte) (string, error)) (int, error)
 
+	// BackfillAgentDefSystemPromptBase walks every agent_defs row,
+	// decodes its definition, fills the `system_prompt_base` field
+	// from `system_prompt` when the former is empty, and writes the
+	// row back. Returns the count of rows updated.
+	//
+	// Idempotent: a second call after a complete backfill finds no
+	// rows missing the field and returns 0. Boot-time hook runs this
+	// once after migrations.
+	//
+	// Why: PR #186 fixed the runtime symptom (substrate-loaded agents
+	// losing their instructions on skill-enabled runs) via a read-side
+	// normalizer. This backfill closes the on-disk data gap so the
+	// field is materialized for legacy rows too — useful when
+	// snapshot/restore round-trips a substrate-only deployment to a
+	// reader that strictly trusts the persisted shape.
+	//
+	// The transform happens at the JSON layer (the store doesn't
+	// import mergedDef from internal/tools/builtin). Rows whose
+	// definition JSON fails to decode are skipped with a log line
+	// rather than aborting the backfill — a single hand-edited row
+	// shouldn't block the rest.
+	BackfillAgentDefSystemPromptBase(ctx context.Context) (int, error)
+
 	// BackfillSkillDefContentSHA256 — mirror of the AgentDef backfill.
 	BackfillSkillDefContentSHA256(ctx context.Context, signFn func(name string, def []byte) (string, error)) (int, error)
 

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -155,6 +155,7 @@ func Run(t *testing.T, factory Factory) {
 		{"AgentDefStaticFallback", testAgentDefStaticFallback},
 		{"AgentDefContentSHA256RoundTrip", testAgentDefContentSHA256RoundTrip},
 		{"BackfillAgentDefContentSHA256", testBackfillAgentDefContentSHA256},
+		{"BackfillAgentDefSystemPromptBaseFillsLegacyRows", testBackfillAgentDefSystemPromptBase},
 		// v0.8.22 SkillDef substrate — mirror of the AgentDef tests.
 		{"SkillDefCreateAndGet", testSkillDefCreateAndGet},
 		{"SkillDefVersionMonotonicUnderContention", testSkillDefVersionMonotonicUnderContention},
@@ -3061,6 +3062,101 @@ func testBackfillAgentDefContentSHA256(t *testing.T, s store.Store) {
 	alpha, _ := s.AgentDefGet(ctx, "d-bf-0")
 	if alpha.ContentSHA256 != "sha256:alpha-bf-hash" {
 		t.Errorf("backfill alpha hash = %q", alpha.ContentSHA256)
+	}
+}
+
+// testBackfillAgentDefSystemPromptBase pins the boot-time backfill
+// for the v0.9.x system_prompt_base field added by the
+// static-vs-dynamic equalization PR. Three fixture rows cover the
+// three cases the backfill must handle:
+//
+//  1. Legacy row WITHOUT system_prompt_base → backfill fills it from
+//     system_prompt.
+//  2. Row that ALREADY has system_prompt_base → backfill leaves it
+//     untouched (don't clobber explicit values).
+//  3. Row without system_prompt either → backfill leaves it as-is
+//     (nothing to fill from; the read-side normalizer is a no-op
+//     too).
+//
+// Idempotent: a second call after a complete backfill returns 0.
+func testBackfillAgentDefSystemPromptBase(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// 1. Legacy row — missing system_prompt_base.
+	legacy := store.AgentDefRow{
+		DefID:       "spb-legacy",
+		Name:        "spb-legacy-name",
+		Description: "legacy",
+		Definition:  json.RawMessage(`{"system_prompt":"be helpful","allowed_tools":["Read"]}`),
+	}
+	if _, err := s.AgentDefCreate(ctx, legacy); err != nil {
+		t.Fatalf("create legacy: %v", err)
+	}
+
+	// 2. Already-filled row — must not be touched.
+	filled := store.AgentDefRow{
+		DefID:       "spb-filled",
+		Name:        "spb-filled-name",
+		Description: "filled",
+		Definition:  json.RawMessage(`{"system_prompt":"new","system_prompt_base":"original base"}`),
+	}
+	if _, err := s.AgentDefCreate(ctx, filled); err != nil {
+		t.Fatalf("create filled: %v", err)
+	}
+
+	// 3. Row with no system_prompt either — must be left as-is.
+	empty := store.AgentDefRow{
+		DefID:       "spb-empty",
+		Name:        "spb-empty-name",
+		Description: "empty",
+		Definition:  json.RawMessage(`{"allowed_tools":["Read"]}`),
+	}
+	if _, err := s.AgentDefCreate(ctx, empty); err != nil {
+		t.Fatalf("create empty: %v", err)
+	}
+
+	n, err := s.BackfillAgentDefSystemPromptBase(ctx)
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("backfilled %d rows, want 1 (only the legacy row)", n)
+	}
+
+	// Verify legacy row got the field.
+	got, _ := s.AgentDefGet(ctx, "spb-legacy")
+	var legacyOut map[string]any
+	_ = json.Unmarshal(got.Definition, &legacyOut)
+	if legacyOut["system_prompt_base"] != "be helpful" {
+		t.Errorf("legacy.system_prompt_base = %v, want %q", legacyOut["system_prompt_base"], "be helpful")
+	}
+	if legacyOut["system_prompt"] != "be helpful" {
+		t.Errorf("legacy.system_prompt mutated: %v", legacyOut["system_prompt"])
+	}
+
+	// Filled row untouched.
+	gotF, _ := s.AgentDefGet(ctx, "spb-filled")
+	var filledOut map[string]any
+	_ = json.Unmarshal(gotF.Definition, &filledOut)
+	if filledOut["system_prompt_base"] != "original base" {
+		t.Errorf("filled.system_prompt_base clobbered: %v", filledOut["system_prompt_base"])
+	}
+
+	// Empty row untouched (no field added).
+	gotE, _ := s.AgentDefGet(ctx, "spb-empty")
+	var emptyOut map[string]any
+	_ = json.Unmarshal(gotE.Definition, &emptyOut)
+	if _, hasField := emptyOut["system_prompt_base"]; hasField {
+		t.Errorf("empty row spuriously got system_prompt_base: %v", emptyOut["system_prompt_base"])
+	}
+
+	// Idempotent: second call returns 0.
+	n2, err := s.BackfillAgentDefSystemPromptBase(ctx)
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("idempotent? second pass backfilled %d rows, want 0", n2)
 	}
 }
 

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -186,6 +186,7 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 			return errResult(fmt.Sprintf("create: %s", err)), nil
 		}
 	}
+	def.normalize()
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
@@ -306,6 +307,7 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 
+	def.normalize()
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
@@ -625,6 +627,7 @@ func assertAllowedToolsSubset(proposed, root []string) error {
 // the immortal lineage root.
 func (a *AgentDef) bootstrapStatic(ctx context.Context, name string, static config.AgentDef) (store.AgentDefRow, error) {
 	def := staticToMergedDef(static)
+	def.normalize()
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return store.AgentDefRow{}, fmt.Errorf("marshal: %w", err)
@@ -660,8 +663,21 @@ type mergedDef struct {
 	// loop default (16). Set higher for discovery-style forks
 	// whose workflow is intrinsically iterative — same knob the
 	// yaml frontmatter exposes via PR #168's `max_iterations` field.
-	MaxIterations    int                               `json:"max_iterations,omitempty"`
-	SystemPrompt     string                            `json:"system_prompt,omitempty"`
+	MaxIterations int    `json:"max_iterations,omitempty"`
+	SystemPrompt  string `json:"system_prompt,omitempty"`
+	// SystemPromptBase is the pre-skill-bake snapshot of SystemPrompt.
+	// Persisted alongside SystemPrompt so the v0.8.22 SkillDef per-run
+	// resolver (`resolveSkillBodiesForRun` in api/http/server.go) can
+	// rebuild the effective prompt from this base + each skill body
+	// when DB-active SkillDef rows shadow the static body.
+	//
+	// For statically-yaml-defined agents, `resolveSkills` sets this at
+	// config-load. For agents persisted via `AgentDef.create` /
+	// `AgentDef.fork`, `normalize()` below copies SystemPrompt into it
+	// when not explicitly supplied. The read-side
+	// `lookup.NormalizeAgentDef` is defense-in-depth for legacy rows
+	// that pre-date this field. See PR #186 for the production bug.
+	SystemPromptBase string                            `json:"system_prompt_base,omitempty"`
 	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
 	Skills           []string                          `json:"skills,omitempty"`
 	Providers        []string                          `json:"providers,omitempty"`
@@ -693,6 +709,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.SystemPrompt != "" {
 		d.SystemPrompt = ov.SystemPrompt
 	}
+	if ov.SystemPromptBase != "" {
+		d.SystemPromptBase = ov.SystemPromptBase
+	}
 	if ov.AllowedTools != nil {
 		d.AllowedTools = ov.AllowedTools
 	}
@@ -716,6 +735,27 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	}
 }
 
+// normalize fills derived fields that the static config-load path
+// applies via `resolveSkills` but the substrate write path would
+// otherwise skip. Called at every write site (execCreate / execFork /
+// bootstrapStatic) right before json.Marshal so persisted rows match
+// what `cfg.Agents[name]` would have looked like after boot
+// normalization for the same content.
+//
+// Today the only field this fills is SystemPromptBase — see the field
+// doc on the struct. Future static-path normalizers added to
+// resolveSkills should grow a sibling assignment here.
+//
+// The read-side `lookup.NormalizeAgentDef` does the same work
+// defensively for legacy rows that pre-date this method; together,
+// the read + write normalizers form belt-and-suspenders against the
+// drift PR #186 fixed.
+func (d *mergedDef) normalize() {
+	if d.SystemPromptBase == "" {
+		d.SystemPromptBase = d.SystemPrompt
+	}
+}
+
 func staticToMergedDef(s config.AgentDef) mergedDef {
 	return mergedDef{
 		Provider:         s.Provider,
@@ -725,6 +765,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		MaxTokens:        s.MaxTokens,
 		MaxIterations:    s.MaxIterations,
 		SystemPrompt:     s.SystemPrompt,
+		SystemPromptBase: s.SystemPromptBase,
 		AllowedTools:     s.AllowedTools,
 		Skills:           s.Skills,
 		Providers:        s.Providers,

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -3,10 +3,12 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -398,4 +400,67 @@ func TestAgentDefTool_ForkWithoutMaxIterationsOmitsField(t *testing.T) {
 		t.Errorf("max_iterations should be omitted (omitempty) when not in overlay; got %v in %s",
 			defJSON["max_iterations"], row.Definition)
 	}
+}
+
+// TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef closes the
+// drift-test gap the code review of PR #188 surfaced: the test in
+// internal/lookup/agent_test.go reflects only SubstrateAgentDef. A
+// behavioural field added to mergedDef + config.AgentDef but
+// accidentally omitted from SubstrateAgentDef would silently leak
+// through. This test lives in the builtin package where mergedDef is
+// in-scope and reflects BOTH shapes against each other.
+//
+// Exemptions list non-behavioural fields that mergedDef carries for
+// substrate-storage reasons but that SubstrateAgentDef deliberately
+// omits because they don't round-trip into config.AgentDef:
+//   - description: stored on AgentDefRow, not in config.AgentDef
+func TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef(t *testing.T) {
+	// Fields in mergedDef that are intentionally NOT mirrored in
+	// SubstrateAgentDef. Adding to this set is the conscious decision
+	// the test forces — drop a tag here only when you've checked the
+	// field genuinely doesn't need to flow into the runtime config.
+	exempt := map[string]bool{
+		"description": true,
+	}
+
+	mergedTags := jsonTagsOfFields(reflect.TypeOf(mergedDef{}))
+	substrateTags := jsonTagsOfFields(reflect.TypeOf(lookup.SubstrateAgentDef{}))
+
+	for tag := range mergedTags {
+		if exempt[tag] {
+			continue
+		}
+		if !substrateTags[tag] {
+			t.Errorf("mergedDef has json tag %q but lookup.SubstrateAgentDef does not — either mirror it on the lookup side OR add %q to the exempt set with a comment justifying why it stays substrate-internal",
+				tag, tag)
+		}
+	}
+	for tag := range substrateTags {
+		if !mergedTags[tag] {
+			t.Errorf("lookup.SubstrateAgentDef has json tag %q but mergedDef does not — substrate persistence is the source-of-truth shape; remove from SubstrateAgentDef OR add the field to mergedDef in this package",
+				tag)
+		}
+	}
+}
+
+// jsonTagsOfFields walks a struct's exported fields and returns the
+// set of json tag names (the part before any "," for `,omitempty`).
+// Mirrors the helper in internal/lookup/agent_test.go; duplicated
+// because that one is _test.go scoped and not importable.
+func jsonTagsOfFields(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		for j, c := range tag {
+			if c == ',' {
+				tag = tag[:j]
+				break
+			}
+		}
+		out[tag] = true
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

Three recent PRs patched the same architectural drift one symptom at a time:

| PR | Symptom |
|----|---------|
| #184 | `/v1/runs` returned "unknown agent" for substrate-registered names. Two bugs in one: (a) `lookupAgent` missed the substrate tier; (b) `json.Unmarshal(row.Definition, &configAgentDef)` silently dropped every field (`config.AgentDef` carries yaml-only tags; substrate persists snake_case json). |
| #186 | Substrate-registered agents lost their system prompt at every skill-enabled run. `resolveSkillBodiesForRun` rebuilds `SystemPrompt = SystemPromptBase + skill bodies`, and the dynamic load path left `SystemPromptBase` empty. |

Root cause: loomcycle's static-yaml era had ONE canonical load path:

```
yaml → config.LoadConfig → resolveSkills / resolveAgent → cfg.Agents
```

v0.8.15 added `dynamic_agents` and v0.8.22 added the AgentDef substrate. Both new READ paths SKIPPED the normalizer chain that `resolveSkills` applied at boot. Future fields added to `config.AgentDef` requiring static-path normalization would silently break for the same class of bug.

This PR consolidates the lookup chain + normalizer chain + JSON adapter into a new `internal/lookup` package, applies the SystemPromptBase fix at the write side too (so new rows persist correctly + a boot-time backfill heals legacy rows), and adds equivalence + drift tests that catch future divergence at PR-time rather than in production.

## Architecture

The 4-pillar fix (one commit per pillar):

1. **`internal/lookup` package** — `lookup.Agent` / `lookup.Skill` / `lookup.MCPServer` are the canonical name → effective-def resolvers. Each walks the static/dynamic precedence chain and applies the normalizer chain. `lookupAgent` in `server.go` is now a 5-line wrapper.
2. **Substrate adapters co-located** — `lookup.SubstrateAgentDef` / `SubstrateSkillDef` / `SubstrateMCPServer` live alongside the resolvers. Used wherever JSON unmarshal of substrate rows happens; the `skillDefOverlay` duplicate in `server.go` collapsed to use `lookup.SubstrateSkillDef`.
3. **Write-side persistence of `SystemPromptBase`** — `mergedDef.normalize()` in `agentdef.go` fills the field at every write site (execCreate / execFork / bootstrapStatic). Boot-time `BackfillAgentDefSystemPromptBase` heals legacy rows. The read-side `lookup.NormalizeAgentDef` (extracted from PR #186) stays as defense-in-depth.
4. **Equivalence + drift tests** — `TestAgent_EquivalenceYamlVsSubstrate` catches the entire class of bugs. `TestAgent_DriftDetection` (reflection-based) prevents future field-addition gaps by failing CI when `SubstrateAgentDef` and the expected json-tag set diverge. Equivalent tests for `SubstrateSkillDef` + `SubstrateMCPServer`.

## What's grouped from prior PRs

| Prior PR | What it did | What this PR does to it |
|----------|-------------|--------------------------|
| #184 lookup fallthrough | Added substrate tier to `lookupAgent` + `substrateAgentDef` adapter. | Moved to `internal/lookup`. Now the canonical home; future substrates follow the same pattern. |
| #186 SystemPromptBase read-fix | Added `normalizeSystemPromptBase` to the dynamic read path. | Moved to `lookup.NormalizeAgentDef`. Joined by a write-side `normalize()` + a boot-time backfill so the on-disk data also converges. |
| #185 skill error UX | Improved error message when static skill set is empty but substrate has names. | Unchanged — different concern (operator-facing UX, not data path). Stays as-is. |

## Audit of OTHER dynamic substrates

The Explore agent inventoried `SkillDef` and `MCPServerDef` for the same patterns. Findings:

| Substrate | Tag mismatch? | Boot normalizer gap? | Lookup tier gap? |
|-----------|---------------|----------------------|-------------------|
| AgentDef  | **Was real (PR #184)** | **Was real (PR #186)** | **Was real (PR #184)** |
| SkillDef  | Symmetric (both marshal + unmarshal go through json-tagged structs); WONTFIRE | resolveSkillBodiesForRun is the canonical runtime path; no static-only normalizer to leak | Dual-aware already in resolveSkillBodiesForRun |
| MCPServerDef | Symmetric; WONTFIRE | No boot-time normalizations needed (no SystemPromptBase-style invariant) | Pool's build callback is dual-aware |

The drift tests are forward-looking insurance: a future refactor that introduces an asymmetric intermediate struct for either of the two currently-symmetric substrates would fail the drift test before shipping.

## Verification

End-to-end smoke against a built binary (cleaned up after):

```
$ sqlite3 data/loomcycle.db "INSERT INTO agent_defs ... \
    definition='{\"system_prompt\":\"be helpful\",...}'"  # legacy row, no system_prompt_base
$ ./bin/loomcycle --config ...
2026/05/22 18:09:07 agent_defs: backfilled 1 rows with system_prompt_base
$ sqlite3 data/loomcycle.db "SELECT definition FROM agent_defs ..."
{"allowed_tools":[...],"system_prompt":"be helpful","system_prompt_base":"be helpful"}
```

Tests:
- `go test ./internal/lookup/ -v` — 6 cases: equivalence, legacy-row-fill-on-read, AgentDef drift, SkillDef drift, MCPServerDef drift, nested SubstrateMCPServerTool drift.
- `go test ./internal/store/sqlite/ -run 'BackfillAgentDefSystemPromptBase' -v` — contract test pinning the 3-case backfill semantics + idempotency.
- `go test ./internal/api/http/ -run 'TestLookupAgent' -v` — all 5 pre-existing PR #184/#186 regression tests still pass against the extracted resolver.
- `go test ./... -timeout 180s` — full pass.
- `gofmt -l .` — clean.

## Notes for review

- **No yaml/json tag unification on `config.AgentDef`** — tempting to add json tags everywhere, but every external consumer (Python adapter, gRPC, TS adapter) depends on current snake_case wire shapes. The adapter pattern stays.
- **No content_sha256 invalidation on the backfill** — the SystemPromptBase fill is data-shape normalization, not content change. Existing hashes remain valid by design.
- **Write-side + read-side belt-and-suspenders** — kept BOTH. Read-side is the runtime correctness floor (legacy rows work without any backfill). Write-side prevents new rows from having the issue. Backfill heals at-rest data over time. The doc explains the rationale.
- **`internal/lookup/README.md`** — documents the architectural pattern for future substrates. Adds a "future substrate" contract operators + AI-assisted developers can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)