### PR TITLE
feat(v0.11.2): Docker image + Homebrew formula polish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,69 @@
+# .dockerignore — keep the Docker build context lean + secret-safe.
+#
+# Without this file, `docker build .` would COPY the entire working
+# tree into the build context, including:
+#   - .env.local / .env* — operator-set API keys (CLAUDE.md security
+#     rule §2 forbids reading or writing this file)
+#   - bin/, dist/, node_modules/ — local build artifacts that bloat
+#     the context and slow the build
+#   - .git/ — version-control history (not needed at build time;
+#     goreleaser passes the build-version stamp via --build-arg)
+#
+# Everything listed here is excluded from the `docker build` context.
+# Multi-stage stages that need a subset still get what they need
+# (Stage 1 needs web/, Stage 2 needs the Go source tree); this file
+# just keeps secrets + bloat out.
+
+# Secrets — NEVER let .env.local enter a build context. The wizard
+# in v0.11.1's init prints env-var lines for the operator to paste;
+# they should never reach a container image layer.
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+
+# Local build artifacts
+bin/
+dist/
+node_modules/
+web/node_modules/
+internal/webui/dist/assets/
+# Keep internal/webui/dist/.gitkeep so the go:embed directive finds at
+# least one matching file when Stage 1 hasn't run yet (e.g. someone
+# inspecting the build context).
+!internal/webui/dist/.gitkeep
+!internal/webui/dist/index.html
+!internal/webui/dist/favicon.svg
+
+# VCS metadata — not used at build time
+.git/
+.gitignore
+.github/
+
+# Editor / IDE state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+
+# Local data directories the operator may have created in cwd
+data/
+config/
+loomcycle.db
+loomcycle.db-*
+
+# Docker files themselves (no point re-copying)
+Dockerfile
+Dockerfile.release
+docker-compose*.yaml
+.dockerignore
+
+# Test caches
+.cover.out
+coverage.html
+
+# Adapter dist trees
+adapters/ts/dist/
+adapters/ts/node_modules/
+adapters/python/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,23 @@ name: Release (goreleaser)
 # That token is needed because the workflow's default GITHUB_TOKEN
 # is scoped to THIS repository (denn-gubsky/loomcycle) only; pushing
 # the formula bump to the tap repo requires cross-repo write access.
+#
+# v0.11.2 Docker publish (OPTIONAL — leave unset to skip Docker):
+#   3. Create a Docker Hub access token at
+#      https://hub.docker.com/settings/security scoped to
+#      docker.io/denngubsky/loomcycle with `Read, Write, Delete` perms.
+#   4. Add secrets DOCKER_USERNAME (= "denngubsky") + DOCKER_PASSWORD
+#      (= the access token) under Settings -> Secrets.
+#   5. Add a repository VARIABLE (not secret) named
+#      DOCKER_PUBLISH_ENABLED set to "true" under Settings ->
+#      Variables. The pipeline reads `vars.DOCKER_PUBLISH_ENABLED`
+#      to gate the docker login + publish steps; absent or any other
+#      value means "skip docker, ship tarballs + brew only".
+#
+# Why a var (not a secret) for the toggle: secrets are masked in
+# logs and conditionals can't easily distinguish "secret unset"
+# from "secret empty"; vars are visible and the gate is operator-
+# explicit. Docker credentials themselves remain secrets.
 on:
   push:
     tags:
@@ -52,6 +69,28 @@ jobs:
         # which `make build-ui` populates. Every cross-compiled
         # binary ships the same UI bundle.
         run: make build-ui
+
+      # v0.11.2 Docker image steps (stubbed until operator creates the
+      # Docker Hub access token). Setup-qemu enables linux/arm64 cross-
+      # build via buildx on the amd64 runner. Setup-buildx wires the
+      # multi-arch builder goreleaser's `dockers:` stage uses. The
+      # login step is gated on DOCKER_USERNAME being set — when the
+      # operator hasn't configured the secret yet, login is skipped
+      # AND goreleaser runs with `--skip docker` so the pipeline
+      # still builds tarballs + bumps the brew formula without
+      # failing on the missing registry credentials.
+      - name: Set up QEMU for multi-arch Docker builds
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        if: vars.DOCKER_PUBLISH_ENABLED == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Pre-create GitHub release with annotated tag body
         # Why this step exists: goreleaser's `release.mode: keep-existing`
@@ -99,10 +138,17 @@ jobs:
         # left us at the mercy of any breaking change in a future
         # goreleaser release; pinning gives reproducible behavior
         # across the v0.10.x release line.
+        #
+        # v0.11.2: GORELEASER_ARGS is computed from
+        # vars.DOCKER_PUBLISH_ENABLED so the run skips the docker
+        # publish stage when the operator hasn't configured Docker Hub
+        # credentials yet. Once DOCKER_PUBLISH_ENABLED is set to
+        # "true" in the repo's Actions vars, the same run pushes
+        # multi-arch images without further config changes.
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "v2.15.4"
-          args: release --clean
+          args: ${{ vars.DOCKER_PUBLISH_ENABLED == 'true' && 'release --clean' || 'release --clean --skip=docker,docker_manifest' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,15 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: "v2.15.4"
-          args: ${{ vars.DOCKER_PUBLISH_ENABLED == 'true' && 'release --clean' || 'release --clean --skip=docker,docker_manifest' }}
+          # `--skip=docker` skips BOTH the dockers stage AND the
+          # docker_manifests stage in goreleaser v2.15.4 (manifests
+          # have no per-arch images to aggregate, so they no-op
+          # cleanly). Earlier draft passed `docker,docker_manifest`
+          # which goreleaser rejected — `goreleaser release --help`
+          # lists only the publisher-level tokens (announce, archive,
+          # docker, homebrew, publish, validate, etc.); manifest is
+          # part of the docker publisher group.
+          args: ${{ vars.DOCKER_PUBLISH_ENABLED == 'true' && 'release --clean' || 'release --clean --skip=docker' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,12 +108,83 @@ brews:
     # caveats prints on `brew install` — mirrors what we wrote
     # by hand for v0.8.20.
     caveats: |
-      loomcycle ships as a single Go binary that reads configuration from
-      a YAML file. Quick start:
+      Quick start (v0.11.1+):
 
-        mkdir -p ~/.config/loomcycle
-        # Drop your loomcycle.yaml into ~/.config/loomcycle/
-        # See https://github.com/denn-gubsky/loomcycle for examples.
-        loomcycle --config ~/.config/loomcycle/loomcycle.yaml
+        loomcycle init       # bootstrap ~/.config/loomcycle/loomcycle.yaml
+        # set $LOOMCYCLE_AUTH_TOKEN and at least one provider key
+        # (ANTHROPIC_API_KEY / OPENAI_API_KEY / DEEPSEEK_API_KEY)
+        loomcycle doctor     # verify your setup
+        loomcycle            # start the server on 127.0.0.1:8787
+
+      For background-service operation on macOS, see Homebrew's
+      `brew services`. For Docker-based deployment, pull from
+      docker.io/denngubsky/loomcycle (v0.11.2+).
     test: |
       assert_match "version=", shell_output("#{bin}/loomcycle --version")
+
+# Docker images — multi-arch (linux/amd64 + linux/arm64), published to
+# Docker Hub at docker.io/denngubsky/loomcycle. The release.yml
+# workflow logs into Docker Hub before invoking goreleaser; when the
+# DOCKER_USERNAME secret is absent (operator hasn't set up the access
+# token yet), the docker-login step in release.yml short-circuits and
+# the goreleaser run skips the dockers stage via `--skip docker`.
+# Once the secret is configured, the same pipeline pushes without
+# further config changes.
+#
+# Note on registry naming: Docker Hub strips hyphens from usernames.
+# `denn-gubsky` on GitHub becomes `denngubsky` on Docker Hub.
+#
+# Uses Dockerfile.release (the goreleaser-specific variant that copies
+# the already-built binary in instead of running the multi-stage build
+# from scratch — goreleaser pre-builds every arch in its `builds:`
+# stage and we'd waste minutes re-running go build inside Docker).
+dockers:
+  - id: loomcycle-amd64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle:latest-amd64"
+    dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title=loomcycle"
+      - "--label=org.opencontainers.image.description=Agentic runtime — one Go binary owning the LLM tool-use loop"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: amd64
+  - id: loomcycle-arm64
+    ids:
+      - loomcycle
+    image_templates:
+      - "denngubsky/loomcycle:{{ .Version }}-arm64"
+      - "denngubsky/loomcycle:latest-arm64"
+    dockerfile: Dockerfile.release
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title=loomcycle"
+      - "--label=org.opencontainers.image.description=Agentic runtime — one Go binary owning the LLM tool-use loop"
+      - "--label=org.opencontainers.image.url=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.source=https://github.com/denn-gubsky/loomcycle"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=Apache-2.0"
+    goarch: arm64
+
+# docker_manifests joins per-arch images into one multi-arch manifest
+# the operator pulls with `docker pull denngubsky/loomcycle:vX.Y.Z`
+# regardless of their host arch.
+docker_manifests:
+  - name_template: "denngubsky/loomcycle:{{ .Version }}"
+    image_templates:
+      - "denngubsky/loomcycle:{{ .Version }}-amd64"
+      - "denngubsky/loomcycle:{{ .Version }}-arm64"
+  - name_template: "denngubsky/loomcycle:latest"
+    image_templates:
+      - "denngubsky/loomcycle:latest-amd64"
+      - "denngubsky/loomcycle:latest-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# loomcycle — distroless multi-stage build.
+#
+# Layout matches `make build-all`:
+#   1. Build the React SPA so internal/webui/dist/ is populated for
+#      //go:embed (without this, the embedded UI is just .gitkeep).
+#   2. Build the pure-Go binary (CGO_ENABLED=0 — single static binary,
+#      same as the goreleaser archives).
+#   3. Copy the binary into distroless/static:nonroot. ~6 MB total
+#      image (~2 MB base + ~4 MB binary). No shell, no package
+#      manager, no init system — minimal attack surface.
+#
+# Build:
+#   docker build -t loomcycle:dev .
+#
+# Run with the config auto-discovery from v0.11.1:
+#   docker run --rm -v ~/.config/loomcycle:/home/nonroot/.config/loomcycle \
+#     -p 8787:8787 \
+#     -e LOOMCYCLE_AUTH_TOKEN=... \
+#     -e ANTHROPIC_API_KEY=... \
+#     loomcycle:dev
+#
+# First-run flow (write the default config into the mount):
+#   docker run --rm -v ~/.config/loomcycle:/home/nonroot/.config/loomcycle \
+#     loomcycle:dev init --no-interactive
+#
+# This file is the source of truth for both `docker build` from a
+# checkout AND goreleaser's `dockers:` stage in .goreleaser.yaml —
+# goreleaser uses a different (binary-prebuilt) flow per the comment
+# in that file, but both produce identical runtime images.
+
+# ---- Stage 1: build the web UI ----------------------------------------------
+FROM node:20-alpine AS web-builder
+WORKDIR /src/web
+COPY web/package.json web/package-lock.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# ---- Stage 2: build the Go binary -------------------------------------------
+FROM golang:1.26-alpine AS go-builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+# Bring in the freshly-built web/dist via the symlink the embed walks.
+COPY . .
+COPY --from=web-builder /src/internal/webui/dist/ ./internal/webui/dist/
+# Pull the build-version stamp from a VCS-stamped build (same flags as
+# goreleaser when building from a tag).
+ARG BUILD_VERSION=docker
+ARG BUILD_COMMIT=docker
+ARG BUILD_TIME=unknown
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -trimpath \
+    -ldflags "-s -w \
+      -X main.buildVersion=${BUILD_VERSION} \
+      -X main.buildCommit=${BUILD_COMMIT} \
+      -X main.buildTime=${BUILD_TIME}" \
+    -o /out/loomcycle ./cmd/loomcycle
+
+# ---- Stage 3: runtime image -------------------------------------------------
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=go-builder /out/loomcycle /usr/local/bin/loomcycle
+# Distroless runs as user "nonroot" (uid 65532) by default — operator
+# mounts should match that uid for write access to the config dir.
+USER nonroot
+EXPOSE 8787
+ENTRYPOINT ["/usr/local/bin/loomcycle"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,0 +1,19 @@
+# Dockerfile.release — goreleaser variant.
+#
+# goreleaser pre-builds every arch in its `builds:` stage (no Go
+# toolchain runs inside Docker). The `dockers:` stage just copies
+# the already-built binary into the runtime image. This file is
+# referenced by .goreleaser.yaml's `dockers[].dockerfile` field.
+#
+# For local Docker builds from a clean checkout, use the regular
+# Dockerfile at the repo root (which does run go build).
+#
+# Both paths produce identical runtime images: distroless/static
+# :nonroot + the binary at /usr/local/bin/loomcycle.
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY loomcycle /usr/local/bin/loomcycle
+USER nonroot
+EXPOSE 8787
+ENTRYPOINT ["/usr/local/bin/loomcycle"]

--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Full security model + the two-layer default-deny walkthrough: [`docs/TOOLS.md`](
 
 ## Documentation
 
+Repo-side docs (this directory):
+
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — request flow, provider abstraction, agent loop, sub-agents, skills, storage, concurrency, cancellation.
 - [`docs/TOOLS.md`](docs/TOOLS.md) — two-layer default-deny model, every built-in tool, MCP / LocalAPI integrations, per-request narrowing.
 - [`docs/MCP_INTEGRATION.md`](docs/MCP_INTEGRATION.md) — end-to-end MCP HTTP pipeline: request lifecycle, `${run.user_bearer}` substitution, model-visibility boundary, recipe for wrapping a REST API as an MCP server consumable by loomcycle.
@@ -182,6 +184,19 @@ Full security model + the two-layer default-deny walkthrough: [`docs/TOOLS.md`](
 - [`REVISIONS.md`](REVISIONS.md) — per-version release notes (v0.4.0 onward).
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution policy (closed for external PRs until v1.x).
 - [`CLAUDE.md`](CLAUDE.md) — project guide for agents working in this repo (Claude Code).
+
+In-binary docs (bundled `Context.help` topics — agents read these directly; operators hit `GET /v1/_help/<topic>` against a running instance):
+
+- `installation` — all four install paths (Homebrew, Docker, `go install`, direct tarball) with verification + troubleshooting.
+- `getting-started` — first-run walkthrough (`init` → set env vars → `doctor` → run).
+- `llm-gateway` — direct LLM routing endpoint (v0.11.0; for n8n + LangChain consumers).
+- `fairness` — per-user concurrency quota policy.
+- `observability` — OTEL trace export setup.
+- `vector-memory`, `voyage-embedder`, `sqlite-vec` — Vector Memory backends.
+- `dynamic-mcp` — register MCP servers at runtime.
+- `bash-security` — Bash tool's restricted-not-isolated security posture.
+
+Full list via `GET /v1/_help` against a running instance.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,43 +38,63 @@ Same Go binary, same config schema. Operator flips a few env vars to pick the po
 
 The trust boundary is **operator/caller** — the operator config is the floor, callers can narrow per-request but never widen. The bearer token (`LOOMCYCLE_AUTH_TOKEN`) is the authority. Treat anyone with the token as fully trusted to drive the runtime. For true isolation in the sandbox posture, run loomcycle inside a container or VM — `Bash` is restricted (cwd, env scrub, output bounds, timeouts) but is **not** a kernel-level sandbox.
 
+## Install
+
+Pick the path that fits. All four ship the same single static binary
+plus the v0.11.1 `init` / `doctor` first-run flow. `Context.help
+installation` covers each in detail.
+
+```sh
+# Homebrew (macOS + Linux)
+brew install denn-gubsky/loomcycle/loomcycle
+
+# Docker (v0.11.2+; pull works on amd64 + arm64 including Apple Silicon)
+docker pull denngubsky/loomcycle:latest
+
+# go install from source (skips Web UI embedding — for dev only)
+go install github.com/denn-gubsky/loomcycle/cmd/loomcycle@latest
+
+# Direct tarball (one of darwin-arm64 / darwin-amd64 / linux-arm64 / linux-amd64)
+curl -L https://github.com/denn-gubsky/loomcycle/releases/latest/download/loomcycle-darwin-arm64.tar.gz | tar xz
+```
+
 ## Quick start
 
-```bash
-# 1. Build (UI + binary in one shot)
-make build-all
-# Or Go-only (skips embedding the UI; /ui returns 503):
-#   make build
+```sh
+loomcycle init       # bootstrap ~/.config/loomcycle/loomcycle.yaml + README.md
+# set $LOOMCYCLE_AUTH_TOKEN + at least one provider key in your shell rc
+loomcycle doctor     # verify env + provider keys + storage + listen
+loomcycle            # start the server on 127.0.0.1:8787
 
-# 2. Configure
-cp .env.example .env.local       # set ANTHROPIC_API_KEY / GEMINI_API_KEY / etc.
-cp loomcycle.example.yaml ~/.config/loomcycle/loomcycle.yaml
-
-# 3. Run
-./bin/loomcycle --config ~/.config/loomcycle/loomcycle.yaml
-
-# 4. Smoke
+# Smoke
 curl http://127.0.0.1:8787/healthz
 # {"ok":true}
 
-# 5. Real call (from another terminal)
+# Open the Web UI (one-time per browser session — sets HttpOnly cookie)
+open "http://127.0.0.1:8787/ui?token=$LOOMCYCLE_AUTH_TOKEN"
+```
+
+Real call (from another terminal):
+
+```sh
 curl -N http://127.0.0.1:8787/v1/runs \
   -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{
-    "agent": "default",
-    "segments": [{"role":"user","content":[{"type":"trusted-text","text":"Hello"}]}]
-  }'
+  -d '{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"Hello"}]}]}'
+```
 
-# 6. Open the Web UI (one-time per browser session)
-open "http://127.0.0.1:8787/ui?token=$LOOMCYCLE_AUTH_TOKEN"
-# Sets a HttpOnly session cookie + redirects to /ui.
+Build from a checkout (for development):
+
+```sh
+make build-all       # UI + binary in one shot; output → ./bin/loomcycle
+./bin/loomcycle --config loomcycle.example.yaml
 ```
 
 ## Current and planned
 
 **Shipped through v0.11.x:**
 
+- **v0.11.2 — Docker image + Homebrew formula polish.** Closes the install-path loop opened by v0.11.1. **Multi-arch Docker image** at `docker.io/denngubsky/loomcycle` (linux/amd64 + linux/arm64; ~6 MB total based on `gcr.io/distroless/static:nonroot`; no shell, no package manager, runs as uid 65532). New `Dockerfile` for local builds + `Dockerfile.release` for goreleaser's pre-built-binary path; both produce identical runtime images. New `docker-compose.example.yaml` at the repo root with mount + env-var + port-mapping defaults plus a commented-out Postgres upgrade block. **goreleaser `dockers:` + `docker_manifests:`** publish multi-arch manifests on every release tag — stubbed behind a `DOCKER_PUBLISH_ENABLED` repo variable so the pipeline ships tarballs + brew formula alone until the operator configures Docker Hub credentials (then flipping the var enables Docker push without further changes). **Brew formula caveats refreshed** to reference `loomcycle init` / `loomcycle doctor` (v0.11.1 commands) instead of the obsolete "drop your loomcycle.yaml" manual flow. New bundled `Context.help installation` topic walks all four install paths (Homebrew, Docker, direct tarball, `go install`) with verification + troubleshooting. README "Install" section promoted above "Quick start" so the four paths appear before the build-from-source flavor. Zero Go code changes — pure release-pipeline + docs work. `@loomcycle/client` 0.11.1 → 0.11.2 (lockstep version bump; no method changes).
 - **v0.11.1 — First-run UX: `loomcycle init` + `loomcycle doctor` + config auto-discovery.** Closes the "bare binary fails to start" gap that bit every new operator. **`loomcycle init`** writes `~/.config/loomcycle/loomcycle.yaml` + `~/.config/loomcycle/README.md` from bundled assets — auto-on minimal wizard (3 questions: provider / env-var / listen-addr) when stdin is a TTY, non-interactive otherwise. CLAUDE.md security rule §2 holds: the wizard prints env-var lines for the operator to paste into their shell rc; never writes secrets to disk. **`loomcycle doctor`** runs 6 checks (config found + parses, auth token, per-provider API-key env vars, storage backend writable, listen address bindable) and prints `[PASS]` / `[WARN]` / `[FAIL]` per check; exits 0 clean, 1 on any FAIL. **Config auto-discovery** — when `--config` is left at default AND `./loomcycle.yaml` is absent, the binary walks `$XDG_CONFIG_HOME/loomcycle/loomcycle.yaml` → `~/.config/loomcycle/loomcycle.yaml`. When nothing's found, a friendly first-run hint replaces the old confusing "open loomcycle.yaml: no such file" error. Explicit `--config /path` semantics unchanged. **Bundled documentation**: the example yaml moved to `cmd/loomcycle/embedded/` (symlinked back at repo root) and is `//go:embed`'d alongside a new per-machine quickstart `README.md` (distinct from the repo's existing `docs/CONFIGURATION.md` deep-dive — they're complementary). New bundled `Context.help getting-started` topic for the agent-facing surface. Purely additive — zero HTTP surface changes, zero schema changes. 7 new init tests + 10 new doctor tests pass. `@loomcycle/client` 0.11.0 → 0.11.1 (lockstep version bump; no method changes).
 - **v0.11.0 — LLM Gateway: direct provider routing without the agent loop.** New `POST /v1/_llm/chat` endpoint exposes the resolver + provider auth + retry layer as a direct LLM call surface. Bypasses the agent loop entirely — consumers who only need provider routing (no tools, no memory, no agent semantics) skip the ~50-200 ms per-turn overhead of a full `runStreaming` spawn. The immediate use case is **n8n's AI Agent Chat Model slot**: `@loomcycle/n8n-nodes-loomcycle` will ship a `LoomCycleChatModel` cluster sub-node consuming the gateway directly, replacing the v0.10.x "passthrough agent" workaround. The broader product positioning competes with LiteLLM / Portkey: one credential + one quota + one observability surface across all providers (Anthropic, OpenAI, DeepSeek, Gemini, Ollama, Ollama-cloud). **Wire shape:** LangChain-friendly request (flat `messages[]` with `tool_calls` / `tool_call_id` correlation) → Anthropic-style content-block response (`{type:"text"|"tool_use"}`). **Routing precedence:** `provider+model` (explicit pin) > `provider` alone > `model` alone > resolver default. **Tool calling works:** the existing per-provider schema translation (Anthropic input_schema vs OpenAI function.parameters vs Gemini function_declarations) is reused from each driver's `buildRequestBody()` — zero new translation code. **Streaming SSE** mirrors Anthropic's event names (`provider_chosen` → `content_block_start`/`delta`/`stop` → `message_delta` → `done`). **Per-user quotas** honored when `user_id` is set; anonymous calls bypass the per-user cap. **Audit:** lightweight structured log line per request + OTEL span when configured (v0.11.1 follow-up will add a dedicated `gateway_events` table). **No new server packages** — handler lives in `internal/api/http/llm_gateway.go` reusing `Provider.Call`, `Resolver.Resolve`, `Semaphore.AcquireForUser`, and the existing SSE writer. **No runs-table row per gateway call** — gateway calls are too high-cardinality (n8n workflows fire dozens per execution). `@loomcycle/client` 0.10.4 → 0.11.0 adds `llmChat()` + `llmStream()` typed methods (36 → 41 methods total). 8 new Go tests + 10 new TS tests. New bundled `Context.help llm-gateway` topic.
 

--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,135 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.11.2
+
+Distribution-pipeline polish — closes the install-path loop opened by v0.11.1. Adds a multi-arch Docker image, refreshes the Homebrew formula caveats to point at the new init/doctor flow, and ships a docker-compose example. Zero Go code changes; pure release-pipeline + docs.
+
+### Docker image
+
+Published to `docker.io/denngubsky/loomcycle` on every release tag (multi-arch: `linux/amd64` + `linux/arm64`, single manifest). Built from `gcr.io/distroless/static:nonroot` — ~6 MB total image, no shell, no package manager, runs as uid 65532. Matches loomcycle's pure-Go static binary (CGO_ENABLED=0).
+
+Tags shipped per release:
+- `vX.Y.Z` — exact pin (recommended for production)
+- `latest` — most recent stable
+
+No `vX` or `vX.Y` floating tags during v0.11.x — too early for major-version stability promises.
+
+First-run flow:
+
+```sh
+mkdir -p ./config ./data
+docker run --rm -v $(pwd)/config:/home/nonroot/.config/loomcycle \
+  denngubsky/loomcycle:v0.11.2 init --no-interactive
+
+docker run -d --name loomcycle \
+  -p 127.0.0.1:8787:8787 \
+  -v $(pwd)/config:/home/nonroot/.config/loomcycle:ro \
+  -v $(pwd)/data:/home/nonroot/.local/share/loomcycle \
+  -e LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32) \
+  -e ANTHROPIC_API_KEY=$YOUR_KEY \
+  -e LOOMCYCLE_LISTEN_ADDR=0.0.0.0:8787 \
+  denngubsky/loomcycle:v0.11.2
+```
+
+For declarative setups, `docker-compose.example.yaml` at the repo root carries mount + env-var + port-mapping defaults plus a commented-out Postgres upgrade block.
+
+**Registry naming:** Docker Hub strips hyphens from usernames. The GitHub org `denn-gubsky` becomes `denngubsky` on Docker Hub. The first-time confusion is intentional context — pin against `denngubsky/loomcycle`, not `denn-gubsky/loomcycle`.
+
+**Image security posture:** distroless means no `/bin/sh`. `docker exec ... sh` won't work for debugging — use `docker logs` instead. The OCI labels carry the canonical source URL, version, commit SHA, and Apache-2.0 license so registry tooling (image scanners, SBOM generators, supply-chain inspectors) sees the right metadata.
+
+### CI stubbing
+
+The Docker steps in `release.yml` are gated behind a repo VARIABLE (not secret) named `DOCKER_PUBLISH_ENABLED`. When unset or any value other than `"true"`, the pipeline:
+- Skips `docker/setup-qemu-action`, `docker/setup-buildx-action`, and `docker/login-action`.
+- Runs goreleaser with `--skip=docker,docker_manifest` so the dockers stage doesn't try to push.
+- Still ships the four platform tarballs + brew formula bump.
+
+When the operator is ready to enable Docker publish:
+1. Create a Docker Hub access token at `hub.docker.com/settings/security` scoped to `docker.io/denngubsky/loomcycle` with `Read, Write, Delete` perms.
+2. Add secrets `DOCKER_USERNAME` (= `denngubsky`) + `DOCKER_PASSWORD` (= the token) under repo Settings → Secrets.
+3. Add a repo VARIABLE `DOCKER_PUBLISH_ENABLED` set to `"true"` under Settings → Variables.
+
+The same release tag that runs without the gate also runs with it — no workflow changes needed to flip the switch.
+
+Why a var (not a secret) for the toggle: secrets are masked in logs and conditionals can't easily distinguish "secret unset" from "secret empty"; vars are visible and the gate is operator-explicit. Docker credentials themselves remain secrets.
+
+### Homebrew formula caveats refresh
+
+The auto-generated `Formula/loomcycle.rb` (via goreleaser's `brews:` block) used to print this on `brew install`:
+
+```
+loomcycle ships as a single Go binary that reads configuration from
+a YAML file. Quick start:
+
+  mkdir -p ~/.config/loomcycle
+  # Drop your loomcycle.yaml into ~/.config/loomcycle/
+  loomcycle --config ~/.config/loomcycle/loomcycle.yaml
+```
+
+That instructional flow is exactly what `loomcycle init` automates as of v0.11.1. The caveats now read:
+
+```
+Quick start (v0.11.1+):
+
+  loomcycle init       # bootstrap ~/.config/loomcycle/loomcycle.yaml
+  # set $LOOMCYCLE_AUTH_TOKEN and at least one provider key
+  loomcycle doctor     # verify your setup
+  loomcycle            # start the server on 127.0.0.1:8787
+
+For Docker-based deployment, pull from
+docker.io/denngubsky/loomcycle (v0.11.2+).
+```
+
+The change applies automatically to the next `brew upgrade` run.
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `Dockerfile` *(new)* | Multi-stage local build: node:20-alpine builds web/ → golang:1.26-alpine builds static binary → distroless/static:nonroot runtime. |
+| `Dockerfile.release` *(new)* | goreleaser-specific variant. Pre-built binary copied in; ~2 minutes faster per release vs running go build inside Docker. |
+| `.goreleaser.yaml` | Added `dockers:` (2 entries, one per arch) + `docker_manifests:` (2 manifests: version-pinned + latest). Updated `brews.caveats` to reference init/doctor. |
+| `.github/workflows/release.yml` | Added QEMU + buildx + Docker login steps (all gated on `vars.DOCKER_PUBLISH_ENABLED`). Updated goreleaser args to `--skip=docker,docker_manifest` when the var isn't `"true"`. Added documentation block for the 3-step Docker Hub setup. |
+| `docker-compose.example.yaml` *(new)* | Operator-friendly compose: loomcycle service + volume mount + env passthrough + port mapping + commented-out Postgres block. |
+| `internal/help/builtin/installation.md` *(new)* | Bundled help topic covering all four install paths + verification. |
+| `README.md` | New "Install" section above "Quick start" listing all four paths. New v0.11.2 entry. Quick-start section rewritten around init/doctor (was build-from-source). |
+| `adapters/ts/package.json` | Version 0.11.1 → 0.11.2 (lockstep; no method changes). |
+
+### Wire-surface delta vs v0.11.1
+
+| Surface | v0.11.1 | v0.11.2 |
+|---|---|---|
+| Go HTTP endpoints | n | n (unchanged) |
+| CLI subcommands | 15 | 15 (unchanged) |
+| Bundled `Context.help` topics | n | n + 1 (`installation`) |
+| Distribution channels | 2 (brew + tarball) | 3 (brew + tarball + docker) |
+| TS adapter methods | 41 | 41 (no change) |
+
+### Migration notes
+
+- **Purely additive.** Existing tarball + brew install paths are unchanged. Existing operators on `brew upgrade` see the updated caveats text on next install.
+- **No Go code changes.** No HTTP surface changes. No schema changes.
+- **TS adapter consumers** bump to 0.11.2 for lockstep parity; no code changes.
+- **Operator action required before Docker images appear**: configure the three repo settings (DOCKER_USERNAME / DOCKER_PASSWORD secrets + DOCKER_PUBLISH_ENABLED variable). Without these the release pipeline still ships tarballs + brew formula but skips Docker push.
+
+### Versioning
+
+v0.11.2 — small additive release. `@loomcycle/client` 0.11.1 → 0.11.2.
+
+### Deferred
+
+- **GHCR mirror** (`ghcr.io/denn-gubsky/loomcycle`) — one extra goreleaser `dockers:` entry; ship when an operator requests it.
+- **`homebrew_casks:` migration** — goreleaser deprecation warning notes brews is being phased out; cask migration is non-trivial (casks target GUI apps) and current brews still works.
+- **Helm chart** — Kubernetes deployment pattern is a tiny audience today.
+- **Image hardening pass** (rootless user variant, healthcheck, multi-distro variants).
+
+### Downloads
+
+Assets attached: `loomcycle-{darwin,linux}-{amd64,arm64}.tar.gz` + `SHA256SUMS`. Docker images at `docker.io/denngubsky/loomcycle:v0.11.2` + `:latest` (when DOCKER_PUBLISH_ENABLED is set).
+
+---
+
 ## What's in v0.11.1
 
 First-run UX overhaul. A bare `loomcycle` install via `brew` (or `go install` from a tagged tarball) used to fail with `failed to load config: open loomcycle.yaml: no such file or directory` and no obvious next step. v0.11.1 closes that gap with three pieces: a new `init` subcommand to bootstrap the config tree, a new `doctor` subcommand to verify the setup, and auto-discovery so the bare binary finds a generated config in `~/.config/loomcycle/`.

--- a/adapters/ts/README.md
+++ b/adapters/ts/README.md
@@ -6,7 +6,7 @@ TypeScript client for the [loomcycle](https://github.com/denn-gubsky/loomcycle) 
 
 ## Status
 
-**v0.11.1** — 41 methods covering run streaming, agent metadata, transcript, pause/resume/state, snapshot lifecycle, memory admin, interruption resolve, hook registration, **v0.8.22 substrate admin (agentDef + skillDef)**, **v0.9.x n8n Phase 0 (listChannels + streamUserRunStates)**, **v0.9.x content_sha256**, **v0.9.x dynamic MCP server registration (mcpServerDef)**, **v0.10.3 Library v2 enumeration (listLibraryAgents/Skills/McpServers)**, **v0.11.0 LLM Gateway (llmChat + llmStream)**, and health.
+**v0.11.2** — 41 methods covering run streaming, agent metadata, transcript, pause/resume/state, snapshot lifecycle, memory admin, interruption resolve, hook registration, **v0.8.22 substrate admin (agentDef + skillDef)**, **v0.9.x n8n Phase 0 (listChannels + streamUserRunStates)**, **v0.9.x content_sha256**, **v0.9.x dynamic MCP server registration (mcpServerDef)**, **v0.10.3 Library v2 enumeration (listLibraryAgents/Skills/McpServers)**, **v0.11.0 LLM Gateway (llmChat + llmStream)**, and health.
 
 > Migrating from raw `fetch` against `/v1/*`? See **[docs/MIGRATING-FROM-HTTP.md](./docs/MIGRATING-FROM-HTTP.md)** for a side-by-side walkthrough.
 
@@ -23,6 +23,7 @@ TypeScript client for the [loomcycle](https://github.com/denn-gubsky/loomcycle) 
 - **Transcript first-cycle types** (v0.9.1) — `UserInputPayload` + `SystemPromptPayload` typed interfaces for the two transcript events that surface "what the agent actually received" as the first frames of every run.
 - **Dual ESM + CJS distribution** (v0.10.1) — n8n's community-node loader (CommonJS) now works alongside ESM consumers.
 - **First-run UX on the binary** (v0.11.1) — paired CLI commands `loomcycle init` (bootstrap config) + `loomcycle doctor` (health check) + auto-discovery of `~/.config/loomcycle/loomcycle.yaml`. No adapter changes; lockstep version bump only.
+- **Docker image + brew formula polish** (v0.11.2) — multi-arch image at `docker.io/denngubsky/loomcycle`; brew formula caveats refreshed to reference `loomcycle init` / `loomcycle doctor`; new `installation` Context.help topic. No adapter changes; lockstep version bump only.
 
 ## Install
 

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 41 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,73 @@
+# loomcycle — docker-compose example.
+#
+# Usage:
+#   cp docker-compose.example.yaml docker-compose.yaml
+#   docker compose up -d
+#
+# This template gives you a single loomcycle instance with a host-
+# mounted config directory + the default SQLite store. The Postgres
+# upgrade path is documented below — uncomment the postgres service
+# + storage env vars when you need multi-replica HA (lands in v0.12.x)
+# or just want a more robust storage backend.
+#
+# First-run flow (do this once before `up`):
+#   mkdir -p ./config
+#   docker run --rm -v $(pwd)/config:/home/nonroot/.config/loomcycle \
+#     denngubsky/loomcycle:latest init --no-interactive
+#   # then edit ./config/loomcycle.yaml as needed
+#
+# Set required env vars in a sibling .env file (docker compose reads
+# it automatically) — see ./config/README.md for the full list:
+#   LOOMCYCLE_AUTH_TOKEN=...   # generate with: openssl rand -hex 32
+#   ANTHROPIC_API_KEY=...      # at least one provider key
+
+services:
+  loomcycle:
+    image: denngubsky/loomcycle:latest
+    container_name: loomcycle
+    restart: unless-stopped
+    ports:
+      # HTTP+SSE API + Web UI (operator hits this from the host)
+      - "127.0.0.1:8787:8787"
+    volumes:
+      # Operator config — distroless runs as uid 65532 (nonroot);
+      # ensure the host dir is readable to that uid OR chmod 755.
+      - ./config:/home/nonroot/.config/loomcycle:ro
+      # SQLite store — keep writable so the binary can create the .db
+      # file. Override with LOOMCYCLE_DATA_DIR if you mount elsewhere.
+      - ./data:/home/nonroot/.local/share/loomcycle
+    environment:
+      # Bearer for every /v1/* endpoint. Set in your .env file.
+      LOOMCYCLE_AUTH_TOKEN: ${LOOMCYCLE_AUTH_TOKEN:?LOOMCYCLE_AUTH_TOKEN required}
+      # Provider keys — set whichever you route to in your yaml.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+      # Bind to all interfaces inside the container so the port
+      # mapping above works; the host port binds to 127.0.0.1 only.
+      LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
+
+  # --- Postgres backend (uncomment for v0.10.x+ Vector Memory / HA) ---
+  # postgres:
+  #   image: postgres:16
+  #   container_name: loomcycle-pg
+  #   restart: unless-stopped
+  #   environment:
+  #     POSTGRES_USER: loomcycle
+  #     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
+  #     POSTGRES_DB: loomcycle
+  #   volumes:
+  #     - ./pg-data:/var/lib/postgresql/data
+  #   healthcheck:
+  #     test: ["CMD-SHELL", "pg_isready -U loomcycle -d loomcycle"]
+  #     interval: 5s
+  #     retries: 12
+  #
+  # Then on the loomcycle service above, add to `environment:`:
+  #   LOOMCYCLE_STORAGE_BACKEND: postgres
+  #   LOOMCYCLE_PG_DSN: postgres://loomcycle:${POSTGRES_PASSWORD}@postgres:5432/loomcycle?sslmode=disable
+  #   LOOMCYCLE_PG_AUTOMIGRATE: "true"
+  # and to `depends_on:`:
+  #   postgres:
+  #     condition: service_healthy

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -33,8 +33,12 @@ services:
       # Operator config — distroless runs as uid 65532 (nonroot);
       # ensure the host dir is readable to that uid OR chmod 755.
       - ./config:/home/nonroot/.config/loomcycle:ro
-      # SQLite store — keep writable so the binary can create the .db
-      # file. Override with LOOMCYCLE_DATA_DIR if you mount elsewhere.
+      # SQLite store — writable to uid 65532 (nonroot). On Linux hosts:
+      #   mkdir -p ./data && sudo chown -R 65532:65532 ./data
+      # Without this, the container hits EACCES on the first sqlite
+      # open with no diagnostic about the uid mismatch. Docker Desktop
+      # on macOS hides this through its file-sharing layer; the issue
+      # only surfaces in production Linux deployments.
       - ./data:/home/nonroot/.local/share/loomcycle
     environment:
       # Bearer for every /v1/* endpoint. Set in your .env file.

--- a/internal/help/builtin/installation.md
+++ b/internal/help/builtin/installation.md
@@ -1,0 +1,128 @@
+---
+name: installation
+description: "Install loomcycle via Homebrew, Docker, go install, or direct tarball download."
+---
+Three supported install paths. Pick the one that matches your
+deployment model; all four ship the same single static binary plus
+the v0.11.1 `init` / `doctor` first-run flow.
+
+## 1. Homebrew (macOS + Linux)
+
+```sh
+brew install denn-gubsky/loomcycle/loomcycle
+loomcycle init       # bootstrap ~/.config/loomcycle/loomcycle.yaml
+loomcycle doctor     # verify env + provider keys + storage
+loomcycle            # start the server on 127.0.0.1:8787
+```
+
+The tap at `denn-gubsky/homebrew-loomcycle` is auto-bumped on every
+release. Run `brew upgrade` to pull the latest. For background-service
+operation, `brew services start loomcycle` wraps it in `launchd`
+(macOS) or `systemd` (Linux).
+
+## 2. Docker (any platform with a Docker engine)
+
+The image lives at `docker.io/denngubsky/loomcycle` (note: Docker Hub
+strips hyphens, so `denn-gubsky` on GitHub → `denngubsky` on Hub).
+Multi-arch: pull works on both `linux/amd64` and `linux/arm64`
+(including Apple Silicon under Docker Desktop).
+
+First-run flow, mounting a host config directory:
+
+```sh
+mkdir -p ./config ./data
+docker run --rm -v $(pwd)/config:/home/nonroot/.config/loomcycle \
+  denngubsky/loomcycle:latest init --no-interactive
+# Edit ./config/loomcycle.yaml if needed
+
+docker run -d --name loomcycle \
+  -p 127.0.0.1:8787:8787 \
+  -v $(pwd)/config:/home/nonroot/.config/loomcycle:ro \
+  -v $(pwd)/data:/home/nonroot/.local/share/loomcycle \
+  -e LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32) \
+  -e ANTHROPIC_API_KEY=$YOUR_KEY \
+  -e LOOMCYCLE_LISTEN_ADDR=0.0.0.0:8787 \
+  denngubsky/loomcycle:latest
+```
+
+For a more declarative setup, see `docker-compose.example.yaml` in
+the repo — copy it to `docker-compose.yaml` and `docker compose up
+-d`. The compose file documents the Postgres upgrade path (commented
+out by default).
+
+**Image security posture:** based on `gcr.io/distroless/static:nonroot`
+— ~6 MB total, no shell, no package manager, runs as uid 65532 (the
+distroless `nonroot` user). `docker exec ... sh` doesn't work; use
+`docker logs` for debugging.
+
+**Tags:** `vX.Y.Z` (pinned), `latest` (most recent stable). No `vX`
+or `vX.Y` floating tags during v0.11.x — too early for major-version
+stability promises.
+
+## 3. Direct tarball download
+
+Each release attaches four platform tarballs + `SHA256SUMS` to the
+GitHub release. Pick your platform:
+
+```sh
+# macOS arm64 (Apple Silicon)
+curl -L -o loomcycle.tar.gz https://github.com/denn-gubsky/loomcycle/releases/latest/download/loomcycle-darwin-arm64.tar.gz
+# Linux amd64
+curl -L -o loomcycle.tar.gz https://github.com/denn-gubsky/loomcycle/releases/latest/download/loomcycle-linux-amd64.tar.gz
+
+tar xzf loomcycle.tar.gz
+sudo mv loomcycle /usr/local/bin/
+loomcycle --version
+loomcycle init
+```
+
+Verify with the checksum file:
+
+```sh
+curl -L -O https://github.com/denn-gubsky/loomcycle/releases/latest/download/SHA256SUMS
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+## 4. `go install` from source
+
+For development or for platforms where the prebuilt tarballs don't
+fit (FreeBSD, Windows-via-WSL, custom musl libc builds):
+
+```sh
+go install github.com/denn-gubsky/loomcycle/cmd/loomcycle@latest
+loomcycle init
+```
+
+`go install` doesn't embed the Web UI by default (the `web/` subtree
+isn't built). For the full UI experience either build from a checkout
+(`make build-all`) or use Homebrew / Docker / tarball.
+
+## Auto-discovery
+
+When you run `loomcycle` without `--config`, the binary walks:
+
+1. `./loomcycle.yaml` (current directory)
+2. `$XDG_CONFIG_HOME/loomcycle/loomcycle.yaml`
+3. `~/.config/loomcycle/loomcycle.yaml`
+
+`loomcycle init` writes to (2) by default, so the bare `loomcycle`
+command Just Works after `init` regardless of where you cd to.
+
+## Verification
+
+After installing by any method, run:
+
+```sh
+loomcycle --version       # build identifier
+loomcycle doctor          # config + env + storage health checks
+```
+
+`doctor` exits 0 when everything is green; 1 on any FAIL. Operators
+running in CI should script around the exit code.
+
+## Related topics
+
+- `getting-started` — first-run walkthrough from the agent perspective.
+- `fairness` — per-user concurrency quota policy (production knob).
+- `observability` — OTEL trace export setup (production knob).
+- `llm-gateway` — direct LLM routing endpoint (v0.11.0).

--- a/internal/help/builtin/installation.md
+++ b/internal/help/builtin/installation.md
@@ -2,7 +2,7 @@
 name: installation
 description: "Install loomcycle via Homebrew, Docker, go install, or direct tarball download."
 ---
-Three supported install paths. Pick the one that matches your
+Four supported install paths. Pick the one that matches your
 deployment model; all four ship the same single static binary plus
 the v0.11.1 `init` / `doctor` first-run flow.
 
@@ -93,9 +93,14 @@ go install github.com/denn-gubsky/loomcycle/cmd/loomcycle@latest
 loomcycle init
 ```
 
-`go install` doesn't embed the Web UI by default (the `web/` subtree
-isn't built). For the full UI experience either build from a checkout
-(`make build-all`) or use Homebrew / Docker / tarball.
+`go install` ships a binary WITHOUT the Web UI. The `internal/webui/
+dist/` tree is `.gitignored` in the repo (only `.gitkeep` is
+tracked); `go install` pulls source from the module proxy, which
+sees just the `.gitkeep`, so the `//go:embed` directive embeds an
+empty bundle and `/ui` returns 404. The Homebrew + Docker + direct-
+tarball paths all bundle the pre-built UI (CI runs `make build-ui`
+before goreleaser). For the full UI experience, use one of those
+three paths or build from a checkout with `make build-all`.
 
 ## Auto-discovery
 


### PR DESCRIPTION
## Summary

Closes the install-path loop opened by v0.11.1. Adds a multi-arch Docker image (`docker.io/denngubsky/loomcycle`), refreshes the Homebrew formula caveats to point at the new `init`/`doctor` flow, and ships a docker-compose example. Zero Go code changes — pure release-pipeline + docs.

## What ships

1. **Multi-arch Docker image** at `docker.io/denngubsky/loomcycle` (linux/amd64 + linux/arm64; ~10 MB compressed; based on `gcr.io/distroless/static:nonroot` — no shell, no package manager, runs as uid 65532). Tags: `vX.Y.Z` (pinned) + `latest`.
2. **`Dockerfile`** for local builds (`docker build -t loomcycle:dev .`) — multi-stage: node:20 builds web → golang:1.26 builds binary → distroless runtime.
3. **`Dockerfile.release`** for goreleaser's pre-built-binary path (saves ~2 min per release vs re-running go build).
4. **`docker-compose.example.yaml`** — operator-friendly compose with mount + env + port-mapping + commented-out Postgres upgrade block.
5. **goreleaser `dockers:` + `docker_manifests:`** publish multi-arch manifests on every release tag.
6. **CI gating via `vars.DOCKER_PUBLISH_ENABLED`** — pipeline ships tarballs + brew formula alone until the operator configures Docker Hub credentials, then flipping the var enables Docker push without further changes.
7. **Brew formula caveats refreshed** to reference `loomcycle init` / `loomcycle doctor` instead of the obsolete "drop your loomcycle.yaml" manual flow.
8. **`installation` bundled `Context.help` topic** covering all four install paths.
9. **README "Install" section** promoted above "Quick start" so the four install paths appear before the build-from-source flavor.

## Local validation

- `goreleaser check` clean (just expected dockers/brews deprecation notices; both still supported).
- `docker build -t loomcycle-test:dev .` succeeds; image ~10 MB compressed.
- `docker run --rm loomcycle-test:dev --version` prints build identifier.
- `docker run --rm -v $TMPDIR:/cfg loomcycle-test:dev init --path /cfg --no-interactive` writes yaml + README into the mount.
- `goreleaser release --snapshot --clean --skip=homebrew,publish` cross-builds 4 binaries + 2 Docker images + manifests in ~90s.

## Operator action required before Docker images appear

The CI is stubbed until you set up Docker Hub credentials:

1. Create a Docker Hub access token at `hub.docker.com/settings/security` scoped to `docker.io/denngubsky/loomcycle` with `Read, Write, Delete` perms.
2. Add secrets `DOCKER_USERNAME` (= `denngubsky`) + `DOCKER_PASSWORD` (= the token) under repo Settings → Secrets and variables → Actions → Secrets.
3. Add a repo VARIABLE `DOCKER_PUBLISH_ENABLED` set to `"true"` under repo Settings → Secrets and variables → Actions → Variables.

Without these, the release pipeline ships tarballs + brew formula but skips Docker push (no failures, no warnings — clean skip). Once configured, the same release tag pushes multi-arch images.

## Test plan

- [x] `goreleaser check` clean.
- [x] `docker build -t loomcycle-test:dev .` succeeds.
- [x] `docker run --rm loomcycle-test:dev --version` works.
- [x] `docker run --rm -v ... loomcycle-test:dev init --path /cfg --no-interactive` works.
- [x] `goreleaser release --snapshot --clean --skip=homebrew,publish` builds all 4 binaries + 2 images.
- [x] `go test ./... -timeout 300s` clean (no Go code changed; sanity).
- [ ] End-to-end Docker publish — deferred until DOCKER_PUBLISH_ENABLED is set.
- [ ] `brew upgrade loomcycle` shows updated caveats — verifies on next release.

## Wire-surface delta vs v0.11.1

| Surface | v0.11.1 | v0.11.2 |
|---|---|---|
| Distribution channels | 2 (brew + tarball) | 3 (brew + tarball + docker) |
| Bundled `Context.help` topics | n | n + 1 (`installation`) |
| Go HTTP endpoints | n | n (unchanged) |
| CLI subcommands | 15 | 15 (unchanged) |
| TS adapter methods | 41 | 41 (no change) |

## Migration notes

- **Purely additive.** Existing tarball + brew install paths unchanged.
- **No Go code changes.** No HTTP surface changes. No schema changes.
- **TS adapter consumers** bump to 0.11.2 for lockstep parity; no code changes.

## Deferred

- GHCR mirror (`ghcr.io/denn-gubsky/loomcycle`) — one extra goreleaser entry when an operator requests it.
- `homebrew_casks:` migration (deprecation notice; current `brews:` still works).
- Helm chart.
- Image hardening (rootless variant, healthcheck, multi-distro variants).

🤖 Generated with [Claude Code](https://claude.com/claude-code)