### PR TITLE
docs: file F29/F30 substrate-authoring limitations (dynamic channels + webhook-spawn)

### DIFF
--- a/internal/help/builtin/channel-admin.md
+++ b/internal/help/builtin/channel-admin.md
@@ -223,6 +223,21 @@ curl -X DELETE http://127.0.0.1:8787/v1/_channels/briefing-ready \
 # → 204 No Content
 ```
 
+> **Known limitation (observed v0.23.x — experiments finding F29).** Despite the
+> "same table rows, same `Bus.Notify`" model in *What this is NOT* above, a
+> runtime-substrate channel created here is **not currently usable for
+> publish/subscribe**. The in-agent `Channel` tool refuses it (`channel "X" is
+> not declared in operator config (channels: block)`) because the per-run policy
+> `channelPolicyForAgent` (`internal/api/http/server.go`) is built **only from
+> `cfg.Channels`** (the yaml block), never the runtime channel store; and the
+> admin `POST /v1/_channels/{name}/publish` route returns `404
+> channel_not_declared` for the same reason. So today a runtime channel can be
+> **created / listed / updated / deleted but not messaged** — to wire agents (or
+> external pub/sub) over a channel, declare it in the yaml `channels:` block. Fix
+> = merge the runtime channel store into the per-run channel policy **and** the
+> publish/subscribe declaration check, so runtime + yaml channels share one
+> lookup (matching the documented "same rows" intent).
+
 `GET /v1/_channels` returns both yaml and runtime channels with a
 `source: "yaml" | "runtime" | "orphan"` discriminator on every row.
 The Web UI's Channels view uses the discriminator to gate the

--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -106,6 +106,18 @@ webhooks:
     payload_mapping: { build_id: "$.build.id", status: "$.build.status" }
 ```
 
+> **Known limitation (observed v0.23.x — experiments finding F30).** A `spawn`
+> webhook's `agent:` must name a **yaml-declared** agent. An agent created at
+> runtime via the **AgentDef substrate** (`POST /v1/_agentdef`, the `agentdef`
+> MCP tool, `register_agent`) is **not resolved by the webhook-spawn path**: the
+> delivery verifies its signature, then fails `rejected_spawn_setup` with
+> `webhook "<name>": async run failed: unknown agent: <agent>`. Note the
+> asymmetry — `POST /v1/runs` *does* resolve dynamically-created agents, so the
+> gap is specific to the webhook receiver's agent lookup (it consults the static
+> config, not the AgentDef store). Until fixed, point a `spawn` webhook at a
+> yaml-declared agent (or wake a parked dynamic agent with `delivery: channel`,
+> once F29's runtime-channel pub/sub gap is also resolved).
+
 ## How a request is processed
 
 A shared front-half runs for every request, then forks on `delivery`:


### PR DESCRIPTION
Files two substrate-authoring limitations surfaced by a fully-dynamic (no-static-yaml) experiment run on `v0.23.2` (all entities created via `POST /v1/_agentdef|_channels|_webhookdef|_mcpserverdef`). Both are filed as **Known-limitation** notes in the authoritative help docs.

### F29 — runtime-substrate channels can't be messaged (`channel-admin.md`)
A channel created via `POST /v1/_channels` is created/listed/deleted fine, but **neither** the in-agent `Channel` tool **nor** the admin `POST /v1/_channels/{name}/publish` route can publish/subscribe to it — both return "not declared in operator config" / `channel_not_declared`. Root cause: `channelPolicyForAgent` (`internal/api/http/server.go`) builds the per-run policy **only from `cfg.Channels`** (the yaml block), never the runtime channel store. This contradicts the section's own *"same table rows, same `Bus.Notify`"* model. Repro: 3 dynamically-created agents looped over 3 dynamically-created channels → the subscriber got 0 deliveries → hit `max_iterations`.

### F30 — webhook-spawn can't resolve a dynamic agent (`input-webhooks.md`)
A `delivery: spawn` webhook's `agent:` resolves **yaml-declared agents only**. An agent created via the AgentDef substrate fails after HMAC verification with `rejected_spawn_setup` → `webhook "X": async run failed: unknown agent: <name>`. Asymmetry: `POST /v1/runs` **does** resolve dynamic agents, so the gap is specific to the webhook receiver's agent lookup (static config, not the AgentDef store).

### Not filed
**F31** (dynamic `MCPServerDef` being http/streamable-http only) is already documented as **by design** in the `mcpserverdef` tool description ("stdio stays yaml-only"; explicit refusal at `mcpserverdef.go:772`), so no doc change.

Docs-only; no code changes.
