### PR TITLE
chore(release): provision v0.15.0 (bump @loomcycle/client for the RFC I release)

### DIFF
--- a/adapters/ts/package-lock.json
+++ b/adapters/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@loomcycle/client",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.6.0",

--- a/adapters/ts/package.json
+++ b/adapters/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@loomcycle/client",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "TypeScript client for the loomcycle sidecar (HTTP+SSE). 46 methods covering run streaming, agent metadata, pause/resume/state, snapshot lifecycle, memory admin (incl. v0.9.0 Vector Memory embed_stats + reembed AND v0.11.5 setMemoryEntry + deleteMemoryEntry), interruption resolve, hook management, v0.8.22 substrate admin (agentDef + skillDef), v0.9.x n8n Phase 0 (listChannels + streamUserRunStates), v0.9.x Channel CRUD (publishChannel + subscribeChannel + peekChannel + ackChannel), v0.11.5 Channel admin CRUD (createChannel + updateChannel + deleteChannel — runtime substrate; yaml channels refuse mutation with HTTP 409), v0.9.x content_sha256 verify, v0.9.1 transcript first-cycle, v0.9.x dynamic MCP server registration (mcpServerDef + MCPServerDefVerifyResult), v0.10.3 Library v2 enumeration (listLibraryAgents + listLibrarySkills + listLibraryMcpServers), and v0.11.0 LLM Gateway (llmChat + llmStream — direct provider routing without agent overhead; primary target is n8n's LoomCycleChatModel AI Agent sub-node and any LangChain-compatible consumer). v0.10.1 — dual ESM + CommonJS distribution (additive — ESM consumers unchanged; CJS consumers like n8n's community-node loader now work).",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Why

Memory ranking, dedup & pluggable backends (RFC I, PR #297) merged to `main` with its REVISIONS v0.15.0 entry, but the TS adapter stayed at 0.14.1 — even though the feature added `memoryBackendDef()`. Tagging `v0.15.0` with the adapter at 0.14.1 would skip the npm publish (gated on tag == package.json), leaving the method unpublished.

## What

- `adapters/ts/package.json` + lock → **0.15.0** (publishes `memoryBackendDef()`).

No code-behavior change; REVISIONS v0.15.0 already landed with the feature.

## After merge

Tag `v0.15.0` on `main` → triggers `release.yml` (goreleaser GitHub release) + `publish-ts-adapter.yml` (npm publish `@loomcycle/client@0.15.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)