### PR TITLE
fix(auth): enforce cross-principal session ownership (RFC L) [HIGH]

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -268,6 +268,28 @@ func (s *Server) applyPrincipal(ctx context.Context, wireTenant, wireUser string
 	return p.TenantID, p.Subject
 }
 
+// sessionOwnershipOK reports whether the ctx principal may continue or read
+// sess (RFC L cross-principal boundary). A continuation or transcript read
+// runs under / exposes the SESSION'S stored (tenant, subject) — so it must
+// belong to the same authoritative principal that created it. Session ids are
+// NOT secrets (they are returned to the caller, logged, shown in the UI, and
+// embedded in events/transcripts), so without this check principal-A could
+// POST to principal-B's session id and have the run execute under B's tenant
+// + subject: cross-tenant memory read/write, replay of B's transcript back to
+// A, fairness-cap evasion, and attribution as B.
+//
+// Exempt (return true): no principal (open dev mode), and the single-operator
+// legacy principal (Legacy=true) — under the legacy shared secret there is
+// exactly one principal, so there is no cross-principal boundary to cross, and
+// pre-RFC-L sessions carry default/empty identity that would otherwise 404.
+func sessionOwnershipOK(ctx context.Context, sess store.Session) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.Legacy {
+		return true
+	}
+	return sess.TenantID == p.TenantID && sess.UserID == p.Subject
+}
+
 // requiredScopeFor maps an HTTP (method, path) to the scope a caller
 // must hold. Empty string = any authenticated principal (no specific
 // scope). substrate:admin satisfies everything (see auth.HasScope), so

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -58,6 +59,62 @@ func seedToken(t *testing.T, st store.Store, plaintext, tenant, subject string, 
 	})
 	if err != nil {
 		t.Fatalf("seed token: %v", err)
+	}
+}
+
+func TestSessionOwnershipOK_Matrix(t *testing.T) {
+	sess := store.Session{TenantID: "acme", UserID: "alice"}
+	cases := []struct {
+		name string
+		ctx  context.Context
+		want bool
+	}{
+		{"no principal (open mode)", context.Background(), true},
+		{"legacy principal exempt", auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "default", Subject: "default", Legacy: true}), true},
+		{"owner matches", auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "alice"}), true},
+		{"wrong tenant", auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "evil", Subject: "alice"}), false},
+		{"wrong subject", auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "mallory"}), false},
+	}
+	for _, c := range cases {
+		if got := sessionOwnershipOK(c.ctx, sess); got != c.want {
+			t.Errorf("%s: sessionOwnershipOK = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// A continuation runs under the SESSION'S stored tenant+subject. Without an
+// ownership check, principal-A could POST to principal-B's session id and
+// execute under B's identity (cross-tenant memory, B's transcript replayed to
+// A, fairness evasion). Session ids are not secrets. The guard returns an
+// opaque 404 to a non-owner.
+func TestHandleMessages_RejectsCrossPrincipalSession(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	sess, err := st.CreateSession(context.Background(), "acme", "agentx", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	body := `{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`
+
+	mkReq := func(tenant, subject string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sess.ID+"/messages", strings.NewReader(body))
+		r.SetPathValue("id", sess.ID)
+		r.Header.Set("Content-Type", "application/json")
+		r = r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: []string{auth.ScopeRunsCreate},
+		}))
+		rr := httptest.NewRecorder()
+		s.handleMessages(rr, r)
+		return rr
+	}
+
+	// Different principal → opaque 404 (the security property).
+	if rr := mkReq("evil", "mallory"); rr.Code != http.StatusNotFound {
+		t.Fatalf("cross-principal continuation: status=%d, want 404 (ownership not enforced?)", rr.Code)
+	}
+	// The owner passes the ownership gate (must NOT be the ownership 404; it
+	// proceeds past the check — any later status is fine, just not 404).
+	if rr := mkReq("acme", "alice"); rr.Code == http.StatusNotFound {
+		t.Fatalf("owner continuation got 404 — the ownership guard rejected the legitimate owner")
 	}
 }
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1344,6 +1344,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 			}
 			return fmt.Errorf("%w: %v", runner.ErrInternal, err)
 		}
+		// RFC L: cross-principal session-ownership guard (see
+		// sessionOwnershipOK). Opaque not-found on mismatch, no oracle.
+		if !sessionOwnershipOK(ctx, sess) {
+			return fmt.Errorf("%w: %s", runner.ErrSessionNotFound, in.SessionID)
+		}
 		effectiveAgentName = sess.Agent
 		effectiveTenantID = sess.TenantID
 		effectiveUserID = sess.UserID
@@ -2770,6 +2775,13 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// RFC L: a continuation runs under the session's stored tenant+subject, so
+	// the caller principal must OWN the session. 404 (not 403) on mismatch so
+	// a non-owner can't probe which session ids exist (no-oracle).
+	if !sessionOwnershipOK(r.Context(), sess) {
+		http.Error(w, (&store.ErrNotFound{Kind: "session", ID: id}).Error(), http.StatusNotFound)
+		return
+	}
 
 	// Per-session continuation lock: take the lock before transcript
 	// replay so two concurrent POSTs to the same session can't read
@@ -3231,6 +3243,12 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// RFC L: the transcript exposes the session's full history — gate it on
+	// the same cross-principal ownership as continuation (opaque 404).
+	if !sessionOwnershipOK(r.Context(), sess) {
+		http.Error(w, (&store.ErrNotFound{Kind: "session", ID: id}).Error(), http.StatusNotFound)
+		return
+	}
 	transcript, err := s.store.GetTranscript(r.Context(), id)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -3290,6 +3308,12 @@ func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSession
 		sess, err = s.store.GetSession(ctx, requestedSessionID)
 		if err != nil {
 			return "", "", err
+		}
+		// RFC L: continuing an existing session via POST /v1/runs runs under
+		// that session's stored identity — enforce cross-principal ownership
+		// (opaque not-found on mismatch).
+		if !sessionOwnershipOK(ctx, sess) {
+			return "", "", &store.ErrNotFound{Kind: "session", ID: requestedSessionID}
 		}
 	} else {
 		sess, err = s.store.CreateSession(ctx, tenantID, agent, userID)


### PR DESCRIPTION
## Severity: HIGH — cross-tenant isolation break via session continuation

## Why

A session continuation runs under the **session's stored** `(tenant, subject)`: `handleMessages` keys fairness (`server.go:2840`), the run row (`:2896`), and the threaded `RunIdentity` — including the **memory-tenancy `TenantID`** (`:2990`) — on `sess.UserID`/`sess.TenantID`. But **nothing checked that the calling principal owns the session**, and session ids are **not secrets** (returned to the caller, logged, shown in the UI, embedded in events/transcripts).

So principal-A holding any `runs:create` token could `POST /v1/sessions/{B-id}/messages` and have the run execute under **principal-B's identity**:
- cross-tenant **memory read/write** (tenancy key = `sess.TenantID`),
- **B's full prior transcript replayed back to A** over SSE,
- **B's fairness cap** spent (evasion / targeted DoS),
- run **attributed to B**.

The same gap existed on the `POST /v1/runs` continuation (`openOrCreateSessionAndRun`), the gRPC/runner `Continue` path (`RunOnce`), and the **`GET` transcript read** (`handleTranscript` — a pure cross-tenant read).

**Attack:** B creates a session → `session_id=S` is returned/logged/shown in UI → A sends `POST /v1/sessions/S/messages` with any `runs:create` token → run executes as B.

## What

`sessionOwnershipOK(ctx, sess)` (`auth_principal.go`): a **non-legacy** principal may act on a session only when `sess.TenantID == p.TenantID && sess.UserID == p.Subject`. Exempt: no principal (open dev mode) and the single-operator **legacy** principal (one principal ⇒ no cross-principal boundary; pre-RFC-L sessions carry default/empty identity). Applied at **all four** session-identity sites — `handleMessages`, `openOrCreateSessionAndRun`, `RunOnce` continuation, `handleTranscript` — returning an **opaque** not-found (404 / `ErrSessionNotFound`) on mismatch so a non-owner can't probe which session ids exist (no-oracle, matching RFC H/L discipline).

## Tested

- **`TestHandleMessages_RejectsCrossPrincipalSession`** — a `(evil,mallory)` token gets **404** on `(acme,alice)`'s session; the owner passes the gate. **Fails-before** (neutralizing the guard → the cross-principal request proceeds past the check, 400 not 404).
- **`TestSessionOwnershipOK_Matrix`** pins legacy/open/match/mismatch.
- `go test ./internal/api/http/` + `go vet` + `go build ./...` green.

Found in the RFC L QA hardening pass (Phase 1 — invariant #1, the continuation-session question).

🤖 Generated with [Claude Code](https://claude.com/claude-code)