### PR TITLE
feat(rfc-e): ScheduleDef 4-transport CRUD — gRPC + MCP + TS adapter

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -641,6 +641,42 @@ export class LoomcycleClient {
     return postJSON<SubstrateToolResponse>(this.ctx, "/v1/_mcpserverdef", input, opts);
   }
 
+  /** Invoke the v1.x RFC E ScheduleDef substrate tool over HTTP.
+   *  Author + fork + retire scheduled-run definitions at runtime.
+   *  Mirror of {@link LoomcycleClient.agentDef} for schedules — the
+   *  primary use case is JobEmber-style "fork a yaml template
+   *  per-user with their bearer + tier cron" workflows.
+   *
+   *  Operator-admin-only: this endpoint requires the bearer token.
+   *
+   *  Op-discriminated input: `{op: "create" | "fork" | "get" |
+   *  "list" | "retire", ...}`. Note that ScheduleDef has 5 ops
+   *  (no separate `promote` — forks auto-promote by default per
+   *  RFC E's worked example; no `verify` — no content_sha256 in
+   *  v1.x).
+   *
+   *  Sharp edges (substrate refuses these):
+   *  - Name colliding with a static cfg.ScheduledRuns entry is
+   *    refused on `create` (yaml is ground truth; use `fork` to
+   *    derive a new version).
+   *  - Fork against a template with `required_credentials` must
+   *    supply all keys in `user_credentials` — loud-fail at fork
+   *    time rather than silent ingestion-time failure when the
+   *    sweeper fires.
+   *  - Cron syntax is validated server-side; invalid expressions
+   *    refuse with a parse error.
+   *
+   *  Raises {@link SubstrateToolRefusedError} on tool-level refusals
+   *  (static-name collision, missing required credential, invalid
+   *  cron, etc.); {@link InvalidArgumentError} on 400 (malformed
+   *  JSON); {@link AuthError} on 401. */
+  async scheduleDef(
+    input: SubstrateToolInput,
+    opts?: { signal?: AbortSignal },
+  ): Promise<SubstrateToolResponse> {
+    return postJSON<SubstrateToolResponse>(this.ctx, "/v1/_scheduledef", input, opts);
+  }
+
   // ---- v0.10.3 Library v2 enumeration (read-only, merged yaml+substrate) ----
 
   /** List every agent the runtime knows about — yaml-static + dynamic

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -42,9 +42,11 @@
  *     listRunInterrupts(runId, opts?): Promise<InterruptListResponse>
  *     resolveInterrupt(runId, interruptId, opts): Promise<unknown>
  *
- *     // Substrate admin (v0.8.22)
+ *     // Substrate admin (v0.8.22; mcpServerDef v0.9.x; scheduleDef v1.x)
  *     agentDef(input): Promise<SubstrateToolResponse>
  *     skillDef(input): Promise<SubstrateToolResponse>
+ *     mcpServerDef(input): Promise<SubstrateToolResponse>
+ *     scheduleDef(input): Promise<SubstrateToolResponse>
  *
  *     // Library v2 enumeration (v0.10.3 — yaml+substrate merged)
  *     listLibraryAgents(): Promise<LibraryListResponse<LibraryAgentDefinition>>

--- a/adapters/ts/tests/substrate.test.ts
+++ b/adapters/ts/tests/substrate.test.ts
@@ -142,3 +142,81 @@ describe("skillDef", () => {
     ).rejects.toBeInstanceOf(UnavailableError);
   });
 });
+
+// v1.x RFC E ScheduleDef — mirror of agentDef + skillDef. Fork
+// auto-promotes by default per RFC E's worked example, so the
+// happy-path response shape includes `promoted: true`.
+describe("scheduleDef", () => {
+  it("posts JSON to /v1/_scheduledef and returns the row envelope", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        def_id: "sd_abc",
+        name: "job-search-alice",
+        version: 1,
+        promoted: true,
+      }),
+    ]);
+
+    const result = (await client.scheduleDef({
+      op: "create",
+      name: "job-search-alice",
+      overlay: {
+        agent: "researcher",
+        schedule: "0 6 * * *",
+        user_id: "alice",
+      },
+    })) as Record<string, unknown>;
+
+    expect(result.def_id).toBe("sd_abc");
+    expect(result.name).toBe("job-search-alice");
+    expect(result.version).toBe(1);
+    expect(result.promoted).toBe(true);
+
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe("http://test-loomcycle:8787/v1/_scheduledef");
+    expect((call[1] as RequestInit).method).toBe("POST");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.op).toBe("create");
+    expect(body.overlay.schedule).toBe("0 6 * * *");
+  });
+
+  it("raises SubstrateToolRefusedError when fork hits required_credentials gate", async () => {
+    const refusalBody = JSON.stringify({
+      code: "tool_refused",
+      tool: "ScheduleDef",
+      error:
+        'fork: required credential "slack" missing from user_credentials (template required: [jobs slack])',
+    });
+    const { client } = makeClient([
+      () =>
+        new Response(refusalBody, {
+          status: 422,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+
+    let caught: unknown;
+    try {
+      await client.scheduleDef({
+        op: "fork",
+        name: "job-search-template",
+        overlay: { user_id: "alice", user_credentials: { jobs: "x" } },
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(SubstrateToolRefusedError);
+    const err = caught as SubstrateToolRefusedError;
+    expect(err.tool).toBe("ScheduleDef");
+    expect(err.message).toContain("required credential");
+    expect(err.message).toContain("slack");
+  });
+
+  it("forwards bearer auth in the Authorization header", async () => {
+    const { client, fetchMock } = makeClient([jsonResponse({ ok: true })]);
+    await client.scheduleDef({ op: "list", name: "job-search-template" });
+    const headers = (fetchMock.mock.calls[0]![1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-bearer");
+  });
+});

--- a/internal/api/grpc/loomcyclepb/loomcycle.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle.pb.go
@@ -4649,7 +4649,7 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\bscope_id\x18\x03 \x01(\tR\ascopeId\x12\x16\n" +
 	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"$\n" +
 	"\x12AckChannelResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok2\xb3\x12\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok2\x83\x13\n" +
 	"\tLoomcycle\x126\n" +
 	"\x03Run\x12\x18.loomcycle.v1.RunRequest\x1a\x13.loomcycle.v1.Event0\x01\x12@\n" +
 	"\bContinue\x12\x1d.loomcycle.v1.ContinueRequest\x1a\x13.loomcycle.v1.Event0\x01\x12M\n" +
@@ -4673,7 +4673,8 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\x0eDeleteSnapshot\x12#.loomcycle.v1.DeleteSnapshotRequest\x1a$.loomcycle.v1.DeleteSnapshotResponse\x12K\n" +
 	"\bAgentDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12K\n" +
 	"\bSkillDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12O\n" +
-	"\fMCPServerDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12U\n" +
+	"\fMCPServerDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12N\n" +
+	"\vScheduleDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12U\n" +
 	"\fListChannels\x12!.loomcycle.v1.ListChannelsRequest\x1a\".loomcycle.v1.ListChannelsResponse\x12^\n" +
 	"\x13StreamUserRunStates\x12(.loomcycle.v1.StreamUserRunStatesRequest\x1a\x1b.loomcycle.v1.RunStateEvent0\x01\x12[\n" +
 	"\x0ePublishChannel\x12#.loomcycle.v1.PublishChannelRequest\x1a$.loomcycle.v1.PublishChannelResponse\x12a\n" +
@@ -4815,42 +4816,44 @@ var file_loomcycle_proto_depIdxs = []int32{
 	47, // 48: loomcycle.v1.Loomcycle.AgentDef:input_type -> loomcycle.v1.SubstrateRequest
 	47, // 49: loomcycle.v1.Loomcycle.SkillDef:input_type -> loomcycle.v1.SubstrateRequest
 	47, // 50: loomcycle.v1.Loomcycle.MCPServerDef:input_type -> loomcycle.v1.SubstrateRequest
-	49, // 51: loomcycle.v1.Loomcycle.ListChannels:input_type -> loomcycle.v1.ListChannelsRequest
-	52, // 52: loomcycle.v1.Loomcycle.StreamUserRunStates:input_type -> loomcycle.v1.StreamUserRunStatesRequest
-	54, // 53: loomcycle.v1.Loomcycle.PublishChannel:input_type -> loomcycle.v1.PublishChannelRequest
-	56, // 54: loomcycle.v1.Loomcycle.SubscribeChannel:input_type -> loomcycle.v1.SubscribeChannelRequest
-	59, // 55: loomcycle.v1.Loomcycle.PeekChannel:input_type -> loomcycle.v1.PeekChannelRequest
-	61, // 56: loomcycle.v1.Loomcycle.AckChannel:input_type -> loomcycle.v1.AckChannelRequest
-	5,  // 57: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
-	5,  // 58: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
-	11, // 59: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
-	14, // 60: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
-	17, // 61: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
-	19, // 62: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
-	21, // 63: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
-	23, // 64: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
-	26, // 65: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
-	28, // 66: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
-	30, // 67: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
-	32, // 68: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
-	34, // 69: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
-	36, // 70: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
-	38, // 71: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
-	40, // 72: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
-	42, // 73: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
-	44, // 74: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
-	46, // 75: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
-	48, // 76: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 77: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 78: loomcycle.v1.Loomcycle.MCPServerDef:output_type -> loomcycle.v1.SubstrateResponse
-	50, // 79: loomcycle.v1.Loomcycle.ListChannels:output_type -> loomcycle.v1.ListChannelsResponse
-	53, // 80: loomcycle.v1.Loomcycle.StreamUserRunStates:output_type -> loomcycle.v1.RunStateEvent
-	55, // 81: loomcycle.v1.Loomcycle.PublishChannel:output_type -> loomcycle.v1.PublishChannelResponse
-	57, // 82: loomcycle.v1.Loomcycle.SubscribeChannel:output_type -> loomcycle.v1.SubscribeChannelResponse
-	60, // 83: loomcycle.v1.Loomcycle.PeekChannel:output_type -> loomcycle.v1.PeekChannelResponse
-	62, // 84: loomcycle.v1.Loomcycle.AckChannel:output_type -> loomcycle.v1.AckChannelResponse
-	57, // [57:85] is the sub-list for method output_type
-	29, // [29:57] is the sub-list for method input_type
+	47, // 51: loomcycle.v1.Loomcycle.ScheduleDef:input_type -> loomcycle.v1.SubstrateRequest
+	49, // 52: loomcycle.v1.Loomcycle.ListChannels:input_type -> loomcycle.v1.ListChannelsRequest
+	52, // 53: loomcycle.v1.Loomcycle.StreamUserRunStates:input_type -> loomcycle.v1.StreamUserRunStatesRequest
+	54, // 54: loomcycle.v1.Loomcycle.PublishChannel:input_type -> loomcycle.v1.PublishChannelRequest
+	56, // 55: loomcycle.v1.Loomcycle.SubscribeChannel:input_type -> loomcycle.v1.SubscribeChannelRequest
+	59, // 56: loomcycle.v1.Loomcycle.PeekChannel:input_type -> loomcycle.v1.PeekChannelRequest
+	61, // 57: loomcycle.v1.Loomcycle.AckChannel:input_type -> loomcycle.v1.AckChannelRequest
+	5,  // 58: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
+	5,  // 59: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
+	11, // 60: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
+	14, // 61: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
+	17, // 62: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
+	19, // 63: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
+	21, // 64: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
+	23, // 65: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
+	26, // 66: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
+	28, // 67: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
+	30, // 68: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
+	32, // 69: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
+	34, // 70: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
+	36, // 71: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
+	38, // 72: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
+	40, // 73: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
+	42, // 74: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
+	44, // 75: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
+	46, // 76: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
+	48, // 77: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 78: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 79: loomcycle.v1.Loomcycle.MCPServerDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 80: loomcycle.v1.Loomcycle.ScheduleDef:output_type -> loomcycle.v1.SubstrateResponse
+	50, // 81: loomcycle.v1.Loomcycle.ListChannels:output_type -> loomcycle.v1.ListChannelsResponse
+	53, // 82: loomcycle.v1.Loomcycle.StreamUserRunStates:output_type -> loomcycle.v1.RunStateEvent
+	55, // 83: loomcycle.v1.Loomcycle.PublishChannel:output_type -> loomcycle.v1.PublishChannelResponse
+	57, // 84: loomcycle.v1.Loomcycle.SubscribeChannel:output_type -> loomcycle.v1.SubscribeChannelResponse
+	60, // 85: loomcycle.v1.Loomcycle.PeekChannel:output_type -> loomcycle.v1.PeekChannelResponse
+	62, // 86: loomcycle.v1.Loomcycle.AckChannel:output_type -> loomcycle.v1.AckChannelResponse
+	58, // [58:87] is the sub-list for method output_type
+	29, // [29:58] is the sub-list for method input_type
 	29, // [29:29] is the sub-list for extension type_name
 	29, // [29:29] is the sub-list for extension extendee
 	0,  // [0:29] is the sub-list for field type_name

--- a/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
@@ -60,6 +60,7 @@ const (
 	Loomcycle_AgentDef_FullMethodName            = "/loomcycle.v1.Loomcycle/AgentDef"
 	Loomcycle_SkillDef_FullMethodName            = "/loomcycle.v1.Loomcycle/SkillDef"
 	Loomcycle_MCPServerDef_FullMethodName        = "/loomcycle.v1.Loomcycle/MCPServerDef"
+	Loomcycle_ScheduleDef_FullMethodName         = "/loomcycle.v1.Loomcycle/ScheduleDef"
 	Loomcycle_ListChannels_FullMethodName        = "/loomcycle.v1.Loomcycle/ListChannels"
 	Loomcycle_StreamUserRunStates_FullMethodName = "/loomcycle.v1.Loomcycle/StreamUserRunStates"
 	Loomcycle_PublishChannel_FullMethodName      = "/loomcycle.v1.Loomcycle/PublishChannel"
@@ -197,6 +198,12 @@ type LoomcycleClient interface {
 	// AgentDef + SkillDef (op-discriminated input_json + is_error
 	// tool refusals in the response).
 	MCPServerDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error)
+	// ScheduleDef dispatches to the v1.x RFC E scheduled-runs
+	// substrate. Mirrors POST /v1/_scheduledef. Operator-admin-only.
+	// Same SubstrateRequest body shape — op-discriminated input_json
+	// (create / fork / get / list / retire) + is_error tool refusals
+	// in the response.
+	ScheduleDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error)
 	// ----- v0.9.x n8n RFC Phase 0 -----
 	//
 	// ListChannels mirrors GET /v1/_channels — operator-declared
@@ -472,6 +479,16 @@ func (c *loomcycleClient) MCPServerDef(ctx context.Context, in *SubstrateRequest
 	return out, nil
 }
 
+func (c *loomcycleClient) ScheduleDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SubstrateResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_ScheduleDef_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *loomcycleClient) ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListChannelsResponse)
@@ -670,6 +687,12 @@ type LoomcycleServer interface {
 	// AgentDef + SkillDef (op-discriminated input_json + is_error
 	// tool refusals in the response).
 	MCPServerDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error)
+	// ScheduleDef dispatches to the v1.x RFC E scheduled-runs
+	// substrate. Mirrors POST /v1/_scheduledef. Operator-admin-only.
+	// Same SubstrateRequest body shape — op-discriminated input_json
+	// (create / fork / get / list / retire) + is_error tool refusals
+	// in the response.
+	ScheduleDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error)
 	// ----- v0.9.x n8n RFC Phase 0 -----
 	//
 	// ListChannels mirrors GET /v1/_channels — operator-declared
@@ -772,6 +795,9 @@ func (UnimplementedLoomcycleServer) SkillDef(context.Context, *SubstrateRequest)
 }
 func (UnimplementedLoomcycleServer) MCPServerDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method MCPServerDef not implemented")
+}
+func (UnimplementedLoomcycleServer) ScheduleDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ScheduleDef not implemented")
 }
 func (UnimplementedLoomcycleServer) ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListChannels not implemented")
@@ -1194,6 +1220,24 @@ func _Loomcycle_MCPServerDef_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Loomcycle_ScheduleDef_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SubstrateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).ScheduleDef(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_ScheduleDef_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).ScheduleDef(ctx, req.(*SubstrateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Loomcycle_ListChannels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListChannelsRequest)
 	if err := dec(in); err != nil {
@@ -1381,6 +1425,10 @@ var Loomcycle_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "MCPServerDef",
 			Handler:    _Loomcycle_MCPServerDef_Handler,
+		},
+		{
+			MethodName: "ScheduleDef",
+			Handler:    _Loomcycle_ScheduleDef_Handler,
 		},
 		{
 			MethodName: "ListChannels",

--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -54,6 +54,10 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 	ctx = tools.WithSkillDefPolicy(ctx, tools.SkillDefPolicyValue{
 		Scopes: []string{"any"},
 	})
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: grpcSubstrateAdminAgentName,
+	})
 	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{
 		Scopes: []string{"submit_self", "submit_descendants", "submit_any", "read_any"},
 	})
@@ -105,6 +109,20 @@ func (s *Server) SkillDef(ctx context.Context, req *loomcyclepb.SubstrateRequest
 func (s *Server) MCPServerDef(ctx context.Context, req *loomcyclepb.SubstrateRequest) (*loomcyclepb.SubstrateResponse, error) {
 	return s.dispatchSubstrateRPC(ctx, "MCPServerDef", req, func(ctx context.Context, in json.RawMessage) (json.RawMessage, bool, error) {
 		res, err := s.connector.MCPServerDef(ctx, in)
+		if err != nil {
+			return nil, false, err
+		}
+		return json.RawMessage(res.Text), res.IsError, nil
+	})
+}
+
+// ScheduleDef serves the v1.x RFC E ScheduleDef gRPC RPC —
+// scheduled-runs substrate. Same shape as the other three substrate
+// RPCs; op-discriminated input_json (create / fork / get / list /
+// retire) routes via the Connector to the in-process tool.
+func (s *Server) ScheduleDef(ctx context.Context, req *loomcyclepb.SubstrateRequest) (*loomcyclepb.SubstrateResponse, error) {
+	return s.dispatchSubstrateRPC(ctx, "ScheduleDef", req, func(ctx context.Context, in json.RawMessage) (json.RawMessage, bool, error) {
+		res, err := s.connector.ScheduleDef(ctx, in)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/api/grpc/substrate_test.go
+++ b/internal/api/grpc/substrate_test.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -21,14 +22,17 @@ import (
 type substrateMock struct {
 	mockConnector
 
-	gotAgentDefInput json.RawMessage
-	gotSkillDefInput json.RawMessage
+	gotAgentDefInput    json.RawMessage
+	gotSkillDefInput    json.RawMessage
+	gotScheduleDefInput json.RawMessage
 
-	agentDefResult connector.ToolResult
-	skillDefResult connector.ToolResult
+	agentDefResult    connector.ToolResult
+	skillDefResult    connector.ToolResult
+	scheduleDefResult connector.ToolResult
 
-	agentDefErr error
-	skillDefErr error
+	agentDefErr    error
+	skillDefErr    error
+	scheduleDefErr error
 }
 
 func (m *substrateMock) AgentDef(_ context.Context, in json.RawMessage) (connector.ToolResult, error) {
@@ -39,6 +43,11 @@ func (m *substrateMock) AgentDef(_ context.Context, in json.RawMessage) (connect
 func (m *substrateMock) SkillDef(_ context.Context, in json.RawMessage) (connector.ToolResult, error) {
 	m.gotSkillDefInput = in
 	return m.skillDefResult, m.skillDefErr
+}
+
+func (m *substrateMock) ScheduleDef(_ context.Context, in json.RawMessage) (connector.ToolResult, error) {
+	m.gotScheduleDefInput = in
+	return m.scheduleDefResult, m.scheduleDefErr
 }
 
 func TestGrpcAgentDef_HappyPath(t *testing.T) {
@@ -88,6 +97,33 @@ func TestGrpcSkillDef_HappyPath(t *testing.T) {
 		t.Errorf("is_error = true, want false")
 	}
 	if string(resp.GetOutputJson()) != `{"def_id":"sdf_abc","name":"voice-applier","version":1}` {
+		t.Errorf("output_json = %s", resp.GetOutputJson())
+	}
+}
+
+func TestGrpcScheduleDef_HappyPath(t *testing.T) {
+	mc := &substrateMock{
+		scheduleDefResult: connector.ToolResult{
+			Text:    `{"def_id":"sd_abc","name":"job-search-alice","version":1,"promoted":true}`,
+			IsError: false,
+		},
+	}
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ScheduleDef(context.Background(), &loomcyclepb.SubstrateRequest{
+		InputJson: []byte(`{"op":"create","name":"job-search-alice","overlay":{"agent":"researcher","schedule":"0 6 * * *","user_id":"alice"}}`),
+	})
+	if err != nil {
+		t.Fatalf("ScheduleDef: %v", err)
+	}
+	if resp.GetIsError() {
+		t.Errorf("is_error = true, want false")
+	}
+	if string(mc.gotScheduleDefInput) == "" {
+		t.Errorf("connector wasn't called with the input")
+	}
+	if string(resp.GetOutputJson()) != `{"def_id":"sd_abc","name":"job-search-alice","version":1,"promoted":true}` {
 		t.Errorf("output_json = %s", resp.GetOutputJson())
 	}
 }
@@ -155,11 +191,17 @@ func TestGrpcSubstrate_RejectsMalformedJSON(t *testing.T) {
 type realToolConnector struct {
 	mockConnector
 
-	skillTool *builtin.SkillDef
+	skillTool    *builtin.SkillDef
+	scheduleTool *builtin.ScheduleDef
 }
 
 func (c *realToolConnector) SkillDef(ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 	res, err := c.skillTool.Execute(ctx, in)
+	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, err
+}
+
+func (c *realToolConnector) ScheduleDef(ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+	res, err := c.scheduleTool.Execute(ctx, in)
 	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, err
 }
 
@@ -195,5 +237,36 @@ func TestGrpcSubstrate_OperatorCtxLetsRealToolThrough(t *testing.T) {
 	}
 	if resp.GetIsError() {
 		t.Errorf("is_error = true with output_json = %s — gRPC ctx synthesis didn't grant scope=[any]", resp.GetOutputJson())
+	}
+}
+
+// TestGrpcSubstrate_ScheduleDefCtxSynthesis is the same regression
+// for ScheduleDef as the SkillDef test above. If the gRPC handler
+// forgets to stamp WithScheduleDefPolicy (added in this PR), the
+// in-process tool's default-deny scope gate refuses the call and
+// returns is_error=true.
+func TestGrpcSubstrate_ScheduleDefCtxSynthesis(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	scheduleTool := &builtin.ScheduleDef{
+		Store: st,
+		Cfg:   &config.Config{},
+	}
+	mc := &realToolConnector{scheduleTool: scheduleTool}
+
+	client, cleanup := startTestServerWithConnector(t, mc)
+	defer cleanup()
+
+	resp, err := client.ScheduleDef(context.Background(), &loomcyclepb.SubstrateRequest{
+		InputJson: []byte(`{"op":"list","name":"unknown-schedule"}`),
+	})
+	if err != nil {
+		t.Fatalf("ScheduleDef: %v", err)
+	}
+	if resp.GetIsError() {
+		t.Errorf("is_error = true with output_json = %s — gRPC ctx synthesis didn't grant ScheduleDef scope=[any]", resp.GetOutputJson())
 	}
 }

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -50,6 +50,13 @@ var handlersByName = map[string]toolHandler{
 	"mcpserverdef": wrapBuiltin("mcpserverdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.MCPServerDef(ctx, in)
 	}),
+	// v1.x RFC E scheduled-runs substrate. Same operator-admin-only
+	// posture; lets external orchestrators (e.g. JobEmber's user-
+	// signup pipeline) author per-user forks of yaml templates over
+	// MCP without going through the HTTP admin endpoint.
+	"scheduledef": wrapBuiltin("scheduledef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.ScheduleDef(ctx, in)
+	}),
 	"evaluation": wrapBuiltin("evaluation", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.Evaluation(ctx, in)
 	}),

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -278,15 +278,15 @@ func TestServer_ToolsList_Returns33Tools(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 33 {
-		t.Errorf("got %d tools, want 33 (v0.9.x adds list_channels + stream_user_run_states + mcpserverdef + publish_channel + subscribe_channel + peek_channel + ack_channel)", len(result.Tools))
+	if len(result.Tools) != 34 {
+		t.Errorf("got %d tools, want 34 (v1.x adds scheduledef on top of v0.9.x's list_channels + stream_user_run_states + mcpserverdef + publish_channel + subscribe_channel + peek_channel + ack_channel)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
-	// Spot-check across categories — through the v0.9.x additions.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
+	// Spot-check across categories — through the v1.x additions.
+	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -153,6 +153,11 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			InputSchema: rawJSON(`{"type": "object"}`),
 		},
 		{
+			Name:        "scheduledef",
+			Description: "ScheduleDef tool ops (create/fork/get/list/retire). v1.x RFC E scheduled-runs substrate. Operator-admin-only — author + fork per-user schedules at runtime. Forks auto-promote by default (schedule versioning model differs from agent/skill where promote is a separate step). Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
 			Name:        "evaluation",
 			Description: "Evaluation tool ops (submit/get/list_for_run/list_for_def/aggregate). Pass-through.",
 			InputSchema: rawJSON(`{"type": "object"}`),

--- a/proto/loomcycle.proto
+++ b/proto/loomcycle.proto
@@ -203,6 +203,13 @@ service Loomcycle {
   // tool refusals in the response).
   rpc MCPServerDef(SubstrateRequest) returns (SubstrateResponse);
 
+  // ScheduleDef dispatches to the v1.x RFC E scheduled-runs
+  // substrate. Mirrors POST /v1/_scheduledef. Operator-admin-only.
+  // Same SubstrateRequest body shape — op-discriminated input_json
+  // (create / fork / get / list / retire) + is_error tool refusals
+  // in the response.
+  rpc ScheduleDef(SubstrateRequest) returns (SubstrateResponse);
+
   // ----- v0.9.x n8n RFC Phase 0 -----
   //
   // ListChannels mirrors GET /v1/_channels — operator-declared


### PR DESCRIPTION
## Summary

PR 4 of the RFC E ScheduleDef series. Completes the 4-transport substrate-pattern parity: HTTP (PR #264) + gRPC + MCP meta-tool + TS adapter all dispatch through the single \`Connector.ScheduleDef\` method that PR #264 added.

**Transports added in this PR**:
- **gRPC** \`ScheduleDef\` RPC mirroring \`AgentDef\` / \`SkillDef\` / \`MCPServerDef\`
- **MCP** \`scheduledef\` meta-tool — external orchestrators (Claude Code, n8n) can author + fork schedules without an HTTP client
- **TS adapter** \`client.scheduleDef()\` method with JSDoc covering the 5 ops + sharp edges + error class mapping

## Substrate-pattern parity (4-transport)

ScheduleDef is the fourth substrate primitive after AgentDef (v0.8.5) / SkillDef (v0.8.22) / MCPServerDef (v0.9.2). With this PR, all four substrates have the full 4-transport CRUD surface:

| Substrate | HTTP | gRPC | MCP | TS adapter |
|---|---|---|---|---|
| AgentDef | ✓ | ✓ | ✓ | ✓ |
| SkillDef | ✓ | ✓ | ✓ | ✓ |
| MCPServerDef | ✓ | ✓ | ✓ | ✓ |
| **ScheduleDef** | ✓ (#264) | ✓ (this) | ✓ (this) | ✓ (this) |

## ctx-synthesis regression test

The gRPC test \`TestGrpcSubstrate_ScheduleDefCtxSynthesis\` uses a real in-process \`builtin.ScheduleDef\` tool (not a mock) to verify the operator-trust ctx is stamped. Without \`WithScheduleDefPolicy{Scopes:[any]}\` in \`substrateGRPCCtx\`, the in-process tool's default-deny scope gate refuses the call and returns \`is_error=true\`. This is the same shape as the existing SkillDef regression test — it would silently pass with a mock but fail with the real tool, exposing missing ctx synthesis.

## Proto regeneration

Generated stubs in \`internal/api/grpc/loomcyclepb/*.pb.go\` regenerated via \`make proto\` (which now requires \`make proto-deps\` first to install \`protoc-gen-go\` + \`protoc-gen-go-grpc\`).

## RFC E pipeline status after this PR

- [x] **PR #263** — substrate foundation (data layer, store methods, lookup resolver, drift test, config)
- [x] **PR #264** — ScheduleDef built-in tool + HTTP admin endpoint
- [x] **PR #266** — scheduler runtime (sweeper goroutine + cron + on_complete dispatch)
- [x] **PR (this)** — gRPC + MCP + TS adapter transports
- [ ] **PR (next)** — Deliverable 6: \`/ui/schedules\` Web UI admin tab

## Test plan

- [x] \`go test ./...\` — 53 packages pass, 0 failures
- [x] \`go vet\` + \`gofmt -l\` clean
- [x] \`npm test\` (adapters/ts) — 162 tests pass, 0 failures
- [x] 2 new gRPC tests (\`TestGrpcScheduleDef_HappyPath\` + \`TestGrpcSubstrate_ScheduleDefCtxSynthesis\`)
- [x] 3 new TS tests (happy-path, required_credentials refusal, bearer auth)
- [x] MCP tools/list count assertion updated 33 → 34 with \`scheduledef\` in the spot-check name set

🤖 Generated with [Claude Code](https://claude.com/claude-code)