### PR TITLE
feat(v0.12.0): multi-replica HA foundation (Phase 1 of 7)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,42 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.12.0
+
+**Phase 1 of the v1.0 multi-replica HA capstone — foundation only.** Activates only when the operator sets `LOOMCYCLE_REPLICA_ID`. Single-replica deployments (env var unset) see no behavior change — every code path added in this release is dormant.
+
+### Scope
+
+The v1.0 capstone is a 7-phase rollout that lifts loomcycle from single-process to cluster-mode (2+ replicas behind a load balancer sharing one Postgres DB). v0.12.0 ships Phase 1 — the substrate that later phases build on.
+
+### What ships
+
+1. **`LOOMCYCLE_REPLICA_ID` env var.** When unset, loomcycle runs in single-replica mode exactly like v0.11.x — no backplane, no replicas table writes, no `/healthz` cluster-view fields. When set, the operator must use the Postgres store; SQLite refuses to start with a clear error. Validates against `[A-Za-z0-9][A-Za-z0-9_-]{0,63}` — UUID4 is the recommended default but short labels like `replica-a` are accepted for human-friendly cluster admin.
+
+2. **New `internal/coord/` package.** Houses the `Backplane` interface + `PostgresBackplane` implementation (Postgres LISTEN/NOTIFY), plus the `ReplicaStore` heartbeat-table reader/writer. Backplane is behind an interface so a future Redis impl (post-v1.0) slots in without touching consumers; v1.0 ships Postgres LISTEN/NOTIFY only. Topic namespace: `loomcycle.*` prevents collision with any other LISTEN consumer sharing the database. Wire envelope is `{"r":"<replica_id>","p":"<base64 payload>"}` — self-messages filtered before delivery; reconnect-on-drop with exponential backoff (500ms → 30s, ±20% jitter); 7800-byte payload cap (margin under the Postgres 8000-byte NOTIFY ceiling).
+
+3. **`replicas` heartbeat table** (migration 0022). One row per running replica — `id`, `hostname`, `started_at`, `last_heartbeat_at`, `version`. Self-registered by a background goroutine on boot (30s interval), self-deleted on graceful shutdown via a fresh 5s context (the parent ctx is already cancelled by the time the DELETE runs). Phase 5 will add a TTL sweeper for replicas that died without graceful shutdown.
+
+4. **`runs.replica_id` column** (migration 0023, nullable). Landed in Phase 1 so Phase 3 (cross-replica cancel) is purely behavioral — Phase 3 adds one line to `CreateRun` and starts populating the column without a migration. Phase 1 itself never writes the column; existing rows stay NULL.
+
+5. **SQLite refuse-to-start guard.** `openStore` checks `cfg.Env.ReplicaID != "" && backend == "sqlite"` and returns a clear error pointing the operator at Postgres + `pg_dsn`, or at unsetting the env var for single-replica mode. The boot fails loud rather than silently degrading to a broken multi-replica deployment.
+
+6. **`GET /healthz` cluster view.** Single-replica deployments (REPLICA_ID unset) see the same response shape as v0.11.x — `omitempty` keeps the new fields invisible. Cluster deployments see two additional fields: `replica_id` (this replica's ID) and `replicas[]` (every alive replica with hostname / started_at / last_heartbeat_at / version). The `ListReplicas` call gets a 2-second timeout; if it fails, the liveness probe still returns 200 + ok:true with the cluster fields omitted — the probe's primary job is liveness, not cluster completeness.
+
+### Locked architecture
+
+- **Backplane = Postgres LISTEN/NOTIFY only in v1.0.** No Redis until v1.1+, and only if a deployment hits LISTEN/NOTIFY's throughput ceiling (~10K msg/s).
+- **SQLite is single-replica only.** Multi-replica requires Postgres.
+- **MCP stdio children stay per-replica.** N replicas × M servers in process tables. Resource-scaling concern, not correctness.
+- **Anthropic OAuth-dev tokens stay single-host.** Already documented in the OAuth-dev RFC.
+- **Global concurrency cap stays per-replica** — per-tenant fairness lifts to cluster-wide in Phase 2 via DB-backed counter; global cap stays per-replica with operator math documented.
+
+### What's coming in the rest of v0.12.x → v1.0
+
+Phase 2 (v0.12.1) — cluster-wide per-user fairness via `user_quotas` table replacing the in-process counter. Phase 3 (v0.12.2) — cross-replica cancel + status. Phase 4 (v0.12.3) — pause/resume + bus fanout. Phase 5 (v0.12.4) — singleton sweepers via `pg_try_advisory_lock`. Phase 6 (v0.12.5) — session-lock + hook-registry → DB-backed. Phase 7 (v0.12.6) — hardening + docs + **tag v1.0**.
+
+---
+
 ## What's in v0.11.12
 
 Two small DX items bundled. Same posture as v0.11.7's polish bundle — closes out the small-items queue before the v1.0 multi-replica HA capstone.

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/cli"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/heartbeat"
 	"github.com/denn-gubsky/loomcycle/internal/help"
 	mcpsign "github.com/denn-gubsky/loomcycle/internal/mcp"
@@ -1093,6 +1094,43 @@ func main() {
 		log.Printf("heartbeat: sweeper disabled (LOOMCYCLE_HEARTBEAT_SWEEPER=0 or no Store)")
 	}
 
+	// v0.12.0 multi-replica HA foundation. Activates only when the
+	// operator sets LOOMCYCLE_REPLICA_ID. openStore already guards
+	// against SQLite + cluster mode, so reaching here with a non-
+	// empty ReplicaID guarantees a Postgres store.
+	if cfg.Env.ReplicaID != "" {
+		pgStore, ok := storeIface.(*storepostgres.Store)
+		if !ok {
+			log.Fatalf("coord: REPLICA_ID set but store is not *storepostgres.Store (openStore guard bypassed?)")
+		}
+		bp, err := coord.NewPostgresBackplane(coord.PostgresBackplaneConfig{
+			Pool:      pgStore.Pool(),
+			DSN:       cfg.Storage.PgDSN,
+			ReplicaID: cfg.Env.ReplicaID,
+		})
+		if err != nil {
+			log.Fatalf("coord: backplane init: %v", err)
+		}
+		defer func() {
+			if err := bp.Close(); err != nil {
+				log.Printf("coord: backplane close: %v", err)
+			}
+		}()
+		replicaStore := coord.NewReplicaStore(pgStore.Pool())
+		hostname, _ := os.Hostname()
+		hb := coord.NewHeartbeat(replicaStore, coord.HeartbeatConfig{
+			ReplicaID: cfg.Env.ReplicaID,
+			Hostname:  hostname,
+			Version:   buildVersion,
+		})
+		go hb.Run(bgCtx)
+		// Wire the cluster view onto /healthz. Phase 1 ships the
+		// backplane behind the interface but with no live publisher/
+		// subscriber — Phase 2+ adds those.
+		srv.SetCoord(bp, replicaStore, cfg.Env.ReplicaID)
+		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify", cfg.Env.ReplicaID)
+	}
+
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.
 	// The store also filters expired entries at read time, so this
 	// goroutine only matters for keeping the table small over the
@@ -1384,6 +1422,13 @@ func main() {
 func openStore(cfg *config.Config) (store.Store, func(), error) {
 	switch cfg.Storage.Backend {
 	case "sqlite", "":
+		if cfg.Env.ReplicaID != "" {
+			return nil, nil, errors.New(
+				"LOOMCYCLE_REPLICA_ID is set but storage.backend is sqlite: " +
+					"multi-replica requires Postgres (LISTEN/NOTIFY backplane + " +
+					"shared replicas heartbeat table). Set storage.backend: postgres " +
+					"+ storage.pg_dsn, or unset LOOMCYCLE_REPLICA_ID for single-replica mode")
+		}
 		if err := os.MkdirAll(cfg.Env.DataDir, 0o755); err != nil {
 			return nil, nil, fmt.Errorf("data dir: %w", err)
 		}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
@@ -172,6 +173,21 @@ type Server struct {
 	// "not configured" errors. Set via SetMCPServerDefTool.
 	mcpServerDefTool tools.Tool
 
+	// v0.12.0 multi-replica HA. backplane + replicaStore are nil in
+	// single-replica deployments (LOOMCYCLE_REPLICA_ID unset); /healthz
+	// then returns the same response shape as v0.11.x. When set,
+	// /healthz includes a cluster view (replica_id + replicas[]).
+	// Phase 1 wires these but the backplane has no live subscribers
+	// outside the package's own tests — Phase 2+ build the consumers.
+	//
+	// replicaStore is typed as the local replicaLister interface (not
+	// *coord.ReplicaStore) so the healthz test can stub the listing
+	// without standing up a Postgres fixture. *coord.ReplicaStore
+	// satisfies it structurally.
+	backplane    coord.Backplane
+	replicaStore replicaLister
+	replicaID    string
+
 	// mcpHTTPHandler is the v0.8.15.3 HTTP MCP transport (alternate
 	// front-end to the stdio MCP server). Typed as http.Handler — NOT
 	// *lcmcp.HTTPHandler — so this package does NOT import
@@ -313,6 +329,25 @@ func (s *Server) SetSkillSet(set *skills.Set) {
 // Same wiring shape as SetMetricsSampler.
 func (s *Server) SetPauseManager(m *pause.Manager) {
 	s.pauseMgr = m
+}
+
+// replicaLister is the minimum read surface of *coord.ReplicaStore
+// the healthz handler needs. Declared here (not in coord) so tests
+// can stub it without importing the live Postgres-backed type.
+type replicaLister interface {
+	ListReplicas(ctx context.Context) ([]coord.Replica, error)
+}
+
+// SetCoord installs the v0.12.0 multi-replica HA bus + replicas table
+// reader. When called with non-nil arguments, /healthz starts including
+// `replica_id` + `replicas[]` fields in its response. When unset (the
+// default), /healthz returns the same response shape as v0.11.x and no
+// cluster-mode code paths run. Phase 1 wires this; Phases 2-6 build
+// publishers/subscribers on top of the backplane.
+func (s *Server) SetCoord(bp coord.Backplane, rs replicaLister, replicaID string) {
+	s.backplane = bp
+	s.replicaStore = rs
+	s.replicaID = replicaID
 }
 
 // PauseManager returns the wired pause manager (or nil). Read-only
@@ -1575,6 +1610,12 @@ type healthzResponse struct {
 	Built          string `json:"built,omitempty"`
 	UptimeSeconds  int64  `json:"uptime_seconds,omitempty"`
 	MetricsEnabled bool   `json:"metrics_enabled"`
+	// v0.12.0 multi-replica cluster view. Populated only when
+	// LOOMCYCLE_REPLICA_ID is set (SetCoord wires the backing
+	// store). The omitempty rule keeps single-replica /healthz
+	// responses byte-identical to v0.11.x.
+	ReplicaID string          `json:"replica_id,omitempty"`
+	Replicas  []coord.Replica `json:"replicas,omitempty"`
 }
 
 func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
@@ -1593,6 +1634,24 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 		Built:          s.buildTime,
 		UptimeSeconds:  uptime,
 		MetricsEnabled: s.metricsSampler != nil,
+	}
+	// v0.12.0 cluster view. replica_id is the in-memory identity of
+	// THIS replica and is always populated when coord is wired —
+	// monitoring/LB systems that key off it must not see intermittent
+	// identity loss when Postgres hiccups (review finding #4). Only
+	// the replicas[] list depends on a successful ListReplicas; on
+	// error we log + omit it but still return ok:true. Liveness probe
+	// semantics trump cluster-view completeness.
+	if s.replicaStore != nil {
+		resp.ReplicaID = s.replicaID
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+		replicas, err := s.replicaStore.ListReplicas(ctx)
+		if err != nil {
+			log.Printf("healthz: list replicas: %v", err)
+		} else {
+			resp.Replicas = replicas
+		}
 	}
 	_ = json.NewEncoder(w).Encode(resp)
 }

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -217,6 +219,111 @@ func TestHealthz(t *testing.T) {
 	}
 	if body.MetricsEnabled {
 		t.Errorf("metrics_enabled = %v, want false (sampler not wired in test)", body.MetricsEnabled)
+	}
+}
+
+// TestHealthz_ClusterViewOmittedWhenCoordUnset pins the back-compat
+// guarantee in the v0.12.0 RFC: single-replica deployments (SetCoord
+// never called) must see /healthz response shape unchanged from
+// v0.11.x. The check is strict — any unexpected new key in the JSON
+// object means we've broken a wire contract.
+func TestHealthz_ClusterViewOmittedWhenCoordUnset(t *testing.T) {
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100}}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, found := raw["replica_id"]; found {
+		t.Errorf("replica_id present when coord is unset: %v", raw)
+	}
+	if _, found := raw["replicas"]; found {
+		t.Errorf("replicas present when coord is unset: %v", raw)
+	}
+}
+
+// fakeReplicaLister stubs the v0.12.0 cluster-view dependency for
+// healthz tests without standing up a Postgres fixture.
+type fakeReplicaLister struct {
+	rows []coord.Replica
+	err  error
+}
+
+func (f *fakeReplicaLister) ListReplicas(ctx context.Context) ([]coord.Replica, error) {
+	return f.rows, f.err
+}
+
+func TestHealthz_ClusterViewIncludedWhenCoordSet(t *testing.T) {
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100}}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	now := time.Now()
+	srv.SetCoord(nil, &fakeReplicaLister{rows: []coord.Replica{
+		{ID: "rep-a", Hostname: "host-a", StartedAt: now, LastHeartbeatAt: now, Version: "v0.12.0"},
+		{ID: "rep-b", Hostname: "host-b", StartedAt: now, LastHeartbeatAt: now, Version: "v0.12.0"},
+	}}, "rep-a")
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	var body struct {
+		OK        bool            `json:"ok"`
+		ReplicaID string          `json:"replica_id"`
+		Replicas  []coord.Replica `json:"replicas"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.ReplicaID != "rep-a" {
+		t.Errorf("replica_id = %q, want rep-a", body.ReplicaID)
+	}
+	if len(body.Replicas) != 2 {
+		t.Fatalf("got %d replicas, want 2: %+v", len(body.Replicas), body.Replicas)
+	}
+}
+
+// TestHealthz_ListErrorDoesNotFailLivenessProbe — a transient DB
+// hiccup must not knock /healthz off the air. The probe still returns
+// 200 + ok:true; replica_id remains populated (it's in-memory and
+// monitoring keyed off it must not see intermittent identity loss);
+// only the replicas[] list is omitted on error.
+func TestHealthz_ListErrorDoesNotFailLivenessProbe(t *testing.T) {
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100}}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	srv.SetCoord(nil, &fakeReplicaLister{err: errors.New("db unreachable")}, "rep-a")
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	var body struct {
+		OK        bool            `json:"ok"`
+		ReplicaID string          `json:"replica_id"`
+		Replicas  []coord.Replica `json:"replicas"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&body)
+	if !body.OK {
+		t.Errorf("ok = %v, want true even on list error", body.OK)
+	}
+	// replica_id MUST stay populated even when ListReplicas fails —
+	// review-1 fix #4. Monitoring keyed off this field must not see
+	// it disappear on transient DB hiccups.
+	if body.ReplicaID != "rep-a" {
+		t.Errorf("replica_id %q, want rep-a (must stay populated on list error)", body.ReplicaID)
+	}
+	if len(body.Replicas) != 0 {
+		t.Errorf("replicas should be empty on list error, got %d", len(body.Replicas))
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1008,6 +1008,18 @@ type Env struct {
 	// LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS.
 	MetricsSweepInterval time.Duration
 
+	// ---- v0.12.0 multi-replica HA (opt-in) ----
+
+	// ReplicaID activates cluster mode. When unset, loomcycle runs
+	// in single-replica mode exactly like v0.11.x — no backplane, no
+	// replicas table writes, no /healthz cluster-view fields. When
+	// set, the operator must use the Postgres store (SQLite refuses
+	// to start). Validated against [A-Za-z0-9][A-Za-z0-9_-]{0,63} at
+	// config-load; UUID4 is the recommended default but short labels
+	// ("replica-a", "lc-1") are accepted for human-friendly cluster
+	// admin. Env: LOOMCYCLE_REPLICA_ID.
+	ReplicaID string
+
 	// PauseDefaultTimeoutMs is the wait-for-non-idempotent-tools cap
 	// applied when POST /v1/_pause omits timeout_ms. 0 ⇒ use the
 	// internal default (pause.DefaultPauseTimeout = 30s). Capped at
@@ -1655,6 +1667,18 @@ func Load(path string) (*Config, error) {
 		}
 	}
 	cfg.Env.MetricsCollectSystem = os.Getenv("LOOMCYCLE_METRICS_COLLECT_SYSTEM") == "1"
+
+	// v0.12.0 multi-replica HA: cluster mode activates when REPLICA_ID
+	// is set. Validation is by coord.ValidateReplicaID; we re-implement
+	// the regex here to avoid an import cycle (coord depends on config
+	// via Env propagation in main.go, not the other way around).
+	cfg.Env.ReplicaID = os.Getenv("LOOMCYCLE_REPLICA_ID")
+	if cfg.Env.ReplicaID != "" {
+		if err := validateReplicaID(cfg.Env.ReplicaID); err != nil {
+			return nil, fmt.Errorf("LOOMCYCLE_REPLICA_ID: %w", err)
+		}
+	}
+
 	cfg.Env.MetricsSweepInterval = 15 * time.Minute
 	if v := os.Getenv("LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -2712,6 +2736,29 @@ func validate(c *Config) error {
 		if c.Memory.Embedder.BatchSize < 0 {
 			return fmt.Errorf("memory.embedder.batch_size must be >= 0")
 		}
+	}
+	return nil
+}
+
+// replicaIDPattern duplicates internal/coord.replicaIDPattern. We
+// can't import coord here because main.go composes config.Load + the
+// coord backplane wiring — config has to validate independently. The
+// two patterns must stay in sync; TestReplicaIDPatternsAreInSync in
+// internal/coord/replica_store_test.go cross-checks them on a shared
+// input corpus so any drift fails CI.
+var replicaIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+// ValidateReplicaID is the exported config-side validator (mirrors
+// coord.ValidateReplicaID with the same accept/reject decisions but
+// different error text). Exported so the drift-checking test in the
+// coord package can call it without re-implementing the regex.
+func ValidateReplicaID(id string) error {
+	return validateReplicaID(id)
+}
+
+func validateReplicaID(id string) error {
+	if !replicaIDPattern.MatchString(id) {
+		return fmt.Errorf("must match [A-Za-z0-9][A-Za-z0-9_-]{0,63} (got %q)", id)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1700,3 +1700,62 @@ memory:
 		t.Errorf("entry[2].value = %v; want 42 (int)", e2.Value)
 	}
 }
+
+// minimalYaml is a yaml config sufficient for Load() to succeed,
+// used by the v0.12.0 REPLICA_ID validation tests.
+const minimalYaml = `
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  default: { model: claude-sonnet-4-6 }
+`
+
+func writeMinimal(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(p, []byte(minimalYaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestEnv_ReplicaIDUnsetLeavesClusterModeOff(t *testing.T) {
+	t.Setenv("LOOMCYCLE_REPLICA_ID", "")
+	cfg, err := Load(writeMinimal(t))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Env.ReplicaID != "" {
+		t.Errorf("ReplicaID = %q, want empty (cluster mode off)", cfg.Env.ReplicaID)
+	}
+}
+
+func TestEnv_ReplicaIDAcceptsValid(t *testing.T) {
+	for _, id := range []string{"a", "replica-a", "lc_1", "3f9b0a2e-1234-4abc-89ef-0123456789ab"} {
+		t.Run(id, func(t *testing.T) {
+			t.Setenv("LOOMCYCLE_REPLICA_ID", id)
+			cfg, err := Load(writeMinimal(t))
+			if err != nil {
+				t.Fatalf("Load: %v", err)
+			}
+			if cfg.Env.ReplicaID != id {
+				t.Errorf("ReplicaID = %q, want %q", cfg.Env.ReplicaID, id)
+			}
+		})
+	}
+}
+
+func TestEnv_ReplicaIDRejectsInvalid(t *testing.T) {
+	for _, id := range []string{"-leading-dash", "has space", "has/slash"} {
+		t.Run(id, func(t *testing.T) {
+			t.Setenv("LOOMCYCLE_REPLICA_ID", id)
+			_, err := Load(writeMinimal(t))
+			if err == nil {
+				t.Fatal("expected Load to fail; got nil error")
+			}
+			if !strings.Contains(err.Error(), "LOOMCYCLE_REPLICA_ID") {
+				t.Errorf("error %q does not mention LOOMCYCLE_REPLICA_ID", err.Error())
+			}
+		})
+	}
+}

--- a/internal/coord/backplane.go
+++ b/internal/coord/backplane.go
@@ -1,0 +1,114 @@
+// Package coord is loomcycle's v0.12.0 multi-replica coordination
+// substrate.
+//
+// One backplane interface, one impl in v1.0:
+//
+//   - Backplane is a publish/subscribe abstraction over an inter-
+//     replica signal channel. Phase 1 wires it up; Phases 2-7 build
+//     cross-replica cancel / pause / bus-fanout / quota signals on
+//     top of it.
+//
+//   - PostgresBackplane (postgres_backplane.go) implements Backplane
+//     via Postgres LISTEN/NOTIFY. Zero new infra dep over what
+//     loomcycle already needs for cluster mode (Postgres is required;
+//     SQLite refuses to start when LOOMCYCLE_REPLICA_ID is set).
+//
+// The package also owns the ReplicaStore — read/write access to the
+// `replicas` heartbeat table that backs the /healthz cluster view.
+// Kept in this package (not the store package) because it's tied to
+// the multi-replica posture: when LOOMCYCLE_REPLICA_ID is unset, no
+// code in this package runs.
+//
+// Topic namespace: every backplane topic is prefixed `loomcycle.` so
+// loomcycle's NOTIFY traffic doesn't collide with any other LISTEN
+// consumer sharing the same Postgres instance. Currently used:
+//
+//	loomcycle.cancel   — Phase 3
+//	loomcycle.pause    — Phase 4
+//	loomcycle.runstate — Phase 4 (RunState bus fanout)
+//	loomcycle.channel  — Phase 4 (Channel bus fanout)
+//	loomcycle.quota    — Phase 2 (observability only)
+//	loomcycle.hook     — Phase 6 (hook registry invalidation)
+//
+// Phase 1 ships the substrate with no live publishers / subscribers
+// in the wider runtime — only the package's own tests exercise the
+// wire roundtrip. Later phases add the producers/consumers.
+package coord
+
+import (
+	"context"
+	"errors"
+)
+
+// Event is one cross-replica notification.
+type Event struct {
+	// Topic is the loomcycle. … namespace string the publisher emitted on.
+	Topic string
+
+	// Payload is the publisher-supplied bytes. Coord does not interpret
+	// the payload; consumers parse it (usually JSON).
+	Payload []byte
+
+	// PublisherReplicaID identifies the originating replica. Subscribers
+	// receive events from all replicas including themselves; the
+	// PostgresBackplane filters self-messages before delivering on the
+	// subscriber channel, but PublisherReplicaID stays populated for
+	// audit/log purposes.
+	PublisherReplicaID string
+}
+
+// Backplane is the cross-replica pub/sub abstraction.
+//
+// Implementations are expected to be safe for concurrent use by
+// multiple goroutines. Subscribe may dial a fresh connection per
+// call (PostgresBackplane does this); callers should treat Subscribe
+// as moderately expensive and Subscribe once per long-lived subscriber.
+type Backplane interface {
+	// Publish broadcasts payload on topic to every subscribed replica
+	// (including this one — implementations filter self-messages).
+	// Returns ErrPayloadTooLarge if the payload exceeds the impl's cap
+	// (Postgres NOTIFY caps at 8000 bytes; PostgresBackplane enforces
+	// 7800 for envelope headroom).
+	Publish(ctx context.Context, topic string, payload []byte) error
+
+	// Subscribe returns a receive-only channel that delivers Events
+	// for topic. The channel closes when ctx is cancelled or the
+	// Backplane is Closed. Self-messages (payloads published by this
+	// replica) are filtered out before delivery.
+	//
+	// Buffer policy: subscriber channels have a fixed buffer; on
+	// overflow the implementation drops events silently. Every Phase
+	// 2+ consumer of these signals must be idempotent against missed
+	// events (cancel re-checks DB state on miss; sweepers re-run next
+	// tick) — the backplane is "best-effort hint, source-of-truth in DB."
+	Subscribe(ctx context.Context, topic string) (<-chan Event, error)
+
+	// Close shuts the backplane down. Outstanding Subscribe channels
+	// close as their goroutines drain. Idempotent.
+	Close() error
+}
+
+// Sentinel errors. Consumers branch on these via errors.Is.
+var (
+	// ErrPayloadTooLarge — caller's payload exceeds the impl's wire
+	// cap. PostgresBackplane: 7800 bytes (200-byte margin under the
+	// Postgres 8000-byte NOTIFY hard cap for the envelope header).
+	ErrPayloadTooLarge = errors.New("coord: payload exceeds backplane wire cap")
+
+	// ErrBackplaneClosed — Publish / Subscribe called after Close.
+	ErrBackplaneClosed = errors.New("coord: backplane is closed")
+
+	// ErrInvalidTopic — topic name failed validation (empty, contains
+	// shell-unsafe chars, doesn't start with the loomcycle. prefix).
+	ErrInvalidTopic = errors.New("coord: invalid topic name")
+)
+
+// TopicPrefix is the namespace every loomcycle backplane topic carries.
+// Implementations enforce this on Publish + Subscribe so non-loomcycle
+// LISTEN/NOTIFY consumers on the same database don't collide.
+const TopicPrefix = "loomcycle."
+
+// MaxPayloadBytes is the largest payload PostgresBackplane will accept.
+// 200-byte margin under the Postgres 8000-byte NOTIFY hard cap for the
+// JSON envelope header (replica_id field, base64 padding overhead).
+const MaxPayloadBytes = 7800

--- a/internal/coord/postgres_backplane.go
+++ b/internal/coord/postgres_backplane.go
@@ -1,0 +1,361 @@
+package coord
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostgresBackplane implements Backplane via Postgres LISTEN/NOTIFY.
+//
+// Architecture:
+//
+//   - Publish acquires a connection from the *pgxpool.Pool and issues
+//     `SELECT pg_notify($1, $2)`. The envelope is `{"r":"<replica>","p":"<b64>"}`.
+//
+//   - Subscribe dials a fresh `pgx.Connect()` per call — NOT from the
+//     pool. A LISTEN connection has to stay blocked in WaitForNotification
+//     to receive events; holding a pooled connection out of the pool
+//     indefinitely would starve everyone else. The dedicated connection
+//     is cheap (~5 MB) and we expect a small number of topics in v1.0
+//     (one per Phase 2-6 coordination concern).
+//
+//   - Self-message filter: Postgres delivers your own NOTIFYs back to
+//     you on the same connection. The receive goroutine drops events
+//     whose envelope.r matches the publisher replica_id.
+//
+//   - Reconnect: on connection drop, the subscribe goroutine reconnects
+//     with exponential backoff (500ms → 30s, ±20% jitter) and re-issues
+//     LISTEN. Events arriving during the window are lost; consumers
+//     must be idempotent against this.
+//
+//   - Payload cap: enforced at Publish (returns ErrPayloadTooLarge).
+//     Receive-side does NOT validate — a malformed/oversize NOTIFY
+//     payload from a buggy peer is logged and dropped.
+//
+//   - Topic validation: every Publish/Subscribe checks the topic
+//     starts with TopicPrefix ("loomcycle.") and contains no shell-
+//     unsafe characters. pgx parameter-substitutes pg_notify args so
+//     SQL injection isn't the concern here; the concern is collision
+//     with other LISTEN/NOTIFY consumers on the same database.
+type PostgresBackplane struct {
+	pool      *pgxpool.Pool
+	dsn       string
+	replicaID string
+
+	mu     sync.Mutex
+	closed bool
+	// subs tracks each Subscribe call's cancel func by an opaque ID.
+	// On goroutine exit the entry is removed; on Close every entry's
+	// cancel is fired. Replaced the v0.12.0 review-1 chain pattern,
+	// which leaked closure pointers as subscriptions were created and
+	// disposed of (review finding #1).
+	subs   map[uint64]context.CancelFunc
+	nextID uint64
+	wg     sync.WaitGroup
+}
+
+// PostgresBackplaneConfig is the constructor input.
+type PostgresBackplaneConfig struct {
+	// Pool is the shared pgxpool used for Publish. Required.
+	Pool *pgxpool.Pool
+
+	// DSN is the Postgres connection string used for Subscribe's
+	// dedicated connections. Required — pgxpool does not expose the
+	// original DSN, so the caller passes it in alongside the pool.
+	DSN string
+
+	// ReplicaID is this replica's identity. Used in the envelope
+	// header and the self-message filter. Required.
+	ReplicaID string
+}
+
+// NewPostgresBackplane validates the config and returns a ready-to-use
+// backplane. Does not dial — connections are opened lazily by
+// Publish / Subscribe.
+func NewPostgresBackplane(cfg PostgresBackplaneConfig) (*PostgresBackplane, error) {
+	if cfg.Pool == nil {
+		return nil, errors.New("coord: pgxpool is required")
+	}
+	if cfg.DSN == "" {
+		return nil, errors.New("coord: DSN is required for Subscribe")
+	}
+	if err := ValidateReplicaID(cfg.ReplicaID); err != nil {
+		return nil, err
+	}
+	return &PostgresBackplane{
+		pool:      cfg.Pool,
+		dsn:       cfg.DSN,
+		replicaID: cfg.ReplicaID,
+		subs:      make(map[uint64]context.CancelFunc),
+	}, nil
+}
+
+// envelope is the wire shape carried inside the NOTIFY payload.
+// Short field names ("r", "p") to maximise the usable payload space
+// under the 8000-byte Postgres cap.
+type envelope struct {
+	R string `json:"r"` // publisher replica_id
+	P string `json:"p"` // base64-encoded payload
+}
+
+// validateTopic returns nil if t is a valid loomcycle backplane topic.
+// Must start with TopicPrefix; the suffix is [A-Za-z0-9_.-]+ to stay
+// within shell-safe and LISTEN-quote-safe identifiers.
+func validateTopic(t string) error {
+	if !strings.HasPrefix(t, TopicPrefix) {
+		return fmt.Errorf("%w: topic %q must start with %q", ErrInvalidTopic, t, TopicPrefix)
+	}
+	suffix := t[len(TopicPrefix):]
+	if suffix == "" {
+		return fmt.Errorf("%w: topic %q has empty suffix", ErrInvalidTopic, t)
+	}
+	for _, r := range suffix {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '_' || r == '-' || r == '.':
+		default:
+			return fmt.Errorf("%w: topic %q has invalid character %q", ErrInvalidTopic, t, r)
+		}
+	}
+	return nil
+}
+
+// Publish encodes the payload, sends it via pg_notify, returns.
+func (b *PostgresBackplane) Publish(ctx context.Context, topic string, payload []byte) error {
+	b.mu.Lock()
+	closed := b.closed
+	b.mu.Unlock()
+	if closed {
+		return ErrBackplaneClosed
+	}
+	if err := validateTopic(topic); err != nil {
+		return err
+	}
+	if len(payload) > MaxPayloadBytes {
+		return fmt.Errorf("%w: %d > %d", ErrPayloadTooLarge, len(payload), MaxPayloadBytes)
+	}
+	env := envelope{
+		R: b.replicaID,
+		P: base64.StdEncoding.EncodeToString(payload),
+	}
+	body, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("coord: marshal envelope: %w", err)
+	}
+	// Final wire size check — base64 + envelope JSON overhead might
+	// push us past the 8000-byte cap even when payload is under
+	// MaxPayloadBytes. Cap the marshaled size strictly to 7900 to keep
+	// the publisher errors deterministic.
+	if len(body) > 7900 {
+		return fmt.Errorf("%w: envelope %d bytes (payload was %d)", ErrPayloadTooLarge, len(body), len(payload))
+	}
+	if _, err := b.pool.Exec(ctx, `SELECT pg_notify($1, $2)`, topic, string(body)); err != nil {
+		return fmt.Errorf("coord: pg_notify %s: %w", topic, err)
+	}
+	return nil
+}
+
+// Subscribe dials a dedicated LISTEN connection and starts a goroutine
+// that pumps events onto the returned channel. The channel closes when
+// ctx is cancelled.
+//
+// Buffer policy: 64-item buffer. Slow subscribers cause silent drops
+// — all Phase 2+ consumers re-check authoritative state in the DB on
+// receipt, so a missed event becomes a delayed-but-eventually-correct
+// operation rather than a correctness bug.
+func (b *PostgresBackplane) Subscribe(ctx context.Context, topic string) (<-chan Event, error) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil, ErrBackplaneClosed
+	}
+	b.mu.Unlock()
+	if err := validateTopic(topic); err != nil {
+		return nil, err
+	}
+	out := make(chan Event, 64)
+	subCtx, cancel := context.WithCancel(ctx)
+	b.mu.Lock()
+	subID := b.nextID
+	b.nextID++
+	b.subs[subID] = cancel
+	b.wg.Add(1)
+	b.mu.Unlock()
+	go func() {
+		defer func() {
+			// Always release the context (go vet flags WithCancel
+			// callers that don't), then remove from the tracking map
+			// so Close doesn't walk dead entries.
+			cancel()
+			b.mu.Lock()
+			delete(b.subs, subID)
+			b.mu.Unlock()
+			close(out)
+			b.wg.Done()
+		}()
+		b.runSubscribeLoop(subCtx, topic, out)
+	}()
+	return out, nil
+}
+
+// runSubscribeLoop is the reconnect-on-drop driver. Holds a fresh
+// pgx.Connect for the lifetime of one LISTEN session; on error,
+// backs off and reconnects.
+func (b *PostgresBackplane) runSubscribeLoop(ctx context.Context, topic string, out chan<- Event) {
+	backoff := 500 * time.Millisecond
+	const maxBackoff = 30 * time.Second
+	for {
+		err := b.subscribeOnce(ctx, topic, out)
+		if err == nil {
+			return // ctx cancelled cleanly
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		jittered := jitter(backoff)
+		log.Printf("coord: LISTEN %s dropped (%v); reconnecting in %s", topic, err, jittered)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(jittered):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// subscribeOnce holds one connection and pumps notifications until
+// either ctx is cancelled (returns nil) or an error occurs.
+func (b *PostgresBackplane) subscribeOnce(ctx context.Context, topic string, out chan<- Event) error {
+	conn, err := pgx.Connect(ctx, b.dsn)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer func() {
+		// pgx.Conn.Close sends a Terminate message over TCP. On a
+		// dead network with context.Background() the write blocks
+		// until the kernel send buffer drains (minutes). Cap it at
+		// 3s so reconnect backoff + global Close() can make progress
+		// when the peer has gone away (review finding #2).
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		_ = conn.Close(closeCtx)
+		closeCancel()
+	}()
+	// Use Exec because LISTEN takes a literal identifier (not a
+	// parameter). The topic is validated by validateTopic above and is
+	// safe to splice. Quote with double-quotes per the Postgres
+	// identifier-quoting rule, which makes the LISTEN target tolerant
+	// of identifiers that would otherwise need escaping (dots in the
+	// "loomcycle.foo" topic name require quoting; without quoting,
+	// Postgres would lowercase + treat the dot as a separator).
+	if _, err := conn.Exec(ctx, fmt.Sprintf(`LISTEN "%s"`, topic)); err != nil {
+		return fmt.Errorf("LISTEN: %w", err)
+	}
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		n, err := conn.WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("wait: %w", err)
+		}
+		evt, ok := b.decode(topic, n.Payload)
+		if !ok {
+			continue
+		}
+		// Self-filter — drop events we ourselves published.
+		if evt.PublisherReplicaID == b.replicaID {
+			continue
+		}
+		select {
+		case out <- evt:
+		default:
+			// Backpressure: drop on overflow. Log at low rate (every
+			// drop logs would be noisy; first-drop-per-topic-per-minute
+			// would be ideal but adds complexity. Phase 1 logs every
+			// drop; if it becomes noisy in practice, rate-limit later).
+			log.Printf("coord: subscriber for %s is slow, dropping event from %s", topic, evt.PublisherReplicaID)
+		}
+	}
+}
+
+// decode parses a NOTIFY payload string. Returns ok=false on malformed
+// payloads (logged); ok=true with a populated Event on success.
+func (b *PostgresBackplane) decode(topic, raw string) (Event, bool) {
+	var env envelope
+	if err := json.Unmarshal([]byte(raw), &env); err != nil {
+		log.Printf("coord: malformed NOTIFY payload on %s (decode env): %v", topic, err)
+		return Event{}, false
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.P)
+	if err != nil {
+		log.Printf("coord: malformed NOTIFY payload on %s (decode b64): %v", topic, err)
+		return Event{}, false
+	}
+	return Event{
+		Topic:              topic,
+		Payload:            payload,
+		PublisherReplicaID: env.R,
+	}, true
+}
+
+// Close shuts down all subscribers and marks the backplane closed.
+// Idempotent. Blocks up to 5s waiting for subscriber goroutines to drain.
+func (b *PostgresBackplane) Close() error {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return nil
+	}
+	b.closed = true
+	// Snapshot every live cancel func before releasing the lock.
+	// Each cancel triggers its subscriber goroutine to exit, which
+	// in turn removes its own entry from b.subs — but we already
+	// have the snapshot so the concurrent mutation is fine.
+	cancels := make([]context.CancelFunc, 0, len(b.subs))
+	for _, c := range b.subs {
+		cancels = append(cancels, c)
+	}
+	b.mu.Unlock()
+	for _, c := range cancels {
+		c()
+	}
+	done := make(chan struct{})
+	go func() {
+		b.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		log.Printf("coord: backplane close timed out waiting for subscribers")
+	}
+	return nil
+}
+
+// jitter applies ±20% randomness to d for thundering-herd protection
+// on reconnect bursts (multiple replicas waking up after a Postgres
+// restart shouldn't all reconnect at the same tick).
+func jitter(d time.Duration) time.Duration {
+	delta := float64(d) * 0.2
+	off := (rand.Float64()*2 - 1) * delta
+	return d + time.Duration(off)
+}

--- a/internal/coord/postgres_backplane_test.go
+++ b/internal/coord/postgres_backplane_test.go
@@ -1,0 +1,230 @@
+package coord
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestValidateTopic_AcceptsLoomcyclePrefix(t *testing.T) {
+	for _, topic := range []string{
+		"loomcycle.cancel",
+		"loomcycle.pause",
+		"loomcycle.test-1",
+		"loomcycle.run_state",
+	} {
+		if err := validateTopic(topic); err != nil {
+			t.Errorf("%q rejected: %v", topic, err)
+		}
+	}
+}
+
+func TestValidateTopic_Rejects(t *testing.T) {
+	cases := []string{
+		"",                    // empty
+		"cancel",              // no prefix
+		"loomcycle.",          // empty suffix
+		"loomcycle.has space", // space in suffix
+		"loomcycle.has/slash", // slash
+		"OTHER.cancel",        // wrong prefix
+	}
+	for _, topic := range cases {
+		if err := validateTopic(topic); err == nil {
+			t.Errorf("invalid topic %q accepted", topic)
+		}
+	}
+}
+
+// ---- Postgres-gated tests ----
+
+func TestPostgresBackplane_PublishSubscribeRoundtrip(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer pool.Close()
+
+	// Two backplanes simulating two replicas sharing one Postgres.
+	bpA, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-A-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane A: %v", err)
+	}
+	defer bpA.Close()
+	bpB, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-B-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane B: %v", err)
+	}
+	defer bpB.Close()
+
+	// Subscribe on B BEFORE A publishes — otherwise the NOTIFY misses
+	// the listener entirely.
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+	topic := "loomcycle.test." + time.Now().Format("150405.000")
+	ch, err := bpB.Subscribe(subCtx, topic)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Give the LISTEN connection a moment to actually issue the LISTEN
+	// statement on its dedicated conn before we publish.
+	time.Sleep(150 * time.Millisecond)
+
+	payload := []byte("hello-from-A")
+	if err := bpA.Publish(context.Background(), topic, payload); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case evt := <-ch:
+		if !bytes.Equal(evt.Payload, payload) {
+			t.Errorf("payload mismatch: got %q, want %q", evt.Payload, payload)
+		}
+		if evt.PublisherReplicaID != bpA.replicaID {
+			t.Errorf("publisher = %q, want %q", evt.PublisherReplicaID, bpA.replicaID)
+		}
+		if evt.Topic != topic {
+			t.Errorf("topic = %q, want %q", evt.Topic, topic)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("did not receive event on B's subscription within 3s")
+	}
+}
+
+func TestPostgresBackplane_SelfMessageFiltered(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer pool.Close()
+	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-self-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane: %v", err)
+	}
+	defer bp.Close()
+
+	subCtx, subCancel := context.WithCancel(context.Background())
+	defer subCancel()
+	topic := "loomcycle.test.self." + time.Now().Format("150405.000")
+	ch, err := bp.Subscribe(subCtx, topic)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	if err := bp.Publish(context.Background(), topic, []byte("self")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	select {
+	case evt := <-ch:
+		t.Errorf("unexpected self-event delivered: %+v", evt)
+	case <-time.After(500 * time.Millisecond):
+		// Expected — self-message filtered.
+	}
+}
+
+func TestPostgresBackplane_PayloadTooLarge(t *testing.T) {
+	// Pure unit: does not need the DB connection to actually round-trip
+	// — the size check fires before pg_notify. Use a real pool to
+	// satisfy the constructor's nil check, but we never publish enough
+	// to reach the DB.
+	dsn := pgDSNFromEnv(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer pool.Close()
+	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-large-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane: %v", err)
+	}
+	defer bp.Close()
+
+	big := bytes.Repeat([]byte("x"), MaxPayloadBytes+1)
+	err = bp.Publish(context.Background(), "loomcycle.test.toolarge", big)
+	if !errors.Is(err, ErrPayloadTooLarge) {
+		t.Errorf("got %v, want ErrPayloadTooLarge", err)
+	}
+}
+
+func TestPostgresBackplane_PublishAfterClose(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer pool.Close()
+	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-closed-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane: %v", err)
+	}
+	if err := bp.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	err = bp.Publish(context.Background(), "loomcycle.test", []byte("nope"))
+	if !errors.Is(err, ErrBackplaneClosed) {
+		t.Errorf("got %v, want ErrBackplaneClosed", err)
+	}
+}
+
+func TestPostgresBackplane_InvalidTopic(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer pool.Close()
+	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-topic-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane: %v", err)
+	}
+	defer bp.Close()
+
+	for _, topic := range []string{"no-prefix", "loomcycle.", "loomcycle.has space"} {
+		err := bp.Publish(context.Background(), topic, []byte("x"))
+		if !errors.Is(err, ErrInvalidTopic) {
+			t.Errorf("topic %q: got %v, want ErrInvalidTopic", topic, err)
+		}
+	}
+}
+
+func TestNewPostgresBackplane_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  PostgresBackplaneConfig
+		want string // substring of error message
+	}{
+		{"nil pool", PostgresBackplaneConfig{DSN: "x", ReplicaID: "x"}, "pgxpool is required"},
+		{"empty DSN", PostgresBackplaneConfig{Pool: &pgxpool.Pool{}, ReplicaID: "x"}, "DSN is required"},
+		{"bad replica id", PostgresBackplaneConfig{Pool: &pgxpool.Pool{}, DSN: "x", ReplicaID: "has space"}, "replica id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewPostgresBackplane(tc.cfg)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/coord/replica_store.go
+++ b/internal/coord/replica_store.go
@@ -1,0 +1,190 @@
+package coord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Replica is one row from the replicas heartbeat table.
+type Replica struct {
+	ID              string    `json:"id"`
+	Hostname        string    `json:"hostname"`
+	StartedAt       time.Time `json:"started_at"`
+	LastHeartbeatAt time.Time `json:"last_heartbeat_at"`
+	Version         string    `json:"version"`
+}
+
+// ReplicaStore is read/write access to the v0.12.0 replicas table.
+// Takes a *pgxpool.Pool directly — bypasses the store.Store interface
+// because the table is Postgres-specific (SQLite refuses to start in
+// cluster mode).
+type ReplicaStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewReplicaStore wraps an existing pgxpool. The pool is not owned;
+// closing ReplicaStore does not close the pool.
+func NewReplicaStore(pool *pgxpool.Pool) *ReplicaStore {
+	return &ReplicaStore{pool: pool}
+}
+
+// UpsertReplica is the heartbeat write — INSERT on first call, UPDATE
+// every subsequent. Bumps last_heartbeat_at to now() on every call.
+// hostname + version are only persisted on the INSERT row; subsequent
+// upserts leave them unchanged (a replica's hostname/version doesn't
+// change between restarts; UPDATE would also overwrite if we wanted).
+func (s *ReplicaStore) UpsertReplica(ctx context.Context, id, hostname, version string) error {
+	if id == "" {
+		return errors.New("replica id is empty")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO replicas (id, hostname, version, started_at, last_heartbeat_at)
+		VALUES ($1, $2, $3, now(), now())
+		ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()
+	`, id, hostname, version)
+	if err != nil {
+		return fmt.Errorf("upsert replica %s: %w", id, err)
+	}
+	return nil
+}
+
+// DeleteReplica removes a replica's row. Called on graceful shutdown;
+// also exposed for the Phase 5 replicas TTL sweeper to reap stale rows.
+func (s *ReplicaStore) DeleteReplica(ctx context.Context, id string) error {
+	if id == "" {
+		return errors.New("replica id is empty")
+	}
+	_, err := s.pool.Exec(ctx, `DELETE FROM replicas WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("delete replica %s: %w", id, err)
+	}
+	return nil
+}
+
+// ListReplicas returns every row, ordered by started_at ascending.
+// Backs the /healthz cluster view + Phase 7's /ui/cluster admin page.
+func (s *ReplicaStore) ListReplicas(ctx context.Context) ([]Replica, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, hostname, started_at, last_heartbeat_at, version
+		FROM replicas
+		ORDER BY started_at ASC
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("list replicas: %w", err)
+	}
+	defer rows.Close()
+	var out []Replica
+	for rows.Next() {
+		var r Replica
+		if err := rows.Scan(&r.ID, &r.Hostname, &r.StartedAt, &r.LastHeartbeatAt, &r.Version); err != nil {
+			return nil, fmt.Errorf("scan replica row: %w", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate replicas: %w", err)
+	}
+	return out, nil
+}
+
+// HeartbeatConfig configures the periodic upsert loop.
+type HeartbeatConfig struct {
+	ReplicaID string
+	Hostname  string
+	Version   string
+
+	// Interval between heartbeats. Default 30s. The Phase 5 replicas
+	// sweeper marks rows stale at ~2× this interval, so shortening it
+	// here also shortens dead-replica detection latency.
+	Interval time.Duration
+
+	// ShutdownTimeout caps the DELETE issued on graceful shutdown.
+	// Default 5s. A separate context is used so the parent ctx (which
+	// is already cancelled at this point) doesn't prevent the cleanup.
+	ShutdownTimeout time.Duration
+}
+
+const (
+	defaultHeartbeatInterval = 30 * time.Second
+	defaultShutdownTimeout   = 5 * time.Second
+)
+
+// Heartbeat is the background goroutine that keeps this replica's row
+// current. Owns the upsert tick and the shutdown DELETE.
+type Heartbeat struct {
+	store *ReplicaStore
+	cfg   HeartbeatConfig
+}
+
+func NewHeartbeat(store *ReplicaStore, cfg HeartbeatConfig) *Heartbeat {
+	if cfg.Interval == 0 {
+		cfg.Interval = defaultHeartbeatInterval
+	}
+	if cfg.ShutdownTimeout == 0 {
+		cfg.ShutdownTimeout = defaultShutdownTimeout
+	}
+	return &Heartbeat{store: store, cfg: cfg}
+}
+
+// Run blocks until ctx is cancelled. Upserts immediately, then every
+// cfg.Interval. On ctx.Done, issues a final DELETE with its own
+// cfg.ShutdownTimeout context (the parent ctx is cancelled by then).
+//
+// A failed UPSERT logs a warning and continues — a stale row will be
+// reaped by the Phase 5 sweeper. A failed final DELETE logs but does
+// not propagate; the row will likewise age out via the sweeper.
+func (h *Heartbeat) Run(ctx context.Context) {
+	// First upsert: synchronous, before the ticker starts. Ensures the
+	// row is visible in /healthz immediately on boot.
+	if err := h.store.UpsertReplica(ctx, h.cfg.ReplicaID, h.cfg.Hostname, h.cfg.Version); err != nil {
+		log.Printf("coord: initial replica upsert failed: %v", err)
+	}
+	t := time.NewTicker(h.cfg.Interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Fresh context so the cancellation doesn't immediately
+			// kill the DELETE.
+			shutCtx, cancel := context.WithTimeout(context.Background(), h.cfg.ShutdownTimeout)
+			if err := h.store.DeleteReplica(shutCtx, h.cfg.ReplicaID); err != nil {
+				log.Printf("coord: shutdown DELETE for replica %s failed: %v", h.cfg.ReplicaID, err)
+			}
+			cancel()
+			return
+		case <-t.C:
+			if err := h.store.UpsertReplica(ctx, h.cfg.ReplicaID, h.cfg.Hostname, h.cfg.Version); err != nil {
+				log.Printf("coord: replica upsert failed: %v (will retry in %s)", err, h.cfg.Interval)
+			}
+		}
+	}
+}
+
+// replicaIDPattern validates LOOMCYCLE_REPLICA_ID values.
+// Accepts either a UUID4 or a short alphanumeric label (operator-
+// supplied, ≤ 64 chars). The character class is deliberately narrow:
+// LISTEN channel names are quoted by pgx so most input would survive,
+// but constraining it here means a replica_id can also serve as a
+// log-line key, a cluster admin label, and a row PK without escaping
+// concerns at any of those sites.
+var replicaIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$`)
+
+// ValidateReplicaID enforces the format. Called once at config-load.
+// Empty replica_id is the "single-replica mode" sentinel and is
+// accepted by callers above this layer; the validation here is for
+// non-empty values only.
+func ValidateReplicaID(id string) error {
+	if id == "" {
+		return errors.New("replica id is empty")
+	}
+	if !replicaIDPattern.MatchString(id) {
+		return fmt.Errorf("replica id %q: must match [A-Za-z0-9][A-Za-z0-9_-]{0,63}", id)
+	}
+	return nil
+}

--- a/internal/coord/replica_store_test.go
+++ b/internal/coord/replica_store_test.go
@@ -1,0 +1,267 @@
+package coord
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+func TestValidateReplicaID_AcceptsUUID(t *testing.T) {
+	// A representative UUID4 — middle char in version field is 4, third
+	// group leads with 8/9/a/b. ValidateReplicaID is regex-only and does
+	// not check the version digit semantics; pass a real one anyway so
+	// the test documents the expected shape.
+	if err := ValidateReplicaID("3f9b0a2e-1234-4abc-89ef-0123456789ab"); err != nil {
+		t.Errorf("UUID4 rejected: %v", err)
+	}
+}
+
+func TestValidateReplicaID_AcceptsShortLabels(t *testing.T) {
+	for _, id := range []string{"a", "replica-a", "lc_1", "R-2", "x123"} {
+		if err := ValidateReplicaID(id); err != nil {
+			t.Errorf("label %q rejected: %v", id, err)
+		}
+	}
+}
+
+func TestValidateReplicaID_RejectsInvalid(t *testing.T) {
+	cases := []string{
+		"",                  // empty
+		"-leads-with-dash",  // first char must be alnum
+		"_leads-with-under", // first char must be alnum
+		"has space",
+		"has/slash",
+		"has.dot",
+		"has:colon",
+		"has;semi",
+		strings.Repeat("a", 65), // too long
+	}
+	for _, id := range cases {
+		if err := ValidateReplicaID(id); err == nil {
+			t.Errorf("invalid id %q accepted", id)
+		}
+	}
+}
+
+// TestReplicaIDPatternsAreInSync is the drift catcher for the
+// duplicated regex in internal/config and internal/coord. Both
+// packages own a copy because the import graph forbids config →
+// coord (main.go composes the two; config has to validate at Load
+// independently). The two validators must produce the same accept/
+// reject decision on every input; this test pins that invariant on
+// a corpus designed to catch every realistic divergence shape
+// (length boundary, first-char rules, allowed-char set, common
+// invalid shapes).
+func TestReplicaIDPatternsAreInSync(t *testing.T) {
+	corpus := []string{
+		// Accept cases
+		"a",
+		"A",
+		"0",
+		"replica-a",
+		"replica_a",
+		"r1",
+		"R-2-3",
+		"3f9b0a2e-1234-4abc-89ef-0123456789ab",
+		strings.Repeat("a", 64), // length boundary — should accept
+		// Reject cases
+		"",
+		"-leading-dash",
+		"_leading-under",
+		"has space",
+		"has/slash",
+		"has.dot",
+		"has:colon",
+		"has;semi",
+		"has,comma",
+		"has\"quote",
+		"has'apos",
+		strings.Repeat("a", 65), // length boundary — should reject
+	}
+	for _, id := range corpus {
+		coordErr := ValidateReplicaID(id)
+		configErr := config.ValidateReplicaID(id)
+		coordOK := coordErr == nil
+		configOK := configErr == nil
+		if coordOK != configOK {
+			t.Errorf("DRIFT on %q: coord accept=%v err=%v / config accept=%v err=%v",
+				id, coordOK, coordErr, configOK, configErr)
+		}
+	}
+}
+
+// ---- Postgres-gated tests ----
+
+func pgDSNFromEnv(t *testing.T) string {
+	t.Helper()
+	dsn := os.Getenv("LOOMCYCLE_TEST_PG_DSN")
+	if dsn == "" {
+		t.Skip("LOOMCYCLE_TEST_PG_DSN not set; skipping coord integration tests.")
+	}
+	return dsn
+}
+
+// freshReplicasTable opens a pgxpool against the DSN and resets the
+// `replicas` table to an empty state. Migrations are applied via the
+// storepostgres package on the operator's database; the tests assume
+// they've already been run (matches the pattern in internal/store/postgres).
+//
+// Tests that need isolation from concurrent runs should namespace their
+// replica IDs (e.g. `TestX_<rand>`) — replicas is a tiny operational
+// table; per-test schemas would be overkill.
+func freshReplicasTable(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial pg: %v", err)
+	}
+	// Tests do NOT TRUNCATE the table — that would race with other
+	// concurrent test packages also touching `replicas`. Each test
+	// inserts a unique-named row and cleans up after itself.
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+func TestReplicaStore_UpsertListDelete(t *testing.T) {
+	pool := freshReplicasTable(t, pgDSNFromEnv(t))
+	store := NewReplicaStore(pool)
+	id := "test-rs-" + time.Now().Format("150405.000")
+	ctx := context.Background()
+	if err := store.UpsertReplica(ctx, id, "host-a", "v0.12.0-test"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	t.Cleanup(func() {
+		// Best-effort — pool may already be closed by t.Cleanup ordering.
+		_ = store.DeleteReplica(context.Background(), id)
+	})
+
+	got, err := store.ListReplicas(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	found := false
+	for _, r := range got {
+		if r.ID == id {
+			found = true
+			if r.Hostname != "host-a" {
+				t.Errorf("hostname = %q, want host-a", r.Hostname)
+			}
+			if r.Version != "v0.12.0-test" {
+				t.Errorf("version = %q, want v0.12.0-test", r.Version)
+			}
+			if r.StartedAt.IsZero() || r.LastHeartbeatAt.IsZero() {
+				t.Errorf("zero timestamps: %+v", r)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("inserted replica %s not present in list (got %d rows)", id, len(got))
+	}
+
+	// Delete + re-list — row should be gone.
+	if err := store.DeleteReplica(ctx, id); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got2, err := store.ListReplicas(ctx)
+	if err != nil {
+		t.Fatalf("list after delete: %v", err)
+	}
+	for _, r := range got2 {
+		if r.ID == id {
+			t.Fatalf("delete left row present: %+v", r)
+		}
+	}
+}
+
+func TestReplicaStore_UpsertUpdatesHeartbeat(t *testing.T) {
+	pool := freshReplicasTable(t, pgDSNFromEnv(t))
+	store := NewReplicaStore(pool)
+	id := "test-hb-" + time.Now().Format("150405.000")
+	ctx := context.Background()
+	if err := store.UpsertReplica(ctx, id, "host-b", "v0.12.0-test"); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	t.Cleanup(func() { _ = store.DeleteReplica(context.Background(), id) })
+
+	rows1, _ := store.ListReplicas(ctx)
+	var first time.Time
+	for _, r := range rows1 {
+		if r.ID == id {
+			first = r.LastHeartbeatAt
+		}
+	}
+	if first.IsZero() {
+		t.Fatal("first upsert row not found")
+	}
+
+	// Sleep enough that Postgres's now() advances measurably even on
+	// fast hosts. 50ms is well below the 30s heartbeat tick but enough
+	// to register at microsecond timestamp resolution.
+	time.Sleep(50 * time.Millisecond)
+	if err := store.UpsertReplica(ctx, id, "host-b", "v0.12.0-test"); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+	rows2, _ := store.ListReplicas(ctx)
+	var second time.Time
+	for _, r := range rows2 {
+		if r.ID == id {
+			second = r.LastHeartbeatAt
+		}
+	}
+	if !second.After(first) {
+		t.Errorf("second heartbeat %v not after first %v", second, first)
+	}
+}
+
+func TestHeartbeat_RunExitsOnContextDone(t *testing.T) {
+	pool := freshReplicasTable(t, pgDSNFromEnv(t))
+	store := NewReplicaStore(pool)
+	id := "test-run-" + time.Now().Format("150405.000")
+	hb := NewHeartbeat(store, HeartbeatConfig{
+		ReplicaID:       id,
+		Hostname:        "host-c",
+		Version:         "v0.12.0-test",
+		Interval:        50 * time.Millisecond,
+		ShutdownTimeout: 2 * time.Second,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		hb.Run(ctx)
+		close(done)
+	}()
+	// Give the goroutine time to register the initial row.
+	time.Sleep(100 * time.Millisecond)
+	rows, _ := store.ListReplicas(context.Background())
+	registered := false
+	for _, r := range rows {
+		if r.ID == id {
+			registered = true
+		}
+	}
+	if !registered {
+		t.Fatal("heartbeat goroutine did not insert initial row")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not exit within 3s of ctx cancel")
+	}
+
+	// After ctx.Done, the shutdown DELETE should have removed the row.
+	rows2, _ := store.ListReplicas(context.Background())
+	for _, r := range rows2 {
+		if r.ID == id {
+			t.Errorf("shutdown DELETE did not remove row: %+v", r)
+		}
+	}
+}

--- a/internal/store/postgres/migrations/0022_replicas.down.sql
+++ b/internal/store/postgres/migrations/0022_replicas.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS replicas;

--- a/internal/store/postgres/migrations/0022_replicas.up.sql
+++ b/internal/store/postgres/migrations/0022_replicas.up.sql
@@ -1,0 +1,18 @@
+-- v0.12.0 multi-replica HA foundation.
+--
+-- One row per loomcycle replica running against this Postgres instance.
+-- A replica self-registers on boot (UPSERT every 30s via heartbeat),
+-- self-deletes on graceful shutdown. /healthz aggregates this table
+-- into the cluster view; later phases use it to detect dead-owner
+-- replicas for cancel/status fallback.
+--
+-- Only populated when LOOMCYCLE_REPLICA_ID is set — single-replica
+-- deployments leave the table empty.
+
+CREATE TABLE IF NOT EXISTS replicas (
+    id                TEXT        PRIMARY KEY,
+    hostname          TEXT        NOT NULL DEFAULT '',
+    started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version           TEXT        NOT NULL DEFAULT ''
+);

--- a/internal/store/postgres/migrations/0023_runs_replica_id.down.sql
+++ b/internal/store/postgres/migrations/0023_runs_replica_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS runs_by_replica;
+ALTER TABLE runs DROP COLUMN IF EXISTS replica_id;

--- a/internal/store/postgres/migrations/0023_runs_replica_id.up.sql
+++ b/internal/store/postgres/migrations/0023_runs_replica_id.up.sql
@@ -1,0 +1,11 @@
+-- v0.12.0 multi-replica HA: stamp every run with the replica_id that
+-- owns its in-process state (cancel registry, semaphore slot, etc.).
+--
+-- Landed in Phase 1 as a nullable column with no writes — Phase 3 adds
+-- the stamping at run creation, at which point cross-replica cancel
+-- can look up the owner via this column instead of broadcasting blind.
+-- Existing single-replica deployments see NULL on every row; nothing
+-- reads it until Phase 3.
+
+ALTER TABLE runs ADD COLUMN IF NOT EXISTS replica_id TEXT;
+CREATE INDEX IF NOT EXISTS runs_by_replica ON runs(replica_id) WHERE replica_id IS NOT NULL;


### PR DESCRIPTION
## Summary

First slice of the v1.0 multi-replica HA capstone. Pure foundation — activates only when `LOOMCYCLE_REPLICA_ID` is set; single-replica deployments see no behavior change. Six follow-up phases (cluster-wide fairness, cross-replica cancel, pause/resume + bus fanout, advisory-lock sweepers, DB-backed session/hook registries, hardening + docs) build consumers on top of this substrate; v1.0 tags when Phase 7 lands.

RFC at `~/work/loomcycle-internal/doc-internal/rfcs/multi-replica-ha.md` covers all 7 phases + locked decisions + audit reference (17 single-replica-assumption subsystems mapped).

## What ships in v0.12.0

- **`LOOMCYCLE_REPLICA_ID` env var** with regex validation (UUID4 or `[A-Za-z0-9][A-Za-z0-9_-]{0,63}` short label).
- **New `internal/coord/` package**: `Backplane` interface + `PostgresBackplane` over LISTEN/NOTIFY. Reconnect-on-drop with 500ms→30s exponential backoff + ±20% jitter; 7800-byte payload cap (margin under the Postgres 8000-byte NOTIFY ceiling); self-message filter via `{"r": "<replica_id>", "p": "<b64>"}` envelope; topic prefix `loomcycle.*` to avoid collision with other LISTEN consumers.
- **`replicas` heartbeat table** (migration 0022) + 30s heartbeat goroutine. Self-registers on boot, self-deletes on graceful shutdown via a fresh 5s context.
- **`runs.replica_id` nullable column** (migration 0023) landed early so Phase 3 (cross-replica cancel) is purely behavioral — no Phase 3 migration needed.
- **SQLite refuse-to-start guard**: `openStore` errors out when `REPLICA_ID` is set + backend is sqlite, with a clear message pointing at Postgres or unsetting the env var.
- **`GET /healthz` cluster view**: `replica_id` + `replicas[]` fields when coord is wired; `omitempty` keeps the single-replica response shape byte-identical to v0.11.x.

## Locked architecture

- **Backplane = Postgres LISTEN/NOTIFY only in v1.0.** Behind the `coord.Backplane` interface so Redis can slot in as a v1.1+ additive impl if a deployment hits LISTEN/NOTIFY's throughput ceiling. No Redis stub in v1.0.
- **SQLite is single-replica only.** Multi-replica requires Postgres; boot fails loud rather than degrade silently.
- **MCP stdio children + OAuth-dev tokens stay per-host.** Resource scaling / dev-path concerns; already documented in OAuth-dev RFC.
- **Global concurrency cap stays per-replica.** Per-user fairness lifts to cluster-wide in Phase 2 via DB-backed `user_quotas` counter.

## Code review (parallel agent) — 4 findings, all fixed pre-commit

1. **CRITICAL**: `cancelFunc` chain leaked closure pointers as subscribers came + went. Replaced with a per-subscription map + goroutine-exit removal; `Close()` snapshots the map under the mutex.
2. **IMPORTANT**: `pgx.Conn.Close(context.Background())` could block on dead network until the kernel TCP send buffer drained (minutes). Bounded with a 3s timeout context.
3. **IMPORTANT**: duplicate `replicaIDPattern` regex in config + coord had no drift enforcement. Added `TestReplicaIDPatternsAreInSync` cross-checking both validators on a 20-input corpus.
4. **IMPORTANT**: `/healthz` dropped `replica_id` on `ListReplicas` error, making monitoring see intermittent identity loss on Postgres hiccups. `replica_id` is now always populated when coord is wired; only `replicas[]` is omitted on error.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./... -count=1 -timeout 300s` all green
- [x] New tests covering: backplane validation (non-PG-gated), backplane roundtrip + self-filter + payload-too-large + closed + invalid-topic (PG-gated, skip without `LOOMCYCLE_TEST_PG_DSN`), replica heartbeat upsert/list/delete lifecycle (PG-gated), config env-var accept/reject, healthz back-compat (coord unwired) + cluster view (coord wired) + list-error preserves `replica_id`, regex drift between config + coord
- [x] Smoke test: `LOOMCYCLE_REPLICA_ID=test-a ./bin/loomcycle --config loomcycle.yaml` (sqlite default) refuses with the new error message
- [x] Smoke test: `./bin/loomcycle --config loomcycle.yaml` (REPLICA_ID unset) boots normally with no new log lines
- [ ] CI green on PR check
- [ ] Integration test against real Postgres via `LOOMCYCLE_TEST_PG_DSN` (runs locally; CI gate depends on operator's CI fixture)

## What's coming next

| Phase | PR | Scope |
|---|---|---|
| 2 | v0.12.1 | Cluster-wide per-user fairness — `user_quotas` table replaces in-process counter |
| 3 | v0.12.2 | Cross-replica cancel + status (uses runs.replica_id from this PR) |
| 4 | v0.12.3 | Pause/resume + bus fanout — DB-backed pause state + backplane invalidation |
| 5 | v0.12.4 | Singleton sweepers via `pg_try_advisory_lock` |
| 6 | v0.12.5 | Session-lock + hook-registry → DB-backed |
| 7 | v0.12.6 | Hardening + docs + **tag v1.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)