### PR TITLE
fix(auth): don't cache outage negatives + bound the token cache (RFC L)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -185,8 +185,15 @@ func (s *Server) resolvePrincipal(ctx context.Context, bearer string) (auth.Prin
 	if p, found, ok := s.tokenCache.get(hash); ok {
 		return p, found
 	}
-	p, found := s.resolvePrincipalUncached(ctx, bearer, hash)
-	s.tokenCache.put(hash, p, found)
+	p, found, cacheable := s.resolvePrincipalUncached(ctx, bearer, hash)
+	// Only memoise DEFINITIVE outcomes (token hit, legacy fallback, genuine
+	// not-found/expired). A transient store OUTAGE resolves to (_, false) but
+	// is NOT cacheable: caching it would lock a VALID token out for the whole
+	// TTL after the DB recovered — a blip amplified into a ≤30s sticky
+	// lockout. On an outage we fail closed for THIS request only and re-probe.
+	if cacheable {
+		s.tokenCache.put(hash, p, found)
+	}
 	return p, found
 }
 
@@ -196,7 +203,11 @@ func (s *Server) resolvePrincipal(ctx context.Context, bearer string) (auth.Prin
 // an admin-scoped token exists — the no-lockout migration gate). Returns
 // (_, false) for unknown/expired/invalid — the caller maps that to an
 // opaque 401. NEVER fails open to the legacy token on a substrate error.
-func (s *Server) resolvePrincipalUncached(ctx context.Context, bearer, hash string) (auth.Principal, bool) {
+//
+// The third return is `cacheable`: true for a DEFINITIVE outcome (hit, legacy,
+// genuine not-found/expired) that resolvePrincipal may memoise; FALSE for a
+// transient store outage so a blip is not cached into a sticky lockout.
+func (s *Server) resolvePrincipalUncached(ctx context.Context, bearer, hash string) (auth.Principal, bool, bool) {
 	if s.store != nil {
 		row, err := s.store.OperatorTokenDefGetByTokenHash(ctx, hash)
 		if err == nil {
@@ -207,33 +218,33 @@ func (s *Server) resolvePrincipalUncached(ctx context.Context, bearer, hash stri
 					Subject:    row.Subject,
 					Scopes:     row.AllowedScopes,
 					TokenDefID: row.DefID,
-				}, true
+				}, true, true
 			}
-			return auth.Principal{}, false // expired → opaque 401, no legacy fall-open
+			return auth.Principal{}, false, true // expired → opaque 401, cacheable
 		}
 		// Not found (ErrNotFound) → fall through to legacy. Any OTHER
-		// store error is a genuine outage: fail closed below (we do not
-		// reach the legacy branch with a usable substrate state).
+		// store error is a genuine outage: fail closed AND not cacheable (we
+		// do not reach the legacy branch with a usable substrate state).
 		if !isNotFound(err) {
 			if s.authVerbose() {
 				log.Printf("auth: token-substrate lookup error (failing closed): %v", err)
 			}
-			return auth.Principal{}, false
+			return auth.Principal{}, false, false
 		}
 	}
 	// Legacy shared-secret fallback.
 	if s.cfg.Env.AuthToken != "" && auth.CompareBearer(bearer, s.cfg.Env.AuthToken) {
 		if s.legacyFallbackDisabled(ctx) {
-			return auth.Principal{}, false
+			return auth.Principal{}, false, true
 		}
 		return auth.Principal{
 			TenantID: "default",
 			Subject:  "default",
 			Scopes:   []string{auth.ScopeAdmin},
 			Legacy:   true,
-		}, true
+		}, true, true
 	}
-	return auth.Principal{}, false
+	return auth.Principal{}, false, true // genuine unknown → cacheable negative
 }
 
 // legacyFallbackDisabled reports whether the LOOMCYCLE_AUTH_TOKEN path is

--- a/internal/api/http/token_cache.go
+++ b/internal/api/http/token_cache.go
@@ -30,15 +30,26 @@ type tokenCacheEntry struct {
 	expiresAt time.Time
 }
 
+// tokenCacheMaxEntries bounds the map. resolvePrincipal caches a negative for
+// every distinct bearer hash, and it runs BEFORE the scope check, so an
+// attacker spraying distinct random bearers at any authed route would
+// otherwise grow the map without bound for the TTL (a memory-amplification
+// DoS — each 256-bit bearer is a fresh key). At the cap, put() sweeps expired
+// entries and, if still full, skips caching (correctness preserved: the next
+// request does the direct lookup). 16384 entries ≈ a few MB — ample for the
+// real working set of live tokens, a hard ceiling for negative spray.
+const tokenCacheMaxEntries = 16384
+
 type tokenCache struct {
-	mu  sync.RWMutex
-	m   map[string]tokenCacheEntry
-	ttl time.Duration
-	now func() time.Time // injectable for tests
+	mu      sync.RWMutex
+	m       map[string]tokenCacheEntry
+	ttl     time.Duration
+	maxSize int
+	now     func() time.Time // injectable for tests
 }
 
 func newTokenCache(ttl time.Duration) *tokenCache {
-	return &tokenCache{m: make(map[string]tokenCacheEntry), ttl: ttl, now: time.Now}
+	return &tokenCache{m: make(map[string]tokenCacheEntry), ttl: ttl, maxSize: tokenCacheMaxEntries, now: time.Now}
 }
 
 // get returns the cached resolution for a hash. ok=false on a miss or an
@@ -56,14 +67,28 @@ func (c *tokenCache) get(hash string) (auth.Principal, bool /*found*/, bool /*ok
 	return e.principal, e.found, true
 }
 
-// put records a resolution. No-op when the cache is disabled.
+// put records a resolution. No-op when the cache is disabled. Bounded by
+// maxSize: at the cap it first evicts expired entries, then — if still full —
+// skips caching this entry (the next request does a direct lookup). This caps
+// the negative-cache memory an invalid-bearer spray can consume.
 func (c *tokenCache) put(hash string, p auth.Principal, found bool) {
 	if c == nil || c.ttl <= 0 {
 		return
 	}
 	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.m[hash]; !exists && c.maxSize > 0 && len(c.m) >= c.maxSize {
+		now := c.now()
+		for k, e := range c.m {
+			if now.After(e.expiresAt) {
+				delete(c.m, k)
+			}
+		}
+		if len(c.m) >= c.maxSize {
+			return // still full of live entries — skip caching, stay bounded
+		}
+	}
 	c.m[hash] = tokenCacheEntry{principal: p, found: found, expiresAt: c.now().Add(c.ttl)}
-	c.mu.Unlock()
 }
 
 // flush drops all entries. Called on a local token mutation and on

--- a/internal/api/http/token_cache_test.go
+++ b/internal/api/http/token_cache_test.go
@@ -2,11 +2,68 @@ package http
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 )
+
+// hashFailStore wraps a store and injects a non-ErrNotFound outage on the
+// auth hot-path lookup, to exercise the fail-closed / don't-cache-outage path.
+type hashFailStore struct {
+	store.Store
+	fail bool
+}
+
+func (f *hashFailStore) OperatorTokenDefGetByTokenHash(ctx context.Context, hash string) (store.OperatorTokenDefRow, error) {
+	if f.fail {
+		return store.OperatorTokenDefRow{}, errors.New("connection refused") // outage, not ErrNotFound
+	}
+	return f.Store.OperatorTokenDefGetByTokenHash(ctx, hash)
+}
+
+// A transient store outage must NOT be cached as a negative — otherwise a
+// valid token is locked out for the full TTL after the DB recovers.
+func TestResolvePrincipal_OutageNotCached(t *testing.T) {
+	s, st := tokenAuthServer(t, "") // no legacy fallback → clean outage path
+	seedToken(t, st, "lct_v", "acme", "v", []string{auth.ScopeRunsCreate}, time.Time{})
+	fs := &hashFailStore{Store: st, fail: true}
+	s.store = fs
+	s.EnableTokenCache(30 * time.Second)
+
+	// During the outage the valid token fails closed...
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_v"); ok {
+		t.Fatal("during a store outage resolution must fail closed")
+	}
+	// ...but the failure must NOT be memoised.
+	if _, _, ok := s.tokenCache.get(auth.HashToken(testTokenPepper, "lct_v")); ok {
+		t.Fatal("a store-outage negative must not be cached (would be a sticky lockout)")
+	}
+	// After recovery the valid token resolves immediately — not served a
+	// stale cached negative.
+	fs.fail = false
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_v"); !ok {
+		t.Fatal("after recovery the valid token must resolve (a cached outage-negative was served)")
+	}
+}
+
+// The cache is bounded: an invalid-bearer spray (distinct hashes) cannot grow
+// the map without limit (each negative is cached before the scope check).
+func TestTokenCache_BoundedBySize(t *testing.T) {
+	c := newTokenCache(30 * time.Second)
+	c.maxSize = 4
+	now := time.Unix(1000, 0)
+	c.now = func() time.Time { return now }
+	for i := 0; i < 1000; i++ {
+		c.put(fmt.Sprintf("h%d", i), auth.Principal{}, false) // distinct negative entries
+	}
+	if len(c.m) > c.maxSize {
+		t.Fatalf("cache grew to %d entries, want <= %d (negative-spray DoS bound)", len(c.m), c.maxSize)
+	}
+}
 
 func TestTokenCache_HitMissExpiryFlush(t *testing.T) {
 	now := time.Unix(1000, 0)


### PR DESCRIPTION
## Severity: HIGH (availability) + MEDIUM (DoS)

Two issues in the per-replica auth resolution cache (RFC L Decision 11):

### (1) HIGH — transient store outage cached as a sticky negative
`resolvePrincipal` cached **every** miss, including a transient store **outage** (`resolvePrincipalUncached` maps a non-`ErrNotFound` store error to `(_,false)`). So a **valid** token that resolved during a DB blip got a negative cache entry for the full TTL — **locked out for up to 30s after the DB recovered**. A blip amplified into a sticky lockout.

### (2) MEDIUM — unbounded negative cache (memory-amplification DoS)
The cache map had **no size bound** and no proactive eviction, and `resolvePrincipal` caches a negative for every distinct bearer hash **before** the scope check. Spraying distinct random bearers at any authed route grew the map without bound for the TTL (each 256-bit bearer = a fresh key).

## What

1. `resolvePrincipalUncached` returns a third `cacheable` flag — **false only on a transient store outage** (fail closed for *this* request, re-probe next time), true for definitive outcomes (hit / legacy / genuine not-found+expired). `resolvePrincipal` caches only when `cacheable`.
2. `tokenCache` gains a `maxSize` bound (16384). `put()` at the cap sweeps expired entries, then skips caching if still full (correctness preserved — next request does the direct lookup).

## Tested

- **`TestResolvePrincipal_OutageNotCached`** — a store-outage negative is not cached and the valid token resolves immediately after recovery. **Fails-before** (always-cache → sticky negative).
- **`TestTokenCache_BoundedBySize`** — 1000 distinct negatives stay ≤ `maxSize`. **Fails-before** (grew to 1000).
- Full `go test ./internal/api/http/` + `go vet` + `go build ./...` green.

Found in the RFC L QA hardening pass (Phase 1 invariant #9 / Phase 2 cache review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)