### PR TITLE
feat(ollama): report the model's actual loaded context window from /api/ps

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1509,7 +1509,12 @@ outerLoop:
 			// used / max" gauge. Set on iterUsage (discarded after this
 			// iteration) NOT totalUsage, so the run-final accounting stays
 			// byte-stable; 0 when the provider reports an unknown window.
-			iterUsage.MaxContextTokens = opts.Provider.Capabilities().MaxContextTokens
+			// A driver may already report a per-CALL window (e.g. Ollama
+			// reads the model's actual loaded context from /api/ps) — prefer
+			// that and only fall back to the static capability default.
+			if iterUsage.MaxContextTokens == 0 {
+				iterUsage.MaxContextTokens = opts.Provider.Capabilities().MaxContextTokens
+			}
 			emit(providers.Event{Type: providers.EventUsage, Usage: iterUsage})
 			// Retain this turn's CURRENT context footprint (input + cache, i.e.
 			// what the request actually sent — NOT cumulative totalUsage, which

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	lcotel "github.com/denn-gubsky/loomcycle/internal/otel"
@@ -51,6 +52,11 @@ type Driver struct {
 	http        *http.Client
 	idleTimeout time.Duration
 	numCtx      int // 0 = omit (Ollama server default applies)
+	// ctxCache memoises each model's loaded context window read from
+	// /api/ps (model name → ctxCacheEntry), so the gauge lookup costs one
+	// cheap request per model, not per turn. Concurrent-safe (the Driver is
+	// shared across runs).
+	ctxCache sync.Map
 }
 
 // New constructs a Driver.
@@ -113,6 +119,83 @@ func (d *Driver) WithNumCtx(n int) *Driver {
 	return d
 }
 
+// ctxCacheEntry caches a model's loaded context window (from /api/ps) with a
+// short TTL so a model reloaded at a different num_ctx is eventually picked up.
+type ctxCacheEntry struct {
+	ctx int
+	at  time.Time
+}
+
+const ctxCacheTTL = 5 * time.Minute
+
+// contextWindow returns the model's effective input window to stamp on the
+// usage event so the UI context gauge is truthful for local models.
+//
+//   - An explicit operator num_ctx (WithNumCtx / LOOMCYCLE_OLLAMA*_NUM_CTX)
+//     wins — it's exact and is precisely what we send as options.num_ctx.
+//   - Otherwise we ask Ollama what the model is ACTUALLY loaded with via
+//     /api/ps. Ollama only publishes context_length once the model is in VRAM
+//     (it's absent while loading), so this returns 0 ("unknown") until the
+//     first turn after a load, then the real window. Cached per model.
+//
+// Called at the stream's done frame — the model is loaded by then — so the
+// turn that loaded the model already reports the real window; later turns hit
+// the cache. 0 leaves the gauge showing only the absolute used size, unchanged.
+func (d *Driver) contextWindow(model string) int {
+	if d.numCtx > 0 {
+		return d.numCtx
+	}
+	if v, ok := d.ctxCache.Load(model); ok {
+		if e := v.(ctxCacheEntry); e.ctx > 0 && time.Since(e.at) < ctxCacheTTL {
+			return e.ctx
+		}
+	}
+	n := d.queryLoadedContext(model)
+	if n > 0 {
+		d.ctxCache.Store(model, ctxCacheEntry{ctx: n, at: time.Now()})
+	}
+	return n
+}
+
+// queryLoadedContext reads the loaded model's context_length from Ollama's
+// /api/ps. Best-effort with a short timeout: this only feeds the gauge, never
+// correctness, so any failure (loading, network, old Ollama) returns 0.
+func (d *Driver) queryLoadedContext(model string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	httpReq, err := http.NewRequestWithContext(ctx, "GET", d.baseURL+"/api/ps", nil)
+	if err != nil {
+		return 0
+	}
+	if d.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+	}
+	resp, err := d.http.Do(httpReq)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0
+	}
+	var body struct {
+		Models []struct {
+			Name          string `json:"name"`
+			Model         string `json:"model"`
+			ContextLength int    `json:"context_length"`
+		} `json:"models"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return 0
+	}
+	for _, m := range body.Models {
+		if m.Name == model || m.Model == model {
+			return m.ContextLength
+		}
+	}
+	return 0
+}
+
 func (d *Driver) ID() string { return d.providerID }
 
 func (d *Driver) Capabilities() providers.Capabilities {
@@ -120,12 +203,12 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		NativePromptCache: false,
 		ParallelToolCalls: true, // model-dependent; we report the optimistic case
 		Streaming:         true,
-		// The real per-model window varies wildly and the driver is
-		// model-agnostic, so we can't name it from here. But when the
-		// operator pins options.num_ctx (WithNumCtx / LOOMCYCLE_OLLAMA*_NUM_CTX)
-		// that IS the input window every request runs in — report it so the
-		// interactive terminal's context gauge can render used/max/%. 0 (no
-		// num_ctx) stays "unknown" and the gauge shows only the absolute size.
+		// Static fallback only. The authoritative per-call window is set on
+		// the usage event by the stream path (contextWindow → /api/ps reads
+		// the model's ACTUAL loaded context); the loop prefers that and falls
+		// back here. When the operator pins options.num_ctx (WithNumCtx /
+		// LOOMCYCLE_OLLAMA*_NUM_CTX) that is the exact window; else 0 here
+		// ("unknown") and the per-call /api/ps value fills it in once loaded.
 		MaxContextTokens: d.numCtx,
 		SupportsThinking: false,
 		// Ollama has no operator-controlled thinking-budget knob today.
@@ -206,7 +289,9 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	out := make(chan providers.Event, 16)
 	go func() {
 		defer cancelStream()
-		streamEvents(streamCtx, resp.Body, out, len(req.Tools) > 0)
+		// maxCtxFn is evaluated lazily at the done frame (model loaded by
+		// then) so the usage event carries the model's real loaded window.
+		streamEvents(streamCtx, resp.Body, out, len(req.Tools) > 0, func() int { return d.contextWindow(req.Model) })
 	}()
 	return out, nil
 }
@@ -409,7 +494,9 @@ type chunkToolCallFn struct {
 	Arguments json.RawMessage `json:"arguments"`
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, wantTools bool) {
+// maxCtxFn (optional) returns the model's effective context window; called
+// once at the done frame to stamp usage.MaxContextTokens. nil → not stamped.
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, wantTools bool, maxCtxFn func() int) {
 	defer body.Close()
 	defer close(out)
 
@@ -530,6 +617,9 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 					InputTokens:  c.PromptEvalCount,
 					OutputTokens: c.EvalCount,
 					Model:        model,
+				}
+				if maxCtxFn != nil {
+					usage.MaxContextTokens = maxCtxFn()
 				}
 			}
 		}

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -18,10 +18,16 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
-// fakeStream serves a canned NDJSON script as one /api/chat response.
+// fakeStream serves a canned NDJSON script as one /api/chat response. It also
+// answers the driver's best-effort /api/ps context-window probe with an empty
+// model list (→ window "unknown"/0), so streamEvents' usage stamp doesn't error.
 func fakeStream(t *testing.T, frames []string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		if r.URL.Path != "/api/chat" {
 			t.Errorf("path = %q, want /api/chat", r.URL.Path)
 		}
@@ -155,6 +161,10 @@ func TestStreamToolCallOnNonFinalFrame(t *testing.T) {
 func TestRequestBodyShape(t *testing.T) {
 	var captured []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		captured, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
@@ -217,6 +227,10 @@ func TestRequestBodyShape(t *testing.T) {
 func TestRequestBody_NumCtxOmittedByDefault(t *testing.T) {
 	var captured []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		captured, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
@@ -262,6 +276,10 @@ func TestCapabilities_MaxContextTokensReflectsNumCtx(t *testing.T) {
 func TestRequestBody_NumCtxPropagated(t *testing.T) {
 	var captured []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		captured, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
@@ -298,6 +316,10 @@ func TestRequestBody_NumCtxPropagated(t *testing.T) {
 func TestRequestBody_NumCtxCombinesWithTemperatureAndMaxTokens(t *testing.T) {
 	var captured []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		captured, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/x-ndjson")
 		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
@@ -411,6 +433,10 @@ func TestRetryOn429PreservesContext(t *testing.T) {
 		callNum int
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" { // best-effort gauge probe — don't count
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
 		body, _ := io.ReadAll(r.Body)
 		mu.Lock()
 		callNum++
@@ -716,4 +742,67 @@ func TestStreamCoalesceFlushesOnNewline(t *testing.T) {
 func jsonString(s string) string {
 	b, _ := json.Marshal(s)
 	return string(b)
+}
+
+// TestUsage_MaxContextTokensFromLoadedContext pins that the driver reports the
+// model's ACTUAL loaded context window (read from /api/ps) on the usage event —
+// so the UI gauge is truthful for local models with no explicit num_ctx. An
+// operator num_ctx still wins (exact), and a not-yet-loaded model (absent from
+// /api/ps) reports 0 ("unknown"). Fail-before: the driver never set
+// usage.MaxContextTokens, so a direct Call always reported 0.
+func TestUsage_MaxContextTokensFromLoadedContext(t *testing.T) {
+	chatFrames := `{"model":"qwen3.6:27b","message":{"role":"assistant","content":"ok"},"done":false}` + "\n" +
+		`{"model":"qwen3.6:27b","message":{"role":"assistant","content":""},"done":true,"done_reason":"stop","prompt_eval_count":10,"eval_count":2}` + "\n"
+	newSrv := func(psBody string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/api/ps" {
+				fmt.Fprint(w, psBody)
+				return
+			}
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			fmt.Fprint(w, chatFrames)
+		}))
+	}
+	runCall := func(t *testing.T, d *Driver) *providers.Usage {
+		t.Helper()
+		ch, err := d.Call(context.Background(), providers.Request{
+			Model:    "qwen3.6:27b",
+			Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+		})
+		if err != nil {
+			t.Fatalf("Call: %v", err)
+		}
+		var u *providers.Usage
+		for ev := range ch {
+			if ev.Type == providers.EventDone {
+				u = ev.Usage
+			}
+		}
+		if u == nil {
+			t.Fatal("no usage on done")
+		}
+		return u
+	}
+
+	t.Run("loaded context from /api/ps", func(t *testing.T) {
+		srv := newSrv(`{"models":[{"name":"qwen3.6:27b","context_length":131072}]}`)
+		defer srv.Close()
+		if u := runCall(t, New("ollama-local", "", srv.URL, streamhttp.Options{}, nil)); u.MaxContextTokens != 131072 {
+			t.Errorf("MaxContextTokens = %d, want 131072 (from /api/ps)", u.MaxContextTokens)
+		}
+	})
+	t.Run("explicit num_ctx wins", func(t *testing.T) {
+		srv := newSrv(`{"models":[{"name":"qwen3.6:27b","context_length":131072}]}`)
+		defer srv.Close()
+		if u := runCall(t, New("ollama-local", "", srv.URL, streamhttp.Options{}, nil).WithNumCtx(32768)); u.MaxContextTokens != 32768 {
+			t.Errorf("MaxContextTokens = %d, want 32768 (operator num_ctx wins)", u.MaxContextTokens)
+		}
+	})
+	t.Run("model not loaded reports 0", func(t *testing.T) {
+		srv := newSrv(`{"models":[]}`)
+		defer srv.Close()
+		if u := runCall(t, New("ollama-local", "", srv.URL, streamhttp.Options{}, nil)); u.MaxContextTokens != 0 {
+			t.Errorf("MaxContextTokens = %d, want 0 (model not in /api/ps)", u.MaxContextTokens)
+		}
+	})
 }


### PR DESCRIPTION
## Why

The interactive context gauge for `ollama-local` could only show a window when the operator set `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` (which the v0.34.4 change reports as `MaxContextTokens`). But that static knob is also sent as `options.num_ctx` on every request — so it both **caps** and **reports** the context, overriding whatever ollama is actually configured for.

Operator's case: `qwen3.6:27b` is trained for 256K and ollama loads it at **128K** (`OLLAMA_CONTEXT_LENGTH`), but loomcycle was forcing/reporting 32K. After removing the static knob, ollama loads at the real 128K — but loomcycle then reported "unknown" (num_ctx=0). As the operator noted, **ollama only publishes the final context size once the model is loaded into VRAM** (it's absent/0 while loading), via `GET /api/ps` → `context_length`.

## What

The ollama driver now reports the model's **actual loaded context**:
- At the stream's **done frame** (model is loaded by then), it reads `context_length` from **`/api/ps`** for the served model and stamps it on the usage event.
- Precedence: an explicit `num_ctx` (`WithNumCtx` / `LOOMCYCLE_OLLAMA*_NUM_CTX`) still **wins** (exact, no probe); otherwise the live `/api/ps` value; **0 while loading / on any failure** ("unknown" — gauge shows just the used size, unchanged).
- **Cached per model** (5-min TTL) so it's one cheap request per model, not per turn; best-effort with a **2s timeout** — it only feeds the gauge, never correctness.
- The **loop** now prefers a driver-reported per-call `MaxContextTokens` over the static `Capabilities()` default (`if iterUsage.MaxContextTokens == 0 { … }`). Other providers are unaffected — they don't set it, so they still fall back to `Capabilities()`.

Verified live against denn-desktop's ollama: `/api/ps` reports `context_length` (gemma4:e4b loaded at `131072`).

## What was tested

- **`TestUsage_MaxContextTokensFromLoadedContext`** (fail-before — the driver never set `usage.MaxContextTokens`, so a direct `Call` reported 0): covers the `/api/ps` window (131072), `num_ctx`-wins (32768), and model-not-loaded → 0. The existing ollama test fakes now answer the `/api/ps` probe.
- Full `go test ./...` green; `gofmt`/`go vet` clean.

Runtime-only (ollama driver + a 3-line loop preference); no wire/schema change (the `max_context_tokens` usage field already exists), no `@loomcycle/client` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)