### PR TITLE
fix(auth): refuse retiring the last admin token into open mode (RFC L) [HIGH]

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1130,6 +1130,7 @@ func main() {
 		Pepper:               cfg.Env.OperatorTokenPepper,
 		Audit:                tokenAudit,
 		RotationGraceSeconds: graceSecs,
+		LegacyTokenSet:       cfg.Env.AuthToken != "",
 	})
 	// RFC L Decision 11: per-replica auth-token resolution cache. Default
 	// 30s TTL; LOOMCYCLE_AUTH_CACHE_TTL_SECONDS=0 disables it (direct

--- a/internal/tools/builtin/operatortokendef.go
+++ b/internal/tools/builtin/operatortokendef.go
@@ -49,6 +49,14 @@ type OperatorTokenDef struct {
 	// MaxScopes caps the allowed_scopes list length (defense-in-depth).
 	// 0 → 64.
 	MaxScopes int
+
+	// LegacyTokenSet reports whether LOOMCYCLE_AUTH_TOKEN is configured
+	// (wired from main.go). When false, retiring the LAST admin-scoped token
+	// would flip authConfigured to false → unauthenticated open mode, so the
+	// no-fail-open guard in execRetire refuses it. When a legacy fallback
+	// exists, retiring the last admin merely re-enables it (recoverable), so
+	// the guard does not fire.
+	LegacyTokenSet bool
 }
 
 // operatorTokenNameRe constrains name / tenant_id / subject. RFC L:
@@ -296,6 +304,23 @@ func (s *OperatorTokenDef) execRetire(ctx context.Context, in operatorTokenDefIn
 	target, err := s.resolveTarget(ctx, "retire", in)
 	if err != nil {
 		return errResult(err.Error()), nil
+	}
+	// No-fail-open guard (RFC L Decision 12). Retiring the last active
+	// admin-scoped token drops the active-admin count to zero; with no legacy
+	// LOOMCYCLE_AUTH_TOKEN fallback, authConfigured then flips to false and the
+	// server falls into UNAUTHENTICATED open mode — a silent fail-open worse
+	// than a lockout. Refuse it; the operator must create/rotate another admin
+	// token first (or keep the legacy fallback). Rotate is exempt by
+	// construction: it mints a replacement admin token for the same principal
+	// before retiring the prior, so the count never reaches zero.
+	if !s.LegacyTokenSet && auth.HasScope(target.AllowedScopes, auth.ScopeAdmin) {
+		n, cErr := s.Store.OperatorTokenDefCountActiveAdmin(ctx)
+		if cErr != nil {
+			return errResult(fmt.Sprintf("retire: admin-count check: %s", cErr)), nil
+		}
+		if n <= 1 {
+			return errResult("retire: refusing to retire the last admin-scoped token — with no LOOMCYCLE_AUTH_TOKEN fallback this would drop the server into unauthenticated open mode; create or rotate another substrate:admin token first"), nil
+		}
 	}
 	now := time.Now().UTC()
 	if err := s.Store.OperatorTokenDefSetRetiredAt(ctx, target.DefID, now); err != nil {

--- a/internal/tools/builtin/operatortokendef_test.go
+++ b/internal/tools/builtin/operatortokendef_test.go
@@ -238,7 +238,10 @@ func TestOperatorTokenDef_RotateMintsNewTokenAndGracesPrior(t *testing.T) {
 func TestOperatorTokenDef_RetireImmediate(t *testing.T) {
 	tool, ctx, s, cleanup := operatorTokenDefFixture(t)
 	defer cleanup()
-	c := mustOp(t, tool, ctx, `{"op":"create","name":"temp","tenant_id":"t"}`)
+	// Non-admin scope so the no-fail-open guard (which protects the LAST
+	// admin token under no legacy fallback) doesn't apply — this test is
+	// about retire taking effect immediately, not the admin-count guard.
+	c := mustOp(t, tool, ctx, `{"op":"create","name":"temp","tenant_id":"t","scopes":["runs:create"]}`)
 	defID := c["def_id"].(string)
 	mustOp(t, tool, ctx, `{"op":"retire","name":"temp"}`)
 	if _, err := s.OperatorTokenDefGetCurrentByName(ctx, "temp"); err == nil {

--- a/internal/tools/builtin/operatortokendef_test.go
+++ b/internal/tools/builtin/operatortokendef_test.go
@@ -42,6 +42,54 @@ func mustOp(t *testing.T, tool *OperatorTokenDef, ctx context.Context, in string
 	return out
 }
 
+// Retiring the LAST admin-scoped token with no legacy fallback would flip the
+// server into unauthenticated open mode (authConfigured → false) — a silent
+// fail-open. The guard refuses it. With another admin token, or with a legacy
+// fallback configured, the retire is allowed.
+func TestOperatorTokenDef_RetireLastAdmin_RefusedWhenNoLegacyFallback(t *testing.T) {
+	tool, ctx, _, cleanup := operatorTokenDefFixture(t) // LegacyTokenSet=false
+	defer cleanup()
+
+	mustOp(t, tool, ctx, `{"op":"create","name":"ops","tenant_id":"acme","subject":"ops","scopes":["substrate:admin"]}`)
+
+	// Retiring the only admin token → refused (would open the server).
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"retire","name":"ops"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError || !strings.Contains(res.Text, "last admin-scoped token") {
+		t.Fatalf("retiring the last admin token should be refused; got is_error=%v text=%q", res.IsError, res.Text)
+	}
+
+	// A second admin token exists → retiring the first is now allowed.
+	mustOp(t, tool, ctx, `{"op":"create","name":"ops2","tenant_id":"acme","subject":"ops2","scopes":["substrate:admin"]}`)
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"retire","name":"ops"}`)); res.IsError {
+		t.Fatalf("retiring one of two admin tokens should be allowed; got %s", res.Text)
+	}
+}
+
+// A non-admin token is never the fail-open concern, so it can always be
+// retired even as the only token; and with a legacy fallback the last-admin
+// retire is permitted (it merely re-enables the legacy secret).
+func TestOperatorTokenDef_RetireLastAdmin_AllowedWithLegacyOrNonAdmin(t *testing.T) {
+	// Non-admin, no legacy: retire allowed.
+	tool, ctx, _, cleanup := operatorTokenDefFixture(t)
+	defer cleanup()
+	mustOp(t, tool, ctx, `{"op":"create","name":"narrow","tenant_id":"acme","subject":"narrow","scopes":["runs:create"]}`)
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"retire","name":"narrow"}`)); res.IsError {
+		t.Fatalf("retiring a non-admin token must always be allowed; got %s", res.Text)
+	}
+
+	// Last admin WITH a legacy fallback: allowed.
+	tool2, ctx2, _, cleanup2 := operatorTokenDefFixture(t)
+	defer cleanup2()
+	tool2.LegacyTokenSet = true
+	mustOp(t, tool2, ctx2, `{"op":"create","name":"ops","tenant_id":"acme","subject":"ops","scopes":["substrate:admin"]}`)
+	if res, _ := tool2.Execute(ctx2, json.RawMessage(`{"op":"retire","name":"ops"}`)); res.IsError {
+		t.Fatalf("with a legacy fallback, retiring the last admin should be allowed; got %s", res.Text)
+	}
+}
+
 func TestOperatorTokenDef_CreateMintsTokenOnceAndStoresPepperedHash(t *testing.T) {
 	tool, ctx, s, cleanup := operatorTokenDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Severity: HIGH — silent fail-open (auth fully disabled)

## Why

`authConfigured()` returns false when `LOOMCYCLE_AUTH_TOKEN` is unset **and** the active-admin count is zero, and the auth middleware treats `!authConfigured` as **open mode** (pass-through, no principal stamped, no scope check). `execRetire` had **no guard**, so an operator who migrated off the legacy env var (`AuthToken` unset) and retired their last admin-scoped token would silently drop the **entire server into unauthenticated open mode** — a fail-**OPEN**, worse than the lockout Decision 12 guards against.

The "open mode is unreachable" argument (Phase 2 brief) only covers *bootstrapping in*; it does not cover *retiring out* of a one-admin state.

## What

`execRetire` now refuses to retire an **admin-scoped** token when:
- no legacy fallback is set (`LegacyTokenSet=false`, wired from `cfg.Env.AuthToken != ""` in `main.go`), **and**
- it is the last active admin (`OperatorTokenDefCountActiveAdmin() <= 1`).

…with a clear message to create/rotate another admin first. **Rotate is exempt** by construction (mints a replacement admin for the same principal before retiring the prior — count never hits zero). When a legacy fallback exists, the last-admin retire is allowed (it merely re-enables the recoverable legacy secret, not open mode).

## Tested

- **`TestOperatorTokenDef_RetireLastAdmin_RefusedWhenNoLegacyFallback`** — retiring the only admin is refused; with a second admin it's allowed. **Fails-before** (neutralizing the guard lets the last-admin retire succeed — the fail-open).
- **`TestOperatorTokenDef_RetireLastAdmin_AllowedWithLegacyOrNonAdmin`** — non-admin always retirable; last-admin allowed when a legacy fallback exists.
- `go build ./...` + `go test ./internal/tools/builtin/` green.

Found in the RFC L QA hardening pass (Phase 2 — the `authConfigured` open-mode edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)