### PR TITLE
chore(release): v0.13.0 — bump @loomcycle/client + tag the A2A release

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.9.2",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.9.2",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.12.8",
+  "version": "0.13.0",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 46 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed AND v0.11.5 setMemoryEntry + deleteMemoryEntry), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.11.5 Channel admin CRUD (createChannel + updateChannel + deleteChannel — runtime substrate; yaml channels refuse mutation with HTTP 409), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Why

A2A (RFC G) merged to `main` with the REVISIONS v0.13.0 entry and the README rows, but two release-finalization steps were missing:

1. The TS adapter (`@loomcycle/client`) was still at **0.12.8** even though the A2A PR added `a2aServerCardDef()` / `a2aAgentDef()`. The npm publish workflow is gated on the tag matching `package.json`, so tagging `v0.13.0` would skip the adapter publish, leaving the A2A methods unpublished.
2. `package-lock.json`'s root version had drifted (stuck at 0.9.2 since that release).

## What

- Bump `adapters/ts/package.json` → **0.13.0**.
- Sync `package-lock.json` root version → 0.13.0.

No source changes; the TS adapter builds clean.

## After merge

Tag `v0.13.0` on `main` (annotated, matching the REVISIONS headline) → triggers `release.yml` (goreleaser GitHub release + binaries) and `publish-ts-adapter.yml` (npm publish of `@loomcycle/client@0.13.0` with the A2A methods).

🤖 Generated with [Claude Code](https://claude.com/claude-code)