### PR TITLE
feat(sqlmem): RFC AA Phase 3f.3 — size-based durable-scope GC

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -10,6 +10,16 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ## What's in vNEXT
 
+**📐 SQL Memory — size-based GC (RFC AA, Phase 3f).** The durable-scope sweeper
+gains an optional aggregate **size budget**: set **`sqlmem_total_max_bytes`** and
+when all durable (`agent`/`user`) scopes together exceed it, the sweeper evicts
+the **largest idle** scopes until back under budget — complementing the TTL sweep
+(idle-targeting) with a bulk-targeting one. Off by default + lossy (like all GC);
+per-scope size is already the quota's job, this bounds the total. In-use scopes
+(in-flight op / open transaction) are never evicted; `run` scopes never counted.
+sqlite measures the true on-disk footprint (`.db` + `-wal`/`-shm`); postgres sums
+`pg_total_relation_size` per scope schema.
+
 **🪆 SQL Memory — nested transactions / SAVEPOINT (RFC AA, Phase 3b).** A second
 `sql_begin` while a transaction is open now **nests** (opens a `SAVEPOINT`)
 instead of erroring — the agent uses the same `sql_begin`/`sql_commit`/

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1155,6 +1155,7 @@ func main() {
 			MaxTxnDepth:        cfg.Storage.SqlMemMaxTxnDepth,
 			ScopeTTLMS:         cfg.Storage.SqlMemScopeTTLMS,
 			GCIntervalMS:       cfg.Storage.SqlMemGCIntervalMS,
+			TotalMaxBytes:      cfg.Storage.SqlMemTotalMaxBytes,
 		}
 		// SQL Memory FOLLOWS the main store backend (RFC AA decision 4): a
 		// postgres deploy gets schema-per-scope in the SEPARATE aux DB; a

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -78,7 +78,8 @@ agents:
 | `LOOMCYCLE_SQLMEM_MAX_OPEN_TXNS` | `sqlmem_max_open_txns` | cap on concurrent open transactions process-wide (default 64; each pins a connection) |
 | `LOOMCYCLE_SQLMEM_MAX_TXN_DEPTH` | `sqlmem_max_txn_depth` | cap on SAVEPOINT nesting depth within one transaction (default 16; a nested `sql_begin` past it errors) |
 | `LOOMCYCLE_SQLMEM_SCOPE_TTL_MS` | `sqlmem_scope_ttl_ms` | durable-scope GC: drop an `agent`/`user` scope idle longer than this. **0 = OFF** (default — GC discards data) |
-| `LOOMCYCLE_SQLMEM_GC_INTERVAL_MS` | `sqlmem_gc_interval_ms` | how often the GC sweeper runs (default 1h; only when the TTL is set) |
+| `LOOMCYCLE_SQLMEM_GC_INTERVAL_MS` | `sqlmem_gc_interval_ms` | how often the GC sweeper runs (default 1h; runs when the TTL or the size budget is set) |
+| `LOOMCYCLE_SQLMEM_TOTAL_MAX_BYTES` | `sqlmem_total_max_bytes` | size-based GC: when ALL durable scopes together exceed this, evict the largest idle ones until under budget. **0 = OFF** (default — GC discards data) |
 
 `LOOMCYCLE_SQLMEM_PG_DSN` carries the aux credentials — like `LOOMCYCLE_PG_DSN`
 it is on the env-expand denylist and is **never** interpolatable into a
@@ -95,6 +96,15 @@ Set **`sqlmem_scope_ttl_ms`** (off by default) and a background sweeper (every
 `sqlmem_gc_interval_ms`, default 1h) drops any durable scope **not used** for
 longer than the TTL — the sqlite `.db` file (fenced removal), or the postgres
 schema + role. `run` scopes are never touched.
+
+The same sweeper also enforces an optional **aggregate size budget**: set
+**`sqlmem_total_max_bytes`** (off by default) and when the combined on-disk
+footprint of all durable scopes exceeds it, the sweeper evicts the **largest
+idle** scopes until back under budget. This complements the TTL (which targets
+*idle* scopes regardless of size); the budget targets *bulk* regardless of
+recency. Per-scope size is already capped per write by the quota — the budget
+bounds the total. An in-use scope (an in-flight op or open transaction) is never
+evicted; the next sweep catches it once idle.
 
 > **GC is lossy — opt in deliberately.** A dropped scope's tables are gone; an
 > agent or user that returns *after* the TTL starts empty. Set the TTL generously

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -339,9 +339,16 @@ type StorageConfig struct {
 	// GC'd. Env: LOOMCYCLE_SQLMEM_SCOPE_TTL_MS.
 	SqlMemScopeTTLMS int `yaml:"sqlmem_scope_ttl_ms"`
 	// SqlMemGCIntervalMS is how often the durable-scope GC sweeper runs. 0 → a
-	// sensible default (one hour); only meaningful when SqlMemScopeTTLMS > 0.
-	// Env: LOOMCYCLE_SQLMEM_GC_INTERVAL_MS.
+	// sensible default (one hour); meaningful when SqlMemScopeTTLMS > 0 OR
+	// SqlMemTotalMaxBytes > 0. Env: LOOMCYCLE_SQLMEM_GC_INTERVAL_MS.
 	SqlMemGCIntervalMS int `yaml:"sqlmem_gc_interval_ms"`
+	// SqlMemTotalMaxBytes turns on size-based GC (Phase 3f): when the AGGREGATE
+	// on-disk size of all durable (agent/user) scopes exceeds this, the sweeper
+	// evicts the largest idle scopes until back under budget (per-scope size is
+	// already capped per-write by the quota; this bounds the total). 0 = OFF (the
+	// default — GC DISCARDS DATA, so it is opt-in). Complements the TTL sweep.
+	// Env: LOOMCYCLE_SQLMEM_TOTAL_MAX_BYTES.
+	SqlMemTotalMaxBytes int64 `yaml:"sqlmem_total_max_bytes"`
 }
 
 // ConfigDir returns the directory the YAML was loaded from. Used by
@@ -2690,6 +2697,11 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_SQLMEM_GC_INTERVAL_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			cfg.Storage.SqlMemGCIntervalMS = n
+		}
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_TOTAL_MAX_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
+			cfg.Storage.SqlMemTotalMaxBytes = n
 		}
 	}
 	// Defaults for the bounds the operator did not set. quota stays 0 (off);

--- a/internal/sqlmem/gc.go
+++ b/internal/sqlmem/gc.go
@@ -53,10 +53,11 @@ func (m *Manager) touch(key ScopeKey) {
 	}
 }
 
-// startGC launches the durable-scope sweeper (no-op when ScopeTTLMS <= 0).
+// startGC launches the durable-scope sweeper. No-op unless TTL GC (ScopeTTLMS)
+// OR size-based GC (TotalMaxBytes) is enabled.
 func (m *Manager) startGC() {
 	m.gcStop = make(chan struct{})
-	if m.cfg.ScopeTTLMS <= 0 {
+	if m.cfg.ScopeTTLMS <= 0 && m.cfg.TotalMaxBytes <= 0 {
 		return
 	}
 	interval := time.Duration(m.cfg.GCIntervalMS) * time.Millisecond
@@ -93,15 +94,32 @@ func (m *Manager) stopGC() {
 	}
 }
 
-// runGC sweeps durable scopes idle longer than ttl.
+// runGC sweeps durable scopes: first by TTL (idle longer than ttl), then by the
+// aggregate size budget (TotalMaxBytes, evicting the largest idle scopes). Each
+// sub-sweep is independent and only runs when its knob is set.
 func (m *Manager) runGC(ttl time.Duration) {
-	cutoff := time.Now().Add(-ttl)
-	dropped, err := m.backend.sweepStale(cutoff)
-	if err != nil {
-		log.Printf("sqlmem: durable-scope GC sweep: %v", err)
+	var dropped int
+	if m.cfg.ScopeTTLMS > 0 {
+		n, err := m.backend.sweepStale(time.Now().Add(-ttl))
+		if err != nil {
+			log.Printf("sqlmem: durable-scope TTL GC sweep: %v", err)
+		}
+		if n > 0 {
+			log.Printf("sqlmem: durable-scope TTL GC dropped %d idle scope(s)", n)
+		}
+		dropped += n
+	}
+	if m.cfg.TotalMaxBytes > 0 {
+		n, err := m.backend.sweepBudget(m.cfg.TotalMaxBytes)
+		if err != nil {
+			log.Printf("sqlmem: durable-scope size GC sweep: %v", err)
+		}
+		if n > 0 {
+			log.Printf("sqlmem: durable-scope size GC dropped %d scope(s) over the %d-byte budget", n, m.cfg.TotalMaxBytes)
+		}
+		dropped += n
 	}
 	if dropped > 0 {
-		log.Printf("sqlmem: durable-scope GC dropped %d idle scope(s)", dropped)
 		// Forget debounce entries so a scope that is recreated after a drop
 		// re-records its last_used promptly (the old entry would suppress it).
 		m.touchMu.Lock()

--- a/internal/sqlmem/gc_test.go
+++ b/internal/sqlmem/gc_test.go
@@ -3,6 +3,7 @@ package sqlmem
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -117,6 +118,142 @@ func TestGC_TouchUpdatesMtime(t *testing.T) {
 	}
 	if info.ModTime().Before(time.Now().Add(-time.Minute)) {
 		t.Fatalf("read did not touch the scope mtime forward (still %v)", info.ModTime())
+	}
+}
+
+// fillScope writes rows*~3KB into scope key's table (created if needed), making
+// its on-disk footprint comfortably exceed a sub-megabyte budget.
+func fillScope(t *testing.T, m *Manager, key ScopeKey, rows int) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := m.Exec(ctx, key, "CREATE TABLE IF NOT EXISTS t (x TEXT)", nil, 0); err != nil {
+		t.Fatalf("create %s/%s: %v", key.Scope, key.ScopeID, err)
+	}
+	blob := strings.Repeat("x", 3000)
+	for i := 0; i < rows; i++ {
+		if _, err := m.Exec(ctx, key, "INSERT INTO t VALUES (?)", []any{blob}, 0); err != nil {
+			t.Fatalf("fill %s/%s: %v", key.Scope, key.ScopeID, err)
+		}
+	}
+}
+
+// TestGC_SweepBudgetSqlite: the size sweep drops the LARGEST idle durable scope
+// to get under the aggregate budget, leaves the small scopes alone, and never
+// touches the run scope even when it is large.
+func TestGC_SweepBudgetSqlite(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	big := agentKey("t1", "big")
+	small1 := agentKey("t1", "small1")
+	small2 := agentKey("t2", "small2")
+	run := ScopeKey{Scope: "run", ScopeID: "run-big"}
+	for _, k := range []ScopeKey{small1, small2} {
+		if _, err := m.Exec(ctx, k, "CREATE TABLE t (x TEXT)", nil, 0); err != nil {
+			t.Fatalf("create %s: %v", k.ScopeID, err)
+		}
+	}
+	fillScope(t, m, big, 500) // ~1.5 MB
+	fillScope(t, m, run, 500) // large too — but a run scope is never swept
+
+	const budget = 300 * 1024 // 300 KB: well below `big`, well above the smalls
+	dropped, err := m.backend.sweepBudget(budget)
+	if err != nil {
+		t.Fatalf("sweepBudget: %v", err)
+	}
+	if dropped != 1 {
+		t.Fatalf("dropped=%d, want 1 (only the largest durable scope)", dropped)
+	}
+	root := managerRoot(t, m)
+	bigPath, _ := big.keyPath(root)
+	if _, err := os.Stat(bigPath); !os.IsNotExist(err) {
+		t.Fatal("largest scope was not dropped by the size sweep")
+	}
+	for _, k := range []ScopeKey{small1, small2} {
+		p, _ := k.keyPath(root)
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("small scope %s dropped by size sweep: %v", k.ScopeID, err)
+		}
+	}
+	runPath, _ := run.keyPath(root)
+	if _, err := os.Stat(runPath); err != nil {
+		t.Fatal("run scope dropped by size GC — run scopes must NEVER be swept")
+	}
+}
+
+// TestGC_SweepBudgetSkipsInUse: the size sweep never drops an in-use scope even
+// when it is over budget; it drops the largest IDLE scope instead.
+func TestGC_SweepBudgetSkipsInUse(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	busy := agentKey("t1", "busy-big")
+	idle := agentKey("t1", "idle-big")
+	fillScope(t, m, busy, 500)
+	fillScope(t, m, idle, 500)
+
+	// Pin `busy` with an open transaction (inUse>0).
+	txnID := agentTxnID("run1", "busy-big")
+	if _, err := m.BeginTxn(ctx, txnID, "run1", busy); err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _, _ = m.RollbackTxn(txnID) }()
+
+	dropped, err := m.backend.sweepBudget(300 * 1024)
+	if err != nil {
+		t.Fatalf("sweepBudget: %v", err)
+	}
+	if dropped != 1 {
+		t.Fatalf("dropped=%d, want 1 (the idle scope; the in-use one is skipped)", dropped)
+	}
+	root := managerRoot(t, m)
+	busyPath, _ := busy.keyPath(root)
+	if _, err := os.Stat(busyPath); err != nil {
+		t.Fatal("in-use scope was dropped by the size sweep")
+	}
+	idlePath, _ := idle.keyPath(root)
+	if _, err := os.Stat(idlePath); !os.IsNotExist(err) {
+		t.Fatal("idle over-budget scope was not dropped")
+	}
+}
+
+// TestGC_SweepBudgetPostgres: the size sweep drops the largest durable scope on
+// the postgres tier and leaves the small one. Gated on LOOMCYCLE_TEST_SQLMEM_PG_DSN.
+func TestGC_SweepBudgetPostgres(t *testing.T) {
+	m, _ := pgTestManager(t, Config{})
+	ctx := context.Background()
+	big := agentKey("t1", "pg-big")
+	small := agentKey("t1", "pg-small")
+	if _, err := m.Exec(ctx, small, "CREATE TABLE t (x text)", nil, 0); err != nil {
+		t.Fatalf("create small: %v", err)
+	}
+	if _, err := m.Exec(ctx, big, "CREATE TABLE t (x text)", nil, 0); err != nil {
+		t.Fatalf("create big: %v", err)
+	}
+	// Incompressible distinct rows so pg_total_relation_size is genuinely large
+	// (a repeated string would TOAST-compress to almost nothing).
+	if _, err := m.Exec(ctx, big, "INSERT INTO t SELECT md5(g::text) FROM generate_series(1, 30000) g", nil, 0); err != nil {
+		t.Fatalf("fill big: %v", err)
+	}
+
+	dropped, err := m.backend.sweepBudget(64 * 1024) // 64 KB: below big, above the empty small
+	if err != nil {
+		t.Fatalf("sweepBudget: %v", err)
+	}
+	if dropped != 1 {
+		t.Fatalf("dropped=%d, want 1 (the largest scope)", dropped)
+	}
+	scopes, err := m.ListScopes(ctx)
+	if err != nil {
+		t.Fatalf("ListScopes: %v", err)
+	}
+	got := map[ScopeKey]bool{}
+	for _, s := range scopes {
+		got[s] = true
+	}
+	if got[big] {
+		t.Fatal("largest scope not dropped by the size sweep")
+	}
+	if !got[small] {
+		t.Fatal("small scope wrongly dropped by the size sweep")
 	}
 }
 

--- a/internal/sqlmem/gc_test.go
+++ b/internal/sqlmem/gc_test.go
@@ -215,6 +215,34 @@ func TestGC_SweepBudgetSkipsInUse(t *testing.T) {
 	}
 }
 
+// TestGC_SweepBudgetAllInUse: when the only over-budget scope is in use, the
+// sweep drops nothing and terminates (no spin) — it can't get under budget this
+// round and catches the scope on a later sweep once idle.
+func TestGC_SweepBudgetAllInUse(t *testing.T) {
+	m := newTestManager(t, Config{})
+	ctx := context.Background()
+	key := agentKey("t1", "only-big")
+	fillScope(t, m, key, 500)
+	txnID := agentTxnID("run1", "only-big")
+	if _, err := m.BeginTxn(ctx, txnID, "run1", key); err != nil { // pin it
+		t.Fatalf("begin: %v", err)
+	}
+	defer func() { _, _ = m.RollbackTxn(txnID) }()
+
+	dropped, err := m.backend.sweepBudget(64 * 1024) // far below the scope; but it's pinned
+	if err != nil {
+		t.Fatalf("sweepBudget: %v", err)
+	}
+	if dropped != 0 {
+		t.Fatalf("dropped=%d, want 0 (the only over-budget scope is in use)", dropped)
+	}
+	root := managerRoot(t, m)
+	p, _ := key.keyPath(root)
+	if _, err := os.Stat(p); err != nil {
+		t.Fatal("in-use scope was dropped despite being pinned")
+	}
+}
+
 // TestGC_SweepBudgetPostgres: the size sweep drops the largest durable scope on
 // the postgres tier and leaves the small one. Gated on LOOMCYCLE_TEST_SQLMEM_PG_DSN.
 func TestGC_SweepBudgetPostgres(t *testing.T) {

--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -789,12 +789,18 @@ func (b *postgresBackend) sweepBudget(budget int64) (int, error) {
 		if busy {
 			continue // pinned by a live op / open txn — skip, catch it next sweep
 		}
-		if _, err := b.dropScopePG(ctx, s.schema, role); err != nil {
+		removed, err := b.dropScopePG(ctx, s.schema, role)
+		if err != nil {
 			log.Printf("sqlmem: size GC drop scope %s: %v", s.schema, err)
-			continue
+			continue // real failure — the schema's bytes are still on disk
 		}
-		dropped++
+		// On a nil error the schema is gone (whether we dropped it or a concurrent
+		// drop already had — removed=false on 3F000), so its bytes left the budget;
+		// only count it as OUR drop when we actually removed it (log accuracy).
 		total -= s.size
+		if removed {
+			dropped++
+		}
 	}
 	return dropped, nil
 }

--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -725,6 +726,75 @@ func (b *postgresBackend) sweepStale(cutoff time.Time) (int, error) {
 			continue
 		}
 		dropped++
+	}
+	return dropped, nil
+}
+
+// sweepBudget drops the LARGEST idle durable scopes until the aggregate durable
+// footprint is at or under budget (Phase 3f size-based GC). Size is
+// pg_total_relation_size summed per scope schema (tables + indexes + toast),
+// read as admin; durable scopes come from the scope_registry joined with live
+// namespaces (a dropped schema doesn't join, so ghosts aren't counted). In-use
+// scopes (inUse>0 — a live op or open txn pins the pool) are skipped; the run
+// scope is never registered, so never counted.
+func (b *postgresBackend) sweepBudget(budget int64) (int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	rows, err := b.admin.QueryContext(ctx,
+		`SELECT n.nspname, COALESCE(SUM(pg_total_relation_size(c.oid)), 0)
+		   FROM sqlmem_meta.scope_registry r
+		   JOIN pg_catalog.pg_namespace n ON n.nspname = r.schema_name
+		   LEFT JOIN pg_catalog.pg_class c ON c.relnamespace = n.oid AND c.relkind IN ('r','m','p')
+		  WHERE r.scope <> $1
+		  GROUP BY n.nspname`, runScope)
+	if err != nil {
+		return 0, err
+	}
+	type scopeSize struct {
+		schema string
+		size   int64
+	}
+	var scopes []scopeSize
+	var total int64
+	for rows.Next() {
+		var s scopeSize
+		if err := rows.Scan(&s.schema, &s.size); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		scopes = append(scopes, s)
+		total += s.size
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	if total <= budget {
+		return 0, nil
+	}
+	sort.Slice(scopes, func(i, j int) bool { return scopes[i].size > scopes[j].size })
+	var dropped int
+	for _, s := range scopes {
+		if total <= budget {
+			break
+		}
+		role := "sqlmem_r_" + strings.TrimPrefix(s.schema, "sqlmem_s_")
+		if !pgIdentRe.MatchString(s.schema) || !pgIdentRe.MatchString(role) {
+			continue // defensive — only our own hashed identifiers
+		}
+		b.mu.Lock()
+		sc, ok := b.scopes[role]
+		busy := ok && sc.inUse > 0
+		b.mu.Unlock()
+		if busy {
+			continue // pinned by a live op / open txn — skip, catch it next sweep
+		}
+		if _, err := b.dropScopePG(ctx, s.schema, role); err != nil {
+			log.Printf("sqlmem: size GC drop scope %s: %v", s.schema, err)
+			continue
+		}
+		dropped++
+		total -= s.size
 	}
 	return dropped, nil
 }

--- a/internal/sqlmem/sqlite.go
+++ b/internal/sqlmem/sqlite.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -408,6 +409,74 @@ func (b *sqliteBackend) sweepStale(cutoff time.Time) (int, error) {
 		return nil
 	})
 	return dropped, err
+}
+
+// sweepBudget drops the LARGEST idle durable scopes until the aggregate durable
+// footprint is at or under budget (Phase 3f size-based GC). Size is the true
+// on-disk footprint — the .db file PLUS its -wal/-shm sidecars (in WAL mode
+// un-checkpointed pages live in -wal, so the .db alone undercounts an active
+// scope). In-use scopes (inUse>0) are skipped — the next sweep catches them once
+// idle — and the run subtree is never counted or dropped.
+func (b *sqliteBackend) sweepBudget(budget int64) (int, error) {
+	runDir := filepath.Join(b.cfg.Root, runScope)
+	type scopeFile struct {
+		path string
+		size int64
+	}
+	var files []scopeFile
+	var total int64
+	err := filepath.WalkDir(b.cfg.Root, func(path string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			if path == runDir {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".db") {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return nil
+		}
+		size := info.Size()
+		for _, suffix := range []string{"-wal", "-shm"} {
+			if si, serr := os.Stat(path + suffix); serr == nil {
+				size += si.Size()
+			}
+		}
+		files = append(files, scopeFile{path: path, size: size})
+		total += size
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if total <= budget {
+		return 0, nil
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].size > files[j].size })
+	var dropped int
+	for _, f := range files {
+		if total <= budget {
+			break
+		}
+		b.mu.Lock()
+		if h, ok := b.open[f.path]; ok && h.inUse > 0 {
+			b.mu.Unlock()
+			continue // pinned by a live op / open txn — skip, catch it next sweep
+		}
+		b.evictPathLocked(f.path)
+		b.mu.Unlock()
+		if removed, rerr := fencedRemoveDB(filepath.Dir(f.path), f.path); rerr == nil && removed {
+			dropped++
+			total -= f.size
+		}
+	}
+	return dropped, nil
 }
 
 // dropRunScope closes+evicts the handle for the run/<runID>.db file and

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -68,8 +68,12 @@ type Config struct {
 	// run-end).
 	ScopeTTLMS int
 	// GCIntervalMS is how often the GC sweeper runs. 0 → a sensible default
-	// (one hour). Only meaningful when ScopeTTLMS > 0.
+	// (one hour). Meaningful when ScopeTTLMS > 0 or TotalMaxBytes > 0.
 	GCIntervalMS int
+	// TotalMaxBytes turns on size-based GC (Phase 3f): when the aggregate on-disk
+	// size of all durable scopes exceeds this, the sweeper evicts the largest idle
+	// scopes until back under budget. 0 = OFF. Complements ScopeTTLMS.
+	TotalMaxBytes int64
 }
 
 // backend is the per-tier DB engine the Manager delegates to AFTER the
@@ -97,6 +101,10 @@ type backend interface {
 	// sweepStale drops every DURABLE (agent/user) scope last used before cutoff
 	// and returns how many were dropped. Never touches the run scope.
 	sweepStale(cutoff time.Time) (dropped int, err error)
+	// sweepBudget drops the LARGEST idle DURABLE scopes until the aggregate
+	// durable footprint is at or under budget (Phase 3f size-based GC). Skips
+	// in-use scopes (inUse>0) and the run scope; returns how many were dropped.
+	sweepBudget(budget int64) (dropped int, err error)
 	// listScopes enumerates every DURABLE scope for snapshot capture (RFC AA
 	// Phase 3e); exportScope/restoreScope move one scope's logical dump in/out.
 	listScopes(ctx context.Context) ([]ScopeKey, error)


### PR DESCRIPTION
## Why

3d's GC drops *idle* durable scopes (TTL). But a deployment can accumulate bulk in *active* scopes too — per-scope size is capped per-write by the quota, but nothing bounded the **aggregate** durable footprint. 3f.3 adds that bound.

## What

An optional aggregate size budget (`sqlmem_total_max_bytes`, off by default): when all durable (`agent`/`user`) scopes together exceed it, the sweeper evicts the **largest idle** scopes until back under budget. Complements the TTL sweep — TTL targets *idle* regardless of size; the budget targets *bulk* regardless of recency.

- **Reuses 3d's machinery** via a new `backend.sweepBudget(budget)`: skips in-use scopes (`inUse>0` — a live op or open transaction pins the scope; the next sweep catches it once idle), never counts/drops the `run` scope, drops via the existing fenced (sqlite) / owned (postgres) path. The GC goroutine now starts when **either** the TTL or the budget is set; `runGC` runs each sub-sweep independently (TTL-off does not run a bogus-cutoff sweep).
- **Size = true footprint.** sqlite sums `.db` + `-wal`/`-shm` (un-checkpointed WAL pages would otherwise undercount an active scope); postgres sums `pg_total_relation_size` per scope schema, read as admin from the 3e registry joined to live namespaces (dropped schemas aren't counted).
- Off by default + **lossy** (like all GC — evicting the largest, idle-or-not). The operator sets a generous budget.

## Tested
- sqlite: drops the largest idle scope to get under budget, leaves the smalls, never touches `run`; in-use (open-txn) scope skipped → largest *idle* dropped instead; **all-remaining-in-use → drops nothing and terminates** (no spin).
- postgres (gated on `LOOMCYCLE_TEST_SQLMEM_PG_DSN`, runs in CI `go-postgres`): largest dropped via `pg_total_relation_size` (incompressible `md5` rows so the size is real, not TOAST-compressed away).
- Full `internal/sqlmem` `-race` green; `go test ./...` clean; `go vet`.

## Review
One adversarial pass: **no load-bearing bugs** — the inUse/eviction path is byte-identical to the vetted `sweepStale`; lifecycle/gate/config/run-exclusion all verified. Fixed one LOW item (postgres counted a no-op drop when a schema vanished cross-replica → now only counts a real removal) and added the all-in-use termination test it flagged.

Part of RFC AA Phase 3f (smaller deferrals). 3f.4 (Sql-tool resolution) and 3f.2 (snapshot cap + bounded streaming) follow as separate PRs; 3f.1 (sqlite vectors) + 3f.5 (write-lease) deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)