### PR TITLE
feat(webui): Claude-Desktop-style composer for the /run terminal

### DIFF
--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import TerminalTranscript from "./TerminalTranscript";
 import {
   type LiveUsage,
@@ -85,6 +85,23 @@ export default function LiveRunPane({
     }
   };
 
+  // Composer chrome from REAL run data: the model the run is actually being
+  // served by (latest usage event) and how many distinct MCP servers it has
+  // reached so far (derived from mcp__<server>__<tool> tool_call names in the
+  // transcript). Both populate as the run produces events; absent → omitted.
+  const model = lastUsage?.model ?? "";
+  const mcpCount = useMemo(() => {
+    const servers = new Set<string>();
+    for (const e of events) {
+      const name = e.event?.tool_use?.name;
+      if (name && name.startsWith("mcp__")) {
+        const server = name.split("__")[1];
+        if (server) servers.add(server);
+      }
+    }
+    return servers.size;
+  }, [events]);
+
   return (
     <div className={compact ? "live-run-pane live-run-pane-compact" : "live-run-pane"}>
       <div className="live-run-header">
@@ -118,10 +135,10 @@ export default function LiveRunPane({
       )}
 
       {showPrompt && (
-        <form className="live-run-continue" onSubmit={handleSend}>
+        <form className="composer" onSubmit={handleSend}>
           <textarea
             ref={taRef}
-            className="live-run-input"
+            className="composer-input"
             value={followUp}
             onChange={(e) => setFollowUp(e.target.value)}
             onKeyDown={onKeyDown}
@@ -132,14 +149,34 @@ export default function LiveRunPane({
                 ? "Wait for the turn to finish…"
                 : running
                   ? awaitingInput
-                    ? "Type to continue (Enter to send, Shift+Enter for newline)…"
-                    : "Steer the running agent (Enter to send, Shift+Enter for newline)…"
-                  : "Continue the conversation (Enter to send, Shift+Enter for newline)…"
+                    ? "Type to continue…"
+                    : "Steer the running agent…"
+                  : "Continue the conversation…"
             }
           />
-          <button type="submit" disabled={!followUp.trim() || promptDisabled}>
-            Send
-          </button>
+          <div className="composer-footer">
+            <div className="composer-meta">
+              {model && (
+                <span className="composer-model" title={`serving model: ${model}`}>
+                  <span aria-hidden="true">⚙</span> {model}
+                </span>
+              )}
+              {mcpCount > 0 && (
+                <span className="composer-mcp" title={`${mcpCount} MCP server(s) reached`}>
+                  MCP ({mcpCount})
+                </span>
+              )}
+            </div>
+            <button
+              type="submit"
+              className="composer-send"
+              disabled={!followUp.trim() || promptDisabled}
+              aria-label="Send"
+              title="Send — Enter (Shift+Enter for newline)"
+            >
+              ↑
+            </button>
+          </div>
         </form>
       )}
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4187,31 +4187,99 @@ button.primary:disabled {
   min-height: 0;
   overflow-y: auto;
 }
-.live-run-continue {
+/* Claude-Desktop-style composer: a rounded, elevated card holding the input on
+   top and a footer row (live model + MCP-tool chrome on the left, a circular
+   send arrow on the right). Replaces the flat textarea+button bar. */
+.composer {
   display: flex;
+  flex-direction: column;
   gap: 8px;
-  padding: 8px 12px;
-  border-top: 1px solid var(--border, #2a2a32);
-  align-items: flex-end;
+  margin: 10px 12px;
+  padding: 10px 12px;
+  background: var(--bg-soft-2, #1d2230);
+  border: 1px solid var(--border, #2a2a32);
+  border-radius: 14px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
 }
-.live-run-continue input {
-  flex: 1;
+.composer:focus-within {
+  border-color: var(--accent, #5b9dff);
 }
-.live-run-input {
-  flex: 1;
+.composer-input {
+  width: 100%;
   resize: none;
   overflow-y: auto;
-  min-height: 34px;
+  min-height: 24px;
   max-height: 160px;
-  line-height: 1.4;
-  padding: 6px 8px;
+  line-height: 1.45;
+  padding: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--fg, #e6e8ee);
   font-family: inherit;
   font-size: inherit;
   box-sizing: border-box;
 }
-.live-run-continue input:disabled,
-.live-run-input:disabled {
+.composer-input::placeholder {
+  color: var(--fg-muted, #8a90a0);
+}
+.composer-input:disabled {
   opacity: 0.55;
+}
+.composer-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.composer-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--fg-muted, #8a90a0);
+}
+.composer-model {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 240px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.composer-mcp {
+  flex-shrink: 0;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border, #2a2a32);
+  background: var(--bg-soft, #161922);
+  white-space: nowrap;
+}
+.composer-send {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--accent, #5b9dff);
+  color: #fff;
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.composer-send:not(:disabled):hover {
+  filter: brightness(1.1);
+}
+.composer-send:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 .live-run-awaiting {
   padding: 6px 12px;


### PR DESCRIPTION
## Why

The interactive `/run` terminal's input was a flat `textarea` + a `Send` button on a bordered bar. This restyles it to match the Claude Desktop composer the user shared: a rounded, elevated card with the input on top and a footer row.

## What

- **Rounded elevated card** (`.composer`) replacing the flat `.live-run-continue` bar — input on top, footer below, accent border on focus.
- **Circular ↑ send button** (`.composer-send`) bottom-right — accent-filled when ready, dimmed when empty/locked.
- **Real run chrome** on the footer-left, not decoration:
  - the **serving model** name, from the latest usage event's `model`;
  - an **`MCP (N)` pill** counting the distinct MCP servers the run has reached, derived from `mcp__<server>__<tool>` tool_call names in the live transcript.
- Both populate as the run produces events and are **omitted when absent**, so a fresh run shows a clean card and the send button stays right-anchored.
- Per the agreed scope, **no fake controls** — no `+` attach / `AUTO` toggle (no loomcycle meaning).

Behavior is unchanged: Enter sends, Shift+Enter inserts a newline, the button disables on empty/locked input (the Enter/Shift+Enter hint moved to the button's `title` so the placeholder stays concise).

## What was tested

- `make build-ui` clean (`tsc --noEmit` + vite build, no type errors).
- Rendered the composer across **running** (typed text + model + MCP pill), **idle** (model only, send disabled), and **fresh-run** (empty chrome, send right-anchored) states in an isolated harness and confirmed the layout matches the approved mockup.
- Web-UI-only change (`web/src`); `internal/webui/dist/*` is gitignored and rebuilt by CI — no dist diff in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)