### PR TITLE
fix(webui): reveal the static agent base in the Library when dynamic versions exist with no active pointer

### DIFF
--- a/internal/lookup/agent_test.go
+++ b/internal/lookup/agent_test.go
@@ -354,3 +354,58 @@ func jsonTagsOf(t reflect.Type) map[string]bool {
 	}
 	return out
 }
+
+// TestAgent_StaticRevealedWhenNoActiveDynamic pins the invariant behind the
+// "static agent buried under retired dynamic versions" bug: when a name has a
+// static cfg.Agents base AND substrate history but NO active pointer (the
+// v0.29.0 soft-reclaim clears the pointer when the active def is retired),
+// lookup.Agent must fall through to the STATIC def at the caller's tenant. The
+// non-active version rows in agent_defs are irrelevant to resolution — only an
+// active pointer shadows the static base.
+func TestAgent_StaticRevealedWhenNoActiveDynamic(t *testing.T) {
+	cfg := &config.Config{Agents: map[string]config.AgentDef{
+		"code-guru": {SystemPrompt: "STATIC-BASE"},
+	}}
+	// jobember has substrate history but an EMPTY active pointer (defs map has
+	// no entry for it) — mirrors the live state (v1/v4 retired, v2/v3 inactive,
+	// agent_def_active empty).
+	ss := &stubStore{
+		dyn:  map[string]store.DynamicAgent{},
+		defs: map[string]store.AgentDefRow{},
+	}
+	got, ok := lookup.Agent(context.Background(), ss, cfg, "jobember", "code-guru")
+	if !ok {
+		t.Fatal("static base must resolve when no dynamic version is active")
+	}
+	if got.SystemPrompt != "STATIC-BASE" {
+		t.Errorf("resolved %q, want the STATIC base", got.SystemPrompt)
+	}
+}
+
+// TestAgent_RetiredActivePointerFallsThroughToStatic covers the defense-in-depth
+// branch (agent.go: a retired def referenced by a stale active pointer must
+// never be served): resolution falls through to the static base instead.
+func TestAgent_RetiredActivePointerFallsThroughToStatic(t *testing.T) {
+	cfg := &config.Config{Agents: map[string]config.AgentDef{
+		"code-guru": {SystemPrompt: "STATIC-BASE"},
+	}}
+	ss := &stubStore{
+		dyn: map[string]store.DynamicAgent{},
+		defs: map[string]store.AgentDefRow{
+			stubKey("jobember", "code-guru"): {
+				DefID:      "def_codeguru_v4",
+				Name:       "code-guru",
+				Version:    4,
+				Retired:    true,
+				Definition: json.RawMessage(`{"system_prompt":"RETIRED-DYNAMIC"}`),
+			},
+		},
+	}
+	got, ok := lookup.Agent(context.Background(), ss, cfg, "jobember", "code-guru")
+	if !ok {
+		t.Fatal("must resolve to static even when the active pointer is on a retired def")
+	}
+	if got.SystemPrompt != "STATIC-BASE" {
+		t.Errorf("resolved %q, want the STATIC base (a retired def must never be served)", got.SystemPrompt)
+	}
+}

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -95,17 +95,27 @@ export default function LineagePanel({
       setSelectedDefID("");
       return;
     }
+    // The static base is shown as a synthetic "v0" row (def_id
+    // "static:<name>") built from the entry's static_definition. We surface it
+    // whenever the entry HAS a static base — not only when there are zero
+    // dynamic versions — so it stays visible + fork-from-able, and (when no
+    // dynamic version is active) it's the definition runs actually resolve to.
+    // Without this, once any dynamic version exists (even all-retired / no
+    // active pointer) the static base was buried and couldn't be edited/forked.
+    const staticRow: DefRow | null = selectedEntry.in_static
+      ? {
+          def_id: `static:${selectedEntry.name}`,
+          name: selectedEntry.name,
+          version: 0,
+          created_at: "",
+          definition: selectedEntry.static_definition,
+        }
+      : null;
+
     if (!selectedEntry.in_substrate) {
-      // Static-only — synthesize the pseudo-row inline. No network.
-      const syntheticRow: DefRow = {
-        def_id: `static:${selectedEntry.name}`,
-        name: selectedEntry.name,
-        version: 0,
-        created_at: "",
-        definition: selectedEntry.static_definition,
-      };
-      setVersions([syntheticRow]);
-      setSelectedDefID(syntheticRow.def_id);
+      // Static-only — no network; the static row is the whole lineage.
+      setVersions(staticRow ? [staticRow] : []);
+      setSelectedDefID(staticRow?.def_id ?? "");
       setVersionsLoading(false);
       setVersionsErr(null);
       return;
@@ -116,14 +126,20 @@ export default function LineagePanel({
     listDefVersionsByName(kind, selectedName)
       .then((r) => {
         if (cancelled) return;
-        setVersions(r.versions ?? []);
+        const dynVersions = r.versions ?? [];
+        // Surface the static base alongside the dynamic lineage.
+        setVersions(staticRow ? [staticRow, ...dynVersions] : dynVersions);
         setVersionsLoading(false);
-        // Pre-select the active version if available, else the
-        // highest-version (most recent) row.
+        // Pre-select the EFFECTIVE definition — what a run resolves to: the
+        // promoted dynamic version if one is active, else the static base
+        // (runtime falls through to it when no dynamic is active), else the
+        // newest dynamic row.
         if (selectedEntry.active_def_id) {
           setSelectedDefID(selectedEntry.active_def_id);
-        } else if (r.versions && r.versions.length > 0) {
-          const top = [...r.versions].sort((a, b) => b.version - a.version)[0]!;
+        } else if (staticRow) {
+          setSelectedDefID(staticRow.def_id);
+        } else if (dynVersions.length > 0) {
+          const top = [...dynVersions].sort((a, b) => b.version - a.version)[0]!;
           setSelectedDefID(top.def_id);
         } else {
           setSelectedDefID("");
@@ -141,6 +157,13 @@ export default function LineagePanel({
 
   const tree = useMemo(() => buildLineageTree(versions), [versions]);
   const activeDefID = selectedEntry?.active_def_id ?? "";
+  // When NO dynamic version is active, the static base is the definition a run
+  // resolves to — flag it "effective" in the tree. (When a dynamic version is
+  // active, activeDefID already badges it "active ★".)
+  const effectiveDefID =
+    selectedEntry && !activeDefID && selectedEntry.in_static
+      ? `static:${selectedEntry.name}`
+      : "";
 
   if (entries.length === 0) {
     return (
@@ -207,6 +230,7 @@ export default function LineagePanel({
         <LineageTree
           tree={tree}
           activeDefID={activeDefID}
+          effectiveDefID={effectiveDefID}
           selectedDefID={selectedDefID}
           onSelect={setSelectedDefID}
           renderDefinition={renderDefinition}

--- a/web/src/components/LineageTree.tsx
+++ b/web/src/components/LineageTree.tsx
@@ -43,9 +43,12 @@ export function buildLineageTree(rows: DefRow[]): LineageNode[] {
 export interface LineageTreeProps {
   tree: LineageNode[];
   // Highlight + click callback. activeDefID — the row stored in the
-  // *_def_active overlay; gets the "active ★" chip. selectedDefID —
-  // the currently-clicked row (independent of active).
+  // *_def_active overlay; gets the "active ★" chip. effectiveDefID — the
+  // row a run actually resolves to when NO dynamic version is active (the
+  // static base); gets the "effective" chip. selectedDefID — the
+  // currently-clicked row (independent of active/effective).
   activeDefID?: string;
+  effectiveDefID?: string;
   selectedDefID?: string;
   onSelect?: (defID: string) => void;
   // Inline-detail renderer (v0.9.x Library v2). When set, each row
@@ -67,6 +70,7 @@ export interface LineageTreeProps {
 export default function LineageTree({
   tree,
   activeDefID,
+  effectiveDefID,
   selectedDefID,
   onSelect,
   renderDefinition,
@@ -134,6 +138,7 @@ export default function LineageTree({
           detailExpanded={detailExpanded}
           toggleDetail={toggleDetail}
           activeDefID={activeDefID}
+          effectiveDefID={effectiveDefID}
           selectedDefID={selectedDefID}
           onSelect={onSelect}
           renderDefinition={renderDefinition}
@@ -154,6 +159,7 @@ function LineageNodeRow({
   detailExpanded,
   toggleDetail,
   activeDefID,
+  effectiveDefID,
   selectedDefID,
   onSelect,
   renderDefinition,
@@ -168,6 +174,7 @@ function LineageNodeRow({
   detailExpanded: Map<string, boolean>;
   toggleDetail: (id: string) => void;
   activeDefID?: string;
+  effectiveDefID?: string;
   selectedDefID?: string;
   onSelect?: (defID: string) => void;
   renderDefinition?: (row: DefRow) => React.ReactNode;
@@ -181,6 +188,9 @@ function LineageNodeRow({
   const isActive = node.row.def_id === activeDefID;
   const isSelected = node.row.def_id === selectedDefID;
   const row = node.row;
+  const isStatic = row.version === 0 && row.def_id.startsWith("static:");
+  // The static base is the effective definition when no dynamic is active.
+  const isEffective = isStatic && !!effectiveDefID && row.def_id === effectiveDefID;
 
   // Whole-row click toggles content visibility (when renderDefinition is
   // wired) AND records selection (highlights + auto-expands ancestors).
@@ -229,8 +239,16 @@ function LineageNodeRow({
           ) : (
             <span className="lineage-version">v{row.version}</span>
           )}
-          {row.version === 0 && row.def_id.startsWith("static:") && (
+          {isStatic && (
             <span className="def-chip def-chip-static">static</span>
+          )}
+          {isEffective && (
+            <span
+              className="def-chip def-chip-effective"
+              title="No dynamic version is active — runs resolve to this static base."
+            >
+              effective
+            </span>
           )}
           {isActive && <span className="def-chip def-chip-active">active ★</span>}
           {row.retired && <span className="def-chip def-chip-retired">retired</span>}
@@ -338,6 +356,7 @@ function LineageNodeRow({
               detailExpanded={detailExpanded}
               toggleDetail={toggleDetail}
               activeDefID={activeDefID}
+              effectiveDefID={effectiveDefID}
               selectedDefID={selectedDefID}
               onSelect={onSelect}
               renderDefinition={renderDefinition}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2936,6 +2936,15 @@ button.primary:disabled {
   color: #b08bd0;
   border: 1px solid #b08bd0;
 }
+/* The static base is the definition runs resolve to when no dynamic version
+   is active — a FILLED accent chip so it reads as "live", visually distinct
+   from the outlined "active ★" (which marks a promoted dynamic version). */
+.def-chip-effective {
+  background: var(--accent, #56c596);
+  color: #0b0b0d;
+  border: 1px solid var(--accent, #56c596);
+  font-weight: 600;
+}
 .lineage-name-chips {
   display: inline-flex;
   gap: 4px;


### PR DESCRIPTION
## Why

A static agent (`code-guru`, declared in yaml → shared tenant `""`) that had accrued dynamic substrate versions which were then retired/deactivated (no `agent_def_active` pointer — the v0.29.0 soft-reclaim clears it when the active def is retired) became **buried** in the Web UI Library: you couldn't see it, **edit its settings, or fork from it** — even though "common sense says the static should re-surface once no dynamic version is active."

**Code-verified scope:** runtime resolution already works — `lookup.Agent` walks *tenant-dynamic → static `cfg.Agents` → shared-dynamic*, and with the active pointer empty it falls through to the static (`internal/lookup/agent.go:101-117`). Every run-creation site uses it (`server.go` `lookupAgent`), and the run-form lists the agent by name. The user confirmed **the agent still starts and runs** — the failure was purely *"can't change its settings in the UI or fork from the static agent."*

**Root cause (UI only):** `LineagePanel.tsx` synthesized the static "v0" row **only when `!in_substrate`**. Once any dynamic version existed, the static row was never built, so the static base — and the already-existing **"Edit (forks from yaml)"** affordance (`LineageTree.tsx`, wired to `LibraryEditModal` → backend bootstrap in `agentdef.go`) — never appeared. The merged `LibraryEntry` already carried everything needed (`in_static`, `active_def_id: ""`, `static_definition`).

## What

- **`LineagePanel.tsx`** — build the synthetic `static:<name>` row whenever the entry has a static base (`in_static`), prepending it to the dynamic lineage instead of gating on `!in_substrate`. Compute the **effective** definition (the one a run resolves to): the active dynamic version if promoted, else the static base, else the newest version — and pre-select it.
- **`LineageTree.tsx`** — new `effectiveDefID` prop; the static row gets an **`effective`** chip (tooltip: *"No dynamic version is active — runs resolve to this static base"*) when it's the resolved def. The existing `active ★` chip still marks a promoted dynamic. Edit/Promote/Retire gates unchanged.
- **`styles.css`** — a filled accent `.def-chip-effective` chip, visually distinct from the outlined `active ★`.
- No backend change. **Regression guard** added in `internal/lookup` (`TestAgent_StaticRevealedWhenNoActiveDynamic`, `TestAgent_RetiredActivePointerFallsThroughToStatic`) pinning the "static reveals itself when nothing is active" invariant.

## What was tested

- `make build-ui` / `make build-all` — `tsc` + vite clean.
- **End-to-end visual verification** against a faithful repro on a throwaway open-mode instance (static `code-guru` + a bootstrapped v1 + a retired v2 + **empty active pointer** — seeded via fork-then-retire, mirroring the live `jobember` state): the lineage now shows the **static** row with `static` + `effective` chips and **"Edit (forks from yaml)"**, which opens the editor **pre-filled from the static base** ("Save fork"). Dynamic v1/v2 still list below. (Screenshots shared with the maintainer.)
- `go test ./...` full suite green; gofmt/vet clean.

Web-UI + one test file; no wire/schema change, no `@loomcycle/client` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)