### PR TITLE
feat(ui): Library v2 — STATIC/DYNAMIC chips + inline content expansion + static MCP tools

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -884,6 +884,28 @@ func main() {
 	// since v0.5.5; HTTP only adopted this in v0.8.21.
 	srv.SetBuildInfo(buildVersion, buildCommit, buildTime)
 	srv.SetMCPFallback(mcpLazyResolver.Resolve)
+	// v0.9.x: expose Pool's cached tools/list snapshots to the unified
+	// /v1/_library/mcp-servers endpoint so static MCP servers' tools
+	// surface alongside substrate-side discovered_tools. The closure
+	// marshals into the substrate-mirror shape ({name, description,
+	// input_schema}) so the wire stays uniform across static + dynamic.
+	srv.SetMCPPoolInspector(func(name string) json.RawMessage {
+		descs := mcpPool.PeekTools(name)
+		if descs == nil {
+			return nil
+		}
+		type td struct {
+			Name        string          `json:"name"`
+			Description string          `json:"description,omitempty"`
+			InputSchema json.RawMessage `json:"input_schema,omitempty"`
+		}
+		out := make([]td, len(descs))
+		for i, d := range descs {
+			out[i] = td{Name: d.Name, Description: d.Description, InputSchema: d.InputSchema}
+		}
+		b, _ := json.Marshal(out)
+		return b
+	})
 	// v0.8.22: hand the static skills.Set to the server so the
 	// per-run SkillDef resolver can fall back to static bodies when
 	// no DB-active row exists for a skill name.

--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -1,0 +1,350 @@
+// library_unified.go — v0.9.x Library v2: bearer-authed read-only
+// enumeration that merges static cfg-defined entries with substrate
+// rows into one envelope per entry. The shipping /v1/_*def/names
+// endpoints (library_admin.go) enumerate ONLY substrate rows; this
+// file's three endpoints enumerate every name the runtime knows
+// about — yaml + dynamic + bootstrapped — and tag each with its
+// source.
+//
+// Wire shape (per row):
+//
+//	{
+//	  "name":              "researcher",
+//	  "source":            "static-only" | "dynamic-only" | "both",
+//	  "in_static":         true,
+//	  "in_substrate":      true,
+//	  "version_count":     3,
+//	  "active_def_id":     "def_abc",
+//	  "latest_version":    3,
+//	  "last_updated":      "2026-05-20T12:00:00Z",
+//	  "static_definition": { ... }    // omitempty
+//	}
+//
+// in_static / in_substrate are the canonical booleans the UI consults
+// for chip rendering; `source` is a derived convenience string.
+//
+// Read-only + bearer-authed via the same authMiddleware that wraps
+// every /v1/_* endpoint.
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// LibraryEntry is one row of the unified library envelope.
+// StaticDefinition is omitted when the entry has no static (yaml /
+// skills-root / cfg.MCPServers) source. Substrate counters are zero
+// for static-only entries.
+type LibraryEntry struct {
+	Name             string          `json:"name"`
+	Source           string          `json:"source"` // "static-only" | "dynamic-only" | "both"
+	InStatic         bool            `json:"in_static"`
+	InSubstrate      bool            `json:"in_substrate"`
+	VersionCount     int             `json:"version_count"`
+	ActiveDefID      string          `json:"active_def_id,omitempty"`
+	LatestVersion    int             `json:"latest_version,omitempty"`
+	LastUpdated      time.Time       `json:"last_updated,omitempty"`
+	StaticDefinition json.RawMessage `json:"static_definition,omitempty"`
+}
+
+// libraryListResponse is the envelope returned by all three handlers.
+type libraryListResponse struct {
+	Entries []LibraryEntry `json:"entries"`
+}
+
+// handleListLibraryAgents serves GET /v1/_library/agents.
+func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request) {
+	// Substrate side — keyed by name for the merge below. Nil-safe:
+	// when store is unset (tests), the substrate map stays empty and
+	// only static cfg entries surface.
+	subRows := map[string]store.AgentDefNameSummary{}
+	if s.store != nil {
+		rows, err := s.store.AgentDefListNames(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		for _, row := range rows {
+			subRows[row.Name] = row
+		}
+	}
+
+	entries := make([]LibraryEntry, 0, len(s.cfg.Agents)+len(subRows))
+	seen := map[string]struct{}{}
+
+	for name, def := range s.cfg.Agents {
+		entry := LibraryEntry{
+			Name:             name,
+			InStatic:         true,
+			StaticDefinition: marshalStaticAgentDef(def),
+		}
+		if sub, ok := subRows[name]; ok {
+			entry.InSubstrate = true
+			entry.VersionCount = sub.VersionCount
+			entry.ActiveDefID = sub.ActiveDefID
+			entry.LatestVersion = sub.LatestVersion
+			entry.LastUpdated = sub.LastUpdated
+		}
+		entry.Source = deriveSource(entry.InStatic, entry.InSubstrate)
+		entries = append(entries, entry)
+		seen[name] = struct{}{}
+	}
+	for name, sub := range subRows {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		entries = append(entries, LibraryEntry{
+			Name:          name,
+			Source:        deriveSource(false, true),
+			InSubstrate:   true,
+			VersionCount:  sub.VersionCount,
+			ActiveDefID:   sub.ActiveDefID,
+			LatestVersion: sub.LatestVersion,
+			LastUpdated:   sub.LastUpdated,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	writeJSONOK(w, libraryListResponse{Entries: entries})
+}
+
+// handleListLibrarySkills serves GET /v1/_library/skills.
+func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request) {
+	subRows := map[string]store.SkillDefNameSummary{}
+	if s.store != nil {
+		rows, err := s.store.SkillDefListNames(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		for _, row := range rows {
+			subRows[row.Name] = row
+		}
+	}
+
+	staticNames := s.skillSet.Names() // nil-safe — Set.Names handles nil receiver
+	entries := make([]LibraryEntry, 0, len(staticNames)+len(subRows))
+	seen := map[string]struct{}{}
+
+	for _, name := range staticNames {
+		sk, _ := s.skillSet.Get(name)
+		entry := LibraryEntry{
+			Name:             name,
+			InStatic:         true,
+			StaticDefinition: marshalStaticSkill(sk),
+		}
+		if sub, ok := subRows[name]; ok {
+			entry.InSubstrate = true
+			entry.VersionCount = sub.VersionCount
+			entry.ActiveDefID = sub.ActiveDefID
+			entry.LatestVersion = sub.LatestVersion
+			entry.LastUpdated = sub.LastUpdated
+		}
+		entry.Source = deriveSource(entry.InStatic, entry.InSubstrate)
+		entries = append(entries, entry)
+		seen[name] = struct{}{}
+	}
+	for name, sub := range subRows {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		entries = append(entries, LibraryEntry{
+			Name:          name,
+			Source:        deriveSource(false, true),
+			InSubstrate:   true,
+			VersionCount:  sub.VersionCount,
+			ActiveDefID:   sub.ActiveDefID,
+			LatestVersion: sub.LatestVersion,
+			LastUpdated:   sub.LastUpdated,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	writeJSONOK(w, libraryListResponse{Entries: entries})
+}
+
+// handleListLibraryMcpServers serves GET /v1/_library/mcp-servers.
+//
+// Static MCP servers get their cached discovered_tools attached when
+// the pool inspector is wired AND the pool has a ready entry for the
+// server. When the inspector returns nil (init pending or failed),
+// the entry omits `discovered_tools` — the operator can re-check
+// after the pool finishes init.
+func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Request) {
+	subRows := map[string]store.MCPServerDefNameSummary{}
+	if s.store != nil {
+		rows, err := s.store.MCPServerDefListNames(r.Context())
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		for _, row := range rows {
+			subRows[row.Name] = row
+		}
+	}
+
+	entries := make([]LibraryEntry, 0, len(s.cfg.MCPServers)+len(subRows))
+	seen := map[string]struct{}{}
+
+	for name, srv := range s.cfg.MCPServers {
+		var discoveredTools json.RawMessage
+		if s.mcpPoolInspector != nil {
+			discoveredTools = s.mcpPoolInspector(name)
+		}
+		entry := LibraryEntry{
+			Name:             name,
+			InStatic:         true,
+			StaticDefinition: marshalStaticMCPServer(srv, discoveredTools),
+		}
+		if sub, ok := subRows[name]; ok {
+			entry.InSubstrate = true
+			entry.VersionCount = sub.VersionCount
+			entry.ActiveDefID = sub.ActiveDefID
+			entry.LatestVersion = sub.LatestVersion
+			entry.LastUpdated = sub.LastUpdated
+		}
+		entry.Source = deriveSource(entry.InStatic, entry.InSubstrate)
+		entries = append(entries, entry)
+		seen[name] = struct{}{}
+	}
+	for name, sub := range subRows {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		entries = append(entries, LibraryEntry{
+			Name:          name,
+			Source:        deriveSource(false, true),
+			InSubstrate:   true,
+			VersionCount:  sub.VersionCount,
+			ActiveDefID:   sub.ActiveDefID,
+			LatestVersion: sub.LatestVersion,
+			LastUpdated:   sub.LastUpdated,
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	writeJSONOK(w, libraryListResponse{Entries: entries})
+}
+
+func deriveSource(inStatic, inSubstrate bool) string {
+	switch {
+	case inStatic && inSubstrate:
+		return "both"
+	case inStatic:
+		return "static-only"
+	default:
+		return "dynamic-only"
+	}
+}
+
+// staticAgentDefJSON mirrors the substrate shape of mergedDef +
+// lookup.SubstrateAgentDef so the same renderer in the UI consumes
+// both static and substrate-derived definitions. config.AgentDef
+// carries yaml-only tags, which is why this shadow struct exists —
+// the same conceptual fix PR #184 applied for the substrate-read
+// path.
+type staticAgentDefJSON struct {
+	Provider         string                            `json:"provider,omitempty"`
+	Model            string                            `json:"model,omitempty"`
+	Tier             string                            `json:"tier,omitempty"`
+	Effort           string                            `json:"effort,omitempty"`
+	MaxTokens        int                               `json:"max_tokens,omitempty"`
+	MaxIterations    int                               `json:"max_iterations,omitempty"`
+	SystemPrompt     string                            `json:"system_prompt,omitempty"`
+	SystemPromptBase string                            `json:"system_prompt_base,omitempty"`
+	AllowedTools     []string                          `json:"allowed_tools,omitempty"`
+	Skills           []string                          `json:"skills,omitempty"`
+	Providers        []string                          `json:"providers,omitempty"`
+	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
+	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
+	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+}
+
+func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
+	b, err := json.Marshal(staticAgentDefJSON{
+		Provider:         def.Provider,
+		Model:            def.Model,
+		Tier:             def.Tier,
+		Effort:           def.Effort,
+		MaxTokens:        def.MaxTokens,
+		MaxIterations:    def.MaxIterations,
+		SystemPrompt:     def.SystemPrompt,
+		SystemPromptBase: def.SystemPromptBase,
+		AllowedTools:     def.AllowedTools,
+		Skills:           def.Skills,
+		Providers:        def.Providers,
+		Models:           def.Models,
+		MemoryScopes:     def.MemoryScopes,
+		MemoryQuotaBytes: def.MemoryQuotaBytes,
+	})
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+type staticSkillJSON struct {
+	Body         string   `json:"body,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	AllowedTools []string `json:"allowed_tools,omitempty"`
+}
+
+// marshalStaticSkill projects the loader's Skill struct (which carries
+// no json tags) onto the substrate-mirror shape so the UI renderer
+// is source-agnostic.
+func marshalStaticSkill(sk *skills.Skill) json.RawMessage {
+	if sk == nil {
+		return nil
+	}
+	b, err := json.Marshal(staticSkillJSON{
+		Body:         sk.Body,
+		Description:  sk.Description,
+		AllowedTools: sk.AllowedTools,
+	})
+	if err != nil {
+		return nil
+	}
+	return b
+}
+
+// marshalStaticMCPServer projects cfg.MCPServer onto a wire shape
+// that mirrors the substrate's mcp_server_defs.definition JSON
+// (transport / url / headers / discovered_tools) plus the stdio-only
+// fields the substrate refuses (command / args / env / pool_size).
+// AllowedTools is the operator's narrowing filter on tool exposure.
+//
+// discoveredTools is the marshaled JSON from PeekTools; nil = absent
+// (init pending or failed). When non-nil it's already in the
+// substrate-mirror shape, so we embed it via json.RawMessage.
+func marshalStaticMCPServer(srv config.MCPServer, discoveredTools json.RawMessage) json.RawMessage {
+	type staticMCPJSON struct {
+		Transport       string            `json:"transport,omitempty"`
+		URL             string            `json:"url,omitempty"`
+		Headers         map[string]string `json:"headers,omitempty"`
+		Command         string            `json:"command,omitempty"`
+		Args            []string          `json:"args,omitempty"`
+		Env             map[string]string `json:"env,omitempty"`
+		PoolSize        int               `json:"pool_size,omitempty"`
+		AllowedTools    []string          `json:"allowed_tools,omitempty"`
+		DiscoveredTools json.RawMessage   `json:"discovered_tools,omitempty"`
+	}
+	b, err := json.Marshal(staticMCPJSON{
+		Transport:       srv.Transport,
+		URL:             srv.URL,
+		Headers:         srv.Headers,
+		Command:         srv.Command,
+		Args:            srv.Args,
+		Env:             srv.Env,
+		PoolSize:        srv.PoolSize,
+		AllowedTools:    srv.AllowedTools,
+		DiscoveredTools: discoveredTools,
+	})
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -1,0 +1,329 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// libraryUnifiedFixture is a variant of libraryFixture (library_admin_test.go)
+// that allows pre-seeding cfg.Agents / cfg.MCPServers so we can exercise the
+// static-side merge in the unified endpoints.
+func libraryUnifiedFixture(
+	t *testing.T,
+	staticAgents map[string]config.AgentDef,
+	staticMCP map[string]config.MCPServer,
+) (*Server, store.Store, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Env: config.Env{
+			AuthToken:             "test-token",
+			ChannelsMaxValueBytes: 64 * 1024,
+			ChannelsLongPollCapMS: 1000,
+		},
+		Agents:     staticAgents,
+		MCPServers: staticMCP,
+	}
+	hookReg := hooks.NewRegistry()
+	srv := &Server{
+		cfg:            cfg,
+		store:          s,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+	return srv, s, func() { _ = s.Close() }
+}
+
+func decodeLibraryEntries(t *testing.T, rec *httptest.ResponseRecorder) []LibraryEntry {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp libraryListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return resp.Entries
+}
+
+// TestUnifiedLibrary_Agents_StaticOnly — yaml-only entry, empty store.
+// Expect source=static-only, in_static=true, in_substrate=false,
+// version_count=0, static_definition non-nil.
+func TestUnifiedLibrary_Agents_StaticOnly(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"qa": {
+			Model:        "stub-model",
+			SystemPrompt: "you are qa",
+			AllowedTools: []string{"Read"},
+		},
+	}, nil)
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 || entries[0].Name != "qa" {
+		t.Fatalf("entries = %+v, want 1 entry 'qa'", entries)
+	}
+	e := entries[0]
+	if e.Source != "static-only" || !e.InStatic || e.InSubstrate {
+		t.Errorf("source flags wrong: source=%q in_static=%v in_substrate=%v", e.Source, e.InStatic, e.InSubstrate)
+	}
+	if e.VersionCount != 0 || e.ActiveDefID != "" || e.LatestVersion != 0 {
+		t.Errorf("substrate counters should be zero: %+v", e)
+	}
+	if len(e.StaticDefinition) == 0 {
+		t.Fatalf("static_definition empty")
+	}
+	var def struct {
+		SystemPrompt string   `json:"system_prompt"`
+		AllowedTools []string `json:"allowed_tools"`
+	}
+	if err := json.Unmarshal(e.StaticDefinition, &def); err != nil {
+		t.Fatal(err)
+	}
+	if def.SystemPrompt != "you are qa" || len(def.AllowedTools) != 1 || def.AllowedTools[0] != "Read" {
+		t.Errorf("static_definition payload wrong: %+v", def)
+	}
+}
+
+// TestUnifiedLibrary_Agents_DynamicOnly — substrate row with no yaml twin.
+// Expect source=dynamic-only, in_substrate=true, no static_definition.
+func TestUnifiedLibrary_Agents_DynamicOnly(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, nil, nil)
+	defer cleanup()
+
+	ctx := t.Context()
+	_, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_evaluator_v1", Name: "evaluator", Version: 1,
+		Definition: []byte(`{"system_prompt":"eval"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = s.AgentDefSetActive(ctx, "evaluator", "def_evaluator_v1", "")
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 || entries[0].Name != "evaluator" {
+		t.Fatalf("entries = %+v, want 1 entry 'evaluator'", entries)
+	}
+	e := entries[0]
+	if e.Source != "dynamic-only" || e.InStatic || !e.InSubstrate {
+		t.Errorf("source flags wrong: %+v", e)
+	}
+	if e.VersionCount != 1 || e.ActiveDefID != "def_evaluator_v1" || e.LatestVersion != 1 {
+		t.Errorf("substrate counters missing: %+v", e)
+	}
+	if len(e.StaticDefinition) != 0 {
+		t.Errorf("static_definition should be absent for dynamic-only: %s", e.StaticDefinition)
+	}
+}
+
+// TestUnifiedLibrary_Agents_Both — yaml AND substrate hold the name.
+// Expect source=both, both flags true, substrate counters populated,
+// static_definition populated.
+func TestUnifiedLibrary_Agents_Both(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"researcher": {Model: "stub", SystemPrompt: "yaml-side"},
+	}, nil)
+	defer cleanup()
+
+	ctx := t.Context()
+	_, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_r_v1", Name: "researcher", Version: 1,
+		Definition: []byte(`{"system_prompt":"substrate-side"}`), CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = s.AgentDefSetActive(ctx, "researcher", "def_r_v1", "")
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v, want 1 entry", entries)
+	}
+	e := entries[0]
+	if e.Source != "both" || !e.InStatic || !e.InSubstrate {
+		t.Errorf("source flags wrong: %+v", e)
+	}
+	if e.VersionCount != 1 || e.ActiveDefID != "def_r_v1" {
+		t.Errorf("substrate counters missing: %+v", e)
+	}
+	if len(e.StaticDefinition) == 0 {
+		t.Fatalf("static_definition missing for both-source entry")
+	}
+}
+
+// TestUnifiedLibrary_Agents_SortedAlphabetically — three names, one of each
+// source flavor, mixed insertion order. Output sorted by name.
+func TestUnifiedLibrary_Agents_SortedAlphabetically(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"zebra": {Model: "x"},
+		"alpha": {Model: "x"},
+	}, nil)
+	defer cleanup()
+	ctx := t.Context()
+	_, _ = s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_m_v1", Name: "middle", Version: 1,
+		Definition: []byte(`{}`), CreatedAt: time.Now(),
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 3 {
+		t.Fatalf("entries = %d, want 3", len(entries))
+	}
+	want := []string{"alpha", "middle", "zebra"}
+	for i, n := range want {
+		if entries[i].Name != n {
+			t.Errorf("entries[%d].Name = %q, want %q", i, entries[i].Name, n)
+		}
+	}
+}
+
+// TestUnifiedLibrary_MCP_StdioStaticOnly — cfg has a stdio server with
+// Command/Args/Env; no substrate row, no pool inspector.
+// Expect static_definition.transport="stdio", command/args/env populated,
+// discovered_tools omitted (no inspector wired).
+func TestUnifiedLibrary_MCP_StdioStaticOnly(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, nil, map[string]config.MCPServer{
+		"local-tools": {
+			Transport: "stdio",
+			Command:   "node",
+			Args:      []string{"server.js"},
+			Env:       map[string]string{"MCP_VERBOSE": "1"},
+			PoolSize:  2,
+		},
+	})
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/mcp-servers", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 || entries[0].Name != "local-tools" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	var def struct {
+		Transport       string            `json:"transport"`
+		Command         string            `json:"command"`
+		Args            []string          `json:"args"`
+		Env             map[string]string `json:"env"`
+		PoolSize        int               `json:"pool_size"`
+		DiscoveredTools json.RawMessage   `json:"discovered_tools"`
+	}
+	if err := json.Unmarshal(entries[0].StaticDefinition, &def); err != nil {
+		t.Fatal(err)
+	}
+	if def.Transport != "stdio" || def.Command != "node" || len(def.Args) != 1 || def.Args[0] != "server.js" {
+		t.Errorf("stdio fields wrong: %+v", def)
+	}
+	if def.Env["MCP_VERBOSE"] != "1" || def.PoolSize != 2 {
+		t.Errorf("env/pool_size wrong: %+v", def)
+	}
+	if len(def.DiscoveredTools) != 0 {
+		t.Errorf("discovered_tools should be absent without pool inspector: %s", def.DiscoveredTools)
+	}
+}
+
+// TestUnifiedLibrary_MCP_HTTPWithPoolInspector — cfg has http server,
+// pool inspector returns 2 tools. Expect discovered_tools populated.
+func TestUnifiedLibrary_MCP_HTTPWithPoolInspector(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, nil, map[string]config.MCPServer{
+		"remote-mcp": {
+			Transport: "http",
+			URL:       "https://example.invalid/api/mcp",
+			Headers:   map[string]string{"Authorization": "Bearer x"},
+		},
+	})
+	defer cleanup()
+
+	srv.SetMCPPoolInspector(func(name string) json.RawMessage {
+		if name != "remote-mcp" {
+			return nil
+		}
+		return json.RawMessage(`[{"name":"search","description":"web search","input_schema":{"type":"object"}},{"name":"fetch","input_schema":{"type":"object"}}]`)
+	})
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/mcp-servers", nil))
+	entries := decodeLibraryEntries(t, rec)
+
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	var def struct {
+		Transport       string `json:"transport"`
+		URL             string `json:"url"`
+		DiscoveredTools []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+		} `json:"discovered_tools"`
+	}
+	if err := json.Unmarshal(entries[0].StaticDefinition, &def); err != nil {
+		t.Fatal(err)
+	}
+	if def.Transport != "http" || def.URL != "https://example.invalid/api/mcp" {
+		t.Errorf("http fields wrong: %+v", def)
+	}
+	if len(def.DiscoveredTools) != 2 || def.DiscoveredTools[0].Name != "search" || def.DiscoveredTools[1].Name != "fetch" {
+		t.Errorf("discovered_tools missing or wrong shape: %+v", def.DiscoveredTools)
+	}
+}
+
+// TestUnifiedLibrary_OldEndpoints_StillWork — invoking the v1 /names
+// endpoint after the new unified endpoint exists must return the
+// pre-v0.9.x wire shape byte-for-byte. Backwards-compat guard for the
+// TS adapter consumer.
+func TestUnifiedLibrary_OldEndpoints_StillWork(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, nil, nil)
+	defer cleanup()
+
+	ctx := t.Context()
+	_, _ = s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_v1", Name: "x", Version: 1,
+		Definition: []byte(`{}`), CreatedAt: time.Now(),
+	})
+	_ = s.AgentDefSetActive(ctx, "x", "def_v1", "")
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_agentdef/names", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("old endpoint broken: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.AgentDefNameSummary `json:"names"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Names) != 1 || resp.Names[0].Name != "x" {
+		t.Errorf("old endpoint shape changed: %+v", resp.Names)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1341,6 +1341,14 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_agentdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListAgentDefNames))))
 	mux.Handle("GET /v1/_skilldef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListSkillDefNames))))
 	mux.Handle("GET /v1/_mcpserverdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMCPServerDefNames))))
+	// v0.9.x Library v2 — unified enumeration that merges static cfg
+	// + substrate views into one envelope per entry. The names/* sister
+	// endpoints above stay as-is for backwards compat with external
+	// adapter consumers; these new endpoints back the /ui/library v2
+	// tab which shows STATIC + DYNAMIC entries with source chips.
+	mux.Handle("GET /v1/_library/agents", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListLibraryAgents))))
+	mux.Handle("GET /v1/_library/skills", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListLibrarySkills))))
+	mux.Handle("GET /v1/_library/mcp-servers", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListLibraryMcpServers))))
 	// v0.9.x Introspection — channels an agent has cursored on
 	// (scope=agent, scope_id={agent_name}). Drives the Web UI's
 	// per-agent "channels this agent is subscribed to" sub-tab.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -112,6 +112,16 @@ type Server struct {
 	// constructed.
 	metricsSampler *metrics.Sampler
 
+	// mcpPoolInspector returns the cached tools/list result for a
+	// named MCP server as already-marshaled JSON. The "already JSON"
+	// wire keeps this package free of internal/tools/mcp imports.
+	// Returns nil when the Pool has no cached entry (init pending or
+	// failed; server unknown). Used by the v0.9.x unified library
+	// endpoints to surface static MCP servers' discovered_tools
+	// alongside the substrate-side discovered_tools field. Wired in
+	// cmd/loomcycle/main.go via SetMCPPoolInspector.
+	mcpPoolInspector MCPPoolInspector
+
 	// skillSet is the static skills.Set loaded at boot from
 	// LOOMCYCLE_SKILLS_ROOT. Used by resolveSkillBodiesForRun (v0.8.22)
 	// to fall back to the static body when a skill name has no
@@ -246,6 +256,22 @@ func (s *Server) SetBuildInfo(version, commit, builtAt string) {
 // cmd/loomcycle/main.go after the MCP pool is built.
 func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
 	s.mcpFallback = fn
+}
+
+// MCPPoolInspector returns the cached tools/list result for an MCP
+// server name as already-JSON-marshaled bytes ([{name, description,
+// input_schema}, …]) or nil when the Pool has no cached entry. The
+// "already JSON" wire keeps this package free of internal/tools/mcp
+// imports — the http layer doesn't need ToolDescriptor's Go shape,
+// only the marshaled output for embedding into the library response.
+type MCPPoolInspector func(name string) json.RawMessage
+
+// SetMCPPoolInspector wires the live Pool's PeekTools accessor so the
+// v0.9.x /v1/_library/mcp-servers endpoint can enumerate static
+// servers' tool lists. Nil leaves the inspector unset — static MCP
+// entries in the library response will omit `discovered_tools`.
+func (s *Server) SetMCPPoolInspector(fn MCPPoolInspector) {
+	s.mcpPoolInspector = fn
 }
 
 // SetMetricsSampler installs the v0.8.x metrics sampler so the

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -240,6 +240,38 @@ func (p *Pool) Tools() []tools.Tool {
 	return out
 }
 
+// PeekTools returns a snapshot of the cached tools/list result for
+// name. Returns nil when the entry is absent, still initialising, or
+// init failed — none of those mean "no tools", they mean "no cached
+// answer to surface." Callers should treat nil as "ask again later"
+// rather than "this server has zero tools".
+//
+// Read-only — never triggers handshake or eviction. Used by the
+// Library introspection endpoint to enumerate static MCP servers'
+// tool lists without forcing wire round-trips.
+func (p *Pool) PeekTools(name string) []ToolDescriptor {
+	p.mu.Lock()
+	e, ok := p.servers[name]
+	p.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	select {
+	case <-e.ready:
+		if e.err != nil {
+			return nil
+		}
+		// Defensive snapshot — descriptors are immutable post-init,
+		// but returning the slice header directly would let a caller
+		// mutate p's state by appending past cap.
+		out := make([]ToolDescriptor, len(e.tools))
+		copy(out, e.tools)
+		return out
+	default:
+		return nil
+	}
+}
+
 // Close tears down all live connections. Idempotent. Skips entries that
 // are still initialising or that failed init (no caller to tear down).
 func (p *Pool) Close() {

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -555,3 +555,48 @@ func TestGetWithRetryGivesUpWhenCtxExpires(t *testing.T) {
 		t.Errorf("retry kept running well past ctx deadline (took %s)", elapsed)
 	}
 }
+
+func TestPool_PeekTools_ReturnsNilForUnknownServer(t *testing.T) {
+	pool := newPoolWithFake(t, "ok")
+	if got := pool.PeekTools("does-not-exist"); got != nil {
+		t.Errorf("PeekTools on unknown name = %+v, want nil", got)
+	}
+}
+
+func TestPool_PeekTools_ReturnsCachedSnapshotAfterGet(t *testing.T) {
+	pool := newPoolWithFake(t, "ok")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, _, err := pool.Get(ctx, "search"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	descs := pool.PeekTools("search")
+	if len(descs) != 1 || descs[0].Name != "web_search" {
+		t.Errorf("PeekTools = %+v, want one entry web_search", descs)
+	}
+}
+
+func TestPool_PeekTools_ReturnsNilAfterEvictedInitFailure(t *testing.T) {
+	// build returns an error on the first call — Pool deletes the
+	// entry from p.servers on init failure (pool.go:121-123), so the
+	// nil-return path here is "entry no longer in map" rather than
+	// "entry has err set". Same external observation, different
+	// internal branch; documented here so a future refactor that
+	// keeps failed entries in the map still produces nil from
+	// PeekTools.
+	pool := mcp.NewPool(
+		func(name string) (mcp.Caller, error) {
+			return nil, errors.New("transient build failure")
+		},
+		func(c mcp.Caller) {},
+	)
+	t.Cleanup(pool.Close)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, _, err := pool.Get(ctx, "broken"); err == nil {
+		t.Fatal("expected init to fail")
+	}
+	if got := pool.PeekTools("broken"); got != nil {
+		t.Errorf("PeekTools after init failure = %+v, want nil", got)
+	}
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -816,7 +816,51 @@ export interface AgentChannelsResponse {
   channels: ChannelCursorEntry[];
 }
 
-// ---- Library fetchers ----
+// ---- Library v2 (unified — yaml + substrate merged) ----
+
+// LibraryEntry is one row of the v0.9.x /v1/_library/* endpoints. It
+// merges substrate name-summary fields with cfg-side staticDefinition,
+// plus the source discriminator (computed server-side from
+// in_static + in_substrate booleans).
+export interface LibraryEntry {
+  name: string;
+  source: "static-only" | "dynamic-only" | "both";
+  in_static: boolean;
+  in_substrate: boolean;
+  version_count: number;
+  active_def_id?: string;
+  latest_version?: number;
+  last_updated?: string;
+  /**
+   * Static-side definition payload. Same JSON shape as the substrate
+   * body (snake_case keys mirroring lookup.SubstrateAgentDef /
+   * skillDefOverlay / mcpServerOverlay) so the same renderer consumes
+   * both static and dynamic sources. Omitted when in_static is false.
+   */
+  static_definition?: unknown;
+}
+
+export interface LibraryListResponse {
+  entries: LibraryEntry[];
+}
+
+export function listLibraryAgents(): Promise<LibraryListResponse> {
+  return jsonFetch<LibraryListResponse>("/v1/_library/agents");
+}
+
+export function listLibrarySkills(): Promise<LibraryListResponse> {
+  return jsonFetch<LibraryListResponse>("/v1/_library/skills");
+}
+
+export function listLibraryMcpServers(): Promise<LibraryListResponse> {
+  return jsonFetch<LibraryListResponse>("/v1/_library/mcp-servers");
+}
+
+// ---- Legacy /names fetchers (substrate-only) ----
+//
+// Kept for the existing Library UI v1 surface + any external adapter
+// consumers that pinned the substrate-only wire shape. Library UI v2
+// uses listLibrary{Agents,Skills,McpServers} above.
 
 export function listAgentDefNames(): Promise<DefNamesResponse> {
   return jsonFetch<DefNamesResponse>("/v1/_agentdef/names");

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -160,6 +160,7 @@ export default function LineagePanel({
           activeDefID={activeDefID}
           selectedDefID={selectedDefID}
           onSelect={setSelectedDefID}
+          renderDefinition={renderDefinition}
         />
         {selectedRow && (
           <div className="lineage-detail">

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -1,29 +1,34 @@
 import { useEffect, useMemo, useState } from "react";
 import {
-  DefNameSummary,
   DefRow,
+  LibraryEntry,
   listDefVersionsByName,
 } from "../api";
 import Splitter from "./Splitter";
 import LineageTree, { buildLineageTree } from "./LineageTree";
 
 // LineagePanel is the shared shape that backs each Library sub-tab
-// (Agents / Skills / MCP Servers). Left pane lists declared NAMES
-// supplied by the parent page; right pane shows the lineage tree
-// for the selected name + the selected version's definition JSON.
+// (Agents / Skills / MCP Servers). Left pane lists entries with
+// STATIC / DYNAMIC source chips; right pane shows the lineage tree
+// for the selected entry + the selected version's definition JSON.
 //
-// Polling cadence: name list refresh is owned by the parent (Library
-// page calls listAgentDefNames / listSkillDefNames / etc.); version
-// lineage refreshes on selection change.
+// v0.9.x Library v2: each entry can be source=static-only,
+// dynamic-only, or both. Static-only entries appear as a synthetic
+// v0 row in the tree (def_id="static:<name>") so the same LineageTree
+// component renders them uniformly with substrate-backed rows.
+//
+// Polling cadence: entry list refresh is owned by the parent
+// (LibraryView calls listLibraryAgents / listLibrarySkills / etc.);
+// version lineage refreshes on selection change.
 
 export interface LineagePanelProps {
   // Substrate kind used in the listDefVersionsByName API call.
   kind: "agentdef" | "skilldef" | "mcpserverdef";
   // Human-readable label for the empty-state copy.
   kindLabel: string;
-  // List of declared names — fetched by the parent so the polling
+  // Unified entries — fetched by the parent so the polling
   // strategy stays uniform with other admin pages.
-  names: DefNameSummary[];
+  entries: LibraryEntry[];
   // Storage key for the Splitter's persisted width (per sub-tab so
   // the operator can size them independently).
   splitterStorageKey: string;
@@ -36,31 +41,53 @@ export interface LineagePanelProps {
 export default function LineagePanel({
   kind,
   kindLabel,
-  names,
+  entries,
   splitterStorageKey,
   renderDefinition,
 }: LineagePanelProps) {
   const [selectedName, setSelectedName] = useState<string>(() =>
-    names.length > 0 ? names[0]!.name : "",
+    entries.length > 0 ? entries[0]!.name : "",
   );
   const [versions, setVersions] = useState<DefRow[]>([]);
   const [versionsErr, setVersionsErr] = useState<string | null>(null);
   const [versionsLoading, setVersionsLoading] = useState(false);
   const [selectedDefID, setSelectedDefID] = useState<string>("");
 
-  // When the names list updates and the currently-selected name is
+  const selectedEntry = useMemo(
+    () => entries.find((e) => e.name === selectedName),
+    [entries, selectedName],
+  );
+
+  // When the entries list updates and the currently-selected name is
   // gone (renamed / retired tree), fall back to the first available.
   useEffect(() => {
-    if (selectedName && names.find((n) => n.name === selectedName)) return;
-    setSelectedName(names.length > 0 ? names[0]!.name : "");
-  }, [names, selectedName]);
+    if (selectedName && entries.find((e) => e.name === selectedName)) return;
+    setSelectedName(entries.length > 0 ? entries[0]!.name : "");
+  }, [entries, selectedName]);
 
-  // Fetch the lineage for the selected name. Selecting a different
-  // name resets the selectedDefID + clears the previous lineage.
+  // Fetch the lineage for the selected entry.
+  // - Static-only: synthesize a single v0 pseudo-row from
+  //   entry.static_definition. Skip the network call entirely.
+  // - dynamic-only / both: fetch the substrate lineage chain.
   useEffect(() => {
-    if (!selectedName) {
+    if (!selectedName || !selectedEntry) {
       setVersions([]);
       setSelectedDefID("");
+      return;
+    }
+    if (!selectedEntry.in_substrate) {
+      // Static-only — synthesize the pseudo-row inline. No network.
+      const syntheticRow: DefRow = {
+        def_id: `static:${selectedEntry.name}`,
+        name: selectedEntry.name,
+        version: 0,
+        created_at: "",
+        definition: selectedEntry.static_definition,
+      };
+      setVersions([syntheticRow]);
+      setSelectedDefID(syntheticRow.def_id);
+      setVersionsLoading(false);
+      setVersionsErr(null);
       return;
     }
     let cancelled = false;
@@ -73,9 +100,8 @@ export default function LineagePanel({
         setVersionsLoading(false);
         // Pre-select the active version if available, else the
         // highest-version (most recent) row.
-        const summary = names.find((n) => n.name === selectedName);
-        if (summary?.active_def_id) {
-          setSelectedDefID(summary.active_def_id);
+        if (selectedEntry.active_def_id) {
+          setSelectedDefID(selectedEntry.active_def_id);
         } else if (r.versions && r.versions.length > 0) {
           const top = [...r.versions].sort((a, b) => b.version - a.version)[0]!;
           setSelectedDefID(top.def_id);
@@ -91,23 +117,20 @@ export default function LineagePanel({
     return () => {
       cancelled = true;
     };
-  }, [kind, selectedName, names]);
+  }, [kind, selectedName, selectedEntry]);
 
   const tree = useMemo(() => buildLineageTree(versions), [versions]);
-  const activeDefID = useMemo(
-    () => names.find((n) => n.name === selectedName)?.active_def_id ?? "",
-    [names, selectedName],
-  );
+  const activeDefID = selectedEntry?.active_def_id ?? "";
   const selectedRow = useMemo(
     () => versions.find((v) => v.def_id === selectedDefID),
     [versions, selectedDefID],
   );
 
-  if (names.length === 0) {
+  if (entries.length === 0) {
     return (
       <div className="empty-state">
         No {kindLabel} declared yet. Use the substrate admin API
-        (POST /v1/_{kind}) to create one.
+        (POST /v1/_{kind}) or add one to loomcycle.yaml.
       </div>
     );
   }
@@ -119,8 +142,8 @@ export default function LineagePanel({
       minLeftWidth={220}
       minRightWidth={320}
     >
-      <NameList
-        names={names}
+      <EntryList
+        entries={entries}
         selectedName={selectedName}
         onSelect={setSelectedName}
       />
@@ -147,9 +170,11 @@ export default function LineagePanel({
                   ← {selectedRow.parent_def_id}
                 </span>
               )}
-              <span className="lineage-detail-meta">
-                created {new Date(selectedRow.created_at).toLocaleString()}
-              </span>
+              {selectedRow.created_at && (
+                <span className="lineage-detail-meta">
+                  created {new Date(selectedRow.created_at).toLocaleString()}
+                </span>
+              )}
               {selectedRow.content_sha256 && (
                 <span className="mono lineage-detail-meta" title={selectedRow.content_sha256}>
                   {shortenSHA(selectedRow.content_sha256)}
@@ -164,22 +189,22 @@ export default function LineagePanel({
   );
 }
 
-function NameList({
-  names,
+function EntryList({
+  entries,
   selectedName,
   onSelect,
 }: {
-  names: DefNameSummary[];
+  entries: LibraryEntry[];
   selectedName: string;
   onSelect: (name: string) => void;
 }) {
   return (
     <ul className="lineage-name-list">
-      {names.map((n) => (
+      {entries.map((e) => (
         <li
-          key={n.name}
+          key={e.name}
           className={
-            n.name === selectedName
+            e.name === selectedName
               ? "lineage-name-row lineage-name-selected"
               : "lineage-name-row"
           }
@@ -187,22 +212,39 @@ function NameList({
           <button
             type="button"
             className="lineage-name-button"
-            onClick={() => onSelect(n.name)}
+            onClick={() => onSelect(e.name)}
           >
-            <span className="lineage-name-label">{n.name}</span>
+            <span className="lineage-name-label">{e.name}</span>
             <span className="lineage-name-versions">
-              {n.version_count} version{n.version_count === 1 ? "" : "s"}
+              {entryCountLabel(e)}
             </span>
-            {n.active_def_id ? (
-              <span className="def-chip def-chip-active">v{n.latest_version} ★</span>
-            ) : (
-              <span className="def-chip def-chip-no-active">no active</span>
-            )}
+            <span className="lineage-name-chips">
+              {e.in_static && (
+                <span className="def-chip def-chip-static">static</span>
+              )}
+              {e.in_substrate && (
+                <span className="def-chip def-chip-dynamic">dynamic</span>
+              )}
+              {e.in_substrate && e.active_def_id && (
+                <span className="def-chip def-chip-active">
+                  v{e.latest_version ?? "?"} ★
+                </span>
+              )}
+              {e.in_substrate && !e.active_def_id && (
+                <span className="def-chip def-chip-no-active">no active</span>
+              )}
+            </span>
           </button>
         </li>
       ))}
     </ul>
   );
+}
+
+function entryCountLabel(e: LibraryEntry): string {
+  if (!e.in_substrate) return "static only";
+  const n = e.version_count;
+  return `${n} version${n === 1 ? "" : "s"}`;
 }
 
 function shortenSHA(s: string): string {

--- a/web/src/components/LineageTree.tsx
+++ b/web/src/components/LineageTree.tsx
@@ -48,6 +48,11 @@ export interface LineageTreeProps {
   activeDefID?: string;
   selectedDefID?: string;
   onSelect?: (defID: string) => void;
+  // Inline-detail renderer (v0.9.x Library v2). When set, each row
+  // gets a content-toggle chevron at the row-end; clicking it
+  // expands the definition body inline under the row. Independent
+  // of the parent/child collapse chevron at the row-start.
+  renderDefinition?: (row: DefRow) => React.ReactNode;
 }
 
 export default function LineageTree({
@@ -55,8 +60,12 @@ export default function LineageTree({
   activeDefID,
   selectedDefID,
   onSelect,
+  renderDefinition,
 }: LineageTreeProps) {
   const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
+  const [detailExpanded, setDetailExpanded] = useState<Map<string, boolean>>(
+    () => new Map(),
+  );
 
   // Auto-expand ancestors of the selected node so a deep-link / fresh
   // click never leaves the selection buried under a collapsed parent.
@@ -88,6 +97,19 @@ export default function LineageTree({
     });
   }, []);
 
+  // Default-COLLAPSED for the content detail toggle — opposite of the
+  // parent/child collapse default. Operators opt into content view
+  // per-row; the detail body can be long and we don't want every
+  // row's body rendered by default.
+  const toggleDetail = useCallback((id: string) => {
+    setDetailExpanded((prev) => {
+      const next = new Map(prev);
+      const currentExpanded = next.get(id) === true;
+      next.set(id, !currentExpanded);
+      return next;
+    });
+  }, []);
+
   return (
     <ul className="lineage-tree" role="tree">
       {tree.map((node) => (
@@ -97,9 +119,12 @@ export default function LineageTree({
           depth={0}
           expanded={expanded}
           toggleExpanded={toggleExpanded}
+          detailExpanded={detailExpanded}
+          toggleDetail={toggleDetail}
           activeDefID={activeDefID}
           selectedDefID={selectedDefID}
           onSelect={onSelect}
+          renderDefinition={renderDefinition}
         />
       ))}
     </ul>
@@ -111,19 +136,26 @@ function LineageNodeRow({
   depth,
   expanded,
   toggleExpanded,
+  detailExpanded,
+  toggleDetail,
   activeDefID,
   selectedDefID,
   onSelect,
+  renderDefinition,
 }: {
   node: LineageNode;
   depth: number;
   expanded: Map<string, boolean>;
   toggleExpanded: (id: string) => void;
+  detailExpanded: Map<string, boolean>;
+  toggleDetail: (id: string) => void;
   activeDefID?: string;
   selectedDefID?: string;
   onSelect?: (defID: string) => void;
+  renderDefinition?: (row: DefRow) => React.ReactNode;
 }) {
   const isExpanded = expanded.get(node.row.def_id) !== false;
+  const isDetailOpen = detailExpanded.get(node.row.def_id) === true;
   const hasChildren = node.children.length > 0;
   const isActive = node.row.def_id === activeDefID;
   const isSelected = node.row.def_id === selectedDefID;
@@ -164,7 +196,27 @@ function LineageNodeRow({
           )}
           <span className="lineage-defid mono">{shortDefID(row.def_id)}</span>
         </button>
+        {renderDefinition && (
+          <button
+            type="button"
+            className="lineage-content-toggle"
+            onClick={() => toggleDetail(row.def_id)}
+            aria-expanded={isDetailOpen}
+            aria-label={isDetailOpen ? "Hide content" : "Show content"}
+            title={isDetailOpen ? "Hide content" : "Show content"}
+          >
+            {isDetailOpen ? "▾" : "▸"} content
+          </button>
+        )}
       </div>
+      {isDetailOpen && renderDefinition && (
+        <div
+          className="lineage-row-detail"
+          style={{ paddingLeft: `${(depth + 1) * 16 + 12}px` }}
+        >
+          {renderDefinition(row)}
+        </div>
+      )}
       {isExpanded && hasChildren && (
         <ul role="group">
           {node.children.map((child) => (
@@ -174,9 +226,12 @@ function LineageNodeRow({
               depth={depth + 1}
               expanded={expanded}
               toggleExpanded={toggleExpanded}
+              detailExpanded={detailExpanded}
+              toggleDetail={toggleDetail}
               activeDefID={activeDefID}
               selectedDefID={selectedDefID}
               onSelect={onSelect}
+              renderDefinition={renderDefinition}
             />
           ))}
         </ul>

--- a/web/src/components/LineageTree.tsx
+++ b/web/src/components/LineageTree.tsx
@@ -149,7 +149,14 @@ function LineageNodeRow({
           className="lineage-row-button"
           onClick={() => onSelect?.(row.def_id)}
         >
-          <span className="lineage-version">v{row.version}</span>
+          {row.version === 0 && row.def_id.startsWith("static:") ? (
+            <span className="lineage-version">static</span>
+          ) : (
+            <span className="lineage-version">v{row.version}</span>
+          )}
+          {row.version === 0 && row.def_id.startsWith("static:") && (
+            <span className="def-chip def-chip-static">static</span>
+          )}
           {isActive && <span className="def-chip def-chip-active">active ★</span>}
           {row.retired && <span className="def-chip def-chip-retired">retired</span>}
           {row.bootstrapped_from_static && (

--- a/web/src/pages/LibraryView.tsx
+++ b/web/src/pages/LibraryView.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import {
-  DefNameSummary,
   DefRow,
-  listAgentDefNames,
-  listMcpServerDefNames,
-  listSkillDefNames,
+  LibraryEntry,
+  listLibraryAgents,
+  listLibraryMcpServers,
+  listLibrarySkills,
 } from "../api";
 import LineagePanel from "../components/LineagePanel";
 
@@ -14,16 +14,20 @@ import LineagePanel from "../components/LineagePanel";
 // sub-tab uses the shared LineagePanel (list-left + lineage-right
 // Splitter) with a substrate-specific definition renderer.
 //
+// v0.9.x Library v2: surfaces yaml-only entries alongside substrate
+// rows. STATIC / DYNAMIC source chips at the name level; static-only
+// entries appear as a synthetic v0 row inside the lineage tree.
+//
 // Polling cadence: 10 s for the name list. Lineage trees per name
 // refresh on selection.
 
 const REFRESH_MS = 10_000;
 
 export default function LibraryView() {
-  // Three independent name lists. Polled in parallel from one effect.
-  const [agents, setAgents] = useState<DefNameSummary[]>([]);
-  const [skills, setSkills] = useState<DefNameSummary[]>([]);
-  const [mcps, setMcps] = useState<DefNameSummary[]>([]);
+  // Three independent unified entry lists. Polled in parallel.
+  const [agents, setAgents] = useState<LibraryEntry[]>([]);
+  const [skills, setSkills] = useState<LibraryEntry[]>([]);
+  const [mcps, setMcps] = useState<LibraryEntry[]>([]);
   const [err, setErr] = useState<string | null>(null);
 
   useEffect(() => {
@@ -31,14 +35,14 @@ export default function LibraryView() {
     const fetchAll = async () => {
       try {
         const [a, s, m] = await Promise.all([
-          listAgentDefNames(),
-          listSkillDefNames(),
-          listMcpServerDefNames(),
+          listLibraryAgents(),
+          listLibrarySkills(),
+          listLibraryMcpServers(),
         ]);
         if (cancelled) return;
-        setAgents(a.names ?? []);
-        setSkills(s.names ?? []);
-        setMcps(m.names ?? []);
+        setAgents(a.entries ?? []);
+        setSkills(s.entries ?? []);
+        setMcps(m.entries ?? []);
         setErr(null);
       } catch (e) {
         if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
@@ -79,7 +83,7 @@ export default function LibraryView() {
           <LineagePanel
             kind="agentdef"
             kindLabel="agents"
-            names={agents}
+            entries={agents}
             splitterStorageKey="loomcycle.library.agents.split"
             renderDefinition={renderAgentDefinition}
           />
@@ -88,7 +92,7 @@ export default function LibraryView() {
           <LineagePanel
             kind="skilldef"
             kindLabel="skills"
-            names={skills}
+            entries={skills}
             splitterStorageKey="loomcycle.library.skills.split"
             renderDefinition={renderSkillDefinition}
           />
@@ -97,7 +101,7 @@ export default function LibraryView() {
           <LineagePanel
             kind="mcpserverdef"
             kindLabel="MCP servers"
-            names={mcps}
+            entries={mcps}
             splitterStorageKey="loomcycle.library.mcp.split"
             renderDefinition={renderMcpDefinition}
           />
@@ -212,12 +216,35 @@ function renderSkillDefinition(row: DefRow) {
   );
 }
 
+interface MCPDiscoveredTool {
+  name: string;
+  description?: string;
+  input_schema?: unknown;
+}
+
 interface MCPServerDefBody {
   transport?: string;
   url?: string;
   description?: string;
   headers?: Record<string, string>;
-  discovered_tools?: string[];
+  /**
+   * Stdio-only fields (present for static yaml MCP servers; the
+   * substrate refuses stdio at create-time, so substrate rows never
+   * carry these).
+   */
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  pool_size?: number;
+  allowed_tools?: string[];
+  /**
+   * Cached tools/list result. Shape mirrors the substrate's
+   * mcp_server_defs.definition `discovered_tools` field —
+   * `[{name, description, input_schema}]`. Older revisions of this
+   * type declared `string[]`; the persisted JSON has always been the
+   * object shape — the wire type was just wrong.
+   */
+  discovered_tools?: MCPDiscoveredTool[];
 }
 
 function renderMcpDefinition(row: DefRow) {
@@ -234,16 +261,48 @@ function renderMcpDefinition(row: DefRow) {
         items={[
           ["transport", body.transport],
           ["url", body.url],
+          ["command", body.command],
+          ["pool_size", body.pool_size?.toString()],
         ]}
       />
+      {body.args && body.args.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">args</span>
+          <div className="def-pill-row">
+            {body.args.map((a, i) => (
+              <span key={`${i}-${a}`} className="def-pill mono">{a}</span>
+            ))}
+          </div>
+        </div>
+      )}
       {body.headers && Object.keys(body.headers).length > 0 && (
         <div className="def-field">
           <span className="def-field-label">headers</span>
           <pre className="def-prompt mono">
             {Object.entries(body.headers)
-              .map(([k, v]) => `${k}: ${maskHeaderValue(k, v)}`)
+              .map(([k, v]) => `${k}: ${maskSensitiveValue(k, v)}`)
               .join("\n")}
           </pre>
+        </div>
+      )}
+      {body.env && Object.keys(body.env).length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">env</span>
+          <pre className="def-prompt mono">
+            {Object.entries(body.env)
+              .map(([k, v]) => `${k}: ${maskSensitiveValue(k, v)}`)
+              .join("\n")}
+          </pre>
+        </div>
+      )}
+      {body.allowed_tools && body.allowed_tools.length > 0 && (
+        <div className="def-field">
+          <span className="def-field-label">allowed_tools</span>
+          <div className="def-pill-row">
+            {body.allowed_tools.map((t) => (
+              <span key={t} className="def-pill mono">{t}</span>
+            ))}
+          </div>
         </div>
       )}
       {body.discovered_tools && body.discovered_tools.length > 0 && (
@@ -251,11 +310,42 @@ function renderMcpDefinition(row: DefRow) {
           <span className="def-field-label">
             discovered_tools ({body.discovered_tools.length})
           </span>
-          <div className="def-pill-row">
-            {body.discovered_tools.map((t) => (
-              <span key={t} className="def-pill mono">{t}</span>
+          <div className="def-tool-list">
+            {body.discovered_tools.map((tool) => (
+              <MCPToolEntry key={tool.name} tool={tool} />
             ))}
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// MCPToolEntry renders one discovered MCP tool as a pill that
+// expands inline to show the tool's description + input_schema.
+function MCPToolEntry({ tool }: { tool: MCPDiscoveredTool }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="def-tool-entry">
+      <button
+        type="button"
+        className="def-pill def-tool-pill mono"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="def-tool-caret">{open ? "▾" : "▸"}</span>
+        {tool.name}
+      </button>
+      {open && (
+        <div className="def-tool-detail">
+          {tool.description && (
+            <div className="def-tool-desc">{tool.description}</div>
+          )}
+          {tool.input_schema !== undefined && tool.input_schema !== null && (
+            <pre className="def-prompt mono">
+              {JSON.stringify(tool.input_schema, null, 2)}
+            </pre>
+          )}
         </div>
       )}
     </div>
@@ -277,12 +367,25 @@ function DefMetaRow({ items }: { items: [string, string | undefined][] }) {
   );
 }
 
-// maskHeaderValue redacts the value of Authorization-shaped headers
-// so a bearer token or API key in an MCP server registration's
-// headers map doesn't get displayed in plaintext.
-function maskHeaderValue(key: string, value: string): string {
+// maskSensitiveValue redacts the value of secret-shaped key/value
+// pairs — Authorization-style HTTP headers AND stdio env vars whose
+// key matches the *_TOKEN / *_KEY / *_SECRET / *_PASSWORD heuristic.
+// Static MCP stdio servers (cfg.MCPServers entries) routinely carry
+// API keys in their Env map; this filter keeps them from leaking
+// into the Library UI's plaintext renderer.
+function maskSensitiveValue(key: string, value: string): string {
   const k = key.toLowerCase();
-  if (k === "authorization" || k.includes("token") || k.includes("api-key") || k.includes("apikey")) {
+  const sensitive =
+    k === "authorization" ||
+    k.includes("token") ||
+    k.includes("api-key") ||
+    k.includes("apikey") ||
+    k.endsWith("_key") ||
+    k.endsWith("_secret") ||
+    k.endsWith("_password") ||
+    k.endsWith("_credential") ||
+    k.endsWith("_auth");
+  if (sensitive) {
     if (value.length <= 12) return "•".repeat(value.length);
     return value.slice(0, 4) + "…" + "•".repeat(8);
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2287,6 +2287,76 @@ pre {
   margin-left: 6px;
 }
 
+/* v0.9.x Library v2 inline content expansion — each row gets a
+   chevron at the row-end; clicking it expands the definition body
+   right under the row. Independent of the parent/child collapse
+   chevron at the row-start. */
+.lineage-content-toggle {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  padding: 1px 6px;
+  margin-left: auto;
+  cursor: pointer;
+}
+.lineage-content-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.lineage-content-toggle[aria-expanded="true"] {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.lineage-row-detail {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  padding-right: 8px;
+  border-left: 2px solid var(--accent);
+  margin-left: 8px;
+  margin-bottom: 6px;
+}
+
+/* MCP discovered_tools per-tool expansion — pill that opens to show
+   description + JSON schema beneath. */
+.def-tool-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.def-tool-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.def-tool-pill {
+  background: transparent;
+  border: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.def-tool-pill:hover {
+  border-color: var(--accent);
+}
+.def-tool-caret {
+  font-size: 9px;
+  color: var(--muted);
+}
+.def-tool-detail {
+  padding-left: 16px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+.def-tool-desc {
+  font-size: 12px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
 /* ---- Channels page ---- */
 .channels-view {
   display: flex;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2266,6 +2266,26 @@ pre {
   color: var(--failed);
   border: 1px solid var(--failed);
 }
+/* v0.9.x Library v2 source chips — name-level marker showing where
+   the entity lives (yaml-only / substrate-only / both). The existing
+   bootstrapped chip stays as the row-level marker inside the
+   lineage tree (different scope). */
+.def-chip-static {
+  background: rgba(125, 165, 220, 0.15);
+  color: #7da5dc;
+  border: 1px solid #7da5dc;
+}
+.def-chip-dynamic {
+  background: rgba(176, 139, 208, 0.15);
+  color: #b08bd0;
+  border: 1px solid #b08bd0;
+}
+.lineage-name-chips {
+  display: inline-flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-left: 6px;
+}
 
 /* ---- Channels page ---- */
 .channels-view {


### PR DESCRIPTION
## Summary

The shipped Library UI (PR #187) enumerates only substrate rows (`agent_defs` / `skill_defs` / `mcp_server_defs`). Static yaml-only entities — agents in `cfg.Agents`, skills under `LOOMCYCLE_SKILLS_ROOT`, MCP servers in `cfg.MCPServers` — are invisible unless bootstrapped into the substrate. Static MCP servers' tool lists (cached in `Pool.entry.tools`) have no path to the UI at all.

This PR fixes that with three coordinated changes:

1. **STATIC/DYNAMIC markers.** Every Library entry now shows where it lives — `[STATIC]` for yaml-only, `[DYNAMIC]` for substrate-only, both chips for entries present in both sources. Existing `bootstrapped` row-level chip inside the lineage tree is untouched (different scope: name-level vs row-level).
2. **Inline content expansion.** Each lineage row gets a `▸ content` chevron at the row-end; clicking expands the definition body inline beneath it. Independent of the existing parent/child collapse chevron — operators can fold structure and content independently, with multiple rows expanded simultaneously. The existing side panel stays for single-click preview.
3. **Static MCP servers + their tools.** `cfg.MCPServers` entries (stdio + http) appear in the MCP Servers tab. Their `tools/list` cache is surfaced via a new `Pool.PeekTools` accessor wired into the Server struct as a closure-typed `MCPPoolInspector` — keeps the http package free of `internal/tools/mcp` imports. Same `discovered_tools` JSON shape as the substrate side, so the renderer is source-agnostic. Each discovered tool pill expands to show `description` + pretty-printed `input_schema`.

Bonus fix: the renderer had a latent type bug — `MCPServerDefBody.discovered_tools` was typed `string[]` while the persisted JSON has always been `Array<{name, description?, input_schema?}>`. Corrected as part of commit 4's renderer rework.

## API

Three new bearer-authed read-only endpoints under `/v1/_library/*`:

```http
GET /v1/_library/agents
GET /v1/_library/skills
GET /v1/_library/mcp-servers
```

Each returns:

```json
{
  "entries": [
    {
      "name": "researcher",
      "source": "both",
      "in_static": true,
      "in_substrate": true,
      "version_count": 3,
      "active_def_id": "def_abc",
      "latest_version": 3,
      "last_updated": "2026-05-20T12:00:00Z",
      "static_definition": { "...": "..." }
    }
  ]
}
```

`in_static` / `in_substrate` are the canonical booleans the UI consults for chip rendering; `source` is the derived convenience string (`static-only` / `dynamic-only` / `both`).

`static_definition`'s shape mirrors the substrate-side persistence so the same renderer handles both. For MCP servers it carries the http (transport/url/headers) AND stdio (command/args/env/pool_size) families plus `discovered_tools` populated from PeekTools.

**Existing `/v1/_*def/names` endpoints stay byte-identical** — external adapter consumers depending on the substrate-only wire shape continue working unchanged. Regression test pins this.

## Commits

1. **`feat(mcp): Pool.PeekTools + Server.MCPPoolInspector seam`** — new read-only Pool accessor + Server typedef/field/setter wired from main.go. No behavior change yet. (~125 LOC)
2. **`feat(http): unified library endpoints — merge static cfg + substrate`** — three new handlers + 7 regression tests + route registration. (~700 LOC)
3. **`feat(ui): Library v2 data layer + STATIC/DYNAMIC chips + static-only synthesis`** — frontend switches to unified endpoints; static-only entries render as synthetic `static` rows; latent MCP type bug fixed; env-var redaction widened. (~290 LOC)
4. **`feat(ui): Library v2 — inline content expansion + MCP per-tool detail`** — per-row content chevron + inline body render + MCP discovered_tool expansion. (~125 LOC)

Total ~1240 LOC. Each commit builds + tests independently.

## Test plan

- [x] `go test ./internal/tools/mcp/... -run TestPool_PeekTools` — 3 new tests
- [x] `go test ./internal/api/http/... -run TestUnifiedLibrary` — 7 new tests including backwards-compat guard
- [x] `go test ./... -timeout 300s` — full suite green
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] `gofmt -l .` clean
- [ ] Manual: `/ui/library/agents` shows yaml + dynamic entities with chips; click a row's `▸ content` to expand inline body; static-only entry shows single `static`-labeled row.
- [ ] Manual: `/ui/library/mcp-servers` shows stdio static server with `command`/`args`/redacted `env`; discovered_tools pills expand to show descriptions + schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)