### PR TITLE
feat(load-test): add Ollama Cloud fallback to absorb OAuth-dev rate limits

### DIFF
--- a/test/load/circuit-stress/README.md
+++ b/test/load/circuit-stress/README.md
@@ -16,7 +16,8 @@ Circuits are grouped `--circuits-per-user 10-20` so the Web UI's per-user agents
 
 ```sh
 # 1. Prereqs (one-time)
-loomcycle anthropic login                              # populate OAuth token
+loomcycle anthropic login                              # populate Anthropic OAuth token (primary provider)
+export OLLAMA_API_KEY=...                              # Ollama Cloud key (fallback when OAuth-dev hits rate limit)
 export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)    # bearer for both server + driver
 
 # 2. Smoke test (x1, ~1 min)

--- a/test/load/circuit-stress/loomcycle.template.yaml
+++ b/test/load/circuit-stress/loomcycle.template.yaml
@@ -1,39 +1,41 @@
 # test/load/circuit-stress — loomcycle config for the multi-agent
 # circuit load test. See README.md for what this test exercises.
 #
-# Three agents, one provider (anthropic-oauth-dev only), Postgres
-# storage, channels declared with prefix-wildcard ACLs so the driver
-# can pre-create per-circuit channels without yaml edits per scale.
-#
-# Concurrency bumped to 200 active / 500 queued — defaults of 8/16
-# would dominate the latency picture at x100+.
+# Two providers in cascade: anthropic-oauth-dev primary, ollama
+# cloud (deepseek-v4-flash) fallback. Ollama Cloud also has a
+# flat-rate plan like Anthropic MAX — models are generally slower
+# but the rate ceiling is independent, so when OAuth-dev hits its
+# per-minute limit individual runs fall over to ollama and the
+# pipeline keeps moving. The previous single-provider config
+# cascade-failed at ~120 concurrent calls (x1000 load test on
+# 2026-05-26); this dual-provider config absorbs that spike.
 
 provider_priority:
   - anthropic-oauth-dev
+  - ollama
 
 # Library-default tier — used by every agent here unless overridden.
-# Pinned to haiku because the goal is exercising the substrate, not
-# generating reasoning tokens; cheaper + faster keeps the OAuth-dev
-# MAX subscription budget alive for higher scales.
+# Both providers' fast/small models so the test exercises the
+# substrate, not reasoning capacity. Haiku is the primary; deepseek-
+# v4-flash is the failover when OAuth-dev hits its rate ceiling.
 tiers:
   middle:
     - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
+    - { provider: ollama,              model: deepseek-v4-flash }
 
 # Default user_tier — every run inherits unless POST /v1/runs sets
-# its own. We don't bother declaring named tiers since this test is
-# single-tier.
+# its own. fallback_on_error: true engages the candidate-list
+# fallback on retryable errors (429 / 5xx / network). At x1000 we
+# saw ~120 OAuth-dev 429s; with this on, those runs route to ollama
+# instead of failing.
 user_tiers:
   default:
-    provider_priority: [anthropic-oauth-dev]
+    provider_priority: [anthropic-oauth-dev, ollama]
     tiers:
       middle:
         - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
-    # No fallback: we WANT this run to fail loudly when the OAuth
-    # MAX subscription quota is exhausted so the driver can detect
-    # and halt the ramp. Falling back to API-key Anthropic would
-    # complete the run but defeat the "how far does OAuth dev go"
-    # measurement that's the whole point of this test.
-    fallback_on_error: false
+        - { provider: ollama,              model: deepseek-v4-flash }
+    fallback_on_error: true
 
 # Concurrency — defaults of 8/16 would queue heavily at x100+.
 # 200/500 gives headroom for 3 concurrent runs per circuit × ~70


### PR DESCRIPTION
## Summary

The x1000 run on 2026-05-26 cascade-failed at ~120 concurrent OAuth-dev calls. PR #235 addresses the matrix-poisoning side of that bug; this PR adds an actual fallback provider so individual runs that DO hit the rate limit have somewhere to route.

**Ollama Cloud has a similar flat-rate plan to Anthropic MAX with an INDEPENDENT rate ceiling.** When OAuth-dev rate-limits, runs route to ollama and the pipeline keeps moving. Models are generally slower on Ollama (e.g. `deepseek-v4-flash`), but that's fine — this test exercises substrate correctness, not p50 latency.

## Changes (test yaml only)

```diff
  provider_priority:
    - anthropic-oauth-dev
+   - ollama

  tiers:
    middle:
      - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
+     - { provider: ollama,              model: deepseek-v4-flash }

  user_tiers:
    default:
-     provider_priority: [anthropic-oauth-dev]
+     provider_priority: [anthropic-oauth-dev, ollama]
      tiers:
        middle:
          - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
+         - { provider: ollama,              model: deepseek-v4-flash }
-     fallback_on_error: false
+     fallback_on_error: true
```

README adds the `OLLAMA_API_KEY` prereq.

## How this interacts with PR #235

| | PR #235 (matrix) | This PR (yaml) |
|---|---|---|
| What it fixes | 429 no longer poisons the matrix for 15 min | Individual 429s have a place to fall over |
| Effect at x100 | Matrix stays healthy → no cascading 503 | The ~120 failing runs route to ollama instead |
| Together | Pipeline survives rate-limit storms without cascade AND individual hits don't fail user-visible | |

Either alone is an improvement; together they should make x1000 with single-binary deployment routine.

## Test plan

- [x] yaml parses cleanly through provider/tier/user_tier (channels block requires runtime gen by run.sh; standalone validation is expected to stop there)
- [ ] Run circuit-stress x300 against this branch — expect zero cascade failures and a mix of `anthropic-oauth-dev` + `ollama` model values in the run records
- [ ] At x1000 with #235 + this merged — expect near-100% success rate with some longer-tail latency where runs routed to ollama

## What's NOT in scope

- The substrate fix (#235) — separate PR
- Tier policy validation that warns when fallback is configured but no second provider has a usable model — could be a future bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)