### PR TITLE
feat(mcpserverdef): auto-discover tools on ingestion (create/fork)

### DIFF
--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -79,7 +79,9 @@ const mcpServerDefDescription = `Register, fork, promote, retire, rediscover, an
 	`Static yaml mcp_servers: entries remain the operator's stable ground truth; this tool ` +
 	`produces the DERIVED layer of runtime registrations. Transport restricted to http + ` +
 	`streamable-http (stdio stays yaml-only). URL hostname must be in the operator's HTTP host ` +
-	`allowlist. Operations: create, fork, get, list, retire, promote, rediscover, verify.`
+	`allowlist. create/fork auto-discover the upstream's tools (tools/list) at ingestion ` +
+	`(best-effort; opt out with discover:false), so a separate rediscover is only needed to ` +
+	`refresh a changed tool surface. Operations: create, fork, get, list, retire, promote, rediscover, verify.`
 
 const mcpServerDefInputSchema = `{
   "type": "object",
@@ -100,6 +102,7 @@ const mcpServerDefInputSchema = `{
     },
     "description":   {"type": "string"},
     "promote":       {"type": "boolean", "description": "create defaults true, fork defaults false."},
+    "discover":      {"type": "boolean", "description": "create/fork: run the tools/list handshake at ingestion so discovered_tools is populated immediately (default true). Best-effort — a peer that is unreachable at ingestion still registers and self-heals on first call. Set false to register metadata only."},
     "retired":       {"type": "boolean", "description": "Required for retire."},
     "content_sha256":{"type": "string", "description": "Input for op:verify."}
   },
@@ -114,6 +117,7 @@ type mcpServerDefInput struct {
 	Overlay       json.RawMessage `json:"overlay,omitempty"`
 	Description   string          `json:"description,omitempty"`
 	Promote       *bool           `json:"promote,omitempty"`
+	Discover      *bool           `json:"discover,omitempty"`
 	Retired       *bool           `json:"retired,omitempty"`
 	ContentSHA256 string          `json:"content_sha256,omitempty"`
 }
@@ -251,6 +255,17 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 		return okJSON(resp)
 	}
 
+	promote := true
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	// Automatic discovery-on-ingestion: fold the tools/list handshake into the
+	// create so v1 carries discovered_tools immediately (no separate
+	// rediscover). Best-effort + only when this version becomes active; an
+	// unreachable peer leaves the def metadata-only and self-heals lazily.
+	var discovered int
+	defJSON, discovered = m.discoverOnIngestion(ctx, in.Name, in, promote, &def, defJSON)
+
 	ident := tools.RunIdentity(ctx)
 	row := store.MCPServerDefRow{
 		DefID:            mintMCPServerDefID(),
@@ -265,16 +280,14 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
 
-	promote := true
-	if in.Promote != nil {
-		promote = *in.Promote
-	}
 	if promote {
 		if err := m.promoteAndWireRegistry(ctx, created, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
 		}
 	}
-	return okJSON(mcpServerDefRowResponse(created, promote))
+	resp := mcpServerDefRowResponse(created, promote)
+	resp["discovered"] = discovered
+	return okJSON(resp)
 }
 
 // ---- fork ----
@@ -332,6 +345,17 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), m.MaxDescriptionBytes)), nil
 	}
 
+	contentSHA := signFromMCPServerOverlay(in.Name, def)
+	promote := false
+	if in.Promote != nil {
+		promote = *in.Promote
+	}
+	// Discover only on a promoted fork: discovery dials by name, which the
+	// pool resolves to the about-to-be-active version's connection params, so
+	// a non-promoted fork (not yet active) can't be dialed meaningfully here.
+	var discovered int
+	defJSON, discovered = m.discoverOnIngestion(ctx, in.Name, in, promote, &def, defJSON)
+
 	ident := tools.RunIdentity(ctx)
 	row := store.MCPServerDefRow{
 		DefID:            mintMCPServerDefID(),
@@ -340,22 +364,20 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		Definition:       defJSON,
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
-		ContentSHA256:    signFromMCPServerOverlay(in.Name, def),
+		ContentSHA256:    contentSHA,
 	}
 	created, err := m.Store.MCPServerDefCreate(ctx, row)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
-	}
-	promote := false
-	if in.Promote != nil {
-		promote = *in.Promote
 	}
 	if promote {
 		if err := m.promoteAndWireRegistry(ctx, created, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
 		}
 	}
-	return okJSON(mcpServerDefRowResponse(created, promote))
+	resp := mcpServerDefRowResponse(created, promote)
+	resp["discovered"] = discovered
+	return okJSON(resp)
 }
 
 // ---- get / list ----
@@ -460,16 +482,86 @@ func (m *MCPServerDef) promoteAndWireRegistry(ctx context.Context, row store.MCP
 	if err := json.Unmarshal(row.Definition, &ov); err != nil {
 		return fmt.Errorf("definition unmarshal: %w", err)
 	}
-	m.Registry.Set(loommcp.DynamicMCPServerSpec{
-		Name:      row.Name,
-		Transport: ov.Transport,
-		URL:       ov.URL,
-		Headers:   ov.Headers,
-	})
+	m.Registry.Set(specFromOverlay(row.Name, ov))
 	if m.Pool != nil {
 		m.Pool.Evict(row.Name) // existing cached client uses stale metadata; rebuild on next agent call
 	}
 	return nil
+}
+
+// specFromOverlay projects an overlay's connection fields onto the in-memory
+// DynamicMCPServerSpec the pool's caller factory resolves names through.
+func specFromOverlay(name string, ov mcpServerOverlay) loommcp.DynamicMCPServerSpec {
+	return loommcp.DynamicMCPServerSpec{
+		Name:      name,
+		Transport: ov.Transport,
+		URL:       ov.URL,
+		Headers:   ov.Headers,
+	}
+}
+
+// discoverTools runs the upstream's tools/list handshake via the pool and
+// returns the result reshaped as toolDescriptors. The caller MUST have
+// registered name in the registry first (so the pool's caller factory can
+// resolve it). Evict-then-Get forces a fresh handshake. Bounded by a 30s
+// budget so a non-responding peer can't park the goroutine — matches the
+// boot-time MCP-init budget shape. Shared by create/fork (best-effort) and
+// rediscover (fatal on error).
+func (m *MCPServerDef) discoverTools(ctx context.Context, name string) ([]toolDescriptor, error) {
+	if m.Pool == nil {
+		return nil, fmt.Errorf("pool not configured")
+	}
+	m.Pool.Evict(name)
+	hsCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	_, descs, err := m.Pool.Get(hsCtx, name)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]toolDescriptor, 0, len(descs))
+	for _, d := range descs {
+		out = append(out, toolDescriptor{
+			Name:        d.Name,
+			Description: d.Description,
+			InputSchema: d.InputSchema,
+		})
+	}
+	return out, nil
+}
+
+// discoverOnIngestion is the best-effort create/fork discovery pass. When the
+// new version will become active (promote) and discovery isn't opted out, it
+// registers the spec so the pool can dial by name, runs the handshake, and —
+// if the peer is reachable AND the result still fits MaxDefinitionBytes —
+// folds discovered_tools into def and re-marshals. discovered_tools is NOT
+// part of content_sha256, so the dedup hash computed by the caller stays
+// valid. Returns the (possibly updated) defJSON + the discovered count.
+// Never errors: an unreachable peer leaves def untouched (empty tools) and
+// self-heals via lazy registration on first call.
+func (m *MCPServerDef) discoverOnIngestion(ctx context.Context, name string, in mcpServerDefInput, promote bool, def *mcpServerOverlay, defJSON []byte) ([]byte, int) {
+	discover := promote && m.Pool != nil
+	if in.Discover != nil {
+		discover = discover && *in.Discover
+	}
+	if !discover {
+		return defJSON, 0
+	}
+	// Register so pool.Get(name) resolves to this server's connection params.
+	m.Registry.Set(specFromOverlay(name, *def))
+	tools, err := m.discoverTools(ctx, name)
+	if err != nil {
+		return defJSON, 0 // best-effort — keep metadata-only def; lazy/rediscover later.
+	}
+	withTools := *def
+	withTools.DiscoveredTools = tools
+	b, merr := json.Marshal(withTools)
+	if merr != nil || (m.MaxDefinitionBytes > 0 && len(b) > m.MaxDefinitionBytes) {
+		// Tools push the definition past the cap → store metadata-only; the
+		// operator can rediscover with a larger cap if they really need them.
+		return defJSON, 0
+	}
+	*def = withTools
+	return b, len(tools)
 }
 
 // ---- rediscover ----
@@ -486,75 +578,55 @@ func (m *MCPServerDef) execRediscover(ctx context.Context, in mcpServerDefInput)
 		}
 		return errResult(fmt.Sprintf("rediscover: %s", err)), nil
 	}
-	// Force a fresh pool handshake: evict + Get triggers tools/list.
-	if m.Pool != nil {
-		m.Pool.Evict(in.Name)
-		// Bound the handshake — a non-responding upstream would otherwise
-		// park this goroutine forever AND block every subsequent
-		// rediscover on the same name (they queue on e.ready). 30s
-		// matches the boot-time MCP-init budget shape so an operator
-		// who deployed a working server can still rediscover even on
-		// the slowest legitimate handshake path.
-		hsCtx, hsCancel := context.WithTimeout(ctx, 30*time.Second)
-		_, descs, err := m.Pool.Get(hsCtx, in.Name)
-		hsCancel()
-		if err != nil {
-			return errResult(fmt.Sprintf("rediscover: pool.Get: %s", err)), nil
-		}
-		// Reshape descs into the JSON-able toolDescriptor slice + store on a
-		// new row version (fork-from-current; preserves audit history).
-		var ov mcpServerOverlay
-		if err := json.Unmarshal(active.Definition, &ov); err != nil {
-			return errResult(fmt.Sprintf("rediscover: definition unmarshal: %s", err)), nil
-		}
-		oldTools := ov.DiscoveredTools
-		newTools := make([]toolDescriptor, 0, len(descs))
-		for _, d := range descs {
-			newTools = append(newTools, toolDescriptor{
-				Name:        d.Name,
-				Description: d.Description,
-				InputSchema: d.InputSchema,
-			})
-		}
-		// Idempotent rediscover: if the freshly-discovered tools match the
-		// active def's, don't mint a new version — otherwise re-discovery on
-		// every boot version-spams even when the peer's tool surface is
-		// unchanged. content_sha256 excludes discovered_tools, so this is a
-		// direct (order- and JSON-whitespace-insensitive) comparison.
-		if canonicalTools(oldTools) == canonicalTools(newTools) {
-			resp := mcpServerDefRowResponse(active, true)
-			resp["deduplicated"] = true
-			resp["discovered"] = len(descs)
-			return okJSON(resp)
-		}
-		ov.DiscoveredTools = newTools
-		defJSON, _ := json.Marshal(ov)
-		ident := tools.RunIdentity(ctx)
-		row := store.MCPServerDefRow{
-			DefID:            mintMCPServerDefID(),
-			Name:             in.Name,
-			ParentDefID:      active.DefID,
-			Definition:       defJSON,
-			Description:      "rediscovered tools/list",
-			CreatedByAgentID: ident.AgentID,
-			ContentSHA256:    signFromMCPServerOverlay(in.Name, ov),
-		}
-		created, err := m.Store.MCPServerDefCreate(ctx, row)
-		if err != nil {
-			return errResult(fmt.Sprintf("rediscover: persist: %s", err)), nil
-		}
-		if err := m.Store.MCPServerDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
-			return errResult(fmt.Sprintf("rediscover: promote: %s", err)), nil
-		}
-		return okJSON(map[string]any{
-			"def_id":         created.DefID,
-			"name":           in.Name,
-			"version":        created.Version,
-			"discovered":     len(descs),
-			"content_sha256": created.ContentSHA256,
-		})
+	if m.Pool == nil {
+		return errResult("rediscover: pool not configured"), nil
 	}
-	return errResult("rediscover: pool not configured"), nil
+	newTools, err := m.discoverTools(ctx, in.Name)
+	if err != nil {
+		return errResult(fmt.Sprintf("rediscover: pool.Get: %s", err)), nil
+	}
+	// Reshape onto a new row version (fork-from-current; preserves audit history).
+	var ov mcpServerOverlay
+	if err := json.Unmarshal(active.Definition, &ov); err != nil {
+		return errResult(fmt.Sprintf("rediscover: definition unmarshal: %s", err)), nil
+	}
+	// Idempotent rediscover: if the freshly-discovered tools match the active
+	// def's, don't mint a new version — otherwise re-discovery on every boot
+	// version-spams even when the peer's tool surface is unchanged.
+	// content_sha256 excludes discovered_tools, so this is a direct (order- and
+	// JSON-whitespace-insensitive) comparison.
+	if canonicalTools(ov.DiscoveredTools) == canonicalTools(newTools) {
+		resp := mcpServerDefRowResponse(active, true)
+		resp["deduplicated"] = true
+		resp["discovered"] = len(newTools)
+		return okJSON(resp)
+	}
+	ov.DiscoveredTools = newTools
+	defJSON, _ := json.Marshal(ov)
+	ident := tools.RunIdentity(ctx)
+	row := store.MCPServerDefRow{
+		DefID:            mintMCPServerDefID(),
+		Name:             in.Name,
+		ParentDefID:      active.DefID,
+		Definition:       defJSON,
+		Description:      "rediscovered tools/list",
+		CreatedByAgentID: ident.AgentID,
+		ContentSHA256:    signFromMCPServerOverlay(in.Name, ov),
+	}
+	created, err := m.Store.MCPServerDefCreate(ctx, row)
+	if err != nil {
+		return errResult(fmt.Sprintf("rediscover: persist: %s", err)), nil
+	}
+	if err := m.Store.MCPServerDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+		return errResult(fmt.Sprintf("rediscover: promote: %s", err)), nil
+	}
+	return okJSON(map[string]any{
+		"def_id":         created.DefID,
+		"name":           in.Name,
+		"version":        created.Version,
+		"discovered":     len(newTools),
+		"content_sha256": created.ContentSHA256,
+	})
 }
 
 // ---- verify ----

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -3,6 +3,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -300,23 +301,110 @@ func TestMCPServerDefTool_RediscoverNoopOnUnchangedTools(t *testing.T) {
 	)
 	t.Cleanup(tool.Pool.Close)
 
+	// create now auto-discovers (discovery-on-ingestion) → v1 already carries
+	// check_user, so a subsequent rediscover with the SAME surface is a no-op.
 	if r, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"jobs","overlay":{"transport":"http","url":"`+srv.URL+`"}}`)); r.IsError {
 		t.Fatalf("create: %s", r.Text)
 	}
-	if r, _ := tool.Execute(ctx, json.RawMessage(`{"op":"rediscover","name":"jobs"}`)); r.IsError {
-		t.Fatalf("rediscover#1: %s", r.Text)
-	}
 	r2, _ := tool.Execute(ctx, json.RawMessage(`{"op":"rediscover","name":"jobs"}`))
 	if r2.IsError {
-		t.Fatalf("rediscover#2: %s", r2.Text)
+		t.Fatalf("rediscover: %s", r2.Text)
 	}
 	if decodeResult(t, r2.Text)["deduplicated"] != true {
 		t.Errorf("rediscover with unchanged tools should be a no-op; got %s", r2.Text)
 	}
 	lr, _ := tool.Execute(ctx, json.RawMessage(`{"op":"list","name":"jobs"}`))
 	vs, _ := decodeResult(t, lr.Text)["versions"].([]any)
-	if len(vs) != 2 { // v1 create + v2 first-rediscover; second rediscover adds nothing
-		t.Errorf("unchanged rediscover must not mint a version; got %d (want 2)", len(vs))
+	if len(vs) != 1 { // create auto-discovered v1; the unchanged rediscover adds nothing
+		t.Errorf("auto-discovery + unchanged rediscover must leave 1 version; got %d (want 1)", len(vs))
+	}
+}
+
+// mcpToolPoolFixture wires a fixture's Pool to a fake MCP server exposing one
+// named tool, allowlists 127.0.0.1, and returns the server URL. Shared by the
+// discovery-on-ingestion tests.
+func mcpToolPoolFixture(t *testing.T, tool *MCPServerDef, toolName string) string {
+	t.Helper()
+	srv := mcptest.NewServer(t, mcptest.WithToolName(toolName))
+	tool.Cfg.Env.HTTPHostAllowlist = append(tool.Cfg.Env.HTTPHostAllowlist, "127.0.0.1")
+	tool.Pool = loommcp.NewPool(
+		func(name string) (loommcp.Caller, error) { return mcphttp.New(mcphttp.Config{URL: srv.URL}) },
+		func(c loommcp.Caller) {},
+	)
+	t.Cleanup(tool.Pool.Close)
+	return srv.URL
+}
+
+// TestMCPServerDefTool_CreateAutoDiscoversTools pins discovery-on-ingestion:
+// a create against a reachable peer populates discovered_tools in v1 itself —
+// no separate rediscover. Fails on the pre-feature code, which stored v1 with
+// empty discovered_tools (the UI's "no tools cached" state until rediscover).
+func TestMCPServerDefTool_CreateAutoDiscoversTools(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	url := mcpToolPoolFixture(t, tool, "check_user")
+
+	cr, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"jobs","overlay":{"transport":"http","url":"`+url+`"}}`))
+	if cr.IsError {
+		t.Fatalf("create: %s", cr.Text)
+	}
+	out := decodeResult(t, cr.Text)
+	if out["discovered"] != float64(1) {
+		t.Errorf("create should report discovered=1; got %v", out["discovered"])
+	}
+	defID := out["def_id"].(string)
+	gr, _ := tool.Execute(ctx, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	def, _ := decodeResult(t, gr.Text)["definition"].(map[string]any)
+	dt, _ := def["discovered_tools"].([]any)
+	if len(dt) != 1 {
+		t.Fatalf("v1 definition should carry 1 discovered tool; got %v", def["discovered_tools"])
+	}
+	if first, _ := dt[0].(map[string]any); first["name"] != "check_user" {
+		t.Errorf("discovered tool name = %v, want check_user", dt[0])
+	}
+}
+
+// TestMCPServerDefTool_CreateDiscoverOptOut pins discover:false — a metadata-
+// only registration that skips the handshake even with a reachable peer.
+func TestMCPServerDefTool_CreateDiscoverOptOut(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	url := mcpToolPoolFixture(t, tool, "check_user")
+
+	cr, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"jobs","discover":false,"overlay":{"transport":"http","url":"`+url+`"}}`))
+	if cr.IsError {
+		t.Fatalf("create: %s", cr.Text)
+	}
+	out := decodeResult(t, cr.Text)
+	if out["discovered"] != float64(0) {
+		t.Errorf("discover:false should report discovered=0; got %v", out["discovered"])
+	}
+	def, _ := out["definition"].(map[string]any)
+	if dt, ok := def["discovered_tools"]; ok && dt != nil {
+		t.Errorf("discover:false should leave discovered_tools unset; got %v", dt)
+	}
+}
+
+// TestMCPServerDefTool_CreateDiscoveryBestEffortOnUnreachable pins that an
+// unreachable peer does NOT fail the create — it registers metadata-only and
+// self-heals via lazy registration on first call. A caller factory that
+// errors immediately stands in for the dead peer (no 30s timeout).
+func TestMCPServerDefTool_CreateDiscoveryBestEffortOnUnreachable(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	tool.Cfg.Env.HTTPHostAllowlist = append(tool.Cfg.Env.HTTPHostAllowlist, "127.0.0.1")
+	tool.Pool = loommcp.NewPool(
+		func(name string) (loommcp.Caller, error) { return nil, fmt.Errorf("connection refused") },
+		func(c loommcp.Caller) {},
+	)
+	t.Cleanup(tool.Pool.Close)
+
+	cr, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"jobs","overlay":{"transport":"http","url":"http://127.0.0.1:1/mcp"}}`))
+	if cr.IsError {
+		t.Fatalf("unreachable peer must not fail create (best-effort discovery); got %s", cr.Text)
+	}
+	if decodeResult(t, cr.Text)["discovered"] != float64(0) {
+		t.Errorf("unreachable discovery should report discovered=0")
 	}
 }
 


### PR DESCRIPTION
## Why

A dynamically-registered MCP server stored `discovered_tools` **empty** until an operator ran a separate `rediscover` op. Until then the Library UI showed "no tools cached" and the cached surface was blank — even though the server *worked* (tools self-heal via lazy registration on first call). Discovery was a manual second step.

This is the follow-up flagged in #351: close the static-vs-dynamic gap by discovering the upstream's tools **at ingestion**, so a reachable server's tools appear immediately.

## What

`create` + `fork` now run the `tools/list` handshake at ingestion and fold the result into the **same** version — `v1` carries `discovered_tools`, no `v2`, no separate `rediscover`.

- **Best-effort:** an unreachable peer does **not** fail the create; the server registers metadata-only and self-heals via lazy registration. Bounded by the existing 30s handshake budget.
- **Promote-gated:** discovery dials *by name*, which the pool resolves to the about-to-be-active version's connection params (the in-memory `DynamicRegistry` — `main.go`'s caller factory, not the store). A non-promoted fork is skipped (it can't be dialed meaningfully yet).
- The spec is registered in the `DynamicRegistry` just before the handshake so `pool.Get(name)` resolves the brand-new server. `discovered_tools` is **not** part of `content_sha256`, so the create's dedup hash is unaffected.
- **Size-guarded:** if discovered tools would push the definition past `MaxDefinitionBytes`, the row stores metadata-only (rediscover later with a larger cap).
- **Opt out** with `discover:false` for a pure metadata registration.
- Extracted a shared `discoverTools` helper from `rediscover` (one handshake + reshape implementation); `rediscover` keeps its idempotent dedup.

## What was tested

Fail-before verified by neutering the discovery pass:
- `TestMCPServerDefTool_CreateAutoDiscoversTools` — `v1` carries the upstream tool; create reports `discovered=1`.
- `TestMCPServerDefTool_CreateDiscoverOptOut` — `discover:false` stays metadata-only.
- `TestMCPServerDefTool_CreateDiscoveryBestEffortOnUnreachable` — a dead peer doesn't fail the create (`discovered=0`).
- `TestMCPServerDefTool_RediscoverNoopOnUnchangedTools` updated: create auto-discovers `v1`, so the unchanged rediscover is a no-op (1 version, was 2).
- `go test ./...`, `go vet`, `gofmt` clean.

## No wire / UI / TS change needed

The Web UI already renders `discovered_tools` (#351) and `MCPServerDefRowResponse.discovered` already exists in the TS client — a reachable server now populates them at ingestion instead of on a later rediscover. The TS `ensureMcpServer({rediscover:true})` path still works (its now-redundant rediscover is an idempotent no-op); simplifying it is an optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)