### PR TITLE
feat(context): op=self reports resolved provider + model

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -768,6 +768,16 @@ outerLoop:
 		// at function-scope only, not loop-iteration-scope.
 		iterCtx, iterSpan := lcotel.RecordIteration(ctx, iter)
 
+		// Stamp the CURRENTLY-resolved provider/model onto the per-iteration
+		// ctx so the Context tool's op=self can report them to the agent
+		// (non-secret introspection). Per-iteration, not once at Run start,
+		// because tryProviderFallback swaps opts.Provider/opts.Model in place
+		// — this keeps op=self truthful about what the agent is actually
+		// running on after a fallback. Tools dispatched this iteration receive
+		// iterCtx, so the value reaches them without per-tool wiring.
+		iterCtx = tools.WithResolvedProvider(iterCtx, opts.Provider.ID())
+		iterCtx = tools.WithResolvedModel(iterCtx, opts.Model)
+
 		// Heartbeat fires at the top of each iteration. Cheap path —
 		// implementations are expected to be ~one UPDATE. Failures
 		// should NOT propagate (a sweeper in the future is the

--- a/internal/loop/resolved_provider_test.go
+++ b/internal/loop/resolved_provider_test.go
@@ -1,0 +1,58 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// probeProviderTool captures the resolved provider/model that the loop
+// stamps onto the per-iteration ctx, proving the values reach a dispatched
+// tool (the path the Context tool's op=self reads).
+type probeProviderTool struct {
+	gotProvider string
+	gotModel    string
+}
+
+func (t *probeProviderTool) Name() string        { return "Probe" }
+func (t *probeProviderTool) Description() string { return "" }
+func (t *probeProviderTool) InputSchema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (t *probeProviderTool) Execute(ctx context.Context, _ json.RawMessage) (tools.Result, error) {
+	t.gotProvider = tools.ResolvedProvider(ctx)
+	t.gotModel = tools.ResolvedModel(ctx)
+	return tools.Result{Text: "ok"}, nil
+}
+
+// TestRun_StampsResolvedProviderModelOnToolCtx asserts loop.Run stamps the
+// run's provider id + model name onto the ctx a dispatched tool receives —
+// the seam Context op=self surfaces to the agent.
+func TestRun_StampsResolvedProviderModelOnToolCtx(t *testing.T) {
+	probe := &probeProviderTool{}
+	prov := &scriptedProvider{toolCalls: []providers.ToolUse{
+		{ID: "call_0", Name: "Probe", Input: json.RawMessage(`{}`)},
+	}}
+	disp := tools.NewDispatcher([]tools.Tool{probe})
+
+	_, err := Run(context.Background(), RunOptions{
+		Provider:        prov,
+		Model:           "scripted-model",
+		Tools:           []tools.Tool{probe},
+		Dispatcher:      disp,
+		Segments:        []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "go"}}}},
+		ToolParallelism: 8,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if probe.gotProvider != "scripted" {
+		t.Errorf("ResolvedProvider on tool ctx = %q, want %q", probe.gotProvider, "scripted")
+	}
+	if probe.gotModel != "scripted-model" {
+		t.Errorf("ResolvedModel on tool ctx = %q, want %q", probe.gotModel, "scripted-model")
+	}
+}

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -28,7 +28,8 @@ import (
 //
 // Nine ops total — PR 1 ships four of them:
 //
-//	self        — identity bundle (agent name, run/agent ids, user, tier)
+//	self        — identity bundle (agent name, run/agent ids, user, tier,
+//	              resolved provider + model)
 //	tools       — post-filter tool catalog
 //	doc         — detailed schema/docstring for one tool by name
 //	permissions — gates that apply to the caller (tool ACL, host policy, scopes)
@@ -179,6 +180,12 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 		// Channel messages — the canonical way an Evaluator agent
 		// gets the Editor's run_id for `Evaluation.submit run_id=…`.
 		"run_id": tools.RunID(ctx),
+		// provider/model are the CURRENTLY-resolved driver + model the
+		// agent is running on (tier/effort + fallback). Non-secret — the
+		// agent is allowed to know what it is. Empty when the run was
+		// started outside the loop's stamping path (e.g. some tests).
+		"provider": tools.ResolvedProvider(ctx),
+		"model":    tools.ResolvedModel(ctx),
 	}
 	return okJSON(out)
 }

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -55,6 +55,8 @@ func contextFixture(t *testing.T) (*Context, context.Context) {
 		AgentDefID: "def_abc",
 	})
 	ctx = tools.WithRunID(ctx, "r_test123")
+	ctx = tools.WithResolvedProvider(ctx, "anthropic")
+	ctx = tools.WithResolvedModel(ctx, "claude-opus-4-test")
 	ctx = tools.WithAgentTools(ctx, []string{"Read", "Memory", "Context", "mcp__jobs__patchApp"})
 	return tool, ctx
 }
@@ -89,6 +91,30 @@ func TestContextTool_SelfReturnsIdentity(t *testing.T) {
 	// (which requires run_id, not agent_id) without a separate lookup.
 	if out["run_id"] != "r_test123" {
 		t.Errorf("run_id = %v, want r_test123", out["run_id"])
+	}
+	// Resolved provider + model — non-secret introspection so the agent
+	// knows what it is running on.
+	if out["provider"] != "anthropic" {
+		t.Errorf("provider = %v, want anthropic", out["provider"])
+	}
+	if out["model"] != "claude-opus-4-test" {
+		t.Errorf("model = %v, want claude-opus-4-test", out["model"])
+	}
+}
+
+// Provider/model are present-as-empty (not missing keys) when the run was
+// started outside the loop's stamping path — mirrors the agent_def_id
+// surfaced-even-when-empty contract so callers can rely on the shape.
+func TestContextTool_SelfProviderModelEmptyWhenUnset(t *testing.T) {
+	tool := &Context{}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a_x"})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
+	out := decodeResult(t, res.Text)
+	if v, ok := out["provider"]; !ok || v != "" {
+		t.Errorf("provider = %v (ok=%v), want present empty string", v, ok)
+	}
+	if v, ok := out["model"]; !ok || v != "" {
+		t.Errorf("model = %v (ok=%v), want present empty string", v, ok)
 	}
 }
 

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -526,6 +526,44 @@ func RunID(ctx context.Context) string {
 	return v
 }
 
+// ctxKeyResolvedProvider / ctxKeyResolvedModel carry the run's
+// CURRENTLY-RESOLVED provider id and model name so the Context tool's
+// op=self can report them to the agent. The model never supplies these
+// (the operator's resolver picks them per tier/effort + fallback), so they
+// travel via ctx. Stamped per-iteration in loop.Run from opts.Provider.ID()
+// / opts.Model, so a mid-run provider fallback is reflected truthfully.
+// Non-secret — the agent is allowed to know what it is running on.
+type ctxKeyResolvedProvider struct{}
+type ctxKeyResolvedModel struct{}
+
+// WithResolvedProvider attaches the resolved provider id to ctx.
+func WithResolvedProvider(ctx context.Context, providerID string) context.Context {
+	if providerID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyResolvedProvider{}, providerID)
+}
+
+// ResolvedProvider returns the resolved provider id from ctx, or "" when unset.
+func ResolvedProvider(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyResolvedProvider{}).(string)
+	return v
+}
+
+// WithResolvedModel attaches the resolved model name to ctx.
+func WithResolvedModel(ctx context.Context, model string) context.Context {
+	if model == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, ctxKeyResolvedModel{}, model)
+}
+
+// ResolvedModel returns the resolved model name from ctx, or "" when unset.
+func ResolvedModel(ctx context.Context) string {
+	v, _ := ctx.Value(ctxKeyResolvedModel{}).(string)
+	return v
+}
+
 // ctxKeyEventEmitter is the context key for the v0.8.4 typed-audit-
 // event emitter. The loop's OnEvent callback is attached at run
 // start; tools that want to surface structured wire events (e.g.


### PR DESCRIPTION
## Why

A loomcycle agent could not see which **provider + model** it was running on. That's useful, non-secret introspection — an agent that knows it's on `anthropic`/`claude-opus-4-…` vs `deepseek`/`deepseek-chat` can adapt its behavior, and the operator asked for it explicitly ("the agent should have it").

## What

`Context op=self` now returns two new fields next to the existing identity bundle:
- `provider` — the resolved driver id (e.g. `anthropic`)
- `model` — the resolved model name

Plumbing:
- `internal/tools/tool.go` — two ctx helpers `WithResolvedProvider`/`ResolvedProvider` + `WithResolvedModel`/`ResolvedModel`, mirroring the existing `WithRunID`/`WithAgentName` pattern.
- `internal/loop/loop.go` — stamp both onto the **per-iteration** ctx from `opts.Provider.ID()` / `opts.Model`. Per-iteration (not once at Run start) so a mid-run provider **fallback** — which swaps `opts.Provider`/`opts.Model` in place — is reflected truthfully. The stamp sits at the single choke point that dispatches tools, so **every** run-creation site (HTTP / gRPC / MCP / scheduler / sub-agent) inherits it with no per-site wiring.
- `internal/tools/builtin/context.go` — add `provider` + `model` to the `op=self` output map (present-as-empty when a run is started outside the loop, mirroring the `agent_def_id` surfaced-even-when-empty contract).

Non-secret by design — no `*_KEY`/token is ever exposed, only the provider id + model name. Runtime-only; no wire-shape change, no `@loomcycle/client` bump.

## What was tested

- `loop.TestRun_StampsResolvedProviderModelOnToolCtx` — a probe tool reads `ResolvedProvider`/`ResolvedModel` off the ctx the loop hands it, proving the stamp reaches dispatched tools.
- `context_test.go` — `op=self` asserts `provider`/`model` are returned, and a second test pins the present-as-empty shape when unset.
- `go test ./...` clean; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)