### PR TITLE
feat(observability): Profile C — Datadog APM wiring + query reference

### DIFF
--- a/examples/observability/datadog/.env.example
+++ b/examples/observability/datadog/.env.example
@@ -1,0 +1,28 @@
+# Copy to .env and fill in. See README.md for the operator quickstart.
+
+# --- Required ---
+
+# Bearer token for the loomcycle API.
+LOOMCYCLE_AUTH_TOKEN=demo-token-change-me
+
+# Datadog agent host — the existing Datadog agent process the
+# operator already runs for the rest of their stack. Could be a
+# sidecar container (DD_AGENT_HOST=datadog-agent), a hostname for a
+# centralized agent, or 127.0.0.1 if agent runs locally.
+DD_AGENT_HOST=datadog-agent
+DD_SITE=datadoghq.com
+
+# --- OTEL wiring — loomcycle sends OTLP to the Datadog agent's OTLP
+# receiver on port 4318. The agent forwards to Datadog APM/Metrics.
+
+LOOMCYCLE_OTEL_EXPORTER_OTLP_ENDPOINT=http://${DD_AGENT_HOST}:4318
+LOOMCYCLE_OTEL_SERVICE_NAME=loomcycle
+# Production-sensible sampler ratio (10%). Datadog APM bills by
+# ingested spans; tune down for high-volume fleets.
+LOOMCYCLE_OTEL_SAMPLER_RATIO=0.1
+
+# --- At least one provider key ---
+
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+DEEPSEEK_API_KEY=

--- a/examples/observability/datadog/README.md
+++ b/examples/observability/datadog/README.md
@@ -1,0 +1,152 @@
+# Profile C — Datadog APM wiring
+
+Send loomcycle's OTEL traces to Datadog APM via the operator's existing Datadog agent + canonical query reference for the most useful operator views.
+
+Locked at [`rfcs/observability-profiles.md`](../../../doc-internal/rfcs/observability-profiles.md) Profile C.
+
+## What this profile ships vs what you author
+
+Datadog APM is SaaS + agent-based (loomcycle sends OTLP to the local Datadog agent; the agent forwards to Datadog's backend). This profile ships:
+
+- **Wiring** (`.env.example`, `loomcycle.yaml`) — env vars pointing OTLP at the operator's existing Datadog agent
+- **Query reference** — canonical Datadog APM queries for the panels operators most often want
+- **Dashboard placeholder** (`datadog-dashboard.json`) — author against your account per the walkthrough below
+
+Like Profile B (Honeycomb), the dashboard JSON is tenant-bound (org-specific service tags, custom metric setup, retention windows). You author the dashboard once against your Datadog org and optionally contribute the redacted export back.
+
+## Prerequisites
+
+You need an existing Datadog agent reachable from where loomcycle runs. Two common shapes:
+
+- **K8s:** the Datadog agent runs as a DaemonSet; `DD_AGENT_HOST` is the agent service's ClusterIP / hostname
+- **VM:** the Datadog agent runs on the same host as loomcycle; `DD_AGENT_HOST=127.0.0.1`
+
+The agent must have OTLP receiver enabled. In the Datadog agent's `datadog.yaml`:
+
+```yaml
+otlp_config:
+  receiver:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+```
+
+Restart the agent after editing.
+
+## Quickstart
+
+```sh
+cd examples/observability/datadog
+cp .env.example .env
+# Edit .env: DD_AGENT_HOST + at least one provider API key.
+source .env && loomcycle serve --config loomcycle.yaml
+```
+
+Spawn a test run:
+
+```sh
+curl -H "Authorization: Bearer $LOOMCYCLE_AUTH_TOKEN" \
+     -H "Content-Type: application/json" \
+     http://localhost:8787/v1/runs \
+     -d '{"agent":"demo","user_id":"alice","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hello"}]}]}'
+```
+
+In Datadog APM (https://app.datadoghq.com/apm/services): within ~30 seconds you'll see a new service `loomcycle` (or whatever `LOOMCYCLE_OTEL_SERVICE_NAME` resolves to). Click it for the auto-generated service-overview panel.
+
+## Canonical Datadog APM queries
+
+Each query produces one of the 10 panels Profile A's Grafana dashboard shows. Paste these into Datadog's query editor; tags map directly to OTEL span attributes (Datadog automatically translates `loomcycle.provider` → tag `loomcycle.provider`).
+
+### 1. Run rate by agent
+
+```
+trace.loomcycle.run.hits{service:loomcycle} by {loomcycle.agent_name}.as_rate()
+```
+
+### 2. Run latency p95
+
+```
+trace.loomcycle.run.duration{service:loomcycle}.p95()
+```
+
+Switch the aggregation to `p50` / `p99` for the percentile breakdown.
+
+### 3. Provider RTT p95 by provider
+
+```
+trace.loomcycle.provider.call.duration{service:loomcycle} by {loomcycle.provider}.p95()
+```
+
+### 4. Tool call rate by tool
+
+```
+trace.loomcycle.tool.call.hits{service:loomcycle} by {loomcycle.tool}.as_rate()
+```
+
+### 5. MCP call latency p95 by server
+
+```
+trace.loomcycle.mcp.call.duration{service:loomcycle} by {loomcycle.mcp_server}.p95()
+```
+
+### 6. Error rate by provider
+
+```
+(trace.loomcycle.provider.call.errors{service:loomcycle} by {loomcycle.provider}.as_rate()) /
+(trace.loomcycle.provider.call.hits{service:loomcycle} by {loomcycle.provider}.as_rate())
+```
+
+### 7. Token spend by agent
+
+Token counts are span attributes; Datadog exposes them via custom metrics or via Trace Analytics. Easiest: enable **APM Trace Metrics** for the `loomcycle.input_tokens` attribute, then:
+
+```
+trace.loomcycle.provider.call.loomcycle.input_tokens{service:loomcycle} by {loomcycle.agent_name}.as_count()
+```
+
+### 8. Recent slowest traces
+
+Datadog APM → Traces → search `service:loomcycle env:prod` → sort by Duration DESC → top 20. Click any row for the full span tree + flame graph.
+
+## Custom metrics — enable per-tag tracking
+
+To make span attributes graphable as Datadog metrics (panel 7 above), enable per-tag tracking in your Datadog APM config:
+
+Settings → APM → Integrations → Span Tag Statistics → Add:
+
+- `loomcycle.provider`
+- `loomcycle.tool`
+- `loomcycle.agent_name`
+- `loomcycle.mcp_server`
+- `loomcycle.tier`
+
+This adds ~minimal extra cost (per-tag aggregates are pre-computed) and unlocks the spanmetrics-equivalent queries Datadog ships natively.
+
+## Authoring the dashboard
+
+Roughly 15 minutes against your account:
+
+1. Run a load against loomcycle (e.g. Profile A's `seed.sh` pointed at this loomcycle instance)
+2. Datadog → Dashboards → New Dashboard → "Loomcycle overview"
+3. For each of the 8 queries above: add a Timeseries panel, paste the query, name it
+4. Arrange widgets (drag-to-resize)
+5. Save the dashboard
+6. Export: Dashboard menu → "Export as JSON" or via the API: `GET /api/v1/dashboard/<id>`
+7. Redact tenant-specific fields (your `dd_org_id`, internal hostnames, etc.)
+8. (Optional) Open a PR replacing `datadog-dashboard.json` with your authored export
+
+## Customisation
+
+| Want to | Change |
+|---|---|
+| Lower / raise sampling | `.env`: `LOOMCYCLE_OTEL_SAMPLER_RATIO=0.1` |
+| Send to a different Datadog environment | `LOOMCYCLE_OTEL_SERVICE_NAME=loomcycle-staging` (creates a separate APM service) |
+| Add APM `env:` tag | `LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS=dd-env=production` (Datadog agent reads this) |
+| Use Datadog DogStatsD instead of OTLP | Not in scope — loomcycle's OTLP path is the canonical one. DogStatsD would require a Datadog-specific exporter that violates the substrate stance |
+
+## See also
+
+- [`../grafana-tempo/`](../grafana-tempo/) — self-hosted equivalent (Profile A)
+- [`../honeycomb/`](../honeycomb/) — Honeycomb cloud equivalent (Profile B)
+- `Context.help observability` in the loomcycle binary — OTEL substrate reference
+- [Datadog OTLP ingestion docs](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/)

--- a/examples/observability/datadog/datadog-dashboard.json
+++ b/examples/observability/datadog/datadog-dashboard.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Datadog dashboard placeholder. The Profile C story is wiring + query reference, not a tenant-bound dashboard JSON — Datadog dashboards reference your org's specific tag values, service names, and metric retention setup that this repo cannot author without a Datadog account. Operators with an account follow the README walkthrough to build the dashboard against their own org, then optionally contribute the export back to this repo. See README.md > 'Authoring the dashboard'.",
+  "_walkthrough": "https://github.com/denn-gubsky/loomcycle/blob/main/examples/observability/datadog/README.md#authoring-the-dashboard",
+  "title": "Loomcycle overview (placeholder)",
+  "description": "Placeholder — replace with operator-authored export from /api/v1/dashboard/<id>",
+  "widgets": [],
+  "layout_type": "ordered"
+}

--- a/examples/observability/datadog/loomcycle.yaml
+++ b/examples/observability/datadog/loomcycle.yaml
@@ -1,0 +1,43 @@
+# Minimal loomcycle config for the Profile C (Datadog APM) demo.
+# OTEL endpoint is driven by env vars (.env.example pointing at the
+# operator's existing Datadog agent OTLP receiver); this file stays
+# focused on agent + provider wiring.
+
+defaults:
+  provider: anthropic
+  model: claude-haiku-4-5
+
+provider_priority:
+  - anthropic
+  - openai
+  - deepseek
+
+user_tiers:
+  default:
+    provider_priority:
+      - anthropic
+      - openai
+      - deepseek
+    tiers:
+      low:
+        - {provider: anthropic, model: claude-haiku-4-5}
+        - {provider: openai, model: gpt-5.4-mini}
+      middle:
+        - {provider: anthropic, model: claude-sonnet-4-6}
+        - {provider: deepseek, model: deepseek-v4-flash}
+    fallback_on_error: true
+    max_fallback_attempts: 3
+
+agents:
+  demo:
+    tier: low
+    allowed_tools: [Read, Memory]
+    memory_scopes: [agent, user]
+    system_prompt: |
+      You are a friendly demo agent. Respond briefly. Use the Memory
+      tool when asked to remember something.
+
+concurrency:
+  max_concurrent_runs: 16
+  max_queue_depth: 64
+  queue_timeout_ms: 30000


### PR DESCRIPTION
## Summary

Datadog APM wiring + canonical query reference. Fourth slice of RFC observability-profiles.md. Same shape as Profile B (Honeycomb) — SaaS, no docker stack, ships wiring + query reference + placeholder dashboard + author-instructions.

## What ships

| File | Purpose |
|---|---|
| \`.env.example\` | OTLP endpoint pointing at \`DD_AGENT_HOST:4318\`, service name, sampler ratio |
| \`loomcycle.yaml\` | Minimal demo agent + provider tiers |
| \`datadog-dashboard.json\` | Placeholder + author-instructions |
| \`README.md\` | Prerequisites (agent OTLP config), 8 Datadog APM queries, per-tag-tracking setup, 15-minute dashboard-authoring walkthrough |

## Canonical queries (in README)

- Run rate by agent (\`as_rate()\`)
- Run latency p95
- Provider RTT p95 by provider
- Tool call rate by tool
- MCP call latency p95 by server
- Error rate by provider
- Token spend by agent (via APM Trace Metrics)
- Recent slowest traces (APM Traces UI)

Plus span-tag-tracking setup steps so the span attribute path works (provider, tool, agent_name, mcp_server, tier).

## Honest about the placeholder dashboard (RFC Decision 4)

Datadog dashboards are tenant-bound (org-specific service tags, custom metric setup, retention windows). The placeholder JSON ships with a walkthrough for operators to author against their own org. Redacted exports contributable via PR.

## Test plan

- [x] \`yaml.safe_load\` parses \`loomcycle.yaml\`
- [x] \`json.load\` parses \`datadog-dashboard.json\` placeholder
- [x] No loomcycle Go code changes
- [ ] Manual smoke (operator-side, post-merge): set \`DD_AGENT_HOST\`, run loomcycle, spawn a test run, see service \`loomcycle\` appear in Datadog APM within ~30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)