### PR TITLE
feat: interactive-terminal waiting indicator + local-model UX (Ollama gauge + timeouts)

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -20,6 +20,14 @@
 # registration entirely, set OLLAMA_BASE_URL=disabled.
 OLLAMA_BASE_URL=http://localhost:11434
 # OLLAMA_CLOUD_BASE_URL=https://ollama.com   # optional override
+#
+# num_ctx pins the input window Ollama runs every request in. Set it: without
+# an explicit num_ctx Ollama silently truncates the prompt at its 4096-token
+# default. It also doubles as the context window the interactive terminal's
+# gauge reports (used/max/%) — unset, the gauge can only show the absolute
+# used size (the per-model window isn't knowable from the driver).
+# LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=32768
+# LOOMCYCLE_OLLAMA_NUM_CTX=32768            # hosted ollama.com counterpart
 
 # ─── Sidecar listen ───────────────────────────────────────────────────
 # (The bearer token /v1 routes require is a secret — set LOOMCYCLE_AUTH_TOKEN
@@ -204,6 +212,16 @@ LOOMCYCLE_DATA_DIR=./data
 # defaults are tuned for direct internet egress.
 # LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
 # LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000
+#
+# The `ollama-local` provider is the exception: local generation is slow on
+# first-token (cold model load from disk + prompt eval over a large num_ctx
+# can take minutes on a consumer GPU/CPU), so it uses its OWN, more generous
+# default pair — 300 s / 300 s — instead of the cloud-shaped 60/90 above.
+# These override only ollama-local; hosted ollama.com and every other cloud
+# provider keep the global Provider*Timeout. Bump these if a slow local model
+# still trips a header/idle timeout before producing its first token.
+# LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=300000
+# LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=300000
 
 # ─── Provider fallback semantics (v0.8.13+) ──────────────────────────
 #

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2370,7 +2370,14 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 	// effectively always-on. Operators disable it via
 	// OLLAMA_BASE_URL=disabled (or an empty string in shell env).
 	if cfg.Env.OllamaBaseURL != "" && cfg.Env.OllamaBaseURL != "disabled" {
-		pr.ollamaLocal = ollama.New("ollama-local", "", cfg.Env.OllamaBaseURL, streamOpts, nil).
+		// Local Ollama is slow on first-token (cold model load + large-context
+		// eval), so it gets its own, more generous timeout pair rather than the
+		// cloud-shaped global defaults — see Env.OllamaLocalHeaderTimeout.
+		localStreamOpts := streamhttp.Options{
+			HeaderTimeout: cfg.Env.OllamaLocalHeaderTimeout,
+			IdleTimeout:   cfg.Env.OllamaLocalIdleTimeout,
+		}
+		pr.ollamaLocal = ollama.New("ollama-local", "", cfg.Env.OllamaBaseURL, localStreamOpts, nil).
 			WithNumCtx(cfg.Env.OllamaLocalNumCtx)
 	}
 	// DeepSeek opts in via DEEPSEEK_API_KEY. Optional DEEPSEEK_BASE_URL

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2176,6 +2176,22 @@ type Env struct {
 	// Env: LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS.
 	ProviderIdleTimeout time.Duration
 
+	// OllamaLocalHeaderTimeout / OllamaLocalIdleTimeout override the
+	// ProviderHeaderTimeout / ProviderIdleTimeout pair for the
+	// "ollama-local" registration ONLY. Local generation is inherently
+	// slow on first-token — a cold model load from disk plus prompt
+	// evaluation over a large num_ctx can take minutes on a consumer
+	// GPU/CPU, blowing past the 60s/90s cloud-shaped defaults and
+	// surfacing as a spurious header/idle timeout. These default to a
+	// generous 300s each so a slow local model isn't cut off, while the
+	// cloud providers keep the tighter fast-fail defaults. Hosted
+	// ollama.com (the "ollama" registration) uses the global
+	// Provider*Timeout, like every other cloud driver.
+	// Env: LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS /
+	// LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS.
+	OllamaLocalHeaderTimeout time.Duration
+	OllamaLocalIdleTimeout   time.Duration
+
 	// v0.10.0 OpenTelemetry tracing — default OFF. Setting
 	// OTELExporterEndpoint to a non-empty value installs an OTLP/HTTP
 	// exporter; loomcycle emits run/iteration/provider.call/tool.call
@@ -2959,6 +2975,23 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.ProviderIdleTimeout = time.Duration(n) * time.Millisecond
+		}
+	}
+
+	// Local Ollama gets a more generous default than the cloud providers:
+	// a cold model load + large-context prompt eval can take minutes to
+	// first token. Scoped to the ollama-local registration; see the field
+	// docs on Env.OllamaLocalHeaderTimeout.
+	cfg.Env.OllamaLocalHeaderTimeout = 300 * time.Second
+	if v := os.Getenv("LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.OllamaLocalHeaderTimeout = time.Duration(n) * time.Millisecond
+		}
+	}
+	cfg.Env.OllamaLocalIdleTimeout = 300 * time.Second
+	if v := os.Getenv("LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.OllamaLocalIdleTimeout = time.Duration(n) * time.Millisecond
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -762,6 +762,48 @@ agents:
 	}
 }
 
+// ollama-local gets a generous 300s/300s default timeout pair (cold local
+// model load + large-context eval is slow), distinct from the cloud-shaped
+// 60s/90s global default; the LOOMCYCLE_OLLAMA_LOCAL_* env vars override it
+// and the global Provider*Timeout is untouched.
+func TestOllamaLocalTimeouts_DefaultsAndOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  default: { model: claude-sonnet-4-6 }
+`), 0o600)
+
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Env.OllamaLocalHeaderTimeout != 300*time.Second {
+		t.Errorf("default header = %v, want 300s", cfg.Env.OllamaLocalHeaderTimeout)
+	}
+	if cfg.Env.OllamaLocalIdleTimeout != 300*time.Second {
+		t.Errorf("default idle = %v, want 300s", cfg.Env.OllamaLocalIdleTimeout)
+	}
+	// The local timeouts must NOT perturb the global cloud defaults.
+	if cfg.Env.ProviderHeaderTimeout != 60*time.Second {
+		t.Errorf("global header default perturbed: %v, want 60s", cfg.Env.ProviderHeaderTimeout)
+	}
+
+	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS", "600000")
+	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS", "450000")
+	cfg, err = Load(yamlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Env.OllamaLocalHeaderTimeout != 600*time.Second {
+		t.Errorf("override header = %v, want 600s", cfg.Env.OllamaLocalHeaderTimeout)
+	}
+	if cfg.Env.OllamaLocalIdleTimeout != 450*time.Second {
+		t.Errorf("override idle = %v, want 450s", cfg.Env.OllamaLocalIdleTimeout)
+	}
+}
+
 // Absolute path bypasses configDir resolution. Used when the operator
 // stages prompts somewhere outside the YAML's directory.
 func TestSystemPromptFileAbsolutePath(t *testing.T) {

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -120,8 +120,14 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		NativePromptCache: false,
 		ParallelToolCalls: true, // model-dependent; we report the optimistic case
 		Streaming:         true,
-		MaxContextTokens:  0, // varies wildly by model; 0 means "ask the model"
-		SupportsThinking:  false,
+		// The real per-model window varies wildly and the driver is
+		// model-agnostic, so we can't name it from here. But when the
+		// operator pins options.num_ctx (WithNumCtx / LOOMCYCLE_OLLAMA*_NUM_CTX)
+		// that IS the input window every request runs in — report it so the
+		// interactive terminal's context gauge can render used/max/%. 0 (no
+		// num_ctx) stays "unknown" and the gauge shows only the absolute size.
+		MaxContextTokens: d.numCtx,
+		SupportsThinking: false,
 		// Ollama has no operator-controlled thinking-budget knob today.
 		// Reasoning models (qwen3, deepseek-r1, hermes3) decide whether
 		// to think based on their own defaults; the message.thinking

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -239,6 +239,21 @@ func TestRequestBody_NumCtxOmittedByDefault(t *testing.T) {
 	}
 }
 
+// TestCapabilities_MaxContextTokensReflectsNumCtx pins that the context
+// window the driver advertises equals the operator-pinned num_ctx — the
+// value the interactive terminal's context gauge renders as used/max/%.
+// Without WithNumCtx the per-model window is genuinely unknown (the driver
+// is model-agnostic), so it stays 0 and the gauge shows only the absolute
+// used size. Fail-before: Capabilities hardcoded MaxContextTokens: 0.
+func TestCapabilities_MaxContextTokensReflectsNumCtx(t *testing.T) {
+	if got := New("ollama-local", "", "", streamhttp.Options{}, nil).Capabilities().MaxContextTokens; got != 0 {
+		t.Errorf("no num_ctx: MaxContextTokens = %d, want 0 (unknown)", got)
+	}
+	if got := New("ollama-local", "", "", streamhttp.Options{}, nil).WithNumCtx(32768).Capabilities().MaxContextTokens; got != 32768 {
+		t.Errorf("num_ctx=32768: MaxContextTokens = %d, want 32768", got)
+	}
+}
+
 // TestRequestBody_NumCtxPropagated pins the headline path: after
 // WithNumCtx(N), every chat request carries options.num_ctx=N. The
 // load-bearing assertion behind the 2026-05-15 employer-profiler

--- a/web/src/components/LiveRunPane.tsx
+++ b/web/src/components/LiveRunPane.tsx
@@ -104,6 +104,26 @@ export default function LiveRunPane({
     return servers.size;
   }, [events]);
 
+  // The agent is actively working when the run is live, not parked awaiting
+  // input, and not blocked on an interruption — i.e. a provider call is in
+  // flight, the model is streaming, or a tool is executing. That's when the
+  // flashing indicator shows. The label adapts: a tool_call with no matching
+  // tool_result yet means a tool is running; otherwise we're waiting on the
+  // model (request in flight / response streaming in).
+  const busy = running && !awaitingInput && !pendingInterrupt;
+  const busyHint = useMemo(() => {
+    const resultIds = new Set<string>();
+    for (const e of events) {
+      const rid = e.event?.tool_use_id;
+      if (rid) resultIds.add(rid);
+    }
+    for (let i = events.length - 1; i >= 0; i--) {
+      const tu = events[i].event?.tool_use;
+      if (tu?.id && !resultIds.has(tu.id)) return `running ${tu.name}…`;
+    }
+    return "waiting for the model…";
+  }, [events]);
+
   return (
     <div className={compact ? "live-run-pane live-run-pane-compact" : "live-run-pane"}>
       <div className="live-run-header">
@@ -159,6 +179,13 @@ export default function LiveRunPane({
 
       {awaitingInput && running && (
         <div className="live-run-awaiting">● agent is idle — waiting for your input</div>
+      )}
+
+      {busy && (
+        <div className="live-run-busy" aria-live="polite">
+          <span className="live-run-busy-dot" aria-hidden="true" />
+          {busyHint}
+        </div>
       )}
 
       {showPrompt && (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4373,6 +4373,34 @@ button.primary:disabled {
   color: var(--accent);
   border-top: 1px solid var(--border, #2a2a32);
 }
+
+/* Busy indicator — the agent is actively working (provider call in flight,
+   response streaming, or a tool running). A flashing dot signals "waiting for
+   the LLM response" so the operator knows the terminal isn't stalled. */
+.live-run-busy {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--accent);
+  border-top: 1px solid var(--border, #2a2a32);
+}
+.live-run-busy-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: lc-pulse 1.1s ease-in-out infinite;
+}
+@keyframes lc-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.25; transform: scale(0.7); }
+}
+/* Respect reduced-motion: keep a steady dimmed dot, no pulsing. */
+@media (prefers-reduced-motion: reduce) {
+  .live-run-busy-dot { animation: none; opacity: 0.6; }
+}
 .live-run-pane-compact {
   min-height: 180px;
 }


### PR DESCRIPTION
## Why

Three rough edges in running agents from the Web UI, all hit hardest with **local Ollama models**:

1. **No "waiting" feedback.** Between the operator's message and the first token, the interactive terminal showed nothing — a slow turn looked stalled.
2. **Context gauge blank for Ollama.** Local models reported no context window, so the gauge could only ever show the absolute used size, never used/max/%.
3. **Local models time out.** The single global 60s-time-to-first-byte / 90s-idle default is cloud-shaped; a cold local model (disk load + large-context eval on a consumer GPU/CPU) blows past it and the run dies before producing anything.

## What

Three focused commits + an env-doc commit:

**1. `fix(ollama): report configured num_ctx as MaxContextTokens`** — `Capabilities()` hardcoded `MaxContextTokens: 0`. The driver already tracks the operator-pinned `options.num_ctx` (`WithNumCtx`, from `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` / `LOOMCYCLE_OLLAMA_NUM_CTX`) — which *is* the window every request runs in — so it now reports that. The gauge renders used/max/%. With no `num_ctx` the per-model window is genuinely unknowable from the (model-agnostic) driver, so it stays `0` and the gauge degrades to the absolute size (unchanged).

**2. `feat(ollama): generous default timeouts for ollama-local`** — the `ollama-local` registration gets its own timeout pair, default **300s / 300s**, via new config fields `OllamaLocalHeaderTimeout` / `OllamaLocalIdleTimeout` (env `LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS` / `_IDLE_TIMEOUT_MS`). Scoped to local only — hosted ollama.com and every other cloud provider keep the tighter fast-fail global `Provider*Timeout`.

**3. `feat(webui): flashing waiting indicator`** — `LiveRunPane` shows a flashing dot + adaptive label whenever the run is live, not parked, and not blocked on an interruption: **"running &lt;tool&gt;…"** when a `tool_call` has no matching `tool_result` yet, else **"waiting for the model…"**. Loom-wood accent; disabled under `prefers-reduced-motion`. Mutually exclusive with the existing "agent is idle — waiting for your input" parked line.

**4. `docs(env)`** — the new timeout knobs + a `num_ctx`-drives-the-gauge note in `.env.insecure.example`.

No wire-protocol/schema change (the `max_context_tokens` usage field already exists — v0.29.x — we just populate it for Ollama). No `@loomcycle/client` bump.

## What was tested

- **`TestCapabilities_MaxContextTokensReflectsNumCtx`** (ollama) — fail-before (hardcoded 0): asserts `MaxContextTokens == num_ctx` when pinned, `0` when not.
- **`TestOllamaLocalTimeouts_DefaultsAndOverrides`** (config) — 300s/300s defaults, ms-env overrides, and that the global `Provider*Timeout` is untouched.
- `go test ./...` full suite green; `gofmt` + `go vet` clean.
- `make build-all` produces a clean UI + binary; `make build-ui` runs `tsc` clean.
- The waiting indicator's transient state was verified by build + logic review (it's deliberately a fleeting state — best confirmed live against a slow local model, which is exactly its target scenario).

🤖 Generated with [Claude Code](https://claude.com/claude-code)