### PR TITLE
fix(code-js): bind all meta-tool ops, not a hardcoded subset

### DIFF
--- a/internal/help/builtin/code-agents.md
+++ b/internal/help/builtin/code-agents.md
@@ -85,8 +85,8 @@ tool, built-in or MCP, is callable. A tool you didn't allow is not a
 
 | JS | Tool | Notes |
 |---|---|---|
-| `Memory.get/set/delete/search(obj)` | Memory | multi-op meta-tool; obj is the input minus `op` |
-| `Channel.publish/subscribe(obj)` | Channel | multi-op meta-tool; subscribe is a non-blocking peek |
+| `Memory.<op>(obj)` | Memory | multi-op meta-tool; `<op>` is any Memory op (get/set/delete/list/incr/search/merge/append_dedupe/bounded_list/add/recall); obj is the input minus `op` |
+| `Channel.<op>(obj)` | Channel | multi-op meta-tool; `<op>` is any Channel op (publish/subscribe/ack/peek/list_channels); subscribe is a non-blocking peek |
 | `Agent.spawn(obj)` | Agent | spawn an LLM (or code) sub-agent; returns its result |
 | `WebFetch(obj)` / `Read(obj)` / `HTTP(obj)` / `WebSearch(obj)` / … | the built-in of that name | every other allowed **built-in**, flat by canonical name |
 | `mcp__<server>__<tool>(obj)` | that MCP tool | every allowed MCP tool, flat by name |

--- a/internal/providers/codejs/bindings.go
+++ b/internal/providers/codejs/bindings.go
@@ -49,18 +49,18 @@ func buildBindFunc(toolNames []string) bindFunc {
 	return func(rt *goja.Runtime, emit toolEmitter) {
 		for _, name := range toolNames {
 			switch name {
-			case "Memory":
-				mem := rt.NewObject()
-				for _, op := range []string{"get", "set", "delete", "search"} {
-					_ = mem.Set(op, opCallable(rt, emit, "Memory", op))
-				}
-				_ = rt.Set(name, mem) // JS: Memory.get(...) etc.
-			case "Channel":
-				ch := rt.NewObject()
-				for _, op := range []string{"publish", "subscribe"} {
-					_ = ch.Set(op, opCallable(rt, emit, "Channel", op))
-				}
-				_ = rt.Set(name, ch) // JS: Channel.publish(...) etc.
+			case "Memory", "Channel":
+				// Multi-op meta-tools bind as a DynamicObject: ANY method access
+				// (Memory.recall, Channel.ack, …) forwards as {op:"<method>",
+				// ...obj}. Generic passthrough — NOT a hardcoded op subset — so
+				// the JS surface never lags the tool's real op set (an op added
+				// to the Memory/Channel tool is reachable from code-js with no
+				// binding change). The tool's own dispatch remains the single
+				// validator: an unknown op returns its "unknown op" error, which
+				// surfaces as a catchable JS throw. (An earlier hardcoded subset
+				// silently hid Memory.incr/list/merge/append_dedupe/bounded_list/
+				// add/recall and Channel.peek/list_channels from code-agents.)
+				_ = rt.Set(name, rt.NewDynamicObject(&metaTool{rt: rt, emit: emit, toolName: name}))
 			case "Agent":
 				ag := rt.NewObject()
 				// Agent.spawn maps to the Agent tool's default invocation; the
@@ -79,6 +79,39 @@ func buildBindFunc(toolNames []string) bindFunc {
 		}
 	}
 }
+
+// metaReservedProps are the property names a meta-tool DynamicObject must NOT
+// shadow with an op callable. Returning a function for these would hijack the
+// JS engine's ordinary semantics — String(Memory) calling toString, thenable
+// probing reading .then, prototype walks reading constructor — and turn them
+// into bogus tool dispatches (op:"toString", …). For these keys Get returns
+// nil so goja falls through to Object.prototype (symbols never reach Get).
+var metaReservedProps = map[string]bool{
+	"constructor": true, "hasOwnProperty": true, "isPrototypeOf": true,
+	"propertyIsEnumerable": true, "toLocaleString": true, "toString": true,
+	"valueOf": true, "then": true, "catch": true, "finally": true,
+}
+
+// metaTool is the goja DynamicObject backing a multi-op meta-tool (Memory,
+// Channel). Property access for any non-reserved key returns an opCallable for
+// that op name — so Memory.<anyOp>(obj) dispatches {op:"<anyOp>", ...obj}
+// without the binding enumerating the op set (the tool's dispatch validates).
+type metaTool struct {
+	rt       *goja.Runtime
+	emit     toolEmitter
+	toolName string
+}
+
+func (m *metaTool) Get(key string) goja.Value {
+	if key == "" || metaReservedProps[key] {
+		return nil // undefined → goja falls through to Object.prototype
+	}
+	return m.rt.ToValue(opCallable(m.rt, m.emit, m.toolName, key))
+}
+func (m *metaTool) Set(string, goja.Value) bool { return false } // read-only surface
+func (m *metaTool) Has(key string) bool         { return key != "" && !metaReservedProps[key] }
+func (m *metaTool) Delete(string) bool          { return false }
+func (m *metaTool) Keys() []string              { return nil } // ops are open-ended; no enumeration
 
 // opCallable builds a JS function that injects {"op": op} into its object
 // argument and dispatches it to toolName. Used for the multi-op meta-tools

--- a/internal/providers/codejs/codejs_test.go
+++ b/internal/providers/codejs/codejs_test.go
@@ -367,6 +367,99 @@ func TestCodeJS_ReplayDivergence_FailsLoud(t *testing.T) {
 	}
 }
 
+// memoryOpsMirror / channelOpsMirror MUST mirror the op switch in
+// internal/tools/builtin/{memory,channel}.go. If you add an op to either tool,
+// add it here — the drift test below then proves it is reachable from code-js
+// (generic passthrough makes it reachable automatically; this list is the
+// canary that catches a regression to a hardcoded subset OR an op whose name
+// collides with a reserved JS property).
+var memoryOpsMirror = []string{"get", "set", "delete", "list", "incr", "search", "merge", "append_dedupe", "bounded_list", "add", "recall"}
+var channelOpsMirror = []string{"publish", "subscribe", "ack", "peek", "list_channels"}
+
+// Meta-tool op drift: every op the Memory/Channel tools accept must be
+// reachable from code-js as Memory.<op>(...) / Channel.<op>(...), and none may
+// collide with a reserved JS property name (which the generic binding skips).
+// A hardcoded op subset (the pre-fix bug) silently hid incr/list/merge/
+// append_dedupe/bounded_list/add/recall and peek/list_channels — this test
+// fails on that regression. The agent calls Memory[op]({}) so one program
+// exercises every op by varying the prompt.
+func TestCodeJS_MetaToolOpPassthrough_NoDrift(t *testing.T) {
+	cases := []struct {
+		tool string
+		ops  []string
+	}{{"Memory", memoryOpsMirror}, {"Channel", channelOpsMirror}}
+	for _, c := range cases {
+		// Guard: a real op must not share a name with a reserved JS prop, else
+		// the generic binding would route it to Object.prototype, not the tool.
+		for _, op := range c.ops {
+			if metaReservedProps[op] {
+				t.Errorf("%s op %q collides with a reserved JS property — unreachable from code-js; rename the op or special-case it", c.tool, op)
+			}
+		}
+		js := `function run(input){ var r = ` + c.tool + `[input.prompt]({}); return {final_text: JSON.stringify(r)}; }`
+		root := writeAgent(t, "drift", js)
+		p := newTestProvider(root)
+		for _, op := range c.ops {
+			var gotOp string
+			res := drive(t, context.Background(), p, "drift", op, []providers.ToolSpec{{Name: c.tool}},
+				func(name string, input json.RawMessage) (string, bool) {
+					var m map[string]interface{}
+					_ = json.Unmarshal(input, &m)
+					if s, ok := m["op"].(string); ok {
+						gotOp = s
+					}
+					return `{"ok":true}`, false
+				})
+			if res.errText != "" {
+				t.Errorf("%s.%s errored (unreachable?): %s", c.tool, op, res.errText)
+				continue
+			}
+			if gotOp != op {
+				t.Errorf("%s.%s dispatched op=%q, want %q (binding dropped or rewrote the op)", c.tool, op, gotOp, op)
+			}
+		}
+	}
+}
+
+// Generic, not enumerated: an op name the binding has never heard of still
+// forwards (the tool's dispatch is the validator, not the binding). This locks
+// the no-hardcoded-subset property so a future edit can't silently re-cage it.
+func TestCodeJS_MetaToolOpPassthrough_IsGeneric(t *testing.T) {
+	root := writeAgent(t, "gen", `function run(){ Memory.totally_new_op_xyz({k:1}); return {final_text:"ok"}; }`)
+	p := newTestProvider(root)
+	var gotOp string
+	res := drive(t, context.Background(), p, "gen", "go", []providers.ToolSpec{{Name: "Memory"}},
+		func(name string, input json.RawMessage) (string, bool) {
+			var m map[string]interface{}
+			_ = json.Unmarshal(input, &m)
+			gotOp, _ = m["op"].(string)
+			return `{}`, false
+		})
+	if res.errText != "" {
+		t.Fatalf("generic op should forward, got error: %s", res.errText)
+	}
+	if gotOp != "totally_new_op_xyz" {
+		t.Errorf("arbitrary op did not forward generically: got op=%q", gotOp)
+	}
+}
+
+// Reserved JS property names must NOT be hijacked into tool dispatches:
+// String(Memory) (which reads .toString) must use Object.prototype, not emit a
+// bogus op:"toString" call. Guards the metaReservedProps fall-through.
+func TestCodeJS_MetaTool_ReservedPropsNotDispatched(t *testing.T) {
+	root := writeAgent(t, "rsv", `function run(){ return {final_text: (typeof Memory.toString) + "|" + String(Memory).slice(0,8)}; }`)
+	p := newTestProvider(root)
+	called := false
+	res := drive(t, context.Background(), p, "rsv", "go", []providers.ToolSpec{{Name: "Memory"}},
+		func(string, json.RawMessage) (string, bool) { called = true; return `{}`, false })
+	if called {
+		t.Error("reading Memory.toString dispatched a tool call — reserved prop leaked into emit")
+	}
+	if res.errText != "" || !strings.HasPrefix(res.finalText, "function|") {
+		t.Errorf("Memory.toString should be the prototype function; got final=%q err=%q", res.finalText, res.errText)
+	}
+}
+
 // Concurrent runs each build their own goja Runtime per Call — no shared
 // Runtime/Value. The race detector guards the no-shared-state invariant.
 func TestCodeJS_ConcurrentRuns_Isolated(t *testing.T) {


### PR DESCRIPTION
## Why

The code-js binding registered `Memory` and `Channel` as plain objects with a **hardcoded** method list — `Memory` got `get/set/delete/search`, `Channel` got `publish/subscribe`. But the Memory tool accepts **11** ops and Channel **5**, so:

- **7 Memory ops unreachable**: `list, incr, merge, append_dedupe, bounded_list, add, recall`
- **3 Channel ops unreachable**: `ack, peek, list_channels`

`Memory.recall(...)` from a code-agent threw `Object has no member 'recall'`. RFC K's entire MemoryLayer `add`/`recall` surface and the dedup helpers were invisible to the very provider meant to drive them deterministically. Found during the v0.16.0 QA review (RFC J × RFC K seam).

## What

`Memory` and `Channel` now bind as a goja `DynamicObject` (`metaTool`) that forwards **any** method access as `{op:"<method>", ...obj}` — **generic passthrough, not enumeration**. The tool's own dispatch stays the single op validator (an unknown op returns its `unknown op` error → catchable JS throw), so an op added to the tool is reachable from code-js with **zero binding change**. A `metaReservedProps` denylist keeps JS-internal names (`toString`/`valueOf`/`then`/`constructor`/…) falling through to `Object.prototype` instead of being hijacked into bogus op dispatches (goja's dynamic object falls through to the prototype when `Get` returns nil; symbols never reach `Get`). Help-doc tool table updated to `<op>`.

## Tested

- **`TestCodeJS_MetaToolOpPassthrough_NoDrift`** — every Memory/Channel op (mirrored from the tool dispatch switch) is reachable and dispatches its own op. **Fails-before** on the simulated old subset (the 7+3 hidden ops error `Object has no member`), **passes-after**.
- **`TestCodeJS_MetaToolOpPassthrough_IsGeneric`** — an unknown op forwards, locking the no-hardcoded-subset property against regression.
- **`TestCodeJS_MetaTool_ReservedPropsNotDispatched`** — `String(Memory)` uses `Object.prototype.toString` and emits no tool call.
- `go test ./internal/providers/codejs/ -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)