### PR TITLE
fix(agentdef): round-trip *_def_scopes capability gates (F40)

### DIFF
--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -214,6 +214,15 @@ type SubstrateAgentDef struct {
 	Channels         config.AgentChannelACL      `json:"channels,omitempty"`
 	EvaluationScopes []string                    `json:"evaluation_scopes,omitempty"`
 	Interruption     config.AgentInterruptionACL `json:"interruption,omitempty"`
+	// F40: the *_def_scopes capability gates — the substrate-def slice of the
+	// F14 closure, so a runtime-authored meta-agent's fork/schedule/etc.
+	// authority survives the round-trip instead of defaulting to deny. The
+	// drift test pins parity with builtin.mergedDef.
+	AgentDefScopes         []string `json:"agent_def_scopes,omitempty"`
+	ScheduleDefScopes      []string `json:"schedule_def_scopes,omitempty"`
+	SkillDefScopes         []string `json:"skill_def_scopes,omitempty"`
+	A2AServerCardDefScopes []string `json:"a2a_server_card_def_scopes,omitempty"`
+	A2AAgentDefScopes      []string `json:"a2a_agent_def_scopes,omitempty"`
 }
 
 // ToConfigDef projects the substrate JSON shape onto config.AgentDef
@@ -244,6 +253,13 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Channels:              s.Channels,
 		EvaluationScopes:      s.EvaluationScopes,
 		Interruption:          s.Interruption,
+		// F40: surface the capability gates to the policy layer so a
+		// runtime-authored meta-agent's AgentDef/Schedule/etc. scopes apply.
+		AgentDefScopes:         s.AgentDefScopes,
+		ScheduleDefScopes:      s.ScheduleDefScopes,
+		SkillDefScopes:         s.SkillDefScopes,
+		A2AServerCardDefScopes: s.A2AServerCardDefScopes,
+		A2AAgentDefScopes:      s.A2AAgentDefScopes,
 	}
 }
 

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -301,6 +301,13 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"channels":                true, // F14 — Channel tool ACL on MCP/HTTP-authored agents
 		"evaluation_scopes":       true, // F14 — Evaluation tool scope gate
 		"interruption":            true, // F14 — Interruption tool gate (enabled/kinds/max_pending)
+		// F40 — the *_def_scopes capability gates (substrate-def slice of the
+		// F14 closure) so a runtime-authored meta-agent can fork/schedule others.
+		"agent_def_scopes":           true,
+		"schedule_def_scopes":        true,
+		"skill_def_scopes":           true,
+		"a2a_server_card_def_scopes": true,
+		"a2a_agent_def_scopes":       true,
 	}
 	have := jsonTagsOf(reflect.TypeOf(lookup.SubstrateAgentDef{}))
 	for tag := range want {

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -863,6 +863,16 @@ type mergedDef struct {
 	Channels         config.AgentChannelACL      `json:"channels,omitempty"`
 	EvaluationScopes []string                    `json:"evaluation_scopes,omitempty"`
 	Interruption     config.AgentInterruptionACL `json:"interruption,omitempty"`
+	// The *_def_scopes capability gates (F40) — the substrate-def slice of the
+	// F14 closure. Without these a runtime-authored meta-agent (one that
+	// forks/promotes/schedules other agents) comes back default-deny and can't
+	// author anything. NOT part of content_sha256 (the *Scopes ACLs are
+	// deliberately excluded from agents.AgentContent — authority, not content).
+	AgentDefScopes         []string `json:"agent_def_scopes,omitempty"`
+	ScheduleDefScopes      []string `json:"schedule_def_scopes,omitempty"`
+	SkillDefScopes         []string `json:"skill_def_scopes,omitempty"`
+	A2AServerCardDefScopes []string `json:"a2a_server_card_def_scopes,omitempty"`
+	A2AAgentDefScopes      []string `json:"a2a_agent_def_scopes,omitempty"`
 }
 
 func (d *mergedDef) applyOverlay(ov mergedDef) {
@@ -946,6 +956,23 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	if ov.Interruption.Enabled || len(ov.Interruption.Kinds) > 0 || ov.Interruption.MaxPending != 0 {
 		d.Interruption = ov.Interruption
 	}
+	// *_def_scopes capability gates (F40): slice-set-if-supplied, same idiom as
+	// EvaluationScopes — overlays build up, they don't blank.
+	if ov.AgentDefScopes != nil {
+		d.AgentDefScopes = ov.AgentDefScopes
+	}
+	if ov.ScheduleDefScopes != nil {
+		d.ScheduleDefScopes = ov.ScheduleDefScopes
+	}
+	if ov.SkillDefScopes != nil {
+		d.SkillDefScopes = ov.SkillDefScopes
+	}
+	if ov.A2AServerCardDefScopes != nil {
+		d.A2AServerCardDefScopes = ov.A2AServerCardDefScopes
+	}
+	if ov.A2AAgentDefScopes != nil {
+		d.A2AAgentDefScopes = ov.A2AAgentDefScopes
+	}
 }
 
 // normalize fills derived fields that the static config-load path
@@ -997,6 +1024,13 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Channels:         s.Channels,
 		EvaluationScopes: s.EvaluationScopes,
 		Interruption:     s.Interruption,
+		// F40: a static meta-agent bootstrapped into the substrate keeps its
+		// capability gates, so a fork of it inherits them.
+		AgentDefScopes:         s.AgentDefScopes,
+		ScheduleDefScopes:      s.ScheduleDefScopes,
+		SkillDefScopes:         s.SkillDefScopes,
+		A2AServerCardDefScopes: s.A2AServerCardDefScopes,
+		A2AAgentDefScopes:      s.A2AAgentDefScopes,
 	}
 }
 

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -63,6 +63,45 @@ func TestAgentDefTool_CreateRefusedOverStaticName(t *testing.T) {
 	}
 }
 
+// F40 (RFC W): an agent created via AgentDef with `*_def_scopes` in the
+// overlay must round-trip those capability gates — overlay → persisted def →
+// lookup.Agent → config.AgentDef — so a runtime-authored meta-agent (breeder /
+// scheduler-of-agents) isn't silently dropped to default-deny. Fail-before:
+// the overlay struct had no def-scope fields, so they resolved empty.
+func TestAgentDefTool_CreateRoundTripsDefScopes(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	// No allowed_tools in the overlay: the def-scopes round-trip is what F40 is about,
+	// and the narrow-only allowed_tools ceiling check requires WithAgentTools on ctx,
+	// which agentDefFixture intentionally does not set (matches TestAgentDefTool_CreateNewName).
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"breeder","overlay":{`+
+		`"system_prompt":"breed agents",`+
+		`"agent_def_scopes":["named:foo"],"schedule_def_scopes":["any"],`+
+		`"skill_def_scopes":["named:s"],"a2a_server_card_def_scopes":["any"],`+
+		`"a2a_agent_def_scopes":["any"]}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+
+	def, ok := lookup.Agent(context.Background(), tool.Store, tool.Cfg, "", "breeder")
+	if !ok {
+		t.Fatal("breeder did not resolve via lookup.Agent")
+	}
+	if got := def.AgentDefScopes; len(got) != 1 || got[0] != "named:foo" {
+		t.Errorf("AgentDefScopes = %v, want [named:foo] (F40: dropped on the overlay round-trip)", got)
+	}
+	if got := def.ScheduleDefScopes; len(got) != 1 || got[0] != "any" {
+		t.Errorf("ScheduleDefScopes = %v, want [any]", got)
+	}
+	if got := def.SkillDefScopes; len(got) != 1 || got[0] != "named:s" {
+		t.Errorf("SkillDefScopes = %v, want [named:s]", got)
+	}
+	if len(def.A2AServerCardDefScopes) != 1 || len(def.A2AAgentDefScopes) != 1 {
+		t.Errorf("a2a def scopes dropped: server=%v agent=%v", def.A2AServerCardDefScopes, def.A2AAgentDefScopes)
+	}
+}
+
 func TestAgentDefTool_CreateNewName(t *testing.T) {
 	tool, ctx, cleanup := agentDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

A runtime-authored **meta-agent** — one whose job is to fork, promote, or schedule *other* agents (the "breeder" / scheduler-of-agents pattern) — needs `agent_def_scopes` / `schedule_def_scopes` / `skill_def_scopes` / `a2a_server_card_def_scopes` / `a2a_agent_def_scopes` to carry the authority to do so. The `AgentDef` create/fork overlay **silently dropped all five**: they had no field in the persisted overlay shape (`mergedDef`) or the read adapter (`lookup.SubstrateAgentDef`), so on every reload the meta-agent came back **default-deny** and could author nothing. The breeder pattern was unbuildable at runtime.

Found by loomcycle-experiments (F40); spec'd as RFC W. This is the substrate-def slice of the **F14 closure** — `channels` / `evaluation_scopes` / `interruption` already round-trip; the `*_def_scopes` ACLs were the remaining gap.

## What

Mirror the five fields across the same chain F14 used, no new mechanism:

- `internal/tools/builtin/agentdef.go` — `mergedDef` fields (json snake_case, `omitempty`), `applyOverlay` (slice-set-if-supplied, same idiom as `EvaluationScopes`), `staticToMergedDef` copy.
- `internal/lookup/agent.go` — `SubstrateAgentDef` fields + `ToConfigDef` projection.
- `internal/lookup/agent_test.go` — the drift want-map (the conscious-addition gate).

**Deliberately NOT added to `agents.AgentContent`.** The `*Scopes` ACLs are *authority, not content* (`sign.go` package doc) — including them would re-hash every existing agent row and mint a new version on a pure fork-scope change. Existing `content_sha256` rows stay byte-stable.

### Scope note (pre-existing, unchanged here)
`agent_def_scopes` + `skill_def_scopes` are **consumed in-loop today** (`server.go` `substratePoliciesForAgent` / `skillDefPolicyForAgent`), so this PR directly unblocks F40. `schedule_def_scopes` / `a2a_*_def_scopes` now **round-trip for parity** but are not yet wired into the in-loop policy ctx — that is a separate, pre-existing gap (the in-loop run ctx wires `WithAgentDefPolicy` + `WithSkillDefPolicy` but not the schedule/a2a twins) and is intentionally **out of scope** for this fix.

Runtime-only change — no wire-shape change, no `@loomcycle/client` bump.

## What was tested

- `TestAgentDefTool_CreateRoundTripsDefScopes` — **fail-before**: creates a `breeder` agentdef with all five def-scopes in the overlay, resolves it via `lookup.Agent`, asserts `config.AgentDef` carries them. Fails on the unfixed code (scopes dropped on the round-trip).
- `TestAgent_DriftDetection` + `TestMergedDef_DriftDetection_VsLookupSubstrateAgentDef` — parity between `mergedDef` ⊇ `SubstrateAgentDef` json tags pinned green.
- `go test ./...` clean · `go build -o bin/loomcycle ./cmd/loomcycle` clean · `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)