### PR TITLE
test(runtime): add code-js + code-js-stress runtime suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,29 @@ jobs:
             exit 1
           fi
 
+  runtime-codejs:
+    name: Runtime suites (code-js)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+          cache: true
+
+      # The code-js runtime suites are deterministic (synthetic provider, no
+      # LLM / key / Postgres) and assert storage state via the sqlite3 CLI +
+      # parse SSE with python3. Both are preinstalled on ubuntu-latest; this
+      # makes the dependency explicit and fails fast if the image changes.
+      - name: Ensure sqlite3 + python3
+        run: |
+          command -v python3 >/dev/null || { echo "python3 missing"; exit 1; }
+          command -v sqlite3  >/dev/null || sudo apt-get update && sudo apt-get install -y sqlite3
+
+      - name: Runtime code-js suites
+        run: make runtime-codejs
+
   ts-adapter:
     name: TypeScript adapter
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,20 @@ test-pg:
 # boot the binary and one waits ~60s for a real cron fire. memory-vector is
 # excluded here (needs Postgres + pgvector); run it via runtime-vector.
 runtime-mock:
-	@set -e; for s in schedules webhooks memory-core; do \
+	@set -e; for s in schedules webhooks memory-core code-js code-js-stress; do \
 		echo "=== runtime/$$s ==="; ./test/runtime/$$s/run.sh; \
 	done; echo "=== all runtime-mock suites PASSED ==="
+
+# runtime-codejs: the synthetic code-js provider (RFC J) suites. Unlike the
+# other runtime suites these are CI-friendly — fully deterministic (no LLM,
+# the provider runs operator JS via goja), no API key, no Postgres, and no
+# long cron waits — so the CI workflow runs this target. Validates the
+# code-js loop+replay end-to-end, the Memory meta-tool op surface, the
+# MaxIterations ceiling + diagnostic, and concurrent-run isolation.
+runtime-codejs:
+	@set -e; for s in code-js code-js-stress; do \
+		echo "=== runtime/$$s ==="; ./test/runtime/$$s/run.sh; \
+	done; echo "=== all runtime-codejs suites PASSED ==="
 
 # runtime-vector: the Memory vector + dedup suite against Postgres+pgvector
 # with the deterministic stub embedder. Provide LOOMCYCLE_TEST_PG_DSN

--- a/test/runtime/code-js-stress/agent_code/counter/index.js
+++ b/test/runtime/code-js-stress/agent_code/counter/index.js
@@ -1,0 +1,13 @@
+// counter — 8 sequential atomic incrs on a SHARED agent-scope key. Each incr
+// is one loop turn; run() re-executes from the top every turn, replaying the
+// 0..k-1 recorded results and dispatching only the k-th. 8 < the 16-iteration
+// default so the run completes end_turn — proving an 8-turn replay chain is
+// divergence-free. Fired concurrently across many runs, the shared "n" must
+// land at exactly 8*N (atomic incr + per-run goja isolation, no lost update).
+function run(input) {
+  var last;
+  for (var i = 0; i < 8; i++) {
+    last = Memory.incr({ scope: "agent", key: "n", delta: 1 });
+  }
+  return { final_text: "done last=" + (last && last.value !== undefined ? last.value : "?") };
+}

--- a/test/runtime/code-js-stress/agent_code/overrun/index.js
+++ b/test/runtime/code-js-stress/agent_code/overrun/index.js
@@ -1,0 +1,12 @@
+// overrun — 25 sequential incrs. Each tool call is one loop turn, so this
+// asks for 25 sequential calls against the 16-iteration default ceiling. The
+// run must terminate with stop_reason=max_iterations BEFORE the loop finishes
+// (run() never returns its final_text). For a code-agent MaxIterations is a
+// HARD ceiling on sequential tool calls, not a soft model-chatter cap — this
+// suite asserts that behaviour and the operator diagnostic that names it.
+function run(input) {
+  for (var i = 0; i < 25; i++) {
+    Memory.incr({ scope: "agent", key: "ovr", delta: 1 });
+  }
+  return { final_text: "UNREACHABLE: completed 25 calls under the cap" };
+}

--- a/test/runtime/code-js-stress/loomcycle.yaml
+++ b/test/runtime/code-js-stress/loomcycle.yaml
@@ -1,0 +1,31 @@
+# test/runtime/code-js-stress — stress + edge behaviours of the synthetic
+# code-js provider (RFC J). Deterministic (no LLM). Exercises:
+#   - many sequential tool calls in one code-agent → the replay engine
+#     re-runs run() each turn (O(N^2)) and must stay divergence-free
+#   - MaxIterations as the HARD ceiling on a code-agent's sequential tool
+#     calls (each loop turn = one call) → stop_reason=max_iterations
+#   - concurrent runs of the same code-agent → per-run goja isolation +
+#     atomic Memory.incr → no lost updates on a shared agent-scope counter
+provider_priority: [mock]
+tiers:
+  middle:
+    - { provider: mock, model: mock-generic }
+
+agents:
+  # counter makes 8 sequential incrs on a SHARED agent-scope key. 8 < the
+  # 16 MaxIterations default, so it completes end_turn — proving 8-turn
+  # replay is divergence-free. Fired concurrently it tests atomic incr +
+  # per-run runtime isolation.
+  counter:
+    provider: code-js
+    description: "8 sequential atomic incrs on a shared agent-scope counter."
+    memory_scopes: [agent]
+    allowed_tools: [Memory]
+
+  # overrun makes 25 sequential incrs — past the 16-call ceiling — so the
+  # run terminates with stop_reason=max_iterations rather than completing.
+  overrun:
+    provider: code-js
+    description: "25 sequential incrs — deliberately exceeds MaxIterations."
+    memory_scopes: [agent]
+    allowed_tools: [Memory]

--- a/test/runtime/code-js-stress/run.sh
+++ b/test/runtime/code-js-stress/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test/runtime/code-js-stress/run.sh — stress + edge behaviours of the
+# synthetic code-js provider (RFC J). Deterministic, no LLM, no key, no PG.
+#
+#   [A] MaxIterations ceiling: the `overrun` agent asks for 25 sequential
+#       tool calls against the 16 default → stop_reason=max_iterations, and
+#       the operator log names it as a code-js sequential-call ceiling.
+#   [B] Concurrency + atomic incr + replay isolation: N parallel `counter`
+#       runs each do 8 sequential incrs on a SHARED agent-scope key; the
+#       final value must be exactly 8*N (no lost update, no cross-run bleed,
+#       and each 8-turn replay chain stayed divergence-free).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-codejs-stress.XXXXXX)"
+PORT=18942
+N=8   # concurrent counter runs
+cleanup() {
+  [[ -n "${PID:-}" ]] && { kill "$PID" 2>/dev/null || true; wait "$PID" 2>/dev/null || true; }
+  echo; echo "Test dir kept for inspection: $TEST_DIR"
+}
+trap cleanup EXIT INT TERM
+
+TOKEN="test-token-$(date +%s)"
+BASE="http://127.0.0.1:$PORT"
+DB="$TEST_DIR/data/loomcycle.db"
+fail() { echo "FAIL ✗ — $1"; exit 1; }
+
+sse_stop() {
+  grep -A1 '^event: done$' "$1" | grep '^data:' | sed 's/^data: //' | \
+    python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('stop_reason',''))
+  except: pass" 2>/dev/null | tail -1 || true
+}
+post_run() {
+  local out="$1" agent="$2" uid="$3"
+  curl -fsS -N -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" -d @- "$BASE/v1/runs" <<EOF > "$out"
+{"agent":"$agent","user_id":"$uid","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}
+EOF
+}
+
+echo "[1/5] build + boot (code-js enabled)"
+go build -o bin/loomcycle ./cmd/loomcycle
+LOOMCYCLE_MOCK_ENABLED=1 \
+LOOMCYCLE_CODE_AGENTS_ENABLED=1 \
+LOOMCYCLE_CODE_AGENTS_ROOT="$SCRIPT_DIR/agent_code" \
+LOOMCYCLE_DATA_DIR="$TEST_DIR/data" \
+LOOMCYCLE_LISTEN_ADDR="127.0.0.1:$PORT" \
+LOOMCYCLE_AUTH_TOKEN="$TOKEN" \
+  ./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$TEST_DIR/boot.log" 2>&1 &
+PID=$!
+READY=0
+for i in $(seq 1 50); do
+  curl -fsS "$BASE/healthz" >/dev/null 2>&1 && { READY=1; break; }
+  kill -0 "$PID" 2>/dev/null || { echo "boot failed:"; cat "$TEST_DIR/boot.log"; exit 1; }
+  sleep 0.2
+done
+[[ "$READY" == "1" ]] || { echo "not ready:"; cat "$TEST_DIR/boot.log"; exit 1; }
+
+echo "[2/5] [A] MaxIterations ceiling — overrun (25 calls vs 16 cap)"
+post_run "$TEST_DIR/overrun.sse" "overrun" "stress-overrun"
+OS=$(sse_stop "$TEST_DIR/overrun.sse")
+echo "      stop_reason: $OS"
+[[ "$OS" == "max_iterations" ]] || fail "overrun stop_reason=$OS, want max_iterations"
+# The per-run incr count must be exactly the cap (16), proving each loop turn
+# advanced the replay by exactly one tool call.
+OVR=$(command -v sqlite3 >/dev/null 2>&1 && sqlite3 "$DB" "SELECT value FROM memory WHERE scope='agent' AND key='ovr';" 2>/dev/null || echo "")
+echo "      incrs executed before the cap: ${OVR:-<no sqlite3>}"
+if [[ -n "$OVR" ]]; then [[ "$OVR" == "16" ]] || fail "overrun executed $OVR incrs, want 16 (the cap)"; fi
+
+echo "[3/5] [A] operator diagnostic names the code-js ceiling (requires the maxiter-diagnostic fix)"
+if grep -q "hit MaxIterations" "$TEST_DIR/boot.log"; then
+  echo "      ✓ $(grep 'hit MaxIterations' "$TEST_DIR/boot.log" | head -1 | sed 's/^[0-9/ :]*//')"
+else
+  fail "no code-js MaxIterations diagnostic in the operator log (maxiter-diagnostic fix not present?)"
+fi
+
+echo "[4/5] [B] concurrency — $N parallel counter runs × 8 incrs on a shared key"
+pids=()
+for k in $(seq 1 "$N"); do
+  post_run "$TEST_DIR/counter-$k.sse" "counter" "stress-counter-$k" &
+  pids+=($!)
+done
+for p in "${pids[@]}"; do wait "$p" || true; done
+# Every run must have completed end_turn.
+for k in $(seq 1 "$N"); do
+  cs=$(sse_stop "$TEST_DIR/counter-$k.sse")
+  [[ "$cs" == "end_turn" ]] || fail "counter run $k stop_reason=$cs, want end_turn"
+done
+echo "      all $N runs completed end_turn"
+
+echo "[5/5] shared counter == 8*N (atomic incr, no lost update)"
+WANT=$((8 * N))
+if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$DB" ]]; then
+  GOT=$(sqlite3 "$DB" "SELECT value FROM memory WHERE scope='agent' AND key='n';" 2>/dev/null || echo "")
+  echo "      shared counter = $GOT (want $WANT)"
+  [[ "$GOT" == "$WANT" ]] || fail "shared counter=$GOT, want $WANT — a concurrent incr was lost"
+else
+  echo "      (sqlite3 not available — skipping counter assertion)"
+fi
+
+echo "PASS ✓ — max_iterations ceiling enforced+diagnosed; $N concurrent code-js runs kept incr atomic"

--- a/test/runtime/code-js/agent_code/kvflow/index.js
+++ b/test/runtime/code-js/agent_code/kvflow/index.js
@@ -1,0 +1,23 @@
+// kvflow — exercises the Memory multi-op meta-tool from a code-js agent over
+// the real loop + Appendix-B replay engine. Each tool call is one loop turn;
+// run() re-executes from the top on every turn, replaying the recorded
+// results, so the value read by get() is the value written by an earlier
+// turn's set(). set/incr/get/list all dispatch through the loop's real
+// Memory tool against sqlite.
+//
+// incr and list are the ops that were UNREACHABLE from code-js before the
+// meta-tool generic op passthrough fix — calling them here is the runtime
+// regression that they are now bound.
+function run(input) {
+  Memory.set({ scope: "user", key: "favorite_color", value: "purple" });
+  var afterIncr = Memory.incr({ scope: "agent", key: "run_count", delta: 1 });
+  var got = Memory.get({ scope: "user", key: "favorite_color" });
+  var keys = Memory.list({ scope: "user" });
+
+  var color = (got && got.value) ? got.value : "MISSING";
+  var count = (afterIncr && afterIncr.value !== undefined && afterIncr.value !== null)
+    ? afterIncr.value : "MISSING";
+  var nKeys = (keys && keys.entries) ? keys.entries.length : -1;
+
+  return { final_text: "color=" + color + " count=" + count + " user_keys=" + nKeys };
+}

--- a/test/runtime/code-js/loomcycle.yaml
+++ b/test/runtime/code-js/loomcycle.yaml
@@ -1,0 +1,20 @@
+# test/runtime/code-js — runtime config for the synthetic code-js provider
+# (RFC J). The code-js provider is SYNTHETIC: it runs operator JavaScript via
+# goja with no LLM, so this suite is deterministic by construction and needs
+# no provider key. The mock provider is declared only so boot succeeds with a
+# valid default provider; the code-js agent below never calls it.
+provider_priority: [mock]
+tiers:
+  middle:
+    - { provider: mock, model: mock-generic }
+
+agents:
+  # kvflow exercises the multi-op Memory meta-tool from JS over the real loop
+  # + replay engine: set (user), incr (agent counter), get (read-back), list.
+  # incr/list were UNREACHABLE from code-js before the meta-tool op
+  # passthrough fix — this suite is their end-to-end regression on the wire.
+  kvflow:
+    provider: code-js
+    description: "Deterministic Memory round-trip via code-js (set/incr/get/list)."
+    memory_scopes: [user, agent]
+    allowed_tools: [Memory]

--- a/test/runtime/code-js/run.sh
+++ b/test/runtime/code-js/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test/runtime/code-js/run.sh — synthetic code-js provider (RFC J) runtime
+# suite. Deterministic by construction: code-js runs operator JS via goja, no
+# LLM, no provider key, no Postgres. Validates that a `provider: code-js`
+# agent drives the REAL loop + Appendix-B replay engine end-to-end:
+#
+#   - the Memory multi-op meta-tool dispatches over the wire (set/incr/get/
+#     list) — incr + list were UNREACHABLE from code-js before the meta-tool
+#     op-passthrough fix, so this is their end-to-end regression
+#   - replay reaches the same state across the loop's tool-call turns (the
+#     value read by get() is the value written by set() on an earlier turn)
+#   - state persists across run boundaries (run 2 sees run 1's counter)
+#   - the synthetic provider emits a provider.code_hash (asserted via the
+#     boot log / run; the unit test pins the span, here we assert the run
+#     completes cleanly through the real provider registration)
+#
+# Same test/runtime/<feature>/ convention as memory-core/.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_DIR="$(mktemp -d -t loomcycle-codejs.XXXXXX)"
+PORT=18941
+cleanup() {
+  [[ -n "${PID:-}" ]] && { kill "$PID" 2>/dev/null || true; wait "$PID" 2>/dev/null || true; }
+  echo; echo "Test dir kept for inspection: $TEST_DIR"
+}
+trap cleanup EXIT INT TERM
+
+TOKEN="test-token-$(date +%s)"
+BASE="http://127.0.0.1:$PORT"
+DB="$TEST_DIR/data/loomcycle.db"
+USER_ID="codejs-user"
+fail() { echo "FAIL ✗ — $1"; exit 1; }
+
+# Extract concatenated EventText deltas from an SSE capture.
+sse_text() {
+  grep -A1 '^event: text$' "$1" | grep '^data:' | sed 's/^data: //' | \
+    python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('text',''), end='')
+  except: pass" 2>/dev/null || true
+}
+# stop_reason from the EventDone frame.
+sse_stop() {
+  grep -A1 '^event: done$' "$1" | grep '^data:' | sed 's/^data: //' | \
+    python3 -c "import sys,json
+for line in sys.stdin:
+  try: print(json.loads(line).get('stop_reason',''))
+  except: pass" 2>/dev/null | tail -1 || true
+}
+post_run() {
+  local out="$1" prompt="$2"
+  curl -fsS -N -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" -d @- "$BASE/v1/runs" <<EOF > "$out"
+{"agent":"kvflow","user_id":"$USER_ID","segments":[{"role":"user","content":[{"type":"trusted-text","text":"$prompt"}]}]}
+EOF
+}
+
+echo "[1/5] build + boot (code-js enabled, code root = $SCRIPT_DIR/agent_code)"
+go build -o bin/loomcycle ./cmd/loomcycle
+LOOMCYCLE_MOCK_ENABLED=1 \
+LOOMCYCLE_CODE_AGENTS_ENABLED=1 \
+LOOMCYCLE_CODE_AGENTS_ROOT="$SCRIPT_DIR/agent_code" \
+LOOMCYCLE_DATA_DIR="$TEST_DIR/data" \
+LOOMCYCLE_LISTEN_ADDR="127.0.0.1:$PORT" \
+LOOMCYCLE_AUTH_TOKEN="$TOKEN" \
+  ./bin/loomcycle --config "$SCRIPT_DIR/loomcycle.yaml" > "$TEST_DIR/boot.log" 2>&1 &
+PID=$!
+READY=0
+for i in $(seq 1 50); do
+  curl -fsS "$BASE/healthz" >/dev/null 2>&1 && { READY=1; break; }
+  kill -0 "$PID" 2>/dev/null || { echo "boot failed:"; cat "$TEST_DIR/boot.log"; exit 1; }
+  sleep 0.2
+done
+[[ "$READY" == "1" ]] || { echo "not ready:"; cat "$TEST_DIR/boot.log"; exit 1; }
+grep -qE "code-js|code_agents|code agents" "$TEST_DIR/boot.log" && echo "      code-js provider registered"
+
+echo "[2/5] run 1 — write phase (set purple, incr run_count→1, get, list)"
+post_run "$TEST_DIR/run1.sse" "go"
+R1=$(sse_text "$TEST_DIR/run1.sse"); S1=$(sse_stop "$TEST_DIR/run1.sse")
+echo "      final_text: $R1"
+echo "      stop_reason: $S1"
+[[ "$S1" == "end_turn" ]] || fail "run 1 stop_reason=$S1, want end_turn"
+echo "$R1" | grep -q "color=purple" || fail "run 1 did not read back the value it set (replay broken?): $R1"
+echo "$R1" | grep -q "count=1"      || fail "run 1 incr did not return 1 (incr unreachable from code-js?): $R1"
+echo "$R1" | grep -q "user_keys=1"  || fail "run 1 list did not see 1 user key (list unreachable from code-js?): $R1"
+
+echo "[3/5] run 2 — persistence phase (counter must advance to 2)"
+post_run "$TEST_DIR/run2.sse" "go"
+R2=$(sse_text "$TEST_DIR/run2.sse"); S2=$(sse_stop "$TEST_DIR/run2.sse")
+echo "      final_text: $R2"
+[[ "$S2" == "end_turn" ]] || fail "run 2 stop_reason=$S2, want end_turn"
+echo "$R2" | grep -q "count=2" || fail "run 2 counter did not persist+advance to 2: $R2"
+
+echo "[4/5] storage inspection"
+if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$DB" ]]; then
+  sqlite3 "$DB" "SELECT scope, scope_id, key, value FROM memory ORDER BY scope, key;" | sed 's/^/        /'
+  CNT=$(sqlite3 "$DB" "SELECT value FROM memory WHERE scope='agent' AND key='run_count';" 2>/dev/null || echo "")
+  [[ "$CNT" == "2" ]] || fail "stored run_count=$CNT, want 2"
+else
+  echo "      (sqlite3 not available or DB missing — skipping row inspection)"
+fi
+
+echo "[5/5] no errors on the SSE stream"
+if grep -q '^event: error$' "$TEST_DIR/run1.sse" "$TEST_DIR/run2.sse"; then
+  fail "an EventError appeared on a code-js run stream"
+fi
+
+echo "PASS ✓ — code-js drove the real loop+replay; Memory set/incr/get/list all reachable and persistent"


### PR DESCRIPTION
## Why

The synthetic **code-js** provider (RFC J) had solid unit coverage but no end-to-end runtime suite driving the real binary + loop + Appendix-B replay over the wire. code-js is the *ideal* runtime suite: synthetic (no LLM) ⇒ deterministic by construction — **no API key, no Postgres, no cron waits** — hence CI-friendly.

## What

- **`test/runtime/code-js`** — a code-js agent does Memory `set`/`incr`/`get`/`list` over the loop; asserts (a) replay reaches the same state (it reads back a value written on an earlier tool-call turn), (b) `incr`+`list` are reachable (they were **not** before the meta-tool op-passthrough fix), (c) state persists across run boundaries (counter 1→2).
- **`test/runtime/code-js-stress`** —
  - **[A]** a 25-call agent hits the 16-iteration ceiling → `stop_reason=max_iterations` **and** the operator diagnostic naming it as a code-js sequential-call ceiling; the pre-cap incr count is exactly 16.
  - **[B]** 8 concurrent runs × 8 incrs on a shared agent-scope key land at exactly **64** — atomic incr + per-run goja isolation + divergence-free 8-turn replay.
- Wired into `make runtime-mock` and a new CI-friendly **`make runtime-codejs`** target; added a `runtime-codejs` CI job (deterministic, no secrets).

## ⚠️ Depends on — merge AFTER:

- **#313** (meta-tool op passthrough — `incr`/`list` reachability)
- **#312** (MaxIterations diagnostic)

These suites are **regression tests for those PRs**, so on a base without them they **fail by design** — the code-js suite reproduces `Object has no member 'incr'`; the stress suite finds no diagnostic line. That failure *is* the proof they have teeth. **CI on this branch will be red until #312 + #313 are on `main`**; rebasing after they merge turns it green.

Verified green locally with #312 + #313 applied:
```
code-js:        color=purple count=2 user_keys=1; run_count persists to 2
code-js-stress: max_iterations at 16 incrs + diagnostic logged; 8×8 → 64
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)