### PR TITLE
feat(parent-context): propagate caller tracking lineage to Agent-tool sub-agents

### DIFF
--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.12.7",
+  "version": "0.12.8",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 46 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed AND v0.11.5 setMemoryEntry + deleteMemoryEntry), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.11.5 Channel admin CRUD (createChannel + updateChannel + deleteChannel — runtime substrate; yaml channels refuse mutation with HTTP 409), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -153,6 +153,7 @@ export class LoomcycleClient {
     if (opts.userTier !== undefined) body.user_tier = opts.userTier;
     if (opts.userBearer !== undefined) body.user_bearer = opts.userBearer;
     if (opts.userCredentials !== undefined) body.user_credentials = opts.userCredentials;
+    if (opts.parentContext !== undefined) body.parent_context = opts.parentContext;
     yield* this.streamSSE("/v1/runs", body, opts.signal, opts.debug);
   }
 
@@ -186,6 +187,7 @@ export class LoomcycleClient {
     if (opts.userTier !== undefined) body.user_tier = opts.userTier;
     if (opts.userBearer !== undefined) body.user_bearer = opts.userBearer;
     if (opts.userCredentials !== undefined) body.user_credentials = opts.userCredentials;
+    if (opts.parentContext !== undefined) body.parent_context = opts.parentContext;
     yield* this.streamSSE(
       `/v1/sessions/${encodeURIComponent(opts.sessionId)}/messages`,
       body,

--- a/adapters/ts/src/index.ts
+++ b/adapters/ts/src/index.ts
@@ -87,6 +87,7 @@ export type {
   ContinueOptions,
   EventType,
   HostWidening,
+  ParentContext,
   PromptContent,
   PromptSegment,
   RetryInfo,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -103,6 +103,9 @@ export interface AgentEvent {
   run_id?: string;
   session_id?: string;
   parent_agent_id?: string | null;
+  // v0.12.x — opaque caller-tracking lineage on the `event: agent` frame
+  // (and inherited by sub-agents). Present only when the run carried it.
+  parent_context?: ParentContext;
   // v0.9.x — client-synthesized observability fields, populated only on
   // events of `type: "_meta"`. `meta_subtype` is always set on a
   // _meta event (distinguishes open from close). `meta_reason` is set
@@ -177,6 +180,14 @@ export interface RunOptions {
    *  field auto-promotes to `userCredentials.default` for back-compat
    *  with v0.8.x flows. Never persisted; never logged. */
   userCredentials?: Record<string, string>;
+  /** Opaque caller-tracking lineage (v0.12.x). Carried verbatim by the
+   *  runtime, inherited UNCHANGED by every sub-agent the Agent tool
+   *  spawns, persisted on each run row, and echoed back on the per-agent
+   *  report surfaces (agent status, run-state stream, the `event: agent`
+   *  frame) — so you can attribute a child sub-agent's usage to the
+   *  user-initiated request that spawned the whole tree. Not a secret.
+   *  Omitted = no tracking context. */
+  parentContext?: ParentContext;
   /** Opt-in observability: when true, the iterator emits client-
    *  synthesized `{ type: "_meta", meta_subtype: "stream_open" | "stream_close" }`
    *  events around the real event stream. `meta_reason` carries the
@@ -186,6 +197,21 @@ export interface RunOptions {
    *  closed" log entries without inferring from event timing. */
   debug?: boolean;
   signal?: AbortSignal;
+}
+
+/** Opaque caller-tracking lineage (v0.12.x) attached to a run and
+ *  propagated to all its sub-agents. The runtime stores and echoes
+ *  these fields verbatim and never interprets them. All fields
+ *  optional; an all-empty object is treated as absent. */
+export interface ParentContext {
+  /** The consumer's identifier for the user-initiated run at the root of
+   *  the spawn tree — echoed on every descendant. */
+  root_agent_run_id?: string;
+  /** The consumer's logical-operation key for the root request. */
+  function_key?: string;
+  /** The consumer's tier marker captured at root-run time (distinct from
+   *  `userTier`, which is loomcycle's resolver policy). */
+  tier_at_run?: string;
 }
 
 export interface ContinueOptions {
@@ -218,6 +244,10 @@ export interface ContinueOptions {
    *  {@link RunOptions.userCredentials} for the full shape — same
    *  semantics, supplied per-continuation rather than per-fresh-run. */
   userCredentials?: Record<string, string>;
+  /** Opaque caller-tracking lineage (v0.12.x). See
+   *  {@link RunOptions.parentContext} — same shape; a continuation may
+   *  (re)set the lineage for the new run it creates. */
+  parentContext?: ParentContext;
   /** Opt-in observability: see {@link RunOptions.debug}. Same shape. */
   debug?: boolean;
   signal?: AbortSignal;
@@ -274,6 +304,11 @@ export interface Agent {
   usage: AgentUsage;
   last_heartbeat_at: string | null;
   live: boolean;
+  /** Opaque caller-tracking lineage this run carries (inherited from its
+   *  root for sub-agents), v0.12.x. Echoed here alongside `usage` so you
+   *  can attribute a child sub-agent's cost to the user-initiated request
+   *  in a single fetch. Omitted when the run carried no context. */
+  parent_context?: ParentContext;
 }
 
 export interface ListAgentsResponse {
@@ -896,6 +931,10 @@ export interface RunStateEvent {
   stop_reason?: string;
   error?: string;
   ts: string;
+  /** Opaque caller-tracking lineage echoed on the transition (v0.12.x),
+   *  so a subscriber learns which root request a finishing sub-agent
+   *  belongs to. Omitted when the run carried no context. */
+  parent_context?: ParentContext;
 }
 
 /** Initial stream_open frame emitted before the first run_state. */

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -135,6 +135,36 @@ describe("runStreaming", () => {
     });
   });
 
+  it("forwards parent_context when set (v0.12.x tracking lineage)", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse(['event: done\ndata: {"type":"done"}\n\n']),
+    ]);
+    for await (const _ of client.runStreaming({
+      agent: "cv-batch-adapter",
+      segments: [],
+      parentContext: {
+        root_agent_run_id: "run_abc",
+        function_key: "cv-batch",
+        tier_at_run: "pro",
+      },
+    })) {}
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect(body.parent_context).toEqual({
+      root_agent_run_id: "run_abc",
+      function_key: "cv-batch",
+      tier_at_run: "pro",
+    });
+  });
+
+  it("omits parent_context when undefined (back-compat)", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse(['event: done\ndata: {"type":"done"}\n\n']),
+    ]);
+    for await (const _ of client.runStreaming({ agent: "qa", segments: [] })) {}
+    const body = JSON.parse(fetchMock.mock.calls[0]![1]!.body as string);
+    expect("parent_context" in body).toBe(false);
+  });
+
   // omitted-when-undefined contract: existing callers see no wire shape change.
   it("omits user_credentials when undefined (no shape change for v0.8.x callers)", async () => {
     const { client, fetchMock } = makeClient([

--- a/internal/api/http/agent_subagent_test.go
+++ b/internal/api/http/agent_subagent_test.go
@@ -680,3 +680,94 @@ func TestSubAgent_InheritsParentUserBearer(t *testing.T) {
 		}
 	}
 }
+
+// TestSubAgent_InheritsParentContext is the load-bearing test for the
+// cv-batch child-tagging feature: a parent run started with a
+// parent_context must have that SAME context copied onto every
+// sub-agent's persisted run row. Without the copy in runSubAgent, the
+// child rows carry no link back to the user-initiated request and the
+// consumer's cost aggregation can't roll up the batch.
+//
+// Regression: delete the `parentIdentity.ParentContext.Clone()` line in
+// server.go runSubAgent and this test fails (child ParentContext == nil).
+func TestSubAgent_InheritsParentContext(t *testing.T) {
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		"parent": {Model: "stub-model", AllowedTools: []string{"Agent"}, SystemPrompt: "you are the parent"},
+		"child":  {Model: "stub-model", AllowedTools: []string{}, SystemPrompt: "you are the child"},
+	}
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{ // parent: spawn the child
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{
+					ID: "tu1", Name: "Agent", Input: json.RawMessage(`{"name":"child","prompt":"go"}`),
+				}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 2}},
+			},
+			{ // child
+				{Type: providers.EventText, Text: "child done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 3, OutputTokens: 2}},
+			},
+			{ // parent: final
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 12, OutputTokens: 3}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent_pc.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Explicit agent_id so we can look up the parent + its children
+	// deterministically. parent_context is the opaque tracking lineage.
+	body := `{"agent":"parent","agent_id":"parent-1",` +
+		`"parent_context":{"root_agent_run_id":"run_root","function_key":"cv-batch","tier_at_run":"pro"},` +
+		`"segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		slurp, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, slurp)
+	}
+	_, _ = io.ReadAll(resp.Body) // drain so the run + sub-run finish
+
+	want := &store.ParentContext{RootAgentRunID: "run_root", FunctionKey: "cv-batch", TierAtRun: "pro"}
+
+	// Parent run carries the context it was started with.
+	parentRun, err := st.GetRunByAgentID(context.Background(), "parent-1")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID(parent-1): %v", err)
+	}
+	if parentRun.ParentContext == nil || *parentRun.ParentContext != *want {
+		t.Errorf("parent ParentContext = %+v, want %+v", parentRun.ParentContext, want)
+	}
+
+	// Every child sub-agent must carry the SAME context (the propagation
+	// seam). This is the assertion that fails if the copy is removed.
+	childRuns, err := st.ListRunsByParentAgentID(context.Background(), "parent-1")
+	if err != nil {
+		t.Fatalf("ListRunsByParentAgentID: %v", err)
+	}
+	if len(childRuns) == 0 {
+		t.Fatal("expected at least one child run; none found (did the spawn happen?)")
+	}
+	for _, cr := range childRuns {
+		if cr.ParentContext == nil {
+			t.Errorf("child run %s ParentContext = nil; the parent's lineage did not propagate", cr.ID)
+			continue
+		}
+		if *cr.ParentContext != *want {
+			t.Errorf("child run %s ParentContext = %+v, want %+v", cr.ID, cr.ParentContext, want)
+		}
+	}
+}

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -99,13 +99,14 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 	runErr := s.RunOnce(ctx, in, cb)
 
 	result := connector.SpawnRunResult{
-		AgentID:    regAgentID,
-		RunID:      regRunID,
-		SessionID:  regSessionID,
-		Status:     string(store.RunCompleted),
-		StopReason: finalStopReason,
-		FinalText:  finalText,
-		Usage:      finalUsage,
+		AgentID:       regAgentID,
+		RunID:         regRunID,
+		SessionID:     regSessionID,
+		Status:        string(store.RunCompleted),
+		StopReason:    finalStopReason,
+		FinalText:     finalText,
+		Usage:         finalUsage,
+		ParentContext: req.ParentContext, // v0.12.x: echo the lineage back to the caller
 	}
 	switch {
 	case runErr != nil && errors.Is(runErr, context.Canceled):

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -57,6 +57,7 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		UserTier:        req.UserTier,
 		UserBearer:      req.UserBearer,
 		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage
 	}
 
 	// Capture: the OnRegistered callback gives us the resolved IDs;

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -196,5 +196,6 @@ func runStateEventToConnector(e runstate.RunStateEvent) connector.RunStateEvent 
 		StopReason:    e.StopReason,
 		Error:         e.Error,
 		TS:            ts,
+		ParentContext: e.ParentContext,
 	}
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1329,7 +1329,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -1423,6 +1423,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		UserTier:        in.UserTier,
 		UserBearer:      in.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials: in.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 	})
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
 	// Memory tool policy: agent name + per-agent scope allowlist +
@@ -2293,7 +2294,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// emitted event through the store before forwarding to SSE. With
 	// s.store == nil the recording becomes a no-op so v0.2 callers see no
 	// behaviour change.
-	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID}
+	identity := store.RunIdentity{AgentID: agentID, UserID: req.UserID, UserTier: req.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: req.ParentContext}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(r.Context(), req.SessionID, req.Agent, req.TenantID, req.UserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
@@ -2425,6 +2426,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		UserTier:        req.UserTier,
 		UserBearer:      req.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 	})
 	// Stash the caller's host policy so any sub-agents spawned by the
 	// Agent tool inherit the same allowed_hosts / WebSearchFilter
@@ -2515,6 +2517,10 @@ type messagesRequest struct {
 	// same validation, same back-compat sugar (legacy UserBearer
 	// promoted to UserCredentials["default"] at WithRunIdentity time).
 	UserCredentials map[string]string `json:"user_credentials,omitempty"`
+	// ParentContext follows runRequest semantics — a continuation can
+	// (re)set the opaque tracking lineage for the new run it creates.
+	// Sub-agents spawned from this continuation inherit it identically.
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -2589,6 +2595,13 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	if errMsg, ok := connector.ValidateUserCredentialsMap(body.UserCredentials); !ok {
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
+	}
+	if errMsg, ok := validateParentContext(body.ParentContext); !ok {
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+	if body.ParentContext.IsZero() {
+		body.ParentContext = nil
 	}
 	providerID, model, effort, err := s.resolveAgent(sess.Agent, body.UserTier)
 	if err != nil {
@@ -2670,11 +2683,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// is per-request (v0.8.2) — a user upgrading mid-session sees
 	// the new tier applied immediately on this continuation.
 	run, err := s.store.CreateRun(r.Context(), id, store.RunIdentity{
-		AgentID:   agentID,
-		UserID:    sess.UserID,
-		UserTier:  body.UserTier,
-		Model:     model,
-		ReplicaID: s.replicaID,
+		AgentID:       agentID,
+		UserID:        sess.UserID,
+		UserTier:      body.UserTier,
+		Model:         model,
+		ReplicaID:     s.replicaID,
+		ParentContext: body.ParentContext, // v0.12.x: tracking lineage for this continuation + its sub-agents
 	})
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -2766,6 +2780,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		UserTier:        body.UserTier,
 		UserBearer:      body.UserBearer,      // v0.8.x: per-run MCP bearer
 		UserCredentials: body.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 	})
 	// Sub-agents spawned by this continuation must inherit the
 	// caller-authoritative host narrowing, same as runRequest +
@@ -3215,6 +3230,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		UserTier:   parentIdentity.UserTier, // v0.8.2: same user_tier across the sub-run tree
 		AgentDefID: defID,                   // v0.8.5: pin defID on the sub-run for evaluation denormalisation
 		Model:      model,                   // resolved model — written at create so the UI sees it during the run
+		// v0.12.x: the root's opaque tracking lineage flows UNCHANGED to
+		// every descendant (Clone so child + parent don't alias). This is
+		// the propagation seam — remove it and child run rows lose their
+		// link back to the user-initiated request.
+		ParentContext: parentIdentity.ParentContext.Clone(),
 	}
 	subSessionID, subRunID, err := s.openOrCreateSessionAndRun(ctx, "", name, "", parentIdentity.UserID, subIdentity)
 	if err != nil {
@@ -3350,10 +3370,11 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
 		UserID:          parentIdentity.UserID,
 		AgentID:         subAgentID,
-		UserTier:        parentIdentity.UserTier,        // v0.8.2: sub-agents inherit parent's user_tier
-		AgentDefID:      defID,                          // v0.8.7: surface pinned def_id via Context.self
-		UserBearer:      parentIdentity.UserBearer,      // v0.8.x: bearer inherited identically (same end-user)
-		UserCredentials: parentIdentity.UserCredentials, // v1.x RFC F: credentials map inherited identically
+		UserTier:        parentIdentity.UserTier,              // v0.8.2: sub-agents inherit parent's user_tier
+		AgentDefID:      defID,                                // v0.8.7: surface pinned def_id via Context.self
+		UserBearer:      parentIdentity.UserBearer,            // v0.8.x: bearer inherited identically (same end-user)
+		UserCredentials: parentIdentity.UserCredentials,       // v1.x RFC F: credentials map inherited identically
+		ParentContext:   parentIdentity.ParentContext.Clone(), // v0.12.x: tracking lineage flows to grandchildren too
 	})
 	subCtx = tools.WithAgentName(subCtx, name)
 	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1369,10 +1369,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// publishes. Constructed once; passed to every finishRun* below
 	// AND used right now for the "running" transition.
 	meta := runStateMeta{
-		RunID:   runID,
-		AgentID: agentID,
-		Agent:   effectiveAgentName,
-		UserID:  effectiveUserID,
+		RunID:         runID,
+		AgentID:       agentID,
+		Agent:         effectiveAgentName,
+		UserID:        effectiveUserID,
+		ParentContext: in.ParentContext,
 	}
 	// Stash the run span on the meta so finishRun* can close it with
 	// final attrs (usage totals + stop_reason + error status).
@@ -2332,11 +2333,12 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// v0.9.x: identity bundle threaded into finishRun* + the
 	// "running" transition publish below.
 	meta := runStateMeta{
-		RunID:    runID,
-		AgentID:  agentID,
-		Agent:    req.Agent,
-		UserID:   req.UserID,
-		otelSpan: runSpan,
+		RunID:         runID,
+		AgentID:       agentID,
+		Agent:         req.Agent,
+		UserID:        req.UserID,
+		otelSpan:      runSpan,
+		ParentContext: req.ParentContext,
 	}
 	if errors.Is(regErr, cancel.ErrInUse) {
 		// We've already created the session+run row in the store
@@ -2408,6 +2410,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		"run_id":          runID,
 		"session_id":      sessionID,
 		"parent_agent_id": nil,
+		"parent_context":  req.ParentContext, // v0.12.x: opaque tracking lineage (nil when absent)
 	})
 
 	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
@@ -2719,11 +2722,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}, cancelFn)
 	// v0.9.x: per-run meta for runstate.Bus.
 	meta := runStateMeta{
-		RunID:    run.ID,
-		AgentID:  agentID,
-		Agent:    sess.Agent,
-		UserID:   sess.UserID,
-		otelSpan: runSpan,
+		RunID:         run.ID,
+		AgentID:       agentID,
+		Agent:         sess.Agent,
+		UserID:        sess.UserID,
+		otelSpan:      runSpan,
+		ParentContext: body.ParentContext,
 	}
 	if errors.Is(regErr, cancel.ErrInUse) {
 		// Same orphan-row mitigation as handleRuns — the run was
@@ -2768,6 +2772,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		"run_id":          run.ID,
 		"session_id":      id,
 		"parent_agent_id": nil,
+		"parent_context":  body.ParentContext, // v0.12.x: opaque tracking lineage (nil when absent)
 	})
 
 	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
@@ -3288,6 +3293,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		UserID:        parentIdentity.UserID,
 		ParentAgentID: parentIdentity.AgentID,
 		otelSpan:      subRunSpan,
+		ParentContext: parentIdentity.ParentContext, // v0.12.x: sub-agent's run-state events carry the root's lineage
 	}
 	s.publishRunState(subMeta, "running", "", "")
 
@@ -3498,6 +3504,12 @@ type agentResponse struct {
 	// cancel handle. Empty (and omitted from JSON) in single-replica
 	// deployments so the UI stays uncluttered for the common case.
 	ReplicaID string `json:"replica_id,omitempty"`
+	// v0.12.x parent_context — the opaque caller-tracking lineage this
+	// run carries (inherited from its root for sub-agents). Echoed here
+	// alongside Usage so a consumer can attribute a child sub-agent's
+	// cost to the user-initiated request in a single fetch. Omitted when
+	// the run carried no context.
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 type agentResponseUsage struct {
@@ -3542,8 +3554,9 @@ func runToAgentResponse(r store.Run, live bool) agentResponse {
 			Model:               r.Model,
 			Provider:            r.Provider,
 		},
-		Live:      live,
-		ReplicaID: r.ReplicaID,
+		Live:          live,
+		ReplicaID:     r.ReplicaID,
+		ParentContext: r.ParentContext, // v0.12.x: echo tracking lineage alongside usage
 	}
 	if !r.CompletedAt.IsZero() {
 		t := r.CompletedAt
@@ -3965,6 +3978,9 @@ type runStateMeta struct {
 	Agent         string
 	UserID        string
 	ParentAgentID string
+	// ParentContext is the run's opaque tracking lineage, echoed on the
+	// published RunStateEvent (v0.12.x).
+	ParentContext *store.ParentContext
 	// otelSpan is the top-level loomcycle.run span the four run-creation
 	// sites open before kicking off the loop. finishRun* attaches final
 	// attributes (usage totals, stop_reason, error status) to it via
@@ -3989,6 +4005,7 @@ func (s *Server) publishRunState(m runStateMeta, status, stopReason, errMsg stri
 		Status:        status,
 		StopReason:    stopReason,
 		Error:         errMsg,
+		ParentContext: m.ParentContext,
 	})
 }
 
@@ -4239,28 +4256,11 @@ func validIdent(s string) bool {
 	return true
 }
 
-// parentContextMaxFieldLen bounds each parent_context string so a
-// consumer can't push unbounded values into the run table / event
-// stream. The fields are opaque consumer ids/keys; 256 is generous.
-const parentContextMaxFieldLen = 256
-
-// validateParentContext bounds the opaque caller-tracking fields. A nil
-// or all-empty struct is valid (treated as "no context" by the caller).
-// Returns (errMsg, ok); ok=false means reject with 400.
+// validateParentContext delegates to connector.ValidateParentContext so
+// every wire surface (HTTP, MCP, gRPC) bounds the opaque tracking fields
+// identically — one source of truth, mirroring ValidateUserCredentialsMap.
 func validateParentContext(pc *store.ParentContext) (string, bool) {
-	if pc == nil {
-		return "", true
-	}
-	for field, v := range map[string]string{
-		"root_agent_run_id": pc.RootAgentRunID,
-		"function_key":      pc.FunctionKey,
-		"tier_at_run":       pc.TierAtRun,
-	} {
-		if len(v) > parentContextMaxFieldLen {
-			return fmt.Sprintf("parent_context.%s exceeds %d bytes", field, parentContextMaxFieldLen), false
-		}
-	}
-	return "", true
+	return connector.ValidateParentContext(pc)
 }
 
 // validUserBearer reports whether s is a valid per-run MCP bearer

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2101,6 +2101,16 @@ type runRequest struct {
 	// See `Context.help per-run-credentials` for the operator-facing
 	// reference; rfcs/per-run-credentials.md for the design lock.
 	UserCredentials map[string]string `json:"user_credentials,omitempty"`
+	// ParentContext is opaque caller-tracking lineage (v0.12.x). The
+	// runtime carries it verbatim, inherits it onto every sub-agent the
+	// Agent tool spawns, persists it on each run row, and echoes it on
+	// the per-agent report surfaces (agents stream, agent status, SSE
+	// "agent" frame) — so an external consumer can attribute a child
+	// sub-agent's usage back to the user-initiated request. Field
+	// lengths bounded at wire entry; an all-empty struct is treated as
+	// absent. Not a secret (safe to persist/log/emit). Omitted = no
+	// tracking context (back-compat).
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
@@ -2162,6 +2172,16 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	if errMsg, ok := connector.ValidateUserCredentialsMap(req.UserCredentials); !ok {
 		http.Error(w, errMsg, http.StatusBadRequest)
 		return
+	}
+	// Bound the opaque tracking fields so a consumer can't push unbounded
+	// strings into the run table / event stream. An all-empty struct is
+	// normalised to nil so back-compat decode paths see "no context".
+	if errMsg, ok := validateParentContext(req.ParentContext); !ok {
+		http.Error(w, errMsg, http.StatusBadRequest)
+		return
+	}
+	if req.ParentContext.IsZero() {
+		req.ParentContext = nil
 	}
 
 	providerID, model, effort, err := s.resolveAgent(req.Agent, req.UserTier)
@@ -4196,6 +4216,30 @@ func validIdent(s string) bool {
 		}
 	}
 	return true
+}
+
+// parentContextMaxFieldLen bounds each parent_context string so a
+// consumer can't push unbounded values into the run table / event
+// stream. The fields are opaque consumer ids/keys; 256 is generous.
+const parentContextMaxFieldLen = 256
+
+// validateParentContext bounds the opaque caller-tracking fields. A nil
+// or all-empty struct is valid (treated as "no context" by the caller).
+// Returns (errMsg, ok); ok=false means reject with 400.
+func validateParentContext(pc *store.ParentContext) (string, bool) {
+	if pc == nil {
+		return "", true
+	}
+	for field, v := range map[string]string{
+		"root_agent_run_id": pc.RootAgentRunID,
+		"function_key":      pc.FunctionKey,
+		"tier_at_run":       pc.TierAtRun,
+	} {
+		if len(v) > parentContextMaxFieldLen {
+			return fmt.Sprintf("parent_context.%s exceeds %d bytes", field, parentContextMaxFieldLen), false
+		}
+	}
+	return "", true
 }
 
 // validUserBearer reports whether s is a valid per-run MCP bearer

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -135,6 +135,9 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 	if errMsg, ok := connector.ValidateUserCredentialsMap(req.UserCredentials); !ok {
 		return toolErr("spawn_run: " + errMsg), nil
 	}
+	if errMsg, ok := connector.ValidateParentContext(req.ParentContext); !ok {
+		return toolErr("spawn_run: " + errMsg), nil
+	}
 
 	useStreaming := env.session != nil && env.session.RunEventsEnabled() && env.runner != nil
 	var result connector.SpawnRunResult
@@ -169,6 +172,7 @@ func spawnRunStreaming(ctx context.Context, env *handlerEnv, req connector.Spawn
 		UserTier:        req.UserTier,
 		UserBearer:      req.UserBearer,
 		UserCredentials: req.UserCredentials, // v1.x RFC F per-tool named credentials
+		ParentContext:   req.ParentContext,   // v0.12.x opaque tracking lineage
 	}
 
 	var (

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -138,6 +138,11 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 	if errMsg, ok := connector.ValidateParentContext(req.ParentContext); !ok {
 		return toolErr("spawn_run: " + errMsg), nil
 	}
+	// Normalise an all-empty struct to nil so the echo surfaces omit it,
+	// matching the HTTP handlers (handleRuns / handleMessages).
+	if req.ParentContext.IsZero() {
+		req.ParentContext = nil
+	}
 
 	useStreaming := env.session != nil && env.session.RunEventsEnabled() && env.runner != nil
 	var result connector.SpawnRunResult
@@ -214,13 +219,14 @@ func spawnRunStreaming(ctx context.Context, env *handlerEnv, req connector.Spawn
 	runErr := env.runner.RunOnce(ctx, in, cb)
 
 	result := connector.SpawnRunResult{
-		AgentID:    regAgentID,
-		RunID:      regRunID,
-		SessionID:  regSessionID,
-		Status:     "completed",
-		StopReason: finalStopReason,
-		FinalText:  finalText,
-		Usage:      finalUsage,
+		AgentID:       regAgentID,
+		RunID:         regRunID,
+		SessionID:     regSessionID,
+		Status:        "completed",
+		StopReason:    finalStopReason,
+		FinalText:     finalText,
+		Usage:         finalUsage,
+		ParentContext: req.ParentContext, // v0.12.x: echo the lineage back to the caller
 	}
 	switch {
 	case runErr != nil && errors.Is(runErr, context.Canceled):

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -38,7 +38,8 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 					"user_credentials": {"type": "object", "additionalProperties": {"type": "string"}, "description": "v1.x RFC F per-tool named credentials map. Keys [a-zA-Z0-9_-]{1,64}; values arbitrary strings. Substituted into ${run.credentials.<name>} in mcp_servers.*.headers. Coexists with user_bearer (legacy promotes to user_credentials.default for back-compat)."},
 					"allowed_tools":    {"type": "array", "items": {"type": "string"}},
 					"allowed_hosts":    {"type": "array", "items": {"type": "string"}, "description": "OMIT for no narrowing (operator's static allowlist applies). Pass empty array [] to DENY ALL outbound HTTP. Pass non-empty array to intersect with operator's list."},
-					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]}
+					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]},
+					"parent_context":   {"type": "object", "description": "v0.12.x opaque caller-tracking lineage carried verbatim, inherited by every sub-agent, and echoed on the per-agent report surfaces so a consumer can attribute a child sub-agent's usage to the user-initiated request.", "properties": {"root_agent_run_id": {"type": "string"}, "function_key": {"type": "string"}, "tier_at_run": {"type": "string"}}}
 				},
 				"anyOf": [
 					{"required": ["agent"]},

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // ToolResult is the output of a builtin-tool invocation through the
@@ -78,6 +79,12 @@ type SpawnRunRequest struct {
 	// ${run.credentials.<name>}. Sub-agents inherit the whole map.
 	// See rfcs/per-run-credentials.md for the locked design.
 	UserCredentials map[string]string `json:"user_credentials,omitempty"`
+
+	// ParentContext is opaque caller-tracking lineage (v0.12.x) carried
+	// verbatim, inherited by every sub-agent the Agent tool spawns,
+	// persisted on each run row, and echoed on the per-agent report
+	// surfaces. Not a secret. Nil = no context (back-compat).
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 // SpawnRunResult is the final outcome of a SpawnRun call (returned
@@ -92,6 +99,10 @@ type SpawnRunResult struct {
 	FinalText  string           `json:"final_text,omitempty"`
 	Usage      *providers.Usage `json:"usage,omitempty"`
 	Error      string           `json:"error,omitempty"`
+	// ParentContext echoes the run's tracking lineage back to the
+	// caller (v0.12.x) so a sub-agent's usage can be attributed to the
+	// root request. Nil when the run carried no context.
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 // CancelRunResult reports the outcome of CancelRun.

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -480,4 +480,7 @@ type RunStateEvent struct {
 	StopReason    string `json:"stop_reason,omitempty"`
 	Error         string `json:"error,omitempty"`
 	TS            string `json:"ts"` // RFC3339
+	// ParentContext echoes the run's opaque tracking lineage (v0.12.x).
+	// Nil when the run carried no context.
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }

--- a/internal/connector/validation.go
+++ b/internal/connector/validation.go
@@ -1,6 +1,36 @@
 package connector
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// parentContextMaxFieldLen bounds each parent_context field so a
+// consumer can't push unbounded strings into the run table / event
+// stream. The fields are opaque consumer ids/keys; 256 is generous.
+const parentContextMaxFieldLen = 256
+
+// ValidateParentContext bounds the opaque caller-tracking fields
+// (v0.12.x). Lives here so all transports (HTTP, gRPC, MCP) validate
+// identically. A nil or all-empty struct is valid (treated as "no
+// context" by the caller). Returns errMsg suitable for a 400 / MCP
+// tool-error naming the offending field.
+func ValidateParentContext(pc *store.ParentContext) (errMsg string, ok bool) {
+	if pc == nil {
+		return "", true
+	}
+	for field, v := range map[string]string{
+		"root_agent_run_id": pc.RootAgentRunID,
+		"function_key":      pc.FunctionKey,
+		"tier_at_run":       pc.TierAtRun,
+	} {
+		if len(v) > parentContextMaxFieldLen {
+			return fmt.Sprintf("parent_context.%s exceeds %d bytes", field, parentContextMaxFieldLen), false
+		}
+	}
+	return "", true
+}
 
 // ValidateUserCredentialsMap validates each key in the v1.x RFC F
 // per-run credentials map against the wire-locked charset. Lives in

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // Runner is the contract both wire surfaces depend on. internal/api/http
@@ -176,6 +177,23 @@ type RunInput struct {
 	// trusts its caller. Empty map is valid (= run uses no per-tool
 	// auth). Never persisted; never logged; not emitted in OTEL spans.
 	UserCredentials map[string]string
+
+	// ParentContext is opaque caller-tracking lineage the runtime
+	// carries but never interprets: it is set once on the root run,
+	// inherited UNCHANGED by every descendant sub-agent (the Agent
+	// tool copies it parent→child, same as UserCredentials), persisted
+	// on each run row, and echoed back on the per-agent report surfaces
+	// (RunStateEvent, the agent status object, the SSE "agent" frame).
+	// It lets an external consumer link a child sub-agent's usage back
+	// to the user-initiated request that spawned the whole tree.
+	//
+	// Unlike UserBearer/UserCredentials it is NOT a secret — it is safe
+	// to persist, log, and emit. Nil = no tracking context (today's
+	// behavior; full back-compat). The canonical type lives in the
+	// store package (next to RunIdentity) so every layer — runner,
+	// tools, connector, store — can reference it without an import
+	// cycle (store imports no internal packages).
+	ParentContext *store.ParentContext
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/coord"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // RunStateEvent is the payload published on every run state transition.
@@ -45,6 +46,11 @@ type RunStateEvent struct {
 	StopReason    string    `json:"stop_reason,omitempty"`
 	Error         string    `json:"error,omitempty"`
 	TS            time.Time `json:"ts"`
+	// ParentContext echoes the run's opaque tracking lineage (v0.12.x)
+	// on each state transition, so a subscriber to the user agents
+	// stream learns which root request a finishing sub-agent belongs to
+	// without a follow-up fetch. Nil when the run carried no context.
+	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
 // subscription is one active subscriber's state.

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -487,6 +487,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 				UserTier:      e.UserTier,
 				AgentDefID:    e.AgentDefID,
 				PauseState:    e.PauseState,
+				ParentContext: e.ParentContext, // v0.12.x: restore the run's tracking lineage
 			}
 			runInserted, err := s.SnapshotRestoreRun(ctx, runRow)
 			if err != nil {

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -318,6 +318,40 @@ func TestRestore_SynthesizesSessionForPausedRun(t *testing.T) {
 	}
 }
 
+// TestRoundTrip_PreservesParentContext pins the v0.12.x contract that a
+// paused run's opaque tracking lineage survives pause→snapshot→restore.
+// Regression: the PausedRunEntry carried no ParentContext field, so the
+// SnapshotRestoreRun parent_context write was dead and the lineage was
+// lost on restore — exactly the long-running runs the feature targets.
+func TestRoundTrip_PreservesParentContext(t *testing.T) {
+	src, srcClose := newTestStore(t)
+	defer srcClose()
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	ctx := context.Background()
+
+	pc := &store.ParentContext{RootAgentRunID: "run_root", FunctionKey: "cv-batch", TierAtRun: "pro"}
+	sess, _ := src.CreateSession(ctx, "t", "qa", "user1")
+	run, _ := src.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a1", UserID: "user1", ParentContext: pc})
+	_ = src.SetRunPauseState(ctx, run.ID, store.PauseStatePaused)
+
+	_, raw, err := Capture(ctx, src, CaptureOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Restore(ctx, dst, raw, RestoreOptions{}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	got, err := dst.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("GetRun on dst: %v", err)
+	}
+	if got.ParentContext == nil || *got.ParentContext != *pc {
+		t.Errorf("restored ParentContext = %+v, want %+v", got.ParentContext, pc)
+	}
+}
+
 // TestRestore_DropsEmbeddingFieldOnPhase1 — restoring a hand-crafted
 // envelope where memory.entries[].embedding is populated (simulating
 // a Phase-2-captured snapshot) on a Phase-1 reader silently drops

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -450,6 +450,7 @@ func capturePausedRuns(ctx context.Context, s store.Store, out *PausedRunsSectio
 			StartedAt:     r.StartedAt,
 			Model:         r.Model,
 			PauseState:    r.PauseState,
+			ParentContext: r.ParentContext.Clone(), // v0.12.x: survive pause→snapshot→restore
 		}
 		// Read the session transcript and filter by run_id. Cost:
 		// O(events-in-session). For long-running sessions this is

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -16,6 +16,8 @@ package snapshot
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // SchemaVersion is the outer envelope version. Bumped only when a
@@ -293,18 +295,22 @@ type PausedRunsSection struct {
 }
 
 type PausedRunEntry struct {
-	RunID            string            `json:"run_id"`
-	AgentID          string            `json:"agent_id,omitempty"`
-	ParentAgentID    string            `json:"parent_agent_id,omitempty"`
-	UserID           string            `json:"user_id,omitempty"`
-	UserTier         string            `json:"user_tier,omitempty"`
-	Agent            string            `json:"agent"`
-	AgentDefID       string            `json:"agent_def_id,omitempty"`
-	SessionID        string            `json:"session_id"`
-	StartedAt        time.Time         `json:"started_at"`
-	Model            string            `json:"model,omitempty"`
-	PauseState       string            `json:"pause_state"`
-	TranscriptEvents []TranscriptEvent `json:"transcript_events"`
+	RunID         string    `json:"run_id"`
+	AgentID       string    `json:"agent_id,omitempty"`
+	ParentAgentID string    `json:"parent_agent_id,omitempty"`
+	UserID        string    `json:"user_id,omitempty"`
+	UserTier      string    `json:"user_tier,omitempty"`
+	Agent         string    `json:"agent"`
+	AgentDefID    string    `json:"agent_def_id,omitempty"`
+	SessionID     string    `json:"session_id"`
+	StartedAt     time.Time `json:"started_at"`
+	Model         string    `json:"model,omitempty"`
+	PauseState    string    `json:"pause_state"`
+	// ParentContext is the run's opaque caller-tracking lineage (v0.12.x),
+	// carried through the snapshot so a paused run's parent_context
+	// survives pause→snapshot→restore. Omitted when the run had none.
+	ParentContext    *store.ParentContext `json:"parent_context,omitempty"`
+	TranscriptEvents []TranscriptEvent    `json:"transcript_events"`
 	// TranscriptError records a per-run transcript-read failure. Set
 	// when GetTranscript returned an error during capture; the entry
 	// is otherwise included in the snapshot (RunID, AgentID etc.

--- a/internal/store/postgres/migrations/0030_runs_parent_context.down.sql
+++ b/internal/store/postgres/migrations/0030_runs_parent_context.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE runs DROP COLUMN parent_context;

--- a/internal/store/postgres/migrations/0030_runs_parent_context.up.sql
+++ b/internal/store/postgres/migrations/0030_runs_parent_context.up.sql
@@ -1,0 +1,11 @@
+-- v0.12.x — opaque caller-tracking lineage (root_agent_run_id /
+-- function_key / tier_at_run), set on the root run and copied verbatim
+-- onto every sub-agent the Agent tool spawns. Stored as JSON; the
+-- runtime never interprets it — it persists + echoes it so a consumer
+-- can attribute a child sub-agent's usage to the user-initiated request
+-- that spawned the whole tree.
+--
+-- Not a secret (safe to persist, unlike user_bearer/user_credentials,
+-- which are never persisted). NULLable to preserve back-compat with
+-- pre-migration rows + runs with no context.
+ALTER TABLE runs ADD COLUMN parent_context TEXT;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -285,12 +285,20 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 
 	id := newID("r_")
 	now := time.Now().UTC()
+	pcJSON, pcOK, pcErr := store.EncodeParentContext(identity.ParentContext)
+	if pcErr != nil {
+		return store.Run{}, fmt.Errorf("create run: encode parent_context: %w", pcErr)
+	}
+	var pcVal any
+	if pcOK {
+		pcVal = pcJSON
+	}
 	if err := retryOnTransientConn(ctx, func() error {
 		_, err := s.pool.Exec(ctx,
 			`INSERT INTO runs (
 				id, session_id, status, started_at,
-				agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, replica_id
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`,
+				agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, replica_id, parent_context
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
 			id, sessionID, string(store.RunRunning), now,
 			nullableText(identity.AgentID),
 			nullableText(identity.ParentAgentID),
@@ -300,6 +308,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 			nullableText(identity.AgentDefID),
 			nullableText(identity.Model),
 			nullableText(identity.ReplicaID),
+			pcVal,
 		)
 		return err
 	}); err != nil {
@@ -318,6 +327,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		AgentDefID:    identity.AgentDefID,
 		Model:         identity.Model,
 		ReplicaID:     identity.ReplicaID,
+		ParentContext: identity.ParentContext.Clone(),
 	}, nil
 }
 
@@ -528,7 +538,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
@@ -553,7 +563,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.id = $1`, runID,
@@ -616,7 +626,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1
@@ -627,7 +637,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1 AND r.status = $2
@@ -652,7 +662,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.parent_agent_id = $1
@@ -747,7 +757,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.pause_state = $1
@@ -1409,21 +1419,29 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 	if pauseState == "" {
 		pauseState = store.PauseStateRunning
 	}
+	pcJSON, pcOK, pcErr := store.EncodeParentContext(r.ParentContext)
+	if pcErr != nil {
+		return false, fmt.Errorf("snapshot restore run: encode parent_context: %w", pcErr)
+	}
+	var pcVal any
+	if pcOK {
+		pcVal = pcJSON
+	}
 	tag, err := s.pool.Exec(ctx,
 		`INSERT INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+			user_tier, agent_def_id, pause_state, parent_context
+		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
 		 ON CONFLICT (id) DO NOTHING`,
 		r.ID, r.SessionID, status, startedAt, completedAt, nullIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nullIfEmpty(r.Model), nullIfEmpty(r.Provider), nullIfEmpty(r.ErrorMsg),
 		nullIfEmpty(r.AgentID), nullIfEmpty(r.ParentAgentID), nullIfEmpty(r.ParentRunID),
 		nullIfEmpty(r.UserID), lastHbAt,
-		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState,
+		nullIfEmpty(r.UserTier), nullIfEmpty(r.AgentDefID), pauseState, pcVal,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)
@@ -4640,6 +4658,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		agentDefID                                            *string
 		pauseState                                            *string
 		replicaID                                             *string
+		parentContext                                         *string
 		lastHeartbeatAt                                       *time.Time
 		sessAgent                                             *string
 
@@ -4651,7 +4670,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
-		&agentDefID, &pauseState, &replicaID,
+		&agentDefID, &pauseState, &replicaID, &parentContext,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -4699,6 +4718,13 @@ func scanRun(r rowScanner) (store.Run, error) {
 	}
 	if replicaID != nil {
 		out.ReplicaID = *replicaID
+	}
+	if parentContext != nil {
+		pc, err := store.DecodeParentContext(*parentContext)
+		if err != nil {
+			return store.Run{}, fmt.Errorf("decode parent_context: %w", err)
+		}
+		out.ParentContext = pc
 	}
 	if sessAgent != nil {
 		out.Agent = *sessAgent

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -512,6 +512,11 @@ func (s *Store) migrate(ctx context.Context) error {
 		// stays NULL here; added for schema/struct parity. Idempotent on
 		// fresh deploys (the CREATE TABLE above already declares it).
 		`ALTER TABLE process_samples ADD COLUMN replica_id TEXT`,
+		// v0.12.x parent_context — opaque caller-tracking lineage (JSON),
+		// set on the root run and copied onto every sub-agent. NULL on
+		// legacy rows + runs with no context. Not a secret (safe to
+		// persist). Read back via DecodeParentContext.
+		`ALTER TABLE runs ADD COLUMN parent_context TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -654,9 +659,17 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 	}
 	id := newID("r_")
 	now := time.Now()
+	pcJSON, pcOK, pcErr := store.EncodeParentContext(identity.ParentContext)
+	if pcErr != nil {
+		return store.Run{}, fmt.Errorf("encode parent_context: %w", pcErr)
+	}
+	var pcVal any
+	if pcOK {
+		pcVal = pcJSON
+	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, parent_context)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
@@ -665,6 +678,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nilIfEmpty(identity.UserTier),
 		nilIfEmpty(identity.AgentDefID),
 		nilIfEmpty(identity.Model),
+		pcVal,
 	)
 	if err != nil {
 		return store.Run{}, err
@@ -681,6 +695,7 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		UserTier:      identity.UserTier,
 		AgentDefID:    identity.AgentDefID,
 		Model:         identity.Model,
+		ParentContext: identity.ParentContext.Clone(),
 	}, nil
 }
 
@@ -867,6 +882,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var agentID, parentAgentID, parentRunID, userID, userTier sql.NullString
 	var agentDefID sql.NullString
 	var pauseState sql.NullString
+	var parentContext sql.NullString
 	var sessAgent sql.NullString
 	var status string
 	if err := scanner.Scan(
@@ -876,7 +892,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
-		&agentDefID, &pauseState,
+		&agentDefID, &pauseState, &parentContext,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -924,6 +940,13 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	if pauseState.Valid {
 		r.PauseState = pauseState.String
 	}
+	if parentContext.Valid {
+		pc, err := store.DecodeParentContext(parentContext.String)
+		if err != nil {
+			return store.Run{}, fmt.Errorf("decode parent_context: %w", err)
+		}
+		r.ParentContext = pc
+	}
 	if sessAgent.Valid {
 		r.Agent = sessAgent.String
 	}
@@ -944,7 +967,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.model, r.provider, r.error,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
-		r.agent_def_id, r.pause_state,
+		r.agent_def_id, r.pause_state, r.parent_context,
 		s.agent`
 
 // runFromTable is the canonical FROM clause paired with runColumns.
@@ -1840,20 +1863,28 @@ func (s *Store) SnapshotRestoreRun(ctx context.Context, r store.Run) (bool, erro
 	if pauseState == "" {
 		pauseState = store.PauseStateRunning
 	}
+	pcJSON, pcOK, pcErr := store.EncodeParentContext(r.ParentContext)
+	if pcErr != nil {
+		return false, fmt.Errorf("snapshot restore run: encode parent_context: %w", pcErr)
+	}
+	var pcVal any
+	if pcOK {
+		pcVal = pcJSON
+	}
 	res, err := s.db.ExecContext(ctx,
 		`INSERT OR IGNORE INTO runs(
 			id, session_id, status, started_at, completed_at, stop_reason,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			model, provider, error,
 			agent_id, parent_agent_id, parent_run_id, user_id, last_heartbeat_at,
-			user_tier, agent_def_id, pause_state
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			user_tier, agent_def_id, pause_state, parent_context
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.ID, r.SessionID, status, startedNs, completedNs, nilIfEmpty(r.StopReason),
 		r.InputTokens, r.OutputTokens, r.CacheCreationTokens, r.CacheReadTokens,
 		nilIfEmpty(r.Model), nilIfEmpty(r.Provider), nilIfEmpty(r.ErrorMsg),
 		nilIfEmpty(r.AgentID), nilIfEmpty(r.ParentAgentID), nilIfEmpty(r.ParentRunID),
 		nilIfEmpty(r.UserID), lastHbNs,
-		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState,
+		nilIfEmpty(r.UserTier), nilIfEmpty(r.AgentDefID), pauseState, pcVal,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore run: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -230,6 +230,14 @@ type Run struct {
 	// created before v0.12.2 or in single-replica mode. Cross-replica
 	// cancel routes via this column.
 	ReplicaID string `json:"replica_id,omitempty"`
+
+	// ParentContext is the opaque caller-tracking lineage (v0.12.x),
+	// set on the root run and copied onto every sub-agent. Persisted as
+	// the runs.parent_context JSON column; nil for rows created before
+	// the column landed or for runs with no context. Echoed on the
+	// per-agent report surfaces so a consumer can attribute a child
+	// sub-agent's usage to the user-initiated request.
+	ParentContext *ParentContext `json:"parent_context,omitempty"`
 }
 
 // PauseState constants — the wire string values stored in runs.pause_state.
@@ -327,6 +335,57 @@ type RunIdentity struct {
 	// mode it routes cross-replica cancel requests to the owning
 	// replica via backplane broadcast. Postgres-only; SQLite ignores.
 	ReplicaID string
+	// ParentContext is opaque caller-tracking lineage (v0.12.x). Set on
+	// the root run and copied verbatim onto every sub-agent the Agent
+	// tool spawns; persisted as runs.parent_context (JSON). nil = no
+	// context (back-compat; old rows decode to nil). See ParentContext.
+	ParentContext *ParentContext
+}
+
+// ParentContext is the typed caller-tracking lineage attached to a run
+// and propagated to all its sub-agents. The runtime stores and echoes
+// these fields verbatim and never branches on their values — they are
+// consumer-domain concepts (a deliberate, operator-requested exception
+// to loomcycle's usual domain-agnostic posture).
+//
+// It lives in the store package — the lowest layer, importing no other
+// internal package — so runner, tools, connector, and the wire surfaces
+// can all reference one type without an import cycle (the same reason
+// store.RunIdentity and tools.RunIdentityValue are kept separate: loop
+// imports tools, so tools cannot import runner).
+//
+// Unlike UserBearer/UserCredentials this is NOT a secret: safe to
+// persist, log, and emit in events. All fields optional; an all-empty
+// struct is treated as absent (nil) at wire entry.
+type ParentContext struct {
+	// RootAgentRunID is the consumer's identifier for the user-
+	// initiated run at the root of the spawn tree. Echoed on every
+	// descendant so the consumer can attribute child costs to it.
+	RootAgentRunID string `json:"root_agent_run_id,omitempty"`
+	// FunctionKey is the consumer's logical-operation key for the root
+	// request (e.g. its cost-aggregation bucket).
+	FunctionKey string `json:"function_key,omitempty"`
+	// TierAtRun is the consumer's tier marker captured at root-run time.
+	// Distinct from UserTier (loomcycle's resolver policy) — this is the
+	// consumer's own snapshot, carried verbatim.
+	TierAtRun string `json:"tier_at_run,omitempty"`
+}
+
+// IsZero reports whether every field is empty (no meaningful tracking
+// context). Wire entry points normalise a zero struct to nil so
+// back-compat decode paths stay clean.
+func (p *ParentContext) IsZero() bool {
+	return p == nil || (p.RootAgentRunID == "" && p.FunctionKey == "" && p.TierAtRun == "")
+}
+
+// Clone returns a deep copy (nil-safe) so a parent's ParentContext can
+// be handed to a child run without aliasing.
+func (p *ParentContext) Clone() *ParentContext {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
 }
 
 // UserSummary is one row of ListUsers' output: distinct user_id with

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -388,6 +388,34 @@ func (p *ParentContext) Clone() *ParentContext {
 	return &cp
 }
 
+// EncodeParentContext returns the JSON to persist in the runs.parent_context
+// column. ok=false means there's nothing to store (nil or all-empty) — the
+// backend writes SQL NULL in that case. Backends share this so the SQLite
+// and Postgres column formats can't drift.
+func EncodeParentContext(p *ParentContext) (encoded string, ok bool, err error) {
+	if p.IsZero() {
+		return "", false, nil
+	}
+	b, mErr := json.Marshal(p)
+	if mErr != nil {
+		return "", false, mErr
+	}
+	return string(b), true, nil
+}
+
+// DecodeParentContext parses a stored runs.parent_context value. An empty
+// string (NULL column / old row) decodes to nil.
+func DecodeParentContext(s string) (*ParentContext, error) {
+	if s == "" {
+		return nil, nil
+	}
+	var p ParentContext
+	if err := json.Unmarshal([]byte(s), &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
 // UserSummary is one row of ListUsers' output: distinct user_id with
 // summary stats. Drives the Web UI's user picker so operators can see
 // who has active runs and pick from a list rather than typing a UUID.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -59,6 +59,7 @@ func Run(t *testing.T, factory Factory) {
 		{"GetTranscriptEmpty", testGetTranscriptEmpty},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
+		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},
 		{"CreateRunModelVisibleMidFlight", testCreateRunModelVisibleMidFlight},
 		{"CreateRunModelEmptyStaysEmpty", testCreateRunModelEmptyStaysEmpty},
 		{"GetRunByAgentIDNotFound", testGetRunByAgentIDNotFound},
@@ -489,6 +490,44 @@ func testCreateRunIdentityRoundTrip(t *testing.T, s store.Store) {
 	}
 	if got.AgentID != "a_top" || got.UserID != "user-1" {
 		t.Errorf("identity not preserved through GetRunByAgentID: %+v", got)
+	}
+}
+
+// testCreateRunParentContextRoundTrip pins the v0.12.x contract: the
+// opaque parent_context (JSON column) round-trips through CreateRun →
+// GetRun for both backends, and a run created without it reads back nil
+// (back-compat with pre-migration rows + runs with no tracking context).
+func testCreateRunParentContextRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	pc := &store.ParentContext{RootAgentRunID: "run_root", FunctionKey: "cv-batch", TierAtRun: "pro"}
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_pc", UserID: "user-1", ParentContext: pc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.ParentContext == nil || *run.ParentContext != *pc {
+		t.Errorf("CreateRun did not return ParentContext: %+v", run.ParentContext)
+	}
+	got, err := s.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ParentContext == nil || *got.ParentContext != *pc {
+		t.Errorf("ParentContext not preserved through GetRun: got %+v want %+v", got.ParentContext, pc)
+	}
+
+	// No context → nil round-trip (back-compat).
+	bare, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_nopc", UserID: "user-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBare, err := s.GetRun(ctx, bare.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBare.ParentContext != nil {
+		t.Errorf("run without context should read back nil ParentContext, got %+v", gotBare.ParentContext)
 	}
 }
 

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -9,6 +9,7 @@ import (
 
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // Tool is one tool the agent can invoke. The Name is what the model sees and
@@ -247,6 +248,20 @@ type RunIdentityValue struct {
 	// (see Decision 5 in rfcs/per-run-credentials.md and the
 	// existing OTEL secret-exclusion posture).
 	UserCredentials map[string]string
+
+	// ParentContext is the v0.12.x opaque caller-tracking lineage. Set
+	// once on the root run; the Agent tool's SubAgentRunner copies it
+	// UNCHANGED onto every sub-agent (same inheritance discipline as
+	// UserCredentials), so a deep spawn tree all carries the root's
+	// context. The runtime never interprets it — it persists it on each
+	// run row and echoes it on the per-agent report surfaces so a
+	// consumer can attribute a child sub-agent's usage to the root
+	// request. Unlike UserBearer/UserCredentials it is NOT a secret:
+	// safe to persist, log, and emit. Nil = no context. The canonical
+	// type lives in the store package (importing no internal package)
+	// to keep this struct cycle-free — same reason RunIdentityValue and
+	// store.RunIdentity are separate structs.
+	ParentContext *store.ParentContext
 }
 
 // WithRunIdentity attaches the current run's identity to ctx. The


### PR DESCRIPTION
## Summary

Adds an opaque, typed **`parent_context`** (`root_agent_run_id` / `function_key` / `tier_at_run`) to the run request that loomcycle carries verbatim, **propagates UNCHANGED to every sub-agent** the Agent tool spawns, persists on each run row, and **echoes on the per-agent report surfaces** — so an external consumer can attribute a child sub-agent's usage back to the user-initiated request that spawned the whole tree.

This is the **loomcycle side** of the cv-batch child-tagging fix: today a `cv-batch-adapter` orchestrator spawns `cv-adapter`/`cl-adapter` sub-agents whose usage reports carry no link to the parent, so the consumer's cost-aggregation can't roll up a batch click's true cost. With this change the consumer can write child rows tagged with the parent's `function_key` + `root_agent_run_id`.

Wire-protocol change → lands in loomcycle first (incl. the in-repo TS adapter, bumped to `@loomcycle/client` 0.12.8), per the CLAUDE.md cross-repo rule. The consumer-side change (forward `parent_context` when its orchestrator calls the Agent tool, read it on child finalize, flip its `SKIPPED_FUNCTION_KEYS` constant) is its **separate repo**.

## Design

- **Typed struct** (operator's call) — `store.ParentContext{RootAgentRunID, FunctionKey, TierAtRun}`. A deliberate, documented exception to loomcycle's usual domain-agnostic posture, in exchange for a validated, self-documenting contract. Not a secret (safe to persist/log/emit, unlike `user_bearer`/`user_credentials`).
- **Rides the existing identity-inheritance seam** — `parent_context` behaves exactly like `UserBearer`/`UserCredentials`: set once on the root run, copied onto each sub-agent in `runSubAgent` (cloned, so parent/child don't alias), inherited transitively by grandchildren. One new line at the propagation seam is the load-bearing change.
- **Home package = `store`** — the lowest layer (imports no internal package), so `runner`, `tools`, `connector`, and the wire surfaces all reference one type without an import cycle (`loop`→`tools`, so the type can't live in `runner`; same reason `store.RunIdentity` and `tools.RunIdentityValue` are separate structs).
- **Idempotency note**: the originating spec assumed a run-table idempotency_key for cross-replica dedup — that column does **not** exist and is out of scope here; this PR is purely the tracking-lineage propagation.

## What changed

- **Type + wire-in**: `store.ParentContext` (+ `IsZero`/`Clone`/`Encode`/`Decode`); `runner.RunInput`, `connector.SpawnRunRequest`/`SpawnRunResult`, HTTP `runRequest` + `messagesRequest`; `connector.ValidateParentContext` (shared validator, ≤256B/field).
- **Propagation + persistence**: `tools.RunIdentityValue` + `store.RunIdentity`/`Run`; threaded through all 4 run-entry paths + `runSubAgent`; new nullable `runs.parent_context` JSON column (SQLite ALTER + Postgres migration `0030`), written in CreateRun + snapshot-restore, read in scanRun.
- **Echo surfaces**: `agentResponse` (GET /v1/agents, /v1/users/{id}/agents), `RunStateEvent` (runstate + connector + n8n mapping, all 4 meta sites), the SSE `event: agent` frame. MCP `spawn_run` + the connector seam thread it; schema documents it. (gRPC intentionally untouched — no proto field; consumer uses HTTP/TS.)
- **TS adapter**: `ParentContext` interface, `RunOptions`/`ContinueOptions.parentContext`, echoed on `AgentEvent`/`Agent`/`RunStateEvent`; serialized in `runStreaming`/`continueSession`; `@loomcycle/client` 0.12.7 → 0.12.8.

## Tested

- `TestSubAgent_InheritsParentContext` (the load-bearing one): end-to-end POST /v1/runs → Agent-tool spawn → asserts parent + every child run row carry the identical `parent_context`. **Regression-verified** — niling the propagation line makes it fail.
- `CreateRunParentContextRoundTrip` store-contract test: JSON column round-trips on SQLite **and** Postgres; no-context runs read back nil (back-compat).
- 2 new TS serialization tests (forwards when set; omits when undefined). 164 TS tests pass; `tsc` clean.
- `go build ./...`, `go vet ./...`, `go test ./...` all clean; `gofmt -l` empty; binary builds + reports v0.12.8.

## Commits (5, ordered)

1. typed `ParentContext` + run-request wire-in
2. propagate to sub-agents + persist (store column + SQLite/PG migration)
3. echo on report surfaces + MCP/connector parity
4. TS adapter mirror (@loomcycle/client 0.12.8)
5. tests (sub-agent propagation + store round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)