### PR TITLE
fix(config): deny loomcycle infra secrets from env-expand (security S1)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3183,21 +3183,33 @@ func ExpandEnvAllowed(name string) bool {
 	return false
 }
 
-// expandDenyNames are loomcycle's OWN infrastructure / admin secrets that must
-// NEVER be interpolated into a YAML/MCP field, even though the LOOMCYCLE_ prefix
-// (or a bare third-party name) would otherwise allow it (exp7 C2). The DB DSN
-// and the operator bearer are loomcycle's own credentials — unlike a per-MCP
-// auth token (which an operator legitimately references in THAT server's own
-// header via ${LOOMCYCLE_*}), interpolating these into an outbound MCP URL/
-// header would exfiltrate loomcycle's infra creds to a third party. They reach
-// the system via the Env struct, never via YAML interpolation, so denying them
-// here breaks no legitimate use. (Deliberately a tight named set, NOT the broad
-// IsSecretEnvName suffix match, which would also block legitimate
-// ${LOOMCYCLE_*_TOKEN} MCP auth headers.)
+// expandDenyNames is the authoritative set of loomcycle's OWN infrastructure /
+// admin secrets that must NEVER be interpolated into a YAML/MCP field, even
+// though the LOOMCYCLE_ prefix (or a bare third-party name) would otherwise
+// allow it (exp7 C2 + the v0.34.0 security review S1). These are loomcycle's
+// own credentials — the DB DSN, the operator bearer, the operator-token hashing
+// pepper, the thin-client upstream MCP token, and the OTEL exporter headers
+// (which carry collector auth like x-honeycomb-team). Interpolating any of them
+// into an attacker-controlled outbound MCP URL/header/arg (a runtime-authored
+// MCPServerDef → config.ExpandEnv at dial time) would exfiltrate the secret to
+// a third party. They reach the system via the Env struct, never via YAML
+// interpolation, so denying them here breaks no legitimate use.
+//
+// Deliberately a tight NAMED set, NOT the broad IsSecretEnvName suffix match —
+// a suffix deny would also block the legitimate operator pattern of referencing
+// a per-MCP auth token via ${LOOMCYCLE_*_TOKEN} / ${LOOMCYCLE_STATIC_BEARER} in
+// THAT server's own header (documented in docs/ARCHITECTURE.md). The
+// completeness this named set needs — every loomcycle-OWNED infra secret denied
+// — is enforced by TestExpandDenyNames_CoversInfraSecretReads, which scans this
+// package's own os.Getenv("LOOMCYCLE_…") secret-bearing reads and fails CI if a
+// new one isn't listed here (closing the "incomplete blocklist" gap S1 named).
 var expandDenyNames = map[string]bool{
-	"PG_DSN":               true,
-	"LOOMCYCLE_PG_DSN":     true,
-	"LOOMCYCLE_AUTH_TOKEN": true,
+	"PG_DSN":                               true,
+	"LOOMCYCLE_PG_DSN":                     true,
+	"LOOMCYCLE_AUTH_TOKEN":                 true,
+	"LOOMCYCLE_OPERATOR_TOKEN_PEPPER":      true, // RFC L token-hash pepper (S1: the high-value miss)
+	"LOOMCYCLE_MCP_UPSTREAM_TOKEN":         true, // thin-client upstream MCP bearer
+	"LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS": true, // collector auth headers
 }
 
 // secretEnvSuffixes are the env-var NAME patterns this project classifies as

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -2305,11 +2306,20 @@ func TestExpandEnv_DeniesInfraSecrets(t *testing.T) {
 	t.Setenv("PG_DSN", "postgres://u:p@h/db")
 	t.Setenv("LOOMCYCLE_PG_DSN", "postgres://u:p@h/db")
 	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "operator-bearer")
+	// v0.34.0 security review S1: these infra secrets passed the old 3-name
+	// denylist and were exfiltratable into an attacker-controlled MCP field.
+	t.Setenv("LOOMCYCLE_OPERATOR_TOKEN_PEPPER", "token-hash-pepper")
+	t.Setenv("LOOMCYCLE_MCP_UPSTREAM_TOKEN", "upstream-bearer")
+	t.Setenv("LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS", "x-honeycomb-team=secret")
 	t.Setenv("LOOMCYCLE_FOO", "ok-value")
 	t.Setenv("LOOMCYCLE_JIRA_TOKEN", "mcp-auth-token")
 
 	// Infra secrets: the literal ${...} survives, the value never appears.
-	for _, name := range []string{"PG_DSN", "LOOMCYCLE_PG_DSN", "LOOMCYCLE_AUTH_TOKEN"} {
+	for _, name := range []string{
+		"PG_DSN", "LOOMCYCLE_PG_DSN", "LOOMCYCLE_AUTH_TOKEN",
+		"LOOMCYCLE_OPERATOR_TOKEN_PEPPER", "LOOMCYCLE_MCP_UPSTREAM_TOKEN",
+		"LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS",
+	} {
 		in := "x=${" + name + "}"
 		if got := expandEnv(in); got != in {
 			t.Errorf("expandEnv(%q) = %q, want unchanged (infra secret must not interpolate)", in, got)
@@ -2324,6 +2334,53 @@ func TestExpandEnv_DeniesInfraSecrets(t *testing.T) {
 	// the broad *_TOKEN suffix match) must still expand into its own header.
 	if got := expandEnv("Bearer ${LOOMCYCLE_JIRA_TOKEN}"); got != "Bearer mcp-auth-token" {
 		t.Errorf("expandEnv(LOOMCYCLE_JIRA_TOKEN) = %q, want Bearer mcp-auth-token", got)
+	}
+}
+
+// TestExpandDenyNames_CoversInfraSecretReads is the v0.34.0 S1 drift guard. The
+// expandDenyNames blocklist is only safe if it's COMPLETE — the review's HIGH
+// was that it silently missed the operator-token pepper. This test scans
+// loomcycle's OWN source for os.Getenv / os.LookupEnv("LOOMCYCLE_…") reads whose
+// name ends in a secret suffix and asserts every one is denied, so a future
+// infra-secret env read added without an expandDenyNames entry fails CI here
+// (the secret would otherwise be interpolatable into an attacker-controlled MCP
+// url/header/arg → exfiltration). It scans this package's config.go plus
+// cmd/loomcycle/main.go (the MCP-upstream-token read). Non-suffix secret names
+// (_HEADERS like the OTEL exporter headers, _BEARER) aren't caught here and need
+// a manual denylist entry + TestExpandEnv_DeniesInfraSecrets coverage above.
+func TestExpandDenyNames_CoversInfraSecretReads(t *testing.T) {
+	secretSuffixes := []string{
+		"_TOKEN", "_KEY", "_SECRET", "_PASSWORD", "_AUTH",
+		"_CREDENTIAL", "_CREDENTIALS", "_PEPPER", "_DSN",
+	}
+	re := regexp.MustCompile(`os\.(?:Getenv|LookupEnv)\("(LOOMCYCLE_[A-Z0-9_]*)"`)
+	sources := []string{"config.go", "../../cmd/loomcycle/main.go"}
+	scanned := 0
+	for _, src := range sources {
+		b, err := os.ReadFile(src)
+		if err != nil {
+			t.Logf("skip %s (not readable: %v)", src, err)
+			continue
+		}
+		scanned++
+		for _, m := range re.FindAllStringSubmatch(string(b), -1) {
+			name := m[1]
+			isSecret := false
+			for _, suf := range secretSuffixes {
+				if strings.HasSuffix(name, suf) {
+					isSecret = true
+					break
+				}
+			}
+			if isSecret && !expandDenyNames[name] {
+				t.Errorf("%s reads infra secret %q via os.Getenv but it is NOT in expandDenyNames — "+
+					"it would be interpolatable into an attacker-controlled MCP field (S1). Add it to expandDenyNames.",
+					src, name)
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("scanned no source files — the drift guard is inert")
 	}
 }
 


### PR DESCRIPTION
## Why

v0.34.0 deep-security-review **S1 (HIGH)**: the env-interpolation denylist (`expandDenyNames`) was an incomplete blocklist. loomcycle's **own** infra secrets passed it and were interpolatable into an attacker-controlled outbound MCP url/header/arg (a runtime-authored MCPServerDef → `config.ExpandEnv` at dial time) → **exfiltration**. The high-value miss is `LOOMCYCLE_OPERATOR_TOKEN_PEPPER` (the RFC L token-hash pepper — a leak + the hash column = offline token brute-force). Same category as exp7-C2 (`PG_DSN`), left un-closed.

## Approach (curated denylist + drift guard)

Chosen over a blanket suffix-deny because `docs/ARCHITECTURE.md` documents a legit pattern — `${run.user_bearer:-${LOOMCYCLE_STATIC_BEARER}}` and per-MCP `${LOOMCYCLE_*_TOKEN}` auth headers — that a suffix-deny would break.

- **Extend `expandDenyNames`** with loomcycle's owned infra secrets: `LOOMCYCLE_OPERATOR_TOKEN_PEPPER`, `LOOMCYCLE_MCP_UPSTREAM_TOKEN`, `LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS` (+ the existing `PG_DSN` / `LOOMCYCLE_PG_DSN` / `LOOMCYCLE_AUTH_TOKEN`). **Not** `LOOMCYCLE_REDACT_SECRETS` — verified it's a boolean flag (`!= "0"`), not an exfiltable key (the review mis-named it).
- **`TestExpandDenyNames_CoversInfraSecretReads`** — a **drift guard** that scans this package's + `cmd/loomcycle/main.go`'s own `os.Getenv("LOOMCYCLE_…")` secret-suffixed reads and fails CI if any isn't denied. Answers the "unmaintainable blocklist" critique: a future infra-secret env read added without a denylist entry now fails the build. (The scan finds exactly the 4 owned secrets — all denied, zero false positives.)
- **Extended `TestExpandEnv_DeniesInfraSecrets`** to cover the three new secrets; it still asserts a non-secret `LOOMCYCLE_` var and a per-MCP `${LOOMCYCLE_*_TOKEN}` header **do** still expand (no breaking change).

## Tested

- `go test ./internal/config/` clean; build/vet/gofmt clean.
- **Fail-before verified:** removing the entries lets the secrets expand (deny test fails); injecting an undenied `LOOMCYCLE_*_TOKEN` read makes the drift guard fail.
- Manual: with `LOOMCYCLE_OPERATOR_TOKEN_PEPPER=x`, `expandEnv("${LOOMCYCLE_OPERATOR_TOKEN_PEPPER}")` returns the literal, not the value.

One of three PRs from the v0.34.0 security review (#476 pause de-flake; this S1; S2 default-deny scope gate next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)