### PR TITLE
feat(ui): tenant user-picker auto-population + super-admin tenant-focus switcher

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -375,6 +375,11 @@ func requiredScopeFor(method, path string) string {
 	// identity (the Web UI's role source); a tenant token needs it too.
 	case path == "/v1/_me":
 		return ""
+	// User listing — any authenticated principal; the handler tenant-scopes
+	// the result (a tenant sees only its tenant's users; admin sees all /
+	// can focus via ?tenant=). The UI's per-tenant workspace picker needs it.
+	case path == "/v1/_users":
+		return ""
 	// Everything else under /v1/_* is operator-admin: the substrate Def
 	// endpoints, runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, users, memory admin, channels admin.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3979,12 +3979,14 @@ func (s *Server) handleListUserAgents(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Multi-tenant authz: a tenant principal sees only runs in its own
+	// tenant (requesting another tenant's user_id yields an empty list);
+	// super-admin sees all, or focuses one tenant via ?tenant= (the UI's
+	// tenant switcher). allTenants=true → no tenant filter.
+	scopeTenant, allTenants := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
 	out := make([]agentResponse, 0, len(runs))
 	for _, run := range runs {
-		// Multi-tenant authz: a tenant principal sees only runs in its
-		// own tenant (so requesting another tenant's user_id yields an
-		// empty list). Super-admin / open mode see all.
-		if !s.tenantVisible(r.Context(), run.TenantID) {
+		if !allTenants && run.TenantID != scopeTenant {
 			continue
 		}
 		_, live := s.cancelReg.Get(run.AgentID)

--- a/internal/api/http/tenant_authz_test.go
+++ b/internal/api/http/tenant_authz_test.go
@@ -91,8 +91,8 @@ func TestHandleListUserAgents_TenantFiltersCrossTenant(t *testing.T) {
 		}
 	}
 
-	call := func(p auth.Principal) []map[string]any {
-		req := principalReq("GET", "/v1/users/alice/agents?status=all", p)
+	call := func(p auth.Principal, target string) []map[string]any {
+		req := principalReq("GET", target, p)
 		req.SetPathValue("user_id", "alice")
 		rec := httptest.NewRecorder()
 		s.handleListUserAgents(rec, req)
@@ -106,13 +106,92 @@ func TestHandleListUserAgents_TenantFiltersCrossTenant(t *testing.T) {
 		return resp.Agents
 	}
 
+	base := "/v1/users/alice/agents?status=all"
 	// Tenant=acme principal sees ONLY the acme run.
-	tenantAgents := call(auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}})
+	tenantAgents := call(auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}}, base)
 	if len(tenantAgents) != 1 || tenantAgents[0]["agent_id"] != "a_acme" {
 		t.Errorf("tenant saw %d agents (want 1 = a_acme): %v", len(tenantAgents), tenantAgents)
 	}
 	// Admin sees both.
-	if adminAgents := call(auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}); len(adminAgents) != 2 {
+	if adminAgents := call(auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}, base); len(adminAgents) != 2 {
 		t.Errorf("admin saw %d agents, want 2", len(adminAgents))
+	}
+	// Admin focusing ?tenant=other sees ONLY the other run (the UI's
+	// tenant-focus switcher).
+	if focused := call(auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}, base+"&tenant=other"); len(focused) != 1 || focused[0]["agent_id"] != "a_other" {
+		t.Errorf("admin ?tenant=other saw %d agents (want 1 = a_other): %v", len(focused), focused)
+	}
+	// A tenant principal cannot widen via ?tenant= — still only its own.
+	if escaped := call(auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}}, base+"&tenant=other"); len(escaped) != 1 || escaped[0]["agent_id"] != "a_acme" {
+		t.Errorf("tenant ?tenant=other leaked %d agents (want 1 = a_acme): %v", len(escaped), escaped)
+	}
+}
+
+// /v1/_users is reachable by any authenticated principal and tenant-scoped:
+// a tenant sees only its own tenant's users; admin sees all and can focus
+// one via ?tenant=. Drives the Web UI's per-tenant user picker.
+func TestHandleListUsers_TenantScope(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy")
+	ctx := context.Background()
+	for _, tt := range []struct{ tenant, user, agentID string }{
+		{"acme", "alice", "a_alice"},
+		{"acme", "bob", "a_bob"},
+		{"other", "carol", "a_carol"},
+	} {
+		sess, err := st.CreateSession(ctx, tt.tenant, "echo", tt.user)
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		if _, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: tt.agentID, UserID: tt.user, TenantID: tt.tenant}); err != nil {
+			t.Fatalf("create run: %v", err)
+		}
+	}
+
+	call := func(p auth.Principal, target string) map[string]bool {
+		rec := httptest.NewRecorder()
+		s.handleListUsers(rec, principalReq("GET", target, p))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+		}
+		var resp struct {
+			Users []struct {
+				UserID string `json:"user_id"`
+			} `json:"users"`
+		}
+		json.Unmarshal(rec.Body.Bytes(), &resp)
+		ids := map[string]bool{}
+		for _, u := range resp.Users {
+			ids[u.UserID] = true
+		}
+		return ids
+	}
+
+	// Tenant=acme sees alice + bob, never carol.
+	tenant := call(auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}}, "/v1/_users")
+	if !tenant["alice"] || !tenant["bob"] || tenant["carol"] {
+		t.Errorf("tenant acme saw %v, want {alice,bob} without carol", tenant)
+	}
+	// Admin (no focus) sees all three.
+	admin := call(auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}, "/v1/_users")
+	if !admin["alice"] || !admin["bob"] || !admin["carol"] {
+		t.Errorf("admin saw %v, want all three", admin)
+	}
+	// Admin focusing ?tenant=other sees only carol.
+	focused := call(auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}, "/v1/_users?tenant=other")
+	if focused["alice"] || focused["bob"] || !focused["carol"] {
+		t.Errorf("admin ?tenant=other saw %v, want only carol", focused)
+	}
+	// Tenant can't widen via ?tenant= — still only acme users.
+	escaped := call(auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}}, "/v1/_users?tenant=other")
+	if escaped["carol"] || !escaped["alice"] {
+		t.Errorf("tenant ?tenant=other leaked %v, want only acme users", escaped)
+	}
+}
+
+// /v1/_users must be exempt from the admin scope gate so a tenant token
+// can reach it (the handler does the tenant scoping, not the route).
+func TestRequiredScopeFor_UsersExempt(t *testing.T) {
+	if got := requiredScopeFor("GET", "/v1/_users"); got != "" {
+		t.Errorf("requiredScopeFor(/v1/_users) = %q, want \"\" (any authenticated)", got)
 	}
 }

--- a/internal/api/http/users.go
+++ b/internal/api/http/users.go
@@ -34,7 +34,14 @@ func (s *Server) handleListUsers(w http.ResponseWriter, r *http.Request) {
 			"store not configured; user listing requires a persistent store")
 		return
 	}
-	users, err := s.store.ListUsers(r.Context())
+	// Tenant scope: a tenant principal sees only its own tenant's users;
+	// super-admin sees all, or focuses one via ?tenant= (the UI's tenant
+	// switcher). all=true → "" filter (every tenant).
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	if all {
+		tenantID = ""
+	}
+	users, err := s.store.ListUsers(r.Context(), tenantID)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -626,18 +626,27 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 // ListUsers returns one row per distinct user_id with summary stats.
 // Drives the v0.7.3 Web UI user picker. Mirrors the SQLite shape so
 // behaviour is identical across backends.
-func (s *Store) ListUsers(ctx context.Context) ([]store.UserSummary, error) {
-	rows, err := s.pool.Query(ctx, `
+func (s *Store) ListUsers(ctx context.Context, tenantID string) ([]store.UserSummary, error) {
+	// tenantID "" = all tenants; otherwise scope to the denormalised
+	// runs.tenant_id (RFC L per-tenant workspace + super-admin focus).
+	q := `
 		SELECT
 			user_id,
 			COUNT(*) FILTER (WHERE status = 'running') AS running_count,
 			COUNT(*) AS total_count,
 			MAX(started_at) AS last_started_at
 		FROM runs
-		WHERE user_id IS NOT NULL AND user_id != ''
+		WHERE user_id IS NOT NULL AND user_id != ''`
+	args := []any{}
+	if tenantID != "" {
+		q += ` AND tenant_id = $1`
+		args = append(args, tenantID)
+	}
+	q += `
 		GROUP BY user_id
 		ORDER BY last_started_at DESC
-		LIMIT 200`)
+		LIMIT 200`
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1237,18 +1237,27 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 //
 // SQLite COUNT(CASE WHEN ...) is the conventional shape for grouped
 // counts by category; both backends produce identical row sets.
-func (s *Store) ListUsers(ctx context.Context) ([]store.UserSummary, error) {
-	rows, err := s.db.QueryContext(ctx, `
+func (s *Store) ListUsers(ctx context.Context, tenantID string) ([]store.UserSummary, error) {
+	// tenantID "" = all tenants; otherwise scope to the denormalised
+	// runs.tenant_id (RFC L per-tenant workspace + super-admin focus).
+	q := `
 		SELECT
 			user_id,
 			COUNT(CASE WHEN status = 'running' THEN 1 END) AS running_count,
 			COUNT(*) AS total_count,
 			MAX(started_at) AS last_started_at
 		FROM runs
-		WHERE user_id IS NOT NULL AND user_id != ''
+		WHERE user_id IS NOT NULL AND user_id != ''`
+	args := []any{}
+	if tenantID != "" {
+		q += ` AND tenant_id = ?`
+		args = append(args, tenantID)
+	}
+	q += `
 		GROUP BY user_id
 		ORDER BY last_started_at DESC
-		LIMIT 200`)
+		LIMIT 200`
+	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -551,7 +551,11 @@ type Store interface {
 	// Capped at 200 users ordered by last_started_at DESC. A bigger
 	// list would be a UX problem anyway — the UI then needs filtering
 	// rather than dropdown.
-	ListUsers(ctx context.Context) ([]UserSummary, error)
+	//
+	// tenantID scopes the result to one tenant (the Web UI's per-tenant
+	// workspace + the super-admin tenant-focus), filtering on the
+	// denormalised runs.tenant_id; "" returns all tenants.
+	ListUsers(ctx context.Context, tenantID string) ([]UserSummary, error)
 
 	// UpdateHeartbeat sets last_heartbeat_at on a run to the current
 	// time. Called by the loop at each iteration. No-op if the run

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -818,21 +818,29 @@ func testListUsers(t *testing.T, s store.Store) {
 	sessAlice, _ := s.CreateSession(ctx, "t", "a", "alice")
 	sessBob, _ := s.CreateSession(ctx, "t", "a", "bob")
 
-	// alice: 2 runs, 1 still running.
-	rA1, _ := s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice1", UserID: "alice"})
-	_, _ = s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice2", UserID: "alice"})
+	// alice: 2 runs, 1 still running. Tenant "t" on every run so the
+	// tenant-scoped ListUsers filter has something to match.
+	rA1, _ := s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice1", UserID: "alice", TenantID: "t"})
+	_, _ = s.CreateRun(ctx, sessAlice.ID, store.RunIdentity{AgentID: "a_alice2", UserID: "alice", TenantID: "t"})
 	_ = s.FinishRun(ctx, rA1.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
 
 	// bob: 1 run, completed.
-	rB1, _ := s.CreateRun(ctx, sessBob.ID, store.RunIdentity{AgentID: "a_bob1", UserID: "bob"})
+	rB1, _ := s.CreateRun(ctx, sessBob.ID, store.RunIdentity{AgentID: "a_bob1", UserID: "bob", TenantID: "t"})
 	_ = s.FinishRun(ctx, rB1.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	// carol lives in a different tenant — must be invisible when the
+	// listing is scoped to tenant "t".
+	sessCarol, _ := s.CreateSession(ctx, "other", "a", "carol")
+	_, _ = s.CreateRun(ctx, sessCarol.ID, store.RunIdentity{AgentID: "a_carol1", UserID: "carol", TenantID: "other"})
 
 	// Empty-userID run should NOT show up in the listing — filtered
 	// by the WHERE user_id != '' clause.
 	sessAnon, _ := s.CreateSession(ctx, "t", "a", "")
-	_, _ = s.CreateRun(ctx, sessAnon.ID, store.RunIdentity{AgentID: "a_anon", UserID: ""})
+	_, _ = s.CreateRun(ctx, sessAnon.ID, store.RunIdentity{AgentID: "a_anon", UserID: "", TenantID: "t"})
 
-	users, err := s.ListUsers(ctx)
+	// Tenant-scoped listing: only tenant "t"'s users (alice + bob), carol
+	// excluded.
+	users, err := s.ListUsers(ctx, "t")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -869,6 +877,30 @@ func testListUsers(t *testing.T, s store.Store) {
 		if u.LastStartedAt.IsZero() {
 			t.Errorf("%s.last_started_at is zero; should reflect a real timestamp", u.UserID)
 		}
+	}
+
+	// All-tenants listing (tenantID "") includes carol from "other".
+	all, err := s.ListUsers(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	allIDs := map[string]bool{}
+	for _, u := range all {
+		allIDs[u.UserID] = true
+	}
+	for _, want := range []string{"alice", "bob", "carol"} {
+		if !allIDs[want] {
+			t.Errorf("all-tenants ListUsers missing %q (got %v)", want, allIDs)
+		}
+	}
+
+	// Focusing a tenant with no users returns an empty list, not an error.
+	none, err := s.ListUsers(ctx, "nonexistent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Errorf("ListUsers(nonexistent) = %d users, want 0", len(none))
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -14,8 +14,12 @@ export interface ListUsersResponse {
   users: UserSummary[];
 }
 
-export function listUsers(): Promise<ListUsersResponse> {
-  return jsonFetch<ListUsersResponse>("/v1/_users");
+// tenant is the super-admin tenant-focus (?tenant=); a tenant principal's
+// own tenant is enforced server-side regardless, so this is admin-only in
+// practice and harmless when set by a tenant (ignored by the backend).
+export function listUsers(tenant?: string): Promise<ListUsersResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return jsonFetch<ListUsersResponse>(`/v1/_users${q}`);
 }
 
 // HealthResponse mirrors handleHealthz on the server. v0.8.21 added
@@ -262,8 +266,12 @@ async function jsonFetchAllowing<T>(
   throw new Error(`${resp.status} ${resp.statusText}: ${text.slice(0, 200)}`);
 }
 
-export function listAgents(userId: string, status?: string): Promise<ListAgentsResponse> {
-  const q = status ? `?status=${encodeURIComponent(status)}` : "";
+export function listAgents(userId: string, status?: string, tenant?: string): Promise<ListAgentsResponse> {
+  const params = new URLSearchParams();
+  if (status) params.set("status", status);
+  // Super-admin tenant-focus; ignored server-side for tenant principals.
+  if (tenant) params.set("tenant", tenant);
+  const q = params.toString() ? `?${params.toString()}` : "";
   return jsonFetch<ListAgentsResponse>(`/v1/users/${encodeURIComponent(userId)}/agents${q}`);
 }
 

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -30,6 +30,13 @@ export default function Layout() {
   const [principalErr, setPrincipalErr] = useState<string | null>(null);
   const isAdmin = principal?.is_admin === true;
 
+  // Super-admin tenant-focus (?tenant=): "" = all tenants (admin's default
+  // global view). A tenant principal can't set this — the backend forces
+  // its own tenant regardless — so it stays "" for non-admins and the
+  // switcher is admin-only. Threaded into the user picker + the runs view.
+  const [focusTenant, setFocusTenant] = useState<string>("");
+  const [draftTenant, setDraftTenant] = useState<string>("");
+
   useEffect(() => {
     localStorage.setItem(USER_ID_KEY, userId);
   }, [userId]);
@@ -69,12 +76,12 @@ export default function Layout() {
     };
   }, []);
 
-  // Poll /v1/_users for the picker — ADMIN ONLY. /v1/_users is operator-
-  // admin-gated, so a tenant token would just 403; skip it (a tenant uses
-  // its own subject + the manual-entry box for other same-tenant users,
-  // which the per-user reads tenant-filter server-side).
+  // Poll /v1/_users for the picker. Since v0.16.x /v1/_users is tenant-
+  // scoped (any authenticated principal): a tenant sees only its own
+  // tenant's users; an admin sees all, or one tenant via ?tenant= when
+  // focused. Wait for the principal to resolve before the first fetch.
   useEffect(() => {
-    if (!isAdmin) {
+    if (!principal) {
       setUsers([]);
       setUsersErr(null);
       return;
@@ -82,7 +89,9 @@ export default function Layout() {
     let cancelled = false;
     const fetchOnce = async () => {
       try {
-        const resp = await listUsers();
+        // focusTenant only takes effect for admins (ignored server-side
+        // for tenants); "" → the caller's own scope (all for admin).
+        const resp = await listUsers(focusTenant || undefined);
         if (!cancelled) {
           setUsers(resp.users ?? []);
           setUsersErr(null);
@@ -97,7 +106,7 @@ export default function Layout() {
       cancelled = true;
       clearInterval(t);
     };
-  }, [isAdmin]);
+  }, [principal, focusTenant]);
 
   // Identity gate: hold the shell until we know the role (a 401 has
   // already redirected to /login by here). A non-auth failure shows a
@@ -153,13 +162,51 @@ export default function Layout() {
             {isAdmin ? "super-admin" : `tenant: ${principal.tenant_id}`}
           </span>
         )}
+        {/* Super-admin tenant-focus switcher: narrows the workspace to one
+            tenant (or all when blank). Changing focus resets the picked
+            user since user_ids don't carry across tenants. Admin-only —
+            tenants are locked to their own tenant by the backend. */}
+        {isAdmin && (
+          <form
+            className="tenant-switcher"
+            onSubmit={(e) => {
+              e.preventDefault();
+              setFocusTenant(draftTenant.trim());
+              setUserId("");
+            }}
+          >
+            <label htmlFor="tenant_focus">tenant</label>
+            <input
+              id="tenant_focus"
+              type="text"
+              value={draftTenant}
+              onChange={(e) => setDraftTenant(e.target.value)}
+              placeholder="all tenants"
+              title="Focus one tenant's workspace; blank = all"
+            />
+            {focusTenant && (
+              <button
+                type="button"
+                className="manual-btn"
+                title="Clear tenant focus (show all)"
+                onClick={() => {
+                  setFocusTenant("");
+                  setDraftTenant("");
+                  setUserId("");
+                }}
+              >
+                ✕
+              </button>
+            )}
+          </form>
+        )}
         <div className="user-picker">
           {usersErr && (
             <span className="picker-err" title={usersErr}>
               users unavailable
             </span>
           )}
-          {!showManual && isAdmin && (
+          {!showManual && (
             <>
               <label htmlFor="user_select">user</label>
               <select
@@ -213,22 +260,33 @@ export default function Layout() {
         </div>
       </header>
       <main className="content">
-        <Outlet context={{ userId, principal: principal ?? null }} />
+        <Outlet context={{ userId, principal: principal ?? null, focusTenant }} />
       </main>
     </div>
   );
 }
 
+interface LayoutContext {
+  userId: string;
+  principal: Principal | null;
+  focusTenant: string;
+}
+
 // Child routes read userId via this helper.
 export function useUserId(): string {
-  const ctx = useOutletContext<{ userId: string; principal: Principal | null }>();
-  return ctx.userId;
+  return useOutletContext<LayoutContext>().userId;
 }
 
 // usePrincipal exposes the resolved identity to child views (role-aware
 // rendering). Null only in the brief pre-resolution window or a non-auth
 // error (the Layout gates rendering on it, so views generally see it set).
 export function usePrincipal(): Principal | null {
-  const ctx = useOutletContext<{ userId: string; principal: Principal | null }>();
-  return ctx.principal;
+  return useOutletContext<LayoutContext>().principal;
+}
+
+// useFocusTenant is the super-admin tenant-focus (?tenant=); "" = all
+// tenants / the caller's own scope. Views thread it into tenant-scoped
+// reads (e.g. listAgents) so the admin's switcher narrows the workspace.
+export function useFocusTenant(): string {
+  return useOutletContext<LayoutContext>().focusTenant;
 }

--- a/web/src/pages/AgentsView.tsx
+++ b/web/src/pages/AgentsView.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { Agent, listAgents } from "../api";
-import { useUserId } from "../components/Layout";
+import { useFocusTenant, useUserId } from "../components/Layout";
 import AgentsTreePanel, { type StatusFilter } from "../components/AgentsTreePanel";
 import AgentDetailPane from "../components/AgentDetailPane";
 import type { BreadcrumbAncestor } from "../components/Breadcrumbs";
@@ -26,6 +26,9 @@ const REFRESH_MS = 3_000;
 
 export default function AgentsView() {
   const userId = useUserId();
+  // Super-admin tenant-focus; "" = the caller's own scope. Threaded into
+  // the run listing so an admin's tenant switcher narrows the runs view.
+  const focusTenant = useFocusTenant();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [filter, setFilter] = useState<StatusFilter>("running");
   const [err, setErr] = useState<string | null>(null);
@@ -48,7 +51,7 @@ export default function AgentsView() {
       try {
         setLoading(true);
         const status = filter === "all" ? undefined : filter;
-        const resp = await listAgents(userId, status);
+        const resp = await listAgents(userId, status, focusTenant || undefined);
         if (!cancelled) {
           setAgents(resp.agents ?? []);
           setErr(null);
@@ -65,7 +68,7 @@ export default function AgentsView() {
       cancelled = true;
       clearInterval(t);
     };
-  }, [userId, filter]);
+  }, [userId, filter, focusTenant]);
 
   const tree = useMemo(() => buildTree(agents), [agents]);
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3866,3 +3866,38 @@ button.primary:disabled {
   color: var(--accent);
   border: 1px solid rgba(80, 140, 220, 0.35);
 }
+
+/* Super-admin tenant-focus switcher (Layout topbar). Mirrors the
+   user-picker so the two controls read as a pair. */
+.tenant-switcher {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+.tenant-switcher label {
+  color: var(--fg-soft);
+  font-size: 12px;
+}
+.tenant-switcher input {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: var(--mono);
+  font-size: 13px;
+  min-width: 140px;
+}
+.tenant-switcher button.manual-btn {
+  background: transparent;
+  color: var(--fg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.tenant-switcher button.manual-btn:hover {
+  color: var(--fg);
+  border-color: var(--accent);
+}


### PR DESCRIPTION
## Why

Two fast-follows flagged in #335 (UI multi-tenant authz). Both are UX gaps left by the security boundary, not security holes:

1. **The user picker was admin-only.** `/v1/_users` was operator-admin-gated, so a tenant token would 403 — the picker skipped it and a tenant had to hand-type same-tenant `user_id`s into the manual-entry box.
2. **No way to scope an admin's workspace to one tenant.** The `principalTenantScope` helper already supported `?tenant=` focus, but the read handlers didn't apply it, and there was no UI control to set it.

## What

**Backend (`feat(authz)` commit):**
- `/v1/_users` is now reachable by **any authenticated principal** and **tenant-scoped server-side**: a tenant sees only its own tenant's users; super-admin sees all, or focuses one via `?tenant=`. Exempted from the admin scope gate — the handler does the scoping, not the route.
- `store.ListUsers` gains a `tenantID` filter on the denormalised `runs.tenant_id` (landed in #334); `""` = all tenants. SQLite + Postgres + contract test updated.
- `GET /v1/users/{id}/agents` now honors `?tenant=` for super-admins (via `principalTenantScope`) instead of the per-row `tenantVisible` check. A tenant principal **still can't widen** via the wire — its own tenant is forced.

**Frontend (`feat(ui)` commit):**
- The user picker populates for tenant principals too (fetch gates on the resolved principal, not `is_admin`).
- A **super-admin-only tenant-focus switcher** in the topbar threads `?tenant=` into the picker and the runs view (`listAgents`). Blank = all tenants. Changing focus resets the picked user (`user_id`s don't carry across tenants). Tenants don't see the switcher.
- `useFocusTenant()` exposes the focus via the outlet context.

## Tested

- `TestHandleListUsers_TenantScope` — tenant sees own users only; admin sees all; admin `?tenant=` focuses; tenant can't widen via the wire.
- `TestRequiredScopeFor_UsersExempt` — `/v1/_users` is any-authenticated.
- Extended `TestHandleListUserAgents_TenantFiltersCrossTenant` with admin `?tenant=` focus + tenant no-widen.
- Store contract `testListUsers` gains tenant-filter, all-tenants, and empty-focus cases (both stores).
- `go test ./...`, `go vet ./...`, `gofmt` clean; `cd web && npm run typecheck && npm run build` clean.
- Manual: tenant token → picker lists own-tenant users, no switcher; admin token → switcher narrows picker + runs to one tenant.

`dist/` is CI-built and not committed (only `.gitkeep` is tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)