### PR TITLE
feat(channels): structured diagnostics for the post-#234 subscribe-race

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -100,6 +100,17 @@ var (
 // corresponding info wasn't available (binary built without VCS — e.g.
 // `go test` by default does not embed VCS info, but `go build` and
 // `go install` do).
+// channelDebugEnabled reports whether the operator opted into the
+// v0.12.7 channel publish/subscribe diagnostic log via the
+// LOOMCYCLE_CHANNEL_DEBUG=1 env var. Read here (not at store package
+// init time) so the env-var coupling stays in main.go where all the
+// other env-var → Config bridging lives. See
+// internal/tools/builtin/channel.go and
+// internal/store/postgres/postgres.go for what gets logged.
+func channelDebugEnabled() bool {
+	return os.Getenv("LOOMCYCLE_CHANNEL_DEBUG") == "1"
+}
+
 // backfillAgentDefSignFn computes the v0.9.x content_sha256 for an
 // existing agent_defs row whose hash column is NULL/empty. The
 // Definition JSONB is the mergedDef shape; agents.FromOverlay
@@ -875,6 +886,19 @@ func main() {
 	// fallback for operators running without a configured store.
 	memoryTool.Store = storeIface
 	channelTool.Store = storeIface
+	// Wire the pool-stats accessor when the backend is Postgres so
+	// the Channel tool's subscribe-race diagnostic log can correlate
+	// retry fires with pool exhaustion. SQLite stores and test builds
+	// leave it nil; the diagnostic log path then reports zeros for
+	// the pool fields and the retry behavior is unchanged. The
+	// PoolStatsFn capture lives inside execSubscribe at the case
+	// <-waker: arm — see internal/tools/builtin/channel.go.
+	if pg, ok := storeIface.(*storepostgres.Store); ok && pg != nil {
+		channelTool.PoolStatsFn = func() (total, acquired, idle int32) {
+			st := pg.Pool().Stat()
+			return st.TotalConns(), st.AcquiredConns(), st.IdleConns()
+		}
+	}
 	agentDefTool.Store = storeIface
 	skillDefTool.Store = storeIface
 	skillTool.Store = storeIface
@@ -1628,6 +1652,7 @@ func openStore(cfg *config.Config) (store.Store, func(), error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("sqlite open: %w", err)
 		}
+		st.SetChannelDebug(channelDebugEnabled())
 		log.Printf("store: sqlite at %s", dbPath)
 		return st, func() { _ = st.Close() }, nil
 
@@ -1641,6 +1666,7 @@ func openStore(cfg *config.Config) (store.Store, func(), error) {
 			MinIdleConns:    cfg.Storage.PgMinIdleConns,
 			AutoMigrate:     cfg.Storage.PgAutoMigrate,
 			PgvectorEnabled: cfg.Env.PgvectorEnabled,
+			ChannelDebug:    channelDebugEnabled(),
 		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("postgres open: %w", err)

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -535,6 +535,16 @@ Cursor monotonicity is enforced: `ack` with a cursor older than the currently co
 
 `subscribe` accepts an optional `wait_ms`. If the storage read returns empty, the tool blocks on the in-process notification bus for that channel until either a new publish lands or the timeout fires. Cap is operator-controlled (`LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS`, default 30 s). Same-process subscribers wake within microseconds of a publish; cross-process subscribers (multi-replica deployments) fall back to polling — that's deferred to v0.9.x.
 
+### Diagnostic logging (v0.12.7)
+
+`LOOMCYCLE_CHANNEL_DEBUG=1` enables structured per-publish + per-retry log lines used to characterise the residual subscribe-empty race the v0.8.x bounded-retry workaround mitigates. Default off — these lines are noisy on a busy install. Operators flip the flag during a load test, capture a window of logs (~20 retry-saved lines), then flip it back. The two log shapes are:
+
+- `channel "X" publish: id=... commit_us=N pool_total=A pool_acquired=B pool_idle=C` — fires on every successful publish. `commit_us` measures the postgres `tx.Commit` duration in microseconds; the pool fields capture pgxpool state at commit time.
+
+- `channel "X" subscribe-race-recovered attempt=N msgs=K recovery_lag_ms=Y first_read_lag_us=Z from_cursor="..." pool_total=A pool_acquired=B pool_idle=C` — fires when the bounded retry rescued a subscribe after Bus.Wait returned via the waker but the immediate re-read found no rows. `first_read_lag_us` is the diagnostic field that distinguishes the race window (waker → empty read), separate from `recovery_lag_ms` (waker → eventually-non-empty read).
+
+A complementary `subscribe-race-exhausted` log fires when all 3 retry attempts return empty. SQLite's parity logging (commit_us only — single-writer, no pool) lets operators A/B the same workload against both backends. See `~/work/loomcycle-internal/doc-internal/channel-race-investigation.md` for the hypothesis table.
+
 ### Quotas and overflow
 
 - Per-write payload cap: `LOOMCYCLE_CHANNELS_MAX_VALUE_BYTES` (default 64 KB). 0 disables.

--- a/internal/store/postgres/channel_race_test.go
+++ b/internal/store/postgres/channel_race_test.go
@@ -1,0 +1,251 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestChannelSubscribe_ConcurrentPublishRace exercises the
+// publish-then-notify path at high concurrency against real Postgres
+// to reproduce the residual subscribe-empty race that PR #234
+// papered over with a bounded retry.
+//
+// Reproduction strategy: each worker publishes a fresh message THEN
+// subscribes from "cur_0" expecting to find its own just-published
+// msg_id in the result set. Because cur_0 replays ALL messages, the
+// only way to miss the row is a true MVCC visibility lag — the row
+// committed but the subscribing transaction's snapshot doesn't yet
+// include it. We measure both "missed on first read" (the race
+// happened) and "still missing after 30ms" (a correctness bug, not
+// just commit-visibility lag — would mean the row is never visible
+// from this pool connection's snapshot).
+//
+// The test asserts `silentMissesAfterDelay == 0` (correctness). It
+// only LOGS missesOnFirstRead so we can characterize the race rate
+// without making the test flaky. The diagnostic log lines from
+// LOOMCYCLE_CHANNEL_DEBUG=1 + the channel.go readWithRetry path
+// surface the same data in production; this test is the
+// reproduction harness operators can use locally.
+//
+// Run with -count=N to gather a histogram. At 200 workers × 10 msgs
+// on a dev box (Postgres in Docker, single client) the race trips
+// rarely; under sustained production load (50+ concurrent runs)
+// PR #234's analysis reported ~2% trip rate, the count this test is
+// scaffolded to characterize.
+func TestChannelSubscribe_ConcurrentPublishRace(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	fx := freshSchema(t, dsn)
+	defer fx.cleanup()
+	s := fx.store
+
+	const (
+		numWorkers    = 200
+		msgsPerWorker = 10
+	)
+
+	var (
+		missesOnFirstRead      atomic.Int64
+		silentMissesAfterDelay atomic.Int64
+		totalReads             atomic.Int64
+		wg                     sync.WaitGroup
+	)
+
+	ctx := context.Background()
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < msgsPerWorker; j++ {
+				payload := json.RawMessage(`{"w":` + strconv.Itoa(workerID) +
+					`,"j":` + strconv.Itoa(j) + `}`)
+				msgID, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+					Channel: "race-test",
+					Scope:   store.MemoryScopeGlobal,
+					ScopeID: "",
+					Payload: payload,
+				}, 0)
+				if err != nil {
+					t.Errorf("publish (worker %d msg %d): %v", workerID, j, err)
+					return
+				}
+				totalReads.Add(1)
+				msgs, _, err := s.ChannelSubscribe(ctx, "race-test",
+					store.MemoryScopeGlobal, "", "cur_0", 5000)
+				if err != nil {
+					t.Errorf("subscribe (worker %d msg %d): %v", workerID, j, err)
+					return
+				}
+				if !containsMsg(msgs, msgID) {
+					missesOnFirstRead.Add(1)
+					time.Sleep(30 * time.Millisecond)
+					msgs2, _, err := s.ChannelSubscribe(ctx, "race-test",
+						store.MemoryScopeGlobal, "", "cur_0", 5000)
+					if err != nil {
+						t.Errorf("subscribe retry (worker %d msg %d): %v",
+							workerID, j, err)
+						return
+					}
+					if !containsMsg(msgs2, msgID) {
+						silentMissesAfterDelay.Add(1)
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	t.Logf("concurrent publish/subscribe race: workers=%d msgs_per_worker=%d total_reads=%d misses_on_first_read=%d (%.2f%%) silent_misses_after_30ms=%d",
+		numWorkers, msgsPerWorker, totalReads.Load(),
+		missesOnFirstRead.Load(),
+		100*float64(missesOnFirstRead.Load())/float64(totalReads.Load()),
+		silentMissesAfterDelay.Load())
+
+	if silentMissesAfterDelay.Load() > 0 {
+		t.Errorf("silent misses after 30ms delay: %d — the just-published row was never visible across a fresh subscribe. This indicates a correctness bug, not just commit-visibility lag; investigate before merging.",
+			silentMissesAfterDelay.Load())
+	}
+}
+
+// TestChannelSubscribe_CursorAdvanceRace exercises the
+// non-cur_0 path that more closely mirrors the production tool-layer
+// flow: each subscriber reads with a cursor, advances on success,
+// reads again. Under contention with concurrent publishers a
+// subscriber's cursor-advancing read should see every newly committed
+// row that's > its cursor — but if the MVCC snapshot is acquired
+// before the commit propagates to this pool connection, the read can
+// miss the row.
+//
+// Distinct from the first test in that:
+//   - cursor advances on each read (matches readWithRetry's call site)
+//   - publish and subscribe interleave per-worker (high contention)
+//   - we measure how many UNIQUE message ids the test never delivered
+//     (= correctness gap; nonzero is a bug)
+func TestChannelSubscribe_CursorAdvanceRace(t *testing.T) {
+	dsn := pgDSNFromEnv(t)
+	fx := freshSchema(t, dsn)
+	defer fx.cleanup()
+	s := fx.store
+
+	const (
+		numWorkers     = 50
+		msgsPerWorker  = 10
+		readBatchLimit = 100
+	)
+
+	var (
+		publishedIDs sync.Map
+		seenIDs      sync.Map
+		publisherWg  sync.WaitGroup
+		subscriberWg sync.WaitGroup
+	)
+
+	ctx := context.Background()
+
+	// Phase 1: publishers run to completion. The two-phase structure
+	// makes the test reliable on slow CI runners: subscribers don't
+	// race the publishers' commit cadence. A row never delivered when
+	// the subscriber drains AFTER all publishers committed is a true
+	// storage gap, not a timing artifact. Original 2026-05-27 review
+	// caught the single-WaitGroup-with-time.After variant as flaky.
+	for i := 0; i < numWorkers; i++ {
+		publisherWg.Add(1)
+		go func(workerID int) {
+			defer publisherWg.Done()
+			for j := 0; j < msgsPerWorker; j++ {
+				payload := json.RawMessage(`{"w":` + strconv.Itoa(workerID) +
+					`,"j":` + strconv.Itoa(j) + `}`)
+				id, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+					Channel: "cursor-race",
+					Scope:   store.MemoryScopeGlobal,
+					Payload: payload,
+				}, 0)
+				if err != nil {
+					t.Errorf("publish: %v", err)
+					return
+				}
+				publishedIDs.Store(id, true)
+			}
+		}(i)
+	}
+	publisherWg.Wait()
+
+	// Phase 2: subscribers drain. With every published row committed
+	// already, the only way for a subscriber to miss an id is a true
+	// MVCC visibility gap on a fresh subscribe — exactly the
+	// correctness signal we want to assert on. Generous deadline
+	// (10s) because slow CI runners drain serially.
+	subscriberDeadline := time.After(10 * time.Second)
+	for s_i := 0; s_i < numWorkers/5; s_i++ {
+		subscriberWg.Add(1)
+		go func(subID int) {
+			defer subscriberWg.Done()
+			cursor := ""
+			idle := 0
+			for {
+				select {
+				case <-subscriberDeadline:
+					return
+				default:
+				}
+				msgs, next, err := s.ChannelSubscribe(ctx, "cursor-race",
+					store.MemoryScopeGlobal, "", cursor, readBatchLimit)
+				if err != nil {
+					t.Errorf("subscribe: %v", err)
+					return
+				}
+				if len(msgs) == 0 {
+					idle++
+					if idle > 5 {
+						return
+					}
+					time.Sleep(20 * time.Millisecond)
+					continue
+				}
+				idle = 0
+				for _, m := range msgs {
+					seenIDs.Store(m.ID, true)
+				}
+				if next != "" {
+					cursor = next
+				}
+			}
+		}(s_i)
+	}
+	subscriberWg.Wait()
+
+	// Tally missing ids — published but never delivered.
+	missing := 0
+	publishedIDs.Range(func(k, _ any) bool {
+		if _, ok := seenIDs.Load(k); !ok {
+			missing++
+		}
+		return true
+	})
+
+	totalPublished := 0
+	publishedIDs.Range(func(_, _ any) bool { totalPublished++; return true })
+
+	t.Logf("cursor-advance race: workers=%d msgs_per_worker=%d published=%d missing=%d",
+		numWorkers, msgsPerWorker, totalPublished, missing)
+
+	if missing > 0 {
+		t.Errorf("delivery gap: %d / %d messages were never returned by ANY subscriber. The cursor-advance read race delivered a correctness gap, not just a latency one. Investigate before merging.",
+			missing, totalPublished)
+	}
+}
+
+func containsMsg(msgs []store.ChannelMessage, id string) bool {
+	for _, m := range msgs {
+		if m.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -68,6 +68,15 @@ type Config struct {
 	// EXISTS vector` either way — only LOAD failures during search
 	// would surface, and search refuses upfront in that case.
 	PgvectorEnabled bool
+
+	// ChannelDebug, when true, enables structured logging on the
+	// channel publish/subscribe paths used to characterise the
+	// post-PR-#234 residual subscribe-empty race. Operators flip this
+	// via LOOMCYCLE_CHANNEL_DEBUG=1; main.go reads the env var and
+	// passes the result here. Read once at Open() and stored on the
+	// Store struct so the hot path is a single bool load. Defaults
+	// to off so noise stays out of production logs.
+	ChannelDebug bool
 }
 
 // Store is the Postgres implementation of store.Store.
@@ -78,6 +87,10 @@ type Store struct {
 	// AND the post-migration `SELECT FROM pg_extension WHERE
 	// extname='vector'` probe. SupportsVectors() returns this.
 	pgvectorEnabled bool
+
+	// channelDebug is captured from Config.ChannelDebug at Open()
+	// time. See ChannelPublish for what the debug log contains.
+	channelDebug bool
 
 	// closeOnce guards the Close() idempotency contract.
 	closeOnce sync.Once
@@ -146,7 +159,7 @@ func Open(ctx context.Context, cfg Config) (*Store, error) {
 		}
 	}
 
-	s := &Store{pool: pool}
+	s := &Store{pool: pool, channelDebug: cfg.ChannelDebug}
 
 	// v0.9.0 Vector Memory: when operator opted in via
 	// LOOMCYCLE_PGVECTOR_ENABLED=1, verify the extension actually
@@ -2624,8 +2637,23 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 		}
 		dropped = int(tag.RowsAffected())
 	}
+	commitStart := time.Now()
 	if err := tx.Commit(ctx); err != nil {
 		return "", 0, fmt.Errorf("channel publish commit: %w", err)
+	}
+	if s.channelDebug {
+		// Bracket the commit so we can correlate publish-side commit
+		// duration with subscriber-side notify_lag_ms (logged from
+		// channel.go readWithRetry). If commit_us is large and
+		// notify_lag_ms small, the race window is not "notify before
+		// commit" — the subscriber genuinely raced a fresh snapshot
+		// against an MVCC-visible row. Microseconds, not milliseconds,
+		// because most commits land in the 200-800µs band at our
+		// concurrency level.
+		st := s.pool.Stat()
+		log.Printf("channel %q publish: id=%s commit_us=%d pool_total=%d pool_acquired=%d pool_idle=%d",
+			msg.Channel, msg.ID, time.Since(commitStart).Microseconds(),
+			st.TotalConns(), st.AcquiredConns(), st.IdleConns())
 	}
 	return msg.ID, dropped, nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -42,6 +42,13 @@ import (
 type Store struct {
 	db *sql.DB
 
+	// channelDebug gates the v0.12.7 channel publish diagnostic log.
+	// Set via SetChannelDebug after Open() — the SQLite store predates
+	// a Config struct, so we wire the operator's LOOMCYCLE_CHANNEL_DEBUG
+	// preference in via a setter rather than adding a parallel Open
+	// variant. Defaults to off so noise stays out of production logs.
+	channelDebug bool
+
 	// closeOnce guards the Close() idempotency contract.
 	closeOnce sync.Once
 }
@@ -68,6 +75,15 @@ func Open(path string) (*Store, error) {
 		return nil, err
 	}
 	return s, nil
+}
+
+// SetChannelDebug opts the store into the v0.12.7 channel publish
+// diagnostic log. See ChannelPublish for what gets logged. Idempotent;
+// safe to call from main.go before serving begins. After serving starts
+// the flag is read-only on the hot path (no atomic; calling this
+// concurrently with a publish would race).
+func (s *Store) SetChannelDebug(enabled bool) {
+	s.channelDebug = enabled
 }
 
 // migrate creates the schema if needed. Idempotent. v0.3 schema is fixed; if
@@ -2486,8 +2502,19 @@ func (s *Store) ChannelPublish(ctx context.Context, msg store.ChannelMessage, ma
 			dropped = int(n)
 		}
 	}
+	commitStart := time.Now()
 	if err := tx.Commit(); err != nil {
 		return "", 0, err
+	}
+	if s.channelDebug {
+		// Parity with the postgres backend's diagnostic — see
+		// internal/store/postgres/postgres.go for the hypothesis
+		// background. SQLite is single-writer (WAL) so the
+		// commit-visibility race shouldn't apply, but logging here
+		// lets us A/B the same load against both backends and
+		// confirm the race is Postgres-specific.
+		log.Printf("channel %q publish: id=%s commit_us=%d",
+			msg.Channel, msg.ID, time.Since(commitStart).Microseconds())
 	}
 	return msg.ID, dropped, nil
 }

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -66,6 +66,18 @@ type Channel struct {
 	// 0 disables long-poll entirely (subscribe always returns
 	// immediately). Sourced from LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS.
 	LongPollCapMS int
+
+	// PoolStatsFn, when non-nil, returns the current pgxpool
+	// connection stats (total, acquired, idle). Captured by
+	// readWithRetry just before the post-notify re-read so the
+	// subscribe-empty race diagnostic log can correlate retry fires
+	// with pool exhaustion or connection-reuse anomalies.
+	//
+	// Wired by main.go when the configured store is a Postgres store
+	// (via type assertion on store.Store). SQLite + test builds leave
+	// it nil; the diagnostic log path then reports zeros for the pool
+	// fields and the retry behavior is unchanged.
+	PoolStatsFn func() (total, acquired, idle int32)
 }
 
 const channelDescription = `Persistent inter-agent message bus. ` +
@@ -410,7 +422,21 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 			// most 30ms in the worst case. The retry pattern also
 			// covers any future visibility window we haven't yet
 			// characterised at higher scale.
-			msgs, next, err = readWithRetry(read, in.Channel)
+			//
+			// Diagnostic capture: stamp the waker-receipt time, the
+			// cursor used for the read, and the pool stats. Fed into
+			// readWithRetry so the structured log when retry fires
+			// carries the data needed to characterise the race (see
+			// doc-internal/channel-race-investigation.md for the
+			// hypothesis table).
+			diag := retryDiagnostics{
+				notifyAt:   time.Now(),
+				fromCursor: from,
+			}
+			if c.PoolStatsFn != nil {
+				diag.poolTotal, diag.poolAcquired, diag.poolIdle = c.PoolStatsFn()
+			}
+			msgs, next, err = readWithRetry(read, in.Channel, diag)
 			if err != nil {
 				return errResult(fmt.Sprintf("subscribe (after wait): %s", err)), nil
 			}
@@ -492,6 +518,37 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	})
 }
 
+// retryDiagnostics carries the per-call telemetry consumed by
+// readWithRetry's structured log lines. Populated by execSubscribe at
+// the case <-waker: arm so we can correlate retry fires with the
+// publish that woke us:
+//
+//   - notifyAt: when Bus.Wait returned via the waker. retry_lag_ms in
+//     the log = time.Since(notifyAt) at the attempt that found rows.
+//     Tests Hypothesis 5 (notify before commit propagates).
+//
+//   - fromCursor: the cursor used for the initial read. Tests
+//     Hypothesis 4 (cursor advanced past the new message) — if the
+//     just-published msg_id is at or below this cursor, the empty
+//     read is correct, not a race.
+//
+//   - poolTotal/poolAcquired/poolIdle: pgxpool.Stat() snapshot just
+//     before the first re-read attempt. Tests Hypothesis 2 (different
+//     pool connection sees an older snapshot) — if AcquiredConns ≈
+//     TotalConns and retries are spiking, connection reuse is the
+//     likely vector.
+//
+// Zero-valued fields are safe: nil PoolStatsFn leaves them at 0 and
+// the diagnostic log reports them as such. The retry behavior itself
+// is unchanged when no PoolStatsFn is wired.
+type retryDiagnostics struct {
+	notifyAt     time.Time
+	fromCursor   string
+	poolTotal    int32
+	poolAcquired int32
+	poolIdle     int32
+}
+
 // readWithRetry is the bounded retry wrapper used by execSubscribe
 // after Bus.Wait returns via the waker (notify). The publish path
 // is commit-then-notify, so MVCC says the row IS visible to any
@@ -506,14 +563,25 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 // so worst-case 30ms latency added when the retry fires.
 //
 // When the retry actually saves a circuit it logs a structured line
-// so we can quantify the issue at scale. When even the 3rd attempt
-// returns empty, we accept the empty result and let the caller decide
-// (current behaviour) — but we log a stronger warning so the operator
-// notices.
-func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel string) ([]store.ChannelMessage, string, error) {
+// carrying the retryDiagnostics fields so operators can correlate the
+// signal with publish-side timing in `~/work/loomcycle-internal/
+// doc-internal/channel-race-investigation.md`. When even the 3rd
+// attempt returns empty, we accept the empty result and let the
+// caller decide (current behaviour) — but we log a stronger warning
+// with the same fields so the operator notices.
+func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel string, diag retryDiagnostics) ([]store.ChannelMessage, string, error) {
 	const maxAttempts = 3
 	const backoff = 10 * time.Millisecond
 
+	// firstEmptyAt records when attempt 1 returned no rows. Used to
+	// compute first_read_lag_us — the time from waker-receipt to the
+	// race-affected empty read — which is the diagnostic field that
+	// distinguishes H5 (notify before commit propagates) from H2
+	// (different pool connection sees older snapshot). H5 produces
+	// first_read_lag_us < 1000 (commit window still open at first
+	// read); H2 produces first_read_lag_us > 100 (snapshot acquired
+	// well after commit but pool reused a stale-snapshot connection).
+	var firstEmptyAt time.Time
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		msgs, next, err := read()
 		if err != nil {
@@ -523,10 +591,19 @@ func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel 
 			if attempt > 1 {
 				// The retry saved this subscriber from a silent miss.
 				// Surface at scale so we can measure the residual rate.
-				log.Printf("channel %q: subscribe re-read empty on attempt %d, retry found %d msg(s) — likely commit-visibility window",
-					channel, attempt-1, len(msgs))
+				// recovery_lag_ms = waker → eventually-non-empty read.
+				// first_read_lag_us = waker → the empty first read.
+				log.Printf("channel %q: subscribe-race-recovered attempt=%d msgs=%d recovery_lag_ms=%d first_read_lag_us=%d from_cursor=%q pool_total=%d pool_acquired=%d pool_idle=%d",
+					channel, attempt, len(msgs),
+					time.Since(diag.notifyAt).Milliseconds(),
+					firstEmptyAt.Sub(diag.notifyAt).Microseconds(),
+					diag.fromCursor,
+					diag.poolTotal, diag.poolAcquired, diag.poolIdle)
 			}
 			return msgs, next, nil
+		}
+		if attempt == 1 {
+			firstEmptyAt = time.Now()
 		}
 		if attempt < maxAttempts {
 			time.Sleep(backoff)
@@ -537,8 +614,12 @@ func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel 
 	// a publish we shouldn't have seen (cursor-past it), or there's
 	// a more pathological timing window we haven't yet diagnosed.
 	// Return empty and let the caller decide.
-	log.Printf("channel %q: subscribe re-read returned empty across %d attempts after notify — silent miss; investigate",
-		channel, maxAttempts)
+	log.Printf("channel %q: subscribe-race-exhausted attempts=%d recovery_lag_ms=%d first_read_lag_us=%d from_cursor=%q pool_total=%d pool_acquired=%d pool_idle=%d — silent miss; investigate",
+		channel, maxAttempts,
+		time.Since(diag.notifyAt).Milliseconds(),
+		firstEmptyAt.Sub(diag.notifyAt).Microseconds(),
+		diag.fromCursor,
+		diag.poolTotal, diag.poolAcquired, diag.poolIdle)
 	return nil, "", nil
 }
 

--- a/internal/tools/builtin/channel_test.go
+++ b/internal/tools/builtin/channel_test.go
@@ -594,7 +594,7 @@ func TestReadWithRetry(t *testing.T) {
 			calls++
 			return []store.ChannelMessage{makeMsg("m1")}, "cur_x", nil
 		}
-		msgs, next, err := readWithRetry(read, "test")
+		msgs, next, err := readWithRetry(read, "test", retryDiagnostics{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -618,7 +618,7 @@ func TestReadWithRetry(t *testing.T) {
 			}
 			return []store.ChannelMessage{makeMsg("m2")}, "cur_y", nil
 		}
-		msgs, _, err := readWithRetry(read, "test")
+		msgs, _, err := readWithRetry(read, "test", retryDiagnostics{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -636,7 +636,7 @@ func TestReadWithRetry(t *testing.T) {
 			calls++
 			return nil, "", nil // always empty
 		}
-		msgs, next, err := readWithRetry(read, "test")
+		msgs, next, err := readWithRetry(read, "test", retryDiagnostics{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -657,7 +657,7 @@ func TestReadWithRetry(t *testing.T) {
 			calls++
 			return nil, "", errSentinel
 		}
-		_, _, err := readWithRetry(read, "test")
+		_, _, err := readWithRetry(read, "test", retryDiagnostics{})
 		if err != errSentinel {
 			t.Errorf("err = %v, want %v", err, errSentinel)
 		}


### PR DESCRIPTION
## Summary

- Adds structured per-publish + per-retry log lines (gated on `LOOMCYCLE_CHANNEL_DEBUG=1`) that capture timing + pgxpool state when the post-#234 bounded-retry path fires. **Instrumentation only — no behaviour change for non-debug operators.**
- Two new Postgres race-reproduction tests; the second uses a two-phase WaitGroup pattern so subscribers can't race ahead of publishers on slow CI runners.
- Findings doc lives at `~/work/loomcycle-internal/doc-internal/channel-race-investigation.md` (Gitea-hosted, per CLAUDE.md doc-internal location); in-repo `docs/TOOLS.md` gets a brief operator-facing reference to the env var + log shapes.

## Why

PR #234 papered over a ~2% subscribe-empty race seen at the v0.12.x x50 load test. The PR body acknowledged the suspected cause as "pgxpool / Postgres timing under high concurrency" but didn't have enough instrumentation to pin it down. This PR adds that instrumentation. The actual root-cause PR is a follow-up driven by the data the new logs collect in production.

## What the logs tell us

```
channel "X" publish: id=01H... commit_us=412 pool_total=32 pool_acquired=18 pool_idle=14

channel "X" subscribe-race-recovered attempt=2 msgs=1 \
  recovery_lag_ms=12 first_read_lag_us=320 from_cursor="" \
  pool_total=32 pool_acquired=28 pool_idle=4
```

`first_read_lag_us` is the sharp instrument: waker → empty first read. Small means commit-visibility window is short (likely pool/snapshot reuse, H2). Large means notify fired before commit propagated (H5). The decision matrix is in the external doc.

## Architecture

- `Channel.PoolStatsFn func() (total, acquired, idle int32)` — wired in `main.go` via type-assertion on `*storepostgres.Store`. Nil-safe for SQLite + tests.
- `retryDiagnostics` struct — value-type, populated at `case <-waker:`. Passed into `readWithRetry`.
- `Config.ChannelDebug bool` (postgres) + `Store.SetChannelDebug()` (sqlite) — operator opt-in. Read once at boot per CLAUDE.md "no package-level mutable globals."

## Review-fix summary

The code-reviewer agent flagged:
1. The cursor-advance test was structurally flaky on slow CI runners (single WaitGroup with `time.After(3s)` racing publish/subscribe). Fixed with two-phase WaitGroup + 10s subscriber deadline.
2. `channelDebug` was a package-level `var` (CLAUDE.md violation). Moved into `Config.ChannelDebug` (postgres) + `SetChannelDebug()` setter (sqlite); env-var read lives in `main.go`.
3. The original `notify_lag_ms` measured waker → eventually-non-empty read (less sharp for H5 vs H2). Added `first_read_lag_us` (waker → empty first read) as the sharper field; kept `recovery_lag_ms` for full-window timing.

## Test plan

- [x] `go build ./... && go test -race ./...` clean.
- [x] `LOOMCYCLE_TEST_PG_DSN=… go test -race -run 'TestChannelSubscribe_*' ./internal/store/postgres/...` clean across multiple runs at 200×10 and 50×10.
- [x] gofmt + go vet clean.

## Out of scope

- The actual root-cause fix. This PR is investigation-grade instrumentation; the next PR (driven by production log data) will diagnose then fix the dominant hypothesis.
- Removing the retry. It stays as defense-in-depth even after we understand the race — any future Postgres oddity (replication lag in multi-replica deployments, pgxpool changes, config drift) could re-introduce a similar race.
- Threading the just-published `msg_id` through `Bus.Notify` for cursor-vs-msg correlation. Would require a Bus API change; deferred until the simpler diagnostic surfaces enough signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)