### PR TITLE
feat(auth): authoritative principal + identity threading (RFC L PR 2/3)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1852,13 +1852,19 @@ func main() {
 	var grpcSrv *googlegrpc.Server
 	if cfg.Env.GrpcAddr != "" {
 		grpcAdapter := loomgrpc.New(loomgrpc.Config{
-			Store:       storeIface,
-			CancelReg:   srv.CancelRegistry(),
-			Connector:   srv, // v0.8.15: *http.Server satisfies connector.Connector
-			Runner:      srv, // *http.Server satisfies runner.Runner (streaming)
-			AuthToken:   cfg.Env.AuthToken,
-			BuildCommit: buildCommit,
-			BuildTime:   buildTime,
+			Store:     storeIface,
+			CancelReg: srv.CancelRegistry(),
+			Connector: srv, // v0.8.15: *http.Server satisfies connector.Connector
+			Runner:    srv, // *http.Server satisfies runner.Runner (streaming)
+			AuthToken: cfg.Env.AuthToken,
+			// RFC L: reuse the HTTP server's token resolution so gRPC
+			// stamps the same authoritative principal (gRPC runs flow
+			// authoritatively through RunOnce) and shares the open-mode
+			// decision.
+			PrincipalResolver: srv.ResolvePrincipal,
+			AuthConfigured:    srv.AuthConfigured,
+			BuildCommit:       buildCommit,
+			BuildTime:         buildTime,
 		})
 		grpcSrv = googlegrpc.NewServer(
 			googlegrpc.UnaryInterceptor(grpcAdapter.UnaryAuthInterceptor()),

--- a/internal/api/grpc/auth_principal_test.go
+++ b/internal/api/grpc/auth_principal_test.go
@@ -1,0 +1,54 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+func mdCtx(bearer string) context.Context {
+	return metadata.NewIncomingContext(context.Background(),
+		metadata.Pairs("authorization", "Bearer "+bearer))
+}
+
+func TestGrpcAuthenticate_OpenMode(t *testing.T) {
+	// authConfigured returns false → pass through even without a bearer.
+	s := &Server{authConfigured: func(context.Context) bool { return false }}
+	if _, err := s.authenticate(context.Background()); err != nil {
+		t.Errorf("open mode should pass through, got %v", err)
+	}
+}
+
+func TestGrpcAuthenticate_StampsPrincipal(t *testing.T) {
+	s := &Server{
+		authConfigured: func(context.Context) bool { return true },
+		principalResolver: func(_ context.Context, bearer string) (auth.Principal, bool) {
+			if bearer != "good" {
+				return auth.Principal{}, false
+			}
+			return auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsCreate}}, true
+		},
+	}
+	// Valid bearer → principal stamped into the returned ctx.
+	ctx, err := s.authenticate(mdCtx("good"))
+	if err != nil {
+		t.Fatalf("authenticate: %v", err)
+	}
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.TenantID != "acme" || p.Subject != "alice" {
+		t.Errorf("principal not stamped: ok=%v p=%+v", ok, p)
+	}
+	// Invalid bearer → Unauthenticated.
+	if _, err := s.authenticate(mdCtx("bad")); status.Code(err) != codes.Unauthenticated {
+		t.Errorf("bad bearer: code = %v, want Unauthenticated", status.Code(err))
+	}
+	// Missing metadata → Unauthenticated.
+	if _, err := s.authenticate(context.Background()); status.Code(err) != codes.Unauthenticated {
+		t.Errorf("missing md: code = %v, want Unauthenticated", status.Code(err))
+	}
+}

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"strings"
 	"time"
 
 	googlegrpc "google.golang.org/grpc"
@@ -73,6 +74,12 @@ type Server struct {
 	// behaviour). Compared in constant time.
 	authToken string
 
+	// principalResolver (RFC L) resolves a bearer → auth.Principal. Nil
+	// = legacy-token-only auth with no principal stamping.
+	principalResolver func(context.Context, string) (auth.Principal, bool)
+	// authConfigured reports whether auth is active (open-mode decision).
+	authConfigured func(context.Context) bool
+
 	// Build identifiers (set at link time in main.go). Surfaced via
 	// Health(). Empty fallbacks are fine — adapters don't depend on
 	// these being populated.
@@ -97,24 +104,39 @@ type Config struct {
 	// *internal/api/http.Server also satisfies it. May be nil — Run +
 	// Continue then return codes.Unimplemented (useful for tests that
 	// don't need streaming).
-	Runner      runner.Runner
-	AuthToken   string
-	BuildCommit string
-	BuildTime   string
+	Runner    runner.Runner
+	AuthToken string
+	// PrincipalResolver resolves a raw bearer to an auth.Principal (RFC
+	// L). Wired in main.go to the HTTP server's resolver so gRPC reuses
+	// the identical token-substrate + legacy-fallback logic. When set,
+	// the auth interceptors resolve the bearer and stamp the principal
+	// into ctx (so gRPC-driven runs flow authoritatively through
+	// RunOnce); when nil, they fall back to the legacy constant-time
+	// AuthToken compare with no principal.
+	PrincipalResolver func(context.Context, string) (auth.Principal, bool)
+	// AuthConfigured reports whether auth is active (legacy secret set OR
+	// an admin token exists). Wired alongside PrincipalResolver so gRPC
+	// shares HTTP's open-mode decision: when it returns false the
+	// interceptors pass through (dev). Nil → fall back to AuthToken != "".
+	AuthConfigured func(context.Context) bool
+	BuildCommit    string
+	BuildTime      string
 }
 
 // New constructs a Server. Caller registers it with a *grpc.Server
 // (in cmd/loomcycle/main.go) and starts the listener.
 func New(cfg Config) *Server {
 	return &Server{
-		store:       cfg.Store,
-		cancelReg:   cfg.CancelReg,
-		connector:   cfg.Connector,
-		runner:      cfg.Runner,
-		authToken:   cfg.AuthToken,
-		buildCommit: cfg.BuildCommit,
-		buildTime:   cfg.BuildTime,
-		startedAt:   time.Now(),
+		store:             cfg.Store,
+		cancelReg:         cfg.CancelReg,
+		connector:         cfg.Connector,
+		runner:            cfg.Runner,
+		authToken:         cfg.AuthToken,
+		principalResolver: cfg.PrincipalResolver,
+		authConfigured:    cfg.AuthConfigured,
+		buildCommit:       cfg.BuildCommit,
+		buildTime:         cfg.BuildTime,
+		startedAt:         time.Now(),
 	}
 }
 
@@ -369,13 +391,11 @@ func (s *Server) UnaryAuthInterceptor() googlegrpc.UnaryServerInterceptor {
 		if info.FullMethod == healthFullMethod {
 			return handler(ctx, req)
 		}
-		if s.authToken == "" {
-			return handler(ctx, req)
-		}
-		if err := checkBearer(ctx, s.authToken); err != nil {
+		authedCtx, err := s.authenticate(ctx)
+		if err != nil {
 			return nil, err
 		}
-		return handler(ctx, req)
+		return handler(authedCtx, req)
 	}
 }
 
@@ -389,43 +409,80 @@ func (s *Server) StreamAuthInterceptor() googlegrpc.StreamServerInterceptor {
 		if info.FullMethod == healthFullMethod {
 			return handler(srv, ss)
 		}
-		if s.authToken == "" {
-			return handler(srv, ss)
-		}
-		if err := checkBearer(ss.Context(), s.authToken); err != nil {
+		authedCtx, err := s.authenticate(ss.Context())
+		if err != nil {
 			return err
 		}
-		return handler(srv, ss)
+		// Carry the principal-bearing ctx into the stream handler.
+		return handler(srv, &principalStream{ServerStream: ss, ctx: authedCtx})
 	}
 }
+
+// authenticate is the shared auth path for both interceptors (RFC L).
+// Open mode → pass through. Otherwise resolve the bearer to a principal
+// (stamped into the returned ctx so gRPC runs flow authoritatively
+// through RunOnce), falling back to the legacy constant-time AuthToken
+// compare when no resolver is wired.
+func (s *Server) authenticate(ctx context.Context) (context.Context, error) {
+	// Open-mode decision, mirroring the HTTP middleware.
+	if s.authConfigured != nil {
+		if !s.authConfigured(ctx) {
+			return ctx, nil
+		}
+	} else if s.authToken == "" {
+		return ctx, nil
+	}
+	bearer, ok := bearerFromMetadata(ctx)
+	if !ok {
+		return nil, status.Error(codes.Unauthenticated, "missing authorization header")
+	}
+	if s.principalResolver != nil {
+		p, ok := s.principalResolver(ctx, bearer)
+		if !ok {
+			return nil, status.Error(codes.Unauthenticated, "invalid bearer token")
+		}
+		return auth.WithPrincipal(ctx, p), nil
+	}
+	// Legacy-only fallback (no resolver wired — e.g. test harnesses).
+	if !auth.CompareBearer(bearer, s.authToken) {
+		return nil, status.Error(codes.Unauthenticated, "invalid bearer token")
+	}
+	return ctx, nil
+}
+
+// bearerFromMetadata extracts the raw token (sans "Bearer ") from the
+// gRPC `authorization` metadata header.
+func bearerFromMetadata(ctx context.Context) (string, bool) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+	values := md.Get("authorization")
+	if len(values) == 0 {
+		return "", false
+	}
+	h := values[0]
+	const pfx = "Bearer "
+	if len(h) > len(pfx) && strings.EqualFold(h[:len(pfx)], pfx) {
+		return h[len(pfx):], true
+	}
+	return "", false
+}
+
+// principalStream wraps a ServerStream to override Context() with the
+// principal-bearing ctx produced by authenticate.
+type principalStream struct {
+	googlegrpc.ServerStream
+	ctx context.Context
+}
+
+func (w *principalStream) Context() context.Context { return w.ctx }
 
 // healthFullMethod is the gRPC method string for Loomcycle.Health.
 // Hardcoded vs derived from the proto descriptor because it's a tiny
 // well-known constant and the descriptor lookup at every interceptor
 // call would be wasted work.
 const healthFullMethod = "/loomcycle.v1.Loomcycle/Health"
-
-// checkBearer validates the `authorization: Bearer <token>` metadata
-// header in constant time. Uses auth.CompareBearer (sha256 + CTC)
-// rather than subtle.ConstantTimeCompare directly so the compare is
-// constant-time regardless of input length — raw CTC returns early
-// on length mismatch and leaks the expected token's length.
-func checkBearer(ctx context.Context, want string) error {
-	md, ok := metadata.FromIncomingContext(ctx)
-	if !ok {
-		return status.Error(codes.Unauthenticated, "missing metadata")
-	}
-	values := md.Get("authorization")
-	if len(values) == 0 {
-		return status.Error(codes.Unauthenticated, "missing authorization header")
-	}
-	got := values[0]
-	expected := "Bearer " + want
-	if !auth.CompareBearer(got, expected) {
-		return status.Error(codes.Unauthenticated, "invalid bearer token")
-	}
-	return nil
-}
 
 // MustLogStartupBanner prints a one-line startup notice when the
 // gRPC server starts listening. Symmetric with the HTTP banner in

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -1,0 +1,244 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/webui"
+)
+
+// isNotFound reports whether err is a store ErrNotFound (a missing
+// token row vs. a genuine store outage — the two are handled
+// differently in resolvePrincipal: miss falls through to legacy, outage
+// fails closed).
+func isNotFound(err error) bool {
+	var nf *store.ErrNotFound
+	return errors.As(err, &nf)
+}
+
+// RFC L OSS multi-tenant authorization — the authenticated-principal
+// middleware. Replaces the v0.7.x single-shared-secret authMiddleware:
+// resolve the bearer to an auth.Principal {tenant, subject, scopes} FROM
+// THE TOKEN, stamp it into ctx, enforce the route's required scope, and
+// let the run-creation sites make the principal authoritative over the
+// wire tenant_id/user_id. The legacy LOOMCYCLE_AUTH_TOKEN keeps working
+// (synthetic default principal) until an admin-scoped token exists.
+
+// authMiddleware authenticates the request, stamps the resolved
+// principal into ctx, and enforces the route's required scope.
+//
+//   - open mode (no auth configured at all) → pass through (dev only)
+//   - unknown/expired/invalid bearer → 401 opaque (no oracle)
+//   - valid bearer but insufficient scope → 403 + RFC 6750 hint
+func (s *Server) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.authConfigured(r.Context()) {
+			// No shared secret AND no tokens → open mode (dev). Startup
+			// logged a warning. No principal is stamped; run-creation
+			// sites fall back to the wire user_id/tenant_id unchanged.
+			next.ServeHTTP(w, r)
+			return
+		}
+		bearer, ok := extractBearer(r)
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		p, ok := s.resolvePrincipal(r.Context(), bearer)
+		if !ok {
+			// Opaque — never distinguish "unknown" from "expired" from
+			// "wrong" (no oracle). Detail only under LOOMCYCLE_AUTH_VERBOSE.
+			if s.authVerbose() {
+				log.Printf("auth: rejected bearer (no matching token / expired / wrong secret)")
+			}
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		if required := requiredScopeFor(r.Method, r.URL.Path); required != "" && !auth.HasScope(p.Scopes, required) {
+			// Scope names are public; token state is not.
+			w.Header().Set("WWW-Authenticate", `Bearer scope="`+required+`"`)
+			http.Error(w, "insufficient scope", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(auth.WithPrincipal(r.Context(), p)))
+	})
+}
+
+// ResolvePrincipal is the exported wrapper main.go wires into the gRPC
+// adapter's Config.PrincipalResolver so both transports share identical
+// token resolution (RFC L). Returns (_, false) for unknown/expired/invalid.
+func (s *Server) ResolvePrincipal(ctx context.Context, bearer string) (auth.Principal, bool) {
+	return s.resolvePrincipal(ctx, bearer)
+}
+
+// AuthConfigured is the exported wrapper for the gRPC adapter's
+// open-mode decision (RFC L) — true when a legacy secret is set or an
+// admin token exists.
+func (s *Server) AuthConfigured(ctx context.Context) bool {
+	return s.authConfigured(ctx)
+}
+
+// extractBearer returns the raw token (sans "Bearer ") from the
+// Authorization header, or the Web-UI session cookie value as a
+// fallback. A present-but-malformed Authorization header is a miss.
+func extractBearer(r *http.Request) (string, bool) {
+	if h := r.Header.Get("Authorization"); h != "" {
+		const pfx = "Bearer "
+		if len(h) > len(pfx) && strings.EqualFold(h[:len(pfx)], pfx) {
+			return h[len(pfx):], true
+		}
+		return "", false
+	}
+	if c, err := r.Cookie(webui.SessionCookie); err == nil && c.Value != "" {
+		return c.Value, true
+	}
+	return "", false
+}
+
+// authConfigured reports whether authentication is active. True when a
+// legacy shared secret is set, or any admin-scoped OperatorTokenDef
+// exists. When neither holds, the server is in dev open-mode.
+//
+// (A deployment with ONLY narrow tokens and no legacy secret + no admin
+// token can't be bootstrapped — the admin endpoints that create tokens
+// require auth — so the admin-count check is sufficient in practice.)
+func (s *Server) authConfigured(ctx context.Context) bool {
+	if s.cfg.Env.AuthToken != "" {
+		return true
+	}
+	if s.store == nil {
+		return false
+	}
+	n, err := s.store.OperatorTokenDefCountActiveAdmin(ctx)
+	return err == nil && n > 0
+}
+
+func (s *Server) authVerbose() bool {
+	return s.cfg.Env.AuthVerbose
+}
+
+// resolvePrincipal maps a raw bearer to a principal. Token substrate
+// first (indexed peppered-hash lookup, honoring the rotation grace
+// window), then the legacy LOOMCYCLE_AUTH_TOKEN fallback (disabled once
+// an admin-scoped token exists — the no-lockout migration gate). Returns
+// (_, false) for unknown/expired/invalid — the caller maps that to an
+// opaque 401. NEVER fails open to the legacy token on a substrate error.
+func (s *Server) resolvePrincipal(ctx context.Context, bearer string) (auth.Principal, bool) {
+	if bearer == "" {
+		return auth.Principal{}, false
+	}
+	if s.store != nil {
+		hash := auth.HashToken(s.cfg.Env.OperatorTokenPepper, bearer)
+		row, err := s.store.OperatorTokenDefGetByTokenHash(ctx, hash)
+		if err == nil {
+			// Valid iff never retired, or still inside the grace window.
+			if row.RetiredAt.IsZero() || time.Now().Before(row.RetiredAt) {
+				return auth.Principal{
+					TenantID:   row.TenantID,
+					Subject:    row.Subject,
+					Scopes:     row.AllowedScopes,
+					TokenDefID: row.DefID,
+				}, true
+			}
+			return auth.Principal{}, false // expired → opaque 401, no legacy fall-open
+		}
+		// Not found (ErrNotFound) → fall through to legacy. Any OTHER
+		// store error is a genuine outage: fail closed below (we do not
+		// reach the legacy branch with a usable substrate state).
+		if !isNotFound(err) {
+			if s.authVerbose() {
+				log.Printf("auth: token-substrate lookup error (failing closed): %v", err)
+			}
+			return auth.Principal{}, false
+		}
+	}
+	// Legacy shared-secret fallback.
+	if s.cfg.Env.AuthToken != "" && auth.CompareBearer(bearer, s.cfg.Env.AuthToken) {
+		if s.legacyFallbackDisabled(ctx) {
+			return auth.Principal{}, false
+		}
+		return auth.Principal{
+			TenantID: "default",
+			Subject:  "default",
+			Scopes:   []string{auth.ScopeAdmin},
+			Legacy:   true,
+		}, true
+	}
+	return auth.Principal{}, false
+}
+
+// legacyFallbackDisabled reports whether the LOOMCYCLE_AUTH_TOKEN path is
+// retired — true once at least one admin-scoped OperatorTokenDef exists
+// (Decision 10/12). On a store error we keep the legacy path ENABLED
+// (return false): the alternative would strand the operator on a
+// transient DB blip.
+func (s *Server) legacyFallbackDisabled(ctx context.Context) bool {
+	if s.store == nil {
+		return false
+	}
+	n, err := s.store.OperatorTokenDefCountActiveAdmin(ctx)
+	return err == nil && n > 0
+}
+
+// applyPrincipal makes the authenticated principal authoritative over
+// the caller-asserted wire tenant_id/user_id (Decision 5). Returns the
+// authoritative (tenant, subject); on open/un-authed paths returns the
+// wire values unchanged. A disagreement is honored server-side and
+// logged kind=identity_overridden for triage.
+func (s *Server) applyPrincipal(ctx context.Context, wireTenant, wireUser string) (tenant, subject string) {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok {
+		return wireTenant, wireUser
+	}
+	if wireTenant != "" && wireTenant != p.TenantID {
+		log.Printf("auth: identity_overridden kind=tenant wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)
+	}
+	if wireUser != "" && wireUser != p.Subject {
+		log.Printf("auth: identity_overridden kind=subject wire=%q principal=%q token_def=%q", wireUser, p.Subject, p.TokenDefID)
+	}
+	return p.TenantID, p.Subject
+}
+
+// requiredScopeFor maps an HTTP (method, path) to the scope a caller
+// must hold. Empty string = any authenticated principal (no specific
+// scope). substrate:admin satisfies everything (see auth.HasScope), so
+// the default admin/legacy token works on every route; narrow tokens
+// get the specific gate. Conservative by design: ambiguous routes fall
+// through to "" rather than risk locking a legitimate narrow token out.
+func requiredScopeFor(method, path string) string {
+	switch {
+	// Consumer LLM gateway / OpenAI-compat shims — NOT an admin surface;
+	// any authenticated principal may drive inference.
+	case path == "/v1/_llm/chat" || path == "/v1/chat/completions" || path == "/v1/embeddings":
+		return ""
+	// Everything else under /v1/_* is operator-admin: the substrate Def
+	// endpoints, runtime admin (pause/resume/state/snapshots/metrics),
+	// resolver, users, memory admin, channels admin.
+	case strings.HasPrefix(path, "/v1/_"):
+		return auth.ScopeAdmin
+	// Operator hook management.
+	case strings.HasPrefix(path, "/v1/hooks"):
+		return auth.ScopeAdmin
+	// Run creation (fresh run + session continuation message).
+	case method == http.MethodPost && path == "/v1/runs":
+		return auth.ScopeRunsCreate
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/sessions/") && strings.HasSuffix(path, "/messages"):
+		return auth.ScopeRunsCreate
+	// Cancel a run — a write on run state.
+	case method == http.MethodDelete && strings.HasPrefix(path, "/v1/agents/"):
+		return auth.ScopeRunsCreate
+	// Run / agent / session reads.
+	case method == http.MethodGet && (strings.HasPrefix(path, "/v1/agents/") ||
+		strings.HasPrefix(path, "/v1/users/") ||
+		strings.HasPrefix(path, "/v1/sessions/")):
+		return auth.ScopeRunsRead
+	default:
+		return ""
+	}
+}

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -1,0 +1,223 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+const testTokenPepper = "pep-rfcl"
+
+// tokenAuthServer builds a Server backed by in-memory SQLite + a legacy
+// AuthToken + a token pepper — enough to exercise resolvePrincipal and
+// the principal-stamping middleware.
+func tokenAuthServer(t *testing.T, legacy string) (*Server, store.Store) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	hookReg := hooks.NewRegistry()
+	cfg := &config.Config{}
+	cfg.Env.AuthToken = legacy
+	cfg.Env.OperatorTokenPepper = testTokenPepper
+	s := &Server{
+		cfg:            cfg,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+		store:          st,
+	}
+	return s, st
+}
+
+func seedToken(t *testing.T, st store.Store, plaintext, tenant, subject string, scopes []string, retiredAt time.Time) {
+	t.Helper()
+	_, err := st.OperatorTokenDefCreate(context.Background(), store.OperatorTokenDefRow{
+		DefID:         "def_" + subject,
+		Name:          subject,
+		TenantID:      tenant,
+		Subject:       subject,
+		TokenHash:     auth.HashToken(testTokenPepper, plaintext),
+		AllowedScopes: scopes,
+		RetiredAt:     retiredAt,
+	})
+	if err != nil {
+		t.Fatalf("seed token: %v", err)
+	}
+}
+
+func TestResolvePrincipal_TokenSubstrateHit(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	seedToken(t, st, "lct_alice", "acme", "alice", []string{auth.ScopeRunsCreate, auth.ScopeRunsRead}, time.Time{})
+
+	p, ok := s.resolvePrincipal(context.Background(), "lct_alice")
+	if !ok {
+		t.Fatal("expected resolution")
+	}
+	if p.TenantID != "acme" || p.Subject != "alice" || p.Legacy {
+		t.Errorf("got %+v", p)
+	}
+	if !auth.HasScope(p.Scopes, auth.ScopeRunsCreate) {
+		t.Errorf("scopes = %v", p.Scopes)
+	}
+}
+
+func TestResolvePrincipal_UnknownTokenFalls(t *testing.T) {
+	s, _ := tokenAuthServer(t, "legacy")
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_nope"); ok {
+		t.Error("unknown token must not resolve")
+	}
+}
+
+func TestResolvePrincipal_ExpiredVsGrace(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	// Expired: retired_at in the past → no resolution.
+	seedToken(t, st, "lct_old", "acme", "old", []string{auth.ScopeAdmin}, time.Now().Add(-time.Hour))
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_old"); ok {
+		t.Error("expired token must not resolve")
+	}
+	// Grace: retired_at in the future → still valid.
+	seedToken(t, st, "lct_grace", "acme", "grace", []string{auth.ScopeAdmin}, time.Now().Add(time.Hour))
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_grace"); !ok {
+		t.Error("token within the rotation grace window must still resolve")
+	}
+}
+
+func TestResolvePrincipal_LegacyFallbackAndNoLockout(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy-secret")
+	// No admin token yet → legacy works, yields the synthetic default
+	// admin principal.
+	p, ok := s.resolvePrincipal(context.Background(), "legacy-secret")
+	if !ok || !p.Legacy || p.TenantID != "default" || p.Subject != "default" {
+		t.Fatalf("legacy fallback: ok=%v p=%+v", ok, p)
+	}
+	if !auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		t.Error("legacy principal must be admin")
+	}
+	// Once an admin-scoped token exists, the legacy fallback is disabled.
+	seedToken(t, st, "lct_admin", "acme", "ops", []string{auth.ScopeAdmin}, time.Time{})
+	if _, ok := s.resolvePrincipal(context.Background(), "legacy-secret"); ok {
+		t.Error("legacy fallback must be disabled once an admin token exists (no-lockout gate)")
+	}
+	// ...but the admin token itself still resolves.
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_admin"); !ok {
+		t.Error("admin token must resolve")
+	}
+}
+
+func TestRequiredScopeFor(t *testing.T) {
+	cases := []struct {
+		method, path, want string
+	}{
+		{"POST", "/v1/runs", auth.ScopeRunsCreate},
+		{"POST", "/v1/sessions/s_1/messages", auth.ScopeRunsCreate},
+		{"DELETE", "/v1/agents/a_1", auth.ScopeRunsCreate},
+		{"GET", "/v1/agents/a_1", auth.ScopeRunsRead},
+		{"GET", "/v1/users/alice/agents", auth.ScopeRunsRead},
+		{"POST", "/v1/_operatortokendef", auth.ScopeAdmin},
+		{"GET", "/v1/_resolver", auth.ScopeAdmin},
+		{"POST", "/v1/_pause", auth.ScopeAdmin},
+		{"DELETE", "/v1/hooks/h_1", auth.ScopeAdmin},
+		// Consumer gateway endpoints are NOT admin.
+		{"POST", "/v1/_llm/chat", ""},
+		{"POST", "/v1/chat/completions", ""},
+		{"POST", "/v1/embeddings", ""},
+		{"GET", "/healthz", ""},
+	}
+	for _, c := range cases {
+		if got := requiredScopeFor(c.method, c.path); got != c.want {
+			t.Errorf("requiredScopeFor(%s %s) = %q, want %q", c.method, c.path, got, c.want)
+		}
+	}
+}
+
+func TestAuthMiddleware_403InsufficientScope(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	// A narrow token: runs:read only.
+	seedToken(t, st, "lct_ro", "acme", "ro", []string{auth.ScopeRunsRead}, time.Time{})
+
+	var reached bool
+	h := s.authMiddleware(passthroughHandler(&reached))
+	// POST /v1/runs requires runs:create — the read-only token is refused.
+	req := httptest.NewRequest("POST", "/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer lct_ro")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+	if reached {
+		t.Error("handler should not have been reached")
+	}
+	if wa := rec.Header().Get("WWW-Authenticate"); wa != `Bearer scope="runs:create"` {
+		t.Errorf("WWW-Authenticate = %q, want the runs:create hint", wa)
+	}
+}
+
+func TestAuthMiddleware_StampsPrincipalAndAllowsScopedRoute(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	seedToken(t, st, "lct_creator", "acme", "alice", []string{auth.ScopeRunsCreate}, time.Time{})
+
+	var gotTenant, gotSubject string
+	h := s.authMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if p, ok := auth.PrincipalFromContext(r.Context()); ok {
+			gotTenant, gotSubject = p.TenantID, p.Subject
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest("POST", "/v1/runs", nil)
+	req.Header.Set("Authorization", "Bearer lct_creator")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotTenant != "acme" || gotSubject != "alice" {
+		t.Errorf("principal in ctx = (%q,%q), want (acme,alice)", gotTenant, gotSubject)
+	}
+}
+
+func TestAuthMiddleware_401UnknownToken(t *testing.T) {
+	s, _ := tokenAuthServer(t, "legacy")
+	var reached bool
+	h := s.authMiddleware(passthroughHandler(&reached))
+	req := httptest.NewRequest("GET", "/v1/agents/x", nil)
+	req.Header.Set("Authorization", "Bearer lct_unknown")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized || reached {
+		t.Errorf("status = %d reached = %v, want 401 + not reached", rec.Code, reached)
+	}
+}
+
+func TestApplyPrincipal_OverridesWireAndFallsBack(t *testing.T) {
+	s, _ := tokenAuthServer(t, "legacy")
+	// With a principal, the wire tenant/user are ignored.
+	ctx := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "alice"})
+	tenant, subject := s.applyPrincipal(ctx, "forged-tenant", "forged-bob")
+	if tenant != "acme" || subject != "alice" {
+		t.Errorf("override = (%q,%q), want (acme,alice) — wire claims must be ignored", tenant, subject)
+	}
+	// Without a principal (open / un-authed), the wire values pass through.
+	tenant, subject = s.applyPrincipal(context.Background(), "wire-t", "wire-u")
+	if tenant != "wire-t" || subject != "wire-u" {
+		t.Errorf("no-principal = (%q,%q), want the wire values", tenant, subject)
+	}
+}

--- a/internal/api/http/embeddings_compat.go
+++ b/internal/api/http/embeddings_compat.go
@@ -11,6 +11,8 @@ import (
 	"math"
 	"net/http"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 )
 
 // embeddings_compat.go — v0.11.4 OpenAI Embeddings compatibility
@@ -83,11 +85,12 @@ func (s *Server) handleEmbeddings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Per-user quota acquisition. Empty user_id bypasses the
-	// per-user cap (operator-scoped "anonymous" embeddings calls
-	// go to the global semaphore only). Mirrors the chat-
-	// completions gateway exactly.
-	release, err := s.sem.AcquireForUser(r.Context(), req.User)
+	// Per-subject quota acquisition. RFC L: the authenticated
+	// principal's Subject is the authoritative fairness key when
+	// present; the wire user is the open/un-authed fallback. Empty
+	// key bypasses the per-user cap. Mirrors the chat-completions
+	// gateway exactly.
+	release, err := s.sem.AcquireForUser(r.Context(), auth.SubjectForFairness(r.Context(), req.User))
 	if err != nil {
 		writeQuotaError(w, err)
 		return

--- a/internal/api/http/llm_gateway.go
+++ b/internal/api/http/llm_gateway.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 )
@@ -128,10 +129,12 @@ func (s *Server) prepareGatewayDispatch(w http.ResponseWriter, r *http.Request, 
 		return gatewayDispatch{}, false
 	}
 
-	// Per-user quota acquisition. Empty user_id bypasses the per-user
-	// cap (operator-scoped "anonymous" gateway calls go to the global
-	// semaphore only).
-	release, err := s.sem.AcquireForUser(r.Context(), req.UserID)
+	// Per-subject quota acquisition. RFC L: when an authenticated
+	// principal is present its Subject is the authoritative fairness key
+	// (a caller can't forge a different user_id to dodge their cap); the
+	// wire user_id is only the fallback for open / un-authed mode. Empty
+	// key bypasses the per-user cap (global semaphore only).
+	release, err := s.sem.AcquireForUser(r.Context(), auth.SubjectForFairness(r.Context(), req.UserID))
 	if err != nil {
 		writeQuotaError(w, err)
 		return gatewayDispatch{}, false

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
@@ -1317,6 +1316,15 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	effectiveAgentName := in.Agent
 	effectiveTenantID := in.TenantID
 	effectiveUserID := in.UserID
+	// RFC L: on an authenticated entry (gRPC interceptor stamps the
+	// principal), the principal is authoritative over the wire fields
+	// (Decision 5). Fresh runs only — a continuation inherits the
+	// session's identity, set authoritatively when the session was
+	// created. Un-authed programmatic callers (scheduler / webhook /
+	// A2A) carry no principal and keep their Def-supplied identity.
+	if !isContinuation {
+		effectiveTenantID, effectiveUserID = s.applyPrincipal(ctx, in.TenantID, in.UserID)
+	}
 	var priorMessages []providers.Message
 
 	if isContinuation {
@@ -1527,6 +1535,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          effectiveUserID,
+		TenantID:        effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
 		AgentID:         agentID,
 		UserTier:        in.UserTier,
 		UserBearer:      in.UserBearer,      // v0.8.x: per-run MCP bearer
@@ -2370,6 +2379,14 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		req.ParentContext = nil
 	}
 
+	// RFC L: on authenticated routes the resolved principal is
+	// authoritative over the caller-asserted wire tenant_id/user_id
+	// (Decision 5). Overriding them here makes the fairness key (the
+	// AcquireForUser call below), the session's tenant, the run-row
+	// attribution, and the threaded RunIdentity all authority-derived in
+	// one place. Open/un-authed paths leave the wire values unchanged.
+	req.TenantID, req.UserID = s.applyPrincipal(r.Context(), req.TenantID, req.UserID)
+
 	providerID, model, effort, err := s.resolveAgent(req.Agent, req.UserTier)
 	if err != nil {
 		http.Error(w, err.Error(), resolveErrorToStatus(err))
@@ -2609,6 +2626,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// any sub-runs it spawns.
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          req.UserID,
+		TenantID:        req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
 		AgentID:         agentID,
 		UserTier:        req.UserTier,
 		UserBearer:      req.UserBearer,      // v0.8.x: per-run MCP bearer
@@ -2966,6 +2984,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          sess.UserID,
+		TenantID:        sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
 		AgentID:         agentID,
 		UserTier:        body.UserTier,
 		UserBearer:      body.UserBearer,      // v0.8.x: per-run MCP bearer
@@ -3561,6 +3580,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	subCtx := tools.WithAgentTools(subRunCtx, toolNames(subTools))
 	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
 		UserID:          parentIdentity.UserID,
+		TenantID:        parentIdentity.TenantID, // RFC L: sub-agents inherit the parent's authoritative tenant (same isolation boundary)
 		AgentID:         subAgentID,
 		UserTier:        parentIdentity.UserTier,              // v0.8.2: sub-agents inherit parent's user_tier
 		AgentDefID:      defID,                                // v0.8.7: surface pinned def_id via Context.self
@@ -4377,48 +4397,11 @@ func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, 
 	s.publishRunState(meta, publishStatus, res.StopReason, errMsg)
 }
 
-// authMiddleware enforces LOOMCYCLE_AUTH_TOKEN bearer auth, except for /healthz which
-// is mounted bare (this middleware is only wrapped around /v1/* routes).
-//
-// Comparison uses auth.CompareBearer, which hashes both sides to a
-// fixed-length digest before subtle.ConstantTimeCompare so the
-// compare is constant-time regardless of input length (raw
-// ConstantTimeCompare returns early on length mismatch and leaks
-// the expected token's length).
-func (s *Server) authMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if s.cfg.Env.AuthToken == "" {
-			// No token configured = open mode (dev only). Startup logged a
-			// warning so the operator knows.
-			next.ServeHTTP(w, r)
-			return
-		}
-		want := "Bearer " + s.cfg.Env.AuthToken
-		// Standard bearer-header path (every adapter / curl / API client).
-		if got := r.Header.Get("Authorization"); got != "" {
-			if auth.CompareBearer(got, want) {
-				next.ServeHTTP(w, r)
-				return
-			}
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
-			return
-		}
-		// Cookie fallback for the embedded Web UI (v0.7.3). The /ui
-		// landing handler converts a `?token=...` query into a
-		// loomcycle_session HttpOnly cookie; subsequent /v1 calls
-		// from the SPA carry the cookie automatically (same-origin
-		// fetch). Operators using bearer headers via curl / SDKs are
-		// unaffected.
-		if cookie, err := r.Cookie(webui.SessionCookie); err == nil && cookie.Value != "" {
-			cookieBearer := "Bearer " + cookie.Value
-			if auth.CompareBearer(cookieBearer, want) {
-				next.ServeHTTP(w, r)
-				return
-			}
-		}
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-	})
-}
+// authMiddleware moved to auth_principal.go (RFC L): it now resolves the
+// bearer to an auth.Principal (tenant + subject + scopes), stamps it into
+// ctx, and enforces the route's required scope. The legacy
+// LOOMCYCLE_AUTH_TOKEN keeps working via the principal-resolution
+// fallback until an admin-scoped OperatorTokenDef exists.
 
 // validIdent reports whether s is a valid user_id or agent_id. Charset
 // matches the spec: [A-Za-z0-9_-] with length 1..128. Used to refuse

--- a/internal/auth/principal.go
+++ b/internal/auth/principal.go
@@ -1,0 +1,63 @@
+package auth
+
+import "context"
+
+// RFC L OSS multi-tenant authorization — the authoritative principal.
+//
+// The auth middleware resolves the inbound bearer to a Principal FROM
+// THE TOKEN and stamps it into ctx. Downstream, the run-creation sites
+// copy Principal.Subject → the run's user_id and Principal.TenantID →
+// the run's tenant, so the keys that isolation already uses (fairness,
+// memory tenancy, attribution, audit) become authority-derived rather
+// than caller-asserted. See rfcs/oss-multi-tenant-authorization.md.
+
+// Principal is the authenticated identity behind a bearer token.
+type Principal struct {
+	// TenantID is the authoritative data-isolation boundary. Always
+	// non-empty for a resolved principal ("default" for the legacy
+	// LOOMCYCLE_AUTH_TOKEN fallback).
+	TenantID string
+	// Subject is the authoritative per-actor id — the run's user_id and
+	// the fairness key. Distinct subjects under one tenant get distinct
+	// fairness caps + attribution while sharing the tenant's data.
+	Subject string
+	// Scopes is the granted capability set (closed catalog). substrate:admin
+	// is a superuser scope (see HasScope).
+	Scopes []string
+	// TokenDefID is the operator_token_defs row id (empty for legacy).
+	TokenDefID string
+	// TokenSuffix is the 6-char grep handle for log correlation (never
+	// the secret; empty for legacy).
+	TokenSuffix string
+	// Legacy is true when this principal came from the LOOMCYCLE_AUTH_TOKEN
+	// shared-secret fallback rather than an OperatorTokenDef row.
+	Legacy bool
+}
+
+type ctxKeyPrincipal struct{}
+
+// WithPrincipal stamps the resolved principal into ctx.
+func WithPrincipal(ctx context.Context, p Principal) context.Context {
+	return context.WithValue(ctx, ctxKeyPrincipal{}, p)
+}
+
+// PrincipalFromContext returns the stamped principal and whether one was
+// present. Absent in open mode (no auth configured) and on un-authed
+// internal paths — callers fall back to wire/explicit values.
+func PrincipalFromContext(ctx context.Context) (Principal, bool) {
+	p, ok := ctx.Value(ctxKeyPrincipal{}).(Principal)
+	return p, ok
+}
+
+// SubjectForFairness returns the authoritative fairness key: the
+// principal's Subject when one is stamped, else the supplied fallback
+// (the wire user_id, used in open mode / un-authed internal paths). This
+// is what makes the per-subject fairness cap a real boundary — a caller
+// can no longer forge a different user_id to dodge their cap, because on
+// authed routes the Subject comes from the token, not the request body.
+func SubjectForFairness(ctx context.Context, fallback string) string {
+	if p, ok := PrincipalFromContext(ctx); ok && p.Subject != "" {
+		return p.Subject
+	}
+	return fallback
+}

--- a/internal/auth/principal_test.go
+++ b/internal/auth/principal_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPrincipalContext_RoundTrip(t *testing.T) {
+	p := Principal{TenantID: "acme", Subject: "alice", Scopes: []string{ScopeRunsCreate}}
+	ctx := WithPrincipal(context.Background(), p)
+	got, ok := PrincipalFromContext(ctx)
+	if !ok {
+		t.Fatal("principal not found in ctx")
+	}
+	if got.TenantID != "acme" || got.Subject != "alice" {
+		t.Errorf("got %+v", got)
+	}
+	if _, ok := PrincipalFromContext(context.Background()); ok {
+		t.Error("bare ctx should carry no principal")
+	}
+}
+
+func TestSubjectForFairness(t *testing.T) {
+	// Principal present → its Subject wins over the wire fallback.
+	ctx := WithPrincipal(context.Background(), Principal{Subject: "alice"})
+	if got := SubjectForFairness(ctx, "wire-bob"); got != "alice" {
+		t.Errorf("got %q, want alice (principal subject authoritative)", got)
+	}
+	// No principal → the wire fallback is used (open / un-authed mode).
+	if got := SubjectForFairness(context.Background(), "wire-bob"); got != "wire-bob" {
+		t.Errorf("got %q, want wire-bob (fallback)", got)
+	}
+	// Principal with empty subject → fallback (defensive).
+	ctx2 := WithPrincipal(context.Background(), Principal{Subject: ""})
+	if got := SubjectForFairness(ctx2, "wire-bob"); got != "wire-bob" {
+		t.Errorf("got %q, want wire-bob (empty subject falls back)", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1275,7 +1275,11 @@ type Env struct {
 	// AuditLogPath is the JSONL sink for OperatorTokenDef mutations
 	// (RFC L). Empty = no file audit (a NopSink is wired).
 	AuditLogPath string
-	DataDir      string
+	// AuthVerbose (LOOMCYCLE_AUTH_VERBOSE=1) logs a server-side reason
+	// when a bearer is rejected. Off by default; the wire 401 stays
+	// opaque regardless (no oracle) — this only affects local logs.
+	AuthVerbose bool
+	DataDir     string
 	// ReadRoot is the sandbox root for the built-in Read tool. Empty by
 	// default — the tool is registered but rejects every call until set.
 	ReadRoot string
@@ -1897,6 +1901,7 @@ func Load(path string) (*Config, error) {
 		AuthToken:                os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
 		OperatorTokenPepper:      os.Getenv("LOOMCYCLE_OPERATOR_TOKEN_PEPPER"),
 		AuditLogPath:             os.Getenv("LOOMCYCLE_AUDIT_LOG_PATH"),
+		AuthVerbose:              os.Getenv("LOOMCYCLE_AUTH_VERBOSE") == "1",
 		DataDir:                  getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
 		ReadRoot:                 os.Getenv("LOOMCYCLE_READ_ROOT"),
 		WriteRoot:                os.Getenv("LOOMCYCLE_WRITE_ROOT"),

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -219,18 +219,18 @@ func (m *Memory) buildMem9(ctx context.Context, name string, def config.MemoryBa
 // package's resolved Tenancy + the tenant_id used for env-pattern
 // resolution. {tenant_id} is substituted from the run's tenant.
 //
-// TENANT SOURCE (assumption, surfaced loudly): loomcycle's
-// RunIdentityValue carries no dedicated tenant field, so we use
-// tools.RunIdentity(ctx).UserID as {tenant_id}. The UserID is
-// operator/caller-authoritative (the API layer stamps it; it is NEVER
-// model input — same trust posture as the Memory scope_id), so using it
-// as the tenant partition key does not open a model-controlled
-// cross-tenant path. The RFC's worked example uses per-tenant user
-// identities (alice@tenant-a, bob@tenant-b); single-tenant deployments
-// have one stable UserID and one resolved key. If a first-class tenant
-// field lands on RunIdentityValue later, change ONLY this function.
+// TENANT SOURCE: the authoritative tools.RunIdentity(ctx).TenantID
+// (RFC L). On authenticated routes this is set from the resolved
+// auth.Principal's tenant — which OVERRIDES the wire tenant_id, so it is
+// a real isolation boundary, not a forgeable label. Distinct subjects
+// under one tenant SHARE this memory partition (they collaborate within
+// the tenant); isolation is per-tenant, NOT per-user (that was the
+// pre-RFC-L shape, which keyed on UserID). For legacy single-token
+// deployments the principal tenant is "default"; in dev open-mode the
+// tenant may be empty, in which case key_per_tenant resolves the "" key
+// and shared_key_with_prefix refuses (the backstop below).
 func resolveTenancy(ctx context.Context, ts config.MemoryBackendTenancy) (mem9.Tenancy, string, error) {
-	tenantID := tools.RunIdentity(ctx).UserID
+	tenantID := tools.RunIdentity(ctx).TenantID
 
 	switch ts.Kind {
 	case "", "key_per_tenant":
@@ -288,7 +288,7 @@ func (m *Memory) mem9CredentialResolver(def config.MemoryBackend, ts config.Memo
 		// tenancy env_pattern (per-tenant key); otherwise the static
 		// api_key_env. Re-resolve the tenant per call so a long-lived
 		// resolver always reflects the current run's identity.
-		tenantID := tools.RunIdentity(ctx).UserID
+		tenantID := tools.RunIdentity(ctx).TenantID
 		envName := def.Config.APIKeyEnv
 		if ts.Kind == "key_per_tenant" && ts.EnvPattern != "" {
 			envName = strings.ReplaceAll(ts.EnvPattern, "{tenant_id}", tenantID)

--- a/internal/tools/builtin/memory_mem9_creds_test.go
+++ b/internal/tools/builtin/memory_mem9_creds_test.go
@@ -93,7 +93,7 @@ func TestMem9Cred_PerTenantEnvPattern(t *testing.T) {
 	}
 	resolver := m.mem9CredentialResolver(def, def.TenancyStrategy, "")
 
-	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{UserID: "alice"})
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "alice"})
 	got, err := resolver(ctx)
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
@@ -107,7 +107,7 @@ func TestMem9Cred_PerTenantEnvPattern(t *testing.T) {
 // shared_key_with_prefix substitutes {tenant_id} into the key prefix.
 func TestMem9Tenancy_SharedPrefixSubstitutesTenant(t *testing.T) {
 	ts := config.MemoryBackendTenancy{Kind: "shared_key_with_prefix", PrefixPattern: "tenant-{tenant_id}::"}
-	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{UserID: "bob"})
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "bob"})
 
 	tenancy, tenant, err := resolveTenancy(ctx, ts)
 	if err != nil {

--- a/internal/tools/builtin/memory_tenancy_leak_test.go
+++ b/internal/tools/builtin/memory_tenancy_leak_test.go
@@ -18,7 +18,8 @@ import (
 // Regression-grade: pre-fix the empty/token-less branch fell through and
 // returned mem9.Tenancy{KeyPrefix: ""} with no error.
 func TestResolveTenancy_SharedPrefixEmptyOrTokenlessRejected(t *testing.T) {
-	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{UserID: "alice"})
+	// RFC L: tenancy keys on the authoritative TenantID (not UserID).
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: "alice"})
 	for _, pat := range []string{"", "static-no-token::", "tenant-::"} {
 		ts := config.MemoryBackendTenancy{Kind: "shared_key_with_prefix", PrefixPattern: pat}
 		tenancy, _, err := resolveTenancy(ctx, ts)

--- a/internal/tools/builtin/operatortokendef.go
+++ b/internal/tools/builtin/operatortokendef.go
@@ -51,7 +51,12 @@ type OperatorTokenDef struct {
 	MaxScopes int
 }
 
-var operatorTokenNameRe = regexp.MustCompile(`^[a-zA-Z0-9_.-]{1,64}$`)
+// operatorTokenNameRe constrains name / tenant_id / subject. RFC L:
+// the subject becomes the authoritative user_id (it overrides the wire
+// user_id at run creation), and user_id must satisfy validIdent
+// ([A-Za-z0-9_-]) so it is safe as a URL path segment + fairness key —
+// hence no '.' or ':' here. Tenants/names share the charset for symmetry.
+var operatorTokenNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,64}$`)
 
 const operatorTokenDefDescription = `Mint, rotate, retire, and inspect operator auth tokens (RFC L). ` +
 	`Each token binds a principal {tenant_id, subject, allowed_scopes}. ` +
@@ -65,7 +70,7 @@ const operatorTokenDefInputSchema = `{
     "name":       {"type": "string", "description": "Token name (required for create/list; create/rotate/retire accept name or def_id)."},
     "def_id":     {"type": "string", "description": "Existing def_id (for get; alternative target for rotate/retire)."},
     "tenant_id":  {"type": "string", "description": "Authoritative tenant (required for create)."},
-    "subject":    {"type": "string", "description": "Authoritative subject (optional for create; defaults to tok:<name>)."},
+    "subject":    {"type": "string", "description": "Authoritative subject (optional for create; defaults to tok-<name>)."},
     "scopes":     {"type": "array", "items": {"type": "string"}, "description": "Allowed scopes from the closed catalog (create; default [substrate:admin])."},
     "grace_seconds": {"type": "integer", "description": "Rotation grace window override (rotate)."}
   },
@@ -145,22 +150,23 @@ func (s *OperatorTokenDef) execCreate(ctx context.Context, in operatorTokenDefIn
 		return errResult("create: missing required field: name"), nil
 	}
 	if !operatorTokenNameRe.MatchString(in.Name) {
-		return errResult(fmt.Sprintf("create: name %q invalid (must match [a-zA-Z0-9_.-]{1,64})", in.Name)), nil
+		return errResult(fmt.Sprintf("create: name %q invalid (must match [a-zA-Z0-9_-]{1,64})", in.Name)), nil
 	}
 	if in.TenantID == "" {
 		return errResult("create: missing required field: tenant_id"), nil
 	}
 	if !operatorTokenNameRe.MatchString(in.TenantID) {
-		return errResult(fmt.Sprintf("create: tenant_id %q invalid (must match [a-zA-Z0-9_.-]{1,64})", in.TenantID)), nil
+		return errResult(fmt.Sprintf("create: tenant_id %q invalid (must match [a-zA-Z0-9_-]{1,64})", in.TenantID)), nil
 	}
 	subject := in.Subject
 	if subject == "" {
 		// Decision 4: default to a stable per-token id so attribution /
 		// fairness / audit are still distinct even without an explicit
-		// subject.
-		subject = "tok:" + in.Name
+		// subject. Hyphen (not colon) so the derived user_id stays
+		// validIdent-safe — it overrides the wire user_id (RFC L).
+		subject = "tok-" + in.Name
 	} else if !operatorTokenNameRe.MatchString(subject) {
-		return errResult(fmt.Sprintf("create: subject %q invalid (must match [a-zA-Z0-9_.-]{1,64})", subject)), nil
+		return errResult(fmt.Sprintf("create: subject %q invalid (must match [a-zA-Z0-9_-]{1,64})", subject)), nil
 	}
 	scopes := in.Scopes
 	if len(scopes) == 0 {

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -201,6 +201,14 @@ type ctxKeyRunIdentity struct{}
 type RunIdentityValue struct {
 	UserID  string
 	AgentID string
+	// TenantID is the RFC L authoritative data-isolation boundary. On
+	// authenticated routes it is set from the resolved auth.Principal's
+	// TenantID (which overrides the wire tenant_id); for legacy /
+	// single-tenant deployments it is "default" (or empty, in which case
+	// memory's resolveTenancy backstop applies). It is the key memory
+	// tenancy partitions on (NOT UserID) — distinct from the per-actor
+	// Subject (which lands in UserID). Sub-agents inherit it unchanged.
+	TenantID string
 	// UserTier is the v0.8.2 user-facing-tier policy name applied to
 	// this run (e.g. "free" / "low" / "medium" / "high"). Sub-agents
 	// inherit it via ctx so the resolver applies the same tier


### PR DESCRIPTION
**PR 2 of 3** in the RFC L series — **the trust-boundary shift**. PR 1 (#323) stored the tokens; this PR makes them *authoritative*. Builds on `main` (PR 1 merged).

## Why

The v0.7.x middleware was a pure allow/deny check that stamped **no identity** into `ctx`; `runRequest.tenant_id` / `user_id` were caller-asserted labels — spoofable, and not isolation boundaries. A team or small-VPS service fronting mutually-distrusting users needs those keys to be derived from the token, not the request body.

## What

- **`auth.Principal`** (`internal/auth/principal.go`) + ctx helpers + `SubjectForFairness`.
- **Rewritten middleware** (`internal/api/http/auth_principal.go`, replacing the single-secret `authMiddleware`): resolves the bearer via **peppered-SHA-256 → `GetByTokenHash`**, honoring the rotation **grace window**; legacy `LOOMCYCLE_AUTH_TOKEN` fallback that **disables once an admin-scoped token exists** (no-lockout gate) and is **fail-closed** on a substrate error; per-route **required-scope** map → **403 + RFC 6750 `WWW-Authenticate`** hint; opaque **401** otherwise (detail only under `LOOMCYCLE_AUTH_VERBOSE`); cookie fallback preserved.
- **Identity threading**: `tools.RunIdentityValue` gains `TenantID`; the four run-creation sites (`handleRuns` / `RunOnce` / `handleMessages` / `runSubAgent`) thread it, and `applyPrincipal` **overrides the wire `tenant_id`/`user_id`** from the principal (logged `kind=identity_overridden`). Sub-agents inherit the parent's tenant.
- **Enforcement repoints**: fairness becomes authoritative for free (override sets the run's `user_id` = `Subject`; the LLM + embeddings gateways use `SubjectForFairness`); memory's `resolveTenancy` now keys on the authoritative `.TenantID` (not `.UserID`) — **per-tenant** isolation, distinct subjects share the tenant's data.
- **gRPC**: the auth interceptors resolve + stamp the same principal (wired from the HTTP resolver), so gRPC runs flow authoritatively through `RunOnce`; shared open-mode decision.
- `OperatorTokenDef` subject/tenant charset tightened to `validIdent`-safe + default subject `tok-<name>` (was `tok:`), since the subject is now the authoritative `user_id`.

## What was tested

- **auth**: Principal ctx round-trip; `SubjectForFairness` (principal wins / fallback / empty-subject).
- **http**: `resolvePrincipal` (substrate hit / unknown / **expired-vs-grace** / legacy fallback + **no-lockout**); `requiredScopeFor` table; middleware **403 + WWW-Authenticate**; principal stamped in ctx; 401 unknown; `applyPrincipal` override + fallback. **Existing cookie/bearer tests still green.**
- **grpc**: `authenticate` (open-mode / stamps principal / Unauthenticated).
- memory tenancy tests repointed to the authoritative `TenantID`.
- **Manual E2E**: alice's token + a forged body `{tenant_id:"zzz",user_id:"bob"}` → run **completes under acme/alice** with two `identity_overridden` log lines; read-only token on `POST /v1/runs` → **403 + scope hint**; legacy works until an admin token exists, then → **401**; unknown bearer → **401**.
- `go build/vet/test ./...` + gofmt clean.

## Re-sequencing note (flagged for review)

The plan put the **per-replica token cache + cross-replica `LISTEN/NOTIFY` invalidation** in this PR. I moved it to **PR 3** (alongside its multi-replica integration test): for a security boundary, correctness-first is the right call, and a direct indexed `GetByTokenHash` per request is simple + obviously correct. PR 3 then becomes cache + invalidation + `Context.help` + docs + RFC retarget. Happy to pull it back into PR 2 if you'd prefer.

## Not in this PR (PR 3)
Token cache + `loomcycle.operator_token_changed` invalidation + multi-replica test; `Context.help operator-tokens`; CONFIGURATION/README/ARCHITECTURE docs; RFC status retarget to v1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)