### PR TITLE
feat(sqlmem): RFC AA — SQL Memory for agents, Phase 1 (sqlite, per-scope, hardened)

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -8,6 +8,39 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ---
 
+## What's in vNEXT
+
+**🗄️ SQL Memory — in-runtime structured SQL storage for agents (RFC AA, Phase 1).**
+A new facet of the `Memory` tool: two ops, **`sql_query`** (read-only SELECT) and
+**`sql_exec`** (DDL/DML), run agent-authored SQL against a **per-scope sqlite
+database the runtime hosts**, fully isolated from the main loomcycle store. It
+targets sandboxed/short-lived agents that need related tables + joins + aggregates
+— structured storage the K/V + vector Memory can't give — without the `Bash +
+sqlite3` cost + safety hole.
+
+- **Scopes:** durable **`agent`** / **`user`** (keyed by the authoritative tenant,
+  persist across runs) + ephemeral **`run`** (one DB per spawn tree, dropped at
+  run completion — fenced removal, mirrors RFC AH ephemeral volumes).
+- **Default-deny `sql_scopes` ACL** (closed enum `{agent,user,run}`, per-agent yaml,
+  boot warning) — `Memory` in `allowed_tools` is not enough; the agent needs an
+  explicit `sql_scopes` list (RFC W pattern). Off unless `storage.sqlmem_enabled`.
+- **Security (the crux): the default `modernc.org/sqlite` driver has no
+  authorizer**, so the primary, driver-agnostic defence is a **Go-layer parsed
+  statement validator** that refuses `ATTACH`/`DETACH`/`VACUUM [INTO]`/`PRAGMA`,
+  `load_extension(…)` (incl. quoted-identifier forms — latent RCE on a future cgo
+  vec build), multi-statement smuggling, and any write on `sql_query` — backed by
+  **per-scope FILE isolation** (one .db per scope ⇒ a missed escape can't cross
+  scopes). Path derivation sanitizes every identifier (no `..`/separator escape,
+  collision-safe).
+- **Limits:** per-scope size **quota** (page-count×page-size, checked before a
+  write; per-agent override), per-statement **timeout** (ctx, honored by modernc's
+  interrupt), **row cap** + `truncated` flag, bind params.
+- **Audit:** every op records actor/scope/op/rows/duration + the **redacted**
+  statement (RFC Z redactor) — `full` or `metadata` mode; best-effort, never blocks
+  the op.
+- **Out of scope (Phase 2/3):** postgres schema-per-scope (multi-replica), vector
+  columns, snapshot/backup integration, explicit transactions.
+
 ## What's in v1.1.1
 
 **🗣️ Interactive agentic sessions over gRPC + TS (RFC AI).** The interactive session

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -72,6 +72,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/scheduler"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
@@ -1132,6 +1133,51 @@ func main() {
 	// server's tool set, which isn't in allTools here (F45). New re-points any
 	// Context tool to the COMPLETE post-append catalog, so don't set it here.
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
+
+	// RFC AA SQL Memory (Phase 1). Off by default; constructed only when the
+	// operator enables it. The manager hosts per-scope sqlite databases that
+	// SEPARATE from the main store — an agent's arbitrary SQL can only ever
+	// reach its own scope file. Wired into the Memory tool (sql_query/sql_exec)
+	// and the server (run-scope drop at top-level run completion).
+	if cfg.Storage.SqlMemEnabled {
+		sqlMemRoot := cfg.Storage.SqlMemRoot
+		if sqlMemRoot == "" {
+			sqlMemRoot = filepath.Join(cfg.Env.DataDir, "sqlmem")
+		}
+		sqlMemMgr, smErr := sqlmem.New(sqlmem.Config{
+			Root:               sqlMemRoot,
+			QuotaBytes:         cfg.Storage.SqlMemQuotaBytes,
+			StatementTimeoutMS: cfg.Storage.SqlMemStatementTimeoutMS,
+			MaxRows:            cfg.Storage.SqlMemMaxRows,
+		})
+		if smErr != nil {
+			log.Fatalf("sqlmem: %v", smErr)
+		}
+		// Audit sink: reuse the operator audit log file when configured (the
+		// records carry a distinct action=sql_query/sql_exec), else NopSink.
+		var sqlAudit audit.Sink = audit.NopSink{}
+		if cfg.Env.AuditLogPath != "" {
+			fs, aerr := audit.NewFileSink(cfg.Env.AuditLogPath)
+			if aerr != nil {
+				log.Fatalf("sqlmem audit: %v", aerr)
+			}
+			sqlAudit = fs
+		}
+		memoryTool.SqlMem = sqlMemMgr
+		memoryTool.SqlAudit = sqlAudit
+		memoryTool.SqlAuditMode = cfg.Storage.SqlMemAuditMode
+		// Reuse the server's redactor (same secret-classified env) so an
+		// audited statement is masked exactly like the rest of the transcript.
+		memoryTool.Redactor = srv.Redactor()
+		srv.SetSqlMem(sqlMemMgr)
+		// Close the manager (all open scope handles) on shutdown, after the
+		// store closer so an in-flight finish-path drop still has a live handle.
+		defer func() { _ = sqlMemMgr.Close() }()
+		log.Printf("sqlmem: SQL Memory enabled (root=%s, quota_bytes=%d, max_rows=%d, timeout_ms=%d, audit=%s)",
+			sqlMemRoot, cfg.Storage.SqlMemQuotaBytes, cfg.Storage.SqlMemMaxRows,
+			cfg.Storage.SqlMemStatementTimeoutMS, cfg.Storage.SqlMemAuditMode)
+	}
+
 	// v0.9.x — wire the MCPServerDef substrate tool. NOT in allTools
 	// (operator-admin-only); reached via Connector.MCPServerDef + the
 	// admin endpoint + the LoomCycle MCP meta-tool.

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -250,6 +250,15 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
 	})
+	// RFC AA SQL Memory: re-derive the sql_scopes ACL from the agent def too —
+	// without this a resumed/restored run reads a zero SqlMemPolicy and every
+	// sql_query/sql_exec default-denies, a silent loss of SQL Memory access
+	// across pause / snapshot / cross-instance resume (mirrors the memory +
+	// volume policy re-derivation above).
+	loopCtx = tools.WithSqlMemPolicy(loopCtx, tools.SqlMemPolicyValue{
+		AllowedScopes: agentDef.SqlScopes,
+		QuotaBytes:    agentDef.SqlQuotaBytes,
+	})
 	// Compaction re-derived from the agent def (per-run override not snapshotted),
 	// stamped for sub-agent inheritance.
 	loopCtx = tools.WithCompactionPolicy(loopCtx, agentDef.Compaction)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	"github.com/denn-gubsky/loomcycle/internal/runstate"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/steer"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -62,6 +63,13 @@ type Server struct {
 	tools     []tools.Tool
 	sem       *concurrency.Semaphore
 	store     store.Store // optional; nil means "don't persist"
+
+	// sqlMem is the RFC AA SQL Memory manager (per-scope sqlite databases
+	// backing the Memory tool's sql_query/sql_exec). Nil when the subsystem
+	// is disabled. Wired from main.go via SetSqlMem; the server uses it ONLY
+	// to drop a run-scope SQL database when the top-level run completes
+	// (mirroring the ephemeral-volume purge).
+	sqlMem *sqlmem.Manager
 
 	// redactor masks secret-shaped substrings in tool I/O before it is
 	// persisted to events.payload (F32). Built in New() from the secret-
@@ -724,6 +732,19 @@ func (s *Server) SetMemoryBackendDefTool(t tools.Tool) {
 func (s *Server) SetOperatorTokenDefTool(t tools.Tool) {
 	s.operatorTokenDefTool = t
 }
+
+// SetSqlMem wires the RFC AA SQL Memory manager so the server can drop a
+// run-scope SQL database when the top-level run completes. Nil leaves the
+// run-scope drop a no-op (the subsystem is disabled).
+func (s *Server) SetSqlMem(m *sqlmem.Manager) {
+	s.sqlMem = m
+}
+
+// Redactor returns the server's secret redactor (nil when redaction is
+// disabled). Exposed so the Memory tool's SQL audit reuses the SAME redactor
+// the server built from the secret-classified env — one source of truth for
+// what counts as a secret. The returned *Redactor's methods are nil-safe.
+func (s *Server) Redactor() *redact.Redactor { return s.redactor }
 
 // newDispatcher centralises Dispatcher construction so the three call
 // sites (handleRuns, handleMessages, runSubAgent) all pick up the
@@ -1978,6 +1999,11 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+	})
+	// RFC AA: the agent's SQL Memory ACL. Empty sql_scopes → default-deny.
+	loopCtx = tools.WithSqlMemPolicy(loopCtx, tools.SqlMemPolicyValue{
+		AllowedScopes: agentDef.SqlScopes,
+		QuotaBytes:    agentDef.SqlQuotaBytes,
 	})
 	// Resolved compaction settings flow down the spawn tree via ctx: a sub-agent
 	// inherits the parent's effective policy (its def fills any gaps the parent
@@ -3340,6 +3366,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
 	})
+	// RFC AA: the agent's SQL Memory ACL. Empty sql_scopes → default-deny.
+	loopCtx = tools.WithSqlMemPolicy(loopCtx, tools.SqlMemPolicyValue{
+		AllowedScopes: agentDef.SqlScopes,
+		QuotaBytes:    agentDef.SqlQuotaBytes,
+	})
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, req.Compaction))
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
 	// empty policy (the file tools fall back to the legacy jail Root);
@@ -3832,6 +3863,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		AllowedScopes: agentDef.MemoryScopes,
 		QuotaBytes:    agentDef.MemoryQuotaBytes,
 		Backend:       agentDef.MemoryBackend,
+	})
+	// RFC AA: the agent's SQL Memory ACL. Empty sql_scopes → default-deny.
+	loopCtx = tools.WithSqlMemPolicy(loopCtx, tools.SqlMemPolicyValue{
+		AllowedScopes: agentDef.SqlScopes,
+		QuotaBytes:    agentDef.SqlQuotaBytes,
 	})
 	loopCtx = tools.WithCompactionPolicy(loopCtx, config.MergeCompaction(agentDef.Compaction, body.Compaction))
 	// RFC AH: the run's filesystem-volume bindings. Unbound agents get an
@@ -4652,6 +4688,15 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 		AllowedScopes: def.MemoryScopes,
 		QuotaBytes:    def.MemoryQuotaBytes,
 		Backend:       def.MemoryBackend,
+	})
+	// RFC AA: the sub-agent's SQL Memory ACL is its OWN def's sql_scopes
+	// (like memory/channels, not inherited down the tree). Empty →
+	// default-deny. The run-scope DB keys off RootRunID (inherited unchanged
+	// above), so a child granted `run` reads/writes the SAME ephemeral DB as
+	// the rest of the tree — dropped once at the top-level run's completion.
+	subCtx = tools.WithSqlMemPolicy(subCtx, tools.SqlMemPolicyValue{
+		AllowedScopes: def.SqlScopes,
+		QuotaBytes:    def.SqlQuotaBytes,
 	})
 	// Compaction flows DOWN the spawn tree (unlike memory/channels/sampling,
 	// which are the child's own). The parent's effective policy (on ctx) wins per
@@ -5823,7 +5868,19 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 // Gated to top-level runs by the caller (meta.IsTopLevel): a sub-agent
 // completing must NOT purge the tree its parent + siblings still use.
 func (s *Server) purgeEphemeralVolumesForRun(rootRunID string) {
-	if rootRunID == "" || s.store == nil {
+	if rootRunID == "" {
+		return
+	}
+	// RFC AA SQL Memory: drop the run-scope SQL database for this top-level
+	// run. Independent of dynamic volumes (a deployment may run SQL Memory
+	// without any dynamic_root), so it happens BEFORE the volume early-return.
+	// Best-effort + logged — a drop fault must never fail the run.
+	if s.sqlMem != nil {
+		if _, err := s.sqlMem.DropRunScope(rootRunID); err != nil {
+			log.Printf("sqlmem run-scope drop (run=%s): %v", rootRunID, err)
+		}
+	}
+	if s.store == nil {
 		return
 	}
 	dynRoot, ok := builtin.DynamicVolumeRoot(s.cfg)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -30,6 +30,18 @@ type Event struct {
 	ScopesBefore     []string  `json:"scopes_before,omitempty"`
 	ScopesAfter      []string  `json:"scopes_after,omitempty"`
 	SourceAddr       string    `json:"source_addr,omitempty"`
+
+	// --- RFC AA SQL Memory (Action = "sql_query" | "sql_exec") ---
+	// All omitempty so a non-SQL audit record is byte-identical to before.
+	// SqlStatement is the REDACTED statement; it is omitted entirely when the
+	// operator runs audit_mode=metadata (statements never recorded).
+	SqlOp         string `json:"sql_op,omitempty"`        // "sql_query" | "sql_exec"
+	SqlScope      string `json:"sql_scope,omitempty"`     // "agent" | "user" | "run"
+	SqlScopeID    string `json:"sql_scope_id,omitempty"`  // resolved scope id (agent name / user id / run id)
+	SqlStatement  string `json:"sql_statement,omitempty"` // redacted; omitted in metadata mode
+	SqlRows       int64  `json:"sql_rows,omitempty"`      // rows returned (query) or affected (exec)
+	SqlDurationMs int64  `json:"sql_duration_ms,omitempty"`
+	SqlError      string `json:"sql_error,omitempty"`
 }
 
 // Sink records audit events. Record must be safe for concurrent use and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -285,6 +285,35 @@ type StorageConfig struct {
 	// `loomcycle migrate up` explicitly. When true, Open() runs
 	// migrations transparently. Env: LOOMCYCLE_PG_AUTOMIGRATE=1.
 	PgAutoMigrate bool `yaml:"pg_automigrate"`
+
+	// --- RFC AA SQL Memory (Phase 1, sqlite-only) ---
+	//
+	// SQL Memory is OFF by default: even an agent with sql_scopes set sees
+	// its SQL ops refuse until the operator enables the subsystem here. The
+	// per-scope databases are a SEPARATE store from the main loomcycle DB.
+
+	// SqlMemEnabled turns the SQL Memory subsystem on. Env:
+	// LOOMCYCLE_SQLMEM_ENABLED=1.
+	SqlMemEnabled bool `yaml:"sqlmem_enabled"`
+	// SqlMemRoot is the parent dir for per-scope .db files. Empty defaults
+	// to <DataDir>/sqlmem. Env: LOOMCYCLE_SQLMEM_ROOT.
+	SqlMemRoot string `yaml:"sqlmem_root"`
+	// SqlMemQuotaBytes caps a single scope file's on-disk size (checked
+	// before each write). 0 = no quota. Per-agent sql_quota_bytes overrides
+	// this. Env: LOOMCYCLE_SQLMEM_QUOTA_BYTES.
+	SqlMemQuotaBytes int `yaml:"sqlmem_quota_bytes"`
+	// SqlMemStatementTimeoutMS bounds a single sql_query/sql_exec. Default
+	// 30000. Env: LOOMCYCLE_SQLMEM_STATEMENT_TIMEOUT_MS.
+	SqlMemStatementTimeoutMS int `yaml:"sqlmem_statement_timeout_ms"`
+	// SqlMemMaxRows caps the rows a sql_query returns (the rest is dropped
+	// and the result is flagged truncated). Default 10000. Env:
+	// LOOMCYCLE_SQLMEM_MAX_ROWS.
+	SqlMemMaxRows int `yaml:"sqlmem_max_rows"`
+	// SqlMemAuditMode controls how much of an audited statement is recorded:
+	// "full" (the default) records the redacted statement text; "metadata"
+	// records only op/scope/row counts, never the statement. Env:
+	// LOOMCYCLE_SQLMEM_AUDIT_MODE.
+	SqlMemAuditMode string `yaml:"sqlmem_audit_mode"`
 }
 
 // ConfigDir returns the directory the YAML was loaded from. Used by
@@ -731,6 +760,25 @@ type AgentDef struct {
 	// legitimately maintain large state (cv-adapter); set lower for
 	// noisy agents you want to keep on a tight leash.
 	MemoryQuotaBytes int `yaml:"memory_quota_bytes"`
+
+	// SqlScopes is the RFC AA SQL Memory ACL — the closed set of
+	// per-scope sqlite databases the agent may run sql_query / sql_exec
+	// against. Empty = NO SQL access (the default-deny invariant: even
+	// with Memory in allowed_tools, an agent without sql_scopes sees its
+	// SQL ops refused). Closed enum {agent, user, run}:
+	//
+	//   - "agent" → this agent's durable DB (tenant-keyed, cross-run)
+	//   - "user"  → this end-user's durable DB (tenant-keyed, cross-agent)
+	//   - "run"   → an ephemeral DB dropped when the top-level run ends
+	//
+	// Same trust posture as MemoryScopes: the model picks the scope, the
+	// operator-resolved config decides which scopes exist at all.
+	SqlScopes []string `yaml:"sql_scopes"`
+
+	// SqlQuotaBytes overrides the global per-scope SQL DB byte cap
+	// (LOOMCYCLE_SQLMEM_QUOTA_BYTES) for this agent. 0 = use the global
+	// default. Checked before each write (approximate; see internal/sqlmem).
+	SqlQuotaBytes int `yaml:"sql_quota_bytes"`
 
 	// MemoryBackend names a memory_backends entry / MemoryBackendDef
 	// this agent routes its Memory ops through. Empty = the
@@ -2563,6 +2611,43 @@ func Load(path string) (*Config, error) {
 		cfg.Storage.Backend = "sqlite"
 	}
 
+	// RFC AA SQL Memory (Phase 1). Off by default; env overrides yaml.
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_ENABLED"); v == "1" {
+		cfg.Storage.SqlMemEnabled = true
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_ROOT"); v != "" {
+		cfg.Storage.SqlMemRoot = v
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_QUOTA_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Storage.SqlMemQuotaBytes = n
+		}
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_STATEMENT_TIMEOUT_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Storage.SqlMemStatementTimeoutMS = n
+		}
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_MAX_ROWS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Storage.SqlMemMaxRows = n
+		}
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_AUDIT_MODE"); v != "" {
+		cfg.Storage.SqlMemAuditMode = v
+	}
+	// Defaults for the bounds the operator did not set. quota stays 0 (off);
+	// timeout/rows get sensible ceilings; audit defaults to full.
+	if cfg.Storage.SqlMemStatementTimeoutMS == 0 {
+		cfg.Storage.SqlMemStatementTimeoutMS = 30000
+	}
+	if cfg.Storage.SqlMemMaxRows == 0 {
+		cfg.Storage.SqlMemMaxRows = 10000
+	}
+	if cfg.Storage.SqlMemAuditMode == "" {
+		cfg.Storage.SqlMemAuditMode = "full"
+	}
+
 	// Hooks block (v0.8.17). The env-var override APPENDS to whatever
 	// yaml already declared rather than replacing, so an operator can
 	// keep their static list in yaml and add an ops-only entry via env
@@ -3685,6 +3770,12 @@ func mergeAgentDef(base, override AgentDef) AgentDef {
 	if override.MemoryQuotaBytes != 0 {
 		out.MemoryQuotaBytes = override.MemoryQuotaBytes
 	}
+	if override.SqlScopes != nil {
+		out.SqlScopes = override.SqlScopes
+	}
+	if override.SqlQuotaBytes != 0 {
+		out.SqlQuotaBytes = override.SqlQuotaBytes
+	}
 	if override.MemoryBackend != "" {
 		out.MemoryBackend = override.MemoryBackend
 	}
@@ -3916,6 +4007,15 @@ var validMemoryScopes = map[string]bool{
 	"user":  true,
 }
 
+// validSqlScopes is the closed set of RFC AA SQL Memory scope names
+// accepted in agent yaml. Unlike Memory's k/v scopes it also includes
+// `run` — an ephemeral per-run database dropped at run completion.
+var validSqlScopes = map[string]bool{
+	"agent": true,
+	"user":  true,
+	"run":   true,
+}
+
 // validChannelScopes is the closed set of Channel tool scope names
 // accepted on a top-level `channels:` entry. agent + user mirror
 // Memory's vocabulary; global is the cross-tenant fan-out shape.
@@ -4105,6 +4205,28 @@ func agentGateWarnings(name string, a AgentDef) []string {
 		w = append(w, fmt.Sprintf("agent %q: allowed_tools includes Interruption but interruption.enabled is false — every Interruption op will refuse; set interruption.enabled: true", name))
 	}
 	return w
+}
+
+// sqlMemConfigWarnings returns the non-fatal advisory when an agent is
+// configured for RFC AA SQL Memory (Memory in allowed_tools + a non-empty
+// sql_scopes) but the subsystem is disabled at the storage layer — the agent
+// boots, but every sql_query/sql_exec refuses with "not enabled". Kept pure +
+// separate from agentGateWarnings because it needs the storage flag, not just
+// the AgentDef. The inverse (sql_scopes empty → default-deny) is enforced at
+// runtime, not flagged here.
+func sqlMemConfigWarnings(name string, a AgentDef, sqlMemEnabled bool) []string {
+	has := func(tool string) bool {
+		for _, t := range a.AllowedTools {
+			if t == tool {
+				return true
+			}
+		}
+		return false
+	}
+	if has("Memory") && len(a.SqlScopes) > 0 && !sqlMemEnabled {
+		return []string{fmt.Sprintf("agent %q: sql_scopes is set but storage.sqlmem_enabled is false — every sql_query/sql_exec will refuse; set LOOMCYCLE_SQLMEM_ENABLED=1 (or storage.sqlmem_enabled: true)", name)}
+	}
+	return nil
 }
 
 // validateStaticWebhook checks a static `webhooks:` entry's delivery target +
@@ -4327,6 +4449,14 @@ func validate(c *Config) error {
 				return fmt.Errorf("agent %q: memory_scopes[%d]: unknown scope %q (want one of: agent, user)", name, i, sc)
 			}
 		}
+		// RFC AA SQL Memory: validate sql_scopes are known scope strings.
+		// Empty = no SQL access (default-deny, enforced at runtime, not here).
+		// Non-empty must be a subset of {agent, user, run}.
+		for i, sc := range agent.SqlScopes {
+			if !validSqlScopes[sc] {
+				return fmt.Errorf("agent %q: sql_scopes[%d]: unknown scope %q (want one of: agent, user, run)", name, i, sc)
+			}
+		}
 		// RFC AH Phase 1: a per-agent `volumes` binding must reference a
 		// declared top-level `volumes:` entry (mirrors how allowed_tools
 		// validates against registered tools — operator-yaml is the floor,
@@ -4344,8 +4474,12 @@ func validate(c *Config) error {
 		// logged once at boot, never fatal — an operator may legitimately list a
 		// tool they haven't gated yet.
 		c.Warnings = append(c.Warnings, agentGateWarnings(name, agent)...)
+		c.Warnings = append(c.Warnings, sqlMemConfigWarnings(name, agent, c.Storage.SqlMemEnabled)...)
 		if agent.MemoryQuotaBytes < 0 {
 			return fmt.Errorf("agent %q: memory_quota_bytes must be >= 0", name)
+		}
+		if agent.SqlQuotaBytes < 0 {
+			return fmt.Errorf("agent %q: sql_quota_bytes must be >= 0", name)
 		}
 		// Memory backend routing (RFC I MR-3b): a static agent that names
 		// a memory_backend must reference a declared memory_backends key

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -596,6 +596,98 @@ agents:
 	}
 }
 
+// TestSqlScopes_RejectsUnknownScope is the RFC AA config-validation
+// regression: an agent with a bogus sql_scopes entry must fail Load.
+func TestSqlScopes_RejectsUnknownScope(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  bad:
+    model: claude-sonnet-4-6
+    allowed_tools: [Memory]
+    sql_scopes: [bogus]
+`), 0o600)
+	_, err := Load(yamlPath)
+	if err == nil {
+		t.Fatal("expected error for unknown sql scope")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error should name the offending scope: %v", err)
+	}
+}
+
+// TestSqlScopes_AcceptsKnownScopes confirms {agent, run} round-trips and
+// sql_quota_bytes is carried through Load.
+func TestSqlScopes_AcceptsKnownScopes(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+agents:
+  ok:
+    model: claude-sonnet-4-6
+    allowed_tools: [Memory]
+    sql_scopes: [agent, run]
+    sql_quota_bytes: 1048576
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	def := cfg.Agents["ok"]
+	if len(def.SqlScopes) != 2 || def.SqlScopes[0] != "agent" || def.SqlScopes[1] != "run" {
+		t.Errorf("SqlScopes round-trip: %v", def.SqlScopes)
+	}
+	if def.SqlQuotaBytes != 1048576 {
+		t.Errorf("SqlQuotaBytes = %d", def.SqlQuotaBytes)
+	}
+}
+
+// TestSqlMem_StorageDefaultsAndEnv confirms the StorageConfig SQL defaults
+// (timeout/rows/audit) land even when unset.
+func TestSqlMem_StorageDefaults(t *testing.T) {
+	tmp := t.TempDir()
+	yamlPath := filepath.Join(tmp, "c.yaml")
+	os.WriteFile(yamlPath, []byte(`
+defaults: { provider: anthropic, model: claude-sonnet-4-6 }
+`), 0o600)
+	cfg, err := Load(yamlPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Storage.SqlMemEnabled {
+		t.Error("SqlMemEnabled should default to false")
+	}
+	if cfg.Storage.SqlMemStatementTimeoutMS != 30000 {
+		t.Errorf("SqlMemStatementTimeoutMS = %d, want 30000", cfg.Storage.SqlMemStatementTimeoutMS)
+	}
+	if cfg.Storage.SqlMemMaxRows != 10000 {
+		t.Errorf("SqlMemMaxRows = %d, want 10000", cfg.Storage.SqlMemMaxRows)
+	}
+	if cfg.Storage.SqlMemAuditMode != "full" {
+		t.Errorf("SqlMemAuditMode = %q, want full", cfg.Storage.SqlMemAuditMode)
+	}
+}
+
+// TestSqlMemConfigWarnings_FlagsDisabledSubsystem confirms the boot warning
+// fires when sql_scopes is set + Memory is allowed but the subsystem is off.
+func TestSqlMemConfigWarnings_FlagsDisabledSubsystem(t *testing.T) {
+	a := AgentDef{AllowedTools: []string{"Memory"}, SqlScopes: []string{"agent"}}
+	if w := sqlMemConfigWarnings("x", a, false); len(w) != 1 {
+		t.Fatalf("expected 1 warning when subsystem disabled, got %v", w)
+	}
+	if w := sqlMemConfigWarnings("x", a, true); len(w) != 0 {
+		t.Fatalf("expected 0 warnings when subsystem enabled, got %v", w)
+	}
+	// No Memory in allowed_tools → no warning even if sql_scopes set.
+	b := AgentDef{SqlScopes: []string{"agent"}}
+	if w := sqlMemConfigWarnings("x", b, false); len(w) != 0 {
+		t.Fatalf("expected 0 warnings without Memory tool, got %v", w)
+	}
+}
+
 // TestMemoryBackend_RoundTripsAndResolvesAgainstStaticMap confirms a
 // static agent's memory_backend round-trips through Load AND validates
 // against a declared memory_backends entry (RFC I MR-3b).

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -1,0 +1,513 @@
+package sqlmem
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// Config configures the SQL Memory Manager. All bounds default to "off"
+// when zero EXCEPT the ones with sensible runtime defaults the caller is
+// expected to supply (see cmd/loomcycle wiring); the Manager itself treats
+// a zero StatementTimeoutMS / MaxRows / QuotaBytes as "no bound".
+type Config struct {
+	// Root is the parent directory under which every per-scope .db file
+	// lives (<DataDir>/sqlmem by convention). Required.
+	Root string
+	// QuotaBytes caps a single scope file's on-disk size. 0 = no quota.
+	// Checked BEFORE a write (PRAGMA page_count * page_size); an approximate
+	// bound that can overshoot by at most one statement (see Exec).
+	QuotaBytes int
+	// StatementTimeoutMS bounds a single Query/Exec via context.WithTimeout.
+	// 0 = no timeout.
+	StatementTimeoutMS int
+	// MaxRows caps the rows a Query returns; the remainder is drained and
+	// Truncated is set. 0 = no cap.
+	MaxRows int
+}
+
+// maxOpenHandles caps the number of live *sql.DB handles the Manager keeps
+// open. On overflow the least-recently-used handle is closed. 64 is a
+// generous ceiling for the per-scope-file model: each scope opens its own
+// file, and a busy multi-tenant runtime touches far fewer than 64 distinct
+// scopes within any short window. Closing an LRU handle is safe — the next
+// access reopens it.
+const maxOpenHandles = 64
+
+// Manager owns the per-scope sqlite databases for RFC AA SQL Memory. Each
+// scope (agent/user/run, keyed by tenant) maps to ONE .db file under Root;
+// the Manager opens at most maxOpenHandles handles at a time, closing the
+// least-recently-used on overflow. Safe for concurrent use.
+//
+// The Manager is deliberately SEPARATE from the main loomcycle store: an
+// agent's arbitrary SQL can only ever reach its own scope file, never the
+// runtime's operational database.
+type Manager struct {
+	cfg Config
+
+	mu    sync.Mutex
+	open  map[string]*openHandle // keyed by resolved file path
+	clock uint64                 // monotonic LRU stamp
+}
+
+// openHandle is one live scope database plus its LRU stamp and an in-flight
+// reference count. inUse > 0 means a Query/Exec is currently running against
+// this handle, so eviction must NOT close it (a close mid-query, or between an
+// Exec's quota-check and its write, would surface as sql.ErrConnDone).
+type openHandle struct {
+	db    *sql.DB
+	used  uint64
+	inUse int
+}
+
+// ScopeKey identifies one scope database. Tenant/Scope/ScopeID are all
+// resolved server-side (never model-supplied raw) but are sanitized
+// defensively here before they touch the filesystem.
+type ScopeKey struct {
+	Tenant  string
+	Scope   string // "agent" | "user" | "run"
+	ScopeID string
+}
+
+// runScope is the scope name for ephemeral run databases. It is stored
+// under <Root>/run/<run_id>.db (NOT keyed by tenant — run ids are globally
+// unique), and is the only scope DropRunScope can target.
+const runScope = "run"
+
+// QueryResult is the shape returned by Query.
+type QueryResult struct {
+	Columns   []string
+	Rows      [][]any
+	Truncated bool // true when MaxRows was hit and more rows existed
+}
+
+// ExecResult is the shape returned by Exec.
+type ExecResult struct {
+	RowsAffected int64
+	LastInsertID int64
+}
+
+// New constructs a Manager and ensures Root exists.
+func New(cfg Config) (*Manager, error) {
+	if strings.TrimSpace(cfg.Root) == "" {
+		return nil, fmt.Errorf("sqlmem: empty Root")
+	}
+	if err := os.MkdirAll(cfg.Root, 0o700); err != nil {
+		return nil, fmt.Errorf("sqlmem: mkdir root %q: %w", cfg.Root, err)
+	}
+	return &Manager{
+		cfg:  cfg,
+		open: make(map[string]*openHandle),
+	}, nil
+}
+
+// sanitizeRe matches the characters allowed VERBATIM in a path segment.
+// Anything outside it is replaced (see sanitize), so no separator or dot
+// run can survive into the on-disk path.
+var sanitizeRe = regexp.MustCompile(`[^A-Za-z0-9_-]`)
+
+// sanitize maps an identifier to a single safe path segment. The inputs
+// (tenant id, agent name, user id, run id) are charset-validated upstream,
+// but the Manager sanitizes defensively — it is the last line before a
+// caller-influenced string becomes a filesystem path.
+//
+// Rules:
+//   - empty → error (an empty segment would collapse the path).
+//   - allowed charset [A-Za-z0-9_-] passes verbatim.
+//   - any other character is replaced with '_', AND a short hash of the
+//     ORIGINAL is appended — so two distinct ids that sanitize to the same
+//     replaced form ("a/b" and "a_b") never collide on the same file.
+//
+// Because every disallowed character (including '/', '.', and the '..'
+// sequence) is replaced, the result can never contain a path separator or
+// a parent-directory token: a malicious scope id like "../../etc/x" becomes
+// a single inert segment, so the derived path stays under Root.
+func sanitize(s string) (string, error) {
+	if s == "" {
+		return "", fmt.Errorf("sqlmem: empty scope identifier")
+	}
+	clean := sanitizeRe.ReplaceAllString(s, "_")
+	if clean != s {
+		// Disambiguate: append a hash of the original so distinct inputs that
+		// map to the same replaced form land on distinct files.
+		sum := sha256.Sum256([]byte(s))
+		clean = clean + "-" + hex.EncodeToString(sum[:6])
+	}
+	return clean, nil
+}
+
+// keyPath resolves the on-disk .db path for a ScopeKey under root.
+//
+//	durable:   <root>/<sanitize(tenant)>/<scope>/<sanitize(scope_id)>.db
+//	ephemeral: <root>/run/<sanitize(scope_id)>.db   (scope == run)
+//
+// The shared tenant "" sanitizes via the empty-check error for durable
+// scopes; callers resolve a non-empty tenant (RunIdentity stamps "default"
+// or a real id). A run scope is NOT tenant-keyed — run ids are globally
+// unique — which is also what lets DropRunScope target a single subtree.
+func (k ScopeKey) keyPath(root string) (string, error) {
+	id, err := sanitize(k.ScopeID)
+	if err != nil {
+		return "", err
+	}
+	if k.Scope == runScope {
+		return filepath.Join(root, runScope, id+".db"), nil
+	}
+	tenant, err := sanitize(k.Tenant)
+	if err != nil {
+		return "", err
+	}
+	// Scope is a closed enum resolved server-side, but sanitize it too so a
+	// future caller can never inject a separator through it.
+	scope, err := sanitize(k.Scope)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, tenant, scope, id+".db"), nil
+}
+
+// dsnPragmas mirrors driver_default.go openDB: WAL + foreign-key enforcement
+// + a 5-second busy timeout. SQL Memory uses the SAME pragma posture as the
+// main store so a scope file behaves identically under contention.
+const dsnPragmas = "?_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)&_pragma=busy_timeout(5000)"
+
+// openScopeDB opens (creating the parent dir) the scope database at path
+// with the hardened pragma set. SetMaxOpenConns(1): one writer per scope
+// file. Each scope is a private, single-agent keyspace, so there is no
+// within-scope concurrency to exploit — a single connection sidesteps
+// SQLITE_BUSY entirely and keeps the WAL simple. Extension loading is NEVER
+// enabled (the DSN carries no extension pragma, and the Go-layer validator
+// already refuses load_extension).
+func openScopeDB(path string) (*sql.DB, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("sqlmem: mkdir %q: %w", filepath.Dir(path), err)
+	}
+	db, err := sql.Open("sqlite", path+dsnPragmas)
+	if err != nil {
+		return nil, fmt.Errorf("sqlmem: open %q: %w", path, err)
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxIdleTime(5 * time.Minute)
+	return db, nil
+}
+
+// acquire returns the (cached or freshly opened) *sql.DB for path and pins it
+// (inUse++) so a concurrent eviction cannot close it mid-use. The caller MUST
+// call release(path) when done — pair them with `defer`. One acquisition spans
+// a whole Query, or a whole Exec (quota-check + write), so neither half ever
+// races eviction.
+func (m *Manager) acquire(path string) (*sql.DB, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clock++
+	h, ok := m.open[path]
+	if !ok {
+		db, err := openScopeDB(path)
+		if err != nil {
+			return nil, err
+		}
+		h = &openHandle{db: db}
+		m.open[path] = h
+	}
+	h.used = m.clock
+	h.inUse++
+	m.evictLocked()
+	return h.db, nil
+}
+
+// release drops one in-flight reference taken by acquire.
+func (m *Manager) release(path string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if h, ok := m.open[path]; ok && h.inUse > 0 {
+		h.inUse--
+	}
+}
+
+// evictLocked closes the least-recently-used IDLE handle while the open set
+// exceeds the cap. Caller must hold m.mu. An in-use handle (inUse > 0) is never
+// a victim, so the set may briefly exceed the cap under heavy concurrency —
+// that is correct (those handles are actively serving). Closing is best-effort.
+func (m *Manager) evictLocked() {
+	for len(m.open) > maxOpenHandles {
+		var lruPath string
+		var lruUsed uint64
+		for p, h := range m.open {
+			if h.inUse > 0 {
+				continue // never evict an in-flight handle
+			}
+			if lruPath == "" || h.used < lruUsed {
+				lruPath, lruUsed = p, h.used
+			}
+		}
+		if lruPath == "" {
+			return // every handle is in use — nothing evictable right now
+		}
+		if h, ok := m.open[lruPath]; ok {
+			if err := h.db.Close(); err != nil {
+				log.Printf("sqlmem: close LRU handle %q: %v", lruPath, err)
+			}
+			delete(m.open, lruPath)
+		}
+	}
+}
+
+// evictPathLocked closes and forgets a single open handle (used by
+// DropRunScope before deleting the file). Caller must hold m.mu.
+func (m *Manager) evictPathLocked(path string) {
+	if h, ok := m.open[path]; ok {
+		if err := h.db.Close(); err != nil {
+			log.Printf("sqlmem: close handle %q before drop: %v", path, err)
+		}
+		delete(m.open, path)
+	}
+}
+
+// effectiveQuota returns the quota to enforce for this call: the per-call
+// override when > 0, else the Manager default.
+func (m *Manager) effectiveQuota(override int) int {
+	if override > 0 {
+		return override
+	}
+	return m.cfg.QuotaBytes
+}
+
+// withTimeout derives a context bounded by StatementTimeoutMS. A zero
+// timeout returns the parent ctx with a no-op cancel.
+func (m *Manager) withTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	if m.cfg.StatementTimeoutMS <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, time.Duration(m.cfg.StatementTimeoutMS)*time.Millisecond)
+}
+
+// Query runs a read-only statement against the scope database. The
+// statement is validated by the Go-layer security floor FIRST
+// (validateStatement(read-only)); only then does it reach the driver.
+// Rows beyond MaxRows are drained and Truncated is set. A *ErrStatement or
+// a driver error is returned as a plain error — the caller surfaces it as
+// is_error.
+func (m *Manager) Query(ctx context.Context, key ScopeKey, statement string, args []any) (*QueryResult, error) {
+	if err := validateStatement(statement, true); err != nil {
+		return nil, err
+	}
+	path, err := key.keyPath(m.cfg.Root)
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := m.acquire(path)
+	if err != nil {
+		return nil, err
+	}
+	defer m.release(path)
+
+	qctx, cancel := m.withTimeout(ctx)
+	defer cancel()
+
+	rows, err := db.QueryContext(qctx, statement, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	res := &QueryResult{Columns: cols, Rows: make([][]any, 0)}
+	for rows.Next() {
+		if m.cfg.MaxRows > 0 && len(res.Rows) >= m.cfg.MaxRows {
+			// Stop scanning but mark truncated. The deferred rows.Close drains
+			// the rest; we do not scan them.
+			res.Truncated = true
+			break
+		}
+		scan := make([]any, len(cols))
+		ptrs := make([]any, len(cols))
+		for i := range scan {
+			ptrs[i] = &scan[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		// Normalize []byte to string so the JSON encoder emits text, not
+		// base64 — sqlite hands TEXT columns back as []byte under modernc.
+		for i, v := range scan {
+			if b, ok := v.([]byte); ok {
+				scan[i] = string(b)
+			}
+		}
+		res.Rows = append(res.Rows, scan)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// Exec runs a DDL/DML statement against the scope database. The statement
+// is validated by the Go-layer floor FIRST (validateStatement(read-write)).
+// The quota is checked BEFORE the write (page_count * page_size): an
+// approximate bound — a single statement can push the file past the quota,
+// but the NEXT write then refuses, so growth is bounded to one statement's
+// worth of overshoot.
+func (m *Manager) Exec(ctx context.Context, key ScopeKey, statement string, args []any, quotaOverride int) (*ExecResult, error) {
+	if err := validateStatement(statement, false); err != nil {
+		return nil, err
+	}
+	path, err := key.keyPath(m.cfg.Root)
+	if err != nil {
+		return nil, err
+	}
+
+	// One acquisition spans the quota check AND the write, so eviction can't
+	// close the handle between them.
+	db, err := m.acquire(path)
+	if err != nil {
+		return nil, err
+	}
+	defer m.release(path)
+
+	if quota := m.effectiveQuota(quotaOverride); quota > 0 {
+		size, err := scopeSizeBytes(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("sqlmem: quota check: %w", err)
+		}
+		if size >= int64(quota) {
+			return nil, fmt.Errorf("sqlmem: scope is at its quota (%d bytes >= %d) — delete rows or drop tables before writing", size, quota)
+		}
+	}
+
+	ectx, cancel := m.withTimeout(ctx)
+	defer cancel()
+
+	r, err := db.ExecContext(ectx, statement, args...)
+	if err != nil {
+		return nil, err
+	}
+	out := &ExecResult{}
+	if n, err := r.RowsAffected(); err == nil {
+		out.RowsAffected = n
+	}
+	// LastInsertId is meaningless for non-INSERT statements; ignore its error.
+	if id, err := r.LastInsertId(); err == nil {
+		out.LastInsertID = id
+	}
+	return out, nil
+}
+
+// scopeSizeBytes returns the on-disk size of the scope database as
+// page_count * page_size. Both pragmas are engine-internal (read-only
+// here); they never touch agent data.
+func scopeSizeBytes(ctx context.Context, db *sql.DB) (int64, error) {
+	var pageCount, pageSize int64
+	if err := db.QueryRowContext(ctx, "PRAGMA page_count").Scan(&pageCount); err != nil {
+		return 0, fmt.Errorf("page_count: %w", err)
+	}
+	if err := db.QueryRowContext(ctx, "PRAGMA page_size").Scan(&pageSize); err != nil {
+		return 0, fmt.Errorf("page_size: %w", err)
+	}
+	return pageCount * pageSize, nil
+}
+
+// DropRunScope closes+evicts the handle for the run/<runID>.db file and
+// removes it (plus -wal/-shm sidecars) behind a fence: the resolved target
+// must sit STRICTLY inside <Root>/run and not equal <Root>/run itself, so a
+// malformed run id can never widen the delete. Best-effort; mirrors the
+// VolumeDef ephemeral-purge fence rooted at <Root>/run. removed reports
+// whether a file was actually deleted (false when it was already gone).
+func (m *Manager) DropRunScope(runID string) (removed bool, err error) {
+	if strings.TrimSpace(runID) == "" {
+		return false, fmt.Errorf("sqlmem: empty run id")
+	}
+	key := ScopeKey{Scope: runScope, ScopeID: runID}
+	path, err := key.keyPath(m.cfg.Root)
+	if err != nil {
+		return false, err
+	}
+
+	m.mu.Lock()
+	m.evictPathLocked(path)
+	m.mu.Unlock()
+
+	runRoot := filepath.Join(m.cfg.Root, runScope)
+	return fencedRemoveDB(runRoot, path)
+}
+
+// fencedRemoveDB removes a single scope .db file (and its -wal/-shm
+// sidecars) only after proving the resolved path is strictly inside
+// expectedRoot. It NEVER trusts a stored path — path is re-derived by the
+// caller from (Root, run, sanitize(run_id)). A non-existent target is a
+// no-op success (removed=false). On a fence failure it logs and returns an
+// error WITHOUT deleting.
+func fencedRemoveDB(expectedRoot, path string) (removed bool, err error) {
+	rootResolved, err := filepath.EvalSymlinks(expectedRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// The run-scope root was never created — nothing to drop.
+			return false, nil
+		}
+		return false, fmt.Errorf("sqlmem: resolve run root: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil // already gone
+		}
+		return false, fmt.Errorf("sqlmem: resolve target: %w", err)
+	}
+	// Strictly inside expectedRoot and not equal to it.
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		log.Printf("sqlmem: DropRunScope REFUSED: %q does not resolve strictly inside %q", path, rootResolved)
+		return false, fmt.Errorf("sqlmem: refusing to delete %q — not inside the run-scope root", resolved)
+	}
+	if resolved == rootResolved {
+		log.Printf("sqlmem: DropRunScope REFUSED: resolved path is the run-scope root itself")
+		return false, fmt.Errorf("sqlmem: refusing to delete the run-scope root")
+	}
+	// Remove the file and its WAL sidecars. RemoveAll tolerates absent
+	// sidecars; we OR the primary file's removal into `removed`.
+	if err := os.Remove(resolved); err != nil {
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("sqlmem: remove %q: %w", resolved, err)
+		}
+	} else {
+		removed = true
+	}
+	for _, suffix := range []string{"-wal", "-shm"} {
+		// Sidecars sit next to the resolved primary file; deriving them from
+		// `resolved` keeps them inside the same fenced directory.
+		_ = os.Remove(resolved + suffix)
+	}
+	return removed, nil
+}
+
+// Close closes every open scope handle. Best-effort: the first close error
+// is returned but every handle is still attempted.
+func (m *Manager) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var firstErr error
+	for path, h := range m.open {
+		if err := h.db.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+		delete(m.open, path)
+	}
+	return firstErr
+}

--- a/internal/sqlmem/sqlmem_concurrency_test.go
+++ b/internal/sqlmem/sqlmem_concurrency_test.go
@@ -1,0 +1,68 @@
+package sqlmem
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestManager_ConcurrentDistinctScopes_NoEvictionRace stresses the LRU
+// eviction path: far more concurrent distinct scopes than maxOpenHandles, each
+// doing a quota-checked Exec then a Query. Before the in-use refcount, an
+// eviction could close a handle mid-Exec (between its quota-check and write),
+// surfacing as a spurious sql.ErrConnDone. With the refcount, an in-flight
+// handle is never a victim. Run with -race to also catch data races on the
+// open-handle map.
+func TestManager_ConcurrentDistinctScopes_NoEvictionRace(t *testing.T) {
+	mgr, err := New(Config{Root: t.TempDir(), QuotaBytes: 1 << 20, MaxRows: 1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mgr.Close()
+
+	const (
+		scopes     = maxOpenHandles * 3 // 192 distinct scope files — forces churn
+		iterations = 4
+	)
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	errs := make(chan error, scopes*iterations*3)
+
+	for s := 0; s < scopes; s++ {
+		wg.Add(1)
+		go func(s int) {
+			defer wg.Done()
+			key := ScopeKey{Tenant: "default", Scope: "agent", ScopeID: fmt.Sprintf("a%d", s)}
+			if _, err := mgr.Exec(ctx, key, "CREATE TABLE t (n INTEGER)", nil, 0); err != nil {
+				errs <- fmt.Errorf("scope %d create: %w", s, err)
+				return
+			}
+			for i := 0; i < iterations; i++ {
+				if _, err := mgr.Exec(ctx, key, "INSERT INTO t (n) VALUES (1)", nil, 0); err != nil {
+					errs <- fmt.Errorf("scope %d insert %d: %w", s, i, err)
+					return
+				}
+				if _, err := mgr.Query(ctx, key, "SELECT count(*) FROM t", nil); err != nil {
+					errs <- fmt.Errorf("scope %d query %d: %w", s, i, err)
+					return
+				}
+			}
+		}(s)
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Error(e)
+	}
+
+	// Each scope wrote `iterations` rows and they live in distinct files —
+	// confirm isolation survived the churn for a sample scope.
+	res, err := mgr.Query(ctx, ScopeKey{Tenant: "default", Scope: "agent", ScopeID: "a0"}, "SELECT count(*) FROM t", nil)
+	if err != nil {
+		t.Fatalf("final query: %v", err)
+	}
+	if len(res.Rows) != 1 || fmt.Sprint(res.Rows[0][0]) != fmt.Sprint(int64(iterations)) {
+		t.Errorf("scope a0 row count = %v, want %d", res.Rows[0][0], iterations)
+	}
+}

--- a/internal/sqlmem/sqlmem_test.go
+++ b/internal/sqlmem/sqlmem_test.go
@@ -1,0 +1,329 @@
+package sqlmem
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+// newTestManager builds a Manager rooted in a temp dir with generous
+// bounds. Individual tests override cfg fields via a returned closure when
+// they need a tighter bound (quota/rows).
+func newTestManager(t *testing.T, cfg Config) *Manager {
+	t.Helper()
+	if cfg.Root == "" {
+		cfg.Root = t.TempDir()
+	}
+	m, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	return m
+}
+
+func agentKey(tenant, agent string) ScopeKey {
+	return ScopeKey{Tenant: tenant, Scope: "agent", ScopeID: agent}
+}
+
+// TestManager_RoundTripsWithinOneScope asserts CREATE TABLE + INSERT + SELECT
+// flows end-to-end through one scope database.
+func TestManager_RoundTripsWithinOneScope(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "writer")
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	res, err := m.Exec(ctx, key, "INSERT INTO notes (body) VALUES (?)", []any{"hello"}, 0)
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	if res.RowsAffected != 1 {
+		t.Fatalf("RowsAffected = %d, want 1", res.RowsAffected)
+	}
+	if res.LastInsertID != 1 {
+		t.Fatalf("LastInsertID = %d, want 1", res.LastInsertID)
+	}
+
+	q, err := m.Query(ctx, key, "SELECT id, body FROM notes ORDER BY id", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got := strings.Join(q.Columns, ","); got != "id,body" {
+		t.Fatalf("columns = %q, want id,body", got)
+	}
+	if len(q.Rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(q.Rows))
+	}
+	if body, ok := q.Rows[0][1].(string); !ok || body != "hello" {
+		t.Fatalf("row body = %#v, want \"hello\"", q.Rows[0][1])
+	}
+}
+
+// TestManager_ScopeAInvisibleToScopeB asserts data written under one agent
+// scope is not visible to another agent scope (different file).
+func TestManager_ScopeAInvisibleToScopeB(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	a := agentKey("t1", "agentA")
+	b := agentKey("t1", "agentB")
+
+	if _, err := m.Exec(ctx, a, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	if _, err := m.Exec(ctx, a, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	// Scope B has its own file — the table created in A does not exist here.
+	if _, err := m.Query(ctx, b, "SELECT x FROM t", nil); err == nil {
+		t.Fatal("scope B saw scope A's table; want an error (no such table)")
+	}
+}
+
+// TestManager_TenantAInvisibleToTenantB asserts tenant isolation: the same
+// agent name under two tenants maps to two distinct files.
+func TestManager_TenantAInvisibleToTenantB(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	a := agentKey("tenantA", "shared-name")
+	b := agentKey("tenantB", "shared-name")
+
+	if _, err := m.Exec(ctx, a, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	if _, err := m.Exec(ctx, a, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	if _, err := m.Query(ctx, b, "SELECT x FROM t", nil); err == nil {
+		t.Fatal("tenant B saw tenant A's table; want an error (separate file)")
+	}
+}
+
+// TestManager_AttachRefusedAndCannotSeeOtherFile asserts a scope connection
+// cannot ATTACH another file (refused by the validator) and cannot see a
+// table that exists only in another scope's file.
+func TestManager_AttachRefusedAndCannotSeeOtherFile(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	victim := agentKey("t1", "victim")
+	attacker := agentKey("t1", "attacker")
+
+	// Seed a secret table in the victim file.
+	if _, err := m.Exec(ctx, victim, "CREATE TABLE secrets (s TEXT)", nil, 0); err != nil {
+		t.Fatalf("create victim: %v", err)
+	}
+	if _, err := m.Exec(ctx, victim, "INSERT INTO secrets VALUES ('topsecret')", nil, 0); err != nil {
+		t.Fatalf("insert victim: %v", err)
+	}
+	victimPath, err := victim.keyPath(m.cfg.Root)
+	if err != nil {
+		t.Fatalf("keyPath: %v", err)
+	}
+
+	// The attacker scope tries to ATTACH the victim file — the validator must
+	// refuse it before it reaches the driver.
+	attachStmt := "ATTACH DATABASE '" + victimPath + "' AS v"
+	if _, err := m.Exec(ctx, attacker, attachStmt, nil, 0); err == nil {
+		t.Fatal("ATTACH was permitted; want a validator refusal")
+	} else if _, ok := err.(*ErrStatement); !ok {
+		t.Fatalf("ATTACH error = %T (%v); want *ErrStatement", err, err)
+	}
+
+	// And the attacker's own file does not contain the victim's table.
+	if _, err := m.Query(ctx, attacker, "SELECT s FROM secrets", nil); err == nil {
+		t.Fatal("attacker scope saw the victim's 'secrets' table; want no such table")
+	}
+}
+
+// TestManager_QueryTruncatesAtMaxRows asserts a SELECT exceeding MaxRows
+// returns Truncated=true with exactly MaxRows rows.
+func TestManager_QueryTruncatesAtMaxRows(t *testing.T) {
+	m := newTestManager(t, Config{MaxRows: 3})
+	ctx := context.Background()
+	key := agentKey("t1", "rows")
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE n (i INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := m.Exec(ctx, key, "INSERT INTO n VALUES (?)", []any{i}, 0); err != nil {
+			t.Fatalf("insert %d: %v", i, err)
+		}
+	}
+	q, err := m.Query(ctx, key, "SELECT i FROM n ORDER BY i", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if !q.Truncated {
+		t.Fatal("Truncated = false, want true")
+	}
+	if len(q.Rows) != 3 {
+		t.Fatalf("rows = %d, want 3 (MaxRows)", len(q.Rows))
+	}
+}
+
+// TestManager_WritePastQuotaRefused asserts a write that would exceed the
+// quota is refused (quota checked before the write).
+func TestManager_WritePastQuotaRefused(t *testing.T) {
+	// 32 KiB quota — a couple of pages plus a fat row pushes past it.
+	m := newTestManager(t, Config{QuotaBytes: 32 * 1024})
+	ctx := context.Background()
+	key := agentKey("t1", "quota")
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE big (b TEXT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	blob := strings.Repeat("x", 8*1024)
+	var lastErr error
+	// Insert until the quota refuses; bounded loop so a never-refusing bug
+	// fails the test instead of hanging.
+	for i := 0; i < 50; i++ {
+		_, lastErr = m.Exec(ctx, key, "INSERT INTO big VALUES (?)", []any{blob}, 0)
+		if lastErr != nil {
+			break
+		}
+	}
+	if lastErr == nil {
+		t.Fatal("no write was refused; want a quota error after the file grew")
+	}
+	if !strings.Contains(lastErr.Error(), "quota") {
+		t.Fatalf("error = %v; want a quota refusal", lastErr)
+	}
+}
+
+// TestManager_QuotaOverrideTighterThanDefault asserts the per-call override
+// is honored over the Manager default.
+func TestManager_QuotaOverrideTighterThanDefault(t *testing.T) {
+	m := newTestManager(t, Config{QuotaBytes: 0}) // no manager default
+	ctx := context.Background()
+	key := agentKey("t1", "override")
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE big (b TEXT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	blob := strings.Repeat("x", 8*1024)
+	var lastErr error
+	for i := 0; i < 50; i++ {
+		_, lastErr = m.Exec(ctx, key, "INSERT INTO big VALUES (?)", []any{blob}, 32*1024)
+		if lastErr != nil {
+			break
+		}
+	}
+	if lastErr == nil || !strings.Contains(lastErr.Error(), "quota") {
+		t.Fatalf("override quota not enforced; lastErr = %v", lastErr)
+	}
+}
+
+// TestManager_RunScopeFileLifecycle asserts an ephemeral run scope file is
+// created on write and removed by DropRunScope.
+func TestManager_RunScopeFileLifecycle(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := ScopeKey{Scope: "run", ScopeID: "run-abc123"}
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE scratch (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	path, err := key.keyPath(m.cfg.Root)
+	if err != nil {
+		t.Fatalf("keyPath: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("run-scope file should exist after write: %v", err)
+	}
+
+	removed, err := m.DropRunScope("run-abc123")
+	if err != nil {
+		t.Fatalf("DropRunScope: %v", err)
+	}
+	if !removed {
+		t.Fatal("DropRunScope removed = false, want true")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("run-scope file should be gone after drop; stat err = %v", err)
+	}
+}
+
+// TestManager_DropRunScopeIsNoopWhenAbsent asserts dropping a never-written
+// run scope is a no-op success.
+func TestManager_DropRunScopeIsNoopWhenAbsent(t *testing.T) {
+	m := newTestManager(t, Config{})
+	removed, err := m.DropRunScope("never-existed")
+	if err != nil {
+		t.Fatalf("DropRunScope: %v", err)
+	}
+	if removed {
+		t.Fatal("removed = true for an absent scope, want false")
+	}
+}
+
+// TestKeyPath_MaliciousScopeIDStaysUnderRoot is the path-escape regression:
+// a scope id like "../../etc/x" must NOT escape Root — the derived path must
+// remain strictly inside Root after Clean.
+func TestKeyPath_MaliciousScopeIDStaysUnderRoot(t *testing.T) {
+	root := t.TempDir()
+	for _, evil := range []string{
+		"../../etc/passwd",
+		"..",
+		"a/../../b",
+		"/abs/path",
+		"foo/bar",
+	} {
+		key := ScopeKey{Tenant: "t1", Scope: "agent", ScopeID: evil}
+		path, err := key.keyPath(root)
+		if err != nil {
+			// An error is an acceptable defence (e.g. empty) — but these are
+			// non-empty, so we expect a path.
+			t.Fatalf("keyPath(%q) errored unexpectedly: %v", evil, err)
+		}
+		clean := filepath.Clean(path)
+		rel, err := filepath.Rel(root, clean)
+		if err != nil {
+			t.Fatalf("Rel(%q): %v", clean, err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			t.Fatalf("scope id %q escaped Root: path=%q rel=%q", evil, clean, rel)
+		}
+	}
+}
+
+// TestKeyPath_DistinctSanitizedIDsDoNotCollide asserts two ids that map to
+// the same replaced form land on distinct files (the hash suffix).
+func TestKeyPath_DistinctSanitizedIDsDoNotCollide(t *testing.T) {
+	root := t.TempDir()
+	p1, err := ScopeKey{Tenant: "t", Scope: "agent", ScopeID: "a/b"}.keyPath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := ScopeKey{Tenant: "t", Scope: "agent", ScopeID: "a.b"}.keyPath(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Fatalf("distinct ids collided on one file: %q", p1)
+	}
+}
+
+// sanity: the underlying driver name matches the store's, so a scope DB is
+// the same engine as the main store (just a different file).
+func TestOpenScopeDB_UsesSqliteDriver(t *testing.T) {
+	dir := t.TempDir()
+	db, err := openScopeDB(filepath.Join(dir, "x.db"))
+	if err != nil {
+		t.Fatalf("openScopeDB: %v", err)
+	}
+	defer db.Close()
+	var one int
+	if err := db.QueryRow("SELECT 1").Scan(&one); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	if one != 1 {
+		t.Fatalf("SELECT 1 = %d", one)
+	}
+}

--- a/internal/sqlmem/validate.go
+++ b/internal/sqlmem/validate.go
@@ -1,0 +1,311 @@
+// Package sqlmem implements RFC AA SQL Memory: a runtime-hosted, per-scope
+// sqlite database that AUTHORIZED agents run arbitrary SQL against, isolated
+// from the main loomcycle store.
+//
+// The security model is NOT injection defence (agents are authorized to run
+// SQL) — it is preventing an agent from ESCAPING its per-scope sqlite file
+// (reading/writing arbitrary host files via ATTACH / VACUUM INTO, or running
+// arbitrary code via load_extension) and from exhausting resources.
+//
+// The DEFAULT sqlite driver loomcycle links — modernc.org/sqlite (pure-Go) —
+// exposes NO sqlite3_set_authorizer, so there is no runtime statement
+// interception. The PRIMARY, driver-agnostic defence is therefore this
+// Go-layer parsed statement validator, run BEFORE any agent SQL reaches the
+// driver. Per-scope file isolation (a separate .db per scope) is the backstop:
+// even a missed escape can only ever touch that one scope's file. (The cgo
+// `mattn/go-sqlite3` vec build additionally exposes RegisterAuthorizer — a
+// future hardening upgrade, not the Phase-1 floor.)
+package sqlmem
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ErrStatement is returned by validateStatement when an agent statement is
+// refused by the security floor. The message is model-facing (surfaced as
+// is_error so the agent can self-correct).
+type ErrStatement struct{ Reason string }
+
+func (e *ErrStatement) Error() string { return e.Reason }
+
+func refuse(format string, a ...any) error { return &ErrStatement{Reason: fmt.Sprintf(format, a...)} }
+
+// loadExtensionRe matches a load_extension(...) function call anywhere in a
+// statement (it can be nested inside an otherwise-allowed SELECT/INSERT), with
+// optional whitespace before the paren. It covers the BARE name AND sqlite's
+// three quoted-identifier forms — "load_extension", [load_extension],
+// `load_extension` — because sqlite resolves a quoted identifier in call
+// position as the function name, so `SELECT "load_extension"('x')` is a genuine
+// call. (Caught here even though the default modernc driver already disables
+// extension loading: this validator is the driver-AGNOSTIC floor, so it must
+// hold for a future cgo / mattn vec build that enables extensions — otherwise
+// the bypass would become a live RCE on a driver swap.) Word-boundary anchored
+// on the bare form so a column like `my_load_extension_flag` is NOT matched.
+const sqlBacktick = "`"
+
+var loadExtensionRe = regexp.MustCompile(
+	`(?i)(?:\bload_extension\b|"load_extension"|\[load_extension\]|` + sqlBacktick + `load_extension` + sqlBacktick + `)\s*\(`,
+)
+
+// leadingKeywordRe captures the first SQL keyword (letters/underscore) after
+// comment-stripping + trimming.
+var leadingKeywordRe = regexp.MustCompile(`^\s*([a-zA-Z_]+)`)
+
+// dataModifyingRe matches a data-modifying / DDL keyword as a whole word —
+// used to keep sql_query (read-only) from smuggling writes via a CTE
+// (`WITH x AS (...) DELETE FROM ...`, which sqlite permits).
+var dataModifyingRe = regexp.MustCompile(`(?i)\b(insert|update|delete|replace|create|drop|alter|truncate)\b`)
+
+// execLeadingAllowed is the closed allow-set of leading keywords for sql_exec
+// (DDL + DML). Transactions (BEGIN/COMMIT/…) are excluded — Phase 1 is one
+// auto-committed statement per call.
+var execLeadingAllowed = map[string]bool{
+	"create": true, "drop": true, "alter": true,
+	"insert": true, "update": true, "delete": true, "replace": true,
+	"with": true, // a CTE that ends in INSERT/UPDATE/DELETE is a valid write
+}
+
+// deniedLeading is the set of statement-leading keywords that can ONLY appear
+// at the top of a statement and are always refused: they reach outside the
+// scope file (ATTACH/DETACH), copy it out (VACUUM [INTO]), or mutate engine
+// state (PRAGMA — the runtime sets the safe pragmas at open; agents never need
+// them). Reattach/transactions are likewise out of scope for Phase 1.
+var deniedLeading = map[string]string{
+	"attach":    "ATTACH is denied — it can read/write arbitrary host files outside this scope",
+	"detach":    "DETACH is denied",
+	"vacuum":    "VACUUM is denied — VACUUM INTO can copy this database to an arbitrary path",
+	"pragma":    "PRAGMA is denied — the runtime sets the safe pragmas; agents cannot change engine state",
+	"begin":     "explicit transactions are not supported (each call is one auto-committed statement)",
+	"commit":    "explicit transactions are not supported (each call is one auto-committed statement)",
+	"rollback":  "explicit transactions are not supported (each call is one auto-committed statement)",
+	"savepoint": "explicit transactions are not supported",
+	"release":   "explicit transactions are not supported",
+}
+
+// validateStatement enforces the Phase-1 SQL security floor on one
+// agent-authored statement. readOnly (sql_query) additionally requires a
+// read-only SELECT/WITH-read statement. Returns *ErrStatement on refusal.
+//
+// Steps: strip comments → reject empty → reject multi-statement → reject
+// load_extension anywhere → check the leading keyword against the deny-set and
+// the per-op allow-set.
+func validateStatement(raw string, readOnly bool) error {
+	stripped := stripComments(raw)
+	trimmed := strings.TrimSpace(stripped)
+	if trimmed == "" {
+		return refuse("empty SQL statement")
+	}
+
+	// One statement per call (Phase 1). A single trailing ';' is fine; any
+	// content after a ';' is a second statement and is refused — both to keep
+	// the auto-commit-one-statement contract and to block `SELECT 1; ATTACH …`.
+	// modernc executes a second ';'-separated statement, so this guard is
+	// LOAD-BEARING (not belt-and-braces). NOTE: it is ALSO what blocks
+	// CREATE TRIGGER (a trigger body has a mandatory inner ';'), which closes
+	// the deferred-payload-via-trigger escape (a trigger that ATTACHes on later
+	// fire). Anyone relaxing the multi-statement rule to support triggers MUST
+	// add a trigger-body scan first.
+	if idx := indexOfStatementSeparator(trimmed); idx >= 0 {
+		rest := strings.TrimSpace(trimmed[idx+1:])
+		if rest != "" {
+			return refuse("only one SQL statement per call is allowed (found a ';' separating multiple statements)")
+		}
+	}
+
+	// load_extension(...) can be nested inside an otherwise-allowed statement
+	// → scan the whole comment-stripped text. Single-quoted string LITERALS are
+	// masked first: a value like 'see load_extension(x) in the docs' is data,
+	// not a call (sqlite never treats a '…' literal as a function name), so it
+	// must not false-positive. Identifier-quoted forms ("load_extension" etc.)
+	// are kept verbatim — they ARE catchable function names (handled by the
+	// regex alternatives).
+	if loadExtensionRe.MatchString(maskStringLiterals(trimmed)) {
+		return refuse("load_extension is denied — loading a sqlite extension runs arbitrary native code")
+	}
+
+	m := leadingKeywordRe.FindStringSubmatch(trimmed)
+	if m == nil {
+		return refuse("could not parse a leading SQL keyword")
+	}
+	kw := strings.ToLower(m[1])
+
+	if reason, denied := deniedLeading[kw]; denied {
+		return refuse("%s", reason)
+	}
+
+	if readOnly {
+		// sql_query is read-only: SELECT, or a WITH whose body is a SELECT
+		// (NOT a data-modifying CTE).
+		if kw != "select" && kw != "with" {
+			return refuse("sql_query only runs read-only statements (SELECT / WITH … SELECT); use sql_exec for writes")
+		}
+		if kw == "with" && dataModifyingRe.MatchString(trimmed) {
+			return refuse("sql_query is read-only — this WITH statement contains a data-modifying clause; use sql_exec")
+		}
+		return nil
+	}
+
+	// sql_exec: DDL/DML only, from the closed allow-set.
+	if !execLeadingAllowed[kw] {
+		return refuse("sql_exec only runs DDL/DML (CREATE/DROP/ALTER/INSERT/UPDATE/DELETE/REPLACE/WITH); %q is not allowed", kw)
+	}
+	return nil
+}
+
+// stripComments removes -- line comments and /* */ block comments WITHOUT
+// removing comment-like sequences inside string/identifier literals (a `--`
+// inside '...' or "..." is data, not a comment). Conservative: when in doubt it
+// keeps text (the leading-keyword + deny checks still apply to whatever
+// remains).
+func stripComments(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	const (
+		normal = iota
+		inSingle
+		inDouble
+		inBracket // [identifier]
+		inBacktick
+		inLine  // -- ...
+		inBlock // /* ... */
+	)
+	state := normal
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch state {
+		case normal:
+			switch {
+			case c == '-' && i+1 < len(s) && s[i+1] == '-':
+				state = inLine
+				i++
+			case c == '/' && i+1 < len(s) && s[i+1] == '*':
+				state = inBlock
+				i++
+			case c == '\'':
+				state = inSingle
+				b.WriteByte(c)
+			case c == '"':
+				state = inDouble
+				b.WriteByte(c)
+			case c == '[':
+				state = inBracket
+				b.WriteByte(c)
+			case c == '`':
+				state = inBacktick
+				b.WriteByte(c)
+			default:
+				b.WriteByte(c)
+			}
+		case inLine:
+			if c == '\n' {
+				state = normal
+				b.WriteByte(c)
+			}
+		case inBlock:
+			if c == '*' && i+1 < len(s) && s[i+1] == '/' {
+				state = normal
+				i++
+				b.WriteByte(' ') // a block comment is a token separator
+			}
+		case inSingle:
+			b.WriteByte(c)
+			if c == '\'' {
+				state = normal
+			}
+		case inDouble:
+			b.WriteByte(c)
+			if c == '"' {
+				state = normal
+			}
+		case inBracket:
+			b.WriteByte(c)
+			if c == ']' {
+				state = normal
+			}
+		case inBacktick:
+			b.WriteByte(c)
+			if c == '`' {
+				state = normal
+			}
+		}
+	}
+	return b.String()
+}
+
+// maskStringLiterals blanks the CONTENT of single-quoted string literals
+// (keeping the quotes) so a function-name/keyword scan can't false-positive on
+// a value. A ” escaped-quote is handled by the open/close toggle (the doubled
+// quote re-enters the string state). Operates on already comment-stripped text.
+// Only single quotes are masked: '…' is ALWAYS a string in sqlite, whereas
+// "…"/[…]/`…` are identifiers (a quoted FUNCTION name we want the scan to see).
+func maskStringLiterals(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	inStr := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			if c == '\'' {
+				inStr = false
+				b.WriteByte(c)
+			}
+			continue // drop string content
+		}
+		if c == '\'' {
+			inStr = true
+		}
+		b.WriteByte(c)
+	}
+	return b.String()
+}
+
+// indexOfStatementSeparator returns the index of the first ';' that is NOT
+// inside a string/identifier literal, or -1. Used to detect multi-statement
+// input. Mirrors stripComments' literal-awareness so a ';' inside '…' is data.
+func indexOfStatementSeparator(s string) int {
+	const (
+		normal = iota
+		inSingle
+		inDouble
+		inBracket
+		inBacktick
+	)
+	state := normal
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch state {
+		case normal:
+			switch c {
+			case ';':
+				return i
+			case '\'':
+				state = inSingle
+			case '"':
+				state = inDouble
+			case '[':
+				state = inBracket
+			case '`':
+				state = inBacktick
+			}
+		case inSingle:
+			if c == '\'' {
+				state = normal
+			}
+		case inDouble:
+			if c == '"' {
+				state = normal
+			}
+		case inBracket:
+			if c == ']' {
+				state = normal
+			}
+		case inBacktick:
+			if c == '`' {
+				state = normal
+			}
+		}
+	}
+	return -1
+}

--- a/internal/sqlmem/validate_test.go
+++ b/internal/sqlmem/validate_test.go
@@ -1,0 +1,138 @@
+package sqlmem
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateStatement_EscapeBlocked is the RFC AA security floor: the escape
+// vectors (ATTACH / load_extension / writable_schema PRAGMA / VACUUM INTO) and
+// multi-statement smuggling are all refused, on BOTH ops. This is the
+// driver-agnostic primary defence (modernc has no authorizer).
+func TestValidateStatement_EscapeBlocked(t *testing.T) {
+	denied := []struct {
+		name string
+		sql  string
+	}{
+		{"attach", `ATTACH DATABASE '/var/lib/loomcycle/loomcycle.db' AS main2`},
+		{"attach-lower", `attach database 'x.db' as y`},
+		{"detach", `DETACH DATABASE x`},
+		{"vacuum-into", `VACUUM INTO '/tmp/exfil.db'`},
+		{"vacuum-bare", `VACUUM`},
+		{"pragma-writable-schema", `PRAGMA writable_schema=ON`},
+		{"pragma-any", `PRAGMA table_info(secrets)`},
+		{"load-extension-select", `SELECT load_extension('/tmp/evil.so')`},
+		{"load-extension-spaced", `SELECT load_extension ('x')`},
+		{"load-extension-exec", `INSERT INTO t VALUES (load_extension('x'))`},
+		// M-1: sqlite resolves a quoted identifier in call position as the
+		// function name, so these are genuine load_extension calls — the
+		// driver-agnostic floor must catch them (latent RCE on a vec build).
+		{"load-extension-dquoted", `SELECT "load_extension"('/tmp/evil.so')`},
+		{"load-extension-bracket", `SELECT [load_extension]('/tmp/evil.so')`},
+		{"load-extension-backtick", "SELECT `load_extension`('/tmp/evil.so')"},
+		{"multi-stmt-attach", `SELECT 1; ATTACH DATABASE 'x' AS y`},
+		{"multi-stmt-drop", `CREATE TABLE t(a); DROP TABLE other`},
+		{"begin-txn", `BEGIN`},
+		{"commit-txn", `COMMIT`},
+		{"comment-hidden-attach", `/* harmless */ ATTACH DATABASE 'x' AS y`},
+		{"line-comment-attach", "-- note\nATTACH DATABASE 'x' AS y"},
+	}
+	for _, tc := range denied {
+		t.Run("exec/"+tc.name, func(t *testing.T) {
+			if err := validateStatement(tc.sql, false); err == nil {
+				t.Errorf("sql_exec MUST refuse %q", tc.sql)
+			} else if !errors.As(err, new(*ErrStatement)) {
+				t.Errorf("refusal should be *ErrStatement, got %T", err)
+			}
+		})
+		t.Run("query/"+tc.name, func(t *testing.T) {
+			if err := validateStatement(tc.sql, true); err == nil {
+				t.Errorf("sql_query MUST refuse %q", tc.sql)
+			}
+		})
+	}
+}
+
+// TestValidateStatement_AllowsLegitimate confirms the floor doesn't over-block:
+// ordinary DDL/DML on sql_exec and SELECT/CTE-read on sql_query pass.
+func TestValidateStatement_AllowsLegitimate(t *testing.T) {
+	exec := []string{
+		`CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)`,
+		`CREATE INDEX idx_notes_body ON notes(body)`,
+		`INSERT INTO notes (body) VALUES ('hello')`,
+		`UPDATE notes SET body = 'x' WHERE id = 1`,
+		`DELETE FROM notes WHERE id = 1`,
+		`DROP TABLE notes`,
+		`ALTER TABLE notes ADD COLUMN tag TEXT`,
+		"WITH new(b) AS (VALUES ('a'),('b')) INSERT INTO notes(body) SELECT b FROM new",
+		`INSERT INTO notes (body) VALUES ('a'); `, // trailing ';' + whitespace is fine
+	}
+	for _, s := range exec {
+		if err := validateStatement(s, false); err != nil {
+			t.Errorf("sql_exec should allow %q, got: %v", s, err)
+		}
+	}
+
+	query := []string{
+		`SELECT id, body FROM notes WHERE body LIKE 'h%' ORDER BY id LIMIT 10`,
+		`select count(*) from notes`,
+		`WITH recent AS (SELECT * FROM notes ORDER BY id DESC LIMIT 5) SELECT body FROM recent`,
+		`SELECT body FROM notes -- inline comment is fine`,
+		// A value MENTIONING load_extension(...) is data, not a call — must
+		// not false-positive (the function scan masks single-quoted strings).
+		`SELECT body FROM notes WHERE body = 'how to use load_extension(x)'`,
+		`SELECT * FROM notes WHERE note LIKE '%attach database%'`,
+	}
+	// And the same string-literal values are fine to WRITE (no false positive
+	// from the keyword/function scans on quoted data).
+	if err := validateStatement(`INSERT INTO notes (body) VALUES ('see load_extension(x) docs')`, false); err != nil {
+		t.Errorf("storing text that mentions load_extension must be allowed, got: %v", err)
+	}
+	for _, s := range query {
+		if err := validateStatement(s, true); err != nil {
+			t.Errorf("sql_query should allow %q, got: %v", s, err)
+		}
+	}
+}
+
+// TestValidateStatement_QueryIsReadOnly locks the read-only contract: sql_query
+// refuses writes — including a data-modifying CTE that smuggles a DELETE.
+func TestValidateStatement_QueryIsReadOnly(t *testing.T) {
+	writes := []string{
+		`INSERT INTO notes (body) VALUES ('x')`,
+		`UPDATE notes SET body='x'`,
+		`DELETE FROM notes`,
+		`CREATE TABLE t(a)`,
+		`DROP TABLE notes`,
+		`WITH x AS (SELECT 1) DELETE FROM notes`, // CTE-smuggled write
+	}
+	for _, s := range writes {
+		if err := validateStatement(s, true); err == nil {
+			t.Errorf("sql_query MUST refuse the write %q", s)
+		}
+		// …but the same statements are fine on sql_exec (except the ones the
+		// deny-set/allow-set reject for other reasons — these are all writes).
+	}
+}
+
+// TestStripComments_LiteralAware confirms a comment marker INSIDE a string
+// literal is preserved (it's data), so a value like '-- x' or '/* y */' isn't
+// silently truncated.
+func TestStripComments_LiteralAware(t *testing.T) {
+	cases := map[string]string{
+		`SELECT '-- not a comment'`:    `SELECT '-- not a comment'`,
+		`SELECT '/* not a comment */'`: `SELECT '/* not a comment */'`,
+		`SELECT 1 -- real comment`:     `SELECT 1 `,
+		`SELECT 1 /* real */ + 2`:      `SELECT 1   + 2`,
+		`INSERT INTO t VALUES ('a;b')`: `INSERT INTO t VALUES ('a;b')`,
+	}
+	for in, want := range cases {
+		if got := stripComments(in); got != want {
+			t.Errorf("stripComments(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// A ';' inside a string literal is NOT a statement separator.
+	if validateStatement(`INSERT INTO t VALUES ('a;b')`, false) != nil {
+		t.Errorf("a ';' inside a string literal must not trip the multi-statement guard")
+	}
+}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/audit"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	memrank "github.com/denn-gubsky/loomcycle/internal/memory"
@@ -17,6 +18,8 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/inprocess"
 	"github.com/denn-gubsky/loomcycle/internal/memory/backends/mem9"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/redact"
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
@@ -103,6 +106,29 @@ type Memory struct {
 	// in-process (a non-allowlisted key must never produce a silent
 	// unauthenticated call).
 	EnvAllowlist map[string]bool
+
+	// SqlMem is the RFC AA SQL Memory manager backing sql_query / sql_exec.
+	// Nil = the SQL ops refuse with "SQL Memory is not enabled on this
+	// server" (the subsystem is off by default; main.go sets it only when
+	// storage.sqlmem_enabled). The k/v ops are unaffected.
+	SqlMem *sqlmem.Manager
+
+	// SqlAudit records one append-only event per sql_query / sql_exec
+	// (WHO ran WHAT op against WHICH scope; the statement is redacted, or
+	// omitted in metadata mode). Nil = SQL ops are not audited (best-effort:
+	// an audit failure never blocks the SQL op).
+	SqlAudit audit.Sink
+
+	// SqlAuditMode is "full" (record the redacted statement) or "metadata"
+	// (record op/scope/row counts only). Empty defaults to "full".
+	SqlAuditMode string
+
+	// Redactor masks operator infra-secrets out of an audited SQL statement
+	// before it is written (full mode only). Nil-safe — a nil Redactor
+	// leaves the statement unchanged (the validator already blocks the
+	// dangerous statement shapes; redaction is defence for incidental
+	// secret-bearing literals in agent SQL).
+	Redactor *redact.Redactor
 }
 
 // backend resolves the memrank.Backend the data ops route through,
@@ -339,13 +365,14 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 	`Values are JSON. Optional TTL is in seconds. ` +
 	`v0.9.0: pass embed=true with embed_text on set to enable semantic search; use op=search with query to find rows by similarity. ` +
 	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible. ` +
-	`add / recall (memory-layer backends only): add ingests conversation messages (the backend may LLM-extract durable facts); recall is a natural-language semantic search over those facts. These require a memory-layer backend (memory_backend kind=mem9); against the default key/value store they return capability_unsupported. Unlike set/get, add does not store value-at-key and is often async — do not assume read-after-write.`
+	`add / recall (memory-layer backends only): add ingests conversation messages (the backend may LLM-extract durable facts); recall is a natural-language semantic search over those facts. These require a memory-layer backend (memory_backend kind=mem9); against the default key/value store they return capability_unsupported. Unlike set/get, add does not store value-at-key and is often async — do not assume read-after-write. ` +
+	`RFC AA SQL Memory: sql_query runs a read-only SELECT and sql_exec runs a single DDL/DML statement (CREATE/INSERT/UPDATE/DELETE) against a per-scope sqlite database SEPARATE from the rest of your memory. Pass statement (one statement, no ATTACH/PRAGMA/load_extension/multiple statements) and optional positional args for ? placeholders. scope selects the database: agent (this agent, durable), user (this end-user, durable), or run (ephemeral, dropped when the run ends). Requires sql_scopes on the agent AND the server-side subsystem enabled.`
 
 const memoryInputSchema = `{
   "type": "object",
   "properties": {
-    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall"], "description": "Which operation to perform."},
-    "scope":      {"type": "string", "enum": ["agent","user"], "description": "Which keyspace: this agent's (cross-run, cross-user) or this user's (cross-agent)."},
+    "op":         {"type": "string", "enum": ["get","set","delete","list","incr","search","merge","append_dedupe","bounded_list","add","recall","sql_query","sql_exec"], "description": "Which operation to perform."},
+    "scope":      {"type": "string", "enum": ["agent","user","run"], "description": "Which keyspace/database. agent: this agent's (cross-run, cross-user). user: this end-user's (cross-agent). run: ephemeral per-run, dropped at run end — SQL ops only."},
     "key":        {"type": "string", "description": "The entry's key. Required for get / set / delete / incr / merge / append_dedupe / bounded_list."},
     "value":      {"description": "The JSON value. Required for set / merge / append_dedupe / bounded_list. For merge: a JSON object whose fields overlay the existing object. For append_dedupe / bounded_list: the item to append."},
     "delta":      {"type": "integer", "description": "Increment delta for incr (default 1, may be negative)."},
@@ -361,7 +388,10 @@ const memoryInputSchema = `{
     "messages":   {"type": "array", "description": "add-only (memory-layer backends): conversation turns to ingest. Each item is {role, content}.", "items": {"type": "object", "properties": {"role": {"type": "string", "enum": ["user","assistant","system"]}, "content": {"type": "string"}}, "required": ["role","content"]}},
     "infer":      {"type": "boolean", "description": "add-only: when true (default) the memory-layer backend LLM-extracts durable facts from the messages; false stores them verbatim."},
     "metadata":   {"type": "object", "description": "add-only: opaque key/value context attached to the ingestion.", "additionalProperties": {"type": "string"}},
-    "threshold":  {"type": "number", "description": "recall-only: 0..1 relevance floor for returned facts (0 = backend default)."}
+    "threshold":  {"type": "number", "description": "recall-only: 0..1 relevance floor for returned facts (0 = backend default)."},
+    "statement":  {"type": "string", "description": "sql_query / sql_exec: ONE SQL statement. sql_query is read-only (SELECT / WITH … SELECT); sql_exec is DDL/DML (CREATE/INSERT/UPDATE/DELETE/etc.). ATTACH, PRAGMA, load_extension, transactions, and multiple statements are refused."},
+    "args":       {"type": "array", "description": "sql_query / sql_exec: positional bind parameters for ? placeholders in statement.", "items": {}},
+    "timeout_ms": {"type": "integer", "description": "sql_query / sql_exec: reserved — the server-configured statement timeout is authoritative in this version."}
   },
   "required": ["op","scope"],
   "additionalProperties": false
@@ -400,6 +430,18 @@ type memoryInput struct {
 	// Threshold is the 0..1 relevance floor for `recall` (RFC K). 0 = the
 	// backend's default.
 	Threshold float64 `json:"threshold,omitempty"`
+
+	// --- RFC AA SQL Memory (sql_query / sql_exec) ---
+	// Statement is the single SQL statement to run (validated by the
+	// Go-layer security floor before it reaches the driver).
+	Statement string `json:"statement,omitempty"`
+	// Args are positional bind parameters for `?` placeholders in Statement.
+	Args []any `json:"args,omitempty"`
+	// TimeoutMs is a per-call statement timeout request. RESERVED in Phase 1:
+	// the operator-configured LOOMCYCLE_SQLMEM_STATEMENT_TIMEOUT_MS is
+	// authoritative (a per-call override that could only ever tighten, never
+	// widen, is a Phase-2 refinement). Accepted so the wire shape is stable.
+	TimeoutMs int `json:"timeout_ms,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -422,6 +464,18 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 	if err := json.Unmarshal(raw, &in); err != nil {
 		return errResult(fmt.Sprintf("invalid input JSON: %s", err)), nil
 	}
+
+	// RFC AA SQL Memory ops resolve scope through resolveSqlScope (their own
+	// {agent,user,run} gate keyed off SqlMemPolicy), NOT the k/v resolveScope
+	// — which is gated on memory_scopes and rejects `run`. Dispatch them
+	// before the k/v scope resolution so a SQL op never trips the k/v gate.
+	switch in.Op {
+	case "sql_query":
+		return m.execSqlQuery(ctx, in)
+	case "sql_exec":
+		return m.execSqlExec(ctx, in)
+	}
+
 	scope, scopeID, err := m.resolveScope(ctx, in.Scope)
 	if err != nil {
 		return errResult(err.Error()), nil
@@ -453,7 +507,7 @@ func (m *Memory) Execute(ctx context.Context, raw json.RawMessage) (tools.Result
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
-		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall)", in.Op)), nil
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: get, set, delete, list, incr, search, merge, append_dedupe, bounded_list, add, recall, sql_query, sql_exec)", in.Op)), nil
 	}
 }
 
@@ -489,6 +543,167 @@ func (m *Memory) resolveScope(ctx context.Context, requested string) (store.Memo
 	default:
 		return "", "", fmt.Errorf("Memory tool: unknown scope %q (only agent / user are supported in v0.8.0)", requested)
 	}
+}
+
+// resolveSqlScope is the RFC AA SQL Memory scope gate. It is SEPARATE from
+// resolveScope: SQL scopes are {agent, user, run} (run has no k/v analogue),
+// and the gate is the agent's sql_scopes ACL (SqlMemPolicy), not memory_scopes.
+//
+// Default-deny: an empty sql_scopes refuses ALL SQL. The scope_id is resolved
+// SERVER-SIDE from the run context (never the wire) exactly like resolveScope:
+//
+//	agent → tools.AgentName(ctx)
+//	user  → tools.RunIdentity(ctx).UserID
+//	run   → tools.RunIdentity(ctx).RootRunID
+//
+// so one agent's run can never read another agent's / user's / run's SQL DB.
+//
+// The run scope keys off RootRunID (the TOP-LEVEL run at the root of the
+// spawn tree), NOT the per-sub-run RunID: that way the whole tree shares one
+// ephemeral DB, and the server's run-completion drop (which targets
+// meta.RootRunID) reclaims exactly the file the tree used — keying off the
+// per-sub-run id instead would orphan a sub-agent's DB (never dropped) and
+// hide the parent's tables from a child granted `run`. Mirrors how RFC AH
+// ephemeral volumes scope to RootRunID.
+func (m *Memory) resolveSqlScope(ctx context.Context, requested string) (scope, scopeID string, err error) {
+	if requested == "" {
+		return "", "", fmt.Errorf("missing required field: scope (one of: agent, user, run)")
+	}
+	pol := tools.SqlMemPolicy(ctx)
+	if len(pol.AllowedScopes) == 0 {
+		return "", "", fmt.Errorf("Memory tool: this agent has no sql_scopes configured — add `sql_scopes: [agent]` (and/or user, run) to the agent yaml")
+	}
+	if !contains(pol.AllowedScopes, requested) {
+		return "", "", fmt.Errorf("Memory tool: sql scope %q not in this agent's sql_scopes %v", requested, pol.AllowedScopes)
+	}
+	switch requested {
+	case "agent":
+		name := tools.AgentName(ctx)
+		if name == "" {
+			return "", "", fmt.Errorf("Memory tool: sql scope=agent requires a yaml-declared agent (no agent name on the run context)")
+		}
+		return "agent", name, nil
+	case "user":
+		uid := tools.RunIdentity(ctx).UserID
+		if uid == "" {
+			return "", "", fmt.Errorf("Memory tool: sql scope=user requires a user_id on the run (caller must supply user_id when starting the run)")
+		}
+		return "user", uid, nil
+	case "run":
+		// RootRunID roots the spawn tree; fall back to RunID for a run started
+		// outside the volume-aware run-start path (RootRunID unset there).
+		ident := tools.RunIdentity(ctx)
+		rid := ident.RootRunID
+		if rid == "" {
+			rid = tools.RunID(ctx)
+		}
+		if rid == "" {
+			return "", "", fmt.Errorf("Memory tool: sql scope=run requires an active run (no run id on the context)")
+		}
+		return "run", rid, nil
+	default:
+		return "", "", fmt.Errorf("Memory tool: unknown sql scope %q (want one of: agent, user, run)", requested)
+	}
+}
+
+// execSqlQuery runs a read-only SELECT against the resolved scope DB.
+func (m *Memory) execSqlQuery(ctx context.Context, in memoryInput) (tools.Result, error) {
+	scope, scopeID, err := m.resolveSqlScope(ctx, in.Scope)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	if m.SqlMem == nil {
+		return errResult("SQL Memory is not enabled on this server (set storage.sqlmem_enabled / LOOMCYCLE_SQLMEM_ENABLED=1)"), nil
+	}
+	if strings.TrimSpace(in.Statement) == "" {
+		return errResult("sql_query: missing required field: statement"), nil
+	}
+	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
+	start := time.Now()
+	res, qerr := m.SqlMem.Query(ctx, key, in.Statement, in.Args)
+	durMs := time.Since(start).Milliseconds()
+	if qerr != nil {
+		m.auditSql(ctx, "sql_query", scope, scopeID, in.Statement, 0, durMs, qerr)
+		return errResult(fmt.Sprintf("sql_query: %s", qerr)), nil
+	}
+	m.auditSql(ctx, "sql_query", scope, scopeID, in.Statement, int64(len(res.Rows)), durMs, nil)
+	return okJSON(map[string]any{
+		"columns":   res.Columns,
+		"rows":      res.Rows,
+		"truncated": res.Truncated,
+	})
+}
+
+// execSqlExec runs a DDL/DML statement against the resolved scope DB.
+func (m *Memory) execSqlExec(ctx context.Context, in memoryInput) (tools.Result, error) {
+	scope, scopeID, err := m.resolveSqlScope(ctx, in.Scope)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	if m.SqlMem == nil {
+		return errResult("SQL Memory is not enabled on this server (set storage.sqlmem_enabled / LOOMCYCLE_SQLMEM_ENABLED=1)"), nil
+	}
+	if strings.TrimSpace(in.Statement) == "" {
+		return errResult("sql_exec: missing required field: statement"), nil
+	}
+	// Per-agent quota override wins over the manager default when > 0.
+	quota := tools.SqlMemPolicy(ctx).QuotaBytes
+	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
+	start := time.Now()
+	res, xerr := m.SqlMem.Exec(ctx, key, in.Statement, in.Args, quota)
+	durMs := time.Since(start).Milliseconds()
+	if xerr != nil {
+		m.auditSql(ctx, "sql_exec", scope, scopeID, in.Statement, 0, durMs, xerr)
+		return errResult(fmt.Sprintf("sql_exec: %s", xerr)), nil
+	}
+	m.auditSql(ctx, "sql_exec", scope, scopeID, in.Statement, res.RowsAffected, durMs, nil)
+	return okJSON(map[string]any{
+		"rows_affected":  res.RowsAffected,
+		"last_insert_id": res.LastInsertID,
+	})
+}
+
+// auditSql records one append-only SQL Memory audit event. Best-effort: a
+// nil sink is skipped, and a Record error is logged but NEVER blocks the op
+// (audit is observability, not a transaction participant). In "full" mode
+// the statement is REDACTED before recording (operator infra-secrets out);
+// in "metadata" mode the statement is omitted entirely.
+func (m *Memory) auditSql(ctx context.Context, op, scope, scopeID, statement string, rows, durMs int64, opErr error) {
+	if m.SqlAudit == nil {
+		return
+	}
+	ident := tools.RunIdentity(ctx)
+	ev := audit.Event{
+		ActorTenant:   ident.TenantID,
+		ActorSubject:  ident.UserID,
+		Action:        op,
+		SqlOp:         op,
+		SqlScope:      scope,
+		SqlScopeID:    scopeID,
+		SqlRows:       rows,
+		SqlDurationMs: durMs,
+	}
+	if opErr != nil {
+		ev.SqlError = opErr.Error()
+	}
+	if m.sqlAuditMode() == "full" {
+		if m.Redactor != nil {
+			ev.SqlStatement = m.Redactor.String(statement)
+		} else {
+			ev.SqlStatement = statement
+		}
+	}
+	if err := m.SqlAudit.Record(ev); err != nil {
+		log.Printf("sqlmem: audit record (%s scope=%s) failed: %v", op, scope, err)
+	}
+}
+
+// sqlAuditMode normalizes the audit mode; empty defaults to "full".
+func (m *Memory) sqlAuditMode() string {
+	if m.SqlAuditMode == "metadata" {
+		return "metadata"
+	}
+	return "full"
 }
 
 func (m *Memory) execGet(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {

--- a/internal/tools/builtin/memory_sql_test.go
+++ b/internal/tools/builtin/memory_sql_test.go
@@ -1,0 +1,249 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/sqlmem"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// sqlMemoryFixture builds a Memory tool with a wired SQL Memory manager and
+// returns a base ctx with a tenant + agent name + user id but NO sql_scopes
+// (so the default-deny path is the starting point — tests opt in).
+func sqlMemoryFixture(t *testing.T) (*Memory, *sqlmem.Manager, context.Context, func()) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	mgr, err := sqlmem.New(sqlmem.Config{
+		Root:               t.TempDir(),
+		StatementTimeoutMS: 30000,
+		MaxRows:            10000,
+	})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	tool := &Memory{Store: s, SqlMem: mgr}
+	ctx := tools.WithAgentName(context.Background(), "qa-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		UserID:   "alice",
+		TenantID: "tenantA",
+		AgentID:  "a_test",
+	})
+	cleanup := func() {
+		_ = mgr.Close()
+		_ = s.Close()
+	}
+	return tool, mgr, ctx, cleanup
+}
+
+// withSqlScopes attaches an sql_scopes ACL to ctx.
+func withSqlScopes(ctx context.Context, scopes ...string) context.Context {
+	return tools.WithSqlMemPolicy(ctx, tools.SqlMemPolicyValue{AllowedScopes: scopes})
+}
+
+// TestMemorySQL_DefaultDenyWithoutScopes is the default-deny regression: a
+// Memory tool with SqlMem wired but NO sql_scopes refuses sql_exec.
+func TestMemorySQL_DefaultDenyWithoutScopes(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	// No WithSqlMemPolicy → empty AllowedScopes → default-deny.
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"sql_exec","scope":"agent","statement":"CREATE TABLE t (x INT)"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.IsError {
+		t.Fatalf("sql_exec without sql_scopes should be an error; got %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "no sql_scopes") {
+		t.Errorf("error should explain the default-deny: %s", res.Text)
+	}
+}
+
+// TestMemorySQL_NotEnabledServer refuses when the manager is nil even if the
+// agent is granted scopes.
+func TestMemorySQL_NotEnabledServer(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer s.Close()
+	tool := &Memory{Store: s} // SqlMem nil
+	ctx := withSqlScopes(tools.WithAgentName(context.Background(), "qa-agent"), "agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{TenantID: "t"})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"SELECT 1"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not enabled") {
+		t.Fatalf("nil SqlMem should refuse with not-enabled; got is_error=%v %s", res.IsError, res.Text)
+	}
+}
+
+// TestMemorySQL_RoundTripThroughTool exercises create + insert + select end
+// to end through the Memory tool with scope=agent.
+func TestMemorySQL_RoundTripThroughTool(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "agent")
+
+	exec := func(stmt string) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{"op": "sql_exec", "scope": "agent", "statement": stmt})
+		res, err := tool.Execute(ctx, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.IsError {
+			t.Fatalf("sql_exec %q is_error: %s", stmt, res.Text)
+		}
+	}
+	exec("CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)")
+	exec("INSERT INTO notes (body) VALUES ('hello')")
+
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"SELECT body FROM notes"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError {
+		t.Fatalf("sql_query is_error: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "hello") {
+		t.Errorf("query result missing inserted row: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, `"truncated":false`) {
+		t.Errorf("expected truncated:false: %s", res.Text)
+	}
+}
+
+// TestMemorySQL_TenantIsolation asserts a table written in scope=agent under
+// tenantA is invisible under tenantB (different scope file).
+func TestMemorySQL_TenantIsolation(t *testing.T) {
+	tool, _, ctxA, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctxA = withSqlScopes(ctxA, "agent")
+
+	// tenantA writes.
+	if res, _ := tool.Execute(ctxA, json.RawMessage(`{"op":"sql_exec","scope":"agent","statement":"CREATE TABLE secret (s TEXT)"}`)); res.IsError {
+		t.Fatalf("tenantA create: %s", res.Text)
+	}
+	if res, _ := tool.Execute(ctxA, json.RawMessage(`{"op":"sql_exec","scope":"agent","statement":"INSERT INTO secret VALUES ('A')"}`)); res.IsError {
+		t.Fatalf("tenantA insert: %s", res.Text)
+	}
+
+	// Same agent name, DIFFERENT tenant — its own empty file; the table does
+	// not exist there.
+	ctxB := tools.WithAgentName(context.Background(), "qa-agent")
+	ctxB = tools.WithRunIdentity(ctxB, tools.RunIdentityValue{UserID: "bob", TenantID: "tenantB"})
+	ctxB = withSqlScopes(ctxB, "agent")
+	res, _ := tool.Execute(ctxB, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"SELECT s FROM secret"}`))
+	if !res.IsError {
+		t.Fatalf("tenantB saw tenantA's table; want an error. got %s", res.Text)
+	}
+}
+
+// TestMemorySQL_ScopeIsolationAgentVsUser asserts the agent and user scopes
+// are distinct databases within one tenant.
+func TestMemorySQL_ScopeIsolationAgentVsUser(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "agent", "user")
+
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_exec","scope":"agent","statement":"CREATE TABLE a (x INT)"}`)); res.IsError {
+		t.Fatalf("agent create: %s", res.Text)
+	}
+	// The user scope has its own DB — the agent-scope table is not visible.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"user","statement":"SELECT x FROM a"}`))
+	if !res.IsError {
+		t.Fatalf("user scope saw the agent-scope table; want an error. got %s", res.Text)
+	}
+}
+
+// TestMemorySQL_RunScopeRequiresActiveRun asserts scope=run refuses when no
+// run id is on the context, and succeeds when one is present.
+func TestMemorySQL_RunScopeRequiresActiveRun(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "run")
+
+	// No RunID on ctx → refuse.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_exec","scope":"run","statement":"CREATE TABLE t (x INT)"}`))
+	if !res.IsError || !strings.Contains(res.Text, "active run") {
+		t.Fatalf("scope=run without a run id should refuse; got is_error=%v %s", res.IsError, res.Text)
+	}
+
+	// With a RunID → succeed.
+	ctxRun := tools.WithRunID(ctx, "run-xyz")
+	if res, _ := tool.Execute(ctxRun, json.RawMessage(`{"op":"sql_exec","scope":"run","statement":"CREATE TABLE t (x INT)"}`)); res.IsError {
+		t.Fatalf("scope=run with a run id should succeed; got %s", res.Text)
+	}
+}
+
+// TestMemorySQL_RunScopeEphemeralLifecycle asserts a run-scope write is
+// readable within the run, then gone after DropRunScope (manager-level drop,
+// mirroring what the HTTP finish-path calls).
+func TestMemorySQL_RunScopeEphemeralLifecycle(t *testing.T) {
+	tool, mgr, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "run")
+	// The run scope keys off RootRunID (the tree root) — set it so the drop
+	// targets the same id the server's run-completion path would.
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
+		UserID: "alice", TenantID: "tenantA", RootRunID: "run-ephemeral-1",
+	})
+	ctx = withSqlScopes(ctx, "run")
+
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_exec","scope":"run","statement":"CREATE TABLE scratch (x INT)"}`)); res.IsError {
+		t.Fatalf("run create: %s", res.Text)
+	}
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_exec","scope":"run","statement":"INSERT INTO scratch VALUES (1)"}`)); res.IsError {
+		t.Fatalf("run insert: %s", res.Text)
+	}
+	// Readable within the run.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"run","statement":"SELECT x FROM scratch"}`))
+	if res.IsError || !strings.Contains(res.Text, `"rows":[[1]]`) {
+		t.Fatalf("run read-after-write failed: is_error=%v %s", res.IsError, res.Text)
+	}
+
+	// Drop the run scope (what purgeEphemeral... calls at run completion).
+	removed, err := mgr.DropRunScope("run-ephemeral-1")
+	if err != nil {
+		t.Fatalf("DropRunScope: %v", err)
+	}
+	if !removed {
+		t.Fatal("DropRunScope removed=false, want true")
+	}
+	// The table is gone — a fresh file is opened on the next access.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"run","statement":"SELECT x FROM scratch"}`))
+	if !res.IsError {
+		t.Fatalf("scratch table should be gone after drop; got %s", res.Text)
+	}
+}
+
+// TestMemorySQL_QueryRefusesWrite asserts sql_query refuses a write attempt
+// (the read-only floor is enforced before the driver).
+func TestMemorySQL_QueryRefusesWrite(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "agent")
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"DELETE FROM x"}`))
+	if !res.IsError {
+		t.Fatalf("sql_query of a DELETE should refuse; got %s", res.Text)
+	}
+}
+
+// TestMemorySQL_ScopeNotInACLRefused asserts a scope outside the agent's ACL
+// is refused even when the subsystem is enabled.
+func TestMemorySQL_ScopeNotInACLRefused(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	ctx = withSqlScopes(ctx, "agent") // user/run NOT granted
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"user","statement":"SELECT 1"}`))
+	if !res.IsError || !strings.Contains(res.Text, "not in this agent's sql_scopes") {
+		t.Fatalf("scope=user outside the ACL should refuse; got is_error=%v %s", res.IsError, res.Text)
+	}
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -535,6 +535,42 @@ func MemoryPolicy(ctx context.Context) MemoryPolicyValue {
 	return v
 }
 
+// ctxKeySqlMemPolicy is the context key for the per-agent RFC AA SQL Memory
+// policy (allowed scopes + per-scope byte-quota override). Set by the HTTP
+// server from the agent's yaml `sql_scopes` / `sql_quota_bytes`; read by the
+// Memory tool's sql_query / sql_exec ops to gate access. Sub-agents inherit
+// the parent's policy via this ctx key, like MemoryPolicy / HostPolicy.
+type ctxKeySqlMemPolicy struct{}
+
+// SqlMemPolicyValue is the per-agent SQL Memory access policy.
+//
+//   - AllowedScopes is the yaml `sql_scopes` allowlist {agent,user,run}. An
+//     empty slice means the agent has NO SQL access — the DEFAULT-DENY
+//     invariant (the Memory tool must be in allowed_tools for the agent to
+//     call it at all, but the scope allowlist is a second, SQL-specific gate).
+//   - QuotaBytes is the yaml `sql_quota_bytes` override; 0 falls back to the
+//     global LOOMCYCLE_SQLMEM_QUOTA_BYTES default.
+//
+// Same trust posture as MemoryPolicyValue: operator-resolved from agent
+// config, never model-supplied. The model picks the scope; the operator
+// decides which scopes exist.
+type SqlMemPolicyValue struct {
+	AllowedScopes []string
+	QuotaBytes    int
+}
+
+// WithSqlMemPolicy attaches the agent's resolved SQL Memory policy to ctx.
+func WithSqlMemPolicy(ctx context.Context, p SqlMemPolicyValue) context.Context {
+	return context.WithValue(ctx, ctxKeySqlMemPolicy{}, p)
+}
+
+// SqlMemPolicy returns the agent's SQL Memory policy from ctx. Zero value
+// (empty AllowedScopes, QuotaBytes=0) means "no SQL access".
+func SqlMemPolicy(ctx context.Context) SqlMemPolicyValue {
+	v, _ := ctx.Value(ctxKeySqlMemPolicy{}).(SqlMemPolicyValue)
+	return v
+}
+
 // ctxKeyChannelPolicy is the context key for the per-agent Channel
 // tool ACL (v0.8.4). Set by the HTTP server from the agent's yaml
 // definition; read by the Channel tool to gate publish/subscribe and


### PR DESCRIPTION
## Why

Sandboxed / short-lived agents often need **structured** storage — related tables, joins, aggregates — that the K/V + vector `Memory` can't provide. Today their only path is `Bash + sqlite3`/`+ psql`: requires Bash (an explicit *non*-sandbox), external DB + credential setup, and is wasteful + a trust hole. RFC AA adds **SQL Memory**: a runtime-hosted, per-scope sqlite database an authorized agent runs arbitrary SQL against, isolated from the main loomcycle store, gated + bounded + audited.

## What (Phase 1 — sqlite)

Two new `Memory` ops:
- **`sql_query`** — read-only SELECT → `{columns, rows, truncated}` (capped at `sql_max_rows`).
- **`sql_exec`** — DDL/DML → `{rows_affected, last_insert_id}`. Bind params (`args`).

Both take `scope: agent | user | run`. Durable `agent`/`user` (keyed by the authoritative tenant) persist across runs; ephemeral **`run`** is one DB per spawn tree, dropped at run completion (fenced removal, mirroring RFC AH ephemeral volumes).

- **Default-deny `sql_scopes` ACL** (closed enum, per-agent yaml, boot warning) — `Memory` in `allowed_tools` is not enough; the agent needs an explicit list (RFC W pattern). Off unless `storage.sqlmem_enabled`.
- **Limits:** per-scope **quota** (page-count×page-size, checked before a write; per-agent override), per-statement **timeout** (ctx → modernc interrupt), **row cap** + `truncated`.
- **Audit:** every op records actor/scope/op/rows/duration + the **redacted** statement (RFC Z redactor), `full` or `metadata` mode; best-effort, never blocks the op.

## The security crux

The threat is not injection (agents are *authorized* to run SQL) — it's **escaping the per-scope file** (arbitrary host file r/w via `ATTACH`/`VACUUM INTO`, native code via `load_extension`) and resource exhaustion.

**The default `modernc.org/sqlite` driver exposes NO authorizer** (only the cgo `mattn` vec build does). So the primary, **driver-agnostic** defence is a **Go-layer parsed statement validator** (`internal/sqlmem/validate.go`), run before any SQL reaches the driver, backed by **per-scope FILE isolation** (one `.db` per scope ⇒ a missed escape can't cross scopes). It refuses:
- `ATTACH`/`DETACH`/`VACUUM [INTO]`/`PRAGMA` (leading), all explicit transactions;
- `load_extension(…)` **anywhere**, including the `"x"`/`[x]`/`` `x` `` quoted-identifier forms (a latent RCE on a future extension-enabled build) — string/comment-literal aware so a *value* mentioning `load_extension(` is data, not a refusal;
- **multi-statement smuggling** (confirmed: modernc *does* run a 2nd `;`-separated statement, so this guard is load-bearing — and it also blocks `CREATE TRIGGER` deferred payloads);
- any **write** on `sql_query`.

Path derivation sanitizes every identifier (no `..`/separator escape; collision-safe). Tenant is always server-authoritative (`RunIdentity.TenantID`), never the wire.

## Review (two adversarial passes ran)

- **Validator-bypass review (adversarial):** APPROVE-WITH-NITS — no live escape on the default driver; the separator tracker matches modernc's lexer; readonly-write + leading-keyword + comment handling all sound. Found **M-1** (quoted-identifier `load_extension` bypass) → **fixed + fail-before tested**; **N-1** (trigger note) → documented.
- **Isolation/wiring/audit review:** confirmed tenant/scope isolation, default-deny, audit redaction, run-end drop, config validation all correct. Found **(1)** `resumePausedRun` missing `WithSqlMemPolicy` (resumed runs lost SQL access) → **fixed**; **(2)** an LRU eviction race that could close a handle mid-op → **fixed** with an in-use refcount + a 192-scope `-race` concurrency test.

## What was tested

`go build ./...`, `go test ./...`, `-race` on `internal/sqlmem`, gofmt — all clean. The escape-blocked suite (19 vectors), scope/tenant isolation end-to-end, ephemeral lifecycle, limits, default-deny, and the config-validation fail-before all pass.

Design: RFC AA (`doc-internal/rfcs/sql-memory.md`). Phase 2 (postgres schema-per-scope, multi-replica) + Phase 3 (vector columns, snapshot integration, transactions) are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)