### PR TITLE
feat(webui): "✕ Stop" button (white on dark red) on the run terminal

### DIFF
--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -109,8 +109,13 @@ export default function LiveRunPane({
         {agentId && <code className="live-run-agentid">{agentId}</code>}
         <ContextGauge usage={lastUsage} />
         {status === "running" && (
-          <button type="button" className="live-run-cancel" onClick={onCancel}>
-            Cancel
+          <button
+            type="button"
+            className="live-run-cancel"
+            onClick={onCancel}
+            title="Stop the run"
+          >
+            <span aria-hidden="true">✕</span> Stop
           </button>
         )}
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4181,6 +4181,24 @@ button.primary:disabled {
 }
 .live-run-cancel {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 12px;
+  border: none;
+  border-radius: 999px;
+  background: #9b2c2c; /* dark red — a clear "stop", distinct from the accent */
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+.live-run-cancel:hover {
+  background: #b5343a;
+}
+.live-run-cancel:active {
+  background: #861f24;
 }
 .live-run-pane .terminal-transcript {
   flex: 1;


### PR DESCRIPTION
## Why

In the interactive `/run` session header, the run-cancel control was a plain white **"Cancel"** button — visually identical to neutral actions and easy to overlook as the destructive stop.

## What

Relabel it **"✕ Stop"** and restyle `.live-run-cancel` to **white text on dark red (`#9b2c2c`) with pill corners** (hover `#b5343a`, active `#861f24`), so the stop affordance reads at a glance and is clearly distinct from the accent-colored primary actions. Same `onCancel` handler, still shown only while the run is `running`.

![header with the new Stop button: white ✕ Stop on dark red, pill corners, right-anchored]

## What was tested

- `make build-ui` clean (`tsc --noEmit` + vite).
- Rendered the running session header in an isolated harness and confirmed the button is white-on-dark-red, pill-cornered, and right-anchored next to the status pill / agent id / context gauge.
- Web-UI-only change (`web/src`); `internal/webui/dist/*` is gitignored and CI-rebuilt — no dist diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)