### PR TITLE
fix(webhook): default run payload to raw body when no `goal` mapping (F28)

### DIFF
--- a/internal/api/webhook/goal_test.go
+++ b/internal/api/webhook/goal_test.go
@@ -1,0 +1,96 @@
+package webhook
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// F28: a def with no `goal` payload_mapping defaults the agent's segment to the
+// RAW signed body (was "" → silent no-op).
+func TestEffectiveGoal_NoMapping_DefaultsToRawBody(t *testing.T) {
+	body := []byte(`{"pull_request":{"title":"Add slugify"}}`)
+	w := config.Webhook{Agent: "a"} // no PayloadMapping
+	proj := projectResult{Fields: map[string]string{}, RawBody: body}
+	if got := effectiveGoal(w, proj); got != string(body) {
+		t.Fatalf("effectiveGoal = %q, want raw body %q", got, string(body))
+	}
+}
+
+// An explicit `goal` mapping wins over the raw-body default — the operator chose
+// which field is the goal.
+func TestEffectiveGoal_ExplicitMapping_UsesProjected(t *testing.T) {
+	w := config.Webhook{Agent: "a", PayloadMapping: map[string]string{"goal": "$.pull_request.title"}}
+	proj := projectResult{Fields: map[string]string{"goal": "Add slugify"}, RawBody: []byte(`{"whole":"body"}`)}
+	if got := effectiveGoal(w, proj); got != "Add slugify" {
+		t.Fatalf("effectiveGoal = %q, want the mapped value", got)
+	}
+}
+
+// A mapped-but-empty goal is the operator's explicit choice — NOT overridden by
+// the raw body (only an absent `goal` target triggers the default).
+func TestEffectiveGoal_MappedButEmpty_Respected(t *testing.T) {
+	w := config.Webhook{Agent: "a", PayloadMapping: map[string]string{"goal": "$.absent.path"}}
+	proj := projectResult{Fields: map[string]string{"goal": ""}, RawBody: []byte(`{"x":1}`)}
+	if got := effectiveGoal(w, proj); got != "" {
+		t.Fatalf("effectiveGoal = %q, want empty (mapped target respected)", got)
+	}
+}
+
+// buildRunInput threads the default through to the actual prompt segment.
+func TestBuildRunInput_NoGoalMapping_SegmentIsRawBody(t *testing.T) {
+	body := []byte(`{"action":"opened","number":7}`)
+	w := config.Webhook{Agent: "a"}
+	proj := projectResult{Fields: map[string]string{}, RawBody: body}
+	in := buildRunInput(w, proj, map[string]bool{}, func(string) string { return "" }, nil)
+	if len(in.Segments) != 1 || len(in.Segments[0].Content) != 1 {
+		t.Fatalf("unexpected segment shape: %+v", in.Segments)
+	}
+	blk := in.Segments[0].Content[0]
+	if blk.Text != string(body) {
+		t.Errorf("segment text = %q, want raw body %q", blk.Text, string(body))
+	}
+	// Still fenced as untrusted — the body is attacker-influenceable.
+	if blk.Type != "untrusted-block" || blk.Kind != "webhook_payload" {
+		t.Errorf("segment not fenced as untrusted webhook_payload: %+v", blk)
+	}
+}
+
+// End-to-end regression (fails on main): a signed delivery to a webhook with NO
+// payload_mapping spawns the agent with the FULL body as its goal, not "".
+func TestReceiver_NoGoalMapping_SpawnsWithBody(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"pull_request":{"title":"do the thing"},"action":"opened"}`)
+
+	wh := config.Webhook{
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "reviewer",
+		Auth:     config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		// deliberately NO PayloadMapping
+	}
+	fr := &fakeRunner{runID: "r", agentID: "a"}
+	rec := newTestReceiver(t, map[string]config.Webhook{"gh": wh}, fr,
+		nil, map[string]string{"WH_SECRET": secret}, []string{"WH_SECRET"}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := doPost(rec, "gh", body, h)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if !fr.wasCalled() {
+		t.Fatal("runner not invoked")
+	}
+	got := fr.input()
+	if len(got.Segments) != 1 || len(got.Segments[0].Content) != 1 {
+		t.Fatalf("unexpected segment shape: %+v", got.Segments)
+	}
+	if txt := got.Segments[0].Content[0].Text; txt != string(body) {
+		t.Errorf("agent goal = %q, want the full signed body %q", txt, string(body))
+	}
+}

--- a/internal/api/webhook/payload.go
+++ b/internal/api/webhook/payload.go
@@ -17,6 +17,12 @@ import (
 type projectResult struct {
 	Fields      map[string]string
 	MissingKeys []string
+	// RawBody is the exact signed body the mapping was applied to. Carried so
+	// the run-input builder can default the agent's `goal` to the whole event
+	// when the def declares no `goal` target (F28) — without re-threading the
+	// bytes through every buildRunInput call site. Set only by projectPayload
+	// (validated as JSON there); nil on hand-constructed results in tests.
+	RawBody []byte
 }
 
 // projectPayload applies a payload_mapping to a raw JSON body. The mapping
@@ -44,7 +50,7 @@ type projectResult struct {
 // a well-formed body is NOT an error: it yields an empty string and a
 // MissingKeys entry.
 func projectPayload(mapping map[string]string, body []byte) (projectResult, error) {
-	res := projectResult{Fields: make(map[string]string, len(mapping))}
+	res := projectResult{Fields: make(map[string]string, len(mapping)), RawBody: body}
 
 	var doc interface{}
 	if err := json.Unmarshal(body, &doc); err != nil {

--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -45,6 +45,27 @@ func collectPrefixed(fields map[string]string, prefix string) map[string]string 
 	return out
 }
 
+// effectiveGoal returns the text that becomes the agent's single
+// `webhook_payload` segment.
+//
+//   - If the def declares a `goal` target in payload_mapping, that projected
+//     value is used verbatim — the operator chose WHICH field is the goal, and
+//     it is respected even when it resolves empty (their explicit choice).
+//   - Otherwise the agent receives the RAW signed body (F28). Without this, a
+//     webhook with no `goal` mapping spawned the agent with an empty payload and
+//     it silently no-op'd — the opposite of the GitHub-pattern expectation that
+//     "the agent receives the event". projectPayload already validated RawBody as
+//     JSON, so it is deterministic, safe text; it is still fenced as an
+//     untrusted-block by the caller (the value is attacker-influenceable).
+//
+// Indexing a nil PayloadMapping is safe (zero value, mapped=false).
+func effectiveGoal(w config.Webhook, proj projectResult) string {
+	if _, mapped := w.PayloadMapping["goal"]; mapped {
+		return proj.Fields["goal"]
+	}
+	return string(proj.RawBody)
+}
+
 // buildRunInput converts a resolved webhook Def + projected payload into the
 // RunInput the runner consumes. It MIRRORS the scheduler's buildRunInput
 // credential pattern (env-allowlist gate over user_credentials_from_env)
@@ -112,7 +133,7 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 		}
 	}
 
-	goal := proj.Fields["goal"]
+	goal := effectiveGoal(w, proj)
 	seg := loop.PromptSegment{
 		Role: "user",
 		Content: []loop.PromptContentBlock{

--- a/internal/api/webhook/triage.go
+++ b/internal/api/webhook/triage.go
@@ -164,9 +164,11 @@ func (rec *Receiver) handleTest(w http.ResponseWriter, r *http.Request) {
 		WouldAccept: true,
 		Verdict:     verdictAccepted,
 		RunInputPreview: runInputPreview{
-			Agent:          in.Agent,
-			UserID:         in.UserID,
-			Goal:           proj.Fields["goal"],
+			Agent:  in.Agent,
+			UserID: in.UserID,
+			// Mirror what a real delivery sends: the mapped goal, or the raw
+			// body when the def declares no `goal` target (F28).
+			Goal:           effectiveGoal(wd, proj),
 			CredentialKeys: keys,
 		},
 	})


### PR DESCRIPTION
## Why

Surfaced by the loomcycle-experiments exp4 workflow (finding **F28**, the
highest-value remaining webhook footgun after the F23 HMAC fix).

A **spawn**-delivery webhook builds the agent's single prompt segment from
`goal := proj.Fields["goal"]` (`internal/api/webhook/runinput.go`). When the def
declares **no `goal` target** in `payload_mapping`, that resolves to `""`, so the
receiver spawns the agent with an **empty** `webhook_payload` and the run silently
no-ops — the opposite of the GitHub/Stripe-pattern expectation that *the agent
receives the event*. Nothing warns; operators had to discover the `goal: "$"`
workaround by reading the JSONPath projector.

## What

Default the agent segment to the **raw signed body** when the def declares no
`goal` target:

- `projectResult` carries the validated body on a new `RawBody` field (set only by
  `projectPayload`), so **no `buildRunInput` call site changes signature** (it has 8
  call sites incl. tests).
- New `effectiveGoal(w, proj)` helper: returns the mapped `goal` when the def
  declares one (respected **even when it resolves empty** — the operator's explicit
  choice), else `string(proj.RawBody)`.
- `buildRunInput` and the triage dry-run preview both use it, so `POST
  /v1/_webhooks/{name}/test` shows the effective goal too.

**Safety:** `projectPayload` already 400s on non-JSON, so the default is
deterministic JSON text; it stays fenced as an `untrusted-block` (the value is
attacker-influenceable) and is already bounded by `body_size_limit_bytes` (1 MiB
default). Channel-delivery is unaffected (it relays the raw body directly and never
calls `buildRunInput`). Runtime-only — no wire-shape change, ships from loomcycle
alone.

## What was tested

- `go build ./...`, `go vet`, `gofmt` — clean. Full `internal/api/webhook` suite green.
- **Regression** (verified failing on the old `goal := proj.Fields["goal"]` line):
  - `TestReceiver_NoGoalMapping_SpawnsWithBody` — signed delivery, no mapping → agent goal == full body (was `""`).
  - `TestBuildRunInput_NoGoalMapping_SegmentIsRawBody`.
  - `TestEffectiveGoal_{NoMapping_DefaultsToRawBody,ExplicitMapping_UsesProjected,MappedButEmpty_Respected}`.
- **E2E** against a built binary: a `webhooks.pr-opened` def with **no**
  `payload_mapping` + a signed POST → dry-run `would_accept:true` and
  `goal == {"pull_request":{"title":"Add slugify"},"action":"opened"}` (was empty).

## Follow-ups (separate, per CHANGE-PLAN)
A validate-time warning when a def maps `goal` to an optional path that commonly
resolves empty (C3), and the `webhooks:` example in the generated config (C3), are
tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
