### PR TITLE
feat(triggers): WebHook/Scheduler metadata sourcing + WebhookDef creds parity (PR 2/2)

### DIFF
--- a/internal/api/webhook/metadata_test.go
+++ b/internal/api/webhook/metadata_test.go
@@ -1,0 +1,59 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestBuildRunInput_MetadataTrustedAndPayloadUntrusted pins the non-secret
+// metadata sourcing: the static def `metadata` becomes RunInput.Metadata
+// (trusted), and payload_mapping `run_metadata.*` targets become
+// RunInput.PayloadMetadata (untrusted). Fails on the pre-feature code, which
+// had no metadata fields and discarded run_metadata.* projection targets.
+func TestBuildRunInput_MetadataTrustedAndPayloadUntrusted(t *testing.T) {
+	w := config.Webhook{
+		Agent:    "reviewer",
+		Metadata: map[string]any{"policy": "strict", "skills": []any{"go"}},
+	}
+	proj := projectResult{Fields: map[string]string{
+		"goal":              "review the PR",
+		"run_metadata.repo": "acme/app",
+		"run_metadata.pr":   "42",
+	}}
+	in := buildRunInput(w, proj, map[string]bool{}, func(string) string { return "" }, nil)
+
+	if in.Metadata["policy"] != "strict" {
+		t.Errorf("static def metadata not carried as trusted Metadata: %v", in.Metadata)
+	}
+	if in.PayloadMetadata["repo"] != "acme/app" || in.PayloadMetadata["pr"] != "42" {
+		t.Errorf("run_metadata.* not routed to PayloadMetadata: %v", in.PayloadMetadata)
+	}
+}
+
+// TestBuildRunInput_UserCredentialsPrecedence pins env < fork-time < payload.
+func TestBuildRunInput_UserCredentialsPrecedence(t *testing.T) {
+	w := config.Webhook{
+		Agent:                  "x",
+		UserCredentialsFromEnv: map[string]string{"slack": "SLACK_ENV", "jobs": "JOBS_ENV"},
+		UserCredentials:        map[string]string{"slack": "fork-slack", "tg": "fork-tg"},
+	}
+	proj := projectResult{Fields: map[string]string{
+		"user_credentials.slack": "payload-slack",
+	}}
+	env := map[string]bool{"SLACK_ENV": true, "JOBS_ENV": true}
+	getenv := func(k string) string {
+		return map[string]string{"SLACK_ENV": "env-slack", "JOBS_ENV": "env-jobs"}[k]
+	}
+	in := buildRunInput(w, proj, env, getenv, nil)
+
+	if in.UserCredentials["slack"] != "payload-slack" {
+		t.Errorf("slack: payload must win over fork-time + env; got %q", in.UserCredentials["slack"])
+	}
+	if in.UserCredentials["jobs"] != "env-jobs" {
+		t.Errorf("jobs: env-only should resolve to env value; got %q", in.UserCredentials["jobs"])
+	}
+	if in.UserCredentials["tg"] != "fork-tg" {
+		t.Errorf("tg: fork-time-only should resolve to fork value; got %q", in.UserCredentials["tg"])
+	}
+}

--- a/internal/api/webhook/metadata_test.go
+++ b/internal/api/webhook/metadata_test.go
@@ -31,6 +31,36 @@ func TestBuildRunInput_MetadataTrustedAndPayloadUntrusted(t *testing.T) {
 	}
 }
 
+// TestBuildRunInput_EmptyProjectedValuesSkipped pins that an absent optional
+// body path (projected to "") does NOT surface as a phantom {name:""} entry —
+// neither a blanked credential nor an empty run_metadata key. Fails on the
+// pre-fix run_metadata loop, which lacked the val=="" skip the credentials
+// loop had, so it injected {repo:""} into PayloadMetadata.
+func TestBuildRunInput_EmptyProjectedValuesSkipped(t *testing.T) {
+	w := config.Webhook{
+		Agent:                  "x",
+		UserCredentialsFromEnv: map[string]string{"slack": "SLACK_ENV"},
+	}
+	proj := projectResult{Fields: map[string]string{
+		"run_metadata.repo":      "acme/app",
+		"run_metadata.pr":        "", // absent optional path
+		"user_credentials.slack": "", // absent — must not clobber the env value
+	}}
+	env := map[string]bool{"SLACK_ENV": true}
+	getenv := func(k string) string { return map[string]string{"SLACK_ENV": "env-slack"}[k] }
+	in := buildRunInput(w, proj, env, getenv, nil)
+
+	if _, ok := in.PayloadMetadata["pr"]; ok {
+		t.Errorf("empty run_metadata.pr must be skipped, not injected as \"\": %v", in.PayloadMetadata)
+	}
+	if in.PayloadMetadata["repo"] != "acme/app" {
+		t.Errorf("non-empty run_metadata.repo should still be present: %v", in.PayloadMetadata)
+	}
+	if in.UserCredentials["slack"] != "env-slack" {
+		t.Errorf("empty payload credential must not clobber the env value; got %q", in.UserCredentials["slack"])
+	}
+}
+
 // TestBuildRunInput_UserCredentialsPrecedence pins env < fork-time < payload.
 func TestBuildRunInput_UserCredentialsPrecedence(t *testing.T) {
 	w := config.Webhook{

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -20,6 +20,31 @@ const credentialsPrefix = "user_credentials."
 // input.payload_metadata). Distinct from the static, TRUSTED w.Metadata.
 const metadataPrefix = "run_metadata."
 
+// collectPrefixed returns the projected fields whose target begins with prefix,
+// re-keyed by the name after the prefix. Empty names and empty VALUES are
+// skipped: projectPayload records an absent optional path as "" (and in
+// MissingKeys), and a missing optional field must not surface as a real
+// {name:""} entry — neither a blanked credential nor a phantom metadata key.
+// Shared by the user_credentials.* and run_metadata.* projection passes so the
+// two namespaces can't drift in scan/skip semantics. Returns nil when empty.
+func collectPrefixed(fields map[string]string, prefix string) map[string]string {
+	var out map[string]string
+	for target, val := range fields {
+		if !strings.HasPrefix(target, prefix) {
+			continue
+		}
+		name := strings.TrimPrefix(target, prefix)
+		if name == "" || val == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]string)
+		}
+		out[name] = val
+	}
+	return out
+}
+
 // buildRunInput converts a resolved webhook Def + projected payload into the
 // RunInput the runner consumes. It MIRRORS the scheduler's buildRunInput
 // credential pattern (env-allowlist gate over user_credentials_from_env)
@@ -63,41 +88,28 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		creds[k] = v
 	}
 
-	// 2. Payload overlay: user_credentials.<name> mapping targets win over
-	//    the env-resolved value for the same key. An empty projected value
-	//    (absent path) does NOT clobber an env-resolved credential — a
-	//    missing optional field shouldn't blank out the static fallback.
-	for target, val := range proj.Fields {
-		if !strings.HasPrefix(target, credentialsPrefix) {
-			continue
-		}
-		name := strings.TrimPrefix(target, credentialsPrefix)
-		if name == "" || val == "" {
-			continue
-		}
-		if _, hadEnv := creds[name]; hadEnv && logf != nil {
-			logf("webhook: credential key %q has both env + payload source — payload value wins", name)
+	// 2. Payload overlay: user_credentials.<name> mapping targets win over the
+	//    env-resolved + fork-time value for the same key. collectPrefixed skips
+	//    empty projected values, so an absent optional path does NOT clobber a
+	//    prior source (a missing optional field shouldn't blank the fallback).
+	for name, val := range collectPrefixed(proj.Fields, credentialsPrefix) {
+		if _, had := creds[name]; had && logf != nil {
+			logf("webhook: credential key %q has both a non-payload source + payload source — payload value wins", name)
 		}
 		creds[name] = val
 	}
 
 	// Non-secret payload metadata: payload_mapping targets under
 	// `run_metadata.<name>` are projected from the (signed) inbound body —
-	// attacker-influenceable, so UNTRUSTED. Collected here from the
-	// otherwise-discarded projection targets and fenced downstream.
+	// attacker-influenceable, so UNTRUSTED. Collected from the otherwise-
+	// discarded projection targets (empties skipped, like credentials) and
+	// fenced downstream.
 	var payloadMeta map[string]any
-	for target, val := range proj.Fields {
-		if !strings.HasPrefix(target, metadataPrefix) {
-			continue
+	if m := collectPrefixed(proj.Fields, metadataPrefix); len(m) > 0 {
+		payloadMeta = make(map[string]any, len(m))
+		for name, val := range m {
+			payloadMeta[name] = val
 		}
-		name := strings.TrimPrefix(target, metadataPrefix)
-		if name == "" {
-			continue
-		}
-		if payloadMeta == nil {
-			payloadMeta = make(map[string]any)
-		}
-		payloadMeta[name] = val
 	}
 
 	goal := proj.Fields["goal"]

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -13,6 +13,13 @@ import (
 // projects a value from the request body into the GITHUB_TOKEN credential.
 const credentialsPrefix = "user_credentials."
 
+// metadataPrefix is the payload-mapping target namespace that routes a body
+// field into the run's UNTRUSTED PayloadMetadata. A mapping key
+// "run_metadata.repo" projects $.repository.full_name into payload_metadata.repo,
+// which the agent receives fenced (LLM: <run_metadata> block; code-js:
+// input.payload_metadata). Distinct from the static, TRUSTED w.Metadata.
+const metadataPrefix = "run_metadata."
+
 // buildRunInput converts a resolved webhook Def + projected payload into the
 // RunInput the runner consumes. It MIRRORS the scheduler's buildRunInput
 // credential pattern (env-allowlist gate over user_credentials_from_env)
@@ -45,6 +52,17 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		creds[k] = v
 	}
 
+	// 1b. Fork-time explicit credentials (RFC F, ScheduleDef parity) override
+	//     the env-resolved value. The payload overlay (step 2) still wins over
+	//     these, preserving "the live per-delivery token is most specific".
+	//     Precedence: env-resolved < fork-time user_credentials < payload.
+	for k, v := range w.UserCredentials {
+		if v == "" {
+			continue
+		}
+		creds[k] = v
+	}
+
 	// 2. Payload overlay: user_credentials.<name> mapping targets win over
 	//    the env-resolved value for the same key. An empty projected value
 	//    (absent path) does NOT clobber an env-resolved credential — a
@@ -61,6 +79,25 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 			logf("webhook: credential key %q has both env + payload source — payload value wins", name)
 		}
 		creds[name] = val
+	}
+
+	// Non-secret payload metadata: payload_mapping targets under
+	// `run_metadata.<name>` are projected from the (signed) inbound body —
+	// attacker-influenceable, so UNTRUSTED. Collected here from the
+	// otherwise-discarded projection targets and fenced downstream.
+	var payloadMeta map[string]any
+	for target, val := range proj.Fields {
+		if !strings.HasPrefix(target, metadataPrefix) {
+			continue
+		}
+		name := strings.TrimPrefix(target, metadataPrefix)
+		if name == "" {
+			continue
+		}
+		if payloadMeta == nil {
+			payloadMeta = make(map[string]any)
+		}
+		payloadMeta[name] = val
 	}
 
 	goal := proj.Fields["goal"]
@@ -94,6 +131,10 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		UserID:          proj.Fields["user_id"],
 		UserTier:        proj.Fields["user_tier"],
 		UserCredentials: creds,
+		// Metadata is the static, operator-authored def blob → TRUSTED.
+		// PayloadMetadata is projected from the inbound body → UNTRUSTED.
+		Metadata:        w.Metadata,
+		PayloadMetadata: payloadMeta,
 		// IdempotencyKey is set by the caller (deliverSpawn) to the
 		// delivery id, keeping this builder's signature focused on the
 		// Def + projected payload. See RFC H Decision 10 "Layer 2".

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -949,6 +949,12 @@ type ScheduledRun struct {
 	// Operator-yaml authoring. Runtime hooks added via the admin HTTP
 	// surface live in the substrate state, not here.
 	OnComplete []ScheduledRunHook `yaml:"on_complete"`
+
+	// Metadata is NON-SECRET structured metadata passed to the agent as
+	// TRUSTED (operator-authored) via RunInput.Metadata. Per-fork metadata
+	// (e.g. a different repo per fork) falls out of the overlay naturally.
+	// Not for secrets — those use UserCredentials / user_credentials_from_env.
+	Metadata map[string]any `yaml:"metadata"`
 }
 
 // ScheduledRunSegment mirrors the loop.PromptSegment wire shape but
@@ -1072,17 +1078,29 @@ type A2AExpectedSkill struct {
 // parity. on_complete reuses ScheduledRunHook — the same hook shape
 // ScheduleDef uses — rather than a parallel type.
 type Webhook struct {
-	Enabled                bool                `json:"enabled,omitempty" yaml:"enabled"`
-	Delivery               string              `json:"delivery,omitempty" yaml:"delivery"`
-	Agent                  string              `json:"agent,omitempty" yaml:"agent"`
-	Channel                string              `json:"channel,omitempty" yaml:"channel"`
-	Auth                   WebhookAuth         `json:"auth,omitempty" yaml:"auth"`
-	RateLimit              WebhookRateLimit    `json:"rate_limit,omitempty" yaml:"rate_limit"`
-	BodySizeLimitBytes     int                 `json:"body_size_limit_bytes,omitempty" yaml:"body_size_limit_bytes"`
-	UserCredentialsFromEnv map[string]string   `json:"user_credentials_from_env,omitempty" yaml:"user_credentials_from_env"`
-	PayloadMapping         map[string]string   `json:"payload_mapping,omitempty" yaml:"payload_mapping"`
-	SyncResponse           WebhookSyncResponse `json:"sync_response,omitempty" yaml:"sync_response"`
-	OnComplete             []ScheduledRunHook  `json:"on_complete,omitempty" yaml:"on_complete"`
+	Enabled                bool              `json:"enabled,omitempty" yaml:"enabled"`
+	Delivery               string            `json:"delivery,omitempty" yaml:"delivery"`
+	Agent                  string            `json:"agent,omitempty" yaml:"agent"`
+	Channel                string            `json:"channel,omitempty" yaml:"channel"`
+	Auth                   WebhookAuth       `json:"auth,omitempty" yaml:"auth"`
+	RateLimit              WebhookRateLimit  `json:"rate_limit,omitempty" yaml:"rate_limit"`
+	BodySizeLimitBytes     int               `json:"body_size_limit_bytes,omitempty" yaml:"body_size_limit_bytes"`
+	UserCredentialsFromEnv map[string]string `json:"user_credentials_from_env,omitempty" yaml:"user_credentials_from_env"`
+	// UserCredentials maps credential KEY → explicit bearer VALUE (RFC F),
+	// parity with ScheduleDef forks. Resolved into the spawned run's
+	// UserCredentials + substituted at the MCP transport. Receiver
+	// precedence: env-resolved < these fork-time values < payload-projected
+	// `user_credentials.<name>` (the live per-delivery token wins). NOTE: a
+	// literal secret here is baked into the signed/content-hashed/snapshotted
+	// def — the weaker posture vs env/payload; prefer those.
+	UserCredentials map[string]string `json:"user_credentials,omitempty" yaml:"user_credentials"`
+	// Metadata is NON-SECRET structured metadata (repo, review policy,
+	// preferred skills, …) passed to the agent as TRUSTED (def-authored) via
+	// RunInput.Metadata. Not for secrets — those use UserCredentials*.
+	Metadata       map[string]any      `json:"metadata,omitempty" yaml:"metadata"`
+	PayloadMapping map[string]string   `json:"payload_mapping,omitempty" yaml:"payload_mapping"`
+	SyncResponse   WebhookSyncResponse `json:"sync_response,omitempty" yaml:"sync_response"`
+	OnComplete     []ScheduledRunHook  `json:"on_complete,omitempty" yaml:"on_complete"`
 }
 
 // WebhookAuth declares how inbound webhook requests are authenticated.

--- a/internal/lookup/schedule.go
+++ b/internal/lookup/schedule.go
@@ -91,6 +91,7 @@ type SubstrateScheduleDef struct {
 	UserTier               string                  `json:"user_tier,omitempty"`
 	UserCredentialsFromEnv map[string]string       `json:"user_credentials_from_env,omitempty"`
 	OnComplete             []SubstrateScheduleHook `json:"on_complete,omitempty"`
+	Metadata               map[string]any          `json:"metadata,omitempty"`
 }
 
 // SubstratePromptSegment mirrors config.ScheduledRunSegment with
@@ -142,6 +143,7 @@ func (s SubstrateScheduleDef) ToConfigDef() config.ScheduledRun {
 		CatchUpMax:             s.CatchUpMax,
 		UserID:                 s.UserID,
 		UserCredentialsFromEnv: s.UserCredentialsFromEnv,
+		Metadata:               s.Metadata,
 	}
 	if len(s.Prompt) > 0 {
 		out.Prompt = make([]config.ScheduledRunSegment, len(s.Prompt))

--- a/internal/lookup/schedule_test.go
+++ b/internal/lookup/schedule_test.go
@@ -193,6 +193,7 @@ func TestSchedule_DriftDetection(t *testing.T) {
 		"user_tier":                 true,
 		"user_credentials_from_env": true,
 		"on_complete":               true,
+		"metadata":                  true, // non-secret agent metadata (PR 2/2)
 	}
 	have := scheduleJsonTagsOf(reflect.TypeOf(lookup.SubstrateScheduleDef{}))
 	for tag := range want {

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -82,6 +82,8 @@ type SubstrateWebhookDef struct {
 	RateLimit              SubstrateWebhookRateLimit `json:"rate_limit,omitempty"`
 	BodySizeLimitBytes     int                       `json:"body_size_limit_bytes,omitempty"`
 	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
+	UserCredentials        map[string]string         `json:"user_credentials,omitempty"`
+	Metadata               map[string]any            `json:"metadata,omitempty"`
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           SubstrateWebhookSyncResp  `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
@@ -135,6 +137,8 @@ func (s SubstrateWebhookDef) ToConfigDef() config.Webhook {
 		},
 		BodySizeLimitBytes:     s.BodySizeLimitBytes,
 		UserCredentialsFromEnv: s.UserCredentialsFromEnv,
+		UserCredentials:        s.UserCredentials,
+		Metadata:               s.Metadata,
 		PayloadMapping:         s.PayloadMapping,
 		SyncResponse: config.WebhookSyncResponse{
 			Enabled:   s.SyncResponse.Enabled,

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -146,6 +146,8 @@ func TestWebhook_DriftDetection(t *testing.T) {
 		"rate_limit":                true,
 		"body_size_limit_bytes":     true,
 		"user_credentials_from_env": true,
+		"user_credentials":          true, // RFC F fork-time parity (PR 2/2)
+		"metadata":                  true, // non-secret agent metadata (PR 2/2)
 		"payload_mapping":           true,
 		"sync_response":             true,
 		"on_complete":               true,

--- a/internal/scheduler/metadata_test.go
+++ b/internal/scheduler/metadata_test.go
@@ -1,0 +1,22 @@
+package scheduler
+
+import "testing"
+
+// TestBuildRunInput_ThreadsDefMetadata pins that a schedule def's non-secret
+// metadata reaches the spawned run as trusted RunInput.Metadata. Fails on the
+// pre-feature scheduleDef, which had no metadata field. The scheduler has no
+// external inbound body, so PayloadMetadata stays nil.
+func TestBuildRunInput_ThreadsDefMetadata(t *testing.T) {
+	def := scheduleDef{
+		Agent:    "digest",
+		Metadata: map[string]any{"repo": "acme/app", "policy": "nightly"},
+	}
+	in := buildRunInput(def, map[string]bool{}, nil)
+
+	if in.Metadata["repo"] != "acme/app" || in.Metadata["policy"] != "nightly" {
+		t.Errorf("schedule def metadata not threaded to RunInput.Metadata: %v", in.Metadata)
+	}
+	if in.PayloadMetadata != nil {
+		t.Errorf("scheduler has no inbound body; PayloadMetadata must be nil, got %v", in.PayloadMetadata)
+	}
+}

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -36,6 +36,7 @@ type scheduleDef struct {
 	UserCredentialsFromEnv map[string]string   `json:"user_credentials_from_env,omitempty"`
 	UserTier               string              `json:"user_tier,omitempty"`
 	OnComplete             []scheduleHook      `json:"on_complete,omitempty"`
+	Metadata               map[string]any      `json:"metadata,omitempty"`
 }
 
 type schedulePromptSeg struct {
@@ -132,5 +133,8 @@ func buildRunInput(def scheduleDef, envAllowlist map[string]bool, logf func(form
 		UserID:          def.UserID,
 		UserTier:        def.UserTier,
 		UserCredentials: creds,
+		// Non-secret, operator-authored → TRUSTED. The scheduler has no
+		// external inbound body, so there is no PayloadMetadata here.
+		Metadata: def.Metadata,
 	}
 }

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -823,6 +823,10 @@ type mergedScheduleDef struct {
 	UserCredentials        map[string]string    `json:"user_credentials,omitempty"`
 	UserCredentialsFromEnv map[string]string    `json:"user_credentials_from_env,omitempty"`
 	OnComplete             []mergedScheduleHook `json:"on_complete,omitempty"`
+	// Metadata is NON-SECRET structured metadata passed to the agent as
+	// TRUSTED (def-authored) via RunInput.Metadata. Per-fork (e.g. a repo
+	// per fork) falls out of the overlay. Not for secrets (UserCredentials*).
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // mergedSchedulePromptSeg mirrors config.ScheduledRunSegment with JSON tags.
@@ -906,6 +910,9 @@ func (d *mergedScheduleDef) applyOverlay(ov mergedScheduleDef) {
 	if ov.OnComplete != nil {
 		d.OnComplete = ov.OnComplete
 	}
+	if ov.Metadata != nil {
+		d.Metadata = ov.Metadata
+	}
 }
 
 func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
@@ -920,6 +927,7 @@ func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
 		CatchUpMax:             sr.CatchUpMax,
 		UserID:                 sr.UserID,
 		UserCredentialsFromEnv: sr.UserCredentialsFromEnv,
+		Metadata:               sr.Metadata,
 	}
 	if len(sr.Prompt) > 0 {
 		out.Prompt = make([]mergedSchedulePromptSeg, len(sr.Prompt))

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -575,6 +575,8 @@ type mergedWebhookDef struct {
 	RateLimit              mergedWebhookRateLimit    `json:"rate_limit,omitempty"`
 	BodySizeLimitBytes     int                       `json:"body_size_limit_bytes,omitempty"`
 	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
+	UserCredentials        map[string]string         `json:"user_credentials,omitempty"` // RFC F fork-time explicit values (ScheduleDef parity)
+	Metadata               map[string]any            `json:"metadata,omitempty"`         // non-secret, trusted agent metadata
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           mergedWebhookSyncResp     `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
@@ -666,6 +668,12 @@ func (d *mergedWebhookDef) applyOverlay(ov mergedWebhookDef) {
 	if ov.UserCredentialsFromEnv != nil {
 		d.UserCredentialsFromEnv = ov.UserCredentialsFromEnv
 	}
+	if ov.UserCredentials != nil {
+		d.UserCredentials = ov.UserCredentials
+	}
+	if ov.Metadata != nil {
+		d.Metadata = ov.Metadata
+	}
 	if ov.PayloadMapping != nil {
 		d.PayloadMapping = ov.PayloadMapping
 	}
@@ -700,6 +708,8 @@ func staticToMergedWebhookDef(w config.Webhook) mergedWebhookDef {
 		},
 		BodySizeLimitBytes:     w.BodySizeLimitBytes,
 		UserCredentialsFromEnv: w.UserCredentialsFromEnv,
+		UserCredentials:        w.UserCredentials,
+		Metadata:               w.Metadata,
 		PayloadMapping:         w.PayloadMapping,
 		SyncResponse: mergedWebhookSyncResp{
 			Enabled:   w.SyncResponse.Enabled,


### PR DESCRIPTION
**PR 2 of 2** (PR 1 #356 — the run-input metadata channel + dual-agent delivery — is on `main`). This sources both data domains at the WebHook/Scheduler def level and wires them into the spawned run. Off `main`, **not stacked**.

## Non-secret metadata (the gap PR 1 created the channel for)

- `config.Webhook` + `config.ScheduledRun` gain a `metadata` field (operator/def-authored → **TRUSTED**), threaded through `merged*Def` / `Substrate*Def` / `ToConfigDef` + the scheduler's `scheduleDef`.
- The **webhook receiver** sets `RunInput.Metadata` from the static def, and routes the previously-**discarded** `payload_mapping` `run_metadata.*` targets into `RunInput.PayloadMetadata` (**UNTRUSTED** — projected from the signed inbound body; fenced downstream).
- The **scheduler** threads `def.Metadata` (no inbound body → no `PayloadMetadata`). Per-fork metadata (a repo per fork) falls out of the overlay naturally.

## Secure-domain parity (user-approved)

- `WebhookDef` gains the fork-time explicit `user_credentials` map (parity with `ScheduleDef`). Receiver credential precedence is now **env-resolved < fork-time `user_credentials` < payload-projected `user_credentials.*`** (the live per-delivery token still wins). Documented that a literal secret in the def is the weaker posture vs env/payload.

> **Secure-domain verification (your original ask):** the RFC F per-user path is confirmed correct + multi-user as-is — env-resolved + per-delivery-payload-projected bearer tokens, isolated per fired run, substituted at the MCP transport, inherited by sub-agents. This PR only *adds* the fork-time map; it changes nothing about the multi-user isolation.

## Persistence

Both fields live in the def `Definition` JSONB → round-trip through snapshot. WebhookDef/ScheduleDef have **no** `content_sha256` (no verify op, RFC E/H), so there is no hash to churn. Updated the `SubstrateWebhookDef` + `SubstrateScheduleDef` drift `want` maps (the conscious-addition gate).

## What was tested

Fail-before (these fields/paths did not exist):
- webhook `TestBuildRunInput_MetadataTrustedAndPayloadUntrusted` (static def → `Metadata`; `run_metadata.*` → `PayloadMetadata`) + `_UserCredentialsPrecedence` (env < fork < payload).
- scheduler `TestBuildRunInput_ThreadsDefMetadata`.
- `TestWebhook_DriftDetection` + `TestSchedule_DriftDetection` updated.
- `go test ./...`, `go vet`, `gofmt` clean.

## End-to-end (after merge)

Define a webhook with `metadata: {review_policy: strict}`, `payload_mapping: {"run_metadata.repo": "$.repository.full_name", "user_credentials.slack": "$.auth.slack"}`. A signed GitHub-shaped POST → a code-js agent reads `input.metadata.review_policy` (trusted) + `input.payload_metadata.repo` (untrusted) + the Slack token substituted via `${run.credentials.slack}`; an LLM agent's transcript shows the trusted metadata block + the fenced `<run_metadata>` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)