### PR TITLE
fix: exp7 crash/correctness/hardening findings — scheduler error log, channel point-lookup, snapshot checksum + 3 hardening (C3/I3/I5/I7/I2/I4)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2122,9 +2122,17 @@ func main() {
 		// v1.x RFC G — register the A2A gRPC binding on the same server.
 		// gRPC is not a path-mounted http.Handler (it needs the HTTP/2
 		// server), so the /a2a/grpc binding rides loomcycle's existing
-		// grpc.Server; the AgentCard advertises the gRPC port. Nil-safe
-		// when the A2A surface is disabled.
-		a2aServer.RegisterGRPC(grpcSrv)
+		// grpc.Server; the AgentCard advertises the gRPC port.
+		//
+		// Call-site nil-guard mirrors the other two a2aServer uses above
+		// (SetExtraMux at ~1426, PathTenantWrapper at ~1497): a2aServer is
+		// nil whenever A2AServerEnabled is off. RegisterGRPC is itself
+		// nil-receiver-safe, so this is defensive consistency rather than a
+		// live-crash fix — it stops the gRPC path depending on the callee's
+		// internal guard (exp7 C3).
+		if a2aServer != nil {
+			a2aServer.RegisterGRPC(grpcSrv)
+		}
 		grpcLis, err := net.Listen("tcp", cfg.Env.GrpcAddr)
 		if err != nil {
 			log.Fatalf("grpc listen %s: %v", cfg.Env.GrpcAddr, err)

--- a/internal/api/http/connector_impl_channels.go
+++ b/internal/api/http/connector_impl_channels.go
@@ -60,15 +60,21 @@ func (s *Server) requireChannelDeclared(ctx context.Context, name string) (chann
 		}, nil
 	}
 	if s.store != nil {
-		if rows, err := s.store.ChannelsList(ctx); err == nil {
-			for _, r := range rows {
-				if r.Name == name {
-					return channelDef{
-						MaxMessages: r.MaxMessages,
-						DefaultTTL:  r.DefaultTTL,
-					}, nil
-				}
-			}
+		// exp7 I5: point lookup (not an O(N) ChannelsList scan on every
+		// publish/subscribe/peek/ack), and propagate a genuine store fault
+		// instead of swallowing it — the old `if err == nil` masked any
+		// transient error as a spurious channel_not_declared denial.
+		row, err := s.store.ChannelGet(ctx, name)
+		switch {
+		case err == nil:
+			return channelDef{
+				MaxMessages: row.MaxMessages,
+				DefaultTTL:  row.DefaultTTL,
+			}, nil
+		case isNotFound(err):
+			// fall through to the not-declared signal below
+		default:
+			return channelDef{}, fmt.Errorf("channel lookup %q: %w", name, err)
 		}
 	}
 	return channelDef{}, fmt.Errorf("%w: %q", connector.ErrChannelNotDeclared, name)

--- a/internal/api/http/connector_impl_channels_test.go
+++ b/internal/api/http/connector_impl_channels_test.go
@@ -1,0 +1,101 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// channelGetErrStore embeds a real store but forces ChannelGet to fail with a
+// non-NotFound error — to exercise the I5 error-propagation path.
+type channelGetErrStore struct {
+	store.Store
+	err error
+}
+
+func (s channelGetErrStore) ChannelGet(context.Context, string) (store.ChannelRow, error) {
+	return store.ChannelRow{}, s.err
+}
+
+// TestRequireChannelDeclared_PropagatesStoreError pins exp7 I5: a genuine store
+// fault on the declared-check must surface as that error, NOT be swallowed into
+// a spurious channel_not_declared denial (the old code did `if err == nil`).
+// FAIL-BEFORE: with the swallow, the returned error wraps ErrChannelNotDeclared.
+func TestRequireChannelDeclared_PropagatesStoreError(t *testing.T) {
+	real, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+
+	srv := &Server{
+		cfg:   &config.Config{}, // no yaml channels → the store path is taken
+		store: channelGetErrStore{Store: real, err: errors.New("db-connection-lost")},
+	}
+
+	_, gotErr := srv.requireChannelDeclared(context.Background(), "anything")
+	if gotErr == nil {
+		t.Fatal("expected an error from a failing ChannelGet, got nil")
+	}
+	if errors.Is(gotErr, connector.ErrChannelNotDeclared) {
+		t.Errorf("store fault was masked as channel_not_declared: %v", gotErr)
+	}
+	if !strings.Contains(gotErr.Error(), "db-connection-lost") {
+		t.Errorf("store error not propagated; got %v", gotErr)
+	}
+}
+
+// TestRequireChannelDeclared_PointLookupResolvesAndNotFound covers the happy
+// paths: a runtime channel resolves via the point lookup (carrying its
+// MaxMessages/DefaultTTL), a yaml channel resolves without touching the store,
+// and an unknown name reports ErrChannelNotDeclared.
+func TestRequireChannelDeclared_PointLookupResolvesAndNotFound(t *testing.T) {
+	real, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+
+	ctx := context.Background()
+	if err := real.ChannelsCreate(ctx, store.ChannelRow{
+		Name: "runtime-q", Scope: "global", Semantic: "queue", MaxMessages: 7, DefaultTTL: 60,
+	}); err != nil {
+		t.Fatalf("ChannelsCreate: %v", err)
+	}
+
+	srv := &Server{
+		cfg: &config.Config{Channels: map[string]config.Channel{
+			"yaml-q": {Scope: "global", Semantic: "queue", MaxMessages: 3, DefaultTTL: 30},
+		}},
+		store: real,
+	}
+
+	// Runtime channel resolves via the point lookup with its own fields.
+	got, err := srv.requireChannelDeclared(ctx, "runtime-q")
+	if err != nil {
+		t.Fatalf("runtime-q: unexpected error %v", err)
+	}
+	if got.MaxMessages != 7 || got.DefaultTTL != 60 {
+		t.Errorf("runtime-q def = %+v, want MaxMessages=7 DefaultTTL=60", got)
+	}
+
+	// yaml channel resolves without the store.
+	got, err = srv.requireChannelDeclared(ctx, "yaml-q")
+	if err != nil {
+		t.Fatalf("yaml-q: unexpected error %v", err)
+	}
+	if got.MaxMessages != 3 || got.DefaultTTL != 30 {
+		t.Errorf("yaml-q def = %+v, want MaxMessages=3 DefaultTTL=30", got)
+	}
+
+	// Unknown name → not declared (a clean NotFound, not a propagated error).
+	if _, err := srv.requireChannelDeclared(ctx, "ghost"); !errors.Is(err, connector.ErrChannelNotDeclared) {
+		t.Errorf("ghost: err = %v, want ErrChannelNotDeclared", err)
+	}
+}

--- a/internal/providers/anthropic_oauth_dev/refresh.go
+++ b/internal/providers/anthropic_oauth_dev/refresh.go
@@ -17,10 +17,11 @@ type Refresher struct {
 	httpClient ExchangeOptions
 	logf       func(string, ...any) // nil = log.Printf
 
-	mu       sync.Mutex
-	stopOnce sync.Once
-	stopCh   chan struct{}
-	doneCh   chan struct{}
+	mu        sync.Mutex
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	doneCh    chan struct{}
 
 	// Token is the in-memory cache the driver reads on every request.
 	// kept in sync with the persisted file by the refresh goroutine.
@@ -52,17 +53,20 @@ func NewRefresher(store *TokenStore, opts ExchangeOptions, logf func(string, ...
 	return r
 }
 
-// Start launches the background refresh goroutine. Must be called
-// EXACTLY ONCE per Refresher lifetime; subsequent Start() calls panic
-// on the deferred close(doneCh) once the first goroutine exits. Stop()
-// must also be called exactly once, AFTER Start().
+// Start launches the background refresh goroutine. Idempotent: a second
+// Start() is a no-op (the first ctx wins) — exp7 I2 hardening. Previously a
+// double Start spawned two loops, each with `defer close(doneCh)`, so the
+// second goroutine's exit panicked on close-of-closed-channel. Stop() must
+// be called exactly once, AFTER Start().
 //
 // Used by the v0.11.9 provider registration in cmd/loomcycle/main.go
 // (one Start at boot, one Stop at shutdown). Callers needing
 // hot-reload semantics should construct a fresh Refresher rather than
 // re-starting an existing one.
 func (r *Refresher) Start(ctx context.Context) {
-	go r.loop(ctx)
+	r.startOnce.Do(func() {
+		go r.loop(ctx)
+	})
 }
 
 // Stop signals the refresh goroutine to exit + waits for it to finish.

--- a/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
+++ b/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
@@ -81,3 +81,27 @@ func TestRefresh_PostsWhenNoNewerOnDiskToken(t *testing.T) {
 		t.Errorf("Token = %q, want POSTED", got)
 	}
 }
+
+// TestRefresher_StartIsIdempotent pins exp7 I2: a double Start() must not
+// spawn a second refresh loop. Each loop runs `defer close(doneCh)`, so two
+// loops crash the process with close-of-closed-channel when the second exits.
+// startOnce makes the second Start a no-op. FAIL-BEFORE: without startOnce the
+// second loop panics during Stop's teardown.
+func TestRefresher_StartIsIdempotent(t *testing.T) {
+	store := NewTokenStore(t.TempDir() + "/tokens.json")
+	r := NewRefresher(store, ExchangeOptions{}, func(string, ...any) {})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r.Start(ctx)
+	r.Start(ctx) // must be a no-op, not a second loop
+
+	r.Stop()
+	r.Stop() // Stop stays idempotent too
+
+	// Give any (erroneously-spawned) second loop a window to run its deferred
+	// close(doneCh) and panic, so the fail-before is deterministic; harmless
+	// on the fixed single-loop path.
+	time.Sleep(50 * time.Millisecond)
+}

--- a/internal/providers/streamhttp/streamhttp.go
+++ b/internal/providers/streamhttp/streamhttp.go
@@ -133,8 +133,11 @@ func WrapBody(rc io.ReadCloser, idleTimeout time.Duration, cancel context.Cancel
 
 // idleReadCloser is the WrapBody implementation. The timer is created
 // in WrapBody (so we don't need a separate Start step) and torn down
-// in Close. Concurrent Close vs Read is allowed; the mutex makes Close
-// idempotent and prevents a double Stop on the timer.
+// in Close. Concurrent Close vs Read is allowed; the mutex serializes
+// every timer operation (Read's Reset vs Close's Stop), makes Close
+// idempotent, and prevents a double Stop — exp7 I7: Read previously
+// called timer.Reset unlocked while Close called timer.Stop after
+// releasing mu, racing two operations on the same *time.Timer.
 type idleReadCloser struct {
 	rc     io.ReadCloser
 	idle   time.Duration
@@ -146,13 +149,18 @@ type idleReadCloser struct {
 }
 
 func (i *idleReadCloser) Read(p []byte) (int, error) {
+	// Read on the underlying body stays OUTSIDE the lock — it blocks until
+	// bytes arrive, and holding mu would serialize a Close behind it.
 	n, err := i.rc.Read(p)
 	if n > 0 {
-		// Reset returns false when the timer was already fired/stopped;
-		// we don't care — if it already fired, cancel() ran and the next
-		// Read will see the context error. If it was stopped (Close),
-		// we're shutting down anyway.
-		i.timer.Reset(i.idle)
+		i.mu.Lock()
+		// Don't resurrect the timer after Close stopped it; otherwise
+		// serialize the Reset against Close's Stop. If the timer already
+		// fired, cancel() ran and the next Read sees the context error.
+		if !i.closed {
+			i.timer.Reset(i.idle)
+		}
+		i.mu.Unlock()
 	}
 	return n, err
 }
@@ -164,7 +172,9 @@ func (i *idleReadCloser) Close() error {
 		return nil
 	}
 	i.closed = true
-	i.mu.Unlock()
+	// Stop inside the critical section so it can never race a concurrent
+	// Read's Reset on the same timer.
 	i.timer.Stop()
+	i.mu.Unlock()
 	return i.rc.Close()
 }

--- a/internal/providers/streamhttp/streamhttp_test.go
+++ b/internal/providers/streamhttp/streamhttp_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -189,3 +190,58 @@ func TestOptions_Resolve(t *testing.T) {
 // Ensure errors.Is wires through cleanly for the cancellation case
 // (sanity check used elsewhere in this codebase).
 var _ = errors.Is
+
+// flipReadCloser returns one byte per Read until Close flips it to EOF.
+// Read never blocks long, so the concurrent Read/Close test churns the
+// timer Reset path against Close's Stop.
+type flipReadCloser struct{ closed atomic.Bool }
+
+func (f *flipReadCloser) Read(p []byte) (int, error) {
+	if f.closed.Load() {
+		return 0, io.EOF
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	p[0] = 'x'
+	return 1, nil
+}
+
+func (f *flipReadCloser) Close() error { f.closed.Store(true); return nil }
+
+// TestIdleReadCloser_ConcurrentReadClose drives Read (which resets the idle
+// timer) concurrently with Close (which stops it) — exp7 I7. The fix
+// serializes both timer operations under the mutex and refuses to reset the
+// timer after Close. Run under `go test -race` to catch any timer-access data
+// race; the loop also exercises the resurrect-after-close window the fix
+// closes (a Read must not re-arm a stopped timer).
+func TestIdleReadCloser_ConcurrentReadClose(t *testing.T) {
+	for iter := 0; iter < 100; iter++ {
+		rc := &flipReadCloser{}
+		ctx, cancel := context.WithCancel(context.Background())
+		body := WrapBody(rc, time.Millisecond, cancel)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			buf := make([]byte, 8)
+			for j := 0; j < 2000; j++ {
+				if _, err := body.Read(buf); err != nil {
+					return
+				}
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			_ = body.Close()
+		}()
+		wg.Wait()
+		// Double Close stays idempotent.
+		if err := body.Close(); err != nil {
+			t.Fatalf("second Close: %v", err)
+		}
+		cancel()
+		_ = ctx
+	}
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -248,13 +248,17 @@ func (s *Scheduler) tick(ctx context.Context) {
 					s.logf("scheduler: PANIC in fireOne(def_id=%s): %v", row.DefID, r)
 					// Best-effort park — re-use the same 1h fallback
 					// the cron-resolve failure path uses.
-					_ = s.store.ScheduleRunStateRecordResult(context.Background(), store.ScheduleRunResult{
+					if rerr := s.store.ScheduleRunStateRecordResult(context.Background(), store.ScheduleRunResult{
 						DefID:      row.DefID,
 						LastStatus: "failed",
 						LastError:  "panic in fireOne",
 						LastRunAt:  time.Now(),
 						NextRunAt:  time.Now().Add(1 * time.Hour),
-					})
+					}); rerr != nil {
+						// exp7 I3: if the park write also fails the def re-fires
+						// next tick — log so the panic→re-fire chain isn't silent.
+						s.logf("scheduler: def %q panic-park record-result failed: %v", row.DefID, rerr)
+					}
 				}
 			}()
 			s.fireOne(ctx, row, now)
@@ -407,12 +411,18 @@ func (s *Scheduler) advanceOnly(ctx context.Context, defID string, def scheduleD
 	if err != nil {
 		next = now.Add(1 * time.Hour)
 	}
-	_ = s.store.ScheduleRunStateRecordResult(ctx, store.ScheduleRunResult{
+	// exp7 I3: a dropped result-write leaves next_run_at unadvanced, so the
+	// def re-presents on every subsequent tick (a re-fire loop). A genuinely
+	// dead store can't advance state at all — logging is the most this path
+	// can do, but it makes the re-fire cause visible instead of silent.
+	if err := s.store.ScheduleRunStateRecordResult(ctx, store.ScheduleRunResult{
 		DefID:      defID,
 		LastStatus: reason,
 		LastRunAt:  now,
 		NextRunAt:  next,
-	})
+	}); err != nil {
+		s.logf("scheduler: def %q advance-only (%s) record-result failed: %v", defID, reason, err)
+	}
 }
 
 // recordFireFailure records an outcome when we never reached the
@@ -420,14 +430,17 @@ func (s *Scheduler) advanceOnly(ctx context.Context, defID string, def scheduleD
 // the def's cron can't be resolved.
 func (s *Scheduler) recordFireFailure(ctx context.Context, defID, runID, status string, err error, now time.Time) {
 	s.logf("scheduler: def %q fire-failed (%s): %v", defID, status, err)
-	_ = s.store.ScheduleRunStateRecordResult(ctx, store.ScheduleRunResult{
+	// exp7 I3: surface a dropped result-write — see advanceOnly above.
+	if rerr := s.store.ScheduleRunStateRecordResult(ctx, store.ScheduleRunResult{
 		DefID:      defID,
 		LastRunID:  runID,
 		LastStatus: status,
 		LastError:  err.Error(),
 		LastRunAt:  now,
 		NextRunAt:  now.Add(1 * time.Hour),
-	})
+	}); rerr != nil {
+		s.logf("scheduler: def %q record fire-failure result failed: %v", defID, rerr)
+	}
 }
 
 // computeNext picks the cron from the def and returns the next-fire time

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -711,3 +711,82 @@ func TestScheduler_InFlightSuppressesDoubleFire(t *testing.T) {
 		t.Errorf("calls = %d, want 1 (in-flight tracker should have suppressed re-fires while the first fire was running)", got)
 	}
 }
+
+// recordResultErrStore embeds a real store but forces every
+// ScheduleRunStateRecordResult to fail — exercising the I3 dropped-error
+// paths without needing a genuinely broken backend.
+type recordResultErrStore struct {
+	store.Store
+	err error
+}
+
+func (s recordResultErrStore) ScheduleRunStateRecordResult(context.Context, store.ScheduleRunResult) error {
+	return s.err
+}
+
+// TestScheduler_AdvanceOnly_LogsDroppedResultWriteError pins exp7 I3: when the
+// result-write fails, next_run_at can't advance and the def re-presents every
+// tick (a re-fire loop). The scheduler previously swallowed the error (`_ =`),
+// hiding the cause. Now it logs. FAIL-BEFORE: with the dropped `_ =` the
+// captured log is empty and this test fails.
+func TestScheduler_AdvanceOnly_LogsDroppedResultWriteError(t *testing.T) {
+	real, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+
+	var mu sync.Mutex
+	var logged strings.Builder
+	logf := func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(&logged, format, args...)
+		logged.WriteByte('\n')
+	}
+
+	st := recordResultErrStore{Store: real, err: errors.New("boom-write-failed")}
+	sched := New(Config{TickInterval: time.Hour}, st, &fakeRunner{}, nil, nil, logf)
+
+	// Empty Schedule → computeNext errors → 1h-park fallback, then the
+	// record-result write fails and must be logged (not swallowed).
+	sched.advanceOnly(context.Background(), "sd-x", scheduleDef{}, "skipped", time.Now())
+
+	mu.Lock()
+	out := logged.String()
+	mu.Unlock()
+	if !strings.Contains(out, "record-result failed") || !strings.Contains(out, "boom-write-failed") {
+		t.Errorf("advanceOnly did not log the dropped result-write error; captured log:\n%s", out)
+	}
+}
+
+// TestScheduler_RecordFireFailure_LogsDroppedResultWriteError mirrors the above
+// for the recordFireFailure path (exp7 I3).
+func TestScheduler_RecordFireFailure_LogsDroppedResultWriteError(t *testing.T) {
+	real, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = real.Close() })
+
+	var mu sync.Mutex
+	var logged strings.Builder
+	logf := func(format string, args ...any) {
+		mu.Lock()
+		defer mu.Unlock()
+		fmt.Fprintf(&logged, format, args...)
+		logged.WriteByte('\n')
+	}
+
+	st := recordResultErrStore{Store: real, err: errors.New("boom-write-failed")}
+	sched := New(Config{TickInterval: time.Hour}, st, &fakeRunner{}, nil, nil, logf)
+
+	sched.recordFireFailure(context.Background(), "sd-y", "r1", "failed", errors.New("decode"), time.Now())
+
+	mu.Lock()
+	out := logged.String()
+	mu.Unlock()
+	if !strings.Contains(out, "record fire-failure result failed") || !strings.Contains(out, "boom-write-failed") {
+		t.Errorf("recordFireFailure did not log the dropped result-write error; captured log:\n%s", out)
+	}
+}

--- a/internal/snapshot/export.go
+++ b/internal/snapshot/export.go
@@ -1,6 +1,8 @@
 package snapshot
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 )
@@ -20,20 +22,38 @@ import (
 // the canonical form is what the restore path consumes, so keep it
 // minimal.
 //
-// Export does NOT include an envelope-level checksum or signature.
-// That's left to the transport layer: HTTP responses include
-// Content-Length; the snapshots table stores byte_size; operators
-// transferring snapshot files between hosts use external tools
-// (sha256sum, signed transfer) when integrity matters.
+// Export stamps an additive "sha256:<hex>" Checksum over the canonical
+// Sections bytes (exp7 I4) so Restore can detect a truncated/tampered body
+// before touching the store. It remains backward-compatible — Restore only
+// verifies the digest when present, so older readers and older snapshots are
+// unaffected. Transport-level integrity (Content-Length, the snapshots
+// table's byte_size, signed transfer) still applies on top.
 func Export(env *Envelope) ([]byte, error) {
 	if env == nil {
 		return nil, fmt.Errorf("snapshot export: nil envelope")
 	}
-	b, err := json.Marshal(env)
+	// Hash the canonical Sections bytes — identical to the "sections" value
+	// that ends up in the marshalled document, since encoding/json marshals
+	// a field value the same standalone as embedded. Stamp on a copy so the
+	// caller's envelope is not mutated.
+	sectionBytes, err := json.Marshal(env.Sections)
+	if err != nil {
+		return nil, fmt.Errorf("snapshot export: marshal sections: %w", err)
+	}
+	out := *env
+	out.Checksum = sectionChecksum(sectionBytes)
+	b, err := json.Marshal(&out)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot export: marshal: %w", err)
 	}
 	return b, nil
+}
+
+// sectionChecksum returns the canonical "sha256:<hex>" digest of the given
+// section bytes. Shared by Export (stamp) and Restore (verify).
+func sectionChecksum(sectionBytes []byte) string {
+	sum := sha256.Sum256(sectionBytes)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 // ExportPretty produces indented JSON for human inspection. Used by

--- a/internal/snapshot/memory_embedding_test.go
+++ b/internal/snapshot/memory_embedding_test.go
@@ -323,6 +323,13 @@ func TestRestore_BadBase64InEmbeddingRecordsWarningAndContinues(t *testing.T) {
 	// Corrupt the vector base64 in the envelope.
 	corrupted := strings.Replace(string(jsonBytes),
 		`"vector":"`, `"vector":"!!not-base64!!`, 1)
+	// Re-stamp the I4 integrity checksum over the corrupted-but-structurally-
+	// valid document: this test models a SELF-CONSISTENT snapshot that
+	// legitimately carries a malformed embedding value (a downstream
+	// decode-warning case), NOT an in-transit truncation/tamper (which the
+	// checksum rightly rejects). Without re-stamping, Capture's checksum no
+	// longer matches the mutated body and Restore would reject it outright.
+	corrupted = restampSectionChecksum(t, corrupted)
 
 	dstBase, cleanupDst := newTestStore(t)
 	defer cleanupDst()

--- a/internal/snapshot/restore.go
+++ b/internal/snapshot/restore.go
@@ -94,15 +94,34 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	// so each section's raw bytes can pass through Migrate() before
 	// being typed-decoded — that's the migration mechanism's hook.
 	var outer struct {
-		SchemaVersion int                        `json:"schema_version"`
-		CreatedAt     time.Time                  `json:"created_at"`
-		Sections      map[string]json.RawMessage `json:"sections"`
+		SchemaVersion int             `json:"schema_version"`
+		CreatedAt     time.Time       `json:"created_at"`
+		Sections      json.RawMessage `json:"sections"`
+		Checksum      string          `json:"checksum,omitempty"`
 	}
 	if err := json.Unmarshal(raw, &outer); err != nil {
 		return RestoreResult{}, fmt.Errorf("snapshot restore: parse envelope: %w", err)
 	}
 	if outer.SchemaVersion > SchemaVersion {
 		return RestoreResult{}, fmt.Errorf("snapshot restore: envelope schema_version %d is newer than reader %d", outer.SchemaVersion, SchemaVersion)
+	}
+
+	// exp7 I4: verify the integrity digest BEFORE any decode/insert, when
+	// present. outer.Sections holds the raw "sections" bytes exactly as they
+	// appear in the document (json.RawMessage), so hashing them reproduces
+	// Export's digest. A snapshot without a checksum (captured before I4)
+	// skips verification and restores unchanged — additive, not a gate.
+	if outer.Checksum != "" {
+		if got := sectionChecksum(outer.Sections); got != outer.Checksum {
+			return RestoreResult{}, fmt.Errorf("snapshot restore: checksum mismatch (want %s, got %s) — snapshot is truncated or tampered", outer.Checksum, got)
+		}
+	}
+
+	// Decode the section map from the raw sections bytes for the per-section
+	// migration + insert logic below.
+	var sections map[string]json.RawMessage
+	if err := json.Unmarshal(outer.Sections, &sections); err != nil {
+		return RestoreResult{}, fmt.Errorf("snapshot restore: parse sections: %w", err)
 	}
 
 	result := RestoreResult{}
@@ -112,7 +131,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	// sessions before paused_runs).
 
 	// agent_defs
-	if rawSection, ok := outer.Sections[migrations.SectionAgentDefs]; ok {
+	if rawSection, ok := sections[migrations.SectionAgentDefs]; ok {
 		var sec AgentDefsSection
 		if err := decodeWithMigration(migrations.SectionAgentDefs, rawSection, &sec); err != nil {
 			return result, err
@@ -143,7 +162,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// agent_def_active (after agent_defs for FK)
-	if rawSection, ok := outer.Sections[migrations.SectionAgentDefActive]; ok {
+	if rawSection, ok := sections[migrations.SectionAgentDefActive]; ok {
 		var sec AgentDefActiveSection
 		if err := decodeWithMigration(migrations.SectionAgentDefActive, rawSection, &sec); err != nil {
 			return result, err
@@ -166,7 +185,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// skill_defs (v0.8.22) — mirror of agent_defs restore
-	if rawSection, ok := outer.Sections[migrations.SectionSkillDefs]; ok {
+	if rawSection, ok := sections[migrations.SectionSkillDefs]; ok {
 		var sec SkillDefsSection
 		if err := decodeWithMigration(migrations.SectionSkillDefs, rawSection, &sec); err != nil {
 			return result, err
@@ -197,7 +216,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// skill_def_active (after skill_defs for FK)
-	if rawSection, ok := outer.Sections[migrations.SectionSkillDefActive]; ok {
+	if rawSection, ok := sections[migrations.SectionSkillDefActive]; ok {
 		var sec SkillDefActiveSection
 		if err := decodeWithMigration(migrations.SectionSkillDefActive, rawSection, &sec); err != nil {
 			return result, err
@@ -220,7 +239,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// mcp_server_defs (v0.9.x) — mirror of agent_defs / skill_defs restore
-	if rawSection, ok := outer.Sections[migrations.SectionMCPServerDefs]; ok {
+	if rawSection, ok := sections[migrations.SectionMCPServerDefs]; ok {
 		var sec MCPServerDefsSection
 		if err := decodeWithMigration(migrations.SectionMCPServerDefs, rawSection, &sec); err != nil {
 			return result, err
@@ -251,7 +270,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// mcp_server_def_active (after mcp_server_defs for FK)
-	if rawSection, ok := outer.Sections[migrations.SectionMCPServerDefActive]; ok {
+	if rawSection, ok := sections[migrations.SectionMCPServerDefActive]; ok {
 		var sec MCPServerDefActiveSection
 		if err := decodeWithMigration(migrations.SectionMCPServerDefActive, rawSection, &sec); err != nil {
 			return result, err
@@ -275,7 +294,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 
 	// memory (no FK; embedding field carried but Phase 1 always
 	// null; Phase 2 will populate)
-	if rawSection, ok := outer.Sections[migrations.SectionMemory]; ok {
+	if rawSection, ok := sections[migrations.SectionMemory]; ok {
 		var sec MemorySection
 		if err := decodeWithMigration(migrations.SectionMemory, rawSection, &sec); err != nil {
 			return result, err
@@ -350,7 +369,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	// yaml-side; restore doesn't write it back into a table — the
 	// operator on the restoring host reconciles against their own
 	// yaml. Messages + cursors get raw inserts.
-	if rawSection, ok := outer.Sections[migrations.SectionChannels]; ok {
+	if rawSection, ok := sections[migrations.SectionChannels]; ok {
 		var sec ChannelsSection
 		if err := decodeWithMigration(migrations.SectionChannels, rawSection, &sec); err != nil {
 			return result, err
@@ -407,7 +426,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	// evaluations (no FK enforced — runs.agent_def_id is
 	// denormalised at submit time; runs may not even exist on the
 	// restoring host)
-	if rawSection, ok := outer.Sections[migrations.SectionEvaluations]; ok {
+	if rawSection, ok := sections[migrations.SectionEvaluations]; ok {
 		var sec EvaluationsSection
 		if err := decodeWithMigration(migrations.SectionEvaluations, rawSection, &sec); err != nil {
 			return result, err
@@ -437,7 +456,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 	}
 
 	// paused_runs (after sessions are synthesized — FK on session_id)
-	if rawSection, ok := outer.Sections[migrations.SectionPausedRuns]; ok {
+	if rawSection, ok := sections[migrations.SectionPausedRuns]; ok {
 		var sec PausedRunsSection
 		if err := decodeWithMigration(migrations.SectionPausedRuns, rawSection, &sec); err != nil {
 			return result, err
@@ -522,7 +541,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 
 	// interaction_history (optional, opt-in via RestoreOptions)
 	if opts.IncludeHistory {
-		if rawSection, ok := outer.Sections[migrations.SectionInteractionHistory]; ok {
+		if rawSection, ok := sections[migrations.SectionInteractionHistory]; ok {
 			var sec InteractionHistorySection
 			if err := decodeWithMigration(migrations.SectionInteractionHistory, rawSection, &sec); err != nil {
 				return result, err
@@ -540,7 +559,7 @@ func Restore(ctx context.Context, s store.Store, raw []byte, opts RestoreOptions
 					"interaction_history events in envelope: Phase 1 restore does not write these back yet; see snapshot.go captureInteractionHistory")
 			}
 		}
-	} else if _, ok := outer.Sections[migrations.SectionInteractionHistory]; ok {
+	} else if _, ok := sections[migrations.SectionInteractionHistory]; ok {
 		result.Warnings = append(result.Warnings,
 			"interaction_history section present in snapshot but RestoreOptions.IncludeHistory=false; skipped")
 	}

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -718,3 +718,129 @@ func mustParseTime(t *testing.T, s string) time.Time {
 	}
 	return tt
 }
+
+// restampSectionChecksum recomputes the I4 integrity checksum over a
+// (possibly mutated) but structurally valid snapshot document and writes it
+// back, so the document is self-consistent again. Used by tests that
+// deliberately mutate section CONTENT (e.g. a malformed embedding) and want
+// Restore to reach the downstream warning path rather than reject on the
+// digest. Lives here so package-internal tests can share it.
+func restampSectionChecksum(t *testing.T, doc string) string {
+	t.Helper()
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(doc), &m); err != nil {
+		t.Fatalf("restamp: parse: %v", err)
+	}
+	cs, err := json.Marshal(sectionChecksum(m["sections"]))
+	if err != nil {
+		t.Fatalf("restamp: marshal checksum: %v", err)
+	}
+	m["checksum"] = cs
+	out, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("restamp: marshal: %v", err)
+	}
+	return string(out)
+}
+
+// mkChecksumEnvelope builds a minimal envelope with one agent def, carrying a
+// recognisable description for tamper tests.
+func mkChecksumEnvelope(t *testing.T) Envelope {
+	t.Helper()
+	return Envelope{
+		SchemaVersion: SchemaVersion,
+		CreatedAt:     mustParseTime(t, "2026-01-01T00:00:00Z"),
+		Sections: Sections{
+			AgentDefs: AgentDefsSection{
+				Version: SectionVersion,
+				Entries: []AgentDefEntry{{
+					DefID:       "d1",
+					Name:        "alpha",
+					Version:     1,
+					Definition:  json.RawMessage(`{"model":"x"}`),
+					Description: "ORIGINAL_DESCRIPTION_TOKEN",
+					CreatedAt:   mustParseTime(t, "2026-01-01T00:00:00Z"),
+				}},
+			},
+		},
+	}
+}
+
+// TestExportRestore_ChecksumRoundTrip pins exp7 I4: Export stamps a
+// sha256:<hex> checksum over the section bytes and Restore accepts the
+// round-trip.
+func TestExportRestore_ChecksumRoundTrip(t *testing.T) {
+	env := mkChecksumEnvelope(t)
+	raw, err := Export(&env)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if !strings.Contains(string(raw), `"checksum":"sha256:`) {
+		t.Fatalf("Export output carries no sha256 checksum: %s", raw)
+	}
+	// Export must NOT mutate the caller's envelope.
+	if env.Checksum != "" {
+		t.Errorf("Export mutated caller's envelope Checksum = %q, want empty", env.Checksum)
+	}
+
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	res, err := Restore(context.Background(), dst, raw, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore of a valid checksummed snapshot failed: %v", err)
+	}
+	if res.AgentDefsRestored != 1 {
+		t.Errorf("AgentDefsRestored = %d, want 1", res.AgentDefsRestored)
+	}
+}
+
+// TestRestore_RejectsTamperedBodyWithStaleChecksum pins the integrity gate: a
+// body mutated AFTER Export (without re-stamping) is rejected before any
+// decode/insert.
+func TestRestore_RejectsTamperedBodyWithStaleChecksum(t *testing.T) {
+	env := mkChecksumEnvelope(t)
+	raw, err := Export(&env)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	// Flip a section byte without recomputing the checksum.
+	tampered := strings.Replace(string(raw), "ORIGINAL_DESCRIPTION_TOKEN", "TAMPERED_DESCRIPTION_XXXX", 1)
+	if tampered == string(raw) {
+		t.Fatal("tamper no-op — token not found in export")
+	}
+
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	_, err = Restore(context.Background(), dst, []byte(tampered), RestoreOptions{})
+	if err == nil {
+		t.Fatal("Restore accepted a tampered body with a stale checksum")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Errorf("err = %v, want a checksum mismatch", err)
+	}
+}
+
+// TestRestore_LegacySnapshotWithoutChecksumStillRestores pins backward-compat:
+// a snapshot captured before I4 (no checksum field) restores unchanged.
+func TestRestore_LegacySnapshotWithoutChecksumStillRestores(t *testing.T) {
+	env := mkChecksumEnvelope(t)
+	// Marshal directly (NOT via Export) so the document carries no checksum —
+	// the pre-I4 producer shape (env.Checksum == "" → omitempty drops it).
+	legacy, err := json.Marshal(&env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(legacy), `"checksum"`) {
+		t.Fatalf("legacy fixture unexpectedly carries a checksum: %s", legacy)
+	}
+
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	res, err := Restore(context.Background(), dst, legacy, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("Restore of a checksum-less (legacy) snapshot failed: %v", err)
+	}
+	if res.AgentDefsRestored != 1 {
+		t.Errorf("AgentDefsRestored = %d, want 1", res.AgentDefsRestored)
+	}
+}

--- a/internal/snapshot/snapshot.go
+++ b/internal/snapshot/snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -141,9 +140,13 @@ func Capture(ctx context.Context, s store.Store, opts CaptureOptions) (*store.Sn
 		envelope.Sections.InteractionHistory = hist
 	}
 
-	jsonBytes, err := json.Marshal(envelope)
+	// Route through Export so the produced snapshot carries the additive
+	// integrity checksum (exp7 I4) — Capture is the production path (HTTP
+	// /v1/_snapshot + the connector), so stamping only in Export would leave
+	// real snapshots unprotected.
+	jsonBytes, err := Export(envelope)
 	if err != nil {
-		return nil, nil, fmt.Errorf("snapshot capture: marshal envelope: %w", err)
+		return nil, nil, fmt.Errorf("snapshot capture: %w", err)
 	}
 	if int64(len(jsonBytes)) > maxBytes {
 		return nil, nil, &ErrSnapshotTooLarge{

--- a/internal/snapshot/types.go
+++ b/internal/snapshot/types.go
@@ -52,6 +52,13 @@ type Envelope struct {
 	SchemaVersion int       `json:"schema_version"`
 	CreatedAt     time.Time `json:"created_at"`
 	Sections      Sections  `json:"sections"`
+	// Checksum is an OPTIONAL "sha256:<hex>" digest over the canonical JSON
+	// bytes of the Sections object (exp7 I4). Additive + backward-compatible:
+	// Export stamps it, Restore verifies it ONLY when present — snapshots
+	// captured before this field (no checksum) still restore unchanged.
+	// omitempty keeps pre-checksum readers byte-identical and lets the
+	// human-only ExportPretty path omit it.
+	Checksum string `json:"checksum,omitempty"`
 }
 
 // Sections is the named section map. Each field is the section's

--- a/internal/store/postgres/channels.go
+++ b/internal/store/postgres/channels.go
@@ -48,6 +48,34 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	return out, rows.Err()
 }
 
+// ChannelGet returns one runtime-declared channel by name. Returns
+// *store.ErrNotFound{Kind:"channel"} when the name has no runtime row
+// (exp7 I5: a point lookup for the hot declared-check, so a real query
+// fault surfaces as an error instead of an empty scan masquerading as
+// "not declared").
+func (s *Store) ChannelGet(ctx context.Context, name string) (store.ChannelRow, error) {
+	var r store.ChannelRow
+	var createdAt time.Time
+	err := s.pool.QueryRow(ctx, `
+		SELECT name, description, scope, semantic,
+		       default_ttl, max_messages, publisher, period, created_at
+		FROM channels
+		WHERE name = $1
+	`, name).Scan(
+		&r.Name, &r.Description, &r.Scope, &r.Semantic,
+		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
+		&createdAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
+	}
+	if err != nil {
+		return store.ChannelRow{}, fmt.Errorf("channel get: %w", err)
+	}
+	r.CreatedAt = createdAt.UTC()
+	return r, nil
+}
+
 // ChannelsCreate inserts a new runtime channel. Returns
 // *store.ErrConflict{Kind:"channel", ID:name} on PK violation
 // (Postgres SQLSTATE 23505 = unique_violation).

--- a/internal/store/sqlite/channels.go
+++ b/internal/store/sqlite/channels.go
@@ -45,6 +45,34 @@ func (s *Store) ChannelsList(ctx context.Context) ([]store.ChannelRow, error) {
 	return out, rows.Err()
 }
 
+// ChannelGet returns one runtime-declared channel by name. Returns
+// *store.ErrNotFound{Kind:"channel"} when the name has no runtime row
+// (exp7 I5: a point lookup for the hot declared-check, so a real query
+// fault surfaces as an error instead of an empty scan masquerading as
+// "not declared").
+func (s *Store) ChannelGet(ctx context.Context, name string) (store.ChannelRow, error) {
+	var r store.ChannelRow
+	var createdNano int64
+	err := s.db.QueryRowContext(ctx, `
+		SELECT name, description, scope, semantic,
+		       default_ttl, max_messages, publisher, period, created_at
+		FROM channels
+		WHERE name = ?
+	`, name).Scan(
+		&r.Name, &r.Description, &r.Scope, &r.Semantic,
+		&r.DefaultTTL, &r.MaxMessages, &r.Publisher, &r.Period,
+		&createdNano,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return store.ChannelRow{}, &store.ErrNotFound{Kind: "channel", ID: name}
+	}
+	if err != nil {
+		return store.ChannelRow{}, fmt.Errorf("channel get: %w", err)
+	}
+	r.CreatedAt = time.Unix(0, createdNano).UTC()
+	return r, nil
+}
+
 // ChannelsCreate inserts a new runtime channel. Returns
 // *store.ErrConflict{Kind:"channel", ID:name} on PK violation
 // (the substrate's standard duplicate-row signal).

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1558,6 +1558,15 @@ type Store interface {
 	// happens in the HTTP handler.
 	ChannelsList(ctx context.Context) ([]ChannelRow, error)
 
+	// ChannelGet returns one runtime-declared channel by name. Returns
+	// *ErrNotFound{Kind:"channel"} when the name isn't in the runtime
+	// table (yaml-declared channels are NOT here — the caller checks
+	// cfg.Channels first). A point lookup so the hot publish/subscribe/
+	// peek/ack declared-check doesn't scan the whole table per op, and
+	// so a real store fault surfaces as an error instead of an empty
+	// list that masquerades as "not declared" (exp7 I5).
+	ChannelGet(ctx context.Context, name string) (ChannelRow, error)
+
 	// ChannelsCreate inserts a new runtime channel. Returns
 	// *ErrConflict{Kind:"channel"} when a runtime row with the
 	// same name already exists. yaml-name collisions are caught

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -174,6 +174,7 @@ func Run(t *testing.T, factory Factory) {
 		{"ChannelReplayFromCursorZero", testChannelReplayFromCursorZero},
 		{"ChannelStatsAggregatesNonExpired", testChannelStatsAggregatesNonExpired},
 		{"ChannelStatsEmptyOnNoMessages", testChannelStatsEmptyOnNoMessages},
+		{"ChannelGetPointLookup", testChannelGetPointLookup},
 		// v0.8.6 deferred publish (PR 1)
 		{"ChannelDeferredHiddenUntilVisible", testChannelDeferredHiddenUntilVisible},
 		{"ChannelDeferredDeliversAfterProgressedCursor", testChannelDeferredDeliversAfterProgressedCursor},
@@ -3245,6 +3246,35 @@ func testChannelStatsEmptyOnNoMessages(t *testing.T, s store.Store) {
 	}
 	if len(stats) != 0 {
 		t.Errorf("expected empty stats, got %d rows: %+v", len(stats), stats)
+	}
+}
+
+// testChannelGetPointLookup pins exp7 I5's new ChannelGet: an existing
+// runtime-declared channel resolves by name with its persisted fields; a
+// missing name returns a typed *store.ErrNotFound (so the connector can
+// distinguish "not declared" from a real store fault).
+func testChannelGetPointLookup(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if err := s.ChannelsCreate(ctx, store.ChannelRow{
+		Name: "cg-point", Description: "d", Scope: "global", Semantic: "queue",
+		DefaultTTL: 90, MaxMessages: 11, Publisher: "system", Period: "1m",
+	}); err != nil {
+		t.Fatalf("ChannelsCreate: %v", err)
+	}
+
+	got, err := s.ChannelGet(ctx, "cg-point")
+	if err != nil {
+		t.Fatalf("ChannelGet(existing): %v", err)
+	}
+	if got.Name != "cg-point" || got.MaxMessages != 11 || got.DefaultTTL != 90 ||
+		got.Scope != "global" || got.Semantic != "queue" || got.Publisher != "system" || got.Period != "1m" {
+		t.Errorf("ChannelGet round-trip mismatch: %+v", got)
+	}
+
+	_, err = s.ChannelGet(ctx, "cg-absent")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("ChannelGet(missing): got %v (%T), want *store.ErrNotFound", err, err)
 	}
 }
 


### PR DESCRIPTION
## Why

Second half of the exp7 self-review top-10 (the security/isolation half is #462). These are the crash / correctness / hardening findings. As with #462, I verified each against current `main` before acting — and two findings (C3, I7) turned out **not** to be live bugs; I kept the changes as honest defensive hardening and say so explicitly below and in the commits.

## What

- **I3 — scheduler dropped result-write error** *(correctness)*. `advanceOnly`, `recordFireFailure`, and the `fireOne` panic-park defer all discarded `ScheduleRunStateRecordResult`'s error with `_ =`. When that write fails, `next_run_at` never advances and the def re-presents on every tick — a silent re-fire loop. Now all three check + `s.logf` the error (mirroring the existing `fireOne` record-result log). A dead store still can't advance state; logging makes the cause visible.
- **I5 — channel declared-check: O(N) scan + swallowed errors** *(correctness + perf)*. `requireChannelDeclared` (per publish/subscribe/peek/ack) called `ChannelsList` and linear-scanned the whole table, and `if err == nil` swallowed any store fault into a spurious `ErrChannelNotDeclared`. Added `Store.ChannelGet(ctx, name)` (point lookup, `*ErrNotFound` on miss) to both backends; the check now resolves on hit, falls through to not-declared only on a typed NotFound, and **propagates** any other store error.
- **I4 — snapshot integrity checksum** *(hardening)*. `Export` delegated integrity to the transport. Added an **optional** `checksum:"sha256:<hex>"` on `Envelope` over the canonical `Sections` bytes; `Export` stamps it (on a copy), `Capture` (the production path) routes through `Export` so real snapshots carry it, and `Restore` **verifies-if-present** before any decode/insert. Backward-compatible: a pre-I4 snapshot (no checksum) restores unchanged; a present-but-mismatched checksum is rejected up front; older readers ignore the field.
- **C3 — `a2aServer.RegisterGRPC` call-site guard** *(NOT a live bug; consistency)*. exp7 flagged a nil-deref when gRPC is on + A2A off. On inspection `RegisterGRPC` already guards its own nil receiver (`if s == nil …`), so there is **no panic**. But the two other `a2aServer` uses in `main.go` guard at the call site; this one relied on the callee's internal guard. Wrapped it in `if a2aServer != nil` for consistency / to drop that coupling.
- **I7 — `idleReadCloser` timer serialization** *(NOT a -race bug; hardening)*. exp7 claimed a `time.Timer` data race "fails -race." Verified it does **not**: for an `AfterFunc` timer the Go runtime serializes concurrent `Reset`/`Stop`, and the new concurrent test passes under `-race` on **both** old and new code. What the fix buys: it closes the resurrect-after-`Close` window (a `Read` re-arming a stopped timer) and makes timer access explicitly mutex-guarded (the old comment overstated the guard).
- **I2 — `Refresher.Start` idempotency** *(hardening)*. A double `Start` spawned two refresh loops, each `defer close(doneCh)` → close-of-closed-channel panic (its own doc warned of this). Today it's called once at boot, so not a live bug. Added `startOnce` mirroring `stopOnce`.

## What was tested

- `go build ./...`, `go vet ./...`, `gofmt` clean.
- `go test ./...` — full suite green (71 packages). `-race` clean on `streamhttp`, `anthropic_oauth_dev`, `scheduler`.
- New fail-before regression tests per fix:
  - scheduler: `TestScheduler_AdvanceOnly_*` / `_RecordFireFailure_LogsDroppedResultWriteError` (record-result-failing store stub; asserts the captured log).
  - channels: `TestRequireChannelDeclared_PropagatesStoreError` / `_PointLookupResolvesAndNotFound` + store-contract `testChannelGetPointLookup` (runs on sqlite **and** Postgres).
  - snapshot: `TestExportRestore_ChecksumRoundTrip`, `TestRestore_RejectsTamperedBodyWithStaleChecksum` (fail-before: disabling the verify accepts it), `TestRestore_LegacySnapshotWithoutChecksumStillRestores`.
  - oauth: `TestRefresher_StartIsIdempotent` (fail-before: unfixed panics close-of-closed-channel).
  - streamhttp: `TestIdleReadCloser_ConcurrentReadClose` (`-race`).

## Note on ordering

Branched off `main` independently of #462 (one-PR-per-feature). Both PRs touch `internal/store/store.go` (different new methods) + `internal/store/storetest/contract.go` (different test additions); merge #462 first and this rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)