### PR TITLE
feat(authz): tenant-scope the agent definition plane (RFC N, agents slice)

### DIFF
--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -35,9 +36,16 @@ const (
 // future RPC reusing it would silently default-deny without these
 // grants. Keep symmetric with operatorCtx / substrateAdminCtx.
 func substrateGRPCCtx(ctx context.Context) context.Context {
+	// RFC N tenant invariant: tenant from the authoritative principal the
+	// gRPC interceptor stamped on ctx, NEVER the wire. Mirrors HTTP
+	// substrateAdminCtx — without carrying TenantID the def-tools stamp
+	// every gRPC-admin-registered def into the shared "" tenant. Zero
+	// value "" when no principal → shared tenant (correct single-tenant).
+	principal, _ := auth.PrincipalFromContext(ctx)
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
-		UserID:  grpcSubstrateAdminUserID,
-		AgentID: grpcSubstrateAdminAgentID,
+		UserID:   grpcSubstrateAdminUserID,
+		AgentID:  grpcSubstrateAdminAgentID,
+		TenantID: principal.TenantID,
 	})
 	ctx = tools.WithAgentName(ctx, grpcSubstrateAdminAgentName)
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -11,6 +11,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/webui"
 )
 
@@ -345,6 +346,30 @@ func (s *Server) principalTenantScope(ctx context.Context, wireTenant string) (t
 		log.Printf("auth: tenant_scope_overridden wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)
 	}
 	return p.TenantID, false
+}
+
+// tenantFromCtx resolves the authoritative tenant for definition-plane
+// resolution + write-stamping (RFC N), mirroring applyPrincipal's
+// authority model:
+//
+//  1. auth.PrincipalFromContext(ctx).TenantID — the bearer-derived
+//     principal stamped by the auth middleware (the floor on authed
+//     routes).
+//  2. tools.RunIdentity(ctx).TenantID — the run's effective tenant,
+//     carried in ctx for in-loop callers (sub-agent spawn, tool
+//     dispatch) where no HTTP principal is present but the parent run's
+//     tenant flows via RunIdentity. Sub-agents inherit it unchanged.
+//  3. "" — the shared/default/legacy tenant (open mode / un-authed
+//     internal paths).
+//
+// NEVER derived from a wire/request body field or model-generated text —
+// the tenant boundary is caller/config-authoritative (the same posture
+// RFC L's applyPrincipal enforces for run stamping).
+func tenantFromCtx(ctx context.Context) string {
+	if p, ok := auth.PrincipalFromContext(ctx); ok && p.TenantID != "" {
+		return p.TenantID
+	}
+	return tools.RunIdentity(ctx).TenantID
 }
 
 // tenantVisible reports whether the caller may read a row belonging to

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -282,6 +282,12 @@ func (s *Server) RegisterAgent(ctx context.Context, req connector.RegisterAgentR
 		CreatedAt:   createdAt,
 		ExpiresAt:   expiresAt,
 		Description: req.Description,
+		// RFC N: stamp the tenant from the authoritative principal in ctx
+		// (RegisterAgentRequest carries no tenant — never trust the wire).
+		// "" = shared/legacy tenant. Scopes the dynamic registration to
+		// the registering principal's tenant so it can't clobber another
+		// tenant's same-named agent.
+		TenantID: tenantFromCtx(ctx),
 	}
 	if err := s.store.DynamicAgentUpsert(ctx, row); err != nil {
 		return connector.AgentDescriptor{}, err

--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -104,7 +104,7 @@ func TestLibrary_AgentDefNames_AfterSeed(t *testing.T) {
 	}
 	_ = r2
 	_ = s.AgentDefSetRetired(ctx, "def_researcher_v1", true)
-	_ = s.AgentDefSetActive(ctx, "researcher", "def_researcher_v2", "")
+	_ = s.AgentDefSetActive(ctx, "", "researcher", "def_researcher_v2", "")
 	sum1, err := s.AgentDefCreate(ctx, store.AgentDefRow{
 		DefID: "def_summariser_v1", Name: "summariser", Version: 1,
 		Definition: []byte(`{"system":"sum"}`), CreatedAt: time.Now(),
@@ -113,7 +113,7 @@ func TestLibrary_AgentDefNames_AfterSeed(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = sum1
-	_ = s.AgentDefSetActive(ctx, "summariser", "def_summariser_v1", "")
+	_ = s.AgentDefSetActive(ctx, "", "summariser", "def_summariser_v1", "")
 
 	req := authedRequest("GET", "/v1/_agentdef/names", nil)
 	rec := httptest.NewRecorder()

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -150,7 +150,7 @@ func TestUnifiedLibrary_Agents_DynamicOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = s.AgentDefSetActive(ctx, "evaluator", "def_evaluator_v1", "")
+	_ = s.AgentDefSetActive(ctx, "", "evaluator", "def_evaluator_v1", "")
 
 	rec := httptest.NewRecorder()
 	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
@@ -188,7 +188,7 @@ func TestUnifiedLibrary_Agents_Both(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = s.AgentDefSetActive(ctx, "researcher", "def_r_v1", "")
+	_ = s.AgentDefSetActive(ctx, "", "researcher", "def_r_v1", "")
 
 	rec := httptest.NewRecorder()
 	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_library/agents", nil))
@@ -341,7 +341,7 @@ func TestUnifiedLibrary_OldEndpoints_StillWork(t *testing.T) {
 		DefID: "def_v1", Name: "x", Version: 1,
 		Definition: []byte(`{}`), CreatedAt: time.Now(),
 	})
-	_ = s.AgentDefSetActive(ctx, "x", "def_v1", "")
+	_ = s.AgentDefSetActive(ctx, "", "x", "def_v1", "")
 
 	rec := httptest.NewRecorder()
 	srv.Mux().ServeHTTP(rec, authedRequest("GET", "/v1/_agentdef/names", nil))

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -775,7 +775,9 @@ func writeQuotaError(w http.ResponseWriter, err error) {
 // overlay (v0.7.x behaviour). Unknown names are rejected upstream
 // before this is called.
 func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, effort string, err error) {
-	def, ok := s.lookupAgent(context.Background(), agentName)
+	// Boot/background resolution carries no run tenant — use the ctx
+	// tenant (empty here, since context.Background()) → shared/default.
+	def, ok := s.lookupAgent(context.Background(), tenantFromCtx(context.Background()), agentName)
 	if !ok {
 		return "", "", "", fmt.Errorf("%w: %s", runner.ErrUnknownAgent, agentName)
 	}
@@ -792,12 +794,18 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 // inline lookup, AND the v0.9.x lookups that silently skipped the
 // boot-time normalizer chain (PRs #184 + #186). Every code path
 // that needs an agent name → def goes through here.
-func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef, bool) {
-	// RFC N: derive the tenant from the authoritative principal in ctx
-	// (never the wire), so a token can only resolve agents within its
-	// own tenant + the shared base. Callers keep their signature — the
-	// tenant rides ctx. "" = shared/default/legacy tenant.
-	tenantID := tenantFromCtx(ctx)
+func (s *Server) lookupAgent(ctx context.Context, tenantID, name string) (config.AgentDef, bool) {
+	// RFC N: tenant is an EXPLICIT argument, not ctx-derived. At the
+	// run-creation entry sites the authoritative tenant is already
+	// computed as effectiveTenantID (via applyPrincipal / the session)
+	// BEFORE WithRunIdentity is stamped on ctx — so for non-HTTP-principal
+	// spawn surfaces (A2A, scheduler, webhook, MCP spawn_run, gRPC-legacy)
+	// tenantFromCtx(ctx) would return the WRONG tenant ("" or the caller's,
+	// not the run's) and the entry agent would resolve at the wrong tenant
+	// while memory + sub-agents use effectiveTenantID. Callers that already
+	// run with RunIdentity on ctx (sub-agents, the Context-tool path, boot)
+	// pass tenantFromCtx(ctx) explicitly to preserve today's behavior.
+	// "" = shared/default/legacy tenant.
 	// nil-store guard at the boundary so the lookup package can
 	// type-assert an interface receiver. The lookup package treats
 	// "no store" identically to "store didn't have the name" — both
@@ -1408,7 +1416,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	if effectiveAgentName == "" {
 		return fmt.Errorf("%w: agent is required", runner.ErrInvalidArgument)
 	}
-	agentDef, ok := s.lookupAgent(ctx, effectiveAgentName)
+	// RFC N: resolve the ENTRY agent at the run's authoritative tenant
+	// (effectiveTenantID), NOT tenantFromCtx(ctx) — WithRunIdentity isn't
+	// stamped until ~line 1500, so for non-HTTP-principal spawn surfaces
+	// the ctx tenant is wrong here.
+	agentDef, ok := s.lookupAgent(ctx, effectiveTenantID, effectiveAgentName)
 	if !ok {
 		return fmt.Errorf("%w: %s", runner.ErrUnknownAgent, effectiveAgentName)
 	}
@@ -2483,7 +2495,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	agentDef, ok := s.lookupAgent(r.Context(), req.Agent)
+	// RFC N: existence-check the agent at this handler's authoritative
+	// tenant. On an authed HTTP route the principal is on ctx, so
+	// tenantFromCtx returns the principal's tenant (the same value
+	// applyPrincipal below resolves into req.TenantID) — never the wire.
+	agentDef, ok := s.lookupAgent(r.Context(), tenantFromCtx(r.Context()), req.Agent)
 	if !ok {
 		http.Error(w, fmt.Sprintf("unknown agent %q", req.Agent), http.StatusBadRequest)
 		return
@@ -2941,7 +2957,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	// Resolve provider+model from the session's stored agent so the
 	// continuation runs against the same model as the original session.
-	agentDef, ok := s.lookupAgent(r.Context(), sess.Agent)
+	// RFC N: resolve at the SESSION's authoritative tenant (the same value
+	// RunOnce uses for a continuation), not tenantFromCtx — the ownership
+	// gate above already proved the caller is entitled to this session.
+	agentDef, ok := s.lookupAgent(r.Context(), sess.TenantID, sess.Agent)
 	if !ok {
 		http.Error(w, fmt.Sprintf("session refers to unknown agent %q", sess.Agent), http.StatusBadRequest)
 		return

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -342,7 +342,9 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		// next call without restart. Returns 0 = no override; the
 		// tool falls back to DefaultMaxConcurrentChildren.
 		CapLookup: func(ctx context.Context, callingAgent string) int {
-			def, ok := lookup.Agent(ctx, s.store, s.cfg, callingAgent)
+			// RFC N: resolve within the calling run's tenant (carried via
+			// ctx RunIdentity for in-loop callers).
+			def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantFromCtx(ctx), callingAgent)
 			if !ok {
 				return 0
 			}
@@ -791,14 +793,19 @@ func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, ef
 // boot-time normalizer chain (PRs #184 + #186). Every code path
 // that needs an agent name → def goes through here.
 func (s *Server) lookupAgent(ctx context.Context, name string) (config.AgentDef, bool) {
+	// RFC N: derive the tenant from the authoritative principal in ctx
+	// (never the wire), so a token can only resolve agents within its
+	// own tenant + the shared base. Callers keep their signature — the
+	// tenant rides ctx. "" = shared/default/legacy tenant.
+	tenantID := tenantFromCtx(ctx)
 	// nil-store guard at the boundary so the lookup package can
 	// type-assert an interface receiver. The lookup package treats
 	// "no store" identically to "store didn't have the name" — both
 	// fall through to (zero, false).
 	if s.store == nil {
-		return lookup.Agent(ctx, nil, s.cfg, name)
+		return lookup.Agent(ctx, nil, s.cfg, tenantID, name)
 	}
-	return lookup.Agent(ctx, s.store, s.cfg, name)
+	return lookup.Agent(ctx, s.store, s.cfg, tenantID, name)
 }
 
 // resolveAgentDef mirrors resolveAgent but takes a caller-supplied
@@ -3536,7 +3543,12 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 // them as IsError tool_results to the parent's model rather than
 // tearing down the parent run.
 func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, defID string) (string, error) {
-	def, ok := lookup.Agent(ctx, s.store, s.cfg, name)
+	// RFC N: a parent in tenant T resolves the sub-agent name within T's
+	// view (parent tenant flows via ctx RunIdentity, inherited by every
+	// sub-agent). Confirms RFC N's open-question on cross-boundary spawn:
+	// the lookup is tenant-scoped, so a parent cannot spawn another
+	// tenant's private agent by name.
+	def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantFromCtx(ctx), name)
 	if !ok {
 		return "", fmt.Errorf("unknown sub-agent %q (not in cfg.Agents, dynamic_agents, or agent_def_active)", name)
 	}

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1808,7 +1808,7 @@ func TestLookupAgent_FallsThroughToSubstrate(t *testing.T) {
 	if _, err := st.AgentDefCreate(ctx, row); err != nil {
 		t.Fatalf("AgentDefCreate: %v", err)
 	}
-	if err := st.AgentDefSetActive(ctx, "substrate-only-agent", "def_test_substrate", "a_test"); err != nil {
+	if err := st.AgentDefSetActive(ctx, "", "substrate-only-agent", "def_test_substrate", "a_test"); err != nil {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 
@@ -1871,7 +1871,7 @@ func TestLookupAgent_DynamicAgentsStillWins(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("AgentDefCreate: %v", err)
 	}
-	if err := st.AgentDefSetActive(ctx, "shared-name", "def_shared", "a_test"); err != nil {
+	if err := st.AgentDefSetActive(ctx, "", "shared-name", "def_shared", "a_test"); err != nil {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 
@@ -1917,7 +1917,7 @@ func TestLookupAgent_SystemPromptBaseSetFromSubstrate(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("AgentDefCreate: %v", err)
 	}
-	if err := st.AgentDefSetActive(ctx, "ats-filter", "def_substrate_ats", "a_test"); err != nil {
+	if err := st.AgentDefSetActive(ctx, "", "ats-filter", "def_substrate_ats", "a_test"); err != nil {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -1815,7 +1815,7 @@ func TestLookupAgent_FallsThroughToSubstrate(t *testing.T) {
 	// Before this PR, lookupAgent only consulted dynamic_agents (empty)
 	// and returned (zero, false). After this PR it falls through to
 	// AgentDefGetActive and resolves.
-	def, ok := srv.lookupAgent(ctx, "substrate-only-agent")
+	def, ok := srv.lookupAgent(ctx, "", "substrate-only-agent")
 	if !ok {
 		t.Fatal("lookupAgent returned ok=false; expected substrate fall-through to resolve the agent")
 	}
@@ -1875,7 +1875,7 @@ func TestLookupAgent_DynamicAgentsStillWins(t *testing.T) {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 
-	def, ok := srv.lookupAgent(ctx, "shared-name")
+	def, ok := srv.lookupAgent(ctx, "", "shared-name")
 	if !ok {
 		t.Fatal("lookupAgent returned ok=false; want ok=true")
 	}
@@ -1921,7 +1921,7 @@ func TestLookupAgent_SystemPromptBaseSetFromSubstrate(t *testing.T) {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 
-	def, ok := srv.lookupAgent(ctx, "ats-filter")
+	def, ok := srv.lookupAgent(ctx, "", "ats-filter")
 	if !ok {
 		t.Fatal("lookupAgent returned ok=false")
 	}
@@ -1931,6 +1931,61 @@ func TestLookupAgent_SystemPromptBaseSetFromSubstrate(t *testing.T) {
 	// THE invariant this test exists to pin.
 	if def.SystemPromptBase != agentBody {
 		t.Errorf("SystemPromptBase = %q, want it set to SystemPrompt %q so resolveSkillBodiesForRun rebuilds from the agent's actual body, not an empty string", def.SystemPromptBase, agentBody)
+	}
+}
+
+// TestLookupAgent_ResolvesExplicitTenantWithoutPrincipalOnCtx — RFC N
+// FIX 2 regression. A non-HTTP-principal spawn surface (A2A / scheduler /
+// webhook / MCP spawn_run / gRPC-legacy) computes the run's authoritative
+// tenant as effectiveTenantID and passes it EXPLICITLY to lookupAgent,
+// with NO auth.Principal on ctx and WithRunIdentity not yet stamped. The
+// entry agent MUST resolve at the run's tenant T, not at "".
+//
+// Pre-fix, lookupAgent derived the tenant from tenantFromCtx(ctx) which —
+// with no principal and no RunIdentity — returns "", so the entry agent
+// resolved at the SHARED tenant while memory + sub-agents used T. This
+// test fails on the unfixed signature (it wouldn't compile against the
+// old ctx-only lookupAgent, and semantically would resolve "" not T).
+func TestLookupAgent_ResolvesExplicitTenantWithoutPrincipalOnCtx(t *testing.T) {
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), st)
+	ctx := context.Background() // NO principal, NO RunIdentity (A2A/scheduler shape)
+
+	// Seed "report-agent" ONLY under tenant "acme" — not the shared "" tenant.
+	defJSON, _ := json.Marshal(map[string]any{
+		"system_prompt": "acme tenant body",
+		"allowed_tools": []string{"Read"},
+	})
+	if _, err := st.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID: "def_acme_report", Name: "report-agent", Definition: defJSON, TenantID: "acme",
+	}); err != nil {
+		t.Fatalf("AgentDefCreate: %v", err)
+	}
+	if err := st.AgentDefSetActive(ctx, "acme", "report-agent", "def_acme_report", "a_test"); err != nil {
+		t.Fatalf("AgentDefSetActive: %v", err)
+	}
+
+	// Explicit tenant "acme" resolves the acme-only agent.
+	def, ok := srv.lookupAgent(ctx, "acme", "report-agent")
+	if !ok {
+		t.Fatal("lookupAgent(acme) returned ok=false; the run's authoritative tenant must resolve its own agent even with no principal/RunIdentity on ctx")
+	}
+	if def.SystemPrompt != "acme tenant body" {
+		t.Errorf("SystemPrompt = %q, want acme tenant body", def.SystemPrompt)
+	}
+
+	// The same name resolved at the SHARED tenant "" must NOT find it —
+	// proving the tenant argument (not a ctx default) is what selects the row.
+	if _, ok := srv.lookupAgent(ctx, "", "report-agent"); ok {
+		t.Error("lookupAgent(\"\") resolved an acme-only agent; tenant isolation breached")
 	}
 }
 
@@ -1964,7 +2019,7 @@ func TestLookupAgent_SystemPromptBaseSetFromDynamic(t *testing.T) {
 		t.Fatalf("DynamicAgentUpsert: %v", err)
 	}
 
-	def, ok := srv.lookupAgent(ctx, "legacy-with-skills")
+	def, ok := srv.lookupAgent(ctx, "", "legacy-with-skills")
 	if !ok {
 		t.Fatal("lookupAgent returned ok=false")
 	}

--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -160,9 +161,18 @@ func (s *Server) dispatchSubstrate(
 // would silently default-deny without these grants. Keep them
 // symmetric with operatorCtx so the helper stays safe to extend.
 func substrateAdminCtx(ctx context.Context) context.Context {
+	// RFC N tenant invariant: the tenant comes from the authoritative
+	// principal the auth middleware stamped on ctx, NEVER the wire. The
+	// def-tools read tools.RunIdentity(ctx).TenantID to stamp the row's
+	// tenant_id; without carrying it here every admin-registered def
+	// lands in the shared "" tenant regardless of the caller. Zero value
+	// "" when no principal (legacy LOOMCYCLE_AUTH_TOKEN / open mode) →
+	// shared tenant, which is the correct single-tenant behavior.
+	principal, _ := auth.PrincipalFromContext(ctx)
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
-		UserID:  substrateAdminUserID,
-		AgentID: substrateAdminAgentID,
+		UserID:   substrateAdminUserID,
+		AgentID:  substrateAdminAgentID,
+		TenantID: principal.TenantID,
 	})
 	ctx = tools.WithAgentName(ctx, substrateAdminAgentName)
 	// AgentTools wildcard: substrate admin = operator trust. Without

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,9 +11,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -348,6 +351,100 @@ func TestSubstrateAdmin_ScheduleDef_NotConfigured(t *testing.T) {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Errorf("status = %d, want 500; body=%s", resp.StatusCode, raw)
 	}
+}
+
+// TestSubstrateAdmin_AgentDef_StampsPrincipalTenant — RFC N FIX 1
+// regression. substrateAdminCtx must carry the authoritative principal's
+// TenantID onto the RunIdentity it stamps; the AgentDef tool reads that to
+// stamp the agent_defs row's tenant_id. Pre-fix, substrateAdminCtx built a
+// RunIdentityValue with NO TenantID, so EVERY admin-registered def landed in
+// the shared "" tenant regardless of which tenant's token drove the call.
+//
+// Drives two cases end-to-end through POST /v1/_agentdef:
+//   - a principal with TenantID="acme" → row tenant_id="acme".
+//   - NO principal (open mode: no auth configured) → row tenant_id="".
+//
+// Pre-fix, the acme case fails (row tenant_id=="" not "acme").
+func TestSubstrateAdmin_AgentDef_StampsPrincipalTenant(t *testing.T) {
+	// rowTenant reads the agent_defs row's tenant_id straight from the DB.
+	// AgentDefListByName returns the AgentDefRow (which carries TenantID).
+	rowTenant := func(t *testing.T, st *sqlite.Store, name string) string {
+		t.Helper()
+		rows, err := st.AgentDefListByName(context.Background(), name)
+		if err != nil {
+			t.Fatalf("AgentDefListByName: %v", err)
+		}
+		if len(rows) == 0 {
+			t.Fatalf("no agent_defs row for %q", name)
+		}
+		return rows[0].TenantID
+	}
+	create := func(t *testing.T, ts *httptest.Server, bearer, name string) {
+		t.Helper()
+		req, _ := http.NewRequest("POST", ts.URL+"/v1/_agentdef",
+			bytes.NewReader([]byte(`{"op":"create","name":"`+name+`","overlay":{"system_prompt":"hi"}}`)))
+		if bearer != "" {
+			req.Header.Set("Authorization", "Bearer "+bearer)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("create %q status = %d, want 200; body=%s", name, resp.StatusCode, raw)
+		}
+	}
+	newSrv := func(t *testing.T, withAuth bool) (*httptest.Server, *sqlite.Store, *config.Config) {
+		t.Helper()
+		st, err := sqlite.Open(":memory:")
+		if err != nil {
+			t.Fatalf("sqlite.Open: %v", err)
+		}
+		t.Cleanup(func() { _ = st.Close() })
+		cfg := &config.Config{
+			Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+		}
+		if withAuth {
+			cfg.Env.AuthToken = "base-token"
+		}
+		agentDefTool := &builtin.AgentDef{Cfg: cfg, Store: st}
+		srv := New(cfg, &stubResolver{}, []tools.Tool{agentDefTool}, concurrency.New(1, 1, time.Second), st)
+		ts := httptest.NewServer(srv.Mux())
+		t.Cleanup(ts.Close)
+		return ts, st, cfg
+	}
+
+	// Case 1: principal with TenantID="acme" → row tenant_id="acme".
+	t.Run("acme_principal", func(t *testing.T) {
+		ts, st, cfg := newSrv(t, true)
+		hash := auth.HashToken(cfg.Env.OperatorTokenPepper, "acme-token")
+		if _, err := st.OperatorTokenDefCreate(context.Background(), store.OperatorTokenDefRow{
+			DefID:         "tok_acme",
+			Name:          "acme-admin",
+			TenantID:      "acme",
+			Subject:       "alice",
+			TokenHash:     hash,
+			AllowedScopes: []string{auth.ScopeAdmin},
+		}); err != nil {
+			t.Fatalf("OperatorTokenDefCreate: %v", err)
+		}
+		create(t, ts, "acme-token", "acme-agent")
+		if got := rowTenant(t, st, "acme-agent"); got != "acme" {
+			t.Errorf("agent_defs row tenant_id=%q, want \"acme\" (substrateAdminCtx dropped the principal tenant)", got)
+		}
+	})
+
+	// Case 2: no principal (open mode) → row tenant_id="".
+	t.Run("no_principal", func(t *testing.T) {
+		ts, st, _ := newSrv(t, false) // open mode: no AuthToken, no token rows
+		create(t, ts, "", "open-agent")
+		if got := rowTenant(t, st, "open-agent"); got != "" {
+			t.Errorf("agent_defs row tenant_id=%q, want \"\" (no principal → shared tenant)", got)
+		}
+	})
 }
 
 func postAdmin(t *testing.T, ts *httptest.Server, path, body string) *http.Response {

--- a/internal/lookup/README.md
+++ b/internal/lookup/README.md
@@ -26,10 +26,30 @@ This package consolidates the lookup chain + the normalizer chain + the adapter 
 Every code path that needs to resolve an agent / skill / MCP server NAME to its effective runtime def should go through this package:
 
 ```go
-def, ok := lookup.Agent(ctx, s.store, s.cfg, name)
+def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantID, name)
 sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, name)
 spec, ok := lookup.MCPServer(s.cfg, dynRegistry, name)
 ```
+
+### Agent resolution precedence (RFC N — tenant axis)
+
+`lookup.Agent` resolves within the caller's `tenantID`:
+
+1. **(tenantID != "")** tenant-scoped dynamic — `dynamic_agents` then
+   `agent_def_active`, both `WHERE tenant_id=tenantID`. A per-tenant
+   registration *shadows* the shared static base by name.
+2. **static `cfg.Agents`** — the shared operator base every tenant inherits.
+3. **shared dynamic** — `dynamic_agents` then `agent_def_active`,
+   `tenant_id=""`.
+
+For the default tenant `""`, step 1 is skipped, so the order collapses to
+**static-cfg → shared-dynamic** — byte-for-byte the pre-RFC-N behavior. A
+single-tenant deployment (everything `tenant_id=""`) is unchanged. The
+`tenantID` MUST come from the authoritative principal in ctx
+(`auth.PrincipalFromContext` → `tools.RunIdentity` fallback → `""`), never
+from a wire/request field — see `internal/api/http/server.go`'s
+`tenantFromCtx`. (Skills + MCP servers still resolve globally; their tenant
+axis is a follow-up.)
 
 Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` + `TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef`) — a future field added to one shape without the other fails CI.
 

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -1,9 +1,11 @@
 // Package lookup is the canonical seam for resolving an agent / skill
 // / MCP server NAME to its effective runtime definition. It walks the
-// multi-tier lookup chain (static cfg → dynamic_agents → substrate
-// active overlay) and applies the same normalizer chain the static
-// boot-time config-load path applies, so a name resolved at runtime
-// returns a byte-equivalent definition to one resolved at boot.
+// multi-tier lookup chain (tenant-scoped dynamic → static cfg → shared
+// dynamic, see Agent for the precedence) and applies the same
+// normalizer chain the static boot-time config-load path applies, so a
+// name resolved at runtime returns a byte-equivalent definition to one
+// resolved at boot. RFC N threaded a tenant axis through the dynamic
+// tiers; the default tenant "" preserves the pre-RFC-N order exactly.
 //
 // # Why this package exists
 //
@@ -59,18 +61,32 @@ import (
 
 // AgentStore is the subset of store.Store the agent resolver uses.
 // Declared here so tests + callers can mock without depending on the
-// full store interface.
+// full store interface. RFC N: the dynamic lookups carry a tenantID.
 type AgentStore interface {
-	DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error)
-	AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error)
+	DynamicAgentGet(ctx context.Context, tenantID, name string) (store.DynamicAgent, error)
+	AgentDefGetActive(ctx context.Context, tenantID, name string) (store.AgentDefRow, error)
 }
 
-// Agent resolves an agent NAME to its effective config.AgentDef by
-// walking the lookup chain in precedence order:
+// Agent resolves an agent NAME to its effective config.AgentDef within
+// the caller's tenant, walking the lookup chain in precedence order:
 //
-//  1. static cfg.Agents (yaml-defined, pre-normalized at boot)
-//  2. dynamic_agents table (v0.8.15 RegisterAgent path)
-//  3. agent_def_active + agent_defs (v0.8.22 substrate path)
+//  1. (tenantID != "") tenant-scoped dynamic lookup — dynamic_agents
+//     then agent_def_active, both WHERE tenant_id=tenantID.
+//  2. static cfg.Agents (yaml-defined, pre-normalized at boot) — the
+//     shared operator base every tenant inherits.
+//  3. shared dynamic lookup (tenant_id="") — dynamic_agents then
+//     agent_def_active.
+//
+// For the default tenant "" step 1 is skipped, so the order collapses to
+// static-cfg → shared-dynamic — IDENTICAL to the pre-RFC-N behavior
+// ("cfg.Agents first, then dynamic"). This is the critical back-compat
+// property: a single-tenant deployment (everything tenant_id="") behaves
+// exactly as before.
+//
+// "static = shared base, tenant-dynamic shadows it" (RFC N §Proposed
+// design): a per-tenant dynamic registration shadows the shared static
+// base by name; the static yaml stays a shared base every tenant
+// inherits unless they override it dynamically.
 //
 // Returns (zero, false) when no source has the name. Malformed
 // persistence JSON also returns (zero, false) — defensive against
@@ -82,29 +98,50 @@ type AgentStore interface {
 // entries already went through config-load's resolveSkills /
 // resolveAgent, so the cfg path returns directly without re-
 // normalizing (avoids double-baking skill bodies into SystemPrompt).
-func Agent(ctx context.Context, s AgentStore, cfg *config.Config, name string) (config.AgentDef, bool) {
+func Agent(ctx context.Context, s AgentStore, cfg *config.Config, tenantID, name string) (config.AgentDef, bool) {
+	// 1. Tenant-scoped dynamic shadow (skipped for the shared "" tenant
+	//    so its order stays static-cfg → shared-dynamic, exactly as
+	//    pre-RFC-N).
+	if tenantID != "" {
+		if def, ok := resolveDynamic(ctx, s, tenantID, name); ok {
+			return def, true
+		}
+	}
+	// 2. Static cfg.Agents — the shared operator base.
 	if cfg != nil {
 		if def, ok := cfg.Agents[name]; ok {
 			return def, true
 		}
 	}
+	// 3. Shared dynamic (tenant_id="").
+	return resolveDynamic(ctx, s, "", name)
+}
+
+// resolveDynamic runs the two dynamic tiers for one tenant pass:
+//
+//	dynamic_agents (RegisterAgent path) → agent_def_active + agent_defs
+//	(AgentDef substrate)
+//
+// both scoped to tenantID. Returns (zero, false) when neither tier has
+// the name for that tenant (or the store is nil). Called once for the
+// tenant pass and once for the shared "" pass by Agent.
+func resolveDynamic(ctx context.Context, s AgentStore, tenantID, name string) (config.AgentDef, bool) {
 	if s == nil {
 		return config.AgentDef{}, false
 	}
-	// Tier 2 — dynamic_agents (RegisterAgent path). Persistence uses
-	// config.AgentDef's JSON tags directly; safe to unmarshal into
-	// config.AgentDef.
-	if row, err := s.DynamicAgentGet(ctx, name); err == nil {
+	// Tier A — dynamic_agents. Persistence uses config.AgentDef's JSON
+	// tags directly; safe to unmarshal into config.AgentDef.
+	if row, err := s.DynamicAgentGet(ctx, tenantID, name); err == nil {
 		var def config.AgentDef
 		if uerr := json.Unmarshal(row.Definition, &def); uerr == nil {
 			NormalizeAgentDef(&def)
 			return def, true
 		}
 	}
-	// Tier 3 — substrate (agent_def_active overlay → agent_defs row).
+	// Tier B — substrate (agent_def_active overlay → agent_defs row).
 	// Persistence uses mergedDef's snake_case JSON tags; must unmarshal
 	// into a json-tagged adapter then convert.
-	activeRow, err := s.AgentDefGetActive(ctx, name)
+	activeRow, err := s.AgentDefGetActive(ctx, tenantID, name)
 	if err != nil {
 		return config.AgentDef{}, false
 	}

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -21,15 +21,19 @@ type stubStore struct {
 	defs map[string]store.AgentDefRow // keyed by name (active)
 }
 
-func (s *stubStore) DynamicAgentGet(_ context.Context, name string) (store.DynamicAgent, error) {
-	if row, ok := s.dyn[name]; ok {
+// stubKey composes the (tenant, name) map key so the stub honours the
+// RFC N tenant axis. Tests that don't care about tenancy use "".
+func stubKey(tenantID, name string) string { return tenantID + "\x00" + name }
+
+func (s *stubStore) DynamicAgentGet(_ context.Context, tenantID, name string) (store.DynamicAgent, error) {
+	if row, ok := s.dyn[stubKey(tenantID, name)]; ok {
 		return row, nil
 	}
 	return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
 }
 
-func (s *stubStore) AgentDefGetActive(_ context.Context, name string) (store.AgentDefRow, error) {
-	if row, ok := s.defs[name]; ok {
+func (s *stubStore) AgentDefGetActive(_ context.Context, tenantID, name string) (store.AgentDefRow, error) {
+	if row, ok := s.defs[stubKey(tenantID, name)]; ok {
 		return row, nil
 	}
 	return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
@@ -93,7 +97,7 @@ func TestAgent_EquivalenceYamlVsSubstrate(t *testing.T) {
 	ss := &stubStore{
 		dyn: map[string]store.DynamicAgent{},
 		defs: map[string]store.AgentDefRow{
-			"researcher": {
+			stubKey("", "researcher"): {
 				DefID:      "def_researcher_v1",
 				Name:       "researcher",
 				Version:    1,
@@ -102,7 +106,7 @@ func TestAgent_EquivalenceYamlVsSubstrate(t *testing.T) {
 			},
 		},
 	}
-	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "researcher")
+	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "", "researcher")
 	if !ok {
 		t.Fatal("resolver returned !ok")
 	}
@@ -163,7 +167,7 @@ func TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead(t *testing.T) {
 	ss := &stubStore{
 		dyn: map[string]store.DynamicAgent{},
 		defs: map[string]store.AgentDefRow{
-			"legacy": {
+			stubKey("", "legacy"): {
 				DefID:      "def_legacy_v1",
 				Name:       "legacy",
 				Version:    1,
@@ -172,7 +176,7 @@ func TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead(t *testing.T) {
 			},
 		},
 	}
-	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "legacy")
+	resolved, ok := lookup.Agent(context.Background(), ss, &config.Config{}, "", "legacy")
 	if !ok {
 		t.Fatal("resolver returned !ok")
 	}
@@ -182,6 +186,78 @@ func TestAgent_LegacyRowGetsSystemPromptBaseFilledOnRead(t *testing.T) {
 	}
 	if resolved.SystemPrompt != "be helpful" {
 		t.Errorf("SystemPrompt unexpectedly mutated: %q", resolved.SystemPrompt)
+	}
+}
+
+// TestAgent_TenantResolutionPrecedence pins the RFC N resolution
+// model: a tenant-scoped dynamic registration shadows the shared
+// static base by name, while a different tenant resolving the same name
+// falls through to the shared static base (it cannot see tenant A's
+// private def).
+func TestAgent_TenantResolutionPrecedence(t *testing.T) {
+	tenantDefJSON, err := json.Marshal(map[string]any{"system_prompt": "tenant-A private"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := &stubStore{
+		dyn: map[string]store.DynamicAgent{},
+		defs: map[string]store.AgentDefRow{
+			stubKey("tenant-a", "shared"): {
+				DefID:      "def_a_v1",
+				Name:       "shared",
+				Version:    1,
+				Definition: tenantDefJSON,
+			},
+		},
+	}
+	cfg := &config.Config{Agents: map[string]config.AgentDef{
+		"shared": {SystemPrompt: "operator shared base"},
+	}}
+
+	// Tenant A: its dynamic def shadows the shared static base.
+	gotA, ok := lookup.Agent(context.Background(), ss, cfg, "tenant-a", "shared")
+	if !ok {
+		t.Fatal("tenant-a resolve !ok")
+	}
+	if gotA.SystemPrompt != "tenant-A private" {
+		t.Errorf("tenant-a: got %q, want its own dynamic def", gotA.SystemPrompt)
+	}
+
+	// Tenant B: no private def → falls through to the shared static base.
+	// It must NOT see tenant A's private def.
+	gotB, ok := lookup.Agent(context.Background(), ss, cfg, "tenant-b", "shared")
+	if !ok {
+		t.Fatal("tenant-b resolve !ok")
+	}
+	if gotB.SystemPrompt != "operator shared base" {
+		t.Errorf("tenant-b: got %q, want the shared static base (no cross-tenant leak)", gotB.SystemPrompt)
+	}
+}
+
+// TestAgent_DefaultTenantPreservesStaticFirstOrder pins the back-compat
+// invariant: for the default tenant "", a name present in BOTH static
+// cfg.Agents AND the shared dynamic tier resolves to the STATIC one —
+// identical to the pre-RFC-N "cfg.Agents first, then dynamic" order.
+func TestAgent_DefaultTenantPreservesStaticFirstOrder(t *testing.T) {
+	dynJSON, err := json.Marshal(map[string]any{"system_prompt": "dynamic shadow"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss := &stubStore{
+		dyn: map[string]store.DynamicAgent{
+			stubKey("", "dual"): {Name: "dual", Definition: dynJSON},
+		},
+		defs: map[string]store.AgentDefRow{},
+	}
+	cfg := &config.Config{Agents: map[string]config.AgentDef{
+		"dual": {SystemPrompt: "static wins"},
+	}}
+	got, ok := lookup.Agent(context.Background(), ss, cfg, "", "dual")
+	if !ok {
+		t.Fatal("resolve !ok")
+	}
+	if got.SystemPrompt != "static wins" {
+		t.Errorf("default tenant precedence broke: got %q, want the static cfg.Agents entry", got.SystemPrompt)
 	}
 }
 

--- a/internal/store/postgres/migrations/0037_agent_defs_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0037_agent_defs_tenant_id.down.sql
@@ -1,0 +1,20 @@
+-- 0037_agent_defs_tenant_id.down.sql — reverse RFC N's tenant axis on the
+-- agent definition plane. Restores the single-column PKs and the
+-- UNIQUE(name, version) constraint, then drops the tenant_id columns.
+--
+-- NOTE: down is only safe while every row is tenant_id='' (the
+-- single-tenant / pre-migration state). If real per-tenant rows exist,
+-- restoring the single-col PK would collide on duplicate names — the
+-- operator must reconcile names before rolling back.
+
+ALTER TABLE dynamic_agents DROP CONSTRAINT dynamic_agents_pkey;
+ALTER TABLE dynamic_agents ADD PRIMARY KEY (name);
+ALTER TABLE dynamic_agents DROP COLUMN tenant_id;
+
+ALTER TABLE agent_def_active DROP CONSTRAINT agent_def_active_pkey;
+ALTER TABLE agent_def_active ADD PRIMARY KEY (name);
+ALTER TABLE agent_def_active DROP COLUMN tenant_id;
+
+ALTER TABLE agent_defs DROP CONSTRAINT agent_defs_tenant_name_version_key;
+ALTER TABLE agent_defs ADD CONSTRAINT agent_defs_name_version_key UNIQUE (name, version);
+ALTER TABLE agent_defs DROP COLUMN tenant_id;

--- a/internal/store/postgres/migrations/0037_agent_defs_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0037_agent_defs_tenant_id.up.sql
@@ -1,0 +1,33 @@
+-- 0037_agent_defs_tenant_id.up.sql — RFC N: tenant-scope the agent
+-- definition plane.
+--
+-- RFC L isolated the STATE plane (runs/sessions/memory keyed on the
+-- authoritative principal). It left the DEFINITION plane global: the
+-- agent_defs / agent_def_active / dynamic_agents tables had no tenant
+-- column, so two tenants registering the same name collided on a single
+-- global active pointer (last-writer-wins) and any token could resolve &
+-- run another tenant's agent. This migration adds the tenant axis the
+-- 0006_agent_defs comment anticipated ("Per-tenant active pointers
+-- (future v0.9.x) extend the PK to (tenant_id, name)").
+--
+-- '' = the shared/operator/legacy tenant. Existing rows backfill to ''
+-- via the column DEFAULT, so a single-tenant deployment behaves exactly
+-- as before. This PR covers AGENTS only; skills + MCP servers follow.
+
+-- agent_defs: tenant the versioned-definition rows. The UNIQUE(name,
+-- version) becomes UNIQUE(tenant_id, name, version) so two tenants can
+-- own the same name independently.
+ALTER TABLE agent_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE agent_defs DROP CONSTRAINT agent_defs_name_version_key;
+ALTER TABLE agent_defs ADD CONSTRAINT agent_defs_tenant_name_version_key UNIQUE (tenant_id, name, version);
+
+-- agent_def_active: the active pointer is now per (tenant_id, name). Add
+-- the column, drop the single-col PK, add the composite PK.
+ALTER TABLE agent_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE agent_def_active DROP CONSTRAINT agent_def_active_pkey;
+ALTER TABLE agent_def_active ADD PRIMARY KEY (tenant_id, name);
+
+-- dynamic_agents: same shape — per (tenant_id, name).
+ALTER TABLE dynamic_agents ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE dynamic_agents DROP CONSTRAINT dynamic_agents_pkey;
+ALTER TABLE dynamic_agents ADD PRIMARY KEY (tenant_id, name);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3362,8 +3362,11 @@ func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([
 
 // AgentDefListNames returns one summary per distinct name.
 func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
+	// RFC N: names are per-tenant; group by tenant_id so a name owned by
+	// N tenants yields N rows (one per tenant) rather than merging them.
 	rows, err := s.pool.Query(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
@@ -3371,8 +3374,8 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM agent_defs d
 		LEFT JOIN agent_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, fmt.Errorf("agent_def list names: %w", err)
 	}
@@ -3381,7 +3384,7 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	var out []store.AgentDefNameSummary
 	for rows.Next() {
 		var s store.AgentDefNameSummary
-		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &s.LastUpdated, &s.ActiveDefID); err != nil {
+		if err := rows.Scan(&s.TenantID, &s.Name, &s.VersionCount, &s.LatestVersion, &s.LastUpdated, &s.ActiveDefID); err != nil {
 			return nil, err
 		}
 		out = append(out, s)

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1036,9 +1036,9 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 	rows, err := s.pool.Query(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition::text, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static
+		        retired, bootstrapped_from_static, tenant_id
 		 FROM agent_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read agent_defs: %w", err)
@@ -1058,7 +1058,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&r.CreatedAt, &createdBy, &createdRun,
-			&r.Retired, &r.BootstrappedFromStatic,
+			&r.Retired, &r.BootstrappedFromStatic, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent_def: %w", err)
 		}
@@ -1083,9 +1083,9 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 // SnapshotReadAgentDefActive implements store.Store.
 func (s *Store) SnapshotReadAgentDefActive(ctx context.Context) ([]store.AgentDefActiveEntry, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM agent_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read agent_def_active: %w", err)
 	}
@@ -1096,7 +1096,7 @@ func (s *Store) SnapshotReadAgentDefActive(ctx context.Context) ([]store.AgentDe
 			e        store.AgentDefActiveEntry
 			promoter *string
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan agent_def_active: %w", err)
 		}
 		if promoter != nil {
@@ -1546,14 +1546,14 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		`INSERT INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)
 		 ON CONFLICT (def_id) DO NOTHING`,
 		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
 		string(r.Definition), nullIfEmpty(r.Description),
 		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
 		r.Retired, r.BootstrappedFromStatic,
-		nullIfEmpty(r.ContentSHA256),
+		nullIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
@@ -1562,10 +1562,10 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 }
 
 // SnapshotRestoreAgentDefActive implements store.Store. ON CONFLICT
-// DO NOTHING — first restore writes the snapshot's promoted_at +
-// def_id; subsequent restores leave the existing row alone so the
-// (bool, error) return reads as "not inserted" and the caller's
-// counter stays honest on a re-restore.
+// (tenant_id, name) DO NOTHING — first restore writes the snapshot's
+// promoted_at + def_id; subsequent restores leave the existing row
+// alone so the (bool, error) return reads as "not inserted" and the
+// caller's counter stays honest on a re-restore.
 func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) (bool, error) {
 	if e.Name == "" || e.DefID == "" {
 		return false, fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
@@ -1575,9 +1575,9 @@ func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.Agent
 		promotedAt = time.Now().UTC()
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (name) DO NOTHING`,
-		e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
+		`INSERT INTO agent_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id, name) DO NOTHING`,
+		e.TenantID, e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def_active: %w", err)
@@ -1986,30 +1986,30 @@ func (s *Store) DynamicAgentUpsert(ctx context.Context, a store.DynamicAgent) er
 		expiresAt = time.Unix(0, 0).UTC()
 	}
 	_, err := s.pool.Exec(ctx, `
-		INSERT INTO dynamic_agents (name, definition, created_at, expires_at, description)
-		VALUES ($1, $2::jsonb, $3, $4, $5)
-		ON CONFLICT (name) DO UPDATE SET
+		INSERT INTO dynamic_agents (tenant_id, name, definition, created_at, expires_at, description)
+		VALUES ($1, $2, $3::jsonb, $4, $5, $6)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
 			definition  = EXCLUDED.definition,
 			created_at  = EXCLUDED.created_at,
 			expires_at  = EXCLUDED.expires_at,
 			description = EXCLUDED.description
-	`, a.Name, string(a.Definition), createdAt, expiresAt, a.Description)
+	`, a.TenantID, a.Name, string(a.Definition), createdAt, expiresAt, a.Description)
 	if err != nil {
 		return fmt.Errorf("dynamic_agents: upsert: %w", err)
 	}
 	return nil
 }
 
-func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error) {
+func (s *Store) DynamicAgentGet(ctx context.Context, tenantID, name string) (store.DynamicAgent, error) {
 	row := s.pool.QueryRow(ctx, `
-		SELECT name, definition::text, created_at, expires_at, COALESCE(description, '')
+		SELECT tenant_id, name, definition::text, created_at, expires_at, COALESCE(description, '')
 		FROM dynamic_agents
-		WHERE name = $1 AND (expires_at = 'epoch' OR expires_at > $2)
-	`, name, time.Now())
+		WHERE tenant_id = $1 AND name = $2 AND (expires_at = 'epoch' OR expires_at > $3)
+	`, tenantID, name, time.Now())
 
 	var a store.DynamicAgent
 	var defStr string
-	if err := row.Scan(&a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
+	if err := row.Scan(&a.TenantID, &a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
 		}
@@ -2027,7 +2027,7 @@ func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.Dynamic
 
 func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, error) {
 	rows, err := s.pool.Query(ctx, `
-		SELECT name, definition::text, created_at, expires_at, COALESCE(description, '')
+		SELECT tenant_id, name, definition::text, created_at, expires_at, COALESCE(description, '')
 		FROM dynamic_agents
 		WHERE expires_at = 'epoch' OR expires_at > $1
 		ORDER BY created_at DESC
@@ -2042,7 +2042,7 @@ func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, err
 	for rows.Next() {
 		var a store.DynamicAgent
 		var defStr string
-		if err := rows.Scan(&a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
+		if err := rows.Scan(&a.TenantID, &a.Name, &defStr, &a.CreatedAt, &a.ExpiresAt, &a.Description); err != nil {
 			return nil, fmt.Errorf("dynamic_agents: list scan: %w", err)
 		}
 		a.Definition = []byte(defStr)
@@ -3268,13 +3268,15 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Per-name advisory lock — serialises version allocation against
-	// concurrent forks of the SAME name. Different names proceed in
-	// parallel. The hash is deterministic so the same name always
-	// hashes to the same lock key.
+	// Per-(tenant, name) advisory lock — serialises version allocation
+	// against concurrent forks of the SAME (tenant, name). Different
+	// (tenant, name) tuples proceed in parallel. The hash is
+	// deterministic so the same tuple always hashes to the same lock
+	// key. RFC N: tenant is part of the version-allocation scope so two
+	// tenants' v1 don't collide on the UNIQUE(tenant_id, name, version).
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
-		"agent_def:"+row.Name,
+		"agent_def:"+row.TenantID+":"+row.Name,
 	); err != nil {
 		return store.AgentDefRow{}, fmt.Errorf("agent_def create lock: %w", err)
 	}
@@ -3290,7 +3292,7 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 	}
 
 	var maxVer sql.NullInt64
-	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM agent_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM agent_defs WHERE tenant_id = $1 AND name = $2`, row.TenantID, row.Name).Scan(&maxVer); err != nil {
 		return store.AgentDefRow{}, fmt.Errorf("agent_def create max version: %w", err)
 	}
 	row.Version = 1
@@ -3303,14 +3305,14 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 		INSERT INTO agent_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
 		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
 		string(row.Definition), nullableString(row.Description),
 		row.CreatedAt,
 		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
 		row.Retired, row.BootstrappedFromStatic,
-		nullableString(row.ContentSHA256),
+		nullableString(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.AgentDefRow{}, fmt.Errorf("agent_def insert: %w", err)
 	}
@@ -3368,7 +3370,7 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM agent_defs d
-		LEFT JOIN agent_def_active a ON a.name = d.name
+		LEFT JOIN agent_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
 		GROUP BY d.name, a.def_id
 		ORDER BY d.name`)
 	if err != nil {
@@ -3387,10 +3389,17 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	return out, rows.Err()
 }
 
-// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
-func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	var rowName string
-	err := s.pool.QueryRow(ctx, `SELECT name FROM agent_defs WHERE def_id = $1`, defID).Scan(&rowName)
+// AgentDefSetActive UPSERTs the agent_def_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// agent AND the supplied tenant — a def can only be promoted within its
+// own tenant, so a caller can't point another tenant's active pointer at
+// a def it owns.
+func (s *Store) AgentDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.pool.QueryRow(ctx, `SELECT name, tenant_id FROM agent_defs WHERE def_id = $1`, defID).Scan(&rowName, &rowTenant)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
 	}
@@ -3400,14 +3409,17 @@ func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAg
 	if rowName != name {
 		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("agent_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (name) DO UPDATE SET
+		INSERT INTO agent_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
 		    def_id               = EXCLUDED.def_id,
 		    promoted_at          = EXCLUDED.promoted_at,
 		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
-		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+		tenantID, name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
 	)
 	if err != nil {
 		return fmt.Errorf("agent_def_active upsert: %w", err)
@@ -3415,11 +3427,11 @@ func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAg
 	return nil
 }
 
-// AgentDefGetActive returns the active row for name. *ErrNotFound
-// when no pointer exists.
-func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+// AgentDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists.
+func (s *Store) AgentDefGetActive(ctx context.Context, tenantID, name string) (store.AgentDefRow, error) {
 	var defID string
-	err := s.pool.QueryRow(ctx, `SELECT def_id FROM agent_def_active WHERE name = $1`, name).Scan(&defID)
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM agent_def_active WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&defID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
 	}
@@ -3451,7 +3463,8 @@ const agentDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM agent_defs`
 
 func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
@@ -3468,6 +3481,7 @@ func (s *Store) scanAgentDef(row pgx.Row) (store.AgentDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&out.Retired, &out.BootstrappedFromStatic,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.AgentDefRow{}, err
@@ -3492,6 +3506,7 @@ func (s *Store) scanAgentDefRows(rows pgx.Rows) ([]store.AgentDefRow, error) {
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&r.Retired, &r.BootstrappedFromStatic,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3480,11 +3480,14 @@ func (s *Store) AgentDefListChildren(ctx context.Context, parentDefID string) ([
 	return s.scanAgentDefRows(rows)
 }
 
-// AgentDefListNames returns one summary row per distinct name. Joins
-// agent_def_active to surface the active def_id when one exists.
+// AgentDefListNames returns one summary row per distinct (tenant, name).
+// Joins agent_def_active to surface the active def_id when one exists.
+// RFC N: names are per-tenant, so the grouping includes tenant_id — a
+// name owned by N tenants yields N rows.
 func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSummary, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
@@ -3492,8 +3495,8 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM agent_defs d
 		LEFT JOIN agent_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, err
 	}
@@ -3503,7 +3506,7 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	for rows.Next() {
 		var s store.AgentDefNameSummary
 		var updatedAt int64
-		if err := rows.Scan(&s.Name, &s.VersionCount, &s.LatestVersion, &updatedAt, &s.ActiveDefID); err != nil {
+		if err := rows.Scan(&s.TenantID, &s.Name, &s.VersionCount, &s.LatestVersion, &updatedAt, &s.ActiveDefID); err != nil {
 			return nil, err
 		}
 		s.LastUpdated = time.Unix(0, updatedAt)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -775,6 +775,29 @@ func (s *Store) migrate(ctx context.Context) error {
 		// unconstrained and the index stays small. Mirrors the postgres
 		// 0033 migration.
 		`CREATE UNIQUE INDEX IF NOT EXISTS runs_idempotency_key ON runs(idempotency_key) WHERE idempotency_key IS NOT NULL`,
+		// RFC N — ON CONFLICT(tenant_id, name) targets for the def plane.
+		// On a FRESH DB these are redundant with the composite PRIMARY KEY /
+		// UNIQUE declared in the CREATE TABLE block above (harmless). On an
+		// UPGRADED v0.8.x DB the addColumns ALTER added tenant_id but SQLite
+		// could NOT rewrite the existing PRIMARY KEY(name) / UNIQUE(name,
+		// version) in place — so the runtime upserts' ON CONFLICT(tenant_id,
+		// name) and the version-bump UNIQUE(tenant_id, name, version) have NO
+		// matching index and SQLite refuses with "ON CONFLICT clause does not
+		// match any PRIMARY KEY or UNIQUE constraint", breaking the FIRST
+		// promote/register even single-tenant. These idempotent indexes
+		// supply that ON CONFLICT target so upserts work on upgraded DBs.
+		// Lives in addIndexes (not the CREATE TABLE block) so the tenant_id
+		// column added by addColumns above is guaranteed present first.
+		//
+		// Residual caveat (unchanged): the upgraded agent_def_active /
+		// dynamic_agents tables still carry PRIMARY KEY(name), so two tenants
+		// cannot share a name on a PRE-EXISTING SQLite DB — a fresh DB is
+		// required for full multi-tenant on SQLite. These indexes restore
+		// single-tenant upgrade functionality only; they do not retrofit the
+		// per-tenant isolation a fresh DB's composite PK provides.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_def_active_tenant_name    ON agent_def_active(tenant_id, name)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_agents_tenant_name      ON dynamic_agents(tenant_id, name)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_defs_tenant_name_version  ON agent_defs(tenant_id, name, version)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -230,7 +230,8 @@ func (s *Store) migrate(ctx context.Context) error {
 			retired                   INTEGER NOT NULL DEFAULT 0,
 			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
 			content_sha256            TEXT,
-			UNIQUE(name, version)
+			tenant_id                 TEXT    NOT NULL DEFAULT '',
+			UNIQUE(tenant_id, name, version)
 		)`,
 		`CREATE INDEX IF NOT EXISTS agent_defs_by_name   ON agent_defs(name, version DESC)`,
 		`CREATE INDEX IF NOT EXISTS agent_defs_by_parent ON agent_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
@@ -238,11 +239,23 @@ func (s *Store) migrate(ctx context.Context) error {
 		// agent_defs_by_content_sha256 is created in addIndexes below
 		// (runs AFTER addColumns adds the column on upgrade-from-v0.8.x
 		// DBs where this CREATE TABLE IF NOT EXISTS is a no-op).
+		// RFC N: tenant-scoped active pointer. PRIMARY KEY(tenant_id, name)
+		// — two tenants own the same name independently. On a FRESH DB this
+		// CREATE applies the composite PK directly. On an UPGRADED v0.8.x
+		// DB this CREATE is a no-op (table exists) and the tenant_id column
+		// is added by the addColumns ALTER below; SQLite cannot rewrite a
+		// PRIMARY KEY in place, so an upgraded DB keeps PK(name). That is
+		// byte-equivalent for single-tenant (everything tenant_id=''); true
+		// per-tenant isolation on SQLite requires a fresh DB (Postgres
+		// upgrades in place via migration 0037). The contract tests run on
+		// a fresh DB, so the isolation guarantee is verified here.
 		`CREATE TABLE IF NOT EXISTS agent_def_active (
-			name                  TEXT    PRIMARY KEY,
+			name                  TEXT    NOT NULL,
 			def_id                TEXT    NOT NULL REFERENCES agent_defs(def_id),
 			promoted_at           INTEGER NOT NULL,
-			promoted_by_agent_id  TEXT
+			promoted_by_agent_id  TEXT,
+			tenant_id             TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY(tenant_id, name)
 		)`,
 		// v0.8.22 SkillDef substrate — mirror of agent_defs with
 		// the same identity / lineage / promotion semantics. The
@@ -543,12 +556,17 @@ func (s *Store) migrate(ctx context.Context) error {
 		// the JSON-encoded config.AgentDef body verbatim (the store
 		// doesn't depend on internal/config; same pattern as v0.8.5
 		// agent_defs). expires_at = 0 means "no expiry".
+		// RFC N: tenant-scoped — PRIMARY KEY(tenant_id, name). Fresh-DB-only
+		// PK shape; see the agent_def_active note above for the SQLite
+		// upgrade caveat.
 		`CREATE TABLE IF NOT EXISTS dynamic_agents (
-			name        TEXT PRIMARY KEY,
+			name        TEXT    NOT NULL,
 			definition  BLOB    NOT NULL,
 			created_at  INTEGER NOT NULL,
 			expires_at  INTEGER NOT NULL DEFAULT 0,
-			description TEXT
+			description TEXT,
+			tenant_id   TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY(tenant_id, name)
 		)`,
 		// v0.8.16 Interruption tool. Agents call Interruption.ask /
 		// .notify / .cancel; pending rows block the run until resolved.
@@ -665,6 +683,16 @@ func (s *Store) migrate(ctx context.Context) error {
 		// sessions JOIN. NULL on legacy rows until the backfill below
 		// copies it from the parent session. New rows set it at CreateRun.
 		`ALTER TABLE runs ADD COLUMN tenant_id TEXT`,
+		// RFC N — tenant-scope the agent definition plane. On an upgraded
+		// v0.8.x DB the CREATE TABLE statements above were no-ops, so these
+		// ALTERs add the tenant_id column to the existing tables. The
+		// PRIMARY KEY stays (name) on the upgraded table (SQLite can't
+		// rewrite a PK in place) — functionally identical for single-tenant
+		// (tenant_id=''); see the CREATE TABLE notes for the isolation
+		// caveat. DEFAULT '' backfills existing rows to the shared tenant.
+		`ALTER TABLE agent_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE agent_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE dynamic_agents ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1610,9 +1638,9 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static
+		        retired, bootstrapped_from_static, tenant_id
 		 FROM agent_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read agent_defs: %w", err)
@@ -1635,7 +1663,7 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&createdNs, &createdBy, &createdRun,
-			&retiredInt, &bootstrap,
+			&retiredInt, &bootstrap, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan agent_def: %w", err)
 		}
@@ -1663,9 +1691,9 @@ func (s *Store) SnapshotReadAgentDefs(ctx context.Context) ([]store.AgentDefRow,
 // SnapshotReadAgentDefActive implements store.Store.
 func (s *Store) SnapshotReadAgentDefActive(ctx context.Context) ([]store.AgentDefActiveEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM agent_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read agent_def_active: %w", err)
 	}
@@ -1677,7 +1705,7 @@ func (s *Store) SnapshotReadAgentDefActive(ctx context.Context) ([]store.AgentDe
 			promotedNs int64
 			promoter   sql.NullString
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan agent_def_active: %w", err)
 		}
 		e.PromotedAt = time.Unix(0, promotedNs)
@@ -2170,13 +2198,13 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 		`INSERT OR IGNORE INTO agent_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
 		string(r.Definition), nilIfEmpty(r.Description),
 		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
 		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
-		nilIfEmpty(r.ContentSHA256),
+		nilIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def: %w", err)
@@ -2186,10 +2214,10 @@ func (s *Store) SnapshotRestoreAgentDef(ctx context.Context, r store.AgentDefRow
 }
 
 // SnapshotRestoreAgentDefActive implements store.Store. INSERT OR
-// IGNORE on the name PK — first restore writes the snapshot's
-// promoted_at + def_id; subsequent restores leave the existing row
-// alone so the (bool, error) return reads as "not inserted" and the
-// caller's counter stays honest.
+// IGNORE on the (tenant_id, name) PK — first restore writes the
+// snapshot's promoted_at + def_id; subsequent restores leave the
+// existing row alone so the (bool, error) return reads as "not
+// inserted" and the caller's counter stays honest.
 func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.AgentDefActiveEntry) (bool, error) {
 	if e.Name == "" || e.DefID == "" {
 		return false, fmt.Errorf("snapshot restore agent_def_active: name and def_id required")
@@ -2199,8 +2227,8 @@ func (s *Store) SnapshotRestoreAgentDefActive(ctx context.Context, e store.Agent
 		promotedNs = time.Now().UnixNano()
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO agent_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)`,
-		e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
+		`INSERT OR IGNORE INTO agent_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?, ?)`,
+		e.TenantID, e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore agent_def_active: %w", err)
@@ -3345,10 +3373,11 @@ func (s *Store) ChannelSweepExpired(ctx context.Context) (int, error) {
 // write lock to this one transaction, and IMMEDIATE means concurrent
 // writers see SQLITE_BUSY at BEGIN time (database/sql retries) rather
 // than upgrade-deadlocking mid-tx. Without this, two concurrent
-// AgentDefCreate calls against the same name both start a DEFERRED
-// tx, both SELECT MAX(version) (returning the same value), then both
-// try to INSERT with the same version — one succeeds, one fails on
-// the UNIQUE(name, version) constraint.
+// AgentDefCreate calls against the same (tenant, name) both start a
+// DEFERRED tx, both SELECT MAX(version) (returning the same value),
+// then both try to INSERT with the same version — one succeeds, one
+// fails on the UNIQUE(tenant_id, name, version) constraint. RFC N:
+// version allocation is scoped per-tenant.
 func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (store.AgentDefRow, error) {
 	if row.DefID == "" || row.Name == "" {
 		return store.AgentDefRow{}, fmt.Errorf("agent_def: def_id + name required")
@@ -3381,7 +3410,7 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 
 	var maxVer sql.NullInt64
 	if err := conn.QueryRowContext(ctx,
-		`SELECT MAX(version) FROM agent_defs WHERE name = ?`, row.Name,
+		`SELECT MAX(version) FROM agent_defs WHERE tenant_id = ? AND name = ?`, row.TenantID, row.Name,
 	).Scan(&maxVer); err != nil {
 		return store.AgentDefRow{}, err
 	}
@@ -3395,14 +3424,14 @@ func (s *Store) AgentDefCreate(ctx context.Context, row store.AgentDefRow) (stor
 		`INSERT INTO agent_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
 		string(row.Definition), nilIfEmpty(row.Description),
 		row.CreatedAt.UnixNano(),
 		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
 		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
-		nilIfEmpty(row.ContentSHA256),
+		nilIfEmpty(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.AgentDefRow{}, err
 	}
@@ -3462,7 +3491,7 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM agent_defs d
-		LEFT JOIN agent_def_active a ON a.name = d.name
+		LEFT JOIN agent_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
 		GROUP BY d.name, a.def_id
 		ORDER BY d.name`)
 	if err != nil {
@@ -3483,12 +3512,18 @@ func (s *Store) AgentDefListNames(ctx context.Context) ([]store.AgentDefNameSumm
 	return out, rows.Err()
 }
 
-// AgentDefSetActive UPSERTs the agent_def_active pointer for name.
-func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	// Validate def_id exists + matches name (defence-in-depth; the
-	// FK isn't enforced without foreign_keys PRAGMA).
-	var rowName string
-	err := s.db.QueryRowContext(ctx, `SELECT name FROM agent_defs WHERE def_id = ?`, defID).Scan(&rowName)
+// AgentDefSetActive UPSERTs the agent_def_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// agent AND the supplied tenant — a def can only be promoted within its
+// own tenant.
+func (s *Store) AgentDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	// Validate def_id exists + matches (name, tenant) (defence-in-depth;
+	// the FK isn't enforced without foreign_keys PRAGMA).
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.db.QueryRowContext(ctx, `SELECT name, tenant_id FROM agent_defs WHERE def_id = ?`, defID).Scan(&rowName, &rowTenant)
 	if err == sql.ErrNoRows {
 		return &store.ErrNotFound{Kind: "agent_def", ID: defID}
 	}
@@ -3498,23 +3533,27 @@ func (s *Store) AgentDefSetActive(ctx context.Context, name, defID, promotedByAg
 	if rowName != name {
 		return fmt.Errorf("agent_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("agent_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO agent_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(name) DO UPDATE SET
+		INSERT INTO agent_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, name) DO UPDATE SET
 		    def_id               = excluded.def_id,
 		    promoted_at          = excluded.promoted_at,
 		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
-		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+		tenantID, name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
 	)
 	return err
 }
 
-// AgentDefGetActive returns the active row for name. *ErrNotFound
-// when no pointer exists — caller falls through to cfg.Agents.
-func (s *Store) AgentDefGetActive(ctx context.Context, name string) (store.AgentDefRow, error) {
+// AgentDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists — caller falls through to
+// cfg.Agents.
+func (s *Store) AgentDefGetActive(ctx context.Context, tenantID, name string) (store.AgentDefRow, error) {
 	var defID string
-	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM agent_def_active WHERE name = ?`, name).Scan(&defID)
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM agent_def_active WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&defID)
 	if err == sql.ErrNoRows {
 		return store.AgentDefRow{}, &store.ErrNotFound{Kind: "agent_def_active", ID: name}
 	}
@@ -3542,8 +3581,7 @@ func (s *Store) AgentDefSetRetired(ctx context.Context, defID string, retired bo
 }
 
 // agentDefSelect is the column list shared by every read. Kept in
-// one place so column additions (a future tenant_id, similarity_score,
-// ...) need only a single touch-point.
+// one place so column additions need only a single touch-point.
 const agentDefSelect = `SELECT
 	def_id, name, version,
 	COALESCE(parent_def_id, ''),
@@ -3554,7 +3592,8 @@ const agentDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM agent_defs`
 
 func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
@@ -3574,6 +3613,7 @@ func (s *Store) scanAgentDef(row *sql.Row) (store.AgentDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&retired, &bootstrap,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.AgentDefRow{}, err
@@ -3604,6 +3644,7 @@ func (s *Store) scanAgentDefRows(rows *sql.Rows) ([]store.AgentDefRow, error) {
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&retired, &bootstrap,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}
@@ -6036,30 +6077,30 @@ func (s *Store) DynamicAgentUpsert(ctx context.Context, a store.DynamicAgent) er
 		expiresAtNS = a.ExpiresAt.UnixNano()
 	}
 	_, err := s.db.ExecContext(ctx, `
-		INSERT INTO dynamic_agents (name, definition, created_at, expires_at, description)
-		VALUES (?, ?, ?, ?, ?)
-		ON CONFLICT(name) DO UPDATE SET
+		INSERT INTO dynamic_agents (tenant_id, name, definition, created_at, expires_at, description)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, name) DO UPDATE SET
 			definition  = excluded.definition,
 			created_at  = excluded.created_at,
 			expires_at  = excluded.expires_at,
 			description = excluded.description
-	`, a.Name, a.Definition, createdAt.UnixNano(), expiresAtNS, a.Description)
+	`, a.TenantID, a.Name, a.Definition, createdAt.UnixNano(), expiresAtNS, a.Description)
 	if err != nil {
 		return fmt.Errorf("dynamic_agents: upsert: %w", err)
 	}
 	return nil
 }
 
-func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.DynamicAgent, error) {
+func (s *Store) DynamicAgentGet(ctx context.Context, tenantID, name string) (store.DynamicAgent, error) {
 	row := s.db.QueryRowContext(ctx, `
-		SELECT name, definition, created_at, expires_at, COALESCE(description, '')
+		SELECT tenant_id, name, definition, created_at, expires_at, COALESCE(description, '')
 		FROM dynamic_agents
-		WHERE name = ? AND (expires_at = 0 OR expires_at > ?)
-	`, name, time.Now().UnixNano())
+		WHERE tenant_id = ? AND name = ? AND (expires_at = 0 OR expires_at > ?)
+	`, tenantID, name, time.Now().UnixNano())
 
 	var a store.DynamicAgent
 	var createdAtNS, expiresAtNS int64
-	if err := row.Scan(&a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
+	if err := row.Scan(&a.TenantID, &a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
 		if err == sql.ErrNoRows {
 			return store.DynamicAgent{}, &store.ErrNotFound{Kind: "dynamic_agent", ID: name}
 		}
@@ -6074,7 +6115,7 @@ func (s *Store) DynamicAgentGet(ctx context.Context, name string) (store.Dynamic
 
 func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, error) {
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT name, definition, created_at, expires_at, COALESCE(description, '')
+		SELECT tenant_id, name, definition, created_at, expires_at, COALESCE(description, '')
 		FROM dynamic_agents
 		WHERE expires_at = 0 OR expires_at > ?
 		ORDER BY created_at DESC
@@ -6089,7 +6130,7 @@ func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, err
 	for rows.Next() {
 		var a store.DynamicAgent
 		var createdAtNS, expiresAtNS int64
-		if err := rows.Scan(&a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
+		if err := rows.Scan(&a.TenantID, &a.Name, &a.Definition, &createdAtNS, &expiresAtNS, &a.Description); err != nil {
 			return nil, fmt.Errorf("dynamic_agents: list scan: %w", err)
 		}
 		a.CreatedAt = time.Unix(0, createdAtNS)

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -233,6 +233,150 @@ func TestMigrate_UpgradeFromV084ChannelMessages(t *testing.T) {
 	}
 }
 
+// TestMigrate_UpgradeFromLegacyAgentDefPlaneTenantUpserts — RFC N
+// regression for the in-place SQLite upgrade bug. Setup: hand-create the
+// LEGACY (pre-RFC-N) agent-def-plane schema — agent_defs with
+// UNIQUE(name, version), agent_def_active with PRIMARY KEY(name),
+// dynamic_agents with PRIMARY KEY(name), none carrying tenant_id. Then
+// reopen via the store path (re-runs migrate(), which ALTERs in tenant_id
+// but CANNOT rewrite the PK/UNIQUE in place) and assert the three runtime
+// upserts SUCCEED.
+//
+// Pre-fix, this FAILS: the upserts' ON CONFLICT(tenant_id, name) /
+// version-bump UNIQUE(tenant_id, name, version) have no matching index on
+// the upgraded table, so SQLite refuses with "ON CONFLICT clause does not
+// match any PRIMARY KEY or UNIQUE constraint" on the FIRST register/promote
+// — broken even single-tenant. The fix adds idempotent CREATE UNIQUE INDEX
+// statements in addIndexes that supply the ON CONFLICT target.
+func TestMigrate_UpgradeFromLegacyAgentDefPlaneTenantUpserts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy_agentdef.db")
+
+	// 1. Stand up the legacy schema: open (which builds the current
+	// schema), then drop + rebuild the three tables in their pre-RFC-N
+	// shape (no tenant_id; old PK/UNIQUE). Mirrors how a pre-RFC-N deploy
+	// looks on disk.
+	{
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("initial open: %v", err)
+		}
+		ctx := context.Background()
+		stmts := []string{
+			`DROP INDEX IF EXISTS uniq_agent_def_active_tenant_name`,
+			`DROP INDEX IF EXISTS uniq_dynamic_agents_tenant_name`,
+			`DROP INDEX IF EXISTS uniq_agent_defs_tenant_name_version`,
+			`DROP TABLE agent_def_active`,
+			`DROP TABLE dynamic_agents`,
+			`DROP TABLE agent_defs`,
+			// Legacy agent_defs: UNIQUE(name, version), no tenant_id.
+			`CREATE TABLE agent_defs (
+				def_id                    TEXT    PRIMARY KEY,
+				name                      TEXT    NOT NULL,
+				version                   INTEGER NOT NULL,
+				parent_def_id             TEXT    REFERENCES agent_defs(def_id),
+				definition                TEXT    NOT NULL,
+				description               TEXT,
+				created_at                INTEGER NOT NULL,
+				created_by_agent_id       TEXT,
+				created_by_run_id         TEXT,
+				retired                   INTEGER NOT NULL DEFAULT 0,
+				bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+				content_sha256            TEXT,
+				UNIQUE(name, version)
+			)`,
+			// Legacy agent_def_active: PRIMARY KEY(name), no tenant_id.
+			`CREATE TABLE agent_def_active (
+				name                  TEXT    PRIMARY KEY,
+				def_id                TEXT    NOT NULL REFERENCES agent_defs(def_id),
+				promoted_at           INTEGER NOT NULL,
+				promoted_by_agent_id  TEXT
+			)`,
+			// Legacy dynamic_agents: PRIMARY KEY(name), no tenant_id.
+			`CREATE TABLE dynamic_agents (
+				name        TEXT    PRIMARY KEY,
+				definition  BLOB    NOT NULL,
+				created_at  INTEGER NOT NULL,
+				expires_at  INTEGER NOT NULL DEFAULT 0,
+				description TEXT
+			)`,
+		}
+		for _, q := range stmts {
+			if _, err := s.db.ExecContext(ctx, q); err != nil {
+				t.Fatalf("setup legacy schema: %q: %v", q, err)
+			}
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 2. Reopen — migrate() ALTERs in tenant_id + creates the ON CONFLICT
+	// target indexes.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("upgrade open: %v", err)
+	}
+	defer s.Close()
+	ctx := context.Background()
+
+	// 3. AgentDefCreate must succeed (exercises UNIQUE(tenant_id, name,
+	// version) via the version-bump path on a second create).
+	created, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:      "def_upgrade_v1",
+		Name:       "upgrade-agent",
+		Definition: []byte(`{"system_prompt":"hi"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("AgentDefCreate on upgraded DB failed (RFC N ON CONFLICT target missing?): %v", err)
+	}
+	if created.Version != 1 {
+		t.Errorf("first create version = %d, want 1", created.Version)
+	}
+	// Second create of the same name bumps the version — relies on the
+	// MAX(version) read + UNIQUE(tenant_id, name, version) insert.
+	created2, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+		DefID:      "def_upgrade_v2",
+		Name:       "upgrade-agent",
+		Definition: []byte(`{"system_prompt":"hi2"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("second AgentDefCreate on upgraded DB failed: %v", err)
+	}
+	if created2.Version != 2 {
+		t.Errorf("second create version = %d, want 2", created2.Version)
+	}
+
+	// 4. AgentDefSetActive must succeed (exercises ON CONFLICT(tenant_id,
+	// name) on agent_def_active).
+	if err := s.AgentDefSetActive(ctx, "", "upgrade-agent", "def_upgrade_v1", "a_admin"); err != nil {
+		t.Fatalf("AgentDefSetActive on upgraded DB failed (ON CONFLICT target missing?): %v", err)
+	}
+	// A re-promote to a different def_id exercises the DO UPDATE branch.
+	if err := s.AgentDefSetActive(ctx, "", "upgrade-agent", "def_upgrade_v2", "a_admin"); err != nil {
+		t.Fatalf("AgentDefSetActive re-promote on upgraded DB failed: %v", err)
+	}
+
+	// 5. DynamicAgentUpsert must succeed (exercises ON CONFLICT(tenant_id,
+	// name) on dynamic_agents).
+	if err := s.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		Name:       "dyn-agent",
+		Definition: []byte(`{"system_prompt":"dyn"}`),
+		TenantID:   "",
+	}); err != nil {
+		t.Fatalf("DynamicAgentUpsert on upgraded DB failed (ON CONFLICT target missing?): %v", err)
+	}
+	// Re-upsert exercises the DO UPDATE branch.
+	if err := s.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		Name:       "dyn-agent",
+		Definition: []byte(`{"system_prompt":"dyn2"}`),
+		TenantID:   "",
+	}); err != nil {
+		t.Fatalf("DynamicAgentUpsert re-upsert on upgraded DB failed: %v", err)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(path)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1914,7 +1914,11 @@ type AgentDefRow struct {
 // count is the version count; ActiveDefID is the agent_def_active
 // pointer (empty when no row is promoted under this name).
 type AgentDefNameSummary struct {
-	Name          string    `json:"name"`
+	Name string `json:"name"`
+	// TenantID is the RFC N owning tenant. A name owned by N tenants
+	// yields N summary rows (one per tenant) — without grouping by tenant
+	// the listing would merge distinct tenants' versions under one name.
+	TenantID      string    `json:"tenant_id,omitempty"`
 	VersionCount  int       `json:"version_count"`
 	ActiveDefID   string    `json:"active_def_id,omitempty"`
 	LatestVersion int       `json:"latest_version"`

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -745,10 +745,11 @@ type Store interface {
 	// the supplied DefID + Version + parent linkage. Idempotent.
 	SnapshotRestoreAgentDef(ctx context.Context, r AgentDefRow) (bool, error)
 
-	// SnapshotRestoreAgentDefActive UPSERTs one agent_def_active
-	// pointer. ON CONFLICT (name) DO UPDATE — preserves snapshot's
-	// promoted_at + promoted_by_agent_id. `inserted` is true only on
-	// the first write (no prior row for the name).
+	// SnapshotRestoreAgentDefActive inserts one agent_def_active
+	// pointer. ON CONFLICT (tenant_id, name) DO NOTHING — preserves the
+	// snapshot's promoted_at + promoted_by_agent_id on first restore;
+	// subsequent restores leave the row alone. `inserted` is true only
+	// on the first write (no prior row for the (tenant_id, name)).
 	SnapshotRestoreAgentDefActive(ctx context.Context, entry AgentDefActiveEntry) (bool, error)
 
 	// SnapshotRestoreSkillDef mirrors SnapshotRestoreAgentDef for
@@ -1085,17 +1086,22 @@ type Store interface {
 	AgentDefListNames(ctx context.Context) ([]AgentDefNameSummary, error)
 
 	// AgentDefSetActive UPSERTs the agent_def_active pointer for
-	// `name` to `defID`. promotedByAgentID is the agent_id that
-	// performed the promotion (may be empty for admin API calls).
+	// `(tenantID, name)` to `defID`. promotedByAgentID is the agent_id
+	// that performed the promotion (may be empty for admin API calls).
 	// Idempotent: promote A → promote B → promote A leaves the
-	// pointer at A with the latest promoted_at.
-	AgentDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
+	// pointer at A with the latest promoted_at. RFC N: the active
+	// pointer is per-tenant, and a def can only be promoted within its
+	// own tenant — implementations refuse if the def's tenant_id ≠
+	// tenantID. tenantID "" = the shared/operator/legacy tenant.
+	AgentDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error
 
-	// AgentDefGetActive returns the currently-active row for `name`
-	// — the (name, version) pointed at by agent_def_active. Returns
-	// *ErrNotFound when no active pointer exists (the caller falls
-	// through to cfg.Agents — the static fallback path).
-	AgentDefGetActive(ctx context.Context, name string) (AgentDefRow, error)
+	// AgentDefGetActive returns the currently-active row for
+	// `(tenantID, name)` — the (name, version) pointed at by
+	// agent_def_active within the tenant. Returns *ErrNotFound when no
+	// active pointer exists (the caller falls through to cfg.Agents —
+	// the static fallback path). RFC N: tenantID "" = the shared/
+	// operator/legacy tenant.
+	AgentDefGetActive(ctx context.Context, tenantID, name string) (AgentDefRow, error)
 
 	// AgentDefSetRetired flips the `retired` flag on one row. The
 	// row stays visible in lineage queries with the flag exposed;
@@ -1363,18 +1369,21 @@ type Store interface {
 	// the count deleted. Idempotent under concurrent sweepers.
 	MetricsSweep(ctx context.Context, cutoff time.Time) (int, error)
 
-	// DynamicAgentUpsert writes a dynamic agent row. The (name)
-	// column is the primary key — re-upserting the same name
-	// overwrites the definition and resets expires_at. expiresAt is
-	// zero-valued to mean "no expiry" (operator must explicitly
-	// DynamicAgentDelete). v0.8.15+.
+	// DynamicAgentUpsert writes a dynamic agent row. RFC N: the
+	// (tenant_id, name) tuple is the primary key — re-upserting the
+	// same (tenant, name) overwrites the definition and resets
+	// expires_at. agent.TenantID is set from the authoritative
+	// principal at the write site ("" = shared/legacy tenant).
+	// expiresAt is zero-valued to mean "no expiry" (operator must
+	// explicitly DynamicAgentDelete). v0.8.15+.
 	DynamicAgentUpsert(ctx context.Context, agent DynamicAgent) error
 
-	// DynamicAgentGet reads one dynamic agent. Returns *ErrNotFound
-	// for both "row missing" and "row expired" — callers don't need
-	// to distinguish. Expired rows are filtered server-side
-	// regardless of whether the sweeper has reaped them yet.
-	DynamicAgentGet(ctx context.Context, name string) (DynamicAgent, error)
+	// DynamicAgentGet reads one dynamic agent by (tenantID, name).
+	// Returns *ErrNotFound for both "row missing" and "row expired" —
+	// callers don't need to distinguish. Expired rows are filtered
+	// server-side regardless of whether the sweeper has reaped them
+	// yet. RFC N: tenantID "" = the shared/operator/legacy tenant.
+	DynamicAgentGet(ctx context.Context, tenantID, name string) (DynamicAgent, error)
 
 	// DynamicAgentList enumerates non-expired dynamic agents.
 	// Capped at 200 rows ordered by created_at DESC.
@@ -1838,11 +1847,16 @@ type MetricsRunWindow struct {
 // explicitly unregister); non-zero rows are filtered by
 // DynamicAgentGet / DynamicAgentList when expires_at < now().
 type DynamicAgent struct {
-	Name        string    `json:"name"`       // primary key; charset [A-Za-z0-9_-]{1,64}
+	Name        string    `json:"name"`       // part of the PK; charset [A-Za-z0-9_-]{1,64}
 	Definition  []byte    `json:"definition"` // JSON-encoded config.AgentDef body
 	CreatedAt   time.Time `json:"created_at"`
 	ExpiresAt   time.Time `json:"expires_at,omitempty"` // zero = no expiry
 	Description string    `json:"description,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. With (tenant_id, name) as the PK, two
+	// tenants register the same name independently. Set from the
+	// authoritative principal at the write site; never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // ---- v0.8.5 Self-Evolution Substrate types ----
@@ -1885,6 +1899,15 @@ type AgentDefRow struct {
 	// "sha256:" + 64 hex chars; empty when the row pre-dates the
 	// content-signature migration and hasn't been backfilled yet.
 	ContentSHA256 string `json:"content_sha256,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. The UNIQUE constraint is (tenant_id, name,
+	// version), so two tenants own the same name+version independently.
+	// Deliberately NOT part of the content hash — tenant is operational
+	// identity, not content (same rule RetryAttempts/RunTimeoutSeconds
+	// follow), so two tenants forking the same body get the same
+	// content_sha256. Set from the authoritative principal at the write
+	// site; never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // AgentDefNameSummary is one entry of AgentDefListNames' output.
@@ -2506,6 +2529,9 @@ type AgentDefActiveEntry struct {
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis (part of the
+	// agent_def_active PK). "" = the shared/operator/legacy tenant.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // MemorySnapshotEntry is one memory row enriched with its scope +

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -166,6 +166,9 @@ func Run(t *testing.T, factory Factory) {
 		{"AgentDefActivePointerIdempotent", testAgentDefActivePointerIdempotent},
 		{"AgentDefRetireReversible", testAgentDefRetireReversible},
 		{"AgentDefStaticFallback", testAgentDefStaticFallback},
+		// RFC N — agent definition plane tenant isolation. Fails on the
+		// pre-migration single-`name`-PK schema (clobber); passes after.
+		{"AgentDefTenantIsolation", testAgentDefTenantIsolation},
 		{"AgentDefContentSHA256RoundTrip", testAgentDefContentSHA256RoundTrip},
 		{"BackfillAgentDefContentSHA256", testBackfillAgentDefContentSHA256},
 		{"BackfillAgentDefSystemPromptBaseFillsLegacyRows", testBackfillAgentDefSystemPromptBase},
@@ -3468,16 +3471,16 @@ func testAgentDefActivePointerIdempotent(t *testing.T, s store.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+	if err := s.AgentDefSetActive(ctx, "", "promo", a.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AgentDefSetActive(ctx, "promo", b.DefID, ""); err != nil {
+	if err := s.AgentDefSetActive(ctx, "", "promo", b.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.AgentDefSetActive(ctx, "promo", a.DefID, ""); err != nil {
+	if err := s.AgentDefSetActive(ctx, "", "promo", a.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.AgentDefGetActive(ctx, "promo")
+	got, err := s.AgentDefGetActive(ctx, "", "promo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3515,10 +3518,104 @@ func testAgentDefRetireReversible(t *testing.T, s store.Store) {
 
 func testAgentDefStaticFallback(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_, err := s.AgentDefGetActive(ctx, "no-such-name")
+	_, err := s.AgentDefGetActive(ctx, "", "no-such-name")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("got %v, want *ErrNotFound", err)
+	}
+}
+
+// testAgentDefTenantIsolation pins the RFC N boundary: the SAME agent
+// name registered under two tenants must resolve to each tenant's OWN
+// definition + active pointer + dynamic_agents row — no cross-tenant
+// clobber, no cross-tenant read.
+//
+// FAIL-BEFORE: on the pre-migration schema (agent_def_active PK = (name),
+// agent_defs UNIQUE = (name, version), dynamic_agents PK = (name)),
+// tenant B's writes overwrite tenant A's (last-writer-wins on the single
+// global pointer / row), so the GetActive(A) assertion reads back B's
+// def_id and the test fails. The composite (tenant_id, name) PK is what
+// makes the two rows coexist.
+func testAgentDefTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "summarize"
+
+	// agent_defs + agent_def_active isolation.
+	aDef := mkDef("ti-a", name, "")
+	aDef.TenantID = "tenant-a"
+	aDef.Definition = json.RawMessage(`{"v":"A"}`)
+	aRow, err := s.AgentDefCreate(ctx, aDef)
+	if err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+
+	bDef := mkDef("ti-b", name, "")
+	bDef.TenantID = "tenant-b"
+	bDef.Definition = json.RawMessage(`{"v":"B"}`)
+	bRow, err := s.AgentDefCreate(ctx, bDef)
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	if err := s.AgentDefSetActive(ctx, "tenant-a", name, aRow.DefID, ""); err != nil {
+		t.Fatalf("promote A: %v", err)
+	}
+	if err := s.AgentDefSetActive(ctx, "tenant-b", name, bRow.DefID, ""); err != nil {
+		t.Fatalf("promote B: %v", err)
+	}
+
+	gotA, err := s.AgentDefGetActive(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("get active A: %v", err)
+	}
+	if gotA.DefID != aRow.DefID || gotA.TenantID != "tenant-a" || string(gotA.Definition) != `{"v":"A"}` {
+		t.Errorf("tenant-a clobbered: got def_id=%q tenant=%q def=%s, want A's own def",
+			gotA.DefID, gotA.TenantID, gotA.Definition)
+	}
+
+	gotB, err := s.AgentDefGetActive(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("get active B: %v", err)
+	}
+	if gotB.DefID != bRow.DefID || gotB.TenantID != "tenant-b" || string(gotB.Definition) != `{"v":"B"}` {
+		t.Errorf("tenant-b clobbered: got def_id=%q tenant=%q def=%s, want B's own def",
+			gotB.DefID, gotB.TenantID, gotB.Definition)
+	}
+
+	// A def can only be promoted within its own tenant — promoting A's
+	// def under tenant-b must be refused.
+	if err := s.AgentDefSetActive(ctx, "tenant-b", name, aRow.DefID, ""); err == nil {
+		t.Error("cross-tenant promote (A's def under tenant-b) unexpectedly succeeded")
+	}
+
+	// dynamic_agents isolation — same name, two tenants, distinct bodies.
+	if err := s.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		TenantID:   "tenant-a",
+		Name:       name,
+		Definition: json.RawMessage(`{"dyn":"A"}`),
+	}); err != nil {
+		t.Fatalf("dyn upsert A: %v", err)
+	}
+	if err := s.DynamicAgentUpsert(ctx, store.DynamicAgent{
+		TenantID:   "tenant-b",
+		Name:       name,
+		Definition: json.RawMessage(`{"dyn":"B"}`),
+	}); err != nil {
+		t.Fatalf("dyn upsert B: %v", err)
+	}
+	dynA, err := s.DynamicAgentGet(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("dyn get A: %v", err)
+	}
+	if string(dynA.Definition) != `{"dyn":"A"}` || dynA.TenantID != "tenant-a" {
+		t.Errorf("dynamic_agents tenant-a clobbered: got tenant=%q def=%s", dynA.TenantID, dynA.Definition)
+	}
+	dynB, err := s.DynamicAgentGet(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("dyn get B: %v", err)
+	}
+	if string(dynB.Definition) != `{"dyn":"B"}` || dynB.TenantID != "tenant-b" {
+		t.Errorf("dynamic_agents tenant-b clobbered: got tenant=%q def=%s", dynB.TenantID, dynB.Definition)
 	}
 }
 

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -420,6 +420,14 @@ func (a *AgentDef) execGet(ctx context.Context, policy tools.AgentDefPolicyValue
 		}
 		return errResult(fmt.Sprintf("get: %s", err)), nil
 	}
+	// RFC N: def_id is a global handle but a def is owned by exactly one
+	// tenant. checkScopeForName is tenant-blind, so guard here: a caller
+	// in tenant T cannot read another tenant's def. Return the SAME opaque
+	// not-found a missing def returns — never leak existence/body of a
+	// cross-tenant row.
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+	}
 	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -437,8 +445,15 @@ func (a *AgentDef) execList(ctx context.Context, policy tools.AgentDefPolicyValu
 	if err != nil {
 		return errResult(fmt.Sprintf("list: %s", err)), nil
 	}
+	// RFC N: AgentDefListByName returns rows across ALL tenants for a
+	// name (names are per-tenant now). Filter to the caller's own tenant
+	// so a tenant lists only its own versions.
+	tenantID := tools.RunIdentity(ctx).TenantID
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
+		if r.TenantID != tenantID {
+			continue
+		}
 		out = append(out, rowResponseMap(r))
 	}
 	return okJSON(map[string]any{"name": in.Name, "versions": out})
@@ -460,6 +475,12 @@ func (a *AgentDef) execRetire(ctx context.Context, policy tools.AgentDefPolicyVa
 			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 		}
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	// RFC N: refuse cross-tenant retire. AgentDefSetRetired is a global
+	// by-def_id mutation; without this guard a caller in tenant T could
+	// retire another tenant's def. Opaque not-found — don't leak existence.
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
 		return errResult(err.Error()), nil

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -220,6 +220,14 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
 	}
 
+	ident := tools.RunIdentity(ctx)
+	// RFC N: the tenant comes from the authoritative run identity in ctx
+	// (the AgentDef tool always runs inside a run whose RunIdentity
+	// carries the principal-derived tenant), never from tool input. ""
+	// = shared/legacy tenant. Used for the dedup probe, the row stamp,
+	// and the promote — all scoped to the agent's own tenant.
+	tenantID := ident.TenantID
+
 	contentSHA := signFromMergedDef(in.Name, def)
 	// Idempotent create: if the active def already carries this exact content,
 	// return it as a no-op instead of minting a byte-identical new version. A
@@ -228,13 +236,12 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 	// MCPServerDef.execCreate; compared only against the ACTIVE row, so
 	// re-creating content that matches a non-active version still mints +
 	// promotes (re-activation is a real state change).
-	if active, gerr := a.Store.AgentDefGetActive(ctx, in.Name); gerr == nil && active.ContentSHA256 == contentSHA {
+	if active, gerr := a.Store.AgentDefGetActive(ctx, tenantID, in.Name); gerr == nil && active.ContentSHA256 == contentSHA {
 		resp := rowResponse(active, true)
 		resp["deduplicated"] = true
 		return okJSON(resp)
 	}
 
-	ident := tools.RunIdentity(ctx)
 	row := store.AgentDefRow{
 		DefID:            mintDefID(),
 		Name:             in.Name,
@@ -242,6 +249,7 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    contentSHA,
+		TenantID:         tenantID,
 		// CreatedByRunID stays empty here — there's no run_id on
 		// RunIdentityValue today; carried via the run ctx separately.
 	}
@@ -254,7 +262,7 @@ func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyVa
 		promote = *in.Promote
 	}
 	if promote {
-		if err := a.Store.AgentDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+		if err := a.Store.AgentDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
 		}
 	}
@@ -276,6 +284,11 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 	//   2. parent_def_id empty + active pointer exists → use it
 	//   3. neither → name must have a static MD; bootstrap v1
 	//      snapshot as the parent
+	// RFC N: fork resolves + stamps within the agent's own tenant (from
+	// the authoritative run identity, never tool input).
+	ident := tools.RunIdentity(ctx)
+	tenantID := ident.TenantID
+
 	parentDefID := in.ParentDefID
 	var parent store.AgentDefRow
 	if parentDefID != "" {
@@ -290,10 +303,16 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		if row.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
 		}
+		// A def_id is a global handle; refuse to fork across the tenant
+		// boundary — a caller in tenant T can't pin another tenant's def
+		// as its parent (which would copy that tenant's body into T).
+		if row.TenantID != tenantID {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to another tenant, refusing", parentDefID)), nil
+		}
 		parent = row
 	} else {
 		// Try the active pointer first.
-		row, err := a.Store.AgentDefGetActive(ctx, in.Name)
+		row, err := a.Store.AgentDefGetActive(ctx, tenantID, in.Name)
 		if err == nil {
 			parent = row
 			parentDefID = row.DefID
@@ -316,7 +335,7 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 				// "another goroutine just won v1." Re-read the active
 				// pointer once before propagating the error — if it's
 				// now set, use that as our parent instead of failing.
-				if row2, gerr := a.Store.AgentDefGetActive(ctx, in.Name); gerr == nil {
+				if row2, gerr := a.Store.AgentDefGetActive(ctx, tenantID, in.Name); gerr == nil {
 					parent = row2
 					parentDefID = row2.DefID
 				} else {
@@ -361,7 +380,6 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), a.MaxDescriptionBytes)), nil
 	}
 
-	ident := tools.RunIdentity(ctx)
 	row := store.AgentDefRow{
 		DefID:            mintDefID(),
 		Name:             in.Name,
@@ -370,6 +388,7 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    signFromMergedDef(in.Name, def),
+		TenantID:         tenantID,
 	}
 	created, err := a.Store.AgentDefCreate(ctx, row)
 	if err != nil {
@@ -380,7 +399,7 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		promote = *in.Promote
 	}
 	if promote {
-		if err := a.Store.AgentDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+		if err := a.Store.AgentDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
 		}
 	}
@@ -467,7 +486,11 @@ func (a *AgentDef) execPromote(ctx context.Context, policy tools.AgentDefPolicyV
 		return errResult(err.Error()), nil
 	}
 	ident := tools.RunIdentity(ctx)
-	if err := a.Store.AgentDefSetActive(ctx, row.Name, row.DefID, ident.AgentID); err != nil {
+	// RFC N: promote within the agent's own tenant. AgentDefSetActive
+	// refuses when ident.TenantID ≠ row.TenantID, so a caller in tenant T
+	// cannot point at (or clobber) another tenant's active pointer — even
+	// though def_id is a global handle.
+	if err := a.Store.AgentDefSetActive(ctx, ident.TenantID, row.Name, row.DefID, ident.AgentID); err != nil {
 		return errResult(fmt.Sprintf("promote: %s", err)), nil
 	}
 	return okJSON(map[string]any{"def_id": row.DefID, "name": row.Name, "promoted": true})
@@ -491,7 +514,8 @@ func (a *AgentDef) execVerify(ctx context.Context, policy tools.AgentDefPolicyVa
 	if err := a.checkScopeForName(policy, in.Name, ""); err != nil {
 		return errResult(err.Error()), nil
 	}
-	row, err := a.Store.AgentDefGetActive(ctx, in.Name)
+	// RFC N: verify against the agent's own tenant active pointer.
+	row, err := a.Store.AgentDefGetActive(ctx, tools.RunIdentity(ctx).TenantID, in.Name)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -683,6 +707,10 @@ func (a *AgentDef) bootstrapStatic(ctx context.Context, name string, static conf
 		CreatedByAgentID:       ident.AgentID,
 		BootstrappedFromStatic: true,
 		ContentSHA256:          signFromMergedDef(name, def),
+		// RFC N: the bootstrapped lineage root lives in the forking
+		// caller's tenant (static cfg.Agents is the shared base; the
+		// fork that triggers bootstrap is per-tenant). "" = shared.
+		TenantID: ident.TenantID,
 	}
 	created, err := a.Store.AgentDefCreate(ctx, row)
 	if err != nil {

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -357,6 +357,75 @@ func TestAgentDefTool_RetireRoundTrip(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_TenantIsolationGetListRetire — RFC N FIX 3. The
+// get / list / retire ops were tenant-blind (gated only by the
+// tenant-blind checkScopeForName), so a caller in tenant A could read,
+// enumerate, and retire defs owned by tenant B. With scopes=[any] on both
+// callers (so the scope gate is NOT what refuses), the only thing keeping
+// tenants apart is the row-TenantID guard added by FIX 3.
+//
+// Pre-fix: get returns B's body, list returns B's versions, retire mutates
+// B's row — all from a tenant-A caller.
+func TestAgentDefTool_TenantIsolationGetListRetire(t *testing.T) {
+	tool, baseCtx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Two tenant contexts over the SAME tool/store. Both carry scopes=[any]
+	// (inherited from the fixture) so refusals come from the tenant guard,
+	// not the scope gate.
+	ctxA := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-a"})
+	ctxB := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-b"})
+
+	// Create a non-static def under tenant B.
+	res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"create","name":"b-only","overlay":{"system_prompt":"tenant b body"}}`))
+	if res.IsError {
+		t.Fatalf("create under B: %s", res.Text)
+	}
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// get from tenant A → opaque not-found (no cross-tenant leak).
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if !res.IsError {
+		t.Errorf("tenant A get of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	if !strings.Contains(res.Text, "not found") {
+		t.Errorf("cross-tenant get should return opaque not-found; got %s", res.Text)
+	}
+
+	// list from tenant A → must NOT include B's version.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("list under A: %s", res.Text)
+	}
+	versions := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 0 {
+		t.Errorf("tenant A list of name owned by B returned %d versions; want 0 (tenant filter)", len(versions))
+	}
+
+	// retire from tenant A → refused; B's row must stay un-retired.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if !res.IsError {
+		t.Errorf("tenant A retire of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	// Confirm B still sees its row un-retired (the retire didn't leak through).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("tenant B get of its own def: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["retired"].(bool) {
+		t.Error("tenant A's cross-tenant retire mutated tenant B's row")
+	}
+
+	// Sanity: tenant B CAN get + list its own def (the guard isn't over-broad).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("tenant B list of its own name: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
+		t.Errorf("tenant B list returned %d versions; want 1", n)
+	}
+}
+
 // Capability-escalation guard on `create`: an agent with narrow
 // allowed_tools cannot mint a new agent with a wider tool surface
 // than its own. The caller's effective AgentTools(ctx) is the

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -392,7 +392,9 @@ func (c *Context) execAgents(ctx context.Context, in contextInput) (tools.Result
 		// so operators see the partial failure without losing the rest
 		// of the catalog. PR 2 review fix.
 		if c.Store != nil {
-			row, err := c.Store.AgentDefGetActive(ctx, name)
+			// RFC N: read the active pointer within the agent's own tenant
+			// (from the authoritative run identity in ctx; "" = shared).
+			row, err := c.Store.AgentDefGetActive(ctx, tools.RunIdentity(ctx).TenantID, name)
 			if err == nil {
 				s.ActiveDefID = row.DefID
 			} else {

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -384,7 +384,7 @@ func substrateFixture(t *testing.T) (*Context, store.Store, context.Context, str
 	if err != nil {
 		t.Fatalf("AgentDefCreate v2: %v", err)
 	}
-	if err := s.AgentDefSetActive(ctx, agentName, v2.DefID, ""); err != nil {
+	if err := s.AgentDefSetActive(ctx, "", agentName, v2.DefID, ""); err != nil {
 		t.Fatalf("AgentDefSetActive: %v", err)
 	}
 


### PR DESCRIPTION
First slice of **RFC N — multi-tenant definition plane** (`doc-internal/rfcs/multi-tenant-definition-plane.md`). Closes the agent half of the gap RFC L left open: agent definitions (static yaml + dynamic substrate) had **no tenant dimension**, so two tenants registering the same name collided on a single global `agent_def_active` pointer (last-writer-wins) and any token could resolve & run another tenant's agent.

**Scope: agents only.** Skills and MCP servers replicate this exact pattern in follow-up PRs.

## What changed
- **Schema** (`0037_agent_defs_tenant_id` + SQLite DDL): `tenant_id` on `agent_defs` / `agent_def_active` / `dynamic_agents`; `agent_def_active` PK → `(tenant_id, name)`, `dynamic_agents` PK → `(tenant_id, name)`, `agent_defs` UNIQUE → `(tenant_id, name, version)`. `''` = shared/legacy tenant; existing rows backfill to `''` via DEFAULT — the migration the `0006_agent_defs` comment anticipated.
- **Resolver** (`internal/lookup.Agent` gains `tenantID`): precedence **tenant-dynamic → static cfg (shared base) → shared-dynamic (`''`)**. For the `''` tenant the tenant step is skipped, so the order collapses to static-cfg→shared-dynamic — **byte-for-byte the pre-RFC-N behavior**. Single-tenant deployments are unchanged.
- **Authoritative tenant**: derived from `auth.PrincipalFromContext` → `tools.RunIdentity` → `''` (new `tenantFromCtx`), **never from a wire/body field or model text** (mirrors RFC L's `applyPrincipal`). `RegisterAgentRequest` still carries no tenant.
- **Write guards**: `AgentDefSetActive` refuses to promote across a tenant boundary; fork refuses a `parent_def_id` from another tenant; create/promote/verify all scope to the agent's own tenant. `runSubAgent` resolves within the parent's inherited tenant.
- `tenant_id` is **excluded from `content_sha256`** (operational identity, not content — same rule as `RetryAttempts`/`RunTimeoutSeconds`), so two tenants forking the same body hash identically.

## Tested
- New `TestStoreContract/AgentDefTenantIsolation` (fail-before verified): same name under tenant A & B, distinct bodies → each resolves its own def, cross-tenant promote refused, `dynamic_agents` isolated. On the pre-migration single-`name` schema it fails with the exact clobber (`UNIQUE constraint failed: agent_defs.name, agent_defs.version`).
- New lookup tests: `TestAgent_TenantResolutionPrecedence`, `TestAgent_DefaultTenantPreservesStaticFirstOrder`.
- `go build ./...`, `go vet ./...`, `gofmt -l`, **full `go test ./...`** all clean.

## Known limitations (documented)
- **SQLite in-place upgrade** keeps `PRIMARY KEY(name)` (SQLite can't rewrite a PK in place) — byte-equivalent for single-tenant (`''`); true per-tenant isolation on SQLite needs a fresh DB. **Postgres upgrades in place** via 0037 (production is Postgres per the deploy plan).
- `ListAgents` (catalog listing) still enumerates all tenants with `TenantID` populated — tenant-filtered listing + MCP-advertising filtering are the RFC §3 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)