### PR TITLE
fix(api): bump UpdateHeartbeat budget 1s → 5s to ride out pool jitter

### DIFF
--- a/internal/api/http/heartbeat_budget_test.go
+++ b/internal/api/http/heartbeat_budget_test.go
@@ -1,0 +1,185 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// delayingHeartbeatStore wraps a real store.Store but injects a
+// configurable sleep into UpdateHeartbeat — exercises the path where
+// the pool acquire would block under burst saturation. Atomic int64
+// for thread-safe delay updates from concurrent test goroutines.
+type delayingHeartbeatStore struct {
+	store.Store
+	delayMS atomic.Int64 // milliseconds to sleep before delegating
+}
+
+func (s *delayingHeartbeatStore) UpdateHeartbeat(ctx context.Context, runID string) error {
+	d := time.Duration(s.delayMS.Load()) * time.Millisecond
+	if d > 0 {
+		select {
+		case <-time.After(d):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return s.Store.UpdateHeartbeat(ctx, runID)
+}
+
+// makeHeartbeatTestServer constructs a Server with a delaying store
+// wrapped around an in-memory sqlite. Returns the server, the
+// delay-control hook, and a cleanup. The caller must invoke heartbeat
+// with a valid runID; we create one off a session for them.
+func makeHeartbeatTestServer(t *testing.T) (*Server, *delayingHeartbeatStore, string, func()) {
+	t.Helper()
+	inner, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	ctx := context.Background()
+	sess, err := inner.CreateSession(ctx, "tenant", "agent", "")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := inner.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "hb-test"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	delayed := &delayingHeartbeatStore{Store: inner}
+	srv := &Server{store: delayed}
+	cleanup := func() { _ = inner.Close() }
+	return srv, delayed, run.ID, cleanup
+}
+
+// captureLog redirects log output to a buffer for the duration of the
+// test. Returns a snapshot accessor + a restore closure.
+func captureLog(t *testing.T) (func() string, func()) {
+	t.Helper()
+	var buf strings.Builder
+	prev := log.Writer()
+	flags := log.Flags()
+	log.SetOutput(&buf)
+	return func() string { return buf.String() }, func() {
+		log.SetOutput(prev)
+		log.SetFlags(flags)
+	}
+}
+
+// TestMakeHeartbeat_TolerantOfPoolSaturation — the canonical x5000
+// scenario reproduction. At the launch crest, store.UpdateHeartbeat
+// can spend up to several seconds waiting for a pgxpool acquire.
+// The prior 1-second timeout fired and produced operator-visible
+// noise on otherwise-healthy runs. The new 5-second budget rides
+// out the natural acquire jitter; a 2-second store delay must NOT
+// trip the deadline.
+func TestMakeHeartbeat_TolerantOfPoolSaturation(t *testing.T) {
+	srv, delayed, runID, cleanup := makeHeartbeatTestServer(t)
+	defer cleanup()
+	logOf, restore := captureLog(t)
+	defer restore()
+
+	delayed.delayMS.Store(2000) // 2 s — well under the 5 s budget
+
+	hb := srv.makeHeartbeat(runID)
+	if hb == nil {
+		t.Fatal("makeHeartbeat returned nil")
+	}
+	start := time.Now()
+	hb()
+	elapsed := time.Since(start)
+
+	if elapsed < 2*time.Second {
+		t.Errorf("heartbeat returned too fast: %v — store delay should have applied", elapsed)
+	}
+	if elapsed > 4*time.Second {
+		t.Errorf("heartbeat took too long: %v — should complete around the 2 s delay", elapsed)
+	}
+	if got := logOf(); strings.Contains(got, "UpdateHeartbeat") {
+		t.Errorf("unexpected log output (deadline shouldn't have fired): %q", got)
+	}
+}
+
+// TestMakeHeartbeat_LogsOnDeadlineExceeded — when the store delay
+// exceeds the budget (real pool starvation), the closure logs the
+// failure and returns silently. The run must NOT see the failure.
+func TestMakeHeartbeat_LogsOnDeadlineExceeded(t *testing.T) {
+	srv, delayed, runID, cleanup := makeHeartbeatTestServer(t)
+	defer cleanup()
+	logOf, restore := captureLog(t)
+	defer restore()
+
+	// 7 s delay > the 5 s budget — deadline will fire.
+	delayed.delayMS.Store(7000)
+
+	hb := srv.makeHeartbeat(runID)
+	start := time.Now()
+	hb() // must not panic; must not propagate the error
+	elapsed := time.Since(start)
+
+	// Should return shortly after the 5 s deadline, not the 7 s store delay.
+	if elapsed < 5*time.Second {
+		t.Errorf("heartbeat returned too fast: %v — deadline should have fired at ~5 s", elapsed)
+	}
+	if elapsed > 6*time.Second {
+		t.Errorf("heartbeat took too long: %v — deadline should fire near the 5 s budget", elapsed)
+	}
+	if got := logOf(); !strings.Contains(got, "UpdateHeartbeat") {
+		t.Errorf("expected timeout log line, got: %q", got)
+	}
+	if got := logOf(); !strings.Contains(got, "context deadline exceeded") {
+		t.Errorf("expected deadline-exceeded reason in log, got: %q", got)
+	}
+}
+
+// TestMakeHeartbeat_NoOpWhenStoreNil — the documented no-op path for
+// store-less deployments.
+func TestMakeHeartbeat_NoOpWhenStoreNil(t *testing.T) {
+	srv := &Server{}
+	if got := srv.makeHeartbeat("run-id"); got != nil {
+		t.Errorf("nil-store makeHeartbeat returned non-nil closure")
+	}
+}
+
+// TestMakeHeartbeat_NoOpWhenRunIDEmpty — sub-agent spawn path passes
+// "" sometimes; must return nil rather than panic.
+func TestMakeHeartbeat_NoOpWhenRunIDEmpty(t *testing.T) {
+	_, _, _, cleanup := makeHeartbeatTestServer(t)
+	defer cleanup()
+	srv, _, _, _ := makeHeartbeatTestServer(t)
+	if got := srv.makeHeartbeat(""); got != nil {
+		t.Errorf("empty-runID makeHeartbeat returned non-nil closure")
+	}
+}
+
+// TestMakeHeartbeat_PropagatesNotFoundSilently — the store returns
+// store.ErrNotFound for a stale run_id (sweeper already collected
+// it); the heartbeat closure logs but continues without panic. Sanity
+// that the existing log-only error handling survives the timeout
+// bump.
+func TestMakeHeartbeat_PropagatesNotFoundSilently(t *testing.T) {
+	srv, _, _, cleanup := makeHeartbeatTestServer(t)
+	defer cleanup()
+	logOf, restore := captureLog(t)
+	defer restore()
+
+	hb := srv.makeHeartbeat("r_does_not_exist")
+	if hb == nil {
+		t.Fatal("makeHeartbeat returned nil for non-empty runID")
+	}
+	hb() // must complete without panic
+	// SQLite's UpdateHeartbeat is a no-op UPDATE for missing rows
+	// (status='running' guard excludes the row from the update set
+	// rather than erroring), so the log may be empty here. If a
+	// future store change DOES return ErrNotFound, we still want
+	// the closure to log + return.
+	_ = logOf()
+	_ = errors.New // keep import used
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3802,12 +3802,36 @@ func (s *Server) publishRunState(m runStateMeta, status, stopReason, errMsg stri
 //
 // nil store or runID makes this a no-op so v0.2 callers stay
 // hands-off.
+//
+// The per-call timeout is sized for pool-saturation tolerance, not for
+// heartbeat freshness. At the launch crest of the v0.12.9 x5000 load
+// test (15 K agent runs, ~140 concurrent), 10 heartbeat UPDATEs timed
+// out within a 1-second window because the pgxpool was briefly burst-
+// saturated by concurrent Memory.set / Channel.publish / AppendEvent
+// calls. The pool acquire blocked past the prior 1-second deadline,
+// the inherited ctx fired, and the heartbeat logged "context deadline
+// exceeded". The runs themselves were unaffected (heartbeats are
+// advisory; the sweeper is the authority on stale-run detection), but
+// the operator-visible noise + the theoretical risk of the sweeper
+// misfiring on a slightly older last_heartbeat_at warranted a fix.
+//
+// 5 seconds is chosen because:
+//   - Heartbeats fire once per loop iteration (~100-200ms cadence
+//     with a mock provider; ~1-3s with a real provider). A 5s budget
+//     means at most 1-2 missed beats under sustained pool saturation
+//     before the next iteration arrives — and "1-2 missed beats" is
+//     well within the sweeper's stale-detection window (60s+ by
+//     default per `heartbeat.SweeperConfig`).
+//   - The substrate-level retryOnTransientConn helper added in PR
+//     #246 doesn't apply here because the error is ctx.DeadlineExceeded,
+//     not SQLSTATE 53300. The fix is to give the heartbeat enough
+//     budget to ride out the pool's natural acquire jitter.
 func (s *Server) makeHeartbeat(runID string) func() {
 	if s.store == nil || runID == "" {
 		return nil
 	}
 	return func() {
-		bg, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		bg, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 		if err := s.store.UpdateHeartbeat(bg, runID); err != nil {
 			// Log only — never fail the run on a heartbeat hiccup.


### PR DESCRIPTION
## Summary

x5000 load test (15 K agent runs, 10 K channels) logged 10 heartbeat-timeout warnings clustered in a 1-second window at the launch crest. Bumping the per-call timeout from 1 s to 5 s eliminates the noise while keeping heartbeats well inside the sweeper's stale-detection window.

## Diagnosis

\`makeHeartbeat\` was already using \`context.Background()\` with its own deadline (the earlier bottleneck-analysis doc mistakenly attributed this to run-ctx inheritance — the actual prior code was \`WithTimeout(bg, 1*time.Second)\`).

The real cause: at the launch crest of x5000, ~140 concurrent runs each cycle \`Memory.set\` / \`Channel.publish\` / \`AppendEvent\` and contend for the 80-connection pgxpool. Most acquires return in sub-100ms; a small fraction overshoot 1 s. The 1-second deadline fired, and the heartbeat logged:

\`\`\`
store: UpdateHeartbeat(r_…) failed: timeout: context deadline exceeded
\`\`\`

Runs were unaffected — heartbeats are advisory and the sweeper's stale-detection threshold is 60 s+. But the warning cluster is operator-confusing and at higher scales could mask a real outage.

## Fix

5-second deadline. Sized for tolerance, not freshness:

- Heartbeats fire once per loop iteration (~100-200 ms with mock, ~1-3 s with real LLM). 5 s of tolerance = at most 1-2 missed beats under sustained pool saturation before the next iteration arrives — well inside the sweeper's 60 s+ window.
- PR #246's \`retryOnTransientConn\` doesn't apply: the error is \`ctx.DeadlineExceeded\`, not \`SQLSTATE 53300\`. The classifier is intentionally narrow.

## Test plan

5 new tests in \`heartbeat_budget_test.go\` (via a delaying-store wrapper):

- \`TolerantOfPoolSaturation\` — 2 s store delay (under the budget) succeeds silently. **Would have failed under the prior 1 s budget.**
- \`LogsOnDeadlineExceeded\` — 7 s store delay (over the budget) logs the deadline-exceeded reason and returns without panic; the run is unaffected.
- \`NoOpWhenStoreNil\` / \`NoOpWhenRunIDEmpty\` — existing nil-guard paths preserved.
- \`PropagatesNotFoundSilently\` — sanity that stale-run lookups don't panic.

All 5 pass with \`-race\`. \`gofmt\` + \`go vet\` clean.

## Out of scope

- The full \`-race\` http-package suite has some pre-existing test-isolation flakes (\`TestUnifiedLibrary_*\`, \`TestRestoreSnapshot_*\`) that pass individually with \`-p 1\`. Same shape as the ChannelTTL / AgentDef flakes captured in earlier sessions. Unrelated to this PR.
- Configurability via env var. The 5 s budget is hardcoded — if a future deployment finds 5 s insufficient under different pool/load shape, a \`LOOMCYCLE_HEARTBEAT_TIMEOUT_MS\` env var would surface it. Not needed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)