### PR TITLE
fix(codejs): recover #350 — thread code_body through .md/CLI/merge hash paths

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -58,9 +58,15 @@ type Agent struct {
 	Description string
 	Provider    string
 	Model       string
-	Tier        string
-	Effort      string
-	MaxTokens   int
+	// Code is the inline code-js orchestrator source (RFC J). Mirrors
+	// config.AgentDef.Code; when set and Provider is "code-js", the runtime
+	// runs this body instead of reading agent_code/<name>/index.js. Carried
+	// here so a .md-discovered code agent and the `hash agent` CLI compute
+	// the SAME content_sha256 as the substrate (FromYAMLAgent → AgentContent).
+	Code      string
+	Tier      string
+	Effort    string
+	MaxTokens int
 	// MaxIterations caps the agent loop at this many provider calls
 	// before terminating with stop_reason="max_iterations". 0 means
 	// use the loop default (16). Set higher for discovery-style
@@ -237,6 +243,7 @@ type frontmatter struct {
 	AllowedTools          []string                   `yaml:"allowed_tools"` // loomcycle's preferred shape
 	Provider              string                     `yaml:"provider"`
 	Model                 string                     `yaml:"model"`
+	Code                  string                     `yaml:"code"` // inline code-js body (RFC J)
 	Tier                  string                     `yaml:"tier"`
 	Effort                string                     `yaml:"effort"`
 	MaxTokens             int                        `yaml:"max_tokens"`
@@ -303,6 +310,7 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.Description = fm.Description
 	a.Provider = fm.Provider
 	a.Model = fm.Model
+	a.Code = fm.Code
 	a.Tier = fm.Tier
 	a.Effort = fm.Effort
 	a.MaxTokens = fm.MaxTokens

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -178,6 +178,7 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		Description:           a.Description,
 		Provider:              a.Provider,
 		Model:                 a.Model,
+		CodeBody:              a.Code,
 		Tier:                  a.Tier,
 		Effort:                a.Effort,
 		MaxTokens:             a.MaxTokens,

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -277,6 +277,48 @@ func TestFromOverlay_RoundTripMatchesYAMLAgent(t *testing.T) {
 	}
 }
 
+// TestFromYAMLAgent_CarriesCodeBody pins that the .md/CLI path threads the
+// inline code-js body into the hash. Fails on the pre-fix code, where
+// FromYAMLAgent dropped Agent.Code so the hash never reflected the body.
+func TestFromYAMLAgent_CarriesCodeBody(t *testing.T) {
+	body := `function run(input){ return {final_text:'x'}; }`
+	withCode := Sign(FromYAMLAgent(&Agent{Name: "ca", Provider: "code-js", Code: body}))
+	without := Sign(FromYAMLAgent(&Agent{Name: "ca", Provider: "code-js"}))
+	if withCode == without {
+		t.Fatal("FromYAMLAgent dropped Code — the inline body did not affect the hash")
+	}
+}
+
+// TestFromOverlay_RoundTripMatchesYAMLAgent_WithCode is the 3-way symmetry
+// guarantee for code agents: the SAME inline body reaching the hash via the
+// yaml/.md/CLI path (FromYAMLAgent) vs the substrate-read path (FromOverlay,
+// which json-unmarshals the persisted code_body) MUST hash identically — so
+// `loomcycle hash agent` and the deployed substrate's content_sha256 agree.
+// Fails on the pre-fix code, where FromYAMLAgent omitted CodeBody and the two
+// paths diverged for any code agent. (signFromMergedDef, the third producer,
+// also maps Code→CodeBody, so all three converge on the same AgentContent.)
+func TestFromOverlay_RoundTripMatchesYAMLAgent_WithCode(t *testing.T) {
+	body := `function run(input){ return {final_text:'x'}; }`
+	agent := &Agent{Name: "ca", Provider: "code-js", SystemPrompt: "orchestrate", Code: body}
+	hashFromYAML := Sign(FromYAMLAgent(agent))
+
+	overlay, err := json.Marshal(map[string]any{
+		"name":          "ca",
+		"provider":      "code-js",
+		"system_prompt": "orchestrate",
+		"code_body":     body,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ := FromOverlay(overlay)
+	hashFromOverlay := Sign(parsed)
+
+	if hashFromYAML != hashFromOverlay {
+		t.Errorf("code agent: yaml/CLI path vs substrate-overlay path diverged:\n %s\n %s", hashFromYAML, hashFromOverlay)
+	}
+}
+
 func TestSign_KnownVector(t *testing.T) {
 	// A pin — if anyone changes the canonical encoding, this test
 	// catches the silent break. Update only with intent: bump a

--- a/internal/cli/hash.go
+++ b/internal/cli/hash.go
@@ -212,6 +212,7 @@ func runHashAgentByName(name, cfgPath string, stdout, stderr io.Writer) int {
 		Name:                  name,
 		Provider:              def.Provider,
 		Model:                 def.Model,
+		Code:                  def.Code,
 		Tier:                  def.Tier,
 		Effort:                def.Effort,
 		MaxTokens:             def.MaxTokens,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2741,6 +2741,7 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 	def := AgentDef{
 		Provider:         d.Provider,
 		Model:            d.Model,
+		Code:             d.Code,
 		SystemPrompt:     d.SystemPrompt,
 		SystemPromptFile: d.SystemPromptFile,
 		AllowedTools:     d.AllowedTools,
@@ -2797,6 +2798,9 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.Model != "" {
 		out.Model = override.Model
+	}
+	if override.Code != "" {
+		out.Code = override.Code
 	}
 	// Either prompt-source override clears the OTHER source on the
 	// merged struct. Without this, a discovered MD that sets

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -855,6 +855,55 @@ agents:
 	}
 }
 
+// TestDiscoverAgents_InlineCodeFlowsThroughDiscoveryAndOverride pins that the
+// RFC J inline code-js body threads through both the .md-discovery projection
+// (agentFromDiscovered) and the yaml-override merge (mergeAgentDef). Fails on
+// the pre-fix code, where neither copied Code, so a discovered or
+// yaml-overridden inline body was silently dropped → the agent fell back to a
+// nonexistent agent_code/<name>/index.js.
+func TestDiscoverAgents_InlineCodeFlowsThroughDiscoveryAndOverride(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "discovered" carries its body purely from the .md frontmatter.
+	writeAgentMD(t, agentsDir, "discovered", `---
+name: discovered
+provider: code-js
+code: "function run(){ return {final_text: 'from-md'}; }"
+---
+`)
+	// "overridden" has a .md body that the yaml override layer replaces.
+	writeAgentMD(t, agentsDir, "overridden", `---
+name: overridden
+provider: code-js
+code: "function run(){ return {final_text: 'from-md'}; }"
+---
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  overridden:
+    code: "function run(){ return {final_text: 'from-yaml'}; }"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["discovered"].Code; got != "function run(){ return {final_text: 'from-md'}; }" {
+		t.Errorf("discovered .md inline code not carried: %q", got)
+	}
+	if got := cfg.Agents["overridden"].Code; got != "function run(){ return {final_text: 'from-yaml'}; }" {
+		t.Errorf("yaml override inline code not applied (mergeAgentDef dropped Code): %q", got)
+	}
+}
+
 // TestDiscoverAgents_DiscoveryOnly: AGENTS_ROOT set, yaml has no
 // `agents:` block at all. All agents come from the MDs, validation
 // passes. The deployment shape an operator using "MDs as sole source


### PR DESCRIPTION
## Why this exists (process recovery)

PR #350 was opened with base = `feature-codejs-inline-agentdef` (stacked on #349) instead of `main`. When it was merged, GitHub squash-merged it **into the #349 branch** — but #349 had already been independently squash-merged to `main`, so #350's commit (`15fdc8b`) landed on a dead-end branch and **never reached `main`**. GitHub shows #350 as "MERGED," but its content isn't in `main`. (This is the merged-but-not-on-main stacked-PR trap.)

This PR re-applies #350's content via a clean cherry-pick of `15fdc8b` onto `main`, so it actually lands this time. **Off `main`, not stacked.**

## What (identical to the original #350)

`AgentContent.CodeBody` is hash-significant (added in #349, which IS on main), but only the substrate producer carried it. This threads the inline code body through the remaining producers so a code agent's `content_sha256` is identical regardless of ingestion path:

- `agents.Agent` + `frontmatter` (yaml `code:`) + `parseAgent`
- `FromYAMLAgent` → `AgentContent.CodeBody`
- `agentFromDiscovered` (`.md` → `config.AgentDef`)
- `cli/hash.go` hand-copy (the `loomcycle hash agent` CI drift-check path)
- `mergeAgentDef` `override.Code` (yaml-override-over-`.md` merge)
- `FromOverlay` already picks up `code_body` via its json tag — all three producers now converge.

Without this, the `loomcycle hash agent` / `.md` / yaml hash for a code agent omits `code_body` and mismatches the deployed substrate hash (`verify` reports false drift).

## What was tested

- `TestFromYAMLAgent_CarriesCodeBody`, `TestFromOverlay_RoundTripMatchesYAMLAgent_WithCode` (the 3-way symmetry), `TestDiscoverAgents_InlineCodeFlowsThroughDiscoveryAndOverride`.
- `go test ./...`, `gofmt` clean.

**Blocks the v0.20.0 tag** — releasing should wait for this so the code-js feature ships with its hash-symmetry fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)