### PR TITLE
examples: add exp6.8-local-evolution (self-evolving GA on local models)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,10 +5,11 @@ needed to start it standalone: a `loomcycle.yaml`, a `run.sh` launcher, a
 `.env.local.example` secret template (empty values), and a comprehensive `README.md`
 with reproduction + verification steps.
 
-## Experiment examples (exp1–exp6)
+## Experiment examples (exp1–exp6, exp6.8)
 
-These six mirror the loomcycle sandbox experiments in **static, self-contained**
-form. Every one routes to **Anthropic OAuth (primary) → deepseek-v4-pro (fallback)**.
+These mirror the loomcycle sandbox experiments in **static, self-contained**
+form. Most route to **Anthropic OAuth (primary) → deepseek-v4-pro (fallback)**;
+exp6.8 is the local-models variant (ollama solver population + cloud-sonnet meta).
 
 | Example | Primitive(s) | Self-contained? |
 |---|---|---|
@@ -18,6 +19,7 @@ form. Every one routes to **Anthropic OAuth (primary) → deepseek-v4-pro (fallb
 | [`exp4-gitea-telegram/`](exp4-gitea-telegram/) | Inbound webhooks + 3rd-party MCP (gitea-mcp) + Telegram: coder→PR→reviewer-merge→advisor→Telegram. | ⚠️ needs external Gitea + Telegram + the gitea-mcp binary (see its README) |
 | [`exp5-scheduler-pipeline/`](exp5-scheduler-pipeline/) | Scheduler fan-out + `Context op=time` + `Channel.await` fan-in + `max_fires`: 5 RSS collectors → consolidator → Telegram, every 5 min, self-stops after 3 cycles. | ⚠️ needs Telegram + loomcycle ≥ v0.25.1 (see its README) |
 | [`exp6-self-evolving-agents/`](exp6-self-evolving-agents/) | `AgentDef.fork`/`promote` + lineage + `Agent.parallel_spawn` + `Evaluation` + `Memory`: a meta-breeder runs a genetic algorithm over solver agents that mutate their own system prompt until one crosses a fitness threshold. | ✅ loomcycle + a provider only |
+| [`exp6.8-local-evolution/`](exp6.8-local-evolution/) | The exp6 GA on **local models**: a `gemma4:max` solver population (the only local model) evolved by **cloud-sonnet** meta-agents, creativity→temperature capped ≤0.7. Completes 5 gens (lineage/promote/v0.37 robustness hold) but the mean doesn't climb — finding: the small local model's per-run reliability (~35% no-usable-result) is the wall, not the substrate. | ⚠️ needs an ollama host + a cloud sonnet provider (loomcycle ≥ v0.37.0) |
 
 (The repo also ships `cluster/`, `observability/`, and `python-cli/` examples.)
 

--- a/examples/exp6.8-local-evolution/.env.local.example
+++ b/examples/exp6.8-local-evolution/.env.local.example
@@ -1,0 +1,15 @@
+# exp6.8 secrets/env — copy to .env.local (run.sh does it on first run).
+
+# Bearer for the loomcycle REST API (/v1/*). Empty = dev open mode. openssl rand -hex 32
+LOOMCYCLE_AUTH_TOKEN=
+
+# Your local ollama host — the gemma4:max SOLVER POPULATION runs here. REQUIRED.
+# (Use the model's exact tag in loomcycle.yaml; gemma4:max is the one this example was tuned on.)
+OLLAMA_BASE_URL=http://localhost:11434
+
+# The META-agents (breeder + advisor) run on cloud sonnet — a LOCAL model as the breeder does NOT
+# work (it mis-formats parallel_spawn / terminates early; see README). Pick ONE:
+#   • OAuth (default): run `loomcycle anthropic login` once (run.sh sets LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1), OR
+#   • API key: set ANTHROPIC_API_KEY below AND change the two meta agents in loomcycle.yaml from
+#     `provider: anthropic-oauth-dev` to `provider: anthropic` (model: claude-sonnet-4-6).
+ANTHROPIC_API_KEY=

--- a/examples/exp6.8-local-evolution/.gitignore
+++ b/examples/exp6.8-local-evolution/.gitignore
@@ -1,0 +1,8 @@
+# runtime state + secrets (never commit)
+.env.local
+data/*.db
+data/*.db-wal
+data/*.db-shm
+# scratch
+work/__pycache__/
+work/*.tmp

--- a/examples/exp6.8-local-evolution/README.md
+++ b/examples/exp6.8-local-evolution/README.md
@@ -1,0 +1,103 @@
+# exp6.8 — self-evolving agents on LOCAL models (gemma4:max population)
+
+The [exp6](../exp6-self-evolving-agents/) genetic algorithm, rerun on **local ollama models** to see
+how local models behave over a long, multi-generation, auto-compacting agentic run. A population of
+**`gemma4:max`** solver agents (the only locally-loaded model) mutate their own system prompt across
+generations; the meta-agents — the **breeder** (GA controller) and **advisor** (task author + judge)
+— run on **cloud sonnet**. No snapshot.
+
+> **Result up front (this is the point of the example): the GA *completes* but the population does
+> NOT converge.** It runs all 5 generations cleanly — lineage + promote intact, genes drift toward
+> the rubric optimum (creativity 4.8→9.0), best output 0.82→0.87 — but the **mean stays flat** because
+> **~35% of variant-slots produce no usable score** (gemma4:max silently skips the self-report ~20% of
+> the time and hallucinates ~15%). **The limiting factor for local agentic evolution is the small
+> model's per-run reliability, not the loomcycle substrate — which performed flawlessly.**
+
+## What it demonstrates
+- The full self-evolution substrate works the same with local models: `AgentDef.fork`/`promote` +
+  lineage, `Agent.parallel_spawn`, `Evaluation`, `Memory`, and **per-agent `sampling.temperature`
+  reaching the ollama model**.
+- The **v0.37 local-model robustness** (heartbeat ticker + compaction tail-cap + 300s local timeouts)
+  keeping long, slow local runs alive through many generations.
+- A real, honest **negative-ish finding**: where small local models hit their ceiling as autonomous
+  multi-step agents.
+
+## Models — why this split
+| Role | Model | Where |
+|---|---|---|
+| `exp6-solver` ×4 (the evolving population) | **gemma4:max** | LOCAL — the only locally-loaded model |
+| `exp6-advisor` (grounded judge) | **claude-sonnet-4-6** | cloud (OAuth or API key) |
+| `exp6-breeder` (GA controller) | **claude-sonnet-4-6** | cloud (OAuth or API key) |
+
+A **local model as the breeder does not work** — `qwen3.6:max` mis-formatted the nested
+`Agent.parallel_spawn` argument (passed the `spawns` array as a JSON *string*) and terminated its
+turn early; the 80-step GA orchestration is beyond a local small model. Keeping **both** meta-agents
+on cloud also means ollama never swaps two large models (qwen↔gemma) in VRAM mid-loop — a swap that
+was corrupting context and dropping solver self-reports.
+
+## The temperature cap
+gemma4:max hallucinates above ~0.8 temperature. The creativity gene maps to a **capped** real
+temperature `round(min(creativity/10, 0.7), 2)`, so every variant stays in the grounded band (≤0.7,
+below the cliff) and produces scoreable answers. (The earlier uncapped 0.0–1.0 run hallucinated too
+much to converge.) The advisor rewards **vivid + decisive + factually GROUNDED** — so hallucinated
+specifics score low.
+
+## Prerequisites
+- **loomcycle ≥ v0.37.0** on PATH (or `LOOMCYCLE_BIN`) — the heartbeat ticker + compaction tail-cap
+  are what keep long local runs from false-timeout deaths. Check `loomcycle --version`.
+- **An ollama host** with your solver model — set `OLLAMA_BASE_URL` in `.env.local`. This example
+  was tuned on `gemma4:max`; swap the tag in `loomcycle.yaml` for your local model.
+- **A cloud sonnet provider for the meta-agents** — Anthropic OAuth (`loomcycle anthropic login`) or
+  an `ANTHROPIC_API_KEY` (then change the two meta agents in `loomcycle.yaml` to `provider: anthropic`).
+- **`python3`** (the driver + verifier are stdlib-only).
+
+⚠️ Not fully self-contained: needs an ollama host + a cloud key. (The point is the local *population*,
+not zero external deps.)
+
+## Run + drive
+Terminal 1 — start the server:
+```bash
+cd examples/exp6.8-local-evolution
+./run.sh        # first launch copies .env.local.example → .env.local; set OLLAMA_BASE_URL + a sonnet provider, re-run
+```
+Watch the boot line `resolve probe: ollama-local reachable (... models)` and your sonnet provider
+`reachable`.
+
+Terminal 2 — drive the evolution (one breeder run per generation; the agents do all the
+mutation/scoring/forking — the script just steps generations):
+```bash
+cd examples/exp6.8-local-evolution
+MAX_GEN=5 THRESHOLD=0.90 ./work/exp6_run.sh evolve
+```
+Expect it to **complete 5 generations** with a flat/declining mean and a best around 0.85–0.90, e.g.:
+```
+gen | mean | max  | mean creativity
+ 0  | 0.75 | 0.82 | 4.8
+ 4  | 0.54 | 0.87 | 9.0   ← winner promoted; stopped at MAX_GEN
+```
+The recurring `0.0` scores are gemma4 solvers that dropped their self-report or hallucinated — the
+finding, live.
+
+## Verify (independent re-derivation)
+```bash
+./work/exp6_run.sh verify
+```
+Reads the `gen:*` ledger from the store and checks improvement (will flag REVIEW — the mean doesn't
+climb), lineage integrity (PASS), and promotion (winner == active `exp6-solver`).
+
+## Files
+| File | Purpose |
+|---|---|
+| `loomcycle.yaml` | routing + the 3 agents (gemma4 solver / sonnet advisor + breeder), capped-temp breeder, compaction tuned for slow local prefill |
+| `run.sh` | launcher — sets `OLLAMA_BASE_URL`, the 16K global window, 300s local timeouts, OAuth on |
+| `work/exp6_run.sh` | thin generation-stepper driver (`evolve` / `verify`) — reused from exp6, model-agnostic |
+| `work/exp6_verify.py` | independent re-derivation (improvement + lineage + gene-drift) |
+| `.env.local.example` | secret/env template (bearer + ollama host + sonnet provider) |
+| `loomcurl.sh` | token-safe REST helper |
+
+## Notes / how you'd push past the wall
+- **Per-model `num_ctx` is global-only** (`LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX`) — you can't give gemma4 a
+  small window and another local model a larger one in the same instance. (RFC candidate.)
+- **To actually converge on local models:** add an N-of-M retry per solver (re-spawn on a dropped
+  self-report), or use a larger/more-reliable local solver model (at the cost of reintroducing the
+  VRAM model-swap question). The infra is ready; the model is the variable.

--- a/examples/exp6.8-local-evolution/loomcurl.sh
+++ b/examples/exp6.8-local-evolution/loomcurl.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Token-safe curl to the local loomcycle REST API. Sources .env.local and passes
+# the bearer via a STDIN config (-K -) so LOOMCYCLE_AUTH_TOKEN never appears in argv.
+# If LOOMCYCLE_AUTH_TOKEN is empty (dev open mode), the header is simply omitted.
+#   ./loomcurl.sh -X POST http://127.0.0.1:8787/v1/runs -H 'Content-Type: application/json' -d @body.json
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+set -a; [ -f "$HERE/.env.local" ] && source "$HERE/.env.local"; set +a
+if [ -n "${LOOMCYCLE_AUTH_TOKEN:-}" ]; then
+  printf 'header = "Authorization: Bearer %s"\n' "$LOOMCYCLE_AUTH_TOKEN" | curl -sS -K - "$@"
+else
+  curl -sS "$@"
+fi

--- a/examples/exp6.8-local-evolution/loomcycle.yaml
+++ b/examples/exp6.8-local-evolution/loomcycle.yaml
@@ -1,0 +1,260 @@
+# exp6.8 — self-evolving agents on LOCAL ollama models (no snapshot)
+#
+# The exp6 genetic algorithm with the ONLY local model = gemma4:max (the evolving solver population);
+# both meta-agents run on cloud sonnet (the local model couldn't drive the orchestration — finding below):
+#   • exp6-solver  population  = gemma4:max  (LOCAL — the ONLY locally-loaded model; the evolving agents)
+#   • exp6-advisor (judge)     = claude-sonnet-4-6 (CLOUD/OAuth — reliable grounded scoring)
+#   • exp6-breeder (GA controller) = claude-sonnet-4-6 (CLOUD/OAuth) — RELIABLE multi-step orchestration
+# Keeping BOTH meta-agents on cloud means ollama never swaps qwen↔gemma in VRAM mid-loop — the suspected
+# cause of corrupted context / dropped solver self-reports in the earlier run.
+# FINDING (why the breeder is cloud): qwen3.6:max as the local breeder could NOT reliably drive the
+# 80-step GA at 16K — it mis-formatted Agent.parallel_spawn (passed the nested `spawns` array as a
+# JSON string → "cannot unmarshal string into []parallelSpawn") and, with sequential spawn, terminated
+# its turn early after ~6 steps. The atomic local roles (solver answers, advisor task-author) worked.
+#
+# THE GOAL — let the gemma4 population actually CONVERGE. gemma4:max hallucinates above ~0.8 temp, so
+# the creativity gene maps to a CAPPED real temperature = round(min(creativity/10, 0.7), 2): every
+# variant stays in the grounded band (≤0.7, below the cliff) and produces scoreable answers. The
+# cloud-sonnet advisor rewards vivid + decisive + FACTUALLY GROUNDED. Observe where in [0.0,0.7] the GA
+# settles for the best vivid+grounded output. (The earlier full-0–1 run hallucinated/dropped too many
+# results to converge — hence the cap + the all-cloud meta + only-gemma4-local changes.)
+#
+# Substrate (all ships): AgentDef fork/promote (mutation + REAL sampling overlay), Agent.parallel_spawn
+# (the generation), Evaluation (fitness), Memory user-scope (the ledger), Context op=self (run_id +
+# resolved temperature). Driven by work/exp6_run.sh evolve|verify (model-agnostic, reused verbatim).
+#
+# RESULT (validated): the GA completes 5 generations (lineage + promote intact, genes drift
+# creativity 4.8→9.0, winner ~0.87, v0.37 heartbeat/compaction held) BUT the population mean does not
+# climb — ~35% of variant-slots produce no usable score (gemma4:max drops the self-report ~20% /
+# hallucinates ~15%). The limiting factor for local agentic evolution is the small model's per-run
+# reliability, NOT the loomcycle substrate (which performed flawlessly). See this folder's README.
+#
+# ENV (set by run.sh from .env.local, NOT here): OLLAMA_BASE_URL=<your ollama host:11434>, global 16K
+# window (LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=16384 — no per-model override exists), 300s local header/idle
+# timeouts. Needs loomcycle >= v0.37.0 (the heartbeat ticker + compaction tail-cap keep long local
+# runs alive). The meta-agents use the OAuth sonnet provider — enable it or swap to an `anthropic`
+# API-key alias (see the README); a LOCAL model as the breeder does NOT work (the finding above).
+
+provider_priority:
+  - ollama-local          # LAN ollama — the EVOLVING roles (solver population + advisor judge)
+  - anthropic-oauth-dev   # cloud sonnet — the BREEDER (GA controller) ONLY; local couldn't drive it
+
+user_tiers:
+  default:
+    provider_priority: [ollama-local, anthropic-oauth-dev]
+    fallback_on_error: false   # pinned agents only — no silent cross-model fallback
+
+models:
+  local-gemma: { provider: ollama-local, model: gemma4:max }    # fast, temperature-sensitive (solver pop)
+  local-qwen:  { provider: ollama-local, model: qwen3.6:max }   # smarter/slower (advisor + breeder)
+
+agents:
+  # ───────────────────────────── exp6-solver (the evolving lineage — gemma4:max) ─────────────────────────────
+  # Operator root / seed of the lineage; the runtime population are FORKS of this def (the fork overlay
+  # re-values the genes + sampling.temperature, and INHERITS this provider+model pin → every variant
+  # runs gemma4:max). Base genes 5/5/5. Short runs (≤120-word answers) so 16K is ample.
+  exp6-solver:
+    provider: ollama-local
+    model: gemma4:max
+    max_iterations: 8
+    max_tokens: 2048
+    effort: medium                 # ollama ignores effort; the temperature knob is what bites on gemma4
+    allowed_tools: [Context, Memory]
+    memory_scopes: [user]
+    compaction: { enabled: true, autocompact_at_pct: 80, target_percentage: 30, keep_last_n: 4, keep_first: true }
+    system_prompt: |
+      You are EXP6-SOLVER, a creative-reasoning agent with a fixed inborn personality.
+
+      YOUR GENES (0 = minimum … 10 = maximum) — express ALL THREE consistently in every answer:
+      - creativity = 5 : 0-3 stay literal & conventional; 4-6 some novelty; 7-10 bold, lateral, vivid leaps.
+      - courage    = 5 : 0-3 hedge, qualify, avoid committing; 4-6 commit with a mild caveat; 7-10 commit decisively to ONE strong answer, no hedging.
+      - caution    = 5 : 0-3 confident & optimistic, minimal caveats; 4-6 note only key caveats; 7-10 self-critical, surface doubts & pile on caveats.
+
+      Be VIVID and DECISIVE per your genes — but stay FACTUALLY GROUNDED: never invent specifics,
+      names, numbers, or quotes. A vivid answer that is also accurate wins; a vivid answer that
+      hallucinates is scored DOWN. (At high creativity/temperature, resist the urge to fabricate.)
+
+      You operate in one of two modes, given in the user message:
+
+      MODE=SOLVE — the user message gives the TASK plus integers g and i.
+        1. Answer the task in <=120 words, FULLY in character per your genes above, vivid AND grounded.
+        2. Call Context op=self to read your own run_id AND your resolved sampling.temperature
+           (op=self returns a "sampling" object when a temperature is configured).
+        3. Memory op=set scope=user key="gen:<g>:var:<i>:result" value (JSON):
+             {"run_id":"<your run_id>","genes":{"creativity":5,"courage":5,"caution":5},
+              "temperature":<your sampling.temperature from Context op=self>,
+              "answer":"<your answer text>","gen":<g>,"var":<i>}
+           (use the g and i from the user message; use YOUR gene values shown above).
+        4. Output your answer text as your final message.
+
+      MODE=REFLECT — the user message gives your last score (0..1) and the advisor's feedback.
+        Propose YOUR CHILD'S genes so the child scores higher on the SAME task + rubric.
+        Output ONLY compact JSON: {"creativity":N,"courage":N,"caution":N}
+        — each an integer 0-10, each within ±3 of your OWN gene value above. No other text.
+
+      Never invent tool output. Reference any secret by name only (you handle none).
+
+  # ───────────────────────────── exp6-advisor (task-giver + GROUNDED fitness judge — CLOUD sonnet) ─────────────────────────────
+  # Moved to cloud sonnet (was qwen3.6:max local): keeping advisor+breeder on cloud means the ONLY
+  # locally-loaded model is gemma4:max (the solver population) — so ollama never swaps qwen↔gemma in
+  # VRAM mid-loop (the suspected cause of corrupted context / dropped solver self-reports). A reliable
+  # judge also matters for the grounded scoring.
+  exp6-advisor:
+    provider: anthropic-oauth-dev
+    model: claude-sonnet-4-6
+    max_iterations: 16
+    max_tokens: 3072
+    effort: medium
+    allowed_tools: [Evaluation, Memory, Context]
+    evaluation_scopes: [submit_any, read_any]
+    memory_scopes: [user]
+    compaction: { enabled: true, autocompact_at_pct: 60, target_percentage: 30, keep_last_n: 4, keep_first: true }
+    system_prompt: |
+      You are EXP6-ADVISOR: you pose ONE creative-reasoning task and you are the fitness function
+      that scores solvers. The fitness landscape REWARDS vivid+decisive answers BUT PUNISHES
+      hallucination — so a solver pushed to high temperature (wild, divergent) that invents false
+      specifics must score LOW. You operate in one of two modes (given in the user message):
+
+      MODE=AUTHOR_TASK:
+        Invent ONE small creative-reasoning task where a VIVID, BOLD answer excels BUT FACTUAL
+        ACCURACY is essential — the best answer is vivid AND correct, and a vivid-but-wrong answer
+        must fail. Prefer a task with a GROUNDED CORE, e.g. "give ONE surprising but ACCURATE
+        one-sentence analogy that explains <a real concept, e.g. how vaccines train the immune
+        system / why the sky is blue / how compound interest grows> to a 10-year-old". Answerable
+        in <=120 words. Store it: Memory op=set scope=user key="task:spec" value (JSON):
+          {"task":"<the task, one short paragraph, naming the REAL concept>",
+           "rubric":"Score 0..1. REWARD novelty/vividness AND decisiveness (commits to ONE answer, no hedging) AND factual GROUNDEDNESS (accurate; NO invented/hallucinated specifics). PENALIZE hedging/wishy-washiness AND hallucination/made-up facts EQUALLY. A vivid but factually wrong answer scores LOW."}
+        Output the task text. (You judge the OUTPUT — its vividness AND its accuracy — never the solver's genes.)
+
+      MODE=SCORE — the user message gives integer g and the variant count N.
+        Read task:spec (Memory op=get scope=user key="task:spec"). Then for each i in 0..N-1:
+          a. Memory op=get scope=user key="gen:<g>:var:<i>:result" → {run_id, answer}.
+          b. Judge the ANSWER ONLY against the rubric (never the genes). Pick score in [0,1] and
+             three dimensions in [0,1]: novelty, decisiveness, GROUNDEDNESS (1.0 = fully accurate,
+             0.0 = hallucinated/false specifics). The overall score must drop hard when groundedness
+             is low, even if novelty is high.
+          c. Evaluation op=submit run_id=<run_id> score=<score>
+               dimensions={"novelty":..,"decisiveness":..,"groundedness":..}
+               rationale="<one tight sentence: what was vivid AND whether it stayed accurate>".
+          d. Memory op=set scope=user key="gen:<g>:var:<i>:eval" value={"score":<score>,
+               "dimensions":{...},"rationale":"<same sentence>"}.
+        Output one line per variant: "var <i> score=<score>".
+
+      Be a consistent, calibrated judge across generations. Reference secrets by name only.
+
+  # ───────────────────────────── exp6-breeder (GA driver / meta-agent — qwen3.6:max) ─────────────────────────────
+  # Spawned once per GENERATION by work/exp6_run.sh with the generation number g in the prompt.
+  exp6-breeder:
+    # CLOUD sonnet, NOT local: qwen3.6:max could not reliably drive the multi-step GA orchestration
+    # at 16K (mis-formatted parallel_spawn's nested array; terminated early after ~6 steps). The
+    # breeder is the reliable CONTROLLER; the agents being STUDIED (solver pop + advisor) stay local.
+    provider: anthropic-oauth-dev
+    model: claude-sonnet-4-6
+    max_iterations: 80
+    max_tokens: 8192                # sonnet has a 200K window — no 16K cap on the controller
+    effort: high
+    allowed_tools: [Agent, AgentDef, Evaluation, Memory, Context]
+    agent_def_scopes: [named:exp6-solver]   # may fork/promote/retire the exp6-solver lineage only (the fork gate)
+    evaluation_scopes: [read_any]
+    memory_scopes: [user]
+    max_concurrent_children: 6
+    # Compact EARLY + small tail: the breeder's GA orchestration accumulates ledger reads + fork
+    # results; at the global 16K window the prefill cost is what kills a slow local run, so compact
+    # at 55% and keep only the 3 most-recent turns verbatim (the v0.37 tail-cap then folds the kept
+    # tail to ≤half the window). The system_prompt (the procedure) is never compacted.
+    compaction: { enabled: true, autocompact_at_pct: 55, target_percentage: 25, keep_last_n: 3, keep_first: true }
+    system_prompt: |
+      You are EXP6-BREEDER, the controller of a self-evolving agent population. You run ONCE per
+      generation; the user message gives the integer generation number g. CONSTANTS: POP=4,
+      MAX_GEN=5, THRESHOLD=0.90. The shared Memory ledger (scope=user) is the source of truth.
+      (THRESHOLD is above the gen-0 seed scores so the population EVOLVES a few generations, but
+      reachable enough to stop once a variant is clearly good — revealing the temperature trajectory.)
+
+      GENES — HARD RULE: there are EXACTLY three genes and their names are ALWAYS, LITERALLY:
+      creativity, courage, caution. NEVER rename, add, drop, or reinterpret a gene (do NOT invent
+      "knowledge_depth", "abstraction", "clarity", etc.) — no matter what the task is. Every genes
+      object you write is {"creativity":<int>,"courage":<int>,"caution":<int>}, each 0-10.
+
+      GENE → SYSTEM-PROMPT: every solver variant is a fork of "exp6-solver" whose system_prompt is
+      the EXACT base template below with only the three integers substituted (keep all other words
+      verbatim — same three gene names, same descriptions, AND the grounded-not-hallucinated rule):
+        ┌─ SOLVER TEMPLATE (substitute <C> <K> <A> with the gene integers) ─
+        | You are EXP6-SOLVER, a creative-reasoning agent with a fixed inborn personality.
+        | YOUR GENES (0=min..10=max) — express ALL THREE consistently in every answer:
+        | - creativity = <C> : 0-3 literal & conventional; 4-6 some novelty; 7-10 bold, lateral, vivid leaps.
+        | - courage    = <K> : 0-3 hedge, qualify, avoid committing; 4-6 commit with a mild caveat; 7-10 commit decisively to ONE strong answer, no hedging.
+        | - caution    = <A> : 0-3 confident & optimistic, minimal caveats; 4-6 note only key caveats; 7-10 self-critical, surface doubts & pile on caveats.
+        | Be VIVID and DECISIVE per your genes BUT stay FACTUALLY GROUNDED — never invent specifics; a vivid-but-wrong answer scores DOWN.
+        | MODE=SOLVE (user gives TASK + g + i): answer in <=120 words, fully in character, vivid AND grounded. Then Context op=self → read your run_id AND your resolved sampling.temperature (op=self returns a "sampling" object);
+        |   Memory op=set scope=user key="gen:<g>:var:<i>:result" value {"run_id":"<id>","genes":{"creativity":<C>,"courage":<K>,"caution":<A>},"temperature":<the sampling.temperature from Context op=self>,"answer":"<answer>","gen":<g>,"var":<i>}. Output your answer.
+        | MODE=REFLECT (user gives your score + feedback): output ONLY {"creativity":N,"courage":N,"caution":N}, each 0-10, within ±3 of your own value. No prose.
+        └─
+      GENE → SAMPLING (the realistic knob, v0.28.0): creativity drives the variant's REAL LLM
+      temperature, but CAPPED at 0.7 to keep gemma4 below its ~0.8 hallucination cliff:
+        temperature = round(min(creativity/10, 0.7), 2)   (0.0 focused … 0.7 max — NEVER higher).
+      Set via the AgentDef `sampling` overlay so it actually changes the model's sampling (readable by
+      the solver via Context op=self). Also map effort = creativity>=7 ? "high" : >=4 ? "medium" : "low".
+      Forks: AgentDef op=fork name="exp6-solver" overlay={"system_prompt":"<template with C,K,A substituted>",
+      "effort":"<mapped>","sampling":{"temperature":<round(min(creativity/10,0.7),2)>}}
+      description="gen<g> var<i> genes=(creativity,courage,caution) temp=<t> parent=<...>".
+      (NOTE: the fork INHERITS exp6-solver's provider+model = gemma4:max — do NOT set provider/model in the overlay.)
+
+      PROCEDURE for generation g:
+
+      A. SEED (only if g==0 AND Memory has no "gen:0:var:0"):
+         1. Author the task: Agent op=spawn name="exp6-advisor" prompt="MODE=AUTHOR_TASK". (It stores task:spec.)
+         2. Seed POP variants spread across the SAFE temperature band (all ≤0.7, below gemma4's ~0.8
+            hallucination cliff) so they stay grounded + scoreable: a low one, two mid, one at the cap. Use:
+            var0=(creativity 2,courage 4,caution 6)  var1=(4,5,5)  var2=(6,6,4)  var3=(7,7,3).
+            (order is creativity,courage,caution → temperatures 0.2 / 0.4 / 0.6 / 0.7.) For each i:
+            fork exp6-solver as above; Memory op=set scope=user key="gen:0:var:<i>" value={"def_id":
+            "<fork def_id>","genes":{...},"parent":null,"gen":0,"var":<i>}.
+
+      B. READ this gen's variants: Memory op=list scope=user prefix="gen:<g>:var:" — collect the
+         POP entries that have a "def_id" (keys "gen:<g>:var:<i>"). Let them be variants[i].
+
+      C. SOLVE (fan-out, PARALLEL — small fast agents run concurrently): Agent op=parallel_spawn with
+         a real spawns ARRAY (NOT a JSON-encoded string — pass the array directly):
+           spawns=[ for each variant i: {"name":"exp6-solver","def_id":variants[i].def_id,
+             "prompt":"MODE=SOLVE. g=<g> i=<i>. TASK: <the task text from task:spec>. Self-report to Memory key gen:<g>:var:<i>:result, then output your answer."} ].
+         The AND-barrier returns when all POP solvers finish; each self-reports its run_id+answer to
+         gen:<g>:var:<i>:result. (True concurrency needs ollama OLLAMA_NUM_PARALLEL>=POP on the box;
+         otherwise ollama queues them — still correct, just serialized.)
+
+      D. SCORE: Agent op=spawn name="exp6-advisor" prompt="MODE=SCORE. g=<g> N=<POP>." (It submits
+         an Evaluation per solver run and writes gen:<g>:var:<i>:eval.)
+
+      E. SELECT: Memory op=get each gen:<g>:var:<i>:eval → score_i. best = the variant with the max
+         score; record Memory op=set key="gen:<g>:summary" value={"scores":[..],"mean":<avg>,
+         "best_var":<i>,"best_def_id":"<def_id>","best_score":<score>}.
+
+      F. STOP or MUTATE:
+         IF best_score >= THRESHOLD OR g == MAX_GEN-1:
+            AgentDef op=promote def_id=<best_def_id>  (sets active exp6-solver = winner).
+            Memory op=set key="result:summary" value={"generations":<g+1>,"best_score":<score>,
+              "winner_def_id":"<def_id>","stopped":"threshold|max_gen"}.
+            Final line: "GEN <g> DONE best=<score> winner=<def_id> status=STOP".
+         ELSE (mutate survivors into gen g+1, POP children):
+            - Elitism: carry the best variant unchanged as gen<g+1> var0 (same def_id+genes):
+              Memory op=set key="gen:<g+1>:var:0" value={"def_id":best_def_id,"genes":best.genes,
+                "parent":best_def_id,"gen":<g+1>,"var":0}.
+            - For j=1..POP-1: pick parent = the j-th best variant (fallback: best). Reflect:
+              Agent op=spawn name="exp6-solver" def_id=parent.def_id prompt="MODE=REFLECT. Your score
+              was <parent.score>/1.0. Advisor feedback: <parent eval rationale>. Propose your child's genes."
+              Parse the child genes JSON from its output (clamp 0-10, within ±3 of parent gene).
+              Fork: AgentDef op=fork name="exp6-solver" parent_def_id=parent.def_id
+                overlay={"system_prompt":<rebuilt for child genes>,"effort":<mapped>,"sampling":{"temperature":<round(min(child creativity/10,0.7),2)>}}
+                description="gen<g+1> var<j> genes=(...) temp=<t> parent gen<g> var<p>".
+              Memory op=set key="gen:<g+1>:var:<j>" value={"def_id":"<child def_id>","genes":{...},
+                "parent":parent.def_id,"gen":<g+1>,"var":<j>}.
+            Final line: "GEN <g> DONE best=<best_score> winner=<best_def_id> status=CONTINUE".
+
+      Do exactly the steps for the given g, then stop. Keep memory values compact JSON. Never invent
+      tool output; if a child run errored, record its score as 0 and continue. Reference secrets by name only.
+
+concurrency:
+  # Local box: ollama serializes requests per loaded model, so parallel_spawn effectively queues —
+  # keep the gate modest. (Only ONE local model loaded: gemma4:max for the solvers; meta on cloud sonnet.)
+  max_concurrent_runs: 6
+  max_queue_depth: 16
+  queue_timeout_ms: 60000

--- a/examples/exp6.8-local-evolution/run.sh
+++ b/examples/exp6.8-local-evolution/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Launch exp6.8 (self-evolving agents on LOCAL models) self-contained from this folder. The ONLY
+# local model is gemma4:max (the evolving solver population); the meta-agents (breeder + advisor) run
+# on cloud sonnet. Needs: loomcycle >= v0.37.0, an ollama host with your solver model, and a sonnet
+# provider (OAuth or an Anthropic API key — see README). Drive from a second terminal:
+#   ./work/exp6_run.sh evolve
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$HERE/.env.local" ] || { cp "$HERE/.env.local.example" "$HERE/.env.local"; \
+  echo "run.sh: created .env.local — set OLLAMA_BASE_URL + a sonnet provider, then re-run."; }
+set -a; source "$HERE/.env.local"; set +a
+
+export LOOMCYCLE_DATA_DIR="${LOOMCYCLE_DATA_DIR:-$HERE/data}"
+export LOOMCYCLE_LISTEN_ADDR="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
+export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED="${LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED:-1}"
+
+# ── Local-model knobs (the gemma4:max solver population dials this ollama host) ──
+export OLLAMA_BASE_URL="${OLLAMA_BASE_URL:-http://localhost:11434}"
+# Global context window for ollama-local (no per-model override exists). 16K is ample for the
+# short (<=120-word) solver answers and keeps prefill cheap on a slow box.
+export LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX="${LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX:-16384}"
+# Generous local time-to-first-byte / inter-token timeouts (cold model load + slow generation).
+export LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS="${LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS:-300000}"
+export LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS="${LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS:-300000}"
+
+mkdir -p "$HERE/data"
+LOOMCYCLE_BIN="${LOOMCYCLE_BIN:-loomcycle}"
+command -v "$LOOMCYCLE_BIN" >/dev/null 2>&1 || { echo "run.sh: '$LOOMCYCLE_BIN' not on PATH — install loomcycle >= v0.37.0 or set LOOMCYCLE_BIN." >&2; exit 127; }
+exec "$LOOMCYCLE_BIN" "$@" --config "$HERE/loomcycle.yaml"

--- a/examples/exp6.8-local-evolution/work/exp6_run.sh
+++ b/examples/exp6.8-local-evolution/work/exp6_run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# exp6 driver — self-evolving agents. A THIN generation-stepper: the agents do ALL the
+# mutation/scoring/forking; this script only loops generations, blocks on each breeder run,
+# reads the shared Memory ledger to detect the stop condition, then runs the independent
+# re-derivation. Token-safe: every REST call goes through ../loomcurl.sh (bearer via stdin;
+# omitted in dev open mode).
+#
+# Usage (run from a second terminal after ./run.sh):
+#   ./work/exp6_run.sh evolve     # run the generation loop until a solver crosses THRESHOLD (or MAX_GEN)
+#   ./work/exp6_run.sh verify     # re-run the independent re-derivation only (reads the store)
+#
+# Env: EXP6_BASE (default http://127.0.0.1:8787 — match run.sh's LOOMCYCLE_LISTEN_ADDR),
+#      EXP6_LOG (default /tmp/exp6.log), EXP6_GEN_TIMEOUT (default 900s),
+#      MAX_GEN (default 5), THRESHOLD (default 0.90 — match the breeder prompt's constant).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+CURL="$ROOT/loomcurl.sh"
+BASE="${EXP6_BASE:-http://127.0.0.1:8787}"
+USER_ID=exp6
+MAX_GEN="${MAX_GEN:-5}"
+THRESHOLD="${THRESHOLD:-0.90}"
+LOG="${EXP6_LOG:-/tmp/exp6.log}"
+PY=python3
+
+jcurl() { "$CURL" -sS "$@"; }
+
+mem_get() { # $1=key → entry.value JSON, or EMPTY string when the key is absent (404)
+  jcurl "$BASE/v1/_memory/scopes/user/$USER_ID/keys/$1" \
+    | "$PY" -c 'import sys,json
+try:
+  d=json.load(sys.stdin); e=d.get("entry")
+  v=e.get("value") if isinstance(e,dict) else None
+  if v is not None:
+    sys.stdout.write(v if isinstance(v,str) else json.dumps(v))
+except Exception: pass' 2>/dev/null
+}
+
+mem_list() { # $1=prefix → entries array JSON
+  jcurl "$BASE/v1/_memory/scopes/user/$USER_ID/keys?prefix=$1&limit=500"
+}
+
+spawn_blocking() { # $1=agent $2=text ; blocks until the run's SSE stream closes
+  local agent="$1" text="$2" body
+  body=$("$PY" -c 'import json,sys
+print(json.dumps({"agent":sys.argv[1],"user_id":sys.argv[2],
+  "segments":[{"role":"user","content":[{"type":"trusted-text","text":sys.argv[3]}]}]}))' \
+    "$agent" "$USER_ID" "$text")
+  timeout "${EXP6_GEN_TIMEOUT:-900}" "$CURL" -N -X POST "$BASE/v1/runs" \
+    -H 'Content-Type: application/json' -d "$body" >>"$LOG" 2>&1 || true
+}
+
+agentdef() { # $1 = JSON body (passed as a literal arg — loomcurl reserves stdin for the auth header).
+  "$CURL" -sS -X POST "$BASE/v1/_agentdef" -H 'Content-Type: application/json' -d "$1"
+}
+
+# ───────────────────────────── evolve (static variant) ─────────────────────────────
+evolve() {
+  : > "$LOG"
+  echo "exp6 → $BASE  user=$USER_ID  MAX_GEN=$MAX_GEN  THRESHOLD=$THRESHOLD"
+  local g stopped=""
+  for g in $(seq 0 $((MAX_GEN-1))); do
+    echo "=== generation $g — spawning exp6-breeder ==="
+    spawn_blocking exp6-breeder "g=$g"
+    local summ; summ="$(mem_get "gen:$g:summary")"
+    echo "  gen:$g:summary = ${summ:-<none>}"
+    local res; res="$(mem_get "result:summary")"
+    if [ -n "$res" ]; then echo "  result:summary = $res"; stopped="$res"; break; fi
+  done
+  [ -z "$stopped" ] && echo "  (reached MAX_GEN without an explicit result:summary)"
+  echo; verify
+}
+
+# ───────────────────────────── verify (independent re-derivation) ─────────────────────────────
+verify() {
+  echo "===== independent re-derivation (from the store, not the breeder's report) ====="
+  local tmp; tmp="$(mktemp /tmp/exp6_ledger.XXXXXX.json)"
+  mem_list 'gen:' > "$tmp"
+  local res; res="$(mem_get "result:summary")"
+  "$PY" "$HERE/exp6_verify.py" "$tmp" "$res"
+  rm -f "$tmp"
+  # winner + promotion detail (re-uses $res from above)
+  echo "[winner] result:summary = ${res:-<none>}"
+  if [ -n "$res" ]; then
+    local wdef; wdef="$(printf '%s' "$res" | "$PY" -c 'import sys,json; print(json.load(sys.stdin).get("winner_def_id",""))' 2>/dev/null || true)"
+    if [ -n "$wdef" ]; then
+      echo "[check] winner def + lineage parent:"
+      agentdef "{\"op\":\"get\",\"def_id\":\"$wdef\"}" \
+        | "$PY" -c 'import sys,json
+try:
+  d=json.load(sys.stdin); print("  def:",d.get("name"),"v"+str(d.get("version")),"parent="+str(d.get("parent_def_id")))
+except Exception as e: print("  (agentdef get failed:",e,")")' 2>/dev/null || true
+    fi
+  fi
+  echo "[check] active exp6-solver def (promotion target):"
+  jcurl "$BASE/v1/_agentdef/names" | "$PY" -c 'import sys,json
+try:
+  d=json.load(sys.stdin);
+  rows=d.get("names") or d.get("agent_defs") or d
+  print("  ",json.dumps(rows)[:400])
+except Exception: print("  (names query shape differs; inspect manually)")' 2>/dev/null || true
+}
+
+case "${1:-evolve}" in
+  evolve) evolve ;;
+  verify) verify ;;
+  *) echo "usage: $0 {evolve|verify}" >&2; exit 2 ;;
+esac

--- a/examples/exp6.8-local-evolution/work/exp6_verify.py
+++ b/examples/exp6.8-local-evolution/work/exp6_verify.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# exp6 independent re-derivation. Reads the generation ledger JSON (the `entries` array from
+# GET /v1/_memory/scopes/user/exp6/keys?prefix=gen:) from a FILE (argv[1]) — never trusts the
+# breeder's self-report. Recomputes per-generation mean/max score + mean gene vector, checks the
+# improvement trend and lineage integrity. argv[2]=result:summary JSON (or "" if none).
+import sys, json
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f).get("entries", [])
+    except Exception:
+        return []
+
+def val(v):
+    if isinstance(v, str):
+        try: return json.loads(v)
+        except Exception: return {}
+    return v or {}
+
+entries = load(sys.argv[1])
+result = sys.argv[2] if len(sys.argv) > 2 else ""
+
+gens = {}  # g -> {i -> {genes, score, def_id, parent}}
+for e in entries:
+    k = e.get("key", ""); v = val(e.get("value"))
+    p = k.split(":")                       # gen:<g>:var:<i>[:result|:eval]
+    if len(p) < 4 or p[0] != "gen" or p[2] != "var":
+        continue
+    try: g, i = int(p[1]), int(p[3])
+    except ValueError: continue
+    slot = gens.setdefault(g, {}).setdefault(i, {})
+    if len(p) == 4:                        # the genotype record
+        slot["def_id"] = v.get("def_id"); slot["genes"] = v.get("genes"); slot["parent"] = v.get("parent")
+    elif p[4] == "eval":
+        slot["score"] = v.get("score")
+    elif p[4] == "result":
+        slot.setdefault("genes", v.get("genes")); slot["run_id"] = v.get("run_id")
+
+print("gen | n | mean_score | max_score | mean_genes {creativity,courage,caution}")
+first_mean = last_mean = None
+for g in sorted(gens):
+    vs = list(gens[g].values())
+    scores = [x["score"] for x in vs if isinstance(x.get("score"), (int, float))]
+    genes = [x["genes"] for x in vs if isinstance(x.get("genes"), dict)]
+    mean = sum(scores) / len(scores) if scores else None
+    mx = max(scores) if scores else None
+    def avg(key):
+        gg = [gd[key] for gd in genes if isinstance(gd.get(key), (int, float))]
+        return round(sum(gg) / len(gg), 1) if gg else None
+    mg = {k: avg(k) for k in ("creativity", "courage", "caution")}
+    ms = f"{mean:8.3f}" if mean is not None else "   n/a  "
+    xs = f"{mx:7.3f}" if mx is not None else "  n/a  "
+    print(f"{g:3d} | {len(vs):d} | {ms} | {xs} | {mg}")
+    if mean is not None:
+        if first_mean is None: first_mean = mean
+        last_mean = mean
+
+print()
+if first_mean is not None and last_mean is not None:
+    verdict = "PASS" if last_mean >= first_mean else "REVIEW (declined)"
+    print(f"[check] mean(score) last gen ({last_mean:.3f}) >= first gen ({first_mean:.3f}) ? {verdict}")
+else:
+    print("[check] improvement: n/a (no scored generations)")
+
+# lineage integrity: every gen>0 variant's parent must resolve to a known def_id
+defids = {x["def_id"] for g in gens for x in gens[g].values() if x.get("def_id")}
+broken = [(g, i) for g in gens if g > 0 for i, x in gens[g].items()
+          if x.get("parent") and x["parent"] not in defids]
+if any(g > 0 for g in gens):
+    print(f"[check] lineage parents all resolve to a known def_id ? {'PASS' if not broken else 'FAIL ' + str(broken)}")
+else:
+    print("[check] lineage: only gen 0 present (no mutation generations to check)")
+
+if result:
+    try:
+        r = json.loads(result) if isinstance(result, str) else result
+        print(f"[winner] generations={r.get('generations')} best_score={r.get('best_score')} "
+              f"winner_def_id={r.get('winner_def_id')} stopped={r.get('stopped')}")
+    except Exception:
+        print(f"[winner] result:summary = {result[:200]}")


### PR DESCRIPTION
## What
Adds `examples/exp6.8-local-evolution/` — the [exp6](../tree/main/examples/exp6-self-evolving-agents) genetic algorithm rerun on **local ollama models**: a `gemma4:max` solver population (the only locally-loaded model) evolved by **cloud-sonnet** meta-agents (breeder + advisor), `creativity→temperature` capped ≤0.7, no snapshot.

## The result is the point (a negative-ish finding)
The GA **completes 5 generations** — lineage + promote intact, genes drift creativity 4.8→9.0, winner ~0.87, and the **v0.37 heartbeat/compaction robustness holds** through the long local run — **but the population mean does not climb**: ~35% of variant-slots produce no usable score (gemma4:max silently drops the self-report ~20% of the time and hallucinates ~15%).

**Finding: the limiting factor for local agentic evolution is the small model's per-run reliability, not the loomcycle substrate** (which performed flawlessly — sonnet orchestration, lineage, parallel_spawn, capped-temp `sampling` reaching gemma4).

Why the split: a **local model as the breeder does not work** (`qwen3.6:max` mis-formatted the nested `parallel_spawn` array / terminated early), so the meta-agents are cloud sonnet; keeping both meta-agents on cloud also stops ollama swapping qwen↔gemma in VRAM mid-loop.

## Contents
`loomcycle.yaml` (gemma4 solver + sonnet advisor/breeder, capped-temp breeder, slow-local compaction) · `run.sh` (sets `OLLAMA_BASE_URL`, 16K global window, 300s local timeouts, OAuth on) · reused `work/exp6_run.sh` + `work/exp6_verify.py` (model-agnostic) · `loomcurl.sh` · a README documenting the finding + how to run + the iteration journey. Adds the `examples/README.md` index row.

## Testing
Validated end-to-end in the loomcycle sandbox (the experiments repo) on a v0.37.0-level build (commit afa9689): full 5-gen run, winner 0.87, the trajectory + reliability numbers above.

## Notes
- ⚠️ Not fully self-contained: needs an ollama host (your solver model) + a cloud sonnet provider (OAuth or `ANTHROPIC_API_KEY`). Needs loomcycle ≥ v0.37.0.
- RFC candidates surfaced: per-model `num_ctx` (global-only today); a config-side `sampling.temperature` clamp (even sonnet leaked one uncapped temp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)