### PR TITLE
fix(codejs): code_agent_timeout class + per-agent/per-run run_timeout override

### DIFF
--- a/adapters/ts/src/client.ts
+++ b/adapters/ts/src/client.ts
@@ -165,6 +165,7 @@ export class LoomcycleClient {
     if (opts.userCredentials !== undefined) body.user_credentials = opts.userCredentials;
     if (opts.parentContext !== undefined) body.parent_context = opts.parentContext;
     if (opts.metadata !== undefined) body.metadata = opts.metadata;
+    if (opts.runTimeoutSeconds !== undefined) body.run_timeout_seconds = opts.runTimeoutSeconds;
     yield* this.streamSSE("/v1/runs", body, opts.signal, opts.debug);
   }
 
@@ -200,6 +201,7 @@ export class LoomcycleClient {
     if (opts.userCredentials !== undefined) body.user_credentials = opts.userCredentials;
     if (opts.parentContext !== undefined) body.parent_context = opts.parentContext;
     if (opts.metadata !== undefined) body.metadata = opts.metadata;
+    if (opts.runTimeoutSeconds !== undefined) body.run_timeout_seconds = opts.runTimeoutSeconds;
     yield* this.streamSSE(
       `/v1/sessions/${encodeURIComponent(opts.sessionId)}/messages`,
       body,

--- a/adapters/ts/src/types.ts
+++ b/adapters/ts/src/types.ts
@@ -195,6 +195,13 @@ export interface RunOptions {
    *  an LLM agent receives it as a trusted prompt block. NOT for secrets —
    *  use {@link RunOptions.userCredentials} for tokens. */
   metadata?: Record<string, unknown>;
+  /** Optional ad-hoc per-run wall-clock budget (seconds) for a CODE-JS agent,
+   *  overriding the agent's `run_timeout_seconds` and the sidecar's global
+   *  default (precedence: per-run > per-agent > global). Use it for a fan-out
+   *  orchestrator that blocks in Agent.parallel_spawn awaiting LLM children —
+   *  its budget spans that wait, so the CPU-oriented default is often too low.
+   *  Ignored by LLM agents. 0 / omitted = inherit. */
+  runTimeoutSeconds?: number;
   /** Opt-in observability: when true, the iterator emits client-
    *  synthesized `{ type: "_meta", meta_subtype: "stream_open" | "stream_close" }`
    *  events around the real event stream. `meta_reason` carries the
@@ -258,6 +265,9 @@ export interface ContinueOptions {
   /** Optional NON-SECRET structured metadata for the new run — see
    *  {@link RunOptions.metadata}. Same shape + trust posture. */
   metadata?: Record<string, unknown>;
+  /** Optional ad-hoc per-run code-js wall-clock budget (seconds) for the
+   *  continuation's new run — see {@link RunOptions.runTimeoutSeconds}. */
+  runTimeoutSeconds?: number;
   /** Opt-in observability: see {@link RunOptions.debug}. Same shape. */
   debug?: boolean;
   signal?: AbortSignal;

--- a/adapters/ts/tests/client.test.ts
+++ b/adapters/ts/tests/client.test.ts
@@ -135,6 +135,22 @@ describe("runStreaming", () => {
     });
   });
 
+  it("forwards run_timeout_seconds when set, omits it when undefined", async () => {
+    const { client, fetchMock } = makeClient([
+      sseResponse(['event: done\ndata: {"type":"done"}\n\n']),
+      sseResponse(['event: done\ndata: {"type":"done"}\n\n']),
+    ]);
+    for await (const _ of client.runStreaming({
+      agent: "research-batch",
+      segments: [],
+      runTimeoutSeconds: 1800,
+    })) {}
+    expect(JSON.parse(fetchMock.mock.calls[0]![1]!.body as string).run_timeout_seconds).toBe(1800);
+
+    for await (const _ of client.runStreaming({ agent: "x", segments: [] })) {}
+    expect("run_timeout_seconds" in JSON.parse(fetchMock.mock.calls[1]![1]!.body as string)).toBe(false);
+  });
+
   it("forwards metadata when set, omits it when undefined (v0.21.0)", async () => {
     const { client, fetchMock } = makeClient([
       sseResponse(['event: done\ndata: {"type":"done"}\n\n']),

--- a/internal/api/http/metadata_segments_test.go
+++ b/internal/api/http/metadata_segments_test.go
@@ -56,6 +56,19 @@ func TestInjectMetadataSegments_CodeJSNoop(t *testing.T) {
 	}
 }
 
+// TestPickRunTimeout pins the per-run > per-agent > global precedence.
+func TestPickRunTimeout(t *testing.T) {
+	if got := pickRunTimeout(900, 300); got != 900 {
+		t.Errorf("per-run must win over per-agent; got %d", got)
+	}
+	if got := pickRunTimeout(0, 300); got != 300 {
+		t.Errorf("per-agent applies when no per-run; got %d", got)
+	}
+	if got := pickRunTimeout(0, 0); got != 0 {
+		t.Errorf("neither set ⇒ 0 (provider global default); got %d", got)
+	}
+}
+
 // TestInjectMetadataSegments_EmptyNoop pins that empty maps add no segment.
 func TestInjectMetadataSegments_EmptyNoop(t *testing.T) {
 	base := []loop.PromptSegment{sysSeg("sp"), userSeg("go")}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1636,6 +1636,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
 		Metadata:               in.Metadata,
 		PayloadMetadata:        in.PayloadMetadata,
+		RunTimeoutSeconds:      pickRunTimeout(in.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -2366,6 +2367,24 @@ type runRequest struct {
 	// input.metadata, and to an LLM agent as a trusted-text prompt segment.
 	// Not a secret (safe to persist/log); credentials use user_credentials.
 	Metadata map[string]any `json:"metadata,omitempty"`
+	// RunTimeoutSeconds is an optional ad-hoc per-run wall-clock budget for a
+	// code-js agent, overriding the agent's run_timeout_seconds and the global
+	// LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS (precedence: per-run >
+	// per-agent > global). 0 = inherit. Ignored by LLM agents.
+	RunTimeoutSeconds int `json:"run_timeout_seconds,omitempty"`
+}
+
+// pickRunTimeout resolves the effective code-js wall-clock budget override:
+// per-run (the request field) wins over per-agent (AgentDef), else 0 (the
+// provider's global default). A code-js orchestrator that blocks in
+// Agent.parallel_spawn awaiting LLM children needs a longer envelope than the
+// CPU-oriented global default; this lets a single run or a single agent raise
+// it without bumping the global for every code agent.
+func pickRunTimeout(perRun, perAgent int) int {
+	if perRun > 0 {
+		return perRun
+	}
+	return perAgent
 }
 
 // injectMetadataSegments inserts the run's NON-SECRET metadata into the prompt
@@ -2789,6 +2808,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		AgentName:              req.Agent,
 		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
 		Metadata:               req.Metadata,  // direct /v1/runs caller is first-party → trusted; no payload_metadata
+		RunTimeoutSeconds:      pickRunTimeout(req.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -2843,6 +2863,9 @@ type messagesRequest struct {
 	// Metadata mirrors runRequest.Metadata for the continuation path —
 	// optional trusted non-secret blob for the new run this message spawns.
 	Metadata map[string]any `json:"metadata,omitempty"`
+	// RunTimeoutSeconds mirrors runRequest.RunTimeoutSeconds for the
+	// continuation's new run (per-run > per-agent > global). 0 = inherit.
+	RunTimeoutSeconds int `json:"run_timeout_seconds,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -3158,6 +3181,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AgentName:              sess.Agent,
 		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
 		Metadata:               body.Metadata,
+		RunTimeoutSeconds:      pickRunTimeout(body.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		UserTier:               body.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3791,22 +3791,29 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 
 	fbPolicy, fbReResolve := s.fallbackForRun(name, parentTier)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
-		Provider:               provider,
-		Model:                  model,
-		Tools:                  subTools,
-		Dispatcher:             subDispatcher,
-		Segments:               segs,
-		OnEvent:                subEmit,
-		OnHeartbeat:            subHeartbeat,
-		MaxTokens:              def.MaxTokens,     // 0 → driver default
-		MaxIterations:          def.MaxIterations, // 0 → loop default (16)
-		Effort:                 effort,
-		MarkStalled:            s.markStalledFn(providerID, model),
-		MarkRateLimited:        s.markRateLimitedFn(parentTier),
-		ClearStall:             s.clearStallFn(providerID, model),
-		ToolParallelism:        s.cfg.Env.ToolParallelism,
-		AgentName:              name,
-		CodeBody:               def.Code, // inline code-js body (RFC J); "" → FS fallback
+		Provider:        provider,
+		Model:           model,
+		Tools:           subTools,
+		Dispatcher:      subDispatcher,
+		Segments:        segs,
+		OnEvent:         subEmit,
+		OnHeartbeat:     subHeartbeat,
+		MaxTokens:       def.MaxTokens,     // 0 → driver default
+		MaxIterations:   def.MaxIterations, // 0 → loop default (16)
+		Effort:          effort,
+		MarkStalled:     s.markStalledFn(providerID, model),
+		MarkRateLimited: s.markRateLimitedFn(parentTier),
+		ClearStall:      s.clearStallFn(providerID, model),
+		ToolParallelism: s.cfg.Env.ToolParallelism,
+		AgentName:       name,
+		CodeBody:        def.Code, // inline code-js body (RFC J); "" → FS fallback
+		// A code-js sub-agent's wall-clock budget is its OWN per-agent
+		// run_timeout_seconds — a spawn has no ad-hoc per-run knob, so
+		// per-agent is the sole source (== pickRunTimeout(0, def...)). Without
+		// this, the 4th run-creation site falls back to the global default,
+		// dropping the budget for the fan-out orchestrator case the per-agent
+		// override exists to serve.
+		RunTimeoutSeconds:      def.RunTimeoutSeconds,
 		UserTier:               parentTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/api/http/subagent_run_timeout_test.go
+++ b/internal/api/http/subagent_run_timeout_test.go
@@ -1,0 +1,137 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// runMetaCapturingProvider records the ctx-carried RunMeta.RunTimeoutSeconds on
+// every Call (in call order) and drives a scripted event sequence. Mirrors
+// bearerCapturingProvider — the seam for asserting what a child run inherits in
+// its ctx at provider-call time.
+type runMetaCapturingProvider struct {
+	calls   int
+	scripts [][]providers.Event
+
+	mu             sync.Mutex
+	capturedBudget []int // RunMeta.RunTimeoutSeconds per Call invocation
+}
+
+func (p *runMetaCapturingProvider) ID() string                    { return "runmeta-capturing" }
+func (p *runMetaCapturingProvider) Probe(_ context.Context) error { return nil }
+func (p *runMetaCapturingProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"stub-model"}, nil
+}
+func (p *runMetaCapturingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *runMetaCapturingProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	meta, _ := providers.RunMetaFromContext(ctx)
+	p.mu.Lock()
+	p.capturedBudget = append(p.capturedBudget, meta.RunTimeoutSeconds)
+	idx := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	var events []providers.Event
+	if idx < len(p.scripts) {
+		events = p.scripts[idx]
+	}
+	ch := make(chan providers.Event, len(events))
+	for _, ev := range events {
+		ch <- ev
+	}
+	close(ch)
+	return ch, nil
+}
+
+// TestSubAgent_InheritsPerAgentRunTimeout is the regression for the code-review
+// finding on PR #359: runSubAgent (the 4th loop.Run site) omitted
+// RunTimeoutSeconds, so a code-js sub-agent's per-agent run_timeout_seconds was
+// silently dropped to the global default — exactly the fan-out orchestrator
+// case the override exists to serve. The child here declares
+// run_timeout_seconds: 1800; its provider Call must see that budget on RunMeta.
+//
+// Fail-before: with the RunTimeoutSeconds line removed from runSubAgent's
+// RunOptions, the child Call captures 0 (global default) and this test fails.
+func TestSubAgent_InheritsPerAgentRunTimeout(t *testing.T) {
+	const childBudget = 1800
+
+	cfg := makeBaseConfig()
+	cfg.Agents = map[string]config.AgentDef{
+		"parent": {Model: "stub-model", AllowedTools: []string{"Agent"}, SystemPrompt: "you are the parent"},
+		// No RunTimeoutSeconds on parent → its own Call sees 0 (the
+		// per-run knob is absent on the top-level test request too).
+		"child": {Model: "stub-model", AllowedTools: []string{}, SystemPrompt: "you are the child", RunTimeoutSeconds: childBudget},
+	}
+
+	prov := &runMetaCapturingProvider{
+		scripts: [][]providers.Event{
+			{ // 1) parent spawns the child
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{
+					ID: "tu1", Name: "Agent", Input: json.RawMessage(`{"name":"child","prompt":"go"}`),
+				}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 10, OutputTokens: 2}},
+			},
+			{ // 2) child
+				{Type: providers.EventText, Text: "child done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 3, OutputTokens: 2}},
+			},
+			{ // 3) parent wraps up
+				{Type: providers.EventText, Text: "parent done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 12, OutputTokens: 3}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "subagent_runtimeout.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"parent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"start"}]}]}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		slurp, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, slurp)
+	}
+	_, _ = io.ReadAll(resp.Body) // drain so the parent + child runs finish
+
+	prov.mu.Lock()
+	captured := append([]int(nil), prov.capturedBudget...)
+	prov.mu.Unlock()
+
+	// call order: parent(1) → child(2) → parent(3). The child Call is the
+	// one that must carry the per-agent budget.
+	if len(captured) < 2 {
+		t.Fatalf("expected at least 2 provider calls (parent + child), got %d", len(captured))
+	}
+	if captured[0] != 0 {
+		t.Errorf("parent Call should see no per-agent budget (0); got %d", captured[0])
+	}
+	if captured[1] != childBudget {
+		t.Errorf("child Call must inherit its per-agent run_timeout_seconds (%d); got %d — runSubAgent dropped RunTimeoutSeconds", childBudget, captured[1])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -563,6 +563,16 @@ type AgentDef struct {
 	// linear-pipeline agents that don't need parallelism.
 	MaxConcurrentChildren int `yaml:"max_concurrent_children"`
 
+	// RunTimeoutSeconds is the per-agent wall-clock budget for a code-js
+	// agent (RFC J), overriding the global LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_
+	// SECONDS. 0 = use the global. A fan-out orchestrator's budget includes
+	// the time it spends blocked in Agent.parallel_spawn awaiting LLM
+	// children, so the CPU-oriented global default (120s) is structurally too
+	// low for one — set this on the orchestrator agent rather than raising the
+	// global for every code agent. Ignored by LLM agents. A /v1/runs request
+	// may override this per-call (per-run > per-agent > global).
+	RunTimeoutSeconds int `yaml:"run_timeout_seconds"`
+
 	// Tier is the model-tier the resolver should pick from when
 	// the agent doesn't declare an explicit Provider+Model pin.
 	// One of "low" / "middle" / "high". Empty = no tier-based
@@ -1476,6 +1486,16 @@ type Env struct {
 	// deadline (the universal cancel path — Appendix A; Interrupt cannot
 	// break a parked tool call). Default 120s. Env:
 	// LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS.
+	//
+	// This is TOTAL wall-clock from the run's start, and it KEEPS TICKING
+	// while the orchestrator is blocked in Agent.parallel_spawn awaiting its
+	// children — each child is a full LLM run (often 60–180s), so a fan-out
+	// orchestrator's budget must envelope the whole batch, not one child. The
+	// CPU-oriented 120s default is structurally too low for one: raise it
+	// per-orchestrator-agent via AgentDef.RunTimeoutSeconds (yaml
+	// run_timeout_seconds) or per-call via the /v1/runs run_timeout_seconds
+	// field rather than bumping this global for every code agent. Exceeding
+	// the budget surfaces as code_agent_timeout (not a throw at a JS line).
 	CodeAgentsRunTimeout time.Duration
 
 	// ---- v0.8.x process-resource metrics sampler (opt-in) ----

--- a/internal/help/builtin/code-agents.md
+++ b/internal/help/builtin/code-agents.md
@@ -195,10 +195,20 @@ tests and snapshot equality.
   time, not a fresh timeout each turn), so the total run cannot exceed it. (A
   very high hard ceiling on turns remains as a pure runaway backstop; reaching
   it means a non-terminating tool-call loop, not a too-small cap.)
-- **Run timeout bounds total wall time.** A CPU-bound JS loop is cut by goja
-  `Interrupt`; a too-slow multi-call run is cut by the same deadline on whatever
-  turn crosses it. Set `LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS`. The heap
-  limit is best-effort (goja exposes no hard cap).
+- **Run timeout bounds total wall time — including the parallel_spawn wait.**
+  A CPU-bound JS loop is cut by goja `Interrupt`; a too-slow multi-call run is
+  cut by the same deadline on whatever turn crosses it. Crucially the budget is
+  whole-run wall-clock from start and KEEPS TICKING while the orchestrator is
+  blocked in `Agent.parallel_spawn` awaiting children (each child a full LLM run,
+  often 60–180s) — so a fan-out orchestrator's budget must envelope the entire
+  batch, not one child. The global default (`LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_
+  SECONDS`, 120s) is CPU-oriented and structurally too low for one; raise it for
+  just the orchestrator via the agent's `run_timeout_seconds` (AgentDef / yaml),
+  or per-call via the `/v1/runs` `run_timeout_seconds` field (precedence:
+  per-run > per-agent > global). Exceeding the budget reports as
+  `code_agent_timeout` (stating the budget, no JS source line) — distinct from
+  `code_agent_threw` (a real exception) and `code_agent_cancelled` (parent
+  cancel). The heap limit is best-effort (goja exposes no hard cap).
 - **ABI versioning.** The JS-side API is versioned on its own semver
   (currently 1.0.0), separate from loomcycle's release vector. Breaking a
   signature is a major bump with a deprecation window.

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -143,8 +143,11 @@ type SubstrateAgentDef struct {
 	// spawn in parallel via Agent.parallel_spawn. 0 = use runtime
 	// default (DefaultMaxConcurrentChildren = 4). Mirrors the
 	// config.AgentDef yaml field.
-	MaxConcurrentChildren int    `json:"max_concurrent_children,omitempty"`
-	SystemPrompt          string `json:"system_prompt,omitempty"`
+	MaxConcurrentChildren int `json:"max_concurrent_children,omitempty"`
+	// RunTimeoutSeconds mirrors config.AgentDef.RunTimeoutSeconds — the
+	// per-agent code-js wall-clock budget (RFC J). 0 = global default.
+	RunTimeoutSeconds int    `json:"run_timeout_seconds,omitempty"`
+	SystemPrompt      string `json:"system_prompt,omitempty"`
 	// SystemPromptBase carries the pre-skill-bake snapshot when the
 	// substrate write path (commit 3 of this PR) persisted it.
 	// Read-side normalizers fall back to SystemPrompt when this is
@@ -179,6 +182,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,
+		RunTimeoutSeconds:     s.RunTimeoutSeconds,
 		SystemPrompt:          s.SystemPrompt,
 		SystemPromptBase:      s.SystemPromptBase,
 		AllowedTools:          s.AllowedTools,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -220,6 +220,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"memory_quota_bytes":      true,
 		"memory_backend":          true,
 		"retry_attempts":          true,
+		"run_timeout_seconds":     true, // RFC J per-agent code-js budget (operational, not hashed)
 	}
 	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateAgentDef{}))
 	for tag := range want {

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -124,6 +124,12 @@ type RunOptions struct {
 	Metadata        map[string]any
 	PayloadMetadata map[string]any
 
+	// RunTimeoutSeconds is the effective per-run/per-agent code-js wall-clock
+	// budget override (per-run wins over per-agent; resolved by the caller).
+	// 0 ⇒ the code-js provider's global default. Stamped onto RunMeta; LLM
+	// drivers ignore it.
+	RunTimeoutSeconds int
+
 	// UserTier is the v0.8.2 user-facing-tier policy name applied
 	// to this run. Informational on the loop side — appears on
 	// store.Run.UserTier + agent-loop log lines so cost/compliance
@@ -596,13 +602,14 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// turns, so code-js's anchored Date.now() is consistent across replays.
 	runIdent := tools.RunIdentity(ctx)
 	ctx = providers.WithRunMeta(ctx, providers.RunMeta{
-		AgentName:       opts.AgentName,
-		UserID:          runIdent.UserID,
-		RunID:           runIdent.AgentID,
-		StartedAt:       time.Now(),
-		CodeBody:        opts.CodeBody,
-		Metadata:        opts.Metadata,
-		PayloadMetadata: opts.PayloadMetadata,
+		AgentName:         opts.AgentName,
+		UserID:            runIdent.UserID,
+		RunID:             runIdent.AgentID,
+		StartedAt:         time.Now(),
+		CodeBody:          opts.CodeBody,
+		Metadata:          opts.Metadata,
+		PayloadMetadata:   opts.PayloadMetadata,
+		RunTimeoutSeconds: opts.RunTimeoutSeconds,
 	})
 
 	// Log once per Run if the agent declared an effort hint but the

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -148,9 +148,18 @@ func (p *Provider) Call(ctx context.Context, req providers.Request) (<-chan prov
 	// MaxIterations cap (Capabilities().UnboundedIterations) and rely on the
 	// timeout as the sole bound. Falls back to a flat per-turn RunTimeout when
 	// StartedAt is unstamped (direct, non-loop callers / tests).
-	budget := p.runTimeout
+	// Effective wall-clock budget: a per-run / per-agent run_timeout_seconds
+	// override (resolved server-side, carried on RunMeta) wins over the global
+	// LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS default — so a fan-out
+	// orchestrator that blocks in Agent.parallel_spawn awaiting LLM children
+	// can have a long envelope without raising the global for every code agent.
+	total := p.runTimeout
+	if meta.RunTimeoutSeconds > 0 {
+		total = time.Duration(meta.RunTimeoutSeconds) * time.Second
+	}
+	budget := total
 	if !meta.StartedAt.IsZero() {
-		budget = time.Until(meta.StartedAt.Add(p.runTimeout))
+		budget = time.Until(meta.StartedAt.Add(total))
 	}
 	// Emit a loomcycle.provider.call span for parity with the real LLM drivers
 	// (which each open one). The synthetic provider makes no HTTP request, so
@@ -163,7 +172,7 @@ func (p *Provider) Call(ctx context.Context, req providers.Request) (<-chan prov
 		Kind:     "synthetic-code",
 		CodeHash: prog.hash,
 	})
-	go p.runTurn(spanCtx, out, span, prog.prog, buildInput(req, meta), extractRecorded(req), toolNames(req), seed, anchorMs, budget)
+	go p.runTurn(spanCtx, out, span, prog.prog, buildInput(req, meta), extractRecorded(req), toolNames(req), seed, anchorMs, budget, total)
 	return out, nil
 }
 
@@ -171,7 +180,7 @@ func (p *Provider) Call(ctx context.Context, req providers.Request) (<-chan prov
 // runtime → harden + hook → bind → run() → emit the turn's outcome → close.
 // The goroutine lives only for the JS execution (µs–ms), never across a
 // dispatch gap.
-func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span trace.Span, prog *goja.Program, input map[string]any, recorded []toolRecord, allowed []string, seed uint32, anchorMs int64, budget time.Duration) {
+func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span trace.Span, prog *goja.Program, input map[string]any, recorded []toolRecord, allowed []string, seed uint32, anchorMs int64, budget, total time.Duration) {
 	defer close(out)
 	defer span.End()
 
@@ -187,10 +196,10 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 	// is interruptible. Stopped as soon as the turn finishes.
 	stop := make(chan struct{})
 	defer close(stop)
-	go p.interruptWatch(ctx, rt, stop, budget)
+	go p.interruptWatch(ctx, state, stop, budget)
 
 	if _, err := rt.RunProgram(prog); err != nil {
-		out <- errorEvent(p.classifyRunErr(state, ctx, err, "evaluating index.js"))
+		out <- errorEvent(p.classifyRunErr(state, ctx, err, "evaluating index.js", total))
 		return
 	}
 	runFn, ok := goja.AssertFunction(rt.Get("run"))
@@ -209,7 +218,7 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 			out <- providers.Event{Type: providers.EventDone, StopReason: "tool_use", Usage: zeroUsage()}
 			return
 		}
-		out <- errorEvent(p.classifyRunErr(state, ctx, err, "run"))
+		out <- errorEvent(p.classifyRunErr(state, ctx, err, "run", total))
 		return
 	}
 
@@ -220,13 +229,24 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 }
 
 // classifyRunErr maps a non-frontier run() error to a code-agent error string.
-func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, err error, where string) string {
+// total is the effective configured wall-clock budget (per-run/per-agent
+// override or the global default) — surfaced in the timeout message.
+func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, err error, where string, total time.Duration) string {
 	switch {
 	case state.diverged != nil:
 		d := state.diverged
 		return fmt.Sprintf("code_agent_replay_divergence: tool call #%d was %q on a prior turn but %q on replay — non-deterministic control flow; set LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1 or remove unhooked non-determinism", d.idx, d.expected, d.got)
 	case ctx.Err() != nil:
+		// Parent/operator cancellation (the ctx.Done branch of interruptWatch).
 		return "code_agent_cancelled: " + ctx.Err().Error()
+	case state.timedOut.Load():
+		// Whole-run wall-clock budget elapsed (the timer branch of
+		// interruptWatch). This is NOT a throw at `where` — the replay was
+		// merely interrupted there — so attribute no source line. For a
+		// fan-out orchestrator this budget spans the time blocked awaiting
+		// Agent.parallel_spawn children, so the CPU-oriented default is often
+		// too low; raise it per-agent (run_timeout_seconds) or per-run.
+		return fmt.Sprintf("code_agent_timeout: run exceeded its %s wall-clock budget (raise run_timeout_seconds per-agent / per-run, or LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS globally; the budget includes time blocked in Agent.parallel_spawn awaiting children)", total)
 	default:
 		return fmt.Sprintf("code_agent_threw: %s: %s", where, err)
 	}
@@ -237,7 +257,7 @@ func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, err e
 // closed). budget is the WHOLE RUN's remaining wall-clock (see Call), so the
 // last turn to cross the run deadline is interrupted — the run total can't
 // exceed RunTimeout even with the loop's iteration cap disabled.
-func (p *Provider) interruptWatch(ctx context.Context, rt *goja.Runtime, stop <-chan struct{}, budget time.Duration) {
+func (p *Provider) interruptWatch(ctx context.Context, state *replayState, stop <-chan struct{}, budget time.Duration) {
 	if budget <= 0 {
 		// Run already over its total budget — interrupt this turn at once.
 		budget = time.Millisecond
@@ -246,9 +266,14 @@ func (p *Provider) interruptWatch(ctx context.Context, rt *goja.Runtime, stop <-
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
-		rt.Interrupt(ctx.Err())
+		state.rt.Interrupt(ctx.Err())
 	case <-timer.C:
-		rt.Interrupt(context.DeadlineExceeded)
+		// Whole-run wall-clock budget elapsed — flag it BEFORE the interrupt
+		// so classifyRunErr reports code_agent_timeout (not code_agent_threw
+		// at whatever line the replay was interrupted). Distinct from the
+		// ctx.Done() branch above (operator/parent cancellation).
+		state.timedOut.Store(true)
+		state.rt.Interrupt(context.DeadlineExceeded)
 	case <-stop:
 	}
 }

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -199,7 +199,7 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 	go p.interruptWatch(ctx, state, stop, budget)
 
 	if _, err := rt.RunProgram(prog); err != nil {
-		out <- errorEvent(p.classifyRunErr(state, ctx, err, "evaluating index.js", total))
+		out <- errorEvent(p.classifyRunErr(state, ctx, state.interruptCause(), err, "evaluating index.js", total))
 		return
 	}
 	runFn, ok := goja.AssertFunction(rt.Get("run"))
@@ -210,15 +210,22 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 
 	ret, err := runFn(goja.Undefined(), rt.ToValue(input))
 	if err != nil {
-		// A frontier or divergence Interrupt surfaces here as the error.
-		if state.frontier != nil {
+		// A frontier, divergence, or watcher (timeout/cancel) Interrupt surfaces
+		// here as the error. A watcher interrupt takes PRECEDENCE over a frontier
+		// reached in the same instant: otherwise a run that overran its budget
+		// while reaching its next tool call would dispatch that call (a full
+		// child run for a fan-out orchestrator) past the deadline and report a
+		// normal tool_use, masking the timeout. cause is causeNone unless the
+		// watcher fired, so the normal frontier path is unchanged.
+		cause := state.interruptCause()
+		if cause == causeNone && state.frontier != nil {
 			fr := state.frontier
 			id := fmt.Sprintf("cj-%d-%d", p.counter.Add(1), fr.idx)
 			out <- providers.Event{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: id, Name: fr.name, Input: fr.input}}
 			out <- providers.Event{Type: providers.EventDone, StopReason: "tool_use", Usage: zeroUsage()}
 			return
 		}
-		out <- errorEvent(p.classifyRunErr(state, ctx, err, "run", total))
+		out <- errorEvent(p.classifyRunErr(state, ctx, cause, err, "run", total))
 		return
 	}
 
@@ -229,17 +236,27 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 }
 
 // classifyRunErr maps a non-frontier run() error to a code-agent error string.
-// total is the effective configured wall-clock budget (per-run/per-agent
-// override or the global default) — surfaced in the timeout message.
-func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, err error, where string, total time.Duration) string {
+// cause is interruptWatch's authoritative stop reason (causeNone unless the
+// watcher interrupted the runtime); total is the effective configured
+// wall-clock budget (per-run/per-agent override or the global default),
+// surfaced in the timeout message. Divergence is checked first because it is a
+// determinism bug the operator must fix and is more actionable than "it timed
+// out"; the watcher cause is preferred over ctx.Err() so a budget timeout that
+// coincides with a parent cancel is not misreported as a cancellation.
+func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, cause interruptCause, err error, where string, total time.Duration) string {
 	switch {
 	case state.diverged != nil:
 		d := state.diverged
 		return fmt.Sprintf("code_agent_replay_divergence: tool call #%d was %q on a prior turn but %q on replay — non-deterministic control flow; set LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1 or remove unhooked non-determinism", d.idx, d.expected, d.got)
-	case ctx.Err() != nil:
+	case cause == causeCancel:
 		// Parent/operator cancellation (the ctx.Done branch of interruptWatch).
-		return "code_agent_cancelled: " + ctx.Err().Error()
-	case state.timedOut.Load():
+		// ctx.Err() is non-nil here since that branch only fires after ctx.Done.
+		msg := "canceled"
+		if e := ctx.Err(); e != nil {
+			msg = e.Error()
+		}
+		return "code_agent_cancelled: " + msg
+	case cause == causeTimeout:
 		// Whole-run wall-clock budget elapsed (the timer branch of
 		// interruptWatch). This is NOT a throw at `where` — the replay was
 		// merely interrupted there — so attribute no source line. For a
@@ -266,13 +283,17 @@ func (p *Provider) interruptWatch(ctx context.Context, state *replayState, stop 
 	defer timer.Stop()
 	select {
 	case <-ctx.Done():
+		// Record the cause BEFORE the interrupt so the runtime goroutine sees
+		// it the instant run() returns the interrupt error. Distinct from the
+		// timer branch so a budget timeout is never misreported as a cancel.
+		state.cause.Store(int32(causeCancel))
 		state.rt.Interrupt(ctx.Err())
 	case <-timer.C:
-		// Whole-run wall-clock budget elapsed — flag it BEFORE the interrupt
-		// so classifyRunErr reports code_agent_timeout (not code_agent_threw
-		// at whatever line the replay was interrupted). Distinct from the
-		// ctx.Done() branch above (operator/parent cancellation).
-		state.timedOut.Store(true)
+		// Whole-run wall-clock budget elapsed — record it BEFORE the interrupt
+		// so classifyRunErr reports code_agent_timeout (not code_agent_threw at
+		// whatever line the replay was interrupted, and not a tool_use if the
+		// run reached a frontier in the same instant).
+		state.cause.Store(int32(causeTimeout))
 		state.rt.Interrupt(context.DeadlineExceeded)
 	case <-stop:
 	}

--- a/internal/providers/codejs/replay.go
+++ b/internal/providers/codejs/replay.go
@@ -2,6 +2,7 @@ package codejs
 
 import (
 	"encoding/json"
+	"sync/atomic"
 
 	"github.com/dop251/goja"
 
@@ -54,6 +55,14 @@ type replayState struct {
 
 	frontier *frontierStop     // set when run() reaches an un-recorded call
 	diverged *replayDivergence // set when the replayed sequence mismatches
+
+	// timedOut is set by interruptWatch's budget-timer branch (NOT the
+	// ctx-cancel branch) before it rt.Interrupt(s) the runtime, so
+	// classifyRunErr can attribute a whole-run wall-clock timeout to a
+	// distinct code_agent_timeout class instead of blaming whichever
+	// innocent line the replay happened to be interrupted at. Written on the
+	// interruptWatch goroutine, read on the runtime goroutine → atomic.
+	timedOut atomic.Bool
 }
 
 // emit is the toolEmitter the bindings call for every JS tool invocation.

--- a/internal/providers/codejs/replay.go
+++ b/internal/providers/codejs/replay.go
@@ -56,14 +56,31 @@ type replayState struct {
 	frontier *frontierStop     // set when run() reaches an un-recorded call
 	diverged *replayDivergence // set when the replayed sequence mismatches
 
-	// timedOut is set by interruptWatch's budget-timer branch (NOT the
-	// ctx-cancel branch) before it rt.Interrupt(s) the runtime, so
-	// classifyRunErr can attribute a whole-run wall-clock timeout to a
-	// distinct code_agent_timeout class instead of blaming whichever
-	// innocent line the replay happened to be interrupted at. Written on the
-	// interruptWatch goroutine, read on the runtime goroutine → atomic.
-	timedOut atomic.Bool
+	// cause records WHY interruptWatch stopped the runtime — it is the single
+	// authoritative signal for the stop reason, set on the watch goroutine
+	// immediately before rt.Interrupt and read on the runtime goroutine after
+	// run() returns the interrupt error. Both classifyRunErr AND the frontier
+	// check branch on it instead of re-deriving the cause: deriving from
+	// ctx.Err() races the timer (a genuine budget timeout coinciding with a
+	// parent cancel would misreport as cancelled), and a coincident timeout
+	// would otherwise be masked by state.frontier (the run would dispatch one
+	// more tool call past its deadline). atomic — crosses the two goroutines.
+	cause atomic.Int32
 }
+
+// interruptCause enumerates why interruptWatch stopped the runtime. causeNone
+// means the watcher did not fire: run() finished, or was interrupted by a
+// frontier / divergence (both set their own state fields).
+type interruptCause int32
+
+const (
+	causeNone    interruptCause = iota
+	causeCancel                 // ctx cancelled (operator/parent)
+	causeTimeout                // whole-run wall-clock budget elapsed
+)
+
+// interruptCause reads the authoritative stop reason set by interruptWatch.
+func (s *replayState) interruptCause() interruptCause { return interruptCause(s.cause.Load()) }
 
 // emit is the toolEmitter the bindings call for every JS tool invocation.
 // It either fast-forwards a recorded result, or stops at the frontier — both

--- a/internal/providers/codejs/timeout_test.go
+++ b/internal/providers/codejs/timeout_test.go
@@ -1,0 +1,72 @@
+package codejs
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// runErr drives a single Call with the given RunMeta and returns the EventError
+// text (empty if the run produced none). Unlike runOnce it does not fail on an
+// error — these tests assert on the error classification.
+func runErr(t *testing.T, p *Provider, meta providers.RunMeta) string {
+	t.Helper()
+	ctx := providers.WithRunMeta(context.Background(), meta)
+	ch, err := p.Call(ctx, providers.Request{
+		Model:    "code-js",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var errText string
+	for ev := range ch {
+		if ev.Type == providers.EventError {
+			errText = ev.Error
+		}
+	}
+	return errText
+}
+
+// TestCodeJS_BudgetTimeout_ClassifiedAsTimeout pins the review fix: a whole-run
+// wall-clock budget exhaustion is reported as code_agent_timeout (with the
+// budget, no source line), NOT code_agent_threw at whatever line the replay was
+// interrupted. Drives it by stamping StartedAt in the past so the resume turn
+// starts already over budget; the CPU loop is then interrupted by the timer.
+func TestCodeJS_BudgetTimeout_ClassifiedAsTimeout(t *testing.T) {
+	root := writeAgent(t, "spin", `function run(){ while(true){} }`)
+	p := New(Config{CodeRoot: root, RunTimeout: 5 * time.Second})
+
+	got := runErr(t, p, providers.RunMeta{
+		AgentName: "spin",
+		StartedAt: time.Now().Add(-10 * time.Second), // already past the 5s budget
+	})
+	if !strings.HasPrefix(got, "code_agent_timeout:") {
+		t.Fatalf("budget exhaustion must classify as code_agent_timeout; got %q", got)
+	}
+	if strings.Contains(got, "code_agent_threw") || strings.Contains(got, "index.js:") {
+		t.Errorf("timeout must not be reported as a throw at a source line; got %q", got)
+	}
+}
+
+// TestCodeJS_RunTimeoutOverride_ExtendsBudget pins that RunMeta.RunTimeoutSeconds
+// overrides the global default: with a tiny global but a large per-run override,
+// a run that would be over-budget under the global completes instead.
+func TestCodeJS_RunTimeoutOverride_ExtendsBudget(t *testing.T) {
+	root := writeAgent(t, "quick", `function run(){ return {final_text:"done"}; }`)
+	p := New(Config{CodeRoot: root, RunTimeout: time.Millisecond}) // tiny global
+
+	// StartedAt 10s ago: under the 1ms global the budget is already < 0 (timeout);
+	// the 3600s override gives ~3590s of headroom, so the run completes.
+	got := runErr(t, p, providers.RunMeta{
+		AgentName:         "quick",
+		StartedAt:         time.Now().Add(-10 * time.Second),
+		RunTimeoutSeconds: 3600,
+	})
+	if got != "" {
+		t.Fatalf("per-run override should extend the budget so the run completes; got error %q", got)
+	}
+}

--- a/internal/providers/codejs/timeout_test.go
+++ b/internal/providers/codejs/timeout_test.go
@@ -52,6 +52,41 @@ func TestCodeJS_BudgetTimeout_ClassifiedAsTimeout(t *testing.T) {
 	}
 }
 
+// TestCodeJS_CtxCancel_ClassifiedAsCancelled pins the cause-based
+// classification: a parent/operator ctx cancellation is reported as
+// code_agent_cancelled, NOT code_agent_timeout. With the budget far in the
+// future, only interruptWatch's ctx.Done branch can fire, so cause==causeCancel
+// — this guards the ordering fix that made the watcher cause (not a racy
+// ctx.Err() read) authoritative for the stop reason.
+func TestCodeJS_CtxCancel_ClassifiedAsCancelled(t *testing.T) {
+	root := writeAgent(t, "spin", `function run(){ while(true){} }`)
+	p := New(Config{CodeRoot: root, RunTimeout: time.Hour}) // huge budget ⇒ timer never fires
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancelled: interruptWatch's ctx.Done branch interrupts the spin loop
+	ctx = providers.WithRunMeta(ctx, providers.RunMeta{AgentName: "spin", StartedAt: time.Now()})
+
+	ch, err := p.Call(ctx, providers.Request{
+		Model:    "code-js",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "go"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var got string
+	for ev := range ch {
+		if ev.Type == providers.EventError {
+			got = ev.Error
+		}
+	}
+	if !strings.HasPrefix(got, "code_agent_cancelled:") {
+		t.Fatalf("ctx cancel must classify as code_agent_cancelled; got %q", got)
+	}
+	if strings.Contains(got, "code_agent_timeout") {
+		t.Errorf("a cancel must not be reported as a budget timeout; got %q", got)
+	}
+}
+
 // TestCodeJS_RunTimeoutOverride_ExtendsBudget pins that RunMeta.RunTimeoutSeconds
 // overrides the global default: with a tiny global but a large per-run override,
 // a run that would be over-budget under the global completes instead.

--- a/internal/providers/runmeta.go
+++ b/internal/providers/runmeta.go
@@ -53,6 +53,14 @@ type RunMeta struct {
 	// into prompt segments instead. Credentials remain deliberately ABSENT.
 	Metadata        map[string]any
 	PayloadMetadata map[string]any
+
+	// RunTimeoutSeconds is the effective per-run/per-agent wall-clock budget
+	// override for a code-js run (resolved server-side: per-run wins over
+	// per-agent). 0 ⇒ the code-js provider uses its global default
+	// (LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS). Lets a fan-out orchestrator
+	// that blocks in Agent.parallel_spawn carry a long envelope without
+	// raising the global for every code agent. LLM drivers ignore it.
+	RunTimeoutSeconds int
 }
 
 type ctxKeyRunMeta struct{}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -221,6 +221,14 @@ type RunInput struct {
 	// <run_metadata> untrusted block. Server-populated only; never a wire
 	// field on /v1/runs (a first-party caller's data is trusted → Metadata).
 	PayloadMetadata map[string]any
+
+	// RunTimeoutSeconds is an optional per-run wall-clock budget override for
+	// a code-js agent (the ad-hoc /v1/runs knob). 0 ⇒ inherit the agent's
+	// run_timeout_seconds, else the global default. The server resolves
+	// per-run > per-agent and passes the winner to loop.RunOptions; only the
+	// code-js provider consumes it (LLM runs are bounded by MaxIterations +
+	// provider HTTP timeouts, not this budget).
+	RunTimeoutSeconds int
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -717,8 +717,11 @@ type mergedDef struct {
 	// use the runtime default (DefaultMaxConcurrentChildren = 4).
 	// Sequential Agent.spawn calls are unaffected; the cap only
 	// applies to a single parallel_spawn op's `spawns` array.
-	MaxConcurrentChildren int    `json:"max_concurrent_children,omitempty"`
-	SystemPrompt          string `json:"system_prompt,omitempty"`
+	MaxConcurrentChildren int `json:"max_concurrent_children,omitempty"`
+	// RunTimeoutSeconds is the per-agent code-js wall-clock budget (RFC J),
+	// overriding the global default. 0 = global. See config.AgentDef.
+	RunTimeoutSeconds int    `json:"run_timeout_seconds,omitempty"`
+	SystemPrompt      string `json:"system_prompt,omitempty"`
 	// SystemPromptBase is the pre-skill-bake snapshot of SystemPrompt.
 	// Persisted alongside SystemPrompt so the v0.8.22 SkillDef per-run
 	// resolver (`resolveSkillBodiesForRun` in api/http/server.go) can
@@ -776,6 +779,9 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	}
 	if ov.MaxConcurrentChildren != 0 {
 		d.MaxConcurrentChildren = ov.MaxConcurrentChildren
+	}
+	if ov.RunTimeoutSeconds != 0 {
+		d.RunTimeoutSeconds = ov.RunTimeoutSeconds
 	}
 	if ov.SystemPrompt != "" {
 		d.SystemPrompt = ov.SystemPrompt
@@ -843,6 +849,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,
+		RunTimeoutSeconds:     s.RunTimeoutSeconds,
 		SystemPrompt:          s.SystemPrompt,
 		SystemPromptBase:      s.SystemPromptBase,
 		AllowedTools:          s.AllowedTools,


### PR DESCRIPTION
Fixes the misclassified code-js wall-clock timeout you found (the `parseBatch:117` red herring) and the structural "120s is too low for a fan-out orchestrator" tension. Off `main`, not stacked.

## Diagnosis (confirmed in code)

A code-js run is a sequence of replay turns; the budget is **whole-run wall-clock from `StartedAt`** and keeps ticking while the orchestrator is parked in `Agent.parallel_spawn` awaiting LLM children. So a resume turn starts over-budget and `interruptWatch`'s **timer** branch fires `rt.Interrupt(context.DeadlineExceeded)` — but it does **not** cancel the parent ctx, so `classifyRunErr` (which only special-cased `ctx.Err()!=nil`) fell through to `code_agent_threw: run: context deadline exceeded at <whatever line the replay was interrupted>`. Hence the innocent `parseBatch` location.

## Fix

1. **`code_agent_timeout` class.** `interruptWatch`'s timer branch sets `replayState.timedOut` (atomic) before the interrupt; `classifyRunErr` emits a distinct `code_agent_timeout` that states the budget and attributes **no source line** — separate from `code_agent_cancelled` (parent ctx) and `code_agent_threw` (real exception). The message points at the override knobs.
2. **Per-agent + per-run override** (precedence **per-run > per-agent > global**):
   - per-agent `run_timeout_seconds` on `config.AgentDef` (+ `mergedDef`/`SubstrateAgentDef`/`ToConfigDef`). Operational, **not** in `content_sha256` — mirrors `RetryAttempts` (so no `agents.Agent`/CLI hash mirror needed; drift `want` map updated).
   - per-run `run_timeout_seconds` on `POST /v1/runs` + `/v1/sessions/{id}/messages`.
   - Resolved server-side (`pickRunTimeout`), threaded `RunInput → RunOptions → RunMeta`; the code-js provider's budget uses the effective value, else the global `LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS`.
3. **Docs** — the env-field doc + code-agents help topic now state the budget spans the `Agent.parallel_spawn` dispatch gap and how to raise it per-agent/per-run.
4. **TS** — `RunOptions`/`ContinueOptions` gain `runTimeoutSeconds` (no version bump per your hold).

## Tested

Fail-before verified by neutering the `timedOut` case — the bug's exact `code_agent_threw: run: context deadline exceeded at run (spin:1:1(1))` reproduces. `TestCodeJS_BudgetTimeout_ClassifiedAsTimeout`, `_RunTimeoutOverride_ExtendsBudget`, `TestPickRunTimeout`; drift map updated. `go test ./...`, vet, gofmt, `npm typecheck && npm test` (192) all clean.

## Notes
- **Overlaps the open #358** in `server.go` (the `injectMetadataSegments` area) + `metadata_segments_test.go`. The edits are on different lines (a new `RunTimeoutSeconds` field / `pickRunTimeout` helper vs #358's signature change), so a 3-way merge should auto-resolve; if not, merge one and rebase the other.
- **Deferred:** per-run `run_timeout` via the gRPC / LoomCycle-MCP `spawn_run` connector (overlaps #358's connector changes — add a tiny follow-up after #358 lands). Per-agent already covers connector-spawned orchestrators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)