### PR TITLE
chore: exp7 (v0.33.0 re-run) dead-code + cosmetic cleanup (PR B)

### DIFF
--- a/internal/pause/tool_policy.go
+++ b/internal/pause/tool_policy.go
@@ -44,27 +44,6 @@ func (c ToolCategory) String() string {
 	}
 }
 
-// idempotentBuiltins is the static allowlist of built-in tool names
-// whose Execute() is read-only OR otherwise safe to cancel-and-retry.
-// Source of truth: doc-internal/rfcs/pause-resume-snapshot.md's locked
-// per-tool cancel policy.
-//
-// Tools that take an `op` field (Memory, Channel, AgentDef, Evaluation,
-// Context) are categorised at the OP level — see CategoryForInput
-// below, which parses the input's `op` field and consults the
-// op-specific table.
-//
-// MCP tools (prefix `mcp__`) are NOT in this map; they get
-// CategoryExternal via the prefix check in CategoryForInput.
-var idempotentBuiltins = map[string]bool{
-	// Read-only file I/O
-	"Read":      true,
-	"WebFetch":  true,
-	"WebSearch": true,
-	// HTTP method-discriminated — see CategoryForInput; map entry
-	// would be misleading.
-}
-
 // Op-discriminated builtin: idempotent ops vs non-idempotent ops on
 // the Memory tool. Reads are safe to cancel; writes need wait-with-
 // timeout.

--- a/internal/scheduler/cron.go
+++ b/internal/scheduler/cron.go
@@ -23,6 +23,7 @@ package scheduler
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/robfig/cron/v3"
@@ -80,13 +81,15 @@ func ResolveCron(schedule string, userTierSchedules map[string]string, tier stri
 	}
 	expr, ok := userTierSchedules[tier]
 	if !ok {
-		// Pick a deterministic tier from the available set for the
-		// error message so operators see what's available rather than
-		// a generic "not found."
-		var avail []string
+		// List the available tiers in the error so operators see what's
+		// valid rather than a generic "not found." Sort so the message is
+		// deterministic — Go randomises map iteration order, so without this
+		// the "(have: ...)" list shuffled between identical failures.
+		avail := make([]string, 0, len(userTierSchedules))
 		for k := range userTierSchedules {
 			avail = append(avail, k)
 		}
+		sort.Strings(avail)
 		return "", fmt.Errorf("tier %q not in user_tier_schedules (have: %v)", tier, avail)
 	}
 	return expr, nil

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -456,14 +456,3 @@ func (s *Scheduler) computeNext(def scheduleDef, now time.Time) (time.Time, erro
 	}
 	return NextFireAfter(expr, def.Timezone, now)
 }
-
-// ctxDone is a non-blocking ctx-cancellation check used inside the
-// fire loop so a Stop() mid-tick gets honoured promptly.
-func ctxDone(ctx context.Context) bool {
-	select {
-	case <-ctx.Done():
-		return true
-	default:
-		return false
-	}
-}

--- a/internal/snapshot/memory_embedding.go
+++ b/internal/snapshot/memory_embedding.go
@@ -79,13 +79,6 @@ func captureEmbedding(ctx context.Context, s store.Store, scope store.MemoryScop
 	}, nil
 }
 
-// nilEmbedding is preserved for back-compat with the Phase-1
-// captureMemory call site. It returns nil → JSON null. New call
-// sites should use captureEmbedding directly.
-//
-// Deprecated: use captureEmbedding for snapshot Phase-2 paths.
-func nilEmbedding() *MemoryEmbeddingSnapshot { return nil }
-
 // encodeFloat32LEBase64 packs []float32 into little-endian bytes
 // then base64-encodes the result. Matches the on-disk pgvector +
 // sqlite-vec wire formats so a JSON snapshot can move bytes

--- a/internal/store/backfill.go
+++ b/internal/store/backfill.go
@@ -1,0 +1,34 @@
+package store
+
+import "encoding/json"
+
+// BackfillSystemPromptBase is the JSON-layer transform shared by the SQLite +
+// Postgres backfill methods. Returns (newDef, true, nil) when the row needed a
+// fill, (nil, false, nil) when it didn't, and (nil, false, err) on a JSON parse
+// failure.
+//
+// Hoisted here (exp7 cleanup) so both adapters call one implementation instead
+// of maintaining byte-identical copies — the transform is pure JSON, with no
+// adapter-specific dependency, so it belongs in the shared store package.
+func BackfillSystemPromptBase(def []byte) ([]byte, bool, error) {
+	var raw map[string]any
+	if err := json.Unmarshal(def, &raw); err != nil {
+		return nil, false, err
+	}
+	existing, _ := raw["system_prompt_base"].(string)
+	if existing != "" {
+		return nil, false, nil
+	}
+	sp, _ := raw["system_prompt"].(string)
+	if sp == "" {
+		// No system_prompt either — nothing to backfill from. Leave the row
+		// as-is; the read-side normalizer is a no-op too.
+		return nil, false, nil
+	}
+	raw["system_prompt_base"] = sp
+	out, err := json.Marshal(raw)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
+}

--- a/internal/store/backfill_test.go
+++ b/internal/store/backfill_test.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestBackfillSystemPromptBase pins the contract of the transform hoisted from
+// the sqlite + postgres adapters: it copies system_prompt → system_prompt_base
+// only when the base is empty and a prompt exists, and is otherwise a no-op.
+func TestBackfillSystemPromptBase(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantOK   bool
+		wantErr  bool
+		wantBase string // expected system_prompt_base in the output (when ok)
+	}{
+		{
+			name:     "fills base from prompt when base empty",
+			in:       `{"model":"x","system_prompt":"be helpful"}`,
+			wantOK:   true,
+			wantBase: "be helpful",
+		},
+		{
+			name:   "no-op when base already set",
+			in:     `{"system_prompt":"p","system_prompt_base":"already"}`,
+			wantOK: false,
+		},
+		{
+			name:   "no-op when neither prompt nor base present",
+			in:     `{"model":"x"}`,
+			wantOK: false,
+		},
+		{
+			name:    "error on malformed JSON",
+			in:      `{"system_prompt":`,
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, ok, err := BackfillSystemPromptBase([]byte(tc.in))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (out=%s ok=%v)", out, ok)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !tc.wantOK {
+				if out != nil {
+					t.Errorf("no-op case returned non-nil out: %s", out)
+				}
+				return
+			}
+			var raw map[string]any
+			if err := json.Unmarshal(out, &raw); err != nil {
+				t.Fatalf("output not valid JSON: %v", err)
+			}
+			if got, _ := raw["system_prompt_base"].(string); got != tc.wantBase {
+				t.Errorf("system_prompt_base = %q, want %q", got, tc.wantBase)
+			}
+		})
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2999,7 +2999,7 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 
 	n := 0
 	for _, p := range todo {
-		updated, ok, err := backfillSystemPromptBase(p.Def)
+		updated, ok, err := store.BackfillSystemPromptBase(p.Def)
 		if err != nil {
 			// Hand-edited row with broken JSON — log + skip rather than
 			// abort the whole backfill. The read-side normalizer in
@@ -3020,31 +3020,6 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 		n++
 	}
 	return n, nil
-}
-
-// backfillSystemPromptBase is the JSON-layer transform shared by the
-// sqlite + postgres backfill methods. Returns (newDef, true, nil)
-// when the row needed a fill; (nil, false, nil) when it didn't;
-// (nil, false, err) on JSON parse failure.
-func backfillSystemPromptBase(def []byte) ([]byte, bool, error) {
-	var raw map[string]any
-	if err := json.Unmarshal(def, &raw); err != nil {
-		return nil, false, err
-	}
-	existing, _ := raw["system_prompt_base"].(string)
-	if existing != "" {
-		return nil, false, nil
-	}
-	sp, _ := raw["system_prompt"].(string)
-	if sp == "" {
-		return nil, false, nil
-	}
-	raw["system_prompt_base"] = sp
-	out, err := json.Marshal(raw)
-	if err != nil {
-		return nil, false, err
-	}
-	return out, true, nil
 }
 
 // BackfillSkillDefContentSHA256 — mirror.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -3241,7 +3241,7 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 
 	n := 0
 	for _, p := range todo {
-		updated, ok, err := backfillSystemPromptBase(p.Def)
+		updated, ok, err := store.BackfillSystemPromptBase(p.Def)
 		if err != nil {
 			// Hand-edited row with broken JSON — log + skip rather than
 			// abort the whole backfill. The read-side normalizer in
@@ -3262,33 +3262,6 @@ func (s *Store) BackfillAgentDefSystemPromptBase(ctx context.Context) (int, erro
 		n++
 	}
 	return n, nil
-}
-
-// backfillSystemPromptBase is the JSON-layer transform shared by
-// the sqlite + postgres backfill methods. Returns (newDef, true,
-// nil) when the row needed a fill; (nil, false, nil) when it didn't;
-// (nil, false, err) on JSON parse failure.
-func backfillSystemPromptBase(def []byte) ([]byte, bool, error) {
-	var raw map[string]any
-	if err := json.Unmarshal(def, &raw); err != nil {
-		return nil, false, err
-	}
-	existing, _ := raw["system_prompt_base"].(string)
-	if existing != "" {
-		return nil, false, nil
-	}
-	sp, _ := raw["system_prompt"].(string)
-	if sp == "" {
-		// No system_prompt either — nothing to backfill from. Leave
-		// the row as-is; the read-side normalizer is a no-op too.
-		return nil, false, nil
-	}
-	raw["system_prompt_base"] = sp
-	out, err := json.Marshal(raw)
-	if err != nil {
-		return nil, false, err
-	}
-	return out, true, nil
 }
 
 // BackfillAgentDefContentSHA256 walks NULL/empty rows + populates the


### PR DESCRIPTION
## Why

Follow-up to #470 (PR A, the confirmed correctness/robustness fixes). This is the **cleanup sweep** for the exp7 (v0.33.0 re-run) findings: dead-code removal, a determinism nit, and one duplication hoist. Near-zero risk — pure deletions + a behavior-preserving refactor.

As with PR A, **every flagged cleanup item was verified before acting** — and **4 of the 9** turned out to be wrong and are deliberately left as-is (see below).

## What

- **chore: remove dead code** — three unused symbols, grep-confirmed no callers:
  - `pause.idempotentBuiltins` map (CategoryForInput's switch is the real source of truth; the map was never read),
  - `scheduler.ctxDone` helper (no callers),
  - `snapshot.nilEmbedding` deprecated stub (CLAUDE.md forbids back-compat shims for unused code).
- **style(scheduler): sort the cron error's tier list** — `ResolveCron`'s "(have: %v)" list was built from a map range, so Go's randomised iteration shuffled it between identical failures; the comment already claimed "deterministic." Error-message-only.
- **refactor(store): hoist `backfillSystemPromptBase`** — the sqlite + postgres adapters carried a byte-identical (modulo one comment) private copy of this pure JSON transform (its own comment even called it "shared"). Hoisted to `store.BackfillSystemPromptBase`; both adapters now call one impl. Adds the focused unit test it never had.

## Verified-and-LEFT-AS-IS (refuted cleanup items)

- **`pause.forceCancelMu` "dead mutex"** — NOT dead: it's a live local passed to `forceCancelRemaining` at two call sites.
- **`pause.Snapshot()` "skip ListPausedRuns on the StateRunning fast path"** — would be a **correctness regression in cluster mode**: `ListPausedRuns` hits the shared store, so a locally-`StateRunning` replica must still query to report runs paused by *other* replicas. The query-for-safety is intentional.
- **`pause.ToolCtx` "bare `cancel` is awkward"** — that branch never stores an `activeTools` entry, so the bare `CancelFunc` (which *is* a `func()`) is correct; wrapping it would be pointless indirection.
- **`config.expandDenyNames` bare `"PG_DSN"` "residue"** — intentional defense-in-depth (exp7 C2); the comment explicitly contemplates a bare third-party name being allowed. Removing a redundant **security** deny-list entry for cleanliness weakens the guard for negligible gain.

## What was tested
- `go build ./...`, `go vet ./...`, `gofmt` — clean.
- `go test ./...` — clean (incl. the new `TestBackfillSystemPromptBase`).
- Store contract suite on sqlite + Postgres (`go-postgres` CI job) covers the hoisted call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)