### PR TITLE
feat(mcp): advertise real op-schemas for builtin meta-tool wrappers

### DIFF
--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
 
@@ -295,7 +296,7 @@ func TestServer_Handshake(t *testing.T) {
 	}
 }
 
-func TestServer_ToolsList_Returns33Tools(t *testing.T) {
+func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
 	in := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n"
 	resps, _ := driveServer(t, srv, in)
@@ -317,6 +318,47 @@ func TestServer_ToolsList_Returns33Tools(t *testing.T) {
 	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
+		}
+	}
+}
+
+// TestBuiltinWrapperSchemas_CoverAllWrappers asserts every op-dispatched
+// builtin tool exposed as an MCP meta-tool advertises that tool's real
+// discriminated-op schema — not the bare {"type":"object"} the wrappers
+// shipped with, which hid the `op` enum + every property from clients
+// introspecting the server. Iterating builtin.MCPWrapperNames() (rather
+// than a hand-kept list) means a newly-exposed wrapper that forgets to
+// source its schema via builtinSchema() fails here.
+func TestBuiltinWrapperSchemas_CoverAllWrappers(t *testing.T) {
+	byName := map[string]json.RawMessage{}
+	for _, td := range toolDescriptors() {
+		byName[td.Name] = td.InputSchema
+	}
+	for _, name := range builtin.MCPWrapperNames() {
+		schema, ok := byName[name]
+		if !ok {
+			t.Errorf("builtin wrapper %q has a schema but no tools/list descriptor", name)
+			continue
+		}
+		want, _ := builtin.MCPWrapperInputSchema(name)
+		if !bytes.Equal(schema, want) {
+			t.Errorf("wrapper %q: descriptor schema not sourced from builtin (bare fallback?)", name)
+		}
+		// The sourced schema must parse and expose a top-level `op` enum —
+		// the whole point of the fix is that clients can discover ops.
+		var parsed struct {
+			Properties struct {
+				Op struct {
+					Enum []string `json:"enum"`
+				} `json:"op"`
+			} `json:"properties"`
+		}
+		if err := json.Unmarshal(schema, &parsed); err != nil {
+			t.Errorf("wrapper %q schema is not valid JSON: %v", name, err)
+			continue
+		}
+		if len(parsed.Properties.Op.Enum) == 0 {
+			t.Errorf("wrapper %q schema exposes no op enum — clients can't discover operations", name)
 		}
 	}
 }

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
 	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
 
@@ -10,10 +11,12 @@ import (
 // by TestServer_ToolsList in server_test.go — let that test be the
 // authoritative source of "how many tools" rather than restating it
 // here (the comment would otherwise drift on every new addition).
-// Each descriptor carries name + description + input schema; the
-// schemas are intentionally minimal — full input validation lives
-// at the connector layer (or, for builtin wrappers, at the
-// underlying tool's discriminated-op schema).
+// Each descriptor carries name + description + input schema. Builtin
+// wrappers source their schema from the underlying tool via
+// builtinSchema(), so the advertised inputSchema is the tool's real
+// discriminated-op schema and can't drift from it; the remaining
+// connector-backed descriptors carry hand-written schemas validated at
+// the connector layer.
 //
 // Naming convention: flat `verb_noun` for actions; single-word for
 // builtin wrappers (memory, channel, agentdef, skilldef, evaluation, context)
@@ -125,73 +128,74 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 
 		// --- Builtin wrappers ---
-		// Each delegates 1:1 to the underlying builtin tool's
-		// discriminated-op input schema. We don't restate the inner
-		// schema here — the loomcycle agent loop already validates it.
+		// Each delegates 1:1 to the underlying builtin tool, and advertises
+		// that tool's own discriminated-op input schema via builtinSchema()
+		// — clients see the real `op` enum + properties, and the schema
+		// can't drift from the validation the agent loop applies.
 		{
 			Name:        "memory",
 			Description: "Memory tool ops (get/set/delete/list/incr). Pass-through to the underlying Memory builtin.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("memory"),
 		},
 		{
 			Name:        "channel",
 			Description: "Channel tool ops (publish/subscribe/ack/peek/list_channels). Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("channel"),
 		},
 		{
 			Name:        "agentdef",
 			Description: "AgentDef tool ops (create/fork/get/list/promote/retire). Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("agentdef"),
 		},
 		{
 			Name:        "skilldef",
 			Description: "SkillDef tool ops (create/fork/get/list/promote/retire). Runtime-mutable skill substrate; mirror of AgentDef for skills. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("skilldef"),
 		},
 		{
 			Name:        "mcpserverdef",
 			Description: "MCPServerDef tool ops (create/fork/get/list/promote/retire/rediscover/verify). v0.9.x dynamic MCP server registration. Operator-admin-only — register HTTP / Streamable-HTTP MCP servers at runtime; stdio stays yaml. URL hostname must be in LOOMCYCLE_HTTP_HOST_ALLOWLIST. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("mcpserverdef"),
 		},
 		{
 			Name:        "scheduledef",
 			Description: "ScheduleDef tool ops (create/fork/get/list/retire). v1.x RFC E scheduled-runs substrate. Operator-admin-only — author + fork per-user schedules at runtime. Forks auto-promote by default (schedule versioning model differs from agent/skill where promote is a separate step). Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("scheduledef"),
 		},
 		{
 			Name:        "a2aservercarddef",
 			Description: "A2AServerCardDef tool ops (create/fork/get/list/retire). v1.x RFC G A2A-server-card substrate. Operator-admin-only — author + fork A2A server cards at runtime. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("a2aservercarddef"),
 		},
 		{
 			Name:        "a2aagentdef",
 			Description: "A2AAgentDef tool ops (create/fork/get/list/retire). v1.x RFC G A2A-agent substrate. Operator-admin-only — author + fork A2A agents at runtime. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("a2aagentdef"),
 		},
 		{
 			Name:        "webhookdef",
 			Description: "WebhookDef tool ops (create/fork/get/list/retire). v1.x RFC H inbound-webhook substrate. Operator-admin-only — author + fork inbound webhook definitions at runtime. Static webhooks.<name>: yaml entries stay immutable ground truth; this produces the derived layer. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("webhookdef"),
 		},
 		{
 			Name:        "memorybackenddef",
 			Description: "MemoryBackendDef tool ops (create/fork/get/list/retire). RFC I MR-3a memory-backend substrate. Operator-admin-only — author + fork named memory backend definitions at runtime. Static memory_backends.<name>: yaml entries stay immutable ground truth; this produces the derived layer. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("memorybackenddef"),
 		},
 		{
 			Name:        "operatortokendef",
 			Description: "OperatorTokenDef tool ops (create/rotate/retire/get/list). RFC L OSS multi-tenant authorization. Operator-admin-only — mint, rotate, and retire bearer tokens each bound to an authoritative principal {tenant_id, subject, allowed_scopes}. The token plaintext is shown ONCE on create/rotate. Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("operatortokendef"),
 		},
 		{
 			Name:        "evaluation",
 			Description: "Evaluation tool ops (submit/get/list_for_run/list_for_def/aggregate). Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("evaluation"),
 		},
 		{
 			Name:        "context",
 			Description: "Context tool ops (self/tools/doc/permissions/agents/lineage/evaluations/channels/history/help). Pass-through.",
-			InputSchema: rawJSON(`{"type": "object"}`),
+			InputSchema: builtinSchema("context"),
 		},
 
 		// --- Pause/Resume (v0.8.17 primitives, exposed via Connector in v0.8.18) ---
@@ -424,3 +428,16 @@ func rawJSON(s string) json.RawMessage { return json.RawMessage(s) }
 // from the registry and can never drift — the static "33" in the help text
 // went stale once the registry had grown to 40.
 func MetaToolCount() int { return len(toolDescriptors()) }
+
+// builtinSchema returns the canonical input schema for an op-dispatched
+// builtin wrapper (memory, channel, agentdef, …), sourced from the
+// builtin tool itself so the advertised MCP schema can't drift from the
+// tool's real validation. Falls back to a bare object if the wrapper has
+// no registered schema — a programmer error caught by
+// TestBuiltinWrapperSchemas_CoverAllWrappers.
+func builtinSchema(name string) json.RawMessage {
+	if s, ok := builtin.MCPWrapperInputSchema(name); ok {
+		return s
+	}
+	return rawJSON(`{"type": "object"}`)
+}

--- a/internal/tools/builtin/wrapper_schemas.go
+++ b/internal/tools/builtin/wrapper_schemas.go
@@ -1,0 +1,63 @@
+package builtin
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// mcpWrapperSchemas maps each op-dispatched builtin tool — by the
+// lowercase name under which the LoomCycle MCP server exposes it as a
+// meta-tool — to that tool's canonical input schema const.
+//
+// internal/api/mcp's tool catalogue resolves these so the advertised
+// MCP inputSchema is sourced from the tool's REAL validation schema
+// rather than restated. The wrappers forward their arguments 1:1 to the
+// underlying builtin (e.g. `memory` → connector.Memory → *Memory.Call,
+// validated against memoryInputSchema), so the canonical schema is
+// exactly what the MCP client should send. Previously each wrapper
+// advertised a bare {"type":"object"}, hiding the `op` enum + every
+// property from clients introspecting the server.
+//
+// When a new op-dispatched builtin is exposed as an MCP wrapper, add it
+// here; TestBuiltinWrapperSchemas_CoverAllWrappers (in internal/api/mcp)
+// fails if a wrapper descriptor has no entry.
+var mcpWrapperSchemas = map[string]string{
+	"memory":           memoryInputSchema,
+	"channel":          channelInputSchema,
+	"agentdef":         agentDefInputSchema,
+	"skilldef":         skillDefInputSchema,
+	"mcpserverdef":     mcpServerDefInputSchema,
+	"scheduledef":      scheduleDefInputSchema,
+	"a2aservercarddef": a2aServerCardDefInputSchema,
+	"a2aagentdef":      a2aAgentDefInputSchema,
+	"webhookdef":       webhookDefInputSchema,
+	"memorybackenddef": memoryBackendDefInputSchema,
+	"operatortokendef": operatorTokenDefInputSchema,
+	"evaluation":       evaluationInputSchema,
+	"context":          contextInputSchema,
+}
+
+// MCPWrapperInputSchema returns the canonical input schema for the
+// op-dispatched builtin tool exposed under the given MCP meta-tool name,
+// and whether such a wrapper exists. The bytes are the tool's own
+// validation schema, so callers may advertise them verbatim.
+func MCPWrapperInputSchema(name string) (json.RawMessage, bool) {
+	s, ok := mcpWrapperSchemas[name]
+	if !ok {
+		return nil, false
+	}
+	return json.RawMessage(s), true
+}
+
+// MCPWrapperNames returns the sorted names of every op-dispatched builtin
+// tool exposed as an MCP meta-tool wrapper. The MCP server's
+// catalogue-coverage test iterates this so a newly-exposed wrapper that
+// forgot to source its schema fails loudly.
+func MCPWrapperNames() []string {
+	names := make([]string, 0, len(mcpWrapperSchemas))
+	for name := range mcpWrapperSchemas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}


### PR DESCRIPTION
## Why

The brew-install review's **finding #2**: the 13 op-dispatched builtin tools exposed over the LoomCycle MCP server all advertised a bare `{"type":"object"}` inputSchema —

`memory`, `channel`, `agentdef`, `skilldef`, `mcpserverdef`, `scheduledef`, `a2aservercarddef`, `a2aagentdef`, `webhookdef`, `memorybackenddef`, `operatortokendef`, `evaluation`, `context`.

An MCP client introspecting the server (Claude Code, Claude Desktop, a custom orchestrator) couldn't see the `op` enum or any per-op property — it had to guess the discriminated-union shape by trial and error. Confirmed live against the IDE plugin's `mcp__plugin_loomcycle_loomcycle__*` tools.

## What

These wrappers forward their arguments **1:1** to the underlying builtin (e.g. `memory` → `connector.Memory` → `*Memory.Call`, validated against `memoryInputSchema`), so the canonical schema is exactly what the client should send. This **sources** each wrapper's advertised inputSchema from that tool's own schema rather than restating it — so the advertised schema *is* the real validation schema and can't drift from it (same anti-drift principle as the meta-tool count in #374).

- **`internal/tools/builtin/wrapper_schemas.go`** (new) — `MCPWrapperInputSchema(name)` maps each wrapper name → the builtin tool's canonical schema const; `MCPWrapperNames()` exposes the set for the coverage test. `builtin` does **not** import the `mcp` package, so there's no import cycle.
- **`internal/api/mcp/tools.go`** — new `builtinSchema(name)` helper sources the schema (bare-object fallback *only* on a missing entry — a programmer error the test catches). The 13 wrapper descriptors call it. Stale "schemas are intentionally minimal" comments updated.
- **`internal/api/mcp/server_test.go`** — `TestBuiltinWrapperSchemas_CoverAllWrappers` iterates `builtin.MCPWrapperNames()` and asserts each descriptor's schema equals the builtin schema **and** exposes a top-level `op` enum, so a future wrapper that forgets `builtinSchema()` fails loudly. Also renamed the stale `TestServer_ToolsList_Returns33Tools` → `_ReturnsFullCatalogue` (the body already asserts 40; the numeric name was itself drift).

This changes the **advertised MCP tool schemas** (the wire surface clients introspect) — strictly additive: clients that previously sent free-form objects still validate; clients can now discover the ops.

## Tested

- `go build ./...` + `go test ./...` clean.
- **Fail-before**: reverting one wrapper to the bare schema makes `TestBuiltinWrapperSchemas_CoverAllWrappers` fail on both the schema-mismatch and the missing-`op`-enum assertions (verified, then restored).

## Relationship to #374

Independent of #374 (first-run doc polish) and branched off `main`, not stacked. Both touch `tools.go` in adjacent regions (this adds `builtinSchema()`; #374 adds `MetaToolCount()` right after `rawJSON`), so whichever merges second may need a **trivial** one-hunk conflict resolution (two adjacent function additions — keep both). No logical dependency either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)