### PR TITLE
fix(scheduler): scheduled-run agents resolve in the def's tenant (F38)

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -300,6 +300,13 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 	runErr := s.runner.RunOnce(fireCtx, in, cb)
 	status := "completed"
 	errStr := ""
+	// F36: every real fire counts toward max_fires (a wedged/always-failing
+	// schedule still retires). F38 exception: a fire that fails AGENT
+	// RESOLUTION never started a run — it's a config error (the agent isn't
+	// resolvable in the run's tenant), identical on every fire. Counting it
+	// would silently burn the cap and retire the schedule after N failures,
+	// masking the misconfig as N normal runs. Don't count it; log loudly.
+	countAsFire := true
 	if runErr != nil {
 		status = "failed"
 		errStr = runErr.Error()
@@ -309,6 +316,11 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		}
 		if errors.Is(runErr, runner.ErrPerUserQuotaExhausted) {
 			status = "skipped"
+		}
+		if errors.Is(runErr, runner.ErrUnknownAgent) {
+			countAsFire = false
+			s.logf("scheduler: schedule %q could not resolve agent %q in tenant %q — not counting toward max_fires; check the agent exists in this tenant (F38)",
+				row.Name, def.Agent, def.TenantID)
 		}
 		if errors.Is(runErr, context.DeadlineExceeded) {
 			// Disambiguate fireCtx (per-fire timeout) from parent ctx
@@ -355,8 +367,9 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 		NextRunAt:  next,
 		// RFC S / F36: this IS a fire (any status counts toward the cap, so
 		// a wedged/always-failing schedule still retires). The disabled-skip
-		// advance (advanceOnly) leaves this false.
-		CountAsFire: true,
+		// advance (advanceOnly) leaves this false; F38 leaves it false for an
+		// unresolved-agent config error (see countAsFire above).
+		CountAsFire: countAsFire,
 	}); err != nil {
 		s.logf("scheduler: record result for %q: %v", row.Name, err)
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -226,6 +226,36 @@ func TestScheduler_MaxFiresNotReachedKeepsActive(t *testing.T) {
 	}
 }
 
+// F38 — a fire that fails AGENT RESOLUTION (unknown agent) is a config error,
+// not a real fire: it must NOT count toward max_fires, else a misconfigured
+// schedule silently retires after N identical failures, masking the misconfig
+// as N normal runs. Fail-before: CountAsFire was hardcoded true, so fire_count
+// reaches 1 and the max_fires=1 def retires.
+func TestScheduler_MaxFiresNotBurnedOnUnknownAgent(t *testing.T) {
+	enabled := true
+	def := scheduleDef{Agent: "ghost-agent", Schedule: "0 * * * *", Enabled: &enabled, MaxFires: 1}
+	sched, fr, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	fr.runErr = runner.ErrUnknownAgent
+	ctx := context.Background()
+
+	fireT(t, sched)
+
+	if got := len(fr.Calls()); got != 1 {
+		t.Fatalf("RunOnce calls = %d, want 1 (the fire was attempted)", got)
+	}
+	state, _ := st.ScheduleRunStateGet(ctx, defID)
+	if state.FireCount != 0 {
+		t.Errorf("fire_count = %d, want 0 (an unknown-agent fire must not count toward max_fires)", state.FireCount)
+	}
+	row, err := st.ScheduleDefGet(ctx, defID)
+	if err != nil {
+		t.Fatalf("def get: %v", err)
+	}
+	if row.Retired {
+		t.Fatalf("def retired after an unknown-agent failure — max_fires must not have been reached")
+	}
+}
+
 func TestScheduler_RecordsCompletion(t *testing.T) {
 	enabled := true
 	def := scheduleDef{Agent: "researcher", Schedule: "0 * * * *", Enabled: &enabled}

--- a/internal/tools/builtin/scheduledef.go
+++ b/internal/tools/builtin/scheduledef.go
@@ -174,6 +174,17 @@ func (s *ScheduleDef) execCreate(ctx context.Context, policy tools.ScheduleDefPo
 	if err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
+	// F38: default the run-execution tenant (def body `tenant_id`) to the
+	// authoritative owning/principal tenant. The scheduler fire path sees
+	// ONLY the def body — not the row's owning tenant — so left empty the
+	// fired run resolves agents/skills/MCP at the shared "" tenant and can't
+	// find the creator's substrate agents (`unknown agent`). Defaulting it to
+	// the creator's tenant resolves them where they live; an explicit overlay
+	// tenant_id still wins (the documented owning-vs-execution split).
+	ident := tools.RunIdentity(ctx)
+	if def.TenantID == "" {
+		def.TenantID = ident.TenantID
+	}
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
@@ -188,8 +199,8 @@ func (s *ScheduleDef) execCreate(ctx context.Context, policy tools.ScheduleDefPo
 		return errResult(fmt.Sprintf("create: description (%d bytes) exceeds max %d", len(in.Description), s.MaxDescriptionBytes)), nil
 	}
 
-	// RFC N: stamp the def under the caller's authoritative tenant.
-	ident := tools.RunIdentity(ctx)
+	// RFC N: stamp the row under the caller's authoritative owning tenant
+	// (ident resolved above for the body default-stamp).
 	tenantID := ident.TenantID
 	row := store.ScheduleDefRow{
 		DefID:            mintDefID(),
@@ -311,6 +322,14 @@ func (s *ScheduleDef) execFork(ctx context.Context, policy tools.ScheduleDefPoli
 	def, err := s.buildDefinition(in.Name, string(parent.Definition), in.Overlay)
 	if err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil
+	}
+	// F38: default the run-execution tenant to the fork-owner's tenant (same
+	// rationale as create). A fork inherits the parent body's tenant_id; when
+	// that's empty (e.g. a legacy or pre-fix parent) default it so the fired
+	// run resolves the fork-owner's substrate agents instead of failing at the
+	// shared "" tenant. An explicit overlay tenant_id still wins.
+	if def.TenantID == "" {
+		def.TenantID = ident.TenantID
 	}
 	if err := validateScheduleDef(def); err != nil {
 		return errResult(fmt.Sprintf("fork: %s", err)), nil

--- a/internal/tools/builtin/scheduledef_test.go
+++ b/internal/tools/builtin/scheduledef_test.go
@@ -92,6 +92,89 @@ func TestScheduleDefTool_CreateNewName(t *testing.T) {
 	}
 }
 
+// ctxForTenant builds a ScheduleDef tool ctx scoped to a principal tenant,
+// for the F38 body-tenant tests.
+func ctxForTenant(tenant string) context.Context {
+	ctx := tools.WithAgentName(context.Background(), "scheduler-orchestrator")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", TenantID: tenant})
+	ctx = tools.WithScheduleDefPolicy(ctx, tools.ScheduleDefPolicyValue{
+		Scopes:   []string{"any"},
+		SelfName: "scheduler-orchestrator",
+	})
+	return ctx
+}
+
+// bodyTenant reads the persisted def body's tenant_id (the run-execution
+// tenant) for the active version under owningTenant.
+func bodyTenant(t *testing.T, tool *ScheduleDef, owningTenant, name string) string {
+	t.Helper()
+	row, err := tool.Store.ScheduleDefGetActive(context.Background(), owningTenant, name)
+	if err != nil {
+		t.Fatalf("get active %s/%s: %v", owningTenant, name, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(row.Definition, &m); err != nil {
+		t.Fatalf("unmarshal def: %v", err)
+	}
+	s, _ := m["tenant_id"].(string)
+	return s
+}
+
+// TestScheduleDefTool_CreateStampsBodyTenant (F38): create stamps the
+// run-execution tenant (def body tenant_id) from the authoritative principal,
+// so the scheduler-fired run resolves the creator's substrate agents (which
+// live under that tenant) instead of failing at the shared "" tenant.
+// Fail-before: the body tenant_id stays "" (only the row was stamped).
+func TestScheduleDefTool_CreateStampsBodyTenant(t *testing.T) {
+	tool, _, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctxForTenant("tnt-a"), json.RawMessage(`{"op":"create","name":"tenant-sched","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	if got := bodyTenant(t, tool, "tnt-a", "tenant-sched"); got != "tnt-a" {
+		t.Errorf("def body tenant_id = %q, want tnt-a (F38: a fired run would resolve agents at the wrong tenant)", got)
+	}
+}
+
+// TestScheduleDefTool_CreateExplicitBodyTenantWins: an explicit overlay
+// tenant_id overrides the principal-tenant default (the documented
+// owning-vs-execution split — an admin can author a def that runs as another
+// tenant).
+func TestScheduleDefTool_CreateExplicitBodyTenantWins(t *testing.T) {
+	tool, _, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctxForTenant("tnt-a"), json.RawMessage(`{"op":"create","name":"explicit-sched","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","tenant_id":"exec-b"}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	if got := bodyTenant(t, tool, "tnt-a", "explicit-sched"); got != "exec-b" {
+		t.Errorf("def body tenant_id = %q, want exec-b (explicit overlay must win)", got)
+	}
+}
+
+// TestScheduleDefTool_ForkStampsBodyTenant: a fork inherits the parent body's
+// tenant, and an empty inherited tenant defaults to the fork-owner's tenant
+// (F38). Here a dynamic base created under tnt-b is forked under tnt-b; the
+// fork's body tenant must be tnt-b.
+func TestScheduleDefTool_ForkStampsBodyTenant(t *testing.T) {
+	tool, _, cleanup := scheduleDefFixture(t)
+	defer cleanup()
+	ctx := ctxForTenant("tnt-b")
+
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"fork-base","overlay":{"agent":"job-search-batch","schedule":"0 9 * * 1","user_id":"alice"}}`)); res.IsError {
+		t.Fatalf("create base: %s", res.Text)
+	}
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"fork-base","overlay":{"user_id":"bob"}}`)); res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	if got := bodyTenant(t, tool, "tnt-b", "fork-base"); got != "tnt-b" {
+		t.Errorf("forked def body tenant_id = %q, want tnt-b", got)
+	}
+}
+
 func TestScheduleDefTool_CreateRefusesInvalidCron(t *testing.T) {
 	tool, ctx, cleanup := scheduleDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

Surfaced running the **fully-dynamic** sandbox Experiment #5 on v0.25.1 (RFC U / **F38**): a `scheduled_runs` def whose `agent` was created at runtime via `POST /v1/_agentdef` (promoted) fired on cadence but **failed every fire** with `unknown agent` — 0 runs. The *same* agent runs fine via `POST /v1/runs`.

## Root cause (corrected from the RFC's first read)

The scheduler fires through `srv.RunOnce`, which **does** resolve via the 3-tier `lookup.Agent` (static cfg → tenant-dynamic substrate → shared `""`). So substrate AgentDefs are reachable — the failure is a **tenant mismatch**:

- `RunOnce` resolves the agent at `RunInput.TenantID`, which `buildRunInput` reads from the def **body** (`definition.tenant_id`).
- On `POST /v1/_scheduledef`, create/fork stamped the principal's tenant onto the def **row** (the *owning* tenant) but **not into the def body** (the *run-execution* tenant) — so it stayed `""`.
- The fire path sees only the body → resolved agents at the shared `""` tenant → missed an AgentDef owned by the creator's tenant (e.g. `"default"` for the legacy bearer) → `unknown agent`.
- `/v1/runs` works because `applyPrincipal` stamps the principal's tenant → tier-1 hit.

The store even documents the split: `ScheduleDefRow.TenantID` is *"the def's OWNING tenant — distinct from the run-execution tenant carried inside the definition JSON."* The execution tenant just wasn't being defaulted to it.

## What

1. **`scheduledef.go` (`execCreate` / `execFork`)** — default the def body's `tenant_id` (run-execution tenant) to the authoritative owning/principal tenant when the overlay didn't set one. The existing `buildRunInput → RunOnce → lookup.Agent` chain then resolves the agent where it lives. An explicit overlay `tenant_id` still wins; static yaml agents are unaffected (tenant-agnostic cfg tier). `ScheduleDef` has no content hash, so stamping the body has no dedup/lineage impact.
2. **`scheduler.go` (`fireOne`)** — a fire that fails *agent resolution* (`ErrUnknownAgent`) no longer counts toward `max_fires` (and logs loudly). Previously a misconfig burned the cap and self-retired after N failures, masking itself as N normal runs. Genuine runtime failures still count.

**Forward-looking:** fixes newly created/forked schedules. An already-stored dynamic scheduledef with an empty body tenant would need re-creation (a fire-time fallback reading the row's owning tenant would need `ScheduleDueRow` + the due-query to carry tenant — a heavier change kept out of scope).

## Tested

- `go test ./...` — clean.
- `scheduledef_test.go`: `CreateStampsBodyTenant` (body `tenant_id` ← principal; fail-before: `""`), `CreateExplicitBodyTenantWins` (overlay overrides), `ForkStampsBodyTenant`.
- `scheduler_test.go`: `MaxFiresNotBurnedOnUnknownAgent` (fire attempted, `fire_count` stays 0, `max_fires=1` def not retired; fail-before: retired).
- Deployable build OK.

Runtime-only — no wire change, no `@loomcycle/client` bump. With this fix a fully runtime-authored scheduler ensemble (agentdef + scheduledef + channel + MCP, all via REST) runs end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)