### PR TITLE
feat(steer): mid-run operator steering — POST /v1/runs/{run_id}/input

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -72,6 +72,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/scheduler"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
@@ -1315,6 +1316,11 @@ func main() {
 	// "intr:<id>" key. Without this the resolve writes the row but
 	// the tool re-checks storage only when its own timer fires.
 	srv.SetInterruptionBus(channelBus)
+	// PR 2 / interactive terminal — operator mid-run steering registry.
+	// Enables POST /v1/runs/{run_id}/input to inject an instruction into an
+	// in-flight run. Default per-run buffer depth (16); single-replica
+	// (cross-replica routing is a later phase).
+	srv.SetSteerRegistry(steer.NewRegistry(0))
 	// v0.9.x — same Bus also drives the Channel CRUD subscribe path
 	// (Connector + HTTP /v1/_channels/{name}/subscribe). Wire-side
 	// subscribers wake on the same Notify() the in-band tool would.

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
@@ -72,6 +73,10 @@ type Server struct {
 	// HTTP request. Always non-nil after New(); empty on startup. See
 	// internal/cancel/registry.go for the trust model.
 	cancelReg *cancel.Registry
+	// steerReg maps a live run_id → its operator steering queue (PR 2 /
+	// interactive terminal). nil disables steering (POST /v1/runs/{id}/input
+	// → 404). Set at boot via SetSteerRegistry.
+	steerReg *steer.Registry
 
 	// sessionLocks tracks per-session mutexes used by continuation
 	// requests (handleMessages, or handleRuns with a non-empty
@@ -575,6 +580,12 @@ func (s *Server) SetSystemPublisher(p channels.SystemPublisher) {
 // SetInterruptionBus wires the v0.8.16 in-process notification bus
 // used by the Interruption-resolve HTTP handler to wake the blocked
 // tool. Same Bus instance the Channel tool uses.
+// SetSteerRegistry wires the operator-steering registry (PR 2). nil leaves
+// steering disabled. Called once at boot.
+func (s *Server) SetSteerRegistry(r *steer.Registry) {
+	s.steerReg = r
+}
+
 func (s *Server) SetInterruptionBus(b *channels.Bus) {
 	s.interruptionBus = b
 }
@@ -1755,6 +1766,10 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		}
 	})
 
+	// PR 2: operator steering queue for this run (in-flight input injection).
+	steerQ, onSteer, deregSteer := s.makeSteer(ctx, runID, agentID, sessionID, effectiveUserID, emit)
+	defer deregSteer()
+
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          effectiveUserID,
@@ -1803,6 +1818,8 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		MaxTokens:              agentDef.MaxTokens,
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		UnboundedIterations:    agentDef.UnboundedIterations,
+		SteerQueue:             steerQ,
+		OnSteer:                onSteer,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(in.UserTier),
@@ -2157,6 +2174,9 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("POST /v1/runs/{run_id}/interrupts/{interrupt_id}/resolve", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResolveInterrupt))))
 	mux.Handle("GET /v1/runs/{run_id}/interrupts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListRunInterrupts))))
 	mux.Handle("GET /v1/users/{user_id}/interrupts", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListUserInterrupts))))
+	// PR 2 / interactive terminal: inject an operator "steering" instruction
+	// into an in-flight run (appended to the live conversation mid-turn).
+	mux.Handle("POST /v1/runs/{run_id}/input", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunInput))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the
@@ -2945,6 +2965,10 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 
 	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
 
+	// PR 2: operator steering queue for this run (in-flight input injection).
+	steerQ, onSteer, deregSteer := s.makeSteer(r.Context(), runID, agentID, sessionID, req.UserID, emit)
+	defer deregSteer()
+
 	// Pass the agent's effective tool names to the dispatcher so tools
 	// that need a runtime view of "what this agent can use" (e.g. the
 	// Skill tool's subset check on each call) read it via ctx instead
@@ -3000,6 +3024,8 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		UnboundedIterations:    agentDef.UnboundedIterations,
+		SteerQueue:             steerQ,
+		OnSteer:                onSteer,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(req.UserTier),
@@ -3339,6 +3365,10 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	})
 
 	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
+
+	// PR 2: operator steering queue for this continuation run.
+	steerQ, onSteer, deregSteer := s.makeSteer(r.Context(), run.ID, agentID, id, sess.UserID, emit)
+	defer deregSteer()
 	heartbeat := s.makeHeartbeat(run.ID)
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
@@ -3387,6 +3417,8 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
 		MaxIterations:          agentDef.MaxIterations, // 0 → loop default (16)
 		UnboundedIterations:    agentDef.UnboundedIterations,
+		SteerQueue:             steerQ,
+		OnSteer:                onSteer,
 		Effort:                 effort,
 		MarkStalled:            s.markStalledFn(providerID, model),
 		MarkRateLimited:        s.markRateLimitedFn(body.UserTier),
@@ -3695,6 +3727,43 @@ func (s *Server) openOrCreateSessionAndRun(ctx context.Context, requestedSession
 // (EventChannelPublish / EventChannelDelivery) emit directly from inside
 // tool.Execute() — which runs in a tool goroutine, not the loop. The
 // mutex makes that safe for any concurrent caller.
+// makeSteer wires a run's operator steering queue (PR 2 / interactive
+// terminal). It registers the run in the steer registry and returns the
+// loop's SteerQueue, the OnSteer callback, and a deregister func (defer it so
+// even a panic cleans up). OnSteer persists each drained instruction as a
+// "user_input" transcript event (so a continuation replay rebuilds the
+// conversation) and emits the live EventSteer via the run's emit. Returns
+// (nil, nil, noop) when steering isn't wired (registry nil / no run_id) so
+// callers pass nil into RunOptions and the loop's steering path stays off.
+func (s *Server) makeSteer(ctx context.Context, runID, agentID, sessionID, userID string, emit func(providers.Event)) (<-chan steer.Message, func(steer.Message), func()) {
+	if s.steerReg == nil || runID == "" {
+		return nil, nil, func() {}
+	}
+	q, dereg := s.steerReg.Register(steer.Entry{
+		RunID:     runID,
+		AgentID:   agentID,
+		SessionID: sessionID,
+		UserID:    userID,
+	})
+	onSteer := func(m steer.Message) {
+		if s.store != nil {
+			seg := []loop.PromptSegment{{
+				Role:    "user",
+				Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: m.Text}},
+			}}
+			if b, err := json.Marshal(seg); err == nil {
+				if err := s.store.AppendEvent(ctx, runID, "user_input", b); err != nil {
+					log.Printf("steer: persist user_input failed (run=%s): %v", runID, err)
+				}
+			}
+		}
+		emit(providers.Event{Type: providers.EventSteer, UserInput: &providers.UserInputEventInfo{
+			Text: m.Text, Source: m.Source, SeenAt: time.Now().UTC().Format(time.RFC3339Nano),
+		}})
+	}
+	return q, onSteer, dereg
+}
+
 func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(providers.Event)) func(providers.Event) {
 	if s.store == nil || runID == "" {
 		// Even on the store-less path, multiple concurrent callers
@@ -3707,6 +3776,15 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 	return func(ev providers.Event) {
 		mu.Lock()
 		defer mu.Unlock()
+		// EventSteer (operator steering, PR 2) is forwarded LIVE only — the
+		// runner's OnSteer persists the operator instruction as a separate
+		// "user_input" transcript row (the shape replayTranscript rebuilds the
+		// conversation from). Persisting the steer Event too would double-write
+		// and feed replayTranscript an Event where it expects []PromptSegment.
+		if ev.Type == providers.EventSteer {
+			fwd(ev)
+			return
+		}
 		// F32: redact secrets out of the PERSISTED copy only — the tool_call
 		// input and tool_result text are the surfaces where a token inlined on a
 		// Bash cmdline / echoed by a tool would otherwise hit the events BLOB
@@ -4545,6 +4623,79 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 		"status":       store.InterruptStatusResolved,
 		"resolved_at":  time.Now().UTC().Format(time.RFC3339Nano),
 	})
+}
+
+// runInputRequest is the JSON body for POST /v1/runs/{run_id}/input.
+type runInputRequest struct {
+	Text string `json:"text"`
+}
+
+// handleRunInput serves POST /v1/runs/{run_id}/input — inject an operator
+// "steering" instruction into an in-flight run (PR 2 / interactive terminal).
+// The text is appended to the running conversation as a user turn at the top
+// of the loop's next iteration. 404 if no run is live for run_id (start a new
+// turn via POST /v1/sessions/{id}/messages instead); 429 if the run's input
+// buffer is full; 422 on empty text. Cross-tenant steers get an opaque 404.
+func (s *Server) handleRunInput(w http.ResponseWriter, r *http.Request) {
+	if s.steerReg == nil {
+		http.Error(w, "steering is not enabled on this server", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	var req runInputRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20)).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("invalid JSON body: %v", err), http.StatusBadRequest)
+		return
+	}
+	text := strings.TrimSpace(req.Text)
+	if text == "" {
+		http.Error(w, "text is required", http.StatusUnprocessableEntity)
+		return
+	}
+
+	// Tenant-ownership gate: resolve the live run's session and refuse a
+	// cross-tenant steer with an opaque 404 (run_ids are not secrets — they're
+	// returned to callers + shown in the UI). Mirrors sessionOwnershipOK used
+	// by continuation/transcript reads. Steering injects arbitrary
+	// instructions, so this gate matters more than for a fixed-options resolve.
+	entry, ok := s.steerReg.Get(runID)
+	if !ok {
+		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+		return
+	}
+	if entry.SessionID != "" && s.store != nil {
+		if sess, err := s.store.GetSession(r.Context(), entry.SessionID); err == nil {
+			if !sessionOwnershipOK(r.Context(), sess) {
+				http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+				return
+			}
+		}
+	}
+
+	source := store.InterruptResolvedByAPI
+	if hasSessionCookie(r) {
+		source = store.InterruptResolvedByWebUI
+	}
+	delivered, err := s.steerReg.Push(r.Context(), runID, steer.Message{
+		Text: text, Source: source, EnqueuedAt: time.Now(),
+	})
+	switch {
+	case errors.Is(err, steer.ErrQueueFull):
+		w.Header().Set("Retry-After", "1")
+		http.Error(w, "run input queue full; retry shortly", http.StatusTooManyRequests)
+		return
+	case errors.Is(err, steer.ErrRunNotFound):
+		http.Error(w, "no in-flight run for that run_id", http.StatusNotFound)
+		return
+	case err != nil:
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "delivered": delivered})
 }
 
 // handleListRunInterrupts serves GET /v1/runs/{run_id}/interrupts.

--- a/internal/api/http/steer_input_test.go
+++ b/internal/api/http/steer_input_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+)
+
+// POST /v1/runs/{run_id}/input delivers an operator steering message to the
+// live run's queue (PR 2). Registers an entry with no SessionID so the
+// tenant-ownership branch is skipped — that gate reuses sessionOwnershipOK,
+// covered by its own tests.
+func TestHandleRunInput_DeliversToInFlightRun(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	srv.SetSteerRegistry(steer.NewRegistry(2))
+	q, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/input", `{"text":"focus on auth"}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	select {
+	case m := <-q:
+		if m.Text != "focus on auth" {
+			t.Errorf("delivered text = %q, want focus on auth", m.Text)
+		}
+	default:
+		t.Fatal("no message delivered to the run's steering queue")
+	}
+}
+
+func TestHandleRunInput_404WhenNoLiveRun(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	srv.SetSteerRegistry(steer.NewRegistry(2))
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/ghost/input", `{"text":"hi"}`)
+	if rec.Code != 404 {
+		t.Errorf("status = %d, want 404 (no in-flight run); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestHandleRunInput_422WhenEmptyText(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	srv.SetSteerRegistry(steer.NewRegistry(2))
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/input", `{"text":"   "}`)
+	if rec.Code != 422 {
+		t.Errorf("status = %d, want 422 (empty text)", rec.Code)
+	}
+}
+
+func TestHandleRunInput_429WhenQueueFull(t *testing.T) {
+	srv, cleanup := channelFanFixture(t)
+	defer cleanup()
+	srv.SetSteerRegistry(steer.NewRegistry(1)) // buffer depth 1
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+
+	// Fill the single-slot buffer, then the next push overflows → 429.
+	if rec := doJSON(t, srv, "POST", "/v1/runs/run-1/input", `{"text":"1"}`); rec.Code != 200 {
+		t.Fatalf("first push status = %d, want 200", rec.Code)
+	}
+	rec := doJSON(t, srv, "POST", "/v1/runs/run-1/input", `{"text":"2"}`)
+	if rec.Code != 429 {
+		t.Errorf("status = %d, want 429 (queue full)", rec.Code)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -19,6 +19,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -57,6 +58,17 @@ type RunOptions struct {
 	// from the agent's config.AgentDef.UnboundedIterations for interactive
 	// terminal-driven runs.
 	UnboundedIterations bool
+
+	// SteerQueue, when non-nil, is the receive side of this run's operator
+	// steering queue (internal/steer). At the TOP of each iteration the loop
+	// drains it (non-blocking) and appends each Message as a user-role turn
+	// before the next provider call. Nil disables steering.
+	SteerQueue <-chan steer.Message
+	// OnSteer fires once per drained steering message, AFTER it's appended to
+	// the conversation, so the runner can persist a user_input transcript
+	// event + emit the EventSteer SSE event. Same "cheap, loop-goroutine,
+	// tolerate failures" contract as OnHeartbeat.
+	OnSteer func(steer.Message)
 
 	// PriorMessages is the conversation history to prepend before the
 	// caller's new Segments. Used by the continuation endpoint to replay
@@ -572,6 +584,29 @@ type RunResult struct {
 }
 
 // Run drives the agent loop to completion.
+// drainSteer non-blocking-pulls every currently-queued operator steering
+// message and appends each as a SEPARATE user-role turn, returning the
+// extended slice. The operator instruction is TRUSTED (bearer-gated, same
+// trust tier as the original run caller) → plain text, not fenced as
+// untrusted. onSteer (if set) fires per message so the runner can persist +
+// emit it.
+func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer func(steer.Message)) []providers.Message {
+	for {
+		select {
+		case m := <-q:
+			messages = append(messages, providers.Message{
+				Role:    "user",
+				Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
+			})
+			if onSteer != nil {
+				onSteer(m)
+			}
+		default:
+			return messages
+		}
+	}
+}
+
 func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	if opts.MaxIterations == 0 {
 		opts.MaxIterations = 16
@@ -706,6 +741,19 @@ outerLoop:
 		if opts.OnHeartbeat != nil {
 			opts.OnHeartbeat()
 		}
+
+		// Mid-turn steering (internal/steer): drain any operator-injected
+		// instructions and append each as a user turn BEFORE this iteration's
+		// provider call. Drained ONLY here, at the top of the iteration —
+		// never between a tool_use assistant turn and its tool_results user
+		// turn (which would orphan the tool_use and 400 the provider). After
+		// a tool round the messages end [...assistant(tool_use),
+		// user(tool_results)]; appending a user(steer) turn yields consecutive
+		// user turns, which every provider accepts (replay already emits them).
+		if opts.SteerQueue != nil {
+			messages = drainSteer(opts.SteerQueue, messages, opts.OnSteer)
+		}
+
 		req := providers.Request{
 			Model:     opts.Model,
 			System:    system,

--- a/internal/loop/steer_test.go
+++ b/internal/loop/steer_test.go
@@ -1,0 +1,167 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// steerProvider records each call's Messages. When `inject` is non-nil it
+// pushes `injected` into that channel on turn 0 and returns tool_use (so the
+// operator "steers" during a tool round); otherwise it returns end_turn.
+type steerProvider struct {
+	mu       sync.Mutex
+	requests [][]providers.Message
+	inject   chan<- steer.Message
+	injected steer.Message
+	turn     int
+}
+
+func (p *steerProvider) ID() string                                   { return "steer-test" }
+func (p *steerProvider) Probe(context.Context) error                  { return nil }
+func (p *steerProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *steerProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+
+func (p *steerProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.requests = append(p.requests, append([]providers.Message(nil), req.Messages...))
+	turn := p.turn
+	p.turn++
+	p.mu.Unlock()
+
+	ch := make(chan providers.Event, 3)
+	if turn == 0 && p.inject != nil {
+		p.inject <- p.injected // simulate an operator steering during the tool round
+		ch <- providers.Event{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "t", Name: "Noop", Input: json.RawMessage(`{}`)}}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{}}
+	} else {
+		ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+		ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	}
+	close(ch)
+	return ch, nil
+}
+
+func steerSegs() []PromptSegment {
+	return []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}}
+}
+
+// A pre-queued steering message is drained at the top of the first iteration
+// and appears as a user turn in that iteration's provider request.
+func TestRun_DrainSteer_AppendsUserTurnBeforeNextCall(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	q <- steer.Message{Text: "steer-A"}
+
+	var seen []steer.Message
+	prov := &steerProvider{} // inject nil → returns end_turn on turn 0
+	_, err := Run(context.Background(), RunOptions{
+		Provider:   prov,
+		Model:      "x",
+		Tools:      []tools.Tool{noopTool{}},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:   steerSegs(),
+		SteerQueue: q,
+		OnSteer:    func(m steer.Message) { seen = append(seen, m) },
+	})
+	if err != nil {
+		t.Fatalf("run errored: %v", err)
+	}
+	if len(prov.requests) == 0 {
+		t.Fatal("provider never called")
+	}
+	if !hasUserText(prov.requests[0], "steer-A") {
+		t.Errorf("iteration-0 request did not contain the steered user turn; messages=%+v", prov.requests[0])
+	}
+	if len(seen) != 1 || seen[0].Text != "steer-A" {
+		t.Errorf("OnSteer fired %v, want one steer-A", seen)
+	}
+}
+
+// The 400-prevention guard: a steer drained AFTER a tool round must land as a
+// user turn AFTER the tool_results user turn — never inserted between the
+// tool_use assistant turn and its tool_results (which orphans the tool_use and
+// 400s the provider).
+func TestRun_DrainSteer_OrderingWithToolResults(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	prov := &steerProvider{inject: q, injected: steer.Message{Text: "steer-B"}}
+
+	_, err := Run(context.Background(), RunOptions{
+		Provider:   prov,
+		Model:      "x",
+		Tools:      []tools.Tool{noopTool{}},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:   steerSegs(),
+		SteerQueue: q,
+	})
+	if err != nil {
+		t.Fatalf("run errored: %v", err)
+	}
+	if len(prov.requests) < 2 {
+		t.Fatalf("expected ≥2 provider calls (tool round + resume), got %d", len(prov.requests))
+	}
+	msgs := prov.requests[1] // iteration 1: after the tool round + steer drain
+
+	// Find the assistant turn carrying the tool_use; the NEXT message must be
+	// the tool_results user turn, and the steer must come strictly after it.
+	toolUseIdx := -1
+	for i, m := range msgs {
+		if m.Role == "assistant" && hasToolUse(m) {
+			toolUseIdx = i
+			break
+		}
+	}
+	if toolUseIdx < 0 || toolUseIdx+1 >= len(msgs) {
+		t.Fatalf("no assistant tool_use turn followed by a result; messages=%+v", msgs)
+	}
+	next := msgs[toolUseIdx+1]
+	if next.Role != "user" || !hasToolResult(next) {
+		t.Errorf("turn after tool_use is %+v, want a user turn with tool_results (steer must not split it)", next)
+	}
+	steerIdx := userTextIdx(msgs, "steer-B")
+	if steerIdx <= toolUseIdx+1 {
+		t.Errorf("steer turn at idx %d, want strictly after the tool_results turn at %d", steerIdx, toolUseIdx+1)
+	}
+}
+
+func hasUserText(msgs []providers.Message, text string) bool {
+	return userTextIdx(msgs, text) >= 0
+}
+
+func userTextIdx(msgs []providers.Message, text string) int {
+	for i, m := range msgs {
+		if m.Role != "user" {
+			continue
+		}
+		for _, c := range m.Content {
+			if c.Type == "text" && c.Text == text {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func hasToolUse(m providers.Message) bool {
+	for _, c := range m.Content {
+		if c.ToolName != "" || c.ToolInput != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasToolResult(m providers.Message) bool {
+	for _, c := range m.Content {
+		if c.ToolUseID != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -357,6 +357,16 @@ const (
 	// makeRecordingEmit path so the events table carries an audit
 	// row for every grant.
 	EventHostWidened EventType = "host_widened"
+
+	// EventSteer is emitted by the loop when an operator-injected steering
+	// message (internal/steer) is drained into the running conversation
+	// mid-turn. The UserInput field carries the text + source. Named "steer"
+	// (not "user_input") deliberately: "user_input" is an existing PERSISTED
+	// transcript-event KIND ([]loop.PromptSegment); the SSE event is distinct
+	// so the recording path doesn't conflate the two shapes (the runner
+	// persists a user_input row separately for replay; this event stays
+	// live-only).
+	EventSteer EventType = "steer"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -402,6 +412,10 @@ type Event struct {
 	// hook is probably echoing model input without independent
 	// validation.
 	HostWidening *HostWideningEventInfo `json:"host_widening,omitempty"`
+
+	// UserInput carries the structured payload on EventSteer (an
+	// operator-injected steering message drained mid-turn). Nil otherwise.
+	UserInput *UserInputEventInfo `json:"user_input,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -547,6 +561,20 @@ type InterruptionEventInfo struct {
 	// interruption will time out. RFC3339. Empty when no timeout
 	// was set.
 	ExpiresAt string `json:"expires_at,omitempty"`
+}
+
+// UserInputEventInfo is the structured payload on EventSteer — an
+// operator-injected steering message (internal/steer) drained into the
+// running conversation mid-turn. The Web UI renders it as an operator-message
+// row in the live terminal.
+type UserInputEventInfo struct {
+	// Text is the operator's instruction (delivered to the model as a
+	// user-role turn).
+	Text string `json:"text"`
+	// Source is "api" | "webui" — resolved at the auth boundary.
+	Source string `json:"source,omitempty"`
+	// SeenAt is when the loop drained the message. RFC3339Nano.
+	SeenAt string `json:"seen_at,omitempty"`
 }
 
 // HostWideningEventInfo is the structured payload on EventHostWidened

--- a/internal/steer/registry.go
+++ b/internal/steer/registry.go
@@ -1,0 +1,175 @@
+// Package steer implements the in-memory per-run input registry for operator
+// "steering" — unsolicited instructions injected into an in-flight run's
+// conversation between iterations (Claude-Code-style interjection).
+//
+// It mirrors internal/cancel: an in-memory map (run_id → live handle) that
+// vanishes when the process exits; the run's transcript (persisted user_input
+// events) is the durable record. Two differences from cancel/interruption:
+//   - Direction: cancel + interruption are agent- or lifecycle-initiated;
+//     steering is OPERATOR-initiated and asynchronous (the operator produces
+//     while the loop consumes).
+//   - Mechanism: a buffered channel per run (not a one-shot bus.Wait), so the
+//     producing HTTP handler is decoupled from the consuming loop goroutine
+//     and ordering + multiple queued messages are preserved.
+//
+// Keyed by run_id (not agent_id): a steering message targets one in-flight
+// run, and the loop knows its run_id. Cross-replica delivery (a Push that
+// lands on a replica not running the target) is the ClusterSteerer seam —
+// nil here = single-replica (local miss → ErrRunNotFound).
+package steer
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrRunNotFound is returned by Push when no in-flight run is registered for
+// the run_id (and, in cluster mode, no replica owns it). HTTP maps it to 404.
+var ErrRunNotFound = errors.New("steer: no in-flight run for run_id")
+
+// ErrQueueFull is returned by Push when the run's buffer is full — the
+// operator is outpacing the loop's drain. HTTP maps it to 429 (retry).
+var ErrQueueFull = errors.New("steer: run input queue full")
+
+// Message is one operator-injected steering instruction.
+type Message struct {
+	Text       string
+	Source     string // "api" | "webui" — resolved at the auth boundary, never the wire
+	EnqueuedAt time.Time
+}
+
+// Entry is the live handle for one run's steering queue.
+type Entry struct {
+	RunID     string
+	AgentID   string
+	SessionID string
+	UserID    string
+	ch        chan Message
+}
+
+// ClusterSteerer is the cross-replica fallback (mirror of
+// cancel.ClusterCanceller). When set, a Push that misses the local map
+// delegates to PushRemote, which routes by runs.replica_id over the backplane.
+// Nil = single-replica mode; a local miss returns ErrRunNotFound directly.
+// The interface lives here so this package stays free of internal/coord.
+type ClusterSteerer interface {
+	PushRemote(ctx context.Context, runID string, m Message) (delivered bool, found bool, err error)
+}
+
+// Registry maps run_id → buffered steering channel. Safe for concurrent use
+// by the HTTP handler goroutines and the run goroutines that deregister on
+// completion.
+type Registry struct {
+	mu      sync.RWMutex
+	entries map[string]Entry
+	cap     int
+	cluster ClusterSteerer // nil in single-replica mode
+}
+
+// NewRegistry returns an empty registry. perRunCap is the per-run buffer
+// depth (<=0 → default 16) — a bound so an operator can't unbounded-buffer
+// against a stuck run; a full buffer surfaces as ErrQueueFull → 429.
+func NewRegistry(perRunCap int) *Registry {
+	if perRunCap <= 0 {
+		perRunCap = 16
+	}
+	return &Registry{entries: make(map[string]Entry), cap: perRunCap}
+}
+
+// SetClusterSteerer installs the cross-replica fallback. Called from main.go
+// in cluster mode after the backplane is wired; not designed for mid-flight
+// swaps.
+func (r *Registry) SetClusterSteerer(c ClusterSteerer) {
+	r.mu.Lock()
+	r.cluster = c
+	r.mu.Unlock()
+}
+
+// Register installs a steering queue for a run and returns the receive side
+// the loop drains plus a deregister func (defer it so even a panic cleans
+// up). A run terminating deregisters; a Push after that returns ErrRunNotFound.
+func (r *Registry) Register(e Entry) (<-chan Message, func()) {
+	ch := make(chan Message, r.cap)
+	e.ch = ch
+	r.mu.Lock()
+	r.entries[e.RunID] = e
+	r.mu.Unlock()
+	return ch, func() {
+		r.mu.Lock()
+		// Guard against clobbering a newer entry that reused the run_id
+		// (shouldn't happen — run_ids are unique — but cheap insurance).
+		if cur, ok := r.entries[e.RunID]; ok && cur.ch == ch {
+			delete(r.entries, e.RunID)
+		}
+		r.mu.Unlock()
+	}
+}
+
+// Push enqueues a message for run_id. Returns:
+//   - (true, nil)              delivered to the local buffer (or a remote replica)
+//   - (false, ErrQueueFull)    local buffer full
+//   - (false, ErrRunNotFound)  no local entry and no cluster route
+func (r *Registry) Push(ctx context.Context, runID string, m Message) (bool, error) {
+	r.mu.RLock()
+	e, ok := r.entries[runID]
+	cluster := r.cluster
+	r.mu.RUnlock()
+	if !ok {
+		if cluster == nil {
+			return false, ErrRunNotFound
+		}
+		delivered, found, err := cluster.PushRemote(ctx, runID, m)
+		if err != nil {
+			return false, err
+		}
+		if !found {
+			return false, ErrRunNotFound
+		}
+		return delivered, nil
+	}
+	select {
+	case e.ch <- m:
+		return true, nil
+	default:
+		return false, ErrQueueFull
+	}
+}
+
+// PushLocal is Push without cluster delegation — for a cluster subscriber
+// dispatching an inbound backplane event to the local registry (mirror of
+// cancel.CancelLocal; using Push there would re-broadcast on a local miss).
+// found=false on a local miss; delivered=false (found=true) on a full buffer.
+func (r *Registry) PushLocal(runID string, m Message) (delivered, found bool) {
+	r.mu.RLock()
+	e, ok := r.entries[runID]
+	r.mu.RUnlock()
+	if !ok {
+		return false, false
+	}
+	select {
+	case e.ch <- m:
+		return true, true
+	default:
+		return false, true
+	}
+}
+
+// Get returns the live entry for run_id (and a presence bool). Used by the
+// HTTP handler to resolve the run's session for the tenant-ownership gate
+// before pushing. The returned Entry's channel is unexported, so callers
+// can only read its metadata (RunID/SessionID/UserID/AgentID).
+func (r *Registry) Get(runID string) (Entry, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	e, ok := r.entries[runID]
+	return e, ok
+}
+
+// Count returns the number of live entries. Test/diagnostic helper.
+func (r *Registry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.entries)
+}

--- a/internal/steer/registry_test.go
+++ b/internal/steer/registry_test.go
@@ -1,0 +1,58 @@
+package steer
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRegistry_PushDeliverDeregister(t *testing.T) {
+	r := NewRegistry(2) // per-run buffer depth 2
+	q, dereg := r.Register(Entry{RunID: "run1", SessionID: "s1", UserID: "u1"})
+
+	// Deliver to a live run.
+	delivered, err := r.Push(context.Background(), "run1", Message{Text: "hi"})
+	if err != nil || !delivered {
+		t.Fatalf("Push = (%v, %v), want (true, nil)", delivered, err)
+	}
+	if m := <-q; m.Text != "hi" {
+		t.Errorf("received %q, want hi", m.Text)
+	}
+
+	// Fill the buffer (cap 2), then a third push → ErrQueueFull.
+	if _, err := r.Push(context.Background(), "run1", Message{Text: "1"}); err != nil {
+		t.Fatalf("push 1: %v", err)
+	}
+	if _, err := r.Push(context.Background(), "run1", Message{Text: "2"}); err != nil {
+		t.Fatalf("push 2: %v", err)
+	}
+	if _, err := r.Push(context.Background(), "run1", Message{Text: "3"}); !errors.Is(err, ErrQueueFull) {
+		t.Errorf("third push err = %v, want ErrQueueFull", err)
+	}
+
+	// A push to an unknown run (single-replica, no cluster) → ErrRunNotFound.
+	if _, err := r.Push(context.Background(), "nope", Message{Text: "x"}); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("unknown-run push err = %v, want ErrRunNotFound", err)
+	}
+
+	// After deregister, the run is no longer found.
+	dereg()
+	if _, err := r.Push(context.Background(), "run1", Message{Text: "x"}); !errors.Is(err, ErrRunNotFound) {
+		t.Errorf("post-deregister push err = %v, want ErrRunNotFound", err)
+	}
+	if r.Count() != 0 {
+		t.Errorf("Count = %d, want 0 after deregister", r.Count())
+	}
+}
+
+func TestRegistry_Get(t *testing.T) {
+	r := NewRegistry(0) // default cap
+	_, dereg := r.Register(Entry{RunID: "run1", SessionID: "sess-9", UserID: "u"})
+	defer dereg()
+	if e, ok := r.Get("run1"); !ok || e.SessionID != "sess-9" {
+		t.Errorf("Get(run1) = (%+v, %v), want SessionID=sess-9, true", e, ok)
+	}
+	if _, ok := r.Get("missing"); ok {
+		t.Error("Get(missing) = true, want false")
+	}
+}


### PR DESCRIPTION
The core new mechanism of the interactive-terminal feature (plan PR 2) — backend, single-replica.

## Why
Today an operator can only answer an agent-raised interruption or wait for a turn to end. This adds **unsolicited mid-run steering**: inject an instruction into an in-flight run, Claude-Code-style, appended to the live conversation between iterations.

## What
- **`internal/steer`** — a per-run in-memory registry (`run_id` → buffered channel, default depth 16) mirroring `internal/cancel`. `Push` → delivered / `ErrQueueFull` (429) / `ErrRunNotFound` (404). A nil `ClusterSteerer` seam leaves cross-replica routing for a later phase.
- **loop** — `RunOptions.SteerQueue` + `OnSteer`. `drainSteer` pulls queued messages at the **top of each iteration** and appends each as a user turn **before** the next provider call. Drained only there — never between a `tool_use` assistant turn and its `tool_results` user turn (which orphans the tool_use → provider 400). After a tool round it yields consecutive user turns, which all providers accept.
- **providers** — new `EventSteer` (`"steer"`) SSE event + `UserInputEventInfo` sidecar. Named `steer` (not `user_input`) so it doesn't collide with the existing persisted `user_input` transcript *kind*.
- **http** — `POST /v1/runs/{run_id}/input` (`handleRunInput`): bearer + `validIdent` + **tenant-ownership gate** (`sessionOwnershipOK`; opaque 404 cross-tenant). The `OnSteer` closure persists each instruction as a `user_input` transcript event (so a continuation replay rebuilds the conversation) **and** emits the live `EventSteer`; `makeRecordingEmit` skips persisting `EventSteer` to avoid a double-write. Wired into all three top-level run paths (RunOnce/gRPC, handleRuns, handleMessages); the registry is constructed + set in `main.go`.

**Single-replica:** a POST landing on a replica not running the target returns 404 (the cross-replica `SteerCoordinator` is a later phase, like cancel was before clustering). **Session alias** `POST /v1/sessions/{id}/input` deferred — the UI has the `run_id` from the stream and uses `/runs/{id}/input` directly.

## Tested
- `steer.TestRegistry_PushDeliverDeregister` / `_Get`.
- `loop.TestRun_DrainSteer_AppendsUserTurnBeforeNextCall` + **`_OrderingWithToolResults`** (the 400-prevention guard).
- `http.TestHandleRunInput_{DeliversToInFlightRun,404WhenNoLiveRun,422WhenEmptyText,429WhenQueueFull}`.
- `go test ./...` clean; gofmt clean; deployable build OK.

Runtime-only — no `@loomcycle/client` bump (the UI wiring is PR 4). Next: persistent runs (park-at-end_turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)