### PR TITLE
fix(loop): interactive runs are unbounded by default (don't cap at 16)

### DIFF
--- a/internal/loop/interactive_unbounded_test.go
+++ b/internal/loop/interactive_unbounded_test.go
@@ -1,0 +1,85 @@
+package loop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/steer"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// An interactive run with the DEFAULT (unset) MaxIterations must not stop at the
+// 16-turn soft cap. It's operator-driven and Cancel-bounded, and each end_turn
+// park + operator turn consumes a loop iteration — so capping at 16 silently
+// ends a live terminal session after 16 turns (the reported bug). This drives
+// more than 16 operator turns and asserts the run is still parked (not
+// terminated). Fails on the pre-fix loop, where iterCap defaulted to 16 for
+// interactive runs too and the run terminated around turn 16.
+func TestRun_Interactive_DefaultIterationsAreUnbounded(t *testing.T) {
+	const turns = 20 // > the 16 default soft cap
+
+	q := make(chan steer.Message, turns+2)
+	parked := make(chan struct{}, turns+4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prov := &endTurnProvider{}
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			// MaxIterations unset (0): a non-interactive run would default to 16;
+			// an interactive run must instead be unbounded.
+			OnEvent: func(ev providers.Event) {
+				if ev.Type == providers.EventAwaitingInput {
+					parked <- struct{}{}
+				}
+			},
+		})
+		close(done)
+	}()
+
+	waitPark := func() {
+		t.Helper()
+		select {
+		case <-parked:
+		case <-done:
+			t.Fatal("interactive run terminated instead of parking — default iterations still capped at 16?")
+		case <-time.After(3 * time.Second):
+			t.Fatal("interactive run did not park within 3s")
+		}
+	}
+
+	waitPark() // initial end_turn → park
+	for i := 0; i < turns; i++ {
+		q <- steer.Message{Text: "keep going"}
+		waitPark()
+	}
+
+	// Past 16 turns and still parked → the soft cap was lifted for the
+	// interactive run.
+	select {
+	case <-done:
+		t.Fatal("interactive run terminated before Cancel — default iterations capped at 16")
+	default:
+	}
+	if got := prov.calls(); got != turns+1 {
+		t.Errorf("provider calls = %d, want %d (1 initial + %d operator turns)", got, turns+1, turns)
+	}
+
+	// Cancel still ends the persistent run cleanly (the hard ceiling never bites
+	// at this scale; Cancel is the real terminator).
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("interactive run did not terminate after Cancel")
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -83,8 +83,11 @@ type RunOptions struct {
 	// Interactive makes this a PERSISTENT run: instead of terminating when the
 	// model ends its turn, the loop parks on SteerQueue waiting for the
 	// operator's next instruction (resuming on it, ending only on Cancel).
-	// Requires SteerQueue; pairs with UnboundedIterations for a true
-	// always-on terminal agent (else parks count toward MaxIterations).
+	// Requires SteerQueue. An interactive run with no explicit MaxIterations is
+	// automatically unbounded (Run lifts the 16-turn soft cap — see the
+	// interactiveUnbounded note in Run), so an always-on terminal works without
+	// also setting UnboundedIterations; the 1<<20 hard ceiling + Cancel still
+	// bound it. Set an explicit MaxIterations to cap an interactive session.
 	Interactive bool
 
 	// PauseGate, when non-nil, cooperatively quiesces this run for the
@@ -981,6 +984,18 @@ func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers
 }
 
 func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
+	// An interactive run is operator-driven and Cancel-bounded: each operator
+	// turn (and each end_turn park awaiting input) consumes a loop iteration,
+	// so the default 16-iteration runaway guard silently ends a live terminal
+	// session after 16 turns (reported as "max_iterations"). That guard exists
+	// to stop a RUNAWAY AUTONOMOUS agent — it has no purpose for a human-driven
+	// terminal the operator can Cancel. So when no explicit cap is set, an
+	// interactive run is unbounded (the 1<<20 hard ceiling + run cancellation
+	// still bound it), and the operator no longer has to ALSO set
+	// unbounded_iterations to get an always-on terminal. An EXPLICIT
+	// max_iterations is still honored; an autonomous run keeps the 16 default.
+	interactiveUnbounded := opts.Interactive && opts.SteerQueue != nil && opts.MaxIterations == 0
+
 	if opts.MaxIterations == 0 {
 		opts.MaxIterations = 16
 	}
@@ -1001,7 +1016,7 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// code-js providers are unbounded by capability; an LLM agent opts in
 	// per-def via UnboundedIterations (interactive/terminal runs). Either way
 	// the 1<<20 hard ceiling stays as a pure runaway backstop.
-	unboundedIters := opts.Provider.Capabilities().UnboundedIterations || opts.UnboundedIterations
+	unboundedIters := opts.Provider.Capabilities().UnboundedIterations || opts.UnboundedIterations || interactiveUnbounded
 	iterCap := opts.MaxIterations
 	if unboundedIters {
 		iterCap = maxIterationsHardCeiling


### PR DESCRIPTION
## The bug (verified)

Reported: interactive agents in the Web UI with `iterations` = 0 (default) stop after 16 turns with "max_iterations exceeded."

Confirmed in the loop. An interactive (persistent terminal) run parks at `end_turn` and resumes on each operator turn — and the loop's `for iter := 0; iter < iterCap` counts **every** model call, including each post-park operator turn (`loop.go`). With no explicit `max_iterations`, `iterCap` defaults to **16** (`loop.go:984`), and the cap is lifted only for code-js or an agent that sets `unbounded_iterations` (`loop.go:1004`). So a default interactive agent silently ends after ~16 turns:
- if it was mid-tool-use on the 16th turn → `stop_reason="max_iterations"` (the message the user saw);
- otherwise it just stops, dropping the operator's last input.

The 16 default is a **runaway-autonomous-agent guard** — it has no purpose for a human-driven terminal the operator can Cancel. The documented workaround ("pair interactive with `unbounded_iterations`") isn't discoverable: the Web UI's interactive toggle doesn't set that agent flag, and `iterations=0` reads as "unlimited" (the convention used elsewhere, e.g. `max_fires`).

## Fix

In `loop.Run`, an interactive run **with no explicit `MaxIterations`** is unbounded — `iterCap` becomes the existing `1<<20` hard ceiling. Run cancellation, the per-user/global run caps, and provider/run timeouts still bound it.

```go
interactiveUnbounded := opts.Interactive && opts.SteerQueue != nil && opts.MaxIterations == 0
...
unboundedIters := provider.Capabilities().UnboundedIterations || opts.UnboundedIterations || interactiveUnbounded
```

- An **explicit** `max_iterations` is still honored (caps an interactive session deliberately).
- **Autonomous** runs keep the 16 default (the runaway guard is unchanged).
- `unbounded_iterations` and the code-js capability are unchanged — interactive just no longer *requires* the flag.

Runtime-only at the loop layer → covers HTTP / gRPC / MCP with no wire, adapter, or Web UI change.

## Tested

- `TestRun_Interactive_DefaultIterationsAreUnbounded` — drives 20 operator turns (> 16), asserts the run stays parked, then Cancel ends it. **Fails on the pre-fix loop** (terminates at the 16 cap — verified by reverting the lift).
- Full `internal/loop` package green; `internal/api/http` interactive/steer/run tests green; `go build ./...`, `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)