### PR TITLE
feat(api): central tenant-scoping accessor + close cross-tenant read gaps (S2)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -400,11 +400,10 @@ func tenantFromCtx(ctx context.Context) string {
 // only its own tenant. Single-row read handlers use this to 404 a
 // cross-tenant probe (opaque — no existence oracle).
 func (s *Server) tenantVisible(ctx context.Context, rowTenant string) bool {
-	p, ok := auth.PrincipalFromContext(ctx)
-	if !ok || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
-		return true
-	}
-	return rowTenant == p.TenantID
+	// Single source of truth for the visibility predicate: the same scope
+	// resolution the tenant-scoped store accessor uses (tenant_store.go).
+	tenantID, all := tenantScopeFromCtx(ctx)
+	return all || rowTenant == tenantID
 }
 
 // requiredScopeFor maps an HTTP (method, path) to the scope a caller

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -406,6 +406,22 @@ func (s *Server) tenantVisible(ctx context.Context, rowTenant string) bool {
 	return all || rowTenant == tenantID
 }
 
+// requirePrincipalOwnsPathUser reports whether the ctx principal may act on the
+// per-user surface for pathUserID. Used by the per-user channel routes, whose
+// backing channel_messages carry NO tenant column — so the whole-tenant model
+// (subjects within a tenant share its workspace) can't be enforced without the
+// deferred tenant_id denormalisation. The safe no-schema mitigation is
+// per-SUBJECT: a non-admin principal may act ONLY on its own subject. Admin /
+// legacy / open mode are unrestricted (mirrors the exemptions of
+// sessionOwnershipOK / tenantVisible).
+func requirePrincipalOwnsPathUser(ctx context.Context, pathUserID string) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return true
+	}
+	return pathUserID == p.Subject
+}
+
 // requiredScopeFor maps an HTTP (method, path) to the scope a caller
 // must hold. Empty string = any authenticated principal (no specific
 // scope). substrate:admin satisfies everything (see auth.HasScope), so

--- a/internal/api/http/channels_admin.go
+++ b/internal/api/http/channels_admin.go
@@ -253,13 +253,38 @@ func (s *Server) handleAdminChannelBroadcast(w http.ResponseWriter, r *http.Requ
 
 // ---- per-user handlers (scope=user) -----------------------------
 
+// userChannelScopeID validates the {user_id} path arg and enforces the
+// per-user channel ownership gate, returning (scopeID, true) when the request
+// may proceed. On a bad id or a cross-subject access it writes the response and
+// returns ("", false).
+//
+// Ownership gate: channel_messages carry NO tenant column (the whole-tenant
+// isolation that runs/sessions get would need the deferred tenant_id
+// denormalisation), so the safe no-schema mitigation is per-SUBJECT — a
+// non-admin principal may act ONLY on its own subject's channels. Without it a
+// channel-scoped tenant token could read/write any user's channel by changing
+// the path (user_ids aren't secret). Opaque 404 on mismatch (no existence
+// oracle — same posture sessionOwnershipOK gives). Admin / legacy / open mode
+// are unrestricted.
+func (s *Server) userChannelScopeID(w http.ResponseWriter, r *http.Request) (string, bool) {
+	userID := r.PathValue("user_id")
+	if !validIdent(userID) {
+		writeJSONError(w, http.StatusBadRequest, "invalid_user_id", `user_id must match [A-Za-z0-9_-]{1,128}`)
+		return "", false
+	}
+	if !requirePrincipalOwnsPathUser(r.Context(), userID) {
+		writeJSONError(w, http.StatusNotFound, "unknown_channel", "no such channel")
+		return "", false
+	}
+	return userID, true
+}
+
 // handleUserChannelPublish serves POST /v1/users/{user_id}/channels/{name}/publish.
 // scope=user, scope_id resolved from the URL path so the bearer
 // can't forge a different user_id in the body.
 func (s *Server) handleUserChannelPublish(w http.ResponseWriter, r *http.Request) {
-	userID := r.PathValue("user_id")
-	if !validIdent(userID) {
-		writeJSONError(w, http.StatusBadRequest, "invalid_user_id", `user_id must match [A-Za-z0-9_-]{1,128}`)
+	userID, ok := s.userChannelScopeID(w, r)
+	if !ok {
 		return
 	}
 	s.handleChannelPublish(w, r, r.PathValue("name"), "user", userID)
@@ -267,9 +292,8 @@ func (s *Server) handleUserChannelPublish(w http.ResponseWriter, r *http.Request
 
 // handleUserChannelSubscribe serves POST /v1/users/{user_id}/channels/{name}/subscribe.
 func (s *Server) handleUserChannelSubscribe(w http.ResponseWriter, r *http.Request) {
-	userID := r.PathValue("user_id")
-	if !validIdent(userID) {
-		writeJSONError(w, http.StatusBadRequest, "invalid_user_id", `user_id must match [A-Za-z0-9_-]{1,128}`)
+	userID, ok := s.userChannelScopeID(w, r)
+	if !ok {
 		return
 	}
 	s.handleChannelSubscribe(w, r, r.PathValue("name"), "user", userID)
@@ -277,9 +301,8 @@ func (s *Server) handleUserChannelSubscribe(w http.ResponseWriter, r *http.Reque
 
 // handleUserChannelPeek serves GET /v1/users/{user_id}/channels/{name}/peek.
 func (s *Server) handleUserChannelPeek(w http.ResponseWriter, r *http.Request) {
-	userID := r.PathValue("user_id")
-	if !validIdent(userID) {
-		writeJSONError(w, http.StatusBadRequest, "invalid_user_id", `user_id must match [A-Za-z0-9_-]{1,128}`)
+	userID, ok := s.userChannelScopeID(w, r)
+	if !ok {
 		return
 	}
 	s.handleChannelPeek(w, r, r.PathValue("name"), "user", userID)
@@ -287,9 +310,8 @@ func (s *Server) handleUserChannelPeek(w http.ResponseWriter, r *http.Request) {
 
 // handleUserChannelAck serves POST /v1/users/{user_id}/channels/{name}/ack.
 func (s *Server) handleUserChannelAck(w http.ResponseWriter, r *http.Request) {
-	userID := r.PathValue("user_id")
-	if !validIdent(userID) {
-		writeJSONError(w, http.StatusBadRequest, "invalid_user_id", `user_id must match [A-Za-z0-9_-]{1,128}`)
+	userID, ok := s.userChannelScopeID(w, r)
+	if !ok {
 		return
 	}
 	s.handleChannelAck(w, r, r.PathValue("name"), "user", userID)

--- a/internal/api/http/channels_user_gate_test.go
+++ b/internal/api/http/channels_user_gate_test.go
@@ -1,0 +1,115 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/channels"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// userChannelFixture builds a server with one declared USER-scoped channel and
+// the channel publisher wired, so a peek on the declared channel returns 200
+// (allow path) — distinguishable from the gate's opaque 404 (which is
+// deliberately identical to an undeclared channel's 404).
+func userChannelFixture(t *testing.T) *Server {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	cfg := &config.Config{
+		Channels: map[string]config.Channel{
+			"inbox": {Scope: "user", Semantic: "broadcast", MaxMessages: 100},
+		},
+	}
+	cfg.Env.ChannelsMaxValueBytes = 64 * 1024
+	hookReg := hooks.NewRegistry()
+	bus := channels.NewBus()
+	srv := &Server{
+		cfg:            cfg,
+		store:          st,
+		cancelReg:      cancel.NewRegistry(),
+		sessionLocks:   runner.NewSessionLockMap(),
+		hookRegistry:   hookReg,
+		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
+		sem:            concurrency.New(8, 16, 30000),
+	}
+	srv.SetSystemPublisher(&channels.StorePublisher{
+		Store:     st,
+		Bus:       bus,
+		Scheduler: channels.NewScheduler(bus, 100),
+	})
+	return srv
+}
+
+// A channel-scoped tenant token must not read/write another subject's per-user
+// channels by changing the {user_id} in the path (user_ids are not secret, and
+// channel_messages have no tenant column to gate on). A non-admin principal may
+// act only on its OWN subject; admin / legacy / open mode are unrestricted. The
+// cross-subject refusal is an opaque 404 — identical to an undeclared channel,
+// so it's not an existence oracle. Fails on the pre-gate wrappers, which passed
+// the path user_id straight through as scope_id.
+func TestHandleUserChannelPeek_RejectsCrossSubject(t *testing.T) {
+	s := userChannelFixture(t)
+
+	peek := func(pathUser, tenant, subject string, scopes []string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest(http.MethodGet, "/v1/users/"+pathUser+"/channels/inbox/peek", nil)
+		r.SetPathValue("user_id", pathUser)
+		r.SetPathValue("name", "inbox")
+		r = r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: scopes,
+		}))
+		rr := httptest.NewRecorder()
+		s.handleUserChannelPeek(rr, r)
+		return rr
+	}
+
+	// Cross-subject (alice's token peeking bob's inbox) → opaque 404.
+	if rr := peek("bob", "acme", "alice", []string{auth.ScopeChannelRead}); rr.Code != http.StatusNotFound {
+		t.Errorf("cross-subject peek status=%d, want 404 (own-subject gate not enforced)\nbody=%s", rr.Code, rr.Body.String())
+	}
+	// Own subject → gate passes; declared channel → 200 (not the gate's 404).
+	if rr := peek("alice", "acme", "alice", []string{auth.ScopeChannelRead}); rr.Code != http.StatusOK {
+		t.Errorf("own-subject peek status=%d, want 200 (gate rejected a legitimate caller)\nbody=%s", rr.Code, rr.Body.String())
+	}
+	// Super-admin may peek any subject's channel.
+	if rr := peek("bob", "x", "ops", []string{auth.ScopeAdmin}); rr.Code != http.StatusOK {
+		t.Errorf("admin peek status=%d, want 200 (super-admin must cross subjects)\nbody=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestRequirePrincipalOwnsPathUser_Matrix locks the per-user ownership predicate
+// directly (the per-subject mitigation for the tenant-column-less channels).
+func TestRequirePrincipalOwnsPathUser_Matrix(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *auth.Principal // nil = open mode (no principal)
+		pathUser  string
+		want      bool
+	}{
+		{"open mode (no principal)", nil, "anyone", true},
+		{"legacy exempt", &auth.Principal{Subject: "default", Legacy: true}, "anyone", true},
+		{"admin crosses subjects", &auth.Principal{Subject: "ops", Scopes: []string{auth.ScopeAdmin}}, "anyone", true},
+		{"own subject", &auth.Principal{Subject: "alice", Scopes: []string{auth.ScopeChannelRead}}, "alice", true},
+		{"other subject blocked", &auth.Principal{Subject: "alice", Scopes: []string{auth.ScopeChannelRead}}, "bob", false},
+	}
+	for _, c := range cases {
+		ctx := context.Background()
+		if c.principal != nil {
+			ctx = auth.WithPrincipal(ctx, *c.principal)
+		}
+		if got := requirePrincipalOwnsPathUser(ctx, c.pathUser); got != c.want {
+			t.Errorf("%s: requirePrincipalOwnsPathUser = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/api/http/connector_impl_n8n.go
+++ b/internal/api/http/connector_impl_n8n.go
@@ -165,6 +165,14 @@ func (s *Server) StreamUserRunStates(ctx context.Context, req connector.StreamUs
 			if !ok {
 				return nil
 			}
+			// RFC L/N tenant isolation: a tenant principal sees only its own
+			// tenant's run transitions. Filtered here (after the bus read, where
+			// the runstate event still carries TenantID) so it also covers the
+			// cluster-backplane path. Left off (TenantScoped=false) for the
+			// gRPC/MCP adapters — behaviour unchanged for them.
+			if req.TenantScoped && evt.TenantID != req.TenantID {
+				continue
+			}
 			if req.Agent != "" && evt.Agent != req.Agent {
 				continue
 			}

--- a/internal/api/http/connector_impl_n8n_test.go
+++ b/internal/api/http/connector_impl_n8n_test.go
@@ -99,6 +99,56 @@ func TestConnector_StreamUserRunStates_VisitsMatchingEvents(t *testing.T) {
 	}
 }
 
+// A tenant-scoped stream must drop run-state events for runs in OTHER tenants
+// even when they share the requested user_id (RFC L/N: run_ids/user_ids aren't
+// secret). Mirrors the user-filter test's "publish a dropped event first, then
+// a passing one; the first RECEIVED event proves the drop" shape. Fails on the
+// pre-filter code, where the cross-tenant event would arrive first.
+func TestConnector_StreamUserRunStates_TenantScopedDropsCrossTenant(t *testing.T) {
+	srv, _, cleanup := systemChannelFixture(t)
+	defer cleanup()
+	bus := runstate.NewBus()
+	srv.SetRunStateBus(bus)
+
+	var c connector.Connector = srv
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	received := make(chan connector.RunStateEvent, 4)
+	done := make(chan error, 1)
+	go func() {
+		done <- c.StreamUserRunStates(ctx, connector.StreamUserRunStatesRequest{
+			UserID:       "u-shared",
+			TenantID:     "acme",
+			TenantScoped: true,
+		}, func(evt connector.RunStateEvent) error {
+			received <- evt
+			return nil
+		})
+	}()
+
+	waitForSubscriber(t, bus)
+
+	// Same user, two tenants. The evil event is published FIRST and must be
+	// dropped; the acme event must pass — so the first RECEIVED event is acme.
+	bus.Publish(runstate.RunStateEvent{RunID: "r_evil", UserID: "u-shared", TenantID: "evil", Status: "completed"})
+	bus.Publish(runstate.RunStateEvent{RunID: "r_acme", UserID: "u-shared", TenantID: "acme", Status: "completed"})
+
+	select {
+	case evt := <-received:
+		if evt.RunID != "r_acme" {
+			t.Errorf("cross-tenant event leaked: got %q, want r_acme (tenant filter not enforced)", evt.RunID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("no event delivered within 1s")
+	}
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("StreamUserRunStates returned err: %v", err)
+	}
+}
+
 func TestConnector_StreamUserRunStates_StopOnSentinel(t *testing.T) {
 	srv, _, cleanup := systemChannelFixture(t)
 	defer cleanup()

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -201,6 +201,7 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		AgentID:       run.AgentID,
 		Agent:         run.Agent,
 		UserID:        run.UserID,
+		TenantID:      run.TenantID,
 		ParentContext: run.ParentContext,
 		otelSpan:      runSpan,
 	}
@@ -356,6 +357,7 @@ func (s *Server) flagRunUnresumable(run store.Run, reason string) {
 		AgentID:       run.AgentID,
 		Agent:         run.Agent,
 		UserID:        run.UserID,
+		TenantID:      run.TenantID,
 		ParentContext: run.ParentContext,
 	}
 	s.finishRunFailedReason(run.ID, "resume failed: "+reason, meta)

--- a/internal/api/http/run_stream.go
+++ b/internal/api/http/run_stream.go
@@ -128,22 +128,14 @@ func (s *Server) handleRunStream(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "run_id must match [A-Za-z0-9_-]{1,128}", http.StatusBadRequest)
 		return
 	}
-	run, err := s.store.GetRun(r.Context(), runID)
+	// Tenant-ownership gate via the tenant-scoped accessor: a cross-tenant run
+	// is folded into *store.ErrNotFound, so an unknown run and a cross-tenant
+	// run both return the same opaque 404 (run_ids are not secret, so the gate
+	// must not become an existence oracle). Super-admin / legacy / open see all.
+	run, err := s.tenantStore(r.Context()).GetRun(r.Context(), runID)
 	if err != nil {
-		// Opaque 404 — run_ids are not secret, but we don't distinguish
-		// "unknown" from "not yours" to avoid a cross-tenant probe oracle.
 		http.Error(w, "no such run", http.StatusNotFound)
 		return
-	}
-	// Tenant-ownership gate (mirrors handleRunInput): resolve the run's session
-	// and refuse a cross-tenant attach with the same opaque 404.
-	if run.SessionID != "" {
-		if sess, serr := s.store.GetSession(r.Context(), run.SessionID); serr == nil {
-			if !sessionOwnershipOK(r.Context(), sess) {
-				http.Error(w, "no such run", http.StatusNotFound)
-				return
-			}
-		}
 	}
 
 	var fromSeq int64

--- a/internal/api/http/runs_stream.go
+++ b/internal/api/http/runs_stream.go
@@ -95,6 +95,14 @@ func (s *Server) handleStreamUserAgents(w http.ResponseWriter, r *http.Request) 
 	}
 
 	req := parseStreamFilter(userID, r.URL.Query())
+	// RFC L/N tenant isolation: a tenant principal sees only its own tenant's
+	// run transitions (run_ids/user_ids aren't secret, so without this a token
+	// could stream another tenant's run states by passing its user_id).
+	// principalTenantScope: tenant → own (TenantScoped), admin/legacy/open →
+	// all (no scope). ?tenant= lets an admin focus one tenant, like the lists.
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	req.TenantID = tenantID
+	req.TenantScoped = !all
 
 	stream.start()
 

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5334,7 +5334,12 @@ func (s *Server) handleListUserInterrupts(w http.ResponseWriter, r *http.Request
 	if statusFilter == "all" {
 		statusFilter = ""
 	}
-	rows, err := s.store.InterruptListByUser(r.Context(), userID, statusFilter)
+	// Tenant-scope the inbox: a tenant principal sees only interrupts on its
+	// own tenant's runs (the accessor passes the principal's tenant down to the
+	// store JOIN); super-admin / legacy / open mode see all. Without this a
+	// token could read another tenant's pending questions by guessing a
+	// user_id (user_ids are not secret). Mirrors handleListUsers' scoping.
+	rows, err := s.tenantStore(r.Context()).InterruptListByUser(r.Context(), userID, statusFilter)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1756,6 +1756,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		AgentID:       agentID,
 		Agent:         effectiveAgentName,
 		UserID:        effectiveUserID,
+		TenantID:      effectiveTenantID,
 		ParentContext: in.ParentContext,
 	}
 	// Stash the run span on the meta so finishRun* can close it with
@@ -3006,6 +3007,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		AgentID:       agentID,
 		Agent:         req.Agent,
 		UserID:        req.UserID,
+		TenantID:      req.TenantID,
 		otelSpan:      runSpan,
 		ParentContext: req.ParentContext,
 	}
@@ -3533,6 +3535,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AgentID:       agentID,
 		Agent:         sess.Agent,
 		UserID:        sess.UserID,
+		TenantID:      sess.TenantID,
 		otelSpan:      runSpan,
 		ParentContext: body.ParentContext,
 	}
@@ -4311,6 +4314,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		AgentID:       subAgentID,
 		Agent:         name,
 		UserID:        parentIdentity.UserID,
+		TenantID:      parentIdentity.TenantID, // sub-agent inherits the parent run's tenant
 		ParentAgentID: parentIdentity.AgentID,
 		otelSpan:      subRunSpan,
 		ParentContext: parentIdentity.ParentContext, // v0.12.x: sub-agent's run-state events carry the root's lineage
@@ -5379,6 +5383,7 @@ type runStateMeta struct {
 	AgentID       string
 	Agent         string
 	UserID        string
+	TenantID      string // run's authoritative tenant — gates the user-agents stream
 	ParentAgentID string
 	// ParentContext is the run's opaque tracking lineage, echoed on the
 	// published RunStateEvent (v0.12.x).
@@ -5403,6 +5408,7 @@ func (s *Server) publishRunState(m runStateMeta, status, stopReason, errMsg stri
 		AgentID:       m.AgentID,
 		Agent:         m.Agent,
 		UserID:        m.UserID,
+		TenantID:      m.TenantID,
 		ParentAgentID: m.ParentAgentID,
 		Status:        status,
 		StopReason:    stopReason,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -4671,7 +4671,11 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	run, err := s.store.GetRunByAgentID(r.Context(), agentID)
+	// Multi-tenant authz: the accessor folds a cross-tenant run into the same
+	// *store.ErrNotFound a missing run returns, so the not-found branch below
+	// covers both — a cross-tenant probe gets the identical opaque 404 (no
+	// existence oracle). Super-admin / legacy / open mode see all.
+	run, err := s.tenantStore(r.Context()).GetRunByAgentID(r.Context(), agentID)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -4681,15 +4685,6 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// Multi-tenant authz: a tenant principal may only read runs in its
-	// own tenant. A cross-tenant probe gets the same 404 as a missing
-	// agent (opaque — no existence oracle). Super-admin / open mode see all.
-	if !s.tenantVisible(r.Context(), run.TenantID) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no run found for agent_id %q"}`, agentID)
 		return
 	}
 	_, live := s.cancelReg.Get(agentID)
@@ -5135,17 +5130,13 @@ func (s *Server) compactRunWithSource(ctx context.Context, runID, source string)
 	if s.store == nil {
 		return connector.CompactResult{}, &compactErr{status: http.StatusServiceUnavailable, msg: "compaction requires persistence"}
 	}
-	run, err := s.store.GetRun(ctx, runID)
+	// Tenant-ownership via the tenant-scoped accessor: a cross-tenant (or
+	// missing) run both fold into the same opaque 404 (run_ids aren't secrets,
+	// so the gate must not become an existence oracle). Shared by the HTTP
+	// handler and the gRPC/MCP CompactRun — both carry the principal in ctx.
+	run, err := s.tenantStore(ctx).GetRun(ctx, runID)
 	if err != nil {
 		return connector.CompactResult{}, &compactErr{status: http.StatusNotFound, msg: "no run for that run_id"}
-	}
-	// Tenant-ownership: opaque 404 cross-tenant (run_ids aren't secrets).
-	if run.SessionID != "" {
-		if sess, serr := s.store.GetSession(ctx, run.SessionID); serr == nil {
-			if !sessionOwnershipOK(ctx, sess) {
-				return connector.CompactResult{}, &compactErr{status: http.StatusNotFound, msg: "no run for that run_id"}
-			}
-		}
 	}
 
 	terminal := isTerminalRunStatus(run.Status)
@@ -5309,8 +5300,18 @@ func (s *Server) handleListRunInterrupts(w http.ResponseWriter, r *http.Request)
 	if statusFilter == "all" {
 		statusFilter = ""
 	}
-	rows, err := s.store.InterruptListByRun(r.Context(), runID, statusFilter)
+	// Tenant-ownership via the accessor: it gates on the OWNING run's tenant
+	// (interrupts have no tenant column — they inherit the run's). A
+	// cross-tenant or unknown run folds into *store.ErrNotFound, which we map
+	// to an empty list — indistinguishable from a real run with zero
+	// interrupts, so the listing can't be a cross-tenant existence oracle.
+	rows, err := s.tenantStore(r.Context()).InterruptListByRun(r.Context(), runID, statusFilter)
 	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			writeJSON(w, http.StatusOK, map[string]any{"interrupts": []store.InterruptRow{}, "total": 0})
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -3337,7 +3337,12 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// Validate the session exists BEFORE taking the per-session lock.
 	// Otherwise an attacker can spam unknown IDs and each LoadOrStore
 	// grows sessionLocks permanently (entries are never GC'd at v0.3.2).
-	sess, err := s.store.GetSession(r.Context(), id)
+	//
+	// RFC L: a continuation runs under the session's stored tenant+subject, so
+	// the caller must OWN the session (the tenant boundary). The tenant-scoped
+	// accessor folds a cross-tenant session into the same *store.ErrNotFound a
+	// missing one returns → identical opaque 404, no existence oracle.
+	sess, err := s.tenantStore(r.Context()).GetSession(r.Context(), id)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -3345,13 +3350,6 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// RFC L: a continuation runs under the session's stored tenant+subject, so
-	// the caller principal must OWN the session. 404 (not 403) on mismatch so
-	// a non-owner can't probe which session ids exist (no-oracle).
-	if !sessionOwnershipOK(r.Context(), sess) {
-		http.Error(w, (&store.ErrNotFound{Kind: "session", ID: id}).Error(), http.StatusNotFound)
 		return
 	}
 
@@ -3881,7 +3879,10 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "session id is required", http.StatusBadRequest)
 		return
 	}
-	sess, err := s.store.GetSession(r.Context(), id)
+	// RFC L: the transcript exposes the session's full history — gate it on the
+	// same tenant ownership as continuation. The accessor folds a cross-tenant
+	// session into the same opaque *store.ErrNotFound a missing one returns.
+	sess, err := s.tenantStore(r.Context()).GetSession(r.Context(), id)
 	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
@@ -3889,12 +3890,6 @@ func (s *Server) handleTranscript(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	// RFC L: the transcript exposes the session's full history — gate it on
-	// the same cross-principal ownership as continuation (opaque 404).
-	if !sessionOwnershipOK(r.Context(), sess) {
-		http.Error(w, (&store.ErrNotFound{Kind: "session", ID: id}).Error(), http.StatusNotFound)
 		return
 	}
 	transcript, err := s.store.GetTranscript(r.Context(), id)

--- a/internal/api/http/tenant_coverage_test.go
+++ b/internal/api/http/tenant_coverage_test.go
@@ -1,0 +1,196 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// TestTenantReachableReads_AreOpaqueCrossTenant is the maintained inventory of
+// the read routes a NON-ADMIN tenant token can reach (scope runs:read /
+// channel:read), each re-verified in one place to stay tenant-gated. It's the
+// "enforced invariant" as a guard: Go's ServeMux exposes no route patterns to
+// introspect, so the list is maintained by hand — when you add a
+// tenant-reachable read route, add a row here and it must be opaque to a
+// cross-tenant caller.
+//
+// Full tenant-reachable surface and where each gate lives:
+//
+//	GET  /v1/agents/{agent_id}                       tenantStore.GetRunByAgentID   (this table + TestTenantStore_GetRunOpaqueCrossTenant)
+//	GET  /v1/runs/{run_id}/stream                    tenantStore.GetRun            (handleRunStream; same accessor as GetRun above)
+//	GET  /v1/sessions/{id}/transcript                tenantStore.GetSession        (this table + TestHandleTranscript_RejectsCrossTenant)
+//	POST /v1/sessions/{id}/messages                  tenantStore.GetSession        (this table + TestHandleMessages_RejectsCrossTenantSession)
+//	POST /v1/runs (continuation)                     sessionOwnershipOK            (openOrCreateSessionAndRun)
+//	POST /v1/runs/{run_id}/input  (steer)            sessionOwnershipOK            (handleRunInput; fails open on store error by design)
+//	POST /v1/runs/{run_id}/compact                   tenantStore.GetRun            (compactRunWithSource)
+//	GET  /v1/runs/{run_id}/interrupts                tenantStore.InterruptListByRun (this table + TestHandleListRunInterrupts_RejectsCrossTenant)
+//	GET  /v1/users/{user_id}/interrupts              tenantStore.InterruptListByUser (this table + TestHandleListUserInterrupts_RejectsCrossTenant)
+//	GET  /v1/users/{user_id}/agents/stream           StreamUserRunStates tenant filter (TestConnector_StreamUserRunStates_TenantScopedDropsCrossTenant)
+//	*    /v1/users/{user_id}/channels/{name}/*        requirePrincipalOwnsPathUser  (TestHandleUserChannelPeek_RejectsCrossSubject)
+//
+// The /v1/_* admin surfaces are OUT of scope (requiredScopeFor gates them at
+// substrate:admin; super-admin sees all tenants by design).
+func TestTenantReachableReads_AreOpaqueCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	ctx := context.Background()
+
+	// Seed a tenant-A (acme) session + run + interrupt owned by user "alice".
+	sess, err := st.CreateSession(ctx, "acme", "agentx", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "ag_cov", UserID: "alice", TenantID: "acme"})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if _, err := st.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: store.MintInterruptID(time.Now()), RunID: run.ID, UserID: "alice",
+		Question: "secret?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+
+	withPrincipal := func(r *http.Request, tenant, subject string) *http.Request {
+		return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: []string{auth.ScopeRunsRead},
+		}))
+	}
+	totalOf := func(rr *httptest.ResponseRecorder) int {
+		var body struct {
+			Total int `json:"total"`
+		}
+		_ = json.Unmarshal(rr.Body.Bytes(), &body)
+		return body.Total
+	}
+
+	type route struct {
+		name string
+		// fire issues the request as the given (tenant, subject) principal.
+		fire func(tenant, subject string) *httptest.ResponseRecorder
+		// crossOK asserts the tenant-B (evil) response is opaque (no leak).
+		crossOK func(t *testing.T, rr *httptest.ResponseRecorder)
+		// ownOK asserts the tenant-A (acme) response is NOT the opaque refusal.
+		ownOK func(t *testing.T, rr *httptest.ResponseRecorder)
+	}
+
+	routes := []route{
+		{
+			name: "GET /v1/agents/{agent_id}",
+			fire: func(tenant, subject string) *httptest.ResponseRecorder {
+				r := withPrincipal(httptest.NewRequest(http.MethodGet, "/v1/agents/ag_cov", nil), tenant, subject)
+				r.SetPathValue("agent_id", "ag_cov")
+				rr := httptest.NewRecorder()
+				s.handleGetAgent(rr, r)
+				return rr
+			},
+			crossOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusNotFound {
+					t.Errorf("cross-tenant agent read = %d, want 404 (opaque)", rr.Code)
+				}
+			},
+			ownOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusOK {
+					t.Errorf("own-tenant agent read = %d, want 200", rr.Code)
+				}
+			},
+		},
+		{
+			name: "GET /v1/sessions/{id}/transcript",
+			fire: func(tenant, subject string) *httptest.ResponseRecorder {
+				r := withPrincipal(httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sess.ID+"/transcript", nil), tenant, subject)
+				r.SetPathValue("id", sess.ID)
+				rr := httptest.NewRecorder()
+				s.handleTranscript(rr, r)
+				return rr
+			},
+			crossOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusNotFound {
+					t.Errorf("cross-tenant transcript = %d, want 404 (opaque)", rr.Code)
+				}
+			},
+			ownOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code == http.StatusNotFound {
+					t.Error("own-tenant transcript got opaque 404")
+				}
+			},
+		},
+		{
+			name: "POST /v1/sessions/{id}/messages (cross-tenant gate only)",
+			fire: func(tenant, subject string) *httptest.ResponseRecorder {
+				body := `{"segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`
+				r := withPrincipal(httptest.NewRequest(http.MethodPost, "/v1/sessions/"+sess.ID+"/messages", strings.NewReader(body)), tenant, subject)
+				r.SetPathValue("id", sess.ID)
+				r.Header.Set("Content-Type", "application/json")
+				rr := httptest.NewRecorder()
+				s.handleMessages(rr, r)
+				return rr
+			},
+			crossOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusNotFound {
+					t.Errorf("cross-tenant continuation = %d, want 404 (opaque)", rr.Code)
+				}
+			},
+			// own-tenant proceeds past the gate into run setup (needs a provider),
+			// so we only assert it did NOT get the ownership 404.
+			ownOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code == http.StatusNotFound {
+					t.Error("own-tenant continuation got opaque 404 (gate rejected a legit caller)")
+				}
+			},
+		},
+		{
+			name: "GET /v1/runs/{run_id}/interrupts",
+			fire: func(tenant, subject string) *httptest.ResponseRecorder {
+				r := withPrincipal(httptest.NewRequest(http.MethodGet, "/v1/runs/"+run.ID+"/interrupts?status=all", nil), tenant, subject)
+				r.SetPathValue("run_id", run.ID)
+				rr := httptest.NewRecorder()
+				s.handleListRunInterrupts(rr, r)
+				return rr
+			},
+			crossOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusOK || totalOf(rr) != 0 {
+					t.Errorf("cross-tenant run-interrupts = (%d, total=%d), want (200, 0)", rr.Code, totalOf(rr))
+				}
+			},
+			ownOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusOK || totalOf(rr) != 1 {
+					t.Errorf("own-tenant run-interrupts = (%d, total=%d), want (200, 1)", rr.Code, totalOf(rr))
+				}
+			},
+		},
+		{
+			name: "GET /v1/users/{user_id}/interrupts",
+			fire: func(tenant, subject string) *httptest.ResponseRecorder {
+				r := withPrincipal(httptest.NewRequest(http.MethodGet, "/v1/users/alice/interrupts?status=all", nil), tenant, subject)
+				r.SetPathValue("user_id", "alice")
+				rr := httptest.NewRecorder()
+				s.handleListUserInterrupts(rr, r)
+				return rr
+			},
+			crossOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusOK || totalOf(rr) != 0 {
+					t.Errorf("cross-tenant user-interrupts = (%d, total=%d), want (200, 0)", rr.Code, totalOf(rr))
+				}
+			},
+			ownOK: func(t *testing.T, rr *httptest.ResponseRecorder) {
+				if rr.Code != http.StatusOK || totalOf(rr) != 1 {
+					t.Errorf("own-tenant user-interrupts = (%d, total=%d), want (200, 1)", rr.Code, totalOf(rr))
+				}
+			},
+		},
+	}
+
+	for _, rt := range routes {
+		t.Run(rt.name, func(t *testing.T) {
+			rt.crossOK(t, rt.fire("evil", "mallory")) // cross-tenant: must be opaque
+			rt.ownOK(t, rt.fire("acme", "alice"))     // own-tenant: must resolve
+		})
+	}
+}

--- a/internal/api/http/tenant_store.go
+++ b/internal/api/http/tenant_store.go
@@ -1,0 +1,94 @@
+package http
+
+import (
+	"context"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// tenantScopedStore is a per-request, tenant-aware façade over store.Store. It
+// turns the per-handler tenant-isolation CONVENTION — each read remembering to
+// call tenantVisible / sessionOwnershipOK — into a single CHOKE-POINT: every
+// tenant-bearing or run-keyed read flows through here, and a row outside the
+// caller's tenant is folded into an opaque *store.ErrNotFound (the same
+// no-existence-oracle posture handlers return by hand today). Build one per
+// request with s.tenantStore(ctx); the scope is captured from the ctx principal
+// at construction.
+//
+// WHOLE-TENANT model (RFC L/N): the boundary is the TENANT, not the subject —
+// subjects within a tenant share its workspace (they collaborate). The
+// cross-TENANT boundary is the security property. A super-admin (substrate:
+// admin) and the single-operator legacy principal cross it by design; open dev
+// mode (no principal) sees all. This matches tenantVisible / sessionOwnershipOK
+// exactly so migrating a handler onto the accessor is behaviour-preserving.
+type tenantScopedStore struct {
+	store      store.Store
+	tenantID   string
+	allTenants bool
+}
+
+// tenantStore captures the caller's tenant scope from the ctx principal and
+// returns a façade that gates every read against it.
+func (s *Server) tenantStore(ctx context.Context) *tenantScopedStore {
+	tenantID, allTenants := tenantScopeFromCtx(ctx)
+	return &tenantScopedStore{store: s.store, tenantID: tenantID, allTenants: allTenants}
+}
+
+// tenantScopeFromCtx resolves (tenantID, allTenants) from the ctx principal,
+// matching the exemption set of tenantVisible + sessionOwnershipOK: no
+// principal (open dev mode), the single-operator legacy principal, and any
+// substrate:admin principal all see every tenant. (Legacy is redundant with the
+// admin scope it carries, but kept explicit to mirror sessionOwnershipOK.)
+func tenantScopeFromCtx(ctx context.Context) (tenantID string, allTenants bool) {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return "", true
+	}
+	return p.TenantID, false
+}
+
+// visible reports whether a row owned by rowTenant is in the caller's scope.
+func (t *tenantScopedStore) visible(rowTenant string) bool {
+	return t.allTenants || rowTenant == t.tenantID
+}
+
+// GetRun fetches a run and folds a cross-tenant row into an opaque
+// *store.ErrNotFound — a cross-tenant probe is indistinguishable from a missing
+// run (run_ids are not secret, so the gate must not become an existence
+// oracle).
+func (t *tenantScopedStore) GetRun(ctx context.Context, runID string) (store.Run, error) {
+	run, err := t.store.GetRun(ctx, runID)
+	if err != nil {
+		return store.Run{}, err
+	}
+	if !t.visible(run.TenantID) {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: runID}
+	}
+	return run, nil
+}
+
+// GetRunByAgentID is GetRun keyed by agent_id (the live-run lookup the agent
+// read endpoint uses). Same opaque cross-tenant fold.
+func (t *tenantScopedStore) GetRunByAgentID(ctx context.Context, agentID string) (store.Run, error) {
+	run, err := t.store.GetRunByAgentID(ctx, agentID)
+	if err != nil {
+		return store.Run{}, err
+	}
+	if !t.visible(run.TenantID) {
+		return store.Run{}, &store.ErrNotFound{Kind: "run", ID: agentID}
+	}
+	return run, nil
+}
+
+// InterruptListByRun returns the run's interrupts, gated by the OWNING run's
+// tenant: a cross-tenant (or missing) run returns *store.ErrNotFound so the
+// list can't be used as a cross-tenant existence oracle. Interrupts carry no
+// tenant column of their own — they inherit the run's tenant, so gating the run
+// is the gate.
+func (t *tenantScopedStore) InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]store.InterruptRow, error) {
+	if _, err := t.GetRun(ctx, runID); err != nil {
+		return nil, err
+	}
+	return t.store.InterruptListByRun(ctx, runID, statusFilter)
+}

--- a/internal/api/http/tenant_store.go
+++ b/internal/api/http/tenant_store.go
@@ -107,3 +107,14 @@ func (t *tenantScopedStore) InterruptListByRun(ctx context.Context, runID, statu
 	}
 	return t.store.InterruptListByRun(ctx, runID, statusFilter)
 }
+
+// InterruptListByUser returns the user's interrupts scoped to the caller's
+// tenant (the store JOINs runs.tenant_id). allTenants → no tenant filter
+// (super-admin / legacy / open mode see every tenant), mirroring ListUsers.
+func (t *tenantScopedStore) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
+	tenantFilter := t.tenantID
+	if t.allTenants {
+		tenantFilter = ""
+	}
+	return t.store.InterruptListByUser(ctx, userID, tenantFilter, statusFilter)
+}

--- a/internal/api/http/tenant_store.go
+++ b/internal/api/http/tenant_store.go
@@ -81,6 +81,21 @@ func (t *tenantScopedStore) GetRunByAgentID(ctx context.Context, agentID string)
 	return run, nil
 }
 
+// GetSession fetches a session and folds a cross-tenant row into an opaque
+// *store.ErrNotFound — mirrors sessionOwnershipOK's 404-on-mismatch (a
+// continuation/transcript exposes the session's history, so the boundary is
+// the tenant; session_ids are not secret).
+func (t *tenantScopedStore) GetSession(ctx context.Context, sessionID string) (store.Session, error) {
+	sess, err := t.store.GetSession(ctx, sessionID)
+	if err != nil {
+		return store.Session{}, err
+	}
+	if !t.visible(sess.TenantID) {
+		return store.Session{}, &store.ErrNotFound{Kind: "session", ID: sessionID}
+	}
+	return sess, nil
+}
+
 // InterruptListByRun returns the run's interrupts, gated by the OWNING run's
 // tenant: a cross-tenant (or missing) run returns *store.ErrNotFound so the
 // list can't be used as a cross-tenant existence oracle. Interrupts carry no

--- a/internal/api/http/tenant_store_test.go
+++ b/internal/api/http/tenant_store_test.go
@@ -121,6 +121,59 @@ func TestHandleTranscript_RejectsCrossTenant(t *testing.T) {
 	}
 }
 
+// The user-scoped interrupt inbox (GET /v1/users/{user_id}/interrupts) keyed on
+// user_id alone before this change; a token could read another tenant's pending
+// questions by passing a user_id that exists in both tenants (user_ids are not
+// secret). The handler now passes the principal's tenant down to the store
+// JOIN. Fails on the pre-gate code, which returned both tenants' rows.
+func TestHandleListUserInterrupts_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	ctx := context.Background()
+	const user = "u_shared"
+	runAcme := seedRunInTenant(t, st, "acme", user, "a_acme_ui")
+	runEvil := seedRunInTenant(t, st, "evil", user, "a_evil_ui")
+	for _, rr := range []struct{ run, q string }{{runAcme, "acme Q"}, {runEvil, "evil Q"}} {
+		if _, err := st.InterruptCreate(ctx, store.InterruptRow{
+			InterruptID: store.MintInterruptID(time.Now()), RunID: rr.run, UserID: user,
+			Question: rr.q, CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("InterruptCreate: %v", err)
+		}
+	}
+
+	totalFor := func(tenant, subject string, scopes []string) int {
+		r := httptest.NewRequest(http.MethodGet, "/v1/users/"+user+"/interrupts?status=all", nil)
+		r.SetPathValue("user_id", user)
+		r = r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: scopes,
+		}))
+		rr := httptest.NewRecorder()
+		s.handleListUserInterrupts(rr, r)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", rr.Code)
+		}
+		var body struct {
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body.Total
+	}
+
+	// A tenant principal sees only its own tenant's interrupt for this user.
+	if got := totalFor("acme", "alice", []string{auth.ScopeRunsRead}); got != 1 {
+		t.Errorf("acme inbox for %q = %d rows, want 1 (cross-tenant leak)", user, got)
+	}
+	if got := totalFor("evil", "mallory", []string{auth.ScopeRunsRead}); got != 1 {
+		t.Errorf("evil inbox for %q = %d rows, want 1 (cross-tenant leak)", user, got)
+	}
+	// Super-admin sees both tenants' interrupts.
+	if got := totalFor("x", "ops", []string{auth.ScopeAdmin}); got != 2 {
+		t.Errorf("admin inbox for %q = %d rows, want 2", user, got)
+	}
+}
+
 // TestTenantStore_GetRunOpaqueCrossTenant locks the accessor's core posture: a
 // cross-tenant run is indistinguishable from a missing one (both
 // *store.ErrNotFound), while the owning tenant + admin resolve it.

--- a/internal/api/http/tenant_store_test.go
+++ b/internal/api/http/tenant_store_test.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// seedRunInTenant creates a session+run in the given tenant and returns the
+// run's id + agent_id. Mirrors makeRunForInterrupt in the store contract but
+// stamps an explicit tenant (CreateRun denormalises identity.TenantID onto the
+// run row — that's the column the tenant gate reads).
+func seedRunInTenant(t *testing.T, st store.Store, tenant, userID, agentID string) (runID string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, tenant, "agentx", userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: agentID, UserID: userID, TenantID: tenant})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return run.ID
+}
+
+// The run-scoped interrupt listing exposes the run's pending questions; without
+// a tenant gate a token from another TENANT could read them by guessing the
+// run_id (run_ids are not secret). The accessor gates on the OWNING run's
+// tenant and folds a cross-tenant run into an opaque empty list — same as a
+// real run with zero interrupts (no existence oracle). Fails on the pre-gate
+// code where the handler queried the store directly.
+func TestHandleListRunInterrupts_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	ctx := context.Background()
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_intr")
+	id := store.MintInterruptID(time.Now())
+	if _, err := st.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: id, RunID: runID, UserID: "alice", Question: "secret?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+
+	listFor := func(tenant, subject string, scopes []string) int {
+		r := httptest.NewRequest(http.MethodGet, "/v1/runs/"+runID+"/interrupts", nil)
+		r.SetPathValue("run_id", runID)
+		r = r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: scopes,
+		}))
+		rr := httptest.NewRecorder()
+		s.handleListRunInterrupts(rr, r)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("status=%d, want 200", rr.Code)
+		}
+		var body struct {
+			Total int `json:"total"`
+		}
+		if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return body.Total
+	}
+
+	// Cross-TENANT → opaque empty (the leak we're closing).
+	if got := listFor("evil", "mallory", []string{auth.ScopeRunsRead}); got != 0 {
+		t.Errorf("cross-tenant run-interrupt list returned %d rows, want 0 (tenant gate not enforced)", got)
+	}
+	// The run's own tenant still sees its interrupt.
+	if got := listFor("acme", "alice", []string{auth.ScopeRunsRead}); got != 1 {
+		t.Errorf("own-tenant list returned %d rows, want 1 (gate rejected a legitimate caller)", got)
+	}
+	// A same-tenant DIFFERENT subject also sees it (whole-tenant collaboration).
+	if got := listFor("acme", "bob", []string{auth.ScopeRunsRead}); got != 1 {
+		t.Errorf("same-tenant different-subject list returned %d rows, want 1 (whole-tenant sharing)", got)
+	}
+	// Super-admin crosses tenants by design.
+	if got := listFor("x", "ops", []string{auth.ScopeAdmin}); got != 1 {
+		t.Errorf("admin list returned %d rows, want 1", got)
+	}
+}
+
+// TestTenantStore_GetRunOpaqueCrossTenant locks the accessor's core posture: a
+// cross-tenant run is indistinguishable from a missing one (both
+// *store.ErrNotFound), while the owning tenant + admin resolve it.
+func TestTenantStore_GetRunOpaqueCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_run")
+
+	mustNotFound := func(ctx context.Context, label string) {
+		if _, err := s.tenantStore(ctx).GetRun(ctx, runID); !isNotFound(err) {
+			t.Errorf("%s: GetRun err=%v, want *store.ErrNotFound", label, err)
+		}
+	}
+	mustResolve := func(ctx context.Context, label string) {
+		if _, err := s.tenantStore(ctx).GetRun(ctx, runID); err != nil {
+			t.Errorf("%s: GetRun err=%v, want nil", label, err)
+		}
+	}
+
+	mustNotFound(auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "evil", Subject: "m", Scopes: []string{auth.ScopeRunsRead}}), "cross-tenant")
+	mustResolve(auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}}), "own-tenant")
+	mustResolve(auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "bob", Scopes: []string{auth.ScopeRunsRead}}), "same-tenant-other-subject")
+	mustResolve(auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "x", Scopes: []string{auth.ScopeAdmin}}), "admin")
+	mustResolve(context.Background(), "open-mode")
+
+	// A genuinely-unknown run is the SAME error shape as cross-tenant (no oracle).
+	uctx := auth.WithPrincipal(context.Background(), auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsRead}})
+	if _, err := s.tenantStore(uctx).GetRun(uctx, "r_does_not_exist"); !isNotFound(err) {
+		t.Errorf("unknown run: GetRun err=%v, want *store.ErrNotFound", err)
+	}
+}

--- a/internal/api/http/tenant_store_test.go
+++ b/internal/api/http/tenant_store_test.go
@@ -85,6 +85,42 @@ func TestHandleListRunInterrupts_RejectsCrossTenant(t *testing.T) {
 	}
 }
 
+// The transcript endpoint exposes a session's full history; the migrated
+// handler gates it through the tenant-scoped accessor. A cross-TENANT caller
+// gets the same opaque 404 a missing session returns; the owning tenant + admin
+// resolve it. Locks the gate on handleTranscript after the accessor migration.
+func TestHandleTranscript_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	sess, err := st.CreateSession(context.Background(), "acme", "agentx", "alice")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	statusFor := func(tenant, subject string, scopes []string) int {
+		r := httptest.NewRequest(http.MethodGet, "/v1/sessions/"+sess.ID+"/transcript", nil)
+		r.SetPathValue("id", sess.ID)
+		r = r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+			TenantID: tenant, Subject: subject, Scopes: scopes,
+		}))
+		rr := httptest.NewRecorder()
+		s.handleTranscript(rr, r)
+		return rr.Code
+	}
+
+	if got := statusFor("evil", "mallory", []string{auth.ScopeRunsRead}); got != http.StatusNotFound {
+		t.Errorf("cross-tenant transcript status=%d, want 404 (tenant gate not enforced)", got)
+	}
+	if got := statusFor("acme", "alice", []string{auth.ScopeRunsRead}); got == http.StatusNotFound {
+		t.Errorf("own-tenant transcript got 404 — gate rejected a legitimate caller")
+	}
+	if got := statusFor("acme", "bob", []string{auth.ScopeRunsRead}); got == http.StatusNotFound {
+		t.Errorf("same-tenant different-subject transcript got 404 — whole-tenant sharing")
+	}
+	if got := statusFor("x", "ops", []string{auth.ScopeAdmin}); got == http.StatusNotFound {
+		t.Errorf("admin transcript got 404 — super-admin must cross tenants")
+	}
+}
+
 // TestTenantStore_GetRunOpaqueCrossTenant locks the accessor's core posture: a
 // cross-tenant run is indistinguishable from a missing one (both
 // *store.ErrNotFound), while the owning tenant + admin resolve it.

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -649,6 +649,16 @@ type StreamUserRunStatesRequest struct {
 	UserID   string   `json:"user_id"`
 	Statuses []string `json:"statuses,omitempty"`
 	Agent    string   `json:"agent,omitempty"`
+	// TenantID + TenantScoped enforce RFC L/N tenant isolation on the stream.
+	// When TenantScoped is true, only events whose run TenantID == TenantID are
+	// yielded (a tenant principal must not see another tenant's run
+	// transitions). Set by the HTTP handler from the request principal; left
+	// false by the gRPC/MCP adapters (they keep their own gating — tenant
+	// scoping those transports is a separate follow-up), so their behaviour is
+	// unchanged. An empty TenantID with TenantScoped=true matches only the
+	// shared/default ("") tenant — never "all".
+	TenantID     string `json:"-"`
+	TenantScoped bool   `json:"-"`
 }
 
 // RunStateEvent is the payload yielded by RunStateVisitor for each

--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -37,10 +37,17 @@ import (
 // RunStateEvent is the payload published on every run state transition.
 // Fields mirror the SSE frame the handler will emit.
 type RunStateEvent struct {
-	RunID         string    `json:"run_id"`
-	AgentID       string    `json:"agent_id"`
-	Agent         string    `json:"agent"`
-	UserID        string    `json:"user_id"`
+	RunID   string `json:"run_id"`
+	AgentID string `json:"agent_id"`
+	Agent   string `json:"agent"`
+	UserID  string `json:"user_id"`
+	// TenantID is the run's authoritative tenant (RFC L/N), carried so the
+	// HTTP user-agents stream can drop events outside a tenant principal's
+	// tenant (a tenant token must not see another tenant's run transitions —
+	// run_ids/user_ids aren't secret). Serialised so it survives the cluster
+	// backplane JSON round-trip (the filter runs after a remote replica
+	// re-publishes locally). "" = the shared/default tenant.
+	TenantID      string    `json:"tenant_id,omitempty"`
 	ParentAgentID string    `json:"parent_agent_id,omitempty"`
 	Status        string    `json:"status"`
 	StopReason    string    `json:"stop_reason,omitempty"`

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -2344,8 +2344,47 @@ func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter stri
 	return s.interruptList(ctx, "run_id", runID, statusFilter)
 }
 
-func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
-	return s.interruptList(ctx, "user_id", userID, statusFilter)
+func (s *Store) InterruptListByUser(ctx context.Context, userID, tenantID, statusFilter string) ([]store.InterruptRow, error) {
+	// Whole-tenant isolation (RFC L/N): when tenantID is set, JOIN runs and
+	// filter the OWNING run's tenant so a caller can't read another tenant's
+	// interrupts by guessing a user_id. "" = all tenants (super-admin / open).
+	q := `
+		SELECT i.interrupt_id, i.run_id, i.kind, i.status,
+		       i.question, i.options::text, i.context_data, i.priority,
+		       i.answer, i.answer_meta::text,
+		       i.created_at, i.expires_at, i.resolved_at, i.resolved_by,
+		       i.user_id, i.agent_id, i.agent_name
+		FROM interrupts i`
+	args := []any{userID}
+	if tenantID != "" {
+		q += ` JOIN runs r ON r.id = i.run_id`
+	}
+	q += ` WHERE i.user_id = $1`
+	if tenantID != "" {
+		args = append(args, tenantID)
+		q += fmt.Sprintf(` AND r.tenant_id = $%d`, len(args))
+	}
+	if statusFilter != "" {
+		args = append(args, statusFilter)
+		q += fmt.Sprintf(` AND i.status = $%d`, len(args))
+	}
+	q += ` ORDER BY i.created_at DESC LIMIT 200`
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list by user: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := s.scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list by user scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) interruptList(ctx context.Context, col, val, statusFilter string) ([]store.InterruptRow, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -6747,8 +6747,49 @@ func (s *Store) InterruptListByRun(ctx context.Context, runID, statusFilter stri
 	return s.interruptList(ctx, "run_id", runID, statusFilter)
 }
 
-func (s *Store) InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]store.InterruptRow, error) {
-	return s.interruptList(ctx, "user_id", userID, statusFilter)
+func (s *Store) InterruptListByUser(ctx context.Context, userID, tenantID, statusFilter string) ([]store.InterruptRow, error) {
+	// Whole-tenant isolation (RFC L/N): when tenantID is set, JOIN runs and
+	// filter the OWNING run's tenant so a caller can't read another tenant's
+	// interrupts by guessing a user_id. "" = all tenants (super-admin / open).
+	// Columns are aliased with i. for the JOIN; scanInterruptRow reads by
+	// position so the SELECT list order is unchanged.
+	q := `
+		SELECT i.interrupt_id, i.run_id, i.kind, i.status,
+		       i.question, i.options, i.context_data, i.priority,
+		       i.answer, i.answer_meta,
+		       i.created_at, i.expires_at, i.resolved_at, i.resolved_by,
+		       i.user_id, i.agent_id, i.agent_name
+		FROM interrupts i`
+	args := []any{userID}
+	if tenantID != "" {
+		q += ` JOIN runs r ON r.id = i.run_id`
+	}
+	q += ` WHERE i.user_id = ?`
+	if tenantID != "" {
+		q += ` AND r.tenant_id = ?`
+		args = append(args, tenantID)
+	}
+	if statusFilter != "" {
+		q += ` AND i.status = ?`
+		args = append(args, statusFilter)
+	}
+	q += ` ORDER BY i.created_at DESC LIMIT 200`
+
+	rows, err := s.db.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("interrupts: list by user: %w", err)
+	}
+	defer rows.Close()
+
+	out := []store.InterruptRow{}
+	for rows.Next() {
+		r, err := scanInterruptRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("interrupts: list by user scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // interruptList is the shared SELECT body for ListByRun / ListByUser.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1525,11 +1525,15 @@ type Store interface {
 	// Capped at 200 rows.
 	InterruptListByRun(ctx context.Context, runID, statusFilter string) ([]InterruptRow, error)
 
-	// InterruptListByUser returns interrupts owned by user_id,
-	// newest first. statusFilter same shape as ListByRun. The
-	// denormalised user_id column drives this query without a JOIN
-	// against runs. Capped at 200 rows.
-	InterruptListByUser(ctx context.Context, userID, statusFilter string) ([]InterruptRow, error)
+	// InterruptListByUser returns interrupts owned by user_id, newest
+	// first. statusFilter same shape as ListByRun. tenantID scopes the
+	// result to the OWNING run's tenant (RFC L/N whole-tenant isolation):
+	// when non-empty the query JOINs runs and filters runs.tenant_id, so a
+	// caller can't read another tenant's interrupts by guessing a user_id;
+	// "" = all tenants (super-admin / open mode — mirrors ListUsers). The
+	// user_id column is indexed; the tenant JOIN is only added when scoped.
+	// Capped at 200 rows.
+	InterruptListByUser(ctx context.Context, userID, tenantID, statusFilter string) ([]InterruptRow, error)
 
 	// InterruptCountPendingByRun returns the count of status=pending
 	// interrupts for the given run_id. Drives max_pending enforcement

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -299,6 +299,7 @@ func Run(t *testing.T, factory Factory) {
 		{"InterruptFinishRejectsAlreadyTerminal", testInterruptFinishRejectsAlreadyTerminal},
 		{"InterruptListByRunFiltersByStatus", testInterruptListByRunFiltersByStatus},
 		{"InterruptListByUserFiltersByStatus", testInterruptListByUserFiltersByStatus},
+		{"InterruptListByUserFiltersByTenant", testInterruptListByUserFiltersByTenant},
 		{"InterruptCountPendingByRunIsAccurateUnderConcurrency", testInterruptCountPendingByRunIsAccurateUnderConcurrency},
 		{"InterruptSweepExpiredMarksOnlyExpiredPending", testInterruptSweepExpiredMarksOnlyExpiredPending},
 		{"InterruptIDIsMonotonicByTime", testInterruptIDIsMonotonicByTime},
@@ -6199,6 +6200,27 @@ func makeRunForInterrupt(t *testing.T, s store.Store, userID, agentID, agentName
 	return sess.ID, run.ID
 }
 
+// makeRunForInterruptTenant is makeRunForInterrupt with an explicit tenant
+// stamped onto the run row (CreateRun denormalises identity.TenantID — the
+// column InterruptListByUser's tenant filter reads). Returns the run id.
+func makeRunForInterruptTenant(t *testing.T, s store.Store, tenant, userID, agentID, agentName string) (runID string) {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := s.CreateSession(ctx, tenant, agentName, userID)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	run, err := s.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID:  agentID,
+		UserID:   userID,
+		TenantID: tenant,
+	})
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	return run.ID
+}
+
 func testInterruptCreateAndGet(t *testing.T, s store.Store) {
 	ctx := context.Background()
 	_, runID := makeRunForInterrupt(t, s, "u_alice", "a_intr_1", "batch-processor")
@@ -6413,7 +6435,9 @@ func testInterruptListByUserFiltersByStatus(t *testing.T, s store.Store) {
 	id3 := store.MintInterruptID(time.Now().Add(2 * time.Millisecond))
 	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: id3, RunID: runC, UserID: "u_other", Question: "Q from C", CreatedAt: time.Now().Add(2 * time.Millisecond)})
 
-	rows, err := s.InterruptListByUser(ctx, "u_bob", store.InterruptStatusPending)
+	// tenantID "" = all tenants (this test exercises the user filter, not the
+	// tenant filter — see testInterruptListByUserFiltersByTenant for that).
+	rows, err := s.InterruptListByUser(ctx, "u_bob", "", store.InterruptStatusPending)
 	if err != nil {
 		t.Fatalf("ListByUser: %v", err)
 	}
@@ -6424,6 +6448,50 @@ func testInterruptListByUserFiltersByStatus(t *testing.T, s store.Store) {
 		if r.UserID != "u_bob" {
 			t.Errorf("listing leaked row from %q", r.UserID)
 		}
+	}
+}
+
+// testInterruptListByUserFiltersByTenant locks RFC L/N whole-tenant isolation
+// on the user-scoped interrupt inbox: when a tenant is passed, interrupts on
+// another tenant's runs are excluded even for the SAME user_id (user_ids are
+// not secret). "" = all tenants. Fails on the pre-tenant signature where the
+// listing keyed on user_id alone and leaked across tenants.
+func testInterruptListByUserFiltersByTenant(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// Same user_id "u_shared" in two tenants — the cross-tenant leak surface.
+	runAcme := makeRunForInterruptTenant(t, s, "acme", "u_shared", "a_acme_intr", "agent-acme")
+	runEvil := makeRunForInterruptTenant(t, s, "evil", "u_shared", "a_evil_intr", "agent-evil")
+
+	idA := store.MintInterruptID(time.Now())
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: idA, RunID: runAcme, UserID: "u_shared", Question: "acme Q", CreatedAt: time.Now()})
+	idE := store.MintInterruptID(time.Now().Add(time.Millisecond))
+	_, _ = s.InterruptCreate(ctx, store.InterruptRow{InterruptID: idE, RunID: runEvil, UserID: "u_shared", Question: "evil Q", CreatedAt: time.Now().Add(time.Millisecond)})
+
+	// Scoped to acme: only the acme interrupt, never evil's.
+	acme, err := s.InterruptListByUser(ctx, "u_shared", "acme", "")
+	if err != nil {
+		t.Fatalf("ListByUser(acme): %v", err)
+	}
+	if len(acme) != 1 || acme[0].InterruptID != idA {
+		t.Fatalf("acme-scoped listing = %d rows (want 1, id=%s) — tenant filter leaked", len(acme), idA)
+	}
+
+	// Scoped to evil: only evil's.
+	evil, err := s.InterruptListByUser(ctx, "u_shared", "evil", "")
+	if err != nil {
+		t.Fatalf("ListByUser(evil): %v", err)
+	}
+	if len(evil) != 1 || evil[0].InterruptID != idE {
+		t.Fatalf("evil-scoped listing = %d rows (want 1, id=%s)", len(evil), idE)
+	}
+
+	// "" = all tenants (super-admin) → both.
+	all, err := s.InterruptListByUser(ctx, "u_shared", "", "")
+	if err != nil {
+		t.Fatalf("ListByUser(all): %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("all-tenants listing = %d rows, want 2", len(all))
 	}
 }
 


### PR DESCRIPTION
## Why

The v0.34.0 security review's **S2** noted tenant isolation was enforced **per-handler** — each read remembering to call `tenantVisible` / `sessionOwnershipOK` — rather than at a choke-point, a latent fragility. Research found it wasn't purely latent: **three tenant-token-reachable (`runs:read`) reads had no tenant gate at all**, a live (low-severity) cross-tenant read since `run_id`s / `user_id`s aren't secret:

- `GET /v1/runs/{run_id}/interrupts` — any run's pending interrupt questions.
- `GET /v1/users/{user_id}/interrupts` — any user's interrupt inbox.
- `GET /v1/users/{user_id}/agents/stream` — any user's run-state transitions.

Plus the per-user channel routes (`/v1/users/{user_id}/channels/*`) took the path `user_id` as the channel scope with no ownership check.

This was the deferred larger item from the S1/S2 resolution (PRs #476/#477/#478).

## What

A per-request **`tenantScopedStore`** accessor (`internal/api/http/tenant_store.go`) that turns the convention into a single choke-point: it captures the caller's tenant scope from the ctx principal (admin / legacy / open mode → all tenants — the same exemption set as `tenantVisible` / `sessionOwnershipOK`) and folds a cross-tenant row into an opaque `*store.ErrNotFound`, so a cross-tenant probe is indistinguishable from a miss (no existence oracle). `tenantVisible` now delegates to the same `tenantScopeFromCtx` (one source of truth).

Closing the gaps, scoped to the tenant-token-reachable read surface:

1. **Accessor + run-keyed reads** — `handleGetAgent`, `handleRunStream`, `compactRunWithSource` migrated onto it (the latter two drop their now-redundant `GetSession` ownership block, gating on `run.TenantID` directly); **`handleListRunInterrupts`** gated via `tenantStore.InterruptListByRun` (gates on the owning run's tenant — interrupts inherit it — and maps the opaque not-found to an empty list, identical to a real run with zero interrupts).
2. **Session reads** — `handleMessages` + `handleTranscript` migrated onto `tenantStore.GetSession` (behaviour-preserving: both already gated with an identical opaque 404).
3. **`InterruptListByUser` tenant axis** — added a `tenantID` arg to the store method (JOINs `runs`, filters `runs.tenant_id` when non-empty; `""` = all tenants, mirrors `ListUsers`). sqlite + postgres + the store contract. `handleListUserInterrupts` passes the principal's tenant down.
4. **Run-state stream** — carry the run's `TenantID` on `runstate.RunStateEvent` (set at all six `runStateMeta` assembly sites; serialised so it survives the cluster-backplane round-trip), and filter in `StreamUserRunStates` via new `TenantID`/`TenantScoped` request fields set by the HTTP handler from `principalTenantScope`.
5. **Per-user channels** — `requirePrincipalOwnsPathUser` gates the four wrappers to the principal's own subject (channel_messages have no tenant column, so whole-tenant sharing needs the deferred `tenant_id` denormalisation; this is the safe no-schema mitigation). Opaque 404 on mismatch.
6. **Coverage** — `TestTenantReachableReads_AreOpaqueCrossTenant`: the hand-maintained inventory of the tenant-reachable read surface, each re-verified opaque in one place (ServeMux exposes no patterns to introspect).

Whole-tenant model preserved throughout: a same-tenant different subject + super-admin still resolve; the cross-**tenant** boundary stays hard.

### Notes for the reviewer
- **`handleRunInput` + `openOrCreateSessionAndRun` deliberately keep their inline `sessionOwnershipOK`**: the former fails *open* on a `GetSession` store error by design (the run is already proven live via the steer registry), and the latter is on the run-creation hot path. Both are already correctly gated, so migrating them would trade a behaviour change for no security gain.
- **`tenantVisible` is retained** (now a thin wrapper over `tenantScopeFromCtx`) as the row-level predicate + its existing matrix test; the accessor subsumes its last production caller. Happy to delete it + the test if you'd prefer.
- **Additive wire change**: the SSE `run_state` frame now carries an optional `tenant_id` (a tenant principal only ever receives its own tenant's events; admin sees all). Purely additive — no consumer break, no lockstep needed.
- **Out of scope (documented in the plan)**: the `/v1/_*` admin reads (`substrate:admin`-gated, super-admin-sees-all by design); full whole-tenant isolation of per-user **channels** (needs a `tenant_id` column on `channel_messages` — the declined schema-denormalisation option); tenant-scoping the **gRPC/MCP** run-state stream (`TenantScoped` left false there — those transports keep their own gating).

## Tested

Each gap closure has a fail-before test (verified failing on the un-gated code by temporarily reverting the gate, never via `git checkout`):
- `TestHandleListRunInterrupts_RejectsCrossTenant` — cross-tenant returned 1 row, want 0.
- `TestHandleListUserInterrupts_RejectsCrossTenant` — acme + evil each saw both rows un-scoped.
- `TestConnector_StreamUserRunStates_TenantScopedDropsCrossTenant` — `r_evil` leaked first without the filter (passes under `-race`).
- `TestHandleUserChannelPeek_RejectsCrossSubject` — cross-subject peek leaked 200.
- store-contract `InterruptListByUserFiltersByTenant` (sqlite + the `go-postgres` CI job).
- Plus `TestTenantStore_GetRunOpaqueCrossTenant`, `TestHandleTranscript_RejectsCrossTenant`, `TestRequirePrincipalOwnsPathUser_Matrix`, and the consolidated inventory.

`go build ./...`, `go vet ./...`, `gofmt` clean. Full `go test ./...` green; `internal/api/http` + `internal/runstate` green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)