### PR TITLE
fix(code-js): detect replayed tool-input divergence on resume

### DIFF
--- a/internal/help/builtin/code-agents.md
+++ b/internal/help/builtin/code-agents.md
@@ -138,17 +138,30 @@ latency, no hallucination. Within a run, code-js is deterministic **by
 construction** — a code-agent runs as a *replay* over its recorded tool
 results, so the ambient clock and RNG are hooked: `Math.random()` is seeded
 per run, and `Date.now()` / `new Date()` are anchored to the run's start plus
-a per-call offset. Every re-execution of a run therefore reproduces the same
-values — which is exactly what makes a run **resumable** (below). Different
-runs still see real-anchored time and fresh entropy, so production behaviour
-is unsurprising.
+a per-call offset. Re-executing a run **in the same process** therefore
+reproduces the same values — which is what makes a run **resumable** (below).
+Different runs still see real-anchored time and fresh entropy, so production
+behaviour is unsurprising.
+
+**Cross-process resume caveat.** The default per-run seed is derived from the
+run's identity and the anchor from its start time. A resume in a *different*
+process (restart, replica handoff) re-derives both from the continuation's own
+identity/start, so a code-agent that feeds `Math.random()` / `Date.now()` into
+a **tool input** (e.g. a key or idempotency token) would compute a different
+input on resume. That no longer corrupts silently: the replay divergence guard
+compares each replayed call's input against the recorded one and fails loud
+with `code_agent_replay_divergence` rather than feeding a stale result into the
+JS. For code-agents that must resume deterministically across processes, set
+`LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1` (it pins the seed + anchor to fixed
+constants for **all** runs, so the continuation re-derives identical values),
+or keep clock/RNG values out of tool inputs (read a real per-call value from a
+tool — it is recorded — rather than from `Date.now()`).
 
 This is reproducible *replay*, not "the world stopped": tool / MCP results are
 recorded and replayed identically, but the upstream service that produced them
 is still whatever it is. `LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1` additionally
 freezes the clock + seed across **all** runs — cross-run reproducibility for
-tests and snapshot equality. If you need a true per-call wall-clock value, read
-it from a tool (it is recorded), not from `Date.now()`.
+tests and snapshot equality.
 
 ## Sharp edges
 
@@ -163,7 +176,10 @@ it from a tool (it is recorded), not from `Date.now()`.
   *replays* the tool results recorded in the run transcript, dispatching only
   the next, not-yet-recorded call. So a run interrupted mid-flight (process
   restart, replica handoff) resumes correctly from the transcript — there is
-  no parked continuation to lose. The cost is that the pure-JS portion
+  no parked continuation to lose. (One caveat for cross-*process* resume: a
+  code-agent that derives a tool input from `Math.random()`/`Date.now()` needs
+  `LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1` to re-derive identical inputs — see
+  **Determinism** above.) The cost is that the pure-JS portion
   re-executes each turn (≈O(N²) for N sequential tool calls), which is fine
   for the glue-logic design center; heavy compute belongs in an MCP server.
   (This is why determinism is always-on above — replay must reproduce the

--- a/internal/providers/codejs/codejs_test.go
+++ b/internal/providers/codejs/codejs_test.go
@@ -367,6 +367,47 @@ func TestCodeJS_ReplayDivergence_FailsLoud(t *testing.T) {
 	}
 }
 
+// Input-level divergence: the recorded call has the SAME tool name at the same
+// index but a DIFFERENT input than the replayed call produces (e.g. a key
+// derived from a clock/RNG value that shifted on a cross-process resume). A
+// name-only guard would silently fast-forward the stale recorded result into
+// the JS; the canonical-input check makes it fail loud instead. The JS here
+// deterministically calls Memory.get({key:"a",...}); the transcript records a
+// Memory call with key:"b" — names match, inputs differ.
+func TestCodeJS_ReplayInputDivergence_FailsLoud(t *testing.T) {
+	root := writeAgent(t, "idiv", `function run(){ var v = Memory.get({key:"a", scope:"user"}); return {final_text: String(v)}; }`)
+	p := newTestProvider(root)
+	ctx := providers.WithRunMeta(context.Background(), providers.RunMeta{AgentName: "idiv"})
+	req := providers.Request{
+		Tools: []providers.ToolSpec{{Name: "Memory"}},
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "go"}}},
+			// Recorded Memory call with a DIFFERENT key than the JS produces.
+			{Role: "assistant", Content: []providers.ContentBlock{{Type: "tool_use", ToolUseID: "cj-1-0", ToolName: "Memory", ToolInput: json.RawMessage(`{"op":"get","scope":"user","key":"b"}`)}}},
+			{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", ToolUseID: "cj-1-0", Text: "stale-value"}}},
+		},
+	}
+	ch, err := p.Call(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var gotErr, finalText string
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventError:
+			gotErr = ev.Error
+		case providers.EventText:
+			finalText += ev.Text
+		}
+	}
+	if !strings.Contains(gotErr, "code_agent_replay_divergence") {
+		t.Errorf("want code_agent_replay_divergence on input mismatch, got err=%q finalText=%q", gotErr, finalText)
+	}
+	if strings.Contains(finalText, "stale-value") {
+		t.Errorf("stale recorded result leaked into the JS: finalText=%q", finalText)
+	}
+}
+
 // Concurrent runs each build their own goja Runtime per Call — no shared
 // Runtime/Value. The race detector guards the no-shared-state invariant.
 func TestCodeJS_ConcurrentRuns_Isolated(t *testing.T) {

--- a/internal/providers/codejs/replay.go
+++ b/internal/providers/codejs/replay.go
@@ -65,14 +65,26 @@ func (s *replayState) emit(name string, input json.RawMessage) (string, bool, er
 	if idx < len(s.recorded) {
 		rec := s.recorded[idx]
 		// Divergence guard: ambient determinism (sandbox.go) keeps the
-		// replayed call sequence identical to the recorded one. A name
-		// mismatch means control flow changed (an unhooked non-determinism
-		// source, or allowed_tools changed mid-run) — abort rather than feed
-		// the wrong result into the JS. (Input-level divergence detection is a
-		// possible hardening; name match is the high-value check and avoids
-		// JSON-canonicalization false positives.)
+		// replayed call sequence identical to the recorded one. A mismatch
+		// means control flow changed (an unhooked non-determinism source, an
+		// anchor/seed shift on a cross-process resume, or allowed_tools
+		// changed mid-run) — abort rather than feed the wrong result into the
+		// JS. We check BOTH the tool name AND the input: a same-name call with
+		// different ARGS (e.g. a key derived from the clock/RNG that shifted on
+		// resume) would otherwise pass a name-only guard and silently consume
+		// a stale result. Inputs are compared canonically (key-order-
+		// independent) to avoid false positives from JSON re-encoding.
 		if rec.name != name {
 			s.diverged = &replayDivergence{idx: idx, expected: rec.name, got: name}
+			s.rt.Interrupt(s.diverged)
+			return "", false, nil
+		}
+		if !sameCanonicalJSON(rec.input, input) {
+			s.diverged = &replayDivergence{
+				idx:      idx,
+				expected: rec.name + " " + truncForErr(canonicalJSON(rec.input)),
+				got:      name + " " + truncForErr(canonicalJSON(input)),
+			}
 			s.rt.Interrupt(s.diverged)
 			return "", false, nil
 		}
@@ -84,6 +96,40 @@ func (s *replayState) emit(name string, input json.RawMessage) (string, bool, er
 	s.frontier = &frontierStop{idx: idx, name: name, input: append(json.RawMessage(nil), input...)}
 	s.rt.Interrupt(s.frontier)
 	return "", false, nil
+}
+
+// canonicalJSON renders raw key-order-independently (unmarshal then
+// re-marshal — encoding/json sorts object keys), falling back to the raw
+// string when it does not parse (so two byte-identical-but-unparseable inputs
+// still compare equal). Used by the divergence guard to compare a replayed
+// tool input against the recorded one without false positives from key
+// reordering or whitespace.
+func canonicalJSON(raw json.RawMessage) string {
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return string(raw)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return string(raw)
+	}
+	return string(b)
+}
+
+// sameCanonicalJSON reports whether two tool inputs are equal ignoring object
+// key order / whitespace.
+func sameCanonicalJSON(a, b json.RawMessage) bool {
+	return canonicalJSON(a) == canonicalJSON(b)
+}
+
+// truncForErr bounds a canonical-input snippet embedded in a divergence error
+// so a large argument cannot blow up the message.
+func truncForErr(s string) string {
+	const max = 120
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
 }
 
 // extractRecorded recovers, in order, the tool calls already dispatched in


### PR DESCRIPTION
## Why

The RFC J replay engine's divergence guard (`replay.go` `emit()`) compared only the tool **name** at each replay index — not the input. A code-agent that feeds `Math.random()`/`Date.now()` into a tool input (a key, an idempotency token) computes a **different input** when resumed in a different process: the per-run RNG seed is keyed on the run identity and the clock anchor on the run's `StartedAt`, both of which shift across a restart / replica handoff (the continuation endpoint `POST /v1/sessions/{id}/messages` mints a fresh agent id and a fresh `started_at`).

With a name-only guard, that same-name/different-input call **silently fast-forwarded the stale recorded result into the JS** — silent state corruption on resume. Found during the v0.16.0 pre-v1.0 QA review (RFC J surface). Severity: HIGH (data integrity).

## What

`emit()` now also compares the replayed input against the recorded input, **canonically** (`encoding/json` key-order/whitespace-independent) to avoid false positives from re-encoding. A mismatch raises the existing `code_agent_replay_divergence` loud-failure path instead of feeding a stale result into the JS.

This closes the **data-integrity danger** outright. Making cross-process resume *succeed* (rather than fail loud) for clock/RNG-derived inputs stays the operator's choice via `LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1`, which pins seed+anchor to fixed constants so a continuation re-derives identical values. The `code-agents` help doc now documents this caveat honestly (it previously over-promised "resumes correctly" unconditionally) and points at the flag. A general **session-scoped** stable seed/anchor — so the unpinned default also resumes deterministically — is tracked as follow-up robustness work, with this guard as its safety net.

## Tested

- **New regression** `TestCodeJS_ReplayInputDivergence_FailsLoud`: records a `Memory` call with `key:"b"` while the JS deterministically calls `Memory.get({key:"a"})` — names match, inputs differ. **Fails-before** (neutralizing the new check leaks `finalText="stale-value"` — the exact silent-corruption bug), **passes-after**.
- `go test ./internal/providers/codejs/ ./internal/loop/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)