### PR TITLE
feat: RFC Y external fan-out run — POST /v1/runs:batch + spawn_runs MCP tool

### DIFF
--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -738,6 +738,9 @@ func (m *mockConnector) CancelRun(_ context.Context, agentID, reason string) (co
 func (m *mockConnector) SpawnRun(context.Context, connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
 	return connector.SpawnRunResult{}, nil
 }
+func (m *mockConnector) SpawnRunBatch(context.Context, connector.BatchSpawnRequest) (connector.BatchSpawnResult, error) {
+	return connector.BatchSpawnResult{}, nil
+}
 func (m *mockConnector) GetRun(context.Context, string) (connector.Run, error) {
 	return connector.Run{}, nil
 }

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -451,6 +451,11 @@ func requiredScopeFor(method, path string) string {
 	// Run creation (fresh run + session continuation message).
 	case method == http.MethodPost && path == "/v1/runs":
 		return auth.ScopeRunsCreate
+	// RFC Y fan-out spawns N runs in one call — same create scope as /v1/runs.
+	// Exact match (not the /v1/runs/ prefix), so it's not shadowed by the
+	// per-run write cases below.
+	case method == http.MethodPost && path == "/v1/runs:batch":
+		return auth.ScopeRunsCreate
 	case method == http.MethodPost && strings.HasPrefix(path, "/v1/sessions/") && strings.HasSuffix(path, "/messages"):
 		return auth.ScopeRunsCreate
 	// Cancel a run — a write on run state. (The real route is POST

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -191,6 +191,8 @@ func TestRequiredScopeFor(t *testing.T) {
 		method, path, want string
 	}{
 		{"POST", "/v1/runs", auth.ScopeRunsCreate},
+		// RFC Y fan-out is a create op (exact path, not the /v1/runs/ prefix).
+		{"POST", "/v1/runs:batch", auth.ScopeRunsCreate},
 		{"POST", "/v1/sessions/s_1/messages", auth.ScopeRunsCreate},
 		// Cancel is POST /v1/agents/{id}/cancel — must be runs:create (was a
 		// dead DELETE case → any-authenticated).

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/channels"
@@ -124,6 +125,77 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		result.Error = lastErrorMsg
 	}
 	return result, nil
+}
+
+// SpawnRunBatch implements the RFC Y external fan-out (mode "join"): spawn every
+// child concurrently via SpawnRun and join them. Each child flows through the
+// SAME per-user admission gate as a lone SpawnRun (RunOnce → sem.AcquireForUser),
+// so there is deliberately NO wrapper semaphore here — admission back-pressure
+// and per-user fairness are already enforced one level down, and adding a second
+// gate would only double-count. The batch caller's ctx (carrying the
+// authoritative principal/tenant from the auth middleware) is passed to every
+// child, so children inherit the caller's tenant via the normal WithRunIdentity
+// path — no manual tenant threading. Per-child failures are captured in that
+// child's SpawnRunResult; the batch itself errors only on a malformed request
+// (over-cap / unsupported mode).
+func (s *Server) SpawnRunBatch(ctx context.Context, req connector.BatchSpawnRequest) (connector.BatchSpawnResult, error) {
+	n := len(req.Spawns)
+	if n == 0 {
+		return connector.BatchSpawnResult{}, fmt.Errorf("spawn_runs: no spawns supplied")
+	}
+	if n > connector.MaxBatchSpawns {
+		return connector.BatchSpawnResult{}, fmt.Errorf("spawn_runs: %d spawns exceeds the per-batch cap of %d", n, connector.MaxBatchSpawns)
+	}
+	mode := req.Mode
+	if mode == "" {
+		mode = "join"
+	}
+	if mode != "join" {
+		// "detach" (return async run handles to poll/stream) requires RFC P's
+		// bounded/async spawn; reject explicitly until it ships rather than
+		// silently degrading to a blocking join.
+		return connector.BatchSpawnResult{}, fmt.Errorf("spawn_runs: mode %q not supported (only %q; %q awaits RFC P async run handles)", mode, "join", "detach")
+	}
+
+	// Optional batch-level join deadline. A child still running when it fires
+	// has its RunOnce ctx cancelled (derived from this ctx) and is reported
+	// with a cancelled status in-envelope — the batch still returns the
+	// finished children's results.
+	if req.TimeoutMS > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMS)*time.Millisecond)
+		defer cancel()
+	}
+
+	results := make([]connector.SpawnRunResult, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := range req.Spawns {
+		go func(i int) {
+			defer wg.Done()
+			spawn := req.Spawns[i]
+			// Batch children are always fresh runs — a per-spawn session_id
+			// would continue an existing session, which the fan-out shape never
+			// intends. ParentContext is the caller's own opaque lineage (cost
+			// attribution); preserve it verbatim — the caller groups a batch by
+			// setting a shared root_agent_run_id across its spawns.
+			spawn.SessionID = ""
+			res, err := s.SpawnRun(ctx, spawn)
+			if err != nil {
+				// SpawnRun captures run failures in-result and returns a nil
+				// error; a non-nil error here is an unexpected dispatch failure.
+				// Surface it in THIS child's envelope, never fail the batch.
+				res.Status = string(store.RunFailed)
+				if res.Error == "" {
+					res.Error = err.Error()
+				}
+			}
+			results[i] = res
+		}(i)
+	}
+	wg.Wait()
+
+	return connector.BatchSpawnResult{Results: results, Spawned: n}, nil
 }
 
 // CancelRun looks up the run by agent_id and triggers cancellation

--- a/internal/api/http/runs_batch.go
+++ b/internal/api/http/runs_batch.go
@@ -1,0 +1,48 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+)
+
+// handleRunsBatch implements the RFC Y external fan-out: POST /v1/runs:batch
+// spawns every child in `spawns` concurrently (mode "join") and returns the
+// combined index-aligned envelope once all settle. Per-child failures are
+// captured in that child's result; the call only 400s on a MALFORMED batch
+// (empty / over-cap / unsupported mode).
+//
+// Authoritative tenant/principal flows from the auth middleware via the request
+// ctx: SpawnRunBatch → SpawnRun → RunOnce re-applies the principal per child
+// (server.go applyPrincipal), so a forged per-spawn `tenant_id` can never widen
+// scope — every child runs under the batch caller's authoritative identity.
+func (s *Server) handleRunsBatch(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if ct := r.Header.Get("Content-Type"); ct != "" && !strings.HasPrefix(ct, "application/json") {
+		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+	// A batch carries up to MaxBatchSpawns prompts, so cap the body more
+	// generously than a single /v1/runs (1 MiB) while still bounding abuse.
+	r.Body = http.MaxBytesReader(w, r.Body, 8<<20)
+	var req connector.BatchSpawnRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	res, err := s.SpawnRunBatch(r.Context(), req)
+	if err != nil {
+		// SpawnRunBatch errors only on a malformed request (empty / over-cap /
+		// unsupported mode) — a client error, not a 500. Per-child run failures
+		// are reported inside res, not as an error here.
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/internal/api/http/runs_batch_test.go
+++ b/internal/api/http/runs_batch_test.go
@@ -1,0 +1,195 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// latchProvider models a run that takes measurable time and records the
+// high-water mark of concurrently in-flight Call()s — so a fan-out test can
+// prove children ran CONCURRENTLY (max-in-flight > 1) rather than serialized.
+type latchProvider struct {
+	dwell   time.Duration
+	inFlt   atomic.Int32
+	maxSeen atomic.Int32
+}
+
+func (p *latchProvider) ID() string                    { return "stub" }
+func (p *latchProvider) Probe(_ context.Context) error { return nil }
+func (p *latchProvider) ListModels(_ context.Context) ([]string, error) {
+	return []string{"stub-model"}, nil
+}
+func (p *latchProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *latchProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	n := p.inFlt.Add(1)
+	for { // track the concurrent high-water mark
+		old := p.maxSeen.Load()
+		if n <= old || p.maxSeen.CompareAndSwap(old, n) {
+			break
+		}
+	}
+	select {
+	case <-time.After(p.dwell):
+	case <-ctx.Done():
+	}
+	p.inFlt.Add(-1)
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}}
+	close(ch)
+	return ch, nil
+}
+
+func newBatchTestServer(t *testing.T, p providers.Provider, maxRuns int) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		Defaults:    config.Defaults{Provider: "stub", Model: "stub-model"},
+		Agents:      map[string]config.AgentDef{"r": {Model: "stub-model", SystemPrompt: "be brief"}},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: maxRuns, MaxQueueDepth: maxRuns, QueueTimeoutMS: 2000},
+	}
+	cfg.Env.AuthToken = "" // open mode
+	sem := concurrency.New(maxRuns, maxRuns, 2*time.Second)
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "batch.db"))
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	return New(cfg, &stubResolver{p: p}, []tools.Tool{}, sem, st)
+}
+
+func oneUserSeg(text string) []loop.PromptSegment {
+	return []loop.PromptSegment{{
+		Role:    "user",
+		Content: []loop.PromptContentBlock{{Type: "trusted-text", Text: text}},
+	}}
+}
+
+// TestSpawnRunBatch_RejectsMalformed pins the request-validation guards: an
+// empty batch, an over-cap batch, and an unsupported mode all error BEFORE any
+// child is spawned (so a bare server with no provider/store suffices).
+func TestSpawnRunBatch_RejectsMalformed(t *testing.T) {
+	s := &Server{}
+	ctx := context.Background()
+
+	if _, err := s.SpawnRunBatch(ctx, connector.BatchSpawnRequest{}); err == nil {
+		t.Error("empty batch: want error, got nil")
+	}
+
+	over := make([]connector.SpawnRunRequest, connector.MaxBatchSpawns+1)
+	for i := range over {
+		over[i] = connector.SpawnRunRequest{Agent: "r"}
+	}
+	if _, err := s.SpawnRunBatch(ctx, connector.BatchSpawnRequest{Spawns: over}); err == nil {
+		t.Errorf("over-cap (%d) batch: want error, got nil", len(over))
+	}
+
+	if _, err := s.SpawnRunBatch(ctx, connector.BatchSpawnRequest{
+		Spawns: []connector.SpawnRunRequest{{Agent: "r"}},
+		Mode:   "detach",
+	}); err == nil {
+		t.Error("mode=detach: want error (needs RFC P), got nil")
+	}
+}
+
+// TestSpawnRunBatch_FanOutConcurrentAndInEnvelopeError proves the join: N
+// children run CONCURRENTLY (max-in-flight > 1, wall-clock ≈ one dwell not N×),
+// the envelope is index-aligned, and a bad-agent child surfaces as a failed
+// result WITHOUT failing the batch.
+func TestSpawnRunBatch_FanOutConcurrentAndInEnvelopeError(t *testing.T) {
+	p := &latchProvider{dwell: 80 * time.Millisecond}
+	s := newBatchTestServer(t, p, 8)
+
+	req := connector.BatchSpawnRequest{Spawns: []connector.SpawnRunRequest{
+		{Agent: "r", Segments: oneUserSeg("a")},
+		{Agent: "r", Segments: oneUserSeg("b")},
+		{Agent: "nonexistent", Segments: oneUserSeg("c")}, // in-envelope failure
+		{Agent: "r", Segments: oneUserSeg("d")},
+		{Agent: "r", Segments: oneUserSeg("e")},
+	}}
+
+	start := time.Now()
+	res, err := s.SpawnRunBatch(context.Background(), req)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("SpawnRunBatch: %v", err)
+	}
+	if res.Spawned != 5 || len(res.Results) != 5 {
+		t.Fatalf("Spawned=%d len(Results)=%d, want 5/5", res.Spawned, len(res.Results))
+	}
+	// The bad-agent child (index 2) failed in-envelope; the others completed.
+	if res.Results[2].Status != "failed" || res.Results[2].Error == "" {
+		t.Errorf("results[2] = %+v, want a failed status with an error (unknown agent)", res.Results[2])
+	}
+	for _, i := range []int{0, 1, 3, 4} {
+		if res.Results[i].Status != "completed" {
+			t.Errorf("results[%d].Status = %q, want completed", i, res.Results[i].Status)
+		}
+	}
+	// Concurrency: the valid children ran at once (max-in-flight > 1), so the
+	// wall-clock is ~one dwell, not the serial sum (4×80ms).
+	if mx := p.maxSeen.Load(); mx < 2 {
+		t.Errorf("max concurrent in-flight = %d, want > 1 (fan-out serialized?)", mx)
+	}
+	if elapsed > 4*60*time.Millisecond {
+		t.Errorf("batch wall-clock %v ≈ serial sum — children did not run concurrently", elapsed)
+	}
+}
+
+// TestRunsBatch_HTTPEndpoint exercises POST /v1/runs:batch end-to-end (also
+// proves the colon path routes through ServeMux) and returns the envelope; an
+// over-cap body is a 400.
+func TestRunsBatch_HTTPEndpoint(t *testing.T) {
+	p := &latchProvider{dwell: 5 * time.Millisecond}
+	s := newBatchTestServer(t, p, 8)
+
+	body := `{"spawns":[
+		{"agent":"r","segments":[{"role":"user","content":[{"type":"trusted-text","text":"a"}]}]},
+		{"agent":"r","segments":[{"role":"user","content":[{"type":"trusted-text","text":"b"}]}]}
+	]}`
+	rec := doJSON(t, s, "POST", "/v1/runs:batch", body)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var got connector.BatchSpawnResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	if got.Spawned != 2 || len(got.Results) != 2 {
+		t.Fatalf("Spawned=%d len(Results)=%d, want 2/2", got.Spawned, len(got.Results))
+	}
+	for i, r := range got.Results {
+		if r.RunID == "" || r.Status != "completed" {
+			t.Errorf("results[%d] = %+v, want a completed run with a run_id", i, r)
+		}
+	}
+
+	// Over-cap → 400.
+	var big strings.Builder
+	big.WriteString(`{"spawns":[`)
+	for i := 0; i <= connector.MaxBatchSpawns; i++ {
+		if i > 0 {
+			big.WriteString(",")
+		}
+		big.WriteString(`{"agent":"r","segments":[{"role":"user","content":[{"type":"trusted-text","text":"x"}]}]}`)
+	}
+	big.WriteString(`]}`)
+	if rec := doJSON(t, s, "POST", "/v1/runs:batch", big.String()); rec.Code != http.StatusBadRequest {
+		t.Errorf("over-cap status = %d, want 400", rec.Code)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1973,6 +1973,10 @@ func (s *Server) Mux() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.Handle("POST /v1/runs", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRuns))))
+	// RFC Y external fan-out: one call spawns N runs concurrently (mode "join").
+	// Literal sibling of /v1/runs — distinct from /v1/runs/{run_id}/* (no slash
+	// after "runs"), so it cannot collide with the per-run routes.
+	mux.Handle("POST /v1/runs:batch", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRunsBatch))))
 	mux.Handle("GET /v1/sessions/{id}/transcript", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleTranscript))))
 	mux.Handle("POST /v1/sessions/{id}/messages", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleMessages))))
 	// v0.4 tracking + cancel API.

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -21,6 +21,7 @@ type toolHandler func(ctx context.Context, env *handlerEnv, args json.RawMessage
 var handlersByName = map[string]toolHandler{
 	// Run lifecycle
 	"spawn_run":  handleSpawnRun,
+	"spawn_runs": handleSpawnRuns, // RFC Y external fan-out
 	"cancel_run": handleCancelRun,
 	"get_run":    handleGetRun,
 	"list_runs":  handleListRuns,
@@ -221,6 +222,47 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 		return toolErr("spawn_run: " + err.Error()), nil
 	}
 	return toolResultJSON(result), nil
+}
+
+// handleSpawnRuns is the RFC Y external fan-out tool: validate each child spec
+// (mirroring handleSpawnRun's per-request validation), then hand the whole batch
+// to the connector, which fans out concurrently under the admission gate and
+// joins. Per-child run failures come back inside the envelope; this returns a
+// tool error only for a malformed batch (bad child spec / over-cap / mode).
+func handleSpawnRuns(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	if env.connector == nil {
+		return nil, fmt.Errorf("spawn_runs: no connector wired")
+	}
+	var req connector.BatchSpawnRequest
+	if err := json.Unmarshal(args, &req); err != nil {
+		return toolErr("invalid spawn_runs arguments: " + err.Error()), nil
+	}
+	if len(req.Spawns) == 0 {
+		return toolErr("spawn_runs: at least one spawn is required"), nil
+	}
+	for i := range req.Spawns {
+		sp := &req.Spawns[i]
+		if sp.Agent == "" {
+			return toolErr(fmt.Sprintf("spawn_runs: spawns[%d].agent is required (batch children are fresh runs)", i)), nil
+		}
+		if errMsg, ok := connector.ValidateUserCredentialsMap(sp.UserCredentials); !ok {
+			return toolErr(fmt.Sprintf("spawn_runs: spawns[%d]: %s", i, errMsg)), nil
+		}
+		if errMsg, ok := connector.ValidateParentContext(sp.ParentContext); !ok {
+			return toolErr(fmt.Sprintf("spawn_runs: spawns[%d]: %s", i, errMsg)), nil
+		}
+		// Normalise an all-empty struct to nil so the echo omits it (matches
+		// handleSpawnRun / the HTTP handlers).
+		if sp.ParentContext.IsZero() {
+			sp.ParentContext = nil
+		}
+	}
+	res, err := env.connector.SpawnRunBatch(ctx, req)
+	if err != nil {
+		// Malformed batch (over-cap / unsupported mode) — a tool error.
+		return toolErr("spawn_runs: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
 }
 
 // effectiveSpawnTimeoutMS resolves the spawn_run transport timeout: a

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -48,6 +48,9 @@ func (m *httpMockConnector) SpawnRun(ctx context.Context, _ connector.SpawnRunRe
 		AgentID: "a_http", RunID: "r_http", SessionID: "s_http", Status: "completed",
 	}, nil
 }
+func (m *httpMockConnector) SpawnRunBatch(context.Context, connector.BatchSpawnRequest) (connector.BatchSpawnResult, error) {
+	return connector.BatchSpawnResult{}, nil
+}
 func (m *httpMockConnector) CancelRun(_ context.Context, _, _ string) (connector.CancelRunResult, error) {
 	m.cancelCalls.Add(1)
 	return connector.CancelRunResult{Cancelled: true}, nil

--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -272,6 +272,7 @@ func frameRequestID(frame []byte) (int64, bool) {
 // here when they're introduced.
 var longRunningTools = map[string]bool{
 	"spawn_run":              true,
+	"spawn_runs":             true, // RFC Y fan-out blocks for the whole join
 	"subscribe_channel":      true,
 	"peek_channel":           true,
 	"stream_user_run_states": true,

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -56,6 +56,11 @@ type mockConnector struct {
 	streamEvents     []connector.RunStateEvent
 	streamErr        error
 	lastStreamReq    connector.StreamUserRunStatesRequest
+
+	// RFC Y fan-out (spawn_runs) injection points.
+	batchReq    atomic.Value // connector.BatchSpawnRequest (last)
+	batchResult connector.BatchSpawnResult
+	batchErr    error
 }
 
 func (m *mockConnector) SpawnRun(ctx context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
@@ -75,6 +80,10 @@ func (m *mockConnector) SpawnRun(ctx context.Context, r connector.SpawnRunReques
 		m.spawnActive.Add(-1)
 	}
 	return m.spawnResult, m.spawnErr
+}
+func (m *mockConnector) SpawnRunBatch(_ context.Context, r connector.BatchSpawnRequest) (connector.BatchSpawnResult, error) {
+	m.batchReq.Store(r)
+	return m.batchResult, m.batchErr
 }
 func (m *mockConnector) CancelRun(_ context.Context, _, _ string) (connector.CancelRunResult, error) {
 	return connector.CancelRunResult{Cancelled: true}, nil
@@ -344,15 +353,15 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 41 {
-		t.Errorf("got %d tools, want 41 (F20 adds channeldef on top of the operatortokendef list)", len(result.Tools))
+	if len(result.Tools) != 42 {
+		t.Errorf("got %d tools, want 42 (RFC Y adds spawn_runs on top of the channeldef list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
 	// Spot-check across categories — through the v1.x additions.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
+	for _, want := range []string{"spawn_run", "spawn_runs", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}
@@ -444,6 +453,70 @@ func TestServer_SpawnRun_BlockingPath(t *testing.T) {
 	}
 	if inner.AgentID != "a_x" || inner.FinalText != "hello world" {
 		t.Errorf("inner = %+v, want AgentID=a_x FinalText=\"hello world\"", inner)
+	}
+}
+
+// TestServer_SpawnRuns_DispatchesBatch verifies the RFC Y spawn_runs tool
+// parses the spawns array, hands it to Connector.SpawnRunBatch, and returns the
+// combined envelope as the tool result.
+func TestServer_SpawnRuns_DispatchesBatch(t *testing.T) {
+	mc := &mockConnector{
+		batchResult: connector.BatchSpawnResult{
+			Spawned: 2,
+			Results: []connector.SpawnRunResult{
+				{AgentID: "a_0", RunID: "r_0", Status: "completed", FinalText: "zero"},
+				{AgentID: "a_1", RunID: "r_1", Status: "completed", FinalText: "one"},
+			},
+		},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_runs","arguments":{"spawns":[{"agent":"rev"},{"agent":"rev"}]}}}`,
+	}, "\n") + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 2 {
+		t.Fatalf("got %d responses, want 2 (init + spawn_runs)", len(resps))
+	}
+	stored, _ := mc.batchReq.Load().(connector.BatchSpawnRequest)
+	if len(stored.Spawns) != 2 || stored.Spawns[0].Agent != "rev" {
+		t.Errorf("Connector saw spawns=%+v, want 2× agent=rev", stored.Spawns)
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	if callRes.IsError {
+		t.Fatalf("expected non-error spawn_runs result, got: %v", callRes.Content)
+	}
+	var inner connector.BatchSpawnResult
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if inner.Spawned != 2 || len(inner.Results) != 2 || inner.Results[1].RunID != "r_1" {
+		t.Errorf("inner = %+v, want 2 results with r_1 at index 1", inner)
+	}
+}
+
+// TestServer_SpawnRuns_RejectsChildMissingAgent verifies per-child validation:
+// a spawn with no agent is a tool error, never reaches the connector.
+func TestServer_SpawnRuns_RejectsChildMissingAgent(t *testing.T) {
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_runs","arguments":{"spawns":[{"agent":""}]}}}`,
+	}, "\n") + "\n"
+	resps, _ := driveServer(t, srv, in)
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	if !callRes.IsError {
+		t.Error("spawn_runs with an empty agent must be a tool error")
+	}
+	if mc.batchReq.Load() != nil {
+		t.Error("connector.SpawnRunBatch must NOT be called when a child fails validation")
 	}
 }
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -52,6 +52,42 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			}`),
 		},
 		{
+			Name:        "spawn_runs",
+			Description: "RFC Y external fan-out: spawn up to 32 agent runs concurrently in ONE call (server-side, bounded by the per-user admission gate) and block until all settle, returning a combined index-aligned envelope. A per-child failure is captured in that child's result and never fails the batch. Prefer this over firing N parallel spawn_run calls, which serialize over a single MCP connection. Each child is a FRESH run (no session continuation). mode \"detach\" (async run handles) is reserved for a future release and rejected today.",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["spawns"],
+				"properties": {
+					"spawns": {
+						"type": "array",
+						"minItems": 1,
+						"maxItems": 32,
+						"description": "The child runs to fan out (each a fresh run; session_id is ignored).",
+						"items": {
+							"type": "object",
+							"required": ["agent"],
+							"properties": {
+								"agent":            {"type": "string", "description": "Registered agent name."},
+								"segments":         {"type": "array"},
+								"tenant_id":        {"type": "string"},
+								"user_id":          {"type": "string"},
+								"agent_id":         {"type": "string", "description": "Optional caller-supplied tracking handle."},
+								"user_tier":        {"type": "string"},
+								"user_bearer":      {"type": "string"},
+								"user_credentials": {"type": "object", "additionalProperties": {"type": "string"}},
+								"allowed_tools":    {"type": "array", "items": {"type": "string"}},
+								"allowed_hosts":    {"type": "array", "items": {"type": "string"}, "description": "OMIT for no narrowing; [] denies all outbound HTTP; non-empty intersects the operator list."},
+								"web_search_filter": {"type": "string", "enum": ["drop", "keep"]},
+								"parent_context":   {"type": "object", "properties": {"root_agent_run_id": {"type": "string"}, "function_key": {"type": "string"}, "tier_at_run": {"type": "string"}}, "description": "Set a shared root_agent_run_id across the spawns to group the batch for cost attribution."}
+							}
+						}
+					},
+					"mode":       {"type": "string", "enum": ["join"], "description": "Only \"join\" (default) is supported today: block until all children settle. \"detach\" awaits a future async-handle release."},
+					"timeout_ms": {"type": "integer", "minimum": 1, "description": "Optional join deadline: a child still running when it elapses is cancelled and reported with a cancelled status in-envelope."}
+				}
+			}`),
+		},
+		{
 			Name:        "cancel_run",
 			Description: "Cancel a running agent by agent_id. Cascades to sub-agents. Idempotent.",
 			InputSchema: rawJSON(`{

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -52,6 +52,14 @@ type Connector interface {
 	// (text, stop_reason, usage) along with the assigned IDs.
 	SpawnRun(ctx context.Context, req SpawnRunRequest) (SpawnRunResult, error)
 
+	// SpawnRunBatch is the RFC Y external fan-out: one call spawns N fresh
+	// child runs server-side concurrent (bounded by the same per-user
+	// admission gate as SpawnRun), joins them, and returns the combined
+	// index-aligned envelope. A per-child failure is captured in that child's
+	// result and never fails the batch. Mirrors POST /v1/runs:batch and the
+	// in-loop Agent op=parallel_spawn.
+	SpawnRunBatch(ctx context.Context, req BatchSpawnRequest) (BatchSpawnResult, error)
+
 	// CancelRun mirrors POST /v1/agents/{agent_id}/cancel. Cascades
 	// to sub-agent runs spawned by this run. Idempotent.
 	CancelRun(ctx context.Context, agentID, reason string) (CancelRunResult, error)

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -114,6 +114,43 @@ type SpawnRunResult struct {
 	ParentContext *store.ParentContext `json:"parent_context,omitempty"`
 }
 
+// MaxBatchSpawns bounds a single external fan-out call (RFC Y). Matches the
+// in-loop Agent op=parallel_spawn child cap so in-loop and external fan-out
+// share the same ceiling.
+const MaxBatchSpawns = 32
+
+// BatchSpawnRequest is the input to SpawnRunBatch — the RFC Y external fan-out
+// run. Each entry in Spawns is a FRESH-run SpawnRunRequest (its SessionID is
+// ignored; batch children never continue an existing session). SpawnRunBatch
+// runs all children server-side concurrent under the existing per-user
+// admission gate and joins them; per-child failures are captured in-envelope
+// and never fail the whole batch (mirrors Agent op=parallel_spawn).
+type BatchSpawnRequest struct {
+	// Spawns is the set of child runs to fan out. Capped at MaxBatchSpawns;
+	// an over-cap request is rejected explicitly (never silently truncated).
+	Spawns []SpawnRunRequest `json:"spawns"`
+
+	// Mode is "join" (default): block until every child settles, then return
+	// the combined envelope. "detach" (return async run handles to poll/stream)
+	// is reserved for RFC P and rejected until that ships.
+	Mode string `json:"mode,omitempty"`
+
+	// TimeoutMS optionally caps the join. A child still running when the
+	// deadline passes is cancelled and reported with a cancelled status
+	// in-envelope. 0 = no batch-level deadline (a child's own timeout, if any,
+	// still applies).
+	TimeoutMS int `json:"timeout_ms,omitempty"`
+}
+
+// BatchSpawnResult is the combined outcome of a "join"-mode SpawnRunBatch.
+// Results is index-aligned with the request's Spawns (a per-child error lives
+// in that child's SpawnRunResult.Error/Status). Spawned is the number of
+// children dispatched (== len(Results) on the join path).
+type BatchSpawnResult struct {
+	Results []SpawnRunResult `json:"results"`
+	Spawned int              `json:"spawned"`
+}
+
 // CancelRunResult reports the outcome of CancelRun.
 type CancelRunResult struct {
 	Cancelled    bool `json:"cancelled"`


### PR DESCRIPTION
## Why

Sandbox Experiment #7 (Claude Code delegating a 10-agent code review to loomcycle) surfaced that the external MCP/REST boundary can't fan out runs. `spawn_run` (MCP) and `POST /v1/runs` (REST) each spawn **one** run and block; to run N agents concurrently from outside you must fire N calls that **serialize over a single MCP stdio connection** (F17). exp7 worked around it by spawning an in-loomcycle dispatcher agent that calls `Agent op=parallel_spawn`. **RFC Y** (`mcp-fanout-run.md`) lifts that fan-out to a first-class external surface — this PR implements `mode:join`.

## What

- **`connector.SpawnRunBatch(ctx, BatchSpawnRequest) (BatchSpawnResult, error)`** — `BatchSpawnRequest.Spawns` reuses `SpawnRunRequest`; `MaxBatchSpawns = 32` matches the in-loop `parallel_spawn` child cap.
- **`(*Server) SpawnRunBatch`** fans out one goroutine per spawn calling the existing `SpawnRun` under a `WaitGroup` AND-barrier — **no wrapper semaphore**: each child already acquires its own slot in `RunOnce` (`sem.AcquireForUser`), so admission back-pressure + per-user fairness are preserved one level down. The batch caller's ctx flows to every child, so `RunOnce`'s `applyPrincipal` stamps the caller's **authoritative tenant** per child — a forged per-spawn `tenant_id` can't widen scope. Per-child failures are captured **in-envelope** (a failing child never sinks the batch); the call errors only on a malformed request (over-cap / unsupported mode / empty). `mode:detach` (async handles) awaits **RFC P** and is rejected explicitly; an optional `timeout_ms` caps the join.
- **REST** `POST /v1/runs:batch` (`runs_batch.go`) → `SpawnRunBatch` → combined JSON envelope; `requiredScopeFor` maps it to `runs:create` (exact path, not shadowed by the `/v1/runs/` per-run write cases). Body capped at 8 MiB.
- **MCP** `spawn_runs` tool wrapping the same handler, with per-child validation mirroring `handleSpawnRun`; added to `longRunningTools`.

Design choice worth a look: I **preserve** each spawn's caller-supplied `ParentContext` rather than mint a synthetic batch id — that field is the consumer's own cost-attribution lineage; overwriting it would clobber their `root_agent_run_id`. Callers group a batch by setting a shared `root_agent_run_id` across spawns.

## What was tested

- `go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...` — full suite green (71 packages).
- New tests:
  - `internal/api/http` `TestSpawnRunBatch_FanOutConcurrentAndInEnvelopeError` (children run **concurrently** — max-in-flight > 1, wall-clock ≈ one dwell not N×; a bad-agent child fails in-envelope without sinking the batch), `TestSpawnRunBatch_RejectsMalformed` (empty / over-cap / `detach`), `TestRunsBatch_HTTPEndpoint` (the `:batch` colon path routes through ServeMux; over-cap → 400), and the `requiredScopeFor` row for `/v1/runs:batch`.
  - `internal/api/mcp` `TestServer_SpawnRuns_DispatchesBatch` + `TestServer_SpawnRuns_RejectsChildMissingAgent`; catalogue count 41→42.

## Out of scope / noted

- **`mode:detach`** (async run handles to poll/stream) — needs **RFC P** (unshipped); rejected with a clear error now, wire shape forward-compatible.
- **RFC O** (concurrent MCP stdio dispatch, unshipped) — `spawn_runs` join works without it (one call blocks the connection for its duration; acceptable, and better than N serialized calls).
- **gRPC parity** — REST/MCP only; proto `runs:batch` deferred (matches the v0.32.0 gRPC-parity-deferred precedent).
- **Per-run `compaction` on spawns + a `compact_run` MCP tool** — the compaction half of this MCP-surface effort lands in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)