### PR TITLE
ci: opt JS actions into Node 24 (clear Node-20 deprecation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   pull_request:
 
+# Run JavaScript-based actions (checkout, setup-go, setup-node, …) on
+# Node.js 24. GitHub forces this default on 2026-06-16 and removes Node 20
+# from runners on 2026-09-16; this opt-in clears the Node-20 deprecation
+# warning now, across every action, without per-action major-version bumps.
+# Safe to delete once Node 24 is the runner default.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
 

--- a/.github/workflows/publish-python-adapter.yml
+++ b/.github/workflows/publish-python-adapter.yml
@@ -26,6 +26,13 @@ on:
     tags:
       - "python-v*"
 
+# Run JavaScript-based actions (checkout, setup-python) on Node.js 24. GitHub
+# forces this default 2026-06-16 and removes Node 20 from runners 2026-09-16;
+# this opt-in clears the Node-20 deprecation now without per-action major
+# bumps. Safe to delete once Node 24 is the runner default.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/publish-ts-adapter.yml
+++ b/.github/workflows/publish-ts-adapter.yml
@@ -25,6 +25,13 @@ on:
     tags:
       - "v*"
 
+# Run JavaScript-based actions (checkout, setup-node) on Node.js 24. GitHub
+# forces this default 2026-06-16 and removes Node 20 from runners 2026-09-16;
+# this opt-in clears the Node-20 deprecation now without per-action major
+# bumps. Safe to delete once Node 24 is the runner default.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,14 @@ on:
     tags:
       - "v*"
 
+# Run JavaScript-based actions (checkout, setup-go/node, docker/*,
+# goreleaser-action) on Node.js 24. GitHub forces this default 2026-06-16
+# and removes Node 20 from runners 2026-09-16; this opt-in clears the
+# Node-20 deprecation across every action without per-action major bumps.
+# Safe to delete once Node 24 is the runner default.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: write  # needed for goreleaser to upload release assets
 


### PR DESCRIPTION
## Why

The v0.20.0 release run emitted GitHub's **Node-20 deprecation** warning — `actions/checkout`, `setup-go`, `setup-node`, `setup-python`, the `docker/*` actions, and `goreleaser-action` all run on Node.js 20. GitHub **forces Node 24 as the default on 2026-06-16** and **removes Node 20 from runners on 2026-09-16**, so releases would start warning now and eventually break.

## What

Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at the workflow `env:` level in all four workflows (`ci`, `release`, `publish-ts-adapter`, `publish-python-adapter`) — GitHub's [documented opt-in](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This runs **every** JS-based action on Node 24 immediately, clearing the deprecation across the board.

**Why the env-var, not per-action major bumps:** the `docker/*` and `goreleaser-action` versions run the release pipeline we just used for v0.20.0 — bumping those majors blind (post-knowledge-cutoff versions) is exactly the risk I don't want in a "small, safe" PR. The env-var is one line per workflow, covers all actions uniformly, and is trivially removable once Node 24 is the runner default.

**Deliberately unchanged:** the `node-version: "20"` inputs (the Node the TS/Python *builds* run under) — that's a separate, test-bearing decision from the action runtime, out of scope here.

## Tested

- `yaml.safe_load` parses all four workflows with `env` at the top level (sibling of `jobs`); the var resolves to `"true"`.
- This PR's own CI run exercises the opt-in end-to-end — green CI confirms the JS actions run cleanly on Node 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)