### PR TITLE
feat(rfc-k): MemoryLayer capability — Memory tool add/recall over LLM-extract backends

### DIFF
--- a/docs/MEMORY-BACKENDS.md
+++ b/docs/MEMORY-BACKENDS.md
@@ -28,8 +28,8 @@ recall.
 
 ## The backend model
 
-Every `Memory` op (get/set/delete/list/search) routes through a
-`memory.Backend`. An agent's `memory_backend: <name>` field selects a
+Every key/value `Memory` op (get/set/delete/list/search) routes through
+a `memory.Backend`. An agent's `memory_backend: <name>` field selects a
 named backend; absent, the agent uses the operator-default (in-process).
 The backend NAME is operator-resolved and stamped onto the run — it is
 **never** model/tool input (same trust posture as the memory scope).
@@ -173,6 +173,40 @@ stale local copy.
 
 Without `fallback_on_error`, a backend error surfaces to the agent as a
 tool error.
+
+> ⚠ **`fallback_on_error` is mutually exclusive with the memory-layer
+> `add` / `recall` ops** (see below). The in-process fallback is a
+> key/value store and cannot honor a semantic add/recall, so a
+> fallback-wrapped memory-layer backend reports `capability_unsupported`
+> for those two ops — fail-closed, never a silent degrade that would
+> drop facts. Use fallback for the six key/value ops, or a memory layer
+> for `add`/`recall`, but not both on one backend.
+
+## Memory layer: add / recall
+
+A `mem9` backend is more than a remote key/value store — it is an
+**LLM-extract memory layer**. Beyond the six key/value ops it serves the
+`add` / `recall` paradigm: you hand it conversation messages and it
+distils durable facts, then answers natural-language recall queries over
+them. There are no caller keys; identity is server-assigned. This is a
+distinct capability the in-process backend does **not** have.
+
+```jsonc
+// ingest a conversation — infer defaults to true (LLM fact extraction)
+{"op": "add", "scope": "user",
+ "messages": [{"role": "user", "content": "I prefer dark mode"}]}
+// → {"status": "pending"}   (often async — no read-after-write guarantee)
+
+// recall distilled facts by meaning
+{"op": "recall", "scope": "user", "query": "ui preferences", "top_k": 5}
+// → {"facts": [{"id": "uuid-1", "memory": "user prefers dark mode", "score": 0.91}]}
+```
+
+Against a non-memory-layer backend (the default in-process store)
+`add` / `recall` return `capability_unsupported` rather than faking it.
+`add` / `recall` honor the agent's `memory_scopes` and the backend's
+tenancy prefix exactly like the key/value ops. See the `memory-layer`
+`Context.help` topic for the full op reference.
 
 ## Observability
 

--- a/internal/help/builtin/memory-layer.md
+++ b/internal/help/builtin/memory-layer.md
@@ -1,0 +1,92 @@
+---
+name: memory-layer
+description: The Memory tool's add / recall ops — the LLM-extract memory-layer paradigm (mem9), and how it differs from key/value and vector search (RFC K).
+---
+loomcycle's `Memory` tool has three retrieval paradigms, not one.
+Most agents only need the first two; `add` / `recall` exist for the
+third — an **external memory layer** like Mem9 that runs its own LLM
+to distil conversations into durable facts.
+
+| You want… | Op | Backend |
+|---|---|---|
+| "what did I store under this exact key?" | `get` / `list` | any |
+| "what notes are *close* to X?" | `search` (`embed: true` on `set`) | any with an embedder |
+| "remember this conversation; recall what you learned" | `add` / `recall` | memory-layer only (`memory_backend` kind=mem9) |
+
+## What a memory layer is
+
+A key/value store is faithful: you `set` a key, you `get` exactly
+that value back. A vector store adds similarity ranking over rows you
+wrote. A **memory layer** is a different contract entirely: you hand
+it conversation messages, and the backend *itself* decides what is
+worth remembering — running an LLM to extract, merge, update, or drop
+facts. There are no caller keys; identity is server-assigned. The
+whole point is that the backend is smarter than a dictionary.
+
+That is why `add` / `recall` are a separate capability and not just
+new ops on the flat store. The default in-process backend is a
+key/value + vector store, **not** a memory layer — so against it,
+`add` / `recall` refuse with `capability_unsupported` rather than
+silently faking it. Wire a `memory_backend` of a memory-layer kind
+(today: `mem9`) to the agent to enable them.
+
+## add — ingest a conversation
+
+```json
+{"op": "add", "scope": "user",
+ "messages": [
+   {"role": "user", "content": "I prefer dark mode and I'm based in Berlin"},
+   {"role": "assistant", "content": "Noted."}
+ ]}
+```
+
+- `infer` (default **true**) asks the backend to LLM-extract durable
+  facts from the messages. Pass `infer: false` to store them verbatim.
+- `metadata` is opaque key/value context attached to the ingestion.
+- The result is `{"status": "pending" | "done", "event_id"?}`.
+  **A memory-layer add is frequently asynchronous** — the backend
+  returns before extraction finishes. Do **not** assume
+  read-after-write: a `recall` immediately after an `add` may not see
+  the new facts yet. `event_id`, when present, is a correlation handle.
+
+## recall — semantic search over extracted facts
+
+```json
+{"op": "recall", "scope": "user", "query": "ui preferences", "top_k": 5}
+```
+
+Returns ranked facts the backend has distilled, each with a
+server-assigned `id`, the `memory` text, and a 0..1 `score`:
+
+```json
+{"facts": [{"id": "uuid-1", "memory": "user prefers dark mode", "score": 0.91}]}
+```
+
+- `top_k` defaults to 10, capped at 50.
+- `threshold` (0..1) is a relevance floor; facts below it are dropped.
+  0 means "use the backend's default".
+
+Unlike `search`, the results are *derived facts* with opaque IDs, not
+the rows you wrote — you cannot `get` them back by key.
+
+## Scope, tenancy, and failure modes
+
+`add` / `recall` honor the agent's `memory_scopes` exactly like every
+other op: `scope: agent` is keyed to this agent, `scope: user` to the
+run's `user_id`. The mem9 backend then namespaces that under its
+tenant prefix, so one tenant can neither write into nor recall from
+another's facts.
+
+- **`capability_unsupported`** — the resolved backend is not a memory
+  layer (e.g. the default in-process store). Wire a `mem9`
+  `memory_backend`.
+- **`fallback_on_error: inprocess` is mutually exclusive with add /
+  recall.** The in-process fallback is a key/value store and cannot
+  honor a semantic `add` / `recall`, so a fallback-wrapped mem9
+  backend reports `capability_unsupported` for these ops — fail-closed
+  by design, never a silent degrade to a store that would lose the
+  facts. Use fallback for the six key/value ops, or the memory layer
+  for `add` / `recall`, but not both on one backend.
+
+See `MEMORY-BACKENDS.md` for wiring a `memory_backend`, and the
+`vector-memory` / `memory-ranking` topics for the `search` paradigm.

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -36,6 +36,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		"interruption",
 		"llm-gateway",
 		"loomcycle",
+		"memory-layer",
 		"memory-ranking",
 		"memory-reducers",
 		"n8n-integration",

--- a/internal/memory/backends/mem9/layer.go
+++ b/internal/memory/backends/mem9/layer.go
@@ -1,0 +1,244 @@
+// layer.go adds the RFC K MemoryLayer capability to the Mem9 Backend.
+//
+// The Mem9 backend genuinely serves BOTH shapes (RFC K §5): the flat KV
+// surface (mem9.go) AND the memory-layer add/recall paradigm (here). The
+// two live in separate files so mem9.go stays focused on the six-op
+// Backend contract; this file is ONLY the two MemoryLayer methods plus
+// Capabilities, and it reuses mem9.go's verified plumbing (do() for the
+// authenticated/size-capped round-trip, resolveKey, the tenancy helpers,
+// joinPath). No HTTP/auth/tenancy logic is duplicated.
+//
+// ⚠ WIRE-SHAPE HONESTY ⚠ — same discipline as mem9.go. The credential
+// (X-API-Key), the size cap, and the tenancy scoping are the VERIFIED,
+// load-bearing parts (they flow through do() + scopedPrefix). The exact
+// JSON field names and the two paths below are an ASSUMED CONTRACT, each
+// tagged with the banner. They are a best-effort reconstruction of Mem9's
+// v1alpha2 smart-mode write + q= recall and are NOT verified against a
+// live server. The httptest stub in layer_test.go IS the contract under
+// test, not real Mem9.
+package mem9
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+
+	memory "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// =====================================================================
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+//
+// Everything between this banner and the next "END ASSUMED WIRE SHAPE"
+// banner is the unverified REST contract for the memory-layer surface.
+// To adapt to the real Mem9 API, change ONLY this block. The Add/Recall
+// methods below call these and stay shape-agnostic.
+// =====================================================================
+
+// layerCollectionPath is the smart-mode write + the q= recall endpoint:
+// POST/GET {base}/{api_version}/mem9s/memories. Per the RFC K research
+// (doc-internal/research/external-memory-products-2026-05-31.md, Mem9
+// section): write is 202-async with body {messages, mode, session_id};
+// recall is GET ?q=&limit= returning scored memory objects.
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+func (b *Backend) layerCollectionPath() string {
+	return b.joinPath("mem9s", "memories")
+}
+
+// wireAddRequest is the POST mem9s/memories body. mode="smart" runs the
+// 2-phase LLM extract+reconcile (opts.Infer); mode="raw" stores verbatim.
+// session_id scopes the ingestion so recall can be narrowed to the same
+// (scope, scopeID) slice — we put loomcycle's tenant-prefixed scope key
+// there. Metadata carries the opts.Metadata hints.
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+type wireAddRequest struct {
+	Messages  []wireAddMessage  `json:"messages"`
+	Mode      string            `json:"mode"`
+	SessionID string            `json:"session_id,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// wireAddMessage is one conversation turn in the smart-mode write body.
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+type wireAddMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+// wireAddResponse is the 202 body. The research says Mem9 echoes NO object
+// on the async write, so this is best-effort: if a future/real server does
+// return a correlation handle we accept any of these field names and pass
+// it through as AddResult.EventID. When absent (the documented case),
+// EventID stays "" and the status is still AddPending.
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+type wireAddResponse struct {
+	EventID string `json:"event_id,omitempty"`
+	ID      string `json:"id,omitempty"`
+}
+
+// wireRecallResponse is the GET ?q= response. The research describes a bare
+// JSON array of memory objects (id, content, tags, type, state, version,
+// relevance score). We decode into a slice of wireRecallItem.
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+type wireRecallItem struct {
+	ID       string            `json:"id"`
+	Content  string            `json:"content"`
+	Score    float64           `json:"relevance"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// toRecallFact maps one assumed wire item onto memory.RecallFact. The
+// server-assigned id is opaque to loomcycle; content is the extracted
+// fact; relevance is the 0..1 score (1−distance per the research).
+//
+// ASSUMED Mem9 wire shape — verify against the real
+// github.com/mem9-ai/mem9 v1alpha2 API before production.
+func toRecallFact(w wireRecallItem) memory.RecallFact {
+	return memory.RecallFact{
+		ID:       w.ID,
+		Memory:   w.Content,
+		Score:    w.Score,
+		Metadata: w.Metadata,
+	}
+}
+
+// =====================================================================
+// END ASSUMED WIRE SHAPE. Everything below is verified loomcycle-side
+// logic: the capability advertisement, tenancy scoping, and the mapping
+// onto the MemoryLayer interface — all reusing mem9.go's do()/tenancy.
+// =====================================================================
+
+// Capabilities advertises that the Mem9 backend serves both the flat KV
+// shape (Get/Set/Delete/List/Search/Stats) AND the memory-layer add/recall
+// shape. This makes *Backend satisfy memory.Capable so the Memory tool can
+// route add/recall here instead of refusing capability_unsupported.
+func (b *Backend) Capabilities() memory.Capabilities {
+	return memory.Capabilities{
+		KV:           true,
+		VectorSearch: true,
+		Stats:        true,
+		MemoryLayer:  true,
+	}
+}
+
+// Add ingests conversation messages via Mem9's smart-mode write. The write
+// is 202-async (the research: "returns 202 Accepted, async, no object
+// echoed"), so we always report AddPending — being honest that extraction
+// has not necessarily completed and read-after-write is not guaranteed. A
+// correlation handle, if the server returns one, is surfaced as EventID;
+// the documented case (no body) yields EventID == "".
+//
+// Tenancy + scope: loomcycle's (scope, scopeID) is namespaced under the
+// tenant prefix (scopedPrefix + scopeKey, the SAME isolation boundary the
+// KV path uses) and sent as session_id, so a shared_key_with_prefix tenant
+// cannot write into another tenant's space and recall can scope to it.
+func (b *Backend) Add(ctx context.Context, scope store.MemoryScope, scopeID string, msgs []memory.LayerMessage, opts memory.AddOptions) (memory.AddResult, error) {
+	mode := "raw"
+	if opts.Infer {
+		mode = "smart"
+	}
+
+	wireMsgs := make([]wireAddMessage, 0, len(msgs))
+	for _, m := range msgs {
+		wireMsgs = append(wireMsgs, wireAddMessage{Role: m.Role, Content: m.Content})
+	}
+
+	req := wireAddRequest{
+		Messages: wireMsgs,
+		Mode:     mode,
+		// Tenant-prefixed scope key as the session id — same isolation
+		// boundary as the KV path's scopedKey. An empty key segment is fine;
+		// the prefix is what enforces tenant + scope separation.
+		SessionID: b.scopedPrefix(scopeKey(scope, scopeID, "")),
+		Metadata:  opts.Metadata,
+	}
+
+	respBody, err := b.do(ctx, http.MethodPost, b.layerCollectionPath(), req)
+	if err != nil {
+		return memory.AddResult{}, err
+	}
+
+	// The async write echoes no object in the documented case; decode is
+	// best-effort so a present correlation handle is surfaced, an empty body
+	// is fine, and a malformed body does not fail an accepted (2xx) write.
+	var w wireAddResponse
+	_ = json.Unmarshal(respBody, &w)
+	eventID := w.EventID
+	if eventID == "" {
+		eventID = w.ID
+	}
+
+	// Mem9's write is async: be honest with AddPending, never AddDone.
+	return memory.AddResult{Status: memory.AddPending, EventID: eventID}, nil
+}
+
+// Recall runs Mem9's natural-language hybrid search (GET ?q=&limit=) and
+// maps the returned memory objects onto RecallFacts. The tenant-prefixed
+// scope is sent so the query stays within the tenant + scope slice (mirrors
+// the KV Search's scopedPrefix usage). Mem9 returns a relevance score; we
+// pass it through, honor q.Threshold client-side (the research lists no
+// threshold param on the q= recall), and trim to q.TopK.
+func (b *Backend) Recall(ctx context.Context, scope store.MemoryScope, scopeID string, q memory.RecallQuery) (memory.RecallResult, error) {
+	vals := url.Values{}
+	vals.Set("q", q.Query)
+	if q.TopK > 0 {
+		vals.Set("limit", strconv.Itoa(q.TopK))
+	}
+	// Scope the query to this tenant + (scope, scopeID). Same isolation
+	// rationale as KV Search: without the prefix, one tenant's recall could
+	// reach another's facts in Mem9's flat space.
+	vals.Set("session_id", b.scopedPrefix(scopeKey(scope, scopeID, "")))
+
+	urlStr := b.layerCollectionPath() + "?" + vals.Encode()
+	respBody, err := b.do(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return memory.RecallResult{}, err
+	}
+
+	var items []wireRecallItem
+	if uerr := json.Unmarshal(respBody, &items); uerr != nil {
+		return memory.RecallResult{}, fmt.Errorf("mem9: decode recall response: %w", uerr)
+	}
+
+	facts := make([]memory.RecallFact, 0, len(items))
+	for _, it := range items {
+		f := toRecallFact(it)
+		// Threshold is a relevance floor; Mem9's q= recall has no documented
+		// threshold param, so filter client-side. Threshold==0 means "backend
+		// default" → keep everything.
+		if q.Threshold > 0 && f.Score < q.Threshold {
+			continue
+		}
+		facts = append(facts, f)
+	}
+
+	// Trim to TopK defensively in case the server returned more than limit
+	// (or we requested no limit) — the contract is "ranked top_k".
+	if q.TopK > 0 && len(facts) > q.TopK {
+		facts = facts[:q.TopK]
+	}
+
+	return memory.RecallResult{Facts: facts}, nil
+}
+
+// Compile-time assertions: the Mem9 Backend implements both the optional
+// MemoryLayer capability and the Capable advertiser.
+var (
+	_ memory.MemoryLayer = (*Backend)(nil)
+	_ memory.Capable     = (*Backend)(nil)
+)

--- a/internal/memory/backends/mem9/layer_test.go
+++ b/internal/memory/backends/mem9/layer_test.go
@@ -1,0 +1,253 @@
+package mem9_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	memory "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/memory/backends/mem9"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// IMPORTANT — same honesty as mem9_test.go: the layerStub below IS the
+// contract under test. It implements the ASSUMED Mem9 v1alpha2 smart-mode
+// write (202) + the q= recall that layer.go isolates behind its wire-shape
+// banner. These tests prove the loomcycle-side mapping (Add mode selection,
+// AddPending honesty, credential header, tenant scoping, recall→facts with
+// TopK trim + Threshold filter) is internally consistent against THAT stub.
+// They do NOT prove it matches the real github.com/mem9-ai/mem9 API — that
+// is verified operator-side. If the real API differs, update the wire block
+// in layer.go AND this stub together.
+
+// layerStub implements the assumed memory-layer endpoints. It records the
+// last write request and the last recall query so tests can assert mode,
+// auth, and tenant scoping without a real Mem9 server.
+type layerStub struct {
+	srv          *httptest.Server
+	lastAPIKey   string
+	lastAddMode  string
+	lastAddSess  string
+	lastRecallQ  string
+	lastRecallSx string
+	recallItems  []layerStubItem
+}
+
+type layerStubItem struct {
+	id      string
+	content string
+	score   float64
+}
+
+func newLayerStub(t *testing.T) *layerStub {
+	t.Helper()
+	s := &layerStub{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1alpha2/mem9s/memories", s.handle)
+	s.srv = httptest.NewServer(mux)
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *layerStub) handle(w http.ResponseWriter, r *http.Request) {
+	s.lastAPIKey = r.Header.Get("X-API-Key")
+	switch r.Method {
+	case http.MethodPost:
+		var req struct {
+			Messages []struct {
+				Role    string `json:"role"`
+				Content string `json:"content"`
+			} `json:"messages"`
+			Mode      string `json:"mode"`
+			SessionID string `json:"session_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		s.lastAddMode = req.Mode
+		s.lastAddSess = req.SessionID
+		// Mem9's documented behavior: 202 Accepted, no object echoed.
+		w.WriteHeader(http.StatusAccepted)
+	case http.MethodGet:
+		s.lastRecallQ = r.URL.Query().Get("q")
+		s.lastRecallSx = r.URL.Query().Get("session_id")
+		type item struct {
+			ID        string  `json:"id"`
+			Content   string  `json:"content"`
+			Relevance float64 `json:"relevance"`
+		}
+		out := make([]item, 0, len(s.recallItems))
+		for _, it := range s.recallItems {
+			out = append(out, item{ID: it.id, Content: it.content, Relevance: it.score})
+		}
+		_ = json.NewEncoder(w).Encode(out)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func newLayerBackend(s *layerStub, tenancy mem9.Tenancy) *mem9.Backend {
+	return mem9.New(mem9.Config{
+		BaseURL:    s.srv.URL,
+		APIVersion: "v1alpha2",
+		Tenancy:    tenancy,
+		CredentialResolver: func(context.Context) (string, error) {
+			return testAPIKey, nil
+		},
+		HTTPClient:  s.srv.Client(),
+		BackendName: "test-mem9-layer",
+	})
+}
+
+// TestMem9Layer_CapabilitiesAdvertisesMemoryLayer pins that the Mem9
+// backend advertises the MemoryLayer capability so the tool routes
+// add/recall here instead of refusing capability_unsupported.
+func TestMem9Layer_CapabilitiesAdvertisesMemoryLayer(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{})
+	caps := b.Capabilities()
+	if !caps.MemoryLayer {
+		t.Error("Capabilities().MemoryLayer = false, want true")
+	}
+	if !caps.KV || !caps.VectorSearch || !caps.Stats {
+		t.Errorf("Capabilities() = %+v, want all of KV/VectorSearch/Stats true (Mem9 serves both shapes)", caps)
+	}
+}
+
+// TestMem9Layer_AddSendsSmartModeWhenInfer pins mode="smart" for Infer=true,
+// that the write reports AddPending (Mem9's write is 202-async), and that
+// the resolved X-API-Key reaches the server.
+func TestMem9Layer_AddSendsSmartModeWhenInfer(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{})
+
+	res, err := b.Add(context.Background(), store.MemoryScopeAgent, "qa",
+		[]memory.LayerMessage{{Role: "user", Content: "I prefer dark mode"}},
+		memory.AddOptions{Infer: true})
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if s.lastAddMode != "smart" {
+		t.Errorf("write mode = %q, want smart (Infer=true)", s.lastAddMode)
+	}
+	if res.Status != memory.AddPending {
+		t.Errorf("AddResult.Status = %v, want AddPending (Mem9 write is async)", res.Status)
+	}
+	if s.lastAPIKey != testAPIKey {
+		t.Errorf("server saw X-API-Key %q, want %q", s.lastAPIKey, testAPIKey)
+	}
+}
+
+// TestMem9Layer_AddSendsRawModeWhenNotInfer pins mode="raw" for Infer=false
+// (verbatim storage, no LLM extraction).
+func TestMem9Layer_AddSendsRawModeWhenNotInfer(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{})
+
+	if _, err := b.Add(context.Background(), store.MemoryScopeAgent, "qa",
+		[]memory.LayerMessage{{Role: "user", Content: "x"}},
+		memory.AddOptions{Infer: false}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if s.lastAddMode != "raw" {
+		t.Errorf("write mode = %q, want raw (Infer=false)", s.lastAddMode)
+	}
+}
+
+// TestMem9Layer_AddScopesSessionToTenant pins that the tenant prefix +
+// loomcycle scope land in session_id, so a shared_key_with_prefix tenant
+// cannot write into another tenant's space.
+func TestMem9Layer_AddScopesSessionToTenant(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{KeyPrefix: "tenant-b::"})
+
+	if _, err := b.Add(context.Background(), store.MemoryScopeUser, "bob",
+		[]memory.LayerMessage{{Role: "user", Content: "x"}},
+		memory.AddOptions{Infer: true}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !strings.HasPrefix(s.lastAddSess, "tenant-b::") {
+		t.Errorf("session_id = %q, want tenant-b:: prefix (tenant isolation)", s.lastAddSess)
+	}
+	if !strings.Contains(s.lastAddSess, "user/bob/") {
+		t.Errorf("session_id = %q, want it to namespace scope user/bob/", s.lastAddSess)
+	}
+}
+
+// TestMem9Layer_RecallMapsFactsWithTopKAndThreshold pins the recall mapping:
+// memory objects → RecallFacts, the Threshold relevance floor filters
+// client-side, and the result is trimmed to TopK.
+func TestMem9Layer_RecallMapsFactsWithTopKAndThreshold(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{})
+
+	// Four candidates; one below threshold should be dropped, then trim to 2.
+	s.recallItems = []layerStubItem{
+		{id: "u1", content: "fact A", score: 0.95},
+		{id: "u2", content: "fact B", score: 0.80},
+		{id: "u3", content: "fact C", score: 0.60},
+		{id: "u4", content: "fact D", score: 0.20}, // below threshold 0.5
+	}
+
+	res, err := b.Recall(context.Background(), store.MemoryScopeUser, "bob",
+		memory.RecallQuery{Query: "preferences", TopK: 2, Threshold: 0.5})
+	if err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if s.lastRecallQ != "preferences" {
+		t.Errorf("recall q = %q, want %q", s.lastRecallQ, "preferences")
+	}
+	if len(res.Facts) != 2 {
+		t.Fatalf("Recall returned %d facts, want 2 (threshold drops u4, TopK trims to 2)", len(res.Facts))
+	}
+	if res.Facts[0].ID != "u1" || res.Facts[0].Memory != "fact A" || res.Facts[0].Score != 0.95 {
+		t.Errorf("Facts[0] = %+v, want {u1, fact A, 0.95}", res.Facts[0])
+	}
+	for _, f := range res.Facts {
+		if f.Score < 0.5 {
+			t.Errorf("fact %q has score %v below threshold 0.5 — filter failed", f.ID, f.Score)
+		}
+	}
+}
+
+// TestMem9Layer_RecallScopesQueryToTenant pins that the recall query carries
+// the tenant prefix (shared_key_with_prefix), mirroring KV Search isolation.
+func TestMem9Layer_RecallScopesQueryToTenant(t *testing.T) {
+	s := newLayerStub(t)
+	b := newLayerBackend(s, mem9.Tenancy{KeyPrefix: "tenant-b::"})
+
+	if _, err := b.Recall(context.Background(), store.MemoryScopeUser, "bob",
+		memory.RecallQuery{Query: "q", TopK: 5}); err != nil {
+		t.Fatalf("Recall: %v", err)
+	}
+	if !strings.HasPrefix(s.lastRecallSx, "tenant-b::") {
+		t.Errorf("recall session_id = %q, want tenant-b:: prefix", s.lastRecallSx)
+	}
+}
+
+// TestMem9Layer_CredentialNeverInError pins that a resolver failure fails
+// the op without reaching the server with a credential and without leaking
+// the (would-be) key into the error — same posture as the KV path.
+func TestMem9Layer_CredentialNeverInError(t *testing.T) {
+	s := newLayerStub(t)
+	b := mem9.New(mem9.Config{
+		BaseURL:    s.srv.URL,
+		APIVersion: "v1alpha2",
+		HTTPClient: s.srv.Client(),
+		CredentialResolver: func(context.Context) (string, error) {
+			return "", errResolve
+		},
+	})
+	_, err := b.Recall(context.Background(), store.MemoryScopeAgent, "qa",
+		memory.RecallQuery{Query: "q", TopK: 3})
+	if err == nil {
+		t.Fatal("Recall with failing resolver: want error, got nil")
+	}
+	if strings.Contains(err.Error(), testAPIKey) {
+		t.Errorf("error leaked a credential: %v", err)
+	}
+	if s.lastAPIKey != "" {
+		t.Errorf("server saw an API key %q despite resolver failure — unauthenticated call leaked", s.lastAPIKey)
+	}
+}

--- a/internal/memory/layer.go
+++ b/internal/memory/layer.go
@@ -1,0 +1,163 @@
+package memory
+
+import (
+	"context"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// MemoryLayer is the OPTIONAL capability for LLM-extract memory products
+// (mem0, Mem9 smart-mode, Zep-style) — RFC K. It is a DIFFERENT paradigm
+// from Backend: conversation messages go in, the backend (optionally) runs
+// an LLM to extract/reconcile durable facts, and recall is a
+// natural-language semantic search returning those facts.
+//
+// It deliberately has NO key-addressed Get/Set: identity is server-assigned
+// (a UUID, not a caller key) and fidelity is not guaranteed — in `infer`
+// mode the server may rewrite, merge, or delete facts. That is the whole
+// value of a memory layer, and the reason it cannot satisfy Backend's
+// faithful KV contract. The two interfaces are intentionally disjoint; a
+// backend implements Backend, MemoryLayer, or both.
+//
+// The Memory tool routes its `add` / `recall` ops here. When the resolved
+// backend does not implement MemoryLayer, the tool refuses with
+// *store.MemoryError{Code: "capability_unsupported"} — the same fail-closed
+// posture as the existing vector_unsupported / embedder_not_configured
+// refusals, never a panic or a silent no-op.
+type MemoryLayer interface {
+	// Add ingests conversation messages under (scope, scopeID). The backend
+	// MAY run an LLM to extract/reconcile durable facts (ADD/UPDATE/DELETE/
+	// NOOP against existing memories) when opts.Infer is set, or store them
+	// verbatim when it is not. Ingestion is often ASYNCHRONOUS (the server
+	// returns before extraction completes): AddResult.Status reports whether
+	// the work is done (AddDone) or still pending (AddPending, with an
+	// EventID the operator can correlate). A synchronous backend returns
+	// AddDone. Read-after-write is NOT guaranteed for a pending add.
+	Add(ctx context.Context, scope store.MemoryScope, scopeID string, msgs []LayerMessage, opts AddOptions) (AddResult, error)
+
+	// Recall runs a natural-language semantic search over the extracted
+	// facts under (scope, scopeID). Distinct from Backend.Search: results are
+	// derived facts with server-assigned IDs, not caller-keyed entries, and
+	// carry a 0..1 relevance score.
+	Recall(ctx context.Context, scope store.MemoryScope, scopeID string, q RecallQuery) (RecallResult, error)
+}
+
+// Capabilities lets the Memory tool probe a backend ONCE at op-routing time
+// and decide what to offer, instead of re-asserting types on every call. A
+// backend advertises it via the optional Capable interface below.
+//
+//   - KV:           satisfies the flat Backend contract faithfully
+//     (Get/Set round-trip, caller keys).
+//   - VectorSearch: Backend.Search works (not vector_unsupported).
+//   - Stats:        Backend.Stats returns real per-(provider,model) rows.
+//   - MemoryLayer:  implements MemoryLayer (the add/recall paradigm).
+type Capabilities struct {
+	KV           bool
+	VectorSearch bool
+	Stats        bool
+	MemoryLayer  bool
+}
+
+// Capable is OPTIONAL. A backend that does NOT implement it is assumed to be
+// a full flat Backend (KV + VectorSearch + Stats, no MemoryLayer) — the
+// zero-config default, so the in-process backend needs no change. A backend
+// that implements MemoryLayer (or that declines part of the flat contract)
+// SHOULD implement Capable so the tool can route + degrade correctly.
+type Capable interface {
+	Capabilities() Capabilities
+}
+
+// CapabilitiesOf returns a backend's advertised capabilities. A backend that
+// implements Capable reports them directly; otherwise the conservative
+// default for a plain Backend is assumed (KV + VectorSearch + Stats, no
+// MemoryLayer) — matching the pre-RFC-K behavior of every existing backend.
+func CapabilitiesOf(b Backend) Capabilities {
+	if c, ok := b.(Capable); ok {
+		return c.Capabilities()
+	}
+	caps := Capabilities{KV: true, VectorSearch: true, Stats: true}
+	// A backend may implement MemoryLayer without bothering with Capable;
+	// detect that too so add/recall route correctly regardless.
+	if _, ok := b.(MemoryLayer); ok {
+		caps.MemoryLayer = true
+	}
+	return caps
+}
+
+// AsMemoryLayer returns the backend as a MemoryLayer when it implements the
+// capability, or (nil, false) when it does not. The tool uses this to route
+// add/recall and to produce the capability_unsupported refusal when false.
+func AsMemoryLayer(b Backend) (MemoryLayer, bool) {
+	ml, ok := b.(MemoryLayer)
+	return ml, ok
+}
+
+// LayerMessage is one conversation turn handed to MemoryLayer.Add.
+type LayerMessage struct {
+	Role    string `json:"role"` // "user" | "assistant" | "system"
+	Content string `json:"content"`
+}
+
+// AddStatus reports whether a MemoryLayer.Add ingestion has completed.
+type AddStatus int
+
+const (
+	// AddPending — the backend accepted the messages but extraction/indexing
+	// is still running (async). EventID, when set, is the correlation handle.
+	AddPending AddStatus = iota
+	// AddDone — the ingestion completed synchronously (or was already
+	// reconciled).
+	AddDone
+)
+
+// String renders the status for tool output.
+func (s AddStatus) String() string {
+	switch s {
+	case AddDone:
+		return "done"
+	default:
+		return "pending"
+	}
+}
+
+// AddOptions carries the write-side knobs for MemoryLayer.Add.
+type AddOptions struct {
+	// Infer requests server-side LLM fact extraction (the layer paradigm).
+	// When false the backend stores messages verbatim with no extraction.
+	// Memory-layer backends default this to true; the tool surfaces it so an
+	// operator can opt into raw storage.
+	Infer bool
+	// Metadata is opaque key/value context attached to the ingestion (e.g.
+	// loomcycle scope/scopeID hints, a source tag). Backends that support
+	// metadata filtering on recall persist it.
+	Metadata map[string]string
+}
+
+// AddResult is the outcome of MemoryLayer.Add.
+type AddResult struct {
+	Status  AddStatus
+	EventID string // poll/correlation handle for async backends (e.g. mem0 event_id)
+}
+
+// RecallQuery is the input to MemoryLayer.Recall.
+type RecallQuery struct {
+	Query     string
+	TopK      int
+	Threshold float64 // 0..1 relevance floor; 0 = backend default
+}
+
+// RecallFact is one extracted fact returned by Recall. ID is server-assigned
+// (a UUID, NOT a caller key) — it is opaque to loomcycle and only meaningful
+// to the backend.
+type RecallFact struct {
+	ID       string            `json:"id"`
+	Memory   string            `json:"memory"`
+	Score    float64           `json:"score"`
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// RecallResult is the ranked output of Recall, trimmed to the query's TopK by
+// the backend.
+type RecallResult struct {
+	Facts []RecallFact
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1631,6 +1631,15 @@ var ErrDimensionMismatch = &MemoryError{Code: "dimension_mismatch", Msg: "memory
 // MemoryError set so callers can switch on a single error family.
 var ErrEmbedderNotConfigured = &MemoryError{Code: "embedder_not_configured", Msg: "memory: no embedder configured — set memory.embedder in operator yaml"}
 
+// ErrCapabilityUnsupported is returned by the Memory tool's `add` / `recall`
+// ops (RFC K) when the agent's resolved memory backend does not implement
+// the MemoryLayer capability — e.g. the default in-process KV+vector backend,
+// which is not an LLM-extract memory layer. Mirrors the vector_unsupported
+// fail-closed posture: the agent sees a clear "this backend isn't a memory
+// layer" message rather than a silent no-op. The Store doesn't raise this —
+// the tool layer does, after probing the backend's Capabilities.
+var ErrCapabilityUnsupported = &MemoryError{Code: "capability_unsupported", Msg: "memory: add/recall require a memory-layer backend (memory_backend with a MemoryLayer-capable kind, e.g. mem9); the default in-process backend is a key/value+vector store, not a memory layer"}
+
 // ErrEmbedderNotImplemented is returned by an embedder driver that
 // is registered but not functionally implemented. v0.9.0–v0.10.1
 // shipped this for the Anthropic stub; v0.10.2 made the Anthropic

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -151,6 +151,25 @@ func (m *Memory) backend(ctx context.Context) memrank.Backend {
 	}
 }
 
+// memoryLayer resolves the MemoryLayer capability for the agent's configured
+// backend (RFC K). It returns (layer, true) when the resolved backend
+// implements the add/recall memory-layer paradigm, or (nil, false) when it
+// does not — e.g. the default in-process KV+vector backend, which is not a
+// memory layer. The caller (execAdd/execRecall) turns false into the typed
+// capability_unsupported refusal.
+//
+// It reuses backend(ctx) so backend selection (the per-agent memory_backend
+// Def, the fallback wrapper, the unknown-name degradation) stays in one
+// place — the memory-layer view is just a capability probe over the same
+// resolved backend. A fallback-wrapped backend is treated as a layer only if
+// the wrapper itself surfaces the capability; today the in-process fallback
+// is not a layer, so a mem9 layer wrapped for fallback degrades to "no layer"
+// rather than silently routing add/recall to in-process KV (which can't
+// honor them) — fail-closed.
+func (m *Memory) memoryLayer(ctx context.Context) (memrank.MemoryLayer, bool) {
+	return memrank.AsMemoryLayer(m.backend(ctx))
+}
+
 // buildMem9 constructs the RFC I MR-4 Mem9 REST backend for a resolved
 // kind=mem9 Def, wraps it in the fallback backend when the Def opts into
 // fallback_on_error=inprocess, and degrades to the operator-default
@@ -179,6 +198,17 @@ func (m *Memory) buildMem9(ctx context.Context, name string, def config.MemoryBa
 
 	// fallback_on_error=inprocess wraps the remote backend so a Mem9
 	// outage degrades to local memory instead of failing the run.
+	//
+	// SCOPE OF FALLBACK (RFC K caveat): fallback applies ONLY to the six KV
+	// ops. The fallback.Backend wrapper does NOT implement MemoryLayer (it
+	// would have to fake add/recall against KV — the lobotomization RFC K
+	// rejects), so a mem9 backend wrapped here will FAIL the
+	// AsMemoryLayer assertion in memoryLayer(): add/recall then return
+	// capability_unsupported even though the underlying mem9 IS a layer.
+	// That is fail-closed-correct — the in-process KV fallback cannot honor
+	// a semantic add/recall, so degrading to it would be wrong. The
+	// trade-off: fallback_on_error and memory-layer add/recall are mutually
+	// exclusive for the same backend.
 	if def.FallbackOnError == "inprocess" {
 		return fallback.New(b, m.defaultBackend(), log.Printf)
 	}
@@ -305,12 +335,13 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 	`Scope is "agent" (this agent's keyspace, shared across users) or "user" (this end-user's keyspace, shared across agents). ` +
 	`Values are JSON. Optional TTL is in seconds. ` +
 	`v0.9.0: pass embed=true with embed_text on set to enable semantic search; use op=search with query to find rows by similarity. ` +
-	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible.`
+	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible. ` +
+	`add / recall (memory-layer backends only): add ingests conversation messages (the backend may LLM-extract durable facts); recall is a natural-language semantic search over those facts. These require a memory-layer backend (memory_backend kind=mem9); against the default key/value store they return capability_unsupported. Unlike set/get, add does not store value-at-key and is often async — do not assume read-after-write.`
 
 const memoryInputSchema = `{
   "type": "object",
   "properties": {
-    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list"], "description": "Which operation to perform."},
+    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall"], "description": "Which operation to perform."},
     "scope":      {"type": "string", "enum": ["agent","user"], "description": "Which keyspace: this agent's (cross-run, cross-user) or this user's (cross-agent)."},
     "key":        {"type": "string", "description": "The entry's key. Required for get / set / delete / incr / merge / append_dedupe / bounded_list."},
     "value":      {"description": "The JSON value. Required for set / merge / append_dedupe / bounded_list. For merge: a JSON object whose fields overlay the existing object. For append_dedupe / bounded_list: the item to append."},
@@ -323,7 +354,11 @@ const memoryInputSchema = `{
     "query":      {"type": "string", "description": "v0.9.0 search-only: the text to embed and use as the similarity query."},
     "top_k":      {"type": "integer", "description": "v0.9.0 search-only: max results (default 10, max 50)."},
     "rank":       {"type": "object", "description": "search-only hybrid ranking weights. Omit for pure semantic (default). Properties: semantic_weight, recency_weight, recency_half_life_hours, source_weight, frequency_weight (source/frequency reserved — contribute 0 today).", "properties": {"semantic_weight": {"type": "number"}, "recency_weight": {"type": "number"}, "recency_half_life_hours": {"type": "number"}, "source_weight": {"type": "number"}, "frequency_weight": {"type": "number"}}},
-    "dedup":      {"type": "object", "description": "search-only near-duplicate collapse. Omit (or enabled=false) for no dedup (default). Drops a result whose embedding cosine similarity to a higher-ranked kept result is >= threshold. Properties: enabled (bool), threshold (number, cosine-similarity floor, default 0.92), mode (\"drop\" default | \"merge\" | \"keep\").", "properties": {"enabled": {"type": "boolean"}, "threshold": {"type": "number"}, "mode": {"type": "string", "enum": ["drop","merge","keep"]}}}
+    "dedup":      {"type": "object", "description": "search-only near-duplicate collapse. Omit (or enabled=false) for no dedup (default). Drops a result whose embedding cosine similarity to a higher-ranked kept result is >= threshold. Properties: enabled (bool), threshold (number, cosine-similarity floor, default 0.92), mode (\"drop\" default | \"merge\" | \"keep\").", "properties": {"enabled": {"type": "boolean"}, "threshold": {"type": "number"}, "mode": {"type": "string", "enum": ["drop","merge","keep"]}}},
+    "messages":   {"type": "array", "description": "add-only (memory-layer backends): conversation turns to ingest. Each item is {role, content}.", "items": {"type": "object", "properties": {"role": {"type": "string", "enum": ["user","assistant","system"]}, "content": {"type": "string"}}, "required": ["role","content"]}},
+    "infer":      {"type": "boolean", "description": "add-only: when true (default) the memory-layer backend LLM-extracts durable facts from the messages; false stores them verbatim."},
+    "metadata":   {"type": "object", "description": "add-only: opaque key/value context attached to the ingestion.", "additionalProperties": {"type": "string"}},
+    "threshold":  {"type": "number", "description": "recall-only: 0..1 relevance floor for returned facts (0 = backend default)."}
   },
   "required": ["op","scope"],
   "additionalProperties": false
@@ -349,6 +384,19 @@ type memoryInput struct {
 	// dedup disabled (today's behavior, zero regression). See
 	// memrank.DedupConfig.
 	Dedup *memrank.DedupConfig `json:"dedup,omitempty"`
+
+	// Messages is the RFC K `add` payload — conversation turns the
+	// memory-layer backend ingests (and optionally LLM-extracts into facts).
+	Messages []memrank.LayerMessage `json:"messages,omitempty"`
+	// Infer controls server-side fact extraction on `add` (RFC K). Pointer
+	// so an omitted value defaults to true (the memory-layer paradigm) while
+	// `false` opts into verbatim storage. Nil = default-true.
+	Infer *bool `json:"infer,omitempty"`
+	// Metadata is opaque context attached to an `add` ingestion (RFC K).
+	Metadata map[string]string `json:"metadata,omitempty"`
+	// Threshold is the 0..1 relevance floor for `recall` (RFC K). 0 = the
+	// backend's default.
+	Threshold float64 `json:"threshold,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -395,10 +443,14 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 		return m.execAppendDedupe(ctx, scope, scopeID, in)
 	case "bounded_list":
 		return m.execBoundedList(ctx, scope, scopeID, in)
+	case "add":
+		return m.execAdd(ctx, scope, scopeID, in)
+	case "recall":
+		return m.execRecall(ctx, scope, scopeID, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall)", in.Op)), nil
 	}
 }
 
@@ -622,6 +674,90 @@ func (m *Memory) execSearch(ctx context.Context, scope store.MemoryScope, scopeI
 		out["rank_note"] = res.RankNote
 	}
 	return okJSON(out)
+}
+
+// execAdd implements the RFC K `add` op: ingest conversation messages into a
+// memory-layer backend (which may LLM-extract durable facts). Refuses with
+// capability_unsupported when the resolved backend is not a memory layer
+// (e.g. the default in-process KV+vector backend) — the same fail-closed
+// posture as the search op's vector_unsupported refusal.
+func (m *Memory) execAdd(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	layer, ok := m.memoryLayer(ctx)
+	if !ok {
+		return errResult(store.ErrCapabilityUnsupported.Msg), nil
+	}
+	if len(in.Messages) == 0 {
+		return errResult("add: missing required field: messages (a non-empty array of {role, content})"), nil
+	}
+	for i, msg := range in.Messages {
+		if msg.Content == "" {
+			return errResult(fmt.Sprintf("add: messages[%d] has empty content", i)), nil
+		}
+	}
+	// infer defaults to true — the memory-layer paradigm is LLM fact
+	// extraction; an operator opts into verbatim storage with infer:false.
+	infer := true
+	if in.Infer != nil {
+		infer = *in.Infer
+	}
+	res, err := layer.Add(ctx, scope, scopeID, in.Messages, memrank.AddOptions{
+		Infer:    infer,
+		Metadata: in.Metadata,
+	})
+	if err != nil {
+		return errResult(fmt.Sprintf("add: %s", err)), nil
+	}
+	out := map[string]any{
+		// status is "pending" (async ingest still extracting) or "done".
+		// A memory-layer add is frequently async, so the agent should NOT
+		// assume read-after-write — recall may not see the facts yet.
+		"status": res.Status.String(),
+	}
+	if res.EventID != "" {
+		out["event_id"] = res.EventID
+	}
+	return okJSON(out)
+}
+
+// execRecall implements the RFC K `recall` op: natural-language semantic
+// search over a memory-layer backend's extracted facts. Refuses with
+// capability_unsupported when the resolved backend is not a memory layer.
+func (m *Memory) execRecall(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	layer, ok := m.memoryLayer(ctx)
+	if !ok {
+		return errResult(store.ErrCapabilityUnsupported.Msg), nil
+	}
+	if in.Query == "" {
+		return errResult("recall: missing required field: query"), nil
+	}
+	topK := in.TopK
+	if topK <= 0 {
+		topK = 10
+	}
+	if topK > 50 {
+		topK = 50
+	}
+	res, err := layer.Recall(ctx, scope, scopeID, memrank.RecallQuery{
+		Query:     in.Query,
+		TopK:      topK,
+		Threshold: in.Threshold,
+	})
+	if err != nil {
+		return errResult(fmt.Sprintf("recall: %s", err)), nil
+	}
+	facts := make([]map[string]any, 0, len(res.Facts))
+	for _, f := range res.Facts {
+		fact := map[string]any{
+			"id":     f.ID, // server-assigned; opaque to loomcycle, NOT a caller key
+			"memory": f.Memory,
+			"score":  f.Score,
+		}
+		if len(f.Metadata) > 0 {
+			fact["metadata"] = f.Metadata
+		}
+		facts = append(facts, fact)
+	}
+	return okJSON(map[string]any{"facts": facts})
 }
 
 func (m *Memory) execDelete(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {

--- a/internal/tools/builtin/memory_layer_test.go
+++ b/internal/tools/builtin/memory_layer_test.go
@@ -1,0 +1,171 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// fakeLayerBackend implements BOTH memrank.Backend (minimally) and
+// memrank.MemoryLayer + memrank.Capable, so the Memory tool routes add/recall
+// to it. Only the layer methods are exercised; the KV methods are stubs that
+// fail loudly if the layer test accidentally hits a KV path.
+type fakeLayerBackend struct {
+	addCalls    []fakeAdd
+	recallQuery memrank.RecallQuery
+	recallOut   []memrank.RecallFact
+}
+
+type fakeAdd struct {
+	scope   store.MemoryScope
+	scopeID string
+	msgs    []memrank.LayerMessage
+	opts    memrank.AddOptions
+}
+
+func (f *fakeLayerBackend) Capabilities() memrank.Capabilities {
+	return memrank.Capabilities{KV: true, VectorSearch: true, Stats: true, MemoryLayer: true}
+}
+
+func (f *fakeLayerBackend) Add(_ context.Context, scope store.MemoryScope, scopeID string, msgs []memrank.LayerMessage, opts memrank.AddOptions) (memrank.AddResult, error) {
+	f.addCalls = append(f.addCalls, fakeAdd{scope, scopeID, msgs, opts})
+	return memrank.AddResult{Status: memrank.AddPending, EventID: "evt-123"}, nil
+}
+
+func (f *fakeLayerBackend) Recall(_ context.Context, _ store.MemoryScope, _ string, q memrank.RecallQuery) (memrank.RecallResult, error) {
+	f.recallQuery = q
+	return memrank.RecallResult{Facts: f.recallOut}, nil
+}
+
+// KV stubs — present so fakeLayerBackend satisfies memrank.Backend; a layer
+// test must never reach these.
+func (f *fakeLayerBackend) Get(context.Context, store.MemoryScope, string, string) (store.MemoryEntry, error) {
+	panic("fakeLayerBackend.Get must not be called in a layer test")
+}
+func (f *fakeLayerBackend) Set(context.Context, store.MemoryScope, string, string, json.RawMessage, memrank.SetOptions) (memrank.SetResult, error) {
+	panic("fakeLayerBackend.Set must not be called in a layer test")
+}
+func (f *fakeLayerBackend) Delete(context.Context, store.MemoryScope, string, string) (bool, error) {
+	panic("fakeLayerBackend.Delete must not be called in a layer test")
+}
+func (f *fakeLayerBackend) List(context.Context, store.MemoryScope, string, string, int) ([]store.MemoryEntry, bool, error) {
+	panic("fakeLayerBackend.List must not be called in a layer test")
+}
+func (f *fakeLayerBackend) Search(context.Context, store.MemoryScope, string, memrank.SearchQuery, memrank.RankConfig, memrank.DedupConfig) (memrank.SearchResult, error) {
+	panic("fakeLayerBackend.Search must not be called in a layer test")
+}
+func (f *fakeLayerBackend) Stats(context.Context, store.MemoryScope) (store.MemoryEmbedStats, error) {
+	panic("fakeLayerBackend.Stats must not be called in a layer test")
+}
+
+// The default in-process backend is NOT a memory layer, so add/recall must
+// refuse with capability_unsupported — the fail-closed posture RFC K
+// mandates (never a panic, never a silent no-op).
+func TestMemoryTool_AddRecall_RefuseOnNonLayerBackend(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t) // default in-process backend
+	defer cleanup()
+
+	for _, in := range []string{
+		`{"op":"add","scope":"user","messages":[{"role":"user","content":"hi"}]}`,
+		`{"op":"recall","scope":"user","query":"anything"}`,
+	} {
+		res, err := tool.Execute(ctx, json.RawMessage(in))
+		if err != nil {
+			t.Fatalf("%s: unexpected go error: %v", in, err)
+		}
+		if !res.IsError {
+			t.Fatalf("%s: expected is_error refusal on a non-layer backend; got %s", in, res.Text)
+		}
+		if res.Text != store.ErrCapabilityUnsupported.Msg {
+			t.Errorf("%s: refusal should be the typed capability_unsupported message %q; got %s", in, store.ErrCapabilityUnsupported.Msg, res.Text)
+		}
+	}
+}
+
+// With a MemoryLayer-capable backend wired, add routes through to it: the
+// messages + infer-default (true) reach the backend and the async pending
+// status + event id surface in the tool result.
+func TestMemoryTool_Add_RoutesToLayerBackend(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	fake := &fakeLayerBackend{}
+	tool.Backend = fake // operator-default backend is the layer
+
+	res, err := tool.Execute(ctx, json.RawMessage(
+		`{"op":"add","scope":"user","messages":[{"role":"user","content":"I prefer dark mode"},{"role":"assistant","content":"noted"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("add is_error: %s", res.Text)
+	}
+	if len(fake.addCalls) != 1 {
+		t.Fatalf("backend.Add called %d times, want 1", len(fake.addCalls))
+	}
+	call := fake.addCalls[0]
+	if len(call.msgs) != 2 || call.msgs[0].Content != "I prefer dark mode" {
+		t.Errorf("messages not threaded through: %+v", call.msgs)
+	}
+	if !call.opts.Infer {
+		t.Error("infer should default to true (the memory-layer paradigm)")
+	}
+	if !strings.Contains(res.Text, `"status":"pending"`) || !strings.Contains(res.Text, "evt-123") {
+		t.Errorf("add result should surface pending status + event id; got %s", res.Text)
+	}
+}
+
+// infer:false opts into verbatim storage — the flag must reach the backend.
+func TestMemoryTool_Add_InferFalseThreadsThrough(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	fake := &fakeLayerBackend{}
+	tool.Backend = fake
+
+	if res, err := tool.Execute(ctx, json.RawMessage(
+		`{"op":"add","scope":"agent","infer":false,"messages":[{"role":"user","content":"raw note"}]}`)); err != nil || res.IsError {
+		t.Fatalf("add infer:false failed: err=%v res=%+v", err, res)
+	}
+	if fake.addCalls[0].opts.Infer {
+		t.Error("infer:false should disable extraction, but Infer was true at the backend")
+	}
+}
+
+// recall threads query + top_k + threshold and renders the returned facts.
+func TestMemoryTool_Recall_RoutesAndRenders(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	fake := &fakeLayerBackend{recallOut: []memrank.RecallFact{
+		{ID: "uuid-1", Memory: "user prefers dark mode", Score: 0.91},
+		{ID: "uuid-2", Memory: "user is in Berlin", Score: 0.77},
+	}}
+	tool.Backend = fake
+
+	res, err := tool.Execute(ctx, json.RawMessage(
+		`{"op":"recall","scope":"user","query":"ui preferences","top_k":5,"threshold":0.5}`))
+	if err != nil || res.IsError {
+		t.Fatalf("recall failed: err=%v res=%+v", err, res)
+	}
+	if fake.recallQuery.Query != "ui preferences" || fake.recallQuery.TopK != 5 || fake.recallQuery.Threshold != 0.5 {
+		t.Errorf("recall query not threaded through: %+v", fake.recallQuery)
+	}
+	if !strings.Contains(res.Text, "uuid-1") || !strings.Contains(res.Text, "user prefers dark mode") {
+		t.Errorf("recall result missing facts: %s", res.Text)
+	}
+}
+
+// add with no messages is a request error (not a capability error) once the
+// backend IS a layer.
+func TestMemoryTool_Add_RejectsEmptyMessages(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+	tool.Backend = &fakeLayerBackend{}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"add","scope":"user","messages":[]}`))
+	if !res.IsError || !strings.Contains(res.Text, "messages") {
+		t.Errorf("empty messages should be refused with a messages error; got %s", res.Text)
+	}
+}


### PR DESCRIPTION
## Why

RFC K (`external-memory-backends.md`) calls for an optional **memory-layer** capability so LLM-extract memory products (Mem9 smart-mode, mem0-style, Zep) integrate as-designed. A memory layer is a *different paradigm* from the flat key/value `Backend`: you hand it conversation messages, the backend itself runs an LLM to extract/reconcile durable facts, and recall is a natural-language semantic search returning those facts — there are no caller keys, identity is server-assigned, and fidelity is not guaranteed. That contract cannot satisfy `Backend`'s faithful get/set round-trip, so the flat `Backend` interface stays **frozen** and the layer is added as new *optional* interfaces only. Every existing backend is untouched and zero-config.

## What

- **ML-1 — capability interface** (`internal/memory/layer.go`): `MemoryLayer` (`Add`/`Recall`), a `Capabilities` struct + optional `Capable` advertiser, and `CapabilitiesOf`/`AsMemoryLayer` probes. A plain `Backend` defaults to `KV+VectorSearch+Stats` (no layer). `store.ErrCapabilityUnsupported` mirrors the existing `vector_unsupported` / `embedder_not_configured` fail-closed errors.
- **ML-2 — Memory tool `add` / `recall` ops** (`internal/tools/builtin/memory.go`): routed through `memoryLayer(ctx)`, which reuses `backend(ctx)` so per-agent `memory_backend` selection, the fallback wrapper, and unknown-name degradation stay in one place. When the resolved backend is not a layer, the ops refuse with `capability_unsupported` — never a silent no-op. `add` defaults `infer=true`, reports `pending`/`done` honestly (often async — no read-after-write), and surfaces an optional `event_id`. `recall` clamps `top_k` (default 10, max 50) and threads a 0..1 `threshold` floor. Both run **after** `resolveScope`, so they inherit the identical tenancy gate (scope forced to the agent name or the run's `user_id`) as every other op.
- **ML-3 — Mem9 implements MemoryLayer** (`internal/memory/backends/mem9/layer.go`): `*Backend` gains `Capabilities`/`Add`/`Recall`, reusing the verified `do()` round-trip and `scopedPrefix`/`scopeKey` tenancy helpers — the **same isolation boundary** as the KV path. The exact JSON field names + paths are an ASSUMED `v1alpha2` contract (the verified parts are auth, size cap, tenancy), each tagged with the existing `// ASSUMED Mem9 wire shape` banner; the `httptest` stub is the contract under test, not real Mem9.
- **Docs**: a new `memory-layer` `Context.help` topic + a "Memory layer: add / recall" section in `docs/MEMORY-BACKENDS.md`, both documenting the one footgun — **`fallback_on_error` and the memory layer are mutually exclusive** (the in-process fallback is a KV store and cannot honor a semantic add/recall, so a fallback-wrapped layer reports `capability_unsupported` — fail-closed by design).

## What was tested

- `internal/tools/builtin` (ML-4): `TestMemoryTool_AddRecall_RefuseOnNonLayerBackend` (both ops refuse `capability_unsupported` on the default in-process backend), `TestMemoryTool_Add_RoutesToLayerBackend`, `TestMemoryTool_Add_InferFalseThreadsThrough`, `TestMemoryTool_Recall_RoutesAndRenders`, `TestMemoryTool_Add_RejectsEmptyMessages`. All pass under `-race`.
- `internal/memory/backends/mem9` (ML-3): smart-vs-raw mode by `infer`, `AddPending`, `X-API-Key` present, recall fact-mapping + TopK trim + threshold filter, tenant-prefixed `session_id` on both ops, **credential never in an error string**, `Capabilities` advertises `MemoryLayer`.
- `internal/help`: loader test extended to cover the new topic.
- Full gate clean: `gofmt -l`, `go build ./...`, `go vet ./...`, `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)