### PR TITLE
harden(a2a): bound peer reads, SSRF-guard, gRPC tenancy fail-closed, list isolation gaps + leak fixes

### DIFF
--- a/internal/a2a/executor.go
+++ b/internal/a2a/executor.go
@@ -291,7 +291,21 @@ func (e *Executor) resumeParkedRun(ctx context.Context, execCtx *a2asrv.Executor
 		e.streamFromParked(ctx, execCtx, parked, yield)
 		return
 	}
-	answer := answerFromMessage(execCtx.Message)
+	answer, aerr := answerFromMessage(execCtx.Message)
+	if aerr != nil {
+		// The follow-up carried a non-text part (file/data). It cannot be an
+		// interruption answer; fail loudly rather than resolve with "" and
+		// wake the parked run as if the human answered nothing — mirroring
+		// buildRunInput's rejection on the brand-new-message path.
+		yield(a2asdk.NewStatusUpdateEvent(execCtx, a2asdk.TaskStateFailed,
+			agentMessage("a2a executor: resume message content unusable (only text parts are accepted): "+aerr.Error())), nil)
+		return
+	}
+	if answer == "" {
+		yield(a2asdk.NewStatusUpdateEvent(execCtx, a2asdk.TaskStateFailed,
+			agentMessage("a2a executor: resume message carried no usable text answer")), nil)
+		return
+	}
 	if err := e.resolver.Resolve(ctx, intrID, answer); err != nil {
 		yield(a2asdk.NewStatusUpdateEvent(execCtx, a2asdk.TaskStateFailed,
 			agentMessage("a2a executor: resolve interruption failed: "+err.Error())), nil)
@@ -347,14 +361,17 @@ func inputRequiredStatus(info a2asdk.TaskInfoProvider, intr *providers.Interrupt
 
 // answerFromMessage extracts the human's answer text from a resume
 // message's parts (text parts concatenated). The answer is recorded
-// against the interruption + fed back into the parked loop.
-func answerFromMessage(msg *a2asdk.Message) string {
+// against the interruption + fed back into the parked loop. It returns an
+// error when the message carries a non-text part (file/data) so the caller
+// can reject the resume rather than silently resolving with "" — the same
+// loud rejection partsToContentBlocks gives the brand-new-message path.
+func answerFromMessage(msg *a2asdk.Message) (string, error) {
 	if msg == nil {
-		return ""
+		return "", nil
 	}
 	blocks, err := partsToContentBlocks(msg.Parts)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	var out string
 	for _, b := range blocks {
@@ -366,7 +383,7 @@ func answerFromMessage(msg *a2asdk.Message) string {
 		}
 		out += b.Text
 	}
-	return out
+	return out, nil
 }
 
 // Cancel requests the loop stop working on the task. It routes through

--- a/internal/a2a/growth_test.go
+++ b/internal/a2a/growth_test.go
@@ -1,0 +1,105 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestTaskStore_Create_EvictsTerminalTasksAtCap pins the unbounded-growth
+// fix: once the in-memory map hits maxInMemoryTasks, Create evicts terminal
+// entries (still readable via the run-table fallback) instead of growing
+// forever. Regression-grade: the pre-fix Create never deleted, so the map
+// would be maxInMemoryTasks+1 here.
+func TestTaskStore_Create_EvictsTerminalTasksAtCap(t *testing.T) {
+	ts := NewTaskStore(&fakeRuns{byAgentID: map[string]store.Run{}})
+	ctx := context.Background()
+	for i := 0; i < maxInMemoryTasks; i++ {
+		_, _ = ts.Create(ctx, &a2asdk.Task{
+			ID:     a2asdk.TaskID(fmt.Sprintf("done-%d", i)),
+			Status: a2asdk.TaskStatus{State: a2asdk.TaskStateCompleted},
+		})
+	}
+	if _, err := ts.Create(ctx, &a2asdk.Task{ID: "fresh", Status: a2asdk.TaskStatus{State: a2asdk.TaskStateWorking}}); err != nil {
+		t.Fatalf("create fresh: %v", err)
+	}
+	// All terminal entries evicted; only the fresh non-terminal remains.
+	if got := len(ts.tasks); got != 1 {
+		t.Fatalf("tasks map = %d after eviction, want 1 (terminals reclaimed)", got)
+	}
+	if len(ts.versions) != len(ts.tasks) {
+		t.Errorf("versions map (%d) drifted from tasks map (%d)", len(ts.versions), len(ts.tasks))
+	}
+}
+
+// TestTaskStore_Create_KeepsInflightTasks confirms non-terminal (in-flight)
+// tasks are never evicted — dropping one would break the SDK's OCC for a
+// live run — so the map may exceed the cap when nothing is evictable (the
+// floor the run-concurrency semaphore bounds).
+func TestTaskStore_Create_KeepsInflightTasks(t *testing.T) {
+	ts := NewTaskStore(&fakeRuns{byAgentID: map[string]store.Run{}})
+	ctx := context.Background()
+	for i := 0; i < maxInMemoryTasks; i++ {
+		_, _ = ts.Create(ctx, &a2asdk.Task{
+			ID:     a2asdk.TaskID(fmt.Sprintf("live-%d", i)),
+			Status: a2asdk.TaskStatus{State: a2asdk.TaskStateWorking},
+		})
+	}
+	_, _ = ts.Create(ctx, &a2asdk.Task{ID: "one-more", Status: a2asdk.TaskStatus{State: a2asdk.TaskStateWorking}})
+	if got := len(ts.tasks); got != maxInMemoryTasks+1 {
+		t.Fatalf("in-flight tasks = %d, want %d (none evictable)", got, maxInMemoryTasks+1)
+	}
+}
+
+// TestParkRegistry_ReapsAbandonedParksOnPut pins the abandoned-park leak
+// fix: a park older than the TTL is reaped (and its detached background run
+// canceled) when a new park is registered. Regression-grade: the pre-fix
+// put never reaped, so the stale entry + its goroutine leaked.
+func TestParkRegistry_ReapsAbandonedParksOnPut(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	nowFunc = func() time.Time { return base }
+	defer func() { nowFunc = time.Now }()
+
+	r := newParkRegistry()
+	canceled := false
+	r.put("abandoned", &parkedRun{cancel: func() { canceled = true }})
+
+	// Advance past the TTL, then register a fresh park — the stale one is
+	// reaped on this put.
+	nowFunc = func() time.Time { return base.Add(2 * defaultParkTTL) }
+	r.put("fresh", &parkedRun{cancel: func() {}})
+
+	if _, ok := r.take("abandoned"); ok {
+		t.Error("abandoned park was not reaped past the TTL")
+	}
+	if !canceled {
+		t.Error("reaped park's cancel() was not called — its background run leaks")
+	}
+	if _, ok := r.take("fresh"); !ok {
+		t.Error("fresh park missing after put")
+	}
+}
+
+// TestParkRegistry_KeepsFreshParks confirms a within-TTL park is retained.
+func TestParkRegistry_KeepsFreshParks(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0)
+	nowFunc = func() time.Time { return base }
+	defer func() { nowFunc = time.Now }()
+
+	r := newParkRegistry()
+	r.put("a", &parkedRun{cancel: func() {}})
+	nowFunc = func() time.Time { return base.Add(defaultParkTTL / 2) }
+	r.put("b", &parkedRun{cancel: func() {}})
+
+	if _, ok := r.take("a"); !ok {
+		t.Error("within-TTL park 'a' was wrongly reaped")
+	}
+	if _, ok := r.take("b"); !ok {
+		t.Error("park 'b' missing")
+	}
+}

--- a/internal/a2a/interruption.go
+++ b/internal/a2a/interruption.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"time"
 
 	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
 
@@ -102,26 +103,58 @@ type parkedRun struct {
 	// used when a park can never be resumed (no bridge) or the client
 	// abandons the stream at the park.
 	cancel context.CancelFunc
+	// parkedAt stamps when the run was registered, so the registry can reap
+	// parks that are never resumed (a peer that received INPUT_REQUIRED and
+	// then vanished). Set by put.
+	parkedAt time.Time
 }
 
 // parkRegistry tracks runs parked on an interruption, keyed by A2A
-// TaskID. Process-local: cross-replica resume is a later-slice concern
-// (it would ride the shared run table + backplane bus), same boundary as
-// TaskStore's in-memory map.
+// TaskID. Process-local: cross-replica resume is a later concern (it would
+// ride the shared run table + backplane bus), same boundary as TaskStore's
+// in-memory map.
 type parkRegistry struct {
 	mu     sync.Mutex
 	parked map[a2asdk.TaskID]*parkedRun
+	ttl    time.Duration
 }
+
+// defaultParkTTL bounds how long an un-resumed park (and its still-live
+// background run goroutine) is retained. A park awaits a human-in-the-loop
+// answer, so the window is generous; past it the run is assumed abandoned
+// (the peer received INPUT_REQUIRED and never returned) and is reaped.
+const defaultParkTTL = 1 * time.Hour
 
 func newParkRegistry() *parkRegistry {
-	return &parkRegistry{parked: make(map[a2asdk.TaskID]*parkedRun)}
+	return &parkRegistry{parked: make(map[a2asdk.TaskID]*parkedRun), ttl: defaultParkTTL}
 }
 
+// put registers a parked run and opportunistically reaps any park older
+// than the TTL. Reaping here (rather than in a background goroutine) keeps
+// the registry free of a lifecycle to manage: an abandoned park — one whose
+// peer got INPUT_REQUIRED and never sent a follow-up — would otherwise
+// retain its entry AND keep its detached background run goroutine blocked
+// on the bus forever (no Delete, no resume). Without this the registry and
+// its goroutines grow unbounded under park-then-abandon load. cancel() on a
+// reaped entry tears down that leaked background run.
 func (r *parkRegistry) put(id a2asdk.TaskID, p *parkedRun) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	now := nowFunc()
+	p.parkedAt = now
+	for k, old := range r.parked {
+		if r.ttl > 0 && now.Sub(old.parkedAt) > r.ttl {
+			if old.cancel != nil {
+				old.cancel()
+			}
+			delete(r.parked, k)
+		}
+	}
 	r.parked[id] = p
 }
+
+// nowFunc is time.Now indirected so tests can drive the reap clock.
+var nowFunc = time.Now
 
 // take removes and returns the parked run for id, if any. Removing on
 // take ensures a resume consumes the entry exactly once; if the resumed

--- a/internal/a2a/resume_answer_test.go
+++ b/internal/a2a/resume_answer_test.go
@@ -1,0 +1,70 @@
+package a2a
+
+import (
+	"context"
+	"testing"
+
+	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
+	"github.com/a2aproject/a2a-go/v2/a2asrv"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestAnswerFromMessage_RejectsNonTextPart pins the helper-level contract:
+// a non-text part yields an error (not "") so the resume path can refuse.
+// Regression-grade: the pre-fix helper returned ("", nil) here.
+func TestAnswerFromMessage_RejectsNonTextPart(t *testing.T) {
+	msg := a2asdk.NewMessage(a2asdk.MessageRoleUser, a2asdk.NewDataPart(map[string]any{"k": "v"}))
+	if _, err := answerFromMessage(msg); err == nil {
+		t.Fatal("answerFromMessage accepted a non-text part; want an error")
+	}
+	got, err := answerFromMessage(a2asdk.NewMessage(a2asdk.MessageRoleUser, a2asdk.NewTextPart("hi")))
+	if err != nil || got != "hi" {
+		t.Fatalf("text answer = (%q, %v), want (\"hi\", nil)", got, err)
+	}
+}
+
+// TestExecutor_ResumeWithNonTextPartFailsWithoutResolving pins the bridge
+// behaviour: a resume carrying a non-text part must FAIL the task and must
+// NOT resolve the interruption with an empty answer.
+//
+// Regression-grade: on the pre-fix code resumeParkedRun resolved with ""
+// (resolver.resolveCalls would be 1) and the run proceeded.
+func TestExecutor_ResumeWithNonTextPartFailsWithoutResolving(t *testing.T) {
+	pr := newParkingRunner("approve?", "intr-1", []providers.Event{
+		{Type: providers.EventDone, StopReason: "end_turn"},
+	})
+	defer close(pr.resume) // release the parked background goroutine at test end
+	runs := &fakeRuns{byAgentID: map[string]store.Run{
+		"task-i": {ID: "run-i", AgentID: "task-i", Status: store.RunRunning},
+	}}
+	resolver := &fakeResolver{pendingID: "intr-1", hasPending: true}
+	ex := NewExecutor(pr, &fakeConnector{}, runs, "qa-agent").WithInterruptionBridge(resolver)
+
+	// First message parks the run.
+	first := &a2asrv.ExecutorContext{
+		TaskID:  "task-i",
+		Message: a2asdk.NewMessage(a2asdk.MessageRoleUser, a2asdk.NewTextPart("deploy please")),
+	}
+	if _, errs := collect(ex.Execute(context.Background(), first)); len(errs) != 0 {
+		t.Fatalf("first Execute errors: %v", errs)
+	}
+	<-pr.started
+
+	// Resume with a NON-TEXT part.
+	second := &a2asrv.ExecutorContext{
+		TaskID:     "task-i",
+		StoredTask: &a2asdk.Task{ID: "task-i", Status: a2asdk.TaskStatus{State: a2asdk.TaskStateInputRequired}},
+		Message:    a2asdk.NewMessage(a2asdk.MessageRoleUser, a2asdk.NewDataPart(map[string]any{"file": "x"})),
+	}
+	events, _ := collect(ex.Execute(context.Background(), second))
+
+	if resolver.resolveCalls != 0 {
+		t.Errorf("resolver.Resolve called %d times for an unusable resume; want 0 (no empty-answer resolve)", resolver.resolveCalls)
+	}
+	last, ok := events[len(events)-1].(*a2asdk.TaskStatusUpdateEvent)
+	if !ok || last.Status.State != a2asdk.TaskStateFailed {
+		t.Fatalf("terminal event = %#v, want FAILED", events[len(events)-1])
+	}
+}

--- a/internal/a2a/task_store.go
+++ b/internal/a2a/task_store.go
@@ -39,10 +39,18 @@ type RunReader interface {
 //     Task.id IS a loomcycle agent_id.
 //
 // The in-memory map is process-local and not durable; cross-replica
-// task addressing is a later-slice concern (it rides on the run table,
-// which IS shared). Lossy eviction is not implemented this slice — the
-// map grows with active tasks and is expected to be bounded by the
-// run concurrency semaphore upstream.
+// task addressing is a later concern (it rides on the run table, which IS
+// shared).
+//
+// Bounding: the SDK taskstore.Store interface has no Delete, so the map
+// would otherwise grow with every distinct A2A task id the process ever
+// served — the run-concurrency semaphore bounds CONCURRENT runs, NOT the
+// cumulative count of completed tasks, so it is not the bound an earlier
+// comment claimed. Create evicts TERMINAL entries once the map exceeds
+// maxInMemoryTasks: a terminal task evicted from memory is still resolvable
+// via the run-table fallback in Get, so eviction is lossless for reads. The
+// floor (tasks that cannot be evicted) is the set of in-flight, non-
+// terminal tasks, which the semaphore genuinely does bound.
 type TaskStore struct {
 	runs RunReader
 
@@ -50,6 +58,12 @@ type TaskStore struct {
 	tasks    map[a2asdk.TaskID]*taskstore.StoredTask
 	versions map[a2asdk.TaskID]taskstore.TaskVersion
 }
+
+// maxInMemoryTasks is the soft cap on the in-memory task map. Past it,
+// Create evicts terminal entries (still readable via the run-table
+// fallback). Generous: it only needs to cover in-flight + recently-
+// completed tasks, not history.
+const maxInMemoryTasks = 4096
 
 var _ taskstore.Store = (*TaskStore)(nil)
 
@@ -70,10 +84,29 @@ func (s *TaskStore) Create(ctx context.Context, task *a2asdk.Task) (taskstore.Ta
 	if _, exists := s.tasks[task.ID]; exists {
 		return taskstore.TaskVersionMissing, taskstore.ErrTaskAlreadyExists
 	}
+	if len(s.tasks) >= maxInMemoryTasks {
+		s.evictTerminalLocked()
+	}
 	const firstVersion taskstore.TaskVersion = 1
 	s.tasks[task.ID] = &taskstore.StoredTask{Task: task, Version: firstVersion}
 	s.versions[task.ID] = firstVersion
 	return firstVersion, nil
+}
+
+// evictTerminalLocked drops terminal (completed/failed/canceled/rejected)
+// tasks from the in-memory maps to bound their growth. A terminal task
+// dropped here is still resolvable through Get's run-table fallback, so the
+// eviction does not lose readable state. In-flight (non-terminal) tasks are
+// never evicted — dropping one would break the SDK's OCC for a live run —
+// so the post-eviction floor is the count of concurrent in-flight tasks,
+// which the run-concurrency semaphore bounds. Caller holds s.mu.
+func (s *TaskStore) evictTerminalLocked() {
+	for id, st := range s.tasks {
+		if st.Task != nil && st.Task.Status.State.Terminal() {
+			delete(s.tasks, id)
+			delete(s.versions, id)
+		}
+	}
 }
 
 // Update applies an OCC-guarded update. Returns

--- a/internal/api/a2a/card.go
+++ b/internal/api/a2a/card.go
@@ -41,8 +41,20 @@ const (
 // separately by signCardIfConfigured after the card is built — keeping
 // buildAgentCard a pure function of its inputs (so card_test can assert
 // card shape without touching the env or crypto).
-func buildAgentCard(card config.A2AServerCard, baseURL, tenantPrefix string, extended bool) *a2asdk.AgentCard {
+func buildAgentCard(card config.A2AServerCard, baseURL, tenantPrefix string, extended, includeGRPC bool) *a2asdk.AgentCard {
 	root := baseURL + tenantPrefix
+
+	// Advertise only the bindings actually served. gRPC is dropped under
+	// host/path tenancy (includeGRPC=false) so the card never points peers
+	// at a binding whose tenancy boundary loomcycle cannot enforce — see
+	// Server.grpcEnabled. REST + JSON-RPC are always served.
+	interfaces := []*a2asdk.AgentInterface{
+		a2asdk.NewAgentInterface(root+pathREST, a2asdk.TransportProtocolHTTPJSON),
+		a2asdk.NewAgentInterface(root+pathJSONRPC, a2asdk.TransportProtocolJSONRPC),
+	}
+	if includeGRPC {
+		interfaces = append(interfaces, a2asdk.NewAgentInterface(root+pathGRPC, a2asdk.TransportProtocolGRPC))
+	}
 
 	out := &a2asdk.AgentCard{
 		Name:        card.Name,
@@ -57,15 +69,11 @@ func buildAgentCard(card config.A2AServerCard, baseURL, tenantPrefix string, ext
 		},
 		// loomcycle agents accept and emit text; richer modes are a
 		// later concern (the bridge rejects non-text parts today).
-		DefaultInputModes:  []string{"text/plain"},
-		DefaultOutputModes: []string{"text/plain"},
-		SupportedInterfaces: []*a2asdk.AgentInterface{
-			a2asdk.NewAgentInterface(root+pathREST, a2asdk.TransportProtocolHTTPJSON),
-			a2asdk.NewAgentInterface(root+pathJSONRPC, a2asdk.TransportProtocolJSONRPC),
-			a2asdk.NewAgentInterface(root+pathGRPC, a2asdk.TransportProtocolGRPC),
-		},
-		Skills:          skillsFromExposedAgents(card.ExposedAgents),
-		SecuritySchemes: securitySchemesFor(card.SecuritySchemes),
+		DefaultInputModes:   []string{"text/plain"},
+		DefaultOutputModes:  []string{"text/plain"},
+		SupportedInterfaces: interfaces,
+		Skills:              skillsFromExposedAgents(card.ExposedAgents),
+		SecuritySchemes:     securitySchemesFor(card.SecuritySchemes),
 	}
 	if card.Provider.Organization != "" || card.Provider.URL != "" {
 		out.Provider = &a2asdk.AgentProvider{

--- a/internal/api/a2a/card_sign_test.go
+++ b/internal/api/a2a/card_sign_test.go
@@ -36,7 +36,7 @@ func TestSignCardIfConfigured_AllowlistedKeySignsAndVerifies(t *testing.T) {
 	const envName = "LOOMCYCLE_A2A_SIGNING_KEY"
 	t.Setenv(envName, pemStr)
 
-	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	cardCfg := fixtureCard()
 	cardCfg.SignWithKeyEnv = envName
 	allowlist := map[string]bool{envName: true}
@@ -72,7 +72,7 @@ func TestSignCardIfConfigured_UnallowlistedKeyServesUnsignedWithTrace(t *testing
 	const envName = "SOME_OTHER_KEY"
 	t.Setenv(envName, pemStr)
 
-	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	cardCfg := fixtureCard()
 	cardCfg.SignWithKeyEnv = envName
 	allowlist := map[string]bool{} // envName NOT allowlisted
@@ -97,7 +97,7 @@ func TestSignCardIfConfigured_UnsetEnvServesUnsignedWithTrace(t *testing.T) {
 	const envName = "LOOMCYCLE_A2A_SIGNING_KEY"
 	t.Setenv(envName, "") // allowlisted but empty
 
-	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	cardCfg := fixtureCard()
 	cardCfg.SignWithKeyEnv = envName
 	allowlist := map[string]bool{envName: true}
@@ -119,7 +119,7 @@ func TestSignCardIfConfigured_UnsetEnvServesUnsignedWithTrace(t *testing.T) {
 // card with no sign_with_key_env is served unsigned with NO trace line
 // (unsigned by design is not a warnable condition).
 func TestSignCardIfConfigured_NoKeyConfiguredServesUnsignedSilently(t *testing.T) {
-	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	cardCfg := fixtureCard() // SignWithKeyEnv == ""
 
 	var traced []string
@@ -142,7 +142,7 @@ func TestSignCardIfConfigured_MalformedKeyServesUnsignedWithTrace(t *testing.T) 
 	const envName = "LOOMCYCLE_A2A_SIGNING_KEY"
 	t.Setenv(envName, "-----BEGIN PRIVATE KEY-----\nnot a key\n-----END PRIVATE KEY-----")
 
-	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	generated := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	cardCfg := fixtureCard()
 	cardCfg.SignWithKeyEnv = envName
 

--- a/internal/api/a2a/card_test.go
+++ b/internal/api/a2a/card_test.go
@@ -42,7 +42,7 @@ func fixtureCard() config.A2AServerCard {
 }
 
 func TestBuildAgentCard_SkillsFromExposedAgents(t *testing.T) {
-	card := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	card := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 
 	if card.Name != "loomcycle-fleet" {
 		t.Errorf("name = %q, want loomcycle-fleet", card.Name)
@@ -75,7 +75,7 @@ func TestBuildAgentCard_PushNotificationsAlwaysFalse(t *testing.T) {
 	// (the server cannot honour push configs yet).
 	c := fixtureCard()
 	c.Capabilities.PushNotifications = true
-	card := buildAgentCard(c, "", "", false)
+	card := buildAgentCard(c, "", "", false, true)
 	if card.Capabilities.PushNotifications {
 		t.Error("pushNotifications must be false (deferred), got true")
 	}
@@ -85,7 +85,7 @@ func TestBuildAgentCard_PushNotificationsAlwaysFalse(t *testing.T) {
 }
 
 func TestBuildAgentCard_BindingInterfaceURLs(t *testing.T) {
-	card := buildAgentCard(fixtureCard(), "https://agents.example", "", false)
+	card := buildAgentCard(fixtureCard(), "https://agents.example", "", false, true)
 	want := map[a2asdk.TransportProtocol]string{
 		a2asdk.TransportProtocolHTTPJSON: "https://agents.example/a2a/v1",
 		a2asdk.TransportProtocolJSONRPC:  "https://agents.example/a2a/jsonrpc",
@@ -105,7 +105,7 @@ func TestBuildAgentCard_PathModePrefixesInterfaceURLs(t *testing.T) {
 	// Path-mode tenancy prepends /{tenant} to the interface URLs so a
 	// peer that fetched the per-tenant card POSTs back to the same
 	// tenant-prefixed binding.
-	card := buildAgentCard(fixtureCard(), "https://agents.example", "/acme", false)
+	card := buildAgentCard(fixtureCard(), "https://agents.example", "/acme", false, true)
 	for _, iface := range card.SupportedInterfaces {
 		if iface.ProtocolBinding == a2asdk.TransportProtocolHTTPJSON {
 			if iface.URL != "https://agents.example/acme/a2a/v1" {

--- a/internal/api/a2a/hardening_test.go
+++ b/internal/api/a2a/hardening_test.go
@@ -1,0 +1,78 @@
+package a2a
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	a2asdk "github.com/a2aproject/a2a-go/v2/a2a"
+)
+
+// TestServer_GRPCDisabledUnderHostPathTenancy pins the fail-closed gRPC
+// gate: under host/path tenancy the routed tenant cannot be derived from
+// the gRPC transport, so the binding must NOT be registered and the served
+// card must NOT advertise it (otherwise a peer could spoof its tenant via
+// the gRPC request body). REST + JSON-RPC remain.
+func TestServer_GRPCDisabledUnderHostPathTenancy(t *testing.T) {
+	for _, tenancy := range []string{"host", "path"} {
+		srv := newTestServer(t, tenancy, "https://agents.example")
+		if srv.grpcEnabled {
+			t.Errorf("tenancy=%s: grpcEnabled=true, want false", tenancy)
+		}
+		if srv.grpc != nil {
+			t.Errorf("tenancy=%s: gRPC handler built despite disabled binding", tenancy)
+		}
+		card := buildAgentCard(fixtureCard(), "https://agents.example", "", false, srv.grpcEnabled)
+		if len(card.SupportedInterfaces) != 2 {
+			t.Errorf("tenancy=%s: card advertises %d interfaces, want 2 (REST+JSON-RPC, no gRPC)", tenancy, len(card.SupportedInterfaces))
+		}
+		for _, iface := range card.SupportedInterfaces {
+			if iface.ProtocolBinding == a2asdk.TransportProtocolGRPC {
+				t.Errorf("tenancy=%s: card still advertises the gRPC interface", tenancy)
+			}
+		}
+	}
+}
+
+// TestServer_GRPCEnabledUnderSingleTenant confirms the binding is served in
+// none/single-tenant mode (the common deployment), with all 3 interfaces.
+func TestServer_GRPCEnabledUnderSingleTenant(t *testing.T) {
+	srv := newTestServer(t, "none", "https://agents.example")
+	if !srv.grpcEnabled || srv.grpc == nil {
+		t.Fatal("none tenancy must serve the gRPC binding")
+	}
+	card := buildAgentCard(fixtureCard(), "https://agents.example", "", false, srv.grpcEnabled)
+	if len(card.SupportedInterfaces) != 3 {
+		t.Errorf("none tenancy: card advertises %d interfaces, want 3", len(card.SupportedInterfaces))
+	}
+}
+
+// TestCapBody_RejectsOversizedBody pins the unauthenticated-body cap: a
+// body over maxA2ABodyBytes must fail the handler's read rather than being
+// buffered in full. Regression-grade: without capBody, io.ReadAll succeeds.
+func TestCapBody_RejectsOversizedBody(t *testing.T) {
+	var readErr error
+	h := capBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, readErr = io.ReadAll(r.Body)
+	}))
+	body := bytes.NewReader(make([]byte, maxA2ABodyBytes+1))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/x", body))
+	if readErr == nil {
+		t.Fatal("capBody allowed an over-cap body to be read in full")
+	}
+}
+
+// TestCapBody_AllowsUnderCapBody confirms a normal small body passes.
+func TestCapBody_AllowsUnderCapBody(t *testing.T) {
+	var n int
+	h := capBody(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		n = len(b)
+	}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/x", bytes.NewReader(make([]byte, 1024))))
+	if n != 1024 {
+		t.Errorf("read %d bytes, want 1024", n)
+	}
+}

--- a/internal/api/a2a/server.go
+++ b/internal/api/a2a/server.go
@@ -80,6 +80,17 @@ type Server struct {
 	// handler is the SDK RequestHandler that all three bindings share.
 	handler a2asrv.RequestHandler
 	grpc    *a2agrpc.Handler
+
+	// grpcEnabled is false when the gRPC binding must NOT be served — i.e.
+	// under host/path tenancy, where the routed tenant is attached by the
+	// HTTP-layer wrappers (hostTenantWrap / PathTenantWrapper) that the
+	// gRPC transport bypasses entirely. Serving gRPC there would let a peer
+	// spoof its tenant via the request body (the bridge falls back to the
+	// body tenant when no routed tenant is stamped). We FAIL CLOSED: skip
+	// the gRPC registration AND drop the gRPC interface from the advertised
+	// card, rather than serve a body-spoofable tenancy boundary. (A proper
+	// gRPC tenant interceptor is future work.)
+	grpcEnabled bool
 }
 
 // New builds the A2A server from the active A2AServerCardDef named in
@@ -157,14 +168,28 @@ func New(ctx context.Context, deps Deps) (*Server, error) {
 		allow[n] = true
 	}
 
+	// gRPC is served only when the routed tenant can be made authoritative
+	// for it. Under host/path tenancy it cannot (the tenant is stamped by
+	// the HTTP wrappers gRPC bypasses), so fail closed: no gRPC handler is
+	// built, and writeCard drops the gRPC interface from the served card.
+	tenancy := deps.Cfg.Env.A2ATenancyRouting
+	grpcEnabled := tenancy != "host" && tenancy != "path"
+	var grpcHandler *a2agrpc.Handler
+	if grpcEnabled {
+		grpcHandler = a2agrpc.NewHandler(handler)
+	} else {
+		log.Printf("a2a server: tenancy=%q — gRPC binding disabled (tenant cannot be derived from the gRPC transport); REST + JSON-RPC remain available", tenancy)
+	}
+
 	return &Server{
 		deps:             deps,
-		tenancy:          deps.Cfg.Env.A2ATenancyRouting,
+		tenancy:          tenancy,
 		baseURL:          deps.Cfg.Env.A2APublicBaseURL,
 		cardName:         cardName,
 		signEnvAllowlist: allow,
 		handler:          handler,
-		grpc:             a2agrpc.NewHandler(handler),
+		grpc:             grpcHandler,
+		grpcEnabled:      grpcEnabled,
 	}, nil
 }
 
@@ -207,6 +232,12 @@ func (s *Server) Mount(mux *http.ServeMux, adminAuth func(http.Handler) http.Han
 	//     the http.Server.Handler level BEFORE the request reaches this
 	//     mux, so the concrete paths still match. See PathTenantWrapper.
 	mux.Handle("GET "+pathWellKnown, s.hostTenantWrap(card))
+	// capBody bounds the binding request bodies. These endpoints are NOT
+	// wrapped by the bearer authMiddleware (auth is an SDK CallInterceptor
+	// that runs AFTER the transport decodes the body), and the SDK decodes
+	// with an unbounded json.NewDecoder — so without this an UNAUTHENTICATED
+	// client could stream a huge body that is fully buffered before the
+	// interceptor rejects it. Mirrors the 1 MiB cap on every /v1/* route.
 	// The SDK REST handler routes on paths RELATIVE to its mount point
 	// (e.g. "POST /message:send", "GET /tasks/{id}"), so the "/a2a/v1"
 	// prefix must be stripped before delegation — otherwise every REST
@@ -214,12 +245,27 @@ func (s *Server) Mount(mux *http.ServeMux, adminAuth func(http.Handler) http.Han
 	// JSON-RPC handler needs no stripping (it is a single endpoint with
 	// no sub-routing). StripPrefix runs INSIDE hostTenantWrap so the
 	// host-derived tenant is still attached.
-	mux.Handle(pathREST+"/", s.hostTenantWrap(http.StripPrefix(pathREST, rest)))
-	mux.Handle(pathJSONRPC, s.hostTenantWrap(jsonrpc))
+	mux.Handle(pathREST+"/", s.hostTenantWrap(capBody(http.StripPrefix(pathREST, rest))))
+	mux.Handle(pathJSONRPC, s.hostTenantWrap(capBody(jsonrpc)))
 
 	if adminAuth != nil {
 		mux.Handle("GET "+pathWellKnown+"/extended", adminAuth(http.HandlerFunc(s.handleExtendedCard)))
 	}
+}
+
+// maxA2ABodyBytes bounds an inbound A2A binding request body, matching the
+// 1 MiB cap loomcycle applies on every /v1/* route.
+const maxA2ABodyBytes = 1 << 20
+
+// capBody wraps a binding handler so the request body is bounded BEFORE the
+// SDK's unbounded json.NewDecoder reads it — the binding endpoints are
+// unauthenticated at the transport layer (auth is an SDK interceptor that
+// runs after decode), so this bounds memory for an unauthenticated caller.
+func capBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxA2ABodyBytes)
+		next.ServeHTTP(w, r)
+	})
 }
 
 // PathTenantWrapper wraps the fully-built server handler so path-mode
@@ -315,7 +361,7 @@ func (s *Server) writeCard(w http.ResponseWriter, tenant string, extended bool) 
 		return
 	}
 	base, prefix := s.cardURLAnchors(tenant)
-	generated := buildAgentCard(card, base, prefix, extended)
+	generated := buildAgentCard(card, base, prefix, extended, s.grpcEnabled)
 	signCardIfConfigured(generated, card, s.signEnvAllowlist, log.Printf)
 
 	// Marshal before writing any header so a (very unlikely) encode

--- a/internal/api/a2a/server.go
+++ b/internal/api/a2a/server.go
@@ -334,7 +334,7 @@ func (s *Server) handleAgentCard(w http.ResponseWriter, r *http.Request) {
 	}
 	tenant := s.tenantFromRequest(r)
 	extended := r.URL.Query().Get("extended") == "true" && s.adminAuthed(r)
-	s.writeCard(w, tenant, extended)
+	s.writeCard(w, r, tenant, extended)
 }
 
 // handleExtendedCard serves the full card; the caller (Mount) has
@@ -344,7 +344,7 @@ func (s *Server) handleExtendedCard(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		return
 	}
-	s.writeCard(w, s.tenantFromRequest(r), true)
+	s.writeCard(w, r, s.tenantFromRequest(r), true)
 }
 
 // writeCard resolves the active card fresh per request (so a substrate
@@ -354,8 +354,11 @@ func (s *Server) handleExtendedCard(w http.ResponseWriter, r *http.Request) {
 // allowlisted + holds a usable key, the served card is JWS-signed
 // (A2A-6); otherwise it is served unsigned with a tracing line — card
 // serving never fails on a signing problem.
-func (s *Server) writeCard(w http.ResponseWriter, tenant string, extended bool) {
-	card, ok := lookup.A2AServerCard(context.Background(), s.deps.Store, s.deps.Cfg, s.cardName)
+func (s *Server) writeCard(w http.ResponseWriter, r *http.Request, tenant string, extended bool) {
+	// Use the request context so a client disconnect / deadline cancels the
+	// substrate card lookup (a DB query on the substrate path) instead of
+	// running it to completion on a detached background context.
+	card, ok := lookup.A2AServerCard(r.Context(), s.deps.Store, s.deps.Cfg, s.cardName)
 	if !ok {
 		http.Error(w, "a2a server card unavailable", http.StatusServiceUnavailable)
 		return

--- a/internal/tools/a2a/client.go
+++ b/internal/tools/a2a/client.go
@@ -13,7 +13,6 @@ package a2a
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -135,8 +134,16 @@ func (c *sdkPeerClient) Close() error { return c.cl.Destroy() }
 //
 // The bearer is wired via bearerInterceptor so it rides every call.
 func newSDKPeerClient(ctx context.Context, def config.A2AAgent, bearer string) (peerClient, error) {
+	// Inject loomcycle's hardened http.Client into the JSON-RPC + REST
+	// transports so peer responses are body-capped (no OOM from a hostile
+	// peer's giant SendMessage response) and SSRF-blocked at the dial layer.
+	// gRPC carries its own default 4 MiB recv cap, so only the two HTTP
+	// transports need the override.
+	hc := hardenedPeerClient(peerCallTimeout)
 	opts := []a2aclient.FactoryOption{
 		a2aclient.WithCallInterceptors(&bearerInterceptor{bearer: bearer}),
+		a2aclient.WithJSONRPCTransport(hc),
+		a2aclient.WithRESTTransport(hc),
 	}
 
 	if def.AgentCardURL != "" {
@@ -174,6 +181,11 @@ func newSDKPeerClient(ctx context.Context, def config.A2AAgent, bearer string) (
 // discovery hop specifically.
 const peerCardFetchTimeout = 15 * time.Second
 
+// peerCallTimeout bounds a single SendMessage exchange with a peer. The
+// agent run ctx still applies on top; this caps the per-call wall-clock so
+// a wedged peer cannot pin a goroutine indefinitely.
+const peerCallTimeout = 5 * time.Minute
+
 // fetchPeerCard resolves a peer AgentCard from its well-known URL using
 // the SDK's resolver. agentCardURL may point at either the well-known
 // path directly or the origin; the resolver appends the default
@@ -181,7 +193,10 @@ const peerCardFetchTimeout = 15 * time.Second
 // base and strip a trailing well-known suffix the operator may have
 // included to avoid double-appending.
 func fetchPeerCard(ctx context.Context, agentCardURL string) (*a2asdk.AgentCard, error) {
-	hc := &http.Client{Timeout: peerCardFetchTimeout}
+	// Hardened client: caps the card body (the SDK resolver does an
+	// unbounded io.ReadAll) and SSRF-blocks the dial, since agent_card_url
+	// can be model-authored via a def-scope fork overlay.
+	hc := hardenedPeerClient(peerCardFetchTimeout)
 	resolver := agentcard.NewResolver(hc)
 
 	const wellKnown = "/.well-known/agent-card.json"

--- a/internal/tools/a2a/transport.go
+++ b/internal/tools/a2a/transport.go
@@ -1,0 +1,177 @@
+package a2a
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// maxPeerResponseBytes caps any single response body loomcycle reads from
+// an A2A peer — the discovery card fetch and every SendMessage response.
+// A2A AgentCards and task results are small JSON documents; a few MiB is
+// generous. The cap is enforced by erroring past the limit rather than
+// silently truncating (a truncated body would only fail JSON parsing later
+// with a misleading error).
+//
+// Without it the SDK transports read peer responses with an unbounded
+// io.ReadAll / json.Decode (a2aclient/agentcard resolver + jsonrpc/rest),
+// so a hostile, compromised, or simply buggy peer could stream a multi-GB
+// body and OOM the process within the request timeout (the timeout bounds
+// wall-clock, not bytes). Every other outbound HTTP read in loomcycle is
+// already bounded this way (providers/*, builtin/httptool, mem9, …); the
+// A2A peer path was the lone exception.
+const maxPeerResponseBytes = 4 << 20 // 4 MiB
+
+// peerDialTimeout bounds the TCP connect to a peer address.
+const peerDialTimeout = 10 * time.Second
+
+// hardenedPeerClient builds the *http.Client loomcycle hands to the A2A SDK
+// for talking to a peer: the card resolver (fetchPeerCard) and the
+// JSON-RPC / REST transports (via WithJSONRPCTransport / WithRESTTransport).
+// It layers three defences the SDK's default client lacks:
+//
+//   - body cap: response bodies are wrapped in a limit reader that ERRORS
+//     past maxPeerResponseBytes, so the SDK's unbounded reads cannot OOM
+//     the process.
+//   - SSRF block: the dialer refuses private / loopback / link-local /
+//     metadata-service addresses. A2AAgentDef agent_card_url / endpoint can
+//     be model-authored (via a granted def-scope fork overlay), so a peer
+//     URL must not be a lever to reach internal hosts. The block is
+//     re-checked at the socket layer (Control) to defeat DNS rebinding.
+//   - redirect bound: redirects are capped and every hop's destination is
+//     re-validated, so a benign-looking public host cannot 302 into the
+//     metadata service.
+//
+// timeout bounds the whole request (connect + headers + body).
+func hardenedPeerClient(timeout time.Duration) *http.Client {
+	base := &http.Transport{
+		DialContext:           peerDialContext,
+		TLSHandshakeTimeout:   peerDialTimeout,
+		ResponseHeaderTimeout: timeout,
+		ExpectContinueTimeout: time.Second,
+	}
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &bodyLimitRoundTripper{base: base, limit: maxPeerResponseBytes},
+		// Bound redirects and re-validate each hop. The default client
+		// follows up to 10 redirects to attacker-chosen targets; the
+		// per-hop dial still passes through peerDialContext, so a redirect
+		// to a private IP is already refused at dial — this also caps the
+		// hop count defensively.
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("a2a: stopped after %d redirects", len(via))
+			}
+			return nil
+		},
+	}
+}
+
+// bodyLimitRoundTripper wraps a RoundTripper so every response body is
+// bounded to limit bytes; a read past the cap returns errResponseTooLarge.
+type bodyLimitRoundTripper struct {
+	base  http.RoundTripper
+	limit int64
+}
+
+func (rt *bodyLimitRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := rt.base.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &cappedBody{rc: resp.Body, remaining: rt.limit}
+	return resp, nil
+}
+
+// errResponseTooLarge is returned by a peer-response read once the body
+// exceeds maxPeerResponseBytes. Surfaced as a tool error, never silently.
+var errResponseTooLarge = fmt.Errorf("a2a: peer response exceeds %d-byte cap", maxPeerResponseBytes)
+
+// cappedBody errors (rather than silently truncating) once more than
+// `remaining` bytes have been read, so an over-cap body fails loudly
+// instead of being parsed as a truncated document.
+type cappedBody struct {
+	rc        io.ReadCloser
+	remaining int64
+}
+
+func (b *cappedBody) Read(p []byte) (int, error) {
+	if b.remaining <= 0 {
+		return 0, errResponseTooLarge
+	}
+	if int64(len(p)) > b.remaining+1 {
+		// Read at most remaining+1 so we can detect the overflow byte
+		// without unbounded buffering.
+		p = p[:b.remaining+1]
+	}
+	n, err := b.rc.Read(p)
+	b.remaining -= int64(n)
+	if b.remaining < 0 {
+		return n, errResponseTooLarge
+	}
+	return n, err
+}
+
+func (b *cappedBody) Close() error { return b.rc.Close() }
+
+// peerDialContext is the SSRF-blocking dialer: it resolves the host, dials
+// only its public addresses, and re-checks the socket-level address to
+// defeat DNS rebinding. Mirrors the canonical guard in
+// internal/tools/builtin/httptool.go (isPrivateIP / dialContext) — kept as
+// a small local copy rather than a shared dependency so the A2A trust path
+// is self-contained; the predicates are stdlib net.IP classifiers, so
+// there is no algorithm to drift.
+func peerDialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	public := ips[:0]
+	for _, ip := range ips {
+		if !isPrivatePeerIP(ip.IP) {
+			public = append(public, ip)
+		}
+	}
+	if len(public) == 0 {
+		return nil, fmt.Errorf("a2a: refusing to dial %q — no public addresses (got %d private)", host, len(ips))
+	}
+	d := net.Dialer{
+		Timeout: peerDialTimeout,
+		Control: func(network, address string, c syscall.RawConn) error {
+			ipStr, _, _ := net.SplitHostPort(address)
+			if parsed := net.ParseIP(ipStr); parsed != nil && isPrivatePeerIP(parsed) {
+				return fmt.Errorf("a2a: refusing to connect to private address %s", ipStr)
+			}
+			return nil
+		},
+	}
+	var lastErr error
+	for _, ip := range public {
+		conn, derr := d.DialContext(ctx, network, net.JoinHostPort(ip.IP.String(), port))
+		if derr == nil {
+			return conn, nil
+		}
+		lastErr = derr
+	}
+	return nil, lastErr
+}
+
+// isPrivatePeerIP reports whether ip is one loomcycle must not let a peer
+// URL reach: loopback, link-local (169.254/16 + fe80::/10 — incl. the
+// cloud metadata service at 169.254.169.254), multicast, unspecified, or
+// RFC1918 / ULA private space. Same classifier set as httptool.isPrivateIP.
+func isPrivatePeerIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate()
+}

--- a/internal/tools/a2a/transport_test.go
+++ b/internal/tools/a2a/transport_test.go
@@ -1,0 +1,111 @@
+package a2a
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestIsPrivatePeerIP table-checks the SSRF classifier, including the cloud
+// metadata service address that is the highest-value SSRF target.
+func TestIsPrivatePeerIP(t *testing.T) {
+	cases := []struct {
+		ip      string
+		private bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"169.254.169.254", true}, // AWS/GCP metadata service
+		{"10.1.2.3", true},
+		{"192.168.0.1", true},
+		{"172.16.5.5", true},
+		{"0.0.0.0", true},
+		{"8.8.8.8", false},
+		{"1.1.1.1", false},
+	}
+	for _, c := range cases {
+		got := isPrivatePeerIP(net.ParseIP(c.ip))
+		if got != c.private {
+			t.Errorf("isPrivatePeerIP(%s) = %v, want %v", c.ip, got, c.private)
+		}
+	}
+}
+
+// TestPeerDialContext_RefusesPrivateAddress proves the dialer refuses a
+// loopback/private target before connecting — the SSRF block.
+func TestPeerDialContext_RefusesPrivateAddress(t *testing.T) {
+	_, err := peerDialContext(context.Background(), "tcp", "127.0.0.1:9")
+	if err == nil {
+		t.Fatal("peerDialContext dialed a loopback address; SSRF block missing")
+	}
+	if !strings.Contains(err.Error(), "no public addresses") && !strings.Contains(err.Error(), "private") {
+		t.Errorf("unexpected error %v, want an SSRF-refusal", err)
+	}
+}
+
+// TestFetchPeerCard_SSRFBlocksLoopbackPeer is regression-grade: an
+// httptest server listens on loopback, and fetchPeerCard must REFUSE to
+// reach it. On the unfixed code (plain http.Client) the fetch would
+// succeed — reaching an internal address chosen via a model-authored
+// agent_card_url.
+func TestFetchPeerCard_SSRFBlocksLoopbackPeer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"evil","version":"1.0.0"}`))
+	}))
+	defer srv.Close()
+
+	_, err := fetchPeerCard(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("fetchPeerCard reached a loopback peer; SSRF block missing")
+	}
+}
+
+// TestBodyLimitRoundTripper_ErrorsPastCap proves an over-cap response body
+// fails loudly with errResponseTooLarge rather than being read unbounded.
+func TestBodyLimitRoundTripper_ErrorsPastCap(t *testing.T) {
+	rt := &bodyLimitRoundTripper{base: &stubRoundTripper{bodyLen: maxPeerResponseBytes + 1024}, limit: maxPeerResponseBytes}
+	resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "http://peer/x", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	_, err = io.ReadAll(resp.Body)
+	if !errors.Is(err, errResponseTooLarge) {
+		t.Fatalf("read err = %v, want errResponseTooLarge", err)
+	}
+}
+
+// TestBodyLimitRoundTripper_PassesUnderCap confirms a normal small body is
+// read through unchanged.
+func TestBodyLimitRoundTripper_PassesUnderCap(t *testing.T) {
+	rt := &bodyLimitRoundTripper{base: &stubRoundTripper{bodyLen: 512}, limit: maxPeerResponseBytes}
+	resp, err := rt.RoundTrip(httptest.NewRequest(http.MethodGet, "http://peer/x", nil))
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(body) != 512 {
+		t.Errorf("read %d bytes, want 512", len(body))
+	}
+}
+
+// stubRoundTripper returns a response whose body is bodyLen zero bytes,
+// without any real network — lets the cap be tested in isolation.
+type stubRoundTripper struct{ bodyLen int }
+
+func (s *stubRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(strings.Repeat("a", s.bodyLen))),
+		Header:     make(http.Header),
+	}, nil
+}

--- a/internal/tools/builtin/a2aagentdef.go
+++ b/internal/tools/builtin/a2aagentdef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -461,11 +462,47 @@ func validateA2AAgentDef(def mergedA2AAgentDef) error {
 	if def.Binding != "" && !a2aBindings[def.Binding] {
 		return fmt.Errorf("unknown binding %q (must be one of: jsonrpc, grpc, rest)", def.Binding)
 	}
+	// Reachability targets can be model-authored (a fork overlay carries
+	// agent_card_url / endpoint), so reject non-HTTP schemes and hostless
+	// URLs upfront. This is defense-in-depth: the HTTP fetch + jsonrpc/rest
+	// transports also dial through the SSRF-blocking client in
+	// internal/tools/a2a, which refuses private/loopback/metadata targets
+	// at connect time. (The gRPC binding dials via grpc-go, outside that
+	// client — so a grpc endpoint is validated for shape here but its
+	// dial is NOT private-IP-blocked; gRPC peers are operator-configured in
+	// practice and a callable fork must already be in allowed_tools.)
+	if hasCardURL {
+		if err := requireHTTPURL("agent_card_url", def.AgentCardURL); err != nil {
+			return err
+		}
+	}
+	if def.Endpoint != "" && (def.Binding == "rest" || def.Binding == "jsonrpc") {
+		if err := requireHTTPURL("endpoint", def.Endpoint); err != nil {
+			return err
+		}
+	}
 	if def.Auth.Scheme != "" && !a2aSecuritySchemeKinds[def.Auth.Scheme] {
 		return fmt.Errorf("auth.scheme %q invalid (must be one of: http, apiKey, oauth2, mtls)", def.Auth.Scheme)
 	}
 	if def.Auth.BearerCredentialRef != "" && !a2aCredentialRefRe.MatchString(def.Auth.BearerCredentialRef) {
 		return fmt.Errorf("auth.bearer_credential_ref %q invalid (must match [a-zA-Z0-9_-]{1,64})", def.Auth.BearerCredentialRef)
+	}
+	return nil
+}
+
+// requireHTTPURL rejects a peer reachability URL that is not an absolute
+// http(s) URL with a host — closing junk and non-HTTP schemes (file://,
+// gopher://, …) a model-authored Def might carry before they reach the SDK.
+func requireHTTPURL(field, raw string) error {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("%s %q is not a valid URL: %v", field, raw, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("%s must be an http or https URL (got scheme %q)", field, u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("%s %q has no host", field, raw)
 	}
 	return nil
 }

--- a/internal/tools/builtin/a2aagentdef_url_test.go
+++ b/internal/tools/builtin/a2aagentdef_url_test.go
@@ -1,0 +1,34 @@
+package builtin
+
+import "testing"
+
+// TestValidateA2AAgentDef_RejectsNonHTTPReachability pins the upfront
+// URL-shape gate on model-authorable reachability fields. Regression-grade:
+// on the unfixed validator a file:// / hostless agent_card_url passed.
+func TestValidateA2AAgentDef_RejectsNonHTTPReachability(t *testing.T) {
+	cardCases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		{"file scheme", "file:///etc/passwd", true},
+		{"gopher scheme", "gopher://attacker/", true},
+		{"no host", "http://", true},
+		{"https ok", "https://peer.example/.well-known/agent-card.json", false},
+		{"http ok", "http://peer.example", false},
+	}
+	for _, c := range cardCases {
+		err := validateA2AAgentDef(mergedA2AAgentDef{AgentCardURL: c.url})
+		if (err != nil) != c.wantErr {
+			t.Errorf("agent_card_url %q: err=%v, wantErr=%v", c.url, err, c.wantErr)
+		}
+	}
+
+	// REST/JSON-RPC endpoints are HTTP too and get the same gate.
+	if err := validateA2AAgentDef(mergedA2AAgentDef{Endpoint: "file:///x", Binding: "rest"}); err == nil {
+		t.Error("rest endpoint with file:// scheme was accepted")
+	}
+	if err := validateA2AAgentDef(mergedA2AAgentDef{Endpoint: "https://peer.example", Binding: "jsonrpc"}); err != nil {
+		t.Errorf("valid https jsonrpc endpoint rejected: %v", err)
+	}
+}


### PR DESCRIPTION
## Why

Follow-up to #299 (A2A tenant isolation). The same formal whole-feature review of the A2A surface (RFC G) surfaced a cluster of MEDIUM/LOW hardening gaps and two unbounded-growth leaks. This PR closes them. **Independent of #299** (both branch off `main`; touch mostly disjoint files — merge in either order).

## What

**MEDIUM — DoS / SSRF on the outbound client (`internal/tools/a2a`)**
- **Unbounded peer reads.** The SDK reads peer responses with unbounded `io.ReadAll`/`json.Decode`; loomcycle handed those a plain `http.Client`. A hostile/buggy peer could OOM the process with a giant card or `SendMessage` body. New `hardenedPeerClient` caps every peer response at 4 MiB (errors past cap), wired into the card resolver + JSON-RPC/REST transports. (gRPC has its own 4 MiB recv cap.)
- **SSRF via model-authorable `agent_card_url`/`endpoint`.** `A2AAgentDef` fork overlays carry these; nothing blocked private targets. The hardened client dials through an SSRF-blocking `DialContext` (resolve → drop private IPs → socket-level recheck for DNS rebinding, mirroring `httptool`) and bounds+revalidates redirects. The Def validator rejects non-http(s)/hostless URLs upfront. *Caveat (in-code + here): the gRPC binding dials via grpc-go, outside this client, so a grpc endpoint is shape-validated but not private-IP-blocked at dial.*

**MEDIUM — server surface (`internal/api/a2a`)**
- **Unauthenticated binding body cap.** REST + JSON-RPC routes aren't bearer-wrapped (auth is an SDK interceptor after decode) and the SDK decodes unbounded — an unauthenticated client could stream a huge body. Added a 1 MiB `capBody` middleware, matching `/v1/*`.
- **gRPC tenancy fail-closed.** Under host/path tenancy the routed tenant is stamped by the HTTP wrappers gRPC bypasses, so gRPC fell back to the body tenant (spoofable). Rather than serve a spoofable binding, `New` skips gRPC registration and the served card drops the gRPC interface under host/path. REST + JSON-RPC remain; none/single-tenant unchanged. (gRPC tenant interceptor = future work.)

**Design-level — unbounded growth (`internal/a2a`)**
- **TaskStore in-memory map** grew forever (SDK store has no Delete; the "bounded by the semaphore" comment was wrong). `Create` now evicts terminal entries past 4096 (still readable via the run-table fallback); in-flight tasks are never evicted.
- **parkRegistry abandoned parks.** An INPUT_REQUIRED park never followed up retained its entry + a blocked background goroutine forever. `put` now reaps parks older than 1h, canceling the leaked run.

**LOW**
- A2A resume with a non-text part silently resolved the interruption with an empty answer — now fails the task without resolving.
- `writeCard` used `context.Background()` — now honours the request context.

**Deferred (writeup, not patched):** the server-card `Capabilities` overlay can't turn a capability *off* (all-false overlay aliases the zero value). It's a model-authored fork-fidelity nit that requires changing the substrate JSON shape (`*mergedA2ACapabilities`) + its drift tests for low value; tracked for a focused follow-up.

## What was tested

All fixes have regression tests; the bug-class ones verified failing on the pre-fix code (neutralize → fail → restore):
- `TestFetchPeerCard_SSRFBlocksLoopbackPeer`, `TestBodyLimitRoundTripper_*`, `TestPeerDialContext_RefusesPrivateAddress`, `TestIsPrivatePeerIP`, `TestValidateA2AAgentDef_RejectsNonHTTPReachability`
- `TestServer_GRPCDisabledUnderHostPathTenancy`, `TestServer_GRPCEnabledUnderSingleTenant`, `TestCapBody_*`
- `TestTaskStore_Create_EvictsTerminalTasksAtCap`, `TestTaskStore_Create_KeepsInflightTasks`, `TestParkRegistry_ReapsAbandonedParksOnPut`, `TestParkRegistry_KeepsFreshParks`
- `TestAnswerFromMessage_RejectsNonTextPart`, `TestExecutor_ResumeWithNonTextPartFailsWithoutResolving`
- `go build/vet/test ./...` clean; `go test -race ./internal/a2a/... ./internal/api/a2a/... ./internal/tools/a2a/...` clean; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)