### PR TITLE
fix(agentdef): fork falls back to shared "" base before refusing no-parent

### DIFF
--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -294,13 +294,19 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		return errResult(fmt.Sprintf("fork: name %q invalid (must match [A-Za-z0-9_-]{1,128})", in.Name)), nil
 	}
 
-	// Resolve the parent. Three paths:
+	// Resolve the parent. Paths, in order:
 	//   1. parent_def_id supplied → pin
-	//   2. parent_def_id empty + active pointer exists → use it
-	//   3. neither → name must have a static MD; bootstrap v1
-	//      snapshot as the parent
-	// RFC N: fork resolves + stamps within the agent's own tenant (from
-	// the authoritative run identity, never tool input).
+	//   2. parent_def_id empty + OWN-tenant active pointer → use it
+	//   3. else + a SHARED ("") active pointer (when tenantID != "") →
+	//      fork the shared base into the caller's tenant. Mirrors the
+	//      run-time lookup.Agent precedence (own-tenant → static → shared
+	//      "") and fixes the admin-`list`-sees-it-but-`fork`-can't gap for
+	//      registries seeded under the legacy "" tenant.
+	//   4. neither → name must have a static MD; bootstrap v1 snapshot.
+	// RFC N: fork resolves the parent within the agent's own tenant first
+	// (then the shared "" base), but the new version is ALWAYS stamped under
+	// the caller's own tenant (from the authoritative run identity, never
+	// tool input).
 	ident := tools.RunIdentity(ctx)
 	tenantID := ident.TenantID
 
@@ -332,7 +338,7 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 		}
 		parent = row
 	} else {
-		// Try the active pointer first.
+		// Try the active pointer in the caller's OWN tenant first.
 		row, err := a.Store.AgentDefGetActive(ctx, tenantID, in.Name)
 		if err == nil {
 			parent = row
@@ -342,29 +348,52 @@ func (a *AgentDef) execFork(ctx context.Context, policy tools.AgentDefPolicyValu
 			if !errors.As(err, &nf) {
 				return errResult(fmt.Sprintf("fork: %s", err)), nil
 			}
-			// No active pointer → must bootstrap from static MD.
-			static, ok := a.Cfg.Agents[in.Name]
-			if !ok {
-				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static cfg.Agents entry", in.Name)), nil
-			}
-			bootstrap, berr := a.bootstrapStatic(ctx, in.Name, static)
-			if berr != nil {
-				// A concurrent first-fork may have already bootstrapped
-				// v1 between our AgentDefGetActive check and our own
-				// bootstrap insert. The store's per-name lock guarantees
-				// monotonic versions but our caller has no way to know
-				// "another goroutine just won v1." Re-read the active
-				// pointer once before propagating the error — if it's
-				// now set, use that as our parent instead of failing.
-				if row2, gerr := a.Store.AgentDefGetActive(ctx, tenantID, in.Name); gerr == nil {
-					parent = row2
-					parentDefID = row2.DefID
-				} else {
-					return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+			// No own-tenant active pointer. Before bootstrapping, fall back
+			// to the SHARED ("") base — the same precedence the run-time
+			// resolver walks (lookup.Agent: own-tenant dynamic → static →
+			// shared "" dynamic). Without this, a per-tenant principal whose
+			// registry was seeded under the legacy "" tenant could SEE a name
+			// via the cross-tenant admin `list` yet be unable to fork it:
+			// `list` reports "deployed", fork reports "no parent". Forking the
+			// shared base lands the new version under the CALLER's tenant
+			// (the row stamp below sets TenantID = tenantID), mirroring the
+			// explicit-parent_def_id branch above which already permits
+			// forking the "" base across the boundary. Skip when tenantID is
+			// already "" — that lookup is identical to the one we just did.
+			if tenantID != "" {
+				if shared, serr := a.Store.AgentDefGetActive(ctx, "", in.Name); serr == nil {
+					parent = shared
+					parentDefID = shared.DefID
+				} else if !errors.As(serr, &nf) {
+					return errResult(fmt.Sprintf("fork: %s", serr)), nil
 				}
-			} else {
-				parent = bootstrap
-				parentDefID = bootstrap.DefID
+			}
+			// Still no parent (own-tenant AND shared "" both missed) →
+			// bootstrap from static MD, else refuse.
+			if parentDefID == "" {
+				static, ok := a.Cfg.Agents[in.Name]
+				if !ok {
+					return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version (own tenant or shared \"\") nor a static cfg.Agents entry", in.Name)), nil
+				}
+				bootstrap, berr := a.bootstrapStatic(ctx, in.Name, static)
+				if berr != nil {
+					// A concurrent first-fork may have already bootstrapped
+					// v1 between our AgentDefGetActive check and our own
+					// bootstrap insert. The store's per-name lock guarantees
+					// monotonic versions but our caller has no way to know
+					// "another goroutine just won v1." Re-read the active
+					// pointer once before propagating the error — if it's
+					// now set, use that as our parent instead of failing.
+					if row2, gerr := a.Store.AgentDefGetActive(ctx, tenantID, in.Name); gerr == nil {
+						parent = row2
+						parentDefID = row2.DefID
+					} else {
+						return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+					}
+				} else {
+					parent = bootstrap
+					parentDefID = bootstrap.DefID
+				}
 			}
 		}
 	}

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -111,6 +111,88 @@ func TestAgentDefTool_ForkInheritsParent(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_ForkFallsBackToSharedBase pins the fix for the
+// admin-`list`-sees-it-but-`fork`-can't gap. A per-tenant principal whose
+// registry was seeded under the legacy shared "" tenant (e.g. a jobember
+// substrate:admin whose pre-RFC-N defs all live under "") must be able to fork
+// that "" base WITHOUT an explicit parent_def_id, landing the new version
+// under its OWN tenant. This mirrors run-time lookup.Agent precedence
+// (own-tenant → static → shared "").
+//
+// Regression: on the pre-fix code the no-parent branch jumped straight from
+// the own-tenant active-pointer miss to static cfg.Agents and refused "fork:
+// no parent" — even though the name was visibly deployed under "". Revert the
+// agentdef.go fallback and this fails with that refusal.
+func TestAgentDefTool_ForkFallsBackToSharedBase(t *testing.T) {
+	tool, baseCtx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// Seed a NON-static name under the shared "" tenant — the fixture ctx
+	// carries TenantID="" by default — promoted so it has an "" active
+	// pointer. (Omit allowed_tools so the later fork can't trip the ceiling.)
+	res, _ := tool.Execute(baseCtx, json.RawMessage(`{"op":"create","name":"legacy-seed","overlay":{"system_prompt":"shared base body"}}`))
+	if res.IsError {
+		t.Fatalf("seed create under \"\" tenant: %s", res.Text)
+	}
+	sharedDefID := decodeResult(t, res.Text)["def_id"].(string)
+
+	// A per-tenant principal with NO own-tenant version of the name.
+	ctxTenant := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "jobember"})
+
+	res, _ = tool.Execute(ctxTenant, json.RawMessage(`{"op":"fork","name":"legacy-seed","overlay":{"system_prompt":"tenant override"},"promote":true}`))
+	if res.IsError {
+		t.Fatalf("fork should fall back to the shared \"\" base; got refusal: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["parent_def_id"].(string) != sharedDefID {
+		t.Errorf("forked parent_def_id = %q, want the \"\" base %q", out["parent_def_id"], sharedDefID)
+	}
+	tenantForkDefID := out["def_id"].(string)
+
+	// The new version is stamped under jobember: a non-admin tenant `list`
+	// is tenant-scoped, so jobember sees exactly its own forked version and
+	// NOT the "" base.
+	res, _ = tool.Execute(ctxTenant, json.RawMessage(`{"op":"list","name":"legacy-seed"}`))
+	if res.IsError {
+		t.Fatalf("tenant list after fork: %s", res.Text)
+	}
+	versions := decodeResult(t, res.Text)["versions"].([]any)
+	if len(versions) != 1 {
+		t.Fatalf("jobember list = %d versions, want 1 (its own fork, stamped under jobember)", len(versions))
+	}
+	if versions[0].(map[string]any)["def_id"].(string) != tenantForkDefID {
+		t.Errorf("jobember's only version should be its fork %q", tenantForkDefID)
+	}
+
+	// Own-tenant precedence: a SECOND jobember fork now resolves jobember's
+	// own active pointer as the parent (not the "" base again).
+	res, _ = tool.Execute(ctxTenant, json.RawMessage(`{"op":"fork","name":"legacy-seed","overlay":{"system_prompt":"second tenant rev"},"promote":true}`))
+	if res.IsError {
+		t.Fatalf("second tenant fork: %s", res.Text)
+	}
+	if pid := decodeResult(t, res.Text)["parent_def_id"].(string); pid != tenantForkDefID {
+		t.Errorf("second fork parent = %q, want the prior tenant fork %q (own-tenant precedence)", pid, tenantForkDefID)
+	}
+}
+
+// TestAgentDefTool_ForkNoParentStillRefuses guards that the "" fallback did not
+// soften the genuine no-parent refusal: a tenant principal forking a name with
+// no own-tenant version, no shared "" base, and no static cfg.Agents entry must
+// still be refused.
+func TestAgentDefTool_ForkNoParentStillRefuses(t *testing.T) {
+	tool, baseCtx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	ctxTenant := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "jobember"})
+	res, _ := tool.Execute(ctxTenant, json.RawMessage(`{"op":"fork","name":"never-existed","overlay":{"system_prompt":"x"}}`))
+	if !res.IsError {
+		t.Fatalf("fork of a name with no own/shared/static parent should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "no parent") {
+		t.Errorf("refusal should mention \"no parent\"; got %s", res.Text)
+	}
+}
+
 // ---- RFC J: inline code_body ingestion ----
 
 // Single-quoted JS string so the body embeds cleanly inside the JSON test

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -337,10 +337,25 @@ func (m *MCPServerDef) execFork(ctx context.Context, in mcpServerDefInput) (tool
 		active, err := m.Store.MCPServerDefGetActive(ctx, tenantID, in.Name)
 		if err != nil {
 			var nf *store.ErrNotFound
-			if errors.As(err, &nf) {
+			if !errors.As(err, &nf) {
+				return errResult(fmt.Sprintf("fork: %s", err)), nil
+			}
+			// No own-tenant active row. Fall back to the SHARED ("") base
+			// (mirrors run-time lookup + the explicit-parent branch) so a
+			// per-tenant principal can fork a name seeded under the legacy ""
+			// tenant; the fork lands under the caller's tenant. Skip when
+			// tenantID is already "" (identical lookup).
+			if tenantID == "" {
 				return errResult(fmt.Sprintf("fork: name %q has no DB rows — use `create`", in.Name)), nil
 			}
-			return errResult(fmt.Sprintf("fork: %s", err)), nil
+			shared, serr := m.Store.MCPServerDefGetActive(ctx, "", in.Name)
+			if serr != nil {
+				if errors.As(serr, &nf) {
+					return errResult(fmt.Sprintf("fork: name %q has no DB rows (own tenant or shared \"\") — use `create`", in.Name)), nil
+				}
+				return errResult(fmt.Sprintf("fork: %s", serr)), nil
+			}
+			active = shared
 		}
 		parentDefID = active.DefID
 		parentJSON = string(active.Definition)

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -577,3 +577,24 @@ func TestMCPServerDefTool_TenantIsolationGetListRetirePromote(t *testing.T) {
 		t.Errorf("tenant B list returned %d versions; want 1", n)
 	}
 }
+
+// TestMCPServerDefTool_ForkFallsBackToSharedBase mirrors the AgentDef fix: a
+// by-name fork by a per-tenant principal falls back to the SHARED ("") base
+// when the name has no own-tenant version, so an MCP server seeded under the
+// legacy "" tenant can be migrated without an explicit parent_def_id.
+func TestMCPServerDefTool_ForkFallsBackToSharedBase(t *testing.T) {
+	tool, baseCtx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+
+	ctxShared := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: ""})
+	res, _ := tool.Execute(ctxShared, json.RawMessage(`{"op":"create","name":"jobs","overlay":{"transport":"http","url":"http://localhost:3000/api/mcp"}}`))
+	if res.IsError {
+		t.Fatalf("create shared mcp server: %s", res.Text)
+	}
+
+	ctxT := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "jobember"})
+	res, _ = tool.Execute(ctxT, json.RawMessage(`{"op":"fork","name":"jobs"}`))
+	if res.IsError {
+		t.Fatalf(`by-name fork of the shared "" MCP server as tenant should succeed; got %s`, res.Text)
+	}
+}

--- a/internal/tools/builtin/skilldef.go
+++ b/internal/tools/builtin/skilldef.go
@@ -303,28 +303,45 @@ func (s *SkillDef) execFork(ctx context.Context, policy tools.SkillDefPolicyValu
 			if !errors.As(err, &nf) {
 				return errResult(fmt.Sprintf("fork: %s", err)), nil
 			}
-			// No active pointer → bootstrap from static SKILL.md.
-			if s.Set == nil {
-				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static SKILL.md entry (LOOMCYCLE_SKILLS_ROOT unset)", in.Name)), nil
-			}
-			static, ok := s.Set.Get(in.Name)
-			if !ok {
-				return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version nor a static SKILL.md entry", in.Name)), nil
-			}
-			bootstrap, berr := s.bootstrapStatic(ctx, in.Name, static)
-			if berr != nil {
-				// Concurrent first-fork may have already bootstrapped
-				// v1 between our GetActive and our own bootstrap insert.
-				// Re-read active before propagating the error.
-				if row2, gerr := s.Store.SkillDefGetActive(ctx, tenantID, in.Name); gerr == nil {
-					parent = row2
-					parentDefID = row2.DefID
-				} else {
-					return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+			// No own-tenant active pointer. Fall back to the SHARED ("")
+			// base before bootstrapping — mirrors run-time lookup precedence
+			// (own-tenant → static → shared "") and the explicit-parent
+			// branch, so a per-tenant principal can fork a name seeded under
+			// the legacy "" tenant. The fork lands under the caller's tenant.
+			// Skip when tenantID is already "" (identical lookup).
+			if tenantID != "" {
+				if shared, serr := s.Store.SkillDefGetActive(ctx, "", in.Name); serr == nil {
+					parent = shared
+					parentDefID = shared.DefID
+				} else if !errors.As(serr, &nf) {
+					return errResult(fmt.Sprintf("fork: %s", serr)), nil
 				}
-			} else {
-				parent = bootstrap
-				parentDefID = bootstrap.DefID
+			}
+			if parentDefID == "" {
+				// Still no parent (own-tenant AND shared "" missed) →
+				// bootstrap from static SKILL.md, else refuse.
+				if s.Set == nil {
+					return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version (own tenant or shared \"\") nor a static SKILL.md entry (LOOMCYCLE_SKILLS_ROOT unset)", in.Name)), nil
+				}
+				static, ok := s.Set.Get(in.Name)
+				if !ok {
+					return errResult(fmt.Sprintf("fork: no parent — name %q has neither a DB version (own tenant or shared \"\") nor a static SKILL.md entry", in.Name)), nil
+				}
+				bootstrap, berr := s.bootstrapStatic(ctx, in.Name, static)
+				if berr != nil {
+					// Concurrent first-fork may have already bootstrapped
+					// v1 between our GetActive and our own bootstrap insert.
+					// Re-read active before propagating the error.
+					if row2, gerr := s.Store.SkillDefGetActive(ctx, tenantID, in.Name); gerr == nil {
+						parent = row2
+						parentDefID = row2.DefID
+					} else {
+						return errResult(fmt.Sprintf("fork: bootstrap static: %s", berr)), nil
+					}
+				} else {
+					parent = bootstrap
+					parentDefID = bootstrap.DefID
+				}
 			}
 		}
 	}

--- a/internal/tools/builtin/skilldef_test.go
+++ b/internal/tools/builtin/skilldef_test.go
@@ -342,3 +342,24 @@ func TestSkillDefTool_TenantIsolationGetListRetire(t *testing.T) {
 		t.Errorf("tenant B list returned %d versions; want 1", n)
 	}
 }
+
+// TestSkillDefTool_ForkFallsBackToSharedBase mirrors the AgentDef fix: a
+// by-name fork by a per-tenant principal falls back to the SHARED ("") base
+// when the name has no own-tenant version, so a skill seeded under the legacy
+// "" tenant can be migrated without an explicit parent_def_id.
+func TestSkillDefTool_ForkFallsBackToSharedBase(t *testing.T) {
+	tool, baseCtx, cleanup := skillDefFixture(t)
+	defer cleanup()
+
+	ctxShared := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: ""})
+	res, _ := tool.Execute(ctxShared, json.RawMessage(`{"op":"create","name":"shared-skill","overlay":{"body":"v1 body"}}`))
+	if res.IsError {
+		t.Fatalf("create shared skill: %s", res.Text)
+	}
+
+	ctxT := tools.WithRunIdentity(baseCtx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "jobember"})
+	res, _ = tool.Execute(ctxT, json.RawMessage(`{"op":"fork","name":"shared-skill","overlay":{"body":"v2 body"}}`))
+	if res.IsError {
+		t.Fatalf(`by-name fork of the shared "" skill as tenant should succeed; got %s`, res.Text)
+	}
+}


### PR DESCRIPTION
## Why (user-visible problem)

A per-tenant principal whose registry was seeded under the legacy shared `""` tenant — concretely the **jobember** `substrate:admin`, whose pre-RFC-N AgentDefs all live under `tenant_id=""` — could **see** a name via the cross-tenant admin `list` yet be **unable to `fork`** it.

`execFork`'s no-`parent_def_id` branch resolved the parent only via `AgentDefGetActive` in the caller's **own** tenant, then jumped straight to static `cfg.Agents` and refused `fork: no parent`. So jobember's boot registry-sync read `deployed=true` (from the cross-tenant list), chose `fork`, and **every fork was refused** — `job-search-batch` could never get a code-js version into the `jobember` tenant. It kept running its `""` LLM v1, because run-time `lookup.Agent` **does** fall back to `""` (own-tenant dynamic → static → shared `""` dynamic). That three-way asymmetry — runtime falls back, admin `list` crosses tenants, `fork` does neither — is the bug.

## What (technical change)

In `execFork`'s no-explicit-`parent_def_id` branch, after the own-tenant active-pointer miss and **before** bootstrapping from static MD, fall back to `AgentDefGetActive(ctx, "", name)` when `tenantID != ""`. The forked row is still **stamped under the caller's own tenant** (unchanged), mirroring:
- run-time `lookup.Agent` precedence (own-tenant → static → shared `""`), and
- the existing explicit-`parent_def_id` branch, which already permits forking the `""` base across the tenant boundary.

The genuine no-parent refusal (no own-tenant, no shared `""`, no static cfg) is preserved, with a clarified message.

## What was tested

- `go test ./...` — clean.
- **`TestAgentDefTool_ForkFallsBackToSharedBase`** — seeds a name under `""`, forks it as a `jobember` principal; asserts the fork succeeds with the `""` base as `parent_def_id`, the new version is stamped under `jobember` (tenant-scoped `list` shows only it), and a second fork uses jobember's own pointer (own-tenant precedence). **Fails on the unfixed code** with the exact `fork: no parent — … neither a DB version nor a static cfg.Agents entry` refusal.
- **`TestAgentDefTool_ForkNoParentStillRefuses`** — refusal path intact when no own/shared/static parent exists.
- `make build` → `bin/loomcycle` v0.21.1.

## Consumer impact

Unblocks jobs-search-agent's boot registry-sync: with this binary, the next web boot forks `job-search-batch` (and `ats-filter-batch`) from the `""` base into `jobember` → code-js versions resolve. No JobEmber-side change required. No wire-protocol/schema change (internal fork resolution only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)