### PR TITLE
fix(channels): make runtime-declared channels usable for pub/sub (F29)

### DIFF
--- a/internal/api/http/channels_crud_test.go
+++ b/internal/api/http/channels_crud_test.go
@@ -178,6 +178,70 @@ func TestAdminChannelPublish_RefusesUndeclared(t *testing.T) {
 	}
 }
 
+// TestAdminChannelPublish_AllowedOnRuntimeChannel is the F29 regression for
+// the admin publish route: POST /v1/_channels/{name}/publish must succeed on a
+// channel declared at runtime (POST /v1/_channels, persisted in the channels
+// table). Before the fix requireChannelDeclared read cfg.Channels (yaml) only,
+// so a runtime channel 404'd `channel_not_declared`.
+func TestAdminChannelPublish_AllowedOnRuntimeChannel(t *testing.T) {
+	srv, s, cleanup := channelCRUDFixture(t)
+	defer cleanup()
+
+	if err := s.ChannelsCreate(t.Context(), store.ChannelRow{
+		Name: "runtime-ch", Scope: "global", Semantic: "broadcast", MaxMessages: 50,
+	}); err != nil {
+		t.Fatalf("ChannelsCreate: %v", err)
+	}
+
+	body := `{"payload":{"event":"hi"}}`
+	req := authedRequest("POST", "/v1/_channels/runtime-ch/publish", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("publish to runtime channel: status %d, want 200 (F29); body=%s", rec.Code, rec.Body.String())
+	}
+
+	rows, err := s.ChannelPeek(t.Context(), "runtime-ch", store.MemoryScopeGlobal, "", "", 10)
+	if err != nil {
+		t.Fatalf("ChannelPeek: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("after publish: %d messages, want 1", len(rows))
+	}
+}
+
+// TestChannelPolicy_IncludesRuntimeChannel is the F29 regression for the
+// in-agent Channel tool: a runtime-declared channel must appear in the per-run
+// channel policy (channelPolicyForAgent) so the tool can pub/sub to it. Before
+// the fix the policy map was built from cfg.Channels (yaml) only, so the tool
+// refused the channel with "not declared in operator config".
+func TestChannelPolicy_IncludesRuntimeChannel(t *testing.T) {
+	srv, s, cleanup := channelCRUDFixture(t)
+	defer cleanup()
+
+	if err := s.ChannelsCreate(t.Context(), store.ChannelRow{
+		Name: "runtime-ch", Scope: "global", Semantic: "broadcast", MaxMessages: 50,
+	}); err != nil {
+		t.Fatalf("ChannelsCreate: %v", err)
+	}
+
+	agentDef := config.AgentDef{
+		Channels: config.AgentChannelACL{Subscribe: []string{"runtime-ch"}},
+	}
+	pol := srv.channelPolicyForAgent(t.Context(), agentDef)
+	def, ok := pol.Channels["runtime-ch"]
+	if !ok {
+		t.Fatalf("runtime channel absent from policy map (F29); map=%v", pol.Channels)
+	}
+	if def.Scope != "global" || def.MaxMessages != 50 {
+		t.Errorf("policy def = %+v, want scope=global max_messages=50", def)
+	}
+	// yaml channels stay present (precedence + refusal phrasing).
+	if _, ok := pol.Channels["team-updates"]; !ok {
+		t.Errorf("yaml channel team-updates dropped from policy map")
+	}
+}
+
 // TestAdminChannelPublish_RequiresBearer guards the auth middleware
 // wiring on the new route.
 func TestAdminChannelPublish_RequiresBearer(t *testing.T) {

--- a/internal/api/http/connector_impl_channels.go
+++ b/internal/api/http/connector_impl_channels.go
@@ -39,19 +39,34 @@ func resolveChannelScope(scopeStr, scopeID string) (store.MemoryScope, string, e
 	}
 }
 
-// requireChannelDeclared reads `cfg.Channels[name]` and returns
-// ErrChannelNotDeclared if the operator yaml didn't declare it.
-// Mirrors the in-band tool's allowlist check (channel.go:resolveChannel)
-// at the wire boundary.
-func (s *Server) requireChannelDeclared(name string) (channelDef, error) {
-	def, ok := s.cfg.Channels[name]
-	if !ok {
-		return channelDef{}, fmt.Errorf("%w: %q", connector.ErrChannelNotDeclared, name)
+// requireChannelDeclared resolves `name` against the yaml `cfg.Channels`
+// block first, then the runtime channel store. F29: a channel declared at
+// runtime (POST /v1/_channels) must be publishable/subscribable like a yaml
+// channel — without the store fallback the admin publish/subscribe routes
+// 404'd `channel_not_declared` for a perfectly valid runtime channel.
+// Returns ErrChannelNotDeclared only when NEITHER source has it. Mirrors the
+// in-band tool's allowlist check (channel.go:resolveChannel) and the per-run
+// channelPolicyForAgent merge, at the wire boundary.
+func (s *Server) requireChannelDeclared(ctx context.Context, name string) (channelDef, error) {
+	if def, ok := s.cfg.Channels[name]; ok {
+		return channelDef{
+			MaxMessages: def.MaxMessages,
+			DefaultTTL:  def.DefaultTTL,
+		}, nil
 	}
-	return channelDef{
-		MaxMessages: def.MaxMessages,
-		DefaultTTL:  def.DefaultTTL,
-	}, nil
+	if s.store != nil {
+		if rows, err := s.store.ChannelsList(ctx); err == nil {
+			for _, r := range rows {
+				if r.Name == name {
+					return channelDef{
+						MaxMessages: r.MaxMessages,
+						DefaultTTL:  r.DefaultTTL,
+					}, nil
+				}
+			}
+		}
+	}
+	return channelDef{}, fmt.Errorf("%w: %q", connector.ErrChannelNotDeclared, name)
 }
 
 // channelDef captures only the fields the Connector methods need —
@@ -82,7 +97,7 @@ func (s *Server) PublishChannel(ctx context.Context, req connector.ChannelPublis
 		return connector.ChannelPublishResult{}, fmt.Errorf("publish: payload (%d bytes) exceeds max %d", len(req.Payload), cap)
 	}
 
-	def, err := s.requireChannelDeclared(req.Channel)
+	def, err := s.requireChannelDeclared(ctx, req.Channel)
 	if err != nil {
 		return connector.ChannelPublishResult{}, err
 	}
@@ -136,7 +151,7 @@ func (s *Server) SubscribeChannel(ctx context.Context, req connector.ChannelSubs
 	if req.Channel == "" {
 		return connector.ChannelSubscribeResult{}, fmt.Errorf("subscribe: missing required field: channel")
 	}
-	if _, err := s.requireChannelDeclared(req.Channel); err != nil {
+	if _, err := s.requireChannelDeclared(ctx, req.Channel); err != nil {
 		return connector.ChannelSubscribeResult{}, err
 	}
 	scope, scopeID, err := resolveChannelScope(req.Scope, req.ScopeID)
@@ -224,7 +239,7 @@ func (s *Server) PeekChannel(ctx context.Context, req connector.ChannelPeekReque
 	if req.Channel == "" {
 		return connector.ChannelPeekResult{}, fmt.Errorf("peek: missing required field: channel")
 	}
-	if _, err := s.requireChannelDeclared(req.Channel); err != nil {
+	if _, err := s.requireChannelDeclared(ctx, req.Channel); err != nil {
 		return connector.ChannelPeekResult{}, err
 	}
 	scope, scopeID, err := resolveChannelScope(req.Scope, req.ScopeID)
@@ -271,7 +286,7 @@ func (s *Server) AckChannel(ctx context.Context, req connector.ChannelAckRequest
 	if req.Cursor == "" {
 		return connector.ChannelAckResult{}, fmt.Errorf("ack: missing required field: cursor")
 	}
-	if _, err := s.requireChannelDeclared(req.Channel); err != nil {
+	if _, err := s.requireChannelDeclared(ctx, req.Channel); err != nil {
 		return connector.ChannelAckResult{}, err
 	}
 	scope, scopeID, err := resolveChannelScope(req.Scope, req.ScopeID)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1280,12 +1280,19 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 }
 
 // channelPolicyForAgent builds the v0.8.4 Channel-tool policy from
-// the agent yaml + the top-level `channels:` block. Returns a value
-// suitable for tools.WithChannelPolicy. The Channels map is a copy
-// of every operator-declared channel — the tool layer needs the
-// per-channel scope/TTL/max_messages even for channels NOT in this
-// agent's allowlist (e.g. to phrase a useful refusal message).
-func (s *Server) channelPolicyForAgent(agentDef config.AgentDef) tools.ChannelPolicyValue {
+// the agent yaml + the top-level `channels:` block AND the runtime
+// channel store. Returns a value suitable for tools.WithChannelPolicy.
+// The Channels map is a copy of every declared channel — the tool layer
+// needs the per-channel scope/TTL/max_messages even for channels NOT in
+// this agent's allowlist (e.g. to phrase a useful refusal message).
+//
+// F29: a channel declared at runtime (POST /v1/_channels, persisted in
+// the `channels` table) must be usable for pub/sub exactly like a yaml
+// channel. We merge the runtime store into the map — yaml wins on a name
+// collision, matching ListChannels' precedence. The store read is skipped
+// when the agent has no channel allowlist at all (it can't touch a channel
+// either way), so the common no-channels run pays nothing.
+func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.AgentDef) tools.ChannelPolicyValue {
 	channels := make(map[string]tools.ChannelDef, len(s.cfg.Channels))
 	for name, ch := range s.cfg.Channels {
 		channels[name] = tools.ChannelDef{
@@ -1295,6 +1302,23 @@ func (s *Server) channelPolicyForAgent(agentDef config.AgentDef) tools.ChannelPo
 			MaxMessages: ch.MaxMessages,
 			Semantic:    ch.Semantic,
 			Publisher:   ch.Publisher, // v0.8.6: agent publish refusal when "system"
+		}
+	}
+	if s.store != nil && (len(agentDef.Channels.Publish) > 0 || len(agentDef.Channels.Subscribe) > 0) {
+		if rows, err := s.store.ChannelsList(ctx); err == nil {
+			for _, r := range rows {
+				if _, exists := channels[r.Name]; exists {
+					continue // yaml takes precedence on a name collision
+				}
+				channels[r.Name] = tools.ChannelDef{
+					Name:        r.Name,
+					Scope:       r.Scope,
+					DefaultTTL:  r.DefaultTTL,
+					MaxMessages: r.MaxMessages,
+					Semantic:    r.Semantic,
+					Publisher:   r.Publisher,
+				}
+			}
 		}
 	}
 	return tools.ChannelPolicyValue{
@@ -1660,7 +1684,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
 	})
-	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
+	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, effectiveAgentName)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -2849,7 +2873,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
 	})
-	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
+	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, req.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -3240,7 +3264,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
 	})
-	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(agentDef))
+	loopCtx = tools.WithChannelPolicy(loopCtx, s.channelPolicyForAgent(loopCtx, agentDef))
 	loopCtx = tools.WithEventEmitter(loopCtx, emit)
 	adPolicy, evPolicy := s.substratePoliciesForAgent(agentDef, sess.Agent)
 	loopCtx = tools.WithAgentDefPolicy(loopCtx, adPolicy)
@@ -3869,7 +3893,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// channels) IS shared with the parent — those are operator
 	// state, not agent state. The ALLOWLISTS (publish / subscribe)
 	// come from the child's yaml.
-	subCtx = tools.WithChannelPolicy(subCtx, s.channelPolicyForAgent(def))
+	subCtx = tools.WithChannelPolicy(subCtx, s.channelPolicyForAgent(subCtx, def))
 	// Sub-agent event emitter writes to the SUB's transcript (per
 	// subEmit above). Channel-tool publishes from inside the sub
 	// surface on the sub's SSE stream, not the parent's.

--- a/internal/help/builtin/channel-admin.md
+++ b/internal/help/builtin/channel-admin.md
@@ -223,20 +223,14 @@ curl -X DELETE http://127.0.0.1:8787/v1/_channels/briefing-ready \
 # → 204 No Content
 ```
 
-> **Known limitation (observed v0.23.x — experiments finding F29).** Despite the
-> "same table rows, same `Bus.Notify`" model in *What this is NOT* above, a
-> runtime-substrate channel created here is **not currently usable for
-> publish/subscribe**. The in-agent `Channel` tool refuses it (`channel "X" is
-> not declared in operator config (channels: block)`) because the per-run policy
-> `channelPolicyForAgent` (`internal/api/http/server.go`) is built **only from
-> `cfg.Channels`** (the yaml block), never the runtime channel store; and the
-> admin `POST /v1/_channels/{name}/publish` route returns `404
-> channel_not_declared` for the same reason. So today a runtime channel can be
-> **created / listed / updated / deleted but not messaged** — to wire agents (or
-> external pub/sub) over a channel, declare it in the yaml `channels:` block. Fix
-> = merge the runtime channel store into the per-run channel policy **and** the
-> publish/subscribe declaration check, so runtime + yaml channels share one
-> lookup (matching the documented "same rows" intent).
+> **Runtime channels are usable for pub/sub (F29, fixed).** A runtime-substrate
+> channel created here works for publish/subscribe exactly like a yaml channel —
+> both the per-run `Channel`-tool policy (`channelPolicyForAgent`) and the
+> wire-level declaration check (`requireChannelDeclared`, behind admin
+> publish/subscribe/peek/ack) merge the runtime channel store with the yaml
+> `channels:` block (yaml wins on a name collision, matching `GET /v1/_channels`).
+> Earlier v0.23.x builds read `cfg.Channels` only, so a runtime channel could be
+> created/listed/updated/deleted but not messaged; that gap is closed.
 
 `GET /v1/_channels` returns both yaml and runtime channels with a
 `source: "yaml" | "runtime" | "orphan"` discriminator on every row.


### PR DESCRIPTION
## Why
A channel created at runtime via the substrate (`POST /v1/_channels`, persisted in the `channels` table) was listed by `GET /v1/_channels` but **could not be messaged**:

- the in-agent `Channel` tool refused it — `channel "X" is not declared in operator config (channels: block)`;
- the admin publish/subscribe routes 404'd `channel_not_declared`.

So a runtime channel could be created / listed / updated / deleted but never **used** — blocking exp3's fully-dynamic multi-agent channel loop (0 deliveries → answerer hit `max_iterations`). Finding **F29** from `loomcycle-experiments`.

## What
Two consumer seams read the yaml `cfg.Channels` block **only**, never the runtime channel store:

| Seam | Surface |
|---|---|
| `channelPolicyForAgent` (server.go) | per-run policy for the in-agent `Channel` tool |
| `requireChannelDeclared` (connector_impl_channels.go) | wire-level gate behind `PublishChannel`/`SubscribeChannel`/`PeekChannel`/`AckChannel` |

Both now merge `store.ChannelsList` with the yaml map, **yaml winning on a name collision** — the same precedence `ListChannels` already uses for the `GET /v1/_channels` yaml+runtime union. `channelPolicyForAgent` **skips the store read when the agent has no channel allowlist at all** (the common run pays nothing); both seams guard `s.store != nil` for yaml-only deployments. Runtime channels are global (no tenant column), so no tenant filtering is needed.

`_system/*` admin publish (`handleSystemChannelPublish`) is deliberately left yaml-only — those are operator/system-authored and were not part of the F29 repro.

## Tested
- `TestChannelPolicy_IncludesRuntimeChannel` (tool policy map) + `TestAdminChannelPublish_AllowedOnRuntimeChannel` (full REST publish path) — both **fail on the unfixed code** (channel absent / `404 channel_not_declared`), pass with the merge. Verified by neutering each merge body and watching them fail. The existing undeclared-channel 404 + yaml happy-path tests stay green.
- `gofmt`/`go vet` clean; full `internal/api/http` package green.

Part of the dynamic-substrate-consumption sweep (F30 webhook→dynamic-agent is #403; F31 dynamic stdio lands separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)