### PR TITLE
fix(mcpserverdef): store env reference, resolve secret at dial-time (F32)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -800,9 +800,25 @@ func main() {
 			}
 			switch spec.Transport {
 			case "http", "streamable-http":
+				// F32: resolve ${LOOMCYCLE_*} at DIAL time, not persist time —
+				// the stored def (and the registry spec) carry only the ${ref};
+				// the live client gets the value. This mirrors yaml-load's
+				// config.Load expansion at exactly the boundary that flattens any
+				// inner ${LOOMCYCLE_*} before the request-time ${run.*}
+				// substituter runs (see mcpserverdef.go buildDefinition). For a
+				// yaml-static spec the values are already flat, so ExpandEnv is an
+				// idempotent no-op; a pre-F32 baked row (resolved value, no ${})
+				// is likewise a no-op → backward-compatible.
+				hdrs := spec.Headers
+				if len(hdrs) > 0 {
+					hdrs = make(map[string]string, len(spec.Headers))
+					for k, v := range spec.Headers {
+						hdrs[k] = config.ExpandEnv(v)
+					}
+				}
 				return mcphttp.New(mcphttp.Config{
-					URL:     spec.URL,
-					Headers: spec.Headers,
+					URL:     config.ExpandEnv(spec.URL),
+					Headers: hdrs,
 				})
 			case "stdio":
 				// F31: a runtime-registered stdio server. The substrate only

--- a/internal/help/builtin/dynamic-mcp.md
+++ b/internal/help/builtin/dynamic-mcp.md
@@ -73,6 +73,16 @@ substitution happens per-request in `Client.do()` against a local map
 copy — `c.headers` is never mutated, so concurrent calls send the
 right bearer per run.
 
+**Secrets are stored by reference, resolved at dial (F32).** The url +
+headers you register are persisted **verbatim** — a header like
+`Authorization: Bearer ${LOOMCYCLE_N8N_TOKEN}` keeps the `${...}`
+reference in `mcp_server_defs.content` (and `content_sha256` is computed
+over the reference, so it stays stable when the token rotates). The
+`${LOOMCYCLE_*}` is resolved only when the pool dials the server, exactly
+as a yaml `mcp_servers.*` entry is expanded at config load. The live
+credential never touches the DB / backups / snapshots. (Earlier revisions
+baked the resolved token into the stored def — that is fixed.)
+
 ## Ops
 
 The `MCPServerDef` tool dispatches eight ops:

--- a/internal/tools/builtin/mcpserverdef.go
+++ b/internal/tools/builtin/mcpserverdef.go
@@ -802,7 +802,10 @@ func (m *MCPServerDef) validateOverlay(ov mcpServerOverlay) error {
 	if ov.URL == "" {
 		return fmt.Errorf("url is required")
 	}
-	u, err := url.Parse(ov.URL)
+	// F32: the stored def keeps the ${ref}, but the host-allowlist gate must
+	// see the RESOLVED host. Expand transiently here (in-memory, validation
+	// only) — buildDefinition does not persist this expanded form.
+	u, err := url.Parse(config.ExpandEnv(ov.URL))
 	if err != nil {
 		return fmt.Errorf("url parse: %w", err)
 	}
@@ -859,32 +862,24 @@ func (m *MCPServerDef) buildDefinition(parentJSON string, overlay json.RawMessag
 		}
 		base.applyOverlay(ov)
 	}
-	// Mirror yaml-load's ${LOOMCYCLE_*} expansion on the operator-authored
-	// connection fields. A yaml MCP server is expanded at config.Load; a
-	// dynamically-registered one never passes through Load, so without this
-	// the inner ${LOOMCYCLE_TOKEN} in a header template like
+	// F32: persist the ${LOOMCYCLE_*} REFERENCE, not the resolved value. An
+	// earlier revision expanded url/headers here to mirror yaml-load — but that
+	// baked the live token into mcp_server_defs.content (and content_sha256),
+	// leaving the credential readable at rest in the DB / backups / snapshots.
+	// Expansion is now deferred to DIAL time in the pool build callback
+	// (cmd/loomcycle/main.go, case "http"), mirroring how a yaml MCP server is
+	// expanded at config.Load — the live client gets the value, the disk keeps
+	// only ${ref}. This matches the webhookdef pattern (store env-var names,
+	// resolve at use-time) the rest of the substrate already follows.
+	//
+	// The nested-brace concern that motivated the old expansion (a header like
 	//   Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
-	// is stored verbatim. The request-time substituter's lazy `.*?` fallback
-	// then truncates on the inner `}` (see internal/tools/mcp/http/
-	// substitute.go:14, whose safety comment depends on this prior expansion)
-	// and sends `Bearer ${LOOMCYCLE_…}` as a literal → 401 upstream.
-	// Expanding here keeps the stored value flat (no nested brace), so
-	// request-time substitution behaves identically for yaml- and substrate-
-	// registered servers. The outer ${run.*} token carries a "." in its name,
-	// which envVarRe ([A-Za-z_][A-Za-z0-9_]*) cannot match, so it survives to
-	// request time untouched. Re-expanding an already-stored (forked) value is
-	// a no-op: bearer tokens cannot contain `${…}` per the HTTP-boundary
-	// charset. Caveat: this bakes the resolved token into the stored def
-	// content (and thus content_sha256) — consistent with yaml semantics, and
-	// dedup stays stable as long as the env value is stable.
-	base.URL = config.ExpandEnv(base.URL)
-	if len(base.Headers) > 0 {
-		expanded := make(map[string]string, len(base.Headers))
-		for k, v := range base.Headers {
-			expanded[k] = config.ExpandEnv(v)
-		}
-		base.Headers = expanded
-	}
+	// whose inner ${LOOMCYCLE_*} must be flattened before the request-time
+	// substituter's lazy `.*?` fallback truncates on the inner `}`; see
+	// internal/tools/mcp/http/substitute.go:14) is unchanged — the dial-time
+	// ExpandEnv flattens the inner token at exactly the same point yaml-load
+	// would, just without writing it to disk first. content_sha256 over the
+	// reference is also MORE stable: it no longer churns when the token rotates.
 	return base, nil
 }
 

--- a/internal/tools/builtin/mcpserverdef_test.go
+++ b/internal/tools/builtin/mcpserverdef_test.go
@@ -479,21 +479,24 @@ func TestCanonicalTools_OrderAndWhitespaceInsensitive(t *testing.T) {
 	}
 }
 
-// TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv pins the dynamic-vs-yaml
-// env-expansion symmetry. A yaml MCP server's header is expanded at
-// config.Load (the whole document passes through expandEnv); a dynamically-
-// registered one never passes through Load. Without expansion at create, the
-// inner ${LOOMCYCLE_*} in a header like
+// TestMCPServerDefTool_CreateStoresEnvReferenceNotValue is the F32 regression:
+// a dynamically-registered http MCP server must persist the ${LOOMCYCLE_*}
+// REFERENCE in mcp_server_defs.content, never the resolved secret. An earlier
+// revision expanded url/headers at create (buildDefinition), baking the live
+// token into the stored def + content_sha256 — readable at rest in the DB /
+// backups / snapshots. Expansion now happens at DIAL time (cmd/loomcycle/
+// main.go pool callback); the disk keeps only the reference.
 //
-//	Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}
+// The test also asserts that re-applying config.ExpandEnv to the stored value
+// (exactly what the pool callback does at dial) still flattens the inner
+// ${LOOMCYCLE_*} while leaving the outer ${run.*} token for the request-time
+// substituter — i.e. the relocation preserves the behaviour the old baking
+// protected (substitute.go's lazy `.*?` would otherwise truncate on a nested
+// `}`; see internal/tools/mcp/http/substitute.go:14).
 //
-// is stored verbatim, and the request-time substituter's lazy `.*?` fallback
-// (internal/tools/mcp/http/substitute.go) then truncates on the inner `}` and
-// sends `Bearer ${LOOMCYCLE_…}` as a literal → 401 upstream.
-//
-// Fails on the pre-fix code, which stored the nested-brace template verbatim:
-// the want-strings below would not match.
-func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
+// Fails on the pre-F32 code, which stored the resolved value: the
+// reference-equality asserts below would see the baked token instead.
+func TestMCPServerDefTool_CreateStoresEnvReferenceNotValue(t *testing.T) {
 	t.Setenv("LOOMCYCLE_JOBS_SEARCH_API_TOKEN", "tok-abc123")
 	t.Setenv("LOOMCYCLE_JOBS_MCP_HOST", "internal.example") // in the fixture allowlist
 
@@ -509,10 +512,6 @@ func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
 		t.Fatalf("create: %s", res.Text)
 	}
 
-	// Read the stored definition back and assert the inner LOOMCYCLE var was
-	// resolved while the outer ${run.credentials.*} token survived for
-	// request-time substitution — i.e. the stored header is now FLAT (no
-	// nested brace), which is exactly what substitute.go's lazy regex needs.
 	active, err := tool.Store.MCPServerDefGetActive(ctx, "", "jobs")
 	if err != nil {
 		t.Fatalf("GetActive: %v", err)
@@ -522,20 +521,96 @@ func TestMCPServerDefTool_CreateExpandsInnerLoomcycleEnv(t *testing.T) {
 		t.Fatalf("unmarshal definition: %v", err)
 	}
 
-	if want := "https://internal.example/mcp"; ov.URL != want {
-		t.Errorf("URL not expanded: got %q, want %q", ov.URL, want)
+	// 1. The stored def keeps the references — no secret at rest.
+	if want := "https://${LOOMCYCLE_JOBS_MCP_HOST}/mcp"; ov.URL != want {
+		t.Errorf("stored URL should keep the env reference:\n got: %q\nwant: %q", ov.URL, want)
 	}
 	gotHdr := ov.Headers["Authorization"]
-	if want := "Bearer ${run.credentials.jobs:-tok-abc123}"; gotHdr != want {
-		t.Fatalf("Authorization header:\n got: %q\nwant: %q", gotHdr, want)
+	if want := "Bearer ${run.credentials.jobs:-${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}}"; gotHdr != want {
+		t.Errorf("stored header should keep the env reference:\n got: %q\nwant: %q", gotHdr, want)
 	}
-	// Belt-and-suspenders: no nested brace remains, and the secret is not a
-	// literal placeholder anymore.
-	if strings.Contains(gotHdr, "${LOOMCYCLE_") {
-		t.Errorf("inner LOOMCYCLE var left unresolved in stored header: %q", gotHdr)
+	// The resolved secret must NOT appear anywhere in the persisted content.
+	if strings.Contains(string(active.Definition), "tok-abc123") {
+		t.Fatalf("resolved token leaked into stored def content: %s", active.Definition)
 	}
-	if !strings.Contains(gotHdr, "${run.credentials.jobs:-") {
-		t.Errorf("outer run-credentials token did not survive expansion: %q", gotHdr)
+
+	// 2. The relocated dial-time expansion still flattens the inner LOOMCYCLE
+	//    var, leaving the outer ${run.*} token for request-time substitution.
+	if got, want := config.ExpandEnv(ov.URL), "https://internal.example/mcp"; got != want {
+		t.Errorf("dial-time URL expansion: got %q, want %q", got, want)
+	}
+	if got, want := config.ExpandEnv(gotHdr), "Bearer ${run.credentials.jobs:-tok-abc123}"; got != want {
+		t.Errorf("dial-time header expansion: got %q, want %q", got, want)
+	}
+}
+
+// TestMCPServerDefTool_ContentSHAStableAcrossTokenRotation pins F32's other
+// win: because the def stores the ${ref} (not the value), content_sha256 is
+// computed over the reference and no longer churns when the underlying secret
+// rotates. On the pre-F32 code the baked value changed with the env, so the
+// two hashes differed (and the resolved token sat in the stored def).
+func TestMCPServerDefTool_ContentSHAStableAcrossTokenRotation(t *testing.T) {
+	tool, _, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+
+	overlay := json.RawMessage(`{"transport":"http","url":"https://internal.example/mcp","headers":{"Authorization":"Bearer ${LOOMCYCLE_JOBS_SEARCH_API_TOKEN}"}}`)
+
+	t.Setenv("LOOMCYCLE_JOBS_SEARCH_API_TOKEN", "tok-AAAAAAAA")
+	defA, err := tool.buildDefinition("", overlay)
+	if err != nil {
+		t.Fatalf("buildDefinition A: %v", err)
+	}
+	shaA := signFromMCPServerOverlay("jobs", defA)
+
+	t.Setenv("LOOMCYCLE_JOBS_SEARCH_API_TOKEN", "tok-BBBBBBBB-rotated")
+	defB, err := tool.buildDefinition("", overlay)
+	if err != nil {
+		t.Fatalf("buildDefinition B: %v", err)
+	}
+	shaB := signFromMCPServerOverlay("jobs", defB)
+
+	if shaA != shaB {
+		t.Fatalf("content_sha256 changed on token rotation (secret baked into content): %s vs %s", shaA, shaB)
+	}
+	if strings.Contains(defA.Headers["Authorization"], "tok-AAAAAAAA") {
+		t.Errorf("resolved token baked into stored def: %q", defA.Headers["Authorization"])
+	}
+}
+
+// TestMCPServerDefTool_HostCheckedAfterExpand guards that F32's reference
+// storage did not break the host-allowlist gate: validateOverlay expands the
+// ${...} URL transiently (in-memory, for the host extraction only) so a URL
+// resolving to an allowlisted host is admitted and one resolving off-allowlist
+// is refused — while the persisted def still keeps the reference.
+func TestMCPServerDefTool_HostCheckedAfterExpand(t *testing.T) {
+	tool, ctx, cleanup := mcpServerDefFixture(t)
+	defer cleanup()
+
+	t.Setenv("LOOMCYCLE_OK_HOST", "internal.example") // allowlisted in the fixture
+	t.Setenv("LOOMCYCLE_BAD_HOST", "evil.example")    // NOT allowlisted
+
+	ok, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"ok-host","overlay":{"transport":"http","url":"https://${LOOMCYCLE_OK_HOST}/mcp"}}`))
+	if ok.IsError {
+		t.Fatalf("allowlisted resolved host should pass: %s", ok.Text)
+	}
+	active, err := tool.Store.MCPServerDefGetActive(ctx, "", "ok-host")
+	if err != nil {
+		t.Fatalf("GetActive: %v", err)
+	}
+	var ov mcpServerOverlay
+	if err := json.Unmarshal(active.Definition, &ov); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if want := "https://${LOOMCYCLE_OK_HOST}/mcp"; ov.URL != want {
+		t.Errorf("admitted def should still store the reference: got %q want %q", ov.URL, want)
+	}
+
+	bad, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"bad-host","overlay":{"transport":"http","url":"https://${LOOMCYCLE_BAD_HOST}/mcp"}}`))
+	if !bad.IsError {
+		t.Fatalf("off-allowlist resolved host should refuse; got %s", bad.Text)
+	}
+	if !strings.Contains(bad.Text, "not in") {
+		t.Errorf("refusal should mention the allowlist; got %s", bad.Text)
 	}
 }
 

--- a/internal/tools/builtin/webhookdef.go
+++ b/internal/tools/builtin/webhookdef.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 
@@ -146,6 +147,7 @@ func (s *WebhookDef) execCreate(ctx context.Context, policy tools.WebhookDefPoli
 	if err := validateWebhookDef(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
+	warnLiteralUserCredentials(in.Name, def)
 	// RFC N: the spawned run executes as the CREATING principal's tenant,
 	// resolved from the authoritative run identity in ctx — never silently
 	// empty. F30: an un-stamped tenant made a `spawn` webhook resolve a
@@ -259,6 +261,7 @@ func (s *WebhookDef) execFork(ctx context.Context, policy tools.WebhookDefPolicy
 	if err := validateWebhookDef(def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
 	}
+	warnLiteralUserCredentials(in.Name, def)
 	// RFC N tenant stamp — see execCreate. A fork defaults to the forking
 	// principal's tenant unless the parent/overlay already carries one.
 	ident := tools.RunIdentity(ctx)
@@ -479,6 +482,19 @@ func (s *WebhookDef) BootstrapStaticWebhooks(ctx context.Context) (int, error) {
 		seeded++
 	}
 	return seeded, nil
+}
+
+// warnLiteralUserCredentials logs a registration-time nudge when a webhook def
+// carries a LITERAL bearer in user_credentials (vs user_credentials_from_env).
+// F32: a literal here is baked into the signed / content-hashed / snapshotted
+// def and is readable at rest. We WARN rather than refuse — RFC F deliberately
+// permits the literal for fork-time explicit values, so refusing would break a
+// legitimate path; the env-name form (user_credentials_from_env) keeps the
+// secret out of the DB and is the preferred posture.
+func warnLiteralUserCredentials(name string, def mergedWebhookDef) {
+	if len(def.UserCredentials) > 0 {
+		log.Printf("webhookdef %q: user_credentials carries %d literal value(s) baked into the stored def (readable at rest) — prefer user_credentials_from_env to keep secrets out of the DB (F32)", name, len(def.UserCredentials))
+	}
 }
 
 // validateWebhookDef enforces the runtime-supplied overlay shape.


### PR DESCRIPTION
## Why

`loomcycle-experiments` secret-scanned the SQLite store and recovered a **real `LOOMCYCLE_GITEA_TOKEN` verbatim** from a tracked `data/loomcycle.db` checkpoint (SHA-256 hash-confirmed). The `LOOMCYCLE_*` env-indirection posture is defeated the moment a resolved value is written back to disk — anyone with DB read access (a copy, a committed checkpoint, a backup) reads live credentials.

This is **F32, path A** (def baking). MCPServerDef was the only substrate def that baked secrets: `buildDefinition` ran `config.ExpandEnv` over the http `url`+`headers` and persisted the **resolved** string into `mcp_server_defs.content` (+ `content_sha256`) — its own comment admitted "this bakes the resolved token into the stored def content." Every other def (`webhookdef`/`agentdef`/`skilldef`/`scheduledef`/`a2a`/`memorybackenddef`) stores env-var *names* and resolves at use-time.

## What

- **`buildDefinition` no longer expands** — it persists the `${ref}` verbatim, matching the webhookdef pattern.
- **Expansion relocated to dial-time** in the pool build callback (`cmd/loomcycle/main.go`, `case "http"`), at exactly the boundary yaml-load expands a static `mcp_servers.*` entry. The inner `${LOOMCYCLE_*}` is still flattened before the request-time `${run.*}` substituter runs (`substitute.go`'s lazy `.*?` would otherwise truncate on the nested `}`), so behaviour is preserved — just moved off disk.
- **`validateOverlay`** expands the URL transiently (in-memory) for the host-allowlist gate only; the persisted def keeps the reference.
- **`content_sha256` is now over the reference** → stable across token rotation.
- **Backward-compatible:** `ExpandEnv` on a pre-F32 baked row (resolved value, no `${}`) is a no-op, so old rows keep dialing; new writes are clean.
- **Webhook audit (path A, second commit):** webhook defs store `signing_secret_env`/`bearer_token_env` as env-var *names* (clean). The one soft spot is `user_credentials`, which (per RFC F) may carry a literal bearer baked into the signed/hashed/snapshotted def. Added a **registration-time warning** at `execCreate`/`execFork` nudging to `user_credentials_from_env` — warn, not refuse (RFC F permits the literal for fork-time explicit values).

This is the structural half of F32. Transcript redaction (path B — secrets inlined on a Bash cmdline / echoed in tool results landing in `events.payload`) ships in a separate PR.

## What was tested

New regression tests (each verified to **fail on the unfixed `buildDefinition`** via stash-revert, pass on the fix):
- `TestMCPServerDefTool_CreateStoresEnvReferenceNotValue` — stored content keeps `${LOOMCYCLE_*}`, resolved token absent; dial-time `ExpandEnv` still flattens correctly.
- `TestMCPServerDefTool_ContentSHAStableAcrossTokenRotation` — `content_sha256` unchanged when the env value rotates.
- `TestMCPServerDefTool_HostCheckedAfterExpand` — `${...}` URL host-checked after transient expand; reference still persisted.

`go test ./...` clean except the pre-existing env-flaky `TestBashTimeout` (a timing test, unrelated; fails identically on a clean tree). Full-repo compile (`go build ./...`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)