### PR TITLE
fix(interruption): durable cross-runtime wake for blocking ask (F15)

### DIFF
--- a/internal/tools/builtin/interruption.go
+++ b/internal/tools/builtin/interruption.go
@@ -81,6 +81,18 @@ type Interruption struct {
 	// LOOMCYCLE_INTERRUPTION_HEARTBEAT_INTERVAL_MS.
 	HeartbeatInterval time.Duration
 
+	// ResolvePollInterval is the durable-wake backstop cadence (F15).
+	// A blocking `ask` wakes instantly via the in-process Bus when the
+	// resolve lands on THIS runtime. In a multi-full-runtime topology
+	// (several full runtimes sharing one DB — NOT the thin-client
+	// `--upstream` shape, which routes every resolve to the owning
+	// runtime), a resolve on a different runtime flips the DB row but
+	// cannot reach this process's Bus. So while blocked we also poll the
+	// interrupt row at this cadence and convert a detected terminal
+	// status into a local Bus.Notify. 0 = use the default below.
+	// Field exists mainly for test injection; not operator-tunable.
+	ResolvePollInterval time.Duration
+
 	// MaxPendingPerRun is the operator-global cap on simultaneous
 	// pending interruptions per run. Agent yaml may NARROW (set its
 	// own lower cap) but cannot exceed this. 0 = unbounded.
@@ -540,6 +552,13 @@ func (it *Interruption) execCancel(ctx context.Context, in interruptionInput) (t
 	return tools.Result{Text: string(out)}, nil
 }
 
+// defaultResolvePollInterval is the durable-wake poll cadence when
+// Interruption.ResolvePollInterval is unset. Deliberately coarse: it only
+// bounds cross-runtime wake latency in a multi-full-runtime topology, and a
+// blocked `ask` is a human-in-the-loop event (low volume), so the periodic
+// InterruptGet adds negligible load in the common single-runtime case.
+const defaultResolvePollInterval = 15 * time.Second
+
 // blockWithHeartbeat is the load-bearing wait: bus.Wait blocks the
 // loop's tool dispatch goroutine until the resolve endpoint calls
 // bus.Notify. A sibling goroutine fires the run's heartbeat
@@ -560,36 +579,64 @@ func (it *Interruption) blockWithHeartbeat(ctx context.Context, interruptID stri
 		waitTimeout = 100 * 365 * 24 * time.Hour
 	}
 
-	// Heartbeat ticker. Calls Store.UpdateHeartbeat(runID) directly
-	// at HeartbeatInterval cadence so the v0.5.0 sweeper doesn't mark
-	// this run as dead while the loop's per-iteration heartbeat is
-	// suspended inside our blocking wait. The DB write uses a ctx
-	// that survives the loop's eventual ctx-cancel so a heartbeat in
-	// flight at cancel time still commits cleanly (cheaper than a
-	// failed DB call's retry storm).
 	runID := tools.RunID(ctx)
 	done := make(chan struct{})
-	if runID != "" {
-		interval := it.HeartbeatInterval
-		if interval <= 0 {
-			interval = 30 * time.Second
-		}
-		ticker := time.NewTicker(interval)
-		go func() {
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
+	defer close(done)
+
+	hbInterval := it.HeartbeatInterval
+	if hbInterval <= 0 {
+		hbInterval = 30 * time.Second
+	}
+	pollInterval := it.ResolvePollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultResolvePollInterval
+	}
+
+	// Sibling goroutine, two jobs:
+	//
+	//  1. Heartbeat. Calls Store.UpdateHeartbeat(runID) at
+	//     HeartbeatInterval cadence so the v0.5.0 sweeper doesn't mark
+	//     this run as dead while the loop's per-iteration heartbeat is
+	//     suspended inside our blocking Wait. The DB write uses a ctx
+	//     that survives the loop's eventual ctx-cancel so a heartbeat in
+	//     flight at cancel time still commits cleanly (cheaper than a
+	//     failed DB call's retry storm).
+	//
+	//  2. Durable resolve-poll (F15). A resolve landing on a DIFFERENT
+	//     full runtime flips the DB row but cannot reach this process's
+	//     in-memory Bus, so the Wait below would hang to its timeout.
+	//     Re-read the row at pollInterval and Bus.Notify when it goes
+	//     terminal. We re-Notify on EVERY terminal tick (not once): Bus
+	//     notifications are edge-triggered and lost if they fire before
+	//     Wait registers its waker, so repeating until `done` closes is
+	//     self-healing. In the single-runtime case the resolve handler's
+	//     own Bus.Notify wakes Wait first and `done` closes before the
+	//     poll ever fires — this is purely the cross-runtime backstop.
+	go func() {
+		hbTicker := time.NewTicker(hbInterval)
+		defer hbTicker.Stop()
+		pollTicker := time.NewTicker(pollInterval)
+		defer pollTicker.Stop()
+		for {
+			select {
+			case <-hbTicker.C:
+				if runID != "" {
 					hbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
 					_ = it.Store.UpdateHeartbeat(hbCtx, runID)
 					cancel()
-				case <-done:
-					return
 				}
+			case <-pollTicker.C:
+				pCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+				row, err := it.Store.InterruptGet(pCtx, interruptID)
+				cancel()
+				if err == nil && row.Status != store.InterruptStatusPending {
+					it.Bus.Notify("intr:" + interruptID)
+				}
+			case <-done:
+				return
 			}
-		}()
-	}
-	defer close(done)
+		}
+	}()
 
 	woke := it.Bus.Wait(ctx, "intr:"+interruptID, waitTimeout)
 	if woke {

--- a/internal/tools/builtin/interruption_test.go
+++ b/internal/tools/builtin/interruption_test.go
@@ -127,6 +127,71 @@ func TestInterruption_AskBlockUntilResolve(t *testing.T) {
 	}
 }
 
+// TestInterruption_AskWakesOnCrossRuntimeResolve guards the F15 durable-wake
+// backstop. In a multi-full-runtime topology the resolve lands on a DIFFERENT
+// runtime: the DB row flips to resolved but THIS process's in-memory Bus is
+// never Notified. Without the resolve-poll the ask hangs to its operator
+// timeout; with it, the poll detects the terminal row and wakes the Wait.
+// (Distinguished from TestInterruption_AskBlockUntilResolve by the deliberate
+// absence of a tool.Bus.Notify call.)
+func TestInterruption_AskWakesOnCrossRuntimeResolve(t *testing.T) {
+	tool, ctx, _, cleanup := interruptionFixture(t)
+	defer cleanup()
+
+	// Tight poll so the test doesn't wait the 15s production default.
+	tool.ResolvePollInterval = 20 * time.Millisecond
+
+	resCh := make(chan tools.Result, 1)
+	go func() {
+		// timeout_ms far exceeds the test's 2s ceiling, so a pass can
+		// only come from the poll waking the Wait — never from a timeout.
+		res, err := tool.Execute(ctx, json.RawMessage(`{
+			"op":"ask",
+			"question":"Proceed with delete?",
+			"options":["Yes","No"],
+			"timeout_ms":60000
+		}`))
+		if err != nil {
+			t.Errorf("Execute: %v", err)
+		}
+		resCh <- res
+	}()
+
+	// Let the create + bus.Wait register.
+	time.Sleep(50 * time.Millisecond)
+
+	pending, err := tool.Store.InterruptListByRun(ctx, tools.RunID(ctx), store.InterruptStatusPending)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(pending) != 1 {
+		t.Fatalf("expected 1 pending interrupt, got %d", len(pending))
+	}
+	id := pending[0].InterruptID
+
+	// Resolve WITHOUT Bus.Notify — the cross-runtime case. The owning
+	// runtime (this process) must wake via the durable poll alone.
+	if err := tool.Store.InterruptResolve(ctx, id, "Yes", store.InterruptResolvedByWebUI, nil); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	select {
+	case res := <-resCh:
+		if res.IsError {
+			t.Fatalf("expected non-error result; got %+v", res)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(res.Text), &out); err != nil {
+			t.Fatalf("result not JSON: %v (raw %q)", err, res.Text)
+		}
+		if out["answer"] != "Yes" {
+			t.Errorf("answer=%v, want Yes", out["answer"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask did not wake on cross-runtime resolve (durable poll missing?)")
+	}
+}
+
 func TestInterruption_AskTimeout(t *testing.T) {
 	tool, ctx, _, cleanup := interruptionFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

A blocking `Interruption.ask` parks on the in-process `channels.Bus`; the
resolve handler wakes it with `bus.Notify`. But the Bus is **per-process**. In
a multi-full-runtime topology (several full runtimes sharing one DB), a resolve
landing on a *different* runtime flips the `interrupts` row to `resolved` yet
never reaches the owning runtime's Bus — so the ask hangs to its operator
timeout (or, with no timeout, effectively forever).

The v0.23.0 thin-client (`mcp --upstream`) dissolves the common case by routing
every resolve to the owning runtime, which is why this is filed as the optional
**B3 / F15** backstop for the genuine multi-full-runtime shape rather than a P0.

## What

Fold a **durable resolve-poll** into the during-block sibling goroutine that
already fires the run heartbeat:

- Re-read the interrupt row at `ResolvePollInterval`; when it goes terminal,
  `bus.Notify` the local waiter so the existing `Wait` path wakes and re-reads
  the resolved answer.
- Re-Notify on **every** terminal tick (not once): Bus notifications are
  edge-triggered and lost if they fire before `Wait` registers its waker, so
  repeating until `done` closes is self-healing.
- Default cadence is coarse (**15s**) — a blocked ask is a low-volume
  human-in-the-loop event, so the periodic `InterruptGet` is negligible. The
  field is injectable for tests; not operator-tunable (no new config knob).

**Single-runtime behaviour is unchanged**: the resolve handler's own
`bus.Notify` wins the race and `done` closes before the poll ever fires.

Runtime-only — no wire-protocol or storage-schema change.

## What was tested

- New `TestInterruption_AskWakesOnCrossRuntimeResolve`: resolves the store row
  **without** calling `bus.Notify` (the cross-runtime case) and asserts the ask
  returns the answer. Distinguished from `TestInterruption_AskBlockUntilResolve`
  (which *does* Notify) by that deliberate omission.
- **Fails on the unfixed path** — verified by neutering the poll's `Notify`; the
  ask then hangs to the 2s test ceiling and the test fails.
- `go test -race ./internal/tools/builtin -run TestInterruption` clean; `gofmt`
  clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
