### PR TITLE
fix(api): record a client-disconnected run as cancelled, not failed

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,24 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in vNEXT
+
+**🔌 A client-disconnected run is recorded as `cancelled`, not `failed`.** A
+non-interactive run's context derives from its HTTP/gRPC request ctx, so a
+dropped connection (the caller timing out or going away) cancels the run. The
+loop returns `context.Canceled` — but with no `ErrCancelledByAPI` cause, so
+`finishRunWithCancel` fell through to the failed path and wrote
+**`status=failed, error="context canceled"`**. A later status poll then saw a
+run that looked like it *failed* (a consumer surfaced these as provider-ish
+errors) when the caller had simply left. Now a context-cancellation that isn't
+an API cancel is recorded as a clean **`cancelled`** (reason `"client
+disconnected"`, or `"parent run cancelled"` for a sub-agent cascade); the
+terminal row is written under a fresh background ctx (via the existing
+`finishRunCancelled`), so it persists even though the run ctx is gone. A run
+**timeout** surfaces as `context.DeadlineExceeded` (not `Canceled`) and still
+records as `failed` — a timeout is a real failure. Surfaced by the JobEmber VPS
+deploy (batch runs cancelled on the client side showed up as failures).
+
 ## What's in v1.1.1
 
 **🗣️ Interactive agentic sessions over gRPC + TS (RFC AI).** The interactive session

--- a/internal/api/http/finish_run_disconnect_test.go
+++ b/internal/api/http/finish_run_disconnect_test.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/loop"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// newRunForFinishTest seeds a running run row and returns the server + run id.
+func newRunForFinishTest(t *testing.T) (*Server, string) {
+	t.Helper()
+	st, err := storesqlite.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	srv := &Server{store: st}
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, "", "agent", "alice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a1", UserID: "alice", Model: "stub-model"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, run.ID
+}
+
+// TestFinishRunWithCancel_ClientDisconnectRecordsCancelled is the regression for
+// the JobEmber symptom: a non-interactive run whose CLIENT disconnected (runCtx
+// cancelled, NO ErrCancelledByAPI cause, loop returned context.Canceled) must be
+// recorded as a clean `cancelled`, NOT `failed: "context canceled"`. The
+// terminal row must persist even though runCtx is already cancelled
+// (finishRunCancelled detaches to a background ctx). Fail-before: the old code
+// fell through to finishRun → status=failed.
+func TestFinishRunWithCancel_ClientDisconnectRecordsCancelled(t *testing.T) {
+	srv, runID := newRunForFinishTest(t)
+
+	// A client disconnect: runCtx cancelled with the default cause (plain
+	// context.Canceled), NOT cancel.ErrCancelledByAPI. The loop returns
+	// context.Canceled.
+	runCtx, cancelFn := context.WithCancelCause(context.Background())
+	cancelFn(nil) // nil cause → context.Canceled (mirrors request-ctx propagation)
+
+	srv.finishRunWithCancel(context.Background(), runCtx, runID, loop.RunResult{}, context.Canceled, runStateMeta{RunID: runID, IsTopLevel: true})
+
+	run, err := srv.store.GetRun(context.Background(), runID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if run.Status != store.RunCancelled {
+		t.Errorf("status = %q, want %q (a client disconnect must record a clean cancel, not a failure)", run.Status, store.RunCancelled)
+	}
+	if run.ErrorMsg != "" {
+		t.Errorf("a cancelled run must carry no error text, got %q", run.ErrorMsg)
+	}
+	if run.StopReason != "client disconnected" {
+		t.Errorf("stop_reason = %q, want %q", run.StopReason, "client disconnected")
+	}
+}
+
+// TestFinishRunWithCancel_RealErrorStillFails locks the inverse: a GENUINE run
+// error (runCtx NOT cancelled) is still recorded as failed — the disconnect
+// reclassification must not swallow real failures.
+func TestFinishRunWithCancel_RealErrorStillFails(t *testing.T) {
+	srv, runID := newRunForFinishTest(t)
+
+	// runCtx alive (never cancelled); the loop returned a real provider error.
+	runCtx, cancelFn := context.WithCancelCause(context.Background())
+	defer cancelFn(nil)
+
+	srv.finishRunWithCancel(context.Background(), runCtx, runID, loop.RunResult{}, errors.New("provider 500: boom"), runStateMeta{RunID: runID, IsTopLevel: true})
+
+	run, _ := srv.store.GetRun(context.Background(), runID)
+	if run.Status != store.RunFailed {
+		t.Errorf("status = %q, want %q (a real error must stay failed)", run.Status, store.RunFailed)
+	}
+	if run.ErrorMsg == "" {
+		t.Errorf("a failed run must carry its error text")
+	}
+}
+
+// TestFinishRunWithCancel_APICancelUnchanged confirms the pre-existing API-cancel
+// path still wins (cancelled with the API reason), unaffected by the new branch.
+func TestFinishRunWithCancel_APICancelUnchanged(t *testing.T) {
+	srv, runID := newRunForFinishTest(t)
+
+	runCtx, cancelFn := context.WithCancelCause(context.Background())
+	cancelFn(cancel.ErrCancelledByAPI)
+
+	srv.finishRunWithCancel(context.Background(), runCtx, runID, loop.RunResult{}, context.Canceled, runStateMeta{RunID: runID, IsTopLevel: true})
+
+	run, _ := srv.store.GetRun(context.Background(), runID)
+	if run.Status != store.RunCancelled {
+		t.Errorf("status = %q, want %q (API cancel)", run.Status, store.RunCancelled)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5736,6 +5736,27 @@ func (s *Server) finishRunWithCancel(ctx context.Context, runCtx context.Context
 		s.finishRunCancelled(ctx, runID, res, reason, meta)
 		return
 	}
+	// A run whose context was cancelled WITHOUT an API-cancel cause ended
+	// because the caller went away — most commonly a CLIENT DISCONNECT on a
+	// non-interactive run (its runCtx derives from the request ctx, so a
+	// dropped connection cancels it), or an upstream/parent cascade. Record it
+	// as a clean `cancelled`, not `failed: "context canceled"`: the run didn't
+	// fail, the caller left. This is the difference between a status poll
+	// seeing a tidy `cancelled` vs a half-written `failed` row (the symptom
+	// JobEmber hit — its disconnected batch runs showed up as provider-ish
+	// failures). finishRunCancelled writes the terminal row under a fresh
+	// background ctx, so it persists even though runCtx is cancelled.
+	//
+	// A run TIMEOUT surfaces as context.DeadlineExceeded (not Canceled), so it
+	// still falls through to finishRun's failed path — a timeout IS a failure.
+	if runCtx.Err() != nil && errors.Is(runErr, context.Canceled) {
+		reason := "client disconnected"
+		if !meta.IsTopLevel {
+			reason = "parent run cancelled"
+		}
+		s.finishRunCancelled(ctx, runID, res, reason, meta)
+		return
+	}
 	s.finishRun(ctx, runID, res, runErr, meta)
 }
 


### PR DESCRIPTION
## Why

Diagnosing the JobEmber VPS deploy ("agents complete with provider connection fail messages"), I found the providers were all healthy — the runs were being **cancelled by the client** (a batch's connection dropping), which loomcycle then recorded as **`status=failed, error="context canceled"`**. A status poll (or JobEmber's UI) then saw what looked like a *failure* when the caller had simply gone away.

Root cause: a non-interactive run's context derives from its HTTP/gRPC request ctx, so a dropped connection cancels the run and the loop returns `context.Canceled`. `finishRunWithCancel` only wrote the clean `cancelled` status for **API cancels** (`ErrCancelledByAPI` cause); a client disconnect has no such cause, so it fell through to `finishRun` → `failed`.

## What

Route a context-cancellation that **isn't** an API cancel to `finishRunCancelled` as well:

```go
if runCtx.Err() != nil && errors.Is(runErr, context.Canceled) {
    reason := "client disconnected"            // or "parent run cancelled" for a sub-agent cascade
    s.finishRunCancelled(ctx, runID, res, reason, meta)
    return
}
```

- `finishRunCancelled` **already** detaches to a fresh background ctx (5s timeout), so the terminal `cancelled` row persists even though `runCtx` is gone — exactly the "persist the terminal status under a non-cancelled ctx" the enhancement called for.
- A run **timeout** surfaces as `context.DeadlineExceeded` (not `Canceled`), so it still records as `failed` — a timeout is a real failure.
- Covers **HTTP and gRPC** (both flow through this shared `finishRunWithCancel` via `runner.RunOnce`).

## ⚠️ Behaviour change

Client-disconnect (and parent-cascade) runs now report **`cancelled`** instead of **`failed: "context canceled"`**. This is the intended, more-accurate outcome — but a consumer that alerts/filters on `status=failed` will see fewer false alarms, and one counting `cancelled` will now include disconnects. Worth a glance for JobEmber.

## What was tested

- `go test ./...` — clean. `gofmt` clean.
- New regression tests (all in `finish_run_disconnect_test.go`):
  - `TestFinishRunWithCancel_ClientDisconnectRecordsCancelled` — a cancelled runCtx (no API cause) + `context.Canceled` → `status=cancelled`, no error text, reason `"client disconnected"`. **Fail-before verified** (old code → `failed`).
  - `TestFinishRunWithCancel_RealErrorStillFails` — a genuine error (runCtx alive) stays `failed`.
  - `TestFinishRunWithCancel_APICancelUnchanged` — the pre-existing API-cancel path still wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)