### PR TITLE
style(redact): gofmt redact_test.go struct alignment

### DIFF
--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -33,10 +33,10 @@ func TestRedactor_ShortEnvValueSkipped(t *testing.T) {
 func TestRedactor_Patterns(t *testing.T) {
 	r := New(nil, true) // patterns only, no exact values
 	cases := []struct {
-		name      string
-		in        string
-		mustGo    string // substring that must be gone
-		mustStay  string // substring that must remain (structure preserved)
+		name     string
+		in       string
+		mustGo   string // substring that must be gone
+		mustStay string // substring that must remain (structure preserved)
 	}{
 		{"auth-token", `Authorization: token ghp_realtokenvalue1234567890`, "ghp_realtokenvalue1234567890", "Authorization: token"},
 		{"auth-bearer", `Authorization: Bearer sk-abc123def456ghi789jkl`, "sk-abc123def456ghi789jkl", "Authorization: Bearer"},


### PR DESCRIPTION
## Why

The `Go 1.26.x` CI job's **gofmt check** went red on `main` after #407 merged: `internal/redact/redact_test.go`'s `TestRedactor_Patterns` case struct had manually-aligned fields that gofmt re-aligns (the trailing `// comment` fields shifted the alignment column).

## What

`gofmt -w internal/redact/redact_test.go` — pure whitespace, 4 lines, no behaviour change.

## What was tested

`gofmt -l` clean; `go test ./internal/redact/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)