### PR TITLE
fix(a2a): block direct-IP SSRF on model-authored gRPC endpoints

### DIFF
--- a/internal/tools/builtin/a2aagentdef.go
+++ b/internal/tools/builtin/a2aagentdef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -467,10 +468,7 @@ func validateA2AAgentDef(def mergedA2AAgentDef) error {
 	// URLs upfront. This is defense-in-depth: the HTTP fetch + jsonrpc/rest
 	// transports also dial through the SSRF-blocking client in
 	// internal/tools/a2a, which refuses private/loopback/metadata targets
-	// at connect time. (The gRPC binding dials via grpc-go, outside that
-	// client — so a grpc endpoint is validated for shape here but its
-	// dial is NOT private-IP-blocked; gRPC peers are operator-configured in
-	// practice and a callable fork must already be in allowed_tools.)
+	// at connect time.
 	if hasCardURL {
 		if err := requireHTTPURL("agent_card_url", def.AgentCardURL); err != nil {
 			return err
@@ -478,6 +476,19 @@ func validateA2AAgentDef(def mergedA2AAgentDef) error {
 	}
 	if def.Endpoint != "" && (def.Binding == "rest" || def.Binding == "jsonrpc") {
 		if err := requireHTTPURL("endpoint", def.Endpoint); err != nil {
+			return err
+		}
+	}
+	// The gRPC binding dials via grpc-go, OUTSIDE the SSRF-blocking
+	// peerDialContext that guards the jsonrpc/rest transports. Block the
+	// common direct-IP SSRF (e.g. grpc://169.254.169.254 → cloud metadata) at
+	// registration/fork time. This does NOT cover a hostname that resolves to
+	// a private address, nor DNS-rebinding at dial time — closing those needs
+	// the gRPC dial routed through peerDialContext, which is deferred because
+	// the SDK's WithGRPCTransport replaces the whole transport and would
+	// require replicating its default credentials (TLS-downgrade risk).
+	if def.Endpoint != "" && def.Binding == "grpc" {
+		if err := requireSafeGRPCEndpoint("endpoint", def.Endpoint); err != nil {
 			return err
 		}
 	}
@@ -503,6 +514,32 @@ func requireHTTPURL(field, raw string) error {
 	}
 	if u.Host == "" {
 		return fmt.Errorf("%s %q has no host", field, raw)
+	}
+	return nil
+}
+
+// requireSafeGRPCEndpoint rejects a gRPC endpoint whose host is a LITERAL
+// private / loopback / link-local IP (notably the cloud metadata service at
+// 169.254.169.254). The gRPC binding dials via grpc-go, outside the
+// SSRF-blocking peerDialContext in internal/tools/a2a, so this is the
+// registration-time defense-in-depth against the common direct-IP SSRF when
+// the endpoint is model-authored via a fork overlay. It deliberately does NOT
+// resolve hostnames (no DNS at registration time, and a resolved answer can
+// change before dial — that TOCTOU is the dialer's job, deferred for gRPC).
+func requireSafeGRPCEndpoint(field, raw string) error {
+	host := raw
+	// gRPC targets may carry a scheme/authority ("dns:///h:p",
+	// "passthrough:///h:p", "grpc://h:p"); take the segment after the last
+	// '/', then strip an optional :port and IPv6 brackets.
+	if i := strings.LastIndex(host, "/"); i >= 0 {
+		host = host[i+1:]
+	}
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.Trim(host, "[]")
+	if ip := net.ParseIP(host); ip != nil && isPrivateIP(ip) {
+		return fmt.Errorf("%s %q is a private/loopback/link-local address — refusing (the gRPC binding dials outside the SSRF guard)", field, raw)
 	}
 	return nil
 }

--- a/internal/tools/builtin/a2aagentdef_test.go
+++ b/internal/tools/builtin/a2aagentdef_test.go
@@ -89,6 +89,32 @@ func TestA2AAgentDefTool_CreateWithEndpointBinding(t *testing.T) {
 	}
 }
 
+// A model-authored grpc endpoint pointing at a literal private/link-local IP
+// (the cloud metadata service) must be refused at create — the gRPC binding
+// dials outside the SSRF-blocking peerDialContext, so registration-time is
+// the defense. A public-host grpc endpoint is still accepted (the dial-time
+// hostname/rebinding case for gRPC is the documented deferred residual).
+func TestA2AAgentDefTool_CreateRefusesPrivateGRPCEndpoint(t *testing.T) {
+	tool, ctx, cleanup := a2aAgentDefFixture(t)
+	defer cleanup()
+
+	for _, ep := range []string{"169.254.169.254:50051", "127.0.0.1:50051", "10.0.0.5:443", "grpc://192.168.1.10:50051", "dns:///[::1]:50051"} {
+		in := `{"op":"create","name":"badgrpc","overlay":{"endpoint":"` + ep + `","binding":"grpc"}}`
+		res, _ := tool.Execute(ctx, json.RawMessage(in))
+		if !res.IsError {
+			t.Errorf("grpc endpoint %q (private/loopback/link-local) should be refused; got %s", ep, res.Text)
+		} else if !strings.Contains(res.Text, "private/loopback/link-local") {
+			t.Errorf("grpc endpoint %q refusal should name the SSRF reason; got %s", ep, res.Text)
+		}
+	}
+
+	// A public-host grpc endpoint passes the literal-IP gate.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"okgrpc","overlay":{"endpoint":"peer.example:50051","binding":"grpc"}}`))
+	if res.IsError {
+		t.Errorf("public-host grpc endpoint should be accepted; got %s", res.Text)
+	}
+}
+
 func TestA2AAgentDefTool_CreateRefusesBothReachabilityModes(t *testing.T) {
 	tool, ctx, cleanup := a2aAgentDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

The jsonrpc/rest A2A transports dial through the SSRF-blocking `peerDialContext` (refuses loopback / link-local / RFC1918 / cloud-metadata), and their endpoints are scheme-validated upfront via `requireHTTPURL`. The **gRPC binding dials via grpc-go, outside that client**, and `validateA2AAgentDef` gated its endpoint check on `rest`/`jsonrpc` only — so a `grpc` endpoint was **neither scheme-checked nor private-IP-blocked**.

Since `A2AAgentDef` reachability is model-authorable via a fork overlay, a granted fork could set `endpoint="169.254.169.254:50051", binding="grpc"` and dial the cloud metadata service / internal hosts. Found in the v0.16.0 QA pass (deferred A2A item **B**). Operator-gated (requires a def-fork grant + the synthetic tool in `allowed_tools`), so low/medium severity — but a real asymmetry with the hardened HTTP path.

## What

`validateA2AAgentDef` now rejects a `grpc` endpoint whose host is a **literal** private/loopback/link-local IP (`requireSafeGRPCEndpoint`), at **create and fork**. Handles bare `host:port`, scheme/authority forms (`grpc://`, `dns:///`, `passthrough:///`), and IPv6 brackets. Closes the direct-IP SSRF (the metadata-service attack) with zero DNS/TOCTOU or SDK-credential risk.

## Deferred (documented in code + QA report)

A hostname that **resolves** to a private address, and **DNS-rebinding** at dial time, are **not** covered — closing those needs the gRPC dial routed through `peerDialContext`, but the SDK's `WithGRPCTransport` replaces the whole transport and would require replicating its default credentials (**TLS-downgrade risk**). Tracked as follow-up.

## Tested

- **`TestA2AAgentDefTool_CreateRefusesPrivateGRPCEndpoint`** — five private grpc endpoints (metadata IP, loopback, RFC1918, `grpc://` form, IPv6 `::1`) are refused with the SSRF reason; a public-host grpc endpoint is accepted. **Fails-before** (all five are created), **passes-after**.
- `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)