### PR TITLE
feat(redact): mask secrets in tool transcripts before persistence (F32)

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -307,6 +307,16 @@ LOOMCYCLE_DATA_DIR=./data
 # Static yaml `mcp_servers:` stdio entries are always allowed regardless.
 # LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1
 #
+# F32 — secret redaction at rest. ON BY DEFAULT: tool I/O (tool_call inputs +
+# tool_result outputs) is scanned for secret-shaped substrings and masked
+# BEFORE it is persisted to the events store (and thus to snapshots + the
+# /v1/_events audit API), so a token inlined on a Bash cmdline or echoed by a
+# tool isn't written to disk in cleartext. The live SSE stream is NOT redacted
+# (the caller already holds the secret). Set to 0 to DISABLE redaction (e.g. to
+# debug a transcript locally). Note: this is defense-in-depth — agents should
+# still pass secrets out-of-band (env / stdin / credential helper), never inline.
+# LOOMCYCLE_REDACT_SECRETS=0
+#
 # Default TTL for agents registered via mcp__loomcycle__register_agent
 # when the caller omits ttl_seconds. Default 86400 (24 h). Set 0 to
 # require callers to ALWAYS supply an explicit ttl_seconds (no

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -798,6 +798,11 @@ cp .env.insecure.example  .env.insecure   # then adjust paths/flags
 
 **How they're loaded.** `loomcycle.sh` and `loomcycle-mcp.sh` source **`.env.insecure` first, then `.env.local`** (config first, secrets last — so a stray config line can never shadow a secret) before exec'ing the binary; either file may be absent. Set `LOOMCYCLE_ENV_FILE=<path>` to collapse the pair back to a single explicit file (the pre-split single-file flow). loomcycle itself reads only process env — it does not parse these files — so any supervisor (systemd `EnvironmentFile=`, Docker `--env-file`, a CI secret store) can substitute for the launcher scripts.
 
+**Secrets at rest (F32).** Two mechanisms keep resolved credentials out of the on-disk state:
+
+- **Definition plane — store the reference, resolve at use-time.** A substrate def persists the `${ENV_NAME}` reference, never the expanded value. Webhook defs store `signing_secret_env` / `bearer_token_env` (env-var *names*), and a dynamic MCP server's `url` / `headers` keep their `${LOOMCYCLE_*}` placeholders in `mcp_server_defs.content` — the secret is resolved only when the pool dials the server (mirroring how a yaml `mcp_servers.*` entry is expanded at config load). `content_sha256` is computed over the reference, so it stays stable when the token rotates.
+- **Transcript plane — redact before persisting (`LOOMCYCLE_REDACT_SECRETS`, default ON).** Tool I/O (tool_call inputs + tool_result outputs) is scanned for secret-shaped substrings and masked before it reaches the events store (and thus snapshots + the `/v1/_events` audit API): the exact values of secret-named env vars (`*_KEY` / `*_TOKEN` / `*_SECRET` / `*_AUTH` / `*_PASSWORD` / `*_CREDENTIAL`) become `[redacted:NAME]`, plus conservative heuristics for `Authorization:` headers, `sk-`/`AKIA`/`xox`/`ghp_` keys, and `*_API_KEY=` assignments. The live SSE stream is **not** redacted (the caller already holds the secret). Set `LOOMCYCLE_REDACT_SECRETS=0` to disable. This is defense-in-depth — agents should still pass secrets out-of-band (env / stdin / credential helper), never inline on a cmdline.
+
 ---
 
 ## 10. Cross-references

--- a/internal/api/http/redact_emit_test.go
+++ b/internal/api/http/redact_emit_test.go
@@ -1,0 +1,113 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/redact"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// emitFixture builds a Server over in-memory sqlite with a session + run, so a
+// makeRecordingEmit closure can persist events. redactor may be nil (disabled).
+func emitFixture(t *testing.T, redactor *redact.Redactor) (*Server, store.Store, string, context.Context, func()) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, "tenant", "agent", "")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_test"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	srv := &Server{store: st, redactor: redactor}
+	return srv, st, run.ID, ctx, func() { _ = st.Close() }
+}
+
+// storedToolResult reads back the single tool_result event's persisted payload,
+// decoded into a providers.Event.
+func storedToolResult(t *testing.T, st store.Store, ctx context.Context) providers.Event {
+	t.Helper()
+	evs, _, err := st.ListEvents(ctx, store.EventFilter{Type: string(providers.EventToolResult)}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("expected exactly 1 tool_result event, got %d", len(evs))
+	}
+	var decoded providers.Event
+	if err := json.Unmarshal(evs[0].Payload, &decoded); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	return decoded
+}
+
+const emitSecret = "abc123def456ghi789xyz"
+
+// TestRecordingEmit_RedactsSecretInToolResult is the F32 transcript regression:
+// a secret in a tool_result's Text AND in the tool_call Input is masked in the
+// PERSISTED event, while the event forwarded to the live SSE stream is left
+// intact. Fails on the pre-F32 code, which marshaled ev verbatim.
+func TestRecordingEmit_RedactsSecretInToolResult(t *testing.T) {
+	redactor := redact.New(map[string]string{"LOOMCYCLE_GITEA_TOKEN": emitSecret}, true)
+	srv, st, runID, ctx, cleanup := emitFixture(t, redactor)
+	defer cleanup()
+
+	var forwarded providers.Event
+	emit := srv.makeRecordingEmit(ctx, runID, func(ev providers.Event) { forwarded = ev })
+
+	input := json.RawMessage(`{"command":"curl -H \"Authorization: token ` + emitSecret + `\" https://gitea"}`)
+	emit(providers.Event{
+		Type:    providers.EventToolResult,
+		ToolUse: &providers.ToolUse{ID: "t1", Name: "Bash", Input: input},
+		Text:    "ran: Authorization: token " + emitSecret + " -> 200 OK",
+	})
+
+	// Persisted copy: the secret is gone from both Text and Input.
+	got := storedToolResult(t, st, ctx)
+	if strings.Contains(got.Text, emitSecret) {
+		t.Errorf("secret survived in persisted Text: %q", got.Text)
+	}
+	if strings.Contains(string(got.ToolUse.Input), emitSecret) {
+		t.Errorf("secret survived in persisted Input: %s", got.ToolUse.Input)
+	}
+	if !strings.Contains(got.Text, "[redacted:LOOMCYCLE_GITEA_TOKEN]") {
+		t.Errorf("expected named redaction marker in Text: %q", got.Text)
+	}
+	if !json.Valid(got.ToolUse.Input) {
+		t.Errorf("persisted Input is not valid JSON: %s", got.ToolUse.Input)
+	}
+
+	// Live stream: the forwarded event is UNredacted (caller already holds it).
+	if !strings.Contains(forwarded.Text, emitSecret) {
+		t.Errorf("forwarded (SSE) event should NOT be redacted; got %q", forwarded.Text)
+	}
+}
+
+// TestRecordingEmit_NoRedactorWhenDisabled — LOOMCYCLE_REDACT_SECRETS=0 leaves
+// s.redactor nil; the payload is persisted verbatim (opt-out works).
+func TestRecordingEmit_NoRedactorWhenDisabled(t *testing.T) {
+	srv, st, runID, ctx, cleanup := emitFixture(t, nil) // redaction disabled
+	defer cleanup()
+
+	emit := srv.makeRecordingEmit(ctx, runID, func(providers.Event) {})
+	emit(providers.Event{
+		Type:    providers.EventToolResult,
+		ToolUse: &providers.ToolUse{ID: "t1", Name: "Bash", Input: json.RawMessage(`{"x":"y"}`)},
+		Text:    "token " + emitSecret,
+	})
+
+	got := storedToolResult(t, st, ctx)
+	if !strings.Contains(got.Text, emitSecret) {
+		t.Errorf("with redaction disabled the secret should persist verbatim; got %q", got.Text)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -30,6 +31,7 @@ import (
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/pause"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/redact"
 	"github.com/denn-gubsky/loomcycle/internal/resolve"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
@@ -57,6 +59,13 @@ type Server struct {
 	tools     []tools.Tool
 	sem       *concurrency.Semaphore
 	store     store.Store // optional; nil means "don't persist"
+
+	// redactor masks secret-shaped substrings in tool I/O before it is
+	// persisted to events.payload (F32). Built in New() from the secret-
+	// classified env when cfg.Env.RedactSecrets; nil (a no-op) when disabled
+	// via LOOMCYCLE_REDACT_SECRETS=0. Read-only after construction; the nil /
+	// no-op cases are handled by *redact.Redactor's nil-safe methods.
+	redactor *redact.Redactor
 
 	// cancelReg holds the in-memory map of agent_id → cancelFn so the
 	// cancel API can tear down a still-running loop from a different
@@ -339,6 +348,12 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		hookRegistry:   hookReg,
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
 		startedAt:      time.Now(),
+	}
+	// F32: build the secret redactor from the process env (secret-classified
+	// names only). Default-ON; LOOMCYCLE_REDACT_SECRETS=0 leaves s.redactor nil
+	// (its methods are nil-safe, so makeRecordingEmit just skips redaction).
+	if cfg.Env.RedactSecrets {
+		s.redactor = redact.New(secretEnvValues(os.Environ()), true)
 	}
 	s.tools = append(s.tools, &builtin.AgentTool{
 		Run: s.runSubAgent,
@@ -3606,7 +3621,22 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 	return func(ev providers.Event) {
 		mu.Lock()
 		defer mu.Unlock()
-		payload, err := json.Marshal(ev)
+		// F32: redact secrets out of the PERSISTED copy only — the tool_call
+		// input and tool_result text are the surfaces where a token inlined on a
+		// Bash cmdline / echoed by a tool would otherwise hit the events BLOB
+		// (and, downstream, snapshots + the /v1/_events audit API). fwd() below
+		// still forwards the ORIGINAL event: the live SSE caller is the trust
+		// boundary that already holds the secret, so we don't mangle its stream.
+		toStore := ev
+		if s.redactor.Enabled() && (ev.Type == providers.EventToolCall || ev.Type == providers.EventToolResult) {
+			if ev.ToolUse != nil {
+				tu := *ev.ToolUse // copy so we don't mutate the event fwd() sends
+				tu.Input = s.redactor.Bytes(tu.Input)
+				toStore.ToolUse = &tu
+			}
+			toStore.Text = s.redactor.String(ev.Text)
+		}
+		payload, err := json.Marshal(toStore)
 		if err == nil {
 			if err := s.store.AppendEvent(ctx, runID, string(ev.Type), payload); err != nil {
 				log.Printf("store: AppendEvent failed (run=%s type=%s): %v", runID, ev.Type, err)
@@ -3614,6 +3644,25 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		}
 		fwd(ev)
 	}
+}
+
+// secretEnvValues extracts the VALUES of secret-classified env vars (by name)
+// from an environ slice ("NAME=value" entries), for the F32 redactor's exact-
+// match tier. Empty values are skipped (nothing to mask).
+func secretEnvValues(environ []string) map[string]string {
+	out := make(map[string]string)
+	for _, kv := range environ {
+		i := strings.IndexByte(kv, '=')
+		if i <= 0 {
+			continue
+		}
+		name, val := kv[:i], kv[i+1:]
+		if val == "" || !config.IsSecretEnvName(name) {
+			continue
+		}
+		out[name] = val
+	}
+	return out
 }
 
 // runSubAgent is the SubAgentRunner closure injected into the Agent

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1610,6 +1610,16 @@ type Env struct {
 	// LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO.
 	MCPAllowDynamicStdio bool
 
+	// RedactSecrets — F32. When true (the DEFAULT), tool I/O is scanned for
+	// secret-shaped substrings and masked BEFORE it is persisted to the
+	// events.payload BLOB (and thus to snapshots + the /v1/_events audit API).
+	// This is defense-in-depth for the runtime-inline leak: an agent that
+	// inlines a token on a Bash cmdline (`curl -H "Authorization: token …"`) or
+	// a tool result that echoes one would otherwise be stored in cleartext at
+	// rest. The live SSE stream is NOT redacted (the caller already holds the
+	// secret). Opt out with LOOMCYCLE_REDACT_SECRETS=0. See internal/redact.
+	RedactSecrets bool
+
 	// DynamicAgentDefaultTTLSeconds — v0.8.15. TTL applied to
 	// dynamic agents registered via mcp__loomcycle__register_agent
 	// when the caller omits ttl_seconds. Default 86400 (24h).
@@ -2482,6 +2492,9 @@ func Load(path string) (*Config, error) {
 	// v0.8.15 LoomCycle MCP: dynamic agent registration policy.
 	cfg.Env.MCPAllowPrivilegedTools = os.Getenv("LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS") == "1"
 	cfg.Env.MCPAllowDynamicStdio = os.Getenv("LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO") == "1"
+	// F32: default-ON. Only an explicit "0" disables redaction; an unset var
+	// keeps the secure posture (secrets masked before persistence).
+	cfg.Env.RedactSecrets = os.Getenv("LOOMCYCLE_REDACT_SECRETS") != "0"
 	cfg.Env.DynamicAgentDefaultTTLSeconds = 86400 // 24h
 	if v := os.Getenv("LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
@@ -2798,6 +2811,31 @@ func ExpandEnvAllowed(name string) bool {
 		"PG_DSN",
 		"REDIS_URL":
 		return true
+	}
+	return false
+}
+
+// secretEnvSuffixes are the env-var NAME patterns this project classifies as
+// secret (CLAUDE.md §security). A name ending in one of these denotes a
+// credential whose VALUE must be kept out of persisted transcripts (F32).
+var secretEnvSuffixes = []string{
+	"_KEY", "_TOKEN", "_SECRET", "_AUTH", "_PASSWORD", "_CREDENTIAL", "_CREDENTIALS",
+}
+
+// IsSecretEnvName reports whether an env-var name denotes a secret VALUE, by the
+// documented suffix classification (case-insensitive). Used by the secret
+// redactor (internal/redact) to decide which env values to mask from persisted
+// tool transcripts. Deliberately NOT keyed off ExpandEnvAllowed: that allows
+// every LOOMCYCLE_*-prefixed var (incl. non-secrets like LOOMCYCLE_LISTEN_ADDR),
+// so reusing it would collect non-secret values and risk masking benign
+// substrings. The suffix list catches both LOOMCYCLE_* secrets and provider keys
+// (ANTHROPIC_API_KEY, OPENAI_API_KEY, …) without a hard-coded name list.
+func IsSecretEnvName(name string) bool {
+	up := strings.ToUpper(name)
+	for _, suf := range secretEnvSuffixes {
+		if strings.HasSuffix(up, suf) {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,168 @@
+// Package redact masks secret-shaped substrings before they are persisted at
+// rest. F32: agent tool I/O (tool_call inputs + tool_result outputs) is stored
+// verbatim in the events.payload BLOB; a secret inlined on a Bash cmdline
+// (`curl -H "Authorization: token <TOKEN>"`) or echoed in a tool result would
+// otherwise sit in cleartext in the DB — and, because the same blob propagates
+// to snapshots and the /v1/_events audit API, in every copy/backup too.
+//
+// Two tiers, both applied:
+//   - Tier A — exact known env-secret values (zero false positives). The caller
+//     passes the VALUES of env vars classified as secret (config.IsSecretEnvName);
+//     any exact occurrence is masked as [redacted:NAME]. This catches the
+//     confirmed repro (LOOMCYCLE_GITEA_TOKEN inlined in a curl cmdline) exactly,
+//     because we redact only values we actually hold.
+//   - Tier B — conservative pattern heuristics (catches secrets NOT sourced from
+//     env, e.g. a token an agent fetched at runtime). Each rule targets a
+//     distinctive secret shape; see patternRules for the per-rule rationale.
+//
+// A Redactor is built once and is safe for concurrent String/Bytes calls (its
+// compiled state is read-only after New). The zero value / a nil *Redactor is a
+// no-op, so callers may hold a nil redactor when redaction is disabled.
+package redact
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// minSecretLen is the shortest env value Tier A will mask. A shorter value is
+// too generic to be a meaningful credential, and masking a common short word
+// (e.g. an env var that happens to be set to "true") would be a false positive.
+const minSecretLen = 8
+
+// Redactor masks secret-shaped substrings.
+type Redactor struct {
+	replacer *strings.Replacer // Tier A: exact env-value → [redacted:NAME]; nil if none
+	patterns []patternRule     // Tier B: nil when patterns are disabled
+}
+
+type patternRule struct {
+	re   *regexp.Regexp
+	repl string
+}
+
+// patternRules are the Tier-B heuristics. Each value-capturing class deliberately
+// EXCLUDES the JSON structural characters " ' , } and backslash so a match can
+// never cross a JSON string boundary — Bytes redacts string leaves directly, but
+// String is also applied to raw tool-result text, and keeping matches inside the
+// token guarantees we never corrupt surrounding structure. The classes also
+// exclude [ and ] so a Tier-A [redacted:NAME] marker (Tier A runs first) is
+// inert to Tier B — the tiers compose instead of clobbering each other's output.
+var patternRules = []patternRule{
+	// HTTP auth header — the F32 repro shape (token/bearer inlined on a curl
+	// cmdline). Keep the scheme, drop the credential.
+	{regexp.MustCompile(`(?i)(Authorization\s*:\s*(?:token|Bearer)\s+)[^\s"',}\[\]\\]+`), "${1}[redacted]"},
+	// OpenAI-style keys: sk- (incl. project keys sk-proj-…) + >=16 of base62/-/_.
+	// Distinctive prefix → low FP.
+	{regexp.MustCompile(`\bsk-[A-Za-z0-9][A-Za-z0-9_-]{15,}\b`), "[redacted-key]"},
+	// AWS access key id: AKIA + 16 upper/digit. Fixed, unmistakable shape.
+	{regexp.MustCompile(`\bAKIA[0-9A-Z]{16}\b`), "[redacted-aws-key]"},
+	// Slack tokens: xoxb-/xoxp-/xoxa-/xoxr-/xoxs- prefix.
+	{regexp.MustCompile(`\bxox[baprs]-[A-Za-z0-9-]{10,}\b`), "[redacted-slack]"},
+	// GitHub PAT: ghp_ + >=36 base62. Distinctive prefix. We do NOT match a bare
+	// 40-hex string — that collides with git commit SHAs (a real false positive
+	// in dev transcripts); env-sourced 40-hex PATs are caught by Tier A and
+	// inline ones by the Authorization rule above.
+	{regexp.MustCompile(`\bghp_[A-Za-z0-9]{36,}\b`), "[redacted-token]"},
+	// key=value / key: "value" assignments for secret-named keys (the *_API_KEY=…
+	// family). Masks only the value; the key + delimiter are preserved so the
+	// structure stays legible.
+	{regexp.MustCompile(`(?i)\b(api[_-]?key|secret|token|password)\b(\s*["']?\s*[:=]\s*["']?)[^\s"',}\[\]\\]+`), "${1}${2}[redacted]"},
+}
+
+// New builds a Redactor. secrets maps an env-var NAME to its secret VALUE; each
+// value is masked as [redacted:NAME] on an exact match (values shorter than
+// minSecretLen are skipped). withPatterns enables the Tier-B heuristics.
+// New(nil, false) is a no-op Redactor, so callers can build unconditionally.
+func New(secrets map[string]string, withPatterns bool) *Redactor {
+	r := &Redactor{}
+	// Tier A: exact env-value replacer, LONGEST value first so a value that is a
+	// substring of another is replaced as part of the longer match first (avoids
+	// a partial mask leaving a fragment of the longer secret behind).
+	type kv struct{ name, val string }
+	kvs := make([]kv, 0, len(secrets))
+	for name, val := range secrets {
+		if len(val) < minSecretLen {
+			continue
+		}
+		kvs = append(kvs, kv{name, val})
+	}
+	if len(kvs) > 0 {
+		sort.Slice(kvs, func(i, j int) bool { return len(kvs[i].val) > len(kvs[j].val) })
+		pairs := make([]string, 0, len(kvs)*2)
+		for _, e := range kvs {
+			pairs = append(pairs, e.val, "[redacted:"+e.name+"]")
+		}
+		r.replacer = strings.NewReplacer(pairs...)
+	}
+	if withPatterns {
+		r.patterns = patternRules
+	}
+	return r
+}
+
+// Enabled reports whether the redactor would mask anything. A no-op / nil
+// redactor returns false, letting callers skip the copy on the hot path.
+func (r *Redactor) Enabled() bool {
+	return r != nil && (r.replacer != nil || len(r.patterns) > 0)
+}
+
+// String returns s with every recognised secret masked. Tier A (exact env
+// values) runs first, then the Tier-B patterns.
+func (r *Redactor) String(s string) string {
+	if !r.Enabled() || s == "" {
+		return s
+	}
+	if r.replacer != nil {
+		s = r.replacer.Replace(s)
+	}
+	for _, p := range r.patterns {
+		s = p.re.ReplaceAllString(s, p.repl)
+	}
+	return s
+}
+
+// Bytes redacts a JSON tool input (json.RawMessage). It walks the JSON and
+// redacts every string LEAF via String, then re-marshals — so the output is
+// always valid JSON (re-marshal handles escaping) and the secret, which is most
+// often a bare string value (a token inlined in a Bash command string), is
+// masked without risk of breaking structure. A non-JSON input (should not occur
+// for tool inputs) is returned unchanged rather than risk corrupting the event.
+func (r *Redactor) Bytes(b []byte) []byte {
+	if !r.Enabled() || len(b) == 0 {
+		return b
+	}
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return b // not the expected JSON shape — leave it rather than corrupt it
+	}
+	out, err := json.Marshal(r.redactValue(v))
+	if err != nil {
+		return b // never drop the event over a redaction failure
+	}
+	return out
+}
+
+// redactValue walks a decoded JSON value, redacting string leaves in place.
+// Object KEYS are not redacted (a key named "password" is not itself a secret;
+// its string value is redacted as a leaf).
+func (r *Redactor) redactValue(v any) any {
+	switch t := v.(type) {
+	case string:
+		return r.String(t)
+	case map[string]any:
+		for k, val := range t {
+			t[k] = r.redactValue(val)
+		}
+		return t
+	case []any:
+		for i, val := range t {
+			t[i] = r.redactValue(val)
+		}
+		return t
+	default:
+		return v
+	}
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,139 @@
+package redact
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestRedactor_ExactEnvValue is the F32 core: the resolved value of a secret
+// env var, inlined anywhere in tool I/O, is masked as [redacted:NAME].
+func TestRedactor_ExactEnvValue(t *testing.T) {
+	r := New(map[string]string{"LOOMCYCLE_GITEA_TOKEN": "abc123def456ghi789"}, false)
+
+	in := `curl -H "Authorization: token abc123def456ghi789" https://gitea/api`
+	got := r.String(in)
+	if strings.Contains(got, "abc123def456ghi789") {
+		t.Fatalf("secret value not masked: %q", got)
+	}
+	if !strings.Contains(got, "[redacted:LOOMCYCLE_GITEA_TOKEN]") {
+		t.Errorf("expected named redaction marker; got %q", got)
+	}
+}
+
+// TestRedactor_ShortEnvValueSkipped — a short value (< minSecretLen) is NOT
+// masked: too generic, and masking it would be a false positive.
+func TestRedactor_ShortEnvValueSkipped(t *testing.T) {
+	r := New(map[string]string{"LOOMCYCLE_FLAG": "true"}, false)
+	if got := r.String("the flag is true today"); got != "the flag is true today" {
+		t.Errorf("short value should not be masked; got %q", got)
+	}
+}
+
+func TestRedactor_Patterns(t *testing.T) {
+	r := New(nil, true) // patterns only, no exact values
+	cases := []struct {
+		name      string
+		in        string
+		mustGo    string // substring that must be gone
+		mustStay  string // substring that must remain (structure preserved)
+	}{
+		{"auth-token", `Authorization: token ghp_realtokenvalue1234567890`, "ghp_realtokenvalue1234567890", "Authorization: token"},
+		{"auth-bearer", `Authorization: Bearer sk-abc123def456ghi789jkl`, "sk-abc123def456ghi789jkl", "Authorization: Bearer"},
+		{"sk-key", `using key sk-proj-abcdefghij1234567890 here`, "sk-proj-abcdefghij1234567890", "using key"},
+		{"aws-key", `id=AKIAIOSFODNN7EXAMPLE done`, "AKIAIOSFODNN7EXAMPLE", "done"},
+		{"slack", `token xoxb-123456789012-abcdefABCDEF here`, "xoxb-123456789012-abcdefABCDEF", "token"},
+		{"github-pat", `pat ghp_abcdefghijklmnopqrstuvwxyz0123456789 ok`, "ghp_abcdefghijklmnopqrstuvwxyz0123456789", "ok"},
+		{"api_key-assign", `API_KEY=supersecretvalue123`, "supersecretvalue123", "API_KEY"},
+		{"password-assign", `password: "hunter2hunter2"`, "hunter2hunter2", "password"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.String(tc.in)
+			if strings.Contains(got, tc.mustGo) {
+				t.Errorf("secret not masked: %q (still contains %q)", got, tc.mustGo)
+			}
+			if !strings.Contains(got, tc.mustStay) {
+				t.Errorf("structure not preserved: %q (lost %q)", got, tc.mustStay)
+			}
+		})
+	}
+}
+
+// TestRedactor_GitSHANotMasked guards the deliberate FP exclusion: a bare
+// 40-hex git commit SHA must survive (we do not match bare 40-hex).
+func TestRedactor_GitSHANotMasked(t *testing.T) {
+	r := New(nil, true)
+	sha := "6c6b0871f0a3e2d4c5b6a7980123456789abcdef"
+	in := "commit " + sha + " merged"
+	if got := r.String(in); got != in {
+		t.Errorf("git SHA must not be masked; got %q", got)
+	}
+}
+
+// TestRedactor_PatternsDisabled — withPatterns=false applies only Tier A.
+func TestRedactor_PatternsDisabled(t *testing.T) {
+	r := New(map[string]string{"X_TOKEN": "knownvalue1234"}, false)
+	in := `Authorization: Bearer sk-someothertoken12345 and knownvalue1234`
+	got := r.String(in)
+	if strings.Contains(got, "knownvalue1234") {
+		t.Errorf("Tier A value should still be masked: %q", got)
+	}
+	// The pattern-only secret survives because patterns are off.
+	if !strings.Contains(got, "sk-someothertoken12345") {
+		t.Errorf("with patterns disabled, sk- key should NOT be masked: %q", got)
+	}
+}
+
+// TestRedactor_BytesRedactsJSONStringLeaf — a token inlined in a Bash command
+// string inside a tool_call input is masked, and the result stays valid JSON.
+func TestRedactor_BytesRedactsJSONStringLeaf(t *testing.T) {
+	r := New(map[string]string{"LOOMCYCLE_GITEA_TOKEN": "abc123def456ghi789"}, true)
+	in := json.RawMessage(`{"command":"curl -H \"Authorization: token abc123def456ghi789\" https://gitea","timeout":30}`)
+
+	out := r.Bytes(in)
+	if !json.Valid(out) {
+		t.Fatalf("redacted Bytes output is not valid JSON: %s", out)
+	}
+	if strings.Contains(string(out), "abc123def456ghi789") {
+		t.Errorf("secret survived in JSON input: %s", out)
+	}
+	// Non-secret fields are preserved.
+	var decoded map[string]any
+	if err := json.Unmarshal(out, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["timeout"] != float64(30) {
+		t.Errorf("non-secret field mangled: %v", decoded["timeout"])
+	}
+}
+
+// TestRedactor_BytesNonJSONUnchanged — a non-JSON input is returned verbatim
+// rather than risk corrupting the persisted event.
+func TestRedactor_BytesNonJSONUnchanged(t *testing.T) {
+	r := New(map[string]string{"X_TOKEN": "knownvalue1234"}, true)
+	in := []byte("not json knownvalue1234")
+	if got := r.Bytes(in); string(got) != string(in) {
+		t.Errorf("non-JSON Bytes should pass through unchanged; got %q", got)
+	}
+}
+
+// TestRedactor_NoOp — a nil / no-op redactor leaves input untouched and reports
+// Enabled()==false so callers can skip the copy.
+func TestRedactor_NoOp(t *testing.T) {
+	var nilR *Redactor
+	if nilR.Enabled() {
+		t.Error("nil redactor should not be Enabled")
+	}
+	if got := nilR.String("Authorization: token secret"); got != "Authorization: token secret" {
+		t.Errorf("nil redactor mutated input: %q", got)
+	}
+
+	empty := New(nil, false)
+	if empty.Enabled() {
+		t.Error("empty redactor (no values, no patterns) should not be Enabled")
+	}
+	if got := empty.Bytes(json.RawMessage(`{"a":"b"}`)); string(got) != `{"a":"b"}` {
+		t.Errorf("empty redactor mutated input: %q", got)
+	}
+}


### PR DESCRIPTION
## Why

`loomcycle-experiments` recovered a **real `LOOMCYCLE_GITEA_TOKEN` verbatim** from a tracked `data/loomcycle.db` checkpoint. This is **F32, path B** (transcript leak), complementary to the def-baking fix in #406.

Agent tool I/O — tool_call inputs and tool_result outputs — was `json.Marshal`'d **verbatim** into the `events.payload` BLOB (`makeRecordingEmit`), and the same blob propagates to **snapshots** and the **`/v1/_events` audit API**. A secret inlined on a Bash cmdline (`curl -H "Authorization: token <TOKEN>"`) or echoed in a tool result was therefore stored in cleartext at rest — forever, including in freed pages, the `-wal`, and any committed/backed-up copy. The structural def-reference fix (path A, #406) **cannot** cover this: an agent can always inline a secret it fetched at runtime.

## What

New leaf package **`internal/redact`** with two tiers, both applied:

- **Tier A — exact known env-secret values (zero false positives).** The values of env vars classified secret by the new `config.IsSecretEnvName` (the documented `*_KEY` / `*_TOKEN` / `*_SECRET` / `*_AUTH` / `*_PASSWORD` / `*_CREDENTIAL` suffixes) are masked as `[redacted:NAME]`. Catches the confirmed `LOOMCYCLE_GITEA_TOKEN` repro exactly, because we redact only values we actually hold.
- **Tier B — conservative pattern heuristics.** `Authorization: token/Bearer` headers, `sk-`/`AKIA`/`xox`/`ghp_` keys, `*_API_KEY=` assignments. **Deliberately excludes bare 40-hex** (collides with git commit SHAs). Value classes exclude JSON structural chars and `[]` so Tier-A markers stay inert and `Bytes` output stays valid JSON (it walks JSON string leaves and re-marshals — never corrupts the event).

**Wired at the single events chokepoint** (`makeRecordingEmit`): redacts a **copy** of `tool_call`/`tool_result` events before `json.Marshal`, so one pass covers events + snapshots + audit. **`fwd()` still forwards the original event** — the live SSE caller is the trust boundary that already holds the secret, so its stream is untouched.

**On by default**; `LOOMCYCLE_REDACT_SECRETS=0` disables (leaves `s.redactor` nil — methods are nil-safe). Documented in `docs/CONFIGURATION.md §9c` + `.env.insecure.example`.

### Scope / non-goals
- Only the **persisted** blob is redacted, not the live SSE stream (intentional).
- Restore/replay re-persists already-stored payloads; **historical** snapshots / DB rows cannot be un-leaked (operator VACUUM + rewrite — see the finding's mitigation).
- Defense-in-depth, not a license to inline: agents should still pass secrets out-of-band (env / stdin / credential helper).

## What was tested

- `internal/redact` unit tests: exact-value mask, short-value skip, each Tier-B pattern, **git-SHA (40-hex) NOT masked**, patterns-disabled (Tier A only), JSON-leaf redaction + validity, nil/no-op redactor.
- `TestRecordingEmit_RedactsSecretInToolResult` — secret in both Text and Input masked in the persisted event; the **forwarded SSE event stays unredacted**. Verified to **fail on the un-redacted persist path** (temporarily marshaling `ev` instead of the redacted copy).
- `TestRecordingEmit_NoRedactorWhenDisabled` — opt-out persists verbatim.
- `go test ./...` clean except the pre-existing env-flaky `TestBashTimeout` (a timing test in `builtin`, unrelated; fails identically on a clean tree). Full-repo `go build ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)