### PR TITLE
fix(tools): resolve relative sandbox paths against the root, not process cwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 # Binaries
 /cmd/ac/ac
 /bin/
+# Stray root build artifact from `go build ./cmd/loomcycle` run without -o
+# (the canonical binary is /bin/loomcycle, produced by `make build`). A loose
+# /loomcycle file at the repo root also shadows relative tool paths in dev.
+/loomcycle
+# Local tool-sandbox scratch (dev points LOOMCYCLE_READ_ROOT / WRITE_ROOT /
+# BASH_CWD here; agents clone + write into it — never committed).
+/tmp/
 *.exe
 *.dll
 *.so

--- a/internal/tools/builtin/sandbox.go
+++ b/internal/tools/builtin/sandbox.go
@@ -6,9 +6,31 @@ import (
 	"strings"
 )
 
-// resolveInsideRoot resolves an absolute target path and verifies it sits
-// inside root after symlink evaluation. Returns the resolved absolute
-// path on success.
+// absUnderRoot makes target absolute, anchoring a RELATIVE target to the
+// sandbox root — NOT the loomcycle process's working directory.
+//
+// Why: a relative tool path ("internal/foo.go") should mean "inside the
+// sandbox", the same thing it means to the Bash tool (whose cwd is the jail)
+// and the same thing every model assumes. The old behaviour
+// (filepath.Abs → process cwd) resolved it against wherever the server
+// happened to start, so a relative path landed OUTSIDE the sandbox and either
+// failed or — if a like-named file sat at the server's cwd — produced a
+// baffling error (a code-reviewer agent's `Read internal/store/store.go`
+// resolved into a stray `loomcycle` binary at the repo root → ENOTDIR).
+//
+// The result is only a CANDIDATE: every caller still EvalSymlinks it and
+// re-checks containment with relInsideRoot, so a relative `..` that climbs
+// out of root is still rejected.
+func absUnderRoot(rootResolved, target string) string {
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target)
+	}
+	return filepath.Join(rootResolved, target)
+}
+
+// resolveInsideRoot resolves a target path (absolute, or relative to the
+// sandbox root — see absUnderRoot) and verifies it sits inside root after
+// symlink evaluation. Returns the resolved absolute path on success.
 //
 // Used by Read and Edit, where the file MUST exist (otherwise EvalSymlinks
 // fails). Write uses resolveParentInsideRoot below because the file may
@@ -23,10 +45,7 @@ func resolveInsideRoot(root, target string) (resolved string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("sandbox root: %w", err)
 	}
-	abs, err := filepath.Abs(filepath.Clean(target))
-	if err != nil {
-		return "", fmt.Errorf("abs path: %w", err)
-	}
+	abs := absUnderRoot(rootResolved, target)
 	resolved, err = filepath.EvalSymlinks(abs)
 	if err != nil {
 		return "", err
@@ -45,10 +64,7 @@ func resolveParentInsideRoot(root, target string) (joined string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("sandbox root: %w", err)
 	}
-	abs, err := filepath.Abs(filepath.Clean(target))
-	if err != nil {
-		return "", fmt.Errorf("abs path: %w", err)
-	}
+	abs := absUnderRoot(rootResolved, target)
 	parentResolved, err := filepath.EvalSymlinks(filepath.Dir(abs))
 	if err != nil {
 		return "", fmt.Errorf("parent dir: %w", err)

--- a/internal/tools/builtin/sandbox_test.go
+++ b/internal/tools/builtin/sandbox_test.go
@@ -1,0 +1,93 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// A RELATIVE tool path resolves against the sandbox ROOT, not the loomcycle
+// process working directory.
+//
+// Fail-before: resolveInsideRoot used filepath.Abs (process-cwd-relative), so
+// "sub/file.txt" looked under the test binary's cwd — outside the sandbox —
+// and returned an error. This is the bug behind the code-reviewer agent's
+// `Read internal/store/store.go` resolving into a stray repo-root binary
+// (ENOTDIR) instead of the cloned tree under the sandbox.
+func TestResolveInsideRoot_RelativeAnchoredToRoot(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(sub, "file.txt")
+	if err := os.WriteFile(want, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// EvalSymlinks the expectation so a /var→/private/var (macOS) root matches.
+	wantResolved, err := filepath.EvalSymlinks(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveInsideRoot(root, "sub/file.txt")
+	if err != nil {
+		t.Fatalf("relative path under root should resolve; got error: %v", err)
+	}
+	if got != wantResolved {
+		t.Errorf("resolved = %q, want %q", got, wantResolved)
+	}
+}
+
+// Absolute in-root paths are unchanged by the anchoring change.
+func TestResolveInsideRoot_AbsoluteStillResolves(t *testing.T) {
+	root := t.TempDir()
+	abs := filepath.Join(root, "f.txt")
+	if err := os.WriteFile(abs, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := resolveInsideRoot(root, abs); err != nil {
+		t.Fatalf("absolute in-root path should resolve: %v", err)
+	}
+}
+
+// Anchoring to root must NOT weaken the escape check: a relative path that
+// climbs out with `..` to a real file outside the sandbox is still rejected.
+func TestResolveInsideRoot_RelativeEscapeRejected(t *testing.T) {
+	base := t.TempDir()
+	root := filepath.Join(base, "root")
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("s"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// From root, ../outside/secret.txt is a REAL file outside the sandbox —
+	// must be rejected by the containment check, not silently read.
+	if _, err := resolveInsideRoot(root, "../outside/secret.txt"); err == nil {
+		t.Error("relative path escaping the sandbox root must be rejected")
+	}
+}
+
+// Write's parent-resolver anchors a relative path (whose file need not exist
+// yet) to the sandbox root too — same fix, same rationale.
+func TestResolveParentInsideRoot_RelativeAnchoredToRoot(t *testing.T) {
+	root := t.TempDir()
+	got, err := resolveParentInsideRoot(root, "newfile.txt")
+	if err != nil {
+		t.Fatalf("relative new-file path under root should resolve: %v", err)
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(rootResolved, "newfile.txt")
+	if got != want {
+		t.Errorf("resolved = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Why

Surfaced live by a `code-reviewer` agent (gemma4:e4b) reviewing the repo from inside its sandbox. It cloned into the jail and ran `Read internal/store/store.go` — a path that plainly exists in the sandbox — and got the baffling **`not a directory`** (ENOTDIR).

Root cause: the file tools made a **relative** path absolute with `filepath.Abs`, i.e. relative to the **loomcycle server process's working directory**, *then* containment-checked against the sandbox root. So a relative tool path meant "relative to wherever the server started," not "inside the sandbox" — and **disagreed with the Bash tool**, whose cwd *is* the jail (`LOOMCYCLE_BASH_CWD`). A relative path that worked in Bash failed in Read/Glob and vice-versa.

I reproduced it exactly: the server's cwd was the repo root, where a stray `loomcycle` binary sat, so `internal/store/store.go` → `<repo>/loomcycle/internal/store/store.go` → traversal into a *file* → ENOTDIR.

## What

Two commits:

1. **`chore(gitignore)`** — the stray repo-root `loomcycle` binary (a `go build` artifact run without `-o`; canonical is `/bin/loomcycle`) is removed and `/loomcycle` + `/tmp/` (dev sandbox scratch) are gitignored. The loose root binary is also what turned a wrong path into the cryptic ENOTDIR.

2. **`fix(tools)`** — relative targets now anchor to the **sandbox root** via a shared `absUnderRoot` helper, fixing all six file tools at once (Read/Edit/Glob/Grep/NotebookEdit via `resolveInsideRoot`, Write via `resolveParentInsideRoot`). This realises the documented *"cwd == jail == roots"* intent so a relative path means the same thing across every tool — and matches what any model assumes.

**Security preserved:** absolute paths are unchanged, and the `EvalSymlinks` + `relInsideRoot` containment check is untouched — a relative `..` that climbs out of root is still rejected (covered by a test). The change is strictly *safer*: a relative path can no longer reach the server's cwd; it's confined to the sandbox.

## What was tested

- **Fail-before** (both reproduced the bug against the old `filepath.Abs` behavior, the error literally showing process-cwd resolution):
  - `TestResolveInsideRoot_RelativeAnchoredToRoot`
  - `TestResolveParentInsideRoot_RelativeAnchoredToRoot`
- Guard tests: `TestResolveInsideRoot_AbsoluteStillResolves`, `TestResolveInsideRoot_RelativeEscapeRejected` (a real out-of-sandbox file via `..` is rejected).
- Full `internal/tools/builtin` package green (existing Read/Write/Edit/Glob/Grep tests use absolute paths — unaffected); `go test ./...` full suite green; `gofmt` + `go vet` clean.

Runtime-only; no wire/schema change, no `@loomcycle/client` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)