### PR TITLE
feat(v0.12.2): cross-replica cancel + status (Phase 3 of 7)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,52 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.12.2
+
+**Phase 3 of the v1.0 multi-replica HA capstone — cross-replica cancel + status.** Closes the most critical correctness gap from the audit: a cancel request that hits the wrong replica now reaches the run via the backplane. Single-replica deployments (`LOOMCYCLE_REPLICA_ID` unset) keep the v0.11.x behavior **byte-identical** — every new code path is gated behind cluster mode.
+
+### Problem
+
+Before v0.12.2, `Cancel.Registry.Cancel(agent_id)` walked an in-process map. A cancel request routed by the load balancer to replica B for a run executing on replica A returned `{cancelled: false}` (the registry didn't find the entry) and the actual run kept executing on A. The CLAUDE.md audit identified this as one of three critical correctness blockers for active-active deployment.
+
+### What ships
+
+1. **`runs.replica_id` is now written at run creation.** The column was added in Phase 1's migration 0023 as nullable; Phase 3 plumbs `s.replicaID` through `store.RunIdentity` at all 4 run-creation sites (`handleRuns`, `handleMessages` continuation, `RunOnce` direct, `runSubAgent`). Single-replica mode writes empty string → NULL via `nullableText`.
+
+2. **`coord.CancelCoordinator`** — implements `cancel.ClusterCanceller` (a new interface added to the cancel package). When a local Registry lookup misses on this replica, the registry delegates to `CancelRemote` which:
+   - Looks up the run's owning `replica_id` in the DB.
+   - Checks owner liveness via `ReplicaStore.IsReplicaAlive` (new method; 90s stale threshold = 3× heartbeat interval). If dead, marks the run failed in the DB and returns success without a broadcast — saves the 5s ack wait.
+   - Otherwise publishes a `loomcycle.cancel` event on the backplane carrying `{agent_id, reason, from_replica}`.
+   - Waits on a per-call ack channel keyed by `agent_id` for `LOOMCYCLE_CANCEL_ACK_TIMEOUT_MS` (default 5000ms). On ack: returns success with cascaded children. On timeout: re-checks the run row (it may have completed during the wait — returns the terminal status) and otherwise returns `{cancelled: false, reason: "owner_replica_unreachable"}`.
+
+3. **Two long-lived subscriber goroutines per replica** (started in main.go inside the existing cluster-mode block):
+   - `RunCancelSubscriber` listens on `loomcycle.cancel`, dispatches each event to the local `cancel.Registry`, and publishes a `loomcycle.cancel.ack` payload when the agent was found locally.
+   - `RunAckSubscriber` listens on `loomcycle.cancel.ack` and routes each ack to the matching in-flight `CancelRemote` waiter by agent_id.
+
+4. **Status queries** (`GET /v1/agents/{id}`, `GET /v1/users/{user_id}/agents`) continue to read from the DB — already authoritative since v0.11.x. No code change needed: the existing `s.store.GetRunByAgentID` + `ListActiveRunsByUser` flow returns correct status regardless of which replica owns the run.
+
+5. **Cascade cancel** — same backplane broadcast pattern. The owning replica's `Registry.Cancel` walks the child map locally; if a child is on a different replica, every replica's `RunCancelSubscriber` tries the agent_id and the owner finds and fires it. Originator's ack carries the cascaded-on-owner list; cross-replica child acks land at the originator's ack subscriber but find no waiter and are silently dropped (correct: the originator cares about the root agent's ack).
+
+6. **Cancel response shape**: `cancelResponse.Cancelled` now reflects `res.Cancelled` instead of being hardcoded `true` when `Registry.Cancel` returns `ok=true`. Old clients that only check `cancelled` continue to work; new clients can read `reason` for `owner_replica_unreachable` / `owner_dead_marked_failed`. `cancelResponse.Reason` was already in the struct since v0.10.x; this PR populates it consistently.
+
+### Wire shape preserved
+
+- `POST /v1/agents/{id}/cancel` request body unchanged (`{"reason": "..."}`).
+- Success response unchanged on the common path (`{"cancelled": true, "agent_id": "...", "cascaded": [...]}`).
+- New `reason` field on cluster-mode-specific paths is additive — old clients ignore unknown JSON fields.
+
+### Crash-safety gap (closes in Phase 5)
+
+A replica that crashes mid-run still has its row stamped with its `replica_id`. Cross-replica cancel handles this via the dead-owner check: when `IsReplicaAlive` returns false, the cancel handler marks the run failed in the DB directly. Phase 5's replicas TTL sweeper will close this loop proactively by reaping orphaned `runs` rows when a replica's heartbeat goes stale.
+
+### Test coverage
+
+- Postgres-gated `CancelCoordinator` tests covering all five paths: not-found, already-terminal idempotent, dead-owner marks failed, ack-timeout returns unreachable, config validation.
+- In-process `cancel.Registry` test confirms single-replica fallback: `ClusterCanceller == nil` → local miss returns `false` (byte-identical to v0.11.x).
+- All v0.11.x existing tests continue green.
+
+---
+
 ## What's in v0.12.1
 
 **Phase 2 of the v1.0 multi-replica HA capstone — cluster-wide per-user fairness.** Lifts the v0.10.1 in-process per-user concurrency counter (`Semaphore.perUser` map) to a cluster-wide DB-backed counter (`user_quotas` table). Activates only when `LOOMCYCLE_REPLICA_ID` is set; single-replica deployments keep the v0.10.1 in-memory path byte-identical.

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1137,7 +1137,30 @@ func main() {
 		// reached when perUserActive evaluates true.
 		quotaStore := coord.NewUserQuotaStore(pgStore.Pool())
 		sem.WithUserQuotaStore(quotaStore)
-		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify user_quotas=db-backed", cfg.Env.ReplicaID)
+
+		// v0.12.2 Phase 3: cross-replica cancel coordinator. When a
+		// cancel hits a replica that doesn't own the run, the registry
+		// delegates to CancelCoordinator.CancelRemote which broadcasts
+		// on the backplane + awaits an ack from the owning replica.
+		// Two long-lived subscribers carry the wire side: one listens
+		// for incoming cancel requests (RunCancelSubscriber), the other
+		// receives acks (RunAckSubscriber).
+		ackTimeout := time.Duration(cfg.Env.CancelAckTimeoutMs) * time.Millisecond
+		cancelCoord, err := coord.NewCancelCoordinator(coord.CancelCoordinatorConfig{
+			Backplane:    bp,
+			ReplicaID:    cfg.Env.ReplicaID,
+			Store:        pgStore,
+			ReplicaStore: replicaStore,
+			AckTimeout:   ackTimeout,
+		})
+		if err != nil {
+			log.Fatalf("coord: cancel coordinator init: %v", err)
+		}
+		srv.CancelRegistry().SetClusterCanceller(cancelCoord)
+		go cancelCoord.RunCancelSubscriber(bgCtx, srv.CancelRegistry())
+		go cancelCoord.RunAckSubscriber(bgCtx)
+
+		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify user_quotas=db-backed cancel_ack_timeout=%s", cfg.Env.ReplicaID, ackTimeout)
 	}
 
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1156,7 +1156,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -2031,7 +2031,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier, Model: model}
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -2397,10 +2397,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// is per-request (v0.8.2) — a user upgrading mid-session sees
 	// the new tier applied immediately on this continuation.
 	run, err := s.store.CreateRun(r.Context(), id, store.RunIdentity{
-		AgentID:  agentID,
-		UserID:   sess.UserID,
-		UserTier: body.UserTier,
-		Model:    model,
+		AgentID:   agentID,
+		UserID:    sess.UserID,
+		UserTier:  body.UserTier,
+		Model:     model,
+		ReplicaID: s.replicaID,
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -2928,6 +2929,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subIdentity := store.RunIdentity{
 		AgentID:       subAgentID,
 		ParentAgentID: parentIdentity.AgentID,
+		ReplicaID:     s.replicaID,
 		// ParentRunID is left empty here — we don't have the parent's
 		// run.ID handy without an extra registry lookup. Cascade
 		// works via parent_agent_id alone; ParentRunID is informational
@@ -3327,8 +3329,13 @@ func (s *Server) handleCancelAgent(w http.ResponseWriter, r *http.Request) {
 
 	res, ok := s.cancelReg.Cancel(agentID, body.Reason)
 	if ok {
+		// v0.12.2: Cancel may now return ok=true with res.Cancelled=false
+		// when the cluster canceller found the run but couldn't cancel
+		// it (owner_replica_unreachable, owner_dead_marked_failed,
+		// already-terminal). Surface res.Cancelled directly instead of
+		// hardcoding true.
 		writeJSON(w, http.StatusOK, cancelResponse{
-			Cancelled: true,
+			Cancelled: res.Cancelled,
 			AgentID:   agentID,
 			Cascaded:  res.Cascaded,
 			Reason:    res.Reason,

--- a/internal/cancel/registry.go
+++ b/internal/cancel/registry.go
@@ -101,18 +101,44 @@ type CancelResult struct {
 	Cascaded  []string
 }
 
+// ClusterCanceller is the v0.12.2 Phase 3 fallback for cross-replica
+// cancel. When set on a Registry, a Cancel that misses the local
+// in-process map delegates to CancelRemote — which broadcasts on the
+// backplane, awaits an ack from the owning replica, and returns the
+// CancelResult shape the local fast-path would have returned. Nil =
+// single-replica mode; local miss returns false directly (v0.11.x
+// behaviour, byte-identical).
+//
+// The interface lives here (not in internal/coord) so the cancel
+// package stays free of the coord dependency. internal/coord
+// implements this interface on a CancelCoordinator type that wraps
+// the backplane.
+type ClusterCanceller interface {
+	CancelRemote(ctx context.Context, agentID, reason string) (CancelResult, bool, error)
+}
+
 // Registry maps agent_id → live cancel handle. Safe for concurrent
 // use by the HTTP handler goroutines AND the run goroutines that
 // deregister on completion.
 type Registry struct {
-	mu      sync.RWMutex
-	entries map[string]Entry
+	mu               sync.RWMutex
+	entries          map[string]Entry
+	clusterCanceller ClusterCanceller // nil in single-replica mode
 }
 
 // NewRegistry returns an empty registry. The HTTP server constructs
 // one at boot and threads it through every handler that creates a run.
 func NewRegistry() *Registry {
 	return &Registry{entries: make(map[string]Entry)}
+}
+
+// SetClusterCanceller installs the v0.12.2 cross-replica fallback.
+// Called from main.go in cluster mode after the backplane is wired.
+// Safe to call once during boot; not designed for mid-flight swaps.
+func (r *Registry) SetClusterCanceller(c ClusterCanceller) {
+	r.mu.Lock()
+	r.clusterCanceller = c
+	r.mu.Unlock()
 }
 
 // Register adds an agent_id → entry mapping. Returns ErrInUse if the
@@ -160,6 +186,55 @@ func (r *Registry) Get(agentID string) (Entry, bool) {
 	return e, ok
 }
 
+// CancelLocal is identical to Cancel except it NEVER delegates to the
+// cluster canceller on local miss. v0.12.2 RunCancelSubscriber uses
+// this to dispatch incoming backplane events to the local registry —
+// using Cancel would re-broadcast on local miss (the registry's
+// ClusterCanceller is set), producing a O(replicas × timeout)
+// broadcast storm of cancel events that nobody can honor.
+//
+// Returns (CancelResult, true) on local hit (with cascade), or
+// (CancelResult{}, false) on local miss. The caller treats false as
+// "not on this replica" and silently skips — the owning replica's
+// subscriber will handle it.
+func (r *Registry) CancelLocal(agentID, reason string) (CancelResult, bool) {
+	cause := ErrCancelledByAPI
+	if reason != "" {
+		cause = &cancelWithReason{reason: reason}
+	}
+	r.mu.Lock()
+	root, ok := r.entries[agentID]
+	if !ok {
+		r.mu.Unlock()
+		return CancelResult{}, false
+	}
+	delete(r.entries, agentID)
+	r.mu.Unlock()
+	root.cancelFn(cause)
+
+	cascaded := []string{}
+	queue := []string{agentID}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		r.mu.Lock()
+		var children []Entry
+		for id, e := range r.entries {
+			if e.ParentAgentID == parent {
+				children = append(children, e)
+				delete(r.entries, id)
+			}
+		}
+		r.mu.Unlock()
+		for _, c := range children {
+			c.cancelFn(cause)
+			cascaded = append(cascaded, c.AgentID)
+			queue = append(queue, c.AgentID)
+		}
+	}
+	return CancelResult{Cancelled: true, Reason: reason, Cascaded: cascaded}, true
+}
+
 // Cancel invokes the cancelFn for agentID and recursively cancels
 // every direct child (an entry whose ParentAgentID equals one of the
 // already-cancelled ids). The reason is attached as the cancel-cause
@@ -188,8 +263,27 @@ func (r *Registry) Cancel(agentID, reason string) (CancelResult, bool) {
 	r.mu.Lock()
 	root, ok := r.entries[agentID]
 	if !ok {
+		// Local miss. v0.12.2: in cluster mode delegate to the
+		// CancelCoordinator which broadcasts on the backplane and
+		// awaits the owning replica's ack. In single-replica mode
+		// (clusterCanceller == nil), return (false) unchanged so the
+		// HTTP handler falls through to the store for idempotent
+		// terminal-status response (v0.11.x behaviour).
+		cc := r.clusterCanceller
 		r.mu.Unlock()
-		return CancelResult{}, false
+		if cc == nil {
+			return CancelResult{}, false
+		}
+		// Use Background context with the coordinator's own timeout
+		// inside CancelRemote — the HTTP request context may be
+		// shorter than the ack window if the client disconnects.
+		res, ok, err := cc.CancelRemote(context.Background(), agentID, reason)
+		if err != nil {
+			// Treat as miss so the handler falls through to the
+			// store's terminal-status lookup.
+			return CancelResult{}, false
+		}
+		return res, ok
 	}
 	delete(r.entries, agentID)
 	r.mu.Unlock()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1020,6 +1020,14 @@ type Env struct {
 	// admin. Env: LOOMCYCLE_REPLICA_ID.
 	ReplicaID string
 
+	// CancelAckTimeoutMs is the v0.12.2 cross-replica cancel ack wait.
+	// On a cluster-mode cancel that broadcasts to the owning replica,
+	// the originator waits this long for a "cancelled" ack on the
+	// backplane before returning {cancelled:false,
+	// reason:"owner_replica_unreachable"}. Default 5000.
+	// Env: LOOMCYCLE_CANCEL_ACK_TIMEOUT_MS.
+	CancelAckTimeoutMs int64
+
 	// PauseDefaultTimeoutMs is the wait-for-non-idempotent-tools cap
 	// applied when POST /v1/_pause omits timeout_ms. 0 ⇒ use the
 	// internal default (pause.DefaultPauseTimeout = 30s). Capped at
@@ -1676,6 +1684,12 @@ func Load(path string) (*Config, error) {
 	if cfg.Env.ReplicaID != "" {
 		if err := validateReplicaID(cfg.Env.ReplicaID); err != nil {
 			return nil, fmt.Errorf("LOOMCYCLE_REPLICA_ID: %w", err)
+		}
+	}
+	cfg.Env.CancelAckTimeoutMs = 5000
+	if v := os.Getenv("LOOMCYCLE_CANCEL_ACK_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.Env.CancelAckTimeoutMs = n
 		}
 	}
 

--- a/internal/coord/cancel_coordinator.go
+++ b/internal/coord/cancel_coordinator.go
@@ -1,0 +1,322 @@
+package coord
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// CancelCoordinator implements cancel.ClusterCanceller via the
+// v0.12.0 Backplane. One instance per replica, wired in main.go
+// inside the cluster-mode init block. When a local cancel registry
+// lookup misses on this replica, the registry delegates to
+// CancelRemote which:
+//
+//  1. Queries the runs table for the agent's owning replica_id.
+//  2. Checks owner liveness via replicas.IsReplicaAlive — if dead,
+//     marks the run failed in the DB and returns success without
+//     a broadcast (Phase 5's TTL sweeper will close this loop, but
+//     this short-circuit saves the 5s ack wait).
+//  3. Publishes a `loomcycle.cancel` event on the backplane carrying
+//     {agent_id, reason, from_replica}.
+//  4. Waits on a per-call ack channel keyed by agent_id for up to
+//     AckTimeout. On ack: returns success with the cascaded child
+//     list. On timeout: re-checks the run row (it may have completed
+//     during the wait) and returns either the terminal status or
+//     `owner_replica_unreachable`.
+//
+// Two long-lived subscriber goroutines (RunCancelSubscriber +
+// RunAckSubscriber) carry the wire side: one listens for incoming
+// cancel events and dispatches to the local registry; the other
+// receives acks and routes them to the in-flight CancelRemote waiters.
+type CancelCoordinator struct {
+	bp         Backplane
+	replicaID  string
+	store      cancelRunStore
+	replicas   *ReplicaStore
+	ackTimeout time.Duration
+
+	mu sync.Mutex
+	// ackSubs is the in-flight waiter registry, fanning out one ack
+	// to every concurrent CancelRemote caller for the same agent_id.
+	// Slice (not single chan) closes the v0.12.2 review-1 finding #2:
+	// with a single shared channel, the second caller for a given
+	// agent_id always timed out because only one receiver gets the
+	// buffered ack. Each CancelRemote now registers its own buffered
+	// chan; RunAckSubscriber iterates the slice and delivers to every
+	// waiter.
+	ackSubs map[string][]chan cancelAckPayload
+}
+
+// CancelCoordinatorConfig is the constructor input.
+type CancelCoordinatorConfig struct {
+	Backplane    Backplane
+	ReplicaID    string
+	Store        cancelRunStore
+	ReplicaStore *ReplicaStore
+	// AckTimeout caps how long CancelRemote waits for the owning
+	// replica's ack publish. Default 5s if zero.
+	AckTimeout time.Duration
+}
+
+// cancelRunStore is the narrow surface CancelCoordinator needs from
+// the store layer. *storepostgres.Store satisfies it implicitly.
+// Declared here so the test suite can stub without dragging the full
+// store.Store interface.
+type cancelRunStore interface {
+	GetRunByAgentID(ctx context.Context, agentID string) (store.Run, error)
+	FinishRun(ctx context.Context, runID string, status store.RunStatus, stopReason string, usage store.Usage, errMsg string) error
+}
+
+// staleReplicaThreshold is the dead-owner cutoff. 3× the 30s
+// heartbeat interval = 90s. A replica whose last_heartbeat_at is
+// older than this is presumed dead and CancelRemote marks the run
+// failed without a broadcast.
+const staleReplicaThreshold = 90 * time.Second
+
+const (
+	topicCancel    = "loomcycle.cancel"
+	topicCancelAck = "loomcycle.cancel.ack"
+)
+
+func NewCancelCoordinator(cfg CancelCoordinatorConfig) (*CancelCoordinator, error) {
+	if cfg.Backplane == nil {
+		return nil, errors.New("coord: backplane is required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("coord: store is required")
+	}
+	if cfg.ReplicaStore == nil {
+		return nil, errors.New("coord: replica store is required")
+	}
+	if err := ValidateReplicaID(cfg.ReplicaID); err != nil {
+		return nil, err
+	}
+	timeout := cfg.AckTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &CancelCoordinator{
+		bp:         cfg.Backplane,
+		replicaID:  cfg.ReplicaID,
+		store:      cfg.Store,
+		replicas:   cfg.ReplicaStore,
+		ackTimeout: timeout,
+		ackSubs:    make(map[string][]chan cancelAckPayload),
+	}, nil
+}
+
+type cancelEventPayload struct {
+	AgentID     string `json:"agent_id"`
+	Reason      string `json:"reason,omitempty"`
+	FromReplica string `json:"from_replica"`
+}
+
+type cancelAckPayload struct {
+	AgentID   string   `json:"agent_id"`
+	ByReplica string   `json:"by_replica"`
+	Cascaded  []string `json:"cascaded,omitempty"`
+}
+
+// CancelRemote satisfies cancel.ClusterCanceller. Returns the tuple
+// the cancel registry needs: (CancelResult, registry_hit, err).
+// "registry_hit" semantics: true means we found something
+// authoritative (a DB row, dead or alive); the handler treats this
+// as "no fall-through to store needed." false means the run row
+// doesn't exist and the handler should serve 404 via the store path.
+func (c *CancelCoordinator) CancelRemote(ctx context.Context, agentID, reason string) (cancel.CancelResult, bool, error) {
+	run, err := c.store.GetRunByAgentID(ctx, agentID)
+	if err != nil {
+		var notFound *store.ErrNotFound
+		if errors.As(err, &notFound) {
+			// 404: handler falls through to store, which will also
+			// 404. The empty CancelResult signals miss.
+			return cancel.CancelResult{}, false, nil
+		}
+		return cancel.CancelResult{}, false, fmt.Errorf("get run by agent_id: %w", err)
+	}
+	// Idempotent terminal case — no broadcast needed.
+	if run.Status != store.RunRunning && run.Status != store.RunStatus("") {
+		return cancel.CancelResult{Cancelled: false, Reason: reason}, true, nil
+	}
+	// Single-replica row stamped before v0.12.2, or a stamp that
+	// somehow points at this replica (registry should have caught the
+	// latter — log a warning either way). Treat as un-routable.
+	if run.ReplicaID == "" {
+		return cancel.CancelResult{}, false, nil
+	}
+	if run.ReplicaID == c.replicaID {
+		log.Printf("coord: CancelRemote called for run %s owned by self (%s) — local registry missed it; treating as deregistered", run.ID, c.replicaID)
+		return cancel.CancelResult{}, false, nil
+	}
+
+	// Check owner liveness before broadcasting. A dead owner triggers
+	// the "mark failed in DB + return success" short-circuit.
+	alive, err := c.replicas.IsReplicaAlive(ctx, run.ReplicaID, staleReplicaThreshold)
+	if err != nil {
+		// Liveness probe failure: log and continue with broadcast. A
+		// real cancel may still succeed if the replica responds.
+		log.Printf("coord: IsReplicaAlive probe for %s failed: %v (proceeding with broadcast)", run.ReplicaID, err)
+	} else if !alive {
+		// Owner is gone. Mark the run failed and return success.
+		if ferr := c.store.FinishRun(ctx, run.ID, store.RunFailed, "owner_replica_dead", store.Usage{}, "owner replica heartbeat stale; marked failed by cancel handler"); ferr != nil {
+			log.Printf("coord: mark run %s failed after dead-owner detection: %v", run.ID, ferr)
+		}
+		return cancel.CancelResult{Cancelled: true, Reason: "owner_dead_marked_failed"}, true, nil
+	}
+
+	// Live owner: broadcast + wait for ack.
+	//
+	// Each CancelRemote gets its OWN buffered channel — concurrent
+	// callers for the same agent_id each receive the ack independently
+	// (review-1 finding #2). RunAckSubscriber fans out to every chan
+	// in the slice at delivery time.
+	ackCh := make(chan cancelAckPayload, 1)
+	c.mu.Lock()
+	c.ackSubs[agentID] = append(c.ackSubs[agentID], ackCh)
+	c.mu.Unlock()
+	defer func() {
+		// Remove only this caller's channel from the slice — leave
+		// the entry in place if other concurrent callers are still
+		// waiting. When the slice empties, delete the map key.
+		c.mu.Lock()
+		slice := c.ackSubs[agentID]
+		for i, ch := range slice {
+			if ch == ackCh {
+				slice = append(slice[:i], slice[i+1:]...)
+				break
+			}
+		}
+		if len(slice) == 0 {
+			delete(c.ackSubs, agentID)
+		} else {
+			c.ackSubs[agentID] = slice
+		}
+		c.mu.Unlock()
+	}()
+
+	payload, _ := json.Marshal(cancelEventPayload{
+		AgentID:     agentID,
+		Reason:      reason,
+		FromReplica: c.replicaID,
+	})
+	if err := c.bp.Publish(ctx, topicCancel, payload); err != nil {
+		return cancel.CancelResult{}, false, fmt.Errorf("publish cancel: %w", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), c.ackTimeout)
+	defer waitCancel()
+	select {
+	case ack := <-ackCh:
+		return cancel.CancelResult{
+			Cancelled: true,
+			Reason:    reason,
+			Cascaded:  ack.Cascaded,
+		}, true, nil
+	case <-waitCtx.Done():
+		// Timeout. Before returning unreachable, re-check the run row
+		// — it may have completed naturally during our wait. Use a
+		// short fresh context for the re-check.
+		recheckCtx, recheckCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer recheckCancel()
+		if run2, err := c.store.GetRunByAgentID(recheckCtx, agentID); err == nil && run2.Status != "" && run2.Status != store.RunRunning {
+			return cancel.CancelResult{Cancelled: false, Reason: string(run2.Status)}, true, nil
+		}
+		return cancel.CancelResult{Cancelled: false, Reason: "owner_replica_unreachable"}, true, nil
+	}
+}
+
+// RunCancelSubscriber is the owning-side listener. Started once per
+// replica via `go coordinator.RunCancelSubscriber(bgCtx)`. Reads from
+// `loomcycle.cancel`, dispatches to the local registry, and publishes
+// an ack on `loomcycle.cancel.ack` when the agent was found locally.
+//
+// reg is the local cancel.Registry — passed in (not held as a field)
+// because Coordinator is constructed before the Server's registry
+// exists.
+func (c *CancelCoordinator) RunCancelSubscriber(ctx context.Context, reg *cancel.Registry) {
+	ch, err := c.bp.Subscribe(ctx, topicCancel)
+	if err != nil {
+		log.Printf("coord: RunCancelSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var p cancelEventPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			log.Printf("coord: malformed cancel event: %v", err)
+			continue
+		}
+		// CRITICAL: use CancelLocal, NOT Cancel. Cancel delegates to
+		// the ClusterCanceller on local miss, which would re-broadcast
+		// the same event we just received — causing a O(replicas ×
+		// ack_timeout) broadcast storm of cancel events nobody can
+		// honor (review-1 finding #1). CancelLocal never delegates.
+		// On local miss we silently skip; the owning replica's own
+		// subscriber will pick it up.
+		res, ok := reg.CancelLocal(p.AgentID, p.Reason)
+		if !ok {
+			continue
+		}
+		ack, _ := json.Marshal(cancelAckPayload{
+			AgentID:   p.AgentID,
+			ByReplica: c.replicaID,
+			Cascaded:  res.Cascaded,
+		})
+		if err := c.bp.Publish(ctx, topicCancelAck, ack); err != nil {
+			log.Printf("coord: publish cancel ack for %s: %v", p.AgentID, err)
+		}
+	}
+}
+
+// RunAckSubscriber is the originator-side ack fan-in. Started once
+// per replica. Reads from `loomcycle.cancel.ack` and routes each ack
+// to the matching in-flight CancelRemote waiter (by agent_id).
+func (c *CancelCoordinator) RunAckSubscriber(ctx context.Context) {
+	ch, err := c.bp.Subscribe(ctx, topicCancelAck)
+	if err != nil {
+		log.Printf("coord: RunAckSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var ack cancelAckPayload
+		if err := json.Unmarshal(evt.Payload, &ack); err != nil {
+			log.Printf("coord: malformed cancel ack: %v", err)
+			continue
+		}
+		c.mu.Lock()
+		waiters := c.ackSubs[ack.AgentID]
+		// Snapshot under the lock; deliver outside. Snapshot is cheap
+		// (slice of channel headers); per-waiter sends mustn't block
+		// the mutex for the whole fan-out.
+		snapshot := make([]chan cancelAckPayload, len(waiters))
+		copy(snapshot, waiters)
+		c.mu.Unlock()
+		if len(snapshot) == 0 {
+			// Ack for an agent we didn't originate a cancel for — a
+			// foreign replica handling its own cancel, or a stale
+			// payload. Drop silently.
+			continue
+		}
+		// Fan out: every concurrent CancelRemote caller for this
+		// agent_id receives the ack independently. Buffered-1 chans
+		// + non-blocking send means a duplicate ack (publisher
+		// retransmits) is silently dropped per receiver.
+		for _, w := range snapshot {
+			select {
+			case w <- ack:
+			default:
+				// Already delivered to this waiter.
+			}
+		}
+	}
+}
+
+// Compile-time check that we satisfy the cancel package's interface.
+var _ cancel.ClusterCanceller = (*CancelCoordinator)(nil)

--- a/internal/coord/cancel_coordinator_test.go
+++ b/internal/coord/cancel_coordinator_test.go
@@ -1,0 +1,314 @@
+package coord
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// stubCancelRunStore implements cancelRunStore for tests without
+// standing up a Postgres fixture.
+type stubCancelRunStore struct {
+	runs       map[string]store.Run // keyed by agent_id
+	finishErr  error
+	finishCall struct {
+		runID  string
+		status store.RunStatus
+		reason string
+	}
+}
+
+func (s *stubCancelRunStore) GetRunByAgentID(_ context.Context, agentID string) (store.Run, error) {
+	r, ok := s.runs[agentID]
+	if !ok {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	return r, nil
+}
+
+func (s *stubCancelRunStore) FinishRun(_ context.Context, runID string, status store.RunStatus, stopReason string, _ store.Usage, _ string) error {
+	s.finishCall.runID = runID
+	s.finishCall.status = status
+	s.finishCall.reason = stopReason
+	if s.finishErr != nil {
+		return s.finishErr
+	}
+	// Update the in-memory row so the timeout-recheck path can see
+	// a terminal status if the test set finish before timeout.
+	for agentID, r := range s.runs {
+		if r.ID == runID {
+			r.Status = status
+			s.runs[agentID] = r
+			break
+		}
+	}
+	return nil
+}
+
+func TestCancelCoordinator_LocalFallback_NoClusterCanceller(t *testing.T) {
+	// Single-replica path: a Registry with no ClusterCanceller set
+	// returns (false) on local miss — unchanged from v0.11.x.
+	reg := cancel.NewRegistry()
+	res, ok := reg.Cancel("does-not-exist", "test")
+	if ok || res.Cancelled {
+		t.Errorf("local miss with no cluster canceller should return (false), got (%v, ok=%v)", res, ok)
+	}
+}
+
+// TestCancelCoordinator_NotFound_ReturnsMiss verifies that a CancelRemote
+// for an unknown agent_id returns (CancelResult{}, false, nil) so the
+// HTTP handler falls through to the store's 404 path.
+func TestCancelCoordinator_NotFound_ReturnsMiss(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool := freshUserQuotasPool(t, dsn)
+	bp, err := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-cc-nf-" + time.Now().Format("150405.000"),
+	})
+	if err != nil {
+		t.Fatalf("backplane: %v", err)
+	}
+	defer bp.Close()
+
+	stub := &stubCancelRunStore{runs: map[string]store.Run{}}
+	rs := NewReplicaStore(pool)
+	cc, err := NewCancelCoordinator(CancelCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    "test-cc-nf-A",
+		Store:        stub,
+		ReplicaStore: rs,
+		AckTimeout:   500 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("coordinator: %v", err)
+	}
+
+	res, ok, err := cc.CancelRemote(context.Background(), "unknown", "")
+	if err != nil {
+		t.Errorf("CancelRemote error: %v", err)
+	}
+	if ok {
+		t.Errorf("ok=true for unknown agent, want false (handler should 404)")
+	}
+	if res.Cancelled {
+		t.Errorf("Cancelled=true for unknown agent, want false")
+	}
+}
+
+// TestCancelCoordinator_AlreadyTerminal_ReturnsIdempotent verifies a
+// CancelRemote for a run that is already in a terminal state returns
+// Cancelled=false without broadcasting.
+func TestCancelCoordinator_AlreadyTerminal_ReturnsIdempotent(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool := freshUserQuotasPool(t, dsn)
+	bp, _ := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-cc-term",
+	})
+	defer bp.Close()
+
+	stub := &stubCancelRunStore{runs: map[string]store.Run{
+		"a_done": {ID: "r1", Status: store.RunCompleted, ReplicaID: "other-replica"},
+	}}
+	cc, _ := NewCancelCoordinator(CancelCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    "test-cc-term",
+		Store:        stub,
+		ReplicaStore: NewReplicaStore(pool),
+		AckTimeout:   500 * time.Millisecond,
+	})
+	res, ok, err := cc.CancelRemote(context.Background(), "a_done", "")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Errorf("ok=false for already-terminal run, want true (handler should 200 with cancelled=false)")
+	}
+	if res.Cancelled {
+		t.Errorf("Cancelled=true for terminal run, want false (idempotent)")
+	}
+}
+
+// TestCancelCoordinator_DeadOwner_MarksRunFailed verifies the
+// short-circuit: when the owning replica's heartbeat is stale, the
+// coordinator marks the run failed in the DB and returns success
+// without broadcasting.
+func TestCancelCoordinator_DeadOwner_MarksRunFailed(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool := freshUserQuotasPool(t, dsn)
+	bp, _ := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-cc-dead",
+	})
+	defer bp.Close()
+
+	stub := &stubCancelRunStore{runs: map[string]store.Run{
+		"a_dead": {ID: "r2", Status: store.RunRunning, ReplicaID: "dead-replica"},
+	}}
+	rs := NewReplicaStore(pool)
+	// Seed a backdated heartbeat row for dead-replica so IsReplicaAlive
+	// returns false.
+	deadID := "dead-replica-" + time.Now().Format("150405.000")
+	stub.runs["a_dead"] = store.Run{ID: "r2", Status: store.RunRunning, ReplicaID: deadID}
+	_, _ = pool.Exec(context.Background(),
+		`INSERT INTO replicas (id, hostname, started_at, last_heartbeat_at, version)
+		 VALUES ($1, 'h', now() - interval '1 hour', now() - interval '10 minutes', 'v')
+		 ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now() - interval '10 minutes'`, deadID)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM replicas WHERE id = $1`, deadID)
+	})
+
+	cc, _ := NewCancelCoordinator(CancelCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    "test-cc-dead",
+		Store:        stub,
+		ReplicaStore: rs,
+		AckTimeout:   500 * time.Millisecond,
+	})
+	res, ok, err := cc.CancelRemote(context.Background(), "a_dead", "user-stop")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok || !res.Cancelled {
+		t.Errorf("dead-owner: got ok=%v Cancelled=%v, want ok=true Cancelled=true", ok, res.Cancelled)
+	}
+	if res.Reason != "owner_dead_marked_failed" {
+		t.Errorf("Reason = %q, want owner_dead_marked_failed", res.Reason)
+	}
+	if stub.finishCall.runID != "r2" || stub.finishCall.status != store.RunFailed {
+		t.Errorf("FinishRun call = %+v, want runID=r2 status=failed", stub.finishCall)
+	}
+}
+
+// TestCancelCoordinator_Timeout_ReturnsOwnerUnreachable verifies the
+// 5s (here 500ms) ack timeout returns the unreachable reason when no
+// owning replica responds.
+func TestCancelCoordinator_Timeout_ReturnsOwnerUnreachable(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	pool := freshUserQuotasPool(t, dsn)
+	bp, _ := NewPostgresBackplane(PostgresBackplaneConfig{
+		Pool: pool, DSN: dsn, ReplicaID: "test-cc-timeout",
+	})
+	defer bp.Close()
+
+	// Owner row: a fake replica with a fresh heartbeat (so the alive
+	// check passes and we proceed to broadcast). No subscriber will
+	// respond, so we hit timeout.
+	freshOwner := "fresh-fake-owner-" + time.Now().Format("150405.000")
+	_, _ = pool.Exec(context.Background(),
+		`INSERT INTO replicas (id, hostname, started_at, last_heartbeat_at, version)
+		 VALUES ($1, 'h', now(), now(), 'v')
+		 ON CONFLICT (id) DO UPDATE SET last_heartbeat_at = now()`, freshOwner)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM replicas WHERE id = $1`, freshOwner)
+	})
+
+	stub := &stubCancelRunStore{runs: map[string]store.Run{
+		"a_timeout": {ID: "r3", Status: store.RunRunning, ReplicaID: freshOwner},
+	}}
+	rs := NewReplicaStore(pool)
+	cc, _ := NewCancelCoordinator(CancelCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    "test-cc-timeout",
+		Store:        stub,
+		ReplicaStore: rs,
+		AckTimeout:   400 * time.Millisecond,
+	})
+
+	start := time.Now()
+	res, ok, err := cc.CancelRemote(context.Background(), "a_timeout", "")
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Error("ok=false on timeout, want true (handler should 200 with cancelled=false)")
+	}
+	if res.Cancelled {
+		t.Error("Cancelled=true on timeout, want false")
+	}
+	if res.Reason != "owner_replica_unreachable" {
+		t.Errorf("Reason = %q, want owner_replica_unreachable", res.Reason)
+	}
+	if elapsed < 400*time.Millisecond {
+		t.Errorf("timeout fired too early: %s", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("timeout took too long: %s (recheck context blocked?)", elapsed)
+	}
+}
+
+// TestCancelCoordinator_NewCoordinator_ValidatesConfig
+func TestCancelCoordinator_NewCoordinator_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  CancelCoordinatorConfig
+		want string
+	}{
+		{"nil backplane", CancelCoordinatorConfig{}, "backplane"},
+		{"nil store", CancelCoordinatorConfig{Backplane: &PostgresBackplane{}}, "store"},
+		{"nil replica store", CancelCoordinatorConfig{Backplane: &PostgresBackplane{}, Store: &stubCancelRunStore{}}, "replica store"},
+		{"bad replica id", CancelCoordinatorConfig{Backplane: &PostgresBackplane{}, Store: &stubCancelRunStore{}, ReplicaStore: &ReplicaStore{}, ReplicaID: "has space"}, "replica id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewCancelCoordinator(tc.cfg)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (len(sub) == 0 || (indexOf(s, sub) >= 0))
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// Sentinel: NewCancelCoordinator returns the right error class.
+func TestNewCancelCoordinator_ErrorType(t *testing.T) {
+	_, err := NewCancelCoordinator(CancelCoordinatorConfig{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Just verify it's a real error (no specific sentinel for this).
+	var anyErr error = errors.New("")
+	if err == anyErr {
+		t.Fatal("unexpected")
+	}
+}
+
+// TestCancelRegistry_CancelLocal_NeverDelegates pins review-1 finding #1's
+// fix: CancelLocal must NEVER call ClusterCanceller, even when one is
+// wired. RunCancelSubscriber uses CancelLocal to dispatch incoming
+// backplane events — using Cancel would re-broadcast and produce a
+// O(replicas × ack_timeout) cascade of cancel events nobody can honor.
+func TestCancelRegistry_CancelLocal_NeverDelegates(t *testing.T) {
+	// Register a stub ClusterCanceller that PANICS if called — proves
+	// CancelLocal never reaches it.
+	reg := cancel.NewRegistry()
+	reg.SetClusterCanceller(panickingCanceller{})
+
+	res, ok := reg.CancelLocal("does-not-exist", "test")
+	if ok || res.Cancelled {
+		t.Errorf("CancelLocal on miss should return (false), got (%v, ok=%v)", res, ok)
+	}
+}
+
+type panickingCanceller struct{}
+
+func (panickingCanceller) CancelRemote(_ context.Context, agentID, _ string) (cancel.CancelResult, bool, error) {
+	panic("ClusterCanceller.CancelRemote must not be called from CancelLocal: " + agentID)
+}

--- a/internal/coord/replica_store.go
+++ b/internal/coord/replica_store.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -65,6 +66,32 @@ func (s *ReplicaStore) DeleteReplica(ctx context.Context, id string) error {
 		return fmt.Errorf("delete replica %s: %w", id, err)
 	}
 	return nil
+}
+
+// IsReplicaAlive returns true when the replica's last_heartbeat_at
+// is within staleThreshold of now. Returns false + nil error when
+// the row doesn't exist (never-seen replica is treated as dead).
+// Used by Phase 3's CancelCoordinator to short-circuit broadcast
+// when the owning replica is known dead — saves a 5s ack-timeout
+// wait by going straight to "mark run failed" instead.
+func (s *ReplicaStore) IsReplicaAlive(ctx context.Context, id string, staleThreshold time.Duration) (bool, error) {
+	if id == "" {
+		return false, nil
+	}
+	var lastHB time.Time
+	err := s.pool.QueryRow(ctx,
+		`SELECT last_heartbeat_at FROM replicas WHERE id = $1`, id,
+	).Scan(&lastHB)
+	if err != nil {
+		// pgx.ErrNoRows means the replica row never existed (e.g. it
+		// crashed before its first heartbeat upsert, or the table was
+		// manually cleaned). Treat as dead.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("IsReplicaAlive %s: %w", id, err)
+	}
+	return time.Since(lastHB) < staleThreshold, nil
 }
 
 // ListReplicas returns every row, ordered by started_at ascending.

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -262,8 +262,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	if _, err := s.pool.Exec(ctx,
 		`INSERT INTO runs (
 			id, session_id, status, started_at,
-			agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+			agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, replica_id
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
 		id, sessionID, string(store.RunRunning), now,
 		nullableText(identity.AgentID),
 		nullableText(identity.ParentAgentID),
@@ -272,6 +272,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nullableText(identity.UserTier),
 		nullableText(identity.AgentDefID),
 		nullableText(identity.Model),
+		nullableText(identity.ReplicaID),
 	); err != nil {
 		return store.Run{}, fmt.Errorf("create run: %w", err)
 	}
@@ -287,6 +288,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		UserTier:      identity.UserTier,
 		AgentDefID:    identity.AgentDefID,
 		Model:         identity.Model,
+		ReplicaID:     identity.ReplicaID,
 	}, nil
 }
 
@@ -483,7 +485,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state,
+		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
@@ -508,7 +510,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state,
+		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.id = $1`, runID,
@@ -571,7 +573,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state,
+			        r.agent_def_id, r.pause_state, r.replica_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1
@@ -582,7 +584,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state,
+			        r.agent_def_id, r.pause_state, r.replica_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1 AND r.status = $2
@@ -607,7 +609,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state,
+		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.parent_agent_id = $1
@@ -702,7 +704,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state,
+		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.pause_state = $1
@@ -3951,6 +3953,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		agentID, parentAgentID, parentRunID, userID, userTier *string
 		agentDefID                                            *string
 		pauseState                                            *string
+		replicaID                                             *string
 		lastHeartbeatAt                                       *time.Time
 		sessAgent                                             *string
 
@@ -3962,7 +3965,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&model, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
-		&agentDefID, &pauseState,
+		&agentDefID, &pauseState, &replicaID,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -4004,6 +4007,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	if pauseState != nil {
 		out.PauseState = *pauseState
+	}
+	if replicaID != nil {
+		out.ReplicaID = *replicaID
 	}
 	if sessAgent != nil {
 		out.Agent = *sessAgent

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -217,6 +217,12 @@ type Run struct {
 	// distinguish runs that need to re-enter from runs that finished
 	// during pause (status terminal already).
 	PauseState string `json:"pause_state,omitempty"`
+
+	// ReplicaID is the replica that created this run and owns its
+	// live cancel handle (v0.12.2 Phase 3). NULL/empty on rows
+	// created before v0.12.2 or in single-replica mode. Cross-replica
+	// cancel routes via this column.
+	ReplicaID string `json:"replica_id,omitempty"`
 }
 
 // PauseState constants — the wire string values stored in runs.pause_state.
@@ -302,6 +308,12 @@ type RunIdentity struct {
 	// recorded by the loop, which may differ if cross-provider
 	// fallback fired mid-run.
 	Model string
+	// ReplicaID stamps this run with the replica that owns its live
+	// cancel handle (v0.12.2 Phase 3). Empty in single-replica mode
+	// (LOOMCYCLE_REPLICA_ID unset); the column stays NULL. In cluster
+	// mode it routes cross-replica cancel requests to the owning
+	// replica via backplane broadcast. Postgres-only; SQLite ignores.
+	ReplicaID string
 }
 
 // UserSummary is one row of ListUsers' output: distinct user_id with


### PR DESCRIPTION
## Summary

Phase 3 of the v1.0 multi-replica HA capstone. Closes the most critical correctness gap from the v0.12.0 audit: a cancel request that hits the wrong replica now reaches the run via the backplane. Single-replica deployments (`LOOMCYCLE_REPLICA_ID` unset) keep v0.11.x behavior **byte-identical**.

## Problem

Before v0.12.2, `Cancel.Registry.Cancel(agent_id)` walked an in-process map. A cancel request routed by the LB to replica B for a run executing on replica A returned `{cancelled: false}` and the actual run kept executing on A. Identified as one of three critical correctness blockers for active-active deployment.

## What ships

1. **`runs.replica_id` written at run creation** — column already existed (Phase 1 migration 0023, nullable). All 4 run-creation sites in `server.go` now plumb `s.replicaID` through `store.RunIdentity`. Empty in single-replica mode → NULL.
2. **`coord.CancelCoordinator`** implements the new `cancel.ClusterCanceller` interface. On local miss: lookup owner → liveness check (90s stale threshold) → if dead, mark run failed in DB (short-circuit); if alive, broadcast on `loomcycle.cancel` and wait for ack on `loomcycle.cancel.ack` with `LOOMCYCLE_CANCEL_ACK_TIMEOUT_MS` (default 5000ms). On timeout: re-check the row (it may have completed) and return either terminal status or `owner_replica_unreachable`.
3. **Two long-lived subscribers per replica** (`RunCancelSubscriber` + `RunAckSubscriber`) carry the wire side.
4. **`cancelResponse.Cancelled`** now reflects `res.Cancelled` instead of hardcoded `true` — correct behavior across the new cluster-mode paths.

## Code review (parallel agent) — 2 CRITICAL findings, both fixed pre-commit

1. **Broadcast storm**: `RunCancelSubscriber`'s call to `reg.Cancel` delegated to the `ClusterCanceller` on local miss (because it's set in cluster mode), which re-broadcasted the same event — `O(replicas × ack_timeout)` cascade nobody could honor. Fixed by adding `cancel.Registry.CancelLocal` which never delegates; `RunCancelSubscriber` uses it. Regression test pins the invariant via a `panickingCanceller` stub.

2. **Concurrent `CancelRemote` for same agent_id**: second caller reused the first's buffered-1 ack channel and always timed out (only one receiver gets the ack). Fixed by `ackSubs map[string][]chan` + per-caller channels + `RunAckSubscriber` fan-out under the lock + per-caller defer that only removes its own slot.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1 -timeout 300s` all green
- [x] New tests: `CancelCoordinator` not-found / already-terminal / dead-owner-marks-failed / ack-timeout / config-validation; `CancelLocal_NeverDelegates` regression
- [x] Smoke test: REPLICA_ID unset → boots normally, no new log lines
- [ ] CI green on PR check
- [ ] Postgres-gated tests run locally via `LOOMCYCLE_TEST_PG_DSN` — green
- [ ] 2-replica live test: start run on A, cancel from B, confirm DB shows status=cancelled within 5s

## Note on dependency

This PR is independent of PRs #214 and #215 in code, but builds on their landed infrastructure (`coord.Backplane`, `replicas` table, `runs.replica_id` column from Phase 1; `WithUserQuotaStore` pattern from Phase 2). It also opens before later phases (4-7) which may show conflicts in `cmd/loomcycle/main.go` because each phase extends the cluster-mode init block — those rebases are trivial 3-way merges.

## Remaining v0.12.x → v1.0 phases

| Phase | PR | Scope |
|---|---|---|
| 4 | v0.12.3 | Pause/resume + bus fanout |
| 5 | v0.12.4 | Singleton sweepers via advisory locks + replicas TTL sweeper (closes Phase 2 + Phase 3 crash-safety gaps) |
| 6 | v0.12.5 | Session-lock + hook-registry → DB-backed |
| 7 | v0.12.6 | Hardening + docs + **tag v1.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)