### PR TITLE
feat(sqlmem): RFC AA Phase 3b — nested transactions / SAVEPOINT

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -10,6 +10,19 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ## What's in vNEXT
 
+**🪆 SQL Memory — nested transactions / SAVEPOINT (RFC AA, Phase 3b).** A second
+`sql_begin` while a transaction is open now **nests** (opens a `SAVEPOINT`)
+instead of erroring — the agent uses the same `sql_begin`/`sql_commit`/
+`sql_rollback` ops at any depth, no savepoint names to manage. A nested
+`sql_rollback` undoes only the inner level's writes (the outer transaction
+continues); a nested `sql_commit` releases it. Each op's result reports the
+current `depth` (1 = the root transaction, 0 = closed). Nesting is LIFO and
+capped at **`sqlmem_max_txn_depth`** (default 16); a whole-transaction rollback
+(explicit, run-end, or the reaper) discards every savepoint with it. The runtime
+issues + names the savepoints — the validator still refuses agent-issued
+`SAVEPOINT`/`RELEASE`/`ROLLBACK`, so the model can't desync the stack. Works on
+both tiers (savepoints are standard SQL).
+
 **💾 SQL Memory — snapshot/backup integration (RFC AA, Phase 3e).** The runtime
 JSON snapshot now captures SQL Memory. Every **durable** (`agent`/`user`) scope
 is dumped **logically** (schema DDL + table data) into an optional, tier-tagged

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1152,6 +1152,7 @@ func main() {
 			MaxRows:            cfg.Storage.SqlMemMaxRows,
 			TxnTimeoutMS:       cfg.Storage.SqlMemTxnTimeoutMS,
 			MaxOpenTxns:        cfg.Storage.SqlMemMaxOpenTxns,
+			MaxTxnDepth:        cfg.Storage.SqlMemMaxTxnDepth,
 			ScopeTTLMS:         cfg.Storage.SqlMemScopeTTLMS,
 			GCIntervalMS:       cfg.Storage.SqlMemGCIntervalMS,
 		}

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -76,6 +76,7 @@ agents:
 | `LOOMCYCLE_SQLMEM_AUDIT_MODE` | `sqlmem_audit_mode` | `full` (redacted statement text, default) or `metadata` (counts only) |
 | `LOOMCYCLE_SQLMEM_TXN_TIMEOUT_MS` | `sqlmem_txn_timeout_ms` | explicit-transaction TTL — the reaper rolls back a txn open longer than this (default 30000; 0 disables) |
 | `LOOMCYCLE_SQLMEM_MAX_OPEN_TXNS` | `sqlmem_max_open_txns` | cap on concurrent open transactions process-wide (default 64; each pins a connection) |
+| `LOOMCYCLE_SQLMEM_MAX_TXN_DEPTH` | `sqlmem_max_txn_depth` | cap on SAVEPOINT nesting depth within one transaction (default 16; a nested `sql_begin` past it errors) |
 | `LOOMCYCLE_SQLMEM_SCOPE_TTL_MS` | `sqlmem_scope_ttl_ms` | durable-scope GC: drop an `agent`/`user` scope idle longer than this. **0 = OFF** (default — GC discards data) |
 | `LOOMCYCLE_SQLMEM_GC_INTERVAL_MS` | `sqlmem_gc_interval_ms` | how often the GC sweeper runs (default 1h; only when the TTL is set) |
 

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -120,14 +120,30 @@ runs any number of `sql_exec` / `sql_query` on the scope, then `sql_commit` or
   connection-pinning + cleanup. While a transaction is open for a `(run, scope)`,
   that scope's `sql_exec`/`sql_query` run **on** it; with none open they
   auto-commit exactly as before.
-- **One open transaction per `(run-tree, scope)`** — a second `sql_begin` before
-  finishing errors (no nesting / `SAVEPOINT` yet). At most `sqlmem_max_open_txns`
+- **One open transaction per `(run-tree, scope)`**, at most `sqlmem_max_open_txns`
   process-wide. The key is the run-**tree** root, so within one run tree an open
   transaction on a scope is **shared**: if a parent opens a transaction on a
   scope and a (parallel) sub-agent then runs `sql_exec`/`sql_query` on that *same*
   scope, it runs on the parent's transaction (and is committed/rolled-back with
   it). Agents that must transact independently should use the per-agent `agent`
   scope (distinct per agent name) rather than a shared `user`/`run` scope.
+- **Nesting (`SAVEPOINT`).** A second `sql_begin` while a transaction is open
+  **nests** — it opens a SAVEPOINT instead of erroring. The matching `sql_commit`
+  releases that inner level (merging it up); `sql_rollback` undoes only the inner
+  level's writes, with the outer transaction continuing. Each op's result reports
+  the current `depth` (1 = the root transaction; 0 = closed). This is the "try a
+  sub-step, undo only that on failure" idiom — no agent-managed savepoint names.
+  Nesting is LIFO (commit/rollback affect the innermost level) and capped at
+  `sqlmem_max_txn_depth` (default 16). A whole-transaction rollback (explicit, a
+  run end, or the reaper) discards every savepoint with it.
+  ```jsonc
+  {"op":"sql_begin",  "scope":"agent"}                                  // depth 1
+  {"op":"sql_exec",   "scope":"agent", "statement":"INSERT INTO log VALUES ('a')"}
+  {"op":"sql_begin",  "scope":"agent"}                                  // depth 2 (SAVEPOINT)
+  {"op":"sql_exec",   "scope":"agent", "statement":"INSERT INTO log VALUES ('b')"}
+  {"op":"sql_rollback","scope":"agent"}    // undoes only 'b'; depth → 1, txn still open
+  {"op":"sql_commit", "scope":"agent"}     // commits 'a'; depth → 0
+  ```
 - **Read-write.** A `sql_query` inside a transaction relies on the validator's
   SELECT-only rule for read-safety (not the auto-commit read-only transaction).
 - **Always cleaned up.** A transaction is rolled back if the run ends with it

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -328,6 +328,11 @@ type StorageConfig struct {
 	// (each pins a scope connection). Default 64. 0 = unbounded. Env:
 	// LOOMCYCLE_SQLMEM_MAX_OPEN_TXNS.
 	SqlMemMaxOpenTxns int `yaml:"sqlmem_max_open_txns"`
+	// SqlMemMaxTxnDepth caps the SAVEPOINT nesting depth of one explicit
+	// transaction (Phase 3b): a nested sql_begin past this errors, bounding the
+	// in-memory savepoint stack a looping agent can grow. Default 16. 0 =
+	// unbounded. Env: LOOMCYCLE_SQLMEM_MAX_TXN_DEPTH.
+	SqlMemMaxTxnDepth int `yaml:"sqlmem_max_txn_depth"`
 	// SqlMemScopeTTLMS turns on durable-scope GC (Phase 3d): a durable
 	// (agent/user) scope idle longer than this is dropped by the sweeper. 0 =
 	// OFF (the default — GC DISCARDS DATA, so it is opt-in). Run scopes are never
@@ -2672,6 +2677,11 @@ func Load(path string) (*Config, error) {
 			cfg.Storage.SqlMemMaxOpenTxns = n
 		}
 	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_MAX_TXN_DEPTH"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			cfg.Storage.SqlMemMaxTxnDepth = n
+		}
+	}
 	if v := os.Getenv("LOOMCYCLE_SQLMEM_SCOPE_TTL_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			cfg.Storage.SqlMemScopeTTLMS = n
@@ -2702,6 +2712,11 @@ func Load(path string) (*Config, error) {
 	}
 	if cfg.Storage.SqlMemMaxOpenTxns == 0 {
 		cfg.Storage.SqlMemMaxOpenTxns = 64
+	}
+	// SAVEPOINT nesting depth cap (Phase 3b). Bounds the in-memory savepoint
+	// stack per transaction; a nested sql_begin past it errors.
+	if cfg.Storage.SqlMemMaxTxnDepth == 0 {
+		cfg.Storage.SqlMemMaxTxnDepth = 16
 	}
 
 	// Hooks block (v0.8.17). The env-var override APPENDS to whatever

--- a/internal/sqlmem/gc_test.go
+++ b/internal/sqlmem/gc_test.go
@@ -66,7 +66,7 @@ func TestGC_SkipsInUseScope(t *testing.T) {
 	// Open a transaction → pins the scope handle (inUse>0); backdate AFTER begin
 	// (BeginTxn touches the scope forward).
 	txnID := agentTxnID("run1", "busy")
-	if err := m.BeginTxn(ctx, txnID, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, txnID, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	_ = os.Chtimes(path, old, old)
@@ -78,7 +78,7 @@ func TestGC_SkipsInUseScope(t *testing.T) {
 	}
 
 	// Finish the txn → inUse drops → now reclaimable.
-	if err := m.RollbackTxn(txnID); err != nil {
+	if _, err := m.RollbackTxn(txnID); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	_ = os.Chtimes(path, old, old)

--- a/internal/sqlmem/postgres_test.go
+++ b/internal/sqlmem/postgres_test.go
@@ -368,7 +368,7 @@ func TestPostgres_TxnAtomicityAndIsolation(t *testing.T) {
 	}
 
 	id := BuildTxnID("run1", "agent", "pgtxn")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
@@ -387,18 +387,18 @@ func TestPostgres_TxnAtomicityAndIsolation(t *testing.T) {
 	if _, err := m.Query(ctx, other, "SELECT count(*) FROM t", nil); err == nil {
 		t.Fatal("other scope read the in-txn scope's table; want a no-such-table / permission error")
 	}
-	if err := m.RollbackTxn(id); err != nil {
+	if _, err := m.RollbackTxn(id); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 
 	// Commit path persists.
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin 2: %v", err)
 	}
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
 		t.Fatalf("exec 2: %v", err)
 	}
-	if err := m.CommitTxn(id); err != nil {
+	if _, err := m.CommitTxn(id); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 	res2, err := m.Query(ctx, key, "SELECT count(*) FROM t", nil)
@@ -524,13 +524,13 @@ func TestPostgres_QueryTxnSelectIntoDenied(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	id := BuildTxnID("run1", "agent", "into")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if _, err := m.QueryTxn(ctx, id, "SELECT x INTO sneaky FROM src", nil); err == nil {
 		t.Fatal("SELECT … INTO via QueryTxn was allowed; want a validator refusal")
 	}
-	if err := m.CommitTxn(id); err != nil { // commit: if INTO had run, the table would persist
+	if _, err := m.CommitTxn(id); err != nil { // commit: if INTO had run, the table would persist
 		t.Fatalf("commit: %v", err)
 	}
 	if _, err := m.Query(ctx, key, "SELECT 1 FROM sneaky LIMIT 1", nil); err == nil {

--- a/internal/sqlmem/savepoint_test.go
+++ b/internal/sqlmem/savepoint_test.go
@@ -1,0 +1,165 @@
+package sqlmem
+
+import (
+	"context"
+	"testing"
+)
+
+// savepoint_test.go — RFC AA Phase 3b: nested transactions (auto-savepoint,
+// LIFO). The sqlite cases run on every `go test`; the postgres case is gated on
+// LOOMCYCLE_TEST_SQLMEM_PG_DSN (savepoints are standard SQL on both tiers).
+
+// wantDepth(t, N) returns a checker for a (depth, err) txn-op result: it fails
+// on a non-nil error or a depth != N. Called as wantDepth(t, 1)(m.BeginTxn(...))
+// — the op's two return values are the checker's sole arguments (valid Go).
+func wantDepth(t *testing.T, want int) func(int, error) {
+	t.Helper()
+	return func(got int, err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatalf("txn op: %v", err)
+		}
+		if got != want {
+			t.Fatalf("depth=%d, want %d", got, want)
+		}
+	}
+}
+
+// TestTxn_NestedRollbackUndoesInnerOnly: a nested rollback undoes only the inner
+// level's writes; the outer transaction's earlier write survives.
+func TestTxn_NestedRollbackUndoesInnerOnly(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "sp-rb")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-rb")
+	wantDepth(t, 1)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	wantDepth(t, 2)(m.BeginTxn(ctx, id, "run1", key)) // nested
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	wantDepth(t, 1)(m.RollbackTxn(id)) // pop inner → B undone, txn open
+	wantDepth(t, 0)(m.CommitTxn(id))   // commit root → A persists
+	if n := rowCount(t, m, key); n != 1 {
+		t.Fatalf("count=%d, want 1 (only the outer insert persists)", n)
+	}
+	res, err := m.Query(ctx, key, "SELECT x FROM t", nil)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if got, _ := res.Rows[0][0].(int64); got != 1 {
+		t.Fatalf("surviving row x=%d, want 1", got)
+	}
+}
+
+// TestTxn_NestedCommitKeepsBoth: releasing the nested level then committing the
+// root persists both writes.
+func TestTxn_NestedCommitKeepsBoth(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "sp-commit")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-commit")
+	wantDepth(t, 1)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	wantDepth(t, 2)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	wantDepth(t, 1)(m.CommitTxn(id)) // release nested
+	wantDepth(t, 0)(m.CommitTxn(id)) // commit root
+	if n := rowCount(t, m, key); n != 2 {
+		t.Fatalf("count=%d, want 2 (both inserts persist)", n)
+	}
+}
+
+// TestTxn_NestedDepthCap: a nested begin past MaxTxnDepth errors; the txn stays
+// usable at the cap.
+func TestTxn_NestedDepthCap(t *testing.T) {
+	m := newTestManager(t, Config{MaxTxnDepth: 1}) // at most 1 savepoint → max depth 2
+	ctx := context.Background()
+	key := agentKey("t1", "sp-cap")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-cap")
+	wantDepth(t, 1)(m.BeginTxn(ctx, id, "run1", key))
+	wantDepth(t, 2)(m.BeginTxn(ctx, id, "run1", key)) // 1 savepoint, at the cap
+	if d, err := m.BeginTxn(ctx, id, "run1", key); err == nil {
+		t.Fatalf("nested begin past the depth cap was allowed (depth=%d)", d)
+	}
+	// Still usable at the cap: a write + pop + root commit succeed.
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (9)", nil, 0); err != nil {
+		t.Fatalf("exec at cap: %v", err)
+	}
+	wantDepth(t, 1)(m.CommitTxn(id))
+	wantDepth(t, 0)(m.CommitTxn(id))
+	if n := rowCount(t, m, key); n != 1 {
+		t.Fatalf("count=%d, want 1", n)
+	}
+}
+
+// TestTxn_NestedCleanupOnRunEnd: a run ending with a nested level open rolls the
+// WHOLE transaction back (savepoints discarded with it); the scope is then free.
+func TestTxn_NestedCleanupOnRunEnd(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "sp-cleanup")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-cleanup")
+	wantDepth(t, 1)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	wantDepth(t, 2)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	m.RollbackRunTxns("run1") // run-end cleanup: whole txn (+ its savepoints) rolled back
+	if m.InTxn(id) {
+		t.Fatal("InTxn=true after run-end cleanup")
+	}
+	if n := rowCount(t, m, key); n != 0 {
+		t.Fatalf("count=%d, want 0 (whole txn discarded)", n)
+	}
+	// The scope is free again — a fresh auto-commit op works.
+	if _, err := m.Exec(ctx, key, "INSERT INTO t VALUES (3)", nil, 0); err != nil {
+		t.Fatalf("post-cleanup exec: %v", err)
+	}
+}
+
+// TestTxn_NestedRollback_Postgres: the nested round trip on the postgres tier
+// (savepoints via pgx). Gated on the aux DSN.
+func TestTxn_NestedRollback_Postgres(t *testing.T) {
+	m, _ := pgTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "sp-pg")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x int)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-pg")
+	wantDepth(t, 1)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+		t.Fatalf("insert A: %v", err)
+	}
+	wantDepth(t, 2)(m.BeginTxn(ctx, id, "run1", key))
+	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
+		t.Fatalf("insert B: %v", err)
+	}
+	wantDepth(t, 1)(m.RollbackTxn(id))
+	wantDepth(t, 0)(m.CommitTxn(id))
+	if n := rowCount(t, m, key); n != 1 {
+		t.Fatalf("count=%d, want 1 (inner insert rolled back)", n)
+	}
+}

--- a/internal/sqlmem/savepoint_test.go
+++ b/internal/sqlmem/savepoint_test.go
@@ -2,6 +2,7 @@ package sqlmem
 
 import (
 	"context"
+	"sync"
 	"testing"
 )
 
@@ -161,5 +162,49 @@ func TestTxn_NestedRollback_Postgres(t *testing.T) {
 	wantDepth(t, 0)(m.CommitTxn(id))
 	if n := rowCount(t, m, key); n != 1 {
 		t.Fatalf("count=%d, want 1 (inner insert rolled back)", n)
+	}
+}
+
+// TestTxn_NestedConcurrentBeginFinish stresses the F1 race: a nested sql_begin
+// racing the root commit on one scope (tool calls in a turn dispatch
+// concurrently). The fix serializes the pop-vs-finish choice and any push under
+// the openTxn mutex + a `done` flag, so a savepoint is never opened on a
+// torn-down tx, the pin never leaks, and the scope stays usable. Meaningful
+// under -race.
+func TestTxn_NestedConcurrentBeginFinish(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "sp-race")
+	if _, err := m.Exec(ctx, key, "CREATE TABLE t (x INT)", nil, 0); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	id := agentTxnID("run1", "sp-race")
+	for i := 0; i < 200; i++ {
+		if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+			t.Fatalf("iter %d begin: %v", i, err)
+		}
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { // nested begin then close that level (best-effort under the race)
+			defer wg.Done()
+			if _, err := m.BeginTxn(ctx, id, "run1", key); err == nil {
+				_, _ = m.CommitTxn(id)
+			}
+		}()
+		go func() { // finish the root concurrently
+			defer wg.Done()
+			_, _ = m.CommitTxn(id)
+		}()
+		wg.Wait()
+		// Drain any level still open (single-threaded now), then the scope MUST be
+		// usable — a leaked pin would wedge the sqlite single-writer handle.
+		for m.InTxn(id) {
+			if _, err := m.CommitTxn(id); err != nil {
+				break
+			}
+		}
+		if _, err := m.Exec(ctx, key, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
+			t.Fatalf("iter %d: scope wedged after race (pin leak?): %v", i, err)
+		}
 	}
 }

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -58,6 +58,10 @@ type Config struct {
 	// MaxOpenTxns caps concurrent open explicit transactions process-wide (each
 	// pins a scope connection). 0 = unbounded.
 	MaxOpenTxns int
+	// MaxTxnDepth caps the SAVEPOINT nesting depth of one explicit transaction
+	// (Phase 3b): a nested sql_begin past this errors, bounding the in-memory
+	// savepoint stack. 0 = unbounded.
+	MaxTxnDepth int
 	// ScopeTTLMS turns on durable-scope GC: a durable (agent/user) scope idle
 	// longer than this is dropped by the sweeper. 0 = GC OFF (the default — GC
 	// discards data, so it is opt-in). Run scopes are never GC'd (dropped at

--- a/internal/sqlmem/txn.go
+++ b/internal/sqlmem/txn.go
@@ -51,6 +51,60 @@ type openTxn struct {
 	runID   string // RootRunID, matched by RollbackRunTxns
 	started time.Time
 	release func()
+
+	// savepoints is the LIFO SAVEPOINT stack for nested transactions (Phase 3b),
+	// innermost last; spCounter mints fresh names so a released-then-re-pushed
+	// level never reuses a name. depth reported to the agent is 1+len(savepoints)
+	// (a freshly-opened txn is depth 1). Both guarded by mu. A whole-tx
+	// commit/rollback (finish) discards every savepoint, so no per-savepoint
+	// cleanup is needed on the reaper / run-end / Close paths.
+	savepoints []string
+	spCounter  int
+}
+
+// pushSavepoint opens a nested level: SAVEPOINT on the tx + push the name.
+// Returns the new depth. Refuses past maxDepth (the stack cap). Holds mu so it
+// can't race a statement / finish on the same tx.
+func (t *openTxn) pushSavepoint(ctx context.Context, maxDepth int) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if maxDepth > 0 && len(t.savepoints) >= maxDepth {
+		return 1 + len(t.savepoints), fmt.Errorf("transaction nesting depth limit (%d) reached — commit or roll back a nested level first", maxDepth)
+	}
+	t.spCounter++
+	name := fmt.Sprintf("loomcycle_sp_%d", t.spCounter)
+	if _, err := t.tx.ExecContext(ctx, "SAVEPOINT "+q(name)); err != nil {
+		return 1 + len(t.savepoints), err
+	}
+	t.savepoints = append(t.savepoints, name)
+	return 1 + len(t.savepoints), nil
+}
+
+// popSavepoint closes the innermost nested level: commit → RELEASE (merge up),
+// rollback → ROLLBACK TO + RELEASE (undo + exit). Returns (newDepth, popped).
+// popped is false when there is no savepoint (the caller then finishes the whole
+// txn). Holds mu. SAVEPOINT/RELEASE/ROLLBACK TO are standard SQL on both tiers.
+func (t *openTxn) popSavepoint(ctx context.Context, commit bool) (depth int, popped bool, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.savepoints) == 0 {
+		return 0, false, nil
+	}
+	name := t.savepoints[len(t.savepoints)-1]
+	if commit {
+		_, err = t.tx.ExecContext(ctx, "RELEASE SAVEPOINT "+q(name))
+	} else {
+		if _, e := t.tx.ExecContext(ctx, "ROLLBACK TO SAVEPOINT "+q(name)); e != nil {
+			err = e
+		} else {
+			_, err = t.tx.ExecContext(ctx, "RELEASE SAVEPOINT "+q(name))
+		}
+	}
+	if err != nil {
+		return 1 + len(t.savepoints), true, err
+	}
+	t.savepoints = t.savepoints[:len(t.savepoints)-1]
+	return 1 + len(t.savepoints), true, nil
 }
 
 // finish commits or rolls back the transaction and always drops the pin. It
@@ -100,17 +154,27 @@ func (m *Manager) InTxn(txnID string) bool {
 	return m.txns.open[txnID] != nil
 }
 
-// BeginTxn opens an explicit transaction for txnID against scope key. Errors if
-// one is already open for txnID or the process-wide MaxOpenTxns cap is reached.
-func (m *Manager) BeginTxn(ctx context.Context, txnID, rootRunID string, key ScopeKey) error {
+// BeginTxn opens an explicit transaction for txnID — or, when one is already
+// open for txnID, opens a nested level (a SAVEPOINT) on it (Phase 3b). Returns
+// the resulting nesting depth (1 for a freshly-opened txn; 2+ for a nested one).
+// Errors if the process-wide MaxOpenTxns cap is reached (new txn) or the
+// per-txn MaxTxnDepth cap is reached (nested).
+func (m *Manager) BeginTxn(ctx context.Context, txnID, rootRunID string, key ScopeKey) (int, error) {
 	m.txns.mu.Lock()
-	if _, ok := m.txns.open[txnID]; ok {
+	if existing, ok := m.txns.open[txnID]; ok {
+		if existing == nil {
+			// A concurrent BeginTxn for this id is mid-round-trip (the reservation
+			// placeholder). Don't nest onto a txn that isn't ready.
+			m.txns.mu.Unlock()
+			return 0, fmt.Errorf("a transaction is being opened for this scope — retry")
+		}
+		// Nested begin → push a SAVEPOINT on the existing txn.
 		m.txns.mu.Unlock()
-		return fmt.Errorf("a transaction is already open for this scope — commit or rollback it before starting another")
+		return existing.pushSavepoint(ctx, m.cfg.MaxTxnDepth)
 	}
 	if max := m.cfg.MaxOpenTxns; max > 0 && len(m.txns.open) >= max {
 		m.txns.mu.Unlock()
-		return fmt.Errorf("too many open transactions (%d) — commit or rollback before opening more", max)
+		return 0, fmt.Errorf("too many open transactions (%d) — commit or rollback before opening more", max)
 	}
 	// Reserve the slot with a placeholder so a concurrent BeginTxn for the same
 	// id can't also pass the check, then release the lock for the DB round-trip.
@@ -122,44 +186,66 @@ func (m *Manager) BeginTxn(ctx context.Context, txnID, rootRunID string, key Sco
 		m.txns.mu.Lock()
 		delete(m.txns.open, txnID)
 		m.txns.mu.Unlock()
-		return err
+		return 0, err
 	}
 	m.txns.mu.Lock()
 	m.txns.open[txnID] = &openTxn{tx: tx, key: key, runID: rootRunID, started: time.Now(), release: release}
 	m.txns.mu.Unlock()
 	m.touch(key) // a transaction is durable-scope use (GC last_used)
-	return nil
+	return 1, nil
 }
 
-// take removes and returns the open txn for txnID (nil if none / still being
-// opened). Used by Commit/Rollback so the same txn is never finished twice.
-func (m *Manager) take(txnID string) *openTxn {
+// CommitTxn releases the innermost nested level, or — at depth 1 — commits +
+// releases the whole transaction. Returns the resulting depth (0 = closed).
+func (m *Manager) CommitTxn(txnID string) (int, error) {
+	return m.finishLevel(txnID, true)
+}
+
+// RollbackTxn rolls back the innermost nested level (ROLLBACK TO + RELEASE, the
+// outer txn continuing), or — at depth 1 — rolls back + releases the whole
+// transaction. Returns the resulting depth (0 = closed).
+func (m *Manager) RollbackTxn(txnID string) (int, error) {
+	return m.finishLevel(txnID, false)
+}
+
+// finishLevel closes one level of txnID: a nested savepoint (depth stays open)
+// or, at the root, the whole transaction. Lock discipline: m.txns.mu and the
+// per-openTxn mu are never held simultaneously (BeginTxn takes m.txns.mu then
+// the openTxn mu via pushSavepoint; here we take them sequentially in the same
+// order), so there is no deadlock. A truly-concurrent root finish + nested begin
+// on one scope is serialized but ordering is undefined (documented) — never
+// corrupting: finish always releases the pin.
+func (m *Manager) finishLevel(txnID string, commit bool) (int, error) {
 	m.txns.mu.Lock()
-	defer m.txns.mu.Unlock()
 	t := m.txns.open[txnID]
+	m.txns.mu.Unlock()
 	if t == nil {
-		return nil
+		verb := "roll back"
+		if commit {
+			verb = "commit"
+		}
+		return 0, fmt.Errorf("no open transaction to %s for this scope", verb)
 	}
-	delete(m.txns.open, txnID)
-	return t
-}
 
-// CommitTxn commits + releases the open transaction for txnID.
-func (m *Manager) CommitTxn(txnID string) error {
-	t := m.take(txnID)
-	if t == nil {
-		return fmt.Errorf("no open transaction to commit for this scope")
+	// Nested level → pop a savepoint and leave the txn open.
+	if depth, popped, err := t.popSavepoint(context.Background(), commit); popped || err != nil {
+		return depth, err
 	}
-	return t.finish(true)
-}
 
-// RollbackTxn rolls back + releases the open transaction for txnID.
-func (m *Manager) RollbackTxn(txnID string) error {
-	t := m.take(txnID)
-	if t == nil {
-		return fmt.Errorf("no open transaction to roll back for this scope")
+	// Root level → remove from the registry (guarding against a concurrent
+	// finish that already took it) and finish the whole transaction.
+	m.txns.mu.Lock()
+	if cur := m.txns.open[txnID]; cur == t {
+		delete(m.txns.open, txnID)
+	} else {
+		m.txns.mu.Unlock()
+		return 0, nil // another caller already finished it
 	}
-	return t.finish(false)
+	m.txns.mu.Unlock()
+	if err := t.finish(commit); err != nil {
+		return 0, err
+	}
+	return 0, nil
 }
 
 // RollbackRunTxns rolls back every open transaction belonging to a run tree

--- a/internal/sqlmem/txn.go
+++ b/internal/sqlmem/txn.go
@@ -60,14 +60,24 @@ type openTxn struct {
 	// cleanup is needed on the reaper / run-end / Close paths.
 	savepoints []string
 	spCounter  int
+	// done is set (under mu) the moment the whole tx is committed/rolled back, so
+	// a nested pushSavepoint that races a root finish refuses cleanly instead of
+	// SAVEPOINT-ing a finished *sql.Tx. The finish decision (pop-vs-finish) and
+	// any push both run under mu, so they are coherently serialized — a savepoint
+	// can never be opened on a tx being torn down (the F1 race).
+	done bool
 }
 
 // pushSavepoint opens a nested level: SAVEPOINT on the tx + push the name.
-// Returns the new depth. Refuses past maxDepth (the stack cap). Holds mu so it
-// can't race a statement / finish on the same tx.
+// Returns the new depth. Refuses past maxDepth (the stack cap), or if the whole
+// tx was already finished (a concurrent root commit/rollback won the mu first —
+// the F1 race). Holds mu so it can't race a statement / finish on the same tx.
 func (t *openTxn) pushSavepoint(ctx context.Context, maxDepth int) (int, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if t.done {
+		return 0, fmt.Errorf("the transaction for this scope was just finished — begin a new one")
+	}
 	if maxDepth > 0 && len(t.savepoints) >= maxDepth {
 		return 1 + len(t.savepoints), fmt.Errorf("transaction nesting depth limit (%d) reached — commit or roll back a nested level first", maxDepth)
 	}
@@ -80,17 +90,21 @@ func (t *openTxn) pushSavepoint(ctx context.Context, maxDepth int) (int, error) 
 	return 1 + len(t.savepoints), nil
 }
 
-// popSavepoint closes the innermost nested level: commit → RELEASE (merge up),
-// rollback → ROLLBACK TO + RELEASE (undo + exit). Returns (newDepth, popped).
-// popped is false when there is no savepoint (the caller then finishes the whole
-// txn). Holds mu. SAVEPOINT/RELEASE/ROLLBACK TO are standard SQL on both tiers.
-func (t *openTxn) popSavepoint(ctx context.Context, commit bool) (depth int, popped bool, err error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if len(t.savepoints) == 0 {
+// popSavepointLocked closes the innermost nested level: commit → RELEASE (merge
+// up), rollback → ROLLBACK TO + RELEASE (undo + exit). Returns (newDepth,
+// popped); popped is false when there is no savepoint (the caller then finishes
+// the whole txn). The caller MUST hold t.mu (finishLevel does, so the
+// pop-vs-finish choice is atomic with a racing push). The name is popped even on
+// error: the level is logically closed regardless, and a leftover DB savepoint
+// is discarded at whole-tx end — keeping the name would desync depth from the
+// agent's view (the F2 fix). SAVEPOINT/RELEASE/ROLLBACK TO are standard SQL on
+// both tiers.
+func (t *openTxn) popSavepointLocked(ctx context.Context, commit bool) (depth int, popped bool, err error) {
+	n := len(t.savepoints)
+	if n == 0 {
 		return 0, false, nil
 	}
-	name := t.savepoints[len(t.savepoints)-1]
+	name := t.savepoints[n-1]
 	if commit {
 		_, err = t.tx.ExecContext(ctx, "RELEASE SAVEPOINT "+q(name))
 	} else {
@@ -100,11 +114,8 @@ func (t *openTxn) popSavepoint(ctx context.Context, commit bool) (depth int, pop
 			_, err = t.tx.ExecContext(ctx, "RELEASE SAVEPOINT "+q(name))
 		}
 	}
-	if err != nil {
-		return 1 + len(t.savepoints), true, err
-	}
-	t.savepoints = t.savepoints[:len(t.savepoints)-1]
-	return 1 + len(t.savepoints), true, nil
+	t.savepoints = t.savepoints[:n-1]
+	return 1 + len(t.savepoints), true, err
 }
 
 // finish commits or rolls back the transaction and always drops the pin. It
@@ -113,6 +124,13 @@ func (t *openTxn) popSavepoint(ctx context.Context, commit bool) (depth int, pop
 func (t *openTxn) finish(commit bool) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	return t.finishLocked(commit)
+}
+
+// finishLocked commits/rolls back the whole tx, drops the pin, and marks the txn
+// done. Caller MUST hold t.mu. The done flag is what makes a racing push refuse
+// instead of SAVEPOINT-ing a finished tx.
+func (t *openTxn) finishLocked(commit bool) error {
 	var err error
 	if commit {
 		err = t.tx.Commit()
@@ -120,6 +138,7 @@ func (t *openTxn) finish(commit bool) error {
 		err = t.tx.Rollback()
 	}
 	t.release()
+	t.done = true
 	return err
 }
 
@@ -209,43 +228,57 @@ func (m *Manager) RollbackTxn(txnID string) (int, error) {
 }
 
 // finishLevel closes one level of txnID: a nested savepoint (depth stays open)
-// or, at the root, the whole transaction. Lock discipline: m.txns.mu and the
-// per-openTxn mu are never held simultaneously (BeginTxn takes m.txns.mu then
-// the openTxn mu via pushSavepoint; here we take them sequentially in the same
-// order), so there is no deadlock. A truly-concurrent root finish + nested begin
-// on one scope is serialized but ordering is undefined (documented) — never
-// corrupting: finish always releases the pin.
+// or, at the root, the whole transaction.
+//
+// The pop-vs-finish choice AND the chosen action run under t.mu in one critical
+// section, so a concurrent nested BeginTxn (which also takes t.mu, via
+// pushSavepoint) is coherently serialized: either it pushes first and this call
+// then pops THAT savepoint (a clean LIFO release), or this call finishes first
+// (setting done) and the push then refuses — a savepoint can never be opened on
+// a tx being torn down, nor a fresh savepoint be silently committed away (F1).
+//
+// Lock order: t.mu is taken FIRST, then m.txns.mu (only for the root-finish
+// registry delete). No other path holds m.txns.mu while blocking on t.mu
+// (BeginTxn releases m.txns.mu before pushSavepoint; the sweepers delete under
+// m.txns.mu then finish outside it), so this t.mu→m.txns.mu order is the only
+// one that ever holds both — no cycle, no deadlock.
 func (m *Manager) finishLevel(txnID string, commit bool) (int, error) {
 	m.txns.mu.Lock()
 	t := m.txns.open[txnID]
 	m.txns.mu.Unlock()
 	if t == nil {
-		verb := "roll back"
-		if commit {
-			verb = "commit"
-		}
-		return 0, fmt.Errorf("no open transaction to %s for this scope", verb)
+		return 0, noOpenTxnErr(commit)
 	}
 
-	// Nested level → pop a savepoint and leave the txn open.
-	if depth, popped, err := t.popSavepoint(context.Background(), commit); popped || err != nil {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.done {
+		return 0, noOpenTxnErr(commit) // finished by a concurrent caller / sweeper
+	}
+
+	// Nested level → pop the innermost savepoint, leave the txn open.
+	if depth, popped, err := t.popSavepointLocked(context.Background(), commit); popped {
 		return depth, err
 	}
 
-	// Root level → remove from the registry (guarding against a concurrent
-	// finish that already took it) and finish the whole transaction.
+	// Root level → finish the whole tx (sets done under this same mu), then
+	// remove it from the registry.
+	err := t.finishLocked(commit)
 	m.txns.mu.Lock()
 	if cur := m.txns.open[txnID]; cur == t {
 		delete(m.txns.open, txnID)
-	} else {
-		m.txns.mu.Unlock()
-		return 0, nil // another caller already finished it
 	}
 	m.txns.mu.Unlock()
-	if err := t.finish(commit); err != nil {
-		return 0, err
+	return 0, err
+}
+
+// noOpenTxnErr is the "nothing to finish" error, phrased for the op.
+func noOpenTxnErr(commit bool) error {
+	verb := "roll back"
+	if commit {
+		verb = "commit"
 	}
-	return 0, nil
+	return fmt.Errorf("no open transaction to %s for this scope", verb)
 }
 
 // RollbackRunTxns rolls back every open transaction belonging to a run tree

--- a/internal/sqlmem/txn_test.go
+++ b/internal/sqlmem/txn_test.go
@@ -39,7 +39,7 @@ func TestTxn_CommitPersists(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	id := agentTxnID("run1", "txn-commit")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if !m.InTxn(id) {
@@ -48,7 +48,7 @@ func TestTxn_CommitPersists(t *testing.T) {
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
 		t.Fatalf("exec in txn: %v", err)
 	}
-	if err := m.CommitTxn(id); err != nil {
+	if _, err := m.CommitTxn(id); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 	if m.InTxn(id) {
@@ -71,7 +71,7 @@ func TestTxn_RollbackDiscards(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 	id := agentTxnID("run1", "txn-rb")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (2)", nil, 0); err != nil {
@@ -85,7 +85,7 @@ func TestTxn_RollbackDiscards(t *testing.T) {
 	if got, _ := res.Rows[0][0].(int64); got != 2 {
 		t.Fatalf("in-txn count=%v, want 2", res.Rows[0][0])
 	}
-	if err := m.RollbackTxn(id); err != nil {
+	if _, err := m.RollbackTxn(id); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
 	if n := rowCount(t, m, key); n != 1 {
@@ -93,26 +93,33 @@ func TestTxn_RollbackDiscards(t *testing.T) {
 	}
 }
 
-// TestTxn_Guards: double-begin, and commit/rollback with none open, all error.
+// TestTxn_Guards: commit/rollback with none open error; a second begin NESTS
+// (Phase 3b — was an error in 3a) and the depths are reported correctly.
 func TestTxn_Guards(t *testing.T) {
 	m := newTestManager(t, Config{})
 	ctx := context.Background()
 	key := agentKey("t1", "txn-g")
 	id := agentTxnID("run1", "txn-g")
-	if err := m.CommitTxn(id); err == nil {
+	if _, err := m.CommitTxn(id); err == nil {
 		t.Fatal("commit with no open txn was allowed")
 	}
-	if err := m.RollbackTxn(id); err == nil {
+	if _, err := m.RollbackTxn(id); err == nil {
 		t.Fatal("rollback with no open txn was allowed")
 	}
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
-		t.Fatalf("begin: %v", err)
+	if d, err := m.BeginTxn(ctx, id, "run1", key); err != nil || d != 1 {
+		t.Fatalf("begin: depth=%d err=%v, want depth 1", d, err)
 	}
-	if err := m.BeginTxn(ctx, id, "run1", key); err == nil {
-		t.Fatal("double begin was allowed")
+	// A second begin opens a nested SAVEPOINT level (depth 2), not an error.
+	if d, err := m.BeginTxn(ctx, id, "run1", key); err != nil || d != 2 {
+		t.Fatalf("nested begin: depth=%d err=%v, want depth 2", d, err)
 	}
-	if err := m.RollbackTxn(id); err != nil {
-		t.Fatalf("rollback: %v", err)
+	// First rollback pops the nested level (back to depth 1, txn still open).
+	if d, err := m.RollbackTxn(id); err != nil || d != 1 {
+		t.Fatalf("nested rollback: depth=%d err=%v, want depth 1", d, err)
+	}
+	// Second rollback ends the whole transaction (depth 0).
+	if d, err := m.RollbackTxn(id); err != nil || d != 0 {
+		t.Fatalf("root rollback: depth=%d err=%v, want depth 0", d, err)
 	}
 }
 
@@ -122,19 +129,19 @@ func TestTxn_MaxOpen(t *testing.T) {
 	ctx := context.Background()
 	k1, k2 := agentKey("t1", "a1"), agentKey("t1", "a2")
 	id1, id2 := agentTxnID("run1", "a1"), agentTxnID("run1", "a2")
-	if err := m.BeginTxn(ctx, id1, "run1", k1); err != nil {
+	if _, err := m.BeginTxn(ctx, id1, "run1", k1); err != nil {
 		t.Fatalf("begin 1: %v", err)
 	}
-	if err := m.BeginTxn(ctx, id2, "run1", k2); err == nil {
+	if _, err := m.BeginTxn(ctx, id2, "run1", k2); err == nil {
 		t.Fatal("begin past MaxOpenTxns was allowed")
 	}
-	if err := m.RollbackTxn(id1); err != nil {
+	if _, err := m.RollbackTxn(id1); err != nil {
 		t.Fatalf("rollback 1: %v", err)
 	}
-	if err := m.BeginTxn(ctx, id2, "run1", k2); err != nil {
+	if _, err := m.BeginTxn(ctx, id2, "run1", k2); err != nil {
 		t.Fatalf("begin 2 after freeing a slot: %v", err)
 	}
-	_ = m.RollbackTxn(id2)
+	_, _ = m.RollbackTxn(id2)
 }
 
 // TestTxn_RollbackRunTxns: run-end cleanup rolls back the tree's open txns.
@@ -146,7 +153,7 @@ func TestTxn_RollbackRunTxns(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	id := agentTxnID("runX", "rr")
-	if err := m.BeginTxn(ctx, id, "runX", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "runX", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (9)", nil, 0); err != nil {
@@ -170,7 +177,7 @@ func TestTxn_ReapStale(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	id := agentTxnID("run1", "reap")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	if _, err := m.ExecTxn(ctx, id, "INSERT INTO t VALUES (1)", nil, 0); err != nil {
@@ -200,7 +207,7 @@ func TestTxn_ConcurrentStatementsSameTxn(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	id := agentTxnID("run1", "concurrent-txn")
-	if err := m.BeginTxn(ctx, id, "run1", key); err != nil {
+	if _, err := m.BeginTxn(ctx, id, "run1", key); err != nil {
 		t.Fatalf("begin: %v", err)
 	}
 	const n = 16
@@ -220,7 +227,7 @@ func TestTxn_ConcurrentStatementsSameTxn(t *testing.T) {
 	for err := range errs {
 		t.Fatalf("concurrent ExecTxn: %v", err)
 	}
-	if err := m.CommitTxn(id); err != nil {
+	if _, err := m.CommitTxn(id); err != nil {
 		t.Fatalf("commit: %v", err)
 	}
 	if got := rowCount(t, m, key); got != n {

--- a/internal/sqlmem/validate_test.go
+++ b/internal/sqlmem/validate_test.go
@@ -34,6 +34,12 @@ func TestValidateStatement_EscapeBlocked(t *testing.T) {
 		{"multi-stmt-drop", `CREATE TABLE t(a); DROP TABLE other`},
 		{"begin-txn", `BEGIN`},
 		{"commit-txn", `COMMIT`},
+		// Phase 3b runtime-issues SAVEPOINT/RELEASE/ROLLBACK TO; an agent must
+		// never issue them raw (it would desync the runtime's savepoint stack).
+		{"rollback-txn", `ROLLBACK`},
+		{"rollback-to", `ROLLBACK TO SAVEPOINT sp1`},
+		{"savepoint", `SAVEPOINT sp1`},
+		{"release", `RELEASE SAVEPOINT sp1`},
 		{"comment-hidden-attach", `/* harmless */ ATTACH DATABASE 'x' AS y`},
 		{"line-comment-attach", "-- note\nATTACH DATABASE 'x' AS y"},
 	}

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -367,7 +367,7 @@ const memoryDescription = `Persistent key/value storage scoped to this agent or 
 	`v0.9.0: pass embed=true with embed_text on set to enable semantic search; use op=search with query to find rows by similarity. ` +
 	`v0.12.x: merge / append_dedupe / bounded_list are atomic reducers — use them instead of get-modify-set when concurrent updates are possible. ` +
 	`add / recall (memory-layer backends only): add ingests conversation messages (the backend may LLM-extract durable facts); recall is a natural-language semantic search over those facts. These require a memory-layer backend (memory_backend kind=mem9); against the default key/value store they return capability_unsupported. Unlike set/get, add does not store value-at-key and is often async — do not assume read-after-write. ` +
-	`RFC AA SQL Memory: sql_query runs a read-only SELECT and sql_exec runs a single DDL/DML statement (CREATE/INSERT/UPDATE/DELETE) against a per-scope sqlite database SEPARATE from the rest of your memory. Pass statement (one statement, no ATTACH/PRAGMA/load_extension/multiple statements) and optional positional args for ? placeholders. scope selects the database: agent (this agent, durable), user (this end-user, durable), or run (ephemeral, dropped when the run ends). For atomic multi-step writes, sql_begin opens a transaction for the scope, subsequent sql_exec/sql_query run on it, and sql_commit / sql_rollback finish it (one open transaction per scope; it auto-rolls-back if the run ends or it is abandoned). Requires sql_scopes on the agent AND the server-side subsystem enabled.`
+	`RFC AA SQL Memory: sql_query runs a read-only SELECT and sql_exec runs a single DDL/DML statement (CREATE/INSERT/UPDATE/DELETE) against a per-scope sqlite database SEPARATE from the rest of your memory. Pass statement (one statement, no ATTACH/PRAGMA/load_extension/multiple statements) and optional positional args for ? placeholders. scope selects the database: agent (this agent, durable), user (this end-user, durable), or run (ephemeral, dropped when the run ends). For atomic multi-step writes, sql_begin opens a transaction for the scope, subsequent sql_exec/sql_query run on it, and sql_commit / sql_rollback finish it (it auto-rolls-back if the run ends or it is abandoned). A second sql_begin while one is open NESTS a savepoint — sql_commit/sql_rollback then affect the innermost level (the outer transaction continues on rollback); each result reports the current depth (0 = closed). Requires sql_scopes on the agent AND the server-side subsystem enabled.`
 
 const memoryInputSchema = `{
   "type": "object",
@@ -730,14 +730,16 @@ func (m *Memory) execSqlBegin(ctx context.Context, in memoryInput) (tools.Result
 	txnID := sqlmem.BuildTxnID(rid, scope, scopeID)
 	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
 	start := time.Now()
-	berr := m.SqlMem.BeginTxn(ctx, txnID, rid, key)
+	depth, berr := m.SqlMem.BeginTxn(ctx, txnID, rid, key)
 	durMs := time.Since(start).Milliseconds()
 	if berr != nil {
 		m.auditSql(ctx, "sql_begin", scope, scopeID, "", 0, durMs, berr)
 		return errResult(fmt.Sprintf("sql_begin: %s", berr)), nil
 	}
 	m.auditSql(ctx, "sql_begin", scope, scopeID, "", 0, durMs, nil)
-	return okJSON(map[string]any{"ok": true})
+	// depth is the nesting level after this begin (1 = root txn; 2+ = a nested
+	// SAVEPOINT level — Phase 3b).
+	return okJSON(map[string]any{"ok": true, "depth": depth})
 }
 
 // execSqlTxnFinish commits (commit=true) or rolls back the open transaction for
@@ -759,11 +761,12 @@ func (m *Memory) execSqlTxnFinish(ctx context.Context, in memoryInput, commit bo
 		return errResult(fmt.Sprintf("%s: an explicit transaction requires an active run", op)), nil
 	}
 	start := time.Now()
+	var depth int
 	var ferr error
 	if commit {
-		ferr = m.SqlMem.CommitTxn(txnID)
+		depth, ferr = m.SqlMem.CommitTxn(txnID)
 	} else {
-		ferr = m.SqlMem.RollbackTxn(txnID)
+		depth, ferr = m.SqlMem.RollbackTxn(txnID)
 	}
 	durMs := time.Since(start).Milliseconds()
 	if ferr != nil {
@@ -771,7 +774,9 @@ func (m *Memory) execSqlTxnFinish(ctx context.Context, in memoryInput, commit bo
 		return errResult(fmt.Sprintf("%s: %s", op, ferr)), nil
 	}
 	m.auditSql(ctx, op, scope, scopeID, "", 0, durMs, nil)
-	return okJSON(map[string]any{"ok": true})
+	// depth is the nesting level AFTER this op: a nested level was closed (still
+	// >0) or the whole transaction committed/rolled back (0). Phase 3b.
+	return okJSON(map[string]any{"ok": true, "depth": depth})
 }
 
 // embedDirective reports whether a bind arg is an {"$embed": "<text>"} directive

--- a/internal/tools/builtin/memory_sql_test.go
+++ b/internal/tools/builtin/memory_sql_test.go
@@ -67,8 +67,8 @@ func TestMemorySQL_DefaultDenyWithoutScopes(t *testing.T) {
 
 // TestMemorySQL_ExplicitTransactionThroughTool drives the Phase-3a ops through
 // the tool's Execute: begin→insert→rollback discards, begin→insert→commit
-// persists (so sql_exec correctly routes onto the open txn), and a double begin
-// errors.
+// persists (so sql_exec correctly routes onto the open txn), and a second
+// sql_begin nests via a SAVEPOINT (Phase 3b).
 func TestMemorySQL_ExplicitTransactionThroughTool(t *testing.T) {
 	tool, _, ctx, cleanup := sqlMemoryFixture(t)
 	defer cleanup()
@@ -119,12 +119,20 @@ func TestMemorySQL_ExplicitTransactionThroughTool(t *testing.T) {
 		t.Fatalf("after commit count=%d, want 1", c)
 	}
 
-	// double begin errors
-	exec(`{"op":"sql_begin","scope":"agent"}`)
-	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_begin","scope":"agent"}`)); !res.IsError {
-		t.Fatal("double sql_begin should error")
+	// Nested begin → SAVEPOINT (Phase 3b): a second sql_begin nests (depth 2)
+	// rather than erroring; an inner rollback undoes only the inner write, and the
+	// outer commit persists the outer write.
+	exec(`{"op":"sql_begin","scope":"agent"}`) // depth 1
+	exec(`{"op":"sql_exec","scope":"agent","statement":"INSERT INTO t VALUES (10)"}`)
+	if res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_begin","scope":"agent"}`)); res.IsError || !strings.Contains(res.Text, `"depth":2`) {
+		t.Fatalf("nested sql_begin should nest to depth 2, got is_error=%v %s", res.IsError, res.Text)
 	}
-	exec(`{"op":"sql_rollback","scope":"agent"}`)
+	exec(`{"op":"sql_exec","scope":"agent","statement":"INSERT INTO t VALUES (11)"}`)
+	exec(`{"op":"sql_rollback","scope":"agent"}`) // pop inner → 11 undone, txn open
+	exec(`{"op":"sql_commit","scope":"agent"}`)   // commit root → 10 persists
+	if c := count(); c != 2 {
+		t.Fatalf("after nested round-trip count=%d, want 2 (x=2 + x=10)", c)
+	}
 }
 
 // TestMemorySQL_NotEnabledServer refuses when the manager is nil even if the


### PR DESCRIPTION
## Why

Phase 3a gave SQL Memory **one** transaction per `(run, scope)` — a second `sql_begin` errored. 3a explicitly deferred nesting ("SAVEPOINT / nesting — deferred to a 3b slice"). This adds it: an agent can "try a sub-step and undo only that on failure" — the nested-transaction idiom every ORM exposes.

## What

A second `sql_begin` while a transaction is open now **nests** (opens a `SAVEPOINT`) instead of erroring. The agent uses the **same three ops at any depth** — no new ops, no agent-managed savepoint names:

| | depth 0 (none open) | depth ≥1 (open) |
|---|---|---|
| `sql_begin` | open the txn | `SAVEPOINT` (push) |
| `sql_commit` | commit the txn | `RELEASE` (merge up) |
| `sql_rollback` | abort the txn | `ROLLBACK TO` + `RELEASE` (undo inner only; outer continues) |

Each op's result now reports the current `depth` (1 = root txn, 0 = closed).

**Surgical extension of 3a** — the savepoint stack lives *inside* the existing `openTxn` (no new `txnID`, no new connection pinning): `MaxOpenTxns` still bounds top-level txns, and one new `sqlmem_max_txn_depth` (default 16) bounds the stack. `BeginTxn`/`CommitTxn`/`RollbackTxn` now return the resulting depth. A whole-transaction commit/rollback (explicit, run-end `RollbackRunTxns`, or the reaper) discards every savepoint with it — no new cleanup path, no snapshot/resume work. Names are runtime-generated + quoted; `SAVEPOINT`/`RELEASE`/`ROLLBACK TO` are standard SQL run directly on the dialect-agnostic `*sql.Tx`, so both tiers work unchanged.

**The one behavior change vs 3a:** a second `sql_begin` previously errored; the 3a "double-begin errors" guard test is replaced by a nesting test.

## Security
No new isolation surface (a savepoint is within the same per-scope txn). The validator already denies agent-issued `savepoint`/`release`/`begin`/`commit`/`rollback`, so the model can't desync the runtime's stack — a regression test now locks that (raw `SAVEPOINT`/`RELEASE`/`ROLLBACK`/`ROLLBACK TO` via `sql_exec` stay refused).

## Commits
1. `feat(sqlmem)` — the nesting mechanism + config + tool surface + tests.
2. `docs(sqlmem)` — SQL_MEMORY.md nesting section + REVISIONS.
3. `fix(sqlmem)` — adversarial-review fixes (below).

## Review
Two adversarial passes ran on the diff. Verified clean: no deadlock (lock order is consistent), no pin double-release, injection-proof savepoint names, correct depth accounting, complete back-compat (only `memory.go` + tests call the changed methods — no wire/RPC surface). Two findings fixed in commit 3:
- **F1 (Med→High, real race):** a nested `sql_begin` racing the root finish could open a savepoint the finish then committed away (data loss) or hit `ErrTxDone`. Fixed by making the pop-vs-finish choice + the action one critical section under the `openTxn` mutex (+ a `done` flag), so a racing push is coherently serialized. Added a `-race` stress regression (concurrent nested begin + root commit ×200; asserts no pin leak/wedge/panic).
- **F2 (Low):** `popSavepoint` could desync the stack if `RELEASE` failed after `ROLLBACK TO` — now pops the name regardless.

## Tested
- `internal/sqlmem` (sqlite, every `go test`): nested rollback undoes inner only, nested commit keeps both, depth cap, whole-txn cleanup at depth, depth reporting, the F1 concurrency stress test.
- `internal/sqlmem` (postgres, gated on `LOOMCYCLE_TEST_SQLMEM_PG_DSN`, runs in CI `go-postgres`): nested round trip via pgx savepoints (live PG16).
- `internal/tools/builtin`: tool-level nested round trip through the JSON depth path.
- Validator regression: raw savepoint keywords stay denied.
- `go test ./...` clean; `go vet`; `-race` on `internal/sqlmem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)