### PR TITLE
fix(loop): cap the kept-verbatim tail to the context window on compaction

### DIFF
--- a/internal/loop/compact_test.go
+++ b/internal/loop/compact_test.go
@@ -92,7 +92,7 @@ func TestMaybeAutoCompact_SummarizesAndKeepsTail(t *testing.T) {
 		Compaction: &config.Compaction{KeepLastN: cptr(2), KeepFirst: cptr(true), TargetPercentage: cptr(10)},
 	}
 	var compacted bool
-	out, did := maybeAutoCompact(context.Background(), opts, msgs, func(providers.Event) {}, "auto")
+	out, did := maybeAutoCompact(context.Background(), opts, msgs, 0 /* no window cap */, func(providers.Event) {}, "auto")
 	if !did {
 		t.Fatal("expected compaction to happen")
 	}
@@ -340,5 +340,40 @@ func TestRun_Interactive_ContextUsageRefreshedAfterCompaction(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("run did not terminate after cancel")
+	}
+}
+
+// TestCapKeptTailToWindow locks the kept-tail window cap: when the provider
+// reports a window, the verbatim tail is reduced (oldest kept turns folded into
+// the summarized span, snapping to fresh-user-turn boundaries) until it fits the
+// budget — the fix for a compaction that "succeeds" but leaves a tail still over
+// the window (the slow-local-model timeout). budget<=0 is a no-op; a single
+// over-budget turn is kept rather than dropping to empty.
+func TestCapKeptTailToWindow(t *testing.T) {
+	big := userMsg(strings.Repeat("x", 800)) // ~200 est tokens (chars/4)
+	// [u0, a0, BIG-u1, a1, u2, a2] — fresh user turns at indices 0, 2, 4.
+	msgs := []providers.Message{
+		userMsg("task"), asstMsg("a0"),
+		big, asstMsg("a1"),
+		userMsg("q2"), asstMsg("a2"),
+	}
+
+	// Initial cut=2 keeps [BIG-u1, a1, u2, a2] (~201 est). Budget 50 forces a
+	// drop to the next fresh-user-turn (index 4) → keeps [u2, a2] (~1 est).
+	if got := capKeptTailToWindow(msgs, 2, 50); got != 4 {
+		t.Errorf("over-budget tail: cut = %d, want 4 (advanced past the big turn)", got)
+	}
+	// Under budget → unchanged.
+	if got := capKeptTailToWindow(msgs, 4, 50); got != 4 {
+		t.Errorf("under-budget tail: cut = %d, want 4 (unchanged)", got)
+	}
+	// budget<=0 (unknown window) → no cap.
+	if got := capKeptTailToWindow(msgs, 2, 0); got != 2 {
+		t.Errorf("no window: cut = %d, want 2 (no cap)", got)
+	}
+	// Irreducible: a single over-budget last turn is kept, not dropped to empty.
+	huge := []providers.Message{userMsg("task"), big}
+	if got := capKeptTailToWindow(huge, 1, 50); got != 1 {
+		t.Errorf("irreducible tail: cut = %d, want 1 (kept, not emptied)", got)
 	}
 }

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -775,6 +775,46 @@ func CompactionSplit(msgs []providers.Message, keepLastN int, keepFirst bool) (f
 	return firstIdx, cut, cut > firstIdx
 }
 
+// compactionKeptTailBudgetPct caps the kept-verbatim tail at this percent of the
+// provider's reported context window. Without it a compaction can "succeed" yet
+// still overflow: keep_last_n snaps to a huge tool-result tail whose size alone
+// approaches (or exceeds) the window, so the next request overflows anyway — a
+// slow local model timed out prefilling a post-compaction context that was
+// STILL over its 131k window. Estimate-based (chars/4, which overcounts dense
+// JSON/code), so it errs toward keeping LESS — the safe direction for a slow
+// local model's prefill cost. The other ~half of the window is left for the
+// summary, the next turn, and the model's response.
+const compactionKeptTailBudgetPct = 50
+
+// capKeptTailToWindow advances `cut` forward — dropping the OLDEST kept-verbatim
+// turns into the summarized span, snapping to fresh-user-turn boundaries — until
+// the kept tail (msgs[cut:]) fits within budget estimated tokens. budget<=0
+// (window unknown, e.g. a provider that doesn't report one) → no cap. Never
+// splits a turn or truncates content: if the tail collapses to a single
+// over-budget turn (one giant tool_result) it stays, since dropping it would
+// lose the agent's most recent context entirely — better over-budget-by-one-turn
+// than empty. Returns the (possibly larger) cut; cut only ever increases, so the
+// summarized span [firstIdx:cut] stays non-empty.
+func capKeptTailToWindow(msgs []providers.Message, cut, budget int) int {
+	if budget <= 0 {
+		return cut
+	}
+	for cut < len(msgs) && estimateMessageTokens(msgs[cut:]) > budget {
+		next := -1
+		for i := cut + 1; i < len(msgs); i++ {
+			if isFreshUserTurn(msgs[i]) {
+				next = i
+				break
+			}
+		}
+		if next < 0 {
+			break // remaining tail is one irreducible chunk — keep it rather than empty
+		}
+		cut = next
+	}
+	return cut
+}
+
 // messageText concatenates a message's text blocks (used to pin the task verbatim).
 func messageText(m providers.Message) string {
 	var b strings.Builder
@@ -941,7 +981,7 @@ func drainSteer(q <-chan steer.Message, messages []providers.Message, onSteer fu
 // compacted form, emitting the marker. Returns the (possibly unchanged) slice +
 // whether it compacted. A failed summary call changes nothing (logged via emit).
 // The caller gates WHEN this runs (threshold / self-request) at a clean boundary.
-func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers.Message, emit func(providers.Event), trigger string) ([]providers.Message, bool) {
+func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers.Message, window int, emit func(providers.Event), trigger string) ([]providers.Message, bool) {
 	c := opts.Compaction
 	keepLastN := config.CompactionDefaultKeepLastN
 	keepFirst := config.CompactionDefaultKeepFirst
@@ -964,6 +1004,14 @@ func maybeAutoCompact(ctx context.Context, opts RunOptions, messages []providers
 	firstIdx, cut, ok := CompactionSplit(messages, keepLastN, keepFirst)
 	if !ok {
 		return messages, false
+	}
+	// Safety cap: when the provider reports a window, never let the kept-
+	// verbatim tail itself approach it — otherwise the post-compaction request
+	// still overflows (the slow-local-model failure: a tail snapped to a huge
+	// tool-result was STILL over the 131k window after compaction). Drop the
+	// oldest kept turns into the summarized span until the tail fits.
+	if window > 0 {
+		cut = capKeptTailToWindow(messages, cut, window*compactionKeptTailBudgetPct/100)
 	}
 	summary, err := Summarize(ctx, opts.Provider, model, messages[firstIdx:cut], targetPct)
 	if err != nil || strings.TrimSpace(summary) == "" {
@@ -1199,7 +1247,7 @@ outerLoop:
 			if selfReq {
 				trigger = "self"
 			}
-			if newMsgs, did := maybeAutoCompact(iterCtx, opts, messages, emit, trigger); did {
+			if newMsgs, did := maybeAutoCompact(iterCtx, opts, messages, lastWindow, emit, trigger); did {
 				messages = newMsgs
 				lastCompactIter = iter
 				// Compaction shrank the history; refresh the footprint so op=self


### PR DESCRIPTION
## Why
Companion to #502, from the same slow-local-model stress test. Auto-compaction could **"succeed" yet leave the context still over the window**: `keep_last_n` snaps to a clean user-turn boundary that, for a tool-heavy agent, keeps a **huge tool-result tail**. The slow `code-reviewer` run compacted `174.2k → 153.8k` (estimate) — but 153.8k was **still over its 131k window**, so the next request's prefill timed out and the run died. Compaction relieved nothing.

## What
When the provider reports a window, advance the compaction `cut` forward — folding the **oldest** kept-verbatim turns into the summarized span, snapping to fresh-user-turn boundaries — until the kept tail fits **~half the window** (`compactionKeptTailBudgetPct = 50`).

- The summary captures the folded turns → **no content is lost**.
- A single irreducible over-budget turn (one giant tool_result) is **kept**, not dropped to empty — the agent keeps its most recent context.
- Budget is estimate-based (`chars/4`, which overcounts dense JSON/code) so it errs toward keeping **less** — the safe direction for a slow local model's prefill cost.
- `window<=0` (a provider that reports no window) → **no cap**, behavior unchanged.

Combined with #502 (heartbeat) and the config tuning (compact earlier / smaller tail), this closes the loop on the slow-local-model failure: compaction now actually fits the window, and a slow-but-healthy call isn't reaped.

## What was tested
- `TestCapKeptTailToWindow` — advances past an over-budget turn; no-op when under budget / window unknown / irreducible single turn.
- Existing compaction tests pass `window=0` (behavior unchanged when no window is known).
- `go test -race ./internal/loop/` clean; `go test ./...` clean.

Independent of #502 (different regions of `loop.go`); merges cleanly alongside it. Runtime-only; no wire-shape change, no `@loomcycle/client` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)