### PR TITLE
fix(webhookdef): stamp tenant so spawn resolves dynamic agents (F30)

### DIFF
--- a/internal/help/builtin/input-webhooks.md
+++ b/internal/help/builtin/input-webhooks.md
@@ -106,17 +106,17 @@ webhooks:
     payload_mapping: { build_id: "$.build.id", status: "$.build.status" }
 ```
 
-> **Known limitation (observed v0.23.x — experiments finding F30).** A `spawn`
-> webhook's `agent:` must name a **yaml-declared** agent. An agent created at
-> runtime via the **AgentDef substrate** (`POST /v1/_agentdef`, the `agentdef`
-> MCP tool, `register_agent`) is **not resolved by the webhook-spawn path**: the
-> delivery verifies its signature, then fails `rejected_spawn_setup` with
-> `webhook "<name>": async run failed: unknown agent: <agent>`. Note the
-> asymmetry — `POST /v1/runs` *does* resolve dynamically-created agents, so the
-> gap is specific to the webhook receiver's agent lookup (it consults the static
-> config, not the AgentDef store). Until fixed, point a `spawn` webhook at a
-> yaml-declared agent (or wake a parked dynamic agent with `delivery: channel`,
-> once F29's runtime-channel pub/sub gap is also resolved).
+> **A `spawn` webhook resolves runtime (AgentDef-substrate) agents (F30, fixed).**
+> A `spawn` webhook's `agent:` may name either a yaml-declared agent or one
+> created at runtime via the AgentDef substrate (`POST /v1/_agentdef`, the
+> `agentdef` MCP tool, `register_agent`). The webhook spawn path already resolves
+> the agent through the same substrate-aware `lookupAgent` that `POST /v1/runs`
+> uses; the earlier asymmetry (`rejected_spawn_setup` / `unknown agent`) was a
+> tenant mismatch — a runtime webhook def persisted with an empty `tenant_id`,
+> so the spawn resolved the agent under `""` while the AgentDef was stored under
+> the creating principal's tenant. The WebhookDef tool now stamps the creating
+> tenant into the def (RFC N), so both author under the same tenant and the
+> dynamic agent resolves.
 
 ## How a request is processed
 

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -146,6 +146,16 @@ func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPoli
 	if err := validateWebhookDef(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
+	// RFC N: the spawned run executes as the CREATING principal's tenant,
+	// resolved from the authoritative run identity in ctx — never silently
+	// empty. F30: an un-stamped tenant made a `spawn` webhook resolve a
+	// dynamic agent under "" while AgentDef persisted it under the principal's
+	// tenant ("default" for the legacy token) → "unknown agent". An explicit
+	// overlay tenant_id still wins. Mirrors AgentDef.execCreate's stamp.
+	ident := tools.RunIdentity(ctx)
+	if def.TenantID == "" {
+		def.TenantID = ident.TenantID
+	}
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("create: marshal: %s", err)), nil
@@ -157,7 +167,6 @@ func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPoli
 		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
 	}
 
-	ident := tools.RunIdentity(ctx)
 	row := store.WebhookDefRow{
 		DefID:            mintDefID(),
 		Name:             in.Name,
@@ -250,6 +259,12 @@ func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicy
 	if err := validateWebhookDef(def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
+	// RFC N tenant stamp — see execCreate. A fork defaults to the forking
+	// principal's tenant unless the parent/overlay already carries one.
+	ident := tools.RunIdentity(ctx)
+	if def.TenantID == "" {
+		def.TenantID = ident.TenantID
+	}
 	defJSON, err := json.Marshal(def)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: marshal: %s", err)), nil
@@ -261,7 +276,6 @@ func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicy
 		return errResult(fmt.Sprintf("fork: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
 	}
 
-	ident := tools.RunIdentity(ctx)
 	row := store.WebhookDefRow{
 		DefID:            mintDefID(),
 		Name:             in.Name,

--- a/internal/tools/builtin/webhookdef_test.go
+++ b/internal/tools/builtin/webhookdef_test.go
@@ -84,6 +84,58 @@ func TestWebhookDefTool_CreateSpawnHmac(t *testing.T) {
 	}
 }
 
+// TestWebhookDefTool_CreateStampsTenant is the F30 regression: a runtime
+// webhook created under a principal whose tenant is "default" must persist
+// that tenant in its definition, so the spawn path resolves a dynamic agent
+// under the SAME tenant the AgentDef substrate stored it. Before the fix the
+// tenant was left "" → `lookup.Webhook` returned TenantID="" → buildRunInput
+// spawned under "" → "unknown agent". Asserts through the resolution path the
+// webhook receiver actually uses.
+func TestWebhookDefTool_CreateStampsTenant(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+	// Re-stamp the run identity with a tenant (the legacy token resolves "default").
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "default"})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc","overlay":{"delivery":"spawn","agent":"intake","auth":{"kind":"hmac","signing_secret_env":"LOOMCYCLE_S"}}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	wd, ok := lookup.Webhook(ctx, tool.Store, tool.Cfg, "adhoc")
+	if !ok {
+		t.Fatalf("lookup.Webhook(adhoc): not found")
+	}
+	if wd.TenantID != "default" {
+		t.Errorf("resolved TenantID = %q, want %q (F30: un-stamped tenant → unknown agent at spawn)", wd.TenantID, "default")
+	}
+}
+
+// TestWebhookDefTool_ForkStampsTenant — the fork twin of the F30 regression.
+// Forks a DYNAMIC webhook (not in yaml; lookup.Webhook is yaml-first, so a
+// forked yaml name would be shadowed by the static def). The parent is created
+// under no tenant, so the FORK — not the create — is what must stamp it.
+func TestWebhookDefTool_ForkStampsTenant(t *testing.T) {
+	tool, ctx, cleanup := webhookDefFixture(t)
+	defer cleanup()
+
+	// Create the dynamic parent under the fixture ctx (no tenant → TenantID "").
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"adhoc","overlay":{"delivery":"spawn","agent":"intake","auth":{"kind":"hmac","signing_secret_env":"LOOMCYCLE_S"}}}`)); res.IsError {
+		t.Fatalf("create parent: %s", res.Text)
+	}
+	// Fork it under a tenant.
+	tctx := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "default"})
+	if res, _ := tool.Execute(tctx, json.RawMessage(`{"op":"fork","name":"adhoc","overlay":{"agent":"intake2"}}`)); res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	wd, ok := lookup.Webhook(tctx, tool.Store, tool.Cfg, "adhoc")
+	if !ok {
+		t.Fatalf("lookup.Webhook(adhoc): not found")
+	}
+	if wd.TenantID != "default" {
+		t.Errorf("forked TenantID = %q, want %q", wd.TenantID, "default")
+	}
+}
+
 func TestWebhookDefTool_CreateChannelDelivery(t *testing.T) {
 	tool, ctx, cleanup := webhookDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why
A `delivery: spawn` webhook created **at runtime** via the WebhookDef substrate (`POST /v1/_webhookdef`) could not spawn an agent that was itself created at runtime via the AgentDef substrate. The signed delivery verified, then the async run failed:

```
webhook "pr-opened": async run failed: unknown agent: exp4-reviewer-dyn
```

Spawning the **same** agent via `POST /v1/runs` worked — an asymmetry surfaced by `loomcycle-experiments` exp4 (fully-dynamic webhook→reviewer loop, finding **F30**). Static-yaml webhooks were unaffected.

## What
Root cause: `WebhookDef.execCreate` / `execFork` marshaled the def **without stamping `TenantID`**, unlike `AgentDef.execCreate` which stamps it from the authoritative `RunIdentity`. The stored webhook-def JSON carried `tenant_id=""`, so:

`ToConfigDef` → `buildRunInput` → `RunOnce` resolved the agent under tenant `""`, while the AgentDef was persisted under the principal's tenant (`"default"` for the legacy token). `AgentDefGetActive` filters on the exact tenant → `"" != "default"` → unknown agent. `/v1/runs` works because `applyPrincipal` resolves under `"default"`.

Fix: stamp `def.TenantID = tools.RunIdentity(ctx).TenantID` in `execCreate` and `execFork` before marshaling, **defaulting only when the overlay (or a forked parent) did not already set one** — RFC N: the tenant comes from the authoritative principal, never silently empty; an explicit overlay `tenant_id` still wins. Mirrors `AgentDef.execCreate`. No schema change — webhook-def rows stay globally name-keyed.

## Tested
- New regression tests `TestWebhookDefTool_CreateStampsTenant` + `TestWebhookDefTool_ForkStampsTenant` — both **fail on the unfixed code** (resolved `TenantID=""`, verified by reverting the stamp) and pass with it. They assert through `lookup.Webhook`, the exact resolution path the receiver uses.
- `go build ./...` clean; `gofmt`/`go vet` clean; `internal/{tools/builtin,lookup,api/webhook}` green (the pre-existing env-flaky `TestBashTimeout` timing test aside — fails identically on a clean tree).

Part of the dynamic-substrate-consumption sweep (F29 channels + F31 dynamic stdio land separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)