### PR TITLE
fix(load-test): always rebuild binaries in run.sh

### DIFF
--- a/test/load/circuit-stress/run.sh
+++ b/test/load/circuit-stress/run.sh
@@ -69,11 +69,15 @@ fi
 export LOOMCYCLE_PG_DSN="postgres://postgres:$PG_PASSWORD@127.0.0.1:$PG_PORT/postgres?sslmode=disable"
 
 # ─── loomcycle binary ───────────────────────────────────────────────
+# Always rebuild — Go's incremental compile is sub-second when source
+# is unchanged, but skipping the rebuild on a stale `bin/loomcycle`
+# silently runs an old binary. The dual-provider load tests on
+# 2026-05-26 chased this trap four times: `make build-all` populates
+# Go's build cache but doesn't write `bin/loomcycle`, so an old
+# artifact from days prior keeps getting executed.
 LC_BIN="${LC_BIN:-$REPO_ROOT/bin/loomcycle}"
-if [ ! -x "$LC_BIN" ]; then
-    echo "→ building loomcycle binary…"
-    go build -o "$LC_BIN" ./cmd/loomcycle/
-fi
+echo "→ rebuilding loomcycle binary from current HEAD…"
+go build -o "$LC_BIN" ./cmd/loomcycle/
 
 # Env that the test yaml + OAuth-dev driver depend on.
 export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1
@@ -150,11 +154,11 @@ curl -fsS -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
     >"$RESULTS_DIR/metrics-summary-pre.json" 2>/dev/null || true
 
 # ─── Run the driver ─────────────────────────────────────────────────
+# Always rebuild — same rationale as the loomcycle binary above.
+# Sub-second when source is unchanged; prevents the stale-binary trap.
 DRIVER_BIN="${DRIVER_BIN:-$SCRIPT_DIR/circuit-stress}"
-if [ ! -x "$DRIVER_BIN" ]; then
-    echo "→ building driver…"
-    (cd "$SCRIPT_DIR" && go build -o circuit-stress .)
-fi
+echo "→ rebuilding driver from current source…"
+(cd "$SCRIPT_DIR" && go build -o circuit-stress .)
 
 echo "→ running driver: $DRIVER_BIN $* --results-dir $RESULTS_DIR --base-url http://127.0.0.1:$LC_PORT"
 echo


### PR DESCRIPTION
## Summary

The `if [ ! -x "\$BIN" ]` caching guard in `run.sh` has bitten the load test workflow **4 times today**. Every time a new PR lands, the next test runs against a stale binary because:

1. `make build-all` calls `go build ./...` which compiles to Go's build cache but **does NOT write `bin/loomcycle`**
2. `run.sh` sees the (days-old) `bin/loomcycle` exists, skips its own rebuild, runs the stale binary
3. Test fails with patterns identical to bugs already fixed in unmerged-into-binary PRs
4. Debug-on-stale-binary cycle costs ~2-5M tokens per iteration

Today's specific incident: the dual-provider Ollama fallback tests blamed upstream provider behavior for what was actually `run.sh` running a pre-#235 binary that still had the matrix-poisoning bug.

## Evidence

Two consecutive x1000 runs hours apart, after multiple `git pull` + `make build-all` cycles, both showed:

```
loomcycle build: version=v0.12.7 commit=a5d62d7f6e50-dirty time=2026-05-26T14:31:03Z
```

Same binary. Same pre-#235 commit. The `mtime` on `bin/loomcycle` was 4+ hours old; `make build-all` never updated it.

## Fix

Drop the `if [ ! -x ]` guard. Always rebuild on `run.sh` invocation. Go's incremental compile is sub-second when source is unchanged; the safety guarantee is worth the second.

Applied to both:
- `LC_BIN` (loomcycle server binary)
- `DRIVER_BIN` (the circuit-stress driver)

## Verification

After this merges, the next `run.sh` invocation will log a fresh build line:

```
→ rebuilding loomcycle binary from current HEAD…
→ rebuilding driver from current source…
loomcycle build: version=v0.12.7 commit=<current-HEAD>  time=<within-seconds-of-now>
```

If `time=` is still hours old, something else is going on (worth investigating then; not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)