### PR TITLE
feat(compaction): interactive context compaction — "Compact" button

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -461,6 +461,8 @@ func requiredScopeFor(method, path string) string {
 	// Human-in-the-loop interrupt: resolve is a run-state write, list a read.
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/resolve"):
 		return auth.ScopeRunsCreate
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/compact"):
+		return auth.ScopeRunsCreate
 	case method == http.MethodGet && strings.HasPrefix(path, "/v1/runs/"):
 		return auth.ScopeRunsRead
 	// Run / agent / session / user reads.

--- a/internal/api/http/compact_test.go
+++ b/internal/api/http/compact_test.go
@@ -1,0 +1,217 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func firstText(m providers.Message) string {
+	if len(m.Content) == 0 {
+		return ""
+	}
+	return m.Content[0].Text
+}
+
+// TestReplayTranscript_ContextCompactionResets: a context_compaction marker
+// collapses everything before it to the summary pair, and turns AFTER the marker
+// replay on top. Fail-before: replayTranscript had no such case, so a rebuild
+// reconstructed the full pre-compaction history.
+func TestReplayTranscript_ContextCompactionResets(t *testing.T) {
+	uinput := func(text string) store.Event {
+		return mkEvent("user_input", []loop.PromptSegment{
+			{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: text}}},
+		})
+	}
+	events := []store.Event{
+		uinput("original question"),
+		mkEvent("text", providers.Event{Type: providers.EventText, Text: "long original answer"}),
+		mkEvent("done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"}),
+		mkEvent(string(providers.EventContextCompaction), providers.Event{
+			Type:              providers.EventContextCompaction,
+			ContextCompaction: &providers.ContextCompactionEventInfo{Summary: "THE-SUMMARY"},
+		}),
+		uinput("follow-up"),
+	}
+	msgs := replayTranscript(events)
+	if len(msgs) != 3 {
+		t.Fatalf("got %d messages, want 3 (summary pair + follow-up): %+v", len(msgs), msgs)
+	}
+	if msgs[0].Role != "user" || !strings.Contains(firstText(msgs[0]), "THE-SUMMARY") {
+		t.Errorf("msg[0] should be the summary user turn: %+v", msgs[0])
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("msg[1] role = %q, want assistant", msgs[1].Role)
+	}
+	if msgs[2].Role != "user" || firstText(msgs[2]) != "follow-up" {
+		t.Errorf("msg[2] = %q (%s); want user 'follow-up'", firstText(msgs[2]), msgs[2].Role)
+	}
+	for _, m := range msgs {
+		if strings.Contains(firstText(m), "original") {
+			t.Errorf("pre-compaction content survived the reset: %+v", m)
+		}
+	}
+}
+
+func compactFixture(t *testing.T) (*Server, *scriptedProvider) {
+	t.Helper()
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"compactor": {Provider: "scripted", Model: "stub-model", AllowedTools: []string{}},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 8, MaxQueueDepth: 8, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	prov := &scriptedProvider{defaultS: []providers.Event{
+		{Type: providers.EventText, Text: "COMPACTED SUMMARY"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+	}}
+	srv, _ := makeServer(t, prov, cfg)
+	srv.SetSteerRegistry(steer.NewRegistry(8))
+	return srv, prov
+}
+
+// seedConversation creates a run with a >=4-message transcript (so it's worth
+// compacting). When terminal, the run is finished completed.
+func seedConversation(t *testing.T, srv *Server, terminal bool) (sessID, runID string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := srv.store.CreateSession(ctx, "", "compactor", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_c", UserID: "alice", Model: "stub-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	uinput := func(text string) []loop.PromptSegment {
+		return []loop.PromptSegment{{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: text}}}}
+	}
+	appendResumeEvent(t, srv, run.ID, "user_input", uinput("question one"))
+	appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: "answer one"})
+	appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+	appendResumeEvent(t, srv, run.ID, "user_input", uinput("question two"))
+	appendResumeEvent(t, srv, run.ID, "text", providers.Event{Type: providers.EventText, Text: "answer two"})
+	appendResumeEvent(t, srv, run.ID, "done", providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+	if terminal {
+		if err := srv.store.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return sess.ID, run.ID
+}
+
+func decodeCompact(t *testing.T, body []byte) compactResponse {
+	t.Helper()
+	var out compactResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode compact response: %v; body=%s", err, body)
+	}
+	return out
+}
+
+// TestHandleCompactRun_409WhenMidTurn: a LIVE run that isn't parked (mid-turn)
+// is refused — compaction is gated to a safe boundary.
+func TestHandleCompactRun_409WhenMidTurn(t *testing.T) {
+	srv, _ := compactFixture(t)
+	sessID, runID := seedConversation(t, srv, false)
+	_, dereg := srv.steerReg.Register(steer.Entry{RunID: runID, SessionID: sessID, UserID: "alice"})
+	defer dereg()
+	// NOT parked → IsParked false → mid-turn.
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+runID+"/compact", `{}`)
+	if rec.Code != 409 {
+		t.Fatalf("status = %d, want 409 (mid-turn); body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestHandleCompactRun_LivePushesCompactControl: a parked live run gets a
+// compact control pushed to its steering queue carrying the summary.
+func TestHandleCompactRun_LivePushesCompactControl(t *testing.T) {
+	srv, _ := compactFixture(t)
+	sessID, runID := seedConversation(t, srv, false)
+	q, dereg := srv.steerReg.Register(steer.Entry{RunID: runID, SessionID: sessID, UserID: "alice"})
+	defer dereg()
+	srv.steerReg.SetParked(runID, true) // parked = safe boundary
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+runID+"/compact", `{}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	out := decodeCompact(t, rec.Body.Bytes())
+	if !out.Compacted || out.Applied != "live" {
+		t.Errorf("response = %+v, want compacted=true applied=live", out)
+	}
+	select {
+	case m := <-q:
+		if m.Kind != steer.KindCompact {
+			t.Errorf("queued message Kind = %q, want %q", m.Kind, steer.KindCompact)
+		}
+		if m.Text != "COMPACTED SUMMARY" {
+			t.Errorf("queued summary = %q, want COMPACTED SUMMARY", m.Text)
+		}
+	default:
+		t.Fatal("no compact control delivered to the run's steering queue")
+	}
+}
+
+// TestHandleCompactRun_TerminalPersistsMarker: a completed run (no live loop)
+// gets a context_compaction marker persisted for the next continuation.
+func TestHandleCompactRun_TerminalPersistsMarker(t *testing.T) {
+	srv, _ := compactFixture(t)
+	sessID, runID := seedConversation(t, srv, true) // completed → no steer entry
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+runID+"/compact", `{}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	out := decodeCompact(t, rec.Body.Bytes())
+	if !out.Compacted || out.Applied != "marker" {
+		t.Errorf("response = %+v, want compacted=true applied=marker", out)
+	}
+	// The marker is on the transcript so the next continuation rebuilds compacted.
+	events, _ := srv.store.GetTranscript(context.Background(), sessID)
+	var found bool
+	for _, e := range events {
+		if e.Type == string(providers.EventContextCompaction) {
+			var pe providers.Event
+			if json.Unmarshal(e.Payload, &pe) == nil && pe.ContextCompaction != nil &&
+				strings.Contains(pe.ContextCompaction.Summary, "COMPACTED SUMMARY") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("no context_compaction marker persisted on the transcript")
+	}
+}
+
+// TestHandleCompactRun_NoopWhenShort: a conversation below the threshold is a
+// no-op (no model call, no marker).
+func TestHandleCompactRun_NoopWhenShort(t *testing.T) {
+	srv, _ := compactFixture(t)
+	ctx := context.Background()
+	sess, _ := srv.store.CreateSession(ctx, "", "compactor", "alice")
+	run, _ := srv.store.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_s", UserID: "alice", Model: "stub-model"})
+	appendResumeEvent(t, srv, run.ID, "user_input", []loop.PromptSegment{
+		{Role: "user", Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: "hi"}}},
+	})
+	_ = srv.store.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{}, "")
+
+	rec := doJSON(t, srv, "POST", "/v1/runs/"+run.ID+"/compact", `{}`)
+	if rec.Code != 200 {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	out := decodeCompact(t, rec.Body.Bytes())
+	if out.Compacted || out.Applied != "noop" {
+		t.Errorf("response = %+v, want compacted=false applied=noop", out)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2208,6 +2208,7 @@ func (s *Server) Mux() http.Handler {
 	// PR 2 / interactive terminal: inject an operator "steering" instruction
 	// into an in-flight run (appended to the live conversation mid-turn).
 	mux.Handle("POST /v1/runs/{run_id}/input", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunInput))))
+	mux.Handle("POST /v1/runs/{run_id}/compact", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleCompactRun))))
 	// Re-attach to a running (or finished) run's event stream — the operator
 	// leaves the interactive /run terminal and returns to the same live run.
 	mux.Handle("GET /v1/runs/{run_id}/stream", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunStream))))
@@ -3744,6 +3745,23 @@ func replayTranscript(events []store.Event) []providers.Message {
 			// no tool_results to carry over).
 			flushAssistant()
 			flushPendingTools()
+		case "context_compaction":
+			// Interactive context compaction: everything before this marker
+			// collapses to the summary. RESET all accumulated state and seed the
+			// same user+assistant summary pair the live loop swapped in, so a
+			// rebuild (crash recovery / resume / /sessions/messages) reconstructs
+			// the compacted conversation, not the full history. Any events AFTER
+			// the marker (turns since the compaction) replay normally on top.
+			flushAssistant()
+			flushPendingTools()
+			var pe providers.Event
+			if err := json.Unmarshal(ev.Payload, &pe); err == nil && pe.ContextCompaction != nil {
+				messages = append([]providers.Message(nil), loop.CompactionMessages(pe.ContextCompaction.Summary)...)
+			}
+			asstText.Reset()
+			asstTools = nil
+			pendingToolResults = nil
+			asstReasoning = ""
 		}
 	}
 	flushAssistant()
@@ -3948,6 +3966,19 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 	}
 	var mu sync.Mutex
 	return func(ev providers.Event) {
+		// Track parked (awaiting_input) state for the compaction boundary gate
+		// (handleCompactRun's IsParked check). The run is parked when it emits
+		// awaiting_input and resumes work on the next steer/text/tool_call. No-op
+		// for non-interactive runs (they never emit awaiting_input) and for
+		// run_ids not in the steer registry. SetParked takes its own lock.
+		if s.steerReg != nil {
+			switch ev.Type {
+			case providers.EventAwaitingInput:
+				s.steerReg.SetParked(runID, true)
+			case providers.EventSteer, providers.EventText, providers.EventToolCall:
+				s.steerReg.SetParked(runID, false)
+			}
+		}
 		mu.Lock()
 		defer mu.Unlock()
 		// EventSteer (operator steering, PR 2) is forwarded LIVE only — the
@@ -4927,6 +4958,226 @@ func (s *Server) handleRunInput(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"run_id": runID, "delivered": delivered})
+}
+
+// compactionSystemPrompt instructs the model to compact a conversation. Used by
+// handleCompactRun's one-shot summarization call (NOT the agent's own system
+// prompt, which is re-derived separately and untouched by compaction).
+const compactionSystemPrompt = "You are compacting a conversation to free up the model's context " +
+	"window. Produce a single concise summary — aim for roughly 10% of the original length — that " +
+	"preserves the user's goals and constraints, decisions made, facts and values established, tool " +
+	"results that still matter, and any open threads or next steps. Write it as durable context the " +
+	"assistant can rely on to continue the conversation. Output ONLY the summary prose — no preamble, " +
+	"no meta-commentary."
+
+// minCompactMessages: a conversation shorter than this isn't worth a model call.
+const minCompactMessages = 4
+
+// compactResponse is the JSON body of POST /v1/runs/{run_id}/compact.
+type compactResponse struct {
+	RunID        string `json:"run_id"`
+	Compacted    bool   `json:"compacted"`
+	BeforeTokens int    `json:"before_tokens"`
+	AfterTokens  int    `json:"after_tokens"`
+	// Applied: "live" (pushed to the running loop), "marker" (persisted for a
+	// terminal run's next continuation), or "noop" (too short to compact).
+	Applied string `json:"applied"`
+}
+
+// handleCompactRun serves POST /v1/runs/{run_id}/compact — summarize the run's
+// conversation to free context and continue from the summary (interactive
+// context compaction). Gated to a safe boundary: a live run must be PARKED
+// (awaiting_input); mid-turn returns 409. Computes the summary with one model
+// call (the run's resolved provider/model), then either pushes a compact
+// control to the live loop (it swaps its in-memory history + emits the persisted
+// marker) or, for a terminal run with no live loop, persists the marker directly
+// so the next continuation rebuilds compacted. Cross-tenant gets an opaque 404.
+func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		http.Error(w, "compaction requires persistence", http.StatusServiceUnavailable)
+		return
+	}
+	runID := r.PathValue("run_id")
+	if !validIdent(runID) {
+		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
+		return
+	}
+	run, err := s.store.GetRun(r.Context(), runID)
+	if err != nil {
+		http.Error(w, "no run for that run_id", http.StatusNotFound)
+		return
+	}
+	// Tenant-ownership: opaque 404 cross-tenant (run_ids aren't secrets).
+	if run.SessionID != "" {
+		if sess, serr := s.store.GetSession(r.Context(), run.SessionID); serr == nil {
+			if !sessionOwnershipOK(r.Context(), sess) {
+				http.Error(w, "no run for that run_id", http.StatusNotFound)
+				return
+			}
+		}
+	}
+
+	terminal := isTerminalRunStatus(run.Status)
+	live := s.steerReg != nil && func() bool { _, ok := s.steerReg.Get(runID); return ok }()
+	// Boundary gate (user-chosen: safe boundary only). A LOCAL live run must be
+	// parked; refuse mid-turn so compaction applies at the boundary the agent is
+	// already at rather than being deferred into the current turn.
+	if live && !terminal && !s.steerReg.IsParked(runID) {
+		writeJSONError(w, http.StatusConflict, "run_busy",
+			"the agent is mid-turn; compact when it's parked waiting for your input")
+		return
+	}
+
+	// Rebuild the conversation from this run's transcript (== the parked loop's
+	// in-memory history — a parked run has persisted everything up to the park).
+	events, terr := s.store.GetTranscript(r.Context(), run.SessionID)
+	if terr != nil {
+		http.Error(w, "read transcript: "+terr.Error(), http.StatusInternalServerError)
+		return
+	}
+	runEvents := make([]store.Event, 0, len(events))
+	for _, e := range events {
+		if e.RunID == runID {
+			runEvents = append(runEvents, e)
+		}
+	}
+	msgs := replayTranscript(runEvents)
+	before := estimateMessageTokens(msgs)
+	if len(msgs) < minCompactMessages {
+		writeJSON(w, http.StatusOK, compactResponse{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"})
+		return
+	}
+
+	// Resolve provider/model + summarize (one model call) — same chain resume
+	// uses; no per-run secrets needed (the operator's provider key serves it).
+	agentDef, ok := s.lookupAgent(r.Context(), run.TenantID, run.Agent)
+	if !ok {
+		writeJSONError(w, http.StatusConflict, "agent_gone", "the run's agent no longer exists")
+		return
+	}
+	providerID, model, _, rerr := s.resolveAgentDef(agentDef, run.Agent, run.UserTier)
+	if rerr != nil {
+		http.Error(w, "resolve provider/model: "+rerr.Error(), http.StatusInternalServerError)
+		return
+	}
+	provider, perr := s.providers.Get(providerID)
+	if perr != nil {
+		http.Error(w, "provider unavailable: "+perr.Error(), http.StatusServiceUnavailable)
+		return
+	}
+	summary, serr := summarizeConversation(r.Context(), provider, model, msgs)
+	if serr != nil {
+		http.Error(w, "summarize: "+serr.Error(), http.StatusBadGateway)
+		return
+	}
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		http.Error(w, "summarization produced no text", http.StatusBadGateway)
+		return
+	}
+	after := estimateMessageTokens(loop.CompactionMessages(summary))
+
+	// Apply. Live (local or cross-replica, routed by steerReg.Push): push the
+	// compact control — the loop swaps its history + emits the persisted marker.
+	// Terminal: no loop, so persist the marker here for the next continuation.
+	applied := "marker"
+	if !terminal && s.steerReg != nil {
+		_, pushErr := s.steerReg.Push(r.Context(), runID, steer.Message{
+			Kind: steer.KindCompact, Text: summary, Source: compactSource(r), EnqueuedAt: time.Now(),
+		})
+		switch {
+		case errors.Is(pushErr, steer.ErrQueueFull):
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, "run input queue full; retry shortly", http.StatusTooManyRequests)
+			return
+		case errors.Is(pushErr, steer.ErrRunNotFound):
+			// Raced to terminal between GetRun and Push → fall through to marker.
+		case pushErr != nil:
+			http.Error(w, pushErr.Error(), http.StatusInternalServerError)
+			return
+		default:
+			applied = "live"
+		}
+	}
+	if applied == "marker" {
+		payload, merr := json.Marshal(providers.Event{
+			Type: providers.EventContextCompaction,
+			ContextCompaction: &providers.ContextCompactionEventInfo{
+				Summary: summary, BeforeTokens: before, AfterTokens: after,
+			},
+		})
+		if merr == nil {
+			if aerr := s.store.AppendEvent(r.Context(), runID, string(providers.EventContextCompaction), payload); aerr != nil {
+				http.Error(w, "persist compaction marker: "+aerr.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, compactResponse{RunID: runID, Compacted: true, BeforeTokens: before, AfterTokens: after, Applied: applied})
+}
+
+// compactSource mirrors handleRunInput's api-vs-webui source resolution.
+func compactSource(r *http.Request) string {
+	if hasSessionCookie(r) {
+		return store.InterruptResolvedByWebUI
+	}
+	return store.InterruptResolvedByAPI
+}
+
+// estimateMessageTokens is a cheap chars/4 heuristic (no tokenizer) over message
+// text + tool I/O — enough for the operator-facing "context compacted (N→M)"
+// readout, not for billing.
+func estimateMessageTokens(msgs []providers.Message) int {
+	chars := 0
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			chars += len(c.Text) + len(c.ToolInput)
+		}
+	}
+	return chars / 4
+}
+
+// summarizeConversation makes ONE provider call to compact msgs into a summary.
+// The conversation is flattened into a single user message (role-tagged) so the
+// call is valid regardless of how msgs alternates or which turn it ends on, and
+// the model clearly sees "summarize this text". Drains the event stream for text.
+func summarizeConversation(ctx context.Context, provider providers.Provider, model string, msgs []providers.Message) (string, error) {
+	var convo strings.Builder
+	for _, m := range msgs {
+		for _, c := range m.Content {
+			switch c.Type {
+			case "text":
+				if c.Text != "" {
+					fmt.Fprintf(&convo, "%s: %s\n\n", m.Role, c.Text)
+				}
+			case "tool_use":
+				fmt.Fprintf(&convo, "%s [tool_use %s]: %s\n\n", m.Role, c.ToolName, string(c.ToolInput))
+			case "tool_result":
+				fmt.Fprintf(&convo, "%s [tool_result]: %s\n\n", m.Role, c.Text)
+			}
+		}
+	}
+	ch, err := provider.Call(ctx, providers.Request{
+		Model:  model,
+		System: []providers.ContentBlock{{Type: "text", Text: compactionSystemPrompt}},
+		Messages: []providers.Message{{
+			Role:    "user",
+			Content: []providers.ContentBlock{{Type: "text", Text: "Conversation to compact:\n\n" + convo.String()}},
+		}},
+	})
+	if err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventText:
+			b.WriteString(ev.Text)
+		case providers.EventError:
+			return "", errors.New(ev.Error)
+		}
+	}
+	return b.String(), nil
 }
 
 // handleListRunInterrupts serves GET /v1/runs/{run_id}/interrupts.

--- a/internal/loop/compact_test.go
+++ b/internal/loop/compact_test.go
@@ -1,0 +1,130 @@
+package loop
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// CompactionMessages is the single source of truth for the compacted history
+// shape (the live loop AND replayTranscript both build it). It must start on a
+// user turn and end on an assistant turn so the operator's next input alternates
+// cleanly (Anthropic et al. require start-with-user + role alternation).
+func TestCompactionMessages_Shape(t *testing.T) {
+	msgs := CompactionMessages("THE SUMMARY")
+	if len(msgs) != 2 {
+		t.Fatalf("got %d messages, want 2 (user intro + assistant ack)", len(msgs))
+	}
+	if msgs[0].Role != "user" {
+		t.Errorf("first role = %q, want user (providers require start-with-user)", msgs[0].Role)
+	}
+	if !strings.Contains(msgs[0].Content[0].Text, "THE SUMMARY") {
+		t.Errorf("summary not embedded in the user turn: %q", msgs[0].Content[0].Text)
+	}
+	if msgs[1].Role != "assistant" {
+		t.Errorf("last role = %q, want assistant (so the next operator turn alternates)", msgs[1].Role)
+	}
+}
+
+// A steer.KindCompact control delivered to a PARKED interactive run replaces the
+// in-memory conversation with the summary pair and RE-parks (no provider call),
+// and the next real operator turn's request carries ONLY the compacted history.
+// Fail-before: pre-feature, a compact-kind message was appended as a user turn
+// (history kept growing) and triggered a provider call.
+func TestRun_Interactive_CompactReplacesHistory(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	parked := make(chan struct{}, 8)
+	compacted := make(chan struct{}, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prov := &steerProvider{} // inject nil → always end_turn; records every request
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			OnEvent: func(ev providers.Event) {
+				switch ev.Type {
+				case providers.EventAwaitingInput:
+					parked <- struct{}{}
+				case providers.EventContextCompaction:
+					compacted <- struct{}{}
+				}
+			},
+		})
+		close(done)
+	}()
+
+	waitOn := func(ch <-chan struct{}, what string) {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: timed out", what)
+		}
+	}
+	calls := func() int { prov.mu.Lock(); defer prov.mu.Unlock(); return len(prov.requests) }
+
+	waitOn(parked, "initial end_turn park")
+	if got := calls(); got != 1 {
+		t.Fatalf("calls=%d before compact, want 1", got)
+	}
+
+	// Compact while parked → emits context_compaction + re-parks, NO provider call.
+	q <- steer.Message{Kind: steer.KindCompact, Text: "SUMMARY-X"}
+	waitOn(compacted, "compaction applied")
+	if got := calls(); got != 1 {
+		t.Errorf("compact triggered a provider call (calls=%d, want 1 — must just re-park)", got)
+	}
+
+	// A real operator turn now → exactly one provider call on the compacted history.
+	q <- steer.Message{Text: "continue"}
+	waitOn(parked, "re-park after the real turn")
+	if got := calls(); got != 2 {
+		t.Fatalf("calls=%d after the real turn, want 2", got)
+	}
+	prov.mu.Lock()
+	last := append([]providers.Message(nil), prov.requests[len(prov.requests)-1]...)
+	prov.mu.Unlock()
+
+	txt := func(m providers.Message) string {
+		var b strings.Builder
+		for _, c := range m.Content {
+			b.WriteString(c.Text)
+		}
+		return b.String()
+	}
+	if len(last) != 3 {
+		t.Fatalf("compacted request has %d messages, want 3 (summary pair + the new turn): %+v", len(last), last)
+	}
+	if last[0].Role != "user" || !strings.Contains(txt(last[0]), "SUMMARY-X") {
+		t.Errorf("msg[0] = %q (%s); want the summary user turn", txt(last[0]), last[0].Role)
+	}
+	if last[1].Role != "assistant" {
+		t.Errorf("msg[1] role = %q, want assistant", last[1].Role)
+	}
+	if last[2].Role != "user" || txt(last[2]) != "continue" {
+		t.Errorf("msg[2] = %q (%s); want user 'continue'", txt(last[2]), last[2].Role)
+	}
+	for _, m := range last {
+		if txt(m) == "go" {
+			t.Errorf("the original pre-compaction turn survived: %+v", m)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not terminate after cancel")
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -648,16 +648,41 @@ func parkForInput(ctx context.Context, q <-chan steer.Message, heartbeat func())
 	}
 }
 
+// CompactionMessages builds the two-message replacement for a steer.KindCompact
+// control: a user turn carrying the summary as established context, then a short
+// assistant ack. The pair starts on a user turn and ends on an assistant turn so
+// the operator's NEXT input alternates cleanly (Anthropic et al. require
+// start-with-user + role alternation). The system prompt is separate (re-derived
+// by the caller), so it is untouched — only the conversation history collapses.
+func CompactionMessages(summary string) []providers.Message {
+	return []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text",
+			Text: "[Conversation compacted — the summary below is the established context for everything before this point.]\n\n" + summary}}},
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "text",
+			Text: "Understood — I'll continue from the summary above."}}},
+	}
+}
+
 // drainSteer non-blocking-pulls every currently-queued operator steering
-// message and appends each as a SEPARATE user-role turn, returning the
-// extended slice. The operator instruction is TRUSTED (bearer-gated, same
-// trust tier as the original run caller) → plain text, not fenced as
-// untrusted. onSteer (if set) fires per message so the runner can persist +
-// emit it.
-func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer func(steer.Message)) []providers.Message {
+// message. An ordinary message (Kind == "") is appended as a SEPARATE user-role
+// turn (TRUSTED — bearer-gated, same trust tier as the run caller — so plain
+// text, not fenced); onSteer (if set) fires per message so the runner persists +
+// emits it. A steer.KindCompact control instead REPLACES the conversation with
+// the summary pair and emits EventContextCompaction (persisted + forwarded), so
+// the in-memory history collapses; it does NOT fire onSteer (the summary is not
+// an operator turn and must not be persisted as a user_input replay row).
+func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer func(steer.Message), emit func(providers.Event)) []providers.Message {
 	for {
 		select {
 		case m := <-q:
+			if m.Kind == steer.KindCompact {
+				messages = CompactionMessages(m.Text)
+				if emit != nil {
+					emit(providers.Event{Type: providers.EventContextCompaction,
+						ContextCompaction: &providers.ContextCompactionEventInfo{Summary: m.Text}})
+				}
+				continue
+			}
 			messages = append(messages, providers.Message{
 				Role:    "user",
 				Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
@@ -838,7 +863,7 @@ outerLoop:
 		// user(tool_results)]; appending a user(steer) turn yields consecutive
 		// user turns, which every provider accepts (replay already emits them).
 		if opts.SteerQueue != nil {
-			messages = drainSteer(opts.SteerQueue, messages, opts.OnSteer)
+			messages = drainSteer(opts.SteerQueue, messages, opts.OnSteer, emit)
 		}
 
 		req := providers.Request{
@@ -1134,20 +1159,37 @@ outerLoop:
 			if opts.Interactive && opts.SteerQueue != nil {
 				emit(providers.Event{Type: providers.EventAwaitingInput,
 					AwaitingInput: &providers.AwaitingInputEventInfo{SinceTurn: iter}})
-				m, resumed := parkForInput(ctx, opts.SteerQueue, opts.OnHeartbeat)
-				if !resumed {
-					// ctx cancelled (or queue closed) → terminate.
-					iterSpan.End()
+				// Park until a real operator turn arrives. A steer.KindCompact
+				// control replaces the in-memory history with the summary pair
+				// and RE-parks (compaction is not itself new input — the
+				// operator's next message is), so the loop never calls the
+				// provider on the bare summary.
+				resumedWithInput := false
+				for {
+					m, resumed := parkForInput(ctx, opts.SteerQueue, opts.OnHeartbeat)
+					if !resumed {
+						break // ctx cancelled (or queue closed) → terminate
+					}
+					if m.Kind == steer.KindCompact {
+						messages = CompactionMessages(m.Text)
+						emit(providers.Event{Type: providers.EventContextCompaction,
+							ContextCompaction: &providers.ContextCompactionEventInfo{Summary: m.Text}})
+						continue // re-park: wait for the operator's actual next turn
+					}
+					messages = append(messages, providers.Message{
+						Role:    "user",
+						Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
+					})
+					if opts.OnSteer != nil {
+						opts.OnSteer(m)
+					}
+					resumedWithInput = true
 					break
 				}
-				messages = append(messages, providers.Message{
-					Role:    "user",
-					Content: []providers.ContentBlock{{Type: "text", Text: m.Text}},
-				})
-				if opts.OnSteer != nil {
-					opts.OnSteer(m)
-				}
 				iterSpan.End()
+				if !resumedWithInput {
+					break
+				}
 				continue outerLoop
 			}
 			iterSpan.End()

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -402,6 +402,14 @@ const (
 	// LOOMCYCLE_RESUME_FANOUT is on.
 	EventSpawnChildStarted EventType = "spawn_child_started"
 	EventSpawnChildResult  EventType = "spawn_child_result"
+
+	// EventContextCompaction marks where an interactive run's conversation was
+	// compacted: everything before it is replaced by a summary. The loop emits
+	// it (persisted + forwarded) when it applies a steer.KindCompact control at
+	// a park boundary; replayTranscript RESETS to the summary pair on replay, so
+	// a crash-recovery/resume rebuild reconstructs the compacted form, not the
+	// full history. The full transcript is retained (non-destructive audit).
+	EventContextCompaction EventType = "context_compaction"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -459,6 +467,10 @@ type Event struct {
 	// SpawnChild carries the structured payload on EventSpawnChildStarted /
 	// EventSpawnChildResult (RFC X Phase 3 spawn ledger). Nil otherwise.
 	SpawnChild *SpawnChildEventInfo `json:"spawn_child,omitempty"`
+
+	// ContextCompaction carries the structured payload on EventContextCompaction
+	// (the conversation summary that replaces prior history). Nil otherwise.
+	ContextCompaction *ContextCompactionEventInfo `json:"context_compaction,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -647,6 +659,17 @@ type SpawnChildEventInfo struct {
 	Ok     bool   `json:"ok,omitempty"`
 	Output string `json:"output,omitempty"`
 	Error  string `json:"error,omitempty"`
+}
+
+// ContextCompactionEventInfo is the structured payload on EventContextCompaction
+// (interactive context compaction). Summary is the model-generated recap that
+// replaces the prior conversation; Before/AfterTokens are the rough token
+// footprint before vs after, for the operator-facing "context compacted (N→M)"
+// line. replayTranscript reads Summary to seed the compacted message pair.
+type ContextCompactionEventInfo struct {
+	Summary      string `json:"summary"`
+	BeforeTokens int    `json:"before_tokens,omitempty"`
+	AfterTokens  int    `json:"after_tokens,omitempty"`
 }
 
 // HostWideningEventInfo is the structured payload on EventHostWidened

--- a/internal/steer/registry.go
+++ b/internal/steer/registry.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -33,11 +34,24 @@ var ErrRunNotFound = errors.New("steer: no in-flight run for run_id")
 // operator is outpacing the loop's drain. HTTP maps it to 429 (retry).
 var ErrQueueFull = errors.New("steer: run input queue full")
 
-// Message is one operator-injected steering instruction.
+// KindCompact marks a Message as a context-compaction control rather than an
+// operator steering turn (RFC: interactive context compaction). The loop, on
+// draining a compact Message, REPLACES its in-memory conversation with a
+// summary pair built from Text instead of appending Text as a user turn. The
+// empty Kind ("") is the default — an ordinary steering/continuation message.
+const KindCompact = "compact"
+
+// Message is one operator-injected steering instruction (Kind == "") or a
+// control message (e.g. KindCompact). Carried over the same per-run queue so
+// the loop applies it at its next iteration / park boundary.
 type Message struct {
 	Text       string
 	Source     string // "api" | "webui" — resolved at the auth boundary, never the wire
 	EnqueuedAt time.Time
+	// Kind discriminates the message. "" = an operator turn (append Text as a
+	// user message). KindCompact = replace the conversation with a summary
+	// built from Text. New kinds extend this without changing the queue plumbing.
+	Kind string
 }
 
 // Entry is the live handle for one run's steering queue.
@@ -47,6 +61,12 @@ type Entry struct {
 	SessionID string
 	UserID    string
 	ch        chan Message
+	// parked reports whether the run is currently parked at end_turn awaiting
+	// operator input (an interactive run between turns) vs. actively mid-turn.
+	// A pointer so the value-copied Entry returned by Get still observes
+	// updates. Flipped by SetParked (driven by the run's awaiting_input /
+	// resume events); read by IsParked for the compaction boundary gate.
+	parked *atomic.Bool
 }
 
 // ClusterSteerer is the cross-replica fallback (mirror of
@@ -93,6 +113,7 @@ func (r *Registry) SetClusterSteerer(c ClusterSteerer) {
 func (r *Registry) Register(e Entry) (<-chan Message, func()) {
 	ch := make(chan Message, r.cap)
 	e.ch = ch
+	e.parked = &atomic.Bool{}
 	r.mu.Lock()
 	r.entries[e.RunID] = e
 	r.mu.Unlock()
@@ -172,4 +193,27 @@ func (r *Registry) Count() int {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return len(r.entries)
+}
+
+// SetParked records whether a registered run is parked at end_turn awaiting
+// input. Driven by the run's awaiting_input event (true) and the events that
+// signal it resumed work (false). No-op for an unregistered run_id.
+func (r *Registry) SetParked(runID string, parked bool) {
+	r.mu.RLock()
+	e, ok := r.entries[runID]
+	r.mu.RUnlock()
+	if ok && e.parked != nil {
+		e.parked.Store(parked)
+	}
+}
+
+// IsParked reports whether a LOCALLY-registered run is parked awaiting input —
+// the safe boundary for context compaction. False when the run_id is unknown
+// locally (terminated, or owned by another replica): the caller treats those
+// via the terminal / cross-replica paths, not as "parked here".
+func (r *Registry) IsParked(runID string) bool {
+	r.mu.RLock()
+	e, ok := r.entries[runID]
+	r.mu.RUnlock()
+	return ok && e.parked != nil && e.parked.Load()
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -132,6 +132,9 @@ export interface EventPayload {
   user_input?: { text: string; source?: string; seen_at?: string };
   // "awaiting_input" sidecar — a persistent interactive run parked at end_turn.
   awaiting_input?: { since_turn?: number };
+  // "context_compaction" sidecar — the conversation before this marker was
+  // summarized to free context (interactive compaction).
+  context_compaction?: { summary?: string; before_tokens?: number; after_tokens?: number };
 }
 
 // v0.9.x — payloads for event types whose shape doesn't fit
@@ -1727,6 +1730,33 @@ export async function sendRunInput(runID: string, text: string): Promise<void> {
     const b = await resp.text();
     throw new Error(`${resp.status} ${resp.statusText}: ${b.slice(0, 200)}`);
   }
+}
+
+// CompactResult mirrors the POST /v1/runs/{run_id}/compact JSON body.
+export interface CompactResult {
+  run_id: string;
+  compacted: boolean;
+  before_tokens: number;
+  after_tokens: number;
+  applied: string; // "live" | "marker" | "noop"
+}
+
+// compactRun summarizes a run's conversation to free context and continue from
+// the summary (POST /v1/runs/{run_id}/compact). Only valid at a safe boundary
+// (the agent parked awaiting input, or a terminal run) — the server returns 409
+// mid-turn.
+export async function compactRun(runID: string): Promise<CompactResult> {
+  const resp = await fetch(`/v1/runs/${encodeURIComponent(runID)}/compact`, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify({}),
+  });
+  if (!resp.ok) {
+    const b = await resp.text();
+    throw new Error(`${resp.status} ${resp.statusText}: ${b.slice(0, 200)}`);
+  }
+  return resp.json() as Promise<CompactResult>;
 }
 
 // continueSession appends a new turn to an existing session

--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -109,8 +109,13 @@ export default function LiveRunPane({
         {agentId && <code className="live-run-agentid">{agentId}</code>}
         <ContextGauge usage={lastUsage} />
         {status === "running" && (
-          <button type="button" className="live-run-cancel" onClick={onCancel}>
-            Cancel
+          <button
+            type="button"
+            className="live-run-cancel"
+            onClick={onCancel}
+            title="Stop the run"
+          >
+            <span aria-hidden="true">✕</span> Stop
           </button>
         )}
       </div>

--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -26,6 +26,7 @@ export default function LiveRunPane({
   onCancel,
   onContinue,
   onSend,
+  onCompact,
   awaitingInput,
   lastUsage,
   pendingInterrupt,
@@ -41,6 +42,7 @@ export default function LiveRunPane({
   onCancel: () => void;
   onContinue?: (prompt: string) => void;
   onSend?: (text: string) => void;
+  onCompact?: () => void;
   awaitingInput?: boolean;
   lastUsage?: LiveUsage | null;
   pendingInterrupt?: PendingInterrupt | null;
@@ -108,6 +110,26 @@ export default function LiveRunPane({
         <span className={`pill ${status}`}>{status}</span>
         {agentId && <code className="live-run-agentid">{agentId}</code>}
         <ContextGauge usage={lastUsage} />
+        {onCompact &&
+          !pendingInterrupt &&
+          events.length > 0 &&
+          (status === "running" || status === "completed") && (
+            <button
+              type="button"
+              className="live-run-compact"
+              onClick={onCompact}
+              disabled={
+                !(status === "completed" || (status === "running" && !!awaitingInput))
+              }
+              title={
+                status === "running" && !awaitingInput
+                  ? "Wait for the current turn to finish, then compact"
+                  : "Summarize the conversation to free up context, then continue"
+              }
+            >
+              Compact
+            </button>
+          )}
         {status === "running" && (
           <button
             type="button"

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -239,6 +239,13 @@ function formatLine(row: TranscriptEvent): FormattedLine {
       return { key, ts, kind, cls: "tl-user", payload: `❯ ${ev.text ?? ""}` };
     case "awaiting_input":
       return { key, ts, kind, cls: "tl-meta", payload: "idle — waiting for operator input" };
+    case "context_compaction": {
+      // The conversation before this point was summarized to free context.
+      const before = ev.context_compaction?.before_tokens ?? 0;
+      const after = ev.context_compaction?.after_tokens ?? 0;
+      const sizes = before > 0 && after > 0 ? ` (~${fmtTokens(before)} → ~${fmtTokens(after)})` : "";
+      return { key, ts, kind, cls: "tl-meta", payload: `↯ context compacted${sizes}` };
+    }
     case "started":
       return { key, ts, kind, cls: "tl-meta", payload: "" };
     case "session":
@@ -277,6 +284,11 @@ function oneLine(s: string): string {
 
 function truncate(s: string, n: number): string {
   return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+// fmtTokens renders a rough token count compactly (1234 → "1.2k").
+function fmtTokens(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
 }
 
 function formatHMSms(ns: number): string {

--- a/web/src/hooks/useRunStream.ts
+++ b/web/src/hooks/useRunStream.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   cancelAgent,
+  compactRun,
   continueSession,
   resolveInterrupt,
   sendRunInput,
@@ -78,6 +79,9 @@ export interface UseRunStream {
   // CONTINUES the session as a fresh turn. The single terminal-prompt entry.
   send: (text: string) => void;
   cancel: () => void;
+  // compact summarizes the conversation and continues from the summary, freeing
+  // context. Valid only at a safe boundary (parked / terminal).
+  compact: () => void;
   reset: () => void;
 }
 
@@ -307,6 +311,17 @@ export function useRunStream(): UseRunStream {
     setStatus((s) => (s === "running" ? "cancelled" : s));
   }, [agentId]);
 
+  // compact summarizes the run's conversation and continues from the summary.
+  // Best-effort; only valid at a safe boundary (the LiveRunPane button gates
+  // this), the server returns 409 mid-turn. The resulting context_compaction
+  // event arrives on the live stream and renders in the transcript.
+  const compact = useCallback(() => {
+    if (!runId) return;
+    void compactRun(runId).catch((e) => {
+      setError(e instanceof Error ? e.message : String(e));
+    });
+  }, [runId]);
+
   const reset = useCallback(() => {
     ctrlRef.current?.abort();
     seqRef.current = 0;
@@ -338,6 +353,7 @@ export function useRunStream(): UseRunStream {
     send,
     sendMessage,
     cancel,
+    compact,
     reset,
   };
 }

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -135,6 +135,7 @@ function SingleRunTab({
           error={run.error}
           onCancel={run.cancel}
           onSend={run.send}
+          onCompact={run.compact}
           awaitingInput={run.awaitingInput}
           lastUsage={run.lastUsage}
           pendingInterrupt={run.pendingInterrupt}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4181,6 +4181,24 @@ button.primary:disabled {
 }
 .live-run-cancel {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 12px;
+  border: none;
+  border-radius: 999px;
+  background: #9b2c2c; /* dark red — a clear "stop", distinct from the accent */
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+.live-run-cancel:hover {
+  background: #b5343a;
+}
+.live-run-cancel:active {
+  background: #861f24;
 }
 .live-run-pane .terminal-transcript {
   flex: 1;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4200,6 +4200,32 @@ button.primary:disabled {
 .live-run-cancel:active {
   background: #861f24;
 }
+/* Compact: a non-destructive action — neutral/outline pill, visually distinct
+   from the red Stop. margin-left:auto pushes the action group to the right (the
+   first right-floated control absorbs the free space; Stop follows it). */
+.live-run-compact {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 12px;
+  border: 1px solid var(--border, #2a2e3a);
+  border-radius: 999px;
+  background: var(--bg-soft-2, #1d2230);
+  color: var(--fg-soft, #9aa);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+  cursor: pointer;
+}
+.live-run-compact:not(:disabled):hover {
+  border-color: var(--accent, #5b9dff);
+  color: var(--fg, #e6e6e6);
+}
+.live-run-compact:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
 .live-run-pane .terminal-transcript {
   flex: 1;
   min-height: 0;


### PR DESCRIPTION
## Why

Long interactive sessions grow the conversation until it crowds the model's context window (the terminal already shows a `ctx used / max` gauge). This adds a one-click **Compact**: summarize the conversation so far (~10%) and continue from the summary, freeing context while preserving the thread.

## The subtlety

A live interactive run holds its conversation in an **in-memory `messages` slice on a long-lived goroutine** — at `end_turn` it parks *blocking* on the steer queue, and the next operator message is appended to that in-memory slice. It is **not** rebuilt from the transcript on continuation. So "replace the conversation" had to mean two things:

1. **Capture (live swap)** — `steer.Message` gains a `Kind`; `KindCompact` tells the loop to **replace** its in-memory history with `loop.CompactionMessages(summary)` (a user+assistant pair — starts-with-user, ends-on-assistant so the next operator turn alternates cleanly) instead of appending, then **re-park**. Applied only at a drain/park boundary, so it can never break `tool_use`/`tool_result` pairing.
2. **Durability (marker)** — a new `context_compaction` event (persisted + forwarded); `replayTranscript` **resets** to the summary pair on replay, so crash-recovery / resume / `/sessions/{id}/messages` rebuild the *compacted* form. The full transcript is retained — non-destructive audit.

## What

- **Endpoint** `POST /v1/runs/{run_id}/compact` (scope `runs:create`): resolves the run's provider/model (same chain resume uses — no per-run secrets), summarizes with **one** `provider.Call`, then for a live **parked** run pushes the compact control (the loop swaps + emits the marker), or for a terminal run persists the marker directly for the next continuation. Returns before/after token estimates + `applied` (`live`/`marker`/`noop`).
- **Safe-boundary gate (chosen behavior)**: a live run must be **parked** (`awaiting_input`); mid-turn returns **409**. Parked state is tracked in `makeRecordingEmit` (`awaiting_input` ⇒ parked; `steer`/`text`/`tool_call` ⇒ not) and exposed via the steer registry's `IsParked`. Below 4 messages is a no-op.
- **Web UI**: a neutral **Compact** pill in the run header (next to the red Stop), enabled only at a safe boundary (parked / completed), **disabled mid-turn**; the `context_compaction` marker renders as `↯ context compacted (N→M)`.

## What was tested

- **loop**: `KindCompact` replaces the parked history with the summary pair + re-parks with **no** provider call, and the next real turn's request carries only the compacted history; `CompactionMessages` shape (start-user/end-assistant).
- **replayTranscript**: a `context_compaction` marker resets to the pair + replays post-marker turns, dropping pre-marker history.
- **handler**: 409 mid-turn; live-parked pushes a `compact` control carrying the summary; terminal persists the marker; short conversation is a no-op.
- `go test ./...` clean; touched packages green under `-race`; `make build-ui` clean; verified the button across parked/mid-turn/completed states in an isolated harness.
- Web-UI changes are `web/src` only; `internal/webui/dist/*` is gitignored + CI-rebuilt.

## Out of scope / future

Auto-compact on a context threshold; compaction for autonomous/batch runs; a tunable ratio / keep-last-N-turns-verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)