### PR TITLE
feat(webui): answer agent interruptions inline in the /run terminal

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -110,6 +110,20 @@ export interface EventPayload {
   };
   error?: string;
   retry?: { provider?: string; attempt?: number; wait_ms?: number; reason?: string };
+  // interruption_pending sidecar (providers.InterruptionEventInfo): the agent
+  // raised a question via the Interruption tool and is now blocked. The run's
+  // SSE stream stays open and resumes once the interrupt is resolved (POST
+  // /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve). `options`, when
+  // present, is the fixed answer set the resolve must match.
+  interruption?: {
+    interrupt_id: string;
+    kind?: string;
+    question?: string;
+    options?: string[];
+    context?: string;
+    priority?: string;
+    expires_at?: string;
+  };
 }
 
 // v0.9.x — payloads for event types whose shape doesn't fit

--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -1,13 +1,14 @@
 import { useState } from "react";
 import TerminalTranscript from "./TerminalTranscript";
-import { type RunStatus } from "../hooks/useRunStream";
+import { type PendingInterrupt, type RunStatus } from "../hooks/useRunStream";
 import { type TranscriptEvent } from "../api";
 
 // LiveRunPane renders one run's live transcript + controls. Decoupled
 // from useRunStream (takes plain props) so both the single-run tab and
 // each ensemble cell can render it. Shows a status pill, the streamed
 // transcript via the shared TerminalTranscript, a Cancel button while
-// running, and a Continue input once a session exists (multi-turn).
+// running, an inline Interruption prompt (Claude-Code-style) when the agent
+// asks a question, and a Continue input once a session exists (multi-turn).
 export default function LiveRunPane({
   events,
   status,
@@ -16,6 +17,8 @@ export default function LiveRunPane({
   error,
   onCancel,
   onContinue,
+  pendingInterrupt,
+  onAnswerInterrupt,
   compact,
 }: {
   events: TranscriptEvent[];
@@ -25,6 +28,8 @@ export default function LiveRunPane({
   error: string | null;
   onCancel: () => void;
   onContinue?: (prompt: string) => void;
+  pendingInterrupt?: PendingInterrupt | null;
+  onAnswerInterrupt?: (answer: string) => void;
   compact?: boolean;
 }) {
   const [followUp, setFollowUp] = useState("");
@@ -56,16 +61,91 @@ export default function LiveRunPane({
         <TerminalTranscript events={events} />
       )}
 
-      {onContinue && sessionId && status !== "running" && status !== "idle" && (
-        <form className="live-run-continue" onSubmit={handleContinue}>
+      {/* Inline interruption prompt — the agent is blocked on a question; the
+          same SSE stream resumes once it's answered. Takes precedence over the
+          continue box (which only shows between turns). */}
+      {pendingInterrupt && onAnswerInterrupt && (
+        <InterruptPrompt pending={pendingInterrupt} onAnswer={onAnswerInterrupt} />
+      )}
+
+      {onContinue &&
+        sessionId &&
+        !pendingInterrupt &&
+        status !== "running" &&
+        status !== "idle" && (
+          <form className="live-run-continue" onSubmit={handleContinue}>
+            <input
+              type="text"
+              value={followUp}
+              onChange={(e) => setFollowUp(e.target.value)}
+              placeholder="Continue the conversation…"
+            />
+            <button type="submit" disabled={!followUp.trim()}>
+              Send
+            </button>
+          </form>
+        )}
+    </div>
+  );
+}
+
+// InterruptPrompt renders the agent's pending question inline: a button per
+// option when the ask declared a fixed set, else a free-text answer box.
+function InterruptPrompt({
+  pending,
+  onAnswer,
+}: {
+  pending: PendingInterrupt;
+  onAnswer: (answer: string) => void;
+}) {
+  const [text, setText] = useState("");
+  const hasOptions = pending.options && pending.options.length > 0;
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    onAnswer(text.trim());
+    setText("");
+  };
+
+  return (
+    <div className="live-run-interrupt">
+      <div className="live-run-interrupt-q">
+        <span className="live-run-interrupt-badge">interruption</span>
+        {pending.priority && pending.priority !== "normal" && (
+          <span className={`live-run-interrupt-prio prio-${pending.priority}`}>
+            {pending.priority}
+          </span>
+        )}
+        <span>{pending.question || "(the agent is waiting for input)"}</span>
+      </div>
+      {pending.context && (
+        <div className="live-run-interrupt-context">{pending.context}</div>
+      )}
+      {hasOptions ? (
+        <div className="live-run-interrupt-options">
+          {pending.options!.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              className="live-run-interrupt-option"
+              onClick={() => onAnswer(opt)}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <form className="live-run-interrupt-form" onSubmit={submit}>
           <input
             type="text"
-            value={followUp}
-            onChange={(e) => setFollowUp(e.target.value)}
-            placeholder="Continue the conversation…"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Type your answer…"
+            autoFocus
           />
-          <button type="submit" disabled={!followUp.trim()}>
-            Send
+          <button type="submit" disabled={!text.trim()}>
+            Answer
           </button>
         </form>
       )}

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -138,6 +138,14 @@ function formatLine(row: TranscriptEvent): FormattedLine {
     }
     case "error":
       return { key, ts, kind, cls: "tl-error", payload: oneLine(ev.error ?? "") };
+    case "interruption_pending": {
+      const i = ev.interruption;
+      const opts = i?.options && i.options.length > 0 ? ` [${i.options.join(" | ")}]` : "";
+      return {
+        key, ts, kind, cls: "tl-interrupt",
+        payload: `❓ ${oneLine(i?.question ?? "")}${opts}`.trimEnd(),
+      };
+    }
     case "started":
       return { key, ts, kind, cls: "tl-meta", payload: "" };
     case "session":

--- a/web/src/hooks/useRunStream.ts
+++ b/web/src/hooks/useRunStream.ts
@@ -2,12 +2,25 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   cancelAgent,
   continueSession,
+  resolveInterrupt,
   startRun,
   sseEventToTranscript,
   type EventPayload,
   type StartRunRequest,
   type TranscriptEvent,
 } from "../api";
+
+// PendingInterrupt is the inline-prompt shape the terminal renders when the
+// running agent raises an Interruption question (the `interruption_pending`
+// SSE event). Answering it resolves the interrupt and the SAME stream resumes.
+export interface PendingInterrupt {
+  interruptId: string;
+  question: string;
+  options?: string[];
+  context?: string;
+  priority?: string;
+  expiresAt?: string;
+}
 
 // useRunStream owns one live run's stream lifecycle: it POSTs /v1/runs (or
 // a continuation), reduces the SSE frames into the TranscriptEvent[] shape
@@ -34,6 +47,11 @@ export interface UseRunStream {
   sessionId: string;
   runId: string;
   error: string | null;
+  // pendingInterrupt is set while the running agent is blocked on an
+  // Interruption question; answerInterrupt resolves it inline and the stream
+  // resumes. null when nothing is pending.
+  pendingInterrupt: PendingInterrupt | null;
+  answerInterrupt: (answer: string) => void;
   start: (req: StartRunRequest) => void;
   sendMessage: (prompt: string) => void;
   cancel: () => void;
@@ -47,9 +65,13 @@ export function useRunStream(): UseRunStream {
   const [sessionId, setSessionId] = useState("");
   const [runId, setRunId] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [pendingInterrupt, setPendingInterrupt] = useState<PendingInterrupt | null>(null);
 
   const seqRef = useRef(0);
   const ctrlRef = useRef<AbortController | null>(null);
+  // runId mirror so answerInterrupt resolves against the live run_id without a
+  // stale-closure race (the click happens after the `agent` frame set it).
+  const runIdRef = useRef("");
 
   // Abort the in-flight stream on unmount so a navigated-away run doesn't
   // keep a dangling reader. (Does not cancel the run server-side — that's
@@ -70,19 +92,56 @@ export function useRunStream(): UseRunStream {
     }
     if (f.event === "agent") {
       if (typeof parsed.agent_id === "string") setAgentId(parsed.agent_id);
-      if (typeof parsed.run_id === "string") setRunId(parsed.run_id);
+      if (typeof parsed.run_id === "string") {
+        setRunId(parsed.run_id);
+        runIdRef.current = parsed.run_id;
+      }
       if (typeof parsed.session_id === "string" && parsed.session_id)
         setSessionId(parsed.session_id);
       return;
     }
     const ev = parsed as unknown as EventPayload;
-    if (ev.type === "done") setStatus("completed");
+    if (ev.type === "done") {
+      setStatus("completed");
+      setPendingInterrupt(null);
+    }
     if (ev.type === "error") {
       setStatus("failed");
       if (typeof ev.error === "string") setError(ev.error);
+      setPendingInterrupt(null);
+    }
+    // The agent raised an Interruption question and is now blocked; surface it
+    // as an inline prompt. The event is also pushed to the transcript below so
+    // it stays in the scrollback.
+    if (ev.type === "interruption_pending" && ev.interruption?.interrupt_id) {
+      const i = ev.interruption;
+      setPendingInterrupt({
+        interruptId: i.interrupt_id,
+        question: i.question ?? "",
+        options: i.options,
+        context: i.context,
+        priority: i.priority,
+        expiresAt: i.expires_at,
+      });
     }
     setEvents((prev) => [...prev, sseEventToTranscript(seqRef.current++, ev)]);
   }, []);
+
+  const answerInterrupt = useCallback(
+    (answer: string) => {
+      const rid = runIdRef.current;
+      const cur = pendingInterrupt;
+      if (!rid || !cur) return;
+      // Optimistically clear the prompt; the agent wakes and the same stream
+      // resumes. Surface a failure (e.g. already resolved / expired) in the
+      // error banner.
+      setPendingInterrupt(null);
+      void resolveInterrupt(rid, cur.interruptId, answer).catch((e) => {
+        setError(e instanceof Error ? e.message : String(e));
+      });
+    },
+    [pendingInterrupt],
+  );
 
   const runStream = useCallback(
     (promise: Promise<void>) => {
@@ -113,7 +172,9 @@ export function useRunStream(): UseRunStream {
       setAgentId(req.agent_id ?? "");
       setSessionId("");
       setRunId("");
+      runIdRef.current = "";
       setError(null);
+      setPendingInterrupt(null);
       setStatus("running");
       runStream(startRun(req, { onFrame, signal: ctrl.signal }));
     },
@@ -127,6 +188,7 @@ export function useRunStream(): UseRunStream {
       const ctrl = new AbortController();
       ctrlRef.current = ctrl;
       setError(null);
+      setPendingInterrupt(null);
       setStatus("running");
       runStream(
         continueSession(sessionId, prompt, { onFrame, signal: ctrl.signal }),
@@ -152,7 +214,9 @@ export function useRunStream(): UseRunStream {
     setAgentId("");
     setSessionId("");
     setRunId("");
+    runIdRef.current = "";
     setError(null);
+    setPendingInterrupt(null);
     setStatus("idle");
   }, []);
 
@@ -163,6 +227,8 @@ export function useRunStream(): UseRunStream {
     sessionId,
     runId,
     error,
+    pendingInterrupt,
+    answerInterrupt,
     start,
     sendMessage,
     cancel,

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -117,6 +117,8 @@ function SingleRunTab({
           error={run.error}
           onCancel={run.cancel}
           onContinue={run.sendMessage}
+          pendingInterrupt={run.pendingInterrupt}
+          onAnswerInterrupt={run.answerInterrupt}
         />
       </div>
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -528,6 +528,10 @@ pre {
   color: var(--fg-soft);
   opacity: 0.75;
 }
+.tl-row.tl-interrupt .tl-payload,
+.tl-row.tl-interrupt .tl-kind {
+  color: #fbbf24;
+}
 .agent-link {
   display: flex;
   gap: 8px;
@@ -4083,6 +4087,76 @@ button.primary:disabled {
 }
 .live-run-pane-compact {
   min-height: 180px;
+}
+
+/* Inline interruption prompt (Claude-Code-style) — the agent is blocked on a
+   question and the same SSE stream resumes once answered. */
+.live-run-interrupt {
+  border-top: 1px solid var(--border, #2a2a32);
+  border-left: 3px solid #fbbf24;
+  background: rgba(251, 191, 36, 0.08);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.live-run-interrupt-q {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--fg);
+}
+.live-run-interrupt-badge {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: rgba(251, 191, 36, 0.18);
+  color: #fbbf24;
+  flex-shrink: 0;
+}
+.live-run-interrupt-prio {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+.live-run-interrupt-prio.prio-high {
+  background: rgba(255, 93, 104, 0.18);
+  color: var(--failed);
+}
+.live-run-interrupt-prio.prio-low {
+  background: var(--bg-soft-2);
+  color: var(--fg-soft);
+}
+.live-run-interrupt-context {
+  font-size: 12px;
+  color: var(--fg-soft);
+}
+.live-run-interrupt-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.live-run-interrupt-option {
+  background: var(--bg-soft-2);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 5px 12px;
+  cursor: pointer;
+}
+.live-run-interrupt-option:hover {
+  border-color: #fbbf24;
+}
+.live-run-interrupt-form {
+  display: flex;
+  gap: 8px;
+}
+.live-run-interrupt-form input {
+  flex: 1;
 }
 
 /* run mode tabs */


### PR DESCRIPTION
First slice of the interactive-terminal feature (plan PR A) — **UI-only, no backend change.**

## Why
When an agent asks a question via the Interruption tool, the `/run` live terminal goes silent and the operator must leave for the separate `/interrupts` inbox. But the run's SSE stream already emits `interruption_pending` (question/options/context/priority) *before* the agent blocks, and resolving via the existing `POST /v1/runs/{id}/interrupts/{id}/resolve` wakes the parked run on the **same open stream**. This surfaces that inline, Claude-Code-style.

## What
- **`api.ts`** — add the `interruption` sidecar to `EventPayload`.
- **`useRunStream`** — capture `interruption_pending` into a `pendingInterrupt` state (cleared on resolve / done / error / new turn); expose `answerInterrupt(answer)` that resolves against the live `run_id` (via a ref to avoid a stale-closure race), optimistically clears the prompt, and surfaces a failure in the error banner. The same SSE stream resumes on the agent side.
- **`LiveRunPane`** — inline prompt when pending: **option buttons** when the ask declared a fixed set, else a **free-text** answer box. Takes precedence over the between-turns continue box.
- **`TerminalTranscript`** — render `interruption_pending` as a distinct (amber) row so the question stays in the scrollback.
- **`RunView`** single-run + `styles.css`.

Optional props, so the fan-out / orchestrator cells are unaffected.

## Tested
- `cd web && npm run build` (tsc --noEmit + vite) green.
- Manual: start an interruption-enabled agent that calls `ask`; the question renders inline; answering (button or text) resumes the stream. Fallback unchanged: the `/interrupts` inbox still works if a resolve fails transiently.

Part of the interactive-terminal plan (next: unbounded iterations, mid-run steering, persistent runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)