### PR TITLE
fix(codejs): deterministic sorted key order for input.metadata across replay

### DIFF
--- a/internal/providers/codejs/metadata_order_test.go
+++ b/internal/providers/codejs/metadata_order_test.go
@@ -1,0 +1,85 @@
+package codejs
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// These tests pin the replay-determinism fix for the Go-map key-order bug:
+// caller metadata arrives as Go map[string]any (key order already lost +
+// randomized per goja conversion), so without stableJSValue an agent that
+// JSON.stringify(s) input.metadata emitted byte-different bytes across replay
+// turns → spurious code_agent_replay_divergence. stableJSValue materializes
+// every map with SORTED keys, so input.* is byte-stable across turns.
+
+// TestStableJSValue_MetadataKeysSorted: top-level input.metadata keys (incl. the
+// loop-stamped user_id/agent) come out sorted, regardless of Go-map order.
+func TestStableJSValue_MetadataKeysSorted(t *testing.T) {
+	p := newTestProvider(t.TempDir())
+	got := runOnce(t, p, providers.RunMeta{
+		AgentName: "x",
+		UserID:    "u",
+		CodeBody:  `function run(input){ return { final_text: Object.keys(input.metadata).join(",") }; }`,
+		Metadata:  map[string]any{"zebra": 1, "mango": 2, "alpha": 3},
+	})
+	// buildInput adds user_id + agent; all keys sorted:
+	const want = "agent,alpha,mango,user_id,zebra"
+	if got != want {
+		t.Fatalf("input.metadata keys not sorted/stable: got %q want %q", got, want)
+	}
+}
+
+// TestStableJSValue_NestedObjectKeysSorted: recursion sorts nested object keys.
+func TestStableJSValue_NestedObjectKeysSorted(t *testing.T) {
+	p := newTestProvider(t.TempDir())
+	got := runOnce(t, p, providers.RunMeta{
+		AgentName: "x",
+		CodeBody:  `function run(input){ return { final_text: JSON.stringify(input.metadata.nested) }; }`,
+		Metadata:  map[string]any{"nested": map[string]any{"charlie": 1, "alpha": 2, "bravo": 3}},
+	})
+	const want = `{"alpha":2,"bravo":3,"charlie":1}`
+	if got != want {
+		t.Fatalf("nested object keys not sorted: got %q want %q", got, want)
+	}
+}
+
+// TestStableJSValue_ArrayOfObjectsKeysSorted: recursion descends through arrays
+// (the ats-filter-batch shape: metadata.matches = [{...}, ...]) and sorts each
+// element-object's keys while preserving array order.
+func TestStableJSValue_ArrayOfObjectsKeysSorted(t *testing.T) {
+	p := newTestProvider(t.TempDir())
+	got := runOnce(t, p, providers.RunMeta{
+		AgentName: "x",
+		CodeBody:  `function run(input){ return { final_text: JSON.stringify(input.metadata.matches) }; }`,
+		Metadata: map[string]any{"matches": []any{
+			map[string]any{"score": 1, "id": "a", "name": "first"},
+			map[string]any{"score": 2, "id": "b", "name": "second"},
+		}},
+	})
+	const want = `[{"id":"a","name":"first","score":1},{"id":"b","name":"second","score":2}]`
+	if got != want {
+		t.Fatalf("array-of-objects not stably key-sorted: got %q want %q", got, want)
+	}
+}
+
+// TestStableJSValue_StableAcrossRuntimeBuilds is the direct replay-stability
+// property: two Call invocations (each a fresh goja runtime, as replay turns
+// are) serialize the SAME metadata to identical bytes. This is what prevents
+// the divergence guard from firing on a serialized tool input.
+func TestStableJSValue_StableAcrossRuntimeBuilds(t *testing.T) {
+	p := newTestProvider(t.TempDir())
+	meta := providers.RunMeta{
+		AgentName: "x",
+		CodeBody:  `function run(input){ return { final_text: JSON.stringify(input.metadata) }; }`,
+		Metadata: map[string]any{
+			"k9": 1, "k1": 2, "k7": 3, "k3": 4, "k5": 5,
+			"k2": 6, "k8": 7, "k4": 8, "k6": 9, "k0": 10,
+		},
+	}
+	a := runOnce(t, p, meta)
+	b := runOnce(t, p, meta)
+	if a != b {
+		t.Fatalf("metadata serialization unstable across runtime builds (replay would diverge):\n  turn1=%s\n  turn2=%s", a, b)
+	}
+}

--- a/internal/providers/codejs/provider.go
+++ b/internal/providers/codejs/provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -211,7 +212,7 @@ func (p *Provider) runTurn(ctx context.Context, out chan providers.Event, span t
 		return
 	}
 
-	ret, err := runFn(goja.Undefined(), rt.ToValue(input))
+	ret, err := runFn(goja.Undefined(), stableJSValue(rt, input))
 	if err != nil {
 		// A frontier, divergence, or watcher (timeout/cancel) Interrupt surfaces
 		// here as the error. A watcher interrupt takes PRECEDENCE over a frontier
@@ -250,7 +251,7 @@ func (p *Provider) classifyRunErr(state *replayState, ctx context.Context, cause
 	switch {
 	case state.diverged != nil:
 		d := state.diverged
-		return fmt.Sprintf("code_agent_replay_divergence: tool call #%d was %q on a prior turn but %q on replay — non-deterministic control flow; set LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1 or remove unhooked non-determinism", d.idx, d.expected, d.got)
+		return fmt.Sprintf("code_agent_replay_divergence: tool call #%d was %q on a prior turn but %q on replay — non-deterministic control flow or serialization. Common causes: an unhooked clock/RNG source (try LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1), OR serializing an object with non-deterministic key/iteration order into a tool input (loomcycle sorts input.metadata keys, but normalize any OTHER object to a fixed key order before JSON.stringify — DETERMINISTIC=1 does NOT fix key-order divergence)", d.idx, d.expected, d.got)
 	case cause == causeCancel:
 		// Parent/operator cancellation (the ctx.Done branch of interruptWatch).
 		// ctx.Err() is non-nil here since that branch only fires after ctx.Done.
@@ -350,6 +351,45 @@ func buildInput(req providers.Request, meta providers.RunMeta) map[string]any {
 		out["payload_metadata"] = meta.PayloadMetadata
 	}
 	return out
+}
+
+// stableJSValue converts a Go value into a goja value with DETERMINISTIC key
+// order: every map is materialized as a JS object whose properties are inserted
+// in sorted-key order. This is load-bearing for the replay model. The input
+// tree carries caller metadata as Go map[string]any (decoded from JSON, where
+// original key order is already lost); goja's default rt.ToValue iterates a Go
+// map in Go's randomized iteration order, so the SAME metadata produced a JS
+// object with a DIFFERENT key order on each Call/runtime build. An agent that
+// JSON.stringify(s) input.metadata into a tool_use input then emitted
+// byte-different bytes turn-1 vs replay → spurious code_agent_replay_divergence
+// (observed in the JobEmber ats-filter-batch orchestrator, 2026-06). Note
+// LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1 does NOT help — it pins the RNG/clock,
+// not Go-map order. Sorting keys here makes input.* byte-stable across turns so
+// no chunk-in-JS agent has to normalize its own serialization. Arrays keep
+// their order (slices are ordered); only maps are reordered. JS objects are
+// insertion-ordered, so sorted insertion yields a sorted, stable iteration.
+func stableJSValue(rt *goja.Runtime, v any) goja.Value {
+	switch t := v.(type) {
+	case map[string]any:
+		obj := rt.NewObject()
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			_ = obj.Set(k, stableJSValue(rt, t[k]))
+		}
+		return obj
+	case []any:
+		elems := make([]any, len(t))
+		for i, e := range t {
+			elems[i] = stableJSValue(rt, e)
+		}
+		return rt.NewArray(elems...)
+	default:
+		return rt.ToValue(v)
+	}
 }
 
 // latestUserText concatenates the text blocks of the most recent user-role


### PR DESCRIPTION
Closes a latent **replay-determinism gap** in the code-js provider, surfaced by the JobEmber `ats-filter-batch` orchestrator (a real `code_agent_replay_divergence` that vitest couldn't catch — only end-to-end-against-the-sidecar did).

## Root cause (loomcycle boundary, not just the agent)
The replay model rebuilds the goja runtime every turn and re-converts the run's metadata (`map[string]any`) to `input.metadata` via `rt.ToValue`. **Go randomizes map iteration order per access**, so the same metadata yielded a different JS key order each turn. An agent that `JSON.stringify`s `input.metadata` into a tool_use input emitted byte-different bytes turn-1 vs replay → the divergence guard fired on tool call #0. This breaks the provider's "deterministic by construction" promise at the metadata boundary, and **`LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1` does NOT fix it** (pins RNG+clock only).

## Fix
`stableJSValue()` recursively materializes every map as a JS object with **sorted keys** (arrays keep order; only maps reorder). JS objects are insertion-ordered, so sorted insertion → byte-stable serialization across turns for `input.metadata` / `input.payload_metadata` / nested objects. **No agent has to normalize its own serialization anymore.** Values + reserved-key precedence (`user_id`/`agent`) unchanged; only output key *order* becomes deterministic (it was already non-deterministic, so nothing could rely on it).

Also fixed the `code_agent_replay_divergence` message, which wrongly implied `DETERMINISTIC=1` fixes everything — it now names non-deterministic serialization key order as a distinct cause.

## Tested
`TestStableJSValue_{MetadataKeysSorted, NestedObjectKeysSorted, ArrayOfObjectsKeysSorted, StableAcrossRuntimeBuilds}` — **fail-before verified** (reverting to `rt.ToValue` → keys unsorted/unstable, all fail). `go build`/`vet`/`gofmt`/full `go test ./...` clean.

## Relationship to the JobEmber-side fix
JobEmber already fixed its `ats-filter-batch` agent-side (commit 13832fd, PR #117) by normalizing to a fixed-key literal — correct defense-in-depth. This is the **systemic cure** so future chunk-in-JS code-js agents don't have to know the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)