### PR TITLE
feat(code-js): emit provider.call span with provider.code_hash

### DIFF
--- a/internal/otel/recorder.go
+++ b/internal/otel/recorder.go
@@ -39,7 +39,15 @@ const (
 	AttrParentAgentID   = "loomcycle.parent_agent_id"
 	AttrIteration       = "loomcycle.iteration"
 	AttrProvider        = "loomcycle.provider"
-	AttrModel           = "loomcycle.model"
+	// AttrProviderKind distinguishes a synthetic provider (no model HTTP
+	// request) from a real LLM driver — set to "synthetic-code" for the
+	// code-js provider so operators can filter/aggregate code-agent runs.
+	AttrProviderKind = "loomcycle.provider.kind"
+	// AttrProviderCodeHash is the sha256 of a code-agent's index.js source
+	// (RFC J Decision 9). It answers "which code version produced this run"
+	// without versioning the JS files separately. Empty for real providers.
+	AttrProviderCodeHash = "loomcycle.provider.code_hash"
+	AttrModel            = "loomcycle.model"
 	AttrTier            = "loomcycle.tier"
 	AttrEffort          = "loomcycle.effort"
 	AttrTool            = "loomcycle.tool"
@@ -107,10 +115,12 @@ func RecordIteration(ctx context.Context, iter int) (context.Context, trace.Span
 
 // ProviderCallAttrs identifies a provider HTTP request.
 type ProviderCallAttrs struct {
-	Provider string // "anthropic" | "openai" | "deepseek" | "gemini" | "ollama" | "ollama-local"
+	Provider string // "anthropic" | "openai" | "deepseek" | "gemini" | "ollama" | "ollama-local" | "code-js"
 	Model    string
 	Tier     string // optional — set when the agent's resolution went through a tier
 	Effort   string // optional — set when the agent declared an effort hint
+	Kind     string // optional — "synthetic-code" for code-js; empty for real LLM drivers
+	CodeHash string // optional — sha256 of the code-agent's index.js (code-js only)
 }
 
 // RecordProviderCall opens loomcycle.provider.call for a single HTTP
@@ -129,6 +139,12 @@ func RecordProviderCall(ctx context.Context, attrs ProviderCallAttrs) (context.C
 	}
 	if attrs.Effort != "" {
 		kvs = append(kvs, attribute.String(AttrEffort, attrs.Effort))
+	}
+	if attrs.Kind != "" {
+		kvs = append(kvs, attribute.String(AttrProviderKind, attrs.Kind))
+	}
+	if attrs.CodeHash != "" {
+		kvs = append(kvs, attribute.String(AttrProviderCodeHash, attrs.CodeHash))
 	}
 	return Tracer().Start(ctx, SpanProviderCall, trace.WithAttributes(kvs...))
 }

--- a/internal/providers/codejs/codejs_test.go
+++ b/internal/providers/codejs/codejs_test.go
@@ -11,7 +11,11 @@ import (
 	"testing"
 	"time"
 
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 // writeAgent writes agent_code/<name>/index.js under a temp root and returns
@@ -162,6 +166,59 @@ func TestCodeJS_NoToolCalls(t *testing.T) {
 	}
 	if len(res.toolCalls) != 0 {
 		t.Errorf("expected zero tool calls, got %d", len(res.toolCalls))
+	}
+}
+
+// Each Call emits a loomcycle.provider.call span (parity with the real LLM
+// drivers, which each open one) carrying provider.code_hash — the sha256 of
+// the agent's index.js (RFC J Decision 9) — and provider.kind=synthetic-code.
+// This is the only place the hash surfaces on a trace, since the synthetic
+// provider makes no HTTP request. Asserts the hash matches the compiled hash.
+func TestCodeJS_ProviderCallSpan_CarriesCodeHash(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	cleanup := lcotel.SetTracerProviderForTest(tp)
+	t.Cleanup(func() { cleanup(); _ = tp.Shutdown(context.Background()) })
+
+	root := writeAgent(t, "hashy", `function run(){ return {final_text:"ok"}; }`)
+	p := newTestProvider(root)
+	wantHash, err := p.Compile("hashy")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res := drive(t, context.Background(), p, "hashy", "go", nil, nil); res.errText != "" {
+		t.Fatalf("run errored: %s", res.errText)
+	}
+
+	var found bool
+	for _, s := range exp.GetSpans() {
+		if s.Name != lcotel.SpanProviderCall {
+			continue
+		}
+		found = true
+		var gotHash, gotKind, gotProvider string
+		for _, a := range s.Attributes {
+			switch string(a.Key) {
+			case lcotel.AttrProviderCodeHash:
+				gotHash = a.Value.AsString()
+			case lcotel.AttrProviderKind:
+				gotKind = a.Value.AsString()
+			case lcotel.AttrProvider:
+				gotProvider = a.Value.AsString()
+			}
+		}
+		if gotHash != wantHash {
+			t.Errorf("provider.call span code_hash=%q, want compiled hash %q", gotHash, wantHash)
+		}
+		if gotKind != "synthetic-code" {
+			t.Errorf("provider.call span kind=%q, want synthetic-code", gotKind)
+		}
+		if gotProvider != "code-js" {
+			t.Errorf("provider.call span provider=%q, want code-js", gotProvider)
+		}
+	}
+	if !found {
+		t.Fatal("no loomcycle.provider.call span emitted by the code-js provider")
 	}
 }
 

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -9,7 +9,9 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"go.opentelemetry.io/otel/trace"
 
+	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
@@ -126,7 +128,18 @@ func (p *Provider) Call(ctx context.Context, req providers.Request) (<-chan prov
 		return out, nil
 	}
 	seed, anchorMs := p.determinism(meta)
-	go p.runTurn(ctx, out, prog.prog, buildInput(req, meta), extractRecorded(req), toolNames(req), seed, anchorMs)
+	// Emit a loomcycle.provider.call span for parity with the real LLM drivers
+	// (which each open one). The synthetic provider makes no HTTP request, so
+	// this is the canonical place to attach provider.code_hash (RFC J Decision
+	// 9) — operators can answer "which index.js version produced this run" and
+	// filter synthetic-code runs via provider.kind. Span is ended in runTurn.
+	spanCtx, span := lcotel.RecordProviderCall(ctx, lcotel.ProviderCallAttrs{
+		Provider: providerID,
+		Model:    syntheticModel,
+		Kind:     "synthetic-code",
+		CodeHash: prog.hash,
+	})
+	go p.runTurn(spanCtx, out, span, prog.prog, buildInput(req, meta), extractRecorded(req), toolNames(req), seed, anchorMs)
 	return out, nil
 }
 
@@ -134,8 +147,9 @@ func (p *Provider) Call(ctx context.Context, req providers.Request) (<-chan prov
 // runtime → harden + hook → bind → run() → emit the turn's outcome → close.
 // The goroutine lives only for the JS execution (µs–ms), never across a
 // dispatch gap.
-func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, prog *goja.Program, input map[string]any, recorded []toolRecord, allowed []string, seed uint32, anchorMs int64) {
+func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span trace.Span, prog *goja.Program, input map[string]any, recorded []toolRecord, allowed []string, seed uint32, anchorMs int64) {
 	defer close(out)
+	defer span.End()
 
 	rt := goja.New()
 	rt.SetFieldNameMapper(goja.TagFieldNameMapper("json", true))


### PR DESCRIPTION
## Why

RFC J **Decision 9** specifies `provider.code_hash` as an OTEL attribute — *"which `index.js` version produced this run"* — and the compiler already computes the sha256 (exposed via `Provider.Compile()`). But nothing wired it onto a span: the real LLM drivers each open a `loomcycle.provider.call` span, while the synthetic **code-js** provider (which makes no HTTP request) opened none. So the hash never reached a trace, and code-agent runs were indistinguishable from LLM runs on a span search. Flagged as a deferred item in the v0.16.0 QA pass (Phase 2).

## What

- code-js now opens its own `loomcycle.provider.call` span per `Call` (ended in `runTurn`) carrying `provider=code-js`, `model=loomcycle/code-js`, `provider.kind=synthetic-code`, and `provider.code_hash=<sha256 of index.js>`.
- Two new **optional** `ProviderCallAttrs` fields (`Kind`, `CodeHash`) and two attribute keys (`loomcycle.provider.kind`, `loomcycle.provider.code_hash`). Both empty for real drivers — their spans are unchanged.

## Tested

- **`TestCodeJS_ProviderCallSpan_CarriesCodeHash`** — drives a code-agent through an in-memory span exporter and asserts the `provider.call` span's `code_hash` equals the compiled hash, `kind=synthetic-code`, `provider=code-js`. **Fails-before** (`code_hash=""` when the wiring is neutralized), **passes-after**.
- `go test ./internal/otel/ ./internal/providers/codejs/` green; `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)