### PR TITLE
fix(webui): cap interactive terminal height + collapse tool results

### DIFF
--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type {
   EventPayload,
   SystemPromptPayload,
@@ -43,15 +43,62 @@ export default function TerminalTranscript({ events }: TerminalTranscriptProps) 
   return (
     <div ref={ref} className="terminal-transcript">
       {lines.map((l, i) => (
-        <div key={l.key ?? i} className={`tl-row ${l.cls}`}>
-          {/* Preserve newlines within a single coalesced text block;
-              wrap long lines via CSS white-space: pre-wrap. */}
-          <span className="tl-ts">{l.ts}</span>
-          <span className="tl-kind">{l.kind}</span>
-          <span className="tl-sep">|</span>
-          <span className="tl-payload">{l.payload}</span>
-        </div>
+        <TerminalRow key={l.key ?? i} line={l} />
       ))}
+    </div>
+  );
+}
+
+// TerminalRow renders one transcript line. Non-collapsible kinds (user
+// messages, agent text, meta) render as a single static row. Collapsible
+// kinds (tool results) scaffold to a one-line summary with a caret and
+// expand to the full payload on click — so the scrollback stays scannable
+// and only the operator's own messages + the agent's responses are open by
+// default. Mirrors AgentDetailPane's EventCard collapse pattern.
+function TerminalRow({ line }: { line: FormattedLine }) {
+  const [open, setOpen] = useState<boolean>(line.defaultOpen ?? false);
+  if (!line.collapsible) {
+    return (
+      <div className={`tl-row ${line.cls}`}>
+        {/* Preserve newlines within a single coalesced text block;
+            wrap long lines via CSS white-space: pre-wrap. */}
+        <span className="tl-ts">{line.ts}</span>
+        <span className="tl-kind">{line.kind}</span>
+        <span className="tl-sep">|</span>
+        <span className="tl-payload">{line.payload}</span>
+      </div>
+    );
+  }
+  // Collapsible row reuses the 4-column grid; the caret prefixes the payload
+  // cell, and the expanded detail is a 5th grid child spanning all columns.
+  const toggle = () => setOpen((v) => !v);
+  return (
+    <div
+      className={`tl-row tl-collapsible ${line.cls} ${open ? "tl-open" : ""}`}
+      onClick={toggle}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggle();
+        }
+      }}
+    >
+      <span className="tl-ts">{line.ts}</span>
+      <span className="tl-kind">{line.kind}</span>
+      <span className="tl-sep">|</span>
+      <span className="tl-payload">
+        <span className="tl-caret">{open ? "▼" : "▶"}</span>
+        {open ? "" : line.payload}
+      </span>
+      {open && (
+        // stopPropagation so selecting text in the expanded output doesn't
+        // collapse the row.
+        <div className="tl-detail" onClick={(e) => e.stopPropagation()}>
+          {line.full ?? line.payload}
+        </div>
+      )}
     </div>
   );
 }
@@ -61,7 +108,10 @@ interface FormattedLine {
   ts: string;     // "[hh:mm:ss.SSS]" or blank
   kind: string;   // padded to KIND_PAD_WIDTH
   cls: string;
-  payload: string;
+  payload: string;     // collapsed/one-line view
+  collapsible?: boolean; // tool results — scaffold + expand on click
+  full?: string;         // full (multi-line) detail shown when expanded
+  defaultOpen?: boolean; // start expanded (e.g. errors — actionable)
 }
 
 // coalesceTextTerminal merges adjacent text + thinking events into
@@ -113,10 +163,16 @@ function formatLine(row: TranscriptEvent): FormattedLine {
     case "tool_result": {
       const id = (ev as { tool_use_id?: string }).tool_use_id ?? "";
       const idTail = id ? `${id.slice(0, 8)} ` : "";
+      const text = ev.text ?? "";
       return {
         key, ts, kind,
         cls: ev.is_error ? "tl-error" : "tl-result",
-        payload: `${idTail}${oneLine(ev.text ?? "")}`,
+        // Collapsed by default: a one-line summary the operator can scan;
+        // click to expand the full output. Errors start open (actionable).
+        payload: `${idTail}${oneLine(text)}`,
+        collapsible: true,
+        full: `${idTail}${text}`.trimEnd(),
+        defaultOpen: !!ev.is_error,
       };
     }
     case "usage":
@@ -164,7 +220,9 @@ function formatLine(row: TranscriptEvent): FormattedLine {
       const segs = (row.payload as UserInputPayload[] | undefined) ?? [];
       const userSeg = segs.find((s) => s.role === "user");
       const text = userSeg?.content?.[0]?.text ?? "";
-      return { key, ts, kind, cls: "tl-text", payload: oneLine(text) };
+      // Operator messages render in full (expanded), like agent text — only
+      // tool results are scaffolded. Preserve newlines via CSS pre-wrap.
+      return { key, ts, kind, cls: "tl-text", payload: text };
     }
     case "system_prompt": {
       // v0.9.x: same sidecar pattern as user_input. Surface the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -537,6 +537,33 @@ pre {
   color: var(--accent);
   font-weight: 600;
 }
+/* Collapsible rows (tool results): the whole row is a click target that
+   toggles between the one-line summary and the full output. */
+.tl-row.tl-collapsible {
+  cursor: pointer;
+}
+.tl-row.tl-collapsible:hover .tl-caret {
+  color: var(--fg);
+}
+.tl-caret {
+  color: var(--fg-soft);
+  display: inline-block;
+  width: 1em;
+  font-size: 10px;
+  user-select: none;
+}
+/* Expanded full output spans all grid columns on its own row. */
+.tl-detail {
+  grid-column: 1 / -1;
+  white-space: pre-wrap;
+  word-break: break-word;
+  padding: 2px 0 4px;
+  cursor: text;
+  color: var(--completed);
+}
+.tl-row.tl-collapsible.tl-error .tl-detail {
+  color: var(--failed);
+}
 .agent-link {
   display: flex;
   gap: 8px;
@@ -4020,6 +4047,11 @@ button.primary:disabled {
   flex-direction: column;
   min-height: 0;
   flex: 1;
+  /* .content (the page scroller) is NOT a flex container, so flex:1 here is
+     inert. Fill .content's already-viewport-bounded height explicitly so the
+     transcript pane below can cap to the window and scroll internally instead
+     of growing the page forever. */
+  height: 100%;
 }
 .run-view h2 {
   margin: 0 0 12px;
@@ -4038,6 +4070,7 @@ button.primary:disabled {
 .run-view-pane-col {
   flex: 1;
   min-width: 0;
+  min-height: 0;
   display: flex;
 }
 .run-form-advanced {


### PR DESCRIPTION
## Why

Two operator-reported gaps in the `/run` interactive terminal (shipped v0.26.x):
1. The transcript grew the **page** taller without bound instead of capping at the viewport and scrolling internally.
2. Every **tool result** was shown truncated to one line with no way to expand, drowning out the operator's own messages and the agent's responses.

## What

**Height cap (CSS).** Root cause: `.content` (the page scroller) is *not* a flex container, so `.run-view`'s `flex:1` was inert — the run view sized to its content and `.content` scrolled the whole page. Fix: `.run-view { height:100% }` (fills `.content`'s already-viewport-bounded box) + `.run-view-pane-col { min-height:0 }`. The transcript's existing `flex:1; min-height:0; overflow-y:auto` then caps to the window and scrolls inside. Auto-tail (80px-from-bottom threshold) is unchanged.

**Collapse tool results (`TerminalTranscript.tsx`).** Tool results now render as a one-line summary with a caret (`▶`) and expand to the full output on click (`▼`); errors start expanded (actionable). The detail spans all grid columns on its own row. Operator (`user_input`) messages now render in full — like agent `text` — so only tool results are scaffolded by default. Reuses the `EventCard` collapse idiom from `AgentDetailPane`.

Frontend only — no backend, no wire change. `internal/webui/dist/*` is gitignored and rebuilt by CI, so this PR is `web/src` only.

## What was tested

`cd web && npm run build` (tsc --noEmit + vite) green. Manual: a long interactive run caps at the window and scrolls internally; tool results collapse with a caret and expand on click; user + agent messages show in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)