### PR TITLE
fix(openai): always serialize content on tool messages (DeepSeek 400) — RFC Q

### DIFF
--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -210,6 +210,30 @@ type wireMessage struct {
 	ReasoningContent string `json:"reasoning_content,omitempty"`
 }
 
+// MarshalJSON forces `content` to always be present on role:"tool"
+// messages, even when empty. OpenAI tolerates an omitted content on a
+// tool message, but DeepSeek's stricter deserializer rejects it with
+// 400 "missing field content" — which broke every tool-using DeepSeek
+// agent the moment a tool returned empty output (a silent `mkdir`, a
+// script that only writes files; see RFC Q / finding F10). For every
+// other role the standard omitempty marshaling is preserved byte-for-
+// byte — notably an assistant message carrying only tool_calls still
+// omits content, which both OpenAI and DeepSeek accept.
+func (m wireMessage) MarshalJSON() ([]byte, error) {
+	type alias wireMessage // shed the MarshalJSON method to avoid recursion
+	if m.Role == "tool" {
+		// The outer Content (no omitempty, depth 0) overrides the
+		// embedded alias's omitempty content (depth 1) — encoding/json
+		// resolves the same-name conflict in favour of the shallower
+		// field, so `content` is always emitted for tool messages.
+		return json.Marshal(struct {
+			alias
+			Content string `json:"content"`
+		}{alias: alias(m), Content: m.Content})
+	}
+	return json.Marshal(alias(m))
+}
+
 type wireToolCall struct {
 	ID       string         `json:"id"`
 	Type     string         `json:"type"` // always "function"

--- a/internal/providers/openai/empty_tool_content_test.go
+++ b/internal/providers/openai/empty_tool_content_test.go
@@ -1,0 +1,105 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// RFC Q / finding F10: the openai-compat driver must always serialize
+// `content` on a role:"tool" message, even when the tool produced empty
+// output. OpenAI tolerates an omitted content; DeepSeek's stricter
+// deserializer 400s with "missing field content", which broke every
+// tool-using DeepSeek agent the moment any tool returned empty stdout
+// (a silent `mkdir`, a script that only writes files).
+
+func decodeWireMessages(t *testing.T, body []byte) []map[string]json.RawMessage {
+	t.Helper()
+	var w struct {
+		Messages []map[string]json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("unmarshal request body: %v (body: %s)", err, body)
+	}
+	return w.Messages
+}
+
+func findByRole(t *testing.T, msgs []map[string]json.RawMessage, role string) map[string]json.RawMessage {
+	t.Helper()
+	for _, m := range msgs {
+		var r string
+		_ = json.Unmarshal(m["role"], &r)
+		if r == role {
+			return m
+		}
+	}
+	t.Fatalf("no message with role=%q in %v", role, msgs)
+	return nil
+}
+
+func TestToolMessage_EmptyResultStillSerializesContent(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{{
+			Role: "user",
+			Content: []providers.ContentBlock{
+				// Empty tool output — the F10 trigger (e.g. `mkdir -p`).
+				{Type: "tool_result", ToolUseID: "call_1", Text: ""},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	tool := findByRole(t, decodeWireMessages(t, body), "tool")
+	raw, ok := tool["content"]
+	if !ok {
+		t.Fatalf("role:tool omitted `content` on empty output — DeepSeek 400s. body: %s", body)
+	}
+	if string(raw) != `""` {
+		t.Errorf("content = %s, want \"\"", raw)
+	}
+}
+
+func TestToolMessage_NonEmptyResultRoundTrips(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{{
+			Role: "user",
+			Content: []providers.ContentBlock{
+				{Type: "tool_result", ToolUseID: "call_1", Text: "done"},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	tool := findByRole(t, decodeWireMessages(t, body), "tool")
+	if string(tool["content"]) != `"done"` {
+		t.Errorf("content = %s, want \"done\"", tool["content"])
+	}
+}
+
+// The fix must NOT change the assistant path: an assistant message that
+// carries only tool_calls (no text) still omits `content`, which both
+// OpenAI and DeepSeek accept. Guards against a "drop omitempty globally"
+// regression.
+func TestAssistantToolCallsOnly_StillOmitsContent(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "deepseek-v4-pro",
+		Messages: []providers.Message{{
+			Role: "assistant",
+			Content: []providers.ContentBlock{
+				{Type: "tool_use", ToolUseID: "call_1", ToolName: "Bash", ToolInput: json.RawMessage(`{"command":"ls"}`)},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	asst := findByRole(t, decodeWireMessages(t, body), "assistant")
+	if _, has := asst["content"]; has {
+		t.Errorf("assistant-with-only-tool_calls should omit content, got: %s", asst["content"])
+	}
+}


### PR DESCRIPTION
Implements **RFC Q** (`loomcycle-internal/doc-internal/rfcs/openai-compat-empty-tool-content.md`) — finding **F10**. Independent of RFC O/P; branched off `main`.

## Why

The openai-compat driver serialized `wireMessage.Content` with `json:"content,omitempty"`, so an **empty tool result** (`role:"tool"`, content `""`) dropped the `content` field entirely. OpenAI tolerates the omission; **DeepSeek's stricter deserializer 400s** with `messages[N]: missing field content` — breaking **every tool-using DeepSeek agent** the moment any tool returned empty stdout (a silent `mkdir -p`, a `cd`, a script that only writes files). Tool-*less* DeepSeek runs were fine, so it hid until an agent used tools. The sandbox's documented workaround was "make every tool print something" — not viable for real agents.

## What

A `MarshalJSON` on `wireMessage` that forces `content` present on **`role:"tool"` only**:
- embedded `type alias wireMessage` sheds the method (no recursion) and carries every other field unchanged;
- an outer `Content string json:"content"` (no `omitempty`) overrides the embedded `omitempty` field — `encoding/json` picks the shallower same-named field, so exactly one `content` is always emitted for tool messages.

Every other role marshals byte-for-byte as before. Critically, an **assistant message carrying only `tool_calls` still omits `content`** (both OpenAI and DeepSeek accept that; emitting `content:""` there would be a behavior change) — guarded by a test.

**Audited the ollama driver:** its `Content` tag is `json:"content"` (no `omitempty`) — it already always emits content, so no fix needed there. Same "serialize for the strict openai-compat consumer" principle as the v0.8.12 `reasoning_content` handling.

## Tested

- `TestToolMessage_EmptyResultStillSerializesContent` — **fail-before verified**: without the fix the tool message is `{"role":"tool","tool_call_id":"call_1"}` (no `content`), the exact DeepSeek-400 trigger.
- `TestToolMessage_NonEmptyResultRoundTrips` — content round-trips.
- `TestAssistantToolCallsOnly_StillOmitsContent` — guards the assistant path against a "drop omitempty globally" regression.

All exercise the real `buildRequestBody → flattenMessage` path. Full `go test ./...` clean; gofmt clean. Independently code-reviewed (recursion, override idiom, non-tool wire unchanged, outbound-only, test soundness): no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)