### PR TITLE
feat(scheduler): static yaml schedules fire autonomously (full symmetry)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1714,6 +1714,21 @@ func main() {
 			FireTimeout:  time.Duration(cfg.Env.SchedulerFireTimeoutSeconds) * time.Second,
 			EnvAllowlist: envAllowlist,
 		}
+		// Materialize static yaml `scheduled_runs:` into the substrate so
+		// they fire autonomously — symmetric with dynamically-created
+		// schedules (which seed run_state on promoted create). The sweeper's
+		// due-query is substrate-only, so without this a yaml-only schedule
+		// never fires. Idempotent + fork-respecting; runs before the sweeper
+		// so the first tick already sees the seeded rows. A minimal tool
+		// instance suffices (bootstrap needs only Store + Cfg).
+		bootSched := &builtin.ScheduleDef{Store: storeIface, Cfg: cfg}
+		bootCtx := tools.WithRunIdentity(bgCtx, tools.RunIdentityValue{AgentID: "scheduler-bootstrap"})
+		if n, err := bootSched.BootstrapStaticSchedules(bootCtx); err != nil {
+			log.Printf("scheduler: static-schedule bootstrap: %v (continuing)", err)
+		} else if n > 0 {
+			log.Printf("scheduler: materialized %d static schedule(s) into the substrate", n)
+		}
+
 		// srv satisfies runner.Runner via its RunOnce method (the same
 		// seam HTTP + gRPC drive interactive runs through). pauseMgr is
 		// guaranteed non-nil in this branch (storeIface != nil ⇒ pause

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -604,6 +605,57 @@ func (s *ScheduleDef) bootstrapStatic(ctx context.Context, name string, static c
 	// Seed schedule_run_state — see commentary in execCreate.
 	_ = s.Store.ScheduleRunStateSeed(ctx, created.DefID, computeInitialNextRunAt(def, time.Now()))
 	return created, nil
+}
+
+// BootstrapStaticSchedules materializes every static cfg.ScheduledRuns entry
+// that lacks an active substrate version into the substrate (create v1 +
+// promote + seed schedule_run_state). This is what lets a yaml-declared
+// `scheduled_runs:` entry fire AUTONOMOUSLY — symmetric with a dynamically-
+// created ScheduleDef, which already seeds run_state on promoted create. The
+// sweeper's due-query is substrate-only (the schedule_run_state ⨝ active ⨝
+// defs JOIN), so without this a yaml-only schedule has no run_state row and
+// silently never fires until something forks/run-now's it.
+//
+// Idempotent + fork-respecting: a name that already has an active version is
+// left untouched — whether that version is a prior bootstrap (so restarts
+// don't re-seed / reset next_run_at) or an operator fork (so yaml never
+// clobbers a deliberate override). A name's active pointer + run_state row
+// persist across restarts, so only newly-added yaml schedules are seeded on a
+// subsequent boot.
+//
+// Intended to run ONCE at boot, before the sweeper starts. Returns the count
+// bootstrapped this call. nil Store/Cfg → no-op.
+//
+// NOTE (intentional scope): editing a yaml schedule's cron after it has been
+// materialized does NOT auto-apply on restart (the active version wins);
+// re-fork via the substrate tool to change it. Removing a yaml entry does not
+// retire its substrate row. Those reconciliation refinements are deferred —
+// this method closes the "static schedules never fire" gap only.
+func (s *ScheduleDef) BootstrapStaticSchedules(ctx context.Context) (int, error) {
+	if s.Store == nil || s.Cfg == nil {
+		return 0, nil
+	}
+	names := make([]string, 0, len(s.Cfg.ScheduledRuns))
+	for name := range s.Cfg.ScheduledRuns {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic order for logs + tests
+	seeded := 0
+	for _, name := range names {
+		_, err := s.Store.ScheduleDefGetActive(ctx, name)
+		if err == nil {
+			continue // already has an active version (prior bootstrap or fork) — leave it
+		}
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			return seeded, fmt.Errorf("bootstrap %q: get active: %w", name, err)
+		}
+		if _, berr := s.bootstrapStatic(ctx, name, s.Cfg.ScheduledRuns[name]); berr != nil {
+			return seeded, fmt.Errorf("bootstrap %q: %w", name, berr)
+		}
+		seeded++
+	}
+	return seeded, nil
 }
 
 // validateScheduleDef performs the substrate-side cron + on_complete

--- a/internal/tools/builtin/scheduledef_test.go
+++ b/internal/tools/builtin/scheduledef_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
@@ -623,4 +624,107 @@ func scheduleJsonTagsOf(t reflect.Type) map[string]bool {
 		out[tag] = true
 	}
 	return out
+}
+
+// TestScheduleDefTool_BootstrapStaticSchedules — the autonomous-firing fix:
+// a yaml-declared schedule with no active substrate version is materialized
+// (create v1 + promote + seed run_state) so the sweeper's substrate-only
+// due-query finds it. Symmetric with dynamically-created schedules.
+func TestScheduleDefTool_BootstrapStaticSchedules(t *testing.T) {
+	tool, _, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+	// A simple-cron static schedule alongside the fixture's tier template.
+	tool.Cfg.ScheduledRuns["nightly"] = config.ScheduledRun{
+		Agent:    "job-search-batch",
+		Schedule: "0 3 * * *",
+		Prompt: []config.ScheduledRunSegment{{Role: "user", Content: []config.ScheduledRunSegmentContent{
+			{Type: "trusted-text", Text: "go"},
+		}}},
+		Enabled: true,
+	}
+	bg := context.Background()
+
+	// Pre-state: neither static name has an active substrate version.
+	for _, n := range []string{"nightly", "job-search-template"} {
+		if _, err := tool.Store.ScheduleDefGetActive(bg, n); err == nil {
+			t.Fatalf("%s unexpectedly has an active version before bootstrap", n)
+		}
+	}
+
+	n, err := tool.BootstrapStaticSchedules(bg)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("bootstrapped %d, want 2", n)
+	}
+
+	// Both now have an active, bootstrapped-from-static version.
+	for _, name := range []string{"nightly", "job-search-template"} {
+		row, gerr := tool.Store.ScheduleDefGetActive(bg, name)
+		if gerr != nil {
+			t.Errorf("%s: no active version after bootstrap: %v", name, gerr)
+			continue
+		}
+		if !row.BootstrappedFromStatic {
+			t.Errorf("%s: expected BootstrappedFromStatic=true", name)
+		}
+	}
+
+	// The cron schedule is now fireable — appears in the substrate due-set
+	// within a window past its next fire (proves run_state was seeded).
+	due, err := tool.Store.ScheduleRunStateListDue(bg, time.Now().Add(48*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, d := range due {
+		if d.Name == "nightly" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("nightly not in the due-set within 48h — run_state was not seeded (won't fire autonomously)")
+	}
+
+	// Idempotent: a second boot bootstraps nothing.
+	n2, err := tool.BootstrapStaticSchedules(bg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n2 != 0 {
+		t.Errorf("second bootstrap seeded %d, want 0 (idempotent)", n2)
+	}
+}
+
+// TestScheduleDefTool_BootstrapStaticSchedules_DoesNotClobberFork — a static
+// name that already has an active FORK is left untouched (yaml never clobbers
+// a deliberate operator override).
+func TestScheduleDefTool_BootstrapStaticSchedules_DoesNotClobberFork(t *testing.T) {
+	tool, ctx, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"job-search-template","overlay":{"user_id":"alice","user_tier":"high","user_credentials":{"jobs":"j","slack":"s"}}}`))
+	if res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	before, err := tool.Store.ScheduleDefGetActive(context.Background(), "job-search-template")
+	if err != nil {
+		t.Fatalf("get active after fork: %v", err)
+	}
+
+	n, err := tool.BootstrapStaticSchedules(context.Background())
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("bootstrap seeded %d, want 0 — an active fork must be preserved", n)
+	}
+	after, _ := tool.Store.ScheduleDefGetActive(context.Background(), "job-search-template")
+	if before.DefID != after.DefID {
+		t.Errorf("bootstrap clobbered the active fork: %s → %s", before.DefID, after.DefID)
+	}
+	if after.BootstrappedFromStatic {
+		t.Error("active version is now bootstrapped-from-static — the fork was overwritten")
+	}
 }


### PR DESCRIPTION
## Why (the asymmetry)

The scheduler sweep is **substrate-only** — its due-query is `schedule_run_state ⨝ schedule_def_active ⨝ schedule_defs`. **Nothing seeded `cfg.ScheduledRuns` into that table at boot.** So:

- **Dynamic** schedules (created/forked via the substrate, promoted): seed `run_state` on create (`computeInitialNextRunAt`) → **fire autonomously.** ✅
- **Static** yaml `scheduled_runs:` entries: never seeded → **no `run_state` row → silently never fire** until something forks / run-now's them. ❌

(So the broken side was *static*, not dynamic — but the goal is the same: full symmetry, both fire.)

## What

- **`ScheduleDef.BootstrapStaticSchedules(ctx)`** — for each `cfg.ScheduledRuns` name **with no active substrate version**, materialize it (create v1 + promote + seed `run_state`) via the existing `bootstrapStatic` helper. **Idempotent + fork-respecting:** a name that already has an active version (a prior bootstrap *or* an operator fork) is left untouched — restarts don't re-seed / reset `next_run_at`, and yaml never clobbers a deliberate fork. Sorted order for deterministic logs/tests.
- **`main.go`** — invoked once at scheduler-enable, **before** `sched.Start`, so the first tick already sees the seeded rows. Uses a minimal tool instance (`Store` + `Cfg`).

## Intentional scope (deferred reconciliation)

Editing a yaml cron *after* materialization doesn't auto-apply on restart (the active version wins — re-fork to change it); removing a yaml entry doesn't retire its substrate row. Those are reconciliation refinements — this PR closes only the "static schedules never fire autonomously" gap. Flagged in the method doc.

## Tested (both verified)

- `TestScheduleDefTool_BootstrapStaticSchedules` — materializes 2 static schedules → each gets an active `BootstrappedFromStatic` version, the cron one appears in the substrate due-set (proves `run_state` seeded → fireable), and a second call seeds 0 (idempotent).
- `TestScheduleDefTool_BootstrapStaticSchedules_DoesNotClobberFork` — a name with an active **fork** is preserved (count 0, `def_id` unchanged, not reverted to bootstrapped-from-static).
- Full `internal/tools/builtin` + `internal/scheduler` green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)