### PR TITLE
fix(metadata): review follow-ups — connector parity, capability gate, per-call doc

### DIFF
--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -193,7 +193,8 @@ export interface RunOptions {
    *  WebHook/Schedule trigger paths. As a first-party (bearer-authed)
    *  caller this is TRUSTED: a code-js agent reads it as `input.metadata`;
    *  an LLM agent receives it as a trusted prompt block. NOT for secrets —
-   *  use {@link RunOptions.userCredentials} for tokens. */
+   *  use {@link RunOptions.userCredentials} for tokens. Per-call, not session
+   *  state: a continuation does not inherit it — re-send on continue(). */
   metadata?: Record<string, unknown>;
   /** Opt-in observability: when true, the iterator emits client-
    *  synthesized `{ type: "_meta", meta_subtype: "stream_open" | "stream_close" }`
@@ -256,7 +257,9 @@ export interface ContinueOptions {
    *  (re)set the lineage for the new run it creates. */
   parentContext?: ParentContext;
   /** Optional NON-SECRET structured metadata for the new run — see
-   *  {@link RunOptions.metadata}. Same shape + trust posture. */
+   *  {@link RunOptions.metadata}. Same shape + trust posture. NOT inherited
+   *  from the original run (metadata is a per-call input, not session state):
+   *  re-send it on the continuation to carry it forward. */
   metadata?: Record<string, unknown>;
   /** Opt-in observability: see {@link RunOptions.debug}. Same shape. */
   debug?: boolean;

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -58,6 +58,7 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		UserBearer:      req.UserBearer,
 		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
 		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage
+		Metadata:        req.Metadata,        // non-secret trusted agent metadata
 	}
 
 	// Capture: the OnRegistered callback gives us the resolved IDs;

--- a/internal/api/http/metadata_segments_test.go
+++ b/internal/api/http/metadata_segments_test.go
@@ -20,7 +20,7 @@ func userSeg(text string) loop.PromptSegment {
 // after the leading system prompt and before the user content.
 func TestInjectMetadataSegments_TrustedAndUntrusted(t *testing.T) {
 	base := []loop.PromptSegment{sysSeg("you are a reviewer"), userSeg("review this")}
-	out := injectMetadataSegments(base, "anthropic",
+	out := injectMetadataSegments(base, false, // LLM: metadataViaInput=false → serialize into segments
 		map[string]any{"policy": "strict"},
 		map[string]any{"repo": "acme/app"},
 	)
@@ -44,22 +44,23 @@ func TestInjectMetadataSegments_TrustedAndUntrusted(t *testing.T) {
 	}
 }
 
-// TestInjectMetadataSegments_CodeJSNoop pins that code-js agents get NOTHING
-// injected (they receive metadata via RunMeta → input.metadata; a user-role
-// block here would shadow the latest-user-text the provider reads as prompt).
-func TestInjectMetadataSegments_CodeJSNoop(t *testing.T) {
+// TestInjectMetadataSegments_StructuredInputNoop pins that a metadataViaInput
+// provider (code-js) gets NOTHING injected — it receives metadata via
+// RunMeta → input.metadata; a user-role block here would shadow the
+// latest-user-text the provider reads as prompt.
+func TestInjectMetadataSegments_StructuredInputNoop(t *testing.T) {
 	base := []loop.PromptSegment{userSeg("go")}
-	out := injectMetadataSegments(base, "code-js",
+	out := injectMetadataSegments(base, true, // metadataViaInput=true (code-js)
 		map[string]any{"policy": "strict"}, map[string]any{"repo": "acme/app"})
 	if len(out) != 1 || out[0].Content[0].Text != "go" {
-		t.Errorf("code-js must be a no-op; got %d segments %+v", len(out), out)
+		t.Errorf("metadataViaInput provider must be a no-op; got %d segments %+v", len(out), out)
 	}
 }
 
 // TestInjectMetadataSegments_EmptyNoop pins that empty maps add no segment.
 func TestInjectMetadataSegments_EmptyNoop(t *testing.T) {
 	base := []loop.PromptSegment{sysSeg("sp"), userSeg("go")}
-	out := injectMetadataSegments(base, "anthropic", nil, nil)
+	out := injectMetadataSegments(base, false, nil, nil)
 	if len(out) != 2 {
 		t.Errorf("empty metadata must add no segment; got %d", len(out))
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1621,7 +1621,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Model:                  model,
 		Tools:                  allowedTools,
 		Dispatcher:             dispatcher,
-		Segments:               injectMetadataSegments(segments, providerID, in.Metadata, in.PayloadMetadata),
+		Segments:               injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, in.Metadata, in.PayloadMetadata),
 		PriorMessages:          priorMessages,
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,
@@ -2364,7 +2364,8 @@ type runRequest struct {
 	// the WebHook/Schedule trigger paths. A first-party /v1/runs caller is
 	// bearer-authed, so this is TRUSTED: delivered to a code-js agent as
 	// input.metadata, and to an LLM agent as a trusted-text prompt segment.
-	// Not a secret (safe to persist/log); credentials use user_credentials.
+	// Not a secret (safe to log); credentials use user_credentials. Per-call,
+	// not session state — a continuation must re-send it (see RunInput.Metadata).
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
@@ -2375,12 +2376,14 @@ type runRequest struct {
 // Both go AFTER a leading system segment (the agent's system prompt stays
 // first) and before the user content.
 //
-// No-op for a code-js agent (it receives metadata structurally via
-// RunMeta → input.metadata / input.payload_metadata; a user-role untrusted
-// block here would also shadow the latest-user-text the provider reads as
-// input.prompt) and when both maps are empty.
-func injectMetadataSegments(segs []loop.PromptSegment, providerID string, metadata, payloadMetadata map[string]any) []loop.PromptSegment {
-	if providerID == "code-js" {
+// No-op when metadataViaInput is true — the provider receives metadata
+// structurally via RunMeta → input.metadata / input.payload_metadata (a
+// user-role block here would also shadow the latest-user-text it reads as
+// input.prompt), and when both maps are empty. metadataViaInput is the
+// provider's Capabilities flag (set by code-js), not a hardcoded id, so a
+// future structured-input provider is handled without a special case.
+func injectMetadataSegments(segs []loop.PromptSegment, metadataViaInput bool, metadata, payloadMetadata map[string]any) []loop.PromptSegment {
+	if metadataViaInput {
 		return segs
 	}
 	var inject []loop.PromptSegment
@@ -2776,7 +2779,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Model:                  model,
 		Tools:                  allowedTools,
 		Dispatcher:             dispatcher,
-		Segments:               injectMetadataSegments(req.Segments, providerID, req.Metadata, nil),
+		Segments:               injectMetadataSegments(req.Segments, provider.Capabilities().MetadataViaInput, req.Metadata, nil),
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
@@ -2842,6 +2845,9 @@ type messagesRequest struct {
 	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 	// Metadata mirrors runRequest.Metadata for the continuation path —
 	// optional trusted non-secret blob for the new run this message spawns.
+	// It is NOT inherited from the original run (metadata is a per-call input,
+	// not session state — see RunInput.Metadata): to carry the original run's
+	// metadata into the continuation, re-send it here.
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
@@ -3144,7 +3150,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Model:                  model,
 		Tools:                  allowedTools,
 		Dispatcher:             dispatcher,
-		Segments:               injectMetadataSegments(segments, providerID, body.Metadata, nil),
+		Segments:               injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, body.Metadata, nil),
 		PriorMessages:          priorMessages,
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -210,6 +210,7 @@ func spawnRunStreaming(ctx context.Context, env *handlerEnv, req connector.Spawn
 		UserBearer:      req.UserBearer,
 		UserCredentials: req.UserCredentials, // v1.x RFC F per-tool named credentials
 		ParentContext:   req.ParentContext,   // v0.12.x opaque tracking lineage
+		Metadata:        req.Metadata,        // non-secret trusted agent metadata
 	}
 
 	var (

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -85,6 +85,14 @@ type SpawnRunRequest struct {
 	// persisted on each run row, and echoed on the per-agent report
 	// surfaces. Not a secret. Nil = no context (back-compat).
 	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
+
+	// Metadata is the optional NON-SECRET structured metadata passed to the
+	// agent (repo name, review policy, …) — the same trusted channel the HTTP
+	// /v1/runs `metadata` field feeds, so a gRPC / LoomCycle-MCP spawn_run /
+	// connector caller reaches it too. A code-js agent reads it as
+	// input.metadata; an LLM agent receives it as a trusted prompt block. Not
+	// a secret — credentials use UserCredentials. Nil = none (back-compat).
+	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
 // SpawnRunResult is the final outcome of a SpawnRun call (returned

--- a/internal/providers/codejs/inline_test.go
+++ b/internal/providers/codejs/inline_test.go
@@ -9,6 +9,17 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
+// TestCapabilities_MetadataViaInput pins that code-js advertises structured
+// metadata delivery, so the run-build path suppresses prompt-segment
+// serialization (review #3 — the gate is this capability, not a hardcoded
+// provider id). Fails if the flag regresses to false.
+func TestCapabilities_MetadataViaInput(t *testing.T) {
+	p := newTestProvider(t.TempDir())
+	if !p.Capabilities().MetadataViaInput {
+		t.Error("code-js must advertise MetadataViaInput=true (it reads input.metadata)")
+	}
+}
+
 // TestBuildInput_MergesCallerMetadata pins that the caller's non-secret
 // metadata reaches the JS as input.metadata / input.payload_metadata. Fails on
 // the pre-feature buildInput, which hardcoded metadata to {user_id, agent}.

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -86,7 +86,10 @@ func (p *Provider) Capabilities() providers.Capabilities {
 	// SEQUENTIAL tool calls, each a loop turn; the MaxIterations soft-cap is
 	// unusable here. The run is bounded by the run-level wall-clock deadline
 	// (see Call/interruptWatch), not by an iteration count.
-	return providers.Capabilities{Streaming: true, UnboundedIterations: true}
+	// MetadataViaInput: code-js receives run metadata structurally as
+	// input.metadata / input.payload_metadata (see buildInput), so the
+	// run-build path must not also serialize it into prompt segments.
+	return providers.Capabilities{Streaming: true, UnboundedIterations: true, MetadataViaInput: true}
 }
 
 // Probe always succeeds — code-js is in-process, always reachable.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -86,6 +86,18 @@ type Capabilities struct {
 	// hard ceiling as a pure runaway backstop. False for every LLM driver,
 	// where MaxIterations remains the runaway-tool-use guard.
 	UnboundedIterations bool
+
+	// MetadataViaInput signals that this provider delivers the run's
+	// non-secret metadata to the agent STRUCTURALLY as part of its input
+	// (the code-js provider surfaces it as input.metadata /
+	// input.payload_metadata), so the run-build path must NOT also serialize
+	// metadata into prompt segments — for such a provider a user-role
+	// metadata block would shadow the latest-user-text it reads as the
+	// prompt. False for every LLM driver, where metadata IS delivered via
+	// prompt segments (the only channel an LLM agent has). Set only by the
+	// synthetic code-js provider today; the generalisation is so a future
+	// structured-input provider doesn't have to be special-cased by id.
+	MetadataViaInput bool
 }
 
 // Request is one round-trip to the provider. The loop builds a fresh Request

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -209,8 +209,15 @@ type RunInput struct {
 	// the agent — repo name, review policy, preferred skills, etc. It is
 	// TRUSTED (operator/def-authored or first-party): delivered to a code-js
 	// agent as input.metadata, and to an LLM agent as a trusted-text prompt
-	// segment. Safe to persist/log — it is NOT credentials (those stay on
-	// UserCredentials, substituted only at the MCP transport).
+	// segment. Not a secret (safe to log) — credentials stay on
+	// UserCredentials, substituted only at the MCP transport.
+	//
+	// PER-CALL, not session state: like the agent's system prompt (re-derived
+	// from the AgentDef on every call), Metadata is NOT persisted on the run
+	// or session and is NOT replayed on a continuation. A
+	// /v1/sessions/{id}/messages continuation that needs the same metadata
+	// must re-supply it (same as it re-supplies the prompt). This keeps the
+	// channel a per-invocation input rather than sticky session state.
 	Metadata map[string]any
 
 	// PayloadMetadata is the optional NON-SECRET structured blob projected


### PR DESCRIPTION
Addresses the three deferred findings from the metadata-channel self-review (PRs #356/#357). All touch #356-merged files, so this is off `main` (not stacked).

## #2 — connector/gRPC/MCP couldn't supply metadata (medium)
`connector.SpawnRunRequest` had no `Metadata` field, so a gRPC / LoomCycle-MCP `spawn_run` / HTTP-connector `SpawnRun` caller's metadata never reached the agent — even though the sibling `ParentContext` is threaded there. Added `SpawnRunRequest.Metadata` and threaded it in `connector_impl.SpawnRun` + the MCP spawn handler (the two paths that build `RunInput` from `SpawnRunRequest`), mirroring `ParentContext`. Delivery is already shared via `Server.RunOnce`, so this is purely the missing **supply** field.
> gRPC's `runInputFromProto` threads neither `ParentContext` nor `Metadata` (a separate proto gap) — left consistent, not widened here.

## #3 — drop the hardcoded `"code-js"` gate (low/robustness)
`injectMetadataSegments` gated on `providerID == "code-js"`; a future structured-input provider would have gotten metadata **both** as `input.metadata` and as a shadowing user-role block. Replaced with a `providers.Capabilities.MetadataViaInput` flag (set by code-js); the run-build path now passes `provider.Capabilities().MetadataViaInput`. A new structured provider is handled with no special case.

## #1 — continuation metadata: per-call contract (your call: no schema change)
Metadata is a **per-call** input — like the agent's system prompt (re-derived each call from the AgentDef, not replayed from the transcript), **not** session state. A `/v1/sessions/{id}/messages` continuation does not inherit it and must re-send it (the endpoint already accepts `metadata`). Documented the contract on `RunInput.Metadata`, `runRequest`/`messagesRequest`, and the TS `RunOptions`/`ContinueOptions`; also corrected the misleading "safe to persist" phrasing (non-secret, but not persisted). **No behavior change.**

## Tested
- `TestCapabilities_MetadataViaInput` (code-js advertises the flag); `TestInjectMetadataSegments_StructuredInputNoop` updated to the capability bool.
- `go test ./...`, `go vet`, `gofmt` clean; `cd adapters/ts && npm run typecheck && npm test` (191).

## Not changed (noted in review)
Finding #7 (wire `metadata` is system-trusted-text reachable by any `runs:create` token) is **pre-existing** — arbitrary system-role `segments` are already accepted; not introduced by this feature. Worth a doc line in the multi-tenant security model, not a code change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)