### PR TITLE
docs(README): reposition headline noun — "Agentic OS" → "agentic runtime"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>The Agentic OS, in a sidecar.</strong><br/>
+  <strong>The agentic runtime, in a sidecar.</strong><br/>
   <em>One Go binary alongside your application — hardened agent loop, MCP on both sides, multi-replica HA. Apache-2.0.</em>
 </p>
 
@@ -28,7 +28,7 @@
 
 ## What it is
 
-**The Agentic OS, in a sidecar.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it. Your app calls loomcycle over HTTP, gRPC, MCP, or via the TypeScript adapter; the agent loop, multi-provider routing, memory and channel primitives, MCP server identity, OpenTelemetry traces, and multi-replica coordination all live in the binary. Your application stays in whatever language you wrote it in.
+**The agentic runtime, in a sidecar.** loomcycle is one ~30 MB Go binary that runs *alongside* your application — not inside it. Your app calls loomcycle over HTTP, gRPC, MCP, or via the TypeScript adapter; the agent loop, multi-provider routing, memory and channel primitives, MCP server identity, OpenTelemetry traces, and multi-replica coordination all live in the binary. It's the substrate your agents live on — and your application stays in whatever language you wrote it in.
 
 **The shape that's different.** The agentic-systems market today gives you three choices — embed a Python or TypeScript library inside your process, rent a managed cloud service tied to one vendor's IAM, or proxy your model calls through a gateway that doesn't actually run agents. loomcycle is the fourth shape: a lightweight self-hostable runtime that owns the loop *and* speaks every wire format your stack already uses.
 


### PR DESCRIPTION
## Summary

Repositions the README headline noun from **"The Agentic OS, in a sidecar"** to **"The agentic runtime, in a sidecar."**

## Why

The "Agentic OS" term genericized fast — within the last couple of weeks it's been claimed by Microsoft (positioning Windows as an "agentic OS"), Xebia, Mira OS, MindStudio, and at least two GitHub projects. The noun no longer differentiates; only the qualifier ("in a sidecar") does.

It's also a mild overclaim: loomcycle is a *runtime*, not a literal OS — no kernel, no scheduler for arbitrary programs, no syscall layer. "OS" was always a metaphor, and the metaphor is now everyone's.

**"Agentic runtime"** is:
- More accurate — loomcycle owns the loop, which is what a runtime does (cf. container runtime, JS runtime)
- Better matched to the platform-engineer buyer's mental model
- Far less crowded than "agentic OS"
- Already in the project's own eyebrow/vocabulary

**"Substrate"** now carries the deeper conceptual hook in the body — and unlike "OS" it's defensible with shipped code (the AgentDef / SkillDef / MCPServerDef substrate is a real, named, shipped thing, not a metaphor).

The differentiating qualifier ("in a sidecar") is unchanged.

## Changes

- Header tagline: `The Agentic OS, in a sidecar.` → `The agentic runtime, in a sidecar.`
- "What it is" lead sentence: same swap, plus a "substrate your agents live on" clause added to carry the deeper framing.

Two lines changed. The loomcycle.dev marketing site is being updated in lockstep (separate repo).

## Test plan

- [ ] README renders correctly on github.com after merge — header reads "The agentic runtime, in a sidecar."

🤖 Generated with [Claude Code](https://claude.com/claude-code)