### PR TITLE
feat(mcp): bounded spawn_run transport timeout (RFC P)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1877,6 +1877,14 @@ func main() {
 				mcpMaxConcurrentCalls = n
 			}
 		}
+		// Optional operator default for the spawn_run transport timeout
+		// (RFC P). 0/unset → disabled (defer to the run's own budget).
+		mcpSpawnRunTimeoutMS := 0
+		if v := os.Getenv("LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS"); v != "" {
+			if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+				mcpSpawnRunTimeoutMS = n
+			}
+		}
 		mcpSrv := lcmcp.New(lcmcp.Config{
 			Connector:          srv, // *http.Server satisfies connector.Connector
 			Runner:             srv, // *http.Server satisfies runner.Runner (streaming)
@@ -1885,6 +1893,7 @@ func main() {
 			ServerName:         "loomcycle",
 			ServerVersion:      buildVersion,
 			MaxConcurrentCalls: mcpMaxConcurrentCalls,
+			SpawnRunTimeoutMS:  mcpSpawnRunTimeoutMS,
 		})
 		// Run the MCP stdio loop in a goroutine. When stdin closes
 		// (Claude Code disconnects), Serve returns; we log and let

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -176,18 +176,68 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 		req.ParentContext = nil
 	}
 
+	// RFC P — transport timeout. A per-call timeout_ms (caller, narrowing)
+	// over the operator default bounds how long this spawn_run CALL blocks
+	// the MCP transport; on expiry we cancel the run (it honors ctx) and
+	// return a status:"timeout" result rather than hanging. Distinct from
+	// the run's own run_timeout_seconds wall-clock budget. 0 = disabled.
+	var callerTimeoutMS struct {
+		TimeoutMS int `json:"timeout_ms"`
+	}
+	_ = json.Unmarshal(args, &callerTimeoutMS) // best-effort; absent → 0
+	effectiveTimeoutMS := effectiveSpawnTimeoutMS(env.spawnRunTimeoutMS, callerTimeoutMS.TimeoutMS)
+
+	runCtx := ctx
+	if effectiveTimeoutMS > 0 {
+		var cancel context.CancelFunc
+		runCtx, cancel = context.WithTimeout(ctx, time.Duration(effectiveTimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+
 	useStreaming := env.session != nil && env.session.RunEventsEnabled() && env.runner != nil
 	var result connector.SpawnRunResult
 	var err error
 	if useStreaming {
-		result, err = spawnRunStreaming(ctx, env, req)
+		result, err = spawnRunStreaming(runCtx, env, req)
 	} else {
-		result, err = env.connector.SpawnRun(ctx, req)
+		result, err = env.connector.SpawnRun(runCtx, req)
+	}
+	// Check the transport deadline BEFORE err: a deadline-cancelled run
+	// surfaces as a ctx error on either path, but we want a structured
+	// timeout result, not a -32603. DeadlineExceeded is specific to our
+	// WithTimeout — a parent-ctx cancel (shutdown / cancel_run) yields
+	// Canceled instead, which falls through to the normal error/result.
+	if effectiveTimeoutMS > 0 && errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+		result.Status = "timeout"
+		if result.Error == "" {
+			result.Error = fmt.Sprintf("spawn_run exceeded the %dms MCP transport timeout; the run was cancelled", effectiveTimeoutMS)
+		}
+		return toolResultJSON(result), nil
 	}
 	if err != nil {
 		return toolErr("spawn_run: " + err.Error()), nil
 	}
 	return toolResultJSON(result), nil
+}
+
+// effectiveSpawnTimeoutMS resolves the spawn_run transport timeout: a
+// caller's per-call timeout_ms narrows the operator default (it may
+// shorten the cap but not extend it). 0 on both → no transport cap (the
+// call blocks until the run finishes on its own run_timeout_seconds
+// budget). This bounds how long the spawn_run CALL blocks the MCP
+// transport — it is not the run's wall-clock budget.
+func effectiveSpawnTimeoutMS(operatorMS, callerMS int) int {
+	switch {
+	case operatorMS > 0 && callerMS > 0:
+		if callerMS < operatorMS {
+			return callerMS // caller narrows
+		}
+		return operatorMS // caller can't exceed the operator cap
+	case callerMS > 0:
+		return callerMS
+	default:
+		return operatorMS
+	}
 }
 
 // spawnRunStreaming drives the runner directly and emits per-event

--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -69,6 +69,15 @@ type Config struct {
 	// (defaultMaxConcurrentCalls). Only consulted by Serve (stdio); the
 	// HTTP transport is already concurrent at the http.Server level.
 	MaxConcurrentCalls int
+
+	// SpawnRunTimeoutMS is the operator default for the spawn_run
+	// TRANSPORT timeout (RFC P): how long a spawn_run MCP call may block
+	// before loomcycle cancels the run and returns a status:"timeout"
+	// result instead of hanging. A caller's per-call timeout_ms narrows
+	// this. <= 0 → disabled (the call blocks until the run finishes on
+	// its own run_timeout_seconds budget). This is a transport bound,
+	// distinct from the run's wall-clock budget.
+	SpawnRunTimeoutMS int
 }
 
 // Server reads MCP JSON-RPC frames from stdin and writes responses +
@@ -408,11 +417,12 @@ func (s *Server) handleToolsCall(ctx context.Context, stdout io.Writer, req loom
 	}
 
 	res, err := handler(ctx, &handlerEnv{
-		connector: s.cfg.Connector,
-		runner:    s.cfg.Runner,
-		session:   s.session,
-		notify:    s.makeNotifier(stdout, req.ID),
-		logf:      s.cfg.Logf,
+		connector:         s.cfg.Connector,
+		runner:            s.cfg.Runner,
+		session:           s.session,
+		notify:            s.makeNotifier(stdout, req.ID),
+		logf:              s.cfg.Logf,
+		spawnRunTimeoutMS: s.cfg.SpawnRunTimeoutMS,
 	}, params.Arguments)
 	if err != nil {
 		// Handler returned a Go error (internal failure, not a
@@ -491,6 +501,9 @@ type handlerEnv struct {
 	session   *Session
 	notify    NotifyFunc
 	logf      func(format string, v ...any)
+	// spawnRunTimeoutMS is the operator-default transport timeout for
+	// spawn_run (Config.SpawnRunTimeoutMS); 0 = disabled.
+	spawnRunTimeoutMS int
 }
 
 func defaultLogf(format string, v ...any) {

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -1151,3 +1151,88 @@ func TestServer_QueuedCallErrorsOnShutdown(t *testing.T) {
 		t.Fatalf("queued call on shutdown: want -32603 error, got %+v", r)
 	}
 }
+
+// --- RFC P: spawn_run transport timeout ------------------------------
+
+func decodeSpawnResult(t *testing.T, r loommcp.Response) connector.SpawnRunResult {
+	t.Helper()
+	var call loommcp.CallToolResult
+	if err := json.Unmarshal(r.Result, &call); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	if len(call.Content) == 0 {
+		t.Fatalf("no content blocks in spawn_run result: %+v", call)
+	}
+	var sr connector.SpawnRunResult
+	if err := json.Unmarshal([]byte(call.Content[0].Text), &sr); err != nil {
+		t.Fatalf("unmarshal spawn result: %v", err)
+	}
+	return sr
+}
+
+func TestEffectiveSpawnTimeoutMS(t *testing.T) {
+	cases := []struct{ op, caller, want int }{
+		{0, 0, 0},       // both unset → no cap
+		{0, 100, 100},   // caller only
+		{200, 0, 200},   // operator only
+		{200, 100, 100}, // caller narrows below the cap
+		{100, 200, 100}, // caller can't exceed the operator cap
+		{100, 100, 100}, // equal
+	}
+	for _, c := range cases {
+		if got := effectiveSpawnTimeoutMS(c.op, c.caller); got != c.want {
+			t.Errorf("effectiveSpawnTimeoutMS(op=%d, caller=%d) = %d; want %d", c.op, c.caller, got, c.want)
+		}
+	}
+}
+
+// TestServer_SpawnRunTimesOut: a per-call timeout_ms bounds a spawn_run
+// whose run never finishes (gate never closed). Without the RFC P
+// timeout the gated call would block forever and waitResp would fatal —
+// so this is also the fail-before regression.
+func TestServer_SpawnRunTimesOut(t *testing.T) {
+	mc := &mockConnector{spawnGate: make(chan struct{})} // never closed
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[],"timeout_ms":120}`))
+	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
+	if got.Status != "timeout" {
+		t.Fatalf("spawn_run status = %q; want \"timeout\"", got.Status)
+	}
+}
+
+// TestServer_SpawnRunOperatorTimeout: the operator default
+// (Config.SpawnRunTimeoutMS) bounds a call that supplies no timeout_ms.
+func TestServer_SpawnRunOperatorTimeout(t *testing.T) {
+	mc := &mockConnector{spawnGate: make(chan struct{})} // never closed
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}, SpawnRunTimeoutMS: 120})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`)) // no per-call timeout_ms
+	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
+	if got.Status != "timeout" {
+		t.Fatalf("spawn_run status = %q; want \"timeout\" (operator default)", got.Status)
+	}
+}
+
+// TestServer_SpawnRunNoTimeoutByDefault: with neither knob set, a
+// completing run returns its normal status (the default imposes no
+// transport cap).
+func TestServer_SpawnRunNoTimeoutByDefault(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed", FinalText: "ok"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ls := newLiveServer(t, srv)
+	defer ls.close()
+
+	ls.handshake()
+	ls.send(toolCallFrame(2, "spawn_run", `{"agent":"x","segments":[]}`))
+	got := decodeSpawnResult(t, ls.waitResp(2, 3*time.Second))
+	if got.Status != "completed" {
+		t.Fatalf("spawn_run status = %q; want \"completed\" (no timeout by default)", got.Status)
+	}
+}

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -42,7 +42,8 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 					"allowed_tools":    {"type": "array", "items": {"type": "string"}},
 					"allowed_hosts":    {"type": "array", "items": {"type": "string"}, "description": "OMIT for no narrowing (operator's static allowlist applies). Pass empty array [] to DENY ALL outbound HTTP. Pass non-empty array to intersect with operator's list."},
 					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]},
-					"parent_context":   {"type": "object", "description": "v0.12.x opaque caller-tracking lineage carried verbatim, inherited by every sub-agent, and echoed on the per-agent report surfaces so a consumer can attribute a child sub-agent's usage to the user-initiated request.", "properties": {"root_agent_run_id": {"type": "string"}, "function_key": {"type": "string"}, "tier_at_run": {"type": "string"}}}
+					"parent_context":   {"type": "object", "description": "v0.12.x opaque caller-tracking lineage carried verbatim, inherited by every sub-agent, and echoed on the per-agent report surfaces so a consumer can attribute a child sub-agent's usage to the user-initiated request.", "properties": {"root_agent_run_id": {"type": "string"}, "function_key": {"type": "string"}, "tier_at_run": {"type": "string"}}},
+					"timeout_ms":       {"type": "integer", "minimum": 1, "description": "Optional transport timeout (RFC P): max milliseconds this spawn_run call may block before loomcycle cancels the run and returns status:\"timeout\" instead of hanging. Narrows the operator default (LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS) — it can shorten but not exceed it. Omit to block until the run finishes on its own run_timeout_seconds budget. This is a transport bound, NOT the run's wall-clock budget."}
 				},
 				"anyOf": [
 					{"required": ["agent"]},


### PR DESCRIPTION
Implements **RFC P** (`loomcycle-internal/doc-internal/rfcs/bounded-cancellable-spawn-run.md`).

> ⚠️ **Stacked on #377 (RFC O).** Base is `feature-mcp-concurrent-dispatch`, not `main` — it reuses RFC O's `handlerCtx` + the `spawnGate`/`liveServer` test harness. **Merge #377 to main first**, then I'll rebase this onto main + retarget the base before merge. The diff shown here is P-only (vs the O branch).

## Why

`spawn_run` blocked the MCP transport for the **entire run** with no per-call timeout (`handlers.go` `SpawnRun`/`RunOnce`). A provider-stalled run (outage) or an interruption-held run (**F15** — a cross-process resolve never wakes it) could tie up the call for minutes to an hour. RFC O stops one slow call from freezing *others*; **RFC P bounds the slow call itself** so it returns a clean result instead of hanging.

## What

`handleSpawnRun` resolves an effective **transport** timeout — per-call `timeout_ms` (caller, narrowing) over the operator default (`Config.SpawnRunTimeoutMS` / env `LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS`) — and, when `> 0`, wraps the run ctx in `context.WithTimeout` (mirroring `stream_user_run_states`). On expiry:
- the run is **cancelled** (`RunOnce` honors ctx — `loop.Run` selects on `ctx.Done()`; the run aborts, not orphaned),
- a **`status:"timeout"`** result is returned, retaining `run_id`/`agent_id` so the caller can `get_run`/`cancel_run`.

`DeadlineExceeded` is matched **specifically**, so a parent-ctx cancel (global shutdown / a concurrent `cancel_run`) returns its normal `cancelled` result, not a spurious timeout.

**Default = 0 (disabled):** the call blocks until the run finishes on its own `run_timeout_seconds` budget (v0.21.0), so legitimately long runs aren't surprise-killed. This is a **transport** bound, distinct from the run's wall-clock budget — operators/clients opt in for a hard cap. `effectiveSpawnTimeoutMS` enforces caller-narrowing (can shorten, can't exceed the operator cap; both-zero = disabled).

- `tools.go`: spawn_run schema gains optional `timeout_ms` (minimum 1, additive/back-compat).
- `server.go`: `SpawnRunTimeoutMS` threaded `Config` → `handlerEnv`.
- `main.go`: env wiring.

## Scope

Does **not** add the non-blocking async spawn mode (RFC P part 3) or fix the **F15** cross-process interruption wake — separate follow-ups. RFC P here is the "(1) bound + (2) honor cancellation" safety net.

## Tested (all under `-race`)

- `TestServer_SpawnRunTimesOut` — per-call `timeout_ms` bounds a gated run. **Fail-before**: without the timeout wrap the gated run blocks forever and the test fatals.
- `TestServer_SpawnRunOperatorTimeout` — the operator default bounds a call with no `timeout_ms`.
- `TestServer_SpawnRunNoTimeoutByDefault` — default-off returns the run's normal status.
- `TestEffectiveSpawnTimeoutMS` — precedence table.

Full `go test ./...` clean; gofmt clean. Independently code-reviewed (deadline-vs-cancel, ordering, precedence, leak, real cancellation, result content): **no issues**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)