### PR TITLE
fix(store): scan nullable operator-token columns as NullString on Postgres [HIGH/prod]

### DIFF
--- a/internal/store/postgres/operator_token.go
+++ b/internal/store/postgres/operator_token.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,14 +29,29 @@ func scanOperatorTokenDef(row pgx.Row) (store.OperatorTokenDefRow, error) {
 		out        store.OperatorTokenDefRow
 		scopesJSON string
 		retiredAt  *time.Time
+		// created_by_agent_id / created_by_run_id / rotated_from are
+		// NULLABLE columns (the CREATE path writes NULL via nullableString
+		// when empty — e.g. a token minted through the HTTP/CLI admin path
+		// has no run context, so created_by_run_id is NULL). They MUST scan
+		// into sql.NullString; scanning a NULL into a plain *string fails
+		// with "cannot scan NULL into *string", which on the auth hot path
+		// (OperatorTokenDefGetByTokenHash) takes down token resolution for
+		// every such token on Postgres. (SQLite already scanned these as
+		// sql.NullString — this restores backend parity.)
+		agentID sql.NullString
+		runID   sql.NullString
+		rotated sql.NullString
 	)
 	if err := row.Scan(
 		&out.DefID, &out.Name, &out.TenantID, &out.Subject, &out.TokenHash,
-		&scopesJSON, &out.CreatedAt, &out.CreatedByAgentID, &out.CreatedByRunID,
-		&out.RotatedFrom, &retiredAt,
+		&scopesJSON, &out.CreatedAt, &agentID, &runID,
+		&rotated, &retiredAt,
 	); err != nil {
 		return store.OperatorTokenDefRow{}, err
 	}
+	out.CreatedByAgentID = agentID.String
+	out.CreatedByRunID = runID.String
+	out.RotatedFrom = rotated.String
 	if err := json.Unmarshal([]byte(scopesJSON), &out.AllowedScopes); err != nil {
 		return store.OperatorTokenDefRow{}, fmt.Errorf("operator_token_def: decode allowed_scopes: %w", err)
 	}


### PR DESCRIPTION
## Severity: HIGH — operator-token auth broken on Postgres (the production backend)

## Why

The Postgres `scanOperatorTokenDef` scanned `created_by_agent_id`, `created_by_run_id`, and `rotated_from` directly into `*string`. The CREATE path writes **NULL** for those when empty (`nullableString`), and a token minted via the **HTTP/CLI admin path has no run context → `created_by_run_id` is NULL**. pgx then fails the scan with:

```
auth: token-substrate lookup error (failing closed): can't scan into dest[8]
  (col: created_by_run_id): cannot scan NULL into *string
```

On the auth hot path (`OperatorTokenDefGetByTokenHash`) this takes down resolution for **every such token** — the request fails closed with **401**. Net: **operator tokens minted through the normal admin path are unusable on Postgres**, so RFC L multi-tenant auth — and the RFC N tenant-scoped definition plane that app tokens drive — is broken on the production backend. The legacy `LOOMCYCLE_AUTH_TOKEN` keeps working (it's a `CompareBearer`, not a row scan), which masked the issue (BOOT→first-admin-mint succeeds, then that admin token can't authenticate to do anything).

Found in the RFC N **Postgres** QA re-run (production-path follow-up). SQLite was unaffected — its `scanOperatorTokenDef` already uses `sql.NullString`; this restores backend parity.

**Why CI missed it:** the `storetest` contract only runs on Postgres when `LOOMCYCLE_TEST_PG_DSN` is set (CI runs SQLite). The contract's `testOperatorTokenDefCreateAndLookup` — which creates a row with a NULL `created_by_run_id` then calls `GetByTokenHash` — **is** the fail-before/pass-after regression: it fails on PG before this fix, passes after.

## What

Scan the three nullable columns into `sql.NullString` and copy `.String` into the row — mirroring the SQLite adapter.

## Tested

- `go build ./...` clean.
- `LOOMCYCLE_TEST_PG_DSN=… go test ./internal/store/postgres/ -run 'StoreContract/OperatorTokenDef'` → all 4 subtests **PASS** (were failing on the NULL scan).
- End-to-end on Postgres: operator tokens now authenticate; the RFC N tenant-isolation runtime matrix passes on PG (BUG-1/#1 execution isolation, #3/#6/#7/#8/#9/#11 all green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)