### PR TITLE
fix(codejs): reject path-traversal agent names (CodeRoot containment) [HIGH]

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. The feature set is now complete; a hardening + QA pass remains before the v1.0 tag. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. The feature set is complete; a hardening + QA pass remains before the v1.0 tag. **OSS multi-tenant authorization** (per-principal bearer tokens) is the headline of **v1.1.0** — see "Planned" below. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
@@ -152,7 +152,11 @@ make build-all       # UI + binary in one shot; output → ./bin/loomcycle
 
 Per-version detail for all of the above is in [`REVISIONS.md`](REVISIONS.md).
 
-**Planned (v0.16.x → v1.0):** a hardening + QA pass across the v0.14–v0.16 surfaces (webhooks, A2A, pluggable memory + memory layer, the code-js provider), then the **v1.0** tag. Remaining polish: a settings UI, an operator cookbook of postures, and broader distribution (Helm).
+**Planned — v1.0 → v1.1.0:**
+
+- **v1.0 — hardening + QA.** No new primitives: a security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A, webhooks, pluggable memory + the memory layer, the code-js provider), then the **v1.0** tag. Ships with the existing single shared-token auth (`LOOMCYCLE_AUTH_TOKEN`) — right for single-operator and single-trusted-team deployments.
+- **v1.1.0 (headline) — OSS multi-tenant authorization.** Replaces the single shared token with per-principal bearer tokens (token-per-developer/app, scopes, rotation, file audit), each bound to an **authoritative `(tenant, subject)`** resolved *from the token* — so per-subject fairness and per-tenant memory isolation become real (today they key on caller-asserted fields). Zero-disruption: `LOOMCYCLE_AUTH_TOKEN` keeps working; multi-tenancy is available, never required. Enterprise-grade auth (SSO / RBAC / SCIM / signed audit) is a separate edition.
+- **Beyond** (polish): a settings UI, an operator cookbook of postures, broader distribution (Helm).
 
 Full per-version release notes: [`REVISIONS.md`](REVISIONS.md).
 Public roadmap with v0.8.x → v1.0 design details: [`docs/PLAN.md`](docs/PLAN.md).

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2,7 +2,29 @@
 
 This is the public roadmap. For decision history, regret notes, and per-version commit-by-commit details, see `~/work/loomcycle-internal/doc-internal/PLAN.md` (operator-side separate repo; migrated out of this tree as part of v0.8.15).
 
-## v0.8.23 — current
+## Where we are
+
+loomcycle has shipped through **v0.16.0** (the memory layer + the synthetic `code-js` provider). Per-version shipped detail now lives in [`REVISIONS.md`](../REVISIONS.md); the historical design-roadmap entries from the v0.8.x series are retained below for context. This section tracks the path forward.
+
+## Planned — v1.0 (hardening) → v1.1.0 (multi-tenant authorization)
+
+**v1.0 — hardening + QA.** No new primitives. A security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A interoperability, input webhooks, pluggable memory + the memory layer, the synthetic code provider), then the v1.0 tag. v1.0 authenticates with the existing single shared `LOOMCYCLE_AUTH_TOKEN` — correct and sufficient for single-operator and single-trusted-team deployments.
+
+**v1.1.0 — OSS multi-tenant authorization (headline).** Replaces the single shared token with a substrate-resident map of bearer tokens, each bound to an **authoritative principal** — a `(tenant, subject, scopes)` resolved *from the token*, not trusted from the request body. What it unlocks:
+
+- **Token-per-principal.** A team or small-VPS service issues a distinct token per developer / app, each minted by loomcycle (CSPRNG, shown once) — callers stop sharing one omnipotent secret.
+- **Authority-derived isolation.** The principal's tenant + subject drive boundaries that already exist — per-subject resource fairness and per-tenant memory isolation become *real* (today they key on caller-asserted fields). The wire `tenant_id` / `user_id` become advisory, overridden by the token.
+- **Scopes.** Narrow tokens (e.g. `runs:create` for an app key) vs admin tokens; default-deny from a documented catalog.
+- **Rotation + audit.** Two-token grace-window rotation; a file-based JSONL audit log of every token create / rotate / retire.
+- **Zero-disruption upgrade.** `LOOMCYCLE_AUTH_TOKEN` keeps working; single-operator deployments need no migration. Multi-tenancy is *available*, never *required*.
+
+Enterprise-grade authorization — SSO (SAML/OIDC), RBAC roles, SCIM provisioning, signed / queryable audit logs, automated rotation policies, compliance evidence — is intentionally **out of scope for OSS** and lives in a separate enterprise edition built on the same token substrate. The OSS edition does enough for a 200-developer team; the enterprise edition does what passes a procurement security review.
+
+**Beyond v1.1.0** (polish, unscheduled): a settings UI, an operator cookbook of deployment postures, broader distribution (Helm).
+
+---
+
+## v0.8.23 — earlier
 
 **Status: shipped (2026-05-20).** **`SkillDef` + `AgentDef` on every wire surface.** PR #163 lifts the v0.8.22 SkillDef substrate (and the previously MCP-only AgentDef substrate) onto HTTP admin endpoints + gRPC RPCs + TS + Python adapter methods. Symmetric exposure across all five transports; same connector dispatch path under each wire.
 

--- a/internal/providers/codejs/compiler.go
+++ b/internal/providers/codejs/compiler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/dop251/goja"
@@ -65,6 +66,16 @@ func (c *compiler) load(name string) (*compiled, error) {
 
 	if name == "" {
 		return nil, fmt.Errorf("code-agent: empty agent name (no RunMeta on ctx?)")
+	}
+	// Host-side containment floor (correct depth — rejects regardless of how
+	// the name reached us). The agent name becomes a path segment under
+	// CodeRoot; without this a name like "../../etc/cron.d/x" would
+	// filepath.Join-collapse out of CodeRoot and read/compile an arbitrary
+	// index.js anywhere on disk. The static .md loader applies the same check
+	// (internal/agents/loader.go:199); the AgentDef substrate create/fork path
+	// also validates the name, but this floor holds even if a caller forgets.
+	if strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return nil, fmt.Errorf("code-agent %q: invalid agent name (must not contain a path separator or be \".\"/\"..\")", name)
 	}
 	path := c.agentFile(name)
 	src, err := os.ReadFile(path)

--- a/internal/providers/codejs/traversal_test.go
+++ b/internal/providers/codejs/traversal_test.go
@@ -1,0 +1,48 @@
+package codejs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCodeJS_Compiler_RejectsPathTraversal pins the host-side containment
+// floor: an agent name must not escape CodeRoot. Regression-grade — a real
+// index.js placed OUTSIDE the root must NOT be compiled via "../evil"; on the
+// unfixed compiler.load (filepath.Join with no containment) it was read +
+// compiled successfully.
+func TestCodeJS_Compiler_RejectsPathTraversal(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "agent_code")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A valid code-agent sitting OUTSIDE CodeRoot, reachable only by traversal.
+	outside := filepath.Join(base, "evil")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outside, "index.js"), []byte("function run(){return {final_text:'pwned'}}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newCompiler(root)
+	if _, err := c.load("../evil"); err == nil {
+		t.Fatal(`load("../evil") compiled an index.js OUTSIDE CodeRoot — containment floor missing`)
+	}
+	for _, bad := range []string{"a/b", `a\b`, "..", ".", "../../etc/hosts"} {
+		if _, err := c.load(bad); err == nil {
+			t.Errorf("load(%q) was not rejected by the containment floor", bad)
+		}
+	}
+	// A plain name still resolves under root (no false positive).
+	if err := os.MkdirAll(filepath.Join(root, "ok"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ok", "index.js"), []byte("function run(){return {}}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.load("ok"); err != nil {
+		t.Errorf("load(%q) for a valid in-root agent failed: %v", "ok", err)
+	}
+}

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/agents"
@@ -14,6 +15,14 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// agentDefNameRe is the AgentDef substrate name floor — the same charset as
+// the HTTP validIdent / RegisterAgent / library_admin checks, so every
+// agent-name entry point is consistent. It matters doubly for code-js: an
+// agent name is also a path segment (agent_code/<name>/index.js), so
+// rejecting "/", "\\", "..", etc. here (plus the compiler.load floor) keeps a
+// substrate-authored name from escaping CodeRoot.
+var agentDefNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
 
 // AgentDef is the v0.8.5 built-in tool that lets agents author, fork,
 // promote, retire, and inspect agent definitions at runtime. Static
@@ -154,6 +163,9 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil
 	}
+	if !agentDefNameRe.MatchString(in.Name) {
+		return errResult(fmt.Sprintf("create: name %q invalid (must match [A-Za-z0-9_-]{1,128})", in.Name)), nil
+	}
 	if err := a.checkScopeForName(policy, in.Name, ""); err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -230,6 +242,9 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
 	if in.Name == "" {
 		return errResult("fork: missing required field: name"), nil
+	}
+	if !agentDefNameRe.MatchString(in.Name) {
+		return errResult(fmt.Sprintf("fork: name %q invalid (must match [A-Za-z0-9_-]{1,128})", in.Name)), nil
 	}
 
 	// Resolve the parent. Three paths:

--- a/internal/tools/builtin/agentdef_name_test.go
+++ b/internal/tools/builtin/agentdef_name_test.go
@@ -1,0 +1,35 @@
+package builtin
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestAgentDefTool_RejectsTraversalName pins the substrate name floor that
+// keeps a code-js agent name (a path segment: agent_code/<name>/index.js)
+// from escaping CodeRoot. Regression-grade — the fixture grants scope ["any"]
+// so on the unfixed create/fork (no character validation) these names were
+// accepted and persisted.
+func TestAgentDefTool_RejectsTraversalName(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	bad := []string{"../x", "../../etc/cron.d/x", "a/b", `a\b`, "..", ".", "has space", "name!"}
+	for _, n := range bad {
+		body, _ := json.Marshal(map[string]any{"op": "create", "name": n, "overlay": map[string]any{"provider": "code-js"}})
+		res, _ := tool.Execute(ctx, json.RawMessage(body))
+		if !res.IsError {
+			t.Errorf("create name=%q was accepted; want a name-validation refusal", n)
+		}
+		bodyF, _ := json.Marshal(map[string]any{"op": "fork", "name": n, "overlay": map[string]any{}})
+		resF, _ := tool.Execute(ctx, json.RawMessage(bodyF))
+		if !resF.IsError {
+			t.Errorf("fork name=%q was accepted; want a name-validation refusal", n)
+		}
+	}
+	// A valid name is still accepted (no false positive).
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"good_agent-1","overlay":{"provider":"openai","system_prompt":"x"}}`))
+	if res.IsError {
+		t.Errorf("create with a valid name was wrongly refused: %s", res.Text)
+	}
+}


### PR DESCRIPTION
## Why (HIGH — found in the pre-v1.0 QA pass)

`code-js` resolves an agent's JS as `filepath.Join(CodeRoot, name, "index.js")` (`compiler.go`) with **no containment check**, and the **AgentDef substrate `create`/`fork` applied zero character validation** to the name (only emptiness, scope, static-collision). The static `.md` loader (`loader.go:199`), `RegisterAgent`, and `library_admin` all treat an agent name as a path/identifier trust boundary — but the two paths feeding code-js did not.

**Impact:** an agent granted `agent_def_scopes` (intended only to author code-agents *under* CodeRoot) can `create`+`promote` a def named `"../../../../tmp/evil"` with `provider: code-js`, and `compiler.load` will read + `goja.Compile` + execute an arbitrary `index.js` anywhere on disk — defeating the "only vetted code under CodeRoot runs" invariant, and leaking the resolved absolute host path in the not-found error. The goja sandbox still caps what that JS can *do* (no fs/net), so this is a **containment/info-disclosure escape, not native RCE** — but it's a real cross-boundary escape in a code-execution provider. Verified by running a failing test (a real `index.js` outside CodeRoot compiled via `../evil`).

## What

Two-layer fix (right depth, not a bandaid):
- **`compiler.load`** gains a host-side containment floor — reject a name containing a path separator or equal to `"."`/`".."` — that holds regardless of caller, mirroring `loader.go:199`.
- **AgentDef `execCreate` + `execFork`** validate the name against `[A-Za-z0-9_-]{1,128}` (`agentDefNameRe`), matching `validIdent`/`RegisterAgent`/`library_admin` so the substrate boundary is consistent.

## Tests (regression-grade)

- `TestCodeJS_Compiler_RejectsPathTraversal` — a real `index.js` placed *outside* CodeRoot is **not** compiled via `../evil`; separator/`..` names rejected; a valid in-root name still resolves. Verified failing on the unfixed `compiler.load`.
- `TestAgentDefTool_RejectsTraversalName` — `create`/`fork` refuse traversal names (fixture grants `["any"]` scope, so they'd otherwise be accepted); a valid name still accepted. Verified failing on the unfixed create/fork.
- `go build/vet/test ./...` clean; `-race` clean on touched packages; `gofmt` clean.

Part of the pre-v1.0 hardening pass (QA report to follow). One of two HIGH code-js findings; the cross-process replay-determinism HIGH is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)