### PR TITLE
refactor(mcp): route the lazy resolver through the shared lookup.MCPServer

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -875,12 +875,11 @@ func main() {
 	// notice the "skipped" log line and restart loomcycle by hand.
 	// In a server environment where peers (jobs-search-web, other MCP
 	// services) restart independently, that's recurring operational
-	// pain. See internal/tools/mcp/lazy.go for the state machine.
-	mcpServerCfgs := make(map[string]mcp.ServerCfg, len(cfg.MCPServers))
-	for name, srv := range cfg.MCPServers {
-		mcpServerCfgs[name] = mcp.ServerCfg{AllowedTools: srv.AllowedTools}
-	}
-	mcpLazyResolver := mcp.NewLazyResolver(mcpPool, mcpServerCfgs, dynamicMCPRegistry, func(server string, count int) {
+	// pain. See internal/tools/mcp/lazy.go for the state machine. Membership +
+	// per-server allowed_tools resolve through the shared lookup.MCPServer
+	// (static cfg.MCPServers → dynamic registry), so cfg + the registry are
+	// passed straight through.
+	mcpLazyResolver := mcp.NewLazyResolver(mcpPool, cfg, dynamicMCPRegistry, func(server string, count int) {
 		log.Printf("mcp[%s]: lazy-registered %d tool(s) on first agent call", server, count)
 	}, 0)
 

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -25,6 +25,12 @@ type MCPServerSpec struct {
 	Transport string
 	URL       string
 	Headers   map[string]string
+	// AllowedTools is the operator's per-server tools/list narrowing (yaml
+	// `allowed_tools`); empty = allow all discovered tools. Only the STATIC
+	// source carries it — a dynamically-registered (substrate) server has
+	// none, so all its discovered tools are allowed and the agent's own
+	// allowed_tools is the gate. Consumed by the MCP lazy tool resolver.
+	AllowedTools []string
 	// Source — "static" or "dynamic". Useful for log lines + the
 	// /ui/library/mcp-servers page's badge.
 	Source string
@@ -52,18 +58,26 @@ type MCPServerSpec struct {
 // no path by which a dynamic row could carry those fields. As a
 // consequence, this function cannot replace the inline pool build
 // callback in cmd/loomcycle/main.go for the stdio case; that callback
-// reads cfg.MCPServer directly to get the stdio fields. Use this
-// resolver from HTTP-only call sites: the /ui/library/mcp-servers
-// page's bearer-authed GET endpoint + any future tool that needs to
-// resolve a name → spec for an http-transport server.
+// reads cfg.MCPServer directly to get the stdio fields.
+//
+// Callers that need the full spec (transport/url/headers) should use it
+// only for http-transport servers (the /ui/library/mcp-servers GET
+// endpoint). Callers that need ONLY membership + AllowedTools are
+// transport-agnostic and safe for any server — notably the MCP lazy tool
+// resolver (internal/tools/mcp/lazy.go), which delegates client
+// construction to the pool and consults this resolver purely to decide
+// "is this name known (static OR dynamic)?" + which tools the operator
+// allowed. Routing the resolver through here is what keeps MCP membership
+// from drifting static-only again (the bug fixed in #341).
 func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, name string) (MCPServerSpec, bool) {
 	if cfg != nil {
 		if srv, ok := cfg.MCPServers[name]; ok {
 			return MCPServerSpec{
-				Transport: srv.Transport,
-				URL:       srv.URL,
-				Headers:   srv.Headers,
-				Source:    "static",
+				Transport:    srv.Transport,
+				URL:          srv.URL,
+				Headers:      srv.Headers,
+				AllowedTools: srv.AllowedTools,
+				Source:       "static",
 			}, true
 		}
 	}

--- a/internal/lookup/mcpserver_test.go
+++ b/internal/lookup/mcpserver_test.go
@@ -4,8 +4,50 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 )
+
+// fakeDynReg is a lookup.MCPDynamicRegistry stub for the resolver test.
+type fakeDynReg map[string]lookup.MCPServerSpec
+
+func (f fakeDynReg) Get(name string) (lookup.MCPServerSpec, bool) {
+	s, ok := f[name]
+	return s, ok
+}
+
+// TestMCPServer_StaticDynamicPrecedence pins the lookup chain MCP now shares
+// with every other primitive: static yaml → dynamic substrate, yaml-wins on
+// collision, AllowedTools carried only for the static source (dynamic =
+// allow-all). This is the resolver-level guard the MCP lazy resolver lacked
+// before #341 — it had duplicated the membership check static-only. The lazy
+// resolver now routes through this function, so this test covers both.
+func TestMCPServer_StaticDynamicPrecedence(t *testing.T) {
+	cfg := &config.Config{MCPServers: map[string]config.MCPServer{
+		"static-srv": {Transport: "http", URL: "http://s/mcp", AllowedTools: []string{"a", "b"}},
+		"both":       {Transport: "http", URL: "http://yaml/mcp"},
+	}}
+	dyn := fakeDynReg{
+		"dyn-srv": {Transport: "http", URL: "http://d/mcp"},
+		"both":    {Transport: "http", URL: "http://substrate/mcp"},
+	}
+
+	if spec, ok := lookup.MCPServer(cfg, dyn, "static-srv"); !ok || spec.Source != "static" || !reflect.DeepEqual(spec.AllowedTools, []string{"a", "b"}) {
+		t.Errorf("static: got (%+v, %v), want source=static + allowed [a b]", spec, ok)
+	}
+	if spec, ok := lookup.MCPServer(cfg, dyn, "dyn-srv"); !ok || spec.Source != "dynamic" || len(spec.AllowedTools) != 0 {
+		t.Errorf("dynamic: got (%+v, %v), want source=dynamic + no allowed_tools (allow-all)", spec, ok)
+	}
+	if spec, ok := lookup.MCPServer(cfg, dyn, "both"); !ok || spec.Source != "static" || spec.URL != "http://yaml/mcp" {
+		t.Errorf("collision: got (%+v, %v), want the static (yaml) entry to win", spec, ok)
+	}
+	if _, ok := lookup.MCPServer(cfg, dyn, "nope"); ok {
+		t.Error("unknown name must return ok=false")
+	}
+	if _, ok := lookup.MCPServer(nil, nil, "x"); ok {
+		t.Error("nil cfg + nil dyn must return ok=false")
+	}
+}
 
 // TestMCPServer_DriftDetection pins the substrate-shape invariant for
 // MCPServerDef. SubstrateMCPServer and the persistence shape in

--- a/internal/tools/mcp/lazy.go
+++ b/internal/tools/mcp/lazy.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -58,17 +60,17 @@ import (
 //     stack on top — it would call Resolve preemptively for known
 //     server names.
 type LazyResolver struct {
-	pool         *Pool
-	serverConfig map[string]ServerCfg
+	pool *Pool
 
-	// dynamicReg holds runtime-registered (MCPServerDef) servers — the
-	// same shared registry the pool's build callback consults. May be nil
-	// (tests / deployments without the substrate). Without it, a server
-	// registered at runtime via `mcpserverdef create` is absent from
-	// serverConfig (which is static-yaml only), so its tools fail the
-	// membership gate below and the agent sees a bare "tool not found"
-	// even though the pool could reach the server. Consulting it here is
-	// what makes dynamic loopback/remote MCP registration actually usable.
+	// cfg + dynamicReg are the two membership sources, consulted via the
+	// SHARED lookup.MCPServer resolver (NOT a private map): cfg.MCPServers
+	// is the static-yaml source, dynamicReg the runtime substrate the pool's
+	// build callback also uses. Routing membership + the per-server
+	// allowed_tools filter through lookup.MCPServer is what stops MCP from
+	// drifting static-only again (the bug fixed in #341) — every other
+	// substrate primitive already resolves through internal/lookup. May both
+	// be nil in tests; lookup.MCPServer is nil-safe.
+	cfg        *config.Config
 	dynamicReg *DynamicRegistry
 
 	// onResolve, if non-nil, is called once per server when its tools
@@ -87,33 +89,38 @@ type LazyResolver struct {
 	registered map[string]map[string]tools.Tool // server → tool name → Tool
 }
 
-// ServerCfg is the subset of an MCP server's yaml config that the
-// resolver needs to reproduce boot-time tool registration faithfully.
-// Only AllowedTools today; if the boot path grows more per-server
-// knobs (e.g. per-server pool size already lives on Pool), they
-// should join here.
-type ServerCfg struct {
-	AllowedTools []string
+// lookupDynView adapts *DynamicRegistry to lookup.MCPDynamicRegistry —
+// lookup returns a uniform lookup.MCPServerSpec, while the registry stores
+// the mcp-package DynamicMCPServerSpec. A dynamic spec carries no
+// allowed_tools (the substrate doesn't record an operator narrowing), so
+// the projected spec leaves AllowedTools nil = allow-all, matching the
+// historical resolver behaviour.
+type lookupDynView struct{ reg *DynamicRegistry }
+
+func (v lookupDynView) Get(name string) (lookup.MCPServerSpec, bool) {
+	if v.reg == nil {
+		return lookup.MCPServerSpec{}, false
+	}
+	s, ok := v.reg.Get(name)
+	if !ok {
+		return lookup.MCPServerSpec{}, false
+	}
+	return lookup.MCPServerSpec{Transport: s.Transport, URL: s.URL, Headers: s.Headers}, true
 }
 
-// NewLazyResolver builds a resolver. configs MUST cover every server
-// the operator yaml declares — Resolve uses configs as the membership
-// check for "is this name plausibly an MCP tool we should try?". A
-// server that successfully registered at boot can still appear in
-// configs; the resolver simply won't be reached for it (its tools are
-// in the dispatcher's static map).
-//
-// dynamicReg is the shared runtime-registration registry (the same one
-// the pool's build callback uses); pass nil to disable dynamic-server
-// resolution. onResolve is optional; pass log.Printf for production.
-// handshakeTimeout of 0 falls back to a sane default.
-func NewLazyResolver(pool *Pool, configs map[string]ServerCfg, dynamicReg *DynamicRegistry, onResolve func(string, int), handshakeTimeout time.Duration) *LazyResolver {
+// NewLazyResolver builds a resolver. cfg + dynamicReg are the static-yaml
+// and dynamic-substrate membership sources; Resolve consults them through
+// the shared lookup.MCPServer resolver (so MCP uses the same static→dynamic
+// chain as every other primitive). Either may be nil (tests). onResolve is
+// optional; pass log.Printf for production. handshakeTimeout of 0 falls back
+// to a sane default.
+func NewLazyResolver(pool *Pool, cfg *config.Config, dynamicReg *DynamicRegistry, onResolve func(string, int), handshakeTimeout time.Duration) *LazyResolver {
 	if handshakeTimeout <= 0 {
 		handshakeTimeout = 10 * time.Second
 	}
 	return &LazyResolver{
 		pool:             pool,
-		serverConfig:     configs,
+		cfg:              cfg,
 		dynamicReg:       dynamicReg,
 		onResolve:        onResolve,
 		handshakeTimeout: handshakeTimeout,
@@ -128,18 +135,12 @@ func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawM
 	if !ok {
 		return tools.Result{}, false
 	}
-	cfg, configured := r.serverConfig[server]
-	if !configured && r.dynamicReg != nil {
-		if _, ok := r.dynamicReg.Get(server); ok {
-			// Dynamically-registered (MCPServerDef) server: present in the
-			// shared registry the pool's build callback uses, but absent
-			// from the static-yaml serverConfig. Resolve its tools too. No
-			// operator allowed_tools filter — the dynamic spec carries none,
-			// and empty = allow-all discovered (the agent's own allowed_tools
-			// still gates which it may call).
-			cfg, configured = ServerCfg{}, true
-		}
-	}
+	// Membership + the operator's per-server allowed_tools filter both come
+	// from the shared lookup.MCPServer resolver, which walks static-yaml then
+	// the dynamic substrate (same chain every other primitive uses). A name
+	// in neither source falls through to the dispatcher's standard
+	// "tool not found".
+	spec, configured := lookup.MCPServer(r.cfg, lookupDynView{r.dynamicReg}, server)
 	if !configured {
 		return tools.Result{}, false
 	}
@@ -176,7 +177,7 @@ func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawM
 	}
 
 	// Apply the operator's per-server filter; build the tool map.
-	filtered := ApplyAllowedToolsFilter(descs, cfg.AllowedTools)
+	filtered := ApplyAllowedToolsFilter(descs, spec.AllowedTools)
 	toolMap := make(map[string]tools.Tool, len(filtered))
 	for _, d := range filtered {
 		t := NewTool(r.pool, server, d)

--- a/internal/tools/mcp/lazy_test.go
+++ b/internal/tools/mcp/lazy_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
 // fakeCaller is a Caller that responds to initialize, tools/list, and
@@ -108,7 +110,7 @@ func newBuildPlan() *buildPlan {
 // Write, etc.) would block on a useless pool.Get.
 func TestLazyResolver_NotMCPName(t *testing.T) {
 	pool := NewPool(newBuildPlan().build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	for _, name := range []string{"Read", "Write", "WebSearch", "mcp__", "mcp__jobs", "mcp__jobs__"} {
 		_, handled := r.Resolve(context.Background(), name, json.RawMessage(`{}`))
@@ -125,7 +127,7 @@ func TestLazyResolver_NotMCPName(t *testing.T) {
 // the right surface.
 func TestLazyResolver_ServerNotConfigured(t *testing.T) {
 	pool := NewPool(newBuildPlan().build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	_, handled := r.Resolve(context.Background(), "mcp__unknown__doSomething", json.RawMessage(`{}`))
 	if handled {
@@ -144,7 +146,7 @@ func TestLazyResolver_FirstCallTriggersHandshakeAndDispatches(t *testing.T) {
 		{Name: "getAgentContext", Description: "load context", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
 	if !handled {
@@ -172,7 +174,7 @@ func TestLazyResolver_SecondCallHitsCache(t *testing.T) {
 		{Name: "patchApplication", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	for i := 0; i < 5; i++ {
 		_, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
@@ -200,7 +202,7 @@ func TestLazyResolver_HandshakeFails(t *testing.T) {
 	plan := newBuildPlan()
 	plan.alwaysFail["jobs"] = true
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
 	if !handled {
@@ -229,8 +231,8 @@ func TestLazyResolver_OperatorAllowedToolsFilter(t *testing.T) {
 		{Name: "expensive_tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{
-		"jobs": {AllowedTools: []string{"safe_tool"}},
+	r := NewLazyResolver(pool, &config.Config{
+		MCPServers: map[string]config.MCPServer{"jobs": {AllowedTools: []string{"safe_tool"}}},
 	}, nil, nil, 0)
 
 	// safe_tool resolves
@@ -269,7 +271,7 @@ func TestLazyResolver_OnResolveCallback(t *testing.T) {
 			count  int
 		}
 	)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, func(server string, count int) {
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, func(server string, count int) {
 		mu.Lock()
 		defer mu.Unlock()
 		callbacks = append(callbacks, struct {
@@ -304,7 +306,7 @@ func TestLazyResolver_ConcurrentCallsCoalesceHandshake(t *testing.T) {
 		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
 	pool := NewPool(plan.build, nil)
-	r := NewLazyResolver(pool, map[string]ServerCfg{"jobs": {}}, nil, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	const N = 50
 	var wg sync.WaitGroup
@@ -341,7 +343,7 @@ func TestLazyResolver_DynamicRegistryServerResolves(t *testing.T) {
 	// registry, as if registered at runtime via `mcpserverdef create`.
 	dyn := NewDynamicRegistry()
 	dyn.Set(DynamicMCPServerSpec{Name: "jobs", Transport: "http", URL: "http://localhost:3000/api/mcp"})
-	r := NewLazyResolver(pool, map[string]ServerCfg{}, dyn, nil, 0)
+	r := NewLazyResolver(pool, &config.Config{}, dyn, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__postResearchIngest", json.RawMessage(`{}`))
 	if !handled {


### PR DESCRIPTION
## Why

The cross-primitive audit (your request) found that **every** substrate primitive resolves static→dynamic through the shared `internal/lookup` package — **except MCP**, whose lazy tool resolver hand-rolled its own static+dynamic membership check (a private `serverConfig` map + an inline `dynamicReg` consult). That duplicated logic is precisely what drifted static-only and caused the #341 "tool not found" bug for dynamically-registered MCP servers.

And `lookup.MCPServer` — the static-yaml → dynamic-substrate resolver that's the established pattern for Webhook/MemoryBackend/A2A/Agent/Skill — **existed but had zero callers** (an orphan). This consolidation wires the lazy resolver through it, so there is one resolution chain that's structurally impossible to re-drift.

## What

- **`lookup.MCPServer`**: `MCPServerSpec` gains `AllowedTools` (the operator's per-server `tools/list` narrowing), populated for the **static** source; the dynamic source stays `nil` = allow-all (the substrate records no narrowing — matches prior resolver behavior). Doc updated to note the lazy resolver is now a (transport-agnostic) caller.
- **`LazyResolver`**: removed the private `serverConfig map[string]ServerCfg` (and the `ServerCfg` type) + the inline `dynamicReg` membership check. It now holds `cfg` + `dynamicReg` and resolves via `lookup.MCPServer`, with a tiny `lookupDynView` adapter (`*DynamicRegistry` → `lookup.MCPDynamicRegistry`). **Behavior is identical** — membership + the allowed_tools filter — only the *source* is now the shared resolver.
- **`main.go`**: dropped the now-dead `mcpServerCfgs` map; passes `cfg` straight through.
- No import cycle: `internal/lookup` does not import `internal/tools/mcp` (the resolver decoupling that made this possible).

## Tested

- New **`TestMCPServer_StaticDynamicPrecedence`** (lookup): static (+allowed_tools) / dynamic (allow-all) / yaml-wins-on-collision / unknown / nil-safe — the resolver-level guard the function previously lacked.
- The #341 dynamic-resolution test (`TestLazyResolver_DynamicRegistryServerResolves`) still passes against the consolidated path; all 8 lazy-resolver tests updated to the new constructor.
- `go test ./...`, `go vet`, `gofmt` all clean.

## Net

MCP is no longer the odd-one-out — all primitives now share `internal/lookup` for static→dynamic resolution, closing the class of bug you flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)