### PR TITLE
feat(load-test): bump driver launch semaphore 50 → 500

### DIFF
--- a/test/load/circuit-stress/main.go
+++ b/test/load/circuit-stress/main.go
@@ -374,9 +374,15 @@ func runCircuits(c *lcClient, f flags, prompts []string) []circuitResult {
 		startedCount   atomic.Int32
 		completedCount atomic.Int32
 		// Throttle initial spawn so we don't slam the runs-admit
-		// semaphore with all N at once — 50 concurrent launches is
-		// plenty for x1000.
-		launchSem = make(chan struct{}, 50)
+		// semaphore with all N at once. Bumped 50 → 500 in v0.12.9
+		// after the 2026-05-27 x5000 research found that 50 was the
+		// actual rate-limiter across every scenario this session —
+		// peak active_runs in loomcycle stayed at ~140 under all
+		// loads from x1000 through x5000, well below the substrate's
+		// max_concurrent_runs: 2000 ceiling. Lifting to 500 lets the
+		// harness actually exercise loomcycle's admission + queue
+		// path at scale.
+		launchSem = make(chan struct{}, 500)
 	)
 
 	startWall := time.Now()


### PR DESCRIPTION
## Summary

One-line change in \`test/load/circuit-stress/main.go\`: \`launchSem := make(chan struct{}, 50)\` → \`500\`.

## Why

The 2026-05-27 load-test research session (5 scenarios, x1000 → x5000) found that **50 was the actual rate-limiter across every run** — peak \`active_runs\` inside loomcycle stayed at ~140 under all loads, well below the substrate's \`max_concurrent_runs: 2000\` ceiling, with queue depth never exceeding 0.

The harness was throttling ITSELF before loomcycle could saturate. None of the five scenarios actually exercised the admission semaphore or queue back-pressure path.

| Scenario | Peak active_runs | Configured cap |
|---|---|---|
| x1000 clean | 142 | 2000 |
| x1000 retry+fallback | 150 | 2000 |
| x2000 retry+fallback | 126 | 2000 |
| **x5000 retry+fallback** | **141** | **2000** |

(Captured in \`~/work/loomcycle-internal/doc-internal/research/load-test-2026-05-27/README.md\` § 5.2.)

## What 500 buys

Lifts the artificial ceiling so future runs can actually push concurrent admissions past \`max_concurrent_runs: 2000\` and exercise:

- Queue saturation behaviour (\`max_queue_depth: 30000\`)
- \`queue_timeout_ms\` drain semantics
- The substrate's per-iteration locking under genuine 2000-active load
- The pgxpool's connection acquisition under heavier contention (which is where PR #249's heartbeat-budget fix exists to help)

The substrate's \`max_concurrent_runs: 2000\` is still the authoritative cap — runs that exceed it queue rather than fail. Driver-side throttling at 500 leaves admission headroom for loomcycle's own backpressure path to actually fire.

## Test plan

- [x] \`go build\` of the driver clean.
- [x] No functional change to the harness logic — same FSM, same per-circuit semantics, just more concurrent in-flight launches.

Real verification is in the next x1000 / x2000 / x5000 stress run with this driver, where \`active_runs\` and \`queued_runs\` will (for the first time this series) actually move beyond their historical ~140 ceiling.

## Out of scope

- Removing the launch sem entirely. 500 is conservative — gives the substrate room to handle queueing without overwhelming the harness's per-circuit polling cost. If a future run finds 500 is also too low, the next step is 2000 or unbounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)