### PR TITLE
feat(api): GET /metrics Prometheus text-format endpoint

### DIFF
--- a/internal/api/http/metrics_prom.go
+++ b/internal/api/http/metrics_prom.go
@@ -1,0 +1,281 @@
+// metrics_prom.go — GET /metrics in Prometheus text-format. Designed
+// to satisfy a stock Prometheus scrape config out of the box (15 s
+// interval, bearer-auth via the same middleware as /v1/_metrics/*).
+//
+// Unlike /v1/_metrics/* (which reads pre-aggregated DB samples), this
+// endpoint is a LIVE read against the runtime — runtime.MemStats +
+// Semaphore.Stats — so each scrape returns the current process shape
+// without a DB hop. Works even when the DB-backed sampler is disabled
+// (LOOMCYCLE_METRICS_ENABLED=0) since the live counters are always
+// trivially available.
+//
+// Architectural lock (RFC observability-profiles.md Decision 1): this
+// endpoint exposes ONLY substrate metrics — process resources +
+// concurrency state. Per-run shape (latency, token spend, error rate)
+// is handled separately: spans flow through OTEL to Tempo, and the
+// OTEL Collector's spanmetrics connector aggregates them into
+// Prometheus histograms downstream (no in-process span processor).
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// handleMetricsProm serves GET /metrics. Bearer-authed (middleware
+// already gates the route). Live-read; no DB query.
+func (s *Server) handleMetricsProm(w http.ResponseWriter, _ *http.Request) {
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	replicaLabels := promReplicaLabels()
+	buildLabels := promBuildLabels()
+
+	// Process-resource gauges.
+	writeGauge(w, "loomcycle_process_rss_bytes",
+		"Process resident set size as reported by runtime.MemStats.Sys (bytes).",
+		replicaLabels, float64(memStats.Sys))
+	writeGauge(w, "loomcycle_process_heap_alloc_bytes",
+		"Bytes of heap currently allocated (runtime.MemStats.HeapAlloc).",
+		replicaLabels, float64(memStats.HeapAlloc))
+	writeGauge(w, "loomcycle_process_goroutines",
+		"Number of goroutines that currently exist (runtime.NumGoroutine).",
+		replicaLabels, float64(runtime.NumGoroutine()))
+
+	// Concurrency gauges. When the semaphore is nil (early init / unit
+	// tests with a partial Server), emit zeros — keeps the metric series
+	// monotonic from the operator's POV rather than appearing/disappearing.
+	active, queued, perUserOpt := semaphoreSnapshot(s)
+	writeGauge(w, "loomcycle_concurrency_active",
+		"Runs currently holding a concurrency slot (semaphore active count).",
+		replicaLabels, float64(active))
+	writeGauge(w, "loomcycle_concurrency_queued",
+		"Runs waiting in the queue for a slot (semaphore queued count).",
+		replicaLabels, float64(queued))
+
+	// Per-user series — only emitted when per-user cap is engaged,
+	// otherwise the cardinality of `user_id` could explode on anonymous
+	// workloads. We can't directly observe the cap value from Stats(),
+	// but the PerUser map is nil/empty when the cap is disabled (see
+	// internal/concurrency/semaphore.go — only populated under the
+	// per-user-capped Acquire path).
+	if len(perUserOpt) > 0 {
+		fmt.Fprintln(w, "# HELP loomcycle_concurrency_per_user Runs currently held (active+queued) per user_id; only emitted when MaxConcurrentRunsPerUser > 0.")
+		fmt.Fprintln(w, "# TYPE loomcycle_concurrency_per_user gauge")
+		// Sort user IDs so successive scrapes produce deterministic
+		// output — easier to diff in regression tests + nicer for
+		// operators eyeballing the endpoint manually.
+		users := make([]string, 0, len(perUserOpt))
+		for u := range perUserOpt {
+			users = append(users, u)
+		}
+		sort.Strings(users)
+		for _, u := range users {
+			labels := mergeLabels(replicaLabels, map[string]string{"user_id": u})
+			fmt.Fprintf(w, "loomcycle_concurrency_per_user%s %d\n", labels, perUserOpt[u])
+		}
+		fmt.Fprintln(w)
+	}
+
+	// Build info as a single-series gauge=1 with version metadata as
+	// labels. Standard Prometheus convention — operators alert on
+	// version churn or filter by version in a multi-replica cluster.
+	fmt.Fprintln(w, "# HELP loomcycle_build_info Loomcycle build identification (version, commit, go version) as labels; value is always 1.")
+	fmt.Fprintln(w, "# TYPE loomcycle_build_info gauge")
+	fmt.Fprintf(w, "loomcycle_build_info%s 1\n", buildLabels)
+}
+
+// writeGauge emits one HELP + TYPE + sample triple. Trailing blank
+// line separates metric blocks per Prometheus convention.
+func writeGauge(w io.Writer, name, help, labels string, value float64) {
+	fmt.Fprintf(w, "# HELP %s %s\n", name, help)
+	fmt.Fprintf(w, "# TYPE %s gauge\n", name)
+	// %g produces a compact float repr (no trailing zeros). For integer
+	// values from runtime + sem.Stats this is identical to strconv.Itoa.
+	fmt.Fprintf(w, "%s%s %s\n\n", name, labels, strconv.FormatFloat(value, 'g', -1, 64))
+}
+
+// semaphoreSnapshot is a nil-safe view of Server.sem state. Returns
+// zero values + nil PerUser when the semaphore is unwired.
+func semaphoreSnapshot(s *Server) (active, queued int, perUser map[string]int) {
+	if s == nil || s.sem == nil {
+		return 0, 0, nil
+	}
+	stats := s.sem.Stats()
+	return stats.Active, stats.Queued, stats.PerUser
+}
+
+// promReplicaLabels returns `{replica_id="..."}` when running in
+// cluster mode (LOOMCYCLE_REPLICA_ID set), otherwise empty string.
+// Empty-string omission keeps single-replica deployments clean —
+// operators never see a label they don't care about.
+func promReplicaLabels() string {
+	id := strings.TrimSpace(os.Getenv("LOOMCYCLE_REPLICA_ID"))
+	if id == "" {
+		return ""
+	}
+	return labelsToString(map[string]string{"replica_id": id})
+}
+
+// promBuildLabels reads version metadata via runtime/debug.ReadBuildInfo.
+// Same source main.go consults for --version output. Stable across
+// release styles (ldflags-injected version OR pure VCS-stamped build).
+func promBuildLabels() string {
+	info, ok := debug.ReadBuildInfo()
+	labels := map[string]string{
+		"version":    "unknown",
+		"commit":     "unknown",
+		"built":      "unknown",
+		"go_version": runtime.Version(),
+	}
+	if ok {
+		if info.Main.Version != "" && info.Main.Version != "(devel)" {
+			labels["version"] = info.Main.Version
+		}
+		for _, kv := range info.Settings {
+			switch kv.Key {
+			case "vcs.revision":
+				if kv.Value != "" {
+					labels["commit"] = kv.Value
+				}
+			case "vcs.time":
+				if kv.Value != "" {
+					labels["built"] = kv.Value
+				}
+			}
+		}
+	}
+	if r := strings.TrimSpace(os.Getenv("LOOMCYCLE_REPLICA_ID")); r != "" {
+		labels["replica_id"] = r
+	}
+	return labelsToString(labels)
+}
+
+// mergeLabels merges a base label set (already pre-formatted as the
+// `{...}` literal) with an additional map. Used to add `user_id` to
+// the existing replica-labels base for per-user series. Returns the
+// formatted `{...}` literal.
+func mergeLabels(base string, extra map[string]string) string {
+	// Decompose base into a map, merge, reformat. Cheap given the
+	// label set is tiny.
+	merged := decomposeLabels(base)
+	for k, v := range extra {
+		merged[k] = v
+	}
+	return labelsToString(merged)
+}
+
+// labelsToString formats a label map as the Prometheus `{k="v",...}`
+// literal. Empty map returns empty string (no braces). Keys sorted
+// for deterministic output.
+func labelsToString(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteString(`="`)
+		b.WriteString(escapeLabelValue(m[k]))
+		b.WriteByte('"')
+	}
+	b.WriteByte('}')
+	return b.String()
+}
+
+// decomposeLabels parses the inverse of labelsToString. Used by
+// mergeLabels. Empty input returns an empty map.
+func decomposeLabels(s string) map[string]string {
+	out := map[string]string{}
+	if len(s) < 2 || s[0] != '{' || s[len(s)-1] != '}' {
+		return out
+	}
+	inner := s[1 : len(s)-1]
+	if inner == "" {
+		return out
+	}
+	// Split on `,` but careful: values can't contain `,` because
+	// escapeLabelValue escapes it. So a simple split is safe.
+	for _, kv := range strings.Split(inner, ",") {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		key := kv[:eq]
+		val := kv[eq+1:]
+		if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+			val = val[1 : len(val)-1]
+		}
+		out[key] = unescapeLabelValue(val)
+	}
+	return out
+}
+
+// escapeLabelValue per the Prometheus exposition format: backslash,
+// double-quote, and newline must be escaped. Operators almost never
+// hit these in practice but the contract is the contract.
+func escapeLabelValue(s string) string {
+	if !strings.ContainsAny(s, `\"`+"\n") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// unescapeLabelValue inverts escapeLabelValue.
+func unescapeLabelValue(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '\\':
+				b.WriteByte('\\')
+			case '"':
+				b.WriteByte('"')
+			case 'n':
+				b.WriteByte('\n')
+			default:
+				b.WriteByte(s[i+1])
+			}
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}

--- a/internal/api/http/metrics_prom_test.go
+++ b/internal/api/http/metrics_prom_test.go
@@ -1,0 +1,220 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+)
+
+func newMetricsPromServer(t *testing.T, withPerUserCap bool) *Server {
+	t.Helper()
+	sem := concurrency.New(8, 16, 30*time.Second)
+	if withPerUserCap {
+		sem = sem.WithPerUserCap(4)
+	}
+	hookReg := hooks.NewRegistry()
+	return &Server{
+		cfg:            &config.Config{},
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            sem,
+	}
+}
+
+// TestMetricsProm_EmitsExpectedSeries pins the metric set the
+// observability-profiles RFC locks: 5 always-on series + build_info.
+// Per-user series stays absent when the per-user cap is disabled
+// (cardinality guard).
+func TestMetricsProm_EmitsExpectedSeries(t *testing.T) {
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+
+	wantSeries := []string{
+		"loomcycle_process_rss_bytes",
+		"loomcycle_process_heap_alloc_bytes",
+		"loomcycle_process_goroutines",
+		"loomcycle_concurrency_active",
+		"loomcycle_concurrency_queued",
+		"loomcycle_build_info",
+	}
+	for _, name := range wantSeries {
+		if !strings.Contains(body, "# TYPE "+name+" gauge") {
+			t.Errorf("missing TYPE line for %q in body:\n%s", name, body)
+		}
+		if !strings.Contains(body, name+" ") && !strings.Contains(body, name+"{") {
+			t.Errorf("missing sample for %q", name)
+		}
+	}
+	// per-user series should be absent when cap is 0
+	if strings.Contains(body, "loomcycle_concurrency_per_user") {
+		t.Errorf("loomcycle_concurrency_per_user should be omitted when per-user cap is disabled; got: %s", body)
+	}
+}
+
+// TestMetricsProm_PerUserSeriesOnlyWhenCapEnabled pins the cardinality
+// guard: per-user labels only appear when the operator opted into
+// per-user fairness. Without this, anonymous workloads would explode
+// cardinality with no operator-visible knob.
+func TestMetricsProm_PerUserSeriesOnlyWhenCapEnabled(t *testing.T) {
+	srv := newMetricsPromServer(t, true)
+	// Acquire a slot for a specific user_id so PerUser is populated.
+	rel, err := srv.sem.AcquireForUser(t.Context(), "alice")
+	if err != nil {
+		t.Fatalf("AcquireForUser failed: %v", err)
+	}
+	defer rel()
+
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "loomcycle_concurrency_per_user{user_id=\"alice\"} 1") {
+		t.Errorf("expected per-user series for alice, body:\n%s", body)
+	}
+}
+
+// TestMetricsProm_NilSemReturnsZeros pins the safety path: a Server
+// missing the semaphore (early init, certain test fixtures) emits
+// concurrency=0 rather than 500-ing.
+func TestMetricsProm_NilSemReturnsZeros(t *testing.T) {
+	srv := &Server{cfg: &config.Config{}, sem: nil}
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "loomcycle_concurrency_active 0") {
+		t.Errorf("expected active=0 with nil sem; body:\n%s", body)
+	}
+	if !strings.Contains(body, "loomcycle_concurrency_queued 0") {
+		t.Errorf("expected queued=0 with nil sem; body:\n%s", body)
+	}
+}
+
+// TestMetricsProm_ReplicaIDLabelWhenSet pins the cluster-mode label:
+// LOOMCYCLE_REPLICA_ID populates a replica_id label on every series.
+// Single-replica deployments (env unset) omit the label entirely so
+// the output stays clean.
+func TestMetricsProm_ReplicaIDLabelWhenSet(t *testing.T) {
+	t.Setenv("LOOMCYCLE_REPLICA_ID", "node-2")
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `loomcycle_process_goroutines{replica_id="node-2"}`) {
+		t.Errorf("expected replica_id label on process series; body:\n%s", body)
+	}
+	if !strings.Contains(body, `replica_id="node-2"`) {
+		t.Errorf("build_info should also carry replica_id; body:\n%s", body)
+	}
+}
+
+// TestMetricsProm_TextFormatShape pins the Prometheus exposition
+// format invariants: every metric line that isn't a comment must
+// match `<name>[{labels}] <value>` and every named series must have
+// a preceding HELP + TYPE line. Lightweight in-package check —
+// avoids pulling in prometheus/common just for testing.
+func TestMetricsProm_TextFormatShape(t *testing.T) {
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	seen := map[string]struct {
+		help bool
+		typ  bool
+	}{}
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "# HELP "):
+			name := strings.SplitN(strings.TrimPrefix(line, "# HELP "), " ", 2)[0]
+			s := seen[name]
+			s.help = true
+			seen[name] = s
+		case strings.HasPrefix(line, "# TYPE "):
+			name := strings.SplitN(strings.TrimPrefix(line, "# TYPE "), " ", 2)[0]
+			s := seen[name]
+			s.typ = true
+			seen[name] = s
+		case strings.HasPrefix(line, "#"):
+			// other comment — ignore
+		default:
+			// must be `name[{labels}] value`
+			parts := strings.SplitN(line, " ", 2)
+			if len(parts) != 2 {
+				t.Errorf("malformed sample line: %q", line)
+				continue
+			}
+			name := parts[0]
+			if i := strings.IndexByte(name, '{'); i >= 0 {
+				name = name[:i]
+			}
+			if _, ok := seen[name]; !ok {
+				t.Errorf("sample %q has no preceding HELP/TYPE", name)
+			}
+		}
+	}
+
+	for name, flags := range seen {
+		if !flags.help {
+			t.Errorf("metric %q missing HELP line", name)
+		}
+		if !flags.typ {
+			t.Errorf("metric %q missing TYPE line", name)
+		}
+	}
+}
+
+// TestMetricsProm_BodyTrailingNewline pins a subtle but real
+// Prometheus expectation — the response must end with a newline.
+// Some scrapers reject responses that don't.
+func TestMetricsProm_BodyTrailingNewline(t *testing.T) {
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	body := rec.Body.String()
+	if !strings.HasSuffix(body, "\n") {
+		t.Errorf("body should end with a newline; ends with %q", body[len(body)-min(20, len(body)):])
+	}
+}
+
+// TestMetricsProm_ContentType pins the standard Prometheus
+// text-format content-type. Scrapers content-negotiate against this.
+func TestMetricsProm_ContentType(t *testing.T) {
+	srv := newMetricsPromServer(t, false)
+	rec := httptest.NewRecorder()
+	srv.handleMetricsProm(rec, httptest.NewRequest("GET", "/metrics", nil))
+
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+		t.Errorf("Content-Type = %q, want text/plain; version=0.0.4; charset=utf-8", got)
+	}
+}
+
+// _silenceUnused ensures io is referenced even if a future refactor
+// drops uses; required because the package builds under -race with
+// strict imports.
+var _silenceUnused = io.Discard

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1625,6 +1625,11 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_metrics/samples", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSamples))))
 	mux.Handle("GET /v1/_metrics/runs/{run_id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsRunSummary))))
 	mux.Handle("GET /v1/_metrics/summary", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsSummary))))
+	// v1.x Prometheus text-format scrape endpoint. Live-read of runtime
+	// + concurrency state — no DB hop, no instrumentation surface.
+	// Bearer-authed identically to /v1/_metrics/*. See
+	// rfcs/observability-profiles.md Decisions 1 + 3.
+	mux.Handle("GET /metrics", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMetricsProm))))
 	// v0.10.1 — per-tenant fairness inspection. Bearer-authed snapshot
 	// of the global semaphore + per-user counts. Sister of the
 	// /v1/_metrics/* family; same auth posture.


### PR DESCRIPTION
## Summary

Standard Prometheus scrape endpoint at \`GET /metrics\`. Live-read against runtime counters (\`runtime.MemStats\` + \`Semaphore.Stats\`) — no DB hop, no new instrumentation surface. Works even when \`LOOMCYCLE_METRICS_ENABLED=0\` since the live values are trivially available.

First slice of the observability-profiles RFC (#2 on loomcycle-internal). Slice A.0 — unblocks A.1 (Profile A's Prometheus scrape config) without committing the bigger profile work.

## Metric surface

| Metric | Type | Notes |
|---|---|---|
| \`loomcycle_process_rss_bytes\` | gauge | \`runtime.MemStats.Sys\` |
| \`loomcycle_process_heap_alloc_bytes\` | gauge | \`runtime.MemStats.HeapAlloc\` |
| \`loomcycle_process_goroutines\` | gauge | \`runtime.NumGoroutine\` |
| \`loomcycle_concurrency_active\` | gauge | active semaphore slots |
| \`loomcycle_concurrency_queued\` | gauge | queued waiters |
| \`loomcycle_concurrency_per_user\` | gauge | per-user_id; **only emitted when MaxConcurrentRunsPerUser > 0** (cardinality guard) |
| \`loomcycle_build_info\` | gauge=1 | version metadata as labels (\`debug.ReadBuildInfo\` + \`runtime.Version\`) |

\`LOOMCYCLE_REPLICA_ID\` is auto-promoted to a label on every series when set; omitted for single-replica deployments.

## Auth

Bearer-authed identically to \`/v1/_metrics/*\` via the same \`authMiddleware\`. No new auth surface; Prometheus scrape config uses \`authorization: { type: Bearer, credentials: \"...\" }\`.

## Architectural locks (RFC observability-profiles.md)

- **Decision 1** — live-read substrate, no DB hop. Operators scraping every 15s see current values, not the last DB sampler write.
- **Decision 2** (revised) — spans stay in Tempo; the OTEL Collector's \`spanmetrics\` connector aggregates them into Prometheus histograms downstream. \`/metrics\` exposes ONLY substrate state; no in-process span processor.
- **Decision 3** — bearer auth, same trust posture as \`/v1/_metrics/*\`.

## Test plan

- [x] \`go test ./internal/api/http/... -run TestMetricsProm -count=1\` (7 subtests pass)
- [x] \`go test ./... -count=1\` clean
- [x] \`go build ./...\` clean
- [ ] Manual smoke (post-merge): \`curl -H \"Authorization: Bearer \$TOKEN\" http://localhost:8787/metrics\` returns valid Prometheus text format

🤖 Generated with [Claude Code](https://claude.com/claude-code)