### PR TITLE
RFC S: ensemble synchronization primitives (agent clock + channel fan-in)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -511,7 +511,28 @@ Wildcards are anchored at the end (`findings/*` matches `findings/alpha` but NOT
 // List — informational, reports this agent's allowlists:
 { "op": "list_channels" }
 //   → { "publish": [...], "subscribe": [...] }
+
+// Await — fan-in barrier across MULTIPLE channels (wait for any / all /
+// at_least N messages, or a timeout). Non-committing.
+{ "op": "await", "channels": ["a", "b", "c"], "mode": "at_least", "n": 3, "wait_ms": 30000 }
+//   → { "satisfied": true, "timed_out": false, "mode": "at_least",
+//       "fired": ["a","b","c"], "total_messages": 3,
+//       "results": { "a": { "messages": [...], "next_cursor": "msg_..." }, ... } }
 ```
+
+### Fan-in barrier (`await`)
+
+`subscribe` reads ONE channel. When a consumer must wait for **several** producers — e.g. a consolidator that fires after "N collectors finish, or a timeout" — `await` is the first-class combinator:
+
+- **`mode: any`** — satisfied when ≥1 named channel has a message.
+- **`mode: all`** — satisfied when every named channel has ≥1.
+- **`mode: at_least` + `n`** — satisfied when the total message count across all named channels reaches `n`.
+
+It long-polls up to `wait_ms` (clamped to the operator's `LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS`), waking the instant a producer publishes. A timeout is **not** an error: it returns `{ "satisfied": false, "timed_out": true }` with whatever partials accumulated — the caller decides what to do.
+
+**`await` is non-committing (detection only).** It returns each fired channel's `next_cursor` but never advances the committed cursor — auto-committing across N channels on a partial/`any`/timeout result would silently consume messages on channels the agent didn't act on. After `await` returns, the agent `subscribe`/`ack`s exactly what it processes. Each channel is resolved through the agent's **subscribe** allowlist, so `await` can't read a channel it couldn't `subscribe` to. Max 32 channels per call.
+
+> **`await` vs `Agent.parallel_spawn`:** both are barriers, but over different things. `parallel_spawn` joins the **sub-agents this agent spawned** (`wg.Wait()`). `await` joins **independent producers** — scheduler-fired runs, inbound webhooks, separately-spawned agents — that `parallel_spawn` can't reach. A scheduler-driven fan-out (N collectors) → consolidator pipeline uses `await`; an in-agent fan-out uses `parallel_spawn`. (`on_complete: channel.publish` on a `ScheduledRun` stamps `schedule_name` per fire — the distinct-producer key an `at_least`/`all` consolidator counts.)
 
 ### Delivery semantics
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -217,7 +217,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 		{
 			Name:        "context",
-			Description: "Context tool ops (self/tools/doc/permissions/agents/lineage/evaluations/channels/history/help). Pass-through.",
+			Description: "Context tool ops (self/tools/doc/permissions/agents/lineage/evaluations/channels/history/help/time). Pass-through.",
 			InputSchema: builtinSchema("context"),
 		},
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -144,7 +144,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		},
 		{
 			Name:        "channel",
-			Description: "Channel tool ops (publish/subscribe/ack/peek/list_channels). Pass-through.",
+			Description: "Channel tool ops (publish/subscribe/ack/peek/list_channels/await). await is the multi-channel fan-in barrier (any/all/at_least N or timeout; non-committing). Pass-through.",
 			InputSchema: builtinSchema("channel"),
 		},
 		{

--- a/internal/help/builtin/subagents.md
+++ b/internal/help/builtin/subagents.md
@@ -59,6 +59,34 @@ You don't need an immediate result:
 → persists immediately; subscriber pulls when ready
 ```
 
+## Joining work: `Agent.parallel_spawn` vs `Channel.await`
+
+Both are barriers — "wait for N things to finish" — but over different
+producer sets. Pick by who you're joining:
+
+- **`Agent.parallel_spawn`** — joins the **sub-agents YOU spawned** in this
+  loop. It's an AND-barrier: control returns when every child completes
+  (`wg.Wait()`). Use it for an in-agent fan-out: "spawn 4 researchers,
+  wait for all 4, synthesize."
+
+- **`Channel.await`** — joins **independent producers** you did NOT spawn:
+  scheduler-fired runs, inbound webhooks, separately-spawned agents.
+  `parallel_spawn` can't see them (they aren't your children).
+  `await {channels, mode: any|all|at_least, n, wait_ms}` waits for a
+  fan-in across channels: `any` (≥1 channel fired), `all` (every channel
+  fired), or `at_least` (total messages ≥ n) — or a timeout
+  (`{satisfied:false, timed_out:true}`, never an error). It's
+  non-committing: the agent then `subscribe`/`ack`s exactly what it
+  processes.
+
+Canonical pattern: a scheduler fans out N collectors (each a
+`ScheduledRun` whose `on_complete: channel.publish` stamps `schedule_name`
+per fire); a consolidator `await`s `at_least` N on those channels, then
+acts. The collectors aren't the consolidator's children — so it's `await`,
+not `parallel_spawn`. (Need a clock to set the `wait_ms` budget or a
+`deliver_at` self-timeout? `Context op=time` gives the agent `now` +
+`elapsed_ms`.)
+
 ## Recursion depth cap
 
 Sub-agents can spawn sub-sub-agents, but loomcycle caps recursion

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -838,12 +838,22 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 				timedOut = true
 				break loop
 			}
-			// A channel waker fired. Re-read ONLY that channel, with the
-			// same bounded MVCC-visibility retry subscribe uses (the row
-			// committed before Notify, so it IS visible — the retry covers
-			// the rare pgxpool snapshot window). `from` is non-advancing, so
-			// the re-read returns the full window for that channel.
+			// A channel waker fired (one-shot — Notify drained it). Re-arm a
+			// FRESH waker BEFORE re-reading, preserving subscribe's race-free
+			// register-before-read invariant (Bus.Register doc): a publish
+			// that lands in the window is then guaranteed to either be caught
+			// by the read below (it committed first) or fire the fresh waker
+			// (caught next iteration). Re-arming AFTER the read would drop a
+			// Notify that fires in the gap between the read and the Register,
+			// leaving the loop blocked on a waker that already missed its
+			// signal until the timer expires.
 			st := states[chosen]
+			c.Bus.Unregister(st.name, wakers[chosen])
+			wakers[chosen] = c.Bus.Register(st.name)
+			// Re-read that channel with the same bounded MVCC-visibility retry
+			// subscribe uses (the row committed before Notify, so it IS
+			// visible — the retry covers the rare pgxpool snapshot window).
+			// `from` is non-advancing, so this returns the full window.
 			diag := retryDiagnostics{notifyAt: time.Now(), fromCursor: st.from}
 			if c.PoolStatsFn != nil {
 				diag.poolTotal, diag.poolAcquired, diag.poolIdle = c.PoolStatsFn()
@@ -859,10 +869,6 @@ func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue
 			if satisfied() {
 				break loop
 			}
-			// Re-arm a fresh waker for the next publish on this channel
-			// (the fired one was drained by Notify).
-			c.Bus.Unregister(st.name, wakers[chosen])
-			wakers[chosen] = c.Bus.Register(st.name)
 		}
 	} else if !satisfied() {
 		// No long-poll budget (Bus nil / wait<=0): the single synchronous

--- a/internal/tools/builtin/channel.go
+++ b/internal/tools/builtin/channel.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -98,15 +99,21 @@ func (c *Channel) shouldWarnTruncation(channel string) bool {
 
 const channelDescription = `Persistent inter-agent message bus. ` +
 	`Publish JSON payloads to a named channel; subscribe to drain new messages with cursor-based at-least-once delivery. ` +
-	`Operations: publish, subscribe, ack, peek, list_channels. ` +
+	`Operations: publish, subscribe, ack, peek, list_channels, await. ` +
 	`Channel ACLs are operator-configured; the tool refuses ops on channels not in this agent's publish/subscribe allowlists. ` +
-	`Scope (agent / user / global) is set by the operator per channel; cursor isolation matches that scope.`
+	`Scope (agent / user / global) is set by the operator per channel; cursor isolation matches that scope. ` +
+	`await is a fan-in barrier across MULTIPLE channels (wait for any / all / at_least N messages, or a timeout) — the complement to ` +
+	`Agent.parallel_spawn (which joins sub-agents); use await to join independent producers (scheduler / webhook / separately-spawned agents). ` +
+	`await is non-committing (detection only) — it never advances cursors, so subscribe/ack exactly what you process.`
 
 const channelInputSchema = `{
   "type": "object",
   "properties": {
-    "op":           {"type": "string", "enum": ["publish","subscribe","ack","peek","list_channels"], "description": "Which operation to perform."},
+    "op":           {"type": "string", "enum": ["publish","subscribe","ack","peek","list_channels","await"], "description": "Which operation to perform."},
     "channel":      {"type": "string", "description": "The channel name (required for publish/subscribe/ack/peek)."},
+    "channels":     {"type": "array", "items": {"type": "string"}, "description": "Await only: the channels to fan in over (max 32). Each is resolved under the agent's SUBSCRIBE allowlist."},
+    "mode":         {"type": "string", "enum": ["any","all","at_least"], "description": "Await only: any = ≥1 channel has a message; all = every channel has ≥1; at_least = total messages across channels ≥ n. Default any."},
+    "n":            {"type": "integer", "description": "Await only: the threshold for mode=at_least (required, >0 for that mode)."},
     "value":        {"description": "Publish only: the JSON payload to append."},
     "ttl":          {"type": "integer", "description": "Publish only: per-message TTL in seconds. Absent = channel default."},
     "deliver_at":   {"type": "string", "description": "Publish only (optional): RFC3339 timestamp at which the message becomes deliverable. Absent or in the past = immediate. TTL counts from publish time, NOT deliver_at — size the TTL to cover both the deferral window AND the desired visibility window."},
@@ -122,6 +129,9 @@ const channelInputSchema = `{
 type channelInput struct {
 	Op          string          `json:"op"`
 	Channel     string          `json:"channel,omitempty"`
+	Channels    []string        `json:"channels,omitempty"` // await: fan-in set
+	Mode        string          `json:"mode,omitempty"`     // await: any|all|at_least
+	N           int             `json:"n,omitempty"`        // await: threshold for at_least
 	Value       json.RawMessage `json:"value,omitempty"`
 	TTL         int64           `json:"ttl,omitempty"`
 	DeliverAt   string          `json:"deliver_at,omitempty"`
@@ -163,10 +173,12 @@ func (c *Channel) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execPeek(ctx, policy, in)
 	case "list_channels":
 		return c.execListChannels(policy)
+	case "await":
+		return c.execAwait(ctx, policy, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: publish, subscribe, ack, peek, list_channels)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: publish, subscribe, ack, peek, list_channels, await)", in.Op)), nil
 	}
 }
 
@@ -645,6 +657,250 @@ func readWithRetry(read func() ([]store.ChannelMessage, string, error), channel 
 		diag.fromCursor,
 		diag.poolTotal, diag.poolAcquired, diag.poolIdle)
 	return nil, "", nil
+}
+
+// awaitMaxChannels caps the fan-in width so one await can't register an
+// unbounded number of Bus wakers / hold an unbounded select.
+const awaitMaxChannels = 32
+
+// execAwait is the RFC S / F35 fan-in barrier: wait until any / all /
+// at_least-N messages are visible across a SET of channels, or a timeout.
+// It is the complement to Agent.parallel_spawn (which joins sub-agents) —
+// await joins INDEPENDENT producers (scheduler / webhook / separately-
+// spawned agents) that parallel_spawn can't reach.
+//
+// A dedicated op — deliberately NOT an overload of subscribe. subscribe's
+// single-channel committed-cursor + auto-commit-on-return is the most
+// concurrency-sensitive path in the tool; forking it behind multi-channel
+// conditionals would risk regressing it. await keeps subscribe byte-for-
+// byte and gives fan-in its own clean contract.
+//
+// NON-COMMITTING (peek-style): await is detection, not drain. It returns
+// each fired channel's next_cursor but NEVER advances the committed
+// cursor — auto-committing across N channels on a partial / any / timeout
+// result would silently consume messages on channels the agent didn't
+// act on. The agent then subscribe/acks exactly what it processes.
+//
+// Timeout is NOT an error: returns {satisfied:false, timed_out:true} with
+// whatever partials accumulated, mirroring subscribe's timeout-returns-empty.
+func (c *Channel) execAwait(ctx context.Context, policy tools.ChannelPolicyValue, in channelInput) (tools.Result, error) {
+	if len(in.Channels) == 0 {
+		return errResult("await: missing required field: channels (non-empty list)"), nil
+	}
+	if len(in.Channels) > awaitMaxChannels {
+		return errResult(fmt.Sprintf("await: too many channels (%d > max %d)", len(in.Channels), awaitMaxChannels)), nil
+	}
+	mode := in.Mode
+	if mode == "" {
+		mode = "any"
+	}
+	switch mode {
+	case "any", "all", "at_least":
+	default:
+		return errResult(fmt.Sprintf("await: unknown mode %q (must be one of: any, all, at_least)", mode)), nil
+	}
+	if mode == "at_least" && in.N <= 0 {
+		return errResult("await: mode=at_least requires n > 0"), nil
+	}
+	limit := in.MaxMessages
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > 100 {
+		limit = 100
+	}
+
+	// Resolve + dedup every channel up front. Each goes through the
+	// SUBSCRIBE ACL + scope resolution (resolveChannel side="subscribe"),
+	// so await can't read a channel the agent can't subscribe to, and
+	// RFC N tenancy is honoured per channel (resolveChannel reads the
+	// run's tenant scope).
+	type chanState struct {
+		name    string
+		scope   store.MemoryScope
+		scopeID string
+		from    string // committed/explicit cursor; NON-advancing
+		msgs    []store.ChannelMessage
+		next    string
+	}
+	seen := make(map[string]bool, len(in.Channels))
+	states := make([]*chanState, 0, len(in.Channels))
+	for _, name := range in.Channels {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		_, scope, scopeID, err := c.resolveChannel(ctx, policy, "subscribe", name)
+		if err != nil {
+			return errResult(err.Error()), nil
+		}
+		from := in.FromCursor
+		if from == "" {
+			committed, err := c.Store.ChannelCommittedCursor(ctx, name, scope, scopeID)
+			if err != nil {
+				return errResult(fmt.Sprintf("await: read committed cursor for %q: %s", name, err)), nil
+			}
+			from = committed
+		}
+		states = append(states, &chanState{name: name, scope: scope, scopeID: scopeID, from: from})
+	}
+
+	readChan := func(st *chanState) error {
+		msgs, next, err := c.Store.ChannelSubscribe(ctx, st.name, st.scope, st.scopeID, st.from, limit)
+		if err != nil {
+			return err
+		}
+		st.msgs = msgs
+		st.next = next
+		return nil
+	}
+
+	satisfied := func() bool {
+		nonEmpty, total := 0, 0
+		for _, st := range states {
+			if len(st.msgs) > 0 {
+				nonEmpty++
+			}
+			total += len(st.msgs)
+		}
+		switch mode {
+		case "any":
+			return nonEmpty >= 1
+		case "all":
+			return nonEmpty == len(states)
+		case "at_least":
+			return total >= in.N
+		}
+		return false
+	}
+
+	longPoll := c.Bus != nil && in.WaitMS > 0 && c.LongPollCapMS > 0
+	wait := in.WaitMS
+	if longPoll && wait > c.LongPollCapMS {
+		// F22: surface the cap once per channel-set so an operator notices
+		// the long-poll budget being clipped.
+		if c.shouldWarnTruncation("await:" + strings.Join(in.Channels, ",")) {
+			log.Printf("channel await: wait_ms=%d truncated to the operator cap %d ms (LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS)", in.WaitMS, c.LongPollCapMS)
+		}
+		wait = c.LongPollCapMS
+	}
+
+	// Register one waker per channel BEFORE the initial read — the same
+	// race-free invariant subscribe uses (Bus.Register doc): a publish
+	// that commits between our read and our wait can't be lost. Wakers
+	// are one-shot (Notify drains the slice), so the woken channel's
+	// waker is re-registered after each wake. Final wakers are cleaned by
+	// the defer (Unregister is idempotent).
+	wakers := make([]chan struct{}, len(states))
+	if longPoll {
+		for i, st := range states {
+			wakers[i] = c.Bus.Register(st.name)
+		}
+		defer func() {
+			for i, w := range wakers {
+				if w != nil {
+					c.Bus.Unregister(states[i].name, w)
+				}
+			}
+		}()
+	}
+
+	// Initial synchronous multi-read. Empty is the EXPECTED state here
+	// (no producer has fired yet) — plain read, no readWithRetry (its
+	// 3×10ms backoff is for the post-notify MVCC-visibility window, not
+	// a legitimately-empty channel).
+	for _, st := range states {
+		if err := readChan(st); err != nil {
+			return errResult(fmt.Sprintf("await: read %q: %s", st.name, err)), nil
+		}
+	}
+
+	timedOut := false
+	if !satisfied() && longPoll {
+		timer := time.NewTimer(time.Duration(wait) * time.Millisecond)
+		defer timer.Stop()
+	loop:
+		for {
+			// Dynamic-N select over the wakers + timer + ctx. reflect.Select
+			// is the idiomatic stdlib dynamic select — no merge goroutines,
+			// so nothing can leak.
+			cases := make([]reflect.SelectCase, 0, len(wakers)+2)
+			for _, w := range wakers {
+				cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(w)})
+			}
+			timerIdx := len(cases)
+			cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(timer.C)})
+			ctxIdx := len(cases)
+			cases = append(cases, reflect.SelectCase{Dir: reflect.SelectRecv, Chan: reflect.ValueOf(ctx.Done())})
+
+			chosen, _, _ := reflect.Select(cases)
+			if chosen == timerIdx || chosen == ctxIdx {
+				timedOut = true
+				break loop
+			}
+			// A channel waker fired. Re-read ONLY that channel, with the
+			// same bounded MVCC-visibility retry subscribe uses (the row
+			// committed before Notify, so it IS visible — the retry covers
+			// the rare pgxpool snapshot window). `from` is non-advancing, so
+			// the re-read returns the full window for that channel.
+			st := states[chosen]
+			diag := retryDiagnostics{notifyAt: time.Now(), fromCursor: st.from}
+			if c.PoolStatsFn != nil {
+				diag.poolTotal, diag.poolAcquired, diag.poolIdle = c.PoolStatsFn()
+			}
+			msgs, next, err := readWithRetry(func() ([]store.ChannelMessage, string, error) {
+				return c.Store.ChannelSubscribe(ctx, st.name, st.scope, st.scopeID, st.from, limit)
+			}, st.name, diag)
+			if err != nil {
+				return errResult(fmt.Sprintf("await: read %q (after wake): %s", st.name, err)), nil
+			}
+			st.msgs = msgs
+			st.next = next
+			if satisfied() {
+				break loop
+			}
+			// Re-arm a fresh waker for the next publish on this channel
+			// (the fired one was drained by Notify).
+			c.Bus.Unregister(st.name, wakers[chosen])
+			wakers[chosen] = c.Bus.Register(st.name)
+		}
+	} else if !satisfied() {
+		// No long-poll budget (Bus nil / wait<=0): the single synchronous
+		// multi-read above is the whole answer; unmet ⇒ timed out.
+		timedOut = true
+	}
+
+	sat := satisfied()
+	fired := make([]string, 0, len(states))
+	results := make(map[string]any, len(states))
+	total := 0
+	for _, st := range states {
+		out := make([]map[string]any, 0, len(st.msgs))
+		for _, m := range st.msgs {
+			out = append(out, map[string]any{
+				"id":           m.ID,
+				"value":        m.Payload,
+				"published_at": m.PublishedAt.UTC().Format(time.RFC3339Nano),
+			})
+		}
+		if len(st.msgs) > 0 {
+			fired = append(fired, st.name)
+		}
+		results[st.name] = map[string]any{
+			"messages":    out,
+			"next_cursor": st.next,
+		}
+		total += len(st.msgs)
+	}
+
+	return okJSON(map[string]any{
+		"satisfied":      sat,
+		"timed_out":      timedOut && !sat,
+		"mode":           mode,
+		"fired":          fired,
+		"results":        results,
+		"total_messages": total,
+	})
 }
 
 func (c *Channel) execAck(ctx context.Context, policy tools.ChannelPolicyValue, in channelInput) (tools.Result, error) {

--- a/internal/tools/builtin/channel_await_test.go
+++ b/internal/tools/builtin/channel_await_test.go
@@ -197,6 +197,48 @@ func TestChannelAwait_NonCommitting(t *testing.T) {
 	}
 }
 
+// TestChannelAwait_MultiWakeReArm exercises the re-arm loop: a single
+// channel must accumulate 2 messages (at_least n=2) delivered as two
+// SEPARATE publishes while await long-polls. The first wake re-reads (1
+// msg, unmet), re-arms a fresh waker, and blocks again; the second
+// publish must wake it via the re-armed waker. This is the path the C1
+// register-before-read fix protects — if the re-arm dropped the second
+// Notify, this would hang to the timeout.
+func TestChannelAwait_MultiWakeReArm(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+
+	done := make(chan map[string]any, 1)
+	errc := make(chan string, 1)
+	go func() {
+		res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1"],"mode":"at_least","n":2,"wait_ms":5000}`))
+		if res.IsError {
+			errc <- res.Text
+			return
+		}
+		done <- decodeResult(t, res.Text)
+	}()
+
+	time.Sleep(40 * time.Millisecond)
+	mustPublish(t, tool, ctx, "c1") // wake 1 → 1 msg, n=2 unmet → re-arm
+	time.Sleep(40 * time.Millisecond)
+	mustPublish(t, tool, ctx, "c1") // wake 2 (via re-armed waker) → 2 msgs → satisfied
+
+	select {
+	case e := <-errc:
+		t.Fatalf("await: %s", e)
+	case out := <-done:
+		if out["satisfied"] != true {
+			t.Errorf("satisfied = %v, want true after 2 publishes", out["satisfied"])
+		}
+		if tm, _ := out["total_messages"].(float64); tm != 2 {
+			t.Errorf("total_messages = %v, want 2", out["total_messages"])
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("await did not return — second wake likely dropped (re-arm race)")
+	}
+}
+
 func TestChannelAwait_InSchemaEnum(t *testing.T) {
 	var schema struct {
 		Properties struct {

--- a/internal/tools/builtin/channel_await_test.go
+++ b/internal/tools/builtin/channel_await_test.go
@@ -1,0 +1,220 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// RFC S / F35 — Channel.await fan-in barrier. These tests fail on main
+// (await is an unknown op there).
+
+// awaitFixture builds a Channel tool over in-memory SQLite + a fresh Bus
+// with three GLOBAL channels c1/c2/c3 the agent may publish + subscribe,
+// plus "secret" which it may publish but NOT subscribe (ACL test).
+func awaitFixture(t *testing.T) (*Channel, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	tool := &Channel{
+		Store:         s,
+		Bus:           channels.NewBus(),
+		MaxValueBytes: 65536,
+		LongPollCapMS: 30000,
+	}
+	ctx := tools.WithAgentName(context.Background(), "consolidator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{UserID: "alice", AgentID: "a_test"})
+	ctx = tools.WithChannelPolicy(ctx, tools.ChannelPolicyValue{
+		Publish:   []string{"c1", "c2", "c3", "secret"},
+		Subscribe: []string{"c1", "c2", "c3"},
+		Channels: map[string]tools.ChannelDef{
+			"c1":     {Name: "c1", Scope: "global", Semantic: "queue"},
+			"c2":     {Name: "c2", Scope: "global", Semantic: "queue"},
+			"c3":     {Name: "c3", Scope: "global", Semantic: "queue"},
+			"secret": {Name: "secret", Scope: "global", Semantic: "queue"},
+		},
+	})
+	return tool, ctx, func() { _ = s.Close() }
+}
+
+func mustPublish(t *testing.T, tool *Channel, ctx context.Context, channel string) {
+	t.Helper()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"publish","channel":"`+channel+`","value":{"src":"`+channel+`"}}`))
+	if res.IsError {
+		t.Fatalf("publish %s: %s", channel, res.Text)
+	}
+}
+
+func TestChannelAwait_AtLeastNSynchronous(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+	mustPublish(t, tool, ctx, "c1")
+	mustPublish(t, tool, ctx, "c2")
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1","c2","c3"],"mode":"at_least","n":2}`))
+	if res.IsError {
+		t.Fatalf("await: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["satisfied"] != true {
+		t.Errorf("satisfied = %v, want true", out["satisfied"])
+	}
+	if out["timed_out"] != false {
+		t.Errorf("timed_out = %v, want false", out["timed_out"])
+	}
+	if tm, _ := out["total_messages"].(float64); tm < 2 {
+		t.Errorf("total_messages = %v, want >= 2", out["total_messages"])
+	}
+	fired, _ := out["fired"].([]any)
+	if len(fired) != 2 {
+		t.Errorf("fired = %v, want 2 channels", fired)
+	}
+}
+
+func TestChannelAwait_AnyLongPollWake(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+
+	type result struct {
+		out     map[string]any
+		isError bool
+		text    string
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1","c2"],"mode":"any","wait_ms":5000}`))
+		r := result{isError: res.IsError, text: res.Text, elapsed: time.Since(start)}
+		if !res.IsError {
+			r.out = decodeResult(t, res.Text)
+		}
+		done <- r
+	}()
+
+	// Publish ~50ms in — the await should wake and return well under the
+	// 5s budget.
+	time.Sleep(50 * time.Millisecond)
+	mustPublish(t, tool, ctx, "c2")
+
+	select {
+	case r := <-done:
+		if r.isError {
+			t.Fatalf("await: %s", r.text)
+		}
+		if r.out["satisfied"] != true {
+			t.Errorf("satisfied = %v, want true", r.out["satisfied"])
+		}
+		if r.elapsed > 3*time.Second {
+			t.Errorf("await took %v — should wake on publish, not wait the full 5s", r.elapsed)
+		}
+		fired, _ := r.out["fired"].([]any)
+		if len(fired) != 1 || fired[0] != "c2" {
+			t.Errorf("fired = %v, want [c2]", fired)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("await did not return within 6s — wake likely missed")
+	}
+}
+
+func TestChannelAwait_AllTimeoutPartial(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+	// Only 2 of the 3 channels get a message; mode=all can't be satisfied.
+	mustPublish(t, tool, ctx, "c1")
+	mustPublish(t, tool, ctx, "c2")
+
+	start := time.Now()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1","c2","c3"],"mode":"all","wait_ms":200}`))
+	elapsed := time.Since(start)
+	if res.IsError {
+		t.Fatalf("await must NOT error on timeout: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	if out["satisfied"] != false {
+		t.Errorf("satisfied = %v, want false", out["satisfied"])
+	}
+	if out["timed_out"] != true {
+		t.Errorf("timed_out = %v, want true", out["timed_out"])
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("returned in %v — should have waited ~200ms for the timeout", elapsed)
+	}
+	// Partial results: c1 + c2 fired, c3 empty.
+	results, _ := out["results"].(map[string]any)
+	if results == nil || results["c1"] == nil || results["c3"] == nil {
+		t.Fatalf("results missing channels: %v", out["results"])
+	}
+	c3 := results["c3"].(map[string]any)
+	if msgs, _ := c3["messages"].([]any); len(msgs) != 0 {
+		t.Errorf("c3 should have 0 messages, got %v", msgs)
+	}
+}
+
+func TestChannelAwait_ACLRefusedOnUnsubscribedChannel(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+	// "secret" is publish-only for this agent — await (subscribe-side) refuses.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1","secret"],"mode":"any"}`))
+	if !res.IsError {
+		t.Fatalf("await over an unsubscribed channel must be refused; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "subscribe") {
+		t.Errorf("refusal should mention subscribe ACL; got %s", res.Text)
+	}
+}
+
+func TestChannelAwait_NonCommitting(t *testing.T) {
+	tool, ctx, cleanup := awaitFixture(t)
+	defer cleanup()
+	mustPublish(t, tool, ctx, "c1")
+
+	// await detects the message...
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"await","channels":["c1"],"mode":"any"}`))
+	if res.IsError {
+		t.Fatalf("await: %s", res.Text)
+	}
+	if decodeResult(t, res.Text)["satisfied"] != true {
+		t.Fatal("await should be satisfied after a publish")
+	}
+
+	// ...but does NOT commit, so a subsequent subscribe still sees it.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"subscribe","channel":"c1","max_messages":10}`))
+	if res.IsError {
+		t.Fatalf("subscribe: %s", res.Text)
+	}
+	msgs, _ := decodeResult(t, res.Text)["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Errorf("subscribe after await got %d messages, want 1 (await must be non-committing)", len(msgs))
+	}
+}
+
+func TestChannelAwait_InSchemaEnum(t *testing.T) {
+	var schema struct {
+		Properties struct {
+			Op struct {
+				Enum []string `json:"enum"`
+			} `json:"op"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(channelInputSchema), &schema); err != nil {
+		t.Fatalf("channelInputSchema invalid JSON: %v", err)
+	}
+	found := false
+	for _, op := range schema.Properties.Op.Enum {
+		if op == "await" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("op enum %v missing \"await\"", schema.Properties.Op.Enum)
+	}
+}

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/help"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -70,8 +71,8 @@ type Context struct {
 const contextDescription = `Read-only runtime introspection. ` +
 	`Answers "what tools do I have? who am I? what permissions apply to me? ` +
 	`what other agents exist? what's my def's lineage and evaluation history? ` +
-	`what runtime concepts and recipes does loomcycle document?". ` +
-	`Operations: self, tools, doc, permissions, agents, lineage, evaluations, channels, history, help. ` +
+	`what runtime concepts and recipes does loomcycle document? what time is it / how long have I been running?". ` +
+	`Operations: self, tools, doc, permissions, agents, lineage, evaluations, channels, history, help, time. ` +
 	`Always safe to call — no side effects, no storage writes, no network calls. ` +
 	`Useful for self-evolving agents that build their own task plans and want to inspect ` +
 	`their environment before deciding what to do. ` +
@@ -81,7 +82,7 @@ const contextDescription = `Read-only runtime introspection. ` +
 const contextInputSchema = `{
   "type": "object",
   "properties": {
-    "op":              {"type": "string", "enum": ["self","tools","doc","permissions","agents","lineage","evaluations","channels","history","help"], "description": "Which introspection op to run."},
+    "op":              {"type": "string", "enum": ["self","tools","doc","permissions","agents","lineage","evaluations","channels","history","help","time"], "description": "Which introspection op to run."},
     "name":            {"type": "string", "description": "doc only: the tool name to fetch detailed docs for."},
     "prefix":          {"type": "string", "description": "agents / channels: optional name prefix filter."},
     "def_id":          {"type": "string", "description": "lineage / evaluations: the agent_defs row id to inspect. Use Context.agents to discover def_ids first."},
@@ -154,10 +155,12 @@ func (c *Context) Execute(ctx context.Context, raw json.RawMessage) (tools.Resul
 		return c.execHistory(ctx, in)
 	case "help":
 		return c.execHelp(ctx, in)
+	case "time":
+		return c.execTime(ctx)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions, agents, lineage, evaluations, channels, history, help)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: self, tools, doc, permissions, agents, lineage, evaluations, channels, history, help, time)", in.Op)), nil
 	}
 }
 
@@ -176,6 +179,41 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 		// Channel messages — the canonical way an Evaluator agent
 		// gets the Editor's run_id for `Evaluation.submit run_id=…`.
 		"run_id": tools.RunID(ctx),
+	}
+	return okJSON(out)
+}
+
+// ---- time ----
+
+// execTime gives the agent a clock (RFC S / F34). Without it an agent
+// can't compute a deadline, bucket a periodic cycle, or build a
+// `deliver_at` for Channel.publish's deferred-visibility timer — it
+// would have to shell out to Bash `date`.
+//
+// now_rfc3339 uses RFC3339Nano (UTC) to match the format Channel emits
+// for published_at / visible_at, so an agent can compare a message
+// timestamp against "now" without reformatting. run_started_at /
+// elapsed_ms come from providers.RunMeta.StartedAt — the wall-clock
+// anchor the loop stamps once per run (the same anchor code-js uses) —
+// and are OMITTED when RunMeta is absent or unstamped rather than
+// fabricated from a zero epoch.
+//
+// Determinism (code-js / replay): execTime reads time.Now() on first
+// execution only. Code-js runs replay tool RESULTS from the transcript
+// rather than re-invoking tools, so a recorded op=time result is
+// reproduced verbatim on replay — there's no need to special-case a
+// pinned clock here. Context stays side_effect_class "pure" (reading a
+// clock mutates nothing).
+func (c *Context) execTime(ctx context.Context) (tools.Result, error) {
+	now := time.Now().UTC()
+	out := map[string]any{
+		"now_rfc3339": now.Format(time.RFC3339Nano),
+		"unix_ms":     now.UnixMilli(),
+	}
+	if meta, ok := providers.RunMetaFromContext(ctx); ok && !meta.StartedAt.IsZero() {
+		started := meta.StartedAt.UTC()
+		out["run_started_at"] = started.Format(time.RFC3339Nano)
+		out["elapsed_ms"] = now.Sub(started).Milliseconds()
 	}
 	return okJSON(out)
 }

--- a/internal/tools/builtin/context_time_test.go
+++ b/internal/tools/builtin/context_time_test.go
@@ -1,0 +1,123 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// RFC S / F34 — Context op=time gives an agent a clock. These tests
+// fail on main (op=time is an unknown op there).
+
+func TestContextTool_TimeWithRunMeta(t *testing.T) {
+	tool := &Context{}
+	started := time.Now().Add(-5 * time.Second)
+	ctx := providers.WithRunMeta(context.Background(), providers.RunMeta{StartedAt: started})
+
+	before := time.Now().UnixMilli()
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"time"}`))
+	after := time.Now().UnixMilli()
+	if res.IsError {
+		t.Fatalf("time: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+
+	// now_rfc3339 parses as RFC3339Nano.
+	nowStr, _ := out["now_rfc3339"].(string)
+	if _, err := time.Parse(time.RFC3339Nano, nowStr); err != nil {
+		t.Errorf("now_rfc3339 %q does not parse as RFC3339Nano: %v", nowStr, err)
+	}
+
+	// unix_ms is within the call window.
+	unixMs, ok := out["unix_ms"].(float64)
+	if !ok {
+		t.Fatalf("unix_ms missing or not a number: %v", out["unix_ms"])
+	}
+	if int64(unixMs) < before || int64(unixMs) > after {
+		t.Errorf("unix_ms %d not in [%d, %d]", int64(unixMs), before, after)
+	}
+
+	// run_started_at parses + matches the anchor.
+	rsa, _ := out["run_started_at"].(string)
+	parsed, err := time.Parse(time.RFC3339Nano, rsa)
+	if err != nil {
+		t.Errorf("run_started_at %q does not parse: %v", rsa, err)
+	} else if d := parsed.Sub(started); d > time.Millisecond || d < -time.Millisecond {
+		t.Errorf("run_started_at %v drifted from anchor %v by %v", parsed, started, d)
+	}
+
+	// elapsed_ms ≈ 5000; wide tolerance for CI scheduling jitter.
+	elapsed, ok := out["elapsed_ms"].(float64)
+	if !ok {
+		t.Fatalf("elapsed_ms missing or not a number: %v", out["elapsed_ms"])
+	}
+	if elapsed < 4000 || elapsed > 8000 {
+		t.Errorf("elapsed_ms = %v, want ~5000 (±tol)", elapsed)
+	}
+}
+
+func TestContextTool_TimeNoRunMetaOmitsElapsed(t *testing.T) {
+	tool := &Context{}
+	res, _ := tool.Execute(context.Background(), json.RawMessage(`{"op":"time"}`))
+	if res.IsError {
+		t.Fatalf("time: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+	// now_rfc3339 + unix_ms always present.
+	if _, ok := out["unix_ms"].(float64); !ok {
+		t.Errorf("unix_ms missing without RunMeta — should always be present")
+	}
+	// run_started_at + elapsed_ms OMITTED (not fabricated) when no anchor.
+	if _, ok := out["run_started_at"]; ok {
+		t.Errorf("run_started_at present without RunMeta — should be omitted, not fabricated")
+	}
+	if _, ok := out["elapsed_ms"]; ok {
+		t.Errorf("elapsed_ms present without RunMeta — should be omitted, not fabricated")
+	}
+}
+
+func TestContextTool_TimeUnstampedRunMetaOmitsElapsed(t *testing.T) {
+	// RunMeta present but StartedAt zero (test/non-loop caller) → omit,
+	// don't fabricate an epoch.
+	tool := &Context{}
+	ctx := providers.WithRunMeta(context.Background(), providers.RunMeta{AgentName: "x"})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"time"}`))
+	out := decodeResult(t, res.Text)
+	if _, ok := out["run_started_at"]; ok {
+		t.Errorf("run_started_at present for zero StartedAt — should be omitted")
+	}
+	if _, ok := out["elapsed_ms"]; ok {
+		t.Errorf("elapsed_ms present for zero StartedAt — should be omitted")
+	}
+}
+
+func TestContextTool_TimeInSchemaEnum(t *testing.T) {
+	// Schema guard: "time" must be in the op enum so MCP auto-propagates it.
+	var schema struct {
+		Properties struct {
+			Op struct {
+				Enum []string `json:"enum"`
+			} `json:"op"`
+		} `json:"properties"`
+	}
+	if err := json.Unmarshal([]byte(contextInputSchema), &schema); err != nil {
+		t.Fatalf("contextInputSchema invalid JSON: %v", err)
+	}
+	found := false
+	for _, op := range schema.Properties.Op.Enum {
+		if op == "time" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("op enum %v missing \"time\"", schema.Properties.Op.Enum)
+	}
+	// Description op-list also lists it (human-facing surface).
+	if !strings.Contains(contextDescription, "time") {
+		t.Errorf("contextDescription op-list missing \"time\"")
+	}
+}


### PR DESCRIPTION
## Why

Experiment #5 (a scheduler-driven fan-out/fan-in ensemble: N collectors → a consolidator that waits for "N producers or a timeout") surfaced two gaps that forced hand-rolled workarounds. RFC S (internal handoff doc) specs three additive primitives; this PR lands the two the experiment needs (**P0 + P1**). P2 (`max_fires`, which adds a DB migration) is deferred to its own follow-up.

Both primitives are **purely additive** — every new op/field is optional and defaults to current behaviour, so the legacy path is byte-identical. No wire change beyond the MCP op-list strings (schema auto-propagates); no HTTP/connector/TS change (in-band tools).

## What

**P0 — `Context op=time` (F34, agent clock).** Agents had no way to read "now"/elapsed or build a `deliver_at` — they'd shell out to Bash `date`. Adds `op=time → {now_rfc3339, unix_ms, run_started_at?, elapsed_ms?}`, sourcing the anchor from `providers.RunMeta.StartedAt` (the loop's once-per-run stamp — no store round-trip), omitting `run_started_at`/`elapsed_ms` when RunMeta is absent/unstamped rather than fabricating an epoch. `now_rfc3339` is RFC3339Nano/UTC to match Channel's timestamps. Stays `side_effect_class: "pure"`.

**P1 — `Channel.await` (F35, fan-in combinator).** `subscribe` is single-channel; a consumer waiting for N producers had to poll-and-count with a pseudo-timeout. Adds `await {channels, mode: any|all|at_least, n, wait_ms} → {satisfied, timed_out, mode, fired, results, total_messages}`. A **new op** — it does not touch the concurrency-sensitive `subscribe` path. Generalizes subscribe's proven race-free pattern to N channels: per-channel subscribe-ACL resolution (RFC N tenancy honoured), register-all-wakers-before-read, dynamic-N `reflect.Select` over wakers + one timer + `ctx.Done()`, woken channel re-read via the same bounded MVCC retry. **Non-committing** (detection only — never advances cursors); timeout returns partials, never an error. The complement to `Agent.parallel_spawn` (which joins sub-agents): `await` joins independent producers (scheduler/webhook).

## What was tested

- **Fail-before regression tests**, verified red on `main` by reverting just the production code: `context_time_test.go` (4: RunMeta / no-RunMeta / unstamped / schema-enum) and `channel_await_test.go` (7: at_least sync, any long-poll wake, all+timeout partial, ACL refusal, non-committing, multi-wake re-arm, schema-enum). All run against a real sqlite store + live `Bus`.
- Full `go test ./...` green; `gofmt`/`go vet` clean; `go build ./...` green.
- **Code review** (adversarial, concurrency-focused) found one real bug — a missed-wake race in `await`'s waker re-registration (re-read before re-register inverted the register-before-read invariant). Fixed by re-arming first, then reading; added `TestChannelAwait_MultiWakeReArm` (hangs to timeout if a second wake is dropped). Reviewer confirmed predicate correctness, the non-committing contract, deferred-cleanup, and `ctx.Done()` handling are all sound.

## Deferred

P2 (`max_fires` self-retiring schedule) — adds a `schedule_run_state.fire_count` migration + scheduler/store changes; lands as a separate PR when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)