### PR TITLE
chore(api): gofmt providers_admin.go + test

### DIFF
--- a/internal/api/http/providers_admin.go
+++ b/internal/api/http/providers_admin.go
@@ -67,9 +67,9 @@ type providerModelsResponse struct {
 // Error mapping:
 //   - 404 provider_unknown:    no driver registered for the URL id
 //   - 503 provider_unavailable: known driver but not configured (no
-//                               API key, OLLAMA_BASE_URL=disabled, etc.)
+//     API key, OLLAMA_BASE_URL=disabled, etc.)
 //   - 502 provider_list_failed: ListModels round-trip failed
-//                               (network, auth rejection, 5xx upstream)
+//     (network, auth rejection, 5xx upstream)
 //
 // We distinguish 404 vs 503 by string-matching the resolver's error
 // message — the only signal the existing ProviderResolver interface

--- a/internal/api/http/providers_admin_test.go
+++ b/internal/api/http/providers_admin_test.go
@@ -31,9 +31,9 @@ type listModelsProvider struct {
 	delay time.Duration
 }
 
-func (p *listModelsProvider) ID() string                         { return p.id }
+func (p *listModelsProvider) ID() string                           { return p.id }
 func (p *listModelsProvider) Capabilities() providers.Capabilities { return providers.Capabilities{} }
-func (p *listModelsProvider) Probe(_ context.Context) error      { return nil }
+func (p *listModelsProvider) Probe(_ context.Context) error        { return nil }
 func (p *listModelsProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
 	return nil, errors.New("not used in this test")
 }
@@ -329,4 +329,3 @@ func TestProviderModels_HandlerImposesTimeout(t *testing.T) {
 		t.Fatalf("status = %d, want 502, body = %s", rec.Code, rec.Body.String())
 	}
 }
-


### PR DESCRIPTION
## Summary

CI gofmt check fails on main after #254 — the doc-comment continuation lines on the error-mapping table were over-indented (gofmt wants the standard 4-space-after-bullet continuation), and the test file needed method-signature alignment + a trailing newline normalised.

\`gofmt -w\` applied to both files. No semantic change.

## Why it matters now

Blocks every open PR's lint job until this lands (#253 in particular is in active rebase to clear merge conflicts and now hits this same gofmt check).

## Test plan
- [x] \`gofmt -l .\` returns empty.
- [x] \`go test ./internal/api/http/... -run TestProviderModels\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)