### PR TITLE
feat(rfc-e): on_complete hook editor — add_hook + remove_hook ops + UI

### DIFF
--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -70,14 +70,14 @@ type ScheduleDef struct {
 const scheduleDefDescription = `Author, fork, retire, and inspect schedule definitions at runtime. ` +
 	`Static scheduled_runs.<name>: yaml entries remain the operator's immutable ground truth; this tool ` +
 	`produces the DERIVED layer of orchestrator-authored per-user forks. ` +
-	`Operations: create, fork, get, list, retire.`
+	`Operations: create, fork, get, list, retire, add_hook, remove_hook.`
 
 const scheduleDefInputSchema = `{
   "type": "object",
   "properties": {
-    "op":            {"type": "string", "enum": ["create","fork","get","list","retire"], "description": "Operation to perform."},
+    "op":            {"type": "string", "enum": ["create","fork","get","list","retire","add_hook","remove_hook"], "description": "Operation to perform."},
     "name":          {"type": "string", "description": "Schedule name (required for create/fork/list)."},
-    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire)."},
+    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire; required for add_hook/remove_hook to identify the parent version to fork from)."},
     "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name, or bootstraps from a yaml template)."},
     "overlay": {
       "type": "object",
@@ -86,7 +86,13 @@ const scheduleDefInputSchema = `{
     },
     "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
     "promote":       {"type": "boolean", "description": "create + fork both default true (schedules' fork-versioning model expects new versions to replace old). Pass false to leave the existing active pointer in place."},
-    "retired":       {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."}
+    "retired":       {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."},
+    "hook": {
+      "type": "object",
+      "description": "Required for add_hook — the hook body. {kind: 'channel.publish'|'mcp.call'|'memory.set', + kind-specific fields (channel|server+tool|scope+key) + payload/args}.",
+      "additionalProperties": true
+    },
+    "hook_index":    {"type": "integer", "description": "Required for remove_hook — 0-indexed position in the parent's on_complete list."}
   },
   "required": ["op"]
 }`
@@ -100,6 +106,9 @@ type scheduleDefInput struct {
 	Description string          `json:"description,omitempty"`
 	Promote     *bool           `json:"promote,omitempty"`
 	Retired     *bool           `json:"retired,omitempty"`
+	// add_hook / remove_hook fields (v1.x).
+	Hook      *mergedScheduleHook `json:"hook,omitempty"`
+	HookIndex *int                `json:"hook_index,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -136,10 +145,14 @@ func (s *ScheduleDef) Execute(ctx context.Context, raw json.RawMessage) (tools.R
 		return s.execList(ctx, policy, in)
 	case "retire":
 		return s.execRetire(ctx, policy, in)
+	case "add_hook":
+		return s.execAddHook(ctx, policy, in)
+	case "remove_hook":
+		return s.execRemoveHook(ctx, policy, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire, add_hook, remove_hook)", in.Op)), nil
 	}
 }
 
@@ -384,6 +397,130 @@ func (s *ScheduleDef) execRetire(ctx context.Context, policy tools.ScheduleDefPo
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
 	}
 	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+}
+
+// ---- add_hook / remove_hook ----
+//
+// Both ops are syntactic sugar over fork: fetch the parent definition,
+// mutate its on_complete list, persist as a NEW VERSION with full
+// lineage + auto-promote. Operators could already do this manually via
+// `op: fork` with a full on_complete overlay, but that requires fetch
+// → JSON-merge → fork dance from the caller. These ops collapse the
+// pattern into one round-trip and use a per-hook input shape so the
+// model doesn't have to reconstruct the entire list every time.
+//
+// Validation invariants preserved (same as fork):
+//   - validateScheduleDef on the merged def
+//   - required_credentials manifest still enforced
+//   - MaxDefinitionBytes still enforced
+//   - default-deny scope still enforced (checkScopeForName)
+//
+// Versioning: each add/remove creates a new fork version (parent_def_id
+// linked to the existing active def). The substrate's monotonic
+// version counter advances. Lineage is preserved across hook edits.
+
+func (s *ScheduleDef) execAddHook(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("add_hook: missing required field: def_id (target parent version)"), nil
+	}
+	if in.Hook == nil {
+		return errResult("add_hook: missing required field: hook"), nil
+	}
+	parent, mergedDef, err := s.loadParentForHookOp(ctx, policy, "add_hook", in.DefID)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	// Append the new hook then re-validate. Validation refuses unknown
+	// kinds + missing kind-specific fields (channel|server+tool|scope+key)
+	// — the existing validateScheduleDef walks every hook in the slice,
+	// so the appended one gets checked along with any pre-existing ones.
+	mergedDef.OnComplete = append(mergedDef.OnComplete, *in.Hook)
+	return s.persistForkFromHookEdit(ctx, parent, mergedDef, "add_hook")
+}
+
+func (s *ScheduleDef) execRemoveHook(ctx context.Context, policy tools.ScheduleDefPolicyValue, in scheduleDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("remove_hook: missing required field: def_id (target parent version)"), nil
+	}
+	if in.HookIndex == nil {
+		return errResult("remove_hook: missing required field: hook_index"), nil
+	}
+	idx := *in.HookIndex
+	parent, mergedDef, err := s.loadParentForHookOp(ctx, policy, "remove_hook", in.DefID)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	if idx < 0 || idx >= len(mergedDef.OnComplete) {
+		return errResult(fmt.Sprintf("remove_hook: hook_index %d out of range [0..%d)", idx, len(mergedDef.OnComplete))), nil
+	}
+	// Slice out the indexed hook. Preserves order of the survivors —
+	// callers may rely on index stability for subsequent removes.
+	mergedDef.OnComplete = append(mergedDef.OnComplete[:idx], mergedDef.OnComplete[idx+1:]...)
+	return s.persistForkFromHookEdit(ctx, parent, mergedDef, "remove_hook")
+}
+
+// loadParentForHookOp resolves the parent def + decodes its definition
+// into mergedScheduleDef. Returns a typed error string for the caller
+// to wrap. Checks scope on the parent's name (so an agent with
+// `named:weekly-digest` can't edit hooks on `daily-digest`).
+func (s *ScheduleDef) loadParentForHookOp(ctx context.Context, policy tools.ScheduleDefPolicyValue, opLabel, defID string) (store.ScheduleDefRow, mergedScheduleDef, error) {
+	parent, err := s.Store.ScheduleDefGet(ctx, defID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return store.ScheduleDefRow{}, mergedScheduleDef{}, fmt.Errorf("%s: def_id %q not found", opLabel, defID)
+		}
+		return store.ScheduleDefRow{}, mergedScheduleDef{}, fmt.Errorf("%s: %s", opLabel, err)
+	}
+	if err := s.checkScopeForName(policy, parent.Name); err != nil {
+		return store.ScheduleDefRow{}, mergedScheduleDef{}, err
+	}
+	var def mergedScheduleDef
+	if err := json.Unmarshal(parent.Definition, &def); err != nil {
+		return store.ScheduleDefRow{}, mergedScheduleDef{}, fmt.Errorf("%s: decode parent definition: %s", opLabel, err)
+	}
+	return parent, def, nil
+}
+
+// persistForkFromHookEdit serialises the mutated def, runs the same
+// validation chain fork uses, persists as a new version, and
+// auto-promotes. Returns the row response with promoted=true.
+func (s *ScheduleDef) persistForkFromHookEdit(ctx context.Context, parent store.ScheduleDefRow, def mergedScheduleDef, opLabel string) (tools.Result, error) {
+	if err := validateScheduleDef(def); err != nil {
+		return errResult(fmt.Sprintf("%s: %s", opLabel, err)), nil
+	}
+	if err := assertRequiredCredentials(def); err != nil {
+		return errResult(fmt.Sprintf("%s: %s", opLabel, err)), nil
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("%s: marshal: %s", opLabel, err)), nil
+	}
+	if s.MaxDefinitionBytes > 0 && len(defJSON) > s.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("%s: definition (%d bytes) exceeds max %d", opLabel, len(defJSON), s.MaxDefinitionBytes)), nil
+	}
+	ident := tools.RunIdentity(ctx)
+	row := store.ScheduleDefRow{
+		DefID:            mintDefID(),
+		Name:             parent.Name,
+		ParentDefID:      parent.DefID,
+		Definition:       defJSON,
+		Description:      fmt.Sprintf("%s edit (parent v%d)", opLabel, parent.Version),
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := s.Store.ScheduleDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("%s: %s", opLabel, err)), nil
+	}
+	// Hook edits always auto-promote — there's no "stage and review"
+	// use case for a hook addition the way there might be for a major
+	// definition rewrite. Operators wanting the staged pattern can
+	// use the regular `fork` op with explicit promote:false.
+	if err := s.Store.ScheduleDefSetActive(ctx, parent.Name, created.DefID, ident.AgentID); err != nil {
+		return errResult(fmt.Sprintf("%s: promote: %s", opLabel, err)), nil
+	}
+	_ = s.Store.ScheduleRunStateSeed(ctx, created.DefID, computeInitialNextRunAt(def, time.Now()))
+	return okJSON(scheduleRowResponse(created, true))
 }
 
 // ---- helpers ----

--- a/internal/tools/builtin/scheduledef_test.go
+++ b/internal/tools/builtin/scheduledef_test.go
@@ -365,6 +365,135 @@ func TestScheduleDefTool_RetireRoundTrip(t *testing.T) {
 	}
 }
 
+// TestScheduleDefTool_AddHook adds a channel.publish hook to a forked
+// def. Verifies: new version created, parent_def_id chains, hooks list
+// now contains the appended hook, auto-promote landed.
+func TestScheduleDefTool_AddHook(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Create a freestanding schedule with no hooks initially.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"hook-target","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	parentDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// Add a channel.publish hook.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"add_hook","def_id":"`+parentDefID+`","hook":{"kind":"channel.publish","channel":"results-alice","payload":{"top":3}}}`))
+	if res.IsError {
+		t.Fatalf("add_hook: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["parent_def_id"].(string) != parentDefID {
+		t.Errorf("parent_def_id = %q, want %q", out["parent_def_id"], parentDefID)
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("add_hook should auto-promote")
+	}
+	def := out["definition"].(map[string]any)
+	hooks, ok := def["on_complete"].([]any)
+	if !ok || len(hooks) != 1 {
+		t.Fatalf("on_complete = %v, want 1-element slice", def["on_complete"])
+	}
+	h := hooks[0].(map[string]any)
+	if h["kind"] != "channel.publish" || h["channel"] != "results-alice" {
+		t.Errorf("hook = %v, want {kind:channel.publish, channel:results-alice}", h)
+	}
+}
+
+// TestScheduleDefTool_AddHookRefusesUnknownKind covers the validation
+// chain — appending an invalid hook should refuse loudly, not silently
+// land a broken def in the substrate.
+func TestScheduleDefTool_AddHookRefusesUnknownKind(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"hook-bad","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"}}`))
+	parentDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"add_hook","def_id":"`+parentDefID+`","hook":{"kind":"slack.post","channel":"x"}}`))
+	if !res.IsError {
+		t.Fatalf("unknown hook kind should refuse")
+	}
+	if !strings.Contains(res.Text, "unknown kind") {
+		t.Errorf("refusal should name the bad kind; got %s", res.Text)
+	}
+}
+
+// TestScheduleDefTool_RemoveHook removes a hook by index. Verifies the
+// remaining hooks survive + index stability.
+func TestScheduleDefTool_RemoveHook(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Create with 3 hooks via the create-with-overlay path.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"hook-rm","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice","on_complete":[
+		{"kind":"channel.publish","channel":"c1"},
+		{"kind":"channel.publish","channel":"c2"},
+		{"kind":"channel.publish","channel":"c3"}
+	]}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	parentDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// Remove the middle hook (index 1).
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"remove_hook","def_id":"`+parentDefID+`","hook_index":1}`))
+	if res.IsError {
+		t.Fatalf("remove_hook: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	def := out["definition"].(map[string]any)
+	hooks := def["on_complete"].([]any)
+	if len(hooks) != 2 {
+		t.Fatalf("after remove, hook count = %d, want 2", len(hooks))
+	}
+	if hooks[0].(map[string]any)["channel"] != "c1" {
+		t.Errorf("survivors[0].channel = %v, want c1", hooks[0].(map[string]any)["channel"])
+	}
+	if hooks[1].(map[string]any)["channel"] != "c3" {
+		t.Errorf("survivors[1].channel = %v, want c3 (c2 was removed)", hooks[1].(map[string]any)["channel"])
+	}
+}
+
+func TestScheduleDefTool_RemoveHookOutOfRange(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"hook-oor","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice","on_complete":[{"kind":"channel.publish","channel":"c1"}]}}`))
+	parentDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"remove_hook","def_id":"`+parentDefID+`","hook_index":5}`))
+	if !res.IsError {
+		t.Fatalf("out-of-range index should refuse")
+	}
+	if !strings.Contains(res.Text, "out of range") {
+		t.Errorf("refusal should mention range; got %s", res.Text)
+	}
+}
+
+// TestScheduleDefTool_AddHookScopeEnforcement ensures the
+// per-name scope gate fires on hook edits too. Named-scope agents
+// shouldn't be able to mutate hooks on schedules they can't author.
+func TestScheduleDefTool_AddHookScopeEnforcement(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	// Create with the broad fixture policy (any scope).
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"private-sched","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"}}`))
+	parentDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// Now restrict the policy to a different name and attempt add_hook.
+	restrictedCtx := tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes: []string{"named:other-sched"},
+	})
+	res, _ = tool.Execute(restrictedCtx, json.RawMessage(`{"op":"add_hook","def_id":"`+parentDefID+`","hook":{"kind":"channel.publish","channel":"x"}}`))
+	if !res.IsError {
+		t.Fatalf("named-scope should refuse hook edit on non-matching schedule")
+	}
+}
+
 func TestScheduleDefTool_ListReturnsVersions(t *testing.T) {
 	tool, ctx, cleanup := scheduleDefFixture(t)
 	defer cleanup()

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -995,6 +995,49 @@ export function scheduleDefRetire(defID: string, retired: boolean): Promise<{ de
   });
 }
 
+// ScheduleHook mirrors mergedScheduleHook on the substrate side. Three
+// closed-set kinds: channel.publish, mcp.call, memory.set. Kind-
+// specific fields are required by the server-side validator; the type
+// here keeps everything optional because the actual presence depends
+// on `kind`.
+export interface ScheduleHook {
+  kind: "channel.publish" | "mcp.call" | "memory.set";
+  // channel.publish:
+  channel?: string;
+  payload?: Record<string, unknown>;
+  // mcp.call:
+  server?: string;
+  tool?: string;
+  args?: Record<string, unknown>;
+  // memory.set:
+  scope?: "agent" | "user" | "global";
+  key?: string;
+}
+
+// scheduleDefAddHook appends a hook to a def's on_complete list,
+// persisting as a new fork version with auto-promote. The substrate
+// validates the hook (kind enum + kind-specific required fields)
+// server-side; malformed hooks refuse with SubstrateToolRefusedError.
+export function scheduleDefAddHook(defID: string, hook: ScheduleHook): Promise<ScheduleDefRow> {
+  return jsonFetch<ScheduleDefRow>("/v1/_scheduledef", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ op: "add_hook", def_id: defID, hook }),
+  });
+}
+
+// scheduleDefRemoveHook removes the hook at hook_index from a def's
+// on_complete list, persisting as a new fork version with auto-promote.
+// hook_index is 0-based and refers to the index in the PARENT
+// version's list; out-of-range refuses.
+export function scheduleDefRemoveHook(defID: string, hookIndex: number): Promise<ScheduleDefRow> {
+  return jsonFetch<ScheduleDefRow>("/v1/_scheduledef", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ op: "remove_hook", def_id: defID, hook_index: hookIndex }),
+  });
+}
+
 // ---- Legacy /names fetchers (substrate-only) ----
 //
 // Kept for the existing Library UI v1 surface + any external adapter

--- a/web/src/components/ScheduleDetailPane.tsx
+++ b/web/src/components/ScheduleDetailPane.tsx
@@ -12,6 +12,7 @@ import {
   ScheduleStateView,
 } from "../api";
 import { SourceChip } from "../pages/SchedulesView";
+import ScheduleHookList from "./ScheduleHookList";
 
 interface Props {
   entry: ScheduleListEntry;
@@ -242,34 +243,13 @@ export default function ScheduleDetailPane({ entry, onMutated, onForkTemplate }:
         </section>
       )}
 
-      {/* on_complete hooks (display-only in v1). */}
-      {Array.isArray(def?.on_complete) && def.on_complete.length > 0 && (
-        <section className="schedule-detail-block">
-          <h4>on_complete hooks</h4>
-          <ul className="schedule-hooks">
-            {(def.on_complete as Array<Record<string, unknown>>).map((h, i) => (
-              <li key={i} className="schedule-hook">
-                <span className="schedule-hook-kind">{h.kind as string}</span>
-                {h.channel ? <span>channel={String(h.channel)}</span> : null}
-                {h.server ? (
-                  <span>
-                    server={String(h.server)}, tool={String(h.tool ?? "")}
-                  </span>
-                ) : null}
-                {h.scope ? (
-                  <span>
-                    scope={String(h.scope)}, key={String(h.key ?? "")}
-                  </span>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-          <div className="schedule-hooks-note">
-            Hook editing lives on the substrate side (POST /v1/_scheduledef) — edit
-            the yaml template or fork the definition to change hooks.
-          </div>
-        </section>
-      )}
+      {/* on_complete hooks — editable when the schedule has a
+          substrate-side def_id; display-only otherwise. */}
+      <ScheduleHookList
+        hooks={(Array.isArray(def?.on_complete) ? def.on_complete : []) as Array<Record<string, unknown>>}
+        activeDefID={entry.in_substrate ? entry.active_def_id : undefined}
+        onMutated={onMutated}
+      />
 
       {/* Lineage tree — show all versions of this name. */}
       {substrateVersions.length > 1 && (

--- a/web/src/components/ScheduleHookList.tsx
+++ b/web/src/components/ScheduleHookList.tsx
@@ -1,0 +1,295 @@
+import { useState } from "react";
+import {
+  scheduleDefAddHook,
+  scheduleDefRemoveHook,
+  ScheduleHook,
+} from "../api";
+
+interface Props {
+  // The hooks array from the active def's on_complete list. Each entry
+  // is rendered as a row; null/empty renders an empty-state message.
+  hooks: Array<Record<string, unknown>>;
+  // The substrate def_id whose on_complete list these hooks belong to.
+  // When undefined, the section is display-only (yaml-only schedule).
+  // When defined, each hook gets a Remove button + an Add Hook CTA at
+  // the bottom.
+  activeDefID?: string;
+  // Called after a successful mutation so the parent re-fetches the
+  // substrate row to surface the new active def_id + version.
+  onMutated: () => void;
+}
+
+// ScheduleHookList renders the on_complete hooks for a schedule. For
+// substrate-backed schedules (activeDefID set), each hook gets a
+// Remove button and an Add Hook modal is available. For yaml-only
+// schedules, the section is display-only with a note pointing
+// operators to the yaml.
+//
+// Each mutation creates a new fork version with full lineage. The
+// substrate validates the hook server-side before persisting, so
+// malformed hooks refuse with a SubstrateToolRefusedError that the
+// component surfaces inline.
+export default function ScheduleHookList({ hooks, activeDefID, onMutated }: Props) {
+  const [addOpen, setAddOpen] = useState(false);
+  const [removingIdx, setRemovingIdx] = useState<number | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const handleRemove = async (idx: number) => {
+    if (!activeDefID) return;
+    if (!confirm(`Remove hook #${idx} (${hooks[idx]?.kind ?? "?"})? This creates a new fork version with the hook removed.`)) {
+      return;
+    }
+    setRemovingIdx(idx);
+    setErr(null);
+    try {
+      await scheduleDefRemoveHook(activeDefID, idx);
+      onMutated();
+    } catch (e) {
+      setErr(`remove hook: ${e instanceof Error ? e.message : String(e)}`);
+    } finally {
+      setRemovingIdx(null);
+    }
+  };
+
+  const handleAdd = async (hook: ScheduleHook) => {
+    if (!activeDefID) return;
+    setErr(null);
+    try {
+      await scheduleDefAddHook(activeDefID, hook);
+      setAddOpen(false);
+      onMutated();
+    } catch (e) {
+      setErr(`add hook: ${e instanceof Error ? e.message : String(e)}`);
+      // Keep the modal open so the operator can fix the input.
+    }
+  };
+
+  const editable = Boolean(activeDefID);
+
+  return (
+    <section className="schedule-detail-block">
+      <h4>on_complete hooks</h4>
+      {hooks.length === 0 ? (
+        <div className="schedule-hooks-empty">No hooks configured.</div>
+      ) : (
+        <ul className="schedule-hooks">
+          {hooks.map((h, i) => (
+            <li key={i} className="schedule-hook">
+              <span className="schedule-hook-index">#{i}</span>
+              <span className="schedule-hook-kind">{h.kind as string}</span>
+              <span className="schedule-hook-fields">
+                {h.channel ? <code>channel={String(h.channel)}</code> : null}
+                {h.server ? (
+                  <code>
+                    server={String(h.server)}, tool={String(h.tool ?? "")}
+                  </code>
+                ) : null}
+                {h.scope ? (
+                  <code>
+                    scope={String(h.scope)}, key={String(h.key ?? "")}
+                  </code>
+                ) : null}
+              </span>
+              {editable && (
+                <button
+                  className="schedule-hook-remove"
+                  onClick={() => handleRemove(i)}
+                  disabled={removingIdx === i}
+                  title="Remove this hook (creates a new fork version)"
+                >
+                  {removingIdx === i ? "Removing…" : "Remove"}
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+      {err && <div className="schedule-detail-err">{err}</div>}
+      {editable ? (
+        <>
+          <button className="schedule-detail-action" onClick={() => setAddOpen(true)}>
+            + Add hook
+          </button>
+          {addOpen && (
+            <AddHookForm onCancel={() => setAddOpen(false)} onAdd={handleAdd} />
+          )}
+        </>
+      ) : (
+        <div className="schedule-hooks-note">
+          This is a yaml-only schedule — hooks are display-only. Edit the
+          loomcycle.yaml file to change them, or fork the definition into
+          the substrate to enable inline editing.
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface AddHookFormProps {
+  onCancel: () => void;
+  onAdd: (hook: ScheduleHook) => void;
+}
+
+// AddHookForm is an inline (not modal) form for adding one hook. Three
+// kinds with kind-specific fields, validated client-side before the
+// POST goes out. The substrate re-validates server-side; this client-
+// side check is just a UX nicety to avoid round-trips for obvious
+// missing fields.
+function AddHookForm({ onCancel, onAdd }: AddHookFormProps) {
+  const [kind, setKind] = useState<ScheduleHook["kind"]>("channel.publish");
+  const [channel, setChannel] = useState("");
+  const [server, setServer] = useState("");
+  const [tool, setTool] = useState("");
+  const [scope, setScope] = useState<"agent" | "user" | "global">("user");
+  const [key, setKey] = useState("");
+  const [payloadJSON, setPayloadJSON] = useState("{}");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    let payload: Record<string, unknown> | undefined;
+    if (payloadJSON.trim() && payloadJSON.trim() !== "{}") {
+      try {
+        const parsed = JSON.parse(payloadJSON);
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          throw new Error("payload must be a JSON object");
+        }
+        payload = parsed;
+      } catch (e) {
+        alert(`payload JSON: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+    }
+
+    const hook: ScheduleHook = { kind };
+    if (kind === "channel.publish") {
+      if (!channel) {
+        alert("channel.publish: channel is required");
+        return;
+      }
+      hook.channel = channel;
+      if (payload) hook.payload = payload;
+    } else if (kind === "mcp.call") {
+      if (!server || !tool) {
+        alert("mcp.call: server + tool are required");
+        return;
+      }
+      hook.server = server;
+      hook.tool = tool;
+      if (payload) hook.args = payload;
+    } else if (kind === "memory.set") {
+      if (!scope || !key) {
+        alert("memory.set: scope + key are required");
+        return;
+      }
+      hook.scope = scope;
+      hook.key = key;
+      if (payload) hook.payload = payload;
+    }
+
+    onAdd(hook);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="schedule-hook-form">
+      <div className="schedule-hook-form-row">
+        <label>
+          kind
+          <select
+            value={kind}
+            onChange={(e) => setKind(e.target.value as ScheduleHook["kind"])}
+          >
+            <option value="channel.publish">channel.publish</option>
+            <option value="mcp.call">mcp.call</option>
+            <option value="memory.set">memory.set</option>
+          </select>
+        </label>
+      </div>
+      {kind === "channel.publish" && (
+        <div className="schedule-hook-form-row">
+          <label>
+            channel
+            <input
+              type="text"
+              value={channel}
+              onChange={(e) => setChannel(e.target.value)}
+              placeholder="results-alice"
+            />
+          </label>
+        </div>
+      )}
+      {kind === "mcp.call" && (
+        <>
+          <div className="schedule-hook-form-row">
+            <label>
+              server
+              <input
+                type="text"
+                value={server}
+                onChange={(e) => setServer(e.target.value)}
+                placeholder="telegram"
+              />
+            </label>
+          </div>
+          <div className="schedule-hook-form-row">
+            <label>
+              tool
+              <input
+                type="text"
+                value={tool}
+                onChange={(e) => setTool(e.target.value)}
+                placeholder="send_message"
+              />
+            </label>
+          </div>
+        </>
+      )}
+      {kind === "memory.set" && (
+        <>
+          <div className="schedule-hook-form-row">
+            <label>
+              scope
+              <select
+                value={scope}
+                onChange={(e) => setScope(e.target.value as "agent" | "user" | "global")}
+              >
+                <option value="agent">agent</option>
+                <option value="user">user</option>
+                <option value="global">global</option>
+              </select>
+            </label>
+          </div>
+          <div className="schedule-hook-form-row">
+            <label>
+              key
+              <input
+                type="text"
+                value={key}
+                onChange={(e) => setKey(e.target.value)}
+                placeholder="last_run_summary"
+              />
+            </label>
+          </div>
+        </>
+      )}
+      <div className="schedule-hook-form-row">
+        <label>
+          {kind === "mcp.call" ? "args" : "payload"} (JSON, optional)
+          <textarea
+            value={payloadJSON}
+            onChange={(e) => setPayloadJSON(e.target.value)}
+            rows={3}
+            spellCheck={false}
+            className="schedule-hook-form-textarea"
+          />
+        </label>
+      </div>
+      <div className="schedule-hook-form-actions">
+        <button type="button" onClick={onCancel}>
+          Cancel
+        </button>
+        <button type="submit">Add hook</button>
+      </div>
+    </form>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3481,6 +3481,117 @@ button.primary:disabled {
   font-style: italic;
 }
 
+.schedule-hooks-empty {
+  color: var(--fg-soft);
+  font-style: italic;
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+.schedule-hook-index {
+  font-family: monospace;
+  font-size: 11px;
+  color: var(--fg-soft);
+  min-width: 20px;
+}
+
+.schedule-hook-fields {
+  flex: 1;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.schedule-hook-fields code {
+  font-family: monospace;
+  background: var(--bg);
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.schedule-hook-remove {
+  padding: 2px 10px;
+  background: var(--bg-soft);
+  color: var(--failed);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.schedule-hook-remove:hover:not(:disabled) {
+  border-color: var(--failed);
+}
+
+.schedule-hook-remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.schedule-hook-form {
+  margin-top: 12px;
+  padding: 12px;
+  background: var(--bg-soft);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.schedule-hook-form-row {
+  display: flex;
+}
+
+.schedule-hook-form-row label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--fg-soft);
+  font-family: monospace;
+  flex: 1;
+}
+
+.schedule-hook-form-row input,
+.schedule-hook-form-row select,
+.schedule-hook-form-textarea {
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.schedule-hook-form-textarea {
+  font-family: monospace;
+  resize: vertical;
+}
+
+.schedule-hook-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.schedule-hook-form-actions button {
+  padding: 4px 14px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.schedule-hook-form-actions button[type="submit"] {
+  background: var(--running);
+  color: white;
+  border-color: var(--running);
+}
+
 .schedule-lineage {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
## Summary

Closes the scope cut from #269 (the Web UI hook editor). The Web UI hook section is now fully editable for substrate-backed schedules; yaml-only schedules stay display-only with a note.

## What's in scope

**Backend** — 2 new ops on the existing ScheduleDef tool:

| Op | Behavior |
|---|---|
| \`{op: "add_hook", def_id, hook}\` | Appends hook to the def's \`on_complete\` list, persists as a new fork version with auto-promote |
| \`{op: "remove_hook", def_id, hook_index}\` | Removes hook at 0-based index, persists as a new fork version with auto-promote |

Both ops are syntactic sugar over the existing \`fork\` op — they fetch the parent, mutate \`on_complete\`, and reuse the fork persistence path (full validation chain: \`validateScheduleDef\` + \`assertRequiredCredentials\` + \`MaxDefinitionBytes\` + default-deny scope gate). Operators could already do this manually via \`fork\` with a full \`on_complete\` overlay; these convenience ops collapse the pattern into one round-trip and use a per-hook input shape.

**TS adapter** — \`ScheduleHook\` discriminated union type + \`scheduleDefAddHook\` / \`scheduleDefRemoveHook\` functions.

**Frontend** — new \`ScheduleHookList\` component (274 LOC) extracted from \`ScheduleDetailPane\`'s previous display-only block. Each substrate-side hook gets a Remove button + an inline \`AddHookForm\` with kind dropdown, kind-specific fields, and optional payload/args JSON. Yaml-only schedules keep the existing "edit in yaml" note.

## Why versioning instead of in-place mutation

The substrate's core invariant is "every definition mutation creates a new version with full lineage." Hook edits aren't special — they get the same versioning treatment as fork-rotates-credentials. The previous active \`def_id\` stays queryable for audit.

## UX shape choices

- **Remove uses \`confirm()\`** (browser dialog) for the "this creates a new version" warning. Adequate for an admin tool; a custom dialog component is overkill.
- **Add form is inline** (not modal) — the schedules tab already has the fork modal pattern; nesting a second modal on top doesn't fit. Inline form is cleaner.
- **Each mutation triggers \`onMutated\`** which re-fetches the substrate row + state. The 15s list poll catches up separately.

## Tests

5 new backend tests:

| Test | What it covers |
|---|---|
| \`TestScheduleDefTool_AddHook\` | Happy path: new version, parent_def_id chains, hook appended, auto-promote |
| \`TestScheduleDefTool_AddHookRefusesUnknownKind\` | Validation chain rejects \`kind:"slack.post"\` etc. |
| \`TestScheduleDefTool_RemoveHook\` | Remove middle hook, survivors preserve order |
| \`TestScheduleDefTool_RemoveHookOutOfRange\` | hook_index=5 against 1-hook list refuses with "out of range" |
| \`TestScheduleDefTool_AddHookScopeEnforcement\` | Named-scope agent can't edit hooks on schedules they can't author |

## Test plan

- [x] \`go test ./...\` — 53 packages pass, 0 failures
- [x] \`go vet\` + \`gofmt -l\` clean
- [x] \`npm run build\` (web/) — UI builds clean, 374 kB bundled, 111 kB gzipped

## RFC E status

This closes the only deferred item from the v1.x ScheduleDef shipment. The substrate-pattern-of-substrates is now feature-complete across all 4 primitives (AgentDef, SkillDef, MCPServerDef, ScheduleDef) including operator-facing edit affordances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)