### PR TITLE
harden(document): atomic deletes, bidirectional edge cleanup, validation

### DIFF
--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -263,6 +263,39 @@ func (d *Document) query(ctx context.Context, key sqlmem.ScopeKey, stmt string, 
 	return d.SqlMem.Query(ctx, key, d.SqlMem.Rebind(stmt), args)
 }
 
+// withSqlTxn runs fn inside a FRESH, independent SQL Memory transaction —
+// committing on success, rolling back on any error. A unique txn id means it
+// never nests onto an agent's explicit sql_begin, so the delete is its own
+// atomic unit: a mid-cascade failure rolls back the whole SQL side, leaving the
+// chunk graph untouched (no half-deleted mess). The chunk Memory BODIES live in
+// a separate store and can't join this txn — callers delete them AFTER a
+// successful commit (an orphaned body is invisible dead k/v; an orphaned row
+// would be visible, so SQL-first is least-bad).
+func (d *Document) withSqlTxn(ctx context.Context, key sqlmem.ScopeKey, fn func(txnID string) error) error {
+	txnID := "doc-tx:" + newDocID()
+	if _, err := d.SqlMem.BeginTxn(ctx, txnID, tools.RunIdentity(ctx).RootRunID, key); err != nil {
+		return err
+	}
+	if err := fn(txnID); err != nil {
+		_, _ = d.SqlMem.RollbackTxn(txnID)
+		return err
+	}
+	if _, err := d.SqlMem.CommitTxn(txnID); err != nil {
+		_, _ = d.SqlMem.RollbackTxn(txnID)
+		return err
+	}
+	return nil
+}
+
+func (d *Document) execTxn(ctx context.Context, txnID, stmt string, args ...any) error {
+	_, err := d.SqlMem.ExecTxn(ctx, txnID, d.SqlMem.Rebind(stmt), args, 0)
+	return err
+}
+
+func (d *Document) queryTxn(ctx context.Context, txnID, stmt string, args ...any) (*sqlmem.QueryResult, error) {
+	return d.SqlMem.QueryTxn(ctx, txnID, d.SqlMem.Rebind(stmt), args)
+}
+
 // chunkRow is the SQL-side chunk record (body/fields come from Memory).
 type chunkRow struct {
 	ID         string `json:"id"`
@@ -447,27 +480,37 @@ func (d *Document) deleteDocument(ctx context.Context, key sqlmem.ScopeKey, msco
 	if err != nil {
 		return errResult("delete_document: " + err.Error()), nil
 	}
-	// Gather every chunk id so we can drop its Memory body (SQL deletes don't
-	// reach the separate Memory store).
-	res, err := d.query(ctx, key, `SELECT id FROM chunks WHERE document_id = ?`, docID)
-	if err != nil {
-		return errResult("delete_document: " + err.Error()), nil
-	}
-	n := 0
-	for _, r := range res.Rows {
-		id := asStr(r[0])
-		_, _ = d.Store.MemoryDelete(ctx, mscope, key.ScopeID, chunkBodyKey(id))
-		n++
-	}
-	for _, stmt := range []string{
-		`DELETE FROM chunk_edges WHERE from_id IN (SELECT id FROM chunks WHERE document_id = ?)`,
-		`DELETE FROM chunks WHERE document_id = ?`,
-		`DELETE FROM documents WHERE id = ?`,
-	} {
-		if err := d.exec(ctx, key, stmt, docID); err != nil {
-			return errResult("delete_document: " + err.Error()), nil
+	// The SQL side runs in ONE transaction: enumerate the chunk ids (for the
+	// Memory-body cleanup below), then delete edges (BOTH directions — so an
+	// INCOMING cross-document edge from another doc no longer dangles), then
+	// the chunk rows, then the document row. Any failure rolls the whole thing
+	// back — no half-deleted document.
+	var ids []string
+	txErr := d.withSqlTxn(ctx, key, func(txnID string) error {
+		res, err := d.queryTxn(ctx, txnID, `SELECT id FROM chunks WHERE document_id = ?`, docID)
+		if err != nil {
+			return err
 		}
+		for _, r := range res.Rows {
+			ids = append(ids, asStr(r[0]))
+		}
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_edges WHERE from_id IN (SELECT id FROM chunks WHERE document_id = ?) OR to_id IN (SELECT id FROM chunks WHERE document_id = ?)`, docID, docID); err != nil {
+			return err
+		}
+		if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE document_id = ?`, docID); err != nil {
+			return err
+		}
+		return d.execTxn(ctx, txnID, `DELETE FROM documents WHERE id = ?`, docID)
+	})
+	if txErr != nil {
+		return errResult("delete_document: " + txErr.Error()), nil
 	}
+	// Bodies AFTER commit (separate store; best-effort — an orphaned body is
+	// invisible dead k/v, never reachable once its chunk row is gone).
+	for _, id := range ids {
+		_, _ = d.Store.MemoryDelete(ctx, mscope, key.ScopeID, chunkBodyKey(id))
+	}
+	n := len(ids)
 	// Drop any Path-tree dirent(s) pointing at this document — best-effort, by
 	// document_id (works whether the caller addressed by id or path, so a
 	// delete-by-id never leaves a dangling name). Scans the scope's document
@@ -643,40 +686,68 @@ func (d *Document) deleteChunk(ctx context.Context, key sqlmem.ScopeKey, mscope 
 	if !ok {
 		return errResult("delete_chunk: no such chunk: " + in.ID), nil
 	}
-	// Enumerate the chunk + all descendants (iterative BFS — portable, no
-	// recursive CTE). A visited set guarantees termination even if a parent_id
-	// cycle somehow exists (move_chunk refuses to create one, but the walk must
-	// never hang on corrupt data).
-	ids := []string{in.ID}
-	visited := map[string]bool{in.ID: true}
-	frontier := []string{in.ID}
-	for len(frontier) > 0 {
-		next := []string{}
-		for _, pid := range frontier {
-			res, qerr := d.query(ctx, key, `SELECT id FROM chunks WHERE parent_id = ?`, pid)
-			if qerr != nil {
-				return errResult("delete_chunk: " + qerr.Error()), nil
-			}
-			for _, r := range res.Rows {
-				cid := asStr(r[0])
-				if visited[cid] {
-					continue
+	// Refuse to delete a document's ROOT chunk — that would orphan the
+	// documents row (root_chunk_id dangling, zero chunks). Use delete_document.
+	// Fail CLOSED if the lookup errors: a guard that silently skips on a query
+	// fault would let exactly the orphan it protects against slip through.
+	if rr, rerr := d.query(ctx, key, `SELECT 1 FROM documents WHERE root_chunk_id = ? LIMIT 1`, in.ID); rerr != nil {
+		return errResult("delete_chunk: " + rerr.Error()), nil
+	} else if len(rr.Rows) > 0 {
+		return errResult("delete_chunk: refusing to delete a document's root chunk — use delete_document"), nil
+	}
+	// The cascade runs in ONE transaction: enumerate the chunk + all
+	// descendants (iterative BFS — portable, no recursive CTE; a visited set
+	// guarantees termination even on a corrupt parent cycle), then delete each
+	// node's edges (both directions) + row. Any failure rolls back the whole
+	// subtree — never a half-deleted graph.
+	var ids []string
+	txErr := d.withSqlTxn(ctx, key, func(txnID string) error {
+		ids = []string{in.ID}
+		visited := map[string]bool{in.ID: true}
+		frontier := []string{in.ID}
+		for len(frontier) > 0 {
+			next := []string{}
+			for _, pid := range frontier {
+				res, qerr := d.queryTxn(ctx, txnID, `SELECT id FROM chunks WHERE parent_id = ?`, pid)
+				if qerr != nil {
+					return qerr
 				}
-				visited[cid] = true
-				ids = append(ids, cid)
-				next = append(next, cid)
+				// Fail CLOSED on truncation: if one frontier level has more
+				// children than the row cap, the unseen rows would survive a
+				// parent delete as orphans. Refuse rather than half-delete the
+				// subtree (the txn rolls back). Pathological (cap default 10k
+				// siblings) but exactly the orphan-mess we're hardening against.
+				if res.Truncated {
+					return fmt.Errorf("subtree too wide to cascade safely (a level exceeds the row cap) — delete children in smaller batches first")
+				}
+				for _, r := range res.Rows {
+					cid := asStr(r[0])
+					if visited[cid] {
+						continue
+					}
+					visited[cid] = true
+					ids = append(ids, cid)
+					next = append(next, cid)
+				}
+			}
+			frontier = next
+		}
+		for _, cid := range ids {
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunk_edges WHERE from_id = ? OR to_id = ?`, cid, cid); err != nil {
+				return err
+			}
+			if err := d.execTxn(ctx, txnID, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {
+				return err
 			}
 		}
-		frontier = next
+		return nil
+	})
+	if txErr != nil {
+		return errResult("delete_chunk: " + txErr.Error()), nil
 	}
+	// Bodies after commit (best-effort; see delete_document).
 	for _, cid := range ids {
 		_, _ = d.Store.MemoryDelete(ctx, mscope, key.ScopeID, chunkBodyKey(cid))
-		if err := d.exec(ctx, key, `DELETE FROM chunk_edges WHERE from_id = ? OR to_id = ?`, cid, cid); err != nil {
-			return errResult("delete_chunk: edges: " + err.Error()), nil
-		}
-		if err := d.exec(ctx, key, `DELETE FROM chunks WHERE id = ?`, cid); err != nil {
-			return errResult("delete_chunk: " + err.Error()), nil
-		}
 	}
 	d.publishChange(ctx, mscope, key.ScopeID, row.DocumentID, "delete_chunk", in.ID)
 	return jsonResult(map[string]any{"deleted": true, "cascade_deleted_descendants": len(ids) - 1})
@@ -734,6 +805,20 @@ func (d *Document) moveChunk(ctx context.Context, key sqlmem.ScopeKey, in docInp
 func (d *Document) linkChunks(ctx context.Context, key sqlmem.ScopeKey, in docInput) (tools.Result, error) {
 	if in.FromID == "" || in.ToID == "" || in.Kind == "" {
 		return errResult("link_chunks: from_id, to_id, and kind are required"), nil
+	}
+	// Both endpoints MUST exist (in this scope) — otherwise the edge is born
+	// dangling. Cross-document edges are allowed (both chunks just have to
+	// exist; they may be in different documents of this scope), but an edge to
+	// a non-existent chunk is refused.
+	if _, ok, err := d.getChunkRow(ctx, key, in.FromID); err != nil {
+		return errResult("link_chunks: " + err.Error()), nil
+	} else if !ok {
+		return errResult("link_chunks: from_id: no such chunk: " + in.FromID), nil
+	}
+	if _, ok, err := d.getChunkRow(ctx, key, in.ToID); err != nil {
+		return errResult("link_chunks: " + err.Error()), nil
+	} else if !ok {
+		return errResult("link_chunks: to_id: no such chunk: " + in.ToID), nil
 	}
 	now := time.Now().UnixNano()
 	// Idempotent (INSERT OR IGNORE-equivalent via existence check for portability).

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -280,13 +280,14 @@ func TestDocument_MoveChunkCycleRefused(t *testing.T) {
 	if _, r := docExec(t, d, ctx, `{"op":"move_chunk","scope":"user","id":"`+a+`","new_parent_id":"`+a+`"}`); !r.IsError {
 		t.Errorf("move under self must be refused")
 	}
-	// a is intact, and delete_chunk(root) terminates (no hang) and removes all.
-	out, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+root+`"}`)
+	// a is intact, and delete_chunk(a) terminates (no hang) and cascades b.
+	// (Can't delete the root chunk directly now — that's delete_document.)
+	out, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+a+`"}`)
 	if r.IsError {
 		t.Fatalf("delete after refused move: %q", r.Text)
 	}
-	if int(out["cascade_deleted_descendants"].(float64)) != 2 { // a + b
-		t.Errorf("cascade count = %v, want 2", out["cascade_deleted_descendants"])
+	if int(out["cascade_deleted_descendants"].(float64)) != 1 { // b
+		t.Errorf("cascade count = %v, want 1", out["cascade_deleted_descendants"])
 	}
 }
 
@@ -375,9 +376,115 @@ func TestDocument_Postgres(t *testing.T) {
 	if _, r := docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c1+`","revision":1,"body":"x"}`); !r.IsError {
 		t.Errorf("pg stale revision should conflict")
 	}
-	// delete cascade (BFS) on pg.
-	out, res = docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+root+`"}`)
-	if res.IsError || int(out["cascade_deleted_descendants"].(float64)) != 1 {
-		t.Errorf("pg delete cascade = %s", res.Text)
+	// delete_chunk cascade (BFS + txn) on pg: c1 is a leaf, cascade 0.
+	out, res = docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+c1+`"}`)
+	if res.IsError || int(out["cascade_deleted_descendants"].(float64)) != 0 {
+		t.Errorf("pg delete_chunk = %s", res.Text)
+	}
+	// delete_document (transactional, bidirectional edge sweep) on pg.
+	out, res = docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+docID+`"}`)
+	if res.IsError {
+		t.Errorf("pg delete_document = %s", res.Text)
+	}
+}
+
+// Hardening: link_chunks must refuse an edge to a non-existent chunk (no
+// born-dangling edges).
+func TestDocument_LinkChunksValidatesEndpoints(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	root := out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+out["document_id"].(string)+`","parent_id":"`+root+`","title":"a","body":""}`)
+	a := out["id"].(string)
+	// to_id doesn't exist → refuse.
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"`+a+`","to_id":"nope","kind":"promotes"}`); !r.IsError || !strings.Contains(r.Text, "no such chunk") {
+		t.Errorf("link to a non-existent chunk should refuse; got %q", r.Text)
+	}
+	// from_id doesn't exist → refuse.
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"ghost","to_id":"`+a+`","kind":"promotes"}`); !r.IsError {
+		t.Errorf("link from a non-existent chunk should refuse; got %q", r.Text)
+	}
+}
+
+// Hardening: deleting a document's root chunk is refused (would orphan the doc).
+func TestDocument_DeleteRootChunkRefused(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	root := out["root_chunk_id"].(string)
+	if _, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+root+`"}`); !r.IsError || !strings.Contains(r.Text, "root chunk") {
+		t.Errorf("deleting the root chunk should be refused; got %q", r.Text)
+	}
+	// The document is intact.
+	if _, r := docExec(t, d, ctx, `{"op":"get_document","scope":"user","id":"`+out["document_id"].(string)+`"}`); r.IsError {
+		t.Errorf("document should survive a refused root-chunk delete")
+	}
+}
+
+// Hardening: delete_document removes INCOMING cross-document edges too (the
+// bidirectional cleanup), so no dangling edge points at a deleted chunk.
+func TestDocument_DeleteDocumentCleansIncomingCrossDocEdges(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	// doc1 with chunk A.
+	o1, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D1"}`)
+	doc1, r1 := o1["document_id"].(string), o1["root_chunk_id"].(string)
+	oa, _ := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc1+`","parent_id":"`+r1+`","title":"a","body":""}`)
+	a := oa["id"].(string)
+	// doc2 with chunk B.
+	o2, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D2"}`)
+	doc2, r2 := o2["document_id"].(string), o2["root_chunk_id"].(string)
+	ob, _ := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc2+`","parent_id":"`+r2+`","title":"b","body":""}`)
+	b := ob["id"].(string)
+	// B (doc2) → A (doc1): an INCOMING edge into doc1. Both exist → allowed.
+	if _, r := docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"`+b+`","to_id":"`+a+`","kind":"targets"}`); r.IsError {
+		t.Fatalf("cross-doc link: %q", r.Text)
+	}
+	// Delete doc1. The B→A edge (from_id=B is in doc2, to_id=A is in doc1) must
+	// be cleaned by the bidirectional sweep — not left dangling.
+	if _, r := docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+doc1+`"}`); r.IsError {
+		t.Fatalf("delete_document: %q", r.Text)
+	}
+	out, res := docExec(t, d, ctx, `{"op":"query_chunks","scope":"user","sql":"SELECT from_id, to_id FROM chunk_edges"}`)
+	if res.IsError {
+		t.Fatalf("edge query: %q", res.Text)
+	}
+	if rows, _ := out["rows"].([]any); len(rows) != 0 {
+		t.Errorf("incoming cross-doc edge left dangling after delete_document: %s", res.Text)
+	}
+}
+
+// Hardening: delete_chunk fails CLOSED when a BFS frontier level exceeds the
+// SQL Memory row cap — a truncated enumeration would orphan the unseen
+// children's rows under a deleted parent, so we refuse rather than half-delete.
+func TestDocument_DeleteChunkRefusesTruncatedSubtree(t *testing.T) {
+	s, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	// MaxRows:1 → any parent with ≥2 children truncates the frontier query.
+	mgr, err := sqlmem.New(sqlmem.Config{Root: t.TempDir(), MaxRows: 1})
+	if err != nil {
+		t.Fatalf("sqlmem.New: %v", err)
+	}
+	t.Cleanup(func() { _ = mgr.Close() })
+	ctx := tools.WithAgentName(context.Background(), "doc-agent")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: "u1", TenantID: "tnt"})
+	d := &Document{Store: s, SqlMem: mgr, Bus: channels.NewBus()}
+
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"D"}`)
+	doc, root := out["document_id"].(string), out["root_chunk_id"].(string)
+	// A parent with two children under it → frontier level of 2 > cap of 1.
+	op, _ := docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+root+`","title":"p","body":""}`)
+	parent := op["id"].(string)
+	for _, name := range []string{"c1", "c2"} {
+		docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+doc+`","parent_id":"`+parent+`","title":"`+name+`","body":""}`)
+	}
+	// delete_chunk(parent) must refuse (fail closed), not orphan a child.
+	if _, r := docExec(t, d, ctx, `{"op":"delete_chunk","scope":"user","id":"`+parent+`"}`); !r.IsError || !strings.Contains(r.Text, "too wide") {
+		t.Fatalf("delete_chunk over a truncated subtree should refuse; got err=%v text=%q", r.IsError, r.Text)
+	}
+	// The parent and both children must still exist (txn rolled back).
+	if _, r := docExec(t, d, ctx, `{"op":"get_chunk","scope":"user","id":"`+parent+`"}`); r.IsError {
+		t.Errorf("parent must survive the refused delete; got %q", r.Text)
 	}
 }


### PR DESCRIPTION
## Why

Follow-up hardening on the Document primitive (RFC AK Phase 1, merged in #539), driven by a Q&A walkthrough of the delete/link paths: *"We do not want to create a mess of orphans."* The merged core had four orphan-creating gaps:

1. **Non-atomic cascades.** `delete_document` and `delete_chunk` issued their SQL deletes as separate auto-commit statements. A failure mid-cascade (e.g. the chunk-rows delete succeeds but the documents-row delete errors) left a half-deleted graph.
2. **One-directional edge cleanup.** `delete_document` only cleaned *outgoing* edges (`from_id IN doc`). An **incoming** cross-document edge from another doc was left dangling at a now-deleted chunk.
3. **Born-dangling edges.** `link_chunks` never checked that its endpoints existed, so an edge could be created pointing at a non-existent chunk.
4. **Root-chunk delete.** Deleting a document's root chunk left the `documents` row pointing at a dangling `root_chunk_id` with zero chunks.

## What

- **Atomic deletes.** New `withSqlTxn` helper wraps the whole SQL cascade in one SQL Memory transaction with a **fresh, unique txn id** (`doc-tx:<uuid>`) so it never nests onto an agent's explicit `sql_begin`. Commit on success; rollback on any error. Chunk Memory **bodies** live in a separate store that can't join the SQL txn, so they're deleted **after** a successful commit — best-effort: an orphaned body is invisible dead k/v, whereas an orphaned row would be visible, so SQL-first is the least-bad ordering.
- **Bidirectional edge sweep.** `delete_document` now deletes `chunk_edges WHERE from_id IN (doc chunks) OR to_id IN (doc chunks)` — incoming cross-document edges no longer dangle.
- **Endpoint validation.** `link_chunks` requires **both** endpoints to exist (cross-document edges are still allowed — both chunks just have to exist in the scope).
- **Root-chunk guard.** `delete_chunk` refuses a document's root chunk (→ `delete_document`). The guard **fails closed** on a lookup error.
- **Truncation guard.** `delete_chunk`'s BFS descendant walk **fails closed** if a frontier level is truncated by the SQL Memory row cap — a partial enumeration would orphan the unseen children's rows under a deleted parent, so it refuses (txn rolls back) rather than half-delete. (`delete_document`'s row deletes are set-based and complete regardless of truncation; only Memory bodies past the cap are best-effort.)

## What was tested

- **4 new regression tests:** `TestDocument_LinkChunksValidatesEndpoints`, `TestDocument_DeleteRootChunkRefused`, `TestDocument_DeleteDocumentCleansIncomingCrossDocEdges`, `TestDocument_DeleteChunkRefusesTruncatedSubtree` (the last verified fails-before: without the guard, `delete_chunk` returns `deleted:true` while orphaning a child).
- `TestDocument_Postgres` extended to exercise the **transactional** `delete_chunk` + `delete_document` paths on a real Postgres tier (CI go-postgres job).
- `go test ./...` clean; `go vet` clean; `gofmt` clean. PG tier verified locally via `make pg-up` + the aux `sqlmem_aux` DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)