### PR TITLE
feat(load-test): drop concurrent runs to 20 for sustainable iteration

### DIFF
--- a/test/load/circuit-stress/loomcycle.template.yaml
+++ b/test/load/circuit-stress/loomcycle.template.yaml
@@ -32,18 +32,23 @@ user_tiers:
         - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
     fallback_on_error: false
 
-# Concurrency — 100 active. The previous 120 cap was tuned for the
-# Ollama-deployed fallback ceiling; with single-provider Anthropic
-# we have more headroom but stay conservative at 100 so the
-# OAuth-dev rate limit (~120 concurrent Haiku calls per the x1000
-# investigation) has buffer.
+# Concurrency — 20 active. Empirical: a day of heavy load testing
+# on 2026-05-26 burned through Anthropic OAuth-dev MAX's per-minute
+# request budget; at 100 concurrent the account stays in a backoff
+# window and every request 429s. 20 leaves clear headroom under
+# the per-minute rate limit on a tired account.
 #
-# Queue depth 1500 (15× active) so x1000 can fully queue without
+# This is intentionally conservative for sustainable iteration —
+# tests can run back-to-back without exhausting the rate limiter.
+# If a fresh account has more headroom, bump this back up to 100.
+#
+# Queue depth 1500 (75× active) so x1000 can fully queue without
 # the 1500th circuit refusing at the admission boundary.
-# Timeout 5 min — at 100 active and ~25s per circuit, the 1000th
-# circuit waits ~4 min in queue.
+# Timeout 5 min — at 20 active and ~25s per circuit, the 1000th
+# circuit waits ~20 min in queue; bump queue_timeout_ms to 1800000
+# (30 min) for full-x1000 runs at this concurrency.
 concurrency:
-  max_concurrent_runs: 100
+  max_concurrent_runs: 20
   max_queue_depth: 1500
   queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0


### PR DESCRIPTION
## Summary

A day of heavy load testing on 2026-05-26 burned through Anthropic OAuth-dev MAX's per-minute rate limit. At 100 concurrent against a backed-off account every request returns 429.

20 active is well under the per-minute ceiling and lets tests run back-to-back without exhausting the rate limiter.

## Changes

```diff
 concurrency:
-  max_concurrent_runs: 100
+  max_concurrent_runs: 20
   max_queue_depth: 1500
   queue_timeout_ms: 300000
   max_concurrent_runs_per_user: 0
```

## Caveat for x1000 at 20-concurrent

At 20 active × ~25s/circuit, x1000 takes ~20 min wall-clock and the 1000th circuit waits ~20 min in queue. The current `queue_timeout_ms=300000` (5 min) may refuse the tail. Bump to `1800000` (30 min) if x1000 fails at the queue boundary.

x100 should run fine at this concurrency — about 2 min wall-clock.

## When to revisit

If a fresh Anthropic account has more rate-limit headroom, or we add a paid API-key fallback, bump `max_concurrent_runs` back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)