### PR TITLE
feat(providers): mock LLM provider for cost-free 10K-agent stress testing

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -52,6 +52,7 @@ import (
 	anthropic_oauth_dev "github.com/denn-gubsky/loomcycle/internal/providers/anthropic_oauth_dev"
 	"github.com/denn-gubsky/loomcycle/internal/providers/deepseek"
 	"github.com/denn-gubsky/loomcycle/internal/providers/gemini"
+	mockprov "github.com/denn-gubsky/loomcycle/internal/providers/mock"
 	"github.com/denn-gubsky/loomcycle/internal/providers/ollama"
 	"github.com/denn-gubsky/loomcycle/internal/providers/openai"
 	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
@@ -1699,6 +1700,14 @@ type providerResolver struct {
 	// pointing at `loomcycle anthropic login`.
 	anthropicOAuthDev       providers.Provider
 	anthropicOAuthRefresher *anthropic_oauth_dev.Refresher
+	// v0.12.8 — synthetic mock provider for cost-free stress testing.
+	// Registered only when LOOMCYCLE_MOCK_ENABLED=1. Drives the
+	// canonical 3-agent circuit-stress pipeline with no real-LLM
+	// cost; injection knobs (LOOMCYCLE_MOCK_429_RATE, 500_RATE,
+	// LATENCY_MS, LATENCY_JITTER_MS) exercise the resolver matrix
+	// + runtime-fallback paths under load. See
+	// internal/providers/mock/driver.go.
+	mock providers.Provider
 }
 
 // buildEmbedder turns cfg.Memory.Embedder into a constructed
@@ -1798,6 +1807,22 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 		pr.gemini = gemini.New(cfg.Env.GeminiAPIKey, cfg.Env.GeminiBaseURL, streamOpts, nil)
 	}
 
+	// v0.12.8 — synthetic mock provider. Single gate: LOOMCYCLE_MOCK_ENABLED=1.
+	// Registers as provider id "mock" with four model variants
+	// (mock-researcher / mock-editor / mock-evaluator / mock-generic)
+	// for the canonical circuit-stress 3-agent pipeline. Failure
+	// injection knobs (LOOMCYCLE_MOCK_429_RATE etc.) are read by the
+	// driver itself; logged here so the boot output makes the active
+	// scenario obvious.
+	if os.Getenv("LOOMCYCLE_MOCK_ENABLED") == "1" {
+		pr.mock = mockprov.New()
+		log.Printf("mock provider: enabled (LATENCY_MS=%q LATENCY_JITTER_MS=%q 429_RATE=%q 500_RATE=%q)",
+			os.Getenv("LOOMCYCLE_MOCK_LATENCY_MS"),
+			os.Getenv("LOOMCYCLE_MOCK_LATENCY_JITTER_MS"),
+			os.Getenv("LOOMCYCLE_MOCK_429_RATE"),
+			os.Getenv("LOOMCYCLE_MOCK_500_RATE"))
+	}
+
 	// v0.11.9 — anthropic-oauth-dev. Two gates: env var + tokens on
 	// disk. Without either, the provider is absent from the resolver
 	// matrix and any agent yaml that pins `provider: anthropic-oauth-dev`
@@ -1866,6 +1891,11 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 			return nil, fmt.Errorf("anthropic-oauth-dev not registered (set LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 + run `loomcycle anthropic login`)")
 		}
 		return p.anthropicOAuthDev, nil
+	case "mock":
+		if p.mock == nil {
+			return nil, fmt.Errorf("mock provider not configured (set LOOMCYCLE_MOCK_ENABLED=1)")
+		}
+		return p.mock, nil
 	default:
 		return nil, fmt.Errorf("unknown provider %q", id)
 	}
@@ -1932,6 +1962,12 @@ func runResolveProbeOnce(ctx context.Context, r *resolve.Resolver, pr *providerR
 		// the canonical "not registered" error) and the
 		// resolver-misconfigured case.
 		{id: "anthropic-oauth-dev"},
+		// v0.12.8 — synthetic mock provider. Excluded unless the
+		// operator opted in via LOOMCYCLE_MOCK_ENABLED=1. The probe
+		// itself is trivial (ListModels returns a fixed slice) so
+		// the matrix populates instantly when enabled.
+		{id: "mock", excluded: os.Getenv("LOOMCYCLE_MOCK_ENABLED") != "1",
+			exclReason: "LOOMCYCLE_MOCK_ENABLED not set"},
 	}
 	for i := range jobs {
 		if jobs[i].excluded {

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3883,6 +3883,7 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 		CacheCreationTokens: res.Usage.CacheCreationTokens,
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
+		Provider:            res.Usage.Provider,
 	}
 	if err := s.store.FinishRun(bg, runID, store.RunCancelled, reason, usage, ""); err != nil {
 		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
@@ -3922,6 +3923,7 @@ func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, 
 		CacheCreationTokens: res.Usage.CacheCreationTokens,
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
+		Provider:            res.Usage.Provider,
 	}
 	if err := s.store.FinishRun(bg, runID, status, res.StopReason, usage, errMsg); err != nil {
 		log.Printf("store: FinishRun failed (run=%s): %v", runID, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2348,6 +2348,11 @@ var validProviderIDs = map[string]bool{
 	// time if LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 isn't set or no
 	// token file exists. See docs/PROVIDERS.md.
 	"anthropic-oauth-dev": true,
+	// v0.12.8 — synthetic mock provider for cost-free stress testing.
+	// config-load accepts the ID; the resolver returns a clear "not
+	// configured" error at request time if LOOMCYCLE_MOCK_ENABLED=1
+	// isn't set. See internal/providers/mock/driver.go.
+	"mock": true,
 }
 
 // validTierNames is the closed set of tier names. Operators choose

--- a/internal/providers/mock/driver.go
+++ b/internal/providers/mock/driver.go
@@ -1,0 +1,737 @@
+// Package mock implements a synthetic LLM provider for cost-free
+// stress testing of the agent runtime. It emits scripted tool_use
+// sequences shaped to drive the canonical circuit-stress 3-agent
+// pipeline (researcher → editor → evaluator) without burning real
+// provider quota.
+//
+// Operators opt in via LOOMCYCLE_MOCK_ENABLED=1; the driver registers
+// as provider id "mock" alongside the real providers. Per-agent yaml
+// pins which model variant to use:
+//
+//	mock-researcher  — 2-step FSM (Memory.set → Channel.publish)
+//	mock-editor      — 5-step FSM (Channel.subscribe → Memory.get →
+//	                    Memory.set → Context.self → Channel.publish)
+//	mock-evaluator   — 5-step FSM (Channel.subscribe → Memory.get(×2)
+//	                    → Memory.set → Evaluation.submit)
+//	mock-generic     — no-op text response (defensive default for
+//	                    mis-pinned configs)
+//
+// Failure injection knobs (env vars, read once at New() time):
+//
+//	LOOMCYCLE_MOCK_429_RATE         — fraction [0.0, 1.0] of calls to
+//	                                  reject with a 429 (drives the
+//	                                  MarkRateLimited matrix cooldown
+//	                                  PR #241 path).
+//	LOOMCYCLE_MOCK_500_RATE         — same shape, 5xx-error path.
+//	LOOMCYCLE_MOCK_LATENCY_MS       — base sleep per Call() (default 50).
+//	LOOMCYCLE_MOCK_LATENCY_JITTER_MS — uniform [0, jitter] random add
+//	                                   to the base (default 25).
+//
+// The driver intentionally does NOT wrap in ratelimit.Do — we want
+// the loop to see the injected 429s + 500s so the resolver matrix
+// and runtime-fallback paths get exercised by the same load test.
+//
+// No real HTTP, no real tokens. Usage fields are derived from
+// request character count so the metrics endpoints have something
+// non-zero to plot under load.
+package mock
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math/rand"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Driver is the synthetic provider. Constructed once via New(), then
+// shared across all runs that resolve to the "mock" provider. The
+// rng is mu-protected because Call() is invoked concurrently from
+// many goroutines under load.
+type Driver struct {
+	latencyBase   time.Duration
+	latencyJitter time.Duration
+	rate429       float64
+	rate500       float64
+
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+// New constructs the driver from LOOMCYCLE_MOCK_* env vars. Invalid
+// values fall back to sensible defaults rather than refusing to
+// start — this is a test tool, not a production hot path; the
+// operator can always check the boot log to see what was applied.
+func New() *Driver {
+	d := &Driver{
+		latencyBase:   parseDurationMS(os.Getenv("LOOMCYCLE_MOCK_LATENCY_MS"), 50*time.Millisecond),
+		latencyJitter: parseDurationMS(os.Getenv("LOOMCYCLE_MOCK_LATENCY_JITTER_MS"), 25*time.Millisecond),
+		rate429:       parseRate(os.Getenv("LOOMCYCLE_MOCK_429_RATE"), 0),
+		rate500:       parseRate(os.Getenv("LOOMCYCLE_MOCK_500_RATE"), 0),
+		// Seed off wall time so re-runs against the same harness
+		// produce different failure-injection patterns; tests that
+		// need determinism use the WithRNG variant below.
+		rng: rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+	return d
+}
+
+// NewWithRNG is the test seam — lets unit tests inject a deterministic
+// rand source so the 429/500/score paths are reproducible. The
+// runtime constructor (New) seeds from wall time.
+func NewWithRNG(rng *rand.Rand) *Driver {
+	d := New()
+	d.rng = rng
+	return d
+}
+
+func (d *Driver) ID() string { return "mock" }
+
+func (d *Driver) Capabilities() providers.Capabilities {
+	return providers.Capabilities{
+		Streaming:         false,
+		ParallelToolCalls: false,
+		// MaxContextTokens left at 0 — the loop treats 0 as "no cap"
+		// for capability-driven decisions; the mock has no real
+		// context window so this is honest.
+		MaxContextTokens:  0,
+		NativePromptCache: false,
+		SupportsThinking:  false,
+		SupportsEffort:    false,
+	}
+}
+
+func (d *Driver) Probe(_ context.Context) error { return nil }
+
+func (d *Driver) ListModels(_ context.Context) ([]string, error) {
+	return []string{
+		"mock-researcher",
+		"mock-editor",
+		"mock-evaluator",
+		"mock-generic",
+	}, nil
+}
+
+// Call dispatches on req.Model. Each model has a deterministic
+// finite-state machine driven by the number of tool_result blocks
+// already in req.Messages: zero results = emit the first tool,
+// one result = emit the second, and so on, until the agent has run
+// through its scripted sequence and stop_reason flips to "end_turn".
+func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan providers.Event, error) {
+	// 1. Failure injection — checked BEFORE the latency sleep so
+	// rate-limit cascades surface promptly under load. Random draw
+	// is mu-protected (rng is not safe for concurrent use).
+	if err := d.rollFailure(); err != nil {
+		return nil, err
+	}
+
+	// 2. Realistic latency. ctx-aware so a cancelled run doesn't
+	// keep the goroutine parked the full window.
+	if err := d.sleepWithLatency(ctx, req); err != nil {
+		return nil, err
+	}
+
+	// 3. Dispatch on model.
+	step := countToolResults(req.Messages)
+	circuitID := extractCircuitID(req)
+
+	var events []providers.Event
+	switch req.Model {
+	case "mock-researcher":
+		events = scriptResearcher(step, circuitID)
+	case "mock-editor":
+		events = scriptEditor(step, circuitID, req.Messages)
+	case "mock-evaluator":
+		events = scriptEvaluator(step, circuitID, req.Messages)
+	default:
+		// mock-generic + anything unpinned. Single text turn, done.
+		// Usage is attached to EventDone below by finalizeUsage —
+		// the loop reads it from there.
+		events = []providers.Event{
+			{Type: providers.EventText, Text: "ok"},
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+
+	// Attach Usage to the terminal EventDone frame so the loop's
+	// iterUsage = ev.Usage merge captures non-zero tokens + Model.
+	// See internal/loop/loop.go case providers.EventDone — Usage on
+	// a separate EventUsage frame would be ignored by the switch.
+	events = finalizeUsage(events, req)
+
+	ch := make(chan providers.Event, len(events))
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return ch, nil
+}
+
+// ---- Failure injection ----
+
+func (d *Driver) rollFailure() error {
+	d.mu.Lock()
+	roll429 := d.rng.Float64()
+	roll500 := d.rng.Float64()
+	d.mu.Unlock()
+	if roll429 < d.rate429 {
+		// Format must match errclass.statusRe ("^[a-z][a-z0-9_-]* (\d{3}):")
+		// so providers.IsRateLimit returns true for this error.
+		return fmt.Errorf("mock 429: rate_limited (injected at %s)", time.Now().Format(time.RFC3339Nano))
+	}
+	if roll500 < d.rate500 {
+		return fmt.Errorf("mock 500: server_error (injected at %s)", time.Now().Format(time.RFC3339Nano))
+	}
+	return nil
+}
+
+func (d *Driver) sleepWithLatency(ctx context.Context, req providers.Request) error {
+	if d.latencyBase <= 0 && d.latencyJitter <= 0 {
+		return nil
+	}
+	// Latency proportional to request size so longer conversations
+	// model a real provider's "more tokens to process" delay. ~1ms
+	// per 100 chars; matches a real provider's order-of-magnitude
+	// behaviour without burning real per-token time.
+	d.mu.Lock()
+	jitter := time.Duration(0)
+	if d.latencyJitter > 0 {
+		jitter = time.Duration(d.rng.Int63n(int64(d.latencyJitter)))
+	}
+	d.mu.Unlock()
+	chars := requestChars(req)
+	body := time.Duration(chars/100) * time.Microsecond
+	total := d.latencyBase + body + jitter
+	if total <= 0 {
+		return nil
+	}
+	t := time.NewTimer(total)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// ---- FSM scripts ----
+
+// scriptResearcher emits the researcher's 2-tool sequence. The
+// canned answer is intentionally short (~12 chars) so Usage fields
+// stay bounded under x10K and so the editor's downstream
+// "tightening" has something to compare against.
+func scriptResearcher(step int, circuitID string) []providers.Event {
+	switch step {
+	case 0:
+		key := fmt.Sprintf("%s-research", circuitID)
+		return []providers.Event{
+			textEvent("storing research"),
+			toolEvent("Memory", map[string]any{
+				"op":    "set",
+				"scope": "user",
+				"key":   key,
+				"value": map[string]any{"text": cannedResearch(circuitID)},
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 1:
+		channel := fmt.Sprintf("research-done/%s", circuitID)
+		return []providers.Event{
+			textEvent("publishing done signal"),
+			toolEvent("Channel", map[string]any{
+				"op":      "publish",
+				"channel": channel,
+				"value":   map[string]any{"circuit_id": circuitID},
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	default:
+		return []providers.Event{
+			textEvent("done"),
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+}
+
+// scriptEditor emits the editor's 5-tool sequence (cases 0–4,
+// indices matching the count of prior tool_result blocks). Case 3
+// (Context.self) is fired BEFORE case 4 (Channel.publish) so the
+// publish payload can carry editor_run_id extracted from the
+// Context.self tool_result.
+func scriptEditor(step int, circuitID string, messages []providers.Message) []providers.Event {
+	switch step {
+	case 0:
+		return []providers.Event{
+			textEvent("subscribing to research-done"),
+			toolEvent("Channel", map[string]any{
+				"op":           "subscribe",
+				"channel":      fmt.Sprintf("research-done/%s", circuitID),
+				"wait_ms":      120000,
+				"max_messages": 1,
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 1:
+		return []providers.Event{
+			textEvent("reading research"),
+			toolEvent("Memory", map[string]any{
+				"op":    "get",
+				"scope": "user",
+				"key":   fmt.Sprintf("%s-research", circuitID),
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 2:
+		return []providers.Event{
+			textEvent("storing edited version"),
+			toolEvent("Memory", map[string]any{
+				"op":    "set",
+				"scope": "user",
+				"key":   fmt.Sprintf("%s-research-edited", circuitID),
+				"value": map[string]any{"text": cannedEdit(circuitID)},
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 3:
+		return []providers.Event{
+			textEvent("fetching self identity"),
+			toolEvent("Context", map[string]any{"op": "self"}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 4:
+		// Extract the editor's run_id from the prior Context.self
+		// tool_result. Fall back to a deterministic synthetic id
+		// derived from circuit_id when the parse fails (defensive —
+		// the next tool_result in the harness still carries enough
+		// for the evaluator to retry on its own).
+		runID := extractRunID(messages)
+		if runID == "" {
+			runID = "mock-editor-" + circuitID
+		}
+		return []providers.Event{
+			textEvent("publishing editing-done"),
+			toolEvent("Channel", map[string]any{
+				"op":      "publish",
+				"channel": fmt.Sprintf("editing-done/%s", circuitID),
+				"value": map[string]any{
+					"circuit_id":    circuitID,
+					"editor_run_id": runID,
+				},
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	default:
+		return []providers.Event{
+			textEvent("done"),
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+}
+
+// scriptEvaluator emits the evaluator's 5-tool sequence (cases 0–4,
+// indices matching the count of prior tool_result blocks). Case 4
+// (Evaluation.submit) requires the editor_run_id extracted from the
+// channel message body delivered in case 0's Channel.subscribe
+// tool_result.
+func scriptEvaluator(step int, circuitID string, messages []providers.Message) []providers.Event {
+	switch step {
+	case 0:
+		return []providers.Event{
+			textEvent("subscribing to editing-done"),
+			toolEvent("Channel", map[string]any{
+				"op":           "subscribe",
+				"channel":      fmt.Sprintf("editing-done/%s", circuitID),
+				"wait_ms":      120000,
+				"max_messages": 1,
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 1:
+		return []providers.Event{
+			textEvent("reading research"),
+			toolEvent("Memory", map[string]any{
+				"op":    "get",
+				"scope": "user",
+				"key":   fmt.Sprintf("%s-research", circuitID),
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 2:
+		return []providers.Event{
+			textEvent("reading edited version"),
+			toolEvent("Memory", map[string]any{
+				"op":    "get",
+				"scope": "user",
+				"key":   fmt.Sprintf("%s-research-edited", circuitID),
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 3:
+		editorRunID := extractEditorRunID(messages)
+		score := deriveScore(editorRunID + circuitID)
+		return []providers.Event{
+			textEvent("storing score"),
+			toolEvent("Memory", map[string]any{
+				"op":    "set",
+				"scope": "user",
+				"key":   fmt.Sprintf("%s-research-scored", circuitID),
+				"value": map[string]any{
+					"score":     score,
+					"rationale": "ok",
+				},
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 4:
+		editorRunID := extractEditorRunID(messages)
+		score := deriveScore(editorRunID + circuitID)
+		return []providers.Event{
+			textEvent("submitting evaluation"),
+			toolEvent("Evaluation", map[string]any{
+				"op":        "submit",
+				"run_id":    editorRunID,
+				"score":     score,
+				"rationale": "ok",
+			}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	default:
+		return []providers.Event{
+			textEvent("done"),
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+}
+
+// ---- Helpers ----
+
+// countToolResults walks req.Messages and counts the tool_result
+// content blocks across all user-role messages. Each successful
+// tool execution by the loop appends ONE user message containing
+// the tool_result(s) for the prior iteration's tool_use(s), so
+// this count is the FSM's step index (0 on the first call).
+func countToolResults(messages []providers.Message) int {
+	n := 0
+	for _, m := range messages {
+		if m.Role != "user" {
+			continue
+		}
+		for _, b := range m.Content {
+			if b.Type == "tool_result" {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// circuitRe matches the c{N} circuit id the driver embeds in the
+// initial user message ("Your circuit_id is c5. Question: ...").
+var circuitRe = regexp.MustCompile(`\bc\d+\b`)
+
+// extractCircuitID scans req.Messages for the c{N} pattern from the
+// initial user prompt. Returns "c0" if none found — the mock's
+// memory keys + channel names will be "c0-…" in that case, which
+// is still a valid string but doesn't match any harness-allocated
+// circuit. Operators see this in the resulting Memory rows.
+func extractCircuitID(req providers.Request) string {
+	for _, m := range req.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		for _, b := range m.Content {
+			if b.Type == "text" && b.Text != "" {
+				if hit := circuitRe.FindString(b.Text); hit != "" {
+					return hit
+				}
+			}
+		}
+	}
+	return "c0"
+}
+
+// extractRunID parses the most recent Context.self tool_result for
+// the run_id field. Returns empty string when no Context.self
+// tool_result has been seen yet.
+func extractRunID(messages []providers.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role != "user" {
+			continue
+		}
+		for _, b := range m.Content {
+			if b.Type != "tool_result" {
+				continue
+			}
+			if id := scanJSONForKey(b.Text, "run_id"); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// extractEditorRunID scans tool_results for `editor_run_id` (the
+// channel message body field). Looks at the Channel.subscribe
+// tool_result delivered in step 1 of the evaluator's FSM.
+func extractEditorRunID(messages []providers.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role != "user" {
+			continue
+		}
+		for _, b := range m.Content {
+			if b.Type != "tool_result" {
+				continue
+			}
+			if id := scanJSONForKey(b.Text, "editor_run_id"); id != "" {
+				return id
+			}
+		}
+	}
+	return ""
+}
+
+// scanJSONForKey extracts a top-level (or nested-once) string-valued
+// field from a JSON blob. Used to pull run_id / editor_run_id out of
+// tool_result text without strictly typing every possible shape.
+//
+// Two strategies: (1) full JSON decode into map[string]any and look
+// for the key at the top level and in any nested {messages: [...]}
+// array (matches the Channel.subscribe response shape), (2) regex
+// fallback for cases where the JSON is wrapped or partial.
+func scanJSONForKey(blob, key string) string {
+	if blob == "" {
+		return ""
+	}
+	// Strategy 1: structured decode.
+	var top map[string]any
+	if err := json.Unmarshal([]byte(blob), &top); err == nil {
+		if v, ok := top[key].(string); ok && v != "" {
+			return v
+		}
+		// Channel.subscribe nests payloads under messages[].value.
+		if msgs, ok := top["messages"].([]any); ok {
+			for _, raw := range msgs {
+				msg, ok := raw.(map[string]any)
+				if !ok {
+					continue
+				}
+				if v, ok := msg[key].(string); ok && v != "" {
+					return v
+				}
+				if val, ok := msg["value"]; ok {
+					switch vv := val.(type) {
+					case map[string]any:
+						if s, ok := vv[key].(string); ok && s != "" {
+							return s
+						}
+					case string:
+						// value may itself be a JSON-encoded string.
+						var inner map[string]any
+						if err := json.Unmarshal([]byte(vv), &inner); err == nil {
+							if s, ok := inner[key].(string); ok && s != "" {
+								return s
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	// Strategy 2: regex fallback. `"key":"value"` shape, allowing
+	// whitespace, handles cases where the JSON is wrapped or the
+	// value lives inside a stringified inner object.
+	re := regexp.MustCompile(`"` + regexp.QuoteMeta(key) + `"\s*:\s*"([^"]+)"`)
+	if m := re.FindStringSubmatch(blob); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// deriveScore hashes the input to a [0.50, 0.99] float so the same
+// run_id always produces the same score (deterministic for tests)
+// but the score distribution across many run_ids spans the band
+// fairly uniformly (50 buckets, hash spreads them out).
+func deriveScore(seed string) float64 {
+	if seed == "" {
+		return 0.85 // defensive fixed score when run_id missing
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(seed))
+	bucket := int(h.Sum32() % 50)
+	return 0.50 + float64(bucket)/100.0
+}
+
+// cannedResearch + cannedEdit produce short payloads so token
+// counts stay bounded under x10K. Content includes the circuit_id
+// so visual inspection of Memory rows after a run is sensible.
+func cannedResearch(circuitID string) string {
+	return fmt.Sprintf("Mock research for %s: a brief factual answer.", circuitID)
+}
+
+func cannedEdit(circuitID string) string {
+	return fmt.Sprintf("Mock edit %s: tightened.", circuitID)
+}
+
+// textEvent constructs an EventText frame. Used to emit a short
+// "narration" line before each tool_use so the SSE stream isn't
+// just tool calls — matches real-provider shape where models emit
+// a sentence of reasoning before invoking a tool.
+func textEvent(s string) providers.Event {
+	return providers.Event{Type: providers.EventText, Text: s}
+}
+
+// toolEvent constructs an EventToolCall frame with a generated
+// tool_use id. The id format mirrors the anthropic shape
+// ("toolu_<hex>") so SSE consumers that parse ids don't choke; it
+// has no semantic meaning to the mock.
+func toolEvent(name string, input map[string]any) providers.Event {
+	raw, _ := json.Marshal(input)
+	id := mintToolUseID()
+	return providers.Event{
+		Type: providers.EventToolCall,
+		ToolUse: &providers.ToolUse{
+			ID:    id,
+			Name:  name,
+			Input: raw,
+		},
+	}
+}
+
+// finalizeUsage attaches a Usage struct to the terminal EventDone
+// frame. The loop reads iterUsage from EventDone.Usage (see
+// internal/loop/loop.go case providers.EventDone), so a separate
+// EventUsage frame in the stream would be ignored. Model is set to
+// req.Model unconditionally so the loop's totalUsage merge gets a
+// non-empty Model field regardless of which mock variant ran.
+//
+// Idempotent — if the script already populated EventDone.Usage,
+// only the Model field is filled in when missing; token counts
+// stay as the script set them.
+func finalizeUsage(events []providers.Event, req providers.Request) []providers.Event {
+	inputTokens := estimateTokens(req)
+	outputTokens := 0
+	for _, e := range events {
+		if e.Type == providers.EventText {
+			outputTokens += len(e.Text) / 4
+		}
+		if e.Type == providers.EventToolCall && e.ToolUse != nil {
+			outputTokens += len(e.ToolUse.Input) / 4
+		}
+	}
+	for i := range events {
+		if events[i].Type != providers.EventDone {
+			continue
+		}
+		if events[i].Usage == nil {
+			events[i].Usage = &providers.Usage{
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+				Model:        req.Model,
+			}
+		} else if events[i].Usage.Model == "" {
+			events[i].Usage.Model = req.Model
+		}
+		return events
+	}
+	return events
+}
+
+// requestChars sums the bytes of every text + tool_result block
+// across messages. Drives both the latency body and the input-
+// token estimate.
+func requestChars(req providers.Request) int {
+	n := 0
+	for _, sys := range req.System {
+		n += len(sys.Text)
+	}
+	for _, m := range req.Messages {
+		for _, b := range m.Content {
+			n += len(b.Text)
+			n += len(b.ToolInput)
+		}
+		n += len(m.Reasoning)
+	}
+	return n
+}
+
+// estimateTokens approximates input tokens as chars/4 — the
+// industry rule-of-thumb that matches GPT-style BPE. Floor at 1
+// so empty conversations don't report zero (which would skew
+// downstream throughput-per-token metrics).
+func estimateTokens(req providers.Request) int {
+	n := requestChars(req) / 4
+	if n < 1 {
+		return 1
+	}
+	return n
+}
+
+// parseRate parses a [0.0, 1.0] env-var value. Out-of-range and
+// malformed values fall back to the default — the mock is a test
+// tool, not a production hot path; a typo shouldn't refuse start.
+func parseRate(s string, def float64) float64 {
+	if s == "" {
+		return def
+	}
+	v, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	if err != nil || v < 0 || v > 1 {
+		return def
+	}
+	return v
+}
+
+// parseDurationMS parses a millisecond-valued env-var. Negative
+// values reset to zero (no sleep), malformed values fall back to
+// the default.
+func parseDurationMS(s string, def time.Duration) time.Duration {
+	if s == "" {
+		return def
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(s))
+	if err != nil {
+		return def
+	}
+	if n < 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Millisecond
+}
+
+// mintToolUseID returns a stable-shape tool_use id ("mock_tu_<16hex>").
+// Mirrors the anthropic shape's distinctive prefix so SSE consumers
+// that filter on id prefix can identify mock-origin tool calls.
+//
+// Uses crypto/rand rather than the math/rand source: the loop
+// correlates tool_use_id → tool_result by the exact string it
+// received, so collision resistance matters far more than
+// reproducibility. Going through d.rng would also bypass the
+// driver's NewWithRNG test seam since this function has no Driver
+// receiver. crypto/rand removes both concerns at once.
+func mintToolUseID() string {
+	var b [8]byte
+	if _, err := cryptorand.Read(b[:]); err != nil {
+		// Test tool only — operator sees the panic in the boot log
+		// and re-runs. Production drivers would degrade gracefully.
+		panic("mock: mintToolUseID: " + err.Error())
+	}
+	return fmt.Sprintf("mock_tu_%016x", b)
+}
+
+// ErrUnsupportedModel is the typed error returned (today: never;
+// the default case in Call() handles unpinned models via the
+// mock-generic branch). Reserved for future tightening when we
+// want resolver-side rejection of unknown mock-* model names.
+var ErrUnsupportedModel = errors.New("mock: unsupported model")

--- a/internal/providers/mock/driver_test.go
+++ b/internal/providers/mock/driver_test.go
@@ -1,0 +1,449 @@
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// userTextMessage builds a synthetic user-text message — used to
+// seed the initial conversation (no prior tool_results) for FSM
+// step-0 tests.
+func userTextMessage(text string) providers.Message {
+	return providers.Message{
+		Role: "user",
+		Content: []providers.ContentBlock{
+			{Type: "text", Text: text},
+		},
+	}
+}
+
+// toolResultMessage wraps a tool_result block. Drives the FSM
+// counter (countToolResults) forward by exactly one.
+func toolResultMessage(text string) providers.Message {
+	return providers.Message{
+		Role: "user",
+		Content: []providers.ContentBlock{
+			{Type: "tool_result", Text: text},
+		},
+	}
+}
+
+func drain(t *testing.T, ch <-chan providers.Event) []providers.Event {
+	t.Helper()
+	var out []providers.Event
+	for e := range ch {
+		out = append(out, e)
+	}
+	return out
+}
+
+func findToolCall(events []providers.Event) *providers.ToolUse {
+	for _, e := range events {
+		if e.Type == providers.EventToolCall && e.ToolUse != nil {
+			return e.ToolUse
+		}
+	}
+	return nil
+}
+
+func decodeInput(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("decode tool input: %v (raw=%s)", err, string(raw))
+	}
+	return m
+}
+
+// TestMockResearcher_FirstTurnEmitsMemorySet — empty history must
+// produce Memory.set as the first tool call with scope=user and the
+// canonical c{N}-research key.
+func TestMockResearcher_FirstTurnEmitsMemorySet(t *testing.T) {
+	d := New()
+	d.latencyBase = 0
+	d.latencyJitter = 0
+
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "mock-researcher",
+		Messages: []providers.Message{userTextMessage("Your circuit_id is c7. Question: What does TCP stand for?")},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	events := drain(t, ch)
+	tu := findToolCall(events)
+	if tu == nil {
+		t.Fatalf("no tool_use in events: %+v", events)
+	}
+	if tu.Name != "Memory" {
+		t.Errorf("tool name = %q, want Memory", tu.Name)
+	}
+	in := decodeInput(t, tu.Input)
+	if in["op"] != "set" {
+		t.Errorf("op = %v, want set", in["op"])
+	}
+	if in["scope"] != "user" {
+		t.Errorf("scope = %v, want user", in["scope"])
+	}
+	if in["key"] != "c7-research" {
+		t.Errorf("key = %v, want c7-research", in["key"])
+	}
+	if got := events[len(events)-1]; got.Type != providers.EventDone || got.StopReason != "tool_use" {
+		t.Errorf("last event = %+v, want Done(tool_use)", got)
+	}
+}
+
+// TestMockEditor_FullSequence drives the 5-step FSM by feeding
+// tool_results one at a time and asserts each iteration's tool_use
+// shape. At step 4 the editor's Channel.publish must carry
+// editor_run_id extracted from the prior Context.self tool_result.
+func TestMockEditor_FullSequence(t *testing.T) {
+	d := New()
+	d.latencyBase = 0
+	d.latencyJitter = 0
+
+	circuitPrompt := userTextMessage("circuit_id is c12. Edit the research.")
+
+	// Step 0: empty history → Channel.subscribe
+	ch, _ := d.Call(context.Background(), providers.Request{
+		Model:    "mock-editor",
+		Messages: []providers.Message{circuitPrompt},
+	})
+	tu := findToolCall(drain(t, ch))
+	if tu == nil || tu.Name != "Channel" {
+		t.Fatalf("step 0: want Channel.subscribe, got %+v", tu)
+	}
+	in := decodeInput(t, tu.Input)
+	if in["op"] != "subscribe" || in["channel"] != "research-done/c12" {
+		t.Errorf("step 0: input = %+v", in)
+	}
+
+	// Step 1: + 1 tool_result → Memory.get
+	ch, _ = d.Call(context.Background(), providers.Request{
+		Model: "mock-editor",
+		Messages: []providers.Message{
+			circuitPrompt,
+			toolResultMessage(`{"channel":"research-done/c12","messages":[{"value":{"circuit_id":"c12"}}]}`),
+		},
+	})
+	tu = findToolCall(drain(t, ch))
+	in = decodeInput(t, tu.Input)
+	if tu.Name != "Memory" || in["op"] != "get" || in["key"] != "c12-research" {
+		t.Errorf("step 1: name=%s in=%+v", tu.Name, in)
+	}
+
+	// Step 2: Memory.set (edited)
+	ch, _ = d.Call(context.Background(), providers.Request{
+		Model: "mock-editor",
+		Messages: []providers.Message{
+			circuitPrompt,
+			toolResultMessage(`{"channel":"…"}`),
+			toolResultMessage(`{"value":{"text":"the original research"}}`),
+		},
+	})
+	tu = findToolCall(drain(t, ch))
+	in = decodeInput(t, tu.Input)
+	if tu.Name != "Memory" || in["op"] != "set" || in["key"] != "c12-research-edited" {
+		t.Errorf("step 2: name=%s in=%+v", tu.Name, in)
+	}
+
+	// Step 3: Context.self
+	ch, _ = d.Call(context.Background(), providers.Request{
+		Model: "mock-editor",
+		Messages: []providers.Message{
+			circuitPrompt,
+			toolResultMessage(`{}`), toolResultMessage(`{}`), toolResultMessage(`{}`),
+		},
+	})
+	tu = findToolCall(drain(t, ch))
+	in = decodeInput(t, tu.Input)
+	if tu.Name != "Context" || in["op"] != "self" {
+		t.Errorf("step 3: name=%s in=%+v", tu.Name, in)
+	}
+
+	// Step 4: Channel.publish, editor_run_id extracted from
+	// Context.self tool_result (the last one in history).
+	ch, _ = d.Call(context.Background(), providers.Request{
+		Model: "mock-editor",
+		Messages: []providers.Message{
+			circuitPrompt,
+			toolResultMessage(`{}`), toolResultMessage(`{}`), toolResultMessage(`{}`),
+			toolResultMessage(`{"agent_id":"editor-c12","run_id":"r_abcdef123"}`),
+		},
+	})
+	tu = findToolCall(drain(t, ch))
+	in = decodeInput(t, tu.Input)
+	if tu.Name != "Channel" || in["op"] != "publish" {
+		t.Fatalf("step 4: name=%s in=%+v", tu.Name, in)
+	}
+	if in["channel"] != "editing-done/c12" {
+		t.Errorf("step 4 channel = %v", in["channel"])
+	}
+	payload, _ := in["value"].(map[string]any)
+	if payload["editor_run_id"] != "r_abcdef123" {
+		t.Errorf("step 4 editor_run_id = %v (raw value = %+v)", payload["editor_run_id"], payload)
+	}
+}
+
+// TestMockEvaluator_ScoreIsDeterministic: same editor_run_id +
+// circuit_id → same score across calls.
+func TestMockEvaluator_ScoreIsDeterministic(t *testing.T) {
+	d := New()
+	d.latencyBase = 0
+	d.latencyJitter = 0
+
+	subscribeResult := `{"messages":[{"value":{"editor_run_id":"r_abc","circuit_id":"c42"}}]}`
+	build := func() providers.Request {
+		return providers.Request{
+			Model: "mock-evaluator",
+			Messages: []providers.Message{
+				userTextMessage("circuit c42"),
+				toolResultMessage(subscribeResult),
+				toolResultMessage(`{"value":"…"}`),
+				toolResultMessage(`{"value":"…"}`),
+				toolResultMessage(`{"ok":true}`),
+			},
+		}
+	}
+
+	ch1, _ := d.Call(context.Background(), build())
+	tu1 := findToolCall(drain(t, ch1))
+	in1 := decodeInput(t, tu1.Input)
+	if tu1.Name != "Evaluation" || in1["op"] != "submit" {
+		t.Fatalf("not the submit step: name=%s in=%+v", tu1.Name, in1)
+	}
+
+	ch2, _ := d.Call(context.Background(), build())
+	tu2 := findToolCall(drain(t, ch2))
+	in2 := decodeInput(t, tu2.Input)
+
+	if in1["score"] != in2["score"] {
+		t.Errorf("score not deterministic: %v vs %v", in1["score"], in2["score"])
+	}
+	if in1["run_id"] != "r_abc" || in2["run_id"] != "r_abc" {
+		t.Errorf("run_id missing: %v / %v", in1["run_id"], in2["run_id"])
+	}
+}
+
+// TestMockEvaluator_ScoreIsDistributed: across many synthetic
+// run_ids the scores span the [0.50, 0.99] band without all
+// clumping in one bucket.
+func TestMockEvaluator_ScoreIsDistributed(t *testing.T) {
+	buckets := map[int]int{}
+	for i := 0; i < 1000; i++ {
+		s := deriveScore("r_" + string(rune('a'+i%26)) + string(rune('a'+(i/26)%26)) + string(rune('a'+(i/676)%26)))
+		if s < 0.50 || s > 0.99 {
+			t.Errorf("score out of range: %f", s)
+		}
+		b := int((s - 0.50) * 100) // 0..49
+		buckets[b]++
+	}
+	if len(buckets) < 30 {
+		t.Errorf("score distribution too clumped: %d unique buckets out of 50, want >=30", len(buckets))
+	}
+}
+
+// TestMockDriver_LatencyHonoursContext — ctx.Done() must short-
+// circuit the latency sleep promptly.
+func TestMockDriver_LatencyHonoursContext(t *testing.T) {
+	d := New()
+	d.latencyBase = 500 * time.Millisecond
+	d.latencyJitter = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := d.Call(ctx, providers.Request{
+		Model:    "mock-generic",
+		Messages: []providers.Message{userTextMessage("hello")},
+	})
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Error("expected ctx error, got nil")
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("ctx cancel didn't short-circuit: elapsed=%v", elapsed)
+	}
+}
+
+// TestMockDriver_429Injection — rate429=1.0 → 100% of calls return
+// an error whose string IsRateLimit classifies as 429.
+func TestMockDriver_429Injection(t *testing.T) {
+	d := NewWithRNG(rand.New(rand.NewSource(1)))
+	d.latencyBase = 0
+	d.latencyJitter = 0
+	d.rate429 = 1.0
+
+	for i := 0; i < 10; i++ {
+		_, err := d.Call(context.Background(), providers.Request{
+			Model:    "mock-researcher",
+			Messages: []providers.Message{userTextMessage("c1 q?")},
+		})
+		if err == nil {
+			t.Fatalf("call %d: expected 429 injection, got nil", i)
+		}
+		if !providers.IsRateLimit(err) {
+			t.Errorf("call %d: IsRateLimit(err) = false; err=%v", i, err)
+		}
+	}
+}
+
+// TestMockDriver_500Injection — rate500=1.0 + rate429=0 → 500 errors
+// matching the "<provider> <code>: msg" shape that errclass parses.
+func TestMockDriver_500Injection(t *testing.T) {
+	d := NewWithRNG(rand.New(rand.NewSource(1)))
+	d.latencyBase = 0
+	d.latencyJitter = 0
+	d.rate429 = 0
+	d.rate500 = 1.0
+
+	_, err := d.Call(context.Background(), providers.Request{
+		Model:    "mock-researcher",
+		Messages: []providers.Message{userTextMessage("c1 q?")},
+	})
+	if err == nil {
+		t.Fatal("expected 500 injection, got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "mock 500:") {
+		t.Errorf("err shape = %q; want mock 500: prefix", err.Error())
+	}
+	if providers.IsRateLimit(err) {
+		t.Errorf("500 misclassified as rate-limit: %v", err)
+	}
+}
+
+// TestMockDriver_UsageReflectsRequestSize — longer messages produce
+// proportionally larger InputTokens. Sanity that the loop's totalUsage
+// merge has non-trivial data to plot.
+func TestMockDriver_UsageReflectsRequestSize(t *testing.T) {
+	d := New()
+	d.latencyBase = 0
+	d.latencyJitter = 0
+
+	short := strings.Repeat("a", 100)
+	long := strings.Repeat("a", 5000)
+
+	// Usage is attached to EventDone (the loop reads it from there;
+	// a separate EventUsage frame would be ignored by the loop's
+	// switch arms — see internal/loop/loop.go).
+	usageFor := func(text string) *providers.Usage {
+		ch, _ := d.Call(context.Background(), providers.Request{
+			Model:    "mock-generic",
+			Messages: []providers.Message{userTextMessage(text)},
+		})
+		for _, e := range drain(t, ch) {
+			if e.Type == providers.EventDone && e.Usage != nil {
+				return e.Usage
+			}
+		}
+		return nil
+	}
+
+	su := usageFor(short)
+	lu := usageFor(long)
+	if su == nil || lu == nil {
+		t.Fatalf("missing Usage frame: short=%+v long=%+v", su, lu)
+	}
+	if lu.InputTokens <= su.InputTokens {
+		t.Errorf("long InputTokens not greater: long=%d short=%d", lu.InputTokens, su.InputTokens)
+	}
+	if lu.Model != "mock-generic" {
+		t.Errorf("Model = %q, want mock-generic", lu.Model)
+	}
+}
+
+// TestMockDriver_ListModelsReturnsKnownSet — sanity that the four
+// model ids are reported. The resolver pre-populates the matrix
+// from this list, so a typo here cascades into agent 503s.
+func TestMockDriver_ListModelsReturnsKnownSet(t *testing.T) {
+	d := New()
+	models, err := d.ListModels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{
+		"mock-researcher": false,
+		"mock-editor":     false,
+		"mock-evaluator":  false,
+		"mock-generic":    false,
+	}
+	for _, m := range models {
+		if _, ok := want[m]; !ok {
+			t.Errorf("unexpected model: %s", m)
+		}
+		want[m] = true
+	}
+	for m, seen := range want {
+		if !seen {
+			t.Errorf("missing model: %s", m)
+		}
+	}
+}
+
+// TestMockDriver_EnvVarParsing — bad env-var values fall back to
+// the documented defaults rather than panicking on start.
+func TestMockDriver_EnvVarParsing(t *testing.T) {
+	if got := parseRate("garbage", 0.42); got != 0.42 {
+		t.Errorf("parseRate(garbage) = %v, want 0.42 default", got)
+	}
+	if got := parseRate("1.5", 0.42); got != 0.42 {
+		t.Errorf("parseRate(out of range) = %v, want 0.42 default", got)
+	}
+	if got := parseRate("0.3", 0); got != 0.3 {
+		t.Errorf("parseRate(0.3) = %v, want 0.3", got)
+	}
+	if got := parseDurationMS("", 42*time.Millisecond); got != 42*time.Millisecond {
+		t.Errorf("parseDurationMS(empty) = %v, want default", got)
+	}
+	if got := parseDurationMS("-5", 42*time.Millisecond); got != 0 {
+		t.Errorf("parseDurationMS(negative) = %v, want 0", got)
+	}
+	if got := parseDurationMS("100", 0); got != 100*time.Millisecond {
+		t.Errorf("parseDurationMS(100) = %v, want 100ms", got)
+	}
+}
+
+// TestExtractCircuitID — the regex finds c{N} only inside text
+// blocks of user-role messages; falls back to c0 when not found.
+func TestExtractCircuitID(t *testing.T) {
+	cases := []struct {
+		name string
+		req  providers.Request
+		want string
+	}{
+		{
+			name: "happy_path",
+			req: providers.Request{Messages: []providers.Message{
+				userTextMessage("Your circuit_id is c42. Answer this."),
+			}},
+			want: "c42",
+		},
+		{
+			name: "no_circuit",
+			req: providers.Request{Messages: []providers.Message{
+				userTextMessage("just a question, no id"),
+			}},
+			want: "c0",
+		},
+		{
+			name: "multiple_picks_first",
+			req: providers.Request{Messages: []providers.Message{
+				userTextMessage("c1 and also c2 in the same line"),
+			}},
+			want: "c1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := extractCircuitID(tc.req); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/test/load/circuit-stress/README.md
+++ b/test/load/circuit-stress/README.md
@@ -134,10 +134,67 @@ Performance:
 - **OAuth-dev provider only.** API-key Anthropic is reachable via the same provider family but would obscure the OAuth quota measurement.
 - **No tier fallback.** `loomcycle.yaml` sets `fallback_on_error: false` deliberately. When quota dies, runs fail and the driver halts — that's the signal we're after.
 
+## Mock mode (v0.12.8) — cost-free substrate stress
+
+The `loomcycle.template.yaml` + `run.sh` path above burns real Anthropic OAuth-dev MAX quota on every call. That's the right tool for "does the substrate plus a real provider stay in sync end-to-end," but a poor tool for the actual stress-test question: **where does the loomcycle binary itself bottleneck at 10K+ concurrent agents?**
+
+Mock mode answers that. It swaps the provider out for a synthetic driver (`internal/providers/mock/driver.go`) that talks the same `providers.Provider` wire shape but:
+
+- Costs zero (no external HTTP, no quota).
+- Synthesises plausibly-shaped tool-call sequences keyed off `req.Model` — `mock-researcher` emits Memory.set → Channel.publish; `mock-editor` and `mock-evaluator` drive their own FSMs.
+- Has env-var-controlled failure injection so the resolver matrix (PR #241 MarkRateLimited) and runtime-fallback (PR #242 provider telemetry) paths get exercised under sustained load.
+
+```bash
+# Smoke — single circuit, default mock behaviour.
+export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)
+./test/load/circuit-stress/run-mock.sh --scale 1
+
+# The real target — 10K concurrent agents, single binary, no LLM cost.
+./test/load/circuit-stress/run-mock.sh --scale 10000 --circuits-per-user 20
+
+# Rate-limit cascade. Confirms MarkRateLimited (PR #241) cools the
+# matrix entry correctly under sustained 5% 429 noise.
+LOOMCYCLE_MOCK_429_RATE=0.05 \
+  ./test/load/circuit-stress/run-mock.sh --scale 1000
+
+# 5xx fallback. Confirms tryProviderFallback (v0.8.2) re-routes
+# without losing tool-state continuity.
+LOOMCYCLE_MOCK_500_RATE=0.01 \
+  ./test/load/circuit-stress/run-mock.sh --scale 1000
+
+# Latency-induced queue backup. At what scale does max_queue_depth
+# saturate? Does queue_timeout_ms drain cleanly?
+LOOMCYCLE_MOCK_LATENCY_MS=200 LOOMCYCLE_MOCK_LATENCY_JITTER_MS=100 \
+  ./test/load/circuit-stress/run-mock.sh --scale 5000
+
+# Channel-race amplification. Pairs with PR #243's diagnostic
+# (LOOMCYCLE_CHANNEL_DEBUG=1) — at high scale the
+# subscribe-race-recovered log lines feed the channel-race
+# investigation doc's hypothesis table.
+LOOMCYCLE_MOCK_LATENCY_MS=10 LOOMCYCLE_CHANNEL_DEBUG=1 \
+  ./test/load/circuit-stress/run-mock.sh --scale 10000
+```
+
+Knobs (all optional env vars, read once at driver init):
+
+| Var | Default | Range | Purpose |
+|---|---|---|---|
+| `LOOMCYCLE_MOCK_LATENCY_MS` | 50 | ≥0 | Base sleep per Call (ms). Plus a body component proportional to request size. |
+| `LOOMCYCLE_MOCK_LATENCY_JITTER_MS` | 25 | ≥0 | Uniform [0, jitter] random add. |
+| `LOOMCYCLE_MOCK_429_RATE` | 0 | [0.0, 1.0] | Fraction of Call()s that return a 429 error. `IsRateLimit`-classifiable so `MarkRateLimited` engages. |
+| `LOOMCYCLE_MOCK_500_RATE` | 0 | [0.0, 1.0] | Fraction returning a 5xx. Drives the runtime-fallback path. |
+
+What the mock does NOT cover:
+- **Provider-specific transcript quirks.** The mock emits clean tool_use blocks; there's no Anthropic cache_control, no DeepSeek reasoning_content, no Gemini schema sanitisation in play. Use `loomcycle.template.yaml` against a real provider to exercise those.
+- **Content quality.** The driver ignores the agent prompts; payloads are canned. The test verifies substrate plumbing (channels, memory, sweeper, queue), not model output.
+- **Multi-replica cluster shape.** Single-binary first; cluster mock is a follow-up.
+
 ## Files in this directory
 
-- `main.go` — the driver
-- `loomcycle.yaml` — minimal test config (Postgres, OAuth-dev, 3 agents, channel ACLs)
-- `prompts.txt` — 30 tiny factual questions (driver round-robins through them)
-- `run.sh` — convenience wrapper
+- `main.go` — the driver (provider-agnostic; same code drives real-LLM and mock modes)
+- `loomcycle.template.yaml` — real-LLM config (Postgres, OAuth-dev, 3 agents, channel ACLs)
+- `loomcycle.mock.yaml` — mock-mode config (Postgres, `provider: mock`, same 3 agents pinned to mock-researcher / mock-editor / mock-evaluator)
+- `prompts.txt` — 30 tiny factual questions (driver round-robins through them; ignored by the mock)
+- `run.sh` — real-LLM convenience wrapper (requires `loomcycle anthropic login`)
+- `run-mock.sh` — mock-mode wrapper (no provider credentials needed)
 - `README.md` — you're reading it

--- a/test/load/circuit-stress/loomcycle.mock.yaml
+++ b/test/load/circuit-stress/loomcycle.mock.yaml
@@ -1,0 +1,130 @@
+# test/load/circuit-stress — mock-mode loomcycle config.
+#
+# This file is the cost-free twin of loomcycle.template.yaml. It pins
+# every agent to the synthetic `mock` provider (see
+# internal/providers/mock/driver.go) so the same harness exercises the
+# substrate without burning real Anthropic / OpenAI quota.
+#
+# When to use this:
+#   - Pure-substrate throughput characterisation (10K-100K concurrent).
+#   - Failure-injection scenarios driven via LOOMCYCLE_MOCK_429_RATE etc.
+#   - Iterating on contention bugs (channel race, sweeper interference,
+#     queue back-pressure) without provider-side latency variance.
+#
+# When NOT to use this:
+#   - End-to-end "did the substrate + a real provider stay in sync"
+#     smoke. For that, run loomcycle.template.yaml against
+#     anthropic-oauth-dev.
+
+provider_priority:
+  - mock
+
+# Library-default tier. mock-generic is the catch-all model variant —
+# it should never actually fire here because every agent below pins
+# its own model, but the resolver wants something to fall back on.
+tiers:
+  middle:
+    - { provider: mock, model: mock-generic }
+
+# Default user_tier. No fallback_on_error — the mock IS the only
+# provider; failure injection is observed at the loop level.
+user_tiers:
+  default:
+    provider_priority: [mock]
+    tiers:
+      middle:
+        - { provider: mock, model: mock-generic }
+    fallback_on_error: false
+
+# Concurrency — sized for the 10K-scale target. The mock has zero
+# real cost so we can crank the active worker count and queue depth
+# significantly higher than the real-provider yaml's 20/1500.
+concurrency:
+  max_concurrent_runs: 2000
+  max_queue_depth: 30000
+  queue_timeout_ms: 600000
+  max_concurrent_runs_per_user: 0
+
+# Storage — Postgres for the same reason as the real-provider yaml.
+# SQLite serialises writes; under 10K concurrent agents that
+# serialisation dominates the latency picture before the substrate
+# itself is meaningfully loaded.
+storage:
+  backend: postgres
+  pg_dsn: ${LOOMCYCLE_PG_DSN}
+  pg_max_open_conns: 128
+  pg_max_idle_conns: 16
+
+# ─── Channels ──────────────────────────────────────────────────────
+# Same generator markers as loomcycle.template.yaml. run-mock.sh
+# uses the SAME awk block to inject N pairs of research-done/cK +
+# editing-done/cK entries; the two yamls are kept structurally
+# parallel so the generator script doesn't need a per-yaml fork.
+
+channels:
+  # ── BEGIN generated channels ── (managed by run-mock.sh)
+  # ── END generated channels ──
+
+# ─── Agents ────────────────────────────────────────────────────────
+# Three agents, each pinned to a distinct mock-* model so the
+# driver dispatches off req.Model. System prompts are still present
+# (for parity with the real-provider yaml — the agent definitions are
+# otherwise identical) but the mock IGNORES them: the FSM is in the
+# driver code, not the prompt.
+
+agents:
+
+  researcher:
+    provider: mock
+    model: mock-researcher
+    max_tokens: 1500
+    system_prompt: |
+      Mock researcher agent. The driver pins this agent to the
+      mock-researcher model; the mock driver synthesises a 2-step
+      sequence (Memory.set, Channel.publish) without reading this
+      prompt. See internal/providers/mock/driver.go scriptResearcher.
+    allowed_tools: [Memory, Channel, Context]
+    memory_scopes: [user]
+    channels:
+      publish: ["research-done/*"]
+      subscribe: []
+
+  editor:
+    provider: mock
+    model: mock-editor
+    max_tokens: 1500
+    system_prompt: |
+      Mock editor agent. The driver pins this agent to the
+      mock-editor model; the mock driver synthesises a 5-step FSM
+      (Channel.subscribe → Memory.get → Memory.set → Context.self →
+      Channel.publish). See internal/providers/mock/driver.go
+      scriptEditor for the per-step shapes.
+    allowed_tools: [Memory, Channel, Context]
+    memory_scopes: [user]
+    channels:
+      publish: ["editing-done/*"]
+      subscribe: ["research-done/*"]
+
+  evaluator:
+    provider: mock
+    model: mock-evaluator
+    max_tokens: 1500
+    system_prompt: |
+      Mock evaluator agent. The driver pins this agent to the
+      mock-evaluator model; the mock driver synthesises a 5-step
+      FSM (Channel.subscribe → Memory.get(×2) → Memory.set →
+      Evaluation.submit). The score is a deterministic-but-
+      pseudorandom hash of the editor's run_id, so distinct test
+      runs produce a varied distribution but a given run is
+      reproducible. See internal/providers/mock/driver.go
+      scriptEvaluator for the FSM and deriveScore for the score
+      function.
+    allowed_tools: [Memory, Channel, Evaluation, Context]
+    memory_scopes: [user]
+    # Same submit_any as the real-provider yaml — the evaluator is
+    # a SIBLING (not a parent/child) of the editor, which the
+    # checkSubmitScope code collapses to "unrelated" today.
+    evaluation_scopes: [submit_any]
+    channels:
+      publish: []
+      subscribe: ["editing-done/*"]

--- a/test/load/circuit-stress/run-mock.sh
+++ b/test/load/circuit-stress/run-mock.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# run-mock.sh — cost-free twin of run.sh.
+#
+# Uses loomcycle.mock.yaml + the synthetic mock provider (see
+# internal/providers/mock/driver.go) so the same circuit-stress
+# harness exercises the substrate at 10K+ concurrent agents without
+# burning real Anthropic / OpenAI quota.
+#
+# Failure-injection knobs (env vars, all optional):
+#   LOOMCYCLE_MOCK_LATENCY_MS         base sleep per provider Call (default 50)
+#   LOOMCYCLE_MOCK_LATENCY_JITTER_MS  uniform [0, jitter] random add (default 25)
+#   LOOMCYCLE_MOCK_429_RATE           fraction [0.0, 1.0] of calls to reject 429
+#   LOOMCYCLE_MOCK_500_RATE           same, but 5xx
+#
+# Prereqs (one-time):
+#   export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)
+#
+# NO Anthropic credentials required — that's the whole point.
+#
+# Usage (from repo root):
+#   ./test/load/circuit-stress/run-mock.sh                                # x1 smoke
+#   ./test/load/circuit-stress/run-mock.sh --scale 1000 --circuits-per-user 20
+#   LOOMCYCLE_MOCK_429_RATE=0.05 \
+#     ./test/load/circuit-stress/run-mock.sh --scale 1000
+#   LOOMCYCLE_MOCK_LATENCY_MS=200 LOOMCYCLE_MOCK_LATENCY_JITTER_MS=100 \
+#     ./test/load/circuit-stress/run-mock.sh --scale 5000
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+PG_CONTAINER="${PG_CONTAINER:-lc-loadtest-pg}"
+PG_PORT="${PG_PORT:-15432}"
+PG_PASSWORD="${PG_PASSWORD:-loomcycle}"
+LC_PORT="${LC_PORT:-8787}"
+RESULTS_DIR="${RESULTS_DIR:-$SCRIPT_DIR/results/$(date -u +%Y-%m-%dT%H-%M-%SZ)-mock}"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "✗ missing dependency: $1" >&2
+        exit 1
+    }
+}
+require docker
+require go
+
+: "${LOOMCYCLE_AUTH_TOKEN:?LOOMCYCLE_AUTH_TOKEN must be set}"
+
+mkdir -p "$RESULTS_DIR"
+echo "→ results dir: $RESULTS_DIR"
+
+# ─── Postgres ───────────────────────────────────────────────────────
+if ! docker inspect "$PG_CONTAINER" >/dev/null 2>&1; then
+    echo "→ starting Postgres container ($PG_CONTAINER on :$PG_PORT)…"
+    docker run -d --name "$PG_CONTAINER" \
+        -p "127.0.0.1:$PG_PORT:5432" \
+        -e POSTGRES_PASSWORD="$PG_PASSWORD" \
+        postgres:16 >/dev/null
+    until docker exec "$PG_CONTAINER" pg_isready -U postgres >/dev/null 2>&1; do
+        sleep 1
+    done
+elif [ "$(docker inspect -f '{{.State.Running}}' "$PG_CONTAINER")" != "true" ]; then
+    echo "→ restarting Postgres container ($PG_CONTAINER)…"
+    docker start "$PG_CONTAINER" >/dev/null
+    until docker exec "$PG_CONTAINER" pg_isready -U postgres >/dev/null 2>&1; do
+        sleep 1
+    done
+else
+    echo "→ Postgres container $PG_CONTAINER already running"
+fi
+
+export LOOMCYCLE_PG_DSN="postgres://postgres:$PG_PASSWORD@127.0.0.1:$PG_PORT/postgres?sslmode=disable"
+
+# ─── loomcycle binary ───────────────────────────────────────────────
+# Always rebuild — Go's incremental compile is sub-second when source
+# is unchanged. The dual-binary stale-artifact trap that bit run.sh on
+# 2026-05-26 applies here too.
+LC_BIN="${LC_BIN:-$REPO_ROOT/bin/loomcycle}"
+echo "→ rebuilding loomcycle binary from current HEAD…"
+go build -o "$LC_BIN" ./cmd/loomcycle/
+
+# Mock provider opt-in + failure-injection defaults. Each can be
+# overridden by the operator's env before invoking this script —
+# the ${VAR:-default} pattern keeps the override semantics natural.
+export LOOMCYCLE_MOCK_ENABLED=1
+export LOOMCYCLE_MOCK_LATENCY_MS="${LOOMCYCLE_MOCK_LATENCY_MS:-50}"
+export LOOMCYCLE_MOCK_LATENCY_JITTER_MS="${LOOMCYCLE_MOCK_LATENCY_JITTER_MS:-25}"
+export LOOMCYCLE_MOCK_429_RATE="${LOOMCYCLE_MOCK_429_RATE:-0}"
+export LOOMCYCLE_MOCK_500_RATE="${LOOMCYCLE_MOCK_500_RATE:-0}"
+
+# Substrate env (identical to run.sh; the harness is provider-
+# agnostic once the yaml swaps).
+export LOOMCYCLE_PG_AUTOMIGRATE=1
+export LOOMCYCLE_METRICS_ENABLED=1
+export LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS=120000
+export LOOMCYCLE_LISTEN_ADDR="127.0.0.1:$LC_PORT"
+
+# Optional channel-debug logging (v0.12.7). Operators flip this on
+# when running mock at high concurrency to capture
+# subscribe-race-recovered telemetry per the channel-race
+# investigation doc.
+export LOOMCYCLE_CHANNEL_DEBUG="${LOOMCYCLE_CHANNEL_DEBUG:-0}"
+
+# ─── Generate the scale-sized yaml ──────────────────────────────────
+SCALE=1
+args=("$@")
+for ((i=0; i<${#args[@]}; i++)); do
+    a="${args[i]}"
+    if [ "$a" = "--scale" ] && [ $((i+1)) -lt ${#args[@]} ]; then
+        SCALE="${args[i+1]}"
+    elif [[ "$a" == --scale=* ]]; then
+        SCALE="${a#--scale=}"
+    fi
+done
+echo "→ generating yaml for scale=${SCALE}..."
+GEN_YAML="$RESULTS_DIR/loomcycle.gen.yaml"
+awk -v scale="$SCALE" '
+    /BEGIN generated channels/ {
+        print
+        for (i = 1; i <= scale; i++) {
+            printf "  research-done/c%d:\n    description: \"researcher → editor signal for circuit %d\"\n    scope: global\n    semantic: queue\n    default_ttl: 600\n    max_messages: 1000\n", i, i
+            printf "  editing-done/c%d:\n    description: \"editor → evaluator signal for circuit %d\"\n    scope: global\n    semantic: queue\n    default_ttl: 600\n    max_messages: 1000\n", i, i
+        }
+        in_block = 1
+        next
+    }
+    /END generated channels/ { in_block = 0 }
+    !in_block { print }
+' "$SCRIPT_DIR/loomcycle.mock.yaml" > "$GEN_YAML"
+
+echo "→ starting loomcycle on :$LC_PORT (logs: $RESULTS_DIR/loomcycle.log)…"
+echo "  scenario: latency_ms=$LOOMCYCLE_MOCK_LATENCY_MS jitter_ms=$LOOMCYCLE_MOCK_LATENCY_JITTER_MS 429_rate=$LOOMCYCLE_MOCK_429_RATE 500_rate=$LOOMCYCLE_MOCK_500_RATE"
+"$LC_BIN" --config "$GEN_YAML" \
+    >"$RESULTS_DIR/loomcycle.log" 2>&1 &
+LC_PID=$!
+
+cleanup() {
+    if kill -0 "$LC_PID" 2>/dev/null; then
+        echo "→ stopping loomcycle (pid=$LC_PID)…"
+        kill -INT "$LC_PID" 2>/dev/null || true
+        wait "$LC_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+echo "→ waiting for /healthz…"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    if curl -fsS -m 2 -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+        "http://127.0.0.1:$LC_PORT/healthz" >/dev/null 2>&1; then
+        echo "  loomcycle healthy"
+        break
+    fi
+    if [ "$i" = "10" ]; then
+        echo "✗ loomcycle never became healthy; tail of log:"
+        tail -40 "$RESULTS_DIR/loomcycle.log"
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "→ metrics snapshot (pre)…"
+curl -fsS -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+    "http://127.0.0.1:$LC_PORT/v1/_metrics/summary" \
+    >"$RESULTS_DIR/metrics-summary-pre.json" 2>/dev/null || true
+
+DRIVER_BIN="${DRIVER_BIN:-$SCRIPT_DIR/circuit-stress}"
+echo "→ rebuilding driver from current source…"
+(cd "$SCRIPT_DIR" && go build -o circuit-stress .)
+
+echo "→ running driver: $DRIVER_BIN $* --results-dir $RESULTS_DIR --base-url http://127.0.0.1:$LC_PORT"
+echo
+"$DRIVER_BIN" "$@" --results-dir "$RESULTS_DIR" --base-url "http://127.0.0.1:$LC_PORT"
+RC=$?
+
+echo "→ metrics snapshot (post)…"
+curl -fsS -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+    "http://127.0.0.1:$LC_PORT/v1/_metrics/summary" \
+    >"$RESULTS_DIR/metrics-summary-post.json" 2>/dev/null || true
+
+echo
+echo "→ done. Results in $RESULTS_DIR/"
+echo "    circuits.jsonl, loomcycle.log, metrics-summary-{pre,post}.json"
+echo "    Web UI:  open \"http://127.0.0.1:$LC_PORT/ui?token=\$LOOMCYCLE_AUTH_TOKEN\""
+
+exit $RC


### PR DESCRIPTION
## Summary

- New `internal/providers/mock` package — synthetic Provider that drives the circuit-stress 3-agent pipeline (researcher → editor → evaluator) with no external HTTP and no real-LLM cost.
- Env-var failure injection (429 / 500 / latency / jitter) so the resolver matrix + runtime-fallback paths are exercised at the same time as the stress test.
- New `loomcycle.mock.yaml` + `run-mock.sh` parallel to the existing template + run.sh; same `main.go` harness drives both modes.
- One-line bug fix in `server.go`: the two FinishRun call sites weren't copying `Usage.Provider` into `store.Usage.Provider`. Pre-existing miss from PR #242 that mock-mode smoke surfaced.

## Why

The v0.12.x x1000 attempt against `anthropic-oauth-dev` halted on `ErrSubscriptionQuotaExhausted` before it could characterise loomcycle's own ceilings. Real-LLM variance + cost makes 10K+ concurrent agents economically infeasible. The mock provider closes that gap — same wire shape, zero cost, controllable failure modes — so the actual stress-test question (where does the loomcycle binary itself bottleneck?) becomes answerable.

## Architecture

Operator opts in with `LOOMCYCLE_MOCK_ENABLED=1`. The driver registers as provider id `mock`, listed alongside the real providers in the resolver matrix. Four model variants (`mock-researcher`, `mock-editor`, `mock-evaluator`, `mock-generic`) drive scripted FSMs that match the existing circuit-stress agent shape. Each model's step is determined by counting `tool_result` blocks in `req.Messages` — no prompt parsing, no template state needed.

Failure injection knobs (read once at New() from env vars):

| Var | Default | Range | Purpose |
|---|---|---|---|
| `LOOMCYCLE_MOCK_LATENCY_MS` | 50 | ≥0 | Base sleep per Call (ms). |
| `LOOMCYCLE_MOCK_LATENCY_JITTER_MS` | 25 | ≥0 | Uniform [0, jitter] add. |
| `LOOMCYCLE_MOCK_429_RATE` | 0 | [0.0, 1.0] | Fraction of calls returning a 429. `IsRateLimit`-classifiable → MarkRateLimited (PR #241) engages. |
| `LOOMCYCLE_MOCK_500_RATE` | 0 | [0.0, 1.0] | Fraction returning a 5xx. → tryProviderFallback path. |

The driver intentionally does NOT wrap in ratelimit.Do — we want injected 429s to reach the loop directly.

## Sample scenarios

```bash
# Smoke
./test/load/circuit-stress/run-mock.sh --scale 1

# The real target — 10K concurrent, no LLM cost
./test/load/circuit-stress/run-mock.sh --scale 10000 --circuits-per-user 20

# Rate-limit cascade — confirms MarkRateLimited matrix cooldown engages
LOOMCYCLE_MOCK_429_RATE=0.05 \
  ./test/load/circuit-stress/run-mock.sh --scale 1000

# Latency-induced queue backup — confirms max_queue_depth / queue_timeout_ms drain cleanly
LOOMCYCLE_MOCK_LATENCY_MS=200 LOOMCYCLE_MOCK_LATENCY_JITTER_MS=100 \
  ./test/load/circuit-stress/run-mock.sh --scale 5000
```

## Review fixes applied

The code-reviewer pass flagged:
1. **`mintToolUseID` used the global math/rand** instead of `d.rng`, breaking the `NewWithRNG` test seam. Fixed by switching to `crypto/rand` — collision resistance matters more than reproducibility for opaque tool_use IDs.
2. **Off-by-one in `scriptEditor` and `scriptEvaluator` docstrings** ("Step 5 (Evaluation.submit)" when the code is `case 4`). Rewritten to use 0-indexed step numbers matching the case labels.

The reviewer confirmed: FSM step counting is stable; the error-string contract with `errclass.statusRe` matches; the Provider-field plumbing fix is complete; concurrent reads of read-only Driver fields are safe.

## Test plan

- [x] `go test -race ./...` clean (no new failures).
- [x] 12 mock-driver unit tests cover each model FSM, failure injection, ctx-honouring latency, deterministic + distributed scores, Usage-proportional-to-request-size, ListModels, env-var parsing.
- [x] Smoke at `--scale 1`, `--scale 10`, and `--scale 5 LOOMCYCLE_MOCK_429_RATE=0.10`: all circuits land 3 completed agent runs, 3 memory rows, 1 evaluation per circuit, with `provider="mock"` on every row.
- [x] gofmt + go vet clean.

## Out of scope

- Multi-replica cluster mock testing — single-binary first.
- Replacing the real-LLM `loomcycle.template.yaml` — mock is additive.
- Provider-specific transcript quirks (Anthropic cache_control, DeepSeek reasoning_content, Gemini schema sanitisation). For those, run the real-provider yaml.
- "Smart" content-aware mock that reads the question and answers it — payloads are intentionally canned. We're stressing substrate, not testing model quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)