### PR TITLE
fix(a2a): enforce routed-tenant isolation on tasks/get, cancel & list

### DIFF
--- a/internal/a2a/auth.go
+++ b/internal/a2a/auth.go
@@ -2,8 +2,12 @@ package a2a
 
 import (
 	"context"
+	"errors"
 
+	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
 	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
 // principal is the authenticated identity the bridge threads into a
@@ -104,4 +108,62 @@ func principalFromContext(ctx context.Context, tenant string) principal {
 		p.TenantID = callCtx.Tenant()
 	}
 	return p
+}
+
+// authorizeTaskTenant enforces the host/path-authoritative tenant on the
+// A2A read/cancel paths, where the caller-supplied A2A Task.id IS the
+// loomcycle agent_id — a non-secret, addressable handle. Without it a peer
+// authenticated on one tenant's routed host could resolve a run owned by
+// another tenant (cross-tenant cancel is destructive; cross-tenant get
+// leaks run status + the raw ErrorMsg). The create path already honours
+// the routed tenant via principalFromContext; this closes the read/cancel
+// side, which previously resolved purely by agent_id.
+//
+// It resolves the run behind agentID and the tenant of its owning session
+// (the runs table has no tenant column — tenant lives on the session, see
+// store.Session.TenantID) and compares that to the authoritative routed
+// tenant stamped by the mounting layer (WithRoutedTenant).
+//
+// Returns:
+//   - nil in single-tenant / none mode (RoutedTenantFrom ok==false): there
+//     is no cross-tenant surface, so this is a no-op and behaviour is
+//     unchanged — no store round-trips are made.
+//   - nil when the run's session tenant equals the routed tenant.
+//   - a2asdk.ErrTaskNotFound on a cross-tenant mismatch, OR when the run /
+//     session is not found. ErrTaskNotFound (not a distinct "forbidden")
+//     is deliberate: a distinct error is an oracle that confirms the task
+//     exists under another tenant. Failing closed on a not-found run also
+//     covers the brief window between SDK task Create and run-row
+//     persistence — a just-created task is hidden from a cross-tenant
+//     probe rather than leaked.
+//   - the underlying store error for any non-not-found failure, so a real
+//     storage fault is not masked as "task not found".
+func authorizeTaskTenant(ctx context.Context, runs RunReader, agentID string) error {
+	routed, ok := RoutedTenantFrom(ctx)
+	if !ok {
+		return nil
+	}
+	run, err := runs.GetRunByAgentID(ctx, agentID)
+	if err != nil {
+		return notFoundAsTaskNotFound(err)
+	}
+	sess, err := runs.GetSession(ctx, run.SessionID)
+	if err != nil {
+		return notFoundAsTaskNotFound(err)
+	}
+	if sess.TenantID != routed {
+		return a2asdk.ErrTaskNotFound
+	}
+	return nil
+}
+
+// notFoundAsTaskNotFound maps a loomcycle store-not-found to the SDK's
+// a2asdk.ErrTaskNotFound sentinel (so the A2A frontier returns a proper
+// task-not-found), while passing any other error through unchanged.
+func notFoundAsTaskNotFound(err error) error {
+	var nf *store.ErrNotFound
+	if errors.As(err, &nf) {
+		return a2asdk.ErrTaskNotFound
+	}
+	return err
 }

--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -376,6 +376,15 @@ func answerFromMessage(msg *a2asdk.Message) string {
 func (e *Executor) Cancel(ctx context.Context, execCtx *a2asrv.ExecutorContext) iter.Seq2[a2asdk.Event, error] {
 	return func(yield func(a2asdk.Event, error) bool) {
 		agentID := string(execCtx.TaskID)
+		// Tenant gate before the destructive cancel. agentID is the
+		// caller-supplied A2A Task.id; CancelRun resolves it purely by
+		// agent_id (no tenant predicate), so without this a peer on
+		// tenant-A's routed host could cancel tenant-B's in-flight run
+		// (cascading to its sub-agents). No-op in single-tenant/none mode.
+		if err := authorizeTaskTenant(ctx, e.runs, agentID); err != nil {
+			yield(nil, err)
+			return
+		}
 		if _, err := e.conn.CancelRun(ctx, agentID, "a2a cancel"); err != nil {
 			yield(nil, fmt.Errorf("a2a executor: cancel run %q: %w", agentID, err))
 			return

--- a/internal/a2a/executor_test.go
+++ b/internal/a2a/executor_test.go
@@ -37,9 +37,13 @@ func (f *fakeRunner) RunOnce(ctx context.Context, in runner.RunInput, cb runner.
 	return f.runErr
 }
 
-// fakeRuns is an in-memory RunReader keyed by agent_id.
+// fakeRuns is an in-memory RunReader keyed by agent_id. bySession is the
+// optional session→Session map the tenant-scoping path (GetSession) reads;
+// nil/absent means GetSession returns ErrNotFound (fine for the
+// single-tenant tests that never stamp a routed tenant).
 type fakeRuns struct {
 	byAgentID map[string]store.Run
+	bySession map[string]store.Session
 }
 
 func (f *fakeRuns) GetRun(ctx context.Context, runID string) (store.Run, error) {
@@ -56,6 +60,13 @@ func (f *fakeRuns) GetRunByAgentID(ctx context.Context, agentID string) (store.R
 		return r, nil
 	}
 	return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+}
+
+func (f *fakeRuns) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
+	if s, ok := f.bySession[sessionID]; ok {
+		return s, nil
+	}
+	return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
 }
 
 // fakeConnector embeds the interface (so we only implement what the

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -13,12 +13,18 @@ import (
 )
 
 // RunReader is the read-only slice of store.Store the task store needs.
-// Narrowed to two methods so tests inject a fake without the full Store
-// surface, and so the bridge cannot accidentally mutate the run table
-// (run rows are owned by the loop; A2A never writes them).
+// Narrowed so tests inject a fake without the full Store surface, and so
+// the bridge cannot accidentally mutate the run table (run rows are owned
+// by the loop; A2A never writes them).
 type RunReader interface {
 	GetRun(ctx context.Context, runID string) (store.Run, error)
 	GetRunByAgentID(ctx context.Context, agentID string) (store.Run, error)
+	// GetSession resolves a run's owning session. Its TenantID is the
+	// authoritative tenant for A2A cross-tenant scoping on the get/cancel
+	// paths: the runs table carries NO tenant column — tenant lives on the
+	// session (store.Session.TenantID) — so resolving the run's tenant
+	// means a run→session hop. store.Store satisfies this.
+	GetSession(ctx context.Context, sessionID string) (store.Session, error)
 }
 
 // TaskStore implements the SDK's taskstore.Store over loomcycle's run
@@ -99,6 +105,17 @@ func (s *TaskStore) Update(ctx context.Context, req *taskstore.UpdateRequest) (t
 // falls through to the run table, treating the A2A Task.id as a
 // loomcycle agent_id. Returns a2a.ErrTaskNotFound when neither has it.
 func (s *TaskStore) Get(ctx context.Context, taskID a2asdk.TaskID) (*taskstore.StoredTask, error) {
+	// Tenant gate FIRST, before either the in-memory hit or the run-table
+	// fallback can return a task. The A2A Task.id IS a caller-supplied
+	// loomcycle agent_id (a non-secret addressable handle), and the
+	// in-memory map is process-global across every tenant a host/path-
+	// routed server fronts — so without this a peer authenticated on
+	// tenant-A's routed host could read tenant-B's task (status + the raw
+	// ErrorMsg taskFromRun packs in). A no-op in single-tenant/none mode.
+	if err := authorizeTaskTenant(ctx, s.runs, string(taskID)); err != nil {
+		return nil, err
+	}
+
 	s.mu.RLock()
 	stored, ok := s.tasks[taskID]
 	s.mu.RUnlock()

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -146,11 +146,14 @@ func (s *TaskStore) Get(ctx context.Context, taskID a2asdk.TaskID) (*taskstore.S
 // List enumerates in-memory tasks. The run-table fallback is not
 // listable (no efficient by-status scan keyed to A2A semantics this
 // slice); callers that need run enumeration use the loomcycle ListRuns
-// surface. Honours req.ContextID and req.Status filters when set.
+// surface. Honours req.ContextID and req.Status filters when set, and the
+// authoritative routed tenant when a routing mode is active.
 func (s *TaskStore) List(ctx context.Context, req *a2asdk.ListTasksRequest) (*a2asdk.ListTasksResponse, error) {
+	// Snapshot the context/status-filtered candidates under the lock, then
+	// resolve tenant ownership OUTSIDE it: the tenant check does store
+	// round-trips (run→session) and must not hold the map lock during I/O.
 	s.mu.RLock()
-	defer s.mu.RUnlock()
-	out := make([]*a2asdk.Task, 0, len(s.tasks))
+	candidates := make([]*a2asdk.Task, 0, len(s.tasks))
 	for _, st := range s.tasks {
 		if req != nil {
 			if req.ContextID != "" && st.Task.ContextID != req.ContextID {
@@ -160,7 +163,27 @@ func (s *TaskStore) List(ctx context.Context, req *a2asdk.ListTasksRequest) (*a2
 				continue
 			}
 		}
-		out = append(out, st.Task)
+		candidates = append(candidates, st.Task)
+	}
+	s.mu.RUnlock()
+
+	// The in-memory map is process-global across every tenant a host/path-
+	// routed server fronts, and the caller-supplied ContextID is the
+	// loomcycle SessionID (run-derived, NOT a tenant boundary), so without
+	// this a peer on tenant-A's routed host could enumerate tenant-B's
+	// task ids / context ids / states / status messages. In a routing mode
+	// (RoutedTenantFrom ok==true) keep only tasks whose backing run belongs
+	// to the routed tenant: authorizeTaskTenant returns nil on a match, and
+	// any non-nil (cross-tenant OR an unresolved run) excludes the task —
+	// fail-closed, never leak. Single-tenant/none mode lists all, as before.
+	out := candidates
+	if _, ok := RoutedTenantFrom(ctx); ok {
+		out = make([]*a2asdk.Task, 0, len(candidates))
+		for _, t := range candidates {
+			if authorizeTaskTenant(ctx, s.runs, string(t.ID)) == nil {
+				out = append(out, t)
+			}
+		}
 	}
 	return &a2asdk.ListTasksResponse{
 		Tasks:     out,

--- a/internal/a2a/tenant_test.go
+++ b/internal/a2a/tenant_test.go
@@ -1,0 +1,137 @@
+package a2a
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// crossTenantRuns builds a fakeRuns where agent_id "task-b" resolves to a
+// run whose owning session belongs to tenant "tenant-b". A request routed
+// to "tenant-a" must not be able to reach it.
+func crossTenantRuns() *fakeRuns {
+	return &fakeRuns{
+		byAgentID: map[string]store.Run{
+			"task-b": {ID: "run-b", AgentID: "task-b", SessionID: "sess-b", Status: store.RunRunning},
+		},
+		bySession: map[string]store.Session{
+			"sess-b": {ID: "sess-b", TenantID: "tenant-b"},
+		},
+	}
+}
+
+// TestTaskStore_GetRejectsCrossTenantAgentID_Fallback pins the HIGH
+// cross-tenant tasks/get leak via the run-table fallback: a peer routed to
+// tenant-a issues tasks/get with tenant-b's agent_id (a non-secret handle)
+// and must get ErrTaskNotFound rather than tenant-b's run status/ErrorMsg.
+//
+// Regression-grade: on the unfixed Get (no tenant gate) this returns a
+// synthesised Task for tenant-b's run.
+func TestTaskStore_GetRejectsCrossTenantAgentID_Fallback(t *testing.T) {
+	ts := NewTaskStore(crossTenantRuns())
+	ctx := WithRoutedTenant(context.Background(), "tenant-a")
+	if _, err := ts.Get(ctx, "task-b"); !errors.Is(err, a2asdk.ErrTaskNotFound) {
+		t.Fatalf("cross-tenant get (fallback) err = %v, want a2a.ErrTaskNotFound", err)
+	}
+}
+
+// TestTaskStore_GetRejectsCrossTenantAgentID_InMemory covers the same leak
+// via the process-global in-memory map (one TaskStore fronts every tenant
+// a host/path-routed server serves). Even with the task present in the
+// map, a tenant-a request for tenant-b's task must be refused.
+//
+// Regression-grade: on the unfixed Get the in-memory hit returns first,
+// before any tenant consideration.
+func TestTaskStore_GetRejectsCrossTenantAgentID_InMemory(t *testing.T) {
+	ts := NewTaskStore(crossTenantRuns())
+	// Seed the in-memory map with tenant-b's task.
+	if _, err := ts.Create(context.Background(), &a2asdk.Task{
+		ID: "task-b", ContextID: "sess-b", Status: a2asdk.TaskStatus{State: a2asdk.TaskStateWorking},
+	}); err != nil {
+		t.Fatalf("seed create: %v", err)
+	}
+	ctx := WithRoutedTenant(context.Background(), "tenant-a")
+	if _, err := ts.Get(ctx, "task-b"); !errors.Is(err, a2asdk.ErrTaskNotFound) {
+		t.Fatalf("cross-tenant get (in-memory) err = %v, want a2a.ErrTaskNotFound", err)
+	}
+}
+
+// TestTaskStore_GetAllowsSameTenant confirms the gate does not block the
+// legitimate owner: a request routed to tenant-b resolves tenant-b's task.
+func TestTaskStore_GetAllowsSameTenant(t *testing.T) {
+	ts := NewTaskStore(crossTenantRuns())
+	ctx := WithRoutedTenant(context.Background(), "tenant-b")
+	got, err := ts.Get(ctx, "task-b")
+	if err != nil {
+		t.Fatalf("same-tenant get: %v", err)
+	}
+	if got.Task.ID != "task-b" {
+		t.Errorf("task id = %q, want task-b", got.Task.ID)
+	}
+}
+
+// TestTaskStore_GetSingleTenantModeUnchanged confirms that with no routing
+// mode active (no WithRoutedTenant stamp), Get performs no tenant check and
+// behaves exactly as before — the gate is purely additive for multi-tenant
+// deployments.
+func TestTaskStore_GetSingleTenantModeUnchanged(t *testing.T) {
+	ts := NewTaskStore(crossTenantRuns())
+	got, err := ts.Get(context.Background(), "task-b") // no routed tenant
+	if err != nil {
+		t.Fatalf("single-tenant get: %v", err)
+	}
+	if got.Task.ID != "task-b" {
+		t.Errorf("task id = %q, want task-b", got.Task.ID)
+	}
+}
+
+// TestExecutor_CancelRejectsCrossTenantTaskID pins the HIGH cross-tenant
+// cancel: a peer routed to tenant-a sends tasks/cancel with tenant-b's
+// agent_id and must be refused with ErrTaskNotFound BEFORE the destructive
+// CancelRun fires.
+//
+// Regression-grade: on the unfixed Cancel, CancelRun is invoked with
+// "task-b" and a CANCELED status is emitted.
+func TestExecutor_CancelRejectsCrossTenantTaskID(t *testing.T) {
+	fc := &fakeConnector{}
+	ex := NewExecutor(&fakeRunner{}, fc, crossTenantRuns(), "qa-agent")
+
+	ctx := WithRoutedTenant(context.Background(), "tenant-a")
+	execCtx := &a2asrv.ExecutorContext{TaskID: "task-b", ContextID: "c"}
+	_, errs := collect(ex.Cancel(ctx, execCtx))
+
+	if len(errs) != 1 || !errors.Is(errs[0], a2asdk.ErrTaskNotFound) {
+		t.Fatalf("cross-tenant cancel errs = %v, want exactly [a2a.ErrTaskNotFound]", errs)
+	}
+	if fc.cancelledAgentID != "" {
+		t.Errorf("CancelRun was invoked for agent_id %q; cross-tenant cancel must not reach the connector", fc.cancelledAgentID)
+	}
+}
+
+// TestExecutor_CancelAllowsSameTenant confirms the legitimate owner
+// (routed to tenant-b) still cancels tenant-b's run and gets CANCELED.
+func TestExecutor_CancelAllowsSameTenant(t *testing.T) {
+	fc := &fakeConnector{}
+	ex := NewExecutor(&fakeRunner{}, fc, crossTenantRuns(), "qa-agent")
+
+	ctx := WithRoutedTenant(context.Background(), "tenant-b")
+	execCtx := &a2asrv.ExecutorContext{TaskID: "task-b", ContextID: "c"}
+	events, errs := collect(ex.Cancel(ctx, execCtx))
+	if len(errs) != 0 {
+		t.Fatalf("same-tenant cancel errs = %v, want none", errs)
+	}
+	if fc.cancelledAgentID != "task-b" {
+		t.Errorf("cancelled agent_id = %q, want task-b", fc.cancelledAgentID)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 (CANCELED)", len(events))
+	}
+	if su, ok := events[0].(*a2asdk.TaskStatusUpdateEvent); !ok || su.Status.State != a2asdk.TaskStateCanceled {
+		t.Errorf("event = %#v, want CANCELED status", events[0])
+	}
+}

--- a/internal/a2a/tenant_test.go
+++ b/internal/a2a/tenant_test.go
@@ -90,6 +90,44 @@ func TestTaskStore_GetSingleTenantModeUnchanged(t *testing.T) {
 	}
 }
 
+// TestTaskStore_ListIsolatesByRoutedTenant pins the cross-tenant
+// tasks/list enumeration: the in-memory map is process-global across every
+// tenant a routed server fronts, so a List routed to tenant-a must return
+// only tenant-a's tasks, never tenant-b's.
+//
+// Regression-grade: on the unfixed List (no tenant filter) both tasks come
+// back.
+func TestTaskStore_ListIsolatesByRoutedTenant(t *testing.T) {
+	runs := &fakeRuns{
+		byAgentID: map[string]store.Run{
+			"task-a": {ID: "run-a", AgentID: "task-a", SessionID: "sess-a", Status: store.RunRunning},
+			"task-b": {ID: "run-b", AgentID: "task-b", SessionID: "sess-b", Status: store.RunRunning},
+		},
+		bySession: map[string]store.Session{
+			"sess-a": {ID: "sess-a", TenantID: "tenant-a"},
+			"sess-b": {ID: "sess-b", TenantID: "tenant-b"},
+		},
+	}
+	ts := NewTaskStore(runs)
+	// Seed one task per tenant into the shared in-memory map.
+	for _, id := range []a2asdk.TaskID{"task-a", "task-b"} {
+		if _, err := ts.Create(context.Background(), &a2asdk.Task{
+			ID: id, Status: a2asdk.TaskStatus{State: a2asdk.TaskStateWorking},
+		}); err != nil {
+			t.Fatalf("seed create %s: %v", id, err)
+		}
+	}
+
+	ctx := WithRoutedTenant(context.Background(), "tenant-a")
+	resp, err := ts.List(ctx, &a2asdk.ListTasksRequest{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(resp.Tasks) != 1 || resp.Tasks[0].ID != "task-a" {
+		t.Fatalf("tenant-a list = %#v, want exactly [task-a] (tenant-b's task must not leak)", resp.Tasks)
+	}
+}
+
 // TestExecutor_CancelRejectsCrossTenantTaskID pins the HIGH cross-tenant
 // cancel: a peer routed to tenant-a sends tasks/cancel with tenant-b's
 // agent_id and must be refused with ErrTaskNotFound BEFORE the destructive

--- a/internal/api/a2a/integration_test.go
+++ b/internal/api/a2a/integration_test.go
@@ -38,13 +38,14 @@ type scriptedBackend struct {
 	scriptFor func(agent string) ([]providers.Event, store.RunStatus, string)
 
 	mu         sync.Mutex
-	runs       map[string]store.Run // keyed by agent_id (== A2A task id)
-	ranAgents  []string             // ordered record of which agents ran
-	ranTenants []string             // ordered record of the tenant each run was attributed to
+	runs       map[string]store.Run     // keyed by agent_id (== A2A task id)
+	sessions   map[string]store.Session // keyed by session_id; carries the run's tenant
+	ranAgents  []string                 // ordered record of which agents ran
+	ranTenants []string                 // ordered record of the tenant each run was attributed to
 }
 
 func newScriptedBackend(scriptFor func(agent string) ([]providers.Event, store.RunStatus, string)) *scriptedBackend {
-	return &scriptedBackend{scriptFor: scriptFor, runs: map[string]store.Run{}}
+	return &scriptedBackend{scriptFor: scriptFor, runs: map[string]store.Run{}, sessions: map[string]store.Session{}}
 }
 
 // RunOnce drives the scripted event stream for the routed agent, then
@@ -73,6 +74,11 @@ func (b *scriptedBackend) RunOnce(ctx context.Context, in runner.RunInput, cb ru
 		row.ErrorMsg = detail
 	}
 	b.runs[in.AgentID] = row
+	// Record the run's owning session with the tenant it was attributed to,
+	// so the tenant-scoping path (GetSession) sees the same tenant the run
+	// was created under — mirroring the real store where tenant lives on
+	// the session row, not the run.
+	b.sessions["sess-"+in.AgentID] = store.Session{ID: "sess-" + in.AgentID, TenantID: in.TenantID}
 	b.mu.Unlock()
 	return nil
 }
@@ -95,6 +101,15 @@ func (b *scriptedBackend) GetRunByAgentID(ctx context.Context, agentID string) (
 		return r, nil
 	}
 	return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+}
+
+func (b *scriptedBackend) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if s, ok := b.sessions[sessionID]; ok {
+		return s, nil
+	}
+	return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
 }
 
 // The card-resolution + interrupt surfaces are unused by these tests

--- a/internal/api/a2a/server_test.go
+++ b/internal/api/a2a/server_test.go
@@ -31,6 +31,9 @@ func (fakeStore) GetRun(ctx context.Context, runID string) (store.Run, error) {
 func (fakeStore) GetRunByAgentID(ctx context.Context, agentID string) (store.Run, error) {
 	return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
 }
+func (fakeStore) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
+	return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
+}
 func (fakeStore) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## Why

A formal whole-feature review of the A2A surface (RFC G, v0.13.0) — its first — surfaced **three cross-tenant isolation bugs (2 HIGH, 1 MEDIUM)** sharing one root cause: the A2A `Task.id` **is** the caller-supplied loomcycle `agent_id` (a non-secret, addressable handle), and the read/cancel/list paths resolved it **purely by `agent_id`**, never consulting the host/path-authoritative routed tenant that the *create* path already honours (`principalFromContext`).

In a multi-tenant deployment (`tenancy: host|path`), an authenticated peer routed to **tenant-A's** host could:

1. **HIGH — `tasks/cancel`** with tenant-B's `agent_id` → cancel B's in-flight run (cascading to its sub-agents). Destructive. (`executor.go`)
2. **HIGH — `tasks/get`** with tenant-B's `agent_id` → read B's run status **plus the raw `ErrorMsg`** (internal/provider failure detail). (`task_store.go`)
3. **MEDIUM — `tasks/list`** → enumerate B's task ids / context ids / states / status messages from the process-global in-memory map (filtered only by the caller-supplied `ContextID`, which is the run-derived SessionID — not a tenant boundary). (`task_store.go`)

All are no-ops in single-tenant/`none` mode (the default).

## What

A single authoritative tenant gate, `authorizeTaskTenant`, resolves the run behind the `agent_id` and the tenant of its **owning session** (the `runs` table has no tenant column — tenant lives on the session) and compares it to the routed tenant.

- **Mismatch / unresolved run-or-session -> `a2asdk.ErrTaskNotFound`** — deliberately not a distinct "forbidden" (which would be an existence oracle). Failing closed on a not-found run also covers the window between SDK task `Create` and run-row persistence.
- **Single-tenant/`none` mode -> strict no-op** (`RoutedTenantFrom` `ok==false`): no store round-trips, zero behaviour change.
- `Get` gates before both the in-memory hit and the run-table fallback.
- `Cancel` gates before the destructive `CancelRun`.
- `List` snapshots context/status-filtered candidates under the lock, then filters by tenant outside the lock (the check does store I/O), keeping only the routed tenant's tasks (fail-closed).
- The resume path is closed transitively: a follow-up carrying a `TaskID` makes the SDK load the task via the now-gated `Get`, failing cross-tenant before `Execute`/`parks.take`.
- `RunReader` gains `GetSession` (`store.Store` already satisfies it) for the run->session hop.

Deferred to the follow-up A2A hardening PR: unbounded-read caps (peer card fetch + `SendMessage` + unauthenticated binding body), SSRF guard on model-authored `agent_card_url`/`endpoint`, gRPC-binding tenancy (fail-closed), the in-memory `TaskStore`/`parkRegistry` unbounded-growth leaks, and the LOW findings.

## What was tested

- Regression tests, verified regression-grade (each fails on the unfixed code, passes with the fix):
  - `TestTaskStore_GetRejectsCrossTenantAgentID_{Fallback,InMemory}`
  - `TestTaskStore_ListIsolatesByRoutedTenant`
  - `TestExecutor_CancelRejectsCrossTenantTaskID`
  - plus same-tenant-allowed and single-tenant-unchanged guards.
- `go build ./...`, `go vet ./...`, `go test ./...` clean.
- `go test -race ./internal/a2a/... ./internal/api/a2a/...` clean.
- `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)