### PR TITLE
feat(v0.12.3): cluster-wide pause/resume + bus fanout (Phase 4 of 7)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,33 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.12.3
+
+**Phase 4 of the v1.0 multi-replica HA capstone — cluster-wide pause/resume + bus fanout.** Single-replica mode (`LOOMCYCLE_REPLICA_ID` unset) keeps the v0.11.x behavior byte-identical: no DB-state reads, no backplane traffic.
+
+### What ships
+
+1. **`runtime_state` table + migration 0025.** Single row (id='singleton') with `state`, `state_changed_at`, `paused_at`, `paused_runs_count`. Seeded via `INSERT ... ON CONFLICT DO NOTHING`.
+2. **`coord.RuntimeStateStore`** — Get/Set on the singleton row.
+3. **`pause.Manager` cluster-mode extension** — optional `RuntimeStateStore` + 1s in-memory cache + `SubscribeBackplane` goroutine listening on `loomcycle.pause`. `Pause`/`Resume` write to DB + publish on backplane after the local transition. `applyRemotePause`/`applyRemoteResume` carry remote events; `applyRemotePause` skips `StatePausing` because the originator already drained tools. Single-replica path: lock-free atomic load, no DB.
+4. **`runstate.Bus` + `channels.Bus` backplane fanout** — `Publish`/`Notify` fan locally THEN publish on backplane (`loomcycle.runstate` / `loomcycle.channel`). `SubscribeBackplane` goroutine fans incoming events to local subscribers via the no-re-publish paths (`publishLocal` / `notifyLocal`) to prevent loops.
+5. **`LOOMCYCLE_PAUSE_CACHE_TTL_MS`** env var (default 1000ms).
+6. **main.go wiring** — `RuntimeStateStore` constructed and wired into the pause manager inside the existing storeIface block; bus backplanes wired inside the cluster init block.
+
+### Code review (parallel agent) — 3 findings, all fixed pre-commit
+
+1. **CRITICAL — data race on `m.rss`**: `State()` read the pointer field with no lock while `SetRuntimeStateStore` wrote it under `m.mu`. Fixed by converting `m.rss` to `atomic.Pointer[coord.RuntimeStateStore]` + `m.stateCacheTTL` to `atomic.Int64` (nanos). `go test -race` confirms clean.
+2. **CRITICAL — `m.mu` held across a DB call**: `Pause()` and `Resume()` called `m.State()` while holding `m.mu`, which in cluster mode does a 2s DB read with the mutex locked — serialising the entire backplane event pipeline. Fixed by replacing `m.State()` with `loadState(&m.state)` (the in-process atomic is the authority on local pause initiation).
+3. **IMPORTANT — test coverage gap on `StatePausing` interleave**: `applyRemotePause`'s guard is `!= StateRunning` which correctly bails when local `Pause()` is mid-flight, but no test pinned this. Added `TestManager_ApplyRemotePause_NoOpDuringLocalPausing`.
+
+### Test coverage
+
+- `manager_cluster_test.go` — 9 cases covering applyRemotePause / applyRemoteResume / SubscribeBackplane / single-replica path / parseRuntimeState defaults.
+- `bus_cluster_test.go` (runstate + channels) — 4 cases each, including the **no-re-publish-on-remote-event** loop-prevention invariant.
+- All v0.11.x tests continue green. `go test -race ./... -count=1 -timeout 300s` clean.
+
+---
+
 ## What's in v0.12.2
 
 **Phase 3 of the v1.0 multi-replica HA capstone — cross-replica cancel + status.** Closes the most critical correctness gap from the audit: a cancel request that hits the wrong replica now reaches the run via the backplane. Single-replica deployments (`LOOMCYCLE_REPLICA_ID` unset) keep the v0.11.x behavior **byte-identical** — every new code path is gated behind cluster mode.

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1160,7 +1160,27 @@ func main() {
 		go cancelCoord.RunCancelSubscriber(bgCtx, srv.CancelRegistry())
 		go cancelCoord.RunAckSubscriber(bgCtx)
 
-		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify user_quotas=db-backed cancel_ack_timeout=%s", cfg.Env.ReplicaID, ackTimeout)
+		// v0.12.3 Phase 4: runstate + channel bus backplane fanout.
+		// Both buses were constructed earlier (lines ~1003/1012) and
+		// wired into the server via SetRunStateBus / SetChannelBus.
+		// Here we add the cluster-mode fanout: every local Publish/
+		// Notify also goes onto the backplane so remote replicas wake
+		// their local subscribers (PostgresBackplane self-filter
+		// prevents the originator from looping).
+		if rsb := srv.RunStateBus(); rsb != nil {
+			rsb.SetBackplane(bp)
+			if err := rsb.SubscribeBackplane(bgCtx, bp); err != nil {
+				log.Fatalf("coord: runstate bus subscribe: %v", err)
+			}
+		}
+		if cb := srv.ChannelBus(); cb != nil {
+			cb.SetBackplane(bp)
+			if err := cb.SubscribeBackplane(bgCtx, bp); err != nil {
+				log.Fatalf("coord: channel bus subscribe: %v", err)
+			}
+		}
+
+		log.Printf("coord: cluster mode active — replica_id=%s heartbeat=30s backplane=postgres-listen-notify user_quotas=db-backed cancel_ack_timeout=%s bus_fanout=on", cfg.Env.ReplicaID, ackTimeout)
 	}
 
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.
@@ -1215,6 +1235,40 @@ func main() {
 			log.Printf("pause: manager wired (default timeout=%s)", pauseDefault)
 		} else {
 			log.Printf("pause: manager wired (default timeout=%s)", pause.DefaultPauseTimeout)
+		}
+
+		// v0.12.3 Phase 4: cluster-wide pause/resume. The pause
+		// manager's cluster paths read/write a singleton runtime_state
+		// row + publish on `loomcycle.pause`. Only active in cluster
+		// mode; single-replica mode keeps the v0.11.x in-process path
+		// byte-identical.
+		if cfg.Env.ReplicaID != "" {
+			pgStoreForPause, ok := storeIface.(*storepostgres.Store)
+			if !ok {
+				log.Fatalf("coord: pause cluster wiring requires Postgres store (REPLICA_ID set + non-Postgres store — should have been caught by openStore)")
+			}
+			rss := coord.NewRuntimeStateStore(pgStoreForPause.Pool())
+			cacheTTL := time.Duration(cfg.Env.PauseCacheTTLMs) * time.Millisecond
+			pauseMgr.SetRuntimeStateStore(rss, cacheTTL)
+			// Reuse the same Backplane the cluster block constructed.
+			// We can't directly reference `bp` here because it's
+			// scoped to the cluster block above; instead read it via
+			// srv's existing wiring (SetCoord stashed it).
+			// Backplane is interface-typed; type-assert through the
+			// known-only path via a separate fetch.
+			//
+			// Simpler approach: rather than re-fetch, do the pause
+			// cluster wiring INSIDE the cluster block where `bp` is
+			// in scope. We can't because pauseMgr isn't constructed
+			// yet at that point. Solution: declare a package-private
+			// hook on Server to retrieve the backplane.
+			if bp := srv.Backplane(); bp != nil {
+				pauseMgr.SetBackplane(bp)
+				if err := pauseMgr.SubscribeBackplane(bgCtx, bp); err != nil {
+					log.Fatalf("coord: pause backplane subscribe: %v", err)
+				}
+				log.Printf("coord: cluster pause/resume wired (cache_ttl=%s)", cacheTTL)
+			}
 		}
 	}
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -409,6 +409,27 @@ func (s *Server) SetRunStateBus(b *runstate.Bus) {
 	s.runStateBus = b
 }
 
+// RunStateBus exposes the wired run-state bus for v0.12.3 Phase 4
+// main.go wiring of the cluster-mode backplane fanout. Returns nil
+// when the bus hasn't been set.
+func (s *Server) RunStateBus() *runstate.Bus {
+	return s.runStateBus
+}
+
+// Backplane exposes the wired v0.12.0 coord.Backplane for Phase 4's
+// pause manager wiring (which runs AFTER SetCoord so it can't see
+// the bp variable scoped to the cluster init block). Returns nil
+// when coord wasn't wired (single-replica mode).
+func (s *Server) Backplane() coord.Backplane {
+	return s.backplane
+}
+
+// ChannelBus exposes the wired channel bus for the same Phase 4
+// reason as RunStateBus. Returns nil when unwired.
+func (s *Server) ChannelBus() *channels.Bus {
+	return s.channelBus
+}
+
 // SetMCPServerDefTool wires the v0.9.x MCPServerDef substrate tool.
 // Without this call, Connector.MCPServerDef + POST /v1/_mcpserverdef
 // + the LoomCycle MCP meta-tool all refuse with "not configured".

--- a/internal/channels/bus.go
+++ b/internal/channels/bus.go
@@ -18,14 +18,33 @@ package channels
 
 import (
 	"context"
+	"encoding/json"
+	"log"
 	"sync"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 )
 
-// Bus is the in-process notification bus.
+// Bus is the in-process notification bus. v0.12.3 Phase 4 adds an
+// optional backplane fanout: when SetBackplane is called, every local
+// Notify ALSO publishes on `loomcycle.channel` so remote replicas'
+// SubscribeBackplane goroutine wakes their local Wait callers. The
+// PostgresBackplane self-filter prevents the originating replica
+// from looping.
 type Bus struct {
 	mu      sync.Mutex
 	waiters map[string][]chan struct{}
+
+	// bp is the cluster-mode backplane. Nil = single-replica mode.
+	bp coord.Backplane
+}
+
+// channelBackplaneEvent is the wire payload on `loomcycle.channel`.
+// Tiny — just the channel name; the receiving Bus re-queries its
+// store, same as the local Notify path.
+type channelBackplaneEvent struct {
+	Channel string `json:"channel"`
 }
 
 // NewBus returns a fresh, empty bus. Single instance per loomcycle
@@ -41,6 +60,24 @@ func NewBus() *Bus {
 // The publish path calls this AFTER the storage write commits, so
 // any waiter that wakes is guaranteed to find at least one new row.
 func (b *Bus) Notify(channel string) {
+	b.notifyLocal(channel)
+	// v0.12.3 Phase 4: cluster-mode fanout. Non-blocking — backplane
+	// errors are logged but never fail Notify.
+	b.mu.Lock()
+	bp := b.bp
+	b.mu.Unlock()
+	if bp != nil {
+		payload, _ := json.Marshal(channelBackplaneEvent{Channel: channel})
+		if err := bp.Publish(context.Background(), "loomcycle.channel", payload); err != nil {
+			log.Printf("channels: backplane publish failed for %s: %v", channel, err)
+		}
+	}
+}
+
+// notifyLocal is the v0.12.3 fan-out-to-local-waiters half of Notify.
+// Extracted so SubscribeBackplane can call it on remote events
+// WITHOUT triggering another backplane publish.
+func (b *Bus) notifyLocal(channel string) {
 	b.mu.Lock()
 	waiters := b.waiters[channel]
 	if len(waiters) == 0 {
@@ -59,6 +96,35 @@ func (b *Bus) Notify(channel string) {
 		default:
 		}
 	}
+}
+
+// SetBackplane installs the v0.12.3 Phase 4 cluster-mode fanout.
+// Nil-safe: calling with nil disables fanout.
+func (b *Bus) SetBackplane(bp coord.Backplane) {
+	b.mu.Lock()
+	b.bp = bp
+	b.mu.Unlock()
+}
+
+// SubscribeBackplane starts a goroutine that listens for remote
+// channel-notify events on `loomcycle.channel` and wakes local Wait
+// callers via notifyLocal. Exits on ctx.Done.
+func (b *Bus) SubscribeBackplane(ctx context.Context, bp coord.Backplane) error {
+	ch, err := bp.Subscribe(ctx, "loomcycle.channel")
+	if err != nil {
+		return err
+	}
+	go func() {
+		for evt := range ch {
+			var p channelBackplaneEvent
+			if err := json.Unmarshal(evt.Payload, &p); err != nil {
+				log.Printf("channels: malformed backplane event: %v", err)
+				continue
+			}
+			b.notifyLocal(p.Channel)
+		}
+	}()
+	return nil
 }
 
 // Wait blocks the caller until either:

--- a/internal/channels/bus_cluster_test.go
+++ b/internal/channels/bus_cluster_test.go
@@ -1,0 +1,96 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/coord"
+)
+
+type stubBackplane struct {
+	publishCount atomic.Int32
+	feedCh       chan coord.Event
+}
+
+func newStubBackplane() *stubBackplane {
+	return &stubBackplane{feedCh: make(chan coord.Event, 16)}
+}
+
+func (s *stubBackplane) Publish(_ context.Context, _ string, _ []byte) error {
+	s.publishCount.Add(1)
+	return nil
+}
+
+func (s *stubBackplane) Subscribe(_ context.Context, _ string) (<-chan coord.Event, error) {
+	return s.feedCh, nil
+}
+
+func (s *stubBackplane) Close() error { return nil }
+
+func TestBus_Notify_PublishesOnBackplane_WhenBPSet(t *testing.T) {
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	b.Notify("my-channel")
+	if bp.publishCount.Load() != 1 {
+		t.Errorf("backplane publishes = %d, want 1", bp.publishCount.Load())
+	}
+}
+
+func TestBus_Notify_NoBackplane_NoPublish(t *testing.T) {
+	// Single-replica path — no backplane interaction.
+	b := NewBus()
+	b.Notify("my-channel") // no panic on nil backplane
+}
+
+func TestBus_SubscribeBackplane_WakesLocalWaiters(t *testing.T) {
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	if err := b.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	// Start a Wait in a goroutine.
+	waited := make(chan bool, 1)
+	go func() {
+		waited <- b.Wait(context.Background(), "my-channel", time.Second)
+	}()
+	// Give Wait time to register.
+	time.Sleep(50 * time.Millisecond)
+
+	// Inject a backplane event.
+	payload, _ := json.Marshal(channelBackplaneEvent{Channel: "my-channel"})
+	bp.feedCh <- coord.Event{Topic: "loomcycle.channel", Payload: payload}
+
+	select {
+	case got := <-waited:
+		if !got {
+			t.Error("Wait returned false; expected true (woken by backplane event)")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait did not return — backplane event did not wake local waiter")
+	}
+}
+
+func TestBus_SubscribeBackplane_DoesNotRePublish(t *testing.T) {
+	// Same invariant as runstate.Bus: backplane-received events MUST
+	// NOT trigger another backplane publish (would loop).
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	if err := b.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	payload, _ := json.Marshal(channelBackplaneEvent{Channel: "x"})
+	bp.feedCh <- coord.Event{Topic: "loomcycle.channel", Payload: payload}
+	time.Sleep(150 * time.Millisecond)
+
+	if bp.publishCount.Load() != 0 {
+		t.Errorf("backplane re-publish detected (count=%d) — notifyLocal contract broken", bp.publishCount.Load())
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1037,6 +1037,15 @@ type Env struct {
 	// LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS.
 	PauseDefaultTimeoutMs int64
 
+	// PauseCacheTTLMs is the v0.12.3 Phase 4 TTL for the cluster-
+	// mode DB-backed pause-state cache in pause.Manager.State().
+	// Default 1000 (1s). Lower values reduce the maximum latency
+	// between a pause event and a remote replica seeing the state
+	// change; higher values reduce DB load. Only effective when
+	// LOOMCYCLE_REPLICA_ID is set. Env:
+	// LOOMCYCLE_PAUSE_CACHE_TTL_MS.
+	PauseCacheTTLMs int64
+
 	// MCPAllowPrivilegedTools — v0.8.15. When true, dynamically-
 	// registered agents may include Bash/Write/Edit in their
 	// allowed_tools. Default false: those three are stripped from
@@ -1701,6 +1710,16 @@ func Load(path string) (*Config, error) {
 			} else {
 				cfg.Env.MetricsSweepInterval = time.Duration(n) * time.Millisecond
 			}
+		}
+	}
+
+	// v0.12.3 Phase 4 pause-state cache TTL. Effective only when
+	// LOOMCYCLE_REPLICA_ID is set (cluster mode); single-replica
+	// pause.Manager skips the DB cache entirely.
+	cfg.Env.PauseCacheTTLMs = 1000 // default 1s
+	if v := os.Getenv("LOOMCYCLE_PAUSE_CACHE_TTL_MS"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.Env.PauseCacheTTLMs = n
 		}
 	}
 

--- a/internal/coord/runtime_state_store.go
+++ b/internal/coord/runtime_state_store.go
@@ -1,0 +1,77 @@
+package coord
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// RuntimeStateStore is the v0.12.3 Phase 4 read/write surface for
+// the cluster's pause state. Backed by the single-row runtime_state
+// table (id = 'singleton'). Every replica in cluster mode reads
+// here on its run-admission gate + iteration-boundary check (via
+// pause.Manager's 1s cache); only pause/resume callers write.
+//
+// Lives in the coord package alongside ReplicaStore + UserQuotaStore
+// — Postgres-only (SQLite refuses cluster mode), takes a pgxpool
+// directly (not the store.Store interface).
+type RuntimeStateStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewRuntimeStateStore(pool *pgxpool.Pool) *RuntimeStateStore {
+	return &RuntimeStateStore{pool: pool}
+}
+
+// Get reads the singleton state row. Returns ("running", 0, nil) if
+// the row doesn't exist (migration 0025 seeds it on first apply, so
+// this should never happen in practice; the defensive default keeps
+// the boot path resilient against an out-of-band migration rollback).
+func (s *RuntimeStateStore) Get(ctx context.Context) (state string, pausedRunsCount int, err error) {
+	err = s.pool.QueryRow(ctx, `
+		SELECT state, paused_runs_count
+		  FROM runtime_state
+		 WHERE id = 'singleton'
+	`).Scan(&state, &pausedRunsCount)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "running", 0, nil
+		}
+		return "", 0, fmt.Errorf("runtime_state get: %w", err)
+	}
+	return state, pausedRunsCount, nil
+}
+
+// Set writes the singleton row atomically. state must be one of
+// "running", "pausing", "paused"; validation is the caller's
+// responsibility (the schema has no CHECK constraint so we can add
+// states without a migration). paused_at is written when state is
+// "paused" and cleared otherwise.
+func (s *RuntimeStateStore) Set(ctx context.Context, state string, pausedRunsCount int) error {
+	if state == "" {
+		return errors.New("runtime_state: state is empty")
+	}
+	pausedAt := "NULL"
+	if state == "paused" {
+		pausedAt = "now()"
+	}
+	// pg_notify-style param substitution would need a CASE; simpler
+	// to splice the literal (pausedAt is a closed-set constant string
+	// from this function, not user input).
+	query := fmt.Sprintf(`
+		INSERT INTO runtime_state (id, state, state_changed_at, paused_at, paused_runs_count)
+		VALUES ('singleton', $1, now(), %s, $2)
+		ON CONFLICT (id) DO UPDATE
+		   SET state             = EXCLUDED.state,
+		       state_changed_at  = now(),
+		       paused_at         = %s,
+		       paused_runs_count = EXCLUDED.paused_runs_count
+	`, pausedAt, pausedAt)
+	if _, err := s.pool.Exec(ctx, query, state, pausedRunsCount); err != nil {
+		return fmt.Errorf("runtime_state set %s: %w", state, err)
+	}
+	return nil
+}

--- a/internal/pause/cluster_state.go
+++ b/internal/pause/cluster_state.go
@@ -1,0 +1,26 @@
+package pause
+
+// pauseBackplaneEvent is the wire payload published on
+// `loomcycle.pause` when a replica transitions to / from paused. The
+// `op` field discriminates pause vs resume so a single backplane
+// topic carries both transitions.
+type pauseBackplaneEvent struct {
+	Op string `json:"op"` // "pause" | "resume"
+}
+
+// parseRuntimeState converts the wire string form (stored in the
+// runtime_state.state column) back to a RuntimeState. Defaults to
+// StateRunning on unknown input — the safest fallback for an
+// out-of-band schema drift.
+func parseRuntimeState(s string) RuntimeState {
+	switch s {
+	case "running":
+		return StateRunning
+	case "pausing":
+		return StatePausing
+	case "paused":
+		return StatePaused
+	default:
+		return StateRunning
+	}
+}

--- a/internal/pause/manager.go
+++ b/internal/pause/manager.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
@@ -104,6 +105,33 @@ type Manager struct {
 	// Per-pause-call value overrides this if the operator supplies
 	// timeout_ms; this is the default used when omitted.
 	defaultTimeout time.Duration
+
+	// v0.12.3 Phase 4 — cluster-mode wiring. All nil in single-replica
+	// mode (LOOMCYCLE_REPLICA_ID unset); the manager runs exactly as
+	// v0.11.x with no DB-state reads, no backplane publishes.
+
+	// rss is the cluster-wide pause-state singleton store. State()
+	// reads it on the hot path (lock-free); SetRuntimeStateStore
+	// writes it. atomic.Pointer makes the read/write race-free —
+	// review-1 finding #1 caught the original plain-pointer race.
+	rss atomic.Pointer[coord.RuntimeStateStore]
+
+	// bp is the backplane for cross-replica pause/resume signals.
+	// Read inside Pause/Resume under m.mu (no race); SetBackplane
+	// writes under m.mu. State() never reads bp, so it stays a
+	// plain field (no atomic needed).
+	bp coord.Backplane
+
+	// stateCache is the 1s in-memory cache over rss.Get() so the
+	// hot-path State() call doesn't hit the DB on every loop
+	// iteration. Invalidated on backplane pause/resume receipt + on
+	// every local Pause/Resume.
+	stateCacheMu    sync.Mutex
+	stateCacheValue RuntimeState
+	stateCacheAt    time.Time
+	// stateCacheTTL is read by State() (lock-free) + written by
+	// SetRuntimeStateStore. atomic.Int64 (nanos) for race-free read.
+	stateCacheTTL atomic.Int64
 }
 
 // toolEntry holds the per-tool-call cancellation handle. Manager-
@@ -135,13 +163,140 @@ func NewManager(s store.Store, timeout time.Duration) *Manager {
 	return m
 }
 
-// State returns the current RuntimeState. Lock-free atomic read; safe
-// to call from any goroutine including the loop's hot path.
+// State returns the current RuntimeState. Lock-free atomic read in
+// single-replica mode; 1s-cached DB read in cluster mode so any
+// replica converges on the cluster-wide state within the cache TTL.
+// Safe to call from any goroutine including the loop's hot path.
 func (m *Manager) State() RuntimeState {
 	if m == nil {
 		return StateRunning
 	}
-	return loadState(&m.state)
+	rss := m.rss.Load() // atomic.Pointer load — race-free
+	if rss == nil {
+		// Single-replica mode: v0.11.x in-process atomic.
+		return loadState(&m.state)
+	}
+	ttl := time.Duration(m.stateCacheTTL.Load())
+	// Cluster mode: serve from cache (TTL nanos), refresh on miss.
+	m.stateCacheMu.Lock()
+	if !m.stateCacheAt.IsZero() && time.Since(m.stateCacheAt) < ttl {
+		v := m.stateCacheValue
+		m.stateCacheMu.Unlock()
+		return v
+	}
+	m.stateCacheMu.Unlock()
+	// Refresh outside the cache lock so a slow DB doesn't serialise
+	// every State() caller. 2s timeout — a longer DB hiccup should
+	// surface as a fallback to the in-process atomic, not block the
+	// caller indefinitely.
+	rctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stateStr, _, err := rss.Get(rctx)
+	if err != nil {
+		log.Printf("pause: RuntimeStateStore.Get failed (serving in-process state): %v", err)
+		return loadState(&m.state)
+	}
+	parsed := parseRuntimeState(stateStr)
+	m.state.Store(int32(parsed))
+	m.stateCacheMu.Lock()
+	m.stateCacheValue = parsed
+	m.stateCacheAt = time.Now()
+	m.stateCacheMu.Unlock()
+	return parsed
+}
+
+// SetRuntimeStateStore installs the v0.12.3 cluster-wide pause-state
+// store + the 1s cache TTL. Called once from main.go inside the
+// cluster-mode init block. Single-replica deployments never call this
+// and the manager behaves identically to v0.11.x.
+func (m *Manager) SetRuntimeStateStore(rss *coord.RuntimeStateStore, cacheTTL time.Duration) {
+	if cacheTTL <= 0 {
+		cacheTTL = 1 * time.Second
+	}
+	// Atomic writes — State() reads both fields lock-free.
+	m.stateCacheTTL.Store(int64(cacheTTL))
+	m.rss.Store(rss)
+}
+
+// SetBackplane installs the cluster-mode signal bus. When set,
+// Pause/Resume publish on `loomcycle.pause` so remote replicas can
+// apply the transition. Called once from main.go.
+func (m *Manager) SetBackplane(bp coord.Backplane) {
+	m.mu.Lock()
+	m.bp = bp
+	m.mu.Unlock()
+}
+
+// SubscribeBackplane starts the goroutine that listens for remote
+// pause/resume events on `loomcycle.pause` and applies them locally
+// via applyRemotePause / applyRemoteResume. The goroutine exits on
+// ctx.Done. Backplane's reconnect-on-drop logic carries the wire-
+// reliability concern; this goroutine only handles event dispatch.
+func (m *Manager) SubscribeBackplane(ctx context.Context, bp coord.Backplane) error {
+	ch, err := bp.Subscribe(ctx, "loomcycle.pause")
+	if err != nil {
+		return fmt.Errorf("pause: subscribe to loomcycle.pause: %w", err)
+	}
+	go func() {
+		for evt := range ch {
+			var p pauseBackplaneEvent
+			if err := json.Unmarshal(evt.Payload, &p); err != nil {
+				log.Printf("pause: malformed backplane event: %v", err)
+				continue
+			}
+			switch p.Op {
+			case "pause":
+				m.applyRemotePause()
+			case "resume":
+				m.applyRemoteResume()
+			default:
+				log.Printf("pause: unknown backplane op %q", p.Op)
+			}
+		}
+	}()
+	return nil
+}
+
+// applyRemotePause is called by the SubscribeBackplane goroutine when
+// another replica publishes a pause event. Transitions THIS replica's
+// in-process state to StatePaused (skipping pausing — the originating
+// replica already did the tool drain), closes the local pauseCh so
+// the loop's iteration-boundary check sees the pause, and invalidates
+// the state cache.
+//
+// Idempotent: a replica already at StatePaused ignores the event.
+func (m *Manager) applyRemotePause() {
+	m.mu.Lock()
+	if loadState(&m.state) != StateRunning {
+		m.mu.Unlock()
+		return
+	}
+	m.state.Store(int32(StatePaused))
+	close(m.pauseCh)
+	m.mu.Unlock()
+
+	m.stateCacheMu.Lock()
+	m.stateCacheAt = time.Time{}
+	m.stateCacheMu.Unlock()
+	log.Printf("pause: cluster pause signal received — local state → paused")
+}
+
+// applyRemoteResume mirrors applyRemotePause for the resume direction.
+// Allocates a fresh pauseCh so the next pause has a clean signal.
+func (m *Manager) applyRemoteResume() {
+	m.mu.Lock()
+	if loadState(&m.state) == StateRunning {
+		m.mu.Unlock()
+		return
+	}
+	m.pauseCh = make(chan struct{})
+	m.state.Store(int32(StateRunning))
+	m.mu.Unlock()
+
+	m.stateCacheMu.Lock()
+	m.stateCacheAt = time.Time{}
+	m.stateCacheMu.Unlock()
+	log.Printf("pause: cluster resume signal received — local state → running")
 }
 
 // PauseCh returns the channel the loop's iteration-boundary check
@@ -268,15 +423,44 @@ func (m *Manager) Pause(ctx context.Context, timeout time.Duration) (PauseResult
 	}
 
 	m.mu.Lock()
-	if m.State() != StateRunning {
+	// Use loadState (in-process atomic) instead of m.State() — Pause
+	// is the authority on whether a LOCAL pause is already in flight,
+	// not the cluster-wide DB state. m.State() in cluster mode would
+	// do a DB read while holding m.mu, serialising the entire
+	// SubscribeBackplane pipeline for the duration. Review-1 #2.
+	if loadState(&m.state) != StateRunning {
+		state := loadState(&m.state)
 		m.mu.Unlock()
-		return PauseResult{State: m.State().String()}, ErrAlreadyPausing
+		return PauseResult{State: state.String()}, ErrAlreadyPausing
 	}
 	m.state.Store(int32(StatePausing))
 	// Close the broadcast channel under the lock so concurrent
 	// PauseCh() callers observe a consistent (state, channel) pair.
 	close(m.pauseCh)
+	bp := m.bp
 	m.mu.Unlock()
+	rss := m.rss.Load()
+
+	// v0.12.3 Phase 4: cluster mode — write DB state + publish on
+	// backplane so remote replicas transition into pausing/paused
+	// within the cache-TTL window. Errors are logged but not fatal:
+	// the local pause still proceeds + the local tool drain still
+	// runs. A remote replica that misses the publish will eventually
+	// converge via the next cache refresh (≤ TTL).
+	if rss != nil {
+		rctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := rss.Set(rctx, "pausing", 0); err != nil {
+			log.Printf("pause: rss.Set(pausing) failed: %v (continuing in-process only)", err)
+		}
+		cancel()
+	}
+	if bp != nil {
+		payload, _ := json.Marshal(pauseBackplaneEvent{Op: "pause"})
+		if err := bp.Publish(context.Background(), "loomcycle.pause", payload); err != nil {
+			log.Printf("pause: backplane publish(pause) failed: %v", err)
+		}
+	}
+	m.invalidateStateCache()
 
 	// Apply per-tool cancel policy. Idempotent → cancel immediately;
 	// non-idempotent / external → leave running, deadline applied
@@ -351,11 +535,21 @@ func (m *Manager) forceCancelRemaining(mu *sync.Mutex, counter *int) {
 	})
 }
 
+// invalidateStateCache forces the next State() call in cluster mode
+// to re-read from the DB. Called after every local state change so
+// concurrent State() callers don't see a stale cached value.
+func (m *Manager) invalidateStateCache() {
+	m.stateCacheMu.Lock()
+	m.stateCacheAt = time.Time{}
+	m.stateCacheMu.Unlock()
+}
+
 // finalizePause transitions to StatePaused, queries the count of
 // runs that committed pause_state='paused' to the DB, and assembles
 // the PauseResult payload.
 func (m *Manager) finalizePause(start time.Time, forceCancel, idempotentCount int, warnings []string) PauseResult {
 	m.state.Store(int32(StatePaused))
+	m.invalidateStateCache()
 
 	paused, err := m.store.ListPausedRuns(context.Background())
 	pausedCount := 0
@@ -364,6 +558,18 @@ func (m *Manager) finalizePause(start time.Time, forceCancel, idempotentCount in
 		warnings = append(warnings, "could not enumerate paused runs (state still transitioned to paused)")
 	} else {
 		pausedCount = len(paused)
+	}
+
+	// v0.12.3 cluster-mode: write final state + cluster-wide paused
+	// count to the singleton row so remote /v1/_state reads see the
+	// authoritative cluster value (not just this replica's view).
+	if rss := m.rss.Load(); rss != nil {
+		rctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		if err := rss.Set(rctx, "paused", pausedCount); err != nil {
+			log.Printf("pause: rss.Set(paused) failed: %v", err)
+			warnings = append(warnings, fmt.Sprintf("rss.Set(paused) failed: %v", err))
+		}
+		cancel()
 	}
 
 	if idempotentCount > 0 {
@@ -396,8 +602,10 @@ func (m *Manager) Resume(ctx context.Context) (ResumeResult, error) {
 		return ResumeResult{}, errors.New("resume: nil Manager")
 	}
 	m.mu.Lock()
-	if m.State() != StatePaused {
-		st := m.State().String()
+	// loadState — see the Pause() comment about avoiding m.State()
+	// under m.mu in cluster mode (review-1 #2).
+	if loadState(&m.state) != StatePaused {
+		st := loadState(&m.state).String()
 		m.mu.Unlock()
 		return ResumeResult{State: st}, ErrNotPaused
 	}
@@ -406,7 +614,27 @@ func (m *Manager) Resume(ctx context.Context) (ResumeResult, error) {
 	// through their select-default branch on the next iteration.
 	m.pauseCh = make(chan struct{})
 	m.state.Store(int32(StateRunning))
+	bp := m.bp
 	m.mu.Unlock()
+	rss := m.rss.Load()
+	m.invalidateStateCache()
+
+	// v0.12.3 Phase 4: cluster mode — write DB state back to running
+	// and publish on backplane so remote replicas re-allow new runs
+	// + new tool dispatches.
+	if rss != nil {
+		rctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		if err := rss.Set(rctx, "running", 0); err != nil {
+			log.Printf("resume: rss.Set(running) failed: %v", err)
+		}
+		cancel()
+	}
+	if bp != nil {
+		payload, _ := json.Marshal(pauseBackplaneEvent{Op: "resume"})
+		if err := bp.Publish(context.Background(), "loomcycle.pause", payload); err != nil {
+			log.Printf("resume: backplane publish(resume) failed: %v", err)
+		}
+	}
 
 	paused, err := m.store.ListPausedRuns(ctx)
 	if err != nil {

--- a/internal/pause/manager_cluster_test.go
+++ b/internal/pause/manager_cluster_test.go
@@ -1,0 +1,208 @@
+package pause
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/coord"
+)
+
+// stubBackplane is the in-process backplane fake for Phase 4 unit
+// tests. Records every Publish + lets tests inject events via a
+// per-topic Subscribe channel.
+type stubBackplane struct {
+	published atomic.Int32
+	mu        chan coord.Event
+}
+
+func newStubBackplane() *stubBackplane {
+	return &stubBackplane{mu: make(chan coord.Event, 16)}
+}
+
+func (s *stubBackplane) Publish(_ context.Context, _ string, payload []byte) error {
+	s.published.Add(1)
+	return nil
+}
+
+func (s *stubBackplane) Subscribe(ctx context.Context, _ string) (<-chan coord.Event, error) {
+	// Return the stub channel; tests inject events by writing to s.mu.
+	return s.mu, nil
+}
+
+func (s *stubBackplane) Close() error { return nil }
+
+func TestManager_ApplyRemotePause_TransitionsLocalState(t *testing.T) {
+	m := NewManager(nil, 0)
+	if m.State() != StateRunning {
+		t.Fatalf("initial state = %s, want running", m.State())
+	}
+
+	m.applyRemotePause()
+
+	// applyRemotePause skips StatePausing and goes straight to
+	// StatePaused (the originating replica already drained tools).
+	if m.State() != StatePaused {
+		t.Errorf("after applyRemotePause: state = %s, want paused", m.State())
+	}
+	// pauseCh should be closed so a select observer fires immediately.
+	select {
+	case <-m.PauseCh():
+	case <-time.After(100 * time.Millisecond):
+		t.Error("pauseCh not closed by applyRemotePause")
+	}
+}
+
+func TestManager_ApplyRemotePause_IdempotentWhenAlreadyPaused(t *testing.T) {
+	m := NewManager(nil, 0)
+	m.applyRemotePause()
+	// Second call — should not panic (close-of-closed-chan would).
+	m.applyRemotePause()
+	if m.State() != StatePaused {
+		t.Errorf("state after double pause = %s, want paused", m.State())
+	}
+}
+
+// TestManager_ApplyRemotePause_NoOpDuringLocalPausing pins review-1
+// finding #3: applyRemotePause's guard is `!= StateRunning`, so it
+// also bails when this replica's own Pause() is mid-flight in
+// StatePausing. Without the guard, the second close(pauseCh) inside
+// applyRemotePause would panic.
+func TestManager_ApplyRemotePause_NoOpDuringLocalPausing(t *testing.T) {
+	m := NewManager(nil, 0)
+	// Simulate "local Pause() is in flight" by setting state to
+	// StatePausing + closing pauseCh, as Pause() does under m.mu.
+	m.state.Store(int32(StatePausing))
+	close(m.pauseCh)
+	// Now applyRemotePause must NOT close pauseCh again (panic) AND
+	// must NOT change state away from StatePausing.
+	m.applyRemotePause()
+	if m.State() != StatePausing {
+		t.Errorf("state was clobbered: %s, want still pausing", m.State())
+	}
+}
+
+func TestManager_ApplyRemoteResume_ReopensPauseCh(t *testing.T) {
+	m := NewManager(nil, 0)
+	m.applyRemotePause()
+	if m.State() != StatePaused {
+		t.Fatal("setup: should be paused")
+	}
+
+	prevCh := m.PauseCh()
+	m.applyRemoteResume()
+	if m.State() != StateRunning {
+		t.Errorf("after applyRemoteResume: state = %s, want running", m.State())
+	}
+	newCh := m.PauseCh()
+	if prevCh == newCh {
+		t.Error("applyRemoteResume should allocate a fresh pauseCh; same channel returned")
+	}
+}
+
+func TestManager_SubscribeBackplane_DispatchesPauseEvent(t *testing.T) {
+	m := NewManager(nil, 0)
+	bp := newStubBackplane()
+	if err := m.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("SubscribeBackplane: %v", err)
+	}
+
+	// Inject a pause event.
+	payload, _ := json.Marshal(pauseBackplaneEvent{Op: "pause"})
+	bp.mu <- coord.Event{Topic: "loomcycle.pause", Payload: payload}
+
+	// Goroutine processes asynchronously; poll.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if m.State() == StatePaused {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if m.State() != StatePaused {
+		t.Errorf("backplane pause event not dispatched; state = %s", m.State())
+	}
+}
+
+func TestManager_SubscribeBackplane_MalformedEventIgnored(t *testing.T) {
+	m := NewManager(nil, 0)
+	bp := newStubBackplane()
+	if err := m.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Malformed JSON — logged + skipped.
+	bp.mu <- coord.Event{Topic: "loomcycle.pause", Payload: []byte("not json")}
+	// Unknown op — logged + skipped.
+	payload, _ := json.Marshal(pauseBackplaneEvent{Op: "neither"})
+	bp.mu <- coord.Event{Topic: "loomcycle.pause", Payload: payload}
+	time.Sleep(100 * time.Millisecond)
+	if m.State() != StateRunning {
+		t.Errorf("malformed events should not transition state; got %s", m.State())
+	}
+}
+
+func TestManager_State_SingleReplicaPathUnchanged(t *testing.T) {
+	// With no SetRuntimeStateStore call, the Manager must hit the
+	// in-process atomic path — no DB, no cache. This pins the
+	// back-compat invariant for v0.11.x deployments.
+	m := NewManager(nil, 0)
+	// State() should return atomically without touching m.rss (nil).
+	got := m.State()
+	if got != StateRunning {
+		t.Errorf("single-replica State() = %s, want running", got)
+	}
+	// Force into pausing via atomic store directly and verify State()
+	// reads from atomic.
+	m.state.Store(int32(StatePausing))
+	if got := m.State(); got != StatePausing {
+		t.Errorf("single-replica State() = %s, want pausing", got)
+	}
+}
+
+func TestParseRuntimeState(t *testing.T) {
+	cases := map[string]RuntimeState{
+		"running": StateRunning,
+		"pausing": StatePausing,
+		"paused":  StatePaused,
+		"":        StateRunning, // defensive
+		"garbage": StateRunning, // defensive
+	}
+	for input, want := range cases {
+		if got := parseRuntimeState(input); got != want {
+			t.Errorf("parseRuntimeState(%q) = %s, want %s", input, got, want)
+		}
+	}
+}
+
+// Sentinel: applyRemoteResume from StateRunning is a no-op.
+func TestManager_ApplyRemoteResume_NoOpWhenAlreadyRunning(t *testing.T) {
+	m := NewManager(nil, 0)
+	prevCh := m.PauseCh()
+	m.applyRemoteResume() // already running
+	if m.PauseCh() != prevCh {
+		t.Error("applyRemoteResume on already-running should NOT replace pauseCh")
+	}
+	if m.State() != StateRunning {
+		t.Errorf("state = %s, want running", m.State())
+	}
+}
+
+// Sentinel: SubscribeBackplane returns the subscribe error.
+type errBackplane struct{ err error }
+
+func (e *errBackplane) Publish(context.Context, string, []byte) error { return nil }
+func (e *errBackplane) Subscribe(context.Context, string) (<-chan coord.Event, error) {
+	return nil, e.err
+}
+func (e *errBackplane) Close() error { return nil }
+
+func TestManager_SubscribeBackplane_PropagatesSubscribeError(t *testing.T) {
+	m := NewManager(nil, 0)
+	want := errors.New("simulated")
+	if err := m.SubscribeBackplane(context.Background(), &errBackplane{err: want}); err == nil {
+		t.Fatal("expected subscribe error to propagate")
+	}
+}

--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -23,9 +23,14 @@
 package runstate
 
 import (
+	"context"
+	"encoding/json"
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 )
 
 // RunStateEvent is the payload published on every run state transition.
@@ -56,11 +61,20 @@ func (s *subscription) DroppedEvents() int64 {
 	return atomic.LoadInt64(&s.dropped)
 }
 
-// Bus is the in-process run-state pub/sub.
+// Bus is the in-process run-state pub/sub. v0.12.3 Phase 4 adds an
+// optional backplane fanout: when SetBackplane is called, every local
+// Publish ALSO publishes on `loomcycle.runstate` so remote replicas'
+// SubscribeBackplane goroutine wakes their local subscribers. The
+// PostgresBackplane self-filter prevents the originating replica from
+// receiving its own NOTIFY.
 type Bus struct {
 	mu         sync.Mutex
 	byUser     map[string][]*subscription
 	bufferSize int
+
+	// bp is the cluster-mode backplane. Nil = single-replica mode
+	// (v0.11.x behavior unchanged — local-only publish).
+	bp coord.Backplane
 }
 
 // NewBus returns a fresh, empty bus. Single instance per loomcycle
@@ -134,13 +148,34 @@ func (b *Bus) Subscribe(userID string) *Subscription {
 // Idempotent + safe to call from any goroutine, including the request
 // handler goroutine.
 func (b *Bus) Publish(evt RunStateEvent) {
+	b.publishLocal(evt)
+	// v0.12.3 Phase 4: cluster-mode fanout. Non-blocking — backplane
+	// errors are logged but never fail Publish (a local subscriber on
+	// THIS replica already received the event; cross-replica delivery
+	// is best-effort).
+	b.mu.Lock()
+	bp := b.bp
+	b.mu.Unlock()
+	if bp != nil {
+		if payload, err := json.Marshal(evt); err == nil {
+			if pubErr := bp.Publish(context.Background(), "loomcycle.runstate", payload); pubErr != nil {
+				log.Printf("runstate: backplane publish failed: %v", pubErr)
+			}
+		}
+	}
+}
+
+// publishLocal is the v0.12.3 fan-out-to-local-subscribers half of
+// Publish. Extracted so SubscribeBackplane can call it on remote
+// events WITHOUT triggering another backplane publish (which would
+// loop). The PostgresBackplane self-filter already prevents the
+// originating replica from looping, but the dedicated entry point
+// keeps the no-re-publish invariant explicit.
+func (b *Bus) publishLocal(evt RunStateEvent) {
 	if evt.TS.IsZero() {
 		evt.TS = time.Now().UTC()
 	}
 	b.mu.Lock()
-	// Build a snapshot of matching subscriptions while holding the
-	// lock; do the actual sends outside the lock so a slow channel
-	// doesn't serialize publishers.
 	matches := make([]*subscription, 0, len(b.byUser[evt.UserID])+len(b.byUser[""]))
 	matches = append(matches, b.byUser[evt.UserID]...)
 	if evt.UserID != "" {
@@ -155,6 +190,37 @@ func (b *Bus) Publish(evt RunStateEvent) {
 			atomic.AddInt64(&sub.dropped, 1)
 		}
 	}
+}
+
+// SetBackplane installs the v0.12.3 Phase 4 cluster-mode fanout.
+// When set, every Publish ALSO publishes on `loomcycle.runstate`.
+// Nil-safe: calling with nil disables fanout (e.g. for tests).
+func (b *Bus) SetBackplane(bp coord.Backplane) {
+	b.mu.Lock()
+	b.bp = bp
+	b.mu.Unlock()
+}
+
+// SubscribeBackplane starts a goroutine that listens for remote
+// run-state events on `loomcycle.runstate` and fans them out to
+// local subscribers via publishLocal (which does NOT re-publish on
+// the backplane). Exits on ctx.Done.
+func (b *Bus) SubscribeBackplane(ctx context.Context, bp coord.Backplane) error {
+	ch, err := bp.Subscribe(ctx, "loomcycle.runstate")
+	if err != nil {
+		return err
+	}
+	go func() {
+		for evt := range ch {
+			var rs RunStateEvent
+			if err := json.Unmarshal(evt.Payload, &rs); err != nil {
+				log.Printf("runstate: malformed backplane event: %v", err)
+				continue
+			}
+			b.publishLocal(rs)
+		}
+	}()
+	return nil
 }
 
 // unsubscribe is called by Subscription.Close. Removes the

--- a/internal/runstate/bus_cluster_test.go
+++ b/internal/runstate/bus_cluster_test.go
@@ -1,0 +1,124 @@
+package runstate
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/coord"
+)
+
+type stubBackplane struct {
+	publishCount atomic.Int32
+	lastTopic    atomic.Value // string
+	feedCh       chan coord.Event
+}
+
+func newStubBackplane() *stubBackplane {
+	return &stubBackplane{feedCh: make(chan coord.Event, 16)}
+}
+
+func (s *stubBackplane) Publish(_ context.Context, topic string, _ []byte) error {
+	s.publishCount.Add(1)
+	s.lastTopic.Store(topic)
+	return nil
+}
+
+func (s *stubBackplane) Subscribe(_ context.Context, _ string) (<-chan coord.Event, error) {
+	return s.feedCh, nil
+}
+
+func (s *stubBackplane) Close() error { return nil }
+
+func TestBus_Publish_FanoutsToBackplane_WhenBPSet(t *testing.T) {
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	sub := b.Subscribe("alice")
+	defer sub.Close()
+
+	b.Publish(RunStateEvent{RunID: "r1", UserID: "alice", Status: "completed"})
+	// Local delivery
+	select {
+	case evt := <-sub.C:
+		if evt.RunID != "r1" {
+			t.Errorf("local delivery: RunID = %q, want r1", evt.RunID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no local delivery")
+	}
+	// Backplane publish (async w.r.t the local delivery but happens
+	// before Publish returns).
+	if bp.publishCount.Load() != 1 {
+		t.Errorf("backplane publishes = %d, want 1", bp.publishCount.Load())
+	}
+	if got := bp.lastTopic.Load(); got != "loomcycle.runstate" {
+		t.Errorf("topic = %v, want loomcycle.runstate", got)
+	}
+}
+
+func TestBus_Publish_NoBackplane_LocalOnly(t *testing.T) {
+	// Single-replica: bp nil → no backplane Publish. v0.11.x invariant.
+	b := NewBus()
+	sub := b.Subscribe("alice")
+	defer sub.Close()
+
+	b.Publish(RunStateEvent{RunID: "r2", UserID: "alice", Status: "completed"})
+	select {
+	case <-sub.C:
+	case <-time.After(time.Second):
+		t.Fatal("no local delivery")
+	}
+	// No backplane => no publish to count, and no panic from a nil
+	// dereference.
+}
+
+func TestBus_SubscribeBackplane_DeliversRemoteEvents(t *testing.T) {
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	if err := b.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("SubscribeBackplane: %v", err)
+	}
+	sub := b.Subscribe("alice")
+	defer sub.Close()
+
+	// Inject a backplane event (simulating a remote replica publish).
+	remoteEvt := RunStateEvent{RunID: "r3", UserID: "alice", Status: "completed"}
+	payload, _ := json.Marshal(remoteEvt)
+	bp.feedCh <- coord.Event{Topic: "loomcycle.runstate", Payload: payload}
+
+	select {
+	case evt := <-sub.C:
+		if evt.RunID != "r3" {
+			t.Errorf("got RunID %q, want r3", evt.RunID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("backplane event did not wake local subscriber")
+	}
+}
+
+func TestBus_SubscribeBackplane_DoesNotRePublish(t *testing.T) {
+	// Critical invariant: events received on backplane MUST NOT be
+	// re-published on backplane (would loop). publishLocal is the
+	// in-package no-republish path.
+	b := NewBus()
+	bp := newStubBackplane()
+	b.SetBackplane(bp)
+	if err := b.SubscribeBackplane(context.Background(), bp); err != nil {
+		t.Fatalf("SubscribeBackplane: %v", err)
+	}
+
+	remoteEvt := RunStateEvent{RunID: "r4", UserID: "alice", Status: "completed"}
+	payload, _ := json.Marshal(remoteEvt)
+	bp.feedCh <- coord.Event{Topic: "loomcycle.runstate", Payload: payload}
+	time.Sleep(200 * time.Millisecond)
+
+	// publishCount must stay 0 — the backplane subscriber calls
+	// publishLocal, not Publish.
+	if bp.publishCount.Load() != 0 {
+		t.Errorf("backplane re-publish detected (count=%d) — publishLocal contract broken", bp.publishCount.Load())
+	}
+}

--- a/internal/store/postgres/migrations/0025_runtime_state.down.sql
+++ b/internal/store/postgres/migrations/0025_runtime_state.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS runtime_state;

--- a/internal/store/postgres/migrations/0025_runtime_state.up.sql
+++ b/internal/store/postgres/migrations/0025_runtime_state.up.sql
@@ -1,0 +1,22 @@
+-- v0.12.3 multi-replica HA Phase 4: cluster-wide pause/resume state.
+--
+-- Single-row table (id = 'singleton') holding the cluster's pause
+-- state. Every replica reads from here on its iteration-boundary
+-- check + run-admission 503 gate (through a 1s in-process cache).
+-- Backplane events ('loomcycle.pause' / 'loomcycle.resume') invalidate
+-- the cache for sub-second propagation.
+--
+-- Only used when LOOMCYCLE_REPLICA_ID is set. Single-replica installs
+-- ignore this table — Phase 4's pause.Manager only reads/writes
+-- when its RuntimeStateStore is non-nil.
+
+CREATE TABLE IF NOT EXISTS runtime_state (
+    id                  TEXT        PRIMARY KEY DEFAULT 'singleton',
+    state               TEXT        NOT NULL    DEFAULT 'running',
+    state_changed_at    TIMESTAMPTZ NOT NULL    DEFAULT now(),
+    paused_at           TIMESTAMPTZ,
+    paused_runs_count   INTEGER     NOT NULL    DEFAULT 0
+);
+
+-- Seed the singleton row so Get never has to handle the "no row" case.
+INSERT INTO runtime_state (id) VALUES ('singleton') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

Phase 4 of the v1.0 multi-replica HA capstone. Cluster-wide pause/resume + run-state + channel notification fanout. Single-replica mode (`LOOMCYCLE_REPLICA_ID` unset) **byte-identical** to v0.11.x.

## What ships

- **`runtime_state` table + migration 0025** — singleton row with state, state_changed_at, paused_at, paused_runs_count.
- **`coord.RuntimeStateStore`** — Get/Set on the row.
- **`pause.Manager` cluster-mode extension** — atomic.Pointer for rss, atomic.Int64 for cache TTL (lock-free hot-path reads); SubscribeBackplane goroutine listens on `loomcycle.pause`; Pause/Resume write to DB + publish on backplane; applyRemotePause/applyRemoteResume handle remote events with StatePausing guard.
- **`runstate.Bus` + `channels.Bus` backplane fanout** — Publish/Notify fan locally THEN backplane publish. SubscribeBackplane uses no-re-publish paths (`publishLocal` / `notifyLocal`) to prevent loops.
- **`LOOMCYCLE_PAUSE_CACHE_TTL_MS`** env var (default 1000ms).

## Code review (parallel agent) — 3 findings, all fixed pre-commit

1. **CRITICAL — data race on `m.rss`**: `State()` read the pointer field lock-free while `SetRuntimeStateStore` wrote it under `m.mu`. Fixed by `atomic.Pointer[coord.RuntimeStateStore]` + `atomic.Int64` for cache TTL. `go test -race` confirms clean.
2. **CRITICAL — `m.mu` held across a 2s DB call**: `Pause()`/`Resume()` called `m.State()` while holding `m.mu`, serialising the entire backplane event pipeline for the DB-read duration. Fixed by replacing `m.State()` with `loadState(&m.state)` — the in-process atomic is the authority on whether a local pause is already in flight.
3. **IMPORTANT — test coverage gap**: `applyRemotePause`'s `!= StateRunning` guard correctly handles `StatePausing` interleave but no test pinned it. Added `TestManager_ApplyRemotePause_NoOpDuringLocalPausing`.

## Test plan

- [x] `go build ./...` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1 -timeout 300s` all green
- [x] `go test -race ./... -count=1` clean (proves data race fix)
- [x] Smoke test: REPLICA_ID unset → boots normally, no new log lines, single-replica path identical to v0.11.x
- [ ] CI green on PR check
- [ ] Postgres-gated tests run locally via `LOOMCYCLE_TEST_PG_DSN` — green
- [ ] 2-replica live test: pause on A → B sees state=paused within 1s (cache TTL); SSE subscriber on B sees runs completed on A; Channel.publish on A wakes Wait on B

## Note on dependency

Branched independently from `main` (post-v0.12.1) like PRs #214 / #215 / #216 / this. Conflicts with prior phase PRs in main.go's cluster init block will be trivial 3-way merges at merge time.

## Remaining v0.12.x → v1.0 phases

| Phase | PR | Scope |
|---|---|---|
| 5 | v0.12.4 | Singleton sweepers via advisory locks + replicas TTL sweeper (closes Phase 2 + Phase 3 crash-safety gaps) |
| 6 | v0.12.5 | Session-lock + hook-registry → DB-backed |
| 7 | v0.12.6 | Hardening + docs + **tag v1.0** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)