### PR TITLE
fix(loop): refresh context footprint after compaction so Context op=self isn't stale

### DIFF
--- a/internal/loop/compact_test.go
+++ b/internal/loop/compact_test.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -224,6 +225,114 @@ func TestRun_Interactive_CompactReplacesHistory(t *testing.T) {
 		if txt(m) == "go" {
 			t.Errorf("the original pre-compaction turn survived: %+v", m)
 		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not terminate after cancel")
+	}
+}
+
+// ctxUsageProvider records the context footprint visible on ctx at each Call —
+// exactly what a Context op=self invoked that turn would report (the loop hands
+// the provider the same iterCtx the tools get). The FIRST call reports a large
+// InputTokens usage so lastCtxTokens becomes large; every call ends the turn.
+type ctxUsageProvider struct {
+	mu       sync.Mutex
+	seenUsed []int
+	firstIn  int
+	maxCtx   int
+	turn     int
+}
+
+func (p *ctxUsageProvider) ID() string                                   { return "ctxusage-test" }
+func (p *ctxUsageProvider) Probe(context.Context) error                  { return nil }
+func (p *ctxUsageProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *ctxUsageProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true, MaxContextTokens: p.maxCtx}
+}
+func (p *ctxUsageProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.seenUsed = append(p.seenUsed, tools.ContextUsage(ctx).Used)
+	turn := p.turn
+	p.turn++
+	p.mu.Unlock()
+
+	in := 0
+	if turn == 0 {
+		in = p.firstIn
+	}
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: in}}
+	close(ch)
+	return ch, nil
+}
+
+// A parked interactive run that compacts (steer.KindCompact) must refresh the
+// context footprint so the NEXT operator turn's Context op=self reports the
+// compacted (small) size — not the stale pre-compaction footprint.
+//
+// Fail-before: the loop never refreshed lastCtxTokens on compaction, so op=self
+// kept reporting the old ~full context (e.g. 164k / 82%) for a whole turn even
+// though the real wire request had already shrunk — the reported bug.
+func TestRun_Interactive_ContextUsageRefreshedAfterCompaction(t *testing.T) {
+	q := make(chan steer.Message, 4)
+	parked := make(chan struct{}, 8)
+	compacted := make(chan struct{}, 8)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	prov := &ctxUsageProvider{firstIn: 164000, maxCtx: 200000}
+	done := make(chan struct{})
+	go func() {
+		_, _ = Run(ctx, RunOptions{
+			Provider:    prov,
+			Model:       "x",
+			Tools:       []tools.Tool{noopTool{}},
+			Dispatcher:  tools.NewDispatcher([]tools.Tool{noopTool{}}),
+			Segments:    steerSegs(),
+			SteerQueue:  q,
+			Interactive: true,
+			OnEvent: func(ev providers.Event) {
+				switch ev.Type {
+				case providers.EventAwaitingInput:
+					parked <- struct{}{}
+				case providers.EventContextCompaction:
+					compacted <- struct{}{}
+				}
+			},
+		})
+		close(done)
+	}()
+	waitOn := func(ch <-chan struct{}, what string) {
+		t.Helper()
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("%s: timed out", what)
+		}
+	}
+
+	// Turn 0: a real turn that reports a large footprint (164k), then parks.
+	waitOn(parked, "initial end_turn park")
+	// Compact while parked → shrinks the in-memory history; re-parks (no call).
+	q <- steer.Message{Kind: steer.KindCompact, Text: "SUMMARY-X"}
+	waitOn(compacted, "compaction applied")
+	// A real operator turn now → exactly one provider call on the compacted history.
+	q <- steer.Message{Text: "continue"}
+	waitOn(parked, "re-park after the real turn")
+
+	prov.mu.Lock()
+	seen := append([]int(nil), prov.seenUsed...)
+	prov.mu.Unlock()
+	if len(seen) < 2 {
+		t.Fatalf("want >=2 provider calls, got %d (%v)", len(seen), seen)
+	}
+	post := seen[len(seen)-1]
+	if post >= prov.firstIn {
+		t.Fatalf("post-compaction Context op=self footprint = %d; want the small compacted size, not the stale pre-compaction %d", post, prov.firstIn)
 	}
 
 	cancel()

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -910,13 +910,17 @@ func shouldAutoCompact(c *config.Compaction, used, window, iter, lastCompactIter
 // emits it. A steer.KindCompact control instead REPLACES the conversation with
 // the compacted form (server-computed summary + keep-N/keep-first) and emits
 // EventContextCompaction; it does NOT fire onSteer (the summary is not an
-// operator turn and must not be persisted as a user_input replay row).
-func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer func(steer.Message), emit func(providers.Event)) []providers.Message {
+// operator turn and must not be persisted as a user_input replay row). Returns
+// the (possibly compacted) messages + whether a compaction was applied, so the
+// caller can refresh the context footprint (lastCtxTokens) after a shrink.
+func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer func(steer.Message), emit func(providers.Event)) ([]providers.Message, bool) {
+	compacted := false
 	for {
 		select {
 		case m := <-q:
 			if m.Kind == steer.KindCompact {
 				messages = applyCompactSummary(messages, m.Text, m.KeepN, m.KeepFirst, emit)
+				compacted = true
 				continue
 			}
 			messages = append(messages, providers.Message{
@@ -927,7 +931,7 @@ func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer fu
 				onSteer(m)
 			}
 		default:
-			return messages
+			return messages, compacted
 		}
 	}
 }
@@ -1140,11 +1144,9 @@ outerLoop:
 		iterCtx = tools.WithResolvedProvider(iterCtx, opts.Provider.ID())
 		iterCtx = tools.WithResolvedModel(iterCtx, opts.Model)
 		iterCtx = tools.WithResolvedSampling(iterCtx, opts.Sampling)
-		// Current context footprint (last completed turn's input+cache vs the
-		// window) so Context op=self can show the agent how full it is — the
-		// signal it needs to decide whether to self-compact (op=compact). Same
-		// values the auto-compact threshold reads; 0 on the first iteration.
-		iterCtx = tools.WithContextUsage(iterCtx, lastCtxTokens, lastWindow)
+		// NB: the context-footprint stamp (tools.WithContextUsage) is applied
+		// LOWER — after drainSteer + auto/self compaction — so a same-turn
+		// op=self never reports a stale pre-compaction footprint.
 
 		// Heartbeat fires at the top of each iteration. Cheap path —
 		// implementations are expected to be ~one UPDATE. Failures
@@ -1176,7 +1178,14 @@ outerLoop:
 		// user(tool_results)]; appending a user(steer) turn yields consecutive
 		// user turns, which every provider accepts (replay already emits them).
 		if opts.SteerQueue != nil {
-			messages = drainSteer(opts.SteerQueue, messages, opts.OnSteer, emit)
+			var steerCompacted bool
+			messages, steerCompacted = drainSteer(opts.SteerQueue, messages, opts.OnSteer, emit)
+			if steerCompacted {
+				// A steer-delivered compaction shrank the running history; refresh
+				// the footprint so the auto-compact check + op=self below reflect
+				// the compacted size, not the stale pre-compaction value.
+				lastCtxTokens = estimateMessageTokens(messages)
+			}
 		}
 
 		// Auto / self-requested compaction — also a clean boundary (drainSteer
@@ -1193,8 +1202,20 @@ outerLoop:
 			if newMsgs, did := maybeAutoCompact(iterCtx, opts, messages, emit, trigger); did {
 				messages = newMsgs
 				lastCompactIter = iter
+				// Compaction shrank the history; refresh the footprint so op=self
+				// below reflects the compacted size, not the pre-compaction value
+				// (the next real turn's usage overwrites it).
+				lastCtxTokens = estimateMessageTokens(messages)
 			}
 		}
+
+		// Context footprint (input+cache of the last completed turn, or the
+		// post-compaction estimate when a compaction just ran above) so Context
+		// op=self can show the agent how full its window is — the signal it needs
+		// to decide whether to self-compact (op=compact). Stamped HERE, below
+		// drainSteer + auto/self compaction, so a same-turn op=self never reports
+		// the stale pre-compaction footprint. 0 on the first iteration.
+		iterCtx = tools.WithContextUsage(iterCtx, lastCtxTokens, lastWindow)
 
 		// Context-transform plugins (RFC Z / F43): run the configured chain on a
 		// COPY of the outbound context — the loop's canonical system/messages
@@ -1525,6 +1546,12 @@ outerLoop:
 					}
 					if m.Kind == steer.KindCompact {
 						messages = applyCompactSummary(messages, m.Text, m.KeepN, m.KeepFirst, emit)
+						// Refresh the footprint so the next operator turn's op=self
+						// reports the compacted size, not the stale pre-compaction
+						// value. Without this a parked run that compacted kept
+						// reporting its old ~full context (used_tokens / used_pct)
+						// until the next real turn's usage landed.
+						lastCtxTokens = estimateMessageTokens(messages)
 						continue // re-park: wait for the operator's actual next turn
 					}
 					messages = append(messages, providers.Message{


### PR DESCRIPTION
## Why

An operator reported that after a context compaction, the agent still reports a large context. The trace told the whole story:

```
context_compacted  ↯ context compacted (~98.1k → ~889)
user_echo          ❯ what is your context size now?
tool_call          Context {"op":"self"}
usage              in=1504 out=90 model=claude-sonnet-4-6     ← real wire context: TINY (compaction worked!)
text               ## Current Context Size … Used tokens 164,520 / 82%   ← op=self: STALE
```

The compaction **did** shrink the outbound request (`in=1504`), but `Context op=self` reported **164,520 / 82%** — the pre-compaction footprint.

## What

`Context op=self` reads `tools.ContextUsage(ctx)`, which the loop stamps from `lastCtxTokens`. `lastCtxTokens` was only ever updated from a **completed provider turn's** usage (`internal/loop/loop.go` ~1498). A compaction rewrites the in-memory `messages` to `[summary, ack] ++ tail` **without** touching `lastCtxTokens`, so the footprint stayed at the old value until the *next* real turn landed — exactly one stale turn, which is the turn the operator's "what is your context size now?" hit.

The fix restores the invariant *"`lastCtxTokens` reflects the current `messages`"* by refreshing it (`estimateMessageTokens(messages)` — the same estimator the `context_compaction` event's before/after numbers use) at **every** compaction site:

- **parked interactive run** — `steer.KindCompact` in the `parkForInput` loop (the reported path),
- **running run** — `steer.KindCompact` drained by `drainSteer` (`drainSteer` now returns whether it compacted),
- **inline auto/self** — `maybeAutoCompact` (covers auto-threshold + `Context op=compact`).

It also moves the `WithContextUsage` stamp **below** the top-of-loop compaction block, so a *same-turn* `op=self` (inline/steer paths) reflects the compacted size too. Refreshing before the `shouldAutoCompact` check additionally suppresses a redundant auto-compact immediately after a steer-delivered compaction.

No wire/schema change; the run-final usage accounting is untouched (the estimate is a transient bridge value, overwritten by the next real turn's actual usage).

## What was tested

- **New fail-before regression test** `TestRun_Interactive_ContextUsageRefreshedAfterCompaction` (`internal/loop/compact_test.go`): a parked interactive run reports a 164k footprint, compacts via `steer.KindCompact`, then a real operator turn's visible `Context op=self` footprint must be the small compacted size. Reverting the park-path refresh reproduces the bug exactly: `post-compaction Context op=self footprint = 164000`.
- `go test ./internal/loop/` — green; `go test ./...` — full suite green; `gofmt`/`go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)