### PR TITLE
feat(agents): per-agent LLM sampling params (temperature + friends)

### DIFF
--- a/internal/agents/loader.go
+++ b/internal/agents/loader.go
@@ -140,6 +140,21 @@ type AgentInterruptionACL struct {
 	MaxPending int      `json:"max_pending,omitempty" yaml:"max_pending"`
 }
 
+// Sampling mirrors config.Sampling locally so the agents package stays
+// config-free (config → agents would otherwise cycle). json: tags mirror the
+// snake_case the substrate persists and are LOAD-BEARING for content_sha256
+// (see AgentChannelACL). Pointers so an unset field omits — and so a meaningful
+// temperature:0.0 is distinct from "unset".
+type Sampling struct {
+	Temperature      *float64 `json:"temperature,omitempty"`
+	TopP             *float64 `json:"top_p,omitempty"`
+	TopK             *int     `json:"top_k,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	Seed             *int     `json:"seed,omitempty"`
+	Stop             []string `json:"stop,omitempty"`
+}
+
 // TierCandidate mirrors config.TierCandidate's shape locally so this
 // package doesn't import config (which would create a cycle:
 // config → agents → config). The merger in config converts these to

--- a/internal/agents/sign.go
+++ b/internal/agents/sign.go
@@ -13,7 +13,7 @@
 // What gets hashed (content-only — NOT metadata or identity):
 //
 //	name, description, system_prompt, allowed_tools, skills, model,
-//	provider, tier, effort, max_tokens, max_iterations,
+//	provider, tier, effort, sampling, max_tokens, max_iterations,
 //	max_concurrent_children, code_body, providers, models, memory_scopes,
 //	memory_quota_bytes, memory_backend, channels, evaluation_scopes,
 //	interruption
@@ -117,9 +117,17 @@ type AgentContent struct {
 	Name                  string                     `json:"name,omitempty"`
 	Provider              string                     `json:"provider,omitempty"`
 	Providers             []string                   `json:"providers,omitempty"`
-	Skills                []string                   `json:"skills,omitempty"`
-	SystemPrompt          string                     `json:"system_prompt,omitempty"`
-	Tier                  string                     `json:"tier,omitempty"`
+	// Sampling is the per-agent LLM sampling block (mirrors config.Sampling;
+	// the agents package stays config-free, so it's a local type). Content-
+	// identifying: a fork that only changes temperature must mint a distinct
+	// content_sha256. Pointer + omitempty so a no-sampling agent omits the key
+	// and hashes byte-identical to pre-feature rows; normalize() collapses an
+	// all-nil pointer back to nil. Tag "sampling" sorts between providers and
+	// skills.
+	Sampling     *Sampling `json:"sampling,omitempty"`
+	Skills       []string  `json:"skills,omitempty"`
+	SystemPrompt string    `json:"system_prompt,omitempty"`
+	Tier         string    `json:"tier,omitempty"`
 	// UnboundedIterations is content-identifying (like MaxIterations): a fork
 	// that only flips it must get a distinct content_sha256, not silently
 	// dedup (cf. F14). omitempty keeps pre-existing rows byte-identical.
@@ -189,6 +197,14 @@ func normalize(c *AgentContent) {
 	}
 	if c.Interruption != nil && !c.Interruption.Enabled && len(c.Interruption.Kinds) == 0 && c.Interruption.MaxPending == 0 {
 		c.Interruption = nil
+	}
+	// Collapse an all-nil Sampling pointer to nil so a `"sampling":{}` (e.g. a
+	// substrate read of a no-sampling def) hashes identically to a pre-feature
+	// row. A meaningful temperature:0.0 is a non-nil *float64 and is preserved.
+	if c.Sampling != nil && c.Sampling.Temperature == nil && c.Sampling.TopP == nil &&
+		c.Sampling.TopK == nil && c.Sampling.FrequencyPenalty == nil && c.Sampling.PresencePenalty == nil &&
+		c.Sampling.Seed == nil && len(c.Sampling.Stop) == 0 {
+		c.Sampling = nil
 	}
 
 	// Trim + normalise the system_prompt to insulate the hash from

--- a/internal/api/http/sampling_test.go
+++ b/internal/api/http/sampling_test.go
@@ -1,0 +1,110 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// (recordingProvider — captures the last providers.Request — lives in
+// llm_gateway_test.go.)
+
+func f64(v float64) *float64 { return &v }
+
+// TestHandleRuns_PerRunSamplingOverridesAgent: a /v1/runs `sampling` block wins
+// PER FIELD over the agent's own sampling (temperature overridden; top_p
+// inherited from the agent). The resolved value reaches the provider.
+func TestHandleRuns_PerRunSamplingOverridesAgent(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"agent": {
+				Model:        "stub-model",
+				SystemPrompt: "hi",
+				Sampling:     &config.Sampling{Temperature: f64(0.2), TopP: f64(0.9)},
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	prov := &recordingProvider{}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "sampling.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Per-run override sets ONLY temperature → wins; top_p inherits the agent's.
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"agent","sampling":{"temperature":0.95},"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	req := prov.last
+	if req == nil {
+		t.Fatal("provider received no request")
+	}
+	if req.Temperature == nil || *req.Temperature != 0.95 {
+		t.Errorf("temperature = %v, want 0.95 (per-run override wins)", req.Temperature)
+	}
+	if req.TopP == nil || *req.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9 (inherited from the agent — per-run left it unset)", req.TopP)
+	}
+}
+
+// TestHandleRuns_AgentSamplingWhenNoOverride: with no per-run sampling, the
+// agent's own sampling reaches the provider unchanged.
+func TestHandleRuns_AgentSamplingWhenNoOverride(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"agent": {Model: "stub-model", SystemPrompt: "hi", Sampling: &config.Sampling{Temperature: f64(0.1)}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	prov := &recordingProvider{}
+	sem := concurrency.New(4, 4, 100*time.Millisecond)
+	st, _ := storesqlite.Open(filepath.Join(t.TempDir(), "sampling2.db"))
+	defer func() { _ = st.Close() }()
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, sem, st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"agent","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	req := prov.last
+	if req == nil {
+		t.Fatal("provider received no request")
+	}
+	if req.Temperature == nil || *req.Temperature != 0.1 {
+		t.Errorf("temperature = %v, want 0.1 (agent default reaches the wire)", req.Temperature)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1844,6 +1844,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		PayloadMetadata:        in.PayloadMetadata,
 		RunTimeoutSeconds:      pickRunTimeout(in.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		Interactive:            in.Interactive,
+		Sampling:               config.MergeSampling(agentDef.Sampling, in.Sampling), // per-run wins per field
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -2602,6 +2603,11 @@ type runRequest struct {
 	// POST /v1/runs/{run_id}/input; pair with an unbounded_iterations agent
 	// for a true always-on terminal. Cancel ends it.
 	Interactive bool `json:"interactive,omitempty"`
+
+	// Sampling is an optional per-RUN LLM sampling override (temperature,
+	// top_p, …) — merged PER FIELD over the agent's own sampling (this wins;
+	// unset fields inherit the agent's). nil = inherit the agent's entirely.
+	Sampling *config.Sampling `json:"sampling,omitempty"`
 }
 
 // pickRunTimeout resolves the effective code-js wall-clock budget override:
@@ -3113,6 +3119,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Metadata:               req.Metadata,  // direct /v1/runs caller is first-party → trusted; no payload_metadata
 		RunTimeoutSeconds:      pickRunTimeout(req.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		Interactive:            req.Interactive,
+		Sampling:               config.MergeSampling(agentDef.Sampling, req.Sampling), // per-run wins per field
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -3230,6 +3237,10 @@ type messagesRequest struct {
 	// operator steering at end_turn (interactive terminal). Same semantics as
 	// runRequest.Interactive.
 	Interactive bool `json:"interactive,omitempty"`
+
+	// Sampling: per-RUN LLM sampling override for this continuation turn,
+	// merged per field over the agent's. Same semantics as runRequest.Sampling.
+	Sampling *config.Sampling `json:"sampling,omitempty"`
 }
 
 func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
@@ -3574,6 +3585,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Metadata:               body.Metadata,
 		RunTimeoutSeconds:      pickRunTimeout(body.RunTimeoutSeconds, agentDef.RunTimeoutSeconds),
 		Interactive:            body.Interactive,
+		Sampling:               config.MergeSampling(agentDef.Sampling, body.Sampling), // per-run wins per field
 		UserTier:               body.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -4304,7 +4316,10 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		// this, the 4th run-creation site falls back to the global default,
 		// dropping the budget for the fan-out orchestrator case the per-agent
 		// override exists to serve.
-		RunTimeoutSeconds:      def.RunTimeoutSeconds,
+		RunTimeoutSeconds: def.RunTimeoutSeconds,
+		// Sub-agents use their OWN def's sampling (no per-spawn override yet —
+		// a breeder varies temperature by FORKING a def, then spawning it).
+		Sampling:               def.Sampling,
 		UserTier:               parentTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -607,6 +607,14 @@ type AgentDef struct {
 	// matrix series; PR 1 plumbs the field through unchanged.
 	Effort string `yaml:"effort"`
 
+	// Sampling tunes the per-agent LLM sampling parameters (temperature,
+	// top_p, …). nil = use the provider/model defaults. Per-run callers can
+	// override individual fields via the /v1/runs `sampling` block (per-run
+	// wins per-field; see MergeSampling). Each driver maps the params it
+	// supports and drops the rest (the same translate-or-drop contract as
+	// Effort). Pointer so a no-sampling agent stays byte-identical pre-feature.
+	Sampling *Sampling `yaml:"sampling,omitempty"`
+
 	// Providers is the per-agent override of the library
 	// ProviderPriority for tier resolution. Full replacement
 	// semantics: when set, the resolver uses this list verbatim
@@ -797,6 +805,145 @@ type AgentDef struct {
 	// the yaml-zero case ("explicitly disable retries"). When set,
 	// must be >= 0; validator refuses negatives at config-load.
 	RetryAttempts *int `yaml:"retry_attempts,omitempty"`
+}
+
+// Sampling is the per-agent LLM sampling-parameter block (the yaml/JSON
+// `sampling:` object). Every field is a pointer (or, for Stop, a slice) so
+// "unset" (nil) is distinct from a meaningful zero value — temperature 0.0 is
+// DETERMINISTIC, not "use the default". Each provider driver maps the params
+// it supports and silently drops the rest. nil Sampling = full provider/model
+// defaults.
+type Sampling struct {
+	// Temperature: sampling randomness. Provider ranges differ (Anthropic
+	// 0–1, OpenAI/Gemini 0–2); validated to 0–2 here, the API is the backstop.
+	Temperature *float64 `json:"temperature,omitempty" yaml:"temperature"`
+	// TopP: nucleus sampling probability mass (0–1).
+	TopP *float64 `json:"top_p,omitempty" yaml:"top_p"`
+	// TopK: top-k token cutoff (>=1). Anthropic / Gemini / Ollama only.
+	TopK *int `json:"top_k,omitempty" yaml:"top_k"`
+	// FrequencyPenalty / PresencePenalty (-2..2). OpenAI/DeepSeek/Ollama only.
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty" yaml:"frequency_penalty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty" yaml:"presence_penalty"`
+	// Seed: deterministic-sampling seed where the provider supports it
+	// (OpenAI/DeepSeek/Gemini/Ollama). Useful for reproducible breeder variants.
+	Seed *int `json:"seed,omitempty" yaml:"seed"`
+	// Stop: up to a few stop sequences.
+	Stop []string `json:"stop,omitempty" yaml:"stop"`
+}
+
+// IsZero reports whether no sampling field is set (so callers can collapse an
+// empty block to nil — keeps content hashes byte-stable for no-sampling agents).
+func (s *Sampling) IsZero() bool {
+	return s == nil || (s.Temperature == nil && s.TopP == nil && s.TopK == nil &&
+		s.FrequencyPenalty == nil && s.PresencePenalty == nil && s.Seed == nil && len(s.Stop) == 0)
+}
+
+// Clone returns a deep copy (pointers + slice) so a merged result never aliases
+// either input's fields.
+func (s *Sampling) Clone() *Sampling {
+	if s == nil {
+		return nil
+	}
+	out := &Sampling{Stop: append([]string(nil), s.Stop...)}
+	if s.Temperature != nil {
+		v := *s.Temperature
+		out.Temperature = &v
+	}
+	if s.TopP != nil {
+		v := *s.TopP
+		out.TopP = &v
+	}
+	if s.TopK != nil {
+		v := *s.TopK
+		out.TopK = &v
+	}
+	if s.FrequencyPenalty != nil {
+		v := *s.FrequencyPenalty
+		out.FrequencyPenalty = &v
+	}
+	if s.PresencePenalty != nil {
+		v := *s.PresencePenalty
+		out.PresencePenalty = &v
+	}
+	if s.Seed != nil {
+		v := *s.Seed
+		out.Seed = &v
+	}
+	return out
+}
+
+// MergeSampling overlays `over` onto `base` PER FIELD — a field set in `over`
+// wins, an unset (nil) field in `over` keeps `base`'s value. Used for both the
+// AgentDef fork overlay (a fork that sets only temperature keeps the parent's
+// top_p) and the per-run override (a /v1/runs sampling field wins over the
+// agent's, field by field). Returns nil only when both inputs contribute
+// nothing. Never aliases either input.
+func MergeSampling(base, over *Sampling) *Sampling {
+	if base.IsZero() && over.IsZero() {
+		return nil
+	}
+	out := base.Clone()
+	if out == nil {
+		out = &Sampling{}
+	}
+	if over == nil {
+		return out
+	}
+	if over.Temperature != nil {
+		v := *over.Temperature
+		out.Temperature = &v
+	}
+	if over.TopP != nil {
+		v := *over.TopP
+		out.TopP = &v
+	}
+	if over.TopK != nil {
+		v := *over.TopK
+		out.TopK = &v
+	}
+	if over.FrequencyPenalty != nil {
+		v := *over.FrequencyPenalty
+		out.FrequencyPenalty = &v
+	}
+	if over.PresencePenalty != nil {
+		v := *over.PresencePenalty
+		out.PresencePenalty = &v
+	}
+	if over.Seed != nil {
+		v := *over.Seed
+		out.Seed = &v
+	}
+	if len(over.Stop) > 0 {
+		out.Stop = append([]string(nil), over.Stop...)
+	}
+	return out
+}
+
+// Validate checks light per-field bounds (the provider API is the final
+// authority). Returns a descriptive error naming the offending field.
+func (s *Sampling) Validate() error {
+	if s == nil {
+		return nil
+	}
+	if s.Temperature != nil && (*s.Temperature < 0 || *s.Temperature > 2) {
+		return fmt.Errorf("sampling.temperature %.3f out of range [0,2]", *s.Temperature)
+	}
+	if s.TopP != nil && (*s.TopP < 0 || *s.TopP > 1) {
+		return fmt.Errorf("sampling.top_p %.3f out of range [0,1]", *s.TopP)
+	}
+	if s.TopK != nil && *s.TopK < 1 {
+		return fmt.Errorf("sampling.top_k %d out of range (>=1)", *s.TopK)
+	}
+	if s.FrequencyPenalty != nil && (*s.FrequencyPenalty < -2 || *s.FrequencyPenalty > 2) {
+		return fmt.Errorf("sampling.frequency_penalty %.3f out of range [-2,2]", *s.FrequencyPenalty)
+	}
+	if s.PresencePenalty != nil && (*s.PresencePenalty < -2 || *s.PresencePenalty > 2) {
+		return fmt.Errorf("sampling.presence_penalty %.3f out of range [-2,2]", *s.PresencePenalty)
+	}
+	if len(s.Stop) > 8 {
+		return fmt.Errorf("sampling.stop has %d sequences (max 8)", len(s.Stop))
+	}
+	return nil
 }
 
 // AgentInterruptionACL is the per-agent v0.8.16 Interruption tool
@@ -3575,6 +3722,9 @@ func validate(c *Config) error {
 		}
 		if !validEffortLevels[agent.Effort] {
 			return fmt.Errorf("agent %q: invalid effort %q (want one of low/medium/high or empty)", name, agent.Effort)
+		}
+		if err := agent.Sampling.Validate(); err != nil {
+			return fmt.Errorf("agent %q: %w", name, err)
 		}
 		if hasTier && !validTierNames[agent.Tier] {
 			return fmt.Errorf("agent %q: invalid tier %q (want one of low/middle/high)", name, agent.Tier)

--- a/internal/config/sampling_test.go
+++ b/internal/config/sampling_test.go
@@ -1,0 +1,99 @@
+package config
+
+import "testing"
+
+func f64(v float64) *float64 { return &v }
+func ip(v int) *int          { return &v }
+
+// TestMergeSampling_PerFieldOverlay pins the per-field merge: `over` wins on
+// the fields it sets, `base` is kept on the fields `over` leaves nil. This is
+// what makes a fork that sets only temperature keep the parent's top_p, and a
+// per-run sampling override win field-by-field over the agent's.
+func TestMergeSampling_PerFieldOverlay(t *testing.T) {
+	base := &Sampling{Temperature: f64(0.2), TopP: f64(0.9), Seed: ip(7)}
+	over := &Sampling{Temperature: f64(0.9)} // override only temperature
+
+	got := MergeSampling(base, over)
+	if got == nil || got.Temperature == nil || *got.Temperature != 0.9 {
+		t.Fatalf("temperature = %v, want 0.9 (over wins)", got.Temperature)
+	}
+	if got.TopP == nil || *got.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9 (inherited from base — over left it nil)", got.TopP)
+	}
+	if got.Seed == nil || *got.Seed != 7 {
+		t.Errorf("seed = %v, want 7 (inherited from base)", got.Seed)
+	}
+	// Must not alias either input.
+	*got.Temperature = 1.5
+	if *over.Temperature != 0.9 {
+		t.Error("MergeSampling aliased over.Temperature")
+	}
+	if base.TopP != nil {
+		*got.TopP = 0.1
+		if *base.TopP != 0.9 {
+			t.Error("MergeSampling aliased base.TopP")
+		}
+	}
+}
+
+func TestMergeSampling_NilCases(t *testing.T) {
+	if got := MergeSampling(nil, nil); got != nil {
+		t.Errorf("MergeSampling(nil,nil) = %v, want nil", got)
+	}
+	base := &Sampling{Temperature: f64(0.3)}
+	if got := MergeSampling(base, nil); got == nil || *got.Temperature != 0.3 {
+		t.Errorf("MergeSampling(base,nil) lost base")
+	}
+	over := &Sampling{TopP: f64(0.5)}
+	got := MergeSampling(nil, over)
+	if got == nil || got.TopP == nil || *got.TopP != 0.5 {
+		t.Errorf("MergeSampling(nil,over) lost over")
+	}
+	if got.Temperature != nil {
+		t.Errorf("MergeSampling(nil,over) invented a temperature")
+	}
+}
+
+// TestSampling_Temperature0IsMeaningful guards the pointer semantics: a
+// deterministic temperature 0.0 is a real value, distinct from unset.
+func TestSampling_Temperature0IsMeaningful(t *testing.T) {
+	s := &Sampling{Temperature: f64(0)}
+	if s.IsZero() {
+		t.Error("Sampling{temperature:0.0} reported IsZero — 0.0 is deterministic, not unset")
+	}
+	if (&Sampling{}).IsZero() != true {
+		t.Error("empty Sampling should be IsZero")
+	}
+	var nilS *Sampling
+	if !nilS.IsZero() {
+		t.Error("nil Sampling should be IsZero")
+	}
+}
+
+func TestSampling_Validate(t *testing.T) {
+	ok := []*Sampling{
+		nil,
+		{Temperature: f64(0)},
+		{Temperature: f64(2), TopP: f64(1), TopK: ip(1)},
+		{FrequencyPenalty: f64(-2), PresencePenalty: f64(2), Seed: ip(0)},
+	}
+	for i, s := range ok {
+		if err := s.Validate(); err != nil {
+			t.Errorf("ok[%d]: unexpected error %v", i, err)
+		}
+	}
+	bad := []*Sampling{
+		{Temperature: f64(2.1)},
+		{Temperature: f64(-0.1)},
+		{TopP: f64(1.1)},
+		{TopK: ip(0)},
+		{FrequencyPenalty: f64(2.5)},
+		{PresencePenalty: f64(-3)},
+		{Stop: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}},
+	}
+	for i, s := range bad {
+		if err := s.Validate(); err == nil {
+			t.Errorf("bad[%d]: want a validation error, got nil", i)
+		}
+	}
+}

--- a/internal/lookup/agent.go
+++ b/internal/lookup/agent.go
@@ -171,11 +171,15 @@ type SubstrateAgentDef struct {
 	// Code mirrors config.AgentDef.Code — the inline code-js body (RFC J).
 	// Persisted in the agent_defs definition JSONB; "" = filesystem
 	// fallback. Tag "code_body" matches mergedDef + AgentContent.
-	Code          string `json:"code_body,omitempty"`
-	Tier          string `json:"tier,omitempty"`
-	Effort        string `json:"effort,omitempty"`
-	MaxTokens     int    `json:"max_tokens,omitempty"`
-	MaxIterations int    `json:"max_iterations,omitempty"`
+	Code   string `json:"code_body,omitempty"`
+	Tier   string `json:"tier,omitempty"`
+	Effort string `json:"effort,omitempty"`
+	// Sampling: per-agent LLM sampling params (mirrors config.Sampling /
+	// mergedDef). Pointer so substrate JSON persists nil (provider default)
+	// vs an explicit temperature:0.0 (deterministic).
+	Sampling      *config.Sampling `json:"sampling,omitempty"`
+	MaxTokens     int              `json:"max_tokens,omitempty"`
+	MaxIterations int              `json:"max_iterations,omitempty"`
 	// UnboundedIterations lifts the MaxIterations soft-cap for an LLM agent
 	// (interactive runs). Mirrors mergedDef; the drift test pins parity.
 	UnboundedIterations bool `json:"unbounded_iterations,omitempty"`
@@ -235,6 +239,7 @@ func (s SubstrateAgentDef) ToConfigDef() config.AgentDef {
 		Code:                  s.Code,
 		Tier:                  s.Tier,
 		Effort:                s.Effort,
+		Sampling:              s.Sampling,
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
 		UnboundedIterations:   s.UnboundedIterations,

--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -283,6 +283,7 @@ func TestAgent_DriftDetection(t *testing.T) {
 		"code_body":               true, // RFC J inline code-js body
 		"tier":                    true,
 		"effort":                  true,
+		"sampling":                true, // per-agent LLM sampling params (temperature, top_p, …)
 		"max_tokens":              true,
 		"max_iterations":          true,
 		"unbounded_iterations":    true, // lift the iteration soft-cap for interactive LLM agents

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -115,6 +116,12 @@ type RunOptions struct {
 	// Ollama no-op. PR 1 plumbs it through providers.Request
 	// unchanged; drivers in PR 1 ignore the field entirely.
 	Effort string
+
+	// Sampling carries the resolved per-agent LLM sampling params (per-run >
+	// per-agent already merged by the caller). The loop maps it onto the flat
+	// providers.Request fields; each driver applies what it supports. nil =
+	// provider defaults.
+	Sampling *config.Sampling
 
 	// ToolParallelism caps how many tool_calls from a single
 	// assistant turn run concurrently. Zero = use the package
@@ -845,6 +852,17 @@ outerLoop:
 			// hook the loop uses for response events. Without this hop
 			// the retry would be invisible to SSE consumers.
 			OnEvent: emit,
+		}
+		// Map the resolved per-agent sampling params onto the flat Request
+		// fields (each driver applies the subset its provider supports).
+		if s := opts.Sampling; s != nil {
+			req.Temperature = s.Temperature
+			req.TopP = s.TopP
+			req.TopK = s.TopK
+			req.FrequencyPenalty = s.FrequencyPenalty
+			req.PresencePenalty = s.PresencePenalty
+			req.Seed = s.Seed
+			req.Stop = s.Stop
 		}
 		ch, err := opts.Provider.Call(iterCtx, req)
 		if err != nil {

--- a/internal/loop/sampling_test.go
+++ b/internal/loop/sampling_test.go
@@ -1,0 +1,48 @@
+package loop
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestRun_SamplingReachesRequest asserts RunOptions.Sampling is mapped onto the
+// flat providers.Request the loop hands the driver — the seam every provider
+// reads. scriptedProvider records each Request it receives.
+func TestRun_SamplingReachesRequest(t *testing.T) {
+	temp, topP := 0.42, 0.8
+	seed := 99
+	prov := &scriptedProvider{toolCalls: nil}
+	disp := tools.NewDispatcher(nil)
+
+	_, _ = Run(t.Context(), RunOptions{
+		Provider:        prov,
+		Model:           "x",
+		Dispatcher:      disp,
+		Segments:        userSeg("go"),
+		MaxIterations:   1, // one provider call is enough to capture the request
+		ToolParallelism: 8,
+		Sampling: &config.Sampling{
+			Temperature: &temp,
+			TopP:        &topP,
+			Seed:        &seed,
+		},
+	})
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	if len(prov.requests) == 0 {
+		t.Fatal("provider received no request")
+	}
+	req := prov.requests[0]
+	if req.Temperature == nil || *req.Temperature != 0.42 {
+		t.Errorf("req.Temperature = %v, want 0.42", req.Temperature)
+	}
+	if req.TopP == nil || *req.TopP != 0.8 {
+		t.Errorf("req.TopP = %v, want 0.8", req.TopP)
+	}
+	if req.Seed == nil || *req.Seed != 99 {
+		t.Errorf("req.Seed = %v, want 99", req.Seed)
+	}
+}

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -154,7 +155,14 @@ type wireRequest struct {
 	Messages    []wireMessage        `json:"messages"`
 	Tools       []providers.ToolSpec `json:"tools,omitempty"`
 	Temperature *float64             `json:"temperature,omitempty"`
-	Stream      bool                 `json:"stream"`
+	// Sampling knobs Anthropic's Messages API accepts. top_k is Anthropic-
+	// native; frequency/presence_penalty + seed are NOT Anthropic params, so
+	// they're intentionally absent here (dropped). Temperature + top_p are also
+	// dropped when Thinking is attached (the API rejects temperature!=1 then).
+	TopP   *float64 `json:"top_p,omitempty"`
+	TopK   *int     `json:"top_k,omitempty"`
+	Stop   []string `json:"stop_sequences,omitempty"`
+	Stream bool     `json:"stream"`
 	// Thinking opts the request into Anthropic's extended-thinking
 	// surface. Only sent when the agent declared an effort hint AND
 	// the model is reasoning-capable (sonnet/opus, NOT haiku). When
@@ -218,6 +226,9 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 		// combinator. See schema.go.
 		Tools:       sanitizeAnthropicTools(req.Tools),
 		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		TopK:        req.TopK,
+		Stop:        req.Stop,
 		Stream:      true, // we always stream
 	}
 
@@ -252,6 +263,19 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 		if budget >= 1024 {
 			w.Thinking = &wireThinking{Type: "enabled", BudgetTokens: budget}
 		}
+	}
+
+	// Anthropic rejects temperature/top_p != default when an extended-thinking
+	// block is attached (the API requires temperature=1 with thinking). An
+	// agent that sets BOTH effort and a custom temperature would hard-400, so
+	// drop the sampling overrides for this call and log the conflict (mirrors
+	// the "effort dropped" signal) — thinking wins, since the operator opted
+	// into reasoning. Only fires for the misconfigured both-set case.
+	if w.Thinking != nil && (w.Temperature != nil || w.TopP != nil) {
+		log.Printf("anthropic: dropped temperature/top_p — incompatible with extended thinking (effort) on model %q; "+
+			"set effort OR temperature, not both", req.Model)
+		w.Temperature = nil
+		w.TopP = nil
 	}
 
 	for _, sb := range req.System {

--- a/internal/providers/anthropic/driver_test.go
+++ b/internal/providers/anthropic/driver_test.go
@@ -461,6 +461,69 @@ func TestRequestBodyShape(t *testing.T) {
 	}
 }
 
+// captureBody runs one Call against a stub server and returns the request body.
+func captureBody(t *testing.T, req providers.Request) string {
+	t.Helper()
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "text/event-stream")
+		fmt.Fprint(w, "event: message_stop\ndata: {}\n\n")
+	}))
+	defer srv.Close()
+	d := New("test-key", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+	return string(captured)
+}
+
+// TestRequestBody_SamplingMapped: the sampling params Anthropic supports land
+// on the wire (temperature, top_p, top_k, stop_sequences).
+func TestRequestBody_SamplingMapped(t *testing.T) {
+	temp, topP := 0.2, 0.9
+	topK := 40
+	body := captureBody(t, providers.Request{
+		Model:       "claude-sonnet-4-6",
+		Messages:    []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+		Temperature: &temp,
+		TopP:        &topP,
+		TopK:        &topK,
+		Stop:        []string{"STOP"},
+	})
+	for _, want := range []string{`"temperature":0.2`, `"top_p":0.9`, `"top_k":40`, `"stop_sequences":["STOP"]`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("missing %s in body:\n%s", want, body)
+		}
+	}
+}
+
+// TestRequestBody_DropsTemperatureWithThinking: Anthropic rejects temperature
+// when extended thinking is attached, so the driver drops temperature/top_p
+// once effort engages thinking on a reasoning model.
+func TestRequestBody_DropsTemperatureWithThinking(t *testing.T) {
+	temp, topP := 0.2, 0.9
+	body := captureBody(t, providers.Request{
+		Model:       "claude-sonnet-4-6", // reasoning-capable → thinking attaches
+		Messages:    []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+		Temperature: &temp,
+		TopP:        &topP,
+		Effort:      "high",
+	})
+	if !strings.Contains(body, `"thinking"`) {
+		t.Fatalf("expected a thinking block for effort=high on sonnet:\n%s", body)
+	}
+	if strings.Contains(body, `"temperature"`) {
+		t.Errorf("temperature must be dropped when thinking is attached:\n%s", body)
+	}
+	if strings.Contains(body, `"top_p"`) {
+		t.Errorf("top_p must be dropped when thinking is attached:\n%s", body)
+	}
+}
+
 // TestBuildRequestBody_MaxTokensDefault verifies the driver's default
 // max_tokens. 4096 was the historical value but caused mid-output
 // truncation for batch agents (~12k chars output ≈ 4k tokens, hitting

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -212,9 +212,15 @@ type wireFunctionDecl struct {
 }
 
 type wireGenConfig struct {
-	MaxOutputTokens int                 `json:"maxOutputTokens,omitempty"`
-	Temperature     *float64            `json:"temperature,omitempty"`
-	ThinkingConfig  *wireThinkingConfig `json:"thinkingConfig,omitempty"`
+	MaxOutputTokens int      `json:"maxOutputTokens,omitempty"`
+	Temperature     *float64 `json:"temperature,omitempty"`
+	// Gemini generationConfig sampling knobs. frequency/presence_penalty are
+	// not Gemini params (dropped). seed is supported on recent models.
+	TopP           *float64            `json:"topP,omitempty"`
+	TopK           *int                `json:"topK,omitempty"`
+	Seed           *int                `json:"seed,omitempty"`
+	StopSequences  []string            `json:"stopSequences,omitempty"`
+	ThinkingConfig *wireThinkingConfig `json:"thinkingConfig,omitempty"`
 }
 
 type wireThinkingConfig struct {
@@ -276,10 +282,15 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 		w.Tools = []wireTool{{FunctionDeclarations: decls}}
 	}
 
-	if req.MaxTokens > 0 || req.Temperature != nil || req.Effort != "" {
+	if req.MaxTokens > 0 || req.Temperature != nil || req.Effort != "" ||
+		req.TopP != nil || req.TopK != nil || req.Seed != nil || len(req.Stop) > 0 {
 		gc := &wireGenConfig{
 			MaxOutputTokens: req.MaxTokens,
 			Temperature:     req.Temperature,
+			TopP:            req.TopP,
+			TopK:            req.TopK,
+			Seed:            req.Seed,
+			StopSequences:   req.Stop,
 		}
 		if budget := geminiEffortBudget(req.Effort, req.MaxTokens); budget >= 0 {
 			gc.ThinkingConfig = &wireThinkingConfig{ThinkingBudget: budget}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -234,6 +234,12 @@ type wireOptions struct {
 	Temperature *float64 `json:"temperature,omitempty"`
 	NumPredict  int      `json:"num_predict,omitempty"` // Ollama's name for max_tokens
 	NumCtx      int      `json:"num_ctx,omitempty"`     // input-window size; 0 = Ollama server default
+	// Ollama options sampling knobs. frequency/presence_penalty exist on some
+	// models but vary; we plumb the broadly-supported set.
+	TopP *float64 `json:"top_p,omitempty"`
+	TopK *int     `json:"top_k,omitempty"`
+	Seed *int     `json:"seed,omitempty"`
+	Stop []string `json:"stop,omitempty"`
 }
 
 type wireMessage struct {
@@ -268,11 +274,16 @@ func (d *Driver) buildRequestBody(req providers.Request) ([]byte, error) {
 		Stream: true,
 	}
 
-	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 {
+	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 ||
+		req.TopP != nil || req.TopK != nil || req.Seed != nil || len(req.Stop) > 0 {
 		w.Options = &wireOptions{
 			Temperature: req.Temperature,
 			NumPredict:  req.MaxTokens,
 			NumCtx:      d.numCtx,
+			TopP:        req.TopP,
+			TopK:        req.TopK,
+			Seed:        req.Seed,
+			Stop:        req.Stop,
 		}
 	}
 

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -177,6 +177,15 @@ type wireRequest struct {
 	Temperature *float64      `json:"temperature,omitempty"`
 	Stream      bool          `json:"stream"`
 
+	// Sampling knobs OpenAI's /v1/chat/completions accepts (DeepSeek's
+	// OpenAI-compat surface inherits the same field names). top_k is NOT an
+	// OpenAI param, so it's intentionally absent here.
+	TopP             *float64 `json:"top_p,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	Seed             *int     `json:"seed,omitempty"`
+	Stop             []string `json:"stop,omitempty"`
+
 	// stream_options.include_usage tells OpenAI to include final usage in the
 	// last data frame before [DONE]. Without this we have no token counts.
 	StreamOptions *wireStreamOptions `json:"stream_options,omitempty"`
@@ -258,11 +267,16 @@ type wireFunction struct {
 
 func buildRequestBody(req providers.Request) ([]byte, error) {
 	w := wireRequest{
-		Model:         req.Model,
-		MaxTokens:     req.MaxTokens,
-		Temperature:   req.Temperature,
-		Stream:        true,
-		StreamOptions: &wireStreamOptions{IncludeUsage: true},
+		Model:            req.Model,
+		MaxTokens:        req.MaxTokens,
+		Temperature:      req.Temperature,
+		TopP:             req.TopP,
+		FrequencyPenalty: req.FrequencyPenalty,
+		PresencePenalty:  req.PresencePenalty,
+		Seed:             req.Seed,
+		Stop:             req.Stop,
+		Stream:           true,
+		StreamOptions:    &wireStreamOptions{IncludeUsage: true},
 		// Pass-through of Request.Effort to OpenAI's reasoning_effort
 		// param. Empty stays empty — omitempty drops it from the wire.
 		// "low" / "medium" / "high" pass through verbatim; the API

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -111,6 +111,19 @@ type Request struct {
 	Temperature *float64       `json:"temperature,omitempty"`
 	Stream      bool           `json:"stream"`
 
+	// Per-agent LLM sampling knobs (config.Sampling, resolved per-run >
+	// per-agent and mapped onto these flat fields by the loop). Each driver
+	// applies the ones its provider supports and DROPS the rest (the same
+	// translate-or-drop contract as Effort) — nil/empty = provider default.
+	// Anthropic also drops Temperature/TopP when it attaches a thinking block
+	// (the API rejects temperature!=1 with thinking).
+	TopP             *float64 `json:"top_p,omitempty"`
+	TopK             *int     `json:"top_k,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	Seed             *int     `json:"seed,omitempty"`
+	Stop             []string `json:"stop,omitempty"`
+
 	// Effort is the reasoning-effort hint: "low" / "medium" / "high"
 	// or empty (= no hint, driver default). Drivers translate it to
 	// their native parameter where supported (Anthropic

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -248,6 +249,13 @@ type RunInput struct {
 	// the run via POST /v1/runs/{run_id}/input; pair with an
 	// unbounded_iterations agent for a true always-on terminal. Cancel ends it.
 	Interactive bool
+
+	// Sampling is an optional per-RUN LLM sampling-param override (temperature,
+	// top_p, …). Merged PER FIELD over the agent's own Sampling (per-run field
+	// wins, an unset field inherits the agent's). nil = inherit the agent's
+	// sampling entirely. The server resolves the merge and passes the winner to
+	// loop.RunOptions.
+	Sampling *config.Sampling
 }
 
 // RunCallbacks is how the wire surfaces observe the run.

--- a/internal/tools/builtin/agentdef.go
+++ b/internal/tools/builtin/agentdef.go
@@ -805,6 +805,10 @@ type mergedDef struct {
 	Tier      string `json:"tier,omitempty"`
 	Effort    string `json:"effort,omitempty"`
 	MaxTokens int    `json:"max_tokens,omitempty"`
+	// Sampling: per-agent LLM sampling params. Round-trips as the `sampling`
+	// object; applyOverlay merges it PER FIELD (a fork that sets only
+	// temperature keeps the parent's top_p). Content-identifying (hashed).
+	Sampling *config.Sampling `json:"sampling,omitempty"`
 	// MaxIterations caps the loop at N provider calls before
 	// terminating with stop_reason="max_iterations". 0 = use the
 	// loop default (16). Set higher for discovery-style forks
@@ -890,6 +894,11 @@ func (d *mergedDef) applyOverlay(ov mergedDef) {
 	}
 	if ov.Effort != "" {
 		d.Effort = ov.Effort
+	}
+	// Sampling merges PER FIELD: a fork that sets only temperature keeps the
+	// parent's top_p (MergeSampling overlays non-nil fields onto the base).
+	if !ov.Sampling.IsZero() {
+		d.Sampling = config.MergeSampling(d.Sampling, ov.Sampling)
 	}
 	if ov.MaxTokens != 0 {
 		d.MaxTokens = ov.MaxTokens
@@ -1003,6 +1012,7 @@ func staticToMergedDef(s config.AgentDef) mergedDef {
 		Code:                  s.Code,
 		Tier:                  s.Tier,
 		Effort:                s.Effort,
+		Sampling:              s.Sampling.Clone(),
 		MaxTokens:             s.MaxTokens,
 		MaxIterations:         s.MaxIterations,
 		UnboundedIterations:   s.UnboundedIterations,
@@ -1115,6 +1125,20 @@ func signFromMergedDef(name string, def mergedDef) string {
 	}
 	if def.Interruption.Enabled || len(def.Interruption.Kinds) > 0 || def.Interruption.MaxPending != 0 {
 		c.Interruption = &agents.AgentInterruptionACL{Enabled: def.Interruption.Enabled, Kinds: def.Interruption.Kinds, MaxPending: def.Interruption.MaxPending}
+	}
+	// Sampling is content-identifying: a fork that only changes temperature
+	// must mint a new content_sha256. Map config→agents (config-free agents pkg);
+	// nil/empty omits so a no-sampling agent hashes exactly as pre-feature.
+	if s := def.Sampling; !s.IsZero() {
+		c.Sampling = &agents.Sampling{
+			Temperature:      s.Temperature,
+			TopP:             s.TopP,
+			TopK:             s.TopK,
+			FrequencyPenalty: s.FrequencyPenalty,
+			PresencePenalty:  s.PresencePenalty,
+			Seed:             s.Seed,
+			Stop:             s.Stop,
+		}
 	}
 	return agents.Sign(c)
 }

--- a/internal/tools/builtin/agentdef_test.go
+++ b/internal/tools/builtin/agentdef_test.go
@@ -102,6 +102,63 @@ func TestAgentDefTool_CreateRoundTripsDefScopes(t *testing.T) {
 	}
 }
 
+// TestAgentDefTool_SamplingRoundTrips: a create overlay's sampling block
+// survives create → persist → lookup → config.AgentDef (the breeder mints
+// variants this way).
+func TestAgentDefTool_SamplingRoundTrips(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"explorer","overlay":{`+
+		`"system_prompt":"explore","sampling":{"temperature":0.2,"top_p":0.9,"seed":7}}}`))
+	if res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	def, ok := lookup.Agent(context.Background(), tool.Store, tool.Cfg, "", "explorer")
+	if !ok {
+		t.Fatal("explorer did not resolve via lookup.Agent")
+	}
+	if def.Sampling == nil {
+		t.Fatal("Sampling dropped on the round-trip")
+	}
+	if def.Sampling.Temperature == nil || *def.Sampling.Temperature != 0.2 {
+		t.Errorf("temperature = %v, want 0.2", def.Sampling.Temperature)
+	}
+	if def.Sampling.TopP == nil || *def.Sampling.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9", def.Sampling.TopP)
+	}
+	if def.Sampling.Seed == nil || *def.Sampling.Seed != 7 {
+		t.Errorf("seed = %v, want 7", def.Sampling.Seed)
+	}
+}
+
+// TestAgentDefTool_ForkMergesSamplingPerField: a fork that overrides ONLY
+// temperature keeps the parent's top_p (per-field merge through the substrate).
+func TestAgentDefTool_ForkMergesSamplingPerField(t *testing.T) {
+	tool, ctx, cleanup := agentDefFixture(t)
+	defer cleanup()
+
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"create","name":"explorer","overlay":{`+
+		`"system_prompt":"explore","sampling":{"temperature":0.2,"top_p":0.9}}}`)); res.IsError {
+		t.Fatalf("create: %s", res.Text)
+	}
+	// Fork overriding only temperature; promote so lookup resolves the fork.
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"fork","name":"explorer","promote":true,`+
+		`"overlay":{"sampling":{"temperature":0.9}}}`)); res.IsError {
+		t.Fatalf("fork: %s", res.Text)
+	}
+	def, ok := lookup.Agent(context.Background(), tool.Store, tool.Cfg, "", "explorer")
+	if !ok {
+		t.Fatal("explorer did not resolve after fork")
+	}
+	if def.Sampling == nil || def.Sampling.Temperature == nil || *def.Sampling.Temperature != 0.9 {
+		t.Errorf("temperature = %v, want 0.9 (fork override)", def.Sampling.Temperature)
+	}
+	if def.Sampling.TopP == nil || *def.Sampling.TopP != 0.9 {
+		t.Errorf("top_p = %v, want 0.9 (inherited from parent — fork left it unset)", def.Sampling.TopP)
+	}
+}
+
 func TestAgentDefTool_CreateNewName(t *testing.T) {
 	tool, ctx, cleanup := agentDefFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Why

exp6's self-evolving breeder needs to **vary LLM sampling per agent variant** (temperature to explore vs. exploit; seed for reproducible variants). The ask: tune at minimum temperature, ideally the rest, settable via **static yaml**, the **AgentDef substrate** (create/fork — how the breeder mints variants), and **per-instance on `POST /v1/runs`** (A/B a single agent without forking).

Pivotal finding: `providers.Request.Temperature` already existed and **every driver already mapped it** — but it was *dangling* (the loop never set it; no config field fed it). This wires the whole vertical and adds the rest of the knobs.

## What — a grouped `sampling:` block

```yaml
agents:
  explorer:
    model: claude-sonnet-4-6
    sampling: { temperature: 0.9, top_p: 0.95, seed: 7 }
```
```jsonc
// AgentDef fork (breeder mints a variant):  {"op":"fork","name":"explorer","overlay":{"sampling":{"temperature":0.2}}}
// POST /v1/runs (per-instance A/B):          {"agent":"explorer","sampling":{"temperature":1.0}, ...}
```

- **`config.Sampling`** — temperature, top_p, top_k, frequency_penalty, presence_penalty, seed, stop. All `*`-pointers (so **temperature 0.0 is deterministic, distinct from unset**) + `Validate` bounds + `MergeSampling` (per-field overlay).
- **`providers.Request`** gains the flat fields; each driver maps the params its provider supports and drops the rest (translate-or-drop, like Effort). **Anthropic drops temperature+top_p when it attaches a thinking block** (the API rejects `temperature!=1` with thinking) — logged.
- **loop** maps `RunOptions.Sampling` onto the flat Request.
- **Round-trip** via the F14/F40 mirror chain: `mergedDef` (+ **per-field merge** in `applyOverlay` — a fork that sets only temperature keeps the parent's top_p) + `staticToMergedDef` + **`AgentContent`** (content-identifying — a temp-only fork mints a new `content_sha256`; an `agents.Sampling` mirror keeps the agents pkg config-free; `normalize` collapses empty) + `SubstrateAgentDef` + `ToConfigDef` + the drift want-map.
- **Per-run override**: `runRequest`/`messagesRequest`/`runner.RunInput` `sampling`, resolved `MergeSampling(agentDef, perRun)` at all 4 `loop.RunOptions` sites (**per-run wins per field**). Sub-agents use their def's sampling (the breeder forks a variant def + spawns it).

### Deferred (flagged)
Per-spawn Agent-tool `temperature`; gRPC proto + TS-adapter wiring (`RunInput.Sampling` lands now, left nil by gRPC until a lockstep `@loomcycle/client` bump). No generic params map (explicit typed fields give validation + drift coverage + per-driver field-name translation).

## What was tested

- `config`: `MergeSampling` per-field overlay (+ no-alias), nil cases, **temperature-0-is-meaningful**, `Validate` bounds.
- `tools/builtin`: create round-trip; **fork per-field merge through the substrate** (override temperature → keep parent top_p).
- `providers/anthropic`: maps temp/top_p/top_k/stop; **drops temp/top_p under thinking**.
- `loop`: `Sampling` reaches the provider `Request`.
- `http`: **per-run override wins per field**; agent default reaches the wire with no override.
- `go test ./...` clean; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)