### PR TITLE
feat(webhook): boot-bootstrap static webhooks + validate delivery target (F24)

### DIFF
--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -808,3 +808,27 @@ cache:
 # under anthropic-oauth-dev — they're exposed under the
 # mcp__loomcycle__* wire mask so Anthropic's subscription-billing
 # layer treats them as if they came from an MCP server.
+
+# ─── Inbound webhooks (RFC H) ────────────────────────────────────────
+# External systems (GitHub / Gitea / Stripe / CI / n8n) trigger agent runs
+# via a signed POST /v1/_webhooks/{name}. Off by default — turn the receiver
+# on with LOOMCYCLE_WEBHOOKS_ENABLED=1. A static webhook needs `enabled: true`
+# AND a valid delivery target (delivery=spawn → `agent`; delivery=channel →
+# `channel`) or loomcycle refuses to boot. The HMAC signing secret resolves
+# from the env-var named here — a LOOMCYCLE_*-prefixed name auto-resolves with
+# no allowlist config; otherwise add it to LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST.
+# `goal: "$"` hands the agent the entire signed body. See
+# `help(topic="input-webhooks")` for the full operator walkthrough.
+#
+# webhooks:
+#   pr-opened:
+#     enabled: true
+#     delivery: spawn
+#     agent: researcher              # must be a declared agent
+#     auth:
+#       kind: hmac                   # hmac (default) | bearer | none
+#       header: X-Hub-Signature-256
+#       signing_secret_env: LOOMCYCLE_GITEA_WEBHOOK_SECRET
+#       delivery_id_header: X-Gitea-Delivery
+#     payload_mapping:
+#       goal: "$"                    # "$" = the whole signed body

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1454,6 +1454,17 @@ func main() {
 		for _, warn := range webhookapi.UnresolvableStaticSecrets(cfg, webhookAllowlist, os.Getenv) {
 			log.Printf("webhooks: WARNING: %s", warn)
 		}
+		// Materialize static yaml `webhooks:` into the webhook_defs substrate
+		// (F24) — parity with agents/skills/schedules, so a static webhook is
+		// listable/forkable in the Library without a prior fork. Idempotent +
+		// fork-respecting. A minimal tool instance (Store + Cfg) suffices.
+		bootWH := &builtin.WebhookDef{Store: storeIface, Cfg: cfg}
+		bootWHCtx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "webhook-bootstrap"})
+		if n, err := bootWH.BootstrapStaticWebhooks(bootWHCtx); err != nil {
+			log.Printf("webhooks: static-webhook bootstrap: %v (continuing)", err)
+		} else if n > 0 {
+			log.Printf("webhooks: materialized %d static webhook(s) into the substrate", n)
+		}
 	} else if cfg.Env.WebhooksEnabled {
 		log.Printf("webhooks: disabled (no Store backend or no HTTP server)")
 	} else {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3343,6 +3343,40 @@ func agentGateWarnings(name string, a AgentDef) []string {
 	return w
 }
 
+// validateStaticWebhook checks a static `webhooks:` entry's delivery target +
+// auth.kind at config-load (F24). A mismatched delivery target (spawn with no
+// agent, channel with no channel) means the webhook can NEVER fire — failing
+// loud at boot is a better operator signal than a 404/500 at request time. The
+// receiver normalizes an empty `delivery` to spawn and an empty `auth.kind` to
+// hmac, so the empty cases validate as those. Secret RESOLVABILITY is a
+// separate, non-fatal boot WARNING (the receiver's UnresolvableStaticSecrets).
+func validateStaticWebhook(name string, w Webhook) error {
+	switch w.Delivery {
+	case "", "spawn":
+		if w.Agent == "" {
+			return fmt.Errorf("webhooks.%s: delivery=spawn requires `agent`", name)
+		}
+		if w.Channel != "" {
+			return fmt.Errorf("webhooks.%s: delivery=spawn forbids `channel` (set agent, not channel)", name)
+		}
+	case "channel":
+		if w.Channel == "" {
+			return fmt.Errorf("webhooks.%s: delivery=channel requires `channel`", name)
+		}
+		if w.Agent != "" {
+			return fmt.Errorf("webhooks.%s: delivery=channel forbids `agent` (set channel, not agent)", name)
+		}
+	default:
+		return fmt.Errorf("webhooks.%s: unknown delivery %q (want spawn or channel)", name, w.Delivery)
+	}
+	switch strings.ToLower(strings.TrimSpace(w.Auth.Kind)) {
+	case "", "hmac", "bearer", "none":
+	default:
+		return fmt.Errorf("webhooks.%s: unknown auth.kind %q (want hmac, bearer, or none)", name, w.Auth.Kind)
+	}
+	return nil
+}
+
 func validate(c *Config) error {
 	if c.Concurrency.MaxConcurrentRuns < 1 {
 		return fmt.Errorf("concurrency.max_concurrent_runs must be >= 1")
@@ -3424,6 +3458,12 @@ func validate(c *Config) error {
 		if mb.TenancyStrategy.Kind == "shared_key_with_prefix" &&
 			!strings.Contains(mb.TenancyStrategy.PrefixPattern, "{tenant_id}") {
 			return fmt.Errorf("memory_backends.%s: tenancy_strategy.prefix_pattern %q must contain {tenant_id} for shared_key_with_prefix (an empty or token-less prefix collapses all tenants into one keyspace)", bname, mb.TenancyStrategy.PrefixPattern)
+		}
+	}
+	// Static webhooks: a misconfigured delivery target can never fire (F24).
+	for wname, wh := range c.Webhooks {
+		if err := validateStaticWebhook(wname, wh); err != nil {
+			return err
 		}
 	}
 	for name, agent := range c.Agents {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2342,3 +2342,57 @@ agents:
 		t.Fatalf("expected a memory_scopes warning for agent porous; warnings=%v", cfg.Warnings)
 	}
 }
+
+// F24: a static webhook with a mismatched delivery target can never fire, so
+// validateStaticWebhook rejects it at config-load.
+func TestValidateStaticWebhook(t *testing.T) {
+	cases := []struct {
+		name    string
+		wh      Webhook
+		wantErr string // substring; "" = no error
+	}{
+		{"spawn ok", Webhook{Delivery: "spawn", Agent: "a"}, ""},
+		{"empty delivery is spawn, ok", Webhook{Agent: "a"}, ""},
+		{"spawn without agent", Webhook{Delivery: "spawn"}, "requires `agent`"},
+		{"spawn with channel", Webhook{Delivery: "spawn", Agent: "a", Channel: "c"}, "forbids `channel`"},
+		{"channel ok", Webhook{Delivery: "channel", Channel: "c"}, ""},
+		{"channel without channel", Webhook{Delivery: "channel"}, "requires `channel`"},
+		{"channel with agent", Webhook{Delivery: "channel", Channel: "c", Agent: "a"}, "forbids `agent`"},
+		{"unknown delivery", Webhook{Delivery: "carrier-pigeon", Agent: "a"}, "unknown delivery"},
+		{"auth none ok", Webhook{Delivery: "spawn", Agent: "a", Auth: WebhookAuth{Kind: "none"}}, ""},
+		{"unknown auth.kind", Webhook{Delivery: "spawn", Agent: "a", Auth: WebhookAuth{Kind: "magic"}}, "unknown auth.kind"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateStaticWebhook("wh", tc.wh)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want contains %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// The validate hook is wired into Load (F24).
+func TestLoad_RejectsWebhookMissingDeliveryTarget(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+webhooks:
+  broken:
+    enabled: true
+    delivery: spawn
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
+	if _, err := Load(yamlPath); err == nil || !strings.Contains(err.Error(), "requires `agent`") {
+		t.Fatalf("Load err = %v, want a webhook delivery-target error", err)
+	}
+}

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -430,6 +431,40 @@ func (s *WebhookDef) bootstrapStatic(ctx context.Context, name string, static co
 		return created, fmt.Errorf("promote bootstrap: %w", err)
 	}
 	return created, nil
+}
+
+// BootstrapStaticWebhooks materializes static yaml `webhooks:` into the
+// webhook_defs substrate at boot — parity with agents/skills/schedules
+// (F24), so a static webhook is listable/forkable via the WebhookDef tool
+// without first being forked, and shows up in the Library like the other Defs.
+// Idempotent + fork-respecting: a name that already has an active version (a
+// prior bootstrap or a runtime fork) is left untouched. Returns the count of
+// webhooks newly seeded. A minimal tool instance (Store + Cfg) suffices.
+func (s *WebhookDef) BootstrapStaticWebhooks(ctx context.Context) (int, error) {
+	if s.Store == nil || s.Cfg == nil {
+		return 0, nil
+	}
+	names := make([]string, 0, len(s.Cfg.Webhooks))
+	for name := range s.Cfg.Webhooks {
+		names = append(names, name)
+	}
+	sort.Strings(names) // deterministic order for logs + tests
+	seeded := 0
+	for _, name := range names {
+		_, err := s.Store.WebhookDefGetActive(ctx, name)
+		if err == nil {
+			continue // already has an active version — leave it
+		}
+		var nf *store.ErrNotFound
+		if !errors.As(err, &nf) {
+			return seeded, fmt.Errorf("bootstrap %q: get active: %w", name, err)
+		}
+		if _, berr := s.bootstrapStatic(ctx, name, s.Cfg.Webhooks[name]); berr != nil {
+			return seeded, fmt.Errorf("bootstrap %q: %w", name, berr)
+		}
+		seeded++
+	}
+	return seeded, nil
 }
 
 // validateWebhookDef enforces the runtime-supplied overlay shape.

--- a/internal/tools/builtin/webhookdef_bootstrap_test.go
+++ b/internal/tools/builtin/webhookdef_bootstrap_test.go
@@ -1,0 +1,36 @@
+package builtin
+
+import "testing"
+
+// F24: static yaml webhooks materialize into webhook_defs at boot — parity with
+// agents/skills/schedules — so they are listable/forkable without a prior fork.
+// Idempotent + fork-respecting.
+func TestWebhookDef_BootstrapStaticWebhooks(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	// First pass seeds the one static webhook (gh-push) from the fixture cfg.
+	n, err := tool.BootstrapStaticWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("bootstrap: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("seeded %d, want 1", n)
+	}
+	row, err := tool.Store.WebhookDefGetActive(ctx, "gh-push")
+	if err != nil {
+		t.Fatalf("get active after bootstrap: %v", err)
+	}
+	if !row.BootstrappedFromStatic {
+		t.Errorf("BootstrappedFromStatic = false, want true")
+	}
+
+	// Idempotent: a name that already has an active version is left untouched.
+	n2, err := tool.BootstrapStaticWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("bootstrap (2nd pass): %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second bootstrap seeded %d, want 0 (idempotent)", n2)
+	}
+}


### PR DESCRIPTION
## Why

Finding **F24** — two static-webhook robustness gaps:

1. **No boot bootstrap.** Static `webhooks:` resolved at the receiver but never
   materialized into `webhook_defs` — unlike agents / skills / schedules, which
   bootstrap at boot (and log `bootstrapped from static cfg.*`). A yaml webhook
   was therefore not listable/forkable in the Library or via the `WebhookDef`
   tool until someone forked it.
2. **No load-time validation.** A misconfigured static webhook (e.g.
   `delivery: spawn` with no `agent`) was **silently inert** — a 404/503 at
   request time with no signal at boot.

## What

- **Boot bootstrap (B2):** `WebhookDef.BootstrapStaticWebhooks` mirrors
  `BootstrapStaticSchedules` — idempotent, fork-respecting, deterministic order.
  Called from `main.go` in the webhooks-enabled block; logs
  `webhooks: materialized N static webhook(s) into the substrate`.
- **Validation (C3):** `config.validate` now rejects a static webhook whose
  delivery target can never fire — `delivery=spawn` w/o `agent` (or with a
  `channel`), `delivery=channel` w/o `channel` (or with an `agent`), or an
  unknown `delivery` / `auth.kind`. **Fatal at load**, matching the rest of
  `validate` ("fail loud at boot is the better operator signal"). Secret
  *resolvability* stays a non-fatal boot WARNING (F23's
  `UnresolvableStaticSecrets`).
- **Example:** a commented `webhooks:` block in the generated example config
  documenting the `enabled` + delivery-target requirement, the `LOOMCYCLE_*`
  secret auto-allow, and the `goal: "$"` full-body mapping.

Runtime-only — no wire change, ships from loomcycle alone.

## What was tested

- `go build ./...`, `go vet`, `gofmt` clean. Full `config` + `tools/builtin`
  suites green; **`TestLoadExample` still passes** (the commented example loads).
- `TestValidateStaticWebhook` (table of valid/invalid delivery + auth.kind) +
  `TestLoad_RejectsWebhookMissingDeliveryTarget` (the hook is wired into `Load`).
- `TestWebhookDef_BootstrapStaticWebhooks` (seeds the static webhook with
  `bootstrapped_from_static=true`; a second pass seeds 0 — idempotent).
- **E2E** on a built binary: a broken webhook (`spawn` w/o `agent`) **refuses to
  boot** (`config: webhooks.broken: delivery=spawn requires agent`); a valid one
  logs `materialized 1 static webhook(s)`; a re-boot on the same data dir
  materializes **0** (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
