### PR TITLE
feat(coord): cross-replica steering coordinator + interactive-terminal e2e test

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1596,6 +1596,25 @@ func main() {
 		go cancelCoord.RunCancelSubscriber(bgCtx, srv.CancelRegistry())
 		go cancelCoord.RunAckSubscriber(bgCtx)
 
+		// Cross-replica operator steering (the twin of cancel): a
+		// POST /v1/runs/{run_id}/input that lands on a replica not running the
+		// target run routes over the backplane to the owning replica.
+		if steerReg := srv.SteerRegistry(); steerReg != nil {
+			steerCoord, err := coord.NewSteerCoordinator(coord.SteerCoordinatorConfig{
+				Backplane:    bp,
+				ReplicaID:    cfg.Env.ReplicaID,
+				Store:        pgStore,
+				ReplicaStore: replicaStore,
+				AckTimeout:   ackTimeout,
+			})
+			if err != nil {
+				log.Fatalf("coord: steer coordinator init: %v", err)
+			}
+			steerReg.SetClusterSteerer(steerCoord)
+			go steerCoord.RunSteerSubscriber(bgCtx, steerReg)
+			go steerCoord.RunSteerAckSubscriber(bgCtx)
+		}
+
 		// v0.12.3 Phase 4: runstate + channel bus backplane fanout.
 		// Both buses were constructed earlier (lines ~1003/1012) and
 		// wired into the server via SetRunStateBus / SetChannelBus.

--- a/internal/api/http/interactive_terminal_e2e_test.go
+++ b/internal/api/http/interactive_terminal_e2e_test.go
@@ -1,0 +1,177 @@
+package http
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestInteractiveTerminal_EndToEnd is the codified "smoke": it drives the full
+// interactive-terminal flow through the real HTTP server + SSE + loop —
+//
+//	start interactive run → loop parks at end_turn (`awaiting_input`)
+//	→ POST /v1/runs/{run_id}/input → `steer` frame + the run RESUMES
+//	→ parks again → client disconnect ends the persistent run.
+//
+// Everything below the SSE wire is real (RunOnce → loop → steer registry →
+// the /input handler → drain → resume); only the provider is stubbed (always
+// end_turn, so each turn parks). This is the chain the unit/integration tests
+// only covered piecewise.
+func TestInteractiveTerminal_EndToEnd(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			// interactive runs pair with unbounded_iterations so parks don't
+			// count toward the 16-cap (a persistent terminal agent).
+			"termagent": {Model: "stub-model", SystemPrompt: "be brief", UnboundedIterations: true},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = "" // open mode
+
+	// Always end_turn → an interactive run parks after every turn.
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	// A real store so openOrCreateSessionAndRun mints a run_id (the steer
+	// registry keys on it — without a store, steering can't be wired).
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "interactive.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, st)
+	srv.SetSteerRegistry(steer.NewRegistry(0))
+
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"termagent","interactive":true,"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post run: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("run status = %d", resp.StatusCode)
+	}
+
+	type frame struct{ typ, data string }
+	frames := make(chan frame, 128)
+	go func() {
+		defer close(frames)
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 64*1024), 1024*1024)
+		var typ, data string
+		for sc.Scan() {
+			line := sc.Text()
+			if line == "" {
+				if typ != "" {
+					frames <- frame{typ, data}
+					typ, data = "", ""
+				}
+				continue
+			}
+			if strings.HasPrefix(line, "event:") {
+				typ = strings.TrimSpace(line[len("event:"):])
+			}
+			if strings.HasPrefix(line, "data:") {
+				data = strings.TrimSpace(line[len("data:"):])
+			}
+		}
+	}()
+	next := func() frame {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatal("SSE stream closed unexpectedly")
+			}
+			return f
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for an SSE frame")
+			return frame{}
+		}
+	}
+
+	// Phase 1: drain until the run parks, capturing run_id from the agent frame.
+	var runID string
+	for {
+		f := next()
+		if f.typ == "agent" {
+			var a struct {
+				RunID string `json:"run_id"`
+			}
+			_ = json.Unmarshal([]byte(f.data), &a)
+			runID = a.RunID
+		}
+		if f.typ == "awaiting_input" {
+			break
+		}
+		if f.typ == "done" || f.typ == "error" {
+			t.Fatalf("run ended (%s) before parking — interactive park not engaged", f.typ)
+		}
+	}
+	if runID == "" {
+		t.Fatal("never captured run_id from the agent frame")
+	}
+
+	// Phase 2: steer the parked run.
+	in, err := http.Post(ts.URL+"/v1/runs/"+runID+"/input", "application/json",
+		strings.NewReader(`{"text":"keep going"}`))
+	if err != nil {
+		t.Fatalf("post input: %v", err)
+	}
+	body, _ := io.ReadAll(in.Body)
+	in.Body.Close()
+	if in.StatusCode != 200 {
+		t.Fatalf("input status = %d: %s", in.StatusCode, body)
+	}
+
+	// Phase 3: the steer surfaces (`steer` frame) and the run RESUMES (another
+	// `text` turn) before parking again.
+	sawSteer, resumed := false, false
+	for {
+		f := next()
+		switch f.typ {
+		case "steer":
+			sawSteer = true
+		case "text":
+			if sawSteer {
+				resumed = true
+			}
+		case "awaiting_input":
+			if sawSteer && resumed {
+				goto done
+			}
+		case "done", "error":
+			goto done
+		}
+	}
+done:
+	if !sawSteer {
+		t.Error("no `steer` frame after POST /input — steering didn't reach the live stream")
+	}
+	if !resumed {
+		t.Error("run did not resume (no `text` after the steer) — park didn't wake")
+	}
+
+	// End the persistent run: client disconnect cancels the run ctx, which
+	// unblocks the park and terminates the loop.
+	resp.Body.Close()
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1855,6 +1855,11 @@ var _ runner.Runner = (*Server)(nil)
 // originated on the HTTP path (or vice versa).
 func (s *Server) CancelRegistry() *cancel.Registry { return s.cancelReg }
 
+// SteerRegistry exposes the operator-steering registry so main.go can wire the
+// cross-replica SteerCoordinator (SetClusterSteerer + the subscriber
+// goroutines). nil when steering isn't enabled.
+func (s *Server) SteerRegistry() *steer.Registry { return s.steerReg }
+
 // trySessionLock try-locks the session-scoped mutex for id. Returns
 // (release, true) on success and (nil, false) if another caller already
 // holds it — in which case the caller should respond 409 / session_busy.

--- a/internal/coord/steer_coordinator.go
+++ b/internal/coord/steer_coordinator.go
@@ -1,0 +1,252 @@
+package coord
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// SteerCoordinator implements steer.ClusterSteerer via the v0.12.0 Backplane —
+// the cross-replica twin of CancelCoordinator, for operator mid-run steering
+// (POST /v1/runs/{run_id}/input). One instance per replica, wired in main.go's
+// cluster block. When the local steer registry misses (the run isn't on this
+// replica), the registry delegates to PushRemote which:
+//
+//  1. Looks up the run row by run_id for its owning replica_id.
+//  2. Short-circuits: unknown run / terminal run / unstamped / self-owned /
+//     dead owner all return "not reachably-live" (the handler serves 404).
+//  3. Publishes a `loomcycle.steer` event {run_id, text, source, from_replica}.
+//  4. Waits on a per-run ack channel for up to AckTimeout. On ack: returns the
+//     owner's delivered bool. On timeout: returns found=true, delivered=false
+//     (the operator sees "not delivered" and can retry).
+//
+// Two long-lived subscriber goroutines carry the wire side: RunSteerSubscriber
+// (owning side: dispatches incoming steers to the LOCAL registry and acks) and
+// RunSteerAckSubscriber (originator side: routes acks to in-flight PushRemote
+// waiters). Keyed by run_id (steering targets one run), unlike cancel's
+// agent_id.
+type SteerCoordinator struct {
+	bp         Backplane
+	replicaID  string
+	store      steerRunStore
+	replicas   ReplicaLiveness
+	ackTimeout time.Duration
+
+	mu sync.Mutex
+	// ackSubs fans one ack out to every concurrent PushRemote waiter for the
+	// same run_id (same per-caller-channel pattern as CancelCoordinator).
+	ackSubs map[string][]chan steerAckPayload
+}
+
+// SteerCoordinatorConfig is the constructor input.
+type SteerCoordinatorConfig struct {
+	Backplane    Backplane
+	ReplicaID    string
+	Store        steerRunStore
+	ReplicaStore ReplicaLiveness
+	// AckTimeout caps how long PushRemote waits for the owning replica's ack.
+	// Default 5s if zero.
+	AckTimeout time.Duration
+}
+
+// steerRunStore is the narrow store surface PushRemote needs. *storepostgres.Store
+// satisfies it implicitly. Run lookup is by run_id (steering's key).
+type steerRunStore interface {
+	GetRun(ctx context.Context, runID string) (store.Run, error)
+}
+
+// ReplicaLiveness is the owner-liveness probe PushRemote needs. *ReplicaStore
+// satisfies it; declared as an interface so the unit test can stub it without
+// a Postgres fixture.
+type ReplicaLiveness interface {
+	IsReplicaAlive(ctx context.Context, replicaID string, threshold time.Duration) (bool, error)
+}
+
+const (
+	topicSteer    = "loomcycle.steer"
+	topicSteerAck = "loomcycle.steer.ack"
+)
+
+func NewSteerCoordinator(cfg SteerCoordinatorConfig) (*SteerCoordinator, error) {
+	if cfg.Backplane == nil {
+		return nil, errors.New("coord: backplane is required")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("coord: store is required")
+	}
+	if cfg.ReplicaStore == nil {
+		return nil, errors.New("coord: replica store is required")
+	}
+	if err := ValidateReplicaID(cfg.ReplicaID); err != nil {
+		return nil, err
+	}
+	timeout := cfg.AckTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	return &SteerCoordinator{
+		bp:         cfg.Backplane,
+		replicaID:  cfg.ReplicaID,
+		store:      cfg.Store,
+		replicas:   cfg.ReplicaStore,
+		ackTimeout: timeout,
+		ackSubs:    make(map[string][]chan steerAckPayload),
+	}, nil
+}
+
+type steerEventPayload struct {
+	RunID       string `json:"run_id"`
+	Text        string `json:"text"`
+	Source      string `json:"source,omitempty"`
+	FromReplica string `json:"from_replica"`
+}
+
+type steerAckPayload struct {
+	RunID     string `json:"run_id"`
+	ByReplica string `json:"by_replica"`
+	Delivered bool   `json:"delivered"`
+}
+
+// PushRemote satisfies steer.ClusterSteerer. found=false ⇒ the handler serves
+// a 404 (no reachably-live run). found=true ⇒ the run was reached; delivered
+// reports whether the owner's per-run buffer accepted it.
+func (c *SteerCoordinator) PushRemote(ctx context.Context, runID string, m steer.Message) (bool, bool, error) {
+	run, err := c.store.GetRun(ctx, runID)
+	if err != nil {
+		var notFound *store.ErrNotFound
+		if errors.As(err, &notFound) {
+			return false, false, nil
+		}
+		return false, false, fmt.Errorf("get run: %w", err)
+	}
+	// Only a running run is steerable. Terminal / unstamped / self-owned all
+	// mean "not reachably-live here" → 404 (the local registry already missed,
+	// so a self-owned row means the run ended).
+	if run.Status != store.RunRunning && run.Status != store.RunStatus("") {
+		return false, false, nil
+	}
+	if run.ReplicaID == "" || run.ReplicaID == c.replicaID {
+		return false, false, nil
+	}
+	if alive, err := c.replicas.IsReplicaAlive(ctx, run.ReplicaID, staleReplicaThreshold); err != nil {
+		// Probe failure: proceed with the broadcast — a real steer may still
+		// land if the owner responds.
+		log.Printf("coord: steer IsReplicaAlive probe for %s failed: %v (proceeding)", run.ReplicaID, err)
+	} else if !alive {
+		return false, false, nil
+	}
+
+	// Live remote owner: broadcast + wait for ack. Each PushRemote gets its own
+	// buffered channel; RunSteerAckSubscriber fans out to every waiter.
+	ackCh := make(chan steerAckPayload, 1)
+	c.mu.Lock()
+	c.ackSubs[runID] = append(c.ackSubs[runID], ackCh)
+	c.mu.Unlock()
+	defer func() {
+		c.mu.Lock()
+		slice := c.ackSubs[runID]
+		for i, ch := range slice {
+			if ch == ackCh {
+				slice = append(slice[:i], slice[i+1:]...)
+				break
+			}
+		}
+		if len(slice) == 0 {
+			delete(c.ackSubs, runID)
+		} else {
+			c.ackSubs[runID] = slice
+		}
+		c.mu.Unlock()
+	}()
+
+	payload, _ := json.Marshal(steerEventPayload{
+		RunID:       runID,
+		Text:        m.Text,
+		Source:      m.Source,
+		FromReplica: c.replicaID,
+	})
+	if err := c.bp.Publish(ctx, topicSteer, payload); err != nil {
+		return false, false, fmt.Errorf("publish steer: %w", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), c.ackTimeout)
+	defer waitCancel()
+	select {
+	case ack := <-ackCh:
+		return ack.Delivered, true, nil
+	case <-waitCtx.Done():
+		// Owner didn't ack in time. The run row says running on a live remote
+		// replica, so report reached-but-not-delivered (operator can retry)
+		// rather than a hard error or a misleading 404.
+		return false, true, nil
+	}
+}
+
+// RunSteerSubscriber is the owning-side listener. Started once per replica.
+// Reads `loomcycle.steer`, dispatches to the LOCAL registry, and acks when the
+// run is owned here.
+//
+// CRITICAL: uses PushLocal (never the cluster-delegating Push) so a local miss
+// doesn't re-broadcast the event we just received (the CancelLocal lesson —
+// avoids a broadcast storm). On local miss we skip silently; the owning
+// replica's own subscriber handles it.
+func (c *SteerCoordinator) RunSteerSubscriber(ctx context.Context, reg *steer.Registry) {
+	ch, err := c.bp.Subscribe(ctx, topicSteer)
+	if err != nil {
+		log.Printf("coord: RunSteerSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var p steerEventPayload
+		if err := json.Unmarshal(evt.Payload, &p); err != nil {
+			log.Printf("coord: malformed steer event: %v", err)
+			continue
+		}
+		delivered, found := reg.PushLocal(p.RunID, steer.Message{Text: p.Text, Source: p.Source, EnqueuedAt: time.Now()})
+		if !found {
+			continue // not our run; the owner's subscriber will ack
+		}
+		ack, _ := json.Marshal(steerAckPayload{RunID: p.RunID, ByReplica: c.replicaID, Delivered: delivered})
+		if err := c.bp.Publish(ctx, topicSteerAck, ack); err != nil {
+			log.Printf("coord: publish steer ack for %s: %v", p.RunID, err)
+		}
+	}
+}
+
+// RunSteerAckSubscriber is the originator-side ack fan-in. Started once per
+// replica. Routes each ack to the matching in-flight PushRemote waiter(s).
+func (c *SteerCoordinator) RunSteerAckSubscriber(ctx context.Context) {
+	ch, err := c.bp.Subscribe(ctx, topicSteerAck)
+	if err != nil {
+		log.Printf("coord: RunSteerAckSubscriber subscribe failed: %v", err)
+		return
+	}
+	for evt := range ch {
+		var ack steerAckPayload
+		if err := json.Unmarshal(evt.Payload, &ack); err != nil {
+			log.Printf("coord: malformed steer ack: %v", err)
+			continue
+		}
+		c.mu.Lock()
+		waiters := c.ackSubs[ack.RunID]
+		snapshot := make([]chan steerAckPayload, len(waiters))
+		copy(snapshot, waiters)
+		c.mu.Unlock()
+		for _, w := range snapshot {
+			select {
+			case w <- ack:
+			default:
+			}
+		}
+	}
+}
+
+// Compile-time check that we satisfy the steer package's interface.
+var _ steer.ClusterSteerer = (*SteerCoordinator)(nil)

--- a/internal/coord/steer_coordinator_test.go
+++ b/internal/coord/steer_coordinator_test.go
@@ -1,0 +1,169 @@
+package coord
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// memBackplane is an in-process Backplane for unit-testing the coordinator
+// round-trip without a Postgres fixture. Publish fans a copy to every current
+// subscriber of the topic (non-blocking; the 64-deep buffers never fill in a
+// test).
+type memBackplane struct {
+	mu   sync.Mutex
+	subs map[string][]chan Event
+}
+
+func newMemBackplane() *memBackplane { return &memBackplane{subs: map[string][]chan Event{}} }
+
+func (b *memBackplane) Publish(_ context.Context, topic string, payload []byte) error {
+	b.mu.Lock()
+	chans := append([]chan Event(nil), b.subs[topic]...)
+	b.mu.Unlock()
+	for _, ch := range chans {
+		select {
+		case ch <- Event{Topic: topic, Payload: payload}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (b *memBackplane) Subscribe(_ context.Context, topic string) (<-chan Event, error) {
+	ch := make(chan Event, 64)
+	b.mu.Lock()
+	b.subs[topic] = append(b.subs[topic], ch)
+	b.mu.Unlock()
+	return ch, nil
+}
+
+func (b *memBackplane) Close() error { return nil }
+
+type stubSteerRunStore struct{ runs map[string]store.Run } // keyed by run_id
+
+func (s *stubSteerRunStore) GetRun(_ context.Context, runID string) (store.Run, error) {
+	r, ok := s.runs[runID]
+	if !ok {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: runID}
+	}
+	return r, nil
+}
+
+type stubLiveness struct {
+	alive bool
+	err   error
+}
+
+func (s stubLiveness) IsReplicaAlive(context.Context, string, time.Duration) (bool, error) {
+	return s.alive, s.err
+}
+
+func newSteerCoord(t *testing.T, bp Backplane, replicaID string, runs map[string]store.Run, alive bool) *SteerCoordinator {
+	t.Helper()
+	c, err := NewSteerCoordinator(SteerCoordinatorConfig{
+		Backplane:    bp,
+		ReplicaID:    replicaID,
+		Store:        &stubSteerRunStore{runs: runs},
+		ReplicaStore: stubLiveness{alive: alive},
+		AckTimeout:   2 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSteerCoordinator: %v", err)
+	}
+	return c
+}
+
+func TestSteerCoordinator_NotFound_ReturnsMiss(t *testing.T) {
+	c := newSteerCoord(t, newMemBackplane(), "replica-A", map[string]store.Run{}, true)
+	delivered, found, err := c.PushRemote(context.Background(), "ghost", steer.Message{Text: "x"})
+	if err != nil || delivered || found {
+		t.Errorf("PushRemote(unknown) = (%v,%v,%v), want (false,false,nil)", delivered, found, err)
+	}
+}
+
+func TestSteerCoordinator_SelfOwned_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: "replica-A"}}
+	c := newSteerCoord(t, newMemBackplane(), "replica-A", runs, true)
+	delivered, found, _ := c.PushRemote(context.Background(), "run-1", steer.Message{Text: "x"})
+	if delivered || found {
+		t.Errorf("self-owned run = (%v,%v), want (false,false) — local registry missed ⇒ run ended", delivered, found)
+	}
+}
+
+func TestSteerCoordinator_Terminal_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunCompleted, ReplicaID: "replica-B"}}
+	c := newSteerCoord(t, newMemBackplane(), "replica-A", runs, true)
+	delivered, found, _ := c.PushRemote(context.Background(), "run-1", steer.Message{Text: "x"})
+	if delivered || found {
+		t.Errorf("terminal run = (%v,%v), want (false,false)", delivered, found)
+	}
+}
+
+func TestSteerCoordinator_DeadOwner_ReturnsMiss(t *testing.T) {
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: "replica-B"}}
+	c := newSteerCoord(t, newMemBackplane(), "replica-A", runs, false /* dead */)
+	delivered, found, _ := c.PushRemote(context.Background(), "run-1", steer.Message{Text: "x"})
+	if delivered || found {
+		t.Errorf("dead-owner run = (%v,%v), want (false,false)", delivered, found)
+	}
+}
+
+// The full cross-replica round-trip: originator (A) PushRemote → owner (B)
+// RunSteerSubscriber delivers to B's local registry + acks → A's ack subscriber
+// routes the ack back → PushRemote returns delivered.
+func TestSteerCoordinator_DeliversToRemoteOwner(t *testing.T) {
+	bp := newMemBackplane()
+	const owner = "replica-B"
+	runs := map[string]store.Run{"run-1": {ID: "run-1", Status: store.RunRunning, ReplicaID: owner}}
+
+	a := newSteerCoord(t, bp, "replica-A", runs, true) // originator
+	b := newSteerCoord(t, bp, owner, runs, true)       // owner
+
+	ownerReg := steer.NewRegistry(4)
+	q, dereg := ownerReg.Register(steer.Entry{RunID: "run-1"})
+	defer dereg()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.RunSteerSubscriber(ctx, ownerReg) // owner side
+	go a.RunSteerAckSubscriber(ctx)        // originator side
+	time.Sleep(30 * time.Millisecond)      // let both Subscribe calls register
+
+	delivered, found, err := a.PushRemote(context.Background(), "run-1", steer.Message{Text: "focus"})
+	if err != nil {
+		t.Fatalf("PushRemote: %v", err)
+	}
+	if !found || !delivered {
+		t.Fatalf("PushRemote = (delivered=%v, found=%v), want (true,true)", delivered, found)
+	}
+	select {
+	case m := <-q:
+		if m.Text != "focus" {
+			t.Errorf("owner queue got %q, want focus", m.Text)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("owner registry never received the steered message")
+	}
+}
+
+func TestSteerCoordinator_ValidatesConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  SteerCoordinatorConfig
+		want string
+	}{
+		{"nil backplane", SteerCoordinatorConfig{}, "backplane"},
+		{"nil store", SteerCoordinatorConfig{Backplane: newMemBackplane()}, "store"},
+		{"nil replica store", SteerCoordinatorConfig{Backplane: newMemBackplane(), Store: &stubSteerRunStore{}}, "replica store"},
+	}
+	for _, tc := range cases {
+		if _, err := NewSteerCoordinator(tc.cfg); err == nil {
+			t.Errorf("%s: want error mentioning %q, got nil", tc.name, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Bundles the two remaining interactive-terminal follow-ups into one PR.

## (1) Cross-replica steering — the deferred PR 5
A `coord.SteerCoordinator` mirroring `CancelCoordinator`: when `POST /v1/runs/{run_id}/input` lands on a replica that isn't running the target run, the steer registry's `ClusterSteerer` routes the instruction over the backplane to the **owning replica** (by `runs.replica_id`), awaits an ack, and reports `delivered`.
- Owning side dispatches to its **local** registry via `PushLocal` (never re-broadcasting — the `CancelLocal` no-storm lesson) and acks.
- Unknown / terminal / self-owned / dead-owner all return not-reachably-live → the handler's 404.
- Wired in `main.go`'s cluster block (`SetClusterSteerer` + the two subscriber goroutines). **Single-replica is unaffected** (nil coordinator → the registry returns `ErrRunNotFound` directly, as before).
- `ReplicaLiveness` is a small interface (`*ReplicaStore` satisfies it) so the coordinator unit-tests with an **in-memory `Backplane` stub** — no Postgres fixture needed.

## (2) The smoke, codified — `TestInteractiveTerminal_EndToEnd`
An automated end-to-end test driving the full interactive flow through the **real** HTTP server + SSE + loop:
```
start interactive run → loop parks (awaiting_input)
→ POST /v1/runs/{run_id}/input → `steer` frame + the run RESUMES
→ parks again → client disconnect ends the persistent run
```
Everything below the wire is real (`RunOnce` → loop → steer registry → the `/input` handler → drain → resume); only the provider is stubbed (always `end_turn`, so each turn parks). This is the chain the unit/integration tests covered only piecewise.

Also adds `Server.SteerRegistry()` (the main.go wiring accessor).

## Tested
- `coord.TestSteerCoordinator_{NotFound,SelfOwned,Terminal,DeadOwner}_ReturnsMiss`, `_DeliversToRemoteOwner` (the full publish→dispatch→ack round-trip over an in-memory backplane), `_ValidatesConfig`.
- `http.TestInteractiveTerminal_EndToEnd`.
- `go test ./...` clean; gofmt clean; deployable build OK.

Runtime-only — no wire change, no `@loomcycle/client` bump. With this, the interactive terminal works against a multi-replica cluster too, and the end-to-end flow has a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)