### PR TITLE
feat(rfc-am): Document Assistant + import_md — RFC AM Phase 3 (final)

### DIFF
--- a/bundles/document-agent/README.md
+++ b/bundles/document-agent/README.md
@@ -10,7 +10,8 @@ This is a **first-class, reusable bundle** — not an `examples/` experiment.
 
 ```
 bundles/document-agent/
-├── loomcycle.yaml                 # the doc-manager agent definition
+├── loomcycle.yaml                 # the doc-manager agent (single-provider)
+├── loomcycle_oauth.yaml           # OAuth-FIRST variant (subscription → fallbacks)
 ├── skills/
 │   ├── semantic-chunking/SKILL.md # split prose into a chunk hierarchy
 │   ├── edge-linking/SKILL.md      # create/curate graph edges
@@ -41,6 +42,18 @@ loomcycle --config bundles/document-agent/loomcycle.yaml
 3. Ensure `LOOMCYCLE_SQLMEM_ENABLED=1`.
 4. Swap the provider/tier for your routing — the agent only needs a `middle`
    tier to resolve.
+
+**Anthropic OAuth (subscription) variant:** `loomcycle_oauth.yaml` is the same
+agent with `anthropic-oauth-dev` first in every tier and the API-key/cloud
+providers (deepseek/gemini/anthropic/openai) as the fallback cascade. Opt into
+the OAuth path (`LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1` + `loomcycle anthropic
+login`; see `docs/PROVIDERS.md`) and run it instead:
+```sh
+export LOOMCYCLE_SQLMEM_ENABLED=1 LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1
+export LOOMCYCLE_SKILLS_ROOT=bundles/document-agent/skills
+loomcycle anthropic login
+loomcycle --config bundles/document-agent/loomcycle_oauth.yaml
+```
 
 The Web UI Assistant targets the agent named **`doc-manager`** by default; if it
 isn't registered, the Assistant panel shows a hint pointing here instead of a

--- a/bundles/document-agent/README.md
+++ b/bundles/document-agent/README.md
@@ -1,0 +1,65 @@
+# document-agent bundle
+
+The **`doc-manager`** agent + document-management skills that power the loomcycle
+Web UI's **Document Assistant** (RFC AM Phase 3). Instead of a complex manual
+chunk-editing UI, the operator types plain-text instructions and this agent
+performs the structural work on a chunked-graph Document (RFC AK): semantic
+import, moving chunks, linking edges, deleting, Markdown round-trip.
+
+This is a **first-class, reusable bundle** — not an `examples/` experiment.
+
+```
+bundles/document-agent/
+├── loomcycle.yaml                 # the doc-manager agent definition
+├── skills/
+│   ├── semantic-chunking/SKILL.md # split prose into a chunk hierarchy
+│   ├── edge-linking/SKILL.md      # create/curate graph edges
+│   ├── restructuring/SKILL.md     # move/reorder/promote/delete chunks
+│   └── md-import/SKILL.md         # import_md (round-trip) vs semantic import
+├── examples/
+│   └── sample-plan.md             # a plain .md to try the Assistant on
+└── README.md
+```
+
+## Enable it
+
+The agent must be present in the **running** config for the Web UI Assistant to
+find it (loomcycle has no built-in-agent-in-binary mechanism yet — see *Forward
+path* below). Two ways:
+
+**Run the bundle directly (demo):**
+```sh
+export LOOMCYCLE_SQLMEM_ENABLED=1                       # Documents require SQL Memory
+export LOOMCYCLE_SKILLS_ROOT=bundles/document-agent/skills
+loomcycle --config bundles/document-agent/loomcycle.yaml
+```
+
+**Register in your own deployment:**
+1. Copy the `agents: doc-manager` block from `loomcycle.yaml` into your config.
+2. Point `LOOMCYCLE_SKILLS_ROOT` at this bundle's `skills/` (or copy them into
+   your skills root) so the four skills resolve.
+3. Ensure `LOOMCYCLE_SQLMEM_ENABLED=1`.
+4. Swap the provider/tier for your routing — the agent only needs a `middle`
+   tier to resolve.
+
+The Web UI Assistant targets the agent named **`doc-manager`** by default; if it
+isn't registered, the Assistant panel shows a hint pointing here instead of a
+broken spawn.
+
+## How the Assistant drives it
+
+When you open a Document in the Web UI and use the Assistant, the panel spawns a
+single **interactive** run of `doc-manager` with `metadata: {document_id, scope}`
+and steers each instruction in, prefixed with a machine line
+`[ctx] selected_chunk_id=<id>` so the agent always knows your live selection. The
+agent reads with `query_chunks`/`get_chunk` and edits with the other `Document`
+ops, all in **`user` scope** — the same scope the viewer shows (the run's
+user_id is your principal subject), so its edits appear when the viewer refreshes.
+
+## Forward path
+
+The intent is for `doc-manager` to eventually be a **built-in-by-default** agent
+— embedded in the binary and auto-registered with no operator config, the way
+Claude Code ships built-in agents/skills. That needs a built-in-agent mechanism
+loomcycle doesn't have yet; until then, this bundle is the source of truth and
+the recommended way to register it.

--- a/bundles/document-agent/examples/sample-plan.md
+++ b/bundles/document-agent/examples/sample-plan.md
@@ -1,0 +1,22 @@
+# Launch plan
+
+A small plain-Markdown file to try the Document Assistant on. Paste it into the
+Assistant and say: *"import this as a new document under /docs/launch and split
+it into sections."* The agent will create a chunk hierarchy from the headings.
+
+## Goals
+
+Ship v1 to the waitlist by end of quarter. Keep the rollout reversible — a
+feature flag gates the new flow so we can dark-launch to 5% first.
+
+## Risks
+
+- Provider rate limits during the announcement spike.
+- The migration backfill is O(n) over the user table; run it off-peak.
+
+## Runbook
+
+1. Flip the flag to 5%.
+2. Watch error rate + p99 for 30 minutes.
+3. Ramp to 50%, then 100% if clean.
+4. Rollback = flip the flag off; no schema change to revert.

--- a/bundles/document-agent/loomcycle.yaml
+++ b/bundles/document-agent/loomcycle.yaml
@@ -1,0 +1,69 @@
+# document-agent bundle — the `doc-manager` agent that powers the Web UI
+# Document Assistant (RFC AM Phase 3).
+#
+# This is a first-class, reusable bundle (NOT an examples/ experiment). Two ways
+# to use it:
+#   1. Run it directly for a demo:
+#        export LOOMCYCLE_SQLMEM_ENABLED=1
+#        export LOOMCYCLE_SKILLS_ROOT=bundles/document-agent/skills
+#        loomcycle --config bundles/document-agent/loomcycle.yaml
+#   2. Register it in your own deployment: copy the `agents: doc-manager` block
+#      (and point LOOMCYCLE_SKILLS_ROOT at this bundle's skills/, or copy the
+#      skills into your skills root). loomcycle has no built-in-agent mechanism
+#      yet (auto-registering this in the binary is a deferred follow-up), so the
+#      agent must be present in the running config for the Assistant to find it.
+#
+# Requirements: SQL Memory (LOOMCYCLE_SQLMEM_ENABLED=1) — Documents need it.
+#
+# Swap the provider/tier below for your own routing; the agent only needs a
+# `middle` tier to resolve.
+
+provider_priority:
+  - anthropic            # set ANTHROPIC_API_KEY, or swap for your provider
+
+tiers:
+  middle:
+    - { provider: anthropic, model: claude-sonnet-4-6 }
+
+user_tiers:
+  default:
+    provider_priority: [anthropic]
+    fallback_on_error: true
+    max_fallback_attempts: 2
+
+agents:
+  doc-manager:
+    tier: middle
+    max_iterations: 24
+    max_tokens: 8192
+    effort: medium
+    allowed_tools: [Document, Memory, Context]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    skills: [semantic-chunking, edge-linking, restructuring, md-import]
+    system_prompt: |
+      You are DOC-MANAGER, a co-author of chunked-graph Documents (RFC AK). You
+      turn an operator's plain-text instructions into Document tool calls — the
+      operator drives you from the Web UI's Document Assistant instead of editing
+      chunks by hand.
+
+      ## Awareness
+      Your run metadata carries {document_id, scope}. Each operator turn begins
+      with a machine line "[ctx] selected_chunk_id=<id>" — the chunk the operator
+      currently has selected. Operate relative to it unless told otherwise. The
+      selection changes between turns; always honor the latest [ctx] line.
+
+      ## How you work
+      - Read before you write: Document op=query_chunks (document_id from the
+        metadata) for structure, op=get_chunk for a body. NEVER invent chunk ids
+        — always resolve them.
+      - Change with create_chunk / update_chunk / move_chunk / link_chunks /
+        unlink_chunks / delete_chunk, all scope=user.
+      - update_chunk needs the chunk's current revision (from get_chunk); on a
+        "revision conflict", re-read and retry.
+      - Confirm intent in one sentence before a large cascade ("Moving 6 chunks
+        under Runbooks — proceed?") and wait for the operator's go-ahead.
+
+      ## Output
+      Be terse. After acting, state what changed in a line or two — the Web UI
+      refreshes the tree, so don't dump the whole document back.

--- a/bundles/document-agent/loomcycle_oauth.yaml
+++ b/bundles/document-agent/loomcycle_oauth.yaml
@@ -1,0 +1,115 @@
+# document-agent bundle — OAuth-FIRST variant.
+#
+# Same `doc-manager` agent as loomcycle.yaml in this bundle, but the
+# reverse-engineered Anthropic subscription provider `anthropic-oauth-dev` is
+# FIRST in every provider_priority + tier candidate list; the API-key / cloud
+# providers below it are the fallback cascade. `fallback_on_error: true` rolls a
+# quota/availability error over to the next candidate.
+#
+# Run it with:
+#     export LOOMCYCLE_SQLMEM_ENABLED=1                       # Documents need SQL Memory
+#     export LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1          # opt into the OAuth path
+#     export LOOMCYCLE_SKILLS_ROOT=bundles/document-agent/skills
+#     loomcycle anthropic login                               # one-time browser login
+#     loomcycle --config bundles/document-agent/loomcycle_oauth.yaml
+#
+# ─── PREREQUISITES for the OAuth path (full text in docs/PROVIDERS.md) ──
+#   1. An active Claude Pro/Max subscription (with inference quota).
+#   2. LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 in the launch env (NOT this file).
+#      Without it, `anthropic-oauth-dev` is ABSENT from the resolver and every
+#      reference below silently falls through to the next provider.
+#   3. `loomcycle anthropic login` (tokens persist at
+#      ~/.config/loomcycle/anthropic-oauth.json, chmod 0600).
+#
+# ─── RISK ──────────────────────────────────────────────────────────────
+# The Anthropic OAuth flow is REVERSE-ENGINEERED, not official — RESEARCH/DEV
+# ONLY, run against YOUR OWN subscription, no warranty. See docs/PROVIDERS.md.
+#
+# ─── API-key fallbacks (set in the launch env, NOT this file) ──────────
+#   ANTHROPIC_API_KEY / DEEPSEEK_API_KEY / GEMINI_API_KEY / OPENAI_API_KEY
+
+# OAuth FIRST; everything else is the fallback cascade. Add `ollama-local` /
+# `ollama` here if you run a LAN/cloud Ollama (see loomcycle_oauth.yaml in your
+# config dir for that shape).
+provider_priority:
+  - anthropic-oauth-dev   # MAX subscription billing — FIRST
+  - deepseek
+  - gemini
+  - anthropic             # API-key Anthropic
+  - openai
+
+# ─── Model aliases (sensitive-path pin pattern) ───────────────────────
+models:
+  oauth-haiku:       { provider: anthropic-oauth-dev, model: claude-haiku-4-5-20251001 }
+  oauth-sonnet:      { provider: anthropic-oauth-dev, model: claude-sonnet-4-6 }
+  haiku:             { provider: anthropic, model: claude-haiku-4-5 }
+  sonnet:            { provider: anthropic, model: claude-sonnet-4-6 }
+  deepseek-pro:      { provider: deepseek, model: deepseek-v4-pro }
+  deepseek-flash:    { provider: deepseek, model: deepseek-v4-flash }
+  gemini-pro:        { provider: gemini,   model: gemini-2.5-pro }
+  gemini-flash-lite: { provider: gemini,   model: gemini-2.5-flash-lite }
+
+# ─── Tier candidate lists — OAuth subscription model FIRST, then fallbacks ──
+tiers:
+  low:
+    - oauth-haiku        # subscription FIRST
+    - deepseek-flash
+    - gemini-flash-lite
+    - haiku              # API-key fallback
+  middle:
+    - oauth-sonnet       # subscription FIRST
+    - deepseek-pro
+    - gemini-pro
+    - sonnet             # API-key fallback
+  high:
+    - oauth-sonnet       # subscription FIRST
+    - deepseek-pro
+    - sonnet             # API-key fallback
+
+user_tiers:
+  default:
+    provider_priority: [anthropic-oauth-dev, deepseek, gemini, anthropic, openai]
+    fallback_on_error: true
+    max_fallback_attempts: 3
+
+# Ultimate fallback when no agent/tier resolves: the OAuth subscription.
+defaults:
+  provider: anthropic-oauth-dev
+  model: claude-sonnet-4-6
+
+agents:
+  doc-manager:
+    tier: middle          # → oauth-sonnet first, then deepseek/gemini/anthropic
+    max_iterations: 24
+    max_tokens: 8192
+    effort: medium        # ignored by some providers; honoured on the OAuth path
+    allowed_tools: [Document, Memory, Context]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    skills: [semantic-chunking, edge-linking, restructuring, md-import]
+    system_prompt: |
+      You are DOC-MANAGER, a co-author of chunked-graph Documents (RFC AK). You
+      turn an operator's plain-text instructions into Document tool calls — the
+      operator drives you from the Web UI's Document Assistant instead of editing
+      chunks by hand.
+
+      ## Awareness
+      Your run metadata carries {document_id, scope}. Each operator turn begins
+      with a machine line "[ctx] selected_chunk_id=<id>" — the chunk the operator
+      currently has selected. Operate relative to it unless told otherwise. The
+      selection changes between turns; always honor the latest [ctx] line.
+
+      ## How you work
+      - Read before you write: Document op=query_chunks (document_id from the
+        metadata) for structure, op=get_chunk for a body. NEVER invent chunk ids
+        — always resolve them.
+      - Change with create_chunk / update_chunk / move_chunk / link_chunks /
+        unlink_chunks / delete_chunk, all scope=user.
+      - update_chunk needs the chunk's current revision (from get_chunk); on a
+        "revision conflict", re-read and retry.
+      - Confirm intent in one sentence before a large cascade ("Moving 6 chunks
+        under Runbooks — proceed?") and wait for the operator's go-ahead.
+
+      ## Output
+      Be terse. After acting, state what changed in a line or two — the Web UI
+      refreshes the tree, so don't dump the whole document back.

--- a/bundles/document-agent/skills/edge-linking/SKILL.md
+++ b/bundles/document-agent/skills/edge-linking/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: edge-linking
+description: Create and curate graph edges between chunks (and across documents) in a chunked-graph Document.
+allowed_tools: [Document]
+license: Apache-2.0
+---
+
+# Edge linking
+
+Chunks form a tree by `parent_id`, but they also carry a free-form **graph** of
+typed edges (`link_chunks`) — "this publication promotes that blog post", "this
+task targets that requirement". Use edges for cross-cutting relations that the
+parent/child hierarchy can't express.
+
+## Method
+1. Resolve both endpoints first with `query_chunks` / `get_chunk` — both chunks
+   must already exist (an edge to a missing chunk is refused). Cross-document
+   edges are allowed as long as both chunks are in this scope.
+2. Pick a clear `kind` verb the operator will recognize: `references`,
+   `promotes`, `targets`, `depends_on`, `supersedes`. Reuse existing kinds in
+   the document rather than inventing near-duplicates.
+3. Link: `Document op=link_chunks from_id=<a> to_id=<b> kind="references"`
+   (idempotent — re-linking the same triple is a no-op).
+4. Remove a stale edge with `op=unlink_chunks from_id=<a> to_id=<b> kind="…"`.
+
+## Notes
+- Edges are directional (`from → to`). State the direction back to the operator.
+- Don't use an edge where a parent/child move is what's meant — see the
+  restructuring skill.

--- a/bundles/document-agent/skills/md-import/SKILL.md
+++ b/bundles/document-agent/skills/md-import/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: md-import
+description: Import a Markdown file into a chunked-graph Document — deterministic round-trip vs semantic chunking.
+allowed_tools: [Document]
+license: Apache-2.0
+---
+
+# Markdown import
+
+Two paths, pick by the input:
+
+## 1. A loomcycle export (round-trip) → `import_md`
+If the Markdown was produced by `export_md` — it contains `<!-- loom: {…} -->`
+comments and maybe a `<!-- loom-edges: … -->` trailer — use the deterministic op
+and let the runtime rebuild the structure:
+
+- New document: `Document op=import_md markdown="<the file>"` (the first heading
+  becomes the root; pass `path:` to also name it in the Path tree).
+- Into an existing document: `op=import_md document_id=<id> markdown="…"`
+  (optionally `parent_id=<chunk>` to graft it under a specific chunk).
+
+`import_md` recreates the heading hierarchy, applies each chunk's type/status/
+fields, and remaps the edge graph. Chunks get fresh ids.
+
+## 2. Arbitrary prose / a plain `.md` → semantic chunking
+If the Markdown has no `loom` metadata (a hand-written file, pasted notes), do
+NOT use `import_md` blindly — its chunk boundaries are the heading lines, so a
+body containing `##` lines would be re-chunked. Instead apply the
+**semantic-chunking** skill: read the structure and `create_chunk` each piece
+with a good title.
+
+## After importing
+Tell the operator the new `document_id` and how many chunks were created. They
+can open it from the Path tree.

--- a/bundles/document-agent/skills/restructuring/SKILL.md
+++ b/bundles/document-agent/skills/restructuring/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: restructuring
+description: Safely move, reparent, reorder, promote, or delete chunks in a chunked-graph Document.
+allowed_tools: [Document]
+license: Apache-2.0
+---
+
+# Restructuring
+
+Reshaping the tree — "promote the risks section to a top-level chunk", "move the
+deployment steps under Runbooks", "reorder these" — is your job (the Web UI
+deliberately has no drag-edit). Be careful: these operations cascade.
+
+## Method
+1. Map the current shape first: `query_chunks document_id=<id>` to see parents
+   and positions before moving anything.
+2. Reparent / reorder with `Document op=move_chunk id=<chunk> new_parent_id=<p>`
+   (and an optional `position`). Moving a chunk takes its whole subtree with it.
+   A move into a chunk's own subtree is refused (it would orphan the tree).
+3. Promote = move to a shallower parent (e.g. `new_parent_id` = the document
+   root). Demote = move under a sibling.
+4. Delete with `op=delete_chunk id=<chunk>` — this **cascades** to all
+   descendants and returns the count. You cannot delete a document's root chunk.
+
+## Safety
+- For any cascade touching more than a couple of chunks, summarize the effect in
+  one sentence and get the operator's confirmation BEFORE acting
+  ("Deleting Section 3 removes it and its 4 sub-chunks — proceed?").
+- Re-read after a move (`query_chunks`) if you're chaining further changes — ids
+  are stable but positions shift.

--- a/bundles/document-agent/skills/semantic-chunking/SKILL.md
+++ b/bundles/document-agent/skills/semantic-chunking/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: semantic-chunking
+description: Split arbitrary prose or a Markdown file into a sensible chunk hierarchy in a chunked-graph Document.
+allowed_tools: [Document]
+license: Apache-2.0
+---
+
+# Semantic chunking
+
+When the operator hands you a body of text (pasted prose, a spec, a Markdown
+file) and asks to "import it" or "chunk it", turn it into a hierarchy of
+chunks — do NOT dump it into one giant chunk.
+
+## Method
+1. Read the text's own structure first: existing headings, numbered sections,
+   topic shifts, and natural paragraphs are your chunk boundaries.
+2. Choose a hierarchy: a top-level chunk per major section, child chunks per
+   sub-section. Aim for chunks that are individually meaningful and editable —
+   a few sentences to a few paragraphs each, not one-liners and not whole pages.
+3. Give every chunk a short, descriptive **title** (it becomes the heading).
+4. Create them top-down so parents exist before children:
+   `Document op=create_chunk document_id=<id> parent_id=<parent> title="…" body="…"`
+   (omit `parent_id` for a child of the root, or pass the document's root chunk).
+5. Carry a `type` when the operator's domain implies one (e.g. `section`,
+   `requirement`, `task`) and a `status` if they use a workflow.
+
+## Notes
+- If the text is a loomcycle export (it has `<!-- loom: … -->` comments), prefer
+  the deterministic `import_md` op instead (see the md-import skill).
+- Keep the operator's wording in the body; don't paraphrase unless asked.

--- a/docs/DOCUMENTS.md
+++ b/docs/DOCUMENTS.md
@@ -32,7 +32,7 @@ enabled** (`LOOMCYCLE_SQLMEM_ENABLED=1`); without it the tool refuses.
 
 ## Surface
 
-One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 14 ops:
+One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 15 ops:
 
 | group | ops |
 |-------|-----|
@@ -41,7 +41,7 @@ One tool, `Document`, gated by per-agent `allowed_tools: [Document]`. 14 ops:
 | Edges | `link_chunks`, `unlink_chunks` |
 | Query | `query_chunks` |
 | Types | `define_type`, `list_types` |
-| Markdown | `export_md` (render the document to Markdown; `include_metadata:false` for clean human MD, default `true` embeds round-trippable chunk metadata + edges as HTML comments) |
+| Markdown | `export_md` (render to Markdown; `include_metadata:false` for clean human MD, default `true` embeds round-trippable metadata + edges as HTML comments), `import_md` (build a document from export_md-shaped Markdown — omit `document_id` for a new document; pass `document_id`/`parent_id` to import under an existing chunk) |
 
 `scope` is `agent` (this agent, the default) or `user` (this end-user — needs a
 `user_id` on the run). **Tenant scope is deferred** — SQL Memory has
@@ -132,10 +132,22 @@ const open = await client.document({
 - **Tenant scope deferred** — `agent`/`user` only in v1.
 - **Orphaned bodies are best-effort on delete** — see the integrity note above
   (invisible dead K/V; the row side is atomic).
-- **`export_md` + the Web UI Document viewer** shipped in RFC AM Phase 2 (a
-  `paths` tab document node, or `/documents/:id`): chunk sub-tree, Markdown
-  view, MD download, and a single-chunk content editor. **Deterministic
-  `import_md` + the document-management agent** are RFC AM Phase 3.
+- **`import_md` chunk boundaries are heading lines** — a chunk body containing
+  ATX headings (`## …`) re-chunks on import. For loomcycle exports this is
+  faithful; for arbitrary prose use the Document Assistant's semantic chunking.
+
+## The Web UI + the Document Assistant
+
+The Web UI exposes Documents through the **`paths`** tab (open a `document`
+node) and the `/documents/:id` deep link: a chunk sub-tree, a Markdown view, MD
+download, and a single-chunk content editor (body/fields, optimistic revision).
+Structural editing — restructuring, semantic import, linking — is done by the
+**Document Assistant** (the viewer's `assistant` toggle): you type instructions
+and the **`doc-manager`** agent performs the `Document` ops. That agent +
+skills ship as the **[`bundles/document-agent/`](../bundles/document-agent/)**
+bundle; register it (see its README) for the Assistant to work — it degrades to
+a hint if absent. (RFC AM: Phase 1 = Path console, Phase 2 = viewer + `export_md`,
+Phase 3 = `import_md` + the agent.)
 
 ## Where it lives
 

--- a/internal/help/builtin/document.md
+++ b/internal/help/builtin/document.md
@@ -43,7 +43,12 @@ for a scope-wide type), `list_types`.
 **Markdown:** `export_md` (`document_id` or `id`/`path`) renders the document to
 Markdown — each chunk a heading (level = depth) + its body. `include_metadata`
 (default `true`) embeds round-trippable chunk metadata + edges as HTML comments;
-`include_metadata:false` is clean human-facing Markdown.
+`include_metadata:false` is clean human-facing Markdown. `import_md` is the
+inverse: `markdown` (an export_md-shaped doc) builds a NEW document (omit
+`document_id`; the first heading becomes the root) or imports under an existing
+chunk (`document_id` + optional `parent_id`). Chunks get fresh ids; the edge
+graph is remapped. Bodies with `##` heading lines re-chunk — do your own
+semantic chunking (`create_chunk`) for arbitrary prose.
 
 ## Concurrency — `update_chunk` revision
 

--- a/internal/tools/builtin/document.go
+++ b/internal/tools/builtin/document.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -37,7 +38,7 @@ type Document struct {
 func (d *Document) Name() string { return "Document" }
 
 func (d *Document) Description() string {
-	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown). Scope is agent or user; documents can be named in the Path tree (path:)."
+	return "A chunked-graph document: each chunk is a first-class unit (UUID, hierarchy, type, fields, graph edges, Markdown body) that agents and humans co-author and query. Ops: create_document/get_document/delete_document, create_chunk/get_chunk/update_chunk/delete_chunk/move_chunk, link_chunks/unlink_chunks, query_chunks (structured filters + a raw sql escape hatch), define_type/list_types, export_md (render the document to Markdown), import_md (build a document from export_md-shaped Markdown). Scope is agent or user; documents can be named in the Path tree (path:)."
 }
 
 // documentInputSchema is a package const so the LoomCycle MCP server can
@@ -47,7 +48,7 @@ func (d *Document) Description() string {
 const documentInputSchema = `{
 	"type": "object",
 	"properties": {
-		"op":          {"type": "string", "enum": ["create_document","get_document","delete_document","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md"]},
+		"op":          {"type": "string", "enum": ["create_document","get_document","delete_document","create_chunk","get_chunk","update_chunk","delete_chunk","move_chunk","link_chunks","unlink_chunks","query_chunks","define_type","list_types","export_md","import_md"]},
 		"scope":       {"type": "string", "enum": ["agent","user"], "description": "Which store (default user). agent = this agent; user = this end-user (needs a user_id on the run). tenant scope is not yet supported."},
 		"id":          {"type": "string", "description": "Document id (get/delete_document) or chunk id (get/update/delete/move_chunk)."},
 		"path":        {"type": "string", "description": "create_document: name the doc in the Path tree (e.g. /docs/launch). get/delete_document: address by path instead of id."},
@@ -68,7 +69,8 @@ const documentInputSchema = `{
 		"sql":         {"type": "string", "description": "query_chunks: raw read-only SELECT against the chunk tables (escape hatch; validator-gated)."},
 		"limit":       {"type": "integer"},
 		"name":        {"type": "string", "description": "define/list_types: the type name."},
-		"include_metadata": {"type": "boolean", "description": "export_md: embed round-trippable chunk metadata + edges as HTML comments (default true). false = clean human-facing Markdown."}
+		"include_metadata": {"type": "boolean", "description": "export_md: embed round-trippable chunk metadata + edges as HTML comments (default true). false = clean human-facing Markdown."},
+		"markdown":    {"type": "string", "description": "import_md: an export_md-shaped Markdown document (headings = hierarchy; <!-- loom: ... --> metadata; <!-- loom-edges: ... --> trailer). Omit document_id to create a new document; pass document_id (+ optional parent_id) to import under an existing chunk."}
 	},
 	"required": ["op"]
 }`
@@ -100,6 +102,8 @@ type docInput struct {
 	// IncludeMetadata gates export_md's round-trip comments (default true when
 	// omitted; a pointer so an explicit `false` is distinguishable from unset).
 	IncludeMetadata *bool `json:"include_metadata"`
+	// Markdown is the import_md source (an export_md-shaped document).
+	Markdown string `json:"markdown"`
 }
 
 // docSchemaDDL is portable across SQL Memory's sqlite + postgres tiers: BIGINT
@@ -181,6 +185,8 @@ func (d *Document) Execute(ctx context.Context, raw json.RawMessage) (tools.Resu
 		return d.listTypes(ctx, key, in)
 	case "export_md":
 		return d.exportMD(ctx, key, mscope, in)
+	case "import_md":
+		return d.importMD(ctx, key, mscope, in)
 	case "":
 		return errResult("missing required field: op"), nil
 	default:
@@ -1071,6 +1077,203 @@ func (d *Document) exportMD(ctx context.Context, key sqlmem.ScopeKey, mscope sto
 	}
 
 	return jsonResult(map[string]any{"markdown": b.String(), "document_id": docID, "title": title})
+}
+
+// --- ops: Markdown import ---
+
+// mdChunk is one parsed chunk from an export_md-shaped document.
+type mdChunk struct {
+	level  int
+	title  string
+	oldID  string // the id in the `<!-- loom: ... -->` comment (for edge remap)
+	typ    string
+	status string
+	fields json.RawMessage
+	body   string
+}
+
+type mdEdge struct{ from, to, kind string }
+
+var (
+	mdHeadingRe = regexp.MustCompile(`^(#{1,6})\s+(.*)$`)
+	mdEdgeRe    = regexp.MustCompile(`^\s*(\S+)\s*->\s*(\S+)\s*\[(.*)\]\s*$`)
+)
+
+// parseLoomMarkdown parses an export_md output: heading lines define the chunk
+// hierarchy (level = heading depth), an optional `<!-- loom: {…} -->` line
+// right after a heading carries id/type/status/fields, and a trailing
+// `<!-- loom-edges: … -->` block carries the graph edges. Lines between
+// headings (minus the loom comment) are the chunk body.
+func parseLoomMarkdown(md string) ([]mdChunk, []mdEdge) {
+	lines := strings.Split(strings.ReplaceAll(md, "\r\n", "\n"), "\n")
+	var chunks []mdChunk
+	var edges []mdEdge
+	var cur *mdChunk
+	var bodyLines []string
+	flush := func() {
+		if cur != nil {
+			cur.body = strings.Trim(strings.Join(bodyLines, "\n"), "\n")
+			chunks = append(chunks, *cur)
+		}
+		cur = nil
+		bodyLines = nil
+	}
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		trimmed := strings.TrimSpace(line)
+		// Edges trailer — consume to its closing "-->".
+		if strings.HasPrefix(trimmed, "<!-- loom-edges:") {
+			for i++; i < len(lines) && !strings.Contains(lines[i], "-->"); i++ {
+				if m := mdEdgeRe.FindStringSubmatch(lines[i]); m != nil {
+					edges = append(edges, mdEdge{from: m[1], to: m[2], kind: m[3]})
+				}
+			}
+			continue
+		}
+		if m := mdHeadingRe.FindStringSubmatch(line); m != nil {
+			flush()
+			cur = &mdChunk{level: len(m[1]), title: strings.TrimSpace(m[2])}
+			continue
+		}
+		// Per-chunk metadata comment (single line directly under a heading).
+		if cur != nil && strings.HasPrefix(trimmed, "<!-- loom:") && strings.HasSuffix(trimmed, "-->") {
+			payload := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "<!-- loom:"), "-->"))
+			var meta struct {
+				ID     string          `json:"id"`
+				Type   string          `json:"type"`
+				Status string          `json:"status"`
+				Fields json.RawMessage `json:"fields"`
+			}
+			if json.Unmarshal([]byte(payload), &meta) == nil {
+				cur.oldID, cur.typ, cur.status, cur.fields = meta.ID, meta.Type, meta.Status, meta.Fields
+			}
+			continue
+		}
+		if cur != nil {
+			bodyLines = append(bodyLines, line)
+		}
+	}
+	flush()
+	return chunks, edges
+}
+
+// resultField pulls a string field out of a sub-op's JSON result (used to chain
+// importMD onto the existing create_document / create_chunk ops).
+func resultField(r tools.Result, field string) string {
+	var m map[string]any
+	_ = json.Unmarshal([]byte(r.Text), &m)
+	return asStr(m[field])
+}
+
+// importMD builds a document from export_md-shaped Markdown (RFC AK §4.5 / RFC
+// AM Phase 3). With no document_id it creates a NEW document (the first heading
+// becomes the root); with a document_id (+ optional parent_id) it imports the
+// parsed subtree under an existing chunk. Chunks get fresh ids; the
+// `<!-- loom-edges -->` graph is recreated by remapping the old ids → new ones
+// (an edge whose endpoint wasn't imported is skipped). Not atomic — it composes
+// the existing create_document / create_chunk / link_chunks ops, so a mid-import
+// failure leaves a partial document the caller can delete and retry.
+func (d *Document) importMD(ctx context.Context, key sqlmem.ScopeKey, mscope store.MemoryScope, in docInput) (tools.Result, error) {
+	if strings.TrimSpace(in.Markdown) == "" {
+		return errResult("import_md: missing required field: markdown"), nil
+	}
+	chunks, edges := parseLoomMarkdown(in.Markdown)
+	if len(chunks) == 0 {
+		return errResult("import_md: no headings found — a document needs at least one '# Heading'"), nil
+	}
+	oldToNew := map[string]string{}
+	type frame struct {
+		level int
+		id    string
+	}
+	var stack []frame
+	var docID, rootID string
+	created := 0
+	start := 0
+
+	if in.DocumentID == "" {
+		// New document: the first heading is the root chunk.
+		first := chunks[0]
+		cd, _ := d.createDocument(ctx, key, mscope, docInput{Title: titleOrUntitled(first.title), Path: in.Path})
+		if cd.IsError {
+			return cd, nil
+		}
+		docID = resultField(cd, "document_id")
+		rootID = resultField(cd, "root_chunk_id")
+		if err := d.writeBody(ctx, mscope, key.ScopeID, rootID, first.body, first.fields); err != nil {
+			return errResult("import_md: root body: " + err.Error()), nil
+		}
+		if first.typ != "" || first.status != "" {
+			if err := d.exec(ctx, key, `UPDATE chunks SET type = ?, status = ? WHERE id = ?`, nullIfEmpty(first.typ), nullIfEmpty(first.status), rootID); err != nil {
+				return errResult("import_md: " + err.Error()), nil
+			}
+		}
+		if first.oldID != "" {
+			oldToNew[first.oldID] = rootID
+		}
+		stack = []frame{{level: first.level, id: rootID}}
+		created, start = 1, 1
+	} else {
+		docID = in.DocumentID
+		base := in.ParentID
+		if base == "" {
+			dres, err := d.query(ctx, key, `SELECT root_chunk_id FROM documents WHERE id = ? LIMIT 1`, docID)
+			if err != nil {
+				return errResult("import_md: " + err.Error()), nil
+			}
+			if len(dres.Rows) == 0 {
+				return errResult("import_md: no such document: " + docID), nil
+			}
+			base = asStr(dres.Rows[0][0])
+		} else if _, ok, err := d.getChunkRow(ctx, key, base); err != nil {
+			return errResult("import_md: " + err.Error()), nil
+		} else if !ok {
+			return errResult("import_md: no such parent chunk: " + base), nil
+		}
+		rootID = base
+		stack = []frame{{level: 0, id: base}}
+	}
+
+	for _, c := range chunks[start:] {
+		// Pop to the nearest ancestor whose heading level is shallower.
+		for len(stack) > 1 && stack[len(stack)-1].level >= c.level {
+			stack = stack[:len(stack)-1]
+		}
+		parent := stack[len(stack)-1].id
+		cc, _ := d.createChunk(ctx, key, mscope, docInput{
+			DocumentID: docID, ParentID: parent, Title: titleOrUntitled(c.title),
+			Type: c.typ, Status: c.status, Body: c.body, Fields: c.fields,
+		})
+		if cc.IsError {
+			return cc, nil
+		}
+		newID := resultField(cc, "id")
+		if c.oldID != "" {
+			oldToNew[c.oldID] = newID
+		}
+		stack = append(stack, frame{level: c.level, id: newID})
+		created++
+	}
+
+	// Recreate edges by remapping old → new ids; skip any whose endpoints
+	// weren't both imported (e.g. a cross-document edge).
+	for _, e := range edges {
+		nf, ok1 := oldToNew[e.from]
+		nt, ok2 := oldToNew[e.to]
+		if !ok1 || !ok2 {
+			continue
+		}
+		_, _ = d.linkChunks(ctx, key, docInput{FromID: nf, ToID: nt, Kind: e.kind})
+	}
+
+	return jsonResult(map[string]any{"document_id": docID, "root_chunk_id": rootID, "chunks_created": created})
+}
+
+func titleOrUntitled(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "Untitled"
+	}
+	return s
 }
 
 // --- ops: type definitions ---

--- a/internal/tools/builtin/document_test.go
+++ b/internal/tools/builtin/document_test.go
@@ -374,6 +374,15 @@ func TestDocument_Postgres(t *testing.T) {
 	if res.IsError || !strings.Contains(out["markdown"].(string), "## c1") {
 		t.Errorf("pg export_md = %s", res.Text)
 	}
+	// import_md (Markdown round-trip) on pg — exercises createDocument/createChunk
+	// + the `UPDATE chunks SET type, status` and root_chunk_id SELECT rebind.
+	{
+		mdReq, _ := json.Marshal(map[string]any{"op": "import_md", "scope": "user", "markdown": out["markdown"]})
+		io, ir := docExec(t, d, ctx, string(mdReq))
+		if ir.IsError || io["document_id"] == "" || io["document_id"] == docID {
+			t.Errorf("pg import_md = %s", ir.Text)
+		}
+	}
 	// update revision (atomic bump + RowsAffected gate on pg).
 	out, res = docExec(t, d, ctx, `{"op":"update_chunk","scope":"user","id":"`+c1+`","revision":1,"status":"published"}`)
 	if res.IsError || int(out["revision"].(float64)) != 2 {
@@ -481,6 +490,57 @@ func TestDocument_ExportMD_HeadingAndOrder(t *testing.T) {
 	iB := strings.Index(md, "## B")
 	if !(iA >= 0 && iA < iA1 && iA1 < iA2 && iA2 < iB) {
 		t.Errorf("sibling/nesting order wrong (A=%d A1=%d A2=%d B=%d):\n%s", iA, iA1, iA2, iB, md)
+	}
+}
+
+// RFC AM Phase 3: import_md is the deterministic inverse of export_md —
+// export → import (new doc) → re-export must be structurally identical, and the
+// graph edge must survive (remapped to the new chunk ids).
+func TestDocument_ImportMD_RoundTrip(t *testing.T) {
+	d, ctx, _ := documentFixture(t)
+	out, _ := docExec(t, d, ctx, `{"op":"create_document","scope":"user","title":"Plan"}`)
+	docID := out["document_id"].(string)
+	root := out["root_chunk_id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"A","type":"section","status":"draft","body":"alpha **body**"}`)
+	a := out["id"].(string)
+	out, _ = docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+a+`","title":"A1","body":"nested"}`)
+	a1 := out["id"].(string)
+	docExec(t, d, ctx, `{"op":"create_chunk","scope":"user","document_id":"`+docID+`","parent_id":"`+root+`","title":"B","body":""}`)
+	docExec(t, d, ctx, `{"op":"link_chunks","scope":"user","from_id":"`+a+`","to_id":"`+a1+`","kind":"references"}`)
+
+	// Metadata-rich export → import into a NEW document.
+	out, res := docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`"}`)
+	if res.IsError {
+		t.Fatalf("export_md: %q", res.Text)
+	}
+	md1 := out["markdown"].(string)
+	reqB, _ := json.Marshal(map[string]any{"op": "import_md", "scope": "user", "markdown": md1})
+	out, res = docExec(t, d, ctx, string(reqB))
+	if res.IsError {
+		t.Fatalf("import_md: %q", res.Text)
+	}
+	newDoc := out["document_id"].(string)
+	if newDoc == "" || newDoc == docID {
+		t.Fatalf("import_md (no document_id) must create a NEW document: %s", res.Text)
+	}
+	if int(out["chunks_created"].(float64)) != 4 {
+		t.Errorf("chunks_created = %v, want 4 (root + A + A1 + B): %s", out["chunks_created"], res.Text)
+	}
+
+	// Clean re-export of the new doc must equal a clean export of the original.
+	out, _ = docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+docID+`","include_metadata":false}`)
+	md0 := out["markdown"].(string)
+	out, res = docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+newDoc+`","include_metadata":false}`)
+	if res.IsError {
+		t.Fatalf("re-export: %q", res.Text)
+	}
+	if md2 := out["markdown"].(string); md2 != md0 {
+		t.Errorf("round-trip structural mismatch:\n--- original ---\n%s\n--- reimported ---\n%s", md0, md2)
+	}
+	// The graph edge was recreated (remapped) — the metadata-rich re-export has it.
+	out, _ = docExec(t, d, ctx, `{"op":"export_md","scope":"user","document_id":"`+newDoc+`"}`)
+	if !strings.Contains(out["markdown"].(string), "[references]") {
+		t.Errorf("edge not recreated on import:\n%s", out["markdown"])
 	}
 }
 

--- a/web/src/components/DocumentAssistantPanel.tsx
+++ b/web/src/components/DocumentAssistantPanel.tsx
@@ -1,0 +1,169 @@
+import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
+import { type DocScope, type LibraryEntry, listLibraryAgents } from "../api";
+import { usePrincipal } from "./Layout";
+import { useRunStream } from "../hooks/useRunStream";
+import LiveRunPane from "./LiveRunPane";
+
+// DocumentAssistantPanel is the RFC AM Phase 3 Document Assistant: instead of a
+// manual structural-editing UI, the operator types instructions and a
+// `doc-manager` agent performs the Document ops (semantic import, move, link,
+// delete). It reuses useRunStream + LiveRunPane wholesale.
+//
+// Lifecycle: lazy — the interactive run is spawned on the FIRST instruction
+// (token-responsible: opening a document doesn't start a run). Each instruction
+// is prefixed with a machine line "[ctx] selected_chunk_id=<id>" so the agent
+// always knows the live selection; the first one starts the run (metadata
+// {document_id, scope}), the rest steer it. The run's user_id is the principal's
+// subject, so the agent's Document tool (scope=user) operates on the same
+// documents the viewer shows. onChanged fires at each turn boundary to refresh.
+
+const ASSISTANT_AGENT = "doc-manager";
+
+export interface DocumentAssistantPanelProps {
+  documentId: string;
+  scope: DocScope;
+  selectedChunkId?: string;
+  onChanged: () => void;
+}
+
+export default function DocumentAssistantPanel({
+  documentId,
+  scope,
+  selectedChunkId,
+  onChanged,
+}: DocumentAssistantPanelProps) {
+  const principal = usePrincipal();
+  const run = useRunStream();
+  const [available, setAvailable] = useState<boolean | null>(null); // null = checking
+  const [started, setStarted] = useState(false);
+  const [draft, setDraft] = useState("");
+
+  // Read the live selection through a ref so the send closures aren't stale.
+  const chunkRef = useRef<string | undefined>(selectedChunkId);
+  useEffect(() => {
+    chunkRef.current = selectedChunkId;
+  }, [selectedChunkId]);
+
+  // Graceful degrade: confirm the assistant agent is registered.
+  useEffect(() => {
+    let cancelled = false;
+    listLibraryAgents()
+      .then((r) => {
+        if (cancelled) return;
+        const ok = (r.entries ?? []).some(
+          (e: LibraryEntry) => e.name === ASSISTANT_AGENT && (e.in_static || e.in_substrate),
+        );
+        setAvailable(ok);
+      })
+      .catch(() => !cancelled && setAvailable(false));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const withCtx = useCallback((text: string) => {
+    const id = chunkRef.current;
+    return id ? `[ctx] selected_chunk_id=${id}\n\n${text}` : text;
+  }, []);
+
+  const send = useCallback(
+    (text: string) => {
+      const t = text.trim();
+      if (!t) return;
+      if (!started) {
+        run.start({
+          agent: ASSISTANT_AGENT,
+          prompt: withCtx(t),
+          user_id: principal?.subject || undefined,
+          interactive: true,
+          metadata: { document_id: documentId, scope },
+        });
+        setStarted(true);
+      } else {
+        run.send(withCtx(t));
+      }
+    },
+    [started, run, withCtx, principal, documentId, scope],
+  );
+
+  // Refresh the viewer at each turn boundary: when the agent parks awaiting
+  // input, or when the run completes. Edge-triggered so it fires once per turn.
+  const prevAwait = useRef(false);
+  useEffect(() => {
+    if (run.awaitingInput && !prevAwait.current) onChanged();
+    prevAwait.current = run.awaitingInput;
+  }, [run.awaitingInput, onChanged]);
+  const prevDone = useRef(false);
+  useEffect(() => {
+    const done = run.status === "completed";
+    if (done && !prevDone.current) onChanged();
+    prevDone.current = done;
+  }, [run.status, onChanged]);
+
+  if (available === false) {
+    return (
+      <div className="doc-assistant doc-assistant-hint">
+        <p>
+          The Document Assistant needs the <code>{ASSISTANT_AGENT}</code> agent. Enable the{" "}
+          <code>bundles/document-agent</code> bundle (see its README), then reload.
+        </p>
+      </div>
+    );
+  }
+
+  if (started) {
+    return (
+      <div className="doc-assistant">
+        <LiveRunPane
+          events={run.events}
+          status={run.status}
+          agentId={run.agentId}
+          sessionId={run.sessionId}
+          runId={run.runId}
+          error={run.error}
+          onCancel={run.cancel}
+          onSend={send}
+          awaitingInput={run.awaitingInput}
+          lastUsage={run.lastUsage}
+          pendingInterrupt={run.pendingInterrupt}
+          onAnswerInterrupt={run.answerInterrupt}
+          compact
+        />
+      </div>
+    );
+  }
+
+  const submit = (e: FormEvent) => {
+    e.preventDefault();
+    send(draft);
+    setDraft("");
+  };
+  return (
+    <div className="doc-assistant">
+      <form className="doc-assistant-start" onSubmit={submit}>
+        <textarea
+          className="doc-assistant-input"
+          rows={2}
+          value={draft}
+          placeholder={
+            available === null
+              ? "Checking assistant…"
+              : "Ask the assistant to restructure, import, link, or clean up this document…"
+          }
+          disabled={available !== true}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send(draft);
+              setDraft("");
+            }
+          }}
+        />
+        <button type="submit" className="primary" disabled={available !== true || !draft.trim()}>
+          send
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/DocumentViewer.tsx
+++ b/web/src/components/DocumentViewer.tsx
@@ -13,6 +13,7 @@ import DocumentChunkTree, {
   type ChunkNode,
 } from "./DocumentChunkTree";
 import ChunkEditorModal from "./ChunkEditorModal";
+import DocumentAssistantPanel from "./DocumentAssistantPanel";
 import Markdown from "./Markdown";
 
 // DocumentViewer is the RFC AM Phase 2 read-mostly surface for one chunked-
@@ -43,6 +44,11 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [reload, setReload] = useState(0);
+  const [assistantOpen, setAssistantOpen] = useState(false);
+
+  // Stable refresh for the assistant panel (avoids re-firing its turn-boundary
+  // effect every render).
+  const refresh = useCallback(() => setReload((n) => n + 1), []);
 
   const tree = useMemo(() => buildChunkTree(chunks), [chunks]);
   const rootTitle = useMemo(() => {
@@ -183,7 +189,15 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
           <button type="button" onClick={() => void download()} title="Download as Markdown (.md)">
             ↓ .md
           </button>
-          <button type="button" onClick={() => setReload((n) => n + 1)} title="Reload">
+          <button
+            type="button"
+            className={assistantOpen ? "active" : ""}
+            onClick={() => setAssistantOpen((o) => !o)}
+            title="Document Assistant — instruct an agent to restructure/import/link chunks"
+          >
+            assistant
+          </button>
+          <button type="button" onClick={refresh} title="Reload">
             ↻
           </button>
         </div>
@@ -248,12 +262,20 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
           </div>
         </div>
       )}
+      {assistantOpen && (
+        <DocumentAssistantPanel
+          documentId={documentId}
+          scope={scope}
+          selectedChunkId={selectedId}
+          onChanged={refresh}
+        />
+      )}
       {editing && (
         <ChunkEditorModal
           chunk={editing}
           scope={scope}
           onClose={() => setEditing(null)}
-          onSaved={() => setReload((n) => n + 1)}
+          onSaved={refresh}
         />
       )}
     </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5324,3 +5324,57 @@ button.primary:disabled {
 .md a {
   color: var(--accent);
 }
+
+/* ───────────────────────────────────────────────────────────────────────────
+ * RFC AM Phase 3 — Document Assistant panel (a steered doc-manager run).
+ * ─────────────────────────────────────────────────────────────────────────── */
+.doc-toolbar-actions button.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.doc-assistant {
+  flex: 0 0 auto;
+  max-height: 45%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+  border-top: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.doc-assistant-hint {
+  padding: 12px 14px;
+  font-size: var(--lc-text-sm, 13px);
+  color: var(--fg-soft);
+}
+.doc-assistant-start {
+  display: flex;
+  gap: 8px;
+  padding: 10px 12px;
+  align-items: flex-end;
+}
+.doc-assistant-input {
+  flex: 1;
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  resize: vertical;
+  box-sizing: border-box;
+}
+.doc-assistant-start button.primary {
+  background: var(--accent);
+  color: white;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+}
+.doc-assistant-start button.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Why

RFC AM **Phase 3 — the final phase** (Phase 1 = Path console #543, Phase 2 = Document viewer #544, both merged). This adds the deterministic `import_md` op, the first-class `doc-manager` bundle, and the **Document Assistant** — so document *restructuring* is done by a text-driven agent rather than a complex manual UI.

## What

**Backend — `Document.import_md`** (RFC AK §4.5; a new op on the existing tool → rides `connector.Document` everywhere, no new RPC). The deterministic inverse of `export_md`: parses headings into the chunk hierarchy, reads `<!-- loom: … -->` metadata + the `<!-- loom-edges: … -->` trailer. No `document_id` → new document (first heading = root); `document_id` (+ optional `parent_id`) → import under an existing chunk. Fresh ids; the edge graph is remapped (unmapped endpoints skipped). Composes the existing create/link ops (not atomic — a mid-import failure leaves a partial document the caller can delete + retry).

**Bundle — `bundles/document-agent/`** (a new top-level `bundles/`, *not* `examples/`): the `doc-manager` agent (`allowed_tools [Document, Memory, Context]`, `sql_scopes`/`memory_scopes [user]`) + four skills (semantic-chunking, edge-linking, restructuring, md-import) + a sample `.md` + a README. Boot-verified: it loads the 4 skills and `doc-manager` registers (`GET /v1/_library/agents`). loomcycle has no built-in-agent-in-binary mechanism yet (a named deferred follow-up), so it ships as a bundle the operator registers.

**Web UI — the Document Assistant** (`DocumentAssistantPanel`, an `assistant` toggle in the viewer): reuses `useRunStream` + `LiveRunPane`. **Lazy** — the interactive run spawns on the *first* instruction (opening a doc starts nothing). Each instruction is prefixed with `[ctx] selected_chunk_id=<id>` (read via a ref, always live); the first starts the run with `metadata {document_id, scope}`, the rest **steer** it. `user_id = principal.subject` so the agent's `Document` tool (`scope=user`) operates on the same documents the viewer shows; the viewer refreshes at each turn boundary. **Graceful degrade**: if `doc-manager` isn't registered, the panel shows a hint pointing at the bundle.

## What was tested

- **`go test ./...`** clean (73 packages). `TestDocument_ImportMD_RoundTrip` (export → import-new → re-export is structurally identical; the graph edge survives remapped) + an `import_md` call in the **postgres-tier** parity test.
- **Bundle boot**: `loomcycle --config bundles/document-agent/loomcycle.yaml` → "skills: loaded 4" + `doc-manager` in the library list.
- **SPA**: `tsc` + `vite build` clean. The Assistant spawn request (agent + `interactive` + `metadata`) is accepted and resolves `doc-manager` + its tier server-side (verified via a live `POST /v1/runs`); the live LLM turn needs a working provider (not exercised in CI) and reuses the same run/steer path as the `/run` terminal.

## Scope / notes

- **`import_md` chunk boundaries are heading lines** — a body containing `##` re-chunks; arbitrary prose goes through the agent's semantic chunking. Documented.
- **RFC AM is now feature-complete** (Path console → Document viewer → agent). README "What's shipped" + `REVISIONS.md` + adapter/version bumps are deferred to a separate **release-prep PR** (the established pattern, e.g. v1.4.0 #542) — this PR is feature + feature-docs only, no tag.
- Deferred follow-ups (unchanged): built-in-by-default `doc-manager` (needs a built-in-agent mechanism); the cleanup items from the Phase 1/2 review (#8–#11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
