### PR TITLE
feat(mcp): thin-client mode — loomcycle mcp --upstream proxies to one runtime (RFC R)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -378,6 +378,11 @@ func main() {
 	// and starts HTTP normally so CI scripts conditionally passing the
 	// flag don't hard-fail.
 	noHTTP := flag.Bool("no-http", false, "suppress the HTTP listener (only honoured in `mcp` subcommand mode)")
+	// RFC R thin-client mode: `loomcycle mcp --upstream <url>` runs as a
+	// stdio↔/v1/_mcp proxy to an authoritative runtime, with NO local
+	// runtime. The single-runtime invariant — a second loomcycle process
+	// is a control client, never a second runtime.
+	upstream := flag.String("upstream", "", "(`mcp` mode) run as a thin client proxying to this runtime's /v1/_mcp instead of booting a local runtime")
 	flag.Parse()
 
 	// Resolve --no-http: takes effect only when mcpMode is true. In
@@ -404,6 +409,32 @@ func main() {
 	// debugging spiral. Critical when development cycle is "git pull
 	// && restart" without a rebuild step in between.
 	log.Printf("loomcycle build: version=%s commit=%s time=%s", buildVersion, buildCommit, buildTime)
+
+	// RFC R thin-client mode runs BEFORE any runtime boot — no config
+	// load, no providers, no store, no listener, no second runtime. The
+	// proxy needs only the upstream URL + bearer + stdio.
+	if mcpMode && *upstream != "" {
+		proxyCtx, stopProxy := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+		defer stopProxy()
+		pc := lcmcp.NewProxyClient(lcmcp.ProxyConfig{
+			Upstream: *upstream,
+			Token:    os.Getenv("LOOMCYCLE_MCP_UPSTREAM_TOKEN"),
+			Logf:     log.Printf, // stderr; never stdout (stdout is the JSON-RPC wire)
+		})
+		log.Printf("mcp: thin-client mode → upstream %s (no local runtime)", *upstream)
+		err := pc.Serve(proxyCtx, os.Stdin, os.Stdout)
+		switch {
+		case err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+			// Clean stop: stdin EOF (client disconnect) or a received
+			// signal. Exit 0 so a supervisor doesn't treat a graceful
+			// stop as a crash and loop-restart.
+			log.Printf("mcp: proxy stopped")
+		default:
+			log.Printf("mcp: proxy ended: %v", err)
+			os.Exit(1)
+		}
+		return
+	}
 
 	// v0.11.1 auto-discovery: when --config wasn't overridden AND
 	// the default file doesn't exist, walk the XDG paths. The

--- a/internal/api/mcp/proxy.go
+++ b/internal/api/mcp/proxy.go
@@ -1,0 +1,280 @@
+// proxy.go — RFC R thin-client MCP transport.
+//
+// `loomcycle mcp --upstream <url>` runs in CLIENT mode: a stdio ↔
+// /v1/_mcp proxy that forwards every JSON-RPC frame to the ONE
+// authoritative runtime and holds NO runtime of its own (no providers,
+// scheduler, sweepers, Store, or bus). This enforces the single-runtime
+// invariant — a second loomcycle process is a control client, never a
+// second runtime — which dissolves the cross-process interruption-wake
+// bug (F15), the listener contention (F9), and the rogue-runtime wedge
+// (F16): every meta-tool call, including interruption_resolve, lands on
+// the runtime that actually owns the run.
+//
+// The upstream's HTTP MCP transport (http_transport.go) already
+// implements the full surface, including SSE streaming for
+// spawn_run+runEvents, so the client only does framing, one HTTP/SSE
+// connection per request, auth-header injection, and Mcp-Session-Id
+// continuity.
+package mcp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// ProxyConfig configures the thin-client proxy.
+type ProxyConfig struct {
+	// Upstream is the authoritative runtime's base URL, e.g.
+	// http://127.0.0.1:8788. The proxy POSTs to <Upstream>/v1/_mcp.
+	Upstream string
+	// Token is the bearer for the runtime's /v1/* auth. Empty in
+	// open mode (no auth middleware) — then no Authorization header.
+	Token string
+	// Logf is the log sink (stderr; never stdout — stdout is the wire).
+	Logf func(format string, v ...any)
+	// Client overrides the HTTP client. nil → a default with no overall
+	// timeout (a streaming spawn_run holds the response open for the
+	// whole run; an overall timeout would truncate it).
+	Client *http.Client
+}
+
+// ProxyClient is the thin-client MCP transport. Construct via
+// NewProxyClient; drive via Serve.
+type ProxyClient struct {
+	cfg    ProxyConfig
+	mcpURL string
+	client *http.Client
+
+	// writeMu serialises stdout writes so concurrent forwards (and the
+	// SSE frames of a streaming spawn_run) can't interleave bytes.
+	writeMu sync.Mutex
+	// wg tracks in-flight forward goroutines for clean shutdown.
+	wg sync.WaitGroup
+
+	// session holds the Mcp-Session-Id the upstream assigns at
+	// initialize; echoed on every subsequent request.
+	sessMu  sync.RWMutex
+	session string
+}
+
+// NewProxyClient builds a thin-client proxy targeting Upstream.
+func NewProxyClient(cfg ProxyConfig) *ProxyClient {
+	if cfg.Logf == nil {
+		cfg.Logf = defaultLogf
+	}
+	client := cfg.Client
+	if client == nil {
+		// No overall timeout: streaming spawn_run holds the response
+		// open for the run's duration. Per-request cancellation rides
+		// the request context instead.
+		client = &http.Client{}
+	}
+	return &ProxyClient{
+		cfg:    cfg,
+		mcpURL: strings.TrimRight(cfg.Upstream, "/") + "/v1/_mcp",
+		client: client,
+	}
+}
+
+// Serve runs the read-forward-write loop until stdin closes or ctx is
+// done. initialize is forwarded INLINE so the Mcp-Session-Id is captured
+// before any later frame needs it; every other frame is forwarded on its
+// own goroutine so a long streaming spawn_run can't head-of-line-block
+// the frames behind it (the RFC O property, preserved across the proxy).
+func (p *ProxyClient) Serve(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+	scanner := bufio.NewScanner(stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxHTTPRequestBodyBytes)
+
+	reqCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	for scanner.Scan() {
+		line := append([]byte(nil), scanner.Bytes()...)
+		if len(line) == 0 {
+			continue
+		}
+		if ctx.Err() != nil {
+			break
+		}
+
+		var probe struct {
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(line, &probe)
+
+		if probe.Method == "initialize" {
+			// Inline: capture the session before forwarding anything that
+			// will need it (the upstream requires Mcp-Session-Id on every
+			// non-initialize request).
+			p.forward(reqCtx, line, stdout)
+			continue
+		}
+
+		p.wg.Add(1)
+		go func(fr []byte) {
+			defer p.wg.Done()
+			p.forward(reqCtx, fr, stdout)
+		}(line)
+	}
+
+	scanErr := scanner.Err()
+	p.wg.Wait() // flush in-flight responses before returning
+	if scanErr != nil {
+		return fmt.Errorf("mcp proxy: read stdin: %w", scanErr)
+	}
+	return ctx.Err()
+}
+
+// forward POSTs one JSON-RPC frame to the upstream /v1/_mcp and relays
+// the response (single JSON frame, or each SSE data frame) to stdout.
+func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Writer) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpURL, bytes.NewReader(frame))
+	if err != nil {
+		p.replyError(stdout, frame, "build request: "+err.Error())
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	// Advertise both per the Streamable HTTP spec — strict servers 406
+	// without text/event-stream when SSE is a possible response.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if p.cfg.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+p.cfg.Token)
+	}
+	if sid := p.sessionID(); sid != "" {
+		req.Header.Set("Mcp-Session-Id", sid)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		// Don't leave the MCP client hanging on a dead upstream.
+		p.replyError(stdout, frame, "upstream unreachable: "+err.Error())
+		return
+	}
+	defer resp.Body.Close()
+
+	// Capture the session id the upstream assigned (initialize) or
+	// echoed. set-if-present is idempotent for subsequent requests.
+	if sid := resp.Header.Get("Mcp-Session-Id"); sid != "" {
+		p.setSessionID(sid)
+	}
+
+	// An HTTP-level error (bad session, auth, body too large) arrives as
+	// a non-2xx with a non-JSON-RPC body. Surface it as a JSON-RPC error
+	// addressed to this frame so the client gets a usable response.
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		p.replyError(stdout, frame, fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body))))
+		return
+	}
+
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
+		// If the stream ends without ever delivering a frame carrying the
+		// request id (the final tools/call response), the upstream dropped
+		// mid-run — surface an error so the client isn't left waiting on a
+		// spawn_run that will never answer.
+		if !p.relaySSE(resp.Body, stdout) {
+			p.replyError(stdout, frame, "upstream SSE stream ended before the final response")
+		}
+		return
+	}
+
+	// Single application/json response. An empty body (a notification has
+	// no response) writes nothing.
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		p.replyError(stdout, frame, "read upstream response: "+err.Error())
+		return
+	}
+	if len(bytes.TrimSpace(body)) == 0 {
+		return
+	}
+	p.writeLine(stdout, bytes.TrimRight(body, "\n"))
+}
+
+// relaySSE reads the upstream text/event-stream and writes each JSON-RPC
+// frame (one per `data:` line — loomcycle's sseWriter emits single-line
+// data) to stdout as a newline-delimited frame, in arrival order. It
+// returns true once it has relayed a frame carrying a request id (the
+// final tools/call response), so the caller can tell a complete run from
+// a stream that dropped after only run_event notifications (which have no
+// id).
+func (p *ProxyClient) relaySSE(body io.Reader, stdout io.Writer) bool {
+	sc := bufio.NewScanner(body)
+	sc.Buffer(make([]byte, 0, 64*1024), maxHTTPRequestBodyBytes)
+	sawFinal := false
+	for sc.Scan() {
+		line := sc.Bytes()
+		if !bytes.HasPrefix(line, []byte("data:")) {
+			continue // skip blank separators / other SSE fields
+		}
+		data := bytes.TrimSpace(line[len("data:"):])
+		if len(data) == 0 {
+			continue
+		}
+		var probe struct {
+			ID *int64 `json:"id"`
+		}
+		if json.Unmarshal(data, &probe) == nil && probe.ID != nil {
+			sawFinal = true
+		}
+		p.writeLine(stdout, data)
+	}
+	return sawFinal
+}
+
+// writeLine emits one newline-delimited JSON-RPC frame to stdout under
+// the write mutex (the stdio MCP framing the client expects).
+func (p *ProxyClient) writeLine(stdout io.Writer, frame []byte) {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+	if _, err := stdout.Write(frame); err != nil {
+		p.cfg.Logf("mcp proxy: write stdout: %v", err)
+		return
+	}
+	if _, err := stdout.Write([]byte("\n")); err != nil {
+		p.cfg.Logf("mcp proxy: write newline: %v", err)
+	}
+}
+
+// replyError writes a JSON-RPC error response addressed to the request's
+// id, so a forward failure (dead upstream, HTTP error) doesn't leave the
+// client waiting. Notifications (no id) get no response, by spec.
+func (p *ProxyClient) replyError(stdout io.Writer, frame []byte, msg string) {
+	id, ok := frameRequestID(frame)
+	if !ok {
+		p.cfg.Logf("mcp proxy: %s (notification dropped)", msg)
+		return
+	}
+	resp := loommcp.Response{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error:   &loommcp.Error{Code: -32603, Message: msg},
+	}
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		p.cfg.Logf("mcp proxy: marshal error reply: %v", err)
+		return
+	}
+	p.writeLine(stdout, raw)
+}
+
+func (p *ProxyClient) sessionID() string {
+	p.sessMu.RLock()
+	defer p.sessMu.RUnlock()
+	return p.session
+}
+
+func (p *ProxyClient) setSessionID(id string) {
+	p.sessMu.Lock()
+	defer p.sessMu.Unlock()
+	p.session = id
+}

--- a/internal/api/mcp/proxy_test.go
+++ b/internal/api/mcp/proxy_test.go
@@ -1,0 +1,292 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// --- mock upstream /v1/_mcp -------------------------------------------
+
+type upstreamRec struct {
+	mu   sync.Mutex
+	reqs []recordedReq
+}
+type recordedReq struct {
+	method    string // JSON-RPC method
+	auth      string // Authorization header
+	sessionID string // Mcp-Session-Id header
+}
+
+func (u *upstreamRec) record(r recordedReq) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.reqs = append(u.reqs, r)
+}
+func (u *upstreamRec) snapshot() []recordedReq {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]recordedReq(nil), u.reqs...)
+}
+
+// mockUpstream serves a minimal /v1/_mcp: initialize mints a session and
+// echoes it; a "stream" tool replies with SSE (a notification + a final
+// response); "boom" replies 500; everything else is a single JSON result.
+func mockUpstream(t *testing.T, rec *upstreamRec) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/_mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &p)
+		rec.record(recordedReq{method: p.Method, auth: r.Header.Get("Authorization"), sessionID: r.Header.Get("Mcp-Session-Id")})
+
+		if p.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}`))
+			return
+		}
+		if p.ID == nil { // notification — no response body
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		switch p.Params.Name {
+		case "stream":
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			fl, _ := w.(http.Flusher)
+			io.WriteString(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/loomcycle/run_event\",\"params\":{\"seq\":1}}\n\n")
+			if fl != nil {
+				fl.Flush()
+			}
+			io.WriteString(w, "data: {\"jsonrpc\":\"2.0\",\"id\":"+itoa(*p.ID)+",\"result\":{\"ok\":true}}\n\n")
+		case "drop":
+			// SSE that delivers a notification then ends WITHOUT a final
+			// response frame (simulates an upstream crash mid-run).
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			if fl, ok := w.(http.Flusher); ok {
+				io.WriteString(w, "data: {\"jsonrpc\":\"2.0\",\"method\":\"notifications/loomcycle/run_event\",\"params\":{\"seq\":1}}\n\n")
+				fl.Flush()
+			}
+			// return → stream closes with no id-bearing final frame
+		case "boom":
+			http.Error(w, "kaboom", http.StatusInternalServerError)
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(*p.ID) + `,"result":{"echo":"` + p.Params.Name + `"}}`))
+		}
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func itoa(n int64) string { b, _ := json.Marshal(n); return string(b) }
+
+// --- proxy pipe harness ----------------------------------------------
+
+type proxyHarness struct {
+	t      *testing.T
+	stdinW *io.PipeWriter
+	cancel context.CancelFunc
+	mu     sync.Mutex
+	cond   *sync.Cond
+	got    map[int64]loommcp.Response
+	notes  []loommcp.Notification
+}
+
+func newProxyHarness(t *testing.T, pc *ProxyClient) *proxyHarness {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	h := &proxyHarness{t: t, stdinW: inW, cancel: cancel, got: map[int64]loommcp.Response{}}
+	h.cond = sync.NewCond(&h.mu)
+	go func() { _ = pc.Serve(ctx, inR, outW); _ = outW.Close() }()
+	go func() {
+		sc := bufio.NewScanner(outR)
+		sc.Buffer(make([]byte, 0, 64*1024), maxHTTPRequestBodyBytes)
+		for sc.Scan() {
+			line := sc.Bytes()
+			var probe struct {
+				ID *int64 `json:"id"`
+			}
+			if json.Unmarshal(line, &probe) != nil {
+				continue
+			}
+			h.mu.Lock()
+			if probe.ID != nil {
+				var r loommcp.Response
+				if json.Unmarshal(line, &r) == nil {
+					h.got[*probe.ID] = r
+				}
+			} else {
+				var n loommcp.Notification
+				if json.Unmarshal(line, &n) == nil {
+					h.notes = append(h.notes, n)
+				}
+			}
+			h.cond.Broadcast()
+			h.mu.Unlock()
+		}
+	}()
+	return h
+}
+
+func (h *proxyHarness) send(frame string) {
+	if _, err := io.WriteString(h.stdinW, frame+"\n"); err != nil {
+		h.t.Fatalf("send: %v", err)
+	}
+}
+func (h *proxyHarness) waitResp(id int64, timeout time.Duration) loommcp.Response {
+	h.t.Helper()
+	deadline := time.Now().Add(timeout)
+	timer := time.AfterFunc(timeout, func() { h.mu.Lock(); h.cond.Broadcast(); h.mu.Unlock() })
+	defer timer.Stop()
+	h.mu.Lock()
+	for {
+		if r, ok := h.got[id]; ok {
+			h.mu.Unlock()
+			return r
+		}
+		if time.Now().After(deadline) {
+			h.mu.Unlock()
+			h.t.Fatalf("timeout waiting for response id=%d", id)
+			return loommcp.Response{}
+		}
+		h.cond.Wait()
+	}
+}
+func (h *proxyHarness) noteCount() int { h.mu.Lock(); defer h.mu.Unlock(); return len(h.notes) }
+func (h *proxyHarness) close()         { _ = h.stdinW.Close(); h.cancel() }
+
+func initFrame() string {
+	return `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`
+}
+func callFrame(id int64, name string) string {
+	return `{"jsonrpc":"2.0","id":` + itoa(id) + `,"method":"tools/call","params":{"name":"` + name + `","arguments":{}}}`
+}
+
+// --- tests ------------------------------------------------------------
+
+func TestProxy_ForwardsWithAuthAndSession(t *testing.T) {
+	rec := &upstreamRec{}
+	up := mockUpstream(t, rec)
+	pc := NewProxyClient(ProxyConfig{Upstream: up.URL, Token: "tok-123", Logf: func(string, ...any) {}})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second) // initialize response relayed
+	h.send(callFrame(2, "memory"))
+	got := h.waitResp(2, 2*time.Second)
+	if got.Error != nil {
+		t.Fatalf("unexpected error: %+v", got.Error)
+	}
+
+	reqs := rec.snapshot()
+	if len(reqs) < 2 {
+		t.Fatalf("upstream saw %d requests, want >=2", len(reqs))
+	}
+	// Both requests carry the bearer; the post-initialize request carries
+	// the session the upstream minted.
+	for _, r := range reqs {
+		if r.auth != "Bearer tok-123" {
+			t.Errorf("request %q auth = %q, want Bearer tok-123", r.method, r.auth)
+		}
+	}
+	var toolReq *recordedReq
+	for i := range reqs {
+		if reqs[i].method == "tools/call" {
+			toolReq = &reqs[i]
+		}
+	}
+	if toolReq == nil || toolReq.sessionID != "sess-1" {
+		t.Fatalf("tools/call Mcp-Session-Id = %v, want sess-1", toolReq)
+	}
+}
+
+func TestProxy_RelaysSSEStream(t *testing.T) {
+	rec := &upstreamRec{}
+	up := mockUpstream(t, rec)
+	pc := NewProxyClient(ProxyConfig{Upstream: up.URL, Logf: func(string, ...any) {}})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(7, "stream")) // upstream answers with SSE: 1 notification + final response
+	got := h.waitResp(7, 2*time.Second)
+	if got.Error != nil {
+		t.Fatalf("stream final response error: %+v", got.Error)
+	}
+	// The run_event notification frame should have been relayed too.
+	deadline := time.Now().Add(time.Second)
+	for h.noteCount() == 0 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if h.noteCount() == 0 {
+		t.Fatal("SSE notification frame was not relayed to stdout")
+	}
+}
+
+func TestProxy_SSEDropBeforeFinalRepliesError(t *testing.T) {
+	rec := &upstreamRec{}
+	up := mockUpstream(t, rec)
+	pc := NewProxyClient(ProxyConfig{Upstream: up.URL, Logf: func(string, ...any) {}})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(11, "drop")) // SSE notification then stream ends, no final response
+	got := h.waitResp(11, 2*time.Second)
+	if got.Error == nil {
+		t.Fatal("SSE stream that dropped before the final response should surface a JSON-RPC error")
+	}
+}
+
+func TestProxy_UpstreamHTTPErrorBecomesJSONRPC(t *testing.T) {
+	rec := &upstreamRec{}
+	up := mockUpstream(t, rec)
+	pc := NewProxyClient(ProxyConfig{Upstream: up.URL, Logf: func(string, ...any) {}})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(9, "boom")) // upstream 500
+	got := h.waitResp(9, 2*time.Second)
+	if got.Error == nil {
+		t.Fatal("upstream 500 should surface as a JSON-RPC error, got success")
+	}
+}
+
+func TestProxy_DeadUpstreamRepliesError(t *testing.T) {
+	// Unreachable upstream → the proxy must reply with an error, not hang.
+	pc := NewProxyClient(ProxyConfig{Upstream: "http://127.0.0.1:1", Logf: func(string, ...any) {}})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(callFrame(3, "memory"))
+	got := h.waitResp(3, 3*time.Second)
+	if got.Error == nil {
+		t.Fatal("dead upstream should surface a JSON-RPC error")
+	}
+}


### PR DESCRIPTION
First slice of **RFC R** (`loomcycle-internal/.../mcp-thin-client-single-runtime.md`). Off `main`, independent.

## Why

The plugin's `loomcycle mcp` boots a **full second runtime** alongside the operator's real one (private in-process bus, own scheduler/sweepers/Store), coordinating only via shared `./data`. That two-runtime topology is the root of **F15** (cross-process `interruption_resolve` writes the DB row but never wakes the run — `bus.Notify` fires on the wrong process's bus), **F9** (listener contention; `--no-http` only mutes it), and **F16** (rogue-runtime wedge).

## What

A **client mode**: `loomcycle mcp --upstream <url>` runs a thin **stdio↔`/v1/_mcp` proxy** to the one authoritative runtime and boots **no local runtime** — no providers, scheduler, sweepers, Store, listener, or bus. The branch runs in `main.go` **before any runtime boot**. Every meta-tool call — including `interruption_resolve` — lands on the runtime that owns the run, so **F15 can't occur**; with no second runtime, **F9/F16 are gone** too.

- `ProxyClient.Serve`: `initialize` forwarded **inline** (captures the `Mcp-Session-Id` the upstream mints before later frames need it); every other frame on its own goroutine (preserves RFC O's no-HOL property).
- `forward()`: POSTs to `<upstream>/v1/_mcp` with `Content-Type` + `Accept: application/json, text/event-stream` + `Authorization: Bearer $LOOMCYCLE_MCP_UPSTREAM_TOKEN` + `Mcp-Session-Id`; relays a single JSON body **or** each SSE `data:` frame to stdout (the upstream already streams `spawn_run`+runEvents over SSE).
- **Robustness:** a dead/erroring upstream, or an SSE stream that **drops before the final response**, surfaces a JSON-RPC error addressed to the frame's id — the client never hangs. stdout serialized by `writeMu`; session `RWMutex`-guarded; `wg.Wait` flushes in-flight on shutdown; per-request ctx is a child of the serve ctx so signals abort in-flight HTTP calls; clean shutdown (stdin EOF / signal) exits 0.

`embedded` mode (no `--upstream`) is **unchanged** — for standalone/single-host (one process, one bus, so F15 can't occur there either).

## Tested

`-race`: forward-with-auth-and-session, SSE relay, SSE-drop→error, upstream-HTTP-error→JSON-RPC, dead-upstream→error (mock `/v1/_mcp` + pipe harness). Full `go test ./...` clean; gofmt clean. Real binary: `mcp --upstream` logs `thin-client mode`, boots **no runtime**, errors cleanly on a dead upstream. Independently code-reviewed; both findings fixed (clean-shutdown exit code; SSE-drop final-response error).

## Follow-ups (RFC R, separate PRs)

- The `claude-code-plugin-loomcycle` `.mcp.json` switch to `--upstream` (the cross-repo wiring change).
- `doctor` warning when a second runtime points at a `./data` already owned by another process.
- Retiring "full runtime under `--no-http`" (the anti-pattern the invariant forbids).

🤖 Generated with [Claude Code](https://claude.com/claude-code)