### PR TITLE
fix(substrate): include definition body in list-op response (fixes empty Library content + empty MCP tool pills)

### DIFF
--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -795,6 +795,11 @@ func rowResponseMap(row store.AgentDefRow) map[string]any {
 		"retired":                  row.Retired,
 		"bootstrapped_from_static": row.BootstrappedFromStatic,
 		"content_sha256":           row.ContentSHA256,
+		// v0.9.x Library v2: include the persisted definition body so
+		// the UI's inline-content view + side panel can render it
+		// without a second round-trip. json.RawMessage embeds verbatim;
+		// nil renders as `null` which the renderer treats as empty.
+		"definition": row.Definition,
 	}
 }
 

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -464,3 +464,37 @@ func jsonTagsOfFields(t reflect.Type) map[string]bool {
 	}
 	return out
 }
+
+// TestAgentDefTool_ListIncludesDefinition pins the v0.9.x Library v2
+// contract: the list op's per-version rows include the persisted
+// `definition` JSON so the UI can render content inline without a
+// second round-trip. Before this fix, rowResponseMap omitted the
+// definition field — `row.definition` was undefined on the wire,
+// every inline-content expansion rendered empty.
+func TestAgentDefTool_ListIncludesDefinition(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+	ctx = tools.WithAgentTools(ctx, []string{"Read"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"with-body","overlay":{"system_prompt":"hello world","allowed_tools":["Read"]},"promote":true}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"with-body"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	versions, _ := out["versions"].([]any)
+	if len(versions) != 1 {
+		t.Fatalf("versions = %d, want 1", len(versions))
+	}
+	v0, _ := versions[0].(map[string]any)
+	if v0["definition"] == nil {
+		t.Fatalf("list response missing definition field: %v", v0)
+	}
+	// definition rides through as embedded JSON bytes; on the wire it
+	// surfaces as a JSON-decoded object. Either shape is acceptable —
+	// what matters is that the field is non-null.
+}

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -653,6 +653,10 @@ func mcpServerDefRowResponseMap(row store.MCPServerDefRow) map[string]any {
 		"retired":                  row.Retired,
 		"bootstrapped_from_static": row.BootstrappedFromStatic,
 		"content_sha256":           row.ContentSHA256,
+		// v0.9.x Library v2: include the persisted transport/url/
+		// headers/discovered_tools body so the UI can render MCP
+		// server content inline without a second round-trip.
+		"definition": row.Definition,
 	}
 }
 

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -643,6 +643,10 @@ func skillDefRowResponseMap(row store.SkillDefRow) map[string]any {
 		"retired":                  row.Retired,
 		"bootstrapped_from_static": row.BootstrappedFromStatic,
 		"content_sha256":           row.ContentSHA256,
+		// v0.9.x Library v2: include the persisted body so the UI can
+		// render skill content inline + in the side panel without a
+		// second round-trip.
+		"definition": row.Definition,
 	}
 }
 


### PR DESCRIPTION
## Summary

Library v2's inline content expansion (PR #191) showed nothing when an operator clicked any row's content chevron. Root cause was on the backend: the three substrate list-op response builders (\`rowResponseMap\` / \`skillDefRowResponseMap\` / \`mcpServerDefRowResponseMap\`) omitted the \`definition\` field from each version row. The UI's renderers cast \`row.definition ?? {}\` to an empty object and produced nothing.

Same root cause produces the MCP \"discovered_tools pills are empty\" bug: \`body.discovered_tools\` is undefined for substrate MCP rows when the wire payload has no \`definition\`, so the section either omits or renders empty pills. After this fix the persisted \`toolDescriptor\` array (name / description / input_schema) flows through correctly.

Latent since PR #187 — the v1 side panel had the same dead-body problem, but it only became visible when v2's inline expansion gave operators an explicit affordance to inspect content.

## Why client-side renderers couldn't compensate

The substrate row's \`Definition json.RawMessage\` carries the agent body verbatim — the only correct source for what the agent / skill / MCP server actually does at runtime. Embedding it inline in the response is cheap (json.RawMessage marshals as-is) and keeps the UI free of a per-row \`op:\"get\"\` round-trip. There was no smaller fix.

## Test plan

- [x] New regression test \`TestAgentDefTool_ListIncludesDefinition\` — asserts \`/v1/_agentdef list\` returns versions with a non-null \`definition\` field
- [x] Existing 16 \`TestAgentDefTool_*\` tests stay green (no regressions on create/fork/promote/retire shape)
- [x] \`go test ./... -timeout 300s\` green
- [ ] Manual: \`/ui/library/agents\` → click any substrate row's content chevron → see system_prompt + allowed_tools render inline
- [ ] Manual: \`/ui/library/mcp-servers\` → expand a substrate MCP row → see discovered_tools pills with proper tool names; click a pill → see description + JSON schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)