### PR TITLE
docs: add BACKERS.md + README pointer

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,0 +1,69 @@
+# Backers
+
+Thank you to the individuals and companies who support loomcycle on GitHub Sponsors. This list is the canonical, machine-readable record; the human-friendly version with logos lives at **[loomcycle.dev/sponsors](https://loomcycle.dev/sponsors)**.
+
+If you'd like to support continued development, see **[github.com/sponsors/denn-gubsky](https://github.com/sponsors/denn-gubsky)**. The runtime stays Apache-2.0 either way — sponsorships fund the maintenance and the operator surface, they are not a precondition for using the OSS.
+
+---
+
+## Enterprise sponsors — $500 / month
+
+Companies running loomcycle in production.
+
+<!-- Add new entries below this comment in reverse-chronological order
+     (newest first). Format: `- **[Company Name](https://example.com)** —
+     joined YYYY-MM` -->
+
+*No enterprise sponsors yet. Could be yours — see [Enterprise tier on GitHub Sponsors](https://github.com/sponsors/denn-gubsky).*
+
+---
+
+## Team sponsors — $100 / month
+
+Teams depending on loomcycle.
+
+<!-- Add new entries below this comment. Format:
+     `- **[Team / Org Name](https://example.com)** — joined YYYY-MM` -->
+
+*No team sponsors yet.*
+
+---
+
+## Patron sponsors — $25 / month
+
+Solo founders, indie devs, and small teams.
+
+<!-- Add new entries below this comment. Format:
+     `- **[Name](https://github.com/handle)** — joined YYYY-MM` -->
+
+*No patron sponsors yet.*
+
+---
+
+## Supporter sponsors — $5 / month
+
+<!-- Add new entries below this comment. Format:
+     `- [@handle](https://github.com/handle)` -->
+
+*No supporter sponsors yet.*
+
+---
+
+## One-time supporters — Coffee tier
+
+A one-time tip rather than a recurring subscription.
+
+<!-- Add new entries below this comment. Format:
+     `- [@handle](https://github.com/handle) — YYYY-MM` -->
+
+*No one-time supporters yet.*
+
+---
+
+## Notes
+
+- **Listed by default:** sponsors are added to this list within a few days of their subscription starting (or, for one-time supporters, within a few days of receipt). Names appear under the tier they sponsor at.
+- **Anonymous / removal:** want to be listed differently, or appear anonymously, or be removed entirely? Email [denn@loomcycle.dev](mailto:denn@loomcycle.dev) and the next update of this file will reflect your preference.
+- **Past sponsors:** when a recurring sponsorship lapses, the sponsor's name remains in this file (in the tier they sponsored at) for one year as a thank-you, then moves to a `## Past supporters` section at the bottom. The default is *"once a sponsor, listed for a while."*
+- **No vendor implications:** appearance in this list is recognition for a sponsorship transaction. It does not imply that the sponsor uses loomcycle, endorses loomcycle, or has any commercial relationship with loomcycle's maintainers beyond the sponsorship itself.
+- **Updates:** this file is maintained by the project maintainer. Pull requests adding sponsor names are not the right channel — those go through the GitHub Sponsors flow. PRs fixing typos or adjusting metadata are welcome.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ If loomcycle is useful to you or your team, [GitHub Sponsors](https://github.com
 
 The runtime stays Apache-2.0 either way. Sponsorships directly fund the v0.12 → v1.0 runway: multi-replica HA, Helm chart, operator cookbook, settings UI, and the per-tier sustained engineering needed to keep the binary small and the substrate stable.
 
+Current sponsors are listed in [`BACKERS.md`](BACKERS.md) (and at [loomcycle.dev/sponsors](https://loomcycle.dev/sponsors) with logos).
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Adds **BACKERS.md** as the canonical machine-readable list of sponsors and points the README Sponsor section at it.

- **BACKERS.md** — grouped by tier (Enterprise / Team / Patron / Supporter / one-time). Empty on launch with template comments showing the entry format for each tier. Includes a small "Notes" section covering the listing policy, anonymous/removal flow, past-sponsors handling, and the rule that PRs adding sponsor names are *not* the right channel (sponsor flow goes through GitHub Sponsors, not git).
- **README** Sponsor section gains a one-line pointer to BACKERS.md and to loomcycle.dev/sponsors (the human-friendly version with logos lives on the marketing site; this file is the canonical record).

## Why these two files instead of one

- **BACKERS.md** is a machine-readable file in the repo. Future tooling (badges, sponsor counters, automation) can parse it. It's where the canonical record lives.
- **loomcycle.dev/sponsors** is the same information presented for humans visiting the marketing site — sponsor logos on a card grid, friendly empty states, a clear CTA. Maintained in lockstep with this file. (That page lives in `loomcycle-internal/web/sponsors.html` — internal marketing repo, not in this repo.)

## Test plan

- [ ] BACKERS.md renders correctly on github.com after merge (tables, links, empty-state notes all readable).
- [ ] README Sponsor section now references BACKERS.md.
- [ ] Once a sponsor joins on github.com/sponsors/denn-gubsky, adding their name to BACKERS.md works via the template comments without re-reading conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)