### PR TITLE
fix(oauth-dev): cross-process refresh lock + reload-before-refresh (F7)

### DIFF
--- a/internal/providers/anthropic_oauth_dev/lock_unix.go
+++ b/internal/providers/anthropic_oauth_dev/lock_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package anthropic_oauth_dev
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// acquireFileLock takes an exclusive advisory lock (flock LOCK_EX) on lockPath,
+// creating it if absent, and BLOCKS until the lock is available. Refresh is rare
+// and brief, so serializing it across processes (the whole point — F7) costs at
+// most the holder's bounded HTTP timeout. The lock auto-releases when the fd is
+// closed or the process dies, so a crash never strands it (unlike an
+// O_EXCL-lockfile scheme, which needs stale-lock reaping).
+//
+// The fd is kept open inside the returned release closure — closing it earlier
+// would drop the lock.
+func acquireFileLock(lockPath string) (func(), error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("flock: %w", err)
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, nil
+}

--- a/internal/providers/anthropic_oauth_dev/lock_unix_test.go
+++ b/internal/providers/anthropic_oauth_dev/lock_unix_test.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package anthropic_oauth_dev
+
+import (
+	"testing"
+	"time"
+)
+
+// acquireFileLock must serialize across open file descriptions: a second
+// acquire BLOCKS while the first is held, then succeeds once it is released.
+// (flock is per-open-file-description, so this holds even within one process.)
+func TestAcquireFileLock_Serializes(t *testing.T) {
+	lockPath := t.TempDir() + "/tok.lock"
+
+	release1, err := acquireFileLock(lockPath)
+	if err != nil {
+		t.Fatalf("first acquire: %v", err)
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		r2, err := acquireFileLock(lockPath)
+		if err != nil {
+			return
+		}
+		close(acquired)
+		r2()
+	}()
+
+	// While we hold the lock, the goroutine must not acquire it.
+	select {
+	case <-acquired:
+		t.Fatal("second acquire succeeded while the first lock was held")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	release1()
+
+	// After release, the goroutine acquires promptly.
+	select {
+	case <-acquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second acquire did not succeed after release")
+	}
+}

--- a/internal/providers/anthropic_oauth_dev/lock_windows.go
+++ b/internal/providers/anthropic_oauth_dev/lock_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package anthropic_oauth_dev
+
+// acquireFileLock is a no-op on Windows. Cross-process advisory file locking is
+// not implemented here: the anthropic-oauth-dev provider is a dev-only
+// convenience whose primary platforms are Linux/macOS, and reload-before-refresh
+// (in refreshLocked) still mitigates the rotation race. Returns a no-op release
+// so the caller path is identical across platforms.
+func acquireFileLock(_ string) (func(), error) {
+	return func() {}, nil
+}

--- a/internal/providers/anthropic_oauth_dev/refresh.go
+++ b/internal/providers/anthropic_oauth_dev/refresh.go
@@ -133,8 +133,42 @@ func (r *Refresher) loop(ctx context.Context) {
 	}
 }
 
-// refreshLocked performs one refresh attempt. Caller holds r.mu.
+// refreshLocked performs one refresh attempt. Caller holds r.mu (the
+// intra-process single-flight). It ALSO takes a cross-process advisory lock so
+// that multiple loomcycle processes sharing one token file can't race to
+// refresh (F7): without it, two processes POST with the same refresh token, the
+// first rotates it server-side, and the second is rejected with invalid_grant —
+// stranding that process until a full re-login.
+//
+// Lock ordering is always r.mu (intra) → flock (inter); both Refresh paths (the
+// background tick and RefreshNow) funnel through here, so the order is uniform.
 func (r *Refresher) refreshLocked(ctx context.Context) error {
+	// Cross-process serialization. A lock-infra failure must not strand refresh
+	// entirely — log and proceed best-effort (degrades to the prior
+	// single-process behavior) rather than failing the refresh outright.
+	if release, err := acquireFileLock(r.store.lockPath()); err != nil {
+		r.logf("anthropic-oauth-dev: token lock unavailable (%v); refreshing without the cross-process guard", err)
+	} else {
+		defer release()
+	}
+
+	// Reload-before-refresh. Another process may have rotated the token while we
+	// blocked on the lock. If the on-disk token is NEWER than ours (a later
+	// ObtainedAt), adopt it and skip the network round-trip — POSTing now would
+	// use a refresh token that peer already invalidated. This also serves the
+	// forced (post-401) path: the rejected access token is replaced by the
+	// peer's newer one, which the caller's retry then uses. When the on-disk
+	// token is NOT newer (no peer refreshed), fall through and refresh with the
+	// freshest refresh token we have — preserving RefreshNow's "always attempt"
+	// contract.
+	if onDisk, err := r.store.Load(); err == nil && onDisk.RefreshToken != "" {
+		if onDisk.ObtainedAt.After(r.cached.ObtainedAt) {
+			r.cached = onDisk
+			r.logf("anthropic-oauth-dev: adopted a token refreshed by another process (expires_at=%s)", onDisk.ExpiresAt.Format(time.RFC3339))
+			return nil
+		}
+	}
+
 	if r.cached.RefreshToken == "" {
 		// Nothing to refresh — operator hasn't logged in yet.
 		return nil

--- a/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
+++ b/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
@@ -1,0 +1,83 @@
+package anthropic_oauth_dev
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingTokenServer returns a fresh token and counts how many refresh POSTs
+// it received — so a test can assert whether refreshLocked hit the network.
+func countingTokenServer(t *testing.T, hits *atomic.Int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"POSTED","refresh_token":"POSTED-rt","expires_in":3600,"scope":"user:inference"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// F7: when another process has already rotated the on-disk token (a NEWER
+// ObtainedAt) while we held the cross-process lock, refreshLocked must ADOPT it
+// and skip the network refresh — POSTing now would use a refresh token the peer
+// already invalidated. On the unfixed code this POSTs unconditionally.
+func TestRefresh_AdoptsNewerOnDiskTokenWithoutPost(t *testing.T) {
+	store := NewTokenStore(t.TempDir() + "/tokens.json")
+	// Our process loaded a stale (needs-refresh) token at startup.
+	stale := Token{AccessToken: "stale-at", RefreshToken: "stale-rt",
+		ObtainedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(-time.Minute)}
+	if err := store.Save(stale); err != nil {
+		t.Fatalf("Save stale: %v", err)
+	}
+	refresher := NewRefresher(store, ExchangeOptions{}, func(string, ...any) {})
+
+	// Another process rotated the file to a NEWER token after we loaded.
+	newer := NewToken("newer-at", "newer-rt", "user:inference", 3600)
+	if err := store.Save(newer); err != nil {
+		t.Fatalf("Save newer: %v", err)
+	}
+
+	var hits atomic.Int32
+	refresher.httpClient = ExchangeOptions{Endpoint: countingTokenServer(t, &hits).URL}
+
+	if err := refresher.RefreshNow(context.Background()); err != nil {
+		t.Fatalf("RefreshNow: %v", err)
+	}
+	if n := hits.Load(); n != 0 {
+		t.Errorf("expected NO refresh POST (adopt the peer's newer token), got %d", n)
+	}
+	if got := refresher.Token().AccessToken; got != "newer-at" {
+		t.Errorf("Token = %q, want the adopted on-disk token %q", got, "newer-at")
+	}
+}
+
+// Counterpart: when the on-disk token is NOT newer than ours (no peer
+// refreshed), refreshLocked still performs the network refresh — the adopt
+// path must not suppress a genuine refresh.
+func TestRefresh_PostsWhenNoNewerOnDiskToken(t *testing.T) {
+	store := NewTokenStore(t.TempDir() + "/tokens.json")
+	stale := Token{AccessToken: "stale-at", RefreshToken: "stale-rt",
+		ObtainedAt: time.Now().Add(-time.Hour), ExpiresAt: time.Now().Add(-time.Minute)}
+	if err := store.Save(stale); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	refresher := NewRefresher(store, ExchangeOptions{}, func(string, ...any) {})
+
+	var hits atomic.Int32
+	refresher.httpClient = ExchangeOptions{Endpoint: countingTokenServer(t, &hits).URL}
+
+	if err := refresher.RefreshNow(context.Background()); err != nil {
+		t.Fatalf("RefreshNow: %v", err)
+	}
+	if n := hits.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 refresh POST, got %d", n)
+	}
+	if got := refresher.Token().AccessToken; got != "POSTED" {
+		t.Errorf("Token = %q, want POSTED", got)
+	}
+}

--- a/internal/providers/anthropic_oauth_dev/tokens.go
+++ b/internal/providers/anthropic_oauth_dev/tokens.go
@@ -96,6 +96,13 @@ func DefaultTokenStorePath() (string, error) {
 // operator.
 func (s *TokenStore) Path() string { return s.path }
 
+// lockPath returns the path of the sibling advisory-lock file used to
+// serialize token refresh ACROSS processes (F7). It is a SEPARATE, stable
+// file — never rename-replaced like the token file is on every Save — so an
+// flock on it actually serializes; flocking the token inode would not, since
+// Save swaps the inode out from under any held lock.
+func (s *TokenStore) lockPath() string { return s.path + ".lock" }
+
 // Load reads and returns the token. Returns os.ErrNotExist when the
 // file doesn't exist — callers branch on errors.Is(err, os.ErrNotExist)
 // to distinguish "not logged in" from "corrupt token store."


### PR DESCRIPTION
## Why

Finding **F7** (`high`). The Anthropic OAuth (dev) token file is shared by every
loomcycle process on the box (the HTTP server, the plugin's `loomcycle mcp`
runtime, a second instance). Refresh was guarded only by an **intra-process**
`sync.Mutex`, so as the token neared expiry each process POSTed a refresh with
its own cached refresh token. Anthropic rotates the refresh token on the first
success — invalidating it — so the other processes got `401 invalid_grant`,
recoverable only by a full `loomcycle anthropic login`. The subscription
provider died unpredictably under multi-process use.

## What

Two-part fix in `refreshLocked` (both the background tick and `RefreshNow`
funnel through it):

1. **Cross-process advisory lock** (`flock`) on a **stable sibling `<path>.lock`
   file** — *not* the token inode, which `Save` rename-replaces on every refresh
   (locking it would not serialize). Held across reload → refresh → save. unix
   uses stdlib `syscall.Flock` (`lock_unix.go`); Windows is a documented no-op
   (`lock_windows.go` — the provider is dev-only, primary platforms Linux/macOS,
   and reload-before-refresh still mitigates there). The lock auto-releases on fd
   close / process death (no stale-lock reaping). A lock-infra error degrades to
   best-effort rather than stranding refresh.
2. **Reload-before-refresh.** Under the lock, re-read the file; if a peer wrote a
   **newer** token (later `ObtainedAt`), **adopt it and skip the network
   round-trip** — the POST would otherwise use a refresh token the peer already
   invalidated. This also serves the forced post-401 path (the rejected token is
   replaced by the peer's newer one, which the caller's retry uses). When no peer
   refreshed, fall through and refresh with the freshest refresh token —
   preserving `RefreshNow`'s "always attempt" contract.

Lock ordering is uniform (`r.mu` intra → `flock` inter). No new dependency
(stdlib `syscall`); `go.mod`/`go.sum` unchanged.

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean on **unix and Windows**
  (`GOOS=windows go vet`/cross-build). Full `internal/providers/anthropic_oauth_dev`
  suite green.
- `TestAcquireFileLock_Serializes` — real two-file-description `flock` mutual
  exclusion (second acquire blocks while the first is held, succeeds after
  release).
- `TestRefresh_AdoptsNewerOnDiskTokenWithoutPost` — **fails on the old code**
  (it POSTs and rotates); with the fix, the peer's newer token is adopted with
  zero network hits.
- `TestRefresh_PostsWhenNoNewerOnDiskToken` — a genuine refresh still POSTs
  exactly once (the adopt path doesn't suppress real refreshes).

A true two-process race against live Anthropic OAuth isn't reproducible in CI
(dev-only, needs real credentials); the unit tests exercise the real
`RefreshNow` + store + `flock` code paths. Runtime-only, ships from loomcycle
alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
