### PR TITLE
feat(mcp): advertise dynamic MCP tools at run start (F33)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1265,33 +1265,11 @@ func main() {
 	// would advertise the wrong tenant's MCP tools. The tenant remains
 	// authoritative (the server derived it from the principal / session /
 	// parent RunIdentity), never from the wire.
-	srv.SetDynamicToolEnumerator(func(ctx context.Context, tenant string) []tools.Tool {
-		var out []tools.Tool
-		for _, name := range dynamicMCPRegistry.NamesForTenant(tenant) {
-			// Resolve the active def with the same precedence as
-			// lookup.MCPServer: the run's tenant first, then the shared ""
-			// base. A tenant-owned name's tools come from the tenant's def;
-			// a shared name's from the "" def. A run never reads another
-			// tenant's row.
-			row, gerr := storeIface.MCPServerDefGetActive(ctx, tenant, name)
-			if gerr != nil && tenant != "" {
-				row, gerr = storeIface.MCPServerDefGetActive(ctx, "", name)
-			}
-			if gerr != nil {
-				continue
-			}
-			var def lookup.SubstrateMCPServer
-			if json.Unmarshal(row.Definition, &def) != nil {
-				continue
-			}
-			for _, dt := range def.DiscoveredTools {
-				out = append(out, mcp.NewTool(mcpPool, name, mcp.ToolDescriptor{
-					Name:        dt.Name,
-					Description: dt.Description,
-					InputSchema: dt.InputSchema,
-				}))
-			}
-		}
+	srv.SetDynamicToolEnumerator(func(ctx context.Context, tenant string, wantServers map[string]bool) []tools.Tool {
+		// F33: dynamic MCP enumeration (cached tools for every server; a
+		// bounded run-start handshake for a REFERENCED server whose cache is
+		// empty) lives in the testable mcp.DynamicToolsForRun helper.
+		out := mcp.DynamicToolsForRun(ctx, mcpPool, dynamicMCPRegistry, mcpActiveDefReader{storeIface}, tenant, wantServers, runStartMCPDiscoveryTimeout, log.Printf)
 		if cfg.Env.A2AServerEnabled {
 			resolve := func(ctx context.Context, name string) (config.A2AAgent, bool) {
 				return lookup.A2AAgent(ctx, storeIface, cfg, name)
@@ -2706,6 +2684,25 @@ func (v mcpLookupView) Get(tenantID, name string) (lookup.MCPServerSpec, bool) {
 
 func spawnStdioMCP(name string, srv config.MCPServer) (mcp.Caller, error) {
 	return spawnStdio(name, srv.Command, srv.Args, srv.Env)
+}
+
+// runStartMCPDiscoveryTimeout bounds the F33 run-start handshake of a referenced
+// dynamic MCP server whose discovered_tools cache is empty. Kept well under the
+// 30s boot-discovery budget: a run shouldn't stall long waiting on one peer, and
+// if it times out the lazy first-call fallback still applies.
+const runStartMCPDiscoveryTimeout = 10 * time.Second
+
+// mcpActiveDefReader adapts the store to mcp.ActiveDefReader (F33), returning the
+// active dynamic-MCP-server def JSON for (tenant, name). Keeps internal/tools/mcp
+// free of an internal/store import.
+type mcpActiveDefReader struct{ store store.Store }
+
+func (r mcpActiveDefReader) ActiveMCPServerDef(ctx context.Context, tenant, name string) (json.RawMessage, bool) {
+	row, err := r.store.MCPServerDefGetActive(ctx, tenant, name)
+	if err != nil {
+		return nil, false
+	}
+	return row.Definition, true
 }
 
 // spawnStdio is the transport-spawn core shared by the static yaml stdio

--- a/internal/api/http/dynamic_tools_tenant_test.go
+++ b/internal/api/http/dynamic_tools_tenant_test.go
@@ -28,8 +28,8 @@ import (
 // RFC N FIX 2-mcp: the enumerator takes the run's authoritative tenant as an
 // EXPLICIT argument (the server passes it), NOT tenantFromCtx(ctx) — matching
 // the production signature.
-func tenantAdvertisingEnumerator(reg *loommcp.DynamicRegistry, st store.Store) func(context.Context, string) []tools.Tool {
-	return func(ctx context.Context, tenant string) []tools.Tool {
+func tenantAdvertisingEnumerator(reg *loommcp.DynamicRegistry, st store.Store) func(context.Context, string, map[string]bool) []tools.Tool {
+	return func(ctx context.Context, tenant string, _ map[string]bool) []tools.Tool {
 		var out []tools.Tool
 		for _, name := range reg.NamesForTenant(tenant) {
 			row, gerr := st.MCPServerDefGetActive(ctx, tenant, name)
@@ -126,8 +126,8 @@ func TestDynamicTools_TenantScopedAdvertising(t *testing.T) {
 	ctxA := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-a", Subject: "alice"})
 	ctxB := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "tenant-b", Subject: "bob"})
 
-	namesA := toolNames(srv.candidateTools(ctxA, "tenant-a"))
-	namesB := toolNames(srv.candidateTools(ctxB, "tenant-b"))
+	namesA := toolNames(srv.candidateTools(ctxA, "tenant-a", nil))
+	namesB := toolNames(srv.candidateTools(ctxB, "tenant-b", nil))
 
 	// Tenant A sees its OWN crm tool + the shared billing tool, never B's
 	// same-name override and never B's exclusive "secret" server.
@@ -172,7 +172,7 @@ func TestDynamicTools_AdvertisesExplicitTenantWithoutPrincipalOnCtx(t *testing.T
 	// The A2A/scheduler shape: NO principal, NO RunIdentity on ctx. The run's
 	// authoritative tenant "acme" is supplied EXPLICITLY by the entry site.
 	ctx := context.Background()
-	names := toolNames(srv.candidateTools(ctx, "acme"))
+	names := toolNames(srv.candidateTools(ctx, "acme", nil))
 
 	// The run sees its OWN acme tool + the shared billing tool even though
 	// nothing on ctx names the tenant.
@@ -182,7 +182,7 @@ func TestDynamicTools_AdvertisesExplicitTenantWithoutPrincipalOnCtx(t *testing.T
 	// With an EMPTY tenant (the pre-fix ctx-derived value) the acme tool is
 	// NOT advertised — proving the explicit tenant argument, not a ctx
 	// default, is what selects the set.
-	sharedOnly := toolNames(srv.candidateTools(ctx, ""))
+	sharedOnly := toolNames(srv.candidateTools(ctx, "", nil))
 	assertHas(t, "shared(empty)", sharedOnly, "mcp__crm__acme_tool", false)
 	assertHas(t, "shared(empty)", sharedOnly, "mcp__billing__shared_tool", true)
 }

--- a/internal/api/http/dynamic_tools_test.go
+++ b/internal/api/http/dynamic_tools_test.go
@@ -27,13 +27,13 @@ func (n namedTool) Execute(context.Context, json.RawMessage) (tools.Result, erro
 func TestCandidateTools_AdvertisesDynamicTools(t *testing.T) {
 	// New auto-appends the built-in Agent tool, so the boot set is N≥1.
 	srv := New(&config.Config{}, &stubResolver{}, []tools.Tool{namedTool{"Read"}}, concurrency.New(4, 4, time.Second), nil)
-	base := len(srv.candidateTools(context.Background(), ""))
+	base := len(srv.candidateTools(context.Background(), "", nil))
 
 	// Enumerator returns a post-boot dynamic MCP tool → exactly one more.
-	srv.SetDynamicToolEnumerator(func(context.Context, string) []tools.Tool {
+	srv.SetDynamicToolEnumerator(func(context.Context, string, map[string]bool) []tools.Tool {
 		return []tools.Tool{namedTool{"mcp__jobs__getAgentContext"}}
 	})
-	cand := srv.candidateTools(context.Background(), "")
+	cand := srv.candidateTools(context.Background(), "", nil)
 	if len(cand) != base+1 {
 		t.Fatalf("with enumerator: %d candidate tools, want base+1 (%d)", len(cand), base+1)
 	}

--- a/internal/api/http/referenced_mcp_servers_test.go
+++ b/internal/api/http/referenced_mcp_servers_test.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestReferencedDynamicMCPServers covers the allowed_tools → server-set parsing
+// that scopes the F33 run-start handshake.
+func TestReferencedDynamicMCPServers(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		want     map[string]bool
+	}{
+		{"wildcard", []string{"mcp__telegram-dyn__*"}, map[string]bool{"telegram-dyn": true}},
+		{"exact-tool", []string{"mcp__gitea__send_message"}, map[string]bool{"gitea": true}},
+		{"mixed-native", []string{"Bash", "mcp__gitea__send", "Context", "mcp__gitea__list"}, map[string]bool{"gitea": true}},
+		{"two-servers", []string{"mcp__a__*", "mcp__b__x"}, map[string]bool{"a": true, "b": true}},
+		{"native-only", []string{"Bash", "Context"}, nil},
+		{"allow-all-star", []string{"*"}, nil},
+		{"a2a-peer", []string{"a2a__peer__skill"}, nil},
+		{"malformed-no-tool-seg", []string{"mcp__srv"}, nil},
+		{"malformed-empty-server", []string{"mcp____tool"}, nil},
+		{"empty", nil, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := referencedDynamicMCPServers(tc.patterns)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("referencedDynamicMCPServers(%v) = %v, want %v", tc.patterns, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -140,7 +140,11 @@ type Server struct {
 	// surfaces (A2A/scheduler/webhook/MCP spawn_run/gRPC-legacy) the ctx
 	// tenant is "" and the enumerator would advertise the wrong tenant's
 	// MCP tool set. The caller passes the run's authoritative tenant.
-	dynamicTools func(ctx context.Context, tenantID string) []tools.Tool
+	//
+	// F33: wantServers is the set of dynamic MCP servers the run references
+	// (from its allowed_tools). The enumerator advertises cached tools for all
+	// servers, but only handshakes a referenced server whose cache is empty.
+	dynamicTools func(ctx context.Context, tenantID string, wantServers map[string]bool) []tools.Tool
 
 	// systemPublisher backs the v0.8.6 POST /v1/_channels/_system/...
 	// admin endpoint. Nil = endpoint refuses every request with a
@@ -408,7 +412,13 @@ func (s *Server) SetMCPFallback(fn tools.FallbackFunc) {
 //
 // RFC N FIX 2-mcp: fn takes the run's authoritative tenant EXPLICITLY rather
 // than deriving it from ctx — see candidateTools.
-func (s *Server) SetDynamicToolEnumerator(fn func(ctx context.Context, tenantID string) []tools.Tool) {
+//
+// F33: fn also takes wantServers — the set of dynamic MCP server names this run
+// references via its allowed_tools. The enumerator advertises every server's
+// CACHED tools regardless, but only HANDSHAKES a referenced server whose cache
+// is empty, so a dynamic-MCP-only agent sees its tools at run start (not just on
+// a first call that, with nothing advertised, the model never makes).
+func (s *Server) SetDynamicToolEnumerator(fn func(ctx context.Context, tenantID string, wantServers map[string]bool) []tools.Tool) {
 	s.dynamicTools = fn
 }
 
@@ -422,17 +432,49 @@ func (s *Server) SetDynamicToolEnumerator(fn func(ctx context.Context, tenantID 
 // EXPLICITLY by the caller. The entry sites call this BEFORE WithRunIdentity
 // is stamped on ctx, so a ctx-derived tenant would be "" for non-HTTP-principal
 // spawn surfaces — and the run would advertise the wrong tenant's MCP tools.
-func (s *Server) candidateTools(ctx context.Context, tenantID string) []tools.Tool {
+//
+// F33: agentAllowed is the agent's declared allowed_tools. We derive the set of
+// dynamic MCP servers it references (referencedDynamicMCPServers) and hand it to
+// the enumerator so a referenced server with no cached tools is handshaked and
+// advertised at run start.
+func (s *Server) candidateTools(ctx context.Context, tenantID string, agentAllowed []string) []tools.Tool {
 	if s.dynamicTools == nil {
 		return s.tools
 	}
-	dyn := s.dynamicTools(ctx, tenantID)
+	dyn := s.dynamicTools(ctx, tenantID, referencedDynamicMCPServers(agentAllowed))
 	if len(dyn) == 0 {
 		return s.tools
 	}
 	out := make([]tools.Tool, 0, len(s.tools)+len(dyn))
 	out = append(out, s.tools...)
 	out = append(out, dyn...)
+	return out
+}
+
+// referencedDynamicMCPServers extracts the set of MCP server names an agent's
+// allowed_tools patterns reference, for the F33 run-start handshake. A pattern
+// of the shape `mcp__<server>__<tool>` or the wildcard `mcp__<server>__*`
+// contributes <server>; any other pattern (a native tool, a bare `*`, an
+// `a2a__…` peer) contributes nothing — those don't gate on dynamic MCP
+// discovery. The names are the SANITISED server segment as it appears in the
+// advertised tool name, so they line up with the enumerator's comparison.
+func referencedDynamicMCPServers(patterns []string) map[string]bool {
+	var out map[string]bool
+	for _, p := range patterns {
+		rest, ok := strings.CutPrefix(p, "mcp__")
+		if !ok {
+			continue
+		}
+		// server is everything up to the first "__" separating it from the tool.
+		server, _, ok := strings.Cut(rest, "__")
+		if !ok || server == "" {
+			continue
+		}
+		if out == nil {
+			out = make(map[string]bool)
+		}
+		out[server] = true
+	}
 	return out
 }
 
@@ -1536,7 +1578,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// tenant (effectiveTenantID), not the ctx tenant — WithRunIdentity
 	// isn't stamped yet, so for non-HTTP-principal spawn surfaces the ctx
 	// tenant is "" and the run would not see its OWN dynamic MCP tools.
-	allowedTools := filterTools(s.candidateTools(ctx, effectiveTenantID), agentDef.AllowedTools, in.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(ctx, effectiveTenantID, agentDef.AllowedTools), agentDef.AllowedTools, in.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if in.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -2683,7 +2725,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// vs the wire tenant), which would advertise the wrong tenant's MCP tools
 	// for an open-mode run. Consistent with the agent existence-check +
 	// resolveAgent on this path.
-	allowedTools := filterTools(s.candidateTools(r.Context(), req.TenantID), agentDef.AllowedTools, req.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(r.Context(), req.TenantID, agentDef.AllowedTools), agentDef.AllowedTools, req.AllowedTools)
 	// Per-run host narrowing for HTTP/WebFetch/WebSearch. Behaviour
 	// depends on LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE — see NarrowHosts
 	// doc comment. In caller-authoritative mode we ALWAYS call so the
@@ -3111,7 +3153,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// authoritative tenant (the same value the continuation run uses), not
 	// the ctx tenant — the ownership gate above already proved the caller
 	// is entitled to this session.
-	allowedTools := filterTools(s.candidateTools(r.Context(), sess.TenantID), agentDef.AllowedTools, body.AllowedTools)
+	allowedTools := filterTools(s.candidateTools(r.Context(), sess.TenantID, agentDef.AllowedTools), agentDef.AllowedTools, body.AllowedTools)
 	var hostPolicy tools.HostPolicyValue
 	if body.AllowedHosts != nil || s.cfg.Env.HTTPCallerAuthoritative {
 		var caller []string
@@ -3867,7 +3909,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// RFC N FIX 2-mcp: sub-agents run with the parent's RunIdentity already
 	// on ctx, so tenantFromCtx returns the run's authoritative tenant —
 	// the sub-agent advertises the same tenant's MCP tools as its parent.
-	subTools := filterTools(s.candidateTools(ctx, tenantFromCtx(ctx)), def.AllowedTools, nil)
+	subTools := filterTools(s.candidateTools(ctx, tenantFromCtx(ctx), def.AllowedTools), def.AllowedTools, nil)
 	// Inherit the parent's caller-authoritative host policy. Without
 	// this, sub-agents fall back to the operator's static
 	// HTTPHostAllowlist — which typically doesn't include localhost

--- a/internal/help/builtin/dynamic-mcp.md
+++ b/internal/help/builtin/dynamic-mcp.md
@@ -127,6 +127,31 @@ the new active row (different URL / headers). `retire` evicts the
 pool entry; in-flight calls complete, new calls get a clean
 "tool not found" error.
 
+## Advertising at run start (F33)
+
+Dispatch (above) is only half the story. For a model to *emit*
+`mcp__<server>__<tool>` as a structured call, that tool must be
+**advertised** in the run's tool spec — a Claude model only enters
+tool-calling mode when it is told ≥1 tool exists. So at run start,
+loomcycle expands the agent's `allowed_tools` against the dynamic
+registry and advertises the matching servers' tools:
+
+- A server whose def carries cached `discovered_tools` is advertised
+  straight from the cache (no handshake).
+- A **referenced** server with an **empty** cache — discovery was
+  skipped (`discover:false`) or its peer was unreachable at
+  registration — is handshaked once at run start (bounded; default 10s)
+  so its tools are advertised this run, and the pool entry is left warm
+  for the dispatch above.
+
+Without this, an agent whose `allowed_tools` is **only** a dynamic-MCP
+wildcard (e.g. `["mcp__telegram-dyn__*"]`) and that carries no native
+tool would have **zero** advertised tools: the model never enters
+tool-calling mode, emits the intended call as inert text, and the run
+silently does nothing. (The lazy resolver above stays the dispatch +
+peer-recovery path; it is no longer the *only* way a substrate MCP
+server becomes usable.)
+
 ## Operator workflow
 
 The shape is the same across the CLI, the TS adapter, the gRPC

--- a/internal/lookup/mcpserver.go
+++ b/internal/lookup/mcpserver.go
@@ -1,6 +1,8 @@
 package lookup
 
 import (
+	"encoding/json"
+
 	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
@@ -144,7 +146,13 @@ type SubstrateMCPServer struct {
 type SubstrateMCPServerTool struct {
 	Name        string `json:"name"`
 	Description string `json:"description,omitempty"`
-	// InputSchema is raw JSON — preserved verbatim to avoid double-
-	// parse on every introspection read.
-	InputSchema []byte `json:"input_schema,omitempty"`
+	// InputSchema is raw JSON — preserved verbatim to avoid double-parse on
+	// every introspection read. MUST be json.RawMessage, not a plain []byte:
+	// the stored input_schema is a JSON OBJECT, and encoding/json unmarshals a
+	// JSON object into []byte as an ERROR (it expects a base64 string), which
+	// aborts the WHOLE def unmarshal. With []byte this silently dropped every
+	// discovered tool (the def carrying any object schema failed to decode), so
+	// the run-start enumerator advertised nothing even for a fully-discovered
+	// server (F33). json.RawMessage captures the raw object verbatim.
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
 }

--- a/internal/lookup/mcpserver_test.go
+++ b/internal/lookup/mcpserver_test.go
@@ -1,12 +1,48 @@
 package lookup_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 )
+
+// TestSubstrateMCPServer_UnmarshalsObjectInputSchema is the F33 root-cause
+// regression: a stored mcp_server_def carries discovered_tools whose
+// input_schema is a JSON OBJECT. SubstrateMCPServerTool.InputSchema must be
+// json.RawMessage — a plain []byte field makes encoding/json reject the object
+// (it expects a base64 string), which aborts the WHOLE def unmarshal and leaves
+// DiscoveredTools empty, so the run-start enumerator advertised nothing even for
+// a fully-discovered server. Fails on the pre-fix []byte type.
+func TestSubstrateMCPServer_UnmarshalsObjectInputSchema(t *testing.T) {
+	const defJSON = `{"transport":"http","url":"https://x/mcp","discovered_tools":[` +
+		`{"name":"send_message","description":"send","input_schema":{"type":"object","properties":{"text":{"type":"string"}}}}]}`
+
+	var def lookup.SubstrateMCPServer
+	if err := json.Unmarshal([]byte(defJSON), &def); err != nil {
+		t.Fatalf("unmarshal failed (object input_schema must decode): %v", err)
+	}
+	if len(def.DiscoveredTools) != 1 {
+		t.Fatalf("DiscoveredTools = %d, want 1 (object input_schema dropped the tool)", len(def.DiscoveredTools))
+	}
+	got := def.DiscoveredTools[0]
+	if got.Name != "send_message" {
+		t.Errorf("tool name = %q", got.Name)
+	}
+	// The raw object schema is preserved verbatim.
+	if !json.Valid(got.InputSchema) || len(got.InputSchema) == 0 {
+		t.Fatalf("InputSchema not preserved as raw JSON: %q", got.InputSchema)
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(got.InputSchema, &schema); err != nil {
+		t.Fatalf("InputSchema is not a JSON object: %v", err)
+	}
+	if schema["type"] != "object" {
+		t.Errorf("InputSchema.type = %v, want object", schema["type"])
+	}
+}
 
 // fakeDynReg is a lookup.MCPDynamicRegistry stub for the resolver test.
 // RFC N: keyed by (tenant, name); the "" tenant is the shared registry.

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -33,10 +33,10 @@ func TestRedactor_ShortEnvValueSkipped(t *testing.T) {
 func TestRedactor_Patterns(t *testing.T) {
 	r := New(nil, true) // patterns only, no exact values
 	cases := []struct {
-		name      string
-		in        string
-		mustGo    string // substring that must be gone
-		mustStay  string // substring that must remain (structure preserved)
+		name     string
+		in       string
+		mustGo   string // substring that must be gone
+		mustStay string // substring that must remain (structure preserved)
 	}{
 		{"auth-token", `Authorization: token ghp_realtokenvalue1234567890`, "ghp_realtokenvalue1234567890", "Authorization: token"},
 		{"auth-bearer", `Authorization: Bearer sk-abc123def456ghi789jkl`, "sk-abc123def456ghi789jkl", "Authorization: Bearer"},

--- a/internal/tools/mcp/enumerate.go
+++ b/internal/tools/mcp/enumerate.go
@@ -1,0 +1,123 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/lookup"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// withTenant stamps tenant onto ctx as the RunIdentity tenant so the pool —
+// which keys its cache and its build callback off tools.RunIdentity(ctx) — dials
+// THIS run's tenant. The enumerator runs at run-creation time, BEFORE the entry
+// site stamps the full RunIdentity, so a bare ctx would otherwise carry tenant
+// "" and the handshake would dial the wrong (shared) server. Preserves any other
+// identity fields already present.
+func withTenant(ctx context.Context, tenant string) context.Context {
+	ident := tools.RunIdentity(ctx)
+	if ident.TenantID == tenant {
+		return ctx
+	}
+	ident.TenantID = tenant
+	return tools.WithRunIdentity(ctx, ident)
+}
+
+// ActiveDefReader returns the active definition JSON for a dynamic MCP server,
+// scoped to (tenant, name). Implemented by an adapter over the store in
+// cmd/loomcycle; modelled as a narrow interface so this low-level package need
+// not import internal/store. ok=false means "no active row for (tenant, name)".
+type ActiveDefReader interface {
+	ActiveMCPServerDef(ctx context.Context, tenant, name string) (def json.RawMessage, ok bool)
+}
+
+// DynamicToolsForRun enumerates the ADVERTISABLE tools for the dynamic
+// (substrate-authored) MCP servers visible to a run in `tenant`. It is the
+// run-start counterpart to the boot-time static-MCP registration loop, and the
+// fix for F33.
+//
+// Per server (reg.NamesForTenant: the tenant's own names + shared "" names):
+//   - If the active def carries cached discovered_tools → advertise them
+//     directly. No handshake — this is the fast path and stays the common case.
+//   - Else if the server is REFERENCED by this run's allowed_tools (wantServers)
+//     → handshake ONCE (bounded by handshakeTimeout) via the pool to fetch
+//     tools/list, advertise the result, and leave the pool entry warm for the
+//     subsequent Execute. This is F33: a dynamic server whose discovery was
+//     best-effort-skipped or failed at registration (an unreachable peer, a
+//     `discover:false` create, or a def that exceeded the size cap) otherwise
+//     advertises ZERO tools, so an agent whose allowed_tools is only that
+//     server's wildcard never enters tool-calling mode and emits its call as
+//     inert text.
+//   - Else (empty cache AND not referenced) → skip. We never handshake a server
+//     the run does not use, so a single down peer can't slow every run.
+//
+// wantServers holds the SANITISED server names the run references (see
+// sanitiseServerName) so it lines up with the advertised tool-name segment.
+// A nil/empty wantServers disables the F33 handshake path (cache-only) — the
+// exact pre-fix behaviour, which keeps cache-only callers unchanged.
+//
+// Best-effort throughout: a store miss, an unmarshal error, or a failed
+// handshake drops that one server and continues; the run still gets every other
+// server's tools. logf may be nil.
+func DynamicToolsForRun(
+	ctx context.Context,
+	pool *Pool,
+	reg *DynamicRegistry,
+	reader ActiveDefReader,
+	tenant string,
+	wantServers map[string]bool,
+	handshakeTimeout time.Duration,
+	logf func(string, ...any),
+) []tools.Tool {
+	if pool == nil || reg == nil || reader == nil {
+		return nil
+	}
+	var out []tools.Tool
+	for _, name := range reg.NamesForTenant(tenant) {
+		// Resolve the active def with the same precedence as lookup.MCPServer:
+		// the run's tenant first, then the shared "" base.
+		raw, ok := reader.ActiveMCPServerDef(ctx, tenant, name)
+		if !ok && tenant != "" {
+			raw, ok = reader.ActiveMCPServerDef(ctx, "", name)
+		}
+		if !ok {
+			continue
+		}
+		var def lookup.SubstrateMCPServer
+		if err := json.Unmarshal(raw, &def); err != nil {
+			continue
+		}
+		if len(def.DiscoveredTools) > 0 {
+			for _, dt := range def.DiscoveredTools {
+				out = append(out, NewTool(pool, name, ToolDescriptor{
+					Name:        dt.Name,
+					Description: dt.Description,
+					InputSchema: dt.InputSchema,
+				}))
+			}
+			continue
+		}
+		// F33: empty cache. Only pay the handshake cost for a server this run
+		// actually references.
+		if !wantServers[sanitiseServerName(name)] {
+			continue
+		}
+		hsCtx, cancel := context.WithTimeout(withTenant(ctx, tenant), handshakeTimeout)
+		_, descs, err := pool.Get(hsCtx, name)
+		cancel()
+		if err != nil {
+			if logf != nil {
+				logf("mcp[%s]: run-start discovery failed: %v — agent references it but no tools advertised this run (lazy first-call fallback still applies)", name, err)
+			}
+			continue
+		}
+		for _, d := range descs {
+			out = append(out, NewTool(pool, name, d))
+		}
+		if logf != nil {
+			logf("mcp[%s]: run-start discovery advertised %d tool(s) (F33: referenced server had no cached tools)", name, len(descs))
+		}
+	}
+	return out
+}

--- a/internal/tools/mcp/enumerate_test.go
+++ b/internal/tools/mcp/enumerate_test.go
@@ -1,0 +1,154 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
+)
+
+// fakeDefReader is an in-memory mcp.ActiveDefReader keyed by tenant+"/"+name.
+type fakeDefReader struct{ defs map[string]json.RawMessage }
+
+func (f fakeDefReader) ActiveMCPServerDef(_ context.Context, tenant, name string) (json.RawMessage, bool) {
+	d, ok := f.defs[tenant+"/"+name]
+	return d, ok
+}
+
+func regWith(specs ...mcp.DynamicMCPServerSpec) *mcp.DynamicRegistry {
+	r := mcp.NewDynamicRegistry()
+	for _, s := range specs {
+		r.Set(s)
+	}
+	return r
+}
+
+// TestDynamicToolsForRun_CacheAdvertisedWithoutHandshake — a server whose def
+// carries discovered_tools is advertised straight from cache; the pool is never
+// dialed (the build callback here would fail if it were).
+func TestDynamicToolsForRun_CacheAdvertisedWithoutHandshake(t *testing.T) {
+	built := false
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		built = true
+		return nil, errors.New("handshake must not happen on the cache path")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	reg := regWith(mcp.DynamicMCPServerSpec{TenantID: "", Name: "telegram", Transport: "stdio"})
+	reader := fakeDefReader{defs: map[string]json.RawMessage{
+		"/telegram": json.RawMessage(`{"transport":"stdio","discovered_tools":[{"name":"send_message","description":"send","input_schema":{"type":"object"}}]}`),
+	}}
+
+	// wantServers nil: cache path does not depend on the reference set.
+	out := mcp.DynamicToolsForRun(context.Background(), pool, reg, reader, "", nil, time.Second, nil)
+	if len(out) != 1 {
+		t.Fatalf("want 1 advertised tool, got %d", len(out))
+	}
+	if got, want := out[0].Name(), "mcp__telegram__send_message"; got != want {
+		t.Errorf("tool name = %q, want %q", got, want)
+	}
+	if built {
+		t.Error("pool was dialed on the cache path — should advertise from discovered_tools only")
+	}
+}
+
+// TestDynamicToolsForRun_HandshakesReferencedEmptyCache is the F33 regression:
+// a referenced server with an EMPTY discovered_tools cache is handshaked at run
+// start and its tools advertised. On the pre-F33 enumerator this server
+// contributed zero tools, so an agent referencing only it saw nothing.
+func TestDynamicToolsForRun_HandshakesReferencedEmptyCache(t *testing.T) {
+	pool := newPoolWithFake(t, "ok") // fake exposes one tool: web_search
+
+	reg := regWith(mcp.DynamicMCPServerSpec{TenantID: "", Name: "search", Transport: "stdio"})
+	reader := fakeDefReader{defs: map[string]json.RawMessage{
+		"/search": json.RawMessage(`{"transport":"stdio"}`), // no discovered_tools → empty cache
+	}}
+
+	want := map[string]bool{"search": true} // agent's allowed_tools referenced mcp__search__*
+	out := mcp.DynamicToolsForRun(context.Background(), pool, reg, reader, "", want, 5*time.Second, nil)
+	if len(out) != 1 {
+		t.Fatalf("want 1 handshaked+advertised tool, got %d", len(out))
+	}
+	if got, want := out[0].Name(), "mcp__search__web_search"; got != want {
+		t.Errorf("tool name = %q, want %q", got, want)
+	}
+}
+
+// TestDynamicToolsForRun_SkipsUnreferencedEmptyCache — an empty-cache server the
+// run does NOT reference is never handshaked (so one down peer can't slow every
+// run). Proven by a build callback that records whether it was dialed.
+func TestDynamicToolsForRun_SkipsUnreferencedEmptyCache(t *testing.T) {
+	dialed := false
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		dialed = true
+		return nil, errors.New("should not be dialed for an unreferenced server")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	reg := regWith(mcp.DynamicMCPServerSpec{TenantID: "", Name: "search", Transport: "stdio"})
+	reader := fakeDefReader{defs: map[string]json.RawMessage{
+		"/search": json.RawMessage(`{"transport":"stdio"}`), // empty cache
+	}}
+
+	// wantServers empty → server is not referenced by the run.
+	out := mcp.DynamicToolsForRun(context.Background(), pool, reg, reader, "", nil, time.Second, nil)
+	if len(out) != 0 {
+		t.Fatalf("want 0 tools for an unreferenced empty-cache server, got %d", len(out))
+	}
+	if dialed {
+		t.Error("pool was dialed for an unreferenced server — F33 handshake must be scoped to referenced servers")
+	}
+}
+
+// TestDynamicToolsForRun_HandshakeDialsRunTenant guards the tenant stamp: the
+// enumerator runs before RunIdentity is on ctx, so the handshake must stamp the
+// EXPLICIT run tenant onto the pool ctx — otherwise pool.Get would dial the
+// shared ("") server instead of the tenant's own. We assert the pool's build
+// callback is invoked with the run's tenant.
+func TestDynamicToolsForRun_HandshakeDialsRunTenant(t *testing.T) {
+	var gotTenant string
+	pool := mcp.NewPool(
+		func(tenant, _ string) (mcp.Caller, error) {
+			gotTenant = tenant
+			return nil, errors.New("stop after recording tenant")
+		},
+		nil,
+		func(ctx context.Context) string { return tools.RunIdentity(ctx).TenantID },
+	)
+	t.Cleanup(pool.Close)
+
+	reg := regWith(mcp.DynamicMCPServerSpec{TenantID: "acme", Name: "search", Transport: "stdio"})
+	reader := fakeDefReader{defs: map[string]json.RawMessage{
+		"acme/search": json.RawMessage(`{"transport":"stdio"}`), // empty cache
+	}}
+
+	// ctx has NO RunIdentity (run-creation time); the explicit tenant must win.
+	mcp.DynamicToolsForRun(context.Background(), pool, reg, reader, "acme", map[string]bool{"search": true}, time.Second, nil)
+	if gotTenant != "acme" {
+		t.Errorf("handshake dialed tenant %q, want %q (tenant stamp missing)", gotTenant, "acme")
+	}
+}
+
+// TestDynamicToolsForRun_ReferencedHandshakeFailsGracefully — a referenced
+// server whose handshake fails (peer down) advertises nothing and does not
+// error the enumeration; other servers still resolve.
+func TestDynamicToolsForRun_ReferencedHandshakeFailsGracefully(t *testing.T) {
+	pool := mcp.NewPool(func(_, _ string) (mcp.Caller, error) {
+		return nil, errors.New("peer down")
+	}, nil, nil)
+	t.Cleanup(pool.Close)
+
+	reg := regWith(mcp.DynamicMCPServerSpec{TenantID: "", Name: "down", Transport: "stdio"})
+	reader := fakeDefReader{defs: map[string]json.RawMessage{
+		"/down": json.RawMessage(`{"transport":"stdio"}`),
+	}}
+
+	out := mcp.DynamicToolsForRun(context.Background(), pool, reg, reader, "", map[string]bool{"down": true}, time.Second, nil)
+	if len(out) != 0 {
+		t.Fatalf("want 0 tools when the referenced peer is down, got %d", len(out))
+	}
+}


### PR DESCRIPTION
## Why

`loomcycle-experiments` F33: a **dynamic-MCP-only agent** — `allowed_tools` is just `mcp__<server>__*` with no native tool — cannot invoke its tools. With nothing advertised in the run's tool spec, the model never enters tool-calling mode, emits the intended call as inert **text**, and the run completes having done nothing while reporting success. (exp4's `advisor → Telegram` leg sent nothing until a `Context` tool was added as a crutch.)

Root-causing on current `main` surfaced **two** distinct bugs — the experiment's "lazy.go doesn't advertise" framing had missed the run-start enumerator (shipped in #347, v0.20.0), which was *supposed* to advertise but didn't:

1. **The enumerator never advertised cached tools at all.** `lookup.SubstrateMCPServerTool.InputSchema` was a plain `[]byte`. A real `discovered_tools` entry's `input_schema` is a JSON **object**, and `encoding/json` rejects an object into `[]byte` (it expects a base64 string) — which aborts the **whole** def unmarshal. So the enumerator hit `if err != nil { continue }` and advertised **zero** tools for every fully-discovered server. Invisible because the only test used schema-less `discovered_tools`.
2. **No run-start handshake for an empty cache.** Even with #1 fixed, a server whose discovery was best-effort-skipped (`discover:false`) or whose peer was down at registration has an empty `discovered_tools` cache, so it still advertises nothing.

## What

Two commits:

- **`fix(lookup)`** — `SubstrateMCPServerTool.InputSchema` → `json.RawMessage` (captures the raw object verbatim). This alone makes a fully-discovered dynamic server advertise from cache.
- **`feat(mcp)`** — new testable helper `mcp.DynamicToolsForRun`: per server visible to the run, advertise cached `discovered_tools` (fast path); for a server the run **references** whose cache is **empty**, handshake **once** (bounded, default 10s) via the pool to load `tools/list`, advertise the result, and leave the pool entry warm for dispatch. An **unreferenced** server is never handshaked, so one down peer can't slow every run. `candidateTools` derives the referenced-server set from the agent's `allowed_tools` (`referencedDynamicMCPServers`) and threads it through the `dynamicTools` enumerator; `main.go`'s closure delegates the MCP half to the helper (keeping `internal/api/http` free of an `internal/tools/mcp` import via the injected func + a narrow `ActiveDefReader`), then appends A2A.

The existing **lazy first-call resolver stays** the dispatch + peer-recovery path — it's just no longer the *only* way a substrate MCP server becomes usable.

**Self-review caught a tenant bug:** the enumerator runs *before* `WithRunIdentity` is stamped, and the pool keys off `tools.RunIdentity(ctx).TenantID`, so a naïve `pool.Get(ctx, …)` would dial the shared (`""`) server. Fixed by stamping the explicit run tenant onto the handshake ctx; guarded by a test.

## What was tested

- `internal/lookup`: `TestSubstrateMCPServer_UnmarshalsObjectInputSchema` — fails on the old `[]byte` (`cannot unmarshal object into … []uint8`), passes on `json.RawMessage` (verified by reverting).
- `internal/tools/mcp`: `TestDynamicToolsForRun_{CacheAdvertisedWithoutHandshake, HandshakesReferencedEmptyCache, SkipsUnreferencedEmptyCache, HandshakeDialsRunTenant, ReferencedHandshakeFailsGracefully}` (the tenant guard verified failing without the stamp).
- `internal/api/http`: `TestReferencedDynamicMCPServers` (allowed_tools → server-set parsing); existing `TestCandidateTools…` / tenant-isolation tests updated to the new signature and green.
- `go test ./...` clean except the pre-existing env-flaky `TestBashTimeout` (timing test in `builtin`, unrelated). Full-repo `go build ./...` green; gofmt clean.

Manual e2e against a live MCP peer (register a notifier agent with only `mcp__server__*`, confirm the tool is advertised and called) is the remaining check; the unit suite covers the cache/handshake/tenant/scoping/failure paths.

> Note: includes a one-line carry of the #408 gofmt fix to `redact_test.go` so this branch's CI gofmt check is green independently (no-op once #408 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)