### PR TITLE
docs(claude-code): add CLAUDE-CODE.md operator setup page (RFC B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Repo-side docs (this directory):
 - [`docs/TOOLS.md`](docs/TOOLS.md) — two-layer default-deny model, every built-in tool, MCP / LocalAPI integrations, per-request narrowing.
 - [`docs/MCP_INTEGRATION.md`](docs/MCP_INTEGRATION.md) — end-to-end MCP HTTP pipeline: request lifecycle, `${run.user_bearer}` substitution, model-visibility boundary, recipe for wrapping a REST API as an MCP server consumable by loomcycle.
 - [`docs/MCP_SERVER.md`](docs/MCP_SERVER.md) — register loomcycle as an MCP server in Claude Code / Claude Desktop: copy-paste config snippets for Docker / Homebrew / direct-binary transports + the `loomcycle mcp install` helper.
+- [`docs/CLAUDE-CODE.md`](docs/CLAUDE-CODE.md) — driving loomcycle from Claude Code: the recommended `claude-code-plugin-loomcycle` plugin (slash commands + skills + hooks) vs. the manual `loomcycle mcp install` path.
 - [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) — operator config guide: provider/tier/user_tier resolution rules, four cookbook patterns (single/multi-provider × single/multi-user-tier), `models:` alias map, and the agent `.md` frontmatter field reference.
 - [`docs/POSTGRES.md`](docs/POSTGRES.md) — Postgres backend operator guide: configuration, migrations, sqlite→postgres runbook, concurrency benchmark.
 - [`docs/GRPC.md`](docs/GRPC.md) — gRPC surface: enablement, wire-shape parity with HTTP+SSE, error mapping, Python adapter quick-start.

--- a/docs/CLAUDE-CODE.md
+++ b/docs/CLAUDE-CODE.md
@@ -1,0 +1,61 @@
+# Using loomcycle from Claude Code
+
+There are two ways to drive loomcycle from Claude Code. Pick based on how much
+UX you want.
+
+> **Why this, not the alternative.** You can register loomcycle's MCP server
+> manually with `loomcycle mcp install` and call its 30+ meta-tools by hand —
+> that works, but you compose each `op` discriminator and remember each input
+> schema yourself. The **plugin** pre-wires the server and adds slash commands
+> + skills, so common workflows are one command instead of a hand-authored
+> tool call. The manual path stays fully supported for operators who prefer it.
+
+## Recommended: the Claude Code plugin
+
+[`claude-code-plugin-loomcycle`](https://github.com/denn-gubsky/claude-code-plugin-loomcycle)
+is a Claude Code plugin that pre-wires the `loomcycle mcp` server and adds:
+
+- **6 slash commands** — `/loomcycle:run`, `/loomcycle:runs`,
+  `/loomcycle:cancel`, `/loomcycle:snapshot`, `/loomcycle:eval`,
+  `/loomcycle:connect`.
+- **4 skills** — spawn-evaluator, replay-failed-run, diff-agentdefs,
+  import-claude-code.
+- **2 opt-in hooks** — run telemetry + auto-snapshot-on-error (both disabled by
+  default).
+
+Install:
+
+```text
+/plugin marketplace add denn-gubsky/claude-code-plugin-loomcycle
+/plugin install loomcycle
+```
+
+You'll be prompted for the loomcycle binary path, your `loomcycle.yaml` path,
+the `LOOMCYCLE_AUTH_TOKEN` bearer (stored in your OS keychain), and the base
+URL. The plugin then launches `loomcycle mcp --config <your.yaml>` automatically.
+
+The plugin **does not** bundle or start loomcycle — install loomcycle separately
+(Homebrew / Docker / release binary) and have an instance reachable first.
+
+## Manual: `loomcycle mcp install`
+
+If you'd rather not use the plugin, register the MCP server directly:
+
+```sh
+loomcycle mcp install            # prints a `claude mcp add` line + JSON snippet
+```
+
+Paste the snippet into Claude Code's config. Claude Code then sees loomcycle's
+meta-tools (`spawn_run`, `cancel_run`, `list_runs`, snapshot ops, `evaluation`,
+`agentdef`, …) as ordinary MCP tools. See [`MCP_SERVER.md`](MCP_SERVER.md) for
+the full meta-tool reference and transport options (docker / brew / binary).
+
+## Which should I use?
+
+| | Plugin | `mcp install` |
+|---|---|---|
+| Setup | `/plugin install` once | paste a config snippet |
+| UX | slash commands + skills | raw MCP tools |
+| Best for | day-to-day operation from the IDE | scripting / custom orchestration |
+
+Both consume the same `loomcycle mcp` server — the plugin is the UX layer on top.


### PR DESCRIPTION
## Summary

The single loomcycle-side change for RFC B (Claude Code plugin). Adds `docs/CLAUDE-CODE.md`, a one-page operator guide for driving loomcycle from Claude Code, and links it from the README docs index.

The plugin itself ships from a **separate repo** (`denn-gubsky/claude-code-plugin-loomcycle`) and consumes loomcycle's existing `loomcycle mcp` meta-tools verbatim — **zero runtime/code changes** here.

## Why

RFC B closes the v1.x batch: it moves *runtime control* into the IDE (the counterpart to RFC C's data-movement `loomcycle import claude-code`). Operators need a discoverable pointer from the loomcycle repo to the plugin, plus a clear statement of the two integration paths.

## What

- `docs/CLAUDE-CODE.md` — recommended plugin path (`/plugin marketplace add` + `/plugin install`, slash commands + skills + opt-in hooks) vs. the manual `loomcycle mcp install` path, with a "which should I use" table and the install-separately / no-lifecycle-management caveats.
- README docs-index link next to `MCP_SERVER.md`.

## Tested

- Markdown renders; internal links (`MCP_SERVER.md`) resolve.
- Doc-only change; no build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)