### PR TITLE
feat(ui): display + edit code-js agents; clarify lazy-MCP tool status

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -250,6 +250,7 @@ func deriveSource(inStatic, inSubstrate bool) string {
 type staticAgentDefJSON struct {
 	Provider              string                            `json:"provider,omitempty"`
 	Model                 string                            `json:"model,omitempty"`
+	Code                  string                            `json:"code_body,omitempty"` // RFC J inline code-js body
 	Tier                  string                            `json:"tier,omitempty"`
 	Effort                string                            `json:"effort,omitempty"`
 	MaxTokens             int                               `json:"max_tokens,omitempty"`
@@ -270,6 +271,7 @@ func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
 	b, err := json.Marshal(staticAgentDefJSON{
 		Provider:              def.Provider,
 		Model:                 def.Model,
+		Code:                  def.Code,
 		Tier:                  def.Tier,
 		Effort:                def.Effort,
 		MaxTokens:             def.MaxTokens,

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -105,6 +105,37 @@ func TestUnifiedLibrary_Agents_StaticOnly(t *testing.T) {
 	}
 }
 
+// TestUnifiedLibrary_Agents_StaticCodeBody pins that a static yaml code-js
+// agent surfaces its inline code_body in static_definition, so the Web UI can
+// display + fork it. Fails on the pre-fix staticAgentDefJSON, which omitted
+// the field → the UI would show a code agent with no body.
+func TestUnifiedLibrary_Agents_StaticCodeBody(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"batch": {
+			Provider: "code-js",
+			Code:     `function run(input){ return {final_text:"ok"}; }`,
+		},
+	}, nil)
+	defer cleanup()
+
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
+	entries := decodeLibraryEntries(t, rec)
+	if len(entries) != 1 {
+		t.Fatalf("entries = %+v, want 1", entries)
+	}
+	var def struct {
+		Provider string `json:"provider"`
+		CodeBody string `json:"code_body"`
+	}
+	if err := json.Unmarshal(entries[0].StaticDefinition, &def); err != nil {
+		t.Fatal(err)
+	}
+	if def.Provider != "code-js" || def.CodeBody != `function run(input){ return {final_text:"ok"}; }` {
+		t.Errorf("static code agent definition missing code_body: %+v", def)
+	}
+}
+
 // TestUnifiedLibrary_Agents_DynamicOnly — substrate row with no yaml twin.
 // Expect source=dynamic-only, in_substrate=true, no static_definition.
 func TestUnifiedLibrary_Agents_DynamicOnly(t *testing.T) {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loomcycle-ui",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "description": "Loomcycle web UI — read-only monitoring view: running agents tree, errors, per-agent transcript log.",

--- a/web/src/components/LibraryEditModal.tsx
+++ b/web/src/components/LibraryEditModal.tsx
@@ -110,6 +110,10 @@ export default function LibraryEditModal({
   const [systemPrompt, setSystemPrompt] = useState(
     pickString(forkSource?.definition, "system_prompt"),
   );
+  // RFC J inline code-js body. Shown only when provider is "code-js".
+  const [codeBody, setCodeBody] = useState(
+    pickString(forkSource?.definition, "code_body"),
+  );
   const [allowedTools, setAllowedTools] = useState(
     pickStringArray(forkSource?.definition, "allowed_tools").join(", "),
   );
@@ -227,6 +231,13 @@ export default function LibraryEditModal({
           return `${label} must be a non-negative integer (got "${raw}").`;
         }
       }
+      // A code-js agent's behaviour IS its inline body — refuse an empty
+      // one locally (the substrate would reject it at create too, but a
+      // local check is a clearer message). Only enforced for code-js so
+      // LLM agents are unaffected.
+      if (provider.trim() === "code-js" && !codeBody.trim()) {
+        return "code_body is required for a code-js agent.";
+      }
       // Per-tier model rows: trim + drop empty pairs at submit time;
       // here just refuse partial rows (provider without model or
       // vice versa) so the operator sees the issue locally.
@@ -269,6 +280,10 @@ export default function LibraryEditModal({
       // Omit when empty so the substrate keeps the parent / yaml value
       // instead of overwriting with "".
       if (systemPrompt.trim()) ov.system_prompt = systemPrompt;
+      // code_body: raw source preserved verbatim (whitespace is
+      // hash-significant). Omit when empty so a fork of an LLM agent
+      // doesn't write a "" body.
+      if (codeBody.trim()) ov.code_body = codeBody;
       const tools = parseCommaList(allowedTools);
       if (tools.length > 0) ov.allowed_tools = tools;
       const sk = parseCommaList(agentSkills);
@@ -432,6 +447,8 @@ export default function LibraryEditModal({
             setEffort={setEffort}
             systemPrompt={systemPrompt}
             setSystemPrompt={setSystemPrompt}
+            codeBody={codeBody}
+            setCodeBody={setCodeBody}
             allowedTools={allowedTools}
             setAllowedTools={setAllowedTools}
             agentSkills={agentSkills}
@@ -526,6 +543,8 @@ interface AgentFieldsProps {
   setEffort: (v: string) => void;
   systemPrompt: string;
   setSystemPrompt: (v: string) => void;
+  codeBody: string;
+  setCodeBody: (v: string) => void;
   allowedTools: string;
   setAllowedTools: (v: string) => void;
   agentSkills: string;
@@ -648,6 +667,28 @@ function AgentFields(props: AgentFieldsProps) {
           placeholder="You are a researcher. Follow these rules…"
         />
       </div>
+
+      {props.provider.trim() === "code-js" && (
+        <div className="library-form-row">
+          <label htmlFor="lib-code-body">
+            code body
+            <span className="library-modal-field-hint">
+              {" "}— inline JavaScript orchestrator (RFC J); requires
+              LOOMCYCLE_CODE_AGENTS_ENABLED on the sidecar
+            </span>
+          </label>
+          <textarea
+            id="lib-code-body"
+            className="library-prompt-textarea mono"
+            value={props.codeBody}
+            onChange={(e) => props.setCodeBody(e.target.value)}
+            disabled={props.submitting}
+            rows={14}
+            spellCheck={false}
+            placeholder={"function run(input) {\n  return { final_text: \"…\" };\n}"}
+          />
+        </div>
+      )}
 
       <div className="library-form-row">
         <label htmlFor="lib-allowed-tools">

--- a/web/src/pages/LibraryView.tsx
+++ b/web/src/pages/LibraryView.tsx
@@ -215,6 +215,7 @@ const subtabClass = ({ isActive }: { isActive: boolean }) =>
 
 interface AgentDefBody {
   system_prompt?: string;
+  code_body?: string;
   allowed_tools?: string[];
   description?: string;
   tier?: string;
@@ -240,6 +241,12 @@ function renderAgentDefinition(row: DefRow) {
         <div className="def-field def-field-prompt">
           <span className="def-field-label">system_prompt</span>
           <pre className="def-prompt mono">{body.system_prompt}</pre>
+        </div>
+      )}
+      {body.code_body && (
+        <div className="def-field def-field-prompt">
+          <span className="def-field-label">code_body</span>
+          <pre className="def-prompt mono">{body.code_body}</pre>
         </div>
       )}
       {body.allowed_tools && body.allowed_tools.length > 0 && (
@@ -420,10 +427,14 @@ function renderMcpDefinition(row: DefRow) {
           </div>
         ) : (
           <div className="def-tool-empty">
-            no tools cached — MCP handshake pending, the server is
-            unreachable, or <code>rediscover</code> hasn't been called
-            for a substrate entry. Check the loomcycle log for{" "}
-            <code>mcp[{"<name>"}]: handshake failed</code> lines.
+            no tools cached yet — this is normal, not an error. Tools are
+            discovered on the first agent call that needs this server
+            (lazy registration), or eagerly when you run{" "}
+            <code>rediscover</code>. An empty list here does{" "}
+            <strong>not</strong> mean the server is down: a server that was
+            unreachable at boot self-heals on first use. If calls actually
+            fail, check the loomcycle log for{" "}
+            <code>mcp[{"<name>"}]: handshake failed</code>.
           </div>
         )}
       </div>


### PR DESCRIPTION
Two Web UI improvements for dynamic substrate entries (Library view).

## 1. Code-js agents — display + edit/add

Code agents now carry an inline `code_body` (RFC J, #349), but the Library UI didn't surface or edit it.

- **Display:** the agent detail pane renders `code_body` as a monospace block (`LibraryView.renderAgentDefinition`), next to `system_prompt`.
- **Edit/Add:** the create/fork modal grows a **code body** textarea, shown only when `provider == "code-js"` (`LibraryEditModal`). Wired into `buildOverlay` (emits `code_body` when non-empty) and `validateLocal` (a code-js agent must carry a body — a clearer message than the substrate's create-time refusal). Forking an existing code agent pre-fills the body.
- **Backend:** `staticAgentDefJSON` now carries `code_body`, so a **static yaml** code agent also displays + forks its body (`config.AgentDef` has yaml-only tags, so the UI consumes this shadow struct — same fix #184 applied for other fields).

## 2. MCP lazy-registration status — false-error fix

The MCP detail pane's "no tools cached" message asserted the server was **"unreachable / handshake failed"** whenever `discovered_tools` was empty. That's wrong for the common, healthy case the user hit: a dynamically-registered (or boot-unreachable) MCP server **self-heals on the first agent call** (lazy registration, `internal/tools/mcp/lazy.go`), and its tools simply aren't discovered until first use or an explicit `rediscover`. The calls work; only the UI cried error.

Reframed the message: an empty list is **normal, not an error**; tools are discovered lazily on first call or eagerly via `rediscover`; the log pointer is now a conditional ("if calls actually fail") rather than the headline.

> Scoped out (follow-up candidate): surfacing the **live pool's** lazily-discovered tools for dynamic substrate servers in the detail view. Today static servers peek the live pool (`mcpPoolInspector`) while dynamic servers read the DB definition (populated only by `rediscover`) — a static-vs-dynamic asymmetry worth closing separately. This PR fixes the misleading *messaging*; `rediscover` remains the way to populate the cached list.

## What was tested

- `TestUnifiedLibrary_Agents_StaticCodeBody` — a static yaml code agent surfaces `code_body` in `static_definition` (fail-before: the pre-fix `staticAgentDefJSON` omitted it).
- `go test ./...`, `go vet`, `gofmt` clean; `cd web && npm run typecheck` clean.
- `make build-all` (UI embeds into `internal/webui/dist` + binary builds); booted the binary and confirmed `GET /ui/` serves the rebuilt SPA (200 + embedded hashed asset).
- `internal/webui/dist/` is gitignored — the UI ships as source; CI (`ci.yml` `npm run build`) and release (`release.yml` `make build-ui`) rebuild it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)