### PR TITLE
feat(load-test): cap concurrent runs at 120 to fit Ollama's limit

### DIFF
--- a/test/load/circuit-stress/loomcycle.template.yaml
+++ b/test/load/circuit-stress/loomcycle.template.yaml
@@ -37,15 +37,22 @@ user_tiers:
         - { provider: ollama,              model: deepseek-v4-flash }
     fallback_on_error: true
 
-# Concurrency — defaults of 8/16 would queue heavily at x100+.
-# 200/500 gives headroom for 3 concurrent runs per circuit × ~70
-# in-flight circuits. Per-user cap stays 0 (off) since circuits are
-# grouped by user_id with 10-20 each; an artificial cap here would
-# block legitimate parallelism.
+# Concurrency — capped at 120 active to stay below Ollama Cloud's
+# per-deployment concurrent-request limit. The x1000 run on
+# 2026-05-26 saw `ollama 429: too many concurrent requests` once
+# in-flight reached ~120 — Ollama's flat-rate plan has tighter
+# concurrency than Anthropic MAX. 120 is the empirical safe floor
+# for BOTH providers; if you swap to a higher-concurrency Ollama
+# deployment (or a different fallback provider), bump this up.
+#
+# Queue depth bumped to 1500 (12× active) so x1000 can fully queue
+# without the 501th circuit refusing at the admission boundary.
+# Timeout bumped to 5 min — at 120 active and ~25s per circuit,
+# the 1000th circuit waits ~3.5 min in queue.
 concurrency:
-  max_concurrent_runs: 200
-  max_queue_depth: 500
-  queue_timeout_ms: 60000
+  max_concurrent_runs: 120
+  max_queue_depth: 1500
+  queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0
 
 # Storage — Postgres only. SQLite would serialise writes at this


### PR DESCRIPTION
## Summary

The 2026-05-26 x1000 run hit `ollama 429: too many concurrent requests` once in-flight reached ~120. Ollama Cloud's flat-rate plan has a tighter per-deployment concurrency ceiling than Anthropic MAX. Combined with the matrix-poisoning behavior in the pre-#235 binary that ran that test, this cascaded into 950+ "no provider available" 503s.

With #235 + #236 in place the cascade itself is fixed — but the **underlying Ollama concurrency ceiling is still real**. The fix is to cap loomcycle's admit semaphore at the lower of the two providers' limits.

## Changes

```diff
 concurrency:
-  max_concurrent_runs: 200
-  max_queue_depth: 500
-  queue_timeout_ms: 60000
+  max_concurrent_runs: 120
+  max_queue_depth: 1500
+  queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0
```

| Setting | Before | After | Why |
|---|---|---|---|
| `max_concurrent_runs` | 200 | **120** | Empirical Ollama-safe floor from the x1000 run |
| `max_queue_depth` | 500 | **1500** | 12× active; absorbs full x1000 without admission refusal |
| `queue_timeout_ms` | 60s | **5 min** | At 120 active × ~25s per circuit, the 1000th circuit waits ~3.5 min in queue |

## Test plan

- [ ] Re-run x1000 with this branch (and **fresh binary** — `rm bin/loomcycle test/load/circuit-stress/circuit-stress` before run.sh, the previous x1000 ran an old binary missing #235 and #236)
- [ ] Expect: 100% success rate, distribution of model usage split between `claude-haiku-4-5-20251001` and `deepseek-v4-flash` per the fallback policy, runs queue for up to ~3.5 min for the tail

## When to revisit

If a future test uses a higher-concurrency Ollama deployment or a different fallback provider (paid API-key Anthropic, DeepSeek API, etc.), bump `max_concurrent_runs` back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)