### PR TITLE
feat(authz): tenant-scope the skill definition plane (RFC N, skills slice)

### DIFF
--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -162,7 +162,7 @@ func TestLibrary_SkillDefNames_AfterSeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = s.SkillDefSetActive(ctx, "voice-applier", "sdef_voice_v1", "")
+	_ = s.SkillDefSetActive(ctx, "", "voice-applier", "sdef_voice_v1", "")
 
 	req := authedRequest("GET", "/v1/_skilldef/names", nil)
 	rec := httptest.NewRecorder()

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1044,8 +1044,12 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 	resolutions := make(map[string]lookup.SkillResolution, len(agentDef.Skills))
 	activeDefIDs := make(map[string]string, len(agentDef.Skills))
 	anySubstrate := false
+	// RFC N: resolve each skill within the run's tenant (from the
+	// authoritative principal in ctx, never the wire). A token only sees
+	// its own tenant's promotions + the shared base. "" = shared tenant.
+	tenantID := tenantFromCtx(ctx)
 	for _, skillName := range agentDef.Skills {
-		sr, ok := lookup.Skill(ctx, s.store, s.skillSet, skillName)
+		sr, ok := lookup.Skill(ctx, s.store, s.skillSet, tenantID, skillName)
 		if !ok {
 			continue
 		}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1032,7 +1032,7 @@ type runPromptProvenance struct {
 // Second return value is the per-run provenance (skillName → active
 // SkillDef def_id) for callers emitting the v0.9.x `system_prompt`
 // transcript event. Empty when no DB-active rows were used.
-func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.AgentDef) (config.AgentDef, runPromptProvenance) {
+func (s *Server) resolveSkillBodiesForRun(ctx context.Context, tenantID string, agentDef config.AgentDef) (config.AgentDef, runPromptProvenance) {
 	var prov runPromptProvenance
 	if len(agentDef.Skills) == 0 || s.store == nil {
 		return agentDef, prov
@@ -1044,10 +1044,16 @@ func (s *Server) resolveSkillBodiesForRun(ctx context.Context, agentDef config.A
 	resolutions := make(map[string]lookup.SkillResolution, len(agentDef.Skills))
 	activeDefIDs := make(map[string]string, len(agentDef.Skills))
 	anySubstrate := false
-	// RFC N: resolve each skill within the run's tenant (from the
-	// authoritative principal in ctx, never the wire). A token only sees
-	// its own tenant's promotions + the shared base. "" = shared tenant.
-	tenantID := tenantFromCtx(ctx)
+	// RFC N: tenant is an EXPLICIT argument, not ctx-derived — mirrors
+	// lookupAgent (FIX 2). At the run-creation entry sites the run's
+	// authoritative tenant (effectiveTenantID / sess.TenantID) is already
+	// computed BEFORE WithRunIdentity is stamped on ctx, so deriving it
+	// from tenantFromCtx(ctx) here would resolve skills at the WRONG tenant
+	// for non-HTTP-principal spawn surfaces (A2A / scheduler / webhook /
+	// MCP spawn_run / gRPC-legacy) while memory + sub-agents use the run's
+	// tenant. The sub-agent call (runSubAgent) passes tenantFromCtx(ctx)
+	// since the parent's RunIdentity already carries the tenant. A token
+	// only sees its own tenant's promotions + the shared base. "" = shared.
 	for _, skillName := range agentDef.Skills {
 		sr, ok := lookup.Skill(ctx, s.store, s.skillSet, tenantID, skillName)
 		if !ok {
@@ -1487,7 +1493,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies
 	// when any of the agent's skills has a DB-active row. No-op
 	// fast path when none do.
-	agentDef, promptProv := s.resolveSkillBodiesForRun(ctx, agentDef)
+	// RFC N: resolve skills at the run's authoritative tenant
+	// (effectiveTenantID), NOT tenantFromCtx(ctx) — WithRunIdentity isn't
+	// stamped until below, so for non-HTTP-principal spawn surfaces the
+	// ctx tenant is wrong here. Mirrors the lookupAgent fix above.
+	agentDef, promptProv := s.resolveSkillBodiesForRun(ctx, effectiveTenantID, agentDef)
 	if agentDef.SystemPrompt != "" {
 		segments = append([]loop.PromptSegment{{
 			Role: "system",
@@ -2629,7 +2639,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	dispatcher := s.newDispatcher(allowedTools)
 
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies.
-	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), agentDef)
+	// RFC N: resolve at this handler's authoritative tenant. On an authed
+	// HTTP route the principal is on ctx, so tenantFromCtx returns the
+	// principal's tenant (the same value applyPrincipal resolves) — never
+	// the wire. Mirrors the lookupAgent existence-check above.
+	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), tenantFromCtx(r.Context()), agentDef)
 	// Optional system prompt from agent def.
 	if agentDef.SystemPrompt != "" {
 		req.Segments = append([]loop.PromptSegment{{
@@ -3044,7 +3058,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies
 	// when any of the agent's skills has a DB-active row. No-op
 	// fast path when none do.
-	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), agentDef)
+	// RFC N: resolve at the SESSION's authoritative tenant (the same value
+	// RunOnce uses for a continuation), not tenantFromCtx — the ownership
+	// gate above already proved the caller is entitled to this session.
+	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), sess.TenantID, agentDef)
 	if agentDef.SystemPrompt != "" {
 		segments = append([]loop.PromptSegment{{
 			Role: "system",
@@ -3712,7 +3729,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// sub-agents would silently keep the static baked body and
 	// SkillDef promotions never take effect for agents only spawned
 	// as sub-agents.
-	def, promptProv := s.resolveSkillBodiesForRun(ctx, def)
+	// RFC N: a sub-agent runs with the parent's RunIdentity already on
+	// ctx, so tenantFromCtx(ctx) returns the parent's (== the run's)
+	// authoritative tenant — resolve the sub-agent's skills there.
+	def, promptProv := s.resolveSkillBodiesForRun(ctx, tenantFromCtx(ctx), def)
 	// Build segments: agent's system_prompt (with cache_control) + the
 	// caller-supplied prompt as the first user message. Mirrors the
 	// shape of /v1/runs.

--- a/internal/api/http/skilldef_resolution_test.go
+++ b/internal/api/http/skilldef_resolution_test.go
@@ -23,7 +23,7 @@ func TestResolveSkillBodiesForRun_NoSkillsIsNoop(t *testing.T) {
 
 	srv := &Server{store: s}
 	def := config.AgentDef{SystemPrompt: "base prompt", SystemPromptBase: "base prompt"}
-	got, _ := srv.resolveSkillBodiesForRun(context.Background(), def)
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
 	if got.SystemPrompt != "base prompt" {
 		t.Errorf("got %q, want unchanged base prompt", got.SystemPrompt)
 	}
@@ -46,7 +46,7 @@ func TestResolveSkillBodiesForRun_NoActiveRowsIsNoop(t *testing.T) {
 		SystemPrompt:     baked,
 		SystemPromptBase: "base prompt",
 	}
-	got, _ := srv.resolveSkillBodiesForRun(context.Background(), def)
+	got, _ := srv.resolveSkillBodiesForRun(context.Background(), "", def)
 	if got.SystemPrompt != baked {
 		t.Errorf("no DB-active row should leave baked prompt unchanged; got %q", got.SystemPrompt)
 	}
@@ -85,7 +85,7 @@ func TestResolveSkillBodiesForRun_DBActiveOverrides(t *testing.T) {
 		SystemPrompt:     "base prompt\n\n---\n\nSTATIC BODY",
 		SystemPromptBase: "base prompt",
 	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
 	if !strings.Contains(got.SystemPrompt, "DB BODY") {
 		t.Errorf("DB body should be substituted into SystemPrompt; got %q", got.SystemPrompt)
 	}
@@ -130,7 +130,7 @@ func TestResolveSkillBodiesForRun_StaleRowIsIgnored(t *testing.T) {
 		SystemPrompt:     baked,
 		SystemPromptBase: "base prompt",
 	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
 	if got.SystemPrompt != baked {
 		t.Errorf("empty-body DB row should NOT trigger rebuild; got %q", got.SystemPrompt)
 	}
@@ -169,8 +169,71 @@ func TestResolveSkillBodiesForRun_OneSkillResolvesEvenIfAnotherIsMissing(t *test
 		SystemPrompt:     "base prompt\n\n---\n\nstatic A\n\n---\n\nstatic B",
 		SystemPromptBase: "base prompt",
 	}
-	got, _ := srv.resolveSkillBodiesForRun(ctx, def)
+	got, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
 	if !strings.Contains(got.SystemPrompt, "DB BODY A") {
 		t.Errorf("DB body for skill-a should be substituted; got %q", got.SystemPrompt)
+	}
+}
+
+// TestResolveSkillBodiesForRun_ResolvesExplicitTenantWithoutPrincipalOnCtx
+// — RFC N FIX 2-skills regression, the skill analogue of
+// TestLookupAgent_ResolvesExplicitTenantWithoutPrincipalOnCtx. A
+// non-HTTP-principal spawn surface (A2A / scheduler / webhook / MCP
+// spawn_run / gRPC-legacy) computes the run's authoritative tenant as
+// effectiveTenantID and passes it EXPLICITLY to resolveSkillBodiesForRun,
+// with NO auth.Principal on ctx and WithRunIdentity not yet stamped. The
+// agent's skills MUST resolve at the run's tenant T, not at "".
+//
+// Pre-fix, resolveSkillBodiesForRun derived the tenant from
+// tenantFromCtx(ctx) which — with no principal and no RunIdentity —
+// returns "", so the run resolved its skills at the SHARED tenant while
+// memory + sub-agents used T. This test fails on the unfixed signature
+// (it wouldn't compile against the old ctx-only helper, and semantically
+// would resolve "" not T's promoted body).
+func TestResolveSkillBodiesForRun_ResolvesExplicitTenantWithoutPrincipalOnCtx(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+	ctx := context.Background() // NO principal, NO RunIdentity (A2A/scheduler shape)
+
+	// Promote a SkillDef body for "tenant-skill" ONLY under tenant "acme"
+	// — not the shared "" tenant.
+	defJSON, _ := json.Marshal(map[string]string{"body": "ACME DB BODY"})
+	row, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID:      "sdf_acme",
+		Name:       "tenant-skill",
+		Definition: defJSON,
+		TenantID:   "acme",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SkillDefSetActive(ctx, "acme", "tenant-skill", row.DefID, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{store: s}
+	def := config.AgentDef{
+		Skills:           []string{"tenant-skill"},
+		SystemPrompt:     "base prompt\n\n---\n\nSTATIC BODY",
+		SystemPromptBase: "base prompt",
+	}
+
+	// Explicit tenant "acme" resolves acme's promoted body even with no
+	// principal/RunIdentity on ctx.
+	got, _ := srv.resolveSkillBodiesForRun(ctx, "acme", def)
+	if !strings.Contains(got.SystemPrompt, "ACME DB BODY") {
+		t.Errorf("the run's authoritative tenant must resolve its own promoted skill body even with no principal on ctx; got %q", got.SystemPrompt)
+	}
+
+	// The same agent resolved at the SHARED tenant "" must NOT see acme's
+	// promotion — proving the tenant argument (not a ctx default) selects
+	// the row. With no shared-tenant active row, the baked static prompt
+	// stays unchanged (fast path).
+	gotShared, _ := srv.resolveSkillBodiesForRun(ctx, "", def)
+	if strings.Contains(gotShared.SystemPrompt, "ACME DB BODY") {
+		t.Error("resolving at the shared tenant \"\" surfaced an acme-only promotion; tenant isolation breached")
 	}
 }

--- a/internal/api/http/skilldef_resolution_test.go
+++ b/internal/api/http/skilldef_resolution_test.go
@@ -73,7 +73,7 @@ func TestResolveSkillBodiesForRun_DBActiveOverrides(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "karpathy-guidelines", row.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "karpathy-guidelines", row.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -119,7 +119,7 @@ func TestResolveSkillBodiesForRun_StaleRowIsIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "empty-skill", row.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "empty-skill", row.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -159,7 +159,7 @@ func TestResolveSkillBodiesForRun_OneSkillResolvesEvenIfAnotherIsMissing(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "skill-a", row.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "skill-a", row.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/lookup/README.md
+++ b/internal/lookup/README.md
@@ -27,7 +27,7 @@ Every code path that needs to resolve an agent / skill / MCP server NAME to its 
 
 ```go
 def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantID, name)
-sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, name)
+sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, tenantID, name)
 spec, ok := lookup.MCPServer(s.cfg, dynRegistry, name)
 ```
 
@@ -48,8 +48,27 @@ single-tenant deployment (everything `tenant_id=""`) is unchanged. The
 `tenantID` MUST come from the authoritative principal in ctx
 (`auth.PrincipalFromContext` → `tools.RunIdentity` fallback → `""`), never
 from a wire/request field — see `internal/api/http/server.go`'s
-`tenantFromCtx`. (Skills + MCP servers still resolve globally; their tenant
-axis is a follow-up.)
+`tenantFromCtx`. (MCP servers still resolve globally; their tenant axis is
+a follow-up.)
+
+### Skill resolution precedence (RFC N — tenant axis)
+
+`lookup.Skill` resolves within the caller's `tenantID`, but the skill
+plane is **substrate-first then static** — the opposite of the agent
+plane:
+
+1. **(tenantID != "")** tenant-scoped substrate — `skill_def_active` →
+   `skill_defs`, `WHERE tenant_id=tenantID`. A per-tenant promotion
+   *shadows* the shared static base by name.
+2. **shared substrate** — `skill_def_active`, `tenant_id=""` — the
+   operator's shared override.
+3. **static skill set** (`LOOMCYCLE_SKILLS_ROOT`) — the shared base every
+   tenant inherits.
+
+For the default tenant `""`, step 1 is skipped, so the order collapses to
+**shared-substrate → static** — byte-for-byte the pre-RFC-N
+"substrate-first then static" behavior. The same ctx-authoritative
+`tenantID` rule applies as for agents.
 
 Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` + `TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef`) — a future field added to one shape without the other fails CI.
 

--- a/internal/lookup/skill.go
+++ b/internal/lookup/skill.go
@@ -11,8 +11,9 @@ import (
 )
 
 // SkillStore is the subset of store.Store the skill resolver uses.
+// RFC N: the active-pointer lookup carries a tenantID.
 type SkillStore interface {
-	SkillDefGetActive(ctx context.Context, name string) (store.SkillDefRow, error)
+	SkillDefGetActive(ctx context.Context, tenantID, name string) (store.SkillDefRow, error)
 }
 
 // SkillResolution is the effective skill body + metadata returned
@@ -30,48 +31,52 @@ type SkillResolution struct {
 	Source string
 }
 
-// Skill resolves a skill NAME to its effective body + allowed_tools by
-// walking the lookup chain in precedence order:
+// Skill resolves a skill NAME to its effective body + allowed_tools
+// within the caller's tenant, walking the lookup chain in precedence
+// order:
 //
-//  1. substrate (skill_def_active overlay → skill_defs row) —
-//     operator pushed via `POST /v1/_skilldef create`.
-//  2. static skill set (loaded from LOOMCYCLE_SKILLS_ROOT at boot).
+//  1. (tenantID != "") tenant-scoped substrate (skill_def_active overlay
+//     → skill_defs row, WHERE tenant_id=tenantID). A per-tenant
+//     promotion shadows the shared base by name.
+//  2. shared-substrate (skill_def_active, tenant_id="") — the operator's
+//     shared override.
+//  3. static skill set (loaded from LOOMCYCLE_SKILLS_ROOT at boot) — the
+//     shared base every tenant inherits.
 //
-// Returns (zero, false) when neither source has the name.
+// For the default tenant "" step 1 is skipped, so the order collapses to
+// shared-substrate → static — byte-for-byte the pre-RFC-N
+// "substrate-first then static" behavior. This is the critical
+// back-compat property; the skill plane resolves substrate-FIRST (the
+// opposite of agents, which is static-first), and that legacy order is
+// preserved exactly for the "" tenant.
+//
+// The tenantID MUST come from the authoritative principal in ctx
+// (auth.PrincipalFromContext → tools.RunIdentity fallback → ""), never
+// from a wire/request field — see internal/api/http/server.go's
+// tenantFromCtx.
+//
+// Returns (zero, false) when no source has the name.
 //
 // This mirrors what resolveSkillBodiesForRun in api/http/server.go
 // has done inline for skill-baking at run-start. Factored here so
 // the multi-tier lookup is in one place + the SubstrateSkillDef
 // adapter has a documented home alongside the AgentDef one.
-func Skill(ctx context.Context, s SkillStore, set *skills.Set, name string) (SkillResolution, bool) {
-	if s != nil {
-		row, err := s.SkillDefGetActive(ctx, name)
-		switch {
-		case err == nil:
-			var sd SubstrateSkillDef
-			if uerr := json.Unmarshal(row.Definition, &sd); uerr != nil {
-				// Hand-edited / corrupted row — log + fall through to
-				// static so the run can continue with the boot bake.
-				log.Printf("lookup.Skill(%q): parse %s definition failed: %v", name, row.DefID, uerr)
-			} else if sd.Body != "" {
-				return SkillResolution{
-					Body:         sd.Body,
-					AllowedTools: sd.AllowedTools,
-					DefID:        row.DefID,
-					Source:       "substrate",
-				}, true
-			}
-		default:
-			var nf *store.ErrNotFound
-			if !errors.As(err, &nf) {
-				// Transient store hiccup. Static fallback preserves
-				// correctness (the static bake still runs); the log line
-				// is the operator's signal that a substrate override was
-				// skipped this run.
-				log.Printf("lookup.Skill(%q): SkillDefGetActive failed: %v", name, err)
-			}
+func Skill(ctx context.Context, s SkillStore, set *skills.Set, tenantID, name string) (SkillResolution, bool) {
+	// 1. Tenant-scoped substrate shadow (skipped for the shared ""
+	//    tenant so its order stays shared-substrate → static, exactly
+	//    as pre-RFC-N).
+	if s != nil && tenantID != "" {
+		if res, ok := resolveSubstrateSkill(ctx, s, tenantID, name); ok {
+			return res, true
 		}
 	}
+	// 2. Shared substrate (tenant_id="").
+	if s != nil {
+		if res, ok := resolveSubstrateSkill(ctx, s, "", name); ok {
+			return res, true
+		}
+	}
+	// 3. Static skill set — the shared base.
 	if set != nil {
 		if sk, ok := set.Get(name); ok {
 			return SkillResolution{
@@ -79,6 +84,42 @@ func Skill(ctx context.Context, s SkillStore, set *skills.Set, name string) (Ski
 				AllowedTools: sk.AllowedTools,
 				Source:       "static",
 			}, true
+		}
+	}
+	return SkillResolution{}, false
+}
+
+// resolveSubstrateSkill runs the skill_def_active → skill_defs lookup
+// for one tenant pass. Returns (zero, false) when the tenant has no
+// usable active row for the name. Preserves the parse-error +
+// transient-error logging/fallback semantics exactly: a corrupt row or
+// a transient store hiccup logs + returns false so the caller falls
+// through to the next tier (the static bake still runs).
+func resolveSubstrateSkill(ctx context.Context, s SkillStore, tenantID, name string) (SkillResolution, bool) {
+	row, err := s.SkillDefGetActive(ctx, tenantID, name)
+	switch {
+	case err == nil:
+		var sd SubstrateSkillDef
+		if uerr := json.Unmarshal(row.Definition, &sd); uerr != nil {
+			// Hand-edited / corrupted row — log + fall through to
+			// static so the run can continue with the boot bake.
+			log.Printf("lookup.Skill(%q): parse %s definition failed: %v", name, row.DefID, uerr)
+		} else if sd.Body != "" {
+			return SkillResolution{
+				Body:         sd.Body,
+				AllowedTools: sd.AllowedTools,
+				DefID:        row.DefID,
+				Source:       "substrate",
+			}, true
+		}
+	default:
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			// Transient store hiccup. Static fallback preserves
+			// correctness (the static bake still runs); the log line
+			// is the operator's signal that a substrate override was
+			// skipped this run.
+			log.Printf("lookup.Skill(%q): SkillDefGetActive failed: %v", name, err)
 		}
 	}
 	return SkillResolution{}, false

--- a/internal/lookup/skill_tenant_test.go
+++ b/internal/lookup/skill_tenant_test.go
@@ -1,0 +1,117 @@
+package lookup_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// stubSkillStore implements lookup.SkillStore honouring the RFC N tenant
+// axis. Active rows are keyed by (tenant, name).
+type stubSkillStore struct {
+	active map[string]store.SkillDefRow
+}
+
+func skillKey(tenantID, name string) string { return tenantID + "\x00" + name }
+
+func (s *stubSkillStore) SkillDefGetActive(_ context.Context, tenantID, name string) (store.SkillDefRow, error) {
+	if row, ok := s.active[skillKey(tenantID, name)]; ok {
+		return row, nil
+	}
+	return store.SkillDefRow{}, &store.ErrNotFound{Kind: "skill_def_active", ID: name}
+}
+
+func mustSubstrateSkill(t *testing.T, body string) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(lookup.SubstrateSkillDef{Body: body})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// staticSetWith builds a skills.Set from a temp dir holding one
+// (name, body) SKILL.md — the established test pattern (LoadSet from
+// disk; the Set has no exported constructor).
+func staticSetWith(t *testing.T, name, body string) *skills.Set {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	md := "---\nname: " + name + "\n---\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(md), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	set, err := skills.LoadSet(root)
+	if err != nil {
+		t.Fatalf("LoadSet: %v", err)
+	}
+	return set
+}
+
+// TestSkill_TenantResolutionPrecedence pins the RFC N resolution model
+// for skills: a tenant-scoped substrate promotion shadows the shared
+// static base by name, while a different tenant resolving the same name
+// falls through to the shared static base (it cannot see tenant A's
+// private skill).
+func TestSkill_TenantResolutionPrecedence(t *testing.T) {
+	ss := &stubSkillStore{active: map[string]store.SkillDefRow{
+		skillKey("tenant-a", "shared"): {
+			DefID:      "sd_a_v1",
+			Name:       "shared",
+			Definition: mustSubstrateSkill(t, "tenant-A private"),
+		},
+	}}
+	set := staticSetWith(t, "shared", "operator shared base")
+
+	// Tenant A: its substrate promotion shadows the shared static base.
+	gotA, ok := lookup.Skill(context.Background(), ss, set, "tenant-a", "shared")
+	if !ok {
+		t.Fatal("tenant-a resolve !ok")
+	}
+	if gotA.Body != "tenant-A private" || gotA.Source != "substrate" {
+		t.Errorf("tenant-a: got body=%q source=%q, want its own substrate def", gotA.Body, gotA.Source)
+	}
+
+	// Tenant B: no private promotion → falls through to the shared static
+	// base. It must NOT see tenant A's private substrate def.
+	gotB, ok := lookup.Skill(context.Background(), ss, set, "tenant-b", "shared")
+	if !ok {
+		t.Fatal("tenant-b resolve !ok")
+	}
+	if gotB.Body != "operator shared base" || gotB.Source != "static" {
+		t.Errorf("tenant-b: got body=%q source=%q, want the shared static base (no cross-tenant leak)", gotB.Body, gotB.Source)
+	}
+}
+
+// TestSkill_DefaultTenantPreservesSubstrateFirstOrder pins the
+// back-compat invariant: for the default tenant "", a name present in
+// BOTH the shared substrate AND the static set resolves to the SUBSTRATE
+// one — identical to the pre-RFC-N "substrate first, then static" order
+// (the opposite of the agent plane).
+func TestSkill_DefaultTenantPreservesSubstrateFirstOrder(t *testing.T) {
+	ss := &stubSkillStore{active: map[string]store.SkillDefRow{
+		skillKey("", "dual"): {
+			DefID:      "sd_shared_v1",
+			Name:       "dual",
+			Definition: mustSubstrateSkill(t, "substrate wins"),
+		},
+	}}
+	set := staticSetWith(t, "dual", "static loses")
+
+	got, ok := lookup.Skill(context.Background(), ss, set, "", "dual")
+	if !ok {
+		t.Fatal("resolve !ok")
+	}
+	if got.Body != "substrate wins" || got.Source != "substrate" {
+		t.Errorf("default tenant precedence broke: got body=%q source=%q, want the shared substrate def", got.Body, got.Source)
+	}
+}

--- a/internal/store/postgres/migrations/0038_skill_defs_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0038_skill_defs_tenant_id.down.sql
@@ -1,0 +1,16 @@
+-- 0038_skill_defs_tenant_id.down.sql — reverse RFC N's tenant axis on
+-- the skill definition plane. Restores the single-column PK and the
+-- UNIQUE(name, version) constraint, then drops the tenant_id columns.
+--
+-- NOTE: down is only safe while every row is tenant_id='' (the
+-- single-tenant / pre-migration state). If real per-tenant rows exist,
+-- restoring the single-col PK would collide on duplicate names — the
+-- operator must reconcile names before rolling back.
+
+ALTER TABLE skill_def_active DROP CONSTRAINT skill_def_active_pkey;
+ALTER TABLE skill_def_active ADD PRIMARY KEY (name);
+ALTER TABLE skill_def_active DROP COLUMN tenant_id;
+
+ALTER TABLE skill_defs DROP CONSTRAINT skill_defs_tenant_name_version_key;
+ALTER TABLE skill_defs ADD CONSTRAINT skill_defs_name_version_key UNIQUE (name, version);
+ALTER TABLE skill_defs DROP COLUMN tenant_id;

--- a/internal/store/postgres/migrations/0038_skill_defs_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0038_skill_defs_tenant_id.up.sql
@@ -1,0 +1,27 @@
+-- 0038_skill_defs_tenant_id.up.sql — RFC N: tenant-scope the skill
+-- definition plane (mirror of 0037 for the skill tables).
+--
+-- RFC L isolated the STATE plane (runs/sessions/memory keyed on the
+-- authoritative principal). It left the DEFINITION plane global: the
+-- skill_defs / skill_def_active tables had no tenant column, so two
+-- tenants registering the same name collided on a single global active
+-- pointer (last-writer-wins) and any token could resolve & run another
+-- tenant's skill. This migration adds the tenant axis, mirroring the
+-- agent definition plane (0037).
+--
+-- '' = the shared/operator/legacy tenant. Existing rows backfill to ''
+-- via the column DEFAULT, so a single-tenant deployment behaves exactly
+-- as before. This PR covers SKILLS only; MCP servers follow.
+
+-- skill_defs: tenant the versioned-definition rows. The UNIQUE(name,
+-- version) becomes UNIQUE(tenant_id, name, version) so two tenants can
+-- own the same name independently.
+ALTER TABLE skill_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE skill_defs DROP CONSTRAINT skill_defs_name_version_key;
+ALTER TABLE skill_defs ADD CONSTRAINT skill_defs_tenant_name_version_key UNIQUE (tenant_id, name, version);
+
+-- skill_def_active: the active pointer is now per (tenant_id, name). Add
+-- the column, drop the single-col PK, add the composite PK.
+ALTER TABLE skill_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE skill_def_active DROP CONSTRAINT skill_def_active_pkey;
+ALTER TABLE skill_def_active ADD PRIMARY KEY (tenant_id, name);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1113,9 +1113,9 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 	rows, err := s.pool.Query(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition::text, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static
+		        retired, bootstrapped_from_static, tenant_id
 		 FROM skill_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read skill_defs: %w", err)
@@ -1135,7 +1135,7 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&r.CreatedAt, &createdBy, &createdRun,
-			&r.Retired, &r.BootstrappedFromStatic,
+			&r.Retired, &r.BootstrappedFromStatic, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan skill_def: %w", err)
 		}
@@ -1160,9 +1160,9 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 // SnapshotReadSkillDefActive implements store.Store.
 func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDefActiveEntry, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM skill_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read skill_def_active: %w", err)
 	}
@@ -1173,7 +1173,7 @@ func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDe
 			e        store.SkillDefActiveEntry
 			promoter *string
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan skill_def_active: %w", err)
 		}
 		if promoter != nil {
@@ -1599,14 +1599,14 @@ func (s *Store) SnapshotRestoreSkillDef(ctx context.Context, r store.SkillDefRow
 		`INSERT INTO skill_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)
 		 ON CONFLICT (def_id) DO NOTHING`,
 		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
 		string(r.Definition), nullIfEmpty(r.Description),
 		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
 		r.Retired, r.BootstrappedFromStatic,
-		nullIfEmpty(r.ContentSHA256),
+		nullIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def: %w", err)
@@ -1624,9 +1624,9 @@ func (s *Store) SnapshotRestoreSkillDefActive(ctx context.Context, e store.Skill
 		promotedAt = time.Now().UTC()
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO skill_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (name) DO NOTHING`,
-		e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
+		`INSERT INTO skill_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id, name) DO NOTHING`,
+		e.TenantID, e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def_active: %w", err)
@@ -3536,9 +3536,13 @@ func (s *Store) SkillDefCreate(ctx context.Context, row store.SkillDefRow) (stor
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Per-(tenant, name) advisory lock — RFC N: version allocation is
+	// scoped per-tenant so two tenants' v1 don't collide on the
+	// UNIQUE(tenant_id, name, version). See AgentDefCreate for the
+	// rationale.
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
-		"skill_def:"+row.Name,
+		"skill_def:"+row.TenantID+":"+row.Name,
 	); err != nil {
 		return store.SkillDefRow{}, fmt.Errorf("skill_def create lock: %w", err)
 	}
@@ -3554,7 +3558,7 @@ func (s *Store) SkillDefCreate(ctx context.Context, row store.SkillDefRow) (stor
 	}
 
 	var maxVer sql.NullInt64
-	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM skill_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM skill_defs WHERE tenant_id = $1 AND name = $2`, row.TenantID, row.Name).Scan(&maxVer); err != nil {
 		return store.SkillDefRow{}, fmt.Errorf("skill_def create max version: %w", err)
 	}
 	row.Version = 1
@@ -3567,14 +3571,14 @@ func (s *Store) SkillDefCreate(ctx context.Context, row store.SkillDefRow) (stor
 		INSERT INTO skill_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
 		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
 		string(row.Definition), nullableString(row.Description),
 		row.CreatedAt,
 		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
 		row.Retired, row.BootstrappedFromStatic,
-		nullableString(row.ContentSHA256),
+		nullableString(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.SkillDefRow{}, fmt.Errorf("skill_def insert: %w", err)
 	}
@@ -3627,7 +3631,7 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM skill_defs d
-		LEFT JOIN skill_def_active a ON a.name = d.name
+		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
 		GROUP BY d.name, a.def_id
 		ORDER BY d.name`)
 	if err != nil {
@@ -3646,9 +3650,17 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	return out, rows.Err()
 }
 
-func (s *Store) SkillDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	var rowName string
-	err := s.pool.QueryRow(ctx, `SELECT name FROM skill_defs WHERE def_id = $1`, defID).Scan(&rowName)
+// SkillDefSetActive UPSERTs the skill_def_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// skill AND the supplied tenant — a def can only be promoted within its
+// own tenant, so a caller can't point another tenant's active pointer at
+// a def it owns.
+func (s *Store) SkillDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.pool.QueryRow(ctx, `SELECT name, tenant_id FROM skill_defs WHERE def_id = $1`, defID).Scan(&rowName, &rowTenant)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return &store.ErrNotFound{Kind: "skill_def", ID: defID}
 	}
@@ -3658,14 +3670,17 @@ func (s *Store) SkillDefSetActive(ctx context.Context, name, defID, promotedByAg
 	if rowName != name {
 		return fmt.Errorf("skill_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("skill_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO skill_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (name) DO UPDATE SET
+		INSERT INTO skill_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
 		    def_id               = EXCLUDED.def_id,
 		    promoted_at          = EXCLUDED.promoted_at,
 		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
-		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+		tenantID, name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
 	)
 	if err != nil {
 		return fmt.Errorf("skill_def_active upsert: %w", err)
@@ -3673,9 +3688,11 @@ func (s *Store) SkillDefSetActive(ctx context.Context, name, defID, promotedByAg
 	return nil
 }
 
-func (s *Store) SkillDefGetActive(ctx context.Context, name string) (store.SkillDefRow, error) {
+// SkillDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists.
+func (s *Store) SkillDefGetActive(ctx context.Context, tenantID, name string) (store.SkillDefRow, error) {
 	var defID string
-	err := s.pool.QueryRow(ctx, `SELECT def_id FROM skill_def_active WHERE name = $1`, name).Scan(&defID)
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM skill_def_active WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&defID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.SkillDefRow{}, &store.ErrNotFound{Kind: "skill_def_active", ID: name}
 	}
@@ -3706,7 +3723,8 @@ const skillDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM skill_defs`
 
 func (s *Store) scanSkillDef(row pgx.Row) (store.SkillDefRow, error) {
@@ -3723,6 +3741,7 @@ func (s *Store) scanSkillDef(row pgx.Row) (store.SkillDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&out.Retired, &out.BootstrappedFromStatic,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.SkillDefRow{}, err
@@ -3747,6 +3766,7 @@ func (s *Store) scanSkillDefRows(rows pgx.Rows) ([]store.SkillDefRow, error) {
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&r.Retired, &r.BootstrappedFromStatic,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -3623,8 +3623,11 @@ func (s *Store) SkillDefListChildren(ctx context.Context, parentDefID string) ([
 }
 
 func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSummary, error) {
+	// RFC N: names are per-tenant; group by tenant_id so a name owned by
+	// N tenants yields N rows (one per tenant) rather than merging them.
 	rows, err := s.pool.Query(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
@@ -3632,8 +3635,8 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM skill_defs d
 		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, fmt.Errorf("skill_def list names: %w", err)
 	}
@@ -3642,7 +3645,7 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	var out []store.SkillDefNameSummary
 	for rows.Next() {
 		var ns store.SkillDefNameSummary
-		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
 			return nil, err
 		}
 		out = append(out, ns)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -274,17 +274,27 @@ func (s *Store) migrate(ctx context.Context) error {
 			retired                   INTEGER NOT NULL DEFAULT 0,
 			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
 			content_sha256            TEXT,
-			UNIQUE(name, version)
+			tenant_id                 TEXT    NOT NULL DEFAULT '',
+			UNIQUE(tenant_id, name, version)
 		)`,
 		`CREATE INDEX IF NOT EXISTS skill_defs_by_name   ON skill_defs(name, version DESC)`,
 		`CREATE INDEX IF NOT EXISTS skill_defs_by_parent ON skill_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS skill_defs_by_run    ON skill_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
 		// skill_defs_by_content_sha256 — see agent_defs_by_content_sha256 note above.
+		// RFC N: tenant-scoped active pointer. PRIMARY KEY(tenant_id, name)
+		// — two tenants own the same name independently. On a FRESH DB this
+		// CREATE applies the composite PK; on an UPGRADED v0.8.x DB the
+		// tenant_id column is added by the addColumns ALTER below and the PK
+		// stays (name) (SQLite can't rewrite a PK in place — byte-equivalent
+		// for single-tenant tenant_id=''). See the agent_def_active note for
+		// the full SQLite upgrade caveat.
 		`CREATE TABLE IF NOT EXISTS skill_def_active (
-			name                  TEXT    PRIMARY KEY,
+			name                  TEXT    NOT NULL,
 			def_id                TEXT    NOT NULL REFERENCES skill_defs(def_id),
 			promoted_at           INTEGER NOT NULL,
-			promoted_by_agent_id  TEXT
+			promoted_by_agent_id  TEXT,
+			tenant_id             TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY(tenant_id, name)
 		)`,
 		// v0.9.x MCPServerDef substrate — third member of the
 		// AgentDef / SkillDef / MCPServerDef family. Mirror of the
@@ -693,6 +703,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		`ALTER TABLE agent_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE agent_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE dynamic_agents ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		// RFC N — tenant-scope the skill definition plane (mirror of the
+		// agent ALTERs above). Same SQLite upgrade caveat: the PK stays
+		// (name) on the upgraded skill_def_active table; functionally
+		// identical for single-tenant (tenant_id=''). DEFAULT '' backfills
+		// existing rows to the shared tenant.
+		`ALTER TABLE skill_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE skill_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1746,9 +1763,9 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static
+		        retired, bootstrapped_from_static, tenant_id
 		 FROM skill_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read skill_defs: %w", err)
@@ -1771,7 +1788,7 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&createdNs, &createdBy, &createdRun,
-			&retiredInt, &bootstrap,
+			&retiredInt, &bootstrap, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan skill_def: %w", err)
 		}
@@ -1799,9 +1816,9 @@ func (s *Store) SnapshotReadSkillDefs(ctx context.Context) ([]store.SkillDefRow,
 // SnapshotReadSkillDefActive implements store.Store.
 func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDefActiveEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM skill_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read skill_def_active: %w", err)
 	}
@@ -1813,7 +1830,7 @@ func (s *Store) SnapshotReadSkillDefActive(ctx context.Context) ([]store.SkillDe
 			promotedNs int64
 			promoter   sql.NullString
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan skill_def_active: %w", err)
 		}
 		e.PromotedAt = time.Unix(0, promotedNs)
@@ -2274,13 +2291,13 @@ func (s *Store) SnapshotRestoreSkillDef(ctx context.Context, r store.SkillDefRow
 		`INSERT OR IGNORE INTO skill_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
 		string(r.Definition), nilIfEmpty(r.Description),
 		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
 		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
-		nilIfEmpty(r.ContentSHA256),
+		nilIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def: %w", err)
@@ -2300,8 +2317,8 @@ func (s *Store) SnapshotRestoreSkillDefActive(ctx context.Context, e store.Skill
 		promotedNs = time.Now().UnixNano()
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO skill_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)`,
-		e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
+		`INSERT OR IGNORE INTO skill_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?, ?)`,
+		e.TenantID, e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore skill_def_active: %w", err)
@@ -3724,7 +3741,7 @@ func (s *Store) SkillDefCreate(ctx context.Context, row store.SkillDefRow) (stor
 
 	var maxVer sql.NullInt64
 	if err := conn.QueryRowContext(ctx,
-		`SELECT MAX(version) FROM skill_defs WHERE name = ?`, row.Name,
+		`SELECT MAX(version) FROM skill_defs WHERE tenant_id = ? AND name = ?`, row.TenantID, row.Name,
 	).Scan(&maxVer); err != nil {
 		return store.SkillDefRow{}, err
 	}
@@ -3738,14 +3755,14 @@ func (s *Store) SkillDefCreate(ctx context.Context, row store.SkillDefRow) (stor
 		`INSERT INTO skill_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
 		string(row.Definition), nilIfEmpty(row.Description),
 		row.CreatedAt.UnixNano(),
 		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
 		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
-		nilIfEmpty(row.ContentSHA256),
+		nilIfEmpty(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.SkillDefRow{}, err
 	}
@@ -3799,7 +3816,7 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM skill_defs d
-		LEFT JOIN skill_def_active a ON a.name = d.name
+		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
 		GROUP BY d.name, a.def_id
 		ORDER BY d.name`)
 	if err != nil {
@@ -3820,9 +3837,16 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	return out, rows.Err()
 }
 
-func (s *Store) SkillDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	var rowName string
-	err := s.db.QueryRowContext(ctx, `SELECT name FROM skill_defs WHERE def_id = ?`, defID).Scan(&rowName)
+// SkillDefSetActive UPSERTs the skill_def_active pointer for
+// (tenantID, name). RFC N: validates the def belongs to BOTH the named
+// skill AND the supplied tenant — a def can only be promoted within its
+// own tenant.
+func (s *Store) SkillDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.db.QueryRowContext(ctx, `SELECT name, tenant_id FROM skill_defs WHERE def_id = ?`, defID).Scan(&rowName, &rowTenant)
 	if err == sql.ErrNoRows {
 		return &store.ErrNotFound{Kind: "skill_def", ID: defID}
 	}
@@ -3832,21 +3856,24 @@ func (s *Store) SkillDefSetActive(ctx context.Context, name, defID, promotedByAg
 	if rowName != name {
 		return fmt.Errorf("skill_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("skill_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO skill_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(name) DO UPDATE SET
+		INSERT INTO skill_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, name) DO UPDATE SET
 		    def_id               = excluded.def_id,
 		    promoted_at          = excluded.promoted_at,
 		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
-		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+		tenantID, name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
 	)
 	return err
 }
 
-func (s *Store) SkillDefGetActive(ctx context.Context, name string) (store.SkillDefRow, error) {
+func (s *Store) SkillDefGetActive(ctx context.Context, tenantID, name string) (store.SkillDefRow, error) {
 	var defID string
-	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM skill_def_active WHERE name = ?`, name).Scan(&defID)
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM skill_def_active WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&defID)
 	if err == sql.ErrNoRows {
 		return store.SkillDefRow{}, &store.ErrNotFound{Kind: "skill_def_active", ID: name}
 	}
@@ -3881,7 +3908,8 @@ const skillDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM skill_defs`
 
 func (s *Store) scanSkillDef(row *sql.Row) (store.SkillDefRow, error) {
@@ -3901,6 +3929,7 @@ func (s *Store) scanSkillDef(row *sql.Row) (store.SkillDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&retired, &bootstrap,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.SkillDefRow{}, err
@@ -3931,6 +3960,7 @@ func (s *Store) scanSkillDefRows(rows *sql.Rows) ([]store.SkillDefRow, error) {
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&retired, &bootstrap,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3808,8 +3808,11 @@ func (s *Store) SkillDefListChildren(ctx context.Context, parentDefID string) ([
 }
 
 func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSummary, error) {
+	// RFC N: names are per-tenant; group by tenant_id so a name owned by
+	// N tenants yields N rows (one per tenant) rather than merging them.
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
@@ -3817,8 +3820,8 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM skill_defs d
 		LEFT JOIN skill_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, err
 	}
@@ -3828,7 +3831,7 @@ func (s *Store) SkillDefListNames(ctx context.Context) ([]store.SkillDefNameSumm
 	for rows.Next() {
 		var ns store.SkillDefNameSummary
 		var updatedAt int64
-		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
 			return nil, err
 		}
 		ns.LastUpdated = time.Unix(0, updatedAt)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -807,14 +807,25 @@ func (s *Store) migrate(ctx context.Context) error {
 		// column added by addColumns above is guaranteed present first.
 		//
 		// Residual caveat (unchanged): the upgraded agent_def_active /
-		// dynamic_agents tables still carry PRIMARY KEY(name), so two tenants
-		// cannot share a name on a PRE-EXISTING SQLite DB — a fresh DB is
-		// required for full multi-tenant on SQLite. These indexes restore
-		// single-tenant upgrade functionality only; they do not retrofit the
-		// per-tenant isolation a fresh DB's composite PK provides.
+		// dynamic_agents / skill_def_active tables still carry PRIMARY
+		// KEY(name), so two tenants cannot share a name on a PRE-EXISTING
+		// SQLite DB — a fresh DB is required for full multi-tenant on SQLite.
+		// These indexes restore single-tenant upgrade functionality only;
+		// they do not retrofit the per-tenant isolation a fresh DB's
+		// composite PK provides. The skill plane has NO dynamic_skills tier
+		// (skills = static skills.Set + the skill_defs/skill_def_active
+		// substrate only), so only two skill indexes are needed.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_def_active_tenant_name    ON agent_def_active(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_agents_tenant_name      ON dynamic_agents(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_defs_tenant_name_version  ON agent_defs(tenant_id, name, version)`,
+		// Skill plane (RFC N FIX 5-skills) — same in-place-upgrade gap.
+		// SkillDefSetActive does ON CONFLICT(tenant_id, name) on
+		// skill_def_active and SkillDefCreate inserts against
+		// UNIQUE(tenant_id, name, version) on skill_defs; on an upgraded DB
+		// neither composite index exists, so the FIRST promote/register
+		// fails even single-tenant. No dynamic_skills table to cover.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_def_active_tenant_name    ON skill_def_active(tenant_id, name)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_defs_tenant_name_version  ON skill_defs(tenant_id, name, version)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -377,6 +377,123 @@ func TestMigrate_UpgradeFromLegacyAgentDefPlaneTenantUpserts(t *testing.T) {
 	}
 }
 
+// TestMigrate_UpgradeFromLegacySkillDefPlaneTenantUpserts — RFC N
+// FIX 5-skills, the skill analogue of the AgentDef in-place upgrade
+// regression. Setup: hand-create the LEGACY (pre-RFC-N) skill-def-plane
+// schema — skill_defs with UNIQUE(name, version) and skill_def_active
+// with PRIMARY KEY(name), neither carrying tenant_id. (Skills have NO
+// dynamic_skills table.) Then reopen via the store path (re-runs
+// migrate(), which ALTERs in tenant_id but CANNOT rewrite the PK/UNIQUE
+// in place) and assert SkillDefCreate + SkillDefSetActive SUCCEED.
+//
+// Pre-fix, this FAILS: SkillDefSetActive's ON CONFLICT(tenant_id, name)
+// and the version-bump UNIQUE(tenant_id, name, version) have no matching
+// index on the upgraded tables, so SQLite refuses with "ON CONFLICT
+// clause does not match any PRIMARY KEY or UNIQUE constraint" on the
+// FIRST register/promote — broken even single-tenant. The fix adds the
+// two idempotent CREATE UNIQUE INDEX statements in addIndexes that supply
+// the ON CONFLICT / UNIQUE target.
+func TestMigrate_UpgradeFromLegacySkillDefPlaneTenantUpserts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy_skilldef.db")
+
+	// 1. Stand up the legacy schema: open (builds the current schema), then
+	// drop + rebuild the two skill tables in their pre-RFC-N shape (no
+	// tenant_id; old PK/UNIQUE). Mirrors how a pre-RFC-N deploy looks on
+	// disk.
+	{
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("initial open: %v", err)
+		}
+		ctx := context.Background()
+		stmts := []string{
+			`DROP INDEX IF EXISTS uniq_skill_def_active_tenant_name`,
+			`DROP INDEX IF EXISTS uniq_skill_defs_tenant_name_version`,
+			`DROP TABLE skill_def_active`,
+			`DROP TABLE skill_defs`,
+			// Legacy skill_defs: UNIQUE(name, version), no tenant_id.
+			`CREATE TABLE skill_defs (
+				def_id                    TEXT    PRIMARY KEY,
+				name                      TEXT    NOT NULL,
+				version                   INTEGER NOT NULL,
+				parent_def_id             TEXT    REFERENCES skill_defs(def_id),
+				definition                TEXT    NOT NULL,
+				description               TEXT,
+				created_at                INTEGER NOT NULL,
+				created_by_agent_id       TEXT,
+				created_by_run_id         TEXT,
+				retired                   INTEGER NOT NULL DEFAULT 0,
+				bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+				content_sha256            TEXT,
+				UNIQUE(name, version)
+			)`,
+			// Legacy skill_def_active: PRIMARY KEY(name), no tenant_id.
+			`CREATE TABLE skill_def_active (
+				name                  TEXT    PRIMARY KEY,
+				def_id                TEXT    NOT NULL REFERENCES skill_defs(def_id),
+				promoted_at           INTEGER NOT NULL,
+				promoted_by_agent_id  TEXT
+			)`,
+		}
+		for _, q := range stmts {
+			if _, err := s.db.ExecContext(ctx, q); err != nil {
+				t.Fatalf("setup legacy schema: %q: %v", q, err)
+			}
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 2. Reopen — migrate() ALTERs in tenant_id + creates the ON CONFLICT
+	// target indexes.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("upgrade open: %v", err)
+	}
+	defer s.Close()
+	ctx := context.Background()
+
+	// 3. SkillDefCreate must succeed (exercises UNIQUE(tenant_id, name,
+	// version) via the version-bump path on a second create).
+	created, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID:      "sdf_upgrade_v1",
+		Name:       "upgrade-skill",
+		Definition: []byte(`{"body":"hi"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("SkillDefCreate on upgraded DB failed (RFC N UNIQUE target missing?): %v", err)
+	}
+	if created.Version != 1 {
+		t.Errorf("first create version = %d, want 1", created.Version)
+	}
+	// Second create of the same name bumps the version — relies on the
+	// MAX(version) read + UNIQUE(tenant_id, name, version) insert.
+	created2, err := s.SkillDefCreate(ctx, store.SkillDefRow{
+		DefID:      "sdf_upgrade_v2",
+		Name:       "upgrade-skill",
+		Definition: []byte(`{"body":"hi2"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("second SkillDefCreate on upgraded DB failed: %v", err)
+	}
+	if created2.Version != 2 {
+		t.Errorf("second create version = %d, want 2", created2.Version)
+	}
+
+	// 4. SkillDefSetActive must succeed (exercises ON CONFLICT(tenant_id,
+	// name) on skill_def_active).
+	if err := s.SkillDefSetActive(ctx, "", "upgrade-skill", "sdf_upgrade_v1", "a_admin"); err != nil {
+		t.Fatalf("SkillDefSetActive on upgraded DB failed (ON CONFLICT target missing?): %v", err)
+	}
+	// A re-promote to a different def_id exercises the DO UPDATE branch.
+	if err := s.SkillDefSetActive(ctx, "", "upgrade-skill", "sdf_upgrade_v2", "a_admin"); err != nil {
+		t.Fatalf("SkillDefSetActive re-promote on upgraded DB failed: %v", err)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(path)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -757,7 +757,7 @@ type Store interface {
 	SnapshotRestoreSkillDef(ctx context.Context, r SkillDefRow) (bool, error)
 
 	// SnapshotRestoreSkillDefActive mirrors SnapshotRestoreAgentDefActive
-	// for skill_def_active.
+	// for skill_def_active. ON CONFLICT (tenant_id, name) DO NOTHING.
 	SnapshotRestoreSkillDefActive(ctx context.Context, entry SkillDefActiveEntry) (bool, error)
 
 	// SnapshotRestoreMCPServerDef — v0.9.x mirror.
@@ -1123,8 +1123,17 @@ type Store interface {
 	SkillDefListByName(ctx context.Context, name string) ([]SkillDefRow, error)
 	SkillDefListChildren(ctx context.Context, parentDefID string) ([]SkillDefRow, error)
 	SkillDefListNames(ctx context.Context) ([]SkillDefNameSummary, error)
-	SkillDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
-	SkillDefGetActive(ctx context.Context, name string) (SkillDefRow, error)
+	// SkillDefSetActive UPSERTs the skill_def_active pointer for
+	// `(tenantID, name)`. RFC N: the active pointer is per-tenant, and a
+	// def can only be promoted within its own tenant — implementations
+	// refuse if the def's tenant_id ≠ tenantID. tenantID "" = the shared/
+	// operator/legacy tenant.
+	SkillDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error
+	// SkillDefGetActive returns the currently-active row for
+	// `(tenantID, name)`. Returns *ErrNotFound when no active pointer
+	// exists (the caller falls through to the static skills.Set). RFC N:
+	// tenantID "" = the shared/operator/legacy tenant.
+	SkillDefGetActive(ctx context.Context, tenantID, name string) (SkillDefRow, error)
 	SkillDefSetRetired(ctx context.Context, defID string, retired bool) error
 
 	// ---- v0.9.x MCPServerDef substrate ----
@@ -1949,6 +1958,14 @@ type SkillDefRow struct {
 	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
 	// ContentSHA256 — see AgentDefRow.ContentSHA256. Same semantics.
 	ContentSHA256 string `json:"content_sha256,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. The UNIQUE constraint is (tenant_id, name,
+	// version), so two tenants own the same name+version independently.
+	// Deliberately NOT part of the content hash — tenant is operational
+	// identity, not content (same rule AgentDefRow follows), so two
+	// tenants forking the same body get the same content_sha256. Set from
+	// the authoritative principal at the write site; never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // SkillDefNameSummary mirrors AgentDefNameSummary.
@@ -1967,6 +1984,9 @@ type SkillDefActiveEntry struct {
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis (part of the
+	// skill_def_active PK). "" = the shared/operator/legacy tenant.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // ---- v0.9.x MCPServerDef substrate types ----

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1970,7 +1970,11 @@ type SkillDefRow struct {
 
 // SkillDefNameSummary mirrors AgentDefNameSummary.
 type SkillDefNameSummary struct {
-	Name          string    `json:"name"`
+	Name string `json:"name"`
+	// TenantID is the RFC N owning tenant. A name owned by N tenants
+	// yields N summary rows (one per tenant) — without grouping by tenant
+	// the listing would merge distinct tenants' versions under one name.
+	TenantID      string    `json:"tenant_id,omitempty"`
 	VersionCount  int       `json:"version_count"`
 	ActiveDefID   string    `json:"active_def_id,omitempty"`
 	LatestVersion int       `json:"latest_version"`

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -180,6 +180,9 @@ func Run(t *testing.T, factory Factory) {
 		{"SkillDefActivePointerIdempotent", testSkillDefActivePointerIdempotent},
 		{"SkillDefRetireReversible", testSkillDefRetireReversible},
 		{"SkillDefStaticFallback", testSkillDefStaticFallback},
+		// RFC N — skill definition plane tenant isolation. Fails on the
+		// pre-migration single-`name`-PK schema (clobber); passes after.
+		{"SkillDefTenantIsolation", testSkillDefTenantIsolation},
 		{"SkillDefContentSHA256RoundTrip", testSkillDefContentSHA256RoundTrip},
 		{"BackfillSkillDefContentSHA256", testBackfillSkillDefContentSHA256},
 		{"SkillDefSnapshotReadEmpty", testSkillDefSnapshotReadEmpty},
@@ -3946,16 +3949,16 @@ func testSkillDefActivePointerIdempotent(t *testing.T, s store.Store) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "skill-promo", a.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "skill-promo", a.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "skill-promo", b.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "skill-promo", b.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	if err := s.SkillDefSetActive(ctx, "skill-promo", a.DefID, ""); err != nil {
+	if err := s.SkillDefSetActive(ctx, "", "skill-promo", a.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
-	got, err := s.SkillDefGetActive(ctx, "skill-promo")
+	got, err := s.SkillDefGetActive(ctx, "", "skill-promo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3992,10 +3995,74 @@ func testSkillDefRetireReversible(t *testing.T, s store.Store) {
 
 func testSkillDefStaticFallback(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	_, err := s.SkillDefGetActive(ctx, "no-such-skill-name")
+	_, err := s.SkillDefGetActive(ctx, "", "no-such-skill-name")
 	var nf *store.ErrNotFound
 	if !errors.As(err, &nf) {
 		t.Errorf("got %v, want *ErrNotFound", err)
+	}
+}
+
+// testSkillDefTenantIsolation pins the RFC N boundary: the SAME skill
+// name registered under two tenants must resolve to each tenant's OWN
+// definition + active pointer — no cross-tenant clobber, no cross-tenant
+// read. Skills have no dynamic tier (static skills.Set + the substrate
+// only), so this covers skill_defs + skill_def_active + the cross-tenant
+// promote refusal.
+//
+// FAIL-BEFORE: on the pre-migration schema (skill_def_active PK = (name),
+// skill_defs UNIQUE = (name, version)), tenant B's writes overwrite
+// tenant A's (last-writer-wins on the single global pointer), so the
+// GetActive(A) assertion reads back B's def_id and the test fails. The
+// composite (tenant_id, name) PK is what makes the two rows coexist.
+func testSkillDefTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "summarize-skill"
+
+	aDef := mkSkillDef("sti-a", name, "")
+	aDef.TenantID = "tenant-a"
+	aDef.Definition = json.RawMessage(`{"body":"A"}`)
+	aRow, err := s.SkillDefCreate(ctx, aDef)
+	if err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+
+	bDef := mkSkillDef("sti-b", name, "")
+	bDef.TenantID = "tenant-b"
+	bDef.Definition = json.RawMessage(`{"body":"B"}`)
+	bRow, err := s.SkillDefCreate(ctx, bDef)
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	if err := s.SkillDefSetActive(ctx, "tenant-a", name, aRow.DefID, ""); err != nil {
+		t.Fatalf("promote A: %v", err)
+	}
+	if err := s.SkillDefSetActive(ctx, "tenant-b", name, bRow.DefID, ""); err != nil {
+		t.Fatalf("promote B: %v", err)
+	}
+
+	gotA, err := s.SkillDefGetActive(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("get active A: %v", err)
+	}
+	if gotA.DefID != aRow.DefID || gotA.TenantID != "tenant-a" || string(gotA.Definition) != `{"body":"A"}` {
+		t.Errorf("tenant-a clobbered: got def_id=%q tenant=%q def=%s, want A's own def",
+			gotA.DefID, gotA.TenantID, gotA.Definition)
+	}
+
+	gotB, err := s.SkillDefGetActive(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("get active B: %v", err)
+	}
+	if gotB.DefID != bRow.DefID || gotB.TenantID != "tenant-b" || string(gotB.Definition) != `{"body":"B"}` {
+		t.Errorf("tenant-b clobbered: got def_id=%q tenant=%q def=%s, want B's own def",
+			gotB.DefID, gotB.TenantID, gotB.Definition)
+	}
+
+	// A def can only be promoted within its own tenant — promoting A's
+	// def under tenant-b must be refused.
+	if err := s.SkillDefSetActive(ctx, "tenant-b", name, aRow.DefID, ""); err == nil {
+		t.Error("cross-tenant promote (A's def under tenant-b) unexpectedly succeeded")
 	}
 }
 

--- a/internal/tools/builtin/skill.go
+++ b/internal/tools/builtin/skill.go
@@ -145,7 +145,9 @@ func (s *SkillTool) Execute(ctx context.Context, input json.RawMessage) (tools.R
 func (s *SkillTool) resolveSkill(ctx context.Context, name string) (string, []string, string, error) {
 	// 1. DB-promoted active SkillDef wins when Store is wired.
 	if s.Store != nil {
-		row, err := s.Store.SkillDefGetActive(ctx, name)
+		// RFC N: read the active pointer within the agent's own tenant
+		// (from the authoritative run identity in ctx; "" = shared).
+		row, err := s.Store.SkillDefGetActive(ctx, tools.RunIdentity(ctx).TenantID, name)
 		if err == nil {
 			var def skillDefOverlay
 			if uerr := json.Unmarshal(row.Definition, &def); uerr != nil {

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -223,6 +223,12 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 	}
 
 	ident := tools.RunIdentity(ctx)
+	// RFC N: the tenant comes from the authoritative run identity in ctx
+	// (the SkillDef tool always runs inside a run whose RunIdentity
+	// carries the principal-derived tenant), never from tool input. ""
+	// = shared/legacy tenant. Used for the row stamp + the promote — both
+	// scoped to the skill's own tenant.
+	tenantID := ident.TenantID
 	row := store.SkillDefRow{
 		DefID:            mintSkillDefID(),
 		Name:             in.Name,
@@ -230,6 +236,7 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    signFromSkillDef(in.Name, def),
+		TenantID:         tenantID,
 	}
 	created, err := s.Store.SkillDefCreate(ctx, row)
 	if err != nil {
@@ -240,7 +247,7 @@ func (s *SkillDef) execCreate(ctx context.Context, policy tools.SkillDefPolicyVa
 		promote = *in.Promote
 	}
 	if promote {
-		if err := s.Store.SkillDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+		if err := s.Store.SkillDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("create: promote: %s", err)), nil
 		}
 	}
@@ -258,6 +265,11 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 	//   1. parent_def_id supplied → pin
 	//   2. parent_def_id empty + active pointer exists → use it
 	//   3. neither → name must have a static SKILL.md; bootstrap v1
+	// RFC N: fork resolves + stamps within the skill's own tenant (from
+	// the authoritative run identity, never tool input).
+	ident := tools.RunIdentity(ctx)
+	tenantID := ident.TenantID
+
 	parentDefID := in.ParentDefID
 	var parent store.SkillDefRow
 	if parentDefID != "" {
@@ -272,9 +284,15 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 		if row.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
 		}
+		// A def_id is a global handle; refuse to fork across the tenant
+		// boundary — a caller in tenant T can't pin another tenant's def
+		// as its parent (which would copy that tenant's body into T).
+		if row.TenantID != tenantID {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to another tenant, refusing", parentDefID)), nil
+		}
 		parent = row
 	} else {
-		row, err := s.Store.SkillDefGetActive(ctx, in.Name)
+		row, err := s.Store.SkillDefGetActive(ctx, tenantID, in.Name)
 		if err == nil {
 			parent = row
 			parentDefID = row.DefID
@@ -296,7 +314,7 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 				// Concurrent first-fork may have already bootstrapped
 				// v1 between our GetActive and our own bootstrap insert.
 				// Re-read active before propagating the error.
-				if row2, gerr := s.Store.SkillDefGetActive(ctx, in.Name); gerr == nil {
+				if row2, gerr := s.Store.SkillDefGetActive(ctx, tenantID, in.Name); gerr == nil {
 					parent = row2
 					parentDefID = row2.DefID
 				} else {
@@ -337,7 +355,6 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
 
-	ident := tools.RunIdentity(ctx)
 	row := store.SkillDefRow{
 		DefID:            mintSkillDefID(),
 		Name:             in.Name,
@@ -346,6 +363,7 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    signFromSkillDef(in.Name, def),
+		TenantID:         tenantID,
 	}
 	created, err := s.Store.SkillDefCreate(ctx, row)
 	if err != nil {
@@ -356,7 +374,7 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 		promote = *in.Promote
 	}
 	if promote {
-		if err := s.Store.SkillDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+		if err := s.Store.SkillDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
 			return errResult(fmt.Sprintf("fork: promote: %s", err)), nil
 		}
 	}
@@ -443,7 +461,11 @@ func (s *SkillDef) execPromote(ctx context.Context, policy tools.SkillDefPolicyV
 		return errResult(err.Error()), nil
 	}
 	ident := tools.RunIdentity(ctx)
-	if err := s.Store.SkillDefSetActive(ctx, row.Name, row.DefID, ident.AgentID); err != nil {
+	// RFC N: promote within the skill's own tenant. SkillDefSetActive
+	// refuses when ident.TenantID ≠ row.TenantID, so a caller in tenant T
+	// cannot point at (or clobber) another tenant's active pointer — even
+	// though def_id is a global handle.
+	if err := s.Store.SkillDefSetActive(ctx, ident.TenantID, row.Name, row.DefID, ident.AgentID); err != nil {
 		return errResult(fmt.Sprintf("promote: %s", err)), nil
 	}
 	return okJSON(map[string]any{"def_id": row.DefID, "name": row.Name, "promoted": true})
@@ -459,7 +481,8 @@ func (s *SkillDef) execVerify(ctx context.Context, policy tools.SkillDefPolicyVa
 	if err := s.checkScopeForName(policy, in.Name, ""); err != nil {
 		return errResult(err.Error()), nil
 	}
-	row, err := s.Store.SkillDefGetActive(ctx, in.Name)
+	// RFC N: verify against the skill's own tenant active pointer.
+	row, err := s.Store.SkillDefGetActive(ctx, tools.RunIdentity(ctx).TenantID, in.Name)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -609,6 +632,10 @@ func (s *SkillDef) bootstrapStatic(ctx context.Context, name string, static *ski
 		CreatedByAgentID:       ident.AgentID,
 		BootstrappedFromStatic: true,
 		ContentSHA256:          signFromSkillDef(name, def),
+		// RFC N: the bootstrapped lineage root lives in the forking
+		// caller's tenant (static skills.Set is the shared base; the fork
+		// that triggers bootstrap is per-tenant). "" = shared.
+		TenantID: ident.TenantID,
 	}
 	return s.Store.SkillDefCreate(ctx, row)
 }

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -395,6 +395,14 @@ func (s *SkillDef) execGet(ctx context.Context, policy tools.SkillDefPolicyValue
 		}
 		return errResult(fmt.Sprintf("get: %s", err)), nil
 	}
+	// RFC N: def_id is a global handle but a def is owned by exactly one
+	// tenant. checkScopeForName is tenant-blind, so guard here: a caller
+	// in tenant T cannot read another tenant's def. Return the SAME opaque
+	// not-found a missing def returns — never leak existence/body of a
+	// cross-tenant row.
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+	}
 	if err := s.checkScopeForName(policy, row.Name, row.DefID); err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -412,8 +420,15 @@ func (s *SkillDef) execList(ctx context.Context, policy tools.SkillDefPolicyValu
 	if err != nil {
 		return errResult(fmt.Sprintf("list: %s", err)), nil
 	}
+	// RFC N: SkillDefListByName returns rows across ALL tenants for a name
+	// (names are per-tenant now). Filter to the caller's own tenant so a
+	// tenant lists only its own versions.
+	tenantID := tools.RunIdentity(ctx).TenantID
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
+		if r.TenantID != tenantID {
+			continue
+		}
 		out = append(out, skillDefRowResponseMap(r))
 	}
 	return okJSON(map[string]any{"name": in.Name, "versions": out})
@@ -435,6 +450,12 @@ func (s *SkillDef) execRetire(ctx context.Context, policy tools.SkillDefPolicyVa
 			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 		}
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	// RFC N: refuse cross-tenant retire. SkillDefSetRetired is a global
+	// by-def_id mutation; without this guard a caller in tenant T could
+	// retire another tenant's def. Opaque not-found — don't leak existence.
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := s.checkScopeForName(policy, row.Name, row.DefID); err != nil {
 		return errResult(err.Error()), nil

--- a/internal/tools/builtin/skilldef_test.go
+++ b/internal/tools/builtin/skilldef_test.go
@@ -271,3 +271,74 @@ func TestSkillDefTool_RetireRoundTrip(t *testing.T) {
 		t.Error("retired flag didn't reverse")
 	}
 }
+
+// TestSkillDefTool_TenantIsolationGetListRetire — RFC N FIX 3-skills, the
+// skill analogue of TestAgentDefTool_TenantIsolationGetListRetire. The
+// get / list / retire ops were tenant-blind (gated only by the
+// tenant-blind checkScopeForName), so a caller in tenant A could read,
+// enumerate, and retire defs owned by tenant B. With scopes=[any] on both
+// callers (so the scope gate is NOT what refuses), the only thing keeping
+// tenants apart is the row-TenantID guard added by FIX 3.
+//
+// Pre-fix: get returns B's body, list returns B's versions, retire mutates
+// B's row — all from a tenant-A caller.
+func TestSkillDefTool_TenantIsolationGetListRetire(t *testing.T) {
+	tool, baseCtx, cleanup := skillDefFixture(t)
+	defer cleanup()
+
+	// Two tenant contexts over the SAME tool/store. Re-wrapping RunIdentity
+	// only swaps the tenant/agent; the scopes=[any] policy + agent tools
+	// from the fixture live under separate ctx keys, so refusals come from
+	// the tenant guard, not the scope gate.
+	ctxA := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-a"})
+	ctxB := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-b"})
+
+	// Create a non-static skill def under tenant B.
+	res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"create","name":"b-only","overlay":{"body":"tenant b body"}}`))
+	if res.IsError {
+		t.Fatalf("create under B: %s", res.Text)
+	}
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// get from tenant A → opaque not-found (no cross-tenant leak).
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if !res.IsError {
+		t.Errorf("tenant A get of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	if !strings.Contains(res.Text, "not found") {
+		t.Errorf("cross-tenant get should return opaque not-found; got %s", res.Text)
+	}
+
+	// list from tenant A → must NOT include B's version.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("list under A: %s", res.Text)
+	}
+	versions := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 0 {
+		t.Errorf("tenant A list of name owned by B returned %d versions; want 0 (tenant filter)", len(versions))
+	}
+
+	// retire from tenant A → refused; B's row must stay un-retired.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if !res.IsError {
+		t.Errorf("tenant A retire of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	// Confirm B still sees its row un-retired (the retire didn't leak through).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("tenant B get of its own def: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["retired"].(bool) {
+		t.Error("tenant A's cross-tenant retire mutated tenant B's row")
+	}
+
+	// Sanity: tenant B CAN get + list its own def (the guard isn't over-broad).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("tenant B list of its own name: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
+		t.Errorf("tenant B list returned %d versions; want 1", n)
+	}
+}


### PR DESCRIPTION
Slice **2/3** of **RFC N — multi-tenant definition plane**. Mirrors the agents slice (#361) for skills: `skill_defs` / `skill_def_active` gain a `tenant_id`, resolution + writes become tenant-scoped.

> ⚠️ **STACKED on #361 (base = `feature-rfc-n-tenant-defs-agents`).** Genuine dependency: this slice reuses #361's `tenantFromCtx` helper, the migration sequence (0037→0038), and the shared store edits. **Do not merge while the base is a feature branch** — per our stacked-PR discipline: merge #361 to `main` first, then this PR auto-retargets to `main` (I'll rebase + verify `origin/main` contains it). The only file overlap with #361 is additive (different methods in `store.go`/`postgres.go`/`sqlite.go`/`contract.go`/`lookup/README.md`).

## What changed (skills only — no agent/MCP files touched)
- **Schema** `0038_skill_defs_tenant_id` + SQLite DDL: `tenant_id` on `skill_defs` (UNIQUE→`(tenant_id,name,version)`) and `skill_def_active` (PK→`(tenant_id,name)`). `''` = shared/legacy; backfill via DEFAULT.
- **Resolver** `lookup.Skill(ctx, s, set, tenantID, name)`: precedence **tenant-substrate → shared-substrate (`''`) → static set (shared base)**. NOTE skills are substrate-first (unlike agents' static-first); for the `''` tenant the tenant step is skipped → **byte-for-byte the pre-RFC-N substrate-first-then-static order**. Parse-error / transient-error `log.Printf` fallbacks preserved.
- **Authoritative tenant** via `tenantFromCtx` / `tools.RunIdentity` (never wire/tool input). `skillDefInput` exposes no tenant field.
- **Write guards**: `SkillDefSetActive` refuses to promote a def outside its own tenant; fork refuses a cross-tenant `parent_def_id`; version allocation + advisory lock scoped per `(tenant, name)`. `tenant_id` excluded from `content_sha256`.

## Tested
- New `TestStoreContract/SkillDefTenantIsolation` (fail-before verified: collides with `UNIQUE constraint failed: skill_defs.name, skill_defs.version` on the single-`name` schema), `TestSkill_TenantResolutionPrecedence`, `TestSkill_DefaultTenantPreservesSubstrateFirstOrder`.
- Independent `go build ./...`, `go vet ./...`, `gofmt -l`, **full `go test ./...`** all clean.

Same SQLite-in-place-upgrade caveat as #361 (fresh DB for true isolation on SQLite; Postgres upgrades in place). MCP-server slice (3/3) + the per-run MCP advertising filter follow next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)