### PR TITLE
feat(loop): persistent interactive runs — park at end_turn for steering

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1830,6 +1830,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Metadata:               in.Metadata,
 		PayloadMetadata:        in.PayloadMetadata,
 		RunTimeoutSeconds:      pickRunTimeout(in.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
+		Interactive:            in.Interactive,
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -2575,6 +2576,11 @@ type runRequest struct {
 	// LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS (precedence: per-run >
 	// per-agent > global). 0 = inherit. Ignored by LLM agents.
 	RunTimeoutSeconds int `json:"run_timeout_seconds,omitempty"`
+	// Interactive starts a PERSISTENT run that parks for operator steering at
+	// end_turn instead of terminating (interactive terminal). Drive it via
+	// POST /v1/runs/{run_id}/input; pair with an unbounded_iterations agent
+	// for a true always-on terminal. Cancel ends it.
+	Interactive bool `json:"interactive,omitempty"`
 }
 
 // pickRunTimeout resolves the effective code-js wall-clock budget override:
@@ -3035,6 +3041,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
 		Metadata:               req.Metadata,  // direct /v1/runs caller is first-party → trusted; no payload_metadata
 		RunTimeoutSeconds:      pickRunTimeout(req.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
+		Interactive:            req.Interactive,
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -3095,6 +3102,10 @@ type messagesRequest struct {
 	// RunTimeoutSeconds mirrors runRequest.RunTimeoutSeconds for the
 	// continuation's new run (per-run > per-agent > global). 0 = inherit.
 	RunTimeoutSeconds int `json:"run_timeout_seconds,omitempty"`
+	// Interactive makes this continuation a PERSISTENT run that parks for
+	// operator steering at end_turn (interactive terminal). Same semantics as
+	// runRequest.Interactive.
+	Interactive bool `json:"interactive,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -3428,6 +3439,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		CodeBody:               agentDef.Code, // inline code-js body (RFC J); "" → FS fallback
 		Metadata:               body.Metadata,
 		RunTimeoutSeconds:      pickRunTimeout(body.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
+		Interactive:            body.Interactive,
 		UserTier:               body.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -70,6 +70,13 @@ type RunOptions struct {
 	// tolerate failures" contract as OnHeartbeat.
 	OnSteer func(steer.Message)
 
+	// Interactive makes this a PERSISTENT run: instead of terminating when the
+	// model ends its turn, the loop parks on SteerQueue waiting for the
+	// operator's next instruction (resuming on it, ending only on Cancel).
+	// Requires SteerQueue; pairs with UnboundedIterations for a true
+	// always-on terminal agent (else parks count toward MaxIterations).
+	Interactive bool
+
 	// PriorMessages is the conversation history to prepend before the
 	// caller's new Segments. Used by the continuation endpoint to replay
 	// a session's prior turns. Empty for a fresh run (the v0.2 case).
@@ -584,6 +591,34 @@ type RunResult struct {
 }
 
 // Run drives the agent loop to completion.
+// parkHeartbeatInterval is how often a parked interactive run pulses
+// OnHeartbeat while idle, so the staleness sweeper doesn't reap it (the
+// per-iteration heartbeat is suspended during the block). Matches the
+// interruption tool's blocked-heartbeat cadence. A var (not const) so tests
+// can lower it; not an operator knob.
+var parkHeartbeatInterval = 30 * time.Second
+
+// parkForInput blocks a persistent interactive run until an operator steering
+// message arrives or ctx is cancelled, ticking OnHeartbeat meanwhile so the
+// idle run isn't reaped. Returns (msg, true) on input; (zero, false) on
+// cancel or a closed queue.
+func parkForInput(ctx context.Context, q <-chan steer.Message, heartbeat func()) (steer.Message, bool) {
+	t := time.NewTicker(parkHeartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case m, ok := <-q:
+			return m, ok
+		case <-t.C:
+			if heartbeat != nil {
+				heartbeat()
+			}
+		case <-ctx.Done():
+			return steer.Message{}, false
+		}
+	}
+}
+
 // drainSteer non-blocking-pulls every currently-queued operator steering
 // message and appends each as a SEPARATE user-role turn, returning the
 // extended slice. The operator instruction is TRUSTED (bearer-gated, same
@@ -1022,6 +1057,30 @@ outerLoop:
 
 		// Terminal: model is done.
 		if iterStop != "tool_use" || len(pendingTools) == 0 {
+			// Persistent interactive run: park instead of terminating. Wait
+			// for the operator's next instruction (or Cancel). The run holds
+			// its concurrency slot while idle — the documented fairness
+			// trade-off of an always-on terminal agent (bounded by the
+			// existing per-user / global run caps).
+			if opts.Interactive && opts.SteerQueue != nil {
+				emit(providers.Event{Type: providers.EventAwaitingInput,
+					AwaitingInput: &providers.AwaitingInputEventInfo{SinceTurn: iter}})
+				m, resumed := parkForInput(ctx, opts.SteerQueue, opts.OnHeartbeat)
+				if !resumed {
+					// ctx cancelled (or queue closed) → terminate.
+					iterSpan.End()
+					break
+				}
+				messages = append(messages, providers.Message{
+					Role:    "user",
+					Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
+				})
+				if opts.OnSteer != nil {
+					opts.OnSteer(m)
+				}
+				iterSpan.End()
+				continue outerLoop
+			}
 			iterSpan.End()
 			break
 		}

--- a/internal/loop/steer_test.go
+++ b/internal/loop/steer_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
@@ -127,6 +129,179 @@ func TestRun_DrainSteer_OrderingWithToolResults(t *testing.T) {
 	steerIdx := userTextIdx(msgs, "steer-B")
 	if steerIdx <= toolUseIdx+1 {
 		t.Errorf("steer turn at idx %d, want strictly after the tool_results turn at %d", steerIdx, toolUseIdx+1)
+	}
+}
+
+// endTurnProvider always returns end_turn and counts its calls — for the
+// persistent-park tests.
+type endTurnProvider struct {
+	mu sync.Mutex
+	n  int
+}
+
+func (p *endTurnProvider) ID() string                                   { return "endturn" }
+func (p *endTurnProvider) Probe(context.Context) error                  { return nil }
+func (p *endTurnProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *endTurnProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *endTurnProvider) calls() int { p.mu.Lock(); defer p.mu.Unlock(); return p.n }
+func (p *endTurnProvider) Call(context.Context, providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.n++
+	p.mu.Unlock()
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+// A persistent interactive run parks at end_turn instead of terminating, and
+// resumes on the next operator steering message.
+func TestRun_Interactive_ParksAtEndTurnUntilInput(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	parked := make(chan struct{}, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prov := &endTurnProvider{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			OnEvent: func(ev providers.Event) {
+				if ev.Type == providers.EventAwaitingInput {
+					parked <- struct{}{}
+				}
+			},
+		})
+		close(done)
+	}()
+
+	// First end_turn → parked (not terminated).
+	select {
+	case <-parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not park at end_turn")
+	}
+	if got := prov.calls(); got != 1 {
+		t.Errorf("calls = %d, want 1 before resume", got)
+	}
+	select {
+	case <-done:
+		t.Fatal("run terminated instead of parking")
+	default:
+	}
+
+	// Resume on a steering message → another turn → parks again.
+	q <- steer.Message{Text: "keep going"}
+	select {
+	case <-parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not resume on steering input")
+	}
+	if got := prov.calls(); got != 2 {
+		t.Errorf("calls = %d, want 2 after resume", got)
+	}
+
+	// Cancel ends the persistent run.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not terminate after cancel")
+	}
+}
+
+// Cancelling a parked interactive run terminates it promptly (no hang).
+func TestRun_Interactive_CancelWhileParked(t *testing.T) {
+	q := make(chan steer.Message, 1)
+	parked := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	prov := &endTurnProvider{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			OnEvent: func(ev providers.Event) {
+				if ev.Type == providers.EventAwaitingInput {
+					parked <- struct{}{}
+				}
+			},
+		})
+		close(done)
+	}()
+	select {
+	case <-parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not park")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancel did not unblock the parked run")
+	}
+}
+
+// While parked, the run pulses OnHeartbeat so the staleness sweeper doesn't
+// reap it. Lower the interval so the test doesn't wait the production 30s.
+func TestRun_Interactive_HeartbeatFiresWhileParked(t *testing.T) {
+	orig := parkHeartbeatInterval
+	parkHeartbeatInterval = 5 * time.Millisecond
+	defer func() { parkHeartbeatInterval = orig }()
+
+	q := make(chan steer.Message, 1)
+	parked := make(chan struct{}, 1)
+	var hb int32
+	ctx, cancel := context.WithCancel(context.Background())
+	prov := &endTurnProvider{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			OnHeartbeat: func() { atomic.AddInt32(&hb, 1) },
+			OnEvent: func(ev providers.Event) {
+				if ev.Type == providers.EventAwaitingInput {
+					select {
+					case parked <- struct{}{}:
+					default:
+					}
+				}
+			},
+		})
+		close(done)
+	}()
+	select {
+	case <-parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not park")
+	}
+	// Give the park heartbeat ticker a few cycles.
+	time.Sleep(60 * time.Millisecond)
+	cancel()
+	<-done
+	// At least the per-iteration heartbeat (1) plus several park ticks.
+	if got := atomic.LoadInt32(&hb); got < 2 {
+		t.Errorf("heartbeat fired %d times, want ≥2 (park ticker not pulsing)", got)
 	}
 }
 

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -367,6 +367,14 @@ const (
 	// persists a user_input row separately for replay; this event stays
 	// live-only).
 	EventSteer EventType = "steer"
+
+	// EventAwaitingInput is emitted by a persistent INTERACTIVE run when the
+	// model ends its turn and the loop parks waiting for the operator's next
+	// instruction (instead of terminating). The run resumes on the next
+	// steering message or ends on Cancel. The AwaitingInput field carries the
+	// turn the run parked at. The UI renders this as the terminal's idle
+	// "waiting for input" state.
+	EventAwaitingInput EventType = "awaiting_input"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -416,6 +424,10 @@ type Event struct {
 	// UserInput carries the structured payload on EventSteer (an
 	// operator-injected steering message drained mid-turn). Nil otherwise.
 	UserInput *UserInputEventInfo `json:"user_input,omitempty"`
+
+	// AwaitingInput carries the structured payload on EventAwaitingInput (a
+	// persistent interactive run parked at end_turn). Nil otherwise.
+	AwaitingInput *AwaitingInputEventInfo `json:"awaiting_input,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -575,6 +587,15 @@ type UserInputEventInfo struct {
 	Source string `json:"source,omitempty"`
 	// SeenAt is when the loop drained the message. RFC3339Nano.
 	SeenAt string `json:"seen_at,omitempty"`
+}
+
+// AwaitingInputEventInfo is the structured payload on EventAwaitingInput — a
+// persistent interactive run parked at end_turn, waiting for the operator's
+// next steering message (or Cancel).
+type AwaitingInputEventInfo struct {
+	// SinceTurn is the iteration index the run parked at. Informational —
+	// lets the UI show "idle after N turns".
+	SinceTurn int `json:"since_turn"`
 }
 
 // HostWideningEventInfo is the structured payload on EventHostWidened

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -236,6 +236,13 @@ type RunInput struct {
 	// code-js provider consumes it (LLM runs are bounded by MaxIterations +
 	// provider HTTP timeouts, not this budget).
 	RunTimeoutSeconds int
+
+	// Interactive starts a PERSISTENT run that parks waiting for operator
+	// steering at end_turn instead of terminating (the interactive terminal
+	// session mode). Requires steering to be wired + the operator to drive
+	// the run via POST /v1/runs/{run_id}/input; pair with an
+	// unbounded_iterations agent for a true always-on terminal. Cancel ends it.
+	Interactive bool
 }
 
 // RunCallbacks is how the wire surfaces observe the run.


### PR DESCRIPTION
Plan PR 3 — the "always-on terminal agent" half of the interactive feature. Backend.

## Why
With PR 2, an operator can steer an in-flight run. But the run still terminates when the model ends its turn. A persistent terminal session needs the run to stay alive and wait for the next instruction.

## What
- **loop** — `RunOptions.Interactive`. At the terminal break, when `Interactive && SteerQueue != nil`, the loop emits `EventAwaitingInput` and **parks** (`parkForInput`) until a steering message arrives (append + `continue`) or ctx is cancelled (terminate). While parked it pulses `OnHeartbeat` on a ticker so the staleness sweeper doesn't reap the idle run. Pair with `unbounded_iterations` (PR 1) for a true persistent terminal; otherwise parks count toward `MaxIterations`.
- **providers** — `EventAwaitingInput` (`"awaiting_input"`) + `AwaitingInputEventInfo` (the UI's idle "waiting for input" state).
- **runner.RunInput.Interactive** + HTTP `runRequest`/`messagesRequest` `interactive`, threaded into the three top-level run paths.

## Scoping notes (deviations from the plan — flagged for your call)
1. **`interactive` is a per-RUN mode** (on `RunInput` + the HTTP request shapes), **not** a per-agent `AgentDef.Interactive` field. It's a session mode, not an agent identity, and this avoids re-mirroring through the 9 AgentDef/content-addressing sites. An "always-interactive agent" is expressed by pairing the per-agent `unbounded_iterations` (PR 1) with the UI's interactive toggle.
2. **`MAX_INTERACTIVE_RUNS` deferred.** A parked run holds its concurrency slot while idle, but the existing per-user + global run caps already bound that. A dedicated cap is a fast-follow if pressure is observed (documented in the loop comment).

Happy to add either back if you'd prefer the plan as written.

## Tested
- `loop.TestRun_Interactive_ParksAtEndTurnUntilInput` (parks instead of terminating; resumes on input; cancel ends it), `_CancelWhileParked` (no hang), `_HeartbeatFiresWhileParked` (park ticker pulses `OnHeartbeat`).
- `go test ./...` clean; gofmt clean; deployable build OK.

Next: PR 4 wires the `/run` terminal UI to steering + the interactive toggle + the `steer`/`awaiting_input` rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)