### PR TITLE
test(heartbeat): de-flake TestSweeperOnce_MarksStale via injectable clock

### DIFF
--- a/internal/heartbeat/sweeper.go
+++ b/internal/heartbeat/sweeper.go
@@ -58,6 +58,12 @@ type Config struct {
 	// AdvisoryLockKey is the lock-key int64 (typically coord.LockKeyHeartbeatSweeper).
 	// Only consulted when AdvisoryLock is non-nil.
 	AdvisoryLockKey int64
+
+	// Now is the clock sweepOnce reads to compute the staleness cutoff
+	// (cutoff = Now() - StaleAfter). Nil defaults to time.Now. Injectable
+	// so tests can pin the cutoff deterministically instead of racing real
+	// wall-clock elapsed time against StaleAfter.
+	Now func() time.Time
 }
 
 // AdvisoryLocker is the minimum surface the sweeper needs from
@@ -82,6 +88,7 @@ type Sweeper struct {
 	logf       func(format string, args ...any)
 	lock       AdvisoryLocker
 	lockKey    int64
+	now        func() time.Time
 }
 
 // New constructs a Sweeper with the supplied tuning. A nil store means
@@ -97,6 +104,9 @@ func New(st store.Store, cfg Config) *Sweeper {
 	if cfg.Logger == nil {
 		cfg.Logger = log.Printf
 	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
 	return &Sweeper{
 		store:      st,
 		interval:   cfg.Interval,
@@ -104,6 +114,7 @@ func New(st store.Store, cfg Config) *Sweeper {
 		logf:       cfg.Logger,
 		lock:       cfg.AdvisoryLock,
 		lockKey:    cfg.AdvisoryLockKey,
+		now:        cfg.Now,
 	}
 }
 
@@ -188,6 +199,6 @@ func (s *Sweeper) Run(ctx context.Context) {
 func (s *Sweeper) sweepOnce(parent context.Context) (int, error) {
 	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 	defer cancel()
-	cutoff := time.Now().Add(-s.staleAfter)
+	cutoff := s.now().Add(-s.staleAfter)
 	return s.store.SweepStaleRuns(ctx, cutoff)
 }

--- a/internal/heartbeat/sweeper_test.go
+++ b/internal/heartbeat/sweeper_test.go
@@ -36,22 +36,26 @@ func TestSweeperOnce_MarksStale(t *testing.T) {
 	stale, _ := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_stale"})
 	_ = st.UpdateHeartbeat(ctx, stale.ID)
 
-	// Sleep + StaleAfter gap was 20ms vs 10ms — flaked under -race
-	// where scheduling slowdown could push the time between fresh
-	// heartbeat write and the sweepOnce cutoff calculation past 10ms,
-	// causing the fresh row to also count as stale (test expects
-	// exactly 1 marked stale). Widened to 100ms sleep + 50ms cutoff
-	// for a 5× margin — still fast (~100ms total test runtime) but
-	// resilient to -race slowdown.
-	time.Sleep(100 * time.Millisecond)
+	// `mid` is captured AFTER the stale row's heartbeat write returns and
+	// BEFORE the fresh row's — so by program order (and nanosecond UnixNano
+	// heartbeats) stale_hb < mid < fresh_hb, strictly. We pin the sweeper's
+	// clock so its cutoff lands exactly at `mid`: the stale row is older
+	// (marked), the fresh row newer (spared). Deterministic, with NO
+	// dependence on wall-clock elapsed time. The previous version slept then
+	// used real time.Now() in sweepOnce, which flaked under -race when the
+	// fresh heartbeat aged past the cutoff in the gap between its write and
+	// the sweep's clock read (CI: "sweepOnce returned 2, want 1").
+	mid := time.Now()
 
 	fresh, _ := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_fresh"})
 	_ = st.UpdateHeartbeat(ctx, fresh.ID)
 
+	const staleWindow = time.Minute
 	sw := New(st, Config{
 		Interval:   1 * time.Hour, // unused — we drive sweepOnce directly
-		StaleAfter: 50 * time.Millisecond,
-		Logger:     func(format string, args ...any) {}, // silence
+		StaleAfter: staleWindow,
+		Logger:     func(format string, args ...any) {},              // silence
+		Now:        func() time.Time { return mid.Add(staleWindow) }, // cutoff == mid
 	})
 	n, err := sw.sweepOnce(ctx)
 	if err != nil {


### PR DESCRIPTION
## Why

The stale-sweeper test separated a *stale* and a *fresh* run by **sleeping** between their heartbeat writes, then drove `sweepOnce` — which reads real `time.Now()` to compute `cutoff = now - StaleAfter`. Under `go test -race` on a loaded CI runner, the gap between the **fresh** heartbeat write and that `time.Now()` could exceed `StaleAfter`, so the fresh row aged past the cutoff and was also marked stale:

```
--- FAIL: TestSweeperOnce_MarksStale
    sweeper_test.go:61: sweepOnce returned 2, want 1
    sweeper_test.go:70: fresh row: status="failed", want running
```

A prior widening (20/10ms → 100/50ms) reduced but didn't remove it; it resurfaced on CI and **blocks every PR's `go test -race ./...`** (surfaced here on the open RFC L token-cache PR #331, which doesn't touch this package).

## What

Make the sweeper's clock **injectable** — `Config.Now` (defaults to `time.Now`), read by `sweepOnce` as `cutoff = Now() - StaleAfter`. The test now captures `mid` strictly **between** the two heartbeat writes (program order + nanosecond `UnixNano` heartbeats guarantee `stale_hb < mid < fresh_hb`) and pins `Now` so the cutoff is exactly `mid` — stale marked, fresh spared, with **no dependence on wall-clock elapsed time**. Production behavior is unchanged (`Now` defaults to `time.Now`).

## Tested

- `go test -race ./internal/heartbeat/ -count=50` — green (was intermittently red on CI).
- `go vet` + `go build ./...` clean.

A standalone CI-stability fix (no behavior change) — unblocks `go test -race ./...` for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)