### PR TITLE
docs(README): align "What it is" lead with header positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What it is
 
-**A sidecar for the agentic loop.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it. Your app calls loomcycle over HTTP, gRPC, MCP, or via the TypeScript adapter; the agent loop, multi-provider routing, memory and channel primitives, MCP server identity, OpenTelemetry traces, and multi-replica coordination all live in the binary. Your application stays in whatever language you wrote it in.
+**The Agentic OS, in a sidecar.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it. Your app calls loomcycle over HTTP, gRPC, MCP, or via the TypeScript adapter; the agent loop, multi-provider routing, memory and channel primitives, MCP server identity, OpenTelemetry traces, and multi-replica coordination all live in the binary. Your application stays in whatever language you wrote it in.
 
 **The shape that's different.** The agentic-systems market today gives you three choices — embed a Python or TypeScript library inside your process, rent a managed cloud service tied to one vendor's IAM, or proxy your model calls through a gateway that doesn't actually run agents. loomcycle is the fourth shape: a lightweight self-hostable runtime that owns the loop *and* speaks every wire format your stack already uses.
 


### PR DESCRIPTION
## Summary

One-line fix: the README header tagline reads *"The Agentic OS, in a sidecar."* but the **What it is** section's lead sentence said *"A sidecar for the agentic loop."* — two different ways of saying overlapping things, sitting directly above one another. Reads as inconsistent positioning to a first-time visitor.

Restate the **What it is** lead with the same phrase as the header so the brand identity is consistent between the visible-above-the-fold tagline and the first body paragraph.

## Diff

```diff
 ## What it is

-**A sidecar for the agentic loop.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it.
+**The Agentic OS, in a sidecar.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)