### PR TITLE
feat(mcp): channeldef meta-tool — channel CRUD over MCP (F20)

### DIFF
--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -30,6 +30,9 @@ var handlersByName = map[string]toolHandler{
 	"unregister_agent": handleUnregisterAgent,
 	"list_agents":      handleListAgents,
 
+	// Channel admin CRUD (F20) — the MCP twin of REST /v1/_channels.
+	"channeldef": handleChannelDef,
+
 	// Builtin wrappers
 	"memory": wrapBuiltin("memory", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.Memory(ctx, in)
@@ -377,6 +380,59 @@ func handleRegisterAgent(ctx context.Context, env *handlerEnv, args json.RawMess
 		return toolErr("register_agent: " + err.Error()), nil
 	}
 	return toolResultJSON(res), nil
+}
+
+// handleChannelDef is the MCP twin of the REST POST/PATCH/DELETE
+// /v1/_channels admin surface (F20): channel create/update/delete over MCP, so
+// an MCP orchestrator no longer has to drop to raw REST (or a DB delete) to
+// manage the runtime channel substrate. Dispatches the op to the existing
+// Connector channel-admin methods — yaml-declared channels stay immutable
+// (the Connector returns channel_yaml_immutable, surfaced as a tool error).
+func handleChannelDef(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("channeldef: no connector wired")
+	}
+	var disc struct {
+		Op   string `json:"op"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &disc); err != nil {
+		return toolErr("invalid channeldef arguments: " + err.Error()), nil
+	}
+	if disc.Name == "" {
+		return toolErr("channeldef: name is required"), nil
+	}
+	switch disc.Op {
+	case "create":
+		var req connector.ChannelCreateRequest
+		if err := json.Unmarshal(args, &req); err != nil {
+			return toolErr("invalid channeldef create arguments: " + err.Error()), nil
+		}
+		res, err := env.connector.CreateChannel(ctx, req)
+		if err != nil {
+			return toolErr("channeldef create: " + err.Error()), nil
+		}
+		return toolResultJSON(res), nil
+	case "update":
+		var req connector.ChannelUpdateRequest
+		if err := json.Unmarshal(args, &req); err != nil {
+			return toolErr("invalid channeldef update arguments: " + err.Error()), nil
+		}
+		res, err := env.connector.UpdateChannel(ctx, disc.Name, req)
+		if err != nil {
+			return toolErr("channeldef update: " + err.Error()), nil
+		}
+		return toolResultJSON(res), nil
+	case "delete":
+		if err := env.connector.DeleteChannel(ctx, disc.Name); err != nil {
+			return toolErr("channeldef delete: " + err.Error()), nil
+		}
+		return toolResultJSON(map[string]any{"name": disc.Name, "deleted": true}), nil
+	case "":
+		return toolErr("channeldef: missing required field: op"), nil
+	default:
+		return toolErr(fmt.Sprintf("channeldef: unknown op %q (want create, update, delete)", disc.Op)), nil
+	}
 }
 
 func handleUnregisterAgent(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -38,6 +38,7 @@ type mockConnector struct {
 	spawnMaxSeen atomic.Int32
 	regCalls     atomic.Int32
 	regResult    connector.AgentDescriptor
+	chanDefCalls atomic.Int32 // CreateChannel + UpdateChannel + DeleteChannel
 	pauseResult  connector.PauseResult
 	listCallback func()
 
@@ -240,12 +241,15 @@ func (m *mockConnector) AckChannel(context.Context, connector.ChannelAckRequest)
 	return connector.ChannelAckResult{}, nil
 }
 func (m *mockConnector) CreateChannel(context.Context, connector.ChannelCreateRequest) (connector.ChannelDescriptor, error) {
+	m.chanDefCalls.Add(1)
 	return connector.ChannelDescriptor{}, nil
 }
 func (m *mockConnector) UpdateChannel(context.Context, string, connector.ChannelUpdateRequest) (connector.ChannelDescriptor, error) {
+	m.chanDefCalls.Add(1)
 	return connector.ChannelDescriptor{}, nil
 }
 func (m *mockConnector) DeleteChannel(context.Context, string) error {
+	m.chanDefCalls.Add(1)
 	return nil
 }
 
@@ -330,8 +334,8 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 40 {
-		t.Errorf("got %d tools, want 40 (RFC L adds operatortokendef on top of the resolve_probe list)", len(result.Tools))
+	if len(result.Tools) != 41 {
+		t.Errorf("got %d tools, want 41 (F20 adds channeldef on top of the operatortokendef list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
@@ -620,6 +624,49 @@ func TestServer_RegisterAgent_DispatchesThroughConnector(t *testing.T) {
 	}
 	if mc.regCalls.Load() != 1 {
 		t.Errorf("Connector.RegisterAgent called %d times, want 1", mc.regCalls.Load())
+	}
+}
+
+// F20: the channeldef meta-tool dispatches create/update/delete to the
+// Connector's channel-admin methods (the MCP twin of REST /v1/_channels).
+func TestServer_ChannelDef_DispatchesThroughConnector(t *testing.T) {
+	for _, tc := range []struct {
+		op   string
+		args string
+	}{
+		{"create", `{"op":"create","name":"runtime-ch","scope":"global","semantic":"queue"}`},
+		{"update", `{"op":"update","name":"runtime-ch","max_messages":100}`},
+		{"delete", `{"op":"delete","name":"runtime-ch"}`},
+	} {
+		t.Run(tc.op, func(t *testing.T) {
+			mc := &mockConnector{}
+			srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+			in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"channeldef","arguments":` + tc.args + `}}` + "\n"
+			resps, _ := driveServer(t, srv, in)
+			if len(resps) != 1 {
+				t.Fatalf("got %d responses, want 1", len(resps))
+			}
+			if resps[0].Error != nil {
+				t.Fatalf("unexpected JSON-RPC error: %+v", resps[0].Error)
+			}
+			if mc.chanDefCalls.Load() != 1 {
+				t.Errorf("%s: Connector channel-admin called %d times, want 1", tc.op, mc.chanDefCalls.Load())
+			}
+		})
+	}
+}
+
+// A channeldef op with no name is refused before reaching the Connector.
+func TestServer_ChannelDef_RequiresName(t *testing.T) {
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"channeldef","arguments":{"op":"create"}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if mc.chanDefCalls.Load() != 0 {
+		t.Errorf("Connector called %d times on a name-less request, want 0", mc.chanDefCalls.Load())
 	}
 }
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -144,6 +144,24 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			InputSchema: builtinSchema("channel"),
 		},
 		{
+			Name:        "channeldef",
+			Description: "Channel admin CRUD (create/update/delete) for the runtime-declared channel substrate — the MCP twin of the REST POST/PATCH/DELETE /v1/_channels surface (F20). yaml-declared channels are immutable (create/update/delete on one returns channel_yaml_immutable).",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["op", "name"],
+				"properties": {
+					"op":           {"type": "string", "enum": ["create", "update", "delete"], "description": "Which admin operation to perform."},
+					"name":         {"type": "string", "description": "Channel name (required for all ops)."},
+					"description":  {"type": "string"},
+					"scope":        {"type": "string", "enum": ["global", "agent", "user"], "description": "create only. Default global."},
+					"semantic":     {"type": "string", "enum": ["queue", "topic"], "description": "Default queue."},
+					"default_ttl":  {"type": "integer", "description": "Per-message TTL seconds. 0 = no TTL."},
+					"max_messages": {"type": "integer", "description": "Bounded-queue cap. 0 = unbounded."},
+					"publisher":    {"type": "string", "description": "create only. Free-form attribution."}
+				}
+			}`),
+		},
+		{
 			Name:        "agentdef",
 			Description: "AgentDef tool ops (create/fork/get/list/promote/retire). Pass-through.",
 			InputSchema: builtinSchema("agentdef"),


### PR DESCRIPTION
## Why

Finding **F20**. Channel admin CRUD existed only over **REST**
(`POST/PATCH/DELETE /v1/_channels`); the MCP surface had
publish/subscribe/peek/ack/list_channels but **no `channeldef`** — so an MCP
orchestrator (Claude Code, a custom dashboard) couldn't create or delete a
runtime channel without dropping to raw REST, and clearing a channel required a
direct DB delete.

## What

The Connector already exposes `CreateChannel` / `UpdateChannel` / `DeleteChannel`
(the REST handlers consume them). This adds the missing **`channeldef`** MCP
meta-tool (`op: create | update | delete`) that dispatches to those existing
methods — no new Connector or store work.

- yaml-declared channels stay immutable: the Connector returns
  `channel_yaml_immutable`, surfaced as a tool error (same contract as REST).
- The live meta-tool count goes **40 → 41**. It's registry-derived (since F1), so
  there's no hardcoded doc/count to update; the tool is self-describing via its
  Description + InputSchema.
- Go-only: the `@loomcycle/client` TS adapter already does channel CRUD over
  HTTP `/v1/_channels`; this meta-tool is for MCP clients.

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `internal/api/mcp` suite green.
- `TestServer_ChannelDef_DispatchesThroughConnector` — create/update/delete each
  route to the Connector exactly once (through the real `tools/call` dispatch).
- `TestServer_ChannelDef_RequiresName` — a name-less op is refused before the
  Connector. `TestServer_ToolsList_ReturnsFullCatalogue` updated to 41.
- **E2E** on a built binary: `initialize` → `tools/call channeldef create` over
  `/v1/_mcp` returns `{"name":"runtime-ch","scope":"global","semantic":"queue",
  "source":"runtime"}`; `delete` returns `{"deleted":true}`.

## Out of scope (follow-up)
F20's secondary ask — a `purge` op to clear buffered **messages** on a
yaml-declared channel — needs a new Connector/store method (distinct from
deleting a runtime channel *definition*) and is left for a separate PR.

This completes the **A2/A3 MCP-authoring-parity batch** (A2a #393 ceiling,
A2b #394 capability fields, A3 this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
