### PR TITLE
feat(sqlmem): RFC AA Phase 3g — operator-defined read-only shared schemas

### DIFF
--- a/REVISIONS.md
+++ b/REVISIONS.md
@@ -10,6 +10,19 @@ For pre-v0.4 history (single-tool runtime, library milestone, security patch), s
 
 ## What's in vNEXT
 
+**🔗 SQL Memory — read-only shared schemas (RFC AA, Phase 3g, postgres tier).**
+Agents are otherwise fully isolated; now an operator can expose **curated
+reference data** (lookup/taxonomy/config tables) to every agent. Load it into a
+dedicated schema, `GRANT SELECT … TO PUBLIC`, and list it in
+**`sqlmem_shared_schemas`** — the runtime bakes it onto every scope role's
+`search_path` so agents can `SELECT`/`JOIN` it, but **cannot write it**
+(read-only is engine-enforced — the role holds `SELECT` only). Generalizes the
+`sqlmem_ext` pattern. Isolation preserved (a scope reads *only* the blessed
+schema, never another scope's); a shared schema is **global/cross-tenant** (put
+only non-sensitive reference data there). A scope's own table shadows a same-named
+shared one; invalid/missing/reserved names are skipped with a boot warning.
+postgres-only (ignored on sqlite).
+
 **📦 SQL Memory — snapshot per-scope cap (RFC AA, Phase 3f.2).** A snapshot can
 now bound an individual SQL Memory scope: set **`sqlmem_snapshot_max_scope_bytes`**
 and a scope whose logical dump exceeds it is **excluded** from the snapshot and

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1156,6 +1156,7 @@ func main() {
 			ScopeTTLMS:         cfg.Storage.SqlMemScopeTTLMS,
 			GCIntervalMS:       cfg.Storage.SqlMemGCIntervalMS,
 			TotalMaxBytes:      cfg.Storage.SqlMemTotalMaxBytes,
+			SharedSchemas:      cfg.Storage.SqlMemSharedSchemas,
 		}
 		// SQL Memory FOLLOWS the main store backend (RFC AA decision 4): a
 		// postgres deploy gets schema-per-scope in the SEPARATE aux DB; a
@@ -1175,6 +1176,9 @@ func main() {
 		} else {
 			if strings.TrimSpace(cfg.Storage.SqlMemPgDSN) != "" {
 				log.Printf("sqlmem: LOOMCYCLE_SQLMEM_PG_DSN is set but the backend is sqlite — ignoring it (file-per-scope at %s)", sqlMemRoot)
+			}
+			if len(cfg.Storage.SqlMemSharedSchemas) > 0 {
+				log.Printf("sqlmem: sqlmem_shared_schemas is set but the backend is sqlite — ignoring it (read-only shared schemas are a postgres-tier feature, RFC AA Phase 3g)")
 			}
 			sqlMemMgr, smErr = sqlmem.New(sqlMemCfg)
 			sqlMemTier = "sqlite (file-per-scope, root=" + sqlMemRoot + ")"

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -95,6 +95,7 @@ agents:
 | `LOOMCYCLE_SQLMEM_GC_INTERVAL_MS` | `sqlmem_gc_interval_ms` | how often the GC sweeper runs (default 1h; runs when the TTL or the size budget is set) |
 | `LOOMCYCLE_SQLMEM_TOTAL_MAX_BYTES` | `sqlmem_total_max_bytes` | size-based GC: when ALL durable scopes together exceed this, evict the largest idle ones until under budget. **0 = OFF** (default — GC discards data) |
 | `LOOMCYCLE_SQLMEM_SNAPSHOT_MAX_SCOPE_BYTES` | `sqlmem_snapshot_max_scope_bytes` | snapshot per-scope cap: a scope whose dump exceeds this is excluded + recorded (not restored). **0 = no cap** (default) |
+| `LOOMCYCLE_SQLMEM_SHARED_SCHEMAS` | `sqlmem_shared_schemas` | **postgres tier:** comma-separated list of operator-curated **read-only** shared schemas every scope can `SELECT` (Phase 3g). Empty by default; ignored on sqlite. See *Read-only shared schemas* |
 
 `LOOMCYCLE_SQLMEM_PG_DSN` carries the aux credentials — like `LOOMCYCLE_PG_DSN`
 it is on the env-expand denylist and is **never** interpolatable into a
@@ -382,6 +383,53 @@ to one the runtime created itself. `run` scopes are never snapshotted.
 For consistency across sections, **pause the runtime** (`POST /v1/runtime/pause`)
 before capturing — a scope written between the section reads is otherwise
 captured at the read instant.
+
+## Read-only shared schemas (postgres tier)
+
+Agents are otherwise fully isolated — each reads only its own scope. To share
+**operator-curated reference data** (lookup/taxonomy/config tables) across every
+agent, the operator loads it into a dedicated schema, grants `SELECT`, and lists
+it in `sqlmem_shared_schemas`. The runtime bakes that schema onto every scope
+role's `search_path`, so an agent can `SELECT` / `JOIN` it — but **cannot write
+it** (read-only is engine-enforced). This generalizes the `sqlmem_ext` pattern
+(which exposes the pgvector type the same way).
+
+One-time provisioning, as the admin in the aux DB (use any non-`sqlmem_`,
+non-`pg_` schema name — the `sqlmem_*` namespace is reserved for the runtime):
+
+```sql
+CREATE SCHEMA refdata;
+CREATE TABLE refdata.countries (code text PRIMARY KEY, name text);
+INSERT INTO refdata.countries VALUES ('US','United States'), ('UA','Ukraine');
+GRANT USAGE  ON SCHEMA refdata TO PUBLIC;                              -- reach the schema
+GRANT SELECT ON ALL TABLES IN SCHEMA refdata TO PUBLIC;               -- read existing tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA refdata GRANT SELECT ON TABLES TO PUBLIC;  -- and future ones
+```
+```yaml
+# loomcycle.yaml — bake it onto every scope role's search_path
+storage:
+  sqlmem_shared_schemas: [refdata]
+```
+
+An agent: `SELECT o.id, c.name FROM orders o JOIN countries c ON c.code = o.country`
+(unqualified `countries` resolves via `search_path`; `orders` is the scope's
+own). `INSERT INTO countries …` → `permission denied`.
+
+- **Read-only is engine-enforced.** The scope role holds only `SELECT` (no
+  `INSERT`/`UPDATE`/`DELETE`, no `CREATE` on the schema), so postgres denies every
+  write + `DROP` — the same hard guarantee as scope isolation. **Grant `SELECT`
+  only**; granting more is operator error (the runtime grants nothing here).
+- **Isolation preserved.** A scope gains read access to *only* the listed shared
+  schema(s) — never another scope's. The shared read does not widen cross-scope
+  or cross-tenant isolation.
+- **Global / cross-tenant.** A shared schema is visible to **every tenant's**
+  scopes. Put only non-sensitive, non-tenant-specific reference data there.
+- **Shadowing = scope wins.** A scope's own table of the same name shadows the
+  shared one for unqualified refs (and `CREATE TABLE` always lands in the scope
+  schema); qualify (`refdata.countries`) to force the shared one.
+- **Resilient config.** An invalid, missing, or reserved (`sqlmem_*`/`pg_*`/
+  `information_schema`) name is skipped with a boot warning — never fatal. The
+  feature is **postgres-only**; on the sqlite tier the setting is ignored.
 
 ## Audit
 

--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -427,9 +427,12 @@ own). `INSERT INTO countries …` → `permission denied`.
 - **Shadowing = scope wins.** A scope's own table of the same name shadows the
   shared one for unqualified refs (and `CREATE TABLE` always lands in the scope
   schema); qualify (`refdata.countries`) to force the shared one.
-- **Resilient config.** An invalid, missing, or reserved (`sqlmem_*`/`pg_*`/
-  `information_schema`) name is skipped with a boot warning — never fatal. The
-  feature is **postgres-only**; on the sqlite tier the setting is ignored.
+- **Resilient config.** An invalid, missing, or reserved name is skipped with a
+  boot warning — never fatal. Reserved = `sqlmem_*` / `pg_*` / `information_schema`
+  / `public` (the runtime's own namespaces, plus `public` — on PG ≤14 it ships
+  `CREATE`-to-PUBLIC, so exposing it could make a *writable* cross-tenant surface;
+  use a dedicated schema like `refdata`). The feature is **postgres-only**; on the
+  sqlite tier the setting is ignored.
 
 ## Audit
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,6 +355,15 @@ type StorageConfig struct {
 	// sink the whole capture or blow the 512 MB envelope cap); it is not
 	// restored. 0 = no per-scope cap. Env: LOOMCYCLE_SQLMEM_SNAPSHOT_MAX_SCOPE_BYTES.
 	SqlMemSnapshotMaxScopeBytes int64 `yaml:"sqlmem_snapshot_max_scope_bytes"`
+	// SqlMemSharedSchemas lists operator-curated READ-ONLY shared schemas (Phase
+	// 3g, postgres tier only). Each is baked onto every scope role's search_path so
+	// agents can SELECT/JOIN the operator's reference tables; read-only is
+	// engine-enforced (the operator grants SELECT only — see docs/SQL_MEMORY.md).
+	// A shared schema is GLOBAL (visible to every tenant's scopes) — put only
+	// non-sensitive, non-tenant-specific data there. Invalid/missing names are
+	// skipped with a boot warning. Ignored on the sqlite tier. Env (comma-
+	// separated): LOOMCYCLE_SQLMEM_SHARED_SCHEMAS.
+	SqlMemSharedSchemas []string `yaml:"sqlmem_shared_schemas"`
 }
 
 // ConfigDir returns the directory the YAML was loaded from. Used by
@@ -2714,6 +2723,15 @@ func Load(path string) (*Config, error) {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n >= 0 {
 			cfg.Storage.SqlMemSnapshotMaxScopeBytes = n
 		}
+	}
+	if v := os.Getenv("LOOMCYCLE_SQLMEM_SHARED_SCHEMAS"); v != "" {
+		var names []string
+		for _, n := range strings.Split(v, ",") {
+			if n = strings.TrimSpace(n); n != "" {
+				names = append(names, n)
+			}
+		}
+		cfg.Storage.SqlMemSharedSchemas = names
 	}
 	// Defaults for the bounds the operator did not set. quota stays 0 (off);
 	// timeout/rows get sensible ceilings; audit defaults to full.

--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -93,6 +93,10 @@ type postgresBackend struct {
 	secret  []byte          // HMAC key for per-scope role passwords (= admin password)
 
 	vectors bool // pgvector present in the aux DB (RFC AA Phase 3c — vector columns)
+	// sharedSchemas are the operator's READ-ONLY shared schemas (RFC AA Phase 3g)
+	// that EXIST + passed name validation — baked onto every scope role's
+	// search_path. Empty when none configured / all skipped.
+	sharedSchemas []string
 
 	mu          sync.Mutex
 	provisioned map[string]bool        // schema names provisioned in THIS process
@@ -163,16 +167,54 @@ func newPostgresBackend(ctx context.Context, cfg Config) (*postgresBackend, erro
 		_ = admin.Close()
 		return nil, fmt.Errorf("sqlmem: provision meta tables: %w", err)
 	}
+	shared := validateSharedSchemas(pingCtx, admin, cfg.SharedSchemas)
 	return &postgresBackend{
-		cfg:         cfg,
-		admin:       admin,
-		baseCfg:     baseCfg,
-		secret:      []byte(baseCfg.Password),
-		vectors:     vectors,
-		provisioned: make(map[string]bool),
-		provLocks:   make(map[string]*sync.Mutex),
-		scopes:      make(map[string]*scopeConn),
+		cfg:           cfg,
+		admin:         admin,
+		baseCfg:       baseCfg,
+		secret:        []byte(baseCfg.Password),
+		vectors:       vectors,
+		sharedSchemas: shared,
+		provisioned:   make(map[string]bool),
+		provLocks:     make(map[string]*sync.Mutex),
+		scopes:        make(map[string]*scopeConn),
 	}, nil
+}
+
+// pgSharedSchemaRe is the shape an operator-configured shared schema name must
+// match before it is interpolated into search_path DDL (RFC AA Phase 3g). A
+// plain lowercase identifier — postgres folds unquoted identifiers to lowercase,
+// and the recipe creates lowercase schemas. Belt-and-braces over the
+// operator-trusted config (a typo / injection attempt is rejected, not run).
+var pgSharedSchemaRe = regexp.MustCompile(`^[a-z_][a-z0-9_]{0,62}$`)
+
+// validateSharedSchemas filters the configured shared schemas down to the ones
+// that pass name validation AND actually exist in the aux DB. An invalid or
+// missing name is SKIPPED with a boot warning (never fatal — a misconfigured
+// shared schema must not take the runtime down), mirroring the pgvector probe.
+// The reserved sqlmem_* / information_schema / pg_* namespaces are refused so a
+// shared schema can't shadow the runtime's own.
+func validateSharedSchemas(ctx context.Context, admin *sql.DB, names []string) []string {
+	var out []string
+	for _, name := range names {
+		if !pgSharedSchemaRe.MatchString(name) {
+			log.Printf("sqlmem: shared schema %q skipped — not a valid lowercase identifier", name)
+			continue
+		}
+		if strings.HasPrefix(name, "sqlmem_") || strings.HasPrefix(name, "pg_") || name == "information_schema" {
+			log.Printf("sqlmem: shared schema %q skipped — reserved namespace", name)
+			continue
+		}
+		var exists bool
+		if err := admin.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = $1)`, name).Scan(&exists); err != nil || !exists {
+			log.Printf("sqlmem: shared schema %q skipped — not found in the aux DB (create + GRANT SELECT first; see docs/SQL_MEMORY.md)", name)
+			continue
+		}
+		out = append(out, name)
+		log.Printf("sqlmem: read-only shared schema %q exposed to all scopes (Phase 3g — global, cross-tenant)", name)
+	}
+	return out
 }
 
 // vectorsEnabled reports whether the postgres tier can serve vector columns
@@ -308,6 +350,14 @@ func (b *postgresBackend) runProvisionDDL(ctx context.Context, schema, role stri
 	searchPath := q(schema)
 	if b.vectors {
 		searchPath = q(schema) + ", " + q(pgVectorExtSchema)
+	}
+	// Append the operator's read-only shared schemas (RFC AA Phase 3g) AFTER the
+	// scope schema (+ sqlmem_ext), so an unqualified ref hits the scope's own
+	// table first (shadowing) and CREATE TABLE still lands in the scope schema
+	// (the role has CREATE only there). Names are pre-validated in
+	// validateSharedSchemas, so q() interpolation is safe.
+	for _, sh := range b.sharedSchemas {
+		searchPath += ", " + q(sh)
 	}
 	stmts := []string{
 		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, q(schema)),

--- a/internal/sqlmem/postgres.go
+++ b/internal/sqlmem/postgres.go
@@ -201,7 +201,11 @@ func validateSharedSchemas(ctx context.Context, admin *sql.DB, names []string) [
 			log.Printf("sqlmem: shared schema %q skipped — not a valid lowercase identifier", name)
 			continue
 		}
-		if strings.HasPrefix(name, "sqlmem_") || strings.HasPrefix(name, "pg_") || name == "information_schema" {
+		if strings.HasPrefix(name, "sqlmem_") || strings.HasPrefix(name, "pg_") || name == "information_schema" || name == "public" {
+			// `public` is refused too: on PG ≤14 it ships CREATE-to-PUBLIC by
+			// default, so exposing it could turn the shared schema into a WRITABLE
+			// cross-tenant surface — the opposite of read-only. Operators use a
+			// dedicated schema (the recipe's `refdata`).
 			log.Printf("sqlmem: shared schema %q skipped — reserved namespace", name)
 			continue
 		}

--- a/internal/sqlmem/shared_schema_test.go
+++ b/internal/sqlmem/shared_schema_test.go
@@ -10,6 +10,33 @@ import (
 // shared_schema_test.go — RFC AA Phase 3g: operator-defined read-only shared
 // schemas (postgres tier). Gated on LOOMCYCLE_TEST_SQLMEM_PG_DSN.
 
+// TestPgSharedSchemaRe locks the shared-schema-name validation regex against
+// injection + a future (?m) drift — no DB needed, so it runs on every `go test`.
+func TestPgSharedSchemaRe(t *testing.T) {
+	valid := []string{"refdata", "_lookup", "country_codes", "a", "ref2data"}
+	for _, s := range valid {
+		if !pgSharedSchemaRe.MatchString(s) {
+			t.Errorf("pgSharedSchemaRe rejected valid name %q", s)
+		}
+	}
+	invalid := []string{
+		"",            // empty
+		"Refdata",     // uppercase (no case bypass)
+		"2ref",        // leading digit
+		"ref-data",    // dash
+		"ref data",    // space
+		"refdata\n",   // trailing newline ($ must be end-of-text, not pre-\n)
+		"a\nDROP",     // embedded newline
+		`a"b`,         // embedded quote (q() break-out attempt)
+		"refdata; --", // statement terminator
+	}
+	for _, s := range invalid {
+		if pgSharedSchemaRe.MatchString(s) {
+			t.Errorf("pgSharedSchemaRe ACCEPTED invalid name %q — injection guard weakened", s)
+		}
+	}
+}
+
 // sharedSchemaManager sets up a read-only shared schema `refdata` (loaded +
 // granted SELECT to PUBLIC, the operator recipe) and returns a Manager that
 // exposes it via SharedSchemas. The shared schema is created BEFORE NewPostgres
@@ -148,7 +175,7 @@ func TestSharedSchema_Shadowing(t *testing.T) {
 // schema names are dropped at construction (boot warning); the runtime starts and
 // scopes provision without them.
 func TestSharedSchema_MisconfigSkipped(t *testing.T) {
-	m, _ := pgTestManager(t, Config{SharedSchemas: []string{"does_not_exist", "Bad-Name!", "sqlmem_meta", "pg_catalog"}})
+	m, _ := pgTestManager(t, Config{SharedSchemas: []string{"does_not_exist", "Bad-Name!", "sqlmem_meta", "pg_catalog", "public"}})
 	ctx := context.Background()
 	pb, ok := m.backend.(*postgresBackend)
 	if !ok {

--- a/internal/sqlmem/shared_schema_test.go
+++ b/internal/sqlmem/shared_schema_test.go
@@ -1,0 +1,164 @@
+package sqlmem
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+)
+
+// shared_schema_test.go — RFC AA Phase 3g: operator-defined read-only shared
+// schemas (postgres tier). Gated on LOOMCYCLE_TEST_SQLMEM_PG_DSN.
+
+// sharedSchemaManager sets up a read-only shared schema `refdata` (loaded +
+// granted SELECT to PUBLIC, the operator recipe) and returns a Manager that
+// exposes it via SharedSchemas. The shared schema is created BEFORE NewPostgres
+// so the boot probe finds it.
+func sharedSchemaManager(t *testing.T) (*Manager, *sql.DB) {
+	t.Helper()
+	dsn := os.Getenv("LOOMCYCLE_TEST_SQLMEM_PG_DSN")
+	if dsn == "" {
+		t.Skip("set LOOMCYCLE_TEST_SQLMEM_PG_DSN to run the postgres SQL Memory tests")
+	}
+	raw, err := sql.Open("pgx", dsn)
+	if err != nil {
+		t.Fatalf("open raw aux: %v", err)
+	}
+	dropAllScopes(t, raw)
+	ctx := context.Background()
+	for _, s := range []string{
+		`DROP SCHEMA IF EXISTS refdata CASCADE`,
+		`CREATE SCHEMA refdata`,
+		`CREATE TABLE refdata.countries (code text PRIMARY KEY, name text)`,
+		`INSERT INTO refdata.countries VALUES ('US','United States'),('UA','Ukraine')`,
+		`GRANT USAGE ON SCHEMA refdata TO PUBLIC`,
+		`GRANT SELECT ON ALL TABLES IN SCHEMA refdata TO PUBLIC`,
+		`ALTER DEFAULT PRIVILEGES IN SCHEMA refdata GRANT SELECT ON TABLES TO PUBLIC`,
+	} {
+		if _, err := raw.ExecContext(ctx, s); err != nil {
+			_ = raw.Close()
+			t.Fatalf("shared-schema setup %q: %v", s, err)
+		}
+	}
+	m, err := NewPostgres(ctx, Config{PgDSN: dsn, StatementTimeoutMS: 30000, MaxRows: 10000, SharedSchemas: []string{"refdata"}})
+	if err != nil {
+		_ = raw.Close()
+		t.Fatalf("NewPostgres: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = m.Close()
+		dropAllScopes(t, raw)
+		_, _ = raw.ExecContext(ctx, `DROP SCHEMA IF EXISTS refdata CASCADE`)
+		_ = raw.Close()
+	})
+	return m, raw
+}
+
+// TestSharedSchema_ReadOnly: a scope can SELECT the shared table (unqualified via
+// search_path AND schema-qualified), but every write is engine-denied.
+func TestSharedSchema_ReadOnly(t *testing.T) {
+	m, _ := sharedSchemaManager(t)
+	ctx := context.Background()
+	key := agentKey("t1", "reader")
+
+	res, err := m.Query(ctx, key, "SELECT name FROM countries WHERE code='US'", nil) // unqualified via search_path
+	if err != nil {
+		t.Fatalf("unqualified read of shared table: %v", err)
+	}
+	if got, _ := res.Rows[0][0].(string); got != "United States" {
+		t.Fatalf("unqualified read = %q, want United States", got)
+	}
+	res, err = m.Query(ctx, key, "SELECT name FROM refdata.countries WHERE code='UA'", nil) // qualified
+	if err != nil {
+		t.Fatalf("qualified read of shared table: %v", err)
+	}
+	if got, _ := res.Rows[0][0].(string); got != "Ukraine" {
+		t.Fatalf("qualified read = %q, want Ukraine", got)
+	}
+
+	if _, err := m.Exec(ctx, key, "INSERT INTO refdata.countries VALUES ('FR','France')", nil, 0); err == nil {
+		t.Fatal("INSERT into shared schema was allowed — read-only must be engine-denied")
+	}
+	if _, err := m.Exec(ctx, key, "UPDATE refdata.countries SET name='x' WHERE code='US'", nil, 0); err == nil {
+		t.Fatal("UPDATE of shared schema was allowed — read-only must be engine-denied")
+	}
+}
+
+// TestSharedSchema_Isolation: read access to the shared schema does NOT widen
+// cross-scope isolation — another scope still cannot read this scope's schema.
+func TestSharedSchema_Isolation(t *testing.T) {
+	m, _ := sharedSchemaManager(t)
+	ctx := context.Background()
+	a := agentKey("t1", "agent-a")
+	b := agentKey("t1", "agent-b")
+
+	if _, err := m.Exec(ctx, a, "CREATE TABLE secrets (x text)", nil, 0); err != nil {
+		t.Fatalf("create a.secrets: %v", err)
+	}
+	if _, err := m.Exec(ctx, a, "INSERT INTO secrets VALUES ('topsecret')", nil, 0); err != nil {
+		t.Fatalf("insert a.secrets: %v", err)
+	}
+	// b reads the shared schema fine...
+	if _, err := m.Query(ctx, b, "SELECT count(*) FROM countries", nil); err != nil {
+		t.Fatalf("agent-b read shared: %v", err)
+	}
+	// ...but still cannot reach agent-a's scope schema.
+	schemaA, _, err := pgScopeNames(a)
+	if err != nil {
+		t.Fatalf("pgScopeNames: %v", err)
+	}
+	if _, err := m.Query(ctx, b, "SELECT x FROM "+q(schemaA)+".secrets", nil); err == nil {
+		t.Fatal("agent-b read agent-a's schema — shared access wrongly widened cross-scope isolation")
+	}
+}
+
+// TestSharedSchema_Shadowing: a scope's own table shadows a same-named shared
+// table for unqualified refs; the shared one stays reachable when qualified.
+func TestSharedSchema_Shadowing(t *testing.T) {
+	m, _ := sharedSchemaManager(t)
+	ctx := context.Background()
+	key := agentKey("t1", "shadow")
+
+	if _, err := m.Exec(ctx, key, "CREATE TABLE countries (code text, name text)", nil, 0); err != nil {
+		t.Fatalf("create own countries: %v", err)
+	}
+	if _, err := m.Exec(ctx, key, "INSERT INTO countries VALUES ('XX','Scope Local')", nil, 0); err != nil {
+		t.Fatalf("insert own: %v", err)
+	}
+	res, err := m.Query(ctx, key, "SELECT name FROM countries", nil) // unqualified → the scope's own
+	if err != nil {
+		t.Fatalf("unqualified read: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("unqualified countries returned %d rows, want 1 (the scope's own, not shared)", len(res.Rows))
+	}
+	if got, _ := res.Rows[0][0].(string); got != "Scope Local" {
+		t.Fatalf("unqualified countries = %q, want the scope's own (Scope Local)", got)
+	}
+	res, err = m.Query(ctx, key, "SELECT name FROM refdata.countries WHERE code='US'", nil) // qualified → shared
+	if err != nil {
+		t.Fatalf("qualified shared read after shadowing: %v", err)
+	}
+	if got, _ := res.Rows[0][0].(string); got != "United States" {
+		t.Fatalf("qualified shared = %q, want United States", got)
+	}
+}
+
+// TestSharedSchema_MisconfigSkipped: invalid / nonexistent / reserved shared
+// schema names are dropped at construction (boot warning); the runtime starts and
+// scopes provision without them.
+func TestSharedSchema_MisconfigSkipped(t *testing.T) {
+	m, _ := pgTestManager(t, Config{SharedSchemas: []string{"does_not_exist", "Bad-Name!", "sqlmem_meta", "pg_catalog"}})
+	ctx := context.Background()
+	pb, ok := m.backend.(*postgresBackend)
+	if !ok {
+		t.Fatalf("backend is not postgres (%T)", m.backend)
+	}
+	if len(pb.sharedSchemas) != 0 {
+		t.Fatalf("invalid/missing/reserved shared schemas were not all skipped: %v", pb.sharedSchemas)
+	}
+	// A scope still provisions + works despite the misconfig.
+	if _, err := m.Exec(ctx, agentKey("t1", "ok"), "CREATE TABLE t (x int)", nil, 0); err != nil {
+		t.Fatalf("scope op after shared-schema misconfig: %v", err)
+	}
+}

--- a/internal/sqlmem/sqlmem.go
+++ b/internal/sqlmem/sqlmem.go
@@ -74,6 +74,12 @@ type Config struct {
 	// size of all durable scopes exceeds this, the sweeper evicts the largest idle
 	// scopes until back under budget. 0 = OFF. Complements ScopeTTLMS.
 	TotalMaxBytes int64
+	// SharedSchemas lists operator-curated READ-ONLY shared schemas (Phase 3g,
+	// postgres tier only): each is baked onto every scope role's search_path so
+	// agents can SELECT the operator's reference tables. Read-only is engine-
+	// enforced (the operator grants SELECT only). Invalid/missing names are
+	// dropped at construction with a warning. Ignored by the sqlite tier.
+	SharedSchemas []string
 }
 
 // backend is the per-tier DB engine the Manager delegates to AFTER the


### PR DESCRIPTION
## Why

Agents in SQL Memory are otherwise fully isolated — each reads only its own scope. Some deployments want agents to share **operator-curated reference data** (lookup / taxonomy / config tables) without each scope duplicating it. 3g adds that — the last item from the original Phase-3 bucket.

## What

The operator loads reference tables into a dedicated schema, `GRANT SELECT … TO PUBLIC`, and lists it in **`sqlmem_shared_schemas`**. The runtime bakes each onto every scope role's `search_path`, so an agent can `SELECT`/`JOIN` the operator's tables — but **cannot write them**.

This **generalizes the existing `sqlmem_ext` pattern** (the pgvector shared schema): one `ALTER ROLE … SET search_path` line extended. The operator loads + grants; the runtime grants nothing for shared schemas, so it can't widen access.

- **Read-only is engine-enforced.** A scope role holds only `SELECT` (no `INSERT/UPDATE/DELETE`, no `CREATE` on the schema), so postgres denies every write + `DROP` — the same hard guarantee as scope isolation.
- **Isolation preserved.** A scope gains read access to *only* the listed shared schema(s) — never another scope's. `search_path` is name-resolution only; privilege comes solely from the operator's PUBLIC grant.
- **Name validation + reserved namespaces.** Each name is regex-validated (lowercase ident) before any DDL interpolation; `sqlmem_*` / `pg_*` / `information_schema` / `public` are reserved (so a shared schema can't shadow the runtime's own or expose a writable `public`). Invalid / missing / reserved names are skipped with a boot warning — never fatal (mirrors the pgvector probe).
- **Global / cross-tenant** (documented: reference data only). **Shadowing:** a scope's own same-named table wins for unqualified refs; `CREATE TABLE` always lands in the scope schema.
- **postgres-only** (sqlite controlled-`ATTACH` deferred); `main.go` warns if set on a sqlite deploy.

## Tested
postgres-gated (`LOOMCYCLE_TEST_SQLMEM_PG_DSN`, CI `go-postgres`): read works unqualified + qualified while writes are engine-denied; the shared grant doesn't widen cross-scope isolation; a scope table shadows a shared one; invalid/missing/reserved names skipped and the runtime + scopes still work. Plus a **DSN-free** regex injection test. Full `internal/sqlmem` `-race` green; `go test ./...` clean; `go vet`; gofmt.

## Review
One adversarial pass scoped on the security crux: **isolation not widened, read-only engine-enforced, no identifier injection, no reserved-namespace bypass — all verified to hold.** Two LOW items fixed: reserved `public` (PG ≤14 writable-public footgun) and added the regex injection unit test.

Completes RFC AA Phase 3g. (Docs use a neutral `refdata` example schema since the `sqlmem_*` namespace is reserved.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)