### PR TITLE
fix(mcp): expand ${ENV} in dynamic stdio MCPServerDef env at spawn (F39)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2734,9 +2734,38 @@ func (r mcpActiveDefReader) ActiveMCPServerDef(ctx context.Context, tenant, name
 
 // spawnStdio is the transport-spawn core shared by the static yaml stdio
 // path (spawnStdioMCP) and the dynamic stdio path (the pool build
-// callback's stdio case, F31). envMap is rendered as sorted KEY=VALUE
-// strings — deterministic child env regardless of map iteration order.
+// callback's stdio case, F31).
+//
+// F39: command / args / env values are ExpandEnv'd HERE, at spawn. The static
+// yaml path arrives pre-expanded (config-load ExpandEnvs the whole file), so
+// this is an idempotent no-op for it; the DYNAMIC path stores raw ${...}
+// placeholders (kept literal in the def per F32) that never went through the
+// yaml-wide expansion, so without this a dynamic stdio server received the
+// literal "${LOOMCYCLE_X}" (and clobbered the inherited real var, since
+// cmd.Env appends def env AFTER the inherited environ). Expanding at spawn —
+// not baking into the stored def — keeps the persisted content free of the
+// resolved secret (F32). Uses the same allowlisted expander as yaml-load;
+// ${run.*} late-binding tokens pass through verbatim as before.
 func spawnStdio(name, command string, args []string, envMap map[string]string) (mcp.Caller, error) {
+	expandedArgs := make([]string, len(args))
+	for i, a := range args {
+		expandedArgs[i] = config.ExpandEnv(a)
+	}
+	return mcpstdio.Spawn(mcpstdio.Config{
+		Command: config.ExpandEnv(command),
+		Args:    expandedArgs,
+		Env:     expandedStdioEnv(envMap),
+		OnStderr: func(line string) {
+			log.Printf("mcp[%s]: %s", name, line)
+		},
+	})
+}
+
+// expandedStdioEnv renders an stdio env map as sorted KEY=VALUE strings,
+// ExpandEnv'ing each VALUE (F39). Sorted for a deterministic child env
+// regardless of map iteration order. Pure (no spawn) so the expansion is
+// unit-testable. See spawnStdio for the static-vs-dynamic rationale + F32.
+func expandedStdioEnv(envMap map[string]string) []string {
 	keys := make([]string, 0, len(envMap))
 	for k := range envMap {
 		keys = append(keys, k)
@@ -2744,16 +2773,9 @@ func spawnStdio(name, command string, args []string, envMap map[string]string) (
 	sort.Strings(keys)
 	env := make([]string, 0, len(keys))
 	for _, k := range keys {
-		env = append(env, k+"="+envMap[k])
+		env = append(env, k+"="+config.ExpandEnv(envMap[k]))
 	}
-	return mcpstdio.Spawn(mcpstdio.Config{
-		Command: command,
-		Args:    args,
-		Env:     env,
-		OnStderr: func(line string) {
-			log.Printf("mcp[%s]: %s", name, line)
-		},
-	})
+	return env
 }
 
 // applyAllowedToolsFilter — thin wrapper over mcp.ApplyAllowedToolsFilter.

--- a/cmd/loomcycle/main_test.go
+++ b/cmd/loomcycle/main_test.go
@@ -209,3 +209,27 @@ func TestResolveBuildInfo_DoesNotPanic(t *testing.T) {
 		}
 	}
 }
+
+// TestExpandedStdioEnv is the F39 regression: a dynamic stdio MCP server's env
+// values must be ExpandEnv'd at spawn (the static yaml path arrives
+// pre-expanded; the dynamic def stores raw ${...}). Allowlisted LOOMCYCLE_*
+// expands; literals and non-allowlisted ${...} pass through verbatim; output
+// is sorted by key. Fail-before: the value was emitted literally
+// (BOT_TOKEN=${LOOMCYCLE_F39_TOKEN}).
+func TestExpandedStdioEnv(t *testing.T) {
+	t.Setenv("LOOMCYCLE_F39_TOKEN", "s3cret")
+
+	got := expandedStdioEnv(map[string]string{
+		"BOT_TOKEN": "${LOOMCYCLE_F39_TOKEN}", // allowlisted → expands
+		"CHAT_ID":   "12345",                  // literal → unchanged
+		"PASSTHRU":  "${NOT_ALLOWLISTED}",     // off-allowlist → verbatim
+	})
+	want := []string{
+		"BOT_TOKEN=s3cret",
+		"CHAT_ID=12345",
+		"PASSTHRU=${NOT_ALLOWLISTED}",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expandedStdioEnv:\n got %q\nwant %q", got, want)
+	}
+}

--- a/internal/tools/mcp/dynamic.go
+++ b/internal/tools/mcp/dynamic.go
@@ -37,7 +37,9 @@ import "sync"
 // substitution placeholders intact — the http client's substitution
 // pass at request-build time resolves them (matches yaml-loaded
 // headers' semantics; see internal/tools/mcp/http/client.go). Env values
-// (stdio) are passed to the child literally — no ${} expansion.
+// (stdio) are likewise stored verbatim and ExpandEnv'd at spawn (F39, in
+// spawnStdio), not baked into the stored spec — so the placeholder, not the
+// resolved secret, persists (F32).
 type DynamicMCPServerSpec struct {
 	Name      string
 	Transport string // "http" | "streamable-http" | "stdio" (stdio gated by LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO)


### PR DESCRIPTION
## Why

Surfaced on the exp5 fully-dynamic variant (v0.25.2), RFC V / **F39**: a runtime-created **stdio** MCP server (`POST /v1/_mcpserverdef`) whose `env` uses `${LOOMCYCLE_*}` received the **literal** placeholder in the child — and because def env is appended after the inherited environ, the un-expanded literal also **clobbered** the real inherited var. The dynamic telegram MCP's `send_message` was correctly advertised + dispatched (F31/F33 hold) but hit the bot path `/bot${LOOMCYCLE_TELEGRAM_BOT_TOKEN}/sendMessage` → Telegram **HTTP 404**. The identical *static* yaml server sends fine.

## Root cause

`config-load` `ExpandEnv`s the **entire raw yaml** (`config.go:1978`), so static `mcp_servers.*` env/command/args arrive pre-expanded. The dynamic def stores raw `${...}` (kept literal by design, per F32) and never passes through that yaml-wide expansion — and `spawnStdio` (the spawn core shared by both paths) emitted env values without `ExpandEnv`. A static-vs-dynamic asymmetry.

## What

`spawnStdio` now `ExpandEnv`s the **command, args, and env values** at spawn:
- **Idempotent for static** (already expanded at load → no `${}` left) — no regression.
- **Corrective for dynamic** — resolves `${LOOMCYCLE_*}` to the real value.
- **At spawn, not baked** — the stored def / DB row keeps the `${ENV}` reference, not the resolved secret (F32).
- Same allowlisted expander as yaml-load; `${run.*}` late-binding tokens pass through verbatim as before.
- The deterministic env-build is extracted to a pure `expandedStdioEnv` helper so the expansion is unit-testable. Stale `dynamic.go` comment updated.

## Tested

- `go test ./...` — clean.
- `cmd/loomcycle/main_test.go::TestExpandedStdioEnv` — allowlisted `LOOMCYCLE_*` expands; literal + off-allowlist `${...}` pass through verbatim; sorted (fail-before: value emitted literally).
- Deployable build OK.

Runtime-only — no wire change, no `@loomcycle/client` bump. Closes the last residual on the exp5 fully-dynamic Telegram leg: a runtime-authored stdio MCP with `${LOOMCYCLE_*}` env now "just works" like the static one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)