### PR TITLE
fix(auth): legacy LOOMCYCLE_AUTH_TOKEN honors wire user_id (F18)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -266,10 +266,33 @@ func (s *Server) legacyFallbackDisabled(ctx context.Context) bool {
 // authoritative (tenant, subject); on open/un-authed paths returns the
 // wire values unchanged. A disagreement is honored server-side and
 // logged kind=identity_overridden for triage.
+//
+// Legacy exception (F18): the LOOMCYCLE_AUTH_TOKEN shared-secret fallback is
+// the single-operator, NO-BOUNDARY mode — its principal carries a FIXED
+// placeholder identity ("default"/"default"), not an authoritative per-actor
+// subject. Overriding the caller's wire user_id with that placeholder gave
+// zero security benefit (one fully-trusted operator, no isolation boundary)
+// while silently scoping every spawn_run / POST /v1/runs to user_id="default"
+// — breaking per-user fairness, memory/channel scope, and attribution, and
+// the documented "zero-disruption upgrade" (pre-RFC-L user_id was caller-set).
+// So for a legacy principal we HONOR the wire user_id (falling back to the
+// placeholder only when the caller omits it). A REAL OperatorTokenDef
+// principal keeps the strict override — its subject IS an authoritative actor
+// and a caller must not be able to spoof another subject.
 func (s *Server) applyPrincipal(ctx context.Context, wireTenant, wireUser string) (tenant, subject string) {
 	p, ok := auth.PrincipalFromContext(ctx)
 	if !ok {
 		return wireTenant, wireUser
+	}
+	if p.Legacy {
+		subject = p.Subject
+		if wireUser != "" {
+			subject = wireUser
+		}
+		// Tenant stays the legacy default ("default"): the shared token is
+		// single-tenant by construction, and tenant routing is a real
+		// isolation axis we don't let the wire steer here.
+		return p.TenantID, subject
 	}
 	if wireTenant != "" && wireTenant != p.TenantID {
 		log.Printf("auth: identity_overridden kind=tenant wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -298,3 +298,27 @@ func TestApplyPrincipal_OverridesWireAndFallsBack(t *testing.T) {
 		t.Errorf("no-principal = (%q,%q), want the wire values", tenant, subject)
 	}
 }
+
+// F18: under the legacy LOOMCYCLE_AUTH_TOKEN (single-operator, no-boundary), the
+// caller-asserted wire user_id must be HONORED, not clobbered to the placeholder
+// "default" — otherwise every spawn_run / POST /v1/runs is scoped to "default"
+// (broken per-user fairness, memory/channel scope, attribution). A REAL
+// OperatorTokenDef principal keeps the strict override —
+// TestApplyPrincipal_OverridesWireAndFallsBack pins that (its principal has
+// Legacy=false), so the security boundary is unchanged.
+func TestApplyPrincipal_LegacyHonorsWireUserID(t *testing.T) {
+	s, _ := tokenAuthServer(t, "legacy")
+	legacy := auth.Principal{TenantID: "default", Subject: "default", Scopes: []string{auth.ScopeAdmin}, Legacy: true}
+	ctx := auth.WithPrincipal(context.Background(), legacy)
+
+	// Caller asserts user_id → honored; tenant stays the legacy default even if
+	// a wire tenant is supplied (tenant routing is a real isolation axis).
+	if tenant, subject := s.applyPrincipal(ctx, "ignored-tenant", "exp1"); tenant != "default" || subject != "exp1" {
+		t.Errorf("legacy+wire = (%q,%q), want (default,exp1)", tenant, subject)
+	}
+
+	// No wire user_id → falls back to the placeholder subject.
+	if tenant, subject := s.applyPrincipal(ctx, "", ""); tenant != "default" || subject != "default" {
+		t.Errorf("legacy+empty = (%q,%q), want (default,default)", tenant, subject)
+	}
+}


### PR DESCRIPTION
## Why

Finding **F18** from the experiments: an MCP `spawn_run` (and `POST /v1/runs`)
with a caller-supplied `user_id` was silently recorded as `user_id="default"`,
and the run's Channel/Memory ops scoped to `default` — breaking per-user
isolation for multi-agent loops under the common single-token setup.

Root cause is **not** the JSON arg-decode (as the change-plan first suspected —
`SpawnRunRequest.UserID` decodes fine and threads correctly to `RunIdentity`).
It is `applyPrincipal` (`internal/api/http/auth_principal.go`), RFC L Decision 5:
the authenticated principal is authoritative over the wire `user_id`. For a real
`OperatorTokenDef` principal that is a **security property** (a token bound to
subject "alice" must not spawn as "bob"). But the **legacy `LOOMCYCLE_AUTH_TOKEN`**
fallback mints a principal with a *fixed placeholder* identity —
`{TenantID:"default", Subject:"default", Legacy:true}` (`auth_principal.go:243`) —
the single-operator, no-isolation-boundary mode. Overriding the wire `user_id`
with that placeholder gives **zero security benefit** while clobbering every
caller-asserted `user_id` to `"default"`, and breaks the documented
"zero-disruption upgrade" (pre-RFC-L, `user_id` was caller-set).

## What

In `applyPrincipal`, when the principal is **Legacy**, honor the wire `user_id`
(fall back to the placeholder only when the caller omits it). Tenant stays the
legacy `"default"` — the shared token is single-tenant by construction and
tenant routing is a real isolation axis we don't let the wire steer.

```go
if p.Legacy {
    subject = p.Subject
    if wireUser != "" { subject = wireUser }
    return p.TenantID, subject
}
// non-legacy OperatorTokenDef principal: strict override (unchanged)
```

**Security boundary unchanged:** a real `OperatorTokenDef` principal
(`Legacy=false`) keeps the strict override — pinned by the existing
`TestApplyPrincipal_OverridesWireAndFallsBack`. Open mode (no principal) already
passed the wire through. The change affects **only** the fully-trusted,
no-boundary single-operator token. `applyPrincipal` has two callers (run
creation + the `/v1/runs` handler), so HTTP, gRPC, and MCP `spawn_run` are all
fixed uniformly.

## What was tested

- `go build`, `go vet`, `gofmt` clean. **Full `internal/api/http` suite green**
  (auth / tenant-isolation / session-ownership / scope gates — the
  identity-resolution change regressed none).
- **Regression** (verified failing on the old code — wire `"exp1"` → `"default"`):
  `TestApplyPrincipal_LegacyHonorsWireUserID`.
- **E2E** on a built binary with `LOOMCYCLE_AUTH_TOKEN` + the mock provider:
  `POST /v1/runs {"user_id":"exp1"}` → persisted `sessions.user_id` and
  `runs.user_id` == `"exp1"` (was `"default"`), `tenant_id` == `"default"`.

## Notes
Runtime-only — no wire-shape change (the `user_id` field already exists), ships
from loomcycle alone. Touches the auth/identity seam, so flagging for a careful
review of the legacy-vs-scoped boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
