### PR TITLE
feat(load-test): single-provider Anthropic at 100 concurrent

### DIFF
--- a/test/load/circuit-stress/README.md
+++ b/test/load/circuit-stress/README.md
@@ -16,8 +16,7 @@ Circuits are grouped `--circuits-per-user 10-20` so the Web UI's per-user agents
 
 ```sh
 # 1. Prereqs (one-time)
-loomcycle anthropic login                              # populate Anthropic OAuth token (primary provider)
-export OLLAMA_API_KEY=...                              # Ollama Cloud key (fallback when OAuth-dev hits rate limit)
+loomcycle anthropic login                              # populate Anthropic OAuth token (single provider for this config)
 export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)    # bearer for both server + driver
 
 # 2. Smoke test (x1, ~1 min)

--- a/test/load/circuit-stress/loomcycle.template.yaml
+++ b/test/load/circuit-stress/loomcycle.template.yaml
@@ -1,56 +1,49 @@
 # test/load/circuit-stress — loomcycle config for the multi-agent
 # circuit load test. See README.md for what this test exercises.
 #
-# Two providers in cascade: anthropic-oauth-dev primary, ollama
-# cloud (deepseek-v4-flash) fallback. Ollama Cloud also has a
-# flat-rate plan like Anthropic MAX — models are generally slower
-# but the rate ceiling is independent, so when OAuth-dev hits its
-# per-minute limit individual runs fall over to ollama and the
-# pipeline keeps moving. The previous single-provider config
-# cascade-failed at ~120 concurrent calls (x1000 load test on
-# 2026-05-26); this dual-provider config absorbs that spike.
+# Single provider: anthropic-oauth-dev (Claude MAX subscription).
+# Ollama Cloud was tried as fallback but its per-deployment
+# concurrency limit kept tripping at ~120 simultaneous runs,
+# adding a SECOND failure source rather than absorbing the first.
+# Simpler tier (Anthropic only) + low concurrency cap = clean test
+# of the substrate without provider-side variability.
 
 provider_priority:
   - anthropic-oauth-dev
-  - ollama
 
 # Library-default tier — used by every agent here unless overridden.
-# Both providers' fast/small models so the test exercises the
-# substrate, not reasoning capacity. Haiku is the primary; deepseek-
-# v4-flash is the failover when OAuth-dev hits its rate ceiling.
+# Pinned to haiku because the goal is exercising the substrate, not
+# generating reasoning tokens; cheaper + faster keeps the OAuth-dev
+# MAX subscription budget alive for higher scales.
 tiers:
   middle:
     - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
-    - { provider: ollama,              model: deepseek-v4-flash }
 
 # Default user_tier — every run inherits unless POST /v1/runs sets
-# its own. fallback_on_error: true engages the candidate-list
-# fallback on retryable errors (429 / 5xx / network). At x1000 we
-# saw ~120 OAuth-dev 429s; with this on, those runs route to ollama
-# instead of failing.
+# its own. fallback_on_error: false because the only candidate is
+# anthropic-oauth-dev; with no fallback target, the flag would just
+# determine whether retryable errors are swallowed or propagated
+# (we want propagation for visibility during load testing).
 user_tiers:
   default:
-    provider_priority: [anthropic-oauth-dev, ollama]
+    provider_priority: [anthropic-oauth-dev]
     tiers:
       middle:
         - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
-        - { provider: ollama,              model: deepseek-v4-flash }
-    fallback_on_error: true
+    fallback_on_error: false
 
-# Concurrency — capped at 120 active to stay below Ollama Cloud's
-# per-deployment concurrent-request limit. The x1000 run on
-# 2026-05-26 saw `ollama 429: too many concurrent requests` once
-# in-flight reached ~120 — Ollama's flat-rate plan has tighter
-# concurrency than Anthropic MAX. 120 is the empirical safe floor
-# for BOTH providers; if you swap to a higher-concurrency Ollama
-# deployment (or a different fallback provider), bump this up.
+# Concurrency — 100 active. The previous 120 cap was tuned for the
+# Ollama-deployed fallback ceiling; with single-provider Anthropic
+# we have more headroom but stay conservative at 100 so the
+# OAuth-dev rate limit (~120 concurrent Haiku calls per the x1000
+# investigation) has buffer.
 #
-# Queue depth bumped to 1500 (12× active) so x1000 can fully queue
-# without the 501th circuit refusing at the admission boundary.
-# Timeout bumped to 5 min — at 120 active and ~25s per circuit,
-# the 1000th circuit waits ~3.5 min in queue.
+# Queue depth 1500 (15× active) so x1000 can fully queue without
+# the 1500th circuit refusing at the admission boundary.
+# Timeout 5 min — at 100 active and ~25s per circuit, the 1000th
+# circuit waits ~4 min in queue.
 concurrency:
-  max_concurrent_runs: 120
+  max_concurrent_runs: 100
   max_queue_depth: 1500
   queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0


### PR DESCRIPTION
## Summary

Ollama Cloud's per-deployment concurrency ceiling kept tripping during the dual-provider load tests on 2026-05-26 — instead of absorbing OAuth-dev's rate limit, it added a **second** failure mode (`ollama 429: too many concurrent requests`). Simpler approach: drop back to single-provider Anthropic and stay well below the rate ceiling.

## Changes

```diff
 provider_priority:
   - anthropic-oauth-dev
-  - ollama

 tiers:
   middle:
     - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
-    - { provider: ollama,              model: deepseek-v4-flash }

 user_tiers:
   default:
-    provider_priority: [anthropic-oauth-dev, ollama]
+    provider_priority: [anthropic-oauth-dev]
     tiers:
       middle:
         - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
-        - { provider: ollama,              model: deepseek-v4-flash }
-    fallback_on_error: true
+    fallback_on_error: false

 concurrency:
-  max_concurrent_runs: 120
+  max_concurrent_runs: 100
   max_queue_depth: 1500
   queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0
```

README drops the `OLLAMA_API_KEY` prereq.

## Why this combination

- **Single provider** — eliminates multi-provider routing variability
- **100 concurrent** — comfortably under OAuth-dev's ~120-call empirical limit, so we shouldn't trip Anthropic's rate ceiling either
- **fallback_on_error: false** — with no fallback target, the flag is mostly informational, but explicit false signals "we want errors to surface during load testing"

## NOTE on binary staleness

The previous load test failure (`results/2026-05-26T17-32-07Z`) ran a binary missing PR #235's stall-feedback fix:

```
loomcycle build: version=v0.12.7 commit=a5d62d7f6e50-dirty time=2026-05-26T14:31:03Z
```

That commit is **pre-#235**, so 429s still poisoned the resolver matrix. After this PR merges, ensure `bin/loomcycle` is freshly built from main:

```sh
rm bin/loomcycle test/load/circuit-stress/circuit-stress
LOOMCYCLE_AUTH_TOKEN=... ./test/load/circuit-stress/run.sh --scale 1000 --circuits-per-user 20
```

Verify in the new run's `loomcycle.log`: `commit=` should be the post-#236 hash.

## Test plan

- [x] yaml parses cleanly through provider/tier/concurrency
- [ ] x1000 run with FRESH binary — expect 100% success, p50 ~25-30s, no rate-limit cascades, ~49M tokens

## Multi-provider revisit

The multi-provider config can come back when we have a non-concurrency-capped fallback (paid API-key Anthropic, DeepSeek API, etc.). Filed as TODO; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)