### PR TITLE
feat(ui): tokenized design system — light/dark themes, brand fonts, loom-wood accent

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,27 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>loomcycle</title>
+    <!-- Resolve the theme before first paint (override ?? OS) so there's no
+         flash-of-wrong-theme. useTheme.ts mirrors + maintains this at runtime. -->
+    <script>
+      (function () {
+        try {
+          var v = localStorage.getItem("loomcycle.theme");
+          var t =
+            v === "light" || v === "dark"
+              ? v
+              : window.matchMedia &&
+                window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+          document.documentElement.setAttribute("data-theme", t);
+          var m = document.querySelector('meta[name="color-scheme"]');
+          if (m) m.setAttribute("content", t);
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,9 @@
       "name": "loomcycle-ui",
       "version": "0.9.0",
       "dependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
+        "@fontsource-variable/jetbrains-mono": "^5.2.8",
+        "@fontsource-variable/outfit": "^5.2.8",
         "js-yaml": "^4.2.0",
         "lucide-react": "^0.460.0",
         "react": "^19.0.0",
@@ -745,6 +748,33 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-WBA9elru6Jdp5df2mES55wuOO0WIrn3kpXnI4+W2ek5u3ZgLS9XS4gmIlcQhiZOWEKl95meYdvK7xI+ETLCq/Q==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/outfit": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/outfit/-/outfit-5.2.8.tgz",
+      "integrity": "sha512-4oUDCZx/Tcz6HZP423w/niqEH31Gks5IsqHV2ZZz1qKHaVIZdj2f0/S1IK2n8jl6Xo0o3N+3RjNHlV9R73ozQA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
+    "@fontsource-variable/jetbrains-mono": "^5.2.8",
+    "@fontsource-variable/outfit": "^5.2.8",
     "js-yaml": "^4.2.0",
     "lucide-react": "^0.460.0",
     "react": "^19.0.0",

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -9,14 +9,17 @@ import {
   Library,
   ListTree,
   type LucideIcon,
+  Moon,
   PanelLeftClose,
   PanelLeftOpen,
   Play,
   Plug,
   Radio,
   ScrollText,
+  Sun,
 } from "lucide-react";
 import { Principal, UserSummary, getHealth, getWhoami, listUsers } from "../api";
+import { useTheme } from "../hooks/useTheme";
 import PauseControls from "./PauseControls";
 
 const USER_ID_KEY = "loomcycle.userId";
@@ -60,6 +63,7 @@ export default function Layout() {
   const [showManual, setShowManual] = useState(false);
   const [draft, setDraft] = useState(userId);
   const [version, setVersion] = useState<string | null>(null);
+  const { theme, toggle: toggleTheme } = useTheme();
 
   // The authenticated principal (RFC L / multi-tenant UI authz), resolved
   // from GET /v1/_me on boot. Drives the role: super-admin (is_admin) sees
@@ -214,6 +218,15 @@ export default function Layout() {
             </Link>
             <span className="version">{version === null ? "…" : version}</span>
           </div>
+          <button
+            type="button"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            title={theme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+            aria-label="Toggle color theme"
+          >
+            {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+          </button>
           {isAdmin && <PauseControls />}
           {/* Role/tenant badge — super-admin sees all tenants; a tenant is
               scoped to its own. */}

--- a/web/src/components/activity/LineChart.tsx
+++ b/web/src/components/activity/LineChart.tsx
@@ -163,26 +163,26 @@ export default function LineChart({
             x2={PAD_LEFT + plotW}
             y1={yScaleLeft(t)}
             y2={yScaleLeft(t)}
-            stroke="#2a2e3a"
+            stroke="var(--lc-chart-grid)"
             strokeOpacity={0.5}
           />
         ))}
 
         {/* axis lines */}
-        <line x1={PAD_LEFT} x2={PAD_LEFT} y1={PAD_TOP} y2={PAD_TOP + plotH} stroke="#2a2e3a" />
+        <line x1={PAD_LEFT} x2={PAD_LEFT} y1={PAD_TOP} y2={PAD_TOP + plotH} stroke="var(--lc-chart-grid)" />
         <line
           x1={PAD_LEFT + plotW}
           x2={PAD_LEFT + plotW}
           y1={PAD_TOP}
           y2={PAD_TOP + plotH}
-          stroke="#2a2e3a"
+          stroke="var(--lc-chart-grid)"
         />
         <line
           x1={PAD_LEFT}
           x2={PAD_LEFT + plotW}
           y1={PAD_TOP + plotH}
           y2={PAD_TOP + plotH}
-          stroke="#2a2e3a"
+          stroke="var(--lc-chart-grid)"
         />
 
         {/* axis tick labels */}
@@ -193,7 +193,7 @@ export default function LineChart({
             y={yScaleLeft(t) + 3}
             textAnchor="end"
             fontSize="10"
-            fill="#9aa0ad"
+            fill="var(--lc-chart-axis)"
             fontFamily="ui-monospace, monospace"
           >
             {yLeftFormat(t)}
@@ -207,7 +207,7 @@ export default function LineChart({
               y={yScaleRight(t) + 3}
               textAnchor="start"
               fontSize="10"
-              fill="#9aa0ad"
+              fill="var(--lc-chart-axis)"
               fontFamily="ui-monospace, monospace"
             >
               {yRightFormat(t)}
@@ -220,7 +220,7 @@ export default function LineChart({
             y={PAD_TOP + plotH + 14}
             textAnchor="middle"
             fontSize="10"
-            fill="#9aa0ad"
+            fill="var(--lc-chart-axis)"
             fontFamily="ui-monospace, monospace"
           >
             {xFormat(t)}
@@ -265,7 +265,7 @@ export default function LineChart({
             x2={hover.x}
             y1={PAD_TOP}
             y2={PAD_TOP + plotH}
-            stroke="#9aa0ad"
+            stroke="var(--lc-chart-axis)"
             strokeOpacity={0.4}
             strokeDasharray="3 3"
           />

--- a/web/src/hooks/useTheme.ts
+++ b/web/src/hooks/useTheme.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Theme resolution (design-system light/dark).
+//
+//   effective theme = localStorage override ?? OS prefers-color-scheme
+//
+// The initial value is applied BEFORE React mounts by the inline script in
+// index.html (no flash-of-wrong-theme); this hook mirrors that state, keeps it
+// in sync with live OS changes (only while there's no explicit override), and
+// exposes a toggle that persists the override.
+
+export type Theme = "light" | "dark";
+
+const STORAGE_KEY = "loomcycle.theme";
+
+function osTheme(): Theme {
+  return typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "light"
+    : "dark";
+}
+
+function storedOverride(): Theme | null {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    return v === "light" || v === "dark" ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveTheme(): Theme {
+  return storedOverride() ?? osTheme();
+}
+
+function applyTheme(t: Theme): void {
+  document.documentElement.setAttribute("data-theme", t);
+  const meta = document.querySelector('meta[name="color-scheme"]');
+  if (meta) meta.setAttribute("content", t);
+}
+
+export function useTheme(): {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggle: () => void;
+} {
+  const [theme, setThemeState] = useState<Theme>(() => resolveTheme());
+
+  // Live-follow the OS setting, but only while the user hasn't pinned a choice.
+  useEffect(() => {
+    if (!window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-color-scheme: light)");
+    const onChange = () => {
+      if (storedOverride()) return; // an explicit override wins over the OS
+      const t = osTheme();
+      applyTheme(t);
+      setThemeState(t);
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  const setTheme = useCallback((t: Theme) => {
+    try {
+      localStorage.setItem(STORAGE_KEY, t);
+    } catch {
+      /* private mode / disabled storage — fall back to in-memory only */
+    }
+    applyTheme(t);
+    setThemeState(t);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  }, [theme, setTheme]);
+
+  return { theme, setTheme, toggle };
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+// Self-hosted brand fonts (bundled into dist by Vite — no CDN, works offline).
+import "@fontsource-variable/outfit";
+import "@fontsource-variable/inter";
+import "@fontsource-variable/jetbrains-mono";
+// Design tokens MUST load before styles.css so the legacy --bg/--fg/--accent
+// aliases resolve to the themed --lc-* tokens.
+import "./tokens.css";
 import "./styles.css";
 import AgentsView from "./pages/AgentsView";
 import RunView from "./pages/RunView";

--- a/web/src/pages/ActivityMonitor.tsx
+++ b/web/src/pages/ActivityMonitor.tsx
@@ -39,14 +39,17 @@ const LS_SHOW_ADVANCED = "loomcycle.activity.showAdvanced";
 // Series colors — pulled from the existing palette + the v0.8.21
 // awaited-state chip palette to stay consistent with the rest of
 // the UI.
-const C_MEMORY = "#5b9dff";     // --accent
+// Accent / running / muted are theme-aware via the design tokens (inline SVG
+// reads ancestor CSS vars); the rest are a fixed multi-series palette that
+// reads on both themes.
+const C_MEMORY = "var(--lc-accent)";
 const C_AGENTS = "#ffb766";     // await-channel orange
-const C_QUEUED = "#5b9dff";     // accent (top of stack)
-const C_ACTIVE = "#f0a040";     // --running (bottom of stack)
-const C_CPU_PROCESS = "#5b9dff";
-const C_CPU_SYSTEM = "#9aa0ad"; // --fg-soft, dashed via opacity
+const C_QUEUED = "var(--lc-accent)"; // accent (top of stack)
+const C_ACTIVE = "var(--lc-running)"; // running (bottom of stack)
+const C_CPU_PROCESS = "var(--lc-accent)";
+const C_CPU_SYSTEM = "var(--lc-chart-axis)"; // muted, dashed via opacity
 const C_GOROUTINES = "#6ee7a3";   // await-running green
-const C_HEAP_ALLOC = "#5b9dff";   // accent
+const C_HEAP_ALLOC = "var(--lc-accent)";
 const C_HEAP_INUSE = "#c9a8ff";   // await-interrupted violet
 const C_SYSMEM_USED = "#ffb766";  // await-channel orange
 const C_SYSMEM_AVAIL = "#6ee7a3"; // await-running green

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,33 +1,8 @@
-/* Loomcycle UI — minimal, dark-first dashboard styling.
-   No CSS framework; vanilla CSS for the v0.7.3 footprint. */
-
-:root {
-  --bg: #0f1115;
-  --bg-soft: #161922;
-  --bg-soft-2: #1d2230;
-  --fg: #e6e6e6;
-  --fg-soft: #9aa0ad;
-  --accent: #5b9dff;
-  --running: #f0a040;
-  --completed: #4ec9b0;
-  --failed: #ff5d68;
-  --cancelled: #b08bd0;
-  --border: #2a2e3a;
-  --mono: ui-monospace, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-  /* v0.11.6 — promoted from inline fallback values (--bg-muted, #181818)
-   * + (--danger, #c33) used in .library-headers-grid + the new
-   * .library-models-* classes. Codifying them here so theming stays
-   * coherent if a future change overrides them. */
-  --bg-muted: #181818;
-  --danger: #c33;
-  /* v0.11.7 — same treatment for --fg-muted and --bg-input. Both have
-   * ~16 call sites across the library/memory/channel form clusters,
-   * always via inline fallback only. A future theme override would
-   * silently fail on those sites; declaring them here makes overrides
-   * authoritative. Values match the predominant inline fallback. */
-  --fg-muted: #888;
-  --bg-input: #1a1a1a;
-}
+/* Loomcycle UI — dashboard styling. Themeable (light/dark) via the design
+   tokens in tokens.css (imported first in main.tsx): the --bg / --fg / --accent
+   / --border / … names used throughout this file are aliases of the themed
+   --lc-* tokens, so this file follows the active theme for free. New rules
+   should prefer the --lc-* tokens directly. */
 
 * {
   box-sizing: border-box;
@@ -37,12 +12,19 @@ html, body, #root {
   padding: 0;
   background: var(--bg);
   color: var(--fg);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: var(--lc-font-body);
   font-size: 14px;
   height: 100%;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+/* Display font for headings (design-system: Outfit). Sizes are left to the
+   existing per-component rules — the dense console keeps its scale. */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--lc-font-display);
 }
 a {
-  color: var(--accent);
+  color: var(--lc-link);
   text-decoration: none;
 }
 a:hover {
@@ -56,6 +38,57 @@ pre {
   margin: 4px 0 0;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+/* Homogeneous form controls (themed).
+ * <input>/<textarea>/<select> don't inherit font or colors from <body>, so an
+ * unstyled field falls back to the UA default. This base gives every text-like
+ * control the same look as the topbar fields, themed via the design tokens.
+ * :where() keeps the selector at element specificity (0,0,1) so any component
+ * rule still wins; checkboxes / radios / file / range / color stay native. */
+input,
+textarea,
+select {
+  font-family: var(--lc-font-mono);
+}
+input:where(:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"])),
+textarea,
+select {
+  background: var(--lc-input-bg);
+  color: var(--lc-text);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: 6px 8px;
+  font-size: var(--lc-text-sm);
+}
+input:where(:not([type="checkbox"]):not([type="radio"]):not([type="file"]):not([type="range"]):not([type="color"])):focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: var(--lc-accent);
+}
+input::placeholder,
+textarea::placeholder {
+  color: var(--lc-text-faint);
+}
+
+/* Topbar theme toggle (sun/moon). Quiet icon button matching the topbar. */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 28px;
+  background: transparent;
+  color: var(--lc-text-muted);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  cursor: pointer;
+  padding: 0;
+}
+.theme-toggle:hover {
+  color: var(--lc-text);
+  border-color: var(--lc-accent);
 }
 
 .layout {
@@ -4228,7 +4261,7 @@ button.primary:disabled {
   cursor: pointer;
 }
 .live-run-compact:not(:disabled):hover {
-  border-color: var(--accent, #5b9dff);
+  border-color: var(--accent);
   color: var(--fg, #e6e6e6);
 }
 .live-run-compact:disabled {
@@ -4255,7 +4288,7 @@ button.primary:disabled {
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
 }
 .composer:focus-within {
-  border-color: var(--accent, #5b9dff);
+  border-color: var(--accent);
 }
 .composer-input {
   width: 100%;
@@ -4318,7 +4351,7 @@ button.primary:disabled {
   padding: 0;
   border: none;
   border-radius: 50%;
-  background: var(--accent, #5b9dff);
+  background: var(--accent);
   color: #fff;
   font-size: 16px;
   line-height: 1;

--- a/web/src/tokens.css
+++ b/web/src/tokens.css
@@ -1,0 +1,166 @@
+/* ============================================================
+ * loomcycle Web UI — design tokens
+ *
+ * The single source of truth for color / spacing / type / radius /
+ * shadow / font, mirroring the brand design system
+ * (loomcycle-internal/web/assets/tokens.css). Two layers:
+ *
+ *   1. --lc-* tokens — the design system. Non-color tokens are
+ *      theme-independent; color tokens are themed (dark default,
+ *      [data-theme="light"] override).
+ *   2. Legacy aliases (--bg / --fg / --accent / …) mapped onto the
+ *      --lc-* tokens, so the rest of styles.css keeps working and
+ *      themes for free while it migrates to the --lc-* names.
+ *
+ * Theme is resolved before paint by the inline script in index.html
+ * (localStorage override ?? OS prefers-color-scheme) which sets
+ * <html data-theme>. useTheme.ts keeps it in sync at runtime.
+ * ============================================================ */
+
+:root {
+  /* —— Typography —— */
+  --lc-font-display: "Outfit Variable", "Outfit", system-ui, -apple-system, "Segoe UI", sans-serif;
+  --lc-font-body: "Inter Variable", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --lc-font-mono: "JetBrains Mono Variable", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Type scale (1.25 modular). Available to components; the dense
+   * console keeps its existing per-element sizes — these are not
+   * force-applied globally. */
+  --lc-text-xs: 12px;
+  --lc-text-sm: 13px;
+  --lc-text-base: 14px;
+  --lc-text-md: 16px;
+  --lc-text-lg: 20px;
+  --lc-text-xl: 25px;
+  --lc-text-2xl: 32px;
+  --lc-text-3xl: 40px;
+  --lc-text-4xl: 56px;
+  --lc-text-5xl: 72px;
+
+  /* —— Spacing (8px base) —— */
+  --lc-space-1: 8px;
+  --lc-space-2: 16px;
+  --lc-space-3: 24px;
+  --lc-space-4: 32px;
+  --lc-space-6: 48px;
+  --lc-space-8: 64px;
+  --lc-space-12: 96px;
+
+  /* —— Radius —— */
+  --lc-radius-sm: 4px;
+  --lc-radius: 8px;
+  --lc-radius-lg: 14px;
+
+  /* —— Elevation —— */
+  --lc-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.20);
+  --lc-shadow: 0 2px 10px rgba(0, 0, 0, 0.30);
+  --lc-shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.40);
+
+  /* ======================================================
+   * DARK theme color tokens (default).
+   * Values are the current palette verbatim, so dark renders
+   * byte-identical to before — except --lc-accent, now the
+   * loom-wood brand green.
+   * ====================================================== */
+  --lc-bg: #0f1115;
+  --lc-surface: #161922;
+  --lc-surface-2: #1d2230;
+  --lc-surface-3: #2a2a32;
+  --lc-input-bg: #1a1a1a;
+
+  --lc-text: #e6e6e6;
+  --lc-text-muted: #9aa0ad;
+  --lc-text-faint: #888888;
+  --lc-text-inverse: #0f1115;
+
+  --lc-rule: #2a2e3a;
+  --lc-rule-strong: #444444;
+
+  --lc-accent: #56c596;        /* loom-wood — the brand accent */
+  --lc-accent-hover: #3da376;
+  --lc-accent-soft: rgba(86, 197, 150, 0.14);
+  --lc-link: #56c596;
+
+  --lc-running: #f0a040;
+  --lc-completed: #4ec9b0;
+  --lc-failed: #ff5d68;
+  --lc-cancelled: #b08bd0;
+  --lc-danger: #cc3333;
+  --lc-danger-strong: #9b2c2c;
+
+  /* Charts (consumed by inline SVG via var()) */
+  --lc-chart-grid: #2a2e3a;
+  --lc-chart-axis: #9aa0ad;
+
+  color-scheme: dark;
+
+  /* ======================================================
+   * Legacy aliases → themed --lc-* tokens. Keep the old names
+   * working (and theming) while styles.css migrates.
+   * ====================================================== */
+  --bg: var(--lc-bg);
+  --bg-soft: var(--lc-surface);
+  --bg-soft-2: var(--lc-surface-2);
+  --bg-muted: var(--lc-input-bg);
+  --bg-input: var(--lc-input-bg);
+  --fg: var(--lc-text);
+  --fg-soft: var(--lc-text-muted);
+  --fg-muted: var(--lc-text-faint);
+  --accent: var(--lc-accent);
+  --border: var(--lc-rule);
+  --running: var(--lc-running);
+  --completed: var(--lc-completed);
+  --failed: var(--lc-failed);
+  --cancelled: var(--lc-cancelled);
+  --danger: var(--lc-danger);
+  --mono: var(--lc-font-mono);
+}
+
+/* Explicit dark selector == the :root default (so the toggle can set
+ * data-theme="dark" unconditionally). */
+[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+/* ======================================================
+ * LIGHT theme — functional, basic-neutral first pass.
+ * Refining this to the brand cream/agent palette is the
+ * documented follow-up; only the color tokens change here,
+ * everything else inherits from :root.
+ * ====================================================== */
+[data-theme="light"] {
+  --lc-bg: #f5f6f8;
+  --lc-surface: #ffffff;
+  --lc-surface-2: #eceef2;
+  --lc-surface-3: #e2e5ea;
+  --lc-input-bg: #ffffff;
+
+  --lc-text: #1a1d24;
+  --lc-text-muted: #5a6270;
+  --lc-text-faint: #8a909c;
+  --lc-text-inverse: #ffffff;
+
+  --lc-rule: #d7dbe2;
+  --lc-rule-strong: #c2c7d0;
+
+  --lc-accent: #2f9e6f;        /* darker loom-wood for AA contrast on light */
+  --lc-accent-hover: #25805a;
+  --lc-accent-soft: rgba(47, 158, 111, 0.12);
+  --lc-link: #2f9e6f;
+
+  --lc-running: #b9740f;
+  --lc-completed: #1f9e86;
+  --lc-failed: #d23f4a;
+  --lc-cancelled: #7d4fb3;
+  --lc-danger: #c0392b;
+  --lc-danger-strong: #962419;
+
+  --lc-chart-grid: #d7dbe2;
+  --lc-chart-axis: #5a6270;
+
+  --lc-shadow-sm: 0 1px 2px rgba(26, 29, 36, 0.05);
+  --lc-shadow: 0 2px 10px rgba(26, 29, 36, 0.08);
+  --lc-shadow-lg: 0 10px 30px rgba(26, 29, 36, 0.12);
+
+  color-scheme: light;
+}


### PR DESCRIPTION
## Why

The Web UI styling grew organically: a single 4571-line `styles.css` with a tiny `:root` set, ~140 hardcoded hexes, ~19 inline chart colors, and **no theming**. This introduces a real, tokenized design system — mirroring the brand reference (`loomcycle-internal/web/design-system.html` / `assets/tokens.css`) — applied across the app, with **light + dark** support, the **brand fonts**, and the **loom-wood accent**.

## What

**Token layer** (`web/src/tokens.css`, imported before `styles.css`): the `--lc-*` system — spacing / type-scale / radius / shadow / font + semantic colors. Dark color tokens = the current palette **verbatim** (dark is unchanged) **except** the accent, now **loom-wood `#56c596`** (was `#5b9dff`). A `[data-theme="light"]` block holds a **functional basic-neutral light** palette. Legacy names (`--bg`/`--fg`/`--accent`/`--border`/…) are **aliased** onto the themed tokens, so all of `styles.css` themes for free.

**Brand fonts, bundled** (`@fontsource-variable/{outfit,inter,jetbrains-mono}` — self-hosted, no CDN, embedded, offline-safe): body→Inter, headings→Outfit, code/mono→JetBrains Mono.

**Theme switch** (`useTheme.ts` + `index.html` pre-paint + topbar toggle): default follows OS `prefers-color-scheme`; a sun/moon toggle overrides + persists (localStorage); pre-paint script sets `data-theme` + `<meta color-scheme>` before React mounts → no FOUC.

**Themed everywhere:** global form controls + the Activity charts (`LineChart` grid/axis, `ActivityMonitor` series) now read `var(--lc-*)` / `var(--lc-accent)` (inline SVG resolves ancestor CSS vars). No `#5b9dff` remains.

## Relationship to #483

This **supersedes #483** (the standalone form-control rule): that rule is re-expressed against the tokens here. Please **close #483** in favor of this (or merge #483 first and I'll resolve the trivial `styles.css` overlap). #481 / #482 are independent.

## Tested

`make build-all` clean (fonts bundle into `dist`). Verified the **real app in both themes** (screenshots shared in-thread): dark = original palette + green accent + brand fonts + working toggle; light = clean basic-neutral with the same green; the agent editor modal shows all form fields themed/homogeneous; charts pick up the accent. OS-default respected, no FOUC, reload persists the override.

CSS/UI-only: `internal/webui/dist/*` gitignored (CI rebuilds). The **Web UI build** job is the gate.

## Out of scope (follow-up)
- Refining the **light** palette to the brand cream/agent colors (ships basic-neutral now so OS-follow + the toggle work).
- Migrating the long tail of semantic literal-hex tints (status pills, event-type borders) + the conventionally-dark terminal pane to light-aware tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)