### PR TITLE
fix: exp7 (v0.33.0 re-run) verified correctness + robustness findings (PR A)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1502,6 +1502,13 @@ func main() {
 		Addr:              cfg.Env.ListenAddr,
 		Handler:           rootHandler,
 		ReadHeaderTimeout: 10 * time.Second,
+		// Bound idle keep-alive connections so abandoned clients don't
+		// accumulate open fds over time. ReadTimeout/WriteTimeout stay OFF
+		// deliberately: SSE run streams + long-poll subscribes are long-lived
+		// and a read/write deadline would sever them mid-stream. IdleTimeout
+		// only fires between requests on a keep-alive connection, so it's
+		// SSE-safe.
+		IdleTimeout: 120 * time.Second,
 	}
 
 	if cfg.Env.AuthToken == "" {
@@ -2173,11 +2180,14 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	_ = httpServer.Shutdown(ctx)
-	// Flush OTEL spans before exit. The OTLP exporter batches; without
-	// this, in-flight spans never reach the collector. Same 5s deadline
-	// as the HTTP shutdown — exporters honor ctx.
+	// Flush OTEL spans before exit. The OTLP exporter batches; without this,
+	// in-flight spans never reach the collector. Give it its OWN 5s budget —
+	// sharing the HTTP shutdown's ctx meant a slow in-flight request drain
+	// could exhaust the deadline first, silently dropping the final spans.
 	if otelShutdown != nil {
-		if err := otelShutdown(ctx); err != nil {
+		otelCtx, otelCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer otelCancel()
+		if err := otelShutdown(otelCtx); err != nil {
 			log.Printf("otel: shutdown failed: %v", err)
 		}
 	}

--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -96,6 +96,7 @@ func writeChannelError(w http.ResponseWriter, err error) {
 // handleCreateChannel serves POST /v1/_channels.
 func (s *Server) handleCreateChannel(w http.ResponseWriter, r *http.Request) {
 	var req connector.ChannelCreateRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 		return
@@ -123,6 +124,7 @@ func (s *Server) handleCreateChannel(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleUpdateChannel(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	var req connector.ChannelUpdateRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
@@ -216,6 +218,7 @@ func (s *Server) handleAdminChannelAck(w http.ResponseWriter, r *http.Request) {
 // timed_out:true, not an error.
 func (s *Server) handleAdminChannelAwait(w http.ResponseWriter, r *http.Request) {
 	var req connector.ChannelAwaitRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 		return
@@ -234,6 +237,7 @@ func (s *Server) handleAdminChannelAwait(w http.ResponseWriter, r *http.Request)
 // (one undeclared channel → 404, nothing published).
 func (s *Server) handleAdminChannelBroadcast(w http.ResponseWriter, r *http.Request) {
 	var req connector.ChannelBroadcastRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 		return
@@ -299,6 +303,7 @@ func (s *Server) handleChannelPublish(w http.ResponseWriter, r *http.Request, na
 		return
 	}
 	var body channelPublishBody
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 		return
@@ -324,6 +329,7 @@ func (s *Server) handleChannelSubscribe(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	var body channelSubscribeBody
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	// Subscribe body is optional — empty body means "poll once from
 	// committed cursor, no wait." JSON-decode failure on an empty
 	// body is expected (io.EOF); only surface real parse errors.
@@ -394,6 +400,7 @@ func (s *Server) handleChannelAck(w http.ResponseWriter, r *http.Request, name, 
 		return
 	}
 	var body channelAckBody
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", "invalid request body: "+err.Error())
 		return

--- a/internal/api/http/channels_admin_test.go
+++ b/internal/api/http/channels_admin_test.go
@@ -133,6 +133,29 @@ func TestCreateChannel_Runtime_HappyPath(t *testing.T) {
 	}
 }
 
+// TestCreateChannel_RejectsOversizedBody is the exp7 regression: admin POST
+// bodies must be bounded by http.MaxBytesReader. A valid create body padded
+// past the 1 MiB cap with an ignored field decodes fully — and the channel is
+// created (201) — on the unfixed code, because the decoder reads the whole
+// 2 MiB stream; with the cap the decode trips at 1 MiB and the handler returns
+// 400 before the body ever reaches the store. Fail-before: 201 without the cap.
+func TestCreateChannel_RejectsOversizedBody(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+
+	pad := strings.Repeat("x", 2<<20) // 2 MiB, over the 1 MiB cap
+	body := `{"name":"oversized-create","scope":"global","semantic":"queue","_pad":"` + pad + `"}`
+	rec := httptest.NewRecorder()
+	srv.Mux().ServeHTTP(rec, authedRequest("POST", "/v1/_channels", strings.NewReader(body)))
+
+	if rec.Code == http.StatusCreated || rec.Code == http.StatusOK {
+		t.Fatalf("oversized create body accepted: status %d — MaxBytesReader missing", rec.Code)
+	}
+	if rec.Code != http.StatusBadRequest && rec.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("status = %d, want 400 or 413; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
 // TestCreateChannel_RejectsYamlName refuses with 409
 // channel_yaml_immutable so operators can't shadow a yaml channel
 // with a runtime row of the same name (yaml is the floor).

--- a/internal/api/http/hooks.go
+++ b/internal/api/http/hooks.go
@@ -23,6 +23,7 @@ import (
 // handleSnapshot style.
 func (s *Server) handleRegisterHook(w http.ResponseWriter, r *http.Request) {
 	var req connector.RegisterHookRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON: "+err.Error())
 		return

--- a/internal/api/http/memory.go
+++ b/internal/api/http/memory.go
@@ -283,6 +283,16 @@ func (s *Server) handlePutMemoryEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body memoryEntryPutBody
+	// Bound the body to the configured per-value limit (default 64 KiB)
+	// plus JSON-envelope headroom; 0 (values uncapped) falls back to a
+	// generous wire ceiling so a deliberately-uncapped deployment still
+	// can't be OOM'd by a single oversized request. The tool layer's
+	// MaxValueBytes / quota check remains the authoritative limit.
+	maxBody := int64(16 << 20)
+	if v := s.cfg.Env.MemoryMaxValueBytes; v > 0 {
+		maxBody = int64(v) + (1 << 16)
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxBody)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body",
 			"invalid request body: "+err.Error())

--- a/internal/api/http/pause.go
+++ b/internal/api/http/pause.go
@@ -50,6 +50,7 @@ func (s *Server) handlePauseRuntime(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req pauseRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON object (or empty)")
 		return

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1940,6 +1940,12 @@ func (s *Server) trySessionLock(id string) (release func(), ok bool) {
 // Replaces both the in-process hooks.Registry AND the Dispatcher's
 // reference to it so the loop sees the new registry on the next
 // tool dispatch.
+//
+// Invariant: call during boot wiring, BEFORE the server starts serving.
+// hookRegistry / hookDispatcher are read unlocked on the request path, so
+// safety relies on the happens-before edge from this call to the request
+// goroutines ListenAndServe later spawns. It is NOT safe to call concurrently
+// with request handling (a hot-reload path would need a guard added here).
 func (s *Server) SetHookRegistry(r hooks.RegistryInterface) {
 	s.hookRegistry = r
 	s.hookDispatcher = hooks.NewDispatcher(r, nil)
@@ -1948,6 +1954,11 @@ func (s *Server) SetHookRegistry(r hooks.RegistryInterface) {
 // SetPgSessionLocker installs the v0.12.5 Phase 6 cluster-wide
 // session lock. When non-nil, trySessionLock dispatches to it
 // instead of the in-process SessionLockMap.
+//
+// Invariant: call during boot wiring, BEFORE the server starts serving —
+// sessionLockPG is read unlocked in trySessionLock on the request path. Same
+// set-before-Serve contract as SetHookRegistry; not safe to call concurrently
+// with request handling.
 func (s *Server) SetPgSessionLocker(l *runner.PgSessionLocker) {
 	s.sessionLockPG = l
 }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2470,6 +2470,7 @@ func (s *Server) handleSystemChannelPublish(w http.ResponseWriter, r *http.Reque
 	}
 
 	var body systemChannelPublishRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid_body", fmt.Sprintf("invalid request body: %s", err))
 		return
@@ -4839,6 +4840,7 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req resolveInterruptRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, fmt.Sprintf("invalid JSON body: %v", err), http.StatusBadRequest)
 		return

--- a/internal/api/http/snapshots.go
+++ b/internal/api/http/snapshots.go
@@ -84,6 +84,7 @@ type snapshotGetResponse struct {
 
 func (s *Server) handleCreateSnapshot(w http.ResponseWriter, r *http.Request) {
 	var req snapshotCreateRequest
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		// Empty body is fine (all fields optional); only error on
 		// malformed JSON.
@@ -243,6 +244,10 @@ func (s *Server) handleRestoreSnapshot(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 
 	var req snapshotRestoreRequest
+	// The body may carry an inline snapshot envelope (req.json) up to the
+	// snapshot ceiling, so the cap is the envelope ceiling + envelope-field
+	// headroom — not the 1 MiB control-body cap used elsewhere.
+	r.Body = http.MaxBytesReader(w, r.Body, snapshot.DefaultMaxBytes+(1<<20))
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
 		writeJSONError(w, http.StatusBadRequest, "invalid_json", "request body must be JSON object (or empty)")
 		return

--- a/internal/channels/bus.go
+++ b/internal/channels/bus.go
@@ -38,6 +38,14 @@ type Bus struct {
 
 	// bp is the cluster-mode backplane. Nil = single-replica mode.
 	bp coord.Backplane
+
+	// bpPublishTimeout bounds the best-effort backplane publish in Notify.
+	// Notify runs synchronously on the publish path (after the storage
+	// commit), so an unbounded context.Background() publish could hang that
+	// path indefinitely if the backplane stalls (e.g. an exhausted pgx pool
+	// or a slow pg_notify). Set in NewBus; a missed fanout degrades to plain
+	// polling on remote replicas, so a bounded best-effort publish is safe.
+	bpPublishTimeout time.Duration
 }
 
 // channelBackplaneEvent is the wire payload on `loomcycle.channel`.
@@ -50,7 +58,10 @@ type channelBackplaneEvent struct {
 // NewBus returns a fresh, empty bus. Single instance per loomcycle
 // process; injected into the Channel tool at registration time.
 func NewBus() *Bus {
-	return &Bus{waiters: make(map[string][]chan struct{})}
+	return &Bus{
+		waiters:          make(map[string][]chan struct{}),
+		bpPublishTimeout: 5 * time.Second,
+	}
 }
 
 // Notify wakes every subscriber currently blocked in Wait on the
@@ -68,9 +79,15 @@ func (b *Bus) Notify(channel string) {
 	b.mu.Unlock()
 	if bp != nil {
 		payload, _ := json.Marshal(channelBackplaneEvent{Channel: channel})
-		if err := bp.Publish(context.Background(), "loomcycle.channel", payload); err != nil {
+		timeout := b.bpPublishTimeout
+		if timeout <= 0 {
+			timeout = 5 * time.Second
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		if err := bp.Publish(ctx, "loomcycle.channel", payload); err != nil {
 			log.Printf("channels: backplane publish failed for %s: %v", channel, err)
 		}
+		cancel()
 	}
 }
 

--- a/internal/channels/bus_cluster_test.go
+++ b/internal/channels/bus_cluster_test.go
@@ -30,6 +30,40 @@ func (s *stubBackplane) Subscribe(_ context.Context, _ string) (<-chan coord.Eve
 
 func (s *stubBackplane) Close() error { return nil }
 
+// blockingBackplane.Publish blocks until ctx is cancelled, then returns
+// ctx.Err() — simulating a stalled backplane (exhausted pgx pool / slow
+// pg_notify).
+type blockingBackplane struct{}
+
+func (b *blockingBackplane) Publish(ctx context.Context, _ string, _ []byte) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+func (b *blockingBackplane) Subscribe(context.Context, string) (<-chan coord.Event, error) {
+	return nil, nil
+}
+func (b *blockingBackplane) Close() error { return nil }
+
+// TestBus_Notify_BoundsBackplanePublish is the exp7 regression: Notify runs
+// synchronously on the publish path, so an unbounded context.Background()
+// backplane publish would hang that path forever when the backplane stalls.
+// Notify now bounds the publish with bpPublishTimeout. FAIL-BEFORE: with
+// context.Background() the blocking Publish never returns and Notify hangs, so
+// this test times out.
+func TestBus_Notify_BoundsBackplanePublish(t *testing.T) {
+	b := NewBus()
+	b.bpPublishTimeout = 50 * time.Millisecond // same package — set the bound low
+	b.SetBackplane(&blockingBackplane{})
+
+	done := make(chan struct{})
+	go func() { b.Notify("my-channel"); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Notify hung — backplane publish is not bounded")
+	}
+}
+
 func TestBus_Notify_PublishesOnBackplane_WhenBPSet(t *testing.T) {
 	b := NewBus()
 	bp := newStubBackplane()

--- a/internal/channels/heartbeat.go
+++ b/internal/channels/heartbeat.go
@@ -45,7 +45,12 @@ type HeartbeatRunner struct {
 	version   string
 	startedAt time.Time
 
+	// mu guards cancel + started against a concurrent Start/Stop. Start is
+	// idempotent (a second call is a no-op) so a double Start can't overwrite
+	// cancel and orphan the first goroutine batch.
+	mu      sync.Mutex
 	cancel  context.CancelFunc
+	started bool
 	stopped sync.Once
 	wg      sync.WaitGroup
 }
@@ -74,14 +79,29 @@ func (h *HeartbeatRunner) Start(parent context.Context) {
 	if len(h.specs) == 0 {
 		return
 	}
+	h.mu.Lock()
+	if h.started {
+		h.mu.Unlock()
+		return // idempotent: a second Start is a no-op
+	}
+	h.started = true
 	ctx, cancel := context.WithCancel(parent)
 	h.cancel = cancel
+	// Reserve the WaitGroup for every runnable spec while still holding the
+	// lock, so a Stop() that races Start can't observe a zero counter
+	// mid-Add. Goroutines are spawned after the lock is released.
+	runnable := make([]HeartbeatSpec, 0, len(h.specs))
 	for _, spec := range h.specs {
 		if spec.Period <= 0 {
 			log.Printf("heartbeat: skip %q (non-positive period)", spec.Name)
 			continue
 		}
-		h.wg.Add(1)
+		runnable = append(runnable, spec)
+	}
+	h.wg.Add(len(runnable))
+	h.mu.Unlock()
+
+	for _, spec := range runnable {
 		go h.run(ctx, spec)
 	}
 }
@@ -90,8 +110,11 @@ func (h *HeartbeatRunner) Start(parent context.Context) {
 // Idempotent — safe to call multiple times.
 func (h *HeartbeatRunner) Stop() {
 	h.stopped.Do(func() {
-		if h.cancel != nil {
-			h.cancel()
+		h.mu.Lock()
+		cancel := h.cancel
+		h.mu.Unlock()
+		if cancel != nil {
+			cancel()
 		}
 		h.wg.Wait()
 	})

--- a/internal/channels/heartbeat_test.go
+++ b/internal/channels/heartbeat_test.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -71,6 +72,56 @@ func TestHeartbeatRunner_StopIdempotent(t *testing.T) {
 	time.Sleep(60 * time.Millisecond)
 	runner.Stop()
 	runner.Stop() // should not panic / hang
+}
+
+// TestHeartbeatRunner_ConcurrentStartStopRaceFree is the exp7 regression for
+// the data race: Start() wrote h.cancel with no synchronization against Stop()'s
+// read. Run Start and Stop concurrently; under -race the unfixed code reports a
+// data race on h.cancel. The parent ctx is cancelled on cleanup so a goroutine
+// that outlives a Stop-before-Start still drains.
+func TestHeartbeatRunner_ConcurrentStartStopRaceFree(t *testing.T) {
+	s, _ := sqlite.Open(":memory:")
+	defer s.Close()
+	pub := &StorePublisher{Store: s, Bus: NewBus()}
+	h := NewHeartbeatRunner(pub, "v", []HeartbeatSpec{
+		{Name: "_system/hb-race", Period: time.Millisecond},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); h.Start(ctx) }()
+	go func() { defer wg.Done(); h.Stop() }()
+	wg.Wait()
+	h.Stop() // idempotent
+}
+
+// TestHeartbeatRunner_DoubleStartNoOp pins the idempotent-Start guard: a second
+// Start must not spawn a second goroutine batch. On the unfixed code the second
+// Start overwrites h.cancel (orphaning the first batch's cancel), so the single
+// Stop cancels only the second context and wg.Wait blocks on the first batch
+// forever. FAIL-BEFORE: Stop hangs and this times out.
+func TestHeartbeatRunner_DoubleStartNoOp(t *testing.T) {
+	s, _ := sqlite.Open(":memory:")
+	defer s.Close()
+	pub := &StorePublisher{Store: s, Bus: NewBus()}
+	h := NewHeartbeatRunner(pub, "v", []HeartbeatSpec{
+		{Name: "_system/hb-double", Period: 50 * time.Millisecond},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	h.Start(ctx)
+	h.Start(ctx) // must be a no-op, not a second batch
+
+	done := make(chan struct{})
+	go func() { h.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() hung — a second Start spawned an un-cancelled goroutine batch")
+	}
 }
 
 // Empty specs is a no-op (no goroutines started, Stop returns immediately).

--- a/internal/channels/scheduler.go
+++ b/internal/channels/scheduler.go
@@ -71,36 +71,48 @@ func (s *Scheduler) Schedule(channel, msgID string, visibleAt time.Time) bool {
 	if msgID == "" {
 		return false
 	}
-	if _, exists := s.timers.Load(msgID); exists {
-		return false // idempotent — caller may legitimately reschedule on bootstrap
-	}
 	if s.MaxPending > 0 && s.pendCnt.Load() >= int64(s.MaxPending) {
 		return false // silent fallback to periodic-poll delivery
 	}
 
-	t := time.AfterFunc(delay, func() {
-		// Order matters: do the bookkeeping BEFORE calling Notify.
-		// Notify hands off to the waiting goroutine synchronously
-		// (bus.Wait returns true the moment Notify lands). If we
-		// notified first, an observer reading PendingCount() right
-		// after their Wait returned could see a stale count of 1
-		// because the Delete + Add(-1) below hadn't completed yet
-		// — the race detector exposed this as a flaky
-		// TestScheduler_FiresAtVisibleAt failure. With this order,
-		// PendingCount is post-fire by the time any subscriber
-		// observes Notify.
-		s.timers.Delete(msgID)
-		s.pendCnt.Add(-1)
-		s.bus.Notify(channel)
-	})
-	if _, loaded := s.timers.LoadOrStore(msgID, t); loaded {
-		// Race: another caller registered the same msgID between
-		// our Load above and the LoadOrStore. Stop our redundant
-		// timer; the first registration wins.
-		t.Stop()
+	// Claim the registry slot BEFORE arming the timer. Arming first (the old
+	// code did `t := AfterFunc(...)` then `LoadOrStore(msgID, t)`) opened a
+	// window where, for a sub-millisecond delay, the fire closure could run
+	// between AfterFunc and the store: its Delete was a no-op (the entry
+	// didn't exist yet) and the subsequent store then parked an
+	// already-fired timer in the map — an orphaned entry that nothing ever
+	// removed (exp7 C1, narrow + low-severity). Reserve a nil placeholder via
+	// LoadOrStore; a loaded result means the msgID is already scheduled
+	// (idempotent re-Schedule on bootstrap).
+	if _, loaded := s.timers.LoadOrStore(msgID, (*time.Timer)(nil)); loaded {
 		return false
 	}
+	// pendCnt is incremented under the claim. Invariant: whoever removes the
+	// slot (the fire closure or Cancel, via LoadAndDelete) decrements exactly
+	// once — so the count can't drift even if they race.
 	s.pendCnt.Add(1)
+
+	t := time.AfterFunc(delay, func() {
+		// Order matters: do the bookkeeping BEFORE calling Notify. Notify
+		// hands off to the waiting goroutine synchronously (bus.Wait returns
+		// true the moment Notify lands). If we notified first, an observer
+		// reading PendingCount() right after their Wait returned could see a
+		// stale count because the LoadAndDelete + Add(-1) below hadn't
+		// completed — the race detector exposed this as a flaky
+		// TestScheduler_FiresAtVisibleAt. With this order, PendingCount is
+		// post-fire by the time any subscriber observes Notify.
+		if _, ok := s.timers.LoadAndDelete(msgID); ok {
+			s.pendCnt.Add(-1)
+		}
+		s.bus.Notify(channel)
+	})
+	// Swap the placeholder for the armed timer — but only if the closure
+	// hasn't already fired and removed the slot. A failed CAS means the timer
+	// already fired (and cleaned up via LoadAndDelete), so there is nothing to
+	// store and Stop is a harmless no-op; either way no orphan is left behind.
+	if !s.timers.CompareAndSwap(msgID, (*time.Timer)(nil), t) {
+		t.Stop()
+	}
 	return true
 }
 
@@ -113,13 +125,14 @@ func (s *Scheduler) Cancel(msgID string) {
 	if !loaded {
 		return
 	}
-	if t, ok := v.(*time.Timer); ok {
-		if t.Stop() {
-			s.pendCnt.Add(-1)
-		}
-		// If Stop() returned false, the timer already fired and
-		// pendCnt was decremented in the AfterFunc closure — don't
-		// double-decrement.
+	// Remover-decrements invariant: we removed a live slot, so we own the
+	// decrement. The racing fire closure's LoadAndDelete now returns ok=false,
+	// so it won't double-decrement. v may be the nil placeholder (Cancel
+	// raced a Schedule between its slot-claim and the CompareAndSwap); guard
+	// the nil so Stop isn't called on a nil *time.Timer.
+	s.pendCnt.Add(-1)
+	if t, ok := v.(*time.Timer); ok && t != nil {
+		t.Stop()
 	}
 }
 

--- a/internal/channels/scheduler_test.go
+++ b/internal/channels/scheduler_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"context"
 	"errors"
+	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -141,6 +143,60 @@ func TestScheduler_CancelUnknown(t *testing.T) {
 	sched.Cancel("msg_does_not_exist")
 	if sched.PendingCount() != 0 {
 		t.Errorf("PendingCount = %d, want 0", sched.PendingCount())
+	}
+}
+
+// timerMapLen counts live registry entries — exposes orphaned entries that
+// PendingCount (an atomic counter that nets to the right value) cannot reveal.
+func timerMapLen(s *Scheduler) int {
+	n := 0
+	s.timers.Range(func(_, _ any) bool { n++; return true })
+	return n
+}
+
+// TestScheduler_ConcurrentScheduleCancelDrainsClean is the exp7 C1 invariant
+// lock for the placeholder-claim + CompareAndSwap rewrite: under concurrent
+// Schedule/Cancel the registry must drain to zero entries with no pendCnt
+// drift and no panic (Cancel can observe the nil placeholder mid-Schedule).
+// Run under -race.
+//
+// Not a strict fail-before: the original arm-then-store orphan race is
+// practically unreproducible because AfterFunc's microsecond firing latency
+// dwarfs the few-nanosecond window between arming the timer and storing it —
+// so this locks the post-fix invariants (clean drain, no panic, no data race)
+// rather than failing on the old code.
+func TestScheduler_ConcurrentScheduleCancelDrainsClean(t *testing.T) {
+	bus := NewBus()
+	sched := NewScheduler(bus, 0)
+
+	const n = 400
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			id := "msg_" + strconv.Itoa(i)
+			sched.Schedule("ch", id, time.Now().Add(20*time.Millisecond))
+			if i%2 == 0 {
+				sched.Cancel(id) // race the just-armed timer / its placeholder
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Let any uncancelled timers fire + run their cleanup.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if timerMapLen(sched) == 0 && sched.PendingCount() == 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := timerMapLen(sched); got != 0 {
+		t.Errorf("registry has %d entries after drain, want 0 (orphaned entry?)", got)
+	}
+	if got := sched.PendingCount(); got != 0 {
+		t.Errorf("PendingCount = %d after drain, want 0", got)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -499,11 +499,14 @@ type UserTier struct {
 	//
 	// 0 (default) keeps the v0.12.x behaviour — 30s default applied
 	// inside the resolver. Values in [1_000, 600_000] (1 s to 10
-	// min) accepted; out-of-range values silently clamp to that
-	// window at config-load. Sub-second cooldowns would defeat the
-	// purpose (the cascade would re-fire on the next call); >10 min
-	// becomes meaningless because the periodic probe (default 15
-	// min) clears the matrix before the cooldown expires anyway.
+	// min) accepted; positive out-of-range values silently clamp to
+	// that window when the resolver overlay is built (see
+	// clampRateLimitCooldownMs in internal/api/http/server.go — the
+	// single source of truth for the bound), and a negative value is
+	// rejected at config-load by validate(). Sub-second cooldowns would
+	// defeat the purpose (the cascade would re-fire on the next call);
+	// >10 min becomes meaningless because the periodic probe (default
+	// 15 min) clears the matrix before the cooldown expires anyway.
 	RateLimitCooldownMs int `yaml:"rate_limit_cooldown_ms"`
 }
 

--- a/internal/pause/tool_policy.go
+++ b/internal/pause/tool_policy.go
@@ -121,7 +121,11 @@ func CategoryForInput(toolName string, input json.RawMessage) ToolCategory {
 		return CategoryExternal
 	}
 	switch toolName {
-	case "Read", "WebFetch", "WebSearch":
+	case "Read", "Glob", "Grep", "WebFetch", "WebSearch":
+		// Read-only file/search tools — safe to cancel immediately on pause
+		// and re-run on resume (same result). Glob/Grep were previously
+		// absent and fell through to the non-idempotent default, so a pending
+		// directory walk needlessly blocked pause until its timeout.
 		return CategoryIdempotent
 	case "Write", "Edit", "Bash":
 		// File writes + shell commands are always non-idempotent.

--- a/internal/pause/tool_policy_test.go
+++ b/internal/pause/tool_policy_test.go
@@ -17,6 +17,10 @@ func TestCategoryForInput(t *testing.T) {
 	}{
 		// Read-only file I/O — idempotent.
 		{"Read", "Read", `{"path":"/etc/hosts"}`, CategoryIdempotent},
+		// exp7: Glob/Grep are read-only searches; previously fell through to
+		// the non-idempotent default.
+		{"Glob", "Glob", `{"pattern":"**/*.go"}`, CategoryIdempotent},
+		{"Grep", "Grep", `{"pattern":"func"}`, CategoryIdempotent},
 		{"WebFetch", "WebFetch", `{"url":"https://example.com"}`, CategoryIdempotent},
 		{"WebSearch", "WebSearch", `{"query":"go modules"}`, CategoryIdempotent},
 

--- a/internal/providers/anthropic_oauth_dev/refresh.go
+++ b/internal/providers/anthropic_oauth_dev/refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -20,6 +21,7 @@ type Refresher struct {
 	mu        sync.Mutex
 	startOnce sync.Once
 	stopOnce  sync.Once
+	started   atomic.Bool // set inside startOnce; gates Stop's doneCh wait
 	stopCh    chan struct{}
 	doneCh    chan struct{}
 
@@ -65,6 +67,10 @@ func NewRefresher(store *TokenStore, opts ExchangeOptions, logf func(string, ...
 // re-starting an existing one.
 func (r *Refresher) Start(ctx context.Context) {
 	r.startOnce.Do(func() {
+		// Mark started BEFORE spawning the loop so a concurrent Stop that
+		// observes started==true is guaranteed the loop will reach its
+		// `defer close(doneCh)` and unblock the wait below.
+		r.started.Store(true)
 		go r.loop(ctx)
 	})
 }
@@ -75,9 +81,13 @@ func (r *Refresher) Stop() {
 	r.stopOnce.Do(func() {
 		close(r.stopCh)
 	})
-	// Block until loop returns. Bounded by the 30-second tick + the
-	// refresh HTTP call's 30-second timeout.
-	<-r.doneCh
+	// Only wait if the loop was ever started — doneCh is closed solely by
+	// loop()'s defer, so a Stop() that precedes (or replaces) Start() would
+	// otherwise block forever. With a started loop the wait is bounded by the
+	// 30-second tick + the refresh HTTP call's 30-second timeout.
+	if r.started.Load() {
+		<-r.doneCh
+	}
 }
 
 // Token returns the most recent cached token. Safe for concurrent use.

--- a/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
+++ b/internal/providers/anthropic_oauth_dev/refresh_reload_test.go
@@ -105,3 +105,31 @@ func TestRefresher_StartIsIdempotent(t *testing.T) {
 	// on the fixed single-loop path.
 	time.Sleep(50 * time.Millisecond)
 }
+
+// TestRefresher_StopBeforeStartDoesNotDeadlock is the exp7 regression for the
+// I2 sibling: Stop() waits on doneCh, which only loop() closes. If Start() was
+// never called the loop never runs, so the unfixed Stop() blocked forever.
+// The started gate skips the wait when no loop exists. FAIL-BEFORE: without the
+// gate this Stop() never returns and the test times out.
+func TestRefresher_StopBeforeStartDoesNotDeadlock(t *testing.T) {
+	store := NewTokenStore(t.TempDir() + "/tokens.json")
+	r := NewRefresher(store, ExchangeOptions{}, func(string, ...any) {})
+
+	done := make(chan struct{})
+	go func() {
+		r.Stop() // never Started — must return, not deadlock
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop() before Start() deadlocked")
+	}
+
+	// A subsequent Start()+Stop() must still behave (loop spawns, sees the
+	// already-closed stopCh, exits cleanly).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r.Start(ctx)
+	r.Stop()
+}

--- a/internal/scheduler/dispatch_test.go
+++ b/internal/scheduler/dispatch_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -30,6 +31,36 @@ func channelHookDef(channel string) scheduleDef {
 		OnComplete: []scheduleHook{
 			{Kind: "channel.publish", Channel: channel, Payload: map[string]any{"top": 3}},
 		},
+	}
+}
+
+// TestScheduler_OnCompleteHookUsesSurvivalCtx is the exp7 regression: a run
+// that completes just as shutdown begins records its result on the survival
+// ctx (recordCtx) — but dispatchHooks used the parent ctx, so the on_complete
+// hook was dropped on a cancelled context. Fire with an already-cancelled
+// parent ctx and assert the channel.publish hook still lands.
+//
+// FAIL-BEFORE: with dispatchHooks(ctx) the ChannelPublish runs on the cancelled
+// ctx, fails, and the global peek returns 0.
+func TestScheduler_OnCompleteHookUsesSurvivalCtx(t *testing.T) {
+	def := channelHookDef("ctx-survival")
+	sched, _, _, defID, st := schedulerFixture(t, def, time.Now().Add(-1*time.Minute))
+	sched.SetChannelScope(func(context.Context, string) (string, bool) { return "global", true })
+
+	// Parent ctx already cancelled — the run still "completes" (the fake
+	// runner ignores ctx), so status=="completed" and the survival ctx kicks
+	// in for both the result-write and (post-fix) the hook dispatch.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	defJSON, err := json.Marshal(def)
+	if err != nil {
+		t.Fatalf("marshal def: %v", err)
+	}
+	sched.fireOne(ctx, store.ScheduleDueRow{DefID: defID, Name: "sched-test", Definition: defJSON}, time.Now())
+
+	if got := peekScopeCount(t, st, "ctx-survival", store.MemoryScopeGlobal, ""); got != 1 {
+		t.Errorf("on_complete publish landed %d messages, want 1 (hook must use the survival ctx)", got)
 	}
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -398,9 +398,13 @@ func (s *Scheduler) fireOne(ctx context.Context, row store.ScheduleDueRow, now t
 	}
 
 	// Dispatch hooks only on success — RFC E says on_complete fires on
-	// "successful runs." Failed/skipped runs don't notify.
+	// "successful runs." Failed/skipped runs don't notify. Use recordCtx (the
+	// survival ctx) not the parent: a run that completes just as shutdown
+	// begins still recorded its result above, so its on_complete hooks
+	// (channel publish / memory set / mcp.call) must fire too rather than be
+	// dropped on a cancelled parent ctx.
 	if status == "completed" {
-		s.dispatchHooks(ctx, row.Name, def, registeredRunID, registeredAgentID)
+		s.dispatchHooks(recordCtx, row.Name, def, registeredRunID, registeredAgentID)
 	}
 }
 

--- a/internal/snapshot/export.go
+++ b/internal/snapshot/export.go
@@ -57,14 +57,25 @@ func sectionChecksum(sectionBytes []byte) string {
 }
 
 // ExportPretty produces indented JSON for human inspection. Used by
-// the CLI's `loomcycle snapshot get --pretty` flag. NOT used by
-// Restore — restoration parses canonical JSON via Export's output
-// shape.
+// the CLI's `loomcycle snapshot get --pretty` flag. NOT the canonical
+// restore artifact — restoration consumes Export's compact output.
+//
+// It clears the integrity Checksum on its copy. Restore (exp7 I4) verifies
+// the digest against the "sections" bytes exactly as they appear in the
+// document, but json.MarshalIndent re-indents the nested "sections" object —
+// so a checksum stamped over the compact bytes (which every Capture/Export
+// envelope carries) no longer matches the indented bytes, and Restore would
+// reject the pretty document as "truncated or tampered". A pretty doc
+// therefore carries no checksum: if one is ever fed to Restore it skips
+// verification (additive) instead of failing on a digest that cannot survive
+// re-indentation.
 func ExportPretty(env *Envelope) ([]byte, error) {
 	if env == nil {
 		return nil, fmt.Errorf("snapshot export pretty: nil envelope")
 	}
-	b, err := json.MarshalIndent(env, "", "  ")
+	out := *env
+	out.Checksum = ""
+	b, err := json.MarshalIndent(&out, "", "  ")
 	if err != nil {
 		return nil, fmt.Errorf("snapshot export pretty: marshal: %w", err)
 	}

--- a/internal/snapshot/restore_test.go
+++ b/internal/snapshot/restore_test.go
@@ -794,6 +794,53 @@ func TestExportRestore_ChecksumRoundTrip(t *testing.T) {
 	}
 }
 
+// TestExportPretty_ClearsChecksumSoRestoreSucceeds is the exp7 regression for
+// the pretty-export path. json.MarshalIndent re-indents the nested "sections"
+// object, so a checksum stamped over the COMPACT section bytes (which every
+// Capture/Export envelope carries) no longer matches the indented bytes —
+// Restore hashes the document's section bytes and would reject a pretty doc as
+// "truncated or tampered". ExportPretty therefore clears the checksum.
+// Fail-before: with the checksum propagated into the pretty doc, this Restore
+// fails with "checksum mismatch".
+func TestExportPretty_ClearsChecksumSoRestoreSucceeds(t *testing.T) {
+	env := mkChecksumEnvelope(t)
+	// Simulate a fetched, stored snapshot: it carries the compact checksum
+	// because Capture routes through Export, which stamps it.
+	raw, err := Export(&env)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	var stored Envelope
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		t.Fatalf("unmarshal stored: %v", err)
+	}
+	if stored.Checksum == "" {
+		t.Fatal("precondition: stored envelope should carry a checksum")
+	}
+
+	pretty, err := ExportPretty(&stored)
+	if err != nil {
+		t.Fatalf("ExportPretty: %v", err)
+	}
+	if strings.Contains(string(pretty), `"checksum"`) {
+		t.Errorf("pretty export still carries a checksum (cannot survive re-indent): %s", pretty)
+	}
+	// Must not mutate the caller's envelope.
+	if stored.Checksum == "" {
+		t.Errorf("ExportPretty cleared the caller's Checksum; it must copy")
+	}
+
+	dst, dstClose := newTestStore(t)
+	defer dstClose()
+	res, err := Restore(context.Background(), dst, pretty, RestoreOptions{})
+	if err != nil {
+		t.Fatalf("ExportPretty -> Restore failed (stale checksum survived?): %v", err)
+	}
+	if res.AgentDefsRestored != 1 {
+		t.Errorf("AgentDefsRestored = %d, want 1", res.AgentDefsRestored)
+	}
+}
+
 // TestRestore_RejectsTamperedBodyWithStaleChecksum pins the integrity gate: a
 // body mutated AFTER Export (without re-stamping) is rejected before any
 // decode/insert.

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -5616,7 +5616,11 @@ func (s *Store) scanEvaluation(row pgx.Row) (store.EvaluationRow, error) {
 		return store.EvaluationRow{}, err
 	}
 	if dimensions != "" {
-		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+		if err := json.Unmarshal([]byte(dimensions), &out.Dimensions); err != nil {
+			// Malformed dimensions JSON (e.g. a hand-edited row) — log + leave
+			// Dimensions nil rather than silently dropping the parse error.
+			log.Printf("evaluations: scan eval_id=%s: dimensions JSON parse failed, skipping: %v", out.EvalID, err)
+		}
 	}
 	if judgement != "" {
 		out.Judgement = json.RawMessage(judgement)
@@ -5640,7 +5644,9 @@ func (s *Store) scanEvaluationRows(rows pgx.Rows) ([]store.EvaluationRow, error)
 			return nil, err
 		}
 		if dimensions != "" {
-			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+			if err := json.Unmarshal([]byte(dimensions), &r.Dimensions); err != nil {
+				log.Printf("evaluations: scan eval_id=%s: dimensions JSON parse failed, skipping: %v", r.EvalID, err)
+			}
 		}
 		if judgement != "" {
 			r.Judgement = json.RawMessage(judgement)

--- a/internal/store/sqlite/eval_dimensions_test.go
+++ b/internal/store/sqlite/eval_dimensions_test.go
@@ -1,0 +1,59 @@
+package sqlite
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestEvaluationGet_MalformedDimensionsLogged is the exp7 regression: the
+// evaluation scan path previously discarded the dimensions json.Unmarshal
+// error (`_ = json.Unmarshal(...)`), so a corrupt row read back with empty
+// Dimensions and no trace of why. The scan now logs the parse failure and
+// still returns the row. Fail-before: the unfixed code emits no log line, so
+// the buffer is empty and this assertion fails.
+func TestEvaluationGet_MalformedDimensionsLogged(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	if _, err := s.EvaluationSubmit(ctx, store.EvaluationRow{
+		EvalID:      "eval_bad_dims",
+		RunID:       "run_1",
+		EmitterRole: "judge",
+		Dimensions:  map[string]float64{"clarity": 0.9},
+	}); err != nil {
+		t.Fatalf("EvaluationSubmit: %v", err)
+	}
+
+	// Corrupt the stored dimensions JSON directly — the write path marshals
+	// valid JSON, so a malformed value can only arrive via a hand-edited row.
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE evaluations SET dimensions = ? WHERE eval_id = ?`,
+		`{not valid json`, "eval_bad_dims",
+	); err != nil {
+		t.Fatalf("corrupt dimensions: %v", err)
+	}
+
+	var buf bytes.Buffer
+	orig := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(orig)
+
+	got, err := s.EvaluationGet(ctx, "eval_bad_dims")
+	if err != nil {
+		t.Fatalf("EvaluationGet returned error for a malformed-dimensions row: %v", err)
+	}
+	if got.EvalID != "eval_bad_dims" {
+		t.Errorf("EvalID = %q, want eval_bad_dims", got.EvalID)
+	}
+	if len(got.Dimensions) != 0 {
+		t.Errorf("Dimensions = %v, want empty after a failed parse", got.Dimensions)
+	}
+	if !strings.Contains(buf.String(), "dimensions JSON parse failed") {
+		t.Errorf("parse failure was not logged; log=%q", buf.String())
+	}
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -6064,7 +6064,11 @@ func (s *Store) scanEvaluation(row *sql.Row) (store.EvaluationRow, error) {
 		return store.EvaluationRow{}, err
 	}
 	if dimensions != "" {
-		_ = json.Unmarshal([]byte(dimensions), &out.Dimensions)
+		if err := json.Unmarshal([]byte(dimensions), &out.Dimensions); err != nil {
+			// Malformed dimensions JSON (e.g. a hand-edited row) — log + leave
+			// Dimensions nil rather than silently dropping the parse error.
+			log.Printf("evaluations: scan eval_id=%s: dimensions JSON parse failed, skipping: %v", out.EvalID, err)
+		}
 	}
 	if judgement != "" {
 		out.Judgement = json.RawMessage(judgement)
@@ -6090,7 +6094,9 @@ func (s *Store) scanEvaluationRows(rows *sql.Rows) ([]store.EvaluationRow, error
 			return nil, err
 		}
 		if dimensions != "" {
-			_ = json.Unmarshal([]byte(dimensions), &r.Dimensions)
+			if err := json.Unmarshal([]byte(dimensions), &r.Dimensions); err != nil {
+				log.Printf("evaluations: scan eval_id=%s: dimensions JSON parse failed, skipping: %v", r.EvalID, err)
+			}
 		}
 		if judgement != "" {
 			r.Judgement = json.RawMessage(judgement)

--- a/internal/tools/builtin/glob.go
+++ b/internal/tools/builtin/glob.go
@@ -106,6 +106,21 @@ func (g *Glob) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 		searchRoot = resolved
 	}
 
+	// The matcher compares pattern segments against walk-root-RELATIVE file
+	// paths. An absolute pattern's leading "/" splits to an empty first
+	// segment that never matches a relative path, so an absolute in-root
+	// pattern silently returned no matches (exp7 R1). Relativize it to the
+	// walk root; an absolute pattern pointing outside the root can't match
+	// anything in the sandbox.
+	pattern := args.Pattern
+	if filepath.IsAbs(pattern) {
+		rel, inRoot := relativizeToRoot(searchRoot, pattern)
+		if !inRoot {
+			return tools.Result{Text: "no matches\n"}, nil
+		}
+		pattern = rel
+	}
+
 	maxResults := g.MaxResults
 	if maxResults <= 0 {
 		maxResults = globDefaultMaxResults
@@ -114,7 +129,7 @@ func (g *Glob) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	// Pre-compile the pattern into a segment slice so we don't re-split
 	// per file. `**` survives as a literal sentinel inside the segment
 	// matcher.
-	patSegments := strings.Split(args.Pattern, "/")
+	patSegments := strings.Split(pattern, "/")
 
 	type fileInfo struct {
 		rel   string
@@ -176,6 +191,26 @@ func (g *Glob) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 		return tools.Result{Text: "no matches\n"}, nil
 	}
 	return tools.Result{Text: out.String()}, nil
+}
+
+// relativizeToRoot converts an absolute glob pattern to one relative to root
+// (the walk root). Returns (rel, true) when the pattern sits inside root, or
+// ("", false) when it is the root itself or points outside it — in which case
+// it can match nothing in the sandbox. Glob metacharacters are preserved;
+// only the fixed leading directory prefix is stripped. filepath.Clean
+// collapses any `..` first, so a traversal-escaping pattern fails the prefix
+// check and yields false.
+func relativizeToRoot(root, pattern string) (string, bool) {
+	cleanRoot := filepath.Clean(root)
+	cleanPat := filepath.Clean(pattern)
+	if cleanPat == cleanRoot {
+		return "", false
+	}
+	prefix := cleanRoot + string(filepath.Separator)
+	if !strings.HasPrefix(cleanPat, prefix) {
+		return "", false
+	}
+	return filepath.ToSlash(cleanPat[len(prefix):]), true
 }
 
 // doublestarMatch matches a `/`-split pattern against a `/`-split

--- a/internal/tools/builtin/glob_test.go
+++ b/internal/tools/builtin/glob_test.go
@@ -171,6 +171,46 @@ func TestGlob_NoMatches(t *testing.T) {
 	}
 }
 
+// TestGlob_AbsoluteInRootPattern is the exp7 R1 regression: an absolute
+// pattern pointing inside the sandbox root must match. The matcher compares
+// against root-relative paths, so the leading "/" used to become an empty
+// first segment that never matched — an absolute in-root pattern silently
+// returned "no matches". It is now relativized to the walk root.
+// FAIL-BEFORE: returns "no matches".
+func TestGlob_AbsoluteInRootPattern(t *testing.T) {
+	root := makeGlobTree(t)
+	g := &Glob{Root: root}
+	abs := root + "/**/*.go"
+	in, _ := json.Marshal(map[string]string{"pattern": abs})
+	res, _ := g.Execute(context.Background(), in)
+	if res.IsError {
+		t.Fatalf("err: %s", res.Text)
+	}
+	for _, want := range []string{"a.go", "src/main.go", "src/pkg/util.go", "vendor/third.go"} {
+		if !strings.Contains(res.Text, want) {
+			t.Errorf("absolute in-root pattern %q: expected %q in results, got %q", abs, want, res.Text)
+		}
+	}
+	if strings.Contains(res.Text, "no matches") {
+		t.Errorf("absolute in-root pattern returned no matches: %q", res.Text)
+	}
+}
+
+// TestGlob_AbsolutePatternOutsideRootMatchesNothing: an absolute pattern that
+// points outside the sandbox root matches nothing — it must not walk or leak
+// files outside the root.
+func TestGlob_AbsolutePatternOutsideRootMatchesNothing(t *testing.T) {
+	root := makeGlobTree(t)
+	g := &Glob{Root: root}
+	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"/etc/**/*.conf"}`))
+	if res.IsError {
+		t.Fatalf("err: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "no matches") {
+		t.Errorf("absolute out-of-root pattern must match nothing, got %q", res.Text)
+	}
+}
+
 func TestGlob_PathEscapeRejected(t *testing.T) {
 	root := makeGlobTree(t)
 	g := &Glob{Root: root}

--- a/internal/tools/builtin/read.go
+++ b/internal/tools/builtin/read.go
@@ -4,6 +4,7 @@ package builtin
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -66,10 +67,15 @@ func (r *Read) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	}
 	defer f.Close()
 
-	buf := make([]byte, maxBytes)
-	n, err := f.Read(buf)
-	if err != nil && err.Error() != "EOF" {
+	// Read up to maxBytes. io.ReadAll over a LimitReader handles a short read
+	// (a single os.File.Read may legally return fewer bytes than requested —
+	// e.g. on a FIFO/device, a network FS, or a >1 GiB read) and treats EOF as
+	// success — replacing the prior single f.Read + the fragile
+	// err.Error() == "EOF" string compare (which breaks on a wrapped EOF). A
+	// file larger than maxBytes is bounded to exactly maxBytes.
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes))
+	if err != nil {
 		return tools.Result{Text: err.Error(), IsError: true}, nil
 	}
-	return tools.Result{Text: string(buf[:n])}, nil
+	return tools.Result{Text: string(data)}, nil
 }

--- a/internal/tools/builtin/read_test.go
+++ b/internal/tools/builtin/read_test.go
@@ -120,3 +120,60 @@ func TestReadAllowsInsideSandbox(t *testing.T) {
 		t.Errorf("Text = %q, want %q", res.Text, "hello")
 	}
 }
+
+// Behaviour lock for the exp7 read-path hardening (io.ReadAll over a
+// LimitReader instead of a single f.Read + err.Error()=="EOF"). These pin
+// the three cases that matter: a multi-page file read in full, a file larger
+// than the cap bounded to exactly maxBytes, and an empty file. (Not a strict
+// fail-before: a single os.File.Read does not truncate a regular file in
+// practice — the hardening covers short reads on FIFOs/devices/>1 GiB reads
+// and removes the fragile EOF string compare.)
+func TestRead_FullReadBoundedAndEmpty(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// (1) Multi-page file (1 MiB), cap above size → read in full, intact.
+	big := strings.Repeat("ABCDEFGH", 1<<17) // 1 MiB
+	bigPath := filepath.Join(root, "big.txt")
+	if err := os.WriteFile(bigPath, []byte(big), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := &Read{Root: root, MaxBytes: 4 << 20}
+	in, _ := json.Marshal(map[string]string{"path": bigPath})
+	res, _ := r.Execute(context.Background(), in)
+	if res.IsError {
+		t.Fatalf("big read errored: %q", res.Text)
+	}
+	if res.Text != big {
+		t.Errorf("big file not read in full: got %d bytes, want %d", len(res.Text), len(big))
+	}
+
+	// (2) File larger than the cap → bounded to exactly maxBytes.
+	rCap := &Read{Root: root, MaxBytes: 1024}
+	res, _ = rCap.Execute(context.Background(), in)
+	if res.IsError {
+		t.Fatalf("capped read errored: %q", res.Text)
+	}
+	if len(res.Text) != 1024 {
+		t.Errorf("capped read = %d bytes, want exactly 1024", len(res.Text))
+	}
+	if res.Text != big[:1024] {
+		t.Errorf("capped read returned the wrong leading bytes")
+	}
+
+	// (3) Empty file → empty result, no error (the old EOF branch).
+	emptyPath := filepath.Join(root, "empty.txt")
+	if err := os.WriteFile(emptyPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inEmpty, _ := json.Marshal(map[string]string{"path": emptyPath})
+	res, _ = r.Execute(context.Background(), inEmpty)
+	if res.IsError {
+		t.Fatalf("empty read errored: %q", res.Text)
+	}
+	if res.Text != "" {
+		t.Errorf("empty file Text = %q, want empty", res.Text)
+	}
+}


### PR DESCRIPTION
## Why

Sandbox **Experiment #7** re-ran the self-code-review against loomcycle @ v0.33.0 (10 `code-reviewer` agents fanned out via `spawn_runs`), producing 35 consolidated findings (doc claimed 1 Critical + 34 Important) plus 3 runtime findings (R1–R3). The review was Sonnet-generated, so every finding was **independently verified against current `main`** before acting. This PR is the first of two: the **confirmed correctness/robustness fixes**, each as its own commit with a fail-before test where one is feasible. A follow-up PR covers the dead-code/cosmetic cleanup.

Several flagged findings were **refuted or reclassified during verification** and are deliberately *not* "fixed" here (see below) — over-fixing a non-bug is its own regression risk.

## What (confirmed fixes, one commit each)

**Robustness / security**
- **Admin POST bodies lack `MaxBytesReader`** — every uncapped bearer-authed admin POST decode (channel CRUD + fan-in/out, system-channel publish, resolve-interrupt, register-hook, pause, snapshot create) now bounds the body at 1 MiB; memory PUT derives its cap from the configured per-value limit, snapshot restore from the snapshot ceiling (it may carry a 512 MiB inline envelope). Regression: oversized create → 400.
- **`Read` short-read + fragile EOF compare** → canonical `io.ReadAll(io.LimitReader(...))` (robustness hardening; honest that a regular-file truncation isn't reproducible).
- **`ExportPretty` propagated a compact checksum into a re-indented doc**, so `ExportPretty`→`Restore` failed with a checksum mismatch — the fix *clears* the checksum (opposite of the original triage). Real fail-before.
- **`scanEvaluation*` swallowed the `dimensions` unmarshal error** (sqlite+pg) → now logged.

**Lifecycle / context-propagation**
- **`Refresher.Stop()` deadlocked when called before `Start()`** → gated the `doneCh` wait on a `started` flag.
- **`HeartbeatRunner`** `cancel` data race + no double-`Start` guard → mutex + idempotent Start (`-race` regression).
- **`Bus.Notify`** unbounded `context.Background()` backplane publish could hang the synchronous publish path → bounded per-Bus timeout.
- **scheduler `dispatchHooks`** used the parent ctx → uses the survival `recordCtx`, so a run completing at shutdown still fires its `on_complete` hooks.
- **cmd**: separate otel-shutdown budget (was sharing the HTTP drain's 5s) + SSE-safe `IdleTimeout`.

**Correctness**
- **pause**: `Glob`/`Grep` classified idempotent (were falling to the non-idempotent default).
- **Glob (R1)**: an absolute in-root pattern now matches (was relativized-mismatch → "no matches"); out-of-root still matches nothing.
- **C1 (the "Critical", downgraded to LOW)**: closed a narrow orphaned-`sync.Map`-entry race in `Scheduler.Schedule` (placeholder-claim + `CompareAndSwap`). The claimed "permanent pendCnt leak" was wrong (it nets out); the race is also practically unreproducible (AfterFunc latency ≫ the arm-then-store window).

**Docs-only (invariants surfaced)**
- `SetHookRegistry`/`SetPgSessionLocker`: documented the set-before-Serve invariant (no active race; hot-path RWMutex would be a net cost).
- `RateLimitCooldownMs`: corrected the docstring — the `[1_000, 600_000]` clamp already exists at the resolver-overlay build site.

## Refuted / not-a-bug during verification (NOT changed)
- **`newID` "silent predictable IDs"** — REFUTED on Go 1.24+: `crypto/rand.Read` never returns an error (it `fatal`s), so the sqlite `_, _ =` can't emit unfilled bytes and the pg `err != nil` branch is dead.
- **`trySessionLock` `context.Background()`** — deliberate; threading the request ctx risks leaking a session-level advisory lock on mid-query cancel.
- `readWithRetry` sleep (≤20ms total), OAuth refresher `Start` (Stop-owned daemon), snapshot paused-`Status`, `EventError` quota-sniff, interactive `release()`, env-only `configDir`, websearch buffer — all examined, all left as-is.

## What was tested
- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./...` — clean.
- `-race` on the heartbeat + scheduler + oauth-refresher concurrency changes.
- Fail-before verified by reverting each fix for: MaxBytesReader (201→400), ExportPretty→Restore (checksum mismatch), scanEvaluation (empty log), refresher Stop (2s deadlock), heartbeat (DATA RACE + 2s hang), bus.Notify (2s hang), scheduler survival-ctx (0 messages), pause Glob/Grep (non_idempotent), Glob R1 ("no matches").
- Store-touching changes covered on sqlite + Postgres via the store contract suite (`go-postgres` CI job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)