### PR TITLE
fix(memory): bound the MemoryLayer add ingest by MaxValueBytes

### DIFF
--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -689,10 +689,23 @@ func (m *Memory) execAdd(ctx context.Context, scope store.MemoryScope, scopeID s
 	if len(in.Messages) == 0 {
 		return errResult("add: missing required field: messages (a non-empty array of {role, content})"), nil
 	}
+	totalContentBytes := 0
 	for i, msg := range in.Messages {
 		if msg.Content == "" {
 			return errResult(fmt.Sprintf("add: messages[%d] has empty content", i)), nil
 		}
+		totalContentBytes += len(msg.Content)
+	}
+	// Bound the ingest the same way execSet bounds a value. The layer.Add path
+	// POSTs the full messages array to the (possibly remote) memory backend
+	// with no request-body cap, and the async-extracted facts are never charged
+	// to the per-scope quota (RFC §8 excludes embedding bytes) — so without
+	// this an agent could push an unbounded conversation payload through `add`
+	// as a free, unaccounted egress / amplification channel. We cap the raw
+	// ingest bytes; the byte cap on the input is the proportionate guard since
+	// the server assigns extracted-fact storage asynchronously and out of band.
+	if m.MaxValueBytes > 0 && totalContentBytes > m.MaxValueBytes {
+		return errResult(fmt.Sprintf("add: messages content (%d bytes) exceeds max %d bytes", totalContentBytes, m.MaxValueBytes)), nil
 	}
 	// infer defaults to true — the memory-layer paradigm is LLM fact
 	// extraction; an operator opts into verbatim storage with infer:false.

--- a/internal/tools/builtin/memory_layer_test.go
+++ b/internal/tools/builtin/memory_layer_test.go
@@ -86,6 +86,34 @@ func TestMemoryTool_AddRecall_RefuseOnNonLayerBackend(t *testing.T) {
 	}
 }
 
+// add must bound its ingest by MaxValueBytes, exactly as set does for a value.
+// Without the cap an agent could POST an arbitrarily large messages array to
+// the (possibly remote) layer backend — unbounded egress, and the bytes are
+// never charged to the per-scope quota (async-extracted facts, RFC §8). The
+// oversized add must refuse BEFORE the backend is called.
+func TestMemoryTool_Add_RefusesOversizedIngest(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t) // MaxValueBytes = 65536
+	defer cleanup()
+	fake := &fakeLayerBackend{}
+	tool.Backend = fake
+
+	big := strings.Repeat("x", tool.MaxValueBytes+1)
+	in := `{"op":"add","scope":"user","messages":[{"role":"user","content":"` + big + `"}]}`
+	res, err := tool.Execute(ctx, json.RawMessage(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("oversized add should be refused; got non-error result %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "exceeds max") {
+		t.Errorf("refusal should name the byte cap; got %s", res.Text)
+	}
+	if len(fake.addCalls) != 0 {
+		t.Errorf("backend.Add must NOT be called for an oversized ingest; got %d calls", len(fake.addCalls))
+	}
+}
+
 // With a MemoryLayer-capable backend wired, add routes through to it: the
 // messages + infer-default (true) reach the backend and the async pending
 // status + event id surface in the tool result.


### PR DESCRIPTION
## Why

`execAdd` (the RFC K memory-layer `add` op) validated only that `messages` was non-empty and each `content` non-empty — it **never checked size**, unlike `execSet` (`MaxValueBytes`, `memory.go:519`) and the reducers. `layer.Add` then POSTs the full messages array to the (possibly remote) backend with **no request-body cap**, and the async-extracted facts are **never charged to the per-scope quota** (RFC §8 excludes embedding bytes). So an agent could push an unbounded conversation payload through `add` as a free, unaccounted egress / store-amplification channel — the same megabytes that `set` refuses. Found in the v0.16.0 RFC K adversarial review (**Finding 4, MEDIUM**).

## What

`execAdd` now sums content bytes across messages and refuses with the same `exceeds max N bytes` shape `execSet` uses when the total exceeds `MaxValueBytes` (when configured). The cap is on the **raw ingest bytes** — the proportionate guard, since extracted-fact storage is assigned by the server asynchronously and out of band, so an exact per-scope quota charge isn't available at call time.

## Tested

- **`TestMemoryTool_Add_RefusesOversizedIngest`** — an `add` whose content exceeds `MaxValueBytes` is refused with `exceeds max` **and** the backend's `Add` is never called. **Fails-before** (oversized add reaches the backend, returns `pending`), **passes-after**.
- Existing add/recall layer tests still green; `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)