### PR TITLE
docs(sqlmem): add Context.help sql-memory topic + fix MCP memory tool description

### DIFF
--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -188,7 +188,7 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 		// can't drift from the validation the agent loop applies.
 		{
 			Name:        "memory",
-			Description: "Memory tool ops (get/set/delete/list/incr). Pass-through to the underlying Memory builtin.",
+			Description: "Memory tool ops. Families: key/value (get/set/delete/list/incr/merge/append_dedupe/bounded_list/search); memory-layer (add/recall — mem9 backends); SQL (sql_query/sql_exec/sql_begin/sql_commit/sql_rollback — a per-scope SQL database, gated separately by sql_scopes). Pass-through to the underlying Memory builtin; see the inputSchema's op enum.",
 			InputSchema: builtinSchema("memory"),
 		},
 		{

--- a/internal/help/builtin/sql-memory.md
+++ b/internal/help/builtin/sql-memory.md
@@ -1,0 +1,80 @@
+---
+name: sql-memory
+description: A per-scope SQL database on the Memory tool — when to use it, the ops, the capability gate, transactions, vectors, and shared schemas (RFC AA).
+---
+SQL Memory is a third facet of the `Memory` tool (alongside k/v and the
+semantic layer): a real, per-scope SQL database the runtime hosts, isolated
+from the main store. Reach for it when an agent needs **related tables, joins,
+and aggregates** — structured storage the k/v + vector Memory can't give —
+without `Bash + sqlite3` (which is not a sandbox). Each scope's data is
+reachable only by that scope; the threat model is escaping the scope, not SQL
+injection (the agent is authorized to run SQL).
+
+## Ops (all on the `Memory` tool)
+- `op: "sql_exec"` — ONE DDL/DML statement (`CREATE TABLE`/`INSERT`/`UPDATE`/
+  `DELETE`/…); `args` are positional bind params for `?`/`$1`. Returns
+  `{rows_affected, last_insert_id?}` (`last_insert_id` is sqlite-only — use
+  `RETURNING` on postgres).
+- `op: "sql_query"` — ONE read-only `SELECT` / `WITH … SELECT`. Returns
+  `{columns, rows, truncated}`.
+- `op: "sql_begin"` / `"sql_commit"` / `"sql_rollback"` — explicit transactions
+  (below).
+
+One statement per call. `ATTACH`, `PRAGMA`, `load_extension`, `COPY`, `SET`,
+raw `BEGIN`/`COMMIT`/`SAVEPOINT`, and multiple statements are refused.
+
+## Capability gate (default-deny)
+SQL is OFF unless **both** hold: the operator enabled the subsystem
+(`sqlmem_enabled`) AND the agent declares `sql_scopes` — having `Memory` in
+`allowed_tools` is NOT enough. SQL is a distinct capability of the tool, gated
+separately:
+```yaml
+agents:
+  research-bot:
+    allowed_tools: [Memory]
+    sql_scopes: [agent, run]   # closed enum {agent,user,run}; empty => every SQL op refuses
+```
+
+## Scope = which database
+`scope` selects the database: `agent` (this agent, durable, cross-run),
+`user` (this end-user, durable, cross-agent), or `run` (ephemeral scratch,
+dropped at run completion). Durable scopes are tenant-keyed. See `op=help
+topic=scopes`.
+
+## Transactions (atomic multi-step writes)
+`sql_begin` opens a transaction for the scope; subsequent `sql_exec`/`sql_query`
+on that scope run ON it until `sql_commit` / `sql_rollback`. A txn auto-rolls
+back if the run ends or it is abandoned. A second `sql_begin` while one is open
+**nests** a SAVEPOINT — then `sql_commit`/`sql_rollback` affect the innermost
+level (a nested rollback undoes only that level; the outer txn continues). Each
+result reports the current `depth` (1 = the root transaction, 0 = closed).
+
+```jsonc
+{"op":"sql_begin",  "scope":"agent"}                                   // depth 1
+{"op":"sql_exec",   "scope":"agent", "statement":"INSERT INTO log VALUES ('a')"}
+{"op":"sql_begin",  "scope":"agent"}                                   // depth 2 (savepoint)
+{"op":"sql_exec",   "scope":"agent", "statement":"INSERT INTO log VALUES ('b')"}
+{"op":"sql_rollback","scope":"agent"}    // undoes only 'b'; depth -> 1
+{"op":"sql_commit", "scope":"agent"}     // commits 'a'; depth -> 0
+```
+
+## Vector columns (postgres tier)
+With pgvector installed, a scope can keep embeddings in its own tables and do
+semantic KNN + structured filters in one query. Pass a bind arg of the form
+`{"$embed": "some text"}` and the runtime embeds it server-side (no raw vector
+in your context); reference it with `::vector`:
+`... ORDER BY embedding <=> ?::vector`.
+
+## Read-only shared schemas (postgres tier)
+The operator can expose curated reference tables (lookups, taxonomies) to every
+agent via `sqlmem_shared_schemas`. They are on your `search_path`, so
+`SELECT … JOIN countries …` just works — but writes are denied (read-only).
+Qualify (`refdata.countries`) to bypass a same-named scope table.
+
+## Bounds
+Per-statement timeout, `sql_query` row cap, and an optional per-scope byte
+quota apply; durable scopes can be reclaimed by an opt-in TTL / size-budget GC.
+The tier follows the main store: **sqlite** = one file per scope (compact,
+single-replica); **postgres** = one schema per scope in a separate aux DB,
+isolated by a per-scope least-privilege role (multi-replica). Full operator
+detail (provisioning, GC, snapshots, security model) is in `docs/SQL_MEMORY.md`.


### PR DESCRIPTION
## Why

A cross-transport audit of the SQL Memory surface surfaced two **discoverability** gaps (no behavior change):

1. **`Context.help` had no SQL Memory topic** — `internal/help/builtin/` has ~40 topics (compaction, vector-memory, scopes, memory-layer/ranking/reducers, fan-out…) but none for SQL Memory, even though it's an RFC-AA-sized subsystem and `Context.help` is part of the doc discipline.
2. **The MCP `memory` meta-tool's advertised `Description` was stale** — `"(get/set/delete/list/incr)"`. Its `InputSchema` (via `builtinSchema()`) already carries the *real* op enum (incl. `sql_*`, `add`/`recall`/`search`/reducers), so MCP clients could always call the SQL ops — the human description just undersold it.

## What

- Add **`internal/help/builtin/sql-memory.md`** (auto-embedded via `//go:embed builtin/*.md`): the ops, the default-deny `sql_scopes` gate, scopes, explicit + nested transactions (with `depth`), vector columns (`$embed`/`::vector`), read-only shared schemas, bounds + tiers, and a pointer to `docs/SQL_MEMORY.md`. Reachable via `Context op=help topic=sql-memory`.
- Refresh the MCP `memory` tool **Description** to list the op families (key/value · memory-layer · SQL, gated by `sql_scopes`), matching the Memory tool's own description.

No logic change. SQL Memory ops were always available in-band to agents and directly via the MCP memory tool's real schema; this only makes them **discoverable** through `help` + the MCP description.

> Note (not in this PR): SQL Memory remains an in-band Memory-tool capability — it is intentionally **not** a first-class gRPC/TS/Python client method (only `Channel` + substrate Defs were lifted to RPCs). Direct operator-driven SQL invocation over those transports would be a larger feature (RFC-first) if ever wanted.

## Tested
`go build ./...`; `internal/help` + `internal/api/mcp` suites green (the topic embeds + loads); `go vet`; gofmt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)