### PR TITLE
feat(load-test): provider telemetry — capture which provider served each run

### DIFF
--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.11.5",
+  "version": "0.12.7",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 46 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed AND v0.11.5 setMemoryEntry + deleteMemoryEntry), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.11.5 Channel admin CRUD (createChannel + updateChannel + deleteChannel — runtime substrate; yaml channels refuse mutation with HTTP 409), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -238,6 +238,12 @@ export interface AgentUsage {
   cache_creation_tokens?: number;
   cache_read_tokens?: number;
   model?: string;
+  // provider is the provider id that actually served the final
+  // successful iteration (e.g. "anthropic", "deepseek"). Distinct
+  // from model so consumers can tell primary-provider runs from
+  // runtime-fallback routed runs. Added in v0.12.7 — pre-migration
+  // server rows + pre-call failures omit this field.
+  provider?: string;
 }
 
 export interface Agent {

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3264,6 +3264,14 @@ type agentResponseUsage struct {
 	CacheCreationTokens int    `json:"cache_creation_tokens,omitempty"`
 	CacheReadTokens     int    `json:"cache_read_tokens,omitempty"`
 	Model               string `json:"model,omitempty"`
+	// Provider is the provider id that actually served the final
+	// successful iteration of the run (e.g. "anthropic", "deepseek").
+	// Distinct from Model so post-run analysis can tell
+	// primary-provider runs from runtime-fallback routed runs (the
+	// v0.8.2 tryProviderFallback path mutates opts.Provider in place
+	// when a 429 / 5xx triggers a switch). Empty for pre-migration
+	// rows and for runs that never reached a provider call.
+	Provider string `json:"provider,omitempty"`
 }
 
 // runToAgentResponse converts a store.Run into the API response shape.
@@ -3290,6 +3298,7 @@ func runToAgentResponse(r store.Run, live bool) agentResponse {
 			CacheCreationTokens: r.CacheCreationTokens,
 			CacheReadTokens:     r.CacheReadTokens,
 			Model:               r.Model,
+			Provider:            r.Provider,
 		},
 		Live:      live,
 		ReplicaID: r.ReplicaID,

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -698,6 +698,12 @@ outerLoop:
 			totalUsage.CacheCreationTokens += iterUsage.CacheCreationTokens
 			totalUsage.CacheReadTokens += iterUsage.CacheReadTokens
 			totalUsage.Model = iterUsage.Model
+			// Capture the ACTUAL provider that served this iteration.
+			// opts.Provider is mutated in place by tryProviderFallback
+			// when a runtime fallback engages, so reading ID() here
+			// reflects the post-fallback identity. Used by downstream
+			// analysis to quantify primary-vs-fallback routing.
+			totalUsage.Provider = opts.Provider.ID()
 			emit(providers.Event{Type: providers.EventUsage, Usage: iterUsage})
 		}
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -575,4 +575,17 @@ type Usage struct {
 	CacheCreationTokens int    `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadTokens     int    `json:"cache_read_input_tokens,omitempty"`
 	Model               string `json:"model,omitempty"`
+
+	// Provider is the provider ID that ACTUALLY served the call.
+	// May differ from the agent's yaml-configured provider when the
+	// v0.8.2 runtime-fallback path switched mid-run (e.g.,
+	// anthropic-oauth-dev → ollama after a 429). Surfaced so post-
+	// run analysis can quantify how often fallback routed runs to
+	// the secondary provider.
+	//
+	// Populated by the loop at iteration success time from
+	// opts.Provider.ID() — which tryProviderFallback mutates in
+	// place when fallback engages, so this naturally captures the
+	// post-fallback identity.
+	Provider string `json:"provider,omitempty"`
 }

--- a/internal/store/postgres/migrations/0027_runs_provider.down.sql
+++ b/internal/store/postgres/migrations/0027_runs_provider.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runs DROP COLUMN provider;

--- a/internal/store/postgres/migrations/0027_runs_provider.up.sql
+++ b/internal/store/postgres/migrations/0027_runs_provider.up.sql
@@ -1,0 +1,12 @@
+-- v0.12.7+ — record the ACTUAL provider that served the final
+-- successful iteration of each run. Distinct from model so post-run
+-- analysis can tell primary-provider runs from runtime-fallback
+-- routed runs (the v0.8.2 tryProviderFallback path mutates
+-- opts.Provider in place when a 429 / 5xx triggers a switch).
+--
+-- Background: the v0.12.7 x1000 load test (2026-05-26) had no
+-- post-run visibility into how many runs routed to fallback. This
+-- column closes the gap.
+--
+-- NULLable to preserve back-compat with pre-migration rows.
+ALTER TABLE runs ADD COLUMN provider TEXT;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -333,12 +333,13 @@ func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunSta
 			cache_creation_tokens = $7,
 			cache_read_tokens = $8,
 			model = $9,
-			error = $10
-		 WHERE id = $1 AND status = $11`,
+			provider = $10,
+			error = $11
+		 WHERE id = $1 AND status = $12`,
 		runID, string(status), completed, nullableText(stopReason),
 		usage.InputTokens, usage.OutputTokens,
 		usage.CacheCreationTokens, usage.CacheReadTokens,
-		nullableText(usage.Model), nullableText(errMsg),
+		nullableText(usage.Model), nullableText(usage.Provider), nullableText(errMsg),
 		string(store.RunRunning),
 	)
 	if err != nil {
@@ -483,7 +484,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 	row := s.pool.QueryRow(ctx,
 		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-		        r.model, r.error,
+		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
@@ -508,7 +509,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 	row := s.pool.QueryRow(ctx,
 		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-		        r.model, r.error,
+		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
@@ -571,7 +572,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 		rows, err = s.pool.Query(ctx,
 			`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-			        r.model, r.error,
+			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 			        r.agent_def_id, r.pause_state, r.replica_id,
 			        s.agent
@@ -582,7 +583,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 		rows, err = s.pool.Query(ctx,
 			`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-			        r.model, r.error,
+			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 			        r.agent_def_id, r.pause_state, r.replica_id,
 			        s.agent
@@ -607,7 +608,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 	rows, err := s.pool.Query(ctx,
 		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-		        r.model, r.error,
+		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
@@ -702,7 +703,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-		        r.model, r.error,
+		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id,
 		        s.agent
@@ -1370,14 +1371,14 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 		`INSERT INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-			model, error,
+			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
 			user_tier, agent_def_id, pause_state
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
 		 ON CONFLICT (id) DO NOTHING`,
 		r.ID, r.SessionID, status, startedAt, completedAt, nullIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
-		nullIfEmpty(r.Model), nullIfEmpty(r.ErrorMsg),
+		nullIfEmpty(r.Model), nullIfEmpty(r.Provider), nullIfEmpty(r.ErrorMsg),
 		nullIfEmpty(r.AgentID), nullIfEmpty(r.ParentAgentID), nullIfEmpty(r.ParentRunID),
 		nullIfEmpty(r.UserID), lastHbAt,
 		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState,
@@ -4036,6 +4037,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		completed  *time.Time
 		stopReason *string
 		model      *string
+		provider   *string
 		errMsg     *string
 
 		agentID, parentAgentID, parentRunID, userID, userTier *string
@@ -4050,7 +4052,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 	if err := r.Scan(
 		&out.ID, &out.SessionID, &statusStr, &started, &completed, &stopReason,
 		&out.InputTokens, &out.OutputTokens, &out.CacheCreationTokens, &out.CacheReadTokens,
-		&model, &errMsg,
+		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
 		&agentDefID, &pauseState, &replicaID,
@@ -4068,6 +4070,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	if model != nil {
 		out.Model = *model
+	}
+	if provider != nil {
+		out.Provider = *provider
 	}
 	if errMsg != nil {
 		out.ErrorMsg = *errMsg

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -99,6 +99,10 @@ func (s *Store) migrate(ctx context.Context) error {
 			cache_creation_tokens    INTEGER NOT NULL DEFAULT 0,
 			cache_read_tokens        INTEGER NOT NULL DEFAULT 0,
 			model                    TEXT,
+			-- v0.12.7+ — actual provider that served the final
+			-- successful iteration. Distinct from model so post-run
+			-- analysis can tell primary from fallback routing.
+			provider                 TEXT,
 			error                    TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS runs_by_session ON runs(session_id)`,
@@ -438,6 +442,10 @@ func (s *Store) migrate(ctx context.Context) error {
 		// until the boot-time backfill walks pre-migration rows.
 		`ALTER TABLE agent_defs ADD COLUMN content_sha256 TEXT`,
 		`ALTER TABLE skill_defs ADD COLUMN content_sha256 TEXT`,
+		// v0.12.7+ provider — actual provider that served the final
+		// successful iteration. Idempotent on fresh deploys (the
+		// CREATE TABLE above already declares it).
+		`ALTER TABLE runs ADD COLUMN provider TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -643,12 +651,13 @@ func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunSta
 			cache_creation_tokens = ?,
 			cache_read_tokens     = ?,
 			model                 = ?,
+			provider              = ?,
 			error                 = ?
 		WHERE id = ? AND status = ?`,
 		string(status), now, stopReason,
 		usage.InputTokens, usage.OutputTokens,
 		usage.CacheCreationTokens, usage.CacheReadTokens,
-		usage.Model, errMsg,
+		usage.Model, nilIfEmpty(usage.Provider), errMsg,
 		runID, string(store.RunRunning),
 	)
 	return err
@@ -788,7 +797,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var r store.Run
 	var startedNs, completedNs sql.NullInt64
 	var lastHbNs sql.NullInt64
-	var stopReason, model, errMsg sql.NullString
+	var stopReason, model, provider, errMsg sql.NullString
 	var agentID, parentAgentID, parentRunID, userID, userTier sql.NullString
 	var agentDefID sql.NullString
 	var pauseState sql.NullString
@@ -798,7 +807,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&r.ID, &r.SessionID, &status, &startedNs, &completedNs,
 		&stopReason,
 		&r.InputTokens, &r.OutputTokens, &r.CacheCreationTokens, &r.CacheReadTokens,
-		&model, &errMsg,
+		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
 		&agentDefID, &pauseState,
@@ -821,6 +830,9 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	}
 	if model.Valid {
 		r.Model = model.String
+	}
+	if provider.Valid {
+		r.Provider = provider.String
 	}
 	if errMsg.Valid {
 		r.ErrorMsg = errMsg.String
@@ -863,7 +875,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.stop_reason,
 		r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
-		r.model, r.error,
+		r.model, r.provider, r.error,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
 		r.agent_def_id, r.pause_state,
@@ -1766,13 +1778,13 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 		`INSERT OR IGNORE INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-			model, error,
+			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
 			user_tier, agent_def_id, pause_state
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.ID, r.SessionID, status, startedNs, completedNs, nilIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
-		nilIfEmpty(r.Model), nilIfEmpty(r.ErrorMsg),
+		nilIfEmpty(r.Model), nilIfEmpty(r.Provider), nilIfEmpty(r.ErrorMsg),
 		nilIfEmpty(r.AgentID), nilIfEmpty(r.ParentAgentID), nilIfEmpty(r.ParentRunID),
 		nilIfEmpty(r.UserID), lastHbNs,
 		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -161,7 +161,14 @@ type Run struct {
 	CacheCreationTokens int       `json:"cache_creation_input_tokens,omitempty"`
 	CacheReadTokens     int       `json:"cache_read_input_tokens,omitempty"`
 	Model               string    `json:"model,omitempty"`
-	ErrorMsg            string    `json:"error,omitempty"`
+	// Provider is the provider ID that ACTUALLY served the final
+	// successful iteration of this run. Distinct from the
+	// yaml-configured provider when v0.8.2 runtime fallback engaged
+	// mid-run (e.g., anthropic-oauth-dev → ollama after a 429).
+	// Empty for pre-v0.12.7-telemetry runs and for runs that never
+	// completed an iteration.
+	Provider string `json:"provider,omitempty"`
+	ErrorMsg string `json:"error,omitempty"`
 
 	// v0.4 tracking + cancel fields. All optional/nullable for
 	// back-compat with rows created before the columns landed.
@@ -267,6 +274,12 @@ type Usage struct {
 	CacheCreationTokens int
 	CacheReadTokens     int
 	Model               string
+	// Provider is the resolver-active provider ID at the final
+	// successful iteration. Carried alongside Model so downstream
+	// consumers see "actually served by" rather than guess from
+	// model-name conventions. Differs from agent yaml when v0.8.2
+	// fallback engaged.
+	Provider string
 }
 
 // RunIdentity carries the v0.4 tracking fields a CreateRun caller can

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -202,6 +202,11 @@ func Run(t *testing.T, factory Factory) {
 		// v0.8.21 awaited-state derivation needs last-event-per-run.
 		{"GetLastEventForRunEmpty", testGetLastEventForRunEmpty},
 		{"GetLastEventForRunReturnsHighestSeq", testGetLastEventForRunReturnsHighestSeq},
+		// v0.12.7 provider telemetry — FinishRun must persist the
+		// final-iteration provider so post-run analysis can count
+		// fallback-routed runs.
+		{"FinishRunPersistsProvider", testFinishRunPersistsProvider},
+		{"FinishRunPersistsProviderEmpty", testFinishRunPersistsProviderEmpty},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -315,6 +320,60 @@ func testCreateRunOnUnknownSession(t *testing.T, s store.Store) {
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("got %v (%T), want *store.ErrNotFound", err, err)
+	}
+}
+
+// testFinishRunPersistsProvider verifies that FinishRun writes the
+// Usage.Provider field to storage and GetRun reads it back. Distinct
+// from Model — the v0.8.2 runtime fallback path lands a row whose
+// Model is the original config target but whose Provider is whatever
+// driver actually served the final iteration. The x1000 load test
+// needs both to be queryable to characterize fallback frequency.
+func testFinishRunPersistsProvider(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_provider_roundtrip"})
+
+	usage := store.Usage{
+		InputTokens:  100,
+		OutputTokens: 50,
+		Model:        "claude-haiku-4-5-20251001",
+		Provider:     "anthropic-oauth-dev",
+	}
+	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", usage, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetRunByAgentID(ctx, "a_provider_roundtrip")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "claude-haiku-4-5-20251001" {
+		t.Errorf("Model = %q, want claude-haiku-4-5-20251001", got.Model)
+	}
+	if got.Provider != "anthropic-oauth-dev" {
+		t.Errorf("Provider = %q, want anthropic-oauth-dev", got.Provider)
+	}
+}
+
+// testFinishRunPersistsProviderEmpty confirms an empty Usage.Provider
+// round-trips as empty string (NULL in the underlying column). Pre-
+// migration rows + pre-call failures hit this path; consumers must
+// not see "" surface as some sentinel like "unknown".
+func testFinishRunPersistsProviderEmpty(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_provider_empty"})
+
+	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn",
+		store.Usage{Model: "m", Provider: ""}, ""); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetRunByAgentID(ctx, "a_provider_empty")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Provider != "" {
+		t.Errorf("Provider = %q, want empty string", got.Provider)
 	}
 }
 

--- a/test/load/circuit-stress/main.go
+++ b/test/load/circuit-stress/main.go
@@ -220,6 +220,13 @@ type agentResp struct {
 		InputTokens  int    `json:"input_tokens"`
 		OutputTokens int    `json:"output_tokens"`
 		Model        string `json:"model"`
+		// Provider is the v0.12.7+ wire field — the provider id that
+		// actually served the run's final iteration. Distinct from
+		// Model so post-run analysis can tell primary-provider runs
+		// from runtime-fallback routed runs (the v0.8.2
+		// tryProviderFallback path mutates opts.Provider in place when
+		// a 429 / 5xx triggers a switch). Empty on pre-migration rows.
+		Provider string `json:"provider"`
 	} `json:"usage"`
 }
 
@@ -244,11 +251,18 @@ type circuitResult struct {
 	Status          string            `json:"status"` // "completed" | "failed" | "timeout"
 	AgentStatus     map[string]string `json:"agent_status"`
 	AgentDurationMS map[string]int64  `json:"agent_duration_ms"`
-	InputTokens     int               `json:"input_tokens"`
-	OutputTokens    int               `json:"output_tokens"`
-	Score           *float64          `json:"score,omitempty"`
-	Rationale       string            `json:"rationale,omitempty"`
-	Error           string            `json:"error,omitempty"`
+	// AgentModel + AgentProvider record what actually served each
+	// role's final successful iteration. v0.12.7 telemetry — captured
+	// at terminal poll. Distinct keys per role so post-test analysis
+	// can pivot by role (e.g. did the editor get routed to fallback
+	// more often than the researcher?).
+	AgentModel    map[string]string `json:"agent_model,omitempty"`
+	AgentProvider map[string]string `json:"agent_provider,omitempty"`
+	InputTokens   int               `json:"input_tokens"`
+	OutputTokens  int               `json:"output_tokens"`
+	Score         *float64          `json:"score,omitempty"`
+	Rationale     string            `json:"rationale,omitempty"`
+	Error         string            `json:"error,omitempty"`
 }
 
 func main() {
@@ -299,7 +313,9 @@ func main() {
 	log.Printf("spawning %d circuits (%d per user, ~%d users)…",
 		f.scale, f.circuitsPerUser, (f.scale+f.circuitsPerUser-1)/f.circuitsPerUser)
 
+	testStart := time.Now()
 	results := runCircuits(c, f, prompts)
+	testEnd := time.Now()
 
 	log.Printf("test complete; writing results to %s/", f.resultsDir)
 	writeResults(f.resultsDir, results)
@@ -312,7 +328,11 @@ func main() {
 		log.Printf("--no-cleanup set; skipping sanity sweep")
 	}
 
-	printSummary(results, f.resultsDir)
+	// Pad both ends by a second so events that landed just before the
+	// first POST or just after the last run terminal-flip still match
+	// the ts >= from / ts <= to window in /v1/_events.
+	fallbackCount := fetchFallbackCount(c, testStart.Add(-time.Second), testEnd.Add(time.Second))
+	printSummary(results, f.resultsDir, fallbackCount)
 }
 
 // ─── Prompts ────────────────────────────────────────────────────────
@@ -405,6 +425,8 @@ func runOneCircuit(c *lcClient, circuitID int, userID, question string, timeout 
 		StartedAt:       time.Now(),
 		AgentStatus:     make(map[string]string),
 		AgentDurationMS: make(map[string]int64),
+		AgentModel:      make(map[string]string),
+		AgentProvider:   make(map[string]string),
 	}
 	cid := fmt.Sprintf("c%d", circuitID)
 	prompt := fmt.Sprintf("Your circuit_id is %s. Question: %s", cid, question)
@@ -470,6 +492,20 @@ func runOneCircuit(c *lcClient, circuitID int, userID, question string, timeout 
 				}
 				res.InputTokens += ar.Usage.InputTokens
 				res.OutputTokens += ar.Usage.OutputTokens
+				// Pre-v0.12.7 servers omit Model/Provider for runs
+				// that failed before the first provider call. Record
+				// "unknown" so the summary's distribution view sees
+				// the row without skewing the legitimate breakdown.
+				if ar.Usage.Model != "" {
+					res.AgentModel[role] = ar.Usage.Model
+				} else {
+					res.AgentModel[role] = "unknown"
+				}
+				if ar.Usage.Provider != "" {
+					res.AgentProvider[role] = ar.Usage.Provider
+				} else {
+					res.AgentProvider[role] = "unknown"
+				}
 				if ar.Status != "completed" && res.Error == "" {
 					res.Error = fmt.Sprintf("%s: %s (%s)", role, ar.Status, ar.Error)
 				}
@@ -683,7 +719,50 @@ func writeResults(dir string, results []circuitResult) {
 	}
 }
 
-func printSummary(results []circuitResult, dir string) {
+// fetchFallbackCount queries the v0.8.21 audit endpoint
+// /v1/_events?type=provider_fallback&from=…&to=… and returns the total
+// count of provider_fallback events that fired during the test window.
+// Each event represents one mid-run cross-provider switch (the v0.8.2
+// tryProviderFallback path, NOT same-provider retries — those don't
+// emit this event type).
+//
+// Returns -1 on failure so the summary can render "unavailable" rather
+// than a misleading 0. The Total field on the wire response is the
+// unbounded match count for the filter, so we don't need to page —
+// limit=1 keeps the response small.
+func fetchFallbackCount(c *lcClient, from, to time.Time) int {
+	path := fmt.Sprintf("/v1/_events?type=provider_fallback&from=%s&to=%s&limit=1",
+		from.UTC().Format(time.RFC3339), to.UTC().Format(time.RFC3339))
+	var resp struct {
+		Total int64 `json:"total"`
+	}
+	if status, err := c.do("GET", path, nil, &resp); err != nil || status != 200 {
+		log.Printf("fetchFallbackCount: %s -> status=%d err=%v (continuing without fallback total)", path, status, err)
+		return -1
+	}
+	return int(resp.Total)
+}
+
+// providerDistribution counts how many agent runs across all circuits
+// were served by each provider. Pivots res.AgentProvider — three rows
+// per completed circuit, one per role. Keys are the provider ids
+// surfaced by /v1/agents/{id}.usage.provider; the special key
+// "unknown" covers pre-v0.12.7 servers or runs that failed before the
+// first provider call.
+func providerDistribution(results []circuitResult) map[string]int {
+	out := map[string]int{}
+	for _, r := range results {
+		for _, p := range r.AgentProvider {
+			if p == "" {
+				continue
+			}
+			out[p]++
+		}
+	}
+	return out
+}
+
+func printSummary(results []circuitResult, dir string, fallbackCount int) {
 	var (
 		completed, failed, silentRegression, timedOut, skipped int
 		durations                                              []int64
@@ -753,6 +832,39 @@ func printSummary(results []circuitResult, dir string) {
 	if quotaSeen {
 		fmt.Printf("  ⚠ Anthropic OAuth-dev quota exhausted at circuit %d\n", quotaCircuit)
 	}
+
+	// Provider telemetry — v0.12.7+ surface. The provider distribution
+	// + fallback count answers "how many runs were actually served by
+	// the configured primary, and how many got rerouted mid-flight?"
+	// without needing to grep loomcycle.log.
+	dist := providerDistribution(results)
+	if len(dist) > 0 {
+		providers := make([]string, 0, len(dist))
+		for p := range dist {
+			providers = append(providers, p)
+		}
+		sort.Strings(providers)
+		parts := make([]string, 0, len(providers))
+		for _, p := range providers {
+			parts = append(parts, fmt.Sprintf("%s=%d", p, dist[p]))
+		}
+		fmt.Printf("  Providers: %s\n", strings.Join(parts, " "))
+	}
+	switch {
+	case fallbackCount < 0:
+		fmt.Printf("  Fallbacks: unavailable (events API unreachable)\n")
+	case fallbackCount > 0:
+		// System-wide, not test-scoped: /v1/_events filters by time
+		// window only, so a parallel load test or production traffic
+		// against the same loomcycle instance would inflate the
+		// count. Acceptable for v0.12.7 (operator runs one test at a
+		// time against a dedicated process); the label has to spell
+		// this out so the number isn't read as test-only.
+		fmt.Printf("  Fallbacks: %d system-wide cross-provider switches in the test window (may include non-test traffic; see GET /v1/_events?type=provider_fallback)\n", fallbackCount)
+	default:
+		fmt.Printf("  Fallbacks: 0 (no cross-provider switches in the test window)\n")
+	}
+
 	fmt.Printf("  Results:  %s/circuits.jsonl\n", dir)
 	fmt.Println()
 	fmt.Println("Post-test resource snapshot:")

--- a/test/load/circuit-stress/main_test.go
+++ b/test/load/circuit-stress/main_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestFetchFallbackCount_HappyPath confirms the driver hits
+// /v1/_events?type=provider_fallback with the correct query string
+// and reads `total` (NOT `len(events)`) for the fallback count. The
+// `Total` field is the unbounded match count for the filter; using it
+// — and asking for limit=1 — keeps the response cheap regardless of
+// how many fallbacks fired across an x1000 run.
+func TestFetchFallbackCount_HappyPath(t *testing.T) {
+	var gotURL string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.Header.Get("Authorization"), "Bearer test-token"; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		gotURL = r.URL.RequestURI()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"events": []any{},
+			"total":  42,
+			"limit":  1,
+			"offset": 0,
+		})
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "test-token")
+	from := time.Date(2026, 5, 27, 10, 0, 0, 0, time.UTC)
+	to := from.Add(time.Hour)
+	got := fetchFallbackCount(c, from, to)
+	if got != 42 {
+		t.Errorf("fetchFallbackCount = %d, want 42", got)
+	}
+	// URL should encode filter + the limit=1 micro-optimization.
+	want := "/v1/_events?type=provider_fallback&from=2026-05-27T10:00:00Z&to=2026-05-27T11:00:00Z&limit=1"
+	if gotURL != want {
+		t.Errorf("URL = %q, want %q", gotURL, want)
+	}
+}
+
+// TestFetchFallbackCount_ServerError verifies the driver surfaces
+// failure as -1 (the "unavailable" sentinel) rather than treating a
+// failed query as zero fallbacks — which would silently mask a real
+// API outage during a load test.
+func TestFetchFallbackCount_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newClient(srv.URL, "test-token")
+	got := fetchFallbackCount(c, time.Now(), time.Now().Add(time.Minute))
+	if got != -1 {
+		t.Errorf("fetchFallbackCount on 500 = %d, want -1", got)
+	}
+}
+
+// TestProviderDistribution_PivotsByProvider exercises the
+// circuit-result → distribution pivot that drives the "Providers:"
+// summary line. Three circuits, mixed providers, with one
+// pre-migration row (empty Provider — surfaces as "unknown" via the
+// runOneCircuit fallback, NOT counted as anthropic/etc).
+func TestProviderDistribution_PivotsByProvider(t *testing.T) {
+	results := []circuitResult{
+		{
+			CircuitID: 1,
+			AgentProvider: map[string]string{
+				"researcher": "anthropic-oauth-dev",
+				"editor":     "anthropic-oauth-dev",
+				"evaluator":  "anthropic-oauth-dev",
+			},
+		},
+		{
+			CircuitID: 2,
+			// Researcher got routed to deepseek mid-flight (v0.8.2
+			// fallback fired on a 429), the other two stayed on the
+			// primary. This is exactly the kind of asymmetry the new
+			// telemetry exists to surface.
+			AgentProvider: map[string]string{
+				"researcher": "deepseek",
+				"editor":     "anthropic-oauth-dev",
+				"evaluator":  "anthropic-oauth-dev",
+			},
+		},
+		{
+			CircuitID: 3,
+			// Pre-v0.12.7 server case — empty Provider on the wire
+			// becomes "unknown" in the result map (see
+			// runOneCircuit fallback). All three roles unknown.
+			AgentProvider: map[string]string{
+				"researcher": "unknown",
+				"editor":     "unknown",
+				"evaluator":  "unknown",
+			},
+		},
+	}
+	dist := providerDistribution(results)
+	if dist["anthropic-oauth-dev"] != 5 {
+		t.Errorf("anthropic-oauth-dev = %d, want 5", dist["anthropic-oauth-dev"])
+	}
+	if dist["deepseek"] != 1 {
+		t.Errorf("deepseek = %d, want 1", dist["deepseek"])
+	}
+	if dist["unknown"] != 3 {
+		t.Errorf("unknown = %d, want 3", dist["unknown"])
+	}
+	if len(dist) != 3 {
+		var keys []string
+		for k := range dist {
+			keys = append(keys, k)
+		}
+		t.Errorf("len(dist) = %d (keys=%s), want 3", len(dist), strings.Join(keys, ","))
+	}
+}


### PR DESCRIPTION
## Summary

- End-to-end provider capture: every `runs` row now records the provider id that actually served the final iteration, distinct from `model`. Surfaces v0.8.2 runtime-fallback routing in storage + the API.
- New summary lines on the circuit-stress driver: `Providers: anthropic-oauth-dev=298 deepseek=2` + `Fallbacks: N system-wide cross-provider switches in the test window`.
- Closes the post-run analysis gap from the v0.12.7 x1000 load test (2026-05-26): no way to count fallback-routed runs without grepping `loomcycle.log`.

## Why

`runs.model` is recorded but says nothing about whether `tryProviderFallback` swapped providers mid-flight when a 429 / 5xx fired. The loop knows it (logs + `EventProviderFallback`) but the storage layer didn't. For load characterization this is the difference between "primary held up" and "we leaned on the fallback cascade for 30% of traffic" — invisible without scraping logs.

## Wire shape

- **Storage**: new `runs.provider TEXT` column (SQLite + Postgres). NULLable; pre-migration rows survive.
- **API**: `GET /v1/agents/{id}.usage.provider` — additive, `omitempty`. Pre-v0.12.7 clients see exactly what they saw before.
- **TS adapter**: `AgentUsage.provider?: string` — additive, optional. `@loomcycle/client` bumped 0.11.5 → 0.12.7.

## Test plan

- [x] Two new store contract tests (FinishRunPersistsProvider, FinishRunPersistsProviderEmpty) — pass on SQLite + Postgres adapters.
- [x] httptest-backed driver tests for `fetchFallbackCount` (happy path verifies URL + reads `total` not `len(events)`; 500 returns -1 sentinel) + `providerDistribution` pivot.
- [x] `go build ./... && cd test/load/circuit-stress && go test ./...` clean.
- [x] `gofmt -l` + `go vet ./...` clean.
- [x] Full `-race` suite passes (pre-existing Channel/AgentDef/SkillDef failures are unrelated — present on `main` too, separate test-isolation issue).
- [x] TS adapter `npm run typecheck` clean.

## Out of scope

- The fallback count is **system-wide** for the test window, not test-scoped — `/v1/_events` filters by time, not test-run-id. Acceptable for v0.12.7 (operator runs one test at a time against a dedicated process); summary label spells this out so the number isn't misread.
- No UI surface yet (`/ui/runs` currently shows model only; surfacing provider in the run row is a follow-up — the field is already on the wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)