### PR TITLE
docs(cluster-demo): add run-agents.sh — populate UI with visible activity

### DIFF
--- a/examples/cluster/run-agents.sh
+++ b/examples/cluster/run-agents.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# run-agents.sh — spawn a small batch of demo runs across both
+# replicas so the Web UI has visible activity to look at.
+#
+# Companion to verify.sh: where verify.sh proves the cluster
+# invariants programmatically, this script populates the UI with
+# representative load so an operator can see runs on different
+# replicas (different chip colors), some completed, some still
+# running.
+#
+# Usage (from repo root, after `docker compose ... up -d`):
+#   source .env.local                      # exports LOOMCYCLE_AUTH_TOKEN
+#   ./examples/cluster/run-agents.sh
+#
+# Layout: 2 users × 3 prompt tiers = 6 parallel runs.
+#   - alice + bob → simulate two distinct users in the Users view
+#   - quick / medium / long → mix of fast-completing + still-running
+#     rows when the UI is opened within ~30s
+#   - alternating PORT → each user's history shows BOTH replica chips,
+#     proving cluster distribution at a glance
+#
+# Re-run to top up activity; agent_ids carry a nanosecond suffix so
+# nothing collides.
+
+set -u
+
+: "${LOOMCYCLE_AUTH_TOKEN:?LOOMCYCLE_AUTH_TOKEN must be set (source .env.local first)}"
+
+for user in alice bob; do
+  for tier in quick medium long; do
+    case $tier in
+      quick)  PORT=18787; PROMPT="One sentence about distributed systems." ;;
+      medium) PORT=18788; PROMPT="Write 200 words on three distributed-systems milestones." ;;
+      long)   PORT=18787; PROMPT="Write a thorough 1500-word essay tracing distributed systems history decade by decade since the 1960s. Be comprehensive." ;;
+    esac
+    AID="demo-${user}-${tier}-$(date +%s%N)"
+    echo "→ $user/$tier on :$PORT  ($AID)"
+    curl -fsS -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+      -X POST "http://localhost:$PORT/v1/runs" \
+      -H "Content-Type: application/json" \
+      -d "{\"agent\":\"default\",\"agent_id\":\"$AID\",\"user_id\":\"$user\",\"segments\":[{\"role\":\"user\",\"content\":[{\"type\":\"trusted-text\",\"text\":\"$PROMPT\"}]}]}" \
+      --no-buffer >/dev/null 2>&1 &
+  done
+done
+
+echo
+echo "6 runs spawned. Open the UI within ~30s to catch the long ones running:"
+echo '  open "http://localhost:18080/ui?token=$LOOMCYCLE_AUTH_TOKEN"'


### PR DESCRIPTION
## Summary

Companion to `verify.sh`: where `verify.sh` proves cluster invariants programmatically (6 checks → pass/fail), this script seeds a small batch of representative runs so an operator opening the Web UI immediately sees:

- Runs distributed across both replicas (different chip colors, courtesy of #226)
- A mix of completed + still-running rows
- Multiple distinct users in the Users view

Layout: 2 users × 3 prompt tiers = 6 parallel runs.
- **alice + bob** → two distinct users
- **quick / medium / long** → mix of completed + running rows when the UI is opened within ~30s
- **alternating replica port** → each user's history shows BOTH replica chips

Re-runnable: agent_ids carry a nanosecond suffix so nothing collides.

## How it relates

- Bring up cluster: `docker compose -f docker-compose.cluster.yaml --env-file ... up -d`
- Prove it works: `./examples/cluster/verify.sh` (this PR's predecessor)
- Make the UI look interesting: `./examples/cluster/run-agents.sh` (this PR)
- Visit: `http://localhost:18080/ui?token=\$LOOMCYCLE_AUTH_TOKEN`

## Test plan

- [x] Sourced `.env.local`, ran the script against the live demo cluster — 6 runs spawned, each visible in the Web UI with the expected replica-a / replica-b chip distribution
- [x] `set -u` + the `:?` guard on `LOOMCYCLE_AUTH_TOKEN` produces a clear error when the env isn't sourced

🤖 Generated with [Claude Code](https://claude.com/claude-code)