### PR TITLE
fix(cluster-mock): restart:on-failure on replicas to bridge PG-DNS race

### DIFF
--- a/test/load/cluster-mock/run-cluster-otel.sh
+++ b/test/load/cluster-mock/run-cluster-otel.sh
@@ -251,6 +251,13 @@ for i in $(seq 1 "$REPLICAS"); do
 cat <<YAML
   replica-${i}:
     image: $IMAGE
+    # Auto-restart past the docker DNS-propagation race against fresh
+    # volumes: on rare clean-cluster boots, pg_isready returns ready
+    # but the replica's first pg ping resolves "postgres" before the
+    # container's network is fully routable. The substrate exits
+    # fatally on first-ping failure; on_failure restart bridges the
+    # ~2-5s window cleanly. Bounded retries so a real bug still surfaces.
+    restart: on-failure:5
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Why: launching the 8h stability test against a fresh build (no cached volumes, no prior image) hit a docker DNS-propagation race. Postgres became healthy per `pg_isready` (which connects locally inside the pg container), but all 4 replicas got `connect: connection refused` to `postgres:5432` on their first ping — the docker bridge network's DNS hadn't yet routed the pg container's hostname. The substrate exits fatally on first store-open failure, so all replicas died at startup and the orchestrator timed out after 3 min.

What: added `restart: on-failure:5` to each replica service in the generated docker-compose. The replica exits, docker auto-restarts it, by then DNS is fully propagated and the connection succeeds. Bounded retries (5) so a real connectivity bug still surfaces as a clear "hit max retries" rather than restarting forever.

The race is rare — fires only against entirely fresh state (no cached loomcycle image, no cached docker volumes). All prior cluster-mock OTEL runs benefited from cached state and never tripped it. Re-running this same orchestrator without the fix would intermittently fail.

Tested by:
- Smoke run before the 8h stability test: r=4 x100:1min, all replicas came up healthy, 20 waves at 100 % completion.
- The 8h stability test itself: ran cleanly, restart-on-failure never needed to fire (race didn't repeat with image already pulled).

<!--
  ⚠️ Loomcycle is CLOSED to external contributions until v1.x ships.

  Pull requests during v0.8 / v0.9 / v1.0 active development are
  acknowledged but not reviewed or merged. See CONTRIBUTING.md for
  the full policy and the trigger conditions for reopening.

  EXCEPTIONS that are still merged during the freeze:
    • Security fixes — mark the PR clearly as such.
    • Internal contributions from the maintainer's own branches.

  If your PR is neither of the above, it will be closed without
  prejudice. The same change is welcome to be re-opened after v1.0
  ships.

  Bug reports for clear-cut runtime defects (panic, data
  corruption, broken wire shape) ARE still triaged — please file as
  an issue rather than a PR.
-->

## Summary

<!-- One-line description of the change. -->

## Why this is being submitted during the v0.8/v0.9/v1.0 freeze

<!-- Required: pick one and check it. PRs without a checked box are
     closed automatically. -->

- [ ] Security fix (CVE / disclosure / mitigation)
- [ ] Internal contributor (maintainer's own work or maintainer-confirmed)
- [ ] None of the above — I understand this PR will be closed without merge

## What was tested

<!-- For security fixes / internal: bullet list of tests run. -->
