### PR TITLE
feat: context-transform plugins — outbound secret redaction (RFC Z Phase 1a)

### DIFF
--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -748,6 +748,19 @@ cache:
   native:
     enabled: true              # honour Anthropic cache_control hints
 
+# ─── Context-transform plugins (RFC Z / v0.33.x) ────────────────────
+# A runtime-wide chain of fast, built-in transforms applied to a COPY of the
+# OUTBOUND LLM request on every turn, in declared order. The only built-in
+# today is `redact` — it scrubs secrets out of what the model sees (Tier-A:
+# the operator's secret-classified env values; Tier-B: heuristic value patterns
+# for sk-/AKIA/xox/ghp_/Authorization/key=value). Complements F32, which
+# redacts the PERSISTED transcript — this redacts what is SENT. The synthetic
+# code-js provider is exempt (local replay; no external leak). Empty = no chain.
+# context_plugins:
+#   - name: redact
+#     # enabled: true            # default on; set false to keep the entry but skip it
+#     # redact_tool_input: false # also scrub tool_use inputs, not just text blocks
+
 # ─── Memory (v0.9.0 embedder + v0.11.5 yaml-seeded entries) ──────────
 # memory:
 #   # v0.9.0 — embedder for Vector Memory (Memory.embed: true + Memory.search).

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -289,6 +289,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		Interactive:            run.Interactive,
 		Sampling:               agentDef.Sampling,   // per-run override not snapshotted
 		Compaction:             agentDef.Compaction, // per-run override not snapshotted
+		ContextPlugins:         s.contextPlugins,    // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               run.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/api/http/runs_batch_test.go
+++ b/internal/api/http/runs_batch_test.go
@@ -123,9 +123,7 @@ func TestSpawnRunBatch_FanOutConcurrentAndInEnvelopeError(t *testing.T) {
 		{Agent: "r", Segments: oneUserSeg("e")},
 	}}
 
-	start := time.Now()
 	res, err := s.SpawnRunBatch(context.Background(), req)
-	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("SpawnRunBatch: %v", err)
 	}
@@ -141,13 +139,12 @@ func TestSpawnRunBatch_FanOutConcurrentAndInEnvelopeError(t *testing.T) {
 			t.Errorf("results[%d].Status = %q, want completed", i, res.Results[i].Status)
 		}
 	}
-	// Concurrency: the valid children ran at once (max-in-flight > 1), so the
-	// wall-clock is ~one dwell, not the serial sum (4×80ms).
+	// Concurrency: the valid children overlapped in flight (max-in-flight >= 2).
+	// This is the deterministic proof; an earlier wall-clock ceiling was dropped
+	// because the race detector's goroutine overhead inflates the concurrent
+	// wall-clock toward the serial sum, making any timing bound flaky.
 	if mx := p.maxSeen.Load(); mx < 2 {
-		t.Errorf("max concurrent in-flight = %d, want > 1 (fan-out serialized?)", mx)
-	}
-	if elapsed > 4*60*time.Millisecond {
-		t.Errorf("batch wall-clock %v ≈ serial sum — children did not run concurrently", elapsed)
+		t.Errorf("max concurrent in-flight = %d, want >= 2 (fan-out serialized?)", mx)
 	}
 }
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/contextplugin"
 	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
@@ -68,6 +69,13 @@ type Server struct {
 	// via LOOMCYCLE_REDACT_SECRETS=0. Read-only after construction; the nil /
 	// no-op cases are handled by *redact.Redactor's nil-safe methods.
 	redactor *redact.Redactor
+
+	// contextPlugins is the runtime-wide context-transform chain (RFC Z / F43),
+	// built once from cfg.ContextPlugins at construction and shared read-only
+	// across every run (the plugins are stateless/concurrent-safe). Passed into
+	// each loop.RunOptions; the loop applies it on a COPY of the outbound
+	// request and skips it for the code-js provider. nil = no chain.
+	contextPlugins []contextplugin.Plugin
 
 	// cancelReg holds the in-memory map of agent_id → cancelFn so the
 	// cancel API can tear down a still-running loop from a different
@@ -364,6 +372,16 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 	// (its methods are nil-safe, so makeRecordingEmit just skips redaction).
 	if cfg.Env.RedactSecrets {
 		s.redactor = redact.New(secretEnvValues(os.Environ()), true)
+	}
+	// RFC Z: build the runtime-wide context-transform chain once. The redact
+	// plugin masks the same operator env-secret values + the Tier-B heuristic
+	// patterns from the OUTBOUND request (vs F32's persisted-transcript path).
+	// config.validate already rejected unknown names at load; a Build error
+	// here is defensive — log it loudly rather than silently drop a transform.
+	if cp, err := contextplugin.Build(cfg.ContextPlugins, secretEnvValues(os.Environ())); err != nil {
+		log.Printf("context_plugins: build failed (chain disabled): %v", err)
+	} else {
+		s.contextPlugins = cp
 	}
 	s.tools = append(s.tools, &builtin.AgentTool{
 		// Run drops the run_id (the common sequential/spawn path); RunDetailed
@@ -1862,6 +1880,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		Interactive:            in.Interactive,
 		Sampling:               config.MergeSampling(agentDef.Sampling, in.Sampling),       // per-run wins per field
 		Compaction:             config.MergeCompaction(agentDef.Compaction, in.Compaction), // per-run wins per field
+		ContextPlugins:         s.contextPlugins,                                           // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               in.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -3149,6 +3168,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		Interactive:            req.Interactive,
 		Sampling:               config.MergeSampling(agentDef.Sampling, req.Sampling),       // per-run wins per field
 		Compaction:             config.MergeCompaction(agentDef.Compaction, req.Compaction), // per-run wins per field
+		ContextPlugins:         s.contextPlugins,                                            // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               req.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -3626,6 +3646,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		Interactive:            body.Interactive,
 		Sampling:               config.MergeSampling(agentDef.Sampling, body.Sampling),       // per-run wins per field
 		Compaction:             config.MergeCompaction(agentDef.Compaction, body.Compaction), // per-run wins per field
+		ContextPlugins:         s.contextPlugins,                                             // RFC Z runtime-wide chain (code-js exempt in the loop)
 		UserTier:               body.UserTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,
@@ -4468,6 +4489,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		// a breeder varies temperature by FORKING a def, then spawning it).
 		Sampling:               def.Sampling,
 		Compaction:             subCompaction,
+		ContextPlugins:         s.contextPlugins, // RFC Z runtime-wide chain (sub-agents included; code-js exempt in the loop)
 		UserTier:               parentTier,
 		FallbackPolicy:         fbPolicy,
 		ReResolve:              fbReResolve,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,16 @@ type Config struct {
 	MCPServers  map[string]MCPServer `yaml:"mcp_servers"`
 	Concurrency Concurrency          `yaml:"concurrency"`
 	Cache       CacheConfig          `yaml:"cache"`
+
+	// ContextPlugins is the runtime-wide chain of context-transform plugins
+	// (RFC Z / F43) — fast, built-in transforms applied to a COPY of the
+	// outbound LLM request on every turn (e.g. secret redaction), in declared
+	// order. Empty = no chain. Runtime-wide only in this version; per-agent +
+	// tenant scopes (with floor composition) are a follow-up. Built once at
+	// server start and shared read-only across runs; the synthetic code-js
+	// provider is exempt (the loop skips the chain for it).
+	ContextPlugins []ContextPluginSpec `yaml:"context_plugins,omitempty"`
+
 	// LocalAPI declares the OpenAPI-derived MCP gateway (v0.4.0+).
 	// One tool is generated per operation; tools forward calls to
 	// BaseURL with the agent's `bearer` field as Authorization.
@@ -1091,6 +1101,31 @@ func (c *Compaction) Validate() error {
 	}
 	return nil
 }
+
+// ContextPluginSpec is one entry in the runtime-wide context-transform plugin
+// chain (RFC Z / F43). `Name` selects a built-in transformer from the
+// contextplugin registry (the only built-in today is "redact"). The chain runs
+// in declared order on a COPY of the outbound LLM request. This is plain
+// config data (no behaviour) so the config package stays free of a dependency
+// on the contextplugin/providers transform layer.
+type ContextPluginSpec struct {
+	// Name selects the built-in transformer (e.g. "redact"). Required.
+	Name string `json:"name" yaml:"name"`
+	// Enabled toggles this entry. nil/true = on; an explicit false leaves the
+	// entry in the config (documented intent) but skips building it.
+	Enabled *bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
+	// RedactToolInput (redact plugin only): also scrub tool_use inputs in the
+	// outbound request, not just text blocks. nil/false = text only.
+	RedactToolInput *bool `json:"redact_tool_input,omitempty" yaml:"redact_tool_input,omitempty"`
+}
+
+// IsEnabled reports whether this spec should be built (nil Enabled = on).
+func (s ContextPluginSpec) IsEnabled() bool { return s.Enabled == nil || *s.Enabled }
+
+// knownContextPluginNames mirrors the internal/contextplugin registry for
+// load-time validation (config can't import contextplugin — cycle). Keep in
+// sync when a built-in plugin is added.
+var knownContextPluginNames = map[string]bool{"redact": true}
 
 // AgentInterruptionACL is the per-agent v0.8.16 Interruption tool
 // gate. Three fields:
@@ -3801,6 +3836,20 @@ func validateStaticWebhook(name string, w Webhook) error {
 func validate(c *Config) error {
 	if c.Concurrency.MaxConcurrentRuns < 1 {
 		return fmt.Errorf("concurrency.max_concurrent_runs must be >= 1")
+	}
+	// Runtime-wide context-transform plugin chain (RFC Z). Validate names
+	// loudly at load — a typo'd plugin name must fail startup, not silently
+	// drop a (possibly security-critical) transform like redaction. The
+	// authoritative registry lives in internal/contextplugin (config can't
+	// import it — that would cycle); knownContextPluginNames mirrors it and
+	// must be kept in sync as built-in plugins are added.
+	for i, p := range c.ContextPlugins {
+		if p.Name == "" {
+			return fmt.Errorf("context_plugins[%d]: name is required", i)
+		}
+		if !knownContextPluginNames[p.Name] {
+			return fmt.Errorf("context_plugins[%d]: unknown plugin %q (want one of: redact)", i, p.Name)
+		}
 	}
 	if c.Concurrency.MaxQueueDepth < 0 {
 		return fmt.Errorf("concurrency.max_queue_depth must be >= 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2495,3 +2495,25 @@ webhooks:
 		t.Fatalf("Load err = %v, want a webhook delivery-target error", err)
 	}
 }
+
+// TestValidate_ContextPlugins pins the RFC-Z load-time guard: a valid built-in
+// name passes; an unknown name or an empty name fails loudly (so a typo can't
+// silently drop a security-critical transform like redaction).
+func TestValidate_ContextPlugins(t *testing.T) {
+	base := func(specs []ContextPluginSpec) *Config {
+		return &Config{
+			Defaults:       Defaults{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			Concurrency:    Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 0},
+			ContextPlugins: specs,
+		}
+	}
+	if err := validate(base([]ContextPluginSpec{{Name: "redact"}})); err != nil {
+		t.Errorf("valid redact spec rejected: %v", err)
+	}
+	if err := validate(base([]ContextPluginSpec{{Name: "redcat"}})); err == nil || !strings.Contains(err.Error(), "unknown plugin") {
+		t.Errorf("unknown plugin name: got %v, want 'unknown plugin' error", err)
+	}
+	if err := validate(base([]ContextPluginSpec{{Name: ""}})); err == nil || !strings.Contains(err.Error(), "name is required") {
+		t.Errorf("empty name: got %v, want 'name is required' error", err)
+	}
+}

--- a/internal/contextplugin/contextplugin.go
+++ b/internal/contextplugin/contextplugin.go
@@ -1,0 +1,89 @@
+// Package contextplugin implements the RFC Z context-transform plugin chain:
+// fast, built-in transforms applied to a COPY of the outbound LLM request on
+// every turn, between the assembled agent context and the provider call. The
+// first (and only built-in today) is `redact` — outbound secret redaction.
+//
+// The chain is built once from runtime config (config.ContextPluginSpec) and
+// shared read-only across runs. Contract every plugin must honour:
+//
+//   - Deterministic + stable (idempotent on its own output) — so the cached
+//     prompt prefix stays byte-stable turn over turn and any future replay holds.
+//   - Never mutate its input — return new slices (copy-on-write), leaving the
+//     loop's canonical messages, the persisted transcript, and the code-js
+//     replay input all byte-stable.
+//   - Preserve ContentBlock.Cacheable markers on blocks it passes through.
+//
+// The loop applies the chain only for real LLM providers; the synthetic code-js
+// provider is exempt (local replay, no external leak, and redacted bytes would
+// trip replay divergence).
+package contextplugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Plugin transforms the outbound request. See the package doc for the contract.
+type Plugin interface {
+	Name() string
+	Transform(ctx context.Context, system []providers.ContentBlock, msgs []providers.Message) (
+		[]providers.ContentBlock, []providers.Message, error)
+}
+
+// builder constructs a plugin from its spec + the run-secret value set (used by
+// the redact plugin's Tier-A exact masking; ignored by plugins that don't need it).
+type builder func(spec config.ContextPluginSpec, secrets map[string]string) (Plugin, error)
+
+// registry maps a built-in plugin name to its constructor. The canonical list
+// of names; config.knownContextPluginNames mirrors it for load-time validation.
+var registry = map[string]builder{
+	"redact": newRedactPlugin,
+}
+
+// Build resolves the runtime-wide plugin chain from config, in declared order.
+// `secrets` is the operator secret-value set (env-derived) the redact plugin
+// masks exactly; the Tier-B heuristic patterns apply regardless. A disabled
+// spec is skipped; an unknown name is an error (config validation rejects these
+// at load — Build is the defensive runtime authority). Returns nil for an empty
+// or all-disabled chain so the loop can skip cheaply.
+func Build(specs []config.ContextPluginSpec, secrets map[string]string) ([]Plugin, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make([]Plugin, 0, len(specs))
+	for i, spec := range specs {
+		if !spec.IsEnabled() {
+			continue
+		}
+		b, ok := registry[spec.Name]
+		if !ok {
+			return nil, fmt.Errorf("context_plugins[%d]: unknown plugin %q", i, spec.Name)
+		}
+		p, err := b(spec, secrets)
+		if err != nil {
+			return nil, fmt.Errorf("context_plugins[%d] (%s): %w", i, spec.Name, err)
+		}
+		out = append(out, p)
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// Apply runs the chain in order, threading each plugin's output into the next.
+// Plugins are copy-on-write, so the caller's `system`/`msgs` are not mutated;
+// the returned pair is what feeds the outbound providers.Request.
+func Apply(ctx context.Context, chain []Plugin, system []providers.ContentBlock, msgs []providers.Message) (
+	[]providers.ContentBlock, []providers.Message, error) {
+	var err error
+	for _, p := range chain {
+		if system, msgs, err = p.Transform(ctx, system, msgs); err != nil {
+			return nil, nil, fmt.Errorf("context plugin %q: %w", p.Name(), err)
+		}
+	}
+	return system, msgs, nil
+}

--- a/internal/contextplugin/contextplugin_test.go
+++ b/internal/contextplugin/contextplugin_test.go
@@ -1,0 +1,137 @@
+package contextplugin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+// TestRedactPlugin_ScrubsOutboundText pins the core behavior: an injected
+// secret VALUE (Tier-A) and a pattern-shaped secret (Tier-B) are masked in the
+// outbound system + message text.
+func TestRedactPlugin_ScrubsOutboundText(t *testing.T) {
+	chain, err := Build(
+		[]config.ContextPluginSpec{{Name: "redact"}},
+		map[string]string{"ACME_API_TOKEN": "supersecretvalue123"},
+	)
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if len(chain) != 1 {
+		t.Fatalf("chain len = %d, want 1", len(chain))
+	}
+
+	system := []providers.ContentBlock{{Type: "text", Text: "system: token is supersecretvalue123"}}
+	msgs := []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "here is an openai key sk-abcdefghijklmnop1234 to use"},
+		}},
+	}
+
+	gotSys, gotMsgs, err := Apply(context.Background(), chain, system, msgs)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Tier-A exact value masked.
+	if got := gotSys[0].Text; got == system[0].Text || containsSecret(got, "supersecretvalue123") {
+		t.Errorf("system block not redacted: %q", got)
+	}
+	// Tier-B pattern (sk-…) masked.
+	if got := gotMsgs[0].Content[0].Text; containsSecret(got, "sk-abcdefghijklmnop1234") {
+		t.Errorf("message block not redacted: %q", got)
+	}
+}
+
+// TestRedactPlugin_DoesNotMutateInput is the outbound-copy guarantee: the
+// caller's slices/blocks are untouched after Transform.
+func TestRedactPlugin_DoesNotMutateInput(t *testing.T) {
+	chain, _ := Build([]config.ContextPluginSpec{{Name: "redact"}}, map[string]string{"K": "topsecretvalue999"})
+
+	origText := "leak topsecretvalue999 here"
+	msgs := []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: origText}}}}
+
+	_, gotMsgs, err := Apply(context.Background(), chain, nil, msgs)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Input unchanged.
+	if msgs[0].Content[0].Text != origText {
+		t.Errorf("input mutated: %q", msgs[0].Content[0].Text)
+	}
+	// Output redacted (a new slice/block).
+	if containsSecret(gotMsgs[0].Content[0].Text, "topsecretvalue999") {
+		t.Errorf("output not redacted: %q", gotMsgs[0].Content[0].Text)
+	}
+}
+
+// TestRedactPlugin_PreservesCacheableAndUnmatched: blocks with no secret pass
+// through unchanged (shared), and Cacheable markers survive on redacted blocks.
+func TestRedactPlugin_PreservesCacheableAndUnmatched(t *testing.T) {
+	chain, _ := Build([]config.ContextPluginSpec{{Name: "redact"}}, map[string]string{"K": "abceasysecret123"})
+	msgs := []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+		{Type: "text", Text: "clean text, nothing here", Cacheable: true},
+		{Type: "text", Text: "secret abceasysecret123", Cacheable: true},
+	}}}
+	_, gotMsgs, _ := Apply(context.Background(), chain, nil, msgs)
+	blocks := gotMsgs[0].Content
+	if blocks[0].Text != "clean text, nothing here" {
+		t.Errorf("clean block changed: %q", blocks[0].Text)
+	}
+	if !blocks[0].Cacheable || !blocks[1].Cacheable {
+		t.Errorf("Cacheable lost: %+v", blocks)
+	}
+	if containsSecret(blocks[1].Text, "abceasysecret123") {
+		t.Errorf("secret block not redacted: %q", blocks[1].Text)
+	}
+}
+
+// TestRedactPlugin_ToolInputOptIn: tool_use input is only scrubbed when
+// redact_tool_input is set.
+func TestRedactPlugin_ToolInputOptIn(t *testing.T) {
+	secret := map[string]string{"K": "toolsecretvalue42"}
+	in := func() []providers.Message {
+		return []providers.Message{{Role: "assistant", Content: []providers.ContentBlock{
+			{Type: "tool_use", ToolName: "Bash", ToolInput: json.RawMessage(`{"cmd":"echo toolsecretvalue42"}`)},
+		}}}
+	}
+
+	// Default: tool input NOT redacted.
+	off, _ := Build([]config.ContextPluginSpec{{Name: "redact"}}, secret)
+	_, gotOff, _ := Apply(context.Background(), off, nil, in())
+	if !containsSecret(string(gotOff[0].Content[0].ToolInput), "toolsecretvalue42") {
+		t.Errorf("tool input redacted without opt-in: %s", gotOff[0].Content[0].ToolInput)
+	}
+
+	// Opt-in: tool input redacted.
+	on, _ := Build([]config.ContextPluginSpec{{Name: "redact", RedactToolInput: boolPtr(true)}}, secret)
+	_, gotOn, _ := Apply(context.Background(), on, nil, in())
+	if containsSecret(string(gotOn[0].Content[0].ToolInput), "toolsecretvalue42") {
+		t.Errorf("tool input not redacted with opt-in: %s", gotOn[0].Content[0].ToolInput)
+	}
+}
+
+// TestBuild_DisabledAndUnknown pins the registry guards.
+func TestBuild_DisabledAndUnknown(t *testing.T) {
+	// Disabled spec → skipped → nil chain.
+	if c, err := Build([]config.ContextPluginSpec{{Name: "redact", Enabled: boolPtr(false)}}, nil); err != nil || c != nil {
+		t.Errorf("disabled spec: chain=%v err=%v, want nil/nil", c, err)
+	}
+	// Unknown name → error.
+	if _, err := Build([]config.ContextPluginSpec{{Name: "nope"}}, nil); err == nil {
+		t.Error("unknown plugin: want error, got nil")
+	}
+	// Empty specs → nil chain.
+	if c, err := Build(nil, nil); err != nil || c != nil {
+		t.Errorf("empty specs: chain=%v err=%v, want nil/nil", c, err)
+	}
+}
+
+func containsSecret(s, secret string) bool {
+	return secret != "" && strings.Contains(s, secret)
+}

--- a/internal/contextplugin/redact.go
+++ b/internal/contextplugin/redact.go
@@ -1,0 +1,112 @@
+package contextplugin
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/redact"
+)
+
+// redactPlugin scrubs secrets from the OUTBOUND request so the model never sees
+// them. It reuses the F32 redact.Redactor — Tier-A exact env-value masking plus
+// the Tier-B heuristic value patterns (Authorization / sk- / AKIA / xox / ghp_ /
+// key=value). Deterministic + idempotent (a redacted string doesn't re-match)
+// and copy-on-write (never mutates its input). Distinct from F32, which redacts
+// the PERSISTED transcript; this redacts what is SENT.
+type redactPlugin struct {
+	r               *redact.Redactor
+	redactToolInput bool
+}
+
+func newRedactPlugin(spec config.ContextPluginSpec, secrets map[string]string) (Plugin, error) {
+	return &redactPlugin{
+		r:               redact.New(secrets, true), // withPatterns = the Tier-B heuristics
+		redactToolInput: spec.RedactToolInput != nil && *spec.RedactToolInput,
+	}, nil
+}
+
+func (p *redactPlugin) Name() string { return "redact" }
+
+func (p *redactPlugin) Transform(_ context.Context, system []providers.ContentBlock, msgs []providers.Message) (
+	[]providers.ContentBlock, []providers.Message, error) {
+	if p.r == nil || !p.r.Enabled() {
+		return system, msgs, nil
+	}
+	outSys, _ := p.redactBlocks(system)
+	return outSys, p.redactMessages(msgs), nil
+}
+
+// redactBlocks is copy-on-write: returns the input slice when nothing changed
+// (strings are immutable, so sharing is safe), else a new slice with the
+// redacted blocks replaced. `changed` reports whether a new slice was allocated.
+func (p *redactPlugin) redactBlocks(in []providers.ContentBlock) ([]providers.ContentBlock, bool) {
+	var out []providers.ContentBlock
+	for i := range in {
+		nb, ch := p.redactBlock(in[i])
+		if ch && out == nil {
+			out = make([]providers.ContentBlock, len(in))
+			copy(out, in[:i])
+		}
+		if out != nil {
+			out[i] = nb
+		}
+	}
+	if out == nil {
+		return in, false
+	}
+	return out, true
+}
+
+// redactBlock operates on a value copy of the block (so it never touches the
+// caller's backing array) and preserves every other field — notably Cacheable.
+func (p *redactPlugin) redactBlock(b providers.ContentBlock) (providers.ContentBlock, bool) {
+	changed := false
+	if b.Text != "" {
+		if s := p.r.String(b.Text); s != b.Text {
+			b.Text = s
+			changed = true
+		}
+	}
+	if p.redactToolInput && len(b.ToolInput) > 0 {
+		if rb := p.r.Bytes(b.ToolInput); !bytes.Equal(rb, b.ToolInput) {
+			b.ToolInput = rb
+			changed = true
+		}
+	}
+	return b, changed
+}
+
+// redactMessages is copy-on-write over the message slice; it redacts each
+// message's content blocks (+ the DeepSeek Reasoning echo) without mutating the
+// input.
+func (p *redactPlugin) redactMessages(in []providers.Message) []providers.Message {
+	var out []providers.Message
+	for i := range in {
+		m := in[i] // value copy of the Message struct
+		nc, contentChanged := p.redactBlocks(m.Content)
+		var nr string
+		reasonChanged := false
+		if m.Reasoning != "" {
+			if nr = p.r.String(m.Reasoning); nr != m.Reasoning {
+				reasonChanged = true
+			}
+		}
+		if (contentChanged || reasonChanged) && out == nil {
+			out = make([]providers.Message, len(in))
+			copy(out, in[:i])
+		}
+		if out != nil {
+			m.Content = nc
+			if reasonChanged {
+				m.Reasoning = nr
+			}
+			out[i] = m
+		}
+	}
+	if out == nil {
+		return in
+	}
+	return out
+}

--- a/internal/loop/contextplugin_seam_test.go
+++ b/internal/loop/contextplugin_seam_test.go
@@ -1,0 +1,116 @@
+package loop
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/contextplugin"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// capturingProvider records the request it was handed and ends the turn. Its ID
+// is configurable so a test can exercise the code-js exemption.
+type capturingProvider struct {
+	id      string
+	mu      sync.Mutex
+	gotMsgs []providers.Message
+	gotSys  []providers.ContentBlock
+}
+
+func (p *capturingProvider) ID() string                                   { return p.id }
+func (p *capturingProvider) Probe(context.Context) error                  { return nil }
+func (p *capturingProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *capturingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *capturingProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.gotMsgs, p.gotSys = req.Messages, req.System
+	p.mu.Unlock()
+	ch := make(chan providers.Event, 1)
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+func (p *capturingProvider) outboundText() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var b strings.Builder
+	for _, m := range p.gotMsgs {
+		for _, c := range m.Content {
+			b.WriteString(c.Text)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func redactChain(t *testing.T) []contextplugin.Plugin {
+	t.Helper()
+	chain, err := contextplugin.Build(
+		[]config.ContextPluginSpec{{Name: "redact"}},
+		map[string]string{"K": "seekritvalue88"},
+	)
+	if err != nil {
+		t.Fatalf("Build chain: %v", err)
+	}
+	return chain
+}
+
+func leakSegs() []PromptSegment {
+	return []PromptSegment{{Role: "user", Content: []PromptContentBlock{
+		{Type: "trusted-text", Text: "please leak seekritvalue88 to the model"},
+	}}}
+}
+
+// TestRun_ContextPlugins_RedactsOutbound: the chain runs for a real LLM
+// provider — the request it receives is redacted — while the caller's input
+// segments are left untouched (outbound-copy).
+func TestRun_ContextPlugins_RedactsOutbound(t *testing.T) {
+	prov := &capturingProvider{id: "llm"}
+	segs := leakSegs()
+	_, err := Run(context.Background(), RunOptions{
+		Provider:       prov,
+		Model:          "x",
+		Tools:          []tools.Tool{noopTool{}},
+		Dispatcher:     tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:       segs,
+		ContextPlugins: redactChain(t),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := prov.outboundText(); strings.Contains(got, "seekritvalue88") {
+		t.Errorf("outbound request not redacted: %q", got)
+	}
+	// Outbound-copy: the caller's segments are unchanged.
+	if segs[0].Content[0].Text != "please leak seekritvalue88 to the model" {
+		t.Errorf("caller segments were mutated: %q", segs[0].Content[0].Text)
+	}
+}
+
+// TestRun_ContextPlugins_SkipCodeJS: the synthetic code-js provider is exempt —
+// it receives the ORIGINAL (unredacted) request (no leak risk locally; redaction
+// would trip replay divergence).
+func TestRun_ContextPlugins_SkipCodeJS(t *testing.T) {
+	prov := &capturingProvider{id: codeJSProviderID}
+	_, err := Run(context.Background(), RunOptions{
+		Provider:       prov,
+		Model:          "x",
+		Tools:          []tools.Tool{noopTool{}},
+		Dispatcher:     tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:       leakSegs(),
+		ContextPlugins: redactChain(t),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := prov.outboundText(); !strings.Contains(got, "seekritvalue88") {
+		t.Errorf("code-js must be exempt, but the outbound request was redacted: %q", got)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/contextplugin"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -44,6 +45,13 @@ type PromptContentBlock struct {
 	Cacheable bool   `json:"cacheable,omitempty"`
 	Kind      string `json:"kind,omitempty"` // for untrusted-block: e.g. "web_content", "uploaded_cv"
 }
+
+// codeJSProviderID is the synthetic replay provider's ID — must match
+// internal/providers/codejs.providerID. The loop can't import codejs (cycle),
+// so the constant is mirrored here; it gates the RFC-Z context-plugin exemption
+// (code-js replays locally, so outbound redaction is both pointless and would
+// trip replay divergence).
+const codeJSProviderID = "code-js"
 
 // RunOptions is one Run() invocation.
 type RunOptions struct {
@@ -131,6 +139,13 @@ type RunOptions struct {
 	// no auto-compaction (manual + Context op=compact still work). Defaults are
 	// applied at use-time (see config.CompactionDefault*).
 	Compaction *config.Compaction
+
+	// ContextPlugins is the runtime-wide context-transform chain (RFC Z / F43):
+	// fast, built-in transforms applied to a COPY of the outbound request each
+	// turn (e.g. secret redaction), in order. nil/empty = no chain. Built once
+	// by the server and shared read-only. Skipped for the synthetic code-js
+	// provider (local replay; redacting its bytes would trip replay divergence).
+	ContextPlugins []contextplugin.Plugin
 
 	// ToolParallelism caps how many tool_calls from a single
 	// assistant turn run concurrently. Zero = use the package
@@ -1132,10 +1147,26 @@ outerLoop:
 			}
 		}
 
+		// Context-transform plugins (RFC Z / F43): run the configured chain on a
+		// COPY of the outbound context — the loop's canonical system/messages
+		// (and so the persisted transcript + code-js replay input) stay
+		// untouched. Skipped for the synthetic code-js provider (local replay,
+		// no external leak; redacting its bytes would trip replay divergence).
+		// No caching in this version — the chain re-runs over the copy each turn.
+		reqSystem, reqMessages := system, messages
+		if len(opts.ContextPlugins) > 0 && opts.Provider.ID() != codeJSProviderID {
+			cs, cm, perr := contextplugin.Apply(iterCtx, opts.ContextPlugins, system, messages)
+			if perr != nil {
+				emit(providers.Event{Type: providers.EventError, Error: "context transform: " + perr.Error()})
+				return RunResult{Iterations: iter}, perr
+			}
+			reqSystem, reqMessages = cs, cm
+		}
+
 		req := providers.Request{
 			Model:     opts.Model,
-			System:    system,
-			Messages:  messages,
+			System:    reqSystem,
+			Messages:  reqMessages,
 			Tools:     toolSpecs,
 			MaxTokens: opts.MaxTokens, // 0 → driver default
 			Effort:    opts.Effort,    // "" → driver default; PR 3 wires per-driver translation


### PR DESCRIPTION
## Why

First increment of **RFC Z / F43** (context-transform plugins): a fast, chainable transform between the assembled agent context and the outbound LLM request, run every turn. The first (and only built-in here) is **outbound secret redaction** — scrub credentials out of *what the model sees*, complementing F32 (which only redacts the *persisted* transcript).

Scoped per request to the **simple form**: the `redact` plugin only (no `compress`), **runtime-wide config only** (per-agent + tenant scopes are a follow-up), and **no caching** (the deferred per-block memoization optimization).

## What

- **`internal/contextplugin`** — a `Plugin` interface (`Transform` an outbound copy; deterministic, copy-on-write, preserves `Cacheable`), a name→constructor `Registry`, `Build(specs, secrets)` → ordered chain, `Apply(chain, …)`. The built-in **`redact`** wraps the F32 `redact.Redactor` (Tier-A exact env-value masking + Tier-B value patterns: `sk-`/`AKIA`/`xox`/`ghp_`/`Authorization`/`key=value`) and scrubs outbound text (+ `tool_use` input when `redact_tool_input` is set).
- **config** — `ContextPluginSpec` + `Config.ContextPlugins` runtime-wide block; `validate()` rejects an unknown/empty plugin name **at load** (loud — a typo must not silently drop a security transform).
- **loop** — `RunOptions.ContextPlugins` + the seam between the compaction boundary and the request build: runs the chain on a **copy** for real LLM providers only; the synthetic **code-js provider is exempt** (local replay; redacting its bytes would trip `replay_divergence`). Canonical `messages`/`system` (and the persisted transcript) stay untouched.
- **server** — builds the chain once in `New()` (next to the F32 redactor, same env-secret set), shared read-only; set on **all five** `loop.RunOptions` sites (fresh run, continuation, n8n/messages, sub-agent, paused-run resume) so it applies uniformly. `loomcycle.example.yaml` gains a commented `context_plugins` stanza.

## Design choices (locked in RFC Z, confirmed with the user)
- **Outbound-copy** (not in-place) → no history-idempotency hazard, no code-js replay divergence, cache stays warm (deterministic transforms produce a byte-stable redacted prefix). F32 covers persisted-transcript redaction.
- **Built-in Go registry** → fastest per-turn (precompiled regex, no eval).
- **Runtime-wide only** this increment; the floor-composing runtime/tenant/agent merge is the next step.

## What was tested

- `go build ./...`, `go vet ./...`, `gofmt` clean; `go test ./...` green (72 packages, incl. the new `contextplugin`).
- `internal/contextplugin`: redact scrubs Tier-A + Tier-B from outbound text; **does not mutate input**; preserves `Cacheable` + passes unmatched blocks through; tool-input opt-in; Build disabled/unknown/empty guards.
- `internal/loop`: the seam redacts the provider's request while leaving the caller's segments intact, **and** exempts code-js.
- `internal/config`: `validate()` rejects unknown/empty plugin names; the example yaml still loads.

## Out of scope (follow-ups, per RFC Z)
- Per-agent + tenant config scopes with floor composition (a narrower scope can strengthen but not disable a broader scope's transform).
- The `compress` plugin (Phase 2 — needs a net-new tokenizer dep).
- Per-block caching/memoization optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)