### PR TITLE
docs: mark the Python client as published on PyPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Internal packages added since v0.9.0: `a2a`, `audit`, `auth`, `claudeimport`, `c
 
 **Key consumers of loomcycle:**
 - `jobs-search-agent` (separate repo; this machine: `/home/denn/workspace/jobs_search_agent`) — first production user. Adopts loomcycle as the only `Runner` backend; CLI / SDK backends were retired in May 2026 after a $80 cost incident traced to subprocess auth inheritance.
-- TypeScript client at `adapters/ts/` → `npm: @loomcycle/client`. Python client at `adapters/python/` → `loomcycle` (installable from source; PyPI Trusted Publisher pending).
+- TypeScript client at `adapters/ts/` → `npm: @loomcycle/client`. Python client at `adapters/python/` → `pip install loomcycle` (published on PyPI from v0.8.0 under the `denn-gubsky` account via the OIDC Trusted Publisher; versioned independently on `python-v*` tags. A `loomcycle` PyPI Organization is pending — the project transfers to it once approved, install name unchanged).
 
 ## Development workflow
 


### PR DESCRIPTION
## Why

`loomcycle@0.8.0` is now live on PyPI — the `python-v0.8.0` release published successfully via the OIDC Trusted Publisher under the `denn-gubsky` account. The CLAUDE.md "Key consumers" line still said "installable from source; PyPI Trusted Publisher pending."

## What

One-line CLAUDE.md update: `installable from source; PyPI Trusted Publisher pending` → `pip install loomcycle` (published from v0.8.0 under the denn-gubsky account, independent `python-v*` versioning, org-transfer pending with the install name unchanged). The READMEs already said `pip install loomcycle`, so no other doc changes.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)