### PR TITLE
feat(cli): `anthropic status --probe` verifies server-side validity (F6)

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -69,10 +69,13 @@ A background goroutine refreshes the access token every 30 seconds, rotating pro
 ### Status check
 
 ```sh
-loomcycle anthropic status
+loomcycle anthropic status            # local token-file metadata only
+loomcycle anthropic status --probe    # ALSO verify server-side validity
 ```
 
 Prints the token file path, whether tokens are loaded, the access token's expiry, the granted scope, and the obtainedAt timestamp. Also surfaces a warning if the token file's permissions have drifted from 0600.
+
+By default every field is **local token-file metadata** — the token can read "valid / expires in 6h" while Anthropic has already revoked it server-side, so plain `status` prints `Server-side: not checked`. Pass **`--probe`** (alias `--verify`) to confirm against Anthropic: it attempts a token refresh (free — token endpoint, no inference billing), reporting `✓ valid` (exit 0) or `✗ INVALID` (exit 1) with the reason. A successful probe **rotates and persists** a fresh token, so it also heals/extends the session.
 
 ### Logout
 

--- a/internal/cli/anthropic.go
+++ b/internal/cli/anthropic.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"io/fs"
@@ -19,7 +20,8 @@ import (
 // RunAnthropic dispatches to one of:
 //
 //	loomcycle anthropic login           one-time OAuth login (opens browser)
-//	loomcycle anthropic status          print current token state
+//	loomcycle anthropic status [--probe] print token state; --probe verifies
+//	                                    server-side validity (refreshes the token)
 //	loomcycle anthropic logout          delete the local token file
 //
 // All three are gated on LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 — when
@@ -165,8 +167,15 @@ func runAnthropicLogin(args []string, stdout, stderr io.Writer) int {
 // when no token exists (logout-status pattern: status is informational,
 // not a precondition check).
 func runAnthropicStatus(args []string, stdout, stderr io.Writer) int {
-	if len(args) > 0 {
-		fmt.Fprintf(stderr, "status: takes no arguments\n")
+	fs := flag.NewFlagSet("anthropic status", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	probe := fs.Bool("probe", false, "verify server-side validity by attempting a token refresh against Anthropic (opt-in network call; rotates + heals the token on success)")
+	fs.BoolVar(probe, "verify", false, "alias for --probe")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if fs.NArg() > 0 {
+		fmt.Fprintf(stderr, "status: takes no positional arguments\n")
 		return 2
 	}
 	storePath, err := oauthdev.DefaultTokenStorePath()
@@ -174,8 +183,14 @@ func runAnthropicStatus(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "status: cannot resolve config dir: %v\n", err)
 		return 1
 	}
-	store := oauthdev.NewTokenStore(storePath)
-	fmt.Fprintf(stdout, "Token storage: %s\n", storePath)
+	return anthropicStatus(stdout, stderr, oauthdev.NewTokenStore(storePath), *probe, oauthdev.ExchangeOptions{})
+}
+
+// anthropicStatus is the testable core of `anthropic status`. store + opts are
+// injected so a test can drive the --probe path against a fake token endpoint.
+// opts is the empty value in production (default endpoint + client).
+func anthropicStatus(stdout, stderr io.Writer, store *oauthdev.TokenStore, probe bool, opts oauthdev.ExchangeOptions) int {
+	fmt.Fprintf(stdout, "Token storage: %s\n", store.Path())
 	tok, err := store.Load()
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -198,6 +213,34 @@ func runAnthropicStatus(args []string, stdout, stderr io.Writer) int {
 	if err := store.VerifyPermissions(); err != nil {
 		fmt.Fprintf(stdout, "⚠ WARNING:     %v\n", err)
 	}
+
+	if !probe {
+		// F6: every field above is LOCAL token-file metadata — a token can read
+		// "valid / expires in 6h" while Anthropic has already revoked it. Say so
+		// instead of implying the green state was confirmed server-side.
+		fmt.Fprintln(stdout, "Server-side:   not checked (local metadata only) — pass --probe to verify against Anthropic")
+		return 0
+	}
+
+	// --probe: confirm server-side validity by attempting a refresh — the exact
+	// path F6 found silently dead ("refresh failed: invalid_grant"). It is free
+	// (token endpoint, no inference billing) and runs through the canonical
+	// Refresher, so a successful probe also ROTATES + persists a fresh token
+	// (heals/extends the session).
+	if tok.RefreshToken == "" {
+		fmt.Fprintln(stdout, "Server-side:   cannot probe — no refresh token in the store; run `loomcycle anthropic login`")
+		return 1
+	}
+	refresher := oauthdev.NewRefresher(store, opts, func(string, ...any) {})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := refresher.RefreshNow(ctx); err != nil {
+		fmt.Fprintf(stdout, "Server-side:   ✗ INVALID — %v\n", err)
+		fmt.Fprintln(stdout, "Run `loomcycle anthropic login` to re-authorize.")
+		return 1
+	}
+	fmt.Fprintf(stdout, "Server-side:   ✓ valid (refresh succeeded; token rotated, new expiry %s)\n",
+		refresher.Token().ExpiresAt.Format(time.RFC3339))
 	return 0
 }
 

--- a/internal/cli/anthropic_status_test.go
+++ b/internal/cli/anthropic_status_test.go
@@ -1,0 +1,90 @@
+package cli
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	oauthdev "github.com/denn-gubsky/loomcycle/internal/providers/anthropic_oauth_dev"
+)
+
+func storeWithToken(t *testing.T, tok oauthdev.Token) *oauthdev.TokenStore {
+	t.Helper()
+	store := oauthdev.NewTokenStore(t.TempDir() + "/tokens.json")
+	if err := store.Save(tok); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	return store
+}
+
+// F6: --probe confirms server-side validity by refreshing; a 200 means the
+// session is alive, and the probe rotates + persists the fresh token.
+func TestAnthropicStatus_ProbeValid(t *testing.T) {
+	store := storeWithToken(t, oauthdev.NewToken("old-at", "old-rt", "user:inference", 3600))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-at","refresh_token":"new-rt","expires_in":3600,"scope":"user:inference"}`))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := anthropicStatus(&out, &errb, store, true, oauthdev.ExchangeOptions{Endpoint: srv.URL})
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "✓ valid") {
+		t.Errorf("output missing ✓ valid:\n%s", out.String())
+	}
+	// The probe healed the store: the rotated token is persisted.
+	if got, _ := store.Load(); got.AccessToken != "new-at" {
+		t.Errorf("store not rotated: access token = %q, want new-at", got.AccessToken)
+	}
+}
+
+// A dead session (the token endpoint rejects the refresh token) → ✗ INVALID + exit 1.
+func TestAnthropicStatus_ProbeInvalid(t *testing.T) {
+	store := storeWithToken(t, oauthdev.NewToken("old-at", "dead-rt", "user:inference", 3600))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_grant"}`))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := anthropicStatus(&out, &errb, store, true, oauthdev.ExchangeOptions{Endpoint: srv.URL})
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(out.String(), "✗ INVALID") || !strings.Contains(out.String(), "invalid_grant") {
+		t.Errorf("output missing ✗ INVALID / invalid_grant:\n%s", out.String())
+	}
+}
+
+// Plain status (no probe) must say it did NOT confirm server-side validity (F6).
+func TestAnthropicStatus_NoProbe_NotChecked(t *testing.T) {
+	store := storeWithToken(t, oauthdev.NewToken("at", "rt", "user:inference", 3600))
+	var out, errb bytes.Buffer
+	code := anthropicStatus(&out, &errb, store, false, oauthdev.ExchangeOptions{})
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "not checked") {
+		t.Errorf("plain status should say server-side not checked:\n%s", out.String())
+	}
+}
+
+// --probe with no refresh token in the store can't verify → exit 1.
+func TestAnthropicStatus_ProbeNoRefreshToken(t *testing.T) {
+	store := storeWithToken(t, oauthdev.Token{AccessToken: "at", ExpiresAt: time.Now().Add(time.Hour), ObtainedAt: time.Now()})
+	var out, errb bytes.Buffer
+	code := anthropicStatus(&out, &errb, store, true, oauthdev.ExchangeOptions{})
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(out.String(), "no refresh token") {
+		t.Errorf("output missing 'no refresh token':\n%s", out.String())
+	}
+}


### PR DESCRIPTION
## Why

Finding **F6**. `loomcycle anthropic status` printed only **local token-file
metadata** — it would report "Logged in: yes / Access expires in ~6h" while
Anthropic had already revoked the session (a live inference returned `401 +
refresh failed: invalid_grant`). Operators and automation trusted a green status
that was actually dead; the failure only surfaced at run time.

## What

- **Plain `status`** now states the limitation: `Server-side: not checked (local
  metadata only) — pass --probe to verify against Anthropic`, instead of implying
  the green fields were confirmed server-side.
- **`--probe`** (alias `--verify`) confirms server-side validity by attempting a
  token **refresh** — the exact path F6 found silently dead (`invalid_grant`).
  It's free (token endpoint, no inference billing) and reports `✓ valid` (exit 0)
  or `✗ INVALID — <reason>` (exit 1). It runs through the canonical `Refresher`,
  so a successful probe also **rotates + persists** a fresh token — healing the
  session. (Complements the F7 cross-process refresh lock.)

The status logic is refactored into a testable `anthropicStatus(stdout, stderr,
store, probe, opts)` core so the probe can be driven against a fake token
endpoint (the endpoint is injected via `ExchangeOptions`).

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `internal/cli` suite green.
- Unit (fake token endpoint): `ProbeValid` (200 → `✓ valid`, **store rotated** to
  the fresh token), `ProbeInvalid` (400 `invalid_grant` → `✗ INVALID`, exit 1),
  `NoProbe_NotChecked`, `ProbeNoRefreshToken` (exit 1).
- Binary checks: `status --probe`/`--verify` parse, gating, unknown flag → exit 2,
  not-logged-in short-circuits before the probe.

The probe against **live** Anthropic isn't reproducible in CI (dev-only provider,
needs real credentials); the unit tests exercise the real `RefreshNow` + store
path. CLI-only — no wire change, ships from loomcycle alone. Documented in
`docs/PROVIDERS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
