### PR TITLE
feat(agentdef): hash channels/interruption/evaluation_scopes (F14)

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -106,6 +106,12 @@ type Agent struct {
 	// "submit_descendants" / "submit_any" / "read_any". Empty =
 	// default-deny.
 	EvaluationScopes []string
+	// Interruption is the v0.8.16 Interruption-tool ACL (enabled / kinds /
+	// max_pending). Mirrors config.AgentDef.Interruption. Carried here (F14)
+	// so an MD-declared `interruption:` block round-trips to config at boot
+	// AND the `hash agent` CLI computes the SAME content_sha256 as the
+	// substrate (which hashes interruption). Zero value = disabled.
+	Interruption AgentInterruptionACL
 	// Path is the absolute path of the source MD, kept for diagnostic
 	// logging (skills/loader.go follows the same convention).
 	Path string
@@ -113,9 +119,25 @@ type Agent struct {
 
 // AgentChannelACL mirrors config.AgentChannelACL locally so this
 // package doesn't import config. The merger in config converts.
+//
+// json: tags are LOAD-BEARING for the content_sha256 (F14): the
+// AgentContent hash includes channels, and the substrate read path
+// (FromOverlay) unmarshals the persisted snake_case JSON into this type.
+// Without the tags the hash would key on capitalized field names and
+// diverge from the substrate write path.
 type AgentChannelACL struct {
-	Publish   []string `yaml:"publish"`
-	Subscribe []string `yaml:"subscribe"`
+	Publish   []string `json:"publish,omitempty"   yaml:"publish"`
+	Subscribe []string `json:"subscribe,omitempty" yaml:"subscribe"`
+}
+
+// AgentInterruptionACL mirrors config.AgentInterruptionACL locally so this
+// package doesn't import config. json: tags mirror the snake_case the
+// substrate persists (F14 — see AgentChannelACL for why they're
+// load-bearing for the content hash).
+type AgentInterruptionACL struct {
+	Enabled    bool     `json:"enabled,omitempty"     yaml:"enabled"`
+	Kinds      []string `json:"kinds,omitempty"       yaml:"kinds"`
+	MaxPending int      `json:"max_pending,omitempty" yaml:"max_pending"`
 }
 
 // TierCandidate mirrors config.TierCandidate's shape locally so this
@@ -259,6 +281,7 @@ type frontmatter struct {
 	AgentDefScopes        []string                   `yaml:"agent_def_scopes"`
 	SkillDefScopes        []string                   `yaml:"skill_def_scopes"`
 	EvaluationScopes      []string                   `yaml:"evaluation_scopes"`
+	Interruption          AgentInterruptionACL       `yaml:"interruption"` // F14: round-trips like channels
 	SystemPromptFile      string                     `yaml:"system_prompt_file"`
 	// SystemPrompt as an inline frontmatter field is intentionally
 	// NOT supported. The body of the MD is the prompt; if you want a
@@ -326,6 +349,7 @@ func parseAgent(raw []byte) (*Agent, error) {
 	a.AgentDefScopes = fm.AgentDefScopes
 	a.SkillDefScopes = fm.SkillDefScopes
 	a.EvaluationScopes = fm.EvaluationScopes
+	a.Interruption = fm.Interruption
 	a.SystemPromptFile = fm.SystemPromptFile
 	a.SystemPrompt = body
 

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -13,26 +13,33 @@
 // What gets hashed (content-only — NOT metadata or identity):
 //
 //	name, description, system_prompt, allowed_tools, skills, model,
-//	provider, tier, effort, max_tokens, max_iterations, providers,
-//	models, memory_scopes, memory_quota_bytes
+//	provider, tier, effort, max_tokens, max_iterations,
+//	max_concurrent_children, code_body, providers, models, memory_scopes,
+//	memory_quota_bytes, memory_backend, channels, evaluation_scopes,
+//	interruption
 //
 // Explicitly excluded (would defeat the "did the content change?"
 // question): def_id, version, parent_def_id, created_at,
 // created_by_agent_id, created_by_run_id, retired,
 // bootstrapped_from_static.
 //
-// Also explicitly excluded — fields that exist on the YAML-loader
-// Agent struct but DO NOT round-trip through `AgentDef set` (the
-// substrate overlay → mergedDef → JSONB persistence path):
+// Also excluded — the *tool-capability* ACLs that gate which substrate
+// tools an agent may CALL but are NOT part of its authored definition:
 //
-//	channels, agent_def_scopes, skill_def_scopes, evaluation_scopes
+//	agent_def_scopes, skill_def_scopes
 //
-// These are operator-yaml-only ACL declarations resolved at boot;
-// the in-DB agent_defs row never stores them. If we hashed them in,
-// a YAML-loaded agent and the same agent pushed via the substrate
-// would hash differently and the bundle-vs-deployed comparison would
-// always falsely report drift. The hash basis MUST match the closed
-// set of fields that round-trip both paths.
+// These are operator-yaml-only declarations resolved at boot; the in-DB
+// agent_defs row never stores them, so hashing them would make a
+// YAML-loaded agent and the same agent pushed via the substrate diverge.
+//
+// F14 (channels / evaluation_scopes / interruption): these three WERE
+// excluded for the same round-trip reason, but they now DO round-trip
+// through `AgentDef set` (mergedDef → agent_defs.definition JSONB) and
+// through the MD loader (agents.Agent), so they are part of the hash on
+// BOTH paths. The hash basis MUST match the closed set of fields that
+// round-trip both paths — and these three now do. Empty values still
+// omit (pointer/omitempty + normalize collapse), so every pre-F14 row
+// without these fields hashes byte-identically.
 //
 // Canonical encoding rules:
 //   - Go's encoding/json renders struct fields in declaration order
@@ -73,6 +80,15 @@ import (
 // version on every existing row + re-running the backfill.
 type AgentContent struct {
 	AllowedTools []string `json:"allowed_tools,omitempty"`
+	// Channels is the Channel-tool ACL (F14). Pointer + omitempty so an
+	// agent without a channels block omits the key entirely — an empty
+	// AgentChannelACL is a VALUE struct that would serialise as
+	// `"channels":{}` and change every pre-F14 row's hash; normalize()
+	// collapses an all-empty pointer back to nil so both the
+	// no-channels-agent and the substrate-read path (`"channels":{}` in the
+	// persisted def) hash identically to before. Tag "channels" sorts
+	// between allowed_tools and code_body.
+	Channels *AgentChannelACL `json:"channels,omitempty"`
 	// CodeBody is the inline code-js orchestrator source (RFC J). Empty
 	// for every LLM agent and for filesystem-backed static code agents
 	// (whose body lives on disk, not in the definition) — so with
@@ -81,9 +97,15 @@ type AgentContent struct {
 	// whitespace/CRLF is semantically load-bearing and must match the
 	// operator's `loomcycle hash agent` CI. Tag "code_body" sorts between
 	// allowed_tools and description, preserving the alphabetical order.
-	CodeBody              string                     `json:"code_body,omitempty"`
-	Description           string                     `json:"description,omitempty"`
-	Effort                string                     `json:"effort,omitempty"`
+	CodeBody    string `json:"code_body,omitempty"`
+	Description string `json:"description,omitempty"`
+	Effort      string `json:"effort,omitempty"`
+	// EvaluationScopes / Interruption are the remaining interactive/
+	// multi-agent ACL fields (F14). evaluation_scopes is a slice (nil →
+	// omitted); interruption is a pointer for the same empty-struct reason
+	// as Channels above. Tags sort between effort and max_concurrent_children.
+	EvaluationScopes      []string                   `json:"evaluation_scopes,omitempty"`
+	Interruption          *AgentInterruptionACL      `json:"interruption,omitempty"`
 	MaxConcurrentChildren int                        `json:"max_concurrent_children,omitempty"`
 	MaxIterations         int                        `json:"max_iterations,omitempty"`
 	MaxTokens             int                        `json:"max_tokens,omitempty"`
@@ -147,6 +169,23 @@ func normalize(c *AgentContent) {
 	if len(c.Models) == 0 {
 		c.Models = nil
 	}
+	if len(c.EvaluationScopes) == 0 {
+		c.EvaluationScopes = nil
+	}
+	// F14: collapse an all-empty channels/interruption pointer to nil so it
+	// omits. CRITICAL for backward-compat + path convergence: a no-channels
+	// agent (signFromMergedDef passes nil OR an empty struct) and the
+	// substrate-read path (FromOverlay unmarshals `"channels":{}` from the
+	// persisted def into a non-nil &{}) must both collapse to nil → no
+	// "channels" key → byte-identical to every pre-F14 row. Only an agent
+	// that actually sets publish/subscribe (or an interruption field)
+	// contributes to the hash.
+	if c.Channels != nil && len(c.Channels.Publish) == 0 && len(c.Channels.Subscribe) == 0 {
+		c.Channels = nil
+	}
+	if c.Interruption != nil && !c.Interruption.Enabled && len(c.Interruption.Kinds) == 0 && c.Interruption.MaxPending == 0 {
+		c.Interruption = nil
+	}
 
 	// Trim + normalise the system_prompt to insulate the hash from
 	// editor drift (Windows line endings, trailing blank lines).
@@ -166,14 +205,19 @@ func normalizeText(s string) string {
 }
 
 // FromYAMLAgent builds an AgentContent from a parsed *Agent (boot-time
-// load + CLI `hash agent` subcommand path). Fields that do NOT round-
-// trip through `AgentDef set` (Path, Channels, *Scopes) are omitted —
-// see the package doc for why.
+// load + CLI `hash agent` subcommand path). F14: channels /
+// evaluation_scopes / interruption now DO round-trip through `AgentDef
+// set` (they live in mergedDef → the agent_defs.definition JSONB), so they
+// are part of the hash on both paths. The *Scopes ACLs
+// (agent_def_scopes / skill_def_scopes) and Path still do not round-trip
+// and stay excluded — see the package doc. The channels/interruption
+// pointers are nil when empty so a no-ACL agent hashes exactly as before
+// (normalize() also collapses an all-empty pointer defensively).
 func FromYAMLAgent(a *Agent) AgentContent {
 	if a == nil {
 		return AgentContent{}
 	}
-	return AgentContent{
+	c := AgentContent{
 		Name:                  a.Name,
 		Description:           a.Description,
 		Provider:              a.Provider,
@@ -192,7 +236,15 @@ func FromYAMLAgent(a *Agent) AgentContent {
 		MemoryScopes:          a.MemoryScopes,
 		MemoryQuotaBytes:      a.MemoryQuotaBytes,
 		MemoryBackend:         a.MemoryBackend,
+		EvaluationScopes:      a.EvaluationScopes,
 	}
+	if len(a.Channels.Publish) > 0 || len(a.Channels.Subscribe) > 0 {
+		c.Channels = &AgentChannelACL{Publish: a.Channels.Publish, Subscribe: a.Channels.Subscribe}
+	}
+	if a.Interruption.Enabled || len(a.Interruption.Kinds) > 0 || a.Interruption.MaxPending != 0 {
+		c.Interruption = &AgentInterruptionACL{Enabled: a.Interruption.Enabled, Kinds: a.Interruption.Kinds, MaxPending: a.Interruption.MaxPending}
+	}
+	return c
 }
 
 // FromOverlay parses a JSON overlay (the structured form `AgentDef set` /

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -194,32 +194,93 @@ func TestFromYAMLAgent_DropsPath(t *testing.T) {
 	}
 }
 
-func TestFromYAMLAgent_ChannelACLIgnored(t *testing.T) {
-	// Channels live in operator yaml + don't round-trip through
-	// AgentDef set; they MUST NOT contribute to the hash. Otherwise a
-	// YAML-loaded agent and the same agent pushed via the substrate
-	// would diverge.
+func TestFromYAMLAgent_ChannelsAffectHash(t *testing.T) {
+	// F14: channels now round-trip through AgentDef set (mergedDef → JSONB),
+	// so they ARE content-identifying — a fork that adds a channel ACL must
+	// get a distinct hash, not be deduped as the parent.
 	bare := FromYAMLAgent(&Agent{Name: "x"})
 	withChannels := FromYAMLAgent(&Agent{
 		Name:     "x",
 		Channels: AgentChannelACL{Publish: []string{"out"}, Subscribe: []string{"in"}},
 	})
-	if Sign(bare) != Sign(withChannels) {
-		t.Error("channel ACL leaked into hash — bundle vs deployed comparison would falsely report drift")
+	if Sign(bare) == Sign(withChannels) {
+		t.Error("channels did NOT affect the hash — a channels-only fork would be wrongly deduped (F14)")
+	}
+	// Backward-compat: an EMPTY channels block must still hash like a bare
+	// agent (omitempty pointer + normalize collapse) so pre-F14 rows are stable.
+	emptyChannels := FromYAMLAgent(&Agent{Name: "x", Channels: AgentChannelACL{}})
+	if Sign(bare) != Sign(emptyChannels) {
+		t.Error("empty channels block changed the hash — would invalidate every pre-F14 row")
 	}
 }
 
-func TestFromYAMLAgent_ScopesIgnored(t *testing.T) {
-	// AgentDef / SkillDef / Evaluation scopes are also yaml-only.
+func TestFromYAMLAgent_EvaluationScopesAndInterruptionAffectHash(t *testing.T) {
+	// F14: evaluation_scopes + interruption also round-trip + are content.
+	bare := FromYAMLAgent(&Agent{Name: "x"})
+	withEval := FromYAMLAgent(&Agent{Name: "x", EvaluationScopes: []string{"submit_self"}})
+	if Sign(bare) == Sign(withEval) {
+		t.Error("evaluation_scopes did NOT affect the hash (F14)")
+	}
+	withInterruption := FromYAMLAgent(&Agent{
+		Name:         "x",
+		Interruption: AgentInterruptionACL{Enabled: true, Kinds: []string{"question"}, MaxPending: 3},
+	})
+	if Sign(bare) == Sign(withInterruption) {
+		t.Error("interruption did NOT affect the hash (F14)")
+	}
+	// Backward-compat: an all-zero interruption block hashes like bare.
+	emptyInterruption := FromYAMLAgent(&Agent{Name: "x", Interruption: AgentInterruptionACL{}})
+	if Sign(bare) != Sign(emptyInterruption) {
+		t.Error("empty interruption block changed the hash — would invalidate every pre-F14 row")
+	}
+}
+
+func TestFromYAMLAgent_ToolCapabilityScopesStillIgnored(t *testing.T) {
+	// agent_def_scopes / skill_def_scopes gate which substrate tools the
+	// agent may CALL; they are NOT part of its authored definition and do
+	// NOT round-trip through AgentDef set, so they MUST stay out of the hash
+	// (else a yaml-loaded agent and its substrate copy diverge).
 	bare := FromYAMLAgent(&Agent{Name: "x"})
 	withScopes := FromYAMLAgent(&Agent{
-		Name:             "x",
-		AgentDefScopes:   []string{"self"},
-		SkillDefScopes:   []string{"descendants"},
-		EvaluationScopes: []string{"submit_self"},
+		Name:           "x",
+		AgentDefScopes: []string{"self"},
+		SkillDefScopes: []string{"descendants"},
 	})
 	if Sign(bare) != Sign(withScopes) {
-		t.Error("*Scopes leaked into hash — same drift risk as channels")
+		t.Error("agent_def_scopes/skill_def_scopes leaked into hash — yaml vs substrate would falsely report drift")
+	}
+}
+
+func TestFromOverlay_ChannelsConvergeWithWritePath(t *testing.T) {
+	// F14 convergence invariant: the substrate write path (signFromMergedDef,
+	// modelled here by FromYAMLAgent which builds the same AgentContent) and
+	// the substrate READ path (FromOverlay, used by the boot backfill + verify
+	// against the persisted definition JSON) must produce the SAME hash.
+	//
+	// mergedDef persists channels/interruption as VALUE structs with
+	// omitempty, which (verified) serialise an empty block as `"channels":{}`
+	// — so the persisted definition for a no-ACL agent literally contains
+	// `"channels":{}`. FromOverlay must collapse that to the bare hash.
+	bareHash := Sign(FromYAMLAgent(&Agent{Name: "x"}))
+
+	persistedEmpty := json.RawMessage(`{"name":"x","channels":{},"interruption":{}}`)
+	cEmpty, err := FromOverlay(persistedEmpty)
+	if err != nil {
+		t.Fatalf("FromOverlay(empty blocks): %v", err)
+	}
+	if Sign(cEmpty) != bareHash {
+		t.Errorf("persisted empty channels/interruption did not collapse to the bare hash — backfill/verify would diverge from create")
+	}
+
+	// A real channel ACL must round-trip identically between the two paths.
+	writeHash := Sign(FromYAMLAgent(&Agent{Name: "x", Channels: AgentChannelACL{Publish: []string{"out"}}}))
+	persisted := json.RawMessage(`{"name":"x","channels":{"publish":["out"]},"interruption":{}}`)
+	cRead, err := FromOverlay(persisted)
+	if err != nil {
+		t.Fatalf("FromOverlay(channels): %v", err)
+	}
+	if Sign(cRead) != writeHash {
+		t.Errorf("read path hash %q != write path hash %q for the same channels ACL", Sign(cRead), writeHash)
 	}
 }
 

--- a/internal/cli/hash.go
+++ b/internal/cli/hash.go
@@ -226,6 +226,12 @@ func runHashAgentByName(name, cfgPath string, stdout, stderr io.Writer) int {
 		MemoryScopes:          def.MemoryScopes,
 		MemoryQuotaBytes:      def.MemoryQuotaBytes,
 		MemoryBackend:         def.MemoryBackend,
+		// F14: channels / evaluation_scopes / interruption are now content-
+		// identifying, so the by-name hash must include them to match the
+		// deployed substrate hash for an agent that uses them.
+		Channels:         agents.AgentChannelACL{Publish: def.Channels.Publish, Subscribe: def.Channels.Subscribe},
+		EvaluationScopes: def.EvaluationScopes,
+		Interruption:     agents.AgentInterruptionACL{Enabled: def.Interruption.Enabled, Kinds: def.Interruption.Kinds, MaxPending: def.Interruption.MaxPending},
 	}
 	fmt.Fprintln(stdout, agents.Sign(agents.FromYAMLAgent(a)))
 	return 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2914,6 +2914,14 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 		AgentDefScopes:   d.AgentDefScopes,
 		SkillDefScopes:   d.SkillDefScopes,
 		EvaluationScopes: d.EvaluationScopes,
+		// F14: an MD-declared `interruption:` block now flows to config
+		// (parity with channels) so it takes effect at runtime AND the
+		// content hash matches the substrate.
+		Interruption: AgentInterruptionACL{
+			Enabled:    d.Interruption.Enabled,
+			Kinds:      d.Interruption.Kinds,
+			MaxPending: d.Interruption.MaxPending,
+		},
 	}
 	if len(d.Models) > 0 {
 		def.Models = make(map[string][]TierCandidate, len(d.Models))
@@ -3019,6 +3027,14 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.EvaluationScopes != nil {
 		out.EvaluationScopes = override.EvaluationScopes
+	}
+	// F14: yaml interruption override replaces the MD-discovered block when
+	// the operator set any field. Mirrors the substrate applyOverlay's
+	// "any non-zero field signals intent" rule (and shares its known limit:
+	// flipping enabled true→false via override isn't expressible — the
+	// all-zero block reads as "not set").
+	if override.Interruption.Enabled || len(override.Interruption.Kinds) > 0 || override.Interruption.MaxPending != 0 {
+		out.Interruption = override.Interruption
 	}
 	return out
 }

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -94,7 +94,7 @@ const agentDefInputSchema = `{
     "parent_def_id": {"type": "string", "description": "Fork parent (optional for fork — when absent, forks the active def of the name)."},
     "overlay": {
       "type": "object",
-      "description": "Mutable subset of AgentDef for create/fork. Immutable / server-set fields (def_id, version, parent_def_id, created_*, bootstrapped_from_static) are silently ignored if supplied.",
+      "description": "Mutable subset of AgentDef for create/fork (snake_case keys). Common fields: provider, model, tier, effort, system_prompt, code_body, allowed_tools, skills, providers, models, max_tokens, max_iterations, max_concurrent_children, run_timeout_seconds, memory_scopes, memory_quota_bytes, memory_backend, retry_attempts. Interactive / multi-agent config also round-trips and is content-identifying: channels ({publish:[...],subscribe:[...]}), evaluation_scopes ([...]), interruption ({enabled,kinds:[...],max_pending}). Immutable / server-set fields (def_id, version, parent_def_id, created_*, bootstrapped_from_static) are silently ignored if supplied.",
       "additionalProperties": true
     },
     "description":   {"type": "string", "description": "Free-text rationale for create/fork."},
@@ -980,6 +980,12 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		MemoryQuotaBytes:      s.MemoryQuotaBytes,
 		MemoryBackend:         s.MemoryBackend,
 		RetryAttempts:         s.RetryAttempts,
+		// F14: a static agent bootstrapped into the substrate keeps its
+		// interactive/multi-agent config (and so its content hash matches a
+		// hand-authored fork of the same shape). Same config types, direct copy.
+		Channels:         s.Channels,
+		EvaluationScopes: s.EvaluationScopes,
+		Interruption:     s.Interruption,
 	}
 }
 
@@ -1031,7 +1037,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 			models[k] = out
 		}
 	}
-	return agents.Sign(agents.AgentContent{
+	c := agents.AgentContent{
 		Name:                  name,
 		Description:           def.Description,
 		Provider:              def.Provider,
@@ -1050,7 +1056,21 @@ func signFromMergedDef(name string, def mergedDef) string {
 		MemoryScopes:          def.MemoryScopes,
 		MemoryQuotaBytes:      def.MemoryQuotaBytes,
 		MemoryBackend:         def.MemoryBackend,
-	})
+		EvaluationScopes:      def.EvaluationScopes,
+	}
+	// F14: include the interactive/multi-agent ACLs in the hash so a fork
+	// that changes ONLY channels/interruption/evaluation_scopes mints a new
+	// version instead of being deduped as identical content. Mirror
+	// config→agents (the agents package stays config-free); nil when empty
+	// so a no-ACL agent hashes exactly as pre-F14 (normalize() also
+	// collapses defensively).
+	if len(def.Channels.Publish) > 0 || len(def.Channels.Subscribe) > 0 {
+		c.Channels = &agents.AgentChannelACL{Publish: def.Channels.Publish, Subscribe: def.Channels.Subscribe}
+	}
+	if def.Interruption.Enabled || len(def.Interruption.Kinds) > 0 || def.Interruption.MaxPending != 0 {
+		c.Interruption = &agents.AgentInterruptionACL{Enabled: def.Interruption.Enabled, Kinds: def.Interruption.Kinds, MaxPending: def.Interruption.MaxPending}
+	}
+	return agents.Sign(c)
 }
 
 // validateInlineCode gates + validates an inline code-js body (RFC J)

--- a/internal/tools/builtin/agentdef_sha256_test.go
+++ b/internal/tools/builtin/agentdef_sha256_test.go
@@ -73,6 +73,39 @@ func TestAgentDefTool_ForkDifferentContentDifferentHash(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_ForkInteractiveConfigMovesHash is the F14 regression: a
+// fork that changes ONLY channels / interruption / evaluation_scopes must
+// move the content hash. Pre-F14 those fields were excluded from the hash,
+// so such a fork produced an IDENTICAL content_sha256 to its parent and the
+// execCreate/dedup path treated it as a no-op duplicate — silently dropping
+// a real ACL change. Each sub-fork below must differ from the baseline.
+func TestAgentDefTool_ForkInteractiveConfigMovesHash(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	base, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1"}}`))
+	if base.IsError {
+		t.Fatalf("base fork: %s", base.Text)
+	}
+	baseHash := decodeResult(t, base.Text)["content_sha256"].(string)
+
+	cases := map[string]string{
+		"channels":          `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","channels":{"publish":["alerts"]}}}`,
+		"evaluation_scopes": `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","evaluation_scopes":["submit_self"]}}`,
+		"interruption":      `{"op":"fork","name":"researcher","overlay":{"system_prompt":"v1","interruption":{"enabled":true,"max_pending":2}}}`,
+	}
+	for field, overlay := range cases {
+		res, _ := tool.Execute(ctx, json.RawMessage(overlay))
+		if res.IsError {
+			t.Fatalf("%s fork: %s", field, res.Text)
+		}
+		h := decodeResult(t, res.Text)["content_sha256"].(string)
+		if h == baseHash {
+			t.Errorf("%s-only fork did NOT move the content hash (still %s) — would be wrongly deduped (F14)", field, baseHash)
+		}
+	}
+}
+
 func TestAgentDefTool_GetSurfacesContentSHA256(t *testing.T) {
 	tool, ctx, cleanup := agentDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

**F14** from the post-experiment architecture review. An agent authored via the AgentDef substrate already round-trips its interactive/multi-agent ACLs — `channels`, `evaluation_scopes`, `interruption` — through `mergedDef` → `agent_defs.definition` JSONB (earlier F14-prep). But the content hash (`content_sha256`) **excluded** them, so:

1. A fork that changed **only** one of those fields produced an *identical* hash to its parent → the `execCreate` dedup path treated it as a no-op duplicate and **silently dropped the ACL change**.
2. They were undiscoverable in the tool's overlay input schema.

The content hash is load-bearing (execCreate dedup, the `verify` op, boot backfill), so this both fixes a real silent-drop bug and completes the round-trip so every hash producer agrees.

## What

Makes the three fields content-identifying + discoverable, and closes the one remaining round-trip leg (the MD loader / config merge):

- **`agents.AgentContent`** gains `channels` (`*ptr`) / `evaluation_scopes` (slice) / `interruption` (`*ptr`), all `omitempty`. `normalize()` collapses an all-empty pointer to nil so a no-ACL agent hashes **byte-identically** to before. (Empirically: a *value* struct with `omitempty` serialises `{}` — NOT omitted; only a nil pointer omits. So the persisted `definition` literally contains `"channels":{}`, and the read path must collapse it to match the write path. Both golden known-vector hashes are unchanged.)
- **Three producers now converge** for the same agent: `signFromMergedDef` (substrate write), `FromYAMLAgent` (`hash agent` CLI), `FromOverlay` (boot backfill / verify, reads the persisted JSON).
- **`agents.Agent` + the MD frontmatter loader gain `Interruption`** (parity with channels); `config.agentFromDiscovered` + `mergeAgentDef` carry it so an MD-declared `interruption:` block takes effect at runtime AND hashes consistently.
- **`staticToMergedDef`** now copies the three (a static agent bootstrapped into the substrate keeps its interactive config + matching hash).
- **`agentDefInputSchema`** overlay description enumerates the mutable field set incl. the three (discoverability).

**No wire-protocol change / no `@loomcycle/client` bump:** the overlay was already free-form (`additionalProperties: true`) and the TS `AgentDefOverlay` already declares all three fields (types.ts).

## What was tested

- Replaced the now-stale `TestFromYAMLAgent_{ChannelACL,Scopes}Ignored` with positive tests: channels / evaluation_scopes / interruption **move** the hash; `agent_def_scopes`/`skill_def_scopes` (tool-capability ACLs, not authored definition) still **don't**; empty blocks still **collapse** (pre-F14 rows stable).
- `TestFromOverlay_ChannelsConvergeWithWritePath` pins the read↔write convergence + the `"channels":{}` collapse.
- `TestAgentDefTool_ForkInteractiveConfigMovesHash` is the substrate fail-before: a channels/eval/interruption-only fork mints a new version instead of being deduped.
- Both golden known-vector hashes unchanged (backward-compat). `go build ./...` + `go test ./...` clean; `gofmt`/`vet` clean.
- Independent review: clean across all 6 invariants (backward-compat, write/read convergence, converter completeness, deterministic ordering, merge semantics, single-hash-per-agent).

## Out-of-scope follow-up found during review
`config.agentFromDiscovered` drops `MaxConcurrentChildren` (an MD agent's `max_concurrent_children` is lost at boot → runtime uses the default, and the substrate hash would diverge from runtime) — a **pre-existing** bug in the same divergence *class* but a different field. Left out to keep this PR focused; trivial one-line fix if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)