### PR TITLE
refactor(config): remove dead MemoryBackendDefScopes config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -664,11 +664,6 @@ type AgentDef struct {
 	// A2AAgentDefScopes: "self" / "descendants" / "named:<name>" / "any".
 	WebhookDefScopes []string `yaml:"webhook_def_scopes"`
 
-	// MemoryBackendDefScopes is the RFC I MR-3a MemoryBackendDef tool
-	// capability gate. Default-deny when empty. Same closed set as
-	// WebhookDefScopes: "self" / "descendants" / "named:<name>" / "any".
-	MemoryBackendDefScopes []string `yaml:"memory_backend_def_scopes"`
-
 	// SkillDefScopes is the v0.8.22 SkillDef tool capability gate.
 	// Default-deny when empty. Mirrors AgentDefScopes minus the
 	// "self" scope (skills have no agent identity, so "self" is

--- a/internal/tools/builtin/memorybackenddef.go
+++ b/internal/tools/builtin/memorybackenddef.go
@@ -355,7 +355,7 @@ func (s *MemoryBackendDef) execRetire(ctx context.Context, policy tools.MemoryBa
 
 func (s *MemoryBackendDef) checkScopeForName(policy tools.MemoryBackendDefPolicyValue, name string) error {
 	if len(policy.Scopes) == 0 {
-		return fmt.Errorf("MemoryBackendDef tool: agent has no memory_backend_def_scopes (default-deny); add `memory_backend_def_scopes: [...]` to the agent yaml")
+		return fmt.Errorf("MemoryBackendDef tool: no def-scope granted in this caller's context (default-deny)")
 	}
 	for _, sc := range policy.Scopes {
 		switch sc {
@@ -378,7 +378,7 @@ func (s *MemoryBackendDef) checkScopeForName(policy tools.MemoryBackendDefPolicy
 			}
 		}
 	}
-	return fmt.Errorf("MemoryBackendDef tool: name %q not in this agent's memory_backend_def_scopes (%v)", name, policy.Scopes)
+	return fmt.Errorf("MemoryBackendDef tool: name %q not in the caller's granted def-scope (%v)", name, policy.Scopes)
 }
 
 func (s *MemoryBackendDef) buildDefinition(name, parentJSON string, overlay json.RawMessage) (mergedMemoryBackendDef, error) {


### PR DESCRIPTION
## Why

The per-agent `memory_backend_def_scopes:` yaml field was parsed but **never read** — a full-repo grep finds zero consumers (vs. `AgentDefScopes`/`SkillDefScopes` which have 9/5 real readers). The `MemoryBackendDef` tool is operator-admin-only and is **not** in the agent tool registry (`server.go` keeps it out of `s.tools`, same posture as `WebhookDef`); its only callers — the admin endpoint, the LoomCycle MCP meta-tool, the gRPC substrate path — all build the policy with a hardcoded `Scopes:["any"]`. So the agent-yaml field could never take effect.

Worse, the tool's own error strings told operators to *"add `memory_backend_def_scopes` to the agent yaml"* — a misleading trap pointing at an inert knob. Found in the v0.16.0 QA pass (deferred-item review). Per CLAUDE.md *"No backward-compat shims for unused code"*, delete it.

## What

- Remove the `MemoryBackendDefScopes` struct field + yaml tag.
- Reword the two `checkScopeForName` error strings to reflect the real grant mechanism (the caller's operator-admin context) instead of the non-existent agent-yaml key. The scope-enforcement logic itself is unchanged.

## Note

`WebhookDefScopes` has the **identical** dead-config shape (admin-only tool, zero readers, same misleading strings). Left out of this PR to keep it on-brief and surgical — tracked in the QA report as the same defect class for a follow-up.

## Tested

`go build ./...` green; `go test ./internal/config/ ./internal/tools/builtin/` green; repo-wide grep confirms zero remaining references to the removed field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)