### PR TITLE
feat(config): warn at boot when a tool lacks its capability gate (F21)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -446,6 +446,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}
+	// Non-fatal config advisories (e.g. an agent with Memory in allowed_tools
+	// but no memory_scopes — the tool would default-deny every call, F21).
+	// Surfaced once at boot so a silent-ish partial misconfig is visible.
+	for _, warn := range cfg.Warnings {
+		log.Printf("config: WARNING: %s", warn)
+	}
 
 	// v0.10.0 OpenTelemetry tracer bootstrap. No-op when
 	// LOOMCYCLE_OTEL_EXPORTER_OTLP_ENDPOINT is unset, so zero runtime

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -165,6 +165,13 @@ type Config struct {
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
 
+	// Warnings holds non-fatal config advisories accumulated during
+	// validate() — surfaced once at boot by main.go (log "config: WARNING:
+	// …"), never returned over the wire. Today: the "tool is in allowed_tools
+	// but its capability gate is unset, so every call default-denies" footgun
+	// (e.g. Memory without memory_scopes — F21). Not in YAML.
+	Warnings []string `yaml:"-"`
+
 	// configDir is the directory of the loaded YAML, kept so relative
 	// paths inside the config (system_prompt_file, local_api.spec) can
 	// be resolved against it.
@@ -3300,6 +3307,37 @@ func validateAgentChannelEntry(declared map[string]Channel, entry string) error 
 	return nil
 }
 
+// agentGateWarnings returns the non-fatal "tool present but its capability gate
+// is unset" advisories for one agent (F21). Each named tool DEFAULT-DENIES every
+// call when its gate is empty, so the agent runs but the tool silently refuses —
+// easy to miss (it looks like the agent "chose" not to use the tool). Pure +
+// deterministic order (Memory, Evaluation, Channel, Interruption) so it is
+// unit-testable; the caller (validate) accumulates these onto Config.Warnings.
+func agentGateWarnings(name string, a AgentDef) []string {
+	has := func(tool string) bool {
+		for _, t := range a.AllowedTools {
+			if t == tool {
+				return true
+			}
+		}
+		return false
+	}
+	var w []string
+	if has("Memory") && len(a.MemoryScopes) == 0 {
+		w = append(w, fmt.Sprintf("agent %q: allowed_tools includes Memory but memory_scopes is empty — every Memory op will default-deny; add memory_scopes: [agent] and/or [user]", name))
+	}
+	if has("Evaluation") && len(a.EvaluationScopes) == 0 {
+		w = append(w, fmt.Sprintf("agent %q: allowed_tools includes Evaluation but evaluation_scopes is empty — every Evaluation op will default-deny; add evaluation_scopes", name))
+	}
+	if has("Channel") && len(a.Channels.Publish) == 0 && len(a.Channels.Subscribe) == 0 {
+		w = append(w, fmt.Sprintf("agent %q: allowed_tools includes Channel but channels.publish and channels.subscribe are both empty — every Channel op will default-deny", name))
+	}
+	if has("Interruption") && !a.Interruption.Enabled {
+		w = append(w, fmt.Sprintf("agent %q: allowed_tools includes Interruption but interruption.enabled is false — every Interruption op will refuse; set interruption.enabled: true", name))
+	}
+	return w
+}
+
 func validate(c *Config) error {
 	if c.Concurrency.MaxConcurrentRuns < 1 {
 		return fmt.Errorf("concurrency.max_concurrent_runs must be >= 1")
@@ -3427,13 +3465,21 @@ func validate(c *Config) error {
 			}
 		}
 		// Memory tool: validate memory_scopes are known scope strings.
-		// Empty memory_scopes is fine (it just means no Memory access);
-		// non-empty must be a subset of {agent, user} for v0.8.0.
+		// Empty memory_scopes is not an ERROR (it just means no Memory
+		// access), but if the agent ALSO lists Memory in allowed_tools the
+		// tool default-denies every call — a silent-ish footgun surfaced as a
+		// boot warning below (F21). Non-empty must be a subset of {agent, user}.
 		for i, sc := range agent.MemoryScopes {
 			if !validMemoryScopes[sc] {
 				return fmt.Errorf("agent %q: memory_scopes[%d]: unknown scope %q (want one of: agent, user)", name, i, sc)
 			}
 		}
+		// Non-fatal: "tool in allowed_tools but its capability gate is unset"
+		// advisories (Memory/memory_scopes, Evaluation/evaluation_scopes,
+		// Channel/channels, Interruption/interruption.enabled). Accumulated and
+		// logged once at boot, never fatal — an operator may legitimately list a
+		// tool they haven't gated yet.
+		c.Warnings = append(c.Warnings, agentGateWarnings(name, agent)...)
 		if agent.MemoryQuotaBytes < 0 {
 			return fmt.Errorf("agent %q: memory_quota_bytes must be >= 0", name)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2279,3 +2279,66 @@ func TestLoad_WebhooksEnvKnobs(t *testing.T) {
 		t.Error("WebhooksAllowUnauthenticated = false, want true")
 	}
 }
+
+// TestAgentGateWarnings pins the F21 "tool present but capability gate unset"
+// advisories: each named tool default-denies when its gate is empty.
+func TestAgentGateWarnings(t *testing.T) {
+	cases := []struct {
+		name  string
+		agent AgentDef
+		want  []string // expected substrings, in order (nil = no warnings)
+	}{
+		{"memory no scopes", AgentDef{AllowedTools: []string{"Read", "Memory"}}, []string{"memory_scopes is empty"}},
+		{"memory with scopes", AgentDef{AllowedTools: []string{"Memory"}, MemoryScopes: []string{"user"}}, nil},
+		{"memory tool absent", AgentDef{AllowedTools: []string{"Read"}}, nil},
+		{"eval no scopes", AgentDef{AllowedTools: []string{"Evaluation"}}, []string{"evaluation_scopes is empty"}},
+		{"channel no acl", AgentDef{AllowedTools: []string{"Channel"}}, []string{"channels.publish and channels.subscribe are both empty"}},
+		{"channel publish-only is fine", AgentDef{AllowedTools: []string{"Channel"}, Channels: AgentChannelACL{Publish: []string{"x"}}}, nil},
+		{"interruption disabled", AgentDef{AllowedTools: []string{"Interruption"}}, []string{"interruption.enabled is false"}},
+		{"interruption enabled", AgentDef{AllowedTools: []string{"Interruption"}, Interruption: AgentInterruptionACL{Enabled: true}}, nil},
+		{"multiple gates, deterministic order", AgentDef{AllowedTools: []string{"Memory", "Evaluation"}}, []string{"memory_scopes is empty", "evaluation_scopes is empty"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := agentGateWarnings("a", tc.agent)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d warnings %v, want %d (%v)", len(got), got, len(tc.want), tc.want)
+			}
+			for i, sub := range tc.want {
+				if !strings.Contains(got[i], sub) {
+					t.Errorf("warning[%d]=%q does not contain %q", i, got[i], sub)
+				}
+			}
+		})
+	}
+}
+
+// TestLoad_CapabilityGateWarnings verifies the advisory is accumulated onto
+// cfg.Warnings during Load (what main.go prints at boot).
+func TestLoad_CapabilityGateWarnings(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  porous:
+    model: claude-sonnet-4-6
+    allowed_tools: [Read, Memory]
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	found := false
+	for _, w := range cfg.Warnings {
+		if strings.Contains(w, `"porous"`) && strings.Contains(w, "memory_scopes is empty") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a memory_scopes warning for agent porous; warnings=%v", cfg.Warnings)
+	}
+}


### PR DESCRIPTION
## Why

Finding **F21** from the experiments. Listing a tool in an agent's
`allowed_tools` is necessary but **not sufficient**: `Memory`, `Evaluation`,
`Channel`, and `Interruption` each have a **separate default-deny capability
gate** (`memory_scopes` / `evaluation_scopes` / `channels` /
`interruption.enabled`). When the tool is allowed but its gate is unset, every
call silently refuses — the agent runs but the tool no-ops, which reads like the
model "chose" not to use it. This bit the bundled exp3 agents (`Memory` allowed,
no `memory_scopes` → the multi-agent loop cycled but shared no state — a
confusing partial failure).

## What

Surface it as a **non-fatal boot advisory** (never fatal — an operator may
legitimately list a tool they haven't gated yet):

- `validate()` accumulates per-agent "tool present but gate unset" warnings onto
  a new `Config.Warnings []string` (`yaml:"-"`, runtime-only, never on the wire).
- `main.go` logs them once at boot: `config: WARNING: …`.
- The check is a pure, deterministically-ordered `agentGateWarnings(name, agent)`
  helper (Memory → Evaluation → Channel → Interruption), so `config` stays a pure
  library (no `log` dependency) and the logic is directly unit-testable.

Covers: `Memory` w/o `memory_scopes`; `Evaluation` w/o `evaluation_scopes`;
`Channel` w/o any `channels.publish`/`channels.subscribe`; `Interruption` w/o
`interruption.enabled`. (Channel publish-only is a valid partial config → no
warning.)

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `internal/config` suite green.
- `TestAgentGateWarnings` (table: each gate present-but-unset → one warning; gate
  set or tool absent → none; multi-gate ordering) and
  `TestLoad_CapabilityGateWarnings` (warning lands on `cfg.Warnings`). Verified
  both fail when the helper is neutered.
- **E2E** on a built binary: a `porous` agent (`[Read, Memory, Channel,
  Interruption]`, no gates) logs **3** `config: WARNING:` lines at boot; a `clean`
  agent (`Memory` + `memory_scopes: [user]`) logs **none**.

Runtime-only (config validation + boot logging) — no wire change, ships from
loomcycle alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
