### PR TITLE
feat(tools): advertise post-boot substrate tools per-run (full symmetry)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1179,6 +1179,40 @@ func main() {
 		b, _ := json.Marshal(out)
 		return b
 	})
+	// Post-boot tool advertising: enumerate the substrate-registered tools
+	// (dynamic MCP servers' discovered tools + A2A peer skills) so a run's
+	// catalog includes them WITHOUT a restart — symmetric with boot-time
+	// tools. Run-creation folds this into the candidate set before the
+	// allowed_tools filter. MCP: each dynamic-registry server's persisted
+	// discovered_tools (set by rediscover). A2A: re-enumerate static +
+	// substrate (the static dups collapse in the by-name filter).
+	srv.SetDynamicToolEnumerator(func(ctx context.Context) []tools.Tool {
+		var out []tools.Tool
+		for _, name := range dynamicMCPRegistry.Names() {
+			row, gerr := storeIface.MCPServerDefGetActive(ctx, name)
+			if gerr != nil {
+				continue
+			}
+			var def lookup.SubstrateMCPServer
+			if json.Unmarshal(row.Definition, &def) != nil {
+				continue
+			}
+			for _, dt := range def.DiscoveredTools {
+				out = append(out, mcp.NewTool(mcpPool, name, mcp.ToolDescriptor{
+					Name:        dt.Name,
+					Description: dt.Description,
+					InputSchema: dt.InputSchema,
+				}))
+			}
+		}
+		if cfg.Env.A2AServerEnabled {
+			resolve := func(ctx context.Context, name string) (config.A2AAgent, bool) {
+				return lookup.A2AAgent(ctx, storeIface, cfg, name)
+			}
+			out = append(out, toolsa2a.RegisterTools(ctx, cfg, storeIface, resolve, nil, log.Printf)...)
+		}
+		return out
+	})
 	// v0.8.22: hand the static skills.Set to the server so the
 	// per-run SkillDef resolver can fall back to static bodies when
 	// no DB-active row exists for a skill name.

--- a/internal/api/http/dynamic_tools_test.go
+++ b/internal/api/http/dynamic_tools_test.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+type namedTool struct{ name string }
+
+func (n namedTool) Name() string                 { return n.name }
+func (n namedTool) Description() string          { return "fake" }
+func (n namedTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (n namedTool) Execute(context.Context, json.RawMessage) (tools.Result, error) {
+	return tools.Result{}, nil
+}
+
+// TestCandidateTools_AdvertisesDynamicTools pins post-boot tool advertising:
+// a substrate-registered tool returned by the dynamic enumerator is folded
+// into the per-run candidate set, so the allowed_tools filter advertises it
+// to the model without a restart — but only when the agent allows it.
+func TestCandidateTools_AdvertisesDynamicTools(t *testing.T) {
+	// New auto-appends the built-in Agent tool, so the boot set is N≥1.
+	srv := New(&config.Config{}, &stubResolver{}, []tools.Tool{namedTool{"Read"}}, concurrency.New(4, 4, time.Second), nil)
+	base := len(srv.candidateTools(context.Background()))
+
+	// Enumerator returns a post-boot dynamic MCP tool → exactly one more.
+	srv.SetDynamicToolEnumerator(func(context.Context) []tools.Tool {
+		return []tools.Tool{namedTool{"mcp__jobs__getAgentContext"}}
+	})
+	cand := srv.candidateTools(context.Background())
+	if len(cand) != base+1 {
+		t.Fatalf("with enumerator: %d candidate tools, want base+1 (%d)", len(cand), base+1)
+	}
+
+	// Advertised when the agent's allowed_tools permits it.
+	if got := toolNames(filterTools(cand, []string{"mcp__jobs__getAgentContext"}, nil)); len(got) != 1 || got[0] != "mcp__jobs__getAgentContext" {
+		t.Errorf("dynamic tool not advertised when allowed; got %v", got)
+	}
+	// NOT advertised when the agent doesn't allow it — the allowlist still gates.
+	for _, n := range toolNames(filterTools(cand, []string{"Read"}, nil)) {
+		if n == "mcp__jobs__getAgentContext" {
+			t.Error("dynamic tool advertised despite not being in allowed_tools")
+		}
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -117,6 +117,15 @@ type Server struct {
 	// that don't exercise MCP at all. See internal/tools/mcp/lazy.go.
 	mcpFallback tools.FallbackFunc
 
+	// dynamicTools, when set, returns the substrate-registered tools
+	// (dynamic MCP servers' discovered tools + A2A peer skills) that were
+	// NOT in the boot-time s.tools set. Folded into the per-run candidate
+	// set BEFORE the allowed_tools filter, so a tool registered post-boot
+	// is both ADVERTISED in the run's catalog and dispatchable — symmetric
+	// with boot-registered tools, no restart needed. nil-safe (tests +
+	// deployments without the substrate); wired in main.go.
+	dynamicTools func(context.Context) []tools.Tool
+
 	// systemPublisher backs the v0.8.6 POST /v1/_channels/_system/...
 	// admin endpoint. Nil = endpoint refuses every request with a
 	// "system publisher not wired" 503. Set via SetSystemPublisher.
@@ -364,6 +373,35 @@ func (s *Server) SetBuildInfo(version, commit, builtAt string) {
 // cmd/loomcycle/main.go after the MCP pool is built.
 func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
 	s.mcpFallback = fn
+}
+
+// SetDynamicToolEnumerator installs the optional post-boot tool advertiser.
+// fn returns the substrate-registered tools (dynamic MCP + A2A) currently
+// available; the run-creation path folds them into the candidate set before
+// the allowed_tools filter, so post-boot registrations are advertised to the
+// model without a restart. Nil-safe; wired in main.go after the registries +
+// pool are built.
+func (s *Server) SetDynamicToolEnumerator(fn func(context.Context) []tools.Tool) {
+	s.dynamicTools = fn
+}
+
+// candidateTools returns the boot-time tool set plus any post-boot
+// substrate-registered tools, so the per-run allowed_tools filter (and thus
+// the advertised catalog) sees dynamically-registered tools. The boot set is
+// the floor; a dynamic tool that duplicates a boot-set name collapses in
+// filterTools's by-name map (last writer wins; both wrap the same upstream).
+func (s *Server) candidateTools(ctx context.Context) []tools.Tool {
+	if s.dynamicTools == nil {
+		return s.tools
+	}
+	dyn := s.dynamicTools(ctx)
+	if len(dyn) == 0 {
+		return s.tools
+	}
+	out := make([]tools.Tool, 0, len(s.tools)+len(dyn))
+	out = append(out, s.tools...)
+	out = append(out, dyn...)
+	return out
 }
 
 // MCPPoolInspector returns the cached tools/list result for an MCP
@@ -1405,7 +1443,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	defer release()
 
 	// ---- Tool filtering + host narrowing ----
-	allowedTools := filterTools(s.tools, agentDef.AllowedTools, in.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(ctx), agentDef.AllowedTools, in.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if in.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -2454,7 +2492,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	// Filter tools by agent allowlist + caller request.
-	allowedTools := filterTools(s.tools, agentDef.AllowedTools, req.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(r.Context()), agentDef.AllowedTools, req.AllowedTools)
 	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
 	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
 	// doc comment. In caller-authoritative mode we ALWAYS call so the
@@ -2859,7 +2897,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	allowedTools := filterTools(s.tools, agentDef.AllowedTools, body.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(r.Context()), agentDef.AllowedTools, body.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if body.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -3564,7 +3602,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		}},
 	})
 
-	subTools := filterTools(s.tools, def.AllowedTools, nil)
+	subTools := filterTools(s.candidateTools(ctx), def.AllowedTools, nil)
 	// Inherit the parent's caller-authoritative host policy. Without
 	// this, sub-agents fall back to the operator's static
 	// HTTPHostAllowlist — which typically doesn't include localhost


### PR DESCRIPTION
## Why

Dynamic MCP servers (`MCPServerDef`) and A2A peers registered **after boot** were *callable* via the lazy MCP resolver (#341/#345) but never *advertised* in the model's tool catalog. The per-run `allowed_tools` filter ran against `s.tools`, which is frozen at boot — so an agent could only use a post-boot tool if it already knew the exact name; the model never saw it in its catalog.

This is the **advertising-side** counterpart to the static-vs-dynamic resolution asymmetry that #341/#345 closed. With this PR, registration via the substrate is fully symmetric with boot-time registration: a post-boot tool is both **resolvable** (existing) and **advertised** (new), no restart.

## What

- `Server.dynamicTools func(context.Context) []tools.Tool` + `SetDynamicToolEnumerator` — optional, nil-safe.
- `candidateTools(ctx)` folds the enumerator's output into the boot set **before** the `allowed_tools` filter. Boot set is the floor; a dynamic tool that duplicates a boot name collapses in `filterTools`'s by-name map (both wrap the same upstream).
- `main.go` wires the enumerator over the dynamic `MCPServerDef` registry (each active def's discovered tools, via `mcp.NewTool`) + `toolsa2a.RegisterTools` when A2A is enabled.
- **All four** run-creation paths route through `candidateTools`: `RunOnce`, `POST /v1/runs`, `POST /v1/sessions/{id}/messages` continuation, and `runSubAgent` — so sub-agents inherit the dynamic catalog identically.

## What was tested

- `TestCandidateTools_AdvertisesDynamicTools` — delta-based: enumerator adds exactly one candidate; the dynamic tool is advertised when in `allowed_tools` and gated out when not (the allowlist still governs).
- `go test ./...` clean, `go vet` clean, `gofmt` clean.

## Out of scope

Per-tool TTL/staleness of the dynamic enumeration (it reflects the registry live each run); UI surfacing of dynamically-advertised tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)