### PR TITLE
feat(volumes): RFC AH Phase 4 — Web UI volume management

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -151,6 +151,38 @@ tenant.
 - **Not in Phase 2b (follow-ups):** gRPC / MCP-meta-tool parity for the
   `ephemeral` create param; Web UI; Phase 3 (legacy-jail removal).
 
+**🖥️ Filesystem Volumes — Web UI management (RFC AH Phase 4).** A dedicated
+**Volumes** console tab (under `/ui`, admin-gated to match Library/Integrations)
+to view and manage volumes for the operator's tenant. Web-UI-only — it consumes
+the existing HTTP surface; no new runtime primitive.
+
+- **Persistent sub-tab.** A flat table merging the **static** `volumes:`
+  universe (source `static`, **read-only** — operator yaml is ground truth,
+  including the one flagged `dynamic_root`) with the tenant's **dynamic**
+  `VolumeDef`s (source `dynamic`). Dynamic rows get **Delete** (non-destructive
+  — unmaps the volume, keeps files on disk; a simple confirm, matching the
+  retire pattern) and **Purge** (destructive). A **Create** button provisions a
+  dynamic volume by name + mode (the runtime derives the path). A **bound by**
+  column cross-references which AgentDefs bind each volume (`AgentDef.volumes`,
+  now surfaced on `/v1/_library/agents`).
+- **Ephemeral sub-tab.** A read-only flat table of the tenant's **live**
+  ephemeral volumes (name / run_id / mode / created_at), polled every 10s, with
+  a "live, run-scoped, auto-purged at run completion" note.
+- **Type-to-confirm purge.** `Purge` opens a modal that names the directory it
+  `RemoveAll`s and requires the operator to **type the volume's name** to enable
+  the confirm button — distinct from `Delete`. The server-side four-way fence
+  remains the real guard; this is a UI affordance.
+- **Two additive read endpoints** (no new primitive): **`GET /v1/_volumes`**
+  (merged persistent universe — statics shown to all as the bind floor, dynamics
+  filtered to the caller's tenant) and **`GET /v1/_volumes/ephemeral`** (the
+  tenant's live ephemeral volumes, backed by the cross-replica
+  `ephemeral_volume_defs` table via the new `EphemeralVolumeListByTenant` store
+  method). Both derive the tenant from the authoritative principal (never the
+  wire) and are gated at `ScopeTenant` (admin satisfies); dynamic + ephemeral
+  rows are opaque cross-tenant. CRUD stays on the existing `POST /v1/_volumedef`.
+- **Not in Phase 4 (follow-ups):** broader tenant-operator UI access (the tab is
+  admin-gated for now); Phase 5 (gRPC / MCP / TS / Python `VolumeDef` parity).
+
 ## What's in v1.0.2
 
 **🌐 Permitted host-widen grants now work with no static HTTP allowlist.** A

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -978,6 +978,15 @@ Create one with `ephemeral: true`:
 - **Requires an active run.** `ephemeral: true` is refused outside a run (no root run id) and on a static-name or in-run-duplicate collision. Same `volume_def_scopes` gate as the persistent op.
 - **Crash backstop — `LOOMCYCLE_EPHEMERAL_VOLUME_SWEEP_MS`.** A singleton sweeper (default **60s**; `0` disables — the inline purge still runs) periodically purges ephemeral volumes whose owning run is terminal **and not paused/pausing** (a paused run is parked, not crashed — its volumes survive to be reused on resume; a resumed run rehydrates its in-memory set from the persisted rows). Cluster-gated, so one replica per tick does the work. Skipped when no `dynamic_root` is configured.
 
+### 9d.3 Volumes console tab (RFC AH Phase 4)
+
+The embedded Web UI (`/ui`) has a dedicated **Volumes** tab (admin-gated, alongside Library / Integrations / Channels / Schedules) to view and manage volumes for the operator's tenant. It's a thin client over the HTTP surface — no new runtime behaviour.
+
+- **Persistent.** A flat table of static volumes (read-only — the operator yaml is ground truth, including the `dynamic_root`) plus the tenant's dynamic `VolumeDef`s. Dynamic rows support **Delete** (non-destructive — unmaps the volume, keeps files) and **Purge** (destructive — `RemoveAll`s the directory tree). A **Create** button provisions a dynamic volume by name + mode (the runtime derives the path). A **bound by** column shows which agents bind each volume.
+- **Ephemeral.** A read-only table of the tenant's live ephemeral volumes (auto-purged at run completion), polled every ~10s.
+- **Purge is type-to-confirm** — the operator must type the volume's name to enable the confirm button, distinct from the one-click Delete. The server-side `RemoveAll` fence (§6 of the RFC: re-derive, EvalSymlinks, strictly-inside, expected-prefix) remains the real guard.
+- **Backed by two read-only endpoints** — `GET /v1/_volumes` (merged static + tenant dynamic) and `GET /v1/_volumes/ephemeral` (the tenant's live ephemeral volumes). Both are tenant-scoped from the authoritative principal (gated at `substrate:tenant`; admin satisfies). CRUD reuses `POST /v1/_volumedef`.
+
 ---
 
 ## 10. Cross-references

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -457,6 +457,15 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin.
 	case isTenantConfinedDefPath(path):
 		return auth.ScopeTenant
+	// RFC AH Phase 4: the two read-only volume views (GET /v1/_volumes +
+	// /v1/_volumes/ephemeral). Same tenant-confined posture as the def plane —
+	// the handlers filter dynamic + ephemeral rows to the principal's
+	// authoritative tenant (statics are the shared bind floor, shown to all).
+	// ScopeTenant (ScopeAdmin also satisfies). Distinct from the
+	// isTenantConfinedDefPath set because these are GETs at /v1/_volumes(/...),
+	// not the /v1/_volumedef def-authoring route.
+	case path == "/v1/_volumes" || path == "/v1/_volumes/ephemeral":
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, audit, cross-tenant user focus.

--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -274,6 +274,10 @@ type staticAgentDefJSON struct {
 	MemoryScopes          []string                          `json:"memory_scopes,omitempty"`
 	MemoryQuotaBytes      int                               `json:"memory_quota_bytes,omitempty"`
 	MemoryBackend         string                            `json:"memory_backend,omitempty"`
+	// RFC AH per-agent filesystem volume bindings — the names this agent is
+	// confined to. Surfaced so the Volumes Web UI (Phase 4) can cross-reference
+	// which agents bind each volume (derived client-side from this list).
+	Volumes []string `json:"volumes,omitempty"`
 }
 
 func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
@@ -295,6 +299,7 @@ func marshalStaticAgentDef(def config.AgentDef) json.RawMessage {
 		MemoryScopes:          def.MemoryScopes,
 		MemoryQuotaBytes:      def.MemoryQuotaBytes,
 		MemoryBackend:         def.MemoryBackend,
+		Volumes:               def.Volumes,
 	})
 	if err != nil {
 		return nil

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2269,6 +2269,13 @@ func (s *Server) Mux() http.Handler {
 	// confined (ScopeTenant via isTenantConfinedDefPath) — the tool stamps
 	// the caller's authoritative tenant + opaque-404s cross-tenant reads.
 	mux.Handle("POST /v1/_volumedef", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleSubstrateVolumeDef))))
+	// RFC AH Phase 4 (Web UI) — two ADDITIVE read-only views of the volume
+	// universe. Tenant-confined (ScopeTenant via isTenantConfinedDefPath):
+	// statics are shown to all (the shared bind floor), dynamic + ephemeral
+	// rows are filtered to the caller's authoritative tenant. No new runtime
+	// primitive — CRUD stays on POST /v1/_volumedef.
+	mux.Handle("GET /v1/_volumes", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListVolumes))))
+	mux.Handle("GET /v1/_volumes/ephemeral", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListEphemeralVolumes))))
 	// v1.x scheduled-runs substrate. Same operator-admin-only dispatch
 	// shape; the tool is reachable only via this endpoint + the MCP
 	// meta-tool + the future gRPC RPC (no per-agent dispatcher slot).

--- a/internal/api/http/volumes_read.go
+++ b/internal/api/http/volumes_read.go
@@ -32,6 +32,31 @@ func volumesReadTenant(r *http.Request) string {
 	return principal.TenantID
 }
 
+// volumesShowPaths reports whether the caller may see host FILESYSTEM PATHS.
+// A static volume's `path` (and the dynamic-root parent) is operator
+// infrastructure: it reveals the host layout the runtime can reach. The route
+// is gated at ScopeTenant (a tenant operator manages its own dynamic volumes),
+// but a tenant operator is NOT the operator — so it sees the volume UNIVERSE
+// (names / modes / which is default / which is the dynamic root / created-at)
+// without the host paths. Only the operator-equivalent set sees them: it
+// reuses tenantScopeFromCtx's exemption (substrate:admin, the legacy
+// single-operator token, and open dev mode — the exact mirror of the Web UI's
+// is_admin). Defense-in-depth at the API: independent of whether the console
+// nav surfaces the tab to a given role.
+func volumesShowPaths(r *http.Request) bool {
+	_, allTenants := tenantScopeFromCtx(r.Context())
+	return allTenants
+}
+
+// redactedPath returns p when the caller may see host paths, else "" (rendered
+// as an empty `path` so a non-operator gets the volume but not its location).
+func redactedPath(show bool, p string) string {
+	if show {
+		return p
+	}
+	return ""
+}
+
 // persistentVolumeEntry is one row of GET /v1/_volumes.
 type persistentVolumeEntry struct {
 	Name string `json:"name"`
@@ -60,9 +85,11 @@ type persistentVolumesResponse struct {
 // bind floor, read-only) plus the tenant's own dynamic VolumeDef rows.
 func (s *Server) handleListVolumes(w http.ResponseWriter, r *http.Request) {
 	entries := make([]persistentVolumeEntry, 0, len(s.cfg.Volumes))
+	showPaths := volumesShowPaths(r)
 
 	// Static volumes — the operator-authored universe, shown to every tenant
 	// (it's the bind floor). Read-only from the UI; config is ground truth.
+	// Host paths are redacted for a non-operator (volumesShowPaths).
 	for name, vol := range s.cfg.Volumes {
 		mode := vol.Mode
 		if mode == "" {
@@ -71,7 +98,7 @@ func (s *Server) handleListVolumes(w http.ResponseWriter, r *http.Request) {
 		entries = append(entries, persistentVolumeEntry{
 			Name:        name,
 			Source:      "static",
-			Path:        vol.Path,
+			Path:        redactedPath(showPaths, vol.Path),
 			Mode:        mode,
 			Default:     vol.Default,
 			DynamicRoot: vol.DynamicRoot,
@@ -91,7 +118,7 @@ func (s *Server) handleListVolumes(w http.ResponseWriter, r *http.Request) {
 			entries = append(entries, persistentVolumeEntry{
 				Name:      row.Name,
 				Source:    "dynamic",
-				Path:      path,
+				Path:      redactedPath(showPaths, path),
 				Mode:      mode,
 				CreatedAt: row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
 			})
@@ -131,6 +158,7 @@ type ephemeralVolumesResponse struct {
 // another tenant's rows.
 func (s *Server) handleListEphemeralVolumes(w http.ResponseWriter, r *http.Request) {
 	entries := make([]ephemeralVolumeEntry, 0)
+	showPaths := volumesShowPaths(r)
 	if s.store != nil {
 		rows, err := s.store.EphemeralVolumeListByTenant(r.Context(), volumesReadTenant(r))
 		if err != nil {
@@ -142,7 +170,7 @@ func (s *Server) handleListEphemeralVolumes(w http.ResponseWriter, r *http.Reque
 			entries = append(entries, ephemeralVolumeEntry{
 				Name:      row.Name,
 				RootRunID: row.RootRunID,
-				Path:      path,
+				Path:      redactedPath(showPaths, path),
 				Mode:      mode,
 				CreatedAt: row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
 			})

--- a/internal/api/http/volumes_read.go
+++ b/internal/api/http/volumes_read.go
@@ -1,0 +1,165 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// volumes_read.go — RFC AH Phase 4 (Web UI volume management) two ADDITIVE,
+// read-only endpoints the console needs to render the volume universe. They
+// add NO runtime primitive; CRUD stays on the existing POST /v1/_volumedef
+// (create/delete/purge) dispatched via the substrate admin handler.
+//
+// Both reads are tenant-scoped from the AUTHORITATIVE principal stamped on
+// ctx by the auth middleware — NEVER a wire/query field. The scope gate
+// (requiredScopeFor → ScopeTenant for these GETs) gates them to the tenant
+// operator; admin/legacy satisfies ScopeTenant. The DYNAMIC + EPHEMERAL rows
+// are filtered to the caller's tenant (opaque: a cross-tenant row is simply
+// absent, never a 403/404 oracle). STATIC volumes are operator-authored
+// config — the shared bind FLOOR every tenant may bind to — so they are shown
+// to everyone.
+
+// volumesReadTenant resolves the caller's authoritative tenant for the read
+// endpoints. Mirrors substrateAdminCtx's tenant derivation: the principal the
+// auth middleware stamped, never the wire. "" (no principal: legacy
+// LOOMCYCLE_AUTH_TOKEN / open mode) = the shared tenant — the correct
+// single-tenant behaviour.
+func volumesReadTenant(r *http.Request) string {
+	principal, _ := auth.PrincipalFromContext(r.Context())
+	return principal.TenantID
+}
+
+// persistentVolumeEntry is one row of GET /v1/_volumes.
+type persistentVolumeEntry struct {
+	Name string `json:"name"`
+	// Source is "static" (operator yaml, read-only) or "dynamic" (a tenant's
+	// VolumeDef row, CRUD-able).
+	Source string `json:"source"`
+	Path   string `json:"path"`
+	Mode   string `json:"mode"`
+	// Default marks the static volume the operator flagged `default: true`.
+	// Dynamic volumes are never the default (only static config can be).
+	Default bool `json:"default"`
+	// DynamicRoot marks the static volume that is the operator-blessed parent
+	// dynamic VolumeDefs are provisioned inside. Always false for dynamic rows.
+	DynamicRoot bool `json:"dynamic_root"`
+	// CreatedAt is set for dynamic rows (the substrate stamps it); empty for
+	// static volumes (config has no creation timestamp).
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+type persistentVolumesResponse struct {
+	Entries []persistentVolumeEntry `json:"entries"`
+}
+
+// handleListVolumes serves GET /v1/_volumes — the merged PERSISTENT volume
+// universe for the caller's tenant: every static cfg.Volumes entry (the shared
+// bind floor, read-only) plus the tenant's own dynamic VolumeDef rows.
+func (s *Server) handleListVolumes(w http.ResponseWriter, r *http.Request) {
+	entries := make([]persistentVolumeEntry, 0, len(s.cfg.Volumes))
+
+	// Static volumes — the operator-authored universe, shown to every tenant
+	// (it's the bind floor). Read-only from the UI; config is ground truth.
+	for name, vol := range s.cfg.Volumes {
+		mode := vol.Mode
+		if mode == "" {
+			mode = "rw" // empty defaults to rw, validated at config-load
+		}
+		entries = append(entries, persistentVolumeEntry{
+			Name:        name,
+			Source:      "static",
+			Path:        vol.Path,
+			Mode:        mode,
+			Default:     vol.Default,
+			DynamicRoot: vol.DynamicRoot,
+		})
+	}
+
+	// Dynamic VolumeDefs — filtered to the caller's authoritative tenant. Nil
+	// store (tests / no persistence) → no dynamic rows, statics still surface.
+	if s.store != nil {
+		rows, err := s.store.VolumeDefList(r.Context(), volumesReadTenant(r))
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		for _, row := range rows {
+			path, mode := decodeVolumeDefBody(row.Definition)
+			entries = append(entries, persistentVolumeEntry{
+				Name:      row.Name,
+				Source:    "dynamic",
+				Path:      path,
+				Mode:      mode,
+				CreatedAt: row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+			})
+		}
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Name != entries[j].Name {
+			return entries[i].Name < entries[j].Name
+		}
+		// Stable secondary key when a static + dynamic name coincide (the tool
+		// refuses dynamic creates over a static name, so this is defensive).
+		return entries[i].Source < entries[j].Source
+	})
+	writeJSONOK(w, persistentVolumesResponse{Entries: entries})
+}
+
+// ephemeralVolumeEntry is one row of GET /v1/_volumes/ephemeral.
+type ephemeralVolumeEntry struct {
+	Name      string `json:"name"`
+	RootRunID string `json:"root_run_id"`
+	Path      string `json:"path"`
+	Mode      string `json:"mode"`
+	CreatedAt string `json:"created_at"`
+}
+
+type ephemeralVolumesResponse struct {
+	Entries []ephemeralVolumeEntry `json:"entries"`
+}
+
+// handleListEphemeralVolumes serves GET /v1/_volumes/ephemeral — the LIVE
+// ephemeral volumes for the caller's tenant. The persisted
+// ephemeral_volume_defs table is the cross-replica source of truth (rows are
+// deleted at run completion / by the sweeper), so a tenant-scoped read returns
+// exactly the currently-active ephemeral volumes. Tenant filtering happens at
+// the store boundary (EphemeralVolumeListByTenant) — a tenant never observes
+// another tenant's rows.
+func (s *Server) handleListEphemeralVolumes(w http.ResponseWriter, r *http.Request) {
+	entries := make([]ephemeralVolumeEntry, 0)
+	if s.store != nil {
+		rows, err := s.store.EphemeralVolumeListByTenant(r.Context(), volumesReadTenant(r))
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
+			return
+		}
+		for _, row := range rows {
+			path, mode := decodeVolumeDefBody(row.Definition)
+			entries = append(entries, ephemeralVolumeEntry{
+				Name:      row.Name,
+				RootRunID: row.RootRunID,
+				Path:      path,
+				Mode:      mode,
+				CreatedAt: row.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z"),
+			})
+		}
+	}
+	writeJSONOK(w, ephemeralVolumesResponse{Entries: entries})
+}
+
+// decodeVolumeDefBody extracts {path, mode} from a VolumeDef/ephemeral row's
+// runtime-derived definition JSON. A malformed body yields empty strings
+// rather than failing the whole list (defensive — the tool always writes a
+// well-formed body, so this never fires in practice).
+func decodeVolumeDefBody(def json.RawMessage) (path, mode string) {
+	var body struct {
+		Path string `json:"path"`
+		Mode string `json:"mode"`
+	}
+	_ = json.Unmarshal(def, &body)
+	return body.Path, body.Mode
+}

--- a/internal/api/http/volumes_read_test.go
+++ b/internal/api/http/volumes_read_test.go
@@ -28,6 +28,18 @@ func reqWithTenant(path, tenant string) *http.Request {
 	}))
 }
 
+// reqWithAdmin is reqWithTenant for an operator-equivalent (substrate:admin)
+// principal — the set that sees host filesystem paths the tenant operator does
+// not (volumesShowPaths).
+func reqWithAdmin(path, tenant string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+		TenantID: tenant,
+		Subject:  "admin-" + tenant,
+		Scopes:   []string{auth.ScopeAdmin},
+	}))
+}
+
 // mkDynamicVolume creates a persistent dynamic VolumeDef for a tenant via the
 // real tool, so the test exercises the same write path the runtime uses.
 func mkDynamicVolume(t *testing.T, st store.Store, cfg *config.Config, tenant, name, mode string) {
@@ -139,8 +151,13 @@ func TestListEphemeralVolumes_TenantScoped(t *testing.T) {
 		if e.RootRunID == "run-other-1" {
 			t.Errorf("cross-tenant ephemeral row leaked: %+v", e)
 		}
-		if e.Path == "" || e.CreatedAt == "" {
-			t.Errorf("entry missing path/created_at: %+v", e)
+		// A tenant-operator principal gets the host path REDACTED (covered by
+		// TestListVolumes_RedactsHostPathsForTenantOperator); created_at stays.
+		if e.CreatedAt == "" {
+			t.Errorf("entry missing created_at: %+v", e)
+		}
+		if e.Path != "" {
+			t.Errorf("tenant operator must not see ephemeral host path: %+v", e)
 		}
 	}
 }
@@ -159,5 +176,90 @@ func TestRequiredScopeFor_VolumeReadsAreTenantConfined(t *testing.T) {
 	// The def-authoring route stays tenant-confined too (unchanged).
 	if got := requiredScopeFor(http.MethodPost, "/v1/_volumedef"); got != auth.ScopeTenant {
 		t.Errorf("requiredScopeFor(POST /v1/_volumedef) = %q, want %q", got, auth.ScopeTenant)
+	}
+}
+
+// TestListVolumes_RedactsHostPathsForTenantOperator is the fail-before guard
+// for the path-disclosure fix: a ScopeTenant caller (the tenant operator who
+// drives the Volumes tab) sees the volume UNIVERSE (name / mode / source /
+// default / dynamic-root / created-at) but NOT host filesystem paths — those
+// are operator infrastructure. Only an operator-equivalent principal
+// (substrate:admin / legacy / open dev mode) sees them. Dropping redactedPath
+// → a tenant token sees the operator's host layout → both halves below fail.
+func TestListVolumes_RedactsHostPathsForTenantOperator(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Volumes: map[string]config.Volume{
+		"pool": {Path: root, Mode: "rw", DynamicRoot: true},
+	}}
+	mkDynamicVolume(t, st, cfg, "acme", "repo-a", "rw")
+	body, _ := json.Marshal(map[string]string{"path": "/pool/_ephemeral/run-1/work", "mode": "rw"})
+	if _, err := st.EphemeralVolumeCreate(context.Background(), store.EphemeralVolumeDefRow{
+		RootRunID: "run-1", Name: "work", TenantID: "acme", Definition: body,
+	}); err != nil {
+		t.Fatalf("create ephemeral: %v", err)
+	}
+	srv := &Server{store: st, cfg: cfg}
+
+	// Operator-equivalent (substrate:admin) sees real host paths everywhere.
+	recA := httptest.NewRecorder()
+	srv.handleListVolumes(recA, reqWithAdmin("/v1/_volumes", "acme"))
+	var adminResp persistentVolumesResponse
+	if err := json.Unmarshal(recA.Body.Bytes(), &adminResp); err != nil {
+		t.Fatalf("decode admin: %v", err)
+	}
+	for _, e := range adminResp.Entries {
+		if e.Path == "" {
+			t.Errorf("admin must see host path for %q (source=%s)", e.Name, e.Source)
+		}
+	}
+	recAE := httptest.NewRecorder()
+	srv.handleListEphemeralVolumes(recAE, reqWithAdmin("/v1/_volumes/ephemeral", "acme"))
+	var adminEph ephemeralVolumesResponse
+	if err := json.Unmarshal(recAE.Body.Bytes(), &adminEph); err != nil {
+		t.Fatalf("decode admin ephemeral: %v", err)
+	}
+	if len(adminEph.Entries) != 1 || adminEph.Entries[0].Path == "" {
+		t.Errorf("admin must see ephemeral host path, got %+v", adminEph.Entries)
+	}
+
+	// Tenant operator (ScopeTenant) gets every host path redacted — but the
+	// rest of the universe survives.
+	recT := httptest.NewRecorder()
+	srv.handleListVolumes(recT, reqWithTenant("/v1/_volumes", "acme"))
+	var tenantResp persistentVolumesResponse
+	if err := json.Unmarshal(recT.Body.Bytes(), &tenantResp); err != nil {
+		t.Fatalf("decode tenant: %v", err)
+	}
+	if len(tenantResp.Entries) != 2 {
+		t.Fatalf("tenant should see 2 persistent entries (1 static + 1 own dynamic), got %d: %+v", len(tenantResp.Entries), tenantResp.Entries)
+	}
+	for _, e := range tenantResp.Entries {
+		if e.Path != "" {
+			t.Errorf("tenant operator must NOT see host path for %q: %q", e.Name, e.Path)
+		}
+		if e.Name == "" || e.Mode == "" || e.Source == "" {
+			t.Errorf("redaction nuked non-path fields: %+v", e)
+		}
+	}
+	recTE := httptest.NewRecorder()
+	srv.handleListEphemeralVolumes(recTE, reqWithTenant("/v1/_volumes/ephemeral", "acme"))
+	var tenantEph ephemeralVolumesResponse
+	if err := json.Unmarshal(recTE.Body.Bytes(), &tenantEph); err != nil {
+		t.Fatalf("decode tenant ephemeral: %v", err)
+	}
+	if len(tenantEph.Entries) != 1 {
+		t.Fatalf("tenant should see its 1 ephemeral row, got %d", len(tenantEph.Entries))
+	}
+	if tenantEph.Entries[0].Path != "" {
+		t.Errorf("tenant operator must NOT see ephemeral host path: %q", tenantEph.Entries[0].Path)
 	}
 }

--- a/internal/api/http/volumes_read_test.go
+++ b/internal/api/http/volumes_read_test.go
@@ -1,0 +1,163 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+	"github.com/denn-gubsky/loomcycle/internal/tools/builtin"
+)
+
+// reqWithTenant builds a GET request whose context carries an authoritative
+// tenant principal — the same shape the auth middleware stamps. The volume
+// read handlers derive the tenant from this principal, never from the wire.
+func reqWithTenant(path, tenant string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, path, nil)
+	return r.WithContext(auth.WithPrincipal(r.Context(), auth.Principal{
+		TenantID: tenant,
+		Subject:  "op-" + tenant,
+		Scopes:   []string{auth.ScopeTenant},
+	}))
+}
+
+// mkDynamicVolume creates a persistent dynamic VolumeDef for a tenant via the
+// real tool, so the test exercises the same write path the runtime uses.
+func mkDynamicVolume(t *testing.T, st store.Store, cfg *config.Config, tenant, name, mode string) {
+	t.Helper()
+	tool := &builtin.VolumeDef{Store: st, Cfg: cfg, MaxNameLen: 64}
+	ctx := tools.WithVolumeDefPolicy(
+		tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{TenantID: tenant}),
+		tools.VolumeDefPolicyValue{Scopes: []string{"any"}},
+	)
+	body, _ := json.Marshal(map[string]string{"op": "create", "name": name, "mode": mode})
+	if res, _ := tool.Execute(ctx, body); res.IsError {
+		t.Fatalf("create dynamic volume %s/%s: %s", tenant, name, res.Text)
+	}
+}
+
+// TestListVolumes_MergesStaticAndTenantDynamic pins GET /v1/_volumes: every
+// static volume (the shared bind floor, source=static, read-only) plus ONLY
+// the caller's-tenant dynamic VolumeDefs (source=dynamic).
+func TestListVolumes_MergesStaticAndTenantDynamic(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Volumes: map[string]config.Volume{
+		"pool":      {Path: root, Mode: "rw", DynamicRoot: true},
+		"reference": {Path: root, Mode: "ro", Default: true},
+	}}
+	mkDynamicVolume(t, st, cfg, "acme", "repo-a", "rw")
+	// A DIFFERENT tenant's dynamic volume must NOT appear in acme's view.
+	mkDynamicVolume(t, st, cfg, "other", "secret", "rw")
+
+	srv := &Server{store: st, cfg: cfg}
+	rec := httptest.NewRecorder()
+	srv.handleListVolumes(rec, reqWithTenant("/v1/_volumes", "acme"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp persistentVolumesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	byName := map[string]persistentVolumeEntry{}
+	for _, e := range resp.Entries {
+		byName[e.Name] = e
+	}
+	// Both statics present.
+	if pool := byName["pool"]; pool.Source != "static" || !pool.DynamicRoot {
+		t.Errorf("pool entry wrong: %+v", pool)
+	}
+	if ref := byName["reference"]; ref.Source != "static" || !ref.Default || ref.Mode != "ro" {
+		t.Errorf("reference entry wrong: %+v", ref)
+	}
+	// acme's own dynamic volume present, with source=dynamic + a timestamp.
+	if rd := byName["repo-a"]; rd.Source != "dynamic" || rd.Mode != "rw" || rd.CreatedAt == "" {
+		t.Errorf("repo-a entry wrong: %+v", rd)
+	}
+	// The OTHER tenant's dynamic volume must be ABSENT (opaque cross-tenant).
+	if _, leaked := byName["secret"]; leaked {
+		t.Errorf("cross-tenant dynamic volume leaked into acme's view: %+v", byName["secret"])
+	}
+	if len(resp.Entries) != 3 {
+		t.Errorf("expected 3 entries (2 static + 1 own dynamic), got %d: %+v", len(resp.Entries), resp.Entries)
+	}
+}
+
+// TestListEphemeralVolumes_TenantScoped pins GET /v1/_volumes/ephemeral: a
+// tenant sees only its OWN live ephemeral rows, never another tenant's.
+func TestListEphemeralVolumes_TenantScoped(t *testing.T) {
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	mk := func(rootRun, name, tenant, mode string) {
+		body, _ := json.Marshal(map[string]string{"path": "/pool/_ephemeral/" + rootRun + "/" + name, "mode": mode})
+		if _, err := st.EphemeralVolumeCreate(context.Background(), store.EphemeralVolumeDefRow{
+			RootRunID: rootRun, Name: name, TenantID: tenant, Definition: body,
+		}); err != nil {
+			t.Fatalf("create ephemeral %s/%s: %v", tenant, name, err)
+		}
+	}
+	mk("run-acme-1", "work", "acme", "rw")
+	mk("run-acme-2", "scratch", "acme", "ro")
+	mk("run-other-1", "work", "other", "rw")
+
+	srv := &Server{store: st, cfg: &config.Config{}}
+	rec := httptest.NewRecorder()
+	srv.handleListEphemeralVolumes(rec, reqWithTenant("/v1/_volumes/ephemeral", "acme"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	var resp ephemeralVolumesResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Entries) != 2 {
+		t.Fatalf("acme should see 2 ephemeral rows, got %d: %+v", len(resp.Entries), resp.Entries)
+	}
+	for _, e := range resp.Entries {
+		if e.RootRunID == "run-other-1" {
+			t.Errorf("cross-tenant ephemeral row leaked: %+v", e)
+		}
+		if e.Path == "" || e.CreatedAt == "" {
+			t.Errorf("entry missing path/created_at: %+v", e)
+		}
+	}
+}
+
+// TestRequiredScopeFor_VolumeReadsAreTenantConfined is the fail-before guard
+// for the gate: both volume read endpoints must require ScopeTenant (not the
+// /v1/_* ScopeAdmin catch-all), so a tenant-operator bearer can drive the
+// Web UI's Volumes tab. Dropping the requiredScopeFor case → ScopeAdmin → a
+// tenant token gets 403 → this fails.
+func TestRequiredScopeFor_VolumeReadsAreTenantConfined(t *testing.T) {
+	for _, path := range []string{"/v1/_volumes", "/v1/_volumes/ephemeral"} {
+		if got := requiredScopeFor(http.MethodGet, path); got != auth.ScopeTenant {
+			t.Errorf("requiredScopeFor(GET %s) = %q, want %q", path, got, auth.ScopeTenant)
+		}
+	}
+	// The def-authoring route stays tenant-confined too (unchanged).
+	if got := requiredScopeFor(http.MethodPost, "/v1/_volumedef"); got != auth.ScopeTenant {
+		t.Errorf("requiredScopeFor(POST /v1/_volumedef) = %q, want %q", got, auth.ScopeTenant)
+	}
+}

--- a/internal/store/postgres/volume_defs.go
+++ b/internal/store/postgres/volume_defs.go
@@ -151,6 +151,33 @@ func (s *Store) EphemeralVolumeListByRun(ctx context.Context, rootRunID string) 
 	return out, rows.Err()
 }
 
+// EphemeralVolumeListByTenant returns the tenant's LIVE ephemeral rows
+// (RFC AH Phase 4 Web UI). Ordered by (root_run_id, name) for a stable
+// view. Tenant-scoped at the query, so a tenant never sees another's rows.
+func (s *Store) EphemeralVolumeListByTenant(ctx context.Context, tenantID string) ([]store.EphemeralVolumeDefRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT root_run_id, name, tenant_id, definition::text, created_at
+		 FROM ephemeral_volume_defs WHERE tenant_id = $1 ORDER BY root_run_id, name`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.EphemeralVolumeDefRow
+	for rows.Next() {
+		var (
+			r          store.EphemeralVolumeDefRow
+			definition string
+		)
+		if err := rows.Scan(&r.RootRunID, &r.Name, &r.TenantID, &definition, &r.CreatedAt); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) EphemeralVolumeDeleteByRun(ctx context.Context, rootRunID string) (int, error) {
 	tag, err := s.pool.Exec(ctx,
 		`DELETE FROM ephemeral_volume_defs WHERE root_run_id = $1`, rootRunID)

--- a/internal/store/sqlite/volume_defs.go
+++ b/internal/store/sqlite/volume_defs.go
@@ -172,6 +172,35 @@ func (s *Store) EphemeralVolumeListByRun(ctx context.Context, rootRunID string) 
 	return out, rows.Err()
 }
 
+// EphemeralVolumeListByTenant returns the tenant's LIVE ephemeral rows
+// (RFC AH Phase 4 Web UI). Ordered by (root_run_id, name) for a stable
+// view. Tenant-scoped at the query, so a tenant never sees another's rows.
+func (s *Store) EphemeralVolumeListByTenant(ctx context.Context, tenantID string) ([]store.EphemeralVolumeDefRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT root_run_id, name, tenant_id, definition, created_at
+		 FROM ephemeral_volume_defs WHERE tenant_id = ? ORDER BY root_run_id, name`, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.EphemeralVolumeDefRow
+	for rows.Next() {
+		var (
+			r          store.EphemeralVolumeDefRow
+			definition string
+			createdAt  int64
+		)
+		if err := rows.Scan(&r.RootRunID, &r.Name, &r.TenantID, &definition, &createdAt); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		r.CreatedAt = time.Unix(0, createdAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 func (s *Store) EphemeralVolumeDeleteByRun(ctx context.Context, rootRunID string) (int, error) {
 	res, err := s.db.ExecContext(ctx,
 		`DELETE FROM ephemeral_volume_defs WHERE root_run_id = ?`, rootRunID)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1245,6 +1245,14 @@ type Store interface {
 	// EphemeralVolumeListByRun returns all ephemeral rows for one root run,
 	// ordered by name. Empty slice (not error) when the run owns none.
 	EphemeralVolumeListByRun(ctx context.Context, rootRunID string) ([]EphemeralVolumeDefRow, error)
+	// EphemeralVolumeListByTenant returns all LIVE ephemeral rows owned by one
+	// tenant, ordered by (root_run_id, name). The persisted table is the
+	// cross-replica source of truth — rows are deleted at run completion (inline
+	// purge) or by the sweeper, so a tenant-scoped read returns exactly the
+	// currently-active ephemeral volumes. tenantID "" = the shared/legacy
+	// tenant. Drives the RFC AH Phase 4 Web UI ephemeral view; scoped here at
+	// the store boundary so a tenant can never observe another tenant's rows.
+	EphemeralVolumeListByTenant(ctx context.Context, tenantID string) ([]EphemeralVolumeDefRow, error)
 	// EphemeralVolumeDeleteByRun deletes ALL ephemeral rows for one root run,
 	// returning the count removed. Idempotent (0 when none existed). It NEVER
 	// touches on-disk directories — the caller (inline purge / sweeper) does

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -280,6 +280,7 @@ func Run(t *testing.T, factory Factory) {
 		{"EphemeralVolumeCreateListDelete", testEphemeralVolumeCreateListDelete},
 		{"EphemeralVolumeSweepCandidatesTerminalOnly", testEphemeralVolumeSweepCandidatesTerminalOnly},
 		{"EphemeralVolumeSweepCandidatesSkipsPaused", testEphemeralVolumeSweepCandidatesSkipsPaused},
+		{"EphemeralVolumeListByTenantIsolation", testEphemeralVolumeListByTenantIsolation},
 		// RFC L OSS multi-tenant authorization — OperatorTokenDef.
 		{"OperatorTokenDefCreateAndLookup", testOperatorTokenDefCreateAndLookup},
 		{"OperatorTokenDefCurrentByName", testOperatorTokenDefCurrentByName},
@@ -7270,5 +7271,53 @@ func testEphemeralVolumeSweepCandidatesSkipsPaused(t *testing.T, s store.Store) 
 		if c.RootRunID == run.ID {
 			t.Fatalf("PAUSED run appeared as a sweep candidate — its volumes would be wrongly purged before resume")
 		}
+	}
+}
+
+// testEphemeralVolumeListByTenantIsolation pins the RFC AH Phase 4 read path:
+// EphemeralVolumeListByTenant returns ONLY the asked-for tenant's live
+// ephemeral rows (across all of that tenant's runs), never another tenant's.
+// This is the store-boundary guarantee the Web UI's ephemeral view relies on.
+func testEphemeralVolumeListByTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// Tenant A owns two runs, each with an ephemeral volume.
+	if _, err := s.EphemeralVolumeCreate(ctx, mkEphemeralVolume("run-a1", "work", "tnt-a", "/pool/_ephemeral/run-a1/work", "rw")); err != nil {
+		t.Fatalf("create a1: %v", err)
+	}
+	if _, err := s.EphemeralVolumeCreate(ctx, mkEphemeralVolume("run-a2", "scratch", "tnt-a", "/pool/_ephemeral/run-a2/scratch", "ro")); err != nil {
+		t.Fatalf("create a2: %v", err)
+	}
+	// Tenant B owns one — must NOT appear in A's list.
+	if _, err := s.EphemeralVolumeCreate(ctx, mkEphemeralVolume("run-b1", "work", "tnt-b", "/pool/_ephemeral/run-b1/work", "rw")); err != nil {
+		t.Fatalf("create b1: %v", err)
+	}
+
+	rowsA, err := s.EphemeralVolumeListByTenant(ctx, "tnt-a")
+	if err != nil {
+		t.Fatalf("list tnt-a: %v", err)
+	}
+	if len(rowsA) != 2 {
+		t.Fatalf("tnt-a list = %d rows, want 2: %+v", len(rowsA), rowsA)
+	}
+	for _, r := range rowsA {
+		if r.TenantID != "tnt-a" {
+			t.Errorf("tnt-a list leaked a %q row: %+v", r.TenantID, r)
+		}
+	}
+	// Ordered by (root_run_id, name): run-a1/work then run-a2/scratch.
+	if rowsA[0].RootRunID != "run-a1" || rowsA[0].Name != "work" {
+		t.Errorf("tnt-a[0] = %s/%s, want run-a1/work", rowsA[0].RootRunID, rowsA[0].Name)
+	}
+	if !jsonEqual(rowsA[0].Definition, `{"path":"/pool/_ephemeral/run-a1/work","mode":"rw"}`) {
+		t.Errorf("tnt-a[0] body = %s", rowsA[0].Definition)
+	}
+
+	rowsB, err := s.EphemeralVolumeListByTenant(ctx, "tnt-b")
+	if err != nil {
+		t.Fatalf("list tnt-b: %v", err)
+	}
+	if len(rowsB) != 1 || rowsB[0].RootRunID != "run-b1" {
+		t.Fatalf("tnt-b list = %+v, want one run-b1 row", rowsB)
 	}
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1237,7 +1237,9 @@ export type SubstrateKind =
   | "webhookdef"
   | "a2aservercarddef"
   | "a2aagentdef"
-  | "memorybackenddef";
+  | "memorybackenddef"
+  // RFC AH dynamic volume substrate. Flat (no versioning): the only ops are
+  | "volumedef"; // create / delete / purge — not the create/fork/promote/retire lifecycle.
 
 export function createDef(
   kind: SubstrateKind,
@@ -1301,6 +1303,98 @@ function substrateDispatch<T>(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+// ---- RFC AH Phase 4 Volumes (Web UI volume management) ----
+//
+// Reads come from two ADDITIVE, tenant-scoped endpoints; CRUD reuses the
+// existing POST /v1/_volumedef op-discriminated dispatch. A VolumeDef is FLAT
+// (no versions / promote / retire) — the op set is create / delete / purge.
+
+export type VolumeMode = "rw" | "ro";
+
+// PersistentVolumeEntry is one row of GET /v1/_volumes. STATIC rows
+// (source="static") are operator yaml — read-only from the UI; DYNAMIC rows
+// (source="dynamic") are the caller-tenant's VolumeDefs — create/delete/purge.
+export interface PersistentVolumeEntry {
+  name: string;
+  source: "static" | "dynamic";
+  path: string;
+  mode: VolumeMode | string;
+  /** Static volume the operator flagged default:true. Dynamic rows: false. */
+  default: boolean;
+  /** Static volume that is the operator-blessed parent dynamic volumes are
+   *  provisioned inside. Dynamic rows: false. */
+  dynamic_root: boolean;
+  /** Set for dynamic rows (substrate-stamped); absent/"" for static volumes. */
+  created_at?: string;
+}
+
+export interface PersistentVolumesResponse {
+  entries: PersistentVolumeEntry[];
+}
+
+// EphemeralVolumeEntry is one row of GET /v1/_volumes/ephemeral — a live,
+// run-scoped volume auto-purged at run completion.
+export interface EphemeralVolumeEntry {
+  name: string;
+  root_run_id: string;
+  path: string;
+  mode: VolumeMode | string;
+  created_at: string;
+}
+
+export interface EphemeralVolumesResponse {
+  entries: EphemeralVolumeEntry[];
+}
+
+// listVolumes fetches the merged persistent volume universe for the caller's
+// tenant: static cfg volumes (the shared bind floor) + the tenant's dynamic
+// VolumeDefs. Tenant scoping is server-side (authoritative principal).
+export function listVolumes(): Promise<PersistentVolumesResponse> {
+  return jsonFetch<PersistentVolumesResponse>("/v1/_volumes");
+}
+
+// listEphemeralVolumes fetches the caller-tenant's live ephemeral volumes.
+export function listEphemeralVolumes(): Promise<EphemeralVolumesResponse> {
+  return jsonFetch<EphemeralVolumesResponse>("/v1/_volumes/ephemeral");
+}
+
+// VolumeDefRow mirrors the {name, path, mode, created_at} the VolumeDef tool
+// returns on create. The runtime DERIVES the path (the caller never supplies a
+// host path), so create takes only name + mode.
+export interface VolumeDefRow {
+  name: string;
+  path?: string;
+  mode?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// createVolume provisions a dynamic VolumeDef (name + mode only — the runtime
+// derives the path inside the operator-blessed dynamic_root). Idempotent: a
+// re-create with the same name updates the mode.
+export function createVolume(name: string, mode: VolumeMode): Promise<VolumeDefRow> {
+  return substrateDispatch<VolumeDefRow>("volumedef", { op: "create", name, mode });
+}
+
+// deleteVolume is NON-destructive — it unmaps the volume (removes the row) but
+// LEAVES the files on disk. Mirrors the tool's `delete` op.
+export function deleteVolume(name: string): Promise<{ name: string; deleted: boolean; files_removed: boolean }> {
+  return substrateDispatch<{ name: string; deleted: boolean; files_removed: boolean }>(
+    "volumedef",
+    { op: "delete", name },
+  );
+}
+
+// purgeVolume is DESTRUCTIVE — it removes the row AND RemoveAll's the directory
+// tree (behind the server-side four-way fence). The UI gates this behind a
+// type-to-confirm modal; the server-side fence is the real guard.
+export function purgeVolume(name: string): Promise<{ name: string; deleted: boolean; files_removed: boolean }> {
+  return substrateDispatch<{ name: string; deleted: boolean; files_removed: boolean }>(
+    "volumedef",
+    { op: "purge", name },
+  );
 }
 
 // ---- Channel fetchers ----

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Brain,
   CalendarClock,
   Camera,
+  HardDrive,
   Library,
   ListTree,
   type LucideIcon,
@@ -39,6 +40,9 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/agents", label: "runs", Icon: ListTree, adminOnly: false },
   { to: "/library/agents", label: "library", Icon: Library, adminOnly: true },
   { to: "/integrations/webhooks", label: "integrations", Icon: Plug, adminOnly: true },
+  // RFC AH Phase 4. adminOnly mirrors the Library/Integrations def-management
+  // gating; broadening to tenant-operator UI access is a separate concern.
+  { to: "/volumes/persistent", label: "volumes", Icon: HardDrive, adminOnly: true },
   { to: "/channels", label: "channels", Icon: Radio, adminOnly: true },
   { to: "/schedules", label: "schedules", Icon: CalendarClock, adminOnly: true },
   { to: "/interrupts", label: "interrupts", Icon: Bell, adminOnly: true },

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -252,6 +252,10 @@ function newCtaLabel(kind: SubstrateKind): string {
     case "a2aservercarddef": return "A2A Server Card";
     case "a2aagentdef": return "A2A Agent";
     case "memorybackenddef": return "Memory Backend";
+    // VolumeDef is FLAT (no lineage); the Volumes tab uses its own flat table,
+    // not LineagePanel, so this label is never rendered for it. The arm keeps
+    // the switch exhaustive over SubstrateKind.
+    case "volumedef": return "Volume";
   }
 }
 

--- a/web/src/components/VolumeEditModal.tsx
+++ b/web/src/components/VolumeEditModal.tsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+import { type VolumeDefRow, type VolumeMode, createVolume } from "../api";
+
+// VolumeEditModal — RFC AH Phase 4 create form for a dynamic VolumeDef.
+//
+// Create-only (a VolumeDef is FLAT — no edit/fork/promote/retire lifecycle).
+// A volume is created by NAME + MODE only: the runtime DERIVES the on-disk
+// path inside the operator-blessed dynamic_root (<root>/<tenant>/<name>), so
+// there is no path field — the caller never supplies a host path. To repoint a
+// name, delete/purge then create.
+//
+// Name charset mirrors the server's volumeNameRe (^[a-z0-9][a-z0-9_-]{0,63}$):
+// the form validates it client-side for a friendly message, but the server is
+// authoritative (a refusal surfaces in the error banner).
+
+const NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export interface VolumeEditModalProps {
+  /** Names already taken (static + dynamic) so create can warn before the
+   *  server refuses a collision. */
+  existingNames: string[];
+  onClose: () => void;
+  onSaved: (row: VolumeDefRow) => void;
+}
+
+export default function VolumeEditModal({
+  existingNames,
+  onClose,
+  onSaved,
+}: VolumeEditModalProps) {
+  const [name, setName] = useState("");
+  const [mode, setMode] = useState<VolumeMode>("rw");
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const trimmed = name.trim();
+  const nameValid = NAME_RE.test(trimmed);
+  const nameTaken = existingNames.includes(trimmed);
+  const canSubmit = nameValid && !nameTaken && !submitting;
+
+  const submit = async () => {
+    setSubmitting(true);
+    setErr(null);
+    try {
+      const row = await createVolume(trimmed, mode);
+      onSaved(row);
+    } catch (e) {
+      setErr(explainRefusal(e instanceof Error ? e.message : String(e)));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal library-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Create volume</h3>
+
+        <div className="library-modal-fields">
+          <label className="library-modal-field">
+            <span>Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="repo-a"
+              autoFocus
+            />
+          </label>
+          {trimmed !== "" && !nameValid && (
+            <div className="library-modal-field-hint">
+              Lowercase letters, digits, <code>_</code> and <code>-</code> only
+              (1–64 chars, no leading dot or slash).
+            </div>
+          )}
+          {nameTaken && (
+            <div className="library-modal-field-hint">
+              A volume named <code>{trimmed}</code> already exists — pick another
+              name (static yaml names and existing dynamic volumes are reserved).
+            </div>
+          )}
+
+          <label className="library-modal-field">
+            <span>Mode</span>
+            <select value={mode} onChange={(e) => setMode(e.target.value as VolumeMode)}>
+              <option value="rw">rw — read + write (Write/Edit/Bash allowed)</option>
+              <option value="ro">ro — read-only (Bash refused; Write/Edit refused)</option>
+            </select>
+          </label>
+
+          <div className="library-modal-field-hint">
+            The path is derived by the runtime inside the operator-blessed
+            dynamic root — you choose only the name + mode.
+          </div>
+        </div>
+
+        {err && <div className="error-banner">{err}</div>}
+
+        <div className="modal-buttons">
+          <button type="button" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button type="button" className="primary" onClick={submit} disabled={!canSubmit}>
+            {submitting ? "Creating…" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// explainRefusal lifts the human-readable text out of the substrate's
+// {"code":"tool_refused","error":"…"} 422 envelope that jsonFetch surfaces in
+// the thrown Error message; falls back to the raw message.
+function explainRefusal(msg: string): string {
+  if (msg.includes("no dynamic volume root configured")) {
+    return "No dynamic volume root is configured — an operator must mark a static volume `dynamic_root: true` in the loomcycle yaml before dynamic volumes can be created.";
+  }
+  const match = msg.match(/"error":"([^"]+)"/);
+  if (match && match[1]) return match[1];
+  return msg;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -18,6 +18,7 @@ import AuditView from "./pages/AuditView";
 import ActivityMonitor from "./pages/ActivityMonitor";
 import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
+import VolumesView from "./pages/VolumesView";
 import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
 import Layout from "./components/Layout";
@@ -65,6 +66,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
             path="integrations/memory-backends"
             element={<IntegrationsView />}
           />
+          <Route path="volumes" element={<VolumesView />}>
+            <Route index element={<Navigate to="/volumes/persistent" replace />} />
+          </Route>
+          <Route path="volumes/persistent" element={<VolumesView />} />
+          <Route path="volumes/ephemeral" element={<VolumesView />} />
           <Route path="channels" element={<ChannelsView />} />
           <Route path="schedules" element={<SchedulesView />} />
           <Route path="memory" element={<MemoryView />} />

--- a/web/src/pages/VolumesView.tsx
+++ b/web/src/pages/VolumesView.tsx
@@ -20,7 +20,9 @@ import VolumeEditModal from "../components/VolumeEditModal";
 //     yaml (read-only). DYNAMIC rows are the tenant's VolumeDefs: Delete
 //     (non-destructive unmap) + Purge (destructive RemoveAll, type-to-confirm).
 //     A "bound by" column cross-references AgentDef.volumes (derived from
-//     listLibraryAgents()).
+//     listLibraryAgents() — STATIC-config agents only; a runtime-created
+//     substrate agent that binds a volume is not reflected, so the column is a
+//     hint, not an authority, before a destructive purge).
 //   Ephemeral — read-only flat table of GET /v1/_volumes/ephemeral (live,
 //     run-scoped, auto-purged at run completion).
 //
@@ -185,7 +187,9 @@ function PersistentTab({
         <span className="muted">
           Static volumes are operator yaml (read-only — the shared bind floor).
           Dynamic volumes are this tenant's — Delete unmaps (keeps files); Purge
-          deletes the directory tree.
+          deletes the directory tree. <strong>“Bound by” reflects static-config
+          agents only</strong> — a runtime-created (substrate) agent may also
+          bind a volume without appearing here.
         </span>
         <button type="button" className="primary" onClick={onCreate}>
           Create volume
@@ -199,7 +203,9 @@ function PersistentTab({
             <th>path</th>
             <th>mode</th>
             <th>default</th>
-            <th>bound by</th>
+            <th title="Static-config (yaml) agents only — a runtime-created agent may also bind this volume without showing here.">
+              bound by <span className="muted">ⓘ</span>
+            </th>
             <th>actions</th>
           </tr>
         </thead>
@@ -355,9 +361,17 @@ function PurgeConfirmModal({
         <h3>Purge volume · {volume.name}</h3>
         <div className="warning-banner">
           This is <strong>destructive</strong>. Purge removes the mapping AND
-          recursively deletes the directory tree (<code className="mono">{volume.path}</code>)
+          recursively deletes the directory tree
+          {volume.path ? (
+            <>
+              {" "}
+              (<code className="mono">{volume.path}</code>)
+            </>
+          ) : null}{" "}
           on disk. This cannot be undone. To unmap without deleting files, use
-          Delete instead.
+          Delete instead. <strong>A runtime-created agent may still be using this
+          volume even if “bound by” shows none</strong> — that column reflects
+          static-config agents only.
         </div>
         <div className="library-modal-fields">
           <label className="library-modal-field">

--- a/web/src/pages/VolumesView.tsx
+++ b/web/src/pages/VolumesView.tsx
@@ -1,0 +1,421 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { NavLink, useLocation } from "react-router-dom";
+import {
+  type EphemeralVolumeEntry,
+  type LibraryEntry,
+  type PersistentVolumeEntry,
+  type VolumeDefRow,
+  deleteVolume,
+  listEphemeralVolumes,
+  listLibraryAgents,
+  listVolumes,
+  purgeVolume,
+} from "../api";
+import VolumeEditModal from "../components/VolumeEditModal";
+
+// VolumesView — RFC AH Phase 4 dedicated "Volumes" console tab.
+//
+// Two sub-tabs (nested routes, like IntegrationsView):
+//   Persistent — flat table of GET /v1/_volumes. STATIC rows are operator
+//     yaml (read-only). DYNAMIC rows are the tenant's VolumeDefs: Delete
+//     (non-destructive unmap) + Purge (destructive RemoveAll, type-to-confirm).
+//     A "bound by" column cross-references AgentDef.volumes (derived from
+//     listLibraryAgents()).
+//   Ephemeral — read-only flat table of GET /v1/_volumes/ephemeral (live,
+//     run-scoped, auto-purged at run completion).
+//
+// A VolumeDef is FLAT (no versions/promote/retire) — hence a simple table, not
+// the lineage tree LibraryView/IntegrationsView use. Tenant scoping is server-
+// side (authoritative principal); the UI never assumes cross-tenant visibility.
+
+const REFRESH_MS = 10_000;
+
+type SubKey = "persistent" | "ephemeral";
+
+export default function VolumesView() {
+  const [persistent, setPersistent] = useState<PersistentVolumeEntry[]>([]);
+  const [ephemeral, setEphemeral] = useState<EphemeralVolumeEntry[]>([]);
+  // agentName -> volume names it binds (for the "bound by" cross-reference).
+  const [bindings, setBindings] = useState<Record<string, string[]>>({});
+  const [err, setErr] = useState<string | null>(null);
+  const [actionErr, setActionErr] = useState<string | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const refreshNow = useCallback(() => setRefreshKey((k) => k + 1), []);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [purgeTarget, setPurgeTarget] = useState<PersistentVolumeEntry | null>(null);
+
+  const loc = useLocation();
+  const sub: SubKey = loc.pathname.startsWith("/volumes/ephemeral")
+    ? "ephemeral"
+    : "persistent";
+
+  useEffect(() => {
+    let cancelled = false;
+    const fetchAll = async () => {
+      try {
+        const [pv, ev, agents] = await Promise.all([
+          listVolumes(),
+          listEphemeralVolumes(),
+          // Bindings are best-effort: an agent-list failure shouldn't blank the
+          // volume tables, so it's tolerated (bindings stay empty).
+          listLibraryAgents().catch(() => ({ entries: [] as LibraryEntry[] })),
+        ]);
+        if (cancelled) return;
+        setPersistent(pv.entries ?? []);
+        setEphemeral(ev.entries ?? []);
+        setBindings(deriveBindings(agents.entries ?? []));
+        setErr(null);
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : String(e));
+      }
+    };
+    fetchAll();
+    const t = setInterval(fetchAll, REFRESH_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [refreshKey]);
+
+  // boundBy maps a volume name -> the agents that bind it.
+  const boundBy = useMemo(() => {
+    const out: Record<string, string[]> = {};
+    for (const [agent, vols] of Object.entries(bindings)) {
+      for (const v of vols) {
+        (out[v] ??= []).push(agent);
+      }
+    }
+    for (const k of Object.keys(out)) out[k].sort();
+    return out;
+  }, [bindings]);
+
+  const handleDelete = async (row: PersistentVolumeEntry) => {
+    if (
+      !window.confirm(
+        `Delete (unmap) volume "${row.name}"? This removes the mapping but LEAVES the files on disk. Use Purge to also delete the directory tree.`,
+      )
+    ) {
+      return;
+    }
+    setActionErr(null);
+    try {
+      await deleteVolume(row.name);
+      refreshNow();
+    } catch (e) {
+      setActionErr(`Delete failed: ${liftRefusal(e)}`);
+    }
+  };
+
+  return (
+    <div className="library-view">
+      <div className="library-subtabs">
+        <NavLink to="/volumes/persistent" end className={subtabClass}>
+          Persistent <span className="library-subtab-count">{persistent.length}</span>
+        </NavLink>
+        <NavLink to="/volumes/ephemeral" end className={subtabClass}>
+          Ephemeral <span className="library-subtab-count">{ephemeral.length}</span>
+        </NavLink>
+      </div>
+
+      {err && <div className="error-banner">Failed to load volumes: {err}</div>}
+      {actionErr && <div className="error-banner">{actionErr}</div>}
+
+      {sub === "persistent" ? (
+        <PersistentTab
+          rows={persistent}
+          boundBy={boundBy}
+          onCreate={() => setShowCreate(true)}
+          onDelete={handleDelete}
+          onPurge={(row) => setPurgeTarget(row)}
+        />
+      ) : (
+        <EphemeralTab rows={ephemeral} />
+      )}
+
+      {showCreate && (
+        <VolumeEditModal
+          existingNames={persistent.map((p) => p.name)}
+          onClose={() => setShowCreate(false)}
+          onSaved={() => {
+            setShowCreate(false);
+            refreshNow();
+          }}
+        />
+      )}
+      {purgeTarget && (
+        <PurgeConfirmModal
+          volume={purgeTarget}
+          onClose={() => setPurgeTarget(null)}
+          onPurged={() => {
+            setPurgeTarget(null);
+            refreshNow();
+          }}
+          onError={(m) => {
+            setPurgeTarget(null);
+            setActionErr(`Purge failed: ${m}`);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+const subtabClass = ({ isActive }: { isActive: boolean }) =>
+  isActive ? "library-subtab library-subtab-active" : "library-subtab";
+
+// ---- Persistent sub-tab ----
+
+function PersistentTab({
+  rows,
+  boundBy,
+  onCreate,
+  onDelete,
+  onPurge,
+}: {
+  rows: PersistentVolumeEntry[];
+  boundBy: Record<string, string[]>;
+  onCreate: () => void;
+  onDelete: (row: PersistentVolumeEntry) => void;
+  onPurge: (row: PersistentVolumeEntry) => void;
+}) {
+  return (
+    <div className="library-content">
+      <div className="volumes-toolbar">
+        <span className="muted">
+          Static volumes are operator yaml (read-only — the shared bind floor).
+          Dynamic volumes are this tenant's — Delete unmaps (keeps files); Purge
+          deletes the directory tree.
+        </span>
+        <button type="button" className="primary" onClick={onCreate}>
+          Create volume
+        </button>
+      </div>
+      <table className="snapshots-table volumes-table">
+        <thead>
+          <tr>
+            <th>name</th>
+            <th>source</th>
+            <th>path</th>
+            <th>mode</th>
+            <th>default</th>
+            <th>bound by</th>
+            <th>actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 && (
+            <tr>
+              <td colSpan={7} className="empty">
+                No volumes. Static volumes come from the loomcycle yaml; dynamic
+                volumes are created here.
+              </td>
+            </tr>
+          )}
+          {rows.map((r) => {
+            const agents = boundBy[r.name] ?? [];
+            return (
+              <tr key={`${r.source}:${r.name}`}>
+                <td className="mono">{r.name}</td>
+                <td>
+                  <span className={`source-chip source-chip-${r.source === "static" ? "static-only" : "dynamic-only"}`}>
+                    {r.source}
+                  </span>
+                  {r.dynamic_root && (
+                    <span className="badge badge-label" title="Dynamic volumes are provisioned inside this root">
+                      dynamic_root
+                    </span>
+                  )}
+                </td>
+                <td className="mono volumes-path">{r.path || <span className="muted">—</span>}</td>
+                <td className="mono">{r.mode}</td>
+                <td>{r.default ? "✓" : <span className="muted">—</span>}</td>
+                <td>
+                  {agents.length === 0 ? (
+                    <span className="muted">—</span>
+                  ) : (
+                    <span className="volumes-boundby" title={agents.join(", ")}>
+                      {agents.join(", ")}
+                    </span>
+                  )}
+                </td>
+                <td className="actions">
+                  {r.source === "dynamic" ? (
+                    <>
+                      <button
+                        type="button"
+                        className="link-btn"
+                        title="Unmap the volume (removes the mapping, keeps files on disk)"
+                        onClick={() => onDelete(r)}
+                      >
+                        delete
+                      </button>
+                      <button
+                        type="button"
+                        className="link-btn link-btn-danger"
+                        title="Destructive: removes the mapping AND deletes the directory tree"
+                        onClick={() => onPurge(r)}
+                      >
+                        purge
+                      </button>
+                    </>
+                  ) : (
+                    <span className="muted" title="Static volumes are operator yaml — edit the yaml + restart">
+                      read-only
+                    </span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---- Ephemeral sub-tab ----
+
+function EphemeralTab({ rows }: { rows: EphemeralVolumeEntry[] }) {
+  return (
+    <div className="library-content">
+      <div className="volumes-toolbar">
+        <span className="muted">
+          Ephemeral volumes are live and run-scoped — created mid-run, inherited
+          by sub-agents, and auto-purged when the run completes. Read-only here.
+        </span>
+      </div>
+      <table className="snapshots-table volumes-table">
+        <thead>
+          <tr>
+            <th>name</th>
+            <th>run_id</th>
+            <th>path</th>
+            <th>mode</th>
+            <th>created_at</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.length === 0 && (
+            <tr>
+              <td colSpan={5} className="empty">
+                No live ephemeral volumes. They appear here while a run that
+                created one is active.
+              </td>
+            </tr>
+          )}
+          {rows.map((r) => (
+            <tr key={`${r.root_run_id}:${r.name}`}>
+              <td className="mono">{r.name}</td>
+              <td className="mono">{r.root_run_id}</td>
+              <td className="mono volumes-path">{r.path || <span className="muted">—</span>}</td>
+              <td className="mono">{r.mode}</td>
+              <td>{r.created_at}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---- Purge confirm (type-to-confirm — the dangerous one) ----
+
+function PurgeConfirmModal({
+  volume,
+  onClose,
+  onPurged,
+  onError,
+}: {
+  volume: PersistentVolumeEntry;
+  onClose: () => void;
+  onPurged: (row: VolumeDefRow) => void;
+  onError: (msg: string) => void;
+}) {
+  const [typed, setTyped] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const confirmed = typed === volume.name;
+
+  const submit = async () => {
+    if (!confirmed) return;
+    setSubmitting(true);
+    try {
+      const row = await purgeVolume(volume.name);
+      onPurged(row);
+    } catch (e) {
+      onError(liftRefusal(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal library-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Purge volume · {volume.name}</h3>
+        <div className="warning-banner">
+          This is <strong>destructive</strong>. Purge removes the mapping AND
+          recursively deletes the directory tree (<code className="mono">{volume.path}</code>)
+          on disk. This cannot be undone. To unmap without deleting files, use
+          Delete instead.
+        </div>
+        <div className="library-modal-fields">
+          <label className="library-modal-field">
+            <span>
+              Type the volume name <code className="mono">{volume.name}</code> to confirm
+            </span>
+            <input
+              type="text"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              placeholder={volume.name}
+              autoFocus
+              autoComplete="off"
+            />
+          </label>
+        </div>
+        <div className="modal-buttons">
+          <button type="button" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary primary-danger"
+            onClick={submit}
+            disabled={!confirmed || submitting}
+          >
+            {submitting ? "Purging…" : "Purge"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- helpers ----
+
+// deriveBindings maps each agent name -> its bound volume names, read from the
+// agent's static_definition.volumes (the library endpoint surfaces it). Agents
+// with no bindings are omitted.
+function deriveBindings(entries: LibraryEntry[]): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const e of entries) {
+    const def = e.static_definition;
+    if (def && typeof def === "object" && "volumes" in def) {
+      const vols = (def as { volumes?: unknown }).volumes;
+      if (Array.isArray(vols)) {
+        const names = vols.filter((v): v is string => typeof v === "string");
+        if (names.length > 0) out[e.name] = names;
+      }
+    }
+  }
+  return out;
+}
+
+// liftRefusal extracts the human-readable text from the substrate's
+// {"code":"tool_refused","error":"…"} 422 envelope surfaced in a thrown Error.
+function liftRefusal(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  const match = msg.match(/"error":"([^"]+)"/);
+  return match && match[1] ? match[1] : msg;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4772,3 +4772,54 @@ button.primary:disabled {
 .orchestrator-children {
   overflow-y: auto;
 }
+
+/* ---- RFC AH Phase 4 Volumes tab ---- */
+.volumes-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 0 12px;
+}
+.volumes-toolbar .muted {
+  font-size: 13px;
+  max-width: 70ch;
+}
+/* Reuse .snapshots-table layout; widen the path column + truncate long
+   path / bound-by cells so a deep path doesn't blow the table width. */
+.volumes-table .volumes-path {
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.volumes-table .volumes-boundby {
+  display: inline-block;
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* The dynamic_root marker sits next to the source chip. */
+.volumes-table .badge-label {
+  margin-left: 6px;
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: var(--bg-soft, #333);
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+/* Destructive purge action + confirm button — danger-coloured. */
+.snapshots-table td.actions .link-btn-danger {
+  color: var(--danger);
+}
+.snapshots-table td.actions .link-btn-danger:hover {
+  color: var(--danger);
+  font-weight: 600;
+}
+.modal-buttons button.primary-danger {
+  background: var(--danger);
+  border-color: var(--danger);
+}


### PR DESCRIPTION
## Why

RFC AH (Filesystem Volumes) Phases 1–3 shipped the runtime mechanism: static volumes, the persistent + ephemeral `VolumeDef` substrate, and the sandbox-by-default cutover that retired the legacy jail. But the only way to *see* a tenant's volume universe or run `delete`/`purge` was raw `POST /v1/_volumedef` calls — no operator surface. This phase adds the console tab so an operator can inspect and manage volumes without curl.

## What

A dedicated **Volumes** console tab (`/volumes`), plus the two read-only endpoints it needs. No new runtime primitive — CRUD stays on the existing `POST /v1/_volumedef` (create/delete/purge).

**Backend**
- `GET /v1/_volumes` — merged persistent universe for the caller's tenant: every static `cfg.Volumes` entry (the shared bind floor, `source=static`, read-only) + the tenant's own dynamic `VolumeDef` rows (`source=dynamic`), opaque cross-tenant (a foreign row is simply absent).
- `GET /v1/_volumes/ephemeral` — the tenant's live, run-scoped ephemeral volumes (`EphemeralVolumeListByTenant`, the cross-replica source of truth).
- Both gated at **`ScopeTenant`** (via an explicit `requiredScopeFor` case, not the `/v1/_*` ScopeAdmin catch-all) so a tenant-operator bearer can drive the tab; tenant is the **authoritative** principal, never the wire.
- `/v1/_library/agents` now surfaces `volumes` on the static agent JSON for the "bound by" cross-reference.
- **Host paths are redacted from non-operator callers**: a static volume's `path` (and the dynamic-root parent) is operator infrastructure. A `ScopeTenant` caller sees the volume universe (name / mode / default / dynamic-root / created-at) but not the on-disk location; only operator-equivalent principals (substrate:admin / legacy / open dev mode — the mirror of the Web UI's `is_admin`) see paths. Defense-in-depth at the API.

**Web UI** (`web/src` only — `internal/webui/dist/` is gitignored + rebuilt by CI/`make build-ui`)
- New `VolumesView` tab: Persistent + Ephemeral sub-tabs, flat tables (a `VolumeDef` is flat — no versions/promote/retire, so no lineage tree).
- Static rows are read-only; dynamic rows get **Delete** (non-destructive unmap, `window.confirm`) + **Purge** (destructive `RemoveAll`, **type-the-name-to-confirm**).
- "Bound by" column cross-references `AgentDef.volumes` — explicitly caveated as **static-config agents only**: a runtime-created substrate agent that binds a volume is not reflected, so it's a hint, not an authority, before a purge (caveat in the toolbar, a column tooltip, and the purge modal).

## What was tested

- `go test ./...` — clean.
- `internal/api/http/volumes_read_test.go`:
  - `TestListVolumes_MergesStaticAndTenantDynamic` — static + own-dynamic merge, cross-tenant dynamic absent.
  - `TestListEphemeralVolumes_TenantScoped` — a tenant sees only its own live ephemeral rows.
  - `TestRequiredScopeFor_VolumeReadsAreTenantConfined` — both GETs require ScopeTenant, not ScopeAdmin.
  - `TestListVolumes_RedactsHostPathsForTenantOperator` — admin sees real paths on static + dynamic + ephemeral; a ScopeTenant caller gets `""` while the rest of the universe survives. **Fail-before verified** (neutered `redactedPath` → both this and the ephemeral test fail).
- `npm run build` (SPA) — clean; no `dist/` committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)