### PR TITLE
feat(v0.12.1): cluster-wide per-user fairness (Phase 2 of 7)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,43 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.12.1
+
+**Phase 2 of the v1.0 multi-replica HA capstone — cluster-wide per-user fairness.** Lifts the v0.10.1 in-process per-user concurrency counter (`Semaphore.perUser` map) to a cluster-wide DB-backed counter (`user_quotas` table). Activates only when `LOOMCYCLE_REPLICA_ID` is set; single-replica deployments keep the v0.10.1 in-memory path byte-identical.
+
+### Problem
+
+v0.10.1's per-user concurrency cap is per-replica. On a 2-replica deployment with `MaxConcurrentRunsPerUser=4`, a single noisy user can burst 8 runs cluster-wide (4 per replica), defeating the fairness invariant. v0.12.1 makes the cap mean what its name says: 4 active+queued runs per user *across the cluster*, regardless of replica count.
+
+### What ships
+
+1. **`user_quotas` table + migration 0024.** `user_id` (PK), `active_count` (int, `CHECK >= 0`), `updated_at`. One row per user with at least one active run. The CHECK constraint prevents underflow; the cap is config-driven (`MaxConcurrentRunsPerUser`), not stored per-row.
+
+2. **`coord.UserQuotaStore`** — new struct in `internal/coord/` next to `ReplicaStore`. Three methods:
+   - `TryAcquire(ctx, userID, cap) (bool, error)` — single-statement `INSERT ... ON CONFLICT DO UPDATE WHERE active_count < cap`. `rows_affected = 1` → slot acquired; `rows_affected = 0` → at cap (false+nil). Atomic across replicas: two concurrent TryAcquires on the same user serialize at the DB level; only as many succeed as the cap allows.
+   - `Release(ctx, userID)` — atomic decrement, guarded by `WHERE active_count > 0` so a double-release or Phase 5 reap landing between acquire and release doesn't underflow.
+   - `Snapshot(ctx)` — `SELECT user_id, active_count WHERE active_count > 0`. Backs `GET /v1/_concurrency/stats`.
+
+3. **`concurrency.Semaphore` refactor with `userQuotaGate` interface.** The Semaphore gains an internal `userQuotaGate` interface and a `WithUserQuotaStore` setter; `*coord.UserQuotaStore` satisfies it implicitly. Crucially, `internal/concurrency` does NOT import `internal/coord` — the interface keeps the dependency direction one-way and lets tests stub the gate without standing up Postgres. When the gate is wired (cluster mode), `AcquireForUser` delegates the per-user cap check to the DB and bypasses the in-memory `perUser` map entirely; when unset (single-replica mode), the v0.10.1 in-memory path runs unchanged.
+
+4. **Compensate-release on global-queue rejection.** When `TryAcquire` succeeds on the DB but the global queue is full, the Semaphore fires a background `Release` so the cluster-wide count stays balanced. Same compensation on cancel/timeout in `cancelWaiter`. All DB calls happen *outside* the Semaphore's mutex via a 5-second-bounded background goroutine — handler `defer release()` chains stay non-blocking.
+
+5. **`Stats()` reads from the DB in cluster mode.** `GET /v1/_concurrency/stats` `per_user` field comes from `qs.Snapshot(ctx)` with a 1-second timeout when cluster-mode is active; on snapshot error the `per_user` map is omitted but the response still returns 200 with the local Active/Queued counters intact. Wire shape preserved exactly — admin dashboards keyed off the v0.10.1 JSON don't notice the mode switch.
+
+6. **Wire surface preserved exactly.** `*ErrPerUserQuotaExhausted` is still the typed error returned to handlers (HTTP 429 + `Retry-After: 5` + `{code:"per_user_quota_exhausted", user_id, cap}`). Sub-agents continue to share the parent's slot AND user count (no double-billing) because `runSubAgent` skips `AcquireForUser` entirely — unchanged from v0.10.1.
+
+### Crash-safety gap (documented; closes in Phase 5)
+
+If a replica crashes after `TryAcquire` but before `Release` fires, the user's `active_count` is permanently incremented until manual intervention. Phase 5's replicas TTL sweeper will reap orphaned slots by joining `user_quotas` against `runs WHERE replica_id = <dead> AND status IN ('active', 'queued')`. Until then, operators monitor `/v1/_concurrency/stats` for stuck non-zero counts after known runs have completed.
+
+### Test coverage
+
+- Postgres-gated contract tests for `UserQuotaStore`: acquire/release lifecycle, at-cap rejection, first-acquire creates row, release underflow no-op, snapshot excludes zero counts, two-replica concurrent atomicity (10 racy acquires against cap=3 → exactly 3 succeed).
+- In-process Semaphore tests with stub gate: dispatch delegation (DB path bypasses in-memory map), typed error on at-cap, compensate-release on queue-full, infrastructure-error wrapping, Stats() from snapshot.
+- All v0.10.1 existing tests continue to pass — the in-memory path is byte-identical when `quotaStore` is nil.
+
+---
+
 ## What's in v0.12.0
 
 **Phase 1 of the v1.0 multi-replica HA capstone — foundation only.** Activates only when the operator sets `LOOMCYCLE_REPLICA_ID`. Single-replica deployments (env var unset) see no behavior change — every code path added in this release is dormant.

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1128,7 +1128,16 @@ func main() {
 		// backplane behind the interface but with no live publisher/
 		// subscriber — Phase 2+ adds those.
 		srv.SetCoord(bp, replicaStore, cfg.Env.ReplicaID)
-		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify", cfg.Env.ReplicaID)
+
+		// v0.12.1 Phase 2: cluster-wide per-user fairness. Replaces the
+		// in-process perUser counter inside Semaphore with a DB-backed
+		// user_quotas atomic counter. No-op when MaxConcurrentRunsPerUser
+		// is 0 (per-user check disabled); the wiring is unconditional
+		// because WithUserQuotaStore is cheap and the gate is only
+		// reached when perUserActive evaluates true.
+		quotaStore := coord.NewUserQuotaStore(pgStore.Pool())
+		sem.WithUserQuotaStore(quotaStore)
+		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify user_quotas=db-backed", cfg.Env.ReplicaID)
 	}
 
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.

--- a/internal/concurrency/semaphore.go
+++ b/internal/concurrency/semaphore.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 	"time"
 )
@@ -46,6 +47,20 @@ func (e *ErrPerUserQuotaExhausted) Error() string {
 // Code is the typed identifier used in the HTTP error envelope.
 func (e *ErrPerUserQuotaExhausted) Code() string { return "per_user_quota_exhausted" }
 
+// userQuotaGate is the contract the v0.12.1 cluster-wide per-user
+// counter must satisfy. coord.UserQuotaStore implements this implicitly;
+// keeping the interface in this package (rather than importing coord)
+// means concurrency stays a low-level dependency-free package and tests
+// can stub the gate without standing up Postgres.
+//
+// TryAcquire returns (acquired, err). false+nil = the user is at cap;
+// false+non-nil = infrastructure error (DB unreachable, etc).
+type userQuotaGate interface {
+	TryAcquire(ctx context.Context, userID string, cap int) (bool, error)
+	Release(ctx context.Context, userID string)
+	Snapshot(ctx context.Context) (map[string]int, error)
+}
+
 // Semaphore caps concurrent acquisitions. Acquire blocks (with timeout) when
 // slots are full and the queue has room; returns BackpressureError when the
 // queue is also full.
@@ -62,8 +77,20 @@ type Semaphore struct {
 	// Both Acquire (with empty userID) and AcquireForUser write to
 	// the same global active/queued counters; only AcquireForUser
 	// with a non-empty userID touches this map.
+	//
+	// In v0.12.1 cluster mode (quotaStore != nil), perUser is left
+	// untouched — the DB-backed counter is authoritative. Single-
+	// replica deployments (quotaStore == nil) use perUser exactly as
+	// v0.10.1 did.
 	perUser map[string]int
 	waiters []chan struct{}
+
+	// quotaStore is the v0.12.1 cluster-wide per-user counter. Nil in
+	// single-replica mode (LOOMCYCLE_REPLICA_ID unset); set by
+	// WithUserQuotaStore in cluster mode. When non-nil, AcquireForUser
+	// delegates the per-user cap enforcement to the DB instead of the
+	// in-memory perUser map. Set via WithUserQuotaStore.
+	quotaStore userQuotaGate
 }
 
 // Stats is a point-in-time snapshot of the semaphore's accounting.
@@ -104,6 +131,23 @@ func (s *Semaphore) WithPerUserCap(n int) *Semaphore {
 	return s
 }
 
+// WithUserQuotaStore installs the v0.12.1 cluster-wide per-user
+// counter. Pass *coord.UserQuotaStore here in cluster mode; pass nil
+// (or skip the call) for single-replica mode. When set, AcquireForUser
+// delegates the per-user cap check to the DB-backed counter; Stats()
+// reads per-user breakdowns from the DB instead of the in-memory map.
+//
+// Idempotent on identical input; safe to call after the Semaphore is
+// in use (the next AcquireForUser picks up the new gate). Existing
+// in-flight slots accounted to the in-memory map stay there until they
+// release — there is no retroactive migration of counts.
+func (s *Semaphore) WithUserQuotaStore(qs userQuotaGate) *Semaphore {
+	s.mu.Lock()
+	s.quotaStore = qs
+	s.mu.Unlock()
+	return s
+}
+
 // Acquire returns a release func. Call release exactly once when done.
 // Returns ctx.Err() if ctx cancels first; *BackpressureError if queue is full.
 // Semantically equivalent to AcquireForUser(ctx, "") — i.e. no per-user
@@ -129,8 +173,34 @@ func (s *Semaphore) Acquire(ctx context.Context) (release func(), err error) {
 func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release func(), err error) {
 	perUserActive := s.maxPerUser > 0 && userID != ""
 
+	// v0.12.1: snapshot the quotaStore reference (and cap) outside the
+	// global-state mutex so the cluster-mode DB round-trip doesn't hold
+	// s.mu. Capturing here means a concurrent WithUserQuotaStore call
+	// can't swap modes mid-Acquire — the release/cancel paths use the
+	// same captured qs.
 	s.mu.Lock()
-	if perUserActive {
+	qs := s.quotaStore
+	cap := s.maxPerUser
+	s.mu.Unlock()
+
+	// Cluster mode: acquire the per-user quota slot FIRST via the DB.
+	// On any later rejection (global-queue full, timeout, cancel), we
+	// compensate-Release so the cluster-wide count stays balanced.
+	if perUserActive && qs != nil {
+		ok, qerr := qs.TryAcquire(ctx, userID, cap)
+		if qerr != nil {
+			return nil, fmt.Errorf("user_quotas acquire: %w", qerr)
+		}
+		if !ok {
+			return nil, &ErrPerUserQuotaExhausted{UserID: userID, Cap: cap}
+		}
+	}
+
+	s.mu.Lock()
+	// Single-replica mode keeps the v0.10.1 in-memory check. In cluster
+	// mode the DB TryAcquire above already enforced the cap and we
+	// skip this block — perUser stays untouched.
+	if perUserActive && qs == nil {
 		if s.perUser == nil {
 			s.perUser = map[string]int{}
 		}
@@ -142,20 +212,24 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 
 	if s.active < s.maxConcurrent {
 		s.active++
-		if perUserActive {
+		if perUserActive && qs == nil {
 			s.perUser[userID]++
 		}
 		s.mu.Unlock()
-		return s.releaseFn(userID), nil
+		return s.releaseFn(userID, qs), nil
 	}
 	if s.queued >= s.maxQueue {
 		s.mu.Unlock()
+		// Cluster mode: compensate-Release the DB slot we just took.
+		if perUserActive && qs != nil {
+			go releaseInBackground(qs, userID)
+		}
 		return nil, &BackpressureError{msg: "queue full"}
 	}
 	w := make(chan struct{}, 1)
 	s.waiters = append(s.waiters, w)
 	s.queued++
-	if perUserActive {
+	if perUserActive && qs == nil {
 		s.perUser[userID]++
 	}
 	s.mu.Unlock()
@@ -167,16 +241,28 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 	case <-w:
 		// Slot acquired. The releaseFn from the previous holder
 		// already promoted us (queued--; active++). Our perUser count
-		// stays the same — increment happened at enqueue, decrement
-		// happens at release.
-		return s.releaseFn(userID), nil
+		// (or DB slot) stays the same — increment happened at enqueue,
+		// decrement happens at release.
+		return s.releaseFn(userID, qs), nil
 	case <-ctx.Done():
-		s.cancelWaiter(w, userID)
+		s.cancelWaiter(w, userID, qs)
 		return nil, ctx.Err()
 	case <-timer.C:
-		s.cancelWaiter(w, userID)
+		s.cancelWaiter(w, userID, qs)
 		return nil, &BackpressureError{msg: "queue timeout"}
 	}
+}
+
+// releaseInBackground decouples the caller from a slow DB Release.
+// Used on the compensate path (queue full after TryAcquire) and on
+// every release/cancel in cluster mode. The defer release() pattern
+// in handler code expects fast return; the Release goroutine carries
+// its own bounded context so a permanently-down DB can't leak
+// goroutines indefinitely.
+func releaseInBackground(qs userQuotaGate, userID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	qs.Release(ctx, userID)
 }
 
 // Stats returns a snapshot for /metrics or admin views. The PerUser
@@ -186,28 +272,53 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 // substrate).
 func (s *Semaphore) Stats() Stats {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	qs := s.quotaStore
 	out := Stats{Active: s.active, Queued: s.queued}
-	if len(s.perUser) > 0 {
+	// In-memory perUser is only authoritative in single-replica mode.
+	// Cluster mode reads from the DB below (after releasing s.mu so
+	// the round-trip doesn't block Acquire callers).
+	if qs == nil && len(s.perUser) > 0 {
 		out.PerUser = make(map[string]int, len(s.perUser))
 		for k, v := range s.perUser {
 			out.PerUser[k] = v
 		}
 	}
+	s.mu.Unlock()
+
+	if qs != nil {
+		// 1s timeout: the admin /v1/_concurrency/stats endpoint hits
+		// this; a permanently-down DB shouldn't stall the operator's
+		// dashboard. On error we log and return Stats with PerUser=nil
+		// (active+queued remain accurate; the DB hiccup is observable).
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		perUser, err := qs.Snapshot(ctx)
+		if err != nil {
+			log.Printf("concurrency: quota snapshot failed: %v", err)
+		} else {
+			out.PerUser = perUser
+		}
+	}
 	return out
 }
 
-func (s *Semaphore) releaseFn(userID string) func() {
+// releaseFn captures the qs reference at acquire time so a later
+// WithUserQuotaStore swap can't make a still-in-flight slot decrement
+// against the wrong gate. qs == nil means we used the in-memory path;
+// non-nil means the DB-backed Release fires in a goroutine.
+func (s *Semaphore) releaseFn(userID string, qs userQuotaGate) func() {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
 			s.mu.Lock()
-			defer s.mu.Unlock()
 			s.active--
-			s.decrementPerUser(userID)
+			if qs == nil {
+				s.decrementPerUser(userID)
+			}
 			// Wake the next waiter if any. NOTE: the woken waiter's
-			// perUser count stays as-is — its increment happened at
-			// enqueue, its decrement happens when ITS release fires.
+			// perUser count (or DB slot) stays as-is — its increment
+			// happened at enqueue, its decrement happens when ITS
+			// release fires.
 			if len(s.waiters) > 0 {
 				w := s.waiters[0]
 				s.waiters = s.waiters[1:]
@@ -218,26 +329,42 @@ func (s *Semaphore) releaseFn(userID string) func() {
 				default:
 				}
 			}
+			s.mu.Unlock()
+			// Cluster mode: DB Release after the mutex is released so
+			// the network round-trip doesn't block other Acquire
+			// callers. Background goroutine with a 5s timeout for safety.
+			if qs != nil && userID != "" {
+				go releaseInBackground(qs, userID)
+			}
 		})
 	}
 }
 
-func (s *Semaphore) cancelWaiter(target chan struct{}, userID string) {
+func (s *Semaphore) cancelWaiter(target chan struct{}, userID string, qs userQuotaGate) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	needRelease := false
 	for i, w := range s.waiters {
 		if w == target {
 			s.waiters = append(s.waiters[:i], s.waiters[i+1:]...)
 			s.queued--
-			s.decrementPerUser(userID)
+			if qs == nil {
+				s.decrementPerUser(userID)
+			} else {
+				needRelease = true
+			}
+			s.mu.Unlock()
+			if needRelease && userID != "" {
+				go releaseInBackground(qs, userID)
+			}
 			return
 		}
 	}
 	// Not found: releaseFn already won the race and transferred a slot to
 	// us. The buffered chan holds a stranded token; drain it and decrement
 	// active to give the slot back, otherwise it's accounted to a goroutine
-	// that returned with ctx.Err() and never released. perUser is
-	// decremented in the same arm so the accounting stays balanced.
+	// that returned with ctx.Err() and never released. perUser (or the
+	// DB slot in cluster mode) is decremented in the same arm so the
+	// accounting stays balanced.
 	//
 	// The `default:` arm is unreachable under the current invariants
 	// (target is a buffered-1 chan with releaseFn as its only sender,
@@ -253,8 +380,17 @@ func (s *Semaphore) cancelWaiter(target chan struct{}, userID string) {
 	select {
 	case <-target:
 		s.active--
-		s.decrementPerUser(userID)
+		if qs == nil {
+			s.decrementPerUser(userID)
+		} else {
+			needRelease = true
+		}
+		s.mu.Unlock()
+		if needRelease && userID != "" {
+			go releaseInBackground(qs, userID)
+		}
 	default:
+		s.mu.Unlock()
 		panic("concurrency: cancelWaiter stranded-token default arm fired — invariant violation (buffered-1 chan, single sender)")
 	}
 }

--- a/internal/concurrency/semaphore_test.go
+++ b/internal/concurrency/semaphore_test.go
@@ -311,3 +311,275 @@ func TestAcquireForUser_CancelDecrementsPerUser(t *testing.T) {
 		t.Errorf("after cancel: user_a count = %d, want 1 (queued one was cleaned up)", c)
 	}
 }
+
+// ---- v0.12.1 cluster-mode (userQuotaGate) tests ----
+
+// stubQuotaGate is the in-process fake for the v0.12.1 DB-backed
+// per-user counter. Lets us test Semaphore's cluster-mode dispatch
+// without standing up Postgres.
+type stubQuotaGate struct {
+	mu       sync.Mutex
+	counts   map[string]int
+	failNext bool
+	atCapFor map[string]bool // when true, TryAcquire returns false+nil for this user
+	releases int
+}
+
+func newStubQuotaGate() *stubQuotaGate {
+	return &stubQuotaGate{counts: map[string]int{}, atCapFor: map[string]bool{}}
+}
+
+func (g *stubQuotaGate) TryAcquire(_ context.Context, userID string, _ int) (bool, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.failNext {
+		g.failNext = false
+		return false, errors.New("stub: simulated failure")
+	}
+	if g.atCapFor[userID] {
+		return false, nil
+	}
+	g.counts[userID]++
+	return true, nil
+}
+
+func (g *stubQuotaGate) Release(_ context.Context, userID string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.counts[userID] > 0 {
+		g.counts[userID]--
+	}
+	g.releases++
+}
+
+func (g *stubQuotaGate) Snapshot(_ context.Context) (map[string]int, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if len(g.counts) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]int, len(g.counts))
+	for k, v := range g.counts {
+		if v > 0 {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func (g *stubQuotaGate) count(userID string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.counts[userID]
+}
+
+func (g *stubQuotaGate) releaseCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.releases
+}
+
+// TestSemaphore_ClusterMode_DelegatesToQuotaGate verifies that when
+// the quotaStore is wired, AcquireForUser calls the gate's
+// TryAcquire (not the in-memory perUser path) and the release func
+// triggers an asynchronous gate Release. The in-memory perUser map
+// must stay empty throughout — cluster mode is authoritative on the
+// DB side.
+func TestSemaphore_ClusterMode_DelegatesToQuotaGate(t *testing.T) {
+	gate := newStubQuotaGate()
+	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
+
+	r, err := s.AcquireForUser(context.Background(), "alice")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	if gate.count("alice") != 1 {
+		t.Errorf("gate count = %d, want 1", gate.count("alice"))
+	}
+	// In-memory map must NOT be touched in cluster mode.
+	s.mu.Lock()
+	got := s.perUser["alice"]
+	s.mu.Unlock()
+	if got != 0 {
+		t.Errorf("in-memory perUser[alice] = %d in cluster mode, want 0", got)
+	}
+
+	r()
+	// Release is async (background goroutine). Poll briefly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if gate.count("alice") == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if gate.count("alice") != 0 {
+		t.Errorf("after release: gate count = %d, want 0", gate.count("alice"))
+	}
+}
+
+// TestSemaphore_ClusterMode_AtCapReturnsTypedError verifies that a
+// false+nil from the gate (user is at cap) becomes the canonical
+// *ErrPerUserQuotaExhausted that HTTP handlers map to 429.
+func TestSemaphore_ClusterMode_AtCapReturnsTypedError(t *testing.T) {
+	gate := newStubQuotaGate()
+	gate.atCapFor["alice"] = true
+	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
+
+	_, err := s.AcquireForUser(context.Background(), "alice")
+	if !IsPerUserQuotaExhausted(err) {
+		t.Errorf("got %v, want *ErrPerUserQuotaExhausted", err)
+	}
+	var pue *ErrPerUserQuotaExhausted
+	if errors.As(err, &pue) {
+		if pue.UserID != "alice" {
+			t.Errorf("UserID = %q, want alice", pue.UserID)
+		}
+		if pue.Cap != 3 {
+			t.Errorf("Cap = %d, want 3", pue.Cap)
+		}
+	}
+}
+
+// TestSemaphore_ClusterMode_QueueFullCompensateReleases verifies the
+// compensate-release path: when TryAcquire succeeds on the DB but
+// the global queue rejects (queue full), the Semaphore must Release
+// the DB slot so the cluster-wide count stays balanced.
+func TestSemaphore_ClusterMode_QueueFullCompensateReleases(t *testing.T) {
+	gate := newStubQuotaGate()
+	// max_concurrent=1, max_queue=0 → second acquire always hits "queue full".
+	s := New(1, 0, time.Second).WithPerUserCap(5).WithUserQuotaStore(gate)
+
+	// First acquire takes the global slot.
+	r, err := s.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+	defer r()
+
+	// Second acquire (with userID) calls gate.TryAcquire successfully
+	// but then hits queue-full backpressure.
+	_, err = s.AcquireForUser(context.Background(), "alice")
+	if !IsBackpressure(err) {
+		t.Fatalf("got %v, want *BackpressureError", err)
+	}
+
+	// Compensate-release runs in a goroutine; poll briefly.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if gate.count("alice") == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if gate.count("alice") != 0 {
+		t.Errorf("after queue-full reject: gate count = %d, want 0 (compensate-release failed)", gate.count("alice"))
+	}
+}
+
+// TestSemaphore_ClusterMode_GateFailureWrapsError verifies a real
+// infrastructure failure from the gate propagates as a wrapped error
+// (NOT as a quota-exhausted false signal). Distinguishes "user is at
+// cap" (false+nil → typed error) from "DB is down" (false+error →
+// wrapped 5xx-shaped error).
+func TestSemaphore_ClusterMode_GateFailureWrapsError(t *testing.T) {
+	gate := newStubQuotaGate()
+	gate.failNext = true
+	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
+
+	_, err := s.AcquireForUser(context.Background(), "alice")
+	if err == nil {
+		t.Fatal("expected error from gate failure")
+	}
+	if IsPerUserQuotaExhausted(err) {
+		t.Errorf("gate failure should NOT be classified as quota exhausted: %v", err)
+	}
+}
+
+// TestSemaphore_ClusterMode_StatsFromSnapshot verifies that Stats()
+// reads PerUser from the gate's Snapshot (not the in-memory map)
+// when in cluster mode. The Active/Queued counters remain
+// in-memory (per-replica accounting).
+func TestSemaphore_ClusterMode_StatsFromSnapshot(t *testing.T) {
+	gate := newStubQuotaGate()
+	s := New(10, 10, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
+
+	r, _ := s.AcquireForUser(context.Background(), "alice")
+	defer r()
+
+	st := s.Stats()
+	if st.PerUser["alice"] != 1 {
+		t.Errorf("Stats.PerUser[alice] = %d, want 1 (from gate.Snapshot)", st.PerUser["alice"])
+	}
+	if st.Active != 1 {
+		t.Errorf("Stats.Active = %d, want 1 (per-replica counter)", st.Active)
+	}
+}
+
+// TestSemaphore_ClusterMode_QueuedWaiterWakesAndReleases pins the
+// cluster-mode hot path that no other test covers: a request queues
+// (TryAcquire fires at enqueue), then wakes when the global slot
+// frees, then completes and releases. Exactly one TryAcquire + one
+// Release for the user — a future regression that double-TryAcquires
+// on wakeup, or skips the eventual Release, fails here.
+// (Review-1 finding #2.)
+func TestSemaphore_ClusterMode_QueuedWaiterWakesAndReleases(t *testing.T) {
+	gate := newStubQuotaGate()
+	s := New(1, 4, time.Second).WithPerUserCap(3).WithUserQuotaStore(gate)
+
+	// Hold the single global slot with an anonymous Acquire — no
+	// per-user gate involvement, so the gate's only interaction is
+	// alice's enqueue + later release.
+	hold, err := s.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("hold acquire: %v", err)
+	}
+
+	done := make(chan func(), 1)
+	go func() {
+		r, err := s.AcquireForUser(context.Background(), "alice")
+		if err != nil {
+			t.Errorf("queued acquire: %v", err)
+			done <- nil
+			return
+		}
+		done <- r
+	}()
+
+	// Give alice's goroutine time to enqueue and call TryAcquire.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if gate.count("alice") == 1 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if gate.count("alice") != 1 {
+		t.Fatalf("after enqueue: gate count = %d, want 1 (TryAcquire should fire at enqueue)", gate.count("alice"))
+	}
+
+	hold() // wake alice
+	r := <-done
+	if r == nil {
+		t.Fatal("alice's release func is nil — acquire failed")
+	}
+	r() // alice releases
+
+	// Background Release; poll briefly.
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if gate.count("alice") == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if gate.count("alice") != 0 {
+		t.Errorf("after release: gate count = %d, want 0", gate.count("alice"))
+	}
+	if r := gate.releaseCount(); r != 1 {
+		t.Errorf("gate.releaseCount = %d, want exactly 1 (no double-release on wakeup)", r)
+	}
+}

--- a/internal/coord/user_quota_store.go
+++ b/internal/coord/user_quota_store.go
@@ -1,0 +1,158 @@
+package coord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// UserQuotaStore is the v0.12.1 cluster-wide per-user concurrency
+// counter, backed by the user_quotas Postgres table. Replaces the
+// in-process counter that v0.10.1's concurrency.Semaphore used in
+// single-replica mode — the in-process path stays unchanged for
+// deployments without LOOMCYCLE_REPLICA_ID set.
+//
+// Lives in the coord package next to ReplicaStore because:
+//   - both are Postgres-only by contract (SQLite refuses cluster mode)
+//   - both need a pgxpool directly (not the store.Store interface)
+//   - both are wired in main.go's `if cfg.Env.ReplicaID != ""` block
+//
+// Concurrency contract: every method is safe for concurrent use by
+// multiple goroutines. The atomic UPDATE pattern in TryAcquire makes
+// the cap check race-free across replicas — two replicas both reading
+// active_count = cap-1 will both INSERT-or-UPDATE atomically; only one
+// will affect a row.
+//
+// Crash-safety gap (until Phase 5): if a replica acquires a slot via
+// TryAcquire and crashes before Release fires, the user's active_count
+// is permanently incremented until a human operator runs:
+//
+//	UPDATE user_quotas SET active_count = active_count - N
+//	WHERE user_id = '<user>';
+//
+// or restarts loomcycle (which does NOT auto-reconcile the DB counter).
+// Phase 5's replicas TTL sweeper will fix this by joining user_quotas
+// against runs WHERE replica_id = dead_replica AND status IN
+// ('active', 'queued') to compute the leaked count and emit
+// compensating UPDATEs. Until then, operators monitor
+// GET /v1/_concurrency/stats for stuck non-zero counts after all known
+// runs have completed.
+type UserQuotaStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewUserQuotaStore wraps an existing pgxpool. The pool is not owned;
+// closing UserQuotaStore does not close the pool (matches ReplicaStore).
+func NewUserQuotaStore(pool *pgxpool.Pool) *UserQuotaStore {
+	return &UserQuotaStore{pool: pool}
+}
+
+// TryAcquire attempts to increment user_quotas[userID].active_count
+// atomically, bounded by cap. Returns:
+//
+//	(true, nil)  → slot acquired (row created at count=1 or
+//	                incremented past the prior count)
+//	(false, nil) → user is at cap; caller should map to the
+//	                ErrPerUserQuotaExhausted shape on its side
+//	(_, err)     → infrastructure error (network, constraint violation)
+//
+// The two-arm signature (bool + error) lets the concurrency package
+// keep its own ErrPerUserQuotaExhausted error type without forcing
+// concurrency → coord import direction. cap must be > 0; cap == 0 is
+// the caller's "per-user check disabled" sentinel and TryAcquire must
+// not be reached in that case.
+//
+// Pattern: single-statement INSERT ... ON CONFLICT DO UPDATE WHERE
+// active_count < cap. Avoids the obvious two-step UPDATE→INSERT race.
+// The INSERT arm always fires for a new user_id (initial count = 1);
+// the UPDATE arm only fires when the existing count is strictly less
+// than cap. rows_affected discriminates the at-cap case.
+func (s *UserQuotaStore) TryAcquire(ctx context.Context, userID string, cap int) (bool, error) {
+	if userID == "" {
+		return false, errors.New("user_id is empty")
+	}
+	if cap <= 0 {
+		return false, fmt.Errorf("cap must be > 0 (got %d)", cap)
+	}
+	tag, err := s.pool.Exec(ctx, `
+		INSERT INTO user_quotas (user_id, active_count, updated_at)
+		VALUES ($1, 1, now())
+		ON CONFLICT (user_id) DO UPDATE
+		  SET active_count = user_quotas.active_count + 1,
+		      updated_at   = now()
+		  WHERE user_quotas.active_count < $2
+	`, userID, cap)
+	if err != nil {
+		return false, fmt.Errorf("user_quotas upsert %s: %w", userID, err)
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// Release decrements user_quotas[userID].active_count. Guarded with
+// `WHERE active_count > 0` so a double-release (or a Phase 5 reap
+// landing between our acquire and release) does not underflow into
+// the CHECK constraint. rows_affected = 0 is logged as a warning —
+// it means a slot was released that we didn't think we held, which is
+// worth knowing during debugging but not a hard error.
+//
+// The row is NOT deleted when count reaches zero — that's a deliberate
+// choice to avoid the INSERT-on-next-acquire churn for active users.
+// The row with count=0 is a tombstone that costs one Postgres row and
+// is harmless. Phase 5's sweeper can DELETE WHERE active_count = 0 if
+// row count ever becomes a concern.
+func (s *UserQuotaStore) Release(ctx context.Context, userID string) {
+	if userID == "" {
+		return
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE user_quotas
+		   SET active_count = active_count - 1,
+		       updated_at   = now()
+		 WHERE user_id = $1 AND active_count > 0
+	`, userID)
+	if err != nil {
+		log.Printf("coord: user_quotas release %s: %v", userID, err)
+		return
+	}
+	if tag.RowsAffected() == 0 {
+		log.Printf("coord: user_quotas release %s: no-op (already at 0 — double-release or Phase 5 reap)", userID)
+	}
+}
+
+// Snapshot returns the per-user active count map for users with
+// at least one active run. Backs GET /v1/_concurrency/stats's
+// per_user field. Returns nil map when no users have active runs
+// (matches the v0.10.1 in-process Stats() behavior so the
+// omitempty JSON marshal stays consistent across modes).
+func (s *UserQuotaStore) Snapshot(ctx context.Context) (map[string]int, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT user_id, active_count
+		  FROM user_quotas
+		 WHERE active_count > 0
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("user_quotas snapshot: %w", err)
+	}
+	defer rows.Close()
+	var out map[string]int
+	for rows.Next() {
+		var (
+			userID string
+			count  int
+		)
+		if err := rows.Scan(&userID, &count); err != nil {
+			return nil, fmt.Errorf("scan user_quotas row: %w", err)
+		}
+		if out == nil {
+			out = make(map[string]int)
+		}
+		out[userID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user_quotas: %w", err)
+	}
+	return out, nil
+}

--- a/internal/coord/user_quota_store_test.go
+++ b/internal/coord/user_quota_store_test.go
@@ -1,0 +1,241 @@
+package coord
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// freshUserQuotasPool returns a pgxpool that the test owns and that
+// is guaranteed to have the `user_quotas` table (migrations applied).
+// Each test seeds and tears down its own user_id rows; we never
+// TRUNCATE because other test packages may share the same database.
+func freshUserQuotasPool(t *testing.T, dsn string) *pgxpool.Pool {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial pg: %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+	return pool
+}
+
+func uniqueUserID(t *testing.T) string {
+	t.Helper()
+	return "test-uq-" + t.Name() + "-" + time.Now().Format("150405.000000")
+}
+
+func TestUserQuotaStore_AcquireReleaseLifecycle(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	ok, err := s.TryAcquire(ctx, user, 2)
+	if err != nil || !ok {
+		t.Fatalf("first TryAcquire: ok=%v err=%v", ok, err)
+	}
+	ok, err = s.TryAcquire(ctx, user, 2)
+	if err != nil || !ok {
+		t.Fatalf("second TryAcquire: ok=%v err=%v", ok, err)
+	}
+
+	snap, err := s.Snapshot(ctx)
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if got := snap[user]; got != 2 {
+		t.Errorf("snapshot[%s] = %d, want 2", user, got)
+	}
+
+	s.Release(ctx, user)
+	s.Release(ctx, user)
+
+	snap2, _ := s.Snapshot(ctx)
+	if _, present := snap2[user]; present {
+		t.Errorf("snapshot still shows %s after full release: %v", user, snap2)
+	}
+}
+
+func TestUserQuotaStore_AtCapRejects(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	// Fill the cap (cap=3).
+	for i := 0; i < 3; i++ {
+		ok, err := s.TryAcquire(ctx, user, 3)
+		if err != nil || !ok {
+			t.Fatalf("acquire #%d: ok=%v err=%v", i, ok, err)
+		}
+	}
+
+	// At-cap: ok=false, err=nil (caller maps to ErrPerUserQuotaExhausted).
+	ok, err := s.TryAcquire(ctx, user, 3)
+	if err != nil {
+		t.Errorf("at-cap should return nil error, got %v", err)
+	}
+	if ok {
+		t.Errorf("at-cap should return ok=false, got true")
+	}
+}
+
+func TestUserQuotaStore_FirstAcquireCreatesRow(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	// Snapshot pre-acquire: user should not be present.
+	snap, _ := s.Snapshot(ctx)
+	if _, present := snap[user]; present {
+		t.Fatalf("user %s present in snapshot before any acquire: %v", user, snap)
+	}
+
+	ok, err := s.TryAcquire(ctx, user, 5)
+	if err != nil || !ok {
+		t.Fatalf("first acquire: ok=%v err=%v", ok, err)
+	}
+	snap, _ = s.Snapshot(ctx)
+	if got := snap[user]; got != 1 {
+		t.Errorf("after first acquire: count=%d, want 1", got)
+	}
+}
+
+func TestUserQuotaStore_ReleaseUnderflowIsNoop(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	ok, err := s.TryAcquire(ctx, user, 1)
+	if err != nil || !ok {
+		t.Fatalf("acquire: ok=%v err=%v", ok, err)
+	}
+	s.Release(ctx, user)
+	// Second Release should be a silent no-op (logs a warning).
+	s.Release(ctx, user)
+
+	// Check the row went to 0 and stays there (no negative count, no
+	// CHECK constraint violation).
+	snap, _ := s.Snapshot(ctx)
+	if _, present := snap[user]; present {
+		t.Errorf("user %s should be absent from snapshot at count=0, got %v", user, snap[user])
+	}
+}
+
+func TestUserQuotaStore_SnapshotExcludesZeroCounts(t *testing.T) {
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	ctx := context.Background()
+
+	// Acquire-and-release leaves the row at count=0; snapshot must exclude.
+	_, _ = s.TryAcquire(ctx, user, 5)
+	s.Release(ctx, user)
+
+	snap, _ := s.Snapshot(ctx)
+	if _, present := snap[user]; present {
+		t.Errorf("user %s with active_count=0 should be excluded from Snapshot, got %v", user, snap)
+	}
+}
+
+func TestUserQuotaStore_TwoReplicasConcurrent(t *testing.T) {
+	// Two backplane consumers backed by SEPARATE pgxpool instances,
+	// simulating two replicas with distinct TCP sessions to Postgres.
+	// The cross-process serialization guarantee for user_quotas comes
+	// from the DB-side atomicity of `INSERT ON CONFLICT DO UPDATE
+	// WHERE active_count < cap`, NOT from any client-side coordination
+	// — using one pool would let pgxpool's per-connection serialization
+	// mask wire-level races (review-1 finding #1).
+	dsn := pgDSNFromEnv(t)
+	poolA, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial poolA: %v", err)
+	}
+	t.Cleanup(poolA.Close)
+	poolB, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("dial poolB: %v", err)
+	}
+	t.Cleanup(poolB.Close)
+
+	sA := NewUserQuotaStore(poolA)
+	sB := NewUserQuotaStore(poolB)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = poolA.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	const cap = 3
+	const attempts = 10
+
+	var successes atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < attempts; i++ {
+		wg.Add(1)
+		store := sA
+		if i%2 == 0 {
+			store = sB
+		}
+		go func() {
+			defer wg.Done()
+			ok, err := store.TryAcquire(context.Background(), user, cap)
+			if err != nil {
+				t.Errorf("acquire err: %v", err)
+				return
+			}
+			if ok {
+				successes.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if int(successes.Load()) != cap {
+		t.Errorf("got %d successful acquires, want exactly %d", successes.Load(), cap)
+	}
+	snap, _ := sA.Snapshot(context.Background())
+	if got := snap[user]; got != cap {
+		t.Errorf("snapshot[%s] = %d, want %d", user, got, cap)
+	}
+}
+
+func TestUserQuotaStore_InvalidCapRejected(t *testing.T) {
+	// Defensive: cap == 0 should never be passed (caller's perUserActive
+	// gate prevents it), but if it is, TryAcquire must error rather
+	// than silently underflow the upsert WHERE clause.
+	pool := freshUserQuotasPool(t, pgDSNFromEnv(t))
+	s := NewUserQuotaStore(pool)
+	user := uniqueUserID(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM user_quotas WHERE user_id = $1`, user)
+	})
+	_, err := s.TryAcquire(context.Background(), user, 0)
+	if err == nil {
+		t.Error("TryAcquire with cap=0 should return error")
+	}
+	_, err = s.TryAcquire(context.Background(), "", 5)
+	if err == nil {
+		t.Error("TryAcquire with empty userID should return error")
+	}
+}

--- a/internal/store/postgres/migrations/0024_user_quotas.down.sql
+++ b/internal/store/postgres/migrations/0024_user_quotas.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_quotas;

--- a/internal/store/postgres/migrations/0024_user_quotas.up.sql
+++ b/internal/store/postgres/migrations/0024_user_quotas.up.sql
@@ -1,0 +1,23 @@
+-- v0.12.1 multi-replica HA Phase 2: cluster-wide per-user concurrency counter.
+--
+-- One row per user_id that has at least one active run across the cluster.
+-- active_count is atomically incremented at run-admission and decremented at
+-- run-completion by whichever replica owns the run. The CHECK constraint
+-- prevents underflow; the operator's MaxConcurrentRunsPerUser config is the
+-- cap, NOT a per-row value (cap-decrease mid-flight is handled naturally:
+-- existing slots stay; new acquires see the new cap on the next TryAcquire).
+--
+-- Only populated when LOOMCYCLE_REPLICA_ID is set — single-replica
+-- deployments leave this table untouched and use the in-memory perUser map
+-- on Semaphore (v0.10.1 behavior, byte-identical).
+--
+-- Phase 5's replica TTL sweeper will reap orphaned slots when a replica
+-- crashes without releasing. Until then, a crashed replica leaks at most
+-- MaxConcurrentRunsPerUser slots per affected user until manual intervention
+-- or process restart.
+
+CREATE TABLE IF NOT EXISTS user_quotas (
+    user_id      TEXT        PRIMARY KEY,
+    active_count INTEGER     NOT NULL DEFAULT 0 CHECK (active_count >= 0),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);


### PR DESCRIPTION
## Summary

Phase 2 of the v1.0 multi-replica HA capstone. Lifts the v0.10.1 in-process per-user concurrency cap (`Semaphore.perUser` map) to a cluster-wide DB-backed counter via a new `user_quotas` table. Activates only when `LOOMCYCLE_REPLICA_ID` is set; single-replica deployments keep the v0.10.1 in-memory path **byte-identical**.

## Problem

v0.10.1's per-user cap is per-replica. On a 2-replica deployment with `MaxConcurrentRunsPerUser=4`, a noisy user can burst 8 runs cluster-wide — defeating the fairness invariant the cap name implies. v0.12.1 makes the cap mean what it says: 4 active+queued runs per user **across the cluster**, regardless of replica count.

## What ships

1. **`user_quotas` table + migration 0024** — `user_id` PK, `active_count` (int, `CHECK >= 0`), `updated_at`.
2. **`coord.UserQuotaStore`** — `TryAcquire`/`Release`/`Snapshot` via atomic `INSERT ON CONFLICT DO UPDATE WHERE active_count < cap`. Two concurrent TryAcquires on the same user serialize at the DB; only as many succeed as the cap allows.
3. **`concurrency.Semaphore` refactor with `userQuotaGate` interface** — the interface keeps `internal/concurrency` FREE of `coord` import; `*coord.UserQuotaStore` satisfies it implicitly. `AcquireForUser` dispatches on `qs != nil`: cluster mode delegates to the DB and bypasses the in-memory `perUser` map entirely; single-replica mode runs v0.10.1 unchanged.
4. **Compensate-release on global-queue rejection** — when `TryAcquire` succeeds on the DB but the queue is full, fire a background `Release` so the cluster-wide count stays balanced. Same on cancel/timeout in `cancelWaiter`. All DB calls happen **outside** Semaphore's mutex via a 5s-bounded background goroutine — handler `defer release()` chains stay non-blocking.
5. **`Stats()` reads from `qs.Snapshot` in cluster mode** with a 1s timeout. `GET /v1/_concurrency/stats` wire shape preserved exactly.
6. **`*ErrPerUserQuotaExhausted` typed error** stays the canonical handler-side shape (HTTP 429 + `Retry-After: 5` + `code:"per_user_quota_exhausted"`).

## Crash-safety gap (documented; closes in Phase 5)

A replica crashing between `TryAcquire` and `Release` leaks a slot until Phase 5's replicas TTL sweeper reaps orphaned rows by joining `user_quotas` against `runs WHERE replica_id = dead`. Until then, operators monitor `/v1/_concurrency/stats` for stuck non-zero counts.

## Code review (parallel agent) — 2 findings, both fixed pre-commit

1. **IMPORTANT** — `TestUserQuotaStore_TwoReplicasConcurrent` shared a single `pgxpool`; pgxpool's per-connection serialization masked the cross-replica race the test name implied. Refactored to open two pgxpool instances so the test actually exercises DB-side atomicity across distinct TCP sessions.
2. **IMPORTANT** — no test covered the cluster-mode wakeup hot path (request queues, global slot frees, waiter wakes, completes). Added `TestSemaphore_ClusterMode_QueuedWaiterWakesAndReleases` pinning exactly one `TryAcquire` + one `Release` across the full lifecycle.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1 -timeout 300s` all green
- [x] `go test ./internal/concurrency/ -race -count=1` all green (no data races in the refactored dispatch)
- [x] Smoke test: REPLICA_ID unset → boots normally, no new log lines
- [ ] CI green on PR check
- [ ] Postgres-gated tests run locally via `LOOMCYCLE_TEST_PG_DSN` — green
- [ ] Operator dogfooding: 2-replica deployment, observe `per_user_quota_exhausted` triggers across replicas when one user bursts

## Remaining v0.12.x → v1.0 phases

| Phase | PR | Scope |
|---|---|---|
| 3 | v0.12.2 | Cross-replica cancel + status (uses runs.replica_id from Phase 1) |
| 4 | v0.12.3 | Pause/resume + bus fanout (channels + runstate over backplane) |
| 5 | v0.12.4 | Singleton sweepers via pg_try_advisory_lock + replicas TTL sweeper (closes the Phase 2 crash-safety gap) |
| 6 | v0.12.5 | Session-lock + hook-registry → DB-backed |
| 7 | v0.12.6 | Hardening + docs + **tag v1.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)