### PR TITLE
feat(webui): Document viewer + export_md op (RFC AM Phase 2)

### DIFF
--- a/docs/DOCUMENTS.md
+++ b/docs/DOCUMENTS.md
@@ -32,7 +32,7 @@ enabled** (`LOOMCYCLE_SQLMEM_ENABLED=1`); without it the tool refuses.
 
 ## Surface
 
-One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 13 ops:
+One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 14 ops:
 
 | group | ops |
 |-------|-----|
@@ -41,6 +41,7 @@ One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 13 ops:
 | Edges | `link_chunks`, `unlink_chunks` |
 | Query | `query_chunks` |
 | Types | `define_type`, `list_types` |
+| Markdown | `export_md` (render the document to Markdown; `include_metadata:false` for clean human MD, default `true` embeds round-trippable chunk metadata + edges as HTML comments) |
 
 `scope` is `agent` (this agent, the default) or `user` (this end-user — needs a
 `user_id` on the run). **Tenant scope is deferred** — SQL Memory has
@@ -131,8 +132,10 @@ const open = await client.document({
 - **Tenant scope deferred** — `agent`/`user` only in v1.
 - **Orphaned bodies are best-effort on delete** — see the integrity note above
   (invisible dead K/V; the row side is atomic).
-- **Markdown round-trip (`export_md`/`import_md`) and the Web UI tree/editor**
-  are RFC AK Phase 2/3 — not in this core.
+- **`export_md` + the Web UI Document viewer** shipped in RFC AM Phase 2 (a
+  `paths` tab document node, or `/documents/:id`): chunk sub-tree, Markdown
+  view, MD download, and a single-chunk content editor. **Deterministic
+  `import_md` + the document-management agent** are RFC AM Phase 3.
 
 ## Where it lives
 

--- a/internal/help/builtin/document.md
+++ b/internal/help/builtin/document.md
@@ -40,6 +40,11 @@ use `get_chunk` for a chunk's body.
 **Types (supertag-like):** `define_type` (`name`, `fields`; omit `document_id`
 for a scope-wide type), `list_types`.
 
+**Markdown:** `export_md` (`document_id` or `id`/`path`) renders the document to
+Markdown — each chunk a heading (level = depth) + its body. `include_metadata`
+(default `true`) embeds round-trippable chunk metadata + edges as HTML comments;
+`include_metadata:false` is clean human-facing Markdown.
+
 ## Concurrency — `update_chunk` revision
 
 Every chunk has a `revision`. `update_chunk` requires you to pass the current

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -965,6 +965,9 @@ func (d *Document) documentsUnderPath(ctx context.Context, key sqlmem.ScopeKey, 
 
 // --- ops: Markdown export ---
 
+// headingReplacer collapses newlines so a chunk title stays on one heading line.
+var headingReplacer = strings.NewReplacer("\r\n", " ", "\n", " ", "\r", " ")
+
 // exportMD renders a document to Markdown (RFC AK §4.5 / RFC AM Phase 2).
 // Walks the chunk hierarchy from the root(s) depth-first in position order:
 // each chunk is a heading (level = depth+1, capped at 6) followed by its
@@ -990,7 +993,11 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 	}
 	title := asStr(dres.Rows[0][0])
 
-	cres, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE document_id = ? ORDER BY position`, docID)
+	// ORDER BY parent_id first so each parent's rows are contiguous, then
+	// position, then id as a stable tiebreaker — makes the byParent grouping
+	// below deterministic even if two siblings somehow share a position
+	// (reachable via an explicit `position` on create_chunk/move_chunk).
+	cres, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE document_id = ? ORDER BY parent_id, position, id`, docID)
 	if err != nil {
 		return errResult("export_md: " + err.Error()), nil
 	}
@@ -1016,7 +1023,10 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 			level = 6
 		}
 		cb := d.readBody(ctx, mscope, key.ScopeID, row.ID)
-		b.WriteString(strings.Repeat("#", level) + " " + row.Title + "\n")
+		// A heading is one line — collapse any newline in the title to a space
+		// so a multi-line title can't split the heading and corrupt the doc.
+		title := headingReplacer.Replace(row.Title)
+		b.WriteString(strings.Repeat("#", level) + " " + title + "\n")
 		if includeMeta {
 			meta := map[string]any{"id": row.ID}
 			if row.Type != "" {

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/channels"
@@ -36,7 +37,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types. Scope is agent or user; documents can be named in the Path tree (path:)."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown). Scope is agent or user; documents can be named in the Path tree (path:)."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -46,7 +47,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","delete_document","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","delete_document","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (e.g. /docs/launch). get/delete_document: address by path instead of id."},
@@ -66,7 +67,8 @@ const documentInputSchema = `{
 		"under_path":  {"type": "string", "description": "query_chunks: restrict to documents at/under this Path-tree path."},
 		"sql":         {"type": "string", "description": "query_chunks: raw read-only SELECT against the chunk tables (escape hatch; validator-gated)."},
 		"limit":       {"type": "integer"},
-		"name":        {"type": "string", "description": "define/list_types: the type name."}
+		"name":        {"type": "string", "description": "define/list_types: the type name."},
+		"include_metadata": {"type": "boolean", "description": "export_md: embed round-trippable chunk metadata + edges as HTML comments (default true). false = clean human-facing Markdown."}
 	},
 	"required": ["op"]
 }`
@@ -95,6 +97,9 @@ type docInput struct {
 	SQL         string          `json:"sql"`
 	Limit       int             `json:"limit"`
 	Name        string          `json:"name"`
+	// IncludeMetadata gates export_md's round-trip comments (default true when
+	// omitted; a pointer so an explicit `false` is distinguishable from unset).
+	IncludeMetadata *bool `json:"include_metadata"`
 }
 
 // docSchemaDDL is portable across SQL Memory's sqlite + postgres tiers: BIGINT
@@ -174,6 +179,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.defineType(ctx, key, in)
 	case "list_types":
 		return d.listTypes(ctx, key, in)
+	case "export_md":
+		return d.exportMD(ctx, key, mscope, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
@@ -954,6 +961,106 @@ func (d *Document) documentsUnderPath(ctx context.Context, key sqlmem.ScopeKey, 
 		}
 	}
 	return ids, nil
+}
+
+// --- ops: Markdown export ---
+
+// exportMD renders a document to Markdown (RFC AK §4.5 / RFC AM Phase 2).
+// Walks the chunk hierarchy from the root(s) depth-first in position order:
+// each chunk is a heading (level = depth+1, capped at 6) followed by its
+// Markdown body. With include_metadata (default true) each chunk carries a
+// `<!-- loom: {...} -->` comment (id/type/status/fields) and a trailing
+// `<!-- loom-edges: ... -->` block, so the output round-trips through import_md
+// (Phase 3); with include_metadata=false it is clean human-facing Markdown.
+func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	docID := in.DocumentID
+	if docID == "" {
+		var err error
+		docID, err = d.docIDFromInput(ctx, key, in)
+		if err != nil {
+			return errResult("export_md: " + err.Error()), nil
+		}
+	}
+	dres, err := d.query(ctx, key, `SELECT title, root_chunk_id FROM documents WHERE id = ? LIMIT 1`, docID)
+	if err != nil {
+		return errResult("export_md: " + err.Error()), nil
+	}
+	if len(dres.Rows) == 0 {
+		return errResult("export_md: no such document: " + docID), nil
+	}
+	title := asStr(dres.Rows[0][0])
+
+	cres, err := d.query(ctx, key, `SELECT `+chunkSelectCols+` FROM chunks WHERE document_id = ? ORDER BY position`, docID)
+	if err != nil {
+		return errResult("export_md: " + err.Error()), nil
+	}
+	// Group children by parent (the global position ORDER BY keeps each parent's
+	// slice in ascending position). parent_id "" = a top-level (root) chunk.
+	byParent := map[string][]chunkRow{}
+	var roots []chunkRow
+	for _, r := range cres.Rows {
+		row := scanChunkRow(cres.Columns, r)
+		if row.ParentID == "" {
+			roots = append(roots, row)
+		} else {
+			byParent[row.ParentID] = append(byParent[row.ParentID], row)
+		}
+	}
+	includeMeta := in.IncludeMetadata == nil || *in.IncludeMetadata
+
+	var b strings.Builder
+	var walk func(row chunkRow, depth int)
+	walk = func(row chunkRow, depth int) {
+		level := depth + 1
+		if level > 6 {
+			level = 6
+		}
+		cb := d.readBody(ctx, mscope, key.ScopeID, row.ID)
+		b.WriteString(strings.Repeat("#", level) + " " + row.Title + "\n")
+		if includeMeta {
+			meta := map[string]any{"id": row.ID}
+			if row.Type != "" {
+				meta["type"] = row.Type
+			}
+			if row.Status != "" {
+				meta["status"] = row.Status
+			}
+			if len(cb.Fields) > 0 {
+				meta["fields"] = cb.Fields
+			}
+			mj, _ := json.Marshal(meta)
+			b.WriteString("<!-- loom: " + string(mj) + " -->\n")
+		}
+		if cb.Body != "" {
+			b.WriteString("\n" + cb.Body + "\n")
+		}
+		b.WriteString("\n")
+		for _, c := range byParent[row.ID] {
+			walk(c, depth+1)
+		}
+	}
+	for _, r := range roots {
+		walk(r, 0)
+	}
+
+	// Edges trailer — the free-form graph edges originating from this document's
+	// chunks (parent-child is the hierarchy above, not an edge). Metadata-only:
+	// a clean export (include_metadata=false) omits it.
+	if includeMeta {
+		eres, err := d.query(ctx, key, `SELECT from_id, to_id, kind FROM chunk_edges WHERE from_id IN (SELECT id FROM chunks WHERE document_id = ?) ORDER BY from_id, to_id, kind`, docID)
+		if err != nil {
+			return errResult("export_md: edges: " + err.Error()), nil
+		}
+		var lines []string
+		for _, r := range eres.Rows {
+			lines = append(lines, asStr(r[0])+" -> "+asStr(r[1])+" ["+asStr(r[2])+"]")
+		}
+		if len(lines) > 0 {
+			b.WriteString("<!-- loom-edges:\n" + strings.Join(lines, "\n") + "\n-->\n")
+		}
+	}
+
+	return jsonResult(map[string]any{"markdown": b.String(), "document_id": docID, "title": title})
 }
 
 // --- ops: type definitions ---

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -368,6 +368,12 @@ func TestDocument_Postgres(t *testing.T) {
 	if rows, _ := out["chunks"].([]any); len(rows) != 1 {
 		t.Errorf("pg query by type = %s", res.Text)
 	}
+	// export_md (Markdown render) on pg — exercises the documents/chunks SELECTs
+	// and the chunk_edges `from_id IN (SELECT ...)` subquery + ? rebind.
+	out, res = docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`"}`)
+	if res.IsError || !strings.Contains(out["markdown"].(string), "## c1") {
+		t.Errorf("pg export_md = %s", res.Text)
+	}
 	// update revision (atomic bump + RowsAffected gate on pg).
 	out, res = docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c1+`","revision":1,"status":"published"}`)
 	if res.IsError || int(out["revision"].(float64)) != 2 {
@@ -385,6 +391,58 @@ func TestDocument_Postgres(t *testing.T) {
 	out, res = docExec(t, d, ctx, `{"op":"delete_document","scope":"user","id":"`+docID+`"}`)
 	if res.IsError {
 		t.Errorf("pg delete_document = %s", res.Text)
+	}
+}
+
+// RFC AM Phase 2: export_md renders the chunk hierarchy to Markdown — heading
+// level = depth, round-trippable metadata + edges as HTML comments by default,
+// clean Markdown with include_metadata:false.
+func TestDocument_ExportMD(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Plan"}`)
+	docID := out["document_id"].(string)
+	root := out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"Intro","type":"section","status":"draft","body":"hello **world**"}`)
+	intro := out["id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+intro+`","title":"Detail","body":"deep"}`)
+	detail := out["id"].(string)
+	docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"`+intro+`","to_id":"`+detail+`","kind":"references"}`)
+
+	// Default export: metadata-rich, round-trippable.
+	out, res := docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`"}`)
+	if res.IsError {
+		t.Fatalf("export_md: %q", res.Text)
+	}
+	if out["title"] != "Plan" {
+		t.Errorf("title = %v", out["title"])
+	}
+	md, _ := out["markdown"].(string)
+	// Heading level reflects depth: root H1, Intro H2, Detail H3.
+	for _, want := range []string{"# Plan", "## Intro", "### Detail", "hello **world**", "deep"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("export_md missing %q:\n%s", want, md)
+		}
+	}
+	// Metadata comment carries the chunk id + type/status.
+	if !strings.Contains(md, "<!-- loom: ") || !strings.Contains(md, intro) || !strings.Contains(md, `"type":"section"`) {
+		t.Errorf("export_md missing metadata comment:\n%s", md)
+	}
+	// Edges trailer present (the graph edge, not the parent-child hierarchy).
+	if !strings.Contains(md, "<!-- loom-edges:") || !strings.Contains(md, intro+" -> "+detail+" [references]") {
+		t.Errorf("export_md missing edges block:\n%s", md)
+	}
+
+	// Clean export: no loom comments, no edges, but the content + headings stay.
+	out, res = docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`","include_metadata":false}`)
+	if res.IsError {
+		t.Fatalf("export_md clean: %q", res.Text)
+	}
+	md, _ = out["markdown"].(string)
+	if strings.Contains(md, "<!-- loom") {
+		t.Errorf("clean export_md must have no loom comments:\n%s", md)
+	}
+	if !strings.Contains(md, "## Intro") || !strings.Contains(md, "hello **world**") {
+		t.Errorf("clean export_md missing content:\n%s", md)
 	}
 }
 

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -446,6 +446,44 @@ func TestDocument_ExportMD(t *testing.T) {
 	}
 }
 
+// RFC AM review hardening: a newline in a chunk title must not split the
+// heading line, and sibling/nesting order must be deterministic.
+func TestDocument_ExportMD_HeadingAndOrder(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Doc"}`)
+	docID := out["document_id"].(string)
+	root := out["root_chunk_id"].(string)
+	// A title with an embedded newline (pos 0 under root).
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"line one\nline two","body":"b"}`)
+	// Siblings A (pos 1), B (pos 2); A gets children A1, A2.
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"A","body":""}`)
+	a := out["id"].(string)
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"B","body":""}`)
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+a+`","title":"A1","body":""}`)
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+a+`","title":"A2","body":""}`)
+
+	out, res := docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`","include_metadata":false}`)
+	if res.IsError {
+		t.Fatalf("export_md: %q", res.Text)
+	}
+	md := out["markdown"].(string)
+	// Fail-before: the old heading wrote the raw title, splitting it across lines.
+	if strings.Contains(md, "line one\nline two") {
+		t.Errorf("newline in title split the heading line:\n%s", md)
+	}
+	if !strings.Contains(md, "## line one line two") {
+		t.Errorf("expected a single-line heading for the newline title:\n%s", md)
+	}
+	// Deterministic depth-first order: A, then its children A1, A2, then B.
+	iA := strings.Index(md, "## A\n")
+	iA1 := strings.Index(md, "### A1")
+	iA2 := strings.Index(md, "### A2")
+	iB := strings.Index(md, "## B")
+	if !(iA >= 0 && iA < iA1 && iA1 < iA2 && iA2 < iB) {
+		t.Errorf("sibling/nesting order wrong (A=%d A1=%d A2=%d B=%d):\n%s", iA, iA1, iA2, iB, md)
+	}
+}
+
 // Hardening: link_chunks must refuse an edge to a non-existent chunk (no
 // born-dangling edges).
 func TestDocument_LinkChunksValidatesEndpoints(t *testing.T) {

--- a/internal/tools/builtin/pathtool_test.go
+++ b/internal/tools/builtin/pathtool_test.go
@@ -280,12 +280,18 @@ func TestPath_MkdirIdempotent(t *testing.T) {
 // dirent into a directory).
 func TestPath_MkdirRefusesClobberNonDirectory(t *testing.T) {
 	p, ctx, s := pathFixture(t)
-	seedAgent(t, s, "/docs/", "a", "document")
-	if _, r := pathExec(t, p, ctx, `{"op":"mkdir","path":"/docs/a"}`); !r.IsError {
-		t.Fatalf("mkdir over a document must be refused; got %q", r.Text)
-	}
-	if o, r := pathExec(t, p, ctx, `{"op":"resolve","path":"/docs/a"}`); r.IsError || o["kind"] != "document" {
-		t.Errorf("/docs/a should still be a document after a refused mkdir: %s (err=%v)", r.Text, r.IsError)
+	// mkdir must refuse to clobber ANY non-directory kind — the guard keys on
+	// kind != "directory", not a document-only check (DirentCreate is an upsert,
+	// so without the guard a mkdir would silently retype the entry).
+	for _, kind := range []string{"document", "volume_mount", "memory_entry"} {
+		seedAgent(t, s, "/x/", kind, kind)
+		path := "/x/" + kind
+		if _, r := pathExec(t, p, ctx, `{"op":"mkdir","path":"`+path+`"}`); !r.IsError {
+			t.Fatalf("mkdir over a %s must be refused; got %q", kind, r.Text)
+		}
+		if o, r := pathExec(t, p, ctx, `{"op":"resolve","path":"`+path+`"}`); r.IsError || o["kind"] != kind {
+			t.Errorf("%s should be intact after a refused mkdir: %s (err=%v)", path, r.Text, r.IsError)
+		}
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -774,6 +774,69 @@ export function documentDelete(
   return substratePost("/v1/_document", { op: "delete_document", id, scope });
 }
 
+// ChunkRow is the structural record returned by query_chunks (no body — kept
+// light; fetch the body with documentGetChunk).
+export interface ChunkRow {
+  id: string;
+  document_id: string;
+  parent_id?: string;
+  position: number;
+  title: string;
+  type?: string;
+  status?: string;
+  revision: number;
+}
+// ChunkDetail adds the Markdown body + typed fields (from get_chunk).
+export interface ChunkDetail extends ChunkRow {
+  body: string;
+  fields?: unknown;
+}
+
+// documentQueryChunks lists a document's chunks (structure only). limit caps at
+// 1000 server-side — adequate for the viewer's per-document trees.
+export function documentQueryChunks(
+  documentId: string,
+  scope: DocScope,
+): Promise<{ chunks: ChunkRow[] }> {
+  return substratePost("/v1/_document", {
+    op: "query_chunks",
+    document_id: documentId,
+    scope,
+    limit: 1000,
+  });
+}
+
+export function documentGetChunk(id: string, scope: DocScope): Promise<ChunkDetail> {
+  return substratePost("/v1/_document", { op: "get_chunk", id, scope });
+}
+
+// documentUpdateChunk applies an optimistic-concurrency update — pass the
+// chunk's current `revision`; a stale revision rejects with a "revision
+// conflict" error (surfaced by substratePost) the editor reloads on.
+export function documentUpdateChunk(
+  id: string,
+  revision: number,
+  patch: { body?: string; fields?: unknown; title?: string; status?: string; type?: string },
+  scope: DocScope,
+): Promise<ChunkDetail> {
+  return substratePost("/v1/_document", { op: "update_chunk", id, revision, scope, ...patch });
+}
+
+// documentExportMd renders the document to Markdown. includeMetadata=true is
+// round-trippable (HTML-comment metadata + edges); false is clean human MD.
+export function documentExportMd(
+  documentId: string,
+  scope: DocScope,
+  includeMetadata: boolean,
+): Promise<{ markdown: string; title: string; document_id: string }> {
+  return substratePost("/v1/_document", {
+    op: "export_md",
+    document_id: documentId,
+    scope,
+    include_metadata: includeMetadata,
+  });
+}
+
 // AuditEvent mirrors wireEvent in internal/api/http/events_audit.go.
 // Payload is left as `unknown` because event payloads vary by type
 // (text / tool_call / tool_result / usage / done / …); the audit

--- a/web/src/components/ChunkEditorModal.tsx
+++ b/web/src/components/ChunkEditorModal.tsx
@@ -1,0 +1,126 @@
+import { useState, type FormEvent } from "react";
+import { type ChunkDetail, type DocScope, documentUpdateChunk } from "../api";
+
+// ChunkEditorModal edits one chunk's content — title, type, status, Markdown
+// body, and (optional) typed fields as JSON. Save is an optimistic-concurrency
+// update_chunk carrying the chunk's revision; a stale revision returns a
+// "revision conflict" the modal surfaces with a reload hint. Structural edits
+// (reparent / reorder / link / delete) are NOT here — those are the
+// document-management agent's job (RFC AM Phase 3).
+export interface ChunkEditorModalProps {
+  chunk: ChunkDetail;
+  scope: DocScope;
+  onClose: () => void;
+  onSaved: (updated: ChunkDetail) => void;
+}
+
+export default function ChunkEditorModal({ chunk, scope, onClose, onSaved }: ChunkEditorModalProps) {
+  const [title, setTitle] = useState(chunk.title);
+  const [type, setType] = useState(chunk.type ?? "");
+  const [status, setStatus] = useState(chunk.status ?? "");
+  const [body, setBody] = useState(chunk.body ?? "");
+  const [fieldsText, setFieldsText] = useState(
+    chunk.fields ? JSON.stringify(chunk.fields, null, 2) : "",
+  );
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [conflict, setConflict] = useState(false);
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    setConflict(false);
+    const patch: { body: string; title: string; type: string; status: string; fields?: unknown } = {
+      body,
+      title,
+      type,
+      status,
+    };
+    // Send fields only when non-empty + valid JSON (a blank box leaves fields
+    // untouched rather than clobbering them).
+    if (fieldsText.trim() !== "") {
+      try {
+        patch.fields = JSON.parse(fieldsText);
+      } catch {
+        setErr("fields must be valid JSON");
+        return;
+      }
+    }
+    setBusy(true);
+    try {
+      const updated = await documentUpdateChunk(chunk.id, chunk.revision, patch, scope);
+      onSaved(updated);
+      onClose();
+    } catch (ex) {
+      const msg = ex instanceof Error ? ex.message : String(ex);
+      setErr(msg);
+      setConflict(/revision conflict/i.test(msg));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <form className="modal chunk-editor" onClick={(e) => e.stopPropagation()} onSubmit={submit}>
+        <h3>Edit chunk</h3>
+        <label className="path-field">
+          <span>Title</span>
+          <input className="path-modal-input" value={title} onChange={(e) => setTitle(e.target.value)} />
+        </label>
+        <div className="chunk-editor-row">
+          <label className="path-field">
+            <span>Type</span>
+            <input
+              className="path-modal-input"
+              value={type}
+              placeholder="(none)"
+              onChange={(e) => setType(e.target.value)}
+            />
+          </label>
+          <label className="path-field">
+            <span>Status</span>
+            <input
+              className="path-modal-input"
+              value={status}
+              placeholder="(none)"
+              onChange={(e) => setStatus(e.target.value)}
+            />
+          </label>
+        </div>
+        <label className="path-field">
+          <span>Body (Markdown)</span>
+          <textarea
+            className="modal-textarea chunk-body-input"
+            rows={12}
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+          />
+        </label>
+        <label className="path-field">
+          <span>Fields (JSON, optional)</span>
+          <textarea
+            className="modal-textarea chunk-fields-input"
+            rows={4}
+            value={fieldsText}
+            placeholder="{}"
+            onChange={(e) => setFieldsText(e.target.value)}
+          />
+        </label>
+        {err && (
+          <div className="modal-err">
+            {err}
+            {conflict && " — reopen the chunk to load the latest, then reapply your edit."}
+          </div>
+        )}
+        <div className="modal-buttons">
+          <button type="button" onClick={onClose} disabled={busy}>
+            cancel
+          </button>
+          <button type="submit" className="primary" disabled={busy}>
+            {busy ? "saving…" : "save"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/DocumentChunkTree.tsx
+++ b/web/src/components/DocumentChunkTree.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useState } from "react";
+import type { ChunkRow } from "../api";
+
+// DocumentChunkTree renders a document's chunk hierarchy (RFC AM Phase 2),
+// built from the flat query_chunks list by parent_id + position. Mirrors
+// PathTree: a single expand Map owned by the tree, default-expanded,
+// click-to-select.
+
+export interface ChunkNode {
+  row: ChunkRow;
+  children: ChunkNode[];
+}
+
+// buildChunkTree groups chunks into parent → children (position-ordered). A
+// chunk whose parent_id is absent or not in the set is a root (the document's
+// root chunk; defensively also any orphan).
+export function buildChunkTree(chunks: ChunkRow[]): ChunkNode[] {
+  const byId = new Map<string, ChunkNode>();
+  chunks.forEach((c) => byId.set(c.id, { row: c, children: [] }));
+  const roots: ChunkNode[] = [];
+  chunks.forEach((c) => {
+    const node = byId.get(c.id)!;
+    if (c.parent_id && byId.has(c.parent_id)) byId.get(c.parent_id)!.children.push(node);
+    else roots.push(node);
+  });
+  const sortRec = (nodes: ChunkNode[]) => {
+    nodes.sort((a, b) => a.row.position - b.row.position);
+    nodes.forEach((n) => sortRec(n.children));
+  };
+  sortRec(roots);
+  return roots;
+}
+
+// findChunkNode locates a node by id within a chunk forest.
+export function findChunkNode(nodes: ChunkNode[], id: string): ChunkNode | undefined {
+  for (const n of nodes) {
+    if (n.row.id === id) return n;
+    const hit = findChunkNode(n.children, id);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+export interface DocumentChunkTreeProps {
+  tree: ChunkNode[];
+  selectedId?: string;
+  onSelect: (node: ChunkNode) => void;
+}
+
+export default function DocumentChunkTree({ tree, selectedId, onSelect }: DocumentChunkTreeProps) {
+  const [expanded, setExpanded] = useState<Map<string, boolean>>(() => new Map());
+  const toggle = useCallback((id: string) => {
+    setExpanded((prev) => {
+      const next = new Map(prev);
+      next.set(id, prev.get(id) === false ? true : false);
+      return next;
+    });
+  }, []);
+
+  // Auto-expand ancestors of the selection.
+  useEffect(() => {
+    if (!selectedId) return;
+    const parents = ancestorIds(tree, selectedId);
+    if (parents.length === 0) return;
+    setExpanded((prev) => {
+      let mutated = false;
+      const next = new Map(prev);
+      for (const id of parents) {
+        if (next.get(id) === false) {
+          next.set(id, true);
+          mutated = true;
+        }
+      }
+      return mutated ? next : prev;
+    });
+  }, [tree, selectedId]);
+
+  if (tree.length === 0) {
+    return (
+      <div className="empty">
+        <p>No chunks.</p>
+      </div>
+    );
+  }
+  return (
+    <ul className="tree chunk-tree">
+      {tree.map((n) => (
+        <ChunkTreeNode
+          key={n.row.id}
+          node={n}
+          expanded={expanded}
+          toggle={toggle}
+          selectedId={selectedId}
+          onSelect={onSelect}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function ancestorIds(roots: ChunkNode[], id: string): string[] {
+  const path: string[] = [];
+  const walk = (nodes: ChunkNode[], parents: string[]): boolean => {
+    for (const n of nodes) {
+      if (n.row.id === id) {
+        path.push(...parents);
+        return true;
+      }
+      if (walk(n.children, [...parents, n.row.id])) return true;
+    }
+    return false;
+  };
+  walk(roots, []);
+  return path;
+}
+
+interface NodeProps {
+  node: ChunkNode;
+  expanded: Map<string, boolean>;
+  toggle: (id: string) => void;
+  selectedId?: string;
+  onSelect: (node: ChunkNode) => void;
+}
+
+function ChunkTreeNode({ node, expanded, toggle, selectedId, onSelect }: NodeProps) {
+  const hasChildren = node.children.length > 0;
+  const isOpen = expanded.get(node.row.id) !== false; // default-expanded
+  const isSelected = selectedId === node.row.id;
+  return (
+    <li className={`node chunk-node ${isSelected ? "selected" : ""}`}>
+      <div className="row chunk-row">
+        <button
+          type="button"
+          className="tree-caret"
+          aria-label={isOpen ? "collapse" : "expand"}
+          disabled={!hasChildren}
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hasChildren) toggle(node.row.id);
+          }}
+        >
+          {hasChildren ? (isOpen ? "▼" : "▶") : "·"}
+        </button>
+        <button
+          type="button"
+          className="chunk-link"
+          onClick={() => onSelect(node)}
+          title={node.row.title}
+        >
+          <span className="chunk-title">{node.row.title || "(untitled)"}</span>
+          {node.row.type && <span className="chunk-badge">{node.row.type}</span>}
+          {node.row.status && <span className="chunk-badge chunk-status">{node.row.status}</span>}
+        </button>
+      </div>
+      {hasChildren && isOpen && (
+        <ul className="children chunk-children">
+          {node.children.map((c) => (
+            <ChunkTreeNode
+              key={c.row.id}
+              node={c}
+              expanded={expanded}
+              toggle={toggle}
+              selectedId={selectedId}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}

--- a/web/src/components/DocumentViewer.tsx
+++ b/web/src/components/DocumentViewer.tsx
@@ -1,0 +1,261 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  type ChunkDetail,
+  type ChunkRow,
+  type DocScope,
+  documentExportMd,
+  documentGetChunk,
+  documentQueryChunks,
+} from "../api";
+import DocumentChunkTree, {
+  buildChunkTree,
+  findChunkNode,
+  type ChunkNode,
+} from "./DocumentChunkTree";
+import ChunkEditorModal from "./ChunkEditorModal";
+import Markdown from "./Markdown";
+
+// DocumentViewer is the RFC AM Phase 2 read-mostly surface for one chunked-
+// graph document: a chunk sub-tree, a selected-chunk view (rendered Markdown +
+// an optional "with sub-chunks" assembly), a whole-document Markdown view, MD
+// download, and a single-chunk content editor. Structural editing (move / link
+// / delete chunks) is deliberately NOT here — it is the document-management
+// agent's job (Phase 3).
+export interface DocumentViewerProps {
+  documentId: string;
+  scope: DocScope;
+  // titleHint shows immediately (e.g. the Path-tree name) until the root chunk
+  // title loads.
+  titleHint?: string;
+}
+
+type Mode = "tree" | "markdown";
+
+export default function DocumentViewer({ documentId, scope, titleHint }: DocumentViewerProps) {
+  const [chunks, setChunks] = useState<ChunkRow[]>([]);
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const [selectedDetail, setSelectedDetail] = useState<ChunkDetail | null>(null);
+  const [mode, setMode] = useState<Mode>("tree");
+  const [mdSource, setMdSource] = useState<string>("");
+  const [includeSub, setIncludeSub] = useState(false);
+  const [subtreeMd, setSubtreeMd] = useState<string | null>(null);
+  const [editing, setEditing] = useState<ChunkDetail | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [reload, setReload] = useState(0);
+
+  const tree = useMemo(() => buildChunkTree(chunks), [chunks]);
+  const rootTitle = useMemo(() => {
+    const root = chunks.find((c) => !c.parent_id);
+    return root?.title || titleHint || "document";
+  }, [chunks, titleHint]);
+
+  // Load the chunk list when the document / scope / reload changes. Default the
+  // selection to the root chunk.
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setErr(null);
+    documentQueryChunks(documentId, scope)
+      .then((resp) => {
+        if (cancelled) return;
+        const rows = resp.chunks ?? [];
+        setChunks(rows);
+        setSelectedId((cur) => cur ?? rows.find((c) => !c.parent_id)?.id);
+      })
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)))
+      .finally(() => !cancelled && setLoading(false));
+    return () => {
+      cancelled = true;
+    };
+  }, [documentId, scope, reload]);
+
+  // Reset selection + caches when the document changes.
+  useEffect(() => {
+    setSelectedId(undefined);
+    setSelectedDetail(null);
+    setIncludeSub(false);
+    setSubtreeMd(null);
+    setMode("tree");
+  }, [documentId, scope]);
+
+  // Fetch the selected chunk's body.
+  useEffect(() => {
+    if (!selectedId) {
+      setSelectedDetail(null);
+      return;
+    }
+    let cancelled = false;
+    documentGetChunk(selectedId, scope)
+      .then((d) => !cancelled && setSelectedDetail(d))
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, scope, reload]);
+
+  // Whole-document Markdown (clean, no metadata comments) for the MD mode.
+  useEffect(() => {
+    if (mode !== "markdown") return;
+    let cancelled = false;
+    documentExportMd(documentId, scope, false)
+      .then((r) => !cancelled && setMdSource(r.markdown))
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+  }, [mode, documentId, scope, reload]);
+
+  // Assemble the selected chunk + its sub-chunks into one Markdown string when
+  // "with sub-chunks" is on (fetches each descendant's body).
+  useEffect(() => {
+    if (!includeSub || !selectedId) {
+      setSubtreeMd(null);
+      return;
+    }
+    const node = findChunkNode(tree, selectedId);
+    if (!node) return;
+    let cancelled = false;
+    const items: { node: ChunkNode; depth: number }[] = [];
+    const walk = (n: ChunkNode, depth: number) => {
+      items.push({ node: n, depth });
+      n.children.forEach((c) => walk(c, depth + 1));
+    };
+    walk(node, 0);
+    Promise.all(items.map((it) => documentGetChunk(it.node.row.id, scope)))
+      .then((details) => {
+        if (cancelled) return;
+        const md = items
+          .map((it, idx) => {
+            const lvl = Math.min(it.depth + 1, 6);
+            const d = details[idx];
+            return "#".repeat(lvl) + " " + it.node.row.title + (d.body ? "\n\n" + d.body : "") + "\n";
+          })
+          .join("\n");
+        setSubtreeMd(md);
+      })
+      .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
+    return () => {
+      cancelled = true;
+    };
+  }, [includeSub, selectedId, tree, scope, reload]);
+
+  const onSelect = useCallback((n: ChunkNode) => setSelectedId(n.row.id), []);
+
+  const download = useCallback(async () => {
+    try {
+      const r = await documentExportMd(documentId, scope, true);
+      const blob = new Blob([r.markdown], { type: "text/markdown" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = (r.title || "document").replace(/[^\w.-]+/g, "_") + ".md";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  }, [documentId, scope]);
+
+  return (
+    <div className="doc-viewer">
+      <div className="doc-toolbar">
+        <strong className="doc-title" title={rootTitle}>
+          {rootTitle}
+        </strong>
+        <div className="doc-toolbar-actions">
+          <div className="doc-mode-toggle">
+            <button
+              type="button"
+              className={mode === "tree" ? "active" : ""}
+              onClick={() => setMode("tree")}
+            >
+              chunks
+            </button>
+            <button
+              type="button"
+              className={mode === "markdown" ? "active" : ""}
+              onClick={() => setMode("markdown")}
+            >
+              markdown
+            </button>
+          </div>
+          <button type="button" onClick={() => void download()} title="Download as Markdown (.md)">
+            ↓ .md
+          </button>
+          <button type="button" onClick={() => setReload((n) => n + 1)} title="Reload">
+            ↻
+          </button>
+        </div>
+      </div>
+      {err && <div className="paths-err">{err}</div>}
+      {mode === "markdown" ? (
+        <div className="doc-md-pane">
+          <Markdown source={mdSource} />
+        </div>
+      ) : (
+        <div className="doc-split">
+          <div className="doc-chunktree">
+            {loading && chunks.length === 0 ? (
+              <div className="empty">
+                <p>Loading…</p>
+              </div>
+            ) : (
+              <DocumentChunkTree tree={tree} selectedId={selectedId} onSelect={onSelect} />
+            )}
+          </div>
+          <div className="doc-content">
+            {selectedDetail ? (
+              <>
+                <div className="doc-content-head">
+                  <h3>{selectedDetail.title || "(untitled)"}</h3>
+                  <div className="doc-content-meta">
+                    {selectedDetail.type && <span className="chunk-badge">{selectedDetail.type}</span>}
+                    {selectedDetail.status && (
+                      <span className="chunk-badge chunk-status">{selectedDetail.status}</span>
+                    )}
+                    <span className="chunk-rev">rev {selectedDetail.revision}</span>
+                  </div>
+                  <div className="doc-content-controls">
+                    <label className="doc-subchunks">
+                      <input
+                        type="checkbox"
+                        checked={includeSub}
+                        onChange={(e) => setIncludeSub(e.target.checked)}
+                      />
+                      with sub-chunks
+                    </label>
+                    <button type="button" onClick={() => setEditing(selectedDetail)}>
+                      edit
+                    </button>
+                  </div>
+                </div>
+                <div className="doc-content-body">
+                  {includeSub && subtreeMd !== null ? (
+                    <Markdown source={subtreeMd} />
+                  ) : selectedDetail.body ? (
+                    <Markdown source={selectedDetail.body} />
+                  ) : (
+                    <p className="doc-empty-body">(empty chunk)</p>
+                  )}
+                </div>
+              </>
+            ) : (
+              <div className="empty">
+                <p>Select a chunk on the left.</p>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+      {editing && (
+        <ChunkEditorModal
+          chunk={editing}
+          scope={scope}
+          onClose={() => setEditing(null)}
+          onSaved={() => setReload((n) => n + 1)}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -137,7 +137,11 @@ function inline(text: string): ReactNode[] {
       const lm = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(tok)!;
       const label = lm[1];
       const url = lm[2];
-      if (/^https?:\/\//i.test(url) || url.startsWith("/")) {
+      // Anchor only for http(s) or a same-origin relative path. Exclude
+      // protocol-relative `//host` (which `startsWith("/")` would otherwise
+      // accept) — it resolves to an off-site URL, not a relative path.
+      const relative = url.startsWith("/") && !url.startsWith("//");
+      if (/^https?:\/\//i.test(url) || relative) {
         nodes.push(
           <a key={key++} href={url} target="_blank" rel="noopener noreferrer">
             {label}

--- a/web/src/components/Markdown.tsx
+++ b/web/src/components/Markdown.tsx
@@ -1,0 +1,153 @@
+import { type ReactNode } from "react";
+
+// Markdown is a minimal, dependency-free, safe-by-construction renderer: it
+// builds React elements (never dangerouslySetInnerHTML), so a chunk body —
+// which originates from agents and humans — cannot inject markup or script.
+// It covers the common block constructs (headings, paragraphs, fenced code,
+// blockquotes, ordered/unordered lists) and inline code/bold/italic/links;
+// anything unrecognized renders as escaped text. A viewer-grade subset of
+// CommonMark (RFC AM Phase 2), not a full implementation.
+
+export default function Markdown({ source }: { source: string }) {
+  return <div className="md">{renderBlocks(source)}</div>;
+}
+
+function renderBlocks(src: string): ReactNode[] {
+  const lines = src.replace(/\r\n/g, "\n").split("\n");
+  const out: ReactNode[] = [];
+  let i = 0;
+  let k = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+    // Fenced code block.
+    if (line.startsWith("```")) {
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        buf.push(lines[i]);
+        i++;
+      }
+      i++; // consume the closing fence (if present)
+      out.push(
+        <pre key={k++} className="md-pre">
+          <code>{buf.join("\n")}</code>
+        </pre>,
+      );
+      continue;
+    }
+    // Heading.
+    const h = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (h) {
+      out.push(heading(h[1].length, inline(h[2]), k++));
+      i++;
+      continue;
+    }
+    // Blockquote (consecutive `> ` lines).
+    if (/^>\s?/.test(line)) {
+      const buf: string[] = [];
+      while (i < lines.length && /^>\s?/.test(lines[i])) {
+        buf.push(lines[i].replace(/^>\s?/, ""));
+        i++;
+      }
+      out.push(
+        <blockquote key={k++}>{inline(buf.join(" "))}</blockquote>,
+      );
+      continue;
+    }
+    // Unordered / ordered list (consecutive item lines).
+    const ul = /^[-*]\s+(.*)$/;
+    const ol = /^\d+\.\s+(.*)$/;
+    if (ul.test(line) || ol.test(line)) {
+      const ordered = ol.test(line);
+      const re = ordered ? ol : ul;
+      const items: ReactNode[] = [];
+      let j = 0;
+      while (i < lines.length && re.test(lines[i])) {
+        const m = re.exec(lines[i])!;
+        items.push(<li key={j++}>{inline(m[1])}</li>);
+        i++;
+      }
+      out.push(ordered ? <ol key={k++}>{items}</ol> : <ul key={k++}>{items}</ul>);
+      continue;
+    }
+    // Paragraph: gather consecutive non-blank, non-special lines.
+    const buf: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !lines[i].startsWith("```") &&
+      !/^(#{1,6})\s+/.test(lines[i]) &&
+      !/^>\s?/.test(lines[i]) &&
+      !ul.test(lines[i]) &&
+      !ol.test(lines[i])
+    ) {
+      buf.push(lines[i]);
+      i++;
+    }
+    out.push(<p key={k++}>{inline(buf.join(" "))}</p>);
+  }
+  return out;
+}
+
+function heading(level: number, children: ReactNode, key: number): ReactNode {
+  switch (level) {
+    case 1:
+      return <h1 key={key}>{children}</h1>;
+    case 2:
+      return <h2 key={key}>{children}</h2>;
+    case 3:
+      return <h3 key={key}>{children}</h3>;
+    case 4:
+      return <h4 key={key}>{children}</h4>;
+    case 5:
+      return <h5 key={key}>{children}</h5>;
+    default:
+      return <h6 key={key}>{children}</h6>;
+  }
+}
+
+// inline tokenizes a single line into code spans, bold, italic, and links.
+// Links render as an anchor only for http(s)/relative URLs (a javascript: or
+// other scheme renders as plain label text — React does not sanitize href).
+const INLINE_RE = /(`[^`]+`)|(\*\*[^*]+?\*\*)|(\*[^*]+?\*)|(\[[^\]]+\]\([^)]+\))/;
+
+function inline(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let rest = text;
+  let key = 0;
+  while (rest.length > 0) {
+    const m = INLINE_RE.exec(rest);
+    if (!m) {
+      nodes.push(rest);
+      break;
+    }
+    if (m.index > 0) nodes.push(rest.slice(0, m.index));
+    const tok = m[0];
+    if (tok.startsWith("`")) {
+      nodes.push(<code key={key++}>{tok.slice(1, -1)}</code>);
+    } else if (tok.startsWith("**")) {
+      nodes.push(<strong key={key++}>{tok.slice(2, -2)}</strong>);
+    } else if (tok.startsWith("*")) {
+      nodes.push(<em key={key++}>{tok.slice(1, -1)}</em>);
+    } else {
+      const lm = /^\[([^\]]+)\]\(([^)]+)\)$/.exec(tok)!;
+      const label = lm[1];
+      const url = lm[2];
+      if (/^https?:\/\//i.test(url) || url.startsWith("/")) {
+        nodes.push(
+          <a key={key++} href={url} target="_blank" rel="noopener noreferrer">
+            {label}
+          </a>,
+        );
+      } else {
+        nodes.push(label); // unsafe scheme → plain text
+      }
+    }
+    rest = rest.slice(m.index + tok.length);
+  }
+  return nodes;
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -20,6 +20,7 @@ import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
 import VolumesView from "./pages/VolumesView";
 import PathTreeView from "./pages/PathTreeView";
+import DocumentsView from "./pages/DocumentsView";
 import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
 import Layout from "./components/Layout";
@@ -73,6 +74,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="volumes/persistent" element={<VolumesView />} />
           <Route path="volumes/ephemeral" element={<VolumesView />} />
           <Route path="paths" element={<PathTreeView />} />
+          <Route path="documents/:documentId" element={<DocumentsView />} />
           <Route path="channels" element={<ChannelsView />} />
           <Route path="schedules" element={<SchedulesView />} />
           <Route path="memory" element={<MemoryView />} />

--- a/web/src/pages/DocumentsView.tsx
+++ b/web/src/pages/DocumentsView.tsx
@@ -1,0 +1,25 @@
+import { useParams, useSearchParams } from "react-router-dom";
+import type { DocScope } from "../api";
+import DocumentViewer from "../components/DocumentViewer";
+
+// DocumentsView is the deep-link surface for one document
+// (/documents/:documentId?scope=user) — a shareable full-page DocumentViewer.
+// Scope defaults to `user` (the interop-correct default; see RFC AM §8); pass
+// ?scope=agent for an agent-scope document.
+export default function DocumentsView() {
+  const { documentId } = useParams();
+  const [params] = useSearchParams();
+  const scope: DocScope = params.get("scope") === "agent" ? "agent" : "user";
+  if (!documentId) {
+    return (
+      <div className="empty">
+        <p>No document id in the URL.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="documents-page">
+      <DocumentViewer documentId={documentId} scope={scope} />
+    </div>
+  );
+}

--- a/web/src/pages/PathTreeView.tsx
+++ b/web/src/pages/PathTreeView.tsx
@@ -11,6 +11,7 @@ import {
   pathRm,
 } from "../api";
 import Splitter from "../components/Splitter";
+import DocumentViewer from "../components/DocumentViewer";
 import PathTree, {
   buildPathTree,
   collectDocumentIds,
@@ -255,47 +256,53 @@ export default function PathTreeView() {
         </div>
         <div className="right">
           {selected ? (
-            <div className="paths-detail">
-              <h2>
-                <span className="paths-detail-kind">{selected.kind}</span>
-                <code>{selected.fullPath}</code>
-              </h2>
-              <dl className="paths-detail-meta">
-                <dt>scope</dt>
-                <dd>{scope}</dd>
-                <dt>stored</dt>
-                <dd>{selected.explicit ? "yes" : "implicit (no entry)"}</dd>
-                {selected.kind === "document" && (
-                  <>
-                    <dt>document_id</dt>
-                    <dd>
-                      <code>
-                        {(selected.resourceRef as { document_id?: string })?.document_id ?? "—"}
-                      </code>
-                    </dd>
-                  </>
-                )}
-              </dl>
-              {mutable ? (
-                <div className="paths-detail-actions">
-                  <button type="button" onClick={renameSelected}>
-                    rename / move
-                  </button>
-                  <button type="button" className="danger" onClick={deleteSelected}>
-                    delete
-                  </button>
+            selected.kind === "document" ? (
+              <div className="paths-doc">
+                <div className="paths-doc-head">
+                  <code className="paths-doc-path">{selected.fullPath}</code>
+                  <div className="paths-detail-actions">
+                    <button type="button" onClick={renameSelected}>
+                      rename / move
+                    </button>
+                    <button type="button" className="danger" onClick={deleteSelected}>
+                      delete
+                    </button>
+                  </div>
                 </div>
-              ) : (
-                <p className="paths-readonly">
-                  Read-only — {selected.kind} entries are managed by their own tool.
-                </p>
-              )}
-              {selected.kind === "document" && (
-                <p className="paths-note">
-                  Chunk viewing &amp; editing arrives with the Document viewer (Phase 2).
-                </p>
-              )}
-            </div>
+                <DocumentViewer
+                  documentId={(selected.resourceRef as { document_id?: string })?.document_id ?? ""}
+                  scope={scope === "agent" ? "agent" : "user"}
+                  titleHint={selected.name}
+                />
+              </div>
+            ) : (
+              <div className="paths-detail">
+                <h2>
+                  <span className="paths-detail-kind">{selected.kind}</span>
+                  <code>{selected.fullPath}</code>
+                </h2>
+                <dl className="paths-detail-meta">
+                  <dt>scope</dt>
+                  <dd>{scope}</dd>
+                  <dt>stored</dt>
+                  <dd>{selected.explicit ? "yes" : "implicit (no entry)"}</dd>
+                </dl>
+                {mutable ? (
+                  <div className="paths-detail-actions">
+                    <button type="button" onClick={renameSelected}>
+                      rename / move
+                    </button>
+                    <button type="button" className="danger" onClick={deleteSelected}>
+                      delete
+                    </button>
+                  </div>
+                ) : (
+                  <p className="paths-readonly">
+                    Read-only — {selected.kind} entries are managed by their own tool.
+                  </p>
+                )}
+              </div>
+            )
           ) : (
             <div className="empty">
               <p>Select a path on the left, or create a folder / document.</p>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5047,3 +5047,280 @@ button.primary:disabled {
   color: var(--fg);
   box-sizing: border-box;
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * RFC AM Phase 2 — Document viewer (chunk tree + Markdown view + chunk editor).
+ * Embedded in the Path console right pane (a document node) and on the
+ * /documents/:id deep-link page. Reuses the .tree skeleton + .modal-* anchors.
+ * ─────────────────────────────────────────────────────────────────────────── */
+
+/* When a document is selected in the Path console, the right pane is a slim
+ * action bar + the viewer filling the rest. */
+.paths-doc {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.paths-doc-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.paths-doc-path {
+  font-family: var(--lc-font-mono, monospace);
+  font-size: var(--lc-text-sm, 13px);
+  word-break: break-all;
+  flex: 1;
+  min-width: 0;
+}
+.documents-page {
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.doc-viewer {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.doc-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.doc-title {
+  font-size: var(--lc-text-base, 14px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.doc-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+.doc-toolbar-actions button {
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.doc-toolbar-actions button:hover {
+  border-color: var(--accent);
+}
+.doc-mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.doc-mode-toggle button {
+  padding: 4px 10px;
+  border: none;
+  background: var(--bg);
+  color: var(--fg-soft);
+  cursor: pointer;
+}
+.doc-mode-toggle button.active {
+  background: var(--accent);
+  color: white;
+}
+.doc-split {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+.doc-chunktree {
+  width: 40%;
+  max-width: 360px;
+  overflow: auto;
+  padding: 8px;
+  border-right: 1px solid var(--border);
+  min-height: 0;
+}
+.doc-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.doc-content-head {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.doc-content-head h3 {
+  margin: 0 0 6px;
+  font-size: var(--lc-text-base, 14px);
+}
+.doc-content-meta {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+.chunk-rev {
+  font-size: var(--lc-text-xs, 11px);
+  color: var(--fg-soft);
+}
+.doc-content-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.doc-content-controls button {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.doc-subchunks {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--lc-text-sm, 13px);
+  color: var(--fg-soft);
+}
+.doc-content-body,
+.doc-md-pane {
+  flex: 1;
+  overflow: auto;
+  padding: 14px;
+  min-height: 0;
+}
+.doc-empty-body {
+  color: var(--fg-soft);
+  font-style: italic;
+}
+
+/* Chunk tree rows — flex layout (override the agents-tree 6-col grid;
+ * ancestor-independent so it also holds on the standalone /documents page). */
+.chunk-node .row {
+  display: flex;
+  grid-template-columns: none;
+  gap: 8px;
+  align-items: center;
+}
+.chunk-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  padding: 0;
+  font: inherit;
+  text-align: left;
+  min-width: 0;
+}
+.chunk-link:hover .chunk-title {
+  color: var(--accent);
+}
+.chunk-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.chunk-badge {
+  font-size: var(--lc-text-xs, 11px);
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg-soft);
+}
+.chunk-badge.chunk-status {
+  border-style: dashed;
+}
+
+/* Chunk editor modal extras. */
+.modal.chunk-editor {
+  max-width: 720px;
+  width: 92vw;
+}
+.chunk-editor-row {
+  display: flex;
+  gap: 12px;
+}
+.chunk-editor-row .path-field {
+  flex: 1;
+}
+.chunk-body-input {
+  font-family: var(--lc-font-mono, monospace);
+}
+
+/* Minimal Markdown renderer output. */
+.md {
+  font-size: var(--lc-text-sm, 13px);
+  line-height: 1.55;
+  word-wrap: break-word;
+}
+.md h1,
+.md h2,
+.md h3,
+.md h4,
+.md h5,
+.md h6 {
+  margin: 0.8em 0 0.4em;
+  line-height: 1.25;
+}
+.md h1 {
+  font-size: 1.6em;
+}
+.md h2 {
+  font-size: 1.35em;
+}
+.md h3 {
+  font-size: 1.15em;
+}
+.md p {
+  margin: 0.5em 0;
+}
+.md ul,
+.md ol {
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+.md code {
+  font-family: var(--lc-font-mono, monospace);
+  font-size: 0.92em;
+  background: var(--bg-soft);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.md-pre {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 10px 12px;
+  overflow: auto;
+}
+.md-pre code {
+  background: none;
+  padding: 0;
+}
+.md blockquote {
+  margin: 0.5em 0;
+  padding-left: 12px;
+  border-left: 3px solid var(--border);
+  color: var(--fg-soft);
+}
+.md a {
+  color: var(--accent);
+}


### PR DESCRIPTION
## Why

RFC AM **Phase 2** (Phase 1 = the Path tree console, #543, merged). Documents (RFC AK) had no human-facing surface beyond the Path console's basic node detail. This adds the read-mostly **Document viewer** and the one backend op it needs (`export_md`).

**PR 2 of 3** for RFC AM (Path console → **Document viewer** → document-management agent + assistant).

## What

**Backend — `Document.export_md`** (RFC AK §4.5; a new op value on the existing tool, so it rides `connector.Document` on every transport — no new RPC). Walks the chunk hierarchy from the root depth-first in position order: each chunk a heading (level = depth+1, capped at 6) + its Markdown body. `include_metadata` (default `true`) embeds round-trippable `<!-- loom: {…} -->` chunk metadata + a `<!-- loom-edges: … -->` trailer; `include_metadata:false` is clean human-facing Markdown.

**Web UI — the Document viewer.** Selecting a `document` node in the Path console (or visiting `/documents/:id?scope=`) opens it:
- **`DocumentChunkTree`** — the chunk sub-tree from `query_chunks`, hierarchized by `parent_id` + `position`, click-to-select (reuses the `.tree` skeleton).
- **`DocumentViewer`** — a selected-chunk view (rendered Markdown body + type/status/revision) with a **"with sub-chunks"** toggle that assembles the subtree, a whole-document **Markdown mode** (`export_md` clean), and a **Download .md** button (`export_md` round-trippable).
- **`ChunkEditorModal`** — edit one chunk's title/type/status/body/fields(JSON), saved via `update_chunk` with **optimistic revision**; a stale revision surfaces the "revision conflict" with a reload hint. No structural editing (move/link/delete) — that's the Phase 3 agent.
- **`Markdown`** — a dependency-free, **safe-by-construction** renderer: it builds React elements and never uses `dangerouslySetInnerHTML`, so agent/human-authored bodies can't inject markup or script. Covers headings/paragraphs/code/lists/blockquotes + inline code/bold/italic/links (http(s)/relative hrefs only).
- `api.ts`: `documentQueryChunks` / `getChunk` / `updateChunk` / `exportMd` over `/v1/_document`.

Identity stays server-derived from the cookie principal; the viewer sends only `document_id` + `scope`.

## What was tested

- **`go test ./...`** clean (73 packages). `TestDocument_ExportMD` (heading levels by depth, metadata comment, edges block, clean-mode) + an `export_md` call added to the **postgres-tier** parity test (exercises the `chunk_edges` `from_id IN (SELECT …)` subquery + `?` rebind).
- **SPA**: `tsc --noEmit` + `vite build` clean; the newest bundle contains the `/documents/:id` route, `export_md`, the editor, and the viewer; `index.html` references it.
- **Live smoke test** against a running binary (`LOOMCYCLE_SQLMEM_ENABLED=1`): `create_document` → `create_chunk` → `query_chunks` (root + child shape the tree consumes) → `update_chunk` rev 1 → ok (rev 2) → stale rev 1 → **revision conflict** → `export_md` clean (`# Launch Plan` / `## Intro` heading levels) → `export_md` metadata-rich (per-chunk `<!-- loom: … -->`).

## Scope / deferred (per RFC AM)

- A safe React-element Markdown renderer (no dependency, no `dangerouslySetInnerHTML`) instead of a markdown lib — matches the app's no-CDN/offline posture; rich rendering beyond the common constructs is a later refinement.
- Deferred to **Phase 3**: deterministic `import_md` + the `doc-manager` agent and Document Assistant. Live Channel-subscription updates remain deferred (the viewer refreshes on action). REVISIONS/README version notes wait for the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
