### PR TITLE
fix(memory): close shared_key_with_prefix cross-tenant leak + quota/SSRF hardening (RFC I)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3174,6 +3174,19 @@ func validate(c *Config) error {
 			}
 		}
 	}
+	// Static memory_backends entries skip the MemoryBackendDef tool's
+	// validateWebhookDef-equivalent, so structurally validate them at load.
+	// Most important: a shared_key_with_prefix backend MUST carry a
+	// {tenant_id} token in its prefix_pattern — an empty/token-less prefix
+	// resolves to an empty key prefix and collapses every tenant into one
+	// keyspace (cross-tenant read+write leak). resolveTenancy is the runtime
+	// backstop, but failing loudly at boot is the better operator signal.
+	for bname, mb := range c.MemoryBackends {
+		if mb.TenancyStrategy.Kind == "shared_key_with_prefix" &&
+			!strings.Contains(mb.TenancyStrategy.PrefixPattern, "{tenant_id}") {
+			return fmt.Errorf("memory_backends.%s: tenancy_strategy.prefix_pattern %q must contain {tenant_id} for shared_key_with_prefix (an empty or token-less prefix collapses all tenants into one keyspace)", bname, mb.TenancyStrategy.PrefixPattern)
+		}
+	}
 	for name, agent := range c.Agents {
 		// Tier-based resolution and explicit pin are mutually
 		// exclusive — pinning a model and asking for a tier is

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -646,6 +646,32 @@ agents:
 	}
 }
 
+// TestMemoryBackend_RejectsSharedPrefixWithoutTenantToken pins the static-
+// config half of the cross-tenant-leak fix: a hand-written memory_backends
+// entry with shared_key_with_prefix and a prefix_pattern lacking {tenant_id}
+// (here: omitted entirely) must fail to load. Without this a static backend
+// bypasses the MemoryBackendDef tool validator and would resolve to an empty
+// key prefix, collapsing every tenant into one Mem9 keyspace.
+func TestMemoryBackend_RejectsSharedPrefixWithoutTenantToken(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+memory_backends:
+  shared:
+    kind: mem9
+    config: { base_url: "https://m.example.com", api_key_env: LOOMCYCLE_M_KEY }
+    tenancy_strategy: { kind: shared_key_with_prefix }
+`), 0o600)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected error: shared_key_with_prefix without {tenant_id} collapses all tenants into one keyspace")
+	}
+	if !strings.Contains(err.Error(), "{tenant_id}") {
+		t.Errorf("error should mention {tenant_id}: %v", err)
+	}
+}
+
 // TestMemoryBackend_LenientWhenNoStaticMap confirms an agent may name a
 // backend that exists only as a future dynamic MemoryBackendDef: when the
 // static memory_backends map is empty, an unresolved name is NOT a load

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -208,16 +208,26 @@ func resolveTenancy(ctx context.Context, ts config.MemoryBackendTenancy) (mem9.T
 		// API key the resolver returns. No prefix in the keyspace.
 		return mem9.Tenancy{}, tenantID, nil
 	case "shared_key_with_prefix":
-		// One shared key; tenant isolation comes from prefixing every key.
-		// A missing tenant here is a hard error: an empty prefix would
-		// collapse all tenants into one keyspace (cross-tenant leak).
+		// One shared key; tenant isolation comes ENTIRELY from prefixing
+		// every key with the per-tenant prefix, so the {tenant_id} token is
+		// mandatory. An empty or token-less prefix_pattern resolves to
+		// KeyPrefix="" (a no-op in scopedKey/scopedPrefix), collapsing every
+		// tenant into one flat keyspace — a cross-tenant read+write leak.
+		// This is the RUNTIME BACKSTOP: the Def validator and the static-
+		// config check reject it earlier, but resolveTenancy refuses
+		// unconditionally so NO configuration path (substrate fork OR
+		// hand-written yaml, which skips Def validation) can ever reach the
+		// leaky no-prefix state. (Contrast key_per_tenant, which legitimately
+		// carries no prefix because isolation rests on a distinct per-tenant
+		// API key.)
 		prefix := ts.PrefixPattern
-		if strings.Contains(prefix, "{tenant_id}") {
-			if tenantID == "" {
-				return mem9.Tenancy{}, "", fmt.Errorf("shared_key_with_prefix needs {tenant_id} but the run carries no tenant (user_id)")
-			}
-			prefix = strings.ReplaceAll(prefix, "{tenant_id}", tenantID)
+		if !strings.Contains(prefix, "{tenant_id}") {
+			return mem9.Tenancy{}, "", fmt.Errorf("shared_key_with_prefix requires prefix_pattern to contain {tenant_id} (got %q); an empty or token-less prefix would collapse all tenants into one keyspace", prefix)
 		}
+		if tenantID == "" {
+			return mem9.Tenancy{}, "", fmt.Errorf("shared_key_with_prefix needs {tenant_id} but the run carries no tenant (user_id)")
+		}
+		prefix = strings.ReplaceAll(prefix, "{tenant_id}", tenantID)
 		return mem9.Tenancy{KeyPrefix: prefix}, tenantID, nil
 	default:
 		return mem9.Tenancy{}, "", fmt.Errorf("unknown tenancy_strategy.kind %q", ts.Kind)
@@ -951,7 +961,13 @@ func (m *Memory) checkQuota(ctx context.Context, scope store.MemoryScope, scopeI
 	// cap silently. An agent that hits this limit should `delete`
 	// rows before writing more, or operators should bump the quota.
 	const listCap = 1000
-	entries, truncated, err := m.Store.MemoryList(ctx, scope, scopeID, "", listCap)
+	// List through the RESOLVED backend, not the in-process store: an agent
+	// routed to a remote backend (mem9) stores its rows there, so summing the
+	// local store would measure ~0 used bytes and let the per-scope
+	// memory_quota_bytes cap silently never apply. backend(ctx) is the
+	// in-process default (which wraps m.Store) when no remote backend is
+	// configured, so this is equivalent for the common case.
+	entries, truncated, err := m.backend(ctx).List(ctx, scope, scopeID, "", listCap)
 	if err != nil {
 		return fmt.Errorf("quota check: %w", err)
 	}

--- a/internal/tools/builtin/memory_tenancy_leak_test.go
+++ b/internal/tools/builtin/memory_tenancy_leak_test.go
@@ -1,0 +1,69 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestResolveTenancy_SharedPrefixEmptyOrTokenlessRejected pins the HIGH
+// cross-tenant leak fix at the runtime backstop: shared_key_with_prefix
+// with an empty OR token-less prefix_pattern must error, never resolve to an
+// empty KeyPrefix (which collapses every tenant into one Mem9 keyspace).
+//
+// Regression-grade: pre-fix the empty/token-less branch fell through and
+// returned mem9.Tenancy{KeyPrefix: ""} with no error.
+func TestResolveTenancy_SharedPrefixEmptyOrTokenlessRejected(t *testing.T) {
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{UserID: "alice"})
+	for _, pat := range []string{"", "static-no-token::", "tenant-::"} {
+		ts := config.MemoryBackendTenancy{Kind: "shared_key_with_prefix", PrefixPattern: pat}
+		tenancy, _, err := resolveTenancy(ctx, ts)
+		if err == nil {
+			t.Errorf("prefix_pattern %q: resolveTenancy returned KeyPrefix=%q with no error; want a refusal (empty prefix = cross-tenant leak)", pat, tenancy.KeyPrefix)
+		}
+	}
+	// Sanity: a valid token-bearing pattern still resolves.
+	ts := config.MemoryBackendTenancy{Kind: "shared_key_with_prefix", PrefixPattern: "tenant-{tenant_id}::"}
+	tenancy, _, err := resolveTenancy(ctx, ts)
+	if err != nil || tenancy.KeyPrefix != "tenant-alice::" {
+		t.Fatalf("valid pattern: got (%q, %v), want (tenant-alice::, nil)", tenancy.KeyPrefix, err)
+	}
+}
+
+// TestMemoryBackendDefTool_RefusesEmptySharedPrefix pins the authoring-time
+// guard: a MemoryBackendDef with shared_key_with_prefix + empty
+// prefix_pattern must be refused at create (pre-fix the validator's
+// `PrefixPattern != "" &&` precondition let an empty pattern pass).
+func TestMemoryBackendDefTool_RefusesEmptySharedPrefix(t *testing.T) {
+	tool, ctx, cleanup := memoryBackendDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"leaky","overlay":{"kind":"mem9","config":{"base_url":"https://m.example.com","api_key_env":"LOOMCYCLE_M_KEY"},"tenancy_strategy":{"kind":"shared_key_with_prefix"}}}`))
+	if !res.IsError {
+		t.Fatal("shared_key_with_prefix with empty prefix_pattern should be refused")
+	}
+	if !strings.Contains(res.Text, "{tenant_id}") {
+		t.Errorf("refusal should mention {tenant_id}; got %s", res.Text)
+	}
+}
+
+// TestMemoryBackendDefTool_RefusesNonHTTPBaseURL pins the SSRF defense-in-
+// depth: a mem9 base_url that is not an http(s) URL with a host is refused
+// at create (base_url is model-authorable via a fork overlay, and the Mem9
+// client sends the allowlisted X-API-Key to whatever host it names).
+func TestMemoryBackendDefTool_RefusesNonHTTPBaseURL(t *testing.T) {
+	tool, ctx, cleanup := memoryBackendDefFixture(t)
+	defer cleanup()
+
+	for _, bad := range []string{"file:///etc/passwd", "ftp://x/", "not a url", "https://"} {
+		body := `{"op":"create","name":"bad","overlay":{"kind":"mem9","config":{"base_url":"` + bad + `","api_key_env":"LOOMCYCLE_M_KEY"}}}`
+		res, _ := tool.Execute(ctx, json.RawMessage(body))
+		if !res.IsError {
+			t.Errorf("base_url %q should be refused", bad)
+		}
+	}
+}

--- a/internal/tools/builtin/memorybackenddef.go
+++ b/internal/tools/builtin/memorybackenddef.go
@@ -460,6 +460,14 @@ func validateMemoryBackendDef(def mergedMemoryBackendDef) error {
 		if def.Config.BaseURL == "" {
 			return fmt.Errorf("kind=mem9 requires config.base_url (non-empty)")
 		}
+		// base_url can be model-authored via a fork overlay (gated by
+		// memory_backend_def scopes), and the Mem9 client sends the
+		// allowlisted X-API-Key to whatever host it names — so reject a
+		// non-http(s)/hostless URL upfront (defense-in-depth against a
+		// blind-SSRF redirect of the egress). Reuses the A2A peer-URL guard.
+		if err := requireHTTPURL("config.base_url", def.Config.BaseURL); err != nil {
+			return err
+		}
 		if def.Config.APIKeyEnv == "" {
 			return fmt.Errorf("kind=mem9 requires config.api_key_env (non-empty)")
 		}
@@ -480,8 +488,13 @@ func validateMemoryBackendDef(def mergedMemoryBackendDef) error {
 			return fmt.Errorf("tenancy_strategy.env_pattern %q must contain {tenant_id}", def.TenancyStrategy.EnvPattern)
 		}
 	case "shared_key_with_prefix":
-		if def.TenancyStrategy.PrefixPattern != "" && !strings.Contains(def.TenancyStrategy.PrefixPattern, "{tenant_id}") {
-			return fmt.Errorf("tenancy_strategy.prefix_pattern %q must contain {tenant_id}", def.TenancyStrategy.PrefixPattern)
+		// The {tenant_id} token is MANDATORY here (no `!= ""` escape): for
+		// shared_key_with_prefix the prefix IS the only tenant-isolation
+		// mechanism, so an empty or token-less pattern would resolve to an
+		// empty key prefix and collapse all tenants into one keyspace. Reject
+		// it at authoring time; resolveTenancy is the runtime backstop.
+		if !strings.Contains(def.TenancyStrategy.PrefixPattern, "{tenant_id}") {
+			return fmt.Errorf("tenancy_strategy.prefix_pattern %q must contain {tenant_id} for shared_key_with_prefix (an empty or token-less prefix collapses all tenants into one keyspace)", def.TenancyStrategy.PrefixPattern)
 		}
 	default:
 		return fmt.Errorf("unknown tenancy_strategy.kind %q (must be one of: key_per_tenant, shared_key_with_prefix)", def.TenancyStrategy.Kind)


### PR DESCRIPTION
## Why

An **independent** formal whole-feature review of the Memory feature (RFC I) — the *integral* feature (backend interface, inprocess/Mem9/fallback backends, ranker, dedup, the Memory tool, `MemoryBackendDef` substrate, admin endpoints, snapshot round-trip, eval), not just dedup. The feature was already reviewed once (commit `946a2aa`, 9 fixes), so this re-attacked it rather than trusting that pass. Result: **14 raw findings → 2 confirmed + 1 conceded residual; 12 refuted** (mostly documented-design or already-fixed — a high refutation rate consistent with a well-built feature). The `946a2aa` HIGH fix (`applyAgentDefOverlay` carrying `memory_backend`) was independently re-verified present and holding.

## What

**HIGH — `shared_key_with_prefix` + empty/token-less `prefix_pattern` → cross-tenant leak.** `resolveTenancy`'s `{tenant_id}` guard sat *inside* `if Contains(prefix, "{tenant_id}")`, so an empty or token-less pattern fell through to `KeyPrefix=""` — a no-op in `scopedKey`/`scopedPrefix` — and every tenant read+wrote every other tenant's rows in Mem9's flat keyspace. The Def validator only rejected *non-empty-but-token-less* patterns (`!= "" &&`), and **static `memory_backends:` yaml is never run through the Def validator at all**. Closed at three layers:
- `resolveTenancy` — refuses `shared_key_with_prefix` unless `prefix_pattern` contains `{tenant_id}` (the **runtime backstop**: no config path — substrate fork *or* hand-written yaml — can reach the no-prefix state);
- `validateMemoryBackendDef` — drops the `!= ""` escape (fail at author time);
- `config.validate()` — boot-time loop over `memory_backends` so static yaml can't bypass it.

Reachable via operator misconfiguration (the tenant id is operator-authoritative, not model input), but it passes all validation **silently** and yields a **total** cross-tenant read+write leak → HIGH.

**LOW — `memory_quota_bytes` unenforced for remote backends.** `checkQuota` summed existing bytes from the in-process store regardless of the resolved `memory_backend`, so a mem9-routed agent measured ~0 used bytes and the cap never applied (while writes landed remotely). Now lists through `m.backend(ctx)` (equivalent for the in-process default, which wraps the store).

**LOW (defense-in-depth) — Mem9 `base_url` blind SSRF.** `base_url` had no scheme/host validation and is model-authorable via a fork overlay; the client sends the allowlisted `X-API-Key` to whatever host it names. `validateMemoryBackendDef` now rejects a non-`http(s)`/hostless `base_url` (reusing the A2A `requireHTTPURL` guard). *The credential itself was already protected — `api_key_env` is env-allowlist-gated, so the finder's "arbitrary-secret exfiltration" framing was **refuted**; this is the residual operator-gated blind-SSRF the verifier conceded.*

## What was tested
- Regression tests, each verified failing on the unfixed code (neutralize → fail → restore, guards checked in isolation): `TestResolveTenancy_SharedPrefixEmptyOrTokenlessRejected`, `TestMemoryBackendDefTool_RefusesEmptySharedPrefix`, `TestMemoryBackendDefTool_RefusesNonHTTPBaseURL`, `TestMemoryBackend_RejectsSharedPrefixWithoutTenantToken` (config).
- `go build/vet/test ./...` clean; `go test -race ./internal/tools/builtin/... ./internal/config/... ./internal/memory/...` clean; `gofmt` clean.

## Notable refutations (confirmed sound, not patched)
fallback Set/Get split-brain (documented graceful-degradation); `truncated`/dedup-pool/`duplication_rate` (documented pool-level semantics); `MemoryBackendDef` "default-deny on agent runs" (it's operator-admin-only, never in the agent tool set); `mergeAgentDef` dropping `MemoryBackendDefScopes` (dead config — MR-3b scaffolding, no consumer yet); `key_per_tenant` empty `env_pattern` (intentional single-tenant path); admin PUT-embed dimension (postgres `MemoryEmbedSet` rejects a len≠dimension mismatch). Two are worth a future follow-up when MR-3b lands (the `MemoryBackendDefScopes` wiring) — noted, not forced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)