### PR TITLE
fix(webhook): resolve static + LOOMCYCLE_* secrets; add auth.kind:none (F23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -350,3 +350,32 @@ LOOMCYCLE_DATA_DIR=./data
 # (300000 vs 30000) won't leave the runtime in StatePausing for an
 # extended period during which new runs 503.
 # LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS=30000
+
+# ---- RFC H inbound webhooks --------------------------------------------
+# External systems (GitHub/Gitea/Stripe/Linear/CI/n8n) trigger agent runs
+# or wake parked agents via signed POST /v1/_webhooks/{name}. Off by
+# default; the WebhookDef tool still authors/lists defs while disabled.
+# LOOMCYCLE_WEBHOOKS_ENABLED=1
+#
+# Secret resolution: a webhook's signing_secret_env / bearer_token_env /
+# user_credentials_from_env env-var NAMES must be authorized, or every
+# delivery 503s `secret_unresolvable`. A name is authorized when ANY of:
+#   1. it is LOOMCYCLE_*-prefixed (or a known third-party name) — auto-
+#      allowed for the VERIFY secret only (consumed by the receiver, never
+#      reaches the agent). So signing_secret_env: LOOMCYCLE_X Just Works.
+#   2. it is declared by a STATIC (yaml) webhook — auto-trusted.
+#   3. it is listed here (comma-separated) or in the scheduler's shared
+#      LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST. REQUIRED for a runtime
+#      (webhookdef-tool) def's non-LOOMCYCLE_ credential env names — those
+#      do NOT get the namespace auto-allow (they reach the agent).
+# LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST=GITEA_WEBHOOK_SECRET,STRIPE_WH_SECRET
+#
+# Trusted-network ingress: honor `auth.kind: none` (skip HMAC) for a
+# receiver only reachable over an already-authenticated transport
+# (WireGuard/tailnet, mTLS). Default OFF — a none-auth webhook 503s
+# `unauthenticated_mode_disabled` until this is set.
+# LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1
+#
+# Shared trigger-credential allowlist (also gates scheduled-run
+# user_credentials_from_env). Merged with LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST.
+# LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST=GITEA_API_TOKEN

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1416,18 +1416,23 @@ func main() {
 	// Registered BEFORE srv.Mux() below — the SetWebhookMux hook fires
 	// inside Mux(), same ordering constraint as SetExtraMux for A2A.
 	if cfg.Env.WebhooksEnabled && storeIface != nil && srv != nil {
-		webhookAllowlist := make(map[string]bool, len(cfg.Env.SchedulerEnvAllowlist))
-		for _, name := range cfg.Env.SchedulerEnvAllowlist {
-			webhookAllowlist[name] = true
-		}
+		// The receiver's secret/credential allowlist is the union of the
+		// explicit operator knobs (LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST +
+		// LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST) and every secret env declared by a
+		// STATIC webhook — so an operator-authored webhook resolves its own
+		// secret without a separate allowlist entry (the F23 trap). A
+		// LOOMCYCLE_*-named VERIFY secret resolves via the namespace auto-allow
+		// in resolveSecret even when not seeded here.
+		webhookAllowlist := webhookapi.BuildEnvAllowlist(cfg)
 		rec := webhookapi.New(webhookapi.Deps{
-			Store:        storeIface,
-			Cfg:          cfg,
-			Runner:       srv,
-			Publisher:    sysPublisher,
-			RunStateBus:  runStateBus,
-			EnvAllowlist: webhookAllowlist,
-			Logf:         log.Printf,
+			Store:                storeIface,
+			Cfg:                  cfg,
+			Runner:               srv,
+			Publisher:            sysPublisher,
+			RunStateBus:          runStateBus,
+			EnvAllowlist:         webhookAllowlist,
+			AllowUnauthenticated: cfg.Env.WebhooksAllowUnauthenticated,
+			Logf:                 log.Printf,
 		})
 		srv.SetWebhookMux(func(reg lchttp.MuxRegistrar, adminAuth func(http.Handler) http.Handler) {
 			// Receiver POST: unauthed (per-WebhookDef secret). Triage
@@ -1435,8 +1440,14 @@ func main() {
 			rec.Mount(reg)
 			rec.MountAdmin(reg, adminAuth)
 		})
-		log.Printf("webhooks: enabled (receiver mounted at POST /v1/_webhooks/{name}, env_allowlist=%d names)",
-			len(cfg.Env.SchedulerEnvAllowlist))
+		log.Printf("webhooks: enabled (POST /v1/_webhooks/{name}, env_allowlist=%d names via LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST + LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST + static-declared secrets; LOOMCYCLE_* verify-secrets auto-allowed; unauthenticated_mode=%t)",
+			len(webhookAllowlist), cfg.Env.WebhooksAllowUnauthenticated)
+		// Surface every static webhook that will fail every delivery (inert,
+		// or its secret won't resolve) so the operator sees WHY at boot rather
+		// than discovering it via a 503 — the F23/F24 discoverability gap.
+		for _, warn := range webhookapi.UnresolvableStaticSecrets(cfg, webhookAllowlist, os.Getenv) {
+			log.Printf("webhooks: WARNING: %s", warn)
+		}
 	} else if cfg.Env.WebhooksEnabled {
 		log.Printf("webhooks: disabled (no Store backend or no HTTP server)")
 	} else {

--- a/internal/api/webhook/allowlist.go
+++ b/internal/api/webhook/allowlist.go
@@ -1,0 +1,112 @@
+package webhook
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// BuildEnvAllowlist computes the env-var-NAME allowlist the receiver uses to
+// gate secret + credential resolution. It is the union of:
+//
+//   - the explicit operator knobs: cfg.Env.SchedulerEnvAllowlist
+//     (LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST) and cfg.Env.WebhooksEnvAllowlist
+//     (LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST);
+//   - every env-var NAME declared by a STATIC (operator-authored) webhook in
+//     cfg.Webhooks: the HMAC signing secret, the bearer token, and every value
+//     in user_credentials_from_env.
+//
+// Static-declared names are auto-trusted because the operator wrote the yaml.
+// Requiring them to ALSO appear in the allowlist env var was the F23 trap: a
+// static webhook's own signing_secret_env silently never resolved (the
+// allowlist stayed at 0 names) and every signed delivery 503'd.
+//
+// Runtime (webhookdef-authored) defs are deliberately NOT scanned here. Their
+// secret/cred env names still need an explicit allowlist entry — except a
+// LOOMCYCLE_*-named VERIFY secret, which resolveSecret admits via the namespace
+// auto-allow (a verify secret never reaches the agent). This keeps a
+// less-trusted authoring path from naming an arbitrary env var as an
+// agent-reachable credential source.
+func BuildEnvAllowlist(cfg *config.Config) map[string]bool {
+	allow := make(map[string]bool)
+	if cfg == nil {
+		return allow
+	}
+	add := func(name string) {
+		if name != "" {
+			allow[name] = true
+		}
+	}
+	for _, name := range cfg.Env.SchedulerEnvAllowlist {
+		add(name)
+	}
+	for _, name := range cfg.Env.WebhooksEnvAllowlist {
+		add(name)
+	}
+	for _, w := range cfg.Webhooks {
+		add(w.Auth.SigningSecretEnv)
+		add(w.Auth.BearerTokenEnv)
+		for _, envName := range w.UserCredentialsFromEnv {
+			add(envName)
+		}
+	}
+	return allow
+}
+
+// UnresolvableStaticSecrets returns one human-readable warning per STATIC
+// webhook that is misconfigured in a way that will fail every delivery:
+//
+//   - enabled:false (addressable but inert — 404s every delivery);
+//   - a verify secret that will not resolve at request time (not allowlisted
+//     and not LOOMCYCLE_*-prefixed, or allowlisted-but-unset/empty);
+//   - auth.kind requires a secret but none is configured.
+//
+// Logged once at boot so an operator seeing "env_allowlist=N names" also sees
+// exactly which webhook will 503 and why — the discoverability gap that made
+// F23 a multi-hour dead end. Pure + getenv-injected for unit-testing; the
+// returned slice order is unspecified (map iteration).
+func UnresolvableStaticSecrets(cfg *config.Config, allow map[string]bool, getenv func(string) string) []string {
+	var warns []string
+	if cfg == nil {
+		return warns
+	}
+	for name, w := range cfg.Webhooks {
+		if !w.Enabled {
+			warns = append(warns, fmt.Sprintf("webhook %q: enabled:false — addressable but inert (every delivery 404s)", name))
+			continue
+		}
+		kind := strings.ToLower(strings.TrimSpace(w.Auth.Kind))
+		var envName string
+		switch kind {
+		case "", "hmac":
+			envName = w.Auth.SigningSecretEnv
+		case "bearer":
+			envName = w.Auth.BearerTokenEnv
+		case "none":
+			continue // no verification secret needed (gated by allowUnauthenticated at request time)
+		default:
+			warns = append(warns, fmt.Sprintf("webhook %q: unknown auth.kind %q — every delivery 503s", name, w.Auth.Kind))
+			continue
+		}
+		if envName == "" {
+			warns = append(warns, fmt.Sprintf("webhook %q: auth.kind=%s but no secret env configured — every delivery 503s", name, kindOrHMAC(kind)))
+			continue
+		}
+		if !allow[envName] && !config.ExpandEnvAllowed(envName) {
+			warns = append(warns, fmt.Sprintf("webhook %q: secret env %q not allowlisted (add it to LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST or use a LOOMCYCLE_*-prefixed name) — every delivery 503s", name, envName))
+			continue
+		}
+		if getenv(envName) == "" {
+			warns = append(warns, fmt.Sprintf("webhook %q: secret env %q is allowlisted but unset/empty — every delivery 503s", name, envName))
+		}
+	}
+	return warns
+}
+
+func kindOrHMAC(kind string) string {
+	if kind == "" {
+		return "hmac"
+	}
+	return kind
+}

--- a/internal/api/webhook/allowlist_test.go
+++ b/internal/api/webhook/allowlist_test.go
@@ -1,0 +1,193 @@
+package webhook
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// F23 regression: a LOOMCYCLE_*-prefixed VERIFY secret resolves even when the
+// explicit allowlist is empty (the namespace auto-allow, mirroring YAML
+// ${LOOMCYCLE_*} expansion). On the unfixed code resolveSecret returned
+// verdictUnresolved here — the exact "secret_unresolvable / env_allowlist=0"
+// trap that blocked exp4.
+func TestResolveSecret_LoomcyclePrefixAutoAllowed(t *testing.T) {
+	env := mapGetenv(map[string]string{"LOOMCYCLE_GITEA_WEBHOOK_SECRET": "s3cr3t"})
+	got, err := resolveSecret("LOOMCYCLE_GITEA_WEBHOOK_SECRET", map[string]bool{}, env)
+	if err != nil {
+		t.Fatalf("LOOMCYCLE_* secret should auto-resolve with empty allowlist, got %v", err)
+	}
+	if got != "s3cr3t" {
+		t.Fatalf("resolved value = %q, want s3cr3t", got)
+	}
+}
+
+// A non-LOOMCYCLE_, non-allowlisted, non-static-declared name stays gated —
+// the security floor for runtime-authored defs is preserved.
+func TestResolveSecret_NonPrefixedNotDeclaredStillGated(t *testing.T) {
+	env := mapGetenv(map[string]string{"GITEA_SECRET": "s3cr3t"})
+	if _, err := resolveSecret("GITEA_SECRET", map[string]bool{}, env); err == nil {
+		t.Fatal("non-prefixed secret not in allowlist should be unresolvable, got nil error")
+	}
+	// Allowlisting it explicitly (as BuildEnvAllowlist does for static defs)
+	// makes it resolve.
+	if _, err := resolveSecret("GITEA_SECRET", map[string]bool{"GITEA_SECRET": true}, env); err != nil {
+		t.Fatalf("allowlisted secret should resolve, got %v", err)
+	}
+}
+
+// Auto-allow does not paper over an unset/empty value — that is still a
+// config error the operator must fix.
+func TestResolveSecret_LoomcyclePrefixButUnset_StillUnresolved(t *testing.T) {
+	env := mapGetenv(map[string]string{}) // LOOMCYCLE_X present in name, absent in env
+	if _, err := resolveSecret("LOOMCYCLE_X", map[string]bool{}, env); err == nil {
+		t.Fatal("auto-allowed but unset secret should be unresolvable, got nil error")
+	}
+}
+
+// BuildEnvAllowlist seeds the union of the two explicit knobs AND every
+// secret/credential env NAME declared by a STATIC webhook — so an
+// operator-authored webhook's own (even non-LOOMCYCLE_) secret resolves
+// without a separate allowlist entry.
+func TestBuildEnvAllowlist_SeedsStaticDeclaredAndMergesKnobs(t *testing.T) {
+	cfg := &config.Config{
+		Webhooks: map[string]config.Webhook{
+			"gitea": {
+				Enabled: true,
+				Auth:    config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "GITEA_WEBHOOK_SECRET"},
+			},
+			"bear": {
+				Enabled:                true,
+				Auth:                   config.WebhookAuth{Kind: "bearer", BearerTokenEnv: "BEARER_TOKEN_ENV"},
+				UserCredentialsFromEnv: map[string]string{"api": "GITEA_API_TOKEN"},
+			},
+		},
+	}
+	cfg.Env.SchedulerEnvAllowlist = []string{"SCHED_VAR"}
+	cfg.Env.WebhooksEnvAllowlist = []string{"WEBHOOK_VAR"}
+
+	allow := BuildEnvAllowlist(cfg)
+	for _, want := range []string{
+		"GITEA_WEBHOOK_SECRET", // static hmac signing secret (non-prefixed)
+		"BEARER_TOKEN_ENV",     // static bearer token
+		"GITEA_API_TOKEN",      // static user_credentials_from_env value
+		"SCHED_VAR",            // LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST
+		"WEBHOOK_VAR",          // LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST
+	} {
+		if !allow[want] {
+			t.Errorf("allowlist missing %q (got %v)", want, allow)
+		}
+	}
+	// A name nobody declared is not present.
+	if allow["UNRELATED"] {
+		t.Error("allowlist contains an undeclared name")
+	}
+}
+
+// Q2 (verify-only auto-allow): user_credentials_from_env — the agent-reachable
+// path — does NOT get the LOOMCYCLE_* namespace auto-allow. A LOOMCYCLE_-named
+// credential env is dropped unless it is in the explicit/seeded allowlist, so a
+// runtime-authored webhook cannot inject an arbitrary LOOMCYCLE_* value into a
+// run. (Contrast resolveSecret, which DOES auto-allow LOOMCYCLE_* verify
+// secrets — those never reach the agent.)
+func TestBuildRunInput_CredEnv_NoNamespaceAutoAllow(t *testing.T) {
+	w := config.Webhook{
+		Agent:                  "a",
+		UserCredentialsFromEnv: map[string]string{"tok": "LOOMCYCLE_RUNTIME_CRED"},
+	}
+	env := mapGetenv(map[string]string{"LOOMCYCLE_RUNTIME_CRED": "value"})
+	proj := projectResult{Fields: map[string]string{}}
+
+	// Not allowlisted → dropped despite the LOOMCYCLE_ prefix.
+	in := buildRunInput(w, proj, map[string]bool{}, env, nil)
+	if _, ok := in.UserCredentials["tok"]; ok {
+		t.Fatalf("LOOMCYCLE_-prefixed credential must NOT be auto-allowed for injection; got %v", in.UserCredentials)
+	}
+
+	// Explicitly allowlisted (as BuildEnvAllowlist would for a STATIC decl) → used.
+	in = buildRunInput(w, proj, map[string]bool{"LOOMCYCLE_RUNTIME_CRED": true}, env, nil)
+	if in.UserCredentials["tok"] != "value" {
+		t.Fatalf("allowlisted credential should be injected; got %v", in.UserCredentials)
+	}
+}
+
+// UnresolvableStaticSecrets surfaces exactly the static webhooks that will fail
+// every delivery — the boot-time discoverability fix for F23/F24.
+func TestUnresolvableStaticSecrets_Warnings(t *testing.T) {
+	cfg := &config.Config{
+		Webhooks: map[string]config.Webhook{
+			"ok":         {Enabled: true, Auth: config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "LOOMCYCLE_OK"}},
+			"disabled":   {Enabled: false, Auth: config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "LOOMCYCLE_OK"}},
+			"notallowed": {Enabled: true, Auth: config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "GITEA_SECRET"}},
+			"unset":      {Enabled: true, Auth: config.WebhookAuth{Kind: "hmac", SigningSecretEnv: "LOOMCYCLE_UNSET"}},
+			"nosecret":   {Enabled: true, Auth: config.WebhookAuth{Kind: "hmac"}},
+			"none":       {Enabled: true, Auth: config.WebhookAuth{Kind: "none"}},
+		},
+	}
+	allow := BuildEnvAllowlist(cfg) // seeds GITEA_SECRET (static) — so it must NOT warn for "notallowed"
+	env := mapGetenv(map[string]string{"LOOMCYCLE_OK": "v", "GITEA_SECRET": "v"})
+
+	warns := UnresolvableStaticSecrets(cfg, allow, env)
+	joined := strings.Join(warns, "\n")
+
+	mustContain := []string{"disabled", "unset", "nosecret"}
+	for _, name := range mustContain {
+		if !strings.Contains(joined, "\""+name+"\"") {
+			t.Errorf("expected a warning naming %q; warnings:\n%s", name, joined)
+		}
+	}
+	mustNotContain := []string{"\"ok\"", "\"none\"", "\"notallowed\""}
+	for _, frag := range mustNotContain {
+		if strings.Contains(joined, frag) {
+			t.Errorf("did not expect a warning for %s; warnings:\n%s", frag, joined)
+		}
+	}
+}
+
+// auth.kind=none is gated by AllowUnauthenticated: 503 when off, accepted when
+// on. The trusted-network escape hatch must never silently accept by default.
+func TestReceiver_NoneKind_GatedByFlag(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"go"}`)
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "a",
+		Auth:           config.WebhookAuth{Kind: "none"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+
+	// Flag OFF → 503 unauthenticated_mode_disabled, no run.
+	frOff := &fakeRunner{runID: "r", agentID: "a"}
+	recOff := New(Deps{
+		Cfg:    &config.Config{Webhooks: map[string]config.Webhook{"wh": wh}},
+		Runner: frOff,
+		Now:    fixedClock(now),
+		Getenv: mapGetenv(map[string]string{}),
+	})
+	if w := doPost(recOff, "wh", body, http.Header{}); w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("flag off: status = %d, want 503; body=%s", w.Code, w.Body.String())
+	}
+	if frOff.wasCalled() {
+		t.Fatal("flag off: runner must not be invoked for none-auth")
+	}
+
+	// Flag ON → accepted (202), run spawned.
+	frOn := &fakeRunner{runID: "r", agentID: "a"}
+	recOn := New(Deps{
+		Cfg:                  &config.Config{Webhooks: map[string]config.Webhook{"wh": wh}},
+		Runner:               frOn,
+		AllowUnauthenticated: true,
+		Now:                  fixedClock(now),
+		Getenv:               mapGetenv(map[string]string{}),
+	})
+	if w := doPost(recOn, "wh", body, http.Header{}); w.Code != http.StatusAccepted {
+		t.Fatalf("flag on: status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if !frOn.wasCalled() {
+		t.Fatal("flag on: runner should be invoked for accepted none-auth delivery")
+	}
+}

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,7 +44,11 @@ type Receiver struct {
 	publisher    channels.SystemPublisher
 	runStateBus  *runstate.Bus
 	envAllowlist map[string]bool
-	logf         func(format string, args ...any)
+	// allowUnauthenticated honors auth.kind="none" (skip verification). When
+	// false (default) a none-auth webhook 503s rather than silently accepting
+	// unsigned external POSTs. Set from LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED.
+	allowUnauthenticated bool
+	logf                 func(format string, args ...any)
 
 	dedup   *dedupCache
 	limiter *rateLimiter
@@ -71,7 +76,9 @@ type Deps struct {
 	Publisher    channels.SystemPublisher
 	RunStateBus  *runstate.Bus
 	EnvAllowlist map[string]bool
-	Logf         func(format string, args ...any)
+	// AllowUnauthenticated enables auth.kind="none" webhooks. Default false.
+	AllowUnauthenticated bool
+	Logf                 func(format string, args ...any)
 
 	// Now + Getenv are test seams. Nil falls back to time.Now / os.Getenv.
 	Now    func() time.Time
@@ -94,17 +101,18 @@ func New(d Deps) *Receiver {
 		logf = func(string, ...any) {}
 	}
 	return &Receiver{
-		store:        d.Store,
-		cfg:          d.Cfg,
-		runner:       d.Runner,
-		publisher:    d.Publisher,
-		runStateBus:  d.RunStateBus,
-		envAllowlist: d.EnvAllowlist,
-		logf:         logf,
-		dedup:        newDedupCache(now),
-		limiter:      newRateLimiter(now),
-		now:          now,
-		getenv:       getenv,
+		store:                d.Store,
+		cfg:                  d.Cfg,
+		runner:               d.Runner,
+		publisher:            d.Publisher,
+		runStateBus:          d.RunStateBus,
+		envAllowlist:         d.EnvAllowlist,
+		allowUnauthenticated: d.AllowUnauthenticated,
+		logf:                 logf,
+		dedup:                newDedupCache(now),
+		limiter:              newRateLimiter(now),
+		now:                  now,
+		getenv:               getenv,
 	}
 }
 
@@ -163,8 +171,22 @@ func (rec *Receiver) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. VERIFY BEFORE PARSE — signature over the raw bytes.
-	if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
+	// 3. AUTHENTICATE (VERIFY BEFORE PARSE — over the raw bytes).
+	//
+	//    auth.kind="none" is the trusted-network escape hatch: skip
+	//    verification entirely, but ONLY when the operator has explicitly
+	//    opted in (LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1). Otherwise it
+	//    503s loudly — silently accepting unsigned external POSTs would be a
+	//    footgun, so the default refuses even though the Def asked for no auth.
+	if strings.EqualFold(strings.TrimSpace(wd.Auth.Kind), "none") {
+		if !rec.allowUnauthenticated {
+			rec.finish(span, name, "", verdictUnresolved, "")
+			rec.logf("webhook %q: auth.kind=none but LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED is not set — refusing", name)
+			writeError(w, http.StatusServiceUnavailable, "unauthenticated_mode_disabled", "set LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1 to enable auth.kind=none")
+			return
+		}
+		rec.logf("webhook %q: accepted UNAUTHENTICATED delivery (auth.kind=none)", name)
+	} else if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
 		var ae *authError
 		if errors.As(verr, &ae) && ae.verdict == verdictUnresolved {
 			// Config-side failure (secret not allowlisted / unset). 503 names

--- a/internal/api/webhook/signature.go
+++ b/internal/api/webhook/signature.go
@@ -71,9 +71,20 @@ const (
 // to 401 with NO body detail.
 var errSignatureMismatch = errors.New("signature_mismatch")
 
-// resolveSecret reads an env var through the allowlist gate. Returns the
-// secret_unresolvable authError when the var is not allowlisted, unset, or
-// empty. The returned value is a secret — callers must never log it.
+// resolveSecret reads a VERIFICATION secret (HMAC signing key / bearer token)
+// through the allowlist gate. Returns the secret_unresolvable authError when the
+// var is not allowlisted, unset, or empty. The returned value is a secret —
+// callers must never log it.
+//
+// The gate admits a name when EITHER it is in the explicit allowlist (the
+// operator's LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST / LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST
+// + every statically-declared webhook secret, seeded by BuildEnvAllowlist) OR it
+// passes config.ExpandEnvAllowed (the LOOMCYCLE_* namespace + known third-party
+// names — the same predicate that gates YAML ${...} expansion). The namespace
+// auto-allow is safe HERE because a verification secret is consumed by the
+// receiver for hmac.Equal / CompareBearer and never reaches the agent. The
+// agent-reachable user_credentials_from_env path deliberately does NOT get this
+// auto-allow (see buildRunInput) — it stays gated on the explicit allowlist.
 //
 // getenv is injected (rather than calling os.Getenv directly) so tests can
 // drive the allowlist/unset/empty branches deterministically without
@@ -82,8 +93,8 @@ func resolveSecret(envName string, allowlist map[string]bool, getenv func(string
 	if envName == "" {
 		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: "auth: no secret env var configured"}
 	}
-	if !allowlist[envName] {
-		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: fmt.Sprintf("auth: env var %q not in allowlist", envName)}
+	if !allowlist[envName] && !config.ExpandEnvAllowed(envName) {
+		return "", &authError{verdict: verdictUnresolved, secretEnv: envName, msg: fmt.Sprintf("auth: env var %q not allowlisted (add it to LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST, or use a LOOMCYCLE_*-prefixed name)", envName)}
 	}
 	v := getenv(envName)
 	if v == "" {

--- a/internal/api/webhook/triage.go
+++ b/internal/api/webhook/triage.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 )
@@ -108,9 +109,21 @@ func (rec *Receiver) handleTest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 1. Verify the signature (no token consumed, no dedup recorded). Map the
-	//    failure to the same verdict labels the receive path uses.
-	if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
+	// 1. Authenticate (no token consumed, no dedup recorded). Mirror the
+	//    receive path: auth.kind=none skips verification only when the operator
+	//    opted in, otherwise the dry-run reports the same refusal a delivery
+	//    would get. Map failures to the same verdict labels the receive path uses.
+	if strings.EqualFold(strings.TrimSpace(wd.Auth.Kind), "none") {
+		if !rec.allowUnauthenticated {
+			writeJSON(w, http.StatusOK, testResult{
+				WouldAccept:     false,
+				Verdict:         verdictUnresolved,
+				RunInputPreview: runInputPreview{},
+			})
+			return
+		}
+		// none + opted in → fall through to projection (would accept).
+	} else if verr := verifySignature(wd.Auth, body, r.Header.Get, rec.envAllowlist, rec.getenv, rec.now); verr != nil {
 		verdict := verdictRejectedSig
 		var ae *authError
 		if errors.As(verr, &ae) && ae.verdict == verdictUnresolved {

--- a/internal/cli/mcp_registry.go
+++ b/internal/cli/mcp_registry.go
@@ -236,7 +236,7 @@ func runMCPRegistryAppend(args []string, stdout, stderr io.Writer) int {
 		var missingEnv *recipes.ErrMissingEnvVars
 		if errors.As(err, &missingEnv) {
 			fmt.Fprintln(stderr, err.Error())
-			fmt.Fprintln(stderr, "  Hint: add the missing names to your `env.allowlist:` block (or LOOMCYCLE_ENV_ALLOWLIST env var) before retrying.")
+			fmt.Fprintln(stderr, "  Hint: add the missing names to your config's `env.allowlist:` block before retrying.")
 			fmt.Fprintln(stderr, "  Or override with --skip-env-check if you understand the implications.")
 			return 2
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1854,7 +1854,11 @@ type Env struct {
 	// signing-secret + bearer-token + user_credentials_from_env reads
 	// (RFC F shared trigger-credential gate). The webhook receiver
 	// reuses it rather than a parallel list so an operator declares
-	// the env-var floor once for all autonomous-run triggers.
+	// the env-var floor once for all autonomous-run triggers. Webhook
+	// operators may also use the better-named LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST
+	// (merged with this one at receiver construction); and a webhook's own
+	// statically-declared secret + a LOOMCYCLE_*-named verify secret resolve
+	// without any allowlist entry. See internal/api/webhook.BuildEnvAllowlist.
 	SchedulerEnvAllowlist []string
 
 	// WebhooksEnabled enables the v1.x RFC H inbound-webhook receiver
@@ -1864,6 +1868,23 @@ type Env struct {
 	// works for authoring + listing, just nothing receives). Mirrors
 	// SchedulerEnabled exactly.
 	WebhooksEnabled bool
+
+	// WebhooksEnvAllowlist is the webhook-specific, correctly-named twin of
+	// SchedulerEnvAllowlist (LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST="VAR1,VAR2").
+	// Webhook operators kept reaching for a LOOMCYCLE_*ENV_ALLOWLIST and
+	// missing the scheduler-named knob; this names the gate after the
+	// subsystem. Merged with SchedulerEnvAllowlist at receiver construction
+	// (union, not replacement) — declaring either authorizes the name.
+	WebhooksEnvAllowlist []string
+
+	// WebhooksAllowUnauthenticated opts into the trusted-network ingress
+	// posture: a webhook with auth.kind="none" skips signature verification
+	// entirely. Default OFF — a none-auth webhook 503s
+	// "unauthenticated_mode_disabled" until the operator sets
+	// LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1. For deployments where the
+	// receiver is only reachable over an already-authenticated transport
+	// (WireGuard/tailnet, mTLS mesh) and HMAC is redundant.
+	WebhooksAllowUnauthenticated bool
 
 	// A2AServerEnabled enables the v1.x RFC G A2A server HTTP surface
 	// (the well-known AgentCard URI + the three protocol-binding mounts
@@ -2359,6 +2380,15 @@ func Load(path string) (*Config, error) {
 	// false the receiver route is not mounted; the WebhookDef tool still
 	// works for authoring + listing.
 	cfg.Env.WebhooksEnabled = os.Getenv("LOOMCYCLE_WEBHOOKS_ENABLED") == "1"
+	if v := os.Getenv("LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST"); v != "" {
+		for _, name := range strings.Split(v, ",") {
+			name = strings.TrimSpace(name)
+			if name != "" {
+				cfg.Env.WebhooksEnvAllowlist = append(cfg.Env.WebhooksEnvAllowlist, name)
+			}
+		}
+	}
+	cfg.Env.WebhooksAllowUnauthenticated = os.Getenv("LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED") == "1"
 
 	// v1.x RFC G A2A server surface. Default OFF; operator opts in via
 	// LOOMCYCLE_A2A_ENABLED=1 + names the active card to serve. Tenancy
@@ -2642,7 +2672,7 @@ func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider stri
 var envVarRe = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 
 // expandEnv replaces ${VAR} with the value of VAR, but only for VARs whose
-// names match expandEnvAllowed. Other ${VAR} tokens pass through verbatim.
+// names match ExpandEnvAllowed. Other ${VAR} tokens pass through verbatim.
 //
 // Why an allowlist: a malicious or compromised YAML in a GitOps / shared-
 // config setup could otherwise inject `${ANTHROPIC_API_KEY}` into outbound
@@ -2657,7 +2687,7 @@ var envVarRe = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 func expandEnv(s string) string {
 	return envVarRe.ReplaceAllStringFunc(s, func(m string) string {
 		name := m[2 : len(m)-1]
-		if !expandEnvAllowed(name) {
+		if !ExpandEnvAllowed(name) {
 			return m // leave verbatim — caller sees the literal ${...}
 		}
 		return os.Getenv(name)
@@ -2708,10 +2738,21 @@ func parseHeaderList(s string) map[string]string {
 	return out
 }
 
-// expandEnvAllowed reports whether the given env-var name may be expanded
+// ExpandEnvAllowed reports whether the given env-var name may be expanded
 // inside YAML. Allowlist:
 //   - any LOOMCYCLE_-prefixed variable (the project's own namespace)
 //   - well-known third-party keys MCP servers commonly need
+//
+// Exported because the v1.x RFC H webhook receiver reuses this exact
+// predicate as the VERIFICATION-secret namespace auto-allow: a webhook
+// whose signing_secret_env / bearer_token_env is LOOMCYCLE_*-prefixed (or
+// one of the known third-party names) resolves without an explicit
+// allowlist entry, mirroring the YAML ${LOOMCYCLE_*} posture. The verify
+// secret is consumed by the receiver and never reaches the agent, so the
+// auto-allow carries no exfiltration risk. (The agent-reachable
+// user_credentials_from_env path does NOT use this predicate — see
+// internal/api/webhook/runinput.go — so a runtime-authored webhook cannot
+// inject an arbitrary LOOMCYCLE_* value into a run.)
 //
 // Note on the v0.8.x ${run.user_bearer} tokens: these are intentionally
 // NOT handled here. envVarRe above requires var names matching
@@ -2722,7 +2763,7 @@ func parseHeaderList(s string) map[string]string {
 // header value like `Bearer ${run.user_bearer:-${LOOMCYCLE_STATIC}}`
 // has its inner ${LOOMCYCLE_STATIC} resolved here, while the outer
 // ${run.user_bearer:-...} flows through to the request-time substitution.
-func expandEnvAllowed(name string) bool {
+func ExpandEnvAllowed(name string) bool {
 	if strings.HasPrefix(name, "LOOMCYCLE_") {
 		return true
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2228,3 +2228,54 @@ scheduled_runs:
 		})
 	}
 }
+
+// TestExpandEnvAllowed_Predicate pins the exported predicate the webhook
+// receiver reuses for its verify-secret namespace auto-allow (F23). LOOMCYCLE_*
+// and the known third-party names are allowed; provider keys + arbitrary names
+// are NOT (they must never be expandable into outbound fields).
+func TestExpandEnvAllowed_Predicate(t *testing.T) {
+	allowed := []string{"LOOMCYCLE_FOO", "LOOMCYCLE_GITEA_WEBHOOK_SECRET", "GITHUB_TOKEN", "BRAVE_API_KEY"}
+	for _, n := range allowed {
+		if !ExpandEnvAllowed(n) {
+			t.Errorf("ExpandEnvAllowed(%q) = false, want true", n)
+		}
+	}
+	denied := []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GITEA_SECRET", "AWS_SECRET_ACCESS_KEY", "", "loomcycle_lowercase"}
+	for _, n := range denied {
+		if ExpandEnvAllowed(n) {
+			t.Errorf("ExpandEnvAllowed(%q) = true, want false", n)
+		}
+	}
+}
+
+// TestLoad_WebhooksEnvKnobs verifies the new webhook-specific env knobs are
+// parsed: LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST (comma list, trimmed) and
+// LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED (=1 → true).
+func TestLoad_WebhooksEnvKnobs(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte("defaults: { provider: anthropic, model: claude-sonnet-4-6 }\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	t.Setenv("LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST", " GITEA_SECRET , STRIPE_WH_SECRET ,")
+	t.Setenv("LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED", "1")
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	got := cfg.Env.WebhooksEnvAllowlist
+	want := []string{"GITEA_SECRET", "STRIPE_WH_SECRET"}
+	if len(got) != len(want) {
+		t.Fatalf("WebhooksEnvAllowlist = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("WebhooksEnvAllowlist[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if !cfg.Env.WebhooksAllowUnauthenticated {
+		t.Error("WebhooksAllowUnauthenticated = false, want true")
+	}
+}

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -35,10 +35,37 @@ loomcycle as an A2A peer, see `a2a-integration`.
 ## Enabling
 
 Off by default. Set `LOOMCYCLE_WEBHOOKS_ENABLED=1`; the receiver mounts at
-`POST /v1/_webhooks/{name}`. Signing secrets + per-run credentials resolve
-through the **same env-allowlist** the scheduler uses
-(`LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`) — a value not on the allowlist is
-never read.
+`POST /v1/_webhooks/{name}`.
+
+**Secret resolution (read this first — it is the #1 setup snag).** A signing
+secret / bearer token / `user_credentials_from_env` value resolves only if its
+env-var NAME is authorized. The receiver authorizes a name when **any** of:
+
+1. it is **`LOOMCYCLE_*`-prefixed** (or a known third-party name like
+   `GITHUB_TOKEN`) — auto-allowed for the **verification secret** only
+   (`signing_secret_env` / `bearer_token_env`), which is consumed by the
+   receiver and never reaches the agent. This is why
+   `signing_secret_env: "LOOMCYCLE_GITEA_WEBHOOK_SECRET"` Just Works with no
+   allowlist config;
+2. it is declared by a **static** (operator-authored yaml) webhook — its own
+   secret + `user_credentials_from_env` names are auto-trusted;
+3. it is listed in **`LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST`** (comma-separated) or
+   the scheduler's shared **`LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`**.
+
+The agent-reachable `user_credentials_from_env` path does **not** get rule 1's
+namespace auto-allow for *runtime*-authored (`webhookdef`-tool) defs — name a
+non-static credential env explicitly in `LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST` so a
+less-trusted authoring path can't inject an arbitrary env var into a run. A name
+that resolves by none of the rules → `503 secret_unresolvable` (naming the env
+var, never its value). The boot log prints the live allowlist count and a
+`WARNING:` line per static webhook whose secret won't resolve.
+
+**Trusted-network (no-auth) ingress.** For a receiver only reachable over an
+already-authenticated transport (WireGuard/tailnet, mTLS mesh) where HMAC is
+redundant, set `auth.kind: none`. It is refused (`503
+unauthenticated_mode_disabled`) unless the operator opts in with
+`LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1` — the default never silently
+accepts unsigned external POSTs.
 
 ## Defining a webhook
 
@@ -110,12 +137,15 @@ A shared front-half runs for every request, then forks on `delivery`:
 
 ## The signing secret
 
-`signing_secret_env` (HMAC) / `bearer_token_env` (bearer) name an env var
-that must be on the operator's env allowlist (the **same**
-`LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST` the scheduler uses — it is the shared
-trigger-credential gate). A missing or unresolvable secret **fails loud**:
-`503 secret_unresolvable`, naming the env var — never its value. Rotate by
-changing the env var and reloading; no plaintext secret ever lives in a Def.
+`signing_secret_env` (HMAC) / `bearer_token_env` (bearer) name an env var the
+receiver authorizes via the rules under **Enabling** above: a `LOOMCYCLE_*` (or
+known third-party) name is auto-allowed; a static webhook's declared name is
+auto-trusted; otherwise list it in `LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST` (or the
+scheduler's shared `LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`). The verification secret
+is consumed by the receiver for the constant-time MAC/bearer compare and never
+reaches the agent. A missing or unresolvable secret **fails loud**: `503
+secret_unresolvable`, naming the env var — never its value. Rotate by changing
+the env var and reloading; no plaintext secret ever lives in a Def.
 
 ## MCP-tool bearer tokens for the spawned run (same as schedulers)
 

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -497,8 +497,18 @@ func validateWebhookDef(def mergedWebhookDef) error {
 		if !envVarNameRe.MatchString(def.Auth.BearerTokenEnv) {
 			return fmt.Errorf("auth.bearer_token_env %q is not a valid env-var name (must match [A-Z][A-Z0-9_]*)", def.Auth.BearerTokenEnv)
 		}
+	case "none":
+		// Trusted-network escape hatch: the receiver performs NO verification.
+		// It is honored only when the operator sets
+		// LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1; otherwise every delivery
+		// 503s "unauthenticated_mode_disabled". Forbid declaring a secret that
+		// would never be consumed — silent dead config is worse than a loud
+		// refusal (RFC H Decision 9, never-silently-degrade).
+		if def.Auth.SigningSecretEnv != "" || def.Auth.BearerTokenEnv != "" {
+			return fmt.Errorf("auth.kind=none forbids signing_secret_env / bearer_token_env (no verification is performed)")
+		}
 	default:
-		return fmt.Errorf("unknown auth.kind %q (must be one of: hmac, bearer)", def.Auth.Kind)
+		return fmt.Errorf("unknown auth.kind %q (must be one of: hmac, bearer, none)", def.Auth.Kind)
 	}
 
 	// Every value in user_credentials_from_env must be a valid env-var


### PR DESCRIPTION
## Why

Hands-on testing (the `loomcycle-experiments` exp4 Gitea-webhook workflow) hit a hard blocker, captured as **finding F23**: a static-yaml webhook with `auth.kind: hmac` routes correctly but **every signed delivery returns `503 secret_unresolvable`**, with the boot log stuck at `env_allowlist=0 names` no matter what is configured.

Root cause is a **naming + discoverability trap**, not a deep bug. The receiver's secret-resolution gate (`internal/api/webhook/signature.go` `resolveSecret`) requires the `signing_secret_env` name to be in an in-memory allowlist that is seeded **only** from `LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST` (`cmd/loomcycle/main.go`). exp4 set `LOOMCYCLE_ENV_ALLOWLIST` — a name the runtime **reads nowhere** — and a stale CLI hint (`internal/cli/mcp_registry.go`) actively pointed operators at that nonexistent var. The one working knob was scheduler-named, which nobody configuring a *webhook* would guess; there was also no `LOOMCYCLE_*` namespace auto-allow (unlike YAML `${...}` expansion) and a static webhook's **own** declared secret was not trusted.

## What

A webhook works out of the box; the knob is discoverable + correctly named; and a loud opt-in no-auth mode exists for trusted networks — without weakening the RFC F gate on agent-reachable injected credentials.

The allow-decision is **split by trust**:

- **Verification secrets** (`signing_secret_env` / `bearer_token_env`) are consumed by the receiver for `hmac.Equal` / `CompareBearer` and never reach the agent → `resolveSecret` now admits them via the existing `config.ExpandEnvAllowed` predicate (the `LOOMCYCLE_*` namespace + known third-party names). So `signing_secret_env: LOOMCYCLE_GITEA_WEBHOOK_SECRET` Just Works with zero allowlist config.
- **Injected `user_credentials_from_env`** is reachable by MCP tool headers → left strictly gated (`buildRunInput` unchanged). It is auto-trusted only for **static, operator-authored** webhooks (seeded by the new `BuildEnvAllowlist`); a runtime (`webhookdef`-tool) def's non-`LOOMCYCLE_*` credential env still needs an explicit allowlist entry, so a less-trusted authoring path cannot inject an arbitrary env var into a run.

Plus:

- **`LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST`** — correctly-named twin of the scheduler knob, merged (union) at receiver construction.
- **`auth.kind: none`** — trusted-network ingress (WireGuard/tailnet, mTLS), refused with `503 unauthenticated_mode_disabled` unless `LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1`. Default never silently accepts unsigned POSTs. Handled symmetrically in the receiver, the triage dry-run, and the `webhookdef` validator.
- **Discoverability** — boot log names both allowlist env vars + the true seeded count + `unauthenticated_mode`, and logs a `WARNING` per static webhook whose secret won't resolve (also addresses **F24**); the stale CLI hint is corrected; the `input-webhooks` help topic + `.env.example` document the rules.

`expandEnvAllowed` → exported `ExpandEnvAllowed` (single source of truth shared by YAML expansion and the verify-secret auto-allow).

### Commits
1. `fix(config)` — export `ExpandEnvAllowed`; add `LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST` + `LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED`.
2. `fix(webhook)` — `BuildEnvAllowlist` + `resolveSecret` namespace auto-allow + `auth.kind:none` + `UnresolvableStaticSecrets` + regression tests.
3. `fix(main)` — seed via `BuildEnvAllowlist`, enriched boot log + per-webhook warnings.
4. `docs(webhook)` — help topic + `.env.example`; fix stale CLI hint.

## What was tested

- `go build ./...`, `go vet`, `gofmt` — all clean.
- **Unit / regression** (`internal/api/webhook`, `internal/config`):
  - `TestResolveSecret_LoomcyclePrefixAutoAllowed` — **verified failing on the old gate**, passing after.
  - `TestResolveSecret_NonPrefixedNotDeclaredStillGated`, `TestResolveSecret_LoomcyclePrefixButUnset_StillUnresolved`
  - `TestBuildEnvAllowlist_SeedsStaticDeclaredAndMergesKnobs`
  - `TestBuildRunInput_CredEnv_NoNamespaceAutoAllow` (guards the verify-only line — creds stay strict)
  - `TestUnresolvableStaticSecrets_Warnings`, `TestReceiver_NoneKind_GatedByFlag`
  - `TestExpandEnvAllowed_Predicate`, `TestLoad_WebhooksEnvKnobs`
- **End-to-end** against a running binary (static webhooks, no allowlist env set):
  - valid `LOOMCYCLE_*` sig → `would_accept:true` (was `503 secret_unresolvable`)
  - wrong sig → `rejected_sig`; `none`+flag-off → `503 unauthenticated_mode_disabled`; `none`+flag-on → accepted; unresolvable secret → `503` naming the var + boot `WARNING`.

### Pre-existing failures (not from this PR)
Two wall-clock-timing tests fail in this environment regardless of these changes (verified on pristine `main`, in untouched areas): `TestBashTimeout` (the Bash tool's subprocess timeout doesn't fire in this container) and `TestStoreContract/SweepStaleRuns` (flakes only under full-suite load; passes in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
