### PR TITLE
fix(sqlite): carry busy_timeout + foreign_keys onto the in-memory DSN

### DIFF
--- a/internal/store/sqlite/driver_default.go
+++ b/internal/store/sqlite/driver_default.go
@@ -39,11 +39,23 @@ var memoryDBCounter atomic.Uint64
 // rooted at a distinct name; `cache=shared` preserves the
 // within-handle multi-connection-sees-the-same-writes semantics
 // needed by the MemoryAtomicUpdate locking pattern.
+//
+// busy_timeout(5000) MUST be carried onto the in-memory DSN too. With
+// SetMaxOpenConns(8) + cache=shared, multiple connections contend on
+// one shared-cache lock; without a busy timeout the loser of a write
+// race gets SQLITE_BUSY *immediately* (default timeout 0) instead of
+// waiting. That surfaced as a CI-only flake in TestSchedulerBearerCompound:
+// 64 concurrent fires raced their ScheduleRunStateRecordResult writes,
+// the BUSY'd ones failed to advance next_run_at, and the still-due rows
+// re-fired — double-firing the early phases. journal_mode(WAL) is a
+// no-op on an in-memory DB (no file journal), so only the two
+// connection-level pragmas carry over.
 func openDB(path string) (*sql.DB, error) {
 	dsn := path + "?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)"
 	if path == ":memory:" {
 		id := memoryDBCounter.Add(1)
-		dsn = "file:lc-mem-" + strconv.FormatUint(id, 10) + "?mode=memory&cache=shared"
+		dsn = "file:lc-mem-" + strconv.FormatUint(id, 10) +
+			"?mode=memory&cache=shared&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)"
 	}
 	return sql.Open("sqlite", dsn)
 }

--- a/internal/store/sqlite/driver_vec.go
+++ b/internal/store/sqlite/driver_vec.go
@@ -59,8 +59,11 @@ func openDB(path string) (*sql.DB, error) {
 	dsn := path + "?_journal_mode=WAL&_foreign_keys=on&_busy_timeout=5000"
 	if path == ":memory:" {
 		// mattn supports shared in-memory dbs the same way: cache=shared
-		// with the file::memory: URI form.
-		dsn = "file::memory:?cache=shared&_journal_mode=WAL"
+		// with the file::memory: URI form. foreign_keys + busy_timeout
+		// MUST carry over (see driver_default.go) — without busy_timeout,
+		// concurrent writers on the shared cache get SQLITE_BUSY instead
+		// of waiting, which double-fired the scheduler compound test.
+		dsn = "file::memory:?cache=shared&_journal_mode=WAL&_foreign_keys=on&_busy_timeout=5000"
 	}
 	return sql.Open("sqlite3_loomcycle_vec", dsn)
 }

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -40,6 +40,44 @@ func TestStoreContract(t *testing.T) {
 // Anything that's true of every Store adapter belongs in
 // storetest/contract.go instead.
 
+// TestOpen_ConnectionPragmas is the regression guard for the CI-only
+// double-fire flake in internal/api/http TestSchedulerBearerCompound. The
+// :memory: DSN branch used to drop busy_timeout + foreign_keys (only the
+// on-disk path carried them). With SetMaxOpenConns(8) + cache=shared,
+// concurrent writers on the shared cache then got SQLITE_BUSY *immediately*
+// (default busy_timeout 0) instead of waiting — under CI load the BUSY'd
+// scheduler RecordResult writes failed to advance next_run_at and the
+// still-due rows re-fired. Both the in-memory and on-disk DSNs must carry
+// busy_timeout=5000 (writers wait) and foreign_keys=1 (parity with prod).
+//
+// Fails on the pre-fix code: in-memory busy_timeout would read back 0.
+func TestOpen_ConnectionPragmas(t *testing.T) {
+	for _, path := range []string{":memory:", filepath.Join(t.TempDir(), "pragmas.db")} {
+		path := path
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("Open(%q): %v", path, err)
+		}
+		t.Cleanup(func() { _ = s.Close() })
+
+		var busy int
+		if err := s.db.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busy); err != nil {
+			t.Fatalf("path=%q PRAGMA busy_timeout: %v", path, err)
+		}
+		if busy != 5000 {
+			t.Errorf("path=%q busy_timeout = %d, want 5000 (concurrent writers must wait, not SQLITE_BUSY)", path, busy)
+		}
+
+		var fk int
+		if err := s.db.QueryRowContext(context.Background(), "PRAGMA foreign_keys").Scan(&fk); err != nil {
+			t.Fatalf("path=%q PRAGMA foreign_keys: %v", path, err)
+		}
+		if fk != 1 {
+			t.Errorf("path=%q foreign_keys = %d, want 1 (FK enforcement parity with prod)", path, fk)
+		}
+	}
+}
+
 // Idempotent migration: opening the same DB twice MUST NOT error. The
 // "duplicate column name" tolerance in migrate() is the only thing that
 // makes this safe.


### PR DESCRIPTION
## Why

`TestSchedulerBearerCompound` (`internal/api/http`) has been intermittently reddening CI under `-race` — most recently on #337, with `server_a calls = 418, want 310` and "cross-fork contamination?" on the early users. The over-count was always *exactly* `phase1Count + phase2Count` (e.g. 9+99=108 at scale=310), and **both** servers showed 2 calls for the same early users → the whole run fired twice (a scheduler double-fire). It only reproduced on the CI runner (passed locally 5× under `-race`, even at scale=2000).

## Root cause

The `:memory:` branch of `openDB` dropped the pragmas the on-disk DSN sets:

```go
dsn := path + "?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)"
if path == ":memory:" {
    dsn = "file:lc-mem-N?mode=memory&cache=shared"   // ← no busy_timeout, no foreign_keys
}
```

With `SetMaxOpenConns(8)` + `cache=shared`, multiple connections contend on one shared-cache lock. Without `busy_timeout`, the loser of a write race gets `SQLITE_BUSY` **immediately** (default timeout 0) instead of waiting. Under CI load the 64 concurrent scheduler fires raced their `ScheduleRunStateRecordResult` writes; the BUSY'd ones failed to advance `next_run_at` (the error is logged + swallowed in `fireOne`), so the still-due rows re-fired. Phase 3 fires *after* the contention wave drains → its writes succeed → single fire, which is exactly why the over-count equalled `phase1+phase2`.

## What

- Append `busy_timeout(5000)` + `foreign_keys(ON)` to the in-memory DSN in **both** drivers (`driver_default.go` modernc, `driver_vec.go` mattn). `journal_mode(WAL)` is a no-op on an in-memory DB, so it doesn't carry over.
- `foreign_keys(ON)` also closes a silent test-vs-prod divergence — in-memory tests previously ran with FK enforcement **off**.

## Tested

- New `TestOpen_ConnectionPragmas` asserts `busy_timeout=5000` + `foreign_keys=1` on both the `:memory:` and on-disk DSNs. **Verified fail-before**: on the pre-fix code the in-memory `busy_timeout` reads back `0` (and `foreign_keys` `0`).
- `go test ./...` fully green — **no latent FK violations** surfaced now that in-memory enforces foreign keys.
- `TestSchedulerBearerCompound -race -scale=2000` ×3 clean.
- `gofmt` + `go vet` clean.

Note: `fireOne` still logs-and-swallows a genuinely-failed `RecordResult` (defense-in-depth for a real persistent-store outage is a separate, lower-priority hardening). This PR fixes the demonstrable root cause of the flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)