### PR TITLE
feat(agents): per-agent retry_attempts override

### DIFF
--- a/internal/api/http/agent_def_overlay_test.go
+++ b/internal/api/http/agent_def_overlay_test.go
@@ -204,3 +204,67 @@ func TestApplyAgentDefOverlay_ZeroMaxIterationsFallsThrough(t *testing.T) {
 		t.Errorf("MaxTokens = %d, want 8192", got.MaxTokens)
 	}
 }
+
+// v0.12.x per-agent retry_attempts substrate overlay tests.
+
+// TestApplyAgentDefOverlay_RetryAttemptsThreadsThrough pins that
+// an overlay carrying an explicit retry_attempts wins over the
+// static yaml's value — including the operator-meaningful 0
+// ("explicitly disable retries even under a generous tier").
+func TestApplyAgentDefOverlay_RetryAttemptsThreadsThrough(t *testing.T) {
+	five := 5
+	base := config.AgentDef{
+		Provider:      "anthropic",
+		Model:         "claude-haiku-4-5",
+		RetryAttempts: &five, // pretend static yaml had retry_attempts: 5
+	}
+	def := json.RawMessage(`{"retry_attempts": 0}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.RetryAttempts == nil {
+		t.Fatal("RetryAttempts is nil; overlay's explicit 0 should produce a non-nil pointer")
+	}
+	if *got.RetryAttempts != 0 {
+		t.Errorf("*RetryAttempts = %d, want 0 (overlay wins)", *got.RetryAttempts)
+	}
+}
+
+// TestApplyAgentDefOverlay_OmittedRetryAttemptsPreservesStatic pins
+// the high-stakes case the F2 review surfaced: when the overlay
+// omits retry_attempts (a fork that doesn't touch the field), the
+// static yaml's value — including a "force 0" for a side-effectful
+// agent — must pass through unchanged. Without *int + nil-check,
+// the overlay would silently strip the static intent.
+func TestApplyAgentDefOverlay_OmittedRetryAttemptsPreservesStatic(t *testing.T) {
+	zero := 0
+	base := config.AgentDef{
+		Provider:      "anthropic",
+		Model:         "claude-haiku-4-5",
+		RetryAttempts: &zero, // static yaml: cv-adapter / evaluator force 0
+	}
+	// Overlay carries max_tokens; explicitly does NOT touch retry_attempts.
+	def := json.RawMessage(`{"max_tokens": 8192}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.RetryAttempts == nil {
+		t.Fatal("static RetryAttempts was lost; expected pointer-to-0 to pass through")
+	}
+	if *got.RetryAttempts != 0 {
+		t.Errorf("static *RetryAttempts (0) was clobbered to %d", *got.RetryAttempts)
+	}
+}
+
+// TestApplyAgentDefOverlay_RetryAttemptsNilStaticStaysNil pins that
+// when both base and overlay leave retry_attempts unset, the
+// resolved AgentDef carries a nil pointer (falls through to tier
+// default at run time).
+func TestApplyAgentDefOverlay_RetryAttemptsNilStaticStaysNil(t *testing.T) {
+	base := config.AgentDef{
+		Provider: "anthropic",
+		Model:    "claude-haiku-4-5",
+		// RetryAttempts intentionally unset.
+	}
+	def := json.RawMessage(`{"max_tokens": 8192}`)
+	got := applyAgentDefOverlay(base, def)
+	if got.RetryAttempts != nil {
+		t.Errorf("RetryAttempts should stay nil; got %v", got.RetryAttempts)
+	}
+}

--- a/internal/api/http/providers_admin.go
+++ b/internal/api/http/providers_admin.go
@@ -67,9 +67,9 @@ type providerModelsResponse struct {
 // Error mapping:
 //   - 404 provider_unknown:    no driver registered for the URL id
 //   - 503 provider_unavailable: known driver but not configured (no
-//                               API key, OLLAMA_BASE_URL=disabled, etc.)
+//     API key, OLLAMA_BASE_URL=disabled, etc.)
 //   - 502 provider_list_failed: ListModels round-trip failed
-//                               (network, auth rejection, 5xx upstream)
+//     (network, auth rejection, 5xx upstream)
 //
 // We distinguish 404 vs 503 by string-matching the resolver's error
 // message — the only signal the existing ProviderResolver interface

--- a/internal/api/http/providers_admin_test.go
+++ b/internal/api/http/providers_admin_test.go
@@ -31,9 +31,9 @@ type listModelsProvider struct {
 	delay time.Duration
 }
 
-func (p *listModelsProvider) ID() string                         { return p.id }
+func (p *listModelsProvider) ID() string                           { return p.id }
 func (p *listModelsProvider) Capabilities() providers.Capabilities { return providers.Capabilities{} }
-func (p *listModelsProvider) Probe(_ context.Context) error      { return nil }
+func (p *listModelsProvider) Probe(_ context.Context) error        { return nil }
 func (p *listModelsProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
 	return nil, errors.New("not used in this test")
 }
@@ -329,4 +329,3 @@ func TestProviderModels_HandlerImposesTimeout(t *testing.T) {
 		t.Fatalf("status = %d, want 502, body = %s", rec.Code, rec.Body.String())
 	}
 }
-

--- a/internal/api/http/retry_attempts_resolution_test.go
+++ b/internal/api/http/retry_attempts_resolution_test.go
@@ -1,0 +1,116 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestRetryAttemptsForAgent_PerAgentOverrideWins pins the v0.12.x
+// per-agent override semantics: when agent.RetryAttempts is non-nil,
+// it wins over the user_tier's value, regardless of which is larger.
+//
+// Why this matters: high-stakes agents (cv-adapter, evaluator,
+// anything with side effects) may need to refuse retries even under
+// a generous tier policy. A *int field distinguishes "unset = use
+// tier" from "0 = explicitly disable retries" — without the pointer
+// the yaml-omitted case (operator wants tier default) and the
+// yaml-zero case (operator wants no retries) would collapse to the
+// same value.
+func TestRetryAttemptsForAgent_PerAgentOverrideWins(t *testing.T) {
+	zero := 0
+	five := 5
+
+	cases := []struct {
+		name       string
+		tier       string
+		tierBudget int
+		agent      *int // nil = field unset
+		want       int
+	}{
+		{
+			name:       "agent unset → tier value",
+			tier:       "paid",
+			tierBudget: 2,
+			agent:      nil,
+			want:       2,
+		},
+		{
+			name:       "agent override forces 0 even under generous tier",
+			tier:       "paid",
+			tierBudget: 5,
+			agent:      &zero,
+			want:       0,
+		},
+		{
+			name:       "agent override raises above tier",
+			tier:       "free",
+			tierBudget: 0,
+			agent:      &five,
+			want:       5,
+		},
+		{
+			name:       "agent unset + tier unset → 0",
+			tier:       "free",
+			tierBudget: 0,
+			agent:      nil,
+			want:       0,
+		},
+		{
+			name:       "unknown tier + agent override → agent wins",
+			tier:       "nonexistent",
+			tierBudget: 0,
+			agent:      &five,
+			want:       5,
+		},
+		{
+			name:       "unknown tier + agent unset → 0",
+			tier:       "nonexistent",
+			tierBudget: 0,
+			agent:      nil,
+			want:       0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &Server{
+				cfg: &config.Config{
+					UserTiers: map[string]config.UserTier{
+						"paid": {RetryAttempts: tc.tierBudget},
+						"free": {RetryAttempts: tc.tierBudget},
+					},
+				},
+			}
+			agentDef := config.AgentDef{RetryAttempts: tc.agent}
+			got := srv.retryAttemptsForAgent(agentDef, tc.tier)
+			if got != tc.want {
+				t.Errorf("retryAttemptsForAgent(agent=%v, tier=%q with budget=%d) = %d, want %d",
+					tc.agent, tc.tier, tc.tierBudget, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRetryAttemptsForAgent_NilCfgFallsThroughToZero pins the safety
+// path: if the Server has no config wired (test fixtures, partial
+// init), the helper returns 0 rather than panicking on nil-map access.
+func TestRetryAttemptsForAgent_NilCfgFallsThroughToZero(t *testing.T) {
+	srv := &Server{cfg: nil}
+	agentDef := config.AgentDef{} // no override
+
+	got := srv.retryAttemptsForAgent(agentDef, "anything")
+	if got != 0 {
+		t.Errorf("nil cfg + no override should be 0, got %d", got)
+	}
+
+	// With an override the cfg is irrelevant.
+	zero := 0
+	five := 5
+	if got := srv.retryAttemptsForAgent(config.AgentDef{RetryAttempts: &zero}, "anything"); got != 0 {
+		t.Errorf("nil cfg + agent override 0 should be 0, got %d", got)
+	}
+	if got := srv.retryAttemptsForAgent(config.AgentDef{RetryAttempts: &five}, "anything"); got != 5 {
+		t.Errorf("nil cfg + agent override 5 should be 5, got %d", got)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -713,7 +713,7 @@ func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string
 // through to "default" — preserves v0.7.x clients that don't yet send
 // user_tier in the request body.
 func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
-	if len(s.cfg.UserTiers) == 0 {
+	if s.cfg == nil || len(s.cfg.UserTiers) == 0 {
 		return nil
 	}
 	if name == "" {
@@ -793,6 +793,21 @@ func (s *Server) rateLimitCooldownForTier(name string) time.Duration {
 		return 0
 	}
 	return time.Duration(ms) * time.Millisecond
+}
+
+// retryAttemptsForAgent resolves the same-provider retry budget for
+// a specific (agent, user_tier) pair. Per-agent override (when set)
+// wins; otherwise falls through to the user_tier value; 0 if neither.
+//
+// The agent override uses *int so "unset" (use tier) is
+// distinguishable from "0" (explicitly disable retries even under a
+// generous tier — high-stakes side-effectful agents force this
+// regardless of operator tier policy).
+func (s *Server) retryAttemptsForAgent(agentDef config.AgentDef, tier string) int {
+	if agentDef.RetryAttempts != nil {
+		return *agentDef.RetryAttempts
+	}
+	return s.retryAttemptsForTier(tier)
 }
 
 // substratePoliciesForAgent returns the v0.8.5 AgentDef +
@@ -1424,7 +1439,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
-		MaxSameProviderRetries: s.retryAttemptsForTier(in.UserTier),
+		MaxSameProviderRetries: s.retryAttemptsForAgent(agentDef, in.UserTier),
 	})
 	s.finishRunWithCancel(ctx, runCtx, runID, res, runErr, meta)
 	return nil
@@ -2369,7 +2384,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
-		MaxSameProviderRetries: s.retryAttemptsForTier(req.UserTier),
+		MaxSameProviderRetries: s.retryAttemptsForAgent(agentDef, req.UserTier),
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -2699,7 +2714,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
-		MaxSameProviderRetries: s.retryAttemptsForTier(body.UserTier),
+		MaxSameProviderRetries: s.retryAttemptsForAgent(agentDef, body.UserTier),
 	})
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
@@ -3300,7 +3315,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
-		MaxSameProviderRetries: s.retryAttemptsForTier(parentTier),
+		MaxSameProviderRetries: s.retryAttemptsForAgent(def, parentTier),
 	})
 	s.finishRunWithCancel(ctx, subRunCtx, subRunID, res, runErr, subMeta)
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1005,6 +1005,11 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 		Models           map[string][]config.TierCandidate `json:"models,omitempty"`
 		MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
 		MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+		// *int because 0 is a meaningful explicit value ("force no
+		// retries"); non-pointer would collapse "not in overlay" and
+		// "explicitly disable" into the same case and silently strip
+		// the static yaml's high-stakes intent on a substrate sub-run.
+		RetryAttempts *int `json:"retry_attempts,omitempty"`
 	}
 	if err := json.Unmarshal(definition, &ov); err != nil {
 		log.Printf("agent_def overlay: malformed definition JSON, falling back to static: %v", err)
@@ -1062,6 +1067,13 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 	}
 	if ov.MemoryQuotaBytes != 0 {
 		out.MemoryQuotaBytes = ov.MemoryQuotaBytes
+	}
+	if ov.RetryAttempts != nil {
+		// Pointer-set means the substrate row carries an explicit
+		// override (including 0). Nil leaves the static yaml's
+		// RetryAttempts in place — including the static yaml's own
+		// "force 0" for high-stakes agents.
+		out.RetryAttempts = ov.RetryAttempts
 	}
 	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -659,6 +659,29 @@ type AgentDef struct {
 	// agent_def_scopes, evaluation_scopes) — operator-yaml is the
 	// floor; the model can never enlarge its own access.
 	Interruption AgentInterruptionACL `yaml:"interruption"`
+
+	// RetryAttempts overrides the user_tier's same-provider retry
+	// budget (UserTier.RetryAttempts) for this agent. Nullable so
+	// "unset" (use tier default) is distinguishable from "0"
+	// (explicitly NO retries — high-stakes agents force this even
+	// under generous tiers).
+	//
+	// Why per-agent: a tier sets fleet-wide policy (free tier = 0
+	// retries, paid tier = 2 retries), but specific high-stakes
+	// agents (cv-adapter, evaluator, anything with side effects)
+	// may want to refuse retries regardless of the tier. Adding
+	// retries to side-effectful flows is a foot-gun; this gives
+	// operators a per-agent escape hatch.
+	//
+	// Resolution order (in s.retryAttemptsForAgent):
+	//   1. agent.RetryAttempts (if non-nil) wins
+	//   2. user_tier.RetryAttempts otherwise
+	//   3. 0 if neither is set
+	//
+	// A pointer keeps the yaml-omitted case ("unset") distinct from
+	// the yaml-zero case ("explicitly disable retries"). When set,
+	// must be >= 0; validator refuses negatives at config-load.
+	RetryAttempts *int `yaml:"retry_attempts,omitempty"`
 }
 
 // AgentInterruptionACL is the per-agent v0.8.16 Interruption tool
@@ -2693,6 +2716,9 @@ func validate(c *Config) error {
 		}
 		if agent.MemoryQuotaBytes < 0 {
 			return fmt.Errorf("agent %q: memory_quota_bytes must be >= 0", name)
+		}
+		if agent.RetryAttempts != nil && *agent.RetryAttempts < 0 {
+			return fmt.Errorf("agent %q: retry_attempts must be >= 0 (0 = explicitly disable retries; omit to use user_tier default)", name)
 		}
 		// Channel tool (v0.8.4): every entry in publish/subscribe must
 		// reference a declared channel (exact match) OR be a "<prefix>/*"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1759,3 +1759,100 @@ func TestEnv_ReplicaIDRejectsInvalid(t *testing.T) {
 		})
 	}
 }
+
+// v0.12.x per-agent retry_attempts override.
+
+// TestAgentRetryAttempts_AcceptsZeroAndPositive pins that the
+// per-agent retry_attempts field accepts the operator-meaningful
+// values: 0 (explicitly disable retries, the high-stakes case) and
+// positive integers. Omitting the field entirely (yaml not present)
+// is exercised by every other passing test that doesn't set it.
+func TestAgentRetryAttempts_AcceptsZeroAndPositive(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  cautious:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    retry_attempts: 0
+  generous:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    retry_attempts: 5
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	cautious := cfg.Agents["cautious"]
+	if cautious.RetryAttempts == nil {
+		t.Fatal("cautious.RetryAttempts is nil; want explicit 0")
+	}
+	if *cautious.RetryAttempts != 0 {
+		t.Errorf("cautious.RetryAttempts = %d, want 0", *cautious.RetryAttempts)
+	}
+
+	generous := cfg.Agents["generous"]
+	if generous.RetryAttempts == nil {
+		t.Fatal("generous.RetryAttempts is nil; want explicit 5")
+	}
+	if *generous.RetryAttempts != 5 {
+		t.Errorf("generous.RetryAttempts = %d, want 5", *generous.RetryAttempts)
+	}
+}
+
+// TestAgentRetryAttempts_RefusesNegative pins the validator rule:
+// negative values are nonsensical and refused at config-load. The
+// error message names retry_attempts so the operator can find the
+// offending agent quickly.
+func TestAgentRetryAttempts_RefusesNegative(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  broken:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    retry_attempts: -1
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected validation error for negative retry_attempts")
+	}
+	if !strings.Contains(err.Error(), "retry_attempts") {
+		t.Errorf("error %q does not mention retry_attempts", err.Error())
+	}
+}
+
+// TestAgentRetryAttempts_OmittedStaysNil pins that the *int pointer
+// distinguishes "operator omitted the field" (nil = use tier
+// default) from "operator wrote 0" (explicitly disable). Without
+// the pointer these would collapse.
+func TestAgentRetryAttempts_OmittedStaysNil(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  defaulted:
+    provider: anthropic
+    model: claude-sonnet-4-6
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if cfg.Agents["defaulted"].RetryAttempts != nil {
+		t.Errorf("omitted retry_attempts should stay nil, got %v", cfg.Agents["defaulted"].RetryAttempts)
+	}
+}

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -152,6 +152,11 @@ type SubstrateAgentDef struct {
 	Models           map[string][]config.TierCandidate `json:"models,omitempty"`
 	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
+	// RetryAttempts mirrors config.AgentDef.RetryAttempts — per-agent
+	// same-provider retry budget override. *int so substrate JSON can
+	// persist the operator-meaningful "force 0" intent as distinct
+	// from "field not set" (use the tier default).
+	RetryAttempts *int `json:"retry_attempts,omitempty"`
 }
 
 // ToConfigDef projects the substrate JSON shape onto config.AgentDef
@@ -174,6 +179,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Models:                s.Models,
 		MemoryScopes:          s.MemoryScopes,
 		MemoryQuotaBytes:      s.MemoryQuotaBytes,
+		RetryAttempts:         s.RetryAttempts,
 	}
 }
 

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -212,6 +212,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"models":                  true,
 		"memory_scopes":           true,
 		"memory_quota_bytes":      true,
+		"retry_attempts":          true,
 	}
 	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateAgentDef{}))
 	for tag := range want {

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -691,6 +691,13 @@ type mergedDef struct {
 	MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
 	Description      string                            `json:"description,omitempty"`
+	// RetryAttempts mirrors config.AgentDef.RetryAttempts — same-
+	// provider retry budget override. *int so the substrate-write
+	// path can persist an explicit 0 ("force no retries") as
+	// distinct from "field not set" (use the tier default).
+	// Without the pointer, AgentDef.create/fork on a high-stakes
+	// agent would silently strip the static yaml's "force 0".
+	RetryAttempts *int `json:"retry_attempts,omitempty"`
 }
 
 func (d *mergedDef) applyOverlay(ov mergedDef) {
@@ -742,6 +749,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.Description != "" {
 		d.Description = ov.Description
 	}
+	if ov.RetryAttempts != nil {
+		d.RetryAttempts = ov.RetryAttempts
+	}
 }
 
 // normalize fills derived fields that the static config-load path
@@ -782,6 +792,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Models:                s.Models,
 		MemoryScopes:          s.MemoryScopes,
 		MemoryQuotaBytes:      s.MemoryQuotaBytes,
+		RetryAttempts:         s.RetryAttempts,
 	}
 }
 


### PR DESCRIPTION
## Summary

Today the same-provider retry budget for a run is set only by `user_tier.retry_attempts`. High-stakes agents (cv-adapter, evaluator, anything with side effects) need a per-agent escape hatch — "force 0 retries even under a generous tier" — without inventing a new tier per agent.

```yaml
agents:
  cv-adapter:
    retry_attempts: 0   # explicit no-retry; sticks even on a paid tier with retry_attempts: 2
  job-searcher:
    retry_attempts: 5   # explicit generous; overrides a stingy tier
```

## Behaviour

Resolution order (new `Server.retryAttemptsForAgent`):
1. `agent.RetryAttempts` (if non-nil) wins
2. `user_tier.RetryAttempts` otherwise
3. `0` if neither is set

The field is `*int` rather than `int` so "unset" (use tier default) is distinguishable from "0" (explicitly disable retries). Without the pointer, a yaml-omitted agent and an agent with `retry_attempts: 0` would collapse to the same value — the high-stakes case would be unrepresentable.

## What changed

- `internal/config/config.go` — `RetryAttempts *int` on `AgentDef`; validator refuses negatives at config-load.
- `internal/api/http/server.go` — new `retryAttemptsForAgent` helper; nil-cfg guard added to `userTierOverlay` so the helper is safe under test fixtures. The 4 RunOptions construction sites (`RunOnce`, `handleRuns`, `handleMessages`, `runSubAgent`) all switched from `retryAttemptsForTier(tier)` to `retryAttemptsForAgent(agentDef, tier)`.
- `internal/api/http/retry_attempts_resolution_test.go` — 6-case matrix on `retryAttemptsForAgent` covering: override-wins, override-0-beats-generous-tier, agent-unset-falls-through-to-tier, unknown-tier + override, nil cfg safety.
- `internal/config/config_test.go` — 3 yaml-validation tests pinning: accepts `0` and positive, refuses negative with `retry_attempts` in the error message, omitted field stays `nil`.

## Test plan
- [x] `go test ./internal/api/http/... -run TestRetryAttemptsForAgent -count=1` passes (6+3 subtests).
- [x] `go test ./internal/config/... -run TestAgentRetryAttempts -count=1` passes (3 cases).
- [x] `go test ./... -count=1` clean.
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)