### PR TITLE
feat(config): model aliases in tier candidates — parse, validate, resolve (YAML + Web UI)

### DIFF
--- a/cmd/loomcycle/alias_test.go
+++ b/cmd/loomcycle/alias_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+)
+
+// TestConvertTiers_ExpandsAlias locks the resolver-boundary expansion for the
+// library tiers: fallback (cfg.Tiers). A candidate whose model is an alias in
+// the top-level models: map is rewritten to its concrete provider/model
+// before the resolver sees it; a literal candidate is unchanged.
+func TestConvertTiers_ExpandsAlias(t *testing.T) {
+	models := map[string]config.ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+	in := map[string][]config.TierCandidate{
+		"low": {
+			{Provider: "ollama-local", Model: "local-gemma"},   // alias
+			{Provider: "anthropic", Model: "claude-haiku-4-5"}, // literal
+		},
+	}
+	got := convertTiers(in, models)
+	want := []resolve.Candidate{
+		{Provider: "ollama-local", Model: "gemma4:max"},
+		{Provider: "anthropic", Model: "claude-haiku-4-5"},
+	}
+	low := got["low"]
+	if len(low) != len(want) {
+		t.Fatalf("low candidates = %d, want %d (%+v)", len(low), len(want), low)
+	}
+	for i := range want {
+		if low[i] != want[i] {
+			t.Errorf("candidate[%d] = %+v, want %+v", i, low[i], want[i])
+		}
+	}
+}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2582,7 +2582,7 @@ func (p *providerResolver) Get(id string) (providers.Provider, error) {
 // Subsequent rounds run in a background goroutine started by main —
 // see runResolveProbeLoop.
 func buildResolver(cfg *config.Config, pr *providerResolver) *resolve.Resolver {
-	libraryTiers := convertTiers(cfg.Tiers)
+	libraryTiers := convertTiers(cfg.Tiers, cfg.Models)
 	r := resolve.NewResolver(cfg.ProviderPriority, libraryTiers)
 
 	// First-round probe — synchronous, so the matrix is hot before
@@ -2703,7 +2703,7 @@ func runResolveProbeLoop(ctx context.Context, r *resolve.Resolver, pr *providerR
 // tier definitions into the resolver-package representation. Mirrors
 // the per-agent helper in internal/api/http/server.go but operates on
 // the top-level cfg.Tiers map.
-func convertTiers(in map[string][]config.TierCandidate) map[string][]resolve.Candidate {
+func convertTiers(in map[string][]config.TierCandidate, models map[string]config.ModelRef) map[string][]resolve.Candidate {
 	if len(in) == 0 {
 		return nil
 	}
@@ -2711,7 +2711,11 @@ func convertTiers(in map[string][]config.TierCandidate) map[string][]resolve.Can
 	for tier, cands := range in {
 		conv := make([]resolve.Candidate, 0, len(cands))
 		for _, c := range cands {
-			conv = append(conv, resolve.Candidate{Provider: c.Provider, Model: c.Model})
+			// Expand model aliases (top-level models:) — mirrors the pin
+			// path and the per-agent converter so a library tier candidate
+			// can name an alias too.
+			prov, mdl := config.ExpandModelAlias(models, c.Provider, c.Model)
+			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl})
 		}
 		out[tier] = conv
 	}

--- a/internal/api/http/alias_expansion_test.go
+++ b/internal/api/http/alias_expansion_test.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+)
+
+// TestConvertConfigCandidates_ExpandsAlias locks the resolver-boundary
+// expansion for per-agent / user-tier candidates: a candidate whose model is
+// an alias in the top-level models: map is rewritten to the alias's concrete
+// provider/model before it reaches the resolver (which matches literal model
+// strings). A literal (non-alias) candidate passes through unchanged.
+func TestConvertConfigCandidates_ExpandsAlias(t *testing.T) {
+	models := map[string]config.ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+	in := map[string][]config.TierCandidate{
+		"low": {
+			{Provider: "ollama-local", Model: "local-gemma"},   // alias
+			{Provider: "anthropic", Model: "claude-haiku-4-5"}, // literal
+		},
+	}
+	got := convertConfigCandidates(in, models)
+	want := []resolve.Candidate{
+		{Provider: "ollama-local", Model: "gemma4:max"},
+		{Provider: "anthropic", Model: "claude-haiku-4-5"},
+	}
+	low := got["low"]
+	if len(low) != len(want) {
+		t.Fatalf("low candidates = %d, want %d (%+v)", len(low), len(want), low)
+	}
+	for i := range want {
+		if low[i] != want[i] {
+			t.Errorf("candidate[%d] = %+v, want %+v", i, low[i], want[i])
+		}
+	}
+}
+
+// TestResolveAgentDef_TierCandidateAliasExpands is the end-to-end repro of the
+// 503 "no provider available for requested tier": a tier-based agent whose
+// candidate names a models: alias must resolve to the alias's concrete
+// provider/model. Fail-before: drop the ExpandModelAlias call in
+// convertConfigCandidates and the candidate model stays "local-gemma", which
+// the resolver never marks available → this test fails with a resolve error.
+func TestResolveAgentDef_TierCandidateAliasExpands(t *testing.T) {
+	r := resolve.NewResolver([]string{"ollama-local"}, nil)
+	// Only the concrete model is ever reachable — the alias name is not.
+	r.SetReachable("ollama-local", true, []string{"gemma4:max"}, "")
+
+	s := minimalServerWithResolver(t, r)
+	s.cfg.Models = map[string]config.ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+
+	def := config.AgentDef{
+		Tier: "low",
+		Models: map[string][]config.TierCandidate{
+			"low": {{Provider: "ollama-local", Model: "local-gemma"}},
+		},
+	}
+	prov, model, _, err := s.resolveAgentDef(def, "code-reviewer", "")
+	if err != nil {
+		t.Fatalf("resolveAgentDef returned error: %v", err)
+	}
+	if prov != "ollama-local" || model != "gemma4:max" {
+		t.Fatalf("resolved (%q, %q), want (ollama-local, gemma4:max)", prov, model)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -958,7 +958,7 @@ func (s *Server) resolveAgentDef(def config.AgentDef, agentName, userTier string
 			Tier:      def.Tier,
 			Effort:    def.Effort,
 			Providers: def.Providers,
-			Models:    convertConfigCandidates(def.Models),
+			Models:    convertConfigCandidates(def.Models, s.cfg.Models),
 			UserTier:  s.userTierOverlay(userTier),
 		}
 		dec, rerr := s.resolver.Resolve(req)
@@ -1008,7 +1008,7 @@ func (s *Server) userTierOverlay(name string) *resolve.UserTierOverlay {
 	return &resolve.UserTierOverlay{
 		Name:                name,
 		ProviderPriority:    ut.ProviderPriority,
-		Tiers:               convertConfigCandidates(ut.Tiers),
+		Tiers:               convertConfigCandidates(ut.Tiers, s.cfg.Models),
 		FallbackOnError:     ut.FallbackOnError,
 		MaxFallbackAttempts: ut.MaxFallbackAttempts,
 		RetryAttempts:       ut.RetryAttempts,
@@ -1515,7 +1515,7 @@ func (s *Server) fallbackForRun(tenantID, agentName, userTier string) (loop.Fall
 // Keeping the resolver package free of internal/config imports avoids
 // circularity (resolver is consumed by the HTTP server, which already
 // depends on config).
-func convertConfigCandidates(in map[string][]config.TierCandidate) map[string][]resolve.Candidate {
+func convertConfigCandidates(in map[string][]config.TierCandidate, models map[string]config.ModelRef) map[string][]resolve.Candidate {
 	if len(in) == 0 {
 		return nil
 	}
@@ -1523,7 +1523,12 @@ func convertConfigCandidates(in map[string][]config.TierCandidate) map[string][]
 	for tier, cands := range in {
 		conv := make([]resolve.Candidate, 0, len(cands))
 		for _, c := range cands {
-			conv = append(conv, resolve.Candidate{Provider: c.Provider, Model: c.Model})
+			// Expand model aliases (top-level models:) the same way the
+			// pin path does — so model: <alias> works in a tier candidate
+			// too, not only as a pin. The resolver matches literal model
+			// strings, so expansion must happen here at the boundary.
+			prov, mdl := config.ExpandModelAlias(models, c.Provider, c.Model)
+			conv = append(conv, resolve.Candidate{Provider: prov, Model: mdl})
 		}
 		out[tier] = conv
 	}

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -1,6 +1,38 @@
 package config
 
-import "testing"
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TestTierCandidate_UnmarshalYAML_BareStringIsModel locks the bare-string
+// authoring form: `- local-qwen` parses to {Provider:"", Model:"local-qwen"}
+// (the alias supplies the provider downstream via ExpandModelAlias), while the
+// mapping form still works. Fail-before: without the custom UnmarshalYAML, a
+// bare scalar fails with "cannot unmarshal !!str into config.TierCandidate".
+func TestTierCandidate_UnmarshalYAML_BareStringIsModel(t *testing.T) {
+	var doc struct {
+		Tiers map[string][]TierCandidate `yaml:"tiers"`
+	}
+	src := "tiers:\n" +
+		"  middle:\n" +
+		"    - local-qwen\n" +
+		"    - { provider: deepseek, model: deepseek-v4-pro }\n"
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	mid := doc.Tiers["middle"]
+	if len(mid) != 2 {
+		t.Fatalf("got %d candidates, want 2 (%+v)", len(mid), mid)
+	}
+	if mid[0] != (TierCandidate{Provider: "", Model: "local-qwen"}) {
+		t.Errorf("bare candidate = %+v, want {Provider: Model:local-qwen}", mid[0])
+	}
+	if mid[1] != (TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}) {
+		t.Errorf("mapping candidate = %+v", mid[1])
+	}
+}
 
 // TestExpandModelAlias_* lock the single source of truth for model-alias
 // expansion shared by the pin path (ResolveAgentDefModel) and the tier path

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+// TestExpandModelAlias_* lock the single source of truth for model-alias
+// expansion shared by the pin path (ResolveAgentDefModel) and the tier path
+// (the resolver-boundary converters). Each behaviour is the same rule the pin
+// path always used; the regression these guard is the tier path NOT honouring
+// aliases, which produced a 503 "no provider available for requested tier".
+func TestExpandModelAlias_ExpandsModelAndFillsEmptyProvider(t *testing.T) {
+	models := map[string]ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+	prov, mdl := ExpandModelAlias(models, "", "local-gemma")
+	if prov != "ollama-local" || mdl != "gemma4:max" {
+		t.Fatalf("got (%q, %q), want (ollama-local, gemma4:max)", prov, mdl)
+	}
+}
+
+func TestExpandModelAlias_ExplicitProviderWins(t *testing.T) {
+	// A candidate that names both a provider and an alias keeps its explicit
+	// provider — the alias only fills an EMPTY provider, mirroring the pin
+	// path. The model is still expanded.
+	models := map[string]ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+	prov, mdl := ExpandModelAlias(models, "openai", "local-gemma")
+	if prov != "openai" || mdl != "gemma4:max" {
+		t.Fatalf("got (%q, %q), want (openai, gemma4:max)", prov, mdl)
+	}
+}
+
+func TestExpandModelAlias_NonAliasIsLiteralNoop(t *testing.T) {
+	models := map[string]ModelRef{
+		"local-gemma": {Provider: "ollama-local", Model: "gemma4:max"},
+	}
+	prov, mdl := ExpandModelAlias(models, "anthropic", "claude-sonnet-4-6")
+	if prov != "anthropic" || mdl != "claude-sonnet-4-6" {
+		t.Fatalf("got (%q, %q), want (anthropic, claude-sonnet-4-6)", prov, mdl)
+	}
+}
+
+func TestExpandModelAlias_NilMapNoop(t *testing.T) {
+	prov, mdl := ExpandModelAlias(nil, "ollama-local", "local-gemma")
+	if prov != "ollama-local" || mdl != "local-gemma" {
+		t.Fatalf("got (%q, %q), want (ollama-local, local-gemma)", prov, mdl)
+	}
+}

--- a/internal/config/alias_test.go
+++ b/internal/config/alias_test.go
@@ -34,6 +34,32 @@ func TestTierCandidate_UnmarshalYAML_BareStringIsModel(t *testing.T) {
 	}
 }
 
+// TestValidateTierCandidate_AliasAware locks the config-load carve-out: a bare
+// alias (empty provider, model is a defined models: alias) passes validation
+// because the alias supplies the provider at resolve time. Fail-before:
+// without the carve-out, an empty-provider candidate fails `unknown provider
+// ""` and an all-aliases tier list won't load.
+func TestValidateTierCandidate_AliasAware(t *testing.T) {
+	models := map[string]ModelRef{
+		"local-qwen": {Provider: "ollama-local", Model: "qwen3.6:max"},
+	}
+	if err := validateTierCandidate(TierCandidate{Model: "local-qwen"}, models); err != nil {
+		t.Errorf("bare alias rejected: %v", err)
+	}
+	if err := validateTierCandidate(TierCandidate{Model: "not-an-alias"}, models); err == nil {
+		t.Error("empty provider + non-alias model accepted, want error")
+	}
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek", Model: "deepseek-v4-pro"}, models); err != nil {
+		t.Errorf("explicit literal candidate rejected: %v", err)
+	}
+	if err := validateTierCandidate(TierCandidate{Provider: "bogus", Model: "x"}, models); err == nil {
+		t.Error("unknown provider accepted, want error")
+	}
+	if err := validateTierCandidate(TierCandidate{Provider: "deepseek"}, models); err == nil {
+		t.Error("explicit provider + empty model accepted, want error")
+	}
+}
+
 // TestExpandModelAlias_* lock the single source of truth for model-alias
 // expansion shared by the pin path (ResolveAgentDefModel) and the tier path
 // (the resolver-boundary converters). Each behaviour is the same rule the pin

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3921,6 +3921,28 @@ func validateStaticWebhook(name string, w Webhook) error {
 	return nil
 }
 
+// validateTierCandidate checks one tier candidate at config-load. A candidate
+// may name a models: alias as a bare model with an empty provider — the alias
+// supplies the provider at resolve time (ExpandModelAlias) — so an empty
+// provider is valid IFF the model is a defined alias. Otherwise the provider
+// must be a known ID and the model non-empty. Without the alias carve-out an
+// all-aliases tier list fails load with `unknown provider ""`.
+func validateTierCandidate(cand TierCandidate, models map[string]ModelRef) error {
+	if cand.Provider == "" {
+		if _, ok := models[cand.Model]; !ok {
+			return fmt.Errorf("empty provider and %q is not a model alias (define it under models: or set an explicit provider)", cand.Model)
+		}
+		return nil
+	}
+	if !validProviderIDs[cand.Provider] {
+		return fmt.Errorf("unknown provider %q", cand.Provider)
+	}
+	if cand.Model == "" {
+		return fmt.Errorf("model is required")
+	}
+	return nil
+}
+
 func validate(c *Config) error {
 	if c.Concurrency.MaxConcurrentRuns < 1 {
 		return fmt.Errorf("concurrency.max_concurrent_runs must be >= 1")
@@ -3956,11 +3978,8 @@ func validate(c *Config) error {
 			return fmt.Errorf("tiers.%s: unknown tier (want one of low/middle/high)", tierName)
 		}
 		for i, cand := range candidates {
-			if !validProviderIDs[cand.Provider] {
-				return fmt.Errorf("tiers.%s[%d]: unknown provider %q", tierName, i, cand.Provider)
-			}
-			if cand.Model == "" {
-				return fmt.Errorf("tiers.%s[%d]: model is required", tierName, i)
+			if err := validateTierCandidate(cand, c.Models); err != nil {
+				return fmt.Errorf("tiers.%s[%d]: %v", tierName, i, err)
 			}
 		}
 	}
@@ -3989,11 +4008,8 @@ func validate(c *Config) error {
 					return fmt.Errorf("user_tiers.%s.tiers.%s: unknown tier (want one of low/middle/high)", tierName, taskTier)
 				}
 				for i, cand := range candidates {
-					if !validProviderIDs[cand.Provider] {
-						return fmt.Errorf("user_tiers.%s.tiers.%s[%d]: unknown provider %q", tierName, taskTier, i, cand.Provider)
-					}
-					if cand.Model == "" {
-						return fmt.Errorf("user_tiers.%s.tiers.%s[%d]: model is required", tierName, taskTier, i)
+					if err := validateTierCandidate(cand, c.Models); err != nil {
+						return fmt.Errorf("user_tiers.%s.tiers.%s[%d]: %v", tierName, taskTier, i, err)
 					}
 				}
 			}
@@ -4065,11 +4081,8 @@ func validate(c *Config) error {
 				return fmt.Errorf("agent %q: models.%s: unknown tier", name, tierName)
 			}
 			for i, cand := range candidates {
-				if !validProviderIDs[cand.Provider] {
-					return fmt.Errorf("agent %q: models.%s[%d]: unknown provider %q", name, tierName, i, cand.Provider)
-				}
-				if cand.Model == "" {
-					return fmt.Errorf("agent %q: models.%s[%d]: model is required", name, tierName, i)
+				if err := validateTierCandidate(cand, c.Models); err != nil {
+					return fmt.Errorf("agent %q: models.%s[%d]: %v", name, tierName, i, err)
 				}
 			}
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -418,6 +418,32 @@ type TierCandidate struct {
 	Model    string `json:"model"    yaml:"model"`
 }
 
+// UnmarshalYAML accepts a tier candidate written EITHER as a mapping
+// ({provider: X, model: Y}) or as a bare scalar string. A bare string is
+// taken as the model with an empty provider — the natural way to name a
+// models: alias (the alias supplies the provider) without repeating the
+// pair, e.g. `- local-qwen`. Without this, a bare scalar fails to unmarshal
+// into the struct ("cannot unmarshal !!str into config.TierCandidate"), which
+// surprised an operator authoring an all-aliases tier list. Only the YAML
+// INPUT shape is affected — the struct still marshals to the same JSON
+// object, so content_sha256 (see the json: tags above) is unchanged.
+func (tc *TierCandidate) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		tc.Provider = ""
+		tc.Model = value.Value
+		return nil
+	}
+	// Mapping form: decode via an alias type so we don't recurse into this
+	// method.
+	type rawTierCandidate TierCandidate
+	var raw rawTierCandidate
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	*tc = TierCandidate(raw)
+	return nil
+}
+
 // UserTier is one named user-facing-tier policy. Operators define
 // these in the top-level `user_tiers:` map; clients reference them by
 // name via the `user_tier` field on POST /v1/runs. See Config.UserTiers

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3055,6 +3055,25 @@ func (c *Config) ResolveAgentModel(agent string) (provider string, model string,
 	return c.ResolveAgentDefModel(agent, def)
 }
 
+// ExpandModelAlias resolves a model-alias (a key in the top-level models:
+// map) to its concrete provider/model. The alias only fills an EMPTY
+// provider — an explicit provider on the pin/candidate always wins — so the
+// tier path and the pin path expand aliases identically. A nil/absent map or
+// a non-alias model is a no-op (the model is treated as a literal). This is
+// the single source of truth for alias expansion, shared by the pin path
+// (ResolveAgentDefModel) and the tier path (the resolver-boundary converters
+// in internal/api/http and cmd/loomcycle); keeping it in one place stops the
+// two paths from drifting.
+func ExpandModelAlias(models map[string]ModelRef, provider, model string) (string, string) {
+	if ref, ok := models[model]; ok {
+		model = ref.Model
+		if provider == "" {
+			provider = ref.Provider
+		}
+	}
+	return provider, model
+}
+
 // ResolveAgentDefModel mirrors ResolveAgentModel but resolves against
 // a caller-supplied AgentDef instead of looking it up in c.Agents.
 // Used by the sub-agent path when an overlay has already produced an
@@ -3075,12 +3094,7 @@ func (c *Config) ResolveAgentDefModel(agent string, def AgentDef) (provider stri
 	}
 
 	// If model is an alias in models:, expand it.
-	if ref, ok := c.Models[model]; ok {
-		model = ref.Model
-		if provider == "" {
-			provider = ref.Provider
-		}
-	}
+	provider, model = ExpandModelAlias(c.Models, provider, model)
 	if provider == "" {
 		provider = c.Defaults.Provider
 	}

--- a/web/src/components/LibraryEditModal.tsx
+++ b/web/src/components/LibraryEditModal.tsx
@@ -1007,8 +1007,9 @@ function AgentFields(props: AgentFieldsProps) {
         <label>
           models (per-tier)
           <span className="library-modal-field-hint">
-            {" "}— per-tier candidate list; leave a tier empty to inherit
-            from the library Tiers map
+            {" "}— per-tier candidate list; model may be a literal model name
+            or an alias from the top-level models: map (e.g. local-gemma);
+            leave a tier empty to inherit from the library Tiers map
           </span>
         </label>
         <div className="library-models-grid">
@@ -1043,7 +1044,7 @@ function AgentFields(props: AgentFieldsProps) {
                   />
                   <input
                     type="text"
-                    placeholder="model"
+                    placeholder="model or alias"
                     value={c.model}
                     onChange={(e) =>
                       updateCandidate(slot, i, { model: e.target.value })


### PR DESCRIPTION
## Why

loomcycle had two ways an agent picks a model, and they disagreed about aliases:

- **Pin path** (`agent.provider`/`agent.model`) — a model name that is a key in the top-level `models:` alias map (e.g. `local-gemma: {provider: ollama-local, model: gemma4:max}`) **is expanded** to its concrete provider/model.
- **Tier path** (per-agent `models:`, `user_tiers.*.tiers`, library `tiers:`) — an alias was never honored.

So `model: local-gemma` worked as a pin but failed as a tier candidate with `503 no provider available for requested tier`. Worse, authoring an all-aliases tier list surfaced two more gaps along the same path: a **bare-string** candidate (`- local-qwen`) wouldn't even parse, and config-load **validation** rejected an empty-provider candidate. This PR closes the whole path — parse, validate, resolve — so an alias works in a tier candidate exactly like it works in a pin, in YAML and via the Web UI.

## What

One shared expansion rule + alias-awareness at each stage of the path:

1. **Resolve** — `config.ExpandModelAlias` (extracted from `ResolveAgentDefModel`, single source of truth) is applied at the two resolver-entry boundaries: `convertConfigCandidates` (`internal/api/http` — per-agent `def.Models` + user-tier overlay; covers HTTP **and** gRPC, plus dynamic/Web-UI/MCP agents) and `convertTiers` (`cmd/loomcycle` — library `tiers:`). These are the only two places candidates enter the resolver. An explicit provider always wins over the alias's; a non-alias is a no-op.
2. **Parse** — `TierCandidate.UnmarshalYAML` accepts a bare scalar as the model (empty provider), so `- local-qwen` reads as written. Only the YAML input shape changes; the struct still marshals identically, so `content_sha256` is unaffected.
3. **Validate** — `validateTierCandidate` treats an empty provider as valid IFF the model names a defined alias (the alias supplies the provider at resolve time); all three validation sites route through it. Otherwise the provider must be known and the model non-empty.

**Web UI (discoverability only):** the Library editor's per-tier model field hint + placeholder note an alias is accepted. No payload change — the modal already sends `{provider, model}` and the server expands.

Wire-shape-neutral (aliases were already a YAML concept; tier candidates just honor them now), so no lockstep jobs-search-agent bump.

## What was tested

- `go test ./...` — clean.
- `make build-all` — UI compiles, binary links.
- New tests: `TestExpandModelAlias_*`, `TestConvertConfigCandidates_ExpandsAlias`, `TestConvertTiers_ExpandsAlias`, `TestResolveAgentDef_TierCandidateAliasExpands` (end-to-end through the real resolver, reproduces the exact 503), `TestTierCandidate_UnmarshalYAML_BareStringIsModel`, `TestValidateTierCandidate_AliasAware`.
- **Fail-before verified** on the resolve path: reverting the expansion makes the end-to-end test fail with the exact production string `no provider available for requested tier`.
- **Real config**: `loomcycle doctor` on an all-aliases config (library tiers + per-agent models authored entirely as bare-string aliases) now reports `[PASS] Config parses`; before these changes it failed first with `cannot unmarshal !!str into config.TierCandidate`, then with `unknown provider ""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)