### PR TITLE
feat(mcp): compact_run tool + per-run compaction on spawn (MCP compaction surface)

### DIFF
--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -741,6 +741,9 @@ func (m *mockConnector) SpawnRun(context.Context, connector.SpawnRunRequest) (co
 func (m *mockConnector) GetRun(context.Context, string) (connector.Run, error) {
 	return connector.Run{}, nil
 }
+func (m *mockConnector) CompactRun(context.Context, string) (connector.CompactResult, error) {
+	return connector.CompactResult{}, nil
+}
 func (m *mockConnector) ListRuns(context.Context, connector.ListRunsFilter) ([]connector.Run, error) {
 	return nil, nil
 }

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -59,6 +59,7 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
 		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage
 		Metadata:        req.Metadata,        // non-secret trusted agent metadata
+		Compaction:      req.Compaction,      // per-run context-compaction override
 	}
 
 	// Capture: the OnRegistered callback gives us the resolved IDs;

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -5012,16 +5013,24 @@ func (s *Server) handleRunInput(w http.ResponseWriter, r *http.Request) {
 // minCompactMessages: a conversation shorter than this isn't worth a model call.
 const minCompactMessages = 4
 
-// compactResponse is the JSON body of POST /v1/runs/{run_id}/compact.
-type compactResponse struct {
-	RunID        string `json:"run_id"`
-	Compacted    bool   `json:"compacted"`
-	BeforeTokens int    `json:"before_tokens"`
-	AfterTokens  int    `json:"after_tokens"`
-	// Applied: "live" (pushed to the running loop), "marker" (persisted for a
-	// terminal run's next continuation), or "noop" (too short to compact).
-	Applied string `json:"applied"`
+// compactResponse is the JSON body of POST /v1/runs/{run_id}/compact — an alias
+// for the canonical connector.CompactResult so the HTTP wire and the connector
+// surface (the MCP compact_run tool, gRPC) share exactly one shape.
+type compactResponse = connector.CompactResult
+
+// compactErr carries the HTTP status + machine code + retry hint a CompactRun
+// failure should surface, so the operation can be shared between the HTTP
+// handler (which maps these onto the response) and the connector tools (MCP /
+// gRPC), which surface only the message as a tool error. A zero status is
+// treated as 500.
+type compactErr struct {
+	status     int
+	code       string // non-empty → writeJSONError(status, code, msg); else plain http.Error
+	msg        string
+	retryAfter int // seconds; >0 → set Retry-After (queue-full back-pressure)
 }
+
+func (e *compactErr) Error() string { return e.msg }
 
 // handleCompactRun serves POST /v1/runs/{run_id}/compact — summarize the run's
 // conversation to free context and continue from the summary (interactive
@@ -5032,26 +5041,65 @@ type compactResponse struct {
 // marker) or, for a terminal run with no live loop, persists the marker directly
 // so the next continuation rebuilds compacted. Cross-tenant gets an opaque 404.
 func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
-	if s.store == nil {
-		http.Error(w, "compaction requires persistence", http.StatusServiceUnavailable)
-		return
-	}
 	runID := r.PathValue("run_id")
 	if !validIdent(runID) {
 		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
 		return
 	}
-	run, err := s.store.GetRun(r.Context(), runID)
+	// Preserve the webui-vs-api source attribution on the HTTP path (a cookie'd
+	// /run terminal vs a programmatic caller); the connector CompactRun uses API.
+	res, err := s.compactRunWithSource(r.Context(), runID, compactSource(r))
 	if err != nil {
-		http.Error(w, "no run for that run_id", http.StatusNotFound)
+		var ce *compactErr
+		if errors.As(err, &ce) {
+			status := ce.status
+			if status == 0 {
+				status = http.StatusInternalServerError
+			}
+			if ce.retryAfter > 0 {
+				w.Header().Set("Retry-After", strconv.Itoa(ce.retryAfter))
+			}
+			if ce.code != "" {
+				writeJSONError(w, status, ce.code, ce.msg)
+			} else {
+				http.Error(w, ce.msg, status)
+			}
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}
+
+// CompactRun is the connector-surface compaction op (the MCP compact_run tool,
+// gRPC, future CLI) — the same operation as POST /v1/runs/{run_id}/compact,
+// attributed to the API source. A run-state mutation, so transports gate it on
+// runs:create. Run lookup, tenant-ownership, the parked-boundary gate, and both
+// apply paths (live steer push vs terminal marker) are shared with the HTTP
+// handler via compactRunWithSource.
+func (s *Server) CompactRun(ctx context.Context, runID string) (connector.CompactResult, error) {
+	return s.compactRunWithSource(ctx, runID, store.InterruptResolvedByAPI)
+}
+
+// compactRunWithSource is the shared compaction core. It returns a *compactErr
+// on every failure path (carrying the status/code the HTTP handler maps) and a
+// CompactResult on success — including the Compacted:false "noop" outcome for a
+// conversation too short to summarize. `source` attributes the steer-push (api
+// vs webui) for audit.
+func (s *Server) compactRunWithSource(ctx context.Context, runID, source string) (connector.CompactResult, error) {
+	if s.store == nil {
+		return connector.CompactResult{}, &compactErr{status: http.StatusServiceUnavailable, msg: "compaction requires persistence"}
+	}
+	run, err := s.store.GetRun(ctx, runID)
+	if err != nil {
+		return connector.CompactResult{}, &compactErr{status: http.StatusNotFound, msg: "no run for that run_id"}
 	}
 	// Tenant-ownership: opaque 404 cross-tenant (run_ids aren't secrets).
 	if run.SessionID != "" {
-		if sess, serr := s.store.GetSession(r.Context(), run.SessionID); serr == nil {
-			if !sessionOwnershipOK(r.Context(), sess) {
-				http.Error(w, "no run for that run_id", http.StatusNotFound)
-				return
+		if sess, serr := s.store.GetSession(ctx, run.SessionID); serr == nil {
+			if !sessionOwnershipOK(ctx, sess) {
+				return connector.CompactResult{}, &compactErr{status: http.StatusNotFound, msg: "no run for that run_id"}
 			}
 		}
 	}
@@ -5062,17 +5110,15 @@ func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
 	// parked; refuse mid-turn so compaction applies at the boundary the agent is
 	// already at rather than being deferred into the current turn.
 	if live && !terminal && !s.steerReg.IsParked(runID) {
-		writeJSONError(w, http.StatusConflict, "run_busy",
-			"the agent is mid-turn; compact when it's parked waiting for your input")
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusConflict, code: "run_busy",
+			msg: "the agent is mid-turn; compact when it's parked waiting for your input"}
 	}
 
 	// Rebuild the conversation from this run's transcript (== the parked loop's
 	// in-memory history — a parked run has persisted everything up to the park).
-	events, terr := s.store.GetTranscript(r.Context(), run.SessionID)
+	events, terr := s.store.GetTranscript(ctx, run.SessionID)
 	if terr != nil {
-		http.Error(w, "read transcript: "+terr.Error(), http.StatusInternalServerError)
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusInternalServerError, msg: "read transcript: " + terr.Error()}
 	}
 	runEvents := make([]store.Event, 0, len(events))
 	for _, e := range events {
@@ -5083,26 +5129,22 @@ func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
 	msgs := replayTranscript(runEvents)
 	before := estimateMessageTokens(msgs)
 	if len(msgs) < minCompactMessages {
-		writeJSON(w, http.StatusOK, compactResponse{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"})
-		return
+		return connector.CompactResult{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"}, nil
 	}
 
 	// Resolve provider/model + summarize (one model call) — same chain resume
 	// uses; no per-run secrets needed (the operator's provider key serves it).
-	agentDef, ok := s.lookupAgent(r.Context(), run.TenantID, run.Agent)
+	agentDef, ok := s.lookupAgent(ctx, run.TenantID, run.Agent)
 	if !ok {
-		writeJSONError(w, http.StatusConflict, "agent_gone", "the run's agent no longer exists")
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusConflict, code: "agent_gone", msg: "the run's agent no longer exists"}
 	}
 	providerID, model, _, rerr := s.resolveAgentDef(agentDef, run.Agent, run.UserTier)
 	if rerr != nil {
-		http.Error(w, "resolve provider/model: "+rerr.Error(), http.StatusInternalServerError)
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusInternalServerError, msg: "resolve provider/model: " + rerr.Error()}
 	}
 	provider, perr := s.providers.Get(providerID)
 	if perr != nil {
-		http.Error(w, "provider unavailable: "+perr.Error(), http.StatusServiceUnavailable)
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusServiceUnavailable, msg: "provider unavailable: " + perr.Error()}
 	}
 
 	// Resolve the run's compaction keep-N / keep-first / target / summary-model
@@ -5127,18 +5169,15 @@ func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
 	// CompactionSplit (shared with the loop) picks what to summarize vs keep.
 	firstIdx, cut, splitOK := loop.CompactionSplit(msgs, keepLastN, keepFirst)
 	if !splitOK {
-		writeJSON(w, http.StatusOK, compactResponse{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"})
-		return
+		return connector.CompactResult{RunID: runID, Compacted: false, BeforeTokens: before, AfterTokens: before, Applied: "noop"}, nil
 	}
-	summary, serr := loop.Summarize(r.Context(), provider, summaryModel, msgs[firstIdx:cut], targetPct)
+	summary, serr := loop.Summarize(ctx, provider, summaryModel, msgs[firstIdx:cut], targetPct)
 	if serr != nil {
-		http.Error(w, "summarize: "+serr.Error(), http.StatusBadGateway)
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusBadGateway, msg: "summarize: " + serr.Error()}
 	}
 	summary = strings.TrimSpace(summary)
 	if summary == "" {
-		http.Error(w, "summarization produced no text", http.StatusBadGateway)
-		return
+		return connector.CompactResult{}, &compactErr{status: http.StatusBadGateway, msg: "summarization produced no text"}
 	}
 	keepN := len(msgs) - cut
 	pinned := ""
@@ -5157,20 +5196,17 @@ func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
 	// for the next continuation.
 	applied := "marker"
 	if !terminal && s.steerReg != nil {
-		_, pushErr := s.steerReg.Push(r.Context(), runID, steer.Message{
+		_, pushErr := s.steerReg.Push(ctx, runID, steer.Message{
 			Kind: steer.KindCompact, Text: summary, KeepN: keepN, KeepFirst: firstIdx > 0,
-			Source: compactSource(r), EnqueuedAt: time.Now(),
+			Source: source, EnqueuedAt: time.Now(),
 		})
 		switch {
 		case errors.Is(pushErr, steer.ErrQueueFull):
-			w.Header().Set("Retry-After", "1")
-			http.Error(w, "run input queue full; retry shortly", http.StatusTooManyRequests)
-			return
+			return connector.CompactResult{}, &compactErr{status: http.StatusTooManyRequests, msg: "run input queue full; retry shortly", retryAfter: 1}
 		case errors.Is(pushErr, steer.ErrRunNotFound):
 			// Raced to terminal between GetRun and Push → fall through to marker.
 		case pushErr != nil:
-			http.Error(w, pushErr.Error(), http.StatusInternalServerError)
-			return
+			return connector.CompactResult{}, &compactErr{status: http.StatusInternalServerError, msg: pushErr.Error()}
 		default:
 			applied = "live"
 		}
@@ -5184,13 +5220,12 @@ func (s *Server) handleCompactRun(w http.ResponseWriter, r *http.Request) {
 			},
 		})
 		if merr == nil {
-			if aerr := s.store.AppendEvent(r.Context(), runID, string(providers.EventContextCompaction), payload); aerr != nil {
-				http.Error(w, "persist compaction marker: "+aerr.Error(), http.StatusInternalServerError)
-				return
+			if aerr := s.store.AppendEvent(ctx, runID, string(providers.EventContextCompaction), payload); aerr != nil {
+				return connector.CompactResult{}, &compactErr{status: http.StatusInternalServerError, msg: "persist compaction marker: " + aerr.Error()}
 			}
 		}
 	}
-	writeJSON(w, http.StatusOK, compactResponse{RunID: runID, Compacted: true, BeforeTokens: before, AfterTokens: after, Applied: applied})
+	return connector.CompactResult{RunID: runID, Compacted: true, BeforeTokens: before, AfterTokens: after, Applied: applied}, nil
 }
 
 // compactSource mirrors handleRunInput's api-vs-webui source resolution.

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -20,10 +20,11 @@ type toolHandler func(ctx context.Context, env *handlerEnv, args json.RawMessage
 
 var handlersByName = map[string]toolHandler{
 	// Run lifecycle
-	"spawn_run":  handleSpawnRun,
-	"cancel_run": handleCancelRun,
-	"get_run":    handleGetRun,
-	"list_runs":  handleListRuns,
+	"spawn_run":   handleSpawnRun,
+	"cancel_run":  handleCancelRun,
+	"get_run":     handleGetRun,
+	"compact_run": handleCompactRun,
+	"list_runs":   handleListRuns,
 
 	// Agent management
 	"register_agent":   handleRegisterAgent,
@@ -350,6 +351,37 @@ func handleGetRun(ctx context.Context, env *handlerEnv, args json.RawMessage) (*
 	res, err := env.connector.GetRun(ctx, p.AgentID)
 	if err != nil {
 		return toolErr("get_run: " + err.Error()), nil
+	}
+	return toolResultJSON(res), nil
+}
+
+// handleCompactRun resolves the caller's agent_id to its run_id (via GetRun,
+// like cancel_run/get_run's agent-keyed convention) and compacts that run. The
+// operation itself (parked-boundary gate, summarize, live-push vs marker) lives
+// in Connector.CompactRun, shared with POST /v1/runs/{run_id}/compact.
+func handleCompactRun(ctx context.Context, env *handlerEnv, args json.RawMessage) (*loommcp.CallToolResult, error) {
+	var p struct {
+		AgentID string `json:"agent_id"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return toolErr("invalid compact_run arguments: " + err.Error()), nil
+	}
+	if p.AgentID == "" {
+		return toolErr("compact_run: agent_id is required"), nil
+	}
+	run, err := env.connector.GetRun(ctx, p.AgentID)
+	if err != nil {
+		return toolErr("compact_run: " + err.Error()), nil
+	}
+	if run.RunID == "" {
+		return toolErr("compact_run: no run_id for agent_id " + p.AgentID), nil
+	}
+	res, err := env.connector.CompactRun(ctx, run.RunID)
+	if err != nil {
+		// Includes the parked-boundary "run_busy" rejection — surfaced as a tool
+		// error so the orchestrator can retry when the run parks.
+		return toolErr("compact_run: " + err.Error()), nil
 	}
 	return toolResultJSON(res), nil
 }

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -55,6 +55,9 @@ func (m *httpMockConnector) CancelRun(_ context.Context, _, _ string) (connector
 func (m *httpMockConnector) GetRun(context.Context, string) (connector.Run, error) {
 	return connector.Run{}, nil
 }
+func (m *httpMockConnector) CompactRun(context.Context, string) (connector.CompactResult, error) {
+	return connector.CompactResult{}, nil
+}
 func (m *httpMockConnector) ListRuns(context.Context, connector.ListRunsFilter) ([]connector.Run, error) {
 	return nil, nil
 }

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -56,6 +56,12 @@ type mockConnector struct {
 	streamEvents     []connector.RunStateEvent
 	streamErr        error
 	lastStreamReq    connector.StreamUserRunStatesRequest
+
+	// compact_run (compaction MCP tool) injection points.
+	getRunResult  connector.Run // returned by GetRun (agent_id→run_id resolution)
+	compactRunID  atomic.Value  // string: the run_id CompactRun was called with
+	compactResult connector.CompactResult
+	compactErr    error
 }
 
 func (m *mockConnector) SpawnRun(ctx context.Context, r connector.SpawnRunRequest) (connector.SpawnRunResult, error) {
@@ -80,7 +86,11 @@ func (m *mockConnector) CancelRun(_ context.Context, _, _ string) (connector.Can
 	return connector.CancelRunResult{Cancelled: true}, nil
 }
 func (m *mockConnector) GetRun(_ context.Context, _ string) (connector.Run, error) {
-	return connector.Run{}, nil
+	return m.getRunResult, nil
+}
+func (m *mockConnector) CompactRun(_ context.Context, runID string) (connector.CompactResult, error) {
+	m.compactRunID.Store(runID)
+	return m.compactResult, m.compactErr
 }
 func (m *mockConnector) ListRuns(_ context.Context, _ connector.ListRunsFilter) ([]connector.Run, error) {
 	if m.listCallback != nil {
@@ -344,15 +354,15 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 41 {
-		t.Errorf("got %d tools, want 41 (F20 adds channeldef on top of the operatortokendef list)", len(result.Tools))
+	if len(result.Tools) != 42 {
+		t.Errorf("got %d tools, want 42 (compact_run added on top of the channeldef list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
 	// Spot-check across categories — through the v1.x additions.
-	for _, want := range []string{"spawn_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
+	for _, want := range []string{"spawn_run", "compact_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}
@@ -444,6 +454,87 @@ func TestServer_SpawnRun_BlockingPath(t *testing.T) {
 	}
 	if inner.AgentID != "a_x" || inner.FinalText != "hello world" {
 		t.Errorf("inner = %+v, want AgentID=a_x FinalText=\"hello world\"", inner)
+	}
+}
+
+// TestServer_SpawnRun_CarriesCompaction verifies a per-run compaction block on
+// a spawn_run call decodes into SpawnRunRequest.Compaction (the new per-run
+// config surface; the connector then carries it to runner.RunInput).
+func TestServer_SpawnRun_CarriesCompaction(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{AgentID: "a", RunID: "r", Status: "completed"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"compaction":{"enabled":true,"keep_last_n":6,"autocompact_at_pct":75}}}}`,
+	}, "\n") + "\n"
+	driveServer(t, srv, in)
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.Compaction == nil {
+		t.Fatal("SpawnRunRequest.Compaction is nil — per-run compaction did not decode")
+	}
+	if stored.Compaction.Enabled == nil || !*stored.Compaction.Enabled {
+		t.Error("compaction.enabled did not decode as true")
+	}
+	if stored.Compaction.KeepLastN == nil || *stored.Compaction.KeepLastN != 6 {
+		t.Errorf("compaction.keep_last_n = %v, want 6", stored.Compaction.KeepLastN)
+	}
+	if stored.Compaction.AutoCompactAtPct == nil || *stored.Compaction.AutoCompactAtPct != 75 {
+		t.Errorf("compaction.autocompact_at_pct = %v, want 75", stored.Compaction.AutoCompactAtPct)
+	}
+}
+
+// TestServer_CompactRun_ResolvesAgentIDThenCompacts verifies the compact_run
+// tool resolves agent_id→run_id via GetRun, calls CompactRun with that run_id,
+// and returns the compaction envelope.
+func TestServer_CompactRun_ResolvesAgentIDThenCompacts(t *testing.T) {
+	mc := &mockConnector{
+		getRunResult:  connector.Run{AgentID: "a_x", RunID: "r_x", Status: "awaiting_input"},
+		compactResult: connector.CompactResult{RunID: "r_x", Compacted: true, BeforeTokens: 900, AfterTokens: 120, Applied: "live"},
+	}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"compact_run","arguments":{"agent_id":"a_x"}}}`,
+	}, "\n") + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if got, _ := mc.compactRunID.Load().(string); got != "r_x" {
+		t.Errorf("CompactRun saw run_id=%q, want r_x (agent_id must resolve via GetRun)", got)
+	}
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal call result: %v", err)
+	}
+	if callRes.IsError {
+		t.Fatalf("expected non-error compact_run result, got: %v", callRes.Content)
+	}
+	var inner connector.CompactResult
+	if err := json.Unmarshal([]byte(callRes.Content[0].Text), &inner); err != nil {
+		t.Fatalf("unmarshal inner: %v", err)
+	}
+	if !inner.Compacted || inner.Applied != "live" || inner.AfterTokens != 120 {
+		t.Errorf("inner = %+v, want compacted live with after_tokens=120", inner)
+	}
+}
+
+// TestServer_CompactRun_RequiresAgentID verifies the agent_id guard short-
+// circuits before any connector call.
+func TestServer_CompactRun_RequiresAgentID(t *testing.T) {
+	mc := &mockConnector{}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := strings.Join([]string{
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"compact_run","arguments":{}}}`,
+	}, "\n") + "\n"
+	resps, _ := driveServer(t, srv, in)
+	var callRes loommcp.CallToolResult
+	if err := json.Unmarshal(resps[1].Result, &callRes); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !callRes.IsError {
+		t.Error("compact_run with no agent_id must be a tool error")
+	}
+	if mc.compactRunID.Load() != nil {
+		t.Error("CompactRun must NOT be called when agent_id is missing")
 	}
 }
 

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -43,7 +43,8 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 					"allowed_hosts":    {"type": "array", "items": {"type": "string"}, "description": "OMIT for no narrowing (operator's static allowlist applies). Pass empty array [] to DENY ALL outbound HTTP. Pass non-empty array to intersect with operator's list."},
 					"web_search_filter": {"type": "string", "enum": ["drop", "keep"]},
 					"parent_context":   {"type": "object", "description": "v0.12.x opaque caller-tracking lineage carried verbatim, inherited by every sub-agent, and echoed on the per-agent report surfaces so a consumer can attribute a child sub-agent's usage to the user-initiated request.", "properties": {"root_agent_run_id": {"type": "string"}, "function_key": {"type": "string"}, "tier_at_run": {"type": "string"}}},
-					"timeout_ms":       {"type": "integer", "minimum": 1, "description": "Optional transport timeout (RFC P): max milliseconds this spawn_run call may block before loomcycle cancels the run and returns status:\"timeout\" instead of hanging. Narrows the operator default (LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS) — it can shorten but not exceed it. Omit to block until the run finishes on its own run_timeout_seconds budget. This is a transport bound, NOT the run's wall-clock budget."}
+					"timeout_ms":       {"type": "integer", "minimum": 1, "description": "Optional transport timeout (RFC P): max milliseconds this spawn_run call may block before loomcycle cancels the run and returns status:\"timeout\" instead of hanging. Narrows the operator default (LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS) — it can shorten but not exceed it. Omit to block until the run finishes on its own run_timeout_seconds budget. This is a transport bound, NOT the run's wall-clock budget."},
+					"compaction":       {"type": "object", "description": "Optional per-run context-compaction override, merged per-field over the agent's own block. Trigger compaction mid-run with the compact_run tool.", "properties": {"enabled": {"type": "boolean", "description": "Turn AUTO-compaction on for this run."}, "target_percentage": {"type": "integer", "minimum": 10, "maximum": 50, "description": "Summary aims for ~N% of the compacted span (default 10)."}, "keep_last_n": {"type": "integer", "minimum": 0, "description": "Keep the last N messages verbatim (default 4; 0 = summarize all)."}, "keep_first": {"type": "boolean", "description": "Pin the first user message (the task) verbatim (default true)."}, "autocompact_at_pct": {"type": "integer", "minimum": 50, "maximum": 95, "description": "Auto-compact when used/window ≥ N% (default 80; only when enabled + the provider reports a window)."}, "model": {"type": "string", "description": "Optional cheaper/faster summary model served by the same provider."}}}
 				},
 				"anyOf": [
 					{"required": ["agent"]},
@@ -70,6 +71,18 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 				"type": "object",
 				"required": ["agent_id"],
 				"properties": {"agent_id": {"type": "string"}}
+			}`),
+		},
+		{
+			Name:        "compact_run",
+			Description: "Compact a run's conversation: summarize the history to free context and continue from the summary. Targets the run by agent_id (resolved to its run_id). A live run must be PARKED (awaiting input) — a mid-turn run is refused. Returns {compacted, before_tokens, after_tokens, applied}, where applied is \"live\" (pushed to the running loop), \"marker\" (persisted for a terminal run's next continuation), or \"noop\" (too short to compact). Honors the agent's compaction settings (keep_last_n / keep_first / target_percentage / summary model).",
+			InputSchema: rawJSON(`{
+				"type": "object",
+				"required": ["agent_id"],
+				"properties": {
+					"agent_id": {"type": "string"},
+					"reason":   {"type": "string", "description": "Optional free-text note (audit only)."}
+				}
 			}`),
 		},
 		{

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -60,6 +60,13 @@ type Connector interface {
 	// agent_id. Mirrors GET /v1/agents/{agent_id}.
 	GetRun(ctx context.Context, agentID string) (Run, error)
 
+	// CompactRun summarizes a run's conversation to free context and continue
+	// from the summary — mirrors POST /v1/runs/{run_id}/compact. Keyed by
+	// run_id (transports holding an agent_id resolve it via GetRun first). A
+	// live run must be parked; a mid-turn run is refused. Cross-tenant is an
+	// opaque not-found.
+	CompactRun(ctx context.Context, runID string) (CompactResult, error)
+
 	// ListRuns enumerates runs matching the filter. Mirrors
 	// GET /v1/runs (with optional user_id / status filters).
 	ListRuns(ctx context.Context, filter ListRunsFilter) ([]Run, error)

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -94,6 +94,13 @@ type SpawnRunRequest struct {
 	// input.metadata; an LLM agent receives it as a trusted prompt block. Not
 	// a secret — credentials use UserCredentials. Nil = none (back-compat).
 	Metadata map[string]any `json:"metadata,omitempty"`
+
+	// Compaction is an optional per-RUN context-compaction override, merged PER
+	// FIELD over the agent's own compaction block (this wins; unset fields
+	// inherit). nil = inherit the agent's entirely. Mirrors the HTTP /v1/runs
+	// `compaction` field so a gRPC / LoomCycle-MCP spawn_run / fan-out child
+	// reaches the same per-run knob. Carried verbatim to runner.RunInput.
+	Compaction *config.Compaction `json:"compaction,omitempty"`
 }
 
 // SpawnRunResult is the final outcome of a SpawnRun call (returned
@@ -119,6 +126,18 @@ type CancelRunResult struct {
 	Cancelled    bool `json:"cancelled"`
 	CascadeCount int  `json:"cascade_count"` // sub-runs also cancelled
 	AlreadyEnded bool `json:"already_ended"` // run had already completed/failed
+}
+
+// CompactResult is the outcome of CompactRun — summarize a run's conversation
+// to free context. Mirrors POST /v1/runs/{run_id}/compact's response body.
+type CompactResult struct {
+	RunID        string `json:"run_id"`
+	Compacted    bool   `json:"compacted"`
+	BeforeTokens int    `json:"before_tokens"`
+	AfterTokens  int    `json:"after_tokens"`
+	// Applied: "live" (pushed to the running loop), "marker" (persisted for a
+	// terminal run's next continuation), or "noop" (too short to compact).
+	Applied string `json:"applied"`
 }
 
 // Run is the status snapshot returned by GetRun / ListRuns. Distinct


### PR DESCRIPTION
## Why

The v0.32.0 context-compaction op is reachable over HTTP (`POST /v1/runs/{id}/compact`) and in-band (`Context op=compact`), and its per-run config rides the HTTP `POST /v1/runs` body — but the external **MCP surface** had neither: no `compact_run` tool, and no `compaction` field on `SpawnRunRequest`. So an MCP orchestrator (Claude Code) could neither trigger compaction on a run nor set a per-run policy at spawn. This applies RFC Y's lift-the-core-to-the-boundary principle to compaction. (Companion to #464, the RFC Y fan-out PR.)

## What

**Operation — `compact_run` MCP tool.** Extracted `handleCompactRun`'s body into `(*Server) CompactRun(ctx, runID)`, added to the `Connector` interface (+ a `CompactResult` type; the HTTP `compactResponse` is now an alias). Failure paths return a typed `*compactErr` carrying the HTTP status/code/retry hint; the HTTP handler maps it — **preserving** the 409 mid-turn gate, the webui-vs-api source attribution, and `Retry-After` — and the MCP tool surfaces the message. The `compact_run` tool is keyed on `agent_id` (mirroring `cancel_run`/`get_run`), resolving `agent_id`→`run_id` via `GetRun` then calling `CompactRun`. **The HTTP path is behaviorally unchanged.**

**Configuration — per-run `compaction` at spawn.** Added `Compaction *config.Compaction` to `SpawnRunRequest`, wired in `(*Server) SpawnRun` into `runner.RunInput.Compaction` (same per-field-merge semantics as the HTTP `/v1/runs` `compaction` field), plus a `compaction` object on the `spawn_run` input schema.

## What was tested

- `go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...` — full suite green (71 packages).
- The existing `internal/api/http` `compact_test` suite **still passes** — proving the `CompactRun` extraction preserved HTTP behavior (parked→live, terminal→marker, noop, 409 mid-turn).
- New `internal/api/mcp` tests: `TestServer_CompactRun_ResolvesAgentIDThenCompacts` (agent_id→run_id resolution + envelope), `TestServer_CompactRun_RequiresAgentID` (guard short-circuits before the connector), `TestServer_SpawnRun_CarriesCompaction` (a `compaction` block decodes into `SpawnRunRequest.Compaction`); catalogue count 41→42.

## Note on ordering vs #464

Branched off `main` independently of #464 (RFC Y fan-out). Both touch `internal/connector/{types,connector}.go` and the MCP test mocks (distinct additions) — whichever merges second rebases cleanly. Once both land, fan-out (`spawn_runs`) children inherit per-run `compaction` automatically (it's a `SpawnRunRequest` field); adding it to the `spawn_runs` *schema doc* is a one-line follow-up.

## Out of scope / noted

- **gRPC parity** — `CompactRun` + `SpawnRunRequest.compaction` are REST/MCP-only; proto additions deferred (matches the v0.32.0 gRPC-parity-deferred precedent).
- **Read surface** (effective compaction policy + context footprint in `get_run`) — out; `Context op=self` already exposes it in-band. Per-agent compaction config remains settable via the existing `agentdef` MCP tool's overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)