### PR TITLE
fix(api): default-deny the scope gate for unlisted mutating routes (security S2)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -482,6 +482,22 @@ func requiredScopeFor(method, path string) string {
 		strings.HasPrefix(path, "/v1/sessions/")):
 		return auth.ScopeRunsRead
 	default:
+		// Default-deny for unlisted MUTATING routes (v0.34.0 security review
+		// S2). The prior `return ""` shipped any unlisted route at
+		// any-authenticated — so a new state-changing endpoint added without a
+		// requiredScopeFor entry was silently reachable by a minimal-scope
+		// tenant token. A mutating method now requires ScopeAdmin by default;
+		// ScopeAdmin still satisfies every check (auth.HasScope), so the
+		// default/legacy admin token is unaffected and the safe failure
+		// direction for a forgotten route is over-restrict (a narrow token gets
+		// 403), never silent exposure. GET/HEAD reads keep the any-authenticated
+		// default — reads are tenant-gated per-handler (tenantVisible /
+		// sessionOwnershipOK), and the consumer LLM-gateway POSTs that are
+		// legitimately any-authenticated are explicit `return ""` cases above.
+		switch method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+			return auth.ScopeAdmin
+		}
 		return ""
 	}
 }

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -222,6 +222,16 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/chat/completions", ""},
 		{"POST", "/v1/embeddings", ""},
 		{"GET", "/healthz", ""},
+		// S2 default-deny: an UNLISTED mutating route falls through to
+		// ScopeAdmin (not any-authenticated), so a forgotten new state-changing
+		// endpoint can't silently ship reachable by a narrow tenant token. An
+		// unlisted READ keeps the any-authenticated default (tenant-gated in the
+		// handler).
+		{"POST", "/v1/widgets", auth.ScopeAdmin},
+		{"PUT", "/v1/widgets/w_1", auth.ScopeAdmin},
+		{"PATCH", "/v1/widgets/w_1", auth.ScopeAdmin},
+		{"DELETE", "/v1/widgets/w_1", auth.ScopeAdmin},
+		{"GET", "/v1/widgets", ""},
 	}
 	for _, c := range cases {
 		if got := requiredScopeFor(c.method, c.path); got != c.want {


### PR DESCRIPTION
## Why

v0.34.0 deep-security-review **S2 (MEDIUM)**: `requiredScopeFor`'s `default:` arm returned `""` (any authenticated principal), so a route registered on the mux but **not listed** in `requiredScopeFor` was reachable by *any* valid token — including a minimal-scope tenant token. Adding a new sensitive endpoint without also editing `requiredScopeFor` silently shipped it at any-authenticated. Latent fragility (not a live leak — the verified run-read paths *are* tenant-gated), but for a multi-tenant-isolation product a forgotten scope decision shouldn't fail open.

## What

- **`auth_principal.go`:** the `default:` arm now returns `auth.ScopeAdmin` for **mutating** methods (`POST`/`PUT`/`PATCH`/`DELETE`); `GET`/`HEAD` keep the any-authenticated default (reads are tenant-gated per-handler). `ScopeAdmin` satisfies every check (`auth.HasScope`), so the default/legacy admin token is unaffected — the only behavior change is a **narrow** token hitting an *unlisted* mutating route now gets 403 (the safe failure direction). The legit any-authenticated mutating routes (consumer LLM-gateway POSTs) are explicit `return ""` cases, untouched.
- **`TestRequiredScopeFor`:** unlisted-route cases — `POST/PUT/PATCH/DELETE /v1/widgets` → `ScopeAdmin`, `GET /v1/widgets` → `""`.

## Tested

- Full `internal/api/http` suite green (no existing handler relied on an unlisted mutating route being any-authenticated).
- **Fail-before verified:** the mutating cases returned `""` before the fix.

**Deferred** (the review's larger S2 item, own follow-up): a central tenant-scoping middleware / typed store accessor — latent, not a live leak.

Third of three PRs from the v0.34.0 security review (#476 pause de-flake, #477 S1 env-expand, this S2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)