### PR TITLE
fix(scheduler): on_complete channel.publish honors the channel's declared scope (F37)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1862,6 +1862,10 @@ func main() {
 		// guaranteed non-nil in this branch (storeIface != nil ⇒ pause
 		// manager constructed earlier in this function).
 		sched := scheduler.New(schedCfg, storeIface, srv, pauseMgrRef, nil, log.Printf)
+		// Resolve on_complete: channel.publish to the channel's DECLARED scope
+		// (F37 / RFC T) so a hook on a scope:global channel lands at global,
+		// not under the run's user scope. Must be set before Start.
+		sched.SetChannelScope(srv.ResolveChannelScope)
 		sched.Start(bgCtx)
 		log.Printf("scheduler: enabled (tick=%ds, fire_timeout=%ds, env_allowlist=%d names)",
 			cfg.Env.SchedulerTickSeconds, cfg.Env.SchedulerFireTimeoutSeconds,

--- a/internal/api/http/channel_scope_resolve_test.go
+++ b/internal/api/http/channel_scope_resolve_test.go
@@ -1,0 +1,63 @@
+package http
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// TestResolveChannelScope_StaticRuntimeAndPrecedence covers the resolver the
+// scheduler's on_complete: channel.publish hook uses (F37 / RFC T): a static
+// yaml channel resolves to its declared scope, a runtime-substrate channel
+// resolves to its store scope, yaml wins on a name collision, and an
+// undeclared channel reports ok=false.
+func TestResolveChannelScope_StaticRuntimeAndPrecedence(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+
+	srv := &Server{
+		cfg: &config.Config{
+			Channels: map[string]config.Channel{
+				"static-global": {Scope: "global", Semantic: "queue"},
+				"static-user":   {Scope: "user", Semantic: "queue"},
+				// Same name as a runtime row below — yaml must win.
+				"shared": {Scope: "global", Semantic: "queue"},
+			},
+		},
+		store: st,
+	}
+
+	ctx := context.Background()
+	// Runtime-substrate channels: one unique, one colliding with yaml.
+	if err := st.ChannelsCreate(ctx, store.ChannelRow{Name: "runtime-agent", Scope: "agent", Semantic: "queue"}); err != nil {
+		t.Fatalf("ChannelsCreate runtime-agent: %v", err)
+	}
+	if err := st.ChannelsCreate(ctx, store.ChannelRow{Name: "shared", Scope: "user", Semantic: "queue"}); err != nil {
+		t.Fatalf("ChannelsCreate shared: %v", err)
+	}
+
+	cases := []struct {
+		channel   string
+		wantScope string
+		wantOK    bool
+	}{
+		{"static-global", "global", true},
+		{"static-user", "user", true},
+		{"runtime-agent", "agent", true},
+		{"shared", "global", true}, // yaml precedence over the runtime "user" row
+		{"undeclared", "", false},
+	}
+	for _, tc := range cases {
+		gotScope, gotOK := srv.ResolveChannelScope(ctx, tc.channel)
+		if gotScope != tc.wantScope || gotOK != tc.wantOK {
+			t.Errorf("ResolveChannelScope(%q) = (%q, %v), want (%q, %v)",
+				tc.channel, gotScope, gotOK, tc.wantScope, tc.wantOK)
+		}
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1349,7 +1349,17 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 // collision, matching ListChannels' precedence. The store read is skipped
 // when the agent has no channel allowlist at all (it can't touch a channel
 // either way), so the common no-channels run pays nothing.
-func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.AgentDef) tools.ChannelPolicyValue {
+// mergedChannelDefs returns the operator-declared channel defs by name —
+// static yaml (cfg.Channels) first, then runtime-substrate rows from the
+// store (yaml wins on a name collision). includeRuntime gates the store
+// query: callers needing only the static set (e.g. an agent with no channel
+// ACLs) pass false to skip the read.
+//
+// Single source of truth for a channel's declared scope: both
+// channelPolicyForAgent (the per-agent Channel tool policy) and
+// ResolveChannelScope (the scheduler on_complete publish path, F37) build on
+// it so static + runtime channels resolve identically everywhere.
+func (s *Server) mergedChannelDefs(ctx context.Context, includeRuntime bool) map[string]tools.ChannelDef {
 	channels := make(map[string]tools.ChannelDef, len(s.cfg.Channels))
 	for name, ch := range s.cfg.Channels {
 		channels[name] = tools.ChannelDef{
@@ -1361,7 +1371,7 @@ func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.Agen
 			Publisher:   ch.Publisher, // v0.8.6: agent publish refusal when "system"
 		}
 	}
-	if s.store != nil && (len(agentDef.Channels.Publish) > 0 || len(agentDef.Channels.Subscribe) > 0) {
+	if includeRuntime && s.store != nil {
 		if rows, err := s.store.ChannelsList(ctx); err == nil {
 			for _, r := range rows {
 				if _, exists := channels[r.Name]; exists {
@@ -1378,11 +1388,36 @@ func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.Agen
 			}
 		}
 	}
+	return channels
+}
+
+func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.AgentDef) tools.ChannelPolicyValue {
+	// Only pay the runtime store query when the agent can actually touch a
+	// channel — preserves the original fast path for channel-less agents.
+	includeRuntime := len(agentDef.Channels.Publish) > 0 || len(agentDef.Channels.Subscribe) > 0
 	return tools.ChannelPolicyValue{
 		Publish:   agentDef.Channels.Publish,
 		Subscribe: agentDef.Channels.Subscribe,
-		Channels:  channels,
+		Channels:  s.mergedChannelDefs(ctx, includeRuntime),
 	}
+}
+
+// ResolveChannelScope returns the declared scope ("global" | "user" |
+// "agent") of a channel by name, consulting static yaml + runtime substrate
+// (the same merge the Channel tool uses). ok=false when the channel is
+// declared nowhere.
+//
+// Injected into the scheduler so its on_complete: channel.publish hook lands
+// at the channel's DECLARED scope — a hook publishing to a scope:global
+// channel writes under global, not under the run's user scope where a global
+// reader (admin peek, Channel.await/subscribe resolving global) can't see it
+// (F37 / RFC T).
+func (s *Server) ResolveChannelScope(ctx context.Context, channel string) (string, bool) {
+	def, ok := s.mergedChannelDefs(ctx, true)[channel]
+	if !ok {
+		return "", false
+	}
+	return def.Scope, true
 }
 
 // fallbackForRun builds the v0.8.2 PR-2 runtime-fallback policy +

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1336,24 +1336,15 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 	return out
 }
 
-// channelPolicyForAgent builds the v0.8.4 Channel-tool policy from
-// the agent yaml + the top-level `channels:` block AND the runtime
-// channel store. Returns a value suitable for tools.WithChannelPolicy.
-// The Channels map is a copy of every declared channel — the tool layer
-// needs the per-channel scope/TTL/max_messages even for channels NOT in
-// this agent's allowlist (e.g. to phrase a useful refusal message).
-//
-// F29: a channel declared at runtime (POST /v1/_channels, persisted in
-// the `channels` table) must be usable for pub/sub exactly like a yaml
-// channel. We merge the runtime store into the map — yaml wins on a name
-// collision, matching ListChannels' precedence. The store read is skipped
-// when the agent has no channel allowlist at all (it can't touch a channel
-// either way), so the common no-channels run pays nothing.
 // mergedChannelDefs returns the operator-declared channel defs by name —
 // static yaml (cfg.Channels) first, then runtime-substrate rows from the
-// store (yaml wins on a name collision). includeRuntime gates the store
-// query: callers needing only the static set (e.g. an agent with no channel
-// ACLs) pass false to skip the read.
+// store (yaml wins on a name collision, matching ListChannels' precedence).
+// includeRuntime gates the store query: callers needing only the static set
+// pass false to skip the read.
+//
+// F29: a channel declared at runtime (POST /v1/_channels, persisted in the
+// `channels` table) must be usable for pub/sub exactly like a yaml channel,
+// so the runtime store is merged in here.
 //
 // Single source of truth for a channel's declared scope: both
 // channelPolicyForAgent (the per-agent Channel tool policy) and
@@ -1391,9 +1382,15 @@ func (s *Server) mergedChannelDefs(ctx context.Context, includeRuntime bool) map
 	return channels
 }
 
+// channelPolicyForAgent builds the v0.8.4 Channel-tool policy from the agent
+// yaml + the top-level `channels:` block AND the runtime channel store.
+// Returns a value suitable for tools.WithChannelPolicy. The Channels map is a
+// copy of every declared channel — the tool layer needs the per-channel
+// scope/TTL/max_messages even for channels NOT in this agent's allowlist
+// (e.g. to phrase a useful refusal message). The runtime store read is
+// skipped when the agent has no channel allowlist at all (it can't touch a
+// channel either way), so the common no-channels run pays nothing.
 func (s *Server) channelPolicyForAgent(ctx context.Context, agentDef config.AgentDef) tools.ChannelPolicyValue {
-	// Only pay the runtime store query when the agent can actually touch a
-	// channel — preserves the original fast path for channel-less agents.
 	includeRuntime := len(agentDef.Channels.Publish) > 0 || len(agentDef.Channels.Subscribe) > 0
 	return tools.ChannelPolicyValue{
 		Publish:   agentDef.Channels.Publish,

--- a/internal/scheduler/dispatch.go
+++ b/internal/scheduler/dispatch.go
@@ -33,17 +33,17 @@ type MCPCaller interface {
 // failed schedule to the hook delivery that follow-on consumed.
 func (s *Scheduler) dispatchHooks(ctx context.Context, scheduleName string, def scheduleDef, runID, agentID string) {
 	for i, h := range def.OnComplete {
-		if err := s.dispatchOneHook(ctx, scheduleName, def.UserID, h, runID, agentID); err != nil {
+		if err := s.dispatchOneHook(ctx, scheduleName, def.UserID, def.Agent, h, runID, agentID); err != nil {
 			s.logf("scheduler: schedule %q on_complete[%d] (%s) failed: %v",
 				scheduleName, i, h.Kind, err)
 		}
 	}
 }
 
-func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID string, h scheduleHook, runID, agentID string) error {
+func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID, agentName string, h scheduleHook, runID, agentID string) error {
 	switch h.Kind {
 	case "channel.publish":
-		return s.dispatchChannelPublish(ctx, scheduleName, userID, h, runID, agentID)
+		return s.dispatchChannelPublish(ctx, scheduleName, userID, agentName, h, runID, agentID)
 	case "memory.set":
 		return s.dispatchMemorySet(ctx, scheduleName, userID, h)
 	case "mcp.call":
@@ -55,7 +55,7 @@ func (s *Scheduler) dispatchOneHook(ctx context.Context, scheduleName, userID st
 	}
 }
 
-func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, userID string, h scheduleHook, runID, agentID string) error {
+func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, userID, agentName string, h scheduleHook, runID, agentID string) error {
 	if h.Channel == "" {
 		return fmt.Errorf("channel.publish missing `channel`")
 	}
@@ -68,11 +68,9 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	scope := store.MemoryScopeGlobal
-	scopeID := ""
-	if userID != "" {
-		scope = store.MemoryScopeUser
-		scopeID = userID
+	scope, scopeID, err := s.resolvePublishScope(ctx, h.Channel, userID, agentName)
+	if err != nil {
+		return err
 	}
 	msg := store.ChannelMessage{
 		Channel:           h.Channel,
@@ -89,6 +87,49 @@ func (s *Scheduler) dispatchChannelPublish(ctx context.Context, scheduleName, us
 	// a sweeper-side cap if operators report unbounded growth.
 	_, _, err = s.store.ChannelPublish(ctx, msg, 0)
 	return err
+}
+
+// resolvePublishScope returns the (scope, scopeID) an on_complete:
+// channel.publish hook should write under.
+//
+// With a resolver wired (the normal path), it honors the channel's DECLARED
+// scope (F37 / RFC T): a `scope: global` channel publishes at global/"" so a
+// global reader (admin peek, Channel.await/subscribe resolving global) can
+// see it — not under the run's user scope where it would be invisible. The
+// run's userID / agentName fill scope_id for user / agent channels. An
+// undeclared channel is an operator error and fails the hook loudly (logged
+// by dispatchHooks) rather than silently mis-scoping.
+//
+// With no resolver (nil — small embeds / tests that don't wire one), it
+// falls back to the legacy behavior: user scope when the schedule has a
+// user_id, else global.
+func (s *Scheduler) resolvePublishScope(ctx context.Context, channel, userID, agentName string) (store.MemoryScope, string, error) {
+	if s.chScope == nil {
+		if userID != "" {
+			return store.MemoryScopeUser, userID, nil
+		}
+		return store.MemoryScopeGlobal, "", nil
+	}
+	declared, ok := s.chScope(ctx, channel)
+	if !ok {
+		return "", "", fmt.Errorf("channel.publish: channel %q is not declared (static yaml or runtime substrate)", channel)
+	}
+	switch declared {
+	case "global":
+		return store.MemoryScopeGlobal, "", nil
+	case "user":
+		if userID == "" {
+			return "", "", fmt.Errorf("channel.publish: channel %q has scope=user but schedule has no user_id", channel)
+		}
+		return store.MemoryScopeUser, userID, nil
+	case "agent":
+		if agentName == "" {
+			return "", "", fmt.Errorf("channel.publish: channel %q has scope=agent but schedule has no agent", channel)
+		}
+		return store.MemoryScopeAgent, agentName, nil
+	default:
+		return "", "", fmt.Errorf("channel.publish: channel %q has unknown scope %q", channel, declared)
+	}
 }
 
 func (s *Scheduler) dispatchMemorySet(ctx context.Context, scheduleName, userID string, h scheduleHook) error {

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -1,0 +1,113 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// peekScopeCount returns how many messages sit on a channel at a specific
+// (scope, scope_id) — the F37 assertion needs scope granularity, which the
+// scope-blind ChannelStats can't give.
+func peekScopeCount(t *testing.T, st store.Store, channel string, scope store.MemoryScope, scopeID string) int {
+	t.Helper()
+	msgs, err := st.ChannelPeek(context.Background(), channel, scope, scopeID, "", 100)
+	if err != nil {
+		t.Fatalf("ChannelPeek(%s/%s): %v", scope, scopeID, err)
+	}
+	return len(msgs)
+}
+
+func channelHookDef(channel string) scheduleDef {
+	enabled := true
+	return scheduleDef{
+		Agent:    "researcher",
+		Schedule: "0 * * * *",
+		Enabled:  &enabled,
+		UserID:   "alice",
+		OnComplete: []scheduleHook{
+			{Kind: "channel.publish", Channel: channel, Payload: map[string]any{"top": 3}},
+		},
+	}
+}
+
+// TestScheduler_OnCompleteChannelPublish_HonorsGlobalScope is the F37 (RFC T)
+// regression: a hook publishing to a scope:global channel must land at
+// global/"" — where a global reader (admin peek, Channel.await/subscribe
+// resolving global) can see it — not under the run's user scope.
+//
+// Fail-before: without the resolver the publish goes to user/alice, so the
+// global peek returns 0 and the user peek returns 1 (both assertions flip).
+func TestScheduler_OnCompleteChannelPublish_HonorsGlobalScope(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("exp5-pings"), time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+
+	fireT(t, sched)
+
+	if got := peekScopeCount(t, st, "exp5-pings", store.MemoryScopeGlobal, ""); got != 1 {
+		t.Errorf("global/\"\" message count = %d, want 1 (F37: hook mis-scoped to user)", got)
+	}
+	if got := peekScopeCount(t, st, "exp5-pings", store.MemoryScopeUser, "alice"); got != 0 {
+		t.Errorf("user/alice message count = %d, want 0 (message should not be at user scope)", got)
+	}
+}
+
+// TestScheduler_OnCompleteChannelPublish_UserScope: a scope:user channel
+// still publishes under user/<user_id> (unchanged from pre-fix).
+func TestScheduler_OnCompleteChannelPublish_UserScope(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("results-alice"), time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "user", true })
+
+	fireT(t, sched)
+
+	if got := peekScopeCount(t, st, "results-alice", store.MemoryScopeUser, "alice"); got != 1 {
+		t.Errorf("user/alice message count = %d, want 1", got)
+	}
+	if got := peekScopeCount(t, st, "results-alice", store.MemoryScopeGlobal, ""); got != 0 {
+		t.Errorf("global/\"\" message count = %d, want 0", got)
+	}
+}
+
+// TestScheduler_OnCompleteChannelPublish_AgentScope: a scope:agent channel
+// publishes under agent/<agent name> (the schedule's def.Agent).
+func TestScheduler_OnCompleteChannelPublish_AgentScope(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("agent-bus"), time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "agent", true })
+
+	fireT(t, sched)
+
+	if got := peekScopeCount(t, st, "agent-bus", store.MemoryScopeAgent, "researcher"); got != 1 {
+		t.Errorf("agent/researcher message count = %d, want 1", got)
+	}
+}
+
+// TestScheduler_OnCompleteChannelPublish_UndeclaredFails: an undeclared
+// channel (resolver ok=false) fails the hook loudly rather than silently
+// mis-scoping — nothing is published.
+func TestScheduler_OnCompleteChannelPublish_UndeclaredFails(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("ghost"), time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "", false })
+
+	fireT(t, sched)
+
+	if got := channelMessageCount(t, st, "ghost"); got != 0 {
+		t.Errorf("undeclared channel message count = %d, want 0 (hook should fail, not publish)", got)
+	}
+}
+
+// TestScheduler_OnCompleteChannelPublish_LegacyNilResolver locks the
+// back-compat contract: with no resolver wired, a hook publishes under the
+// run's user scope (the pre-F37 behavior), so small embeds that don't inject
+// a resolver keep working.
+func TestScheduler_OnCompleteChannelPublish_LegacyNilResolver(t *testing.T) {
+	sched, _, _, _, st := schedulerFixture(t, channelHookDef("results-alice"), time.Now().Add(-1*time.Minute))
+	// No SetChannelScope call → chScope nil → legacy path.
+
+	fireT(t, sched)
+
+	if got := peekScopeCount(t, st, "results-alice", store.MemoryScopeUser, "alice"); got != 1 {
+		t.Errorf("legacy user/alice message count = %d, want 1", got)
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -62,12 +62,13 @@ func (c Config) defaults() Config {
 // Construction is via New + Start. Stop the goroutine via
 // (*Scheduler).Stop or by cancelling the ctx passed to Start.
 type Scheduler struct {
-	cfg    Config
-	store  store.Store
-	runner runner.Runner
-	pause  *pause.Manager
-	mcp    MCPCaller
-	logf   func(format string, args ...any)
+	cfg     Config
+	store   store.Store
+	runner  runner.Runner
+	pause   *pause.Manager
+	mcp     MCPCaller
+	chScope ChannelScopeResolver
+	logf    func(format string, args ...any)
 
 	wg     sync.WaitGroup
 	stopCh chan struct{}
@@ -96,6 +97,23 @@ type Scheduler struct {
 	// timeout cancels the RunOnce call (default 10m), which is the
 	// existing budget. No separate TTL needed.
 	inFlight sync.Map
+}
+
+// ChannelScopeResolver returns the declared scope ("global" | "user" |
+// "agent") of a channel by name. ok=false when the channel is declared
+// nowhere (static yaml + runtime substrate). Injected so the on_complete:
+// channel.publish hook publishes at the channel's declared scope instead of
+// blindly under the run's user scope (F37 / RFC T). Satisfied by
+// (*http.Server).ResolveChannelScope; nil leaves the legacy user-scope
+// behavior untouched.
+type ChannelScopeResolver func(ctx context.Context, channel string) (scope string, ok bool)
+
+// SetChannelScope wires the channel-scope resolver. Must be called before
+// Start (the sweeper reads chScope when dispatching on_complete hooks). A
+// no-op-safe setter rather than a New parameter so the many existing
+// New(...) call sites stay unchanged.
+func (s *Scheduler) SetChannelScope(r ChannelScopeResolver) {
+	s.chScope = r
 }
 
 // New constructs a Scheduler. All four runtime dependencies are


### PR DESCRIPTION
## Why

Sandbox **Experiment #5** (scheduler-driven fan-in) on v0.25.0 surfaced **F37** (RFC T): the scheduler's `on_complete: channel.publish` hook publishes under the **run's user scope** (`scope=user, scope_id=<user_id>`) regardless of the target channel's declared `scope`. A hook publishing to a `scope: global` channel lands in `user/<user_id>` instead of `global/""` — so a global reader (admin peek, `Channel.await`/`subscribe` resolving the channel as global) sees **zero** messages. **Silent**: the rows physically exist, just at a scope nobody reads.

Evidence (exp5): 5 collector hooks pinged the global `exp5-pings`; the consolidator's `Channel.await {mode:at_least, n:5}` returned `{satisfied:false, timed_out:true, total_messages:0}` and admin peek showed 0 — while `channel_messages` held the rows under `user/exp5`. The workaround was declaring the fan-in channel `scope: user`.

## What

- **`internal/api/http`** — extract the static-yaml + runtime-substrate channel-def merge out of `channelPolicyForAgent` into a shared `mergedChannelDefs`, and add **`ResolveChannelScope(ctx, channel) -> (scope, ok)`** on top of it. Single source of truth, so static + runtime channels resolve identically for both the Channel tool policy and the scheduler. The no-store fast path for channel-less agents is preserved (`includeRuntime` gate).
- **`internal/scheduler`** — `dispatchChannelPublish` now resolves the channel's **declared** scope via an injected `ChannelScopeResolver` and publishes under it: `global → scope_id=""`, `user → <run user_id>`, `agent → <agent name>`. An undeclared channel **fails the hook loudly** (logged by `dispatchHooks`) rather than silently mis-scoping. With **no resolver wired** the legacy user-scope behavior is preserved for small embeds. The agent name (`def.Agent`) is threaded through for `scope: agent` channels.
- **`cmd/loomcycle/main.go`** — inject `srv.ResolveChannelScope` into the scheduler before `Start`.

**`memory.set` is unaffected** — the RFC asked to check it; it already takes an *explicit* operator-specified `scope` (agent/user/global) rather than deriving one, so it has never had this defect.

## Tested

- `go test ./...` — clean (0 failures).
- **`internal/scheduler/dispatch_test.go`** (new, real sqlite store + real sweeper tick + real `ChannelPublish`):
  - `…_HonorsGlobalScope` — the **F37 regression**: a global-channel hook lands at `global/""`, asserts `user/alice` is empty (flips on the buggy path).
  - `…_UserScope` (unchanged: `user/<id>`), `…_AgentScope` (`agent/<name>`), `…_UndeclaredFails` (no publish), `…_LegacyNilResolver` (back-compat lock: pre-fix user-scope behavior with no resolver).
- **`internal/api/http/channel_scope_resolve_test.go`** (new) — `ResolveChannelScope` across static, runtime-substrate, yaml-precedence-on-collision, and undeclared.
- Deployable build: `go build -o bin/loomcycle ./cmd/loomcycle` OK.

With this fix the exp5 fan-in channel can be `scope: global` (the natural choice) instead of needing the `scope: user` workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)