### PR TITLE
fix(webui): truncate collapsed tool_result summary so the fold hides it

### DIFF
--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -191,9 +191,11 @@ function formatLine(row: TranscriptEvent): FormattedLine {
       return {
         key, ts, kind,
         cls: ev.is_error ? "tl-error" : "tl-result",
-        // Collapsed by default: a one-line summary the operator can scan;
-        // click to expand the full output. Errors start open (actionable).
-        payload: `${idTail}${oneLine(text)}`,
+        // Collapsed by default: a TRUNCATED one-line summary the operator can
+        // scan (oneLine alone only flattens whitespace — a big result would
+        // still render in full and defeat the fold); click to expand the full
+        // output. Errors start open (actionable).
+        payload: `${idTail}${truncate(oneLine(text), 100)}`,
         collapsible: true,
         full: `${idTail}${text}`.trimEnd(),
         defaultOpen: !!ev.is_error,


### PR DESCRIPTION
## Why

Tool results still showed their full content when **collapsed** (caret ▶) — the fold appeared to do nothing (reported with a screenshot: same content visible folded and unfolded).

Root cause: the collapsed `tool_result` summary was `oneLine(text)` — `oneLine` only flattens whitespace to single spaces, it doesn't **truncate**. So a large result rendered in full as one wrapped blob in the collapsed state, and expanding just moved the same text into the detail block. (`tool_call` was fixed in #442 with `truncate(…, 80)`, which is why short calls looked fine.)

## What

Truncate the collapsed `tool_result` summary to 100 chars (`truncate(oneLine(text), 100)`), matching the `tool_call` treatment. The full output remains available in the expanded `tl-detail`. One-file change in `TerminalTranscript.tsx`.

## What was tested

`cd web && npm run build` green. Collapsed tool results now show a short one-line summary + caret; clicking expands the full output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)