### PR TITLE
feat(webui): Path tree console + mkdir directory materialization (RFC AM Phase 1)

### DIFF
--- a/docs/PATH.md
+++ b/docs/PATH.md
@@ -32,7 +32,7 @@ One tool, `Path`, gated by per-agent `allowed_tools: [Path]`. Six ops:
 | `resolve` | path → the dirent + its `resource_ref` (the backing id). |
 | `ls`      | list a directory's entries (`recursive:true` walks descendants; `kind_filter` narrows by kind). |
 | `stat`    | one entry's metadata (name, kind, resource_ref). |
-| `mkdir`   | **no-op in v1** — directories are implicit (S3-style); kept for forward-compat + shell ergonomics. |
+| `mkdir`   | materialize an empty `directory` dirent so an empty branch persists and lists. Idempotent (ok if the directory already exists, explicitly or implied by descendants); refuses to clobber a non-directory. Intermediate directories under a created resource stay implicit (S3-style) — `mkdir` is only needed for an *empty* folder. |
 | `mv`      | re-parent / rename a dirent (a move into the path's own subtree is refused — it would orphan the tree). |
 | `rm`      | remove a dirent (`recursive:true` is **required** to remove a path that has descendants). |
 
@@ -45,8 +45,8 @@ is the shared `""`.
 segments match `[a-zA-Z0-9._-]+`; **no `..`** (rejected, not resolved — this is
 what makes the tree tenant-safe); at most 64 segments / 1024 chars.
 
-**Resource kinds** a dirent can point at: `directory` (implicit), `document`,
-`volume_mount`, `memory_entry`.
+**Resource kinds** a dirent can point at: `directory` (implicit, or materialized
+by `mkdir`), `document`, `volume_mount`, `memory_entry`.
 
 ## How resources get a name
 

--- a/internal/help/builtin/path.md
+++ b/internal/help/builtin/path.md
@@ -31,8 +31,11 @@ scopes is two different entries.
   default; `recursive:true` lists all descendants; `kind_filter` narrows to one
   kind (`document` / `volume_mount` / `memory_entry`).
 - `stat path [scope]` — the dirent's full record.
-- `mkdir path [scope]` — **no-op in v1**: directories are implicit (a leaf at
-  `/a/b/c` implies `/a/` and `/a/b/`). Kept for forward-compat.
+- `mkdir path [scope]` — materialize an empty `directory` dirent so an empty
+  branch persists and lists. Idempotent (ok if the directory already exists,
+  explicitly or implied by descendants); refuses to clobber a non-directory.
+  Intermediate directories under a resource stay implicit (a leaf at `/a/b/c`
+  implies `/a/` and `/a/b/`) — `mkdir` is only needed for an *empty* folder.
 - `mv from to [scope]` — rename/relocate; the underlying resource is unchanged.
   Refuses if `to` already exists (no clobber). Moving a directory cascades to
   every descendant atomically.

--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -28,7 +28,7 @@ type Path struct {
 func (p *Path) Name() string { return "Path" }
 
 func (p *Path) Description() string {
-	return "A Unix-like filesystem over your Memory, Volumes, and Documents. Address resources by human-readable paths (e.g. /docs/launch). Ops: resolve, ls, stat, mkdir (no-op — dirs are implicit), mv, rm. Paths are scoped (agent/user/tenant, default agent) and tenant-isolated; segments are [a-zA-Z0-9._-], no \"..\"."
+	return "A Unix-like filesystem over your Memory, Volumes, and Documents. Address resources by human-readable paths (e.g. /docs/launch). Ops: resolve, ls, stat, mkdir (create an empty directory), mv, rm. Paths are scoped (agent/user/tenant, default agent) and tenant-isolated; segments are [a-zA-Z0-9._-], no \"..\"."
 }
 
 // pathInputSchema is a package const so the LoomCycle MCP server can source
@@ -81,12 +81,7 @@ func (p *Path) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, 
 	case "stat":
 		return p.stat(ctx, tenantID, scope, scopeID, in)
 	case "mkdir":
-		// Directories are implicit (S3-style) in v1 — mkdir is a no-op kept
-		// for forward-compat + ergonomic parity with a real shell.
-		if _, err := normalizePath(in.Path); err != nil {
-			return errResult(err.Error()), nil
-		}
-		return jsonResult(map[string]any{"ok": true, "note": "directories are implicit in v1; mkdir is a no-op"})
+		return p.mkdir(ctx, tenantID, scope, scopeID, in)
 	case "mv":
 		return p.mv(ctx, tenantID, scope, scopeID, in)
 	case "rm":
@@ -200,6 +195,56 @@ func (p *Path) stat(ctx context.Context, tenantID, scope, scopeID string, in pat
 		"scope": scope, "resource_ref": row.ResourceRef,
 		"created_at": row.CreatedAt, "updated_at": row.UpdatedAt,
 	})
+}
+
+// mkdir materializes an explicit `directory` dirent so an empty branch
+// persists and is listable. RFC AL shipped mkdir as a no-op (directories are
+// implicit, S3-style) and parked explicit directories as a v2 item (RFC AL
+// §11); RFC AM pulls it forward so the Web UI can create empty folders.
+// Idempotent: ok if a directory already exists at the path (an explicit row OR
+// one implied by descendants); refuses to clobber a non-directory resource
+// (DirentCreate is an upsert, so the clobber guard is load-bearing).
+func (p *Path) mkdir(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {
+	canonical, err := normalizePath(in.Path)
+	if err != nil {
+		return errResult(err.Error()), nil
+	}
+	parent, name, isRoot := splitPath(canonical)
+	if isRoot {
+		return errResult("cannot mkdir the root path (it always exists)"), nil
+	}
+	// Something already named here? ok if it's a directory; never overwrite a
+	// document / volume_mount / memory_entry with a directory.
+	row, gerr := p.Store.DirentGet(ctx, tenantID, scope, scopeID, parent, name)
+	if gerr == nil {
+		if row.Kind == "directory" {
+			return jsonResult(map[string]any{"ok": true, "path": canonical, "created": false, "note": "already a directory"})
+		}
+		return errResult(fmt.Sprintf("path exists and is not a directory: %s (kind=%s)", canonical, row.Kind)), nil
+	}
+	var nf *store.ErrNotFound
+	if !asNotFound(gerr, &nf) {
+		return errResult("mkdir: " + gerr.Error()), nil
+	}
+	// No explicit row. If the path is already implied (has descendants) it
+	// effectively exists — no-op success, don't rewrite history (RFC AM §13).
+	kids, lerr := p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, dirPrefix(canonical))
+	if lerr != nil {
+		return errResult("mkdir: " + lerr.Error()), nil
+	}
+	if len(kids) > 0 {
+		return jsonResult(map[string]any{"ok": true, "path": canonical, "created": false, "note": "directory already implied by descendants"})
+	}
+	// Materialize an empty directory dirent. ResourceRef is left nil (a
+	// directory backs no resource); the store coerces it to "{}" for backend
+	// parity.
+	if _, err := p.Store.DirentCreate(ctx, store.DirentRow{
+		TenantID: tenantID, Scope: scope, ScopeID: scopeID,
+		ParentPath: parent, Name: name, Kind: "directory",
+	}); err != nil {
+		return errResult("mkdir: " + err.Error()), nil
+	}
+	return jsonResult(map[string]any{"ok": true, "path": canonical, "created": true})
 }
 
 func (p *Path) mv(ctx context.Context, tenantID, scope, scopeID string, in pathInput) (tools.Result, error) {

--- a/internal/tools/builtin/pathtool_test.go
+++ b/internal/tools/builtin/pathtool_test.go
@@ -226,3 +226,72 @@ func TestPath_ScopeUserRequiresUserID(t *testing.T) {
 		t.Errorf("scope=user without a user_id should error")
 	}
 }
+
+// RFC AM: mkdir now MATERIALIZES an empty `directory` dirent (RFC AL shipped it
+// as a no-op). Fail-before — the old no-op created nothing, so resolve/ls would
+// not see the branch.
+func TestPath_MkdirMaterializesDirectory(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	out, res := pathExec(t, p, ctx, `{"op":"mkdir","path":"/work"}`)
+	if res.IsError {
+		t.Fatalf("mkdir: %q", res.Text)
+	}
+	if out["created"] != true {
+		t.Errorf("mkdir /work created = %v, want true: %s", out["created"], res.Text)
+	}
+	// It persists: resolve sees a directory, and ls / lists it.
+	if o, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/work"}`); r.IsError || o["kind"] != "directory" {
+		t.Errorf("resolve /work after mkdir = %s (err=%v)", r.Text, r.IsError)
+	}
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/"}`)
+	if res.IsError {
+		t.Fatalf("ls /: %q", res.Text)
+	}
+	if entries, _ := out["entries"].([]any); len(entries) != 1 {
+		t.Errorf("ls / after mkdir = %d entries, want 1: %s", len(entries), res.Text)
+	}
+	// An empty materialized dir is removable without recursive (no descendants).
+	if _, r := pathExec(t, p, ctx, `{"op":"rm","path":"/work"}`); r.IsError {
+		t.Errorf("rm of an empty dir should succeed without recursive: %q", r.Text)
+	}
+}
+
+// mkdir is idempotent: a re-mkdir, or a mkdir over a path only IMPLIED by
+// descendants, is a no-op success (created:false) — it never rewrites history.
+func TestPath_MkdirIdempotent(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	if _, r := pathExec(t, p, ctx, `{"op":"mkdir","path":"/work"}`); r.IsError {
+		t.Fatalf("mkdir 1: %q", r.Text)
+	}
+	out, res := pathExec(t, p, ctx, `{"op":"mkdir","path":"/work"}`)
+	if res.IsError || out["created"] != false {
+		t.Errorf("re-mkdir should be created:false ok; got %s (err=%v)", res.Text, res.IsError)
+	}
+	// Implied directory (has a descendant, no explicit row).
+	seedAgent(t, s, "/docs/launches/", "v1", "document")
+	out, res = pathExec(t, p, ctx, `{"op":"mkdir","path":"/docs/launches"}`)
+	if res.IsError || out["created"] != false {
+		t.Errorf("mkdir over an implied dir should be created:false ok; got %s (err=%v)", res.Text, res.IsError)
+	}
+}
+
+// mkdir must NOT clobber a non-directory — DirentCreate is an upsert, so the
+// guard is load-bearing (without it a mkdir would silently convert a document
+// dirent into a directory).
+func TestPath_MkdirRefusesClobberNonDirectory(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/docs/", "a", "document")
+	if _, r := pathExec(t, p, ctx, `{"op":"mkdir","path":"/docs/a"}`); !r.IsError {
+		t.Fatalf("mkdir over a document must be refused; got %q", r.Text)
+	}
+	if o, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs/a"}`); r.IsError || o["kind"] != "document" {
+		t.Errorf("/docs/a should still be a document after a refused mkdir: %s (err=%v)", r.Text, r.IsError)
+	}
+}
+
+func TestPath_MkdirRejectsRoot(t *testing.T) {
+	p, ctx, _ := pathFixture(t)
+	if _, r := pathExec(t, p, ctx, `{"op":"mkdir","path":"/"}`); !r.IsError {
+		t.Errorf("mkdir of the root path should be refused")
+	}
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -675,6 +675,105 @@ async function postJSON<T>(path: string, body: string | undefined): Promise<T> {
   return resp.json() as Promise<T>;
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// RFC AM — Path + Document console (off-run substrate endpoints).
+//
+// The Web UI drives the Path VFS (RFC AL) and chunked-graph Documents (RFC AK)
+// through the off-run endpoints POST /v1/_path and POST /v1/_document. Scope +
+// tenant are resolved server-side from the authenticated principal
+// (substrateAdminUserCtx) — the browser never sends them as authority; `scope`
+// is only the subtree SELECTOR (which of the principal's own trees). The
+// console defaults to `user` scope so its tree lines up with the principal's
+// own agent runs (user_id = principal.subject). `agent` scope is operator-
+// private off-run; Documents support agent|user only (tenant is refused).
+
+export type PathScope = "agent" | "user" | "tenant";
+export type DocScope = "agent" | "user";
+
+// PathEntry is one dirent in an `ls` listing.
+export interface PathEntry {
+  name: string;
+  kind: string; // directory | document | volume_mount | memory_entry
+  full_path: string;
+  resource_ref?: unknown;
+}
+
+// substratePost POSTs a tool op to an off-run substrate endpoint. A 200 returns
+// the tool's JSON result verbatim; a 422 tool refusal carries {code,error,tool}
+// — surface the human-readable `error` (e.g. "Documents require SQL Memory").
+async function substratePost<T>(path: string, body: unknown): Promise<T> {
+  const resp = await fetch(baseURL + path, {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (resp.ok) return resp.json() as Promise<T>;
+  if (redirectToLoginOn401(resp.status)) return new Promise<T>(() => {});
+  const raw = await resp.text();
+  let msg = `${resp.status} ${resp.statusText}: ${raw.slice(0, 200)}`;
+  try {
+    const j = JSON.parse(raw) as { error?: string };
+    if (j && typeof j.error === "string") msg = j.error;
+  } catch {
+    /* non-JSON body — keep the status-line message */
+  }
+  throw new Error(msg);
+}
+
+// pathLs lists a path. recursive returns the whole subtree (the tree view
+// fetches the subtree once and reconstructs intermediate dirs client-side).
+export function pathLs(
+  path: string,
+  scope: PathScope,
+  recursive = false,
+): Promise<{ path: string; entries: PathEntry[] }> {
+  return substratePost("/v1/_path", { op: "ls", path, scope, recursive });
+}
+
+// pathMkdir materializes an empty `directory` dirent (RFC AM); idempotent.
+export function pathMkdir(
+  path: string,
+  scope: PathScope,
+): Promise<{ ok: boolean; created: boolean; path: string }> {
+  return substratePost("/v1/_path", { op: "mkdir", path, scope });
+}
+
+// pathMv renames/relocates a dirent (atomic; cascades a subtree; no-clobber).
+export function pathMv(from: string, to: string, scope: PathScope): Promise<{ ok: boolean }> {
+  return substratePost("/v1/_path", { op: "mv", path: from, to, scope });
+}
+
+// pathRm removes a dirent (recursive required for a non-empty branch). Removes
+// the path entry only — backing resources are deleted via their own tool.
+export function pathRm(
+  path: string,
+  scope: PathScope,
+  recursive = false,
+): Promise<{ ok: boolean; n_removed: number }> {
+  return substratePost("/v1/_path", { op: "rm", path, scope, recursive });
+}
+
+// documentCreate makes a new chunked-graph Document and names it in the Path
+// tree at `path`. Requires SQL Memory on the runtime; a not-enabled runtime
+// returns a tool refusal surfaced by substratePost.
+export function documentCreate(
+  title: string,
+  path: string,
+  scope: DocScope,
+): Promise<{ document_id: string; root_chunk_id: string; title: string; path?: string }> {
+  return substratePost("/v1/_document", { op: "create_document", title, path, scope });
+}
+
+// documentDelete removes a Document by id: SQL rows + Memory bodies + the Path
+// dirent, cascading its chunks (RFC AK).
+export function documentDelete(
+  id: string,
+  scope: DocScope,
+): Promise<{ deleted: boolean; document_id: string; n_chunks_deleted: number }> {
+  return substratePost("/v1/_document", { op: "delete_document", id, scope });
+}
+
 // AuditEvent mirrors wireEvent in internal/api/http/events_audit.go.
 // Payload is left as `unknown` because event payloads vary by type
 // (text / tool_call / tool_result / usage / done / …); the audit

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Brain,
   CalendarClock,
   Camera,
+  FolderTree,
   HardDrive,
   Library,
   ListTree,
@@ -43,6 +44,10 @@ const NAV_ITEMS: NavItem[] = [
   // RFC AH Phase 4. adminOnly mirrors the Library/Integrations def-management
   // gating; broadening to tenant-operator UI access is a separate concern.
   { to: "/volumes/persistent", label: "volumes", Icon: HardDrive, adminOnly: true },
+  // RFC AM Phase 1 — the Path VFS tree console. adminOnly mirrors the
+  // volumes/library def-management gating; broadening to tenant-operator UI
+  // access is a separate concern (the data is per-principal scoped regardless).
+  { to: "/paths", label: "paths", Icon: FolderTree, adminOnly: true },
   { to: "/channels", label: "channels", Icon: Radio, adminOnly: true },
   { to: "/schedules", label: "schedules", Icon: CalendarClock, adminOnly: true },
   { to: "/interrupts", label: "interrupts", Icon: Bell, adminOnly: true },

--- a/web/src/components/PathTree.tsx
+++ b/web/src/components/PathTree.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from "react";
+import type { PathEntry } from "../api";
+
+// PathTree renders the RFC AL dirent tree (RFC AM Web UI Phase 1). The Path
+// tool's `ls recursive` returns a FLAT list of dirents; buildPathTree
+// reconstructs the hierarchy, synthesizing intermediate `directory` nodes for
+// path segments that have no explicit dirent row (implicit dirs, S3-style).
+// Modeled on AgentsTree: a single expand Map owned by the tree, default-
+// expanded, click-to-select.
+
+export interface PathNode {
+  name: string;
+  fullPath: string;
+  kind: string; // directory | document | volume_mount | memory_entry
+  resourceRef?: unknown;
+  explicit: boolean; // false = synthesized intermediate dir (no dirent row)
+  children: PathNode[];
+}
+
+// buildPathTree turns a flat dirent list into a hierarchy. Each entry's
+// full_path is split into segments; ancestors with no explicit row are created
+// as implicit `directory` nodes (an explicit dirent later upgrades them).
+export function buildPathTree(entries: PathEntry[]): PathNode[] {
+  const root: PathNode = {
+    name: "",
+    fullPath: "",
+    kind: "directory",
+    explicit: true,
+    children: [],
+  };
+  const byPath = new Map<string, PathNode>([["", root]]);
+  const ensure = (fullPath: string): PathNode => {
+    const hit = byPath.get(fullPath);
+    if (hit) return hit;
+    const idx = fullPath.lastIndexOf("/");
+    const parentPath = idx <= 0 ? "" : fullPath.slice(0, idx);
+    const name = fullPath.slice(idx + 1);
+    const parent = ensure(parentPath);
+    const node: PathNode = {
+      name,
+      fullPath,
+      kind: "directory",
+      explicit: false,
+      children: [],
+    };
+    parent.children.push(node);
+    byPath.set(fullPath, node);
+    return node;
+  };
+  for (const e of entries) {
+    const node = ensure(e.full_path);
+    node.kind = e.kind;
+    node.explicit = true;
+    node.resourceRef = e.resource_ref;
+  }
+  const sortRec = (nodes: PathNode[]) => {
+    nodes.sort((a, b) => {
+      const ad = a.kind === "directory";
+      const bd = b.kind === "directory";
+      if (ad !== bd) return ad ? -1 : 1; // directories first
+      return a.name.localeCompare(b.name);
+    });
+    nodes.forEach((n) => sortRec(n.children));
+  };
+  sortRec(root.children);
+  return root.children;
+}
+
+// parentPathOf returns the canonical parent of a node path ("" = root).
+export function parentPathOf(fullPath: string): string {
+  const idx = fullPath.lastIndexOf("/");
+  return idx <= 0 ? "" : fullPath.slice(0, idx);
+}
+
+// collectDocumentIds walks a subtree and returns the document_id of every
+// `document` node under it (used to cascade-delete Documents before rm'ing a
+// branch, so a branch delete leaves no orphaned Document content).
+export function collectDocumentIds(node: PathNode): string[] {
+  const ids: string[] = [];
+  const walk = (n: PathNode) => {
+    if (n.kind === "document") {
+      const ref = n.resourceRef as { document_id?: string } | undefined;
+      if (ref?.document_id) ids.push(ref.document_id);
+    }
+    n.children.forEach(walk);
+  };
+  walk(node);
+  return ids;
+}
+
+const KIND_ICON: Record<string, string> = {
+  directory: "📁",
+  document: "📄",
+  volume_mount: "💾",
+  memory_entry: "🧠",
+};
+
+export interface PathTreeProps {
+  tree: PathNode[];
+  selectedPath?: string;
+  onSelect: (node: PathNode) => void;
+}
+
+export default function PathTree({ tree, selectedPath, onSelect }: PathTreeProps) {
+  const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
+  const toggle = useCallback((p: string) => {
+    setExpanded((prev) => {
+      const next = new Map(prev);
+      next.set(p, prev.get(p) === false ? true : false);
+      return next;
+    });
+  }, []);
+
+  // Auto-expand the ancestors of the selection so a post-refresh / deep
+  // selection isn't buried under a collapsed parent.
+  useEffect(() => {
+    if (!selectedPath) return;
+    setExpanded((prev) => {
+      let mutated = false;
+      const next = new Map(prev);
+      let p = parentPathOf(selectedPath);
+      while (p !== "") {
+        if (next.get(p) === false) {
+          next.set(p, true);
+          mutated = true;
+        }
+        p = parentPathOf(p);
+      }
+      return mutated ? next : prev;
+    });
+  }, [selectedPath]);
+
+  if (tree.length === 0) {
+    return (
+      <div className="empty">
+        <p>This tree is empty. Create a folder or document to begin.</p>
+      </div>
+    );
+  }
+  return (
+    <ul className="tree path-tree">
+      {tree.map((n) => (
+        <PathTreeNode
+          key={n.fullPath}
+          node={n}
+          expanded={expanded}
+          toggle={toggle}
+          selectedPath={selectedPath}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+}
+
+interface NodeProps {
+  node: PathNode;
+  expanded: Map<string, boolean>;
+  toggle: (p: string) => void;
+  selectedPath?: string;
+  onSelect: (node: PathNode) => void;
+}
+
+function PathTreeNode({ node, expanded, toggle, selectedPath, onSelect }: NodeProps) {
+  const hasChildren = node.children.length > 0;
+  const isOpen = expanded.get(node.fullPath) !== false; // default-expanded
+  const isSelected = selectedPath === node.fullPath;
+  return (
+    <li className={`node path-node kind-${node.kind} ${isSelected ? "selected" : ""}`}>
+      <div className="row path-row">
+        <button
+          type="button"
+          className="tree-caret"
+          aria-label={isOpen ? "collapse" : "expand"}
+          disabled={!hasChildren}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasChildren) toggle(node.fullPath);
+          }}
+        >
+          {hasChildren ? (isOpen ? "▼" : "▶") : "·"}
+        </button>
+        <button
+          type="button"
+          className="path-link"
+          onClick={() => onSelect(node)}
+          title={node.fullPath}
+        >
+          <span className="path-kind-icon" aria-hidden>
+            {KIND_ICON[node.kind] ?? "•"}
+          </span>
+          <span className="path-name">{node.name}</span>
+          {!node.explicit && (
+            <span className="path-implicit" title="Implicit directory (no stored entry)">
+              implicit
+            </span>
+          )}
+        </button>
+      </div>
+      {hasChildren && isOpen && (
+        <ul className="children path-children">
+          {node.children.map((c) => (
+            <PathTreeNode
+              key={c.fullPath}
+              node={c}
+              expanded={expanded}
+              toggle={toggle}
+              selectedPath={selectedPath}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -19,6 +19,7 @@ import ActivityMonitor from "./pages/ActivityMonitor";
 import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
 import VolumesView from "./pages/VolumesView";
+import PathTreeView from "./pages/PathTreeView";
 import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
 import Layout from "./components/Layout";
@@ -71,6 +72,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           </Route>
           <Route path="volumes/persistent" element={<VolumesView />} />
           <Route path="volumes/ephemeral" element={<VolumesView />} />
+          <Route path="paths" element={<PathTreeView />} />
           <Route path="channels" element={<ChannelsView />} />
           <Route path="schedules" element={<SchedulesView />} />
           <Route path="memory" element={<MemoryView />} />

--- a/web/src/pages/PathTreeView.tsx
+++ b/web/src/pages/PathTreeView.tsx
@@ -1,0 +1,363 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import {
+  type DocScope,
+  type PathEntry,
+  type PathScope,
+  documentDelete,
+  documentCreate,
+  pathLs,
+  pathMkdir,
+  pathMv,
+  pathRm,
+} from "../api";
+import Splitter from "../components/Splitter";
+import PathTree, {
+  buildPathTree,
+  collectDocumentIds,
+  parentPathOf,
+  type PathNode,
+} from "../components/PathTree";
+
+// PathTreeView is the RFC AM Phase 1 Path console: the unified dirent tree
+// (RFC AL) with directory + document CRUD. Identity (tenant + the user-scope
+// id) is resolved server-side from the cookie principal — the page sends only
+// `scope`, which is the subtree SELECTOR, not an authority grant. Defaults to
+// `user` scope so the tree lines up with the principal's own agent runs.
+
+const NAME_RE = /^[A-Za-z0-9._-]+$/;
+
+// joinPath appends a leaf segment to a canonical parent dir ("" = root).
+function joinPath(dir: string, name: string): string {
+  return `${dir}/${name}`;
+}
+
+function findNode(tree: PathNode[], fullPath: string): PathNode | undefined {
+  for (const n of tree) {
+    if (n.fullPath === fullPath) return n;
+    const hit = findNode(n.children, fullPath);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+interface ModalField {
+  key: string;
+  label: string;
+  placeholder?: string;
+  value?: string;
+}
+interface ModalState {
+  title: string;
+  message?: string;
+  fields: ModalField[];
+  submitLabel: string;
+  danger?: boolean;
+  onSubmit: (vals: Record<string, string>) => Promise<void>;
+}
+
+export default function PathTreeView() {
+  const [scope, setScope] = useState<PathScope>("user");
+  const [entries, setEntries] = useState<PathEntry[]>([]);
+  const [selectedPath, setSelectedPath] = useState<string | undefined>(undefined);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [modal, setModal] = useState<ModalState | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      const resp = await pathLs("/", scope, true);
+      setEntries(resp.entries ?? []);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [scope]);
+
+  // Reload whenever the scope changes (and on mount). Clear the selection so a
+  // stale path from the previous scope doesn't drive the detail pane.
+  useEffect(() => {
+    setSelectedPath(undefined);
+    void refresh();
+  }, [refresh]);
+
+  const tree = useMemo(() => buildPathTree(entries), [entries]);
+  const selected = useMemo(
+    () => (selectedPath ? findNode(tree, selectedPath) : undefined),
+    [tree, selectedPath],
+  );
+
+  // The directory new items are created under: the selected directory, the
+  // parent of a selected leaf, or root.
+  const currentDir = useMemo(() => {
+    if (!selected) return "";
+    return selected.kind === "directory" ? selected.fullPath : parentPathOf(selected.fullPath);
+  }, [selected]);
+  const currentDirLabel = currentDir || "/";
+
+  const canDocuments = scope !== "tenant"; // Documents are agent|user only.
+
+  const newFolder = useCallback(() => {
+    setModal({
+      title: `New folder in ${currentDirLabel}`,
+      fields: [{ key: "name", label: "Folder name", placeholder: "e.g. launches" }],
+      submitLabel: "Create",
+      onSubmit: async (v) => {
+        const name = v.name.trim();
+        if (!NAME_RE.test(name)) throw new Error("name may contain only [A-Za-z0-9._-]");
+        const p = joinPath(currentDir, name);
+        await pathMkdir(p, scope);
+        await refresh();
+        setSelectedPath(p);
+      },
+    });
+  }, [currentDir, currentDirLabel, scope, refresh]);
+
+  const newDocument = useCallback(() => {
+    setModal({
+      title: `New document in ${currentDirLabel}`,
+      fields: [
+        { key: "name", label: "Path name", placeholder: "e.g. launch-plan" },
+        { key: "title", label: "Title", placeholder: "e.g. Launch Plan" },
+      ],
+      submitLabel: "Create",
+      onSubmit: async (v) => {
+        const name = v.name.trim();
+        if (!NAME_RE.test(name)) throw new Error("name may contain only [A-Za-z0-9._-]");
+        const title = v.title.trim() || name;
+        const p = joinPath(currentDir, name);
+        await documentCreate(title, p, scope as DocScope);
+        await refresh();
+        setSelectedPath(p);
+      },
+    });
+  }, [currentDir, currentDirLabel, scope, refresh]);
+
+  const renameSelected = useCallback(() => {
+    if (!selected) return;
+    setModal({
+      title: `Rename / move ${selected.fullPath}`,
+      fields: [{ key: "to", label: "New path", value: selected.fullPath }],
+      submitLabel: "Move",
+      onSubmit: async (v) => {
+        const to = v.to.trim();
+        if (!to.startsWith("/")) throw new Error("path must start with /");
+        await pathMv(selected.fullPath, to, scope);
+        await refresh();
+        setSelectedPath(to);
+      },
+    });
+  }, [selected, scope, refresh]);
+
+  const deleteSelected = useCallback(() => {
+    if (!selected) return;
+    if (selected.kind === "document") {
+      const ref = selected.resourceRef as { document_id?: string } | undefined;
+      const id = ref?.document_id;
+      setModal({
+        title: `Delete document ${selected.fullPath}`,
+        message: "This deletes the document, all its chunks, and its path entry. This cannot be undone.",
+        fields: [],
+        submitLabel: "Delete",
+        danger: true,
+        onSubmit: async () => {
+          if (!id) throw new Error("this document dirent has no document_id");
+          await documentDelete(id, scope as DocScope);
+          await refresh();
+          setSelectedPath(undefined);
+        },
+      });
+      return;
+    }
+    // Directory: cascade-delete contained Documents (so no orphaned content),
+    // then remove the dirent subtree. Documents only exist in agent|user scope.
+    const docIds = scope === "tenant" ? [] : collectDocumentIds(selected);
+    const childCount = selected.children.length;
+    setModal({
+      title: `Delete branch ${selected.fullPath}`,
+      message:
+        childCount === 0
+          ? "This removes the (empty) folder."
+          : `This removes the folder and everything under it` +
+            (docIds.length > 0
+              ? ` — including ${docIds.length} document(s), whose chunks are deleted.`
+              : "."),
+      fields: [],
+      submitLabel: "Delete",
+      danger: true,
+      onSubmit: async () => {
+        for (const id of docIds) {
+          await documentDelete(id, scope as DocScope);
+        }
+        await pathRm(selected.fullPath, scope, true);
+        await refresh();
+        setSelectedPath(undefined);
+      },
+    });
+  }, [selected, scope, refresh]);
+
+  const mutable = selected && (selected.kind === "directory" || selected.kind === "document");
+
+  return (
+    <>
+      <Splitter
+        className="paths-view"
+        defaultLeftWidth={420}
+        minLeftWidth={280}
+        minRightWidth={300}
+        storageKey="loomcycle.split.paths"
+      >
+        <div className="left">
+          <div className="paths-toolbar">
+            <label className="paths-scope">
+              <span>scope</span>
+              <select value={scope} onChange={(e) => setScope(e.target.value as PathScope)}>
+                <option value="user">user</option>
+                <option value="agent">agent</option>
+                <option value="tenant">tenant</option>
+              </select>
+            </label>
+            <div className="paths-toolbar-actions">
+              <button type="button" onClick={newFolder} title={`New folder in ${currentDirLabel}`}>
+                + folder
+              </button>
+              <button
+                type="button"
+                onClick={newDocument}
+                disabled={!canDocuments}
+                title={
+                  canDocuments
+                    ? `New document in ${currentDirLabel}`
+                    : "Documents are agent/user scope only"
+                }
+              >
+                + document
+              </button>
+              <button type="button" onClick={() => void refresh()} title="Reload the tree">
+                ↻
+              </button>
+            </div>
+          </div>
+          <p className="paths-context">
+            new items → <code>{currentDirLabel}</code>
+          </p>
+          {err && <div className="paths-err">{err}</div>}
+          {loading && entries.length === 0 ? (
+            <div className="empty">
+              <p>Loading…</p>
+            </div>
+          ) : (
+            <PathTree tree={tree} selectedPath={selectedPath} onSelect={(n) => setSelectedPath(n.fullPath)} />
+          )}
+        </div>
+        <div className="right">
+          {selected ? (
+            <div className="paths-detail">
+              <h2>
+                <span className="paths-detail-kind">{selected.kind}</span>
+                <code>{selected.fullPath}</code>
+              </h2>
+              <dl className="paths-detail-meta">
+                <dt>scope</dt>
+                <dd>{scope}</dd>
+                <dt>stored</dt>
+                <dd>{selected.explicit ? "yes" : "implicit (no entry)"}</dd>
+                {selected.kind === "document" && (
+                  <>
+                    <dt>document_id</dt>
+                    <dd>
+                      <code>
+                        {(selected.resourceRef as { document_id?: string })?.document_id ?? "—"}
+                      </code>
+                    </dd>
+                  </>
+                )}
+              </dl>
+              {mutable ? (
+                <div className="paths-detail-actions">
+                  <button type="button" onClick={renameSelected}>
+                    rename / move
+                  </button>
+                  <button type="button" className="danger" onClick={deleteSelected}>
+                    delete
+                  </button>
+                </div>
+              ) : (
+                <p className="paths-readonly">
+                  Read-only — {selected.kind} entries are managed by their own tool.
+                </p>
+              )}
+              {selected.kind === "document" && (
+                <p className="paths-note">
+                  Chunk viewing &amp; editing arrives with the Document viewer (Phase 2).
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="empty">
+              <p>Select a path on the left, or create a folder / document.</p>
+            </div>
+          )}
+        </div>
+      </Splitter>
+      {modal && <PromptModal state={modal} onClose={() => setModal(null)} />}
+    </>
+  );
+}
+
+// PromptModal is a minimal create/rename/confirm dialog reusing the shared
+// .modal-* anchors. Zero fields + a message renders a confirm; submit errors
+// (incl. tool refusals surfaced by substratePost) show inline.
+function PromptModal({ state, onClose }: { state: ModalState; onClose: () => void }) {
+  const [vals, setVals] = useState<Record<string, string>>(() =>
+    Object.fromEntries(state.fields.map((f) => [f.key, f.value ?? ""])),
+  );
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    setErr(null);
+    try {
+      await state.onSubmit(vals);
+      onClose();
+    } catch (ex) {
+      setErr(ex instanceof Error ? ex.message : String(ex));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <form className="modal" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>{state.title}</h3>
+        {state.message && <p className="modal-context">{state.message}</p>}
+        {state.fields.map((f, i) => (
+          <label key={f.key} className="path-field">
+            <span>{f.label}</span>
+            <input
+              className="path-modal-input"
+              value={vals[f.key]}
+              placeholder={f.placeholder}
+              autoFocus={i === 0}
+              onChange={(e) => setVals((v) => ({ ...v, [f.key]: e.target.value }))}
+            />
+          </label>
+        ))}
+        {err && <div className="modal-err">{err}</div>}
+        <div className="modal-buttons">
+          <button type="button" onClick={onClose} disabled={busy}>
+            cancel
+          </button>
+          <button type="submit" className={state.danger ? "danger" : "primary"} disabled={busy}>
+            {busy ? "working…" : state.submitLabel}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -4823,3 +4823,227 @@ button.primary:disabled {
   background: var(--danger);
   border-color: var(--danger);
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * RFC AM Phase 1 — Path tree console (/paths). Reuses the .splitter +
+ * .tree/.children/.tree-caret skeleton + the .modal-* anchors; only the
+ * path-specific row layout, toolbar, and detail pane are new.
+ * ─────────────────────────────────────────────────────────────────────────── */
+.paths-view {
+  height: 100%;
+  min-height: 0;
+}
+.paths-view .left,
+.paths-view .right {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  flex: 1;
+}
+.paths-view .left > .tree,
+.paths-view .left > .empty {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  padding: 8px 10px;
+}
+.paths-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.paths-scope {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--lc-text-sm, 13px);
+  color: var(--fg-soft);
+}
+.paths-scope select {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 6px;
+}
+.paths-toolbar-actions {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.paths-toolbar-actions button {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.paths-toolbar-actions button:hover:not(:disabled) {
+  border-color: var(--accent);
+}
+.paths-toolbar-actions button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.paths-context {
+  margin: 0;
+  padding: 6px 12px;
+  font-size: var(--lc-text-xs, 12px);
+  color: var(--fg-soft);
+  border-bottom: 1px solid var(--border);
+}
+.paths-err {
+  margin: 0;
+  padding: 8px 12px;
+  color: var(--failed);
+  font-size: var(--lc-text-sm, 13px);
+  border-bottom: 1px solid var(--border);
+}
+
+/* Override the agents-tree 6-column grid for path rows — a path row is a
+ * caret + a single name affordance, not status/model/replica/time columns. */
+.paths-view .node .row {
+  display: flex;
+  grid-template-columns: none;
+  gap: 8px;
+  align-items: center;
+}
+.path-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  min-width: 0;
+}
+.path-link:hover .path-name {
+  color: var(--accent);
+}
+.path-kind-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+.path-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.path-implicit {
+  font-size: var(--lc-text-xs, 11px);
+  color: var(--fg-soft);
+  opacity: 0.7;
+  font-style: italic;
+}
+.path-node.kind-document > .row .path-kind-icon {
+  filter: none;
+}
+
+/* Detail (right) pane. */
+.paths-detail {
+  flex: 1;
+  overflow: auto;
+  min-height: 0;
+  padding: 14px;
+}
+.paths-detail h2 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--lc-text-base, 14px);
+  margin: 0 0 14px;
+  flex-wrap: wrap;
+}
+.paths-detail h2 code {
+  font-family: var(--lc-font-mono, monospace);
+  font-size: var(--lc-text-sm, 13px);
+  word-break: break-all;
+}
+.paths-detail-kind {
+  text-transform: uppercase;
+  font-size: var(--lc-text-xs, 11px);
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  color: var(--fg-soft);
+}
+.paths-detail-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 16px;
+  margin: 0 0 16px;
+  font-size: var(--lc-text-sm, 13px);
+}
+.paths-detail-meta dt {
+  color: var(--fg-soft);
+}
+.paths-detail-meta dd {
+  margin: 0;
+  word-break: break-all;
+}
+.paths-detail-actions {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.paths-detail-actions button {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.paths-detail-actions button:hover {
+  border-color: var(--accent);
+}
+.paths-detail-actions button.danger,
+.modal-buttons button.danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+.modal-buttons button.danger {
+  background: var(--danger);
+  color: white;
+  border-radius: 4px;
+  padding: 8px 16px;
+}
+.paths-readonly,
+.paths-note {
+  font-size: var(--lc-text-sm, 13px);
+  color: var(--fg-soft);
+}
+
+/* Modal field label/input for the create/rename dialogs. */
+.path-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+  font-size: var(--lc-text-sm, 13px);
+  color: var(--fg-soft);
+}
+.path-modal-input {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Why

RFC AM Phase 1. Path (RFC AL) and chunked-graph Documents (RFC AK) shipped on every transport in v1.4.0 but have **no human-facing surface** — an operator can only touch them through tool calls. This adds the **Path tree console** to the Web UI and the one small backend change it needs.

This is **PR 1 of 3** for RFC AM (Path console → Document viewer → document-management agent + assistant).

## What

**Backend — `Path.mkdir` materializes a `directory` dirent.** RFC AL shipped `mkdir` as a no-op (directories implicit, S3-style) and parked explicit directories as a v2 item (RFC AL §11). The console needs empty branches to persist, so this pulls it forward: `mkdir` now inserts a `directory` dirent. Idempotent (ok if the directory already exists explicitly or is implied by descendants); refuses to clobber a non-directory (`DirentCreate` is an upsert, so the guard is load-bearing); root `mkdir` refused. Intermediate dirs under a resource stay implicit.

**Web UI — a `paths` left-nav tab** (`adminOnly`, mirroring volumes/library):
- Unified RFC AL dirent tree (documents / volume mounts / memory entries / directories), reconstructed client-side from the flat `ls recursive` list (intermediate dirs synthesized).
- Directory + document **CRUD**: new folder (`mkdir`), new document (`create_document` + path dirent), rename/move (`mv`), delete. A **branch delete cascades contained Documents** (`delete_document`) before `rm`, so it leaves no orphaned content. Document creation is disabled in `tenant` scope (Documents are agent|user only).
- Scope selector — defaults to **`user`** so the tree lines up with the principal's own agent runs (`substrateAdminUserCtx` → `principal.Subject`). Identity is server-derived; the page sends only `scope` (the subtree selector, not authority).
- Reuses `Splitter`, the `.tree` / `.modal-*` anchors, and the `--lc-*` design tokens — no new dependencies.

**Docs.** `docs/PATH.md` + the in-runtime `path` help topic updated (they documented `mkdir` as a no-op).

## What was tested

- **`go test ./...`** clean (73 packages, exit 0). New Path tool tests: `TestPath_MkdirMaterializesDirectory` (fail-before — the old no-op created nothing, so `resolve`/`ls` saw no branch), `TestPath_MkdirIdempotent` (re-mkdir + implied-dir), `TestPath_MkdirRefusesClobberNonDirectory`, `TestPath_MkdirRejectsRoot`.
- **SPA**: `tsc --noEmit` + `vite build` clean; the `/paths` route is present in the built bundle; `GET /ui/` serves 200.
- **Live smoke test** against a running binary (`LOOMCYCLE_SQLMEM_ENABLED=1`): the full CRUD lifecycle — `mkdir` → idempotent re-mkdir → `mkdir` nested → `create_document` → `ls / recursive` → `mv` (subtree cascade) → `delete_document` → `rm` empty dir → `rm` recursive → empty tree — plus every guard (root `mkdir`, clobber `mkdir`, tenant-scope `create_document`) returning the expected `422 {code,error,tool}` refusal (surfaced as a clean message by `substratePost`).

## Scope / deferred (per RFC AM)

- REVISIONS/README version notes are deferred to the release tag (no tag yet; REVISIONS is per-version).
- Deferred to later phases: live Channel-subscription updates (v1 refreshes on action), the Document chunk viewer + content editor (Phase 2), and the `doc-manager` agent + Document Assistant (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
