### PR TITLE
feat(mcpserverdef): gated dynamic stdio MCP registration (F31)

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -299,6 +299,14 @@ LOOMCYCLE_DATA_DIR=./data
 # (operator-launched stdio = trusted; remote HTTP MCP would not be).
 # LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1
 #
+# By default the MCPServerDef substrate (POST /v1/_mcpserverdef) may
+# register only http / streamable-http servers; a `stdio` server runs an
+# ARBITRARY LOCAL COMMAND, so dynamic stdio registration is off by default
+# (a second local-exec path alongside the Bash tool). Set this to 1 to let
+# operators register stdio MCP servers at runtime with command/args/env.
+# Static yaml `mcp_servers:` stdio entries are always allowed regardless.
+# LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1
+#
 # Default TTL for agents registered via mcp__loomcycle__register_agent
 # when the caller omits ttl_seconds. Default 86400 (24 h). Set 0 to
 # require callers to ALWAYS supply an explicit ttl_seconds (no

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -804,8 +804,15 @@ func main() {
 					URL:     spec.URL,
 					Headers: spec.Headers,
 				})
+			case "stdio":
+				// F31: a runtime-registered stdio server. The substrate only
+				// admits a stdio row when LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO is
+				// set, so reaching here already means the operator opted in.
+				// Spawned + lifecycle-managed (respawn on crash, teardown on
+				// retire) by the same pool path as a yaml stdio server.
+				return spawnStdio(name, spec.Command, spec.Args, spec.Env)
 			default:
-				return nil, fmt.Errorf("mcp_servers.%s: invalid transport %q for non-stdio resolution (data corruption?)", name, spec.Transport)
+				return nil, fmt.Errorf("mcp_servers.%s: invalid transport %q (data corruption?)", name, spec.Transport)
 			}
 		},
 		func(c mcp.Caller) {
@@ -1049,6 +1056,9 @@ func main() {
 				Transport string            `json:"transport"`
 				URL       string            `json:"url"`
 				Headers   map[string]string `json:"headers"`
+				Command   string            `json:"command"` // stdio (F31)
+				Args      []string          `json:"args"`
+				Env       map[string]string `json:"env"`
 			}
 			if err := json.Unmarshal(active.Definition, &ov); err != nil {
 				log.Printf("mcp_server_defs: parse active %q (tenant=%q): %v", ns.Name, ns.TenantID, err)
@@ -1058,6 +1068,7 @@ func main() {
 			// keyed by (tenant, name) and only resolved for that tenant's runs.
 			dynamicMCPRegistry.Set(mcp.DynamicMCPServerSpec{
 				TenantID: active.TenantID, Name: active.Name, Transport: ov.Transport, URL: ov.URL, Headers: ov.Headers,
+				Command: ov.Command, Args: ov.Args, Env: ov.Env, // stdio (F31)
 			})
 		}
 		if size := dynamicMCPRegistry.Size(); size > 0 {
@@ -2671,22 +2682,33 @@ func (v mcpLookupView) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
 	if !ok {
 		return lookup.MCPServerSpec{}, false
 	}
-	return lookup.MCPServerSpec{Transport: s.Transport, URL: s.URL, Headers: s.Headers}, true
+	return lookup.MCPServerSpec{
+		Transport: s.Transport, URL: s.URL, Headers: s.Headers,
+		Command: s.Command, Args: s.Args, Env: s.Env, // stdio (F31)
+	}, true
 }
 
 func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {
-	keys := make([]string, 0, len(srv.Env))
-	for k := range srv.Env {
+	return spawnStdio(name, srv.Command, srv.Args, srv.Env)
+}
+
+// spawnStdio is the transport-spawn core shared by the static yaml stdio
+// path (spawnStdioMCP) and the dynamic stdio path (the pool build
+// callback's stdio case, F31). envMap is rendered as sorted KEY=VALUE
+// strings — deterministic child env regardless of map iteration order.
+func spawnStdio(name, command string, args []string, envMap map[string]string) (mcp.Caller, error) {
+	keys := make([]string, 0, len(envMap))
+	for k := range envMap {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	env := make([]string, 0, len(keys))
 	for _, k := range keys {
-		env = append(env, k+"="+srv.Env[k])
+		env = append(env, k+"="+envMap[k])
 	}
 	return mcpstdio.Spawn(mcpstdio.Config{
-		Command: srv.Command,
-		Args:    srv.Args,
+		Command: command,
+		Args:    args,
 		Env:     env,
 		OnStderr: func(line string) {
 			log.Printf("mcp[%s]: %s", name, line)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1599,6 +1599,17 @@ type Env struct {
 	// LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS.
 	MCPAllowPrivilegedTools bool
 
+	// MCPAllowDynamicStdio — F31. When true, the MCPServerDef substrate
+	// (POST /v1/_mcpserverdef, the `mcpserverdef` tool) may register a
+	// `transport: stdio` server at runtime. Default false: dynamic
+	// registration is http/streamable-http only, because a stdio server
+	// runs an ARBITRARY LOCAL COMMAND (a second local-exec path alongside
+	// Bash, with no outbound-host-allowlist mediation). Like BashEnabled,
+	// this is operator-gated and off by default; static yaml `mcp_servers:`
+	// stdio entries are unaffected (operator-authored = trusted). Env:
+	// LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO.
+	MCPAllowDynamicStdio bool
+
 	// DynamicAgentDefaultTTLSeconds — v0.8.15. TTL applied to
 	// dynamic agents registered via mcp__loomcycle__register_agent
 	// when the caller omits ttl_seconds. Default 86400 (24h).
@@ -2470,6 +2481,7 @@ func Load(path string) (*Config, error) {
 
 	// v0.8.15 LoomCycle MCP: dynamic agent registration policy.
 	cfg.Env.MCPAllowPrivilegedTools = os.Getenv("LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS") == "1"
+	cfg.Env.MCPAllowDynamicStdio = os.Getenv("LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO") == "1"
 	cfg.Env.DynamicAgentDefaultTTLSeconds = 86400 // 24h
 	if v := os.Getenv("LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {

--- a/internal/help/builtin/dynamic-mcp.md
+++ b/internal/help/builtin/dynamic-mcp.md
@@ -31,11 +31,17 @@ Read this section before anything else.
   reach it — via `POST /v1/_mcpserverdef`, the loomcycle MCP
   meta-tool, the gRPC RPC, or the TS adapter — all bearer-authed
   against `LOOMCYCLE_AUTH_TOKEN`.
-- **NOT stdio.** Stdio MCP servers stay yaml-only. Dynamic
-  registration is HTTP + Streamable-HTTP only. The substrate refuses
-  any other transport. The decision closes the agent-process-spawn
-  escalation path entirely: there is no way to register a
-  loomcycle-spawned subprocess at runtime.
+- **Stdio is opt-in (default OFF).** Dynamic registration is HTTP +
+  Streamable-HTTP only **unless** the operator sets
+  `LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1`. A stdio server runs an
+  **arbitrary local command** — a second local-exec path alongside the
+  Bash tool, with no outbound-host-allowlist mediation — so by default
+  the substrate refuses a `stdio` transport (the refusal names the
+  flag). When the flag is set, a `create`/`fork` overlay may carry
+  `command` / `args` / `env`; the server is spawned + lifecycle-managed
+  (respawn on crash, teardown on retire) by the same pool path as a yaml
+  stdio server. Static yaml `mcp_servers:` stdio entries are unaffected
+  (operator-authored ⇒ trusted) regardless of the flag.
 - **NOT a yaml replacement.** Static and dynamic registrations
   coexist. A dynamic `create` colliding with a name already present
   in `cfg.MCPServers` is refused with a typed error — yaml is ground
@@ -50,8 +56,9 @@ Read this section before anything else.
 A row in `mcp_server_defs` carries the substrate's content fields:
 
 ```
-name, description, transport ("http" | "streamable-http"),
-url, headers (map<string,string>), discovered_tools (cached;
+name, description, transport ("http" | "streamable-http" |
+"stdio" [opt-in]), url, headers (map<string,string>),
+command/args/env (stdio only), discovered_tools (cached;
 refreshed via rediscover)
 ```
 
@@ -183,7 +190,7 @@ tables untouched.
 
 | Error code | When |
 |---|---|
-| `mcp_server_def_transport_invalid` | `transport` is not `http` or `streamable-http`. |
+| `mcp_server_def_transport_invalid` | `transport` is not `http`, `streamable-http`, or (with `LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1`) `stdio`. A `stdio` overlay with the flag unset is refused, naming the flag; with the flag set it requires a `command`. |
 | `mcp_server_def_url_invalid` | `url` is empty, malformed, or not http(s). |
 | `mcp_server_def_host_not_allowed` | URL hostname isn't in `LOOMCYCLE_HTTP_HOST_ALLOWLIST`. |
 | `mcp_server_def_name_collision` | A yaml `mcp_servers.<name>` already owns this name. |

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -19,14 +19,19 @@ type MCPDynamicRegistry interface {
 // lookup chain can return a uniform shape regardless of whether the
 // name came from the static yaml or the dynamic registry.
 //
-// (The static cfg.MCPServer has additional yaml-only fields like
-// `command`, `args`, `env`, `pool_size` for stdio servers; those
-// don't apply to dynamically-registered http / streamable-http
-// servers — the substrate refuses stdio at the create boundary.)
+// The static cfg.MCPServer also has `pool_size` (http) which this spec
+// omits. Command/Args/Env carry the stdio invocation: empty for http
+// transports, populated only for a `stdio` row, which the substrate
+// accepts solely when LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO is set (F31).
 type MCPServerSpec struct {
 	Transport string
 	URL       string
 	Headers   map[string]string
+	// Command/Args/Env carry a dynamic stdio server's invocation (F31);
+	// empty for http transports.
+	Command string
+	Args    []string
+	Env     map[string]string
 	// AllowedTools is the operator's per-server tools/list narrowing (yaml
 	// `allowed_tools`); empty = allow all discovered tools. Only the STATIC
 	// source carries it — a dynamically-registered (substrate) server has
@@ -64,18 +69,16 @@ type MCPServerSpec struct {
 // from a wire/request field — see internal/api/http/server.go's
 // tenantFromCtx.
 //
-// LIMITATION (intentional): MCPServerSpec is the HTTP / streamable-http
-// subset. The stdio transport carries additional yaml-only fields
-// (Command/Args/Env/PoolSize) that this resolver deliberately omits
-// because the substrate refuses stdio at the create boundary — there's
-// no path by which a dynamic row could carry those fields. As a
-// consequence, this function cannot replace the inline pool build
-// callback in cmd/loomcycle/main.go for the stdio case; that callback
-// reads cfg.MCPServer directly to get the stdio fields.
+// stdio (F31): when the operator sets LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO,
+// a dynamic row MAY carry transport=stdio with Command/Args/Env, and this
+// resolver returns them so the pool build callback can spawn the child.
+// STATIC yaml stdio servers are still resolved directly from
+// cfg.MCPServers in the build callback (that first branch short-circuits
+// before this resolver), so the static stdio path is unchanged.
 //
-// Callers that need the full spec (transport/url/headers) should use it
-// only for http-transport servers (the /ui/library/mcp-servers GET
-// endpoint). Callers that need ONLY membership + AllowedTools are
+// Callers that need the full spec (transport/url/headers, or stdio
+// command/args/env) get it for any transport. Callers that need ONLY
+// membership + AllowedTools are
 // transport-agnostic and safe for any server — notably the MCP lazy tool
 // resolver (internal/tools/mcp/lazy.go), which delegates client
 // construction to the pool and consults this resolver purely to decide
@@ -128,6 +131,9 @@ type SubstrateMCPServer struct {
 	Transport       string                   `json:"transport,omitempty"`
 	URL             string                   `json:"url,omitempty"`
 	Headers         map[string]string        `json:"headers,omitempty"`
+	Command         string                   `json:"command,omitempty"` // stdio (F31)
+	Args            []string                 `json:"args,omitempty"`    // stdio (F31)
+	Env             map[string]string        `json:"env,omitempty"`     // stdio (F31)
 	Description     string                   `json:"description,omitempty"`
 	DiscoveredTools []SubstrateMCPServerTool `json:"discovered_tools,omitempty"`
 }

--- a/internal/lookup/mcpserver_test.go
+++ b/internal/lookup/mcpserver_test.go
@@ -105,6 +105,9 @@ func TestMCPServer_DriftDetection(t *testing.T) {
 		"transport":        true,
 		"url":              true,
 		"headers":          true,
+		"command":          true, // stdio (F31)
+		"args":             true, // stdio (F31)
+		"env":              true, // stdio (F31)
 		"description":      true,
 		"discovered_tools": true,
 	}

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -129,6 +129,9 @@ type mcpServerOverlay struct {
 	Transport       string            `json:"transport,omitempty"`
 	URL             string            `json:"url,omitempty"`
 	Headers         map[string]string `json:"headers,omitempty"`
+	Command         string            `json:"command,omitempty"` // stdio (F31)
+	Args            []string          `json:"args,omitempty"`    // stdio (F31)
+	Env             map[string]string `json:"env,omitempty"`     // stdio (F31)
 	Description     string            `json:"description,omitempty"`
 	DiscoveredTools []toolDescriptor  `json:"discovered_tools,omitempty"`
 }
@@ -150,6 +153,15 @@ func (a *mcpServerOverlay) applyOverlay(ov mcpServerOverlay) {
 	}
 	if ov.Headers != nil {
 		a.Headers = ov.Headers
+	}
+	if ov.Command != "" {
+		a.Command = ov.Command
+	}
+	if ov.Args != nil {
+		a.Args = ov.Args
+	}
+	if ov.Env != nil {
+		a.Env = ov.Env
 	}
 	if ov.Description != "" {
 		a.Description = ov.Description
@@ -585,6 +597,9 @@ func specFromOverlay(tenantID, name string, ov mcpServerOverlay) loommcp.Dynamic
 		Transport: ov.Transport,
 		URL:       ov.URL,
 		Headers:   ov.Headers,
+		Command:   ov.Command, // stdio (F31); empty for http
+		Args:      ov.Args,
+		Env:       ov.Env,
 	}
 }
 
@@ -765,11 +780,24 @@ func (m *MCPServerDef) execVerify(ctx context.Context, in mcpServerDefInput) (to
 func (m *MCPServerDef) validateOverlay(ov mcpServerOverlay) error {
 	switch ov.Transport {
 	case "http", "streamable-http":
-		// ok
+		// ok — validated against the URL + host allowlist below.
+	case "stdio":
+		// F31: a stdio server runs an arbitrary LOCAL command, so dynamic
+		// registration is gated behind an explicit operator opt-in (like
+		// the Bash tool). Off by default → refuse, naming the flag. When
+		// enabled, validate the command and return early — the URL/host
+		// allowlist checks below are http-only and don't apply.
+		if !m.Cfg.Env.MCPAllowDynamicStdio {
+			return fmt.Errorf("transport \"stdio\" not allowed for dynamic registration by default — it runs an arbitrary local command; set LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1 to opt in, or declare the stdio server in yaml mcp_servers: (operator-trusted)")
+		}
+		if ov.Command == "" {
+			return fmt.Errorf("transport stdio requires a command")
+		}
+		return nil
 	case "":
-		return fmt.Errorf("transport is required (http or streamable-http)")
+		return fmt.Errorf("transport is required (http, streamable-http, or stdio)")
 	default:
-		return fmt.Errorf("transport %q not allowed for dynamic registration — only http and streamable-http are supported (stdio stays yaml-only)", ov.Transport)
+		return fmt.Errorf("transport %q not allowed for dynamic registration — only http, streamable-http, and (opt-in) stdio are supported", ov.Transport)
 	}
 	if ov.URL == "" {
 		return fmt.Errorf("url is required")

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -61,12 +61,59 @@ func TestMCPServerDefTool_CreateRefusedOnStdioTransport(t *testing.T) {
 	tool, ctx, cleanup := mcpServerDefFixture(t)
 	defer cleanup()
 
-	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad-stdio","overlay":{"transport":"stdio","url":"https://n8n.example.com/mcp"}}`))
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad-stdio","overlay":{"transport":"stdio","command":"x"}}`))
 	if !res.IsError {
-		t.Fatalf("create with stdio transport should refuse; got %s", res.Text)
+		t.Fatalf("create with stdio transport should refuse by default; got %s", res.Text)
 	}
 	if !strings.Contains(res.Text, "stdio") {
 		t.Errorf("refusal should mention stdio; got %s", res.Text)
+	}
+	// F31: the refusal must name the opt-in flag so operators can discover it.
+	if !strings.Contains(res.Text, "LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO") {
+		t.Errorf("refusal should name LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO; got %s", res.Text)
+	}
+}
+
+// TestMCPServerDefTool_CreateStdioAllowedWithFlag is the F31 regression: with
+// LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO set, a stdio server registers and its
+// command/args/env round-trip into the pool registry the build callback reads.
+func TestMCPServerDefTool_CreateStdioAllowedWithFlag(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	tool.Cfg.Env.MCPAllowDynamicStdio = true // operator opt-in
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"local-mcp","overlay":{"transport":"stdio","command":"my-mcp","args":["--serve"],"env":{"FOO":"bar"}}}`))
+	if res.IsError {
+		t.Fatalf("create stdio with flag on: %s", res.Text)
+	}
+	spec, ok := tool.Registry.Get("", "local-mcp")
+	if !ok {
+		t.Fatalf("registry missing local-mcp after create")
+	}
+	if spec.Transport != "stdio" || spec.Command != "my-mcp" {
+		t.Errorf("spec = %+v, want transport=stdio command=my-mcp", spec)
+	}
+	if len(spec.Args) != 1 || spec.Args[0] != "--serve" {
+		t.Errorf("spec.Args = %v, want [--serve]", spec.Args)
+	}
+	if spec.Env["FOO"] != "bar" {
+		t.Errorf("spec.Env = %v, want FOO=bar", spec.Env)
+	}
+}
+
+// TestMCPServerDefTool_CreateStdioRequiresCommand — even with the flag on, a
+// stdio overlay with no command is refused (nothing to spawn).
+func TestMCPServerDefTool_CreateStdioRequiresCommand(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+	tool.Cfg.Env.MCPAllowDynamicStdio = true
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"no-cmd","overlay":{"transport":"stdio"}}`))
+	if !res.IsError {
+		t.Fatalf("stdio without command should refuse; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "command") {
+		t.Errorf("refusal should mention command; got %s", res.Text)
 	}
 }
 

--- a/internal/tools/mcp/dynamic.go
+++ b/internal/tools/mcp/dynamic.go
@@ -24,18 +24,29 @@ package mcp
 import "sync"
 
 // DynamicMCPServerSpec is the in-memory shape the pool's build
-// callback needs. Mirrors the operator-yaml mcp_servers.* shape minus
-// stdio bits (dynamic registration is HTTP + Streamable-HTTP only).
+// callback needs. Mirrors the operator-yaml mcp_servers.* shape.
+//
+// Transport is http / streamable-http by default; a `stdio` entry is
+// only ever present when the operator opted in via
+// LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO (F31) — the substrate refuses to
+// register a stdio server otherwise, since it runs an arbitrary local
+// command. Command/Args/Env carry the stdio invocation and are empty for
+// http transports.
 //
 // Headers are stored verbatim with their ${LOOMCYCLE_*} / ${run.user_bearer}
 // substitution placeholders intact — the http client's substitution
 // pass at request-build time resolves them (matches yaml-loaded
-// headers' semantics; see internal/tools/mcp/http/client.go).
+// headers' semantics; see internal/tools/mcp/http/client.go). Env values
+// (stdio) are passed to the child literally — no ${} expansion.
 type DynamicMCPServerSpec struct {
 	Name      string
-	Transport string // "http" | "streamable-http"
+	Transport string // "http" | "streamable-http" | "stdio" (stdio gated by LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO)
 	URL       string
 	Headers   map[string]string
+	// stdio invocation (F31); empty for http transports.
+	Command string
+	Args    []string
+	Env     map[string]string
 	// TenantID is the RFC N tenant-isolation axis. "" = the shared/
 	// operator/legacy tenant. Entries are keyed by (TenantID, Name) so
 	// two tenants register the same name with distinct URLs without


### PR DESCRIPTION
## Why
Dynamic MCP-server registration (`POST /v1/_mcpserverdef`, the `mcpserverdef` tool) was **http / streamable-http only** — the overlay, the persisted JSON, the resolver spec, the in-memory registry spec, and the pool build callback all deliberately omitted the stdio fields. So an operator could not register a runtime stdio MCP server even when they wanted one (`loomcycle-experiments` finding **F31**, previously filed as "by design").

Stdio stayed yaml-only for a real reason: a stdio server runs an **arbitrary local command** — a second local-exec path alongside the Bash tool, with no outbound-host-allowlist mediation (that guard only applies to http).

## What
Land it **behind a default-OFF operator flag**, `LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO`, mirroring `LOOMCYCLE_BASH_ENABLED` / `LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS`:

- **Gate** — `validateOverlay` gains a `case "stdio"`: flag off ⇒ refuse, now **naming the flag** (was an opaque "stdio stays yaml-only"); flag on ⇒ require a `command`, skip the http URL/host-allowlist checks. Static yaml `mcp_servers:` stdio entries are unaffected regardless of the flag.
- **Plumbing** — thread `Command`/`Args`/`Env` through every layer that previously dropped them: `mcpServerOverlay` (+ `applyOverlay`, `specFromOverlay`), `lookup.SubstrateMCPServer` (persisted JSON) + `lookup.MCPServerSpec` (+ the `MCPServer` resolver), `mcp.DynamicMCPServerSpec` (+ the boot-loader rehydrate and `mcpLookupView` mapping in main.go).
- **Spawn** — the pool build callback gains a `case "stdio"` that spawns via a new shared `spawnStdio()` core (factored out of `spawnStdioMCP`), so a runtime stdio server is spawned + lifecycle-managed (lazy spawn, respawn on crash, teardown on retire) by the **same pool path** as a yaml stdio server. **No pool refactor.** Env values are passed to the child literally (no `${}` expansion).

## Security posture
Default-off; the refusal names the flag; the help topic + `.env.insecure.example` document the arbitrary-local-command risk. A per-command allowlist is noted as a possible hardening follow-up (the flag is the primary control).

## Tested
- **Unit**: `validateOverlay` stdio refused-by-default (refusal names the flag), allowed-with-flag (`command`/`args`/`env` round-trip into the registry the build callback reads), requires-command. Drift `want` set updated for the three new `SubstrateMCPServer` tags.
- **e2e (built binary)**: flag OFF → `POST` stdio create refused naming the flag; flag ON → create succeeds, def persists `{transport:stdio, command, args, env}`; reboot on the same DB → boot loader logs `loaded 1 active registration(s)` and the registration survives. (A successful tool **call** through a live stdio MCP server reuses the proven yaml `spawnStdio` path.)
- `gofmt`/`go vet` clean; `go build ./...` + `make build` clean; touched + adjacent packages (`builtin`, `lookup`, `mcp`, `config`, `api/mcp`) green.

Third and last of the dynamic-substrate-consumption sweep (F30 webhook→dynamic-agent #403; F29 channels #404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)