### PR TITLE
fix(authz): substrate:admin crosses tenants on def get/list (Web UI library bodies)

### DIFF
--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/agents"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/providers/codejs"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -165,6 +166,20 @@ func (a *AgentDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 }
 
 // ---- create ----
+
+// defCallerIsAdmin reports whether the ctx principal holds substrate:admin —
+// the super-admin who crosses tenant boundaries BY DESIGN (RFC L, mirroring
+// sessionOwnershipOK / tenantVisible). The def-tool read guards consult it so
+// the role-aware Web UI library (admin) can view EVERY tenant's def bodies
+// (the get/list ops back the library + lineage panel), while a non-admin
+// (tenant-scoped) caller — e.g. an agent calling AgentDef.list mid-run — still
+// sees only its own tenant. Without this, an admin viewing the library got
+// empty bodies for every def outside its own principal tenant (notably the
+// shared "" tenant where bootstrapped/legacy defs live).
+func defCallerIsAdmin(ctx context.Context) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	return ok && auth.HasScope(p.Scopes, auth.ScopeAdmin)
+}
 
 func (a *AgentDef) execCreate(ctx context.Context, policy tools.AgentDefPolicyValue, in agentDefInput) (tools.Result, error) {
 	if in.Name == "" {
@@ -425,7 +440,7 @@ func (a *AgentDef) execGet(ctx context.Context, policy tools.AgentDefPolicyValue
 	// in tenant T cannot read another tenant's def. Return the SAME opaque
 	// not-found a missing def returns — never leak existence/body of a
 	// cross-tenant row.
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
 	}
 	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {
@@ -451,7 +466,7 @@ func (a *AgentDef) execList(ctx context.Context, policy tools.AgentDefPolicyValu
 	tenantID := tools.RunIdentity(ctx).TenantID
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
-		if r.TenantID != tenantID {
+		if !defCallerIsAdmin(ctx) && r.TenantID != tenantID {
 			continue
 		}
 		out = append(out, rowResponseMap(r))
@@ -479,7 +494,7 @@ func (a *AgentDef) execRetire(ctx context.Context, policy tools.AgentDefPolicyVa
 	// RFC N: refuse cross-tenant retire. AgentDefSetRetired is a global
 	// by-def_id mutation; without this guard a caller in tenant T could
 	// retire another tenant's def. Opaque not-found — don't leak existence.
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := a.checkScopeForName(policy, row.Name, row.DefID); err != nil {

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -423,6 +424,51 @@ func TestAgentDefTool_TenantIsolationGetListRetire(t *testing.T) {
 	}
 	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
 		t.Errorf("tenant B list returned %d versions; want 1", n)
+	}
+}
+
+// TestAgentDefTool_AdminCrossesTenantsGetList pins the RFC L invariant that a
+// substrate:admin principal crosses tenant boundaries on the def-tool READ ops
+// (get/list) — the regression behind "agent/skill/MCP bodies not visible in the
+// Web UI library": the role-aware library is an admin surface, but the get/list
+// ops (which back the lineage panel's def bodies) tenant-filtered with no admin
+// bypass, so an admin whose principal tenant differed from the def's tenant
+// (notably the shared "" tenant where bootstrapped/legacy defs live) saw empty
+// bodies. A NON-admin principal must still be tenant-scoped.
+func TestAgentDefTool_AdminCrossesTenantsGetList(t *testing.T) {
+	tool, baseCtx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// A def owned by tenant-b.
+	ctxB := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-b"})
+	res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"create","name":"b-only","overlay":{"system_prompt":"tenant b body"}}`))
+	if res.IsError {
+		t.Fatalf("create under B: %s", res.Text)
+	}
+	defID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// substrate:admin principal in a DIFFERENT tenant must SEE tenant-b's def.
+	ctxAdmin := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "ops"})
+	ctxAdmin = auth.WithPrincipal(ctxAdmin, auth.Principal{TenantID: "ops", Subject: "op", Scopes: []string{auth.ScopeAdmin}})
+
+	res, _ = tool.Execute(ctxAdmin, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if res.IsError {
+		t.Errorf("admin get of another tenant's def should succeed (admin crosses tenants); got %s", res.Text)
+	}
+	res, _ = tool.Execute(ctxAdmin, json.RawMessage(`{"op":"list","name":"b-only"}`))
+	if res.IsError {
+		t.Fatalf("admin list: %s", res.Text)
+	}
+	if n := len(decodeResult(t, res.Text)["versions"].([]any)); n != 1 {
+		t.Errorf("admin list should see tenant-b's version across tenants; got %d", n)
+	}
+
+	// Control: a NON-admin principal in "ops" still cannot see tenant-b's def.
+	ctxNon := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "ops"})
+	ctxNon = auth.WithPrincipal(ctxNon, auth.Principal{TenantID: "ops", Subject: "op", Scopes: []string{auth.ScopeRunsCreate}})
+	res, _ = tool.Execute(ctxNon, json.RawMessage(`{"op":"get","def_id":"`+defID+`"}`))
+	if !res.IsError {
+		t.Errorf("non-admin cross-tenant get should be refused; got %s", res.Text)
 	}
 }
 

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -417,7 +417,7 @@ func (m *MCPServerDef) execGet(ctx context.Context, in mcpServerDefInput) (tools
 	// a caller in tenant T cannot read another tenant's def. Return the SAME
 	// opaque not-found a missing def returns — never leak existence/body of a
 	// cross-tenant row.
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
 	}
 	return okJSON(mcpServerDefRowResponseMap(row))
@@ -435,7 +435,7 @@ func (m *MCPServerDef) execList(ctx context.Context, in mcpServerDefInput) (tool
 		}
 		out := make([]map[string]any, 0, len(rows))
 		for _, r := range rows {
-			if r.TenantID != tenantID {
+			if !defCallerIsAdmin(ctx) && r.TenantID != tenantID {
 				continue
 			}
 			out = append(out, mcpServerDefRowResponseMap(r))
@@ -451,7 +451,7 @@ func (m *MCPServerDef) execList(ctx context.Context, in mcpServerDefInput) (tool
 	}
 	out := make([]store.MCPServerDefNameSummary, 0, len(summaries))
 	for _, s := range summaries {
-		if s.TenantID != tenantID {
+		if !defCallerIsAdmin(ctx) && s.TenantID != tenantID {
 			continue
 		}
 		out = append(out, s)
@@ -482,7 +482,7 @@ func (m *MCPServerDef) execRetire(ctx context.Context, in mcpServerDefInput) (to
 	// client). Opaque not-found — don't leak existence. After this guard
 	// row.TenantID == the caller's tenant, so the Registry.Remove /
 	// Pool.Evict below stay keyed to the caller's own (tenant, name).
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := m.Store.MCPServerDefSetRetired(ctx, in.DefID, *in.Retired); err != nil {

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -400,7 +400,7 @@ func (s *SkillDef) execGet(ctx context.Context, policy tools.SkillDefPolicyValue
 	// in tenant T cannot read another tenant's def. Return the SAME opaque
 	// not-found a missing def returns — never leak existence/body of a
 	// cross-tenant row.
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("get: def_id %q not found", in.DefID)), nil
 	}
 	if err := s.checkScopeForName(policy, row.Name, row.DefID); err != nil {
@@ -426,7 +426,7 @@ func (s *SkillDef) execList(ctx context.Context, policy tools.SkillDefPolicyValu
 	tenantID := tools.RunIdentity(ctx).TenantID
 	out := make([]map[string]any, 0, len(rows))
 	for _, r := range rows {
-		if r.TenantID != tenantID {
+		if !defCallerIsAdmin(ctx) && r.TenantID != tenantID {
 			continue
 		}
 		out = append(out, skillDefRowResponseMap(r))
@@ -454,7 +454,7 @@ func (s *SkillDef) execRetire(ctx context.Context, policy tools.SkillDefPolicyVa
 	// RFC N: refuse cross-tenant retire. SkillDefSetRetired is a global
 	// by-def_id mutation; without this guard a caller in tenant T could
 	// retire another tenant's def. Opaque not-found — don't leak existence.
-	if row.TenantID != tools.RunIdentity(ctx).TenantID {
+	if !defCallerIsAdmin(ctx) && row.TenantID != tools.RunIdentity(ctx).TenantID {
 		return errResult(fmt.Sprintf("retire: def_id %q not found", in.DefID)), nil
 	}
 	if err := s.checkScopeForName(policy, row.Name, row.DefID); err != nil {


### PR DESCRIPTION
**Fixes: agent / skill / MCP-tool bodies not visible in the Web UI library since the RFC N tenancy updates.**

## Root cause
The role-aware library is an **admin** surface. It lists names via the (unfiltered) `/v1/_library/*` endpoints, but a def's **body** is fetched via the `AgentDef`/`SkillDef`/`MCPServerDef` **`list` op** (lineage panel) / **`get` op**. The RFC N adversarial-review fix added a tenant filter to those read ops (`row.TenantID != RunIdentity(ctx).TenantID`) **with no `substrate:admin` bypass**.

RFC L's design is that a **super-admin crosses tenant boundaries** (`sessionOwnershipOK` / `tenantVisible` already do). So an admin whose principal tenant differs from a def's tenant — notably the shared `""` tenant where **bootstrapped/legacy defs live** — got opaque `not found` on `get` and empty `versions[]` on `list` → **no body rendered**. (Open-mode / single-tenant deployments were unaffected, which is why it only showed up with the role-aware/authed UI.)

## Fix
Add `defCallerIsAdmin(ctx)` (principal holds `substrate:admin`) and skip the tenant filter on `get`/`list`/`retire` for admins, across all three def tools. A **non-admin (tenant-scoped) caller — e.g. an agent calling `AgentDef.list` mid-run — is unchanged** (still sees only its own tenant). This restores the admin exemption the rest of RFC L already has.

## Tested
`TestAgentDefTool_AdminCrossesTenantsGetList` — **fail-before verified** (admin got `not-found`/empty without the bypass; the non-admin control is still refused). Existing `*TenantIsolationGetListRetire` tests still pass (they carry no principal → not admin → tenant filter applies). `go build`/`vet`/`gofmt`/full `go test ./...` clean.

## Note
This is read-side (`get`/`list` back the library bodies; `retire` also bypassed for consistency). Cross-tenant **promote** by an admin is still blocked at the store level for agent/skill (a deeper, separate consideration — not part of this regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)