### PR TITLE
feat(triggers): tenant_id axis on ScheduleDef + WebhookDef (RFC N follow-up)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -772,6 +772,8 @@ Config knobs (full reference: `loomcycle context help operator-tokens` or the `C
 
 Routes enforce a scope from a closed catalog (`substrate:admin` is superuser); an under-scoped token gets `403` + `WWW-Authenticate: Bearer scope="…"`. The legacy `LOOMCYCLE_AUTH_TOKEN` is disabled only once an admin-scoped token exists (the no-lockout gate).
 
+**Trigger-spawned runs choose their tenant in the def (RFC N).** An interactive run inherits its tenant from the caller's token, but a scheduler- or webhook-spawned run has no inbound bearer — so the tenant is declared in the def via `tenant_id:` on a `scheduled_runs:` entry or a `webhooks:` entry. The spawned run then resolves that tenant's agents/skills/MCP and isolates its memory/runs. It is operator-authored def-content (`""` = shared/default). **Security: for webhooks the tenant comes from the static def ONLY — never from the inbound `payload_mapping`** (the attacker-influenceable body must not be able to select another tenant). See `Context.help scheduled-runs` / `Context.help input-webhooks`.
+
 ---
 
 ## 10. Cross-references

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -147,6 +147,12 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		// PayloadMetadata is projected from the inbound body → UNTRUSTED.
 		Metadata:        w.Metadata,
 		PayloadMetadata: payloadMeta,
+		// TenantID picks which tenant's agents/skills/MCP resolve and whose
+		// memory/runs the spawned run is isolated to. SECURITY: it comes from
+		// the STATIC def `w` ONLY — NEVER from proj.Fields (the signed-but-
+		// attacker-influenceable payload). There is deliberately no
+		// payload_mapping / run_metadata path for tenant (RFC N follow-up).
+		TenantID: w.TenantID,
 		// IdempotencyKey is set by the caller (deliverSpawn) to the
 		// delivery id, keeping this builder's signature focused on the
 		// Def + projected payload. See RFC H Decision 10 "Layer 2".

--- a/internal/api/webhook/tenant_test.go
+++ b/internal/api/webhook/tenant_test.go
@@ -1,0 +1,35 @@
+package webhook
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestWebhookBuildRunInput_TenantFromDefNotPayload pins the security
+// invariant for the webhook tenant axis (RFC N follow-up): the tenant the
+// spawned run executes as comes from the STATIC operator-authored def ONLY,
+// NEVER from the inbound payload. The payload here carries tenant-ish fields
+// (a mapped `tenant_id` target and a `run_metadata.tenant`), and NONE of them
+// may override the def — otherwise an attacker who can shape the signed body
+// could steer the run into another tenant's agents/skills/memory. An empty
+// def tenant must resolve to "" (shared/default), not pick up the payload.
+func TestWebhookBuildRunInput_TenantFromDefNotPayload(t *testing.T) {
+	w := config.Webhook{Agent: "reviewer", TenantID: "acme"}
+	proj := projectResult{Fields: map[string]string{
+		"goal":                "review",
+		"tenant_id":           "attacker", // not a real mapping target, but pin it can't leak
+		"run_metadata.tenant": "attacker", // projected metadata is UNTRUSTED — must not become the tenant
+	}}
+	in := buildRunInput(w, proj, map[string]bool{}, func(string) string { return "" }, nil)
+	if in.TenantID != "acme" {
+		t.Errorf("def tenant must win and payload cannot set it: got %q, want %q", in.TenantID, "acme")
+	}
+
+	// Empty def tenant: payload tenant-ish fields still cannot inject a tenant.
+	noTenant := config.Webhook{Agent: "reviewer"}
+	got := buildRunInput(noTenant, proj, map[string]bool{}, func(string) string { return "" }, nil).TenantID
+	if got != "" {
+		t.Errorf("empty def tenant must stay \"\" (shared/default); payload must not inject %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -965,6 +965,12 @@ type ScheduledRun struct {
 	// (e.g. a different repo per fork) falls out of the overlay naturally.
 	// Not for secrets — those use UserCredentials / user_credentials_from_env.
 	Metadata map[string]any `yaml:"metadata"`
+
+	// TenantID is the tenant the fired run EXECUTES as (RFC N follow-up).
+	// It flows to RunInput.TenantID, so the run resolves that tenant's
+	// agents/skills/MCP and isolates its memory/runs. "" = shared/default
+	// (no tenant scoping). Operator-authored (def content), never inbound.
+	TenantID string `json:"tenant_id,omitempty" yaml:"tenant_id"`
 }
 
 // ScheduledRunSegment mirrors the loop.PromptSegment wire shape but

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1113,7 +1113,13 @@ type Webhook struct {
 	// Metadata is NON-SECRET structured metadata (repo, review policy,
 	// preferred skills, …) passed to the agent as TRUSTED (def-authored) via
 	// RunInput.Metadata. Not for secrets — those use UserCredentials*.
-	Metadata       map[string]any      `json:"metadata,omitempty" yaml:"metadata"`
+	Metadata map[string]any `json:"metadata,omitempty" yaml:"metadata"`
+	// TenantID is the tenant the spawned run EXECUTES as (RFC N follow-up).
+	// It flows to RunInput.TenantID so the run resolves that tenant's
+	// agents/skills/MCP and isolates its memory/runs. "" = shared/default.
+	// SECURITY: tenant comes from this STATIC operator-authored def ONLY —
+	// NEVER from the inbound payload / payload_mapping (attacker-influenceable).
+	TenantID       string              `json:"tenant_id,omitempty" yaml:"tenant_id"`
 	PayloadMapping map[string]string   `json:"payload_mapping,omitempty" yaml:"payload_mapping"`
 	SyncResponse   WebhookSyncResponse `json:"sync_response,omitempty" yaml:"sync_response"`
 	OnComplete     []ScheduledRunHook  `json:"on_complete,omitempty" yaml:"on_complete"`

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -164,6 +164,30 @@ leak a secret onto the message bus. `user_credentials_from_env` (and any
 `payload_mapping` `user_credentials.*` target) is **refused at create time**
 for `delivery: channel` (RFC H Decision 11).
 
+## `tenant_id` — which tenant the spawned run executes as (RFC N)
+
+Set `tenant_id:` on a webhook def to make its **spawn** run execute as that
+tenant: the run resolves that tenant's agents / skills / MCP servers and its
+memory and run records are isolated to the tenant (RFC L multi-tenant
+boundary). Omit it (`""`) for a shared/default run with no tenant scoping.
+
+```yaml
+  github-pr-review:
+    delivery: spawn
+    agent: reviewer
+    tenant_id: acme            # spawned run executes as tenant "acme"
+```
+
+**Security — the tenant comes from the static def ONLY, never the payload.**
+Unlike `user_id` / `user_tier` (which an operator MAY project from the signed
+body via `payload_mapping`, accepting that they are only as trustworthy as
+the per-def signing secret), there is deliberately **no** `payload_mapping`
+or `run_metadata.*` path for the tenant. The inbound body is attacker-
+influenceable; letting it select the tenant would let a sender steer the run
+into another tenant's agents/skills/memory. `tenant_id` is def-content
+(operator-authored), flows to `RunInput.TenantID`, and cannot be overridden
+from the wire.
+
 ## Response policy
 
 `202 Accepted` with `{run_id, webhook_name, delivery_id}` (async, the

--- a/internal/help/builtin/scheduled-runs.md
+++ b/internal/help/builtin/scheduled-runs.md
@@ -74,6 +74,27 @@ standalone entry has an explicit `user_id` and a single `schedule:`.
 Mutual exclusion: a template can't fix one cron AND offer per-tier
 defaults. The config validator refuses at boot.
 
+## `tenant_id` — which tenant the fired run executes as (RFC N)
+
+Set `tenant_id:` on a schedule to make its spawned run execute as that
+tenant: the run resolves that tenant's agents / skills / MCP servers and
+its memory and run records are isolated to the tenant (RFC L multi-tenant
+boundary). Omit it (`""`) for a shared/default run with no tenant scoping.
+
+```yaml
+  nightly-acme-digest:
+    agent: digest
+    tenant_id: acme            # run executes as tenant "acme"
+    schedule: "0 2 * * *"
+    user_id: ops@acme.example
+```
+
+It is def-content (lives in the definition, participates in the def's
+serialized identity), so a schedule that runs as tenant A is a genuinely
+different def than one running as tenant B. It is **operator-authored
+only** — the scheduler has no inbound payload, so there is no way for an
+external value to set the tenant. It flows to `RunInput.TenantID`.
+
 ## What ships in the v1.x.0 substrate PR
 
 This is the data-layer foundation. The agent-facing tool +

--- a/internal/lookup/schedule.go
+++ b/internal/lookup/schedule.go
@@ -92,6 +92,7 @@ type SubstrateScheduleDef struct {
 	UserCredentialsFromEnv map[string]string       `json:"user_credentials_from_env,omitempty"`
 	OnComplete             []SubstrateScheduleHook `json:"on_complete,omitempty"`
 	Metadata               map[string]any          `json:"metadata,omitempty"`
+	TenantID               string                  `json:"tenant_id,omitempty"`
 }
 
 // SubstratePromptSegment mirrors config.ScheduledRunSegment with
@@ -144,6 +145,7 @@ func (s SubstrateScheduleDef) ToConfigDef() config.ScheduledRun {
 		UserID:                 s.UserID,
 		UserCredentialsFromEnv: s.UserCredentialsFromEnv,
 		Metadata:               s.Metadata,
+		TenantID:               s.TenantID,
 	}
 	if len(s.Prompt) > 0 {
 		out.Prompt = make([]config.ScheduledRunSegment, len(s.Prompt))

--- a/internal/lookup/schedule_test.go
+++ b/internal/lookup/schedule_test.go
@@ -194,6 +194,7 @@ func TestSchedule_DriftDetection(t *testing.T) {
 		"user_credentials_from_env": true,
 		"on_complete":               true,
 		"metadata":                  true, // non-secret agent metadata (PR 2/2)
+		"tenant_id":                 true, // tenant the fired run executes as (RFC N follow-up)
 	}
 	have := scheduleJsonTagsOf(reflect.TypeOf(lookup.SubstrateScheduleDef{}))
 	for tag := range want {

--- a/internal/lookup/webhook.go
+++ b/internal/lookup/webhook.go
@@ -84,6 +84,7 @@ type SubstrateWebhookDef struct {
 	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
 	UserCredentials        map[string]string         `json:"user_credentials,omitempty"`
 	Metadata               map[string]any            `json:"metadata,omitempty"`
+	TenantID               string                    `json:"tenant_id,omitempty"`
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           SubstrateWebhookSyncResp  `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
@@ -139,6 +140,7 @@ func (s SubstrateWebhookDef) ToConfigDef() config.Webhook {
 		UserCredentialsFromEnv: s.UserCredentialsFromEnv,
 		UserCredentials:        s.UserCredentials,
 		Metadata:               s.Metadata,
+		TenantID:               s.TenantID,
 		PayloadMapping:         s.PayloadMapping,
 		SyncResponse: config.WebhookSyncResponse{
 			Enabled:   s.SyncResponse.Enabled,

--- a/internal/lookup/webhook_test.go
+++ b/internal/lookup/webhook_test.go
@@ -148,6 +148,7 @@ func TestWebhook_DriftDetection(t *testing.T) {
 		"user_credentials_from_env": true,
 		"user_credentials":          true, // RFC F fork-time parity (PR 2/2)
 		"metadata":                  true, // non-secret agent metadata (PR 2/2)
+		"tenant_id":                 true, // tenant the spawned run executes as (RFC N follow-up)
 		"payload_mapping":           true,
 		"sync_response":             true,
 		"on_complete":               true,

--- a/internal/scheduler/runinput.go
+++ b/internal/scheduler/runinput.go
@@ -37,6 +37,7 @@ type scheduleDef struct {
 	UserTier               string              `json:"user_tier,omitempty"`
 	OnComplete             []scheduleHook      `json:"on_complete,omitempty"`
 	Metadata               map[string]any      `json:"metadata,omitempty"`
+	TenantID               string              `json:"tenant_id,omitempty"`
 }
 
 type schedulePromptSeg struct {
@@ -136,5 +137,9 @@ func buildRunInput(def scheduleDef, envAllowlist map[string]bool, logf func(form
 		// Non-secret, operator-authored → TRUSTED. The scheduler has no
 		// external inbound body, so there is no PayloadMetadata here.
 		Metadata: def.Metadata,
+		// TenantID comes from the def ONLY (operator-authored) — the run
+		// executes as this tenant, resolving its agents/skills/MCP and
+		// isolating memory/runs. "" = shared/default (RFC N follow-up).
+		TenantID: def.TenantID,
 	}
 }

--- a/internal/scheduler/tenant_test.go
+++ b/internal/scheduler/tenant_test.go
@@ -1,0 +1,21 @@
+package scheduler
+
+import "testing"
+
+// TestSchedulerBuildRunInput_ThreadsDefTenant pins that a schedule def's
+// TenantID reaches the spawned run as RunInput.TenantID, so the run resolves
+// that tenant's agents/skills/MCP and isolates its memory/runs (RFC N
+// follow-up). Fails on the pre-feature scheduleDef, which had no TenantID
+// field. An empty def tenant must stay "" (shared/default, no scoping).
+func TestSchedulerBuildRunInput_ThreadsDefTenant(t *testing.T) {
+	def := scheduleDef{Agent: "digest", TenantID: "acme"}
+	in := buildRunInput(def, map[string]bool{}, nil)
+	if in.TenantID != "acme" {
+		t.Errorf("schedule def TenantID not threaded to RunInput.TenantID: got %q, want %q", in.TenantID, "acme")
+	}
+
+	empty := scheduleDef{Agent: "digest"}
+	if got := buildRunInput(empty, map[string]bool{}, nil).TenantID; got != "" {
+		t.Errorf("absent def tenant must stay \"\" (shared/default), got %q", got)
+	}
+}

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -827,6 +827,9 @@ type mergedScheduleDef struct {
 	// TRUSTED (def-authored) via RunInput.Metadata. Per-fork (e.g. a repo
 	// per fork) falls out of the overlay. Not for secrets (UserCredentials*).
 	Metadata map[string]any `json:"metadata,omitempty"`
+	// TenantID is the tenant the fired run EXECUTES as (RFC N follow-up).
+	// Flows to RunInput.TenantID. Per-fork tenant falls out of the overlay.
+	TenantID string `json:"tenant_id,omitempty"`
 }
 
 // mergedSchedulePromptSeg mirrors config.ScheduledRunSegment with JSON tags.
@@ -913,6 +916,9 @@ func (d *mergedScheduleDef) applyOverlay(ov mergedScheduleDef) {
 	if ov.Metadata != nil {
 		d.Metadata = ov.Metadata
 	}
+	if ov.TenantID != "" {
+		d.TenantID = ov.TenantID
+	}
 }
 
 func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
@@ -928,6 +934,7 @@ func staticToMergedScheduleDef(sr config.ScheduledRun) mergedScheduleDef {
 		UserID:                 sr.UserID,
 		UserCredentialsFromEnv: sr.UserCredentialsFromEnv,
 		Metadata:               sr.Metadata,
+		TenantID:               sr.TenantID,
 	}
 	if len(sr.Prompt) > 0 {
 		out.Prompt = make([]mergedSchedulePromptSeg, len(sr.Prompt))

--- a/internal/tools/builtin/tenant_serialization_test.go
+++ b/internal/tools/builtin/tenant_serialization_test.go
@@ -1,0 +1,42 @@
+package builtin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestScheduleDef_TenantInContentHash pins the serialization back-compat that
+// the locked RFC N design requires of the def-content TenantID field: it is
+// `omitempty`, so a def with NO tenant marshals IDENTICALLY to a pre-change
+// def (no `tenant_id` key in the persisted JSONB / snapshot / content image),
+// while setting the tenant changes the serialized bytes. ScheduleDef has no
+// content_sha256 op (see scheduledef.go) — the serialized image IS the
+// content identity that matters for round-trip, so byte-equality is the
+// testable analog of "the content hash is unchanged for existing defs".
+func TestScheduleDef_TenantInContentHash(t *testing.T) {
+	noTenant := mergedScheduleDef{Agent: "digest"}
+	withTenant := mergedScheduleDef{Agent: "digest", TenantID: "acme"}
+
+	noBytes, err := json.Marshal(noTenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	withBytes, err := json.Marshal(withTenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// omitempty back-compat: an absent tenant must not emit the key at all,
+	// so an existing def's serialized image (and any hash over it) is unchanged.
+	if strings.Contains(string(noBytes), "tenant_id") {
+		t.Errorf("empty TenantID must be omitted (omitempty) so existing defs serialize identically; got %s", noBytes)
+	}
+	// Setting the tenant is a genuinely different def → different bytes.
+	if string(noBytes) == string(withBytes) {
+		t.Errorf("setting TenantID must change the serialized content; both produced %s", noBytes)
+	}
+	if !strings.Contains(string(withBytes), `"tenant_id":"acme"`) {
+		t.Errorf("set TenantID must serialize as tenant_id; got %s", withBytes)
+	}
+}

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -577,6 +577,7 @@ type mergedWebhookDef struct {
 	UserCredentialsFromEnv map[string]string         `json:"user_credentials_from_env,omitempty"`
 	UserCredentials        map[string]string         `json:"user_credentials,omitempty"` // RFC F fork-time explicit values (ScheduleDef parity)
 	Metadata               map[string]any            `json:"metadata,omitempty"`         // non-secret, trusted agent metadata
+	TenantID               string                    `json:"tenant_id,omitempty"`        // tenant the spawned run executes as (RFC N follow-up); def-authored, never from payload
 	PayloadMapping         map[string]string         `json:"payload_mapping,omitempty"`
 	SyncResponse           mergedWebhookSyncResp     `json:"sync_response,omitempty"`
 	OnComplete             []config.ScheduledRunHook `json:"on_complete,omitempty"`
@@ -674,6 +675,9 @@ func (d *mergedWebhookDef) applyOverlay(ov mergedWebhookDef) {
 	if ov.Metadata != nil {
 		d.Metadata = ov.Metadata
 	}
+	if ov.TenantID != "" {
+		d.TenantID = ov.TenantID
+	}
 	if ov.PayloadMapping != nil {
 		d.PayloadMapping = ov.PayloadMapping
 	}
@@ -710,6 +714,7 @@ func staticToMergedWebhookDef(w config.Webhook) mergedWebhookDef {
 		UserCredentialsFromEnv: w.UserCredentialsFromEnv,
 		UserCredentials:        w.UserCredentials,
 		Metadata:               w.Metadata,
+		TenantID:               w.TenantID,
 		PayloadMapping:         w.PayloadMapping,
 		SyncResponse: mergedWebhookSyncResp{
 			Enabled:   w.SyncResponse.Enabled,


### PR DESCRIPTION
RFC N follow-up (the deferred scheduler/webhook tenant gap the adversarial review flagged). Lets an operator declare which **tenant** a schedule's / webhook's spawned run executes as, so the run resolves that tenant's agents/skills/MCP and isolates its memory/runs. Off `main`, **not stacked** — composes with the RFC N PRs (#361–#363).

## What
`tenant_id` is a def-**content** field (`omitempty`, no DB column / no migration) on `ScheduledRun` and `Webhook`, threaded through the standard substrate mirrors to `RunInput.TenantID`:
- **Scheduler:** `config.ScheduledRun.TenantID` → `mergedScheduleDef`/`applyOverlay`/`staticToMerged` (scheduledef.go) → `SubstrateScheduleDef`/`ToConfigDef` (lookup/schedule.go) → the sweeper-read `scheduleDef` + `buildRunInput` sets `RunInput.TenantID: def.TenantID` (scheduler/runinput.go).
- **Webhook:** same mirror chain (config → webhookdef.go → lookup/webhook.go → `buildRunInput` sets `RunInput.TenantID: w.TenantID`).

## Security
The webhook tenant comes from the **static operator-authored def only** (`w.TenantID`), **never** the inbound payload / `payload_mapping` — an attacker-influenceable body cannot set the tenant. `TestWebhookBuildRunInput_TenantFromDefNotPayload` asserts a payload carrying `tenant_id` / `run_metadata.tenant` is ignored (def wins). Scheduler tenant is likewise def-only.

## Composition with RFC N
`RunInput.TenantID` exists from RFC L, and `RunOnce` (no principal on these paths) takes `effectiveTenantID = in.TenantID`. So:
- **Today (RFC N not yet merged):** a tenant-scoped schedule/webhook correctly attributes its run's session/memory to the tenant (RFC L), but the entry agent/skill/MCP still resolve globally.
- **Once RFC N merges:** the entry resolution (now keyed on `effectiveTenantID`) resolves the declared tenant's defs — full isolation, no further change here.

## Note (deviation from the original framing)
ScheduleDef/WebhookDef have **no `content_sha256`/`verify` op** (unlike Agent/Skill), so there's no hash to churn; back-compat is preserved via `omitempty` serialization (absent tenant emits no key → byte-identical existing defs), tested by `TestScheduleDef_TenantInContentHash`.

## Tested
`TestSchedulerBuildRunInput_ThreadsDefTenant`, `TestWebhookBuildRunInput_TenantFromDefNotPayload`, `TestScheduleDef_TenantInContentHash` (each fail-before verified); 3-way drift tests updated (lookup schedule/webhook `want` maps + reflection-based scheduler drift). `go build`/`vet`/`gofmt`/**full `go test ./...`** clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)