### PR TITLE
examples: add exp7-code-review-fanout (MCP spawn_runs / RFC Y)

### DIFF
--- a/examples/exp7-code-review-fanout/.env.local.example
+++ b/examples/exp7-code-review-fanout/.env.local.example
@@ -1,0 +1,9 @@
+# exp7 secrets — copy to .env.local (run.sh does it on first run). No external services needed
+# beyond a provider + a Go repo to review (cloned into ./work/loomcycle-src — see README step 1).
+
+# Bearer for the loomcycle REST API (/v1/*) AND the MCP thin client's upstream. Empty = dev open
+# mode (no auth). For a non-trivial setup: openssl rand -hex 32
+LOOMCYCLE_AUTH_TOKEN=
+
+# Model fallback (deepseek-v4-pro). Or use the Anthropic OAuth primary (loomcycle anthropic login).
+DEEPSEEK_API_KEY=

--- a/examples/exp7-code-review-fanout/.gitignore
+++ b/examples/exp7-code-review-fanout/.gitignore
@@ -1,0 +1,10 @@
+# runtime state + secrets (never commit)
+.env.local
+data/*.db
+data/*.db-wal
+data/*.db-shm
+# the review target is cloned at run time, not committed
+work/loomcycle-src/
+# scratch
+work/__pycache__/
+work/*.tmp

--- a/examples/exp7-code-review-fanout/README.md
+++ b/examples/exp7-code-review-fanout/README.md
@@ -1,0 +1,191 @@
+# exp7 — delegate a real code review to loomcycle (MCP fan-out)
+
+An external orchestrator (Claude Code, or the `work/exp7_run.sh` driver here) **delegates a whole
+code review to loomcycle and fans the reviewers out _through the MCP server_** — one
+[`spawn_runs`](#the-primitive-spawn_runs-rfc-y) call spawns **10 read-only `code-reviewer` agents**
+concurrently over repo slices; each records its confidence-scored findings to **Memory**; then one
+`spawn_run` runs a **consolidator** that merges the ledger and returns the executive report. The
+orchestrator's own context never reads the code — loomcycle's agents do.
+
+It exercises loomcycle as a **runtime for someone else's agents**: import a Claude Code agent + skill
+(`loomcycle import claude-code`), fan it out natively over MCP (RFC Y `spawn_runs`), collect via
+Memory, consolidate, return.
+
+```
+ ORCHESTRATOR (Claude Code / ./work/exp7_run.sh)        loomcycle MCP thin client: `loomcycle mcp --upstream`
+   step 1.  git clone <a Go repo> → work/loomcycle-src   (read-only review target, inside the jail)
+   step 2.  ONE spawn_runs  (MCP, mode=join, N=10)  ─────────────────────────►  loomcycle runtime
+              spawns=[ {agent:code-reviewer, prompt: slice=<s> path=<p>} ×10 ]     (server-side concurrent,
+              join AND-barrier: blocks until all 10 settle → index-aligned envelope  bounded by admission gate)
+                    │
+                    ▼
+              10 × code-reviewer (one per slice), each:
+                Glob/Grep/Read loomcycle-src/<path> (READ-ONLY, relative to read-root)
+                → Memory.set review:<slice>:findings   (confidence ≥ 80 only, file:line + fix)
+   step 3.  ONE spawn_run  (MCP) → exp7-consolidator
+              Memory.list "review:" → merge + dedup + count → Memory.set consolidated:report → RETURN
+   step 4.  orchestrator reads the report (consolidator final_text / consolidated:report)
+```
+
+The `spawn_runs` join barrier **is** the fan-in — there is no in-loomcycle dispatcher agent and no
+fan-in channel. (loomcycle < v0.32.0 had no `spawn_runs`; the original sandbox exp7 used an
+in-loomcycle dispatcher + `Agent op=parallel_spawn` as the workaround — that motivated RFC Y, shipped
+in v0.32.0. See [the note below](#a-note-on-the-sandbox-origin--rfc-y).)
+
+## What it demonstrates
+
+| Primitive | Role |
+|---|---|
+| **`loomcycle import claude-code`** | bring a Claude Code `code-reviewer` agent + a `code-review` skill into loomcycle yaml (`tools`→`allowed_tools`, body→`system_prompt`, skill body bundled at load) |
+| **`spawn_runs` (RFC Y, MCP/`POST /v1/runs:batch`)** | the **external fan-out** — ONE call spawns N runs server-side-concurrent, `mode:join` blocks until all settle, returns an index-aligned envelope (a per-child failure is captured in-envelope, never fails the batch) |
+| **`spawn_run` (MCP)** | the single consolidator run after the fan-out |
+| **`Memory` (user scope)** | the shared findings ledger — `review:<slice>:findings` per reviewer → `consolidated:report` |
+| **read-only `Read`/`Grep`/`Glob` jail** | reviewers get the file tools sandboxed to `LOOMCYCLE_READ_ROOT` with **no Bash/Write** — they can read the repo but not mutate or execute |
+| **`Context op=self`** | each reviewer self-reports its `run_id` into its findings (provenance) |
+
+Routing: **Anthropic OAuth (primary) → deepseek-v4-pro (fallback)** via `tier: middle`.
+
+## Prerequisites
+- **loomcycle ≥ v0.32.0** on PATH (or `LOOMCYCLE_BIN`) — `spawn_runs` shipped in v0.32.0. Check:
+  `loomcycle --version`.
+- **A provider** — Anthropic OAuth (`loomcycle anthropic login`, kept enabled by `run.sh`) or
+  `DEEPSEEK_API_KEY` in `.env.local`.
+- **`git`** (to clone the review target) and **`python3`** (the driver + MCP client are stdlib-only).
+
+⚠️ Not fully self-contained: you clone a Go repo to review (step 1). Everything else is local — no
+external services, no MCP servers to install, no scheduler/webhooks.
+
+## Step 1 — clone the review target into the jail
+The reviewers read `work/loomcycle-src/<slice>` (relative to the read-root `./work`). Clone any Go
+repo there; the default slices match **loomcycle's own** layout, so reviewing loomcycle is the
+turnkey path:
+```bash
+cd examples/exp7-code-review-fanout
+git clone --depth 1 https://github.com/denn-gubsky/loomcycle work/loomcycle-src
+# (or point at your own checkout: cp -r /path/to/loomcycle work/loomcycle-src — Go repo, the 10
+#  default slices are internal/api/http, internal/tools/builtin, …, cmd/loomcycle; edit them in
+#  work/exp7_run.sh's SLICES list if your repo differs.)
+```
+
+## Step 2 — run + drive
+
+> **`loomcycle validate` note:** this is tier-based config (for the OAuth→deepseek fallback), so
+> `validate` reports `no provider resolved` — it doesn't probe providers. Not a config bug; verify by
+> **running** and watching the boot `resolve probe:` lines (and `skills: loaded 1`).
+
+Terminal 1 — start the server:
+```bash
+cd examples/exp7-code-review-fanout
+./run.sh        # first launch copies .env.local.example → .env.local; add a provider, re-run
+```
+You should see `skills: loaded 1 from …/skills` and `loomcycle listening on 127.0.0.1:8787`.
+
+Terminal 2 — **smoke-test the MCP path** (one reviewer, the small `pause` slice), then run the full
+delegation:
+```bash
+cd examples/exp7-code-review-fanout
+./work/exp7_run.sh smoke        # spawn_runs N=1 → validate the MCP fan-out end-to-end (~1-2 min)
+./work/exp7_run.sh delegate     # spawn_runs N=10 + the consolidator (~8-15 min; see the throttle note)
+```
+`delegate` prints the per-child envelope (each reviewer's `run_id` + status + its `REVIEWED` line),
+then the consolidator's returned report. Expect something like:
+```
+[fanout] caller -> MCP spawn_runs: fanning out 10 code-reviewer run(s) (mode=join)...
+  envelope: 10 child result(s)
+    completed run=r_…  REVIEWED slice=api-http files=15 issues=4
+    completed run=r_…  REVIEWED slice=store    files=12 issues=7
+    …
+[consolidate] caller -> MCP spawn_run: exp7-consolidator …
+  --- consolidated:report (from Memory) ---
+  { "slices_reviewed":"10/10", "files_reviewed":86, "total_issues":35,
+    "by_severity":{"Critical":1,"Important":34}, "top_findings":[ … ], "summary":"…" }
+```
+(Exact counts vary — the reviewers are LLM agents over a real repo.)
+
+### How the fan-out goes "through MCP"
+`work/exp7_mcp.py` launches `loomcycle mcp --upstream http://127.0.0.1:8787` (the same thin client
+that backs the Claude Code loomcycle plugin) and speaks JSON-RPC to it over stdio — `initialize` →
+`tools/call spawn_runs`. The thin client proxies to the runtime's `/v1/_mcp`. The upstream bearer is
+passed via the `LOOMCYCLE_MCP_UPSTREAM_TOKEN` env (never argv/printed); empty = open mode.
+
+**Three equivalent ways to drive the same `spawn_runs` handler:**
+1. **This driver** (`work/exp7_run.sh`) — MCP stdio thin client, no Claude Code needed. ← default
+2. **Claude Code's loomcycle plugin** — `/loomcycle:connect --base-url=http://127.0.0.1:8787` then
+   `/loomcycle:fanout code-reviewer --count=10 <prompt>` (the `mcp__loomcycle__spawn_runs` tool).
+3. **REST** — `POST /v1/runs:batch` with `{spawns:[…], mode:"join"}` via `./loomcurl.sh`.
+
+## Verify (independent re-derivation — don't trust the consolidator's narration)
+`delegate` ends by leaving the ledger in the store; re-derive it any time:
+```bash
+./work/exp7_run.sh verify
+```
+It reads straight from the store and checks:
+- **Coverage** — how many of the 10 `review:<slice>:findings` recorded (and per-slice file/issue counts).
+- **The report is grounded** — `consolidated:report` only aggregates what the reviewers recorded.
+- Each finding cites a real `file:line` you can open in `work/loomcycle-src` and confirm.
+
+By hand:
+```bash
+BASE=http://127.0.0.1:8787
+./loomcurl.sh "$BASE/v1/_memory/scopes/user/exp7/keys?prefix=review:&limit=100"   # the per-slice ledger
+./loomcurl.sh "$BASE/v1/_memory/scopes/user/exp7/keys/consolidated:report"        # the returned report
+```
+**Read-only safety:** reviewers have `[Read, Grep, Glob, Memory, Context]` — no Bash/Write; nothing
+under `work/loomcycle-src` is ever modified.
+
+## The throttle (rate limits) — important
+10 concurrent sonnet reviewers each reading 10–15 files can **saturate a subscription (OAuth) account
+rate limit** (HTTP 429). So `loomcycle.yaml` sets `concurrency.max_concurrent_runs: 4` (+ a long
+`queue_timeout_ms`): the `spawn_runs` join still accepts all 10 — the other 6 **queue** and run as
+slots free. If you drive on a **paid API key** with more headroom, raise `max_concurrent_runs` for a
+faster wall-clock. (`queue_timeout_ms` must exceed a reviewer's runtime, or queued children are
+rejected instead of waiting.)
+
+## Provenance — how `code-reviewer` was imported
+`./claude-code-src/agents/code-reviewer.md` + `./claude-code-src/skills/code-review/SKILL.md` are the
+Claude Code source artifacts (a normal `.claude`-layout dir — `agents/` + `skills/` — renamed only
+because the loomcycle repo gitignores `.claude/`; the importer reads the structure, not the name).
+They were imported into `loomcycle.yaml` with:
+```bash
+loomcycle import claude-code --from=./claude-code-src --write --diff=./loomcycle.yaml --skills-dest=./skills
+```
+The importer maps `tools`→`allowed_tools` and the body→`system_prompt`, and copies the skill to
+`./skills/code-review/SKILL.md` (bundled into the reviewer's prompt at load via `LOOMCYCLE_SKILLS_ROOT`).
+Two manual touch-ups after import (both noted in `loomcycle.yaml`): the importer **drops the agent's
+`skills:` frontmatter**, so `skills:[code-review]` is re-attached; and `model: sonnet` (a Claude-Code
+alias) is replaced with `tier: middle`. The shipped `loomcycle.yaml` is the post-import result, ready
+to run — you don't need to re-run the import unless you change the source artifacts.
+
+## Tuning
+- **Slices.** The 10 `(slice, path)` pairs live in `work/exp7_run.sh`'s `SLICES` list (and the
+  consolidator's expected-keys list in `loomcycle.yaml`). Edit them to match your repo, or cut the
+  list down for a cheaper run.
+- **Reviewer budget.** `code-reviewer.max_iterations` (40) / `max_tokens` (8192) — raise for very
+  large slices.
+- **Model.** `tier: middle` = sonnet → deepseek. Drop the reviewers to `tier: low` (haiku/flash) for
+  a cheaper, faster pass.
+
+## Teardown
+Ctrl-C the server; `rm -rf data` for a clean ledger; `rm -rf work/loomcycle-src` to drop the clone.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `loomcycle.yaml` | routing + `code-reviewer` (imported, read-only) + `exp7-consolidator`; throttled concurrency |
+| `run.sh` | launcher — sets the read-only jail (`LOOMCYCLE_READ_ROOT=./work`) + skills root + MCP upstream token |
+| `claude-code-src/{agents/code-reviewer.md,skills/code-review/SKILL.md}` | the Claude Code source artifacts the import was produced from (provenance; `.claude`-layout) |
+| `skills/code-review/SKILL.md` | the imported skill body, bundled into the reviewer's prompt at load |
+| `work/exp7_mcp.py` | token-safe MCP stdio JSON-RPC client driving `loomcycle mcp --upstream` |
+| `work/exp7_run.sh` | the driver — `smoke` / `fanout` / `consolidate` / `delegate` / `verify` |
+| `loomcurl.sh` | token-safe loomcycle REST helper (omits the bearer in dev open mode) |
+| `.env.local.example` | secret template (empty) — bearer + provider only |
+
+## A note on the sandbox origin + RFC Y
+This is the **static, self-contained** form of loomcycle sandbox **Experiment #7**. The original
+exp7 ran before `spawn_runs` existed and had to fan out with an **in-loomcycle dispatcher agent**
+(`Agent op=parallel_spawn`), because an external caller couldn't fan out N runs over MCP in one call
+— N concurrent blocking calls serialise over a single MCP connection. That gap was filed as **RFC Y
+(external fan-out run)** and **shipped in v0.32.0** as `spawn_runs` (MCP) + `POST /v1/runs:batch`
+(REST), `mode:join`, cap 32, reusing the in-loop `parallel_spawn` core at the external boundary. This
+example is the post-RFC-Y topology: the dispatcher is gone; the fan-out happens at the MCP boundary.

--- a/examples/exp7-code-review-fanout/claude-code-src/agents/code-reviewer.md
+++ b/examples/exp7-code-review-fanout/claude-code-src/agents/code-reviewer.md
@@ -1,0 +1,41 @@
+---
+name: code-reviewer
+description: Reviews a slice of a code repository for bugs, security, and quality with confidence-based filtering (reports only high-confidence issues). Read-only.
+tools: Read, Grep, Glob, Memory, Context
+model: sonnet
+skills: [code-review]
+---
+
+You are an expert CODE REVIEWER (read-only) working one slice of a Go repository. The repo is
+cloned inside your sandbox read-root: your cwd IS the read-root, and the repo lives at
+`loomcycle-src/` directly beneath it. ALWAYS address files by the path RELATIVE to the read-root
+(e.g. `loomcycle-src/internal/api/http/server.go`), NOT by an absolute `/…` path — the Glob/Read
+sandbox resolves relative to the read-root, and an absolute `**` pattern will NOT match. Follow the
+**code-review** skill: confidence-score every candidate issue and report only those with
+**confidence ≥ 80**; apply the Karpathy guidelines (surface assumptions, flag overcomplication /
+non-surgical changes, prefer verifiable findings). Honor the repo's own `CLAUDE.md` where present.
+
+The user message gives you `slice=<name>` and a `path=` (a subdirectory under `loomcycle-src/`).
+
+PROCEDURE — do exactly this, then stop:
+1. Discover the slice: `Glob` `loomcycle-src/<path>/**/*.go` (RELATIVE; skip `*_test.go` unless
+   reviewing tests). The repo IS present — if a glob returns no matches, do NOT conclude the repo is
+   missing: retry with a shallower pattern (`loomcycle-src/<path>/*.go`) and/or `Read` known files
+   directly. Then `Read` the most important 10–15 source files — prioritise entrypoints, request
+   handlers, lifecycle/shutdown, locking, and the largest files; do NOT read every file in a big
+   slice. Use `Grep` to scan the WHOLE slice for risky patterns (error-dropping, unchecked type
+   assertions, `panic`, goroutine/lock misuse, unbounded reads, secret-ish strings, missing context
+   cancellation, etc.) and Read only the hits worth confirming.
+2. Form findings. For each issue keep only confidence ≥ 80: `{file, line, severity:"Critical"|
+   "Important", confidence, message, fix}`. Be precise — cite real `file:line` you actually read.
+3. Record (run-id from `Context op=self`):
+   `Memory op=set scope=user key="review:<slice>:findings"` value (compact JSON):
+   `{"slice":"<slice>","run_id":"<id>","path":"<path>","files_reviewed":<n>,
+     "issues":[ ... ≥80-confidence only ... ],"summary":"<2-3 sentence audit>"}`
+   (If the slice is clean, write `issues:[]` + a "meets standards" summary — still record it.)
+4. Output one line: `REVIEWED slice=<slice> files=<n> issues=<k>` and stop. (This line is your
+   final_text — it rides back in the `spawn_runs` join envelope to the caller.)
+
+Rules: READ-ONLY — never write/edit/execute (you have no Bash/Write). Stay under `loomcycle-src/`
+(relative to the read-root). Keep memory values compact JSON. Reference any secret by name only (you
+handle none).

--- a/examples/exp7-code-review-fanout/claude-code-src/skills/code-review/SKILL.md
+++ b/examples/exp7-code-review-fanout/claude-code-src/skills/code-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-review
+description: How to review a slice of a code repository with high precision — confidence-scored findings, project-guideline compliance, and Karpathy behavioral guidelines (simplicity, surgical scope, surfaced assumptions). Use when reviewing or auditing source files.
+license: MIT
+allowed_tools: [Read, Grep, Glob]
+---
+
+# Code Review
+
+Synthesized for loomcycle exp7 from Claude Code's `code-reviewer` agent + `code-review` command +
+the `karpathy-guidelines` skill. Methodology for reviewing a slice of a repository with high
+precision and minimal false positives.
+
+## What to look for
+- **Project-guideline compliance.** Honor the repo's own rules (e.g. `CLAUDE.md`): import patterns,
+  error handling, logging, naming, platform compatibility, testing conventions.
+- **Bugs that bite in practice.** Logic errors, nil/undefined handling, race conditions, resource
+  leaks, unchecked errors, security issues (injection, secret handling, authz gaps), performance.
+- **Quality.** Significant duplication, missing critical error handling, inadequate test coverage.
+
+## Confidence scoring (the precision lever)
+Rate each candidate issue 0–100:
+- **0** false positive / pre-existing; **25** maybe; **50** real but minor/nit; **75** verified, will
+  hit in practice / guideline-backed; **100** certain, frequent.
+- **Only report issues with confidence ≥ 80.** Quality over quantity — a short list of true issues
+  beats a long list of nits.
+
+## Karpathy behavioral guidelines (apply to the review itself)
+- **Surface assumptions.** If a finding depends on an assumption (caller behavior, invariant), say
+  so. If unsure, lower the confidence rather than over-claim.
+- **Simplicity.** Flag overcomplication: speculative abstractions, unrequested configurability,
+  error handling for impossible cases, 200 lines that could be 50.
+- **Surgical scope.** Judge whether changes touch only what they must; flag drive-by edits/refactors
+  and orphaned (newly-unused) imports/vars. Don't demand rewrites of code that isn't broken.
+- **Verifiable.** Prefer findings a developer can act on + verify (a failing case, a concrete fix).
+
+## Output per issue
+`file:line` · severity (Critical | Important) · confidence · one-line problem · concrete fix.
+Group by severity. If no ≥80 issues in the slice, say so with a one-line "meets standards" summary.

--- a/examples/exp7-code-review-fanout/loomcurl.sh
+++ b/examples/exp7-code-review-fanout/loomcurl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Token-safe curl to the local loomcycle REST API. Sources .env.local and passes
+# the bearer via a STDIN config (-K -) so LOOMCYCLE_AUTH_TOKEN never appears in argv.
+# If LOOMCYCLE_AUTH_TOKEN is empty (dev open mode), the header is simply omitted.
+#   ./loomcurl.sh -X POST http://127.0.0.1:8787/v1/runs -H 'Content-Type: application/json' -d @body.json
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a; [ -f "$HERE/.env.local" ] && source "$HERE/.env.local"; set +a
+if [ -n "${LOOMCYCLE_AUTH_TOKEN:-}" ]; then
+  printf 'header = "Authorization: Bearer %s"\n' "$LOOMCYCLE_AUTH_TOKEN" | curl -sS -K - "$@"
+else
+  curl -sS "$@"
+fi

--- a/examples/exp7-code-review-fanout/loomcycle.yaml
+++ b/examples/exp7-code-review-fanout/loomcycle.yaml
@@ -1,0 +1,148 @@
+# exp7 — Claude Code delegates a real code review to loomcycle, fanning the reviewers
+#        out THROUGH THE MCP SERVER (RFC Y `spawn_runs`, loomcycle ≥ v0.32.0).
+#
+# An external orchestrator (Claude Code, or the `work/exp7_run.sh` driver here) clones a Go repo
+# into the jail (work/loomcycle-src), then:
+#
+#   1. ONE `spawn_runs` MCP call (mode=join, N=10) → 10 × `code-reviewer` runs server-side
+#      CONCURRENTLY (bounded by the admission gate); the join AND-barrier returns the index-aligned
+#      envelope when all settle. Each reviewer reads ONE repo slice (READ-ONLY) and writes its
+#      confidence-≥80 findings to Memory (review:<slice>:findings).
+#   2. ONE `spawn_run` MCP call → `exp7-consolidator`, which reads the review:* ledger, merges +
+#      counts, writes consolidated:report, and RETURNS the executive report — back to the caller.
+#
+# The `spawn_runs` join barrier IS the fan-in — there is NO in-loomcycle dispatcher agent and NO
+# fan-in channel. (loomcycle < v0.32.0 had no `spawn_runs`; the original sandbox exp7 used an
+# in-loomcycle dispatcher + `Agent op=parallel_spawn` as the workaround — that motivated RFC Y,
+# shipped in v0.32.0.)
+#
+# Substrate (all shipped): `loomcycle import claude-code` + skills bundling, the MCP `spawn_runs`
+# external fan-out (RFC Y), Memory (user scope), the read-only Read/Grep/Glob jail. The reviewer is
+# read-only (no Bash/Write). Routing: Anthropic OAuth → deepseek-v4-pro (tier: middle = sonnet).
+#
+# `run.sh` sets the jail (LOOMCYCLE_READ_ROOT=./work) and the skills root
+# (LOOMCYCLE_SKILLS_ROOT=./skills) so the imported code-review skill body is bundled into the
+# reviewer's system prompt at config-load (boot log: `skills: loaded 1`).
+#
+# PROVENANCE — how `code-reviewer` was produced: `./claude-code-src/agents/code-reviewer.md` (+
+# `./claude-code-src/skills/code-review/SKILL.md`) are the Claude Code source artifacts; imported with
+#   loomcycle import claude-code --from=./claude-code-src --write --diff=./loomcycle.yaml --skills-dest=./skills
+# (claude-code-src/ is a normal `.claude`-layout dir — agents/ + skills/ — renamed only because the
+#  loomcycle repo gitignores `.claude/`; the importer reads the structure, not the dir name).
+# (tools→allowed_tools, body→system_prompt). The importer drops the agent's `skills:` frontmatter
+# ("no loomcycle equivalent"), so `skills:[code-review]` is re-attached here, and `model: sonnet`
+# (a Claude-Code alias) is replaced with `tier: middle`. The agent below is the post-import result.
+
+provider_priority:
+  - anthropic-oauth-dev
+  - deepseek
+
+tiers:
+  middle:
+    - { provider: anthropic-oauth-dev, model: claude-sonnet-4-6 }
+    - { provider: deepseek,            model: deepseek-v4-pro }
+  low:
+    - { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
+    - { provider: deepseek,            model: deepseek-v4-flash }
+  high:
+    - { provider: anthropic-oauth-dev, model: claude-sonnet-4-6 }
+    - { provider: deepseek,            model: deepseek-v4-pro }
+
+user_tiers:
+  default:
+    provider_priority: [anthropic-oauth-dev, deepseek]
+    fallback_on_error: true
+    max_fallback_attempts: 3
+
+agents:
+  # ───────────────────────── code-reviewer (imported; fanned out via MCP spawn_runs) ─────────────────────────
+  # Claude Code / the driver fans out N=10 of THESE in ONE `spawn_runs` (mode=join) MCP call — no
+  # in-loomcycle dispatcher. Each spawn carries its `slice=`/`path=` in the prompt.
+  code-reviewer:
+    tier: middle              # sonnet (OAuth) → deepseek-v4-pro fallback (replaces the imported `model: sonnet`)
+    max_iterations: 40        # large slices finish + record
+    max_tokens: 8192
+    effort: medium
+    skills: [code-review]     # re-attached (the importer drops the agent's `skills:` frontmatter)
+    memory_scopes: [user]
+    allowed_tools: [Read, Grep, Glob, Memory, Context]   # READ-ONLY — no Bash/Write
+    system_prompt: |2
+      You are an expert CODE REVIEWER (read-only) working one slice of a Go repository. The repo is
+      cloned inside your sandbox read-root: **your cwd IS the read-root**, and the repo lives at
+      `loomcycle-src/` directly beneath it. ALWAYS address files by the path RELATIVE to the read-root
+      (e.g. `loomcycle-src/internal/api/http/server.go`), NOT by an absolute `/…` path — the Glob/Read
+      sandbox resolves relative to the read-root, and an absolute `**` pattern will NOT match. Follow
+      the **code-review** skill: confidence-score every candidate issue and report only those with
+      **confidence ≥ 80**; apply the Karpathy guidelines (surface assumptions, flag overcomplication /
+      non-surgical changes, prefer verifiable findings). Honor the repo's own `CLAUDE.md` where present.
+
+      The user message gives you `slice=<name>` and a `path=` (a subdirectory under `loomcycle-src/`).
+
+      PROCEDURE — do exactly this, then stop:
+      1. Discover the slice: `Glob` `loomcycle-src/<path>/**/*.go` (RELATIVE; skip `*_test.go` unless
+         reviewing tests). The repo IS present — if a glob returns no matches, do NOT conclude the repo
+         is missing: retry with a shallower pattern (`loomcycle-src/<path>/*.go`) and/or `Read` known
+         files directly. Then `Read` the **most important 10–15 source files** — prioritise entrypoints,
+         request handlers, lifecycle/shutdown, locking, and the largest files; do NOT read every file in
+         a big slice (it wastes the token budget). Use `Grep` to scan the WHOLE slice for risky patterns
+         instead (error-dropping, unchecked type assertions, `panic`, goroutine/lock misuse, unbounded
+         reads, secret-ish strings, missing context cancellation, etc.) and Read only the hits worth
+         confirming.
+      2. Form findings. For each issue keep only confidence ≥ 80: `{file, line, severity:"Critical"|
+         "Important", confidence, message, fix}`. Be precise — cite real `file:line` you actually read.
+      3. Record (run-id from `Context op=self`):
+         `Memory op=set scope=user key="review:<slice>:findings"` value (compact JSON):
+         `{"slice":"<slice>","run_id":"<id>","path":"<path>","files_reviewed":<n>,
+           "issues":[ ... ≥80-confidence only ... ],"summary":"<2-3 sentence audit>"}`
+         (If the slice is clean, write `issues:[]` + a "meets standards" summary — still record it.)
+      4. Output one line: `REVIEWED slice=<slice> files=<n> issues=<k>` and stop. (This line is your
+         final_text — it rides back in the `spawn_runs` join envelope to the caller.)
+
+      Rules: READ-ONLY — never write/edit/execute (you have no Bash/Write). Stay under `loomcycle-src/`
+      (relative to the read-root). Keep memory values compact JSON. Reference any secret by name only.
+
+  # ───────────────────────── exp7-consolidator (single spawn_run after the fan-out) ─────────────────────────
+  # The caller spawns THIS once (a single MCP `spawn_run`) AFTER the `spawn_runs` fan-out settles.
+  # It reads the review:* ledger the 10 reviewers wrote, merges + counts, writes consolidated:report,
+  # and returns the executive report as its final_text — the delegated result the caller keeps.
+  exp7-consolidator:
+    tier: middle
+    max_iterations: 12
+    max_tokens: 8192
+    effort: high
+    allowed_tools: [Memory, Context]
+    memory_scopes: [user]
+    system_prompt: |
+      You are EXP7-CONSOLIDATOR. Ten read-only `code-reviewer` agents were just fanned out (via the
+      MCP `spawn_runs` call) over 10 slices of a Go repo; each wrote its findings to Memory under key
+      `review:<slice>:findings`. Your job: gather them, consolidate, and return one report. CONSTANTS:
+      N=10 slices; user_id is the run's user_id.
+
+      SLICES (the 10 expected keys): api-http, tools-builtin, providers, store, config, snapshot,
+        scheduler, pause, channels, cmd.
+
+      PROCEDURE:
+      1. GATHER: `Memory op=list scope=user prefix="review:" limit=100` → collect each
+         `review:<slice>:findings` value (parse the compact JSON). Note which of the 10 slices recorded.
+      2. CONSOLIDATE: merge all issues; dedup obvious repeats; count by severity (Critical/Important)
+         and by slice; pick the top ~10 highest-confidence findings across the repo.
+      3. WRITE: `Memory op=set scope=user key="consolidated:report"` value (JSON):
+           {"slices_reviewed":<k>/10,"files_reviewed":<sum>,"total_issues":<n>,
+            "by_severity":{"Critical":<c>,"Important":<i>},"by_slice":{...},
+            "top_findings":[{"slice","file","line","severity","confidence","message","fix"} ...up to 10],
+            "summary":"<3-5 sentence executive code-review summary of the repo>"}
+      4. RETURN: output a concise human-readable report (the executive summary + the top findings as a
+         bulleted list with file:line + severity) as your final message — this goes back to the caller.
+
+      Never invent findings; only consolidate what the reviewers actually recorded. If a slice is
+      missing from the ledger, report it as 0/not-recorded — do not fabricate. Reference secrets by name only.
+
+concurrency:
+  # Throttle the fan-out: 10 concurrent heavy sonnet reviewers can saturate a subscription (OAuth)
+  # account rate limit (HTTP 429). Run a few at a time; the `spawn_runs` join still accepts all 10 —
+  # the rest QUEUE and run as slots free. queue_timeout MUST exceed a reviewer's wall-clock so queued
+  # children wait for a slot instead of being rejected. (Raise max_concurrent_runs if your provider /
+  # plan has the headroom — e.g. a paid API key rather than a subscription.)
+  max_concurrent_runs: 4
+  max_queue_depth: 24
+  queue_timeout_ms: 1200000

--- a/examples/exp7-code-review-fanout/run.sh
+++ b/examples/exp7-code-review-fanout/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Launch exp7 (code-review fan-out) self-contained from this folder. Needs loomcycle ≥ v0.32.0
+# (for the `spawn_runs` MCP fan-out) + a provider. Drive it from a second terminal:
+#   ./work/exp7_run.sh delegate     (clone the review target first — see README step 1)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$HERE/.env.local" ] || { cp "$HERE/.env.local.example" "$HERE/.env.local"; \
+  echo "run.sh: created .env.local — add a provider (loomcycle anthropic login, or DEEPSEEK_API_KEY)."; }
+set -a; source "$HERE/.env.local"; set +a
+
+export LOOMCYCLE_DATA_DIR="${LOOMCYCLE_DATA_DIR:-$HERE/data}"
+export LOOMCYCLE_LISTEN_ADDR="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
+export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED="${LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED:-1}"
+
+# The read-only review jail + the imported skill. The reviewers get Read/Grep/Glob sandboxed to
+# LOOMCYCLE_READ_ROOT (=./work); the repo under review is cloned to ./work/loomcycle-src and
+# addressed by reviewers RELATIVE to the read-root (loomcycle-src/<path>). No Bash/Write/egress.
+export LOOMCYCLE_READ_ROOT="${LOOMCYCLE_READ_ROOT:-$HERE/work}"
+export LOOMCYCLE_SKILLS_ROOT="${LOOMCYCLE_SKILLS_ROOT:-$HERE/skills}"   # bundle ./skills/code-review/SKILL.md
+# Bearer the MCP thin client (work/exp7_mcp.py → `loomcycle mcp --upstream`) uses to reach this runtime.
+export LOOMCYCLE_MCP_UPSTREAM_TOKEN="${LOOMCYCLE_MCP_UPSTREAM_TOKEN:-${LOOMCYCLE_AUTH_TOKEN:-}}"
+
+mkdir -p "$HERE/data" "$HERE/work"
+LOOMCYCLE_BIN="${LOOMCYCLE_BIN:-loomcycle}"
+command -v "$LOOMCYCLE_BIN" >/dev/null 2>&1 || { echo "run.sh: '$LOOMCYCLE_BIN' not on PATH — install loomcycle (≥ v0.32.0) or set LOOMCYCLE_BIN." >&2; exit 127; }
+exec "$LOOMCYCLE_BIN" "$@" --config "$HERE/loomcycle.yaml"

--- a/examples/exp7-code-review-fanout/skills/code-review/SKILL.md
+++ b/examples/exp7-code-review-fanout/skills/code-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: code-review
+description: How to review a slice of a code repository with high precision — confidence-scored findings, project-guideline compliance, and Karpathy behavioral guidelines (simplicity, surgical scope, surfaced assumptions). Use when reviewing or auditing source files.
+license: MIT
+allowed_tools: [Read, Grep, Glob]
+---
+
+# Code Review
+
+Synthesized for loomcycle exp7 from Claude Code's `code-reviewer` agent + `code-review` command +
+the `karpathy-guidelines` skill. Methodology for reviewing a slice of a repository with high
+precision and minimal false positives.
+
+## What to look for
+- **Project-guideline compliance.** Honor the repo's own rules (e.g. `CLAUDE.md`): import patterns,
+  error handling, logging, naming, platform compatibility, testing conventions.
+- **Bugs that bite in practice.** Logic errors, nil/undefined handling, race conditions, resource
+  leaks, unchecked errors, security issues (injection, secret handling, authz gaps), performance.
+- **Quality.** Significant duplication, missing critical error handling, inadequate test coverage.
+
+## Confidence scoring (the precision lever)
+Rate each candidate issue 0–100:
+- **0** false positive / pre-existing; **25** maybe; **50** real but minor/nit; **75** verified, will
+  hit in practice / guideline-backed; **100** certain, frequent.
+- **Only report issues with confidence ≥ 80.** Quality over quantity — a short list of true issues
+  beats a long list of nits.
+
+## Karpathy behavioral guidelines (apply to the review itself)
+- **Surface assumptions.** If a finding depends on an assumption (caller behavior, invariant), say
+  so. If unsure, lower the confidence rather than over-claim.
+- **Simplicity.** Flag overcomplication: speculative abstractions, unrequested configurability,
+  error handling for impossible cases, 200 lines that could be 50.
+- **Surgical scope.** Judge whether changes touch only what they must; flag drive-by edits/refactors
+  and orphaned (newly-unused) imports/vars. Don't demand rewrites of code that isn't broken.
+- **Verifiable.** Prefer findings a developer can act on + verify (a failing case, a concrete fix).
+
+## Output per issue
+`file:line` · severity (Critical | Important) · confidence · one-line problem · concrete fix.
+Group by severity. If no ≥80 issues in the slice, say so with a one-line "meets standards" summary.

--- a/examples/exp7-code-review-fanout/work/exp7_mcp.py
+++ b/examples/exp7-code-review-fanout/work/exp7_mcp.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""exp7 MCP stdio driver — drive `loomcycle mcp --upstream <base>` (the thin client that backs the
+Claude Code loomcycle plugin) and call its meta-tools over JSON-RPC. This is the REAL MCP path: the
+thin client proxies to the upstream runtime's /v1/_mcp. Used to fan reviewers out through the MCP
+server's `spawn_runs` tool (RFC Y), then to spawn the consolidator.
+
+Token-safe: the upstream bearer is read from $LOOMCYCLE_MCP_UPSTREAM_TOKEN (env, set by run.sh /
+exp7_run.sh from .env.local) and handed to the child via env only — never argv, never printed. Empty
+token = dev open mode (no auth header).
+
+Usage:
+  exp7_mcp.py tools                        # tools/list (names only) — quick connectivity check
+  exp7_mcp.py call <tool> <args_json_file> # tools/call <tool> with arguments from a JSON file
+Env: LOOMCYCLE_BIN (default "loomcycle"), EXP7_BASE (default http://127.0.0.1:8787),
+     LOOMCYCLE_MCP_UPSTREAM_TOKEN (optional).
+"""
+import json, os, subprocess, sys, threading
+
+BIN  = os.environ.get("LOOMCYCLE_BIN", "loomcycle")
+BASE = os.environ.get("EXP7_BASE", "http://127.0.0.1:8787")
+
+
+def _pump_stderr(stream):
+    for line in iter(stream.readline, b""):
+        sys.stderr.write("[mcp] " + line.decode("utf-8", "replace"))
+    stream.close()
+
+
+def run(method, params, want_id):
+    """Spawn the thin client, do the initialize handshake, send one request, return its result."""
+    env = dict(os.environ)  # the child consumes LOOMCYCLE_MCP_UPSTREAM_TOKEN from env; we never echo it
+    proc = subprocess.Popen(
+        [BIN, "mcp", "-upstream", BASE],
+        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+    )
+    threading.Thread(target=_pump_stderr, args=(proc.stderr,), daemon=True).start()
+
+    def send(obj):
+        proc.stdin.write((json.dumps(obj) + "\n").encode())
+        proc.stdin.flush()
+
+    send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+          "params": {"protocolVersion": "2025-06-18", "capabilities": {},
+                     "clientInfo": {"name": "exp7", "version": "1"}}})
+    send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    send({"jsonrpc": "2.0", "id": want_id, "method": method, "params": params})
+
+    result = None
+    for raw in iter(proc.stdout.readline, b""):
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            sys.stderr.write("[mcp/non-json] " + raw.decode("utf-8", "replace") + "\n")
+            continue
+        if msg.get("id") == want_id:
+            result = {"__error__": msg["error"]} if "error" in msg else msg.get("result")
+            break
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()
+    return result
+
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("usage: exp7_mcp.py {tools|call <tool> <args_json_file>}")
+    verb = sys.argv[1]
+    if verb == "tools":
+        r = run("tools/list", {}, 2)
+        tools = (r or {}).get("tools", []) if isinstance(r, dict) else []
+        print(json.dumps([t.get("name") for t in tools], indent=2))
+        return
+    if verb == "call":
+        tool = sys.argv[2]
+        with open(sys.argv[3]) as f:
+            args = json.load(f)
+        print(json.dumps(run("tools/call", {"name": tool, "arguments": args}, 2), indent=2))
+        return
+    sys.exit("unknown verb " + verb)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/exp7-code-review-fanout/work/exp7_run.sh
+++ b/examples/exp7-code-review-fanout/work/exp7_run.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# exp7 driver — delegate a code review of work/loomcycle-src to loomcycle, fanning the reviewers
+# out THROUGH THE MCP SERVER (RFC Y `spawn_runs`).
+#
+#   ONE `spawn_runs` (mode=join, N=10) → 10 × code-reviewer (concurrent, server-side)
+#        each reads its slice (read-only) → Memory.set review:<slice>:findings
+#   ONE `spawn_run` → exp7-consolidator → reads review:* → consolidated:report → returns it
+#
+# The fan-out + the single consolidate both go through the loomcycle MCP thin client (exp7_mcp.py).
+# (REST equivalent of `spawn_runs`: POST /v1/runs:batch.)
+#
+# Usage (start the server first with ../run.sh, and clone the review target — see README step 1):
+#   ./work/exp7_run.sh smoke        # spawn_runs N=1 (pause slice) — validate the MCP path end-to-end
+#   ./work/exp7_run.sh fanout       # spawn_runs N=10 — fan all reviewers out through MCP (join)
+#   ./work/exp7_run.sh consolidate  # spawn_run exp7-consolidator — merge the ledger, return the report
+#   ./work/exp7_run.sh delegate     # fanout then consolidate (the full delegation)
+#   ./work/exp7_run.sh verify       # independent re-derivation from the store (REST reads)
+#
+# Token-safe: the MCP upstream bearer comes from .env.local via env (never argv/printed); empty =
+# open mode. Env: EXP7_BASE (default from .env.local LOOMCYCLE_LISTEN_ADDR), EXP7_JOIN_MS.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"     # .../work
+ROOT="$(cd "$HERE/.." && pwd)"
+CURL="$ROOT/loomcurl.sh"
+PY=python3
+USER_ID=exp7
+JOIN_MS="${EXP7_JOIN_MS:-1200000}"    # 20-min join deadline; a slow child is cancelled + reported in-envelope
+
+# Consume provider/bearer + listen addr from .env.local (never printed).
+set -a; [ -f "$ROOT/.env.local" ] && source "$ROOT/.env.local"; set +a
+export EXP7_BASE="${EXP7_BASE:-http://${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}}"
+export LOOMCYCLE_BIN="${LOOMCYCLE_BIN:-loomcycle}"
+export LOOMCYCLE_MCP_UPSTREAM_TOKEN="${LOOMCYCLE_MCP_UPSTREAM_TOKEN:-${LOOMCYCLE_AUTH_TOKEN:-}}"
+
+mcp_call(){ "$PY" "$HERE/exp7_mcp.py" call "$1" "$2"; }   # $1=tool $2=args-json-file
+jcurl(){ "$CURL" -sS "$@"; }
+mem_get(){ jcurl "$EXP7_BASE/v1/_memory/scopes/user/$USER_ID/keys/$1" \
+  | "$PY" -c 'import sys,json
+try:
+  e=json.load(sys.stdin).get("entry"); v=e.get("value") if isinstance(e,dict) else None
+  sys.stdout.write("" if v is None else (v if isinstance(v,str) else json.dumps(v)))
+except Exception: pass' 2>/dev/null; }
+
+# Build the spawns args for spawn_runs. $1 = "all" | a single slice name. $2 = join_ms.
+# Paths are RELATIVE to the read-root (=../work); the repo is cloned at work/loomcycle-src. An
+# absolute /…/**/*.go glob does NOT match under the read-only sandbox.
+build_spawns(){ "$PY" - "$1" "$2" <<'PY'
+import json, sys
+which = sys.argv[1]
+SLICES = [
+  ("api-http","internal/api/http"), ("tools-builtin","internal/tools/builtin"),
+  ("providers","internal/providers"), ("store","internal/store"),
+  ("config","internal/config"), ("snapshot","internal/snapshot"),
+  ("scheduler","internal/scheduler"), ("pause","internal/pause"),
+  ("channels","internal/channels"), ("cmd","cmd/loomcycle"),
+]
+sel = SLICES if which == "all" else [s for s in SLICES if s[0] == which]
+spawns = []
+for slice_name, path in sel:
+    prompt = (f"slice={slice_name} path={path}. Review loomcycle-src/{path} (read-only; path is "
+              f"RELATIVE to your sandbox read-root). The repo IS present — if a glob is empty, retry "
+              f"shallower / Read files directly. Record your confidence->=80 findings to Memory key "
+              f"review:{slice_name}:findings, then output one REVIEWED line and stop.")
+    spawns.append({
+        "agent": "code-reviewer", "user_id": "exp7",
+        "segments": [{"role": "user", "content": [{"type": "trusted-text", "text": prompt}]}],
+        "parent_context": {"root_agent_run_id": "exp7-mcp-fanout"},
+    })
+print(json.dumps({"spawns": spawns, "mode": "join", "timeout_ms": int(sys.argv[2])}))
+PY
+}
+
+fanout(){ # $1 = "all" | slice
+  local which="${1:-all}" args; args="$(mktemp "${TMPDIR:-/tmp}/exp7_spawns.XXXX.json")"
+  build_spawns "$which" "$JOIN_MS" > "$args"
+  local n; n=$("$PY" -c 'import json,sys;print(len(json.load(open(sys.argv[1]))["spawns"]))' "$args")
+  echo "[fanout] caller -> MCP spawn_runs: fanning out $n code-reviewer run(s) (mode=join)..."
+  mcp_call spawn_runs "$args" \
+    | "$PY" -c 'import sys,json
+r=json.load(sys.stdin)
+if isinstance(r,dict) and r.get("__error__"): print("  ERROR:",r["__error__"]); sys.exit(0)
+txt=None
+for c in (r or {}).get("content",[]):
+    if c.get("type")=="text": txt=c.get("text")
+env=json.loads(txt) if txt else r
+res=env.get("results") or env.get("runs") or []
+print(f"  envelope: {len(res)} child result(s)")
+for x in res:
+    ft=(x.get("final_text") or x.get("error") or ""); fl=ft.splitlines()
+    print("   %9s run=%-22s %s" % (x.get("status"), str(x.get("run_id"))[:20], fl[-1] if fl else ""))' 2>/dev/null
+  rm -f "$args"
+}
+
+consolidate(){
+  local args; args="$(mktemp "${TMPDIR:-/tmp}/exp7_consol.XXXX.json")"
+  "$PY" - <<'PY' > "$args"
+import json
+prompt=("The 10 code-reviewer agents have finished (fanned out via MCP spawn_runs). Gather every "
+        "review:<slice>:findings from Memory, consolidate, write consolidated:report, return the report.")
+print(json.dumps({"agent":"exp7-consolidator","user_id":"exp7",
+  "segments":[{"role":"user","content":[{"type":"trusted-text","text":prompt}]}]}))
+PY
+  echo "[consolidate] caller -> MCP spawn_run: exp7-consolidator (merge the ledger, return the report)..."
+  mcp_call spawn_run "$args" \
+    | "$PY" -c 'import sys,json
+r=json.load(sys.stdin)
+if isinstance(r,dict) and r.get("__error__"): print("  ERROR:",r["__error__"]); sys.exit(0)
+txt=None
+for c in (r or {}).get("content",[]):
+    if c.get("type")=="text": txt=c.get("text")
+print("  --- consolidator final_text ---"); print(txt or json.dumps(r)[:800])' 2>/dev/null
+  rm -f "$args"
+  echo "  --- consolidated:report (from Memory) ---"
+  mem_get "consolidated:report" | "$PY" -m json.tool 2>/dev/null || echo "  <none>"
+}
+
+verify(){
+  echo "===== independent re-derivation (REST reads from the store) ====="
+  echo "--- per-slice reviews recorded in Memory (review:<slice>:findings) ---"
+  jcurl "$EXP7_BASE/v1/_memory/scopes/user/$USER_ID/keys?prefix=review:&limit=100" | "$PY" -c 'import sys,json,re
+def load(v):
+    if isinstance(v,dict): return v
+    try: return json.loads(v)
+    except Exception:
+        try: return json.loads(re.sub(r"\\(?![\\/\"bfnrtu])", r"\\\\", v))  # tolerate stray backslash escapes
+        except Exception: return {}
+d=json.load(sys.stdin); tot=0; rows=[]
+for e in d.get("entries",[]):
+    k=e["key"]
+    if not k.endswith(":findings"): continue
+    v=load(e["value"]); n=len(v.get("issues",[])); tot+=n
+    rows.append((k, v.get("files_reviewed"), n, str(v.get("run_id"))[:18]))
+for k,f,n,r in sorted(rows): print("  %-34s files=%s issues=%s run=%s" % (k,f,n,r))
+print(f"  slices_recorded={len(rows)}/10  TOTAL issues={tot}")' 2>/dev/null
+  echo "--- consolidated:report (returned to the caller) ---"
+  mem_get "consolidated:report" | "$PY" -m json.tool 2>/dev/null || echo "  <none>"
+}
+
+case "${1:-delegate}" in
+  smoke)       fanout pause ;;
+  fanout)      fanout all ;;
+  consolidate) consolidate ;;
+  delegate)    fanout all; echo; consolidate ;;
+  verify)      verify ;;
+  *) echo "usage: $0 {smoke|fanout|consolidate|delegate|verify}" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## What

Adds `examples/exp7-code-review-fanout/` — a static, self-contained example where an external orchestrator (Claude Code, or the bundled driver) **delegates a real code review to loomcycle and fans the reviewers out _through the MCP server_**:

```
ONE spawn_runs (MCP, mode=join, N=10) → 10 read-only code-reviewer agents over repo slices → Memory
ONE spawn_run                          → exp7-consolidator → merges the ledger → returns the report
```

The `spawn_runs` join AND-barrier **is** the fan-in — no in-loomcycle dispatcher agent and no fan-in channel. (The pre-v0.32.0 workaround used an in-loomcycle dispatcher + `Agent op=parallel_spawn`; that gap motivated **RFC Y**, shipped in v0.32.0 as `spawn_runs` / `POST /v1/runs:batch`.)

## What it demonstrates
- **`loomcycle import claude-code`** — bring a Claude Code `code-reviewer` agent + `code-review` skill into loomcycle yaml (provenance under `claude-code-src/`, renamed from `.claude/` only because the repo gitignores that name; the importer reads structure, not the dir name).
- **`spawn_runs` (RFC Y)** — the external MCP fan-out, `mode:join`, throttled via `concurrency.max_concurrent_runs` to stay under subscription rate limits (the rest queue).
- **Memory** (user-scope findings ledger) and the **read-only `Read`/`Grep`/`Glob` jail** (reviewers have no Bash/Write).

## Contents
`loomcycle.yaml` (code-reviewer + exp7-consolidator) · `run.sh` (read-only jail + skills root) · `work/exp7_mcp.py` (token-safe MCP stdio client) · `work/exp7_run.sh` (`smoke`/`fanout`/`consolidate`/`delegate`/`verify`) · the imported skill · `claude-code-src/` (provenance) · a detailed `README.md` with reproduction + verification (incl. the three equivalent ways to drive the same handler: this driver, Claude Code's `/loomcycle:fanout`, and REST `/v1/runs:batch`).

## Testing
Smoke-tested end-to-end on loomcycle 0.33.0 (OAuth→deepseek): booted the example, cloned a Go repo into the jail, ran `spawn_runs` (N=1) → reviewer completed and wrote `review:<slice>:findings` to Memory; `verify` re-derived it from the store.

## Notes
- Scoped to the `examples/exp7-code-review-fanout/` directory only (no `examples/README.md` index-row change in this PR).
- Needs loomcycle ≥ v0.32.0 (for `spawn_runs`) + a provider + a Go repo to clone (see the example README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)