### PR TITLE
feat(webui): interactive-session switcher on the run page + interactive tags

### DIFF
--- a/internal/api/http/agent_tracking_test.go
+++ b/internal/api/http/agent_tracking_test.go
@@ -800,3 +800,26 @@ func TestRunToAgentResponse_ReplicaIDRoundTrip(t *testing.T) {
 		}
 	})
 }
+
+// TestRunToAgentResponse_InteractiveRoundTrip pins that the run list surfaces
+// runs.interactive so the Web UI can tag interactive runs + list re-attachable
+// interactive sessions. Omitted for ordinary runs (omitempty).
+func TestRunToAgentResponse_InteractiveRoundTrip(t *testing.T) {
+	t.Run("interactive run", func(t *testing.T) {
+		resp := runToAgentResponse(store.Run{ID: "r1", AgentID: "a1", Interactive: true}, true)
+		if !resp.Interactive {
+			t.Error("Interactive = false, want true")
+		}
+		b, _ := json.Marshal(resp)
+		if !strings.Contains(string(b), `"interactive":true`) {
+			t.Errorf("JSON missing interactive:true: %s", b)
+		}
+	})
+	t.Run("ordinary run omits interactive", func(t *testing.T) {
+		resp := runToAgentResponse(store.Run{ID: "r2", AgentID: "a2"}, false)
+		b, _ := json.Marshal(resp)
+		if strings.Contains(string(b), "interactive") {
+			t.Errorf("JSON should omit interactive when false: %s", b)
+		}
+	})
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -4555,6 +4555,11 @@ type agentResponse struct {
 	Usage           agentResponseUsage `json:"usage"`
 	LastHeartbeatAt *time.Time         `json:"last_heartbeat_at,omitempty"`
 	Live            bool               `json:"live"`
+	// Interactive marks a persistent interactive run (started with
+	// interactive:true; parks at end_turn for operator steering). Surfaced
+	// from runs.interactive so the Web UI can tag interactive runs and list
+	// re-attachable interactive sessions. Omitted for ordinary runs.
+	Interactive bool `json:"interactive,omitempty"`
 	// v0.8.21 awaited-state surface — what the running agent is
 	// currently blocked on. Empty for non-running rows AND for
 	// running rows where the agent is making progress (no
@@ -4620,6 +4625,7 @@ func runToAgentResponse(r store.Run, live bool) agentResponse {
 			Provider:            r.Provider,
 		},
 		Live:          live,
+		Interactive:   r.Interactive,
 		ReplicaID:     r.ReplicaID,
 		ParentContext: r.ParentContext, // v0.12.x: echo tracking lineage alongside usage
 	}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -72,6 +72,10 @@ export interface Agent {
   };
   last_heartbeat_at: string | null;
   live: boolean;
+  // interactive marks a persistent interactive run (parks at end_turn for
+  // operator steering). Drives the run page's interactive-session switcher
+  // and the runs-page "interactive" tag. Absent/false for ordinary runs.
+  interactive?: boolean;
   // v0.8.21 awaited-state surface. Empty/absent for non-running
   // runs AND for running runs making normal progress. When set,
   // `awaited_state` is "channel" (open Channel.subscribe) or

--- a/web/src/components/AgentDetailPane.tsx
+++ b/web/src/components/AgentDetailPane.tsx
@@ -149,6 +149,11 @@ export default function AgentDetailPane({ agentId, ancestors, onSelect }: AgentD
         <div className="agent-header">
           <div className="line1">
             <span className={`pill ${agent.status}`}>{agent.status}</span>
+            {agent.interactive && (
+              <span className="pill-interactive" title="Interactive session — parks for operator steering; re-attachable in the run terminal">
+                interactive
+              </span>
+            )}
             <strong>{agent.agent || "(unknown agent)"}</strong>
             <code className="agent-id">{agent.agent_id}</code>
             {agent.status === "running" && (

--- a/web/src/components/AgentsTree.tsx
+++ b/web/src/components/AgentsTree.tsx
@@ -170,6 +170,11 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
           {hasChildren ? (expanded ? "▼" : "▶") : "·"}
         </button>
         <span className={`pill ${a.status}`}>{a.status}</span>
+        {a.interactive && (
+          <span className="pill-interactive" title="Interactive session — parks for operator steering; re-attachable in the run terminal">
+            interactive
+          </span>
+        )}
         {onSelect ? (
           <button
             type="button"

--- a/web/src/components/InteractiveSessionsPanel.tsx
+++ b/web/src/components/InteractiveSessionsPanel.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useState } from "react";
+import { listAgents, type Agent } from "../api";
+
+// Persisted collapse state so the operator's choice survives navigation.
+const COLLAPSE_KEY = "loomcycle.run.interactive-sessions.collapsed";
+const POLL_MS = 4000;
+
+// InteractiveSessionsPanel lists the operator's RUNNING interactive sessions in
+// the run page's left column, so they can switch between sessions or re-open one
+// they left — without detouring through the runs page "resume in terminal" link.
+//
+// Source: listAgents(userId, "running") filtered to interactive runs (the
+// runs.interactive flag, surfaced on the run-list row). Clicking a row
+// re-attaches it in the run terminal (onOpen → useRunStream.attach, which
+// replays from seq 0 then live-tails). Collapsible; collapsed it shows just the
+// "N interactive sessions" header.
+export default function InteractiveSessionsPanel({
+  userId,
+  currentRunId,
+  onOpen,
+}: {
+  userId: string;
+  currentRunId?: string;
+  onOpen: (runId: string) => void;
+}) {
+  const [sessions, setSessions] = useState<Agent[]>([]);
+  const [collapsed, setCollapsed] = useState<boolean>(
+    () => localStorage.getItem(COLLAPSE_KEY) === "1",
+  );
+  useEffect(() => {
+    localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+
+  const refresh = useCallback(() => {
+    if (!userId) {
+      setSessions([]);
+      return;
+    }
+    listAgents(userId, "running")
+      .then((r) => setSessions((r.agents ?? []).filter((a) => a.interactive)))
+      .catch(() => {
+        /* transient poll failure — keep the last good list */
+      });
+  }, [userId]);
+
+  useEffect(() => {
+    refresh();
+    const id = window.setInterval(refresh, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  // No user context → nothing to list (admins without a picked user, etc.).
+  if (!userId) return null;
+
+  const count = sessions.length;
+  return (
+    <div
+      className={
+        "interactive-sessions" + (collapsed ? " interactive-sessions-collapsed" : "")
+      }
+    >
+      <button
+        type="button"
+        className="interactive-sessions-head"
+        onClick={() => setCollapsed((c) => !c)}
+        aria-expanded={!collapsed}
+        title={collapsed ? "Show interactive sessions" : "Hide interactive sessions"}
+      >
+        <span className="interactive-sessions-caret" aria-hidden="true">
+          {collapsed ? "▸" : "▾"}
+        </span>
+        <span className="interactive-sessions-title">
+          {count} interactive session{count === 1 ? "" : "s"}
+        </span>
+      </button>
+      {!collapsed && (
+        <div className="interactive-sessions-list">
+          {count === 0 ? (
+            <div className="interactive-sessions-empty">No interactive sessions.</div>
+          ) : (
+            sessions.map((s) => {
+              const isCurrent = !!currentRunId && s.run_id === currentRunId;
+              return (
+                <button
+                  key={s.run_id}
+                  type="button"
+                  className={
+                    "interactive-session-row" +
+                    (isCurrent ? " interactive-session-current" : "")
+                  }
+                  onClick={() => onOpen(s.run_id)}
+                  disabled={isCurrent}
+                  title={
+                    isCurrent ? "Currently open" : `Open ${s.agent} in the terminal`
+                  }
+                >
+                  <span className="interactive-session-agent">
+                    {s.agent || "(unknown agent)"}
+                  </span>
+                  <code className="interactive-session-runid">
+                    {s.run_id.slice(0, 12)}…
+                  </code>
+                  {isCurrent && <span className="pill-interactive">open</span>}
+                </button>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -5,6 +5,7 @@ import { useUserId } from "../components/Layout";
 import { useRunStream } from "../hooks/useRunStream";
 import RunForm from "../components/RunForm";
 import LiveRunPane from "../components/LiveRunPane";
+import InteractiveSessionsPanel from "../components/InteractiveSessionsPanel";
 import FanOutForm from "../components/FanOutForm";
 import EnsembleDashboard from "../components/EnsembleDashboard";
 import OrchestratorView from "../components/OrchestratorView";
@@ -118,6 +119,11 @@ function SingleRunTab({
   return (
     <div className="run-view-body">
       <div className="run-view-form-col">
+        <InteractiveSessionsPanel
+          userId={defaultUserId}
+          currentRunId={run.runId}
+          onOpen={run.attach}
+        />
         <RunForm
           agents={agents}
           defaultUserId={defaultUserId}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4152,12 +4152,107 @@ button.primary:disabled {
   width: 380px;
   flex: 0 0 380px;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 .run-view-pane-col {
   flex: 1;
   min-width: 0;
   min-height: 0;
   display: flex;
+}
+
+/* Interactive-sessions switcher — a collapsible list at the top of the run
+   page's left column. Lets the operator switch between / re-open running
+   interactive sessions without the runs-page "resume in terminal" detour. */
+.interactive-sessions {
+  flex: 0 0 auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.interactive-sessions-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  text-align: left;
+}
+.interactive-sessions-caret {
+  color: var(--fg-soft, #9aa);
+}
+.interactive-sessions-title {
+  font-weight: 600;
+}
+.interactive-sessions-list {
+  max-height: 33vh;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.interactive-sessions-empty {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--fg-soft, #9aa);
+}
+.interactive-session-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+.interactive-session-row:hover:not(:disabled) {
+  background: rgba(125, 165, 220, 0.08);
+  border-color: var(--border);
+}
+.interactive-session-current {
+  border-color: var(--accent);
+  background: rgba(86, 197, 150, 0.1);
+  cursor: default;
+}
+.interactive-session-agent {
+  font-weight: 600;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.interactive-session-runid {
+  color: var(--fg-soft, #9aa);
+  font-size: 11px;
+}
+
+/* "interactive" tag — runs page (tree row + detail header) + the
+   current-session marker in the switcher. Loom-wood accent. */
+.pill-interactive {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 10px;
+  text-transform: lowercase;
+  letter-spacing: 0.03em;
+  background: rgba(86, 197, 150, 0.15);
+  color: var(--accent, #56c596);
+  border: 1px solid var(--accent, #56c596);
 }
 .run-form-advanced {
   margin: 8px 0;


### PR DESCRIPTION
## Why

An interactive run survives leaving the `/run` terminal (v0.27.0 background execution + re-attach), but the only way back was the **runs page → "resume in terminal"** link — easy to miss, and a detour off the run page. Operators juggling several interactive sessions couldn't see or switch between them. Nothing distinguished interactive runs in the runs list either.

## What

**Backend (additive, 2 lines + test):** `runs.interactive` is already persisted and scanned into `store.Run.Interactive` by the run-list query — but `agentResponse` dropped it. Surface `interactive` (omitempty) on `GET /v1/users/{id}/agents`.

**Run page — interactive-session switcher** (`InteractiveSessionsPanel`, new): a collapsible list in the left column of the Single tab, above the run form. Polls `listAgents(userId, "running")` filtered to interactive runs; each row (agent name + short run_id) re-attaches in the terminal on click via the existing `useRunStream.attach` (replay-from-seq-0 + live-tail). The currently-attached session is marked **open** (disabled). Collapsed → just `N interactive sessions`; collapse state persisted in localStorage. The expanded list caps at ~1/3 of the column height with inner scroll.

**Runs page — interactive tag:** an **`interactive`** chip next to the status pill in `AgentsTree` rows and the `AgentDetailPane` header, driven by the new `Agent.interactive` field.

No `@loomcycle/client` change (the Web UI uses its own `api.ts`); the run-list field is additive.

## What was tested

- `make build-ui` / `make build` clean (`tsc` passes); `go test ./...` full suite green; gofmt clean.
- Backend: `TestRunToAgentResponse_InteractiveRoundTrip`.
- **End-to-end** on a throwaway open-mode instance (mock provider, 2 interactive runs that park at `awaiting_input`):
  - left column shows **"2 interactive sessions"** with both rows;
  - clicking a row **re-attaches** that run in the terminal (full replay → "idle — waiting for your input") and marks it **open**;
  - the header **collapses** to "2 interactive sessions";
  - the runs page shows the **interactive** tag on both running runs.
  - (Screenshots shared with the maintainer.)

Web-UI + one additive backend field; no wire-breaking change, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)