### PR TITLE
fix(channel): bounded retry on subscribe re-read after notify

### DIFF
--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -391,9 +391,26 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 		defer t.Stop()
 		select {
 		case <-waker:
-			// New publish landed — re-query (the row is committed
-			// because Notify is called AFTER ChannelPublish commits).
-			msgs, next, err = read()
+			// New publish landed. The publish's Bus.Notify is called
+			// AFTER ChannelPublish commits, so by Postgres MVCC the
+			// row IS visible to any new transaction. In theory one
+			// re-read suffices.
+			//
+			// In practice, the v0.12.x circuit-stress x50 load test
+			// surfaced a small residual rate (~2%) where the re-read
+			// immediately after waker fires returns empty despite a
+			// confirmed publish committed ~15-20ms earlier. The exact
+			// mechanism is unclear — most likely pgxpool / connection-
+			// level timing under high concurrency (50+ parallel
+			// queries against the same channel_messages partition).
+			//
+			// Defensive fix: bounded retry. If the re-read sees the
+			// row, return immediately (no extra cost). If empty,
+			// brief backoff and retry — up to 3 attempts adds at
+			// most 30ms in the worst case. The retry pattern also
+			// covers any future visibility window we haven't yet
+			// characterised at higher scale.
+			msgs, next, err = readWithRetry(read, in.Channel)
 			if err != nil {
 				return errResult(fmt.Sprintf("subscribe (after wait): %s", err)), nil
 			}
@@ -473,6 +490,56 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 		"messages":    out,
 		"next_cursor": next,
 	})
+}
+
+// readWithRetry is the bounded retry wrapper used by execSubscribe
+// after Bus.Wait returns via the waker (notify). The publish path
+// is commit-then-notify, so MVCC says the row IS visible to any
+// subsequent transaction; one read should suffice.
+//
+// Under heavy concurrency on Postgres (observed at x50 load test in
+// 2026-05-26's circuit-stress), an immediate re-read after a confirmed
+// publish has occasionally returned empty. The exact mechanism is
+// unclear (suspected: pgxpool connection-level state or a Postgres
+// snapshot edge case under contention). Until we can characterise it,
+// this retry covers it pragmatically: max 3 attempts, 10ms backoff,
+// so worst-case 30ms latency added when the retry fires.
+//
+// When the retry actually saves a circuit it logs a structured line
+// so we can quantify the issue at scale. When even the 3rd attempt
+// returns empty, we accept the empty result and let the caller decide
+// (current behaviour) — but we log a stronger warning so the operator
+// notices.
+func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel string) ([]store.ChannelMessage, string, error) {
+	const maxAttempts = 3
+	const backoff = 10 * time.Millisecond
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		msgs, next, err := read()
+		if err != nil {
+			return nil, "", err
+		}
+		if len(msgs) > 0 {
+			if attempt > 1 {
+				// The retry saved this subscriber from a silent miss.
+				// Surface at scale so we can measure the residual rate.
+				log.Printf("channel %q: subscribe re-read empty on attempt %d, retry found %d msg(s) — likely commit-visibility window",
+					channel, attempt-1, len(msgs))
+			}
+			return msgs, next, nil
+		}
+		if attempt < maxAttempts {
+			time.Sleep(backoff)
+		}
+	}
+	// All retries exhausted. The publish-then-notify ordering says the
+	// row SHOULD have been visible by now. Either the notify was for
+	// a publish we shouldn't have seen (cursor-past it), or there's
+	// a more pathological timing window we haven't yet diagnosed.
+	// Return empty and let the caller decide.
+	log.Printf("channel %q: subscribe re-read returned empty across %d attempts after notify — silent miss; investigate",
+		channel, maxAttempts)
+	return nil, "", nil
 }
 
 func (c *Channel) execAck(ctx context.Context, policy tools.ChannelPolicyValue, in channelInput) (tools.Result, error) {

--- a/internal/tools/builtin/channel_test.go
+++ b/internal/tools/builtin/channel_test.go
@@ -568,3 +568,109 @@ func TestChannelTool_AgentRefusedOnSystemPrefix(t *testing.T) {
 		t.Errorf("error should mention _system/ prefix; got %q", res.Text)
 	}
 }
+
+// TestReadWithRetry covers the residual-race defensive retry that
+// runs after Bus.Wait fires the waker. Three scenarios:
+//
+//  1. read succeeds on the first attempt — no retry cost.
+//  2. read returns empty initially, then non-empty on attempt 2 —
+//     retry saves the subscriber from a silent miss.
+//  3. read returns empty on all 3 attempts — the function returns
+//     empty (current behaviour); the caller decides.
+//
+// This is the safety net for the unexplained ~2% subscribe miss
+// observed in x50 load testing: a publish committed, Bus.Notify
+// fired, the waker woke, but an immediate re-read returned empty.
+// The retry covers any commit/visibility window without making
+// strong claims about the root mechanism.
+func TestReadWithRetry(t *testing.T) {
+	makeMsg := func(id string) store.ChannelMessage {
+		return store.ChannelMessage{ID: id}
+	}
+
+	t.Run("succeeds_on_first_attempt", func(t *testing.T) {
+		calls := 0
+		read := func() ([]store.ChannelMessage, string, error) {
+			calls++
+			return []store.ChannelMessage{makeMsg("m1")}, "cur_x", nil
+		}
+		msgs, next, err := readWithRetry(read, "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 1 || msgs[0].ID != "m1" {
+			t.Errorf("msgs = %v, want [{m1}]", msgs)
+		}
+		if next != "cur_x" {
+			t.Errorf("next = %q, want cur_x", next)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (no retries needed)", calls)
+		}
+	})
+
+	t.Run("retry_finds_message_on_second_attempt", func(t *testing.T) {
+		calls := 0
+		read := func() ([]store.ChannelMessage, string, error) {
+			calls++
+			if calls == 1 {
+				return nil, "", nil // initial empty (the race)
+			}
+			return []store.ChannelMessage{makeMsg("m2")}, "cur_y", nil
+		}
+		msgs, _, err := readWithRetry(read, "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 1 || msgs[0].ID != "m2" {
+			t.Errorf("retry should have returned the message; got %v", msgs)
+		}
+		if calls != 2 {
+			t.Errorf("calls = %d, want 2", calls)
+		}
+	})
+
+	t.Run("all_three_attempts_empty_returns_empty", func(t *testing.T) {
+		calls := 0
+		read := func() ([]store.ChannelMessage, string, error) {
+			calls++
+			return nil, "", nil // always empty
+		}
+		msgs, next, err := readWithRetry(read, "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("msgs should be empty, got %v", msgs)
+		}
+		if next != "" {
+			t.Errorf("next should be empty, got %q", next)
+		}
+		if calls != 3 {
+			t.Errorf("calls = %d, want 3 (full retry budget exhausted)", calls)
+		}
+	})
+
+	t.Run("error_propagates_without_retry", func(t *testing.T) {
+		calls := 0
+		read := func() ([]store.ChannelMessage, string, error) {
+			calls++
+			return nil, "", errSentinel
+		}
+		_, _, err := readWithRetry(read, "test")
+		if err != errSentinel {
+			t.Errorf("err = %v, want %v", err, errSentinel)
+		}
+		if calls != 1 {
+			t.Errorf("calls = %d, want 1 (errors don't retry)", calls)
+		}
+	})
+}
+
+// errSentinel — fixed sentinel error for the propagate-without-retry
+// subtest above. Identity comparison only.
+var errSentinel = sentinelErr{}
+
+type sentinelErr struct{}
+
+func (sentinelErr) Error() string { return "sentinel" }


### PR DESCRIPTION
## Summary

Fix #3 from the [x50 load test analysis](https://github.com/denn-gubsky/loomcycle/pull/232) — ~2% of subscribes returned empty despite a confirmed `Channel.publish` committing 15-20ms earlier.

The bus-level race fix (#232) eliminated the missing-notify case, but a residual window survived: `Bus.Wait` fires the waker, the re-read runs immediately, and finds no rows — even though the row IS visible to a follow-up diagnostic query milliseconds later.

## Root cause (suspected)

pgxpool / Postgres timing under high concurrency (50+ parallel queries against `channel_messages`). The publish path is commit-then-notify per the code, so MVCC says the row SHOULD be visible to any subsequent transaction. Yet empirically the immediate re-read sometimes misses it. Exact mechanism unclear without deeper instrumentation.

## Fix

Bounded retry on the re-read after waker fires:
- **3 attempts max**
- **10ms backoff** between attempts
- **Worst-case 30ms** added to subscribe latency when retry triggers

The retry is defensive — most subscribes return on attempt 1 with no extra cost. When attempt 2+ succeeds, a structured log surfaces so we can measure the residual rate at scale:

```
channel %q: subscribe re-read empty on attempt N, retry found M msg(s)
  — likely commit-visibility window
```

When all 3 attempts exhaust, a stronger warning logs and the empty result is returned (current behaviour — caller decides):

```
channel %q: subscribe re-read returned empty across N attempts after
  notify — silent miss; investigate
```

## Limits

This is a defensive fix, not a structural one. It papers over the residual timing window rather than eliminating it. If x100 testing surfaces failure rates above ~0.5%, we'll need deeper diagnosis (pgx pool config, Postgres isolation level, or possibly a backplane post-notify barrier). The structured logs above are the data point to revisit this with.

## Test plan

- [x] **TestReadWithRetry** (4 subtests):
  - Success on first attempt: no retry cost (`calls == 1`)
  - Empty then non-empty: retry saves the subscriber (`calls == 2`)
  - 3x empty: returns empty, logs warning (`calls == 3`)
  - Error: propagates without retry (`calls == 1`)
- [x] Full `go test ./internal/... -race -short` passes
- [ ] Re-run circuit-stress x50 — expect residual ~2% to drop to ≤0.5%

## Expected impact

| Scale | Before #232 | After #232 | After #232 + this |
|---|---|---|---|
| x10 | 50% fail | 0% fail | 0% fail |
| x50 | ~50% fail | ~2% fail (this race) | ≤0.5% fail (retry covers it) |
| x100 | catastrophic | ~5% fail (extrapolation) | ≤1% fail |

The structural fix (#232) handles the missing-notify case. This handles the post-notify visibility window. Together they should make scale-up routine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)