### PR TITLE
feat(ui): show replica_id on running agents in the Web UI

### DIFF
--- a/internal/api/http/agent_tracking_test.go
+++ b/internal/api/http/agent_tracking_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -772,4 +773,30 @@ func waitForRegistry(t *testing.T, srv *Server, agentID string, within time.Dura
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("agent_id %q did not register within %s", agentID, within)
+}
+
+// TestRunToAgentResponse_ReplicaIDRoundTrip pins the wire contract for
+// the v0.12.x cluster-mode replica_id field: when the underlying run
+// row carries a ReplicaID it surfaces on the response (so the Web UI
+// can show which replica owns the run); when empty it's omitted from
+// JSON via `omitempty` (so single-replica deployments stay
+// uncluttered).
+func TestRunToAgentResponse_ReplicaIDRoundTrip(t *testing.T) {
+	t.Run("populated", func(t *testing.T) {
+		resp := runToAgentResponse(store.Run{ID: "r1", AgentID: "a1", ReplicaID: "replica-a"}, false)
+		if resp.ReplicaID != "replica-a" {
+			t.Errorf("ReplicaID = %q, want %q", resp.ReplicaID, "replica-a")
+		}
+		b, _ := json.Marshal(resp)
+		if !strings.Contains(string(b), `"replica_id":"replica-a"`) {
+			t.Errorf("JSON missing replica_id: %s", b)
+		}
+	})
+	t.Run("empty omitted from JSON", func(t *testing.T) {
+		resp := runToAgentResponse(store.Run{ID: "r2", AgentID: "a2"}, false)
+		b, _ := json.Marshal(resp)
+		if strings.Contains(string(b), "replica_id") {
+			t.Errorf("JSON should omit replica_id when empty: %s", b)
+		}
+	})
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3252,6 +3252,10 @@ type agentResponse struct {
 	//                  interruption kind (when state=interrupted)
 	AwaitedState string `json:"awaited_state,omitempty"`
 	AwaitedOn    string `json:"awaited_on,omitempty"`
+	// v0.12.x cluster-mode surface — which replica owns the run's live
+	// cancel handle. Empty (and omitted from JSON) in single-replica
+	// deployments so the UI stays uncluttered for the common case.
+	ReplicaID string `json:"replica_id,omitempty"`
 }
 
 type agentResponseUsage struct {
@@ -3287,7 +3291,8 @@ func runToAgentResponse(r store.Run, live bool) agentResponse {
 			CacheReadTokens:     r.CacheReadTokens,
 			Model:               r.Model,
 		},
-		Live: live,
+		Live:      live,
+		ReplicaID: r.ReplicaID,
 	}
 	if !r.CompletedAt.IsZero() {
 		t := r.CompletedAt
@@ -3329,6 +3334,10 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 			Status:    store.RunRunning,
 			StartedAt: entry.StartedAt,
 			Live:      true,
+			// The registry only holds local entries, so a hit here is
+			// always owned by the responding replica. Empty in
+			// single-replica mode (omitted from JSON via omitempty).
+			ReplicaID: s.replicaID,
 		})
 		return
 	}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -75,6 +75,10 @@ export interface Agent {
   // the channel name or interruption kind respectively.
   awaited_state?: "channel" | "interrupted" | "";
   awaited_on?: string;
+  // v0.12.x cluster mode: the replica owning this run's live cancel
+  // handle. Absent in single-replica deployments (the server omits
+  // the field when its replica_id is unset).
+  replica_id?: string;
 }
 
 export interface ListAgentsResponse {

--- a/web/src/components/AgentsTree.tsx
+++ b/web/src/components/AgentsTree.tsx
@@ -186,6 +186,15 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
           </Link>
         )}
         <span className="model">{a.usage?.model || "—"}</span>
+        {a.replica_id && (
+          <span
+            className="replica"
+            style={{ background: replicaHue(a.replica_id) }}
+            title={`Running on ${a.replica_id}`}
+          >
+            {a.replica_id}
+          </span>
+        )}
         <span className="time">{relativeTime(a.started_at)}</span>
         {a.error && <span className="error-flag" title={a.error}>error</span>}
       </div>
@@ -219,4 +228,18 @@ function awaitClass(state: Agent["awaited_state"] | undefined, status: Agent["st
   if (state === "interrupted") return "await-interrupted";
   if (status === "running") return "await-running";
   return "";
+}
+
+// replicaHue maps a replica_id to a stable HSL background so different
+// replicas get visually distinct chips without an ever-growing color
+// table. djb2 hash → hue; fixed low-saturation pastel keeps it
+// readable on both light and dark themes alongside the existing
+// .pill / .model chips.
+function replicaHue(replicaID: string): string {
+  let hash = 5381;
+  for (let i = 0; i < replicaID.length; i++) {
+    hash = ((hash << 5) + hash + replicaID.charCodeAt(i)) | 0;
+  }
+  const hue = Math.abs(hash) % 360;
+  return `hsl(${hue}, 55%, 82%)`;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -452,6 +452,15 @@ pre {
   color: var(--fg-soft);
   font-size: 12px;
 }
+.replica {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 10px;
+  color: #222;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  letter-spacing: 0.02em;
+}
 .time {
   color: var(--fg-soft);
   font-size: 12px;


### PR DESCRIPTION
## Summary

- Adds the v0.12.x `replica_id` to the runs list/get API response (`agentResponse` struct, populated from `r.ReplicaID` in `runToAgentResponse` and from `s.replicaID` in the store-less branch of `GET /v1/agents/{id}`).
- Renders a small chip on each running-agent row in the Web UI tree, next to the model name, with a deterministic hash-derived HSL background so different replicas are visually distinct without an ever-growing palette.
- Field is `omitempty` on the wire and conditionally rendered in TSX, so single-replica deployments are unchanged visually.

## Test plan

- [x] `go test ./internal/api/http/...` — passes, including new `TestRunToAgentResponse_ReplicaIDRoundTrip` regression test (populated case + empty-omitted case).
- [x] `go test ./... -count=1 -short` — full suite green.
- [x] `npm run build` in `web/` — clean Vite build.
- [x] Live cluster smoke: seeded 4 runs across replica-a + replica-b with `user_id=smoke-user`; `GET /v1/users/smoke-user/agents` returned `replica_id` per row interleaved as expected.

## How to see it

Once the v0.12.x cluster demo is running:
```bash
docker compose -f docker-compose.cluster.yaml --env-file examples/cluster/.env up -d
open "http://localhost:18080/ui?token=\$LOOMCYCLE_AUTH_TOKEN"
```
Trigger a couple of runs against both replicas (`:18787` and `:18788`) and visit the Users → smoke-user → Agents view — running agents on different replicas show different-coloured `replica-a` / `replica-b` chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)