### PR TITLE
feat(webui): collapsible left column on the run page

### DIFF
--- a/web/src/components/InteractiveSessionsPanel.tsx
+++ b/web/src/components/InteractiveSessionsPanel.tsx
@@ -1,53 +1,35 @@
-import { useCallback, useEffect, useState } from "react";
-import { listAgents, type Agent } from "../api";
+import { useEffect, useState } from "react";
+import { type Agent } from "../api";
 
 // Persisted collapse state so the operator's choice survives navigation.
 const COLLAPSE_KEY = "loomcycle.run.interactive-sessions.collapsed";
-const POLL_MS = 4000;
 
 // InteractiveSessionsPanel lists the operator's RUNNING interactive sessions in
 // the run page's left column, so they can switch between sessions or re-open one
 // they left — without detouring through the runs page "resume in terminal" link.
 //
-// Source: listAgents(userId, "running") filtered to interactive runs (the
-// runs.interactive flag, surfaced on the run-list row). Clicking a row
-// re-attaches it in the run terminal (onOpen → useRunStream.attach, which
-// replays from seq 0 then live-tails). Collapsible; collapsed it shows just the
-// "N interactive sessions" header.
+// Source: the `sessions` prop (the parent polls via useInteractiveSessions so
+// the count is shared with the collapsed left-column strip — one poll, not two).
+// Clicking a row re-attaches it in the run terminal (onOpen → useRunStream.attach,
+// which replays from seq 0 then live-tails). Collapsible; collapsed it shows just
+// the "N interactive sessions" header.
 export default function InteractiveSessionsPanel({
   userId,
+  sessions,
   currentRunId,
   onOpen,
 }: {
   userId: string;
+  sessions: Agent[];
   currentRunId?: string;
   onOpen: (runId: string) => void;
 }) {
-  const [sessions, setSessions] = useState<Agent[]>([]);
   const [collapsed, setCollapsed] = useState<boolean>(
     () => localStorage.getItem(COLLAPSE_KEY) === "1",
   );
   useEffect(() => {
     localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0");
   }, [collapsed]);
-
-  const refresh = useCallback(() => {
-    if (!userId) {
-      setSessions([]);
-      return;
-    }
-    listAgents(userId, "running")
-      .then((r) => setSessions((r.agents ?? []).filter((a) => a.interactive)))
-      .catch(() => {
-        /* transient poll failure — keep the last good list */
-      });
-  }, [userId]);
-
-  useEffect(() => {
-    refresh();
-    const id = window.setInterval(refresh, POLL_MS);
-    return () => window.clearInterval(id);
-  }, [refresh]);
 
   // No user context → nothing to list (admins without a picked user, etc.).
   if (!userId) return null;

--- a/web/src/hooks/useInteractiveSessions.ts
+++ b/web/src/hooks/useInteractiveSessions.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useState } from "react";
+import { listAgents, type Agent } from "../api";
+
+const POLL_MS = 4000;
+
+// useInteractiveSessions polls the operator's RUNNING interactive sessions
+// (listAgents(userId, "running") filtered to interactive runs). Lifted out of
+// InteractiveSessionsPanel so the run page's left column has ONE poll shared by
+// both states: the expanded panel (the list) and the collapsed strip (just the
+// count). Returns the last good list; a transient poll failure is swallowed.
+export function useInteractiveSessions(userId: string): Agent[] {
+  const [sessions, setSessions] = useState<Agent[]>([]);
+
+  const refresh = useCallback(() => {
+    if (!userId) {
+      setSessions([]);
+      return;
+    }
+    listAgents(userId, "running")
+      .then((r) => setSessions((r.agents ?? []).filter((a) => a.interactive)))
+      .catch(() => {
+        /* transient poll failure — keep the last good list */
+      });
+  }, [userId]);
+
+  useEffect(() => {
+    refresh();
+    const id = window.setInterval(refresh, POLL_MS);
+    return () => window.clearInterval(id);
+  }, [refresh]);
+
+  return sessions;
+}

--- a/web/src/pages/RunView.tsx
+++ b/web/src/pages/RunView.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from "react-router-dom";
 import { listLibraryAgents, type StartRunRequest } from "../api";
 import { useUserId } from "../components/Layout";
 import { useRunStream } from "../hooks/useRunStream";
+import { useInteractiveSessions } from "../hooks/useInteractiveSessions";
 import RunForm from "../components/RunForm";
 import LiveRunPane from "../components/LiveRunPane";
 import InteractiveSessionsPanel from "../components/InteractiveSessionsPanel";
@@ -15,6 +16,10 @@ import OrchestratorView from "../components/OrchestratorView";
 //   fanout       — N independent top-level runs in a live grid
 //   orchestrator — one parent agent that parallel_spawns a live child tree
 type Tab = "single" | "fanout" | "orchestrator";
+
+// Persisted collapse state for the Single-tab left column (sessions + form),
+// so the operator's "give the terminal full width" choice survives navigation.
+const FORM_COL_COLLAPSE_KEY = "loomcycle.run.form-col.collapsed";
 
 export default function RunView() {
   const defaultUserId = useUserId();
@@ -100,6 +105,15 @@ function SingleRunTab({
   defaultUserId: string;
 }) {
   const run = useRunStream();
+  const sessions = useInteractiveSessions(defaultUserId);
+  // Collapse the whole left column to a thin strip so the live terminal can
+  // use the full width during a run. Persisted so it survives navigation.
+  const [colCollapsed, setColCollapsed] = useState<boolean>(
+    () => localStorage.getItem(FORM_COL_COLLAPSE_KEY) === "1",
+  );
+  useEffect(() => {
+    localStorage.setItem(FORM_COL_COLLAPSE_KEY, colCollapsed ? "1" : "0");
+  }, [colCollapsed]);
   const [searchParams, setSearchParams] = useSearchParams();
   // `?attach=<run_id>` re-attaches to a detached interactive run (the operator
   // returned from the runs list). Attach once on mount, then drop the param so
@@ -116,21 +130,55 @@ function SingleRunTab({
     }
   }, [attachRunId, run, searchParams, setSearchParams]);
 
+  const sessionCount = sessions.length;
   return (
     <div className="run-view-body">
-      <div className="run-view-form-col">
-        <InteractiveSessionsPanel
-          userId={defaultUserId}
-          currentRunId={run.runId}
-          onOpen={run.attach}
-        />
-        <RunForm
-          agents={agents}
-          defaultUserId={defaultUserId}
-          submitting={run.status === "running"}
-          onSubmit={(req) => run.start(req)}
-        />
-      </div>
+      {colCollapsed ? (
+        <button
+          type="button"
+          className="run-view-form-col-collapsed"
+          onClick={() => setColCollapsed(false)}
+          title={`Expand panel — ${sessionCount} interactive session${sessionCount === 1 ? "" : "s"}`}
+          aria-label="Expand panel"
+        >
+          <span className="run-col-toggle-icon" aria-hidden="true">
+            »
+          </span>
+          <span
+            className="run-col-collapsed-badge"
+            data-empty={sessionCount === 0 ? "1" : undefined}
+          >
+            {sessionCount}
+          </span>
+          <span className="run-col-collapsed-vtext">interactive</span>
+        </button>
+      ) : (
+        <div className="run-view-form-col">
+          <div className="run-col-toolbar">
+            <button
+              type="button"
+              className="run-col-toggle"
+              onClick={() => setColCollapsed(true)}
+              title="Collapse panel (give the terminal full width)"
+              aria-label="Collapse panel"
+            >
+              «
+            </button>
+          </div>
+          <InteractiveSessionsPanel
+            userId={defaultUserId}
+            sessions={sessions}
+            currentRunId={run.runId}
+            onOpen={run.attach}
+          />
+          <RunForm
+            agents={agents}
+            defaultUserId={defaultUserId}
+            submitting={run.status === "running"}
+            onSubmit={(req) => run.start(req)}
+          />
+        </div>
+      )}
       <div className="run-view-pane-col">
         <LiveRunPane
           events={run.events}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4172,6 +4172,80 @@ button.primary:disabled {
   display: flex;
 }
 
+/* Collapse toggle inside the expanded left column (top-right). */
+.run-col-toolbar {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+}
+.run-col-toggle {
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-soft);
+  border-radius: var(--lc-radius-sm, 6px);
+  cursor: pointer;
+  padding: 1px 9px;
+  font-size: 15px;
+  line-height: 1.4;
+}
+.run-col-toggle:hover {
+  background: var(--bg-soft);
+  color: var(--fg);
+}
+
+/* Collapsed left column: a thin vertical strip showing the running-interactive
+   count + an expand affordance, so the live terminal gets the full width. */
+.run-view-form-col-collapsed {
+  flex: 0 0 38px;
+  width: 38px;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  cursor: pointer;
+  color: var(--fg-soft);
+}
+.run-view-form-col-collapsed:hover {
+  background: var(--bg-soft);
+  color: var(--fg);
+}
+.run-col-toggle-icon {
+  font-size: 16px;
+  line-height: 1;
+}
+.run-col-collapsed-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 11px;
+  font-size: 12px;
+  font-weight: 600;
+  background: rgba(86, 197, 150, 0.15);
+  color: var(--accent, #56c596);
+  border: 1px solid var(--accent, #56c596);
+}
+/* Zero running sessions: mute the badge so it doesn't read as a live count. */
+.run-col-collapsed-badge[data-empty="1"] {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border);
+}
+.run-col-collapsed-vtext {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
 /* Interactive-sessions switcher — a collapsible list at the top of the run
    page's left column. Lets the operator switch between / re-open running
    interactive sessions without the runs-page "resume in terminal" detour. */


### PR DESCRIPTION
## Why
During an interactive run, the operator wants the live terminal at full width — but the Single tab's left column (interactive-sessions switcher + run form) holds a fixed 380px regardless. This makes that column collapsible so the terminal can reclaim the space.

## What
- **Collapse the whole left column** to a thin (38px) vertical strip via a toggle (`«`). The strip shows the **running-interactive count** (an accent badge, muted when 0) + an expand affordance (`»`); clicking it restores the column. The terminal pane (`flex:1`) expands automatically as the form col shrinks.
- **Persisted** across navigation in `localStorage` (`loomcycle.run.form-col.collapsed`), separate from the sessions-*list* collapse already inside the panel.
- **One poll, not two:** extracted the running-interactive polling into a new `useInteractiveSessions(userId)` hook, called once in `SingleRunTab`. `InteractiveSessionsPanel` is now presentational (takes `sessions` as a prop); the collapsed strip uses the same list for its count. Previously the panel polled itself; lifting it avoids a second poll when the strip needs the count while the panel is unmounted.

Files: `web/src/pages/RunView.tsx`, `web/src/components/InteractiveSessionsPanel.tsx`, `web/src/hooks/useInteractiveSessions.ts` (new), `web/src/styles.css`.

## What was tested
- `make build-all` — SPA type-checks (`tsc`) and builds, binary links.
- Self-review of the render: collapsed → `<button>` strip (icon + count badge + vertical label); expanded → full column with collapse toggle + the (now prop-driven) panel + run form. Only caller of the panel is `RunView`, updated to pass `sessions`.

Per repo convention `internal/webui/dist/*` is gitignored and rebuilt by CI; this PR commits `web/src` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)