### PR TITLE
feat(pause): cooperatively quiesce in-flight runs + gate new spawns (F41)

### DIFF
--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -863,6 +863,10 @@ func mapRunnerErr(err error) error {
 		// `code` field + Retry-After header; gRPC consumers branch on
 		// the error message if they need to distinguish.
 		return status.Error(codes.ResourceExhausted, err.Error())
+	case errors.Is(err, runner.ErrRuntimePaused):
+		// Runtime-wide pause in effect (RFC X) — new runs rejected until
+		// resume. Unavailable mirrors the HTTP 503 gate.
+		return status.Error(codes.Unavailable, err.Error())
 	default:
 		return status.Errorf(codes.Internal, "runner: %v", err)
 	}

--- a/internal/api/http/pause_gate.go
+++ b/internal/api/http/pause_gate.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"log"
 	"net/http"
 	"time"
 
@@ -47,13 +48,23 @@ func (g *pauseGate) Park(ctx context.Context) error {
 	// barrier: Pause() only treats a run as quiesced once MarkParked fires, so
 	// this ordering guarantees finalizePause / snapshot (which read the store)
 	// see the 'paused' row by the time the barrier releases.
-	g.setPauseState(ctx, store.PauseStatePaused)
-	g.mgr.MarkParked(g.runID)
+	//
+	// If the durable write FAILS we still block (the run stops executing — the
+	// quiesce we want) but do NOT MarkParked: the barrier must never count a
+	// run as paused when its store row isn't durably 'paused', or
+	// paused_runs_count / snapshot would disagree with the store. Pause then
+	// reports it as not-yet-parked (a warning), so the operator won't snapshot
+	// an inconsistent state.
+	if err := g.setPauseState(ctx, store.PauseStatePaused); err != nil {
+		log.Printf("pause: persist paused for run %s failed: %v — parking without barrier credit", g.runID, err)
+	} else {
+		g.mgr.MarkParked(g.runID)
+	}
 	defer func() {
 		g.mgr.EndPark(g.runID)
 		// Resume() also bulk-flips paused→running (covers restored/orphaned
 		// runs with no live loop); this per-run flip is idempotent with it.
-		g.setPauseState(context.Background(), store.PauseStateRunning)
+		_ = g.setPauseState(context.Background(), store.PauseStateRunning)
 	}()
 	select {
 	case <-resume:
@@ -64,14 +75,15 @@ func (g *pauseGate) Park(ctx context.Context) error {
 }
 
 // setPauseState writes runs.pause_state under a bounded, non-cancellable ctx so
-// the marker survives a run-ctx cancellation racing the pause.
-func (g *pauseGate) setPauseState(parent context.Context, state string) {
+// the marker survives a run-ctx cancellation racing the pause. Returns the
+// store error so Park can decide whether the run earned barrier credit.
+func (g *pauseGate) setPauseState(parent context.Context, state string) error {
 	if g.store == nil || g.runID == "" {
-		return
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), pauseStatePersistTimeout)
 	defer cancel()
-	_ = g.store.SetRunPauseState(ctx, g.runID, state)
+	return g.store.SetRunPauseState(ctx, g.runID, state)
 }
 
 // newPauseGate builds a loop.PauseGate for runID and registers the run with the

--- a/internal/api/http/pause_gate.go
+++ b/internal/api/http/pause_gate.go
@@ -1,0 +1,118 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/pause"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// pauseGate is the per-run loop.PauseGate implementation (RFC X / F41). It
+// wraps the runtime pause Manager + store so the loop can cooperatively park
+// at an iteration boundary when a runtime-wide pause is in effect, keeping
+// loop.go free of pause/store imports.
+type pauseGate struct {
+	mgr   *pause.Manager
+	store store.Store
+	runID string
+}
+
+// pauseStatePersistTimeout bounds the store write that records a run's
+// pause_state. The write rides a non-cancellable ctx (it must land even if the
+// run's own ctx is racing cancellation), so a deadline prevents a wedged store
+// from blocking park/unpark forever.
+const pauseStatePersistTimeout = 5 * time.Second
+
+// PauseRequested reports whether a runtime pause is in effect — the loop's
+// cheap top-of-iteration check. State() is the hot-path-safe accessor
+// (lock-free in single-replica mode, 1s-cached in cluster mode).
+func (g *pauseGate) PauseRequested() bool {
+	return g.mgr != nil && !g.mgr.State().AcceptsNewRuns()
+}
+
+// Park persists pause_state='paused', blocks until the runtime resumes (or the
+// run ctx is cancelled), then restores 'running'. The Manager's BeginPark
+// re-checks state under its lock so a run that raced a concurrent resume
+// returns immediately without parking.
+func (g *pauseGate) Park(ctx context.Context) error {
+	resume, shouldPark := g.mgr.BeginPark(g.runID)
+	if !shouldPark {
+		return nil
+	}
+	// Persist 'paused' to the store BEFORE marking the run parked in the
+	// barrier: Pause() only treats a run as quiesced once MarkParked fires, so
+	// this ordering guarantees finalizePause / snapshot (which read the store)
+	// see the 'paused' row by the time the barrier releases.
+	g.setPauseState(ctx, store.PauseStatePaused)
+	g.mgr.MarkParked(g.runID)
+	defer func() {
+		g.mgr.EndPark(g.runID)
+		// Resume() also bulk-flips paused→running (covers restored/orphaned
+		// runs with no live loop); this per-run flip is idempotent with it.
+		g.setPauseState(context.Background(), store.PauseStateRunning)
+	}()
+	select {
+	case <-resume:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// setPauseState writes runs.pause_state under a bounded, non-cancellable ctx so
+// the marker survives a run-ctx cancellation racing the pause.
+func (g *pauseGate) setPauseState(parent context.Context, state string) {
+	if g.store == nil || g.runID == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), pauseStatePersistTimeout)
+	defer cancel()
+	_ = g.store.SetRunPauseState(ctx, g.runID, state)
+}
+
+// newPauseGate builds a loop.PauseGate for runID and registers the run with the
+// pause barrier, returning a deregister func to defer at the loop site. Returns
+// (nil, no-op) when pause isn't wired (no manager / no store) — the loop then
+// skips pausing entirely.
+func (s *Server) newPauseGate(runID string) (loop.PauseGate, func()) {
+	if s.pauseMgr == nil || s.store == nil || runID == "" {
+		return nil, func() {}
+	}
+	s.pauseMgr.RegisterRun(runID)
+	return &pauseGate{mgr: s.pauseMgr, store: s.store, runID: runID}, func() {
+		s.pauseMgr.DeregisterRun(runID)
+	}
+}
+
+// runtimePaused reports whether new runs should be rejected (a pause is in
+// flight). The admission gate (RFC X / F41) — the help doc already promises
+// "new /v1/runs return 503 while pausing/paused".
+func (s *Server) runtimePaused() bool {
+	return s.pauseMgr != nil && !s.pauseMgr.State().AcceptsNewRuns()
+}
+
+// rejectIfPausedHTTP writes a 503 and returns true when the runtime is paused,
+// so an HTTP run-admission handler can `if s.rejectIfPausedHTTP(w) { return }`
+// BEFORE acquiring a concurrency slot.
+func (s *Server) rejectIfPausedHTTP(w http.ResponseWriter) bool {
+	if !s.runtimePaused() {
+		return false
+	}
+	writeJSONError(w, http.StatusServiceUnavailable, "runtime_paused",
+		"runtime is paused (snapshot quiesce); retry after resume")
+	return true
+}
+
+// pausedRunErr returns runner.ErrRuntimePaused when the runtime is paused, for
+// the runner.RunOnce admission path (gRPC / webhook / A2A / scheduler). nil
+// when not paused.
+func (s *Server) pausedRunErr() error {
+	if s.runtimePaused() {
+		return runner.ErrRuntimePaused
+	}
+	return nil
+}

--- a/internal/api/http/pause_gate_test.go
+++ b/internal/api/http/pause_gate_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,9 +15,145 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/pause"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/store"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// failSetPauseStore fails every SetRunPauseState write (simulating a store
+// outage during pause). Embeds store.Store so it satisfies the interface; only
+// SetRunPauseState is exercised by the gate, so the nil embed is never reached.
+type failSetPauseStore struct{ store.Store }
+
+func (failSetPauseStore) SetRunPauseState(context.Context, string, string) error {
+	return errors.New("store down")
+}
+
+// TestPauseGate_StoreWriteFailure_NotCreditedToBarrier (review finding #1): when
+// the durable pause_state='paused' write fails, the run still parks (stops
+// executing) but is NOT counted as quiesced — so paused_runs_count / snapshot
+// never disagree with the store. Pause times out with a warning instead.
+func TestPauseGate_StoreWriteFailure_NotCreditedToBarrier(t *testing.T) {
+	realStore, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = realStore.Close() }()
+	mgr := pause.NewManager(realStore, time.Second) // mgr reads via the real store
+	runID := "r_failwrite"
+	mgr.RegisterRun(runID)
+	defer mgr.DeregisterRun(runID)
+
+	// Gate writes to a store whose SetRunPauseState always fails.
+	gate := &pauseGate{mgr: mgr, store: failSetPauseStore{}, runID: runID}
+
+	parkDone := make(chan struct{})
+	go func() {
+		for mgr.State() == pause.StateRunning {
+			time.Sleep(2 * time.Millisecond)
+		}
+		_ = gate.Park(context.Background()) // blocks (quiesces) until resume
+		close(parkDone)
+	}()
+
+	res, err := mgr.Pause(context.Background(), 250*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if res.PausedRunsCount != 0 {
+		t.Errorf("PausedRunsCount = %d, want 0 (a failed durable write must not credit the barrier)", res.PausedRunsCount)
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("want a warning naming the run that did not durably park")
+	}
+
+	// Resume releases the still-blocked gate.
+	if _, err := mgr.Resume(context.Background()); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	select {
+	case <-parkDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("gate.Park never returned after resume")
+	}
+}
+
+// panicProvider panics on Call — to exercise the detached interactive run's
+// panic-recovery path (review finding #3).
+type panicProvider struct{}
+
+func (panicProvider) ID() string                  { return "panic" }
+func (panicProvider) Probe(context.Context) error { return nil }
+func (panicProvider) ListModels(context.Context) ([]string, error) {
+	return []string{"stub-model"}, nil
+}
+func (panicProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (panicProvider) Call(context.Context, providers.Request) (<-chan providers.Event, error) {
+	panic("boom from provider")
+}
+
+// TestInteractiveRun_PanicRecovered_NoBarrierLeak (review finding #3): a panic
+// in a DETACHED interactive run must be recovered (no process crash) and must
+// still deregister the run — otherwise it leaks in the pause barrier and every
+// future Pause times out waiting for the ghost. Verified by a clean Pause
+// (no warning) after the panicking run settles.
+func TestInteractiveRun_PanicRecovered_NoBarrierLeak(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"agent": {Model: "stub-model", SystemPrompt: "hi", UnboundedIterations: true},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "panic.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: panicProvider{}}, []tools.Tool{}, sem, st)
+	srv.SetSteerRegistry(steer.NewRegistry(0))
+	mgr := pause.NewManager(st, 200*time.Millisecond)
+	srv.SetPauseManager(mgr)
+
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"agent","interactive":true,"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post run: %v", err)
+	}
+	// Drain the SSE stream to completion (the run panics → recovered → marked
+	// failed → terminal → the store-tail closes). If the panic crashed the
+	// process or wedged teardown, this read (or the whole test) would hang.
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// The panicked run must have deregistered: a clean Pause (no warning) proves
+	// the pause barrier has no ghost run. A leak would time out + warn.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		res, perr := mgr.Pause(context.Background(), 150*time.Millisecond)
+		if perr != nil {
+			t.Fatalf("Pause: %v", perr)
+		}
+		if len(res.Warnings) == 0 {
+			break // clean — no leaked run
+		}
+		_, _ = mgr.Resume(context.Background())
+		if time.Now().After(deadline) {
+			t.Fatalf("Pause kept warning (%v) — panicked run leaked in the barrier", res.Warnings)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	_, _ = mgr.Resume(context.Background())
+}
 
 // TestHandleRuns_503WhilePaused asserts the runtime-pause admission gate
 // (RFC X / F41): a new POST /v1/runs is rejected with 503 while the runtime is

--- a/internal/api/http/pause_gate_test.go
+++ b/internal/api/http/pause_gate_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/pause"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestHandleRuns_503WhilePaused asserts the runtime-pause admission gate
+// (RFC X / F41): a new POST /v1/runs is rejected with 503 while the runtime is
+// paused, and admitted again after resume.
+func TestHandleRuns_503WhilePaused(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"agent": {Model: "stub-model", SystemPrompt: "hi"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = "" // open mode
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "pausegate.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, st)
+	mgr := pause.NewManager(st, 200*time.Millisecond)
+	srv.SetPauseManager(mgr)
+
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	post := func() (int, string) {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"agent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+		))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, string(b)
+	}
+
+	// Pause → new runs rejected with 503.
+	if _, err := mgr.Pause(context.Background(), 100*time.Millisecond); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if code, body := post(); code != http.StatusServiceUnavailable {
+		t.Fatalf("POST /v1/runs while paused = %d (%s), want 503", code, body)
+	}
+
+	// Resume → admitted again (200, SSE stream).
+	if _, err := mgr.Resume(context.Background()); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if code, _ := post(); code != http.StatusOK {
+		t.Fatalf("POST /v1/runs after resume = %d, want 200", code)
+	}
+}
+
+// TestRunOnce_RuntimePausedRejected asserts the RunOnce admission gate (the
+// gRPC / webhook / A2A / scheduler surface) returns runner.ErrRuntimePaused
+// while paused.
+func TestRunOnce_RuntimePausedRejected(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"agent": {Model: "stub-model", SystemPrompt: "hi"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	provider := &stubProvider{events: []providers.Event{
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+	}}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "pausegate2.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: provider}, []tools.Tool{}, sem, st)
+	mgr := pause.NewManager(st, 200*time.Millisecond)
+	srv.SetPauseManager(mgr)
+
+	if _, err := mgr.Pause(context.Background(), 100*time.Millisecond); err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if got := srv.pausedRunErr(); got == nil {
+		t.Fatal("pausedRunErr() = nil while paused, want runner.ErrRuntimePaused")
+	}
+	if _, err := mgr.Resume(context.Background()); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if got := srv.pausedRunErr(); got != nil {
+		t.Errorf("pausedRunErr() = %v after resume, want nil", got)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1605,6 +1605,13 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		priorMessages = replayTranscript(transcript)
 	}
 
+	// Runtime-pause admission gate (RFC X / F41) — reject new runs while
+	// pausing/paused. Covers the gRPC / webhook / A2A / scheduler surfaces
+	// that drive runs through RunOnce. Checked before the concurrency slot.
+	if err := s.pausedRunErr(); err != nil {
+		return err
+	}
+
 	// ---- Concurrency slot ----
 	acquireStart := time.Now()
 	release, err := s.sem.AcquireForUser(ctx, effectiveUserID)
@@ -1805,6 +1812,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 
 	heartbeat := s.makeHeartbeat(runID)
 
+	// Cooperative pause quiesce (RFC X / F41): park at an iteration boundary
+	// while paused. RunOnce is synchronous, so a plain defer-deregister works.
+	gate, deregGate := s.newPauseGate(runID)
+	defer deregGate()
+
 	fbPolicy, fbReResolve := s.fallbackForRun(effectiveTenantID, effectiveAgentName, in.UserTier)
 	res, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
@@ -1813,6 +1825,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Dispatcher:             dispatcher,
 		Segments:               injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, in.Metadata, in.PayloadMetadata),
 		PriorMessages:          priorMessages,
+		PauseGate:              gate,
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,
@@ -2783,6 +2796,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		defer releaseSess()
 	}
 
+	// Runtime-pause admission gate (RFC X / F41): reject new runs with 503
+	// while pausing/paused, BEFORE acquiring a slot so a rejected run doesn't
+	// burn a quota slot. The help doc already documents this 503.
+	if s.rejectIfPausedHTTP(w) {
+		return
+	}
+
 	// Acquire concurrency slot first so backpressure is reported as 429
 	// before we open the SSE stream.
 	acquireStart := time.Now()
@@ -3100,6 +3120,13 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		MaxSameProviderRetries: s.retryAttemptsForAgent(agentDef, req.UserTier),
 	}
 
+	// Cooperative pause quiesce (RFC X / F41): the loop parks at an iteration
+	// boundary while paused. Registers the run with the pause barrier; the
+	// matching deregister runs after the loop (inline) or in the detached
+	// goroutine (interactive) — never a handler-level defer (handOff).
+	gate, deregGate := s.newPauseGate(runID)
+	runOpts.PauseGate = gate
+
 	if req.Interactive && s.store != nil {
 		// Detached run: execute the loop in a background goroutine that
 		// OUTLIVES this handler, so navigating away (client disconnect) no
@@ -3120,6 +3147,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			// API-cancel already cancelled (the cause is still read from runCtx).
 			s.finishRunWithCancel(context.WithoutCancel(runCtx), runCtx, runID, loopRes, runErr, meta)
 			deregSteer()
+			deregGate()
 			s.cancelReg.Deregister(agentID)
 			runSpan.End()
 			cancelFn(nil)
@@ -3136,6 +3164,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.finishRunWithCancel(r.Context(), runCtx, runID, loopRes, runErr, meta)
+	deregGate()
 }
 
 // messagesRequest is the JSON body for POST /v1/sessions/{id}/messages. It
@@ -3299,6 +3328,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	priorMessages := replayTranscript(transcript)
+
+	// Runtime-pause admission gate (RFC X / F41): a continuation starts a new
+	// turn/run, so reject it with 503 while pausing/paused (before the slot).
+	if s.rejectIfPausedHTTP(w) {
+		return
+	}
 
 	// Acquire concurrency slot before opening the SSE stream so backpressure
 	// is reported as 429. user_id comes from the session (set at original
@@ -3498,6 +3533,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	loopCtx = tools.WithInterruptionPolicy(loopCtx, s.interruptionPolicyForAgent(agentDef))
 	loopCtx = tools.WithRunID(loopCtx, run.ID)
 	loopCtx = tools.WithDispatcher(loopCtx, dispatcher)
+	// Cooperative pause quiesce (RFC X / F41) — synchronous handler, defer-deregister.
+	gate, deregGate := s.newPauseGate(run.ID)
+	defer deregGate()
 	fbPolicy, fbReResolve := s.fallbackForRun(sess.TenantID, sess.Agent, body.UserTier)
 	loopRes, runErr := loop.Run(loopCtx, loop.RunOptions{
 		Provider:               provider,
@@ -3506,6 +3544,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Dispatcher:             dispatcher,
 		Segments:               injectMetadataSegments(segments, provider.Capabilities().MetadataViaInput, body.Metadata, nil),
 		PriorMessages:          priorMessages,
+		PauseGate:              gate,
 		OnEvent:                emit,
 		OnHeartbeat:            heartbeat,
 		MaxTokens:              agentDef.MaxTokens,     // 0 → driver default
@@ -4221,6 +4260,12 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 
 	subHeartbeat := s.makeHeartbeat(subRunID)
 
+	// Cooperative pause quiesce (RFC X / F41): a sub-agent parks at its own
+	// boundary while paused (so a fan-out tree quiesces). NOT admission-gated —
+	// it's a child of an already-admitted run, not new top-level work.
+	subGate, deregSubGate := s.newPauseGate(subRunID)
+	defer deregSubGate()
+
 	fbPolicy, fbReResolve := s.fallbackForRun(tenantFromCtx(ctx), name, parentTier)
 	res, runErr := loop.Run(subCtx, loop.RunOptions{
 		Provider:            provider,
@@ -4230,6 +4275,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		Segments:            segs,
 		OnEvent:             subEmit,
 		OnHeartbeat:         subHeartbeat,
+		PauseGate:           subGate,
 		MaxTokens:           def.MaxTokens,     // 0 → driver default
 		MaxIterations:       def.MaxIterations, // 0 → loop default (16)
 		UnboundedIterations: def.UnboundedIterations,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3138,6 +3138,23 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		// returns). Returning here does NOT cancel the run.
 		handOff = true
 		go func() {
+			// Teardown is DEFERRED + panic-guarded: a panic in loop.Run must
+			// not (a) crash the process (this goroutine has no other recover —
+			// the recoveryMiddleware only wraps the synchronous handler) nor
+			// (b) skip deregistration, which would leak the run in the cancel /
+			// steer / pause-barrier registries — a leaked pause entry never
+			// parks, so every future Pause would time out waiting for a ghost.
+			defer func() {
+				if rec := recover(); rec != nil {
+					log.Printf("interactive run %s panicked: %v", runID, rec)
+					s.finishRunFailedReason(runID, fmt.Sprintf("panic: %v", rec), meta)
+				}
+				deregSteer()
+				deregGate()
+				s.cancelReg.Deregister(agentID)
+				runSpan.End()
+				cancelFn(nil)
+			}()
 			loopRes, runErr := loop.Run(loopCtx, runOpts)
 			if runErr != nil {
 				// Persist (not stream) the failure so a tailing client sees it.
@@ -3146,11 +3163,6 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 			// WithoutCancel: the store write must not ride a runCtx that an
 			// API-cancel already cancelled (the cause is still read from runCtx).
 			s.finishRunWithCancel(context.WithoutCancel(runCtx), runCtx, runID, loopRes, runErr, meta)
-			deregSteer()
-			deregGate()
-			s.cancelReg.Deregister(agentID)
-			runSpan.End()
-			cancelFn(nil)
 		}()
 		// Tail the store to this client until they disconnect (r.Context()) or
 		// the run terminates. from_seq=0 → stream the whole run live.

--- a/internal/help/builtin/pause-resume-snapshot.md
+++ b/internal/help/builtin/pause-resume-snapshot.md
@@ -22,8 +22,17 @@ state machine transitions `running → pausing → paused`:
   tools are given a grace window — 30 s by default — to finish
   cleanly. Any still running at the deadline get force-cancelled
   and counted in the result.
-- New `/v1/runs` requests return 503 while the runtime is in
-  `pausing` or `paused`.
+- New `/v1/runs` requests (and the gRPC / webhook / A2A run-admission
+  paths) return 503 / Unavailable while the runtime is in `pausing` or
+  `paused`; the scheduler skips firing. Sub-agents of an already-admitted
+  run are NOT rejected — they park at their own boundary.
+- Pause WAITS (up to `timeout_ms`) for in-flight runs to reach a boundary
+  and park, so `paused_runs_count` is meaningful on return. A run blocked
+  inside a single long tool / provider turn parks at its NEXT boundary; if
+  it doesn't reach one within the window, Pause returns with a warning
+  naming it (it parks on its next boundary regardless). Snapshot only
+  captures `pause_state='paused'` runs, so wait for a clean Pause result
+  (no "did not reach a boundary" warning) before snapshotting mid-run.
 
 **Resume** flips back to `running`. Each previously-paused run's
 state row is updated; the runner goroutine watching the broadcast

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -77,6 +77,13 @@ type RunOptions struct {
 	// always-on terminal agent (else parks count toward MaxIterations).
 	Interactive bool
 
+	// PauseGate, when non-nil, cooperatively quiesces this run for the
+	// runtime-wide pause/snapshot protocol (RFC X / F41). At the TOP of each
+	// iteration the loop asks PauseRequested(); if true it calls Park, which
+	// persists pause_state='paused', blocks until resume (or ctx cancel), then
+	// restores 'running'. nil disables pausing (direct loop callers / tests).
+	PauseGate PauseGate
+
 	// PriorMessages is the conversation history to prepend before the
 	// caller's new Segments. Used by the continuation endpoint to replay
 	// a session's prior turns. Empty for a fresh run (the v0.2 case).
@@ -293,6 +300,21 @@ type RunOptions struct {
 	// Sourced from cfg.UserTiers[req.user_tier].RetryAttempts on the
 	// HTTP layer. The HTTP layer caps at 5 before passing to the loop.
 	MaxSameProviderRetries int
+}
+
+// PauseGate is the loop's seam into the runtime pause/quiesce protocol
+// (internal/pause). The server builds a per-run implementation wrapping the
+// pause Manager + store; the loop stays free of pause/store imports. Both
+// methods are no-ops behind a nil RunOptions.PauseGate.
+type PauseGate interface {
+	// PauseRequested reports whether a runtime pause is in effect. Cheap +
+	// non-blocking; the loop calls it at the top of every iteration.
+	PauseRequested() bool
+	// Park persists this run's pause_state='paused', blocks until the runtime
+	// resumes (or ctx is cancelled), then restores 'running'. Returns ctx.Err()
+	// if cancelled while parked (the loop then exits cleanly). A no-op return
+	// (nil, no block) is valid if the pause was already lifted (lost race).
+	Park(ctx context.Context) error
 }
 
 // FallbackPolicy controls the v0.8.2 runtime fallback path. The HTTP
@@ -785,6 +807,18 @@ outerLoop:
 		// to wait for the sweeper to catch up).
 		if opts.OnHeartbeat != nil {
 			opts.OnHeartbeat()
+		}
+
+		// Cooperative pause/quiesce (RFC X / F41): if a runtime pause is in
+		// effect, park HERE — a clean iteration boundary, never mid-turn /
+		// between a tool_use and its tool_results. Park persists
+		// pause_state='paused', blocks until resume, then restores 'running'.
+		// On ctx cancel while parked it returns an error and we exit the run.
+		if opts.PauseGate != nil && opts.PauseGate.PauseRequested() {
+			if err := opts.PauseGate.Park(iterCtx); err != nil {
+				iterSpan.End()
+				return RunResult{StopReason: "cancelled", Usage: totalUsage}, ctx.Err()
+			}
 		}
 
 		// Mid-turn steering (internal/steer): drain any operator-injected

--- a/internal/loop/pause_test.go
+++ b/internal/loop/pause_test.go
@@ -1,0 +1,156 @@
+package loop
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// (endTurnProvider lives in steer_test.go — one text + end_turn per Call, with
+// a calls() counter — reused here as the single-clean-turn provider.)
+
+// fakePauseGate parks the loop on the FIRST iteration boundary, then releases
+// it when release() is called — exercising the RunOptions.PauseGate seam.
+type fakePauseGate struct {
+	mu       sync.Mutex
+	parked   bool
+	releaseC chan struct{}
+	requests int
+}
+
+func newFakePauseGate() *fakePauseGate { return &fakePauseGate{releaseC: make(chan struct{})} }
+
+func (g *fakePauseGate) PauseRequested() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.requests++
+	return g.requests == 1 // pause only on the first boundary
+}
+
+func (g *fakePauseGate) Park(ctx context.Context) error {
+	g.mu.Lock()
+	g.parked = true
+	g.mu.Unlock()
+	select {
+	case <-g.releaseC:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (g *fakePauseGate) isParked() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.parked
+}
+
+func (g *fakePauseGate) release() { close(g.releaseC) }
+
+func userSeg(text string) []PromptSegment {
+	return []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: text}}}}
+}
+
+// TestRun_ParksAtBoundaryWhenPaused asserts the loop calls PauseGate.Park at
+// the iteration boundary when a pause is requested, blocks there (before the
+// provider call), and resumes to end_turn once the gate releases.
+func TestRun_ParksAtBoundaryWhenPaused(t *testing.T) {
+	gate := newFakePauseGate()
+	prov := &endTurnProvider{}
+	disp := tools.NewDispatcher(nil)
+
+	done := make(chan struct{})
+	var res RunResult
+	var runErr error
+	go func() {
+		res, runErr = Run(context.Background(), RunOptions{
+			Provider:        prov,
+			Model:           "x",
+			Dispatcher:      disp,
+			Segments:        userSeg("go"),
+			ToolParallelism: 8,
+			PauseGate:       gate,
+		})
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for !gate.isParked() {
+		select {
+		case <-done:
+			t.Fatal("run finished without parking — PauseGate.Park was never called")
+		case <-deadline:
+			t.Fatal("timed out waiting for the loop to park")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	// The park sits BEFORE the provider call.
+	if prov.calls() != 0 {
+		t.Errorf("provider called %d times while parked; want 0", prov.calls())
+	}
+
+	gate.release()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not finish after the gate released")
+	}
+	if runErr != nil {
+		t.Fatalf("Run after resume: %v", runErr)
+	}
+	if res.StopReason != "end_turn" {
+		t.Errorf("stop = %q, want end_turn", res.StopReason)
+	}
+	if prov.calls() != 1 {
+		t.Errorf("provider called %d times after resume; want 1", prov.calls())
+	}
+}
+
+// TestRun_PauseGateCancelledWhileParked asserts cancelling the run ctx while
+// parked unblocks Park and the loop exits cleanly (no provider call).
+func TestRun_PauseGateCancelledWhileParked(t *testing.T) {
+	gate := newFakePauseGate()
+	prov := &endTurnProvider{}
+	disp := tools.NewDispatcher(nil)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	var runErr error
+	go func() {
+		_, runErr = Run(ctx, RunOptions{
+			Provider:        prov,
+			Model:           "x",
+			Dispatcher:      disp,
+			Segments:        userSeg("go"),
+			ToolParallelism: 8,
+			PauseGate:       gate,
+		})
+		close(done)
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for !gate.isParked() {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for park")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not exit after ctx cancel while parked")
+	}
+	if runErr == nil {
+		t.Error("want a non-nil error (ctx cancelled while parked)")
+	}
+	if prov.calls() != 0 {
+		t.Errorf("provider called %d times; want 0 (cancelled while parked)", prov.calls())
+	}
+}

--- a/internal/pause/barrier_test.go
+++ b/internal/pause/barrier_test.go
@@ -2,6 +2,7 @@ package pause
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -96,7 +97,13 @@ func TestManager_PauseTimesOutOnUnparkedRun(t *testing.T) {
 		t.Errorf("PausedRunsCount = %d, want 0 (the run never parked)", res.PausedRunsCount)
 	}
 	if len(res.Warnings) == 0 {
-		t.Error("want a warning naming the run(s) that did not reach a boundary in time")
+		t.Fatal("want a warning naming the run(s) that did not reach a boundary in time")
+	}
+	// The warning must NAME the unparked run (review finding #2 — actionable so
+	// an operator knows a fan-out parent / long turn held back the quiesce).
+	joined := strings.Join(res.Warnings, " ")
+	if !strings.Contains(joined, run.ID) {
+		t.Errorf("warning %q does not name the unparked run %q", joined, run.ID)
 	}
 	if got := m.State(); got != StatePaused {
 		t.Errorf("State after timeout = %s, want paused (state still transitions)", got)

--- a/internal/pause/barrier_test.go
+++ b/internal/pause/barrier_test.go
@@ -1,0 +1,122 @@
+package pause
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestManager_PauseWaitsForRunToPark asserts Pause()'s Stage-2 barrier blocks
+// until a registered in-flight run reaches a boundary and parks — so
+// paused_runs_count is accurate on return (the RFC X fix). A simulated
+// PauseGate parks the run (store 'paused' → MarkParked) only after pause is
+// declared, exactly as the real loop gate does.
+func TestManager_PauseWaitsForRunToPark(t *testing.T) {
+	m, s, cleanup := newTestManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "r1"})
+
+	m.RegisterRun(run.ID)
+	defer m.DeregisterRun(run.ID)
+
+	// Simulated PauseGate: once pause is declared, persist 'paused' then mark
+	// parked (the BeginPark→store→MarkParked ordering the real gate uses), and
+	// stay parked until resume.
+	parked := make(chan struct{})
+	go func() {
+		for m.State() == StateRunning {
+			time.Sleep(2 * time.Millisecond)
+		}
+		resume, should := m.BeginPark(run.ID)
+		if !should {
+			return
+		}
+		_ = s.SetRunPauseState(ctx, run.ID, store.PauseStatePaused)
+		m.MarkParked(run.ID)
+		close(parked)
+		<-resume
+		_ = s.SetRunPauseState(ctx, run.ID, store.PauseStateRunning)
+		m.EndPark(run.ID)
+	}()
+
+	res, err := m.Pause(ctx, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	select {
+	case <-parked:
+	case <-time.After(time.Second):
+		t.Fatal("gate never parked the run")
+	}
+	if res.PausedRunsCount != 1 {
+		t.Errorf("PausedRunsCount = %d, want 1 (Pause must wait for the run to park)", res.PausedRunsCount)
+	}
+	if len(res.Warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", res.Warnings)
+	}
+
+	// Resume wakes the parked gate goroutine + flips the row back.
+	rr, err := m.Resume(ctx)
+	if err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	if rr.ResumedRunsCount != 1 {
+		t.Errorf("ResumedRunsCount = %d, want 1", rr.ResumedRunsCount)
+	}
+}
+
+// TestManager_PauseTimesOutOnUnparkedRun asserts a registered run that never
+// reaches a boundary (e.g. blocked in a long tool / provider turn) does not
+// hang Pause forever: Pause returns at the timeout with a warning and
+// paused_runs_count=0 (the run is still executing).
+func TestManager_PauseTimesOutOnUnparkedRun(t *testing.T) {
+	m, s, cleanup := newTestManager(t)
+	defer cleanup()
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "a", "u")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "r1"})
+
+	m.RegisterRun(run.ID) // registered but never parks
+	defer m.DeregisterRun(run.ID)
+
+	start := time.Now()
+	res, err := m.Pause(ctx, 150*time.Millisecond)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if elapsed < 150*time.Millisecond {
+		t.Errorf("Pause returned in %v, want ≥ timeout (should wait the full window for the run to park)", elapsed)
+	}
+	if res.PausedRunsCount != 0 {
+		t.Errorf("PausedRunsCount = %d, want 0 (the run never parked)", res.PausedRunsCount)
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("want a warning naming the run(s) that did not reach a boundary in time")
+	}
+	if got := m.State(); got != StatePaused {
+		t.Errorf("State after timeout = %s, want paused (state still transitions)", got)
+	}
+}
+
+// TestManager_PauseQuiescesImmediatelyWhenNoRuns pins the idle case: no
+// registered runs → the barrier is satisfied at once.
+func TestManager_PauseQuiescesImmediatelyWhenNoRuns(t *testing.T) {
+	m, _, cleanup := newTestManager(t)
+	defer cleanup()
+	start := time.Now()
+	res, err := m.Pause(context.Background(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("Pause: %v", err)
+	}
+	if time.Since(start) > 500*time.Millisecond {
+		t.Errorf("Pause with no in-flight runs took %v, want near-immediate", time.Since(start))
+	}
+	if res.PausedRunsCount != 0 {
+		t.Errorf("PausedRunsCount = %d, want 0", res.PausedRunsCount)
+	}
+}

--- a/internal/pause/manager.go
+++ b/internal/pause/manager.go
@@ -90,6 +90,21 @@ type Manager struct {
 	// allocated so the next pause has a clean signal.
 	pauseCh chan struct{}
 
+	// resumeCh is closed on Resume to WAKE runs parked at an iteration
+	// boundary (the loop's PauseGate.Park selects on it). A fresh one is
+	// allocated each Resume so the next pause cycle has a clean signal.
+	// Mirror of pauseCh — pauseCh signals "stop", resumeCh signals "go".
+	resumeCh chan struct{}
+
+	// activeRuns is the in-flight-run registry the PauseGate registers
+	// with (RegisterRun on loop entry, DeregisterRun on exit, parked flag
+	// set while a run is parked at a boundary). Pause()'s Stage-2 barrier
+	// waits until every registered run is parked (or the deadline) so
+	// paused_runs_count is meaningful on return. Key: runID; value:
+	// *runEntry. sync.Map so per-run registration doesn't contend with
+	// state transitions (same rationale as activeTools).
+	activeRuns sync.Map
+
 	// store is used to persist runs.pause_state and to list paused
 	// runs on resume. Manager treats the store as the source of
 	// truth — process-local atomic is the fast path; DB is the
@@ -143,6 +158,12 @@ type toolEntry struct {
 	id       string
 }
 
+// runEntry tracks one in-flight run for the pause barrier. parked flips
+// true while the run's loop is parked at an iteration boundary.
+type runEntry struct {
+	parked atomic.Bool
+}
+
 // NewManager constructs a Manager wired to the given store. The
 // initial state is StateRunning; no pause is in flight. timeout is the
 // default wait-for-non-idempotent-tools cap when POST /v1/runtime/pause
@@ -157,6 +178,7 @@ func NewManager(s store.Store, timeout time.Duration) *Manager {
 	m := &Manager{
 		store:          s,
 		pauseCh:        make(chan struct{}),
+		resumeCh:       make(chan struct{}),
 		defaultTimeout: timeout,
 	}
 	m.state.Store(int32(StateRunning))
@@ -290,6 +312,8 @@ func (m *Manager) applyRemoteResume() {
 		return
 	}
 	m.pauseCh = make(chan struct{})
+	close(m.resumeCh)
+	m.resumeCh = make(chan struct{})
 	m.state.Store(int32(StateRunning))
 	m.mu.Unlock()
 
@@ -318,6 +342,81 @@ func (m *Manager) PauseCh() <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.pauseCh
+}
+
+// RegisterRun adds a run to the in-flight registry so Pause()'s barrier knows
+// to wait for it to reach an iteration boundary. Called by the run's PauseGate
+// (via the server) at loop entry. Idempotent. No-op on a nil manager.
+func (m *Manager) RegisterRun(runID string) {
+	if m == nil || runID == "" {
+		return
+	}
+	m.activeRuns.LoadOrStore(runID, &runEntry{})
+}
+
+// DeregisterRun removes a run from the registry (loop exit — completed,
+// failed, or cancelled). A deregistered run no longer holds back the barrier.
+func (m *Manager) DeregisterRun(runID string) {
+	if m == nil || runID == "" {
+		return
+	}
+	m.activeRuns.Delete(runID)
+}
+
+// BeginPark is called by a run's PauseGate at an iteration boundary when a
+// pause is in effect. Under the manager lock it RE-CHECKS state (so a run that
+// raced a concurrent Resume does not park) and returns the resume channel to
+// wait on. shouldPark=false means the runtime is already running again — the
+// caller must not park. It does NOT mark the run parked: the caller must
+// persist pause_state='paused' to the store FIRST, then call MarkParked, so
+// the Pause() barrier (which waits on the parked flag) never reports a run
+// parked before its store row is durably 'paused' (else finalizePause /
+// snapshot, which read the store, would miss it).
+func (m *Manager) BeginPark(runID string) (resume <-chan struct{}, shouldPark bool) {
+	if m == nil {
+		return nil, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if loadState(&m.state) == StateRunning {
+		return nil, false
+	}
+	return m.resumeCh, true
+}
+
+// MarkParked flags a run parked for the Pause() barrier. Called by the
+// PauseGate AFTER it has persisted pause_state='paused' (see BeginPark).
+func (m *Manager) MarkParked(runID string) {
+	if m == nil {
+		return
+	}
+	if e, ok := m.activeRuns.Load(runID); ok {
+		e.(*runEntry).parked.Store(true)
+	}
+}
+
+// EndPark clears a run's parked flag (the loop woke and is resuming).
+func (m *Manager) EndPark(runID string) {
+	if m == nil {
+		return
+	}
+	if e, ok := m.activeRuns.Load(runID); ok {
+		e.(*runEntry).parked.Store(false)
+	}
+}
+
+// runsQuiesced reports whether every registered in-flight run is parked at a
+// boundary (or none are registered). total is the registered count; used by
+// Pause()'s Stage-2 barrier and for the not-all-parked warning.
+func (m *Manager) runsQuiesced() (allParked bool, total, parked int) {
+	m.activeRuns.Range(func(_, v any) bool {
+		total++
+		if v.(*runEntry).parked.Load() {
+			parked++
+		}
+		return true
+	})
+	return total == parked, total, parked
 }
 
 // ToolCtx derives a per-tool-call context with the right cancellation
@@ -482,19 +581,25 @@ func (m *Manager) Pause(ctx context.Context, timeout time.Duration) (PauseResult
 		return true
 	})
 
-	// Stage 2: wait for activeTools to drain or hit the deadline.
+	// Stage 2: wait for activeTools to drain AND for every in-flight run to
+	// reach a pause boundary (PauseGate.Park persisting pause_state='paused'),
+	// or hit the deadline. Waiting for runs to park is what makes
+	// paused_runs_count meaningful on return — a run blocked in a long tool /
+	// provider turn parks at its NEXT boundary, bounded by this deadline.
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	tick := time.NewTicker(50 * time.Millisecond)
 	defer tick.Stop()
 
+	var warnings []string
 	for {
-		empty := true
+		toolsEmpty := true
 		m.activeTools.Range(func(_, _ any) bool {
-			empty = false
+			toolsEmpty = false
 			return false
 		})
-		if empty {
+		runsParked, _, _ := m.runsQuiesced()
+		if toolsEmpty && runsParked {
 			break
 		}
 		select {
@@ -503,11 +608,21 @@ func (m *Manager) Pause(ctx context.Context, timeout time.Duration) (PauseResult
 			// still in flight as force-cancelled, transition to
 			// StatePaused, return the partial result.
 			m.forceCancelRemaining(&forceCancelMu, &forceCancel)
-			return m.finalizePause(start, forceCancel, idempotentCount, []string{
-				fmt.Sprintf("pause request cancelled by caller: %v", ctx.Err()),
-			}), nil
+			if _, total, parked := m.runsQuiesced(); total > parked {
+				warnings = append(warnings, fmt.Sprintf(
+					"%d of %d in-flight run(s) had not reached a pause boundary at cancellation",
+					total-parked, total))
+			}
+			return m.finalizePause(start, forceCancel, idempotentCount, append(warnings,
+				fmt.Sprintf("pause request cancelled by caller: %v", ctx.Err()))), nil
 		case <-deadline.C:
 			m.forceCancelRemaining(&forceCancelMu, &forceCancel)
+			if _, total, parked := m.runsQuiesced(); total > parked {
+				warnings = append(warnings, fmt.Sprintf(
+					"%d of %d in-flight run(s) did not reach a pause boundary within the timeout "+
+						"(still executing a tool / provider turn); they will park on their next boundary",
+					total-parked, total))
+			}
 			break
 		case <-tick.C:
 			continue
@@ -517,7 +632,7 @@ func (m *Manager) Pause(ctx context.Context, timeout time.Duration) (PauseResult
 		break
 	}
 
-	return m.finalizePause(start, forceCancel, idempotentCount, nil), nil
+	return m.finalizePause(start, forceCancel, idempotentCount, warnings), nil
 }
 
 // forceCancelRemaining cancels every entry still in activeTools and
@@ -613,6 +728,10 @@ func (m *Manager) Resume(ctx context.Context) (ResumeResult, error) {
 	// holding the closed channel from the prior pause naturally fall
 	// through their select-default branch on the next iteration.
 	m.pauseCh = make(chan struct{})
+	// Wake every parked run (PauseGate.Park is selecting on this channel),
+	// then allocate a fresh one for the next pause cycle.
+	close(m.resumeCh)
+	m.resumeCh = make(chan struct{})
 	m.state.Store(int32(StateRunning))
 	bp := m.bp
 	m.mu.Unlock()

--- a/internal/pause/manager.go
+++ b/internal/pause/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -419,6 +420,41 @@ func (m *Manager) runsQuiesced() (allParked bool, total, parked int) {
 	return total == parked, total, parked
 }
 
+// unparkedRunIDs returns the registered runs that have NOT reached a pause
+// boundary yet — used to name them in the timeout/cancel warning. The classic
+// case is a fan-out PARENT blocked in Agent.parallel_spawn: its loop is
+// suspended in the tool while its children park, so it can't reach its own
+// boundary until the spawn returns (on resume). Snapshotting mid-fan-out would
+// capture the parked children WITHOUT the parent, so callers must snapshot only
+// at a quiescent boundary (a clean Pause with no warning).
+func (m *Manager) unparkedRunIDs() []string {
+	var out []string
+	m.activeRuns.Range(func(k, v any) bool {
+		if !v.(*runEntry).parked.Load() {
+			out = append(out, k.(string))
+		}
+		return true
+	})
+	return out
+}
+
+// unparkedWarning builds the "runs didn't reach a boundary" warning (shared by
+// the deadline + caller-cancel paths), naming the runs so an operator knows a
+// fan-out parent (or a long tool/provider turn) held back the quiesce — and
+// that paused_runs_count therefore excludes them. Empty when all parked.
+func (m *Manager) unparkedWarning(whenPhrase string) string {
+	ids := m.unparkedRunIDs()
+	if len(ids) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d in-flight run(s) did not reach a pause boundary %s — still executing a tool / "+
+			"provider turn (e.g. a fan-out PARENT blocked in parallel_spawn whose children HAVE "+
+			"parked); they park on their next boundary, so paused_runs_count excludes them. Snapshot "+
+			"only at a quiescent boundary (a clean Pause with no warning), not mid-fan-out. runs: %s",
+		len(ids), whenPhrase, strings.Join(ids, ", "))
+}
+
 // ToolCtx derives a per-tool-call context with the right cancellation
 // policy for the current runtime state. Called from inside the loop's
 // executePendingTools fan-out, ONCE per pending tool, before the
@@ -608,20 +644,15 @@ func (m *Manager) Pause(ctx context.Context, timeout time.Duration) (PauseResult
 			// still in flight as force-cancelled, transition to
 			// StatePaused, return the partial result.
 			m.forceCancelRemaining(&forceCancelMu, &forceCancel)
-			if _, total, parked := m.runsQuiesced(); total > parked {
-				warnings = append(warnings, fmt.Sprintf(
-					"%d of %d in-flight run(s) had not reached a pause boundary at cancellation",
-					total-parked, total))
+			if w := m.unparkedWarning("at cancellation"); w != "" {
+				warnings = append(warnings, w)
 			}
 			return m.finalizePause(start, forceCancel, idempotentCount, append(warnings,
 				fmt.Sprintf("pause request cancelled by caller: %v", ctx.Err()))), nil
 		case <-deadline.C:
 			m.forceCancelRemaining(&forceCancelMu, &forceCancel)
-			if _, total, parked := m.runsQuiesced(); total > parked {
-				warnings = append(warnings, fmt.Sprintf(
-					"%d of %d in-flight run(s) did not reach a pause boundary within the timeout "+
-						"(still executing a tool / provider turn); they will park on their next boundary",
-					total-parked, total))
+			if w := m.unparkedWarning("within the timeout"); w != "" {
+				warnings = append(warnings, w)
 			}
 			break
 		case <-tick.C:

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -87,6 +87,11 @@ var (
 	// Wire: HTTP 429 + Retry-After: 5 / gRPC ResourceExhausted.
 	// (v0.10.1)
 	ErrPerUserQuotaExhausted = errors.New("per_user_quota_exhausted")
+	// ErrRuntimePaused — a runtime-wide pause (POST /v1/_pause) is in
+	// effect, so new runs are not admitted (RFC X / F41). The runtime is
+	// quiescing for a snapshot; retry after resume. Wire: HTTP 503 / gRPC
+	// Unavailable.
+	ErrRuntimePaused = errors.New("runtime paused")
 	// ErrInternal — unexpected error from store / loop / providers.
 	// Wire: HTTP 500 / gRPC Internal.
 	ErrInternal = errors.New("internal error")


### PR DESCRIPTION
## Why

`POST /v1/_pause` was a **soft** quiesce (sandbox finding **F41** / RFC X): pausing mid-run returned `paused_runs_count: 0`, `/v1/_state` stayed `0`, and `POST /v1/runs` during the pause was admitted (200, not 503). Root cause (confirmed by code, stronger than F41 suspected): **the loop-side park and the admission gate were never wired** — designed-but-dead code. The loop never checked `PauseCh()` / called `SetRunPauseState(…,'paused')` (only `Resume()` flipped rows back), and `AcceptsNewRuns()` was never called even though the help doc *promised* the 503. So nothing ever parked, `paused_runs_count` was always 0, and snapshot (which captures only `pause_state='paused'` runs) could never capture a mid-run.

## What — wire the intended cooperative-quiesce + gating design

- **Loop park** (`internal/loop/loop.go`): new `RunOptions.PauseGate` (`PauseRequested`/`Park`). At the **top of each iteration** — a clean boundary, never between a `tool_use` and its `tool_results` — the loop parks while paused: persist `'paused'` → block until resume → restore `'running'`; ctx-cancel while parked exits the run cleanly.
- **Manager** (`internal/pause/manager.go`): a `resumeCh` (closed on `Resume`) wakes parked loops; an **active-run registry** (`RegisterRun`/`DeregisterRun` + `MarkParked`/`EndPark`) lets `Pause()`'s Stage-2 barrier **wait until every in-flight run has parked** (or the deadline), so `paused_runs_count` is accurate on return and a run that didn't reach a boundary in time surfaces as a **warning**. The gate persists `'paused'` to the store **before** `MarkParked`, so the barrier never releases ahead of the durable row that `finalizePause`/snapshot read.
- **Admission gate** (`internal/api/http/server.go` + `pause_gate.go`): a per-run `pauseGate{mgr,store,runID}` wired into all four `loop.Run` sites (RunOnce / handleRuns inline+detached / handleMessages / sub-agent). New runs return **503** (`handleRuns`/`handleMessages`) or **`runner.ErrRuntimePaused`** (`RunOnce` → gRPC `Unavailable`, webhook 503) while pausing/paused. **Sub-agents park but are not admission-gated** (children of an already-admitted run). The scheduler already skips while paused — unchanged.

### Resulting behavior
- A multi-iteration run parks within one iteration of `pause`; a run blocked inside one long tool/provider turn parks at its **next** boundary (bounded by `timeout_ms`; a warning names any that didn't make it).
- New `/v1/runs` + gRPC/webhook/A2A → 503/Unavailable; `paused_runs_count` is meaningful; **snapshot-mid-run reliably captures parked runs**.

### Deferred (Phase 2)
Making `Agent.parallel_spawn`'s `wg.Wait` pause-aware so a fanned-out **parent** also parks mid-fan-out. Its children already park in Phase 1; not a blocker (F41 is "low", continuity already holds).

No store schema change (`pause_state`/`SetRunPauseState`/`ListPausedRuns` already exist). Runtime-only; no `@loomcycle/client` bump. (`EventPaused` SSE signal deferred — operators poll `/v1/_state`.)

## What was tested

- `loop.TestRun_ParksAtBoundaryWhenPaused` (parks before the provider call, resumes to end_turn), `_PauseGateCancelledWhileParked`.
- `pause.TestManager_PauseWaitsForRunToPark` (barrier → `paused_runs_count=1`), `_PauseTimesOutOnUnparkedRun` (warning + count 0), `_PauseQuiescesImmediatelyWhenNoRuns`.
- `http.TestHandleRuns_503WhilePaused`, `TestRunOnce_RuntimePausedRejected`.
- `go test ./...` clean; `gofmt` clean; `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)