### PR TITLE
fix(authz): allow forking the shared "" base across tenants (unblocks def migration)

### DIFF
--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -318,10 +318,16 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		if row.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
 		}
-		// A def_id is a global handle; refuse to fork across the tenant
-		// boundary — a caller in tenant T can't pin another tenant's def
-		// as its parent (which would copy that tenant's body into T).
-		if row.TenantID != tenantID {
+		// A def_id is a global handle. A caller may fork the SHARED ("")
+		// base — the common ground every tenant builds on (e.g. migrate a
+		// pre-RFC-N / bootstrapped def to code-js) — or its OWN tenant's def;
+		// the fork lands under the caller's tenant. Refuse only forking
+		// ANOTHER specific tenant's private def (which would copy that
+		// tenant's body across the boundary), unless the caller is a
+		// substrate:admin (crosses tenants by design, RFC L). Without the ""
+		// allowance, a legacy/default or tenant principal could not fork the
+		// shared base at all.
+		if row.TenantID != "" && row.TenantID != tenantID && !defCallerIsAdmin(ctx) {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to another tenant, refusing", parentDefID)), nil
 		}
 		parent = row

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -472,6 +472,48 @@ func TestAgentDefTool_AdminCrossesTenantsGetList(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_ForkFromSharedBaseAllowed pins the regression behind
+// "job-search-batch never migrated to code-js": the RFC N cross-tenant fork
+// guard refused forking the SHARED ("") base, so an authenticated principal
+// (legacy "default" or any tenant — never "" once auth is on) could not fork a
+// pre-RFC-N / bootstrapped def (which lives at "") to migrate it (e.g. to
+// code-js). Forking the shared base must succeed (it lands under the caller's
+// tenant); forking ANOTHER specific tenant's private def stays refused.
+func TestAgentDefTool_ForkFromSharedBaseAllowed(t *testing.T) {
+	tool, baseCtx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// A def owned by the SHARED "" tenant (the pre-RFC-N / bootstrapped shape).
+	ctxShared := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: ""})
+	res, _ := tool.Execute(ctxShared, json.RawMessage(`{"op":"create","name":"shared-base","overlay":{"system_prompt":"v1"}}`))
+	if res.IsError {
+		t.Fatalf("create shared base: %s", res.Text)
+	}
+	sharedID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// A "default"-tenant principal forks the shared base by def_id → must
+	// SUCCEED (was refused "belongs to another tenant").
+	ctxDefault := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "default"})
+	res, _ = tool.Execute(ctxDefault, json.RawMessage(`{"op":"fork","name":"shared-base","parent_def_id":"`+sharedID+`","overlay":{"system_prompt":"v2"}}`))
+	if res.IsError {
+		t.Fatalf(`fork of the shared ("") base as tenant "default" should succeed; got %s`, res.Text)
+	}
+
+	// Control: forking ANOTHER specific tenant's PRIVATE def is still refused
+	// for a non-admin caller (cross-tenant isolation preserved).
+	ctxB := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-b"})
+	res, _ = tool.Execute(ctxB, json.RawMessage(`{"op":"create","name":"b-priv","overlay":{"system_prompt":"b"}}`))
+	if res.IsError {
+		t.Fatalf("create b-priv: %s", res.Text)
+	}
+	bID := decodeResult(t, res.Text)["def_id"].(string)
+	ctxA := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tenant-a"})
+	res, _ = tool.Execute(ctxA, json.RawMessage(`{"op":"fork","name":"b-priv","parent_def_id":"`+bID+`","overlay":{"system_prompt":"x"}}`))
+	if !res.IsError {
+		t.Errorf("forking another tenant's PRIVATE def should still be refused; got %s", res.Text)
+	}
+}
+
 // Capability-escalation guard on `create`: an agent with narrow
 // allowed_tools cannot mint a new agent with a wider tool surface
 // than its own. The caller's effective AgentTools(ctx) is the

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -323,9 +323,12 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		if parent.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, parent.Name, in.Name)), nil
 		}
-		// RFC N: a fork stays within its own tenant — refuse a parent that
-		// belongs to a different tenant (no cross-tenant lineage / leak).
-		if parent.TenantID != tenantID {
+		// RFC N: a fork may pin the SHARED ("") base or the caller's own
+		// tenant (it lands under the caller's tenant); refuse only another
+		// specific tenant's private def, unless the caller is substrate:admin
+		// (crosses tenants, RFC L). The "" allowance lets a legacy/default or
+		// tenant principal migrate a pre-RFC-N / bootstrapped shared def.
+		if parent.TenantID != "" && parent.TenantID != tenantID && !defCallerIsAdmin(ctx) {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to tenant %q, refusing to fork under tenant %q", parentDefID, parent.TenantID, tenantID)), nil
 		}
 		parentJSON = string(parent.Definition)

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -284,10 +284,12 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 		if row.Name != in.Name {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q has name %q, refusing to fork under name %q", parentDefID, row.Name, in.Name)), nil
 		}
-		// A def_id is a global handle; refuse to fork across the tenant
-		// boundary — a caller in tenant T can't pin another tenant's def
-		// as its parent (which would copy that tenant's body into T).
-		if row.TenantID != tenantID {
+		// Allow forking the SHARED ("") base or the caller's own tenant (the
+		// fork lands under the caller's tenant); refuse only another specific
+		// tenant's private def, unless the caller is substrate:admin (crosses
+		// tenants, RFC L). The "" allowance lets a legacy/default or tenant
+		// principal migrate a pre-RFC-N / bootstrapped shared def.
+		if row.TenantID != "" && row.TenantID != tenantID && !defCallerIsAdmin(ctx) {
 			return errResult(fmt.Sprintf("fork: parent_def_id %q belongs to another tenant, refusing", parentDefID)), nil
 		}
 		parent = row


### PR DESCRIPTION
**Fixes the confirmed cause of "job-search-batch never migrated to code-js"** (and the class behind "agents migrated after multi-tenant deploy can't update").

## Diagnosis (from the live sidecar DB, not the logs)
The sidecar's SQLite store showed: `LOOMCYCLE_CODE_AGENTS_ENABLED=1` (code agents ON — rules out "code disabled"), and `ats-filter-batch`/`cv-cl-batch`/`employer-research-batch` are all **code-js at tenant `""`**, but **`job-search-batch` has only a v1 LLM def at `""`** — its code-js fork never landed.

Every def is at `""` (single-tenant), yet once auth is on the caller's principal tenant is **never `""`** (legacy = `"default"`, or a named tenant). The RFC N cross-tenant fork guard refused forking any parent whose tenant ≠ the caller's — **including the shared `""` base** — so `execFork` rejected the `""` parent with *"belongs to another tenant."* The three earlier agents escaped because they were forked **before RFC N** (at `""`, no guard); `job-search-batch` migrated **after** → refused. JobEmber's `sync.ts` then masked that refusal as a "lost race" and poisoned its drift marker (a jobs-search-agent-side bug — not this PR).

## Fix
A fork may pin the **shared `""` base** OR the caller's own tenant (it lands under the caller's tenant); refuse only forking **another specific tenant's private def**, unless the caller is `substrate:admin` (crosses tenants, RFC L). Applied to `AgentDef`/`SkillDef`/`MCPServerDef` `execFork`. Cross-tenant isolation is preserved (can't fork tenant B's private def); every tenant can build on the shared base.

## Tested
`TestAgentDefTool_ForkFromSharedBaseAllowed` — forking the `""` base as `"default"` succeeds (**fail-before**: "belongs to another tenant"); forking another tenant's private def stays refused; existing isolation/fork/admin tests pass. `go build`/`vet`/`gofmt`/full `go test ./...` clean.

## On your side (after merge + rebuilt sidecar)
1. Merge + `make build-all`, restart the sidecar.
2. **Clear JobEmber's poisoned drift marker** so its sync retries the fork (the QA's `DELETE FROM agent_def_registry WHERE name IN ('job-search-batch', …)` in `pipeline.db`) — otherwise the next web boot short-circuits to "unchanged".
3. The `sync.ts` refusal-masking + marker-poisoning is a **jobs-search-agent** bug (its own repo/agent) — worth fixing so a genuine refusal surfaces instead of being relabeled "lost race".

Note: the fork lands under the caller's tenant (`"default"`), shadowing the `""` base for that tenant's runs (lookup precedence tenant→static→shared handles it). The deeper legacy-`"default"`-vs-shared-`""` asymmetry is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)