### PR TITLE
fix(scheduler): in-flight tracker prevents double-fire under heavy load

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -72,6 +72,30 @@ type Scheduler struct {
 	wg     sync.WaitGroup
 	stopCh chan struct{}
 	once   sync.Once
+
+	// inFlight tracks def_ids whose fire goroutine is currently
+	// running (between slot-acquire and RecordResult). Used to
+	// suppress double-fire when a fire takes longer than the tick
+	// interval and the next tick still sees the same row as due
+	// (because RecordResult hasn't advanced next_run_at yet).
+	//
+	// Surfaced by the compound test at scale=30000 where every
+	// schedule fired twice — every fire's RecordResult write was
+	// slower than the 100ms tick under heavy concurrent load, so
+	// each row stayed "due" for the next tick. The in-memory
+	// tracker is single-replica-only; cluster-mode advisory locks
+	// (v0.12+) would cover the cross-replica case symmetrically.
+	//
+	// Entry lifecycle:
+	//   tick():
+	//     LoadOrStore(def_id, _) before slot-acquire — skip if loaded
+	//   fire goroutine (deferred):
+	//     Delete(def_id) after fireOne returns or panics
+	//
+	// A goroutine that hangs leaks the entry until the fireCtx
+	// timeout cancels the RunOnce call (default 10m), which is the
+	// existing budget. No separate TTL needed.
+	inFlight sync.Map
 }
 
 // New constructs a Scheduler. All four runtime dependencies are
@@ -166,10 +190,23 @@ func (s *Scheduler) tick(ctx context.Context) {
 	sem := make(chan struct{}, s.cfg.MaxConcurrentFires)
 	var wg sync.WaitGroup
 	for _, row := range due {
+		// In-flight suppression: skip rows whose fire goroutine from
+		// a previous tick is still running (RecordResult hasn't yet
+		// advanced next_run_at, so the row would otherwise re-fire).
+		// LoadOrStore is atomic so the racy "check then store" hole
+		// is closed. See the inFlight field's commentary for the
+		// lifecycle + why it solves the x30000 over-fire finding.
+		if _, alreadyFiring := s.inFlight.LoadOrStore(row.DefID, time.Now()); alreadyFiring {
+			continue
+		}
 		// Slot-acquire is ctx-aware so cancellation during a slow
 		// tick doesn't block waiting for slots indefinitely.
 		select {
 		case <-ctx.Done():
+			// We reserved the inFlight slot above but won't fire;
+			// release it so the next tick can pick up this def
+			// freely.
+			s.inFlight.Delete(row.DefID)
 			// Skip remaining rows; in-flight fires continue (their
 			// own fireCtx still has a timeout). Wait below drains.
 			wg.Wait()
@@ -180,6 +217,11 @@ func (s *Scheduler) tick(ctx context.Context) {
 		go func(row store.ScheduleDueRow) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			// Always release the in-flight reservation, even on
+			// panic. defer order is LIFO so this runs AFTER the
+			// recover() below; that ordering means a panicking fire
+			// still clears its in-flight slot before the next tick.
+			defer s.inFlight.Delete(row.DefID)
 			// Recover panics so one bad fire doesn't bring down
 			// the sweeper goroutine. Log + advance with a parked
 			// next_run_at so the def doesn't re-present every tick.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -563,3 +563,63 @@ func TestScheduler_PanicInFireOneIsRecovered(t *testing.T) {
 		t.Errorf("calls = %d, want 3 (panic-recovery should allow the other fires to complete)", got)
 	}
 }
+
+// TestScheduler_InFlightSuppressesDoubleFire regresses the x30000
+// compound-test ceiling: when a fire takes longer than the tick
+// interval, the previous fire's RecordResult hasn't yet advanced
+// next_run_at, so the same row appears in the NEXT tick's due list
+// and fires AGAIN. Before the in-flight tracker fix, this produced
+// 2× MCP call counts at compound test scale=30000.
+//
+// Test shape: one schedule due in the past + a fake runner that
+// blocks for 300ms + back-to-back tick() calls 50ms apart. Without
+// the in-flight tracker, every tick during the in-flight window
+// re-fires the same schedule. With the tracker, only the FIRST
+// tick fires; subsequent ticks see the def in s.inFlight and skip.
+func TestScheduler_InFlightSuppressesDoubleFire(t *testing.T) {
+	enabled := true
+	def := scheduleDef{Agent: "researcher", Schedule: "0 * * * *", Enabled: &enabled}
+
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	ctx := context.Background()
+	defJSON, _ := json.Marshal(def)
+	const defID = "sd-double-fire"
+	if _, err := st.ScheduleDefCreate(ctx, store.ScheduleDefRow{
+		DefID:      defID,
+		Name:       "sched-double-fire",
+		Definition: defJSON,
+	}); err != nil {
+		t.Fatalf("def create: %v", err)
+	}
+	_ = st.ScheduleDefSetActive(ctx, "sched-double-fire", defID, "test")
+	_ = st.ScheduleRunStateSeed(ctx, defID, time.Now().Add(-time.Minute))
+
+	const perFireDelay = 300 * time.Millisecond
+	var calls atomic.Int32
+	fr := &fakeRunner{onRun: func(_ runner.RunInput) {
+		calls.Add(1)
+		time.Sleep(perFireDelay)
+	}}
+	sched := New(Config{TickInterval: time.Hour, MaxConcurrentFires: 8}, st, fr, nil, nil, t.Logf)
+
+	// First tick fires the schedule asynchronously (via the goroutine
+	// pool). The fire takes 300ms; meanwhile we issue more ticks at
+	// 50ms intervals. WITHOUT the in-flight tracker, each of these
+	// ticks would re-fire the same schedule (the listDue query still
+	// returns it because next_run_at hasn't advanced yet).
+	go sched.tick(ctx)
+	for i := 0; i < 4; i++ {
+		time.Sleep(50 * time.Millisecond)
+		sched.tick(ctx)
+	}
+	// Wait for the in-flight fire to finish.
+	time.Sleep(perFireDelay + 100*time.Millisecond)
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("calls = %d, want 1 (in-flight tracker should have suppressed re-fires while the first fire was running)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the ceiling the compound test (#271) surfaced at scale=30000. Every schedule was firing **twice** (60000 MCP calls instead of 30000) and the test's per-server call-count assertion correctly **FAILED**.

**Root cause:** when a fire's \`RecordResult\` write is slower than the tick interval (100 ms), the same row still appears as "due" on the next tick and fires again before the previous fire's status update lands. The for-loop's only guard was \`ctx.Done()\` — no suppression of already-firing rows.

## Fix

Add a \`sync.Map\` field \`inFlight\` on \`Scheduler\`. Keys = \`def_id\`s whose fire goroutine is currently running.

- \`tick()\` does atomic \`LoadOrStore(def_id, time.Now())\` before slot-acquire. Loaded keys (= "previous fire still running") are skipped.
- Fire goroutine's deferred cleanup deletes the entry — runs **AFTER** the panic recover so panicking fires still clear their slot before the next tick.
- \`ctx.Done()\` path explicitly Deletes the reserved entry so a cancelled tick doesn't leave def_ids "stuck" in-flight forever.

Single-replica only. Cluster mode (v0.12+) gets symmetric suppression via the existing per-def advisory-lock pattern already used by heartbeat / memory / channels sweepers.

## Regression test

\`TestScheduler_InFlightSuppressesDoubleFire\`:
- 1 schedule, fakeRunner sleeps 300 ms per fire
- 5 back-to-back ticks at 50 ms (4 fall during the in-flight window)
- Asserts: \`calls == 1\` (without fix: \`2\`)

Reproduces the exact pattern the compound test caught at scale=30000, just shrunken to a deterministic unit-scale shape.

## Verified at compound-test scale

Re-ran the compound test (\`TestSchedulerBearerCompound\`) at the scales that previously exposed the race:

| Scale | Pre-fix | Post-fix |
|---|---|---|
| 30000 | 60000 calls/srv ✗, 163 s | **30000 calls/srv ✓, 58 s** |
| 50000 | (n/a) | **50000 calls/srv ✓, 115 s** |
| 100000 | (n/a) | **75% complete at 5min test deadline** (rate ceiling, not race) |

Full characterisation including the scale curve + machine specs lives at \`~/work/loomcycle-internal/doc-internal/research/scheduler-compound-test-2026-05-28/\`.

## Test plan

- [x] \`go test ./...\` — 54 packages pass, 0 failures
- [x] \`go vet\` + \`gofmt -l\` clean
- [x] New regression test \`TestScheduler_InFlightSuppressesDoubleFire\` — passes with fix, FAILS without (verified via \`git stash\`)
- [x] Compound test at scale=30000 → 30000 calls per server, 0 mismatches, 58 s wall
- [x] Compound test at scale=50000 → 50000 calls per server, 0 mismatches, 115 s wall

🤖 Generated with [Claude Code](https://claude.com/claude-code)