### PR TITLE
fix(auth): remove inert memory:read/memory:write scopes from the catalog

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -749,7 +749,7 @@ By default every authenticated caller presents the single shared `LOOMCYCLE_AUTH
 ```sh
 # Mint a per-developer token (shown once). Needs an existing admin bearer.
 loomcycle operator-token create --tenant acme --subject alice \
-  --scopes runs:create,runs:read,memory:read,memory:write
+  --scopes runs:create,runs:read
 loomcycle operator-token rotate --name alice   # zero-downtime roll (grace window)
 loomcycle operator-token retire --name alice   # immediate revoke
 ```

--- a/internal/auth/scopes.go
+++ b/internal/auth/scopes.go
@@ -14,19 +14,26 @@ const (
 
 	ScopeRunsCreate     = "runs:create"
 	ScopeRunsRead       = "runs:read"
-	ScopeMemoryRead     = "memory:read"
-	ScopeMemoryWrite    = "memory:write"
 	ScopeChannelPublish = "channel:publish"
 	ScopeChannelRead    = "channel:read"
+
+	// NOTE: memory:read / memory:write are intentionally NOT in the
+	// catalog. They were inert — grantable but enforced by no route: the
+	// HTTP memory surface (/v1/_memory/*) is operator-admin, and
+	// per-tenant memory read/write is the agent-facing Memory tool gated
+	// by the run's memory policy, not an HTTP scope. A scope the runtime
+	// never checks is a false limitation, so it's removed (same
+	// dead-config posture as the retired WebhookDefScopes /
+	// MemoryBackendDefScopes). Reintroduce only alongside a route that
+	// actually enforces them.
 )
 
-// scopeCatalog is the closed set. A map for O(1) validation.
+// scopeCatalog is the closed set — every entry is enforced by at least
+// one route in requiredScopeFor. A map for O(1) validation.
 var scopeCatalog = map[string]struct{}{
 	ScopeAdmin:          {},
 	ScopeRunsCreate:     {},
 	ScopeRunsRead:       {},
-	ScopeMemoryRead:     {},
-	ScopeMemoryWrite:    {},
 	ScopeChannelPublish: {},
 	ScopeChannelRead:    {},
 }

--- a/internal/auth/token_test.go
+++ b/internal/auth/token_test.go
@@ -67,4 +67,11 @@ func TestScopeCatalog(t *testing.T) {
 	if HasScope([]string{ScopeRunsRead}, ScopeRunsCreate) {
 		t.Error("runs:read must NOT satisfy runs:create")
 	}
+	// memory:read / memory:write were removed as inert dead config — a
+	// scope no route enforces must not be grantable (it would be a false
+	// limitation). Guards against silent re-introduction without a
+	// route that enforces it.
+	if ValidScope("memory:read") || ValidScope("memory:write") {
+		t.Error("memory:read/write must not be in the catalog (inert — no route enforces them)")
+	}
 }

--- a/internal/help/builtin/operator-tokens.md
+++ b/internal/help/builtin/operator-tokens.md
@@ -35,19 +35,21 @@ user/tenant by editing the request body.
 ## Scope catalog (closed)
 
 `substrate:admin` (superuser — satisfies every scope), `runs:create`,
-`runs:read`, `memory:read`, `memory:write`, `channel:publish`,
-`channel:read`. Operators can't invent scope names (the runtime wouldn't
-enforce them). The default at create is `["substrate:admin"]`, so a
-first token keeps "single token, full power". Narrow app tokens
-(`["runs:create"]`) are the upgrade path; a route that needs a scope the
-token lacks returns **403** with `WWW-Authenticate: Bearer scope="…"`.
+`runs:read`, `channel:publish`, `channel:read`. Every catalog scope is
+enforced by at least one route — operators can't invent scope names, and
+the catalog intentionally excludes scopes no route checks (a scope that
+enforces nothing is a false limitation). The default at create is
+`["substrate:admin"]`, so a first token keeps "single token, full
+power". Narrow app tokens (`["runs:create"]`) are the upgrade path; a
+route that needs a scope the token lacks returns **403** with
+`WWW-Authenticate: Bearer scope="…"`.
 
 ## Managing tokens
 
 ```sh
 # Mint a per-developer token (shown ONCE — store it now).
 loomcycle operator-token create --tenant acme --subject alice \
-  --scopes runs:create,runs:read,memory:read,memory:write
+  --scopes runs:create,runs:read
 
 # A narrow production token.
 loomcycle operator-token create --tenant acme-prod --subject app --scopes runs:create


### PR DESCRIPTION
Actions the **non-blocking H4** recommendation from the v1.0 regression review (`~/work/loomcycle-internal/doc-internal/research/v1.0-regression-review-2026-06-02.md`).

## Why remove (not graduate)

`memory:read` / `memory:write` were **inert**: in the catalog (grantable) but enforced by **no route**. The HTTP memory surface (`/v1/_memory/*`) is operator-admin (`substrate:admin`); per-tenant memory read/write is the **agent-facing Memory tool**, gated by the run's memory policy — not an HTTP scope. A scope the runtime never checks is a *false limitation* (a token "scoped to memory:read" implies a boundary that doesn't exist).

**Graduating** them onto `/v1/_memory/*` would be wrong — those are admin endpoints; gating them to a narrower scope would *weaken* them. So this **removes** them, matching the `WebhookDefScopes` / `MemoryBackendDefScopes` dead-config precedent (#316/#319).

The catalog now contains only scopes `requiredScopeFor` actually enforces: `substrate:admin`, `runs:create`, `runs:read`, `channel:publish`, `channel:read` (`channel:*` was wired by the review's scope-map-gap fix in #327–#331).

## Safety

- **No behavior change for existing token rows** — `resolvePrincipal` loads `allowed_scopes` verbatim and never re-validates against the catalog. Only `create`/`rotate` now reject `memory:read/write` as unknown scopes (the intended honest-catalog outcome; pre-release, no production tokens carry them).

## Tested

`TestScopeCatalog` now asserts `memory:read`/`memory:write` are **not** valid (guards silent re-introduction without an enforcing route). Help topic + CONFIGURATION catalog listings updated to the enforced set. `go test ./...` + gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)