### PR TITLE
feat(ui): login page + role-aware workspace (UI multi-tenant PR 2/2)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loomcycle-ui",
-  "version": "0.7.7",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Loomcycle web UI — read-only monitoring view: running agents tree, errors, per-agent transcript log.",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -167,6 +167,23 @@ export interface TranscriptResponse {
 
 const baseURL = ""; // same-origin
 
+// LOGIN_PATH is the SPA login route (router basename is /ui). An
+// unauthenticated /v1/* call (401 — missing/expired/invalid bearer
+// cookie) bounces here. A 403 (authenticated but insufficient scope) does
+// NOT redirect — you're logged in, just not permitted; callers surface it.
+const LOGIN_PATH = "/ui/login";
+
+// redirectToLoginOn401 sends the browser to the login page on a 401,
+// unless already there (no redirect loop). Returns true when it
+// triggered a navigation so callers can stop processing.
+function redirectToLoginOn401(status: number): boolean {
+  if (status === 401 && window.location.pathname !== LOGIN_PATH) {
+    window.location.href = LOGIN_PATH;
+    return true;
+  }
+  return false;
+}
+
 async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const resp = await fetch(baseURL + path, {
     credentials: "same-origin",
@@ -177,10 +194,34 @@ async function jsonFetch<T>(path: string, init?: RequestInit): Promise<T> {
     },
   });
   if (!resp.ok) {
+    if (redirectToLoginOn401(resp.status)) {
+      // Navigation underway — return a never-settling promise so the
+      // caller doesn't flash an error mid-redirect.
+      return new Promise<T>(() => {});
+    }
     const body = await resp.text();
     throw new Error(`${resp.status} ${resp.statusText}: ${body.slice(0, 200)}`);
   }
   return resp.json() as Promise<T>;
+}
+
+// Principal is the authenticated identity behind the session cookie,
+// resolved by GET /v1/_me. Drives the UI's role: super-admin (is_admin)
+// sees all tenants' workspaces; a tenant sees only its own.
+export interface Principal {
+  tenant_id: string;
+  subject: string;
+  scopes: string[];
+  is_admin: boolean;
+  legacy: boolean;
+  open_mode?: boolean;
+}
+
+// getWhoami resolves the current principal. A 401 redirects to /login via
+// jsonFetch (the returned promise never settles), so callers only ever
+// see a resolved Principal or a non-auth error.
+export function getWhoami(): Promise<Principal> {
+  return jsonFetch<Principal>("/v1/_me");
 }
 
 // jsonFetchAllowing is a sibling of jsonFetch that does NOT throw on

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link, NavLink, Outlet, useOutletContext } from "react-router-dom";
-import { UserSummary, getHealth, listUsers } from "../api";
+import { Principal, UserSummary, getHealth, getWhoami, listUsers } from "../api";
 import PauseControls from "./PauseControls";
 
 const USER_ID_KEY = "loomcycle.userId";
@@ -19,35 +19,66 @@ export default function Layout() {
   const [usersErr, setUsersErr] = useState<string | null>(null);
   const [showManual, setShowManual] = useState(false);
   const [draft, setDraft] = useState(userId);
-  // Fetched from /healthz once on mount. Falls back to the static
-  // shipped version on failure (offline server or pre-v0.8.21 binary
-  // that only returns {"ok":true}). Undefined while in-flight.
   const [version, setVersion] = useState<string | null>(null);
+
+  // The authenticated principal (RFC L / multi-tenant UI authz), resolved
+  // from GET /v1/_me on boot. Drives the role: super-admin (is_admin) sees
+  // all tenants + every tab; a tenant sees only its own workspace. A 401
+  // redirects to /login inside the api layer, so a failure here is a
+  // non-auth error. `undefined` = still loading.
+  const [principal, setPrincipal] = useState<Principal | null | undefined>(undefined);
+  const [principalErr, setPrincipalErr] = useState<string | null>(null);
+  const isAdmin = principal?.is_admin === true;
 
   useEffect(() => {
     localStorage.setItem(USER_ID_KEY, userId);
   }, [userId]);
 
-  // Fetch the running binary's version once on mount. Not polled —
-  // the version doesn't change without a process restart, at which
-  // point the UI bundle is likely reloaded too.
+  // Resolve identity first — everything below branches on the role.
   useEffect(() => {
     let cancelled = false;
-    getHealth()
-      .then((h) => {
-        if (!cancelled) setVersion(h.version || "unknown");
+    getWhoami()
+      .then((p) => {
+        if (cancelled) return;
+        setPrincipal(p);
+        // A tenant's workspace defaults to its own subject's runs so the
+        // runs view is populated immediately without picking a user.
+        if (!p.is_admin && !p.open_mode) {
+          setUserId((cur) => cur || p.subject);
+        }
       })
-      .catch(() => {
-        if (!cancelled) setVersion("offline");
+      .catch((e) => {
+        if (!cancelled) {
+          setPrincipal(null);
+          setPrincipalErr(e instanceof Error ? e.message : String(e));
+        }
       });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  // Poll /v1/_users so the dropdown reflects who has active runs in
-  // near-real-time. Server response is bounded (LIMIT 200) and fast.
+  // Fetch the running binary's version once on mount.
   useEffect(() => {
+    let cancelled = false;
+    getHealth()
+      .then((h) => !cancelled && setVersion(h.version || "unknown"))
+      .catch(() => !cancelled && setVersion("offline"));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Poll /v1/_users for the picker — ADMIN ONLY. /v1/_users is operator-
+  // admin-gated, so a tenant token would just 403; skip it (a tenant uses
+  // its own subject + the manual-entry box for other same-tenant users,
+  // which the per-user reads tenant-filter server-side).
+  useEffect(() => {
+    if (!isAdmin) {
+      setUsers([]);
+      setUsersErr(null);
+      return;
+    }
     let cancelled = false;
     const fetchOnce = async () => {
       try {
@@ -66,7 +97,24 @@ export default function Layout() {
       cancelled = true;
       clearInterval(t);
     };
-  }, []);
+  }, [isAdmin]);
+
+  // Identity gate: hold the shell until we know the role (a 401 has
+  // already redirected to /login by here). A non-auth failure shows a
+  // clear error rather than a half-rendered, mis-scoped UI.
+  if (principal === undefined && principalErr === null) {
+    return <div className="auth-splash">Authenticating…</div>;
+  }
+  if (principalErr !== null) {
+    return (
+      <div className="auth-splash auth-error">
+        Could not load your identity: {principalErr}
+        <div>
+          <a href="/ui/login">Sign in again</a>
+        </div>
+      </div>
+    );
+  }
 
   const knownUser = users.find((u) => u.user_id === userId);
 
@@ -75,25 +123,43 @@ export default function Layout() {
       <header className="topbar">
         <div className="brand">
           <Link to="/">loomcycle</Link>
-          <span className="version">
-            {version === null ? "…" : version}
-          </span>
+          <span className="version">{version === null ? "…" : version}</span>
         </div>
         <nav className="nav-tabs">
+          {/* runs is every role's workspace; the rest are operator-global /
+              admin surfaces, hidden for a tenant (and 403 server-side). */}
           <NavLink to="/agents">runs</NavLink>
-          <NavLink to="/library/agents">library</NavLink>
-          <NavLink to="/channels">channels</NavLink>
-          <NavLink to="/schedules">schedules</NavLink>
-          <NavLink to="/interrupts">interrupts</NavLink>
-          <NavLink to="/memory">memory</NavLink>
-          <NavLink to="/snapshots">snapshots</NavLink>
-          <NavLink to="/audit">audit</NavLink>
-          <NavLink to="/activity">activity</NavLink>
+          {isAdmin && (
+            <>
+              <NavLink to="/library/agents">library</NavLink>
+              <NavLink to="/channels">channels</NavLink>
+              <NavLink to="/schedules">schedules</NavLink>
+              <NavLink to="/interrupts">interrupts</NavLink>
+              <NavLink to="/memory">memory</NavLink>
+              <NavLink to="/snapshots">snapshots</NavLink>
+              <NavLink to="/audit">audit</NavLink>
+              <NavLink to="/activity">activity</NavLink>
+            </>
+          )}
         </nav>
-        <PauseControls />
+        {isAdmin && <PauseControls />}
+        {/* Role/tenant badge — super-admin sees all tenants; a tenant is
+            scoped to its own. */}
+        {principal && (
+          <span
+            className={"role-badge " + (isAdmin ? "role-admin" : "role-tenant")}
+            title={`subject: ${principal.subject}`}
+          >
+            {isAdmin ? "super-admin" : `tenant: ${principal.tenant_id}`}
+          </span>
+        )}
         <div className="user-picker">
-          {usersErr && <span className="picker-err" title={usersErr}>users unavailable</span>}
-          {!showManual && (
+          {usersErr && (
+            <span className="picker-err" title={usersErr}>
+              users unavailable
+            </span>
+          )}
+          {!showManual && isAdmin && (
             <>
               <label htmlFor="user_select">user</label>
               <select
@@ -108,18 +174,20 @@ export default function Layout() {
                   </option>
                 ))}
               </select>
-              <button
-                type="button"
-                className="manual-btn"
-                title="Type a user_id manually (e.g. for users with no runs yet)"
-                onClick={() => {
-                  setDraft(userId);
-                  setShowManual(true);
-                }}
-              >
-                ✎
-              </button>
             </>
+          )}
+          {!showManual && (
+            <button
+              type="button"
+              className="manual-btn"
+              title="Type a user_id manually"
+              onClick={() => {
+                setDraft(userId);
+                setShowManual(true);
+              }}
+            >
+              ✎
+            </button>
           )}
           {showManual && (
             <form
@@ -145,14 +213,22 @@ export default function Layout() {
         </div>
       </header>
       <main className="content">
-        <Outlet context={{ userId }} />
+        <Outlet context={{ userId, principal: principal ?? null }} />
       </main>
     </div>
   );
 }
 
-// Small helper: child routes import this to read userId.
+// Child routes read userId via this helper.
 export function useUserId(): string {
-  const ctx = useOutletContext<{ userId: string }>();
+  const ctx = useOutletContext<{ userId: string; principal: Principal | null }>();
   return ctx.userId;
+}
+
+// usePrincipal exposes the resolved identity to child views (role-aware
+// rendering). Null only in the brief pre-resolution window or a non-auth
+// error (the Layout gates rendering on it, so views generally see it set).
+export function usePrincipal(): Principal | null {
+  const ctx = useOutletContext<{ userId: string; principal: Principal | null }>();
+  return ctx.principal;
 }

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -13,6 +13,7 @@ import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
+import LoginView from "./pages/LoginView";
 
 // Mounted at /ui/ in production; the BrowserRouter basename matches
 // so links / navigation generate correct paths.
@@ -25,6 +26,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter basename="/ui">
       <Routes>
+        {/* Login is outside the Layout shell (no nav, no whoami gate) —
+            it's where a 401 bounces and where the token-entry form lives. */}
+        <Route path="login" element={<LoginView />} />
         <Route path="/" element={<Layout />}>
           <Route index element={<Navigate to="/agents" replace />} />
           <Route path="agents" element={<AgentsView />} />

--- a/web/src/pages/LoginView.tsx
+++ b/web/src/pages/LoginView.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+
+// LoginView is the token-entry auth page (multi-tenant UI authz). loomcycle
+// authenticates by bearer token, not username/password — paste an
+// operator-token (lct_… or the legacy LOOMCYCLE_AUTH_TOKEN) and the
+// resolved principal's scopes decide the experience:
+//   - a substrate:admin token → super-admin (sees/edits all tenants);
+//   - any other token → that token's tenant workspace only.
+//
+// Submitting navigates to /ui?token=… — the Go handler (internal/webui)
+// sets the HttpOnly loomcycle_session cookie and 302s back to /ui, so the
+// token never lives in JS storage. This is also where a 401 bounces to.
+export default function LoginView() {
+  const [token, setToken] = useState("");
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const t = token.trim();
+    if (!t) return;
+    // The server's ?token= landing handler sets the cookie + redirects
+    // back to /ui (stripping the token from the URL so a refresh doesn't
+    // re-set it). Full navigation, not a router push — we want the Go
+    // handler to run and the SPA to re-boot with the cookie present.
+    window.location.href = "/ui?token=" + encodeURIComponent(t);
+  };
+
+  return (
+    <div className="login-page">
+      <form className="login-card" onSubmit={submit}>
+        <div className="login-brand">loomcycle</div>
+        <h1 className="login-title">Sign in</h1>
+        <p className="login-sub">
+          Paste your access token. A <code>substrate:admin</code> token signs
+          you in as super-admin (all tenants); any other token opens just its
+          own tenant&rsquo;s workspace.
+        </p>
+        <input
+          className="login-input"
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="lct_…  (or the legacy LOOMCYCLE_AUTH_TOKEN)"
+          autoFocus
+          spellCheck={false}
+          autoComplete="off"
+        />
+        <button className="login-btn" type="submit" disabled={token.trim() === ""}>
+          Sign in
+        </button>
+        <p className="login-hint">
+          Tokens are minted with <code>loomcycle operator-token create</code>.
+          Lost tokens are rotated, not recovered.
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3755,3 +3755,114 @@ button.primary:disabled {
   color: white;
   border-color: var(--running);
 }
+
+/* ---- Multi-tenant auth (RFC L UI): login page, identity gate, role badge ---- */
+
+.auth-splash {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 60vh;
+  color: var(--fg);
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+.auth-splash.auth-error {
+  opacity: 1;
+  color: var(--failed);
+}
+.auth-splash a {
+  color: var(--accent);
+}
+
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: var(--bg);
+  padding: 1rem;
+}
+.login-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem;
+  border: 1px solid var(--border, #2a2f3a);
+  border-radius: 12px;
+  background: var(--panel, #161a22);
+}
+.login-brand {
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+}
+.login-title {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--fg);
+}
+.login-sub {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--fg);
+  opacity: 0.7;
+}
+.login-sub code,
+.login-hint code {
+  background: var(--bg);
+  padding: 0 0.3em;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+.login-input {
+  padding: 0.6rem 0.7rem;
+  border: 1px solid var(--border, #2a2f3a);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: ui-monospace, monospace;
+  font-size: 0.9rem;
+}
+.login-btn {
+  padding: 0.6rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.login-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.login-hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--fg);
+  opacity: 0.55;
+}
+
+.role-badge {
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.18rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.role-badge.role-admin {
+  background: rgba(220, 160, 40, 0.18);
+  color: #e0a030;
+  border: 1px solid rgba(220, 160, 40, 0.4);
+}
+.role-badge.role-tenant {
+  background: rgba(80, 140, 220, 0.15);
+  color: var(--accent);
+  border: 1px solid rgba(80, 140, 220, 0.35);
+}


### PR DESCRIPTION
**PR 2 of 2** — the **frontend** of the Web UI multi-tenant authorization feature, on top of the backend boundary (#334, on `main`). Turns today's implicit "`?token=` cookie + operator view" into a real auth page with **super-admin vs tenant** roles.

## What

- **`LoginView`** (route `/login`, outside the Layout shell): a token-entry page. loomcycle is token-authed, so "login" = paste an operator token (`lct_…` or the legacy secret); submit navigates to `/ui?token=…` so the existing Go handler sets the HttpOnly cookie + 302s back — **the token never lives in JS**. Also the 401 redirect target.
- **`api.ts`**: `getWhoami()` (`GET /v1/_me`) + the `Principal` type; `jsonFetch` redirects to `/ui/login` on **401** (missing/expired bearer). A **403** (insufficient scope) still surfaces as an error — you're logged in, just not permitted.
- **`Layout`**: resolves the principal on boot (gates the shell behind an *Authenticating…* splash; a non-auth failure shows an error). **Role-aware nav** — a tenant sees only its `runs` workspace; the operator-global/admin tabs (library, channels, schedules, interrupts, memory, snapshots, audit, activity) + PauseControls render for **super-admin only** (and 403 server-side for a tenant regardless). A **role/tenant badge** in the header. A tenant's runs view defaults to its own subject; the admin-gated `/v1/_users` picker is skipped for tenants. `usePrincipal()` exposes the identity to child views.
- `styles.css`: `.login-*`, `.auth-splash`, `.role-badge`. `web/package.json` → `0.8.0`.
- **`dist/` is gitignored** — CI (`npm run build` in ci.yml, `make build-ui` in release.yml) rebuilds + embeds the bundle, so this PR is **source-only**.

## Tested

`tsc --noEmit` clean; `make build-ui` builds (74 modules); the binary embeds it; **manual** — `/ui/login` serves the SPA (200), `/v1/_me` returns the role for an admin token, an unauthenticated `/v1/_me` → 401 (the UI bounces to `/login`). `go test ./internal/webui/...` green.

## Known fast-follows (noted, not blocking)

These need small **backend** additions that PR 1 didn't include, so they're deliberately deferred:
1. **Tenant user-picker auto-population** — listing all same-tenant users needs `/v1/_users` to be tenant-scoped (it's admin-gated today). For now a tenant defaults to its own subject + can manually enter another same-tenant `user_id` (per-user reads are tenant-filtered server-side, so a cross-tenant entry yields empty — safe).
2. **Admin tenant-focus switcher** — "focus one tenant" as super-admin needs the read handlers to honor `?tenant=` (the helper supports it; the handlers don't apply it yet). Super-admin already *sees all tenants* (unfiltered) — this is a focus convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)