### PR TITLE
fix(mcp,grpc): operator ctx grants AgentTools ceiling for agentdef create (F11)

### DIFF
--- a/internal/api/grpc/agentdef_ceiling_test.go
+++ b/internal/api/grpc/agentdef_ceiling_test.go
@@ -1,0 +1,20 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// F11: substrateGRPCCtx must attach the AgentTools wildcard ceiling (mirrors
+// HTTP substrateAdminCtx + MCP operatorCtx) so a gRPC `agentdef`/`skilldef`
+// create with a tool-bearing allowed_tools overlay validates instead of
+// refusing "caller's effective allowed_tools not on ctx". Fails on the pre-fix
+// code, where AgentTools(ctx) was nil.
+func TestGrpcSubstrate_OperatorCtxGrantsAgentToolsWildcard(t *testing.T) {
+	got := tools.AgentTools(substrateGRPCCtx(context.Background()))
+	if len(got) != 1 || got[0] != "*" {
+		t.Fatalf("substrateGRPCCtx AgentTools = %v, want [*] (F11)", got)
+	}
+}

--- a/internal/api/grpc/substrate.go
+++ b/internal/api/grpc/substrate.go
@@ -48,6 +48,12 @@ func substrateGRPCCtx(ctx context.Context) context.Context {
 		TenantID: principal.TenantID,
 	})
 	ctx = tools.WithAgentName(ctx, grpcSubstrateAdminAgentName)
+	// AgentTools wildcard ceiling (F11): operator-trust path → mirror HTTP
+	// substrateAdminCtx + MCP operatorCtx so a gRPC `agentdef`/`skilldef`
+	// create with a tool-bearing allowed_tools overlay validates instead of
+	// refusing "caller's effective allowed_tools not on ctx". Per-run contexts
+	// keep the agent's actual list, so the in-loop escalation guard is unchanged.
+	ctx = tools.WithAgentTools(ctx, []string{"*"})
 	ctx = tools.WithMemoryPolicy(ctx, tools.MemoryPolicyValue{
 		AllowedScopes: []string{"agent", "user", "global"},
 	})

--- a/internal/api/mcp/agentdef_ceiling_test.go
+++ b/internal/api/mcp/agentdef_ceiling_test.go
@@ -1,0 +1,22 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// F11: operatorCtx must attach the AgentTools wildcard ceiling so an MCP
+// `agentdef`/`skilldef` create with a tool-bearing allowed_tools overlay
+// validates instead of refusing "caller's effective allowed_tools not on ctx
+// (runtime misconfiguration)". The builtin agentdef test pins that a ["*"]
+// ceiling actually accepts a tool-bearing create; this pins that operatorCtx
+// provides it (mirroring HTTP substrateAdminCtx). Fails on the pre-fix code,
+// where AgentTools(ctx) was nil.
+func TestOperatorCtx_GrantsAgentToolsWildcard(t *testing.T) {
+	got := tools.AgentTools(operatorCtx(context.Background()))
+	if len(got) != 1 || got[0] != "*" {
+		t.Fatalf("operatorCtx AgentTools = %v, want [*] (F11)", got)
+	}
+}

--- a/internal/api/mcp/context.go
+++ b/internal/api/mcp/context.go
@@ -57,6 +57,17 @@ func operatorCtx(ctx context.Context) context.Context {
 	})
 	ctx = tools.WithAgentName(ctx, operatorAgentName)
 
+	// AgentTools wildcard ceiling (F11). Without it, `agentdef`/`skilldef`
+	// create with a non-empty allowed_tools overlay refuse with "caller's
+	// effective allowed_tools not on ctx (runtime misconfiguration)" — the
+	// create-time subset check treats a nil ceiling as "unknown → refuse". The
+	// MCP server is operator-trust (single-operator by construction), so attach
+	// the same wildcard the HTTP /v1/_agentdef admin path uses (see
+	// substrateAdminCtx), making MCP agentdef-create symmetric with HTTP/gRPC.
+	// Per-RUN contexts still set WithAgentTools to the agent's actual list, so
+	// the in-loop AgentDef capability-escalation guard is unchanged.
+	ctx = tools.WithAgentTools(ctx, []string{"*"})
+
 	// Memory: full scope access. QuotaBytes=0 falls back to the
 	// global default (LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES) — operators
 	// who want a tighter cap on MCP-direct writes can set the env.


### PR DESCRIPTION
## Why

Finding **F11**: "the dynamic agent-creation path via MCP is unusable for
tool-bearing agents." `agentdef create` (and `skilldef create`) with a non-empty
`allowed_tools` overlay refused over **MCP and gRPC** with `caller's effective
allowed_tools not on ctx (runtime misconfiguration)`. The create-time subset
check treats a nil ceiling on ctx as "unknown → refuse rather than risk silent
widening" — and neither `operatorCtx` (MCP) nor `substrateGRPCCtx` (gRPC)
attached one. Setting `LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1` didn't help,
because `agentdef create` is the operator-trust **substrate** path, not
`register_agent`'s lighter tool-stripping path.

The HTTP `/v1/_agentdef` admin path already solved this — `substrateAdminCtx`
attaches the operator-trust wildcard ceiling `tools.WithAgentTools(ctx, ["*"])`,
with a comment explaining why it's safe. MCP and gRPC just never got the same
line (an asymmetry, since the three substrate-authoring transports are supposed
to be symmetric).

## What

Attach the same wildcard ceiling in `operatorCtx` (MCP) and `substrateGRPCCtx`
(gRPC), so `agentdef`/`skilldef` create over those transports validates exactly
like HTTP.

**No new authority:** the MCP server is single-operator by construction (stdio =
the operator running it) and the gRPC substrate path is operator-trust — both
already grant `any` scope on every Def policy. Per-**run** contexts still set
`WithAgentTools` to the agent's *actual* allowed_tools list, so the in-loop
`AgentDef` capability-escalation guard (a running agent can't author a child with
tools it doesn't itself hold) is completely unchanged. This only affects the
operator-trust direct-authoring paths.

No wire-shape change — ships from loomcycle alone.

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `internal/api/mcp` +
  `internal/api/grpc` suites green.
- `TestOperatorCtx_GrantsAgentToolsWildcard` (mcp) +
  `TestGrpcSubstrate_OperatorCtxGrantsAgentToolsWildcard` (grpc) — both **fail on
  the pre-fix code** (`AgentTools` nil). The existing builtin `agentdef` test
  already pins that a `["*"]` ceiling accepts a tool-bearing create, and HTTP has
  its own end-to-end create-with-allowed-tools test.
- **E2E** on a built binary: the MCP `initialize` → `tools/call agentdef create`
  handshake over `/v1/_mcp` with `allowed_tools: [Read, Write, Bash]` now returns
  a `def_id` (created_by `a_mcp-operator`) instead of the "runtime
  misconfiguration" refusal.

This is **A2a** of the F11/F14 batch. A follow-up adds the missing per-agent
config fields (`channels` / `evaluation_scopes` / `interruption`) to
`register_agent` + the `agentdef` overlay (F14), and a separate PR adds the
`channeldef` meta-tool (F20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
