### PR TITLE
fix(mcp): apply spawn_run timeout to the HTTP transport (G1)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1915,6 +1915,17 @@ func main() {
 			})
 		log.Printf("dynamic_agents: sweeper enabled (interval=%s)", cfg.Env.DynamicAgentSweepInterval)
 	}
+	// Optional operator default for the spawn_run transport timeout
+	// (RFC P). 0/unset → disabled (defer to the run's own budget).
+	// Read outside the mcpMode block: the HTTP MCP transport below is
+	// always wired (both server and mcp modes) and the RFC R thin client
+	// (`mcp --upstream`) proxies to it, so it needs the same bound.
+	mcpSpawnRunTimeoutMS := 0
+	if v := os.Getenv("LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS"); v != "" {
+		if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
+			mcpSpawnRunTimeoutMS = n
+		}
+	}
 	if mcpMode {
 		// Optional operator override for the stdio dispatch concurrency
 		// cap (RFC O). 0/unset → the package default (16).
@@ -1922,14 +1933,6 @@ func main() {
 		if v := os.Getenv("LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS"); v != "" {
 			if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
 				mcpMaxConcurrentCalls = n
-			}
-		}
-		// Optional operator default for the spawn_run transport timeout
-		// (RFC P). 0/unset → disabled (defer to the run's own budget).
-		mcpSpawnRunTimeoutMS := 0
-		if v := os.Getenv("LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS"); v != "" {
-			if n, perr := strconv.Atoi(v); perr == nil && n > 0 {
-				mcpSpawnRunTimeoutMS = n
 			}
 		}
 		mcpSrv := lcmcp.New(lcmcp.Config{
@@ -1972,6 +1975,16 @@ func main() {
 		Logf:          log.Printf,
 		ServerName:    "loomcycle",
 		ServerVersion: buildVersion,
+		// RFC P spawn_run timeout must apply to the HTTP transport too —
+		// the RFC R thin client (`mcp --upstream`) proxies to /v1/_mcp, so
+		// without this the now-recommended topology would have no spawn_run
+		// bound (the exp3 wedge class, one layer up). MaxConcurrentCalls is
+		// intentionally NOT passed: it builds the stdio Serve loop's
+		// semaphore and is meaningless here — the HTTP transport is already
+		// per-request concurrent at the http.Server level, and run
+		// concurrency is bounded downstream by the runtime semaphore +
+		// per-tenant fairness.
+		SpawnRunTimeoutMS: mcpSpawnRunTimeoutMS,
 	})
 	srv.SetMCPHTTPHandler(mcpHTTPHandler)
 	// Background session sweeper. Reuses the dynamic-agent sweeper

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -26,9 +26,24 @@ import (
 // signal we want.
 type httpMockConnector struct {
 	cancelCalls atomic.Int32
+	// spawnGate, when non-nil, makes SpawnRun block until the gate is
+	// closed or the context is cancelled — used by the RFC P transport
+	// timeout test to model a run that never finishes. When nil (the
+	// default for every other test), SpawnRun returns immediately.
+	spawnGate chan struct{}
 }
 
-func (m *httpMockConnector) SpawnRun(context.Context, connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+func (m *httpMockConnector) SpawnRun(ctx context.Context, _ connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
+	if m.spawnGate != nil {
+		// Honor the context so the RFC P WithTimeout cancellation actually
+		// unblocks the call — mirrors a real connector that propagates ctx
+		// into the run loop.
+		select {
+		case <-m.spawnGate:
+		case <-ctx.Done():
+			return connector.SpawnRunResult{}, ctx.Err()
+		}
+	}
 	return connector.SpawnRunResult{
 		AgentID: "a_http", RunID: "r_http", SessionID: "s_http", Status: "completed",
 	}, nil
@@ -541,5 +556,69 @@ func TestHTTPTransport_SpawnRunWithoutOptIn_ReturnsJSONNotSSE(t *testing.T) {
 	var env loommcp.Response
 	if err := json.Unmarshal(body, &env); err != nil {
 		t.Errorf("response body not JSON-RPC: %v body=%s", err, body)
+	}
+}
+
+// TestHTTPTransport_SpawnRunOperatorTimeout is the HTTP-transport mirror
+// of TestServer_SpawnRunOperatorTimeout (stdio): the operator default
+// (Config.SpawnRunTimeoutMS) must bound a spawn_run on the HTTP path too.
+// This matters because the RFC R thin client (`mcp --upstream`) proxies
+// to /v1/_mcp — the HTTP transport IS the now-recommended topology's
+// spawn_run path. The stdio path had this coverage; the HTTP path did
+// not, which is how G1 (main.go's NewHTTPHandler call dropping
+// SpawnRunTimeoutMS, leaving --upstream spawn_run unbounded — the exp3
+// wedge class one layer up) shipped unnoticed. The connector gate is
+// never closed, so without an effective transport timeout this call
+// blocks forever and the test hangs.
+func TestHTTPTransport_SpawnRunOperatorTimeout(t *testing.T) {
+	mc := &httpMockConnector{spawnGate: make(chan struct{})} // never closed
+	h := NewHTTPHandler(Config{
+		Connector:         mc,
+		Logf:              func(string, ...any) {},
+		ServerName:        "loomcycle-test",
+		ServerVersion:     "v-test",
+		SpawnRunTimeoutMS: 120,
+	})
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	// initialize → session ID. No runEvents opt-in and no Runner wired,
+	// so spawn_run takes the blocking Connector.SpawnRun path (the gate).
+	resp, body := postFrame(t, ts.URL, "",
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`)
+	if resp.StatusCode != 200 {
+		t.Fatalf("initialize status=%d body=%s", resp.StatusCode, body)
+	}
+	sessionID := resp.Header.Get("Mcp-Session-Id")
+
+	// spawn_run with NO per-call timeout_ms — only the operator default
+	// can bound it. Use a client deadline well above the 120ms operator
+	// timeout: if the fix regresses (timeout not applied), the gate blocks
+	// forever and the client deadline gives a clean, fast failure instead
+	// of hanging until the go-test global timeout.
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"x","segments":[]}}}`))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("spawn_run POST failed (operator timeout not applied? gate blocks forever): %v", err)
+	}
+	body, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("spawn_run status=%d body=%s", resp.StatusCode, body)
+	}
+	var env loommcp.Response
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("response body not JSON-RPC: %v body=%s", err, body)
+	}
+	got := decodeSpawnResult(t, env)
+	if got.Status != "timeout" {
+		t.Fatalf("spawn_run status = %q; want \"timeout\" (operator default on HTTP transport)", got.Status)
 	}
 }


### PR DESCRIPTION
## Why

This is the **P0** fix from the post-experiment architecture review (finding **G1**).

The RFC P spawn_run transport timeout (`Config.SpawnRunTimeoutMS`, env `LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS`) bounds how long a `spawn_run` MCP call may block before loomcycle cancels the run and returns a structured `status:"timeout"` rather than hanging — the direct mitigation for the exp3 "wedged session" class (F17 head-of-line blocking + F15 cross-process interruption).

The package (`internal/api/mcp/http_transport.go` → disposable `&Server{cfg: h.cfg}` → `handlers.go handleSpawnRun`) threads `cfg.SpawnRunTimeoutMS` correctly on **both** transports. But `cmd/loomcycle/main.go`'s `NewHTTPHandler(Config{...})` call literal **dropped the field** — only the stdio `New()` call carried it.

Result: the HTTP transport (`/v1/_mcp`) had **no** spawn_run bound. And since the RFC R thin client (`loomcycle mcp --upstream`) proxies to `/v1/_mcp`, the *now-recommended* topology was exactly the one left unprotected — a held/stalled/long `spawn_run` could block the call indefinitely, one layer up from where RFC P was supposed to stop it.

## What

- Hoist the `LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS` env read **out of** the `if mcpMode {` block. The HTTP handler is wired in *both* `server` and `mcp` modes (outside that block), so the variable must be in scope at both call sites.
- Pass `SpawnRunTimeoutMS: mcpSpawnRunTimeoutMS` to `NewHTTPHandler`.
- `MaxConcurrentCalls` is intentionally **not** passed to the HTTP handler — it only builds the stdio `Serve` loop's semaphore (read solely in the stdio read loop). The HTTP transport is already per-request concurrent at the `http.Server` level, and run concurrency is bounded downstream by the runtime semaphore + per-tenant fairness. (Verified in review.)

No wire-protocol or schema change; runtime-only. No `@loomcycle/client` / jobs-search-agent bump needed.

## What was tested

- **New regression test** `TestHTTPTransport_SpawnRunOperatorTimeout` (mirrors the existing stdio `TestServer_SpawnRunOperatorTimeout`). The HTTP path had **no** operator-default-timeout coverage — that gap is how the dropped field shipped unnoticed. A gated `httpMockConnector.SpawnRun` (ctx-honoring) models a never-finishing run; the test asserts the operator default yields `status:"timeout"`.
- **Fail-before verified**: with the timeout dropped (`SpawnRunTimeoutMS: 0`, the G1 condition) the gated call blocks forever and the test fails fast at a 5s client deadline with `spawn_run POST failed (operator timeout not applied? gate blocks forever)` — not a go-test global-timeout hang. With the field set it passes in 0.12s.
- `go build ./...`, `go test ./...` clean. `gofmt`/`go vet` clean.
- Independent code review (scope hoist correct; `MaxConcurrentCalls` omission justified; gate mechanics + ctx-cancellation path sound; `spawnGate` nil-default leaves all other tests unaffected; env-parsing consistent with the repo's other knobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)