### PR TITLE
fix(config): carry max_concurrent_children through MD agent discovery

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2901,12 +2901,17 @@ func agentFromDiscovered(d *agents.Agent) AgentDef {
 		Skills:           d.Skills,
 		MaxTokens:        d.MaxTokens,
 		MaxIterations:    d.MaxIterations,
-		Tier:             d.Tier,
-		Effort:           d.Effort,
-		Providers:        d.Providers,
-		MemoryScopes:     d.MemoryScopes,
-		MemoryQuotaBytes: d.MemoryQuotaBytes,
-		MemoryBackend:    d.MemoryBackend,
+		// MaxConcurrentChildren rounds out the loop-budget trio (with
+		// MaxTokens/MaxIterations) — it lives on agents.Agent + the MD
+		// frontmatter, so dropping it here silently capped an MD-declared
+		// agent at the runtime default (4) instead of its declared value.
+		MaxConcurrentChildren: d.MaxConcurrentChildren,
+		Tier:                  d.Tier,
+		Effort:                d.Effort,
+		Providers:             d.Providers,
+		MemoryScopes:          d.MemoryScopes,
+		MemoryQuotaBytes:      d.MemoryQuotaBytes,
+		MemoryBackend:         d.MemoryBackend,
 		Channels: AgentChannelACL{
 			Publish:   d.Channels.Publish,
 			Subscribe: d.Channels.Subscribe,
@@ -2983,6 +2988,9 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	}
 	if override.MaxIterations != 0 {
 		out.MaxIterations = override.MaxIterations
+	}
+	if override.MaxConcurrentChildren != 0 {
+		out.MaxConcurrentChildren = override.MaxConcurrentChildren
 	}
 	if override.Tier != "" {
 		out.Tier = override.Tier

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -904,6 +904,53 @@ agents:
 	}
 }
 
+// TestDiscoverAgents_MaxConcurrentChildrenFlowsThroughDiscoveryAndOverride
+// pins max_concurrent_children through BOTH the discovery copy
+// (agentFromDiscovered) and the yaml-override merge (mergeAgentDef). Fails on
+// the pre-fix code, where neither carried the field, so an MD-declared
+// parallel-spawn cap was silently dropped → the agent fell back to the
+// runtime default (4) instead of its declared value.
+func TestDiscoverAgents_MaxConcurrentChildrenFlowsThroughDiscoveryAndOverride(t *testing.T) {
+	tmp := t.TempDir()
+	agentsDir := filepath.Join(tmp, "agents")
+	if err := os.Mkdir(agentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// "discovered" declares the cap purely in its .md frontmatter.
+	writeAgentMD(t, agentsDir, "discovered", `---
+name: discovered
+max_concurrent_children: 8
+---
+`)
+	// "overridden" declares 8 in the .md; the yaml override layer raises it to 12.
+	writeAgentMD(t, agentsDir, "overridden", `---
+name: overridden
+max_concurrent_children: 8
+---
+`)
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	if err := os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  overridden:
+    max_concurrent_children: 12
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LOOMCYCLE_AGENTS_ROOT", agentsDir)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got := cfg.Agents["discovered"].MaxConcurrentChildren; got != 8 {
+		t.Errorf("discovered .md max_concurrent_children not carried (agentFromDiscovered dropped it): got %d, want 8", got)
+	}
+	if got := cfg.Agents["overridden"].MaxConcurrentChildren; got != 12 {
+		t.Errorf("yaml override max_concurrent_children not applied (mergeAgentDef dropped it): got %d, want 12", got)
+	}
+}
+
 // TestDiscoverAgents_DiscoveryOnly: AGENTS_ROOT set, yaml has no
 // `agents:` block at all. All agents come from the MDs, validation
 // passes. The deployment shape an operator using "MDs as sole source


### PR DESCRIPTION
## Why

An MD-discovered agent's `max_concurrent_children:` frontmatter was **silently dropped at boot**, so a parallel-spawning agent declared via a `.md` file was capped at the runtime default (4) instead of its declared value. Two gaps in the discovery→config conversion:

1. `agentFromDiscovered` (`agents.Agent` → `config.AgentDef`) omitted the field → a **pure-MD agent** lost it.
2. `mergeAgentDef` had no `MaxConcurrentChildren` branch → a **yaml override** of `max_concurrent_children` on a discovered agent was ignored.

`MaxTokens` and `MaxIterations` — the other two loop-budget knobs, both on `agents.Agent` + the frontmatter — were already carried; `max_concurrent_children` was the odd one out.

Surfaced during the F14 review ([#412](https://github.com/denn-gubsky/loomcycle/pull/412)). It's the same drop-on-convert *class* as F14's channels/interruption/evaluation_scopes, but a distinct field and unrelated to the content hash, so it's its own focused fix.

## What

- `agentFromDiscovered`: copy `MaxConcurrentChildren` (alongside `MaxTokens`/`MaxIterations`).
- `mergeAgentDef`: add the `if override.MaxConcurrentChildren != 0` branch, matching the existing `MaxIterations`/`MaxTokens` branches.

## What was tested

- `TestDiscoverAgents_MaxConcurrentChildrenFlowsThroughDiscoveryAndOverride` (mirrors the existing inline-code flow test) pins **both** legs: an MD-declared cap survives discovery, and a yaml override is applied.
- **Fail-before verified**: reverting the fix (keeping the test) → both assertions read `0` (`agentFromDiscovered dropped it` / `mergeAgentDef dropped it`); with the fix → 8 and 12.
- `go build ./...` + `go test ./...` clean; `gofmt`/`vet` clean.

No wire/schema/hash change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)