### PR TITLE
fix(authz): handleRuns resolves skills + MCP at req.TenantID (re-land #367 follow-up)

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2637,10 +2637,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	defer release()
 
 	// Filter tools by agent allowlist + caller request.
-	// RFC N FIX 2-mcp: advertise at this handler's authoritative tenant. On
-	// an authed HTTP route the principal is on ctx, so tenantFromCtx returns
-	// the principal's tenant (never the wire).
-	allowedTools := filterTools(s.candidateTools(r.Context(), tenantFromCtx(r.Context())), agentDef.AllowedTools, req.AllowedTools)
+	// RFC N: advertise at the run's authoritative tenant. Use req.TenantID
+	// (made authoritative by applyPrincipal above), NOT tenantFromCtx — the
+	// two agree on authed routes but diverge in open mode (tenantFromCtx=""
+	// vs the wire tenant), which would advertise the wrong tenant's MCP tools
+	// for an open-mode run. Consistent with the agent existence-check +
+	// resolveAgent on this path.
+	allowedTools := filterTools(s.candidateTools(r.Context(), req.TenantID), agentDef.AllowedTools, req.AllowedTools)
 	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
 	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
 	// doc comment. In caller-authoritative mode we ALWAYS call so the
@@ -2667,11 +2670,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	dispatcher := s.newDispatcher(allowedTools)
 
 	// v0.8.22: rebuild SystemPrompt from per-run SkillDef bodies.
-	// RFC N: resolve at this handler's authoritative tenant. On an authed
-	// HTTP route the principal is on ctx, so tenantFromCtx returns the
-	// principal's tenant (the same value applyPrincipal resolves) — never
-	// the wire. Mirrors the lookupAgent existence-check above.
-	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), tenantFromCtx(r.Context()), agentDef)
+	// RFC N: resolve skills at the run's authoritative tenant — req.TenantID
+	// (authed: == principal; open: == wire), NOT tenantFromCtx, so an
+	// open-mode run resolves its tenant-scoped skills instead of "". Mirrors
+	// the agent existence-check + resolveAgent on this path.
+	agentDef, promptProv := s.resolveSkillBodiesForRun(r.Context(), req.TenantID, agentDef)
 	// Optional system prompt from agent def.
 	if agentDef.SystemPrompt != "" {
 		req.Segments = append([]loop.PromptSegment{{


### PR DESCRIPTION
**Recovery** — re-lands the second commit of #367, which was orphaned: #367 squash-merged **only its first commit** (the `resolveAgent` BUG-1 fix) before I pushed the follow-up `037796b`, so that follow-up never reached `main`. Verified: `main` still had **2 leftover `tenantFromCtx(r.Context())`** in `handleRuns` (the skill + MCP resolution calls).

This is a clean `git cherry-pick 037796b` onto `main` (original authorship + message preserved); applied with no conflict, 0 leftover `tenantFromCtx` in the handlers afterward.

## What it does (unchanged from the #367 follow-up)
`handleRuns` resolved its agent existence-check + `resolveAgent` at `req.TenantID` (authoritative after `applyPrincipal`), but its **skill** (`resolveSkillBodiesForRun`) and **MCP advertising** (`candidateTools`) calls still used `tenantFromCtx(r.Context())`. Authed routes agree (principal tenant == `req.TenantID`), but **open mode diverges** (`""` vs the wire tenant) — the BUG-1 class for the skill/MCP planes. Both now use `req.TenantID`, so the whole `handleRuns` path resolves agent + skills + MCP at one consistent authoritative tenant in authed **and** open mode. `handleMessages` already used `sess.TenantID`; `runSubAgent` uses `tenantFromCtx(ctx)` (parent run ctx). No behaviour change on authed routes or the shared `""` tenant.

`go build`/`vet`/`gofmt`/full `go test ./...` clean.

> Process note: this is the orphaned-commit symptom again — a multi-commit PR squash-merged before a later-pushed commit landed. The post-merge `grep` check caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)