### PR TITLE
fix(loop): keep the heartbeat alive during a slow model call

### DIFF
--- a/internal/loop/heartbeat_test.go
+++ b/internal/loop/heartbeat_test.go
@@ -1,0 +1,74 @@
+package loop
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// slowCallProvider simulates a slow local model: Call blocks (a long prefill)
+// before returning the stream, with no events emitted during the block.
+type slowCallProvider struct {
+	delay time.Duration
+}
+
+func (p *slowCallProvider) ID() string                                   { return "slowcall-test" }
+func (p *slowCallProvider) Probe(context.Context) error                  { return nil }
+func (p *slowCallProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *slowCallProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *slowCallProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	select {
+	case <-time.After(p.delay):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	ch := make(chan providers.Event, 2)
+	ch <- providers.Event{Type: providers.EventText, Text: "ok"}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1}}
+	close(ch)
+	return ch, nil
+}
+
+// TestRun_HeartbeatPulsedDuringSlowCall locks the run-lifetime heartbeat: a
+// single iteration whose model call blocks far longer than the heartbeat
+// cadence (a large-context prefill on a slow local model, or same-provider
+// retry backoff) must keep pulsing OnHeartbeat, so the stale-run sweeper
+// doesn't reap a live-but-slow run as crashed (the heartbeat_timeout that
+// killed a slow ollama review). Fail-before: with OnHeartbeat firing ONLY at
+// iteration start, a one-iteration run pulses exactly once and this fails.
+func TestRun_HeartbeatPulsedDuringSlowCall(t *testing.T) {
+	orig := parkHeartbeatInterval
+	parkHeartbeatInterval = 15 * time.Millisecond
+	defer func() { parkHeartbeatInterval = orig }()
+
+	var beats atomic.Int64
+	prov := &slowCallProvider{delay: 120 * time.Millisecond}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err := Run(ctx, RunOptions{
+		Provider:      prov,
+		Model:         "x",
+		Tools:         []tools.Tool{noopTool{}},
+		Dispatcher:    tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:      steerSegs(),
+		MaxIterations: 1,
+		OnHeartbeat:   func() { beats.Add(1) },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// One iteration's per-iteration pulse fires once; the run-lifetime ticker
+	// adds ~8 more during the 120ms blocking call at a 15ms cadence. Without
+	// the ticker only the single iteration-start pulse fires.
+	if n := beats.Load(); n < 3 {
+		t.Fatalf("OnHeartbeat fired %d times during a slow model call, want >= 3 "+
+			"(the run-lifetime ticker must pulse while the call blocks)", n)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1123,6 +1123,39 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 		opts.MaxSameProviderRetries = maxSameProviderRetriesCap
 	}
 
+	// Run-lifetime heartbeat: pulse OnHeartbeat every parkHeartbeatInterval for
+	// as long as this run's goroutine is alive, IN ADDITION to the per-iteration
+	// pulse below. The stale-run sweeper reaps a run whose heartbeat hasn't
+	// advanced in HeartbeatStaleAfter (default 10m) as CRASHED — but a SINGLE
+	// iteration can legitimately block far longer than the per-iteration cadence:
+	// a large-context prefill on a slow local model, a long tool, or
+	// same-provider retry backoff. A slow ollama review hit exactly this — two
+	// 300s header timeouts inside one iteration (>10m with no pulse) got the
+	// live run reaped as heartbeat_timeout. A live goroutine is not a crashed
+	// process, so keep the heartbeat fresh regardless of which phase the
+	// iteration is in. The callback is a fire-and-forget DB write (server's
+	// makeHeartbeat) — safe to call concurrently with the per-iteration pulse.
+	// Stops when Run returns (close) or ctx is cancelled. parkForInput keeps its
+	// own pulse (this subsumes it; harmless overlap).
+	if opts.OnHeartbeat != nil {
+		hbDone := make(chan struct{})
+		defer close(hbDone)
+		go func() {
+			t := time.NewTicker(parkHeartbeatInterval)
+			defer t.Stop()
+			for {
+				select {
+				case <-hbDone:
+					return
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					opts.OnHeartbeat()
+				}
+			}
+		}()
+	}
+
 outerLoop:
 	for iter := 0; iter < iterCap; iter++ {
 		// v0.10.0 OTEL: one loomcycle.iteration span per turn. Nested


### PR DESCRIPTION
## Why
A slow local model uncovered a real gap. An interactive `code-reviewer` run on `qwen3.6:max` filled its context to ~84%, auto-compacted (it works), then the post-compaction model call had to prefill a still-large context on a slow local GPU. That single iteration blocked through **two 300s response-header timeouts** (`net/http: timeout awaiting response headers`) — ~10 min with no heartbeat — and the stale-run sweeper reaped the **live** run as `failed / heartbeat_timeout`.

Root cause: `OnHeartbeat` fired only at the **start of each iteration** (`loop.go`), so any single iteration that blocks longer than the cadence (a large-context prefill on a slow model, a long tool, or same-provider retry backoff) can exceed `HeartbeatStaleAfter` (default 10m) with no pulse. The sweeper's purpose is detecting a **crashed process** — a slow-but-alive call is not crashed.

## What
Add a **run-lifetime heartbeat ticker**: a goroutine pulses `OnHeartbeat` every `parkHeartbeatInterval` (30s) for as long as the run goroutine is alive, *in addition* to the per-iteration pulse.

- The HTTP header/idle timeouts remain the authority on a genuinely stalled provider; the heartbeat just reflects "this run's goroutine is alive."
- The callback is the server's fire-and-forget `UpdateHeartbeat` DB write — safe to call concurrently with the per-iteration pulse (verified `makeHeartbeat`; no shared mutable state).
- The ticker stops on `Run` return (`defer close`) or `ctx` cancel — no goroutine leak. `parkForInput` keeps its own pulse (now subsumed; harmless overlap).

This is part of a slow-local-model robustness pass; the companion config tuning (compact earlier / keep a smaller tail) reduces the prefill load that triggered it.

## What was tested
- `TestRun_HeartbeatPulsedDuringSlowCall` — a one-iteration run whose `Call` blocks 120ms at a 15ms cadence pulses `OnHeartbeat` several times. **Fail-before:** without the ticker it pulses exactly once.
- `go test -race ./internal/loop/` clean; `go test ./...` clean.

Runtime-only; no wire-shape change, no `@loomcycle/client` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)