### PR TITLE
feat(channel): warn when subscribe wait_ms is truncated by the cap (F22)

### DIFF
--- a/internal/help/builtin/channel-admin.md
+++ b/internal/help/builtin/channel-admin.md
@@ -83,8 +83,15 @@ Mirror of the in-band tool. The wire docs cover the deltas:
   for scope=user.
 - **subscribe** — single-round-trip long-poll. Returns immediately
   if messages are present; otherwise waits up to `wait_ms` (capped
-  at the operator's `ChannelsLongPollCapMS`, default 30s) for a
-  publish. **Auto-commits the cursor on a non-empty batch** —
+  at the operator's `ChannelsLongPollCapMS` / `LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS`,
+  default 30s) for a publish. A `wait_ms` larger than the cap is
+  **silently truncated** to it (logged once per channel as a boot/runtime
+  WARNING). **Interaction with `max_iterations`:** an agent that wants a long
+  wait (e.g. 300s) but is capped at 30s re-subscribes ~10× — each
+  re-subscribe consumes one of the agent's `max_iterations`, so a too-low cap
+  can exhaust the iteration budget before any message arrives. Raise the cap
+  (or the agent's `max_iterations`) when long parks are intended.
+  **Auto-commits the cursor on a non-empty batch** —
   at-most-once shape, same as the in-band tool's subscribe op.
   Returns `{channel, messages, next_cursor}`.
 - **peek** — non-destructive read. Defaults to `cur_0` (replay from

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -78,6 +79,21 @@ type Channel struct {
 	// it nil; the diagnostic log path then reports zeros for the pool
 	// fields and the retry behavior is unchanged.
 	PoolStatsFn func() (total, acquired, idle int32)
+
+	// truncWarned dedupes the F22 wait_ms-truncation advisory to once per
+	// channel name (per process). A subscriber whose wait_ms exceeds
+	// LongPollCapMS re-subscribes every cap interval, so logging on every
+	// subscribe would spam. Keyed by channel name; zero-value ready (the
+	// Channel tool is always used by pointer, so the sync.Map is never copied).
+	truncWarned sync.Map
+}
+
+// shouldWarnTruncation reports whether a wait_ms truncation on `channel` should
+// be logged now — true only the FIRST time per channel (per process), so the
+// F22 advisory does not spam on every re-subscribe. Concurrency-safe.
+func (c *Channel) shouldWarnTruncation(channel string) bool {
+	_, dup := c.truncWarned.LoadOrStore(channel, struct{}{})
+	return !dup
 }
 
 const channelDescription = `Persistent inter-agent message bus. ` +
@@ -397,6 +413,14 @@ func (c *Channel) execSubscribe(ctx context.Context, policy tools.ChannelPolicyV
 	if len(msgs) == 0 && longPollEnabled {
 		wait := in.WaitMS
 		if wait > c.LongPollCapMS {
+			// F22: the requested wait_ms is silently truncated to the operator
+			// cap. Surface it once per channel so an operator notices the
+			// long-poll budget being clipped — a subscriber that keeps
+			// requesting longer waits re-subscribes every cap interval, burning
+			// the agent's max_iterations.
+			if c.shouldWarnTruncation(in.Channel) {
+				log.Printf("channel %q: subscribe wait_ms=%d truncated to the operator cap %d ms (LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS) — repeated truncation re-subscribes every cap interval and burns the agent's max_iterations; raise the cap if longer waits are intended", in.Channel, in.WaitMS, c.LongPollCapMS)
+			}
 			wait = c.LongPollCapMS
 		}
 		t := time.NewTimer(time.Duration(wait) * time.Millisecond)

--- a/internal/tools/builtin/channel_longpoll_test.go
+++ b/internal/tools/builtin/channel_longpoll_test.go
@@ -1,0 +1,57 @@
+package builtin
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"strings"
+	"testing"
+)
+
+// F22: the dedup guard logs a wait_ms truncation only the first time per channel.
+func TestChannel_ShouldWarnTruncationDedup(t *testing.T) {
+	c := &Channel{}
+	if !c.shouldWarnTruncation("findings") {
+		t.Fatal("first truncation on a channel should warn")
+	}
+	if c.shouldWarnTruncation("findings") {
+		t.Fatal("second truncation on the same channel should be deduped")
+	}
+	if !c.shouldWarnTruncation("alerts") {
+		t.Fatal("a different channel should warn independently")
+	}
+}
+
+// F22 end-to-end: a subscribe whose wait_ms exceeds the operator cap is
+// truncated and surfaces a one-time WARNING per channel (not on every
+// re-subscribe); a within-cap wait_ms does not warn.
+func TestChannelTool_SubscribeWaitMSTruncationWarnsOnce(t *testing.T) {
+	tool, ctx, cleanup := channelFixture(t)
+	defer cleanup()
+	tool.LongPollCapMS = 20 // tiny cap so wait_ms=5000 truncates fast
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	over := json.RawMessage(`{"op":"subscribe","channel":"findings","wait_ms":5000,"max_messages":10}`)
+	for i := 0; i < 2; i++ {
+		if res, _ := tool.Execute(ctx, over); res.IsError {
+			t.Fatalf("over-cap subscribe %d: %s", i, res.Text)
+		}
+	}
+	if n := strings.Count(buf.String(), "truncated to the operator cap"); n != 1 {
+		t.Fatalf("want exactly 1 truncation warning across 2 over-cap subscribes, got %d:\n%s", n, buf.String())
+	}
+
+	// A within-cap wait_ms must NOT warn (different channel to avoid the dedup).
+	buf.Reset()
+	within := json.RawMessage(`{"op":"subscribe","channel":"alerts","wait_ms":10,"max_messages":10}`)
+	if res, _ := tool.Execute(ctx, within); res.IsError {
+		t.Fatalf("within-cap subscribe: %s", res.Text)
+	}
+	if strings.Contains(buf.String(), "truncated to the operator cap") {
+		t.Errorf("within-cap wait_ms should not warn:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Why

Finding **F22**. `LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS` (default 30s) **silently
truncates** an agent's `Channel.subscribe` `wait_ms`. A subscriber that wants a
long park (the exp3 prompts use 120–600s) is clipped to the cap, so it
re-subscribes every cap interval — and **each re-subscribe consumes one of the
agent's `max_iterations`**, which can exhaust the iteration budget before any
message arrives. The truncation was invisible (no log, no signal), making this a
confusing partial failure.

## What

Surface the truncation without changing the cap behavior:

- When `wait_ms > LongPollCapMS`, log a **one-time WARNING per channel** — naming
  the requested wait, the cap, the env var, and the `max_iterations` interaction.
  Deduped via a `sync.Map` keyed by channel name, so a re-subscribing agent
  doesn't spam the log (the Channel tool is always pointer-used, so the `sync.Map`
  is never copied). The dedup decision is a small testable helper
  (`shouldWarnTruncation`).
- Documented the cap + `max_iterations` interaction in the `channel-admin` help
  topic (with the env-var name and "raise the cap / max_iterations" guidance).

The cap itself is unchanged — this only makes the silent clip visible.

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `internal/tools/builtin` suite
  green (minus the pre-existing env-flaky `TestBashTimeout`, unrelated).
- `TestChannel_ShouldWarnTruncationDedup` — per-channel dedup (first→warn,
  repeat→silent, new channel→warn).
- `TestChannelTool_SubscribeWaitMSTruncationWarnsOnce` — **end-to-end through the
  real `tool.Execute` subscribe path** with log capture: 2 over-cap subscribes →
  exactly 1 warning; a within-cap subscribe → none. Verified it fails when the
  warning is neutered.
- Built binary: the warning string is compiled in.

Runtime-only (Channel tool + docs) — no wire change, ships from loomcycle alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
