### PR TITLE
feat(runs): interactive runs survive view-switch + re-attach stream

### DIFF
--- a/internal/api/http/interactive_terminal_e2e_test.go
+++ b/internal/api/http/interactive_terminal_e2e_test.go
@@ -23,13 +23,18 @@ import (
 // interactive-terminal flow through the real HTTP server + SSE + loop —
 //
 //	start interactive run → loop parks at end_turn (`awaiting_input`)
-//	→ POST /v1/runs/{run_id}/input → `steer` frame + the run RESUMES
+//	→ POST /v1/runs/{run_id}/input → the run RESUMES (a new `text` turn)
 //	→ parks again → client disconnect ends the persistent run.
 //
-// Everything below the SSE wire is real (RunOnce → loop → steer registry →
-// the /input handler → drain → resume); only the provider is stubbed (always
-// end_turn, so each turn parks). This is the chain the unit/integration tests
-// only covered piecewise.
+// Everything below the SSE wire is real (loop → steer registry → the /input
+// handler → drain → resume); only the provider is stubbed (always end_turn, so
+// each turn parks). Since interactive runs are now DETACHED (the loop runs in a
+// background goroutine that survives client disconnect) and the live view is
+// served by tailing the persisted store, the operator's instruction reaches
+// the agent and the run resumes — but the steer ECHO frame is no longer on the
+// live wire (it is shown optimistically by the frontend + via the persisted
+// user_input row on reload). This asserts the functional chain: park → input →
+// resume → re-park.
 func TestInteractiveTerminal_EndToEnd(t *testing.T) {
 	cfg := &config.Config{
 		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
@@ -143,20 +148,19 @@ func TestInteractiveTerminal_EndToEnd(t *testing.T) {
 		t.Fatalf("input status = %d: %s", in.StatusCode, body)
 	}
 
-	// Phase 3: the steer surfaces (`steer` frame) and the run RESUMES (another
-	// `text` turn) before parking again.
-	sawSteer, resumed := false, false
+	// Phase 3: the steered instruction reaches the parked loop, which wakes and
+	// RESUMES — a new `text` turn appears (via the store tail) before it parks
+	// again. The steer echo frame is intentionally NOT on the live wire under
+	// the detached/store-tail model.
+	resumed, reparked := false, false
 	for {
 		f := next()
 		switch f.typ {
-		case "steer":
-			sawSteer = true
 		case "text":
-			if sawSteer {
-				resumed = true
-			}
+			resumed = true
 		case "awaiting_input":
-			if sawSteer && resumed {
+			if resumed {
+				reparked = true
 				goto done
 			}
 		case "done", "error":
@@ -164,11 +168,11 @@ func TestInteractiveTerminal_EndToEnd(t *testing.T) {
 		}
 	}
 done:
-	if !sawSteer {
-		t.Error("no `steer` frame after POST /input — steering didn't reach the live stream")
-	}
 	if !resumed {
-		t.Error("run did not resume (no `text` after the steer) — park didn't wake")
+		t.Error("run did not resume (no `text` after POST /input) — park didn't wake")
+	}
+	if !reparked {
+		t.Error("run did not re-park after resuming")
 	}
 
 	// End the persistent run: client disconnect cancels the run ctx, which

--- a/internal/api/http/run_reattach_test.go
+++ b/internal/api/http/run_reattach_test.go
@@ -1,0 +1,219 @@
+package http
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// sseLines reads an SSE response into a channel of (event, data) frames until
+// the body closes. Mirrors the reader in the interactive e2e test.
+func sseLines(t *testing.T, body io.Reader) <-chan [2]string {
+	t.Helper()
+	out := make(chan [2]string, 256)
+	go func() {
+		defer close(out)
+		sc := bufio.NewScanner(body)
+		sc.Buffer(make([]byte, 64*1024), 1024*1024)
+		var typ, data string
+		for sc.Scan() {
+			line := sc.Text()
+			if line == "" {
+				if typ != "" {
+					out <- [2]string{typ, data}
+					typ, data = "", ""
+				}
+				continue
+			}
+			if strings.HasPrefix(line, "event:") {
+				typ = strings.TrimSpace(line[len("event:"):])
+			}
+			if strings.HasPrefix(line, "data:") {
+				data = strings.TrimSpace(line[len("data:"):])
+			}
+		}
+	}()
+	return out
+}
+
+func interactiveReattachServer(t *testing.T) (*httptest.Server, func()) {
+	t.Helper()
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"termagent": {Model: "stub-model", SystemPrompt: "be brief", UnboundedIterations: true},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = "" // open mode
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "reattach.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, st)
+	srv.SetSteerRegistry(steer.NewRegistry(0))
+	ts := httptest.NewServer(srv.Mux())
+	return ts, func() { ts.Close(); _ = st.Close() }
+}
+
+// startAndPark posts an interactive run, drains until it parks, and returns the
+// run_id + agent_id captured from the side-channel frame. Closes the stream
+// (simulating the operator navigating away) before returning.
+func startAndPark(t *testing.T, ts *httptest.Server) (runID, agentID string) {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"termagent","interactive":true,"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post run: %v", err)
+	}
+	frames := sseLines(t, resp.Body)
+	next := func() [2]string {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatal("stream closed before park")
+			}
+			return f
+		case <-time.After(3 * time.Second):
+			t.Fatal("timed out waiting for park")
+			return [2]string{}
+		}
+	}
+	for {
+		f := next()
+		if f[0] == "agent" {
+			var a struct {
+				RunID   string `json:"run_id"`
+				AgentID string `json:"agent_id"`
+			}
+			_ = json.Unmarshal([]byte(f[1]), &a)
+			runID, agentID = a.RunID, a.AgentID
+		}
+		if f[0] == "awaiting_input" {
+			break
+		}
+		if f[0] == "done" || f[0] == "error" {
+			t.Fatalf("run ended (%s) before parking", f[0])
+		}
+	}
+	if runID == "" {
+		t.Fatal("no run_id captured")
+	}
+	// Operator navigates away: close the initial stream. Under the OLD
+	// (request-bound) model this cancelled the run; the detached model keeps
+	// it alive.
+	_ = resp.Body.Close()
+	return runID, agentID
+}
+
+// TestInteractiveRun_SurvivesDisconnect_AndReattaches is the core PR proof: an
+// interactive run keeps running after the client disconnects, accepts a steer,
+// and is re-attachable via GET /v1/runs/{run_id}/stream (replay + resume).
+func TestInteractiveRun_SurvivesDisconnect_AndReattaches(t *testing.T) {
+	ts, cleanup := interactiveReattachServer(t)
+	defer cleanup()
+
+	runID, agentID := startAndPark(t, ts)
+
+	// The decisive assertion: after disconnect the steer endpoint still finds
+	// the live run (200). Under the request-bound model the steer registry
+	// would have been deregistered → 404. Poll briefly to let the server
+	// observe the disconnect first.
+	var delivered bool
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		in, err := http.Post(ts.URL+"/v1/runs/"+runID+"/input", "application/json",
+			strings.NewReader(`{"text":"keep going"}`))
+		if err != nil {
+			t.Fatalf("post input: %v", err)
+		}
+		body, _ := io.ReadAll(in.Body)
+		in.Body.Close()
+		if in.StatusCode == 200 {
+			delivered = true
+			_ = body
+			break
+		}
+		if in.StatusCode != 404 {
+			t.Fatalf("unexpected input status %d: %s", in.StatusCode, body)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !delivered {
+		t.Fatal("POST /input never delivered after disconnect — the run did not survive (detach failed)")
+	}
+
+	// Re-attach: replay from seq 0 and tail. We must see the agent's resumed
+	// `text` turn (the steer woke the park) and a re-park.
+	resp, err := http.Get(ts.URL + "/v1/runs/" + runID + "/stream?from_seq=0")
+	if err != nil {
+		t.Fatalf("get stream: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("stream status = %d", resp.StatusCode)
+	}
+	frames := sseLines(t, resp.Body)
+	sawText, sawPark := false, false
+	timeout := time.After(5 * time.Second)
+	for !(sawText && sawPark) {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatal("re-attach stream closed early")
+			}
+			switch f[0] {
+			case "text":
+				sawText = true
+			case "awaiting_input":
+				sawPark = true
+			}
+		case <-timeout:
+			t.Fatalf("re-attach did not replay text+park (text=%v park=%v)", sawText, sawPark)
+		}
+	}
+
+	// Clean up the detached goroutine: cancel the run.
+	if agentID != "" {
+		c, _ := http.Post(ts.URL+"/v1/agents/"+agentID+"/cancel", "application/json", strings.NewReader(`{}`))
+		if c != nil {
+			c.Body.Close()
+		}
+	}
+}
+
+// TestRunStream_UnknownRun404 — re-attaching to an unknown run is an opaque 404
+// (the same shape a cross-tenant attach gets; cross-tenant uses the
+// sessionOwnershipOK gate mirrored from handleRunInput).
+func TestRunStream_UnknownRun404(t *testing.T) {
+	ts, cleanup := interactiveReattachServer(t)
+	defer cleanup()
+
+	resp, err := http.Get(ts.URL + "/v1/runs/r_does_not_exist/stream")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}

--- a/internal/api/http/run_stream.go
+++ b/internal/api/http/run_stream.go
@@ -1,0 +1,171 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// runStreamPollInterval is how often the store-tail re-reads a run's events.
+// Sub-second so a human-driven interactive terminal feels live, but not so
+// tight that a long-idle parked run hammers the store.
+const runStreamPollInterval = 250 * time.Millisecond
+
+// nonStreamableEventTypes are persisted transcript rows whose payload is NOT a
+// providers.Event (so they can't round-trip to an SSE frame) — the operator's
+// own prompt segments and the resolved system prompt. A re-attaching client
+// renders those from the one-shot transcript fetch; the live tail only carries
+// the loop's typed events. Steer/session/agent frames are never persisted, so
+// they never appear here.
+var nonStreamableEventTypes = map[string]bool{
+	"user_input":    true,
+	"system_prompt": true,
+}
+
+// streamRunEvents tails a run's persisted events to an SSE stream by polling
+// the store, re-emitting each loop event (text / tool_call / tool_result /
+// done / …) as the same providers.Event frame the live run stream produces.
+// It is the shared engine behind two callers: the interactive POST /v1/runs
+// handler (whose loop runs detached in a goroutine) and the re-attach endpoint
+// GET /v1/runs/{run_id}/stream.
+//
+// It returns when ctx is done (the client disconnected — which for an
+// interactive run does NOT stop the run itself) or the run reaches a terminal
+// state and all its events have been streamed. fromSeq lets a re-attaching
+// client skip events it already rendered from the transcript snapshot.
+func (s *Server) streamRunEvents(ctx context.Context, stream *sse, runID string, fromSeq int64) {
+	if s.store == nil {
+		return
+	}
+	cursor := fromSeq
+	ticker := time.NewTicker(runStreamPollInterval)
+	defer ticker.Stop()
+	for {
+		// Drain everything past the cursor before deciding whether to stop.
+		drainErr := false
+		for {
+			evs, more, err := s.runEventsSince(ctx, runID, cursor)
+			if err != nil {
+				drainErr = true
+				break
+			}
+			for _, ev := range evs {
+				cursor = ev.Seq
+				if nonStreamableEventTypes[ev.Type] {
+					continue
+				}
+				var pe providers.Event
+				if json.Unmarshal(ev.Payload, &pe) != nil {
+					continue // payload not a providers.Event — skip defensively
+				}
+				stream.send(pe)
+			}
+			if !more {
+				break
+			}
+		}
+		// If the run is terminal and we've drained it, we're done. A parked
+		// interactive run never reaches terminal until cancelled, so this loop
+		// stays live until the client disconnects (ctx) — exactly what we want.
+		if !drainErr {
+			if run, err := s.store.GetRun(ctx, runID); err == nil && isTerminalRunStatus(run.Status) {
+				return
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// runEventsSince returns the run's events with seq > cursor, ordered ascending.
+// `more` reports whether the page hit the limit (caller should drain again).
+// Run-scoped + incremental via GetRunEventsSince, so a long-running interactive
+// agent's tail doesn't re-read the whole session transcript each tick. Returns
+// ([], false, err) on a store error so the caller backs off.
+func (s *Server) runEventsSince(ctx context.Context, runID string, cursor int64) ([]store.Event, bool, error) {
+	const pageLimit = 500
+	out, err := s.store.GetRunEventsSince(ctx, runID, cursor, pageLimit)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, len(out) == pageLimit, nil
+}
+
+// isTerminalRunStatus reports whether a run has reached an end state (so a
+// store-tail can stop). "running" is the only non-terminal status.
+func isTerminalRunStatus(st store.RunStatus) bool {
+	switch st {
+	case store.RunCompleted, store.RunFailed, store.RunCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// handleRunStream is GET /v1/runs/{run_id}/stream — re-attach to a running (or
+// finished) run's event stream. Replays from ?from_seq (default 0) and live-
+// tails. The companion to interactive runs surviving a client disconnect: the
+// operator leaves the /run terminal and returns to the same live run via the
+// runs list. Read scope (ScopeRunsRead, mapped in auth_principal.go) +
+// tenant-ownership gated. Single-replica: a run owned by another replica is
+// not tailable here (its events are in the shared store, so for a DB-backed
+// deployment this still works; an in-memory store on another replica 404s).
+func (s *Server) handleRunStream(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "run streaming requires a persistence backend", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	run, err := s.store.GetRun(r.Context(), runID)
+	if err != nil {
+		// Opaque 404 — run_ids are not secret, but we don't distinguish
+		// "unknown" from "not yours" to avoid a cross-tenant probe oracle.
+		http.Error(w, "no such run", http.StatusNotFound)
+		return
+	}
+	// Tenant-ownership gate (mirrors handleRunInput): resolve the run's session
+	// and refuse a cross-tenant attach with the same opaque 404.
+	if run.SessionID != "" {
+		if sess, serr := s.store.GetSession(r.Context(), run.SessionID); serr == nil {
+			if !sessionOwnershipOK(r.Context(), sess) {
+				http.Error(w, "no such run", http.StatusNotFound)
+				return
+			}
+		}
+	}
+
+	var fromSeq int64
+	if q := r.URL.Query().Get("from_seq"); q != "" {
+		if n, perr := strconv.ParseInt(q, 10, 64); perr == nil && n >= 0 {
+			fromSeq = n
+		}
+	}
+
+	stream, ok := newSSE(w)
+	if !ok {
+		http.Error(w, "server does not support streaming on this transport", http.StatusInternalServerError)
+		return
+	}
+	stream.start()
+	stream.startKeepalive(r.Context(), s.cfg.Env.SSEKeepaliveInterval)
+	// Announce the run/session so the re-attached terminal can address steer /
+	// cancel without a separate lookup (parity with the POST /v1/runs stream).
+	stream.sendRaw("agent", map[string]any{
+		"agent_id":   run.AgentID,
+		"run_id":     runID,
+		"session_id": run.SessionID,
+	})
+	s.streamRunEvents(r.Context(), stream, runID, fromSeq)
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2183,6 +2183,9 @@ func (s *Server) Mux() http.Handler {
 	// PR 2 / interactive terminal: inject an operator "steering" instruction
 	// into an in-flight run (appended to the live conversation mid-turn).
 	mux.Handle("POST /v1/runs/{run_id}/input", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunInput))))
+	// Re-attach to a running (or finished) run's event stream — the operator
+	// leaves the interactive /run terminal and returns to the same live run.
+	mux.Handle("GET /v1/runs/{run_id}/stream", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunStream))))
 	// v0.7.3 Web UI — embedded React SPA. The cookie-set landing
 	// page (/ui with a ?token= query) is intentionally NOT
 	// auth-middleware-wrapped; it sets the cookie that the
@@ -2868,12 +2871,29 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Derive the loop ctx with a cancel-cause function. The HTTP request
-	// ctx remains the parent so client-disconnect still tears down. We
-	// register the cancelFn under agent_id so an external cancel API
-	// call can fire it.
-	runCtx, cancelFn := context.WithCancelCause(r.Context())
-	defer cancelFn(nil) // ensure ctx leaks don't survive the handler
+	// Derive the loop ctx with a cancel-cause function. For a normal run the
+	// HTTP request ctx is the parent so client-disconnect tears the run down.
+	// For an INTERACTIVE run we detach with context.WithoutCancel: the run
+	// keeps the request's ctx VALUES (auth principal, tenant) but is NOT
+	// cancelled when the client navigates away — it parks and the operator
+	// re-attaches via GET /v1/runs/{run_id}/stream. cancelFn (registered under
+	// agent_id) is the only thing that stops it.
+	runParent := r.Context()
+	if req.Interactive {
+		runParent = context.WithoutCancel(r.Context())
+	}
+	runCtx, cancelFn := context.WithCancelCause(runParent)
+	// handOff flips true once an interactive run's background goroutine takes
+	// ownership of teardown (cancelFn / span / steer / cancel registry /
+	// finishRun). Until then — and always for non-interactive runs — the
+	// handler's defers own teardown. This prevents the handler returning on
+	// client-disconnect from tearing down a still-running detached run.
+	handOff := false
+	defer func() {
+		if !handOff {
+			cancelFn(nil) // ensure ctx leaks don't survive the handler
+		}
+	}()
 	// v0.10.0 OTEL: top-level loomcycle.run span covers the whole run.
 	runCtx, runSpan := lcotel.RecordRunStart(runCtx, lcotel.RunStartAttrs{
 		RunID:     runID,
@@ -2881,7 +2901,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		AgentName: req.Agent,
 		UserID:    req.UserID,
 	})
-	defer runSpan.End()
+	defer func() {
+		if !handOff {
+			runSpan.End()
+		}
+	}()
 	lcotel.RecordQueueWait(runSpan, queueWait)
 
 	regErr := s.cancelReg.Register(cancel.Entry{
@@ -2920,16 +2944,22 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, regErr.Error(), http.StatusInternalServerError)
 		return
 	}
-	defer s.cancelReg.Deregister(agentID)
+	defer func() {
+		if !handOff {
+			s.cancelReg.Deregister(agentID)
+		}
+	}()
 	s.publishRunState(meta, "running", "", "")
 
 	// If we're persisting, record the caller's input segments as the first
 	// event in the run. The loop never emits the caller's input itself, so
 	// without this the transcript would start with the assistant's first
-	// turn — and replay couldn't reconstruct the user prompt.
+	// turn — and replay couldn't reconstruct the user prompt. Persist under
+	// runCtx (not r.Context()) so an interactive run's prompt survives a
+	// client disconnect; for a normal run runCtx tracks the request anyway.
 	if s.store != nil && runID != "" {
 		if inputJSON, err := json.Marshal(req.Segments); err == nil {
-			if err := s.store.AppendEvent(r.Context(), runID, "user_input", inputJSON); err != nil {
+			if err := s.store.AppendEvent(runCtx, runID, "user_input", inputJSON); err != nil {
 				log.Printf("store: AppendEvent(user_input) failed: %v", err)
 			}
 		}
@@ -2937,7 +2967,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// v0.9.x: persist the resolved system prompt + provenance so the
 	// Web UI surfaces it as a card on the run timeline. Mirrors the
 	// emission in RunOnce + handleMessages + runSubAgent.
-	s.emitSystemPromptEvent(r.Context(), runID, agentDef.SystemPrompt, "", promptProv)
+	s.emitSystemPromptEvent(runCtx, runID, agentDef.SystemPrompt, "", promptProv)
 
 	stream, ok := newSSE(w)
 	if !ok {
@@ -2974,11 +3004,27 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		"parent_context":  req.ParentContext, // v0.12.x: opaque tracking lineage (nil when absent)
 	})
 
-	emit := s.makeRecordingEmit(r.Context(), runID, stream.send)
+	// For an interactive (detached) run the loop runs in a background
+	// goroutine that OUTLIVES this handler — and net/http forbids writing to
+	// the ResponseWriter after the handler returns. So the loop must NOT push
+	// to the live stream; it only persists. The handler (and any re-attach)
+	// streams by tailing the store. For a normal run, forward live as before.
+	streamFwd := stream.send
+	if req.Interactive {
+		streamFwd = func(providers.Event) {}
+	}
+	// Persist under runCtx so events survive a client disconnect on an
+	// interactive run (runCtx tracks the request for a normal run).
+	emit := s.makeRecordingEmit(runCtx, runID, streamFwd)
 
 	// PR 2: operator steering queue for this run (in-flight input injection).
-	steerQ, onSteer, deregSteer := s.makeSteer(r.Context(), runID, agentID, sessionID, req.UserID, emit)
-	defer deregSteer()
+	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, runID, agentID, sessionID, req.UserID, emit)
+	deferDeregSteer := func() {
+		if !handOff {
+			deregSteer()
+		}
+	}
+	defer deferDeregSteer()
 
 	// Pass the agent's effective tool names to the dispatcher so tools
 	// that need a runtime view of "what this agent can use" (e.g. the
@@ -3024,7 +3070,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	heartbeat := s.makeHeartbeat(runID)
 
 	fbPolicy, fbReResolve := s.fallbackForRun(req.TenantID, req.Agent, req.UserTier)
-	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
+	runOpts := loop.RunOptions{
 		Provider:               provider,
 		Model:                  model,
 		Tools:                  allowedTools,
@@ -3052,7 +3098,39 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		ReResolve:              fbReResolve,
 		Hooks:                  s.hookDispatcher,
 		MaxSameProviderRetries: s.retryAttemptsForAgent(agentDef, req.UserTier),
-	})
+	}
+
+	if req.Interactive && s.store != nil {
+		// Detached run: execute the loop in a background goroutine that
+		// OUTLIVES this handler, so navigating away (client disconnect) no
+		// longer kills the run — it parks and the operator re-attaches via
+		// GET /v1/runs/{run_id}/stream. The goroutine owns teardown (handOff
+		// neutralises the handler's defers); the handler streams by tailing
+		// the store (it must NOT use the loop's emit→stream path, because
+		// net/http forbids writing to the ResponseWriter after the handler
+		// returns). Returning here does NOT cancel the run.
+		handOff = true
+		go func() {
+			loopRes, runErr := loop.Run(loopCtx, runOpts)
+			if runErr != nil {
+				// Persist (not stream) the failure so a tailing client sees it.
+				emit(providers.Event{Type: providers.EventError, Error: runErr.Error()})
+			}
+			// WithoutCancel: the store write must not ride a runCtx that an
+			// API-cancel already cancelled (the cause is still read from runCtx).
+			s.finishRunWithCancel(context.WithoutCancel(runCtx), runCtx, runID, loopRes, runErr, meta)
+			deregSteer()
+			s.cancelReg.Deregister(agentID)
+			runSpan.End()
+			cancelFn(nil)
+		}()
+		// Tail the store to this client until they disconnect (r.Context()) or
+		// the run terminates. from_seq=0 → stream the whole run live.
+		s.streamRunEvents(r.Context(), stream, runID, 0)
+		return
+	}
+
+	loopRes, runErr := loop.Run(loopCtx, runOpts)
 	if runErr != nil {
 		stream.send(providers.Event{Type: providers.EventError, Error: runErr.Error()})
 	}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -446,6 +446,41 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 	return out, nil
 }
 
+// GetRunEventsSince returns a run's events with seq > afterSeq, ordered by seq
+// ascending, capped at limit. Incremental run-scoped read for the interactive
+// SSE tail. Index hint: events_by_run_seq (run_id, seq) from migration 0015.
+func (s *Store) GetRunEventsSince(ctx context.Context, runID string, afterSeq int64, limit int) ([]store.Event, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT seq, session_id, run_id, ts, type, payload
+		 FROM events WHERE run_id = $1 AND seq > $2 ORDER BY seq ASC LIMIT $3`,
+		runID, afterSeq, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query run events: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.Event{}
+	for rows.Next() {
+		var (
+			ev store.Event
+			ts time.Time
+		)
+		if err := rows.Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload); err != nil {
+			return nil, fmt.Errorf("scan run event: %w", err)
+		}
+		ev.Timestamp = ts
+		out = append(out, ev)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iter run events: %w", err)
+	}
+	return out, nil
+}
+
 // GetLastEventForRun returns the latest event by seq for the given
 // run. Index hint: events_by_run_seq (added in migration 0015).
 func (s *Store) GetLastEventForRun(ctx context.Context, runID string) (store.Event, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1137,6 +1137,36 @@ func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Ev
 	return out, rows.Err()
 }
 
+// GetRunEventsSince returns a run's events with seq > afterSeq, ordered by seq
+// ascending, capped at limit. Incremental run-scoped read for the interactive
+// SSE tail — indexed on events.run_id like GetLastEventForRun.
+func (s *Store) GetRunEventsSince(ctx context.Context, runID string, afterSeq int64, limit int) ([]store.Event, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT seq, session_id, run_id, ts, type, payload
+		 FROM events WHERE run_id = ? AND seq > ? ORDER BY seq ASC LIMIT ?`,
+		runID, afterSeq, limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.Event
+	for rows.Next() {
+		var ev store.Event
+		var ts int64
+		if err := rows.Scan(&ev.Seq, &ev.SessionID, &ev.RunID, &ts, &ev.Type, &ev.Payload); err != nil {
+			return nil, err
+		}
+		ev.Timestamp = time.Unix(0, ts)
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
 // GetLastEventForRun returns the latest event by seq for the given
 // run. Indexed by events.run_id under the existing schema; the
 // composite (session_id, seq) index doesn't cover this query, but

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -492,6 +492,14 @@ type Store interface {
 	// Returns an empty slice (not error) for a session with no runs yet.
 	GetTranscript(ctx context.Context, sessionID string) ([]Event, error)
 
+	// GetRunEventsSince returns a run's events with Seq > afterSeq, ordered by
+	// Seq ascending, capped at limit (<=0 means a sane default). Run-scoped
+	// (not session-scoped) and incremental, so the interactive-run SSE tail
+	// (GET /v1/runs/{run_id}/stream) can poll cheaply without re-reading the
+	// whole session transcript each tick. Returns an empty slice (not error)
+	// when nothing is newer than afterSeq.
+	GetRunEventsSince(ctx context.Context, runID string, afterSeq int64, limit int) ([]Event, error)
+
 	// ListEvents returns events across all sessions matching the
 	// filter, ordered by ts DESC (newest first). Used by the v0.8.21
 	// /v1/_events audit endpoint. Returns the rows AND the total

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -75,6 +75,7 @@ func Run(t *testing.T, factory Factory) {
 		{"CreateRunOnUnknownSession", testCreateRunOnUnknownSession},
 		{"FinishRunIdempotent", testFinishRunIdempotent},
 		{"GetTranscriptEmpty", testGetTranscriptEmpty},
+		{"GetRunEventsSince", testGetRunEventsSince},
 		{"CreateSessionUserIDRoundTrip", testCreateSessionUserIDRoundTrip},
 		{"CreateRunIdentityRoundTrip", testCreateRunIdentityRoundTrip},
 		{"CreateRunParentContextRoundTrip", testCreateRunParentContextRoundTrip},
@@ -394,6 +395,68 @@ func testRunLifecycle(t *testing.T, s store.Store) {
 		if transcript[i].Seq <= transcript[i-1].Seq {
 			t.Errorf("seq not ascending at %d: %d -> %d", i, transcript[i-1].Seq, transcript[i].Seq)
 		}
+	}
+}
+
+func testGetRunEventsSince(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, typ := range []string{"started", "text", "tool_call", "tool_result", "done"} {
+		if err := s.AppendEvent(ctx, run.ID, typ, []byte(`{"type":"`+typ+`"}`)); err != nil {
+			t.Fatalf("AppendEvent[%d]: %v", i, err)
+		}
+	}
+
+	// from 0 → all events, ascending by seq.
+	all, err := s.GetRunEventsSince(ctx, run.ID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("GetRunEventsSince(0) len = %d, want 5", len(all))
+	}
+	for i := 1; i < len(all); i++ {
+		if all[i].Seq <= all[i-1].Seq {
+			t.Errorf("seq not ascending at %d: %d -> %d", i, all[i-1].Seq, all[i].Seq)
+		}
+		if all[i].RunID != run.ID {
+			t.Errorf("event %d run_id = %q, want %q", i, all[i].RunID, run.ID)
+		}
+	}
+
+	// from a mid cursor → only newer events (the tail's incremental read).
+	cursor := all[1].Seq
+	tail, err := s.GetRunEventsSince(ctx, run.ID, cursor, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tail) != 3 {
+		t.Fatalf("GetRunEventsSince(seq=%d) len = %d, want 3", cursor, len(tail))
+	}
+	if tail[0].Seq <= cursor {
+		t.Errorf("first tail seq %d not > cursor %d", tail[0].Seq, cursor)
+	}
+
+	// limit caps the page.
+	capped, err := s.GetRunEventsSince(ctx, run.ID, 0, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(capped) != 2 {
+		t.Errorf("GetRunEventsSince(limit=2) len = %d, want 2", len(capped))
+	}
+
+	// caught up → empty (not error).
+	none, err := s.GetRunEventsSince(ctx, run.ID, all[len(all)-1].Seq, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Errorf("GetRunEventsSince past tail len = %d, want 0", len(none))
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1583,6 +1583,39 @@ async function streamSSE(
   await pumpSSE(resp.body, h.onFrame);
 }
 
+// streamRunByID RE-ATTACHES to a running (or finished) run's event stream via
+// GET /v1/runs/{run_id}/stream — the operator left the interactive terminal
+// and returned to the same live run. Replays from fromSeq (0 = whole run) then
+// live-tails until the run terminates or the reader is aborted. Same frame
+// shape as the POST /v1/runs stream, so the caller's onFrame is unchanged.
+export async function streamRunByID(
+  runID: string,
+  fromSeq: number,
+  h: RunStreamHandlers,
+): Promise<void> {
+  const q = fromSeq > 0 ? `?from_seq=${fromSeq}` : "";
+  const resp = await fetch(
+    `${baseURL}/v1/runs/${encodeURIComponent(runID)}/stream${q}`,
+    {
+      method: "GET",
+      credentials: "same-origin",
+      signal: h.signal,
+      headers: { Accept: "text/event-stream" },
+    },
+  );
+  if (!resp.ok) {
+    if (redirectToLoginOn401(resp.status)) {
+      return new Promise<void>(() => {});
+    }
+    const text = await resp.text();
+    throw new Error(`${resp.status} ${resp.statusText}: ${text.slice(0, 200)}`);
+  }
+  if (!resp.body) {
+    throw new Error("stream response had no body");
+  }
+  await pumpSSE(resp.body, h.onFrame);
+}
+
 // pumpSSE drains a text/event-stream ReadableStream, parsing frames and
 // invoking onFrame for each non-comment frame. Shared by streamSSE (POST)
 // and streamRunStates (GET).

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -169,6 +169,13 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
                 {cancelInFlight ? "cancelling…" : "cancel"}
               </button>
             )}
+            {agent.status === "running" && agent.run_id && (
+              // Re-attach to a live (notably interactive/parked) run in the
+              // terminal — the run kept executing after you navigated away.
+              <Link className="resume-btn" to={`/run?attach=${encodeURIComponent(agent.run_id)}`}>
+                resume in terminal
+              </Link>
+            )}
           </div>
           {agent.status === "running" && (
             <div className="line-await">

--- a/web/src/hooks/useRunStream.ts
+++ b/web/src/hooks/useRunStream.ts
@@ -5,6 +5,7 @@ import {
   resolveInterrupt,
   sendRunInput,
   startRun,
+  streamRunByID,
   sseEventToTranscript,
   type EventPayload,
   type StartRunRequest,
@@ -57,6 +58,11 @@ export interface UseRunStream {
   // end_turn waiting for the operator's next instruction (the agent is idle).
   awaitingInput: boolean;
   start: (req: StartRunRequest) => void;
+  // attach RE-CONNECTS to an already-running (or finished) run by id —
+  // the operator returns to a detached interactive run from the runs list.
+  // Replays the run's transcript then live-tails; the terminal prompt /
+  // steering / cancel all work against the re-attached run.
+  attach: (runId: string) => void;
   sendMessage: (prompt: string) => void;
   // send routes by state: while the run is running it STEERS the live run
   // (POST /input — also resumes a parked interactive run); otherwise it
@@ -194,6 +200,31 @@ export function useRunStream(): UseRunStream {
     [onFrame, runStream],
   );
 
+  const attach = useCallback(
+    (rid: string) => {
+      if (!rid) return;
+      ctrlRef.current?.abort();
+      const ctrl = new AbortController();
+      ctrlRef.current = ctrl;
+      // Replay from seq 0: the re-attach stream carries the whole run, so the
+      // returning operator sees the full scrollback then live updates. (The
+      // run's own user_input/system_prompt rows aren't on the tail; for a
+      // detached interactive run the agent's turns are what matter live.)
+      seqRef.current = 0;
+      setEvents([]);
+      setAgentId("");
+      setSessionId("");
+      setRunId(rid);
+      runIdRef.current = rid;
+      setError(null);
+      setPendingInterrupt(null);
+      setAwaitingInput(false);
+      setStatus("running");
+      runStream(streamRunByID(rid, 0, { onFrame, signal: ctrl.signal }));
+    },
+    [onFrame, runStream],
+  );
+
   const sendMessage = useCallback(
     (prompt: string) => {
       if (!sessionId) return;
@@ -268,6 +299,7 @@ export function useRunStream(): UseRunStream {
     answerInterrupt,
     awaitingInput,
     start,
+    attach,
     send,
     sendMessage,
     cancel,

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { listLibraryAgents, type StartRunRequest } from "../api";
 import { useUserId } from "../components/Layout";
 import { useRunStream } from "../hooks/useRunStream";
@@ -98,6 +99,22 @@ function SingleRunTab({
   defaultUserId: string;
 }) {
   const run = useRunStream();
+  const [searchParams, setSearchParams] = useSearchParams();
+  // `?attach=<run_id>` re-attaches to a detached interactive run (the operator
+  // returned from the runs list). Attach once on mount, then drop the param so
+  // a manual reset/new-run isn't re-hijacked by a stale URL.
+  const attachRunId = searchParams.get("attach");
+  const attachedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (attachRunId && attachedRef.current !== attachRunId) {
+      attachedRef.current = attachRunId;
+      run.attach(attachRunId);
+      const next = new URLSearchParams(searchParams);
+      next.delete("attach");
+      setSearchParams(next, { replace: true });
+    }
+  }, [attachRunId, run, searchParams, setSearchParams]);
+
   return (
     <div className="run-view-body">
       <div className="run-view-form-col">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -694,6 +694,21 @@ pre {
 .cancel-btn:disabled {
   opacity: 0.6;
 }
+.resume-btn {
+  background: var(--accent);
+  color: white;
+  border: none;
+  border-radius: 3px;
+  padding: 4px 10px;
+  cursor: pointer;
+  margin-left: 8px;
+  font-size: 12px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.resume-btn:hover {
+  filter: brightness(1.1);
+}
 .agent-err {
   margin-top: 8px;
   padding: 6px 10px;


### PR DESCRIPTION
## Why

An interactive `/run` terminal run **stopped when the operator navigated to the runs menu**. Root cause: the run's loop ctx was a child of the HTTP request ctx (`context.WithCancelCause(r.Context())`) and `loop.Run` executed inline in the handler — closing the SSE stream cancelled the request ctx, which cascaded to the loop and terminated the parked run. There was also no way to return to a still-running run.

The operator must be able to leave the terminal and come back to the same live interaction.

## What

**Backend — detach interactive runs from the request.**
- The interactive loop runs in a **background goroutine** under `context.WithoutCancel(r.Context())`: it keeps the request's ctx *values* (auth principal / tenant) but is **not** cancelled on client disconnect. The goroutine owns teardown (a `handOff` flag neutralises the handler's `defer`s so a disconnect doesn't tear down the run); the run stops only via the cancel registry. Persistence (`emit` / steer / `user_input` / `system_prompt`) moved onto the detached `runCtx` so events survive a disconnect.
- net/http forbids writing to the `ResponseWriter` after the handler returns, so for interactive runs the loop **persists only** and the handler **streams by tailing the store** — the same engine the re-attach path uses.
- **New `GET /v1/runs/{run_id}/stream`** re-attaches: replays from `?from_seq` then live-tails, re-emitting each persisted `providers.Event` as the same SSE frame the live run produced. `ScopeRunsRead` + tenant-ownership gated (opaque 404, mirroring `POST /input`).
- **New store method `GetRunEventsSince(runID, afterSeq, limit)`** — run-scoped, incremental (indexed on `events.run_id` / `events_by_run_seq`), so a long interactive session's tail doesn't re-read the whole transcript each tick. Implemented for sqlite + postgres; contract test added.

**Behavior change (called out):** the operator's steer **echo frame** is no longer on the live wire for interactive runs (steer events aren't persisted). Steering itself is unchanged — the instruction reaches the agent and the run resumes; the operator's input shows optimistically + via the persisted `user_input` row on reload.

**Frontend.**
- `api.streamRunByID(runId, fromSeq)` → the GET stream.
- `useRunStream.attach(runId)` — re-connect mode (replay + live tail); terminal prompt / steering / cancel all work against the re-attached run.
- `AgentDetailPane` gains a **"resume in terminal"** link on a running run → the runs list (`/agents`) is the way back into a live interactive run.
- `RunView` honors `?attach=<run_id>` (attach once, then drops the param).

## Scope / deferrals

Single-replica (a run owned by another replica isn't tailable via its in-memory state; **DB-backed deployments still work** since events live in the shared store), single attached viewer. Cross-replica re-attach + multi-viewer fan-out are deferred — same single-replica-first path steering took. No `@loomcycle/client` bump (the SPA ships its own client). Adds one GET route; no new wire primitive.

## What was tested

- `store` contract `GetRunEventsSince` (sqlite + postgres parity: from-0, mid-cursor incremental, limit cap, caught-up-empty).
- `http.TestInteractiveRun_SurvivesDisconnect_AndReattaches` — the decisive proof: `POST /input` still **delivers after the client disconnects** (404 under the old model), then `GET /stream` replays the resumed turn.
- `http.TestRunStream_UnknownRun404`; updated `TestInteractiveTerminal_EndToEnd` for the detached/store-tail flow.
- `go test ./...` clean; `gofmt` clean; `go build` + `cd web && npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)