### PR TITLE
fix(webui): terminal auto-scroll, collapse tool_call, multi-line input

### DIFF
--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import TerminalTranscript from "./TerminalTranscript";
 import { type PendingInterrupt, type RunStatus } from "../hooks/useRunStream";
 import { type TranscriptEvent } from "../api";
@@ -42,6 +42,15 @@ export default function LiveRunPane({
   compact?: boolean;
 }) {
   const [followUp, setFollowUp] = useState("");
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  // Auto-grow the input with its content (up to a cap), and shrink back to one
+  // line after a send clears it.
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 160)}px`;
+  }, [followUp]);
 
   const running = status === "running";
   // The terminal prompt is available once a run exists (so steering works as
@@ -53,11 +62,21 @@ export default function LiveRunPane({
   // The legacy onContinue can only fire between turns; onSend handles both.
   const promptDisabled = !onSend && running;
 
-  const handleSend = (e: React.FormEvent) => {
-    e.preventDefault();
+  const doSend = () => {
     if (!promptHandler || !followUp.trim() || promptDisabled) return;
     promptHandler(followUp.trim());
     setFollowUp("");
+  };
+  const handleSend = (e: React.FormEvent) => {
+    e.preventDefault();
+    doSend();
+  };
+  // Enter sends; Shift+Enter inserts a soft newline (multi-line editing).
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      doSend();
+    }
   };
 
   return (
@@ -93,19 +112,22 @@ export default function LiveRunPane({
 
       {showPrompt && (
         <form className="live-run-continue" onSubmit={handleSend}>
-          <input
-            type="text"
+          <textarea
+            ref={taRef}
+            className="live-run-input"
             value={followUp}
             onChange={(e) => setFollowUp(e.target.value)}
+            onKeyDown={onKeyDown}
             disabled={promptDisabled}
+            rows={1}
             placeholder={
               promptDisabled
                 ? "Wait for the turn to finish…"
                 : running
                   ? awaitingInput
-                    ? "Type to continue the session…"
-                    : "Steer the running agent…"
-                  : "Continue the conversation…"
+                    ? "Type to continue (Enter to send, Shift+Enter for newline)…"
+                    : "Steer the running agent (Enter to send, Shift+Enter for newline)…"
+                  : "Continue the conversation (Enter to send, Shift+Enter for newline)…"
             }
           />
           <button type="submit" disabled={!followUp.trim() || promptDisabled}>

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -31,17 +31,29 @@ export interface TerminalTranscriptProps {
 
 export default function TerminalTranscript({ events }: TerminalTranscriptProps) {
   const ref = useRef<HTMLDivElement | null>(null);
+  // stickRef tracks whether the operator is pinned to the bottom (following
+  // the tail). Starts true; the onScroll handler flips it when they scroll up
+  // to read and back when they return to the bottom. So we follow live output
+  // by default but never yank them off a line they're reading.
+  const stickRef = useRef(true);
   const lines = useMemo(() => coalesceTextTerminal(events).map(formatLine), [events]);
 
+  // Depend on the events array (not lines.length): streaming text deltas
+  // COALESCE into one line, so lines.length stays flat while the content
+  // grows — keying on events.length would stall the tail mid-stream.
   useEffect(() => {
     const el = ref.current;
+    if (el && stickRef.current) el.scrollTop = el.scrollHeight;
+  }, [events]);
+
+  const onScroll = () => {
+    const el = ref.current;
     if (!el) return;
-    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-    if (nearBottom) el.scrollTop = el.scrollHeight;
-  }, [lines.length]);
+    stickRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+  };
 
   return (
-    <div ref={ref} className="terminal-transcript">
+    <div ref={ref} className="terminal-transcript" onScroll={onScroll}>
       {lines.map((l, i) => (
         <TerminalRow key={l.key ?? i} line={l} />
       ))}
@@ -149,15 +161,27 @@ function formatLine(row: TranscriptEvent): FormattedLine {
       return { key, ts, kind, cls: "tl-text", payload: ev.text ?? "" };
     case "tool_call": {
       const t = ev.tool_use;
-      const inputStr = t?.input
+      const oneLineInput = t?.input
         ? typeof t.input === "string"
           ? oneLine(t.input)
           : oneLine(JSON.stringify(t.input))
         : "";
+      // Expanded detail: the full input, pretty-printed when it's an object so
+      // a Write's file content / a multi-field call is readable.
+      const fullInput = t?.input
+        ? typeof t.input === "string"
+          ? t.input
+          : JSON.stringify(t.input, null, 2)
+        : "";
       const idTail = t?.id ? ` ${t.id.slice(0, 8)}` : "";
+      // Collapsed by default: a tool call's input can be huge (a Write's whole
+      // file body) and contaminates the scrollback — show name + id + a short
+      // preview, expand on click.
       return {
         key, ts, kind, cls: "tl-tool",
-        payload: `${t?.name ?? "?"}${idTail} ${inputStr}`.trimEnd(),
+        payload: `${t?.name ?? "?"}${idTail} ${truncate(oneLineInput, 80)}`.trimEnd(),
+        collapsible: true,
+        full: `${t?.name ?? "?"}${idTail}\n${fullInput}`.trimEnd(),
       };
     }
     case "tool_result": {
@@ -241,6 +265,10 @@ function formatLine(row: TranscriptEvent): FormattedLine {
 
 function oneLine(s: string): string {
   return s.replace(/\s+/g, " ").trim();
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n) + "…" : s;
 }
 
 function formatHMSms(ns: number): string {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4134,11 +4134,25 @@ button.primary:disabled {
   gap: 8px;
   padding: 8px 12px;
   border-top: 1px solid var(--border, #2a2a32);
+  align-items: flex-end;
 }
 .live-run-continue input {
   flex: 1;
 }
-.live-run-continue input:disabled {
+.live-run-input {
+  flex: 1;
+  resize: none;
+  overflow-y: auto;
+  min-height: 34px;
+  max-height: 160px;
+  line-height: 1.4;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: inherit;
+  box-sizing: border-box;
+}
+.live-run-continue input:disabled,
+.live-run-input:disabled {
   opacity: 0.55;
 }
 .live-run-awaiting {


### PR DESCRIPTION
## Why

Three operator-reported gaps in the interactive `/run` terminal after v0.27.0:
1. It didn't auto-scroll to the bottom on new output.
2. Tool **calls** dumped their full input inline (a `Write`'s whole file body wrapped across the scrollback — see the reported screenshot), contaminating the view.
3. The input box was single-line.

(The re-attach-after-view-switch flow from v0.27.0 works correctly — confirmed by the reporter.)

## What

**1. Auto-scroll.** Streaming text deltas **coalesce** into a single transcript line, so `lines.length` stayed flat while the content grew — keying the scroll effect on `lines.length` stalled the tail mid-stream. Now keyed on the `events` array, with a **stick-to-bottom** ref (flipped by an `onScroll` handler): the view follows live output by default and only stops when the operator scrolls up to read, resuming when they return to the bottom.

**2. Collapse `tool_call`.** `tool_result` became collapsible in #438, but `tool_call` still rendered its full input inline. It now scaffolds to `name + id + an 80-char preview` and expands to the **pretty-printed** input on click — same caret idiom as `tool_result`. So only user messages + agent responses are open by default.

**3. Multi-line input.** The continue/steer box is now a `<textarea>`: **Enter sends, Shift+Enter** inserts a soft newline; it auto-grows with content up to a cap (then scrolls), and the Send button aligns to the bottom.

Frontend only — `internal/webui/dist/*` is gitignored and rebuilt by CI, so this PR is `web/src` only.

## What was tested

`cd web && npm run build` (tsc --noEmit + vite) green. Manual: live output now tails; a `Write` tool call shows a one-line summary and expands to its full content; Enter sends, Shift+Enter newlines, the box grows then scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)