### PR TITLE
feat(webui): interactive terminal — steer live runs + persistent sessions

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -124,6 +124,10 @@ export interface EventPayload {
     priority?: string;
     expires_at?: string;
   };
+  // "steer" sidecar — an operator-injected steering message drained mid-turn.
+  user_input?: { text: string; source?: string; seen_at?: string };
+  // "awaiting_input" sidecar — a persistent interactive run parked at end_turn.
+  awaiting_input?: { since_turn?: number };
 }
 
 // v0.9.x — payloads for event types whose shape doesn't fit
@@ -1634,6 +1638,11 @@ export interface StartRunRequest {
   web_search_filter?: "drop" | "keep";
   allowed_tools?: string[];
   metadata?: Record<string, unknown>;
+  // interactive: start a PERSISTENT run that parks for operator steering at
+  // end_turn instead of terminating (the interactive terminal session mode).
+  // Drive it via sendRunInput; pair with an unbounded_iterations agent for a
+  // true always-on terminal. Cancel ends it.
+  interactive?: boolean;
 }
 
 // startRun POSTs /v1/runs and streams events to the handlers. The prompt
@@ -1656,7 +1665,25 @@ export function startRun(req: StartRunRequest, h: RunStreamHandlers): Promise<vo
   if (req.allowed_tools && req.allowed_tools.length > 0)
     body.allowed_tools = req.allowed_tools;
   if (req.metadata) body.metadata = req.metadata;
+  if (req.interactive) body.interactive = true;
   return streamSSE("/v1/runs", body, h);
+}
+
+// sendRunInput injects an operator "steering" instruction into an IN-FLIGHT
+// run (POST /v1/runs/{run_id}/input) — appended to the live conversation at
+// the loop's next iteration (and resumes a parked interactive run). 404 if no
+// run is live for run_id; 429 if its input buffer is full; 422 on empty text.
+export async function sendRunInput(runID: string, text: string): Promise<void> {
+  const resp = await fetch(`/v1/runs/${encodeURIComponent(runID)}/input`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({ text }),
+  });
+  if (!resp.ok) {
+    const b = await resp.text();
+    throw new Error(`${resp.status} ${resp.statusText}: ${b.slice(0, 200)}`);
+  }
 }
 
 // continueSession appends a new turn to an existing session

--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -8,15 +8,21 @@ import { type TranscriptEvent } from "../api";
 // each ensemble cell can render it. Shows a status pill, the streamed
 // transcript via the shared TerminalTranscript, a Cancel button while
 // running, an inline Interruption prompt (Claude-Code-style) when the agent
-// asks a question, and a Continue input once a session exists (multi-turn).
+// asks a question, and an always-on terminal prompt: while the run is live it
+// STEERS the agent mid-flight (or resumes a parked interactive run); between
+// turns it CONTINUES the session. (`onContinue` is the legacy between-turns-
+// only fallback for ensemble cells that don't pass `onSend`.)
 export default function LiveRunPane({
   events,
   status,
   agentId,
   sessionId,
+  runId,
   error,
   onCancel,
   onContinue,
+  onSend,
+  awaitingInput,
   pendingInterrupt,
   onAnswerInterrupt,
   compact,
@@ -25,19 +31,32 @@ export default function LiveRunPane({
   status: RunStatus;
   agentId: string;
   sessionId: string;
+  runId?: string;
   error: string | null;
   onCancel: () => void;
   onContinue?: (prompt: string) => void;
+  onSend?: (text: string) => void;
+  awaitingInput?: boolean;
   pendingInterrupt?: PendingInterrupt | null;
   onAnswerInterrupt?: (answer: string) => void;
   compact?: boolean;
 }) {
   const [followUp, setFollowUp] = useState("");
 
-  const handleContinue = (e: React.FormEvent) => {
+  const running = status === "running";
+  // The terminal prompt is available once a run exists (so steering works as
+  // soon as the run_id is known), hidden while an interruption is pending
+  // (that prompt takes precedence) and before any run starts.
+  const promptHandler = onSend ?? onContinue;
+  const showPrompt =
+    !!promptHandler && !pendingInterrupt && status !== "idle" && !!(sessionId || runId);
+  // The legacy onContinue can only fire between turns; onSend handles both.
+  const promptDisabled = !onSend && running;
+
+  const handleSend = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!onContinue || !followUp.trim()) return;
-    onContinue(followUp.trim());
+    if (!promptHandler || !followUp.trim() || promptDisabled) return;
+    promptHandler(followUp.trim());
     setFollowUp("");
   };
 
@@ -68,23 +87,32 @@ export default function LiveRunPane({
         <InterruptPrompt pending={pendingInterrupt} onAnswer={onAnswerInterrupt} />
       )}
 
-      {onContinue &&
-        sessionId &&
-        !pendingInterrupt &&
-        status !== "running" &&
-        status !== "idle" && (
-          <form className="live-run-continue" onSubmit={handleContinue}>
-            <input
-              type="text"
-              value={followUp}
-              onChange={(e) => setFollowUp(e.target.value)}
-              placeholder="Continue the conversation…"
-            />
-            <button type="submit" disabled={!followUp.trim()}>
-              Send
-            </button>
-          </form>
-        )}
+      {awaitingInput && running && (
+        <div className="live-run-awaiting">● agent is idle — waiting for your input</div>
+      )}
+
+      {showPrompt && (
+        <form className="live-run-continue" onSubmit={handleSend}>
+          <input
+            type="text"
+            value={followUp}
+            onChange={(e) => setFollowUp(e.target.value)}
+            disabled={promptDisabled}
+            placeholder={
+              promptDisabled
+                ? "Wait for the turn to finish…"
+                : running
+                  ? awaitingInput
+                    ? "Type to continue the session…"
+                    : "Steer the running agent…"
+                  : "Continue the conversation…"
+            }
+          />
+          <button type="submit" disabled={!followUp.trim() || promptDisabled}>
+            Send
+          </button>
+        </form>
+      )}
     </div>
   );
 }

--- a/web/src/components/RunForm.tsx
+++ b/web/src/components/RunForm.tsx
@@ -25,6 +25,7 @@ export default function RunForm({
   const [denyAllHosts, setDenyAllHosts] = useState(false);
   const [webSearchFilter, setWebSearchFilter] = useState<"" | "drop" | "keep">("");
   const [metadataJSON, setMetadataJSON] = useState("");
+  const [interactive, setInteractive] = useState(false);
   const [formErr, setFormErr] = useState<string | null>(null);
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -54,6 +55,7 @@ export default function RunForm({
       if (hosts.length > 0) req.allowed_hosts = hosts;
     }
     if (webSearchFilter) req.web_search_filter = webSearchFilter;
+    if (interactive) req.interactive = true;
     if (metadataJSON.trim()) {
       try {
         const parsed = JSON.parse(metadataJSON);
@@ -183,6 +185,19 @@ export default function RunForm({
           />
         </div>
       </details>
+
+      <div className="library-form-row library-form-row-checkbox">
+        <label>
+          <input
+            type="checkbox"
+            checked={interactive}
+            onChange={(e) => setInteractive(e.target.checked)}
+            disabled={submitting}
+          />{" "}
+          interactive session — stays alive for steering (pair with an
+          unbounded-iterations agent; Cancel to end)
+        </label>
+      </div>
 
       {formErr && <div className="modal-err">{formErr}</div>}
 

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -146,6 +146,11 @@ function formatLine(row: TranscriptEvent): FormattedLine {
         payload: `❓ ${oneLine(i?.question ?? "")}${opts}`.trimEnd(),
       };
     }
+    case "steer":
+      // operator-injected mid-run instruction; "»" marks it as operator input.
+      return { key, ts, kind, cls: "tl-steer", payload: `» ${oneLine(ev.user_input?.text ?? "")}` };
+    case "awaiting_input":
+      return { key, ts, kind, cls: "tl-meta", payload: "idle — waiting for operator input" };
     case "started":
       return { key, ts, kind, cls: "tl-meta", payload: "" };
     case "session":

--- a/web/src/hooks/useRunStream.ts
+++ b/web/src/hooks/useRunStream.ts
@@ -3,6 +3,7 @@ import {
   cancelAgent,
   continueSession,
   resolveInterrupt,
+  sendRunInput,
   startRun,
   sseEventToTranscript,
   type EventPayload,
@@ -52,8 +53,15 @@ export interface UseRunStream {
   // resumes. null when nothing is pending.
   pendingInterrupt: PendingInterrupt | null;
   answerInterrupt: (answer: string) => void;
+  // awaitingInput is true while a persistent INTERACTIVE run is parked at
+  // end_turn waiting for the operator's next instruction (the agent is idle).
+  awaitingInput: boolean;
   start: (req: StartRunRequest) => void;
   sendMessage: (prompt: string) => void;
+  // send routes by state: while the run is running it STEERS the live run
+  // (POST /input — also resumes a parked interactive run); otherwise it
+  // CONTINUES the session as a fresh turn. The single terminal-prompt entry.
+  send: (text: string) => void;
   cancel: () => void;
   reset: () => void;
 }
@@ -66,6 +74,7 @@ export function useRunStream(): UseRunStream {
   const [runId, setRunId] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [pendingInterrupt, setPendingInterrupt] = useState<PendingInterrupt | null>(null);
+  const [awaitingInput, setAwaitingInput] = useState(false);
 
   const seqRef = useRef(0);
   const ctrlRef = useRef<AbortController | null>(null);
@@ -124,6 +133,9 @@ export function useRunStream(): UseRunStream {
         expiresAt: i.expires_at,
       });
     }
+    // awaiting_input ⇒ a persistent interactive run parked (idle); any other
+    // event ⇒ the agent is active again, so clear the idle flag.
+    setAwaitingInput(ev.type === "awaiting_input");
     setEvents((prev) => [...prev, sseEventToTranscript(seqRef.current++, ev)]);
   }, []);
 
@@ -175,6 +187,7 @@ export function useRunStream(): UseRunStream {
       runIdRef.current = "";
       setError(null);
       setPendingInterrupt(null);
+      setAwaitingInput(false);
       setStatus("running");
       runStream(startRun(req, { onFrame, signal: ctrl.signal }));
     },
@@ -189,12 +202,35 @@ export function useRunStream(): UseRunStream {
       ctrlRef.current = ctrl;
       setError(null);
       setPendingInterrupt(null);
+      setAwaitingInput(false);
       setStatus("running");
       runStream(
         continueSession(sessionId, prompt, { onFrame, signal: ctrl.signal }),
       );
     },
     [sessionId, onFrame, runStream],
+  );
+
+  // send is the single terminal-prompt entry. While the run is live it STEERS
+  // it (POST /input — appended mid-turn, or resumes a parked interactive run);
+  // otherwise it CONTINUES the session as a fresh turn. Steering does NOT tear
+  // down the open SSE reader — the same stream carries the response.
+  const send = useCallback(
+    (text: string) => {
+      const t = text.trim();
+      if (!t) return;
+      if (status === "running") {
+        const rid = runIdRef.current;
+        if (!rid) return;
+        setAwaitingInput(false); // optimistic; the resumed activity will stream
+        void sendRunInput(rid, t).catch((e) =>
+          setError(e instanceof Error ? e.message : String(e)),
+        );
+        return;
+      }
+      sendMessage(t);
+    },
+    [status, sendMessage],
   );
 
   const cancel = useCallback(() => {
@@ -217,6 +253,7 @@ export function useRunStream(): UseRunStream {
     runIdRef.current = "";
     setError(null);
     setPendingInterrupt(null);
+    setAwaitingInput(false);
     setStatus("idle");
   }, []);
 
@@ -229,7 +266,9 @@ export function useRunStream(): UseRunStream {
     error,
     pendingInterrupt,
     answerInterrupt,
+    awaitingInput,
     start,
+    send,
     sendMessage,
     cancel,
     reset,

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -114,9 +114,11 @@ function SingleRunTab({
           status={run.status}
           agentId={run.agentId}
           sessionId={run.sessionId}
+          runId={run.runId}
           error={run.error}
           onCancel={run.cancel}
-          onContinue={run.sendMessage}
+          onSend={run.send}
+          awaitingInput={run.awaitingInput}
           pendingInterrupt={run.pendingInterrupt}
           onAnswerInterrupt={run.answerInterrupt}
         />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -532,6 +532,11 @@ pre {
 .tl-row.tl-interrupt .tl-kind {
   color: #fbbf24;
 }
+.tl-row.tl-steer .tl-payload,
+.tl-row.tl-steer .tl-kind {
+  color: var(--accent);
+  font-weight: 600;
+}
 .agent-link {
   display: flex;
   gap: 8px;
@@ -4084,6 +4089,15 @@ button.primary:disabled {
 }
 .live-run-continue input {
   flex: 1;
+}
+.live-run-continue input:disabled {
+  opacity: 0.55;
+}
+.live-run-awaiting {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--accent);
+  border-top: 1px solid var(--border, #2a2a32);
 }
 .live-run-pane-compact {
   min-height: 180px;


### PR DESCRIPTION
Plan PR 4 — the payoff: wires the backend interactive pieces (PRs 1–3) into the `/run` terminal so the whole feature is usable end-to-end. **UI-only, upgrades the pane in place.**

## What
- **`api.ts`** — `sendRunInput(runId, text)` → `POST /v1/runs/{id}/input`; `interactive` on `StartRunRequest`.
- **`useRunStream`** — a single `send(text)` that routes by state: while the run is live it **steers** it (`sendRunInput`, which also resumes a parked interactive run, on the **same open SSE stream**); otherwise it **continues** the session as a fresh turn. Tracks `awaitingInput` from the `awaiting_input` event (cleared when the agent resumes activity).
- **`LiveRunPane`** — the between-turns continue box becomes an **always-on terminal prompt** (steer while running, continue between turns) with a mode-aware placeholder, plus an "idle — waiting for input" banner when a persistent run is parked. The inline interruption prompt (PR A) still takes precedence.
- **`RunForm`** — an **"interactive session"** checkbox sets `StartRunRequest.interactive`.
- **`TerminalTranscript`** — renders the `steer` event (`» <text>`, operator input) and `awaiting_input` rows; `styles.css` adds `.tl-steer` + `.live-run-awaiting`.

## End-to-end flow (now usable)
1. Tick **interactive session** + run an `unbounded_iterations` agent → it parks at end_turn (`idle — waiting for input`).
2. Type in the prompt → steers / resumes the same run; the agent's `» your text` shows in the transcript.
3. Mid-work, type again → injected as the next user turn; answer inline interruptions in place; **Cancel** ends the session.

Frontend-only — every endpoint/event already exists; no `@loomcycle/client` bump (the UI ships its own `api.ts`).

## Tested
- `cd web && npm run build` (tsc --noEmit + vite) green.
- Ensemble (fan-out / orchestrator) cells unaffected — `onSend` is optional; they keep the legacy `onContinue` fallback.

This completes the user-facing interactive terminal. Remaining: **PR 5** (cross-replica steering) is deferrable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)