### PR TITLE
feat(code-js): name max_iterations as the sequential-call ceiling

### DIFF
--- a/internal/help/builtin/code-agents.md
+++ b/internal/help/builtin/code-agents.md
@@ -169,6 +169,13 @@ it from a tool (it is recorded), not from `Date.now()`.
   (This is why determinism is always-on above — replay must reproduce the
   same call sequence; a non-deterministic divergence fails loud as
   `code_agent_replay_divergence`.)
+- **MaxIterations is a hard sequential-tool-call ceiling.** Each loop turn
+  advances a code-agent's replay by exactly one tool call, so the run's
+  `MaxIterations` caps how many sequential tool calls `run()` may make — it is
+  not a soft "model chatter" cap as it is for an LLM agent. A code-agent that
+  needs more sequential calls than the cap ends with `stop_reason:
+  max_iterations` (and an operator log line naming the agent + cap). Raise
+  `MaxIterations` for that run, or fan out concurrent work via `Agent.spawn`.
 - **Run timeout bounds wall time.** A CPU-bound JS loop is cut by goja
   `Interrupt` at the per-turn timeout; the overall run deadline rides the
   loop's ctx. Set `LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS`. The heap limit

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -956,6 +956,15 @@ outerLoop:
 	// surface a different error to the user.
 	if stopReason == "tool_use" {
 		stopReason = "max_iterations"
+		// For a code-js agent, MaxIterations is a HARD ceiling on the number
+		// of SEQUENTIAL tool calls run() may make (each loop turn advances the
+		// replay by exactly one frontier call), not a soft cap on model
+		// chatter. Hitting it means run() did not return — it wanted call
+		// #(MaxIterations+1). The opaque "max_iterations" reason hides that, so
+		// name it in the operator log with the actionable lever.
+		if opts.Provider != nil && opts.Provider.ID() == "code-js" {
+			log.Printf("code-js agent %q hit MaxIterations=%d: run() requested more sequential tool calls than the cap (each turn = one call). Raise the run's MaxIterations or restructure the agent to fan out via Agent.spawn.", opts.AgentName, opts.MaxIterations)
+		}
 	}
 
 	emit(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: &totalUsage})


### PR DESCRIPTION
## Why

For a code-js agent, each loop turn advances the replay by exactly **one** tool call — so `MaxIterations` is a **hard ceiling on the number of sequential tool calls** `run()` may make, not a soft "model chatter" cap as it is for an LLM agent. When `run()` wants more calls than the cap, the run ends with the opaque `stop_reason: max_iterations` and nothing tells the operator that, for a code-agent, this specifically means "raise `MaxIterations` or fan out." Found during the v0.16.0 QA review (RFC J `MaxIterations` seam). The behaviour is correct — only its legibility was poor.

## What

- When a run whose provider is `code-js` exits via the `max_iterations` rewrite, log an operator line naming the agent, the cap, and the lever (raise `MaxIterations` / fan out via `Agent.spawn`).
- Document the ceiling in the `code-agents` help doc's sharp-edges list.

No wire change, no behaviour change (the `max_iterations` path is unchanged and already covered by loop tests) — this is a diagnostic + doc improvement.

## Tested

`go build ./...` + `go vet ./internal/loop/` green; existing loop tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)