### PR TITLE
docs: clarify file-tool CWD + document process-resource metrics (F13/F19)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -55,6 +55,7 @@ Bash has additional warnings: it is **not a true sandbox** even when enabled. Ru
 
 Sandbox semantics (file tools):
 - Paths must resolve **inside** the sandbox root after full `EvalSymlinks` evaluation. Symlinks pointing outside the root are refused.
+- **Relative paths resolve against the loomcycle process's current working directory — NOT against `LOOMCYCLE_WRITE_ROOT` / `LOOMCYCLE_READ_ROOT`.** Those env vars are the *absolute jail* the fully-resolved path must fall inside; they are not the base a relative path is joined to. So if you launch loomcycle from a different directory than your jail root, a relative `Write` path (joined to the process CWD) and `Bash`'s `LOOMCYCLE_BASH_CWD` can point at different places — the offset that scattered files in the experiments harness (the agent wrote to `./foo` while `Bash` ran in `./work/`). **Launch loomcycle from the directory you set as the write/read root** (so process CWD == jail root == `LOOMCYCLE_BASH_CWD`), or have agents use absolute paths.
 - `Write` resolves the **parent** dir (target may not exist yet); `Read`, `Edit`, `Grep`, `Glob`, and `NotebookEdit` resolve the target itself.
 - All file writes are atomic via tempfile + same-directory rename.
 - `Grep` skips binary files via NUL-byte heuristic on the first 8 KiB; caps output at 256 KiB + `head_limit` (default 100).

--- a/internal/help/builtin/observability.md
+++ b/internal/help/builtin/observability.md
@@ -290,6 +290,32 @@ RSS, heap, goroutines, concurrency state, build_info) — scraped by
 Profile A's Prometheus and reusable by any operator-existing
 Prometheus deployment regardless of which profile they pick.
 
+## Process-resource metrics (diagnosing host pressure)
+
+Distinct from the OTEL traces above: loomcycle has a built-in **process-resource
+sampler** that records its own RSS / heap / goroutines / concurrency state — and,
+optionally, **system-wide CPU + memory** — to a `process_samples` table, exposed
+at `GET /v1/_metrics/*` (bearer-authed). This is the surface for capacity planning
+and for diagnosing "the box got slow" incidents.
+
+- **Off by default.** Enable with `LOOMCYCLE_METRICS_ENABLED=1` (cadence
+  `LOOMCYCLE_METRICS_SAMPLE_INTERVAL_MS`, default 5 s; sleeps when no run is
+  active — no DB writes / `/proc` reads while idle).
+- **System-wide CPU% + memory stay OFF even when metrics are on.** Set
+  `LOOMCYCLE_METRICS_COLLECT_SYSTEM=1` to also read `/proc/stat` + `/proc/meminfo`
+  (Linux only; silently ignored on macOS/Windows). Without it the
+  `system_cpu_pct_x100` / `system_mem_*_mb` columns stay NULL — so a runaway
+  driven by *co-tenant* host pressure (a hypervisor balloon / ZFS ARC eating RAM
+  in a shared VM) is invisible to loomcycle's own metrics.
+- **The sampler is not a substitute for a host monitor.** It samples only while a
+  run is active and only what the kernel exposes to its own process — pressure
+  that arrives *between* runs is missed. For always-on host telemetry also run an
+  external monitor (node_exporter / `vmstat` / your cloud's host metrics).
+- Endpoints: `GET /v1/_metrics/samples?since=&until=&limit=`,
+  `GET /v1/_metrics/runs/{run_id}` (peak/mean RSS + max CPU% for the run window),
+  `GET /v1/_metrics/summary?period=1h|24h|7d`. The Web UI's Activity tab renders
+  these live.
+
 ## Related topics
 
 - `pause-resume-snapshot` — runtime quiesce + snapshot lifecycle.


### PR DESCRIPTION
## Why

Class E of the experiments change-plan — the documentation sweep. Several items
were **already correct** on `main` (fixed in releases after the v0.22.0 findings
snapshot), so this PR is the two genuine gaps:

- **F3 / E1** (help topic "nine vs twelve" + basic-group double-count) — already
  fixed: `loomcycle.md` says "twelve higher-level tools" with the basic group
  (`Read/Write/Edit/HTTP/WebFetch/WebSearch/Bash`) correctly *excluding*
  Grep/Glob/NotebookEdit. No change.
- **F4 / E2** (`Agent` vs `spawn_run` mapping) — already documented: the
  `subagents` help topic has an "`Agent` (in-loop) vs `spawn_run` (MCP surface)"
  section. No change.

## What

- **F13 / E4** — `docs/TOOLS.md` sandbox semantics now spell out that file-tool
  **relative paths resolve against the loomcycle process's CWD**, *not* against
  `LOOMCYCLE_WRITE_ROOT` / `READ_ROOT` (those are the absolute jail the resolved
  path must fall inside, not a join base). Launching loomcycle from a different
  directory than the jail root offsets relative `Write` paths from `Bash`'s
  `LOOMCYCLE_BASH_CWD` — the "agent wrote to `./foo` while Bash ran in `./work/`"
  footgun. Recommends launching from the jail root (CWD == root ==
  `LOOMCYCLE_BASH_CWD`) or using absolute paths.
- **F19 / E5** — the `observability` help topic gains a **Process-resource
  metrics** section. The OTEL-only topic never mentioned the `/v1/_metrics`
  sampler; this documents that it's off by default
  (`LOOMCYCLE_METRICS_ENABLED=1`), that **system-wide CPU/memory stay OFF even
  when metrics are on** until `LOOMCYCLE_METRICS_COLLECT_SYSTEM=1` (so the
  `system_*` columns read NULL and co-tenant host pressure is invisible — the
  exact F19 incident), and that the sampler is **not a substitute** for an
  always-on external host monitor.

Docs-only. The plugin-side item (**F12 / E3** — `settings` env changes need a
full Claude Code restart, not `/reload-plugins`) is a separate PR in the
`claude-code-plugin-loomcycle` repo.

## What was tested

`internal/help` builds + tests green (the embedded `observability.md` still
loads). `docs/TOOLS.md` is a plain doc. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

