### PR TITLE
fix(api): runSubAgent resolves through lookup.Agent (dynamic + substrate agents)

### DIFF
--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -313,7 +314,110 @@ func TestSubAgent_UnknownChildName(t *testing.T) {
 	}
 }
 
-// TestSubAgent_InheritsParentCallerHostAllowlist asserts that when a
+// TestSubAgent_SpawnsDynamicallyRegisteredChild is the regression for
+// the 2026-05-22 cv-batch-adapter ↔ cv-adapter incident: a parent
+// agent (statically yaml-defined) tried to spawn a child registered
+// via the dynamic_agents table (RegisterAgent / connector path) and
+// got "unknown sub-agent" because runSubAgent was reading
+// `s.cfg.Agents[name]` directly instead of going through lookup.Agent.
+//
+// PR #188 consolidated the lookup chain but missed this site;
+// runSubAgent now calls lookup.Agent which walks cfg.Agents →
+// dynamic_agents → agent_def_active.
+//
+// Production symptom: cv-batch-adapter (yaml) tried to spawn N
+// instances of cv-adapter (registered dynamically per user at boot
+// of jobs-search-agent's own MCP server) and every spawn failed.
+func TestSubAgent_SpawnsDynamicallyRegisteredChild(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"parent": {
+				Model:        "stub-model",
+				AllowedTools: []string{"Agent"},
+				SystemPrompt: "you are the parent",
+			},
+			// NB: "child" is NOT in cfg.Agents — it's registered
+			// dynamically below. The pre-fix runSubAgent would fail
+			// here at the s.cfg.Agents[name] read.
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// 1) parent emits a tool_call(Agent, name="child")
+			{
+				{
+					Type: providers.EventToolCall,
+					ToolUse: &providers.ToolUse{
+						ID:    "tu_parent_1",
+						Name:  "Agent",
+						Input: json.RawMessage(`{"name":"child","prompt":"hi"}`),
+					},
+				},
+				{Type: providers.EventDone, StopReason: "tool_use"},
+			},
+			// 2) child emits final text
+			{
+				{Type: providers.EventText, Text: "dynamic child says hi"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+			// 3) parent wraps up
+			{
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent_dynamic.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// Register "child" via the dynamic_agents path — same shape
+	// connector.RegisterAgent persists.
+	childDef := config.AgentDef{
+		Model:        "stub-model",
+		AllowedTools: []string{},
+		SystemPrompt: "you are the dynamic child",
+	}
+	childDefJSON, err := json.Marshal(childDef)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.DynamicAgentUpsert(context.Background(), store.DynamicAgent{
+		Name:       "child",
+		Definition: childDefJSON,
+		CreatedAt:  time.Now(),
+	}); err != nil {
+		t.Fatalf("DynamicAgentUpsert: %v", err)
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	if strings.Contains(bodyStr, "unknown sub-agent") {
+		t.Fatalf("regression: dynamic-only sub-agent failed to resolve, got:\n%s", bodyStr)
+	}
+	if !strings.Contains(bodyStr, "dynamic child says hi") {
+		t.Errorf("parent stream missing dynamic child output:\n%s", bodyStr)
+	}
+}
 // parent run was started under CALLER_AUTHORITATIVE with a per-call
 // allowed_hosts list, sub-agents spawned via the Agent tool inherit
 // that same host policy and can reach the same hosts.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2614,8 +2614,9 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 }
 
 // runSubAgent is the SubAgentRunner closure injected into the Agent
-// built-in tool. It looks up the named agent in cfg.Agents, builds a
-// fresh session+run for the sub-execution, drives loop.Run with the
+// built-in tool. It resolves the named agent through lookup.Agent
+// (cfg.Agents → dynamic_agents → agent_def_active), builds a fresh
+// session+run for the sub-execution, drives loop.Run with the
 // sub-agent's full declared tool set, and returns the FinalText.
 //
 // Trust model: the sub-agent's `allowed_tools` is the SOLE authority on
@@ -2639,9 +2640,9 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 // them as IsError tool_results to the parent's model rather than
 // tearing down the parent run.
 func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, defID string) (string, error) {
-	def, ok := s.cfg.Agents[name]
+	def, ok := lookup.Agent(ctx, s.store, s.cfg, name)
 	if !ok {
-		return "", fmt.Errorf("unknown sub-agent %q (not in loomcycle.yaml agents map)", name)
+		return "", fmt.Errorf("unknown sub-agent %q (not in cfg.Agents, dynamic_agents, or agent_def_active)", name)
 	}
 
 	// v0.8.5 substrate: when defID is set, overlay the named def's


### PR DESCRIPTION
## Summary

- PR #188 consolidated agent name resolution through `internal/lookup`, but missed `runSubAgent` — the SubAgentRunner closure the Agent built-in tool calls. That site still did `s.cfg.Agents[name]` directly, so a static-yaml parent could not spawn a dynamically-registered child.
- Production symptom: `cv-batch-adapter` → `cv-adapter` spawns all failed with `"unknown sub-agent \"cv-adapter\" (not in loomcycle.yaml agents map)"`, even though `cv-adapter` was registered via `RegisterAgent`. The failure was silent at the parent-run level (Agent tool surfaces tool-errors via IsError tool_results, not run-failing).
- Fix: replace the direct map read with `lookup.Agent(ctx, s.store, s.cfg, name)`. Walks the same three-tier chain `lookupAgent` already uses: `cfg.Agents → dynamic_agents → agent_def_active`. Error message updated to name all three tiers so future misses are discoverable.

## Audit

`grep "s\.cfg\.Agents\["` against `server.go` confirms `runSubAgent` was the only remaining missed site. The four other cfg.Agents[name] reads in the codebase are legitimately static-only by design:

| Site | Purpose |
|---|---|
| `internal/config/config.go` | Boot-time loading, static-only by definition |
| `internal/tools/builtin/agentdef.go` (lines 162, 267, 538, 561) | AgentDef tool collision/static-base checks — refuses create-over-static, reads operator-blessed AllowedTools ceiling |
| `internal/api/http/connector_impl.go:248,305` | `register_agent` / `unregister_agent` refuse to operate on yaml-defined names |
| `internal/tools/builtin/context.go:375` | Context tool enumerates the static roster only (separate UX concern; out of scope) |

## Test plan

- [x] New `TestSubAgent_SpawnsDynamicallyRegisteredChild` — parent in cfg.Agents, child via `DynamicAgentUpsert`, asserts `"unknown sub-agent"` is NOT in the response.
- [x] Regression-discipline check: temporarily reverted the production fix; new test fails with `"unknown sub-agent"`. Re-applied the fix; new test passes.
- [x] All seven existing `TestSubAgent_*` tests stay green.
- [x] `go test ./... -timeout 300s` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)