### PR TITLE
fix(release): pre-create release with annotated-tag body + pin goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,10 +53,55 @@ jobs:
         # binary ships the same UI bundle.
         run: make build-ui
 
+      - name: Pre-create GitHub release with annotated tag body
+        # Why this step exists: goreleaser's `release.mode: keep-existing`
+        # (set in .goreleaser.yaml) skips updating the release body when
+        # one already exists — perfect for the operator workflow where
+        # the curated release notes live in the annotated tag message.
+        # BUT when no release exists yet, goreleaser falls back to a
+        # two-step "create draft → finish-publish" path. The
+        # finish-publish PATCH intermittently 401's against the
+        # workflow-issued GITHUB_TOKEN (the asset uploads work, only
+        # the draft→published PATCH fails). v0.10.1 hit this on
+        # 2026-05-23; v0.10.0 squeaked through three days earlier.
+        #
+        # By pre-creating the release as PUBLISHED here with notes from
+        # the annotated tag, goreleaser's keep-existing mode finds an
+        # actual published release and only appends assets — no risky
+        # draft→published PATCH.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          # Extract the annotated tag's message as the release body.
+          # Empty body = unannotated tag → fail loud so we don't ship
+          # a release with no notes.
+          git tag -l --format='%(contents)' "$TAG" > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "::error::Tag $TAG has no annotated message. Push annotated tag (git tag -a $TAG -m ...) before triggering the release workflow."
+            exit 1
+          fi
+          # Skip if release already exists (manual pre-create or retry).
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "::notice::Release $TAG already exists — skipping pre-create. Goreleaser will append assets to it."
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --notes-file /tmp/release-notes.md \
+            --latest \
+            --verify-tag \
+            --title "$TAG"
+
       - name: Run goreleaser
+        # Pinned to v2.15.4 (the version that built v0.10.0 + v0.10.1
+        # successfully on the build side). `version: latest` previously
+        # left us at the mercy of any breaking change in a future
+        # goreleaser release; pinning gives reproducible behavior
+        # across the v0.10.x release line.
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
+          version: "v2.15.4"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The Release (goreleaser) workflow intermittently fails with `401 Bad credentials` on the final `PATCH /releases/{id}` step that flips the release from draft → published. v0.10.0 squeaked through; v0.10.1 hit it. Asset uploads succeed using the same token; only the wrap-up PATCH fails. The parallel npm publish (federated OIDC, no PATCH) runs cleanly through this.

For v0.10.1 I had to `gh release edit v0.10.1 --notes-file /tmp/v0.10.1-body.md --latest` manually after the workflow failed, then `gh api -X PATCH .../releases/{id} -f draft=false` to publish. This PR removes that manual step from future releases.

## Root cause

The interaction between `release.mode: keep-existing` in `.goreleaser.yaml` and the absence of a pre-existing release:

- The operator workflow is "push annotated tag with curated notes; let goreleaser attach the binaries." `keep-existing` was meant for exactly that — skip body updates when a release already exists.
- **But when no release exists**, goreleaser falls back to a two-step "create draft → finish-publish" path. That second step is what intermittently hits 401.

```
14:01:06 — homebrew formula writing                            ← OK
14:01:06 — releasing tag=v0.10.1 repo=denn-gubsky/loomcycle    ← OK
14:01:08 — release failed: PATCH /releases/...: 401 Bad credentials
```

The "releasing" line is the draft→published PATCH. ~2 seconds later, 401.

## Fix

**Pre-create the release as PUBLISHED in the workflow, using the annotated tag's message as the body.** Goreleaser's `keep-existing` mode then finds an actual published release with proper notes + latest flag, and only appends assets. No risky draft→published PATCH from goreleaser.

The pre-create step:
- Extracts the annotated tag's message via `git tag -l --format='%(contents)'` — the canonical place curated release notes already live (operators write `git tag -a vX.Y.Z -m "<notes>"` today).
- Fails loud if the tag has no annotated message — better to abort the release than ship empty notes.
- Is idempotent — skips when a release already exists, so retries + manual pre-creates remain safe.
- Sets `--latest` and `--verify-tag` so the release is correctly marked.

Also **pinned `goreleaser-action` from `version: latest` to `version: v2.15.4`** — the version that built both v0.10.0 (successful) and v0.10.1 (build successful, only the wrap-up failed). Pinning gives reproducible behavior across the v0.10.x release line; future bumps go through an explicit PR.

## What this doesn't change

- The brews step (Homebrew formula push to the tap) keeps its existing config + `HOMEBREW_TAP_GITHUB_TOKEN` secret. That works.
- The `.goreleaser.yaml` config is untouched — `mode: keep-existing` semantics are preserved, just with the pre-condition (release already exists) now guaranteed by the workflow step.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] `gh release create` command shape matches the v0.10.1 recovery flow I ran by hand.
- [ ] First tag push after merge will exercise the new step end-to-end. The next release will be v0.10.2 (slice 3 of v0.10.x: in-memory run-status cache or multi-replica HA via Redis cancel pubsub, depending on operator priority).

If the new step also fails for some reason, recovery is identical to today: `gh release edit <tag> --notes-file <body> --latest` from a local shell. No worse than the current state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)