### PR TITLE
feat(agent): per-agent unbounded_iterations for interactive LLM runs

### DIFF
--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -120,6 +120,10 @@ type AgentContent struct {
 	Skills                []string                   `json:"skills,omitempty"`
 	SystemPrompt          string                     `json:"system_prompt,omitempty"`
 	Tier                  string                     `json:"tier,omitempty"`
+	// UnboundedIterations is content-identifying (like MaxIterations): a fork
+	// that only flips it must get a distinct content_sha256, not silently
+	// dedup (cf. F14). omitempty keeps pre-existing rows byte-identical.
+	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
 }
 
 // Sign returns "sha256:" + the lowercase-hex SHA-256 of the canonical

--- a/internal/agents/sign_test.go
+++ b/internal/agents/sign_test.go
@@ -19,6 +19,23 @@ func TestSign_PrefixedHex(t *testing.T) {
 	}
 }
 
+// UnboundedIterations is content-identifying: two agents differing only in it
+// must hash differently (F14-class — else a fork toggling it silently dedups),
+// and an unset (false) flag must hash identically to an agent without it
+// (omitempty keeps pre-existing rows byte-identical → no re-backfill).
+func TestSign_UnboundedIterations_IsContentIdentifying(t *testing.T) {
+	base := AgentContent{Name: "term-agent", SystemPrompt: "interactive"}
+	withFlag := base
+	withFlag.UnboundedIterations = true
+
+	if Sign(base) == Sign(withFlag) {
+		t.Error("UnboundedIterations not content-identifying: enabling it did not change the hash")
+	}
+	if got, want := Sign(base), Sign(AgentContent{Name: "term-agent", SystemPrompt: "interactive", UnboundedIterations: false}); got != want {
+		t.Errorf("unset UnboundedIterations changed the hash (omitempty broken): %s vs %s", got, want)
+	}
+}
+
 func TestSign_DeterministicAcrossCalls(t *testing.T) {
 	c := AgentContent{
 		Name:         "researcher",

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1246,20 +1246,21 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 	// into the merge by accident; an inline anonymous struct keeps
 	// the overlay surface explicit.
 	var ov struct {
-		Provider         string                            `json:"provider,omitempty"`
-		Model            string                            `json:"model,omitempty"`
-		Tier             string                            `json:"tier,omitempty"`
-		Effort           string                            `json:"effort,omitempty"`
-		MaxTokens        int                               `json:"max_tokens,omitempty"`
-		MaxIterations    int                               `json:"max_iterations,omitempty"`
-		SystemPrompt     string                            `json:"system_prompt,omitempty"`
-		AllowedTools     []string                          `json:"allowed_tools,omitempty"`
-		Skills           []string                          `json:"skills,omitempty"`
-		Providers        []string                          `json:"providers,omitempty"`
-		Models           map[string][]config.TierCandidate `json:"models,omitempty"`
-		MemoryScopes     []string                          `json:"memory_scopes,omitempty"`
-		MemoryQuotaBytes int                               `json:"memory_quota_bytes,omitempty"`
-		MemoryBackend    string                            `json:"memory_backend,omitempty"`
+		Provider            string                            `json:"provider,omitempty"`
+		Model               string                            `json:"model,omitempty"`
+		Tier                string                            `json:"tier,omitempty"`
+		Effort              string                            `json:"effort,omitempty"`
+		MaxTokens           int                               `json:"max_tokens,omitempty"`
+		MaxIterations       int                               `json:"max_iterations,omitempty"`
+		UnboundedIterations bool                              `json:"unbounded_iterations,omitempty"`
+		SystemPrompt        string                            `json:"system_prompt,omitempty"`
+		AllowedTools        []string                          `json:"allowed_tools,omitempty"`
+		Skills              []string                          `json:"skills,omitempty"`
+		Providers           []string                          `json:"providers,omitempty"`
+		Models              map[string][]config.TierCandidate `json:"models,omitempty"`
+		MemoryScopes        []string                          `json:"memory_scopes,omitempty"`
+		MemoryQuotaBytes    int                               `json:"memory_quota_bytes,omitempty"`
+		MemoryBackend       string                            `json:"memory_backend,omitempty"`
 		// *int because 0 is a meaningful explicit value ("force no
 		// retries"); non-pointer would collapse "not in overlay" and
 		// "explicitly disable" into the same case and silently strip
@@ -1301,6 +1302,9 @@ func applyAgentDefOverlay(base config.AgentDef, definition json.RawMessage) conf
 	}
 	if ov.MaxIterations != 0 {
 		out.MaxIterations = ov.MaxIterations
+	}
+	if ov.UnboundedIterations {
+		out.UnboundedIterations = true
 	}
 	if ov.SystemPrompt != "" {
 		out.SystemPrompt = ov.SystemPrompt
@@ -1798,6 +1802,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations:    agentDef.UnboundedIterations,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(in.UserTier),
@@ -2994,6 +2999,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations:    agentDef.UnboundedIterations,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(req.UserTier),
@@ -3380,6 +3386,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations:    agentDef.UnboundedIterations,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(body.UserTier),
@@ -4043,22 +4050,23 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 
 	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), name, parentTier)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
-		Provider:        provider,
-		Model:           model,
-		Tools:           subTools,
-		Dispatcher:      subDispatcher,
-		Segments:        segs,
-		OnEvent:         subEmit,
-		OnHeartbeat:     subHeartbeat,
-		MaxTokens:       def.MaxTokens,     // 0 → driver default
-		MaxIterations:   def.MaxIterations, // 0 → loop default (16)
-		Effort:          effort,
-		MarkStalled:     s.markStalledFn(providerID, model),
-		MarkRateLimited: s.markRateLimitedFn(parentTier),
-		ClearStall:      s.clearStallFn(providerID, model),
-		ToolParallelism: s.cfg.Env.ToolParallelism,
-		AgentName:       name,
-		CodeBody:        def.Code, // inline code-js body (RFC J); "" → FS fallback
+		Provider:            provider,
+		Model:               model,
+		Tools:               subTools,
+		Dispatcher:          subDispatcher,
+		Segments:            segs,
+		OnEvent:             subEmit,
+		OnHeartbeat:         subHeartbeat,
+		MaxTokens:           def.MaxTokens,     // 0 → driver default
+		MaxIterations:       def.MaxIterations, // 0 → loop default (16)
+		UnboundedIterations: def.UnboundedIterations,
+		Effort:              effort,
+		MarkStalled:         s.markStalledFn(providerID, model),
+		MarkRateLimited:     s.markRateLimitedFn(parentTier),
+		ClearStall:          s.clearStallFn(providerID, model),
+		ToolParallelism:     s.cfg.Env.ToolParallelism,
+		AgentName:           name,
+		CodeBody:            def.Code, // inline code-js body (RFC J); "" → FS fallback
 		// A code-js sub-agent's wall-clock budget is its OWN per-agent
 		// run_timeout_seconds — a spawn has no ad-hoc per-run knob, so
 		// per-agent is the sole source (== pickRunTimeout(0, def...)). Without

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -560,6 +560,15 @@ type AgentDef struct {
 	// (2026-05-21).
 	MaxIterations int `yaml:"max_iterations"`
 
+	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
+	// (the 1<<20 hard backstop in the loop still applies as a runaway guard).
+	// Cancel is the stop, and LLM runs have no wall-clock timeout — use this
+	// for interactive / terminal-driven agents whose turn count is
+	// operator-driven, not bounded by a fixed task. Code-js agents are
+	// already exempt via their provider Capabilities().UnboundedIterations;
+	// this is the LLM-side opt-in.
+	UnboundedIterations bool `yaml:"unbounded_iterations"`
+
 	// MaxConcurrentChildren caps how many sub-agents this agent may
 	// spawn in parallel via Agent.parallel_spawn (v0.11.8+). Zero =
 	// use the runtime default (4 — see builtin.DefaultMaxConcurrentChildren).

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -176,6 +176,9 @@ type SubstrateAgentDef struct {
 	Effort        string `json:"effort,omitempty"`
 	MaxTokens     int    `json:"max_tokens,omitempty"`
 	MaxIterations int    `json:"max_iterations,omitempty"`
+	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
+	// (interactive runs). Mirrors mergedDef; the drift test pins parity.
+	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
 	// MaxConcurrentChildren caps how many sub-agents this agent may
 	// spawn in parallel via Agent.parallel_spawn. 0 = use runtime
 	// default (DefaultMaxConcurrentChildren = 4). Mirrors the
@@ -225,6 +228,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Effort:                s.Effort,
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
+		UnboundedIterations:   s.UnboundedIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,
 		RunTimeoutSeconds:     s.RunTimeoutSeconds,
 		SystemPrompt:          s.SystemPrompt,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -285,6 +285,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"effort":                  true,
 		"max_tokens":              true,
 		"max_iterations":          true,
+		"unbounded_iterations":    true, // lift the iteration soft-cap for interactive LLM agents
 		"max_concurrent_children": true,
 		"system_prompt":           true,
 		"system_prompt_base":      true,
@@ -311,6 +312,16 @@ func TestAgent_DriftDetection(t *testing.T) {
 		if !want[tag] {
 			t.Errorf("SubstrateAgentDef has json tag %q not in expected set — if this field was deliberately added, update the `want` map in this test to confirm the addition was conscious", tag)
 		}
+	}
+}
+
+// TestSubstrateAgentDef_UnboundedIterations_ToConfigDef pins the read-side
+// projection: a substrate def with unbounded_iterations resolves to a
+// config.AgentDef carrying it (catches a dropped ToConfigDef line).
+func TestSubstrateAgentDef_UnboundedIterations_ToConfigDef(t *testing.T) {
+	got := lookup.SubstrateAgentDef{UnboundedIterations: true}.ToConfigDef()
+	if !got.UnboundedIterations {
+		t.Error("ToConfigDef dropped UnboundedIterations")
 	}
 }
 

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -51,6 +51,12 @@ type RunOptions struct {
 	Segments      []PromptSegment
 	OnEvent       func(providers.Event) // streaming hook (called from loop goroutine)
 	MaxIterations int                   // safety cap; default 16
+	// UnboundedIterations lifts the MaxIterations soft-cap for THIS run even
+	// on an LLM provider (the 1<<20 hard backstop still applies). Distinct
+	// from Provider.Capabilities().UnboundedIterations (code-js only); set
+	// from the agent's config.AgentDef.UnboundedIterations for interactive
+	// terminal-driven runs.
+	UnboundedIterations bool
 
 	// PriorMessages is the conversation history to prepend before the
 	// caller's new Segments. Used by the continuation endpoint to replay
@@ -584,7 +590,10 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// timeout (LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS, enforced as a run-level
 	// deadline). A high hard ceiling stays as a pure runaway backstop. For every
 	// LLM driver MaxIterations is unchanged (the runaway-tool-use guard).
-	unboundedIters := opts.Provider.Capabilities().UnboundedIterations
+	// code-js providers are unbounded by capability; an LLM agent opts in
+	// per-def via UnboundedIterations (interactive/terminal runs). Either way
+	// the 1<<20 hard ceiling stays as a pure runaway backstop.
+	unboundedIters := opts.Provider.Capabilities().UnboundedIterations || opts.UnboundedIterations
 	iterCap := opts.MaxIterations
 	if unboundedIters {
 		iterCap = maxIterationsHardCeiling

--- a/internal/loop/unbounded_iterations_test.go
+++ b/internal/loop/unbounded_iterations_test.go
@@ -106,3 +106,32 @@ func TestRun_UnboundedIterations_ExemptFromMaxIterations(t *testing.T) {
 		t.Errorf("capped: made %d calls, want ≤ %d (cap not enforced)", provCapped.calls, cap)
 	}
 }
+
+// The per-agent UnboundedIterations RunOptions flag lifts the cap even when
+// the provider capability is OFF (an LLM driver) — the interactive/terminal
+// agent opt-in. Fail-before: without the `|| opts.UnboundedIterations` in the
+// loop, capability-OFF + flag-ON caps at MaxIterations → "max_iterations".
+func TestRun_UnboundedIterationsFlag_LiftsCapForLLM(t *testing.T) {
+	const cap, want = 3, 10
+	segs := []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}}
+
+	prov := &iterCounterProvider{target: want, unbounded: false} // LLM driver
+	res, err := Run(context.Background(), RunOptions{
+		Provider:            prov,
+		Model:               "x",
+		Tools:               []tools.Tool{noopTool{}},
+		Dispatcher:          tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:            segs,
+		MaxIterations:       cap,
+		UnboundedIterations: true, // per-agent opt-in
+	})
+	if err != nil {
+		t.Fatalf("unbounded-flag run errored: %v", err)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("flag: stop = %q, want end_turn (per-agent UnboundedIterations not honored)", res.StopReason)
+	}
+	if prov.calls < want {
+		t.Errorf("flag: made %d calls, want ≥ %d (capped despite UnboundedIterations flag)", prov.calls, want)
+	}
+}

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -811,6 +811,10 @@ type mergedDef struct {
 	// whose workflow is intrinsically iterative — same knob the
 	// yaml frontmatter exposes via PR #168's `max_iterations` field.
 	MaxIterations int `json:"max_iterations,omitempty"`
+	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
+	// (interactive / terminal runs; the 1<<20 backstop still applies).
+	// Mirrors config.AgentDef.UnboundedIterations.
+	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
 	// MaxConcurrentChildren caps how many sub-agents this agent may
 	// spawn in parallel via Agent.parallel_spawn (v0.11.8+). Zero =
 	// use the runtime default (DefaultMaxConcurrentChildren = 4).
@@ -882,6 +886,12 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	}
 	if ov.MaxIterations != 0 {
 		d.MaxIterations = ov.MaxIterations
+	}
+	// Bool overlay: a fork can ENABLE unbounded iterations; omitting the
+	// field inherits the parent's value (a fork can't flip it back to false —
+	// author a new def for that, same limitation as other bool overlays).
+	if ov.UnboundedIterations {
+		d.UnboundedIterations = true
 	}
 	if ov.MaxConcurrentChildren != 0 {
 		d.MaxConcurrentChildren = ov.MaxConcurrentChildren
@@ -968,6 +978,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Effort:                s.Effort,
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
+		UnboundedIterations:   s.UnboundedIterations,
 		MaxConcurrentChildren: s.MaxConcurrentChildren,
 		RunTimeoutSeconds:     s.RunTimeoutSeconds,
 		SystemPrompt:          s.SystemPrompt,
@@ -1047,6 +1058,7 @@ func signFromMergedDef(name string, def mergedDef) string {
 		Effort:                def.Effort,
 		MaxTokens:             def.MaxTokens,
 		MaxIterations:         def.MaxIterations,
+		UnboundedIterations:   def.UnboundedIterations,
 		MaxConcurrentChildren: def.MaxConcurrentChildren,
 		AllowedTools:          def.AllowedTools,
 		Skills:                def.Skills,


### PR DESCRIPTION
Second slice of the interactive-terminal feature (plan PR 1) — backend, no wire-shape change.

## Why
LLM runs are capped at `max_iterations` (default 16), so an operator-driven / terminal session can't run long. This adds a per-agent `unbounded_iterations` flag that lifts the soft-cap for LLM agents — the same exemption code-js providers already get by capability — keeping the `1<<20` hard ceiling as a runaway backstop. Cancel is the stop (LLM runs have no wall-clock timeout).

## What
One-line behavior change in the loop:
```go
unboundedIters := opts.Provider.Capabilities().UnboundedIterations || opts.UnboundedIterations
```
The flag round-trips through every `AgentDef` mirror so it survives the content-addressed substrate:
- `config.AgentDef` (yaml `unbounded_iterations`) + `loop.RunOptions`.
- `mergedDef` (write/overlay) + `lookup.SubstrateAgentDef` (read adapter) — drift test parity (want-map updated).
- `agents.AgentContent` — **content-identifying** (F14-class: a fork toggling it gets a distinct `content_sha256`; `omitempty` keeps existing rows byte-stable, so no re-backfill).
- `server.go`: `applyAgentDefOverlay` + all four `loop.RunOptions` literals (RunOnce, handleRuns, handleMessages, sub-agent spawn).

## Tested
- `loop.TestRun_UnboundedIterationsFlag_LiftsCapForLLM` — capability OFF + flag ON runs past the cap (fail-before: stops at `max_iterations`).
- `agents.TestSign_UnboundedIterations_IsContentIdentifying` — hash differs when set; stable when unset.
- `lookup.TestSubstrateAgentDef_UnboundedIterations_ToConfigDef` + the updated drift test.
- `go test ./...` clean; gofmt clean.

Runtime-only — no wire change, no `@loomcycle/client` bump. Next: mid-run steering (`internal/steer` + `POST /v1/runs/{id}/input`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)