### PR TITLE
feat(volumes)!: RFC AH Phase 3 — retire the legacy filesystem jail

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -1,7 +1,7 @@
 # loomcycle CONFIG (non-secret) — copy to .env.insecure and edit.
 #
 # This file holds ONLY non-secret operational config: listen address,
-# storage + sandbox paths, host allowlists, feature flags, timeouts, and
+# storage paths, host allowlists, feature flags, timeouts, and
 # the trigger-credential allowlists (which list env-var NAMES, never
 # values). Nothing here is a secret, so it is safe to read, diff, and —
 # if you keep your deployment in its own repo — commit.
@@ -37,14 +37,16 @@ LOOMCYCLE_LISTEN_ADDR=127.0.0.1:8787
 # ─── Storage ──────────────────────────────────────────────────────────
 LOOMCYCLE_DATA_DIR=./data
 
-# ─── Built-in tool sandboxes (each tool refuses every call until set) ─
+# ─── Filesystem volumes (RFC AH Phase 3) ─────────────────────────────
 #
-# Read tool — agents may read files inside this directory only.
-# Symlinks resolved before the sandbox check (no symlink-escape).
-# LOOMCYCLE_READ_ROOT=/srv/loomcycle/files
-
-# Write + Edit tools — same shape as Read. Atomic tempfile + rename.
-# LOOMCYCLE_WRITE_ROOT=/srv/loomcycle/scratch
+# The file/exec tools (Read/Write/Edit/Glob/Grep/Bash/NotebookEdit) are
+# sandboxed to named VOLUMES, declared in the YAML `volumes:` block — NOT
+# via env vars. The legacy LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD jail
+# is RETIRED: setting one now fails startup with a migration hint.
+# Sandbox-by-default — an agent bound to no volume has no disk access.
+# To restore the old single shared jail, add to your loomcycle.yaml:
+#   volumes:
+#     default: { path: /srv/loomcycle/scratch, mode: rw, default: true }
 
 # HTTP + WebFetch tools — comma-separated suffix-match host allowlist.
 # Entry "example.com" matches "example.com" and "api.example.com" but
@@ -78,9 +80,9 @@ LOOMCYCLE_DATA_DIR=./data
 # Bash tool — explicitly opt-in. NOT a true sandbox: cwd-restricted,
 # env-scrubbed (only PATH leaks), output-bounded (1 MiB), time-capped
 # (30s default, 5min max). Run loomcycle inside a container if you
-# expose Bash to untrusted prompts.
+# expose Bash to untrusted prompts. Bash requires a rw `volumes:` binding
+# (it runs in the bound volume's root) — see the volumes note above.
 # LOOMCYCLE_BASH_ENABLED=1
-# LOOMCYCLE_BASH_CWD=/srv/loomcycle/scratch
 
 # ─── Skills (v0.4.0+) ────────────────────────────────────────────────
 #

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Same Go binary, same config schema. Operator flips a few env vars to pick the po
 
 | Posture | Configuration shape | Use case |
 |---|---|---|
-| **True managed sandbox** | `LOOMCYCLE_BASH_ENABLED=0`, `LOOMCYCLE_READ_ROOT` / `LOOMCYCLE_WRITE_ROOT` unset, `LOOMCYCLE_HTTP_HOST_ALLOWLIST` empty, `LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1`. Every tool default-deny; agents can only reach what the caller's per-request `allowed_hosts` says. | Shared-server deployments processing untrusted prompts. The runtime survives contact with adversarial input. |
-| **Agentic dev environment** | Bash enabled, filesystem roots set to your workspace, broad `allowed_hosts`, optional local Ollama for offline work. | Local development. Internal trusted operators. Single-user research workstation. |
+| **True managed sandbox** | `LOOMCYCLE_BASH_ENABLED=0`, no `volumes:` block (sandbox-by-default — agents get no disk access), `LOOMCYCLE_HTTP_HOST_ALLOWLIST` empty, `LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1`. Every tool default-deny; agents can only reach what the caller's per-request `allowed_hosts` says. | Shared-server deployments processing untrusted prompts. The runtime survives contact with adversarial input. |
+| **Agentic dev environment** | Bash enabled, a `default` rw `volumes:` entry pointing at your workspace, broad `allowed_hosts`, optional local Ollama for offline work. | Local development. Internal trusted operators. Single-user research workstation. |
 
 The trust boundary is **operator / caller**. The operator config is the floor; callers can narrow per-request but never widen. The bearer token (`LOOMCYCLE_AUTH_TOKEN`) is the authority. Treat anyone with the token as fully trusted to drive the runtime. For true isolation in the sandbox posture, run loomcycle inside a container or VM. `Bash` is restricted (cwd, env scrub, output bounds, timeouts) but it is **not** a kernel-level sandbox.
 

--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -10,6 +10,24 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ## What's in vNEXT
 
+**⚠️ BREAKING — the legacy filesystem jail is retired (RFC AH Phase 3).** The
+`LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD` env vars are **removed**;
+Volumes (below) are now the SOLE filesystem mechanism. An agent not bound to any
+volume — and a deployment with no `default` volume declared — has **no
+filesystem access**: every Read/Write/Edit/Glob/Grep/Bash/NotebookEdit call
+refuses (sandbox-by-default, mirroring "no `allowed_hosts` → no egress").
+
+- **Migration:** replace the three env vars with a single `default` volume —
+  `volumes: { default: { path: /work/sandbox, mode: rw, default: true } }`
+  reproduces the old single-jail behaviour. A deploy that still sets any of the
+  retired env vars now **fails at config-load** with a migration hint (so a
+  stale config is caught at boot, not silently denied).
+- This **supersedes** the Phase-1 interim "unbound agents fall back to the
+  legacy roots" behaviour described below — that fallback no longer exists.
+- The TOCTOU-safe `resolveInsideRoot` containment is unchanged; the only change
+  is that an inactive volume policy now DENIES instead of falling back, and the
+  tools no longer carry a construction-time `Root`/`Cwd`.
+
 **📁 Filesystem Volumes — per-agent ro/rw scopes (RFC AH Phase 1).** The
 file/exec tools were confined to a single per-instance jail
 (`LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD`) shared by every agent and

--- a/cmd/loomcycle/embedded/loomcycle.example.yaml
+++ b/cmd/loomcycle/embedded/loomcycle.example.yaml
@@ -412,20 +412,21 @@ defaults:
 
 # (Model aliases are defined at the TOP of this file — see "Model aliases".)
 
-# ─── Volumes (RFC AH Phase 1) ─────────────────────────────────────────
+# ─── Volumes (RFC AH) ─────────────────────────────────────────────────
 # Named filesystem roots the file/exec tools (Read/Write/Edit/Glob/Grep/
 # Bash/NotebookEdit) resolve paths against — the filesystem analog of the
-# host allowlist. Each path MUST already exist and be a directory
-# (validated at config-load; the runtime never creates a static volume).
-# At most one may be `default: true` — it's used when a tool call omits
-# the `volume` argument.
+# host allowlist, and the SOLE filesystem mechanism. Each path MUST
+# already exist and be a directory (validated at config-load; the runtime
+# never creates a static volume). At most one may be `default: true` —
+# it's used when a tool call omits the `volume` argument.
 #
-# OMIT this whole block to keep the legacy single jail: with no volumes:
-# and no per-agent `volumes:`, the file tools use LOOMCYCLE_READ_ROOT /
-# WRITE_ROOT / BASH_CWD exactly as before (nothing is synthesized — the
-# three legacy roots are NOT collapsed into one volume). Declare a volume
-# named `default` here to give unbound agents a default; otherwise bind an
-# agent via its `volumes:` list (see the agents block below).
+# SANDBOX-BY-DEFAULT (RFC AH Phase 3): the legacy LOOMCYCLE_READ_ROOT /
+# WRITE_ROOT / BASH_CWD jail is RETIRED. An agent bound to no volume (and
+# a deployment with no `default` volume) has NO filesystem access — every
+# file/exec tool refuses. Setting one of the retired env vars now fails
+# startup with a migration hint. To restore the old single shared jail,
+# declare one `default` volume below. Bind an agent to a narrower set via
+# its `volumes:` list (see the agents block below).
 # ro = Read/Glob/Grep only; rw = also Write/Edit/Bash/Notebook.
 # `loomcycle help volumes` for the full topic.
 #

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -561,19 +561,20 @@ func main() {
 	}
 
 	allTools := []tools.Tool{
-		&builtin.Read{Root: cfg.Env.ReadRoot},
-		&builtin.Write{Root: cfg.Env.WriteRoot},
-		&builtin.Edit{Root: cfg.Env.WriteRoot},
-		// Grep + Glob ride the Read sandbox (read-only content/path
-		// search). NotebookEdit rides the Write sandbox (it mutates
-		// .ipynb files atomically, same posture as Edit).
-		&builtin.Grep{Root: cfg.Env.ReadRoot},
-		&builtin.Glob{Root: cfg.Env.ReadRoot},
-		&builtin.NotebookEdit{Root: cfg.Env.WriteRoot},
+		// The file/exec tools resolve their sandbox root per-call from the
+		// run's VolumePolicy (RFC AH); an agent bound to no volume is refused
+		// (sandbox-by-default — the legacy READ_ROOT/WRITE_ROOT/BASH_CWD jail
+		// was retired in Phase 3).
+		&builtin.Read{},
+		&builtin.Write{},
+		&builtin.Edit{},
+		&builtin.Grep{},
+		&builtin.Glob{},
+		&builtin.NotebookEdit{},
 		httpTool,
 		&builtin.WebFetch{HTTP: httpTool},
 		&builtin.WebSearch{APIKey: cfg.Env.BraveAPIKey},
-		&builtin.Bash{Enabled: cfg.Env.BashEnabled, Cwd: cfg.Env.BashCwd},
+		&builtin.Bash{Enabled: cfg.Env.BashEnabled},
 		// SkillTool's Store is late-bound below (so DB-active SkillDef
 		// rows override the static Set body). Nil-Store before
 		// late-binding falls back to the static Set; the assignment
@@ -739,11 +740,8 @@ func main() {
 			allTools = append(allTools, laTools...)
 		}
 	}
-	if cfg.Env.ReadRoot == "" {
-		log.Printf("note: Read tool is registered but disabled — set LOOMCYCLE_READ_ROOT to enable")
-	}
-	if cfg.Env.WriteRoot == "" {
-		log.Printf("note: Write + Edit tools are registered but disabled — set LOOMCYCLE_WRITE_ROOT to enable")
+	if len(cfg.Volumes) == 0 {
+		log.Printf("note: file tools (Read/Write/Edit/Glob/Grep/Bash) require a `volumes:` binding — none configured; agents with no volume binding have no filesystem access")
 	}
 	if len(staticHosts) == 0 && !cfg.Env.HTTPCallerAuthoritative {
 		log.Printf("note: HTTP + WebFetch tools are registered but disabled — set LOOMCYCLE_HTTP_HOST_ALLOWLIST to enable (or LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1 to delegate the allowlist to the caller)")
@@ -759,9 +757,7 @@ func main() {
 	}
 	if cfg.Env.BashEnabled {
 		log.Printf("WARNING: Bash tool is enabled (LOOMCYCLE_BASH_ENABLED=1). This is NOT a true sandbox — run loomcycle inside a container or VM if you expose this to untrusted prompts.")
-		if cfg.Env.BashCwd == "" {
-			log.Printf("note: Bash is enabled but has no cwd; every call will refuse — set LOOMCYCLE_BASH_CWD")
-		}
+		log.Printf("note: Bash requires a rw volume binding — it runs in the bound volume's root and refuses an agent with no rw volume")
 	} else {
 		log.Printf("note: Bash tool is registered but disabled — set LOOMCYCLE_BASH_ENABLED=1 to enable (NOT a true sandbox; see docs)")
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -855,7 +855,7 @@ loomcycle is configured entirely through environment variables (the `loomcycle.y
 | File | Holds | Git posture | Safe to read/diff/share? |
 |---|---|---|---|
 | **`.env.local`** | **Secrets** — provider API keys (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, …), the sidecar bearer `LOOMCYCLE_AUTH_TOKEN`, `BRAVE_API_KEY`, the operator-token pepper, and the secret **values** behind any trigger-credential env names. | **git-ignored**, never committed | **No** — surfacing it leaks credentials |
-| **`.env.insecure`** | **Non-secret config** — `LOOMCYCLE_LISTEN_ADDR`, `LOOMCYCLE_DATA_DIR`, the sandbox roots (`READ_ROOT`/`WRITE_ROOT`/`BASH_CWD`), host allowlists, feature flags (metrics, webhooks, fallback), timeouts, and the trigger-credential allowlist **names** (`LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST` / `LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`). | git-ignored in *this* repo; commit it in your own deployment repo if you wish | **Yes** — nothing here is a secret |
+| **`.env.insecure`** | **Non-secret config** — `LOOMCYCLE_LISTEN_ADDR`, `LOOMCYCLE_DATA_DIR`, host allowlists, feature flags (metrics, webhooks, fallback), timeouts, and the trigger-credential allowlist **names** (`LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST` / `LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST`). (Filesystem sandboxing moved to the YAML `volumes:` block — RFC AH Phase 3 retired the `READ_ROOT`/`WRITE_ROOT`/`BASH_CWD` env vars.) | git-ignored in *this* repo; commit it in your own deployment repo if you wish | **Yes** — nothing here is a secret |
 
 **Why split.** The two halves have different blast radii. `.env.insecure` is the part you want in code review, in a config-management repo, in a teammate's hands when they ask "what's your sandbox set to?" — none of it is dangerous to expose. `.env.local` is the part one accidental `cat` in a screen-share burns. Keeping them in one file forces the whole thing to the secret tier and makes the operational config needlessly hard to share. The split also matches the security rule in `CLAUDE.md` — agents (and Claude Code) must never open `.env.local`, but `.env.insecure` is freely readable.
 
@@ -877,9 +877,9 @@ cp .env.insecure.example  .env.insecure   # then adjust paths/flags
 
 ---
 
-## 9d. Filesystem Volumes — per-agent ro/rw scopes (RFC AH Phase 1)
+## 9d. Filesystem Volumes — per-agent ro/rw scopes (RFC AH)
 
-The file/exec tools (Read / Write / Edit / Glob / Grep / Bash / NotebookEdit) used to share a single per-instance jail (`LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD`). A **Volume** is a named, per-agent, read-only-or-read-write root that replaces it — the filesystem analog of the caller-authoritative `allowed_hosts` host policy. Two ensembles in one runtime can now be confined to separate working trees.
+The file/exec tools (Read / Write / Edit / Glob / Grep / Bash / NotebookEdit) used to share a single per-instance jail (`LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD`). **Phase 3 retired that jail** — a **Volume** (a named, per-agent, read-only-or-read-write root) is now the *sole* filesystem mechanism, the filesystem analog of the caller-authoritative `allowed_hosts` host policy. Two ensembles in one runtime can be confined to separate working trees, and **disk access is sandbox-by-default**: an agent bound to no volume has none.
 
 **Top-level `volumes:` map** — the universe of bindable roots (the filesystem analog of registered tools). Declared once by the operator:
 
@@ -903,16 +903,23 @@ agents:
     volumes: [repo-a, shared-ro]   # confined to these; cannot touch default or repo-b
 ```
 
-- An agent that declares **no** `volumes` is implicitly bound to `[default]` — backward-compatible.
+- An agent that declares **no** `volumes` is implicitly bound to `[default]` — *if* a `default` volume exists. With no `default` volume declared, an unbound agent has **no filesystem access** (sandbox-by-default).
 - An agent that declares volumes is confined to **exactly those** — it does *not* implicitly also get `default`.
 
 **ro / rw enforcement.** Read / Glob / Grep operate on any bound volume. Write / Edit / NotebookEdit require a `rw` volume (a `ro` target is refused). **Bash requires `rw` and is refused on a `ro` volume** — a shell can write via absolute paths and redirection, so loomcycle refuses rather than ship a read-only guarantee it cannot keep (CLAUDE.md rule #7).
 
-**Spawn confinement.** A sub-agent inherits its parent's confinement: an *unbound* child gets the parent's policy verbatim; a child that *declares* volumes is **narrowed** to (child-declared) ∩ (parent's active bindings), with ro/rw resolving to the more restrictive. A child can never gain a volume its parent lacks; a child that shares none of the parent's volumes is confined to nothing — its file tools are denied (it does **not** fall back to the legacy jail). Mirrors host-allowlist narrowing.
+**Spawn confinement.** A sub-agent inherits its parent's confinement: an *unbound* child gets the parent's policy verbatim; a child that *declares* volumes is **narrowed** to (child-declared) ∩ (parent's active bindings), with ro/rw resolving to the more restrictive. A child can never gain a volume its parent lacks; a child that shares none of the parent's volumes is confined to nothing — its file tools are denied. Mirrors host-allowlist narrowing.
 
-**Backward compatibility.** With no `volumes:` block and no agent bindings, agents run **unconfined by volumes** and each file tool uses its own legacy root (`Read`←`LOOMCYCLE_READ_ROOT`, `Write`←`WRITE_ROOT`, `Bash`←`BASH_CWD`) — **byte-identical** to before. The three legacy roots are deliberately **not** collapsed into one synthesized `default` volume: a single root can't reproduce three distinct ones (Read would read `WriteRoot`, Bash would lose `BashCwd`), and a `ReadRoot`-only "writes disabled" deployment must not silently gain write access. A `default` volume exists only if you declare it (unbound agents then bind to it); declare explicit `volumes:` to adopt the feature.
+**Sandbox-by-default & migration (RFC AH Phase 3).** The legacy `LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD` jail is **retired** — volumes are the only filesystem mechanism. With no `volumes:` block and no agent bindings, every file/exec tool **refuses** (no disk access), mirroring the network model (no `allowed_hosts` → no egress). **Setting any of the three retired env vars now fails startup** with a migration hint. To restore the old single shared jail, declare one `default` volume:
 
-**Introspection.** `Context op=self` reports the bound volumes (`volumes.bindings`: name / path / mode / default), so an agent knows precisely which roots it may touch and which verb each allows. An unbound agent still sees the legacy `sandbox` block.
+```yaml
+volumes:
+  default: { path: /work/sandbox, mode: rw, default: true }
+```
+
+Unbound agents then bind to it. (There is no auto-synthesis from the old env vars — a single root can't reproduce three distinct ones, and a `READ_ROOT`-only "writes disabled" deploy must not silently gain write access — so the operator declares the replacement volume once, explicitly.)
+
+**Introspection.** `Context op=self` reports the bound volumes (`volumes.bindings`: name / path / mode / default), so an agent knows precisely which roots it may touch and which verb each allows. An agent with no volume bound reports `filesystem: "none — no volume bound"`.
 
 ### 9d.1 Dynamic volumes — the `VolumeDef` substrate (RFC AH Phase 2a)
 

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -722,10 +722,11 @@ v1.0 keeps a single binary and a single config schema. There is **no** `--profil
 LOOMCYCLE_BASH_ENABLED=0
 LOOMCYCLE_HTTP_HOST_ALLOWLIST=             # empty — agents reach no hosts unless caller supplies allowed_hosts
 LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1      # caller's per-request allowed_hosts is the policy
-LOOMCYCLE_READ_ROOT=                       # unset → Read tool refuses every call
-LOOMCYCLE_WRITE_ROOT=                      # unset → Write/Edit refuse every call
 LOOMCYCLE_SKILLS_ROOT=/srv/loomcycle/skills
 ```
+
+No `volumes:` block in the yaml — sandbox-by-default (RFC AH Phase 3): with no
+volume declared, Read/Write/Edit/Bash refuse every call.
 
 YAML: every agent's `allowed_tools` lists only the network-restricted set (`HTTP` only with caller-supplied hosts, `WebSearch` with `web_search_filter: drop`, `Agent` for orchestration). Run inside a container; rely on the container for true filesystem isolation.
 
@@ -733,12 +734,18 @@ YAML: every agent's `allowed_tools` lists only the network-restricted set (`HTTP
 
 ```bash
 LOOMCYCLE_BASH_ENABLED=1                   # bash on (still NOT a real sandbox; container required)
-LOOMCYCLE_BASH_CWD=/work
 LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.anthropic.com,api.brave.com,github.com,...
-LOOMCYCLE_READ_ROOT=/work
-LOOMCYCLE_WRITE_ROOT=/work
 LOOMCYCLE_SKILLS_ROOT=/work/.claude/skills
 LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST=localhost,127.0.0.1
+```
+
+The filesystem reach is a `volumes:` block in the yaml (RFC AH Phase 3 retired
+the `LOOMCYCLE_READ_ROOT`/`WRITE_ROOT`/`BASH_CWD` jail). A `default` rw volume
+gives Read/Write/Edit/Bash access to `/work`:
+
+```yaml
+volumes:
+  default: { path: /work, mode: rw, default: true }
 ```
 
 YAML: agents can list any tool. The bearer token (`LOOMCYCLE_AUTH_TOKEN`) is the trust boundary; treat anyone with the token as fully trusted to drive the runtime.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -32,20 +32,20 @@ Both layers are intersection-only: nothing the model sees can ever exceed what t
 
 ### Built-ins
 
-Each built-in is registered into the dispatcher at process startup but **refuses every call** until its sandbox is configured via env. The model will see the tool's spec and may try to call it, but every call comes back with `{"is_error": true, "text": "<tool> is not configured ..."}`. This deliberate behaviour means the model gets a clear "not configured" signal it can self-correct from, instead of `unknown tool`.
+Each built-in is registered into the dispatcher at process startup but **refuses every call** until its sandbox is configured. For the file/exec tools that means a bound **volume** (RFC AH); for the network tools, a host allowlist or key. The model sees the tool's spec and may try to call it, but every call comes back with `{"is_error": true, "text": "<tool> ... refuses ..."}`. This deliberate behaviour means the model gets a clear "not configured" signal it can self-correct from, instead of `unknown tool`.
 
 | Tool        | Enabled by                                            |
 |-------------|-------------------------------------------------------|
-| `Read`      | `LOOMCYCLE_READ_ROOT=/path/to/sandbox`                |
-| `Write`     | `LOOMCYCLE_WRITE_ROOT=/path/to/sandbox`               |
-| `Edit`      | `LOOMCYCLE_WRITE_ROOT=/path/to/sandbox` (shared)      |
-| `Grep`      | `LOOMCYCLE_READ_ROOT=...` (shared with Read; v0.8.24) |
-| `Glob`      | `LOOMCYCLE_READ_ROOT=...` (shared with Read; v0.8.24) |
-| `NotebookEdit` | `LOOMCYCLE_WRITE_ROOT=...` (shared with Write; v0.8.24) |
+| `Read`      | a bound `volumes:` volume (any mode)                  |
+| `Write`     | a bound **rw** `volumes:` volume                      |
+| `Edit`      | a bound **rw** `volumes:` volume                      |
+| `Grep`      | a bound `volumes:` volume (any mode)                  |
+| `Glob`      | a bound `volumes:` volume (any mode)                  |
+| `NotebookEdit` | a bound **rw** `volumes:` volume                   |
 | `HTTP`      | `LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.example.com,...`   |
 | `WebFetch`  | (same allowlist as HTTP — shared backend)             |
 | `WebSearch` | `BRAVE_API_KEY=...`                                   |
-| `Bash`      | `LOOMCYCLE_BASH_ENABLED=1` + `LOOMCYCLE_BASH_CWD=...` |
+| `Bash`      | `LOOMCYCLE_BASH_ENABLED=1` + a bound **rw** volume    |
 | `Agent`     | Always registered (server-internal); per-agent `allowed_tools` controls who can spawn. |
 | `Skill`     | `LOOMCYCLE_SKILLS_ROOT=/path/to/skills` (or skills inlined per-agent via YAML `skills:` list). v0.8.22+ also consults the `skill_defs` store for DB-active overrides. |
 | `SkillDef`  | Always registered (v0.8.22). Per-agent `skill_def_scopes:` YAML gate (default-deny); no extra env var. Storage shared with the rest of the substrate. |
@@ -56,17 +56,17 @@ Bash has additional warnings: it is **not a true sandbox** even when enabled. Ru
 
 Sandbox semantics (file tools):
 - Paths must resolve **inside** the sandbox root after full `EvalSymlinks` evaluation. Symlinks pointing outside the root are refused.
-- **Relative paths are joined to the sandbox root, NOT the loomcycle process's current working directory.** A relative `Read`/`Edit`/`Grep`/`Glob` path is resolved under `LOOMCYCLE_READ_ROOT`; a relative `Write`/`Edit` path under `LOOMCYCLE_WRITE_ROOT` (`internal/tools/builtin/sandbox.go` `absUnderRoot`). This is what the model assumes and means agents should pass **relative paths** (e.g. `src/main.go`) regardless of where loomcycle was launched from. `~` is **not** expanded; an absolute path is accepted only if it still resolves inside the root. (The older behaviour joined relative paths to the process CWD, so a relative path could land outside the jail — the offset that scattered files in the experiments harness and made a code-reviewer's `Read internal/store/store.go` resolve into a stray binary at the launch dir.) `Bash` is separate: its commands run with the working directory set to `LOOMCYCLE_BASH_CWD`, so relative paths in a shell command are relative to *that*. Keep `LOOMCYCLE_BASH_CWD` equal to the read/write root so file-tool paths and Bash paths agree. Agents can read the active roots at runtime via `Context op=self` (`sandbox.read_root` / `write_root` / `bash_cwd`).
+- **Relative paths are joined to the bound volume's root, NOT the loomcycle process's current working directory.** A relative `Read`/`Edit`/`Grep`/`Glob`/`Write` path resolves under the volume the call targets (`internal/tools/builtin/sandbox.go` `absUnderRoot`). This is what the model assumes and means agents should pass **relative paths** (e.g. `src/main.go`) regardless of where loomcycle was launched from. `~` is **not** expanded; an absolute path is accepted only if it still resolves inside the root. (The older behaviour joined relative paths to the process CWD, so a relative path could land outside the jail — the offset that scattered files in the experiments harness and made a code-reviewer's `Read internal/store/store.go` resolve into a stray binary at the launch dir.) `Bash` runs with its working directory set to the bound (rw) volume's root, so relative paths in a shell command are relative to *that* — the same root the file tools use, so paths agree. Agents read their bound volumes at runtime via `Context op=self` (`volumes.bindings`).
 - `Write` resolves the **parent** dir (target may not exist yet); `Read`, `Edit`, `Grep`, `Glob`, and `NotebookEdit` resolve the target itself.
 - All file writes are atomic via tempfile + same-directory rename.
 - `Grep` skips binary files via NUL-byte heuristic on the first 8 KiB; caps output at 256 KiB + `head_limit` (default 100).
 - `Glob` supports `**` for recursive segment match; returns paths sorted by mtime DESC, capped at 100 results.
 - `NotebookEdit` accepts `replace` / `insert` / `delete` modes; preserves all non-target cells and notebook metadata verbatim.
-- **Filesystem Volumes (RFC AH Phase 1).** When the operator declares a top-level `volumes:` map (named ro/rw roots) and binds an agent via `AgentDef.volumes`, the file/exec tools resolve paths against those volumes instead of the single jail. Each of `Read` / `Write` / `Edit` / `Glob` / `Grep` / `Bash` / `NotebookEdit` then accepts an optional `"volume"` string argument:
+- **Filesystem Volumes (RFC AH).** Volumes are the **sole** filesystem mechanism — the operator declares a top-level `volumes:` map (named ro/rw roots) and binds an agent via `AgentDef.volumes`; the file/exec tools resolve paths against those volumes. Each of `Read` / `Write` / `Edit` / `Glob` / `Grep` / `Bash` / `NotebookEdit` accepts an optional `"volume"` string argument:
   - **omitted** → the agent's designated default binding (the one marked `default: true`, or the sole binding). Multiple bindings + no designated default → an error listing the available names.
   - **named** → that binding; naming a volume the agent isn't bound to → an error listing the bound volumes.
   - **ro / rw**: `Read` / `Glob` / `Grep` operate on any volume; `Write` / `Edit` / `NotebookEdit` and **`Bash`** require a `rw` volume (a `ro` target is refused — `Bash` cannot enforce read-only, so it refuses rather than ship a false guarantee). The unchanged `resolveInsideRoot` containment still applies per-volume — a `..` escape from one volume into another is rejected.
-  - An agent with **no** volume binding (or a deployment with no `volumes:` config) is unaffected: the tools use the legacy `LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD` jail exactly as before. Sub-agents inherit the **narrow-only** intersection of the parent's volumes. Agents read their bound volumes at runtime via `Context op=self` (`volumes.bindings`: name / path / mode / default). See `docs/CONFIGURATION.md` §9d.
+  - **Sandbox-by-default (RFC AH Phase 3).** An agent with **no** volume binding (or a deployment with no `volumes:` config) has **no filesystem access** — every file/exec tool refuses. The legacy `LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD` jail is retired (setting one fails startup with a migration hint; declare a `default` volume to restore the single shared jail). Sub-agents inherit the **narrow-only** intersection of the parent's volumes. Agents read their bound volumes at runtime via `Context op=self` (`volumes.bindings`: name / path / mode / default); an unbound agent sees `filesystem: "none …"`. See `docs/CONFIGURATION.md` §9d.
 - **`VolumeDef` — dynamic volumes (RFC AH Phase 2a/2b).** The `VolumeDef` tool provisions *dynamic* volumes at runtime: tenant-scoped, mutable, and confined inside an operator-blessed parent (a static volume marked `dynamic_root: true`). Ops: `create {name, mode}` (the path is **runtime-derived** — `<dynamic_root>/<tenant-segment>/<name>`; you supply a name + mode, never a host path; idempotent, mode-updates), `get {name}` / `list` (tenant-scoped reads), `delete {name}` (unmap — **leaves files**), `purge {name}` (unmap **and** delete the directory tree, behind a four-way fence: tenant ownership, re-derive-don't-trust, `EvalSymlinks`-the-real-path, assert-strictly-inside-root). **Phase 2b** adds `create {name, mode, ephemeral:true}` — a **run-scoped** volume at `<dynamic_root>/_ephemeral/<root_run_id>/<name>`, resolvable by the whole creating run tree and **auto-purged when the top-level run completes** (a singleton sweeper backstops crashes; `LOOMCYCLE_EPHEMERAL_VOLUME_SWEEP_MS`); it requires an active run and has no `delete`/`purge` (lifetime is the run). Names must match `^[a-z0-9][a-z0-9_-]{0,63}$`. Gated by per-agent `volume_def_scopes` (`any` / `named:<volume>`; default-deny). An agent binds to a dynamic volume by name exactly like a static one. See `docs/CONFIGURATION.md` §9d.1/§9d.2 and the `volumedef` help topic.
 
 SSRF semantics (network tools):
@@ -203,7 +203,7 @@ Continuations on `/v1/sessions/{id}/messages` re-supply `allowed_hosts` and `web
 
 | Situation                                                 | Result                                |
 |-----------------------------------------------------------|---------------------------------------|
-| Operator hasn't set `LOOMCYCLE_WRITE_ROOT`                | `Write`/`Edit` calls refuse with a clear message. |
+| Agent bound to no (rw) `volumes:` volume                  | `Write`/`Edit`/`Bash`/etc. refuse with a clear "no filesystem volume available" message. |
 | Agent omits `allowed_tools`                               | The model sees zero tools.            |
 | Agent includes a tool the operator hasn't enabled         | The tool is registered (visible) but every call refuses. |
 | Caller's request lists a tool the agent doesn't allow     | That tool is silently dropped from the run's set. |

--- a/examples/exp1-tools-usage/loomcycle.yaml
+++ b/examples/exp1-tools-usage/loomcycle.yaml
@@ -31,6 +31,12 @@ user_tiers:
     fallback_on_error: true
     max_fallback_attempts: 3
 
+# path: . is the cwd run.sh cd's into ($HERE/work) — replaces the retired
+# LOOMCYCLE_READ_ROOT/WRITE_ROOT/BASH_CWD jail (RFC AH Phase 3). The unbound
+# code-guru agent binds to `default`.
+volumes:
+  default: { path: ., mode: rw, default: true }
+
 agents:
   code-guru:
     tier: middle            # claude-sonnet-4-6 (OAuth) → deepseek-v4-pro fallback

--- a/examples/exp1-tools-usage/run.sh
+++ b/examples/exp1-tools-usage/run.sh
@@ -12,11 +12,9 @@ export LOOMCYCLE_LISTEN_ADDR="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
 # Anthropic-OAuth primary (research/dev). If you have NOT run `loomcycle anthropic
 # login`, leave this unset (or the provider is excluded) and runs use deepseek-v4-pro.
 export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED="${LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED:-1}"
-# exp1 tool sandbox: Read/Write/Edit/Bash scoped to ./work (roots aligned; run from ./work).
-export LOOMCYCLE_READ_ROOT="${LOOMCYCLE_READ_ROOT:-$HERE/work}"
-export LOOMCYCLE_WRITE_ROOT="${LOOMCYCLE_WRITE_ROOT:-$HERE/work}"
+# exp1 tool sandbox: Read/Write/Edit/Bash scoped to ./work via the `default`
+# volume in loomcycle.yaml (run.sh cd's to ./work, so `path: .` == ./work).
 export LOOMCYCLE_BASH_ENABLED="${LOOMCYCLE_BASH_ENABLED:-1}"
-export LOOMCYCLE_BASH_CWD="${LOOMCYCLE_BASH_CWD:-$HERE/work}"
 
 mkdir -p "$HERE/data" "$HERE/work"
 LOOMCYCLE_BIN="${LOOMCYCLE_BIN:-loomcycle}"

--- a/examples/exp4-gitea-telegram/loomcycle.yaml
+++ b/examples/exp4-gitea-telegram/loomcycle.yaml
@@ -34,6 +34,12 @@ user_tiers:
     fallback_on_error: true
     max_fallback_attempts: 3
 
+# path: . is the cwd run.sh cd's into ($HERE/work) — replaces the retired
+# LOOMCYCLE_READ_ROOT/WRITE_ROOT/BASH_CWD jail (RFC AH Phase 3). The coder +
+# reviewer agents are unbound, so they bind to `default`.
+volumes:
+  default: { path: ., mode: rw, default: true }
+
 channels:
   exp4-tasks:
     description: "Exp4 → code-guru inbox. Orchestrator + advisor publish coding tasks / change requests."

--- a/examples/exp4-gitea-telegram/run.sh
+++ b/examples/exp4-gitea-telegram/run.sh
@@ -12,11 +12,9 @@ export LOOMCYCLE_DATA_DIR="${LOOMCYCLE_DATA_DIR:-$HERE/data}"
 # (or a tailnet/LAN IP) and point the Gitea webhook URL at it. See README.
 export LOOMCYCLE_LISTEN_ADDR="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
 export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED="${LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED:-1}"
-# tool sandbox (the coder/reviewer use Bash+git under ./work)
-export LOOMCYCLE_READ_ROOT="${LOOMCYCLE_READ_ROOT:-$HERE/work}"
-export LOOMCYCLE_WRITE_ROOT="${LOOMCYCLE_WRITE_ROOT:-$HERE/work}"
+# tool sandbox: the coder/reviewer use Bash+git under ./work via the `default`
+# volume in loomcycle.yaml (run.sh cd's to ./work, so `path: .` == ./work).
 export LOOMCYCLE_BASH_ENABLED="${LOOMCYCLE_BASH_ENABLED:-1}"
-export LOOMCYCLE_BASH_CWD="${LOOMCYCLE_BASH_CWD:-$HERE/work}"
 export LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS="${LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS:-180000}"
 # inbound webhooks + the HMAC secret allowlist (the receiver resolves these env NAMES)
 export LOOMCYCLE_WEBHOOKS_ENABLED="${LOOMCYCLE_WEBHOOKS_ENABLED:-1}"

--- a/examples/exp7-code-review-fanout/README.md
+++ b/examples/exp7-code-review-fanout/README.md
@@ -40,7 +40,7 @@ in v0.32.0. See [the note below](#a-note-on-the-sandbox-origin--rfc-y).)
 | **`spawn_runs` (RFC Y, MCP/`POST /v1/runs:batch`)** | the **external fan-out** — ONE call spawns N runs server-side-concurrent, `mode:join` blocks until all settle, returns an index-aligned envelope (a per-child failure is captured in-envelope, never fails the batch) |
 | **`spawn_run` (MCP)** | the single consolidator run after the fan-out |
 | **`Memory` (user scope)** | the shared findings ledger — `review:<slice>:findings` per reviewer → `consolidated:report` |
-| **read-only `Read`/`Grep`/`Glob` jail** | reviewers get the file tools sandboxed to `LOOMCYCLE_READ_ROOT` with **no Bash/Write** — they can read the repo but not mutate or execute |
+| **read-only `Read`/`Grep`/`Glob` jail** | reviewers get the file tools sandboxed to the read-only `default` volume (`loomcycle.yaml`, `path: .` == `./work`) with **no Bash/Write** — they can read the repo but not mutate or execute |
 | **`Context op=self`** | each reviewer self-reports its `run_id` into its findings (provenance) |
 
 Routing: **Anthropic OAuth (primary) → deepseek-v4-pro (fallback)** via `tier: middle`.
@@ -173,7 +173,7 @@ Ctrl-C the server; `rm -rf data` for a clean ledger; `rm -rf work/loomcycle-src`
 | File | Purpose |
 |---|---|
 | `loomcycle.yaml` | routing + `code-reviewer` (imported, read-only) + `exp7-consolidator`; throttled concurrency |
-| `run.sh` | launcher — sets the read-only jail (`LOOMCYCLE_READ_ROOT=./work`) + skills root + MCP upstream token |
+| `run.sh` | launcher — cd's into the read-only jail (`./work`, bound by `loomcycle.yaml`'s `default` ro volume) + sets skills root + MCP upstream token |
 | `claude-code-src/{agents/code-reviewer.md,skills/code-review/SKILL.md}` | the Claude Code source artifacts the import was produced from (provenance; `.claude`-layout) |
 | `skills/code-review/SKILL.md` | the imported skill body, bundled into the reviewer's prompt at load |
 | `work/exp7_mcp.py` | token-safe MCP stdio JSON-RPC client driving `loomcycle mcp --upstream` |

--- a/examples/exp7-code-review-fanout/loomcycle.yaml
+++ b/examples/exp7-code-review-fanout/loomcycle.yaml
@@ -20,9 +20,10 @@
 # external fan-out (RFC Y), Memory (user scope), the read-only Read/Grep/Glob jail. The reviewer is
 # read-only (no Bash/Write). Routing: Anthropic OAuth → deepseek-v4-pro (tier: middle = sonnet).
 #
-# `run.sh` sets the jail (LOOMCYCLE_READ_ROOT=./work) and the skills root
-# (LOOMCYCLE_SKILLS_ROOT=./skills) so the imported code-review skill body is bundled into the
-# reviewer's system prompt at config-load (boot log: `skills: loaded 1`).
+# The read-only `default` volume (below) IS the review jail — `run.sh` cd's to ./work so its
+# `path: .` resolves there. `run.sh` also sets the skills root (LOOMCYCLE_SKILLS_ROOT=./skills) so
+# the imported code-review skill body is bundled into the reviewer's system prompt at config-load
+# (boot log: `skills: loaded 1`).
 #
 # PROVENANCE — how `code-reviewer` was produced: `./claude-code-src/agents/code-reviewer.md` (+
 # `./claude-code-src/skills/code-review/SKILL.md`) are the Claude Code source artifacts; imported with
@@ -53,6 +54,13 @@ user_tiers:
     provider_priority: [anthropic-oauth-dev, deepseek]
     fallback_on_error: true
     max_fallback_attempts: 3
+
+# path: . is the cwd run.sh cd's into ($HERE/work) — replaces the retired
+# LOOMCYCLE_READ_ROOT jail (RFC AH Phase 3). READ-ONLY: the reviewers get only
+# Read/Grep/Glob (no Bash/Write), so the volume is `ro`. The unbound reviewer +
+# consolidator agents bind to `default`.
+volumes:
+  default: { path: ., mode: ro, default: true }
 
 agents:
   # ───────────────────────── code-reviewer (imported; fanned out via MCP spawn_runs) ─────────────────────────

--- a/examples/exp7-code-review-fanout/run.sh
+++ b/examples/exp7-code-review-fanout/run.sh
@@ -13,9 +13,9 @@ export LOOMCYCLE_LISTEN_ADDR="${LOOMCYCLE_LISTEN_ADDR:-127.0.0.1:8787}"
 export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED="${LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED:-1}"
 
 # The read-only review jail + the imported skill. The reviewers get Read/Grep/Glob sandboxed to
-# LOOMCYCLE_READ_ROOT (=./work); the repo under review is cloned to ./work/loomcycle-src and
-# addressed by reviewers RELATIVE to the read-root (loomcycle-src/<path>). No Bash/Write/egress.
-export LOOMCYCLE_READ_ROOT="${LOOMCYCLE_READ_ROOT:-$HERE/work}"
+# the read-only `default` volume in loomcycle.yaml (run.sh cd's to ./work below, so `path: .` ==
+# ./work); the repo under review is cloned to ./work/loomcycle-src and addressed by reviewers
+# RELATIVE to that volume root (loomcycle-src/<path>). No Bash/Write/egress.
 export LOOMCYCLE_SKILLS_ROOT="${LOOMCYCLE_SKILLS_ROOT:-$HERE/skills}"   # bundle ./skills/code-review/SKILL.md
 # Bearer the MCP thin client (work/exp7_mcp.py → `loomcycle mcp --upstream`) uses to reach this runtime.
 export LOOMCYCLE_MCP_UPSTREAM_TOKEN="${LOOMCYCLE_MCP_UPSTREAM_TOKEN:-${LOOMCYCLE_AUTH_TOKEN:-}}"
@@ -23,4 +23,6 @@ export LOOMCYCLE_MCP_UPSTREAM_TOKEN="${LOOMCYCLE_MCP_UPSTREAM_TOKEN:-${LOOMCYCLE
 mkdir -p "$HERE/data" "$HERE/work"
 LOOMCYCLE_BIN="${LOOMCYCLE_BIN:-loomcycle}"
 command -v "$LOOMCYCLE_BIN" >/dev/null 2>&1 || { echo "run.sh: '$LOOMCYCLE_BIN' not on PATH — install loomcycle (≥ v0.32.0) or set LOOMCYCLE_BIN." >&2; exit 127; }
+# cd into the read-only volume root so loomcycle.yaml's `default: {path: .}` resolves to ./work.
+cd "$HERE/work"
 exec "$LOOMCYCLE_BIN" "$@" --config "$HERE/loomcycle.yaml"

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1274,10 +1274,10 @@ func (s *Server) interruptionPolicyForAgent(agentDef config.AgentDef) tools.Inte
 //
 //   - An agent that declares NO volumes is implicitly bound to [default]
 //     — a single synthesized binding from the `default` config volume.
-//     When no `default` volume exists (no `volumes:` config AND no legacy
-//     ReadRoot/WriteRoot), the policy is EMPTY (nil Bindings) so the
-//     tools fall back to their construction-time Root — byte-identical to
-//     a pre-feature deployment.
+//     When no `default` volume exists (no `volumes:` config), the policy is
+//     INACTIVE so every file/exec tool refuses — sandbox-by-default, RFC AH
+//     Phase 3 (the legacy jail is gone; declare a `default` volume to grant
+//     disk access).
 //   - An agent that declares volumes is confined to EXACTLY those (it
 //     does NOT implicitly also get `default`). Each binding's Default
 //     flag carries through from the config volume's `default: true`, so
@@ -1295,13 +1295,10 @@ func (s *Server) volumePolicyForAgent(ctx context.Context, agentDef config.Agent
 	if len(agentDef.Volumes) == 0 {
 		def, ok := s.cfg.Volumes["default"]
 		if !ok {
-			// No explicit `default` volume → inactive policy. The file tools
-			// fall back to their construction-time Root (the legacy
-			// ReadRoot/WriteRoot/BashCwd), byte-identical to a pre-feature
-			// deployment. We deliberately do NOT synthesize a single-root
-			// `default` from the three legacy roots — collapsing them into one
-			// root cannot be byte-identical when they differ (Read would read
-			// WriteRoot, Bash would lose BashCwd).
+			// No explicit `default` volume → inactive policy. RFC AH Phase 3:
+			// the legacy jail is gone, so an inactive policy means DENY — every
+			// file/exec tool refuses (sandbox-by-default). Declare a `default`
+			// volume to grant the old single-jail behaviour.
 			return tools.VolumePolicyValue{}
 		}
 		return tools.VolumePolicyValue{Active: true, Bindings: []tools.VolumeBinding{{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,21 +153,22 @@ type Config struct {
 	// factory land in MR-3b.
 	MemoryBackends map[string]MemoryBackend `yaml:"memory_backends"`
 
-	// Volumes is the RFC AH Phase 1 registry of named filesystem volumes
-	// — the universe of ro/rw roots an AgentDef may bind to (the
-	// filesystem analog of "registered tools" for allowed_tools). Each
-	// entry's `path` MUST already exist and be a directory (validated at
-	// config-load; the runtime never mkdir's a static volume); at most
-	// one entry may be `default: true`. When the operator declares no
-	// `volumes:` block, agents run UNCONFINED by volumes and the file tools
-	// use their legacy LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD roots
-	// (byte-identical to a pre-feature deployment) — the three legacy roots
-	// are deliberately NOT collapsed into one synthesized `default` volume (a
-	// single root can't reproduce three distinct ones: Read would read
-	// WriteRoot, Bash would lose BashCwd). A `default` volume exists only if
-	// the operator declares it; unbound agents bind to it when present. Only
-	// the static Phase 1 surface lives here; the dynamic VolumeDef substrate
-	// (Phase 2) is a separate, later feature.
+	// Volumes is the RFC AH registry of named filesystem volumes — the
+	// universe of ro/rw roots an AgentDef may bind to (the filesystem
+	// analog of "registered tools" for allowed_tools). Each entry's `path`
+	// MUST already exist and be a directory (validated at config-load; the
+	// runtime never mkdir's a static volume); at most one entry may be
+	// `default: true`.
+	//
+	// RFC AH Phase 3: Volumes are the SOLE filesystem mechanism — the legacy
+	// LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD jail is gone. No binding =
+	// no disk access (sandbox-by-default): an agent bound to no volume (and a
+	// deployment with no `default` volume) has every file/exec tool refuse.
+	// To restore the old single shared jail, declare one `default` volume:
+	//   volumes:
+	//     default: { path: /work/sandbox, mode: rw, default: true }
+	// Unbound agents bind to `default` when it exists. The dynamic VolumeDef
+	// substrate (Phase 2) is a separate, later feature.
 	Volumes map[string]Volume `yaml:"volumes"`
 
 	// Interruption is the v0.8.16 top-level config block for the
@@ -1802,13 +1803,6 @@ type Env struct {
 	// opaque regardless (no oracle) — this only affects local logs.
 	AuthVerbose bool
 	DataDir     string
-	// ReadRoot is the sandbox root for the built-in Read tool. Empty by
-	// default — the tool is registered but rejects every call until set.
-	ReadRoot string
-	// WriteRoot is the sandbox root for both Write and Edit. Empty by
-	// default — both tools refuse every call until set. Same TOCTOU
-	// guarantees as ReadRoot.
-	WriteRoot string
 	// HTTPHostAllowlist is the comma-separated list of hostnames the
 	// HTTP and WebFetch tools may reach. Empty = both tools refuse all
 	// calls. Suffix-matched: an entry "example.com" matches both
@@ -1850,9 +1844,6 @@ type Env struct {
 	// network calls. Operators wanting real isolation should run
 	// loomcycle inside a container or VM.
 	BashEnabled bool
-	// BashCwd is the working directory for spawned bash commands. Required
-	// when BashEnabled is true; if unset the tool refuses every call.
-	BashCwd string
 	// SkillsRoot points at a directory holding subdirectories of the
 	// shape `<name>/SKILL.md`. When unset, agents may not list skills
 	// (resolveSkills errors loudly to surface the misconfiguration —
@@ -2522,15 +2513,12 @@ func Load(path string) (*Config, error) {
 		AuditLogPath:             os.Getenv("LOOMCYCLE_AUDIT_LOG_PATH"),
 		AuthVerbose:              os.Getenv("LOOMCYCLE_AUTH_VERBOSE") == "1",
 		DataDir:                  getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
-		ReadRoot:                 os.Getenv("LOOMCYCLE_READ_ROOT"),
-		WriteRoot:                os.Getenv("LOOMCYCLE_WRITE_ROOT"),
 		HTTPHostAllowlist:        splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
 		HTTPPrivateHostAllowlist: splitCSV(os.Getenv("LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST")),
 		HTTPCallerAuthoritative:  os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:             os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
 		BraveAPIKey:              os.Getenv("BRAVE_API_KEY"),
 		BashEnabled:              os.Getenv("LOOMCYCLE_BASH_ENABLED") == "1",
-		BashCwd:                  os.Getenv("LOOMCYCLE_BASH_CWD"),
 		SkillsRoot:               os.Getenv("LOOMCYCLE_SKILLS_ROOT"),
 		AgentsRoot:               os.Getenv("LOOMCYCLE_AGENTS_ROOT"),
 		HelpRoot:                 os.Getenv("LOOMCYCLE_HELP_ROOT"),
@@ -2538,6 +2526,14 @@ func Load(path string) (*Config, error) {
 		// env var below was set. The fallbacks are applied in
 		// cmd/loomcycle/main.go where the goroutines are started.
 		HeartbeatSweeperEnabled: true,
+	}
+
+	// RFC AH Phase 3 — the legacy filesystem jail is retired. The three env
+	// vars (LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD) no longer exist.
+	// Fail fast with a migration hint when a stale deploy still sets one,
+	// rather than silently denying every file op (sandbox-by-default).
+	if err := checkRetiredJailEnv(); err != nil {
+		return nil, err
 	}
 
 	// Env-overrides for the storage block. Env wins over YAML so prod
@@ -3183,6 +3179,23 @@ func addContextToolDefaults(cfg *Config) {
 		def.AllowedTools = append(def.AllowedTools, "Context")
 		cfg.Agents[name] = def
 	}
+}
+
+// checkRetiredJailEnv fails config load when a deploy still sets one of the
+// retired legacy-jail env vars (RFC AH Phase 3). Volumes are now the sole
+// filesystem mechanism; honoring these silently would no-op (an unbound agent
+// is denied all disk access), so we surface a clear migration hint instead.
+func checkRetiredJailEnv() error {
+	var set []string
+	for _, name := range []string{"LOOMCYCLE_READ_ROOT", "LOOMCYCLE_WRITE_ROOT", "LOOMCYCLE_BASH_CWD"} {
+		if os.Getenv(name) != "" {
+			set = append(set, name)
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s retired in RFC AH Phase 3 — declare a `volumes:` block instead, e.g. `default: {path: …, mode: rw, default: true}` (see docs/CONFIGURATION.md)", strings.Join(set, ", "))
 }
 
 // validateVolumes checks the top-level `volumes:` map (RFC AH Phase 1)
@@ -4247,10 +4260,11 @@ func validate(c *Config) error {
 			return err
 		}
 	}
-	// RFC AH Phase 1: validate the top-level `volumes:` map. Each path must
+	// RFC AH: validate the top-level `volumes:` map. Each path must
 	// already exist + be a directory (static volumes map existing
-	// infrastructure; the runtime never creates them — same posture as a
-	// missing legacy ReadRoot failing at call time, surfaced earlier here).
+	// infrastructure; the runtime never creates them — a missing/non-dir
+	// path is a config-load error surfaced here rather than a baffling
+	// call-time failure).
 	// At most one volume may be `default: true`. Mode must be ro/rw/empty.
 	// Paths are resolved to absolute IN PLACE so the run-start binding
 	// resolution gets a stable absolute Root regardless of process cwd.

--- a/internal/config/volumes_test.go
+++ b/internal/config/volumes_test.go
@@ -115,38 +115,30 @@ agents:
 	}
 }
 
-// Backward-compat: with legacy ReadRoot/WriteRoot env and NO `volumes:` block,
-// NOTHING is synthesized — there is no `default` volume. Unbound agents then
-// run with an inactive policy and each file tool uses its own legacy root
-// (Read←ReadRoot, Write←WriteRoot, Bash←BashCwd), byte-identical to a
-// pre-feature deployment. We deliberately do NOT collapse the three legacy
-// roots into one synthesized `default`: a single root can't reproduce three
-// distinct ones, and a ReadRoot-only "writes disabled" deploy must not silently
-// gain write access on upgrade.
-func TestLoadVolumes_NoSynthesisFromLegacyEnv(t *testing.T) {
-	base, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatal(err)
-	}
-	writeDir := filepath.Join(base, "out")
-	if err := os.MkdirAll(writeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("LOOMCYCLE_READ_ROOT", base)
-	t.Setenv("LOOMCYCLE_WRITE_ROOT", writeDir)
+// RFC AH Phase 3: the legacy jail env vars are retired. Setting any of
+// LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD must fail Load with a migration
+// hint naming the var(s) + pointing at `volumes:`, rather than silently
+// denying every file op. Fail-before: remove the checkRetiredJailEnv call in
+// Load and Load returns nil error (a stale deploy then silently no-ops).
+func TestLoad_LegacyJailEnvErrors(t *testing.T) {
 	yamlPath := writeVolConfig(t, `
 agents:
   a: { model: claude-sonnet-4-6 }
 `)
-	cfg, err := Load(yamlPath)
-	if err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	if _, ok := cfg.Volumes["default"]; ok {
-		t.Error("no `volumes:` block must NOT synthesize a `default` volume from legacy env")
-	}
-	if _, ok := cfg.Volumes["default-read"]; ok {
-		t.Error("no `default-read` companion should be synthesized either")
+	for _, name := range []string{"LOOMCYCLE_READ_ROOT", "LOOMCYCLE_WRITE_ROOT", "LOOMCYCLE_BASH_CWD"} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv(name, "/work/sandbox")
+			_, err := Load(yamlPath)
+			if err == nil {
+				t.Fatalf("Load must error when %s is set", name)
+			}
+			if !strings.Contains(err.Error(), name) {
+				t.Errorf("error should name the retired var %s; got %q", name, err)
+			}
+			if !strings.Contains(err.Error(), "volumes:") {
+				t.Errorf("error should point at `volumes:`; got %q", err)
+			}
+		})
 	}
 }
 

--- a/internal/help/builtin/volumes.md
+++ b/internal/help/builtin/volumes.md
@@ -5,17 +5,18 @@ description: filesystem volumes — the named ro/rw roots your file/exec tools r
 A **volume** is a named filesystem root your file/exec tools
 (Read / Write / Edit / Glob / Grep / Bash / NotebookEdit) resolve paths
 against. The operator binds you to a set of volumes; each is either
-read-write (`rw`) or read-only (`ro`). Volumes replace the older single
-"sandbox jail" — they let one runtime confine different agents to
-different working trees.
+read-write (`rw`) or read-only (`ro`). Volumes are the *only* way you get
+filesystem access — they let one runtime confine different agents to
+different working trees. **If you're bound to no volume, every file/exec
+tool refuses: you have no disk access.**
 
 ## Seeing your volumes
 
 Call `Context op=self`. When you're bound to volumes it reports a
 `volumes.bindings` list — each entry's `name`, `path`, `mode` (`ro`/`rw`),
-and whether it's the `default`. If you're unbound (the legacy single-jail
-case) it reports a `sandbox` block with `read_root` / `write_root` /
-`bash_cwd` instead.
+and whether it's the `default`. If you're bound to no volume it reports
+`filesystem: "none — no volume bound"` — ask the operator to bind one
+(file/exec tools will refuse until then).
 
 ## The `volume` tool argument
 

--- a/internal/tools/builtin/bash.go
+++ b/internal/tools/builtin/bash.go
@@ -31,12 +31,10 @@ import (
 // + a startup warning + this comment lets the right operator wire it up
 // for their controlled environment.
 type Bash struct {
-	// Enabled gates the entire tool. False (default) refuses every call,
-	// even when Cwd is set.
+	// Enabled gates the entire tool. False (default) refuses every call.
+	// The working directory comes from the run's VolumePolicy (RFC AH) —
+	// Bash requires a rw volume (it cannot honestly enforce ro; see §6).
 	Enabled bool
-	// Cwd is the working directory for spawned commands. Required when
-	// Enabled. Empty Cwd refuses every call.
-	Cwd string
 	// MaxOutputBytes caps stdout+stderr. Default 1 MiB.
 	MaxOutputBytes int64
 	// Timeout caps wall-clock per call. Default 30s. Hard ceiling 5min.
@@ -91,12 +89,9 @@ func (b *Bash) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	// read-only (a shell can write via absolute paths / redirection — see
 	// the "not a true sandbox" doc above + RFC AH §6). Rather than ship a
 	// false ro guarantee, effectiveRoot refuses a read-only volume here.
-	cwdRoot, rootErr := effectiveRoot(ctx, b.Cwd, args.Volume, true)
+	cwdRoot, rootErr := effectiveRoot(ctx, args.Volume, true)
 	if rootErr != nil {
 		return tools.Result{Text: rootErr.Error(), IsError: true}, nil
-	}
-	if cwdRoot == "" {
-		return tools.Result{Text: "Bash tool has no cwd configured; refusing", IsError: true}, nil
 	}
 
 	cwd, err := filepath.EvalSymlinks(cwdRoot)

--- a/internal/tools/builtin/bash_test.go
+++ b/internal/tools/builtin/bash_test.go
@@ -8,14 +8,22 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
+// bashCtx attaches a default rw volume rooted at root, the standard ctx the
+// Bash tests run under (RFC AH Phase 3: Bash requires a bound rw volume).
+func bashCtx(root string) context.Context {
+	return ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
+}
+
 // Refusal cases: empty Enabled flag rejects every call. We test this
-// before any cwd config because Enabled is the single security gate
-// operators need to flip — a misconfigured cwd should never matter
-// when Enabled is false.
+// before any volume config because Enabled is the single security gate
+// operators need to flip — a missing volume should never matter when
+// Enabled is false.
 func TestBashRefusesWhenNotEnabled(t *testing.T) {
-	b := &Bash{Cwd: "/tmp"}
+	b := &Bash{}
 	res, err := b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
 	if err != nil {
 		t.Fatal(err)
@@ -25,14 +33,16 @@ func TestBashRefusesWhenNotEnabled(t *testing.T) {
 	}
 }
 
-func TestBashRefusesWithoutCwd(t *testing.T) {
+// RFC AH Phase 3: an enabled Bash bound to no volume must refuse
+// (sandbox-by-default; the legacy LOOMCYCLE_BASH_CWD jail is gone).
+func TestBashRefusesWithoutVolume(t *testing.T) {
 	b := &Bash{Enabled: true}
 	res, err := b.Execute(context.Background(), json.RawMessage(`{"command":"echo hi"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.IsError || !strings.Contains(res.Text, "no cwd") {
-		t.Errorf("expected no-cwd refusal, got %q", res.Text)
+	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Errorf("expected no-volume refusal, got %q", res.Text)
 	}
 }
 
@@ -48,9 +58,9 @@ func TestBashRunsInsideCwd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := &Bash{Enabled: true, Cwd: cwd}
+	b := &Bash{Enabled: true}
 	body, _ := json.Marshal(map[string]string{"command": "ls"})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,10 +80,10 @@ func TestBashTruncatesOutput(t *testing.T) {
 		t.Skip()
 	}
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
-	b := &Bash{Enabled: true, Cwd: cwd, MaxOutputBytes: 100}
+	b := &Bash{Enabled: true, MaxOutputBytes: 100}
 	// yes | head -c 5000 produces ~5KB of "y\n" repeated.
 	body, _ := json.Marshal(map[string]string{"command": "yes | head -c 5000"})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,9 +101,9 @@ func TestBashScrubsParentEnv(t *testing.T) {
 	}
 	t.Setenv("LOOMCYCLE_SECRET_FOR_TEST", "leak-me")
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
-	b := &Bash{Enabled: true, Cwd: cwd}
+	b := &Bash{Enabled: true}
 	body, _ := json.Marshal(map[string]string{"command": "env"})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,11 +125,10 @@ func TestBashAllowsExplicitlyAllowedEnv(t *testing.T) {
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
 	b := &Bash{
 		Enabled:         true,
-		Cwd:             cwd,
 		AllowedExtraEnv: []string{"LOOMCYCLE_PUBLIC_FOR_TEST"},
 	}
 	body, _ := json.Marshal(map[string]string{"command": "env"})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,9 +144,9 @@ func TestBashNonZeroExitSurfacesAsError(t *testing.T) {
 		t.Skip()
 	}
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
-	b := &Bash{Enabled: true, Cwd: cwd}
+	b := &Bash{Enabled: true}
 	body, _ := json.Marshal(map[string]string{"command": "echo something; exit 7"})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,12 +167,12 @@ func TestBashCallerTimeoutCappedAtHardCeiling(t *testing.T) {
 		t.Skip()
 	}
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
-	b := &Bash{Enabled: true, Cwd: cwd, MaxOutputBytes: 64}
+	b := &Bash{Enabled: true, MaxOutputBytes: 64}
 	// timeout_seconds: 9999 → must clamp to 300s. We don't actually wait;
 	// just verify the configured timeout doesn't allow >5min via reflection
 	// of behaviour: a quick command should still complete.
 	body, _ := json.Marshal(map[string]any{"command": "echo fast", "timeout_seconds": 9999})
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/builtin/bash_timeout_test.go
+++ b/internal/tools/builtin/bash_timeout_test.go
@@ -37,7 +37,6 @@
 package builtin
 
 import (
-	"context"
 	"encoding/json"
 	"path/filepath"
 	"runtime"
@@ -50,11 +49,11 @@ func TestBashTimeout(t *testing.T) {
 		t.Skip()
 	}
 	cwd, _ := filepath.EvalSymlinks(t.TempDir())
-	b := &Bash{Enabled: true, Cwd: cwd, Timeout: 100 * time.Millisecond}
+	b := &Bash{Enabled: true, Timeout: 100 * time.Millisecond}
 	body, _ := json.Marshal(map[string]any{"command": "sleep 5"})
 
 	start := time.Now()
-	res, err := b.Execute(context.Background(), body)
+	res, err := b.Execute(bashCtx(cwd), body)
 	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -243,9 +243,10 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 	// verb each allows, instead of guessing host paths.
 	//
 	// Active volume policy → report the binding list (an active-but-empty
-	// policy reports an empty bindings list = confined to no volume). Inactive
-	// (no policy) → fall back to the legacy read_root/write_root/bash_cwd
-	// sandbox fields so single-jail deployments report unchanged.
+	// policy reports an empty bindings list = confined to no volume).
+	// Inactive (no policy) → the agent has NO filesystem access (RFC AH
+	// Phase 3 sandbox-by-default; the legacy jail is gone), reported so the
+	// model knows file/exec tools will refuse rather than guessing host paths.
 	if vp := tools.VolumePolicy(ctx); vp.Active {
 		vols := make([]map[string]any, 0, len(vp.Bindings))
 		for _, b := range vp.Bindings {
@@ -264,24 +265,8 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 			"bindings":        vols,
 			"path_convention": "Pass paths RELATIVE to a volume root (e.g. \"src/main.go\"); ~ is not expanded and an absolute path must resolve inside the root. Set the \"volume\" tool argument to target a non-default volume; omit it to use the one marked default.",
 		}
-	} else if c.Cfg != nil {
-		// Legacy single-jail fallback (unbound agent). Omitted when no roots
-		// are configured (Cfg is nil in some test fixtures; an unset root means
-		// that tool refuses every call).
-		sb := map[string]any{}
-		if c.Cfg.Env.ReadRoot != "" {
-			sb["read_root"] = c.Cfg.Env.ReadRoot
-		}
-		if c.Cfg.Env.WriteRoot != "" {
-			sb["write_root"] = c.Cfg.Env.WriteRoot
-		}
-		if c.Cfg.Env.BashCwd != "" {
-			sb["bash_cwd"] = c.Cfg.Env.BashCwd
-		}
-		if len(sb) > 0 {
-			sb["path_convention"] = "Pass paths RELATIVE to these roots (e.g. \"src/main.go\"); ~ is not expanded and an absolute path must resolve inside the root."
-			out["sandbox"] = sb
-		}
+	} else {
+		out["filesystem"] = "none — no volume bound; Read/Write/Edit/Glob/Grep/Bash refuse. Bind a volume via the agent's `volumes:` list (operator declares the universe in the top-level `volumes:` config)."
 	}
 	// network: the host allowlist the HTTP/WebFetch/WebSearch tools enforce for
 	// this run, so an agent knows which hosts it may reach instead of probing

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -114,18 +114,15 @@ func TestContextTool_SelfReturnsIdentity(t *testing.T) {
 	}
 }
 
-// TestContextTool_SelfReportsSandboxAndNetwork: op=self surfaces the
-// filesystem jail (read/write roots + bash cwd, with the relative-path
-// convention) and the effective host allowlist, so a jailed agent can
-// introspect its sandbox instead of guessing host paths / probing hosts. With
-// no per-run caller list, the operator's static allowlist is reported as the
-// floor (source=operator_default).
-func TestContextTool_SelfReportsSandboxAndNetwork(t *testing.T) {
+// TestContextTool_SelfReportsNoFilesystemAndNetwork: RFC AH Phase 3 retired
+// the legacy jail, so an agent with no volume bound reports
+// `filesystem: "none …"` (sandbox-by-default — the file/exec tools refuse)
+// rather than read/write roots. The effective host allowlist still surfaces;
+// with no per-run caller list, the operator's static allowlist is reported as
+// the floor (source=operator_default).
+func TestContextTool_SelfReportsNoFilesystemAndNetwork(t *testing.T) {
 	tool, ctx := contextFixture(t)
 	tool.Cfg = &config.Config{Env: config.Env{
-		ReadRoot:          "/work/sandbox",
-		WriteRoot:         "/work/sandbox/out",
-		BashCwd:           "/work/sandbox",
 		HTTPHostAllowlist: []string{"api.example.com", "docs.example.com"},
 	}}
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
@@ -134,21 +131,12 @@ func TestContextTool_SelfReportsSandboxAndNetwork(t *testing.T) {
 	}
 	out := decodeResult(t, res.Text)
 
-	sb, ok := out["sandbox"].(map[string]any)
-	if !ok {
-		t.Fatalf("sandbox = %v (%T), want an object", out["sandbox"], out["sandbox"])
+	if _, ok := out["sandbox"]; ok {
+		t.Errorf("legacy `sandbox` block must be gone post-Phase-3, got %v", out["sandbox"])
 	}
-	if sb["read_root"] != "/work/sandbox" {
-		t.Errorf("sandbox.read_root = %v, want /work/sandbox", sb["read_root"])
-	}
-	if sb["write_root"] != "/work/sandbox/out" {
-		t.Errorf("sandbox.write_root = %v, want /work/sandbox/out", sb["write_root"])
-	}
-	if sb["bash_cwd"] != "/work/sandbox" {
-		t.Errorf("sandbox.bash_cwd = %v, want /work/sandbox", sb["bash_cwd"])
-	}
-	if s, _ := sb["path_convention"].(string); !strings.Contains(s, "RELATIVE") {
-		t.Errorf("sandbox.path_convention should mention RELATIVE, got %q", s)
+	fs, _ := out["filesystem"].(string)
+	if !strings.Contains(fs, "none") || !strings.Contains(fs, "volume") {
+		t.Errorf("filesystem = %q, want a 'none — no volume bound' report", fs)
 	}
 
 	net, ok := out["network"].(map[string]any)
@@ -191,14 +179,20 @@ func TestContextTool_SelfNetworkCallerList(t *testing.T) {
 	}
 }
 
-// TestContextTool_SelfOmitsSandboxWhenNoCfg: a bare fixture (no Cfg, no host
-// policy) omits sandbox + network rather than emitting empty objects.
-func TestContextTool_SelfOmitsSandboxWhenNoCfg(t *testing.T) {
+// TestContextTool_SelfOmitsNetworkWhenNoCfg: a bare fixture (no Cfg, no host
+// policy) omits network rather than emitting an empty object. The filesystem
+// report does NOT depend on Cfg post-Phase-3 — with no volume bound it always
+// reports "none" (sandbox-by-default).
+func TestContextTool_SelfOmitsNetworkWhenNoCfg(t *testing.T) {
 	tool, ctx := contextFixture(t)
 	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
 	out := decodeResult(t, res.Text)
 	if _, ok := out["sandbox"]; ok {
-		t.Errorf("sandbox should be omitted when Cfg is nil, got %v", out["sandbox"])
+		t.Errorf("legacy `sandbox` block must never appear post-Phase-3, got %v", out["sandbox"])
+	}
+	fs, _ := out["filesystem"].(string)
+	if !strings.Contains(fs, "none") {
+		t.Errorf("filesystem should report 'none' with no volume bound, got %q", fs)
 	}
 	if _, ok := out["network"]; ok {
 		t.Errorf("network should be omitted with no caller list and nil Cfg, got %v", out["network"])

--- a/internal/tools/builtin/edit.go
+++ b/internal/tools/builtin/edit.go
@@ -16,13 +16,11 @@ import (
 // occur EXACTLY once — ambiguity is an error so the model can supply
 // more surrounding context. ReplaceAll lifts that requirement.
 //
-// Sandbox shares Root with Write. The file must already exist; Edit
-// does not create files (callers should use Write for that). The whole
-// file is read into memory, mutated, and written back via the same
-// atomic tempfile + rename dance Write uses.
+// Sandbox mirrors Write: a rw volume is required. The file must already
+// exist; Edit does not create files (callers should use Write for that).
+// The whole file is read into memory, mutated, and written back via the
+// same atomic tempfile + rename dance Write uses.
 type Edit struct {
-	// Root is the sandbox root (same one used by Write). Required.
-	Root string
 	// MaxBytes caps the file size Edit will load. Default 1 MiB.
 	MaxBytes int64
 }
@@ -63,12 +61,9 @@ func (e *Edit) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	if args.OldString == args.NewString {
 		return tools.Result{Text: "old_string and new_string must differ", IsError: true}, nil
 	}
-	root, err := effectiveRoot(ctx, e.Root, args.Volume, true)
+	root, err := effectiveRoot(ctx, args.Volume, true)
 	if err != nil {
 		return tools.Result{Text: err.Error(), IsError: true}, nil
-	}
-	if root == "" {
-		return tools.Result{Text: "Edit tool is not configured with a sandbox root; refusing to edit", IsError: true}, nil
 	}
 
 	maxBytes := e.MaxBytes

--- a/internal/tools/builtin/edit_test.go
+++ b/internal/tools/builtin/edit_test.go
@@ -7,21 +7,24 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
-func TestEditRefusesEmptyRoot(t *testing.T) {
+func TestEditRefusesNoVolume(t *testing.T) {
 	e := &Edit{}
 	res, err := e.Execute(context.Background(), json.RawMessage(`{"path":"/tmp/x","old_string":"a","new_string":"b"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.IsError || !strings.Contains(res.Text, "sandbox") {
-		t.Fatalf("expected sandbox-refusal error, got Text=%q IsError=%v", res.Text, res.IsError)
+	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Fatalf("expected no-volume refusal, got Text=%q IsError=%v", res.Text, res.IsError)
 	}
 }
 
 func TestEditRejectsIdenticalOldAndNew(t *testing.T) {
-	e := &Edit{Root: t.TempDir()}
+	// old==new is checked before the volume resolves, so this needs no binding.
+	e := &Edit{}
 	body, _ := json.Marshal(map[string]string{"path": "/x", "old_string": "same", "new_string": "same"})
 	res, err := e.Execute(context.Background(), body)
 	if err != nil {
@@ -42,9 +45,10 @@ func TestEditOldStringNotFound(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root}
+	e := &Edit{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "missing", "new_string": "x"})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -66,9 +70,10 @@ func TestEditRejectsAmbiguousMatchWithoutReplaceAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root}
+	e := &Edit{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "foo", "new_string": "bar"})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,9 +97,10 @@ func TestEditSingleReplacement(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root}
+	e := &Edit{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "world", "new_string": "earth"})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,9 +123,10 @@ func TestEditReplaceAll(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root}
+	e := &Edit{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]any{"path": target, "old_string": "foo", "new_string": "bar", "replace_all": true})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,9 +160,10 @@ func TestEditRejectsSymlinkEscape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root}
+	e := &Edit{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": link, "old_string": "CLASSIFIED", "new_string": "OPEN"})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,9 +186,10 @@ func TestEditRejectsOversizedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	e := &Edit{Root: root, MaxBytes: 8}
+	e := &Edit{MaxBytes: 8}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "old_string": "0", "new_string": "X"})
-	res, err := e.Execute(context.Background(), body)
+	res, err := e.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/builtin/glob.go
+++ b/internal/tools/builtin/glob.go
@@ -26,13 +26,10 @@ import (
 // `**` is the value-add over stdlib `filepath.Match`. Inline matcher
 // below (~30 LOC) keeps the binary self-contained — no doublestar dep.
 //
-// Sandbox model: same Root as Read. Empty Root = refuse every call.
-// All paths resolved via resolveInsideRoot — symlinks evaluated;
-// refusal on root escape.
+// Sandbox model: same as Read — the root comes from the run's VolumePolicy
+// (RFC AH); an agent bound to no volume is refused. All paths resolved via
+// resolveInsideRoot — symlinks evaluated; refusal on root escape.
 type Glob struct {
-	// Root is the sandbox root (reuses LOOMCYCLE_READ_ROOT in
-	// production; set in cmd/loomcycle/main.go). Empty = refuse.
-	Root string
 	// MaxResults caps the result list so a model-issued `**` doesn't
 	// blow the context window. 0 = 100 default (matches Claude Code).
 	MaxResults int
@@ -73,12 +70,9 @@ func (g *Glob) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	if args.Pattern == "" {
 		return errResult("pattern is required"), nil
 	}
-	root, rootErr := effectiveRoot(ctx, g.Root, args.Volume, false)
+	root, rootErr := effectiveRoot(ctx, args.Volume, false)
 	if rootErr != nil {
 		return errResult(rootErr.Error()), nil
-	}
-	if root == "" {
-		return errResult("Glob tool is not configured with a sandbox root; set LOOMCYCLE_READ_ROOT"), nil
 	}
 	// Validate every pattern segment up-front. filepath.Match returns
 	// ErrBadPattern on malformed brackets etc.; without this pre-check

--- a/internal/tools/builtin/glob_test.go
+++ b/internal/tools/builtin/glob_test.go
@@ -8,7 +8,15 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// globCtx attaches a default rw volume rooted at root, the standard ctx the
+// Glob tests run under (RFC AH Phase 3: file tools require a bound volume).
+func globCtx(root string) context.Context {
+	return ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
+}
 
 // makeGlobTree builds a known structure for the Glob tests.
 //
@@ -47,8 +55,8 @@ func makeGlobTree(t *testing.T) string {
 
 func TestGlob_DoubleStarRecursive(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"**/*.go"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"**/*.go"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -68,8 +76,8 @@ func TestGlob_DoubleStarRecursive(t *testing.T) {
 
 func TestGlob_SingleSegmentPattern(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"*.go"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"*.go"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -84,8 +92,8 @@ func TestGlob_SingleSegmentPattern(t *testing.T) {
 
 func TestGlob_MultiSegmentPattern(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"src/**/*.tsx"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"src/**/*.tsx"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -120,8 +128,8 @@ func TestGlob_MtimeDescOrdering(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"*.go"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"*.go"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -145,8 +153,8 @@ func TestGlob_MaxResultsTruncation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	g := &Glob{Root: root, MaxResults: 3}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"*.go"}`))
+	g := &Glob{MaxResults: 3}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"*.go"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -161,8 +169,8 @@ func TestGlob_MaxResultsTruncation(t *testing.T) {
 
 func TestGlob_NoMatches(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"**/*.rs"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"**/*.rs"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -179,10 +187,10 @@ func TestGlob_NoMatches(t *testing.T) {
 // FAIL-BEFORE: returns "no matches".
 func TestGlob_AbsoluteInRootPattern(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
+	g := &Glob{}
 	abs := root + "/**/*.go"
 	in, _ := json.Marshal(map[string]string{"pattern": abs})
-	res, _ := g.Execute(context.Background(), in)
+	res, _ := g.Execute(globCtx(root), in)
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -201,8 +209,8 @@ func TestGlob_AbsoluteInRootPattern(t *testing.T) {
 // files outside the root.
 func TestGlob_AbsolutePatternOutsideRootMatchesNothing(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"/etc/**/*.conf"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"/etc/**/*.conf"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}
@@ -213,21 +221,23 @@ func TestGlob_AbsolutePatternOutsideRootMatchesNothing(t *testing.T) {
 
 func TestGlob_PathEscapeRejected(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"*","path":"/etc"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"*","path":"/etc"}`))
 	if !res.IsError {
 		t.Errorf("path outside root must refuse, got %q", res.Text)
 	}
 }
 
-func TestGlob_MissingRootRefuses(t *testing.T) {
+// RFC AH Phase 3: an agent bound to no volume must refuse (sandbox-by-default;
+// the legacy LOOMCYCLE_READ_ROOT jail is gone).
+func TestGlob_NoVolumeRefuses(t *testing.T) {
 	g := &Glob{}
 	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"*"}`))
 	if !res.IsError {
-		t.Errorf("missing Root must refuse, got %q", res.Text)
+		t.Errorf("no volume bound must refuse, got %q", res.Text)
 	}
-	if !strings.Contains(res.Text, "LOOMCYCLE_READ_ROOT") {
-		t.Errorf("refusal must mention env var, got %q", res.Text)
+	if !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Errorf("refusal must report no volume, got %q", res.Text)
 	}
 }
 
@@ -236,8 +246,8 @@ func TestGlob_MissingRootRefuses(t *testing.T) {
 // per-file filepath.Match's swallowed ErrBadPattern.
 func TestGlob_InvalidPatternIsError(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"[unclosed"}`))
+	g := &Glob{}
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"[unclosed"}`))
 	if !res.IsError {
 		t.Errorf("invalid pattern must return IsError, got %q", res.Text)
 	}
@@ -248,9 +258,9 @@ func TestGlob_InvalidPatternIsError(t *testing.T) {
 
 func TestGlob_PathSubdirScopes(t *testing.T) {
 	root := makeGlobTree(t)
-	g := &Glob{Root: root}
+	g := &Glob{}
 	// Scope to src/ — vendor/third.go must not appear.
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"**/*.go","path":"src"}`))
+	res, _ := g.Execute(globCtx(root), json.RawMessage(`{"pattern":"**/*.go","path":"src"}`))
 	if res.IsError {
 		t.Fatalf("err: %s", res.Text)
 	}

--- a/internal/tools/builtin/grep.go
+++ b/internal/tools/builtin/grep.go
@@ -23,13 +23,10 @@ import (
 // on huge trees for a self-contained binary; for the typical agent
 // workload (single-digit MB of source) the difference is invisible.
 //
-// Sandbox model: same Root as Read. A Grep with Root="" rejects every
-// call (matching Read's posture). All paths resolved via
+// Sandbox model: same as Read — the root comes from the run's VolumePolicy
+// (RFC AH); an agent bound to no volume is refused. All paths resolved via
 // resolveInsideRoot — symlinks evaluated; refusal on root escape.
 type Grep struct {
-	// Root is the sandbox root. Reuses LOOMCYCLE_READ_ROOT in
-	// production (set in cmd/loomcycle/main.go). Empty = refuse.
-	Root string
 	// MaxOutputBytes caps the assembled response so a model-readable
 	// pattern that matches half the repo doesn't blow the context
 	// window. 0 = 256 KiB default.
@@ -88,12 +85,9 @@ func (g *Grep) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	if args.Pattern == "" {
 		return errResult("pattern is required"), nil
 	}
-	root, rootErr := effectiveRoot(ctx, g.Root, args.Volume, false)
+	root, rootErr := effectiveRoot(ctx, args.Volume, false)
 	if rootErr != nil {
 		return errResult(rootErr.Error()), nil
-	}
-	if root == "" {
-		return errResult("Grep tool is not configured with a sandbox root; set LOOMCYCLE_READ_ROOT"), nil
 	}
 
 	// Compile regex with applied flags. Use bracket prefix so user

--- a/internal/tools/builtin/grep_test.go
+++ b/internal/tools/builtin/grep_test.go
@@ -7,7 +7,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// grepCtx attaches a default rw volume rooted at root, the standard ctx the
+// Grep tests run under (RFC AH Phase 3: file tools require a bound volume).
+func grepCtx(root string) context.Context {
+	return ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
+}
 
 // makeGrepTree builds a small sandbox with a known structure for the
 // Grep tests. Returns the root path; t.TempDir handles cleanup.
@@ -46,8 +54,8 @@ func makeGrepTree(t *testing.T) string {
 
 func TestGrep_FilesWithMatchesIsDefault(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"func main"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"func main"}`))
 	if res.IsError {
 		t.Fatalf("unexpected error: %s", res.Text)
 	}
@@ -68,8 +76,8 @@ func TestGrep_FilesWithMatchesIsDefault(t *testing.T) {
 
 func TestGrep_NoMatchesReturnsClearMessage(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"this-pattern-matches-nothing"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"this-pattern-matches-nothing"}`))
 	if res.IsError {
 		t.Fatalf("no-match should not be IsError: %s", res.Text)
 	}
@@ -80,37 +88,39 @@ func TestGrep_NoMatchesReturnsClearMessage(t *testing.T) {
 
 func TestGrep_InvalidRegexIsError(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"["}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"["}`))
 	if !res.IsError {
 		t.Errorf("invalid regex should be IsError: %s", res.Text)
 	}
 }
 
-func TestGrep_MissingRootRefuses(t *testing.T) {
-	g := &Grep{} // no Root
+// RFC AH Phase 3: an agent bound to no volume must refuse (sandbox-by-default;
+// the legacy LOOMCYCLE_READ_ROOT jail is gone).
+func TestGrep_NoVolumeRefuses(t *testing.T) {
+	g := &Grep{}
 	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"x"}`))
 	if !res.IsError {
-		t.Errorf("missing Root should refuse: %s", res.Text)
+		t.Errorf("no volume bound should refuse: %s", res.Text)
 	}
-	if !strings.Contains(res.Text, "LOOMCYCLE_READ_ROOT") {
-		t.Errorf("refusal should mention the env var, got %q", res.Text)
+	if !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Errorf("refusal should report no volume, got %q", res.Text)
 	}
 }
 
 func TestGrep_CaseInsensitive(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"TODO","case_insensitive":false}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"TODO","case_insensitive":false}`))
 	if res.IsError || !strings.Contains(res.Text, "b.go") {
 		t.Errorf("case-sensitive TODO should match b.go: %s", res.Text)
 	}
-	res, _ = g.Execute(context.Background(), json.RawMessage(`{"pattern":"todo","case_insensitive":true}`))
+	res, _ = g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"todo","case_insensitive":true}`))
 	if res.IsError || !strings.Contains(res.Text, "b.go") {
 		t.Errorf("case-insensitive todo should match b.go: %s", res.Text)
 	}
 	// Default case-sensitive: lowercase "todo" shouldn't match.
-	res, _ = g.Execute(context.Background(), json.RawMessage(`{"pattern":"todo"}`))
+	res, _ = g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"todo"}`))
 	if !strings.Contains(res.Text, "no matches") {
 		t.Errorf("default case-sensitive lowercase 'todo' should not match: %s", res.Text)
 	}
@@ -118,13 +128,13 @@ func TestGrep_CaseInsensitive(t *testing.T) {
 
 func TestGrep_GlobFilter(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"hello","glob":"*.go"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"hello","glob":"*.go"}`))
 	// hello is only in c.txt; glob excludes it.
 	if !strings.Contains(res.Text, "no matches") {
 		t.Errorf("glob=*.go should exclude c.txt: %s", res.Text)
 	}
-	res, _ = g.Execute(context.Background(), json.RawMessage(`{"pattern":"hello","glob":"*.txt"}`))
+	res, _ = g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"hello","glob":"*.txt"}`))
 	if res.IsError || !strings.Contains(res.Text, "c.txt") {
 		t.Errorf("glob=*.txt should include c.txt: %s", res.Text)
 	}
@@ -132,8 +142,8 @@ func TestGrep_GlobFilter(t *testing.T) {
 
 func TestGrep_ContentModeFormatsLineNumber(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"func main","output_mode":"content"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"func main","output_mode":"content"}`))
 	if res.IsError {
 		t.Fatalf("content mode err: %s", res.Text)
 	}
@@ -145,8 +155,8 @@ func TestGrep_ContentModeFormatsLineNumber(t *testing.T) {
 
 func TestGrep_ContentModeWithContextLines(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"func main","output_mode":"content","-C":1}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"func main","output_mode":"content","-C":1}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}
@@ -163,8 +173,8 @@ func TestGrep_ContentModeWithContextLines(t *testing.T) {
 
 func TestGrep_CountModeReportsPerFileCount(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"func","output_mode":"count"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"func","output_mode":"count"}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}
@@ -179,11 +189,11 @@ func TestGrep_CountModeReportsPerFileCount(t *testing.T) {
 
 func TestGrep_BinaryFileSkipped(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
+	g := &Grep{}
 	// The binary file contains \x00\x01\x02\x03 — bytes 1 and 2 are
 	// ASCII chars. Search for "\x02" via regex would match bytes;
 	// but binary detection should skip the file entirely.
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":".","output_mode":"files_with_matches"}`))
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":".","output_mode":"files_with_matches"}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}
@@ -194,8 +204,8 @@ func TestGrep_BinaryFileSkipped(t *testing.T) {
 
 func TestGrep_PathEscapeIsRefused(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"x","path":"/etc"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"x","path":"/etc"}`))
 	if !res.IsError {
 		t.Errorf("path outside root should refuse, got %q", res.Text)
 	}
@@ -210,8 +220,8 @@ func TestGrep_HeadLimitTruncates(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"MATCH","head_limit":5}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"MATCH","head_limit":5}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}
@@ -232,8 +242,8 @@ func TestGrep_HeadLimitExactCountNoTruncation(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"MATCH","head_limit":5}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"MATCH","head_limit":5}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}
@@ -244,8 +254,8 @@ func TestGrep_HeadLimitExactCountNoTruncation(t *testing.T) {
 
 func TestGrep_InvalidGlobFilterIsError(t *testing.T) {
 	root := makeGrepTree(t)
-	g := &Grep{Root: root}
-	res, _ := g.Execute(context.Background(), json.RawMessage(`{"pattern":"x","glob":"[unclosed"}`))
+	g := &Grep{}
+	res, _ := g.Execute(grepCtx(root), json.RawMessage(`{"pattern":"x","glob":"[unclosed"}`))
 	if !res.IsError {
 		t.Errorf("invalid glob filter must be reported, got %q", res.Text)
 	}

--- a/internal/tools/builtin/narrowing_test.go
+++ b/internal/tools/builtin/narrowing_test.go
@@ -14,7 +14,7 @@ import (
 func TestNarrowHostsNilPassThrough(t *testing.T) {
 	original := []tools.Tool{
 		&HTTP{HostAllowlist: []string{"a.example"}},
-		&Read{Root: "/x"},
+		&Read{},
 	}
 	out := NarrowHosts(original, nil, "", false)
 	if len(out) != 2 {
@@ -136,9 +136,9 @@ func TestNarrowHostsEmptyCallerDeniesAll(t *testing.T) {
 
 // Non-network tools pass through untouched even when narrowing applies.
 func TestNarrowHostsLeavesUnrelatedToolsAlone(t *testing.T) {
-	r := &Read{Root: "/x"}
-	w := &Write{Root: "/x"}
-	b := &Bash{Enabled: true, Cwd: "/x"}
+	r := &Read{}
+	w := &Write{}
+	b := &Bash{Enabled: true}
 	out := NarrowHosts([]tools.Tool{r, w, b}, []string{"x.example"}, "", false)
 	if len(out) != 3 {
 		t.Fatalf("len = %d, want 3", len(out))

--- a/internal/tools/builtin/notebook_edit.go
+++ b/internal/tools/builtin/notebook_edit.go
@@ -24,12 +24,9 @@ import (
 // corrupt. NotebookEdit handles the on-disk shape and preserves all
 // non-target cells + top-level metadata verbatim.
 //
-// Sandbox model: same Root as Write (this mutates files). Writes
-// are atomic: tempfile in the same dir + rename.
+// Sandbox model: mirrors Write (this mutates files) — a rw volume is
+// required. Writes are atomic: tempfile in the same dir + rename.
 type NotebookEdit struct {
-	// Root is the sandbox root (reuses LOOMCYCLE_WRITE_ROOT in
-	// production). Empty = refuse.
-	Root string
 	// MaxBytes caps both input file size and produced JSON. Default 8 MiB
 	// — notebooks routinely run larger than the 1 MiB Write default
 	// because of inline base64 image outputs.
@@ -96,12 +93,9 @@ func (n *NotebookEdit) Execute(ctx context.Context, input json.RawMessage) (tool
 	if err := json.Unmarshal(input, &args); err != nil {
 		return errResult("invalid input: " + err.Error()), nil
 	}
-	root, rootErr := effectiveRoot(ctx, n.Root, args.Volume, true)
+	root, rootErr := effectiveRoot(ctx, args.Volume, true)
 	if rootErr != nil {
 		return errResult(rootErr.Error()), nil
-	}
-	if root == "" {
-		return errResult("NotebookEdit tool is not configured with a sandbox root; set LOOMCYCLE_WRITE_ROOT"), nil
 	}
 	if args.FilePath == "" {
 		return errResult("file_path is required"), nil

--- a/internal/tools/builtin/notebook_edit_test.go
+++ b/internal/tools/builtin/notebook_edit_test.go
@@ -7,7 +7,16 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// nbCtx attaches a default rw volume rooted at root, the standard ctx the
+// NotebookEdit tests run under (RFC AH Phase 3: file tools require a bound
+// volume).
+func nbCtx(root string) context.Context {
+	return ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
+}
 
 // fixtureNotebook is a 2-cell .ipynb file used by every test.
 const fixtureNotebook = `{
@@ -47,8 +56,8 @@ func readNB(t *testing.T, path string) notebook {
 
 func TestNotebookEdit_ReplaceExistingCell(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"print(42)","mode":"replace"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"print(42)","mode":"replace"}`))
 	if res.IsError {
 		t.Fatalf("replace failed: %s", res.Text)
 	}
@@ -69,8 +78,8 @@ func TestNotebookEdit_ReplaceExistingCell(t *testing.T) {
 
 func TestNotebookEdit_InsertAfterCell(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"y = 2","mode":"insert"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"y = 2","mode":"insert"}`))
 	if res.IsError {
 		t.Fatalf("insert: %s", res.Text)
 	}
@@ -95,8 +104,8 @@ func TestNotebookEdit_InsertAfterCell(t *testing.T) {
 
 func TestNotebookEdit_InsertAtStartWhenCellIDEmpty(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","source":"top","cell_type":"markdown","mode":"insert"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","source":"top","cell_type":"markdown","mode":"insert"}`))
 	if res.IsError {
 		t.Fatalf("insert at start: %s", res.Text)
 	}
@@ -118,8 +127,8 @@ func TestNotebookEdit_InsertAtStartWhenCellIDEmpty(t *testing.T) {
 
 func TestNotebookEdit_DeleteCell(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","mode":"delete"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","mode":"delete"}`))
 	if res.IsError {
 		t.Fatalf("delete: %s", res.Text)
 	}
@@ -134,8 +143,8 @@ func TestNotebookEdit_DeleteCell(t *testing.T) {
 
 func TestNotebookEdit_CellNotFoundIsError(t *testing.T) {
 	root, _ := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"nonexistent","source":"x","mode":"replace"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"nonexistent","source":"x","mode":"replace"}`))
 	if !res.IsError {
 		t.Errorf("expected error for missing cell, got %q", res.Text)
 	}
@@ -147,8 +156,8 @@ func TestNotebookEdit_InvalidJSONIsError(t *testing.T) {
 	if err := os.WriteFile(file, []byte("{not json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"bad.ipynb","cell_id":"x","source":"y","mode":"replace"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"bad.ipynb","cell_id":"x","source":"y","mode":"replace"}`))
 	if !res.IsError {
 		t.Errorf("expected JSON parse error")
 	}
@@ -156,8 +165,8 @@ func TestNotebookEdit_InvalidJSONIsError(t *testing.T) {
 
 func TestNotebookEdit_NonIpynbExtensionRejected(t *testing.T) {
 	root := t.TempDir()
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"file.txt","cell_id":"x","source":"y","mode":"replace"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"file.txt","cell_id":"x","source":"y","mode":"replace"}`))
 	if !res.IsError {
 		t.Errorf("non-.ipynb path should be rejected")
 	}
@@ -175,29 +184,31 @@ func TestNotebookEdit_PathEscapeRejected(t *testing.T) {
 	if err := os.WriteFile(outsideFile, []byte(fixtureNotebook), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	n := &NotebookEdit{Root: root}
+	n := &NotebookEdit{}
 	body := json.RawMessage(`{"file_path":"` + outsideFile + `","cell_id":"aaaaaaaa","source":"y","mode":"replace"}`)
-	res, _ := n.Execute(context.Background(), body)
+	res, _ := n.Execute(nbCtx(root), body)
 	if !res.IsError {
 		t.Errorf("path outside root must refuse, got %q", res.Text)
 	}
 }
 
-func TestNotebookEdit_MissingRootRefuses(t *testing.T) {
+// RFC AH Phase 3: an agent bound to no volume must refuse (sandbox-by-default;
+// the legacy LOOMCYCLE_WRITE_ROOT jail is gone).
+func TestNotebookEdit_NoVolumeRefuses(t *testing.T) {
 	n := &NotebookEdit{}
 	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"x.ipynb","cell_id":"y","source":"z","mode":"replace"}`))
 	if !res.IsError {
-		t.Errorf("missing root must refuse")
+		t.Errorf("no volume bound must refuse")
 	}
-	if !strings.Contains(res.Text, "LOOMCYCLE_WRITE_ROOT") {
-		t.Errorf("refusal should mention LOOMCYCLE_WRITE_ROOT, got %q", res.Text)
+	if !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Errorf("refusal should report no volume, got %q", res.Text)
 	}
 }
 
 func TestNotebookEdit_AtomicWriteLeavesNoTempfile(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"q","mode":"replace"}`))
+	n := &NotebookEdit{}
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"q","mode":"replace"}`))
 	if res.IsError {
 		t.Fatalf("replace: %s", res.Text)
 	}
@@ -219,9 +230,9 @@ func TestNotebookEdit_AtomicWriteLeavesNoTempfile(t *testing.T) {
 // both keys on code cells).
 func TestNotebookEdit_PromoteToCodeSeedsRequiredFields(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
+	n := &NotebookEdit{}
 	// bbbbbbbb is the markdown cell in the fixture. Promote to code.
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"bbbbbbbb","source":"x = 1","cell_type":"code","mode":"replace"}`))
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"bbbbbbbb","source":"x = 1","cell_type":"code","mode":"replace"}`))
 	if res.IsError {
 		t.Fatalf("promote-to-code: %s", res.Text)
 	}
@@ -254,9 +265,9 @@ func TestNotebookEdit_PromoteToCodeSeedsRequiredFields(t *testing.T) {
 
 func TestNotebookEdit_PreservesUnaffectedCells(t *testing.T) {
 	root, file := writeFixture(t)
-	n := &NotebookEdit{Root: root}
+	n := &NotebookEdit{}
 	// Replace aaaaaaaa; bbbbbbbb must be untouched.
-	res, _ := n.Execute(context.Background(), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"new","mode":"replace"}`))
+	res, _ := n.Execute(nbCtx(root), json.RawMessage(`{"file_path":"nb.ipynb","cell_id":"aaaaaaaa","source":"new","mode":"replace"}`))
 	if res.IsError {
 		t.Fatalf("%s", res.Text)
 	}

--- a/internal/tools/builtin/read.go
+++ b/internal/tools/builtin/read.go
@@ -12,13 +12,9 @@ import (
 
 // Read returns text from a file path. Bounded by MaxBytes (default 256 KiB)
 // so a malicious or confused model can't blow the context window with a huge
-// file. Always sandboxed: Root must be set to a directory the tool may read
-// from. An empty Root is rejected at call time — there is no "open mode".
+// file. Always sandboxed to a volume: the call resolves a root from the run's
+// VolumePolicy (RFC AH) — an agent bound to no volume is refused.
 type Read struct {
-	// Root is the sandbox root. All paths must resolve inside Root after
-	// full symlink evaluation; otherwise the call returns an error.
-	// Required: a Read with empty Root rejects every call.
-	Root     string
 	MaxBytes int64
 }
 
@@ -47,12 +43,9 @@ func (r *Read) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 	if args.Path == "" {
 		return tools.Result{Text: "path is required", IsError: true}, nil
 	}
-	root, err := effectiveRoot(ctx, r.Root, args.Volume, false)
+	root, err := effectiveRoot(ctx, args.Volume, false)
 	if err != nil {
 		return tools.Result{Text: err.Error(), IsError: true}, nil
-	}
-	if root == "" {
-		return tools.Result{Text: "Read tool is not configured with a sandbox root; refusing to read", IsError: true}, nil
 	}
 
 	resolved, err := resolveInsideRoot(root, args.Path)

--- a/internal/tools/builtin/read_test.go
+++ b/internal/tools/builtin/read_test.go
@@ -7,21 +7,24 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
-// Regression: with no Root configured, Read must refuse rather than open
-// any path the process can reach.
-func TestReadRefusesEmptyRoot(t *testing.T) {
+// Regression: an agent bound to no volume (no VolumePolicy on ctx) must
+// refuse rather than open any path the process can reach. RFC AH Phase 3
+// retired the legacy jail — no volume = no disk access.
+func TestReadRefusesNoVolume(t *testing.T) {
 	r := &Read{}
 	res, err := r.Execute(context.Background(), json.RawMessage(`{"path":"/etc/hosts"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !res.IsError {
-		t.Fatal("expected IsError=true when Root is empty")
+		t.Fatal("expected IsError=true with no volume bound")
 	}
-	if !strings.Contains(res.Text, "sandbox") {
-		t.Errorf("error text should mention sandbox; got %q", res.Text)
+	if !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Errorf("error text should report no volume; got %q", res.Text)
 	}
 }
 
@@ -53,9 +56,10 @@ func TestReadRejectsSymlinkEscapingRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := &Read{Root: root}
+	r := &Read{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	input, _ := json.Marshal(map[string]string{"path": link})
-	res, err := r.Execute(context.Background(), input)
+	res, err := r.Execute(ctx, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,14 +79,15 @@ func TestReadRejectsParentTraversal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	r := &Read{Root: root}
+	r := &Read{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 
 	// Construct an absolute path one level above root.
 	parent := filepath.Dir(root)
 	probe := filepath.Join(parent, "anything.txt")
 
 	input, _ := json.Marshal(map[string]string{"path": probe})
-	res, err := r.Execute(context.Background(), input)
+	res, err := r.Execute(ctx, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,9 +112,10 @@ func TestReadAllowsInsideSandbox(t *testing.T) {
 	if err := os.WriteFile(target, []byte("hello"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	r := &Read{Root: root}
+	r := &Read{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	input, _ := json.Marshal(map[string]string{"path": target})
-	res, err := r.Execute(context.Background(), input)
+	res, err := r.Execute(ctx, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,6 +139,7 @@ func TestRead_FullReadBoundedAndEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 
 	// (1) Multi-page file (1 MiB), cap above size → read in full, intact.
 	big := strings.Repeat("ABCDEFGH", 1<<17) // 1 MiB
@@ -140,9 +147,9 @@ func TestRead_FullReadBoundedAndEmpty(t *testing.T) {
 	if err := os.WriteFile(bigPath, []byte(big), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	r := &Read{Root: root, MaxBytes: 4 << 20}
+	r := &Read{MaxBytes: 4 << 20}
 	in, _ := json.Marshal(map[string]string{"path": bigPath})
-	res, _ := r.Execute(context.Background(), in)
+	res, _ := r.Execute(ctx, in)
 	if res.IsError {
 		t.Fatalf("big read errored: %q", res.Text)
 	}
@@ -151,8 +158,8 @@ func TestRead_FullReadBoundedAndEmpty(t *testing.T) {
 	}
 
 	// (2) File larger than the cap → bounded to exactly maxBytes.
-	rCap := &Read{Root: root, MaxBytes: 1024}
-	res, _ = rCap.Execute(context.Background(), in)
+	rCap := &Read{MaxBytes: 1024}
+	res, _ = rCap.Execute(ctx, in)
 	if res.IsError {
 		t.Fatalf("capped read errored: %q", res.Text)
 	}
@@ -169,7 +176,7 @@ func TestRead_FullReadBoundedAndEmpty(t *testing.T) {
 		t.Fatal(err)
 	}
 	inEmpty, _ := json.Marshal(map[string]string{"path": emptyPath})
-	res, _ = r.Execute(context.Background(), inEmpty)
+	res, _ = r.Execute(ctx, inEmpty)
 	if res.IsError {
 		t.Fatalf("empty read errored: %q", res.Text)
 	}

--- a/internal/tools/builtin/sandbox.go
+++ b/internal/tools/builtin/sandbox.go
@@ -10,19 +10,20 @@ import (
 )
 
 // effectiveRoot resolves which sandbox root a file/exec tool call targets
-// (RFC AH Phase 1). It is the ONE seam volumes add: every file tool calls
-// this to pick a root, then the UNCHANGED resolveInsideRoot(root, path)
-// does the TOCTOU-safe containment check against it.
+// (RFC AH). It is the ONE seam volumes add: every file tool calls this to
+// pick a root, then the UNCHANGED resolveInsideRoot(root, path) does the
+// TOCTOU-safe containment check against it.
 //
-// Two paths:
+// Phase 3 retired the legacy jail (LOOMCYCLE_READ_ROOT/WRITE_ROOT/BASH_CWD):
+// volumes are now the SOLE filesystem mechanism, and access is
+// sandbox-by-default. An agent with no active VolumePolicy is bound to no
+// volume and is REFUSED — the same posture the network model uses (no
+// allowed_hosts → no egress).
 //
 //   - No VolumePolicy on ctx (an UNBOUND agent, or a deployment with no
-//     `volumes:` config) → return fallbackRoot, the tool's
-//     construction-time Root (the legacy jail). This is the
-//     backward-compat path: behaviour is byte-identical to pre-feature.
-//     The `volume` argument is ignored in this mode — there are no named
-//     volumes to address, so naming one is meaningless rather than an
-//     error (the legacy single-jail has exactly one root).
+//     `volumes:` config) → DENY. There is no fallback root; declare a
+//     `volumes:` block (with a `default` volume to restore the old
+//     single-jail behaviour).
 //
 //   - A VolumePolicy exists (a BOUND agent) → resolve the named binding,
 //     or the designated default when volumeName is empty, and enforce the
@@ -40,7 +41,7 @@ import (
 //   - needWrite && binding.ReadOnly → refuse (Write/Edit/NotebookEdit
 //     and Bash require rw; Bash cannot truly enforce ro, so it refuses
 //     rather than ship a false guarantee — RFC §6).
-func effectiveRoot(ctx context.Context, fallbackRoot, volumeName string, needWrite bool) (string, error) {
+func effectiveRoot(ctx context.Context, volumeName string, needWrite bool) (string, error) {
 	// RFC AH Phase 2b — ephemeral (run-tree-scoped) volumes resolve FIRST,
 	// but ONLY for an explicitly NAMED volume (ephemeral volumes are always
 	// named — an omitted `volume` uses the existing default-binding logic
@@ -60,15 +61,15 @@ func effectiveRoot(ctx context.Context, fallbackRoot, volumeName string, needWri
 
 	pol := tools.VolumePolicy(ctx)
 	if !pol.Active {
-		// No volume confinement in force → legacy construction-time root.
-		// fallbackRoot may be "" (an unset root), in which case the caller's
-		// existing empty-Root guard refuses the call exactly as before.
-		return fallbackRoot, nil
+		// No volume confinement in force → DENY (RFC AH Phase 3:
+		// sandbox-by-default; the legacy fallback root is gone). An agent
+		// gets filesystem access only via a `volumes:` binding.
+		return "", fmt.Errorf("no filesystem volume available to this agent — bind one via the agent's `volumes:` list (Read/Write/etc. require a volume)")
 	}
 	if len(pol.Bindings) == 0 {
 		// Active but confined to NOTHING (e.g. a sub-agent whose declared
-		// volumes share none of the parent's). Deny — do NOT fall back to the
-		// legacy jail, or spawn confinement would be a no-op.
+		// volumes share none of the parent's). Deny — identical posture to
+		// the inactive case above; spawn confinement must never leak a root.
 		return "", fmt.Errorf("no filesystem volume is available to this agent; refusing")
 	}
 

--- a/internal/tools/builtin/volumedef_test.go
+++ b/internal/tools/builtin/volumedef_test.go
@@ -535,7 +535,8 @@ func TestPurgeEphemeralRunTree_RefusesEmptyRunID(t *testing.T) {
 
 // a NAMED ephemeral volume resolves to its root via effectiveRoot; rw allows
 // a write, ro refuses; a name not in the set falls through (and with no
-// VolumePolicy → the legacy fallback root).
+// VolumePolicy → DENY, RFC AH Phase 3 sandbox-by-default; the legacy
+// fallback root is gone).
 func TestEffectiveRoot_EphemeralTier(t *testing.T) {
 	set := tools.NewEphemeralVolumeSet()
 	set.Add("work", tools.EphemeralVolumeRef{Root: "/pool/_ephemeral/run-1/work", ReadOnly: false})
@@ -543,22 +544,22 @@ func TestEffectiveRoot_EphemeralTier(t *testing.T) {
 	ctx := tools.WithEphemeralVolumes(context.Background(), set)
 
 	// rw ephemeral resolves for both read + write.
-	if got, err := effectiveRoot(ctx, "/fallback", "work", false); err != nil || got != "/pool/_ephemeral/run-1/work" {
+	if got, err := effectiveRoot(ctx, "work", false); err != nil || got != "/pool/_ephemeral/run-1/work" {
 		t.Errorf("read work = %q err=%v", got, err)
 	}
-	if got, err := effectiveRoot(ctx, "/fallback", "work", true); err != nil || got != "/pool/_ephemeral/run-1/work" {
+	if got, err := effectiveRoot(ctx, "work", true); err != nil || got != "/pool/_ephemeral/run-1/work" {
 		t.Errorf("write work = %q err=%v", got, err)
 	}
 	// ro ephemeral allows read, refuses write.
-	if got, err := effectiveRoot(ctx, "/fallback", "ref", false); err != nil || got != "/pool/_ephemeral/run-1/ref" {
+	if got, err := effectiveRoot(ctx, "ref", false); err != nil || got != "/pool/_ephemeral/run-1/ref" {
 		t.Errorf("read ref = %q err=%v", got, err)
 	}
-	if _, err := effectiveRoot(ctx, "/fallback", "ref", true); err == nil || !strings.Contains(err.Error(), "read-only") {
+	if _, err := effectiveRoot(ctx, "ref", true); err == nil || !strings.Contains(err.Error(), "read-only") {
 		t.Errorf("write ref must refuse ro; err=%v", err)
 	}
-	// A name not in the set + no VolumePolicy → legacy fallback (unchanged).
-	if got, err := effectiveRoot(ctx, "/fallback", "other", false); err != nil || got != "/fallback" {
-		t.Errorf("unknown name = %q err=%v, want fallback", got, err)
+	// A name not in the set + no VolumePolicy → DENY (no fallback root).
+	if _, err := effectiveRoot(ctx, "other", false); err == nil || !strings.Contains(err.Error(), "no filesystem volume available") {
+		t.Errorf("unknown name + no policy must deny; err=%v", err)
 	}
 }
 
@@ -586,7 +587,7 @@ func TestEffectiveRoot_EphemeralStillContains(t *testing.T) {
 	set.Add("work", tools.EphemeralVolumeRef{Root: realRoot})
 	ctx := tools.WithEphemeralVolumes(context.Background(), set)
 
-	root, err := effectiveRoot(ctx, "", "work", false)
+	root, err := effectiveRoot(ctx, "work", false)
 	if err != nil {
 		t.Fatalf("effectiveRoot: %v", err)
 	}

--- a/internal/tools/builtin/volumes_test.go
+++ b/internal/tools/builtin/volumes_test.go
@@ -33,7 +33,7 @@ func realDir(t *testing.T) string {
 func TestWrite_RwVolumeAllowsWrite(t *testing.T) {
 	root := realDir(t)
 	ctx := ctxWith(tools.VolumeBinding{Name: "work", Root: root, Default: true})
-	w := &Write{Root: ""} // construction-time Root unset: only the volume can satisfy it.
+	w := &Write{} // RFC AH Phase 3: only the volume can satisfy a file tool.
 	body, _ := json.Marshal(map[string]string{"path": "out.txt", "content": "hi", "volume": "work"})
 	res, err := w.Execute(ctx, body)
 	if err != nil {
@@ -316,46 +316,48 @@ func TestContextSelf_ReportsBoundVolumes(t *testing.T) {
 	}
 }
 
-// Backward-compat: an UNBOUND agent (no VolumePolicy on ctx) uses the tool's
-// construction-time Root exactly as before the feature.
-func TestRead_UnboundAgentUsesLegacyRoot(t *testing.T) {
+// RFC AH Phase 3 (the load-bearing behavior): an UNBOUND agent (no
+// VolumePolicy on ctx) is bound to no volume, so every file tool REFUSES —
+// sandbox-by-default; the legacy construction-time fallback root is gone.
+// Fail-before: revert effectiveRoot's inactive branch to `return
+// fallbackRoot, nil` and this test fails (the Read would succeed on a host
+// path / silently no-op instead of denying).
+func TestRead_UnboundAgentDenies(t *testing.T) {
 	root := realDir(t)
 	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("legacy"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// No VolumePolicy attached → effectiveRoot returns the construction-time Root.
-	r := &Read{Root: root}
-	body, _ := json.Marshal(map[string]string{"path": "f.txt"})
+	// No VolumePolicy attached → effectiveRoot denies (no fallback root exists).
+	r := &Read{}
+	body, _ := json.Marshal(map[string]string{"path": filepath.Join(root, "f.txt")})
 	res, err := r.Execute(context.Background(), body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if res.IsError || res.Text != "legacy" {
-		t.Fatalf("unbound agent should use legacy Root, got Text=%q IsError=%v", res.Text, res.IsError)
+	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Fatalf("unbound agent must refuse (no legacy fallback), got Text=%q IsError=%v", res.Text, res.IsError)
 	}
 }
 
 // An ACTIVE policy with NO bindings (a sub-agent narrowed to an empty
 // intersection — it shares none of the parent's volumes) DENIES every
-// file-tool call. It must NOT fall back to the construction-time Root, or
-// spawn confinement would silently hand the child the (broader) legacy jail.
-// Fail-before: pre-fix, effectiveRoot keyed off len(Bindings)==0 and treated an
-// empty policy as "no policy", returning the Root.
+// file-tool call, identically to the inactive case. Spawn confinement must
+// never leak a root.
 func TestRead_ActiveEmptyPolicyRefuses(t *testing.T) {
 	root := realDir(t)
 	if err := os.WriteFile(filepath.Join(root, "f.txt"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	// Active, zero bindings. A legacy Root IS set — it must NOT be reached.
+	// Active, zero bindings → deny.
 	ctx := tools.WithVolumePolicy(context.Background(), tools.VolumePolicyValue{Active: true})
-	r := &Read{Root: root}
-	body, _ := json.Marshal(map[string]string{"path": "f.txt"})
+	r := &Read{}
+	body, _ := json.Marshal(map[string]string{"path": filepath.Join(root, "f.txt")})
 	res, err := r.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume is available") {
-		t.Fatalf("active-empty policy must refuse (not fall back to the legacy Root); got Text=%q IsError=%v", res.Text, res.IsError)
+		t.Fatalf("active-empty policy must refuse; got Text=%q IsError=%v", res.Text, res.IsError)
 	}
 }
 

--- a/internal/tools/builtin/volumes_test.go
+++ b/internal/tools/builtin/volumes_test.go
@@ -334,6 +334,8 @@ func TestRead_UnboundAgentDenies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// "available" (no "is") — effectiveRoot's !pol.Active branch. The one-word
+	// difference from the active-empty refusal below is intentional; don't unify.
 	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume available") {
 		t.Fatalf("unbound agent must refuse (no legacy fallback), got Text=%q IsError=%v", res.Text, res.IsError)
 	}
@@ -356,6 +358,9 @@ func TestRead_ActiveEmptyPolicyRefuses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// "is available" — effectiveRoot's len(pol.Bindings)==0 branch (active policy,
+	// no bindings). The one-word difference from the inactive refusal above is
+	// intentional; don't "correct" it or this assertion silently passes the wrong branch.
 	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume is available") {
 		t.Fatalf("active-empty policy must refuse; got Text=%q IsError=%v", res.Text, res.IsError)
 	}

--- a/internal/tools/builtin/write.go
+++ b/internal/tools/builtin/write.go
@@ -15,15 +15,12 @@ import (
 // directory, then a single rename into place. Partial writes are never
 // observed by readers (POSIX rename is atomic on the same filesystem).
 //
-// Sandbox semantics mirror Read: empty Root rejects every call. Path
-// resolution checks the PARENT directory (the file may not exist yet),
+// Sandbox semantics mirror Read: an agent bound to no rw volume is refused.
+// Path resolution checks the PARENT directory (the file may not exist yet),
 // then writes the new file beside the resolved parent. A symlink at the
 // target path is silently replaced by the rename, which is fine — we
 // never follow it.
 type Write struct {
-	// Root is the sandbox root. The target's parent must resolve inside
-	// Root after symlink evaluation. Required.
-	Root string
 	// MaxBytes caps the content size. Default 1 MiB.
 	MaxBytes int64
 }
@@ -57,12 +54,9 @@ func (w *Write) Execute(ctx context.Context, input json.RawMessage) (tools.Resul
 	if args.Path == "" {
 		return tools.Result{Text: "path is required", IsError: true}, nil
 	}
-	root, err := effectiveRoot(ctx, w.Root, args.Volume, true)
+	root, err := effectiveRoot(ctx, args.Volume, true)
 	if err != nil {
 		return tools.Result{Text: err.Error(), IsError: true}, nil
-	}
-	if root == "" {
-		return tools.Result{Text: "Write tool is not configured with a sandbox root; refusing to write", IsError: true}, nil
 	}
 
 	maxBytes := w.MaxBytes

--- a/internal/tools/builtin/write_test.go
+++ b/internal/tools/builtin/write_test.go
@@ -7,17 +7,20 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
-// Mirrors TestReadRefusesEmptyRoot: no Root → no writes regardless of input.
-func TestWriteRefusesEmptyRoot(t *testing.T) {
+// Mirrors TestReadRefusesNoVolume: no volume bound → no writes regardless of
+// input (RFC AH Phase 3 sandbox-by-default).
+func TestWriteRefusesNoVolume(t *testing.T) {
 	w := &Write{}
 	res, err := w.Execute(context.Background(), json.RawMessage(`{"path":"/tmp/x","content":"y"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !res.IsError || !strings.Contains(res.Text, "sandbox") {
-		t.Fatalf("expected sandbox-refusal error, got Text=%q IsError=%v", res.Text, res.IsError)
+	if !res.IsError || !strings.Contains(res.Text, "no filesystem volume available") {
+		t.Fatalf("expected no-volume refusal, got Text=%q IsError=%v", res.Text, res.IsError)
 	}
 }
 
@@ -28,9 +31,10 @@ func TestWriteAllowsInsideSandbox(t *testing.T) {
 	}
 	target := filepath.Join(root, "out.txt")
 
-	w := &Write{Root: root}
+	w := &Write{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "content": "hello world"})
-	res, err := w.Execute(context.Background(), body)
+	res, err := w.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,9 +61,10 @@ func TestWriteRejectsParentTraversal(t *testing.T) {
 	parent := filepath.Dir(root)
 	probe := filepath.Join(parent, "anywhere.txt")
 
-	w := &Write{Root: root}
+	w := &Write{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": probe, "content": "x"})
-	res, err := w.Execute(context.Background(), body)
+	res, err := w.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,9 +96,10 @@ func TestWriteRejectsSymlinkedParentEscape(t *testing.T) {
 	}
 	target := filepath.Join(link, "x.txt")
 
-	w := &Write{Root: root}
+	w := &Write{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "content": "leaked"})
-	res, err := w.Execute(context.Background(), body)
+	res, err := w.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,9 +127,10 @@ func TestWriteOverwritesExistingFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	w := &Write{Root: root}
+	w := &Write{}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "content": "new"})
-	res, err := w.Execute(context.Background(), body)
+	res, err := w.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,9 +151,10 @@ func TestWriteRefusesOversizedContent(t *testing.T) {
 	}
 	target := filepath.Join(root, "big.txt")
 
-	w := &Write{Root: root, MaxBytes: 8}
+	w := &Write{MaxBytes: 8}
+	ctx := ctxWith(tools.VolumeBinding{Name: "default", Root: root, Default: true})
 	body, _ := json.Marshal(map[string]string{"path": target, "content": "this is way more than eight bytes"})
-	res, err := w.Execute(context.Background(), body)
+	res, err := w.Execute(ctx, body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -221,16 +221,16 @@ type VolumeBinding struct {
 // VolumePolicyValue is the run's resolved volume policy.
 //
 // Active distinguishes "volume confinement is in force" from "no policy",
-// which is load-bearing for spawn confinement:
-//   - Active == false (the zero value / never attached): the file tools
-//     fall back to their construction-time Root (the legacy jail). This is
-//     the backward-compat path for deployments + agents that don't use
-//     volumes.
+// which is load-bearing for both spawn confinement and sandbox-by-default
+// (RFC AH Phase 3 — the legacy jail is gone):
+//   - Active == false (the zero value / never attached): the agent is bound
+//     to NO volume, so every file/exec tool REFUSES (no filesystem access).
+//     Disk access is an explicit grant — declare a `volumes:` block (with a
+//     `default` volume to restore the old single-jail behaviour).
 //   - Active == true: the run is confined to Bindings. An Active policy with
 //     an EMPTY Bindings slice DENIES every file-tool call (e.g. a sub-agent
-//     whose declared volumes share none of the parent's). It must NOT fall
-//     back to the legacy jail — otherwise narrowing a child to nothing would
-//     silently hand it the (broader) jail instead of denying it.
+//     whose declared volumes share none of the parent's), exactly like the
+//     inactive case — there is no longer any fallback root to leak to.
 type VolumePolicyValue struct {
 	Active   bool
 	Bindings []VolumeBinding
@@ -246,8 +246,9 @@ func WithVolumePolicy(ctx context.Context, p VolumePolicyValue) context.Context 
 }
 
 // VolumePolicy returns the run's volume policy from ctx, or the zero value
-// (Active=false) when none was attached. Active=false is the "unbound /
-// legacy jail" signal — the tools use their construction-time Root.
+// (Active=false) when none was attached. Active=false is the "no volume
+// bound" signal — the file/exec tools refuse (RFC AH Phase 3: no legacy
+// fallback root survives).
 func VolumePolicy(ctx context.Context) VolumePolicyValue {
 	v, _ := ctx.Value(ctxKeyVolumePolicy{}).(VolumePolicyValue)
 	return v

--- a/loomcycle.local-interactive.example.yaml
+++ b/loomcycle.local-interactive.example.yaml
@@ -25,8 +25,14 @@
 #   LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=131072  # pin the context window (see note).
 #   LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=300000  # time-to-FIRST-token budget.
 #   LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=300000    # inter-token idle budget.
-#   LOOMCYCLE_BASH_ENABLED=1   LOOMCYCLE_BASH_CWD=<dir>   # if the agent runs shell
-#   LOOMCYCLE_READ_ROOT=<dir>  LOOMCYCLE_WRITE_ROOT=<dir> # the file sandbox jail
+#   LOOMCYCLE_BASH_ENABLED=1   # if the agent runs shell (NOT a true sandbox)
+#
+# Filesystem access (RFC AH Phase 3): declare a `volumes:` block — the legacy
+# LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD jail is retired (setting one now
+# fails startup). To restore the old single shared jail, give the agent a
+# default volume:
+#   volumes:
+#     default: { path: <dir>, mode: rw, default: true }
 #
 # num_ctx is GLOBAL (one value for ALL ollama-local models) and is sent as
 # options.num_ctx — it both CAPS the window the model loads AND is what the


### PR DESCRIPTION
**BREAKING.** The finale of RFC AH's runtime line (Phases 1 #510, 2a #511, 2b #512 merged). With Volumes shipped and no real consumers of the legacy jail (JobEmber runs loomcycle as a no-disk sandbox), retire `LOOMCYCLE_READ_ROOT` / `WRITE_ROOT` / `BASH_CWD`. **Volumes are now the sole filesystem mechanism; sandbox-by-default.** RFC §5b.

## What
- Remove the three env vars (`cfg.Env.ReadRoot/WriteRoot/BashCwd` + reads) + the per-tool construction-time `Root`/`Cwd` fields + `effectiveRoot`'s `fallbackRoot` param.
- **An inactive volume policy now DENIES** (was: fall back to the legacy root). No volume binding ⇒ no filesystem access — every Read/Write/Edit/Glob/Grep/Bash/NotebookEdit refuses (mirrors "no `allowed_hosts` ⇒ no egress").
- An operator wanting the old single jail declares one volume: `volumes: { default: { path: /work/sandbox, mode: rw, default: true } }`.
- A deploy still setting any retired var **fails at config-load** with a migration hint (`checkRetiredJailEnv`) — surfaced at boot and by `loomcycle doctor`, so a stale config is caught, not silently denied.
- `Context op=self` reports the no-filesystem-access state; the boot notes are updated. The TOCTOU-safe `resolveInsideRoot` containment is **byte-identical**.

## Migration (in this PR)
The 3 bundled examples (exp1/exp4/exp7), the README deployment-postures table, and the `docs/PLAN.md` recipes are migrated off the env vars to a `default` volume (exp7's read-only reviewers → an `ro` default). `.env.insecure.example` + CONFIGURATION/TOOLS/help updated.

## Process note (transparency)
The implementing subagent was cut off by a session limit after completing the runtime + test migration but **before committing or reporting**. I verified the work independently (build, full suite, gofmt, containment-unchanged), committed it in reviewable groups, ran the review, and completed the gaps the review surfaced.

## Review (2 reviewers) + fixes
- **Removal complete + correct:** no leftover path where a file/exec tool resolves a root without an Active volume; `checkRetiredJailEnv` fires for all three vars + is called in `Load`; no stray consumer; op=self clean; `doctor` surfaces the error; `claudeimport` correctly untouched (never referenced the vars).
- **Test migration preserved coverage** (no gutted assertions; the ro/rw + `..`-escape tests intact; the deny/migration/op=self tests are real).
- **Gaps the review found + I fixed:** the 3 examples' `run.sh` exported the retired vars → would fail-to-boot post-Phase-3 → migrated to a `default` volume; README/PLAN stale guidance → updated; a test-comment nit (two near-identical refusal strings) → annotated.

## Tested
- `go build ./...` + full `go test ./...` clean; `gofmt` clean.
- **Fail-before-verified:** `TestRead_UnboundAgentDenies` (unbound agent refuses — no fallback) and `TestLoad_LegacyJailEnvErrors` (a retired env var → config-load error). Containment core unchanged (diff-verified).

## RFC AH status
Runtime line complete: 1 → 2a → 2b → **3 (this)**. Remaining (plan-only, in the RFC): **Phase 4** (Web UI volume management) and **Phase 5** (gRPC/MCP/TS/Python parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)