### PR TITLE
fix(pause): count ResumedRunsCount before waking gates (de-flake CI)

### DIFF
--- a/internal/pause/barrier_test.go
+++ b/internal/pause/barrier_test.go
@@ -115,15 +115,27 @@ func TestManager_PauseTimesOutOnUnparkedRun(t *testing.T) {
 func TestManager_PauseQuiescesImmediatelyWhenNoRuns(t *testing.T) {
 	m, _, cleanup := newTestManager(t)
 	defer cleanup()
-	start := time.Now()
-	res, err := m.Pause(context.Background(), 2*time.Second)
-	if err != nil {
-		t.Fatalf("Pause: %v", err)
-	}
-	if time.Since(start) > 500*time.Millisecond {
-		t.Errorf("Pause with no in-flight runs took %v, want near-immediate", time.Since(start))
-	}
-	if res.PausedRunsCount != 0 {
-		t.Errorf("PausedRunsCount = %d, want 0", res.PausedRunsCount)
+	// A LONG pause timeout: if the barrier failed to short-circuit on "no
+	// registered runs" it would block the full 10s. Assert Pause returns well
+	// within that window via a generous 3s select bound — robust under -race CI
+	// load (a near-instant Pause never approaches 3s) while still catching a
+	// regression that waits the whole timeout. Avoids the prior tight
+	// `< 500ms` wall-clock assertion, which could flake under scheduler
+	// contention even on the happy path.
+	done := make(chan PauseResult, 1)
+	go func() {
+		res, perr := m.Pause(context.Background(), 10*time.Second)
+		if perr != nil {
+			t.Errorf("Pause: %v", perr)
+		}
+		done <- res
+	}()
+	select {
+	case res := <-done:
+		if res.PausedRunsCount != 0 {
+			t.Errorf("PausedRunsCount = %d, want 0", res.PausedRunsCount)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Pause with no in-flight runs did not quiesce within 3s — barrier did not short-circuit")
 	}
 }

--- a/internal/pause/manager.go
+++ b/internal/pause/manager.go
@@ -755,6 +755,28 @@ func (m *Manager) Resume(ctx context.Context) (ResumeResult, error) {
 		m.mu.Unlock()
 		return ResumeResult{State: st}, ErrNotPaused
 	}
+	m.mu.Unlock()
+
+	// Snapshot the paused set BEFORE waking any gate. While the manager is
+	// still StatePaused the gates are parked (selecting on resumeCh) and no new
+	// runs are admitted, so this list is a stable, accurate count. If we woke
+	// the gates first (the old ordering: close(resumeCh) then ListPausedRuns),
+	// a woken gate flips its own pause_state back to running and races the
+	// list — under-counting ResumedRunsCount nondeterministically (the flaky
+	// TestManager_PauseWaitsForRunToPark). The per-run SetRunPauseState(running)
+	// below is idempotent with a gate's self-flip; only the count must be
+	// snapshotted pre-wake.
+	paused, listErr := m.store.ListPausedRuns(ctx)
+
+	m.mu.Lock()
+	// Re-check under the lock: a concurrent Resume may have transitioned us to
+	// running between the pre-check and here. The loser reports ErrNotPaused
+	// (the winner already woke the gates) — keeps the state transition atomic.
+	if loadState(&m.state) != StatePaused {
+		st := loadState(&m.state).String()
+		m.mu.Unlock()
+		return ResumeResult{State: st}, ErrNotPaused
+	}
 	// New broadcast channel for the next pause cycle. Old callers
 	// holding the closed channel from the prior pause naturally fall
 	// through their select-default branch on the next iteration.
@@ -786,12 +808,13 @@ func (m *Manager) Resume(ctx context.Context) (ResumeResult, error) {
 		}
 	}
 
-	paused, err := m.store.ListPausedRuns(ctx)
-	if err != nil {
-		log.Printf("resume: ListPausedRuns failed: %v", err)
+	// The gates are now woken (above); even if the snapshot failed we must not
+	// short-circuit before that. Handle the snapshot error here for the count.
+	if listErr != nil {
+		log.Printf("resume: ListPausedRuns failed: %v", listErr)
 		return ResumeResult{
 			State:    StateRunning.String(),
-			Warnings: []string{fmt.Sprintf("could not enumerate paused runs: %v", err)},
+			Warnings: []string{fmt.Sprintf("could not enumerate paused runs: %v", listErr)},
 		}, nil
 	}
 	resumed := 0


### PR DESCRIPTION
## Why

CI (Go 1.26.x, `-race`) intermittently red on `internal/pause/TestManager_PauseWaitsForRunToPark` (`ResumedRunsCount = 0, want 1`), reddening `main` on pushes. Root-caused to a **real `Resume()` race**, not a test artifact.

`Resume()` did `close(m.resumeCh)` — waking every parked gate — **before** `ListPausedRuns(ctx)` counted them. A woken gate flips its own `pause_state` back to running (the real loop gate does this; the test's gate mirrors it) and races the list, so `Resume` under-counts `ResumedRunsCount` nondeterministically. Cosmetic in prod (the count is for reporting; the resume itself still works) but genuinely racy.

## What

- **`manager.go`:** snapshot `ListPausedRuns` while still `StatePaused` (gates parked, no new runs admitted → stable count), *then* wake the gates. Re-check `state == Paused` under `m.mu` before the transition so a concurrent `Resume` can't double-transition (the split lock would otherwise open that window — the loser returns `ErrNotPaused`). The per-run `SetRunPauseState(running)` loop stays (idempotent with a gate's self-flip); only the count must be pre-wake.
- **`barrier_test.go`:** replaced the latent-flaky `<500ms` wall-clock upper bound in the idle test with a 10s timeout + a generous 3s select bound (robust under `-race`, still catches a "barrier didn't short-circuit" regression). Kept the `>=150ms` lower bound (timer-gated — can't fire early, doesn't flake).

## Tested

- `go test ./internal/pause/ -race -count=100` — **clean (574s)** (previously flaked within tens of runs).
- `go build`/`vet`/`gofmt` clean.

First of three PRs resolving the v0.34.0 security review + this flake; this one lands first to stabilize CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)