### PR TITLE
fix(mcpserverdef): expand inner ${LOOMCYCLE_*} at dynamic create/fork

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2589,6 +2589,17 @@ func expandEnv(s string) string {
 	})
 }
 
+// ExpandEnv is the exported entry point for substrate paths that register
+// servers OUTSIDE yaml-load and must mirror its ${LOOMCYCLE_*} expansion.
+// A yaml-configured MCP server gets expansion for free in Load() (the whole
+// document passes through expandEnv at line ~1852); a server registered at
+// runtime via MCPServerDef never passes through Load, so it calls this on its
+// operator-authored string fields to get the identical, same-allowlist
+// behaviour. Without it the inner ${LOOMCYCLE_TOKEN} in a header like
+// `Bearer ${run.credentials.x:-${LOOMCYCLE_TOKEN}}` survives verbatim and the
+// request-time substituter truncates on the nested brace.
+func ExpandEnv(s string) string { return expandEnv(s) }
+
 // parseHeaderList parses a comma-separated `key=value,key2=value2` string
 // into a map. Whitespace around keys, values, and separators is trimmed.
 // Entries without `=` are skipped. Returns nil for an empty input so the

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -662,6 +662,32 @@ func (m *MCPServerDef) buildDefinition(parentJSON string, overlay json.RawMessag
 		}
 		base.applyOverlay(ov)
 	}
+	// Mirror yaml-load's ${LOOMCYCLE_*} expansion on the operator-authored
+	// connection fields. A yaml MCP server is expanded at config.Load; a
+	// dynamically-registered one never passes through Load, so without this
+	// the inner ${LOOMCYCLE_TOKEN} in a header template like
+	//   Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
+	// is stored verbatim. The request-time substituter's lazy `.*?` fallback
+	// then truncates on the inner `}` (see internal/tools/mcp/http/
+	// substitute.go:14, whose safety comment depends on this prior expansion)
+	// and sends `Bearer ${LOOMCYCLE_…}` as a literal → 401 upstream.
+	// Expanding here keeps the stored value flat (no nested brace), so
+	// request-time substitution behaves identically for yaml- and substrate-
+	// registered servers. The outer ${run.*} token carries a "." in its name,
+	// which envVarRe ([A-Za-z_][A-Za-z0-9_]*) cannot match, so it survives to
+	// request time untouched. Re-expanding an already-stored (forked) value is
+	// a no-op: bearer tokens cannot contain `${…}` per the HTTP-boundary
+	// charset. Caveat: this bakes the resolved token into the stored def
+	// content (and thus content_sha256) — consistent with yaml semantics, and
+	// dedup stays stable as long as the env value is stable.
+	base.URL = config.ExpandEnv(base.URL)
+	if len(base.Headers) > 0 {
+		expanded := make(map[string]string, len(base.Headers))
+		for k, v := range base.Headers {
+			expanded[k] = config.ExpandEnv(v)
+		}
+		base.Headers = expanded
+	}
 	return base, nil
 }
 

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -340,3 +340,63 @@ func TestCanonicalTools_OrderAndWhitespaceInsensitive(t *testing.T) {
 		t.Error("genuinely different tool sets must not compare equal")
 	}
 }
+
+// TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv pins the dynamic-vs-yaml
+// env-expansion symmetry. A yaml MCP server's header is expanded at
+// config.Load (the whole document passes through expandEnv); a dynamically-
+// registered one never passes through Load. Without expansion at create, the
+// inner ${LOOMCYCLE_*} in a header like
+//
+//	Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
+//
+// is stored verbatim, and the request-time substituter's lazy `.*?` fallback
+// (internal/tools/mcp/http/substitute.go) then truncates on the inner `}` and
+// sends `Bearer ${LOOMCYCLE_…}` as a literal → 401 upstream.
+//
+// Fails on the pre-fix code, which stored the nested-brace template verbatim:
+// the want-strings below would not match.
+func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
+	t.Setenv("LOOMCYCLE_JOBS_SEARCH_API_TOKEN", "tok-abc123")
+	t.Setenv("LOOMCYCLE_JOBS_MCP_HOST", "internal.example") // in the fixture allowlist
+
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+
+	body := `{"op":"create","name":"jobs","overlay":{` +
+		`"transport":"http",` +
+		`"url":"https://${LOOMCYCLE_JOBS_MCP_HOST}/mcp",` +
+		`"headers":{"Authorization":"Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}"}}}`
+	res, _ := tool.Execute(ctx, json.RawMessage(body))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+
+	// Read the stored definition back and assert the inner LOOMCYCLE var was
+	// resolved while the outer ${run.credentials.*} token survived for
+	// request-time substitution — i.e. the stored header is now FLAT (no
+	// nested brace), which is exactly what substitute.go's lazy regex needs.
+	active, err := tool.Store.MCPServerDefGetActive(ctx, "jobs")
+	if err != nil {
+		t.Fatalf("GetActive: %v", err)
+	}
+	var ov mcpServerOverlay
+	if err := json.Unmarshal(active.Definition, &ov); err != nil {
+		t.Fatalf("unmarshal definition: %v", err)
+	}
+
+	if want := "https://internal.example/mcp"; ov.URL != want {
+		t.Errorf("URL not expanded: got %q, want %q", ov.URL, want)
+	}
+	gotHdr := ov.Headers["Authorization"]
+	if want := "Bearer ${run.credentials.jobs:-tok-abc123}"; gotHdr != want {
+		t.Fatalf("Authorization header:\n got: %q\nwant: %q", gotHdr, want)
+	}
+	// Belt-and-suspenders: no nested brace remains, and the secret is not a
+	// literal placeholder anymore.
+	if strings.Contains(gotHdr, "${LOOMCYCLE_") {
+		t.Errorf("inner LOOMCYCLE var left unresolved in stored header: %q", gotHdr)
+	}
+	if !strings.Contains(gotHdr, "${run.credentials.jobs:-") {
+		t.Errorf("outer run-credentials token did not survive expansion: %q", gotHdr)
+	}
+}


### PR DESCRIPTION
## Why (the bug)

A **yaml-configured** MCP server has its header templates expanded at `config.Load` — the whole document passes through `expandEnv`, so the inner `${LOOMCYCLE_TOKEN}` inside a header like:

```
Authorization: Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
```

is resolved at load, leaving the flat `Bearer ${run.credentials.jobs:-<token>}` for request-time substitution.

A server registered at **runtime** via `MCPServerDef` **never passes through `config.Load`**, so its inner `${LOOMCYCLE_*}` was stored verbatim. At outbound-request time the substituter's lazy `.*?` fallback — `internal/tools/mcp/http/substitute.go:14`, whose safety comment *explicitly* states it is safe only because the inner var is already resolved — then truncates on the nested `}`:

```
INPUT : Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
OUTPUT: Bearer ${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}    ← literal, sent as-is → 401
```

This is the **env-expansion twin** of the static-vs-dynamic asymmetry class (#341/#345 resolution side; #346 scheduling side; #347 advertising side).

## What

- `config.ExpandEnv` — exported thin wrapper over the existing `expandEnv` (+ its `LOOMCYCLE_*`-prefixed allowlist). No new expansion semantics.
- `MCPServerDef.buildDefinition` (the shared chokepoint for **create** and **fork**) now calls it on the operator-authored connection fields: `url` + each header value. The stored header becomes flat, so request-time substitution behaves identically for yaml- and substrate-registered servers.
- The outer `${run.*}` token carries a `.` in its name that `envVarRe` (`[A-Za-z_][A-Za-z0-9_]*`) cannot match, so it flows through to request time untouched. Re-expanding an already-stored (forked) value is a no-op — bearer tokens cannot contain `${…}` per the HTTP-boundary charset.

## Caveat (documented at the call site)

This bakes the resolved token into the stored def content and thus `content_sha256` — consistent with yaml semantics. Dedup stays stable as long as the env value is stable: the `ensureMcpServer` consumer flow re-sends the **literal template** each boot (the TS doc tells consumers to keep placeholders literal), so identical env → identical expansion → identical sha → server-side dedup still engages. If the token rotates, a new version is minted — which is correct, the content genuinely changed.

## What was tested

- **`TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv`** — fail-before/pass-after (verified by reverting the production change): asserts the inner `${LOOMCYCLE_*}` is resolved, the `url` var is expanded, the outer `${run.credentials.*}` token is preserved, and **no nested brace remains** in the stored header.
- Existing `TestMCPServerDefTool_CreateIdempotentOnSameContent` (which uses the nested-brace header) still passes — dedup unaffected.
- `go test ./...`, `go vet`, `gofmt` all clean.

## Out of scope

Request-time env expansion / a brace-balanced substituter parser (more invasive; the substitute.go invariant is now satisfied at store time). Description/transport-field expansion (not connection-bearing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)