### PR TITLE
feat(authz): tenant-scope the MCP-server definition plane + advertising/pool (RFC N, MCP slice)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -757,36 +757,36 @@ func main() {
 	// restart.
 	dynamicMCPRegistry := mcp.NewDynamicRegistry()
 
+	// RFC N: the pool's build callback resolves through lookup.MCPServer
+	// with the run's tenant so a per-tenant dynamic registration dials its
+	// OWN URL — not a shared one of the same name. A tenant-scoped dynamic
+	// shadow takes precedence; otherwise the static yaml base resolves;
+	// otherwise a shared ("") dynamic registration. stdio is yaml-only and
+	// resolved straight from cfg (lookup.MCPServerSpec omits stdio fields).
+	mcpDynView := mcpLookupView{dynamicMCPRegistry}
 	mcpPool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
-			// Static yaml entries are ground truth + take precedence.
-			if srv, ok := cfg.MCPServers[name]; ok {
-				switch srv.Transport {
-				case "stdio":
-					return spawnStdioMCP(name, srv)
-				case "http":
-					return mcphttp.New(mcphttp.Config{
-						URL:     srv.URL,
-						Headers: srv.Headers,
-					})
-				default:
-					return nil, fmt.Errorf("mcp_servers.%s: unknown transport %q", name, srv.Transport)
-				}
+		func(tenant, name string) (mcp.Caller, error) {
+			// Static stdio entries are yaml-only ground truth (lookup's
+			// spec can't carry Command/Args/Env). A tenant never overrides
+			// a stdio server — resolve it directly at the shared base.
+			if srv, ok := cfg.MCPServers[name]; ok && srv.Transport == "stdio" {
+				return spawnStdioMCP(name, srv)
 			}
-			// v0.9.x dynamic registration. Restricted to http + streamable-http
-			// at the substrate-tool layer; stdio cannot reach this path.
-			if spec, ok := dynamicMCPRegistry.Get(name); ok {
-				switch spec.Transport {
-				case "http", "streamable-http":
-					return mcphttp.New(mcphttp.Config{
-						URL:     spec.URL,
-						Headers: spec.Headers,
-					})
-				default:
-					return nil, fmt.Errorf("mcp_servers.%s: dynamic registration has invalid transport %q (substrate should have refused this; data corruption?)", name, spec.Transport)
-				}
+			// http / streamable-http: tenant-dynamic → static yaml →
+			// shared-dynamic, via the shared resolver.
+			spec, ok := lookup.MCPServer(cfg, mcpDynView, tenant, name)
+			if !ok {
+				return nil, fmt.Errorf("mcp_servers.%s: not in static yaml or dynamic registry (tenant=%q)", name, tenant)
 			}
-			return nil, fmt.Errorf("mcp_servers.%s: not in static yaml or dynamic registry", name)
+			switch spec.Transport {
+			case "http", "streamable-http":
+				return mcphttp.New(mcphttp.Config{
+					URL:     spec.URL,
+					Headers: spec.Headers,
+				})
+			default:
+				return nil, fmt.Errorf("mcp_servers.%s: invalid transport %q for non-stdio resolution (data corruption?)", name, spec.Transport)
+			}
 		},
 		func(c mcp.Caller) {
 			// Both stdio.Client and http.Client implement Close() error.
@@ -799,6 +799,14 @@ func main() {
 				return
 			}
 			_ = cl.Close()
+		},
+		// RFC N tenantOf: the pool cache is keyed by (tenant, name). The
+		// tenant is the authoritative principal's tenant carried on the run
+		// ctx via RunIdentity (set from applyPrincipal / inherited by
+		// sub-agents). RunIdentity, not the http auth package, keeps the
+		// pool free of an import cycle. "" = shared/legacy tenant.
+		func(ctx context.Context) string {
+			return tools.RunIdentity(ctx).TenantID
 		},
 	)
 	defer mcpPool.Close()
@@ -990,18 +998,22 @@ func main() {
 			if ns.ActiveDefID == "" {
 				continue
 			}
-			// Skip names that collide with a static yaml `mcp_servers:` entry.
-			// The pool's build callback prefers yaml over the dynamic
-			// registry, so loading a colliding name here would only inflate
-			// Registry.Size() + lie in operator diagnostics (the registry
-			// entry is unreachable). Mirrors the execCreate refusal.
-			if _, ok := cfg.MCPServers[ns.Name]; ok {
-				log.Printf("mcp_server_defs: skipping %q at boot — name collides with static yaml entry (yaml takes precedence)", ns.Name)
+			// Skip SHARED-tenant names that collide with a static yaml
+			// `mcp_servers:` entry — yaml is ground truth for the "" tenant,
+			// so a shared registry entry of that name would be unreachable
+			// (lookup.MCPServer's "" path is static → shared-dynamic) and
+			// only inflate diagnostics. A per-TENANT row (ns.TenantID != "")
+			// that shares the name is a legitimate RFC N override (the
+			// tenant-dynamic pass shadows the static base), so it is NOT
+			// skipped. Mirrors the execCreate refusal, which only refuses
+			// over yaml within the same tenant scope.
+			if _, ok := cfg.MCPServers[ns.Name]; ok && ns.TenantID == "" {
+				log.Printf("mcp_server_defs: skipping shared %q at boot — name collides with static yaml entry (yaml takes precedence)", ns.Name)
 				continue
 			}
 			active, err := storeIface.MCPServerDefGet(context.Background(), ns.ActiveDefID)
 			if err != nil {
-				log.Printf("mcp_server_defs: load active %q: %v", ns.Name, err)
+				log.Printf("mcp_server_defs: load active %q (tenant=%q): %v", ns.Name, ns.TenantID, err)
 				continue
 			}
 			// Skip retired active rows. SetRetired leaves the active overlay
@@ -1010,7 +1022,7 @@ func main() {
 			// Rehydrating a retired spec would silently revive a name the
 			// operator explicitly retired.
 			if active.Retired {
-				log.Printf("mcp_server_defs: skipping %q at boot — active row is retired (def_id=%s)", ns.Name, active.DefID)
+				log.Printf("mcp_server_defs: skipping %q (tenant=%q) at boot — active row is retired (def_id=%s)", ns.Name, ns.TenantID, active.DefID)
 				continue
 			}
 			var ov struct {
@@ -1019,11 +1031,13 @@ func main() {
 				Headers   map[string]string `json:"headers"`
 			}
 			if err := json.Unmarshal(active.Definition, &ov); err != nil {
-				log.Printf("mcp_server_defs: parse active %q: %v", ns.Name, err)
+				log.Printf("mcp_server_defs: parse active %q (tenant=%q): %v", ns.Name, ns.TenantID, err)
 				continue
 			}
+			// RFC N: carry the def's tenant onto the registry entry so it is
+			// keyed by (tenant, name) and only resolved for that tenant's runs.
 			dynamicMCPRegistry.Set(mcp.DynamicMCPServerSpec{
-				Name: active.Name, Transport: ov.Transport, URL: ov.URL, Headers: ov.Headers,
+				TenantID: active.TenantID, Name: active.Name, Transport: ov.Transport, URL: ov.URL, Headers: ov.Headers,
 			})
 		}
 		if size := dynamicMCPRegistry.Size(); size > 0 {
@@ -1164,7 +1178,10 @@ func main() {
 	// marshals into the substrate-mirror shape ({name, description,
 	// input_schema}) so the wire stays uniform across static + dynamic.
 	srv.SetMCPPoolInspector(func(name string) json.RawMessage {
-		descs := mcpPool.PeekTools(name)
+		// Static yaml MCP servers live at the shared "" tenant in the
+		// (tenant, name)-keyed pool. The Library introspection endpoint
+		// surfaces those operator-blessed servers' cached tool lists.
+		descs := mcpPool.PeekTools("", name)
 		if descs == nil {
 			return nil
 		}
@@ -1187,10 +1204,26 @@ func main() {
 	// allowed_tools filter. MCP: each dynamic-registry server's persisted
 	// discovered_tools (set by rediscover). A2A: re-enumerate static +
 	// substrate (the static dups collapse in the by-name filter).
+	//
+	// RFC N §3 tenant boundary: enumerate ONLY the names visible to the
+	// run's tenant (NamesForTenant = own + shared), and read each name's
+	// active def with the tenant→shared precedence. NET EFFECT: a run in
+	// tenant A's candidate set contains ONLY A's + shared MCP tools, never
+	// tenant B's. The tenant is authoritative from ctx (principal →
+	// RunIdentity → ""), never from the wire.
 	srv.SetDynamicToolEnumerator(func(ctx context.Context) []tools.Tool {
 		var out []tools.Tool
-		for _, name := range dynamicMCPRegistry.Names() {
-			row, gerr := storeIface.MCPServerDefGetActive(ctx, name)
+		tenant := mcpTenantFromCtx(ctx)
+		for _, name := range dynamicMCPRegistry.NamesForTenant(tenant) {
+			// Resolve the active def with the same precedence as
+			// lookup.MCPServer: the run's tenant first, then the shared ""
+			// base. A tenant-owned name's tools come from the tenant's def;
+			// a shared name's from the "" def. A run never reads another
+			// tenant's row.
+			row, gerr := storeIface.MCPServerDefGetActive(ctx, tenant, name)
+			if gerr != nil && tenant != "" {
+				row, gerr = storeIface.MCPServerDefGetActive(ctx, "", name)
+			}
 			if gerr != nil {
 				continue
 			}
@@ -2567,6 +2600,37 @@ func runAdvisoryGatedSweeper(
 
 // spawnStdioMCP starts a stdio MCP child for one server entry. Env keys are
 // sorted so process listings are deterministic across runs.
+// mcpLookupView adapts *mcp.DynamicRegistry to lookup.MCPDynamicRegistry
+// so the pool's build callback + the boot rehydrator can resolve through
+// the shared lookup.MCPServer chain (RFC N). The dynamic registry stores
+// mcp.DynamicMCPServerSpec; lookup wants the uniform lookup.MCPServerSpec.
+// A dynamic spec carries no operator allowed_tools (the substrate doesn't
+// record a narrowing), so AllowedTools stays nil = allow-all.
+type mcpLookupView struct{ reg *mcp.DynamicRegistry }
+
+func (v mcpLookupView) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
+	if v.reg == nil {
+		return lookup.MCPServerSpec{}, false
+	}
+	s, ok := v.reg.Get(tenantID, name)
+	if !ok {
+		return lookup.MCPServerSpec{}, false
+	}
+	return lookup.MCPServerSpec{Transport: s.Transport, URL: s.URL, Headers: s.Headers}, true
+}
+
+// mcpTenantFromCtx mirrors internal/api/http's tenantFromCtx for the
+// boot-wired closures in main.go that can't reach the unexported HTTP
+// helper. The tenant is authoritative-principal-first (the HTTP request
+// ctx carries it), then the RunIdentity fallback (sub-agent / internal
+// dispatch), then "" (shared/legacy). NEVER derived from wire/tool input.
+func mcpTenantFromCtx(ctx context.Context) string {
+	if p, ok := auth.PrincipalFromContext(ctx); ok && p.TenantID != "" {
+		return p.TenantID
+	}
+	return tools.RunIdentity(ctx).TenantID
+}
+
 func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {
 	keys := make([]string, 0, len(srv.Env))
 	for k := range srv.Env {

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1209,11 +1209,17 @@ func main() {
 	// run's tenant (NamesForTenant = own + shared), and read each name's
 	// active def with the tenant→shared precedence. NET EFFECT: a run in
 	// tenant A's candidate set contains ONLY A's + shared MCP tools, never
-	// tenant B's. The tenant is authoritative from ctx (principal →
-	// RunIdentity → ""), never from the wire.
-	srv.SetDynamicToolEnumerator(func(ctx context.Context) []tools.Tool {
+	// tenant B's.
+	//
+	// RFC N FIX 2-mcp: the tenant is the run's AUTHORITATIVE tenant passed
+	// in by the server, NOT derived from ctx here. candidateTools runs at
+	// the entry sites before WithRunIdentity is stamped, so a ctx-derived
+	// tenant would be "" for non-HTTP-principal spawn surfaces and the run
+	// would advertise the wrong tenant's MCP tools. The tenant remains
+	// authoritative (the server derived it from the principal / session /
+	// parent RunIdentity), never from the wire.
+	srv.SetDynamicToolEnumerator(func(ctx context.Context, tenant string) []tools.Tool {
 		var out []tools.Tool
-		tenant := mcpTenantFromCtx(ctx)
 		for _, name := range dynamicMCPRegistry.NamesForTenant(tenant) {
 			// Resolve the active def with the same precedence as
 			// lookup.MCPServer: the run's tenant first, then the shared ""
@@ -2617,18 +2623,6 @@ func (v mcpLookupView) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
 		return lookup.MCPServerSpec{}, false
 	}
 	return lookup.MCPServerSpec{Transport: s.Transport, URL: s.URL, Headers: s.Headers}, true
-}
-
-// mcpTenantFromCtx mirrors internal/api/http's tenantFromCtx for the
-// boot-wired closures in main.go that can't reach the unexported HTTP
-// helper. The tenant is authoritative-principal-first (the HTTP request
-// ctx carries it), then the RunIdentity fallback (sub-agent / internal
-// dispatch), then "" (shared/legacy). NEVER derived from wire/tool input.
-func mcpTenantFromCtx(ctx context.Context) string {
-	if p, ok := auth.PrincipalFromContext(ctx); ok && p.TenantID != "" {
-		return p.TenantID
-	}
-	return tools.RunIdentity(ctx).TenantID
 }
 
 func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {

--- a/internal/api/http/dynamic_tools_tenant_test.go
+++ b/internal/api/http/dynamic_tools_tenant_test.go
@@ -1,0 +1,149 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// tenantAdvertisingEnumerator replicates the RFC N §3 advertising filter
+// wired in cmd/loomcycle/main.go's SetDynamicToolEnumerator: enumerate ONLY
+// the names visible to the run's tenant (NamesForTenant = own + shared) and
+// read each name's active def with the tenant→shared precedence. Replicated
+// here (not imported) because the production closure lives in package main;
+// the logic under test — NamesForTenant + tenantFromCtx + the per-name
+// tenant-scoped GetActive — is the package-level surface this exercises.
+func tenantAdvertisingEnumerator(reg *loommcp.DynamicRegistry, st store.Store) func(context.Context) []tools.Tool {
+	return func(ctx context.Context) []tools.Tool {
+		var out []tools.Tool
+		tenant := tenantFromCtx(ctx)
+		for _, name := range reg.NamesForTenant(tenant) {
+			row, gerr := st.MCPServerDefGetActive(ctx, tenant, name)
+			if gerr != nil && tenant != "" {
+				row, gerr = st.MCPServerDefGetActive(ctx, "", name)
+			}
+			if gerr != nil {
+				continue
+			}
+			var def lookup.SubstrateMCPServer
+			if json.Unmarshal(row.Definition, &def) != nil {
+				continue
+			}
+			for _, dt := range def.DiscoveredTools {
+				out = append(out, namedTool{"mcp__" + name + "__" + dt.Name})
+			}
+		}
+		return out
+	}
+}
+
+// registerActiveMCPServer creates + promotes an active mcp_server_def for
+// (tenant, name) with one discovered tool, then mirrors it into the
+// in-memory registry — exactly what the substrate tool's create/promote
+// does, so the advertising enumerator can resolve it.
+func registerActiveMCPServer(t *testing.T, st store.Store, reg *loommcp.DynamicRegistry, tenant, name, toolName string) {
+	t.Helper()
+	ctx := context.Background()
+	def := map[string]any{
+		"transport": "http",
+		"url":       "https://" + name + ".example/mcp",
+		"discovered_tools": []map[string]any{
+			{"name": toolName, "description": "d"},
+		},
+	}
+	body, _ := json.Marshal(def)
+	row, err := st.MCPServerDefCreate(ctx, store.MCPServerDefRow{
+		DefID:      "mdef_" + tenant + "_" + name,
+		Name:       name,
+		Definition: body,
+		CreatedAt:  time.Now(),
+		TenantID:   tenant,
+	})
+	if err != nil {
+		t.Fatalf("create %s/%s: %v", tenant, name, err)
+	}
+	if err := st.MCPServerDefSetActive(ctx, tenant, name, row.DefID, ""); err != nil {
+		t.Fatalf("promote %s/%s: %v", tenant, name, err)
+	}
+	reg.Set(loommcp.DynamicMCPServerSpec{TenantID: tenant, Name: name, Transport: "http", URL: "https://" + name + ".example/mcp"})
+}
+
+// TestDynamicTools_TenantScopedAdvertising is the RFC N §3 regression guard:
+// an MCP server registered under tenant B must NOT appear in a run's
+// candidate tool set when the run's authoritative principal is tenant A, and
+// MUST appear for tenant B. A shared ("") server is visible to both. This is
+// the boundary that keeps tenant A from ever seeing — let alone dialing —
+// tenant B's MCP tools.
+func TestDynamicTools_TenantScopedAdvertising(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	reg := loommcp.NewDynamicRegistry()
+
+	// Same server NAME under two tenants with distinct tools, plus a shared
+	// one, plus a tenant-B-ONLY name (no A counterpart) — the latter is the
+	// case the NamesForTenant filter must exclude from A's set. A naive
+	// all-pairs Names() enumeration would leak "secret" into A's candidates.
+	registerActiveMCPServer(t, st, reg, "tenant-a", "crm", "a_tool")
+	registerActiveMCPServer(t, st, reg, "tenant-b", "crm", "b_tool")
+	registerActiveMCPServer(t, st, reg, "tenant-b", "secret", "b_secret_tool")
+	registerActiveMCPServer(t, st, reg, "", "billing", "shared_tool")
+
+	// Registry-level §3 boundary: tenant A's candidate NAME set must not
+	// contain B's exclusive "secret" server. This guards against a
+	// regression that swaps NamesForTenant back to the all-pairs Names()
+	// (the leak the per-tenant enumeration closes at the name layer, before
+	// the per-name tenant-scoped GetActive provides defence-in-depth).
+	for _, n := range reg.NamesForTenant("tenant-a") {
+		if n == "secret" {
+			t.Fatal("NamesForTenant(tenant-a) leaked tenant-b's exclusive 'secret' server")
+		}
+	}
+
+	srv := New(&config.Config{}, &stubResolver{}, nil, concurrency.New(4, 4, time.Second), nil)
+	srv.SetDynamicToolEnumerator(tenantAdvertisingEnumerator(reg, st))
+
+	ctxA := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-a", Subject: "alice"})
+	ctxB := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-b", Subject: "bob"})
+
+	namesA := toolNames(srv.candidateTools(ctxA))
+	namesB := toolNames(srv.candidateTools(ctxB))
+
+	// Tenant A sees its OWN crm tool + the shared billing tool, never B's
+	// same-name override and never B's exclusive "secret" server.
+	assertHas(t, "tenant-a", namesA, "mcp__crm__a_tool", true)
+	assertHas(t, "tenant-a", namesA, "mcp__billing__shared_tool", true)
+	assertHas(t, "tenant-a", namesA, "mcp__crm__b_tool", false)
+	assertHas(t, "tenant-a", namesA, "mcp__secret__b_secret_tool", false)
+
+	// Tenant B sees its OWN crm tool + the shared billing tool, never A's.
+	assertHas(t, "tenant-b", namesB, "mcp__crm__b_tool", true)
+	assertHas(t, "tenant-b", namesB, "mcp__billing__shared_tool", true)
+	assertHas(t, "tenant-b", namesB, "mcp__crm__a_tool", false)
+}
+
+func assertHas(t *testing.T, who string, names []string, want string, shouldHave bool) {
+	t.Helper()
+	has := false
+	for _, n := range names {
+		if n == want {
+			has = true
+			break
+		}
+	}
+	if has != shouldHave {
+		t.Errorf("%s candidate set: has(%q)=%v, want %v (set=%v)", who, want, has, shouldHave, names)
+	}
+}

--- a/internal/api/http/dynamic_tools_tenant_test.go
+++ b/internal/api/http/dynamic_tools_tenant_test.go
@@ -21,12 +21,16 @@ import (
 // the names visible to the run's tenant (NamesForTenant = own + shared) and
 // read each name's active def with the tenant→shared precedence. Replicated
 // here (not imported) because the production closure lives in package main;
-// the logic under test — NamesForTenant + tenantFromCtx + the per-name
-// tenant-scoped GetActive — is the package-level surface this exercises.
-func tenantAdvertisingEnumerator(reg *loommcp.DynamicRegistry, st store.Store) func(context.Context) []tools.Tool {
-	return func(ctx context.Context) []tools.Tool {
+// the logic under test — NamesForTenant + the EXPLICIT run tenant + the
+// per-name tenant-scoped GetActive — is the package-level surface this
+// exercises.
+//
+// RFC N FIX 2-mcp: the enumerator takes the run's authoritative tenant as an
+// EXPLICIT argument (the server passes it), NOT tenantFromCtx(ctx) — matching
+// the production signature.
+func tenantAdvertisingEnumerator(reg *loommcp.DynamicRegistry, st store.Store) func(context.Context, string) []tools.Tool {
+	return func(ctx context.Context, tenant string) []tools.Tool {
 		var out []tools.Tool
-		tenant := tenantFromCtx(ctx)
 		for _, name := range reg.NamesForTenant(tenant) {
 			row, gerr := st.MCPServerDefGetActive(ctx, tenant, name)
 			if gerr != nil && tenant != "" {
@@ -115,11 +119,15 @@ func TestDynamicTools_TenantScopedAdvertising(t *testing.T) {
 	srv := New(&config.Config{}, &stubResolver{}, nil, concurrency.New(4, 4, time.Second), nil)
 	srv.SetDynamicToolEnumerator(tenantAdvertisingEnumerator(reg, st))
 
+	// The server derives the authoritative tenant from the principal and
+	// passes it to candidateTools EXPLICITLY (RFC N FIX 2-mcp). We keep the
+	// principal on ctx to mirror the realistic HTTP shape, but it is the
+	// explicit tenant argument — not a ctx default — that selects the set.
 	ctxA := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-a", Subject: "alice"})
 	ctxB := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-b", Subject: "bob"})
 
-	namesA := toolNames(srv.candidateTools(ctxA))
-	namesB := toolNames(srv.candidateTools(ctxB))
+	namesA := toolNames(srv.candidateTools(ctxA, "tenant-a"))
+	namesB := toolNames(srv.candidateTools(ctxB, "tenant-b"))
 
 	// Tenant A sees its OWN crm tool + the shared billing tool, never B's
 	// same-name override and never B's exclusive "secret" server.
@@ -132,6 +140,51 @@ func TestDynamicTools_TenantScopedAdvertising(t *testing.T) {
 	assertHas(t, "tenant-b", namesB, "mcp__crm__b_tool", true)
 	assertHas(t, "tenant-b", namesB, "mcp__billing__shared_tool", true)
 	assertHas(t, "tenant-b", namesB, "mcp__crm__a_tool", false)
+}
+
+// TestDynamicTools_AdvertisesExplicitTenantWithoutPrincipalOnCtx — RFC N
+// FIX 2-mcp regression. A non-HTTP-principal spawn surface (A2A / scheduler /
+// webhook / MCP spawn_run / gRPC-legacy) computes the run's authoritative
+// tenant as effectiveTenantID and passes it EXPLICITLY to candidateTools,
+// with NO auth.Principal on ctx and WithRunIdentity not yet stamped. The run
+// MUST advertise its own tenant's (+ shared) MCP tools, not "".
+//
+// Pre-fix, the enumerator derived the tenant from ctx (mcpTenantFromCtx /
+// tenantFromCtx), which — with no principal and no RunIdentity — returns "",
+// so the run advertised ONLY shared MCP tools and could not see its OWN
+// tenant's dynamic MCP server. This test fails on the unfixed signature (it
+// would not compile against the old ctx-only enumerator, and semantically
+// would advertise "" not T).
+func TestDynamicTools_AdvertisesExplicitTenantWithoutPrincipalOnCtx(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	reg := loommcp.NewDynamicRegistry()
+
+	registerActiveMCPServer(t, st, reg, "acme", "crm", "acme_tool")
+	registerActiveMCPServer(t, st, reg, "", "billing", "shared_tool")
+
+	srv := New(&config.Config{}, &stubResolver{}, nil, concurrency.New(4, 4, time.Second), nil)
+	srv.SetDynamicToolEnumerator(tenantAdvertisingEnumerator(reg, st))
+
+	// The A2A/scheduler shape: NO principal, NO RunIdentity on ctx. The run's
+	// authoritative tenant "acme" is supplied EXPLICITLY by the entry site.
+	ctx := context.Background()
+	names := toolNames(srv.candidateTools(ctx, "acme"))
+
+	// The run sees its OWN acme tool + the shared billing tool even though
+	// nothing on ctx names the tenant.
+	assertHas(t, "acme(explicit)", names, "mcp__crm__acme_tool", true)
+	assertHas(t, "acme(explicit)", names, "mcp__billing__shared_tool", true)
+
+	// With an EMPTY tenant (the pre-fix ctx-derived value) the acme tool is
+	// NOT advertised — proving the explicit tenant argument, not a ctx
+	// default, is what selects the set.
+	sharedOnly := toolNames(srv.candidateTools(ctx, ""))
+	assertHas(t, "shared(empty)", sharedOnly, "mcp__crm__acme_tool", false)
+	assertHas(t, "shared(empty)", sharedOnly, "mcp__billing__shared_tool", true)
 }
 
 func assertHas(t *testing.T, who string, names []string, want string, shouldHave bool) {

--- a/internal/api/http/dynamic_tools_test.go
+++ b/internal/api/http/dynamic_tools_test.go
@@ -27,13 +27,13 @@ func (n namedTool) Execute(context.Context, json.RawMessage) (tools.Result, erro
 func TestCandidateTools_AdvertisesDynamicTools(t *testing.T) {
 	// New auto-appends the built-in Agent tool, so the boot set is N≥1.
 	srv := New(&config.Config{}, &stubResolver{}, []tools.Tool{namedTool{"Read"}}, concurrency.New(4, 4, time.Second), nil)
-	base := len(srv.candidateTools(context.Background()))
+	base := len(srv.candidateTools(context.Background(), ""))
 
 	// Enumerator returns a post-boot dynamic MCP tool → exactly one more.
-	srv.SetDynamicToolEnumerator(func(context.Context) []tools.Tool {
+	srv.SetDynamicToolEnumerator(func(context.Context, string) []tools.Tool {
 		return []tools.Tool{namedTool{"mcp__jobs__getAgentContext"}}
 	})
-	cand := srv.candidateTools(context.Background())
+	cand := srv.candidateTools(context.Background(), "")
 	if len(cand) != base+1 {
 		t.Fatalf("with enumerator: %d candidate tools, want base+1 (%d)", len(cand), base+1)
 	}

--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -195,7 +195,7 @@ func TestLibrary_MCPServerDefNames_AfterSeed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_ = s.MCPServerDefSetActive(ctx, "n8n-mailgun", "mdef_n8n_v1", "")
+	_ = s.MCPServerDefSetActive(ctx, "", "n8n-mailgun", "mdef_n8n_v1", "")
 
 	req := authedRequest("GET", "/v1/_mcpserverdef/names", nil)
 	rec := httptest.NewRecorder()

--- a/internal/api/http/scheduler_bearer_compound_test.go
+++ b/internal/api/http/scheduler_bearer_compound_test.go
@@ -143,7 +143,7 @@ func TestSchedulerBearerCompound(t *testing.T) {
 	// MCP pool factory — returns a Client for each configured server
 	// using the same URL+headers shape main.go uses.
 	pool := loommcp.NewPool(
-		func(name string) (loommcp.Caller, error) {
+		func(_, name string) (loommcp.Caller, error) {
 			srv, ok := cfg.MCPServers[name]
 			if !ok {
 				return nil, fmt.Errorf("mcp_servers.%s: not configured", name)
@@ -156,6 +156,7 @@ func TestSchedulerBearerCompound(t *testing.T) {
 				_ = cl.Close()
 			}
 		},
+		nil,
 	)
 	t.Cleanup(pool.Close)
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -124,7 +124,14 @@ type Server struct {
 	// is both ADVERTISED in the run's catalog and dispatchable — symmetric
 	// with boot-registered tools, no restart needed. nil-safe (tests +
 	// deployments without the substrate); wired in main.go.
-	dynamicTools func(context.Context) []tools.Tool
+	//
+	// RFC N FIX 2-mcp: the tenant is an EXPLICIT argument, not ctx-derived.
+	// candidateTools runs at the run-creation ENTRY sites BEFORE
+	// WithRunIdentity is stamped on ctx, so for non-HTTP-principal spawn
+	// surfaces (A2A/scheduler/webhook/MCP spawn_run/gRPC-legacy) the ctx
+	// tenant is "" and the enumerator would advertise the wrong tenant's
+	// MCP tool set. The caller passes the run's authoritative tenant.
+	dynamicTools func(ctx context.Context, tenantID string) []tools.Tool
 
 	// systemPublisher backs the v0.8.6 POST /v1/_channels/_system/...
 	// admin endpoint. Nil = endpoint refuses every request with a
@@ -379,11 +386,14 @@ func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
 
 // SetDynamicToolEnumerator installs the optional post-boot tool advertiser.
 // fn returns the substrate-registered tools (dynamic MCP + A2A) currently
-// available; the run-creation path folds them into the candidate set before
-// the allowed_tools filter, so post-boot registrations are advertised to the
-// model without a restart. Nil-safe; wired in main.go after the registries +
-// pool are built.
-func (s *Server) SetDynamicToolEnumerator(fn func(context.Context) []tools.Tool) {
+// available for the passed tenant; the run-creation path folds them into the
+// candidate set before the allowed_tools filter, so post-boot registrations
+// are advertised to the model without a restart. Nil-safe; wired in main.go
+// after the registries + pool are built.
+//
+// RFC N FIX 2-mcp: fn takes the run's authoritative tenant EXPLICITLY rather
+// than deriving it from ctx — see candidateTools.
+func (s *Server) SetDynamicToolEnumerator(fn func(ctx context.Context, tenantID string) []tools.Tool) {
 	s.dynamicTools = fn
 }
 
@@ -392,11 +402,16 @@ func (s *Server) SetDynamicToolEnumerator(fn func(context.Context) []tools.Tool)
 // the advertised catalog) sees dynamically-registered tools. The boot set is
 // the floor; a dynamic tool that duplicates a boot-set name collapses in
 // filterTools's by-name map (last writer wins; both wrap the same upstream).
-func (s *Server) candidateTools(ctx context.Context) []tools.Tool {
+//
+// RFC N FIX 2-mcp: tenantID is the run's authoritative tenant, passed
+// EXPLICITLY by the caller. The entry sites call this BEFORE WithRunIdentity
+// is stamped on ctx, so a ctx-derived tenant would be "" for non-HTTP-principal
+// spawn surfaces — and the run would advertise the wrong tenant's MCP tools.
+func (s *Server) candidateTools(ctx context.Context, tenantID string) []tools.Tool {
 	if s.dynamicTools == nil {
 		return s.tools
 	}
-	dyn := s.dynamicTools(ctx)
+	dyn := s.dynamicTools(ctx, tenantID)
 	if len(dyn) == 0 {
 		return s.tools
 	}
@@ -1472,7 +1487,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	defer release()
 
 	// ---- Tool filtering + host narrowing ----
-	allowedTools := filterTools(s.candidateTools(ctx), agentDef.AllowedTools, in.AllowedTools)
+	// RFC N FIX 2-mcp: advertise MCP tools at the run's authoritative
+	// tenant (effectiveTenantID), not the ctx tenant — WithRunIdentity
+	// isn't stamped yet, so for non-HTTP-principal spawn surfaces the ctx
+	// tenant is "" and the run would not see its OWN dynamic MCP tools.
+	allowedTools := filterTools(s.candidateTools(ctx, effectiveTenantID), agentDef.AllowedTools, in.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if in.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -2612,7 +2631,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	// Filter tools by agent allowlist + caller request.
-	allowedTools := filterTools(s.candidateTools(r.Context()), agentDef.AllowedTools, req.AllowedTools)
+	// RFC N FIX 2-mcp: advertise at this handler's authoritative tenant. On
+	// an authed HTTP route the principal is on ctx, so tenantFromCtx returns
+	// the principal's tenant (never the wire).
+	allowedTools := filterTools(s.candidateTools(r.Context(), tenantFromCtx(r.Context())), agentDef.AllowedTools, req.AllowedTools)
 	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
 	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
 	// doc comment. In caller-authoritative mode we ALWAYS call so the
@@ -3036,7 +3058,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	}
 	defer release()
 
-	allowedTools := filterTools(s.candidateTools(r.Context()), agentDef.AllowedTools, body.AllowedTools)
+	// RFC N FIX 2-mcp: a continuation advertises at the SESSION's
+	// authoritative tenant (the same value the continuation run uses), not
+	// the ctx tenant — the ownership gate above already proved the caller
+	// is entitled to this session.
+	allowedTools := filterTools(s.candidateTools(r.Context(), sess.TenantID), agentDef.AllowedTools, body.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if body.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -3755,7 +3781,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		}},
 	})
 
-	subTools := filterTools(s.candidateTools(ctx), def.AllowedTools, nil)
+	// RFC N FIX 2-mcp: sub-agents run with the parent's RunIdentity already
+	// on ctx, so tenantFromCtx returns the run's authoritative tenant —
+	// the sub-agent advertises the same tenant's MCP tools as its parent.
+	subTools := filterTools(s.candidateTools(ctx, tenantFromCtx(ctx)), def.AllowedTools, nil)
 	// Inherit the parent's caller-authoritative host policy. Without
 	// this, sub-agents fall back to the operator's static
 	// HTTPHostAllowlist — which typically doesn't include localhost

--- a/internal/lookup/README.md
+++ b/internal/lookup/README.md
@@ -28,7 +28,7 @@ Every code path that needs to resolve an agent / skill / MCP server NAME to its 
 ```go
 def, ok := lookup.Agent(ctx, s.store, s.cfg, tenantID, name)
 sk, ok  := lookup.Skill(ctx, s.store, s.skillSet, tenantID, name)
-spec, ok := lookup.MCPServer(s.cfg, dynRegistry, name)
+spec, ok := lookup.MCPServer(s.cfg, dynRegistry, tenantID, name)
 ```
 
 ### Agent resolution precedence (RFC N — tenant axis)
@@ -48,8 +48,7 @@ single-tenant deployment (everything `tenant_id=""`) is unchanged. The
 `tenantID` MUST come from the authoritative principal in ctx
 (`auth.PrincipalFromContext` → `tools.RunIdentity` fallback → `""`), never
 from a wire/request field — see `internal/api/http/server.go`'s
-`tenantFromCtx`. (MCP servers still resolve globally; their tenant axis is
-a follow-up.)
+`tenantFromCtx`.
 
 ### Skill resolution precedence (RFC N — tenant axis)
 
@@ -69,6 +68,28 @@ For the default tenant `""`, step 1 is skipped, so the order collapses to
 **shared-substrate → static** — byte-for-byte the pre-RFC-N
 "substrate-first then static" behavior. The same ctx-authoritative
 `tenantID` rule applies as for agents.
+
+### MCP server resolution precedence (RFC N — tenant axis)
+
+`lookup.MCPServer` resolves within the caller's `tenantID`. Like agents,
+the MCP plane is **static-first** (the opposite of skills), with a
+tenant-dynamic shadow in front:
+
+1. **(tenantID != "")** tenant-scoped dynamic registry — a per-tenant
+   registration *shadows* the shared static yaml base by name.
+2. **static `cfg.MCPServers`** — the shared operator (yaml) base.
+3. **shared dynamic registry** (`tenant_id=""`) — operator/runtime
+   registrations every tenant inherits.
+
+For the default tenant `""`, step 1 is skipped, so the order collapses to
+**static → shared-dynamic** — byte-for-byte the pre-RFC-N behavior. The
+in-memory `DynamicRegistry` is keyed by `(tenant, name)`; the MCP
+connection `Pool` is keyed by `(tenant, name)` too, so two tenants
+registering the same name with different URLs never share a cached client.
+The same ctx-authoritative `tenantID` rule applies. The advertising filter
+(`cmd/loomcycle/main.go`'s `SetDynamicToolEnumerator`) enumerates
+`DynamicRegistry.NamesForTenant(tenant)` so a run's candidate tool set
+contains ONLY that tenant's + shared MCP tools (RFC §3).
 
 Don't read substrate rows directly. Don't unmarshal into `config.AgentDef` (use the json-tagged adapters). The pattern is enforced by the drift tests (`TestAgent_DriftDetection` + `TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef`) — a future field added to one shape without the other fails CI.
 

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -9,7 +9,9 @@ import (
 // doesn't import internal/tools/mcp (which would invert the existing
 // dependency direction; tools/mcp is consumed by everything else).
 type MCPDynamicRegistry interface {
-	Get(name string) (MCPServerSpec, bool)
+	// Get is an exact (tenantID, name) read — the resolver drives the
+	// tenant→shared precedence by calling Get twice (RFC N).
+	Get(tenantID, name string) (MCPServerSpec, bool)
 }
 
 // MCPServerSpec is the runtime spec for an MCP server registration.
@@ -36,20 +38,31 @@ type MCPServerSpec struct {
 	Source string
 }
 
-// MCPServer resolves an MCP server NAME to its effective runtime
-// spec by walking the lookup chain in precedence order:
+// MCPServer resolves an MCP server NAME to its effective runtime spec
+// within the caller's tenant, walking the lookup chain in precedence
+// order (MCP is STATIC-first — the opposite of skills):
 //
-//  1. static cfg.MCPServers (yaml-defined; ground truth).
-//  2. dynamic registry (v0.9.x substrate, rehydrated from
+//  1. (tenantID != "") tenant-scoped dynamic registry — a per-tenant
+//     registration shadows the shared static base by name.
+//  2. static cfg.MCPServers (yaml-defined; the shared operator base).
+//  3. shared dynamic registry (tenant_id="", rehydrated from
 //     mcp_server_defs at boot + mutated by promote / retire).
 //
-// Returns (zero, false) when neither source has the name.
+// Returns (zero, false) when no source has the name.
 //
-// Yaml takes precedence on name collisions: the substrate tool refuses
-// `create` over a yaml-occupied name, and the boot-time loader skips
-// dynamic rows whose name collides with yaml. This resolver enforces
-// the same order at the lookup boundary so future refactors that add
-// a third tier can't accidentally invert it.
+// For the default tenant "" step 1 is skipped, so the order collapses to
+// static → shared-dynamic — byte-for-byte the pre-RFC-N behaviour
+// (single-tenant deployments are unchanged). Yaml still takes precedence
+// over a SHARED dynamic registration on name collisions: the substrate
+// tool refuses `create` over a yaml-occupied name, and the boot loader
+// skips shared dynamic rows whose name collides with yaml. A per-TENANT
+// registration (step 1) deliberately CAN shadow the shared yaml base —
+// that is the per-tenant override RFC N grants.
+//
+// The tenantID MUST come from the authoritative principal in ctx
+// (auth.PrincipalFromContext → tools.RunIdentity fallback → ""), never
+// from a wire/request field — see internal/api/http/server.go's
+// tenantFromCtx.
 //
 // LIMITATION (intentional): MCPServerSpec is the HTTP / streamable-http
 // subset. The stdio transport carries additional yaml-only fields
@@ -69,7 +82,16 @@ type MCPServerSpec struct {
 // "is this name known (static OR dynamic)?" + which tools the operator
 // allowed. Routing the resolver through here is what keeps MCP membership
 // from drifting static-only again (the bug fixed in #341).
-func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, name string) (MCPServerSpec, bool) {
+func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, tenantID, name string) (MCPServerSpec, bool) {
+	// 1. Tenant-scoped dynamic shadow (skipped for the shared "" tenant so
+	//    its order stays static → shared-dynamic, exactly as pre-RFC-N).
+	if dyn != nil && tenantID != "" {
+		if spec, ok := dyn.Get(tenantID, name); ok {
+			spec.Source = "dynamic"
+			return spec, true
+		}
+	}
+	// 2. Static cfg.MCPServers — the shared operator base.
 	if cfg != nil {
 		if srv, ok := cfg.MCPServers[name]; ok {
 			return MCPServerSpec{
@@ -81,8 +103,9 @@ func MCPServer(cfg *config.Config, dyn MCPDynamicRegistry, name string) (MCPServ
 			}, true
 		}
 	}
+	// 3. Shared dynamic registry (tenant_id="").
 	if dyn != nil {
-		if spec, ok := dyn.Get(name); ok {
+		if spec, ok := dyn.Get("", name); ok {
 			spec.Source = "dynamic"
 			return spec, true
 		}

--- a/internal/lookup/mcpserver_test.go
+++ b/internal/lookup/mcpserver_test.go
@@ -9,10 +9,11 @@ import (
 )
 
 // fakeDynReg is a lookup.MCPDynamicRegistry stub for the resolver test.
-type fakeDynReg map[string]lookup.MCPServerSpec
+// RFC N: keyed by (tenant, name); the "" tenant is the shared registry.
+type fakeDynReg map[[2]string]lookup.MCPServerSpec
 
-func (f fakeDynReg) Get(name string) (lookup.MCPServerSpec, bool) {
-	s, ok := f[name]
+func (f fakeDynReg) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
+	s, ok := f[[2]string{tenantID, name}]
 	return s, ok
 }
 
@@ -28,24 +29,65 @@ func TestMCPServer_StaticDynamicPrecedence(t *testing.T) {
 		"both":       {Transport: "http", URL: "http://yaml/mcp"},
 	}}
 	dyn := fakeDynReg{
-		"dyn-srv": {Transport: "http", URL: "http://d/mcp"},
-		"both":    {Transport: "http", URL: "http://substrate/mcp"},
+		{"", "dyn-srv"}: {Transport: "http", URL: "http://d/mcp"},
+		{"", "both"}:    {Transport: "http", URL: "http://substrate/mcp"},
 	}
 
-	if spec, ok := lookup.MCPServer(cfg, dyn, "static-srv"); !ok || spec.Source != "static" || !reflect.DeepEqual(spec.AllowedTools, []string{"a", "b"}) {
+	// Default "" tenant: order collapses to static → shared-dynamic, exactly
+	// as pre-RFC-N.
+	if spec, ok := lookup.MCPServer(cfg, dyn, "", "static-srv"); !ok || spec.Source != "static" || !reflect.DeepEqual(spec.AllowedTools, []string{"a", "b"}) {
 		t.Errorf("static: got (%+v, %v), want source=static + allowed [a b]", spec, ok)
 	}
-	if spec, ok := lookup.MCPServer(cfg, dyn, "dyn-srv"); !ok || spec.Source != "dynamic" || len(spec.AllowedTools) != 0 {
+	if spec, ok := lookup.MCPServer(cfg, dyn, "", "dyn-srv"); !ok || spec.Source != "dynamic" || len(spec.AllowedTools) != 0 {
 		t.Errorf("dynamic: got (%+v, %v), want source=dynamic + no allowed_tools (allow-all)", spec, ok)
 	}
-	if spec, ok := lookup.MCPServer(cfg, dyn, "both"); !ok || spec.Source != "static" || spec.URL != "http://yaml/mcp" {
+	if spec, ok := lookup.MCPServer(cfg, dyn, "", "both"); !ok || spec.Source != "static" || spec.URL != "http://yaml/mcp" {
 		t.Errorf("collision: got (%+v, %v), want the static (yaml) entry to win", spec, ok)
 	}
-	if _, ok := lookup.MCPServer(cfg, dyn, "nope"); ok {
+	if _, ok := lookup.MCPServer(cfg, dyn, "", "nope"); ok {
 		t.Error("unknown name must return ok=false")
 	}
-	if _, ok := lookup.MCPServer(nil, nil, "x"); ok {
+	if _, ok := lookup.MCPServer(nil, nil, "", "x"); ok {
 		t.Error("nil cfg + nil dyn must return ok=false")
+	}
+}
+
+// TestMCPServer_TenantResolutionPrecedence pins the RFC N tenant axis:
+//  1. a per-tenant dynamic registration shadows the shared static base;
+//  2. otherwise the static shared base resolves;
+//  3. otherwise a shared ("") dynamic registration resolves;
+//  4. the "" tenant preserves static-first (no tenant shadow pass).
+func TestMCPServer_TenantResolutionPrecedence(t *testing.T) {
+	cfg := &config.Config{MCPServers: map[string]config.MCPServer{
+		"shared-srv": {Transport: "http", URL: "http://static/mcp"},
+	}}
+	dyn := fakeDynReg{
+		// tenant-a overrides the shared static "shared-srv" by name.
+		{"tenant-a", "shared-srv"}: {Transport: "http", URL: "http://a-override/mcp"},
+		// a shared-dynamic-only name (no static entry).
+		{"", "shared-dyn"}: {Transport: "http", URL: "http://shared-dyn/mcp"},
+	}
+
+	// 1. tenant-a's override shadows the static base.
+	if spec, ok := lookup.MCPServer(cfg, dyn, "tenant-a", "shared-srv"); !ok || spec.URL != "http://a-override/mcp" {
+		t.Errorf("tenant override: got (%+v, %v), want a-override URL", spec, ok)
+	}
+	// A different tenant with no override falls through to the static base.
+	if spec, ok := lookup.MCPServer(cfg, dyn, "tenant-b", "shared-srv"); !ok || spec.Source != "static" || spec.URL != "http://static/mcp" {
+		t.Errorf("tenant-b base: got (%+v, %v), want the static shared base", spec, ok)
+	}
+	// 3. shared-dynamic-only name resolves for any tenant.
+	if spec, ok := lookup.MCPServer(cfg, dyn, "tenant-a", "shared-dyn"); !ok || spec.URL != "http://shared-dyn/mcp" {
+		t.Errorf("shared dynamic: got (%+v, %v), want shared-dyn URL", spec, ok)
+	}
+	// 4. "" tenant never sees tenant-a's override — resolves the static base.
+	if spec, ok := lookup.MCPServer(cfg, dyn, "", "shared-srv"); !ok || spec.Source != "static" || spec.URL != "http://static/mcp" {
+		t.Errorf("default tenant: got (%+v, %v), want the static base (no tenant shadow)", spec, ok)
+	}
+	// tenant-a's override is invisible to the "" tenant entirely (the name
+	// only exists in static for "").
+	if _, ok := lookup.MCPServer(cfg, dyn, "tenant-c", "a-only-nonexistent"); ok {
+		t.Error("nonexistent name must return ok=false")
 	}
 }
 

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -139,7 +139,7 @@ func TestRoundTrip_WithMCPServerDefs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := src.MCPServerDefSetActive(ctx, def.Name, def.DefID, ""); err != nil {
+	if err := src.MCPServerDefSetActive(ctx, "", def.Name, def.DefID, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/store/postgres/migrations/0039_mcp_server_defs_tenant_id.down.sql
+++ b/internal/store/postgres/migrations/0039_mcp_server_defs_tenant_id.down.sql
@@ -1,0 +1,16 @@
+-- 0039_mcp_server_defs_tenant_id.down.sql — reverse RFC N's tenant axis
+-- on the MCP server definition plane. Restores the single-column PK and
+-- the UNIQUE(name, version) constraint, then drops the tenant_id columns.
+--
+-- NOTE: down is only safe while every row is tenant_id='' (the
+-- single-tenant / pre-migration state). If real per-tenant rows exist,
+-- restoring the single-col PK would collide on duplicate names — the
+-- operator must reconcile names before rolling back.
+
+ALTER TABLE mcp_server_def_active DROP CONSTRAINT mcp_server_def_active_pkey;
+ALTER TABLE mcp_server_def_active ADD PRIMARY KEY (name);
+ALTER TABLE mcp_server_def_active DROP COLUMN tenant_id;
+
+ALTER TABLE mcp_server_defs DROP CONSTRAINT mcp_server_defs_tenant_name_version_key;
+ALTER TABLE mcp_server_defs ADD CONSTRAINT mcp_server_defs_name_version_key UNIQUE (name, version);
+ALTER TABLE mcp_server_defs DROP COLUMN tenant_id;

--- a/internal/store/postgres/migrations/0039_mcp_server_defs_tenant_id.up.sql
+++ b/internal/store/postgres/migrations/0039_mcp_server_defs_tenant_id.up.sql
@@ -1,0 +1,28 @@
+-- 0039_mcp_server_defs_tenant_id.up.sql — RFC N: tenant-scope the MCP
+-- server definition plane (mirror of 0037/0038 for the MCP tables).
+--
+-- RFC L isolated the STATE plane (runs/sessions/memory keyed on the
+-- authoritative principal). It left the DEFINITION plane global: the
+-- mcp_server_defs / mcp_server_def_active tables had no tenant column, so
+-- two tenants registering the same name collided on a single global active
+-- pointer (last-writer-wins) and any token could resolve & dial another
+-- tenant's MCP server. This migration adds the tenant axis, mirroring the
+-- agent (0037) and skill (0038) definition planes.
+--
+-- '' = the shared/operator/legacy tenant. Existing rows backfill to ''
+-- via the column DEFAULT, so a single-tenant deployment behaves exactly
+-- as before. This PR completes the RFC N definition plane (agents +
+-- skills + MCP servers).
+
+-- mcp_server_defs: tenant the versioned-definition rows. The UNIQUE(name,
+-- version) becomes UNIQUE(tenant_id, name, version) so two tenants can
+-- own the same name independently.
+ALTER TABLE mcp_server_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE mcp_server_defs DROP CONSTRAINT mcp_server_defs_name_version_key;
+ALTER TABLE mcp_server_defs ADD CONSTRAINT mcp_server_defs_tenant_name_version_key UNIQUE (tenant_id, name, version);
+
+-- mcp_server_def_active: the active pointer is now per (tenant_id, name).
+-- Add the column, drop the single-col PK, add the composite PK.
+ALTER TABLE mcp_server_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE mcp_server_def_active DROP CONSTRAINT mcp_server_def_active_pkey;
+ALTER TABLE mcp_server_def_active ADD PRIMARY KEY (tenant_id, name);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -1189,9 +1189,9 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 	rows, err := s.pool.Query(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition::text, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static, content_sha256
+		        retired, bootstrapped_from_static, content_sha256, tenant_id
 		 FROM mcp_server_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read mcp_server_defs: %w", err)
@@ -1212,7 +1212,7 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&r.CreatedAt, &createdBy, &createdRun,
-			&r.Retired, &r.BootstrappedFromStatic, &contentHash,
+			&r.Retired, &r.BootstrappedFromStatic, &contentHash, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan mcp_server_def: %w", err)
 		}
@@ -1240,9 +1240,9 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 // SnapshotReadMCPServerDefActive — v0.9.x mirror.
 func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCPServerDefActiveEntry, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM mcp_server_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read mcp_server_def_active: %w", err)
 	}
@@ -1253,7 +1253,7 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 			e        store.MCPServerDefActiveEntry
 			promoter *string
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &e.PromotedAt, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan mcp_server_def_active: %w", err)
 		}
 		if promoter != nil {
@@ -1647,14 +1647,14 @@ func (s *Store) SnapshotRestoreMCPServerDef(ctx context.Context, r store.MCPServ
 		`INSERT INTO mcp_server_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)
 		 ON CONFLICT (def_id) DO NOTHING`,
 		r.DefID, r.Name, r.Version, nullIfEmpty(r.ParentDefID),
 		string(r.Definition), nullIfEmpty(r.Description),
 		createdAt, nullIfEmpty(r.CreatedByAgentID), nullIfEmpty(r.CreatedByRunID),
 		r.Retired, r.BootstrappedFromStatic,
-		nullIfEmpty(r.ContentSHA256),
+		nullIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore mcp_server_def: %w", err)
@@ -1672,9 +1672,9 @@ func (s *Store) SnapshotRestoreMCPServerDefActive(ctx context.Context, e store.M
 		promotedAt = time.Now().UTC()
 	}
 	tag, err := s.pool.Exec(ctx,
-		`INSERT INTO mcp_server_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4)
-		 ON CONFLICT (name) DO NOTHING`,
-		e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
+		`INSERT INTO mcp_server_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (tenant_id, name) DO NOTHING`,
+		e.TenantID, e.Name, e.DefID, promotedAt, nullIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore mcp_server_def_active: %w", err)
@@ -3796,9 +3796,12 @@ func (s *Store) MCPServerDefCreate(ctx context.Context, row store.MCPServerDefRo
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Per-(tenant, name) advisory lock — RFC N scopes version allocation
+	// per tenant so two tenants' v1 don't collide on the
+	// UNIQUE(tenant_id, name, version).
 	if _, err := tx.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
-		"mcp_server_def:"+row.Name,
+		"mcp_server_def:"+row.TenantID+":"+row.Name,
 	); err != nil {
 		return store.MCPServerDefRow{}, fmt.Errorf("mcp_server_def create lock: %w", err)
 	}
@@ -3814,7 +3817,7 @@ func (s *Store) MCPServerDefCreate(ctx context.Context, row store.MCPServerDefRo
 	}
 
 	var maxVer sql.NullInt64
-	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM mcp_server_defs WHERE name = $1`, row.Name).Scan(&maxVer); err != nil {
+	if err := tx.QueryRow(ctx, `SELECT MAX(version) FROM mcp_server_defs WHERE tenant_id = $1 AND name = $2`, row.TenantID, row.Name).Scan(&maxVer); err != nil {
 		return store.MCPServerDefRow{}, fmt.Errorf("mcp_server_def create max version: %w", err)
 	}
 	row.Version = 1
@@ -3827,14 +3830,14 @@ func (s *Store) MCPServerDefCreate(ctx context.Context, row store.MCPServerDefRo
 		INSERT INTO mcp_server_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10, $11, $12, $13)`,
 		row.DefID, row.Name, row.Version, nullableString(row.ParentDefID),
 		string(row.Definition), nullableString(row.Description),
 		row.CreatedAt,
 		nullableString(row.CreatedByAgentID), nullableString(row.CreatedByRunID),
 		row.Retired, row.BootstrappedFromStatic,
-		nullableString(row.ContentSHA256),
+		nullableString(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.MCPServerDefRow{}, fmt.Errorf("mcp_server_def insert: %w", err)
 	}
@@ -3881,15 +3884,16 @@ func (s *Store) MCPServerDefListChildren(ctx context.Context, parentDefID string
 func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDefNameSummary, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM mcp_server_defs d
-		LEFT JOIN mcp_server_def_active a ON a.name = d.name
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		LEFT JOIN mcp_server_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, fmt.Errorf("mcp_server_def list names: %w", err)
 	}
@@ -3898,7 +3902,7 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	var out []store.MCPServerDefNameSummary
 	for rows.Next() {
 		var ns store.MCPServerDefNameSummary
-		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &ns.LastUpdated, &ns.ActiveDefID); err != nil {
 			return nil, err
 		}
 		out = append(out, ns)
@@ -3906,9 +3910,16 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	return out, rows.Err()
 }
 
-func (s *Store) MCPServerDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	var rowName string
-	err := s.pool.QueryRow(ctx, `SELECT name FROM mcp_server_defs WHERE def_id = $1`, defID).Scan(&rowName)
+// MCPServerDefSetActive UPSERTs the active pointer for (tenantID, name).
+// RFC N: validates the def belongs to BOTH the named server AND the
+// supplied tenant — a def can only be promoted within its own tenant, so
+// a caller can't point another tenant's active pointer at a def it owns.
+func (s *Store) MCPServerDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.pool.QueryRow(ctx, `SELECT name, tenant_id FROM mcp_server_defs WHERE def_id = $1`, defID).Scan(&rowName, &rowTenant)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return &store.ErrNotFound{Kind: "mcp_server_def", ID: defID}
 	}
@@ -3918,14 +3929,17 @@ func (s *Store) MCPServerDefSetActive(ctx context.Context, name, defID, promoted
 	if rowName != name {
 		return fmt.Errorf("mcp_server_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("mcp_server_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.pool.Exec(ctx, `
-		INSERT INTO mcp_server_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES ($1, $2, $3, $4)
-		ON CONFLICT (name) DO UPDATE SET
+		INSERT INTO mcp_server_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES ($1, $2, $3, $4, $5)
+		ON CONFLICT (tenant_id, name) DO UPDATE SET
 		    def_id               = EXCLUDED.def_id,
 		    promoted_at          = EXCLUDED.promoted_at,
 		    promoted_by_agent_id = EXCLUDED.promoted_by_agent_id`,
-		name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
+		tenantID, name, defID, time.Now().UTC(), nullableString(promotedByAgentID),
 	)
 	if err != nil {
 		return fmt.Errorf("mcp_server_def_active upsert: %w", err)
@@ -3933,9 +3947,12 @@ func (s *Store) MCPServerDefSetActive(ctx context.Context, name, defID, promoted
 	return nil
 }
 
-func (s *Store) MCPServerDefGetActive(ctx context.Context, name string) (store.MCPServerDefRow, error) {
+// MCPServerDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists. RFC N: tenantID "" = the shared/
+// operator/legacy tenant.
+func (s *Store) MCPServerDefGetActive(ctx context.Context, tenantID, name string) (store.MCPServerDefRow, error) {
 	var defID string
-	err := s.pool.QueryRow(ctx, `SELECT def_id FROM mcp_server_def_active WHERE name = $1`, name).Scan(&defID)
+	err := s.pool.QueryRow(ctx, `SELECT def_id FROM mcp_server_def_active WHERE tenant_id = $1 AND name = $2`, tenantID, name).Scan(&defID)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return store.MCPServerDefRow{}, &store.ErrNotFound{Kind: "mcp_server_def_active", ID: name}
 	}
@@ -3971,7 +3988,8 @@ const mcpServerDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM mcp_server_defs`
 
 func (s *Store) scanMCPServerDef(row pgx.Row) (store.MCPServerDefRow, error) {
@@ -3988,6 +4006,7 @@ func (s *Store) scanMCPServerDef(row pgx.Row) (store.MCPServerDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&out.Retired, &out.BootstrappedFromStatic,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.MCPServerDefRow{}, err
@@ -4012,6 +4031,7 @@ func (s *Store) scanMCPServerDefRows(rows pgx.Rows) ([]store.MCPServerDefRow, er
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&r.Retired, &r.BootstrappedFromStatic,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -822,14 +822,16 @@ func (s *Store) migrate(ctx context.Context) error {
 		// column added by addColumns above is guaranteed present first.
 		//
 		// Residual caveat (unchanged): the upgraded agent_def_active /
-		// dynamic_agents / skill_def_active tables still carry PRIMARY
-		// KEY(name), so two tenants cannot share a name on a PRE-EXISTING
-		// SQLite DB — a fresh DB is required for full multi-tenant on SQLite.
-		// These indexes restore single-tenant upgrade functionality only;
-		// they do not retrofit the per-tenant isolation a fresh DB's
-		// composite PK provides. The skill plane has NO dynamic_skills tier
-		// (skills = static skills.Set + the skill_defs/skill_def_active
-		// substrate only), so only two skill indexes are needed.
+		// dynamic_agents / skill_def_active / mcp_server_def_active tables
+		// still carry PRIMARY KEY(name), so two tenants cannot share a name on
+		// a PRE-EXISTING SQLite DB — a fresh DB is required for full
+		// multi-tenant on SQLite. These indexes restore single-tenant upgrade
+		// functionality only; they do not retrofit the per-tenant isolation a
+		// fresh DB's composite PK provides. The skill + mcp planes have NO
+		// dynamic_* tier (skills = static skills.Set + the
+		// skill_defs/skill_def_active substrate; mcp = static cfg.MCPServers +
+		// the mcp_server_defs/mcp_server_def_active substrate), so each needs
+		// only two indexes.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_def_active_tenant_name    ON agent_def_active(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_dynamic_agents_tenant_name      ON dynamic_agents(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_agent_defs_tenant_name_version  ON agent_defs(tenant_id, name, version)`,
@@ -841,6 +843,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		// fails even single-tenant. No dynamic_skills table to cover.
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_def_active_tenant_name    ON skill_def_active(tenant_id, name)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_skill_defs_tenant_name_version  ON skill_defs(tenant_id, name, version)`,
+		// MCP plane (RFC N FIX 5-mcp) — same in-place-upgrade gap.
+		// MCPServerDefSetActive does ON CONFLICT(tenant_id, name) on
+		// mcp_server_def_active and MCPServerDefCreate's version-bump inserts
+		// against UNIQUE(tenant_id, name, version) on mcp_server_defs; on an
+		// upgraded DB neither composite index exists, so the FIRST
+		// promote/register fails even single-tenant. No dynamic_mcp table.
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_mcp_server_def_active_tenant_name   ON mcp_server_def_active(tenant_id, name)`,
+		`CREATE UNIQUE INDEX IF NOT EXISTS uniq_mcp_server_defs_tenant_name_version ON mcp_server_defs(tenant_id, name, version)`,
 	}
 	for _, q := range addIndexes {
 		// Note the asymmetry vs addColumns above: indexes use

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -316,17 +316,25 @@ func (s *Store) migrate(ctx context.Context) error {
 			retired                   INTEGER NOT NULL DEFAULT 0,
 			bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
 			content_sha256            TEXT,
-			UNIQUE(name, version)
+			tenant_id                 TEXT    NOT NULL DEFAULT '',
+			UNIQUE(tenant_id, name, version)
 		)`,
 		`CREATE INDEX IF NOT EXISTS mcp_server_defs_by_name   ON mcp_server_defs(name, version DESC)`,
 		`CREATE INDEX IF NOT EXISTS mcp_server_defs_by_parent ON mcp_server_defs(parent_def_id) WHERE parent_def_id IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS mcp_server_defs_by_run    ON mcp_server_defs(created_by_run_id) WHERE created_by_run_id IS NOT NULL`,
 		// mcp_server_defs_by_content_sha256 — see agent_defs_by_content_sha256 note above.
+		// RFC N: tenant-scoped active pointer, PRIMARY KEY(tenant_id, name)
+		// — two tenants own the same name independently. Fresh-DB-only PK
+		// shape; an upgraded v0.9.x DB keeps PK(name) (SQLite can't rewrite
+		// a PK in place) which is byte-equivalent for single-tenant. See the
+		// agent_def_active note earlier for the full upgrade caveat.
 		`CREATE TABLE IF NOT EXISTS mcp_server_def_active (
-			name                  TEXT    PRIMARY KEY,
+			name                  TEXT    NOT NULL,
 			def_id                TEXT    NOT NULL REFERENCES mcp_server_defs(def_id),
 			promoted_at           INTEGER NOT NULL,
-			promoted_by_agent_id  TEXT
+			promoted_by_agent_id  TEXT,
+			tenant_id             TEXT    NOT NULL DEFAULT '',
+			PRIMARY KEY(tenant_id, name)
 		)`,
 		// v1.x RFC E Scheduled Agent Runs substrate — mirror of
 		// agent_defs/skill_defs/mcp_server_defs with the same identity
@@ -710,6 +718,13 @@ func (s *Store) migrate(ctx context.Context) error {
 		// existing rows to the shared tenant.
 		`ALTER TABLE skill_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE skill_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		// RFC N — tenant-scope the MCP server definition plane (mirror of the
+		// agent + skill ALTERs above). Same SQLite upgrade caveat: the PK
+		// stays (name) on the upgraded mcp_server_def_active table;
+		// functionally identical for single-tenant (tenant_id=''). DEFAULT ''
+		// backfills existing rows to the shared tenant.
+		`ALTER TABLE mcp_server_defs ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE mcp_server_def_active ADD COLUMN tenant_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1858,9 +1873,9 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT def_id, name, version, parent_def_id, definition, description,
 		        created_at, created_by_agent_id, created_by_run_id,
-		        retired, bootstrapped_from_static, content_sha256
+		        retired, bootstrapped_from_static, content_sha256, tenant_id
 		 FROM mcp_server_defs
-		 ORDER BY name ASC, version ASC`,
+		 ORDER BY tenant_id ASC, name ASC, version ASC`,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read mcp_server_defs: %w", err)
@@ -1884,7 +1899,7 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 			&r.DefID, &r.Name, &r.Version, &parentDefID,
 			&definition, &description,
 			&createdNs, &createdBy, &createdRun,
-			&retiredInt, &bootstrap, &contentHash,
+			&retiredInt, &bootstrap, &contentHash, &r.TenantID,
 		); err != nil {
 			return nil, fmt.Errorf("scan mcp_server_def: %w", err)
 		}
@@ -1915,9 +1930,9 @@ func (s *Store) SnapshotReadMCPServerDefs(ctx context.Context) ([]store.MCPServe
 // SnapshotReadMCPServerDefActive — v0.9.x mirror.
 func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCPServerDefActiveEntry, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT name, def_id, promoted_at, promoted_by_agent_id
+		`SELECT name, def_id, promoted_at, promoted_by_agent_id, tenant_id
 		 FROM mcp_server_def_active
-		 ORDER BY name ASC`)
+		 ORDER BY tenant_id ASC, name ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot read mcp_server_def_active: %w", err)
 	}
@@ -1929,7 +1944,7 @@ func (s *Store) SnapshotReadMCPServerDefActive(ctx context.Context) ([]store.MCP
 			promotedNs int64
 			promoter   sql.NullString
 		)
-		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter); err != nil {
+		if err := rows.Scan(&e.Name, &e.DefID, &promotedNs, &promoter, &e.TenantID); err != nil {
 			return nil, fmt.Errorf("scan mcp_server_def_active: %w", err)
 		}
 		e.PromotedAt = time.Unix(0, promotedNs)
@@ -2351,13 +2366,13 @@ func (s *Store) SnapshotRestoreMCPServerDef(ctx context.Context, r store.MCPServ
 		`INSERT OR IGNORE INTO mcp_server_defs(
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		r.DefID, r.Name, r.Version, nilIfEmpty(r.ParentDefID),
 		string(r.Definition), nilIfEmpty(r.Description),
 		createdNs, nilIfEmpty(r.CreatedByAgentID), nilIfEmpty(r.CreatedByRunID),
 		boolToInt(r.Retired), boolToInt(r.BootstrappedFromStatic),
-		nilIfEmpty(r.ContentSHA256),
+		nilIfEmpty(r.ContentSHA256), r.TenantID,
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore mcp_server_def: %w", err)
@@ -2376,8 +2391,8 @@ func (s *Store) SnapshotRestoreMCPServerDefActive(ctx context.Context, e store.M
 		promotedNs = time.Now().UnixNano()
 	}
 	res, err := s.db.ExecContext(ctx,
-		`INSERT OR IGNORE INTO mcp_server_def_active(name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?)`,
-		e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
+		`INSERT OR IGNORE INTO mcp_server_def_active(tenant_id, name, def_id, promoted_at, promoted_by_agent_id) VALUES (?, ?, ?, ?, ?)`,
+		e.TenantID, e.Name, e.DefID, promotedNs, nilIfEmpty(e.PromotedByAgentID),
 	)
 	if err != nil {
 		return false, fmt.Errorf("snapshot restore mcp_server_def_active: %w", err)
@@ -4024,9 +4039,11 @@ func (s *Store) MCPServerDefCreate(ctx context.Context, row store.MCPServerDefRo
 		}
 	}
 
+	// RFC N: version allocation is scoped per (tenant, name) so two
+	// tenants' v1 don't collide on UNIQUE(tenant_id, name, version).
 	var maxVer sql.NullInt64
 	if err := conn.QueryRowContext(ctx,
-		`SELECT MAX(version) FROM mcp_server_defs WHERE name = ?`, row.Name,
+		`SELECT MAX(version) FROM mcp_server_defs WHERE tenant_id = ? AND name = ?`, row.TenantID, row.Name,
 	).Scan(&maxVer); err != nil {
 		return store.MCPServerDefRow{}, err
 	}
@@ -4040,14 +4057,14 @@ func (s *Store) MCPServerDefCreate(ctx context.Context, row store.MCPServerDefRo
 		`INSERT INTO mcp_server_defs (
 			def_id, name, version, parent_def_id, definition, description,
 			created_at, created_by_agent_id, created_by_run_id,
-			retired, bootstrapped_from_static, content_sha256
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			retired, bootstrapped_from_static, content_sha256, tenant_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		row.DefID, row.Name, row.Version, nilIfEmpty(row.ParentDefID),
 		string(row.Definition), nilIfEmpty(row.Description),
 		row.CreatedAt.UnixNano(),
 		nilIfEmpty(row.CreatedByAgentID), nilIfEmpty(row.CreatedByRunID),
 		boolToInt(row.Retired), boolToInt(row.BootstrappedFromStatic),
-		nilIfEmpty(row.ContentSHA256),
+		nilIfEmpty(row.ContentSHA256), row.TenantID,
 	); err != nil {
 		return store.MCPServerDefRow{}, err
 	}
@@ -4095,15 +4112,16 @@ func (s *Store) MCPServerDefListChildren(ctx context.Context, parentDefID string
 func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDefNameSummary, error) {
 	rows, err := s.db.QueryContext(ctx, `
 		SELECT
+			d.tenant_id,
 			d.name,
 			COUNT(*)                  AS version_count,
 			MAX(d.version)            AS latest_version,
 			MAX(d.created_at)         AS last_updated,
 			COALESCE(a.def_id, '')    AS active_def_id
 		FROM mcp_server_defs d
-		LEFT JOIN mcp_server_def_active a ON a.name = d.name
-		GROUP BY d.name, a.def_id
-		ORDER BY d.name`)
+		LEFT JOIN mcp_server_def_active a ON a.name = d.name AND a.tenant_id = d.tenant_id
+		GROUP BY d.tenant_id, d.name, a.def_id
+		ORDER BY d.tenant_id, d.name`)
 	if err != nil {
 		return nil, err
 	}
@@ -4113,7 +4131,7 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	for rows.Next() {
 		var ns store.MCPServerDefNameSummary
 		var updatedAt int64
-		if err := rows.Scan(&ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
+		if err := rows.Scan(&ns.TenantID, &ns.Name, &ns.VersionCount, &ns.LatestVersion, &updatedAt, &ns.ActiveDefID); err != nil {
 			return nil, err
 		}
 		ns.LastUpdated = time.Unix(0, updatedAt)
@@ -4122,9 +4140,15 @@ func (s *Store) MCPServerDefListNames(ctx context.Context) ([]store.MCPServerDef
 	return out, rows.Err()
 }
 
-func (s *Store) MCPServerDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error {
-	var rowName string
-	err := s.db.QueryRowContext(ctx, `SELECT name FROM mcp_server_defs WHERE def_id = ?`, defID).Scan(&rowName)
+// MCPServerDefSetActive UPSERTs the active pointer for (tenantID, name).
+// RFC N: validates the def belongs to BOTH the named server AND the
+// supplied tenant — a def can only be promoted within its own tenant.
+func (s *Store) MCPServerDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error {
+	var (
+		rowName   string
+		rowTenant string
+	)
+	err := s.db.QueryRowContext(ctx, `SELECT name, tenant_id FROM mcp_server_defs WHERE def_id = ?`, defID).Scan(&rowName, &rowTenant)
 	if err == sql.ErrNoRows {
 		return &store.ErrNotFound{Kind: "mcp_server_def", ID: defID}
 	}
@@ -4134,21 +4158,27 @@ func (s *Store) MCPServerDefSetActive(ctx context.Context, name, defID, promoted
 	if rowName != name {
 		return fmt.Errorf("mcp_server_def_active: def_id %q has name %q, refusing to promote under name %q", defID, rowName, name)
 	}
+	if rowTenant != tenantID {
+		return fmt.Errorf("mcp_server_def_active: def_id %q belongs to tenant %q, refusing to promote under tenant %q", defID, rowTenant, tenantID)
+	}
 	_, err = s.db.ExecContext(ctx, `
-		INSERT INTO mcp_server_def_active (name, def_id, promoted_at, promoted_by_agent_id)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT(name) DO UPDATE SET
+		INSERT INTO mcp_server_def_active (tenant_id, name, def_id, promoted_at, promoted_by_agent_id)
+		VALUES (?, ?, ?, ?, ?)
+		ON CONFLICT(tenant_id, name) DO UPDATE SET
 		    def_id               = excluded.def_id,
 		    promoted_at          = excluded.promoted_at,
 		    promoted_by_agent_id = excluded.promoted_by_agent_id`,
-		name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
+		tenantID, name, defID, time.Now().UnixNano(), nilIfEmpty(promotedByAgentID),
 	)
 	return err
 }
 
-func (s *Store) MCPServerDefGetActive(ctx context.Context, name string) (store.MCPServerDefRow, error) {
+// MCPServerDefGetActive returns the active row for (tenantID, name).
+// *ErrNotFound when no pointer exists. RFC N: tenantID "" = the shared/
+// operator/legacy tenant.
+func (s *Store) MCPServerDefGetActive(ctx context.Context, tenantID, name string) (store.MCPServerDefRow, error) {
 	var defID string
-	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM mcp_server_def_active WHERE name = ?`, name).Scan(&defID)
+	err := s.db.QueryRowContext(ctx, `SELECT def_id FROM mcp_server_def_active WHERE tenant_id = ? AND name = ?`, tenantID, name).Scan(&defID)
 	if err == sql.ErrNoRows {
 		return store.MCPServerDefRow{}, &store.ErrNotFound{Kind: "mcp_server_def_active", ID: name}
 	}
@@ -4188,7 +4218,8 @@ const mcpServerDefSelect = `SELECT
 	COALESCE(created_by_run_id, ''),
 	retired,
 	bootstrapped_from_static,
-	COALESCE(content_sha256, '')
+	COALESCE(content_sha256, ''),
+	tenant_id
 FROM mcp_server_defs`
 
 func (s *Store) scanMCPServerDef(row *sql.Row) (store.MCPServerDefRow, error) {
@@ -4208,6 +4239,7 @@ func (s *Store) scanMCPServerDef(row *sql.Row) (store.MCPServerDefRow, error) {
 		&out.CreatedByAgentID, &out.CreatedByRunID,
 		&retired, &bootstrap,
 		&out.ContentSHA256,
+		&out.TenantID,
 	)
 	if err != nil {
 		return store.MCPServerDefRow{}, err
@@ -4238,6 +4270,7 @@ func (s *Store) scanMCPServerDefRows(rows *sql.Rows) ([]store.MCPServerDefRow, e
 			&r.CreatedByAgentID, &r.CreatedByRunID,
 			&retired, &bootstrap,
 			&r.ContentSHA256,
+			&r.TenantID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -494,6 +494,120 @@ func TestMigrate_UpgradeFromLegacySkillDefPlaneTenantUpserts(t *testing.T) {
 	}
 }
 
+// TestMigrate_UpgradeFromLegacyMCPServerDefPlaneTenantUpserts — RFC N FIX
+// 5-mcp regression for the in-place SQLite upgrade bug. Setup: hand-create
+// the LEGACY (pre-RFC-N) mcp-server-def-plane schema — mcp_server_defs with
+// UNIQUE(name, version) and mcp_server_def_active with PRIMARY KEY(name),
+// neither carrying tenant_id. Then reopen via the store path (re-runs
+// migrate(), which ALTERs in tenant_id but CANNOT rewrite the PK/UNIQUE in
+// place) and assert MCPServerDefCreate + MCPServerDefSetActive SUCCEED.
+//
+// Pre-fix, this FAILS: the version-bump UNIQUE(tenant_id, name, version) and
+// MCPServerDefSetActive's ON CONFLICT(tenant_id, name) have no matching index
+// on the upgraded table, so SQLite refuses with "ON CONFLICT clause does not
+// match any PRIMARY KEY or UNIQUE constraint" on the FIRST register/promote
+// — broken even single-tenant. The fix adds idempotent CREATE UNIQUE INDEX
+// statements in addIndexes that supply the ON CONFLICT / UNIQUE target.
+func TestMigrate_UpgradeFromLegacyMCPServerDefPlaneTenantUpserts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy_mcpdef.db")
+
+	// 1. Stand up the legacy schema: open (builds the current schema), then
+	// drop + rebuild the two mcp tables in their pre-RFC-N shape (no
+	// tenant_id; old PK/UNIQUE). Mirrors how a pre-RFC-N deploy looks on disk.
+	{
+		s, err := Open(path)
+		if err != nil {
+			t.Fatalf("initial open: %v", err)
+		}
+		ctx := context.Background()
+		stmts := []string{
+			`DROP INDEX IF EXISTS uniq_mcp_server_def_active_tenant_name`,
+			`DROP INDEX IF EXISTS uniq_mcp_server_defs_tenant_name_version`,
+			`DROP TABLE mcp_server_def_active`,
+			`DROP TABLE mcp_server_defs`,
+			// Legacy mcp_server_defs: UNIQUE(name, version), no tenant_id.
+			`CREATE TABLE mcp_server_defs (
+				def_id                    TEXT    PRIMARY KEY,
+				name                      TEXT    NOT NULL,
+				version                   INTEGER NOT NULL,
+				parent_def_id             TEXT    REFERENCES mcp_server_defs(def_id),
+				definition                TEXT    NOT NULL,
+				description               TEXT,
+				created_at                INTEGER NOT NULL,
+				created_by_agent_id       TEXT,
+				created_by_run_id         TEXT,
+				retired                   INTEGER NOT NULL DEFAULT 0,
+				bootstrapped_from_static  INTEGER NOT NULL DEFAULT 0,
+				content_sha256            TEXT,
+				UNIQUE(name, version)
+			)`,
+			// Legacy mcp_server_def_active: PRIMARY KEY(name), no tenant_id.
+			`CREATE TABLE mcp_server_def_active (
+				name                  TEXT    PRIMARY KEY,
+				def_id                TEXT    NOT NULL REFERENCES mcp_server_defs(def_id),
+				promoted_at           INTEGER NOT NULL,
+				promoted_by_agent_id  TEXT
+			)`,
+		}
+		for _, q := range stmts {
+			if _, err := s.db.ExecContext(ctx, q); err != nil {
+				t.Fatalf("setup legacy schema: %q: %v", q, err)
+			}
+		}
+		if err := s.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 2. Reopen — migrate() ALTERs in tenant_id + creates the ON CONFLICT
+	// target indexes.
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("upgrade open: %v", err)
+	}
+	defer s.Close()
+	ctx := context.Background()
+
+	// 3. MCPServerDefCreate must succeed (exercises UNIQUE(tenant_id, name,
+	// version) via the version-bump path on a second create).
+	created, err := s.MCPServerDefCreate(ctx, store.MCPServerDefRow{
+		DefID:      "mdf_upgrade_v1",
+		Name:       "upgrade-mcp",
+		Definition: []byte(`{"transport":"http","url":"https://x.example/mcp"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("MCPServerDefCreate on upgraded DB failed (RFC N UNIQUE target missing?): %v", err)
+	}
+	if created.Version != 1 {
+		t.Errorf("first create version = %d, want 1", created.Version)
+	}
+	// Second create of the same name bumps the version — relies on the
+	// MAX(version) read + UNIQUE(tenant_id, name, version) insert.
+	created2, err := s.MCPServerDefCreate(ctx, store.MCPServerDefRow{
+		DefID:      "mdf_upgrade_v2",
+		Name:       "upgrade-mcp",
+		Definition: []byte(`{"transport":"http","url":"https://x.example/mcp2"}`),
+		TenantID:   "",
+	})
+	if err != nil {
+		t.Fatalf("second MCPServerDefCreate on upgraded DB failed: %v", err)
+	}
+	if created2.Version != 2 {
+		t.Errorf("second create version = %d, want 2", created2.Version)
+	}
+
+	// 4. MCPServerDefSetActive must succeed (exercises ON CONFLICT(tenant_id,
+	// name) on mcp_server_def_active).
+	if err := s.MCPServerDefSetActive(ctx, "", "upgrade-mcp", "mdf_upgrade_v1", "a_admin"); err != nil {
+		t.Fatalf("MCPServerDefSetActive on upgraded DB failed (ON CONFLICT target missing?): %v", err)
+	}
+	// A re-promote to a different def_id exercises the DO UPDATE branch.
+	if err := s.MCPServerDefSetActive(ctx, "", "upgrade-mcp", "mdf_upgrade_v2", "a_admin"); err != nil {
+		t.Fatalf("MCPServerDefSetActive re-promote on upgraded DB failed: %v", err)
+	}
+}
+
 func TestCloseIsIdempotent(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test.db")
 	s, err := Open(path)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1154,9 +1154,21 @@ type Store interface {
 	MCPServerDefGetByNameVersion(ctx context.Context, name string, version int) (MCPServerDefRow, error)
 	MCPServerDefListByName(ctx context.Context, name string) ([]MCPServerDefRow, error)
 	MCPServerDefListChildren(ctx context.Context, parentDefID string) ([]MCPServerDefRow, error)
+	// MCPServerDefListNames returns one summary per (tenant, name) pair,
+	// each carrying its TenantID. RFC N: the boot rehydrator + the
+	// advertising filter rely on the TenantID so each run only resolves
+	// its own + shared servers.
 	MCPServerDefListNames(ctx context.Context) ([]MCPServerDefNameSummary, error)
-	MCPServerDefSetActive(ctx context.Context, name, defID, promotedByAgentID string) error
-	MCPServerDefGetActive(ctx context.Context, name string) (MCPServerDefRow, error)
+	// MCPServerDefSetActive UPSERTs the mcp_server_def_active pointer for
+	// (tenantID, name). RFC N: the active pointer is per-tenant, and a
+	// def can only be promoted within its own tenant — implementations
+	// refuse if the def's tenant_id ≠ tenantID. tenantID "" = the
+	// shared/operator/legacy tenant.
+	MCPServerDefSetActive(ctx context.Context, tenantID, name, defID, promotedByAgentID string) error
+	// MCPServerDefGetActive returns the active row for (tenantID, name).
+	// Returns *ErrNotFound when no active pointer exists. RFC N: tenantID
+	// "" = the shared/operator/legacy tenant.
+	MCPServerDefGetActive(ctx context.Context, tenantID, name string) (MCPServerDefRow, error)
 	MCPServerDefSetRetired(ctx context.Context, defID string, retired bool) error
 
 	// BackfillMCPServerDefContentSHA256 — mirror of the AgentDef /
@@ -2014,6 +2026,14 @@ type MCPServerDefRow struct {
 	BootstrappedFromStatic bool            `json:"bootstrapped_from_static"`
 	// ContentSHA256 — see AgentDefRow.ContentSHA256.
 	ContentSHA256 string `json:"content_sha256,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. The UNIQUE constraint is (tenant_id, name,
+	// version), so two tenants own the same name+version independently.
+	// Deliberately NOT part of the content hash — tenant is operational
+	// identity, not content — so two tenants registering the same body
+	// get the same content_sha256. Set from the authoritative principal
+	// at the write site; never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // MCPServerDefNameSummary mirrors AgentDefNameSummary.
@@ -2023,6 +2043,11 @@ type MCPServerDefNameSummary struct {
 	ActiveDefID   string    `json:"active_def_id,omitempty"`
 	LatestVersion int       `json:"latest_version"`
 	LastUpdated   time.Time `json:"last_updated"`
+	// TenantID is the RFC N tenant axis the name belongs to. "" = the
+	// shared/operator/legacy tenant. The boot rehydrator + advertising
+	// filter key the per-name GetActive call on this so a run only ever
+	// sees its own + shared MCP servers.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // MCPServerDefActiveEntry mirrors AgentDefActiveEntry / SkillDefActiveEntry.
@@ -2031,6 +2056,9 @@ type MCPServerDefActiveEntry struct {
 	DefID             string    `json:"def_id"`
 	PromotedAt        time.Time `json:"promoted_at"`
 	PromotedByAgentID string    `json:"promoted_by_agent_id,omitempty"`
+	// TenantID is the RFC N tenant-isolation axis (part of the
+	// mcp_server_def_active PK). "" = the shared/operator/legacy tenant.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // ScheduleDefRow mirrors AgentDefRow / SkillDefRow / MCPServerDefRow

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -191,6 +191,9 @@ func Run(t *testing.T, factory Factory) {
 		{"MCPServerDefVersionMonotonic", testMCPServerDefVersionMonotonic},
 		{"MCPServerDefActivePointerIdempotent", testMCPServerDefActivePointerIdempotent},
 		{"MCPServerDefRetireReversible", testMCPServerDefRetireReversible},
+		// RFC N — MCP server definition plane tenant isolation. Fails on the
+		// pre-migration single-`name`-PK schema (clobber); passes after.
+		{"MCPServerDefTenantIsolation", testMCPServerDefTenantIsolation},
 		{"MCPServerDefContentSHA256RoundTrip", testMCPServerDefContentSHA256RoundTrip},
 		{"BackfillMCPServerDefContentSHA256", testBackfillMCPServerDefContentSHA256},
 		// v1.x RFC E ScheduleDef substrate — same shape minus content_sha256.
@@ -4223,19 +4226,81 @@ func testMCPServerDefActivePointerIdempotent(t *testing.T, s store.Store) {
 	r1, _ := s.MCPServerDefCreate(ctx, mkMCPServerDef("md-active-1", "mcp-active", ""))
 	r2, _ := s.MCPServerDefCreate(ctx, mkMCPServerDef("md-active-2", "mcp-active", ""))
 
-	if err := s.MCPServerDefSetActive(ctx, "mcp-active", r1.DefID, "test"); err != nil {
+	if err := s.MCPServerDefSetActive(ctx, "", "mcp-active", r1.DefID, "test"); err != nil {
 		t.Fatal(err)
 	}
-	got, _ := s.MCPServerDefGetActive(ctx, "mcp-active")
+	got, _ := s.MCPServerDefGetActive(ctx, "", "mcp-active")
 	if got.DefID != r1.DefID {
 		t.Errorf("active = %s, want %s", got.DefID, r1.DefID)
 	}
-	if err := s.MCPServerDefSetActive(ctx, "mcp-active", r2.DefID, "test"); err != nil {
+	if err := s.MCPServerDefSetActive(ctx, "", "mcp-active", r2.DefID, "test"); err != nil {
 		t.Fatal(err)
 	}
-	got, _ = s.MCPServerDefGetActive(ctx, "mcp-active")
+	got, _ = s.MCPServerDefGetActive(ctx, "", "mcp-active")
 	if got.DefID != r2.DefID {
 		t.Errorf("after re-promote: active = %s, want %s", got.DefID, r2.DefID)
+	}
+}
+
+// testMCPServerDefTenantIsolation pins the RFC N boundary: the SAME MCP
+// server name registered under two tenants must resolve to each tenant's
+// OWN definition + active pointer — no cross-tenant clobber, no
+// cross-tenant read, no cross-tenant promote.
+//
+// FAIL-BEFORE: on the pre-migration schema (mcp_server_def_active PK =
+// (name), mcp_server_defs UNIQUE = (name, version)), tenant B's promote
+// overwrites tenant A's single global pointer (last-writer-wins), so the
+// GetActive(A) assertion reads back B's def_id and the test fails. The
+// composite (tenant_id, name) PK is what makes the two rows coexist.
+func testMCPServerDefTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	const name = "n8n"
+
+	aDef := mkMCPServerDef("mti-a", name, "")
+	aDef.TenantID = "tenant-a"
+	aDef.Definition = json.RawMessage(`{"transport":"http","url":"https://a.example.com/mcp"}`)
+	aRow, err := s.MCPServerDefCreate(ctx, aDef)
+	if err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+
+	bDef := mkMCPServerDef("mti-b", name, "")
+	bDef.TenantID = "tenant-b"
+	bDef.Definition = json.RawMessage(`{"transport":"http","url":"https://b.example.com/mcp"}`)
+	bRow, err := s.MCPServerDefCreate(ctx, bDef)
+	if err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+
+	if err := s.MCPServerDefSetActive(ctx, "tenant-a", name, aRow.DefID, ""); err != nil {
+		t.Fatalf("promote A: %v", err)
+	}
+	if err := s.MCPServerDefSetActive(ctx, "tenant-b", name, bRow.DefID, ""); err != nil {
+		t.Fatalf("promote B: %v", err)
+	}
+
+	gotA, err := s.MCPServerDefGetActive(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("get active A: %v", err)
+	}
+	if gotA.DefID != aRow.DefID || gotA.TenantID != "tenant-a" || string(gotA.Definition) != `{"transport":"http","url":"https://a.example.com/mcp"}` {
+		t.Errorf("tenant-a clobbered: got def_id=%q tenant=%q def=%s, want A's own def",
+			gotA.DefID, gotA.TenantID, gotA.Definition)
+	}
+
+	gotB, err := s.MCPServerDefGetActive(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("get active B: %v", err)
+	}
+	if gotB.DefID != bRow.DefID || gotB.TenantID != "tenant-b" || string(gotB.Definition) != `{"transport":"http","url":"https://b.example.com/mcp"}` {
+		t.Errorf("tenant-b clobbered: got def_id=%q tenant=%q def=%s, want B's own def",
+			gotB.DefID, gotB.TenantID, gotB.Definition)
+	}
+
+	// A def can only be promoted within its own tenant — promoting A's
+	// def under tenant-b must be refused.
+	if err := s.MCPServerDefSetActive(ctx, "tenant-b", name, aRow.DefID, ""); err == nil {
+		t.Error("cross-tenant promote (A's def under tenant-b) unexpectedly succeeded")
 	}
 }
 

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -412,10 +412,22 @@ func (m *MCPServerDef) execGet(ctx context.Context, in mcpServerDefInput) (tools
 		}
 		return errResult(fmt.Sprintf("get: %s", err)), nil
 	}
+	// RFC N: def_id is a global handle but a def is owned by exactly one
+	// tenant. MCPServerDefGet is by-def_id and tenant-blind, so guard here:
+	// a caller in tenant T cannot read another tenant's def. Return the SAME
+	// opaque not-found a missing def returns — never leak existence/body of a
+	// cross-tenant row.
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
+	}
 	return okJSON(mcpServerDefRowResponseMap(row))
 }
 
 func (m *MCPServerDef) execList(ctx context.Context, in mcpServerDefInput) (tools.Result, error) {
+	// RFC N: both list shapes return rows across ALL tenants (names are
+	// per-tenant now). Filter to the caller's own tenant so a tenant lists
+	// only its own servers — never enumerates another tenant's.
+	tenantID := tools.RunIdentity(ctx).TenantID
 	if in.Name != "" {
 		rows, err := m.Store.MCPServerDefListByName(ctx, in.Name)
 		if err != nil {
@@ -423,15 +435,28 @@ func (m *MCPServerDef) execList(ctx context.Context, in mcpServerDefInput) (tool
 		}
 		out := make([]map[string]any, 0, len(rows))
 		for _, r := range rows {
+			if r.TenantID != tenantID {
+				continue
+			}
 			out = append(out, mcpServerDefRowResponseMap(r))
 		}
 		return okJSON(map[string]any{"name": in.Name, "versions": out})
 	}
+	// MCPServerDefListNames returns a TenantID per summary (it's the
+	// boot/advertising key, NOT a tenant-scoped query) — filter the
+	// summaries to the caller's tenant here, the consumer-side guard.
 	summaries, err := m.Store.MCPServerDefListNames(ctx)
 	if err != nil {
 		return errResult(fmt.Sprintf("list: %s", err)), nil
 	}
-	return okJSON(map[string]any{"names": summaries})
+	out := make([]store.MCPServerDefNameSummary, 0, len(summaries))
+	for _, s := range summaries {
+		if s.TenantID != tenantID {
+			continue
+		}
+		out = append(out, s)
+	}
+	return okJSON(map[string]any{"names": out})
 }
 
 // ---- retire / promote ----
@@ -450,6 +475,15 @@ func (m *MCPServerDef) execRetire(ctx context.Context, in mcpServerDefInput) (to
 			return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 		}
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
+	}
+	// RFC N: refuse cross-tenant retire. MCPServerDefSetRetired is a global
+	// by-def_id mutation; without this guard a caller in tenant T could
+	// retire another tenant's def (and below, evict another tenant's pooled
+	// client). Opaque not-found — don't leak existence. After this guard
+	// row.TenantID == the caller's tenant, so the Registry.Remove /
+	// Pool.Evict below stay keyed to the caller's own (tenant, name).
+	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := m.Store.MCPServerDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
@@ -484,6 +518,15 @@ func (m *MCPServerDef) execPromote(ctx context.Context, in mcpServerDefInput) (t
 		return errResult(fmt.Sprintf("promote: %s", err)), nil
 	}
 	ident := tools.RunIdentity(ctx)
+	// RFC N: promote within the caller's OWN tenant. def_id is a global
+	// handle, and promoteAndWireRegistry keys SetActive/Registry/Pool on the
+	// def's own tenant — so without this guard a caller in tenant T could
+	// promote (and evict the pooled client of) another tenant's def. Opaque
+	// not-found — don't leak existence. Mirrors agentdef execPromote, which
+	// gets the same protection by passing ident.TenantID to AgentDefSetActive.
+	if row.TenantID != ident.TenantID {
+		return errResult(fmt.Sprintf("promote: def_id %q not found", in.DefID)), nil
+	}
 	if err := m.promoteAndWireRegistry(ctx, row, ident.AgentID); err != nil {
 		return errResult(fmt.Sprintf("promote: %s", err)), nil
 	}

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -214,9 +214,17 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 	if in.Name == "" {
 		return errResult("create: missing required field: name"), nil
 	}
-	// Refuse if the yaml block already covers this name. Mirror of
-	// AgentDef.create refusal over static cfg.Agents.
-	if _, ok := m.Cfg.MCPServers[in.Name]; ok {
+	// RFC N: the tenant is authoritative from the run ctx — never from the
+	// wire/tool input. It scopes the version lock, the active pointer, the
+	// dedup read, and the registry entry. "" = shared/operator/legacy.
+	tenantID := tools.RunIdentity(ctx).TenantID
+	// Refuse if the yaml block already covers this name FOR THE SHARED
+	// TENANT. Mirror of AgentDef.create refusal over static cfg.Agents.
+	// A tenant principal (tenantID != "") MAY register a name that collides
+	// with a shared yaml server — that is the RFC N per-tenant override
+	// (the tenant-dynamic pass shadows the static base); yaml stays ground
+	// truth only for the "" tenant.
+	if _, ok := m.Cfg.MCPServers[in.Name]; ok && tenantID == "" {
 		return errResult(fmt.Sprintf("create: name %q matches a static cfg.MCPServers entry — yaml is ground truth; use a different name", in.Name)), nil
 	}
 
@@ -249,7 +257,7 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 	// path dedups separately. Re-creating content that matches a NON-active
 	// version still mints + promotes (re-activation is a real state change),
 	// so we compare only against the active row.
-	if active, gerr := m.Store.MCPServerDefGetActive(ctx, in.Name); gerr == nil && active.ContentSHA256 == contentSHA {
+	if active, gerr := m.Store.MCPServerDefGetActive(ctx, tenantID, in.Name); gerr == nil && active.ContentSHA256 == contentSHA {
 		resp := mcpServerDefRowResponse(active, true)
 		resp["deduplicated"] = true
 		return okJSON(resp)
@@ -264,7 +272,7 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 	// rediscover). Best-effort + only when this version becomes active; an
 	// unreachable peer leaves the def metadata-only and self-heals lazily.
 	var discovered int
-	defJSON, discovered = m.discoverOnIngestion(ctx, in.Name, in, promote, &def, defJSON)
+	defJSON, discovered = m.discoverOnIngestion(ctx, tenantID, in.Name, in, promote, &def, defJSON)
 
 	ident := tools.RunIdentity(ctx)
 	row := store.MCPServerDefRow{
@@ -274,6 +282,7 @@ func (m *MCPServerDef) execCreate(ctx context.Context, in mcpServerDefInput) (to
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    contentSHA,
+		TenantID:         tenantID,
 	}
 	created, err := m.Store.MCPServerDefCreate(ctx, row)
 	if err != nil {
@@ -296,6 +305,9 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 	if in.Name == "" {
 		return errResult("fork: missing required field: name"), nil
 	}
+	// RFC N: tenant from ctx (never the wire). Scopes the parent lookup,
+	// the active pointer, and the row's tenant stamp.
+	tenantID := tools.RunIdentity(ctx).TenantID
 
 	var parentJSON string
 	parentDefID := in.ParentDefID
@@ -311,10 +323,15 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		if parent.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, parent.Name, in.Name)), nil
 		}
+		// RFC N: a fork stays within its own tenant — refuse a parent that
+		// belongs to a different tenant (no cross-tenant lineage / leak).
+		if parent.TenantID != tenantID {
+			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to tenant %q, refusing to fork under tenant %q", parentDefID, parent.TenantID, tenantID)), nil
+		}
 		parentJSON = string(parent.Definition)
 	} else {
 		// No explicit parent → fork from the active row.
-		active, err := m.Store.MCPServerDefGetActive(ctx, in.Name)
+		active, err := m.Store.MCPServerDefGetActive(ctx, tenantID, in.Name)
 		if err != nil {
 			var nf *store.ErrNotFound
 			if errors.As(err, &nf) {
@@ -354,7 +371,7 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 	// pool resolves to the about-to-be-active version's connection params, so
 	// a non-promoted fork (not yet active) can't be dialed meaningfully here.
 	var discovered int
-	defJSON, discovered = m.discoverOnIngestion(ctx, in.Name, in, promote, &def, defJSON)
+	defJSON, discovered = m.discoverOnIngestion(ctx, tenantID, in.Name, in, promote, &def, defJSON)
 
 	ident := tools.RunIdentity(ctx)
 	row := store.MCPServerDefRow{
@@ -365,6 +382,7 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		Description:      in.Description,
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    contentSHA,
+		TenantID:         tenantID,
 	}
 	created, err := m.Store.MCPServerDefCreate(ctx, row)
 	if err != nil {
@@ -437,13 +455,16 @@ func (m *MCPServerDef) execRetire(ctx context.Context, in mcpServerDefInput) (to
 		return errResult(fmt.Sprintf("retire: %s", err)), nil
 	}
 	// Side-effect on the registry + pool ONLY if retiring the currently-
-	// active version. Otherwise the active row stays callable.
+	// active version. Otherwise the active row stays callable. RFC N: the
+	// active pointer + registry + pool entries are keyed by the def's OWN
+	// tenant, so eviction stays tenant-correct (retiring tenant A's server
+	// leaves tenant B's same-name server untouched).
 	if *in.Retired {
-		active, err := m.Store.MCPServerDefGetActive(ctx, row.Name)
+		active, err := m.Store.MCPServerDefGetActive(ctx, row.TenantID, row.Name)
 		if err == nil && active.DefID == in.DefID {
-			m.Registry.Remove(row.Name)
+			m.Registry.Remove(row.TenantID, row.Name)
 			if m.Pool != nil {
-				m.Pool.Evict(row.Name)
+				m.Pool.Evict(row.TenantID, row.Name)
 			}
 		}
 	}
@@ -474,7 +495,10 @@ func (m *MCPServerDef) execPromote(ctx context.Context, in mcpServerDefInput) (t
 // name (which may be using the previous active row's URL / headers)
 // MUST be evicted so the next agent call gets a fresh client.
 func (m *MCPServerDef) promoteAndWireRegistry(ctx context.Context, row store.MCPServerDefRow, promotedByAgentID string) error {
-	if err := m.Store.MCPServerDefSetActive(ctx, row.Name, row.DefID, promotedByAgentID); err != nil {
+	// RFC N: promote within the def's OWN tenant. The store refuses a
+	// def whose tenant_id ≠ the passed tenant, so a caller can't point
+	// another tenant's active pointer at a def it owns.
+	if err := m.Store.MCPServerDefSetActive(ctx, row.TenantID, row.Name, row.DefID, promotedByAgentID); err != nil {
 		return err
 	}
 	// Parse the definition back into the in-memory spec for the registry.
@@ -482,17 +506,20 @@ func (m *MCPServerDef) promoteAndWireRegistry(ctx context.Context, row store.MCP
 	if err := json.Unmarshal(row.Definition, &ov); err != nil {
 		return fmt.Errorf("definition unmarshal: %w", err)
 	}
-	m.Registry.Set(specFromOverlay(row.Name, ov))
+	m.Registry.Set(specFromOverlay(row.TenantID, row.Name, ov))
 	if m.Pool != nil {
-		m.Pool.Evict(row.Name) // existing cached client uses stale metadata; rebuild on next agent call
+		m.Pool.Evict(row.TenantID, row.Name) // existing cached client uses stale metadata; rebuild on next agent call
 	}
 	return nil
 }
 
 // specFromOverlay projects an overlay's connection fields onto the in-memory
 // DynamicMCPServerSpec the pool's caller factory resolves names through.
-func specFromOverlay(name string, ov mcpServerOverlay) loommcp.DynamicMCPServerSpec {
+// RFC N: the spec carries its tenant so the registry keys it by
+// (tenant, name).
+func specFromOverlay(tenantID, name string, ov mcpServerOverlay) loommcp.DynamicMCPServerSpec {
 	return loommcp.DynamicMCPServerSpec{
+		TenantID:  tenantID,
 		Name:      name,
 		Transport: ov.Transport,
 		URL:       ov.URL,
@@ -507,11 +534,14 @@ func specFromOverlay(name string, ov mcpServerOverlay) loommcp.DynamicMCPServerS
 // budget so a non-responding peer can't park the goroutine — matches the
 // boot-time MCP-init budget shape. Shared by create/fork (best-effort) and
 // rediscover (fatal on error).
-func (m *MCPServerDef) discoverTools(ctx context.Context, name string) ([]toolDescriptor, error) {
+func (m *MCPServerDef) discoverTools(ctx context.Context, tenantID, name string) ([]toolDescriptor, error) {
 	if m.Pool == nil {
 		return nil, fmt.Errorf("pool not configured")
 	}
-	m.Pool.Evict(name)
+	// RFC N: evict + dial the (tenant, name) entry. Pool.Get derives the
+	// tenant from ctx (RunIdentity), which is this run's tenant == tenantID,
+	// so the handshake dials this tenant's spec.
+	m.Pool.Evict(tenantID, name)
 	hsCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	_, descs, err := m.Pool.Get(hsCtx, name)
@@ -538,7 +568,7 @@ func (m *MCPServerDef) discoverTools(ctx context.Context, name string) ([]toolDe
 // valid. Returns the (possibly updated) defJSON + the discovered count.
 // Never errors: an unreachable peer leaves def untouched (empty tools) and
 // self-heals via lazy registration on first call.
-func (m *MCPServerDef) discoverOnIngestion(ctx context.Context, name string, in mcpServerDefInput, promote bool, def *mcpServerOverlay, defJSON []byte) ([]byte, int) {
+func (m *MCPServerDef) discoverOnIngestion(ctx context.Context, tenantID, name string, in mcpServerDefInput, promote bool, def *mcpServerOverlay, defJSON []byte) ([]byte, int) {
 	discover := promote && m.Pool != nil
 	if in.Discover != nil {
 		discover = discover && *in.Discover
@@ -546,9 +576,10 @@ func (m *MCPServerDef) discoverOnIngestion(ctx context.Context, name string, in 
 	if !discover {
 		return defJSON, 0
 	}
-	// Register so pool.Get(name) resolves to this server's connection params.
-	m.Registry.Set(specFromOverlay(name, *def))
-	tools, err := m.discoverTools(ctx, name)
+	// Register under (tenant, name) so pool.Get resolves to THIS tenant's
+	// connection params during the discovery handshake.
+	m.Registry.Set(specFromOverlay(tenantID, name, *def))
+	tools, err := m.discoverTools(ctx, tenantID, name)
 	if err != nil {
 		return defJSON, 0 // best-effort — keep metadata-only def; lazy/rediscover later.
 	}
@@ -570,7 +601,10 @@ func (m *MCPServerDef) execRediscover(ctx context.Context, in mcpServerDefInput)
 	if in.Name == "" {
 		return errResult("rediscover: missing required field: name"), nil
 	}
-	active, err := m.Store.MCPServerDefGetActive(ctx, in.Name)
+	// RFC N: tenant from ctx scopes the active lookup, the discovery
+	// handshake, and the new row's stamp.
+	tenantID := tools.RunIdentity(ctx).TenantID
+	active, err := m.Store.MCPServerDefGetActive(ctx, tenantID, in.Name)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -581,7 +615,7 @@ func (m *MCPServerDef) execRediscover(ctx context.Context, in mcpServerDefInput)
 	if m.Pool == nil {
 		return errResult("rediscover: pool not configured"), nil
 	}
-	newTools, err := m.discoverTools(ctx, in.Name)
+	newTools, err := m.discoverTools(ctx, tenantID, in.Name)
 	if err != nil {
 		return errResult(fmt.Sprintf("rediscover: pool.Get: %s", err)), nil
 	}
@@ -612,12 +646,13 @@ func (m *MCPServerDef) execRediscover(ctx context.Context, in mcpServerDefInput)
 		Description:      "rediscovered tools/list",
 		CreatedByAgentID: ident.AgentID,
 		ContentSHA256:    signFromMCPServerOverlay(in.Name, ov),
+		TenantID:         tenantID,
 	}
 	created, err := m.Store.MCPServerDefCreate(ctx, row)
 	if err != nil {
 		return errResult(fmt.Sprintf("rediscover: persist: %s", err)), nil
 	}
-	if err := m.Store.MCPServerDefSetActive(ctx, in.Name, created.DefID, ident.AgentID); err != nil {
+	if err := m.Store.MCPServerDefSetActive(ctx, tenantID, in.Name, created.DefID, ident.AgentID); err != nil {
 		return errResult(fmt.Sprintf("rediscover: promote: %s", err)), nil
 	}
 	return okJSON(map[string]any{
@@ -635,7 +670,8 @@ func (m *MCPServerDef) execVerify(ctx context.Context, in mcpServerDefInput) (to
 	if in.Name == "" {
 		return errResult("verify: missing required field: name"), nil
 	}
-	row, err := m.Store.MCPServerDefGetActive(ctx, in.Name)
+	tenantID := tools.RunIdentity(ctx).TenantID
+	row, err := m.Store.MCPServerDefGetActive(ctx, tenantID, in.Name)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -179,7 +179,7 @@ func TestMCPServerDefTool_CreateHappyPath(t *testing.T) {
 		t.Error("create should default to promoted=true")
 	}
 	// Registry should now hold the entry.
-	spec, ok := tool.Registry.Get("n8n-mailgun")
+	spec, ok := tool.Registry.Get("", "n8n-mailgun")
 	if !ok {
 		t.Fatal("registry doesn't have the new entry")
 	}
@@ -231,7 +231,7 @@ func TestMCPServerDefTool_RetireRemovesFromRegistry(t *testing.T) {
 
 	createRes, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"n8n-retire","overlay":{"transport":"http","url":"https://n8n.example.com/mcp"}}`))
 	defID := decodeResult(t, createRes.Text)["def_id"].(string)
-	if _, ok := tool.Registry.Get("n8n-retire"); !ok {
+	if _, ok := tool.Registry.Get("", "n8n-retire"); !ok {
 		t.Fatal("registry should have the entry after create")
 	}
 
@@ -239,7 +239,7 @@ func TestMCPServerDefTool_RetireRemovesFromRegistry(t *testing.T) {
 	if res.IsError {
 		t.Fatalf("retire: %s", res.Text)
 	}
-	if _, ok := tool.Registry.Get("n8n-retire"); ok {
+	if _, ok := tool.Registry.Get("", "n8n-retire"); ok {
 		t.Error("registry should NOT have the entry after retiring the active version")
 	}
 }
@@ -296,8 +296,9 @@ func TestMCPServerDefTool_RediscoverNoopOnUnchangedTools(t *testing.T) {
 	srv := mcptest.NewServer(t, mcptest.WithToolName("check_user"))
 	tool.Cfg.Env.HTTPHostAllowlist = append(tool.Cfg.Env.HTTPHostAllowlist, "127.0.0.1")
 	tool.Pool = loommcp.NewPool(
-		func(name string) (loommcp.Caller, error) { return mcphttp.New(mcphttp.Config{URL: srv.URL}) },
+		func(_, name string) (loommcp.Caller, error) { return mcphttp.New(mcphttp.Config{URL: srv.URL}) },
 		func(c loommcp.Caller) {},
+		nil,
 	)
 	t.Cleanup(tool.Pool.Close)
 
@@ -328,8 +329,9 @@ func mcpToolPoolFixture(t *testing.T, tool *MCPServerDef, toolName string) strin
 	srv := mcptest.NewServer(t, mcptest.WithToolName(toolName))
 	tool.Cfg.Env.HTTPHostAllowlist = append(tool.Cfg.Env.HTTPHostAllowlist, "127.0.0.1")
 	tool.Pool = loommcp.NewPool(
-		func(name string) (loommcp.Caller, error) { return mcphttp.New(mcphttp.Config{URL: srv.URL}) },
+		func(_, name string) (loommcp.Caller, error) { return mcphttp.New(mcphttp.Config{URL: srv.URL}) },
 		func(c loommcp.Caller) {},
+		nil,
 	)
 	t.Cleanup(tool.Pool.Close)
 	return srv.URL
@@ -394,8 +396,9 @@ func TestMCPServerDefTool_CreateDiscoveryBestEffortOnUnreachable(t *testing.T) {
 	defer cleanup()
 	tool.Cfg.Env.HTTPHostAllowlist = append(tool.Cfg.Env.HTTPHostAllowlist, "127.0.0.1")
 	tool.Pool = loommcp.NewPool(
-		func(name string) (loommcp.Caller, error) { return nil, fmt.Errorf("connection refused") },
+		func(_, name string) (loommcp.Caller, error) { return nil, fmt.Errorf("connection refused") },
 		func(c loommcp.Caller) {},
+		nil,
 	)
 	t.Cleanup(tool.Pool.Close)
 
@@ -463,7 +466,7 @@ func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
 	// resolved while the outer ${run.credentials.*} token survived for
 	// request-time substitution — i.e. the stored header is now FLAT (no
 	// nested brace), which is exactly what substitute.go's lazy regex needs.
-	active, err := tool.Store.MCPServerDefGetActive(ctx, "jobs")
+	active, err := tool.Store.MCPServerDefGetActive(ctx, "", "jobs")
 	if err != nil {
 		t.Fatalf("GetActive: %v", err)
 	}

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -491,3 +491,89 @@ func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
 		t.Errorf("outer run-credentials token did not survive expansion: %q", gotHdr)
 	}
 }
+
+// TestMCPServerDefTool_TenantIsolationGetListRetirePromote — RFC N FIX
+// 3-mcp. The get / list / retire / promote ops were tenant-blind: get and
+// retire are by-def_id global mutations, list returns rows across ALL
+// tenants, and promote keyed SetActive/Registry/Pool on the def's OWN
+// tenant (so the store's "def belongs to passed tenant" check always
+// passed — it never compared the CALLER's tenant). A caller in tenant A
+// could read, enumerate, retire, and promote (and evict the pooled client
+// of) defs owned by tenant B.
+//
+// Two tenant contexts over the SAME tool/store. The only thing keeping
+// them apart is the row-TenantID guards added by FIX 3-mcp. Pre-fix: get
+// returns B's body, list returns B's versions/names, retire mutates B's
+// row, promote repoints B's active pointer + evicts B's pool entry — all
+// from a tenant-A caller.
+func TestMCPServerDefTool_TenantIsolationGetListRetirePromote(t *testing.T) {
+	tool, baseCtx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+
+	ctxA := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-a"})
+	ctxB := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-b"})
+
+	// Create a def under tenant B (a non-yaml name so the static-collision
+	// refusal doesn't fire).
+	res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"create","name":"b-only","overlay":{"transport":"http","url":"https://n8n.example.com/mcp"}}`))
+	if res.IsError {
+		t.Fatalf("create under B: %s", res.Text)
+	}
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// get from tenant A → opaque not-found (no cross-tenant leak).
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if !res.IsError {
+		t.Errorf("tenant A get of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	if !strings.Contains(res.Text, "not found") {
+		t.Errorf("cross-tenant get should return opaque not-found; got %s", res.Text)
+	}
+
+	// list-by-name from tenant A → must NOT include B's version.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("list-by-name under A: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 0 {
+		t.Errorf("tenant A list-by-name of B's name returned %d versions; want 0 (tenant filter)", n)
+	}
+
+	// list-names (no name) from tenant A → must NOT enumerate B's name.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"list"}`))
+	if res.IsError {
+		t.Fatalf("list-names under A: %s", res.Text)
+	}
+	if names, _ := decodeResult(t, res.Text)["names"].([]any); len(names) != 0 {
+		t.Errorf("tenant A list-names leaked %d entries owned by B; want 0", len(names))
+	}
+
+	// promote from tenant A → refused (don't repoint/evict B's server).
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"promote","def_id":"`+defID+`"}`))
+	if !res.IsError {
+		t.Errorf("tenant A promote of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+
+	// retire from tenant A → refused; B's row must stay un-retired.
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"retire","def_id":"`+defID+`","retired":true}`))
+	if !res.IsError {
+		t.Errorf("tenant A retire of tenant B's def succeeded; want refusal. body=%s", res.Text)
+	}
+	// Confirm B still sees its row un-retired (the retire didn't leak through).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Fatalf("tenant B get of its own def: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["retired"].(bool) {
+		t.Error("tenant A's cross-tenant retire mutated tenant B's row")
+	}
+
+	// Sanity: tenant B CAN get + list its own def (the guard isn't over-broad).
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("tenant B list of its own name: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
+		t.Errorf("tenant B list returned %d versions; want 1", n)
+	}
+}

--- a/internal/tools/mcp/dynamic.go
+++ b/internal/tools/mcp/dynamic.go
@@ -36,6 +36,12 @@ type DynamicMCPServerSpec struct {
 	Transport string // "http" | "streamable-http"
 	URL       string
 	Headers   map[string]string
+	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. Entries are keyed by (TenantID, Name) so
+	// two tenants register the same name with distinct URLs without
+	// colliding. Set from the authoritative principal at the write site;
+	// never from the wire.
+	TenantID string
 }
 
 // DynamicRegistry holds runtime-registered MCP server specs. One
@@ -45,71 +51,130 @@ type DynamicMCPServerSpec struct {
 // Empty registry behaves the same as no registry at all — the pool's
 // build callback falls back to the yaml-static map.
 type DynamicRegistry struct {
-	mu      sync.RWMutex
-	entries map[string]DynamicMCPServerSpec
+	mu sync.RWMutex
+	// RFC N: keyed by (tenant, name). Two tenants register the same name
+	// with distinct connection metadata without colliding. The shared/
+	// legacy tenant is the "" tenant key.
+	entries map[regKey]DynamicMCPServerSpec
+}
+
+// regKey is the composite (tenant, name) registry key. RFC N.
+type regKey struct {
+	tenant string
+	name   string
 }
 
 // NewDynamicRegistry returns an empty registry.
 func NewDynamicRegistry() *DynamicRegistry {
-	return &DynamicRegistry{entries: make(map[string]DynamicMCPServerSpec)}
+	return &DynamicRegistry{entries: make(map[regKey]DynamicMCPServerSpec)}
 }
 
-// Set installs (or replaces) the entry for spec.Name. The pool's
-// build callback consults the registry on every cache miss; existing
-// pool entries for the same name continue serving until they crash
-// or are explicitly evicted via PoolEvict (called by the tool's
-// retire / promote-replaces-version paths).
+// Set installs (or replaces) the entry for (spec.TenantID, spec.Name).
+// The pool's build callback consults the registry on every cache miss;
+// existing pool entries for the same (tenant, name) continue serving
+// until they crash or are explicitly evicted via Pool.Evict (called by
+// the tool's retire / promote-replaces-version paths).
 func (r *DynamicRegistry) Set(spec DynamicMCPServerSpec) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.entries[spec.Name] = spec
+	r.entries[regKey{spec.TenantID, spec.Name}] = spec
 }
 
-// Remove evicts the named entry. Returns true if it existed.
+// Remove evicts the (tenantID, name) entry. Returns true if it existed.
 //
 // Removing an entry does NOT close existing pool clients on its own —
-// the substrate-tool layer is responsible for invoking Pool.evict(name)
-// (or the equivalent) to tear down any in-flight client BEFORE
-// removing the registry entry. Otherwise an agent in-flight on the
-// MCP server's tool call continues using the cached pool entry until
-// the underlying transport crashes naturally.
-func (r *DynamicRegistry) Remove(name string) bool {
+// the substrate-tool layer is responsible for invoking Pool.Evict BEFORE
+// removing the registry entry. Otherwise an agent in-flight on the MCP
+// server's tool call continues using the cached pool entry until the
+// underlying transport crashes naturally.
+func (r *DynamicRegistry) Remove(tenantID, name string) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.entries[name]; !ok {
+	k := regKey{tenantID, name}
+	if _, ok := r.entries[k]; !ok {
 		return false
 	}
-	delete(r.entries, name)
+	delete(r.entries, k)
 	return true
 }
 
-// Get returns the spec for `name` and a presence boolean. Called by
-// the pool's build callback on every cache miss.
-func (r *DynamicRegistry) Get(name string) (DynamicMCPServerSpec, bool) {
+// Get returns the spec for (tenantID, name) and a presence boolean.
+// Called by the resolver on every lookup. RFC N: the caller is
+// responsible for the static→tenant→shared precedence (see
+// lookup.MCPServer); Get is an exact (tenant, name) read.
+func (r *DynamicRegistry) Get(tenantID, name string) (DynamicMCPServerSpec, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	spec, ok := r.entries[name]
+	spec, ok := r.entries[regKey{tenantID, name}]
 	return spec, ok
 }
 
-// Names returns every registered name, sorted. Used by diagnostic
-// surfaces (the LoomCycle MCP server's get_runtime_state, etc.).
+// Names returns every registered name across ALL tenants, sorted +
+// deduped. Diagnostic-only (the LoomCycle MCP server's
+// get_runtime_state) — it is NOT tenant-scoped and must never gate
+// advertising. Use NamesForTenant for the per-run candidate set.
 //
 // Safe to call concurrently with Set/Remove — returns a snapshot.
 func (r *DynamicRegistry) Names() []string {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	seen := make(map[string]struct{}, len(r.entries))
 	out := make([]string, 0, len(r.entries))
-	for name := range r.entries {
+	for k := range r.entries {
+		if _, dup := seen[k.name]; dup {
+			continue
+		}
+		seen[k.name] = struct{}{}
+		out = append(out, k.name)
+	}
+	sortStrings(out)
+	return out
+}
+
+// NamesForTenant returns the names visible to a run in tenantID: that
+// tenant's own names PLUS the shared ("" tenant) names, sorted +
+// deduped. A tenant-owned name shadows a shared one of the same name
+// (it appears once). RFC N §3: this is the per-run candidate set the
+// advertising filter enumerates so a run in tenant A never sees tenant
+// B's MCP servers.
+func (r *DynamicRegistry) NamesForTenant(tenantID string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	seen := make(map[string]struct{}, len(r.entries))
+	out := make([]string, 0, len(r.entries))
+	add := func(name string) {
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
 		out = append(out, name)
 	}
-	// Inline sort to avoid pulling in sort for one-call shape.
+	// Tenant-owned first so it claims the name; shared "" entries only
+	// fill names the tenant doesn't already own (tenant shadows shared).
+	for k := range r.entries {
+		if k.tenant == tenantID {
+			add(k.name)
+		}
+	}
+	if tenantID != "" {
+		for k := range r.entries {
+			if k.tenant == "" {
+				add(k.name)
+			}
+		}
+	}
+	sortStrings(out)
+	return out
+}
+
+// sortStrings is an inline insertion sort — avoids pulling in the sort
+// package for these small diagnostic / candidate-set lists.
+func sortStrings(out []string) {
 	for i := 1; i < len(out); i++ {
 		for j := i; j > 0 && out[j-1] > out[j]; j-- {
 			out[j-1], out[j] = out[j], out[j-1]
 		}
 	}
-	return out
 }
 
 // Size returns the current count. Diagnostic helper.

--- a/internal/tools/mcp/dynamic_test.go
+++ b/internal/tools/mcp/dynamic_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestDynamicRegistry_GetReturnsZeroValueForUnknown(t *testing.T) {
 	r := NewDynamicRegistry()
-	_, ok := r.Get("nope")
+	_, ok := r.Get("", "nope")
 	if ok {
 		t.Error("Get on unknown name returned ok=true")
 	}
@@ -22,7 +22,7 @@ func TestDynamicRegistry_SetGetRoundTrip(t *testing.T) {
 		Headers:   map[string]string{"Authorization": "Bearer ${LOOMCYCLE_N8N_TOKEN}"},
 	}
 	r.Set(spec)
-	got, ok := r.Get("n8n-mailgun")
+	got, ok := r.Get("", "n8n-mailgun")
 	if !ok {
 		t.Fatal("Get after Set returned ok=false")
 	}
@@ -38,7 +38,7 @@ func TestDynamicRegistry_SetReplacesExisting(t *testing.T) {
 	r := NewDynamicRegistry()
 	r.Set(DynamicMCPServerSpec{Name: "x", URL: "https://v1.example/mcp"})
 	r.Set(DynamicMCPServerSpec{Name: "x", URL: "https://v2.example/mcp"})
-	got, _ := r.Get("x")
+	got, _ := r.Get("", "x")
 	if got.URL != "https://v2.example/mcp" {
 		t.Errorf("second Set didn't replace: %s", got.URL)
 	}
@@ -47,17 +47,17 @@ func TestDynamicRegistry_SetReplacesExisting(t *testing.T) {
 func TestDynamicRegistry_RemoveExisting(t *testing.T) {
 	r := NewDynamicRegistry()
 	r.Set(DynamicMCPServerSpec{Name: "x"})
-	if !r.Remove("x") {
+	if !r.Remove("", "x") {
 		t.Error("Remove of existing entry returned false")
 	}
-	if _, ok := r.Get("x"); ok {
+	if _, ok := r.Get("", "x"); ok {
 		t.Error("entry still present after Remove")
 	}
 }
 
 func TestDynamicRegistry_RemoveNonexistent(t *testing.T) {
 	r := NewDynamicRegistry()
-	if r.Remove("nope") {
+	if r.Remove("", "nope") {
 		t.Error("Remove of nonexistent entry returned true")
 	}
 }
@@ -79,6 +79,77 @@ func TestDynamicRegistry_Names(t *testing.T) {
 	}
 }
 
+// TestDynamicRegistry_TenantKeying pins the RFC N boundary: two tenants
+// register the SAME name with DIFFERENT specs and each reads back its OWN
+// — no cross-tenant collision (the leak the pool-key change closes).
+func TestDynamicRegistry_TenantKeying(t *testing.T) {
+	r := NewDynamicRegistry()
+	r.Set(DynamicMCPServerSpec{TenantID: "a", Name: "n8n", URL: "https://a.example/mcp"})
+	r.Set(DynamicMCPServerSpec{TenantID: "b", Name: "n8n", URL: "https://b.example/mcp"})
+
+	gotA, ok := r.Get("a", "n8n")
+	if !ok || gotA.URL != "https://a.example/mcp" {
+		t.Errorf("tenant a: got %+v ok=%v, want a's URL", gotA, ok)
+	}
+	gotB, ok := r.Get("b", "n8n")
+	if !ok || gotB.URL != "https://b.example/mcp" {
+		t.Errorf("tenant b: got %+v ok=%v, want b's URL", gotB, ok)
+	}
+	if _, ok := r.Get("c", "n8n"); ok {
+		t.Error("tenant c unexpectedly resolved a's/b's n8n")
+	}
+	if !r.Remove("a", "n8n") {
+		t.Error("Remove(a, n8n) returned false")
+	}
+	if _, ok := r.Get("a", "n8n"); ok {
+		t.Error("a's entry still present after Remove")
+	}
+	if _, ok := r.Get("b", "n8n"); !ok {
+		t.Error("b's entry was clobbered by Remove(a, n8n)")
+	}
+}
+
+// TestDynamicRegistry_NamesForTenant pins the RFC N §3 candidate set: a
+// tenant sees its own names PLUS shared ("" tenant) names, a tenant name
+// shadows a shared one of the same name (appears once), and a different
+// tenant's names are never visible.
+func TestDynamicRegistry_NamesForTenant(t *testing.T) {
+	r := NewDynamicRegistry()
+	r.Set(DynamicMCPServerSpec{TenantID: "", Name: "shared-srv"})
+	r.Set(DynamicMCPServerSpec{TenantID: "", Name: "shadowed"})
+	r.Set(DynamicMCPServerSpec{TenantID: "a", Name: "a-only"})
+	r.Set(DynamicMCPServerSpec{TenantID: "a", Name: "shadowed"}) // shadows the shared one
+	r.Set(DynamicMCPServerSpec{TenantID: "b", Name: "b-only"})
+
+	gotA := r.NamesForTenant("a")
+	wantA := []string{"a-only", "shadowed", "shared-srv"}
+	if !equalStrs(gotA, wantA) {
+		t.Errorf("NamesForTenant(a) = %v, want %v (no b-only, shadowed dedup'd)", gotA, wantA)
+	}
+	gotShared := r.NamesForTenant("")
+	wantShared := []string{"shadowed", "shared-srv"}
+	if !equalStrs(gotShared, wantShared) {
+		t.Errorf("NamesForTenant(\"\") = %v, want %v", gotShared, wantShared)
+	}
+	for _, n := range r.NamesForTenant("b") {
+		if n == "a-only" {
+			t.Error("tenant b's candidate set leaked a-only")
+		}
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestDynamicRegistry_ConcurrentSetGetRemove(t *testing.T) {
 	r := NewDynamicRegistry()
 	var wg sync.WaitGroup
@@ -93,11 +164,11 @@ func TestDynamicRegistry_ConcurrentSetGetRemove(t *testing.T) {
 		}()
 		go func() {
 			defer wg.Done()
-			_, _ = r.Get("x")
+			_, _ = r.Get("", "x")
 		}()
 		go func() {
 			defer wg.Done()
-			r.Remove("x")
+			r.Remove("", "x")
 		}()
 	}
 	wg.Wait()

--- a/internal/tools/mcp/lazy.go
+++ b/internal/tools/mcp/lazy.go
@@ -85,8 +85,13 @@ type LazyResolver struct {
 	// the agent's tool call blocks. Default is 10s.
 	handshakeTimeout time.Duration
 
-	mu         sync.Mutex
-	registered map[string]map[string]tools.Tool // server → tool name → Tool
+	mu sync.Mutex
+	// RFC N: memo keyed by (tenant, server) → tool name → Tool. Two
+	// tenants registering the same server name with distinct URLs /
+	// allowed_tools get distinct memos (the pool is tenant-keyed too, so
+	// the dispatched call dials the right tenant's URL). The shared/
+	// legacy tenant is the "" tenant key.
+	registered map[regKey]map[string]tools.Tool
 }
 
 // lookupDynView adapts *DynamicRegistry to lookup.MCPDynamicRegistry —
@@ -97,11 +102,11 @@ type LazyResolver struct {
 // historical resolver behaviour.
 type lookupDynView struct{ reg *DynamicRegistry }
 
-func (v lookupDynView) Get(name string) (lookup.MCPServerSpec, bool) {
+func (v lookupDynView) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
 	if v.reg == nil {
 		return lookup.MCPServerSpec{}, false
 	}
-	s, ok := v.reg.Get(name)
+	s, ok := v.reg.Get(tenantID, name)
 	if !ok {
 		return lookup.MCPServerSpec{}, false
 	}
@@ -124,7 +129,7 @@ func NewLazyResolver(pool *Pool, cfg *config.Config, dynamicReg *DynamicRegistry
 		dynamicReg:       dynamicReg,
 		onResolve:        onResolve,
 		handshakeTimeout: handshakeTimeout,
-		registered:       make(map[string]map[string]tools.Tool),
+		registered:       make(map[regKey]map[string]tools.Tool),
 	}
 }
 
@@ -135,19 +140,26 @@ func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawM
 	if !ok {
 		return tools.Result{}, false
 	}
+	// RFC N: the tenant is authoritative from the run ctx (RunIdentity),
+	// never from the tool name / input. It scopes BOTH the resolver
+	// (tenant-dynamic shadows static shadows shared-dynamic) and the
+	// per-(tenant, server) memo so tenant A never resolves tenant B's
+	// MCP server.
+	tenant := tools.RunIdentity(ctx).TenantID
+	key := regKey{tenant, server}
 	// Membership + the operator's per-server allowed_tools filter both come
-	// from the shared lookup.MCPServer resolver, which walks static-yaml then
-	// the dynamic substrate (same chain every other primitive uses). A name
-	// in neither source falls through to the dispatcher's standard
+	// from the shared lookup.MCPServer resolver, which walks tenant-dynamic →
+	// static-yaml → shared-dynamic (same chain every other primitive uses). A
+	// name in no source falls through to the dispatcher's standard
 	// "tool not found".
-	spec, configured := lookup.MCPServer(r.cfg, lookupDynView{r.dynamicReg}, server)
+	spec, configured := lookup.MCPServer(r.cfg, lookupDynView{r.dynamicReg}, tenant, server)
 	if !configured {
 		return tools.Result{}, false
 	}
 
 	// Cache fast path.
 	r.mu.Lock()
-	if reg, ok := r.registered[server]; ok {
+	if reg, ok := r.registered[key]; ok {
 		t, hit := reg[name]
 		r.mu.Unlock()
 		if hit {
@@ -189,7 +201,7 @@ func (r *LazyResolver) Resolve(ctx context.Context, name string, input json.RawM
 	// map is built from the same pool/descs and Tool instances are
 	// stateless wrappers. Last writer wins; no harm.
 	r.mu.Lock()
-	r.registered[server] = toolMap
+	r.registered[key] = toolMap
 	r.mu.Unlock()
 
 	if r.onResolve != nil {

--- a/internal/tools/mcp/lazy_test.go
+++ b/internal/tools/mcp/lazy_test.go
@@ -69,7 +69,7 @@ type buildPlan struct {
 	buildCallCount map[string]int
 }
 
-func (b *buildPlan) build(name string) (Caller, error) {
+func (b *buildPlan) build(_, name string) (Caller, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.buildCallCount[name]++
@@ -109,7 +109,7 @@ func newBuildPlan() *buildPlan {
 // detour. Without this, every miss for a built-in tool name (Read,
 // Write, etc.) would block on a useless pool.Get.
 func TestLazyResolver_NotMCPName(t *testing.T) {
-	pool := NewPool(newBuildPlan().build, nil)
+	pool := NewPool(newBuildPlan().build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	for _, name := range []string{"Read", "Write", "WebSearch", "mcp__", "mcp__jobs", "mcp__jobs__"} {
@@ -126,7 +126,7 @@ func TestLazyResolver_NotMCPName(t *testing.T) {
 // likely hallucinated the name and the standard "tool not found" is
 // the right surface.
 func TestLazyResolver_ServerNotConfigured(t *testing.T) {
-	pool := NewPool(newBuildPlan().build, nil)
+	pool := NewPool(newBuildPlan().build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	_, handled := r.Resolve(context.Background(), "mcp__unknown__doSomething", json.RawMessage(`{}`))
@@ -145,7 +145,7 @@ func TestLazyResolver_FirstCallTriggersHandshakeAndDispatches(t *testing.T) {
 	plan.tools["jobs"] = []ToolDescriptor{
 		{Name: "getAgentContext", Description: "load context", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
@@ -173,7 +173,7 @@ func TestLazyResolver_SecondCallHitsCache(t *testing.T) {
 		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
 		{Name: "patchApplication", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	for i := 0; i < 5; i++ {
@@ -201,7 +201,7 @@ func TestLazyResolver_SecondCallHitsCache(t *testing.T) {
 func TestLazyResolver_HandshakeFails(t *testing.T) {
 	plan := newBuildPlan()
 	plan.alwaysFail["jobs"] = true
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	res, handled := r.Resolve(context.Background(), "mcp__jobs__getAgentContext", json.RawMessage(`{}`))
@@ -230,7 +230,7 @@ func TestLazyResolver_OperatorAllowedToolsFilter(t *testing.T) {
 		{Name: "safe_tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
 		{Name: "expensive_tool", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{
 		MCPServers: map[string]config.MCPServer{"jobs": {AllowedTools: []string{"safe_tool"}}},
 	}, nil, nil, 0)
@@ -263,7 +263,7 @@ func TestLazyResolver_OnResolveCallback(t *testing.T) {
 		{Name: "alpha", InputSchema: json.RawMessage(`{"type":"object"}`)},
 		{Name: "beta", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	var (
 		mu        sync.Mutex
 		callbacks []struct {
@@ -305,7 +305,7 @@ func TestLazyResolver_ConcurrentCallsCoalesceHandshake(t *testing.T) {
 	plan.tools["jobs"] = []ToolDescriptor{
 		{Name: "getAgentContext", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	r := NewLazyResolver(pool, &config.Config{MCPServers: map[string]config.MCPServer{"jobs": {}}}, nil, nil, 0)
 
 	const N = 50
@@ -338,7 +338,7 @@ func TestLazyResolver_DynamicRegistryServerResolves(t *testing.T) {
 	plan.tools["jobs"] = []ToolDescriptor{
 		{Name: "postResearchIngest", InputSchema: json.RawMessage(`{"type":"object"}`)},
 	}
-	pool := NewPool(plan.build, nil)
+	pool := NewPool(plan.build, nil, nil)
 	// serverConfig deliberately omits "jobs" — it lives ONLY in the dynamic
 	// registry, as if registered at runtime via `mcpserverdef create`.
 	dyn := NewDynamicRegistry()

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -18,15 +18,35 @@ import (
 // the shared connection (the underlying transport handles the JSON-RPC ID
 // demuxing).
 //
-// The Pool is intentionally shared across sessions and tenants: per-tenant
-// auth is passed through tool arguments, not by spawning per-tenant
-// children. This keeps memory bounded — n active sessions doesn't mean
-// n × m MCP child processes.
+// The Pool is shared across sessions. RFC N: the client cache is keyed by
+// (tenant, name), not name alone — two tenants registering the SAME name
+// with DIFFERENT URLs must not share one cached Caller (the first-cached
+// URL would otherwise be served to both, a cross-tenant leak the
+// advertising filter alone does NOT close). The tenant is derived from the
+// run ctx via tenantOf at Get time, so a static yaml server (shared) and a
+// per-tenant dynamic registration of the same name get distinct slots.
+// Per-server memory is still bounded: a name only spawns a child for the
+// tenants that actually call it.
 type Pool struct {
-	mu       sync.Mutex
-	servers  map[string]*entry
-	build    func(name string) (Caller, error)
+	mu      sync.Mutex
+	servers map[poolKey]*entry
+	// build resolves a (tenant, name) to a fresh Caller. The tenant lets
+	// the callback dial the RIGHT tenant's URL via lookup.MCPServer.
+	build    func(tenant, name string) (Caller, error)
 	teardown func(c Caller) // Close hook for the concrete transport
+	// tenantOf derives the authoritative tenant from the run ctx
+	// (tools.RunIdentity(ctx).TenantID). Injected to avoid importing the
+	// http auth package here (which would invert the dependency
+	// direction). Nil-safe: a nil tenantOf treats every call as the
+	// shared "" tenant (legacy single-tenant behaviour).
+	tenantOf func(ctx context.Context) string
+}
+
+// poolKey is the RFC N composite cache key: a server name within a
+// tenant. The shared/legacy tenant is the "" tenant key.
+type poolKey struct {
+	tenant string
+	name   string
 }
 
 // entry is one server slot. Once created it lives in p.servers until Pool.Close
@@ -40,16 +60,28 @@ type entry struct {
 	err    error // non-nil means init failed and the entry is unusable
 }
 
-// NewPool creates a pool. build is called the first time a server is needed;
-// it should spawn the transport (e.g. stdio.Spawn) and return its Caller.
+// NewPool creates a pool. build is called the first time a (tenant,
+// server) is needed; it should resolve the tenant's spec, spawn the
+// transport (e.g. stdio.Spawn / mcphttp.New) and return its Caller.
 // teardown is called on Pool.Close for each live entry; pass a function
-// that closes the underlying transport.
-func NewPool(build func(name string) (Caller, error), teardown func(c Caller)) *Pool {
+// that closes the underlying transport. tenantOf derives the authoritative
+// tenant from the run ctx (RFC N); pass nil for legacy single-tenant
+// keying ("" tenant for every call).
+func NewPool(build func(tenant, name string) (Caller, error), teardown func(c Caller), tenantOf func(ctx context.Context) string) *Pool {
 	return &Pool{
-		servers:  make(map[string]*entry),
+		servers:  make(map[poolKey]*entry),
 		build:    build,
 		teardown: teardown,
+		tenantOf: tenantOf,
 	}
+}
+
+// tenantFor derives the cache tenant for a run ctx. Nil-safe.
+func (p *Pool) tenantFor(ctx context.Context) string {
+	if p.tenantOf == nil {
+		return ""
+	}
+	return p.tenantOf(ctx)
 }
 
 // Get returns the Caller for a named server, spawning the connection on
@@ -61,12 +93,13 @@ func NewPool(build func(name string) (Caller, error), teardown func(c Caller)) *
 // crashed), Get evicts it and re-initialises a fresh entry inline. The
 // caller never sees a "permanently dead" slot.
 func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
+	key := poolKey{p.tenantFor(ctx), name}
 	// Phase 1 (fast path): check the map under the lock. If the entry
 	// exists, ready, and healthy, return immediately. If it exists but is
 	// still initialising, wait on its ready channel without holding p.mu.
 	// If it's ready but unhealthy, evict and fall through to a fresh init.
 	p.mu.Lock()
-	e, exists := p.servers[name]
+	e, exists := p.servers[key]
 	if exists {
 		select {
 		case <-e.ready:
@@ -80,7 +113,7 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 			if e.err == nil && e.caller != nil && p.teardown != nil {
 				p.teardown(e.caller)
 			}
-			delete(p.servers, name)
+			delete(p.servers, key)
 			exists = false
 		default:
 			// Still initialising — fall through to wait.
@@ -88,7 +121,7 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 	}
 	if !exists {
 		e = &entry{ready: make(chan struct{})}
-		p.servers[name] = e
+		p.servers[key] = e
 	}
 	p.mu.Unlock()
 
@@ -114,13 +147,13 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 	// Drop the lock during build/initialize/list; other goroutines wait on
 	// e.ready. On failure, remove the entry from the map so a retry can
 	// re-attempt rather than seeing a permanently-dead slot.
-	caller, descs, err := p.initEntry(ctx, name)
+	caller, descs, err := p.initEntry(ctx, key.tenant, name)
 	if err != nil {
 		p.mu.Lock()
 		// Only remove if it's still our entry (paranoid against a Close
 		// having already cleared the map).
-		if cur, ok := p.servers[name]; ok && cur == e {
-			delete(p.servers, name)
+		if cur, ok := p.servers[key]; ok && cur == e {
+			delete(p.servers, key)
 		}
 		p.mu.Unlock()
 		e.err = err
@@ -135,8 +168,8 @@ func (p *Pool) Get(ctx context.Context, name string) (Caller, []ToolDescriptor, 
 
 // initEntry runs build → Initialize → ListTools without any pool locks held.
 // On failure the caller (Get) removes the half-built entry from the map.
-func (p *Pool) initEntry(ctx context.Context, name string) (Caller, []ToolDescriptor, error) {
-	caller, err := p.build(name)
+func (p *Pool) initEntry(ctx context.Context, tenant, name string) (Caller, []ToolDescriptor, error) {
+	caller, err := p.build(tenant, name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("mcp pool: build %q: %w", name, err)
 	}
@@ -217,14 +250,14 @@ func (p *Pool) Tools() []tools.Tool {
 	p.mu.Lock()
 	// Snapshot the entry pointers so we can safely iterate the ready
 	// channels without holding p.mu (ready is closed under no lock).
-	entries := make(map[string]*entry, len(p.servers))
-	for name, e := range p.servers {
-		entries[name] = e
+	entries := make(map[poolKey]*entry, len(p.servers))
+	for key, e := range p.servers {
+		entries[key] = e
 	}
 	p.mu.Unlock()
 
 	var out []tools.Tool
-	for serverName, e := range entries {
+	for key, e := range entries {
 		select {
 		case <-e.ready:
 			if e.err != nil {
@@ -235,7 +268,7 @@ func (p *Pool) Tools() []tools.Tool {
 			continue
 		}
 		for _, td := range e.tools {
-			out = append(out, NewTool(p, serverName, td))
+			out = append(out, NewTool(p, key.name, td))
 		}
 	}
 	return out
@@ -249,10 +282,11 @@ func (p *Pool) Tools() []tools.Tool {
 //
 // Read-only — never triggers handshake or eviction. Used by the
 // Library introspection endpoint to enumerate static MCP servers'
-// tool lists without forcing wire round-trips.
-func (p *Pool) PeekTools(name string) []ToolDescriptor {
+// tool lists without forcing wire round-trips. RFC N: keyed by
+// (tenant, name); pass "" for static yaml servers (the shared tenant).
+func (p *Pool) PeekTools(tenant, name string) []ToolDescriptor {
 	p.mu.Lock()
-	e, ok := p.servers[name]
+	e, ok := p.servers[poolKey{tenant, name}]
 	p.mu.Unlock()
 	if !ok {
 		return nil
@@ -278,7 +312,7 @@ func (p *Pool) PeekTools(name string) []ToolDescriptor {
 func (p *Pool) Close() {
 	p.mu.Lock()
 	entries := p.servers
-	p.servers = map[string]*entry{}
+	p.servers = map[poolKey]*entry{}
 	p.mu.Unlock()
 
 	for _, e := range entries {
@@ -307,12 +341,18 @@ func (p *Pool) Close() {
 // map empty and triggers a fresh build() — which consults the dynamic
 // registry for the up-to-date spec.
 //
+// RFC N: keyed by (tenant, name) — evicting tenant A's cached client for
+// a name leaves tenant B's (same name, different URL) untouched. The
+// substrate tool passes the def's own tenant (derived from RunIdentity)
+// so eviction stays tenant-correct.
+//
 // Returns true if an entry was evicted (existed in the map).
-func (p *Pool) Evict(name string) bool {
+func (p *Pool) Evict(tenant, name string) bool {
 	p.mu.Lock()
-	e, exists := p.servers[name]
+	key := poolKey{tenant, name}
+	e, exists := p.servers[key]
 	if exists {
-		delete(p.servers, name)
+		delete(p.servers, key)
 	}
 	p.mu.Unlock()
 	if !exists {

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -115,7 +115,7 @@ func runFakeServer(mode string) {
 
 func newPoolWithFake(t *testing.T, mode string) *mcp.Pool {
 	t.Helper()
-	build := func(name string) (mcp.Caller, error) {
+	build := func(_, name string) (mcp.Caller, error) {
 		c, err := stdio.Spawn(stdio.Config{
 			Command: os.Args[0],
 			Env:     []string{"BE_MCP_SERVER=" + mode},
@@ -130,7 +130,7 @@ func newPoolWithFake(t *testing.T, mode string) *mcp.Pool {
 			_ = cl.Close()
 		}
 	}
-	pool := mcp.NewPool(build, teardown)
+	pool := mcp.NewPool(build, teardown, nil)
 	t.Cleanup(pool.Close)
 	return pool
 }
@@ -228,7 +228,7 @@ func TestPoolGetCachesConnection(t *testing.T) {
 		if cl, ok := c.(*stdio.Client); ok {
 			_ = cl.Close()
 		}
-	})
+	}, nil)
 	t.Cleanup(pool.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -252,7 +252,7 @@ func TestPoolGetSharesInFlightInit(t *testing.T) {
 		if cl, ok := c.(*stdio.Client); ok {
 			_ = cl.Close()
 		}
-	})
+	}, nil)
 	t.Cleanup(pool.Close)
 
 	const N = 8
@@ -285,7 +285,7 @@ func TestPoolGetSharesInFlightInit(t *testing.T) {
 func TestPoolGetRetriesAfterInitFailure(t *testing.T) {
 	var attempts int
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			attempts++
 			if attempts == 1 {
 				return nil, errors.New("transient build failure")
@@ -301,6 +301,7 @@ func TestPoolGetRetriesAfterInitFailure(t *testing.T) {
 				_ = cl.Close()
 			}
 		},
+		nil,
 	)
 	t.Cleanup(pool.Close)
 
@@ -324,7 +325,7 @@ func TestPoolGetRespectsCtxWhileWaitingOnPeerInit(t *testing.T) {
 	// Use a slow build so the second Get can race the first's init.
 	releaseBuild := make(chan struct{})
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			<-releaseBuild
 			return stdio.Spawn(stdio.Config{
 				Command: os.Args[0],
@@ -336,6 +337,7 @@ func TestPoolGetRespectsCtxWhileWaitingOnPeerInit(t *testing.T) {
 				_ = cl.Close()
 			}
 		},
+		nil,
 	)
 	t.Cleanup(func() {
 		// Unblock any stuck build before Close.
@@ -378,7 +380,7 @@ func TestPoolGetRespawnsAfterUnhealthy(t *testing.T) {
 		if cl, ok := c.(*stdio.Client); ok {
 			_ = cl.Close()
 		}
-	})
+	}, nil)
 	t.Cleanup(pool.Close)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -423,9 +425,10 @@ func TestPoolGetRespawnsAfterUnhealthy(t *testing.T) {
 
 func TestPoolGetReturnsBuildError(t *testing.T) {
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			return nil, errors.New("synthetic build failure")
 		},
+		nil,
 		nil,
 	)
 	t.Cleanup(pool.Close)
@@ -451,7 +454,7 @@ func newCountingBuild(t *testing.T, mode string) *countingBuild {
 	return &countingBuild{t: t, mode: mode}
 }
 
-func (b *countingBuild) fn(name string) (mcp.Caller, error) {
+func (b *countingBuild) fn(_, name string) (mcp.Caller, error) {
 	b.count++
 	c, err := stdio.Spawn(stdio.Config{
 		Command: os.Args[0],
@@ -473,7 +476,7 @@ func (b *countingBuild) fn(name string) (mcp.Caller, error) {
 func TestGetWithRetryRecoversFromTransientBuildFailure(t *testing.T) {
 	failureBudget := 2
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			if failureBudget > 0 {
 				failureBudget--
 				return nil, errors.New("ECONNREFUSED (peer still starting)")
@@ -489,6 +492,7 @@ func TestGetWithRetryRecoversFromTransientBuildFailure(t *testing.T) {
 				_ = cl.Close()
 			}
 		},
+		nil,
 	)
 	t.Cleanup(pool.Close)
 
@@ -526,9 +530,10 @@ func TestGetWithRetryRecoversFromTransientBuildFailure(t *testing.T) {
 // returns an error including the attempt count.
 func TestGetWithRetryGivesUpWhenCtxExpires(t *testing.T) {
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			return nil, errors.New("ECONNREFUSED (peer never starts)")
 		},
+		nil,
 		nil,
 	)
 	t.Cleanup(pool.Close)
@@ -558,7 +563,7 @@ func TestGetWithRetryGivesUpWhenCtxExpires(t *testing.T) {
 
 func TestPool_PeekTools_ReturnsNilForUnknownServer(t *testing.T) {
 	pool := newPoolWithFake(t, "ok")
-	if got := pool.PeekTools("does-not-exist"); got != nil {
+	if got := pool.PeekTools("", "does-not-exist"); got != nil {
 		t.Errorf("PeekTools on unknown name = %+v, want nil", got)
 	}
 }
@@ -570,7 +575,7 @@ func TestPool_PeekTools_ReturnsCachedSnapshotAfterGet(t *testing.T) {
 	if _, _, err := pool.Get(ctx, "search"); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	descs := pool.PeekTools("search")
+	descs := pool.PeekTools("", "search")
 	if len(descs) != 1 || descs[0].Name != "web_search" {
 		t.Errorf("PeekTools = %+v, want one entry web_search", descs)
 	}
@@ -585,10 +590,11 @@ func TestPool_PeekTools_ReturnsNilAfterEvictedInitFailure(t *testing.T) {
 	// keeps failed entries in the map still produces nil from
 	// PeekTools.
 	pool := mcp.NewPool(
-		func(name string) (mcp.Caller, error) {
+		func(_, name string) (mcp.Caller, error) {
 			return nil, errors.New("transient build failure")
 		},
 		func(c mcp.Caller) {},
+		nil,
 	)
 	t.Cleanup(pool.Close)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -596,7 +602,7 @@ func TestPool_PeekTools_ReturnsNilAfterEvictedInitFailure(t *testing.T) {
 	if _, _, err := pool.Get(ctx, "broken"); err == nil {
 		t.Fatal("expected init to fail")
 	}
-	if got := pool.PeekTools("broken"); got != nil {
+	if got := pool.PeekTools("", "broken"); got != nil {
 		t.Errorf("PeekTools after init failure = %+v, want nil", got)
 	}
 }


### PR DESCRIPTION
Final slice **3/3** of **RFC N — multi-tenant definition plane**. Closes the MCP half of the gap, including the two runtime boundaries the agents/skills slices didn't have: the **per-run advertising filter** (§3) and **pool client-cache tenant-keying**.

> ⚠️ **STACKED (3-deep): base = `feature-rfc-n-tenant-defs-skills` (#362) → which bases on `feature-rfc-n-tenant-defs-agents` (#361) → which bases on `main`.** Genuine dependency chain (shared `tenantFromCtx`, migration sequence 0037→0038→0039, shared store edits). **Merge order, per our stacked-PR discipline (never merge while base is a feature branch):** #361 → `main`, then #362 retargets→`main`→merge, then this retargets→`main`→merge. I'll rebase + verify `origin/main` contains each before the next.

## Four layers (more than agents/skills)
1. **Storage** — migration `0039` + SQLite DDL: `tenant_id` on `mcp_server_defs` (UNIQUE→`(tenant_id,name,version)`) and `mcp_server_def_active` (PK→`(tenant_id,name)`). Cross-tenant promote guard; per-`(tenant,name)` version lock.
2. **In-memory `DynamicRegistry`** tenant-keyed (`Get(tenant,name)`, `NamesForTenant` with tenant-shadows-shared precedence). Boot rehydration carries tenant.
3. **Resolver + advertising filter (security crux)** — `lookup.MCPServer(cfg, dyn, tenant, name)` (tenant-dynamic → static shared → shared-dynamic; `""` = legacy static-first). The `SetDynamicToolEnumerator` callback filters to the run's tenant: **a run in tenant A's candidate tool set contains only A's + shared MCP tools, never tenant B's.**
4. **Pool client-cache tenant-keying** — cache keyed by `poolKey{tenant,name}` via an injected `tenantOf` (from `RunIdentity`, nil-safe → `""`); build callback `func(tenant,name)` dials the right tenant's URL. Closes the same-name/different-URL leak the advertising filter alone doesn't. The lazy-resolver memo is likewise `(tenant,server)`-keyed.

Authoritative tenant only from ctx (principal → RunIdentity → `""`), never wire/tool input. `tenant_id` excluded from the content hash. stdio servers stay yaml-only/shared (the documented `lookup.MCPServerSpec` limitation).

## Tested
- `TestStoreContract/MCPServerDefTenantIsolation` (fail-before verified).
- `TestMCPServer_TenantResolutionPrecedence`.
- **`TestDynamicTools_TenantScopedAdvertising`** (the §3 regression): same name `crm` under A & B + a B-only `secret` + a shared `billing` → A's candidate set has `crm(a)`+`billing`, never `crm(b)`/`secret`; symmetric for B.
- Pool unit test: two tenants, same name, distinct cache entries (no collision).
- Independent `go build`/`vet`/`gofmt`/**full `go test ./...`** clean.

Same SQLite-in-place-upgrade caveat as #361/#362 (fresh DB for true isolation on SQLite; Postgres upgrades in place). With this slice, RFC N's three shared primitives (agents, skills, MCP servers) are all tenant-isolated end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)