### PR TITLE
style(ui): homogeneous dark-theme form fields across all editors

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -58,6 +58,46 @@ pre {
   word-break: break-word;
 }
 
+/* Homogeneous dark-theme form controls.
+ *
+ * loomcycle is a dark-first console, but <input>/<textarea>/<select> do NOT
+ * inherit font or colors from <body>, so a field that isn't wrapped in a styled
+ * container falls back to the white-on-black UA default (thin font, square
+ * corners) — and even the styled editor rules set colors but no font-family, so
+ * their text stayed in the thin UA font. This base gives every text-like
+ * control the same dark look the topbar fields have (dark bg, light text, mono
+ * font, rounded corners, accent focus).
+ *
+ * `:where()` keeps the selector at element-level specificity (0,0,1) so any
+ * existing component rule still wins where it sets a property — this only fills
+ * the gaps. Checkboxes / radios / file / range / color keep native rendering.
+ */
+input,
+textarea,
+select {
+  font-family: var(--mono);
+}
+input:where(:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"])),
+textarea,
+select {
+  background: var(--bg-input);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 13px;
+}
+input:where(:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"])):focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+input::placeholder,
+textarea::placeholder {
+  color: var(--fg-muted);
+}
+
 .layout {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Why

The topbar fields (tenant switcher, user picker) are styled dark / rounded / mono, but the primitive editors' fields looked out of place — black-on-white, thin font, square corners. Root cause: `<input>` / `<textarea>` / `<select>` don't inherit font or colors from `<body>`, so a field that isn't wrapped in a styled container falls back to the white-on-black UA default; and even the *styled* editor rules (`.library-modal-field input`, …) set colors but **no `font-family`**, so their text stayed in the thin UA font.

## What

One low-specificity base rule (right after the element base styles in `web/src/styles.css`) gives every text-like control the topbar look:

- `--bg-input` background, `--fg` text, `1px solid --border`, `4px` radius, `--mono` font, `13px`
- `--accent` border on `:focus`, `--fg-muted` placeholder

`:where()` keeps the selector at element-level specificity (`0,0,1`), so **every existing component rule still wins** where it sets a property — this only fills the gaps (most importantly the missing `font-family`) and styles otherwise-unstyled fields. Checkboxes / radios / file / range / color are excluded via `:where(:not([type=…]))`, so they keep native rendering.

No markup changes — purely the stylesheet, so it covers every current and future editor field at once.

## Tested

Rendered the **built CSS** against the real editor classes (`library-form-row`, `library-modal-field`, `library-prompt-textarea`, `library-json-textarea`) alongside a plain unstyled `<input>`, a native checkbox, and a file input:

- Editor fields now match the topbar (dark, rounded, mono, accent focus).
- The previously-ugly plain input is fixed.
- The native checkbox and file input stay native (the `:where(:not(...))` exclusions held).

`make build-all` clean. CSS-only — `internal/webui/dist/*` is gitignored and rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)