### PR TITLE
fix(resolve): MarkRateLimited matrix flag — structural fix for #235

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -474,43 +474,67 @@ func (s *Server) SessionLocks() *runner.SessionLockMap { return s.sessionLocks }
 func (s *Server) SetResolver(r *resolve.Resolver) { s.resolver = r }
 
 // markStalledFn returns a closure suitable for loop.RunOptions.MarkStalled.
-// The closure captures the resolver-scoped (provider, model) for the
-// current iteration; the loop calls it on driver errors that suggest
-// the model itself is broken (5xx after retry, mid-stream errors).
+// The loop invokes the closure with the LIVE (provider, model) for the
+// current iteration — which is meaningful when v0.8.2 fallback switched
+// providers mid-run. The unused `provider`/`model` args are kept on the
+// constructor signature for the wiring symmetry with markRateLimitedFn /
+// clearStallFn at call sites; their values seed the initial resolution
+// but the resolver receives the loop-supplied live pair.
 //
 // Returns nil when no resolver is wired (back-compat path) — RunOptions
 // treats nil as "stall feedback disabled".
-func (s *Server) markStalledFn(provider, model string) func(p, m, reason string) {
+//
+// PRE-2026-05-27 BUG: the closure used to ignore the loop's args and
+// pin to the construction-time (provider, model). When fallback ran
+// mid-run, MarkStalled poisoned the WRONG matrix entry — the original
+// provider got blamed for the post-switch provider's failure. Fixed
+// alongside the markRateLimitedFn addition (PR for #235 follow-up).
+func (s *Server) markStalledFn(_, _ string) func(p, m, reason string) {
 	if s.resolver == nil {
 		return nil
 	}
-	// Closure captures only what the loop needs. Loop passes
-	// (provider, model, reason); we ignore the loop's args and use
-	// the resolved pair from the call site, since they're the
-	// authoritative inputs to the resolver — the loop wouldn't know
-	// to discriminate between OpenAI vs DeepSeek without us telling
-	// it via opts.Provider.ID() (which is what it'll pass anyway,
-	// but pinning here keeps the contract explicit).
-	return func(_, _, reason string) {
-		s.resolver.MarkStalled(provider, model, reason)
+	return func(p, m, reason string) {
+		s.resolver.MarkStalled(p, m, reason)
+	}
+}
+
+// markRateLimitedFn returns a closure suitable for
+// loop.RunOptions.MarkRateLimited. Sibling to markStalledFn but for
+// the transient-429 case: the loop calls this — instead of
+// markStalledFn — when the surfaced error is a rate-limit response
+// that exhausted the driver's internal retry budget.
+//
+// Uses the LIVE (provider, model) from the loop's call. Critical for
+// the fallback case: the post-fallback provider is the one that
+// actually rate-limited, and that's the entry that should get the
+// cooldown — NOT the pre-fallback original provider.
+//
+// retryAfter flows through unchanged (the loop currently passes 0 =
+// use default; future work can thread the real Retry-After header up
+// from the driver).
+//
+// Returns nil when no resolver is wired — RunOptions treats nil as
+// "rate-limit feedback disabled".
+func (s *Server) markRateLimitedFn(_, _ string) func(p, m string, retryAfter time.Duration) {
+	if s.resolver == nil {
+		return nil
+	}
+	return func(p, m string, retryAfter time.Duration) {
+		s.resolver.MarkRateLimited(p, m, retryAfter)
 	}
 }
 
 // clearStallFn returns a closure suitable for loop.RunOptions.ClearStall.
 // Companion to markStalledFn: the loop calls it on a SUCCESSFUL
-// iteration, which is direct evidence the (provider, model) is
-// healthy now and any prior stall flag is stale. Idempotent at the
-// resolver layer.
-//
-// Pinning the provider+model here (same shape as markStalledFn) keeps
-// the resolver-feedback contract symmetric — both sides receive an
-// authoritative (provider, model) regardless of what the loop passes.
-func (s *Server) clearStallFn(provider, model string) func(p, m string) {
+// iteration with the live (provider, model). After fallback the
+// healthy provider is the one we want to credit — same fix as
+// markStalledFn for the same reason.
+func (s *Server) clearStallFn(_, _ string) func(p, m string) {
 	if s.resolver == nil {
 		return nil
 	}
-	return func(_, _ string) {
-		s.resolver.ClearStall(provider, model)
+	return func(p, m string) {
+		s.resolver.ClearStall(p, m)
 	}
 }
 
@@ -1321,6 +1345,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		MaxIterations:   agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
+		MarkRateLimited: s.markRateLimitedFn(providerID, model),
 		ClearStall:      s.clearStallFn(providerID, model),
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       effectiveAgentName,
@@ -2259,6 +2284,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		MaxIterations:   agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
+		MarkRateLimited: s.markRateLimitedFn(providerID, model),
 		ClearStall:      s.clearStallFn(providerID, model),
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       req.Agent,
@@ -2587,6 +2613,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		MaxIterations:   agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
+		MarkRateLimited: s.markRateLimitedFn(providerID, model),
 		ClearStall:      s.clearStallFn(providerID, model),
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       sess.Agent,
@@ -3186,6 +3213,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		MaxIterations:   def.MaxIterations, // 0 → loop default (16)
 		Effort:          effort,
 		MarkStalled:     s.markStalledFn(providerID, model),
+		MarkRateLimited: s.markRateLimitedFn(providerID, model),
 		ClearStall:      s.clearStallFn(providerID, model),
 		ToolParallelism: s.cfg.Env.ToolParallelism,
 		AgentName:       name,

--- a/internal/api/http/stall_feedback_test.go
+++ b/internal/api/http/stall_feedback_test.go
@@ -1,0 +1,125 @@
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+)
+
+// TestStallFeedbackClosures_UseLoopProvidedArgsNotConstructionPin pins
+// the v0.12.7+ correctness fix for the markStalledFn / markRateLimitedFn
+// / clearStallFn closure factories: they must use the live (provider,
+// model) the loop passes at INVOCATION time, NOT the (provider, model)
+// captured at the factory construction time.
+//
+// Why this matters: v0.8.2 fallback (tryProviderFallback) mutates
+// opts.Provider and opts.Model in place when a retryable error
+// triggers a provider switch. The loop's subsequent MarkStalled /
+// MarkRateLimited / ClearStall calls pass the LIVE pair via
+// opts.Provider.ID() + opts.Model — which is the post-fallback
+// provider, not the original. Closures that pin to construction-time
+// args poison the WRONG matrix entry and praise the WRONG entry.
+//
+// Pre-2026-05-27 the closures pinned. Code review during the
+// MarkRateLimited PR caught this; the fix replaces capture with
+// pass-through. This test pins the contract.
+func TestStallFeedbackClosures_UseLoopProvidedArgsNotConstructionPin(t *testing.T) {
+	// Minimal Server: just the resolver. The closure factories are
+	// `*Server` methods and only touch s.resolver.
+	r := resolve.NewResolver(
+		[]string{"anthropic", "deepseek"},
+		map[string][]resolve.Candidate{
+			"middle": {
+				{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+				{Provider: "deepseek", Model: "deepseek-v4-flash"},
+			},
+		},
+	)
+	r.SeedModel("anthropic", "claude-sonnet-4-6")
+	r.SeedModel("deepseek", "deepseek-v4-flash")
+	r.SetProviderReachable("anthropic", true)
+	r.SetProviderReachable("deepseek", true)
+	srv := &Server{resolver: r}
+
+	t.Run("markRateLimitedFn uses loop args", func(t *testing.T) {
+		// Factory called with "original" pair — that's what existed
+		// at run start, before fallback.
+		fn := srv.markRateLimitedFn("anthropic", "claude-sonnet-4-6")
+		if fn == nil {
+			t.Fatal("factory returned nil despite resolver set")
+		}
+		// Loop invokes with "post-fallback" pair — that's the one
+		// that actually 429'd.
+		fn("deepseek", "deepseek-v4-flash", 1*time.Hour)
+
+		// Assert: deepseek/deepseek-v4-flash is rate-limited, NOT
+		// anthropic/claude-sonnet-4-6.
+		snap := r.Snapshot()
+		if ds := snap["deepseek"].Models["deepseek-v4-flash"]; !ds.RateLimited {
+			t.Error("closure routed RateLimited to wrong matrix entry: deepseek/deepseek-v4-flash should have RateLimited=true")
+		}
+		if anthr := snap["anthropic"].Models["claude-sonnet-4-6"]; anthr.RateLimited {
+			t.Error("closure poisoned the construction-pin pair: anthropic/claude-sonnet-4-6 has RateLimited=true (should be false)")
+		}
+	})
+
+	t.Run("markStalledFn uses loop args", func(t *testing.T) {
+		// Reset by re-probing both providers.
+		r.SetReachable("anthropic", true, []string{"claude-sonnet-4-6"}, "")
+		r.SetReachable("deepseek", true, []string{"deepseek-v4-flash"}, "")
+
+		fn := srv.markStalledFn("anthropic", "claude-sonnet-4-6")
+		if fn == nil {
+			t.Fatal("factory returned nil")
+		}
+		fn("deepseek", "deepseek-v4-flash", "upstream 500")
+
+		snap := r.Snapshot()
+		if !snap["deepseek"].Models["deepseek-v4-flash"].Stalled {
+			t.Error("closure routed Stalled to wrong entry: deepseek/deepseek-v4-flash should be stalled")
+		}
+		if snap["anthropic"].Models["claude-sonnet-4-6"].Stalled {
+			t.Error("closure poisoned the construction-pin pair: anthropic/claude-sonnet-4-6 is stalled (should not be)")
+		}
+	})
+
+	t.Run("clearStallFn uses loop args", func(t *testing.T) {
+		// Set both stalled so we can prove the closure cleared the
+		// right one.
+		r.MarkStalled("anthropic", "claude-sonnet-4-6", "test")
+		r.MarkStalled("deepseek", "deepseek-v4-flash", "test")
+
+		fn := srv.clearStallFn("anthropic", "claude-sonnet-4-6")
+		if fn == nil {
+			t.Fatal("factory returned nil")
+		}
+		fn("deepseek", "deepseek-v4-flash")
+
+		snap := r.Snapshot()
+		// deepseek's stall cleared, anthropic's still set.
+		if snap["deepseek"].Models["deepseek-v4-flash"].Stalled {
+			t.Error("closure cleared wrong entry: deepseek/deepseek-v4-flash should be unstalled")
+		}
+		if !snap["anthropic"].Models["claude-sonnet-4-6"].Stalled {
+			t.Error("closure cleared construction-pin pair instead of loop-arg pair")
+		}
+	})
+}
+
+// TestStallFeedbackClosures_NilResolverReturnsNil pins the back-compat
+// path: with no resolver wired (Server.resolver == nil), the factories
+// return nil and the loop treats that as "feedback disabled."
+func TestStallFeedbackClosures_NilResolverReturnsNil(t *testing.T) {
+	srv := &Server{resolver: nil}
+
+	if fn := srv.markStalledFn("a", "b"); fn != nil {
+		t.Error("markStalledFn should return nil when resolver is unset")
+	}
+	if fn := srv.markRateLimitedFn("a", "b"); fn != nil {
+		t.Error("markRateLimitedFn should return nil when resolver is unset")
+	}
+	if fn := srv.clearStallFn("a", "b"); fn != nil {
+		t.Error("clearStallFn should return nil when resolver is unset")
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
@@ -184,6 +185,37 @@ type RunOptions struct {
 	// tiers, a stall surviving past a successful call on the
 	// same pair was collapsing the cascade between probes.
 	ClearStall func(provider, model string)
+
+	// MarkRateLimited is the resolver-feedback hook for 429
+	// rate-limit responses that exhausted the driver's internal
+	// retry budget. Distinct from MarkStalled: rate-limit is
+	// transient ("slow down for a moment"), not "the model is
+	// broken for the probe interval".
+	//
+	// The loop calls this — instead of MarkStalled — when the
+	// surfaced error is a 429. The matrix records a time-bound
+	// cooldown that self-recovers without waiting for the next
+	// probe; subsequent Resolve calls during the cooldown either
+	// fall through to the next tier candidate (when fallback is
+	// configured) or surface a clean tier-unavailable error.
+	//
+	// retryAfter is the duration to mark the model unavailable.
+	// Pass 0 to use the resolver's default (30s). When/if a future
+	// version threads provider Retry-After headers up from the
+	// driver, pass the parsed duration here.
+	//
+	// Optional: nil disables rate-limit feedback (the model gets
+	// retried on every subsequent run until the rate window
+	// resets organically — worse for the next caller's latency
+	// but no worse than pre-v0.12.7).
+	//
+	// Background: the v0.12.7 x1000 load test (2026-05-26)
+	// discovered that treating 429 like 5xx in MarkStalled
+	// poisoned the matrix for the full 15-min probe interval
+	// after a single rate-limit storm. PR #235 patched this
+	// with a skip-on-429 guard at the MarkStalled call site;
+	// MarkRateLimited is the proper structural fix.
+	MarkRateLimited func(provider, model string, retryAfter time.Duration)
 }
 
 // FallbackPolicy controls the v0.8.2 runtime fallback path. The HTTP
@@ -543,29 +575,34 @@ outerLoop:
 		}
 		ch, err := opts.Provider.Call(iterCtx, req)
 		if err != nil {
-			// Resolver stall feedback: a non-context error from Call()
-			// is the driver giving up after its own retries. Mark the
-			// (provider, model) stalled so the resolver stops returning
-			// it until the next periodic probe re-validates.
+			// Resolver feedback: a non-context error from Call() is
+			// the driver giving up after its own retries. Route the
+			// feedback by error class:
 			//
-			// EXCEPTION: rate-limit errors (HTTP 429). Originally these
-			// also triggered MarkStalled, but the v0.12.x x1000 load
-			// test (2026-05-26) showed it's too aggressive: ~120
-			// concurrent OAuth-dev calls into Anthropic's rate limit
-			// poisoned the matrix, and the resolver's 15-min probe
-			// interval meant the next ~800 run-admit attempts ALL
-			// failed with 503 `no provider available`. A 429 is "slow
-			// down for a moment", not "the model is broken"; the
-			// fallback path (just below) handles the per-call response
-			// correctly, and the next call has its own ratelimit.Do
-			// retry budget. Sustained 5xx still triggers stall — that
-			// case IS "model broken for a while, stop wasting calls."
+			//   429 (rate limit) → MarkRateLimited (self-recovering
+			//     30s cooldown; transient, not "model broken")
+			//   5xx / model 404 / network → MarkStalled (15-min
+			//     probe-gated recovery; "model is broken for a
+			//     while, stop wasting calls")
+			//
+			// The split matters: pre-v0.12.7 MarkStalled treated 429
+			// the same as 5xx, which under the x1000 load test
+			// (2026-05-26) cascaded ~120 rate-limited runs into 800+
+			// "no provider available" 503s for the rest of the probe
+			// interval. PR #235 patched this with a skip-on-429
+			// guard; this site is the structural fix — positive call
+			// to the right method.
 			//
 			// ctx errors are user-side cancellation, not provider
-			// faults — also don't pollute the matrix.
-			if opts.MarkStalled != nil && ctx.Err() == nil &&
-				!providers.IsRateLimit(err) {
-				opts.MarkStalled(opts.Provider.ID(), opts.Model, err.Error())
+			// faults — don't pollute the matrix on either path.
+			if ctx.Err() == nil {
+				if providers.IsRateLimit(err) {
+					if opts.MarkRateLimited != nil {
+						opts.MarkRateLimited(opts.Provider.ID(), opts.Model, 0)
+					}
+				} else if opts.MarkStalled != nil {
+					opts.MarkStalled(opts.Provider.ID(), opts.Model, err.Error())
+				}
 			}
 			// v0.8.2: when the run carries a fallback policy and the
 			// error class is retryable, swap to the next provider
@@ -628,18 +665,21 @@ outerLoop:
 				iterUsage = ev.Usage
 				iterReasoning = ev.Reasoning
 			case providers.EventError:
-				// Resolver stall feedback for in-stream errors:
-				// driver opened the SSE/NDJSON stream successfully
-				// but then surfaced a provider-side error (5xx
-				// mid-stream, model 404 on dispatch, etc.). Mark
-				// stalled. Same ctx-guard as above — user cancel
-				// shouldn't pollute the matrix. Same 429 exception
-				// as above — rate limits are transient and shouldn't
-				// poison the matrix for 15 min.
+				// Resolver feedback for in-stream errors: same
+				// 429-vs-5xx routing as the Call() error path
+				// above. Driver opened the SSE/NDJSON stream
+				// successfully but then surfaced a provider-side
+				// error mid-stream — route to MarkRateLimited or
+				// MarkStalled based on whether it's a 429.
 				streamErr := errors.New(ev.Error)
-				if opts.MarkStalled != nil && ctx.Err() == nil &&
-					!providers.IsRateLimit(streamErr) {
-					opts.MarkStalled(opts.Provider.ID(), opts.Model, ev.Error)
+				if ctx.Err() == nil {
+					if providers.IsRateLimit(streamErr) {
+						if opts.MarkRateLimited != nil {
+							opts.MarkRateLimited(opts.Provider.ID(), opts.Model, 0)
+						}
+					} else if opts.MarkStalled != nil {
+						opts.MarkStalled(opts.Provider.ID(), opts.Model, ev.Error)
+					}
 				}
 				// v0.8.2: classify the RAW provider error string
 				// (e.g. "anthropic 503: backend unavailable") for

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -393,6 +394,120 @@ func TestLoop_NoMarkStalledOnRateLimit(t *testing.T) {
 	}
 	if stallCount != 0 {
 		t.Errorf("MarkStalled called %d times on 429, want 0 (rate limits are transient — must not poison the matrix)", stallCount)
+	}
+}
+
+// TestRun_MarkRateLimitedCalledOn429 pins the v0.12.x+ structural
+// fix: a 429 surfacing from the driver routes to MarkRateLimited
+// (NOT MarkStalled). Companion to TestLoop_NoMarkStalledOnRateLimit
+// above — this one asserts the positive side (MarkRateLimited fires).
+func TestRun_MarkRateLimitedCalledOn429(t *testing.T) {
+	prov := &erroringProvider{err: fmt.Errorf("anthropic 429: rate limit exceeded")}
+	type rateLimitCall struct {
+		provider, model string
+		retryAfter      time.Duration
+	}
+	var (
+		rateLimits []rateLimitCall
+		stalls     int
+	)
+	_, err := Run(context.Background(), RunOptions{
+		Provider: prov,
+		Model:    "claude-haiku-4-5",
+		Segments: []PromptSegment{
+			{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "x"}}},
+		},
+		MarkStalled: func(_, _, _ string) { stalls++ },
+		MarkRateLimited: func(p, m string, retryAfter time.Duration) {
+			rateLimits = append(rateLimits, rateLimitCall{p, m, retryAfter})
+		},
+	})
+	if err == nil {
+		t.Fatal("Run should propagate the 429 to the caller")
+	}
+	if len(rateLimits) != 1 {
+		t.Fatalf("MarkRateLimited calls = %d, want 1", len(rateLimits))
+	}
+	got := rateLimits[0]
+	if got.provider != "erroring" || got.model != "claude-haiku-4-5" {
+		t.Errorf("MarkRateLimited = %+v, want erroring/claude-haiku-4-5", got)
+	}
+	// Loop passes retryAfter=0 (default-cooldown). The matrix
+	// interprets 0 as "use defaultRateLimitCooldown". Pin the
+	// contract: the loop doesn't compute its own duration.
+	if got.retryAfter != 0 {
+		t.Errorf("retryAfter = %v, want 0 (loop should defer to matrix default)", got.retryAfter)
+	}
+	if stalls != 0 {
+		t.Errorf("MarkStalled called %d times on 429, want 0", stalls)
+	}
+}
+
+// TestRun_MarkStalledCalledOn5xx pins the regression guard for the
+// 429/5xx split: a 5xx error must still trigger MarkStalled (and not
+// MarkRateLimited). The fix in v0.12.x routes by error class — this
+// test confirms 5xx stays on the stall path.
+func TestRun_MarkStalledCalledOn5xx(t *testing.T) {
+	prov := &erroringProvider{err: fmt.Errorf("anthropic 500: upstream timeout")}
+	var (
+		stalls     int
+		rateLimits int
+	)
+	_, err := Run(context.Background(), RunOptions{
+		Provider: prov,
+		Model:    "claude-opus-4-7",
+		Segments: []PromptSegment{
+			{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "x"}}},
+		},
+		MarkStalled:     func(_, _, _ string) { stalls++ },
+		MarkRateLimited: func(_, _ string, _ time.Duration) { rateLimits++ },
+	})
+	if err == nil {
+		t.Fatal("Run should propagate the 500 to the caller")
+	}
+	if stalls != 1 {
+		t.Errorf("MarkStalled calls = %d, want 1 (5xx still stalls)", stalls)
+	}
+	if rateLimits != 0 {
+		t.Errorf("MarkRateLimited calls = %d, want 0 (5xx is not a rate-limit error)", rateLimits)
+	}
+}
+
+// TestRun_StreamEventError429CallsMarkRateLimited covers the second
+// MarkStalled/MarkRateLimited call site in the loop: in-stream
+// EventError. Same 429/5xx routing as the Call() error path.
+func TestRun_StreamEventError429CallsMarkRateLimited(t *testing.T) {
+	// Provider opens a stream then emits an EventError carrying a
+	// 429-shaped error. fakeProvider supports this directly via the
+	// responses [][]providers.Event scripting field.
+	prov := &fakeProvider{
+		responses: [][]providers.Event{
+			{
+				{Type: providers.EventError, Error: "anthropic 429: rate limit exceeded mid-stream"},
+				{Type: providers.EventDone, StopReason: "error"},
+			},
+		},
+	}
+
+	var (
+		rateLimits int
+		stalls     int
+	)
+	_, _ = Run(context.Background(), RunOptions{
+		Provider: prov,
+		Model:    "claude-haiku-4-5",
+		Segments: []PromptSegment{
+			{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "x"}}},
+		},
+		MarkStalled:     func(_, _, _ string) { stalls++ },
+		MarkRateLimited: func(_, _ string, _ time.Duration) { rateLimits++ },
+	})
+
+	if rateLimits != 1 {
+		t.Errorf("MarkRateLimited calls = %d, want 1 (in-stream 429 should hit the rate-limit path)", rateLimits)
+	}
+	if stalls != 0 {
+		t.Errorf("MarkStalled calls = %d, want 0 (in-stream 429 should NOT trigger stall)", stalls)
 	}
 }
 

--- a/internal/providers/errclass_test.go
+++ b/internal/providers/errclass_test.go
@@ -102,6 +102,19 @@ func TestIsRateLimit(t *testing.T) {
 		{"context canceled", context.Canceled, false},
 		{"context deadline exceeded", context.DeadlineExceeded, false},
 		{"429 in body but not prefix", errors.New("got body: error 429"), false},
+		// Wrapped-driver cases: DeepSeek delegates to the OpenAI
+		// inner driver, so its 429 surfaces with an "openai 429:"
+		// prefix even though the matrix entry is "deepseek". Same
+		// for anthropic-oauth-dev wrapping anthropic. IsRateLimit
+		// looks at the status code only, so detection works either
+		// way; the resolver-side matrix entry is keyed by what the
+		// loop passes via opts.Provider.ID().
+		{"openai 429 (also deepseek wrap)", errors.New("openai 429: rate limited"), true},
+		{"anthropic 429 (also oauth-dev wrap)", errors.New("anthropic 429: limit exceeded"), true},
+		// Ollama uses hyphenated provider IDs ("ollama" or
+		// "ollama-local"). The regex accepts hyphens — verify both.
+		{"ollama 429", errors.New("ollama 429: too many concurrent requests"), true},
+		{"ollama-local 429", errors.New("ollama-local 429: too many requests"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -228,7 +228,10 @@ type Availability struct {
 }
 
 // ModelStatus is one model's status under a provider. A model is
-// usable iff (provider.Reachable && model.Listed && !model.Stalled).
+// usable iff:
+//
+//	provider.Reachable && model.Listed && !model.Stalled &&
+//	  (!model.RateLimited || now >= model.RateLimitedUntil)
 type ModelStatus struct {
 	// Listed means the provider's models endpoint surfaced this
 	// model on the most recent probe. PR 1's stub probe pre-seeds
@@ -240,8 +243,29 @@ type ModelStatus struct {
 	// Stalled is set by MarkStalled when a runtime call failed in a
 	// way that suggests the model itself is broken (404 on the model
 	// name, 5xx after the rate-limit retry budget). Cleared by the
-	// next successful probe of this provider.
+	// next successful probe of this provider. Stall recovery is
+	// gated by the periodic probe interval (~15 min default).
 	Stalled bool
+
+	// RateLimited is set by MarkRateLimited when a runtime call
+	// returned a 429 AFTER the driver's internal retry budget was
+	// exhausted. Unlike Stalled, this flag is SELF-RECOVERING:
+	// isAvailableLocked treats the model as available again once
+	// time.Now() >= RateLimitedUntil, without waiting for the
+	// next periodic probe.
+	//
+	// 429 is "slow down for a moment" not "the model is broken";
+	// matrix-poisoning that model for the full 15-min probe interval
+	// is too aggressive. The v0.12.7 x1000 load test (2026-05-26)
+	// showed why: a single rate-limit storm took down the entire
+	// pipeline for the rest of the test until the resolver re-probed.
+	//
+	// Independent of Stalled — a model can have both flags set
+	// simultaneously (e.g., transient 5xx stall, then a 429 on the
+	// re-attempt before the probe clears the stall). isAvailableLocked
+	// returns false if EITHER flag is active.
+	RateLimited      bool
+	RateLimitedUntil time.Time
 
 	// LastError is the last failure for this specific model.
 	// Independent of the provider-level LastError so an operator can
@@ -477,6 +501,11 @@ func (r *Resolver) priorityFor(req AgentRequest) (order []string, refused bool) 
 
 // isAvailableLocked checks whether a (provider, model) is currently
 // usable. Caller holds r.mu (read or write).
+//
+// The RateLimited check is read-only: when now >= RateLimitedUntil
+// the flag is treated as expired without rewriting the matrix. The
+// next MarkRateLimited or successful probe clears the stored field.
+// This keeps isAvailableLocked free of lock upgrades on the hot path.
 func (r *Resolver) isAvailableLocked(provider, model string) bool {
 	avail, ok := r.matrix[provider]
 	if !ok || avail.Excluded || !avail.Reachable {
@@ -486,7 +515,13 @@ func (r *Resolver) isAvailableLocked(provider, model string) bool {
 	if !ok {
 		return false
 	}
-	return status.Listed && !status.Stalled
+	if !status.Listed || status.Stalled {
+		return false
+	}
+	if status.RateLimited && time.Now().Before(status.RateLimitedUntil) {
+		return false
+	}
+	return true
 }
 
 // SetReachable updates the matrix for a probe outcome. PR 1 calls
@@ -536,8 +571,24 @@ func (r *Resolver) SetReachable(provider string, reachable bool, listedModels []
 	for _, m := range listedModels {
 		listed[m] = true
 	}
+	// Re-probe success clears Stalled (the model came back from the
+	// wire, so the runtime feedback that set it was transient). But
+	// it does NOT clear an unexpired RateLimited cooldown: the
+	// /v1/models endpoint and the inference endpoint have separate
+	// quotas at most providers, so a list success doesn't imply
+	// inference quota recovery. Carry forward live cooldowns so a
+	// rate-limit storm isn't masked by a probe-window coincidence.
+	// Expired cooldowns naturally lapse to zero — `time.Time{}.Before`
+	// of "now" is always true, so isAvailableLocked treats them as
+	// available regardless.
+	now := time.Now()
 	for m := range listed {
-		newModels[m] = ModelStatus{Listed: true} // Stalled cleared on re-probe
+		st := ModelStatus{Listed: true}
+		if prev, ok := avail.Models[m]; ok && prev.RateLimited && now.Before(prev.RateLimitedUntil) {
+			st.RateLimited = true
+			st.RateLimitedUntil = prev.RateLimitedUntil
+		}
+		newModels[m] = st
 	}
 	avail.Models = newModels
 }
@@ -614,6 +665,10 @@ func (r *Resolver) SetExcluded(provider, reason string) {
 // Stall is per-model, not per-provider, so a single bad model on
 // DeepSeek doesn't take down the whole driver — the resolver just
 // skips that candidate and moves to the next.
+//
+// Stall recovery is gated by the periodic probe interval (15 min
+// default). For TRANSIENT failures (429 rate limit) use
+// MarkRateLimited instead — it self-recovers on a short timer.
 func (r *Resolver) MarkStalled(provider, model, reason string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -632,6 +687,78 @@ func (r *Resolver) MarkStalled(provider, model, reason string) {
 	st := avail.Models[model]
 	st.Stalled = true
 	st.LastError = reason
+	avail.Models[model] = st
+	avail.LastCheck = time.Now()
+}
+
+// defaultRateLimitCooldown is how long MarkRateLimited blocks a model
+// when the caller doesn't supply a Retry-After-derived duration. 30s
+// chosen as a balance between two competing concerns:
+//
+//   - Anthropic's rate windows are typically 60s; waiting the full
+//     window means leaving capacity on the table.
+//   - Anthropic's `Retry-After` headers (when set) are usually
+//     1-30s, so the floor 30s is the conservative end of observed
+//     real-world wait times.
+//
+// 30s gives the rate window time to partially recover and lets
+// subsequent runs reattempt before the full window closes. The
+// fallback path runs in parallel — runs that need a model RIGHT NOW
+// route to the next tier candidate.
+const defaultRateLimitCooldown = 30 * time.Second
+
+// MarkRateLimited records a 429-exhausted state for a (provider, model)
+// pair. The loop calls this when Provider.Call() — or an EventError in
+// the stream — surfaces a rate-limit response AFTER the driver's
+// internal retry budget is spent.
+//
+// Distinct from MarkStalled in two ways:
+//
+//   - Self-recovering: isAvailableLocked treats the model as available
+//     again once time.Now() >= RateLimitedUntil. No probe required.
+//   - Per-call: the current run already failed with the 429. This
+//     method only affects FUTURE Resolve calls during the cooldown
+//     window. The flag tells the resolver "skip this candidate; it'll
+//     just 429 again", which lets fallback engage cleanly. With no
+//     fallback configured, the next Resolve within the cooldown
+//     returns ErrTierUnavailable — the operator's responsibility,
+//     same as today.
+//
+// retryAfter is added to time.Now() to compute the cooldown deadline.
+// Pass 0 to use defaultRateLimitCooldown (30s). When/if a future
+// version threads Retry-After up from the driver, pass the parsed
+// duration here.
+//
+// Independent of MarkStalled — a model can be both rate-limited AND
+// stalled simultaneously (e.g., 5xx stall, then 429 on re-attempt
+// before the probe clears the stall). isAvailableLocked returns false
+// if either flag is active.
+//
+// Background: the v0.12.7 x1000 load test (2026-05-26) discovered
+// that treating 429 like 5xx took down the entire pipeline for the
+// rest of the probe interval (~15 min). PR #235 patched this with a
+// skip-on-429 in the loop; this method is the proper structural fix
+// (the loop calls MarkRateLimited instead of skipping matrix feedback
+// entirely). The skip is replaced with a positive method call.
+func (r *Resolver) MarkRateLimited(provider, model string, retryAfter time.Duration) {
+	if retryAfter <= 0 {
+		retryAfter = defaultRateLimitCooldown
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	avail, ok := r.matrix[provider]
+	if !ok {
+		// Same defensive shape as MarkStalled — create the entry so
+		// the next Resolve can see the rate-limit flag.
+		avail = &Availability{Models: map[string]ModelStatus{}}
+		r.matrix[provider] = avail
+	}
+	if avail.Models == nil {
+		avail.Models = map[string]ModelStatus{}
+	}
+	st := avail.Models[model]
+	st.RateLimited = true
+	st.RateLimitedUntil = time.Now().Add(retryAfter)
 	avail.Models[model] = st
 	avail.LastCheck = time.Now()
 }

--- a/internal/resolve/matrix_test.go
+++ b/internal/resolve/matrix_test.go
@@ -3,7 +3,9 @@ package resolve
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 )
 
 // fixtureLibrary returns the May-2026 default matrix — same shape the
@@ -833,5 +835,265 @@ func TestForceProbe_ReplacingCallbackUsesLatest(t *testing.T) {
 	}
 	if new != 1 {
 		t.Errorf("new callback called %d times; expected 1", new)
+	}
+}
+
+// ---- MarkRateLimited tests (v0.12.7+) ----
+
+// TestMarkRateLimited_BlocksResolveWithinCooldown — model marked
+// rate-limited with a long cooldown is excluded from Resolve;
+// the candidate after it in the priority list gets picked.
+func TestMarkRateLimited_BlocksResolveWithinCooldown(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	// 5s cooldown — well in the future for this test.
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 5*time.Second)
+
+	d, err := r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	// deepseek-v4-flash was first in tier `low`; with it rate-limited
+	// the next candidate should win — that's ollama-local/gemma4:9b.
+	if d.Provider == "deepseek" {
+		t.Errorf("rate-limited candidate was picked: provider=%s model=%s", d.Provider, d.Model)
+	}
+}
+
+// TestMarkRateLimited_SelfRecoversAfterCooldown — once the cooldown
+// expires (RateLimitedUntil <= now) the model is available again
+// WITHOUT any probe running. The expiry check is read-only in
+// isAvailableLocked; no rewrite needed.
+func TestMarkRateLimited_SelfRecoversAfterCooldown(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	// 1ns cooldown — instantly expires.
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 1*time.Nanosecond)
+	// Sleep a touch to ensure now > RateLimitedUntil.
+	time.Sleep(2 * time.Millisecond)
+
+	d, err := r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.Provider != "deepseek" || d.Model != "deepseek-v4-flash" {
+		t.Errorf("expected self-recovery to deepseek-v4-flash; got %s/%s", d.Provider, d.Model)
+	}
+	// Snapshot the model — the RateLimited flag stays true in the
+	// stored record (we don't rewrite on expiry); the check is
+	// transparent based on time. Documenting the invariant.
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if !snap.RateLimited {
+		t.Error("RateLimited flag should still be set in the stored record (read-only expiry)")
+	}
+}
+
+// TestMarkRateLimited_IndependentOfStalled — Stalled and RateLimited
+// are independent flags. A model with both set is unavailable;
+// clearing one leaves the other in effect.
+func TestMarkRateLimited_IndependentOfStalled(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	r.MarkStalled("deepseek", "deepseek-v4-flash", "test 5xx")
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 1*time.Hour)
+
+	// Both flags set → unavailable.
+	d, _ := r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if d.Provider == "deepseek" && d.Model == "deepseek-v4-flash" {
+		t.Error("model with both Stalled+RateLimited should be unavailable")
+	}
+
+	// Clear stall only — rate-limit still in effect → still unavailable.
+	r.ClearStall("deepseek", "deepseek-v4-flash")
+	d, _ = r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if d.Provider == "deepseek" && d.Model == "deepseek-v4-flash" {
+		t.Error("ClearStall on a still-rate-limited model should not restore availability")
+	}
+
+	// Verify the matrix state directly: Stalled cleared, RateLimited
+	// still set.
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if snap.Stalled {
+		t.Error("Stalled should be cleared after ClearStall")
+	}
+	if !snap.RateLimited {
+		t.Error("RateLimited should remain set after ClearStall")
+	}
+}
+
+// TestMarkRateLimited_SetReachableClearsStallButPreservesActiveCooldown —
+// the periodic probe represents "we just talked to this provider's
+// /v1/models endpoint successfully." Stalled clears (the model came
+// back from the wire, so runtime feedback was transient) but an
+// active RateLimited cooldown DOES NOT clear: the listing endpoint
+// and the inference endpoint have separate quotas at most providers,
+// so a list success doesn't imply inference quota recovery.
+//
+// This pins the v0.12.7+ behavior; pre-fix, SetReachable wiped both
+// flags, which created a real production hazard — under a 429 storm
+// the probe could clear the cooldown mid-window and the next run
+// would immediately 429 again.
+func TestMarkRateLimited_SetReachableClearsStallButPreservesActiveCooldown(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	r.MarkStalled("deepseek", "deepseek-v4-flash", "test 5xx")
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 1*time.Hour)
+
+	// Probe-style re-set with the model listed.
+	r.SetReachable("deepseek", true, []string{"deepseek-v4-flash", "deepseek-v4-pro"}, "")
+
+	// Stalled IS cleared. RateLimited (still 1h in the future) is NOT.
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if snap.Stalled {
+		t.Error("Stalled should be cleared by SetReachable (model re-listed)")
+	}
+	if !snap.RateLimited {
+		t.Error("RateLimited should NOT be cleared by SetReachable (cooldown still active)")
+	}
+
+	// Resolve should fall through to the next candidate, not pick the
+	// still-rate-limited deepseek.
+	d, _ := r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if d.Provider == "deepseek" {
+		t.Errorf("expected fallthrough past still-cooldown model; got %s/%s", d.Provider, d.Model)
+	}
+}
+
+// TestMarkRateLimited_SetReachableClearsExpiredCooldown — companion
+// to the above. When the cooldown has already expired by the time
+// the probe runs, the new ModelStatus literal naturally has no
+// RateLimited carry-forward (the condition `prev.RateLimitedUntil >
+// now` is false). The model returns to the pool cleanly.
+func TestMarkRateLimited_SetReachableClearsExpiredCooldown(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	// Cooldown that expires immediately.
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 1*time.Nanosecond)
+	time.Sleep(2 * time.Millisecond)
+
+	r.SetReachable("deepseek", true, []string{"deepseek-v4-flash"}, "")
+
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if snap.RateLimited {
+		t.Error("expired RateLimited cooldown should clear on re-probe")
+	}
+}
+
+// TestMarkRateLimited_PinUnavailableWhenRateLimited — explicit pin
+// path consults isAvailableLocked just like the tier path. A
+// pinned-but-rate-limited model surfaces as ErrPinUnavailable.
+func TestMarkRateLimited_PinUnavailableWhenRateLimited(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	r.MarkRateLimited("anthropic", "claude-opus-4-7", 5*time.Second)
+
+	_, err := r.Resolve(AgentRequest{
+		Name:        "agent-x",
+		PinProvider: "anthropic",
+		PinModel:    "claude-opus-4-7",
+	})
+	if !errors.Is(err, ErrPinUnavailable) {
+		t.Errorf("expected ErrPinUnavailable on rate-limited pin; got %v", err)
+	}
+}
+
+// TestMarkRateLimited_DefaultCooldownUsedWhenZeroPassed — passing 0
+// for retryAfter uses defaultRateLimitCooldown (30s).
+func TestMarkRateLimited_DefaultCooldownUsedWhenZeroPassed(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	before := time.Now()
+	r.MarkRateLimited("deepseek", "deepseek-v4-flash", 0)
+	after := time.Now()
+
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if !snap.RateLimited {
+		t.Fatal("RateLimited not set")
+	}
+	// RateLimitedUntil should be in [before+30s, after+30s].
+	wantLower := before.Add(30 * time.Second)
+	wantUpper := after.Add(30 * time.Second).Add(100 * time.Millisecond)
+	if snap.RateLimitedUntil.Before(wantLower) || snap.RateLimitedUntil.After(wantUpper) {
+		t.Errorf("RateLimitedUntil = %v, want approximately %v (default 30s)",
+			snap.RateLimitedUntil, wantLower)
+	}
+}
+
+// TestMarkRateLimited_NoOpOnUnknownProvider — calling on a provider
+// not in the matrix creates the entry but doesn't break subsequent
+// Resolve calls on configured providers. Same shape as
+// MarkStalled's defensive behavior.
+func TestMarkRateLimited_NoOpOnUnknownProvider(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	// Should not panic, should not affect deepseek's availability.
+	r.MarkRateLimited("never-heard-of-it", "ghost-model", 1*time.Hour)
+
+	d, err := r.Resolve(AgentRequest{Name: "agent-x", Tier: "low"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if d.Provider != "deepseek" || d.Model != "deepseek-v4-flash" {
+		t.Errorf("unrelated MarkRateLimited disrupted Resolve: got %s/%s", d.Provider, d.Model)
+	}
+}
+
+// TestMarkRateLimited_ConcurrentWritesSafe pins the concurrency
+// contract: many goroutines calling MarkRateLimited on the same
+// model simultaneously do not panic and produce a consistent
+// final state. The implementation holds r.mu.Lock() across the
+// read-modify-write so last-writer-wins by mutex ordering.
+//
+// At x1000 load this is the actual access pattern — N parallel
+// failing runs all hit MarkRateLimited on the same (provider, model)
+// at roughly the same moment.
+//
+// Pinning current behavior: the LAST cooldown written wins (not the
+// max). If a future call passes a 1s cooldown after a 30s call landed,
+// the model becomes available 29 seconds early. Acceptable for now —
+// production callers all pass 0 (use default 30s) so they're identical.
+// If we ever thread real Retry-After values through, consider switching
+// to max() semantics here.
+func TestMarkRateLimited_ConcurrentWritesSafe(t *testing.T) {
+	priority, tiers := fixtureLibrary()
+	r := NewResolver(priority, tiers)
+	seedAll(t, r, tiers)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.MarkRateLimited("deepseek", "deepseek-v4-flash", 30*time.Second)
+		}()
+	}
+	wg.Wait()
+
+	// All N writes complete without panic; the final state has
+	// RateLimited=true and a future RateLimitedUntil.
+	snap := r.Snapshot()["deepseek"].Models["deepseek-v4-flash"]
+	if !snap.RateLimited {
+		t.Error("RateLimited should be set after concurrent writes")
+	}
+	if !snap.RateLimitedUntil.After(time.Now()) {
+		t.Errorf("RateLimitedUntil = %v should be in the future after concurrent writes",
+			snap.RateLimitedUntil)
 	}
 }


### PR DESCRIPTION
## Summary

PR #235 patched the v0.12.7 x1000 cascade by **skipping** `MarkStalled` on 429 errors. That's a workaround — the matrix still had no representation for "rate-limited" distinct from "broken", and at scale every concurrent run rediscovered the limit independently.

This PR is the structural fix: a dedicated `RateLimited` flag on `ModelStatus` with a self-recovering 30s cooldown.

## Changes

### `internal/resolve/matrix.go`

- `ModelStatus.RateLimited bool` + `RateLimitedUntil time.Time`
- `Resolver.MarkRateLimited(provider, model, retryAfter)` — sets the cooldown, defaults 30s when `retryAfter=0`
- `isAvailableLocked` treats a model as unavailable when `RateLimited && now < RateLimitedUntil`. The expiry check is read-only — no lock upgrade.
- `SetReachable` preserves **unexpired** rate-limit cooldowns (the `/v1/models` endpoint and inference endpoint have separate quotas at most providers; a probe success doesn't imply inference recovery)

### `internal/loop/loop.go`

- `RunOptions.MarkRateLimited func(provider, model, retryAfter)`
- Both call sites (Call() error + EventError in-stream) now route by `providers.IsRateLimit(err)`:
  - **429** → `opts.MarkRateLimited` (self-recovering, 30s default)
  - **5xx** → `opts.MarkStalled` (probe-gated, 15 min)
- Replaces the skip-on-429 guards from PR #235.

### `internal/api/http/server.go`

- New `markRateLimitedFn` closure factory, sibling to `markStalledFn`
- Wired at all 4 `RunOptions` construction sites

## Code review fixes (caught before PR)

1. **`markStalledFn` / `markRateLimitedFn` / `clearStallFn` used to capture `(provider, model)` at construction time**, ignoring post-fallback mutation of `opts.Provider` / `opts.Model`. The closures now pass through the loop-supplied args. This was a **pre-existing bug** for `markStalledFn` and `clearStallFn` that this PR amplified — fixed for all three.

2. **`SetReachable` used to wipe `RateLimited` on every probe success.** But `/v1/models` and inference endpoints have separate quotas; a list success doesn't imply inference recovery. Now preserves unexpired cooldowns.

## Test plan

- [x] `internal/resolve/matrix_test.go` — 9 new tests covering: cooldown blocks Resolve, self-recovery after expiry, independence from Stalled, SetReachable preserves active + clears expired cooldowns, pin path, default cooldown derivation, no-op on unknown provider, concurrent writes safe
- [x] `internal/loop/loop_test.go` — 3 new tests covering both call sites (Call() error + EventError) routing by error class
- [x] `internal/api/http/stall_feedback_test.go` (new file) — 2 tests for the closure-uses-loop-args correctness fix
- [x] `internal/providers/errclass_test.go` — 4 new cases covering driver-wrap shapes (DeepSeek-via-OpenAI, OAuth-dev-via-Anthropic, Ollama hyphenated IDs)
- [x] Full `go test ./internal/... -race -short` clean
- [x] gofmt clean
- [ ] Re-run circuit-stress x100+ when Anthropic rate-limit cools — expect MarkRateLimited fires on 429s, matrix preserves health, runs route to fallback cleanly

## Effect at the failing x1000 scenario

**Before #235**: 429 storm → matrix poisoned → 950 cascade-503s for 15 min
**After #235** (workaround): 429 errors surface per-call, matrix stays clean, but each run rediscovers the limit
**After this PR** (structural): 429 storm → matrix records 30s cooldown → subsequent Resolve calls within 30s either fall through to fallback OR cleanly 503 with `tier_unavailable` (operator decides via FallbackPolicy). Self-recovers without probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)