### PR TITLE
fix(authz): resolve run agent at its tenant on every run path (RFC N BUG-1, QA NO-GO)

### DIFF
--- a/internal/api/http/resolveagent_tenant_test.go
+++ b/internal/api/http/resolveagent_tenant_test.go
@@ -1,0 +1,93 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestResolveAgent_TenantScopedDynamicAgentRunnable is the regression for BUG-1
+// (RFC N runtime QA, 2026-06-04): the provider/model resolution gate
+// (resolveAgent) re-looked-up the agent at tenant "" (context.Background)
+// instead of the run's tenant, so a tenant-scoped DYNAMIC agent was unrunnable
+// via POST /v1/runs ("unknown agent") — even though the entry def lookup was
+// tenant-correct. Here "probe" exists ONLY as a dynamic agent registered under
+// tenant "acme" (no static def). Open mode (no auth token) makes the wire
+// tenant_id the effective tenant, so we drive the two tenants directly.
+//
+// Fail-before: revert resolveAgent's body to look up at "" → the acme run
+// returns "unknown agent" and this test fails.
+func TestResolveAgent_TenantScopedDynamicAgentRunnable(t *testing.T) {
+	cfg := &config.Config{
+		Defaults:    config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents:      map[string]config.AgentDef{}, // NO static "probe"
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = "" // open mode → wire tenant_id is authoritative
+
+	prov := &scriptedProvider{defaultS: []providers.Event{
+		{Type: providers.EventText, Text: "probe ran"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "resolveagent_tenant.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	// "probe" registered ONLY under tenant "acme".
+	probeDef, _ := json.Marshal(config.AgentDef{Model: "stub-model", AllowedTools: []string{}, SystemPrompt: "probe"})
+	if err := st.DynamicAgentUpsert(context.Background(), store.DynamicAgent{
+		TenantID: "acme", Name: "probe", Definition: probeDef, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	run := func(tenant string) (int, string) {
+		body := `{"agent":"probe","tenant_id":"` + tenant + `","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post(%s): %v", tenant, err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(b)
+	}
+
+	// acme: the tenant that OWNS "probe" → the run executes (no "unknown agent").
+	code, out := run("acme")
+	if strings.Contains(out, "unknown agent") {
+		t.Errorf("BUG-1: tenant-owned dynamic agent reported unknown agent (status=%d):\n%s", code, out)
+	}
+	if !strings.Contains(out, "probe ran") {
+		t.Errorf("acme: expected the probe run to execute (status=%d):\n%s", code, out)
+	}
+
+	// globex: must NOT resolve acme's tenant-scoped agent.
+	if _, out := run("globex"); !strings.Contains(out, "unknown agent") {
+		t.Errorf("globex: expected 'unknown agent' (cross-tenant isolation), got:\n%s", out)
+	}
+
+	// shared "" tenant: must NOT resolve acme's tenant-scoped agent.
+	if _, out := run(""); !strings.Contains(out, "unknown agent") {
+		t.Errorf("shared tenant: expected 'unknown agent', got:\n%s", out)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -789,10 +789,15 @@ func writeQuotaError(w http.ResponseWriter, err error) {
 // has a user_tiers block; otherwise the resolver operates without an
 // overlay (v0.7.x behaviour). Unknown names are rejected upstream
 // before this is called.
-func (s *Server) resolveAgent(agentName, userTier string) (providerID, model, effort string, err error) {
-	// Boot/background resolution carries no run tenant — use the ctx
-	// tenant (empty here, since context.Background()) → shared/default.
-	def, ok := s.lookupAgent(context.Background(), tenantFromCtx(context.Background()), agentName)
+func (s *Server) resolveAgent(ctx context.Context, tenantID, agentName, userTier string) (providerID, model, effort string, err error) {
+	// RFC N: resolve at the RUN's authoritative tenant (threaded by the
+	// caller — effectiveTenantID / req.TenantID / sess.TenantID), NOT a
+	// ctx-derived or empty tenant. This is the provider/model resolution +
+	// existence gate; resolving at "" here made tenant-scoped DYNAMIC agents
+	// unrunnable via /v1/runs ("unknown agent") even though the entry def
+	// lookup (lookupAgent at the run sites) was already tenant-correct.
+	// "" = shared/default tenant.
+	def, ok := s.lookupAgent(ctx, tenantID, agentName)
 	if !ok {
 		return "", "", "", fmt.Errorf("%w: %s", runner.ErrUnknownAgent, agentName)
 	}
@@ -1313,7 +1318,7 @@ func (s *Server) channelPolicyForAgent(agentDef config.AgentDef) tools.ChannelPo
 // On no-more-candidates the closure returns an error — the loop
 // then surfaces the ORIGINAL provider error to the caller (the
 // fallback path is terminal for this run).
-func (s *Server) fallbackForRun(agentName, userTier string) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
+func (s *Server) fallbackForRun(tenantID, agentName, userTier string) (loop.FallbackPolicy, func(ctx context.Context, failedProvider, failedModel string, cause error) (providers.Provider, string, string, error)) {
 	overlay := s.userTierOverlay(userTier)
 	if overlay == nil || !overlay.FallbackOnError {
 		return loop.FallbackPolicy{}, nil
@@ -1332,11 +1337,12 @@ func (s *Server) fallbackForRun(agentName, userTier string) (loop.FallbackPolicy
 		if s.resolver != nil {
 			s.resolver.MarkStalled(failedProvider, failedModel, cause.Error())
 		}
-		// Re-resolve with the same agent + user_tier. The resolver's
-		// stall flag we just set excludes the failed pair; the next
-		// non-stalled candidate in the user_tier's priority is what
+		// Re-resolve with the same agent + user_tier at the run's tenant
+		// (RFC N — captured tenantID, not a ctx-derived/empty tenant). The
+		// resolver's stall flag we just set excludes the failed pair; the
+		// next non-stalled candidate in the user_tier's priority is what
 		// we get back.
-		newProviderID, newModel, newEffort, err := s.resolveAgent(agentName, userTier)
+		newProviderID, newModel, newEffort, err := s.resolveAgent(ctx, tenantID, agentName, userTier)
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -1667,7 +1673,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 
 	heartbeat := s.makeHeartbeat(runID)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(effectiveAgentName, in.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveAgentName, in.UserTier)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -2528,11 +2534,16 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// RFC N: existence-check the agent at this handler's authoritative
-	// tenant. On an authed HTTP route the principal is on ctx, so
-	// tenantFromCtx returns the principal's tenant (the same value
-	// applyPrincipal below resolves into req.TenantID) — never the wire.
-	agentDef, ok := s.lookupAgent(r.Context(), tenantFromCtx(r.Context()), req.Agent)
+	// RFC L/N: resolve the authoritative identity FIRST (principal over the
+	// wire on authed routes; the wire value on open/un-authed paths), so the
+	// existence-check + ALL downstream resolution use req.TenantID and agree
+	// in BOTH modes. A pre-applyPrincipal check at tenantFromCtx returned ""
+	// in open mode while the run used the wire tenant — rejecting a
+	// tenant-scoped dynamic agent as "unknown agent" (RFC N runtime QA BUG-1).
+	req.TenantID, req.UserID = s.applyPrincipal(r.Context(), req.TenantID, req.UserID)
+
+	// Existence-check the agent at the run's authoritative tenant.
+	agentDef, ok := s.lookupAgent(r.Context(), req.TenantID, req.Agent)
 	if !ok {
 		http.Error(w, fmt.Sprintf("unknown agent %q", req.Agent), http.StatusBadRequest)
 		return
@@ -2568,15 +2579,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		req.ParentContext = nil
 	}
 
-	// RFC L: on authenticated routes the resolved principal is
-	// authoritative over the caller-asserted wire tenant_id/user_id
-	// (Decision 5). Overriding them here makes the fairness key (the
-	// AcquireForUser call below), the session's tenant, the run-row
-	// attribution, and the threaded RunIdentity all authority-derived in
-	// one place. Open/un-authed paths leave the wire values unchanged.
-	req.TenantID, req.UserID = s.applyPrincipal(r.Context(), req.TenantID, req.UserID)
-
-	providerID, model, effort, err := s.resolveAgent(req.Agent, req.UserTier)
+	// (req.TenantID / req.UserID were made authoritative above via
+	// applyPrincipal — fairness key, session tenant, run-row attribution,
+	// and threaded RunIdentity all derive from them.)
+	providerID, model, effort, err := s.resolveAgent(r.Context(), req.TenantID, req.Agent, req.UserTier)
 	if err != nil {
 		http.Error(w, err.Error(), resolveErrorToStatus(err))
 		return
@@ -2855,7 +2861,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// minutes → presumed dead). Cheap (~10–100 calls per run).
 	heartbeat := s.makeHeartbeat(runID)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(req.Agent, req.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.Agent, req.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -3027,7 +3033,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	if body.ParentContext.IsZero() {
 		body.ParentContext = nil
 	}
-	providerID, model, effort, err := s.resolveAgent(sess.Agent, body.UserTier)
+	providerID, model, effort, err := s.resolveAgent(r.Context(), sess.TenantID, sess.Agent, body.UserTier)
 	if err != nil {
 		http.Error(w, err.Error(), resolveErrorToStatus(err))
 		return
@@ -3240,7 +3246,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
 	loopCtx = tools.WithRunID(loopCtx, run.ID)
 	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
-	fbPolicy, fbReResolve := s.fallbackForRun(sess.Agent, body.UserTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
@@ -3879,7 +3885,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 
-	fbPolicy, fbReResolve := s.fallbackForRun(name, parentTier)
+	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), name, parentTier)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
 		Provider:        provider,
 		Model:           model,


### PR DESCRIPTION
Fixes **BUG-1** from the RFC N multi-tenant runtime QA (the NO-GO): tenant-scoped **dynamic** agents were unrunnable via `POST /v1/runs` — "unknown agent" — even though the entry def lookup was already tenant-correct.

## Root cause
The RFC N agents slice threaded tenant into the entry `lookupAgent`, but **three other agent-resolution sites still resolved at tenant `""`**:
- `resolveAgent` (provider/model resolution + existence gate) hardcoded `lookupAgent(context.Background(), tenantFromCtx(context.Background()))` → always `""`.
- `fallbackForRun`'s re-resolve closure called `resolveAgent` with no tenant.
- `handleRuns`' existence pre-check ran `tenantFromCtx(r.Context())` **before** `applyPrincipal`, so in open mode it saw `""` while the run used the wire `tenant_id`.

## Fix
- `resolveAgent(ctx, tenantID, …)` and `fallbackForRun(tenantID, …)` take the run's tenant explicitly.
- Threaded the authoritative tenant at every caller: `effectiveTenantID` (RunOnce), `req.TenantID` (handleRuns), `sess.TenantID` (handleMessages), `tenantFromCtx(ctx)` (runSubAgent — parent tenant via RunIdentity).
- `handleRuns` now runs `applyPrincipal` **first**, so the existence-check + `resolveAgent` use `req.TenantID` consistently in **authed and open** mode.
- Untouched (already correct): `handleMessages` existence-check (`sess.TenantID`); RunOnce (`resolveAgentDef` with the tenant-correct def).

## Tested
`TestResolveAgent_TenantScopedDynamicAgentRunnable` — a dynamic agent registered only under tenant `acme` runs via `/v1/runs` as acme, and is "unknown agent" to `globex` and the shared `""` tenant. **Fail-before verified** (acme run returned "unknown agent"). `go build`/`vet`/`gofmt`/full `go test ./...` clean.

## Context
Found by the separate RFC N runtime-isolation QA session. No cross-tenant *leak* was found (isolation holds); this is the inverse — a tenant couldn't reach its OWN dynamic agent. Off `main`, independent of the code-js determinism fix (#366).

🤖 Generated with [Claude Code](https://claude.com/claude-code)