### PR TITLE
feat(auth): token cache + invalidation, --copy-from-env, docs (RFC L PR 3/3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ---
 
-> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. The feature set is complete; a hardening + QA pass remains before the v1.0 tag. **OSS multi-tenant authorization** (per-principal bearer tokens) is the headline of **v1.1.0** — see "Planned" below. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
+> 🌳 **Active development toward v1.0.** The core primitives stabilised through v0.8 → v0.16 — multi-replica HA, the substrate Defs (Agent/Skill/MCPServer/Schedule/Webhook/MemoryBackend), A2A interoperability, inbound webhooks, pluggable memory + a memory layer, and a synthetic code provider. **OSS multi-tenant authorization** (per-principal bearer tokens) is landing as the **v1.0 capstone** alongside the hardening + QA pass — see "Planned" below. We welcome bug reports, security disclosures, feature contributions, downstream consumers, and forks. See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ---
 
@@ -152,10 +152,10 @@ make build-all       # UI + binary in one shot; output → ./bin/loomcycle
 
 Per-version detail for all of the above is in [`REVISIONS.md`](REVISIONS.md).
 
-**Planned — v1.0 → v1.1.0:**
+**Planned — v1.0:**
 
-- **v1.0 — hardening + QA.** No new primitives: a security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A, webhooks, pluggable memory + the memory layer, the code-js provider), then the **v1.0** tag. Ships with the existing single shared-token auth (`LOOMCYCLE_AUTH_TOKEN`) — right for single-operator and single-trusted-team deployments.
-- **v1.1.0 (headline) — OSS multi-tenant authorization.** Replaces the single shared token with per-principal bearer tokens (token-per-developer/app, scopes, rotation, file audit), each bound to an **authoritative `(tenant, subject)`** resolved *from the token* — so per-subject fairness and per-tenant memory isolation become real (today they key on caller-asserted fields). Zero-disruption: `LOOMCYCLE_AUTH_TOKEN` keeps working; multi-tenancy is available, never required. Enterprise-grade auth (SSO / RBAC / SCIM / signed audit) is a separate edition.
+- **v1.0 — hardening + QA + the multi-tenant-auth capstone.** A security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A, webhooks, pluggable memory + the memory layer, the code-js provider), landing alongside the **OSS multi-tenant authorization** capstone (below), then the **v1.0** tag.
+- **OSS multi-tenant authorization (the v1.0 capstone).** Replaces the single shared token with per-principal bearer tokens (`OperatorTokenDef` — token-per-developer/app, a closed scope catalog, rotation-with-grace, file audit), each bound to an **authoritative `(tenant, subject, scopes)`** resolved *from the token* and overriding the wire fields — so per-subject fairness and per-tenant memory isolation become real boundaries (they previously keyed on caller-asserted fields). **Zero-disruption**: `LOOMCYCLE_AUTH_TOKEN` keeps working (and migrates in place via `operator-token create --copy-from-env`); multi-tenancy is available, never required. See `Context.help operator-tokens`. Enterprise-grade auth (SSO / RBAC / SCIM / signed audit) is a separate edition.
 - **Beyond** (polish): a settings UI, an operator cookbook of postures, broader distribution (Helm).
 
 Full per-version release notes: [`REVISIONS.md`](REVISIONS.md).

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1131,6 +1131,17 @@ func main() {
 		Audit:                tokenAudit,
 		RotationGraceSeconds: graceSecs,
 	})
+	// RFC L Decision 11: per-replica auth-token resolution cache. Default
+	// 30s TTL; LOOMCYCLE_AUTH_CACHE_TTL_SECONDS=0 disables it (direct
+	// lookup per request — immediate revocation). A token mutation
+	// flushes it locally + (in cluster mode) broadcasts a flush.
+	authCacheTTL := 30
+	if v := os.Getenv("LOOMCYCLE_AUTH_CACHE_TTL_SECONDS"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n >= 0 {
+			authCacheTTL = n
+		}
+	}
+	srv.EnableTokenCache(time.Duration(authCacheTTL) * time.Second)
 	// Surface the resolved build identifiers via /healthz so the Web UI
 	// can render the running binary's real version instead of a stale
 	// hard-coded string. Mirrors what gRPC's Health RPC has reported
@@ -1460,6 +1471,11 @@ func main() {
 			if err := cb.SubscribeBackplane(bgCtx, bp); err != nil {
 				log.Fatalf("coord: channel bus subscribe: %v", err)
 			}
+		}
+		// RFC L Decision 11: flush the local auth-token cache when a peer
+		// replica creates/rotates/retires a token.
+		if err := srv.SubscribeTokenInvalidations(bgCtx, bp); err != nil {
+			log.Fatalf("coord: token-cache invalidation subscribe: %v", err)
 		}
 
 		// v0.12.4 Phase 5: advisory-lock helper + replicas TTL sweeper.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -742,6 +742,38 @@ After v0.8.16 (PR #116), the model is also persisted at run start, so `GET /v1/u
 
 ---
 
+## 9b. Multi-tenant authentication (RFC L)
+
+By default every authenticated caller presents the single shared `LOOMCYCLE_AUTH_TOKEN` — correct for one operator or a single trusted team. For a team or small-VPS service fronting users who don't trust each other's claims, **OperatorTokenDef** issues per-principal bearer tokens, each bound to an **authoritative `(tenant, subject, scopes)`** that the middleware resolves *from the token* and stamps over the wire `tenant_id`/`user_id`. The token's `subject` becomes the run's `user_id` (the fairness key); its `tenant_id` is the memory-isolation boundary.
+
+```sh
+# Mint a per-developer token (shown once). Needs an existing admin bearer.
+loomcycle operator-token create --tenant acme --subject alice \
+  --scopes runs:create,runs:read,memory:read,memory:write
+loomcycle operator-token rotate --name alice   # zero-downtime roll (grace window)
+loomcycle operator-token retire --name alice   # immediate revoke
+```
+
+Migrate the existing shared secret in place — it keeps working as an admin token after the legacy fallback disables:
+
+```sh
+loomcycle operator-token create --tenant default --subject ops --copy-from-env
+```
+
+Config knobs (full reference: `loomcycle context help operator-tokens` or the `Context.help operator-tokens` tool topic):
+
+| Env var | Purpose |
+|---|---|
+| `LOOMCYCLE_OPERATOR_TOKEN_PEPPER` | Mixed into the token hash; a stolen DB dump without it yields no usable lookup. Set it for multi-tenant deployments. |
+| `LOOMCYCLE_AUTH_CACHE_TTL_SECONDS` | Per-replica resolution-cache TTL (default 30; `0` = direct lookup, immediate revocation). Worst-case revocation lag if a cross-replica invalidation is dropped. |
+| `LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS` | Default rotation grace window (default 24h). |
+| `LOOMCYCLE_AUDIT_LOG_PATH` | JSONL audit of every create/rotate/retire (never a token or hash). |
+| `LOOMCYCLE_AUTH_VERBOSE` | `1` logs a server-side reason on a rejected bearer (the wire 401 stays opaque). |
+
+Routes enforce a scope from a closed catalog (`substrate:admin` is superuser); an under-scoped token gets `403` + `WWW-Authenticate: Bearer scope="…"`. The legacy `LOOMCYCLE_AUTH_TOKEN` is disabled only once an admin-scoped token exists (the no-lockout gate).
+
+---
+
 ## 10. Cross-references
 
 - [`loomcycle.example.yaml`](../loomcycle.example.yaml) — the repo-root reference yaml. All six user_tiers wired, inline comments on every section. Copy-paste and edit.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -6,11 +6,11 @@ This is the public roadmap. For decision history, regret notes, and per-version 
 
 loomcycle has shipped through **v0.16.0** (the memory layer + the synthetic `code-js` provider). Per-version shipped detail now lives in [`REVISIONS.md`](../REVISIONS.md); the historical design-roadmap entries from the v0.8.x series are retained below for context. This section tracks the path forward.
 
-## Planned — v1.0 (hardening) → v1.1.0 (multi-tenant authorization)
+## Planned — v1.0 (hardening + the multi-tenant-auth capstone)
 
-**v1.0 — hardening + QA.** No new primitives. A security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A interoperability, input webhooks, pluggable memory + the memory layer, the synthetic code provider), then the v1.0 tag. v1.0 authenticates with the existing single shared `LOOMCYCLE_AUTH_TOKEN` — correct and sufficient for single-operator and single-trusted-team deployments.
+**v1.0 — hardening + QA + multi-tenant authorization.** A security + robustness + runtime-QA pass across the v0.13–v0.16 surfaces (A2A interoperability, input webhooks, pluggable memory + the memory layer, the synthetic code provider), landing together with the OSS multi-tenant-authorization capstone (below), then the v1.0 tag. Single-operator deployments keep authenticating with `LOOMCYCLE_AUTH_TOKEN` unchanged — multi-tenancy is available, never required.
 
-**v1.1.0 — OSS multi-tenant authorization (headline).** Replaces the single shared token with a substrate-resident map of bearer tokens, each bound to an **authoritative principal** — a `(tenant, subject, scopes)` resolved *from the token*, not trusted from the request body. What it unlocks:
+**OSS multi-tenant authorization — the v1.0 capstone (RFC L).** Replaces the single shared token with a substrate of bearer tokens (`OperatorTokenDef`), each bound to an **authoritative principal** — a `(tenant, subject, scopes)` resolved *from the token*, not trusted from the request body. Lands as a three-PR series (token substrate + store + CLI/audit → auth middleware + principal + identity threading + scope enforcement → cache/invalidation + docs). What it unlocks:
 
 - **Token-per-principal.** A team or small-VPS service issues a distinct token per developer / app, each minted by loomcycle (CSPRNG, shown once) — callers stop sharing one omnipotent secret.
 - **Authority-derived isolation.** The principal's tenant + subject drive boundaries that already exist — per-subject resource fairness and per-tenant memory isolation become *real* (today they key on caller-asserted fields). The wire `tenant_id` / `user_id` become advisory, overridden by the token.
@@ -20,7 +20,7 @@ loomcycle has shipped through **v0.16.0** (the memory layer + the synthetic `cod
 
 Enterprise-grade authorization — SSO (SAML/OIDC), RBAC roles, SCIM provisioning, signed / queryable audit logs, automated rotation policies, compliance evidence — is intentionally **out of scope for OSS** and lives in a separate enterprise edition built on the same token substrate. The OSS edition does enough for a 200-developer team; the enterprise edition does what passes a procurement security review.
 
-**Beyond v1.1.0** (polish, unscheduled): a settings UI, an operator cookbook of deployment postures, broader distribution (Helm).
+**Beyond v1.0** (polish, unscheduled): a settings UI, an operator cookbook of deployment postures, broader distribution (Helm).
 
 ---
 

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/webui"
 )
@@ -70,6 +71,54 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// tokenInvalidateTopic is the backplane channel for cross-replica auth
+// cache invalidation (RFC L Decision 11).
+const tokenInvalidateTopic = "loomcycle.operator_token_changed"
+
+// EnableTokenCache wires the per-replica auth-token resolution cache
+// with the given TTL (RFC L Decision 11). ttl <= 0 leaves the cache
+// disabled (direct lookup per request — immediate revocation).
+func (s *Server) EnableTokenCache(ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	s.tokenCache = newTokenCache(ttl)
+}
+
+// invalidateTokenCache flushes the local cache and, in cluster mode,
+// broadcasts a flush to peer replicas. Called after a successful token
+// mutation (create/rotate/retire). The local flush is essential: the
+// backplane self-filters the publisher's own message, so the mutating
+// replica would not otherwise see its own invalidation.
+func (s *Server) invalidateTokenCache(ctx context.Context) {
+	s.tokenCache.flush()
+	if s.backplane != nil {
+		// Payload is a sentinel — subscribers flush their whole cache
+		// (a mutation can change any resolution, incl. the legacy gate).
+		if err := s.backplane.Publish(ctx, tokenInvalidateTopic, []byte("flush")); err != nil {
+			log.Printf("auth: token-cache invalidation publish failed: %v", err)
+		}
+	}
+}
+
+// SubscribeTokenInvalidations starts the goroutine that flushes the
+// local auth cache when a peer replica reports a token mutation. Wired
+// from main.go in cluster mode (mirrors the runstate/channel bus
+// SubscribeBackplane pattern). Returns once subscribed; the goroutine
+// exits on ctx.Done.
+func (s *Server) SubscribeTokenInvalidations(ctx context.Context, bp coord.Backplane) error {
+	ch, err := bp.Subscribe(ctx, tokenInvalidateTopic)
+	if err != nil {
+		return err
+	}
+	go func() {
+		for range ch {
+			s.tokenCache.flush()
+		}
+	}()
+	return nil
+}
+
 // ResolvePrincipal is the exported wrapper main.go wires into the gRPC
 // adapter's Config.PrincipalResolver so both transports share identical
 // token resolution (RFC L). Returns (_, false) for unknown/expired/invalid.
@@ -123,18 +172,32 @@ func (s *Server) authVerbose() bool {
 	return s.cfg.Env.AuthVerbose
 }
 
-// resolvePrincipal maps a raw bearer to a principal. Token substrate
+// resolvePrincipal maps a raw bearer to a principal, with a short-TTL
+// per-replica cache in front of the DB lookup (RFC L Decision 11).
+// The cache key is the token's SHA-256 hash (never a secret); a
+// mutation flushes it locally + cross-replica. ttl<=0 (or no cache
+// wired) → direct lookup every time.
+func (s *Server) resolvePrincipal(ctx context.Context, bearer string) (auth.Principal, bool) {
+	if bearer == "" {
+		return auth.Principal{}, false
+	}
+	hash := auth.HashToken(s.cfg.Env.OperatorTokenPepper, bearer)
+	if p, found, ok := s.tokenCache.get(hash); ok {
+		return p, found
+	}
+	p, found := s.resolvePrincipalUncached(ctx, bearer, hash)
+	s.tokenCache.put(hash, p, found)
+	return p, found
+}
+
+// resolvePrincipalUncached is the resolution itself: token substrate
 // first (indexed peppered-hash lookup, honoring the rotation grace
 // window), then the legacy LOOMCYCLE_AUTH_TOKEN fallback (disabled once
 // an admin-scoped token exists — the no-lockout migration gate). Returns
 // (_, false) for unknown/expired/invalid — the caller maps that to an
 // opaque 401. NEVER fails open to the legacy token on a substrate error.
-func (s *Server) resolvePrincipal(ctx context.Context, bearer string) (auth.Principal, bool) {
-	if bearer == "" {
-		return auth.Principal{}, false
-	}
+func (s *Server) resolvePrincipalUncached(ctx context.Context, bearer, hash string) (auth.Principal, bool) {
 	if s.store != nil {
-		hash := auth.HashToken(s.cfg.Env.OperatorTokenPepper, bearer)
 		row, err := s.store.OperatorTokenDefGetByTokenHash(ctx, hash)
 		if err == nil {
 			// Valid iff never retired, or still inside the grace window.

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -479,7 +479,32 @@ func (s *Server) OperatorTokenDef(ctx context.Context, input json.RawMessage) (c
 	if err != nil {
 		return connector.ToolResult{}, err
 	}
+	// RFC L Decision 11: a successful mutation flushes the auth cache
+	// (locally + cross-replica) so a created/rotated token authenticates
+	// and a retired one stops within one backplane round-trip. Reads
+	// (get/list) don't invalidate.
+	if !res.IsError && isMutatingTokenOp(input) {
+		s.invalidateTokenCache(ctx)
+	}
 	return connector.ToolResult{Text: res.Text, IsError: res.IsError}, nil
+}
+
+// isMutatingTokenOp reports whether an OperatorTokenDef input is a
+// create/rotate/retire (vs a read get/list) — used to decide whether to
+// flush the auth cache.
+func isMutatingTokenOp(input json.RawMessage) bool {
+	var p struct {
+		Op string `json:"op"`
+	}
+	if err := json.Unmarshal(input, &p); err != nil {
+		return true // unknown shape → invalidate defensively
+	}
+	switch p.Op {
+	case "create", "rotate", "retire":
+		return true
+	default:
+		return false
+	}
 }
 
 // dispatchBuiltin is the shared lookup-and-execute path for the five

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -257,6 +257,11 @@ type Server struct {
 	replicaStore replicaLister
 	replicaID    string
 
+	// tokenCache is the RFC L per-replica auth-token resolution cache.
+	// Nil = disabled (direct lookup per request). Wired via
+	// EnableTokenCache from main.go with LOOMCYCLE_AUTH_CACHE_TTL_SECONDS.
+	tokenCache *tokenCache
+
 	// mcpHTTPHandler is the v0.8.15.3 HTTP MCP transport (alternate
 	// front-end to the stdio MCP server). Typed as http.Handler — NOT
 	// *lcmcp.HTTPHandler — so this package does NOT import

--- a/internal/api/http/token_cache.go
+++ b/internal/api/http/token_cache.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// RFC L Decision 11 — the per-replica auth-token resolution cache.
+//
+// resolvePrincipal does an indexed peppered-hash DB lookup per
+// authenticated request. This cache memoises the WHOLE resolution
+// outcome (token hit, legacy fallback, or not-found) keyed by the
+// token's SHA-256 hash — never a secret — so a hot path of repeated
+// bearers skips the DB. Entries expire after a short TTL (default 30s,
+// LOOMCYCLE_AUTH_CACHE_TTL_SECONDS); the TTL is the worst-case
+// enforcement lag for a revocation if a cross-replica invalidation
+// NOTIFY is dropped. A mutation (create/rotate/retire) flushes the local
+// cache immediately and broadcasts a flush to peer replicas, so typical
+// propagation is one backplane round-trip (50–200ms).
+//
+// TTL <= 0 disables the cache entirely (every request does the direct
+// lookup — immediate revocation, the safest setting for an operator who
+// prefers correctness over the DB-hit reduction).
+
+type tokenCacheEntry struct {
+	principal auth.Principal
+	found     bool
+	expiresAt time.Time
+}
+
+type tokenCache struct {
+	mu  sync.RWMutex
+	m   map[string]tokenCacheEntry
+	ttl time.Duration
+	now func() time.Time // injectable for tests
+}
+
+func newTokenCache(ttl time.Duration) *tokenCache {
+	return &tokenCache{m: make(map[string]tokenCacheEntry), ttl: ttl, now: time.Now}
+}
+
+// get returns the cached resolution for a hash. ok=false on a miss or an
+// expired entry (or when the cache is disabled).
+func (c *tokenCache) get(hash string) (auth.Principal, bool /*found*/, bool /*ok*/) {
+	if c == nil || c.ttl <= 0 {
+		return auth.Principal{}, false, false
+	}
+	c.mu.RLock()
+	e, ok := c.m[hash]
+	c.mu.RUnlock()
+	if !ok || c.now().After(e.expiresAt) {
+		return auth.Principal{}, false, false
+	}
+	return e.principal, e.found, true
+}
+
+// put records a resolution. No-op when the cache is disabled.
+func (c *tokenCache) put(hash string, p auth.Principal, found bool) {
+	if c == nil || c.ttl <= 0 {
+		return
+	}
+	c.mu.Lock()
+	c.m[hash] = tokenCacheEntry{principal: p, found: found, expiresAt: c.now().Add(c.ttl)}
+	c.mu.Unlock()
+}
+
+// flush drops all entries. Called on a local token mutation and on
+// receipt of a cross-replica invalidation. Flush-all (not per-hash)
+// because a create/rotate/retire can change ANY resolution — including
+// enabling/disabling the legacy fallback (the no-lockout gate).
+func (c *tokenCache) flush() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.m = make(map[string]tokenCacheEntry)
+	c.mu.Unlock()
+}

--- a/internal/api/http/token_cache_test.go
+++ b/internal/api/http/token_cache_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+func TestTokenCache_HitMissExpiryFlush(t *testing.T) {
+	now := time.Unix(1000, 0)
+	c := newTokenCache(30 * time.Second)
+	c.now = func() time.Time { return now }
+
+	c.put("h1", auth.Principal{Subject: "alice"}, true)
+	if p, found, ok := c.get("h1"); !ok || !found || p.Subject != "alice" {
+		t.Fatalf("hit expected: ok=%v found=%v p=%+v", ok, found, p)
+	}
+	if _, _, ok := c.get("absent"); ok {
+		t.Error("absent key should miss")
+	}
+	// Advance past the TTL → expired miss.
+	now = now.Add(31 * time.Second)
+	if _, _, ok := c.get("h1"); ok {
+		t.Error("entry past TTL should miss")
+	}
+	// Re-put then flush.
+	now = time.Unix(2000, 0)
+	c.put("h2", auth.Principal{}, false) // negative entry
+	if _, found, ok := c.get("h2"); !ok || found {
+		t.Errorf("negative entry should be a hit with found=false (ok=%v found=%v)", ok, found)
+	}
+	c.flush()
+	if _, _, ok := c.get("h2"); ok {
+		t.Error("flush should drop all entries")
+	}
+}
+
+func TestTokenCache_DisabledTTLZero(t *testing.T) {
+	var c *tokenCache // nil receiver — disabled
+	c.put("h", auth.Principal{Subject: "x"}, true)
+	if _, _, ok := c.get("h"); ok {
+		t.Error("nil cache must always miss")
+	}
+	c.flush() // must not panic
+	c2 := newTokenCache(0)
+	c2.put("h", auth.Principal{Subject: "x"}, true)
+	if _, _, ok := c2.get("h"); ok {
+		t.Error("ttl<=0 cache must always miss")
+	}
+}
+
+// TestResolvePrincipal_CacheServesAndInvalidates proves the cache fronts
+// the DB lookup (a row retired directly in the store still resolves from
+// cache) and that invalidateTokenCache flushes it (the retire then takes
+// effect). Exercises the RFC L Decision 11 propagation path.
+func TestResolvePrincipal_CacheServesAndInvalidates(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	s.EnableTokenCache(30 * time.Second)
+	seedToken(t, st, "lct_x", "acme", "alice", []string{auth.ScopeAdmin}, time.Time{})
+
+	// Prime the cache.
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_x"); !ok {
+		t.Fatal("expected initial resolution")
+	}
+	// Retire the row DIRECTLY in the store (bypassing the connector, so no
+	// flush) — the cache should still serve the stale positive result.
+	if err := st.OperatorTokenDefSetRetiredAt(context.Background(), "def_alice", time.Now().Add(-time.Hour)); err != nil {
+		t.Fatalf("retire: %v", err)
+	}
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_x"); !ok {
+		t.Error("cache should still serve the pre-retire resolution (≤TTL window)")
+	}
+	// Flush (what a mutation broadcast does) → the retire now takes effect.
+	s.invalidateTokenCache(context.Background())
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_x"); ok {
+		t.Error("after invalidation, the retired token must no longer resolve")
+	}
+}

--- a/internal/cli/operator_token.go
+++ b/internal/cli/operator_token.go
@@ -55,8 +55,9 @@ func runOperatorTokenCreate(args []string, stdout, stderr io.Writer) int {
 	token := fs.String("token", defaultAuthToken(), "bearer token (an existing admin token; defaults to $LOOMCYCLE_AUTH_TOKEN)")
 	name := fs.String("name", "", "token name (required)")
 	tenant := fs.String("tenant", "", "authoritative tenant_id (required)")
-	subject := fs.String("subject", "", "authoritative subject (default tok:<name>)")
+	subject := fs.String("subject", "", "authoritative subject (default tok-<name>)")
 	scopes := fs.String("scopes", "", "comma-separated scopes (default substrate:admin)")
+	copyFromEnv := fs.Bool("copy-from-env", false, "migration: bind the existing $LOOMCYCLE_AUTH_TOKEN instead of minting (zero-disruption upgrade)")
 	httpTimeout := fs.Duration("http-timeout", 15*time.Second, "client-side HTTP request timeout")
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -71,6 +72,14 @@ func runOperatorTokenCreate(args []string, stdout, stderr io.Writer) int {
 	}
 	if *scopes != "" {
 		payload["scopes"] = splitCSV(*scopes)
+	}
+	if *copyFromEnv {
+		env := getenvDefault("LOOMCYCLE_AUTH_TOKEN", "")
+		if env == "" {
+			fmt.Fprintln(stderr, "loomcycle: error: --copy-from-env set but $LOOMCYCLE_AUTH_TOKEN is empty")
+			return 2
+		}
+		payload["import_token"] = env
 	}
 	return postOperatorToken(*target, *token, payload, *httpTimeout, stdout, stderr)
 }

--- a/internal/help/builtin/operator-tokens.md
+++ b/internal/help/builtin/operator-tokens.md
@@ -1,0 +1,111 @@
+---
+name: operator-tokens
+description: multi-tenant auth — bearer tokens bound to an authoritative principal (tenant + subject + scopes), rotation, audit, and the LOOMCYCLE_AUTH_TOKEN migration.
+---
+loomcycle's default auth is one shared secret, `LOOMCYCLE_AUTH_TOKEN`:
+everyone who holds it can do everything, and the wire `tenant_id` /
+`user_id` on a run are caller-asserted LABELS — not trust boundaries.
+That is the right shape for one operator and wrong the moment a team or
+a small VPS fronts users who don't trust each other's claims.
+
+**OperatorTokenDef** (RFC L) replaces the shared secret with a
+substrate of bearer tokens, each bound to an **authoritative principal**
+the auth middleware resolves *from the token* and stamps into the
+request — so the keys downstream isolation already uses become
+authority-derived instead of forgeable.
+
+## The principal model
+
+A token resolves to `{tenant_id, subject, scopes}`:
+
+- **tenant_id** — the data-isolation boundary. Memory tenancy partitions
+  on it; distinct subjects under one tenant SHARE the tenant's data
+  (they collaborate).
+- **subject** — the per-actor id. It becomes the run's `user_id`, so it
+  is the **fairness key** and the attribution/audit actor. Fifty
+  developers under one tenant get fifty distinct subjects → fifty
+  distinct fairness caps, while sharing the tenant's memory.
+- **scopes** — a capability set from a closed catalog.
+
+On an authenticated route the principal **overrides** the wire
+`tenant_id`/`user_id`; a disagreement is honored server-side and logged
+`kind=identity_overridden`. A caller can no longer become a different
+user/tenant by editing the request body.
+
+## Scope catalog (closed)
+
+`substrate:admin` (superuser — satisfies every scope), `runs:create`,
+`runs:read`, `memory:read`, `memory:write`, `channel:publish`,
+`channel:read`. Operators can't invent scope names (the runtime wouldn't
+enforce them). The default at create is `["substrate:admin"]`, so a
+first token keeps "single token, full power". Narrow app tokens
+(`["runs:create"]`) are the upgrade path; a route that needs a scope the
+token lacks returns **403** with `WWW-Authenticate: Bearer scope="…"`.
+
+## Managing tokens
+
+```sh
+# Mint a per-developer token (shown ONCE — store it now).
+loomcycle operator-token create --tenant acme --subject alice \
+  --scopes runs:create,runs:read,memory:read,memory:write
+
+# A narrow production token.
+loomcycle operator-token create --tenant acme-prod --subject app --scopes runs:create
+
+loomcycle operator-token list                 # all names (no secrets)
+loomcycle operator-token list --name alice    # one name's history
+loomcycle operator-token rotate --name alice  # new token; old one graces out
+loomcycle operator-token retire --name alice  # immediate revoke
+```
+
+`create`/`rotate` show the token plaintext exactly once; it is never
+persisted or logged (only `SHA-256(pepper ‖ token)` is stored). A lost
+token is rotated, not recovered. The same operations are available over
+HTTP (`POST /v1/_operatortokendef`), gRPC, the MCP `operatortokendef`
+meta-tool, and the TS client's `operatorTokenDef()`.
+
+## Rotation grace
+
+`rotate` mints a new token for the same principal and marks the prior
+one to retire after a grace window (default 24h,
+`LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS`, or per-call
+`--grace-seconds`). Both authenticate during the window — a zero-downtime
+roll. `retire` revokes immediately.
+
+## Migration from LOOMCYCLE_AUTH_TOKEN (zero-disruption)
+
+The legacy shared secret keeps working until the **first admin-scoped**
+OperatorTokenDef exists; then it's disabled (a startup/triage log names
+it). To upgrade WITHOUT a flag day, bind the existing env token as a real
+admin principal so it keeps authenticating:
+
+```sh
+loomcycle operator-token create --tenant default --subject ops --copy-from-env
+```
+
+`--copy-from-env` imports `$LOOMCYCLE_AUTH_TOKEN`'s hash (it is never
+re-displayed). Now distribute per-principal tokens at your own pace.
+
+## Configuration
+
+- `LOOMCYCLE_OPERATOR_TOKEN_PEPPER` — mixed into the token hash; a stolen
+  DB dump without it yields no usable lookup. Set it in multi-tenant
+  deployments (env-allowlisted, never logged).
+- `LOOMCYCLE_AUTH_CACHE_TTL_SECONDS` — per-replica resolution cache TTL
+  (default 30; `0` disables it for immediate revocation). A token
+  mutation flushes the cache locally and, in a cluster, broadcasts a
+  flush over the backplane (`loomcycle.operator_token_changed`), so
+  typical revocation propagates in one round-trip; the TTL is the
+  worst-case backstop.
+- `LOOMCYCLE_AUDIT_LOG_PATH` — JSONL audit of every create/rotate/retire
+  (`{ts, actor_*, action, target_*, scopes_*}` — never a token or hash).
+  Per-replica local file; ship it with logrotate/fluentd/Loki.
+- `LOOMCYCLE_AUTH_VERBOSE=1` — log a server-side reason on a rejected
+  bearer (the wire 401 stays opaque regardless).
+
+## The OSS ceiling
+
+OSS does *basic* multi-tenancy: token-per-principal, scopes, rotation,
+file audit. SSO/OIDC/SAML, RBAC roles, SCIM, automated rotation policy,
+signed/queryable audit, and compliance evidence are the enterprise
+edition — layered on this same substrate without changing it.

--- a/internal/tools/builtin/operatortokendef.go
+++ b/internal/tools/builtin/operatortokendef.go
@@ -72,7 +72,8 @@ const operatorTokenDefInputSchema = `{
     "tenant_id":  {"type": "string", "description": "Authoritative tenant (required for create)."},
     "subject":    {"type": "string", "description": "Authoritative subject (optional for create; defaults to tok-<name>)."},
     "scopes":     {"type": "array", "items": {"type": "string"}, "description": "Allowed scopes from the closed catalog (create; default [substrate:admin])."},
-    "grace_seconds": {"type": "integer", "description": "Rotation grace window override (rotate)."}
+    "grace_seconds": {"type": "integer", "description": "Rotation grace window override (rotate)."},
+    "import_token": {"type": "string", "description": "Migration only (create): bind an existing secret (the legacy LOOMCYCLE_AUTH_TOKEN) instead of minting. Hashed, never echoed."}
   },
   "required": ["op"]
 }`
@@ -85,6 +86,10 @@ type operatorTokenDefInput struct {
 	Subject      string   `json:"subject,omitempty"`
 	Scopes       []string `json:"scopes,omitempty"`
 	GraceSeconds *int     `json:"grace_seconds,omitempty"`
+	// ImportToken (Decision 10 migration) binds an existing secret —
+	// the legacy LOOMCYCLE_AUTH_TOKEN via `--copy-from-env` — instead of
+	// minting. Admin-only; the plaintext is hashed, never echoed.
+	ImportToken string `json:"import_token,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -190,9 +195,28 @@ func (s *OperatorTokenDef) execCreate(ctx context.Context, in operatorTokenDefIn
 		}
 	}
 
-	plaintext, suffix, err := auth.MintToken()
-	if err != nil {
-		return errResult(fmt.Sprintf("create: %s", err)), nil
+	// Token source. Default: mint a fresh CSPRNG token. Migration
+	// exception (Decision 10): `import_token` binds an EXISTING secret —
+	// the legacy LOOMCYCLE_AUTH_TOKEN, via `--copy-from-env` — to a real
+	// principal so the env token keeps working as an admin token after
+	// the legacy fallback disables (zero-disruption upgrade). This is the
+	// only sanctioned operator-supplied-token path; it imports a hash,
+	// never echoes the plaintext back.
+	var plaintext, suffix string
+	imported := in.ImportToken != ""
+	if imported {
+		if len(in.ImportToken) < 8 {
+			return errResult("create: import_token too short (min 8 chars)"), nil
+		}
+	} else {
+		var err error
+		if plaintext, suffix, err = auth.MintToken(); err != nil {
+			return errResult(fmt.Sprintf("create: %s", err)), nil
+		}
+	}
+	hashInput := plaintext
+	if imported {
+		hashInput = in.ImportToken
 	}
 	ident := tools.RunIdentity(ctx)
 	row := store.OperatorTokenDefRow{
@@ -200,7 +224,7 @@ func (s *OperatorTokenDef) execCreate(ctx context.Context, in operatorTokenDefIn
 		Name:             in.Name,
 		TenantID:         in.TenantID,
 		Subject:          subject,
-		TokenHash:        auth.HashToken(s.Pepper, plaintext),
+		TokenHash:        auth.HashToken(s.Pepper, hashInput),
 		AllowedScopes:    scopes,
 		CreatedByAgentID: ident.AgentID,
 	}
@@ -212,6 +236,12 @@ func (s *OperatorTokenDef) execCreate(ctx context.Context, in operatorTokenDefIn
 		Action: "create", TargetDefID: created.DefID, TargetName: created.Name,
 		TargetTenant: created.TenantID, TargetSubject: created.Subject, ScopesAfter: scopes,
 	})
+	if imported {
+		// No plaintext to show — the operator already holds the env token.
+		m := operatorTokenRowResponse(created)
+		m["imported"] = true
+		return okJSON(m)
+	}
 	return okJSON(operatorTokenCreateResponse(created, plaintext, suffix))
 }
 

--- a/internal/tools/builtin/operatortokendef_test.go
+++ b/internal/tools/builtin/operatortokendef_test.go
@@ -96,6 +96,30 @@ func TestOperatorTokenDef_RequiresAdmin(t *testing.T) {
 	}
 }
 
+func TestOperatorTokenDef_CopyFromEnvImportsExistingSecret(t *testing.T) {
+	tool, ctx, s, cleanup := operatorTokenDefFixture(t)
+	defer cleanup()
+	// Migration: bind the existing LOOMCYCLE_AUTH_TOKEN ("legacy-secret")
+	// as an admin token instead of minting.
+	out := mustOp(t, tool, ctx, `{"op":"create","name":"ops","tenant_id":"default","subject":"ops","import_token":"legacy-secret"}`)
+	if out["imported"] != true {
+		t.Errorf("response should mark imported=true; got %v", out["imported"])
+	}
+	if _, ok := out["token"]; ok {
+		t.Error("import must NOT echo a plaintext token")
+	}
+	// The stored hash must be the hash of the imported secret, so the env
+	// token now resolves to this principal.
+	defID := out["def_id"].(string)
+	row, err := s.OperatorTokenDefGet(ctx, defID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if row.TokenHash != auth.HashToken(testPepper, "legacy-secret") {
+		t.Error("imported token_hash must equal SHA-256(pepper‖legacy-secret)")
+	}
+}
+
 func TestOperatorTokenDef_DefaultScopeIsAdmin(t *testing.T) {
 	tool, ctx, _, cleanup := operatorTokenDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
**PR 3 of 3 — the final PR of the RFC L series** (OSS multi-tenant authorization, the v1.0 capstone). Builds on PR 1 (#323, substrate) + PR 2 (#324, trust boundary), both on `main`.

This PR adds the performance optimization PR 2 deliberately deferred, plus the operator-facing migration story and docs.

## What

- **Per-replica resolution cache** (`token_cache.go`) in front of `resolvePrincipal`, keyed by the token's SHA-256 hash (never a secret). Default **30s TTL** (`LOOMCYCLE_AUTH_CACHE_TTL_SECONDS`; `0` disables → direct lookup, immediate revocation). A mutation flushes the local cache **and** broadcasts a flush over the cluster backplane (`loomcycle.operator_token_changed`) — typical revocation propagates in one round-trip; the TTL is the worst-case backstop. `SubscribeTokenInvalidations` wired in cluster mode, mirroring the runstate/channel-bus pattern.
- **`--copy-from-env` migration** (Decision 10): `operator-token create --copy-from-env` binds the existing `LOOMCYCLE_AUTH_TOKEN` as a real admin token (imports its hash, never echoes plaintext), so the env token keeps authenticating after the legacy fallback disables — the **zero-disruption upgrade**. The only sanctioned operator-supplied-token path.
- **`Context.help operator-tokens`** topic — the full operator guide.
- **Docs**: CONFIGURATION "Multi-tenant authentication" section; README + `docs/PLAN.md` **retargeted from "v1.1.0 headline" to "the v1.0 capstone"** (per your decision).

## What was tested

- **Unit**: token cache (hit/miss/expiry/flush; disabled `TTL=0`; serves-then-invalidates); `--copy-from-env` import (stored hash = `SHA-256(pepper‖secret)`, no plaintext echoed); help loader accepts the topic.
- **Manual E2E**: `--copy-from-env` imports the env token → it **keeps working (200)** after an admin token exists (zero-disruption); a self-retire **flushes the cache → 401 immediately** despite the 30s TTL; the no-lockout gate correctly rejects the legacy bearer once an admin token exists.
- `go build/vet/test ./...` + gofmt clean.

## Completes RFC L

| PR | Scope | |
|---|---|---|
| #323 | `OperatorTokenDef` substrate + store + CLI + audit | ✅ merged |
| #324 | `auth.Principal` + middleware + identity threading + enforcement repoints + scope enforcement + gRPC | ✅ merged |
| **#325** | **token cache + cross-replica invalidation + `--copy-from-env` + help + docs + RFC retarget** | this PR |

## Note on the internal RFC

`oss-multi-tenant-authorization.md` (Gitea, operator-side) is updated locally to retarget v1.1.0 → v1.0 capstone + record the 3-PR implementation. Pushing that to Gitea is a separate step — I'll do it on your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)