### PR TITLE
fix(ui): Library v2 — drop side panel + diagnostic empty-state for MCP tools

### DIFF
--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -121,10 +121,6 @@ export default function LineagePanel({
 
   const tree = useMemo(() => buildLineageTree(versions), [versions]);
   const activeDefID = selectedEntry?.active_def_id ?? "";
-  const selectedRow = useMemo(
-    () => versions.find((v) => v.def_id === selectedDefID),
-    [versions, selectedDefID],
-  );
 
   if (entries.length === 0) {
     return (
@@ -162,29 +158,6 @@ export default function LineagePanel({
           onSelect={setSelectedDefID}
           renderDefinition={renderDefinition}
         />
-        {selectedRow && (
-          <div className="lineage-detail">
-            <div className="lineage-detail-header">
-              <span className="mono">{selectedRow.def_id}</span>
-              {selectedRow.parent_def_id && (
-                <span className="lineage-detail-meta">
-                  ← {selectedRow.parent_def_id}
-                </span>
-              )}
-              {selectedRow.created_at && (
-                <span className="lineage-detail-meta">
-                  created {new Date(selectedRow.created_at).toLocaleString()}
-                </span>
-              )}
-              {selectedRow.content_sha256 && (
-                <span className="mono lineage-detail-meta" title={selectedRow.content_sha256}>
-                  {shortenSHA(selectedRow.content_sha256)}
-                </span>
-              )}
-            </div>
-            {renderDefinition(selectedRow)}
-          </div>
-        )}
       </div>
     </Splitter>
   );
@@ -248,8 +221,3 @@ function entryCountLabel(e: LibraryEntry): string {
   return `${n} version${n === 1 ? "" : "s"}`;
 }
 
-function shortenSHA(s: string): string {
-  // `sha256:64hex` → `sha256:8hex…` for compact display; hover for full.
-  if (s.length <= 18) return s;
-  return s.slice(0, 14) + "…";
-}

--- a/web/src/components/LineageTree.tsx
+++ b/web/src/components/LineageTree.tsx
@@ -214,6 +214,25 @@ function LineageNodeRow({
           className="lineage-row-detail"
           style={{ paddingLeft: `${(depth + 1) * 16 + 12}px` }}
         >
+          <div className="lineage-detail-header">
+            <span className="mono">{row.def_id}</span>
+            {row.parent_def_id && (
+              <span className="lineage-detail-meta">← {row.parent_def_id}</span>
+            )}
+            {row.created_at && (
+              <span className="lineage-detail-meta">
+                created {new Date(row.created_at).toLocaleString()}
+              </span>
+            )}
+            {row.content_sha256 && (
+              <span
+                className="mono lineage-detail-meta"
+                title={row.content_sha256}
+              >
+                {shortenSHA(row.content_sha256)}
+              </span>
+            )}
+          </div>
           {renderDefinition(row)}
         </div>
       )}
@@ -261,4 +280,11 @@ function shortDefID(defID: string): string {
   // doesn't need the full 24; full id available via tooltip in caller.
   if (defID.length <= 12) return defID;
   return defID.slice(0, 12) + "…";
+}
+
+function shortenSHA(s: string): string {
+  // `sha256:64hex` → compact form for the inline-detail header; hover
+  // shows the full value via the title attribute.
+  if (s.length <= 18) return s;
+  return s.slice(0, 14) + "…";
 }

--- a/web/src/pages/LibraryView.tsx
+++ b/web/src/pages/LibraryView.tsx
@@ -305,26 +305,45 @@ function renderMcpDefinition(row: DefRow) {
           </div>
         </div>
       )}
-      {body.discovered_tools && body.discovered_tools.length > 0 && (
-        <div className="def-field">
-          <span className="def-field-label">
-            discovered_tools ({body.discovered_tools.length})
-          </span>
+      <div className="def-field">
+        <span className="def-field-label">
+          discovered_tools
+          {body.discovered_tools && body.discovered_tools.length > 0
+            ? ` (${body.discovered_tools.length})`
+            : ""}
+        </span>
+        {body.discovered_tools && body.discovered_tools.length > 0 ? (
           <div className="def-tool-list">
-            {body.discovered_tools.map((tool) => (
-              <MCPToolEntry key={tool.name} tool={tool} />
+            {body.discovered_tools.map((tool, i) => (
+              <MCPToolEntry
+                key={tool.name || `unnamed-${i}`}
+                tool={tool}
+                index={i}
+              />
             ))}
           </div>
-        </div>
-      )}
+        ) : (
+          <div className="def-tool-empty">
+            no tools cached — MCP handshake pending, the server is
+            unreachable, or <code>rediscover</code> hasn't been called
+            for a substrate entry. Check the loomcycle log for{" "}
+            <code>mcp[{"<name>"}]: handshake failed</code> lines.
+          </div>
+        )}
+      </div>
     </div>
   );
 }
 
 // MCPToolEntry renders one discovered MCP tool as a pill that
 // expands inline to show the tool's description + input_schema.
-function MCPToolEntry({ tool }: { tool: MCPDiscoveredTool }) {
+// The defensive `(unnamed tool #N)` fallback covers the case where
+// an upstream MCP server returns a tools/list result with empty/
+// missing name fields — surfaces a visible signal instead of a blank
+// pill that looks like a render bug.
+function MCPToolEntry({ tool, index }: { tool: MCPDiscoveredTool; index: number }) {
   const [open, setOpen] = useState(false);
+  const label = tool.name && tool.name.length > 0 ? tool.name : `(unnamed tool #${index})`;
   return (
     <div className="def-tool-entry">
       <button
@@ -334,7 +353,7 @@ function MCPToolEntry({ tool }: { tool: MCPDiscoveredTool }) {
         aria-expanded={open}
       >
         <span className="def-tool-caret">{open ? "▾" : "▸"}</span>
-        {tool.name}
+        <span className="def-tool-name">{label}</span>
       </button>
       {open && (
         <div className="def-tool-detail">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2356,6 +2356,22 @@ pre {
   color: var(--muted);
   margin-bottom: 4px;
 }
+.def-tool-name {
+  font-size: 11px;
+}
+.def-tool-empty {
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+  padding: 4px 0;
+}
+.def-tool-empty code {
+  font-style: normal;
+  font-size: 11px;
+  background: var(--bg-soft);
+  padding: 0 4px;
+  border-radius: 3px;
+}
 
 /* ---- Channels page ---- */
 .channels-view {


### PR DESCRIPTION
## Summary

Two follow-up fixes from PR #191 land-and-test:

1. **Content rendered twice.** The lineage tree's per-row inline expansion AND the side panel below the tree both rendered the SAME content for the selected row. For multi-version entities the inline view was actually richer (each row's body distinct) while the side panel only ever showed the active row. Dropped the side panel — content lives in the inline expansion only. Each row's metadata header (def_id / parent / created_at / content_sha256) moves into its own inline expansion so it stays reachable.

2. **MCP discovered_tools section showed "empty panels".** Root cause is environmental — the user's static MCP server's pool init was failing (server unreachable / handshake refused), so `PeekTools` returned nil → the `discovered_tools` field was omitted from the response → the section didn't render at all. Verified end-to-end with a fake MCP server that the wire shape is correct when init succeeds (tool names show properly in pills).

   Added a defensive empty-state: when the section would have been omitted, render a hint instead pointing the operator at the loomcycle log for `mcp[<name>]: handshake failed` lines. Also added an `(unnamed tool #N)` fallback for any tool with empty `name` so a pill is never visually blank — a missing tool name now reads as a render result, not a render bug.

## Diagnostics from the live test

```sh
$ curl -s http://127.0.0.1:9990/v1/_library/mcp-servers | jq
{
  "entries": [{
    "name": "test-mcp-http",
    "source": "static-only",
    "static_definition": {
      "transport": "http",
      "url": "http://127.0.0.1:9999/api/mcp",
      "discovered_tools": [
        { "name": "search_jobs", "description": "Search job postings", "input_schema": {"type": "object"} },
        { "name": "get_profile", "description": "Get user profile", "input_schema": {"type": "object"} }
      ]
    }
  }]
}
```

When PeekTools has data, the wire is exactly what the UI expects. The user's environment has handshake failures (likely because the upstream HTTP MCP server doesn't always run); the empty-state hint now makes the situation diagnosable from the UI.

## Test plan

- [x] `go test ./... -timeout 300s` green
- [x] `npm run typecheck` clean
- [x] `npm run build` clean
- [x] End-to-end smoke against the actual binary: real fake MCP server returns tools via tools/list → static_definition.discovered_tools populated with name + description + input_schema → pills render with names.
- [ ] Manual: re-test the user's environment after merge — empty-state hint should appear for MCP servers whose handshake is failing, with the log-line pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)