### PR TITLE
fix(auth): close per-route scope-map gaps (RFC L) [HIGH]

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -288,15 +288,34 @@ func requiredScopeFor(method, path string) string {
 	// Operator hook management.
 	case strings.HasPrefix(path, "/v1/hooks"):
 		return auth.ScopeAdmin
+	// Prometheus scrape — operator surface, same posture as /v1/_metrics/*.
+	case path == "/metrics":
+		return auth.ScopeAdmin
+	// Per-user channel surface (/v1/users/{id}/channels/...) — graduate the
+	// channel scopes. MUST precede the generic "/v1/users/" reads case below
+	// so peek resolves to channel:read, not runs:read, and the writes
+	// (publish/subscribe/ack) are not left at the any-authenticated default.
+	case strings.HasPrefix(path, "/v1/users/") && strings.Contains(path, "/channels/"):
+		if method == http.MethodGet {
+			return auth.ScopeChannelRead
+		}
+		return auth.ScopeChannelPublish
 	// Run creation (fresh run + session continuation message).
 	case method == http.MethodPost && path == "/v1/runs":
 		return auth.ScopeRunsCreate
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/sessions/") && strings.HasSuffix(path, "/messages"):
 		return auth.ScopeRunsCreate
-	// Cancel a run — a write on run state.
-	case method == http.MethodDelete && strings.HasPrefix(path, "/v1/agents/"):
+	// Cancel a run — a write on run state. (The real route is POST
+	// /v1/agents/{id}/cancel; the prior DELETE /v1/agents/ case matched no
+	// registered route, so cancel fell through to any-authenticated.)
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/agents/") && strings.HasSuffix(path, "/cancel"):
 		return auth.ScopeRunsCreate
-	// Run / agent / session reads.
+	// Human-in-the-loop interrupt: resolve is a run-state write, list a read.
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/resolve"):
+		return auth.ScopeRunsCreate
+	case method == http.MethodGet && strings.HasPrefix(path, "/v1/runs/"):
+		return auth.ScopeRunsRead
+	// Run / agent / session / user reads.
 	case method == http.MethodGet && (strings.HasPrefix(path, "/v1/agents/") ||
 		strings.HasPrefix(path, "/v1/users/") ||
 		strings.HasPrefix(path, "/v1/sessions/")):

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -126,13 +126,24 @@ func TestRequiredScopeFor(t *testing.T) {
 	}{
 		{"POST", "/v1/runs", auth.ScopeRunsCreate},
 		{"POST", "/v1/sessions/s_1/messages", auth.ScopeRunsCreate},
-		{"DELETE", "/v1/agents/a_1", auth.ScopeRunsCreate},
+		// Cancel is POST /v1/agents/{id}/cancel — must be runs:create (was a
+		// dead DELETE case → any-authenticated).
+		{"POST", "/v1/agents/a_1/cancel", auth.ScopeRunsCreate},
+		// Interrupt resolve = write, list = read (were any-authenticated).
+		{"POST", "/v1/runs/r_1/interrupts/i_1/resolve", auth.ScopeRunsCreate},
+		{"GET", "/v1/runs/r_1/interrupts", auth.ScopeRunsRead},
 		{"GET", "/v1/agents/a_1", auth.ScopeRunsRead},
 		{"GET", "/v1/users/alice/agents", auth.ScopeRunsRead},
+		// Per-user channel surface uses the channel scopes (were
+		// any-authenticated / wrongly runs:read for peek).
+		{"POST", "/v1/users/alice/channels/work/publish", auth.ScopeChannelPublish},
+		{"POST", "/v1/users/alice/channels/work/ack", auth.ScopeChannelPublish},
+		{"GET", "/v1/users/alice/channels/work/peek", auth.ScopeChannelRead},
 		{"POST", "/v1/_operatortokendef", auth.ScopeAdmin},
 		{"GET", "/v1/_resolver", auth.ScopeAdmin},
 		{"POST", "/v1/_pause", auth.ScopeAdmin},
 		{"DELETE", "/v1/hooks/h_1", auth.ScopeAdmin},
+		{"GET", "/metrics", auth.ScopeAdmin},
 		// Consumer gateway endpoints are NOT admin.
 		{"POST", "/v1/_llm/chat", ""},
 		{"POST", "/v1/chat/completions", ""},


### PR DESCRIPTION
## Severity: HIGH — under-gated mutating routes (broken access control)

## Why

`requiredScopeFor` left several mutating/sensitive routes at the **any-authenticated default (`""`)**, so a narrow token — even `runs:read`-only — could reach them:

- **`POST /v1/agents/{id}/cancel`** — the cancel case was keyed on **DELETE** (a verb no route uses; route is `POST .../cancel` at `server.go:1704`), so the real POST cancel fell through to `""` → any token could cancel any run.
- **`POST /v1/runs/{id}/interrupts/{id}/resolve`** (a run-state write) and **`GET /v1/runs/{id}/interrupts`** (a read) → `""` (no `/v1/runs/` case existed).
- **Per-user channel surface** `POST /v1/users/{id}/channels/{name}/{publish,subscribe,ack}` → `""`, and `GET .../peek` → `runs:read` (wrong). The `channel:*` scopes existed but **no route used them** (dead vocabulary).
- **`GET /metrics`** → `""` though its `/v1/_metrics/*` siblings require admin (the comment even claimed parity).

## What

Add the missing cases — POST cancel → `runs:create`; interrupt resolve → `runs:create`, list → `runs:read`; per-user channel → `channel:publish` (writes) / `channel:read` (peek), placed **before** the generic `/v1/users/` read case so peek resolves correctly; `/metrics` → `substrate:admin`. Removed the dead `DELETE /v1/agents/` case.

## Tested

- **`TestRequiredScopeFor`** extended with the cancel/interrupt/channel/metrics cases — **fails-before** (old map returns `""`/`runs:read`), passes after.
- Full `go test ./internal/api/http/` + `go vet` + `go build ./...` green.

## Residuals (documented in the QA report, tracked as follow-ups)

- The per-user channel **handlers** take `user_id` from the URL path and don't yet check it equals the principal `Subject` — a `channel:publish` token can still target another subject's channel (handler-level ownership, same class as the session-ownership fix).
- `memory:read`/`memory:write` remain **unused vocabulary** (the HTTP memory surface is all admin-gated under `/v1/_memory`) — graduate or remove.

Found in the RFC L QA hardening pass (Phase 1 — invariant #8, scope-map completeness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)