### PR TITLE
chore(release): provision v0.14.1 (first tagged build of the v0.14 line)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,25 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in v0.14.1
+
+**First tagged build of the v0.14 line.** v0.14.0 (Input Webhooks, below) was
+merged but never tagged; v0.14.1 is the cut point that publishes the whole
+v0.14 line — the webhooks work **plus** a documentation correction — as one
+release.
+
+- **README pre-v1.0 status correction.** Dropped the inaccurate "v1.0
+  shipped — multi-replica HA in production" banner and the "v1.0 capstone …
+  | v1.0" shipped-row. loomcycle is in **active development toward v1.0** —
+  no v1.0 tag exists; the primitives stabilised through v0.8 → v0.14, with a
+  final feature + hardening pass remaining. Forward-looking roadmap
+  references are unchanged.
+- **`@loomcycle/client` → 0.14.1** publishes the `webhookDef()` substrate
+  method that shipped with Input Webhooks (the adapter version had stayed at
+  0.13.0 through the webhooks merge).
+
+No code behavior change beyond the v0.14.0 feature set below.
+
 ## What's in v0.14.0
 
 **Headline: Input Webhooks (RFC H) — the `WebhookDef` substrate.** External

--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.13.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.13.0",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.13.0",
+  "version": "0.14.1",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 46 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed AND v0.11.5 setMemoryEntry + deleteMemoryEntry), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.11.5 Channel admin CRUD (createChannel + updateChannel + deleteChannel — runtime substrate; yaml channels refuse mutation with HTTP 409), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Why

v0.14.0 (Input Webhooks, RFC H) merged to `main` with its REVISIONS entry but was **never tagged** — the latest tag is v0.13.0, and `@loomcycle/client` is still 0.13.0 (without the `webhookDef()` method). This provisions **v0.14.1** as the first tagged build of the v0.14 line: it ships the webhooks work plus the README pre-v1.0 correction in one release.

## What

- `adapters/ts/package.json` + lock → **0.14.1** (publishes `webhookDef()`).
- `REVISIONS.md` → "What's in v0.14.1" (the README pre-v1.0 status correction; notes it's the first tagged build delivering the v0.14.0 webhooks work).

No code-behavior change beyond the already-merged v0.14.0 feature set.

## After merge

Tag `v0.14.1` on `main` → triggers `release.yml` (goreleaser GitHub release) + `publish-ts-adapter.yml` (npm publish `@loomcycle/client@0.14.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)