### PR TITLE
docs(observability): top-level profiles README + CONFIGURATION + help cross-links

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -737,6 +737,7 @@ After v0.8.16 (PR #116), the model is also persisted at run start, so `GET /v1/u
 - [`docs/TOOLS.md`](TOOLS.md) — tool policy and built-in tool reference (the `allowed_tools` / `tools` axis).
 - [`docs/POSTGRES.md`](POSTGRES.md) — storage backend configuration.
 - [`docs/PLAN.md`](PLAN.md) — historical design rationale, including the v0.8.2 `user_tiers` RFC and the precedence design decisions.
+- [`examples/observability/`](../examples/observability/) — three drop-in observability profiles (Grafana+Tempo self-hosted / Honeycomb / Datadog) for sending loomcycle's OTEL traces + Prometheus metrics to your existing stack. Five-minute quickstart per profile.
 - MCP spec: https://modelcontextprotocol.io (only relevant if you're also wiring MCP servers — see `MCP_INTEGRATION.md` first).
 
 ## 11. Code path index

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,58 @@
+# Observability profiles
+
+Three drop-in profiles for wiring loomcycle into your existing observability stack. Pick the one matching where you already send telemetry:
+
+| Profile | What it is | When to use it |
+|---|---|---|
+| **[`grafana-tempo/`](grafana-tempo/)** | Self-hosted Grafana + Tempo + Prometheus + Loki + OTEL Collector stack via docker-compose. Pre-built 10-panel dashboard. | You don't yet have an observability stack, or you prefer self-hosted open-source tooling. |
+| **[`honeycomb/`](honeycomb/)** | Wiring for Honeycomb cloud + canonical query reference + board-authoring walkthrough. | You already use Honeycomb for distributed tracing. |
+| **[`datadog/`](datadog/)** | Wiring for Datadog APM via the operator's existing Datadog agent + canonical query reference + dashboard-authoring walkthrough. | You already use Datadog APM. |
+
+## Common architecture
+
+All three profiles consume the same loomcycle OTEL substrate (shipped v0.10.0) and the same `/metrics` Prometheus endpoint (shipped via RFC observability-profiles.md, slice A.0). What differs is the downstream stack — same telemetry, three destinations.
+
+```
+loomcycle ──OTLP──▶ ┌──────────────────┐
+                    │ Profile A: Grafana-Tempo (self-hosted)
+                    │ Profile B: Honeycomb (cloud)
+                    │ Profile C: Datadog (APM agent)
+                    └──────────────────┘
+loomcycle ──/metrics──▶ Prometheus (Profile A) or scraped from each profile's stack
+```
+
+The substrate exposes:
+
+- **5 span types** — `loomcycle.run`, `loomcycle.iteration`, `loomcycle.provider.call`, `loomcycle.tool.call`, `loomcycle.mcp.call`
+- **19 span attributes** — identity (`run_id`, `agent_id`, `user_id`, `agent_name`, `parent_agent_id`, `iteration`), provider (`provider`, `model`, `tier`, `effort`), tools (`tool`, `mcp_server`, `mcp_tool`), cost (`input_tokens`, `output_tokens`, `cache_read_tokens`), latency (`stop_reason`, `tool_is_error`, `queue_wait_ms`)
+- **7 Prometheus metrics** — process resources (RSS, heap, goroutines), concurrency state (active, queued, per-user), build_info
+- **OTEL Collector `spanmetrics` connector** (Profile A only) — aggregates spans into Prometheus histograms downstream; same metrics queryable in any Prometheus-compatible backend
+
+## Choosing a profile
+
+```
+┌────────────────────────────────────────────────────────┐
+│ Do you already send observability data somewhere?      │
+├────────────────────────────────────────────────────────┤
+│  No → Profile A (Grafana-Tempo, self-hosted)            │
+│  Yes, Honeycomb → Profile B                             │
+│  Yes, Datadog → Profile C                               │
+│  Yes, something else (New Relic, Splunk, Dynatrace,    │
+│                       Lightstep, etc.)                  │
+│         → Use OTEL substrate primitives directly       │
+│           (see Context.help observability for env vars) │
+└────────────────────────────────────────────────────────┘
+```
+
+Each profile's README has the operator-facing five-minute quickstart + customisation guidance + production-hardening notes. The substrate itself (env vars, attribute schema, span types) is documented in `Context.help observability` available inside any loomcycle agent's conversation.
+
+## Contributing
+
+If you author a real Honeycomb board (Profile B) or Datadog dashboard (Profile C) against your own tenant, redacted JSON exports are welcome contributions — open a PR replacing the placeholder JSON. See each profile's README "Authoring..." section for the walkthrough.
+
+## See also
+
+- [`Context.help observability`](../../internal/help/builtin/observability.md) — OTEL substrate reference (env vars, attribute schema, sampling guidance)
+- [`docs/CONFIGURATION.md`](../../docs/CONFIGURATION.md) — full operator config reference
+- [`rfcs/observability-profiles.md`](../../doc-internal/rfcs/observability-profiles.md) — the design lock
+- [`rfcs/observability-cookbook.md`](../../doc-internal/rfcs/observability-cookbook.md) — original design sketch (now superseded by the locked RFC)

--- a/internal/help/builtin/observability.md
+++ b/internal/help/builtin/observability.md
@@ -261,6 +261,32 @@ different loomcycle instance).
   v0.10.x slice. Until then, sub-agent runs that span replicas show
   as separate disconnected traces.
 
+## Bundled profiles (v1.x)
+
+Three drop-in profile directories live under `examples/observability/`
+in the loomcycle repo. Pick the one matching your existing stack;
+each ships its own README with a five-minute quickstart.
+
+- **`examples/observability/grafana-tempo/`** — self-hosted Grafana
+  + Tempo + Prometheus + Loki + OTEL Collector stack via docker-
+  compose. Pre-built 10-panel dashboard auto-provisioned on Grafana
+  startup. The OTEL Collector's `spanmetrics` connector aggregates
+  loomcycle spans into Prometheus histograms downstream — no
+  in-process span processor; the substrate stays clean.
+- **`examples/observability/honeycomb/`** — wiring + 8 canonical
+  Honeycomb queries + 3 derived-column definitions + 10-minute
+  board-authoring walkthrough.
+- **`examples/observability/datadog/`** — wiring (via the
+  operator's existing Datadog agent OTLP receiver) + 8 canonical
+  Datadog APM queries + per-tag-tracking setup + 15-minute
+  dashboard-authoring walkthrough.
+
+Plus a `/metrics` Prometheus text-format endpoint on loomcycle
+itself (added v1.x, slice A.0) exposing substrate counters (process
+RSS, heap, goroutines, concurrency state, build_info) — scraped by
+Profile A's Prometheus and reusable by any operator-existing
+Prometheus deployment regardless of which profile they pick.
+
 ## Related topics
 
 - `pause-resume-snapshot` — runtime quiesce + snapshot lifecycle.


### PR DESCRIPTION
## Summary

Final slice of RFC observability-profiles.md. Adds the top-level \"which profile to pick\" README + cross-links from CONFIGURATION.md + a Bundled-profiles section in the bundled \`Context.help observability\` topic.

Closes out the observability-profiles RFC batch:
- #256 — A.0 \`/metrics\` Prometheus endpoint
- #257 — A.1 Profile A (Grafana + Tempo + Prometheus + Loki)
- #258 — A.2 Profile B (Honeycomb)
- #259 — A.3 Profile C (Datadog)
- **This PR** — A.D Docs

## What ships

| File | Change |
|---|---|
| \`examples/observability/README.md\` | NEW — three-way decision tree, substrate shape diagram, contribution guidance for operator-authored boards/dashboards |
| \`docs/CONFIGURATION.md\` | One-line cross-link in §10 Cross-references |
| \`internal/help/builtin/observability.md\` | New \"Bundled profiles (v1.x)\" section referencing the three profile directories + \`/metrics\` |

The help-topic update means agents inside loomcycle conversations get the same content as operators reading the README — the substrate-stance promise that operators + agents read the same docs.

## Test plan

- [x] \`go test ./internal/help/... -count=1\` clean (help topic embeds correctly)
- [x] \`go test ./... -count=1\` clean (no Go behaviour changes)
- [x] All cross-links resolve manually

No loomcycle code changes — pure documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)