### PR TITLE
chore: P2 cleanups from the architecture review

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1959,7 +1959,10 @@ func main() {
 		// can wrap loomcycle in a supervisor that watches for the
 		// log line.
 		go func() {
-			log.Printf("mcp: stdio server starting (20 tools registered)")
+			// Sourced from the registry (lcmcp.MetaToolCount) so the count
+			// can't drift — the hardcoded "20" went stale once the registry
+			// grew past 40. Same rationale as the CLI help count.
+			log.Printf("mcp: stdio server starting (%d tools registered)", lcmcp.MetaToolCount())
 			if err := mcpSrv.Serve(bgCtx, os.Stdin, os.Stdout); err != nil {
 				log.Printf("mcp: serve ended: %v", err)
 			} else {

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -163,6 +163,7 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelSweepReapsExpired", testChannelSweepReapsExpired},
 		{"ChannelMaxMessagesTrimsOldest", testChannelMaxMessagesTrimsOldest},
 		{"ChannelScopeIsolation", testChannelScopeIsolation},
+		{"ChannelPurge", testChannelPurge},
 		{"ChannelPeekDoesNotConsume", testChannelPeekDoesNotConsume},
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
 		{"ChannelStatsAggregatesNonExpired", testChannelStatsAggregatesNonExpired},
@@ -2987,6 +2988,58 @@ func testChannelScopeIsolation(t *testing.T, s store.Store) {
 	msgs, _, _ = s.ChannelSubscribe(ctx, "shared", store.MemoryScopeAgent, "agent-b", "", 10)
 	if len(msgs) != 1 || !jsonEqual(msgs[0].Payload, `{"from":"b"}`) {
 		t.Errorf("agent-b sees: %+v, want only its own message", msgs)
+	}
+}
+
+// testChannelPurge pins the ChannelPurge contract: it drains every buffered
+// message for a channel name and returns the count, is idempotent on an
+// empty/unknown channel (0, nil — NOT ErrNotFound), and leaves the channel
+// usable for new publishes (it drains the queue, it does not tear the
+// channel down).
+func testChannelPurge(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for i := 0; i < 3; i++ {
+		if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+			Channel: "purge-ch", Scope: store.MemoryScopeAgent, ScopeID: "x",
+			Payload: json.RawMessage(`{"i":` + strconv.Itoa(i) + `}`),
+		}, 0); err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+
+	n, err := s.ChannelPurge(ctx, "purge-ch")
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("purge returned %d, want 3", n)
+	}
+	if msgs, _, _ := s.ChannelSubscribe(ctx, "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 0 {
+		t.Errorf("post-purge msgs = %d, want 0 (queue drained)", len(msgs))
+	}
+
+	// Idempotent on an already-empty channel.
+	n2, err := s.ChannelPurge(ctx, "purge-ch")
+	if err != nil {
+		t.Fatalf("purge empty: %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("purge empty returned %d, want 0", n2)
+	}
+	// Idempotent on a never-seen channel (existence is the caller's concern).
+	if n3, err := s.ChannelPurge(ctx, "never-existed"); err != nil || n3 != 0 {
+		t.Errorf("purge unknown channel = (%d, %v), want (0, nil)", n3, err)
+	}
+
+	// The channel still accepts new messages — purge drained, didn't delete.
+	if _, _, err := s.ChannelPublish(ctx, store.ChannelMessage{
+		Channel: "purge-ch", Scope: store.MemoryScopeAgent, ScopeID: "x",
+		Payload: json.RawMessage(`{"i":99}`),
+	}, 0); err != nil {
+		t.Fatalf("publish after purge: %v", err)
+	}
+	if msgs, _, _ := s.ChannelSubscribe(ctx, "purge-ch", store.MemoryScopeAgent, "x", "", 10); len(msgs) != 1 {
+		t.Errorf("post-purge-republish msgs = %d, want 1", len(msgs))
 	}
 }
 

--- a/internal/tools/mcp/pool.go
+++ b/internal/tools/mcp/pool.go
@@ -241,38 +241,11 @@ func (p *Pool) GetWithRetry(ctx context.Context, name string, logf func(string, 
 	}
 }
 
-// Tools returns wrapped tools.Tool entries for every server that has
-// finished initialising. Each tool is named "mcp__{server}__{tool}" to match
-// the convention used by Claude Code (and therefore by jobs-search-agent's
-// policies). Entries that are still initialising or that failed init are
-// skipped.
-func (p *Pool) Tools() []tools.Tool {
-	p.mu.Lock()
-	// Snapshot the entry pointers so we can safely iterate the ready
-	// channels without holding p.mu (ready is closed under no lock).
-	entries := make(map[poolKey]*entry, len(p.servers))
-	for key, e := range p.servers {
-		entries[key] = e
-	}
-	p.mu.Unlock()
-
-	var out []tools.Tool
-	for key, e := range entries {
-		select {
-		case <-e.ready:
-			if e.err != nil {
-				continue
-			}
-		default:
-			// Still initialising — skip; caller can ask again later.
-			continue
-		}
-		for _, td := range e.tools {
-			out = append(out, NewTool(p, key.name, td))
-		}
-	}
-	return out
-}
+// (Pool.Tools was removed in the RFC N follow-up: it enumerated EVERY
+// server's tools with no tenant filter, a latent cross-tenant leak if ever
+// wired into the per-run advertising path. Production tool advertising goes
+// through the tenant-aware enumerate.go DynamicToolsForRun + lazy.go, both
+// of which wrap via NewTool; nothing called Pool.Tools outside tests.)
 
 // PeekTools returns a snapshot of the cached tools/list result for
 // name. Returns nil when the entry is absent, still initialising, or

--- a/internal/tools/mcp/pool_test.go
+++ b/internal/tools/mcp/pool_test.go
@@ -15,9 +15,25 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp/stdio"
 )
+
+// firstTool resolves a server's first discovered tool via the SAME path
+// production uses (pool.Get → mcp.NewTool, mirroring enumerate.go) —
+// replacing the removed tenant-blind Pool.Tools() convenience.
+func firstTool(t *testing.T, ctx context.Context, pool *mcp.Pool, server string) tools.Tool {
+	t.Helper()
+	_, descs, err := pool.Get(ctx, server)
+	if err != nil {
+		t.Fatalf("Get(%q): %v", server, err)
+	}
+	if len(descs) == 0 {
+		t.Fatalf("no tools discovered for %q", server)
+	}
+	return mcp.NewTool(pool, server, descs[0])
+}
 
 // fakeMCPBinary is the path to the stdio test binary. Tests rely on the
 // stdio package's TestMain installing the BE_MCP_SERVER hook — we run the
@@ -148,12 +164,8 @@ func TestPoolGetSpawnsAndDiscoversTools(t *testing.T) {
 		t.Errorf("descs: %+v", descs)
 	}
 
-	tools := pool.Tools()
-	if len(tools) != 1 {
-		t.Fatalf("tools = %d", len(tools))
-	}
 	want := "mcp__search__web_search"
-	if got := tools[0].Name(); got != want {
+	if got := mcp.NewTool(pool, "search", descs[0]).Name(); got != want {
 		t.Errorf("tool name = %q, want %q", got, want)
 	}
 }
@@ -162,10 +174,7 @@ func TestPoolToolExecuteRoutesToServer(t *testing.T) {
 	pool := newPoolWithFake(t, "ok")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if _, _, err := pool.Get(ctx, "search"); err != nil {
-		t.Fatal(err)
-	}
-	tool := pool.Tools()[0]
+	tool := firstTool(t, ctx, pool, "search")
 	res, err := tool.Execute(ctx, json.RawMessage(`{"q":"hi"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -191,10 +200,7 @@ func TestPoolToolReturnsErrOnCtxCancel(t *testing.T) {
 	pool := newPoolWithFake(t, "slow-call")
 	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer initCancel()
-	if _, _, err := pool.Get(initCtx, "search"); err != nil {
-		t.Fatal(err)
-	}
-	tool := pool.Tools()[0]
+	tool := firstTool(t, initCtx, pool, "search")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
@@ -209,10 +215,7 @@ func TestPoolToolPropagatesIsError(t *testing.T) {
 	pool := newPoolWithFake(t, "tool_iserror")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if _, _, err := pool.Get(ctx, "search"); err != nil {
-		t.Fatal(err)
-	}
-	tool := pool.Tools()[0]
+	tool := firstTool(t, ctx, pool, "search")
 	res, err := tool.Execute(ctx, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)


### PR DESCRIPTION
## Why

The remaining **P2** items from the post-experiment architecture review — three small, independent cleanups. One PR with a single commit (per-item commits would be overkill at this size); each item is self-contained.

## What

1. **Stale boot-log tool count.** The stdio MCP server start line hardcoded `"(20 tools registered)"` — stale since the meta-tool registry grew past 40. Now sourced from `lcmcp.MetaToolCount()`, the same registry-backed count that exists precisely to stop this drift (see its doc: the static "33" → "40" drift on the CLI help).

2. **Delete the tenant-blind `Pool.Tools()`.** It enumerated *every* server's tools with **no tenant filter** — a latent cross-tenant leak if it were ever wired into the per-run advertising path. It had **no production caller** (the tenant-aware `enumerate.go` `DynamicToolsForRun` + `lazy.go` are the live paths, both wrapping via `NewTool`); only 4 tests used it. Migrated them to a `firstTool` helper that resolves via `pool.Get → mcp.NewTool` — the *same* path production uses (`enumerate.go:116`), so the wrapper/execute tests now mirror production instead of a dead accessor.

3. **Add the missing `ChannelPurge` store-contract test** (runs on SQLite **and** the `go-postgres` CI job): drains the queue + returns the count, is idempotent on an empty/unknown channel (`(0, nil)`, not `ErrNotFound`), and leaves the channel usable for new publishes (purge drains, it doesn't tear the channel down).

## Deferred (with rationale)

**`WebhookDef.Enabled` bool→*bool — intentionally NOT done.** On inspection the plain `bool` is a **deliberate, documented** design (`webhookdef.go applyOverlay`: *"an overlay can only flip it true … matching the A2AAgentDef VerifySignedCard / server-card capabilities posture"*). Changing only `WebhookDef.Enabled` to a pointer would break that sibling-consistency for marginal benefit — disabling a webhook is already expressible via `retire`. Left as-is pending an explicit decision to change the capability-flag convention across all the sibling defs. (Flagging per "surface contradictions rather than proceed.")

## What was tested

- New `ChannelPurge` contract test passes on SQLite (+ auto-covered on the real-Postgres CI).
- The 4 migrated `Pool` tests pass (wrapper naming + execute-routing + ctx-cancel + IsError-propagation), now exercising the production `NewTool` path.
- `go build ./...` + `go test ./...` clean; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)