### PR TITLE
feat(tools): RFC E ScheduleDef built-in tool + HTTP admin endpoint

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -973,6 +973,17 @@ func main() {
 	// (operator-admin-only); reached via Connector.MCPServerDef + the
 	// admin endpoint + the LoomCycle MCP meta-tool.
 	srv.SetMCPServerDefTool(mcpServerDefTool)
+	// v1.x — wire the ScheduleDef substrate tool. Same operator-admin-
+	// only posture; reached via Connector.ScheduleDef + the admin
+	// endpoint + the future LoomCycle MCP meta-tool. Tool needs only
+	// the store + cfg (no MCP-pool dependency) so this could move
+	// earlier — kept next to MCPServerDef for substrate-wiring locality.
+	srv.SetScheduleDefTool(&builtin.ScheduleDef{
+		Store:               storeIface,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
+		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
+	})
 	// Surface the resolved build identifiers via /healthz so the Web UI
 	// can render the running binary's real version instead of a stale
 	// hard-coded string. Mirrors what gRPC's Health RPC has reported

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -816,6 +816,11 @@ func (m *mockConnector) MCPServerDef(context.Context, json.RawMessage) (connecto
 	return connector.ToolResult{}, nil
 }
 
+// v1.x ScheduleDef stub.
+func (m *mockConnector) ScheduleDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *mockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, nil

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -397,6 +397,20 @@ func (s *Server) MCPServerDef(ctx context.Context, input json.RawMessage) (conne
 	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
 }
 
+// ScheduleDef dispatches to the v1.x dynamic scheduled-runs substrate
+// tool. Same operator-admin-only posture as MCPServerDef. See
+// SetScheduleDefTool for wiring.
+func (s *Server) ScheduleDef(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	if s.scheduleDefTool == nil {
+		return connector.ToolResult{}, fmt.Errorf("ScheduleDef: not configured (no tool wired via SetScheduleDefTool)")
+	}
+	res, err := s.scheduleDefTool.Execute(ctx, input)
+	if err != nil {
+		return connector.ToolResult{}, err
+	}
+	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
 // dispatchBuiltin is the shared lookup-and-execute path for the five
 // builtin wrappers. tools.Result {Text, IsError} maps directly onto
 // connector.ToolResult; the transport adapter (MCP) then wraps both

--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -63,6 +63,19 @@ func (s *Server) handleListMCPServerDefNames(w http.ResponseWriter, r *http.Requ
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
+// handleListScheduleDefNames serves GET /v1/_scheduledef/names.
+func (s *Server) handleListScheduleDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.ScheduleDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []store.ScheduleDefNameSummary{}
+	}
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
 // handleAgentChannels serves GET /v1/agents/{agent_name}/channels.
 // Returns every channel_cursors row for (scope=agent, scope_id={agent_name}),
 // ordered by channel ASC. Drives the v0.9.x Web UI's per-agent

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -186,6 +186,13 @@ type Server struct {
 	// "not configured" errors. Set via SetMCPServerDefTool.
 	mcpServerDefTool tools.Tool
 
+	// scheduleDefTool is the v1.x ScheduleDef substrate tool. Same
+	// operator-admin-only posture as mcpServerDefTool — NOT in
+	// s.tools, reached via Connector.ScheduleDef + the admin endpoint
+	// + future LoomCycle MCP meta-tool. Nil = the surface returns
+	// "not configured" errors. Set via SetScheduleDefTool.
+	scheduleDefTool tools.Tool
+
 	// v0.12.0 multi-replica HA. backplane + replicaStore are nil in
 	// single-replica deployments (LOOMCYCLE_REPLICA_ID unset); /healthz
 	// then returns the same response shape as v0.11.x. When set,
@@ -449,6 +456,16 @@ func (s *Server) ChannelBus() *channels.Bus {
 // Set from main.go once the tool + dynamic registry + pool are built.
 func (s *Server) SetMCPServerDefTool(t tools.Tool) {
 	s.mcpServerDefTool = t
+}
+
+// SetScheduleDefTool wires the v1.x ScheduleDef substrate tool.
+// Without this call, Connector.ScheduleDef + POST /v1/_scheduledef
+// + the future LoomCycle MCP meta-tool all refuse with "not
+// configured". Set from main.go once the tool is built. The tool
+// only needs the store + cfg, so it can be constructed earlier
+// than the MCP-dependent MCPServerDef tool.
+func (s *Server) SetScheduleDefTool(t tools.Tool) {
+	s.scheduleDefTool = t
 }
 
 // newDispatcher centralises Dispatcher construction so the three call
@@ -1651,6 +1668,10 @@ func (s *Server) Mux() http.Handler {
 	// admin-only (no per-agent surface). Same dispatch shape as the
 	// other two substrate admin endpoints.
 	mux.Handle("POST /v1/_mcpserverdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateMCPServerDef))))
+	// v1.x scheduled-runs substrate. Same operator-admin-only dispatch
+	// shape; the tool is reachable only via this endpoint + the MCP
+	// meta-tool + the future gRPC RPC (no per-agent dispatcher slot).
+	mux.Handle("POST /v1/_scheduledef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateScheduleDef))))
 	// v0.11.0 LLM Gateway — direct provider routing without the agent
 	// loop. Bearer-authed admin scope. Both stream:true (SSE) and
 	// stream:false (single-shot JSON) selected by the request body.
@@ -1679,6 +1700,7 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_agentdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListAgentDefNames))))
 	mux.Handle("GET /v1/_skilldef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListSkillDefNames))))
 	mux.Handle("GET /v1/_mcpserverdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMCPServerDefNames))))
+	mux.Handle("GET /v1/_scheduledef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListScheduleDefNames))))
 	// v0.9.x Library v2 — unified enumeration that merges static cfg
 	// + substrate views into one envelope per entry. The names/* sister
 	// endpoints above stay as-is for backwards compat with external

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -55,6 +55,13 @@ func (s *Server) handleSubstrateMCPServerDef(w http.ResponseWriter, r *http.Requ
 	s.dispatchSubstrate(w, r, "MCPServerDef", s.MCPServerDef)
 }
 
+// handleSubstrateScheduleDef serves POST /v1/_scheduledef.
+// v1.x scheduled-runs substrate. Bearer-authed; same dispatch
+// shape as the AgentDef + SkillDef + MCPServerDef endpoints.
+func (s *Server) handleSubstrateScheduleDef(w http.ResponseWriter, r *http.Request) {
+	s.dispatchSubstrate(w, r, "ScheduleDef", s.ScheduleDef)
+}
+
 // dispatchSubstrate is the shared body of the two handlers.
 // connectorFn is the Connector method (already a method value
 // bound to the Server). toolName is the label used in error
@@ -160,6 +167,13 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 	})
 	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{
 		Scopes: []string{"any"},
+	})
+	// ScheduleDef: same operator-trust posture; "any" scope lets the
+	// HTTP-admin call create/fork/retire any schedule name regardless
+	// of the orchestrator-agent naming used by in-loop callers.
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: substrateAdminAgentName,
 	})
 	// Evaluation: all 4 valid scope values.
 	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -44,6 +44,11 @@ func substrateAdminFixture(t *testing.T) *httptest.Server {
 	skillDefTool := &builtin.SkillDef{Set: emptySkillSet, Store: st}
 
 	srv := New(cfg, &stubResolver{}, []tools.Tool{agentDefTool, skillDefTool}, concurrency.New(1, 1, time.Second), st)
+	// ScheduleDef is operator-admin-only — not in the per-agent
+	// dispatcher slice; wired via the dedicated setter that the
+	// HTTP handler + Connector method look up. Without this call,
+	// POST /v1/_scheduledef returns "ScheduleDef: not configured".
+	srv.SetScheduleDefTool(&builtin.ScheduleDef{Store: st, Cfg: cfg})
 	return httptest.NewServer(srv.Mux())
 }
 
@@ -242,6 +247,106 @@ func TestSubstrateAdmin_ToolRefusal_Returns422(t *testing.T) {
 	}
 	if env["tool"] != "SkillDef" {
 		t.Errorf("tool = %v, want SkillDef", env["tool"])
+	}
+}
+
+// TestSubstrateAdmin_ScheduleDef_HappyPath exercises the v1.x
+// scheduled-runs substrate end-to-end over HTTP: bearer-authed
+// POST /v1/_scheduledef with a `create` op, response body decoded
+// via the same wire shape AgentDef + SkillDef use.
+func TestSubstrateAdmin_ScheduleDef_HappyPath(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	// The fixture's cfg has no Agents map entries, so any agent
+	// reference here would fail validation. Use a static agent on
+	// the cfg by passing the agent name through the overlay — the
+	// scheduledef tool only validates that agent != "" at create
+	// time (full resolution happens at sweeper-fire time).
+	body := `{"op":"create","name":"adhoc-sched","overlay":{"agent":"researcher","schedule":"0 6 * * *","user_id":"alice"}}`
+	resp := postAdmin(t, ts, "/v1/_scheduledef", body)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out["name"] != "adhoc-sched" {
+		t.Errorf("name = %v, want adhoc-sched", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("create default promote = false; want true (RFC E auto-promote)")
+	}
+}
+
+// TestSubstrateAdmin_ScheduleDef_ListNames covers the read-only
+// GET /v1/_scheduledef/names endpoint (introspection complement
+// to the op-dispatched POST endpoint).
+func TestSubstrateAdmin_ScheduleDef_ListNames(t *testing.T) {
+	ts := substrateAdminFixture(t)
+	defer ts.Close()
+
+	// Seed one row.
+	_ = postAdmin(t, ts, "/v1/_scheduledef",
+		`{"op":"create","name":"weekly-digest","overlay":{"agent":"researcher","schedule":"0 9 * * 1","user_id":"alice"}}`)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/v1/_scheduledef/names", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, raw)
+	}
+	var env struct {
+		Names []map[string]any `json:"names"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	found := false
+	for _, n := range env.Names {
+		if n["name"] == "weekly-digest" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("weekly-digest not in names list: %v", env.Names)
+	}
+}
+
+// TestSubstrateAdmin_ScheduleDef_NotConfigured covers the
+// graceful-degradation path: when the operator hasn't called
+// SetScheduleDefTool, the Connector method returns a Go error,
+// which dispatchSubstrate maps to 500 with code=internal.
+func TestSubstrateAdmin_ScheduleDef_NotConfigured(t *testing.T) {
+	// Bare server WITHOUT the SetScheduleDefTool wiring.
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100}}
+	cfg.Env.AuthToken = "test-token"
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp := postAdmin(t, ts, "/v1/_scheduledef", `{"op":"create","name":"x","overlay":{"agent":"a","schedule":"0 0 * * *","user_id":"u"}}`)
+	defer resp.Body.Close()
+	if resp.StatusCode != 500 {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 500; body=%s", resp.StatusCode, raw)
 	}
 }
 

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -122,6 +122,10 @@ func (m *httpMockConnector) MCPServerDef(context.Context, json.RawMessage) (conn
 	return connector.ToolResult{}, errors.New("not implemented")
 }
 
+func (m *httpMockConnector) ScheduleDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, errors.New("not implemented")
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *httpMockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, errors.New("not implemented")

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -169,6 +169,11 @@ func (m *mockConnector) MCPServerDef(context.Context, json.RawMessage) (connecto
 	return connector.ToolResult{}, nil
 }
 
+// v1.x ScheduleDef stub.
+func (m *mockConnector) ScheduleDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *mockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -601,6 +601,13 @@ type AgentDef struct {
 	// access via a templated string.
 	AgentDefScopes []string `yaml:"agent_def_scopes"`
 
+	// ScheduleDefScopes is the v1.x RFC E ScheduleDef tool capability
+	// gate. Default-deny when empty. Same closed set as
+	// AgentDefScopes: "self" / "descendants" / "named:<name>" / "any".
+	// Lets operator-blessed orchestrators author + fork schedules at
+	// runtime; arbitrary agents have no access.
+	ScheduleDefScopes []string `yaml:"schedule_def_scopes"`
+
 	// SkillDefScopes is the v0.8.22 SkillDef tool capability gate.
 	// Default-deny when empty. Mirrors AgentDefScopes minus the
 	// "self" scope (skills have no agent identity, so "self" is

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -121,6 +121,15 @@ type Connector interface {
 	// through this single Connector method.
 	MCPServerDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
 
+	// ScheduleDef — v1.x dynamic scheduled-runs registration substrate.
+	// Op-discriminated (create / fork / get / list / retire). Operator-
+	// admin-only: NOT auto-attached to every agent's per-run dispatcher.
+	// Reachable via POST /v1/_scheduledef admin endpoint, the LoomCycle
+	// MCP meta-tool `scheduledef`, the gRPC ScheduleDef RPC, and the TS
+	// adapter's client.scheduleDef() method — all four dispatch through
+	// this single Connector method.
+	ScheduleDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+
 	// --- Pause/Resume/Snapshot (real in v0.8.18) ---
 	//
 	// Wire shapes finalised v0.8.15. Real implementations landed in

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -1,0 +1,698 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/robfig/cron/v3"
+)
+
+// ScheduleDef is the v1.x RFC E built-in tool that lets agents
+// author, fork, retire, and inspect schedule definitions at runtime.
+// Yaml `scheduled_runs.<name>:` entries remain the operator-blessed
+// root; this tool produces the DERIVED layer of orchestrator-authored
+// per-user forks.
+//
+// Five operations dispatched off the `op` field:
+//
+//	create  — declare a brand-new schedule name with a v1 definition.
+//	          Refused if `name` matches a static cfg.ScheduledRuns
+//	          entry (operators expect their yaml to be ground truth;
+//	          use `fork` to derive a new version).
+//	fork    — make a new version from an existing parent (by def_id,
+//	          or by-name from the active pointer / yaml template).
+//	          The JobEmber-primary op. Auto-promotes by default per
+//	          RFC E's worked example (fork-with-new-credentials chain
+//	          where v2 should immediately replace v1 as active).
+//	get     — fetch one row by def_id.
+//	list    — list versions for a name (version DESC). Drives
+//	          JobEmber's "enumerate all forks of job-search-template"
+//	          query.
+//	retire  — flip the retired flag. Lineage stays visible; sweeper
+//	          skips retired rows.
+//
+// No `promote` op (vs AgentDef): schedules' fork-auto-promote model
+// makes a separate promote step unnecessary. No `verify` op: no
+// content_sha256 surface in v1.x.
+//
+// No AllowedTools ceiling enforcement (vs AgentDef): schedules don't
+// expose tools to agents, they spawn runs. The capability check is
+// `schedule_def_scopes` (default-deny) — operators grant orchestrator
+// agents the scopes they need.
+//
+// Server-stamped fields: created_at, created_by_agent_id (from
+// tools.RunIdentity). The model NEVER supplies these.
+type ScheduleDef struct {
+	// Store is the persistence backend. Required.
+	Store store.Store
+
+	// Cfg is the loaded operator config. Used to resolve the
+	// operator-blessed root (cfg.ScheduledRuns[name]) for the
+	// static-name-replace refusal and the bootstrap-from-yaml path.
+	Cfg *config.Config
+
+	// MaxDefinitionBytes caps the serialised definition JSON.
+	// 0 = no cap.
+	MaxDefinitionBytes int
+
+	// MaxDescriptionBytes caps the description field.
+	// 0 = no cap.
+	MaxDescriptionBytes int
+}
+
+const scheduleDefDescription = `Author, fork, retire, and inspect schedule definitions at runtime. ` +
+	`Static scheduled_runs.<name>: yaml entries remain the operator's immutable ground truth; this tool ` +
+	`produces the DERIVED layer of orchestrator-authored per-user forks. ` +
+	`Operations: create, fork, get, list, retire.`
+
+const scheduleDefInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":            {"type": "string", "enum": ["create","fork","get","list","retire"], "description": "Operation to perform."},
+    "name":          {"type": "string", "description": "Schedule name (required for create/fork/list)."},
+    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire)."},
+    "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name, or bootstraps from a yaml template)."},
+    "overlay": {
+      "type": "object",
+      "description": "Mutable subset of ScheduledRun for create/fork. Immutable / server-set fields are silently ignored if supplied.",
+      "additionalProperties": true
+    },
+    "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
+    "promote":       {"type": "boolean", "description": "create + fork both default true (schedules' fork-versioning model expects new versions to replace old). Pass false to leave the existing active pointer in place."},
+    "retired":       {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."}
+  },
+  "required": ["op"]
+}`
+
+type scheduleDefInput struct {
+	Op          string          `json:"op"`
+	Name        string          `json:"name,omitempty"`
+	DefID       string          `json:"def_id,omitempty"`
+	ParentDefID string          `json:"parent_def_id,omitempty"`
+	Overlay     json.RawMessage `json:"overlay,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Promote     *bool           `json:"promote,omitempty"`
+	Retired     *bool           `json:"retired,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (s *ScheduleDef) Name() string { return "ScheduleDef" }
+
+// Description implements tools.Tool.
+func (s *ScheduleDef) Description() string { return scheduleDefDescription }
+
+// InputSchema implements tools.Tool.
+func (s *ScheduleDef) InputSchema() json.RawMessage { return json.RawMessage(scheduleDefInputSchema) }
+
+// Execute implements tools.Tool.
+func (s *ScheduleDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if s.Store == nil {
+		return errResult("ScheduleDef tool: not configured (no Store backend)"), nil
+	}
+	if s.Cfg == nil {
+		return errResult("ScheduleDef tool: not configured (no Config — operator-blessed root unavailable)"), nil
+	}
+	var in scheduleDefInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	policy := tools.ScheduleDefPolicy(ctx)
+
+	switch in.Op {
+	case "create":
+		return s.execCreate(ctx, policy, in)
+	case "fork":
+		return s.execFork(ctx, policy, in)
+	case "get":
+		return s.execGet(ctx, policy, in)
+	case "list":
+		return s.execList(ctx, policy, in)
+	case "retire":
+		return s.execRetire(ctx, policy, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire)", in.Op)), nil
+	}
+}
+
+// ---- create ----
+
+func (s *ScheduleDef) execCreate(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("create: missing required field: name"), nil
+	}
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if _, ok := s.Cfg.ScheduledRuns[in.Name]; ok {
+		return errResult(fmt.Sprintf("create: name %q matches a static cfg.ScheduledRuns entry — use `fork` to derive a new version", in.Name)), nil
+	}
+
+	def, err := s.buildDefinition(in.Name, "", in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	if err := validateScheduleDef(def); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
+	}
+	if s.MaxDefinitionBytes > 0 && len(defJSON) > s.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("create: definition (%d bytes) exceeds max %d", len(defJSON), s.MaxDefinitionBytes)), nil
+	}
+	if s.MaxDescriptionBytes > 0 && len(in.Description) > s.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.ScheduleDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := s.Store.ScheduleDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := s.Store.ScheduleDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
+		}
+	}
+	return okJSON(scheduleRowResponse(created, promote))
+}
+
+// ---- fork ----
+
+func (s *ScheduleDef) execFork(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("fork: missing required field: name"), nil
+	}
+
+	// Resolve the parent. Three paths (mirror AgentDef):
+	//   1. parent_def_id supplied → pin
+	//   2. parent_def_id empty + active pointer exists → use it
+	//   3. neither → name must have a yaml template; bootstrap v1
+	parentDefID := in.ParentDefID
+	var parent store.ScheduleDefRow
+	if parentDefID != "" {
+		row, err := s.Store.ScheduleDefGet(ctx, parentDefID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: parent_def_id %q not found", parentDefID)), nil
+			}
+			return errResult(fmt.Sprintf("fork: %s", err)), nil
+		}
+		if row.Name != in.Name {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
+		}
+		parent = row
+	} else {
+		row, err := s.Store.ScheduleDefGetActive(ctx, in.Name)
+		if err == nil {
+			parent = row
+			parentDefID = row.DefID
+		} else {
+			var nf *store.ErrNotFound
+			if !errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: %s", err)), nil
+			}
+			// No active pointer → must bootstrap from yaml.
+			static, ok := s.Cfg.ScheduledRuns[in.Name]
+			if !ok {
+				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static cfg.ScheduledRuns entry", in.Name)), nil
+			}
+			bootstrap, berr := s.bootstrapStatic(ctx, in.Name, static)
+			if berr != nil {
+				// Concurrent first-fork may have already bootstrapped v1;
+				// re-read active pointer before propagating.
+				if row2, gerr := s.Store.ScheduleDefGetActive(ctx, in.Name); gerr == nil {
+					parent = row2
+					parentDefID = row2.DefID
+				} else {
+					return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+				}
+			} else {
+				parent = bootstrap
+				parentDefID = bootstrap.DefID
+			}
+		}
+	}
+
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	def, err := s.buildDefinition(in.Name, string(parent.Definition), in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := validateScheduleDef(def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	// required_credentials check — the template's manifest must be
+	// satisfied by the merged credentials map. Forks without all
+	// required keys are loud-refused per the RFC E sharp edge.
+	if err := assertRequiredCredentials(def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
+	}
+	if s.MaxDefinitionBytes > 0 && len(defJSON) > s.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("fork: definition (%d bytes) exceeds max %d", len(defJSON), s.MaxDefinitionBytes)), nil
+	}
+	if s.MaxDescriptionBytes > 0 && len(in.Description) > s.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.ScheduleDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		ParentDefID:      parentDefID,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := s.Store.ScheduleDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	// Schedules' fork-auto-promote default: each new fork version
+	// REPLACES the prior active version. Pass promote:false to leave
+	// the existing pointer in place (rare; the model use-case is
+	// "stage a fork, evaluate, decide whether to swap").
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := s.Store.ScheduleDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
+		}
+	}
+	return okJSON(scheduleRowResponse(created, promote))
+}
+
+// ---- get / list ----
+
+func (s *ScheduleDef) execGet(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("get: missing required field: def_id"), nil
+	}
+	row, err := s.Store.ScheduleDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("get: %s", err)), nil
+	}
+	if err := s.checkScopeForName(policy, row.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	return okJSON(scheduleRowResponse(row, false))
+}
+
+func (s *ScheduleDef) execList(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("list: missing required field: name"), nil
+	}
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	rows, err := s.Store.ScheduleDefListByName(ctx, in.Name)
+	if err != nil {
+		return errResult(fmt.Sprintf("list: %s", err)), nil
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, scheduleRowResponseMap(r))
+	}
+	return okJSON(map[string]any{"name": in.Name, "versions": out})
+}
+
+// ---- retire ----
+
+func (s *ScheduleDef) execRetire(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("retire: missing required field: def_id"), nil
+	}
+	if in.Retired == nil {
+		return errResult("retire: missing required field: retired (true|false)"), nil
+	}
+	row, err := s.Store.ScheduleDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	if err := s.checkScopeForName(policy, row.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if err := s.Store.ScheduleDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+}
+
+// ---- helpers ----
+
+func (s *ScheduleDef) checkScopeForName(policy tools.ScheduleDefPolicyValue, name string) error {
+	if len(policy.Scopes) == 0 {
+		return fmt.Errorf("ScheduleDef tool: agent has no schedule_def_scopes (default-deny); add `schedule_def_scopes: [...]` to the agent yaml")
+	}
+	for _, sc := range policy.Scopes {
+		switch sc {
+		case "any":
+			return nil
+		case "self":
+			if name == policy.SelfName {
+				return nil
+			}
+		case "descendants":
+			// Same KNOWN GAP as AgentDef's "descendants" — accept on
+			// presence; tighten when RunIdentity gains the parent
+			// lineage walk surface.
+			return nil
+		default:
+			if strings.HasPrefix(sc, "named:") {
+				if strings.TrimPrefix(sc, "named:") == name {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf("ScheduleDef tool: name %q not in this agent's schedule_def_scopes (%v)", name, policy.Scopes)
+}
+
+func (s *ScheduleDef) buildDefinition(name, parentJSON string, overlay json.RawMessage) (mergedScheduleDef, error) {
+	base := mergedScheduleDef{}
+	if parentJSON != "" {
+		if err := json.Unmarshal([]byte(parentJSON), &base); err != nil {
+			return mergedScheduleDef{}, fmt.Errorf("parse parent definition: %w", err)
+		}
+	} else if static, ok := s.Cfg.ScheduledRuns[name]; ok {
+		// Create-with-static-name path is REFUSED in execCreate; this
+		// branch handles fork's bootstrap-from-static when no parent
+		// JSON yet but a static entry exists.
+		base = staticToMergedScheduleDef(static)
+	}
+
+	if len(overlay) > 0 {
+		var ov mergedScheduleDef
+		if err := json.Unmarshal(overlay, &ov); err != nil {
+			return mergedScheduleDef{}, fmt.Errorf("parse overlay: %w", err)
+		}
+		base.applyOverlay(ov)
+	}
+	return base, nil
+}
+
+func (s *ScheduleDef) bootstrapStatic(ctx context.Context, name string, static config.ScheduledRun) (store.ScheduleDefRow, error) {
+	def := staticToMergedScheduleDef(static)
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return store.ScheduleDefRow{}, fmt.Errorf("marshal: %w", err)
+	}
+	ident := tools.RunIdentity(ctx)
+	row := store.ScheduleDefRow{
+		DefID:                  mintDefID(),
+		Name:                   name,
+		Definition:             defJSON,
+		Description:            "bootstrapped from static cfg.ScheduledRuns",
+		CreatedByAgentID:       ident.AgentID,
+		BootstrappedFromStatic: true,
+	}
+	created, err := s.Store.ScheduleDefCreate(ctx, row)
+	if err != nil {
+		return store.ScheduleDefRow{}, err
+	}
+	if err := s.Store.ScheduleDefSetActive(ctx, name, created.DefID, ident.AgentID); err != nil {
+		// Bootstrap succeeded but couldn't promote — return the row;
+		// the next fork iteration finds it via the active pointer
+		// retry. (Same posture as AgentDef.)
+		return created, fmt.Errorf("promote bootstrap: %w", err)
+	}
+	return created, nil
+}
+
+// validateScheduleDef performs the substrate-side cron + on_complete
+// validation that complements the boot-time config validator. Catches
+// runtime-supplied overlays that would otherwise produce broken
+// schedule rows the sweeper can't fire.
+func validateScheduleDef(def mergedScheduleDef) error {
+	if def.Agent == "" {
+		return fmt.Errorf("agent: required")
+	}
+	if def.Schedule != "" && len(def.UserTierSchedules) > 0 {
+		return fmt.Errorf("cannot set both schedule and user_tier_schedules (pick one)")
+	}
+	if def.Schedule != "" {
+		if _, err := cron.ParseStandard(def.Schedule); err != nil {
+			return fmt.Errorf("invalid cron expression %q: %w", def.Schedule, err)
+		}
+	}
+	for tier, cronExpr := range def.UserTierSchedules {
+		if _, err := cron.ParseStandard(cronExpr); err != nil {
+			return fmt.Errorf("user_tier_schedules.%s: invalid cron %q: %w", tier, cronExpr, err)
+		}
+	}
+	if def.CatchUpMax < 0 {
+		return fmt.Errorf("catch_up_max must be >= 0")
+	}
+	for i, h := range def.OnComplete {
+		switch h.Kind {
+		case "channel.publish":
+			if h.Channel == "" {
+				return fmt.Errorf("on_complete[%d]: channel required for channel.publish", i)
+			}
+		case "mcp.call":
+			if h.Server == "" || h.Tool == "" {
+				return fmt.Errorf("on_complete[%d]: server + tool required for mcp.call", i)
+			}
+		case "memory.set":
+			if h.Scope == "" || h.Key == "" {
+				return fmt.Errorf("on_complete[%d]: scope + key required for memory.set", i)
+			}
+		default:
+			return fmt.Errorf("on_complete[%d]: unknown kind %q", i, h.Kind)
+		}
+	}
+	return nil
+}
+
+// assertRequiredCredentials checks the def's required_credentials
+// manifest against the credentials map present in the merged def.
+// Fork-time enforcement: a fork against a template that declares
+// required_credentials: [jobs, slack] but supplies user_credentials:
+// {jobs: ...} only is refused. RFC E sharp edge: loud-fail at fork
+// time, not silent ingestion-time failure when the sweeper fires.
+func assertRequiredCredentials(def mergedScheduleDef) error {
+	if len(def.RequiredCredentials) == 0 {
+		return nil
+	}
+	for _, key := range def.RequiredCredentials {
+		v, ok := def.UserCredentials[key]
+		if !ok || v == "" {
+			return fmt.Errorf("required credential %q missing from user_credentials (template required: %v)", key, def.RequiredCredentials)
+		}
+	}
+	return nil
+}
+
+// ---- response shape ----
+
+func scheduleRowResponse(row store.ScheduleDefRow, promoted bool) map[string]any {
+	m := scheduleRowResponseMap(row)
+	m["promoted"] = promoted
+	return m
+}
+
+func scheduleRowResponseMap(row store.ScheduleDefRow) map[string]any {
+	return map[string]any{
+		"def_id":                   row.DefID,
+		"name":                     row.Name,
+		"version":                  row.Version,
+		"parent_def_id":            row.ParentDefID,
+		"description":              row.Description,
+		"created_at":               row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		"created_by_agent_id":      row.CreatedByAgentID,
+		"retired":                  row.Retired,
+		"bootstrapped_from_static": row.BootstrappedFromStatic,
+		"definition":               row.Definition,
+	}
+}
+
+// ---- mergedScheduleDef: the JSON-tagged persistence shape ----
+//
+// Same conceptual fields as config.ScheduledRun but with JSON tags
+// (snake_case) for the substrate-write path. The lookup.SubstrateScheduleDef
+// adapter mirrors this exactly for read-side round-trip; a drift
+// test pins parity.
+//
+// One additional field beyond config.ScheduledRun: UserCredentials.
+// Forks need a place to store the per-fork credentials map (the
+// counterpart to RFC F's RunInput.UserCredentials at the wire). The
+// scheduler reads this when building RunInput from the schedule row.
+type mergedScheduleDef struct {
+	Agent               string                    `json:"agent,omitempty"`
+	Prompt              []mergedSchedulePromptSeg `json:"prompt,omitempty"`
+	Schedule            string                    `json:"schedule,omitempty"`
+	UserTierSchedules   map[string]string         `json:"user_tier_schedules,omitempty"`
+	RequiredCredentials []string                  `json:"required_credentials,omitempty"`
+	Timezone            string                    `json:"timezone,omitempty"`
+	// Enabled is *bool (not bool) because the overlay-merge path
+	// distinguishes "overlay omits the field" (leave parent's value
+	// alone) from "overlay sets enabled:false explicitly" (disable
+	// the fork). With a plain bool, the JSON zero value (false)
+	// silently clobbered the parent's enabled:true on any partial
+	// overlay — fix landed alongside TestScheduleDefTool_Fork
+	// PreservesEnabledWhenOverlayOmits.
+	Enabled                *bool                `json:"enabled,omitempty"`
+	CatchUpMax             int                  `json:"catch_up_max,omitempty"`
+	UserID                 string               `json:"user_id,omitempty"`
+	UserCredentials        map[string]string    `json:"user_credentials,omitempty"`
+	UserCredentialsFromEnv map[string]string    `json:"user_credentials_from_env,omitempty"`
+	OnComplete             []mergedScheduleHook `json:"on_complete,omitempty"`
+}
+
+// mergedSchedulePromptSeg mirrors config.ScheduledRunSegment with JSON tags.
+type mergedSchedulePromptSeg struct {
+	Role    string                           `json:"role,omitempty"`
+	Content []mergedSchedulePromptSegContent `json:"content,omitempty"`
+}
+
+// mergedSchedulePromptSegContent mirrors config.ScheduledRunSegmentContent.
+type mergedSchedulePromptSegContent struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+// mergedScheduleHook mirrors config.ScheduledRunHook.
+type mergedScheduleHook struct {
+	Kind    string                 `json:"kind,omitempty"`
+	Channel string                 `json:"channel,omitempty"`
+	Server  string                 `json:"server,omitempty"`
+	Tool    string                 `json:"tool,omitempty"`
+	Scope   string                 `json:"scope,omitempty"`
+	Key     string                 `json:"key,omitempty"`
+	Args    map[string]interface{} `json:"args,omitempty"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+func (d *mergedScheduleDef) applyOverlay(ov mergedScheduleDef) {
+	if ov.Agent != "" {
+		d.Agent = ov.Agent
+	}
+	if ov.Prompt != nil {
+		d.Prompt = ov.Prompt
+	}
+	if ov.Schedule != "" {
+		d.Schedule = ov.Schedule
+		// Mutual-exclusion: explicit schedule clears tier schedules.
+		d.UserTierSchedules = nil
+	}
+	if ov.UserTierSchedules != nil {
+		d.UserTierSchedules = ov.UserTierSchedules
+		d.Schedule = ""
+	}
+	if ov.RequiredCredentials != nil {
+		d.RequiredCredentials = ov.RequiredCredentials
+	}
+	if ov.Timezone != "" {
+		d.Timezone = ov.Timezone
+	}
+	if ov.Enabled != nil {
+		d.Enabled = ov.Enabled
+	}
+	if ov.CatchUpMax != 0 {
+		d.CatchUpMax = ov.CatchUpMax
+	}
+	if ov.UserID != "" {
+		d.UserID = ov.UserID
+	}
+	// Credentials maps: partial-merge so fork-with-{slack: "<new>"}
+	// preserves the parent's {jobs, telegram}. Matches RFC E's
+	// worked-example step 6 ("substrate MERGES with the parent fork's
+	// credential map").
+	if len(ov.UserCredentials) > 0 {
+		if d.UserCredentials == nil {
+			d.UserCredentials = make(map[string]string, len(ov.UserCredentials))
+		}
+		for k, v := range ov.UserCredentials {
+			d.UserCredentials[k] = v
+		}
+	}
+	if len(ov.UserCredentialsFromEnv) > 0 {
+		if d.UserCredentialsFromEnv == nil {
+			d.UserCredentialsFromEnv = make(map[string]string, len(ov.UserCredentialsFromEnv))
+		}
+		for k, v := range ov.UserCredentialsFromEnv {
+			d.UserCredentialsFromEnv[k] = v
+		}
+	}
+	if ov.OnComplete != nil {
+		d.OnComplete = ov.OnComplete
+	}
+}
+
+func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
+	enabled := sr.Enabled
+	out := mergedScheduleDef{
+		Agent:                  sr.Agent,
+		Schedule:               sr.Schedule,
+		UserTierSchedules:      sr.UserTierSchedules,
+		RequiredCredentials:    sr.RequiredCredentials,
+		Timezone:               sr.Timezone,
+		Enabled:                &enabled,
+		CatchUpMax:             sr.CatchUpMax,
+		UserID:                 sr.UserID,
+		UserCredentialsFromEnv: sr.UserCredentialsFromEnv,
+	}
+	if len(sr.Prompt) > 0 {
+		out.Prompt = make([]mergedSchedulePromptSeg, len(sr.Prompt))
+		for i, seg := range sr.Prompt {
+			out.Prompt[i].Role = seg.Role
+			if len(seg.Content) > 0 {
+				out.Prompt[i].Content = make([]mergedSchedulePromptSegContent, len(seg.Content))
+				for j, c := range seg.Content {
+					out.Prompt[i].Content[j] = mergedSchedulePromptSegContent{Type: c.Type, Text: c.Text}
+				}
+			}
+		}
+	}
+	if len(sr.OnComplete) > 0 {
+		out.OnComplete = make([]mergedScheduleHook, len(sr.OnComplete))
+		for i, h := range sr.OnComplete {
+			out.OnComplete[i] = mergedScheduleHook{
+				Kind: h.Kind, Channel: h.Channel,
+				Server: h.Server, Tool: h.Tool,
+				Scope: h.Scope, Key: h.Key,
+				Args: h.Args, Payload: h.Payload,
+			}
+		}
+	}
+	return out
+}

--- a/internal/tools/builtin/scheduledef_test.go
+++ b/internal/tools/builtin/scheduledef_test.go
@@ -1,0 +1,382 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// scheduleDefFixture builds a ScheduleDef tool over in-memory SQLite +
+// a stub Config with one yaml template. Returns a ctx with a
+// permissive policy (scopes=[any]); per-test code overrides for
+// scope-specific cases.
+func scheduleDefFixture(t *testing.T) (*ScheduleDef, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Agents: map[string]config.AgentDef{
+			"job-search-batch": {Provider: "anthropic", Model: "claude-haiku-4-5"},
+		},
+		ScheduledRuns: map[string]config.ScheduledRun{
+			"job-search-template": {
+				Agent: "job-search-batch",
+				Prompt: []config.ScheduledRunSegment{
+					{Role: "user", Content: []config.ScheduledRunSegmentContent{
+						{Type: "trusted-text", Text: "run the search"},
+					}},
+				},
+				UserTierSchedules:   map[string]string{"low": "0 6 1 * *", "high": "0 6 * * *"},
+				RequiredCredentials: []string{"jobs", "slack"},
+				Timezone:            "Europe/Berlin",
+				Enabled:             true,
+			},
+		},
+	}
+	tool := &ScheduleDef{
+		Store:               s,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  131072,
+		MaxDescriptionBytes: 8192,
+	}
+	ctx := tools.WithAgentName(context.Background(), "scheduler-orchestrator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: "scheduler-orchestrator",
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func TestScheduleDefTool_CreateRefusedOverStaticName(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"job-search-template","overlay":{"agent":"x","schedule":"0 0 * * *"}}`))
+	if !res.IsError {
+		t.Fatalf("create over static name should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "static cfg.ScheduledRuns") {
+		t.Errorf("refusal should mention static; got %s", res.Text)
+	}
+}
+
+func TestScheduleDefTool_CreateNewName(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc-sched","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"},"description":"weekly digest"}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["name"] != "adhoc-sched" {
+		t.Errorf("name = %v, want adhoc-sched", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("create default promote = false; want true")
+	}
+}
+
+func TestScheduleDefTool_CreateRefusesInvalidCron(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad","overlay":{"agent":"job-search-batch","schedule":"not a cron","user_id":"alice"}}`))
+	if !res.IsError {
+		t.Fatalf("invalid cron should refuse")
+	}
+	if !strings.Contains(res.Text, "invalid cron") {
+		t.Errorf("refusal should mention cron failure; got %s", res.Text)
+	}
+}
+
+func TestScheduleDefTool_CreateRefusesMissingAgent(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"noagent","overlay":{"schedule":"0 0 * * *"}}`))
+	if !res.IsError {
+		t.Fatalf("create without agent should refuse")
+	}
+}
+
+func TestScheduleDefTool_ForkBootstrapsTemplate(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Fork the yaml template — first fork bootstraps v1 from yaml,
+	// then forks v2 with the user's credentials overlay.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","overlay":{"user_id":"alice","user_credentials":{"jobs":"x","slack":"y"}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	// First fork: bootstrap v1 + fork v2. So the returned row is v2.
+	if out["name"] != "job-search-template" {
+		t.Errorf("name = %v, want job-search-template", out["name"])
+	}
+	if v := out["version"].(float64); v != 2 {
+		t.Errorf("version = %v, want 2 (v1 bootstrap + v2 fork)", v)
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("fork default promote = false; want true (schedules auto-promote per RFC E)")
+	}
+}
+
+func TestScheduleDefTool_ForkRefusesMissingRequiredCredentials(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Template requires credentials {jobs, slack}; supply only jobs.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","overlay":{"user_id":"alice","user_credentials":{"jobs":"x"}}}`))
+	if !res.IsError {
+		t.Fatalf("fork with missing required cred should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "required credential") || !strings.Contains(res.Text, "slack") {
+		t.Errorf("refusal should name the missing key; got %s", res.Text)
+	}
+}
+
+func TestScheduleDefTool_ForkPartialCredentialMerge(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// First fork with full credentials.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","overlay":{"user_id":"alice","user_credentials":{"jobs":"j1","slack":"s1"}}}`))
+	if res.IsError {
+		t.Fatalf("first fork: %s", res.Text)
+	}
+	out1 := decodeResult(t, res.Text)
+	v1DefID := out1["def_id"].(string)
+
+	// Second fork rotates ONLY slack — substrate must merge with v2's
+	// credentials map so jobs is preserved.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","parent_def_id":"`+v1DefID+`","overlay":{"user_credentials":{"slack":"s2"}}}`))
+	if res.IsError {
+		t.Fatalf("rotation fork: %s", res.Text)
+	}
+	// Verify the v3 row's persisted definition includes both jobs
+	// (preserved from v2) + slack (rotated from v2's s1 → s2).
+	// ScheduleDefRow.Definition is json.RawMessage; once decoded
+	// through decodeResult's map[string]any path it nests directly
+	// as a sub-map (no base64 wrapping).
+	out2 := decodeResult(t, res.Text)
+	if out2["parent_def_id"].(string) != v1DefID {
+		t.Errorf("parent_def_id = %q, want %q (rotation should chain)", out2["parent_def_id"], v1DefID)
+	}
+	def, ok := out2["definition"].(map[string]any)
+	if !ok {
+		t.Fatalf("definition not a JSON object: %T %v", out2["definition"], out2["definition"])
+	}
+	creds, ok := def["user_credentials"].(map[string]any)
+	if !ok {
+		t.Fatalf("user_credentials missing or not a map: %T %v", def["user_credentials"], def["user_credentials"])
+	}
+	if creds["jobs"] != "j1" {
+		t.Errorf("jobs not preserved from parent fork; got %v, want j1 (RFC E §6: partial merge)", creds["jobs"])
+	}
+	if creds["slack"] != "s2" {
+		t.Errorf("slack not rotated by overlay; got %v, want s2", creds["slack"])
+	}
+}
+
+// TestScheduleDefTool_ForkPreservesEnabledWhenOverlayOmits regresses
+// a self-review bug: applyOverlay used to unconditionally clobber
+// d.Enabled with ov.Enabled. The fork-rotate-credentials path
+// supplies only `user_credentials` in the overlay → ov.Enabled
+// decodes to the zero value (false) → enabled=true template
+// silently became enabled=false in the fork. Fixed by treating
+// Enabled as pointer (*bool) so absence in overlay leaves the
+// parent's value alone; explicit true/false in overlay overrides.
+func TestScheduleDefTool_ForkPreservesEnabledWhenOverlayOmits(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Fork the yaml template (Enabled:true) supplying only credentials.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","overlay":{"user_id":"alice","user_credentials":{"jobs":"x","slack":"y"}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	def, ok := out["definition"].(map[string]any)
+	if !ok {
+		t.Fatalf("definition not a JSON object: %T", out["definition"])
+	}
+	// The yaml template sets enabled:true; the fork's overlay omits
+	// it; the merged def MUST stay enabled. A false here means the
+	// overlay's zero-value boolean clobbered the parent — the exact
+	// bug this test guards against.
+	if enabled, _ := def["enabled"].(bool); !enabled {
+		t.Errorf("enabled=%v in fork — overlay zero-value clobbered the template's enabled:true", def["enabled"])
+	}
+}
+
+func TestScheduleDefTool_NoScopesIsDefaultDeny(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Drop the permissive policy.
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"x","overlay":{"agent":"job-search-batch","schedule":"0 0 * * *","user_id":"alice"}}`))
+	if !res.IsError {
+		t.Fatalf("empty scopes should default-deny")
+	}
+	if !strings.Contains(res.Text, "default-deny") {
+		t.Errorf("refusal should mention default-deny; got %s", res.Text)
+	}
+}
+
+func TestScheduleDefTool_NamedScope(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Restrict to named:adhoc-sched only.
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes: []string{"named:adhoc-sched"},
+	})
+	// Creating the allowed name → ok.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc-sched","overlay":{"agent":"job-search-batch","schedule":"0 0 * * *","user_id":"alice"}}`))
+	if res.IsError {
+		t.Fatalf("named scope should allow matching name; got %s", res.Text)
+	}
+	// Creating a different name → refuse.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"other","overlay":{"agent":"job-search-batch","schedule":"0 0 * * *","user_id":"alice"}}`))
+	if !res.IsError {
+		t.Fatalf("named scope should refuse non-matching name")
+	}
+}
+
+func TestScheduleDefTool_RetireRoundTrip(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Create one.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"retire-test","overlay":{"agent":"job-search-batch","schedule":"0 0 * * *","user_id":"alice"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	defID := out["def_id"].(string)
+
+	// Retire it.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if res.IsError {
+		t.Fatalf("retire: %s", res.Text)
+	}
+	out = decodeResult(t, res.Text)
+	if out["retired"].(bool) != true {
+		t.Errorf("retired = %v, want true", out["retired"])
+	}
+
+	// Un-retire.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":false}`))
+	if res.IsError {
+		t.Fatalf("un-retire: %s", res.Text)
+	}
+	out = decodeResult(t, res.Text)
+	if out["retired"].(bool) != false {
+		t.Errorf("retired = %v, want false", out["retired"])
+	}
+}
+
+func TestScheduleDefTool_ListReturnsVersions(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Create 3 versions via create+fork+fork.
+	for i := 0; i < 3; i++ {
+		op := `create`
+		if i > 0 {
+			op = `fork`
+		}
+		_, _ = tool.Execute(ctx, json.RawMessage(`{"op":"`+op+`","name":"multi","overlay":{"agent":"job-search-batch","schedule":"0 0 * * *","user_id":"alice"}}`))
+	}
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"multi"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	versions := out["versions"].([]any)
+	if len(versions) != 3 {
+		t.Errorf("got %d versions, want 3", len(versions))
+	}
+}
+
+// TestMergedScheduleDef_DriftDetection_VsLookupSubstrateScheduleDef
+// pins json-tag parity between mergedScheduleDef (this package — the
+// substrate-write shape) and lookup.SubstrateScheduleDef (the
+// substrate-read adapter). A field added to either side without the
+// matching addition fails this test instead of silently dropping at
+// the JSON boundary.
+//
+// Two fields are intentionally NOT mirrored: `user_credentials` only
+// exists in mergedScheduleDef (forks store credentials in the
+// substrate row; the lookup path returns a config.ScheduledRun which
+// does NOT have credentials — credentials flow into RunInput at the
+// scheduler's sweeper-fire seam, not through the config layer).
+// Listed in the exempt set with explicit rationale.
+func TestMergedScheduleDef_DriftDetection_VsLookupSubstrateScheduleDef(t *testing.T) {
+	exempt := map[string]bool{
+		// user_credentials lives only in the substrate-write shape;
+		// the read side (config.ScheduledRun) has no credentials
+		// field. The scheduler's RunInput build step reads it from
+		// the SubstrateScheduleDef adapter at sweeper-fire time —
+		// but that's a future PR's runtime path, not a config-layer
+		// concern. Keeping credentials out of config.ScheduledRun
+		// also prevents accidental yaml-side credential exposure.
+		"user_credentials": true,
+	}
+
+	mergedTags := scheduleJsonTagsOf(reflect.TypeOf(mergedScheduleDef{}))
+	substrateTags := scheduleJsonTagsOf(reflect.TypeOf(lookup.SubstrateScheduleDef{}))
+
+	for tag := range mergedTags {
+		if exempt[tag] {
+			continue
+		}
+		if !substrateTags[tag] {
+			t.Errorf("mergedScheduleDef has json tag %q but lookup.SubstrateScheduleDef does not — either mirror it on the lookup side OR add %q to the exempt set with a justifying comment",
+				tag, tag)
+		}
+	}
+	for tag := range substrateTags {
+		if !mergedTags[tag] {
+			t.Errorf("lookup.SubstrateScheduleDef has json tag %q but mergedScheduleDef does not — substrate-write is the source-of-truth shape; remove from SubstrateScheduleDef OR add the field to mergedScheduleDef in this package",
+				tag)
+		}
+	}
+}
+
+// scheduleJsonTagsOf mirrors jsonTagsOfFields in agentdef_test.go;
+// duplicated here because that helper is package-private and reusing
+// it would require widening test-helper visibility.
+func scheduleJsonTagsOf(t reflect.Type) map[string]bool {
+	out := map[string]bool{}
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		for j, c := range tag {
+			if c == ',' {
+				tag = tag[:j]
+				break
+			}
+		}
+		out[tag] = true
+	}
+	return out
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -575,6 +575,29 @@ func AgentDefPolicy(ctx context.Context) AgentDefPolicyValue {
 	return v
 }
 
+type ctxKeyScheduleDefPolicy struct{}
+
+// ScheduleDefPolicyValue is the per-agent ScheduleDef-tool access
+// policy (v1.x RFC E). Same shape as AgentDefPolicyValue + same
+// "self / descendants / named:<n> / any" closed scope set.
+// Default-deny when Scopes is empty.
+type ScheduleDefPolicyValue struct {
+	Scopes   []string
+	SelfName string
+}
+
+// WithScheduleDefPolicy attaches the policy to ctx.
+func WithScheduleDefPolicy(ctx context.Context, p ScheduleDefPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyScheduleDefPolicy{}, p)
+}
+
+// ScheduleDefPolicy returns the policy from ctx. Zero value =
+// default-deny.
+func ScheduleDefPolicy(ctx context.Context) ScheduleDefPolicyValue {
+	v, _ := ctx.Value(ctxKeyScheduleDefPolicy{}).(ScheduleDefPolicyValue)
+	return v
+}
+
 // ctxKeySkillDefPolicy carries the v0.8.22 SkillDef-tool capability
 // gate. Mirrors AgentDefPolicy shape, sans the SelfName field —
 // skills have no agent identity so a "self" scope is meaningless.


### PR DESCRIPTION
**STACKED ON #263** — base branch is \`feat-scheduled-agent-runs\` (PR #263).

**⚠ Action required before merge:** once #263 lands on main, run \`gh pr edit <this#> --base main\`. **DO NOT merge with the current base** — the squash button would target #263's feature branch, not main (the GitHub "Merged" badge is misleading in that case; the change would never reach main). This is the same stacked-PR footgun that hit PRs #140-#142 + #144-#146 in May 2026.

## Summary

PR 2 of the RFC E ScheduleDef substrate series. PR #263 shipped the data layer (tables, store methods, lookup resolver, drift test, config validation, robfig/cron dep). This PR ships:

- **\`internal/tools/builtin/scheduledef.go\`** — 5-op built-in tool (create / fork / get / list / retire) over the store layer
- **HTTP admin endpoint** \`POST /v1/_scheduledef\` + \`GET /v1/_scheduledef/names\` enumeration
- **Connector interface method** \`ScheduleDef(ctx, input)\` — the seam HTTP/gRPC/MCP/TS all dispatch through (mirrors AgentDef/SkillDef/MCPServerDef)
- **Scope policy ctx wiring** \`tools.WithScheduleDefPolicy\` + default-deny enforcement
- **Drift test** pinning \`mergedScheduleDef\` ↔ \`lookup.SubstrateScheduleDef\` JSON-tag parity via reflection
- **12 feature tests** for the tool + **3 HTTP admin tests** + **3 Connector-interface-mock stubs** across grpc/mcp test files

## Substrate-pattern-of-substrates parity

This is the fourth substrate primitive. Side-by-side shape:

| Concern | AgentDef (v0.8.5) | ScheduleDef (this PR) |
|---|---|---|
| 5+ ops with op-discriminated JSON | 6 ops | 5 ops (no \`promote\` — fork auto-promotes per RFC E; no \`verify\` — no \`content_sha256\` in v1.x) |
| Static yaml entry refused at \`create\` | ✓ | ✓ |
| Bootstrap-from-yaml at first \`fork\` | ✓ | ✓ |
| Default-deny scope (\`self / descendants / named:X / any\`) | ✓ | ✓ |
| Operator-trust HTTP admin endpoint | \`POST /v1/_agentdef\` | \`POST /v1/_scheduledef\` |
| Names enumeration | \`GET /v1/_agentdef/names\` | \`GET /v1/_scheduledef/names\` |
| Drift test against the read-side adapter | ✓ | ✓ |

ScheduleDef has one extra concern over AgentDef: **\`required_credentials\` manifest enforcement at fork time**. A template declaring \`required_credentials: [jobs, slack]\` rejects a fork that supplies only \`{jobs: ...}\` with a loud error, rather than letting the run fail at sweeper-fire time when the MCP server returns 401. The RFC E sharp edge is "loud-fail at fork time, not silent ingestion-time failure."

## Self-review fix included

Caught a real bug during the self-review pass: \`applyOverlay\` had \`d.Enabled = ov.Enabled\` (unconditional), which silently clobbered the parent's \`enabled:true\` whenever a fork overlay omitted the field (which is most of the time — typical overlays only set credentials + user_id). Changed to \`*bool\` so absence-in-overlay leaves the parent value alone, with \`TestScheduleDefTool_ForkPreservesEnabledWhenOverlayOmits\` as a regression test that fails on the unfixed code.

## What's next in the RFC E series (separate PRs)

- **PR 3** (E.5 + remaining E.6 transports): \`internal/scheduler/\` package + sweeper + cron parser + \`on_complete\` dispatch; gRPC \`ScheduleDef\` RPC + MCP \`scheduledef\` meta-tool + \`@loomcycle/client.scheduleDef()\` adapter
- **PR 4** (Web UI): \`/ui/schedules\` admin tab (mirrors \`/ui/library\` shape)

## Test plan

- [x] \`go test ./...\` — 52 packages pass, 0 failures
- [x] \`go vet ./...\` clean
- [x] \`gofmt -l\` clean
- [x] 12 feature tests cover: static-name refusal, valid/invalid cron at create, bootstrap-from-yaml at first fork, required_credentials enforcement, partial credential merge, enabled preservation, scope policy (default-deny + named scope), retire round-trip, list versions, drift test
- [x] 3 HTTP admin tests cover: happy-path create over POST /v1/_scheduledef, names enumeration over GET /v1/_scheduledef/names, not-configured fallback
- [x] Connector mock stubs updated in 3 test files so the interface change builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)