### PR TITLE
fix(sqlmem): durable SQL Memory scopes work in open mode (empty tenant → default)

### DIFF
--- a/docs/SQL_MEMORY.md
+++ b/docs/SQL_MEMORY.md
@@ -27,8 +27,11 @@ Two `Memory` ops (the `Memory` tool must be in the agent's `allowed_tools`):
 
 `scope` selects the database: `agent` (this agent, durable), `user` (this
 end-user, durable), or `run` (ephemeral scratch, dropped at run completion).
-Durable scopes are keyed by the authoritative tenant. One statement per call;
-`ATTACH`/`PRAGMA`/`load_extension`/`COPY`/`SET`/multiple statements are refused.
+Durable scopes are keyed by the authoritative tenant; in open mode / with the
+legacy token (no per-principal tenant) durable scopes fall back to the `default`
+tenant, so they work without the caller passing `tenant_id`. One statement per
+call; `ATTACH`/`PRAGMA`/`load_extension`/`COPY`/`SET`/multiple statements are
+refused.
 
 For **atomic multi-step writes**, three more ops manage a transaction:
 

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -630,7 +630,7 @@ func (m *Memory) execSqlQuery(ctx context.Context, in memoryInput) (tools.Result
 		m.auditSql(ctx, "sql_query", scope, scopeID, in.Statement, 0, 0, aerr)
 		return errResult(fmt.Sprintf("sql_query: %s", aerr)), nil
 	}
-	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
+	key := sqlmem.ScopeKey{Tenant: sqlScopeTenant(ctx), Scope: scope, ScopeID: scopeID}
 	txnID := currentSqlTxnID(ctx, scope, scopeID)
 	start := time.Now()
 	var res *sqlmem.QueryResult
@@ -672,7 +672,7 @@ func (m *Memory) execSqlExec(ctx context.Context, in memoryInput) (tools.Result,
 	}
 	// Per-agent quota override wins over the manager default when > 0.
 	quota := tools.SqlMemPolicy(ctx).QuotaBytes
-	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
+	key := sqlmem.ScopeKey{Tenant: sqlScopeTenant(ctx), Scope: scope, ScopeID: scopeID}
 	txnID := currentSqlTxnID(ctx, scope, scopeID)
 	start := time.Now()
 	var res *sqlmem.ExecResult
@@ -692,6 +692,23 @@ func (m *Memory) execSqlExec(ctx context.Context, in memoryInput) (tools.Result,
 		"rows_affected":  res.RowsAffected,
 		"last_insert_id": res.LastInsertID,
 	})
+}
+
+// sqlScopeTenant returns the tenant partition for a DURABLE SQL Memory scope.
+// Unlike the k/v store (which accepts an empty tenant as a valid partition), SQL
+// Memory sanitizes the tenant into a filesystem path (sqlite) / postgres
+// identifier (postgres) and so cannot key on "". In open mode / legacy-token
+// deployments the run carries no authoritative tenant (TenantID==""), which would
+// otherwise fail durable agent/user ops with "empty scope identifier";
+// canonicalize it to "default" — the value keyPath's docs assume and the
+// documented manual `tenant_id: default` workaround used (so data is continuous
+// across both). A real (non-empty) tenant is used verbatim; the run scope is not
+// tenant-keyed, so this is a no-op there.
+func sqlScopeTenant(ctx context.Context) string {
+	if t := tools.RunIdentity(ctx).TenantID; t != "" {
+		return t
+	}
+	return "default"
 }
 
 // currentSqlTxnID returns the explicit-transaction registry key for the current
@@ -728,7 +745,7 @@ func (m *Memory) execSqlBegin(ctx context.Context, in memoryInput) (tools.Result
 		return errResult("sql_begin: an explicit transaction requires an active run"), nil
 	}
 	txnID := sqlmem.BuildTxnID(rid, scope, scopeID)
-	key := sqlmem.ScopeKey{Tenant: tools.RunIdentity(ctx).TenantID, Scope: scope, ScopeID: scopeID}
+	key := sqlmem.ScopeKey{Tenant: sqlScopeTenant(ctx), Scope: scope, ScopeID: scopeID}
 	start := time.Now()
 	depth, berr := m.SqlMem.BeginTxn(ctx, txnID, rid, key)
 	durMs := time.Since(start).Milliseconds()

--- a/internal/tools/builtin/memory_sql_test.go
+++ b/internal/tools/builtin/memory_sql_test.go
@@ -65,6 +65,43 @@ func TestMemorySQL_DefaultDenyWithoutScopes(t *testing.T) {
 	}
 }
 
+// TestMemorySQL_OpenModeEmptyTenant: in open mode / legacy-token deployments the
+// run carries NO authoritative tenant (TenantID==""). A durable agent/user SQL
+// scope must still work without the caller passing tenant_id — the empty tenant
+// is canonicalized to "default" (unlike the k/v store, SQL Memory can't key on
+// "" because it sanitizes the tenant into a path / identifier). Regression for
+// the open-mode "empty scope identifier" failure.
+func TestMemorySQL_OpenModeEmptyTenant(t *testing.T) {
+	tool, _, ctx, cleanup := sqlMemoryFixture(t)
+	defer cleanup()
+	// Re-stamp the run identity with NO tenant (open mode); AgentName stays on ctx.
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test"}) // TenantID == ""
+	ctx = withSqlScopes(ctx, "agent")
+
+	for _, stmt := range []string{
+		`{"op":"sql_exec","scope":"agent","statement":"CREATE TABLE t (x INT)"}`,
+		`{"op":"sql_exec","scope":"agent","statement":"INSERT INTO t VALUES (1)"}`,
+	} {
+		if res, _ := tool.Execute(ctx, json.RawMessage(stmt)); res.IsError {
+			t.Fatalf("durable sql op in open mode (empty tenant) errored: %s -> %s", stmt, res.Text)
+		}
+	}
+	open, _ := tool.Execute(ctx, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"SELECT count(*) FROM t"}`))
+	if open.IsError {
+		t.Fatalf("query in open mode: %s", open.Text)
+	}
+	// Continuity: an explicit tenant_id="default" (the documented manual
+	// workaround) resolves to the SAME scope, so data is shared across both.
+	ctxDefault := tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "default"})
+	def, _ := tool.Execute(ctxDefault, json.RawMessage(`{"op":"sql_query","scope":"agent","statement":"SELECT count(*) FROM t"}`))
+	if def.IsError {
+		t.Fatalf("query via explicit tenant=default: %s", def.Text)
+	}
+	if open.Text != def.Text {
+		t.Fatalf("open-mode empty tenant and explicit tenant=default resolved to DIFFERENT scopes: %q vs %q", open.Text, def.Text)
+	}
+}
+
 // TestMemorySQL_ExplicitTransactionThroughTool drives the Phase-3a ops through
 // the tool's Execute: begin→insert→rollback discards, begin→insert→commit
 // persists (so sql_exec correctly routes onto the open txn), and a second


### PR DESCRIPTION
## The bug (found by the runtime test pass)

In **open mode / legacy-token** deployments a run carries no per-principal tenant — `TenantID == ""`. A durable `agent`/`user` SQL Memory op then fails:

```
sql_exec: sqlmem: empty scope identifier
```

because SQL Memory sanitizes the tenant into a filesystem path (sqlite) / postgres identifier, and can't key on `""` (`keyPath(sanitize(""))` errors; `pgScopeNames` errors the same). Unlike the k/v store — which accepts `""` as a valid partition — SQL Memory uniquely can't. Operators were working around it with *"always pass `tenant_id: default` in spawn_run."*

The existing tests never caught it because they all pass an explicit non-empty tenant; the **runtime test pass in actual open mode** surfaced it.

## Fix

Canonicalize an empty tenant to `"default"` at the SQL scope-key boundary (new `sqlScopeTenant` helper used by `sql_query`/`sql_exec`/`sql_begin`):

- `"default"` is the value `keyPath`'s docs already assume **and** the manual workaround used — so data is **continuous**: an open-mode run and an explicit `tenant_id:"default"` resolve to the **same** scope (the regression test asserts this).
- A **real (non-empty) tenant is used verbatim** — tenant isolation is unchanged (`TestMemorySQL_TenantIsolation` still passes; real tenants are never `""` so never remapped → no collision with a tenant literally named `default`).
- **Tier-agnostic** — the `ScopeKey` feeds both sqlite + postgres identically.
- The defensive empty-tenant *error* stays in `sqlmem.keyPath`/`pgScopeNames` (catches a genuine caller bug); the canonicalization lives at the caller that **knows** open mode means the default tenant.
- `run` scope is unaffected (not tenant-keyed).

## Tested
- **Fail-before regression** `TestMemorySQL_OpenModeEmptyTenant`: a durable `sql_exec` with `TenantID=""` errored `"empty scope identifier"` before; now works, and `tenant_id="default"` reaches the same scope.
- `TestMemorySQL_TenantIsolation` + the full sqlmem-tool suite green; `go test ./...` clean; `go vet`; gofmt.
- Doc note added (open mode → `default` tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)