### PR TITLE
fix(anthropic): flatten top-level oneOf/anyOf/allOf in tool input_schema

### DIFF
--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -210,9 +210,13 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 	}
 
 	w := wireRequest{
-		Model:       req.Model,
-		MaxTokens:   maxTokens,
-		Tools:       req.Tools,
+		Model:     req.Model,
+		MaxTokens: maxTokens,
+		// Flatten any top-level oneOf/anyOf/allOf in a tool's input_schema
+		// — Anthropic rejects those (e.g. a Zod discriminatedUnion at the
+		// root of an MCP tool). No-op for schemas without a top-level
+		// combinator. See schema.go.
+		Tools:       sanitizeAnthropicTools(req.Tools),
 		Temperature: req.Temperature,
 		Stream:      true, // we always stream
 	}

--- a/internal/providers/anthropic/schema.go
+++ b/internal/providers/anthropic/schema.go
@@ -1,0 +1,189 @@
+package anthropic
+
+import (
+	"encoding/json"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Anthropic's Messages API rejects a tool whose input_schema carries a
+// combinator at the TOP LEVEL:
+//
+//	tools.N.custom.input_schema: input_schema does not support
+//	oneOf, allOf, or anyOf at the top level
+//
+// A Zod `z.discriminatedUnion(...)` / `z.union(...)` at the ROOT of an
+// MCP tool's input compiles (via zod-to-json-schema) to exactly that.
+// This is the Anthropic-side manifestation of the same root cause the
+// v0.8.10 Gemini sanitizer (sanitizeGeminiSchema) handles — but
+// Anthropic's constraint is NARROWER: it forbids the combinator ONLY at
+// the top level. Nested oneOf/anyOf/allOf, $ref, $defs, and
+// additionalProperties are all accepted.
+//
+// So this sanitizer is deliberately minimal and SURGICAL: it flattens
+// ONLY a top-level combinator into a single object schema (merging the
+// variants' properties + required, resolving $ref variants against the
+// schema's own $defs/definitions), and returns every schema WITHOUT a
+// top-level combinator byte-for-byte unchanged. Currently-working tools
+// are untouched; nested unions Anthropic already accepts are preserved.
+//
+// The merge semantics intentionally mirror the Gemini sanitizer's
+// mergeGeminiSchemaInto (union of properties + required, type-conflict
+// defense) so the SAME union-rooted tool produces the same flattened
+// shape on both providers — least-surprising, and already validated in
+// production on the Gemini path for the union-rooted jobs-search-agent
+// tools. (Kept self-contained rather than extracting a shared helper, to
+// avoid refactoring the working Gemini driver on a behaviour change.)
+
+// sanitizeAnthropicTools returns a copy of the tool list with each
+// input_schema sanitized. The input slice + its ToolSpecs are not
+// mutated (the raw schema may be shared with other providers in a
+// fallback chain).
+func sanitizeAnthropicTools(in []providers.ToolSpec) []providers.ToolSpec {
+	if len(in) == 0 {
+		return in
+	}
+	out := make([]providers.ToolSpec, len(in))
+	for i, t := range in {
+		t.InputSchema = sanitizeAnthropicToolSchema(t.InputSchema)
+		out[i] = t
+	}
+	return out
+}
+
+// sanitizeAnthropicToolSchema flattens a top-level oneOf/anyOf/allOf into
+// a single object schema. A schema with no top-level combinator (or one
+// that doesn't parse as a JSON object) is returned unchanged.
+func sanitizeAnthropicToolSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var root map[string]any
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return raw // not an object schema we recognise — leave it
+	}
+
+	var variants []any
+	combinator := ""
+	for _, key := range []string{"oneOf", "anyOf", "allOf"} {
+		if v, ok := root[key].([]any); ok && len(v) > 0 {
+			variants, combinator = v, key
+			break
+		}
+	}
+	if combinator == "" {
+		return raw // no top-level union → untouched (the common case)
+	}
+
+	defs := collectAnthropicDefs(root)
+	for _, v := range variants {
+		mergeAnthropicSchemaInto(root, resolveAnthropicVariant(v, defs))
+	}
+	delete(root, combinator)
+	// A union-rooted schema declares no top-level type; the flattened
+	// result is an object.
+	if _, ok := root["type"]; !ok {
+		root["type"] = "object"
+	}
+
+	out, err := json.Marshal(root)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+// collectAnthropicDefs gathers the top-level $defs / definitions blocks
+// (where zod-to-json-schema hoists the discriminated-union variants),
+// keyed by canonical JSON-pointer ref string.
+func collectAnthropicDefs(root map[string]any) map[string]any {
+	defs := map[string]any{}
+	for _, bucket := range []string{"$defs", "definitions"} {
+		if d, ok := root[bucket].(map[string]any); ok {
+			for k, v := range d {
+				defs["#/"+bucket+"/"+k] = v
+			}
+		}
+	}
+	return defs
+}
+
+// resolveAnthropicVariant returns the variant's object schema, inlining a
+// single `$ref` against defs. A dangling ref or a non-object variant
+// yields nil (merged as a no-op).
+func resolveAnthropicVariant(v any, defs map[string]any) map[string]any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if ref, ok := m["$ref"].(string); ok {
+		if def, found := defs[ref].(map[string]any); found {
+			return def
+		}
+		return nil
+	}
+	return m
+}
+
+// mergeAnthropicSchemaInto folds src into dst: existing dst keys win for
+// scalars; `properties` maps merge key-by-key; `required` slices union.
+// On a type conflict (dst object vs src array), src's structural fields
+// (properties/items/required) are dropped — folding them across a type
+// boundary produces a malformed schema. Mirrors mergeGeminiSchemaInto.
+func mergeAnthropicSchemaInto(dst, src map[string]any) {
+	if src == nil {
+		return
+	}
+	typesConflict := false
+	if dstType, dstHas := dst["type"].(string); dstHas {
+		if srcType, srcHas := src["type"].(string); srcHas {
+			typesConflict = dstType != srcType
+		}
+	}
+	structural := map[string]bool{"properties": true, "items": true, "required": true}
+	for k, v := range src {
+		if typesConflict && structural[k] {
+			continue
+		}
+		switch k {
+		case "properties":
+			vmap, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			dstProps, _ := dst["properties"].(map[string]any)
+			if dstProps == nil {
+				dstProps = map[string]any{}
+				dst["properties"] = dstProps
+			}
+			for pk, pv := range vmap {
+				if _, exists := dstProps[pk]; !exists {
+					dstProps[pk] = pv
+				}
+			}
+		case "required":
+			varr, ok := v.([]any)
+			if !ok {
+				continue
+			}
+			dstReq, _ := dst["required"].([]any)
+			seen := map[string]bool{}
+			for _, r := range dstReq {
+				if s, ok := r.(string); ok {
+					seen[s] = true
+				}
+			}
+			for _, r := range varr {
+				if s, ok := r.(string); ok && !seen[s] {
+					dstReq = append(dstReq, s)
+					seen[s] = true
+				}
+			}
+			dst["required"] = dstReq
+		default:
+			if _, exists := dst[k]; !exists {
+				dst[k] = v
+			}
+		}
+	}
+}

--- a/internal/providers/anthropic/schema_test.go
+++ b/internal/providers/anthropic/schema_test.go
@@ -1,0 +1,128 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+func parseSchema(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("result not an object: %v (%s)", err, raw)
+	}
+	return m
+}
+
+func hasTopLevelCombinator(m map[string]any) bool {
+	for _, k := range []string{"oneOf", "anyOf", "allOf"} {
+		if _, ok := m[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// The reproducer: a Zod discriminatedUnion at the ROOT compiles to a
+// top-level anyOf of $ref variants + a $defs block — exactly the shape
+// Anthropic 400s on. After sanitizing, the top-level combinator is gone
+// and every variant's properties are merged into one object schema.
+func TestSanitizeAnthropicToolSchema_FlattensTopLevelRefUnion(t *testing.T) {
+	raw := json.RawMessage(`{
+	  "anyOf": [ {"$ref": "#/$defs/Create"}, {"$ref": "#/$defs/Delete"} ],
+	  "$defs": {
+	    "Create": {"type":"object","properties":{"kind":{"const":"create"},"name":{"type":"string"}},"required":["kind","name"]},
+	    "Delete": {"type":"object","properties":{"kind":{"const":"delete"},"id":{"type":"string"}},"required":["kind","id"]}
+	  }
+	}`)
+	got := parseSchema(t, sanitizeAnthropicToolSchema(raw))
+	if hasTopLevelCombinator(got) {
+		t.Fatalf("top-level combinator survived: %v", got)
+	}
+	if got["type"] != "object" {
+		t.Errorf("type = %v, want object", got["type"])
+	}
+	props, _ := got["properties"].(map[string]any)
+	for _, want := range []string{"kind", "name", "id"} {
+		if _, ok := props[want]; !ok {
+			t.Errorf("merged properties missing %q: %v", want, props)
+		}
+	}
+	// $defs may remain (Anthropic accepts nested $ref/$defs); the point
+	// is only that the TOP LEVEL has no combinator.
+}
+
+func TestSanitizeAnthropicToolSchema_FlattensInlineUnion(t *testing.T) {
+	raw := json.RawMessage(`{"oneOf":[
+	  {"type":"object","properties":{"a":{"type":"string"}}},
+	  {"type":"object","properties":{"b":{"type":"number"}}}
+	]}`)
+	got := parseSchema(t, sanitizeAnthropicToolSchema(raw))
+	if hasTopLevelCombinator(got) {
+		t.Fatalf("combinator survived: %v", got)
+	}
+	props, _ := got["properties"].(map[string]any)
+	if _, ok := props["a"]; !ok {
+		t.Errorf("missing a: %v", props)
+	}
+	if _, ok := props["b"]; !ok {
+		t.Errorf("missing b: %v", props)
+	}
+}
+
+// Regression guard: a plain object schema (the overwhelming common case)
+// must pass through BYTE-FOR-BYTE unchanged — no over-sanitizing.
+func TestSanitizeAnthropicToolSchema_PlainObjectUntouched(t *testing.T) {
+	raw := json.RawMessage(`{"type":"object","properties":{"x":{"type":"string"}},"required":["x"],"additionalProperties":false}`)
+	got := sanitizeAnthropicToolSchema(raw)
+	if string(got) != string(raw) {
+		t.Errorf("plain schema was modified:\n got: %s\nwant: %s", got, raw)
+	}
+}
+
+// A NESTED union must be preserved — Anthropic accepts nested
+// oneOf/anyOf/allOf; only the top level is forbidden. Over-sanitizing
+// here would regress currently-working tools.
+func TestSanitizeAnthropicToolSchema_NestedUnionPreserved(t *testing.T) {
+	raw := json.RawMessage(`{"type":"object","properties":{"payload":{"anyOf":[{"type":"string"},{"type":"number"}]}}}`)
+	got := sanitizeAnthropicToolSchema(raw)
+	if string(got) != string(raw) {
+		t.Errorf("nested union was altered (Anthropic accepts nested):\n got: %s\nwant: %s", got, raw)
+	}
+}
+
+func TestSanitizeAnthropicToolSchema_TypeConflictDefense(t *testing.T) {
+	// One variant object, one array → the array variant's structural
+	// fields must not fold into the object (would be malformed).
+	raw := json.RawMessage(`{"anyOf":[
+	  {"type":"object","properties":{"a":{"type":"string"}}},
+	  {"type":"array","items":{"type":"string"}}
+	]}`)
+	got := parseSchema(t, sanitizeAnthropicToolSchema(raw))
+	if got["type"] != "object" {
+		t.Errorf("type = %v, want object (first variant wins)", got["type"])
+	}
+	if _, hasItems := got["items"]; hasItems {
+		t.Error("array variant's `items` must not fold into the object schema")
+	}
+}
+
+func TestSanitizeAnthropicTools_MapsAndDoesNotMutate(t *testing.T) {
+	orig := json.RawMessage(`{"anyOf":[{"type":"object","properties":{"a":{"type":"string"}}}]}`)
+	in := []providers.ToolSpec{
+		{Name: "plain", InputSchema: json.RawMessage(`{"type":"object","properties":{}}`)},
+		{Name: "union", InputSchema: orig},
+	}
+	out := sanitizeAnthropicTools(in)
+	if hasTopLevelCombinator(parseSchema(t, out[1].InputSchema)) {
+		t.Error("union tool not sanitized")
+	}
+	// Input ToolSpec's raw schema must be untouched (may be shared with a
+	// fallback provider).
+	if !reflect.DeepEqual([]byte(in[1].InputSchema), []byte(orig)) {
+		t.Error("input InputSchema was mutated")
+	}
+}


### PR DESCRIPTION
## The bug

`jobs-search-agent`'s `cv-batch-adapter` (on Anthropic Haiku) 400s on the **first** request of every run, burning **0 tokens**:

```
anthropic 400 invalid_request_error
tools.1.custom.input_schema: input_schema does not support
oneOf, allOf, or anyOf at the top level
```

It's a **wire-construction** failure, not a model/prompt failure (so it's deterministic, zero-token, and Haiku→Sonnet wouldn't help). A Zod `z.discriminatedUnion` / `z.union` at the **root** of an MCP tool's input compiles (via zod-to-json-schema) to a top-level `anyOf`/`oneOf`/`allOf`, which Anthropic refuses. The Anthropic driver passed tool schemas through verbatim — this is the Anthropic-side manifestation of the same root cause the **v0.8.10 Gemini sanitizer** already handles.

## The fix

A **surgical, top-level-only** sanitizer (`internal/providers/anthropic/schema.go`), wired at the single chokepoint (`buildRequestBody` → `wireRequest.Tools`):

- Anthropic's constraint is **narrower** than Gemini's — it forbids the combinator *only at the top level* (nested `oneOf`/`anyOf`/`allOf`, `$ref`, `$defs`, `additionalProperties` are all accepted). So this sanitizer flattens **only a top-level** combinator into a single object schema (merging the variants' properties + required, resolving `$ref` variants against the schema's own `$defs`), and returns every schema **without** a top-level combinator **byte-for-byte unchanged**. No over-sanitizing → zero regression risk for currently-working tools.
- Merge semantics **mirror `mergeGeminiSchemaInto`** (union properties + required, type-conflict defense), so the same union-rooted tool produces the same flattened shape on both providers — already validated in production on the Gemini path for these exact `mcp__jobs__*` tools.
- Covers every tool source (MCP / builtin / LocalAPI) and the `anthropic_oauth_dev` driver (which wraps this one).

## Scope

**Runtime-only** (no HTTP/SSE wire, YAML, or storage change) → ships from loomcycle alone, **no jobs-search-agent lockstep**. A complementary source-side cleanup (wrap the union under an object property in jobs-search-agent) stays optional — this makes loomcycle resilient to *any* union-rooted MCP schema, not just this agent.

## Tested

`schema_test.go`:
- **Reproducer** — a top-level `anyOf` of `$ref` variants + `$defs` (the failing discriminatedUnion shape) → flattened: no top-level combinator, `type: object`, all variants' properties merged.
- Inline-variant union; type-conflict defense (object vs array → array's structural fields dropped); `sanitizeAnthropicTools` maps the list without mutating the shared input schema.
- **No-regression guards**: a plain object schema **and** a nested union both pass through **byte-for-byte unchanged**.

`go build/vet/test ./...` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)