### PR TITLE
fix(mcpserverdef): honor the private-host allowlist at create-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ loomcycle doctor              # verify env + keys + storage + the just-minted to
 loomcycle                     # starts on 127.0.0.1:8787 (auto-loads auth.env — no shell-rc edit)
 ```
 
-`init --with-token` prints a one-time Web UI link (`http://127.0.0.1:8787/ui?token=…`) — open it once to set the session cookie. That's it: an authenticated runtime, no secret to copy-paste. `loomcycle` and `loomcycle doctor` both auto-load `auth.env` from the config dir; a real `export LOOMCYCLE_AUTH_TOKEN=…` always overrides it.
+`init --with-token` prints the Web UI URL (`http://127.0.0.1:8787/ui`); open it, then paste the token from `~/.config/loomcycle/auth.env` at the login prompt. (The token is kept in the `0600` file and never embedded in a URL — a `?token=` link would leak the bearer into browser history and any fronting proxy's logs.) `loomcycle` and `loomcycle doctor` both auto-load `auth.env` from the config dir; a real `export LOOMCYCLE_AUTH_TOKEN=…` always overrides it.
 
 ## Bootstrap tiers
 

--- a/README.md
+++ b/README.md
@@ -99,20 +99,65 @@ go install github.com/denn-gubsky/loomcycle/cmd/loomcycle@latest
 curl -L https://github.com/denn-gubsky/loomcycle/releases/latest/download/loomcycle-darwin-arm64.tar.gz | tar xz
 ```
 
-## Quick start
+## Quick start (seconds, authenticated)
 
 ```sh
-loomcycle init       # bootstrap ~/.config/loomcycle/loomcycle.yaml + README.md
-# set $LOOMCYCLE_AUTH_TOKEN + at least one provider key in your shell rc
-loomcycle doctor     # verify env + provider keys + storage + listen
-loomcycle            # start the server on 127.0.0.1:8787
+loomcycle init --with-token   # writes config + mints a token to ~/.config/loomcycle/auth.env (0600)
+export ANTHROPIC_API_KEY=sk-...   # (or OPENAI_API_KEY / DEEPSEEK_API_KEY) — at least one provider key
+loomcycle doctor              # verify env + keys + storage + the just-minted token
+loomcycle                     # starts on 127.0.0.1:8787 (auto-loads auth.env — no shell-rc edit)
+```
 
-# Smoke
+`init --with-token` prints a one-time Web UI link (`http://127.0.0.1:8787/ui?token=…`) — open it once to set the session cookie. That's it: an authenticated runtime, no secret to copy-paste. `loomcycle` and `loomcycle doctor` both auto-load `auth.env` from the config dir; a real `export LOOMCYCLE_AUTH_TOKEN=…` always overrides it.
+
+## Bootstrap tiers
+
+Pick the tier that fits — each is a superset of the one above. **Auth is enforced only once something is configured**, so Tier 1 needs no token at all.
+
+### Tier 1 — zero-config dev (open mode, localhost)
+
+No token, no flags. Fastest way to kick the tires on `127.0.0.1`.
+
+```sh
+loomcycle init               # config only — no secret written
+export ANTHROPIC_API_KEY=sk-...
+loomcycle                    # open mode: /v1/* + /ui pass through unauthenticated (logs a warning)
+open http://127.0.0.1:8787/ui
+```
+
+With no `LOOMCYCLE_AUTH_TOKEN` and no minted tokens, the runtime runs **open** on localhost — every request is allowed, whoami returns a synthetic admin. Great for a 10-second smoke test; **never** expose this off localhost.
+
+### Tier 2 — single shared token (the recommended default)
+
+One bearer gates everything. `init --with-token` is the easy button (above). Equivalent manual setup:
+
+```sh
+loomcycle init
+export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)   # or: loomcycle init --with-token
+export ANTHROPIC_API_KEY=sk-...
+loomcycle
+open "http://127.0.0.1:8787/ui?token=$LOOMCYCLE_AUTH_TOKEN"   # sets the cookie once
+```
+
+Treat anyone holding the token as fully trusted to drive the runtime.
+
+### Tier 3 — multi-tenant, per-principal tokens (RFC L, v0.17.0)
+
+Mint a distinct bearer per developer/app, each bound to an authoritative `(tenant, subject, scopes)`. Migrate a Tier-2 deployment in place — no downtime:
+
+```sh
+# promote your existing shared token into the substrate, then mint scoped tokens
+loomcycle operator-token create --copy-from-env --name ops --tenant ops --scopes substrate:admin
+loomcycle operator-token create --name acme-app --tenant acme --subject alice --scopes runs:create
+```
+
+The first admin `OperatorTokenDef` disables the legacy shared-token fallback. Per-route HTTP + per-RPC gRPC scopes; the Web UI becomes role-aware (super-admin vs tenant). See `Context.help operator-tokens` and the v0.17.0 notes in [`REVISIONS.md`](REVISIONS.md).
+
+**Smoke any tier:**
+
+```sh
 curl http://127.0.0.1:8787/healthz
 # {"ok":true}
-
-# Open the Web UI (one-time per browser session — sets HttpOnly cookie)
-open "http://127.0.0.1:8787/ui?token=$LOOMCYCLE_AUTH_TOKEN"
 ```
 
 Real call (from another terminal):

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -419,6 +419,15 @@ func main() {
 		fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, or pass --config <path> to use an existing file.")
 		os.Exit(1)
 	}
+	// Auto-load <configdir>/auth.env (companion to `loomcycle init
+	// --with-token`) BEFORE config.Load reads os.Getenv, so a persisted
+	// LOOMCYCLE_AUTH_TOKEN is in scope without a shell-rc edit. Set-if-unset
+	// (real env wins), so an explicit shell export still overrides it.
+	if authEnvPath, n, err := cli.LoadAuthEnv(resolvedCfg); err != nil {
+		log.Printf("auth.env: %v (continuing without it)", err)
+	} else if n > 0 {
+		log.Printf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
+	}
 	cfg, err := config.Load(resolvedCfg)
 	if err != nil {
 		log.Fatalf("config: %v", err)

--- a/internal/cli/authenv.go
+++ b/internal/cli/authenv.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// authEnvFileName is the operator-owned env file that `loomcycle init
+// --with-token` writes (mode 0600) next to loomcycle.yaml. Auto-loading it
+// is what lets a brew-installed operator get an authenticated runtime with
+// zero shell-rc edits — the difference between "source this every shell"
+// and "it just works". The server (cmd/loomcycle) and `loomcycle doctor`
+// both call LoadAuthEnv so their view of the token is identical.
+const authEnvFileName = "auth.env"
+
+// LoadAuthEnv reads <dir-of-configPath>/auth.env into the process
+// environment and returns the file path + the number of variables it set.
+//
+// Two deliberate guarantees:
+//
+//   - Real env wins. A variable is set ONLY if it is currently unset, so an
+//     explicit shell `export LOOMCYCLE_AUTH_TOKEN=…` always overrides the
+//     file. The file is a fallback, never a silent shadow.
+//   - Narrow scope. Only the operator-owned config directory is consulted,
+//     and only a boring `KEY=VALUE` / `export KEY=VALUE` shape is parsed
+//     (blank lines and `#` comments ignored). No globbing, no nesting.
+//
+// An absent file is the common case, not an error (most deployments set the
+// token via the real environment). Parsing is lenient — a malformed line is
+// skipped, never fatal, so a hand-edited file can't wedge startup.
+func LoadAuthEnv(configPath string) (path string, n int, err error) {
+	path = filepath.Join(filepath.Dir(configPath), authEnvFileName)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return path, 0, nil
+		}
+		return path, 0, err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		// Strip one layer of matching surrounding quotes if present.
+		if len(v) >= 2 && (v[0] == '"' || v[0] == '\'') && v[len(v)-1] == v[0] {
+			v = v[1 : len(v)-1]
+		}
+		if k == "" || os.Getenv(k) != "" {
+			continue
+		}
+		if err := os.Setenv(k, v); err != nil {
+			return path, n, err
+		}
+		n++
+	}
+	return path, n, sc.Err()
+}

--- a/internal/cli/authenv_test.go
+++ b/internal/cli/authenv_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// fakeConfigPath returns a loomcycle.yaml path inside dir (LoadAuthEnv reads
+// auth.env from the config file's directory).
+func fakeConfigPath(dir string) string { return filepath.Join(dir, "loomcycle.yaml") }
+
+func TestLoadAuthEnv_AbsentIsNotAnError(t *testing.T) {
+	_, n, err := LoadAuthEnv(fakeConfigPath(t.TempDir()))
+	if err != nil {
+		t.Fatalf("absent auth.env should not error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("absent auth.env set %d vars, want 0", n)
+	}
+}
+
+func TestLoadAuthEnv_SetsUnsetVarsAndParsesShape(t *testing.T) {
+	dir := t.TempDir()
+	// export prefix, quotes, a comment, and a blank line must all parse.
+	body := "# comment\n\nexport LOOMCYCLE_AUTH_TOKEN=abc123\nLOOMCYCLE_FOO=\"quoted val\"\n"
+	if err := os.WriteFile(filepath.Join(dir, authEnvFileName), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	os.Unsetenv("LOOMCYCLE_AUTH_TOKEN")
+	os.Unsetenv("LOOMCYCLE_FOO")
+	t.Cleanup(func() { os.Unsetenv("LOOMCYCLE_AUTH_TOKEN"); os.Unsetenv("LOOMCYCLE_FOO") })
+
+	_, n, err := LoadAuthEnv(fakeConfigPath(dir))
+	if err != nil {
+		t.Fatalf("LoadAuthEnv: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("set %d vars, want 2", n)
+	}
+	if got := os.Getenv("LOOMCYCLE_AUTH_TOKEN"); got != "abc123" {
+		t.Errorf("LOOMCYCLE_AUTH_TOKEN = %q, want abc123", got)
+	}
+	if got := os.Getenv("LOOMCYCLE_FOO"); got != "quoted val" {
+		t.Errorf("LOOMCYCLE_FOO = %q, want 'quoted val' (quotes stripped)", got)
+	}
+}
+
+// The security-load-bearing guarantee: a real shell export always wins over
+// the file, so auth.env can never silently shadow an explicit token.
+func TestLoadAuthEnv_RealEnvWins(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, authEnvFileName),
+		[]byte("LOOMCYCLE_AUTH_TOKEN=from-file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "from-shell")
+
+	_, n, err := LoadAuthEnv(fakeConfigPath(dir))
+	if err != nil {
+		t.Fatalf("LoadAuthEnv: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("set %d vars, want 0 (the var was already set)", n)
+	}
+	if got := os.Getenv("LOOMCYCLE_AUTH_TOKEN"); got != "from-shell" {
+		t.Errorf("LOOMCYCLE_AUTH_TOKEN = %q, want from-shell (shell export must win)", got)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -71,8 +71,20 @@ func RunDoctor(args []string, stdout, stderr io.Writer) int {
 	}
 	r.pass("Config parses", "")
 
+	// Mirror the server: auto-load <configdir>/auth.env (set-if-unset)
+	// BEFORE the token check, so doctor's verdict matches what `loomcycle`
+	// will actually see. Without this, `init --with-token` followed by
+	// `doctor` would falsely warn "unauthenticated" while the server runs
+	// authed off the persisted token.
+	tokenFromFile := false
+	if _, n, lerr := LoadAuthEnv(resolvedPath); lerr == nil && n > 0 && os.Getenv("LOOMCYCLE_AUTH_TOKEN") != "" {
+		tokenFromFile = true
+	}
+
 	if os.Getenv("LOOMCYCLE_AUTH_TOKEN") == "" {
 		r.warn("LOOMCYCLE_AUTH_TOKEN set", "empty; every /v1/* request will be allowed unauthenticated")
+	} else if tokenFromFile {
+		r.pass("LOOMCYCLE_AUTH_TOKEN set", "loaded from auth.env (init --with-token)")
 	} else {
 		r.pass("LOOMCYCLE_AUTH_TOKEN set", "")
 	}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"io"
@@ -46,11 +48,13 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 	interactive := fs.Bool("interactive", false, "force interactive wizard (default: auto-on when stdin is a TTY)")
 	noInteractive := fs.Bool("no-interactive", false, "force non-interactive mode (writes the example yaml verbatim)")
 	force := fs.Bool("force", false, "overwrite existing files (default: refuse with a clear error)")
+	withToken := fs.Bool("with-token", false, "mint a LOOMCYCLE_AUTH_TOKEN, persist it to <configdir>/auth.env (mode 0600, auto-loaded by `loomcycle`), and print the ready-to-open UI URL")
 	fs.Usage = func() {
-		fmt.Fprintln(stderr, "Usage: loomcycle init [--path <dir>] [--interactive|--no-interactive] [--force]")
+		fmt.Fprintln(stderr, "Usage: loomcycle init [--path <dir>] [--interactive|--no-interactive] [--force] [--with-token]")
 		fmt.Fprintln(stderr)
 		fmt.Fprintln(stderr, "Writes loomcycle.yaml + README.md to the operator's config directory.")
-		fmt.Fprintln(stderr, "Auto-on wizard when stdin is a TTY; never writes secrets to disk.")
+		fmt.Fprintln(stderr, "Auto-on wizard when stdin is a TTY. By default writes no secrets;")
+		fmt.Fprintln(stderr, "--with-token is the explicit opt-in that mints + persists an auth token.")
 	}
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -114,10 +118,42 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 
 	fmt.Fprintf(stdout, "Wrote %s\n", yamlPath)
 	fmt.Fprintf(stdout, "Wrote %s\n", docPath)
+
+	// --with-token: mint + persist a LOOMCYCLE_AUTH_TOKEN so the operator
+	// gets an authenticated runtime without a shell-rc edit. mintedToken is
+	// non-empty only when we actually wrote a fresh token THIS run — when an
+	// auth.env already exists we keep it (never clobber a live token) and
+	// never read its value back (no secret echo).
+	var mintedToken string
+	if *withToken {
+		authEnvPath := filepath.Join(destDir, "auth.env")
+		if !*force && firstExistingFile(authEnvPath) != "" {
+			fmt.Fprintf(stdout, "Kept existing %s (pass --force to mint a fresh token).\n", authEnvPath)
+		} else {
+			tok, err := mintAuthToken()
+			if err != nil {
+				return fail(stderr, "init: mint auth token: %v", err)
+			}
+			body := "# loomcycle auth — auto-loaded by `loomcycle` from this directory.\n" +
+				"# A real shell `export LOOMCYCLE_AUTH_TOKEN=…` overrides this file.\n" +
+				"# Secret: keep mode 0600; do not commit.\n" +
+				"LOOMCYCLE_AUTH_TOKEN=" + tok + "\n"
+			if err := os.WriteFile(authEnvPath, []byte(body), 0o600); err != nil {
+				return fail(stderr, "init: write %s: %v", authEnvPath, err)
+			}
+			mintedToken = tok
+			fmt.Fprintf(stdout, "Wrote %s (mode 0600 — minted LOOMCYCLE_AUTH_TOKEN)\n", authEnvPath)
+		}
+	}
+
 	fmt.Fprintln(stdout)
 	if wizard {
-		fmt.Fprintln(stdout, "Add these to your shell rc (e.g. ~/.zshrc):")
-		fmt.Fprintln(stdout, "    export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
+		if mintedToken == "" {
+			fmt.Fprintln(stdout, "Add these to your shell rc (e.g. ~/.zshrc):")
+			fmt.Fprintln(stdout, "    export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
+		} else {
+			fmt.Fprintln(stdout, "Auth token persisted (auto-loaded by `loomcycle`). Add your provider key to your shell rc:")
+		}
 		if provider != "skip" {
 			fmt.Fprintf(stdout, "    export %s=<your-key-here>\n", envVar)
 		}
@@ -134,16 +170,50 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 		}
 		fmt.Fprintln(stdout)
 		fmt.Fprintf(stdout, "Then read %s and run `loomcycle doctor` to verify.\n", docPath)
+		printUIURL(stdout, listenAddr, mintedToken)
 	} else {
 		fmt.Fprintln(stdout, "Next steps:")
 		fmt.Fprintf(stdout, "  1. Read %s for the env-var reference.\n", docPath)
-		fmt.Fprintln(stdout, "  2. Set the required environment variables in your shell rc:")
-		fmt.Fprintln(stdout, "       export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
-		fmt.Fprintln(stdout, "       export ANTHROPIC_API_KEY=<your-key>   # or OPENAI_API_KEY, DEEPSEEK_API_KEY")
+		if mintedToken == "" {
+			fmt.Fprintln(stdout, "  2. Set the required environment variables in your shell rc:")
+			fmt.Fprintln(stdout, "       export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
+			fmt.Fprintln(stdout, "       export ANTHROPIC_API_KEY=<your-key>   # or OPENAI_API_KEY, DEEPSEEK_API_KEY")
+		} else {
+			fmt.Fprintln(stdout, "  2. Auth token persisted + auto-loaded; just set a provider key in your shell rc:")
+			fmt.Fprintln(stdout, "       export ANTHROPIC_API_KEY=<your-key>   # or OPENAI_API_KEY, DEEPSEEK_API_KEY")
+		}
 		fmt.Fprintln(stdout, "  3. Run `loomcycle doctor` to verify your setup.")
 		fmt.Fprintln(stdout, "  4. Run `loomcycle` to start the server.")
+		printUIURL(stdout, listenAddr, mintedToken)
 	}
 	return 0
+}
+
+// mintAuthToken returns a 256-bit CSPRNG token, hex-encoded — the same
+// shape as the `openssl rand -hex 32` line init has always suggested, so a
+// minted token is indistinguishable from a hand-rolled one.
+func mintAuthToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// printUIURL prints the one-shot Web UI URL. With a freshly minted token it
+// embeds `?token=…` (the cookie-set bootstrap); otherwise it prints the bare
+// /ui URL — we never read an existing auth.env back to recover its secret.
+func printUIURL(stdout io.Writer, listenAddr, mintedToken string) {
+	if listenAddr == "" {
+		listenAddr = "127.0.0.1:8787"
+	}
+	fmt.Fprintln(stdout)
+	if mintedToken != "" {
+		fmt.Fprintln(stdout, "Open the Web UI (one-time link — sets the session cookie):")
+		fmt.Fprintf(stdout, "    http://%s/ui?token=%s\n", listenAddr, mintedToken)
+	} else {
+		fmt.Fprintf(stdout, "Web UI: http://%s/ui  (append ?token=$LOOMCYCLE_AUTH_TOKEN once to set the cookie)\n", listenAddr)
+	}
 }
 
 // runWizard asks the minimal 3-question set. Returns the operator's

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -120,15 +120,17 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 	fmt.Fprintf(stdout, "Wrote %s\n", docPath)
 
 	// --with-token: mint + persist a LOOMCYCLE_AUTH_TOKEN so the operator
-	// gets an authenticated runtime without a shell-rc edit. mintedToken is
-	// non-empty only when we actually wrote a fresh token THIS run — when an
-	// auth.env already exists we keep it (never clobber a live token) and
-	// never read its value back (no secret echo).
-	var mintedToken string
+	// gets an authenticated runtime without a shell-rc edit. authEnvPersisted
+	// is the path to the 0600 file holding the token (set when we minted one
+	// THIS run, or when we kept an existing one). The raw token is written ONLY
+	// to that 0600 file — never echoed to stdout and never embedded in a URL
+	// (a token in a URL leaks into browser history / a fronting proxy's logs).
+	var authEnvPersisted string
 	if *withToken {
 		authEnvPath := filepath.Join(destDir, "auth.env")
 		if !*force && firstExistingFile(authEnvPath) != "" {
 			fmt.Fprintf(stdout, "Kept existing %s (pass --force to mint a fresh token).\n", authEnvPath)
+			authEnvPersisted = authEnvPath
 		} else {
 			tok, err := mintAuthToken()
 			if err != nil {
@@ -141,14 +143,14 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 			if err := os.WriteFile(authEnvPath, []byte(body), 0o600); err != nil {
 				return fail(stderr, "init: write %s: %v", authEnvPath, err)
 			}
-			mintedToken = tok
+			authEnvPersisted = authEnvPath
 			fmt.Fprintf(stdout, "Wrote %s (mode 0600 — minted LOOMCYCLE_AUTH_TOKEN)\n", authEnvPath)
 		}
 	}
 
 	fmt.Fprintln(stdout)
 	if wizard {
-		if mintedToken == "" {
+		if authEnvPersisted == "" {
 			fmt.Fprintln(stdout, "Add these to your shell rc (e.g. ~/.zshrc):")
 			fmt.Fprintln(stdout, "    export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
 		} else {
@@ -170,11 +172,11 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 		}
 		fmt.Fprintln(stdout)
 		fmt.Fprintf(stdout, "Then read %s and run `loomcycle doctor` to verify.\n", docPath)
-		printUIURL(stdout, listenAddr, mintedToken)
+		printUIURL(stdout, listenAddr, authEnvPersisted)
 	} else {
 		fmt.Fprintln(stdout, "Next steps:")
 		fmt.Fprintf(stdout, "  1. Read %s for the env-var reference.\n", docPath)
-		if mintedToken == "" {
+		if authEnvPersisted == "" {
 			fmt.Fprintln(stdout, "  2. Set the required environment variables in your shell rc:")
 			fmt.Fprintln(stdout, "       export LOOMCYCLE_AUTH_TOKEN=$(openssl rand -hex 32)")
 			fmt.Fprintln(stdout, "       export ANTHROPIC_API_KEY=<your-key>   # or OPENAI_API_KEY, DEEPSEEK_API_KEY")
@@ -184,7 +186,7 @@ func runInitWithStdin(args []string, stdin io.Reader, stdout, stderr io.Writer) 
 		}
 		fmt.Fprintln(stdout, "  3. Run `loomcycle doctor` to verify your setup.")
 		fmt.Fprintln(stdout, "  4. Run `loomcycle` to start the server.")
-		printUIURL(stdout, listenAddr, mintedToken)
+		printUIURL(stdout, listenAddr, authEnvPersisted)
 	}
 	return 0
 }
@@ -200,19 +202,21 @@ func mintAuthToken() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// printUIURL prints the one-shot Web UI URL. With a freshly minted token it
-// embeds `?token=…` (the cookie-set bootstrap); otherwise it prints the bare
-// /ui URL — we never read an existing auth.env back to recover its secret.
-func printUIURL(stdout io.Writer, listenAddr, mintedToken string) {
+// printUIURL prints the Web UI URL. The token is deliberately NOT embedded
+// in the URL: a `?token=…` link leaks the bearer into browser history and any
+// fronting proxy's access log. We print the bare /ui URL (which lands on the
+// login prompt) and point at the 0600 file the operator pastes from — the
+// secret never travels in a URL we emit, nor through stdout.
+func printUIURL(stdout io.Writer, listenAddr, authEnvPersisted string) {
 	if listenAddr == "" {
 		listenAddr = "127.0.0.1:8787"
 	}
 	fmt.Fprintln(stdout)
-	if mintedToken != "" {
-		fmt.Fprintln(stdout, "Open the Web UI (one-time link — sets the session cookie):")
-		fmt.Fprintf(stdout, "    http://%s/ui?token=%s\n", listenAddr, mintedToken)
+	fmt.Fprintf(stdout, "Open the Web UI: http://%s/ui\n", listenAddr)
+	if authEnvPersisted != "" {
+		fmt.Fprintf(stdout, "    → at the login prompt, paste the token from %s\n", authEnvPersisted)
 	} else {
-		fmt.Fprintf(stdout, "Web UI: http://%s/ui  (append ?token=$LOOMCYCLE_AUTH_TOKEN once to set the cookie)\n", listenAddr)
+		fmt.Fprintln(stdout, "    → at the login prompt, paste your LOOMCYCLE_AUTH_TOKEN (open mode needs no token)")
 	}
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -184,7 +184,9 @@ func tail(s string, lines int) string {
 }
 
 // TestInit_WithToken_MintsAuthEnv — --with-token persists a 0600 auth.env
-// carrying a 64-hex LOOMCYCLE_AUTH_TOKEN and prints the one-time UI URL.
+// carrying a 64-hex LOOMCYCLE_AUTH_TOKEN, prints the bare UI URL, and (the
+// security-load-bearing part) NEVER echoes the token to stdout nor embeds it
+// in a URL.
 func TestInit_WithToken_MintsAuthEnv(t *testing.T) {
 	dir := t.TempDir()
 	var stdout, stderr bytes.Buffer
@@ -220,10 +222,22 @@ func TestInit_WithToken_MintsAuthEnv(t *testing.T) {
 			t.Fatalf("token has non-hex char %q", c)
 		}
 	}
-	// The UI URL must embed the freshly minted token so the operator can
-	// click straight through to an authenticated UI.
-	if !strings.Contains(stdout.String(), "/ui?token="+token) {
-		t.Errorf("stdout missing the ready-to-open UI URL with the minted token; got:\n%s", stdout.String())
+	out := stdout.String()
+	// The token must NEVER appear in stdout — not raw, not in a URL. It lives
+	// only in the 0600 file. (Guards against a regression that re-embeds it
+	// in a `/ui?token=…` link, which leaks into history / proxy logs.)
+	if strings.Contains(out, token) {
+		t.Error("stdout contains the raw token — it must stay in the 0600 file, never echoed")
+	}
+	if strings.Contains(out, "?token=") {
+		t.Errorf("stdout embeds a ?token= URL; the token must not travel in a URL. got:\n%s", out)
+	}
+	// The bare UI URL + a pointer to the auth.env file must be present.
+	if !strings.Contains(out, "/ui\n") && !strings.Contains(out, "/ui ") {
+		t.Errorf("stdout missing the bare /ui URL; got:\n%s", out)
+	}
+	if !strings.Contains(out, authEnv) {
+		t.Errorf("stdout missing the auth.env path to paste from; got:\n%s", out)
 	}
 }
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -182,3 +182,92 @@ func tail(s string, lines int) string {
 	}
 	return strings.Join(parts[len(parts)-lines:], "\n")
 }
+
+// TestInit_WithToken_MintsAuthEnv — --with-token persists a 0600 auth.env
+// carrying a 64-hex LOOMCYCLE_AUTH_TOKEN and prints the one-time UI URL.
+func TestInit_WithToken_MintsAuthEnv(t *testing.T) {
+	dir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runInitWithStdin(
+		[]string{"--path", dir, "--no-interactive", "--with-token"},
+		&bytes.Buffer{}, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("init --with-token exit=%d stderr=%s", code, stderr.String())
+	}
+
+	authEnv := filepath.Join(dir, "auth.env")
+	info, err := os.Stat(authEnv)
+	if err != nil {
+		t.Fatalf("auth.env not written: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("auth.env mode = %o, want 600 (it holds a secret)", perm)
+	}
+
+	body, _ := os.ReadFile(authEnv)
+	var token string
+	for _, line := range strings.Split(string(body), "\n") {
+		if strings.HasPrefix(line, "LOOMCYCLE_AUTH_TOKEN=") {
+			token = strings.TrimPrefix(line, "LOOMCYCLE_AUTH_TOKEN=")
+		}
+	}
+	if len(token) != 64 {
+		t.Errorf("minted token len = %d, want 64 hex chars", len(token))
+	}
+	for _, c := range token {
+		if !strings.ContainsRune("0123456789abcdef", c) {
+			t.Fatalf("token has non-hex char %q", c)
+		}
+	}
+	// The UI URL must embed the freshly minted token so the operator can
+	// click straight through to an authenticated UI.
+	if !strings.Contains(stdout.String(), "/ui?token="+token) {
+		t.Errorf("stdout missing the ready-to-open UI URL with the minted token; got:\n%s", stdout.String())
+	}
+}
+
+// TestInit_WithToken_NoClobber — a non-force re-run must never clobber a live
+// token. init refuses on the pre-existing yaml before reaching the token
+// block, so the secret is preserved; --force is the explicit "regenerate
+// everything" signal.
+func TestInit_WithToken_NoClobber(t *testing.T) {
+	dir := t.TempDir()
+	var o1, e1 bytes.Buffer
+	if code := runInitWithStdin([]string{"--path", dir, "--no-interactive", "--with-token"},
+		&bytes.Buffer{}, &o1, &e1); code != 0 {
+		t.Fatalf("first init exit=%d stderr=%s", code, e1.String())
+	}
+	before, _ := os.ReadFile(filepath.Join(dir, "auth.env"))
+
+	var o2, e2 bytes.Buffer
+	code := runInitWithStdin([]string{"--path", dir, "--no-interactive", "--with-token"},
+		&bytes.Buffer{}, &o2, &e2)
+	if code == 0 {
+		t.Errorf("non-force re-run should refuse (yaml already exists); got exit 0")
+	}
+	if !strings.Contains(e2.String(), "already exists") {
+		t.Errorf("expected an 'already exists' refusal; got stderr:\n%s", e2.String())
+	}
+	after, _ := os.ReadFile(filepath.Join(dir, "auth.env"))
+	if string(before) != string(after) {
+		t.Error("auth.env changed on a non-force re-run — a live token must never be clobbered")
+	}
+}
+
+func TestMintAuthToken_UniqueAndHex(t *testing.T) {
+	a, err := mintAuthToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := mintAuthToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a) != 64 || len(b) != 64 {
+		t.Fatalf("token lengths = %d,%d, want 64", len(a), len(b))
+	}
+	if a == b {
+		t.Error("two mints returned the same token — not random")
+	}
+}

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -587,7 +587,7 @@ func (m *MCPServerDef) validateOverlay(ov mcpServerOverlay) error {
 		return fmt.Errorf("url missing hostname")
 	}
 	if !m.hostAllowed(host) {
-		return fmt.Errorf("host %q not in LOOMCYCLE_HTTP_HOST_ALLOWLIST (operator-blessed allowlist is the floor for outbound HTTP)", host)
+		return fmt.Errorf("host %q not in LOOMCYCLE_HTTP_HOST_ALLOWLIST or LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST (operator-blessed allowlists are the floor for outbound HTTP; loopback / RFC1918 callback hosts like a self-hosted localhost MCP server belong in the private allowlist)", host)
 	}
 	return nil
 }
@@ -598,8 +598,22 @@ func (m *MCPServerDef) validateOverlay(ov mcpServerOverlay) error {
 // the load-bearing operator contract: the same yaml allowlist must
 // produce the same allow/deny decision regardless of which tool the
 // call goes through.
+//
+// A runtime-registered MCP server's host may be either a general outbound
+// target (HTTPHostAllowlist) OR an operator-blessed loopback / RFC1918
+// callback (HTTPPrivateHostAllowlist — the SAME exemption the HTTP/WebFetch
+// *dial-time* SSRF guard already honours, see httptool.go). Consulting only
+// the general floor here was an asymmetry the static `mcp_servers:` block
+// hid: an operator-declared loopback callback (e.g. a self-hosted
+// `http://localhost:3000/api/mcp`) would be refused at create even though
+// the operator explicitly blessed it for outbound HTTP via the private
+// allowlist — forcing them to widen the GENERAL SSRF floor just to register
+// their own callback server. Both lists are operator-declared, so honouring
+// either never widens beyond operator intent; it aligns create-time with
+// dial-time.
 func (m *MCPServerDef) hostAllowed(host string) bool {
-	return hostAllowed(host, m.Cfg.Env.HTTPHostAllowlist)
+	return hostAllowed(host, m.Cfg.Env.HTTPHostAllowlist) ||
+		hostAllowed(host, m.Cfg.Env.HTTPPrivateHostAllowlist)
 }
 
 // buildDefinition merges parent JSON (or empty for create) with the

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -80,6 +80,39 @@ func TestMCPServerDefTool_CreateRefusedOnHostNotInAllowlist(t *testing.T) {
 	}
 }
 
+// TestMCPServerDefTool_CreateAllowsPrivateAllowlistHost pins the fix for the
+// dynamic-loopback-registration gap. A runtime `create` whose URL host is an
+// operator-blessed loopback (HTTPPrivateHostAllowlist) must succeed even when
+// that host is NOT in the general HTTPHostAllowlist — a self-hosted
+// `http://localhost:3000/api/mcp` callback shouldn't force the operator to
+// widen the general SSRF floor. This is the create-time/dial-time alignment:
+// the HTTP tool already exempts private-allowlisted hosts at dial time.
+//
+// Fails on the pre-fix code, where hostAllowed consulted only
+// HTTPHostAllowlist, so a loopback host blessed only via the private
+// allowlist was refused at create (fail-soft → no mcp__jobs__* tools).
+func TestMCPServerDefTool_CreateAllowsPrivateAllowlistHost(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	// Loopback host blessed ONLY in the private allowlist — deliberately
+	// absent from the general floor.
+	tool.Cfg.Env.HTTPHostAllowlist = []string{"n8n.example.com"}
+	tool.Cfg.Env.HTTPPrivateHostAllowlist = []string{"localhost", "127.0.0.1"}
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"jobs","overlay":{"transport":"http","url":"http://localhost:3000/api/mcp"}}`))
+	if res.IsError {
+		t.Fatalf("loopback host blessed via HTTPPrivateHostAllowlist should be allowed at create; got: %s", res.Text)
+	}
+
+	// Negative control: a private host in NEITHER allowlist is still refused
+	// — the SSRF floor is preserved, only the operator-declared private
+	// exemption is honoured.
+	res2, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"sneaky","overlay":{"transport":"http","url":"http://10.0.0.5:9000/mcp"}}`))
+	if !res2.IsError {
+		t.Errorf("private host in neither allowlist must still be refused; got: %s", res2.Text)
+	}
+}
+
 // TestMCPServerDefTool_HostAllowlistMatchesCanonical pins the contract
 // that this tool's allowlist semantics MATCH the canonical hostAllowed
 // helper used by HTTP + WebFetch. Specifically: a bare allowlist entry


### PR DESCRIPTION
## Root cause

Runtime `MCPServerDef create` validated the URL host via `hostAllowed(host, HTTPHostAllowlist)` (`mcpserverdef.go`) — consulting **only** `LOOMCYCLE_HTTP_HOST_ALLOWLIST`, never `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST`. So a dynamically-registered loopback / RFC1918 callback (a self-hosted `http://localhost:3000/api/mcp`) was **refused at create** even when the operator had explicitly blessed that host in the private allowlist → fail-soft → the `mcp__<server>__*` tools never registered (the exact symptom behind "agents ignoring tool usage" for the dynamically-registered `jobs` server).

This was an asymmetry the static `mcp_servers:` block hid: **operator-declared servers skip the create-time SSRF check**, but a **runtime-registered** one was gated on the *general* outbound floor — forcing operators to widen SSRF for **all** outbound HTTP just to register their own loopback callback. loomcycle already has a dedicated private-host allowlist for exactly this loopback case, and the HTTP/WebFetch **dial-time** guard already exempts private-allowlisted hosts (`httptool.go:245`). Create-time was the outlier.

## Fix

`hostAllowed` now accepts a host present in **either** `HTTPHostAllowlist` **or** `HTTPPrivateHostAllowlist`. Both are operator-declared, so honoring either never widens beyond operator intent — a private host in **neither** list is still refused (the SSRF floor is preserved). This aligns create-time with dial-time. The refusal message now names both allowlists and points loopback/RFC1918 callbacks at the private allowlist.

## Tested

- New `TestMCPServerDefTool_CreateAllowsPrivateAllowlistHost`: a loopback host blessed **only** via the private allowlist is allowed at create; a private host in **neither** allowlist is still refused (negative control). **Verified to fail on the pre-fix code** (`host "localhost" not in …`).
- Full `internal/tools/builtin` package green; `go vet` + `gofmt` clean.

## Notes

- **Dev unblock** (no code needed, already identified by the operator): add `localhost,127.0.0.1` to `LOOMCYCLE_HTTP_HOST_ALLOWLIST` and restart — but with this fix, putting them in `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST` (where loopback belongs) is sufficient and doesn't widen the general SSRF floor.
- **Production**: the registered URL is `${NEXT_PUBLIC_BASE_URL}/api/mcp` — in Docker that's the web service's hostname, which must be in `HTTPHostAllowlist` (public-style host) or `HTTPPrivateHostAllowlist` (internal service host). This fix makes the internal-service-host case work via the private allowlist without loosening the general floor.
- The A2A gRPC binding's absolute private-IP refusal (`a2aagentdef.go`, #317) is intentionally stricter and untouched — that transport dials outside the SSRF guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)