### PR TITLE
docs: announce OSS multi-tenant authorization (RFC L) as the v1.1.0 headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. The feature set is now complete; a hardening + QA pass remains before the v1.0 tag. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. The feature set is complete; a hardening + QA pass remains before the v1.0 tag. **OSS multi-tenant authorization** (per-principal bearer tokens) is the headline of **v1.1.0** — see "Planned" below. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
@@ -152,7 +152,11 @@ make build-all       # UI + binary in one shot; output → ./bin/loomcycle
 
 Per-version detail for all of the above is in [`REVISIONS.md`](REVISIONS.md).
 
-**Planned (v0.16.x → v1.0):** a hardening + QA pass across the v0.14–v0.16 surfaces (webhooks, A2A, pluggable memory + memory layer, the code-js provider), then the **v1.0** tag. Remaining polish: a settings UI, an operator cookbook of postures, and broader distribution (Helm).
+**Planned — v1.0 → v1.1.0:**
+
+- **v1.0 — hardening + QA.** No new primitives: a security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A, webhooks, pluggable memory + the memory layer, the code-js provider), then the **v1.0** tag. Ships with the existing single shared-token auth (`LOOMCYCLE_AUTH_TOKEN`) — right for single-operator and single-trusted-team deployments.
+- **v1.1.0 (headline) — OSS multi-tenant authorization.** Replaces the single shared token with per-principal bearer tokens (token-per-developer/app, scopes, rotation, file audit), each bound to an **authoritative `(tenant, subject)`** resolved *from the token* — so per-subject fairness and per-tenant memory isolation become real (today they key on caller-asserted fields). Zero-disruption: `LOOMCYCLE_AUTH_TOKEN` keeps working; multi-tenancy is available, never required. Enterprise-grade auth (SSO / RBAC / SCIM / signed audit) is a separate edition.
+- **Beyond** (polish): a settings UI, an operator cookbook of postures, broader distribution (Helm).
 
 Full per-version release notes: [`REVISIONS.md`](REVISIONS.md).
 Public roadmap with v0.8.x → v1.0 design details: [`docs/PLAN.md`](docs/PLAN.md).

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,7 +2,29 @@
 
 This is the public roadmap. For decision history, regret notes, and per-version commit-by-commit details, see `~/work/loomcycle-internal/doc-internal/PLAN.md` (operator-side separate repo; migrated out of this tree as part of v0.8.15).
 
-## v0.8.23 — current
+## Where we are
+
+loomcycle has shipped through **v0.16.0** (the memory layer + the synthetic `code-js` provider). Per-version shipped detail now lives in [`REVISIONS.md`](../REVISIONS.md); the historical design-roadmap entries from the v0.8.x series are retained below for context. This section tracks the path forward.
+
+## Planned — v1.0 (hardening) → v1.1.0 (multi-tenant authorization)
+
+**v1.0 — hardening + QA.** No new primitives. A security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A interoperability, input webhooks, pluggable memory + the memory layer, the synthetic code provider), then the v1.0 tag. v1.0 authenticates with the existing single shared `LOOMCYCLE_AUTH_TOKEN` — correct and sufficient for single-operator and single-trusted-team deployments.
+
+**v1.1.0 — OSS multi-tenant authorization (headline).** Replaces the single shared token with a substrate-resident map of bearer tokens, each bound to an **authoritative principal** — a `(tenant, subject, scopes)` resolved *from the token*, not trusted from the request body. What it unlocks:
+
+- **Token-per-principal.** A team or small-VPS service issues a distinct token per developer / app, each minted by loomcycle (CSPRNG, shown once) — callers stop sharing one omnipotent secret.
+- **Authority-derived isolation.** The principal's tenant + subject drive boundaries that already exist — per-subject resource fairness and per-tenant memory isolation become *real* (today they key on caller-asserted fields). The wire `tenant_id` / `user_id` become advisory, overridden by the token.
+- **Scopes.** Narrow tokens (e.g. `runs:create` for an app key) vs admin tokens; default-deny from a documented catalog.
+- **Rotation + audit.** Two-token grace-window rotation; a file-based JSONL audit log of every token create / rotate / retire.
+- **Zero-disruption upgrade.** `LOOMCYCLE_AUTH_TOKEN` keeps working; single-operator deployments need no migration. Multi-tenancy is *available*, never *required*.
+
+Enterprise-grade authorization — SSO (SAML/OIDC), RBAC roles, SCIM provisioning, signed / queryable audit logs, automated rotation policies, compliance evidence — is intentionally **out of scope for OSS** and lives in a separate enterprise edition built on the same token substrate. The OSS edition does enough for a 200-developer team; the enterprise edition does what passes a procurement security review.
+
+**Beyond v1.1.0** (polish, unscheduled): a settings UI, an operator cookbook of deployment postures, broader distribution (Helm).
+
+---
+
+## v0.8.23 — earlier
 
 **Status: shipped (2026-05-20).** **`SkillDef` + `AgentDef` on every wire surface.** PR #163 lifts the v0.8.22 SkillDef substrate (and the previously MCP-only AgentDef substrate) onto HTTP admin endpoints + gRPC RPCs + TS + Python adapter methods. Symmetric exposure across all five transports; same connector dispatch path under each wire.
 


### PR DESCRIPTION
RFC L (OSS multi-tenant authorization) was reopened, refactored against the actual auth/identity/tenancy code, and **redirected from a v1.0 blocker to the v1.1.0 headline**. This PR reflects that in the public docs (docs only — no code).

## Why the RFC was reopened (summary)

Validating the original draft against the code found five load-bearing claims that didn't hold — the same failure mode that unlocked RFC J:
1. "tenant identity already flows through the loop" — **false**: neither `store.RunIdentity` nor `tools.RunIdentityValue` carries a tenant; the wire `tenant_id` is attribution-only.
2. per-tenant fairness "already keys on tenant identity" — **false**: `AcquireForUser` keys on the *caller-provided* `user_id`.
3. token→tenant binding too coarse — 50 devs under one tenant are indistinguishable (no per-subject fairness/attribution/audit).
4. **argon2id on the hot path** is wrong + can't be indexed; the codebase's own `CompareBearer` already uses SHA-256 — the token hash should be peppered SHA-256.
5. the RFC I/K **memory tenancy** interaction was missing (`resolveTenancy` keys `{tenant_id}` on `user_id`).

The refactored RFC fixes the identity threading, the `(tenant, subject)` principal binding, the crypto, and the memory repoint — and moves it **after v1.0** so the trust-boundary rewrite doesn't land inside the stabilization window. (The full refactored RFC lives in the internal doc repo.)

## Docs changed

- **README "Planned"** splits into **v1.0** (hardening + QA; ships with the existing single shared-token auth — correct for single-operator / single-team) and **v1.1.0 (headline)**: per-principal bearer tokens bound to an authoritative `(tenant, subject)` resolved from the token, so per-subject fairness + per-tenant memory isolation become real; zero-disruption (`LOOMCYCLE_AUTH_TOKEN` keeps working); enterprise-grade auth (SSO/RBAC/SCIM/signed audit) is a separate edition. Dev-status banner updated.
- **docs/PLAN.md** gains a top-of-file "Where we are" + "Planned — v1.0 → v1.1.0" roadmap section, and de-stales the old "v0.8.23 — current" marker (shipped per-version detail now lives in `REVISIONS.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)