### PR TITLE
fix(ui): user_input card filters role=system segments (drop SYSTEM-card dupe)

### DIFF
--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -418,6 +418,7 @@ func TestSubAgent_SpawnsDynamicallyRegisteredChild(t *testing.T) {
 		t.Errorf("parent stream missing dynamic child output:\n%s", bodyStr)
 	}
 }
+
 // parent run was started under CALLER_AUTHORITATIVE with a per-call
 // allowed_hosts list, sub-agents spawned via the Agent tool inherit
 // that same host policy and can reach the same hosts.

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -455,7 +455,16 @@ function textPayloadFor(ev: EventPayload, row?: TranscriptEvent): string {
       return lines.join("\n");
     }
     case "user_input": {
-      const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
+      // Filter out role="system" segments — the agent's system prompt
+      // is already surfaced by the dedicated system_prompt card; showing
+      // it again here makes the operator scroll past it to find what
+      // was actually said to the agent. Sub-agent spawns + run-creation
+      // paths prepend a system segment for provider wire-shape reasons
+      // (see server.go runSubAgent), but the operator dashboard wants
+      // the "user said" view.
+      const segs = ((row?.payload as UserInputPayload[] | undefined) ?? []).filter(
+        (s) => s.role === "user",
+      );
       return JSON.stringify(segs, null, 2);
     }
     case "system_prompt": {
@@ -525,11 +534,10 @@ function summaryFor(ev: EventPayload, row?: TranscriptEvent): string {
         : "";
     case "user_input": {
       const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
-      // Surface the first user-role content text (typical: the
-      // initial prompt the caller sent). Skip system-role segments
-      // — those usually duplicate the AgentDef prompt that the
-      // separate system_prompt card already surfaces.
-      const userSeg = segs.find((s) => s.role === "user") ?? segs[0];
+      // Surface the first user-role content text (the prompt the
+      // caller sent). Skip system-role segments — those duplicate the
+      // AgentDef prompt that the separate system_prompt card surfaces.
+      const userSeg = segs.find((s) => s.role === "user");
       const text = userSeg?.content?.[0]?.text ?? "";
       return firstLine(text, 200);
     }
@@ -594,12 +602,13 @@ function detailFor(ev: EventPayload, row?: TranscriptEvent): ReactNode {
         </div>
       );
     case "user_input": {
-      const segs = (row?.payload as UserInputPayload[] | undefined) ?? [];
+      const segs = ((row?.payload as UserInputPayload[] | undefined) ?? []).filter(
+        (s) => s.role === "user",
+      );
       return (
         <div className="user-input-detail">
           {segs.map((seg, i) => (
             <div key={i} className="user-input-segment">
-              <div className="seg-role">role: <code>{seg.role}</code></div>
               {seg.content?.map((c, j) => (
                 <pre key={j} className="full-text">{c.text ?? JSON.stringify(c)}</pre>
               ))}

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -144,13 +144,12 @@ function formatLine(row: TranscriptEvent): FormattedLine {
     case "agent":
       return { key, ts, kind, cls: "tl-meta", payload: oneLine(JSON.stringify(ev)) };
     case "user_input": {
-      // v0.9.x: user_input's payload lives on the sidecar (the
-      // raw segments JSON) — `ev.text` is empty because the event
-      // doesn't fit providers.Event. Show the first user-role
-      // segment's text as a one-liner; expanded view lives in
-      // the panels (AgentDetailPane).
+      // v0.9.x: user_input's payload lives on the sidecar (the raw
+      // segments JSON). Show the first user-role segment's text as a
+      // one-liner; system-role segments are skipped because the
+      // dedicated system_prompt event already surfaces them.
       const segs = (row.payload as UserInputPayload[] | undefined) ?? [];
-      const userSeg = segs.find((s) => s.role === "user") ?? segs[0];
+      const userSeg = segs.find((s) => s.role === "user");
       const text = userSeg?.content?.[0]?.text ?? "";
       return { key, ts, kind, cls: "tl-text", payload: oneLine(text) };
     }


### PR DESCRIPTION
## Summary

- The top two transcript cards on \`/ui/agents/<agent_id>\` (\`input · user\` and \`input · system\`) currently both visually lead with the agent's system prompt. The actual user prompt is buried under the system content at the bottom of the USER card.
- Root cause: the persisted \`user_input\` event payload is the full \`[]loop.PromptSegment\` array, which for sub-agent spawns + run-creation paths includes both a \`{role:"system"}\` segment (the agent's SystemPrompt) and a \`{role:"user"}\` segment (the actual prompt). The renderer mapped over all segments, surfacing the system content first — exact dupe of what the SYSTEM card separately renders.
- Fix: filter \`role === "system"\` out of the three \`user_input\` renderer branches in \`AgentDetailPane.tsx\` + the matching one in \`TerminalTranscript.tsx\`. The summary path was already correct; the detail + clipboard + terminal paths weren't.

## Why client-side, not server-side

The events table is the canonical wire-shape source — replay (\`server.go:2378\` walks \`seg.Role != "user"\` for the same conceptual filter) and external consumers (TS adapter transcript reconstruction, snapshot/restore) depend on the full segs preservation. Filtering server-side would alter the wire contract for one consumer. The duplication is only a display bug; the wire shape is informationally correct.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run build\` clean
- [x] \`go test ./... -timeout 300s\` green
- [ ] Manual: spawn a sub-agent run, open child's \`/ui/agents/<agent_id>\`, expand USER card → expect only the spawn-prompt text; expand SYSTEM card → expect only the agent's system prompt; no content duplication between the two cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)