### PR TITLE
feat(scheduler): compound test — scheduled runs + per-user bearers + MCP

### DIFF
--- a/internal/api/http/scheduler_bearer_compound_test.go
+++ b/internal/api/http/scheduler_bearer_compound_test.go
@@ -1,0 +1,381 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/pause"
+	"github.com/denn-gubsky/loomcycle/internal/providers/mock"
+	"github.com/denn-gubsky/loomcycle/internal/scheduler"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	mcphttp "github.com/denn-gubsky/loomcycle/internal/tools/mcp/http"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp/mcptest"
+)
+
+// compoundScale is the override knob for TestSchedulerBearerCompound.
+// Default 310 (10 + 100 + 200 across the 3 phases). Set higher to
+// stress under load — proportions across the 3 phases are preserved.
+var compoundScale = flag.Int("scale", 310, "total number of schedules to seed in TestSchedulerBearerCompound (split 3% / 32% / 65% across the 3 phases)")
+
+// TestSchedulerBearerCompound is the v0.12.7 release-gate test. It
+// verifies the three v1.x substrates COMPOSE correctly:
+//
+//  1. RFC E ScheduleDef — the sweeper picks up forked schedules
+//     and spawns runs.
+//  2. RFC F per-run credentials — each fork's user_credentials map
+//     flows into the run via RunInput → ctx → MCP HTTP header.
+//  3. MCP per-server bearer substitution — outgoing MCP requests
+//     carry the per-user bearer in the Authorization header, and
+//     two distinct servers each see their own substituted value.
+//
+// Workload shape (default scale=310):
+//
+//	phase 1 (~3% of total): N forks seeded with next_run_at = T+0
+//	phase 2 (~32%):          N forks seeded with next_run_at = T+1s
+//	phase 3 (~65%):          N forks seeded with next_run_at = T+2s
+//
+// Each fork has user_id u_NNN and credential {user_token: u_NNN};
+// each MCP server expects Authorization: Bearer u_NNN. The mock-mcp-
+// caller provider variant inspects the agent's tool catalog, extracts
+// the two mcp__-prefixed tools, and calls each with {user_id: u_NNN}
+// (extracted from the prompt's "user_id=u_NNN" literal). The MCP
+// servers each compare bearer == "Bearer " + user_id and count
+// matched / mismatched pairs.
+//
+// Pass criteria:
+//   - All N runs complete with status=completed.
+//   - Each server received exactly N calls.
+//   - Zero bearer/user_id mismatches across both servers.
+//   - Each user_id appears exactly twice in the combined call log
+//     (once per server) — proves per-user isolation under parallel-fire.
+func TestSchedulerBearerCompound(t *testing.T) {
+	scale := *compoundScale
+	if scale < 30 {
+		// Floor the per-phase counts so each phase has at least
+		// one fork (scale=1 would split into 0/0/1).
+		t.Logf("scale=%d clamped to 30 (minimum per-phase = 1+1+1 = 3 wouldn't exercise the cascade)", scale)
+		scale = 30
+	}
+	phase1Count := scale * 3 / 100
+	if phase1Count < 1 {
+		phase1Count = 1
+	}
+	phase2Count := scale * 32 / 100
+	if phase2Count < 1 {
+		phase2Count = 1
+	}
+	phase3Count := scale - phase1Count - phase2Count
+
+	// Two test MCP servers, each exposing ONE check_user-shaped tool
+	// under a distinct name so the mock-mcp-caller can extract them
+	// as two separate mcp__-prefixed entries from the agent catalog.
+	mcpA := mcptest.NewServer(t, mcptest.WithToolName("check_user"))
+	mcpB := mcptest.NewServer(t, mcptest.WithToolName("check_user"))
+
+	// Build the operator config:
+	//   - one agent `cascade-agent` using the mock-mcp-caller provider
+	//   - two mcp_servers, each pointing at a test server with a
+	//     credential-substituted Authorization header
+	//   - one scheduled_runs template `cascade-template` referencing
+	//     the agent. We won't actually drive the template through
+	//     yaml — we seed forks directly via the store at scale.
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "mock", Model: "mock-mcp-caller"},
+		Agents: map[string]config.AgentDef{
+			"cascade-agent": {
+				Model: "mock-mcp-caller",
+				AllowedTools: []string{
+					"mcp__server_a__check_user",
+					"mcp__server_b__check_user",
+				},
+				SystemPrompt: "you are the cascade test agent",
+			},
+		},
+		MCPServers: map[string]config.MCPServer{
+			"server_a": {
+				Transport: "http",
+				URL:       mcpA.URL,
+				Headers:   map[string]string{"Authorization": "Bearer ${run.credentials.user_token}"},
+			},
+			"server_b": {
+				Transport: "http",
+				URL:       mcpB.URL,
+				Headers:   map[string]string{"Authorization": "Bearer ${run.credentials.user_token}"},
+			},
+		},
+		Concurrency: config.Concurrency{
+			MaxConcurrentRuns: 64,
+			MaxQueueDepth:     scale * 2,
+			QueueTimeoutMS:    30_000,
+		},
+	}
+	cfg.Env.AuthToken = ""
+
+	// Mock provider — low base latency + small jitter so the cascade
+	// completes in tens of seconds even at scale=310. Operators wanting
+	// realistic LLM-call shape can override via env before running.
+	t.Setenv("LOOMCYCLE_MOCK_LATENCY_MS", "20")
+	t.Setenv("LOOMCYCLE_MOCK_LATENCY_JITTER_MS", "30")
+	t.Setenv("LOOMCYCLE_MOCK_ENABLED", "1")
+	t.Setenv("LOOMCYCLE_MOCK_429_RATE", "0")
+	mockProv := mock.New()
+
+	// In-memory store; cleanup via t.TempDir-equivalent.
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	// MCP pool factory — returns a Client for each configured server
+	// using the same URL+headers shape main.go uses.
+	pool := loommcp.NewPool(
+		func(name string) (loommcp.Caller, error) {
+			srv, ok := cfg.MCPServers[name]
+			if !ok {
+				return nil, fmt.Errorf("mcp_servers.%s: not configured", name)
+			}
+			return mcphttp.New(mcphttp.Config{URL: srv.URL, Headers: srv.Headers})
+		},
+		func(c loommcp.Caller) {
+			type closer interface{ Close() error }
+			if cl, ok := c.(closer); ok {
+				_ = cl.Close()
+			}
+		},
+	)
+	t.Cleanup(pool.Close)
+
+	// Eagerly handshake both servers so the mcp__-prefixed tool names
+	// land in the agent's catalog at run time. (The lazy resolver
+	// would also work but eager makes the test deterministic.)
+	allTools := []tools.Tool{}
+	mcpInitCtx, mcpInitCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	for name := range cfg.MCPServers {
+		_, descs, err := pool.GetWithRetry(mcpInitCtx, name, t.Logf)
+		if err != nil {
+			t.Fatalf("mcp[%s]: handshake failed: %v", name, err)
+		}
+		for _, d := range descs {
+			allTools = append(allTools, loommcp.NewTool(pool, name, d))
+		}
+	}
+	mcpInitCancel()
+	if len(allTools) != 2 {
+		t.Fatalf("expected 2 MCP tools registered (one per server); got %d", len(allTools))
+	}
+
+	sem := concurrency.New(cfg.Concurrency.MaxConcurrentRuns, cfg.Concurrency.MaxQueueDepth, cfg.Concurrency.QueueTimeout())
+	srv := New(cfg, &stubResolver{p: mockProv}, allTools, sem, st)
+	httpServer := httptest.NewServer(srv.Mux())
+	t.Cleanup(httpServer.Close)
+	// Wire the pause manager so the scheduler's pause-gate check is
+	// satisfied (StateRunning).
+	pauseMgr := pause.NewManager(st, 100*time.Millisecond)
+	srv.SetPauseManager(pauseMgr)
+
+	// Seed 310 (or scale) schedules across the 3 phases.
+	now := time.Now()
+	type seeded struct {
+		userID    string
+		defID     string
+		nextRunAt time.Time
+		phase     int
+	}
+	all := make([]seeded, 0, scale)
+	idx := 0
+	seedPhase := func(count int, offset time.Duration, phase int) {
+		for i := 0; i < count; i++ {
+			idx++
+			userID := fmt.Sprintf("u_%04d", idx)
+			defID := "sd_" + userID
+			seedScheduleFork(t, st, defID, userID, "cascade-agent")
+			all = append(all, seeded{userID: userID, defID: defID, nextRunAt: now.Add(offset), phase: phase})
+		}
+	}
+	seedPhase(phase1Count, 0, 1)
+	seedPhase(phase2Count, 1*time.Second, 2)
+	seedPhase(phase3Count, 2*time.Second, 3)
+
+	// Apply the staggered next_run_at offsets via Seed (UPSERT
+	// semantics — overwrites the just-seeded "now" value from the
+	// fork helper).
+	for _, s := range all {
+		if err := st.ScheduleRunStateSeed(context.Background(), s.defID, s.nextRunAt); err != nil {
+			t.Fatalf("seed %s: %v", s.defID, err)
+		}
+	}
+
+	// Spin the scheduler with a tight 100ms tick + large concurrent-fire
+	// cap so all due rows in each phase enter the queue rapidly.
+	sched := scheduler.New(scheduler.Config{
+		TickInterval:       100 * time.Millisecond,
+		FireTimeout:        2 * time.Minute,
+		MaxConcurrentFires: 64,
+	}, st, srv, pauseMgr, nil, t.Logf)
+
+	schedCtx, schedCancel := context.WithCancel(context.Background())
+	defer schedCancel()
+	sched.Start(schedCtx)
+
+	// Wait for all 2N MCP calls (one per server × scale) with a
+	// generous deadline. Poll the counters every 100ms.
+	totalCallsExpected := int64(scale * 2)
+	deadline := time.Now().Add(5 * time.Minute)
+	for {
+		got := mcpA.ToolCalls() + mcpB.ToolCalls()
+		if got >= totalCallsExpected {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout: only %d/%d MCP calls observed after 5 min (server_a=%d, server_b=%d)",
+				got, totalCallsExpected, mcpA.ToolCalls(), mcpB.ToolCalls())
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	// Give the scheduler a moment to advance final next_run_at values.
+	time.Sleep(500 * time.Millisecond)
+	sched.Stop()
+
+	// ----- Assertions -----
+
+	if mcpA.ToolCalls() != int64(scale) {
+		t.Errorf("server_a calls = %d, want %d", mcpA.ToolCalls(), scale)
+	}
+	if mcpB.ToolCalls() != int64(scale) {
+		t.Errorf("server_b calls = %d, want %d", mcpB.ToolCalls(), scale)
+	}
+	if got := mcpA.MismatchedBearers(); got != 0 {
+		t.Errorf("server_a bearer mismatches = %d, want 0", got)
+		dumpMismatches(t, "server_a", mcpA.CallLog())
+	}
+	if got := mcpB.MismatchedBearers(); got != 0 {
+		t.Errorf("server_b bearer mismatches = %d, want 0", got)
+		dumpMismatches(t, "server_b", mcpB.CallLog())
+	}
+
+	// Per-user isolation: every user_id must appear exactly once on
+	// each server. Aggregate the call logs and tally.
+	tallyA := tallyByUser(mcpA.CallLog())
+	tallyB := tallyByUser(mcpB.CallLog())
+	for _, s := range all {
+		if got := tallyA[s.userID]; got != 1 {
+			t.Errorf("server_a calls for %s = %d, want 1 (cross-fork contamination?)", s.userID, got)
+		}
+		if got := tallyB[s.userID]; got != 1 {
+			t.Errorf("server_b calls for %s = %d, want 1", s.userID, got)
+		}
+	}
+
+	// Verify last_status=completed on every fork.
+	failedCount := 0
+	for _, s := range all {
+		state, err := st.ScheduleRunStateGet(context.Background(), s.defID)
+		if err != nil {
+			t.Errorf("get state %s: %v", s.defID, err)
+			continue
+		}
+		if state.LastStatus != "completed" {
+			failedCount++
+			if failedCount <= 5 {
+				t.Errorf("schedule %s last_status = %q, want completed (last_error=%q)",
+					s.defID, state.LastStatus, state.LastError)
+			}
+		}
+	}
+	if failedCount > 5 {
+		t.Errorf("... (%d more schedules failed; first 5 logged above)", failedCount-5)
+	}
+
+	// Summary line for operator-visible test output.
+	t.Logf("compound test PASS — scale=%d, server_a=%d calls, server_b=%d calls, 0 mismatches, %d failed runs",
+		scale, mcpA.ToolCalls(), mcpB.ToolCalls(), failedCount)
+}
+
+// seedScheduleFork inserts one substrate schedule row with the canonical
+// shape this test needs: agent points at cascade-agent, prompt embeds
+// user_id=<userID> (the mock-mcp-caller extracts it), user_credentials
+// maps the single bearer key. Auto-promotes via SetActive + seeds
+// schedule_run_state at time.Now() (caller overrides via a second
+// Seed call to stagger phases).
+func seedScheduleFork(t *testing.T, st store.Store, defID, userID, agentName string) {
+	t.Helper()
+	def := map[string]any{
+		"agent": agentName,
+		// schedule cron — picked arbitrarily; we override next_run_at
+		// directly via the store, so the cron value only matters for
+		// the post-fire next_run_at advance.
+		"schedule": "0 * * * *",
+		"enabled":  true,
+		"user_id":  userID,
+		"prompt": []map[string]any{
+			{
+				"role": "user",
+				"content": []map[string]any{
+					{
+						"type": "trusted-text",
+						"text": fmt.Sprintf("Run cascade for user_id=%s now.", userID),
+					},
+				},
+			},
+		},
+		"user_credentials": map[string]string{"user_token": userID},
+	}
+	defJSON, _ := json.Marshal(def)
+	ctx := context.Background()
+	if _, err := st.ScheduleDefCreate(ctx, store.ScheduleDefRow{
+		DefID:      defID,
+		Name:       "sched-" + userID,
+		Definition: defJSON,
+	}); err != nil {
+		t.Fatalf("ScheduleDefCreate %s: %v", defID, err)
+	}
+	if err := st.ScheduleDefSetActive(ctx, "sched-"+userID, defID, "compound-test"); err != nil {
+		t.Fatalf("SetActive %s: %v", defID, err)
+	}
+	if err := st.ScheduleRunStateSeed(ctx, defID, time.Now()); err != nil {
+		t.Fatalf("Seed %s: %v", defID, err)
+	}
+}
+
+// tallyByUser counts how many times each user_id appears in a call log.
+func tallyByUser(log []mcptest.CallRecord) map[string]int {
+	out := make(map[string]int, len(log))
+	for _, r := range log {
+		out[r.UserID]++
+	}
+	return out
+}
+
+func dumpMismatches(t *testing.T, label string, log []mcptest.CallRecord) {
+	t.Helper()
+	var mismatches []string
+	for _, r := range log {
+		if !r.Matched {
+			mismatches = append(mismatches, fmt.Sprintf("user_id=%s observed=%q", r.UserID, r.ObservedBearer))
+		}
+	}
+	sort.Strings(mismatches)
+	max := 5
+	if len(mismatches) < max {
+		max = len(mismatches)
+	}
+	t.Logf("%s first %d mismatch(es): %s", label, max, strings.Join(mismatches[:max], " | "))
+}
+
+// _ ensures atomic is referenced even if a future edit removes its
+// usage (the package-level var keeps imports honest under gofmt).
+var _ = atomic.Int32{}

--- a/internal/providers/mock/driver.go
+++ b/internal/providers/mock/driver.go
@@ -150,6 +150,7 @@ func (d *Driver) ListModels(_ context.Context) ([]string, error) {
 		"mock-editor",
 		"mock-evaluator",
 		"mock-generic",
+		"mock-mcp-caller",
 	}, nil
 }
 
@@ -184,6 +185,11 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		events = scriptEditor(step, circuitID, req.Messages)
 	case "mock-evaluator":
 		events = scriptEvaluator(step, circuitID, req.Messages)
+	case "mock-mcp-caller":
+		// v0.12.7 compound-test variant — inspects req.Tools for
+		// mcp__-prefixed names and emits tool_use calls against
+		// them with user_id extracted from the prompt.
+		events = scriptMCPCaller(step, extractMCPTools(req), extractUserID(req))
 	default:
 		// mock-generic + anything unpinned. Single text turn, done.
 		// Usage is attached to EventDone below by finalizeUsage —

--- a/internal/providers/mock/driver_test.go
+++ b/internal/providers/mock/driver_test.go
@@ -358,7 +358,7 @@ func TestMockDriver_UsageReflectsRequestSize(t *testing.T) {
 	}
 }
 
-// TestMockDriver_ListModelsReturnsKnownSet — sanity that the four
+// TestMockDriver_ListModelsReturnsKnownSet — sanity that the five
 // model ids are reported. The resolver pre-populates the matrix
 // from this list, so a typo here cascades into agent 503s.
 func TestMockDriver_ListModelsReturnsKnownSet(t *testing.T) {
@@ -372,6 +372,7 @@ func TestMockDriver_ListModelsReturnsKnownSet(t *testing.T) {
 		"mock-editor":     false,
 		"mock-evaluator":  false,
 		"mock-generic":    false,
+		"mock-mcp-caller": false,
 	}
 	for _, m := range models {
 		if _, ok := want[m]; !ok {

--- a/internal/providers/mock/mcp_caller.go
+++ b/internal/providers/mock/mcp_caller.go
@@ -1,0 +1,117 @@
+package mock
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// scriptMCPCaller is the v0.12.7 mock variant that exercises MCP tool
+// dispatch end-to-end. Unlike the hardcoded researcher/editor/evaluator
+// scripts, this variant INSPECTS req.Tools at call time to find tools
+// whose name starts with the MCP convention prefix `mcp__` and emits
+// tool_use blocks calling them. The compound test fixture
+// (internal/api/http/scheduler_bearer_compound_test.go) uses this to
+// drive real MCP HTTP requests so the per-run credential substitution
+// chain (scheduler → RunInput → ctx → MCP header) gets a live exercise.
+//
+// FSM (driven by countToolResults like the other scripts):
+//
+//	step 0: extract user_id from the prompt's text content (look for
+//	        the "user_id=<value>" substring), call the FIRST mcp__ tool
+//	        with {"user_id": <value>}.
+//	step 1: same shape, call the SECOND mcp__ tool with the same user_id.
+//	step 2+: emit "done" + end_turn.
+//
+// Why two tools: the compound test wires up TWO mcptest servers each
+// with its own Authorization header expressed in different credential
+// keys (${run.credentials.token_a} vs ${run.credentials.token_b}, or
+// the same key — orchestrator's choice). Calling both proves the
+// per-server header substitution path works in parallel under load.
+//
+// When fewer than two mcp__ tools are present, the script gracefully
+// degrades: 1 tool present → call once + done; 0 present → emit "no
+// mcp tools" text + end_turn. The scheduler test asserts on the MCP
+// server's request counter, so a misconfigured agent shows up as
+// "expected 310 calls, got 0" instead of a silent test pass.
+
+// userIDRe matches the literal token "user_id=<value>" anywhere in
+// the prompt text. The compound test embeds this into each fork's
+// prompt via the schedule_runs template.
+var userIDRe = regexp.MustCompile(`user_id=([A-Za-z0-9_-]+)`)
+
+// scriptMCPCaller emits the MCP-calling FSM. mcpTools is the prefiltered
+// list of tools whose name starts with "mcp__" (caller computes this
+// from req.Tools to keep the script focused). userID is extracted from
+// the prompt's text — empty when the prompt didn't include the token.
+func scriptMCPCaller(step int, mcpTools []string, userID string) []providers.Event {
+	if len(mcpTools) == 0 {
+		return []providers.Event{
+			textEvent("no mcp tools in allowed_tools — nothing to call"),
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+
+	switch step {
+	case 0:
+		return []providers.Event{
+			textEvent("calling " + mcpTools[0]),
+			toolEvent(mcpTools[0], map[string]any{"user_id": userID}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	case 1:
+		if len(mcpTools) < 2 {
+			// Only one mcp tool exposed — done after step 0's reply.
+			return []providers.Event{
+				textEvent("done"),
+				{Type: providers.EventDone, StopReason: "end_turn"},
+			}
+		}
+		return []providers.Event{
+			textEvent("calling " + mcpTools[1]),
+			toolEvent(mcpTools[1], map[string]any{"user_id": userID}),
+			{Type: providers.EventDone, StopReason: "tool_use"},
+		}
+	default:
+		return []providers.Event{
+			textEvent("done"),
+			{Type: providers.EventDone, StopReason: "end_turn"},
+		}
+	}
+}
+
+// extractMCPTools returns the subset of req.Tools whose name starts
+// with "mcp__". Preserves catalog order. Caller treats nil + empty
+// identically; the script falls through to the degraded path.
+func extractMCPTools(req providers.Request) []string {
+	out := make([]string, 0, len(req.Tools))
+	for _, t := range req.Tools {
+		if strings.HasPrefix(t.Name, "mcp__") {
+			out = append(out, t.Name)
+		}
+	}
+	return out
+}
+
+// extractUserID parses the most recent user-role text content for the
+// literal token "user_id=<value>". Returns empty string when no match
+// — the script then emits an empty user_id arg which the mcptest
+// server's bearer check would reject, making the failure mode visible
+// in the compound test's mismatch counter rather than silent.
+func extractUserID(req providers.Request) string {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		m := req.Messages[i]
+		if m.Role != "user" {
+			continue
+		}
+		for _, b := range m.Content {
+			if b.Type == "text" && b.Text != "" {
+				if hit := userIDRe.FindStringSubmatch(b.Text); len(hit) > 1 {
+					return hit[1]
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/providers/mock/mcp_caller_test.go
+++ b/internal/providers/mock/mcp_caller_test.go
@@ -1,0 +1,132 @@
+package mock
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+func TestExtractMCPTools_FiltersByPrefix(t *testing.T) {
+	req := providers.Request{
+		Tools: []providers.ToolSpec{
+			{Name: "Memory"},
+			{Name: "mcp__server_a__check_user"},
+			{Name: "Channel"},
+			{Name: "mcp__server_b__check_user"},
+			{Name: "Context"},
+		},
+	}
+	got := extractMCPTools(req)
+	want := []string{"mcp__server_a__check_user", "mcp__server_b__check_user"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, n := range want {
+		if got[i] != n {
+			t.Errorf("got[%d] = %q, want %q (order must be preserved)", i, got[i], n)
+		}
+	}
+}
+
+func TestExtractUserID_FindsTokenInLatestUserMessage(t *testing.T) {
+	req := providers.Request{
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "boilerplate"}}},
+			{Role: "assistant", Content: []providers.ContentBlock{{Type: "text", Text: "ack"}}},
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "run for user_id=u_077 now"}}},
+		},
+	}
+	if got := extractUserID(req); got != "u_077" {
+		t.Errorf("got %q, want u_077", got)
+	}
+}
+
+func TestExtractUserID_EmptyWhenAbsent(t *testing.T) {
+	req := providers.Request{
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "no token here"}}},
+		},
+	}
+	if got := extractUserID(req); got != "" {
+		t.Errorf("got %q, want empty string", got)
+	}
+}
+
+func TestScriptMCPCaller_TwoToolFSM(t *testing.T) {
+	tools := []string{"mcp__server_a__check_user", "mcp__server_b__check_user"}
+	userID := "u_007"
+
+	// Step 0 — calls first tool.
+	events0 := scriptMCPCaller(0, tools, userID)
+	if !hasToolUse(events0, "mcp__server_a__check_user") {
+		t.Errorf("step 0 should call tool A; events=%v", events0)
+	}
+	if !hasArg(events0, "user_id", userID) {
+		t.Errorf("step 0 should pass user_id=%q in tool input", userID)
+	}
+
+	// Step 1 — calls second tool.
+	events1 := scriptMCPCaller(1, tools, userID)
+	if !hasToolUse(events1, "mcp__server_b__check_user") {
+		t.Errorf("step 1 should call tool B; events=%v", events1)
+	}
+
+	// Step 2 — terminal.
+	events2 := scriptMCPCaller(2, tools, userID)
+	if events2[len(events2)-1].StopReason != "end_turn" {
+		t.Errorf("step 2 should terminate (end_turn); got %q", events2[len(events2)-1].StopReason)
+	}
+}
+
+func TestScriptMCPCaller_NoMCPTools(t *testing.T) {
+	events := scriptMCPCaller(0, nil, "u_001")
+	if events[len(events)-1].StopReason != "end_turn" {
+		t.Errorf("with no MCP tools, step 0 should terminate immediately")
+	}
+	// Should have a text event explaining the situation.
+	found := false
+	for _, e := range events {
+		if e.Type == providers.EventText && strings.Contains(e.Text, "no mcp tools") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected explanatory text event; got %v", events)
+	}
+}
+
+func TestScriptMCPCaller_OneMCPToolDoesntDoubleCall(t *testing.T) {
+	// With only one mcp tool, step 1 should terminate (no second tool).
+	tools := []string{"mcp__server_a__check_user"}
+	events := scriptMCPCaller(1, tools, "u_001")
+	if events[len(events)-1].StopReason != "end_turn" {
+		t.Errorf("with 1 tool, step 1 should terminate; got %v", events)
+	}
+}
+
+func hasToolUse(events []providers.Event, name string) bool {
+	for _, e := range events {
+		if e.Type == providers.EventToolCall && e.ToolUse != nil && e.ToolUse.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasArg(events []providers.Event, key, value string) bool {
+	for _, e := range events {
+		if e.Type != providers.EventToolCall || e.ToolUse == nil {
+			continue
+		}
+		var args map[string]any
+		if err := json.Unmarshal(e.ToolUse.Input, &args); err != nil {
+			continue
+		}
+		if got, ok := args[key].(string); ok && got == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"time"
 
@@ -28,6 +29,16 @@ type Config struct {
 	// disables env-credential resolution entirely — a safe-by-default
 	// posture. Operators opt in via LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST.
 	EnvAllowlist map[string]bool
+
+	// MaxConcurrentFires bounds the number of schedules a single tick
+	// fires in parallel. 0 → default runtime.NumCPU()*4. Each fire is
+	// a goroutine that calls runner.RunOnce synchronously; the tick
+	// itself waits for the whole batch to drain before returning so
+	// the "one tick at a time" invariant holds. Larger values trade
+	// memory + concurrency-store pressure for tighter cascading at
+	// burst-fire moments (e.g. cron crossings where 100s of forks
+	// become due in the same second).
+	MaxConcurrentFires int
 }
 
 // defaults applies the documented defaults to a zero-value Config.
@@ -37,6 +48,9 @@ func (c Config) defaults() Config {
 	}
 	if c.FireTimeout == 0 {
 		c.FireTimeout = 10 * time.Minute
+	}
+	if c.MaxConcurrentFires == 0 {
+		c.MaxConcurrentFires = runtime.NumCPU() * 4
 	}
 	return c
 }
@@ -120,6 +134,15 @@ func (s *Scheduler) run(ctx context.Context) {
 // tick processes one sweeper iteration. Skips when pause manager
 // reports runtime != StateRunning (matches the v0.8.17 pause/resume
 // composition rule from RFC E).
+//
+// Due rows fire in parallel up to cfg.MaxConcurrentFires goroutines.
+// The tick waits for the whole batch to drain before returning so
+// the "next tick won't start until this one finishes" invariant
+// holds — important because each fire's RecordResult advances
+// next_run_at; without the wait, the next tick could re-fire a row
+// whose status update is still in flight. The bounded semaphore
+// keeps memory + per-user-fairness pressure predictable when 100s
+// of forks become due in one cron crossing.
 func (s *Scheduler) tick(ctx context.Context) {
 	if s.pause != nil && s.pause.State() != pause.StateRunning {
 		// Paused / pausing — the runtime is quiesced for snapshot.
@@ -132,12 +155,52 @@ func (s *Scheduler) tick(ctx context.Context) {
 		s.logf("scheduler: list due: %v", err)
 		return
 	}
-	for _, row := range due {
-		if ctxDone(ctx) {
-			return
-		}
-		s.fireOne(ctx, row, now)
+	if len(due) == 0 {
+		return
 	}
+
+	// Buffered semaphore caps concurrent fires. Each goroutine
+	// acquires a slot before calling fireOne and releases on exit.
+	// A nil semaphore (size <= 0) would mean unbounded parallelism;
+	// the Config.defaults() floor ensures size is always positive.
+	sem := make(chan struct{}, s.cfg.MaxConcurrentFires)
+	var wg sync.WaitGroup
+	for _, row := range due {
+		// Slot-acquire is ctx-aware so cancellation during a slow
+		// tick doesn't block waiting for slots indefinitely.
+		select {
+		case <-ctx.Done():
+			// Skip remaining rows; in-flight fires continue (their
+			// own fireCtx still has a timeout). Wait below drains.
+			wg.Wait()
+			return
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(row store.ScheduleDueRow) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			// Recover panics so one bad fire doesn't bring down
+			// the sweeper goroutine. Log + advance with a parked
+			// next_run_at so the def doesn't re-present every tick.
+			defer func() {
+				if r := recover(); r != nil {
+					s.logf("scheduler: PANIC in fireOne(def_id=%s): %v", row.DefID, r)
+					// Best-effort park — re-use the same 1h fallback
+					// the cron-resolve failure path uses.
+					_ = s.store.ScheduleRunStateRecordResult(context.Background(), store.ScheduleRunResult{
+						DefID:      row.DefID,
+						LastStatus: "failed",
+						LastError:  "panic in fireOne",
+						LastRunAt:  time.Now(),
+						NextRunAt:  time.Now().Add(1 * time.Hour),
+					})
+				}
+			}()
+			s.fireOne(ctx, row, now)
+		}(row)
+	}
+	wg.Wait()
 }
 
 // fireOne handles one due schedule end-to-end: unmarshal the def,

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -438,3 +439,127 @@ func TestScheduler_DecodeFailureRecordedAsFailed(t *testing.T) {
 
 // ensure no goroutine leaks across tests.
 var _ = atomic.Int32{}
+
+// TestScheduler_TickFiresInParallel verifies the v0.12.7 concurrency
+// change: when N due rows are present at tick time, they fire in
+// parallel up to MaxConcurrentFires goroutines. The test stages N rows
+// with a fake runner that blocks for ~100ms each; if firing were
+// serial, the wall would be ~N*100ms. With concurrent fire and 8 slots
+// the wall should be roughly N/8 * 100ms — the test asserts that
+// observed wall < (serial-wall * 0.5) as a robust bound that doesn't
+// flake under loaded CI.
+func TestScheduler_TickFiresInParallel(t *testing.T) {
+	const N = 24
+	enabled := true
+	def := scheduleDef{Agent: "researcher", Schedule: "0 * * * *", Enabled: &enabled}
+
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	defJSON, _ := json.Marshal(def)
+	for i := 0; i < N; i++ {
+		defID := fmt.Sprintf("sd-par-%03d", i)
+		name := fmt.Sprintf("sched-par-%03d", i)
+		if _, err := st.ScheduleDefCreate(ctx, store.ScheduleDefRow{DefID: defID, Name: name, Definition: defJSON}); err != nil {
+			t.Fatalf("def create %d: %v", i, err)
+		}
+		_ = st.ScheduleDefSetActive(ctx, name, defID, "test")
+		_ = st.ScheduleRunStateSeed(ctx, defID, time.Now().Add(-time.Minute))
+	}
+	const perFireDelay = 100 * time.Millisecond
+	fr := &fakeRunner{onRun: func(_ runner.RunInput) { time.Sleep(perFireDelay) }}
+	sched := New(Config{TickInterval: time.Hour, MaxConcurrentFires: 8}, st, fr, nil, nil, t.Logf)
+
+	start := time.Now()
+	sched.tick(ctx)
+	wall := time.Since(start)
+	serialWall := time.Duration(N) * perFireDelay
+	if wall > serialWall/2 {
+		t.Errorf("tick wall = %v, want < %v (serial would be %v); parallel-fire change appears to have regressed",
+			wall, serialWall/2, serialWall)
+	}
+	if got := len(fr.Calls()); got != N {
+		t.Errorf("got %d fires, want %d (some due rows were not fired)", got, N)
+	}
+}
+
+// TestScheduler_TickRespectsMaxConcurrentFires verifies the slot
+// semaphore actually bounds in-flight fires. Sets MaxConcurrentFires=4
+// against 12 due rows + per-fire 80ms delay, then asserts wall is at
+// least 3 * delay (i.e., 3 batches required to drain).
+func TestScheduler_TickRespectsMaxConcurrentFires(t *testing.T) {
+	const N = 12
+	const cap = 4
+	const perFireDelay = 80 * time.Millisecond
+	enabled := true
+	def := scheduleDef{Agent: "researcher", Schedule: "0 * * * *", Enabled: &enabled}
+
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	defJSON, _ := json.Marshal(def)
+	for i := 0; i < N; i++ {
+		defID := fmt.Sprintf("sd-cap-%03d", i)
+		name := fmt.Sprintf("sched-cap-%03d", i)
+		_, _ = st.ScheduleDefCreate(ctx, store.ScheduleDefRow{DefID: defID, Name: name, Definition: defJSON})
+		_ = st.ScheduleDefSetActive(ctx, name, defID, "test")
+		_ = st.ScheduleRunStateSeed(ctx, defID, time.Now().Add(-time.Minute))
+	}
+	fr := &fakeRunner{onRun: func(_ runner.RunInput) { time.Sleep(perFireDelay) }}
+	sched := New(Config{TickInterval: time.Hour, MaxConcurrentFires: cap}, st, fr, nil, nil, t.Logf)
+
+	start := time.Now()
+	sched.tick(ctx)
+	wall := time.Since(start)
+	// 12 fires / 4 cap = 3 batches minimum. Allow some slack on the
+	// lower bound (single batch should NOT drain everything).
+	minWall := 3*perFireDelay - 20*time.Millisecond
+	if wall < minWall {
+		t.Errorf("tick wall = %v, want >= %v (cap=%d should serialise into 3 batches)",
+			wall, minWall, cap)
+	}
+}
+
+// TestScheduler_PanicInFireOneIsRecovered ensures a panic inside one
+// fire doesn't propagate up to kill the sweeper. The fake runner
+// panics on the first call; subsequent due rows still fire normally.
+func TestScheduler_PanicInFireOneIsRecovered(t *testing.T) {
+	enabled := true
+	def := scheduleDef{Agent: "researcher", Schedule: "0 * * * *", Enabled: &enabled}
+
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	defJSON, _ := json.Marshal(def)
+	for i := 0; i < 3; i++ {
+		defID := fmt.Sprintf("sd-panic-%d", i)
+		name := fmt.Sprintf("sched-panic-%d", i)
+		_, _ = st.ScheduleDefCreate(ctx, store.ScheduleDefRow{DefID: defID, Name: name, Definition: defJSON})
+		_ = st.ScheduleDefSetActive(ctx, name, defID, "test")
+		_ = st.ScheduleRunStateSeed(ctx, defID, time.Now().Add(-time.Minute))
+	}
+	var calls atomic.Int32
+	fr := &fakeRunner{onRun: func(_ runner.RunInput) {
+		n := calls.Add(1)
+		if n == 1 {
+			panic("test panic — should be recovered")
+		}
+	}}
+	sched := New(Config{TickInterval: time.Hour, MaxConcurrentFires: 8}, st, fr, nil, nil, t.Logf)
+
+	// The tick should return without panicking even though one
+	// goroutine panicked. Survivors must still record results.
+	sched.tick(ctx)
+	if got := calls.Load(); got != 3 {
+		t.Errorf("calls = %d, want 3 (panic-recovery should allow the other fires to complete)", got)
+	}
+}

--- a/internal/tools/mcp/mcptest/server.go
+++ b/internal/tools/mcp/mcptest/server.go
@@ -1,0 +1,255 @@
+// Package mcptest provides a minimal httptest-based MCP Streamable-HTTP
+// server suitable for end-to-end tests that exercise the MCP HTTP
+// client without standing up a real upstream.
+//
+// The server speaks just enough of the wire protocol to satisfy the
+// loomcycle MCP HTTP client's handshake (initialize → notifications/
+// initialized → tools/list → tools/call). It exposes ONE tool —
+// `check_user` — whose handler:
+//
+//  1. Reads the inbound Authorization header.
+//  2. Reads the `user_id` argument from the tool call.
+//  3. Compares: bearer == "Bearer " + user_id.
+//  4. Returns {ok, observed_bearer, observed_user_id, expected_bearer}.
+//  5. Increments per-user_id + per-bearer counters atomically so the
+//     test can assert call totals and bearer correctness.
+//
+// Intended use case is the v0.12.7 compound test
+// (internal/api/http/scheduler_bearer_compound_test.go) which spins
+// up TWO instances — one per agent-allowed-tool — to prove that
+// per-server bearer header substitution propagates independently
+// under cascading scheduler load.
+//
+// NOT intended as a full MCP server implementation. Notification
+// handling is minimal; capability negotiation is just enough to pass
+// the client's handshake. Anything beyond `check_user` returns a
+// JSON-RPC method-not-found.
+package mcptest
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// Server wraps the underlying httptest.Server and exposes thread-safe
+// accessors for the call counters + the per-call log. The test driver
+// reads these after the cascade to assert correctness.
+type Server struct {
+	*httptest.Server
+
+	// toolName is the single tool exposed. Defaults to "check_user"
+	// but the constructor accepts an override so the compound test can
+	// stand up two distinct servers with two distinct tool names.
+	toolName string
+
+	// Total request count across the entire server lifetime. Includes
+	// the handshake (initialize + tools/list) so callers should
+	// subtract the handshake count when asserting tool-call totals.
+	requests atomic.Int64
+
+	// toolCalls counts JUST tools/call invocations on `toolName`.
+	toolCalls atomic.Int64
+
+	// matchedBearers counts tool calls whose bearer matched the
+	// expected pattern "Bearer " + user_id.
+	matchedBearers atomic.Int64
+
+	// log captures every tool call's (bearer, user_id) pair so the
+	// test can assert per-user isolation (each user_id should appear
+	// exactly once when the compound test fires one schedule per user).
+	mu  sync.Mutex
+	log []CallRecord
+}
+
+// CallRecord is one entry in the server's per-call log.
+type CallRecord struct {
+	UserID         string
+	ObservedBearer string
+	Matched        bool
+}
+
+// Option configures a Server at construction.
+type Option func(*Server)
+
+// WithToolName overrides the default "check_user" tool name. Used by
+// the compound test to expose tools with distinct mcp__ names so the
+// agent's allowed_tools list can route to specific servers.
+func WithToolName(name string) Option {
+	return func(s *Server) { s.toolName = name }
+}
+
+// NewServer returns a ready-to-use Server. The test must Close() it
+// in a Cleanup hook (or defer) to release the port.
+func NewServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+	s := &Server{toolName: "check_user"}
+	for _, opt := range opts {
+		opt(s)
+	}
+	s.Server = httptest.NewServer(http.HandlerFunc(s.handle))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// ToolCalls returns the total tools/call hit count for the exposed tool.
+func (s *Server) ToolCalls() int64 { return s.toolCalls.Load() }
+
+// MatchedBearers returns the count of tool calls whose Authorization
+// header matched the expected "Bearer " + user_id pattern.
+func (s *Server) MatchedBearers() int64 { return s.matchedBearers.Load() }
+
+// MismatchedBearers is a convenience accessor: total calls minus
+// matched. Useful in the compound test's assertion line.
+func (s *Server) MismatchedBearers() int64 {
+	return s.toolCalls.Load() - s.matchedBearers.Load()
+}
+
+// CallLog returns a snapshot of every recorded tool call. Safe to call
+// after Close(); the underlying slice is copied to avoid aliasing
+// concurrent appends.
+func (s *Server) CallLog() []CallRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]CallRecord, len(s.log))
+	copy(out, s.log)
+	return out
+}
+
+func (s *Server) handle(w http.ResponseWriter, r *http.Request) {
+	s.requests.Add(1)
+	body, _ := io.ReadAll(r.Body)
+	var probe struct {
+		ID     *int64          `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	_ = json.Unmarshal(body, &probe)
+
+	if probe.Method == "initialize" {
+		// Set a per-server session id so the client's session-id
+		// tracking exercise gets a non-empty value.
+		w.Header().Set("Mcp-Session-Id", "s_mcptest")
+	}
+
+	// Notifications carry no id; respond with 202 and no body.
+	if probe.ID == nil {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
+	switch probe.Method {
+	case "initialize":
+		writeJSON(w, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      *probe.ID,
+			"result": map[string]any{
+				"protocolVersion": loommcp.ProtocolVersion,
+				"capabilities":    map[string]any{},
+				"serverInfo":      map[string]any{"name": "mcptest", "version": "0.1"},
+			},
+		})
+	case "tools/list":
+		writeJSON(w, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      *probe.ID,
+			"result": map[string]any{
+				"tools": []map[string]any{
+					{
+						"name":        s.toolName,
+						"description": "Validates that the inbound bearer matches the supplied user_id.",
+						"inputSchema": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"user_id": map[string]any{"type": "string"},
+							},
+							"required": []string{"user_id"},
+						},
+					},
+				},
+			},
+		})
+	case "tools/call":
+		s.handleToolCall(w, r, *probe.ID, probe.Params)
+	default:
+		writeJSON(w, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      *probe.ID,
+			"error":   map[string]any{"code": -32601, "message": "method not found"},
+		})
+	}
+}
+
+// handleToolCall is the bearer-validation core of the test server.
+// The contract: bearer must be "Bearer " + user_id. The compound test
+// constructs schedule forks where each user_id is identical to its
+// `user_token` credential, so the round-trip succeeds for every call.
+// Any mismatch (e.g. credential races, header substitution bugs)
+// surfaces as MismatchedBearers() > 0.
+func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request, id int64, params json.RawMessage) {
+	var p struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	_ = json.Unmarshal(params, &p)
+	if p.Name != s.toolName {
+		writeJSON(w, map[string]any{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"error":   map[string]any{"code": -32602, "message": "unknown tool: " + p.Name},
+		})
+		return
+	}
+	s.toolCalls.Add(1)
+
+	var args struct {
+		UserID string `json:"user_id"`
+	}
+	_ = json.Unmarshal(p.Arguments, &args)
+
+	observedBearer := r.Header.Get("Authorization")
+	expectedBearer := "Bearer " + args.UserID
+	matched := observedBearer == expectedBearer
+	if matched {
+		s.matchedBearers.Add(1)
+	}
+
+	s.mu.Lock()
+	s.log = append(s.log, CallRecord{
+		UserID:         args.UserID,
+		ObservedBearer: observedBearer,
+		Matched:        matched,
+	})
+	s.mu.Unlock()
+
+	// The MCP tool-call response shape: a `content` array with at
+	// least one text block. The compound test doesn't parse the body
+	// (it asserts on the server-side counters) but we return useful
+	// detail for debugging when an operator runs the test by hand.
+	resultText, _ := json.Marshal(map[string]any{
+		"ok":               matched,
+		"observed_bearer":  observedBearer,
+		"expected_bearer":  expectedBearer,
+		"observed_user_id": args.UserID,
+	})
+	writeJSON(w, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result": map[string]any{
+			"content": []map[string]any{
+				{"type": "text", "text": string(resultText)},
+			},
+		},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/tools/mcp/mcptest/server_test.go
+++ b/internal/tools/mcp/mcptest/server_test.go
@@ -1,0 +1,121 @@
+package mcptest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+	mcphttp "github.com/denn-gubsky/loomcycle/internal/tools/mcp/http"
+)
+
+// TestMCPTestServer_HandshakeAndCallSucceeds drives the real loomcycle
+// MCP HTTP client against the test server to prove the handshake
+// (initialize → notifications/initialized → tools/list) works and a
+// tool call with a correct bearer is reported as matched.
+func TestMCPTestServer_HandshakeAndCallSucceeds(t *testing.T) {
+	srv := NewServer(t)
+
+	// Wire the loomcycle MCP HTTP client with a credential-substituted
+	// Authorization header. The bearer value resolves at request build
+	// time against tools.RunIdentity(ctx).UserCredentials.
+	c, err := mcphttp.New(mcphttp.Config{
+		URL: srv.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer ${run.credentials.user_token}",
+		},
+	})
+	if err != nil {
+		t.Fatalf("mcphttp.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		AgentID:         "a_test",
+		UserCredentials: map[string]string{"user_token": "u_alpha"},
+	})
+
+	// The first call against a fresh client triggers the handshake.
+	_, err = loommcp.CallTool(ctx, c, "check_user", json.RawMessage(`{"user_id":"u_alpha"}`))
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	if got := srv.ToolCalls(); got != 1 {
+		t.Errorf("ToolCalls = %d, want 1", got)
+	}
+	if got := srv.MatchedBearers(); got != 1 {
+		t.Errorf("MatchedBearers = %d, want 1 (bearer should have matched user_id)", got)
+	}
+	if got := srv.MismatchedBearers(); got != 0 {
+		t.Errorf("MismatchedBearers = %d, want 0", got)
+	}
+	log := srv.CallLog()
+	if len(log) != 1 || log[0].UserID != "u_alpha" || !log[0].Matched {
+		t.Errorf("unexpected call log entry: %+v", log)
+	}
+}
+
+// TestMCPTestServer_BearerMismatch verifies the negative path —
+// when the inbound bearer DOESN'T match the user_id, the server
+// counts it as a mismatch but still returns a 200 OK response so
+// the test driver sees `ok: false` in the tool body.
+func TestMCPTestServer_BearerMismatch(t *testing.T) {
+	srv := NewServer(t)
+
+	c, err := mcphttp.New(mcphttp.Config{
+		URL: srv.URL,
+		Headers: map[string]string{
+			"Authorization": "Bearer ${run.credentials.user_token}",
+		},
+	})
+	if err != nil {
+		t.Fatalf("mcphttp.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// Bearer is "u_alpha" but the tool is called with user_id=u_beta.
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		AgentID:         "a_test",
+		UserCredentials: map[string]string{"user_token": "u_alpha"},
+	})
+
+	if _, err := loommcp.CallTool(ctx, c, "check_user", json.RawMessage(`{"user_id":"u_beta"}`)); err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	if got := srv.MismatchedBearers(); got != 1 {
+		t.Errorf("MismatchedBearers = %d, want 1 (u_alpha bearer with u_beta user_id should be reported as a mismatch)", got)
+	}
+}
+
+// TestMCPTestServer_WithToolName verifies the override option used by
+// the compound test to spin up two distinct servers with two distinct
+// tool names.
+func TestMCPTestServer_WithToolName(t *testing.T) {
+	srv := NewServer(t, WithToolName("custom_check"))
+
+	c, err := mcphttp.New(mcphttp.Config{
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer u_alpha"},
+	})
+	if err != nil {
+		t.Fatalf("mcphttp.New: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+
+	// Calling under the custom name should succeed.
+	if _, err := loommcp.CallTool(ctx, c, "custom_check", json.RawMessage(`{"user_id":"u_alpha"}`)); err != nil {
+		t.Fatalf("CallTool(custom_check): %v", err)
+	}
+	if got := srv.ToolCalls(); got != 1 {
+		t.Errorf("custom_check ToolCalls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

**v0.12.7 release gate.** Single test case that proves the three v1.x substrates compose correctly end-to-end:

1. **RFC E ScheduleDef** — sweeper picks up forked schedules and spawns runs
2. **RFC F per-run credentials** — fork's \`user_credentials\` map flows into the run via \`RunInput\` → ctx → MCP HTTP header
3. **MCP per-server bearer substitution** — outgoing MCP requests carry the per-user bearer, with two distinct servers each seeing their own substituted value

These three were tested in isolation before; nothing exercised the full path. The compound test seeds 310 schedules across 3 phases (10 at T+0, 100 at T+1s, 200 at T+2s) and asserts:

- All 310 runs complete with status=completed
- Each MCP server received exactly 310 calls
- Zero bearer/user_id mismatches across both servers (620 total validations)
- Per-user isolation: each user_id appears exactly once on each server (no credential races under parallel-fire)

\`-scale=N\` tunes total schedules; phase ratios preserved. Verified at scale=1000 (2000 MCP calls in ~4 s, zero mismatches).

## Load-bearing change: scheduler tick parallel-fire

The previous \`tick()\` loop fired due rows **serially** — one \`fireOne\` after another, blocking on \`RunOnce\`. For 200 due rows × ~750 ms each that's ~2.5 min serial wall, contradicting the cascade pattern operators expect when 100s of forks become due in one cron crossing.

| | Before | After |
|---|---|---|
| 200 due rows × 750 ms | ~150 s serial | ~3 s parallel |
| Behavior under burst | sequential wall | bounded parallelism |
| Knob | none | \`Config.MaxConcurrentFires\` (default \`NumCPU()*4\`) |

Bounded goroutine pool in \`tick()\`. The tick \`WaitGroup\`-blocks on its batch so the "one tick at a time" invariant holds. Panics inside a fire goroutine are recovered + logged so one bad fire doesn't kill the sweeper. Ctx cancellation during a slow tick stops acquiring new slots; in-flight fires drain via their own \`fireCtx\` timeout.

Three new scheduler tests pin this: bounded concurrency observed, slot cap actually serialises into batches, panic recovery leaves survivors firing.

## New infrastructure

| File | Purpose |
|---|---|
| \`internal/providers/mock/mcp_caller.go\` | New \`mock-mcp-caller\` model variant. Inspects \`req.Tools\` for \`mcp__\`-prefixed names, extracts \`user_id\` from prompt via regex, emits 3-step FSM (call tool A → call tool B → done). Uses existing \`LOOMCYCLE_MOCK_LATENCY_*\` env vars. |
| \`internal/tools/mcp/mcptest/server.go\` | Reusable httptest-based MCP server speaking enough Streamable-HTTP wire shape to satisfy the loomcycle MCP HTTP client's handshake. Exposes ONE bearer-checking tool; per-call counters + log for test assertion. |

Both helpers are intentionally minimal so future tests can compose them.

## Test plan

- [x] \`go test ./...\` — 54 packages pass, 0 failures
- [x] \`go vet\` + \`gofmt -l\` clean
- [x] \`TestSchedulerBearerCompound\` at default scale 310 → ~3 s wall (620 MCP calls, 0 mismatches)
- [x] \`TestSchedulerBearerCompound -scale=1000\` → ~4 s wall (2000 MCP calls, 0 mismatches)
- [x] 3 new scheduler concurrency tests
- [x] 6 new mock-mcp-caller FSM tests
- [x] 3 new mcptest helper tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)