### PR TITLE
feat(rfc-h): Input Webhooks — the WebhookDef substrate (server-side inbound triggers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 | **Parent-context propagation** — opaque `parent_context` {root_agent_run_id, function_key, tier_at_run} on a run is inherited by every Agent-tool sub-agent, persisted, and echoed on the agent-status / run-state / SSE surfaces — so a consumer can attribute a child sub-agent's usage to the user-initiated request | v0.12.8 |
 | **Tool-use hooks** — register HTTP webhooks against `(agent, tool, phase)` selectors via `POST /v1/hooks`. `pre` hooks rewrite a tool's input, deny it with a synthetic result, or (operator opt-in) widen hosts for one call; `post` hooks rewrite the result. Fail-open or fail-closed; narrows policy by default; DB-backed in cluster mode | v0.8.x → v0.12.5 |
 | **A2A (Agent2Agent) interoperability** — loomcycle as an A2A **server** (well-known AgentCard + REST/JSON-RPC/gRPC bindings) and **client** (call remote peers as `a2a__<peer>__<skill>` tools). Two substrate Defs, signed cards (JWS/JCS), multi-tenant routing, `INPUT_REQUIRED` ↔ Interruption resume. Off by default | v0.13.0 |
+| **Input webhooks** — `WebhookDef` substrate: external systems (GitHub/Stripe/Linear/CI/n8n) trigger agent runs or wake parked agents via signed `POST /v1/_webhooks/{name}`. HMAC-over-raw-body (verify-before-parse), strict JSONPath mapping, two-layer idempotency, per-Def rate limit, per-run credentials, `on_complete` hooks, admin triage. Off by default | v0.14.0 |
 
 Full per-version log: [`REVISIONS.md`](REVISIONS.md).
 

--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,76 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.14.0
+
+**Headline: Input Webhooks (RFC H) — the `WebhookDef` substrate.** External
+systems (GitHub, Stripe, Linear, CI servers, n8n cloud) can now trigger
+loomcycle agent runs — or wake agents parked on a callback — via signed HTTP
+POST, without operators gluing a bespoke receiver in front of `/v1/runs`.
+`WebhookDef` is the fifth substrate primitive alongside AgentDef / SkillDef /
+MCPServerDef / ScheduleDef. Additive and **off by default**
+(`LOOMCYCLE_WEBHOOKS_ENABLED`).
+
+### The receiver — `POST /v1/_webhooks/{name}`
+
+A shared front-half runs for every request, then forks on delivery mode:
+**resolve** the active Def by URL name (unknown/disabled → opaque 404) →
+**read** the raw body under `body_size_limit_bytes` (1 MiB default) →
+**verify the HMAC signature over the raw bytes, before any parsing**
+(constant-time `hmac.Equal`; Stripe `t=,v1=` + GitHub `sha256=` envelopes
+auto-detected, ±5-min window; bearer fallback) → **replay/idempotency
+guard** → **JSONPath payload projection** (strict subset: `$.a.b`, `$.a[N]`;
+no wildcards/filters/eval) → **rate limit** (per-Def token bucket, 429 +
+Retry-After) → **deliver**.
+
+- **spawn** → builds a RunInput and drives `runner.RunOnce` (the scheduler's
+  path, same admission semaphore). The mapped `goal` enters as an
+  **untrusted-block** (fenced in `<untrusted>` tags) — a webhook payload is
+  external, attacker-influenceable input. Async `202 {run_id, …}`, or
+  `?sync=true` blocks on the run-state bus to terminal (200 / 504).
+- **channel** → `SystemPublisher.PublishNow` + bus notify, waking agents
+  parked on `Channel.subscribe`. No run, no credentials.
+
+### Two idempotency layers
+
+- **Layer 1** — in-memory per-replica replay cache keyed `(name,
+  delivery_id)`, 10-min TTL; the cheap fast path for near-instant retries.
+- **Layer 2** — a new durable `runs.idempotency_key` column (migration 0033)
+  + unique partial index. Spawn sets `idempotency_key = delivery_id`; a
+  re-delivered event lands on the same run instead of double-spawning, across
+  replicas and past the Layer-1 TTL. (Also unblocks A2A push + a general
+  `POST /v1/runs` dedup.) A delivery rejected downstream — rate-limited,
+  mapping error, transient setup 503 — never burns its id, so the sender's
+  retry is processed, not dropped (Decision 9: never silently degrade).
+
+### Substrate + transports + auth
+
+- 5-op `WebhookDef` tool + scope policy + full 4-transport CRUD (HTTP
+  `/v1/_webhookdef`, gRPC, MCP meta-tool — count 36→37, TS `webhookDef()`) +
+  3-way drift test. `webhooks:` static yaml + content-addressed dynamic
+  forks. Migration 0032.
+- Signing secrets + per-run credentials resolve through the env-allowlist
+  gate (shared with the scheduler). `user_credentials_from_env` (operator-
+  owned) merged with `payload_mapping` `user_credentials.<name>` (per-event,
+  payload wins) onto the RFC F `${run.credentials.<name>}` seam. Channel mode
+  forbids credentials (no run identity).
+- **on_complete** hooks fire after a spawned run (`channel.publish` +
+  `memory.set` wired; `mcp.call` reserved).
+- **Triage** (admin-bearer-gated, distinct from the open receiver):
+  `GET …/recent-deliveries` (last 50 verdicts) and `POST …/test` (dry-run:
+  would-accept + RunInput preview with credential KEY NAMES only).
+
+### Notes
+
+- Single-replica v1: Layer-1 dedup + rate-limit buckets are per-replica;
+  Layer-2 `idempotency_key` is the cross-replica backstop.
+- `Context.help input-webhooks` topic; comprehensive unit + handler-level
+  tests (signature envelopes, tampered/replay/out-of-window, rate limit,
+  unresolvable secret, payload mapping, sync mode, both idempotency layers,
+  on_complete, triage). `@loomcycle/client` gains `webhookDef()`.
+- Wire-protocol additions are back-compatible (new endpoints / RPC / MCP
+  meta-tool / TS method only).
+
 ## What's in v0.13.0
 
 **Headline: comprehensive Agent2Agent (A2A) protocol support (RFC G).** loomcycle now speaks the Linux Foundation A2A protocol on **both** sides — reachable *as* an A2A server from the Microsoft / Google enterprise agent stacks, and able to call remote A2A peers *as* synthetic tools. Built on the official Go SDK (`github.com/a2aproject/a2a-go/v2@v2.3.1`, which shares loomcycle's existing grpc/protobuf stack → ~zero net-new heavy deps). Additive and **off by default**; `/v1/runs`, MCP, gRPC, and the TS adapter are untouched. PR #286.

--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -717,6 +717,25 @@ export class LoomcycleClient {
     return postJSON<SubstrateToolResponse>(this.ctx, "/v1/_a2aagentdef", input, opts);
   }
 
+  /** Invoke the v1.x RFC H WebhookDef substrate tool over HTTP.
+   *  Author + fork + retire inbound webhook definitions at runtime.
+   *  Mirror of {@link LoomcycleClient.a2aAgentDef} for inbound webhooks.
+   *
+   *  Operator-admin-only: this endpoint requires the bearer token.
+   *
+   *  Op-discriminated input: `{op: "create" | "fork" | "get" |
+   *  "list" | "retire", ...}`.
+   *
+   *  Raises {@link SubstrateToolRefusedError} on tool-level refusals;
+   *  {@link InvalidArgumentError} on 400 (malformed JSON);
+   *  {@link AuthError} on 401. */
+  async webhookDef(
+    input: SubstrateToolInput,
+    opts?: { signal?: AbortSignal },
+  ): Promise<SubstrateToolResponse> {
+    return postJSON<SubstrateToolResponse>(this.ctx, "/v1/_webhookdef", input, opts);
+  }
+
   // ---- v0.10.3 Library v2 enumeration (read-only, merged yaml+substrate) ----
 
   /** List every agent the runtime knows about — yaml-static + dynamic

--- a/adapters/ts/tests/substrate.test.ts
+++ b/adapters/ts/tests/substrate.test.ts
@@ -325,3 +325,47 @@ describe("a2aAgentDef", () => {
     expect(headers.Authorization).toBe("Bearer test-bearer");
   });
 });
+
+// RFC H WH-3 / mirrors the a2aAgentDef suite above.
+describe("webhookDef", () => {
+  it("posts JSON to /v1/_webhookdef and returns the row envelope", async () => {
+    const { client, fetchMock } = makeClient([
+      jsonResponse({
+        def_id: "whd_abc",
+        name: "gh-push",
+        version: 1,
+        promoted: true,
+      }),
+    ]);
+
+    const result = (await client.webhookDef({
+      op: "create",
+      name: "gh-push",
+      overlay: { delivery: "spawn", agent: "ingest" },
+    })) as Record<string, unknown>;
+
+    expect(result.def_id).toBe("whd_abc");
+    expect(result.name).toBe("gh-push");
+
+    const call = fetchMock.mock.calls[0]!;
+    expect(call[0]).toBe("http://test-loomcycle:8787/v1/_webhookdef");
+    expect((call[1] as RequestInit).method).toBe("POST");
+    const body = JSON.parse((call[1] as RequestInit).body as string);
+    expect(body.op).toBe("create");
+  });
+
+  it("raises AuthError on 401", async () => {
+    const { client } = makeClient([errorResponse(401, "invalid token")]);
+    await expect(
+      client.webhookDef({ op: "create", name: "x", overlay: {} }),
+    ).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("forwards bearer auth in the Authorization header", async () => {
+    const { client, fetchMock } = makeClient([jsonResponse({ ok: true })]);
+    await client.webhookDef({ op: "list", name: "gh-push" });
+    const headers = (fetchMock.mock.calls[0]![1] as RequestInit)
+      .headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer test-bearer");
+  });
+});

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1040,6 +1040,16 @@ func main() {
 		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
 		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
 	})
+	// v1.x RFC H — wire the WebhookDef substrate tool. Same operator-
+	// admin-only posture as the A2A substrate tools; reached via
+	// Connector.WebhookDef + the admin endpoint + the LoomCycle MCP
+	// meta-tool. Identical Store + Cfg + byte-cap construction.
+	srv.SetWebhookDefTool(&builtin.WebhookDef{
+		Store:               storeIface,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  cfg.Env.AgentDefMaxDefinitionBytes,
+		MaxDescriptionBytes: cfg.Env.AgentDefMaxDescriptionBytes,
+	})
 	// Surface the resolved build identifiers via /healthz so the Web UI
 	// can render the running binary's real version instead of a stale
 	// hard-coded string. Mirrors what gRPC's Health RPC has reported

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1241,7 +1241,12 @@ func main() {
 			EnvAllowlist: webhookAllowlist,
 			Logf:         log.Printf,
 		})
-		srv.SetWebhookMux(func(reg lchttp.MuxRegistrar) { rec.Mount(reg) })
+		srv.SetWebhookMux(func(reg lchttp.MuxRegistrar, adminAuth func(http.Handler) http.Handler) {
+			// Receiver POST: unauthed (per-WebhookDef secret). Triage
+			// endpoints (recent-deliveries / test): admin-bearer gated.
+			rec.Mount(reg)
+			rec.MountAdmin(reg, adminAuth)
+		})
 		log.Printf("webhooks: enabled (receiver mounted at POST /v1/_webhooks/{name}, env_allowlist=%d names)",
 			len(cfg.Env.SchedulerEnvAllowlist))
 	} else if cfg.Env.WebhooksEnabled {

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/agents"
 	a2aapi "github.com/denn-gubsky/loomcycle/internal/api/a2a"
 	lchttp "github.com/denn-gubsky/loomcycle/internal/api/http"
+	webhookapi "github.com/denn-gubsky/loomcycle/internal/api/webhook"
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/cli"
@@ -1216,6 +1217,39 @@ func main() {
 		}
 	}
 
+	// v1.x RFC H inbound-webhook receiver. Default OFF; operator opts in
+	// via LOOMCYCLE_WEBHOOKS_ENABLED=1. The receiver is the trust boundary:
+	// it authenticates each external POST against the resolved WebhookDef's
+	// own HMAC/bearer secret (gated by the SAME env allowlist the scheduler
+	// uses — the shared RFC F trigger-credential gate), then spawns a run
+	// (srv as runner) or publishes to a channel (sysPublisher). ?sync runs
+	// block on runStateBus. The route mounts WITHOUT the global bearer auth.
+	//
+	// Registered BEFORE srv.Mux() below — the SetWebhookMux hook fires
+	// inside Mux(), same ordering constraint as SetExtraMux for A2A.
+	if cfg.Env.WebhooksEnabled && storeIface != nil && srv != nil {
+		webhookAllowlist := make(map[string]bool, len(cfg.Env.SchedulerEnvAllowlist))
+		for _, name := range cfg.Env.SchedulerEnvAllowlist {
+			webhookAllowlist[name] = true
+		}
+		rec := webhookapi.New(webhookapi.Deps{
+			Store:        storeIface,
+			Cfg:          cfg,
+			Runner:       srv,
+			Publisher:    sysPublisher,
+			RunStateBus:  runStateBus,
+			EnvAllowlist: webhookAllowlist,
+			Logf:         log.Printf,
+		})
+		srv.SetWebhookMux(func(reg lchttp.MuxRegistrar) { rec.Mount(reg) })
+		log.Printf("webhooks: enabled (receiver mounted at POST /v1/_webhooks/{name}, env_allowlist=%d names)",
+			len(cfg.Env.SchedulerEnvAllowlist))
+	} else if cfg.Env.WebhooksEnabled {
+		log.Printf("webhooks: disabled (no Store backend or no HTTP server)")
+	} else {
+		log.Printf("webhooks: disabled (LOOMCYCLE_WEBHOOKS_ENABLED=0)")
+	}
+
 	// In path-mode A2A tenancy, the leading /{tenant} segment is stripped
 	// before the mux sees the request (an open first-segment wildcard
 	// cannot coexist with the HTTP server's subtree routes). The wrapper
@@ -1584,6 +1618,7 @@ func main() {
 	} else {
 		log.Printf("scheduler: disabled (LOOMCYCLE_SCHEDULER_ENABLED=0)")
 	}
+
 	// Boot summary of operator-declared channels. Mirrors the
 	// "user_tiers: configured N — ..." line shape so operators see
 	// the framework-primitive state at startup.

--- a/internal/api/grpc/loomcyclepb/loomcycle.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle.pb.go
@@ -4649,7 +4649,7 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\bscope_id\x18\x03 \x01(\tR\ascopeId\x12\x16\n" +
 	"\x06cursor\x18\x04 \x01(\tR\x06cursor\"$\n" +
 	"\x12AckChannelResponse\x12\x0e\n" +
-	"\x02ok\x18\x01 \x01(\bR\x02ok2\xa8\x14\n" +
+	"\x02ok\x18\x01 \x01(\bR\x02ok2\xf7\x14\n" +
 	"\tLoomcycle\x126\n" +
 	"\x03Run\x12\x18.loomcycle.v1.RunRequest\x1a\x13.loomcycle.v1.Event0\x01\x12@\n" +
 	"\bContinue\x12\x1d.loomcycle.v1.ContinueRequest\x1a\x13.loomcycle.v1.Event0\x01\x12M\n" +
@@ -4676,7 +4676,9 @@ const file_loomcycle_proto_rawDesc = "" +
 	"\fMCPServerDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12N\n" +
 	"\vScheduleDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12S\n" +
 	"\x10A2AServerCardDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12N\n" +
-	"\vA2AAgentDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12U\n" +
+	"\vA2AAgentDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12M\n" +
+	"\n" +
+	"WebhookDef\x12\x1e.loomcycle.v1.SubstrateRequest\x1a\x1f.loomcycle.v1.SubstrateResponse\x12U\n" +
 	"\fListChannels\x12!.loomcycle.v1.ListChannelsRequest\x1a\".loomcycle.v1.ListChannelsResponse\x12^\n" +
 	"\x13StreamUserRunStates\x12(.loomcycle.v1.StreamUserRunStatesRequest\x1a\x1b.loomcycle.v1.RunStateEvent0\x01\x12[\n" +
 	"\x0ePublishChannel\x12#.loomcycle.v1.PublishChannelRequest\x1a$.loomcycle.v1.PublishChannelResponse\x12a\n" +
@@ -4821,45 +4823,47 @@ var file_loomcycle_proto_depIdxs = []int32{
 	47, // 51: loomcycle.v1.Loomcycle.ScheduleDef:input_type -> loomcycle.v1.SubstrateRequest
 	47, // 52: loomcycle.v1.Loomcycle.A2AServerCardDef:input_type -> loomcycle.v1.SubstrateRequest
 	47, // 53: loomcycle.v1.Loomcycle.A2AAgentDef:input_type -> loomcycle.v1.SubstrateRequest
-	49, // 54: loomcycle.v1.Loomcycle.ListChannels:input_type -> loomcycle.v1.ListChannelsRequest
-	52, // 55: loomcycle.v1.Loomcycle.StreamUserRunStates:input_type -> loomcycle.v1.StreamUserRunStatesRequest
-	54, // 56: loomcycle.v1.Loomcycle.PublishChannel:input_type -> loomcycle.v1.PublishChannelRequest
-	56, // 57: loomcycle.v1.Loomcycle.SubscribeChannel:input_type -> loomcycle.v1.SubscribeChannelRequest
-	59, // 58: loomcycle.v1.Loomcycle.PeekChannel:input_type -> loomcycle.v1.PeekChannelRequest
-	61, // 59: loomcycle.v1.Loomcycle.AckChannel:input_type -> loomcycle.v1.AckChannelRequest
-	5,  // 60: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
-	5,  // 61: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
-	11, // 62: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
-	14, // 63: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
-	17, // 64: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
-	19, // 65: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
-	21, // 66: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
-	23, // 67: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
-	26, // 68: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
-	28, // 69: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
-	30, // 70: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
-	32, // 71: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
-	34, // 72: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
-	36, // 73: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
-	38, // 74: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
-	40, // 75: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
-	42, // 76: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
-	44, // 77: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
-	46, // 78: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
-	48, // 79: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 80: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 81: loomcycle.v1.Loomcycle.MCPServerDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 82: loomcycle.v1.Loomcycle.ScheduleDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 83: loomcycle.v1.Loomcycle.A2AServerCardDef:output_type -> loomcycle.v1.SubstrateResponse
-	48, // 84: loomcycle.v1.Loomcycle.A2AAgentDef:output_type -> loomcycle.v1.SubstrateResponse
-	50, // 85: loomcycle.v1.Loomcycle.ListChannels:output_type -> loomcycle.v1.ListChannelsResponse
-	53, // 86: loomcycle.v1.Loomcycle.StreamUserRunStates:output_type -> loomcycle.v1.RunStateEvent
-	55, // 87: loomcycle.v1.Loomcycle.PublishChannel:output_type -> loomcycle.v1.PublishChannelResponse
-	57, // 88: loomcycle.v1.Loomcycle.SubscribeChannel:output_type -> loomcycle.v1.SubscribeChannelResponse
-	60, // 89: loomcycle.v1.Loomcycle.PeekChannel:output_type -> loomcycle.v1.PeekChannelResponse
-	62, // 90: loomcycle.v1.Loomcycle.AckChannel:output_type -> loomcycle.v1.AckChannelResponse
-	60, // [60:91] is the sub-list for method output_type
-	29, // [29:60] is the sub-list for method input_type
+	47, // 54: loomcycle.v1.Loomcycle.WebhookDef:input_type -> loomcycle.v1.SubstrateRequest
+	49, // 55: loomcycle.v1.Loomcycle.ListChannels:input_type -> loomcycle.v1.ListChannelsRequest
+	52, // 56: loomcycle.v1.Loomcycle.StreamUserRunStates:input_type -> loomcycle.v1.StreamUserRunStatesRequest
+	54, // 57: loomcycle.v1.Loomcycle.PublishChannel:input_type -> loomcycle.v1.PublishChannelRequest
+	56, // 58: loomcycle.v1.Loomcycle.SubscribeChannel:input_type -> loomcycle.v1.SubscribeChannelRequest
+	59, // 59: loomcycle.v1.Loomcycle.PeekChannel:input_type -> loomcycle.v1.PeekChannelRequest
+	61, // 60: loomcycle.v1.Loomcycle.AckChannel:input_type -> loomcycle.v1.AckChannelRequest
+	5,  // 61: loomcycle.v1.Loomcycle.Run:output_type -> loomcycle.v1.Event
+	5,  // 62: loomcycle.v1.Loomcycle.Continue:output_type -> loomcycle.v1.Event
+	11, // 63: loomcycle.v1.Loomcycle.GetTranscript:output_type -> loomcycle.v1.Transcript
+	14, // 64: loomcycle.v1.Loomcycle.GetAgent:output_type -> loomcycle.v1.Agent
+	17, // 65: loomcycle.v1.Loomcycle.CancelAgent:output_type -> loomcycle.v1.CancelAgentResponse
+	19, // 66: loomcycle.v1.Loomcycle.ListUserAgents:output_type -> loomcycle.v1.ListUserAgentsResponse
+	21, // 67: loomcycle.v1.Loomcycle.Health:output_type -> loomcycle.v1.HealthResponse
+	23, // 68: loomcycle.v1.Loomcycle.RegisterHook:output_type -> loomcycle.v1.RegisterHookResponse
+	26, // 69: loomcycle.v1.Loomcycle.ListHooks:output_type -> loomcycle.v1.ListHooksResponse
+	28, // 70: loomcycle.v1.Loomcycle.DeleteHook:output_type -> loomcycle.v1.DeleteHookResponse
+	30, // 71: loomcycle.v1.Loomcycle.PauseRuntime:output_type -> loomcycle.v1.PauseRuntimeResponse
+	32, // 72: loomcycle.v1.Loomcycle.ResumeRuntime:output_type -> loomcycle.v1.ResumeRuntimeResponse
+	34, // 73: loomcycle.v1.Loomcycle.GetRuntimeState:output_type -> loomcycle.v1.RuntimeStateResponse
+	36, // 74: loomcycle.v1.Loomcycle.CreateSnapshot:output_type -> loomcycle.v1.SnapshotDescriptor
+	38, // 75: loomcycle.v1.Loomcycle.ListSnapshots:output_type -> loomcycle.v1.ListSnapshotsResponse
+	40, // 76: loomcycle.v1.Loomcycle.GetSnapshot:output_type -> loomcycle.v1.SnapshotEnvelope
+	42, // 77: loomcycle.v1.Loomcycle.ExportSnapshot:output_type -> loomcycle.v1.ExportSnapshotResponse
+	44, // 78: loomcycle.v1.Loomcycle.RestoreSnapshot:output_type -> loomcycle.v1.RestoreSnapshotResponse
+	46, // 79: loomcycle.v1.Loomcycle.DeleteSnapshot:output_type -> loomcycle.v1.DeleteSnapshotResponse
+	48, // 80: loomcycle.v1.Loomcycle.AgentDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 81: loomcycle.v1.Loomcycle.SkillDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 82: loomcycle.v1.Loomcycle.MCPServerDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 83: loomcycle.v1.Loomcycle.ScheduleDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 84: loomcycle.v1.Loomcycle.A2AServerCardDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 85: loomcycle.v1.Loomcycle.A2AAgentDef:output_type -> loomcycle.v1.SubstrateResponse
+	48, // 86: loomcycle.v1.Loomcycle.WebhookDef:output_type -> loomcycle.v1.SubstrateResponse
+	50, // 87: loomcycle.v1.Loomcycle.ListChannels:output_type -> loomcycle.v1.ListChannelsResponse
+	53, // 88: loomcycle.v1.Loomcycle.StreamUserRunStates:output_type -> loomcycle.v1.RunStateEvent
+	55, // 89: loomcycle.v1.Loomcycle.PublishChannel:output_type -> loomcycle.v1.PublishChannelResponse
+	57, // 90: loomcycle.v1.Loomcycle.SubscribeChannel:output_type -> loomcycle.v1.SubscribeChannelResponse
+	60, // 91: loomcycle.v1.Loomcycle.PeekChannel:output_type -> loomcycle.v1.PeekChannelResponse
+	62, // 92: loomcycle.v1.Loomcycle.AckChannel:output_type -> loomcycle.v1.AckChannelResponse
+	61, // [61:93] is the sub-list for method output_type
+	29, // [29:61] is the sub-list for method input_type
 	29, // [29:29] is the sub-list for extension type_name
 	29, // [29:29] is the sub-list for extension extendee
 	0,  // [0:29] is the sub-list for field type_name

--- a/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
+++ b/internal/api/grpc/loomcyclepb/loomcycle_grpc.pb.go
@@ -63,6 +63,7 @@ const (
 	Loomcycle_ScheduleDef_FullMethodName         = "/loomcycle.v1.Loomcycle/ScheduleDef"
 	Loomcycle_A2AServerCardDef_FullMethodName    = "/loomcycle.v1.Loomcycle/A2AServerCardDef"
 	Loomcycle_A2AAgentDef_FullMethodName         = "/loomcycle.v1.Loomcycle/A2AAgentDef"
+	Loomcycle_WebhookDef_FullMethodName          = "/loomcycle.v1.Loomcycle/WebhookDef"
 	Loomcycle_ListChannels_FullMethodName        = "/loomcycle.v1.Loomcycle/ListChannels"
 	Loomcycle_StreamUserRunStates_FullMethodName = "/loomcycle.v1.Loomcycle/StreamUserRunStates"
 	Loomcycle_PublishChannel_FullMethodName      = "/loomcycle.v1.Loomcycle/PublishChannel"
@@ -218,6 +219,12 @@ type LoomcycleClient interface {
 	// (create / fork / get / list / retire) + is_error tool refusals
 	// in the response.
 	A2AAgentDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error)
+	// WebhookDef dispatches to the v1.x RFC H inbound-webhook substrate.
+	// Mirrors POST /v1/_webhookdef. Operator-admin-only. Same
+	// SubstrateRequest body shape — op-discriminated input_json
+	// (create / fork / get / list / retire) + is_error tool refusals
+	// in the response. (RFC H WH-3 / mirrors A2AAgentDef.)
+	WebhookDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error)
 	// ----- v0.9.x n8n RFC Phase 0 -----
 	//
 	// ListChannels mirrors GET /v1/_channels — operator-declared
@@ -523,6 +530,16 @@ func (c *loomcycleClient) A2AAgentDef(ctx context.Context, in *SubstrateRequest,
 	return out, nil
 }
 
+func (c *loomcycleClient) WebhookDef(ctx context.Context, in *SubstrateRequest, opts ...grpc.CallOption) (*SubstrateResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SubstrateResponse)
+	err := c.cc.Invoke(ctx, Loomcycle_WebhookDef_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *loomcycleClient) ListChannels(ctx context.Context, in *ListChannelsRequest, opts ...grpc.CallOption) (*ListChannelsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ListChannelsResponse)
@@ -739,6 +756,12 @@ type LoomcycleServer interface {
 	// (create / fork / get / list / retire) + is_error tool refusals
 	// in the response.
 	A2AAgentDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error)
+	// WebhookDef dispatches to the v1.x RFC H inbound-webhook substrate.
+	// Mirrors POST /v1/_webhookdef. Operator-admin-only. Same
+	// SubstrateRequest body shape — op-discriminated input_json
+	// (create / fork / get / list / retire) + is_error tool refusals
+	// in the response. (RFC H WH-3 / mirrors A2AAgentDef.)
+	WebhookDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error)
 	// ----- v0.9.x n8n RFC Phase 0 -----
 	//
 	// ListChannels mirrors GET /v1/_channels — operator-declared
@@ -850,6 +873,9 @@ func (UnimplementedLoomcycleServer) A2AServerCardDef(context.Context, *Substrate
 }
 func (UnimplementedLoomcycleServer) A2AAgentDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method A2AAgentDef not implemented")
+}
+func (UnimplementedLoomcycleServer) WebhookDef(context.Context, *SubstrateRequest) (*SubstrateResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method WebhookDef not implemented")
 }
 func (UnimplementedLoomcycleServer) ListChannels(context.Context, *ListChannelsRequest) (*ListChannelsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListChannels not implemented")
@@ -1326,6 +1352,24 @@ func _Loomcycle_A2AAgentDef_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Loomcycle_WebhookDef_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SubstrateRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(LoomcycleServer).WebhookDef(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Loomcycle_WebhookDef_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(LoomcycleServer).WebhookDef(ctx, req.(*SubstrateRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Loomcycle_ListChannels_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ListChannelsRequest)
 	if err := dec(in); err != nil {
@@ -1525,6 +1569,10 @@ var Loomcycle_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "A2AAgentDef",
 			Handler:    _Loomcycle_A2AAgentDef_Handler,
+		},
+		{
+			MethodName: "WebhookDef",
+			Handler:    _Loomcycle_WebhookDef_Handler,
 		},
 		{
 			MethodName: "ListChannels",

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -830,6 +830,11 @@ func (m *mockConnector) A2AAgentDef(context.Context, json.RawMessage) (connector
 	return connector.ToolResult{}, nil
 }
 
+// v1.x RFC H Input Webhooks substrate stub.
+func (m *mockConnector) WebhookDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *mockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, nil

--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -66,6 +66,13 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 		Scopes:   []string{"any"},
 		SelfName: grpcSubstrateAdminAgentName,
 	})
+	// WebhookDef: same operator-trust posture; "any" scope lets the
+	// gRPC-admin call create/fork/retire any webhook name
+	// (RFC H WH-3 / mirrors A2AAgentDef).
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: grpcSubstrateAdminAgentName,
+	})
 	ctx = tools.WithEvaluationPolicy(ctx, tools.EvaluationPolicyValue{
 		Scopes: []string{"submit_self", "submit_descendants", "submit_any", "read_any"},
 	})
@@ -157,6 +164,19 @@ func (s *Server) A2AServerCardDef(ctx context.Context, req *loomcyclepb.Substrat
 func (s *Server) A2AAgentDef(ctx context.Context, req *loomcyclepb.SubstrateRequest) (*loomcyclepb.SubstrateResponse, error) {
 	return s.dispatchSubstrateRPC(ctx, "A2AAgentDef", req, func(ctx context.Context, in json.RawMessage) (json.RawMessage, bool, error) {
 		res, err := s.connector.A2AAgentDef(ctx, in)
+		if err != nil {
+			return nil, false, err
+		}
+		return json.RawMessage(res.Text), res.IsError, nil
+	})
+}
+
+// WebhookDef serves the v1.x RFC H WebhookDef gRPC RPC — inbound-webhook
+// substrate. Same shape as the other substrate RPCs.
+// (RFC H WH-3 / mirrors A2AAgentDef.)
+func (s *Server) WebhookDef(ctx context.Context, req *loomcyclepb.SubstrateRequest) (*loomcyclepb.SubstrateResponse, error) {
+	return s.dispatchSubstrateRPC(ctx, "WebhookDef", req, func(ctx context.Context, in json.RawMessage) (json.RawMessage, bool, error) {
+		res, err := s.connector.WebhookDef(ctx, in)
 		if err != nil {
 			return nil, false, err
 		}

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -441,6 +441,20 @@ func (s *Server) A2AAgentDef(ctx context.Context, input json.RawMessage) (connec
 	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
 }
 
+// WebhookDef dispatches to the v1.x RFC H inbound-webhook substrate tool.
+// Same operator-admin-only posture as A2AAgentDef. See SetWebhookDefTool
+// for wiring.
+func (s *Server) WebhookDef(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	if s.webhookDefTool == nil {
+		return connector.ToolResult{}, fmt.Errorf("WebhookDef: not configured (no tool wired via SetWebhookDefTool)")
+	}
+	res, err := s.webhookDefTool.Execute(ctx, input)
+	if err != nil {
+		return connector.ToolResult{}, err
+	}
+	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
 // dispatchBuiltin is the shared lookup-and-execute path for the five
 // builtin wrappers. tools.Result {Text, IsError} maps directly onto
 // connector.ToolResult; the transport adapter (MCP) then wraps both

--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -102,6 +102,19 @@ func (s *Server) handleListA2AAgentDefNames(w http.ResponseWriter, r *http.Reque
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
+// handleListWebhookDefNames serves GET /v1/_webhookdef/names.
+func (s *Server) handleListWebhookDefNames(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.WebhookDefListNames(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []store.WebhookDefNameSummary{}
+	}
+	writeJSONOK(w, map[string]any{"names": rows})
+}
+
 // handleAgentChannels serves GET /v1/agents/{agent_name}/channels.
 // Returns every channel_cursors row for (scope=agent, scope_id={agent_name}),
 // ordered by channel ASC. Drives the v0.9.x Web UI's per-agent

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -134,6 +134,18 @@ type Server struct {
 	// Set via SetExtraMux; nil when the A2A surface is disabled.
 	extraMux func(mux *http.ServeMux, adminAuth func(http.Handler) http.Handler)
 
+	// webhookMux is the optional v1.x RFC H hook for registering the
+	// inbound-webhook receiver route. Set via SetWebhookMux; nil when
+	// LOOMCYCLE_WEBHOOKS_ENABLED is unset. Unlike extraMux it is NOT
+	// handed the admin-auth wrapper: the receiver authenticates each
+	// request against the resolved WebhookDef's own secret (HMAC /
+	// bearer), so wrapping it in the global LOOMCYCLE_AUTH_TOKEN bearer
+	// would defeat the per-webhook secret model. The hook receives a
+	// MuxRegistrar (an adapter that applies recovery middleware) rather
+	// than the bare mux, so a panicking webhook handler still becomes a
+	// 500 instead of crashing the process.
+	webhookMux func(reg MuxRegistrar)
+
 	// mcpPoolInspector returns the cached tools/list result for a
 	// named MCP server as already-marshaled JSON. The "already JSON"
 	// wire keeps this package free of internal/tools/mcp imports.
@@ -1861,7 +1873,38 @@ func (s *Server) Mux() http.Handler {
 			return recoveryMiddleware(s.authMiddleware(next))
 		})
 	}
+	// v1.x RFC H inbound-webhook receiver. Mounted WITHOUT the bearer
+	// authMiddleware — the receiver does its own per-WebhookDef auth.
+	// Wrapped in recoveryMiddleware only, so a panic in a handler still
+	// becomes a 500 rather than tearing down the process. Nil when the
+	// receiver is disabled (the default).
+	if s.webhookMux != nil {
+		s.webhookMux(&webhookMuxAdapter{mux: mux})
+	}
 	return mux
+}
+
+// MuxRegistrar is the minimal mux surface the webhook receiver's Mount
+// needs. Declared here (not as a concrete *http.ServeMux) so the recovery
+// wrapper can be interposed transparently.
+type MuxRegistrar interface {
+	Handle(pattern string, handler http.Handler)
+}
+
+// webhookMuxAdapter wraps each webhook handler in recoveryMiddleware
+// (recovery only — no auth; the receiver authenticates per-WebhookDef).
+type webhookMuxAdapter struct{ mux *http.ServeMux }
+
+func (a *webhookMuxAdapter) Handle(pattern string, h http.Handler) {
+	a.mux.Handle(pattern, recoveryMiddleware(h))
+}
+
+// SetWebhookMux installs the v1.x RFC H webhook-receiver mount hook,
+// called at the end of Mux(). Nil-safe. The hook receives a MuxRegistrar
+// that applies recovery middleware; it does NOT receive the bearer-auth
+// wrapper, by design (per-WebhookDef auth).
+func (s *Server) SetWebhookMux(fn func(reg MuxRegistrar)) {
+	s.webhookMux = fn
 }
 
 // SetExtraMux installs a hook called at the end of Mux() to register

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -207,6 +207,13 @@ type Server struct {
 	a2aServerCardDefTool tools.Tool
 	a2aAgentDefTool      tools.Tool
 
+	// webhookDefTool is the v1.x RFC H WebhookDef substrate tool. Same
+	// operator-admin-only posture as a2aAgentDefTool — NOT in s.tools,
+	// reached via Connector.WebhookDef + the admin endpoint + the
+	// LoomCycle MCP meta-tool. Nil = the surface returns "not
+	// configured" errors. Set via SetWebhookDefTool.
+	webhookDefTool tools.Tool
+
 	// v0.12.0 multi-replica HA. backplane + replicaStore are nil in
 	// single-replica deployments (LOOMCYCLE_REPLICA_ID unset); /healthz
 	// then returns the same response shape as v0.11.x. When set,
@@ -496,6 +503,15 @@ func (s *Server) SetA2AServerCardDefTool(t tools.Tool) {
 // LoomCycle MCP meta-tool all refuse with "not configured".
 func (s *Server) SetA2AAgentDefTool(t tools.Tool) {
 	s.a2aAgentDefTool = t
+}
+
+// SetWebhookDefTool wires the v1.x RFC H WebhookDef substrate tool.
+// Without this call, Connector.WebhookDef + POST /v1/_webhookdef + the
+// LoomCycle MCP meta-tool all refuse with "not configured". The tool
+// only needs the store + cfg, so it can be constructed alongside the
+// A2A substrate tools in main.go.
+func (s *Server) SetWebhookDefTool(t tools.Tool) {
+	s.webhookDefTool = t
 }
 
 // newDispatcher centralises Dispatcher construction so the three call
@@ -1710,6 +1726,9 @@ func (s *Server) Mux() http.Handler {
 	// per-agent dispatcher slot).
 	mux.Handle("POST /v1/_a2aservercarddef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateA2AServerCardDef))))
 	mux.Handle("POST /v1/_a2aagentdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateA2AAgentDef))))
+	// v1.x RFC H Input Webhooks substrate. Same operator-admin-only
+	// dispatch shape as the other substrate admin endpoints.
+	mux.Handle("POST /v1/_webhookdef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateWebhookDef))))
 	// v0.11.0 LLM Gateway — direct provider routing without the agent
 	// loop. Bearer-authed admin scope. Both stream:true (SSE) and
 	// stream:false (single-shot JSON) selected by the request body.
@@ -1741,6 +1760,7 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_scheduledef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListScheduleDefNames))))
 	mux.Handle("GET /v1/_a2aservercarddef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListA2AServerCardDefNames))))
 	mux.Handle("GET /v1/_a2aagentdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListA2AAgentDefNames))))
+	mux.Handle("GET /v1/_webhookdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListWebhookDefNames))))
 	// v0.9.x Library v2 — unified enumeration that merges static cfg
 	// + substrate views into one envelope per entry. The names/* sister
 	// endpoints above stay as-is for backwards compat with external

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1387,12 +1387,23 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Session+run creation ----
-	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext}
+	identity := store.RunIdentity{AgentID: agentID, UserID: effectiveUserID, UserTier: in.UserTier, Model: model, ReplicaID: s.replicaID, ParentContext: in.ParentContext, IdempotencyKey: in.IdempotencyKey}
 	sessionID, runID, sessErr := s.openOrCreateSessionAndRun(ctx, in.SessionID, effectiveAgentName, effectiveTenantID, effectiveUserID, identity)
 	if sessErr != nil {
 		var nf *store.ErrNotFound
 		if errors.As(sessErr, &nf) {
 			return fmt.Errorf("%w: %v", runner.ErrSessionNotFound, sessErr)
+		}
+		// RFC H Decision 10: a duplicate idempotency_key means an earlier
+		// run already claimed this key. CRITICAL: return BEFORE the cancel
+		// registry + agent loop so the run never double-executes. Wrap the
+		// sentinel verbatim (no ErrInternal masking) so the webhook
+		// receiver can errors.Is-detect it and resolve to the existing
+		// run. (CreateSession ran before the failed CreateRun, leaving an
+		// orphan session with no run — acceptable: it carries no events
+		// and is never returned to a caller.)
+		if errors.Is(sessErr, store.ErrDuplicateIdempotencyKey) {
+			return sessErr
 		}
 		return fmt.Errorf("%w: %v", runner.ErrInternal, sessErr)
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -143,8 +143,11 @@ type Server struct {
 	// would defeat the per-webhook secret model. The hook receives a
 	// MuxRegistrar (an adapter that applies recovery middleware) rather
 	// than the bare mux, so a panicking webhook handler still becomes a
-	// 500 instead of crashing the process.
-	webhookMux func(reg MuxRegistrar)
+	// 500 instead of crashing the process. It ALSO receives the admin-auth
+	// wrapper (recovery + bearer) so the WH-5b triage endpoints
+	// (recent-deliveries / test) can sit behind LOOMCYCLE_AUTH_TOKEN while
+	// the receiver POST stays unauthed.
+	webhookMux func(reg MuxRegistrar, adminAuth func(http.Handler) http.Handler)
 
 	// mcpPoolInspector returns the cached tools/list result for a
 	// named MCP server as already-marshaled JSON. The "already JSON"
@@ -1890,7 +1893,9 @@ func (s *Server) Mux() http.Handler {
 	// becomes a 500 rather than tearing down the process. Nil when the
 	// receiver is disabled (the default).
 	if s.webhookMux != nil {
-		s.webhookMux(&webhookMuxAdapter{mux: mux})
+		s.webhookMux(&webhookMuxAdapter{mux: mux}, func(next http.Handler) http.Handler {
+			return recoveryMiddleware(s.authMiddleware(next))
+		})
 	}
 	return mux
 }
@@ -1912,9 +1917,10 @@ func (a *webhookMuxAdapter) Handle(pattern string, h http.Handler) {
 
 // SetWebhookMux installs the v1.x RFC H webhook-receiver mount hook,
 // called at the end of Mux(). Nil-safe. The hook receives a MuxRegistrar
-// that applies recovery middleware; it does NOT receive the bearer-auth
-// wrapper, by design (per-WebhookDef auth).
-func (s *Server) SetWebhookMux(fn func(reg MuxRegistrar)) {
+// that applies recovery middleware (for the unauthed receiver POST, which
+// does its own per-WebhookDef auth) AND an admin-auth wrapper (recovery +
+// bearer) for the WH-5b triage endpoints, which ARE operator-only.
+func (s *Server) SetWebhookMux(fn func(reg MuxRegistrar, adminAuth func(http.Handler) http.Handler)) {
 	s.webhookMux = fn
 }
 

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -76,6 +76,13 @@ func (s *Server) handleSubstrateA2AAgentDef(w http.ResponseWriter, r *http.Reque
 	s.dispatchSubstrate(w, r, "A2AAgentDef", s.A2AAgentDef)
 }
 
+// handleSubstrateWebhookDef serves POST /v1/_webhookdef.
+// v1.x RFC H Input Webhooks substrate. Bearer-authed; same dispatch
+// shape as the other substrate endpoints.
+func (s *Server) handleSubstrateWebhookDef(w http.ResponseWriter, r *http.Request) {
+	s.dispatchSubstrate(w, r, "WebhookDef", s.WebhookDef)
+}
+
 // dispatchSubstrate is the shared body of the two handlers.
 // connectorFn is the Connector method (already a method value
 // bound to the Server). toolName is the label used in error
@@ -196,6 +203,12 @@ func substrateAdminCtx(ctx context.Context) context.Context {
 		SelfName: substrateAdminAgentName,
 	})
 	ctx = tools.WithA2AAgentDefPolicy(ctx, tools.A2AAgentDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: substrateAdminAgentName,
+	})
+	// WebhookDef: same operator-trust posture; "any" scope lets the
+	// HTTP-admin call create/fork/retire any webhook name (RFC H WH-2).
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{
 		Scopes:   []string{"any"},
 		SelfName: substrateAdminAgentName,
 	})

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -112,6 +112,14 @@ func operatorCtx(ctx context.Context) context.Context {
 		SelfName: operatorAgentName,
 	})
 
+	// WebhookDef (v1.x RFC H): "any" scope so the MCP `webhookdef`
+	// meta-tool reaches the in-process tool instead of being
+	// default-denied at the scope gate. (RFC H WH-3 / mirrors A2AAgentDef.)
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: operatorAgentName,
+	})
+
 	// Evaluation: all 4 valid scope values. submit_any + read_any
 	// are the load-bearing ones; submit_self + submit_descendants
 	// are included for completeness in case an operator wants the

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -66,6 +66,13 @@ var handlersByName = map[string]toolHandler{
 	"a2aagentdef": wrapBuiltin("a2aagentdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.A2AAgentDef(ctx, in)
 	}),
+	// v1.x RFC H inbound-webhook substrate. Same operator-admin-only
+	// posture as a2aagentdef; lets external orchestrators author + fork
+	// inbound webhook definitions over MCP without the HTTP admin
+	// endpoint. (RFC H WH-3 / mirrors a2aagentdef.)
+	"webhookdef": wrapBuiltin("webhookdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.WebhookDef(ctx, in)
+	}),
 	"evaluation": wrapBuiltin("evaluation", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.Evaluation(ctx, in)
 	}),

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -135,6 +135,11 @@ func (m *httpMockConnector) A2AAgentDef(context.Context, json.RawMessage) (conne
 	return connector.ToolResult{}, errors.New("not implemented")
 }
 
+// v1.x RFC H Input Webhooks substrate stub.
+func (m *httpMockConnector) WebhookDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, errors.New("not implemented")
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *httpMockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, errors.New("not implemented")

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -183,6 +183,11 @@ func (m *mockConnector) A2AAgentDef(context.Context, json.RawMessage) (connector
 	return connector.ToolResult{}, nil
 }
 
+// v1.x RFC H Input Webhooks substrate stub.
+func (m *mockConnector) WebhookDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
+
 // v0.9.x Channel CRUD stubs.
 func (m *mockConnector) PublishChannel(context.Context, connector.ChannelPublishRequest) (connector.ChannelPublishResult, error) {
 	return connector.ChannelPublishResult{}, nil

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -292,15 +292,15 @@ func TestServer_ToolsList_Returns33Tools(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 36 {
-		t.Errorf("got %d tools, want 36 (v1.x RFC G adds a2aservercarddef + a2aagentdef on top of the v1.x scheduledef list)", len(result.Tools))
+	if len(result.Tools) != 37 {
+		t.Errorf("got %d tools, want 37 (v1.x RFC H adds webhookdef on top of the RFC G a2aservercarddef + a2aagentdef list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
 	// Spot-check across categories — through the v1.x additions.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
+	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "pause_runtime", "create_snapshot", "get_snapshot", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -169,6 +169,11 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			InputSchema: rawJSON(`{"type": "object"}`),
 		},
 		{
+			Name:        "webhookdef",
+			Description: "WebhookDef tool ops (create/fork/get/list/retire). v1.x RFC H inbound-webhook substrate. Operator-admin-only — author + fork inbound webhook definitions at runtime. Static webhooks.<name>: yaml entries stay immutable ground truth; this produces the derived layer. Pass-through.",
+			InputSchema: rawJSON(`{"type": "object"}`),
+		},
+		{
 			Name:        "evaluation",
 			Description: "Evaluation tool ops (submit/get/list_for_run/list_for_def/aggregate). Pass-through.",
 			InputSchema: rawJSON(`{"type": "object"}`),

--- a/internal/api/webhook/dedup.go
+++ b/internal/api/webhook/dedup.go
@@ -1,0 +1,112 @@
+package webhook
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// dedupTTL is how long a (webhook_name, delivery_id) pair is remembered as
+// "already seen". This is the Layer-1, per-replica replay guard — a
+// best-effort defense against duplicate deliveries and naive replays within
+// a short window. The durable, cross-replica guard is the
+// runs.idempotency_key column landing in WH-5 (Layer 2); this in-memory
+// layer absorbs the common case cheaply without a DB round-trip.
+const dedupTTL = 10 * time.Minute
+
+// dedupCache is a per-replica replay cache keyed by (webhook_name,
+// delivery_id) with lazy TTL expiry. Entries are evicted on access (a hit
+// past its TTL is treated as a miss and refreshed) plus an optional
+// background sweep; lazy expiry alone is sufficient for correctness, the
+// sweep only bounds idle memory growth.
+type dedupCache struct {
+	m   sync.Map // key string -> time.Time (expiry)
+	now func() time.Time
+}
+
+// newDedupCache returns a cache using the supplied clock. now is injected so
+// the TTL window is deterministic in tests.
+func newDedupCache(now func() time.Time) *dedupCache {
+	if now == nil {
+		now = time.Now
+	}
+	return &dedupCache{now: now}
+}
+
+// dedupKey composes the cache key. The webhook name is operator-addressable
+// (from the URL path), the delivery id is request-derived; combining them
+// scopes the replay window per webhook so two different webhooks can't
+// collide on a shared delivery id namespace.
+func dedupKey(webhookName, deliveryID string) string {
+	return webhookName + "\x00" + deliveryID
+}
+
+// seen reports whether this (name, delivery_id) was RECORDED as an accepted
+// delivery within the TTL — a pure check that does NOT record. Returns true
+// on a replay of an already-accepted delivery (caller rejects 401), false on
+// first sight or a stale entry.
+//
+// Check and record are deliberately split (vs a single check-and-set): the
+// id must be recorded only once a delivery is actually ACCEPTED (run admitted
+// / channel published), never at the guard step. Otherwise a request that
+// passes the signature but is then rejected downstream — rate-limited (429),
+// mapping error (400), or a transient spawn-setup 503 — would burn its
+// delivery id, and the sender's legitimate retry (same id) would be dropped
+// as a replay. That is silent event loss, which Decision 9 forbids. By
+// recording only on acceptance, a non-accepted delivery stays retryable.
+//
+// The residual window (two identical deliveries both passing seen() before
+// either calls record()) is bounded by the Layer-2 runs.idempotency_key
+// dedup landing in WH-5; Layer-1 here is best-effort per-replica.
+func (c *dedupCache) seen(webhookName, deliveryID string) bool {
+	v, ok := c.m.Load(dedupKey(webhookName, deliveryID))
+	if !ok {
+		return false
+	}
+	exp, ok := v.(time.Time)
+	if !ok || c.now().After(exp) {
+		return false // stale entry → treat as first sight
+	}
+	return true
+}
+
+// record marks (name, delivery_id) as an accepted delivery for dedupTTL.
+// Called only after the delivery is accepted, so a downstream rejection
+// never burns the id (see seen()).
+func (c *dedupCache) record(webhookName, deliveryID string) {
+	c.m.Store(dedupKey(webhookName, deliveryID), c.now().Add(dedupTTL))
+}
+
+// sweep evicts all expired entries. Optional — lazy expiry on seen
+// keeps correctness; a periodic sweep bounds memory for delivery ids that
+// are never seen again. Safe to call concurrently with seen/record.
+func (c *dedupCache) sweep() {
+	now := c.now()
+	c.m.Range(func(k, v interface{}) bool {
+		if exp, ok := v.(time.Time); ok && now.After(exp) {
+			c.m.Delete(k)
+		}
+		return true
+	})
+}
+
+// deliveryID extracts the dedup delivery identity from the request. When the
+// Def names a delivery_id_header and it is present, that header value is
+// used verbatim. Otherwise a SHA-256 of the raw body is the fallback id, so
+// two byte-identical bodies inside the TTL are treated as one delivery.
+//
+// Hashing the body (vs using it raw as a key) bounds key size and avoids
+// holding the full payload in the cache. The hash is NOT a security
+// primitive here — it's a content fingerprint — so a plain digest is fine.
+func deliveryID(a config.WebhookAuth, body []byte, headerGet func(string) string) string {
+	if a.DeliveryIDHeader != "" {
+		if v := headerGet(a.DeliveryIDHeader); v != "" {
+			return v
+		}
+	}
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/api/webhook/dedup_test.go
+++ b/internal/api/webhook/dedup_test.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+func TestDedup_ReplayWithinTTL_Detected(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	c := newDedupCache(fixedClock(now))
+
+	if c.seen("gh", "delivery-1") {
+		t.Fatal("first sight reported as replay")
+	}
+	c.record("gh", "delivery-1")
+	if !c.seen("gh", "delivery-1") {
+		t.Fatal("recorded delivery within TTL not detected as replay")
+	}
+}
+
+// A check that is never followed by record() must NOT burn the delivery id:
+// this is the rate-limited / mapping-error / setup-error retry path, where
+// the request was authenticated but not accepted, so the sender's retry of
+// the SAME delivery id must still be processed (Decision 9: no silent loss).
+func TestDedup_CheckWithoutRecord_StaysRetryable(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	c := newDedupCache(fixedClock(now))
+
+	if c.seen("gh", "delivery-1") {
+		t.Fatal("first sight reported as replay")
+	}
+	// No record() — the delivery was rejected downstream. The retry must
+	// still be a first sight.
+	if c.seen("gh", "delivery-1") {
+		t.Fatal("a checked-but-not-recorded delivery id was burned — retry would be lost")
+	}
+}
+
+func TestDedup_DifferentWebhooks_NoCollision(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	c := newDedupCache(fixedClock(now))
+
+	c.record("hook-a", "shared-id")
+	// Same delivery id on a different webhook is a fresh first-sight.
+	if c.seen("hook-b", "shared-id") {
+		t.Fatal("delivery id collided across distinct webhook names")
+	}
+}
+
+func TestDedup_ExpiryAfterTTL_AcceptsAgain(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	c := newDedupCache(func() time.Time { return clock })
+
+	c.record("gh", "delivery-1")
+	// Advance past the TTL window.
+	clock = base.Add(dedupTTL + time.Minute)
+	if c.seen("gh", "delivery-1") {
+		t.Fatal("entry past TTL still treated as replay")
+	}
+}
+
+func TestDeliveryID_HeaderPreferred_BodyHashFallback(t *testing.T) {
+	body := []byte(`{"x":1}`)
+	a := config.WebhookAuth{DeliveryIDHeader: "X-Delivery"}
+
+	withHeader := deliveryID(a, body, func(k string) string {
+		if k == "X-Delivery" {
+			return "abc-123"
+		}
+		return ""
+	})
+	if withHeader != "abc-123" {
+		t.Errorf("header delivery id = %q, want abc-123", withHeader)
+	}
+
+	// Header absent → body-hash fallback (stable + prefixed).
+	noHeader := deliveryID(a, body, func(string) string { return "" })
+	if noHeader == "" || noHeader[:7] != "sha256:" {
+		t.Errorf("fallback delivery id = %q, want sha256: prefix", noHeader)
+	}
+	// Same body → same fallback id (so replays of identical bodies dedup).
+	if again := deliveryID(a, body, func(string) string { return "" }); again != noHeader {
+		t.Errorf("body-hash fallback not stable: %q vs %q", noHeader, again)
+	}
+}

--- a/internal/api/webhook/oncomplete.go
+++ b/internal/api/webhook/oncomplete.go
@@ -1,0 +1,134 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// dispatchOnComplete fires each of a WebhookDef's on_complete hooks after a
+// spawned run has completed (WH-5b). It MIRRORS the scheduler's dispatch in
+// internal/scheduler/dispatch.go rather than importing it — the receiver and
+// the scheduler already duplicate the WebhookDef/ScheduleDef hook shape
+// (config.ScheduledRunHook), so replicating the two wired arms here keeps the
+// two surfaces decoupled and avoids a scheduler refactor.
+//
+// Hooks are best-effort: the run has ALREADY completed, so a hook failure is
+// logged and the next hook runs. This function never returns an error, never
+// panics, and never affects the accept/reject decision of the inbound request
+// (which was made long before the run finished).
+//
+// runID + agentID are stamped into channel messages for traceability.
+// userID selects the scope: when non-empty, channel.publish + memory.set
+// land under the user keyspace; otherwise global (agent scope keys on the
+// webhook NAME, matching the scheduler's stable-key choice).
+func (rec *Receiver) dispatchOnComplete(ctx context.Context, name string, wd config.Webhook, runID, agentID, userID string) {
+	for i, h := range wd.OnComplete {
+		if err := rec.dispatchOneOnComplete(ctx, name, h, runID, agentID, userID); err != nil {
+			rec.logf("webhook %q: on_complete[%d] (%s) failed: %v", name, i, h.Kind, err)
+		}
+	}
+}
+
+func (rec *Receiver) dispatchOneOnComplete(ctx context.Context, name string, h config.ScheduledRunHook, runID, agentID, userID string) error {
+	switch h.Kind {
+	case "channel.publish":
+		return rec.dispatchOnCompleteChannelPublish(ctx, name, h, runID, agentID, userID)
+	case "memory.set":
+		return rec.dispatchOnCompleteMemorySet(ctx, name, h, userID)
+	case "mcp.call":
+		// The receiver has no MCPCaller wired (exactly like the scheduler's
+		// nil case). Log + skip — never fail the (already-completed) run.
+		rec.logf("webhook %q: on_complete mcp.call not wired (no MCPCaller)", name)
+		return nil
+	case "":
+		// Defensive: validation (WH-1/WH-2) should have rejected a kind-less
+		// hook at write time. Log + skip rather than fail.
+		rec.logf("webhook %q: on_complete hook missing kind — skipping", name)
+		return nil
+	default:
+		rec.logf("webhook %q: on_complete unknown hook kind %q — skipping", name, h.Kind)
+		return nil
+	}
+}
+
+// dispatchOnCompleteChannelPublish mirrors scheduler.dispatchChannelPublish.
+// The published payload carries the webhook name + run/agent ids alongside
+// the operator-declared hook payload so a downstream consumer can correlate
+// the delivery to the run that produced it.
+func (rec *Receiver) dispatchOnCompleteChannelPublish(ctx context.Context, name string, h config.ScheduledRunHook, runID, agentID, userID string) error {
+	if h.Channel == "" {
+		return fmt.Errorf("channel.publish missing `channel`")
+	}
+	if rec.store == nil {
+		return fmt.Errorf("channel.publish hook fired but no store wired")
+	}
+	payload, err := json.Marshal(map[string]any{
+		"webhook_name": name,
+		"run_id":       runID,
+		"agent_id":     agentID,
+		"payload":      h.Payload,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	scope := store.MemoryScopeGlobal
+	scopeID := ""
+	if userID != "" {
+		scope = store.MemoryScopeUser
+		scopeID = userID
+	}
+	msg := store.ChannelMessage{
+		Channel:           h.Channel,
+		Scope:             scope,
+		ScopeID:           scopeID,
+		Payload:           payload,
+		PublishedAt:       rec.now(),
+		PublishedByUserID: userID,
+	}
+	// maxMessages = 0 means use the store's default cap (operator sizing is a
+	// per-channel cfg concern the publish path doesn't see), mirroring the
+	// scheduler.
+	_, _, err = rec.store.ChannelPublish(ctx, msg, 0)
+	return err
+}
+
+// dispatchOnCompleteMemorySet mirrors scheduler.dispatchMemorySet. agent
+// scope keys on the webhook NAME (a stable, operator-recognisable key, since
+// a webhook hook doesn't run "as an agent" the way an in-loop tool call
+// does); user scope requires a userID; global has no scope id.
+func (rec *Receiver) dispatchOnCompleteMemorySet(ctx context.Context, name string, h config.ScheduledRunHook, userID string) error {
+	if h.Scope == "" || h.Key == "" {
+		return fmt.Errorf("memory.set missing `scope` or `key`")
+	}
+	if rec.store == nil {
+		return fmt.Errorf("memory.set hook fired but no store wired")
+	}
+	var scope store.MemoryScope
+	scopeID := ""
+	switch h.Scope {
+	case "agent":
+		scope = store.MemoryScopeAgent
+		scopeID = name
+	case "user":
+		if userID == "" {
+			return fmt.Errorf("memory.set scope=user but delivery has no user_id")
+		}
+		scope = store.MemoryScopeUser
+		scopeID = userID
+	case "global":
+		scope = store.MemoryScopeGlobal
+	default:
+		return fmt.Errorf("memory.set: unknown scope %q (must be agent|user|global)", h.Scope)
+	}
+	value, err := json.Marshal(h.Payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	// ttl = 0 means no expiry, mirroring the scheduler's memory.set hook.
+	return rec.store.MemorySet(ctx, scope, scopeID, h.Key, value, time.Duration(0))
+}

--- a/internal/api/webhook/payload.go
+++ b/internal/api/webhook/payload.go
@@ -1,0 +1,199 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// projectResult is the outcome of applying a WebhookDef's payload_mapping
+// to a request body. Fields holds the resolved string values keyed by the
+// operator-chosen dotted target (e.g. "goal", "user_id",
+// "user_credentials.GITHUB_TOKEN", "run_metadata.repo"). MissingKeys lists
+// the mapping targets whose source path resolved to nothing — the caller
+// logs these as a tracing note but does NOT fail the request (a webhook
+// payload is external and may legitimately omit optional fields).
+type projectResult struct {
+	Fields      map[string]string
+	MissingKeys []string
+}
+
+// projectPayload applies a payload_mapping to a raw JSON body. The mapping
+// is target → source-jsonpath: each key is an arbitrary dotted target the
+// caller interprets (goal, user_id, user_credentials.*, run_metadata.*),
+// and each value is a STRICT-subset JSONPath expression evaluated against
+// the body.
+//
+// Supported JSONPath subset (validated up front, anything else rejected):
+//   - root marker "$"
+//   - dot segments: $.a.b.c
+//   - array index segments: $.a[0].b, $.items[2]
+//
+// Explicitly UNSUPPORTED (rejected at validate, never evaluated):
+//   - wildcards ($.a[*], $..b)
+//   - filters ($.a[?(@.x)])
+//   - recursive descent ($..)
+//   - any expression / script
+//
+// A malformed body is a request error (returned err → server maps 400).
+// A malformed mapping EXPRESSION is also a request error (the path string
+// failed the allowlist) — this is a 400 because the operator's Def shape is
+// validated at write time (WH-2), so an invalid path reaching here means a
+// hand-edited/forged Def; failing closed is correct. An absent path inside
+// a well-formed body is NOT an error: it yields an empty string and a
+// MissingKeys entry.
+func projectPayload(mapping map[string]string, body []byte) (projectResult, error) {
+	res := projectResult{Fields: make(map[string]string, len(mapping))}
+
+	var doc interface{}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return projectResult{}, fmt.Errorf("malformed json body: %w", err)
+	}
+
+	for target, path := range mapping {
+		segs, err := parsePath(path)
+		if err != nil {
+			return projectResult{}, fmt.Errorf("payload_mapping[%q]: %w", target, err)
+		}
+		v, ok := evalPath(doc, segs)
+		if !ok {
+			res.Fields[target] = ""
+			res.MissingKeys = append(res.MissingKeys, target)
+			continue
+		}
+		res.Fields[target] = stringify(v)
+	}
+	return res, nil
+}
+
+// pathSeg is one resolved step in a parsed JSONPath: either a map key
+// (Key set, IsIndex false) or an array index (Index set, IsIndex true).
+type pathSeg struct {
+	Key     string
+	Index   int
+	IsIndex bool
+}
+
+// parsePath validates and tokenizes a strict-subset JSONPath. Returns an
+// error for any shape outside the allowlist (wildcards, filters, recursive
+// descent, empty segments). The grammar is intentionally tiny so the
+// rejection surface is exhaustive: a leading "$", then zero or more
+// segments of the form `.key` or `[N]`.
+func parsePath(path string) ([]pathSeg, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	if path[0] != '$' {
+		return nil, fmt.Errorf("path must start with $")
+	}
+	// Reject recursive descent ("..") and the bare-wildcard forms outright,
+	// before the segment walk, so the error message names the actual
+	// violation rather than a downstream parse glitch.
+	if strings.Contains(path, "..") {
+		return nil, fmt.Errorf("recursive descent (..) not supported")
+	}
+	if strings.Contains(path, "*") {
+		return nil, fmt.Errorf("wildcard (*) not supported")
+	}
+	if strings.Contains(path, "?") || strings.Contains(path, "@") {
+		return nil, fmt.Errorf("filter expressions not supported")
+	}
+
+	rest := path[1:] // strip the leading $
+	var segs []pathSeg
+	for len(rest) > 0 {
+		switch rest[0] {
+		case '.':
+			rest = rest[1:]
+			// Read a key up to the next '.' or '['.
+			end := strings.IndexAny(rest, ".[")
+			var key string
+			if end == -1 {
+				key = rest
+				rest = ""
+			} else {
+				key = rest[:end]
+				rest = rest[end:]
+			}
+			if key == "" {
+				return nil, fmt.Errorf("empty key segment")
+			}
+			segs = append(segs, pathSeg{Key: key})
+		case '[':
+			end := strings.IndexByte(rest, ']')
+			if end == -1 {
+				return nil, fmt.Errorf("unterminated [ index")
+			}
+			idxStr := rest[1:end]
+			idx, err := strconv.Atoi(strings.TrimSpace(idxStr))
+			if err != nil || idx < 0 {
+				// Only non-negative integer indices are allowed. A quoted
+				// key form (['key']) is intentionally NOT supported — it
+				// widens the grammar with no payload-mapping need.
+				return nil, fmt.Errorf("invalid array index %q", idxStr)
+			}
+			segs = append(segs, pathSeg{Index: idx, IsIndex: true})
+			rest = rest[end+1:]
+		default:
+			return nil, fmt.Errorf("unexpected character %q in path", string(rest[0]))
+		}
+	}
+	return segs, nil
+}
+
+// evalPath walks the parsed segments over a decoded JSON document. Returns
+// (value, true) when every segment resolves; (nil, false) on any miss
+// (wrong type, absent key, out-of-range index). No panics — a type
+// mismatch is a miss, not a crash.
+func evalPath(doc interface{}, segs []pathSeg) (interface{}, bool) {
+	cur := doc
+	for _, s := range segs {
+		if s.IsIndex {
+			arr, ok := cur.([]interface{})
+			if !ok || s.Index >= len(arr) {
+				return nil, false
+			}
+			cur = arr[s.Index]
+			continue
+		}
+		obj, ok := cur.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		v, present := obj[s.Key]
+		if !present {
+			return nil, false
+		}
+		cur = v
+	}
+	return cur, true
+}
+
+// stringify converts a resolved JSON value to the flat string the mapping
+// produces. Strings pass through verbatim; numbers/bools render via their
+// natural form; objects/arrays/null render as compact JSON so a mapping
+// that targets a sub-object still yields a deterministic string rather than
+// Go's %v formatting.
+func stringify(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case float64:
+		// json.Unmarshal decodes all numbers to float64. strconv with -1
+		// precision avoids trailing zeros and scientific notation for the
+		// common integer-id case.
+		return strconv.FormatFloat(t, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(t)
+	case nil:
+		return ""
+	default:
+		b, err := json.Marshal(t)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}

--- a/internal/api/webhook/payload_test.go
+++ b/internal/api/webhook/payload_test.go
@@ -1,0 +1,102 @@
+package webhook
+
+import "testing"
+
+func TestProjectPayload_NestedArrayAndAbsent_ProjectsCorrectly(t *testing.T) {
+	body := []byte(`{
+		"goal_text": "research the company",
+		"user": {"id": "u-42"},
+		"items": [{"name": "first"}, {"name": "second"}],
+		"meta": {"count": 7, "flag": true}
+	}`)
+
+	mapping := map[string]string{
+		"goal":        "$.goal_text",
+		"user_id":     "$.user.id",
+		"first_item":  "$.items[0].name",
+		"second_item": "$.items[1].name",
+		"count":       "$.meta.count",
+		"flag":        "$.meta.flag",
+		"missing":     "$.does.not.exist",
+	}
+
+	res, err := projectPayload(mapping, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]string{
+		"goal":        "research the company",
+		"user_id":     "u-42",
+		"first_item":  "first",
+		"second_item": "second",
+		"count":       "7",
+		"flag":        "true",
+		"missing":     "",
+	}
+	for k, v := range want {
+		if res.Fields[k] != v {
+			t.Errorf("field %q = %q, want %q", k, res.Fields[k], v)
+		}
+	}
+	// The absent path must surface as a missing-key note (not a failure).
+	foundMissing := false
+	for _, mk := range res.MissingKeys {
+		if mk == "missing" {
+			foundMissing = true
+		}
+	}
+	if !foundMissing {
+		t.Errorf("expected %q in MissingKeys, got %v", "missing", res.MissingKeys)
+	}
+}
+
+func TestProjectPayload_MalformedBody_Errors(t *testing.T) {
+	_, err := projectPayload(map[string]string{"goal": "$.x"}, []byte(`{not json`))
+	if err == nil {
+		t.Fatal("want error on malformed body, got nil")
+	}
+}
+
+func TestParsePath_RejectsDisallowedShapes(t *testing.T) {
+	cases := []string{
+		"$.a[*]",      // wildcard index
+		"$..a",        // recursive descent
+		"$.a[?(@.x)]", // filter
+		"a.b",         // missing $ root
+		"$.",          // empty key
+		"$.a[xyz]",    // non-integer index
+		"$.a[-1]",     // negative index
+	}
+	for _, c := range cases {
+		if _, err := parsePath(c); err == nil {
+			t.Errorf("path %q: want reject, got accept", c)
+		}
+	}
+}
+
+func TestParsePath_AcceptsAllowedShapes(t *testing.T) {
+	cases := []string{
+		"$",
+		"$.a",
+		"$.a.b.c",
+		"$.a[0]",
+		"$.a[10].b",
+	}
+	for _, c := range cases {
+		if _, err := parsePath(c); err != nil {
+			t.Errorf("path %q: want accept, got %v", c, err)
+		}
+	}
+}
+
+func TestProjectPayload_ObjectValue_RendersCompactJSON(t *testing.T) {
+	body := []byte(`{"obj":{"k":"v"}}`)
+	res, err := projectPayload(map[string]string{"o": "$.obj"}, body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Fields["o"] != `{"k":"v"}` {
+		t.Errorf("object render = %q, want compact JSON", res.Fields["o"])
+	}
+}

--- a/internal/api/webhook/ratelimit.go
+++ b/internal/api/webhook/ratelimit.go
@@ -1,0 +1,103 @@
+package webhook
+
+import (
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+const (
+	defaultRequestsPerMinute = 60
+	defaultBurst             = 10
+)
+
+// tokenBucket is a classic token-bucket limiter for one WebhookDef. Tokens
+// refill continuously at refillPerSec; allow() removes one token when
+// available. Per-replica — the cluster-wide story is intentionally out of
+// scope (RFC H Layer-2/L7 concern), this bounds a single replica's intake.
+type tokenBucket struct {
+	mu           sync.Mutex
+	capacity     float64 // burst ceiling
+	tokens       float64
+	refillPerSec float64
+	last         time.Time
+}
+
+func newTokenBucket(requestsPerMinute, burst int, now time.Time) *tokenBucket {
+	if requestsPerMinute <= 0 {
+		requestsPerMinute = defaultRequestsPerMinute
+	}
+	if burst <= 0 {
+		burst = defaultBurst
+	}
+	return &tokenBucket{
+		capacity:     float64(burst),
+		tokens:       float64(burst),
+		refillPerSec: float64(requestsPerMinute) / 60.0,
+		last:         now,
+	}
+}
+
+// allow refills based on elapsed time, then consumes one token. Returns
+// (true, 0) when a token was available; (false, retryAfter) when the bucket
+// is empty, where retryAfter is the wait until one token refills.
+func (b *tokenBucket) allow(now time.Time) (bool, time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens += elapsed * b.refillPerSec
+		if b.tokens > b.capacity {
+			b.tokens = b.capacity
+		}
+		b.last = now
+	}
+	if b.tokens >= 1 {
+		b.tokens--
+		return true, 0
+	}
+	// Time until one full token is available again.
+	needed := 1 - b.tokens
+	var retry time.Duration
+	if b.refillPerSec > 0 {
+		retry = time.Duration(needed/b.refillPerSec*float64(time.Second)) + time.Second
+	} else {
+		retry = time.Minute
+	}
+	return false, retry
+}
+
+// rateLimiter holds one token bucket per webhook name. Buckets are created
+// lazily on first request for a name, using that Def's rate_limit config.
+type rateLimiter struct {
+	mu      sync.Mutex
+	buckets map[string]*tokenBucket
+	now     func() time.Time
+}
+
+func newRateLimiter(now func() time.Time) *rateLimiter {
+	if now == nil {
+		now = time.Now
+	}
+	return &rateLimiter{
+		buckets: make(map[string]*tokenBucket),
+		now:     now,
+	}
+}
+
+// allow checks the named webhook's bucket, creating it from rl config on
+// first use. Returns (true, 0) when permitted; (false, retryAfter) when the
+// per-Def rate is exceeded (server maps to 429 + Retry-After).
+func (r *rateLimiter) allow(name string, rl config.WebhookRateLimit) (bool, time.Duration) {
+	now := r.now()
+	r.mu.Lock()
+	b, ok := r.buckets[name]
+	if !ok {
+		b = newTokenBucket(rl.RequestsPerMinute, rl.Burst, now)
+		r.buckets[name] = b
+	}
+	r.mu.Unlock()
+	return b.allow(now)
+}

--- a/internal/api/webhook/ratelimit_test.go
+++ b/internal/api/webhook/ratelimit_test.go
@@ -1,0 +1,63 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+func TestRateLimit_BurstThenExceeded_Returns429Signal(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rl := newRateLimiter(fixedClock(now))
+	cfg := config.WebhookRateLimit{RequestsPerMinute: 60, Burst: 3}
+
+	// Burst of 3 should pass.
+	for i := 0; i < 3; i++ {
+		if ok, _ := rl.allow("hook", cfg); !ok {
+			t.Fatalf("burst request %d unexpectedly limited", i+1)
+		}
+	}
+	// 4th within the same instant (no refill) must be limited.
+	ok, retry := rl.allow("hook", cfg)
+	if ok {
+		t.Fatal("4th request past burst was allowed")
+	}
+	if retry <= 0 {
+		t.Fatalf("expected positive Retry-After, got %v", retry)
+	}
+}
+
+func TestRateLimit_RefillAfterTime_AllowsAgain(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	clock := base
+	rl := newRateLimiter(func() time.Time { return clock })
+	cfg := config.WebhookRateLimit{RequestsPerMinute: 60, Burst: 1} // 1 token/sec
+
+	if ok, _ := rl.allow("hook", cfg); !ok {
+		t.Fatal("first request limited")
+	}
+	if ok, _ := rl.allow("hook", cfg); ok {
+		t.Fatal("second immediate request should be limited")
+	}
+	// Advance 2s → ~2 tokens refilled (capped at burst=1).
+	clock = base.Add(2 * time.Second)
+	if ok, _ := rl.allow("hook", cfg); !ok {
+		t.Fatal("request after refill was limited")
+	}
+}
+
+func TestRateLimit_PerWebhookIsolation(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rl := newRateLimiter(fixedClock(now))
+	cfg := config.WebhookRateLimit{RequestsPerMinute: 60, Burst: 1}
+
+	rl.allow("hook-a", cfg) // exhaust hook-a
+	if ok, _ := rl.allow("hook-a", cfg); ok {
+		t.Fatal("hook-a should be exhausted")
+	}
+	// hook-b has its own bucket.
+	if ok, _ := rl.allow("hook-b", cfg); !ok {
+		t.Fatal("hook-b limited by hook-a's bucket")
+	}
+}

--- a/internal/api/webhook/recent.go
+++ b/internal/api/webhook/recent.go
@@ -1,0 +1,104 @@
+package webhook
+
+import "time"
+
+// recentBufferCap is the per-webhook ring depth: the last N invocations of a
+// given webhook name are retained for the triage endpoint. Bounded so a
+// high-traffic webhook can't grow the buffer without limit — triage is a
+// recent-activity window, not an audit log (the runs table is the durable
+// record). 50 matches the recent-deliveries endpoint's hard cap.
+const recentBufferCap = 50
+
+// deliveryRecord is one entry in a webhook's recent-deliveries ring. It holds
+// ONLY non-sensitive triage fields: the delivery id (a content fingerprint or
+// operator-supplied header, never a secret), the verdict label, the receive
+// time, and the spawned run id (empty for channel deliveries / rejections).
+// Credentials and raw payloads are deliberately absent.
+type deliveryRecord struct {
+	DeliveryID string    `json:"delivery_id"`
+	Verdict    string    `json:"verdict"`
+	ReceivedAt time.Time `json:"received_at"`
+	RunID      string    `json:"run_id,omitempty"`
+}
+
+// recentRing is a fixed-capacity, newest-overwrites-oldest ring of
+// deliveryRecords for one webhook name. Not safe for concurrent use on its
+// own — the Receiver's recentMu guards all access.
+type recentRing struct {
+	buf  []deliveryRecord
+	next int  // index to write the next record
+	full bool // whether the ring has wrapped at least once
+}
+
+// add appends a record, overwriting the oldest once at capacity.
+func (r *recentRing) add(rec deliveryRecord) {
+	if r.buf == nil {
+		r.buf = make([]deliveryRecord, recentBufferCap)
+	}
+	r.buf[r.next] = rec
+	r.next = (r.next + 1) % recentBufferCap
+	if r.next == 0 {
+		r.full = true
+	}
+}
+
+// snapshot returns the records newest-first, capped at limit (after the
+// ring's own length). A limit <= 0 is treated as the full available depth.
+func (r *recentRing) snapshot(limit int) []deliveryRecord {
+	n := r.next
+	if r.full {
+		n = recentBufferCap
+	}
+	if n == 0 {
+		return nil
+	}
+	if limit <= 0 || limit > n {
+		limit = n
+	}
+	out := make([]deliveryRecord, 0, limit)
+	// Walk backwards from the most-recently-written slot.
+	idx := (r.next - 1 + recentBufferCap) % recentBufferCap
+	for i := 0; i < limit; i++ {
+		out = append(out, r.buf[idx])
+		idx = (idx - 1 + recentBufferCap) % recentBufferCap
+	}
+	return out
+}
+
+// recordDelivery appends a triage record for the given webhook name. Called
+// at every terminal point in handle()/deliver* with the verdict already
+// computed for the span. did + runID may be empty (a rejection before the
+// delivery id is derived, or a non-spawn / rejected delivery). Best-effort:
+// it holds recentMu only briefly and never affects the response.
+func (rec *Receiver) recordDelivery(name, did, verdict, runID string) {
+	r := deliveryRecord{
+		DeliveryID: did,
+		Verdict:    verdict,
+		ReceivedAt: rec.now(),
+		RunID:      runID,
+	}
+	rec.recentMu.Lock()
+	defer rec.recentMu.Unlock()
+	if rec.recent == nil {
+		rec.recent = make(map[string]*recentRing)
+	}
+	ring := rec.recent[name]
+	if ring == nil {
+		ring = &recentRing{}
+		rec.recent[name] = ring
+	}
+	ring.add(r)
+}
+
+// recentSnapshot returns the recorded deliveries for a webhook name,
+// newest-first, capped at limit. ok=false when the name has never been seen
+// (so the endpoint can 404 rather than return an empty list for a typo).
+func (rec *Receiver) recentSnapshot(name string, limit int) ([]deliveryRecord, bool) {
+	rec.recentMu.Lock()
+	defer rec.recentMu.Unlock()
+	ring := rec.recent[name]
+	if ring == nil {
+		return nil, false
+	}
+	return ring.snapshot(limit), true
+}

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -86,8 +86,8 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		UserID:          proj.Fields["user_id"],
 		UserTier:        proj.Fields["user_tier"],
 		UserCredentials: creds,
-		// WH-5: idempotency_key (Layer 2) — the durable cross-replica replay
-		// key (runs.idempotency_key) is set here from the delivery id once
-		// the column lands in WH-5.
+		// IdempotencyKey is set by the caller (deliverSpawn) to the
+		// delivery id, keeping this builder's signature focused on the
+		// Def + projected payload. See RFC H Decision 10 "Layer 2".
 	}
 }

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -1,0 +1,93 @@
+package webhook
+
+import (
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+)
+
+// credentialsPrefix is the payload-mapping target namespace that overlays
+// resolved credentials. A mapping key "user_credentials.GITHUB_TOKEN"
+// projects a value from the request body into the GITHUB_TOKEN credential.
+const credentialsPrefix = "user_credentials."
+
+// buildRunInput converts a resolved webhook Def + projected payload into the
+// RunInput the runner consumes. It MIRRORS the scheduler's buildRunInput
+// credential pattern (env-allowlist gate over user_credentials_from_env)
+// and ADDS the webhook-specific rule: a payload_mapping target under
+// `user_credentials.<name>` overlays the env-resolved value, and the
+// PAYLOAD WINS. Rationale: the webhook payload is the live, per-delivery
+// secret (e.g. a per-call token the sender minted), whereas the env var is
+// the static fallback; the more specific source should override.
+//
+// getenv is injected so tests drive the env branches deterministically.
+// logf may be nil.
+func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string]bool, getenv func(string) string, logf func(format string, args ...any)) runner.RunInput {
+	creds := make(map[string]string)
+
+	// 1. Env-resolved credentials, gated by the allowlist (scheduler parity).
+	for k, envName := range w.UserCredentialsFromEnv {
+		if !envAllowlist[envName] {
+			if logf != nil {
+				logf("webhook: env var %q for credential key %q not in allowlist — skipping", envName, k)
+			}
+			continue
+		}
+		v := getenv(envName)
+		if v == "" {
+			if logf != nil {
+				logf("webhook: env var %q for credential key %q is empty — skipping", envName, k)
+			}
+			continue
+		}
+		creds[k] = v
+	}
+
+	// 2. Payload overlay: user_credentials.<name> mapping targets win over
+	//    the env-resolved value for the same key. An empty projected value
+	//    (absent path) does NOT clobber an env-resolved credential — a
+	//    missing optional field shouldn't blank out the static fallback.
+	for target, val := range proj.Fields {
+		if !strings.HasPrefix(target, credentialsPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(target, credentialsPrefix)
+		if name == "" || val == "" {
+			continue
+		}
+		if _, hadEnv := creds[name]; hadEnv && logf != nil {
+			logf("webhook: credential key %q has both env + payload source — payload value wins", name)
+		}
+		creds[name] = val
+	}
+
+	goal := proj.Fields["goal"]
+	seg := loop.PromptSegment{
+		Role: "user",
+		Content: []loop.PromptContentBlock{
+			// The goal is projected from an EXTERNAL, attacker-influenceable
+			// webhook payload (a PR title, an issue body, a commit message).
+			// Wrap it as an untrusted-block so the loop fences it in
+			// <untrusted> tags before the model sees it — the operator's
+			// payload_mapping chooses WHICH field becomes the goal, but the
+			// VALUE is not trusted. (Contrast the scheduler, which uses
+			// trusted-text: its prompt is operator-authored static text, not
+			// live external input.) This is the prompt-injection boundary for
+			// webhook-triggered runs.
+			{Type: "untrusted-block", Kind: "webhook_payload", Text: goal},
+		},
+	}
+
+	return runner.RunInput{
+		Agent:           w.Agent,
+		Segments:        []loop.PromptSegment{seg},
+		UserID:          proj.Fields["user_id"],
+		UserTier:        proj.Fields["user_tier"],
+		UserCredentials: creds,
+		// WH-5: idempotency_key (Layer 2) — the durable cross-replica replay
+		// key (runs.idempotency_key) is set here from the delivery id once
+		// the column lands in WH-5.
+	}
+}

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -264,8 +264,29 @@ func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, sp
 		return
 	}
 	in := buildRunInput(wd, proj, rec.envAllowlist, rec.getenv, rec.logf)
-	// WH-5: idempotency_key (Layer 2) — set in.IdempotencyKey = did here once
-	// the runs.idempotency_key column lands, for durable cross-replica dedup.
+	// RFC H Decision 10 "Layer 2" durable dedup: stamp the run with the
+	// delivery id so CreateRun persists it to runs.idempotency_key.
+	in.IdempotencyKey = did
+
+	// Layer-2 BEFORE-spawn check: if a run already carries this delivery
+	// id (a redelivery that survived past the in-memory Layer-1 TTL, or
+	// landed on a different replica), return the existing run as accepted
+	// without spawning a duplicate. The store is nil for yaml-only
+	// deployments; treat a lookup error as "not found" (fail open to the
+	// spawn path — the unique index is the real backstop).
+	if rec.store != nil && did != "" {
+		if existing, ok, lerr := rec.store.RunByIdempotencyKey(ctx, did); lerr == nil && ok {
+			rec.dedup.record(name, did)
+			rec.finish(span, verdictAccepted)
+			writeJSON(w, http.StatusAccepted, map[string]string{
+				"webhook_name": name,
+				"delivery_id":  did,
+				"run_id":       existing.ID,
+				"deduped":      "true",
+			})
+			return
+		}
+	}
 
 	wantSync := r.URL.Query().Get("sync") == "true" && wd.SyncResponse.Enabled
 
@@ -333,6 +354,39 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 			writeJSON(w, http.StatusAccepted, map[string]string{
 				"webhook_name": name,
 				"delivery_id":  did,
+			})
+			return
+		}
+		// RFC H Decision 10 concurrent-race: two deliveries with the same
+		// id both passed the BEFORE-spawn Layer-2 check, and the unique
+		// index let only one CreateRun win. The loser's RunOnce returns
+		// ErrDuplicateIdempotencyKey (BEFORE its agent loop ran — no
+		// double-execution). Re-look-up the winner and return it as
+		// accepted (202), NOT a 503 — the delivery WAS processed, just by
+		// the racing request.
+		if errors.Is(err, store.ErrDuplicateIdempotencyKey) {
+			if rec.store != nil && did != "" {
+				if existing, ok, lerr := rec.store.RunByIdempotencyKey(context.Background(), did); lerr == nil && ok {
+					rec.dedup.record(name, did)
+					rec.finish(span, verdictAccepted)
+					writeJSON(w, http.StatusAccepted, map[string]string{
+						"webhook_name": name,
+						"delivery_id":  did,
+						"run_id":       existing.ID,
+						"deduped":      "true",
+					})
+					return
+				}
+			}
+			// Winner's row not visible yet (replication lag / nil store):
+			// still accepted — the delivery was handled by the racing
+			// request. Record so a retry doesn't re-spawn.
+			rec.dedup.record(name, did)
+			rec.finish(span, verdictAccepted)
+			writeJSON(w, http.StatusAccepted, map[string]string{
+				"webhook_name": name,
+				"delivery_id":  did,
+				"deduped":      "true",
 			})
 			return
 		}

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -1,0 +1,513 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+const defaultBodySizeLimitBytes = 1 << 20 // 1 MiB
+
+// Receiver is the RFC H inbound-webhook HTTP handler. It is the
+// security/trust boundary: it authenticates a raw external POST, guards
+// against replay + overload, projects the payload through the Def's
+// allowlisted mapping, then forks on delivery mode to either spawn an agent
+// run or publish to a channel.
+//
+// The receiver does its OWN per-Def authentication (HMAC / bearer); it is
+// therefore mounted WITHOUT the global bearer authMiddleware. Mounting it
+// behind authMiddleware would force every external sender to also carry the
+// operator's LOOMCYCLE_AUTH_TOKEN, defeating the per-webhook secret model.
+type Receiver struct {
+	store        lookup.WebhookStore
+	cfg          *config.Config
+	runner       runner.Runner
+	publisher    channels.SystemPublisher
+	runStateBus  *runstate.Bus
+	envAllowlist map[string]bool
+	logf         func(format string, args ...any)
+
+	dedup   *dedupCache
+	limiter *rateLimiter
+
+	// now + getenv are injected so the timestamp-window, dedup-TTL,
+	// rate-limit refill, and secret-resolution paths are deterministic in
+	// tests. Production wiring uses time.Now + os.Getenv.
+	now    func() time.Time
+	getenv func(string) string
+}
+
+// Deps is the constructor input. runStateBus may be nil (disables ?sync);
+// publisher may be nil (channel-delivery webhooks then 503). store may be
+// nil (only yaml-defined webhooks resolve).
+type Deps struct {
+	Store        lookup.WebhookStore
+	Cfg          *config.Config
+	Runner       runner.Runner
+	Publisher    channels.SystemPublisher
+	RunStateBus  *runstate.Bus
+	EnvAllowlist map[string]bool
+	Logf         func(format string, args ...any)
+
+	// Now + Getenv are test seams. Nil falls back to time.Now / os.Getenv.
+	Now    func() time.Time
+	Getenv func(string) string
+}
+
+// New constructs a Receiver. The dedup cache + rate limiter share the
+// injected clock so tests advance both with one fake now().
+func New(d Deps) *Receiver {
+	now := d.Now
+	if now == nil {
+		now = time.Now
+	}
+	getenv := d.Getenv
+	if getenv == nil {
+		getenv = osGetenv
+	}
+	logf := d.Logf
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	return &Receiver{
+		store:        d.Store,
+		cfg:          d.Cfg,
+		runner:       d.Runner,
+		publisher:    d.Publisher,
+		runStateBus:  d.RunStateBus,
+		envAllowlist: d.EnvAllowlist,
+		logf:         logf,
+		dedup:        newDedupCache(now),
+		limiter:      newRateLimiter(now),
+		now:          now,
+		getenv:       getenv,
+	}
+}
+
+// Registrar is the minimal mux surface Mount needs. *http.ServeMux
+// satisfies it directly; the HTTP server passes an adapter that wraps each
+// handler in its recovery middleware. Declared as an interface so the
+// receiver stays decoupled from the http package (no import cycle).
+type Registrar interface {
+	Handle(pattern string, handler http.Handler)
+}
+
+// Mount registers the receiver route. Mirrors a2a.Server.Mount. The route
+// is NOT wrapped in admin/bearer auth — the receiver authenticates each
+// request against the resolved Def's own secret.
+func (rec *Receiver) Mount(reg Registrar) {
+	reg.Handle("POST /v1/_webhooks/{name}", http.HandlerFunc(rec.handle))
+}
+
+// handle is the shared front-half + delivery fork. The webhook NAME comes
+// from the URL path (operator-addressable), never from the body — the body
+// is fully attacker-controlled until the signature verifies.
+func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+
+	ctx, span := lcotel.Tracer().Start(ctx, "webhook.receive")
+	defer span.End()
+	span.SetAttributes(attribute.String("webhook.name", name))
+
+	// 1. Resolve the active Def. Unknown name → 404.
+	wd, ok := lookup.Webhook(ctx, rec.store, rec.cfg, name)
+	if !ok {
+		rec.finish(span, "rejected_unknown")
+		writeError(w, http.StatusNotFound, "unknown_webhook", "")
+		return
+	}
+	if !wd.Enabled {
+		// A disabled Def is addressable but inert. 404 (not 403) so a
+		// disabled webhook is indistinguishable from a never-registered one
+		// to an external caller — no enumeration signal.
+		rec.finish(span, "rejected_disabled")
+		writeError(w, http.StatusNotFound, "unknown_webhook", "")
+		return
+	}
+
+	// 2. Read the raw body under the Def's size limit. Raw bytes are what
+	//    the signature is verified against — we never re-serialize.
+	limit := wd.BodySizeLimitBytes
+	if limit <= 0 {
+		limit = defaultBodySizeLimitBytes
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, int64(limit)))
+	if err != nil {
+		rec.finish(span, "rejected_body")
+		writeError(w, http.StatusBadRequest, "bad_body", "")
+		return
+	}
+
+	// 3. VERIFY BEFORE PARSE — signature over the raw bytes.
+	if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
+		var ae *authError
+		if errors.As(verr, &ae) && ae.verdict == verdictUnresolved {
+			// Config-side failure (secret not allowlisted / unset). 503 names
+			// the env var (NAME, not value) so the operator can fix it.
+			rec.finish(span, verdictUnresolved)
+			rec.logf("webhook %q: secret unresolvable (env=%q)", name, ae.secretEnv)
+			writeSecretUnresolvable(w, ae.secretEnv)
+			return
+		}
+		// Signature mismatch / replay-window / bad header / wrong bearer:
+		// one opaque 401, NO body detail (no timing/oracle leak).
+		rec.finish(span, verdictRejectedSig)
+		rec.logf("webhook %q: signature rejected", name)
+		writeError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	// 4. Replay guard (Layer-1, per-replica). delivery id from the Def's
+	//    header or a body hash. A hit inside the TTL → 401 (same opaque
+	//    posture as a sig failure — a replayed-but-valid request is still
+	//    "not accepted").
+	did := deliveryID(wd.Auth, body, r.Header.Get)
+	if rec.dedup.seen(name, did) {
+		// Replay of an already-ACCEPTED delivery (recorded on acceptance
+		// below). Same opaque 401 posture as a sig failure.
+		rec.finish(span, "rejected_replay")
+		rec.logf("webhook %q: replay rejected (delivery_id seen within TTL)", name)
+		writeError(w, http.StatusUnauthorized, "unauthorized", "")
+		return
+	}
+
+	// 5. Project the payload through the allowlisted mapping. A malformed
+	//    body or invalid mapping expression → 400.
+	proj, perr := projectPayload(wd.PayloadMapping, body)
+	if perr != nil {
+		rec.finish(span, "rejected_mapping")
+		rec.logf("webhook %q: payload mapping failed: %v", name, perr)
+		writeError(w, http.StatusBadRequest, "bad_mapping", "")
+		return
+	}
+	for _, mk := range proj.MissingKeys {
+		// Missing optional fields are a tracing note, not a failure.
+		rec.logf("webhook %q: payload_mapping target %q resolved to empty", name, mk)
+	}
+
+	// 6. Rate limit (per-Def token bucket). Exceeded → 429 + Retry-After.
+	if okRate, retry := rec.limiter.allow(name, wd.RateLimit); !okRate {
+		rec.finish(span, "rejected_rate")
+		writeRetryAfter(w, retry)
+		return
+	}
+
+	// Accepted at the trust boundary — fork on delivery mode.
+	switch wd.Delivery {
+	case "channel":
+		rec.deliverChannel(ctx, w, span, name, did, wd, body)
+	case "spawn", "":
+		rec.deliverSpawn(ctx, w, span, name, did, wd, proj, r)
+	default:
+		rec.finish(span, "rejected_delivery")
+		rec.logf("webhook %q: unknown delivery mode %q", name, wd.Delivery)
+		writeError(w, http.StatusBadRequest, "bad_delivery", "")
+	}
+}
+
+// deliverChannel publishes the RAW payload to the Def's channel. No
+// RunInput, no credential resolution — channel delivery is a pure relay.
+func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, body []byte) {
+	if rec.publisher == nil {
+		rec.finish(span, "rejected_no_publisher")
+		writeError(w, http.StatusServiceUnavailable, "channel_unavailable", "")
+		return
+	}
+	// Publish under the global scope — a webhook is an operator-level
+	// ingress, not bound to a user/agent keyspace. maxMessages/TTL default
+	// to 0 (the channel's own config / store defaults govern retention).
+	_, err := rec.publisher.PublishNow(ctx, wd.Channel, store.MemoryScopeGlobal, "",
+		json.RawMessage(body), channels.SystemPublisherUserID, 0, 0)
+	if err != nil {
+		rec.finish(span, "rejected_publish")
+		rec.logf("webhook %q: channel publish failed: %v", name, err)
+		writeError(w, http.StatusServiceUnavailable, "channel_unavailable", "")
+		return
+	}
+	// Accepted — record the delivery id now (not at the guard) so a publish
+	// failure above stays retryable.
+	rec.dedup.record(name, did)
+	rec.finish(span, verdictAccepted)
+	writeJSON(w, http.StatusAccepted, map[string]string{
+		"webhook_name": name,
+		"delivery_id":  did,
+		"channel":      wd.Channel,
+	})
+}
+
+// deliverSpawn builds a RunInput and drives runner.RunOnce. Default async
+// (202 with the run id captured via OnRegistered). When ?sync=true AND the
+// Def's sync_response is enabled, the request blocks on the run-state bus
+// until this run reaches a terminal state or sync_response.timeout_ms.
+func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, proj projectResult, r *http.Request) {
+	if rec.runner == nil {
+		rec.finish(span, "rejected_no_runner")
+		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
+		return
+	}
+	in := buildRunInput(wd, proj, rec.envAllowlist, rec.getenv, rec.logf)
+	// WH-5: idempotency_key (Layer 2) — set in.IdempotencyKey = did here once
+	// the runs.idempotency_key column lands, for durable cross-replica dedup.
+
+	wantSync := r.URL.Query().Get("sync") == "true" && wd.SyncResponse.Enabled
+
+	if !wantSync {
+		rec.spawnAsync(w, span, name, did, in)
+		return
+	}
+	rec.spawnSync(ctx, w, span, name, did, wd, in)
+}
+
+// spawnAsync fires the run on a detached background ctx (so a client
+// disconnect does NOT abort an accepted run) and returns 202 with the run
+// id. We wait briefly for ONE of two signals before responding:
+//
+//   - OnRegistered fires → the run was admitted; 202 with the run id.
+//   - RunOnce returns an error before OnRegistered → a setup-time rejection
+//     (unknown agent / backpressure / runtime paused); 503, no run id.
+//
+// OnRegistered fires after the cancel-registry entry is in place but before
+// the loop starts, so on the happy path it always precedes any meaningful
+// work — the 202 carries a real id. The select also guards a (rare) hung
+// setup with a timeout that surfaces 503 rather than hanging the request.
+func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, did string, in runner.RunInput) {
+	registered := make(chan string, 1)
+	setupErr := make(chan error, 1)
+	cb := runner.RunCallbacks{
+		OnRegistered: func(_, runID, _, _ string) {
+			select {
+			case registered <- runID:
+			default:
+			}
+		},
+	}
+	go func() {
+		err := rec.runner.RunOnce(context.Background(), in, cb)
+		if err != nil {
+			rec.logf("webhook %q: async run failed: %v", name, err)
+		}
+		// Always signal completion so a setup-time error (which returns
+		// before OnRegistered) unblocks the select below. A nil err after
+		// OnRegistered already fired is harmless — the select will have
+		// returned the run id already.
+		setupErr <- err
+	}()
+
+	select {
+	case runID := <-registered:
+		// Run admitted = delivery accepted. Record the id now (not at the
+		// guard) so a setup-time rejection below stays retryable.
+		rec.dedup.record(name, did)
+		rec.finish(span, verdictAccepted)
+		writeJSON(w, http.StatusAccepted, map[string]string{
+			"webhook_name": name,
+			"delivery_id":  did,
+			"run_id":       runID,
+		})
+	case err := <-setupErr:
+		// RunOnce returned before OnRegistered → setup rejected. (If it
+		// returned nil here the run completed faster than we observed
+		// OnRegistered, which OnRegistered's pre-loop ordering makes
+		// effectively impossible; treat a nil as accepted with no id.)
+		if err == nil {
+			rec.dedup.record(name, did)
+			rec.finish(span, verdictAccepted)
+			writeJSON(w, http.StatusAccepted, map[string]string{
+				"webhook_name": name,
+				"delivery_id":  did,
+			})
+			return
+		}
+		// Setup-time rejection: the id was NOT recorded, so the sender's
+		// retry of this delivery is processed rather than dropped.
+		rec.finish(span, "rejected_spawn_setup")
+		rec.spawnSetupErrorResponse(w, err)
+	case <-time.After(5 * time.Second):
+		rec.finish(span, "rejected_spawn_setup")
+		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
+	}
+}
+
+// spawnSetupErrorResponse maps a runner setup-time sentinel to the wire
+// status. Mirrors the HTTP run-endpoint mapping so a webhook-spawned run
+// fails the same way an interactive run would.
+func (rec *Receiver) spawnSetupErrorResponse(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, runner.ErrUnknownAgent), errors.Is(err, runner.ErrUnknownProvider), errors.Is(err, runner.ErrInvalidArgument):
+		writeError(w, http.StatusBadRequest, "invalid_run", "")
+	case errors.Is(err, runner.ErrBackpressure), errors.Is(err, runner.ErrPerUserQuotaExhausted):
+		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
+	default:
+		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
+	}
+}
+
+// spawnSync subscribes to the run-state bus BEFORE starting the run, then
+// blocks until this run's agent reaches a terminal state or the timeout.
+func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, in runner.RunInput) {
+	if rec.runStateBus == nil {
+		// Def asked for sync but the runtime has no bus — fail closed (503)
+		// rather than silently degrade to async (Decision 9: never silently
+		// degrade).
+		rec.finish(span, "rejected_no_bus")
+		writeError(w, http.StatusServiceUnavailable, "sync_unavailable", "")
+		return
+	}
+	timeout := time.Duration(wd.SyncResponse.TimeoutMs) * time.Millisecond
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	sub := rec.runStateBus.Subscribe(in.UserID)
+	defer sub.Close()
+
+	registered := make(chan struct {
+		agentID string
+		runID   string
+	}, 1)
+	cb := runner.RunCallbacks{
+		OnRegistered: func(agentID, runID, _, _ string) {
+			select {
+			case registered <- struct {
+				agentID string
+				runID   string
+			}{agentID, runID}:
+			default:
+			}
+		},
+	}
+	go func() {
+		if err := rec.runner.RunOnce(context.Background(), in, cb); err != nil {
+			rec.logf("webhook %q: sync run failed: %v", name, err)
+		}
+	}()
+
+	// Learn our agent_id (the bus events are keyed by it) before matching.
+	var ourAgentID, ourRunID string
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	select {
+	case reg := <-registered:
+		ourAgentID, ourRunID = reg.agentID, reg.runID
+		// Run admitted = delivery accepted; record so a later terminal-wait
+		// timeout does not leave the (now-running) delivery retryable.
+		rec.dedup.record(name, did)
+	case <-deadline.C:
+		rec.finish(span, "timeout")
+		writeError(w, http.StatusGatewayTimeout, "sync_timeout", "")
+		return
+	case <-ctx.Done():
+		rec.finish(span, "client_gone")
+		return
+	}
+
+	for {
+		select {
+		case evt := <-sub.C:
+			if evt.AgentID != ourAgentID {
+				continue
+			}
+			if isTerminal(evt.Status) {
+				rec.finish(span, verdictAccepted)
+				writeJSON(w, http.StatusOK, map[string]string{
+					"webhook_name": name,
+					"delivery_id":  did,
+					"run_id":       ourRunID,
+					"agent_id":     ourAgentID,
+					"status":       evt.Status,
+				})
+				return
+			}
+		case <-deadline.C:
+			rec.finish(span, "timeout")
+			writeError(w, http.StatusGatewayTimeout, "sync_timeout", "")
+			return
+		case <-ctx.Done():
+			rec.finish(span, "client_gone")
+			return
+		}
+	}
+}
+
+// isTerminal reports whether a run status is a terminal state. Mirrors the
+// store's RunStatus transitions (running → completed | failed | cancelled).
+func isTerminal(status string) bool {
+	switch store.RunStatus(status) {
+	case store.RunCompleted, store.RunFailed, store.RunCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// finish stamps the verdict on the span. accepted = Ok status; everything
+// else = Error status with the verdict as the description. We never put a
+// secret or signature value on the span (only the verdict label + webhook
+// name, set by the caller).
+func (rec *Receiver) finish(s trace.Span, verdict string) {
+	s.SetAttributes(attribute.String("webhook.verdict", verdict))
+	if verdict == verdictAccepted {
+		s.SetStatus(codes.Ok, "")
+	} else {
+		s.SetStatus(codes.Error, verdict)
+	}
+}
+
+// --- HTTP response helpers ---
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// writeError emits a minimal {"error":code} body. detail is included only
+// when non-empty — the signature-failure path passes "" so no information
+// leaks.
+func writeError(w http.ResponseWriter, status int, code, detail string) {
+	body := map[string]string{"error": code}
+	if detail != "" {
+		body["detail"] = detail
+	}
+	writeJSON(w, status, body)
+}
+
+// writeSecretUnresolvable emits the 503 with the env-var NAME (never value).
+func writeSecretUnresolvable(w http.ResponseWriter, secretEnv string) {
+	writeJSON(w, http.StatusServiceUnavailable, map[string]string{
+		"error":      "secret_unresolvable",
+		"secret_env": secretEnv,
+	})
+}
+
+// writeRetryAfter emits 429 + Retry-After (whole seconds, min 1).
+func writeRetryAfter(w http.ResponseWriter, retry time.Duration) {
+	secs := int(retry.Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(secs))
+	writeError(w, http.StatusTooManyRequests, "rate_limited", "")
+}
+
+// osGetenv is the production env reader. Indirected so the Receiver's
+// getenv field defaults to it while tests inject a map-backed reader.
+func osGetenv(name string) string { return os.Getenv(name) }

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -46,6 +47,12 @@ type Receiver struct {
 
 	dedup   *dedupCache
 	limiter *rateLimiter
+
+	// recent is the per-webhook-name triage ring buffer (WH-5b). Holds the
+	// last recentBufferCap invocations per name for the admin-gated
+	// recent-deliveries endpoint. recentMu guards the map + every ring.
+	recentMu sync.Mutex
+	recent   map[string]*recentRing
 
 	// now + getenv are injected so the timestamp-window, dedup-TTL,
 	// rate-limit refill, and secret-resolution paths are deterministic in
@@ -130,7 +137,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	// 1. Resolve the active Def. Unknown name → 404.
 	wd, ok := lookup.Webhook(ctx, rec.store, rec.cfg, name)
 	if !ok {
-		rec.finish(span, "rejected_unknown")
+		rec.finish(span, name, "", "rejected_unknown", "")
 		writeError(w, http.StatusNotFound, "unknown_webhook", "")
 		return
 	}
@@ -138,7 +145,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 		// A disabled Def is addressable but inert. 404 (not 403) so a
 		// disabled webhook is indistinguishable from a never-registered one
 		// to an external caller — no enumeration signal.
-		rec.finish(span, "rejected_disabled")
+		rec.finish(span, name, "", "rejected_disabled", "")
 		writeError(w, http.StatusNotFound, "unknown_webhook", "")
 		return
 	}
@@ -151,7 +158,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, int64(limit)))
 	if err != nil {
-		rec.finish(span, "rejected_body")
+		rec.finish(span, name, "", "rejected_body", "")
 		writeError(w, http.StatusBadRequest, "bad_body", "")
 		return
 	}
@@ -162,14 +169,14 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 		if errors.As(verr, &ae) && ae.verdict == verdictUnresolved {
 			// Config-side failure (secret not allowlisted / unset). 503 names
 			// the env var (NAME, not value) so the operator can fix it.
-			rec.finish(span, verdictUnresolved)
+			rec.finish(span, name, "", verdictUnresolved, "")
 			rec.logf("webhook %q: secret unresolvable (env=%q)", name, ae.secretEnv)
 			writeSecretUnresolvable(w, ae.secretEnv)
 			return
 		}
 		// Signature mismatch / replay-window / bad header / wrong bearer:
 		// one opaque 401, NO body detail (no timing/oracle leak).
-		rec.finish(span, verdictRejectedSig)
+		rec.finish(span, name, "", verdictRejectedSig, "")
 		rec.logf("webhook %q: signature rejected", name)
 		writeError(w, http.StatusUnauthorized, "unauthorized", "")
 		return
@@ -183,7 +190,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	if rec.dedup.seen(name, did) {
 		// Replay of an already-ACCEPTED delivery (recorded on acceptance
 		// below). Same opaque 401 posture as a sig failure.
-		rec.finish(span, "rejected_replay")
+		rec.finish(span, name, did, "rejected_replay", "")
 		rec.logf("webhook %q: replay rejected (delivery_id seen within TTL)", name)
 		writeError(w, http.StatusUnauthorized, "unauthorized", "")
 		return
@@ -193,7 +200,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	//    body or invalid mapping expression → 400.
 	proj, perr := projectPayload(wd.PayloadMapping, body)
 	if perr != nil {
-		rec.finish(span, "rejected_mapping")
+		rec.finish(span, name, did, "rejected_mapping", "")
 		rec.logf("webhook %q: payload mapping failed: %v", name, perr)
 		writeError(w, http.StatusBadRequest, "bad_mapping", "")
 		return
@@ -205,7 +212,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 
 	// 6. Rate limit (per-Def token bucket). Exceeded → 429 + Retry-After.
 	if okRate, retry := rec.limiter.allow(name, wd.RateLimit); !okRate {
-		rec.finish(span, "rejected_rate")
+		rec.finish(span, name, did, "rejected_rate", "")
 		writeRetryAfter(w, retry)
 		return
 	}
@@ -217,7 +224,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	case "spawn", "":
 		rec.deliverSpawn(ctx, w, span, name, did, wd, proj, r)
 	default:
-		rec.finish(span, "rejected_delivery")
+		rec.finish(span, name, did, "rejected_delivery", "")
 		rec.logf("webhook %q: unknown delivery mode %q", name, wd.Delivery)
 		writeError(w, http.StatusBadRequest, "bad_delivery", "")
 	}
@@ -227,7 +234,7 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 // RunInput, no credential resolution — channel delivery is a pure relay.
 func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, body []byte) {
 	if rec.publisher == nil {
-		rec.finish(span, "rejected_no_publisher")
+		rec.finish(span, name, did, "rejected_no_publisher", "")
 		writeError(w, http.StatusServiceUnavailable, "channel_unavailable", "")
 		return
 	}
@@ -237,7 +244,7 @@ func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, 
 	_, err := rec.publisher.PublishNow(ctx, wd.Channel, store.MemoryScopeGlobal, "",
 		json.RawMessage(body), channels.SystemPublisherUserID, 0, 0)
 	if err != nil {
-		rec.finish(span, "rejected_publish")
+		rec.finish(span, name, did, "rejected_publish", "")
 		rec.logf("webhook %q: channel publish failed: %v", name, err)
 		writeError(w, http.StatusServiceUnavailable, "channel_unavailable", "")
 		return
@@ -245,7 +252,7 @@ func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, 
 	// Accepted — record the delivery id now (not at the guard) so a publish
 	// failure above stays retryable.
 	rec.dedup.record(name, did)
-	rec.finish(span, verdictAccepted)
+	rec.finish(span, name, did, verdictAccepted, "")
 	writeJSON(w, http.StatusAccepted, map[string]string{
 		"webhook_name": name,
 		"delivery_id":  did,
@@ -259,7 +266,7 @@ func (rec *Receiver) deliverChannel(ctx context.Context, w http.ResponseWriter, 
 // until this run reaches a terminal state or sync_response.timeout_ms.
 func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, proj projectResult, r *http.Request) {
 	if rec.runner == nil {
-		rec.finish(span, "rejected_no_runner")
+		rec.finish(span, name, did, "rejected_no_runner", "")
 		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
 		return
 	}
@@ -277,7 +284,7 @@ func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, sp
 	if rec.store != nil && did != "" {
 		if existing, ok, lerr := rec.store.RunByIdempotencyKey(ctx, did); lerr == nil && ok {
 			rec.dedup.record(name, did)
-			rec.finish(span, verdictAccepted)
+			rec.finish(span, name, did, verdictAccepted, existing.ID)
 			writeJSON(w, http.StatusAccepted, map[string]string{
 				"webhook_name": name,
 				"delivery_id":  did,
@@ -290,11 +297,16 @@ func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, sp
 
 	wantSync := r.URL.Query().Get("sync") == "true" && wd.SyncResponse.Enabled
 
+	// userID selects the on_complete hook scope. It is the same value
+	// buildRunInput stamped onto in.UserID (proj.Fields["user_id"]); read
+	// from proj so the source is explicit at the call site.
+	userID := proj.Fields["user_id"]
+
 	if !wantSync {
-		rec.spawnAsync(w, span, name, did, in)
+		rec.spawnAsync(w, span, name, did, wd, in, userID)
 		return
 	}
-	rec.spawnSync(ctx, w, span, name, did, wd, in)
+	rec.spawnSync(ctx, w, span, name, did, wd, in, userID)
 }
 
 // spawnAsync fires the run on a detached background ctx (so a client
@@ -309,11 +321,13 @@ func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, sp
 // the loop starts, so on the happy path it always precedes any meaningful
 // work — the 202 carries a real id. The select also guards a (rare) hung
 // setup with a timeout that surfaces 503 rather than hanging the request.
-func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, did string, in runner.RunInput) {
+func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, in runner.RunInput, userID string) {
 	registered := make(chan string, 1)
 	setupErr := make(chan error, 1)
+	var spawnedRunID, spawnedAgentID string
 	cb := runner.RunCallbacks{
-		OnRegistered: func(_, runID, _, _ string) {
+		OnRegistered: func(agentID, runID, _, _ string) {
+			spawnedRunID, spawnedAgentID = runID, agentID
 			select {
 			case registered <- runID:
 			default:
@@ -324,6 +338,14 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 		err := rec.runner.RunOnce(context.Background(), in, cb)
 		if err != nil {
 			rec.logf("webhook %q: async run failed: %v", name, err)
+		}
+		// Fire on_complete hooks AFTER the run returns. Only when the run was
+		// actually admitted (OnRegistered fired → spawnedRunID set) and the
+		// Def declares hooks. A setup-time rejection (err before OnRegistered)
+		// never reaches a run completion, so no hooks fire. Detached ctx — the
+		// request ctx is long gone. Best-effort; never affects the response.
+		if err == nil && spawnedRunID != "" && len(wd.OnComplete) > 0 {
+			rec.dispatchOnComplete(context.Background(), name, wd, spawnedRunID, spawnedAgentID, userID)
 		}
 		// Always signal completion so a setup-time error (which returns
 		// before OnRegistered) unblocks the select below. A nil err after
@@ -337,7 +359,7 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 		// Run admitted = delivery accepted. Record the id now (not at the
 		// guard) so a setup-time rejection below stays retryable.
 		rec.dedup.record(name, did)
-		rec.finish(span, verdictAccepted)
+		rec.finish(span, name, did, verdictAccepted, runID)
 		writeJSON(w, http.StatusAccepted, map[string]string{
 			"webhook_name": name,
 			"delivery_id":  did,
@@ -350,7 +372,7 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 		// effectively impossible; treat a nil as accepted with no id.)
 		if err == nil {
 			rec.dedup.record(name, did)
-			rec.finish(span, verdictAccepted)
+			rec.finish(span, name, did, verdictAccepted, "")
 			writeJSON(w, http.StatusAccepted, map[string]string{
 				"webhook_name": name,
 				"delivery_id":  did,
@@ -368,7 +390,7 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 			if rec.store != nil && did != "" {
 				if existing, ok, lerr := rec.store.RunByIdempotencyKey(context.Background(), did); lerr == nil && ok {
 					rec.dedup.record(name, did)
-					rec.finish(span, verdictAccepted)
+					rec.finish(span, name, did, verdictAccepted, existing.ID)
 					writeJSON(w, http.StatusAccepted, map[string]string{
 						"webhook_name": name,
 						"delivery_id":  did,
@@ -382,7 +404,7 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 			// still accepted — the delivery was handled by the racing
 			// request. Record so a retry doesn't re-spawn.
 			rec.dedup.record(name, did)
-			rec.finish(span, verdictAccepted)
+			rec.finish(span, name, did, verdictAccepted, "")
 			writeJSON(w, http.StatusAccepted, map[string]string{
 				"webhook_name": name,
 				"delivery_id":  did,
@@ -392,10 +414,10 @@ func (rec *Receiver) spawnAsync(w http.ResponseWriter, span trace.Span, name, di
 		}
 		// Setup-time rejection: the id was NOT recorded, so the sender's
 		// retry of this delivery is processed rather than dropped.
-		rec.finish(span, "rejected_spawn_setup")
+		rec.finish(span, name, did, "rejected_spawn_setup", "")
 		rec.spawnSetupErrorResponse(w, err)
 	case <-time.After(5 * time.Second):
-		rec.finish(span, "rejected_spawn_setup")
+		rec.finish(span, name, did, "rejected_spawn_setup", "")
 		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
 	}
 }
@@ -416,12 +438,12 @@ func (rec *Receiver) spawnSetupErrorResponse(w http.ResponseWriter, err error) {
 
 // spawnSync subscribes to the run-state bus BEFORE starting the run, then
 // blocks until this run's agent reaches a terminal state or the timeout.
-func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, in runner.RunInput) {
+func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span trace.Span, name, did string, wd config.Webhook, in runner.RunInput, userID string) {
 	if rec.runStateBus == nil {
 		// Def asked for sync but the runtime has no bus — fail closed (503)
 		// rather than silently degrade to async (Decision 9: never silently
 		// degrade).
-		rec.finish(span, "rejected_no_bus")
+		rec.finish(span, name, did, "rejected_no_bus", "")
 		writeError(w, http.StatusServiceUnavailable, "sync_unavailable", "")
 		return
 	}
@@ -437,8 +459,10 @@ func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span 
 		agentID string
 		runID   string
 	}, 1)
+	var spawnedRunID, spawnedAgentID string
 	cb := runner.RunCallbacks{
 		OnRegistered: func(agentID, runID, _, _ string) {
+			spawnedRunID, spawnedAgentID = runID, agentID
 			select {
 			case registered <- struct {
 				agentID string
@@ -449,8 +473,15 @@ func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span 
 		},
 	}
 	go func() {
-		if err := rec.runner.RunOnce(context.Background(), in, cb); err != nil {
+		err := rec.runner.RunOnce(context.Background(), in, cb)
+		if err != nil {
 			rec.logf("webhook %q: sync run failed: %v", name, err)
+		}
+		// Fire on_complete hooks AFTER the run returns, same posture as the
+		// async path. OnRegistered runs before the loop, so spawnedRunID is
+		// set by the time RunOnce returns nil. Detached ctx + best-effort.
+		if err == nil && spawnedRunID != "" && len(wd.OnComplete) > 0 {
+			rec.dispatchOnComplete(context.Background(), name, wd, spawnedRunID, spawnedAgentID, userID)
 		}
 	}()
 
@@ -465,11 +496,11 @@ func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span 
 		// timeout does not leave the (now-running) delivery retryable.
 		rec.dedup.record(name, did)
 	case <-deadline.C:
-		rec.finish(span, "timeout")
+		rec.finish(span, name, did, "timeout", "")
 		writeError(w, http.StatusGatewayTimeout, "sync_timeout", "")
 		return
 	case <-ctx.Done():
-		rec.finish(span, "client_gone")
+		rec.finish(span, name, did, "client_gone", "")
 		return
 	}
 
@@ -480,7 +511,7 @@ func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span 
 				continue
 			}
 			if isTerminal(evt.Status) {
-				rec.finish(span, verdictAccepted)
+				rec.finish(span, name, did, verdictAccepted, ourRunID)
 				writeJSON(w, http.StatusOK, map[string]string{
 					"webhook_name": name,
 					"delivery_id":  did,
@@ -491,11 +522,11 @@ func (rec *Receiver) spawnSync(ctx context.Context, w http.ResponseWriter, span 
 				return
 			}
 		case <-deadline.C:
-			rec.finish(span, "timeout")
+			rec.finish(span, name, did, "timeout", "")
 			writeError(w, http.StatusGatewayTimeout, "sync_timeout", "")
 			return
 		case <-ctx.Done():
-			rec.finish(span, "client_gone")
+			rec.finish(span, name, did, "client_gone", "")
 			return
 		}
 	}
@@ -512,17 +543,24 @@ func isTerminal(status string) bool {
 	}
 }
 
-// finish stamps the verdict on the span. accepted = Ok status; everything
-// else = Error status with the verdict as the description. We never put a
-// secret or signature value on the span (only the verdict label + webhook
-// name, set by the caller).
-func (rec *Receiver) finish(s trace.Span, verdict string) {
+// finish stamps the verdict on the span AND records a triage entry in the
+// per-name recent-deliveries ring (WH-5b). accepted = Ok span status;
+// everything else = Error status with the verdict as the description. We
+// never put a secret or signature value on the span or the ring (only the
+// verdict label, the delivery id, and — for accepted spawns — the run id).
+//
+// did is "" for rejects that fail before the delivery id is derived (unknown
+// name, disabled, body read, signature). runID is "" except for accepted
+// spawn deliveries. The ring is bounded per name, so recording on every
+// terminal point (including rejects) cannot grow memory without limit.
+func (rec *Receiver) finish(s trace.Span, name, did, verdict, runID string) {
 	s.SetAttributes(attribute.String("webhook.verdict", verdict))
 	if verdict == verdictAccepted {
 		s.SetStatus(codes.Ok, "")
 	} else {
 		s.SetStatus(codes.Error, verdict)
 	}
+	rec.recordDelivery(name, did, verdict, runID)
 }
 
 // --- HTTP response helpers ---

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -1,0 +1,381 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/runstate"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// fakeRunner records the RunInput it was driven with and invokes
+// OnRegistered so the async-spawn path returns a run id.
+type fakeRunner struct {
+	mu      sync.Mutex
+	lastIn  runner.RunInput
+	called  bool
+	runErr  error // when set, returned BEFORE OnRegistered (setup-error path)
+	runID   string
+	agentID string
+}
+
+func (f *fakeRunner) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunCallbacks) error {
+	f.mu.Lock()
+	f.lastIn = in
+	f.called = true
+	f.mu.Unlock()
+	if f.runErr != nil {
+		return f.runErr // setup-time failure: return before OnRegistered
+	}
+	if cb.OnRegistered != nil {
+		cb.OnRegistered(f.agentID, f.runID, "sess-1", "")
+	}
+	return nil
+}
+
+func (f *fakeRunner) input() runner.RunInput {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.lastIn
+}
+
+// fakePublisher records channel publishes.
+type fakePublisher struct {
+	mu      sync.Mutex
+	channel string
+	payload json.RawMessage
+	called  bool
+}
+
+func (p *fakePublisher) Publish(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+	payload json.RawMessage, deliverAt time.Time, publishedByUserID string, maxMessages, defaultTTLSeconds int,
+) (store.ChannelMessage, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.channel = channel
+	p.payload = payload
+	p.called = true
+	return store.ChannelMessage{ID: "msg-1"}, nil
+}
+
+func (p *fakePublisher) PublishNow(ctx context.Context, channel string, scope store.MemoryScope, scopeID string,
+	payload json.RawMessage, publishedByUserID string, maxMessages, defaultTTLSeconds int,
+) (store.ChannelMessage, error) {
+	return p.Publish(ctx, channel, scope, scopeID, payload, time.Time{}, publishedByUserID, maxMessages, defaultTTLSeconds)
+}
+
+// newTestReceiver wires a Receiver against a yaml-only config (no store),
+// a fixed clock, and a map-backed getenv.
+func newTestReceiver(t *testing.T, webhooks map[string]config.Webhook, fr runner.Runner, fp *fakePublisher, env map[string]string, allow []string, now time.Time) *Receiver {
+	t.Helper()
+	cfg := &config.Config{Webhooks: webhooks}
+	al := make(map[string]bool, len(allow))
+	for _, n := range allow {
+		al[n] = true
+	}
+	d := Deps{
+		Cfg:          cfg,
+		Runner:       fr,
+		EnvAllowlist: al,
+		Now:          fixedClock(now),
+		Getenv:       mapGetenv(env),
+	}
+	if fp != nil {
+		d.Publisher = fp
+	}
+	return New(d)
+}
+
+func bytesReader(b []byte) io.Reader { return bytes.NewReader(b) }
+
+func doPost(rec *Receiver, name string, body []byte, hdr http.Header) *httptest.ResponseRecorder {
+	mux := http.NewServeMux()
+	rec.Mount(mux)
+	req := httptest.NewRequest(http.MethodPost, "/v1/_webhooks/"+name, bytesReader(body))
+	for k, vs := range hdr {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	return w
+}
+
+func TestReceiver_SpawnMode_ValidGitHubSig_Builds202AndRunInput(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do the thing","user":"u-9","tok":"payload-cred"}`)
+
+	wh := config.Webhook{
+		Enabled:                true,
+		Delivery:               "spawn",
+		Agent:                  "researcher",
+		Auth:                   config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		UserCredentialsFromEnv: map[string]string{"API_KEY": "ENV_CRED", "TOK": "ENV_TOK"},
+		PayloadMapping: map[string]string{
+			"goal":                 "$.goal",
+			"user_id":              "$.user",
+			"user_credentials.TOK": "$.tok",
+		},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	env := map[string]string{"WH_SECRET": secret, "ENV_CRED": "env-api-key", "ENV_TOK": "env-tok-value"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, env, []string{"WH_SECRET", "ENV_CRED", "ENV_TOK"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := doPost(rec, "gh", body, h)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if !fr.called {
+		t.Fatal("runner was not invoked")
+	}
+	in := fr.input()
+	if in.Agent != "researcher" {
+		t.Errorf("agent = %q, want researcher", in.Agent)
+	}
+	if in.UserID != "u-9" {
+		t.Errorf("user_id = %q, want u-9", in.UserID)
+	}
+	// The goal is external webhook payload → untrusted-block (fenced in
+	// <untrusted> tags by the loop), NOT trusted-text. This is the
+	// prompt-injection boundary for webhook-triggered runs.
+	if len(in.Segments) != 1 || len(in.Segments[0].Content) != 1 ||
+		in.Segments[0].Content[0].Text != "do the thing" ||
+		in.Segments[0].Content[0].Type != "untrusted-block" ||
+		in.Segments[0].Content[0].Kind != "webhook_payload" {
+		t.Errorf("segment not built from mapped goal as untrusted-block: %+v", in.Segments)
+	}
+	// Env-resolved credential survives.
+	if in.UserCredentials["API_KEY"] != "env-api-key" {
+		t.Errorf("API_KEY cred = %q, want env-api-key", in.UserCredentials["API_KEY"])
+	}
+	// Payload overlay WINS over env for the same key.
+	if in.UserCredentials["TOK"] != "payload-cred" {
+		t.Errorf("TOK cred = %q, want payload-cred (payload wins)", in.UserCredentials["TOK"])
+	}
+}
+
+func TestReceiver_TamperedBody_401(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	signed := []byte(`{"goal":"a"}`)
+	tampered := []byte(`{"goal":"b"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "x",
+		Auth: config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}}
+	fr := &fakeRunner{runID: "r", agentID: "a"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, signed))
+	w := doPost(rec, "gh", tampered, h)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if fr.called {
+		t.Fatal("runner invoked on bad signature")
+	}
+}
+
+func TestReceiver_ReplayWithinTTL_401(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"a"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "x",
+		Auth: config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET", DeliveryIDHeader: "X-Delivery"}}
+	fr := &fakeRunner{runID: "r", agentID: "a"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	h.Set("X-Delivery", "dup-1")
+
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+		t.Fatalf("first delivery status = %d, want 202", w.Code)
+	}
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusUnauthorized {
+		t.Fatalf("replay status = %d, want 401", w.Code)
+	}
+}
+
+func TestReceiver_UnresolvableSecret_503(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"a"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "x",
+		Auth: config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}}
+	fr := &fakeRunner{runID: "r", agentID: "a"}
+	// WH_SECRET NOT in allowlist.
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, map[string]string{"WH_SECRET": "shhh"}, []string{}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig("shhh", body))
+	w := doPost(rec, "gh", body, h)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", w.Code)
+	}
+	var got map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got["error"] != "secret_unresolvable" || got["secret_env"] != "WH_SECRET" {
+		t.Errorf("body = %v, want secret_unresolvable + secret_env=WH_SECRET", got)
+	}
+}
+
+func TestReceiver_RateLimited_429WithRetryAfter(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "x",
+		Auth:      config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		RateLimit: config.WebhookRateLimit{RequestsPerMinute: 60, Burst: 1}}
+	fr := &fakeRunner{runID: "r", agentID: "a"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	// Distinct bodies so dedup doesn't intercept the second request first.
+	mk := func(i string) (*http.Header, []byte) {
+		b := []byte(`{"goal":"` + i + `"}`)
+		h := http.Header{}
+		h.Set("X-Hub-Signature-256", githubSig(secret, b))
+		return &h, b
+	}
+	h1, b1 := mk("one")
+	if w := doPost(rec, "gh", b1, *h1); w.Code != http.StatusAccepted {
+		t.Fatalf("first status = %d, want 202", w.Code)
+	}
+	h2, b2 := mk("two")
+	w := doPost(rec, "gh", b2, *h2)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("second status = %d, want 429", w.Code)
+	}
+	if w.Header().Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on 429")
+	}
+}
+
+func TestReceiver_ChannelMode_PublishesRawPayload(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"event":"ping"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "channel", Channel: "_system/ingress",
+		Auth: config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}}
+	fp := &fakePublisher{}
+	rec := newTestReceiver(t, map[string]config.Webhook{"ch": wh}, &fakeRunner{}, fp, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := doPost(rec, "ch", body, h)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if !fp.called {
+		t.Fatal("publisher not invoked")
+	}
+	if fp.channel != "_system/ingress" {
+		t.Errorf("channel = %q, want _system/ingress", fp.channel)
+	}
+	if string(fp.payload) != string(body) {
+		t.Errorf("payload = %s, want raw body %s", fp.payload, body)
+	}
+}
+
+func TestReceiver_UnknownWebhook_404(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rec := newTestReceiver(t, map[string]config.Webhook{}, &fakeRunner{}, nil, nil, nil, now)
+	w := doPost(rec, "nope", []byte(`{}`), http.Header{})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+// busRunner publishes a terminal run-state event after OnRegistered so the
+// ?sync path observes completion. It subscribes-side races are avoided
+// because spawnSync subscribes BEFORE invoking RunOnce.
+type busRunner struct {
+	bus     *runstate.Bus
+	runID   string
+	agentID string
+}
+
+func (r *busRunner) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunCallbacks) error {
+	if cb.OnRegistered != nil {
+		cb.OnRegistered(r.agentID, r.runID, "sess-1", "")
+	}
+	// Simulate the loop reaching a terminal state.
+	r.bus.Publish(runstate.RunStateEvent{
+		RunID:   r.runID,
+		AgentID: r.agentID,
+		UserID:  in.UserID,
+		Status:  string(store.RunCompleted),
+	})
+	return nil
+}
+
+func TestReceiver_SyncMode_BlocksUntilTerminal_200(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"g","user":"u-7"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "x",
+		Auth:         config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		SyncResponse: config.WebhookSyncResponse{Enabled: true, TimeoutMs: 2000},
+		PayloadMapping: map[string]string{
+			"goal":    "$.goal",
+			"user_id": "$.user",
+		}}
+	bus := runstate.NewBus()
+	br := &busRunner{bus: bus, runID: "run-9", agentID: "agent-9"}
+	cfg := &config.Config{Webhooks: map[string]config.Webhook{"gh": wh}}
+	rec := New(Deps{
+		Cfg:          cfg,
+		Runner:       br,
+		RunStateBus:  bus,
+		EnvAllowlist: map[string]bool{"WH_SECRET": true},
+		Now:          fixedClock(now),
+		Getenv:       mapGetenv(map[string]string{"WH_SECRET": secret}),
+	})
+
+	mux := http.NewServeMux()
+	rec.Mount(mux)
+	req := httptest.NewRequest(http.MethodPost, "/v1/_webhooks/gh?sync=true", bytesReader(body))
+	req.Header.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got map[string]string
+	_ = json.Unmarshal(w.Body.Bytes(), &got)
+	if got["status"] != "completed" || got["run_id"] != "run-9" {
+		t.Errorf("body = %v, want status=completed run_id=run-9", got)
+	}
+}
+
+func TestReceiver_SpawnSetupError_503(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"a"}`)
+	wh := config.Webhook{Enabled: true, Delivery: "spawn", Agent: "ghost",
+		Auth: config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}}
+	fr := &fakeRunner{runErr: runner.ErrUnknownAgent}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := doPost(rec, "gh", body, h)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (unknown agent setup error)", w.Code)
+	}
+}

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -379,3 +379,180 @@ func TestReceiver_SpawnSetupError_503(t *testing.T) {
 		t.Fatalf("status = %d, want 400 (unknown agent setup error)", w.Code)
 	}
 }
+
+// fakeWebhookStore satisfies lookup.WebhookStore for the RFC H Decision
+// 10 "Layer 2" durable-dedup tests. WebhookDefGetActive always misses (so
+// the yaml cfg path resolves the Def); RunByIdempotencyKey returns a
+// preconfigured run for a matching key.
+type fakeWebhookStore struct {
+	existing  map[string]store.Run // key -> run returned by RunByIdempotencyKey
+	lookupErr error
+	calls     int
+}
+
+func (f *fakeWebhookStore) WebhookDefGetActive(_ context.Context, name string) (store.WebhookDefRow, error) {
+	return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: name}
+}
+
+func (f *fakeWebhookStore) RunByIdempotencyKey(_ context.Context, key string) (store.Run, bool, error) {
+	f.calls++
+	if f.lookupErr != nil {
+		return store.Run{}, false, f.lookupErr
+	}
+	r, ok := f.existing[key]
+	return r, ok, nil
+}
+
+// newTestReceiverWithStore mirrors newTestReceiver but wires a store so
+// the Layer-2 dedup path is exercised. A fixed DeliveryIDHeader lets the
+// test control the delivery id (= idempotency key) deterministically.
+func newTestReceiverWithStore(t *testing.T, webhooks map[string]config.Webhook, fr runner.Runner, st *fakeWebhookStore, env map[string]string, allow []string, now time.Time) *Receiver {
+	t.Helper()
+	cfg := &config.Config{Webhooks: webhooks}
+	al := make(map[string]bool, len(allow))
+	for _, n := range allow {
+		al[n] = true
+	}
+	return New(Deps{
+		Cfg:          cfg,
+		Store:        st,
+		Runner:       fr,
+		EnvAllowlist: al,
+		Now:          fixedClock(now),
+		Getenv:       mapGetenv(env),
+	})
+}
+
+// TestReceiver_Layer2Dedup_ExistingRunReturnedWithoutSpawn pins the RFC H
+// Decision 10 BEFORE-spawn check: a delivery whose id already has a run
+// (e.g. a redelivery past the in-memory Layer-1 TTL) returns the existing
+// run id as 202 WITHOUT invoking the runner.
+func TestReceiver_Layer2Dedup_ExistingRunReturnedWithoutSpawn(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it"}`)
+	const did = "delivery-abc"
+
+	wh := config.Webhook{
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "researcher",
+		Auth: config.WebhookAuth{
+			Kind: "hmac", Header: "X-Hub-Signature-256",
+			SigningSecretEnv: "WH_SECRET", DeliveryIDHeader: "X-Delivery-Id",
+		},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+	fr := &fakeRunner{runID: "run-fresh", agentID: "agent-fresh"}
+	st := &fakeWebhookStore{existing: map[string]store.Run{did: {ID: "run-existing", AgentID: "agent-existing"}}}
+	rec := newTestReceiverWithStore(t, map[string]config.Webhook{"gh": wh}, fr, st, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	h.Set("X-Delivery-Id", did)
+	w := doPost(rec, "gh", body, h)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if fr.called {
+		t.Error("runner WAS invoked; Layer-2 dedup should have short-circuited the spawn")
+	}
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["run_id"] != "run-existing" {
+		t.Errorf("run_id = %q, want run-existing (the deduped run)", got["run_id"])
+	}
+	if got["deduped"] != "true" {
+		t.Errorf("deduped = %q, want true", got["deduped"])
+	}
+}
+
+// TestReceiver_Layer2Dedup_ConcurrentRaceResolvesToWinner pins the
+// concurrent-race path: the BEFORE-spawn check misses (no run yet), but a
+// racing request won the CreateRun insert, so this request's RunOnce
+// returns ErrDuplicateIdempotencyKey. The receiver re-looks-up the winner
+// and returns it as 202 — NOT a 503.
+func TestReceiver_Layer2Dedup_ConcurrentRaceResolvesToWinner(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it"}`)
+	const did = "delivery-race"
+
+	wh := config.Webhook{
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "researcher",
+		Auth: config.WebhookAuth{
+			Kind: "hmac", Header: "X-Hub-Signature-256",
+			SigningSecretEnv: "WH_SECRET", DeliveryIDHeader: "X-Delivery-Id",
+		},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+	// fakeRunner returns the dup sentinel BEFORE OnRegistered (setup-time),
+	// modelling the loser of the insert race.
+	fr := &fakeRunner{runErr: store.ErrDuplicateIdempotencyKey}
+	// The store's BEFORE-spawn lookup misses first, then HITS on the
+	// re-lookup after the dup error. Pre-seed the winner so the re-lookup
+	// resolves it. (The BEFORE-check and the re-lookup both call the same
+	// fake; pre-seeding means the BEFORE-check would also hit — so instead
+	// we leave existing empty and flip it via a tiny indirection.)
+	st := &raceStore{winner: store.Run{ID: "run-winner", AgentID: "agent-winner"}, key: did}
+	rec := New(Deps{
+		Cfg:          &config.Config{Webhooks: map[string]config.Webhook{"gh": wh}},
+		Store:        st,
+		Runner:       fr,
+		EnvAllowlist: map[string]bool{"WH_SECRET": true},
+		Now:          fixedClock(now),
+		Getenv:       mapGetenv(map[string]string{"WH_SECRET": secret}),
+	})
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	h.Set("X-Delivery-Id", did)
+	w := doPost(rec, "gh", body, h)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202 (race resolved to winner); body=%s", w.Code, w.Body.String())
+	}
+	if !fr.called {
+		t.Error("runner should have been invoked (this is the insert-race loser path)")
+	}
+	var got map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["run_id"] != "run-winner" {
+		t.Errorf("run_id = %q, want run-winner (re-lookup after dup)", got["run_id"])
+	}
+	if got["deduped"] != "true" {
+		t.Errorf("deduped = %q, want true", got["deduped"])
+	}
+}
+
+// raceStore models the insert-race timeline: the FIRST RunByIdempotencyKey
+// (the BEFORE-spawn check) misses; subsequent calls (the post-dup
+// re-lookup) hit the winner. This reproduces the window where two requests
+// both pass the BEFORE-check and only one wins the unique-index insert.
+type raceStore struct {
+	winner store.Run
+	key    string
+	calls  int
+}
+
+func (s *raceStore) WebhookDefGetActive(_ context.Context, name string) (store.WebhookDefRow, error) {
+	return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: name}
+}
+
+func (s *raceStore) RunByIdempotencyKey(_ context.Context, key string) (store.Run, bool, error) {
+	s.calls++
+	if s.calls == 1 {
+		return store.Run{}, false, nil // BEFORE-spawn check: no run yet
+	}
+	if key == s.key {
+		return s.winner, true, nil // re-lookup after the dup error
+	}
+	return store.Run{}, false, nil
+}

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -385,9 +385,22 @@ func TestReceiver_SpawnSetupError_503(t *testing.T) {
 // the yaml cfg path resolves the Def); RunByIdempotencyKey returns a
 // preconfigured run for a matching key.
 type fakeWebhookStore struct {
+	mu        sync.Mutex
 	existing  map[string]store.Run // key -> run returned by RunByIdempotencyKey
 	lookupErr error
 	calls     int
+
+	// on_complete hook recordings (WH-5b). channelPublishes + memorySets
+	// capture the dispatched hooks so tests can assert they fired.
+	channelPublishes []store.ChannelMessage
+	memorySets       []memorySetCall
+}
+
+type memorySetCall struct {
+	scope   store.MemoryScope
+	scopeID string
+	key     string
+	value   json.RawMessage
 }
 
 func (f *fakeWebhookStore) WebhookDefGetActive(_ context.Context, name string) (store.WebhookDefRow, error) {
@@ -395,12 +408,38 @@ func (f *fakeWebhookStore) WebhookDefGetActive(_ context.Context, name string) (
 }
 
 func (f *fakeWebhookStore) RunByIdempotencyKey(_ context.Context, key string) (store.Run, bool, error) {
+	f.mu.Lock()
 	f.calls++
+	f.mu.Unlock()
 	if f.lookupErr != nil {
 		return store.Run{}, false, f.lookupErr
 	}
 	r, ok := f.existing[key]
 	return r, ok, nil
+}
+
+func (f *fakeWebhookStore) ChannelPublish(_ context.Context, msg store.ChannelMessage, _ int) (string, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.channelPublishes = append(f.channelPublishes, msg)
+	return "msg-1", 0, nil
+}
+
+func (f *fakeWebhookStore) MemorySet(_ context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.memorySets = append(f.memorySets, memorySetCall{scope: scope, scopeID: scopeID, key: key, value: value})
+	return nil
+}
+
+// snapshotHooks returns copies of the recorded hook calls under the lock, so
+// a test reads a consistent view while the dispatch goroutine may still run.
+func (f *fakeWebhookStore) snapshotHooks() ([]store.ChannelMessage, []memorySetCall) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := append([]store.ChannelMessage(nil), f.channelPublishes...)
+	ms := append([]memorySetCall(nil), f.memorySets...)
+	return cp, ms
 }
 
 // newTestReceiverWithStore mirrors newTestReceiver but wires a store so
@@ -555,4 +594,14 @@ func (s *raceStore) RunByIdempotencyKey(_ context.Context, key string) (store.Ru
 		return s.winner, true, nil // re-lookup after the dup error
 	}
 	return store.Run{}, false, nil
+}
+
+// ChannelPublish + MemorySet satisfy lookup.WebhookStore (WH-5b). The race
+// tests never declare on_complete hooks, so no-ops suffice.
+func (s *raceStore) ChannelPublish(_ context.Context, _ store.ChannelMessage, _ int) (string, int, error) {
+	return "", 0, nil
+}
+
+func (s *raceStore) MemorySet(_ context.Context, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
+	return nil
 }

--- a/internal/api/webhook/signature.go
+++ b/internal/api/webhook/signature.go
@@ -1,0 +1,229 @@
+// Package webhook implements the RFC H inbound-webhook RECEIVER — the
+// security/trust boundary that turns an external HTTP POST into either
+// an agent run (delivery=spawn) or a channel publish (delivery=channel).
+//
+// This package is deliberately self-contained: it re-declares the small
+// credential-resolution shape rather than importing the scheduler (which
+// would create a cycle, since the scheduler already imports the store +
+// runner). The duplication mirrors the scheduler's own re-declaration of
+// the ScheduleDef wire shape; parity is the operator's concern, not a
+// compile-time one, because the surfaces are intentionally decoupled.
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// signatureTolerance is the ±window applied to the timestamp embedded in
+// a Stripe-style signature header. A request whose `t=` is more than this
+// far from the receiver's clock (in either direction) is rejected as
+// stale-or-future — the standard replay-window guard. 5 minutes matches
+// Stripe's documented default tolerance.
+const signatureTolerance = 5 * time.Minute
+
+// authError is a typed verification failure the server maps to an HTTP
+// status. We do NOT leak the reason to the client for signature failures
+// (no timing/oracle leak — Decision 9); the reason exists only for the
+// structured log line and the verdict the server records internally.
+type authError struct {
+	// verdict is the internal-only classification (e.g. "rejected_sig",
+	// "unresolvable_secret"). Used for logging + the server's status map.
+	verdict string
+	// secretEnv is populated only for the secret_unresolvable case, so the
+	// 503 body can name WHICH env var is missing (the env-var NAME is not a
+	// secret; its value is). Never holds a secret value.
+	secretEnv string
+	// msg is an operator-facing description for the log line only. Never
+	// returned in an HTTP body for the signature-mismatch verdicts.
+	msg string
+}
+
+func (e *authError) Error() string { return e.msg }
+
+// Verdict classifications. These are the internal labels the server logs
+// and maps to status codes; they are never echoed verbatim to the client
+// for the signature-failure cases.
+const (
+	verdictAccepted    = "accepted"
+	verdictRejectedSig = "rejected_sig"
+	verdictUnresolved  = "unresolvable_secret"
+)
+
+// errSignatureMismatch is the catch-all for every "the request did not
+// authenticate" case: bad MAC, tampered body, missing/garbled header,
+// out-of-window timestamp, wrong bearer. They all collapse to one verdict
+// so the client cannot distinguish them (no oracle). The server maps it
+// to 401 with NO body detail.
+var errSignatureMismatch = errors.New("signature_mismatch")
+
+// resolveSecret reads an env var through the allowlist gate. Returns the
+// secret_unresolvable authError when the var is not allowlisted, unset, or
+// empty. The returned value is a secret — callers must never log it.
+//
+// getenv is injected (rather than calling os.Getenv directly) so tests can
+// drive the allowlist/unset/empty branches deterministically without
+// mutating process environment.
+func resolveSecret(envName string, allowlist map[string]bool, getenv func(string) string) (string, error) {
+	if envName == "" {
+		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: "auth: no secret env var configured"}
+	}
+	if !allowlist[envName] {
+		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: fmt.Sprintf("auth: env var %q not in allowlist", envName)}
+	}
+	v := getenv(envName)
+	if v == "" {
+		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: fmt.Sprintf("auth: env var %q unset or empty", envName)}
+	}
+	return v, nil
+}
+
+// verifySignature authenticates a raw request body against a WebhookDef's
+// auth config. It MUST be called with the RAW bytes read off the wire —
+// never a re-serialized body — because the HMAC integrity guarantee is
+// over exactly those bytes.
+//
+// Three shapes are supported, dispatched by auth.kind + header:
+//
+//   - hmac, Stripe envelope (default): header value `t=<unix>, v1=<hexmac>`
+//     where the MAC is HMAC-SHA256 of `<t> + "." + <rawbody>`, keyed by the
+//     signing secret. The `t` is checked against ±signatureTolerance.
+//   - hmac, GitHub envelope: header `X-Hub-Signature-256: sha256=<hexmac>`
+//     where the MAC is HMAC-SHA256 of the raw body ONLY (no timestamp). The
+//     shape is detected from the `sha256=` prefix.
+//   - bearer: the request's Authorization bearer is compared (constant-time)
+//     against the configured bearer_token_env value.
+//
+// The constant-time primitive is crypto/hmac.Equal for the HMAC cases
+// (compares the freshly-computed MAC bytes against the decoded header MAC)
+// and auth.CompareBearer (sha256-then-subtle.ConstantTimeCompare) for the
+// bearer case. We never compare hex strings with == and never use
+// bytes.Equal on the MAC.
+//
+// now is injected so the timestamp-window check is deterministic in tests.
+func verifySignature(a config.WebhookAuth, body []byte, headerGet func(string) string, allowlist map[string]bool, getenv func(string) string, now func() time.Time) error {
+	kind := strings.ToLower(strings.TrimSpace(a.Kind))
+	if kind == "" {
+		kind = "hmac"
+	}
+
+	switch kind {
+	case "bearer":
+		want, err := resolveSecret(a.BearerTokenEnv, allowlist, getenv)
+		if err != nil {
+			return err
+		}
+		got := headerGet("Authorization")
+		if got == "" {
+			return errSignatureMismatch
+		}
+		// CompareBearer hashes both sides to a fixed length before the
+		// constant-time compare, so neither the presence/absence of the
+		// "Bearer " prefix nor the token length leaks via timing.
+		if !auth.CompareBearer(got, "Bearer "+want) {
+			return errSignatureMismatch
+		}
+		return nil
+
+	case "hmac":
+		secret, err := resolveSecret(a.SigningSecretEnv, allowlist, getenv)
+		if err != nil {
+			return err
+		}
+		return verifyHMAC(a, secret, body, headerGet, now)
+
+	default:
+		// Unknown auth kind is a config error, not a request error. Treat
+		// as unresolvable so the operator sees a 503 rather than silently
+		// accepting or returning a misleading 401.
+		return &authError{verdict: verdictUnresolved, secretEnv: "", msg: fmt.Sprintf("auth: unknown kind %q", a.Kind)}
+	}
+}
+
+// verifyHMAC handles the two HMAC envelope shapes. The header name comes
+// from a.Header (operator-addressable); when empty we default to the
+// Stripe header. The envelope shape (Stripe `t=,v1=` vs GitHub `sha256=`)
+// is detected from the header VALUE, not just its name, so an operator who
+// points a.Header at a custom name still gets correct parsing.
+func verifyHMAC(a config.WebhookAuth, secret string, body []byte, headerGet func(string) string, now func() time.Time) error {
+	headerName := a.Header
+	if headerName == "" {
+		headerName = "X-Loomcycle-Signature"
+	}
+	raw := strings.TrimSpace(headerGet(headerName))
+	if raw == "" {
+		// Fall back to probing the GitHub header by its canonical name when
+		// the configured header is absent — lets a Def declare GitHub auth
+		// purely via header name without a separate envelope flag.
+		if alt := strings.TrimSpace(headerGet("X-Hub-Signature-256")); alt != "" {
+			raw = alt
+		}
+	}
+	if raw == "" {
+		return errSignatureMismatch
+	}
+
+	// GitHub envelope: `sha256=<hexmac>` over the raw body only.
+	if strings.HasPrefix(raw, "sha256=") {
+		wantHex := strings.TrimPrefix(raw, "sha256=")
+		return compareHMAC(secret, body, wantHex)
+	}
+
+	// Stripe envelope: `t=<unix>, v1=<hexmac>` over `<t>.<rawbody>`.
+	var tsStr, macHex string
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "t="):
+			tsStr = strings.TrimPrefix(part, "t=")
+		case strings.HasPrefix(part, "v1="):
+			macHex = strings.TrimPrefix(part, "v1=")
+		}
+	}
+	if tsStr == "" || macHex == "" {
+		return errSignatureMismatch
+	}
+	tsUnix, perr := strconv.ParseInt(tsStr, 10, 64)
+	if perr != nil {
+		return errSignatureMismatch
+	}
+	ts := time.Unix(tsUnix, 0)
+	skew := now().Sub(ts)
+	if skew < 0 {
+		skew = -skew
+	}
+	if skew > signatureTolerance {
+		// Stale or future timestamp — replay-window guard. Collapses to
+		// the same verdict so the client cannot probe the tolerance.
+		return errSignatureMismatch
+	}
+	signedPayload := append([]byte(tsStr+"."), body...)
+	return compareHMAC(secret, signedPayload, macHex)
+}
+
+// compareHMAC computes HMAC-SHA256(secret, payload) and compares it to the
+// hex-decoded wantHex using crypto/hmac.Equal (constant-time). Returns
+// errSignatureMismatch on any failure (bad hex, length mismatch, MAC
+// mismatch) — all collapse to one verdict so no information leaks.
+func compareHMAC(secret string, payload []byte, wantHex string) error {
+	want, derr := hex.DecodeString(strings.TrimSpace(wantHex))
+	if derr != nil {
+		return errSignatureMismatch
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	got := mac.Sum(nil)
+	if !hmac.Equal(got, want) {
+		return errSignatureMismatch
+	}
+	return nil
+}

--- a/internal/api/webhook/signature.go
+++ b/internal/api/webhook/signature.go
@@ -122,14 +122,22 @@ func verifySignature(a config.WebhookAuth, body []byte, headerGet func(string) s
 		if err != nil {
 			return err
 		}
-		got := headerGet("Authorization")
-		if got == "" {
-			return errSignatureMismatch
-		}
+		// Two shapes. Default (no auth.header): the standard
+		// `Authorization: Bearer <token>`. When auth.header is set, the
+		// shared secret is carried RAW in that header instead — e.g.
+		// GitLab's `X-Gitlab-Token: <token>` — so compare the raw value.
 		// CompareBearer hashes both sides to a fixed length before the
-		// constant-time compare, so neither the presence/absence of the
-		// "Bearer " prefix nor the token length leaks via timing.
-		if !auth.CompareBearer(got, "Bearer "+want) {
+		// constant-time compare, so neither the "Bearer " prefix nor the
+		// token length leaks via timing.
+		if a.Header != "" {
+			got := strings.TrimSpace(headerGet(a.Header))
+			if got == "" || !auth.CompareBearer(got, want) {
+				return errSignatureMismatch
+			}
+			return nil
+		}
+		got := headerGet("Authorization")
+		if got == "" || !auth.CompareBearer(got, "Bearer "+want) {
 			return errSignatureMismatch
 		}
 		return nil
@@ -149,11 +157,11 @@ func verifySignature(a config.WebhookAuth, body []byte, headerGet func(string) s
 	}
 }
 
-// verifyHMAC handles the two HMAC envelope shapes. The header name comes
+// verifyHMAC handles the three HMAC envelope shapes. The header name comes
 // from a.Header (operator-addressable); when empty we default to the
-// Stripe header. The envelope shape (Stripe `t=,v1=` vs GitHub `sha256=`)
-// is detected from the header VALUE, not just its name, so an operator who
-// points a.Header at a custom name still gets correct parsing.
+// Stripe header. The envelope shape (Stripe `t=,v1=` vs GitHub `sha256=`
+// vs bare hex) is detected from the header VALUE, not just its name, so an
+// operator who points a.Header at a custom name still gets correct parsing.
 func verifyHMAC(a config.WebhookAuth, secret string, body []byte, headerGet func(string) string, now func() time.Time) error {
 	headerName := a.Header
 	if headerName == "" {
@@ -176,6 +184,15 @@ func verifyHMAC(a config.WebhookAuth, secret string, body []byte, headerGet func
 	if strings.HasPrefix(raw, "sha256=") {
 		wantHex := strings.TrimPrefix(raw, "sha256=")
 		return compareHMAC(secret, body, wantHex)
+	}
+
+	// Bare-hex envelope (Linear `Linear-Signature`, and many custom HMAC
+	// sources): the entire header value is the hex HMAC-SHA256 of the raw
+	// body — no prefix, no timestamp. A Stripe envelope always contains ','
+	// and '=' so it is never all-hex; this branch is therefore unambiguous
+	// and must be checked BEFORE the Stripe parse.
+	if isHexString(raw) {
+		return compareHMAC(secret, body, raw)
 	}
 
 	// Stripe envelope: `t=<unix>, v1=<hexmac>` over `<t>.<rawbody>`.
@@ -208,6 +225,23 @@ func verifyHMAC(a config.WebhookAuth, secret string, body []byte, headerGet func
 	}
 	signedPayload := append([]byte(tsStr+"."), body...)
 	return compareHMAC(secret, signedPayload, macHex)
+}
+
+// isHexString reports whether s is a non-empty run of only hex digits — the
+// bare-hex signature envelope (e.g. Linear's `Linear-Signature`). Used to
+// disambiguate a raw hex MAC from a Stripe `t=,v1=` envelope (which always
+// contains non-hex bytes).
+func isHexString(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')) {
+			return false
+		}
+	}
+	return true
 }
 
 // compareHMAC computes HMAC-SHA256(secret, payload) and compares it to the

--- a/internal/api/webhook/signature_test.go
+++ b/internal/api/webhook/signature_test.go
@@ -1,0 +1,170 @@
+package webhook
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// fixedClock returns a now() that always reports t.
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+// mapGetenv builds a getenv from a map.
+func mapGetenv(m map[string]string) func(string) string {
+	return func(k string) string { return m[k] }
+}
+
+// githubSig computes a GitHub-style `sha256=<hexmac>` over the raw body.
+func githubSig(secret string, body []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// stripeSig computes a Stripe-style `t=<unix>, v1=<hexmac>` over `<t>.<body>`.
+func stripeSig(secret string, body []byte, ts time.Time) string {
+	tsStr := fmt.Sprintf("%d", ts.Unix())
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(append([]byte(tsStr+"."), body...))
+	return fmt.Sprintf("t=%s, v1=%s", tsStr, hex.EncodeToString(mac.Sum(nil)))
+}
+
+func headerGetter(h http.Header) func(string) string {
+	return func(k string) string { return h.Get(k) }
+}
+
+func TestVerifySignature_GitHubStyleValid_Accepts(t *testing.T) {
+	secret := "shhh"
+	body := []byte(`{"action":"opened"}`)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{"WH_SECRET": secret})
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+
+	a := config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}
+	if err := verifySignature(a, body, headerGetter(h), allow, env, time.Now); err != nil {
+		t.Fatalf("want accept, got %v", err)
+	}
+}
+
+func TestVerifySignature_TamperedBody_Rejects(t *testing.T) {
+	secret := "shhh"
+	signed := []byte(`{"action":"opened"}`)
+	tampered := []byte(`{"action":"closed"}`)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{"WH_SECRET": secret})
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, signed))
+
+	a := config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}
+	err := verifySignature(a, tampered, headerGetter(h), allow, env, time.Now)
+	if !errors.Is(err, errSignatureMismatch) {
+		t.Fatalf("want errSignatureMismatch, got %v", err)
+	}
+}
+
+func TestVerifySignature_StripeStyleValid_Accepts(t *testing.T) {
+	secret := "topsecret"
+	body := []byte(`{"id":"evt_1"}`)
+	now := time.Unix(1_700_000_000, 0)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{"WH_SECRET": secret})
+
+	h := http.Header{}
+	h.Set("X-Loomcycle-Signature", stripeSig(secret, body, now))
+
+	a := config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "WH_SECRET"}
+	if err := verifySignature(a, body, headerGetter(h), allow, env, fixedClock(now)); err != nil {
+		t.Fatalf("want accept, got %v", err)
+	}
+}
+
+func TestVerifySignature_OutOfWindowTimestamp_Rejects(t *testing.T) {
+	secret := "topsecret"
+	body := []byte(`{"id":"evt_1"}`)
+	signedAt := time.Unix(1_700_000_000, 0)
+	// Verify 10 minutes later — beyond the ±5m tolerance.
+	checkAt := signedAt.Add(10 * time.Minute)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{"WH_SECRET": secret})
+
+	h := http.Header{}
+	h.Set("X-Loomcycle-Signature", stripeSig(secret, body, signedAt))
+
+	a := config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "WH_SECRET"}
+	err := verifySignature(a, body, headerGetter(h), allow, env, fixedClock(checkAt))
+	if !errors.Is(err, errSignatureMismatch) {
+		t.Fatalf("want errSignatureMismatch (stale ts), got %v", err)
+	}
+}
+
+func TestVerifySignature_BearerValid_Accepts(t *testing.T) {
+	token := "bearer-token-xyz"
+	allow := map[string]bool{"WH_BEARER": true}
+	env := mapGetenv(map[string]string{"WH_BEARER": token})
+
+	h := http.Header{}
+	h.Set("Authorization", "Bearer "+token)
+
+	a := config.WebhookAuth{Kind: "bearer", BearerTokenEnv: "WH_BEARER"}
+	if err := verifySignature(a, []byte(`{}`), headerGetter(h), allow, env, time.Now); err != nil {
+		t.Fatalf("want accept, got %v", err)
+	}
+}
+
+func TestVerifySignature_BearerMissing_Rejects(t *testing.T) {
+	allow := map[string]bool{"WH_BEARER": true}
+	env := mapGetenv(map[string]string{"WH_BEARER": "bearer-token-xyz"})
+
+	h := http.Header{} // no Authorization header
+
+	a := config.WebhookAuth{Kind: "bearer", BearerTokenEnv: "WH_BEARER"}
+	err := verifySignature(a, []byte(`{}`), headerGetter(h), allow, env, time.Now)
+	if !errors.Is(err, errSignatureMismatch) {
+		t.Fatalf("want errSignatureMismatch, got %v", err)
+	}
+}
+
+func TestVerifySignature_SecretNotInAllowlist_Unresolvable(t *testing.T) {
+	body := []byte(`{}`)
+	allow := map[string]bool{} // WH_SECRET deliberately absent
+	env := mapGetenv(map[string]string{"WH_SECRET": "shhh"})
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig("shhh", body))
+
+	a := config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}
+	err := verifySignature(a, body, headerGetter(h), allow, env, time.Now)
+	var ae *authError
+	if !errors.As(err, &ae) || ae.verdict != verdictUnresolved {
+		t.Fatalf("want unresolvable authError, got %v", err)
+	}
+	if ae.secretEnv != "WH_SECRET" {
+		t.Fatalf("want secretEnv=WH_SECRET, got %q", ae.secretEnv)
+	}
+}
+
+func TestVerifySignature_SecretUnsetInEnv_Unresolvable(t *testing.T) {
+	body := []byte(`{}`)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{}) // allowlisted but unset
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig("shhh", body))
+
+	a := config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"}
+	err := verifySignature(a, body, headerGetter(h), allow, env, time.Now)
+	var ae *authError
+	if !errors.As(err, &ae) || ae.verdict != verdictUnresolved {
+		t.Fatalf("want unresolvable authError, got %v", err)
+	}
+}

--- a/internal/api/webhook/signature_test.go
+++ b/internal/api/webhook/signature_test.go
@@ -55,6 +55,52 @@ func TestVerifySignature_GitHubStyleValid_Accepts(t *testing.T) {
 	}
 }
 
+// Linear (and many custom HMAC sources) send the bare hex HMAC-SHA256 of
+// the raw body with no prefix or timestamp — the bare-hex envelope.
+func TestVerifySignature_BareHexStyleValid_Accepts(t *testing.T) {
+	secret := "shhh"
+	body := []byte(`{"action":"create","type":"Issue"}`)
+	allow := map[string]bool{"WH_SECRET": true}
+	env := mapGetenv(map[string]string{"WH_SECRET": secret})
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	bareHex := hex.EncodeToString(mac.Sum(nil)) // no "sha256=" prefix, no t=/v1=
+
+	h := http.Header{}
+	h.Set("Linear-Signature", bareHex)
+
+	a := config.WebhookAuth{Kind: "hmac", Header: "Linear-Signature", SigningSecretEnv: "WH_SECRET"}
+	if err := verifySignature(a, body, headerGetter(h), allow, env, time.Now); err != nil {
+		t.Fatalf("want accept for bare-hex envelope, got %v", err)
+	}
+	// A tampered body under the same envelope must still be rejected.
+	if err := verifySignature(a, []byte(`{"action":"remove"}`), headerGetter(h), allow, env, time.Now); !errors.Is(err, errSignatureMismatch) {
+		t.Fatalf("tampered bare-hex: want errSignatureMismatch, got %v", err)
+	}
+}
+
+// GitLab (and custom shared-secret sources) carry the token RAW in a
+// configured header (X-Gitlab-Token), not as Authorization: Bearer.
+func TestVerifySignature_BearerCustomHeaderRawToken_Accepts(t *testing.T) {
+	allow := map[string]bool{"GL_TOKEN": true}
+	env := mapGetenv(map[string]string{"GL_TOKEN": "s3cr3t-shared"})
+	a := config.WebhookAuth{Kind: "bearer", Header: "X-Gitlab-Token", BearerTokenEnv: "GL_TOKEN"}
+	body := []byte(`{"object_kind":"merge_request"}`)
+
+	ok := http.Header{}
+	ok.Set("X-Gitlab-Token", "s3cr3t-shared")
+	if err := verifySignature(a, body, headerGetter(ok), allow, env, time.Now); err != nil {
+		t.Fatalf("raw-token custom header: want accept, got %v", err)
+	}
+
+	bad := http.Header{}
+	bad.Set("X-Gitlab-Token", "wrong")
+	if err := verifySignature(a, body, headerGetter(bad), allow, env, time.Now); !errors.Is(err, errSignatureMismatch) {
+		t.Fatalf("wrong raw token: want errSignatureMismatch, got %v", err)
+	}
+}
+
 func TestVerifySignature_TamperedBody_Rejects(t *testing.T) {
 	secret := "shhh"
 	signed := []byte(`{"action":"opened"}`)

--- a/internal/api/webhook/triage.go
+++ b/internal/api/webhook/triage.go
@@ -1,0 +1,160 @@
+package webhook
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+)
+
+// MountAdmin registers the WH-5b triage routes WRAPPED in adminAuth. Unlike
+// Mount (the unauthed receiver POST, which does its own per-WebhookDef auth),
+// these endpoints expose operator-only introspection and MUST sit behind the
+// global LOOMCYCLE_AUTH_TOKEN bearer — they reveal which deliveries arrived
+// and let an operator dry-run a signature, so they are never attacker-facing.
+//
+// adminAuth is the same recovery+bearer wrapper the HTTP server hands the
+// A2A extraMux hook, so these routes get the identical posture as the other
+// /v1/_* admin endpoints.
+func (rec *Receiver) MountAdmin(reg Registrar, adminAuth func(http.Handler) http.Handler) {
+	reg.Handle("GET /v1/_webhooks/{name}/recent-deliveries",
+		adminAuth(http.HandlerFunc(rec.handleRecentDeliveries)))
+	reg.Handle("POST /v1/_webhooks/{name}/test",
+		adminAuth(http.HandlerFunc(rec.handleTest)))
+}
+
+// handleRecentDeliveries returns the recorded triage entries for a webhook
+// name, newest-first, capped at min(limit, recentBufferCap, ring length).
+// 404 when the name has never been invoked (so a typo is distinguishable
+// from a quiet-but-real webhook). The entries carry ONLY non-sensitive
+// fields (delivery id, verdict, received_at, run id) — no credentials, no
+// payloads.
+func (rec *Receiver) handleRecentDeliveries(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	limit := recentBufferCap
+	if q := r.URL.Query().Get("limit"); q != "" {
+		if n, err := strconv.Atoi(q); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > recentBufferCap {
+		limit = recentBufferCap
+	}
+
+	entries, ok := rec.recentSnapshot(name, limit)
+	if !ok {
+		writeError(w, http.StatusNotFound, "unknown_webhook", "")
+		return
+	}
+	if entries == nil {
+		entries = []deliveryRecord{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"webhook_name": name,
+		"deliveries":   entries,
+	})
+}
+
+// testResult is the dry-run validator response. It NEVER carries credential
+// values — only the resolved credential KEY names — so an operator can
+// confirm a payload_mapping wires the right keys without leaking the secrets
+// the run would receive.
+type testResult struct {
+	WouldAccept     bool            `json:"would_accept"`
+	Verdict         string          `json:"verdict"`
+	RunInputPreview runInputPreview `json:"run_input_preview"`
+}
+
+// runInputPreview is the non-sensitive projection of the RunInput a real
+// delivery would build. CredentialKeys lists the credential map's KEYS only.
+type runInputPreview struct {
+	Agent          string   `json:"agent"`
+	UserID         string   `json:"user_id"`
+	Goal           string   `json:"goal"`
+	CredentialKeys []string `json:"credential_keys"`
+}
+
+// handleTest is the admin dry-run validator. It verifies the signature and
+// runs the payload projection against the posted body+headers, then returns
+// whether a real delivery WOULD be accepted plus a non-sensitive preview of
+// the RunInput. It creates NO run, publishes NO channel message, records NO
+// dedup entry, consumes NO rate-limit token, and adds NO triage record — it
+// is a pure read-only validation against the resolved WebhookDef.
+//
+// Credentials are NEVER returned (only their key names). The goal IS returned
+// because it is the operator-projected field the dry-run is meant to confirm;
+// it is the same value a delivery would put in the run prompt.
+func (rec *Receiver) handleTest(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+
+	wd, ok := lookup.Webhook(r.Context(), rec.store, rec.cfg, name)
+	if !ok || !wd.Enabled {
+		// Same 404 posture as the receiver: a disabled/unknown webhook is not
+		// addressable for a dry-run either.
+		writeError(w, http.StatusNotFound, "unknown_webhook", "")
+		return
+	}
+
+	limit := wd.BodySizeLimitBytes
+	if limit <= 0 {
+		limit = defaultBodySizeLimitBytes
+	}
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, int64(limit)))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_body", "")
+		return
+	}
+
+	// 1. Verify the signature (no token consumed, no dedup recorded). Map the
+	//    failure to the same verdict labels the receive path uses.
+	if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
+		verdict := verdictRejectedSig
+		var ae *authError
+		if errors.As(verr, &ae) && ae.verdict == verdictUnresolved {
+			verdict = verdictUnresolved
+		}
+		// A bad signature short-circuits: no projection preview (the body is
+		// unauthenticated). would_accept=false, empty preview.
+		writeJSON(w, http.StatusOK, testResult{
+			WouldAccept:     false,
+			Verdict:         verdict,
+			RunInputPreview: runInputPreview{},
+		})
+		return
+	}
+
+	// 2. Project the payload (same allowlisted mapping the receive path uses).
+	proj, perr := projectPayload(wd.PayloadMapping, body)
+	if perr != nil {
+		writeJSON(w, http.StatusOK, testResult{
+			WouldAccept:     false,
+			Verdict:         "rejected_mapping",
+			RunInputPreview: runInputPreview{},
+		})
+		return
+	}
+
+	// 3. Build the RunInput preview (no run is created). We reuse buildRunInput
+	//    so the preview matches exactly what a delivery would produce, then
+	//    project ONLY the non-sensitive fields — credential VALUES are
+	//    dropped, keys retained.
+	in := buildRunInput(wd, proj, rec.envAllowlist, rec.getenv, rec.logf)
+	keys := make([]string, 0, len(in.UserCredentials))
+	for k := range in.UserCredentials {
+		keys = append(keys, k)
+	}
+
+	writeJSON(w, http.StatusOK, testResult{
+		WouldAccept: true,
+		Verdict:     verdictAccepted,
+		RunInputPreview: runInputPreview{
+			Agent:          in.Agent,
+			UserID:         in.UserID,
+			Goal:           proj.Fields["goal"],
+			CredentialKeys: keys,
+		},
+	})
+}

--- a/internal/api/webhook/wh5b_test.go
+++ b/internal/api/webhook/wh5b_test.go
@@ -1,0 +1,352 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// waitForHooks polls the fake store until it has recorded at least the
+// expected number of channel publishes + memory sets, or the deadline
+// elapses. The on_complete dispatch runs in the spawn goroutine AFTER the
+// 202 is returned, so a test cannot assume the hooks fired by the time
+// doPost returns.
+func waitForHooks(t *testing.T, st *fakeWebhookStore, wantChan, wantMem int) ([]store.ChannelMessage, []memorySetCall) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		cp, ms := st.snapshotHooks()
+		if len(cp) >= wantChan && len(ms) >= wantMem {
+			return cp, ms
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("on_complete hooks not fired in time: got %d channel / %d memory, want %d / %d",
+				len(cp), len(ms), wantChan, wantMem)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func TestReceiver_OnCompleteChannelPublish_FiresAfterSpawnedRun(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it","user":"u-7"}`)
+
+	wh := config.Webhook{
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "researcher",
+		Auth:     config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{
+			"goal":    "$.goal",
+			"user_id": "$.user",
+		},
+		OnComplete: []config.ScheduledRunHook{
+			{Kind: "channel.publish", Channel: "results", Payload: map[string]any{"k": "v"}},
+		},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	st := &fakeWebhookStore{existing: map[string]store.Run{}}
+	rec := newTestReceiverWithStore(t, map[string]config.Webhook{"gh": wh}, fr, st,
+		map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+
+	cp, _ := waitForHooks(t, st, 1, 0)
+	msg := cp[0]
+	if msg.Channel != "results" {
+		t.Errorf("channel = %q, want results", msg.Channel)
+	}
+	// userID was projected (u-7) → user scope.
+	if msg.Scope != store.MemoryScopeUser || msg.ScopeID != "u-7" {
+		t.Errorf("scope = %q/%q, want user/u-7", msg.Scope, msg.ScopeID)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(msg.Payload, &payload); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if payload["webhook_name"] != "gh" || payload["run_id"] != "run-1" || payload["agent_id"] != "agent-1" {
+		t.Errorf("payload missing traceability fields: %+v", payload)
+	}
+}
+
+func TestReceiver_OnCompleteMemorySet_FiresAfterSpawnedRun(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it"}`)
+
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "researcher",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+		OnComplete: []config.ScheduledRunHook{
+			{Kind: "memory.set", Scope: "agent", Key: "last_seen", Payload: map[string]any{"n": 1}},
+		},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	st := &fakeWebhookStore{existing: map[string]store.Run{}}
+	rec := newTestReceiverWithStore(t, map[string]config.Webhook{"gh": wh}, fr, st,
+		map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+
+	_, ms := waitForHooks(t, st, 0, 1)
+	set := ms[0]
+	// agent scope keys on the webhook NAME (scheduler-parity choice).
+	if set.scope != store.MemoryScopeAgent || set.scopeID != "gh" {
+		t.Errorf("scope = %q/%q, want agent/gh", set.scope, set.scopeID)
+	}
+	if set.key != "last_seen" {
+		t.Errorf("key = %q, want last_seen", set.key)
+	}
+}
+
+func TestReceiver_OnCompleteMCPCall_LogsAndSkips(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do it"}`)
+
+	var logged []string
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "researcher",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+		OnComplete: []config.ScheduledRunHook{
+			{Kind: "mcp.call", Server: "s", Tool: "t"},
+			// A trailing channel.publish proves the loop CONTINUES past the
+			// skipped mcp.call rather than aborting.
+			{Kind: "channel.publish", Channel: "results"},
+		},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	st := &fakeWebhookStore{existing: map[string]store.Run{}}
+	rec := New(Deps{
+		Cfg:          &config.Config{Webhooks: map[string]config.Webhook{"gh": wh}},
+		Store:        st,
+		Runner:       fr,
+		EnvAllowlist: map[string]bool{"WH_SECRET": true},
+		Now:          fixedClock(now),
+		Getenv:       mapGetenv(map[string]string{"WH_SECRET": secret}),
+		Logf:         func(f string, a ...any) { logged = append(logged, f) },
+	})
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", w.Code)
+	}
+
+	// The channel.publish after the skipped mcp.call must still fire.
+	waitForHooks(t, st, 1, 0)
+
+	foundSkipLog := false
+	for _, l := range logged {
+		if strings.Contains(l, "mcp.call not wired") {
+			foundSkipLog = true
+		}
+	}
+	if !foundSkipLog {
+		t.Errorf("expected an mcp.call-not-wired log line; got %v", logged)
+	}
+}
+
+func TestReceiver_RecentDeliveries_ReturnsVerdictsNewestFirstCapped(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "researcher",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET", DeliveryIDHeader: "X-Delivery-Id"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil,
+		map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	// One accepted delivery, then a tampered (bad-sig) one.
+	good := []byte(`{"goal":"a"}`)
+	hGood := http.Header{}
+	hGood.Set("X-Hub-Signature-256", githubSig(secret, good))
+	hGood.Set("X-Delivery-Id", "d-1")
+	if w := doPost(rec, "gh", good, hGood); w.Code != http.StatusAccepted {
+		t.Fatalf("good delivery status = %d, want 202", w.Code)
+	}
+
+	bad := []byte(`{"goal":"b"}`)
+	hBad := http.Header{}
+	hBad.Set("X-Hub-Signature-256", githubSig(secret, good)) // sig over `good`, body is `bad`
+	if w := doPost(rec, "gh", bad, hBad); w.Code != http.StatusUnauthorized {
+		t.Fatalf("bad delivery status = %d, want 401", w.Code)
+	}
+
+	// Pass-through adminAuth (gating is wired+tested at the http-server layer).
+	mux := http.NewServeMux()
+	rec.MountAdmin(mux, func(h http.Handler) http.Handler { return h })
+	req := httptest.NewRequest(http.MethodGet, "/v1/_webhooks/gh/recent-deliveries?limit=10", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("recent-deliveries status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		WebhookName string           `json:"webhook_name"`
+		Deliveries  []deliveryRecord `json:"deliveries"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.WebhookName != "gh" {
+		t.Errorf("webhook_name = %q, want gh", resp.WebhookName)
+	}
+	if len(resp.Deliveries) != 2 {
+		t.Fatalf("got %d deliveries, want 2", len(resp.Deliveries))
+	}
+	// Newest-first: the bad-sig reject was recorded last.
+	if resp.Deliveries[0].Verdict != verdictRejectedSig {
+		t.Errorf("newest verdict = %q, want %s", resp.Deliveries[0].Verdict, verdictRejectedSig)
+	}
+	if resp.Deliveries[1].Verdict != verdictAccepted {
+		t.Errorf("oldest verdict = %q, want %s", resp.Deliveries[1].Verdict, verdictAccepted)
+	}
+	if resp.Deliveries[1].RunID != "run-1" {
+		t.Errorf("accepted run_id = %q, want run-1", resp.Deliveries[1].RunID)
+	}
+}
+
+func TestReceiver_RecentDeliveries_UnknownName_404(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	rec := newTestReceiver(t, map[string]config.Webhook{}, &fakeRunner{}, nil, nil, nil, now)
+	mux := http.NewServeMux()
+	rec.MountAdmin(mux, func(h http.Handler) http.Handler { return h })
+	req := httptest.NewRequest(http.MethodGet, "/v1/_webhooks/never-seen/recent-deliveries", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestReceiver_Test_ValidSig_ReturnsPreviewWithoutCredentialValuesAndNoRun(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"do the thing","user":"u-9","tok":"PAYLOAD-SECRET-VALUE"}`)
+
+	wh := config.Webhook{
+		Enabled:                true,
+		Delivery:               "spawn",
+		Agent:                  "researcher",
+		Auth:                   config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		UserCredentialsFromEnv: map[string]string{"API_KEY": "ENV_CRED"},
+		PayloadMapping: map[string]string{
+			"goal":                 "$.goal",
+			"user_id":              "$.user",
+			"user_credentials.TOK": "$.tok",
+		},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	env := map[string]string{"WH_SECRET": secret, "ENV_CRED": "ENV-SECRET-VALUE"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil, env,
+		[]string{"WH_SECRET", "ENV_CRED"}, now)
+
+	mux := http.NewServeMux()
+	rec.MountAdmin(mux, func(h http.Handler) http.Handler { return h })
+	req := httptest.NewRequest(http.MethodPost, "/v1/_webhooks/gh/test", strings.NewReader(string(body)))
+	req.Header.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if fr.called {
+		t.Fatal("dry-run /test must NOT invoke the runner")
+	}
+
+	// Credential VALUES must never appear anywhere in the response body.
+	raw := w.Body.String()
+	if strings.Contains(raw, "PAYLOAD-SECRET-VALUE") || strings.Contains(raw, "ENV-SECRET-VALUE") {
+		t.Fatalf("credential VALUE leaked in /test response: %s", raw)
+	}
+
+	var resp testResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.WouldAccept || resp.Verdict != verdictAccepted {
+		t.Errorf("would_accept=%v verdict=%q, want true/%s", resp.WouldAccept, resp.Verdict, verdictAccepted)
+	}
+	if resp.RunInputPreview.Agent != "researcher" || resp.RunInputPreview.UserID != "u-9" ||
+		resp.RunInputPreview.Goal != "do the thing" {
+		t.Errorf("preview = %+v", resp.RunInputPreview)
+	}
+	// Credential KEYS are present (the operator confirms wiring) — values not.
+	keys := map[string]bool{}
+	for _, k := range resp.RunInputPreview.CredentialKeys {
+		keys[k] = true
+	}
+	if !keys["API_KEY"] || !keys["TOK"] {
+		t.Errorf("credential_keys = %v, want API_KEY + TOK present", resp.RunInputPreview.CredentialKeys)
+	}
+}
+
+func TestReceiver_Test_BadSig_WouldAcceptFalse(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	signed := []byte(`{"goal":"a"}`)
+	tampered := []byte(`{"goal":"b"}`)
+
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "researcher",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr, nil,
+		map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	mux := http.NewServeMux()
+	rec.MountAdmin(mux, func(h http.Handler) http.Handler { return h })
+	req := httptest.NewRequest(http.MethodPost, "/v1/_webhooks/gh/test", strings.NewReader(string(tampered)))
+	req.Header.Set("X-Hub-Signature-256", githubSig(secret, signed)) // sig over the wrong body
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp testResult
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.WouldAccept {
+		t.Errorf("would_accept = true on bad sig, want false")
+	}
+	if resp.Verdict != verdictRejectedSig {
+		t.Errorf("verdict = %q, want %s", resp.Verdict, verdictRejectedSig)
+	}
+	if fr.called {
+		t.Fatal("dry-run /test must NOT invoke the runner even on bad sig")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,14 @@ type Config struct {
 	// Empty / nil = no statically-declared peers.
 	A2AAgents map[string]A2AAgent `yaml:"a2a_agents"`
 
+	// Webhooks is the v1.x RFC H registry of inbound HTTP webhook
+	// declarations — how an external system reaches loomcycle to
+	// trigger an agent run (or publish to a channel), plus the auth,
+	// rate limit, payload mapping, and on_complete hooks. Yaml entries
+	// are the operator-blessed root; the WebhookDef tool produces the
+	// derived fork layer. Empty / nil = no statically-declared webhooks.
+	Webhooks map[string]Webhook `yaml:"webhooks"`
+
 	// Interruption is the v0.8.16 top-level config block for the
 	// Interruption tool. Operator picks the delivery backend
 	// (webui / mcp_server:<name> / cli) and the env-cap defaults.
@@ -635,6 +643,11 @@ type AgentDef struct {
 	// ScheduleDefScopes: "self" / "descendants" / "named:<name>" / "any".
 	A2AAgentDefScopes []string `yaml:"a2a_agent_def_scopes"`
 
+	// WebhookDefScopes is the v1.x RFC H WebhookDef tool capability
+	// gate. Default-deny when empty. Same closed set as
+	// A2AAgentDefScopes: "self" / "descendants" / "named:<name>" / "any".
+	WebhookDefScopes []string `yaml:"webhook_def_scopes"`
+
 	// SkillDefScopes is the v0.8.22 SkillDef tool capability gate.
 	// Default-deny when empty. Mirrors AgentDefScopes minus the
 	// "self" scope (skills have no agent identity, so "self" is
@@ -1019,6 +1032,57 @@ type A2AAgentAuth struct {
 type A2AExpectedSkill struct {
 	ID       string `yaml:"id"`
 	Required bool   `yaml:"required"`
+}
+
+// Webhook is one entry in the v1.x RFC H `webhooks:` yaml block. It
+// declares an INBOUND HTTP webhook: how an external system reaches
+// loomcycle to trigger an agent run (delivery=spawn) or publish to a
+// channel (delivery=channel), plus the auth, rate limit, payload
+// mapping, and on_complete hooks.
+//
+// Unlike the A2A config structs (yaml-only), Webhook carries BOTH json
+// and yaml tags: the SAME field set backs the tool-layer merged shape
+// (WH-2), which persists snake_case JSON into webhook_defs.definition.
+// A 3-way drift test (yaml ↔ lookup.SubstrateWebhookDef ↔ json) pins
+// parity. on_complete reuses ScheduledRunHook — the same hook shape
+// ScheduleDef uses — rather than a parallel type.
+type Webhook struct {
+	Enabled                bool                `json:"enabled,omitempty" yaml:"enabled"`
+	Delivery               string              `json:"delivery,omitempty" yaml:"delivery"`
+	Agent                  string              `json:"agent,omitempty" yaml:"agent"`
+	Channel                string              `json:"channel,omitempty" yaml:"channel"`
+	Auth                   WebhookAuth         `json:"auth,omitempty" yaml:"auth"`
+	RateLimit              WebhookRateLimit    `json:"rate_limit,omitempty" yaml:"rate_limit"`
+	BodySizeLimitBytes     int                 `json:"body_size_limit_bytes,omitempty" yaml:"body_size_limit_bytes"`
+	UserCredentialsFromEnv map[string]string   `json:"user_credentials_from_env,omitempty" yaml:"user_credentials_from_env"`
+	PayloadMapping         map[string]string   `json:"payload_mapping,omitempty" yaml:"payload_mapping"`
+	SyncResponse           WebhookSyncResponse `json:"sync_response,omitempty" yaml:"sync_response"`
+	OnComplete             []ScheduledRunHook  `json:"on_complete,omitempty" yaml:"on_complete"`
+}
+
+// WebhookAuth declares how inbound webhook requests are authenticated.
+// Kind is "hmac" (default) or "bearer". For hmac, the signature header
+// carries an HMAC of the body keyed by the secret in SigningSecretEnv.
+type WebhookAuth struct {
+	Kind             string `json:"kind,omitempty" yaml:"kind"`
+	Algorithm        string `json:"algorithm,omitempty" yaml:"algorithm"`
+	Header           string `json:"header,omitempty" yaml:"header"`
+	SigningSecretEnv string `json:"signing_secret_env,omitempty" yaml:"signing_secret_env"`
+	DeliveryIDHeader string `json:"delivery_id_header,omitempty" yaml:"delivery_id_header"`
+	BearerTokenEnv   string `json:"bearer_token_env,omitempty" yaml:"bearer_token_env"`
+}
+
+// WebhookRateLimit bounds inbound request volume per webhook.
+type WebhookRateLimit struct {
+	RequestsPerMinute int `json:"requests_per_minute,omitempty" yaml:"requests_per_minute"`
+	Burst             int `json:"burst,omitempty" yaml:"burst"`
+}
+
+// WebhookSyncResponse, when enabled, holds the inbound HTTP request
+// open until the triggered run completes (or TimeoutMs elapses).
+type WebhookSyncResponse struct {
+	Enabled   bool `json:"enabled,omitempty" yaml:"enabled"`
+	TimeoutMs int  `json:"timeout_ms,omitempty" yaml:"timeout_ms"`
 }
 
 // MCPServer declares one MCP server. Transport "stdio" or "http".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1688,7 +1688,21 @@ type Env struct {
 	// safe-by-default posture. Operators opt in by setting
 	// LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST="VAR1,VAR2" — only those
 	// var names will be readable by scheduled runs.
+	//
+	// This same allowlist gates the v1.x RFC H webhook receiver's
+	// signing-secret + bearer-token + user_credentials_from_env reads
+	// (RFC F shared trigger-credential gate). The webhook receiver
+	// reuses it rather than a parallel list so an operator declares
+	// the env-var floor once for all autonomous-run triggers.
 	SchedulerEnvAllowlist []string
+
+	// WebhooksEnabled enables the v1.x RFC H inbound-webhook receiver
+	// (the POST /v1/_webhooks/{name} mount). Default OFF — operator
+	// opts in via LOOMCYCLE_WEBHOOKS_ENABLED=1. When false, no route
+	// is mounted and webhook_defs sit idle (the WebhookDef tool still
+	// works for authoring + listing, just nothing receives). Mirrors
+	// SchedulerEnabled exactly.
+	WebhooksEnabled bool
 
 	// A2AServerEnabled enables the v1.x RFC G A2A server HTTP surface
 	// (the well-known AgentCard URI + the three protocol-binding mounts
@@ -2155,6 +2169,12 @@ func Load(path string) (*Config, error) {
 			}
 		}
 	}
+
+	// v1.x RFC H inbound-webhook receiver. Default OFF; operator opts in
+	// via LOOMCYCLE_WEBHOOKS_ENABLED=1. Mirrors SchedulerEnabled — when
+	// false the receiver route is not mounted; the WebhookDef tool still
+	// works for authoring + listing.
+	cfg.Env.WebhooksEnabled = os.Getenv("LOOMCYCLE_WEBHOOKS_ENABLED") == "1"
 
 	// v1.x RFC G A2A server surface. Default OFF; operator opts in via
 	// LOOMCYCLE_A2A_ENABLED=1 + names the active card to serve. Tenancy

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -148,6 +148,15 @@ type Connector interface {
 	// Connector method.
 	A2AAgentDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
 
+	// WebhookDef — v1.x RFC H inbound-webhook registration substrate.
+	// Op-discriminated (create / fork / get / list / retire). Same
+	// operator-admin-only posture as A2AAgentDef. Reachable via
+	// POST /v1/_webhookdef admin endpoint, the LoomCycle MCP meta-tool
+	// `webhookdef`, the gRPC WebhookDef RPC, and the TS adapter's
+	// client.webhookDef() method — all four dispatch through this single
+	// Connector method.
+	WebhookDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+
 	// --- Pause/Resume/Snapshot (real in v0.8.18) ---
 	//
 	// Wire shapes finalised v0.8.15. Real implementations landed in

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -87,10 +87,14 @@ A shared front-half runs for every request, then forks on `delivery`:
    from the body). Unknown or disabled → opaque `404`.
 2. **Read** the raw body under `body_size_limit_bytes` (default 1 MiB).
 3. **Verify the signature over the raw bytes, before any parsing.**
-   HMAC-SHA256 with a constant-time compare. Two envelopes auto-detected:
-   Stripe (`X-Loomcycle-Signature: t=<unix>,v1=<hex>`, signs `<t>.<body>`,
-   ±5-minute window) and GitHub (`X-Hub-Signature-256: sha256=<hex>`, signs
-   the body). Bearer fallback for systems that can't sign.
+   HMAC-SHA256 with a constant-time compare. Three envelopes auto-detected
+   from the header *value* (so a custom header name still parses):
+   - **Stripe** — `t=<unix>,v1=<hex>`, signs `<t>.<body>`, ±5-minute window
+     (default header `X-Loomcycle-Signature`).
+   - **GitHub** — `sha256=<hex>`, signs the body.
+   - **bare hex** — the whole value is the hex MAC over the body, no prefix
+     (Linear and many custom sources).
+   Plus a **bearer** fallback (`kind: bearer`) for systems that can't sign.
 4. **Replay/dedup** (Layer 1, in-memory, per `delivery_id`) + **idempotency**
    (Layer 2, durable `runs.idempotency_key`) so a re-delivered event lands
    on the same run instead of spawning twice.
@@ -104,17 +108,61 @@ A shared front-half runs for every request, then forks on `delivery`:
    external, attacker-influenceable input) and run it; channel → publish +
    notify.
 
-## Auth, secrets, credentials
+## The signing secret
 
-- `signing_secret_env` / `bearer_token_env` name an env var that must be on
-  the allowlist; a missing/unresolvable secret **fails loud** (`503
-  secret_unresolvable`, naming the env var — never its value).
-- **spawn** credentials: `user_credentials_from_env` (env-allowlisted,
-  operator-owned) merged with `payload_mapping` targets under
-  `user_credentials.<name>` (per-event tokens; the payload value wins). They
-  land on the run's `${run.credentials.<name>}` substitution seam (RFC F).
-- **channel** mode carries **no** credentials (a publish has no run identity)
-  — declaring them on a channel Def is refused at create time.
+`signing_secret_env` (HMAC) / `bearer_token_env` (bearer) name an env var
+that must be on the operator's env allowlist (the **same**
+`LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST` the scheduler uses — it is the shared
+trigger-credential gate). A missing or unresolvable secret **fails loud**:
+`503 secret_unresolvable`, naming the env var — never its value. Rotate by
+changing the env var and reloading; no plaintext secret ever lives in a Def.
+
+## MCP-tool bearer tokens for the spawned run (same as schedulers)
+
+A webhook-triggered **spawn** run is autonomous run creation from a
+non-interactive source — exactly like a scheduled run — so it wires
+MCP-tool bearers through the **same first-class field and the same resolver
+as `ScheduleDef`**: `user_credentials_from_env`. There are two sources, and
+both land on the run's `UserCredentials` map, which the MCP HTTP transport
+substitutes into `${run.credentials.<name>}` in your `mcp_servers.*.headers`
+(the RFC F seam) — so a webhook-spawned agent calls your authorized MCP
+servers with per-user/service bearers, just as scheduled and interactive
+runs do.
+
+1. **`user_credentials_from_env`** — operator-owned, static, env-allowlist-
+   gated. The value of each entry is an env-var NAME (validated
+   `[A-Z][A-Z0-9_]*`), never a literal secret. This is the **identical
+   field, identical semantics** as `ScheduleDef.user_credentials_from_env`.
+   ```yaml
+   user_credentials_from_env:
+     github: "LOOMCYCLE_GITHUB_PR_REVIEW_TOKEN"   # → ${run.credentials.github}
+     slack:  "LOOMCYCLE_SLACK_BOT_TOKEN"          # → ${run.credentials.slack}
+   ```
+2. **`payload_mapping` → `user_credentials.<name>`** — the webhook-specific
+   addition: a *per-event* token projected from the inbound (verified) body,
+   e.g. a GitHub App installation token. The payload value **overlays** (and
+   wins over) the env-resolved one for the same key; an absent path does not
+   clobber the env fallback.
+   ```yaml
+   payload_mapping:
+     user_credentials.github: "$.installation.access_token.value"
+   ```
+
+Then reference them in the MCP server config exactly as any other run does:
+```yaml
+mcp_servers:
+  github:
+    transport: http
+    url: "https://api.githubcopilot.com/mcp/"
+    headers:
+      Authorization: "Bearer ${run.credentials.github}"
+```
+
+**Channel-delivery** webhooks carry **no** credentials — a channel publish
+has no run identity to attach per-user bearers to, and accepting them would
+leak a secret onto the message bus. `user_credentials_from_env` (and any
+`payload_mapping` `user_credentials.*` target) is **refused at create time**
+for `delivery: channel` (RFC H Decision 11).
 
 ## Response policy
 
@@ -151,6 +199,156 @@ Two bearer-authed endpoints help debug a webhook that's silently failing
 - `POST /v1/_webhooks/{name}/test` — dry-run: POST a sample body + signature
   and get back `{would_accept, verdict, run_input_preview}` (credential
   **key names** only, never values). No run is created.
+
+## Provider recipes
+
+Copy-paste starting points for well-known sources. Each shows the
+`WebhookDef` (the `op: create` body is the same object under `"op":"create",
+"name":"…"`), the env vars to set, and where the provider's secret comes
+from. All are verified against the receiver's signature handling.
+
+### GitHub — PR opened → review it (spawn)
+
+GitHub signs the raw body HMAC-SHA256 as `X-Hub-Signature-256: sha256=…`,
+with a unique `X-GitHub-Delivery` id. Carry the org's GitHub MCP bearer from
+the operator env, and (optionally) overlay the per-event App installation
+token from the payload.
+
+```yaml
+webhooks:
+  github-pr-review:
+    enabled: true
+    delivery: spawn
+    agent: pr-review-agent
+    auth:
+      kind: hmac
+      header: "X-Hub-Signature-256"
+      signing_secret_env: "LOOMCYCLE_GITHUB_WEBHOOK_SECRET"
+      delivery_id_header: "X-GitHub-Delivery"
+    user_credentials_from_env:
+      github: "LOOMCYCLE_GITHUB_TOKEN"            # → ${run.credentials.github}
+    payload_mapping:
+      goal:    "$.pull_request.title"
+      user_id: "$.sender.login"
+      user_credentials.github: "$.installation.access_token.value"  # per-event token wins
+```
+GitHub repo settings → Webhooks → Secret = `LOOMCYCLE_GITHUB_WEBHOOK_SECRET`;
+content type `application/json`.
+
+### Stripe — payment event (spawn or channel)
+
+Stripe's `Stripe-Signature: t=…,v1=…` signs `<t>.<body>` (the receiver's
+default envelope). Stripe sends no delivery-id header, so omit
+`delivery_id_header` — the body-hash fallback dedups identical events (each
+event's unique `id` is in the body).
+
+```yaml
+webhooks:
+  stripe-payment:
+    enabled: true
+    delivery: spawn
+    agent: billing-agent
+    auth:
+      kind: hmac
+      header: "Stripe-Signature"
+      signing_secret_env: "LOOMCYCLE_STRIPE_WEBHOOK_SECRET"   # whsec_…
+    payload_mapping:
+      goal: "$.type"                  # e.g. "invoice.payment_failed"
+      run_metadata.event_id: "$.id"
+```
+
+### Linear — issue created (spawn)
+
+Linear sends a bare hex HMAC-SHA256 of the body in `Linear-Signature` (no
+prefix, no timestamp — the bare-hex envelope).
+
+```yaml
+webhooks:
+  linear-issue:
+    enabled: true
+    delivery: spawn
+    agent: triage-agent
+    auth:
+      kind: hmac
+      header: "Linear-Signature"
+      signing_secret_env: "LOOMCYCLE_LINEAR_WEBHOOK_SECRET"
+    payload_mapping:
+      goal:    "$.data.title"
+      user_id: "$.data.creator.email"
+```
+
+### GitLab — merge request (spawn, shared-secret token)
+
+GitLab does not sign; it sends a raw shared secret in `X-Gitlab-Token`. Use
+`kind: bearer` with `header:` set so the receiver compares that header's raw
+value constant-time.
+
+```yaml
+webhooks:
+  gitlab-mr:
+    enabled: true
+    delivery: spawn
+    agent: mr-review-agent
+    auth:
+      kind: bearer
+      header: "X-Gitlab-Token"
+      bearer_token_env: "LOOMCYCLE_GITLAB_WEBHOOK_TOKEN"
+    payload_mapping:
+      goal:    "$.object_attributes.title"
+      user_id: "$.user.username"
+```
+
+### Generic / internal service or n8n (bearer, Authorization)
+
+Any source that can send `Authorization: Bearer <token>` (n8n, Zapier, an
+internal service). Omit `header:` for the standard Authorization shape.
+
+```yaml
+webhooks:
+  internal-event:
+    enabled: true
+    delivery: spawn
+    agent: ops-agent
+    auth:
+      kind: bearer
+      bearer_token_env: "LOOMCYCLE_INTERNAL_WEBHOOK_TOKEN"
+    payload_mapping:
+      goal: "$.message"
+```
+
+### CI build done → wake a waiting agent (channel)
+
+An agent parked on `Channel.subscribe("_system/webhook.ci-build-done")` is
+woken when the build callback arrives. No run, no credentials.
+
+```yaml
+webhooks:
+  ci-build-done:
+    enabled: true
+    delivery: channel
+    channel: "_system/webhook.ci-build-done"
+    auth:
+      kind: hmac
+      signing_secret_env: "LOOMCYCLE_CI_WEBHOOK_SECRET"   # default X-Loomcycle-Signature envelope
+      delivery_id_header: "X-Delivery-Id"
+    payload_mapping:
+      build_id: "$.build.id"
+      status:   "$.build.status"
+```
+
+### Signature schemes — supported vs not yet
+
+Supported today: HMAC-SHA256 over the raw body as **`sha256=<hex>`**
+(GitHub), **`t=,v1=<hex>`** over `<t>.<body>` (Stripe), **bare `<hex>`**
+(Linear and custom sources), and a **shared-secret bearer** (in
+`Authorization` or a custom header — GitLab/n8n/Zapier/internal).
+
+Not yet supported (the secret resolves but verification would fail —
+prefer the bearer fallback or an upstream verifier for these until added):
+**base64-encoded** HMAC digests (e.g. Shopify's `X-Shopify-Hmac-Sha256`),
+and custom signed-payload constructions that sign more than the raw body or
+`<t>.<body>` (e.g. Slack's `v0:<ts>:<body>` with the timestamp in a separate
+header).
 
 ## Caveats
 

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -1,0 +1,169 @@
+---
+name: input-webhooks
+description: Inbound webhooks (WebhookDef) — let external systems (GitHub, Stripe, Linear, n8n) trigger agent runs or wake parked agents via signed HTTP POST. HMAC-over-raw-body auth, JSONPath payload mapping, spawn vs channel delivery, idempotency, rate limiting, per-run credentials, on_complete hooks, triage endpoints.
+---
+
+# Input webhooks (`WebhookDef`)
+
+An input webhook turns an external HTTP POST into loomcycle work: an
+external system (GitHub, Stripe, Linear, a CI server, n8n cloud) signs and
+POSTs an event, and loomcycle either **spawns an agent run** (`delivery:
+spawn`) or **publishes to a channel** to wake an agent already waiting on a
+callback (`delivery: channel`). `WebhookDef` is the fifth substrate
+primitive, alongside AgentDef / SkillDef / MCPServerDef / ScheduleDef.
+
+## Why a substrate primitive, not glue code
+
+Without this, every operator writes the same receiver: decode the GitHub
+payload, verify `X-Hub-Signature-256` against a per-route secret, reshape
+the body into a run request, POST it to `/v1/runs` with the operator's
+bearer. That glue moves credential handling *out* of the substrate (where
+the env-allowlist gate is the trust boundary) into bespoke code, and it is
+re-implemented per source.
+
+`WebhookDef` makes inbound triggers a first-class, versioned, signed-by-
+default primitive — the same content-addressed CRUD as the other Defs, so
+the operator mental model stays symmetric. Scheduled runs (ScheduleDef) and
+webhook-triggered runs are the two halves of one problem — autonomous run
+creation from a non-interactive source; the trigger shape (cron tick vs.
+HTTP POST) is the only difference.
+
+This is the **inbound** direction. For loomcycle calling *out* to your
+service during a run, see the `hooks` topic (tool-use webhooks). For
+loomcycle as an A2A peer, see `a2a-integration`.
+
+## Enabling
+
+Off by default. Set `LOOMCYCLE_WEBHOOKS_ENABLED=1`; the receiver mounts at
+`POST /v1/_webhooks/{name}`. Signing secrets + per-run credentials resolve
+through the **same env-allowlist** the scheduler uses
+(`LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`) — a value not on the allowlist is
+never read.
+
+## Defining a webhook
+
+`WebhookDef` is a 5-op substrate tool (`create`/`fork`/`get`/`list`/
+`retire`) with 4-transport admin (HTTP `POST /v1/_webhookdef`, gRPC, MCP
+meta-tool, TS `webhookDef()`), or a static `webhooks:` yaml block.
+
+```yaml
+webhooks:
+  # spawn mode (default): trigger a fresh agent run
+  github-pr-review:
+    enabled: true
+    delivery: spawn
+    agent: pr-review-agent
+    auth:
+      kind: hmac                      # hmac (default) | bearer
+      header: "X-Hub-Signature-256"   # default X-Loomcycle-Signature (Stripe shape)
+      signing_secret_env: "LOOMCYCLE_GITHUB_PR_REVIEW_SECRET"
+      delivery_id_header: "X-GitHub-Delivery"
+    rate_limit: { requests_per_minute: 60, burst: 10 }
+    body_size_limit_bytes: 1048576
+    user_credentials_from_env:        # operator-owned MCP bearers (env-allowlisted)
+      github: "LOOMCYCLE_GITHUB_PR_REVIEW_TOKEN"
+    payload_mapping:
+      goal: "$.pull_request.title"
+      user_id: "$.sender.login"
+      user_credentials.github: "$.installation.access_token.value"  # per-event token; payload wins
+    sync_response: { enabled: false, timeout_ms: 30000 }
+    on_complete:
+      - { kind: channel.publish, channel: "_system/pr-reviews", payload: { text: "reviewed" } }
+
+  # channel mode: wake an agent parked on Channel.subscribe (no run, no creds)
+  ci-build-done:
+    enabled: true
+    delivery: channel
+    channel: "_system/webhook.ci-build-done"
+    auth: { kind: hmac, signing_secret_env: "LOOMCYCLE_CI_WEBHOOK_SECRET", delivery_id_header: "X-Delivery-Id" }
+    payload_mapping: { build_id: "$.build.id", status: "$.build.status" }
+```
+
+## How a request is processed
+
+A shared front-half runs for every request, then forks on `delivery`:
+
+1. **Resolve** the active `WebhookDef` by the `{name}` in the URL (never
+   from the body). Unknown or disabled → opaque `404`.
+2. **Read** the raw body under `body_size_limit_bytes` (default 1 MiB).
+3. **Verify the signature over the raw bytes, before any parsing.**
+   HMAC-SHA256 with a constant-time compare. Two envelopes auto-detected:
+   Stripe (`X-Loomcycle-Signature: t=<unix>,v1=<hex>`, signs `<t>.<body>`,
+   ±5-minute window) and GitHub (`X-Hub-Signature-256: sha256=<hex>`, signs
+   the body). Bearer fallback for systems that can't sign.
+4. **Replay/dedup** (Layer 1, in-memory, per `delivery_id`) + **idempotency**
+   (Layer 2, durable `runs.idempotency_key`) so a re-delivered event lands
+   on the same run instead of spawning twice.
+5. **Project** the payload via the Def's `payload_mapping` (strict JSONPath
+   subset: `$.a.b`, `$.a[0]` — no wildcards/filters/recursion). An absent
+   path resolves to empty + a tracing note, never a failure.
+6. **Rate limit** (per-Def token bucket) → `429` + `Retry-After` when
+   exceeded.
+7. **Deliver**: spawn → build a RunInput (the mapped `goal` enters as an
+   **untrusted-block**, fenced in `<untrusted>` tags — a webhook payload is
+   external, attacker-influenceable input) and run it; channel → publish +
+   notify.
+
+## Auth, secrets, credentials
+
+- `signing_secret_env` / `bearer_token_env` name an env var that must be on
+  the allowlist; a missing/unresolvable secret **fails loud** (`503
+  secret_unresolvable`, naming the env var — never its value).
+- **spawn** credentials: `user_credentials_from_env` (env-allowlisted,
+  operator-owned) merged with `payload_mapping` targets under
+  `user_credentials.<name>` (per-event tokens; the payload value wins). They
+  land on the run's `${run.credentials.<name>}` substitution seam (RFC F).
+- **channel** mode carries **no** credentials (a publish has no run identity)
+  — declaring them on a channel Def is refused at create time.
+
+## Response policy
+
+`202 Accepted` with `{run_id, webhook_name, delivery_id}` (async, the
+default). `?sync=true` (when the Def's `sync_response.enabled`) blocks on the
+run-state bus until the run reaches a terminal state — `200` with the
+status, or `504` on `sync_timeout_ms`. Channel mode returns `202`.
+
+## Never silently degrade
+
+Every failure mode is loud and distinct: `404` unknown/disabled (opaque, no
+enumeration), `401` any auth/replay failure (no body detail — no oracle),
+`503 secret_unresolvable`, `400` malformed body/mapping, `429` rate limit,
+`503` runtime unavailable. A rate-limited or rejected delivery does **not**
+burn its `delivery_id`, so the sender's retry is processed rather than
+dropped as a replay.
+
+## on_complete
+
+Spawn-delivery webhooks may declare `on_complete` hooks that fire after the
+run finishes: `channel.publish` and `memory.set` are wired; `mcp.call` is
+reserved (logged + skipped until an MCP caller is wired, same as the
+scheduler). A hook failure is logged and never affects the run.
+
+## Triage (admin-gated)
+
+Two bearer-authed endpoints help debug a webhook that's silently failing
+(the receiver POST itself is unauthed — it uses the per-Def secret):
+
+- `GET /v1/_webhooks/{name}/recent-deliveries?limit=50` — the last N
+  invocations with `delivery_id`, `verdict`
+  (`accepted`/`rejected_sig`/`rejected_replay`/`rejected_rate`/
+  `unresolvable_secret`/…), `received_at`, `run_id`.
+- `POST /v1/_webhooks/{name}/test` — dry-run: POST a sample body + signature
+  and get back `{would_accept, verdict, run_input_preview}` (credential
+  **key names** only, never values). No run is created.
+
+## Caveats
+
+- **Single-replica v1.** The Layer-1 dedup cache + rate-limit buckets are
+  per-replica; the durable `runs.idempotency_key` (Layer 2) is the
+  cross-replica backstop for spawn mode. Cluster-wide dedup/rate-limit is a
+  later concern.
+- **Not a DDoS shield.** Signature verification is cheap and the body is
+  size-capped, but front-line flood protection belongs at your ingress; the
+  per-Def rate limit caps *accepted* invocations (runtime protection), not
+  unauthenticated noise.
+
+**Bottom line:** `WebhookDef` is the signed-by-default front door for
+external events — one substrate shape for "an outside system wants to start
+(or wake) an agent," with the verify-before-parse, fail-loud, retry-safe
+discipline a trust boundary needs.

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -31,6 +31,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		"fan-out-patterns",
 		"getting-started",
 		"hooks",
+		"input-webhooks",
 		"installation",
 		"interruption",
 		"llm-gateway",

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -14,6 +14,12 @@ import (
 // WebhookDef substrate.
 type WebhookStore interface {
 	WebhookDefGetActive(ctx context.Context, name string) (store.WebhookDefRow, error)
+
+	// RunByIdempotencyKey backs RFC H Decision 10 "Layer 2" durable
+	// dedup in the receiver: before spawning, it looks up whether a run
+	// already exists for this delivery id (the idempotency key). ok=false
+	// means no prior run — proceed with the spawn.
+	RunByIdempotencyKey(ctx context.Context, key string) (store.Run, bool, error)
 }
 
 // Webhook resolves a webhook NAME to its effective config.Webhook by

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -53,10 +53,11 @@ func Webhook(ctx context.Context, s WebhookStore, cfg *config.Config, name strin
 // The runtime consumer (`config.Webhook`) carries yaml tags for the
 // operator-yaml path; this adapter is the substrate-read seam.
 //
-// Kept in sync with `mergedWebhookDef`; a drift test in the builtin
-// package pins parity. WH-2: the tool-layer `mergedWebhookDef` does not
-// exist yet (later slice), so the parity assertion here is against an
-// explicit expected field-set in webhook_test.go.
+// Kept in sync with `mergedWebhookDef`; the builtin-package drift test
+// TestMergedWebhookDef_DriftDetection_VsLookupSubstrate pins
+// merged↔substrate parity. The complementary assertion here
+// (webhook_test.go TestWebhook_DriftDetection) pins this shape against
+// an explicit expected field-set, mirroring the A2AAgentDef resolver.
 type SubstrateWebhookDef struct {
 	Enabled                bool                      `json:"enabled,omitempty"`
 	Delivery               string                    `json:"delivery,omitempty"`

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -1,0 +1,129 @@
+package lookup
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// WebhookStore is the subset of store.Store the webhook resolver uses.
+// Declared here so tests + callers can mock without depending on the
+// full store interface. Mirrors A2AAgentStore for the v1.x RFC H
+// WebhookDef substrate.
+type WebhookStore interface {
+	WebhookDefGetActive(ctx context.Context, name string) (store.WebhookDefRow, error)
+}
+
+// Webhook resolves a webhook NAME to its effective config.Webhook by
+// walking the lookup chain in precedence order:
+//
+//  1. static cfg.Webhooks (yaml-defined, pre-validated at boot)
+//  2. webhook_def_active + webhook_defs (substrate path)
+//
+// Returns (zero, false) when no source has the name. Malformed
+// persistence JSON also returns (zero, false) — defensive against
+// future-field churn or hand-edited rows.
+//
+// Mirrors lookup.A2AAgent for the v1.x RFC H WebhookDef substrate.
+func Webhook(ctx context.Context, s WebhookStore, cfg *config.Config, name string) (config.Webhook, bool) {
+	if cfg != nil {
+		if w, ok := cfg.Webhooks[name]; ok {
+			return w, true
+		}
+	}
+	if s == nil {
+		return config.Webhook{}, false
+	}
+	activeRow, err := s.WebhookDefGetActive(ctx, name)
+	if err != nil {
+		return config.Webhook{}, false
+	}
+	var wd SubstrateWebhookDef
+	if uerr := json.Unmarshal(activeRow.Definition, &wd); uerr != nil {
+		return config.Webhook{}, false
+	}
+	return wd.ToConfigDef(), true
+}
+
+// SubstrateWebhookDef mirrors the JSON shape `WebhookDef` create/fork
+// persists in `webhook_defs.definition` (snake_case JSON tags via the
+// `mergedWebhookDef` adapter in internal/tools/builtin/webhookdef.go).
+// The runtime consumer (`config.Webhook`) carries yaml tags for the
+// operator-yaml path; this adapter is the substrate-read seam.
+//
+// Kept in sync with `mergedWebhookDef`; a drift test in the builtin
+// package pins parity. WH-2: the tool-layer `mergedWebhookDef` does not
+// exist yet (later slice), so the parity assertion here is against an
+// explicit expected field-set in webhook_test.go.
+type SubstrateWebhookDef struct {
+	Enabled                bool                      `json:"enabled,omitempty"`
+	Delivery               string                    `json:"delivery,omitempty"`
+	Agent                  string                    `json:"agent,omitempty"`
+	Channel                string                    `json:"channel,omitempty"`
+	Auth                   SubstrateWebhookAuth      `json:"auth,omitempty"`
+	RateLimit              SubstrateWebhookRateLimit `json:"rate_limit,omitempty"`
+	BodySizeLimitBytes     int                       `json:"body_size_limit_bytes,omitempty"`
+	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
+	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
+	SyncResponse           SubstrateWebhookSyncResp  `json:"sync_response,omitempty"`
+	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
+}
+
+// SubstrateWebhookAuth mirrors config.WebhookAuth.
+type SubstrateWebhookAuth struct {
+	Kind             string `json:"kind,omitempty"`
+	Algorithm        string `json:"algorithm,omitempty"`
+	Header           string `json:"header,omitempty"`
+	SigningSecretEnv string `json:"signing_secret_env,omitempty"`
+	DeliveryIDHeader string `json:"delivery_id_header,omitempty"`
+	BearerTokenEnv   string `json:"bearer_token_env,omitempty"`
+}
+
+// SubstrateWebhookRateLimit mirrors config.WebhookRateLimit.
+type SubstrateWebhookRateLimit struct {
+	RequestsPerMinute int `json:"requests_per_minute,omitempty"`
+	Burst             int `json:"burst,omitempty"`
+}
+
+// SubstrateWebhookSyncResp mirrors config.WebhookSyncResponse.
+type SubstrateWebhookSyncResp struct {
+	Enabled   bool `json:"enabled,omitempty"`
+	TimeoutMs int  `json:"timeout_ms,omitempty"`
+}
+
+// ToConfigDef projects the substrate JSON shape onto config.Webhook for
+// the runtime to consume. Pure data shuffling.
+//
+// OnComplete is config.ScheduledRunHook on BOTH sides (the substrate
+// shape reuses ScheduleDef's hook type per RFC H), so the slice is
+// copied by reference — no field-by-field projection needed.
+func (s SubstrateWebhookDef) ToConfigDef() config.Webhook {
+	return config.Webhook{
+		Enabled:  s.Enabled,
+		Delivery: s.Delivery,
+		Agent:    s.Agent,
+		Channel:  s.Channel,
+		Auth: config.WebhookAuth{
+			Kind:             s.Auth.Kind,
+			Algorithm:        s.Auth.Algorithm,
+			Header:           s.Auth.Header,
+			SigningSecretEnv: s.Auth.SigningSecretEnv,
+			DeliveryIDHeader: s.Auth.DeliveryIDHeader,
+			BearerTokenEnv:   s.Auth.BearerTokenEnv,
+		},
+		RateLimit: config.WebhookRateLimit{
+			RequestsPerMinute: s.RateLimit.RequestsPerMinute,
+			Burst:             s.RateLimit.Burst,
+		},
+		BodySizeLimitBytes:     s.BodySizeLimitBytes,
+		UserCredentialsFromEnv: s.UserCredentialsFromEnv,
+		PayloadMapping:         s.PayloadMapping,
+		SyncResponse: config.WebhookSyncResponse{
+			Enabled:   s.SyncResponse.Enabled,
+			TimeoutMs: s.SyncResponse.TimeoutMs,
+		},
+		OnComplete: s.OnComplete,
+	}
+}

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -3,6 +3,7 @@ package lookup
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -20,6 +21,14 @@ type WebhookStore interface {
 	// already exists for this delivery id (the idempotency key). ok=false
 	// means no prior run — proceed with the spawn.
 	RunByIdempotencyKey(ctx context.Context, key string) (store.Run, bool, error)
+
+	// ChannelPublish + MemorySet back the WH-5b on_complete hooks (the
+	// receiver MIRRORS the scheduler's dispatch rather than importing it).
+	// Signatures match store.Store exactly so store.Store satisfies this
+	// interface unchanged; the webhook receiver only needs these two of
+	// the channel/memory surface.
+	ChannelPublish(ctx context.Context, msg store.ChannelMessage, maxMessages int) (id string, dropped int, err error)
+	MemorySet(ctx context.Context, scope store.MemoryScope, scopeID, key string, value json.RawMessage, ttl time.Duration) error
 }
 
 // Webhook resolves a webhook NAME to its effective config.Webhook by

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -114,10 +114,11 @@ func TestWebhook_StaticBeforeSubstrate(t *testing.T) {
 // against an explicit `want` enumeration. A field added to or removed
 // from SubstrateWebhookDef without updating this map fails CI.
 //
-// WH-2: the complementary direction (mergedWebhookDef ↔
-// SubstrateWebhookDef) lives in the builtin package and does not exist
-// yet — the tool layer is a later slice. Until then this `want` map is
-// the canonical field-set the merged shape must match.
+// The complementary direction (mergedWebhookDef ↔ SubstrateWebhookDef)
+// lives in the builtin package (WH-2:
+// TestMergedWebhookDef_DriftDetection_VsLookupSubstrate). This `want`
+// map is the canonical field-set both the substrate-read shape here and
+// the substrate-write `mergedWebhookDef` must match.
 func TestWebhook_DriftDetection(t *testing.T) {
 	want := map[string]bool{
 		"enabled":                   true,

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -35,6 +35,17 @@ func (s *stubWebhookStore) RunByIdempotencyKey(_ context.Context, _ string) (sto
 	return store.Run{}, false, nil
 }
 
+// ChannelPublish + MemorySet satisfy lookup.WebhookStore (WH-5b
+// on_complete hooks). The resolver tests never fire hooks, so no-ops
+// suffice.
+func (s *stubWebhookStore) ChannelPublish(_ context.Context, _ store.ChannelMessage, _ int) (string, int, error) {
+	return "", 0, nil
+}
+
+func (s *stubWebhookStore) MemorySet(_ context.Context, _ store.MemoryScope, _, _ string, _ json.RawMessage, _ time.Duration) error {
+	return nil
+}
+
 func TestWebhook_EquivalenceYamlVsSubstrate(t *testing.T) {
 	yamlHook := config.Webhook{
 		Enabled:  true,

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -29,6 +29,12 @@ func (s *stubWebhookStore) WebhookDefGetActive(_ context.Context, name string) (
 	return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def_active", ID: name}
 }
 
+// RunByIdempotencyKey satisfies lookup.WebhookStore (RFC H Decision 10).
+// The resolver tests never exercise dedup, so a constant miss suffices.
+func (s *stubWebhookStore) RunByIdempotencyKey(_ context.Context, _ string) (store.Run, bool, error) {
+	return store.Run{}, false, nil
+}
+
 func TestWebhook_EquivalenceYamlVsSubstrate(t *testing.T) {
 	yamlHook := config.Webhook{
 		Enabled:  true,

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -1,0 +1,137 @@
+package lookup_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// ---- WebhookDef resolver ----
+//
+// Mirrors the A2AAgentDef resolver tests (a2a_test.go). Reuses the
+// a2aJSONTagsOf + assertTagSetsEqual helpers from that file (same
+// lookup_test package).
+
+type stubWebhookStore struct {
+	defs map[string]store.WebhookDefRow
+}
+
+func (s *stubWebhookStore) WebhookDefGetActive(_ context.Context, name string) (store.WebhookDefRow, error) {
+	if row, ok := s.defs[name]; ok {
+		return row, nil
+	}
+	return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def_active", ID: name}
+}
+
+func TestWebhook_EquivalenceYamlVsSubstrate(t *testing.T) {
+	yamlHook := config.Webhook{
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "intake",
+		Auth: config.WebhookAuth{
+			Kind:             "hmac",
+			Algorithm:        "sha256",
+			Header:           "X-Hub-Signature-256",
+			SigningSecretEnv: "LOOMCYCLE_WH_SECRET",
+			DeliveryIDHeader: "X-Delivery-ID",
+		},
+		RateLimit:              config.WebhookRateLimit{RequestsPerMinute: 60, Burst: 10},
+		BodySizeLimitBytes:     1 << 20,
+		UserCredentialsFromEnv: map[string]string{"peer-token": "LOOMCYCLE_PEER_TOKEN"},
+		PayloadMapping:         map[string]string{"action": "$.action"},
+		SyncResponse:           config.WebhookSyncResponse{Enabled: true, TimeoutMs: 30000},
+		OnComplete: []config.ScheduledRunHook{
+			{Kind: "channel.publish", Channel: "_system/webhooks"},
+		},
+	}
+
+	substrateShape := lookup.SubstrateWebhookDef{
+		Enabled:  yamlHook.Enabled,
+		Delivery: yamlHook.Delivery,
+		Agent:    yamlHook.Agent,
+		Auth: lookup.SubstrateWebhookAuth{
+			Kind:             "hmac",
+			Algorithm:        "sha256",
+			Header:           "X-Hub-Signature-256",
+			SigningSecretEnv: "LOOMCYCLE_WH_SECRET",
+			DeliveryIDHeader: "X-Delivery-ID",
+		},
+		RateLimit:              lookup.SubstrateWebhookRateLimit{RequestsPerMinute: 60, Burst: 10},
+		BodySizeLimitBytes:     1 << 20,
+		UserCredentialsFromEnv: map[string]string{"peer-token": "LOOMCYCLE_PEER_TOKEN"},
+		PayloadMapping:         map[string]string{"action": "$.action"},
+		SyncResponse:           lookup.SubstrateWebhookSyncResp{Enabled: true, TimeoutMs: 30000},
+		OnComplete: []config.ScheduledRunHook{
+			{Kind: "channel.publish", Channel: "_system/webhooks"},
+		},
+	}
+	defJSON, err := json.Marshal(substrateShape)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	ss := &stubWebhookStore{
+		defs: map[string]store.WebhookDefRow{
+			"gh-push": {DefID: "wh_v1", Name: "gh-push", Version: 1, Definition: defJSON, CreatedAt: time.Now()},
+		},
+	}
+	resolved, ok := lookup.Webhook(context.Background(), ss, &config.Config{}, "gh-push")
+	if !ok {
+		t.Fatal("resolver returned !ok")
+	}
+	if !reflect.DeepEqual(resolved, yamlHook) {
+		t.Errorf("substrate-resolved webhook != yaml webhook:\n got %+v\nwant %+v", resolved, yamlHook)
+	}
+}
+
+func TestWebhook_StaticBeforeSubstrate(t *testing.T) {
+	cfg := &config.Config{
+		Webhooks: map[string]config.Webhook{
+			"hook": {Delivery: "spawn", Agent: "yaml-agent"},
+		},
+	}
+	ss := &stubWebhookStore{
+		defs: map[string]store.WebhookDefRow{
+			"hook": {DefID: "wh_v1", Name: "hook", Definition: json.RawMessage(`{"delivery":"spawn","agent":"substrate-agent"}`)},
+		},
+	}
+	got, ok := lookup.Webhook(context.Background(), ss, cfg, "hook")
+	if !ok {
+		t.Fatal("resolver returned !ok")
+	}
+	if got.Agent != "yaml-agent" {
+		t.Errorf("Agent = %q, want yaml-agent (static must win)", got.Agent)
+	}
+}
+
+// TestWebhook_DriftDetection pins the SubstrateWebhookDef field set
+// against an explicit `want` enumeration. A field added to or removed
+// from SubstrateWebhookDef without updating this map fails CI.
+//
+// WH-2: the complementary direction (mergedWebhookDef ↔
+// SubstrateWebhookDef) lives in the builtin package and does not exist
+// yet — the tool layer is a later slice. Until then this `want` map is
+// the canonical field-set the merged shape must match.
+func TestWebhook_DriftDetection(t *testing.T) {
+	want := map[string]bool{
+		"enabled":                   true,
+		"delivery":                  true,
+		"agent":                     true,
+		"channel":                   true,
+		"auth":                      true,
+		"rate_limit":                true,
+		"body_size_limit_bytes":     true,
+		"user_credentials_from_env": true,
+		"payload_mapping":           true,
+		"sync_response":             true,
+		"on_complete":               true,
+	}
+	have := a2aJSONTagsOf(reflect.TypeOf(lookup.SubstrateWebhookDef{}))
+	assertTagSetsEqual(t, "SubstrateWebhookDef", want, have)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -194,6 +194,15 @@ type RunInput struct {
 	// tools, connector, store — can reference it without an import
 	// cycle (store imports no internal packages).
 	ParentContext *store.ParentContext
+
+	// IdempotencyKey is the optional RFC H Decision 10 "Layer 2"
+	// durable dedup key. Empty (the default) for interactive runs. Set
+	// by the webhook spawn path to the delivery id; threaded into
+	// RunIdentity so CreateRun persists it to runs.idempotency_key. When
+	// a second run carries a key already claimed, CreateRun returns
+	// store.ErrDuplicateIdempotencyKey and RunOnce aborts BEFORE the
+	// agent loop, so the run never double-executes.
+	IdempotencyKey string
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/store/postgres/migrations/0032_webhook_defs.down.sql
+++ b/internal/store/postgres/migrations/0032_webhook_defs.down.sql
@@ -1,0 +1,3 @@
+-- 0032_webhook_defs.down.sql — drop the RFC H webhook tables.
+DROP TABLE IF EXISTS webhook_def_active;
+DROP TABLE IF EXISTS webhook_defs;

--- a/internal/store/postgres/migrations/0032_webhook_defs.up.sql
+++ b/internal/store/postgres/migrations/0032_webhook_defs.up.sql
@@ -1,0 +1,41 @@
+-- 0032_webhook_defs.up.sql — v1.x RFC H Input Webhooks storage.
+--
+-- A single content-addressed substrate Def with the same dual-table
+-- shape as a2a_agent_defs / a2a_agent_def_active (0031) — minus the
+-- sweeper-only run_state table, which was scheduler-specific.
+--
+-- webhook_defs declares an inbound HTTP webhook endpoint: the auth
+-- scheme (hmac or bearer) + signing-secret env ref, rate limit,
+-- delivery target (spawn an agent or publish to a channel), payload
+-- mapping, and on_complete hooks.
+--
+-- definition is JSONB so future ops (find-similar-forks, etc.) can use
+-- @> operators without a migration. Same shape A2AAgentDef uses. The
+-- payload schema is owned by the tool layer (internal/tools/builtin);
+-- the store treats it as opaque JSON.
+
+CREATE TABLE webhook_defs (
+    def_id                    TEXT        PRIMARY KEY,
+    name                      TEXT        NOT NULL,
+    version                   INTEGER     NOT NULL,
+    parent_def_id             TEXT        REFERENCES webhook_defs(def_id),
+    definition                JSONB       NOT NULL,
+    description               TEXT,
+    created_at                TIMESTAMPTZ NOT NULL,
+    created_by_agent_id       TEXT,
+    created_by_run_id         TEXT,
+    retired                   BOOLEAN     NOT NULL DEFAULT FALSE,
+    bootstrapped_from_static  BOOLEAN     NOT NULL DEFAULT FALSE,
+    UNIQUE(name, version)
+);
+
+CREATE INDEX webhook_defs_by_name   ON webhook_defs(name, version DESC);
+CREATE INDEX webhook_defs_by_parent ON webhook_defs(parent_def_id) WHERE parent_def_id IS NOT NULL;
+CREATE INDEX webhook_defs_by_run    ON webhook_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL;
+
+CREATE TABLE webhook_def_active (
+    name                  TEXT        PRIMARY KEY,
+    def_id                TEXT        NOT NULL REFERENCES webhook_defs(def_id),
+    promoted_at           TIMESTAMPTZ NOT NULL,
+    promoted_by_agent_id  TEXT
+);

--- a/internal/store/postgres/migrations/0033_runs_idempotency_key.down.sql
+++ b/internal/store/postgres/migrations/0033_runs_idempotency_key.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS runs_idempotency_key;
+ALTER TABLE runs DROP COLUMN idempotency_key;

--- a/internal/store/postgres/migrations/0033_runs_idempotency_key.up.sql
+++ b/internal/store/postgres/migrations/0033_runs_idempotency_key.up.sql
@@ -1,0 +1,12 @@
+-- RFC H Decision 10 "Layer 2" durable dedup. A run may carry an
+-- optional idempotency_key; a second CreateRun with the same key is
+-- refused at the unique index rather than spawning a duplicate. The
+-- webhook spawn path sets idempotency_key = delivery_id so a redelivery
+-- that survives past the in-memory Layer-1 TTL — or lands on a different
+-- replica — still dedups durably.
+--
+-- NULLable + a partial unique index (WHERE idempotency_key IS NOT NULL)
+-- so the vast majority of runs (no key) are unconstrained and the index
+-- stays small. Not a secret (the delivery id is opaque, safe to persist).
+ALTER TABLE runs ADD COLUMN idempotency_key TEXT;
+CREATE UNIQUE INDEX runs_idempotency_key ON runs (idempotency_key) WHERE idempotency_key IS NOT NULL;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -4621,6 +4621,236 @@ func (s *Store) scanA2AAgentDefRows(rows pgx.Rows) ([]store.A2AAgentDefRow, erro
 	return out, rows.Err()
 }
 
+// ---- v1.x RFC H WebhookDef substrate ----
+//
+// Mirror of A2AAgentDef* without the sweeper run_state table.
+
+func (s *Store) WebhookDefCreate(ctx context.Context, row store.WebhookDefRow) (store.WebhookDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def: def_id + name required")
+	}
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def create begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"webhook_def:"+row.Name,
+	); err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def create lock: %w", err)
+	}
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM webhook_defs WHERE def_id = $1`, row.ParentDefID).Scan(&n); err != nil {
+			return store.WebhookDefRow{}, fmt.Errorf("webhook_def create parent check: %w", err)
+		}
+		if n == 0 {
+			return store.WebhookDefRow{}, store.ErrWebhookDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM webhook_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def create max version: %w", err)
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now().UTC()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO webhook_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11)`,
+		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
+		string(row.Definition), nullableString(row.Description),
+		row.CreatedAt,
+		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
+		row.Retired, row.BootstrappedFromStatic,
+	); err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def insert: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def commit: %w", err)
+	}
+	return row, nil
+}
+
+func (s *Store) WebhookDefGet(ctx context.Context, defID string) (store.WebhookDefRow, error) {
+	row, err := s.scanWebhookDef(s.pool.QueryRow(ctx, webhookDefSelect+` WHERE def_id = $1`, defID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	return row, err
+}
+
+func (s *Store) WebhookDefGetByNameVersion(ctx context.Context, name string, version int) (store.WebhookDefRow, error) {
+	row, err := s.scanWebhookDef(s.pool.QueryRow(ctx, webhookDefSelect+` WHERE name = $1 AND version = $2`, name, version))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+func (s *Store) WebhookDefListByName(ctx context.Context, name string) ([]store.WebhookDefRow, error) {
+	rows, err := s.pool.Query(ctx, webhookDefSelect+` WHERE name = $1 ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, fmt.Errorf("webhook_def list by name: %w", err)
+	}
+	defer rows.Close()
+	return s.scanWebhookDefRows(rows)
+}
+
+func (s *Store) WebhookDefListChildren(ctx context.Context, parentDefID string) ([]store.WebhookDefRow, error) {
+	rows, err := s.pool.Query(ctx, webhookDefSelect+` WHERE parent_def_id = $1 ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, fmt.Errorf("webhook_def list children: %w", err)
+	}
+	defer rows.Close()
+	return s.scanWebhookDefRows(rows)
+}
+
+func (s *Store) WebhookDefListNames(ctx context.Context) ([]store.WebhookDefNameSummary, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM webhook_defs d
+		LEFT JOIN webhook_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, fmt.Errorf("webhook_def list names: %w", err)
+	}
+	defer rows.Close()
+
+	var out []store.WebhookDefNameSummary
+	for rows.Next() {
+		var ns store.WebhookDefNameSummary
+		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
+			return nil, err
+		}
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) WebhookDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	var rowName string
+	err := s.pool.QueryRow(ctx, `SELECT name FROM webhook_defs WHERE def_id = $1`, defID).Scan(&rowName)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	if err != nil {
+		return fmt.Errorf("webhook_def_active check: %w", err)
+	}
+	if rowName != name {
+		return fmt.Errorf("webhook_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.pool.Exec(ctx, `
+		INSERT INTO webhook_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (name) DO UPDATE SET
+		    def_id               = EXCLUDED.def_id,
+		    promoted_at          = EXCLUDED.promoted_at,
+		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
+		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+	)
+	if err != nil {
+		return fmt.Errorf("webhook_def_active upsert: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) WebhookDefGetActive(ctx context.Context, name string) (store.WebhookDefRow, error) {
+	var defID string
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM webhook_def_active WHERE name = $1`, name).Scan(&defID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def_active", ID: name}
+	}
+	if err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def_active lookup: %w", err)
+	}
+	return s.WebhookDefGet(ctx, defID)
+}
+
+func (s *Store) WebhookDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	tag, err := s.pool.Exec(ctx, `UPDATE webhook_defs SET retired = $1 WHERE def_id = $2`, retired, defID)
+	if err != nil {
+		return fmt.Errorf("webhook_def set retired: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	return nil
+}
+
+const webhookDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition::text,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM webhook_defs`
+
+func (s *Store) scanWebhookDef(row pgx.Row) (store.WebhookDefRow, error) {
+	var (
+		out        store.WebhookDefRow
+		definition string
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&out.CreatedAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&out.Retired, &out.BootstrappedFromStatic,
+	)
+	if err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	return out, nil
+}
+
+func (s *Store) scanWebhookDefRows(rows pgx.Rows) ([]store.WebhookDefRow, error) {
+	var out []store.WebhookDefRow
+	for rows.Next() {
+		var (
+			r          store.WebhookDefRow
+			definition string
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&r.CreatedAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&r.Retired, &r.BootstrappedFromStatic,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // ---- v1.x RFC E ScheduleDef runtime (sweeper-side) ----
 
 func (s *Store) ScheduleRunStateSeed(ctx context.Context, defID string, nextRunAt time.Time) error {

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -297,8 +297,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		_, err := s.pool.Exec(ctx,
 			`INSERT INTO runs (
 				id, session_id, status, started_at,
-				agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, replica_id, parent_context
-			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
+				agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, replica_id, parent_context, idempotency_key
+			) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
 			id, sessionID, string(store.RunRunning), now,
 			nullableText(identity.AgentID),
 			nullableText(identity.ParentAgentID),
@@ -309,25 +309,39 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 			nullableText(identity.Model),
 			nullableText(identity.ReplicaID),
 			pcVal,
+			nullableText(identity.IdempotencyKey),
 		)
 		return err
 	}); err != nil {
+		// RFC H Decision 10: a 23505 unique_violation on the
+		// runs_idempotency_key partial index means an earlier run
+		// already claimed this key — surface the typed sentinel so the
+		// caller dedups. Scope to the idempotency case (key != "" AND
+		// the violation names that constraint) so a future unique
+		// constraint elsewhere on runs is never misreported.
+		var pgErr *pgconn.PgError
+		if identity.IdempotencyKey != "" &&
+			errors.As(err, &pgErr) && pgErr.Code == "23505" &&
+			pgErr.ConstraintName == "runs_idempotency_key" {
+			return store.Run{}, store.ErrDuplicateIdempotencyKey
+		}
 		return store.Run{}, fmt.Errorf("create run: %w", err)
 	}
 	return store.Run{
-		ID:            id,
-		SessionID:     sessionID,
-		Status:        store.RunRunning,
-		StartedAt:     now,
-		AgentID:       identity.AgentID,
-		ParentAgentID: identity.ParentAgentID,
-		ParentRunID:   identity.ParentRunID,
-		UserID:        identity.UserID,
-		UserTier:      identity.UserTier,
-		AgentDefID:    identity.AgentDefID,
-		Model:         identity.Model,
-		ReplicaID:     identity.ReplicaID,
-		ParentContext: identity.ParentContext.Clone(),
+		ID:             id,
+		SessionID:      sessionID,
+		Status:         store.RunRunning,
+		StartedAt:      now,
+		AgentID:        identity.AgentID,
+		ParentAgentID:  identity.ParentAgentID,
+		ParentRunID:    identity.ParentRunID,
+		UserID:         identity.UserID,
+		UserTier:       identity.UserTier,
+		AgentDefID:     identity.AgentDefID,
+		Model:          identity.Model,
+		ReplicaID:      identity.ReplicaID,
+		ParentContext:  identity.ParentContext.Clone(),
+		IdempotencyKey: identity.IdempotencyKey,
 	}, nil
 }
 
@@ -538,7 +552,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
@@ -553,6 +567,35 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 	return r, nil
 }
 
+// RunByIdempotencyKey returns the run created with the given RFC H
+// Decision 10 idempotency key. An empty key short-circuits to
+// (Run{}, false, nil); a key with no matching row returns the same. The
+// runs_idempotency_key partial unique index guarantees at most one
+// match.
+func (s *Store) RunByIdempotencyKey(ctx context.Context, key string) (store.Run, bool, error) {
+	if key == "" {
+		return store.Run{}, false, nil
+	}
+	row := s.pool.QueryRow(ctx,
+		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+		        r.model, r.provider, r.error,
+		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
+		        s.agent
+		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+		 WHERE r.idempotency_key = $1 LIMIT 1`, key,
+	)
+	r, err := scanRun(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return store.Run{}, false, nil
+		}
+		return store.Run{}, false, fmt.Errorf("run by idempotency_key: %w", err)
+	}
+	return r, true, nil
+}
+
 // GetRun returns one row by run_id (the primary key on runs).
 func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 	if runID == "" {
@@ -563,7 +606,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.id = $1`, runID,
@@ -626,7 +669,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1
@@ -637,7 +680,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1 AND r.status = $2
@@ -662,7 +705,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.parent_agent_id = $1
@@ -757,7 +800,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
-		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.pause_state = $1
@@ -5351,6 +5394,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		pauseState                                            *string
 		replicaID                                             *string
 		parentContext                                         *string
+		idempotencyKey                                        *string
 		lastHeartbeatAt                                       *time.Time
 		sessAgent                                             *string
 
@@ -5362,7 +5406,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHeartbeatAt,
 		&userTier,
-		&agentDefID, &pauseState, &replicaID, &parentContext,
+		&agentDefID, &pauseState, &replicaID, &parentContext, &idempotencyKey,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -5417,6 +5461,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 			return store.Run{}, fmt.Errorf("decode parent_context: %w", err)
 		}
 		out.ParentContext = pc
+	}
+	if idempotencyKey != nil {
+		out.IdempotencyKey = *idempotencyKey
 	}
 	if sessAgent != nil {
 		out.Agent = *sessAgent

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -401,6 +401,36 @@ func (s *Store) migrate(ctx context.Context) error {
 			promoted_at           INTEGER NOT NULL,
 			promoted_by_agent_id  TEXT
 		)`,
+		// v1.x RFC H Input Webhooks substrate — a single content-addressed
+		// Def mirroring a2a_agent_defs exactly (identity + lineage +
+		// promotion), minus the sweeper-only run_state table. webhook_defs
+		// declares inbound HTTP webhook endpoints (auth, rate limit,
+		// delivery target, payload mapping). See
+		// internal/store/postgres/migrations/0032_webhook_defs.up.sql for
+		// the full design rationale.
+		`CREATE TABLE IF NOT EXISTS webhook_defs (
+			def_id                    TEXT    PRIMARY KEY,
+			name                      TEXT    NOT NULL,
+			version                   INTEGER NOT NULL,
+			parent_def_id             TEXT    REFERENCES webhook_defs(def_id),
+			definition                TEXT    NOT NULL,
+			description               TEXT,
+			created_at                INTEGER NOT NULL,
+			created_by_agent_id       TEXT,
+			created_by_run_id         TEXT,
+			retired                   INTEGER NOT NULL DEFAULT 0,
+			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+			UNIQUE(name, version)
+		)`,
+		`CREATE INDEX IF NOT EXISTS webhook_defs_by_name   ON webhook_defs(name, version DESC)`,
+		`CREATE INDEX IF NOT EXISTS webhook_defs_by_parent ON webhook_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
+		`CREATE INDEX IF NOT EXISTS webhook_defs_by_run    ON webhook_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
+		`CREATE TABLE IF NOT EXISTS webhook_def_active (
+			name                  TEXT    PRIMARY KEY,
+			def_id                TEXT    NOT NULL REFERENCES webhook_defs(def_id),
+			promoted_at           INTEGER NOT NULL,
+			promoted_by_agent_id  TEXT
+		)`,
 		// v0.8.5 evaluations table. emitter_role is server-derived in
 		// the tool layer; the store stores the string verbatim. Score
 		// is REAL (Go float64). Dimensions + Judgement are JSON-as-TEXT
@@ -4696,6 +4726,257 @@ func (s *Store) scanA2AAgentDefRows(rows *sql.Rows) ([]store.A2AAgentDefRow, err
 	for rows.Next() {
 		var (
 			r          store.A2AAgentDefRow
+			definition string
+			createdAt  int64
+			retired    int
+			bootstrap  int
+		)
+		if err := rows.Scan(
+			&r.DefID, &r.Name, &r.Version,
+			&r.ParentDefID,
+			&definition,
+			&r.Description,
+			&createdAt,
+			&r.CreatedByAgentID, &r.CreatedByRunID,
+			&retired, &bootstrap,
+		); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdAt)
+		r.Retired = retired != 0
+		r.BootstrappedFromStatic = bootstrap != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ---- v1.x RFC H WebhookDef substrate ----
+//
+// Mirror of A2AAgentDef* without the sweeper run_state table.
+
+func (s *Store) WebhookDefCreate(ctx context.Context, row store.WebhookDefRow) (store.WebhookDefRow, error) {
+	if row.DefID == "" || row.Name == "" {
+		return store.WebhookDefRow{}, fmt.Errorf("webhook_def: def_id + name required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+	}()
+
+	if row.ParentDefID != "" {
+		var n int
+		if err := conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM webhook_defs WHERE def_id = ?`, row.ParentDefID).Scan(&n); err != nil {
+			return store.WebhookDefRow{}, err
+		}
+		if n == 0 {
+			return store.WebhookDefRow{}, store.ErrWebhookDefParentNotFound
+		}
+	}
+
+	var maxVer sql.NullInt64
+	if err := conn.QueryRowContext(ctx,
+		`SELECT MAX(version) FROM webhook_defs WHERE name = ?`, row.Name,
+	).Scan(&maxVer); err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	row.Version = 1
+	if maxVer.Valid {
+		row.Version = int(maxVer.Int64) + 1
+	}
+	row.CreatedAt = time.Now()
+
+	if _, err := conn.ExecContext(ctx,
+		`INSERT INTO webhook_defs (
+			def_id, name, version, parent_def_id, definition, description,
+			created_at, created_by_agent_id, created_by_run_id,
+			retired, bootstrapped_from_static
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
+		string(row.Definition), nilIfEmpty(row.Description),
+		row.CreatedAt.UnixNano(),
+		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
+		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
+	); err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	committed = true
+	return row, nil
+}
+
+func (s *Store) WebhookDefGet(ctx context.Context, defID string) (store.WebhookDefRow, error) {
+	row, err := s.scanWebhookDef(s.db.QueryRowContext(ctx, webhookDefSelect+` WHERE def_id = ?`, defID))
+	if err == sql.ErrNoRows {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	return row, err
+}
+
+func (s *Store) WebhookDefGetByNameVersion(ctx context.Context, name string, version int) (store.WebhookDefRow, error) {
+	row, err := s.scanWebhookDef(s.db.QueryRowContext(ctx, webhookDefSelect+` WHERE name = ? AND version = ?`, name, version))
+	if err == sql.ErrNoRows {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def", ID: fmt.Sprintf("%s@v%d", name, version)}
+	}
+	return row, err
+}
+
+func (s *Store) WebhookDefListByName(ctx context.Context, name string) ([]store.WebhookDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, webhookDefSelect+` WHERE name = ? ORDER BY version DESC`, name)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanWebhookDefRows(rows)
+}
+
+func (s *Store) WebhookDefListChildren(ctx context.Context, parentDefID string) ([]store.WebhookDefRow, error) {
+	rows, err := s.db.QueryContext(ctx, webhookDefSelect+` WHERE parent_def_id = ? ORDER BY version DESC`, parentDefID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return s.scanWebhookDefRows(rows)
+}
+
+func (s *Store) WebhookDefListNames(ctx context.Context) ([]store.WebhookDefNameSummary, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT
+			d.name,
+			COUNT(*)                  AS version_count,
+			MAX(d.version)            AS latest_version,
+			MAX(d.created_at)         AS last_updated,
+			COALESCE(a.def_id, '')    AS active_def_id
+		FROM webhook_defs d
+		LEFT JOIN webhook_def_active a ON a.name = d.name
+		GROUP BY d.name, a.def_id
+		ORDER BY d.name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.WebhookDefNameSummary
+	for rows.Next() {
+		var ns store.WebhookDefNameSummary
+		var updatedAt int64
+		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
+			return nil, err
+		}
+		ns.LastUpdated = time.Unix(0, updatedAt)
+		out = append(out, ns)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) WebhookDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
+	var rowName string
+	err := s.db.QueryRowContext(ctx, `SELECT name FROM webhook_defs WHERE def_id = ?`, defID).Scan(&rowName)
+	if err == sql.ErrNoRows {
+		return &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	if err != nil {
+		return err
+	}
+	if rowName != name {
+		return fmt.Errorf("webhook_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
+	}
+	_, err = s.db.ExecContext(ctx, `
+		INSERT INTO webhook_def_active (name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?)
+		ON CONFLICT(name) DO UPDATE SET
+		    def_id               = excluded.def_id,
+		    promoted_at          = excluded.promoted_at,
+		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
+		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+	)
+	return err
+}
+
+func (s *Store) WebhookDefGetActive(ctx context.Context, name string) (store.WebhookDefRow, error) {
+	var defID string
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM webhook_def_active WHERE name = ?`, name).Scan(&defID)
+	if err == sql.ErrNoRows {
+		return store.WebhookDefRow{}, &store.ErrNotFound{Kind: "webhook_def_active", ID: name}
+	}
+	if err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	return s.WebhookDefGet(ctx, defID)
+}
+
+func (s *Store) WebhookDefSetRetired(ctx context.Context, defID string, retired bool) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE webhook_defs SET retired = ? WHERE def_id = ?`,
+		boolToInt(retired), defID,
+	)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return &store.ErrNotFound{Kind: "webhook_def", ID: defID}
+	}
+	return nil
+}
+
+const webhookDefSelect = `SELECT
+	def_id, name, version,
+	COALESCE(parent_def_id, ''),
+	definition,
+	COALESCE(description, ''),
+	created_at,
+	COALESCE(created_by_agent_id, ''),
+	COALESCE(created_by_run_id, ''),
+	retired,
+	bootstrapped_from_static
+FROM webhook_defs`
+
+func (s *Store) scanWebhookDef(row *sql.Row) (store.WebhookDefRow, error) {
+	var (
+		out        store.WebhookDefRow
+		definition string
+		createdAt  int64
+		retired    int
+		bootstrap  int
+	)
+	err := row.Scan(
+		&out.DefID, &out.Name, &out.Version,
+		&out.ParentDefID,
+		&definition,
+		&out.Description,
+		&createdAt,
+		&out.CreatedByAgentID, &out.CreatedByRunID,
+		&retired, &bootstrap,
+	)
+	if err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	out.CreatedAt = time.Unix(0, createdAt)
+	out.Retired = retired != 0
+	out.BootstrappedFromStatic = bootstrap != 0
+	return out, nil
+}
+
+func (s *Store) scanWebhookDefRows(rows *sql.Rows) ([]store.WebhookDefRow, error) {
+	var out []store.WebhookDefRow
+	for rows.Next() {
+		var (
+			r          store.WebhookDefRow
 			definition string
 			createdAt  int64
 			retired    int

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -600,6 +600,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// legacy rows + runs with no context. Not a secret (safe to
 		// persist). Read back via DecodeParentContext.
 		`ALTER TABLE runs ADD COLUMN parent_context TEXT`,
+		// RFC H Decision 10 "Layer 2" durable dedup — optional
+		// idempotency_key. NULL on legacy rows + runs with no key. The
+		// partial unique index is created below in addIndexes (so the
+		// column added here is guaranteed present first). The webhook
+		// spawn path sets this = delivery_id for cross-replica /
+		// past-Layer-1-TTL dedup.
+		`ALTER TABLE runs ADD COLUMN idempotency_key TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -661,6 +668,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS interrupts_by_run_status  ON interrupts(run_id, status)`,
 		`CREATE INDEX IF NOT EXISTS interrupts_by_user_status ON interrupts(user_id, status) WHERE user_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS interrupts_by_expires     ON interrupts(expires_at) WHERE expires_at IS NOT NULL AND status = 'pending'`,
+		// RFC H Decision 10 "Layer 2" durable dedup — partial unique
+		// index on idempotency_key. Lives in addIndexes (not the CREATE
+		// TABLE block) so the column added by addColumns above is
+		// guaranteed present on the v0.12.x → idempotency-key upgrade
+		// path. Partial (WHERE ... IS NOT NULL) so keyless runs are
+		// unconstrained and the index stays small. Mirrors the postgres
+		// 0033 migration.
+		`CREATE UNIQUE INDEX IF NOT EXISTS runs_idempotency_key ON runs(idempotency_key) WHERE idempotency_key IS NOT NULL`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use
@@ -751,8 +766,8 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		pcVal = pcJSON
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, parent_context)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		`INSERT INTO runs(id, session_id, status, started_at, agent_id, parent_agent_id, parent_run_id, user_id, user_tier, agent_def_id, model, parent_context, idempotency_key)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		id, sessionID, store.RunRunning, now.UnixNano(),
 		nilIfEmpty(identity.AgentID),
 		nilIfEmpty(identity.ParentAgentID),
@@ -762,23 +777,36 @@ func (s *Store) CreateRun(ctx context.Context, sessionID string, identity store.
 		nilIfEmpty(identity.AgentDefID),
 		nilIfEmpty(identity.Model),
 		pcVal,
+		nilIfEmpty(identity.IdempotencyKey),
 	)
 	if err != nil {
+		// RFC H Decision 10: a collision on the runs_idempotency_key
+		// partial unique index means an earlier run already claimed this
+		// key — surface the typed sentinel so the caller dedups instead
+		// of failing. Scope the classification to the idempotency case
+		// (key != "" AND the violation names that index) so a future
+		// UNIQUE constraint elsewhere on runs is never misreported.
+		if identity.IdempotencyKey != "" &&
+			strings.Contains(err.Error(), "UNIQUE constraint failed") &&
+			strings.Contains(err.Error(), "runs.idempotency_key") {
+			return store.Run{}, store.ErrDuplicateIdempotencyKey
+		}
 		return store.Run{}, err
 	}
 	return store.Run{
-		ID:            id,
-		SessionID:     sessionID,
-		Status:        store.RunRunning,
-		StartedAt:     now,
-		AgentID:       identity.AgentID,
-		ParentAgentID: identity.ParentAgentID,
-		ParentRunID:   identity.ParentRunID,
-		UserID:        identity.UserID,
-		UserTier:      identity.UserTier,
-		AgentDefID:    identity.AgentDefID,
-		Model:         identity.Model,
-		ParentContext: identity.ParentContext.Clone(),
+		ID:             id,
+		SessionID:      sessionID,
+		Status:         store.RunRunning,
+		StartedAt:      now,
+		AgentID:        identity.AgentID,
+		ParentAgentID:  identity.ParentAgentID,
+		ParentRunID:    identity.ParentRunID,
+		UserID:         identity.UserID,
+		UserTier:       identity.UserTier,
+		AgentDefID:     identity.AgentDefID,
+		Model:          identity.Model,
+		ParentContext:  identity.ParentContext.Clone(),
+		IdempotencyKey: identity.IdempotencyKey,
 	}, nil
 }
 
@@ -966,6 +994,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var agentDefID sql.NullString
 	var pauseState sql.NullString
 	var parentContext sql.NullString
+	var idempotencyKey sql.NullString
 	var sessAgent sql.NullString
 	var status string
 	if err := scanner.Scan(
@@ -975,7 +1004,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&model, &provider, &errMsg,
 		&agentID, &parentAgentID, &parentRunID, &userID, &lastHbNs,
 		&userTier,
-		&agentDefID, &pauseState, &parentContext,
+		&agentDefID, &pauseState, &parentContext, &idempotencyKey,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -1030,6 +1059,9 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		}
 		r.ParentContext = pc
 	}
+	if idempotencyKey.Valid {
+		r.IdempotencyKey = idempotencyKey.String
+	}
 	if sessAgent.Valid {
 		r.Agent = sessAgent.String
 	}
@@ -1050,7 +1082,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.model, r.provider, r.error,
 		r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at,
 		r.user_tier,
-		r.agent_def_id, r.pause_state, r.parent_context,
+		r.agent_def_id, r.pause_state, r.parent_context, r.idempotency_key,
 		s.agent`
 
 // runFromTable is the canonical FROM clause paired with runColumns.
@@ -1075,6 +1107,29 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
 	}
 	return r, err
+}
+
+// RunByIdempotencyKey returns the run created with the given RFC H
+// Decision 10 idempotency key. An empty key short-circuits to
+// (Run{}, false, nil); a key with no matching row returns the same.
+// The runs_idempotency_key partial unique index guarantees at most one
+// match.
+func (s *Store) RunByIdempotencyKey(ctx context.Context, key string) (store.Run, bool, error) {
+	if key == "" {
+		return store.Run{}, false, nil
+	}
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.idempotency_key = ? LIMIT 1`,
+		key,
+	)
+	r, err := scanRun(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.Run{}, false, nil
+	}
+	if err != nil {
+		return store.Run{}, false, fmt.Errorf("run by idempotency_key: %w", err)
+	}
+	return r, true, nil
 }
 
 // GetRun returns one row by run_id (the primary key on runs).

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1201,6 +1201,22 @@ type Store interface {
 	A2AAgentDefGetActive(ctx context.Context, name string) (A2AAgentDefRow, error)
 	A2AAgentDefSetRetired(ctx context.Context, defID string, retired bool) error
 
+	// WebhookDef is the v1.x RFC H Input Webhooks substrate — same
+	// content-addressed identity + lineage + promotion shape as
+	// A2AAgentDef, minus the sweeper run_state table. A WebhookDef
+	// declares an inbound HTTP webhook endpoint (auth, rate limit,
+	// delivery target, payload mapping, on_complete hooks); the
+	// Definition payload schema is owned by the tool layer.
+	WebhookDefCreate(ctx context.Context, row WebhookDefRow) (WebhookDefRow, error)
+	WebhookDefGet(ctx context.Context, defID string) (WebhookDefRow, error)
+	WebhookDefGetByNameVersion(ctx context.Context, name string, version int) (WebhookDefRow, error)
+	WebhookDefListByName(ctx context.Context, name string) ([]WebhookDefRow, error)
+	WebhookDefListChildren(ctx context.Context, parentDefID string) ([]WebhookDefRow, error)
+	WebhookDefListNames(ctx context.Context) ([]WebhookDefNameSummary, error)
+	WebhookDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
+	WebhookDefGetActive(ctx context.Context, name string) (WebhookDefRow, error)
+	WebhookDefSetRetired(ctx context.Context, defID string, retired bool) error
+
 	// ScheduleRunStatePause sets paused_until = until (or NULL if
 	// until.IsZero()). Resume = call with zero time.
 	ScheduleRunStatePause(ctx context.Context, defID string, until time.Time) error
@@ -1971,6 +1987,42 @@ type A2AAgentDefActiveEntry struct {
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
 }
 
+// WebhookDefRow mirrors A2AAgentDefRow — same identity + lineage +
+// retire flag shape. The Definition payload carries the JSON-encoded
+// inbound-webhook body (delivery target, auth scheme + signing-secret
+// ref, rate limit, payload mapping, on_complete hooks); the schema is
+// owned by the tool layer. v1.x RFC H.
+type WebhookDefRow struct {
+	DefID                  string          `json:"def_id"`
+	Name                   string          `json:"name"`
+	Version                int             `json:"version"`
+	ParentDefID            string          `json:"parent_def_id,omitempty"`
+	Definition             json.RawMessage `json:"definition"`
+	Description            string          `json:"description,omitempty"`
+	CreatedAt              time.Time       `json:"created_at"`
+	CreatedByAgentID       string          `json:"created_by_agent_id,omitempty"`
+	CreatedByRunID         string          `json:"created_by_run_id,omitempty"`
+	Retired                bool            `json:"retired"`
+	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
+}
+
+// WebhookDefNameSummary mirrors A2AAgentDefNameSummary.
+type WebhookDefNameSummary struct {
+	Name          string    `json:"name"`
+	VersionCount  int       `json:"version_count"`
+	ActiveDefID   string    `json:"active_def_id,omitempty"`
+	LatestVersion int       `json:"latest_version"`
+	LastUpdated   time.Time `json:"last_updated"`
+}
+
+// WebhookDefActiveEntry mirrors A2AAgentDefActiveEntry.
+type WebhookDefActiveEntry struct {
+	Name              string    `json:"name"`
+	DefID             string    `json:"def_id"`
+	PromotedAt        time.Time `json:"promoted_at"`
+	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+}
+
 // ScheduleRunStateRow is one row in schedule_run_state — the
 // sweeper's runtime view of a def. Seeded when a def becomes
 // active; updated after each fire.
@@ -2100,6 +2152,10 @@ var ErrA2AServerCardDefParentNotFound = &SubstrateError{Code: "parent_not_found"
 // ErrA2AAgentDefParentNotFound mirrors the ScheduleDef pattern for
 // the v1.x RFC G A2AAgentDef substrate.
 var ErrA2AAgentDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "a2a_agent_def: parent_def_id does not exist"}
+
+// ErrWebhookDefParentNotFound mirrors the A2AAgentDef pattern for the
+// v1.x RFC H WebhookDef substrate.
+var ErrWebhookDefParentNotFound = &SubstrateError{Code: "parent_not_found", Msg: "webhook_def: parent_def_id does not exist"}
 
 // ErrAgentDefImmutable is returned by store-layer assertions if
 // someone tries to UPDATE an agent_defs row's definition column.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -238,6 +238,13 @@ type Run struct {
 	// per-agent report surfaces so a consumer can attribute a child
 	// sub-agent's usage to the user-initiated request.
 	ParentContext *ParentContext `json:"parent_context,omitempty"`
+
+	// IdempotencyKey is the RFC H Decision 10 "Layer 2" durable dedup
+	// key the run was created with (runs.idempotency_key). Empty on rows
+	// created without one (the common case) and on pre-migration rows.
+	// Round-trips on read so a deduped caller can look up the winning run
+	// and confirm the key. Not a secret.
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
 }
 
 // PauseState constants — the wire string values stored in runs.pause_state.
@@ -340,6 +347,17 @@ type RunIdentity struct {
 	// tool spawns; persisted as runs.parent_context (JSON). nil = no
 	// context (back-compat; old rows decode to nil). See ParentContext.
 	ParentContext *ParentContext
+
+	// IdempotencyKey is the optional RFC H Decision 10 "Layer 2"
+	// durable dedup key. Empty (the default) = no dedup; the run is
+	// created unconditionally. Non-empty = persisted to
+	// runs.idempotency_key (a partial unique index); a second CreateRun
+	// with the same key returns ErrDuplicateIdempotencyKey instead of
+	// inserting a duplicate row. The webhook spawn path sets this to the
+	// delivery id so a redelivery that survives past the in-memory
+	// Layer-1 TTL — or lands on a different replica — still dedups.
+	// Not a secret (safe to persist + echo).
+	IdempotencyKey string
 }
 
 // ParentContext is the typed caller-tracking lineage attached to a run
@@ -488,6 +506,13 @@ type Store interface {
 	// Used by the GET /v1/agents/{agent_id} and cancel endpoints to
 	// resolve the API-facing handle to a Run.
 	GetRunByAgentID(ctx context.Context, agentID string) (Run, error)
+
+	// RunByIdempotencyKey returns the run created with the given RFC H
+	// Decision 10 idempotency key. ok=false (with a nil error) when no
+	// run carries the key. An empty key short-circuits to (Run{}, false,
+	// nil) — callers don't have to pre-check. Used by the webhook
+	// receiver to resolve a deduped delivery to its already-spawned run.
+	RunByIdempotencyKey(ctx context.Context, key string) (Run, bool, error)
 
 	// GetRun returns one row by run_id (the primary key on runs).
 	// Distinct from GetRunByAgentID which queries by the caller-
@@ -2270,6 +2295,14 @@ type ErrConflict struct {
 }
 
 func (e *ErrConflict) Error() string { return e.Kind + " already exists: " + e.ID }
+
+// ErrDuplicateIdempotencyKey is returned by CreateRun when the supplied
+// RunIdentity.IdempotencyKey collides with an existing run's key (RFC H
+// Decision 10 "Layer 2" durable dedup). The caller is expected to look
+// the existing run up via RunByIdempotencyKey and return it rather than
+// treating this as a failure. It is a sentinel (errors.Is-comparable),
+// distinct from *ErrConflict whose Kind/ID vary per call.
+var ErrDuplicateIdempotencyKey = errors.New("duplicate idempotency_key")
 
 // SnapshotRow is the persisted shape of one snapshots row, used by
 // SnapshotCreate/Get. The JSONContent is the full envelope per the

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -206,6 +206,13 @@ func Run(t *testing.T, factory Factory) {
 		{"A2AAgentDefParentNotFound", testA2AAgentDefParentNotFound},
 		{"A2AAgentDefListByName", testA2AAgentDefListByName},
 		{"A2AAgentDefListChildren", testA2AAgentDefListChildren},
+		{"WebhookDefCreateAndGet", testWebhookDefCreateAndGet},
+		{"WebhookDefVersionMonotonic", testWebhookDefVersionMonotonic},
+		{"WebhookDefActivePointerIdempotent", testWebhookDefActivePointerIdempotent},
+		{"WebhookDefRetireReversible", testWebhookDefRetireReversible},
+		{"WebhookDefParentNotFound", testWebhookDefParentNotFound},
+		{"WebhookDefListByName", testWebhookDefListByName},
+		{"WebhookDefListChildren", testWebhookDefListChildren},
 		// v1.x RFC E ScheduleDef runtime — sweeper-side state.
 		{"ScheduleRunStateSeedAndGet", testScheduleRunStateSeedAndGet},
 		{"ScheduleRunStateListDueRespectsRetiredAndPaused", testScheduleRunStateListDueRespectsRetiredAndPaused},
@@ -4345,6 +4352,147 @@ func testA2AAgentDefListChildren(t *testing.T, s store.Store) {
 		}
 	}
 	children, err := s.A2AAgentDefListChildren(ctx, parent.DefID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(children) != 2 {
+		t.Errorf("children len = %d, want 2", len(children))
+	}
+}
+
+// ---- v1.x RFC H WebhookDef substrate ----
+//
+// Mirror of the A2AAgentDef round-trip contract tests.
+
+func mkWebhookDef(id, name string, parent string) store.WebhookDefRow {
+	return store.WebhookDefRow{
+		DefID:       id,
+		Name:        name,
+		ParentDefID: parent,
+		Definition:  json.RawMessage(`{"delivery":"spawn","agent":"intake","auth":{"kind":"hmac","algorithm":"sha256","header":"X-Hub-Signature-256","signing_secret_env":"LOOMCYCLE_WH_SECRET"}}`),
+		Description: "test row",
+	}
+}
+
+func testWebhookDefCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, err := s.WebhookDefCreate(ctx, mkWebhookDef("wh-1", "hook-alpha", ""))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if row.Version != 1 {
+		t.Errorf("first version = %d, want 1", row.Version)
+	}
+	got, err := s.WebhookDefGet(ctx, "wh-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "hook-alpha" || got.Version != 1 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func testWebhookDefVersionMonotonic(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for i := 0; i < 5; i++ {
+		row := mkWebhookDef(fmt.Sprintf("wh-mono-%d", i), "hook-mono", "")
+		written, err := s.WebhookDefCreate(ctx, row)
+		if err != nil {
+			t.Fatalf("create #%d: %v", i, err)
+		}
+		if want := i + 1; written.Version != want {
+			t.Errorf("create #%d: version = %d, want %d", i, written.Version, want)
+		}
+	}
+}
+
+func testWebhookDefActivePointerIdempotent(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	r1, _ := s.WebhookDefCreate(ctx, mkWebhookDef("wh-active-1", "hook-active", ""))
+	r2, _ := s.WebhookDefCreate(ctx, mkWebhookDef("wh-active-2", "hook-active", ""))
+
+	if err := s.WebhookDefSetActive(ctx, "hook-active", r1.DefID, "test"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.WebhookDefGetActive(ctx, "hook-active")
+	if got.DefID != r1.DefID {
+		t.Errorf("active = %s, want %s", got.DefID, r1.DefID)
+	}
+	if err := s.WebhookDefSetActive(ctx, "hook-active", r2.DefID, "test"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.WebhookDefGetActive(ctx, "hook-active")
+	if got.DefID != r2.DefID {
+		t.Errorf("after re-promote: active = %s, want %s", got.DefID, r2.DefID)
+	}
+}
+
+func testWebhookDefRetireReversible(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row, _ := s.WebhookDefCreate(ctx, mkWebhookDef("wh-retire", "hook-retire", ""))
+	if row.Retired {
+		t.Error("freshly created row should not be retired")
+	}
+	if err := s.WebhookDefSetRetired(ctx, row.DefID, true); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := s.WebhookDefGet(ctx, row.DefID)
+	if !got.Retired {
+		t.Error("after retire(true): row should be retired")
+	}
+	if err := s.WebhookDefSetRetired(ctx, row.DefID, false); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.WebhookDefGet(ctx, row.DefID)
+	if got.Retired {
+		t.Error("after retire(false): row should NOT be retired")
+	}
+}
+
+func testWebhookDefParentNotFound(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	row := mkWebhookDef("wh-orphan", "hook-orphan", "wh-nonexistent")
+	_, err := s.WebhookDefCreate(ctx, row)
+	if err == nil {
+		t.Fatal("expected ErrWebhookDefParentNotFound, got nil")
+	}
+	if !errors.Is(err, store.ErrWebhookDefParentNotFound) {
+		t.Errorf("got %v, want ErrWebhookDefParentNotFound", err)
+	}
+}
+
+func testWebhookDefListByName(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		_, err := s.WebhookDefCreate(ctx, mkWebhookDef(fmt.Sprintf("wh-list-%d", i), "hook-list", ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := s.WebhookDefListByName(ctx, "hook-list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("len = %d, want 3", len(rows))
+	}
+	// version DESC ordering
+	if rows[0].Version != 3 || rows[1].Version != 2 || rows[2].Version != 1 {
+		t.Errorf("ordering wrong; versions = %d/%d/%d, want 3/2/1",
+			rows[0].Version, rows[1].Version, rows[2].Version)
+	}
+}
+
+func testWebhookDefListChildren(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	parent, _ := s.WebhookDefCreate(ctx, mkWebhookDef("wh-parent", "hook-tree", ""))
+	for i := 0; i < 2; i++ {
+		_, err := s.WebhookDefCreate(ctx, mkWebhookDef(fmt.Sprintf("wh-child-%d", i), fmt.Sprintf("hook-child-%d", i), parent.DefID))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	children, err := s.WebhookDefListChildren(ctx, parent.DefID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -60,6 +60,9 @@ func Run(t *testing.T, factory Factory) {
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
 		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},
+		{"CreateRunIdempotencyKeyRoundTrip", testCreateRunIdempotencyKeyRoundTrip},
+		{"CreateRunDuplicateIdempotencyKeyRefused", testCreateRunDuplicateIdempotencyKeyRefused},
+		{"RunByIdempotencyKeyHitAndMiss", testRunByIdempotencyKeyHitAndMiss},
 		{"CreateRunModelVisibleMidFlight", testCreateRunModelVisibleMidFlight},
 		{"CreateRunModelEmptyStaysEmpty", testCreateRunModelEmptyStaysEmpty},
 		{"GetRunByAgentIDNotFound", testGetRunByAgentIDNotFound},
@@ -550,6 +553,123 @@ func testCreateRunParentContextRoundTrip(t *testing.T, s store.Store) {
 	}
 	if gotBare.ParentContext != nil {
 		t.Errorf("run without context should read back nil ParentContext, got %+v", gotBare.ParentContext)
+	}
+}
+
+// testCreateRunIdempotencyKeyRoundTrip pins the RFC H Decision 10 "Layer
+// 2" contract: a run created with an idempotency_key persists it and
+// reads it back through CreateRun → GetRun. A run created without one
+// reads back empty (back-compat with pre-migration rows + the common
+// keyless case).
+func testCreateRunIdempotencyKeyRoundTrip(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_idem", UserID: "user-1", IdempotencyKey: "delivery-123"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.IdempotencyKey != "delivery-123" {
+		t.Errorf("CreateRun did not return IdempotencyKey: got %q", run.IdempotencyKey)
+	}
+	got, err := s.GetRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.IdempotencyKey != "delivery-123" {
+		t.Errorf("IdempotencyKey not preserved through GetRun: got %q want %q", got.IdempotencyKey, "delivery-123")
+	}
+
+	// No key → empty round-trip (back-compat).
+	bare, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_noidem", UserID: "user-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotBare, err := s.GetRun(ctx, bare.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotBare.IdempotencyKey != "" {
+		t.Errorf("run without key should read back empty IdempotencyKey, got %q", gotBare.IdempotencyKey)
+	}
+}
+
+// testCreateRunDuplicateIdempotencyKeyRefused pins the RFC H Decision 10
+// durable-dedup invariant: a second CreateRun carrying a key already
+// claimed returns store.ErrDuplicateIdempotencyKey (not a generic error)
+// and does NOT insert a second row. Two DIFFERENT keys, and a keyless run
+// alongside a keyed one, are both unaffected — the constraint is scoped
+// to the key, never the keyless majority.
+func testCreateRunDuplicateIdempotencyKeyRefused(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	first, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a1", UserID: "user-1", IdempotencyKey: "dup-key"})
+	if err != nil {
+		t.Fatalf("first CreateRun: %v", err)
+	}
+
+	_, err = s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a2", UserID: "user-1", IdempotencyKey: "dup-key"})
+	if !errors.Is(err, store.ErrDuplicateIdempotencyKey) {
+		t.Fatalf("second CreateRun with same key: got err %v, want ErrDuplicateIdempotencyKey", err)
+	}
+
+	// The existing run is still the only one carrying the key.
+	got, ok, err := s.RunByIdempotencyKey(ctx, "dup-key")
+	if err != nil || !ok {
+		t.Fatalf("RunByIdempotencyKey after dup: ok=%v err=%v", ok, err)
+	}
+	if got.ID != first.ID {
+		t.Errorf("dup key resolved to wrong run: got %s want %s", got.ID, first.ID)
+	}
+
+	// A DIFFERENT key is unaffected.
+	if _, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a3", UserID: "user-1", IdempotencyKey: "other-key"}); err != nil {
+		t.Errorf("CreateRun with a distinct key should succeed, got %v", err)
+	}
+
+	// Two keyless runs coexist — the partial unique index never fires on
+	// NULL. (This is the regression guard against accidentally
+	// constraining the keyless majority.)
+	if _, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a4", UserID: "user-1"}); err != nil {
+		t.Errorf("first keyless CreateRun: %v", err)
+	}
+	if _, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a5", UserID: "user-1"}); err != nil {
+		t.Errorf("second keyless CreateRun should not collide on NULL key: %v", err)
+	}
+}
+
+// testRunByIdempotencyKeyHitAndMiss pins the lookup contract: a known key
+// returns (run, true, nil); an unknown key and an empty key both return
+// (zero, false, nil) — no error on miss.
+func testRunByIdempotencyKeyHitAndMiss(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "agent-x", "user-1")
+
+	want, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_hit", UserID: "user-1", IdempotencyKey: "key-hit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok, err := s.RunByIdempotencyKey(ctx, "key-hit")
+	if err != nil {
+		t.Fatalf("RunByIdempotencyKey hit: %v", err)
+	}
+	if !ok || got.ID != want.ID {
+		t.Errorf("hit: got (ok=%v id=%s), want (ok=true id=%s)", ok, got.ID, want.ID)
+	}
+	if got.AgentID != "a_hit" {
+		t.Errorf("hit: identity not preserved: %+v", got)
+	}
+
+	_, ok, err = s.RunByIdempotencyKey(ctx, "key-absent")
+	if err != nil || ok {
+		t.Errorf("miss: got (ok=%v err=%v), want (false, nil)", ok, err)
+	}
+
+	_, ok, err = s.RunByIdempotencyKey(ctx, "")
+	if err != nil || ok {
+		t.Errorf("empty key: got (ok=%v err=%v), want (false, nil)", ok, err)
 	}
 }
 

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -1,0 +1,705 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// WebhookDef is the v1.x RFC H (Input Webhooks) built-in tool that lets
+// agents author, fork, retire, and inspect INBOUND webhook definitions
+// at runtime. Yaml `webhooks.<name>:` entries remain the operator-blessed
+// root; this tool produces the DERIVED layer of orchestrator-authored
+// forks.
+//
+// RFC H WH-2 / mirrors A2AAgentDef exactly minus the schedule-only
+// add_hook/remove_hook ops. Five operations dispatched off the `op`
+// field:
+//
+//	create  — declare a brand-new webhook name with a v1 definition.
+//	          Refused if `name` matches a static cfg.Webhooks entry.
+//	fork    — make a new version from an existing parent.
+//	get     — fetch one row by def_id.
+//	list    — list versions for a name (version DESC).
+//	retire  — flip the retired flag. Lineage stays visible.
+//
+// Server-stamped fields: created_at, created_by_agent_id (from
+// tools.RunIdentity). The model NEVER supplies these.
+type WebhookDef struct {
+	// Store is the persistence backend. Required.
+	Store store.Store
+
+	// Cfg is the loaded operator config. Used to resolve the
+	// operator-blessed root (cfg.Webhooks[name]) for the
+	// static-name-replace refusal and the bootstrap-from-yaml path.
+	Cfg *config.Config
+
+	// MaxDefinitionBytes caps the serialised definition JSON. 0 = no cap.
+	MaxDefinitionBytes int
+
+	// MaxDescriptionBytes caps the description field. 0 = no cap.
+	MaxDescriptionBytes int
+}
+
+const webhookDefDescription = `Author, fork, retire, and inspect inbound webhook definitions at runtime. ` +
+	`Static webhooks.<name>: yaml entries remain the operator's immutable ground truth; this tool ` +
+	`produces the DERIVED layer of orchestrator-authored forks. ` +
+	`Operations: create, fork, get, list, retire.`
+
+const webhookDefInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":            {"type": "string", "enum": ["create","fork","get","list","retire"], "description": "Operation to perform."},
+    "name":          {"type": "string", "description": "Webhook name (required for create/fork/list)."},
+    "def_id":        {"type": "string", "description": "Existing def_id (required for get/retire)."},
+    "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name, or bootstraps from a yaml template)."},
+    "overlay": {
+      "type": "object",
+      "description": "Mutable subset of the webhook definition for create/fork. Server-set fields are silently ignored if supplied.",
+      "additionalProperties": true
+    },
+    "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
+    "promote":       {"type": "boolean", "description": "create + fork both default true (new versions replace old). Pass false to leave the existing active pointer in place."},
+    "retired":       {"type": "boolean", "description": "Required for retire — set true to retire, false to un-retire."}
+  },
+  "required": ["op"]
+}`
+
+type webhookDefInput struct {
+	Op          string          `json:"op"`
+	Name        string          `json:"name,omitempty"`
+	DefID       string          `json:"def_id,omitempty"`
+	ParentDefID string          `json:"parent_def_id,omitempty"`
+	Overlay     json.RawMessage `json:"overlay,omitempty"`
+	Description string          `json:"description,omitempty"`
+	Promote     *bool           `json:"promote,omitempty"`
+	Retired     *bool           `json:"retired,omitempty"`
+}
+
+// Name implements tools.Tool.
+func (s *WebhookDef) Name() string { return "WebhookDef" }
+
+// Description implements tools.Tool.
+func (s *WebhookDef) Description() string { return webhookDefDescription }
+
+// InputSchema implements tools.Tool.
+func (s *WebhookDef) InputSchema() json.RawMessage {
+	return json.RawMessage(webhookDefInputSchema)
+}
+
+// Execute implements tools.Tool.
+func (s *WebhookDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if s.Store == nil {
+		return errResult("WebhookDef tool: not configured (no Store backend)"), nil
+	}
+	if s.Cfg == nil {
+		return errResult("WebhookDef tool: not configured (no Config — operator-blessed root unavailable)"), nil
+	}
+	var in webhookDefInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
+	}
+	policy := tools.WebhookDefPolicy(ctx)
+
+	switch in.Op {
+	case "create":
+		return s.execCreate(ctx, policy, in)
+	case "fork":
+		return s.execFork(ctx, policy, in)
+	case "get":
+		return s.execGet(ctx, policy, in)
+	case "list":
+		return s.execList(ctx, policy, in)
+	case "retire":
+		return s.execRetire(ctx, policy, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, fork, get, list, retire)", in.Op)), nil
+	}
+}
+
+// ---- create ----
+
+func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPolicyValue, in webhookDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("create: missing required field: name"), nil
+	}
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if _, ok := s.Cfg.Webhooks[in.Name]; ok {
+		return errResult(fmt.Sprintf("create: name %q matches a static cfg.Webhooks entry — use `fork` to derive a new version", in.Name)), nil
+	}
+
+	def, err := s.buildDefinition(in.Name, "", in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	if err := validateWebhookDef(def); err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
+	}
+	if s.MaxDefinitionBytes > 0 && len(defJSON) > s.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("create: definition (%d bytes) exceeds max %d", len(defJSON), s.MaxDefinitionBytes)), nil
+	}
+	if s.MaxDescriptionBytes > 0 && len(in.Description) > s.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.WebhookDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := s.Store.WebhookDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("create: %s", err)), nil
+	}
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := s.Store.WebhookDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
+		}
+	}
+	return okJSON(webhookRowResponse(created, promote))
+}
+
+// ---- fork ----
+
+func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicyValue, in webhookDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("fork: missing required field: name"), nil
+	}
+
+	// Resolve the parent. Three paths (mirror A2AAgentDef):
+	//   1. parent_def_id supplied → pin
+	//   2. parent_def_id empty + active pointer exists → use it
+	//   3. neither → name must have a yaml template; bootstrap v1
+	parentDefID := in.ParentDefID
+	var parent store.WebhookDefRow
+	if parentDefID != "" {
+		row, err := s.Store.WebhookDefGet(ctx, parentDefID)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: parent_def_id %q not found", parentDefID)), nil
+			}
+			return errResult(fmt.Sprintf("fork: %s", err)), nil
+		}
+		if row.Name != in.Name {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
+		}
+		parent = row
+	} else {
+		row, err := s.Store.WebhookDefGetActive(ctx, in.Name)
+		if err == nil {
+			parent = row
+			parentDefID = row.DefID
+		} else {
+			var nf *store.ErrNotFound
+			if !errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: %s", err)), nil
+			}
+			// No active pointer → must bootstrap from yaml.
+			static, ok := s.Cfg.Webhooks[in.Name]
+			if !ok {
+				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static cfg.Webhooks entry", in.Name)), nil
+			}
+			bootstrap, berr := s.bootstrapStatic(ctx, in.Name, static)
+			if berr != nil {
+				// Concurrent first-fork may have already bootstrapped v1;
+				// re-read active pointer before propagating.
+				if row2, gerr := s.Store.WebhookDefGetActive(ctx, in.Name); gerr == nil {
+					parent = row2
+					parentDefID = row2.DefID
+				} else {
+					return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+				}
+			} else {
+				parent = bootstrap
+				parentDefID = bootstrap.DefID
+			}
+		}
+	}
+
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	def, err := s.buildDefinition(in.Name, string(parent.Definition), in.Overlay)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	if err := validateWebhookDef(def); err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
+	}
+	if s.MaxDefinitionBytes > 0 && len(defJSON) > s.MaxDefinitionBytes {
+		return errResult(fmt.Sprintf("fork: definition (%d bytes) exceeds max %d", len(defJSON), s.MaxDefinitionBytes)), nil
+	}
+	if s.MaxDescriptionBytes > 0 && len(in.Description) > s.MaxDescriptionBytes {
+		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
+	}
+
+	ident := tools.RunIdentity(ctx)
+	row := store.WebhookDefRow{
+		DefID:            mintDefID(),
+		Name:             in.Name,
+		ParentDefID:      parentDefID,
+		Definition:       defJSON,
+		Description:      in.Description,
+		CreatedByAgentID: ident.AgentID,
+	}
+	created, err := s.Store.WebhookDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	if promote {
+		if err := s.Store.WebhookDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
+		}
+	}
+	return okJSON(webhookRowResponse(created, promote))
+}
+
+// ---- get / list ----
+
+func (s *WebhookDef) execGet(ctx context.Context, policy tools.WebhookDefPolicyValue, in webhookDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("get: missing required field: def_id"), nil
+	}
+	row, err := s.Store.WebhookDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("get: %s", err)), nil
+	}
+	if err := s.checkScopeForName(policy, row.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	return okJSON(webhookRowResponse(row, false))
+}
+
+func (s *WebhookDef) execList(ctx context.Context, policy tools.WebhookDefPolicyValue, in webhookDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("list: missing required field: name"), nil
+	}
+	if err := s.checkScopeForName(policy, in.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	rows, err := s.Store.WebhookDefListByName(ctx, in.Name)
+	if err != nil {
+		return errResult(fmt.Sprintf("list: %s", err)), nil
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, webhookRowResponseMap(r))
+	}
+	return okJSON(map[string]any{"name": in.Name, "versions": out})
+}
+
+// ---- retire ----
+
+func (s *WebhookDef) execRetire(ctx context.Context, policy tools.WebhookDefPolicyValue, in webhookDefInput) (tools.Result, error) {
+	if in.DefID == "" {
+		return errResult("retire: missing required field: def_id"), nil
+	}
+	if in.Retired == nil {
+		return errResult("retire: missing required field: retired (true|false)"), nil
+	}
+	row, err := s.Store.WebhookDefGet(ctx, in.DefID)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
+		}
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	if err := s.checkScopeForName(policy, row.Name); err != nil {
+		return errResult(err.Error()), nil
+	}
+	if err := s.Store.WebhookDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
+		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	return okJSON(map[string]any{"def_id": in.DefID, "retired": *in.Retired})
+}
+
+// ---- helpers ----
+
+func (s *WebhookDef) checkScopeForName(policy tools.WebhookDefPolicyValue, name string) error {
+	if len(policy.Scopes) == 0 {
+		return fmt.Errorf("WebhookDef tool: agent has no webhook_def_scopes (default-deny); add `webhook_def_scopes: [...]` to the agent yaml")
+	}
+	for _, sc := range policy.Scopes {
+		switch sc {
+		case "any":
+			return nil
+		case "self":
+			if name == policy.SelfName {
+				return nil
+			}
+		case "descendants":
+			// Same KNOWN GAP as ScheduleDef's "descendants" — accept on
+			// presence; tighten when RunIdentity gains the parent
+			// lineage walk surface.
+			return nil
+		default:
+			if strings.HasPrefix(sc, "named:") {
+				if strings.TrimPrefix(sc, "named:") == name {
+					return nil
+				}
+			}
+		}
+	}
+	return fmt.Errorf("WebhookDef tool: name %q not in this agent's webhook_def_scopes (%v)", name, policy.Scopes)
+}
+
+func (s *WebhookDef) buildDefinition(name, parentJSON string, overlay json.RawMessage) (mergedWebhookDef, error) {
+	base := mergedWebhookDef{}
+	if parentJSON != "" {
+		if err := json.Unmarshal([]byte(parentJSON), &base); err != nil {
+			return mergedWebhookDef{}, fmt.Errorf("parse parent definition: %w", err)
+		}
+	} else if static, ok := s.Cfg.Webhooks[name]; ok {
+		// Create-with-static-name is REFUSED in execCreate; this branch
+		// handles fork's bootstrap-from-static when no parent JSON yet
+		// but a static entry exists.
+		base = staticToMergedWebhookDef(static)
+	}
+
+	if len(overlay) > 0 {
+		var ov mergedWebhookDef
+		if err := json.Unmarshal(overlay, &ov); err != nil {
+			return mergedWebhookDef{}, fmt.Errorf("parse overlay: %w", err)
+		}
+		base.applyOverlay(ov)
+	}
+	// Unlike A2AServerCardDef, config.Webhook carries no Name field — the
+	// webhook's addressable name is the registry key (the `name` arg)
+	// only, exactly like A2AAgentDef. So no name stamp here.
+	return base, nil
+}
+
+func (s *WebhookDef) bootstrapStatic(ctx context.Context, name string, static config.Webhook) (store.WebhookDefRow, error) {
+	def := staticToMergedWebhookDef(static)
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		return store.WebhookDefRow{}, fmt.Errorf("marshal: %w", err)
+	}
+	ident := tools.RunIdentity(ctx)
+	row := store.WebhookDefRow{
+		DefID:                  mintDefID(),
+		Name:                   name,
+		Definition:             defJSON,
+		Description:            "bootstrapped from static cfg.Webhooks",
+		CreatedByAgentID:       ident.AgentID,
+		BootstrappedFromStatic: true,
+	}
+	created, err := s.Store.WebhookDefCreate(ctx, row)
+	if err != nil {
+		return store.WebhookDefRow{}, err
+	}
+	if err := s.Store.WebhookDefSetActive(ctx, name, created.DefID, ident.AgentID); err != nil {
+		// Bootstrap succeeded but couldn't promote — return the row;
+		// the next fork iteration finds it via the active-pointer retry.
+		return created, fmt.Errorf("promote bootstrap: %w", err)
+	}
+	return created, nil
+}
+
+// validateWebhookDef enforces the runtime-supplied overlay shape.
+// STRUCTURAL validation only — the env-allowlist RESOLVABILITY check for
+// signing_secret_env / bearer_token_env / user_credentials_from_env is
+// deferred to the WH-4 receiver/admin (this validator only checks the
+// env-var-NAME charset, not whether the var is actually set + allowed).
+//
+// RFC H WH-2 / mirrors A2AServerCardDef's structure-only posture.
+func validateWebhookDef(def mergedWebhookDef) error {
+	// delivery ∈ {"", "spawn", "channel"} ("" treated as spawn).
+	switch def.Delivery {
+	case "", "spawn":
+		if def.Agent == "" {
+			return fmt.Errorf("delivery=spawn requires agent (non-empty)")
+		}
+		if def.Channel != "" {
+			return fmt.Errorf("delivery=spawn forbids channel (set agent, not channel)")
+		}
+	case "channel":
+		if def.Channel == "" {
+			return fmt.Errorf("delivery=channel requires channel (non-empty)")
+		}
+		if def.Agent != "" {
+			return fmt.Errorf("delivery=channel forbids agent (set channel, not agent)")
+		}
+		// RFC H Decision 11: channel mode forbids credentials. A channel
+		// publish is not an autonomous run, so it has no run identity to
+		// carry per-user MCP-tool bearers — silently accepting them would
+		// be a credential leak into the message bus.
+		if len(def.UserCredentialsFromEnv) > 0 {
+			return fmt.Errorf("delivery=channel forbids user_credentials_from_env (RFC H Decision 11: channel mode has no run identity to carry credentials)")
+		}
+		for k := range def.PayloadMapping {
+			if strings.HasPrefix(k, "user_credentials.") {
+				return fmt.Errorf("delivery=channel forbids payload_mapping key %q (RFC H Decision 11: channel mode cannot map user credentials)", k)
+			}
+		}
+	default:
+		return fmt.Errorf("unknown delivery %q (must be one of: spawn, channel)", def.Delivery)
+	}
+
+	// auth.kind ∈ {"", "hmac", "bearer"} ("" treated as hmac).
+	switch def.Auth.Kind {
+	case "", "hmac":
+		if def.Auth.SigningSecretEnv == "" {
+			return fmt.Errorf("auth.kind=hmac requires auth.signing_secret_env")
+		}
+		if !envVarNameRe.MatchString(def.Auth.SigningSecretEnv) {
+			return fmt.Errorf("auth.signing_secret_env %q is not a valid env-var name (must match [A-Z][A-Z0-9_]*)", def.Auth.SigningSecretEnv)
+		}
+	case "bearer":
+		if def.Auth.BearerTokenEnv == "" {
+			return fmt.Errorf("auth.kind=bearer requires auth.bearer_token_env")
+		}
+		if !envVarNameRe.MatchString(def.Auth.BearerTokenEnv) {
+			return fmt.Errorf("auth.bearer_token_env %q is not a valid env-var name (must match [A-Z][A-Z0-9_]*)", def.Auth.BearerTokenEnv)
+		}
+	default:
+		return fmt.Errorf("unknown auth.kind %q (must be one of: hmac, bearer)", def.Auth.Kind)
+	}
+
+	// Every value in user_credentials_from_env must be a valid env-var
+	// name (WH-4 checks resolvability against the allowlist).
+	for k, v := range def.UserCredentialsFromEnv {
+		if !envVarNameRe.MatchString(v) {
+			return fmt.Errorf("user_credentials_from_env[%q] = %q is not a valid env-var name (must match [A-Z][A-Z0-9_]*)", k, v)
+		}
+	}
+
+	// Every payload_mapping value must be non-empty (JSONPath strings;
+	// JSONPath SYNTAX validation is deferred to WH-4's payload.go).
+	for k, v := range def.PayloadMapping {
+		if v == "" {
+			return fmt.Errorf("payload_mapping[%q] is empty (expected a JSONPath string)", k)
+		}
+	}
+
+	if def.BodySizeLimitBytes < 0 {
+		return fmt.Errorf("body_size_limit_bytes must be >= 0")
+	}
+	if def.RateLimit.RequestsPerMinute < 0 {
+		return fmt.Errorf("rate_limit.requests_per_minute must be >= 0")
+	}
+	if def.RateLimit.Burst < 0 {
+		return fmt.Errorf("rate_limit.burst must be >= 0")
+	}
+	if def.SyncResponse.Enabled {
+		if def.SyncResponse.TimeoutMs <= 0 || def.SyncResponse.TimeoutMs > 60000 {
+			return fmt.Errorf("sync_response.timeout_ms must be in (0, 60000] when sync_response.enabled")
+		}
+	}
+	return nil
+}
+
+// ---- response shape ----
+
+func webhookRowResponse(row store.WebhookDefRow, promoted bool) map[string]any {
+	m := webhookRowResponseMap(row)
+	m["promoted"] = promoted
+	return m
+}
+
+func webhookRowResponseMap(row store.WebhookDefRow) map[string]any {
+	return map[string]any{
+		"def_id":                   row.DefID,
+		"name":                     row.Name,
+		"version":                  row.Version,
+		"parent_def_id":            row.ParentDefID,
+		"description":              row.Description,
+		"created_at":               row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+		"created_by_agent_id":      row.CreatedByAgentID,
+		"retired":                  row.Retired,
+		"bootstrapped_from_static": row.BootstrappedFromStatic,
+		"definition":               row.Definition,
+	}
+}
+
+// ---- mergedWebhookDef: the JSON-tagged persistence shape ----
+//
+// EXACT field set of config.Webhook (WH-1) with the same snake_case JSON
+// tags for the substrate-write path. The lookup.SubstrateWebhookDef
+// adapter mirrors this exactly for read-side round-trip; a drift test
+// pins parity (TestMergedWebhookDef_DriftDetection_VsLookupSubstrate).
+//
+// on_complete reuses config.ScheduledRunHook — the same hook shape
+// ScheduleDef uses — rather than a parallel type, per RFC H WH-2.
+type mergedWebhookDef struct {
+	Enabled                bool                      `json:"enabled,omitempty"`
+	Delivery               string                    `json:"delivery,omitempty"`
+	Agent                  string                    `json:"agent,omitempty"`
+	Channel                string                    `json:"channel,omitempty"`
+	Auth                   mergedWebhookAuth         `json:"auth,omitempty"`
+	RateLimit              mergedWebhookRateLimit    `json:"rate_limit,omitempty"`
+	BodySizeLimitBytes     int                       `json:"body_size_limit_bytes,omitempty"`
+	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
+	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
+	SyncResponse           mergedWebhookSyncResp     `json:"sync_response,omitempty"`
+	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
+}
+
+// mergedWebhookAuth mirrors config.WebhookAuth.
+type mergedWebhookAuth struct {
+	Kind             string `json:"kind,omitempty"`
+	Algorithm        string `json:"algorithm,omitempty"`
+	Header           string `json:"header,omitempty"`
+	SigningSecretEnv string `json:"signing_secret_env,omitempty"`
+	DeliveryIDHeader string `json:"delivery_id_header,omitempty"`
+	BearerTokenEnv   string `json:"bearer_token_env,omitempty"`
+}
+
+// mergedWebhookRateLimit mirrors config.WebhookRateLimit.
+type mergedWebhookRateLimit struct {
+	RequestsPerMinute int `json:"requests_per_minute,omitempty"`
+	Burst             int `json:"burst,omitempty"`
+}
+
+// mergedWebhookSyncResp mirrors config.WebhookSyncResponse.
+type mergedWebhookSyncResp struct {
+	Enabled   bool `json:"enabled,omitempty"`
+	TimeoutMs int  `json:"timeout_ms,omitempty"`
+}
+
+func (d *mergedWebhookDef) applyOverlay(ov mergedWebhookDef) {
+	// Enabled is a plain bool: an overlay can only flip it true. The model
+	// disables a webhook by restating the full def via a parent fork
+	// rather than relying on overlay zero-value semantics — matching the
+	// A2AAgentDef VerifySignedCard / server-card capabilities posture.
+	if ov.Enabled {
+		d.Enabled = true
+	}
+	if ov.Delivery != "" {
+		d.Delivery = ov.Delivery
+	}
+	// delivery=spawn and delivery=channel use disjoint target fields
+	// (agent vs channel; the validator rejects both-set). When an overlay
+	// supplies EXACTLY ONE target, clear the OTHER so a fork can flip a
+	// webhook from one delivery mode to the other without leaving a stale
+	// field that would trip the validation refusal. When an overlay
+	// supplies BOTH (a caller mistake), we deliberately do NOT clear
+	// either — the merged def then carries both and the validator rejects
+	// it loudly, rather than silently dropping one target. Mirrors
+	// A2AAgentDef's both-set reachability posture.
+	overlayHasAgent := ov.Agent != ""
+	overlayHasChannel := ov.Channel != ""
+	if overlayHasAgent {
+		d.Agent = ov.Agent
+		if !overlayHasChannel {
+			d.Channel = ""
+		}
+	}
+	if overlayHasChannel {
+		d.Channel = ov.Channel
+		if !overlayHasAgent {
+			d.Agent = ""
+		}
+	}
+	if ov.Auth.Kind != "" {
+		d.Auth.Kind = ov.Auth.Kind
+	}
+	if ov.Auth.Algorithm != "" {
+		d.Auth.Algorithm = ov.Auth.Algorithm
+	}
+	if ov.Auth.Header != "" {
+		d.Auth.Header = ov.Auth.Header
+	}
+	if ov.Auth.SigningSecretEnv != "" {
+		d.Auth.SigningSecretEnv = ov.Auth.SigningSecretEnv
+	}
+	if ov.Auth.DeliveryIDHeader != "" {
+		d.Auth.DeliveryIDHeader = ov.Auth.DeliveryIDHeader
+	}
+	if ov.Auth.BearerTokenEnv != "" {
+		d.Auth.BearerTokenEnv = ov.Auth.BearerTokenEnv
+	}
+	if ov.RateLimit.RequestsPerMinute != 0 {
+		d.RateLimit.RequestsPerMinute = ov.RateLimit.RequestsPerMinute
+	}
+	if ov.RateLimit.Burst != 0 {
+		d.RateLimit.Burst = ov.RateLimit.Burst
+	}
+	if ov.BodySizeLimitBytes != 0 {
+		d.BodySizeLimitBytes = ov.BodySizeLimitBytes
+	}
+	if ov.UserCredentialsFromEnv != nil {
+		d.UserCredentialsFromEnv = ov.UserCredentialsFromEnv
+	}
+	if ov.PayloadMapping != nil {
+		d.PayloadMapping = ov.PayloadMapping
+	}
+	// sync_response is a small struct; an overlay that touches it replaces
+	// the block wholesale (no partial-merge use case — the model either
+	// omits the key to keep the parent's value, or restates the pair).
+	if ov.SyncResponse != (mergedWebhookSyncResp{}) {
+		d.SyncResponse = ov.SyncResponse
+	}
+	if ov.OnComplete != nil {
+		d.OnComplete = ov.OnComplete
+	}
+}
+
+func staticToMergedWebhookDef(w config.Webhook) mergedWebhookDef {
+	out := mergedWebhookDef{
+		Enabled:  w.Enabled,
+		Delivery: w.Delivery,
+		Agent:    w.Agent,
+		Channel:  w.Channel,
+		Auth: mergedWebhookAuth{
+			Kind:             w.Auth.Kind,
+			Algorithm:        w.Auth.Algorithm,
+			Header:           w.Auth.Header,
+			SigningSecretEnv: w.Auth.SigningSecretEnv,
+			DeliveryIDHeader: w.Auth.DeliveryIDHeader,
+			BearerTokenEnv:   w.Auth.BearerTokenEnv,
+		},
+		RateLimit: mergedWebhookRateLimit{
+			RequestsPerMinute: w.RateLimit.RequestsPerMinute,
+			Burst:             w.RateLimit.Burst,
+		},
+		BodySizeLimitBytes:     w.BodySizeLimitBytes,
+		UserCredentialsFromEnv: w.UserCredentialsFromEnv,
+		PayloadMapping:         w.PayloadMapping,
+		SyncResponse: mergedWebhookSyncResp{
+			Enabled:   w.SyncResponse.Enabled,
+			TimeoutMs: w.SyncResponse.TimeoutMs,
+		},
+		// OnComplete is config.ScheduledRunHook on BOTH sides (the merged
+		// shape reuses ScheduleDef's hook type), so the slice is copied by
+		// reference — no field-by-field projection needed.
+		OnComplete: w.OnComplete,
+	}
+	return out
+}

--- a/internal/tools/builtin/webhookdef_test.go
+++ b/internal/tools/builtin/webhookdef_test.go
@@ -1,0 +1,369 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// webhookDefFixture builds a WebhookDef tool over in-memory SQLite + a
+// stub Config with one yaml template (a spawn-delivery hmac webhook).
+// Mirrors a2aAgentDefFixture (RFC H WH-2).
+func webhookDefFixture(t *testing.T) (*WebhookDef, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	cfg := &config.Config{
+		Webhooks: map[string]config.Webhook{
+			"gh-push": {
+				Enabled:  true,
+				Delivery: "spawn",
+				Agent:    "intake",
+				Auth: config.WebhookAuth{
+					Kind:             "hmac",
+					Algorithm:        "sha256",
+					SigningSecretEnv: "LOOMCYCLE_WH_SECRET",
+				},
+			},
+		},
+	}
+	tool := &WebhookDef{
+		Store:               s,
+		Cfg:                 cfg,
+		MaxDefinitionBytes:  131072,
+		MaxDescriptionBytes: 8192,
+	}
+	ctx := tools.WithAgentName(context.Background(), "webhook-orchestrator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"})
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: "webhook-orchestrator",
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func TestWebhookDefTool_CreateRefusedOverStaticName(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"gh-push","overlay":{"delivery":"spawn","agent":"x","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("create over static name should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "static cfg.Webhooks") {
+		t.Errorf("refusal should mention static; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateSpawnHmac(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc","overlay":{"delivery":"spawn","agent":"intake","auth":{"kind":"hmac","signing_secret_env":"LOOMCYCLE_S"}},"description":"new hook"}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["name"] != "adhoc" {
+		t.Errorf("name = %v, want adhoc", out["name"])
+	}
+	if out["version"].(float64) != 1 {
+		t.Errorf("version = %v, want 1", out["version"])
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("create default promote = false; want true")
+	}
+}
+
+func TestWebhookDefTool_CreateChannelDelivery(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"chan-hook","overlay":{"delivery":"channel","channel":"_system/webhooks","auth":{"kind":"bearer","bearer_token_env":"LOOMCYCLE_TOKEN"}}}`))
+	if res.IsError {
+		t.Fatalf("create channel delivery: %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesSpawnWithoutAgent(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"noagent","overlay":{"delivery":"spawn","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("spawn without agent should refuse")
+	}
+	if !strings.Contains(res.Text, "requires agent") {
+		t.Errorf("refusal should mention requires agent; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesChannelWithAgent(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"both","overlay":{"delivery":"channel","channel":"c","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("channel with agent should refuse")
+	}
+	if !strings.Contains(res.Text, "forbids agent") {
+		t.Errorf("refusal should mention forbids agent; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesChannelWithCredentials(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"chan-cred","overlay":{"delivery":"channel","channel":"c","auth":{"signing_secret_env":"LOOMCYCLE_S"},"user_credentials_from_env":{"peer":"LOOMCYCLE_PEER_TOKEN"}}}`))
+	if !res.IsError {
+		t.Fatalf("channel with user_credentials_from_env should refuse (RFC H Decision 11)")
+	}
+	if !strings.Contains(res.Text, "user_credentials_from_env") {
+		t.Errorf("refusal should mention user_credentials_from_env; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesChannelWithCredentialPayloadKey(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"chan-credkey","overlay":{"delivery":"channel","channel":"c","auth":{"signing_secret_env":"LOOMCYCLE_S"},"payload_mapping":{"user_credentials.token":"$.token"}}}`))
+	if !res.IsError {
+		t.Fatalf("channel with user_credentials.* payload key should refuse (RFC H Decision 11)")
+	}
+	if !strings.Contains(res.Text, "user_credentials.token") {
+		t.Errorf("refusal should name the offending key; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesHmacWithoutSecretEnv(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"nosecret","overlay":{"delivery":"spawn","agent":"a","auth":{"kind":"hmac"}}}`))
+	if !res.IsError {
+		t.Fatalf("hmac without signing_secret_env should refuse")
+	}
+	if !strings.Contains(res.Text, "signing_secret_env") {
+		t.Errorf("refusal should mention signing_secret_env; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesBearerWithoutTokenEnv(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"notoken","overlay":{"delivery":"spawn","agent":"a","auth":{"kind":"bearer"}}}`))
+	if !res.IsError {
+		t.Fatalf("bearer without bearer_token_env should refuse")
+	}
+	if !strings.Contains(res.Text, "bearer_token_env") {
+		t.Errorf("refusal should mention bearer_token_env; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesBadEnvVarName(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"badenv","overlay":{"delivery":"spawn","agent":"a","auth":{"kind":"hmac","signing_secret_env":"lower-case"}}}`))
+	if !res.IsError {
+		t.Fatalf("malformed signing_secret_env should refuse")
+	}
+	if !strings.Contains(res.Text, "valid env-var name") {
+		t.Errorf("refusal should mention env-var name; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesUnknownDelivery(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"baddelivery","overlay":{"delivery":"carrier-pigeon","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("unknown delivery should refuse")
+	}
+	if !strings.Contains(res.Text, "unknown delivery") {
+		t.Errorf("refusal should name the bad delivery; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_CreateRefusesBadSyncTimeout(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"badsync","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"},"sync_response":{"enabled":true,"timeout_ms":120000}}}`))
+	if !res.IsError {
+		t.Fatalf("out-of-range sync_response.timeout_ms should refuse")
+	}
+	if !strings.Contains(res.Text, "timeout_ms") {
+		t.Errorf("refusal should mention timeout_ms; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_ForkBootstrapsTemplate(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	// Bootstrap v1 from yaml + fork v2 rotating only the rate limit.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"gh-push","overlay":{"rate_limit":{"requests_per_minute":120}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if v := out["version"].(float64); v != 2 {
+		t.Errorf("version = %v, want 2 (v1 bootstrap + v2 fork)", v)
+	}
+	if out["promoted"].(bool) != true {
+		t.Errorf("fork default promote = false; want true")
+	}
+	def := out["definition"].(map[string]any)
+	// agent survived from the template; only the rate limit changed.
+	if def["agent"] != "intake" {
+		t.Errorf("fork lost template agent; got %v", def["agent"])
+	}
+	rl := def["rate_limit"].(map[string]any)
+	if rl["requests_per_minute"].(float64) != 120 {
+		t.Errorf("rate limit not rotated; got %v", rl["requests_per_minute"])
+	}
+}
+
+// TestWebhookDefTool_ForkFlipsDeliveryMode verifies the overlay can flip
+// a webhook from spawn to channel without leaving the stale agent that
+// would trip the channel-forbids-agent refusal.
+func TestWebhookDefTool_ForkFlipsDeliveryMode(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"gh-push","overlay":{"delivery":"channel","channel":"_system/webhooks"}}`))
+	if res.IsError {
+		t.Fatalf("fork flip: %s", res.Text)
+	}
+	def := decodeResult(t, res.Text)["definition"].(map[string]any)
+	if _, ok := def["agent"]; ok {
+		t.Errorf("agent should be cleared after flipping to channel; got %v", def["agent"])
+	}
+	if def["channel"] != "_system/webhooks" {
+		t.Errorf("channel = %v, want _system/webhooks", def["channel"])
+	}
+}
+
+func TestWebhookDefTool_NoScopesIsDefaultDeny(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"x","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("empty scopes should default-deny")
+	}
+	if !strings.Contains(res.Text, "default-deny") {
+		t.Errorf("refusal should mention default-deny; got %s", res.Text)
+	}
+}
+
+func TestWebhookDefTool_NamedScope(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	ctx = tools.WithWebhookDefPolicy(ctx, tools.WebhookDefPolicyValue{
+		Scopes: []string{"named:adhoc"},
+	})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if res.IsError {
+		t.Fatalf("named scope should allow matching name; got %s", res.Text)
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"other","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if !res.IsError {
+		t.Fatalf("named scope should refuse non-matching name")
+	}
+}
+
+func TestWebhookDefTool_RetireRoundTrip(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"retire-hook","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if res.IsError {
+		t.Fatalf("retire: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["retired"].(bool) != true {
+		t.Errorf("retired = false, want true")
+	}
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":false}`))
+	if res.IsError {
+		t.Fatalf("un-retire: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["retired"].(bool) != false {
+		t.Errorf("retired = true, want false")
+	}
+}
+
+func TestWebhookDefTool_GetRoundTrip(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"get-hook","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("get: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["name"] != "get-hook" {
+		t.Errorf("get returned wrong name")
+	}
+}
+
+func TestWebhookDefTool_ListReturnsVersions(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	for i := 0; i < 3; i++ {
+		op := `create`
+		if i > 0 {
+			op = `fork`
+		}
+		_, _ = tool.Execute(ctx, json.RawMessage(`{"op":"`+op+`","name":"multi-hook","overlay":{"delivery":"spawn","agent":"a","auth":{"signing_secret_env":"LOOMCYCLE_S"}}}`))
+	}
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"multi-hook"}`))
+	if res.IsError {
+		t.Fatalf("list: %s", res.Text)
+	}
+	versions := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 3 {
+		t.Errorf("got %d versions, want 3", len(versions))
+	}
+}
+
+// TestMergedWebhookDef_DriftDetection_VsLookupSubstrate pins json-tag
+// parity between mergedWebhookDef (substrate-write) and
+// lookup.SubstrateWebhookDef (substrate-read). RFC H WH-2.
+func TestMergedWebhookDef_DriftDetection_VsLookupSubstrate(t *testing.T) {
+	mergedTags := a2aBuiltinJSONTagsOf(reflect.TypeOf(mergedWebhookDef{}))
+	substrateTags := a2aBuiltinJSONTagsOf(reflect.TypeOf(lookup.SubstrateWebhookDef{}))
+
+	for tag := range mergedTags {
+		if !substrateTags[tag] {
+			t.Errorf("mergedWebhookDef has json tag %q but lookup.SubstrateWebhookDef does not — mirror it on the lookup side", tag)
+		}
+	}
+	for tag := range substrateTags {
+		if !mergedTags[tag] {
+			t.Errorf("lookup.SubstrateWebhookDef has json tag %q but mergedWebhookDef does not — substrate-write is the source-of-truth shape", tag)
+		}
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -659,6 +659,29 @@ func A2AAgentDefPolicy(ctx context.Context) A2AAgentDefPolicyValue {
 	return v
 }
 
+type ctxKeyWebhookDefPolicy struct{}
+
+// WebhookDefPolicyValue is the per-agent WebhookDef-tool access policy
+// (v1.x RFC H). Same shape as A2AAgentDefPolicyValue + same
+// "self / descendants / named:<n> / any" closed scope set.
+// Default-deny when Scopes is empty.
+type WebhookDefPolicyValue struct {
+	Scopes   []string
+	SelfName string
+}
+
+// WithWebhookDefPolicy attaches the policy to ctx.
+func WithWebhookDefPolicy(ctx context.Context, p WebhookDefPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeyWebhookDefPolicy{}, p)
+}
+
+// WebhookDefPolicy returns the policy from ctx. Zero value =
+// default-deny.
+func WebhookDefPolicy(ctx context.Context) WebhookDefPolicyValue {
+	v, _ := ctx.Value(ctxKeyWebhookDefPolicy{}).(WebhookDefPolicyValue)
+	return v
+}
+
 // ctxKeySkillDefPolicy carries the v0.8.22 SkillDef-tool capability
 // gate. Mirrors AgentDefPolicy shape, sans the SelfName field —
 // skills have no agent identity so a "self" scope is meaningless.

--- a/proto/loomcycle.proto
+++ b/proto/loomcycle.proto
@@ -224,6 +224,13 @@ service Loomcycle {
   // in the response.
   rpc A2AAgentDef(SubstrateRequest) returns (SubstrateResponse);
 
+  // WebhookDef dispatches to the v1.x RFC H inbound-webhook substrate.
+  // Mirrors POST /v1/_webhookdef. Operator-admin-only. Same
+  // SubstrateRequest body shape — op-discriminated input_json
+  // (create / fork / get / list / retire) + is_error tool refusals
+  // in the response. (RFC H WH-3 / mirrors A2AAgentDef.)
+  rpc WebhookDef(SubstrateRequest) returns (SubstrateResponse);
+
   // ----- v0.9.x n8n RFC Phase 0 -----
   //
   // ListChannels mirrors GET /v1/_channels — operator-declared


### PR DESCRIPTION
## Why

External systems (GitHub, Stripe, Linear, CI servers, n8n cloud) had no first-class way to trigger loomcycle work. Operators wrote the same glue every time: decode the payload, verify the per-route HMAC, reshape the body into a run request, POST to `/v1/runs` with the operator bearer — moving credential handling *out* of the substrate and re-implementing it per source. RFC H closes that gap with a fifth substrate primitive, `WebhookDef`, that makes inbound triggers signed-by-default, versioned, and symmetric with the other Defs. Scheduled runs (RFC E) and webhook-triggered runs are the two halves of one problem — autonomous run creation from a non-interactive source.

Additive and **off by default** (`LOOMCYCLE_WEBHOOKS_ENABLED`). No existing surface changes.

## What

Six slices, each reviewed + gated + committed:

| Slice | What |
|---|---|
| **WH-1** | Store foundation — `WebhookDef*` (9 methods, both backends), migration 0032, `config.Webhook` schema, lookup adapter + 3-way drift test, contract tests |
| **WH-2** | 5-op tool + scope policy + `validateWebhookDef` (incl. Decision 11: channel mode forbids credentials) + HTTP admin `/v1/_webhookdef` |
| **WH-3** | 4-transport CRUD — gRPC RPC + MCP meta-tool (count 36→37) + TS `webhookDef()` |
| **WH-4** | **The receiver** — `POST /v1/_webhooks/{name}`: verify-before-parse HMAC (Stripe + GitHub envelopes + bearer), replay/dedup, strict JSONPath, rate limit, spawn + channel delivery |
| **WH-5a** | `runs.idempotency_key` (Layer-2 durable dedup, migration 0033) — re-delivered events land on the same run, never double-spawn |
| **WH-5b** | `on_complete` hooks (channel.publish + memory.set) + admin triage endpoints (`/recent-deliveries`, `/test`) |
| **WH-6** | `Context.help input-webhooks` + REVISIONS v0.14.0 + README |

**Delivery modes:** `spawn` → `runner.RunOnce` (the mapped goal enters as an **untrusted-block**, fenced in `<untrusted>` tags — external payload is attacker-influenceable); async `202 {run_id}` or `?sync=true` → block to terminal (200/504). `channel` → `SystemPublisher` + bus notify (wakes parked agents; no run, no credentials).

**Security posture (trust boundary):** signature verified over raw bytes **before** any parse, constant-time `hmac.Equal`; secrets env-allowlist-gated and never logged/echoed; the receiver POST is unauthed (per-Def secret) while triage endpoints are admin-bearer-gated; `/test` previews credential **key names** only. Error contract is fail-loud and oracle-free (401 opaque on any auth failure, 503 `secret_unresolvable` naming the env var only, 400/429/404 distinct).

## Two trust-boundary bugs caught + fixed in review (each with a regression test)
- **Silent event loss** — the Layer-1 dedup recorded the `delivery_id` at the guard step, so a delivery that passed signature but was then rate-limited / mapping-rejected / hit a transient setup 503 burned its id and the sender's legitimate retry was dropped as a replay. Split into `seen()`/`record()` so the id is only burned on actual acceptance.
- **Prompt-injection gap** — the external payload `goal` was marked `trusted-text`, bypassing the loop's `<untrusted>` fence. Changed to `untrusted-block`.

## What was tested
- `go build ./... && go vet ./... && go test ./...` — clean (full suite; WH-5a is a core-path change touching every run's creation).
- `-race` clean on `internal/api/webhook/`.
- `gofmt` clean. TS adapter builds + 173 tests pass.
- Comprehensive unit + handler-level coverage: both signature envelopes, tampered/replay/out-of-window, bearer fallback, unresolvable secret (503), rate limit (429), JSONPath (nested/array/absent/malformed), channel mode, sync mode, both idempotency layers (incl. the concurrent-race → 202-deduped resolution), on_complete (channel.publish/memory.set fire; mcp.call skips), and the triage endpoints (recent-deliveries cap/order; /test no-run + no credential-value leak).
- Live-Postgres contract tests confirm migrations 0032 + 0033 apply and the 23505/constraint-name dup detection works.

## Notes / deferred (clearly scoped)
- **Single-replica v1** per the RFC: Layer-1 dedup + rate-limit buckets are per-replica; Layer-2 `idempotency_key` is the durable cross-replica backstop. Cluster-wide dedup/rate-limit is a later concern.
- `on_complete` `mcp.call` is reserved (logged + skipped — the receiver has no MCPCaller, same as the scheduler's pending follow-up).
- `@loomcycle/client` gains `webhookDef()` (will need a version bump on the v0.14.0 release tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)