### PR TITLE
feat(tools): Path primitive — Unix-like VFS over Memory/Volumes/Documents (RFC AL)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -684,6 +684,11 @@ func main() {
 	}
 	allTools = append(allTools, volumeDefTool)
 
+	// RFC AL — the Path tool (Unix-like VFS over the dirents substrate). Store
+	// late-bound below alongside the other substrate tools.
+	pathTool := &builtin.Path{}
+	allTools = append(allTools, pathTool)
+
 	// MCPServerDef tool construction is deferred until after the pool
 	// + dynamic registry are built (operator-admin-only — NOT appended
 	// to allTools; wired via SetMCPServerDefTool after the pool exists).
@@ -1050,6 +1055,7 @@ func main() {
 	agentDefTool.Store = storeIface
 	skillDefTool.Store = storeIface
 	volumeDefTool.Store = storeIface
+	pathTool.Store = storeIface
 	skillTool.Store = storeIface
 	evaluationTool.Store = storeIface
 	contextTool.Store = storeIface

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -52,6 +52,7 @@ Each built-in is registered into the dispatcher at process startup but **refuses
 | `SkillDef`  | Always registered (v0.8.22). Per-agent `skill_def_scopes:` YAML gate (default-deny); no extra env var. Storage shared with the rest of the substrate. |
 | `VolumeDef` | Always registered (RFC AH Phase 2a/2b). Per-agent `volume_def_scopes:` YAML gate (default-deny) for create/delete/purge; get/list are tenant-scoped reads. `create {ephemeral:true}` provisions a run-scoped volume auto-purged at top-level-run completion. Requires a static volume marked `dynamic_root: true`. Storage shared with the rest of the substrate. |
 | `Memory`    | Storage backend (SQLite default; Postgres opt-in) + per-agent `memory_scopes:` allowlist. |
+| `Path`      | Always registered (RFC AL). Per-agent `allowed_tools:[Path]`. A Unix-like VFS (`resolve`/`ls`/`stat`/`mkdir`/`mv`/`rm`) over the `dirents` runtime-store table, naming Memory entries / Volume mounts / Documents by tenant-rooted, scope-aware (agent/user/tenant) paths. Resources keep native ids; a dirent is a name, not an authority grant. Paths reject `..`; tenant-isolated. Resources opt in via `Memory.set path:` / `VolumeDef.create mount_at:` / `Document.create_document path:`. |
 
 Bash has additional warnings: it is **not a true sandbox** even when enabled. Run loomcycle inside a container or VM if Bash is exposed to untrusted prompts. See `internal/tools/builtin/bash.go` for the full warning.
 

--- a/internal/help/builtin/path.md
+++ b/internal/help/builtin/path.md
@@ -1,0 +1,60 @@
+---
+name: path
+description: Path — a Unix-like filesystem (VFS) over your Memory, Volumes, and Documents. Address resources by human-readable, scoped, tenant-isolated paths with resolve/ls/stat/mkdir/mv/rm (RFC AL).
+---
+The `Path` tool gives your Memory entries, Volumes, and Documents a **Unix-like
+directory tree** — so instead of remembering a Memory key or a Volume name, you
+can say `/prefs/voice` or `/vol/repo-a` and navigate with familiar operations.
+
+It is a **naming layer**, not a new store: each resource keeps its native id
+(Memory key, Volume name, Document UUID); a *dirent* maps a path to it (Linux
+inode/dirent separation). Resolving a path tells you what's there — using the
+resource still goes through its own tool (Memory / Volume / Document) with its
+own access rules. A path can't grant access you didn't already have.
+
+## Scopes
+
+Every path lives in a tree chosen by `scope`:
+- `agent` (default) — your own tree.
+- `user` — the end-user's tree (requires a `user_id` on the run).
+- `tenant` — shared across the tenant.
+
+Trees are **tenant-isolated**: you never see another tenant's paths (a
+cross-tenant lookup is an opaque "no such path"). The same path string in two
+scopes is two different entries.
+
+## Ops
+
+- `resolve path [scope]` — what's at this path? Returns `{kind, resource_ref,
+  full_path}`, or an error if absent.
+- `ls path [recursive] [kind_filter] [scope]` — list a directory. One level by
+  default; `recursive:true` lists all descendants; `kind_filter` narrows to one
+  kind (`document` / `volume_mount` / `memory_entry`).
+- `stat path [scope]` — the dirent's full record.
+- `mkdir path [scope]` — **no-op in v1**: directories are implicit (a leaf at
+  `/a/b/c` implies `/a/` and `/a/b/`). Kept for forward-compat.
+- `mv from to [scope]` — rename/relocate; the underlying resource is unchanged.
+  Refuses if `to` already exists (no clobber). Moving a directory cascades to
+  every descendant atomically.
+- `rm path [recursive] [scope]` — remove the path entry. Refuses a path that has
+  descendants unless `recursive:true` (Linux semantics). Removes the **name**
+  only — the backing resource stays reachable by its native id. (`resource_too`
+  is **not supported in v1**; delete the resource via its own tool.)
+
+## Path rules
+
+Absolute, slash-rooted (`/docs/launch`). Segments are
+`[a-zA-Z0-9._-]` (no spaces, no inner slashes); `..` is **rejected** (a path
+can't climb out of its tree). Max 64 segments, 1024 chars.
+
+## Registering paths
+
+Resources opt in to a path — nothing is auto-named:
+- **Memory:** `Memory op=set … path:/prefs/voice` registers the entry; later
+  `Memory op=get scope:… path:/prefs/voice` reads it by path.
+- **Volume:** `VolumeDef op=create name:repo-a mode:rw [mount_at:/vol/repo-a]`
+  mounts the volume in the tenant tree (default `/vol/<name>`).
+- **Document** (when shipped): `Document op=create_document … path:/docs/plan`.
+
+A resource created without a `path` / `mount_at` simply has no dirent and is
+reached by its native id as before — the path layer is purely additive.

--- a/internal/help/loader_test.go
+++ b/internal/help/loader_test.go
@@ -45,6 +45,7 @@ func TestLoadSet_BundledOnly(t *testing.T) {
 		"n8n-integration",
 		"observability",
 		"openai-compat",
+		"path",
 		"pause-resume-snapshot",
 		"scopes",
 		"skills-evolution",

--- a/internal/store/postgres/dirents.go
+++ b/internal/store/postgres/dirents.go
@@ -1,0 +1,175 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Dirent* implements the RFC AL Path-tree substrate on Postgres. PK is the
+// full (tenant_id, scope, scope_id, parent_path, name) coordinate. Paths
+// arrive pre-normalized (canonical, no "..") from the tool layer. See
+// internal/store/store.go for the interface contract.
+
+const direntCols = `tenant_id, scope, scope_id, parent_path, name, kind, resource_ref::text, created_at, updated_at`
+
+// likeEscape escapes the LIKE metacharacters (%, _, \) in a prefix so a path
+// segment containing '_' (a valid dirent char) can't act as a wildcard in a
+// recursive prefix match. Used with `LIKE $n ESCAPE '\'`.
+func likeEscape(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}
+
+func (s *Store) DirentCreate(ctx context.Context, row store.DirentRow) (store.DirentRow, error) {
+	now := time.Now().UTC()
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO dirents (tenant_id, scope, scope_id, parent_path, name, kind, resource_ref, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9)
+		 ON CONFLICT (tenant_id, scope, scope_id, parent_path, name) DO UPDATE SET
+		     kind = EXCLUDED.kind,
+		     resource_ref = EXCLUDED.resource_ref,
+		     updated_at = EXCLUDED.updated_at`,
+		row.TenantID, row.Scope, row.ScopeID, row.ParentPath, row.Name,
+		row.Kind, string(row.ResourceRef), now, now,
+	); err != nil {
+		return store.DirentRow{}, err
+	}
+	return s.DirentGet(ctx, row.TenantID, row.Scope, row.ScopeID, row.ParentPath, row.Name)
+}
+
+func scanDirent(sc interface{ Scan(...any) error }) (store.DirentRow, error) {
+	var (
+		r   store.DirentRow
+		ref string
+	)
+	if err := sc.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &r.ParentPath, &r.Name,
+		&r.Kind, &ref, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		return store.DirentRow{}, err
+	}
+	r.ResourceRef = json.RawMessage(ref)
+	return r, nil
+}
+
+func (s *Store) DirentGet(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (store.DirentRow, error) {
+	r, err := scanDirent(s.pool.QueryRow(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND parent_path = $4 AND name = $5`,
+		tenantID, scope, scopeID, parentPath, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.DirentRow{}, &store.ErrNotFound{Kind: "dirent", ID: parentPath + name}
+	}
+	if err != nil {
+		return store.DirentRow{}, err
+	}
+	return r, nil
+}
+
+func (s *Store) DirentList(ctx context.Context, tenantID, scope, scopeID, parentPath string) ([]store.DirentRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND parent_path = $4
+		 ORDER BY name`, tenantID, scope, scopeID, parentPath)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectDirents(rows)
+}
+
+func (s *Store) DirentListUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) ([]store.DirentRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
+		   AND (parent_path = $4 OR parent_path LIKE $5 ESCAPE '\')
+		 ORDER BY parent_path, name`,
+		tenantID, scope, scopeID, prefix, likeEscape(prefix)+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectDirents(rows)
+}
+
+func collectDirents(rows pgx.Rows) ([]store.DirentRow, error) {
+	var out []store.DirentRow
+	for rows.Next() {
+		r, err := scanDirent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) DirentDelete(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM dirents
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND parent_path = $4 AND name = $5`,
+		tenantID, scope, scopeID, parentPath, name)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (s *Store) DirentDeleteUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM dirents
+		 WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3
+		   AND (parent_path = $4 OR parent_path LIKE $5 ESCAPE '\')`,
+		tenantID, scope, scopeID, prefix, likeEscape(prefix)+"%")
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// DirentMove relocates the dirent at (fromParent, fromName) to (toParent,
+// toName) AND rewrites every descendant's parent_path prefix, in one
+// transaction (recursive rename). found=false if the source doesn't exist.
+func (s *Store) DirentMove(ctx context.Context, tenantID, scope, scopeID, fromParent, fromName, toParent, toName string) (bool, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	now := time.Now().UTC()
+	tag, err := tx.Exec(ctx,
+		`UPDATE dirents SET parent_path = $1, name = $2, updated_at = $3
+		 WHERE tenant_id = $4 AND scope = $5 AND scope_id = $6 AND parent_path = $7 AND name = $8`,
+		toParent, toName, now, tenantID, scope, scopeID, fromParent, fromName)
+	if err != nil {
+		return false, err
+	}
+	if tag.RowsAffected() == 0 {
+		return false, nil
+	}
+
+	// Rewrite descendants: old full path of the moved node is fromFull; its
+	// descendants' parent_path begins with fromFull. SUBSTRING drops that
+	// leading prefix; concat the new prefix.
+	fromFull := fromParent + fromName + "/"
+	toFull := toParent + toName + "/"
+	if _, err := tx.Exec(ctx,
+		`UPDATE dirents
+		 SET parent_path = $1 || SUBSTRING(parent_path FROM $2), updated_at = $3
+		 WHERE tenant_id = $4 AND scope = $5 AND scope_id = $6
+		   AND (parent_path = $7 OR parent_path LIKE $8 ESCAPE '\')`,
+		toFull, len(fromFull)+1, now,
+		tenantID, scope, scopeID, fromFull, likeEscape(fromFull)+"%"); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/store/postgres/dirents.go
+++ b/internal/store/postgres/dirents.go
@@ -29,6 +29,11 @@ func likeEscape(s string) string {
 
 func (s *Store) DirentCreate(ctx context.Context, row store.DirentRow) (store.DirentRow, error) {
 	now := time.Now().UTC()
+	// resource_ref is jsonb NOT NULL — an empty string is not valid JSON and
+	// the cast would fail; default to "{}" (matches the sqlite backend).
+	if len(row.ResourceRef) == 0 {
+		row.ResourceRef = json.RawMessage("{}")
+	}
 	if _, err := s.pool.Exec(ctx,
 		`INSERT INTO dirents (tenant_id, scope, scope_id, parent_path, name, kind, resource_ref, created_at, updated_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9)

--- a/internal/store/postgres/dirents.go
+++ b/internal/store/postgres/dirents.go
@@ -165,8 +165,12 @@ func (s *Store) DirentMove(ctx context.Context, tenantID, scope, scopeID, fromPa
 	fromFull := fromParent + fromName + "/"
 	toFull := toParent + toName + "/"
 	if _, err := tx.Exec(ctx,
+		// $2::int — without the cast Postgres infers $2 as text (it can't tell
+		// SUBSTRING's FROM arg is an integer from a bare placeholder) and pgx
+		// fails to encode the Go int. SQLite is untyped so its contract run
+		// passed; the go-postgres CI job caught this parity gap.
 		`UPDATE dirents
-		 SET parent_path = $1 || SUBSTRING(parent_path FROM $2), updated_at = $3
+		 SET parent_path = $1 || SUBSTRING(parent_path FROM $2::int), updated_at = $3
 		 WHERE tenant_id = $4 AND scope = $5 AND scope_id = $6
 		   AND (parent_path = $7 OR parent_path LIKE $8 ESCAPE '\')`,
 		toFull, len(fromFull)+1, now,

--- a/internal/store/postgres/migrations/0050_dirents.down.sql
+++ b/internal/store/postgres/migrations/0050_dirents.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS dirents;

--- a/internal/store/postgres/migrations/0050_dirents.up.sql
+++ b/internal/store/postgres/migrations/0050_dirents.up.sql
@@ -1,0 +1,20 @@
+-- 0050_dirents.up.sql — RFC AL Path primitive: the dirent (path tree) substrate.
+--
+-- Maps a (tenant_id, scope, scope_id, parent_path, name) coordinate to a
+-- backing resource (kind + resource_ref jsonb). PK is the full coordinate so
+-- each (tenant, scope, scope_id) tree is independent and a name is unique
+-- within its parent directory. The PK doubles as the resolve/ls lookup index;
+-- parent_path supports one-level (=) and recursive (prefix) listings.
+
+CREATE TABLE dirents (
+    tenant_id    TEXT        NOT NULL DEFAULT '',
+    scope        TEXT        NOT NULL,
+    scope_id     TEXT        NOT NULL DEFAULT '',
+    parent_path  TEXT        NOT NULL,
+    name         TEXT        NOT NULL,
+    kind         TEXT        NOT NULL,
+    resource_ref JSONB       NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL,
+    updated_at   TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, scope, scope_id, parent_path, name)
+);

--- a/internal/store/sqlite/dirents.go
+++ b/internal/store/sqlite/dirents.go
@@ -28,6 +28,12 @@ func likeEscape(s string) string {
 
 func (s *Store) DirentCreate(ctx context.Context, row store.DirentRow) (store.DirentRow, error) {
 	now := time.Now()
+	// resource_ref is NOT NULL and must be valid JSON (postgres stores it as
+	// jsonb, which rejects ""); default an empty ref to "{}" for backend
+	// parity.
+	if len(row.ResourceRef) == 0 {
+		row.ResourceRef = json.RawMessage("{}")
+	}
 	if _, err := s.db.ExecContext(ctx,
 		`INSERT INTO dirents (`+direntCols+`)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/internal/store/sqlite/dirents.go
+++ b/internal/store/sqlite/dirents.go
@@ -1,0 +1,199 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Dirent* implements the RFC AL Path-tree substrate. The PK is the full
+// coordinate (tenant_id, scope, scope_id, parent_path, name) so each
+// (tenant, scope, scope_id) tree is independent and a name is unique within
+// its parent directory. Paths arrive pre-normalized (canonical, no "..") from
+// the tool layer. See internal/store/store.go for the interface contract.
+
+const direntCols = `tenant_id, scope, scope_id, parent_path, name, kind, resource_ref, created_at, updated_at`
+
+// likeEscape escapes the LIKE metacharacters (%, _, \) in a prefix so a
+// path segment containing '_' (a valid dirent char) can't act as a wildcard
+// in a recursive prefix match. Used with `LIKE ? ESCAPE '\'`.
+func likeEscape(s string) string {
+	r := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return r.Replace(s)
+}
+
+func (s *Store) DirentCreate(ctx context.Context, row store.DirentRow) (store.DirentRow, error) {
+	now := time.Now()
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO dirents (`+direntCols+`)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, scope, scope_id, parent_path, name) DO UPDATE SET
+		     kind = excluded.kind,
+		     resource_ref = excluded.resource_ref,
+		     updated_at = excluded.updated_at`,
+		row.TenantID, row.Scope, row.ScopeID, row.ParentPath, row.Name,
+		row.Kind, string(row.ResourceRef), now.UnixNano(), now.UnixNano(),
+	); err != nil {
+		return store.DirentRow{}, err
+	}
+	return s.DirentGet(ctx, row.TenantID, row.Scope, row.ScopeID, row.ParentPath, row.Name)
+}
+
+func scanDirent(sc interface{ Scan(...any) error }) (store.DirentRow, error) {
+	var (
+		r         store.DirentRow
+		ref       string
+		createdAt int64
+		updatedAt int64
+	)
+	if err := sc.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &r.ParentPath, &r.Name,
+		&r.Kind, &ref, &createdAt, &updatedAt); err != nil {
+		return store.DirentRow{}, err
+	}
+	r.ResourceRef = json.RawMessage(ref)
+	r.CreatedAt = time.Unix(0, createdAt)
+	r.UpdatedAt = time.Unix(0, updatedAt)
+	return r, nil
+}
+
+func (s *Store) DirentGet(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (store.DirentRow, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND parent_path = ? AND name = ?`,
+		tenantID, scope, scopeID, parentPath, name)
+	r, err := scanDirent(row)
+	if err == sql.ErrNoRows {
+		return store.DirentRow{}, &store.ErrNotFound{Kind: "dirent", ID: parentPath + name}
+	}
+	if err != nil {
+		return store.DirentRow{}, err
+	}
+	return r, nil
+}
+
+func (s *Store) DirentList(ctx context.Context, tenantID, scope, scopeID, parentPath string) ([]store.DirentRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND parent_path = ?
+		 ORDER BY name`, tenantID, scope, scopeID, parentPath)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectDirents(rows)
+}
+
+// DirentListUnder returns every dirent at or under prefix (a trailing-slashed
+// directory path, e.g. "/docs/"): rows whose parent_path == prefix or begins
+// with prefix. Used for recursive ls.
+func (s *Store) DirentListUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) ([]store.DirentRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+direntCols+` FROM dirents
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?
+		   AND (parent_path = ? OR parent_path LIKE ? ESCAPE '\')
+		 ORDER BY parent_path, name`,
+		tenantID, scope, scopeID, prefix, likeEscape(prefix)+"%")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return collectDirents(rows)
+}
+
+func collectDirents(rows *sql.Rows) ([]store.DirentRow, error) {
+	var out []store.DirentRow
+	for rows.Next() {
+		r, err := scanDirent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) DirentDelete(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM dirents
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND parent_path = ? AND name = ?`,
+		tenantID, scope, scopeID, parentPath, name)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
+// DirentDeleteUnder removes every descendant at or under prefix (a
+// trailing-slashed directory path). It does NOT remove the directory's own
+// entry (which lives at its parent) — the tool removes that separately.
+func (s *Store) DirentDeleteUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM dirents
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?
+		   AND (parent_path = ? OR parent_path LIKE ? ESCAPE '\')`,
+		tenantID, scope, scopeID, prefix, likeEscape(prefix)+"%")
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return int(n), nil
+}
+
+// DirentMove relocates the dirent at (fromParent, fromName) to (toParent,
+// toName) AND rewrites the parent_path prefix of every descendant, in one
+// transaction (recursive rename). found=false if the source doesn't exist.
+func (s *Store) DirentMove(ctx context.Context, tenantID, scope, scopeID, fromParent, fromName, toParent, toName string) (bool, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	now := time.Now().UnixNano()
+	// 1. Move the entry itself.
+	res, err := tx.ExecContext(ctx,
+		`UPDATE dirents SET parent_path = ?, name = ?, updated_at = ?
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND parent_path = ? AND name = ?`,
+		toParent, toName, now, tenantID, scope, scopeID, fromParent, fromName)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	if n == 0 {
+		return false, nil // source absent; nothing moved
+	}
+
+	// 2. Rewrite descendants. The moved node's old full path is fromFull; its
+	// descendants have parent_path starting with fromFull+"/". Replace that
+	// leading prefix with toFull+"/" (toFull = toParent+toName). SUBSTR drops
+	// the old prefix and keeps the tail.
+	fromFull := fromParent + fromName + "/"
+	toFull := toParent + toName + "/"
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE dirents
+		 SET parent_path = ? || SUBSTR(parent_path, ?), updated_at = ?
+		 WHERE tenant_id = ? AND scope = ? AND scope_id = ?
+		   AND (parent_path = ? OR parent_path LIKE ? ESCAPE '\')`,
+		toFull, len(fromFull)+1, now,
+		tenantID, scope, scopeID, fromFull, likeEscape(fromFull)+"%"); err != nil {
+		return false, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -543,6 +543,25 @@ func (s *Store) migrate(ctx context.Context) error {
 			updated_at  INTEGER NOT NULL,
 			PRIMARY KEY (tenant_id, name)
 		)`,
+		// RFC AL Path primitive — the dirent (path tree) substrate. Maps a
+		// (tenant_id, scope, scope_id, parent_path, name) coordinate to a
+		// backing resource (kind + resource_ref json). PK is the full
+		// coordinate so each (tenant, scope, scope_id) tree is independent and
+		// a name is unique within its parent directory. The composite PK is
+		// also the lookup index for resolve/ls; parent_path enables one-level
+		// (=) and recursive (prefix) listings.
+		`CREATE TABLE IF NOT EXISTS dirents (
+			tenant_id    TEXT NOT NULL DEFAULT '',
+			scope        TEXT NOT NULL,
+			scope_id     TEXT NOT NULL DEFAULT '',
+			parent_path  TEXT NOT NULL,
+			name         TEXT NOT NULL,
+			kind         TEXT NOT NULL,
+			resource_ref TEXT NOT NULL,
+			created_at   INTEGER NOT NULL,
+			updated_at   INTEGER NOT NULL,
+			PRIMARY KEY (tenant_id, scope, scope_id, parent_path, name)
+		)`,
 		// RFC AH Phase 2b — ephemeral (run-tree-scoped) volumes. SEPARATE
 		// from volume_defs: PK (root_run_id, name), NOT (tenant_id, name) —
 		// two concurrent runs (any tenant) can each own a `work` volume with

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1227,6 +1227,32 @@ type Store interface {
 	// op, which deletes the row AND the files behind a four-way fence.
 	VolumeDefDelete(ctx context.Context, tenantID, name string) (bool, error)
 
+	// ---- RFC AL Path primitive — the dirent (path tree) substrate ----
+	//
+	// A dirent maps a (tenant_id, scope, scope_id, parent_path, name)
+	// coordinate to a backing resource (a Document / Volume mount / Memory
+	// entry), Linux inode/dirent style: the resource keeps its native id, the
+	// dirent is just the name. tenantID "" = the shared/operator/legacy
+	// tenant; every method scopes by (tenant_id, scope, scope_id) so tenant +
+	// scope isolation is enforced at the store boundary (and re-checked at the
+	// tool layer, opaque-404). All paths passed here are pre-normalized at the
+	// tool layer (canonical, no "..").
+	//
+	// DirentCreate upserts by the full coordinate key (re-create updates
+	// kind+resource_ref). DirentGet/DirentDelete return *ErrNotFound /
+	// found=false on a miss. DirentList is a one-level listing (ls); the
+	// *Under variants act on the whole subtree at/under a prefix (recursive ls
+	// / rm). DirentMove relocates a dirent AND rewrites every descendant's
+	// parent_path in one transaction (recursive rename); no-clobber is the
+	// tool's job (DirentGet the destination first).
+	DirentCreate(ctx context.Context, row DirentRow) (DirentRow, error)
+	DirentGet(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (DirentRow, error)
+	DirentList(ctx context.Context, tenantID, scope, scopeID, parentPath string) ([]DirentRow, error)
+	DirentListUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) ([]DirentRow, error)
+	DirentDelete(ctx context.Context, tenantID, scope, scopeID, parentPath, name string) (bool, error)
+	DirentDeleteUnder(ctx context.Context, tenantID, scope, scopeID, prefix string) (int, error)
+	DirentMove(ctx context.Context, tenantID, scope, scopeID, fromParent, fromName, toParent, toName string) (bool, error)
+
 	// ---- RFC AH Phase 2b ephemeral (run-tree-scoped) volumes ----
 	//
 	// A SEPARATE table from volume_defs: an ephemeral volume is scoped to
@@ -2241,6 +2267,38 @@ type VolumeDefRow struct {
 	Definition json.RawMessage `json:"definition"`
 	CreatedAt  time.Time       `json:"created_at"`
 	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// DirentRow is one entry in the RFC AL Path tree: it names a backing resource
+// at a (tenant_id, scope, scope_id, parent_path, name) coordinate. The
+// resource keeps its native id (Document UUID / Volume name / Memory key) —
+// the dirent is just the name (Linux inode/dirent separation). Paths are
+// canonical (slash-rooted, no "..", normalized at the tool layer).
+type DirentRow struct {
+	// TenantID is the RFC L/N tenant-isolation axis. "" = the shared/
+	// operator/legacy tenant. Set from the authoritative principal at the
+	// write site, never from the wire.
+	TenantID string `json:"tenant_id,omitempty"`
+	// Scope is the subtree: "agent" / "user" / "tenant" (validated at the
+	// tool layer). ScopeID is the owning entity (agent name / user id; empty
+	// for tenant scope). Each (tenant, scope, scope_id) tuple has its own
+	// tree rooted at "/".
+	Scope   string `json:"scope"`
+	ScopeID string `json:"scope_id,omitempty"`
+	// ParentPath is the canonical parent directory (e.g. "/docs/launches/",
+	// always trailing-slashed; the root's children have parent_path "/").
+	// Name is the leaf segment (charset-validated `[a-zA-Z0-9._-]{1,64}` at
+	// the tool layer so it can't carry slashes or "..").
+	ParentPath string `json:"parent_path"`
+	Name       string `json:"name"`
+	// Kind is "document" / "volume_mount" / "memory_entry" / "directory"
+	// (implicit dirs are rarely stored; see RFC AL §4). ResourceRef is the
+	// backing pointer, shape-by-kind ({document_id} / {volume_name,mode} /
+	// {scope,scope_id,key,facet}).
+	Kind        string          `json:"kind"`
+	ResourceRef json.RawMessage `json:"resource_ref"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
 }
 
 // EphemeralVolumeDefRow is one run-tree-scoped ephemeral volume (RFC AH

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -276,6 +276,14 @@ func Run(t *testing.T, factory Factory) {
 		{"VolumeDefDelete", testVolumeDefDelete},
 		{"VolumeDefList", testVolumeDefList},
 		{"VolumeDefCreateUpdatesDefinition", testVolumeDefCreateUpdatesDefinition},
+		// RFC AL Path primitive — the dirent (path tree) substrate.
+		{"DirentCreateAndGet", testDirentCreateAndGet},
+		{"DirentListOneLevel", testDirentListOneLevel},
+		{"DirentListUnderRecursive", testDirentListUnderRecursive},
+		{"DirentDeleteAndDeleteUnder", testDirentDeleteAndDeleteUnder},
+		{"DirentMoveCascade", testDirentMoveCascade},
+		{"DirentScopeIsolation", testDirentScopeIsolation},
+		{"DirentTenantIsolation", testDirentTenantIsolation},
 		// RFC AH Phase 2b ephemeral (run-tree-scoped) volumes.
 		{"EphemeralVolumeCreateListDelete", testEphemeralVolumeCreateListDelete},
 		{"EphemeralVolumeSweepCandidatesTerminalOnly", testEphemeralVolumeSweepCandidatesTerminalOnly},
@@ -7320,4 +7328,189 @@ func testEphemeralVolumeListByTenantIsolation(t *testing.T, s store.Store) {
 	if len(rowsB) != 1 || rowsB[0].RootRunID != "run-b1" {
 		t.Fatalf("tnt-b list = %+v, want one run-b1 row", rowsB)
 	}
+}
+
+// ── RFC AL Path primitive — dirent (path tree) substrate ────────────────────
+
+func mkDirent(tenantID, scope, scopeID, parentPath, name, kind, ref string) store.DirentRow {
+	return store.DirentRow{
+		TenantID: tenantID, Scope: scope, ScopeID: scopeID,
+		ParentPath: parentPath, Name: name, Kind: kind,
+		ResourceRef: json.RawMessage(ref),
+	}
+}
+
+func testDirentCreateAndGet(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	_, err := s.DirentCreate(ctx, mkDirent("", "user", "u1", "/", "docs", "directory", `{}`))
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := s.DirentGet(ctx, "", "user", "u1", "/", "docs")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Name != "docs" || got.Kind != "directory" {
+		t.Errorf("got %+v", got)
+	}
+	if got.CreatedAt.IsZero() || got.UpdatedAt.IsZero() {
+		t.Errorf("timestamps not stamped: %+v", got)
+	}
+	var nf *store.ErrNotFound
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/", "nope"); !errors.As(err, &nf) {
+		t.Errorf("miss err = %v, want *ErrNotFound", err)
+	}
+}
+
+func testDirentListOneLevel(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	mustCreate := func(parent, name string) {
+		if _, err := s.DirentCreate(ctx, mkDirent("", "user", "u1", parent, name, "directory", `{}`)); err != nil {
+			t.Fatalf("create %s%s: %v", parent, name, err)
+		}
+	}
+	mustCreate("/", "docs")
+	mustCreate("/docs/", "a")
+	mustCreate("/docs/", "b")
+	mustCreate("/docs/a/", "deep") // must NOT show in a one-level listing of /docs/
+	got, err := s.DirentList(ctx, "", "user", "u1", "/docs/")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 || got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("one-level list of /docs/ = %+v, want [a b]", names(got))
+	}
+}
+
+func testDirentListUnderRecursive(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for _, d := range [][2]string{{"/", "docs"}, {"/docs/", "a"}, {"/docs/a/", "b"}, {"/", "other"}} {
+		if _, err := s.DirentCreate(ctx, mkDirent("", "user", "u1", d[0], d[1], "directory", `{}`)); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	got, err := s.DirentListUnder(ctx, "", "user", "u1", "/docs/")
+	if err != nil {
+		t.Fatalf("list under: %v", err)
+	}
+	// a (parent /docs/) + b (parent /docs/a/); NOT docs itself (parent /), NOT other.
+	if len(got) != 2 {
+		t.Fatalf("recursive list of /docs/ = %+v, want 2 (a, b)", names(got))
+	}
+}
+
+func testDirentDeleteAndDeleteUnder(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for _, d := range [][2]string{{"/", "docs"}, {"/docs/", "a"}, {"/docs/a/", "b"}} {
+		if _, err := s.DirentCreate(ctx, mkDirent("", "user", "u1", d[0], d[1], "directory", `{}`)); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	n, err := s.DirentDeleteUnder(ctx, "", "user", "u1", "/docs/")
+	if err != nil {
+		t.Fatalf("delete under: %v", err)
+	}
+	if n != 2 { // a + b; the /docs entry (parent /) is NOT a descendant
+		t.Errorf("deleteUnder count = %d, want 2", n)
+	}
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/", "docs"); err != nil {
+		t.Errorf("the /docs entry should survive deleteUnder: %v", err)
+	}
+	found, err := s.DirentDelete(ctx, "", "user", "u1", "/", "docs")
+	if err != nil || !found {
+		t.Fatalf("delete /docs: found=%v err=%v", found, err)
+	}
+	found, _ = s.DirentDelete(ctx, "", "user", "u1", "/", "docs")
+	if found {
+		t.Error("second delete should be idempotent (found=false)")
+	}
+}
+
+func testDirentMoveCascade(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	for _, d := range [][2]string{{"/", "docs"}, {"/docs/", "a"}, {"/docs/a/", "b"}} {
+		if _, err := s.DirentCreate(ctx, mkDirent("", "user", "u1", d[0], d[1], "directory", `{}`)); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	}
+	// mv /docs -> /archive (a dir with descendants → cascade).
+	moved, err := s.DirentMove(ctx, "", "user", "u1", "/", "docs", "/", "archive")
+	if err != nil || !moved {
+		t.Fatalf("move: moved=%v err=%v", moved, err)
+	}
+	// The entry itself + every descendant must live under /archive now.
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/", "archive"); err != nil {
+		t.Errorf("moved entry /archive missing: %v", err)
+	}
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/archive/", "a"); err != nil {
+		t.Errorf("cascade: /archive/a missing: %v", err)
+	}
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/archive/a/", "b"); err != nil {
+		t.Errorf("cascade: /archive/a/b missing: %v", err)
+	}
+	// Old coordinates must be gone.
+	var nf *store.ErrNotFound
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/", "docs"); !errors.As(err, &nf) {
+		t.Errorf("old /docs still present after move: %v", err)
+	}
+	if _, err := s.DirentGet(ctx, "", "user", "u1", "/docs/", "a"); !errors.As(err, &nf) {
+		t.Errorf("old /docs/a still present after move: %v", err)
+	}
+	// Moving an absent source returns found=false.
+	moved, err = s.DirentMove(ctx, "", "user", "u1", "/", "ghost", "/", "x")
+	if err != nil || moved {
+		t.Errorf("move of absent source: moved=%v err=%v, want false/nil", moved, err)
+	}
+}
+
+func testDirentScopeIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	// Same path /notes in agent scope vs tenant scope → distinct dirents.
+	if _, err := s.DirentCreate(ctx, mkDirent("", "agent", "a1", "/", "notes", "memory_entry", `{"k":"agent"}`)); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	if _, err := s.DirentCreate(ctx, mkDirent("", "tenant", "", "/", "notes", "memory_entry", `{"k":"tenant"}`)); err != nil {
+		t.Fatalf("create tenant: %v", err)
+	}
+	gotA, err := s.DirentGet(ctx, "", "agent", "a1", "/", "notes")
+	if err != nil || !jsonEqual(gotA.ResourceRef, `{"k":"agent"}`) {
+		t.Errorf("agent /notes = %+v err=%v", gotA, err)
+	}
+	// The agent-scope listing must not see the tenant-scope dirent.
+	list, err := s.DirentList(ctx, "", "agent", "a1", "/")
+	if err != nil {
+		t.Fatalf("list agent: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("agent / listing leaked across scope: %+v", names(list))
+	}
+}
+
+func testDirentTenantIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	if _, err := s.DirentCreate(ctx, mkDirent("tnt-a", "user", "u1", "/", "x", "directory", `{"t":"a"}`)); err != nil {
+		t.Fatalf("create A: %v", err)
+	}
+	if _, err := s.DirentCreate(ctx, mkDirent("tnt-b", "user", "u1", "/", "x", "directory", `{"t":"b"}`)); err != nil {
+		t.Fatalf("create B: %v", err)
+	}
+	gotB, err := s.DirentGet(ctx, "tnt-b", "user", "u1", "/", "x")
+	if err != nil || !jsonEqual(gotB.ResourceRef, `{"t":"b"}`) {
+		t.Errorf("tenant B /x = %+v err=%v", gotB, err)
+	}
+	// Deleting A's dirent leaves B's untouched.
+	if _, err := s.DirentDelete(ctx, "tnt-a", "user", "u1", "/", "x"); err != nil {
+		t.Fatalf("delete A: %v", err)
+	}
+	if _, err := s.DirentGet(ctx, "tnt-b", "user", "u1", "/", "x"); err != nil {
+		t.Errorf("tenant B vanished after A delete: %v", err)
+	}
+}
+
+func names(rows []store.DirentRow) []string {
+	out := make([]string, len(rows))
+	for i, r := range rows {
+		out[i] = r.Name
+	}
+	return out
 }

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -7360,6 +7360,16 @@ func testDirentCreateAndGet(t *testing.T, s store.Store) {
 	if _, err := s.DirentGet(ctx, "", "user", "u1", "/", "nope"); !errors.As(err, &nf) {
 		t.Errorf("miss err = %v, want *ErrNotFound", err)
 	}
+	// An empty resource_ref must round-trip as valid JSON on BOTH backends
+	// (sqlite TEXT accepts ""; postgres jsonb rejects "" — DirentCreate
+	// defaults empty to "{}"). Review finding #2 / backend-parity guard.
+	got2, err := s.DirentCreate(ctx, store.DirentRow{Scope: "user", ScopeID: "u1", ParentPath: "/", Name: "noref", Kind: "directory"})
+	if err != nil {
+		t.Fatalf("create with empty ref: %v", err)
+	}
+	if !jsonEqual(got2.ResourceRef, `{}`) {
+		t.Errorf("empty ref = %s, want {}", got2.ResourceRef)
+	}
 }
 
 func testDirentListOneLevel(t *testing.T, s store.Store) {

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -399,9 +399,14 @@ const memoryInputSchema = `{
 }`
 
 type memoryInput struct {
-	Op        string          `json:"op"`
-	Scope     string          `json:"scope"`
-	Key       string          `json:"key,omitempty"`
+	Op    string `json:"op"`
+	Scope string `json:"scope"`
+	Key   string `json:"key,omitempty"`
+	// Path (RFC AL) optionally registers/addresses this entry in the Path
+	// tree. On `set`, a memory_entry dirent is registered at this path; on
+	// `get`, the path resolves to the entry's key (an alternative to `key`).
+	// Same (scope, scope_id) as the entry; tenant from the run identity.
+	Path      string          `json:"path,omitempty"`
 	Value     json.RawMessage `json:"value,omitempty"`
 	Delta     *int64          `json:"delta,omitempty"`
 	TTL       int64           `json:"ttl,omitempty"`
@@ -912,8 +917,15 @@ func (m *Memory) sqlAuditMode() string {
 }
 
 func (m *Memory) execGet(ctx context.Context, scope store.MemoryScope, scopeID string, in memoryInput) (tools.Result, error) {
+	if in.Path != "" && in.Key == "" {
+		key, err := m.resolveMemoryPath(ctx, scope, scopeID, in.Path)
+		if err != nil {
+			return errResult("get: " + err.Error()), nil
+		}
+		in.Key = key
+	}
 	if in.Key == "" {
-		return errResult("get: missing required field: key"), nil
+		return errResult("get: missing required field: key (or path)"), nil
 	}
 	entry, err := m.backend(ctx).Get(ctx, scope, scopeID, in.Key)
 	if err != nil {
@@ -938,6 +950,12 @@ func (m *Memory) execSet(ctx context.Context, scope store.MemoryScope, scopeID s
 	}
 	if !json.Valid(in.Value) {
 		return errResult("set: value is not valid JSON"), nil
+	}
+	// Fail fast on a malformed path before writing the value (RFC AL).
+	if in.Path != "" {
+		if _, err := normalizePath(in.Path); err != nil {
+			return errResult("set: " + err.Error()), nil
+		}
 	}
 	if m.MaxValueBytes > 0 && len(in.Value) > m.MaxValueBytes {
 		return errResult(fmt.Sprintf("set: value (%d bytes) exceeds max %d bytes", len(in.Value), m.MaxValueBytes)), nil
@@ -981,7 +999,75 @@ func (m *Memory) execSet(ctx context.Context, scope store.MemoryScope, scopeID s
 			resp["embed_warning"] = res.EmbedWarning
 		}
 	}
+	// RFC AL — register a Path-tree dirent for this entry. The k/v value is
+	// already durable; a dirent failure is surfaced as a warning so the value
+	// isn't lost (the agent can retry the path). The path was validated at the
+	// top of execSet, so this only fails on a store fault.
+	if in.Path != "" {
+		if err := m.registerMemoryDirent(ctx, scope, scopeID, in.Key, in.Path); err != nil {
+			resp["path_warning"] = fmt.Sprintf("value set but path registration failed: %s", err)
+		} else {
+			resp["path"] = in.Path
+		}
+	}
 	return okJSON(resp)
+}
+
+// resolveMemoryPath resolves a Path-tree path to the memory key it names,
+// within the entry's own (scope, scope_id) tree. tenant from the run identity.
+func (m *Memory) resolveMemoryPath(ctx context.Context, scope store.MemoryScope, scopeID, rawPath string) (string, error) {
+	if m.Store == nil {
+		return "", fmt.Errorf("path addressing requires a Store backend")
+	}
+	canonical, err := normalizePath(rawPath)
+	if err != nil {
+		return "", err
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return "", fmt.Errorf("path may not be the root")
+	}
+	row, err := m.Store.DirentGet(ctx, tools.RunIdentity(ctx).TenantID, string(scope), scopeID, parent, name)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return "", fmt.Errorf("no such path: %s", canonical)
+		}
+		return "", err
+	}
+	if row.Kind != "memory_entry" {
+		return "", fmt.Errorf("path %s is a %s, not a memory entry", canonical, row.Kind)
+	}
+	var ref struct {
+		Key string `json:"key"`
+	}
+	_ = json.Unmarshal(row.ResourceRef, &ref)
+	if ref.Key == "" {
+		return "", fmt.Errorf("path %s has no memory key", canonical)
+	}
+	return ref.Key, nil
+}
+
+// registerMemoryDirent registers (upserts) a memory_entry dirent naming this
+// k/v entry at the given path, in the entry's own (scope, scope_id) tree.
+func (m *Memory) registerMemoryDirent(ctx context.Context, scope store.MemoryScope, scopeID, key, rawPath string) error {
+	if m.Store == nil {
+		return fmt.Errorf("path addressing requires a Store backend")
+	}
+	canonical, err := normalizePath(rawPath)
+	if err != nil {
+		return err
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return fmt.Errorf("path may not be the root")
+	}
+	ref, _ := json.Marshal(map[string]any{"scope": string(scope), "scope_id": scopeID, "key": key, "facet": "kv"})
+	_, err = m.Store.DirentCreate(ctx, store.DirentRow{
+		TenantID: tools.RunIdentity(ctx).TenantID, Scope: string(scope), ScopeID: scopeID,
+		ParentPath: parent, Name: name, Kind: "memory_entry", ResourceRef: ref,
+	})
+	return err
 }
 
 // execSearch implements the v0.9.0 Memory.search op. Refuses with

--- a/internal/tools/builtin/pathnorm.go
+++ b/internal/tools/builtin/pathnorm.go
@@ -1,0 +1,84 @@
+package builtin
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Path normalization for the RFC AL Path primitive. Canonical form: slash-
+// rooted, no "..", no empty segments, case-sensitive, segment chars
+// [a-zA-Z0-9._-] (no spaces, no inner slashes), <=64 segments, <=1024 chars.
+// This is the logical-path analog of sandbox.go's relInsideRoot host-path
+// confinement — a crafted path can't escape its (tenant, scope) tree because
+// ".." is rejected outright rather than resolved.
+
+const (
+	maxPathLen      = 1024
+	maxPathSegments = 64
+	maxSegmentLen   = 64
+)
+
+var pathSegmentRe = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// normalizePath validates and canonicalizes a path. Returns the canonical form
+// ("/" for the root, or "/a/b/c" with no trailing slash) or an error the model
+// can self-correct from.
+func normalizePath(raw string) (string, error) {
+	if len(raw) > maxPathLen {
+		return "", fmt.Errorf("path too long (%d chars, max %d)", len(raw), maxPathLen)
+	}
+	if raw == "" || raw == "/" {
+		return "/", nil
+	}
+	if !strings.HasPrefix(raw, "/") {
+		return "", fmt.Errorf("path must be absolute (start with %q): %q", "/", raw)
+	}
+	segs := make([]string, 0, 8)
+	for _, p := range strings.Split(raw, "/") {
+		if p == "" {
+			continue // collapse "//" and a trailing "/"
+		}
+		if p == "." || p == ".." {
+			return "", fmt.Errorf("path may not contain %q segments: %q", p, raw)
+		}
+		if len(p) > maxSegmentLen {
+			return "", fmt.Errorf("path segment %q too long (max %d chars)", p, maxSegmentLen)
+		}
+		if !pathSegmentRe.MatchString(p) {
+			return "", fmt.Errorf("invalid path segment %q (allowed: letters, digits, . _ -): %q", p, raw)
+		}
+		segs = append(segs, p)
+	}
+	if len(segs) == 0 {
+		return "/", nil
+	}
+	if len(segs) > maxPathSegments {
+		return "", fmt.Errorf("too many path segments (%d, max %d)", len(segs), maxPathSegments)
+	}
+	return "/" + strings.Join(segs, "/"), nil
+}
+
+// splitPath splits a canonical full path into the stored parent_path (always
+// trailing-slashed) and the leaf name. isRoot is true for "/" (no name).
+//
+//	"/docs/x" -> ("/docs/", "x", false)
+//	"/x"      -> ("/", "x", false)
+//	"/"       -> ("", "", true)
+func splitPath(canonical string) (parentPath, name string, isRoot bool) {
+	if canonical == "/" {
+		return "", "", true
+	}
+	i := strings.LastIndex(canonical, "/")
+	return canonical[:i+1], canonical[i+1:], false
+}
+
+// dirPrefix returns the stored parent_path of the children of a directory at
+// the given canonical path: the root's children sit at "/", and "/docs"'s
+// children sit at "/docs/".
+func dirPrefix(canonical string) string {
+	if canonical == "/" {
+		return "/"
+	}
+	return canonical + "/"
+}

--- a/internal/tools/builtin/pathnorm_test.go
+++ b/internal/tools/builtin/pathnorm_test.go
@@ -1,0 +1,73 @@
+package builtin
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizePath_Canonical(t *testing.T) {
+	cases := map[string]string{
+		"":              "/",
+		"/":             "/",
+		"/docs":         "/docs",
+		"/docs/x":       "/docs/x",
+		"//docs//x/":    "/docs/x", // collapse empty segments + trailing slash
+		"/a.b/c-d/e_f":  "/a.b/c-d/e_f",
+		"/docs/launch1": "/docs/launch1",
+	}
+	for in, want := range cases {
+		got, err := normalizePath(in)
+		if err != nil {
+			t.Errorf("normalize(%q) error: %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizePath_Rejects(t *testing.T) {
+	bad := []string{
+		"docs/x",                      // not absolute
+		"/docs/../etc",                // ".." escape
+		"/docs/./x",                   // "." segment
+		"/docs/a b",                   // space
+		"/docs/a\tb",                  // control char
+		"/docs/a/b\\c",                // backslash
+		"/" + strings.Repeat("a", 65), // segment too long
+		"/" + strings.Repeat("a/", maxPathSegments+1), // too many segments
+	}
+	for _, in := range bad {
+		if got, err := normalizePath(in); err == nil {
+			t.Errorf("normalize(%q) = %q, want error", in, got)
+		}
+	}
+}
+
+func TestSplitPath(t *testing.T) {
+	cases := []struct {
+		in, parent, name string
+		root             bool
+	}{
+		{"/", "", "", true},
+		{"/x", "/", "x", false},
+		{"/docs/x", "/docs/", "x", false},
+		{"/a/b/c", "/a/b/", "c", false},
+	}
+	for _, c := range cases {
+		p, n, r := splitPath(c.in)
+		if p != c.parent || n != c.name || r != c.root {
+			t.Errorf("splitPath(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, p, n, r, c.parent, c.name, c.root)
+		}
+	}
+}
+
+func TestDirPrefix(t *testing.T) {
+	if got := dirPrefix("/"); got != "/" {
+		t.Errorf("dirPrefix(/) = %q, want /", got)
+	}
+	if got := dirPrefix("/docs"); got != "/docs/" {
+		t.Errorf("dirPrefix(/docs) = %q, want /docs/", got)
+	}
+}

--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -214,6 +215,13 @@ func (p *Path) mv(ctx context.Context, tenantID, scope, scopeID string, in pathI
 	}
 	if fromC == toC {
 		return errResult("source and destination are the same path"), nil
+	}
+	// A directory can't be moved into itself or its own subtree — the
+	// descendant-rewrite would reparent the moved node beneath itself and
+	// orphan the whole subtree (real filesystems reject this, EINVAL). The
+	// trailing-slash form avoids a /docs vs /docs2 false positive.
+	if strings.HasPrefix(toC+"/", fromC+"/") {
+		return errResult("cannot move a path into itself or its own subtree: " + fromC + " -> " + toC), nil
 	}
 	// No-clobber: the destination must not already exist.
 	if _, err := p.Store.DirentGet(ctx, tenantID, scope, scopeID, toParent, toName); err == nil {

--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -1,0 +1,286 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// Path is the RFC AL Path-tree tool: a Unix-like VFS over the dirents
+// substrate, addressing Documents / Volume mounts / Memory entries by
+// human-readable, tenant-rooted, scope-aware paths. Resources keep their
+// native ids; a dirent is just the name (Linux inode/dirent separation).
+//
+// Gated by allowed_tools:[Path]. Tenant + scope isolation is enforced at the
+// store boundary — every op scopes by (tenant, scope, scope_id), and a crafted
+// path can't escape its tree because normalizePath rejects "..". A dirent is a
+// NAME, not an authority grant: resolving one returns a resource_ref, but
+// using the resource still goes through that resource's own tool + gates.
+type Path struct {
+	Store store.Store
+}
+
+func (p *Path) Name() string { return "Path" }
+
+func (p *Path) Description() string {
+	return "A Unix-like filesystem over your Memory, Volumes, and Documents. Address resources by human-readable paths (e.g. /docs/launch). Ops: resolve, ls, stat, mkdir (no-op — dirs are implicit), mv, rm. Paths are scoped (agent/user/tenant, default agent) and tenant-isolated; segments are [a-zA-Z0-9._-], no \"..\"."
+}
+
+func (p *Path) InputSchema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"op":            {"type": "string", "enum": ["resolve","ls","stat","mkdir","mv","rm"], "description": "The operation."},
+			"path":          {"type": "string", "description": "Absolute path, e.g. /docs/launch. Segments are [a-zA-Z0-9._-]; no \"..\"."},
+			"to":            {"type": "string", "description": "Destination path (mv only)."},
+			"scope":         {"type": "string", "enum": ["agent","user","tenant"], "description": "Which tree (default agent). user requires a user_id on the run; tenant is shared across the tenant."},
+			"recursive":     {"type": "boolean", "description": "ls: list all descendants. rm: required to remove a path that has descendants."},
+			"kind_filter":   {"type": "string", "description": "ls: only entries of this kind (document/volume_mount/memory_entry/directory)."},
+			"resource_too":  {"type": "boolean", "description": "rm: also delete the backing resource. NOT supported in v1 (dirent-only removal)."}
+		},
+		"required": ["op"]
+	}`)
+}
+
+type pathInput struct {
+	Op          string `json:"op"`
+	Path        string `json:"path"`
+	To          string `json:"to"`
+	Scope       string `json:"scope"`
+	Recursive   bool   `json:"recursive"`
+	KindFilter  string `json:"kind_filter"`
+	ResourceToo bool   `json:"resource_too"`
+}
+
+func (p *Path) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if p.Store == nil {
+		return errResult("Path tool: not configured (no Store backend)"), nil
+	}
+	var in pathInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult("invalid input JSON: " + err.Error()), nil
+	}
+	tenantID, scope, scopeID, err := p.resolveScope(ctx, in.Scope)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+
+	switch in.Op {
+	case "resolve":
+		return p.resolve(ctx, tenantID, scope, scopeID, in)
+	case "ls":
+		return p.ls(ctx, tenantID, scope, scopeID, in)
+	case "stat":
+		return p.stat(ctx, tenantID, scope, scopeID, in)
+	case "mkdir":
+		// Directories are implicit (S3-style) in v1 — mkdir is a no-op kept
+		// for forward-compat + ergonomic parity with a real shell.
+		if _, err := normalizePath(in.Path); err != nil {
+			return errResult(err.Error()), nil
+		}
+		return jsonResult(map[string]any{"ok": true, "note": "directories are implicit in v1; mkdir is a no-op"})
+	case "mv":
+		return p.mv(ctx, tenantID, scope, scopeID, in)
+	case "rm":
+		return p.rm(ctx, tenantID, scope, scopeID, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: resolve, ls, stat, mkdir, mv, rm)", in.Op)), nil
+	}
+}
+
+// resolveScope derives the authoritative (tenant, scope, scope_id) from the run
+// identity — never the wire (mirrors Memory.resolveScope). scope defaults to
+// agent. tenant_id is always the principal's tenant (the isolation axis).
+func (p *Path) resolveScope(ctx context.Context, requested string) (tenantID, scope, scopeID string, err error) {
+	tenantID = tools.RunIdentity(ctx).TenantID
+	if requested == "" {
+		requested = "agent"
+	}
+	switch requested {
+	case "agent":
+		name := tools.AgentName(ctx)
+		if name == "" {
+			return "", "", "", fmt.Errorf("Path: scope=agent requires a yaml-declared agent (no agent name on the run)")
+		}
+		return tenantID, "agent", name, nil
+	case "user":
+		uid := tools.RunIdentity(ctx).UserID
+		if uid == "" {
+			return "", "", "", fmt.Errorf("Path: scope=user requires a user_id on the run (caller must supply user_id)")
+		}
+		return tenantID, "user", uid, nil
+	case "tenant":
+		return tenantID, "tenant", "", nil
+	default:
+		return "", "", "", fmt.Errorf("Path: unknown scope %q (agent | user | tenant)", requested)
+	}
+}
+
+type pathEntry struct {
+	Name        string          `json:"name"`
+	Kind        string          `json:"kind"`
+	FullPath    string          `json:"full_path"`
+	ResourceRef json.RawMessage `json:"resource_ref,omitempty"`
+}
+
+func (p *Path) resolve(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	canonical, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return jsonResult(map[string]any{"kind": "directory", "full_path": "/"})
+	}
+	row, err := p.Store.DirentGet(ctx, tenantID, scope, scopeID, parent, name)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if asNotFound(err, &nf) {
+			return errResult("no such path: " + canonical), nil
+		}
+		return errResult("resolve: " + err.Error()), nil
+	}
+	return jsonResult(pathEntry{Name: name, Kind: row.Kind, FullPath: canonical, ResourceRef: row.ResourceRef})
+}
+
+func (p *Path) ls(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	canonical, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	prefix := dirPrefix(canonical)
+	var rows []store.DirentRow
+	if in.Recursive {
+		rows, err = p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, prefix)
+	} else {
+		rows, err = p.Store.DirentList(ctx, tenantID, scope, scopeID, prefix)
+	}
+	if err != nil {
+		return errResult("ls: " + err.Error()), nil
+	}
+	entries := make([]pathEntry, 0, len(rows))
+	for _, r := range rows {
+		if in.KindFilter != "" && r.Kind != in.KindFilter {
+			continue
+		}
+		entries = append(entries, pathEntry{Name: r.Name, Kind: r.Kind, FullPath: r.ParentPath + r.Name, ResourceRef: r.ResourceRef})
+	}
+	return jsonResult(map[string]any{"path": canonical, "entries": entries})
+}
+
+func (p *Path) stat(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	canonical, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return jsonResult(map[string]any{"kind": "directory", "full_path": "/", "scope": scope})
+	}
+	row, err := p.Store.DirentGet(ctx, tenantID, scope, scopeID, parent, name)
+	if err != nil {
+		var nf *store.ErrNotFound
+		if asNotFound(err, &nf) {
+			return errResult("no such path: " + canonical), nil
+		}
+		return errResult("stat: " + err.Error()), nil
+	}
+	return jsonResult(map[string]any{
+		"full_path": canonical, "name": row.Name, "kind": row.Kind,
+		"scope": scope, "resource_ref": row.ResourceRef,
+		"created_at": row.CreatedAt, "updated_at": row.UpdatedAt,
+	})
+}
+
+func (p *Path) mv(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	fromC, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult("from: " + err.Error()), nil
+	}
+	toC, err := normalizePath(in.To)
+	if err != nil {
+		return errResult("to: " + err.Error()), nil
+	}
+	fromParent, fromName, fromRoot := splitPath(fromC)
+	toParent, toName, toRoot := splitPath(toC)
+	if fromRoot || toRoot {
+		return errResult("cannot move the root path"), nil
+	}
+	if fromC == toC {
+		return errResult("source and destination are the same path"), nil
+	}
+	// No-clobber: the destination must not already exist.
+	if _, err := p.Store.DirentGet(ctx, tenantID, scope, scopeID, toParent, toName); err == nil {
+		return errResult("destination already exists: " + toC), nil
+	}
+	moved, err := p.Store.DirentMove(ctx, tenantID, scope, scopeID, fromParent, fromName, toParent, toName)
+	if err != nil {
+		return errResult("mv: " + err.Error()), nil
+	}
+	if !moved {
+		return errResult("no such path: " + fromC), nil
+	}
+	return jsonResult(map[string]any{"ok": true, "from": fromC, "to": toC})
+}
+
+func (p *Path) rm(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	canonical, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return errResult("cannot remove the root path"), nil
+	}
+	if in.ResourceToo {
+		return errResult("resource_too is not supported in v1 — rm removes only the path entry; delete the backing resource via its own tool (Memory/Volume/Document)"), nil
+	}
+	// Refuse to remove a path with descendants unless recursive (Linux semantics).
+	prefix := dirPrefix(canonical)
+	descendants, err := p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, prefix)
+	if err != nil {
+		return errResult("rm: " + err.Error()), nil
+	}
+	if len(descendants) > 0 && !in.Recursive {
+		return errResult(fmt.Sprintf("path %q has %d descendant(s); pass recursive:true to remove them", canonical, len(descendants))), nil
+	}
+	removed := 0
+	if in.Recursive && len(descendants) > 0 {
+		n, derr := p.Store.DirentDeleteUnder(ctx, tenantID, scope, scopeID, prefix)
+		if derr != nil {
+			return errResult("rm: " + derr.Error()), nil
+		}
+		removed += n
+	}
+	found, err := p.Store.DirentDelete(ctx, tenantID, scope, scopeID, parent, name)
+	if err != nil {
+		return errResult("rm: " + err.Error()), nil
+	}
+	if found {
+		removed++
+	}
+	if !found && removed == 0 {
+		return errResult("no such path: " + canonical), nil
+	}
+	return jsonResult(map[string]any{"ok": true, "removed": canonical, "n_removed": removed})
+}
+
+// asNotFound reports whether err is a *store.ErrNotFound (the store's miss
+// sentinel), tolerant of wrapping.
+func asNotFound(err error, target **store.ErrNotFound) bool {
+	return errors.As(err, target)
+}
+
+func jsonResult(v any) (tools.Result, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return errResult("internal: marshal result: " + err.Error()), nil
+	}
+	return tools.Result{Text: string(b)}, nil
+}

--- a/internal/tools/builtin/pathtool_test.go
+++ b/internal/tools/builtin/pathtool_test.go
@@ -1,0 +1,209 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// pathFixture returns a Path tool over an in-memory sqlite store, plus a ctx
+// whose identity resolves the agent scope to scope_id "agent-1" under tenant
+// "tnt". Seed dirents with seedDirent (the tool itself doesn't create them —
+// that's the Memory/Volume/Document wiring's job).
+func pathFixture(t *testing.T) (*Path, context.Context, store.Store) {
+	t.Helper()
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	ctx := tools.WithAgentName(context.Background(), "agent-1")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", UserID: "u1", TenantID: "tnt"})
+	return &Path{Store: s}, ctx, s
+}
+
+func seedDirent(t *testing.T, s store.Store, tenant, scope, scopeID, parent, name, kind string) {
+	t.Helper()
+	if _, err := s.DirentCreate(context.Background(), store.DirentRow{
+		TenantID: tenant, Scope: scope, ScopeID: scopeID,
+		ParentPath: parent, Name: name, Kind: kind, ResourceRef: json.RawMessage(`{}`),
+	}); err != nil {
+		t.Fatalf("seed %s%s: %v", parent, name, err)
+	}
+}
+
+// seedAgent seeds into the fixture's agent scope (tnt / agent / agent-1).
+func seedAgent(t *testing.T, s store.Store, parent, name, kind string) {
+	seedDirent(t, s, "tnt", "agent", "agent-1", parent, name, kind)
+}
+
+func pathExec(t *testing.T, p *Path, ctx context.Context, body string) (map[string]any, tools.Result) {
+	t.Helper()
+	res, err := p.Execute(ctx, json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("Execute hard error: %v", err)
+	}
+	var out map[string]any
+	if !res.IsError {
+		_ = json.Unmarshal([]byte(res.Text), &out)
+	}
+	return out, res
+}
+
+func TestPath_LsOneLevel(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "docs", "directory")
+	seedAgent(t, s, "/docs/", "a", "document")
+	seedAgent(t, s, "/docs/", "b", "document")
+	seedAgent(t, s, "/docs/a/", "deep", "document") // must not appear one-level
+
+	out, res := pathExec(t, p, ctx, `{"op":"ls","path":"/docs"}`)
+	if res.IsError {
+		t.Fatalf("ls: %q", res.Text)
+	}
+	entries, _ := out["entries"].([]any)
+	if len(entries) != 2 {
+		t.Errorf("ls /docs one-level = %d entries, want 2: %s", len(entries), res.Text)
+	}
+
+	// Recursive picks up the deep child.
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/docs","recursive":true}`)
+	if res.IsError {
+		t.Fatalf("ls recursive: %q", res.Text)
+	}
+	entries, _ = out["entries"].([]any)
+	if len(entries) != 3 {
+		t.Errorf("ls /docs recursive = %d entries, want 3: %s", len(entries), res.Text)
+	}
+}
+
+func TestPath_ResolveAndStat(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/notes/", "x", "memory_entry")
+	seedAgent(t, s, "/", "notes", "directory")
+
+	out, res := pathExec(t, p, ctx, `{"op":"resolve","path":"/notes/x"}`)
+	if res.IsError || out["kind"] != "memory_entry" || out["full_path"] != "/notes/x" {
+		t.Errorf("resolve /notes/x = %s (err=%v)", res.Text, res.IsError)
+	}
+	// A miss is a model-facing error.
+	_, res = pathExec(t, p, ctx, `{"op":"resolve","path":"/notes/missing"}`)
+	if !res.IsError {
+		t.Errorf("resolve of a missing path should error; got %q", res.Text)
+	}
+}
+
+func TestPath_MvCascade(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "docs", "directory")
+	seedAgent(t, s, "/docs/", "a", "document")
+	seedAgent(t, s, "/docs/a/", "b", "document")
+
+	_, res := pathExec(t, p, ctx, `{"op":"mv","path":"/docs","to":"/archive"}`)
+	if res.IsError {
+		t.Fatalf("mv: %q", res.Text)
+	}
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/archive/a/b"}`); r.IsError {
+		t.Errorf("cascade: /archive/a/b should resolve after mv: %q", r.Text)
+	}
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs/a"}`); !r.IsError {
+		t.Errorf("old /docs/a should be gone after mv")
+	}
+}
+
+func TestPath_MvRejectsClobberAndRoot(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "a", "document")
+	seedAgent(t, s, "/", "b", "document")
+	// no-clobber: destination exists.
+	if _, r := pathExec(t, p, ctx, `{"op":"mv","path":"/a","to":"/b"}`); !r.IsError {
+		t.Errorf("mv onto an existing path should refuse (no-clobber)")
+	}
+	// can't move the root.
+	if _, r := pathExec(t, p, ctx, `{"op":"mv","path":"/","to":"/x"}`); !r.IsError {
+		t.Errorf("mv of root should refuse")
+	}
+}
+
+func TestPath_RmRecursiveRefusal(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "docs", "directory")
+	seedAgent(t, s, "/docs/", "a", "document")
+
+	// rm without recursive on a path with descendants refuses.
+	if _, r := pathExec(t, p, ctx, `{"op":"rm","path":"/docs"}`); !r.IsError {
+		t.Errorf("rm of a non-empty path should refuse without recursive")
+	}
+	// recursive removes it.
+	if _, r := pathExec(t, p, ctx, `{"op":"rm","path":"/docs","recursive":true}`); r.IsError {
+		t.Fatalf("rm recursive: %q", r.Text)
+	}
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs"}`); !r.IsError {
+		t.Errorf("/docs should be gone after recursive rm")
+	}
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs/a"}`); !r.IsError {
+		t.Errorf("/docs/a should be gone after recursive rm")
+	}
+}
+
+func TestPath_RmResourceTooRejected(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "x", "memory_entry")
+	if _, r := pathExec(t, p, ctx, `{"op":"rm","path":"/x","resource_too":true}`); !r.IsError {
+		t.Errorf("rm resource_too should be rejected in v1")
+	}
+}
+
+func TestPath_NoDotDot(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs/../etc/passwd"}`); !r.IsError {
+		t.Errorf("a path containing .. must be refused")
+	}
+}
+
+// THE isolation test: a dirent in the agent scope is invisible to a user-scope
+// listing, and a different tenant can't see it either.
+func TestPath_ScopeAndTenantIsolation(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "secret", "memory_entry") // tnt / agent / agent-1
+
+	// Same path under user scope (scope_id u1) is a different tree → empty.
+	out, res := pathExec(t, p, ctx, `{"op":"ls","path":"/","scope":"user"}`)
+	if res.IsError {
+		t.Fatalf("ls user: %q", res.Text)
+	}
+	if entries, _ := out["entries"].([]any); len(entries) != 0 {
+		t.Errorf("user-scope listing leaked the agent-scope dirent: %s", res.Text)
+	}
+
+	// A run in a DIFFERENT tenant can't resolve it.
+	ctxB := tools.WithAgentName(context.Background(), "agent-1")
+	ctxB = tools.WithRunIdentity(ctxB, tools.RunIdentityValue{AgentID: "a_test", TenantID: "other"})
+	if _, r := pathExec(t, p, ctxB, `{"op":"resolve","path":"/secret"}`); !r.IsError {
+		t.Errorf("cross-tenant resolve must 404 (opaque); got %q", r.Text)
+	}
+
+	// The owning agent sees it.
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/"}`)
+	if res.IsError {
+		t.Fatalf("ls agent: %q", res.Text)
+	}
+	if entries, _ := out["entries"].([]any); len(entries) != 1 {
+		t.Errorf("agent-scope listing should see its own dirent: %s", res.Text)
+	}
+}
+
+func TestPath_ScopeUserRequiresUserID(t *testing.T) {
+	p, _, s := pathFixture(t)
+	// ctx with NO user_id.
+	ctx := tools.WithAgentName(context.Background(), "agent-1")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a_test", TenantID: "tnt"})
+	_ = s
+	if _, r := pathExec(t, p, ctx, `{"op":"ls","path":"/","scope":"user"}`); !r.IsError {
+		t.Errorf("scope=user without a user_id should error")
+	}
+}

--- a/internal/tools/builtin/pathtool_test.go
+++ b/internal/tools/builtin/pathtool_test.go
@@ -129,6 +129,25 @@ func TestPath_MvRejectsClobberAndRoot(t *testing.T) {
 	}
 }
 
+// Regression (review finding #1): moving a directory into its own subtree
+// must be refused — otherwise the descendant-rewrite orphans the whole tree.
+func TestPath_MvIntoOwnSubtreeRefused(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "proj", "directory")
+	seedAgent(t, s, "/proj/", "file", "document")
+
+	if _, r := pathExec(t, p, ctx, `{"op":"mv","path":"/proj","to":"/proj/inner"}`); !r.IsError {
+		t.Fatalf("mv into own subtree must be refused; got %q", r.Text)
+	}
+	// The tree must be intact — /proj and /proj/file still resolve.
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/proj"}`); r.IsError {
+		t.Errorf("/proj was corrupted by a refused mv: %q", r.Text)
+	}
+	if _, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/proj/file"}`); r.IsError {
+		t.Errorf("/proj/file was corrupted by a refused mv: %q", r.Text)
+	}
+}
+
 func TestPath_RmRecursiveRefusal(t *testing.T) {
 	p, ctx, s := pathFixture(t)
 	seedAgent(t, s, "/", "docs", "directory")

--- a/internal/tools/builtin/pathwiring_test.go
+++ b/internal/tools/builtin/pathwiring_test.go
@@ -1,0 +1,94 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// RFC AL — Memory + Volume path: wiring.
+
+func TestMemorySetWithPath_RegistersAndResolves(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	// set with a path registers a memory_entry dirent.
+	res, err := tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"agent","key":"voice","value":{"style":"crisp"},"path":"/prefs/voice"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Text, `"path":"/prefs/voice"`) {
+		t.Fatalf("set with path: %q", res.Text)
+	}
+	// The dirent exists in the agent tree (tenant "", scope agent, scope_id qa-agent).
+	row, derr := tool.Store.DirentGet(context.Background(), "", "agent", "qa-agent", "/prefs/", "voice")
+	if derr != nil {
+		t.Fatalf("dirent not registered: %v", derr)
+	}
+	if row.Kind != "memory_entry" || !strings.Contains(string(row.ResourceRef), `"key":"voice"`) {
+		t.Errorf("dirent = %+v", row)
+	}
+
+	// get BY PATH (no key) returns the value.
+	res, err = tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","path":"/prefs/voice"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.IsError || !strings.Contains(res.Text, `"style":"crisp"`) {
+		t.Errorf("get by path: %q", res.Text)
+	}
+
+	// get by a path that doesn't exist is a model-facing error.
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","path":"/prefs/missing"}`))
+	if !res.IsError {
+		t.Errorf("get of a missing path should error; got %q", res.Text)
+	}
+}
+
+func TestMemorySetWithBadPath_RefusesAndDoesNotWrite(t *testing.T) {
+	tool, ctx, cleanup := memoryFixture(t)
+	defer cleanup()
+
+	// A malformed path (..) must fail BEFORE the value is written.
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"set","scope":"agent","key":"k","value":1,"path":"/a/../b"}`))
+	if !res.IsError {
+		t.Fatalf("set with a '..' path should refuse; got %q", res.Text)
+	}
+	// The value must NOT have been written (fail-fast).
+	res, _ = tool.Execute(ctx, json.RawMessage(`{"op":"get","scope":"agent","key":"k"}`))
+	if strings.Contains(res.Text, `"value":1`) {
+		t.Errorf("value was written despite the bad path: %q", res.Text)
+	}
+}
+
+func TestVolumeDefCreate_RegistersMount(t *testing.T) {
+	tool, ctx, _, cleanup := volumeDefFixture(t)
+	defer cleanup()
+
+	// Default mount at /vol/<name>.
+	out, res := vdExec(t, tool, ctx, `{"op":"create","name":"repo-a","mode":"rw"}`)
+	if res.IsError {
+		t.Fatalf("create: %q", res.Text)
+	}
+	if out["mount_at"] != "/vol/repo-a" {
+		t.Errorf("default mount_at = %v, want /vol/repo-a", out["mount_at"])
+	}
+	// A tenant-scoped volume_mount dirent exists at /vol/repo-a.
+	row, derr := tool.Store.DirentGet(context.Background(), "", "tenant", "", "/vol/", "repo-a")
+	if derr != nil {
+		t.Fatalf("volume_mount dirent not registered: %v", derr)
+	}
+	if row.Kind != "volume_mount" || !strings.Contains(string(row.ResourceRef), `"volume_name":"repo-a"`) {
+		t.Errorf("dirent = %+v", row)
+	}
+
+	// Custom mount_at.
+	out, res = vdExec(t, tool, ctx, `{"op":"create","name":"repo-b","mode":"ro","mount_at":"/code/b"}`)
+	if res.IsError || out["mount_at"] != "/code/b" {
+		t.Errorf("custom mount_at: out=%v err=%q", out["mount_at"], res.Text)
+	}
+	if _, derr := tool.Store.DirentGet(context.Background(), "", "tenant", "", "/code/", "b"); derr != nil {
+		t.Errorf("custom-mount dirent missing: %v", derr)
+	}
+}

--- a/internal/tools/builtin/volumedef.go
+++ b/internal/tools/builtin/volumedef.go
@@ -94,6 +94,9 @@ type volumeDefInput struct {
 	Name      string `json:"name,omitempty"`
 	Mode      string `json:"mode,omitempty"`
 	Ephemeral bool   `json:"ephemeral,omitempty"`
+	// MountAt (RFC AL) is the Path-tree mount point for this volume; defaults
+	// to "/vol/<name>". Registers a volume_mount dirent in the tenant scope.
+	MountAt string `json:"mount_at,omitempty"`
 }
 
 // Name implements tools.Tool.
@@ -209,7 +212,41 @@ func (v *VolumeDef) execCreate(ctx context.Context, in volumeDefInput) (tools.Re
 	if err != nil {
 		return errResult(fmt.Sprintf("create: %s", err)), nil
 	}
-	return okJSON(volumeDefRowResponse(row, mode))
+	resp := volumeDefRowResponse(row, mode)
+	// RFC AL — register the volume's Path-tree mount (tenant-scoped). The
+	// VolumeDef row is already durable; a dirent failure is a warning so the
+	// volume isn't lost. Default mount is /vol/<name>.
+	mountAt := in.MountAt
+	if mountAt == "" {
+		mountAt = "/vol/" + in.Name
+	}
+	if mp, perr := v.registerVolumeMount(ctx, tenantID, in.Name, mode, mountAt); perr != nil {
+		resp["mount_warning"] = fmt.Sprintf("volume created but mount registration failed: %s", perr)
+	} else {
+		resp["mount_at"] = mp
+	}
+	return okJSON(resp)
+}
+
+// registerVolumeMount registers (upserts) a volume_mount dirent for the volume
+// in the tenant-scoped Path tree. Returns the canonical mount path.
+func (v *VolumeDef) registerVolumeMount(ctx context.Context, tenantID, name, mode, rawMount string) (string, error) {
+	canonical, err := normalizePath(rawMount)
+	if err != nil {
+		return "", err
+	}
+	parent, leaf, isRoot := splitPath(canonical)
+	if isRoot {
+		return "", fmt.Errorf("mount_at may not be the root path")
+	}
+	ref, _ := json.Marshal(map[string]any{"volume_name": name, "mode": mode})
+	if _, err := v.Store.DirentCreate(ctx, store.DirentRow{
+		TenantID: tenantID, Scope: "tenant", ScopeID: "",
+		ParentPath: parent, Name: leaf, Kind: "volume_mount", ResourceRef: ref,
+	}); err != nil {
+		return "", err
+	}
+	return canonical, nil
 }
 
 // execCreateEphemeral provisions a RUN-TREE-SCOPED ephemeral volume (RFC AH


### PR DESCRIPTION
## Why

loomcycle addresses every resource by its native id — Memory by `(scope, key)`, Volumes by `name`, Documents (RFC AK) by UUID. There's no human-readable, hierarchical way for an agent or operator to say "the v1.0 launch plan" or "everything under `/team/launches/`". This adds **RFC AL — a Path primitive**: a tenant-rooted, scope-aware **Unix-like VFS** over those resources. It's **Plan 1 of two** (Document, RFC AK, rebases onto it as Plan 2).

## What

A **`dirents` table** (in the runtime store, not SQL Memory) maps a `(tenant_id, scope, scope_id, parent_path, name)` coordinate to a backing resource — Linux inode/dirent separation: resources keep their native ids, a dirent is just the name. A new **`Path` MCP tool** exposes unix ops over it; resources opt in to a path via lightweight wiring.

- **Store layer** — `Dirent*` methods (Create/Get/List/ListUnder/Delete/DeleteUnder/Move-with-cascade) on **both** sqlite (idempotent DDL; int64-nanos; LIKE-escaped prefix match) and postgres (migration `0050`; jsonb; TIMESTAMPTZ). Composite PK makes each `(tenant, scope, scope_id)` tree independent. 8 contract tests run against **both** backends.
- **`Path` tool** — `resolve` / `ls` (one-level + recursive + `kind_filter`) / `stat` / `mkdir` (v1 no-op, dirs implicit) / `mv` (no-clobber + descendant cascade + self-subtree guard) / `rm` (dirent-only; refuses a non-empty path without `recursive`; `resource_too` rejected in v1). Scope (agent/user/tenant, default agent) + tenant resolved from `RunIdentity`/`AgentName`, **never the wire** (rule #8).
- **Normalization** (`pathnorm.go`) — canonical slash-rooted form; rejects `..`, inner slashes, bad chars; ≤64 segments / ≤1024 chars. The logical-path analog of `sandbox.go`'s `relInsideRoot`.
- **Wiring** — `Memory.set/get path:` (register/resolve a `memory_entry` dirent; value fail-safe — a dirent fault is a `path_warning`, never loses the value) and `VolumeDef.create mount_at:` (register a tenant-scoped `volume_mount`, default `/vol/<name>`). SQL Memory stays out of the tree.

**Trust posture:** every op scopes by `(tenant, scope, scope_id)` at the store boundary — cross-tenant/scope reads, lists, moves, deletes are impossible; a crafted path can't escape its tree (`..` rejected, not resolved); a dirent is a **name, not an authority grant** (resolving returns a `resource_ref`, but using the resource still goes through its own tool + gates).

**Scope:** the lazy-implicit `/vol/<name>` mount for *pre-existing* volumes is deferred (a convenience). **Document (RFC AK) + its `create_document(path:)` glue is Plan 2.**

## What was tested

- **~30 tests:** 8 `Dirent*` contract tests (both backends), 4 normalization, 10 Path-tool (incl. `mv`-cascade, `mv`-into-own-subtree refusal, `rm`-recursive refusal, no-`..`, **scope + cross-tenant isolation**), 3 Memory/Volume wiring.
- `go test ./...` clean, `go vet` clean, `make build` OK.
- **Adversarial code-review** → found one **blocking** data-corruption bug (`mv` into own subtree orphaned the tree) + one latent backend-parity nit (empty `resource_ref`); **both fixed** with regression tests in the last commit. The review confirmed the isolation, LIKE-escaping, cascade correctness, and wiring fail-safety are sound.

RFC: `doc-internal/rfcs/path-primitive.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
