### PR TITLE
docs: model-aliases-first config/example + local-model guide; + runs-chip UI fix

### DIFF
--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -16,12 +16,46 @@
 # config setup from exfiltrating, say, ANTHROPIC_API_KEY into an MCP
 # server URL.
 
+# ─── Model aliases — name your models ONCE, here, FIRST ───────────────
+# A model alias maps a friendly name → (provider, real model id). Define
+# every model you use here, then reference it BY NAME everywhere else:
+# tier candidate lists (below), per-agent pins (`model: sonnet`), and the
+# per-agent `models:` override. This is the recommended way to name models
+# — editing one right-hand side re-points every agent/tier that uses the
+# alias (e.g. when Anthropic ships sonnet-5, change `sonnet:` once). A raw
+# `{provider, model}` pair still works anywhere an alias does; the alias
+# just avoids repeating the id. NOTE: `defaults:` (far below) is NOT
+# alias-expanded — pin it with a concrete provider+model.
+models:
+  # — Anthropic (key: ANTHROPIC_API_KEY) —
+  haiku:  { provider: anthropic, model: claude-haiku-4-5 }
+  sonnet: { provider: anthropic, model: claude-sonnet-4-6 }
+  opus:   { provider: anthropic, model: claude-opus-4-7 }
+  # — OpenAI (OPENAI_API_KEY) —
+  gpt-mini: { provider: openai, model: gpt-5.4-mini }
+  gpt:      { provider: openai, model: gpt-5.4 }
+  gpt-max:  { provider: openai, model: gpt-5.5 }
+  # — DeepSeek — the cost floor (DEEPSEEK_API_KEY) —
+  deepseek-flash: { provider: deepseek, model: deepseek-v4-flash }
+  deepseek-pro:   { provider: deepseek, model: deepseek-v4-pro }
+  # — Hosted Ollama cloud (OLLAMA_API_KEY) — for models too big to run locally —
+  cloud-kimi: { provider: ollama, model: kimi-k2.6 }
+  # — Local Ollama on your workstation / LAN (OLLAMA_BASE_URL; no key) —
+  # Slow local models have their own knobs (num_ctx, header/idle timeouts,
+  # compaction tuning, unbounded interactive runs). See "Local models" in
+  # docs/CONFIGURATION.md and loomcycle.local-interactive.example.yaml.
+  local-small:  { provider: ollama-local, model: gemma4:9b }        # low tier
+  local-medium: { provider: ollama-local, model: qwen3.6:27b }      # middle tier
+  local-coder:  { provider: ollama-local, model: qwen3-coder-next } # high tier (coding)
+
 # ─── Tier-based model resolution (v0.7+, opt-in) ──────────────────────
 # Agents can declare `tier: low | middle | high` instead of pinning a
-# specific (provider, model). The resolver walks `provider_priority`
-# below and picks the first available candidate from `tiers.<level>`
-# for that provider. Cost-floor-first by default — try DeepSeek, fall
-# through to Ollama (local llama), then OpenAI, then Anthropic.
+# specific model. The resolver walks `provider_priority` below and picks
+# the first available candidate from `tiers.<level>`. Candidates are
+# written as bare ALIASES (defined above) — `- deepseek-flash` is the same
+# as `- { provider: deepseek, model: deepseek-v4-flash }`, just shorter and
+# single-sourced. Cost-floor-first by default — try DeepSeek, fall through
+# to local Ollama, then OpenAI, then Anthropic.
 #
 # Per-agent overrides: an agent may set its own `providers:` list
 # (full replacement of provider_priority) and/or `models:` map (full
@@ -43,23 +77,22 @@ provider_priority:
 
 tiers:
   low:
-    - { provider: deepseek,     model: deepseek-v4-flash }
-    - { provider: ollama-local, model: gemma4:9b }
-    - { provider: openai,       model: gpt-5.4-mini }
-    - { provider: anthropic,    model: claude-haiku-4-5 }
+    - deepseek-flash   # cost floor first
+    - local-small      # workstation GPU
+    - gpt-mini
+    - haiku            # cloud-frontier fallback
   middle:
-    - { provider: deepseek,     model: deepseek-v4-pro }
-    - { provider: ollama-local, model: qwen3.6:27b }
-    - { provider: openai,       model: gpt-5.4 }
-    - { provider: anthropic,    model: claude-sonnet-4-6 }
+    - deepseek-pro
+    - local-medium
+    - gpt
+    - sonnet
   high:
     # DeepSeek absent — V4 Pro doesn't compete with Opus 4.7 / GPT-5.5.
-    # ollama-local typically can't host 600B+ kimi-k2.6 either; the
-    # `ollama` (hosted) entry covers that case for operators with a
-    # paid quota.
-    - { provider: ollama,    model: kimi-k2.6 }
-    - { provider: openai,    model: gpt-5.5 }
-    - { provider: anthropic, model: claude-opus-4-7 }
+    # A local box typically can't host 600B+ kimi-k2.6 either; cloud-kimi
+    # (hosted Ollama) covers that case for operators with a paid quota.
+    - cloud-kimi
+    - gpt-max
+    - opus
 
 # ─── User tiers (v0.8.2+) ─────────────────────────────────────────────
 # Operator-defined per-user-tier overlay on the resolver matrix above.
@@ -109,10 +142,10 @@ user_tiers:
   # prompt.
   free:
     provider_priority: [ollama-local]
-    tiers:
-      low:    [{provider: ollama-local, model: gemma4:9b}]
-      middle: [{provider: ollama-local, model: qwen3.6:27b}]
-      high:   [{provider: ollama-local, model: qwen3.6:27b}]
+    tiers:                  # bare aliases again — same names as the top-level models: map
+      low:    [local-small]
+      middle: [local-medium]
+      high:   [local-medium]
     fallback_on_error: false
 
   # Low tier: cost-floor-first with one paid backstop. DeepSeek's free
@@ -363,21 +396,13 @@ hooks:
 # Used by agents that declare neither `tier:` nor an explicit
 # `provider:`+`model:` pin. v0.6.x back-compat path; tier-based agents
 # bypass these defaults entirely.
+# NOT alias-expanded — pin a concrete provider+model here (an alias name
+# in `defaults.model` would be sent to the provider verbatim, not resolved).
 defaults:
   provider: anthropic
   model: claude-sonnet-4-6
 
-# ─── Model aliases ────────────────────────────────────────────────────
-# Agents reference these names via `model: <alias>`. The alias resolves
-# to (provider, real_model_id). Cleaner than repeating model strings,
-# and makes "swap haiku→sonnet for cv-adapter" a one-line YAML change.
-models:
-  cheap:  { provider: anthropic, model: claude-haiku-4-5 }
-  smart:  { provider: anthropic, model: claude-sonnet-4-6 }
-  best:   { provider: anthropic, model: claude-opus-4-7 }
-  gpt:    { provider: openai,    model: gpt-4o-mini }
-  gpt-4:  { provider: openai,    model: gpt-4o }
-  local:  { provider: ollama-local, model: llama3.1:8b }  # tool-tuned model on workstation
+# (Model aliases are defined at the TOP of this file — see "Model aliases".)
 
 # ─── Agents ───────────────────────────────────────────────────────────
 # Each agent is addressed by name in POST /v1/runs's "agent" field.
@@ -406,7 +431,7 @@ agents:
   # Reaches no resources outside the model. Safe for prompts that only
   # need text generation (Q&A bots, classifiers, summarisers).
   default:
-    model: smart
+    model: sonnet
     system_prompt: "You are a helpful assistant."
     allowed_tools: []
 
@@ -447,7 +472,7 @@ agents:
     effort: medium
     models:
       high:
-        - { provider: anthropic, model: claude-opus-4-7 }
+        - opus   # alias → {anthropic, claude-opus-4-7}; locks this sensitive agent to Anthropic
     system_prompt: "You adapt the user's CV to a target job description."
     allowed_tools: [Read, Write]
 
@@ -455,7 +480,7 @@ agents:
   # directory. Mutually exclusive with system_prompt. Useful when the
   # prompt is long enough to be uncomfortable to inline.
   # docs-from-file:
-  #   model: smart
+  #   model: sonnet
   #   system_prompt_file: prompts/docs-agent.md
   #   allowed_tools: [WebFetch]
 
@@ -463,7 +488,7 @@ agents:
   # the network. Good for code-review or doc-editing flows where the
   # operator has staged inputs into LOOMCYCLE_WRITE_ROOT.
   file-editor:
-    model: smart
+    model: sonnet
     system_prompt: "You edit files in the configured sandbox. Never speculate about files you haven't read."
     allowed_tools: [Read, Write, Edit]
 
@@ -478,7 +503,7 @@ agents:
   # implement the "researcher-feeds-analyst" canonical pattern from
   # the v0.8.4 Channel-tool RFC.
   researcher:
-    model: smart
+    model: sonnet
     system_prompt: "You do focused web research. Cite every claim with a URL. Publish each finding as a single JSON object to the `findings` channel."
     allowed_tools: [WebSearch, WebFetch, Channel]
     channels:
@@ -489,7 +514,7 @@ agents:
   # batches into reports, and reads the alerts broadcast. Demonstrates
   # the consumer side of the Channel tool.
   analyst:
-    model: smart
+    model: sonnet
     system_prompt: "You drain the `findings` channel and produce summary reports. Subscribe to `alerts` for cross-tenant notifications."
     allowed_tools: [Channel, Write]
     channels:
@@ -500,7 +525,7 @@ agents:
   # operator has containerised loomcycle (Bash is NOT a true sandbox).
   # Keep `Bash` off this list unless you really need it.
   power-user:
-    model: best
+    model: opus
     system_prompt: "You have broad access. Do the minimum work needed."
     allowed_tools: [Read, Write, Edit, WebSearch, WebFetch]
     # Add Bash only if loomcycle runs inside a container/VM:
@@ -510,7 +535,7 @@ agents:
   # server registers, alongside built-in WebFetch for the deep-dive.
   # The mcp_servers.brave-search block below declares the server.
   brave-researcher:
-    model: smart
+    model: sonnet
     allowed_tools: ["mcp__brave-search__*", WebFetch]
     system_prompt: "Search via Brave, fetch top results, synthesise."
 
@@ -518,7 +543,7 @@ agents:
   # all the heavy lifting. Good for routing/triage where you'd
   # otherwise pay sonnet rates per call.
   classifier:
-    model: cheap
+    model: haiku
     system_prompt: |
       Classify each input into exactly one of: bug, feature, question, spam.
       Output ONLY the label, no explanation.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -48,7 +48,7 @@ The doc presents this as **four cookbook patterns**. Find the pattern matching y
 |---|---|---|---|
 | **Library `provider_priority`** | top-level `provider_priority:` | The walk order across providers when nothing else overrides | Always — every config sets this |
 | **Library `tiers`** | top-level `tiers:` | Per-task-tier (`low`/`middle`/`high`) ordered candidate lists | Always — every agent that uses `tier:` reads this |
-| **`models:` alias map** | top-level `models:` | Aliases like `sonnet → {anthropic, claude-sonnet-4-6}` so agents can say `model: sonnet` | When you want short names in agent .md files instead of full model IDs |
+| **`models:` alias map** | top-level `models:` | Aliases like `sonnet → {anthropic, claude-sonnet-4-6}`. Reference by name in tier candidate lists (`- sonnet`), per-agent pins (`model: sonnet`), and per-agent `models[tier]` — define the model once, single-source the id | The recommended way to name models — always; raw `{provider, model}` pairs still work but repeat the id |
 | **`user_tiers:` overlay** | top-level `user_tiers:` | Per-user-class policy (free/low/medium/high). Restricts which providers + models a user's runs may touch | When your app has multiple plan tiers OR multi-tenant cost/privacy boundaries |
 | **Per-agent `providers:`** | agent .md `providers:` | Replaces the priority order for THIS agent only | When one agent must skip certain providers (privacy, capability) |
 | **Per-agent `models[tier]:`** | agent .md `models:` | Replaces the tier candidate list for THIS agent | When one agent needs specific models in its tier slot |
@@ -132,24 +132,28 @@ If you set both `tier: middle` AND `model: claude-sonnet-4-6` in an agent's fron
 ```yaml
 # loomcycle.yaml — single-provider, tier-driven
 
-provider_priority:
-  - anthropic
-
-tiers:
-  low:
-    - { provider: anthropic, model: claude-haiku-4-5 }
-  middle:
-    - { provider: anthropic, model: claude-sonnet-4-6 }
-  high:
-    - { provider: anthropic, model: claude-opus-4-7 }
-
-# Alias map — left-hand-side is what agents write; resolver expands.
+# Aliases FIRST — name every model once; reference it by name everywhere
+# (tier candidates, agent pins). Editing one right-hand side re-points
+# every agent/tier that uses the alias.
 models:
   haiku:  { provider: anthropic, model: claude-haiku-4-5 }
   sonnet: { provider: anthropic, model: claude-sonnet-4-6 }
   opus:   { provider: anthropic, model: claude-opus-4-7 }
 
+provider_priority:
+  - anthropic
+
+# Tier candidates are bare ALIASES (v0.35.0+) — `- haiku` is the same as
+# `- { provider: anthropic, model: claude-haiku-4-5 }`, single-sourced from
+# the models: map above. A raw {provider, model} pair still works too.
+tiers:
+  low:    [haiku]
+  middle: [sonnet]
+  high:   [opus]
+
 # Default for agents without tier or explicit pin (rare; back-compat path).
+# NOT alias-expanded — pin a concrete provider+model (an alias name here is
+# sent to the provider verbatim, not resolved).
 defaults:
   provider: anthropic
   model:    claude-sonnet-4-6
@@ -537,6 +541,60 @@ It's what real production deployments look like. The library is the backstop; us
 
 ---
 
+## 6b. Local models (Ollama) — configuring + slow-model advice
+
+Local models change the economics. A frontier cloud model prefills a 100k-token context in about a second; a single consumer GPU can take minutes. The knobs below exist because of that. For a ready-to-run config, see [`loomcycle.local-interactive.example.yaml`](../loomcycle.local-interactive.example.yaml).
+
+### Two Ollama providers
+
+| Provider id | What it is | Auth | Set |
+|---|---|---|---|
+| `ollama-local` | Ollama on your workstation / LAN / Tailscale host | none | `OLLAMA_BASE_URL=http://<host>:11434` |
+| `ollama` | Hosted Ollama cloud (ollama.com) — for models too big to run locally | Bearer | `OLLAMA_API_KEY` |
+
+`OLLAMA_BASE_URL` is the **host**, not a model — the model comes from a `models:` alias (`local-coder: { provider: ollama-local, model: qwen3-coder-next }`). Name your aliases to match what `ollama list` shows on that host.
+
+### The context window (`num_ctx`) — the knob that bites
+
+`LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` controls the window for **all** `ollama-local` models. It is sent as `options.num_ctx`, so it both **caps the window the model loads** and **is what the UI context gauge reports**.
+
+- **Unset** → `num_ctx` is omitted; Ollama uses each model's Modelfile `num_ctx`, and the gauge reads the **actual loaded window** from Ollama's `/api/ps` (after the model is in VRAM — it may read 0 while loading).
+- **Set** → that value is forced for every local model and reported verbatim.
+
+Pick a value **every** local model you use can handle (it's global), e.g. `131072`. Too low starves long sessions; too high blows up prefill time and VRAM on a slow GPU. ~128K is a sane middle for a 24GB+ card. A model's *training* context (e.g. 256K) is an upper bound, not what you must load — load only what your GPU can prefill in reasonable time.
+
+> **Symptom:** the gauge shows a small window (e.g. 32K) you didn't expect. Almost always `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` is pinned low in the launch env — it's global and overrides the Modelfile. A model also stays resident at whatever window it was first loaded with until it unloads/reloads, so a stale low-context load can linger until the next fresh load.
+
+### Slow models — timeouts + heartbeat
+
+A big prefill can take a long time before the first token. Two budgets (defaults 300s; raise for very large contexts on slow hardware):
+
+- `LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS` — **time to first byte** (the prefill). Exceeding it surfaces as `net/http: timeout awaiting response headers`.
+- `LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS` — max gap **between** streamed tokens.
+
+A slow-but-alive call no longer trips the stale-run sweeper: the loop pulses the run heartbeat throughout a model call, so a long prefill won't be reaped as `heartbeat_timeout`. The HTTP timeouts above remain the authority on a genuinely stuck call.
+
+### Compaction — tune it for the prefill cost
+
+On a slow model, the prefill cost of a near-full window is what times you out — so compact **early** and keep a **small** verbatim tail. In a per-agent `compaction:` block:
+
+- `autocompact_at_pct: 55` — compact well before the window fills (vs. the 80% default).
+- `keep_last_n: 3` — a tool-heavy agent's tail (big file reads) dominates the post-compaction prefill, so fewer kept turns is the real lever.
+
+When the provider reports a window, the loop also caps the kept tail to ~half the window automatically — folding an over-window tail into the summary — so a compaction always actually relieves pressure (it won't "succeed" yet leave you still over the window).
+
+### Interactive local agents
+
+For a terminal you steer turn-by-turn:
+
+- `unbounded_iterations: true` — an interactive run is operator-driven and Cancel-bounded; don't let the 16-iteration runaway guard end a live session (each steer + each end_turn park burns an iteration).
+- `interruption: { enabled: true }` — let the operator answer the agent's questions inline.
+- `max_tokens: 8192` — the local default (4096) truncates large output.
+
+All of this is wired together in [`loomcycle.local-interactive.example.yaml`](../loomcycle.local-interactive.example.yaml).
+
+---
+
 ## 7. Agent `.md` frontmatter reference
 
 Agent files live under `LOOMCYCLE_AGENTS_ROOT` (set in the env file). Each `<name>.md` has YAML frontmatter between `---` delimiters; the body is the system prompt.
@@ -811,6 +869,8 @@ cp .env.insecure.example  .env.insecure   # then adjust paths/flags
 ## 10. Cross-references
 
 - [`loomcycle.example.yaml`](../loomcycle.example.yaml) — the repo-root reference yaml. All six user_tiers wired, inline comments on every section. Copy-paste and edit.
+- [`loomcycle.example.yaml`](../loomcycle.example.yaml) — the comprehensive example config (aliases-first, every tool/feature exercised). Start here.
+- [`loomcycle.local-interactive.example.yaml`](../loomcycle.local-interactive.example.yaml) — a focused config for driving interactive agents on local (Ollama) models, with the slow-model knobs from §6b wired together.
 - [`.env.local.example`](../.env.local.example) + [`.env.insecure.example`](../.env.insecure.example) — the two env-file templates (secrets vs. non-secret config; see §9c). Every operational env var is documented inline in one or the other.
 - [`docs/MCP_INTEGRATION.md`](MCP_INTEGRATION.md) — MCP server configuration (deliberately out of scope for this doc).
 - [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — broader runtime context, provider driver table, probe semantics.

--- a/loomcycle.local-interactive.example.yaml
+++ b/loomcycle.local-interactive.example.yaml
@@ -1,0 +1,122 @@
+# loomcycle.local-interactive.example.yaml
+# ─────────────────────────────────────────────────────────────────────
+# A focused config for driving INTERACTIVE agents on LOCAL (Ollama) models —
+# a coding/review terminal you steer turn-by-turn on your own GPU, with a
+# cloud fallback for when the local box is down or a task needs a frontier
+# model.
+#
+#   Run it:   loomcycle --config loomcycle.local-interactive.example.yaml
+#   Drive it: the /run terminal in the Web UI (/ui), or
+#             POST /v1/runs {"agent":"coder","interactive":true,...}
+#             then steer via POST /v1/runs/{id}/input.
+#
+# WHY a separate example: local models are SLOW and their context is
+# precious. A frontier cloud model prefills a 100k-token context in ~1s; a
+# single consumer GPU can take minutes. That changes how you configure
+# things — the env knobs and the per-agent `compaction` block below are the
+# difference between a terminal that hums and one that times out. See the
+# "Local models (Ollama)" section in docs/CONFIGURATION.md for the full
+# rationale.
+#
+# ─── Local-model ENV (set in .env.insecure — operational, not secret) ─────
+#   OLLAMA_BASE_URL=http://<host>:11434    # your Ollama host (LAN / Tailscale /
+#                                          #   localhost). NOT a model name — the
+#                                          #   model comes from the aliases below.
+#   LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=131072  # pin the context window (see note).
+#   LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=300000  # time-to-FIRST-token budget.
+#   LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=300000    # inter-token idle budget.
+#   LOOMCYCLE_BASH_ENABLED=1   LOOMCYCLE_BASH_CWD=<dir>   # if the agent runs shell
+#   LOOMCYCLE_READ_ROOT=<dir>  LOOMCYCLE_WRITE_ROOT=<dir> # the file sandbox jail
+#
+# num_ctx is GLOBAL (one value for ALL ollama-local models) and is sent as
+# options.num_ctx — it both CAPS the window the model loads AND is what the
+# UI context gauge reports. Pin it to a value EVERY local model you use can
+# handle (e.g. 131072), or omit it to inherit each model's Modelfile default
+# (the gauge then reads the ACTUAL loaded window from Ollama's /api/ps). Too
+# LOW starves long sessions; too HIGH makes prefill + VRAM explode on a slow
+# GPU. ~128K is a sane middle for a 24GB+ card.
+
+# ─── Model aliases — name your models first ──────────────────────────
+# Match the names to what `ollama list` shows on your OLLAMA_BASE_URL host.
+models:
+  local-fast:  { provider: ollama-local, model: gemma4:9b }        # quick / low-context
+  local-chat:  { provider: ollama-local, model: qwen3.6:27b }      # general reasoning
+  local-coder: { provider: ollama-local, model: qwen3-coder-next } # coding / review
+  # Cloud fallback for when the local box is down or a task is too big for it
+  # (pick whichever you have a key for; this one needs ANTHROPIC_API_KEY).
+  cloud-sonnet: { provider: anthropic, model: claude-sonnet-4-6 }
+
+# Local first; the cloud entry catches outages and oversized prefills.
+provider_priority:
+  - ollama-local
+  - anthropic
+
+# Tier candidates are bare aliases (same names as the models: map above).
+tiers:
+  low:    [local-fast,  cloud-sonnet]
+  middle: [local-chat,  cloud-sonnet]
+  high:   [local-coder, cloud-sonnet]
+
+# defaults is NOT alias-expanded — pin a concrete provider+model here.
+defaults:
+  provider: ollama-local
+  model: qwen3-coder-next
+
+# ─── Interruption (human-in-the-loop steering) ───────────────────────
+interruption:
+  backend: webui
+  default_timeout_ms: 3600000     # 1h
+  max_timeout_ms: 86400000        # 24h ceiling
+
+# ─── Interactive local agents ────────────────────────────────────────
+agents:
+
+  # An interactive coding/review agent. The three settings that make a SLOW
+  # LOCAL model usable in a terminal you steer:
+  coder:
+    tier: high                # → local-coder, falling back to cloud-sonnet
+    max_tokens: 8192          # local default (4096) truncates large output
+    effort: medium            # ollama ignores; honoured on the cloud fallback
+
+    # (1) unbounded_iterations — an interactive terminal is operator-driven
+    # and Cancel-bounded, so don't let the 16-iteration runaway guard end a
+    # live session (each steer + each end_turn park burns an iteration). The
+    # 1<<20 hard backstop + Cancel still bound it.
+    unbounded_iterations: true
+
+    # (2) compaction tuned for a SLOW model — the prefill cost of a near-full
+    # window is what times a local model out. Compact EARLY (55%) and keep a
+    # SMALL verbatim tail (3): a tool-heavy agent's tail (big file reads)
+    # dominates the post-compaction prefill, so fewer kept turns is the lever.
+    # When the window is known, the loop also folds an over-window tail into
+    # the summary automatically. The task (keep_first) stays pinned.
+    compaction:
+      enabled: true
+      autocompact_at_pct: 55
+      target_percentage: 25
+      keep_last_n: 3
+      keep_first: true
+
+    # (3) interruption — let the operator answer the agent's questions inline.
+    interruption: { enabled: true }
+
+    allowed_tools: [Read, Write, Edit, Grep, Glob, Bash, Context]
+    system_prompt: |
+      You are an interactive coding agent running on a local model. Read
+      before you edit; make surgical changes; verify with Bash. Pass file
+      paths RELATIVE to the sandbox root (call Context op=self to see your
+      roots and which hosts you may reach). Keep tool output focused — a
+      large file read fills a small local context window fast.
+
+# ─── Concurrency (single-user / workstation defaults) ────────────────
+concurrency:
+  max_concurrent_runs: 4
+  max_queue_depth: 8
+  queue_timeout_ms: 30000
+
+# ─── Cache ────────────────────────────────────────────────────────────
+cache:
+  native: { enabled: true }     # honour native prompt caching where the provider supports it
+
+# Storage defaults to sqlite at ./data when omitted — fine for a single
+# workstation. For Postgres, see the storage: block in loomcycle.example.yaml.

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4336,6 +4336,10 @@ button.primary:disabled {
   background: rgba(86, 197, 150, 0.15);
   color: var(--accent, #56c596);
   border: 1px solid var(--accent, #56c596);
+  /* In the runs tree row the chip sits in a 1fr grid column, so a stretched
+     grid item filled the whole column. Keep it text-wide, left-aligned in its
+     cell. justify-self is a no-op in the (non-grid) detail-pane + switcher uses. */
+  justify-self: start;
 }
 .run-form-advanced {
   margin: 8px 0;


### PR DESCRIPTION
Docs + examples only, no code.

## What
**1. `loomcycle.example.yaml` — aliases-first.** The `models:` alias map moves to the **top**; tier candidate lists and per-agent pins now reference **bare aliases** (`- deepseek-flash`) instead of repeating `{provider, model}` pairs (v0.35.0 made bare-string aliases work in tier candidates). Comments present aliases as the recommended way to name models — edit one RHS to re-point every agent/tier. `defaults:` stays a concrete pin (it's not alias-expanded; noted inline).

**2. `docs/CONFIGURATION.md` — aliases-first + local-model guide.**
- §3 (Pattern 1) reworked aliases-first (models defined once, tiers reference them as bare aliases).
- §1 resolution-axes table reframes aliases as the **always-recommended** naming, not agent-`.md`-only.
- New **§6b. Local models (Ollama)** — the slow-local-model lessons from recent work: the two Ollama providers; the global `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX` knob (caps **and** reports; unset → Modelfile default; gauge reads `/api/ps`); header/idle timeouts; the heartbeat-during-call behavior; compaction tuned for prefill cost (compact early, small `keep_last_n`); and the interactive knobs.
- §10 cross-references both example files.

**3. `loomcycle.local-interactive.example.yaml` (new).** A focused, ready-to-run config for steering interactive agents on local models: aliases, local-first tiers + cloud fallback, and a `coder` agent wiring `unbounded_iterations` + early/small-tail `compaction` + `interruption`, with the env knobs documented in the header.

## What was tested
- `loomcycle doctor --config <each>` → `[PASS] Config parses` for **both** example YAMLs (the new bare-alias tiers + the alias-aware load-time validation).
- Self-reviewed the restructured example for coherence; relative doc links resolve to the two root example files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)