### PR TITLE
fix: exp7 security findings — tenant-scope agent delete, infra-secret YAML expansion, input-endpoint scope (C1/C2/I6/I1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -463,6 +463,12 @@ func requiredScopeFor(method, path string) string {
 		return auth.ScopeRunsCreate
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/compact"):
 		return auth.ScopeRunsCreate
+	// Operator steering / continuation input is a run-state MUTATION (it injects
+	// text into a live run), so it requires runs:create like cancel/resolve/
+	// compact — NOT the read scope. (exp7 I1: it previously fell through to the
+	// default empty arm, letting a read-only bearer steer a run.)
+	case method == http.MethodPost && strings.HasPrefix(path, "/v1/runs/") && strings.HasSuffix(path, "/input"):
+		return auth.ScopeRunsCreate
 	case method == http.MethodGet && strings.HasPrefix(path, "/v1/runs/"):
 		return auth.ScopeRunsRead
 	// Run / agent / session / user reads.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -198,6 +198,11 @@ func TestRequiredScopeFor(t *testing.T) {
 		// Interrupt resolve = write, list = read (were any-authenticated).
 		{"POST", "/v1/runs/r_1/interrupts/i_1/resolve", auth.ScopeRunsCreate},
 		{"GET", "/v1/runs/r_1/interrupts", auth.ScopeRunsRead},
+		// Compact + operator steering input both MUTATE run state → runs:create
+		// (exp7 I1: /input previously fell through to any-authenticated, so a
+		// read-only bearer could steer a run).
+		{"POST", "/v1/runs/r_1/compact", auth.ScopeRunsCreate},
+		{"POST", "/v1/runs/r_1/input", auth.ScopeRunsCreate},
 		{"GET", "/v1/agents/a_1", auth.ScopeRunsRead},
 		{"GET", "/v1/users/alice/agents", auth.ScopeRunsRead},
 		// Per-user channel surface uses the channel scopes (were

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -322,7 +322,10 @@ func (s *Server) UnregisterAgent(ctx context.Context, name string) error {
 	if s.store == nil {
 		return fmt.Errorf("unregister_agent requires persistence (no Store configured)")
 	}
-	_, err := s.store.DynamicAgentDelete(ctx, name)
+	// RFC N: delete scoped to the registering principal's tenant — mirrors
+	// RegisterAgent's tenantFromCtx stamping so one tenant can't unregister
+	// another tenant's same-named agent (exp7 C1).
+	_, err := s.store.DynamicAgentDelete(ctx, tenantFromCtx(ctx), name)
 	return err
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3044,10 +3044,21 @@ var envVarRe = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
 func expandEnv(s string) string {
 	return envVarRe.ReplaceAllStringFunc(s, func(m string) string {
 		name := m[2 : len(m)-1]
-		if !ExpandEnvAllowed(name) {
+		if !ExpandEnvAllowed(name) || expandDenyNames[name] {
 			return m // leave verbatim — caller sees the literal ${...}
 		}
-		return os.Getenv(name)
+		v := os.Getenv(name)
+		// exp7 I6: env values are interpolated into raw YAML bytes BEFORE
+		// yaml.Unmarshal, so a value carrying a newline could inject new
+		// keys/structure into the document. A legitimate scalar is never
+		// multi-line, so refuse to expand it — leaving the literal ${name}
+		// is a visible "didn't expand" signal and cannot corrupt the
+		// document structure (vs. an error path that would change this
+		// helper's signature, which the runtime ExpandEnv path also uses).
+		if strings.ContainsAny(v, "\r\n") {
+			return m
+		}
+		return v
 	})
 }
 
@@ -3128,11 +3139,27 @@ func ExpandEnvAllowed(name string) bool {
 	case "BRAVE_API_KEY",
 		"GITHUB_TOKEN",
 		"SLACK_BOT_TOKEN",
-		"PG_DSN",
 		"REDIS_URL":
 		return true
 	}
 	return false
+}
+
+// expandDenyNames are loomcycle's OWN infrastructure / admin secrets that must
+// NEVER be interpolated into a YAML/MCP field, even though the LOOMCYCLE_ prefix
+// (or a bare third-party name) would otherwise allow it (exp7 C2). The DB DSN
+// and the operator bearer are loomcycle's own credentials — unlike a per-MCP
+// auth token (which an operator legitimately references in THAT server's own
+// header via ${LOOMCYCLE_*}), interpolating these into an outbound MCP URL/
+// header would exfiltrate loomcycle's infra creds to a third party. They reach
+// the system via the Env struct, never via YAML interpolation, so denying them
+// here breaks no legitimate use. (Deliberately a tight named set, NOT the broad
+// IsSecretEnvName suffix match, which would also block legitimate
+// ${LOOMCYCLE_*_TOKEN} MCP auth headers.)
+var expandDenyNames = map[string]bool{
+	"PG_DSN":               true,
+	"LOOMCYCLE_PG_DSN":     true,
+	"LOOMCYCLE_AUTH_TOKEN": true,
 }
 
 // secretEnvSuffixes are the env-var NAME patterns this project classifies as

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2295,6 +2295,58 @@ func TestExpandEnvAllowed_Predicate(t *testing.T) {
 	}
 }
 
+// TestExpandEnv_DeniesInfraSecrets pins exp7 C2: loomcycle's own DB DSN and
+// operator bearer must never be interpolated into a YAML/MCP field, even
+// though the LOOMCYCLE_ prefix (or the bare PG_DSN third-party name) would
+// otherwise allow it. They stay verbatim. A non-secret LOOMCYCLE_ var and a
+// per-MCP auth token (the legitimate ${LOOMCYCLE_*_TOKEN} header use the deny
+// set must NOT break) still expand.
+func TestExpandEnv_DeniesInfraSecrets(t *testing.T) {
+	t.Setenv("PG_DSN", "postgres://u:p@h/db")
+	t.Setenv("LOOMCYCLE_PG_DSN", "postgres://u:p@h/db")
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "operator-bearer")
+	t.Setenv("LOOMCYCLE_FOO", "ok-value")
+	t.Setenv("LOOMCYCLE_JIRA_TOKEN", "mcp-auth-token")
+
+	// Infra secrets: the literal ${...} survives, the value never appears.
+	for _, name := range []string{"PG_DSN", "LOOMCYCLE_PG_DSN", "LOOMCYCLE_AUTH_TOKEN"} {
+		in := "x=${" + name + "}"
+		if got := expandEnv(in); got != in {
+			t.Errorf("expandEnv(%q) = %q, want unchanged (infra secret must not interpolate)", in, got)
+		}
+	}
+
+	// Non-secret LOOMCYCLE_ var still expands.
+	if got := expandEnv("${LOOMCYCLE_FOO}"); got != "ok-value" {
+		t.Errorf("expandEnv(LOOMCYCLE_FOO) = %q, want ok-value", got)
+	}
+	// A legitimate per-MCP auth token (the deny set is a tight named set, NOT
+	// the broad *_TOKEN suffix match) must still expand into its own header.
+	if got := expandEnv("Bearer ${LOOMCYCLE_JIRA_TOKEN}"); got != "Bearer mcp-auth-token" {
+		t.Errorf("expandEnv(LOOMCYCLE_JIRA_TOKEN) = %q, want Bearer mcp-auth-token", got)
+	}
+}
+
+// TestExpandEnv_RejectsNewlineValue pins exp7 I6: env values are interpolated
+// into raw YAML bytes before yaml.Unmarshal, so a value carrying a newline
+// could inject new keys/structure. Such a value is left verbatim (a visible
+// "didn't expand" signal); a normal single-line value expands as usual.
+func TestExpandEnv_RejectsNewlineValue(t *testing.T) {
+	t.Setenv("LOOMCYCLE_INJ", "value\ninjected_key: pwned")
+	t.Setenv("LOOMCYCLE_CR", "value\rmore")
+	t.Setenv("LOOMCYCLE_OK", "clean-value")
+
+	if got := expandEnv("${LOOMCYCLE_INJ}"); got != "${LOOMCYCLE_INJ}" {
+		t.Errorf("expandEnv(newline value) = %q, want unchanged ${LOOMCYCLE_INJ}", got)
+	}
+	if got := expandEnv("${LOOMCYCLE_CR}"); got != "${LOOMCYCLE_CR}" {
+		t.Errorf("expandEnv(CR value) = %q, want unchanged ${LOOMCYCLE_CR}", got)
+	}
+	if got := expandEnv("${LOOMCYCLE_OK}"); got != "clean-value" {
+		t.Errorf("expandEnv(clean value) = %q, want clean-value", got)
+	}
+}
+
 // TestLoad_WebhooksEnvKnobs verifies the new webhook-specific env knobs are
 // parsed: LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST (comma list, trimmed) and
 // LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED (=1 → true).

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2097,8 +2097,10 @@ func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, err
 	return out, rows.Err()
 }
 
-func (s *Store) DynamicAgentDelete(ctx context.Context, name string) (bool, error) {
-	tag, err := s.pool.Exec(ctx, `DELETE FROM dynamic_agents WHERE name = $1`, name)
+func (s *Store) DynamicAgentDelete(ctx context.Context, tenantID, name string) (bool, error) {
+	// RFC N: scope the delete to (tenant_id, name) — a principal must not be
+	// able to unregister another tenant's same-named agent (exp7 C1).
+	tag, err := s.pool.Exec(ctx, `DELETE FROM dynamic_agents WHERE tenant_id = $1 AND name = $2`, tenantID, name)
 	if err != nil {
 		return false, fmt.Errorf("dynamic_agents: delete: %w", err)
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -6480,8 +6480,10 @@ func (s *Store) DynamicAgentList(ctx context.Context) ([]store.DynamicAgent, err
 	return out, rows.Err()
 }
 
-func (s *Store) DynamicAgentDelete(ctx context.Context, name string) (bool, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM dynamic_agents WHERE name = ?`, name)
+func (s *Store) DynamicAgentDelete(ctx context.Context, tenantID, name string) (bool, error) {
+	// RFC N: scope the delete to (tenant_id, name) — a principal must not be
+	// able to unregister another tenant's same-named agent (exp7 C1).
+	res, err := s.db.ExecContext(ctx, `DELETE FROM dynamic_agents WHERE tenant_id = ? AND name = ?`, tenantID, name)
 	if err != nil {
 		return false, fmt.Errorf("dynamic_agents: delete: %w", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1469,10 +1469,13 @@ type Store interface {
 	// Capped at 200 rows ordered by created_at DESC.
 	DynamicAgentList(ctx context.Context) ([]DynamicAgent, error)
 
-	// DynamicAgentDelete removes one dynamic agent. Returns true
-	// when a row was actually deleted, false when the name didn't
-	// exist (or had already expired). Both are non-error paths.
-	DynamicAgentDelete(ctx context.Context, name string) (bool, error)
+	// DynamicAgentDelete removes one dynamic agent scoped to (tenantID,
+	// name) — RFC N: a principal may only delete its own tenant's agent,
+	// never another tenant's same-named row. Returns true when a row was
+	// actually deleted, false when no (tenant, name) match existed (or it
+	// had already expired). Both are non-error paths. tenantID "" = the
+	// shared/operator/legacy tenant.
+	DynamicAgentDelete(ctx context.Context, tenantID, name string) (bool, error)
 
 	// DynamicAgentSweep deletes every dynamic_agents row whose
 	// expires_at has passed. Returns the row count deleted. Safe to

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -3932,6 +3932,28 @@ func testAgentDefTenantIsolation(t *testing.T, s store.Store) {
 	if !jsonEqual(dynB.Definition, `{"dyn":"B"}`) || dynB.TenantID != "tenant-b" {
 		t.Errorf("dynamic_agents tenant-b clobbered: got tenant=%q def=%s", dynB.TenantID, dynB.Definition)
 	}
+
+	// dynamic_agents DELETE isolation (exp7 C1) — deleting tenant-a's row
+	// must not touch tenant-b's same-named row. FAIL-BEFORE: when the delete
+	// filtered on (name) alone, this wiped BOTH tenants' rows, so the
+	// tenant-b GetActive below would 404.
+	deleted, err := s.DynamicAgentDelete(ctx, "tenant-a", name)
+	if err != nil {
+		t.Fatalf("dyn delete A: %v", err)
+	}
+	if !deleted {
+		t.Error("dyn delete A: reported no row deleted, want true")
+	}
+	if _, err := s.DynamicAgentGet(ctx, "tenant-a", name); err == nil {
+		t.Error("dyn get A after delete: row still present, want not-found")
+	}
+	survivor, err := s.DynamicAgentGet(ctx, "tenant-b", name)
+	if err != nil {
+		t.Fatalf("dyn get B after deleting A: tenant-b's row was wiped by a cross-tenant delete: %v", err)
+	}
+	if !jsonEqual(survivor.Definition, `{"dyn":"B"}`) || survivor.TenantID != "tenant-b" {
+		t.Errorf("dynamic_agents tenant-b altered by tenant-a delete: got tenant=%q def=%s", survivor.TenantID, survivor.Definition)
+	}
 }
 
 func testAgentDefContentSHA256RoundTrip(t *testing.T, s store.Store) {


### PR DESCRIPTION
## Why

Sandbox Experiment #7 had loomcycle review its own repo; the consolidated top-10 findings (catalogued in `loomcycle-internal/doc-internal/rfcs/exp7-code-review-findings.md`) are sonnet-generated with approximate line numbers and an explicit "verify before acting." I verified all 10 against current `main`. This is the **security/isolation half** — the four findings that touch a trust boundary, landed first so they can merge fast. The crash/correctness/hardening half (C3, I3, I5, I7, I2, I4) follows in a second PR.

## What

- **C1 — tenant-scope `DynamicAgentDelete`** *(cross-tenant isolation break)*. RFC N scopes every dynamic agent to `(tenant_id, name)`; `Get`/`Upsert` already key on the tuple and `RegisterAgent` stamps the tenant from the authoritative principal. But `DynamicAgentDelete` took only `(ctx, name)` and both backends ran `DELETE … WHERE name = ?`, so any principal (incl. the MCP `unregister_agent` meta-tool) could delete **every** tenant's same-named agent. Added a `tenantID` param; both backends now `WHERE tenant_id = ? AND name = ?`; the caller resolves it via `tenantFromCtx(ctx)`, mirroring `RegisterAgent`. The connector interface signature is unchanged, so the MCP path inherits the fix.
- **C2 — never expand infra secrets into YAML** *(credential exfiltration)*. `expandEnv` interpolates `${VAR}` into the raw YAML document **before** `yaml.Unmarshal`. The allowlist accepted any `LOOMCYCLE_`-prefixed name plus bare `PG_DSN`, so an MCP `url: "https://x/?d=${PG_DSN}"` (or `${LOOMCYCLE_PG_DSN}` / `${LOOMCYCLE_AUTH_TOKEN}`) would exfiltrate loomcycle's own DB DSN / operator bearer to a third party. Dropped bare `PG_DSN` from the allow-switch and added a **tight named** `expandDenyNames` set `{PG_DSN, LOOMCYCLE_PG_DSN, LOOMCYCLE_AUTH_TOKEN}` consulted in `expandEnv`. Deliberately **not** a broad `*_TOKEN`/`*_SECRET` suffix deny — that would break the legitimate `${LOOMCYCLE_*_TOKEN}` an operator references in an MCP server's own auth header, and the webhook verify-secret path that reuses `ExpandEnvAllowed`.
- **I6 — reject newline values in expansion** *(YAML structure injection)*. Because expansion is on raw bytes pre-`Unmarshal`, an env value with a newline could inject new YAML keys/structure. `expandEnv` now leaves the literal `${name}` verbatim when the resolved value contains `\r`/`\n` — a visible "didn't expand" signal that can't corrupt the document, and avoids changing the shared helper's signature (the runtime `MCPServerDef` path calls the same `expandEnv`).
- **I1 — scope-gate `POST /v1/runs/{id}/input`** *(read-only bearer could steer)*. The operator-steering/continuation endpoint mutates live run state exactly like cancel/interrupt-resolve/compact, but `requiredScopeFor` had no case for the `/input` suffix → it fell through to any-authenticated. Added the `/input` → `runs:create` case (and a `/compact` row) to the scope map.

## What was tested

- `go build ./...`, `go vet ./internal/{config,api/http,store}/...`, `gofmt` clean.
- `go test ./...` — full suite green (71 packages).
- New fail-before regression tests:
  - `internal/config` `TestExpandEnv_DeniesInfraSecrets` (infra secrets stay verbatim; a non-secret `LOOMCYCLE_` var and a per-MCP `${LOOMCYCLE_*_TOKEN}` still expand) + `TestExpandEnv_RejectsNewlineValue`.
  - `internal/api/http` `TestRequiredScopeFor` extended with the `/input` + `/compact` rows.
  - `internal/store/storetest` `testAgentDefTenantIsolation` extended with the delete-isolation assertion — runs on **both** sqlite + Postgres (the `go-postgres` CI job). Confirmed fail-before by reverting the sqlite `WHERE` clause (the surviving-tenant read 404s).

## Out of scope (follow-up)

- The crash/correctness/hardening half: C3 (a2aServer nil-deref), I3 (scheduler dropped result-write error), I5 (channel O(N) check + swallowed errors), I7 (`idleReadCloser` timer race), I2 (Refresher double-Start), I4 (additive snapshot checksum) — second PR.
- I6 full structural safety (expand **after** `Unmarshal`, walking string fields) is a larger refactor; the newline-rejection closes the injection lever now.
- Deeper MCP-surface tenancy (the MCP ctx carries no authenticated tenant → operates in tenant `""`) — C1 closes the cross-tenant *delete*; broader MCP auth is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)