### PR TITLE
feat(resolve): rate_limit_cooldown_ms per user_tier

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -509,17 +509,25 @@ func (s *Server) markStalledFn(_, _ string) func(p, m, reason string) {
 // actually rate-limited, and that's the entry that should get the
 // cooldown — NOT the pre-fallback original provider.
 //
-// retryAfter flows through unchanged (the loop currently passes 0 =
-// use default; future work can thread the real Retry-After header up
-// from the driver).
+// tier is the run's user_tier name. When the operator yaml sets
+// `user_tiers.<tier>.rate_limit_cooldown_ms` > 0, the closure
+// substitutes that value for the loop's `retryAfter` ONLY when the
+// loop passed 0 (the common "use default" case). A non-zero
+// retryAfter from the loop (future work threading the real
+// Retry-After header up from the driver) takes precedence — operators
+// trust provider-supplied hints over their own static knob.
 //
 // Returns nil when no resolver is wired — RunOptions treats nil as
 // "rate-limit feedback disabled".
-func (s *Server) markRateLimitedFn(_, _ string) func(p, m string, retryAfter time.Duration) {
+func (s *Server) markRateLimitedFn(tier string) func(p, m string, retryAfter time.Duration) {
 	if s.resolver == nil {
 		return nil
 	}
+	operatorCooldown := s.rateLimitCooldownForTier(tier)
 	return func(p, m string, retryAfter time.Duration) {
+		if retryAfter <= 0 && operatorCooldown > 0 {
+			retryAfter = operatorCooldown
+		}
 		s.resolver.MarkRateLimited(p, m, retryAfter)
 	}
 }
@@ -722,7 +730,31 @@ func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
 		FallbackOnError:     ut.FallbackOnError,
 		MaxFallbackAttempts: ut.MaxFallbackAttempts,
 		RetryAttempts:       ut.RetryAttempts,
+		RateLimitCooldownMs: clampRateLimitCooldownMs(ut.RateLimitCooldownMs),
 	}
+}
+
+// clampRateLimitCooldownMs enforces the operator-doc-promised
+// [1_000, 600_000] bounds on the per-tier cooldown. 0 (unset)
+// passes through so the resolver picks its default. The clamp
+// happens here rather than at config-load so the bounds are a
+// single source of truth (the docstring on UserTier.RateLimitCooldownMs
+// names the same range).
+func clampRateLimitCooldownMs(ms int) int {
+	if ms <= 0 {
+		return 0
+	}
+	const (
+		minMs = 1_000   // 1 s — anything lower defeats the cooldown's purpose
+		maxMs = 600_000 // 10 min — beyond this the periodic probe clears the matrix first
+	)
+	if ms < minMs {
+		return minMs
+	}
+	if ms > maxMs {
+		return maxMs
+	}
+	return ms
 }
 
 // retryAttemptsForTier returns the same-provider retry budget the
@@ -735,6 +767,20 @@ func (s *Server) retryAttemptsForTier(name string) int {
 		return 0
 	}
 	return overlay.RetryAttempts
+}
+
+// rateLimitCooldownForTier returns the operator-tunable cooldown
+// duration the resolver should apply on MarkRateLimited for runs
+// carrying this user_tier. Zero (the default) means "use the
+// resolver's hardcoded default" — the closure passes 0 through to
+// resolver.MarkRateLimited, which substitutes its own default
+// (30 s) when retryAfter <= 0.
+func (s *Server) rateLimitCooldownForTier(name string) time.Duration {
+	overlay := s.userTierOverlay(name)
+	if overlay == nil || overlay.RateLimitCooldownMs <= 0 {
+		return 0
+	}
+	return time.Duration(overlay.RateLimitCooldownMs) * time.Millisecond
 }
 
 // substratePoliciesForAgent returns the v0.8.5 AgentDef +
@@ -1358,7 +1404,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(providerID, model),
+		MarkRateLimited:        s.markRateLimitedFn(in.UserTier),
 		ClearStall:             s.clearStallFn(providerID, model),
 		ToolParallelism:        s.cfg.Env.ToolParallelism,
 		AgentName:              effectiveAgentName,
@@ -2298,7 +2344,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(providerID, model),
+		MarkRateLimited:        s.markRateLimitedFn(req.UserTier),
 		ClearStall:             s.clearStallFn(providerID, model),
 		ToolParallelism:        s.cfg.Env.ToolParallelism,
 		AgentName:              req.Agent,
@@ -2628,7 +2674,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(providerID, model),
+		MarkRateLimited:        s.markRateLimitedFn(body.UserTier),
 		ClearStall:             s.clearStallFn(providerID, model),
 		ToolParallelism:        s.cfg.Env.ToolParallelism,
 		AgentName:              sess.Agent,
@@ -3229,7 +3275,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		MaxIterations:          def.MaxIterations, // 0 → loop default (16)
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(providerID, model),
+		MarkRateLimited:        s.markRateLimitedFn(parentTier),
 		ClearStall:             s.clearStallFn(providerID, model),
 		ToolParallelism:        s.cfg.Env.ToolParallelism,
 		AgentName:              name,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -775,12 +775,24 @@ func (s *Server) retryAttemptsForTier(name string) int {
 // resolver's hardcoded default" — the closure passes 0 through to
 // resolver.MarkRateLimited, which substitutes its own default
 // (30 s) when retryAfter <= 0.
+//
+// Reads s.cfg directly (not via userTierOverlay) — this is called
+// once per RunOptions construction and we only need a single int
+// field; rebuilding the full overlay (with candidate conversion)
+// would be wasted work per run.
 func (s *Server) rateLimitCooldownForTier(name string) time.Duration {
-	overlay := s.userTierOverlay(name)
-	if overlay == nil || overlay.RateLimitCooldownMs <= 0 {
+	if s.cfg == nil || name == "" {
 		return 0
 	}
-	return time.Duration(overlay.RateLimitCooldownMs) * time.Millisecond
+	ut, ok := s.cfg.UserTiers[name]
+	if !ok {
+		return 0
+	}
+	ms := clampRateLimitCooldownMs(ut.RateLimitCooldownMs)
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
 }
 
 // substratePoliciesForAgent returns the v0.8.5 AgentDef +

--- a/internal/api/http/stall_feedback_test.go
+++ b/internal/api/http/stall_feedback_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 )
 
@@ -40,12 +41,20 @@ func TestStallFeedbackClosures_UseLoopProvidedArgsNotConstructionPin(t *testing.
 	r.SeedModel("deepseek", "deepseek-v4-flash")
 	r.SetProviderReachable("anthropic", true)
 	r.SetProviderReachable("deepseek", true)
-	srv := &Server{resolver: r}
+	srv := &Server{
+		resolver: r,
+		// Empty cfg so markRateLimitedFn(tier) finds no overlay
+		// and uses the resolver's hardcoded 30s default. The
+		// per-tier substitution path is covered by
+		// TestMarkRateLimitedFn_SubstitutesTierCooldown below.
+		cfg: &config.Config{},
+	}
 
 	t.Run("markRateLimitedFn uses loop args", func(t *testing.T) {
-		// Factory called with "original" pair — that's what existed
-		// at run start, before fallback.
-		fn := srv.markRateLimitedFn("anthropic", "claude-sonnet-4-6")
+		// Factory called with default tier — the closure has no
+		// per-tier cooldown to substitute; the loop's retryAfter
+		// flows through unchanged.
+		fn := srv.markRateLimitedFn("default")
 		if fn == nil {
 			t.Fatal("factory returned nil despite resolver set")
 		}
@@ -116,10 +125,125 @@ func TestStallFeedbackClosures_NilResolverReturnsNil(t *testing.T) {
 	if fn := srv.markStalledFn("a", "b"); fn != nil {
 		t.Error("markStalledFn should return nil when resolver is unset")
 	}
-	if fn := srv.markRateLimitedFn("a", "b"); fn != nil {
+	if fn := srv.markRateLimitedFn("default"); fn != nil {
 		t.Error("markRateLimitedFn should return nil when resolver is unset")
 	}
 	if fn := srv.clearStallFn("a", "b"); fn != nil {
 		t.Error("clearStallFn should return nil when resolver is unset")
+	}
+}
+
+// TestMarkRateLimitedFn_SubstitutesTierCooldown pins the v0.12.x
+// operator-tunable behaviour: when the loop passes retryAfter=0
+// (the common "use default" case), the closure substitutes the
+// per-tier rate_limit_cooldown_ms from the operator's yaml. A
+// non-zero retryAfter from the loop still takes precedence
+// (future-Retry-After-header threading is operator-trust-supreme).
+func TestMarkRateLimitedFn_SubstitutesTierCooldown(t *testing.T) {
+	r := resolve.NewResolver(
+		[]string{"anthropic"},
+		map[string][]resolve.Candidate{
+			"middle": {{Provider: "anthropic", Model: "haiku"}},
+		},
+	)
+	r.SeedModel("anthropic", "haiku")
+	r.SetProviderReachable("anthropic", true)
+	srv := &Server{
+		resolver: r,
+		cfg: &config.Config{
+			UserTiers: map[string]config.UserTier{
+				// 5 s cooldown — under the resolver's 30 s default
+				// so a re-Resolve right after the closure call still
+				// returns the model after a 5 s wait.
+				"fast": {
+					RateLimitCooldownMs: 5_000,
+				},
+				// 0 = use the resolver's hardcoded default.
+				"unset": {},
+			},
+		},
+	}
+
+	t.Run("operator cooldown substitutes when loop passes zero", func(t *testing.T) {
+		fn := srv.markRateLimitedFn("fast")
+		if fn == nil {
+			t.Fatal("factory returned nil")
+		}
+		// Loop passes 0 — closure must substitute 5 s.
+		fn("anthropic", "haiku", 0)
+
+		snap := r.Snapshot()
+		until := snap["anthropic"].Models["haiku"].RateLimitedUntil
+		now := time.Now()
+		// Cooldown should be ~5 s, not the resolver's 30 s default.
+		elapsed := until.Sub(now)
+		if elapsed < 4*time.Second || elapsed > 6*time.Second {
+			t.Errorf("cooldown deadline = %v from now, want ~5s (operator-supplied), got something else", elapsed)
+		}
+	})
+
+	t.Run("loop-supplied non-zero takes precedence", func(t *testing.T) {
+		r.SetReachable("anthropic", true, []string{"haiku"}, "")
+		fn := srv.markRateLimitedFn("fast")
+		// Loop passes explicit 1 hour — must NOT be overridden by the
+		// 5 s tier value.
+		fn("anthropic", "haiku", 1*time.Hour)
+
+		snap := r.Snapshot()
+		until := snap["anthropic"].Models["haiku"].RateLimitedUntil
+		elapsed := until.Sub(time.Now())
+		if elapsed < 50*time.Minute {
+			t.Errorf("cooldown deadline = %v from now, want ~1h (loop precedence)", elapsed)
+		}
+	})
+
+	t.Run("unset tier uses resolver default", func(t *testing.T) {
+		r.SetReachable("anthropic", true, []string{"haiku"}, "")
+		fn := srv.markRateLimitedFn("unset")
+		fn("anthropic", "haiku", 0)
+
+		snap := r.Snapshot()
+		until := snap["anthropic"].Models["haiku"].RateLimitedUntil
+		elapsed := until.Sub(time.Now())
+		// Resolver default is 30 s.
+		if elapsed < 28*time.Second || elapsed > 32*time.Second {
+			t.Errorf("cooldown deadline = %v from now, want ~30s (resolver default)", elapsed)
+		}
+	})
+
+	t.Run("unknown tier (no overlay) uses resolver default", func(t *testing.T) {
+		r.SetReachable("anthropic", true, []string{"haiku"}, "")
+		fn := srv.markRateLimitedFn("does-not-exist")
+		fn("anthropic", "haiku", 0)
+
+		snap := r.Snapshot()
+		until := snap["anthropic"].Models["haiku"].RateLimitedUntil
+		elapsed := until.Sub(time.Now())
+		if elapsed < 28*time.Second || elapsed > 32*time.Second {
+			t.Errorf("cooldown deadline = %v from now, want ~30s (resolver default for unknown tier)", elapsed)
+		}
+	})
+}
+
+// TestClampRateLimitCooldownMs pins the operator-doc-promised bounds
+// on the per-tier cooldown.
+func TestClampRateLimitCooldownMs(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{0, 0},         // unset passes through
+		{-100, 0},      // negative -> unset (validator already refused)
+		{1, 1_000},     // below 1s floor
+		{500, 1_000},   // below 1s floor
+		{1_000, 1_000}, // at floor
+		{30_000, 30_000},
+		{600_000, 600_000},   // at ceiling
+		{900_000, 600_000},   // above ceiling
+		{3_600_000, 600_000}, // way above ceiling
+	}
+	for _, tc := range cases {
+		if got := clampRateLimitCooldownMs(tc.in); got != tc.want {
+			t.Errorf("clamp(%d) = %d, want %d", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -434,7 +434,7 @@ type UserTier struct {
 	// min) accepted; out-of-range values silently clamp to that
 	// window at config-load. Sub-second cooldowns would defeat the
 	// purpose (the cascade would re-fire on the next call); >10 min
-	// becomes meaningless because the periodic probe (default 5
+	// becomes meaningless because the periodic probe (default 15
 	// min) clears the matrix before the cooldown expires anyway.
 	RateLimitCooldownMs int `yaml:"rate_limit_cooldown_ms"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -414,6 +414,29 @@ type UserTier struct {
 	// MaxFallbackAttempts: retries stay on the same (provider,
 	// model); fallbacks switch.
 	RetryAttempts int `yaml:"retry_attempts"`
+
+	// RateLimitCooldownMs overrides the resolver's hardcoded
+	// 30-second MarkRateLimited cooldown per user_tier. The
+	// resolver flips a (provider, model) entry to "unavailable"
+	// for this many milliseconds after a 429 — Resolve() refuses
+	// to pick the pair during the window, letting tryProviderFallback
+	// engage cleanly without waiting on the periodic probe.
+	//
+	// Why per-tier: real providers' Retry-After windows vary widely.
+	// Anthropic burst limits clear in 1-10s; Voyage AI per-minute
+	// caps may take 30-60s; some self-hosted providers recover
+	// instantly. A single hardcoded value (30s) is conservative for
+	// some providers and wasteful for others. Operators tune per
+	// the tier's actual fleet.
+	//
+	// 0 (default) keeps the v0.12.x behaviour — 30s default applied
+	// inside the resolver. Values in [1_000, 600_000] (1 s to 10
+	// min) accepted; out-of-range values silently clamp to that
+	// window at config-load. Sub-second cooldowns would defeat the
+	// purpose (the cascade would re-fire on the next call); >10 min
+	// becomes meaningless because the periodic probe (default 5
+	// min) clears the matrix before the cooldown expires anyway.
+	RateLimitCooldownMs int `yaml:"rate_limit_cooldown_ms"`
 }
 
 // AgentDef is one agent the API can address by name.
@@ -2611,6 +2634,9 @@ func validate(c *Config) error {
 			}
 			if ut.MaxFallbackAttempts < 0 {
 				return fmt.Errorf("user_tiers.%s.max_fallback_attempts: must be >= 0 (0 = use default of 3)", tierName)
+			}
+			if ut.RateLimitCooldownMs < 0 {
+				return fmt.Errorf("user_tiers.%s.rate_limit_cooldown_ms: must be >= 0 (0 = use resolver default of 30000ms)", tierName)
 			}
 		}
 	}

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -151,6 +151,15 @@ type UserTierOverlay struct {
 	// retryable errors. Like FallbackOnError, the resolver doesn't
 	// act on it directly — it's read by the loop via RunOptions.
 	RetryAttempts int
+
+	// RateLimitCooldownMs (v0.12.x) overrides the resolver's
+	// 30-second default for MarkRateLimited. The HTTP layer reads
+	// this off the overlay and seeds the MarkRateLimited closure
+	// the loop calls; the resolver itself sees the explicit
+	// duration in retryAfter and uses it verbatim. 0 = preserve
+	// 30-second default. Bounded at config-load to [1_000, 600_000]
+	// before reaching this overlay.
+	RateLimitCooldownMs int
 }
 
 // Candidate is one (provider, model) pair in a tier's candidate list.


### PR DESCRIPTION
## Summary

Surface the MarkRateLimited cooldown (today hardcoded 30 s) as a per-user_tier yaml field. Operators tune to their provider fleet — Anthropic burst limits clear in 1-10 s, Voyage AI per-minute caps need 30-60 s, self-hosted may be instant.

```yaml
user_tiers:
  fast:
    rate_limit_cooldown_ms: 5000   # haiku burst window
  paid:
    rate_limit_cooldown_ms: 60000  # voyage per-minute cap
```

Captured as follow-up #2 in `~/work/loomcycle-internal/doc-internal/research/load-test-2026-05-27/README.md`.

## Behaviour

- **Default OFF**: 0 (unset) → resolver's existing 30 s applies. v0.12.x behaviour unchanged.
- **Loop precedence**: when the loop passes a non-zero `retryAfter` (future Retry-After-header path; doesn't fire today), that value wins over the operator's static knob. Provider-supplied hints beat operator config.
- **Bounds**: `clampRateLimitCooldownMs` enforces [1 000, 600 000] (1 s floor, 10 min ceiling). Sub-second values defeat the cooldown's purpose; values larger than the periodic probe interval (~5 min) are silently re-clamped because the probe clears the matrix first anyway.

## Test plan

- [x] `TestMarkRateLimitedFn_SubstitutesTierCooldown` — 4 subtests pinning substitution + precedence + unset/unknown tier paths.
- [x] `TestClampRateLimitCooldownMs` — 9 cases pinning the bounds (passthrough at 0, clamp at floor, in-range, clamp at ceiling).
- [x] Existing `TestStallFeedbackClosures_*` updated for the new \`markRateLimitedFn(tier)\` signature; still pins the live-args-not-construction-pin contract.
- [x] `go test -short -race ./...` clean. gofmt + go vet clean.

## API change

`Server.markRateLimitedFn` signature: `(_, _ string)` → `(tier string)`. The two legacy args were captured-but-unused after PR #235's "use loop args" fix; nothing in production relied on the old shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)