### PR TITLE
fix(mcp): resolve tools for dynamically-registered MCP servers

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -880,8 +880,8 @@ func main() {
 	for name, srv := range cfg.MCPServers {
 		mcpServerCfgs[name] = mcp.ServerCfg{AllowedTools: srv.AllowedTools}
 	}
-	mcpLazyResolver := mcp.NewLazyResolver(mcpPool, mcpServerCfgs, func(server string, count int) {
-		log.Printf("mcp[%s]: lazy-registered %d tool(s) on first agent call (was skipped at boot)", server, count)
+	mcpLazyResolver := mcp.NewLazyResolver(mcpPool, mcpServerCfgs, dynamicMCPRegistry, func(server string, count int) {
+		log.Printf("mcp[%s]: lazy-registered %d tool(s) on first agent call", server, count)
 	}, 0)
 
 	// Storage: SQLite (default, compact installs) or Postgres

--- a/internal/tools/mcp/lazy.go
+++ b/internal/tools/mcp/lazy.go
@@ -61,6 +61,16 @@ type LazyResolver struct {
 	pool         *Pool
 	serverConfig map[string]ServerCfg
 
+	// dynamicReg holds runtime-registered (MCPServerDef) servers — the
+	// same shared registry the pool's build callback consults. May be nil
+	// (tests / deployments without the substrate). Without it, a server
+	// registered at runtime via `mcpserverdef create` is absent from
+	// serverConfig (which is static-yaml only), so its tools fail the
+	// membership gate below and the agent sees a bare "tool not found"
+	// even though the pool could reach the server. Consulting it here is
+	// what makes dynamic loopback/remote MCP registration actually usable.
+	dynamicReg *DynamicRegistry
+
 	// onResolve, if non-nil, is called once per server when its tools
 	// are first registered via the lazy path. Used for operator-visible
 	// "mcp[%s]: lazy-registered N tools after agent call (was skipped at
@@ -93,15 +103,18 @@ type ServerCfg struct {
 // configs; the resolver simply won't be reached for it (its tools are
 // in the dispatcher's static map).
 //
-// onResolve is optional; pass log.Printf for production. handshakeTimeout
-// of 0 falls back to a sane default.
-func NewLazyResolver(pool *Pool, configs map[string]ServerCfg, onResolve func(string, int), handshakeTimeout time.Duration) *LazyResolver {
+// dynamicReg is the shared runtime-registration registry (the same one
+// the pool's build callback uses); pass nil to disable dynamic-server
+// resolution. onResolve is optional; pass log.Printf for production.
+// handshakeTimeout of 0 falls back to a sane default.
+func NewLazyResolver(pool *Pool, configs map[string]ServerCfg, dynamicReg *DynamicRegistry, onResolve func(string, int), handshakeTimeout time.Duration) *LazyResolver {
 	if handshakeTimeout <= 0 {
 		handshakeTimeout = 10 * time.Second
 	}
 	return &LazyResolver{
 		pool:             pool,
 		serverConfig:     configs,
+		dynamicReg:       dynamicReg,
 		onResolve:        onResolve,
 		handshakeTimeout: handshakeTimeout,
 		registered:       make(map[string]map[string]tools.Tool),
@@ -116,6 +129,17 @@ func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawM
 		return tools.Result{}, false
 	}
 	cfg, configured := r.serverConfig[server]
+	if !configured && r.dynamicReg != nil {
+		if _, ok := r.dynamicReg.Get(server); ok {
+			// Dynamically-registered (MCPServerDef) server: present in the
+			// shared registry the pool's build callback uses, but absent
+			// from the static-yaml serverConfig. Resolve its tools too. No
+			// operator allowed_tools filter — the dynamic spec carries none,
+			// and empty = allow-all discovered (the agent's own allowed_tools
+			// still gates which it may call).
+			cfg, configured = ServerCfg{}, true
+		}
+	}
 	if !configured {
 		return tools.Result{}, false
 	}

--- a/internal/tools/mcp/lazy_test.go
+++ b/internal/tools/mcp/lazy_test.go
@@ -108,7 +108,7 @@ func newBuildPlan() *buildPlan {
 // Write, etc.) would block on a useless pool.Get.
 func TestLazyResolver_NotMCPName(t *testing.T) {
 	pool := NewPool(newBuildPlan().build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	for _, name := range []string{"Read", "Write", "WebSearch", "mcp__", "mcp__jobs", "mcp__jobs__"} {
 		_, handled := r.Resolve(context.Background(), name, json.RawMessage(`{}`))
@@ -125,7 +125,7 @@ func TestLazyResolver_NotMCPName(t *testing.T) {
 // the right surface.
 func TestLazyResolver_ServerNotConfigured(t *testing.T) {
 	pool := NewPool(newBuildPlan().build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	_, handled := r.Resolve(context.Background(), "mcp__unknown__doSomething", json.RawMessage(`{}`))
 	if handled {
@@ -144,7 +144,7 @@ func TestLazyResolver_FirstCallTriggersHandshakeAndDispatches(t *testing.T) {
 		{Name: "getAgentContext", Description: "load context", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
 	if !handled {
@@ -172,7 +172,7 @@ func TestLazyResolver_SecondCallHitsCache(t *testing.T) {
 		{Name: "patchApplication", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	for i := 0; i < 5; i++ {
 		_, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
@@ -200,7 +200,7 @@ func TestLazyResolver_HandshakeFails(t *testing.T) {
 	plan := newBuildPlan()
 	plan.alwaysFail["jobs"] = true
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
 	if !handled {
@@ -231,7 +231,7 @@ func TestLazyResolver_OperatorAllowedToolsFilter(t *testing.T) {
 	pool := NewPool(plan.build, nil)
 	r := NewLazyResolver(pool, map[string]ServerCfg{
 		"jobs": {AllowedTools: []string{"safe_tool"}},
-	}, nil, 0)
+	}, nil, nil, 0)
 
 	// safe_tool resolves
 	_, handled := r.Resolve(context.Background(), "mcp__jobs__safe_tool", json.RawMessage(`{}`))
@@ -269,7 +269,7 @@ func TestLazyResolver_OnResolveCallback(t *testing.T) {
 			count  int
 		}
 	)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, func(server string, count int) {
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, func(server string, count int) {
 		mu.Lock()
 		defer mu.Unlock()
 		callbacks = append(callbacks, struct {
@@ -304,7 +304,7 @@ func TestLazyResolver_ConcurrentCallsCoalesceHandshake(t *testing.T) {
 		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, 0)
+	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
 
 	const N = 50
 	var wg sync.WaitGroup
@@ -321,5 +321,42 @@ func TestLazyResolver_ConcurrentCallsCoalesceHandshake(t *testing.T) {
 	wg.Wait()
 	if got := plan.calls("jobs"); got != 1 {
 		t.Errorf("build called %d times under %d-way concurrent first-touch, want 1", got, N)
+	}
+}
+
+// TestLazyResolver_DynamicRegistryServerResolves pins the fix for
+// dynamically-registered (MCPServerDef) servers: a server absent from the
+// static serverConfig but present in the shared DynamicRegistry must still
+// resolve its tools. Before the fix the membership gate consulted only
+// serverConfig, so a runtime-registered `jobs` server fell through to the
+// dispatcher's bare "tool not found" even though the pool could reach it —
+// the exact `tool not found: mcp__jobs__postResearchIngest` symptom.
+func TestLazyResolver_DynamicRegistryServerResolves(t *testing.T) {
+	plan := newBuildPlan()
+	plan.tools["jobs"] = []ToolDescriptor{
+		{Name: "postResearchIngest", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	pool := NewPool(plan.build, nil)
+	// serverConfig deliberately omits "jobs" — it lives ONLY in the dynamic
+	// registry, as if registered at runtime via `mcpserverdef create`.
+	dyn := NewDynamicRegistry()
+	dyn.Set(DynamicMCPServerSpec{Name: "jobs", Transport: "http", URL: "http://localhost:3000/api/mcp"})
+	r := NewLazyResolver(pool, map[string]ServerCfg{}, dyn, nil, 0)
+
+	res, handled := r.Resolve(context.Background(), "mcp__jobs__postResearchIngest", json.RawMessage(`{}`))
+	if !handled {
+		t.Fatal("dynamically-registered server should be handled (pre-fix: fell through → 'tool not found')")
+	}
+	if res.IsError {
+		t.Fatalf("expected success Result, got IsError: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "fake-call-result") {
+		t.Errorf("expected dispatch to the underlying tool; got %q", res.Text)
+	}
+
+	// Control: a server in NEITHER serverConfig NOR the registry still falls
+	// through to the dispatcher's generic "tool not found".
+	if _, handled2 := r.Resolve(context.Background(), "mcp__ghost__doThing", json.RawMessage(`{}`)); handled2 {
+		t.Error("unknown server (not static, not dynamic) must fall through (handled=false)")
 	}
 }


### PR DESCRIPTION
## Root cause

After `mcpserverdef create` + `rediscover` succeed (confirmed live: `[ensure-jobs-mcp] registered 'jobs' MCP server + rediscovered`, `POST /api/mcp 200`), agents still got `tool not found: mcp__jobs__postResearchIngest` and the tools were unusable.

The lazy tool resolver (`internal/tools/mcp/lazy.go`) is the dispatcher fallback that turns `mcp__<server>__<tool>` misses into a handshake + dispatch. Its membership gate consulted **only** the static-yaml `serverConfig`:

```go
cfg, configured := r.serverConfig[server]
if !configured { return tools.Result{}, false }   // → dispatcher's bare "tool not found"
```

A **dynamically-registered** server lives in the shared `DynamicRegistry` (which the *pool's* build callback already consults), but `NewLazyResolver` was only handed the static map. So the resolver rejected `jobs` at the gate **before** ever trying the pool — even though the pool could reach it. That's why the error was the generic `tool not found` rather than the resolver's own "unreachable"/"does not expose" message. This is the same static-vs-dynamic asymmetry as #340, one layer up.

## Fix

Thread the shared `DynamicRegistry` into `NewLazyResolver`. On a `serverConfig` miss, `Resolve` now also consults the registry; a hit is treated as configured with **no operator `allowed_tools` filter** (the dynamic spec carries none — empty = allow-all discovered; the agent's own `allowed_tools` still gates which it may call). A server in **neither** source still falls through to the standard `tool not found`.

## Tested

- New `TestLazyResolver_DynamicRegistryServerResolves`: a server present **only** in the registry resolves + dispatches; a server in neither source falls through (`handled=false`). **Verified to fail on the pre-fix code.**
- All 8 existing `LazyResolver` tests updated for the new constructor param (pass `nil`) and green; `internal/tools/mcp` package green; `go vet` + `gofmt` clean.

## Separate follow-up (noted, not in this PR)

The Library UI (`GET /v1/_library/mcp-servers`) lists substrate servers but **does not attach `discovered_tools` to substrate-only entries** — only static servers get them via the pool inspector (`library_unified.go:196`). That's why the dynamic `jobs` server's tools don't render in the Library UI yet. Small, separate fix (surface the def's rediscovered tools, or run the pool inspector for dynamic names). Happy to do it next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)