### PR TITLE
fix(webhook): replayed valid delivery → 200 idempotent ack (not 401)

### DIFF
--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -183,16 +183,29 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 4. Replay guard (Layer-1, per-replica). delivery id from the Def's
-	//    header or a body hash. A hit inside the TTL → 401 (same opaque
-	//    posture as a sig failure — a replayed-but-valid request is still
-	//    "not accepted").
+	//    header or a body hash. A hit inside the TTL is a re-delivery of an
+	//    ALREADY-ACCEPTED, already-signature-verified request (this path is
+	//    only reachable AFTER verifySignature passes), so it is NOT an auth
+	//    failure — it is an idempotent re-send. Respond 200 with the original
+	//    run_id when recoverable, matching the GitHub/Stripe redelivery
+	//    contract. (Earlier revisions returned an opaque 401 here "same as a
+	//    sig failure", which shielded no attacker — the signature already
+	//    verified — and misled legitimate senders into rotating their secret
+	//    on a dedup. Changed to an idempotent ack.)
 	did := deliveryID(wd.Auth, body, r.Header.Get)
 	if rec.dedup.seen(name, did) {
-		// Replay of an already-ACCEPTED delivery (recorded on acceptance
-		// below). Same opaque 401 posture as a sig failure.
-		rec.finish(span, name, did, "rejected_replay", "")
-		rec.logf("webhook %q: replay rejected (delivery_id seen within TTL)", name)
-		writeError(w, http.StatusUnauthorized, "unauthorized", "")
+		rec.finish(span, name, did, verdictAcceptedReplay, "")
+		rec.logf("webhook %q: replayed delivery (delivery_id seen within TTL) — idempotent ack", name)
+		resp := map[string]string{"webhook_name": name, "delivery_id": did, "deduped": "true"}
+		// Best-effort: surface the original run for the spawn path, which set
+		// idempotency_key = delivery_id (RFC H Decision 10). Channel-delivery
+		// has no run row, so run_id is simply omitted.
+		if rec.store != nil {
+			if existing, ok, lerr := rec.store.RunByIdempotencyKey(ctx, did); lerr == nil && ok {
+				resp["run_id"] = existing.ID
+			}
+		}
+		writeJSON(w, http.StatusOK, resp)
 		return
 	}
 
@@ -577,7 +590,9 @@ func isTerminal(status string) bool {
 // terminal point (including rejects) cannot grow memory without limit.
 func (rec *Receiver) finish(s trace.Span, name, did, verdict, runID string) {
 	s.SetAttributes(attribute.String("webhook.verdict", verdict))
-	if verdict == verdictAccepted {
+	// Both a fresh acceptance and an idempotent replay-ack are Ok outcomes —
+	// a replay is a successful re-delivery, not an error.
+	if verdict == verdictAccepted || verdict == verdictAcceptedReplay {
 		s.SetStatus(codes.Ok, "")
 	} else {
 		s.SetStatus(codes.Error, verdict)

--- a/internal/api/webhook/server_test.go
+++ b/internal/api/webhook/server_test.go
@@ -48,6 +48,21 @@ func (f *fakeRunner) input() runner.RunInput {
 	return f.lastIn
 }
 
+// reset clears the "was called" flag so a later spawn is independently
+// observable (used to prove a replay does NOT spawn a second run).
+func (f *fakeRunner) reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.called = false
+}
+
+// wasCalled reads the flag under the lock (race-clean alongside RunOnce).
+func (f *fakeRunner) wasCalled() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.called
+}
+
 // fakePublisher records channel publishes.
 type fakePublisher struct {
 	mu      sync.Mutex
@@ -190,7 +205,11 @@ func TestReceiver_TamperedBody_401(t *testing.T) {
 	}
 }
 
-func TestReceiver_ReplayWithinTTL_401(t *testing.T) {
+// A replayed valid delivery (same delivery id, within the dedup TTL) is an
+// idempotent re-send, NOT an auth failure — it is only reachable after the
+// signature already verified. It must respond 200 + deduped:true (the
+// GitHub/Stripe redelivery contract), and must NOT spawn a second run.
+func TestReceiver_ReplayWithinTTL_IdempotentAck(t *testing.T) {
 	secret := "shhh"
 	now := time.Unix(1_700_000_000, 0)
 	body := []byte(`{"goal":"a"}`)
@@ -206,8 +225,21 @@ func TestReceiver_ReplayWithinTTL_401(t *testing.T) {
 	if w := doPost(rec, "gh", body, h); w.Code != http.StatusAccepted {
 		t.Fatalf("first delivery status = %d, want 202", w.Code)
 	}
-	if w := doPost(rec, "gh", body, h); w.Code != http.StatusUnauthorized {
-		t.Fatalf("replay status = %d, want 401", w.Code)
+	fr.reset() // forget the first run so a second spawn would be observable
+
+	w := doPost(rec, "gh", body, h)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay status = %d, want 200 (idempotent ack)", w.Code)
+	}
+	var got map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got["deduped"] != "true" {
+		t.Errorf("replay deduped = %q, want true", got["deduped"])
+	}
+	if fr.wasCalled() {
+		t.Error("replay spawned a second run — dedup did not suppress it")
 	}
 }
 

--- a/internal/api/webhook/signature.go
+++ b/internal/api/webhook/signature.go
@@ -54,9 +54,14 @@ func (e *authError) Error() string { return e.msg }
 // and maps to status codes; they are never echoed verbatim to the client
 // for the signature-failure cases.
 const (
-	verdictAccepted    = "accepted"
-	verdictRejectedSig = "rejected_sig"
-	verdictUnresolved  = "unresolvable_secret"
+	verdictAccepted = "accepted"
+	// verdictAcceptedReplay is an idempotent re-delivery of an
+	// already-accepted (already-signature-verified) request — a 200 ack, NOT
+	// an error. Distinct from verdictAccepted so triage can tell a fresh
+	// acceptance from a deduped re-send.
+	verdictAcceptedReplay = "accepted_replay"
+	verdictRejectedSig    = "rejected_sig"
+	verdictUnresolved     = "unresolvable_secret"
 )
 
 // errSignatureMismatch is the catch-all for every "the request did not

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -173,12 +173,21 @@ status, or `504` on `sync_timeout_ms`. Channel mode returns `202`.
 
 ## Never silently degrade
 
-Every failure mode is loud and distinct: `404` unknown/disabled (opaque, no
-enumeration), `401` any auth/replay failure (no body detail — no oracle),
+Every outcome is loud and distinct: `404` unknown/disabled (opaque, no
+enumeration), `401` signature/auth failure (no body detail — no oracle),
 `503 secret_unresolvable`, `400` malformed body/mapping, `429` rate limit,
 `503` runtime unavailable. A rate-limited or rejected delivery does **not**
 burn its `delivery_id`, so the sender's retry is processed rather than
 dropped as a replay.
+
+A **replayed valid delivery** (a re-send of an already-accepted
+`delivery_id`, within the dedup window) is **not** an error — it is only
+reachable after the signature has already verified, so it is an idempotent
+re-delivery, not an attacker. The receiver acks it **`200`** with
+`{deduped: true}` and the original `run_id` (when the spawn path recorded
+one), matching the GitHub/Stripe redelivery contract, and does **not** spawn
+a second run. (A sender that retries on non-2xx therefore stops, rather than
+rotating its secret on a misread `401`.)
 
 ## on_complete
 
@@ -194,7 +203,7 @@ Two bearer-authed endpoints help debug a webhook that's silently failing
 
 - `GET /v1/_webhooks/{name}/recent-deliveries?limit=50` — the last N
   invocations with `delivery_id`, `verdict`
-  (`accepted`/`rejected_sig`/`rejected_replay`/`rejected_rate`/
+  (`accepted`/`accepted_replay`/`rejected_sig`/`rejected_rate`/
   `unresolvable_secret`/…), `received_at`, `run_id`.
 - `POST /v1/_webhooks/{name}/test` — dry-run: POST a sample body + signature
   and get back `{would_accept, verdict, run_input_preview}` (credential

--- a/test/runtime/webhooks/run.sh
+++ b/test/runtime/webhooks/run.sh
@@ -102,22 +102,20 @@ BIG="{\"goal\":\"$(head -c 600 < /dev/zero | tr '\0' 'A')\"}"
 CODE=$(deliver "$BIG" -H "X-Hub-Signature-256: sha256=$(sign "$BIG")" -H "X-Delivery-Id: d-big")
 [[ "$CODE" = "400" ]] || fail "oversized code=$CODE (want 400)"
 
-echo "[7/8] replay same delivery id (VALID signature) → deduped, no 2nd run"
-# Re-send d-ok-1's exact body+signature. Because the signature is VALID
-# (identical to the accepted [4] delivery), a non-2xx here can ONLY be the
-# replay guard firing — not a signature failure — so this genuinely proves
-# dedup, not an accidental rejection.
-# NOTE (discovered by this suite): the replay guard returns 401
-# "unauthorized" (server.go:195 — deliberately "opaque, same as a sig
-# failure"). That is arguably misleading for a valid-but-duplicate delivery
-# (a 200/409 idempotent ack is the usual webhook contract, and the replay
-# path is only reachable AFTER signature verification, so no unauthorized
-# attacker is being protected). Flagged for the maintainer; this suite
-# asserts the SHIPPED behaviour so a future change to it is a conscious one.
+echo "[7/8] replay same delivery id (VALID signature) → 200 idempotent ack, no 2nd run"
+# Re-send d-ok-1's exact body+signature. The signature is VALID (identical to
+# the accepted [4] delivery), so this exercises the replay/dedup guard, not a
+# signature failure. A replayed valid delivery is an idempotent re-send (the
+# path is only reachable AFTER signature verification), so the receiver acks
+# it 200 with deduped=true and the original run_id — the GitHub/Stripe
+# redelivery contract — and must NOT spawn a second run. (Earlier this guard
+# returned an opaque 401; changed to a 200 idempotent ack so a legitimate
+# sender isn't misled into rotating its secret on a dedup.)
 RUNS_BEFORE=$(sqlite3 "$DB" "SELECT count(*) FROM runs;")
 CODE=$(deliver "$BODY" -H "X-Hub-Signature-256: sha256=$(sign "$BODY")" -H "X-Delivery-Id: d-ok-1")
 echo "  replay code=$CODE body=$(cat "$TEST_DIR/deliver.body")"
-[[ "$CODE" = "401" ]] || fail "replay (valid sig) code=$CODE; expected the replay guard to reject (currently 401)"
+[[ "$CODE" = "200" ]] || fail "replay (valid sig) code=$CODE; expected 200 idempotent ack"
+grep -q '"deduped":"true"' "$TEST_DIR/deliver.body" || fail "replay ack missing deduped:true (body=$(cat "$TEST_DIR/deliver.body"))"
 sleep 1
 RUNS_AFTER=$(sqlite3 "$DB" "SELECT count(*) FROM runs;")
 [[ "$RUNS_BEFORE" = "$RUNS_AFTER" ]] || fail "replay spawned a duplicate run ($RUNS_BEFORE→$RUNS_AFTER)"


### PR DESCRIPTION
## Why

The whole-feature QA hardening report (`doc-internal/research/hardening-and-runtime-test-report-2026-05-31.md`, §5.2) flagged the webhook replay guard returning **`401 unauthorized`** for a valid-but-duplicate delivery. That path is only reachable **after** `verifySignature` passes — so it shields no attacker (the signature already verified); its only effect is misleading a legitimate sender, which may rotate its secret on a `401`. The GitHub/Stripe redelivery contract is an **idempotent ack**.

Maintainer decision: change to **200 idempotent ack**.

## What

- A replayed delivery (already-seen `delivery_id` within the dedup TTL) now responds **`200`** with `{deduped: true}` and the **original `run_id`** when recoverable (spawn mode sets `idempotency_key = delivery_id`, so `RunByIdempotencyKey` resolves it; channel mode omits `run_id`). It still does **not** spawn a second run.
- New verdict **`accepted_replay`** (distinct from `accepted`, so triage tells a fresh accept from a deduped re-send); `finish()` marks it an **Ok** span, not Error.
- Unit test rewritten (`TestReceiver_ReplayWithinTTL_IdempotentAck`): asserts 200 + `deduped:true` + no second spawn; added race-clean `fakeRunner.reset()`/`wasCalled()`.
- `Context.help input-webhooks` topic + the `webhooks/` runtime suite updated to the new contract.

## Tested

- `go build/vet/test ./...` clean; `-race` clean on the receiver.
- **Runtime suite against a live binary** (`make runtime-mock`) PASS — replay returns `200 {"deduped":"true","run_id":"r_989a...","webhook_name":"gh"}`, no duplicate run.

Closes the one open wire-contract decision from the hardening report (§5.2 / §6). The other deferred items (gRPC tenant interceptor, gRPC SSRF, MemoryBackendDefScopes dead-config) are being tracked separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)