### PR TITLE
feat(mcp): concurrent stdio dispatch — un-wedge the loomcycle MCP server (RFC O)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1869,13 +1869,22 @@ func main() {
 		log.Printf("dynamic_agents: sweeper enabled (interval=%s)", cfg.Env.DynamicAgentSweepInterval)
 	}
 	if mcpMode {
+		// Optional operator override for the stdio dispatch concurrency
+		// cap (RFC O). 0/unset → the package default (16).
+		mcpMaxConcurrentCalls := 0
+		if v := os.Getenv("LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS"); v != "" {
+			if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+				mcpMaxConcurrentCalls = n
+			}
+		}
 		mcpSrv := lcmcp.New(lcmcp.Config{
-			Connector:     srv, // *http.Server satisfies connector.Connector
-			Runner:        srv, // *http.Server satisfies runner.Runner (streaming)
-			Store:         storeIface,
-			Logf:          log.Printf, // log goes to stderr; never stdout (stdout is the JSON-RPC wire)
-			ServerName:    "loomcycle",
-			ServerVersion: buildVersion,
+			Connector:          srv, // *http.Server satisfies connector.Connector
+			Runner:             srv, // *http.Server satisfies runner.Runner (streaming)
+			Store:              storeIface,
+			Logf:               log.Printf, // log goes to stderr; never stdout (stdout is the JSON-RPC wire)
+			ServerName:         "loomcycle",
+			ServerVersion:      buildVersion,
+			MaxConcurrentCalls: mcpMaxConcurrentCalls,
 		})
 		// Run the MCP stdio loop in a goroutine. When stdin closes
 		// (Claude Code disconnects), Serve returns; we log and let

--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -60,6 +60,15 @@ type Config struct {
 	// to. Empty fallbacks are fine.
 	ServerName    string
 	ServerVersion string
+
+	// MaxConcurrentCalls bounds how many long-running tool calls
+	// (spawn_run, subscribe_channel, peek_channel, stream_user_run_states)
+	// may execute concurrently on the stdio dispatch loop. Cheap/control
+	// calls (list_*, get_run, cancel_run, …) are never bounded, so they
+	// stay responsive even when every slot is occupied. <= 0 → default
+	// (defaultMaxConcurrentCalls). Only consulted by Serve (stdio); the
+	// HTTP transport is already concurrent at the http.Server level.
+	MaxConcurrentCalls int
 }
 
 // Server reads MCP JSON-RPC frames from stdin and writes responses +
@@ -78,7 +87,24 @@ type Server struct {
 	// emitted atomically (one frame per line). Tool handlers and the
 	// notification path both acquire this before writing.
 	writeMu sync.Mutex
+
+	// sem bounds concurrently-executing long-running tool calls on the
+	// stdio Serve loop (see Config.MaxConcurrentCalls). Acquired INSIDE
+	// the per-call goroutine so the read loop never blocks. Buffered to
+	// the cap; nil for the HTTP transport's disposable *Server (it never
+	// calls Serve, so it never touches sem).
+	sem chan struct{}
+	// wg tracks in-flight tools/call goroutines so Serve can flush their
+	// responses before returning (clean shutdown on stdin EOF).
+	wg sync.WaitGroup
 }
+
+// defaultMaxConcurrentCalls bounds in-flight long-running tool calls
+// when Config.MaxConcurrentCalls is unset. Ample for a single MCP
+// client (Claude Code sends roughly one call at a time); the cap exists
+// to keep a pathological burst from spawning unbounded in-flight runs,
+// not to throttle normal use.
+const defaultMaxConcurrentCalls = 16
 
 // New constructs an MCP Server. Caller drives it by calling Serve.
 func New(cfg Config) *Server {
@@ -88,9 +114,14 @@ func New(cfg Config) *Server {
 	if cfg.ServerName == "" {
 		cfg.ServerName = "loomcycle"
 	}
+	maxCalls := cfg.MaxConcurrentCalls
+	if maxCalls <= 0 {
+		maxCalls = defaultMaxConcurrentCalls
+	}
 	return &Server{
 		cfg:     cfg,
 		session: NewSession(),
+		sem:     make(chan struct{}, maxCalls),
 	}
 }
 
@@ -99,20 +130,22 @@ func New(cfg Config) *Server {
 // write errors. Each line on stdin is one JSON-RPC frame (per MCP's
 // stdio framing — newline-delimited JSON, no header).
 //
-// Frames are dispatched SEQUENTIALLY per the MCP initialization
-// contract: initialize must complete before any tool call, and the
-// initialized notification must arrive before other requests are
-// honored. Serialising the entire dispatch satisfies this without
-// per-method gating. Concurrent tools/call (long-running spawn_run
-// vs short list_runs on the same connection) is a v0.8.15.x or v0.9.x
-// optimisation; the writeMu is retained for the notification path
-// where in-flight spawn_run emits notifications while reading the
-// next frame is desired — but those notifications come from the
-// handler goroutine, which is the same goroutine that's dispatching.
+// Dispatch is CONCURRENT for tools/call and INLINE for everything
+// else (RFC O). A tools/call request runs on its own goroutine so a
+// long-running call (spawn_run blocking on a whole run, a channel
+// long-poll, an event wait) can't head-of-line-block the frames the
+// client sends behind it — the prior serial loop let one slow call
+// freeze every subsequent request, including a cheap list_runs or a
+// cancel_run, wedging the whole connection until the process was
+// killed. The init handshake stays correctly ordered for free:
+// initialize / tools/list / notifications are handled inline on the
+// read loop, in arrival order, and a client sends them before any
+// tools/call. writeMu keeps concurrent responses + notifications from
+// interleaving bytes on stdout.
 //
-// In practice MCP clients (Claude Code first) send one request at a
-// time and wait for the response, so sequential dispatch matches
-// real-world usage.
+// Long-running tools take a slot in s.sem (acquired inside the
+// goroutine, so the read loop never blocks); cheap/control tools run
+// unbounded so they stay responsive even when every slot is occupied.
 func (s *Server) Serve(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
 	scanner := bufio.NewScanner(stdin)
 	// MCP messages can be large (tool inputs, agent system prompts).
@@ -120,26 +153,122 @@ func (s *Server) Serve(ctx context.Context, stdin io.Reader, stdout io.Writer) e
 	// server's effective request-size budget.
 	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 
+	// Handlers get a child of ctx so a global shutdown (parent ctx
+	// cancel) propagates into in-flight tools/call goroutines.
+	handlerCtx, cancelHandlers := context.WithCancel(ctx)
+	defer cancelHandlers()
+
 	for scanner.Scan() {
 		// Copy the line — scanner reuses its buffer on next Scan().
 		line := append([]byte(nil), scanner.Bytes()...)
 		if len(line) == 0 {
 			continue
 		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
+		if ctx.Err() != nil {
+			break
 		}
 
-		s.handleFrame(ctx, line, stdout)
+		async, bounded := frameRoute(line)
+		if !async {
+			// initialize / tools/list / notifications / malformed —
+			// fast and ordering-sensitive; handle inline on the read
+			// loop (and the HTTP transport reuses handleFrame the same
+			// synchronous way).
+			s.handleFrame(ctx, line, stdout)
+			continue
+		}
+
+		// tools/call — dispatch concurrently so it can't HOL-block the
+		// next frame.
+		s.wg.Add(1)
+		go func(fr []byte, bound bool) {
+			defer s.wg.Done()
+			if bound {
+				select {
+				case s.sem <- struct{}{}:
+					defer func() { <-s.sem }()
+				case <-handlerCtx.Done():
+					// Global shutdown fired before a slot freed. Respond
+					// with an explicit error rather than silently
+					// abandoning the call, so the client doesn't wait out
+					// its own timeout. Best-effort — stdout may already be
+					// tearing down (writeFrame logs + ignores write errors).
+					if id, ok := frameRequestID(fr); ok {
+						s.writeError(stdout, id, -32603, "server shutting down")
+					}
+					return
+				}
+			}
+			s.handleFrame(handlerCtx, fr, stdout)
+		}(line, bounded)
 	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("mcp: read stdin: %w", err)
+
+	scanErr := scanner.Err()
+	// Stop reading: wait for in-flight tools/call goroutines to flush
+	// their responses before returning, so a caller draining stdout
+	// after Serve sees every frame. We do NOT cancel them here on a
+	// clean EOF — a client that sent a request then closed stdin still
+	// expects the response on stdout. Global shutdown cancellation
+	// flows through handlerCtx (child of ctx) instead.
+	s.wg.Wait()
+	if scanErr != nil {
+		return fmt.Errorf("mcp: read stdin: %w", scanErr)
 	}
-	return nil
+	return ctx.Err()
 }
+
+// frameRoute peeks at a JSON-RPC frame to decide stdio dispatch.
+// async is true for a tools/call request (run on its own goroutine so
+// it can't head-of-line-block later frames). bounded is true when that
+// call targets a long-running tool that must take a concurrency slot.
+// A best-effort decode failure routes inline (async=false) — the
+// authoritative parse + error reporting happens in handleFrame.
+func frameRoute(frame []byte) (async, bounded bool) {
+	var p struct {
+		ID     *int64 `json:"id"`
+		Method string `json:"method"`
+		Params struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &p); err != nil {
+		return false, false
+	}
+	if p.ID == nil || p.Method != "tools/call" {
+		return false, false
+	}
+	return true, isLongRunningTool(p.Params.Name)
+}
+
+// frameRequestID extracts the JSON-RPC request id from a frame, used to
+// address a shutdown error response back to a dropped tools/call. ok is
+// false for notifications (no id) or undecodable frames.
+func frameRequestID(frame []byte) (int64, bool) {
+	var p struct {
+		ID *int64 `json:"id"`
+	}
+	if json.Unmarshal(frame, &p) != nil || p.ID == nil {
+		return 0, false
+	}
+	return *p.ID, true
+}
+
+// longRunningTools are the meta-tools whose handler can block for a
+// significant or unbounded time — a full run (spawn_run), a long-poll
+// (subscribe_channel / peek_channel), or an event wait
+// (stream_user_run_states). They take a concurrency slot so a burst
+// can't spawn unbounded in-flight work; every other tool (cheap reads
+// + control ops like cancel_run / get_run) runs unbounded so it stays
+// responsive even when all slots are occupied. Add new blocking tools
+// here when they're introduced.
+var longRunningTools = map[string]bool{
+	"spawn_run":              true,
+	"subscribe_channel":      true,
+	"peek_channel":           true,
+	"stream_user_run_states": true,
+}
+
+func isLongRunningTool(name string) bool { return longRunningTools[name] }
 
 // handleFrame decodes one inbound JSON-RPC frame and dispatches to
 // the appropriate handler. Requests get a response written back to

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -1,10 +1,12 @@
 package mcp
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -24,9 +26,16 @@ import (
 // the ones explicitly exercised. Lets tests focus on what they care
 // about without faking unrelated surfaces.
 type mockConnector struct {
-	spawnReq     atomic.Value // connector.SpawnRunRequest (last)
-	spawnResult  connector.SpawnRunResult
-	spawnErr     error
+	spawnReq    atomic.Value // connector.SpawnRunRequest (last)
+	spawnResult connector.SpawnRunResult
+	spawnErr    error
+	// spawnGate, when non-nil, makes SpawnRun block until the channel is
+	// closed (or ctx is cancelled) — lets a test hold a spawn_run "in
+	// flight" to exercise concurrent dispatch. spawnActive/spawnMaxSeen
+	// track in-flight + high-water concurrency for the cap test.
+	spawnGate    chan struct{}
+	spawnActive  atomic.Int32
+	spawnMaxSeen atomic.Int32
 	regCalls     atomic.Int32
 	regResult    connector.AgentDescriptor
 	pauseResult  connector.PauseResult
@@ -48,8 +57,22 @@ type mockConnector struct {
 	lastStreamReq    connector.StreamUserRunStatesRequest
 }
 
-func (m *mockConnector) SpawnRun(_ context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+func (m *mockConnector) SpawnRun(ctx context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
 	m.spawnReq.Store(r)
+	if m.spawnGate != nil {
+		n := m.spawnActive.Add(1)
+		for { // record the high-water mark of concurrent in-flight calls
+			old := m.spawnMaxSeen.Load()
+			if n <= old || m.spawnMaxSeen.CompareAndSwap(old, n) {
+				break
+			}
+		}
+		select {
+		case <-m.spawnGate:
+		case <-ctx.Done():
+		}
+		m.spawnActive.Add(-1)
+	}
 	return m.spawnResult, m.spawnErr
 }
 func (m *mockConnector) CancelRun(_ context.Context, _, _ string) (connector.CancelRunResult, error) {
@@ -898,3 +921,233 @@ func TestServer_StreamUserRunStates_RequiresUserID(t *testing.T) {
 // case Go's stdlib evolves; kept as a guard.
 var _ io.Reader = strings.NewReader("")
 var _ sync.Locker = (*sync.Mutex)(nil)
+
+// --- RFC O: concurrent stdio dispatch ---------------------------------
+//
+// liveServer drives a Server over real pipes so a test can write frames
+// over time and read responses as they arrive (driveServer is batch —
+// it can't observe the non-blocking property). Responses/notifications
+// are demuxed onto channels; waitResp blocks for a specific JSON-RPC id.
+
+type liveServer struct {
+	t      *testing.T
+	stdinW *io.PipeWriter
+	cancel context.CancelFunc
+	done   chan error
+
+	mu    sync.Mutex
+	got   map[int64]loommcp.Response // id → response, as they arrive
+	notes []loommcp.Notification
+	cond  *sync.Cond
+}
+
+func newLiveServer(t *testing.T, srv *Server) *liveServer {
+	t.Helper()
+	stdinR, stdinW := io.Pipe()
+	stdoutR, stdoutW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	ls := &liveServer{t: t, stdinW: stdinW, cancel: cancel, done: make(chan error, 1), got: map[int64]loommcp.Response{}}
+	ls.cond = sync.NewCond(&ls.mu)
+
+	go func() {
+		err := srv.Serve(ctx, stdinR, stdoutW)
+		_ = stdoutW.Close() // unblock the reader goroutine
+		ls.done <- err
+	}()
+	go func() {
+		sc := bufio.NewScanner(stdoutR)
+		sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for sc.Scan() {
+			line := sc.Bytes()
+			var probe struct {
+				ID *int64 `json:"id"`
+			}
+			if json.Unmarshal(line, &probe) != nil {
+				continue
+			}
+			ls.mu.Lock()
+			if probe.ID != nil {
+				var r loommcp.Response
+				if json.Unmarshal(line, &r) == nil {
+					ls.got[*probe.ID] = r
+				}
+			} else {
+				var n loommcp.Notification
+				if json.Unmarshal(line, &n) == nil {
+					ls.notes = append(ls.notes, n)
+				}
+			}
+			ls.cond.Broadcast()
+			ls.mu.Unlock()
+		}
+	}()
+	return ls
+}
+
+func (ls *liveServer) send(frame string) {
+	if _, err := io.WriteString(ls.stdinW, frame+"\n"); err != nil {
+		ls.t.Fatalf("send frame: %v", err)
+	}
+}
+
+// waitResp blocks until the response for id arrives or timeout elapses.
+func (ls *liveServer) waitResp(id int64, timeout time.Duration) loommcp.Response {
+	ls.t.Helper()
+	deadline := make(chan struct{})
+	timer := time.AfterFunc(timeout, func() {
+		ls.mu.Lock()
+		close(deadline)
+		ls.cond.Broadcast()
+		ls.mu.Unlock()
+	})
+	defer timer.Stop()
+	ls.mu.Lock()
+	for {
+		if r, ok := ls.got[id]; ok {
+			ls.mu.Unlock()
+			return r
+		}
+		select {
+		case <-deadline:
+			// Unlock before Fatalf: Fatalf runs runtime.Goexit, and we
+			// must not leave ls.mu held while the stdout-reader goroutine
+			// is trying to acquire it.
+			ls.mu.Unlock()
+			ls.t.Fatalf("timed out after %s waiting for response id=%d", timeout, id)
+			return loommcp.Response{} // unreachable; Fatalf exits the goroutine
+		default:
+		}
+		ls.cond.Wait()
+	}
+}
+
+// hasResp reports whether a response for id has arrived yet (non-blocking).
+func (ls *liveServer) hasResp(id int64) bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	_, ok := ls.got[id]
+	return ok
+}
+
+func (ls *liveServer) close() {
+	_ = ls.stdinW.Close()
+	ls.cancel()
+}
+
+func toolCallFrame(id int64, name, args string) string {
+	return fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":%q,"arguments":%s}}`, id, name, args)
+}
+
+// handshake runs initialize + initialized and waits for the init response.
+func (ls *liveServer) handshake() {
+	ls.send(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`)
+	ls.waitResp(1, 2*time.Second)
+	ls.send(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+}
+
+// TestServer_LongCallDoesNotBlockSubsequent is the RFC O regression test:
+// a blocked spawn_run must NOT delay a subsequent cheap list_runs. On the
+// pre-RFC-O serial loop the list_runs response never arrives until the
+// spawn_run completes, so waitResp(id=3) times out and the test fails.
+func TestServer_LongCallDoesNotBlockSubsequent(t *testing.T) {
+	gate := make(chan struct{})
+	mc := &mockConnector{spawnGate: gate}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // blocks on gate
+	ls.send(toolCallFrame(3, "list_runs", `{"user_id":"u"}`))             // cheap; must not be HOL-blocked
+
+	// id=3 must arrive while id=2 is still blocked.
+	ls.waitResp(3, 2*time.Second)
+	if ls.hasResp(2) {
+		t.Fatal("spawn_run (id=2) responded before the gate was released — test setup broken")
+	}
+
+	close(gate) // release spawn_run
+	ls.waitResp(2, 2*time.Second)
+}
+
+// TestServer_CancelRunBypassesCapDuringSaturation proves the selective
+// cap: with the cap fully occupied by a blocked spawn_run, a control
+// call (cancel_run) is NOT bounded and still runs.
+func TestServer_CancelRunBypassesCapDuringSaturation(t *testing.T) {
+	gate := make(chan struct{})
+	mc := &mockConnector{spawnGate: gate}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}, MaxConcurrentCalls: 1})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // fills the only slot
+	ls.send(toolCallFrame(3, "cancel_run", `{"agent_id":"a"}`))           // not bounded → must run
+
+	ls.waitResp(3, 2*time.Second) // cancel_run responds despite the saturated cap
+	if ls.hasResp(2) {
+		t.Fatal("spawn_run responded before gate release")
+	}
+	close(gate)
+	ls.waitResp(2, 2*time.Second)
+}
+
+// TestServer_LongCallsRespectConcurrencyCap proves the cap bounds the
+// number of long-running tools executing at once: with cap=2 and three
+// blocked spawn_runs outstanding, only two reach the connector.
+func TestServer_LongCallsRespectConcurrencyCap(t *testing.T) {
+	gate := make(chan struct{})
+	mc := &mockConnector{spawnGate: gate}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}, MaxConcurrentCalls: 2})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`))
+	ls.send(toolCallFrame(3, "spawn_run", `{"agent":"x","segments":[]}`))
+	ls.send(toolCallFrame(4, "spawn_run", `{"agent":"x","segments":[]}`))
+
+	// Wait for two to enter the connector; the third must stay parked on
+	// the semaphore (never enters SpawnRun).
+	deadline := time.After(2 * time.Second)
+	for mc.spawnActive.Load() < 2 {
+		select {
+		case <-deadline:
+			t.Fatalf("only %d spawn_runs entered the connector; want 2", mc.spawnActive.Load())
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	// Give the third a chance to (wrongly) slip through, then assert it didn't.
+	time.Sleep(100 * time.Millisecond)
+	if got := mc.spawnMaxSeen.Load(); got != 2 {
+		t.Fatalf("max concurrent spawn_run = %d; cap=2 should bound it to 2", got)
+	}
+
+	close(gate) // release all; the third now proceeds
+	ls.waitResp(2, 2*time.Second)
+	ls.waitResp(3, 2*time.Second)
+	ls.waitResp(4, 2*time.Second)
+}
+
+// TestServer_QueuedCallErrorsOnShutdown locks the shutdown branch: a
+// bounded call still waiting for a concurrency slot when global shutdown
+// fires gets an explicit -32603 (not a silent drop the client would
+// wait out). An unbuffered sem makes the slot unacquirable, so the call
+// deterministically parks until the context is cancelled.
+func TestServer_QueuedCallErrorsOnShutdown(t *testing.T) {
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	srv.sem = make(chan struct{}) // unbuffered: a bounded call can never acquire → parks until shutdown
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // bounded → parks on the sem
+	time.Sleep(50 * time.Millisecond)                                     // let the read loop dispatch the goroutine
+	ls.cancel()                                                           // simulate global shutdown (bgCtx / SIGTERM)
+
+	r := ls.waitResp(2, 2*time.Second)
+	if r.Error == nil || r.Error.Code != -32603 {
+		t.Fatalf("queued call on shutdown: want -32603 error, got %+v", r)
+	}
+}


### PR DESCRIPTION
Implements **RFC O** (`loomcycle-internal/doc-internal/rfcs/concurrent-mcp-stdio-dispatch.md`).

## Why

The `loomcycle mcp` stdio server dispatched **every** JSON-RPC frame on a single goroutine, sequentially (`Serve` was a bare `for scanner.Scan() { handleFrame(...) }`). One long-blocking tool call **head-of-line-blocked the entire connection** — every subsequent frame, including a cheap `list_runs` or a `cancel_run`, sat unread in the stdin pipe until the blocker returned or the process was killed. This wedged a live Claude session on a "list" confirmation that only a `pkill` could free (experiment finding **F17**).

## What

`Serve` now dispatches each `tools/call` on its own goroutine; `initialize` / `tools/list` / notifications stay **inline** on the read loop (ordering-sensitive + fast — the client sends them before any `tools/call`, so the handshake stays correctly ordered for free). A long call no longer blocks the frames behind it.

- **Selective bounding.** Long-running tools (`spawn_run`, `subscribe_channel`, `peek_channel`, `stream_user_run_states`) take a slot in a bounded semaphore (`Config.MaxConcurrentCalls`, default **16**, env `LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS`). The slot is acquired **inside** the goroutine so the read loop never blocks (acquiring on the loop would reintroduce HOL). Cheap/control tools — `list_*`, `get_run`, and crucially **`cancel_run`** — are never bounded, so they stay responsive even when every slot is full.
- **Why it's low-risk.** `writeFrame` already serialises stdout via `writeMu`; `Session` is already all-atomic (it was *designed* for concurrent access — the goroutines were just never spawned). `handleFrame` is unchanged and stays synchronous, so the HTTP transport (`http_transport.go`, which reuses `handleFrame` per-request) is **unaffected**.
- **Clean shutdown.** A child `handlerCtx` propagates global-shutdown cancellation into in-flight handlers; on stdin EOF, `Serve` waits (`wg.Wait`) for in-flight responses to flush **without** pre-cancelling (a sent-then-EOF request still gets its response). A bounded call still queued on the semaphore when shutdown fires gets an explicit `-32603` rather than a silent drop.

## Scope

Removes the HOL **coupling**. It does **not** bound `spawn_run`'s own duration or fix the cross-process interruption wake — those are **RFC P** and the **F15** follow-up.

## Tested

All under `go test -race`:
- **`TestServer_LongCallDoesNotBlockSubsequent`** — the HOL regression: a blocked `spawn_run` must not delay a subsequent `list_runs`. **Fail-before verified** — forcing serial dispatch makes this test hang (the `list_runs` never returns).
- `TestServer_CancelRunBypassesCapDuringSaturation` — `cancel_run` runs even when the cap is saturated by a blocked `spawn_run`.
- `TestServer_LongCallsRespectConcurrencyCap` — cap bounds concurrent long-running tools.
- `TestServer_QueuedCallErrorsOnShutdown` — a queued bounded call gets `-32603` on shutdown.

New `liveServer` pipe harness drives frames over time + demuxes responses by id (the existing `driveServer` is batch and can't observe the non-blocking property). Full `go test ./...` clean; gofmt clean; manual e2e against the built binary (handshake + `tools/list` → 40 tools).

Independently code-reviewed for concurrency (goroutine leaks, `wg.Wait` deadlock, lost responses, read-loop blocking, races, init ordering): no production-logic issues; the two review notes (test `t.Fatalf` under mutex; silent shutdown drop) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)