### PR TITLE
fix(channel): close subscribe long-poll race against concurrent publish

### DIFF
--- a/internal/channels/bus.go
+++ b/internal/channels/bus.go
@@ -140,17 +140,20 @@ func (b *Bus) SubscribeBackplane(ctx context.Context, bp coord.Backplane) error 
 // sends on the waker is Notify. Callers should still re-query the
 // store after Wait returns true, because Notify only signals
 // presence-of-new-data, not which specific rows are new.
+//
+// **Race warning**: Wait registers its waker AFTER you call it. If
+// you have a "check store → if empty, wait" pattern, there's a race
+// window between the check returning empty and Wait registering the
+// waker. A concurrent publish in that window fires Notify against an
+// empty waiter slice — the notification is lost and the caller waits
+// the full timeout. Use Register + Unregister instead for the
+// race-free check-then-wait pattern (see Register's doc).
 func (b *Bus) Wait(ctx context.Context, channel string, timeout time.Duration) bool {
 	if timeout <= 0 {
 		return false
 	}
-	waker := make(chan struct{}, 1)
-
-	b.mu.Lock()
-	b.waiters[channel] = append(b.waiters[channel], waker)
-	b.mu.Unlock()
-
-	defer b.removeWaiter(channel, waker)
+	waker := b.Register(channel)
+	defer b.Unregister(channel, waker)
 
 	t := time.NewTimer(timeout)
 	defer t.Stop()
@@ -163,6 +166,55 @@ func (b *Bus) Wait(ctx context.Context, channel string, timeout time.Duration) b
 	case <-ctx.Done():
 		return false
 	}
+}
+
+// Register adds a waker for `channel` and returns it. The caller MUST
+// call Unregister(channel, waker) when done — typically via defer —
+// to prevent waker-slice leaks.
+//
+// Use this instead of Wait when you need to register the waker
+// BEFORE doing an initial state check. The pattern closes the
+// check-then-wait race that bare Wait has:
+//
+//	waker := bus.Register(channel)
+//	defer bus.Unregister(channel, waker)
+//	rows, _ := store.Read(...)
+//	if len(rows) > 0 {
+//	    return rows                    // synchronous fast path
+//	}
+//	select {
+//	case <-waker:
+//	    return store.Read(...)         // notify fired during wait
+//	case <-time.After(timeout):
+//	    return nil                     // timeout
+//	case <-ctx.Done():
+//	    return nil                     // cancelled
+//	}
+//
+// Why this is race-free: by the time `store.Read` runs, the waker
+// is already in the waiters slice. ANY publish that commits-and-
+// notifies from this point on will either:
+//
+//  1. Race the read and win — Read returns the row (no wait needed)
+//  2. Race the read and lose — Notify fires the waker, which is
+//     already queued; the select wakes, Read returns the row
+//
+// The lost-notification case ("publish notified before subscriber
+// registered") is structurally eliminated.
+func (b *Bus) Register(channel string) chan struct{} {
+	waker := make(chan struct{}, 1)
+	b.mu.Lock()
+	b.waiters[channel] = append(b.waiters[channel], waker)
+	b.mu.Unlock()
+	return waker
+}
+
+// Unregister removes the waker from the channel's waiter slice.
+// Idempotent — safe to defer even if the waker already fired
+// (Notify drained the slice; this finds nothing to remove and
+// returns silently).
+func (b *Bus) Unregister(channel string, waker chan struct{}) {
+	b.removeWaiter(channel, waker)
 }
 
 // removeWaiter is the defer cleanup. Removes the waker from the

--- a/internal/channels/bus_test.go
+++ b/internal/channels/bus_test.go
@@ -134,3 +134,144 @@ func TestBus_RaceDetectorCleanUnderConcurrentNotifyWait(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestBus_RegisterBuffersNotifyBeforeSelect is the key correctness
+// invariant for the v0.12.x check-then-wait race fix. After calling
+// Register, ANY subsequent Notify fires the waker — even one that
+// arrives before the caller has started `select`-ing on it. The
+// waker's channel buffer (cap 1) captures the signal.
+//
+// This property is what makes the "register-before-read" pattern
+// race-free in Channel.execSubscribe: by the time the SQL read
+// runs, the waker is already registered, so a Notify that fires
+// concurrent with the read is queued in the buffer and the
+// post-read `select` consumes it immediately.
+//
+// Without this property, a Notify between Register and select
+// would be lost — defeating the purpose of pre-registration.
+func TestBus_RegisterBuffersNotifyBeforeSelect(t *testing.T) {
+	t.Parallel()
+	b := NewBus()
+
+	waker := b.Register("ch")
+	defer b.Unregister("ch", waker)
+
+	// Fire Notify BEFORE we start selecting. The waker's buffer
+	// (cap 1) must capture it so the next read finds the signal.
+	b.Notify("ch")
+
+	select {
+	case <-waker:
+		// ok — pre-fired notify was captured by the buffered waker
+	default:
+		t.Fatal("waker did not capture Notify that fired before select; the check-then-wait race fix relies on this")
+	}
+}
+
+// TestBus_RegisterRaceFreePattern simulates the exact
+// Channel.execSubscribe pattern under concurrent publish.
+// Demonstrates that the race-free pattern captures every notify,
+// regardless of whether the publish lands during the "read" or
+// during the wait. The 1000-iteration loop with tight timing
+// surfaces any regression in the buffered-waker semantics.
+func TestBus_RegisterRaceFreePattern(t *testing.T) {
+	t.Parallel()
+	b := NewBus()
+
+	const iterations = 1000
+	var (
+		received atomic.Int32
+		missed   atomic.Int32
+	)
+	for i := 0; i < iterations; i++ {
+		// Each iteration: fresh "publish state" via per-iter counter.
+		var published atomic.Bool
+		check := func() bool { return published.Load() }
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Race-free subscriber: Register → check → select-on-waker.
+		go func() {
+			defer wg.Done()
+			waker := b.Register("ch")
+			defer b.Unregister("ch", waker)
+
+			if check() {
+				received.Add(1)
+				return
+			}
+			select {
+			case <-waker:
+				if check() {
+					received.Add(1)
+					return
+				}
+				// Notify fired but check still empty: this can only
+				// happen if the iteration's Notify was for a different
+				// "publish" event, which can't happen in this test
+				// because publisher only fires once per iteration.
+				missed.Add(1)
+			case <-time.After(200 * time.Millisecond):
+				// Timeout: would mean Notify was lost — the bug.
+				missed.Add(1)
+			}
+		}()
+
+		// Publisher.
+		go func() {
+			defer wg.Done()
+			// Tiny random delay so we land in different windows
+			// relative to subscriber across iterations: some
+			// publishes happen before Register, some after, some
+			// concurrent with check.
+			time.Sleep(time.Duration(i%23) * time.Microsecond)
+			published.Store(true)
+			b.Notify("ch")
+		}()
+
+		wg.Wait()
+	}
+
+	// Hard assertion: zero misses across 1000 iterations.
+	if missed.Load() > 0 {
+		t.Errorf("race-free pattern: %d/%d notifies lost (want 0); received=%d",
+			missed.Load(), iterations, received.Load())
+	}
+}
+
+// TestBus_UnregisterIdempotent — Unregister must be safe to call
+// even after Notify already drained the waker. Defer pattern relies
+// on this.
+func TestBus_UnregisterIdempotent(t *testing.T) {
+	t.Parallel()
+	b := NewBus()
+	waker := b.Register("ch")
+	b.Notify("ch") // drains the waker slice
+	<-waker        // confirm waker fired
+	// Now Unregister: must be a no-op (waker already gone).
+	b.Unregister("ch", waker)
+	// And calling Unregister twice is safe.
+	b.Unregister("ch", waker)
+}
+
+// TestBus_RegisterFiresOnNotify — minimal happy path: Register then
+// receive on the returned channel after Notify.
+func TestBus_RegisterFiresOnNotify(t *testing.T) {
+	t.Parallel()
+	b := NewBus()
+	waker := b.Register("ch")
+	defer b.Unregister("ch", waker)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		b.Notify("ch")
+	}()
+
+	select {
+	case <-waker:
+		// ok
+	case <-time.After(time.Second):
+		t.Fatal("waker never fired after Notify")
+	}
+}

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -692,11 +692,15 @@ func testSweepStaleRuns(t *testing.T, s store.Store) {
 	_, _ = s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_no_hb"})
 
 	// Sleep enough that "now" is after both rows' (last_heartbeat_at
-	// or started_at). 60ms gives enough headroom to survive
-	// heavily-loaded CI runners doing dozens of parallel Postgres
-	// tests against a containerised fixture; tighter values
-	// (we ran 30ms briefly) flaked under load.
-	time.Sleep(60 * time.Millisecond)
+	// or started_at). We previously ran with 60ms sleep + 30ms cutoff
+	// (= 30ms margin), but PR #232's CI race-detector run flaked: the
+	// fresh row's heartbeat write landed before the cutoff because
+	// `-race`'s 2-5× scheduling slowdown collapsed the 30ms margin.
+	// Bumped to 200ms sleep + 100ms cutoff offset = 100ms margin in
+	// either direction. Test runtime up by 140ms but no longer
+	// timing-sensitive to scheduler load. Same shape as the
+	// heartbeat-sweeper fix in PR #224.
+	time.Sleep(200 * time.Millisecond)
 
 	// 3) A fresh run that heartbeated AFTER the cutoff — must NOT be
 	//    swept.
@@ -708,10 +712,11 @@ func testSweepStaleRuns(t *testing.T, s store.Store) {
 	_ = s.FinishRun(ctx, terminalRun.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
 
 	// Cutoff: between the stale row's last activity and the fresh
-	// row's. 30ms-back keeps the stale + noHB rows past the cutoff
-	// while the fresh row stays after it. Doubling from the previous
-	// 15ms gives ~30ms of margin in either direction.
-	cutoff := time.Now().Add(-30 * time.Millisecond)
+	// row's. 100ms-back keeps the stale + noHB rows clearly past the
+	// cutoff (200ms ago) while the fresh row (just heartbeated)
+	// stays clearly after it. 100ms margin survives -race scheduling
+	// slowdown.
+	cutoff := time.Now().Add(-100 * time.Millisecond)
 
 	swept, err := s.SweepStaleRuns(ctx, cutoff)
 	if err != nil {

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -356,23 +356,51 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	read := func() ([]store.ChannelMessage, string, error) {
 		return c.Store.ChannelSubscribe(ctx, in.Channel, scope, scopeID, from, limit)
 	}
+
+	// Long-poll pattern: when long-poll is enabled, register the
+	// waker BEFORE the initial read so a publish that commits between
+	// our check and our wait isn't lost. See Bus.Register doc for
+	// the race-free invariant.
+	//
+	// Without this pre-registration, a concurrent publish in the
+	// window between read() returning empty and Bus.Wait() registering
+	// its waker fires Notify against an empty waiter slice — the
+	// notification vanishes, the subscriber waits the full wait_ms,
+	// and the just-published row is silently missed. At x10 circuit
+	// scale this races at ~50% (cf. PR #231 analysis); at x1 it's
+	// invisible because there's no concurrent publisher.
+	longPollEnabled := c.Bus != nil && in.WaitMS > 0 && c.LongPollCapMS > 0
+	var waker chan struct{}
+	if longPollEnabled {
+		waker = c.Bus.Register(in.Channel)
+		defer c.Bus.Unregister(in.Channel, waker)
+	}
+
 	msgs, next, err := read()
 	if err != nil {
 		return errResult(fmt.Sprintf("subscribe: %s", err)), nil
 	}
 
 	// Long-poll if empty AND caller requested it AND operator allows.
-	if len(msgs) == 0 && c.Bus != nil && in.WaitMS > 0 && c.LongPollCapMS > 0 {
+	if len(msgs) == 0 && longPollEnabled {
 		wait := in.WaitMS
 		if wait > c.LongPollCapMS {
 			wait = c.LongPollCapMS
 		}
-		if c.Bus.Wait(ctx, in.Channel, time.Duration(wait)*time.Millisecond) {
-			// New publish landed — re-query (the row is committed).
+		t := time.NewTimer(time.Duration(wait) * time.Millisecond)
+		defer t.Stop()
+		select {
+		case <-waker:
+			// New publish landed — re-query (the row is committed
+			// because Notify is called AFTER ChannelPublish commits).
 			msgs, next, err = read()
 			if err != nil {
 				return errResult(fmt.Sprintf("subscribe (after wait): %s", err)), nil
 			}
+		case <-t.C:
+			// Timeout — caller gets empty messages and decides.
+		case <-ctx.Done():
+			// Cancelled — same as timeout from the wire shape.
 		}
 	}
 


### PR DESCRIPTION
## Summary

Bug A from the [PR #231 x10 analysis](https://github.com/denn-gubsky/loomcycle/pull/231): at x10 circuit-stress scale, ~50% of circuits failed because `Channel.subscribe` returned empty + empty `next_cursor` when a concurrent `Channel.publish` had just committed.

## Root cause

Classic **check-then-wait race** in `Channel.execSubscribe`:

```go
// OLD pattern (race):
msgs, _ := read()                     // ① initial read returns empty
if empty:
    bus.Wait(ctx, ch, t)              // ② register waker, then wait
    // ↑ between ① and ② another goroutine can call:
    //   - ChannelPublish (commits row)
    //   - bus.Notify(ch) → no waiters yet → notification LOST
```

A publish that lands in the window between the read and `Wait()`'s waker registration fires `Notify` against an empty waiter slice. The signal vanishes. The subscriber waits the full timeout and reports empty.

At x10 with concurrent publishers, this race fires on ~50% of circuits (5/10 in the latest run). At x1, with no concurrent publisher, the race never fires.

## Fix

Invert the order — register the waker BEFORE the initial read:

```go
// NEW pattern (race-free):
waker := bus.Register(ch)             // ① register FIRST
defer bus.Unregister(ch, waker)
msgs, _ := read()                     // ② now read
if empty:
    select {
    case <-waker: read() again        // ③ select-on-waker
    case <-timeout: ...
    }
```

By the time `read` runs, the waker is in the waiters slice. ANY publish that commits-and-notifies from `Register` onward either:
- **(a)** is captured by the read (the row is committed and visible), OR
- **(b)** fires the buffered waker (cap 1), which the `select` consumes immediately

The lost-notification case is **structurally eliminated**.

## Changes

| File | Change |
|---|---|
| `internal/channels/bus.go` | New `Register(channel) chan struct{}` + `Unregister(channel, waker)` exposed; `Wait()` now delegates internally; explicit race-warning doc added to `Wait` pointing operators at the new API for check-then-wait code. |
| `internal/tools/builtin/channel.go` | `execSubscribe` switched to register-before-read. Explanatory comment with race-window diagram. |
| `internal/channels/bus_test.go` | 4 new tests covering buffer semantics (`Notify-then-select`), 1000-iter race-free pattern, happy path, idempotent Unregister. |

## Test plan

- [x] `go test ./internal/channels/... -count=3 -race` — 3 consecutive clean runs
- [x] `go test ./internal/tools/builtin/... -count=1 -race -run Channel` — channel integration tests still pass under `-race`
- [x] `go test ./internal/... -count=1 -race -short` — full short suite passes under `-race`
- [x] **TestBus_RegisterBuffersNotifyBeforeSelect** asserts the key invariant: a Notify fired AFTER `Register` but BEFORE the caller's `select` is captured by the buffered waker.
- [x] **TestBus_RegisterRaceFreePattern** — 1000-iteration concurrent publish+subscribe loop with hard assertion of zero misses.
- [ ] Re-run `./test/load/circuit-stress/run.sh --scale 10` against this branch after merge — expected 10/10 success vs the current 5/10.

## Expected impact

- **circuit-stress x10**: 50% → ~100% success (race window structurally closed)
- **Any production agent doing `Channel.subscribe` with `wait_ms > 0` under concurrent publish**: same fix applies, no API change needed

## Backwards compatibility

- `Bus.Wait()` external API unchanged — same signature, same semantics for callers that don't need pre-registration.
- New `Register`/`Unregister` are additive.
- No yaml schema changes, no wire-protocol changes, no storage migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)