### PR TITLE
fix(webui): Document Assistant injects outline + selected chunk on start

### DIFF
--- a/bundles/document-agent/README.md
+++ b/bundles/document-agent/README.md
@@ -62,12 +62,14 @@ broken spawn.
 ## How the Assistant drives it
 
 When you open a Document in the Web UI and use the Assistant, the panel spawns a
-single **interactive** run of `doc-manager` with `metadata: {document_id, scope}`
-and steers each instruction in, prefixed with a machine line
-`[ctx] selected_chunk_id=<id>` so the agent always knows your live selection. The
-agent reads with `query_chunks`/`get_chunk` and edits with the other `Document`
-ops, all in **`user` scope** — the same scope the viewer shows (the run's
-user_id is your principal subject), so its edits appear when the viewer refreshes.
+single **interactive** run of `doc-manager` and steers each instruction in,
+prefixed with a `[context]` block: the **first** turn carries the document
+**outline** (every chunk's title/type/status/id) plus the **selected chunk's
+full content**, so the agent is grounded immediately; later turns carry the live
+selection's current content. The agent re-reads with `query_chunks`/`get_chunk`
+and edits with the other `Document` ops, all in **`user` scope** — the same scope
+the viewer shows (the run's user_id is your principal subject), so its edits
+appear when the viewer refreshes.
 
 ## Forward path
 

--- a/bundles/document-agent/loomcycle.yaml
+++ b/bundles/document-agent/loomcycle.yaml
@@ -48,10 +48,14 @@ agents:
       chunks by hand.
 
       ## Awareness
-      Your run metadata carries {document_id, scope}. Each operator turn begins
-      with a machine line "[ctx] selected_chunk_id=<id>" — the chunk the operator
-      currently has selected. Operate relative to it unless told otherwise. The
-      selection changes between turns; always honor the latest [ctx] line.
+      Each operator turn begins with a `[context] … [/context]` block. The FIRST
+      turn carries the document OUTLINE (every chunk's title/type/status/id) plus
+      the SELECTED chunk's full content; later turns carry the live selection's
+      current content. `document_id`, `scope`, and `selected_chunk_id` are on the
+      first `[context]` line. Operate relative to the selected chunk unless told
+      otherwise; the selection changes between turns — always honor the latest
+      block. The content there is a snapshot — if you've already changed the
+      document, re-read with query_chunks/get_chunk before the next mutation.
 
       ## How you work
       - Read before you write: Document op=query_chunks (document_id from the

--- a/bundles/document-agent/loomcycle_oauth.yaml
+++ b/bundles/document-agent/loomcycle_oauth.yaml
@@ -94,10 +94,14 @@ agents:
       chunks by hand.
 
       ## Awareness
-      Your run metadata carries {document_id, scope}. Each operator turn begins
-      with a machine line "[ctx] selected_chunk_id=<id>" — the chunk the operator
-      currently has selected. Operate relative to it unless told otherwise. The
-      selection changes between turns; always honor the latest [ctx] line.
+      Each operator turn begins with a `[context] … [/context]` block. The FIRST
+      turn carries the document OUTLINE (every chunk's title/type/status/id) plus
+      the SELECTED chunk's full content; later turns carry the live selection's
+      current content. `document_id`, `scope`, and `selected_chunk_id` are on the
+      first `[context]` line. Operate relative to the selected chunk unless told
+      otherwise; the selection changes between turns — always honor the latest
+      block. The content there is a snapshot — if you've already changed the
+      document, re-read with query_chunks/get_chunk before the next mutation.
 
       ## How you work
       - Read before you write: Document op=query_chunks (document_id from the

--- a/web/src/components/DocumentAssistantPanel.tsx
+++ b/web/src/components/DocumentAssistantPanel.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
-import { type DocScope, type LibraryEntry, listLibraryAgents } from "../api";
+import { type ChunkDetail, type ChunkRow, type DocScope, type LibraryEntry, listLibraryAgents } from "../api";
 import { usePrincipal } from "./Layout";
 import { useRunStream } from "../hooks/useRunStream";
+import { buildChunkTree, type ChunkNode } from "./DocumentChunkTree";
 import LiveRunPane from "./LiveRunPane";
 
 // DocumentAssistantPanel is the RFC AM Phase 3 Document Assistant: instead of a
@@ -10,26 +11,68 @@ import LiveRunPane from "./LiveRunPane";
 // delete). It reuses useRunStream + LiveRunPane wholesale.
 //
 // Lifecycle: lazy — the interactive run is spawned on the FIRST instruction
-// (token-responsible: opening a document doesn't start a run). Each instruction
-// is prefixed with a machine line "[ctx] selected_chunk_id=<id>" so the agent
-// always knows the live selection; the first one starts the run (metadata
-// {document_id, scope}), the rest steer it. The run's user_id is the principal's
-// subject, so the agent's Document tool (scope=user) operates on the same
-// documents the viewer shows. onChanged fires at each turn boundary to refresh.
+// (token-responsible: opening a document doesn't start a run). The first
+// instruction is prefixed with a `[context]` block carrying the document
+// OUTLINE (every chunk's title/type/status/id) + the SELECTED chunk's full
+// content (title/fields/body), so the agent is grounded from turn one instead
+// of having to blind-probe. Each steer keeps a lighter preamble with the live
+// selection's current content. The run's user_id is the principal's subject, so
+// the agent's Document tool (scope=user) operates on the same documents the
+// viewer shows. onChanged fires at each turn boundary to refresh.
 
 const ASSISTANT_AGENT = "doc-manager";
+// Cap the injected outline so a huge document can't blow up the first prompt.
+const MAX_OUTLINE_CHUNKS = 200;
 
 export interface DocumentAssistantPanelProps {
   documentId: string;
   scope: DocScope;
   selectedChunkId?: string;
+  // The viewer's already-loaded structure + selected-chunk content, injected as
+  // start context so the agent reads the document + selected chunk on turn one.
+  chunks: ChunkRow[];
+  selectedChunk: ChunkDetail | null;
   onChanged: () => void;
+}
+
+// outlineText renders the chunk hierarchy as an indented, body-less list
+// (title + id + type/status), marking the selected chunk. Bounded by
+// MAX_OUTLINE_CHUNKS so a large document degrades to "… use query_chunks".
+function outlineText(chunks: ChunkRow[], selectedId?: string): string {
+  const roots = buildChunkTree(chunks);
+  const lines: string[] = [];
+  let truncated = false;
+  const walk = (n: ChunkNode, depth: number) => {
+    if (lines.length >= MAX_OUTLINE_CHUNKS) {
+      truncated = true;
+      return;
+    }
+    const r = n.row;
+    const meta = [r.type, r.status].filter(Boolean).join("/");
+    const sel = r.id === selectedId ? "  ← selected" : "";
+    lines.push(`${"  ".repeat(depth)}- ${r.title || "(untitled)"} [${r.id}${meta ? " " + meta : ""}]${sel}`);
+    n.children.forEach((c) => walk(c, depth + 1));
+  };
+  roots.forEach((n) => walk(n, 0));
+  if (truncated) lines.push(`  … (${chunks.length} chunks total — use Document op=query_chunks for the rest)`);
+  return lines.join("\n");
+}
+
+// selectedBlock renders one chunk's full content for the agent to act on.
+function selectedBlock(c: ChunkDetail): string {
+  const meta = [c.type && `type=${c.type}`, c.status && `status=${c.status}`, `rev=${c.revision}`]
+    .filter(Boolean)
+    .join(" ");
+  const fields = c.fields ? `\nfields: ${JSON.stringify(c.fields)}` : "";
+  return `selected chunk [${c.id}] ${meta}\ntitle: ${c.title}${fields}\nbody:\n${c.body || "(empty)"}`;
 }
 
 export default function DocumentAssistantPanel({
   documentId,
   scope,
   selectedChunkId,
+  chunks,
+  selectedChunk,
   onChanged,
 }: DocumentAssistantPanelProps) {
   const principal = usePrincipal();
@@ -38,11 +81,16 @@ export default function DocumentAssistantPanel({
   const [started, setStarted] = useState(false);
   const [draft, setDraft] = useState("");
 
-  // Read the live selection through a ref so the send closures aren't stale.
+  // Read the live selection + loaded content through refs so the send closures
+  // always reflect the current viewer state (selection changes between turns).
   const chunkRef = useRef<string | undefined>(selectedChunkId);
+  const chunksRef = useRef<ChunkRow[]>(chunks);
+  const selectedRef = useRef<ChunkDetail | null>(selectedChunk);
   useEffect(() => {
     chunkRef.current = selectedChunkId;
-  }, [selectedChunkId]);
+    chunksRef.current = chunks;
+    selectedRef.current = selectedChunk;
+  }, [selectedChunkId, chunks, selectedChunk]);
 
   // Graceful degrade: confirm the assistant agent is registered.
   useEffect(() => {
@@ -61,10 +109,22 @@ export default function DocumentAssistantPanel({
     };
   }, []);
 
-  const withCtx = useCallback((text: string) => {
+  // contextPreamble grounds the agent in the live document state. On the FIRST
+  // turn it includes the full outline + selected-chunk content; later turns keep
+  // a lighter block (the selected chunk's current content) — the agent already
+  // has the outline and re-reads via query_chunks as it works.
+  const contextPreamble = useCallback((first: boolean) => {
     const id = chunkRef.current;
-    return id ? `[ctx] selected_chunk_id=${id}\n\n${text}` : text;
-  }, []);
+    const lines = [`[context] document_id=${documentId} scope=${scope}${id ? ` selected_chunk_id=${id}` : ""}`];
+    if (first && chunksRef.current.length > 0) {
+      lines.push("", "document outline (titles only — get_chunk for any body):", outlineText(chunksRef.current, id));
+    }
+    if (selectedRef.current && selectedRef.current.id === id) {
+      lines.push("", selectedBlock(selectedRef.current));
+    }
+    lines.push("[/context]");
+    return lines.join("\n");
+  }, [documentId, scope]);
 
   const send = useCallback(
     (text: string) => {
@@ -73,17 +133,17 @@ export default function DocumentAssistantPanel({
       if (!started) {
         run.start({
           agent: ASSISTANT_AGENT,
-          prompt: withCtx(t),
+          prompt: `${contextPreamble(true)}\n\n${t}`,
           user_id: principal?.subject || undefined,
           interactive: true,
-          metadata: { document_id: documentId, scope },
+          metadata: { document_id: documentId, scope, selected_chunk_id: chunkRef.current || "" },
         });
         setStarted(true);
       } else {
-        run.send(withCtx(t));
+        run.send(`${contextPreamble(false)}\n\n${t}`);
       }
     },
-    [started, run, withCtx, principal, documentId, scope],
+    [started, run, contextPreamble, principal, documentId, scope],
   );
 
   // Refresh the viewer at each turn boundary: when the agent parks awaiting

--- a/web/src/components/DocumentViewer.tsx
+++ b/web/src/components/DocumentViewer.tsx
@@ -267,6 +267,8 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
           documentId={documentId}
           scope={scope}
           selectedChunkId={selectedId}
+          chunks={chunks}
+          selectedChunk={selectedDetail}
           onChanged={refresh}
         />
       )}


### PR DESCRIPTION
## Why

Testing the RFC AM Phase 3 Document Assistant surfaced this: the panel only sent the `document_id` + a `[ctx] selected_chunk_id=<id>` line, so the `doc-manager` agent started **blind to the actual content** — it had to blind-probe (or guess) before it was grounded. "Otherwise it is out of context."

## What

The panel now injects a `[context]` block built from the viewer's **already-loaded** data (no extra fetches — `DocumentViewer` passes its `chunks` + `selectedDetail` down):

- **First turn**: the document **outline** (every chunk's `title [id type/status]`, indented by hierarchy, the selected one marked, bounded at 200 chunks with a "use query_chunks" note) **plus the selected chunk's full content** (title / fields / body). So the agent reads the document + selected chunk on turn one.
- **Later turns**: a lighter block with the live selection's current content (the agent already has the outline and re-reads via `query_chunks`/`get_chunk` as it works — the block notes the content is a snapshot).

`metadata` now also carries `selected_chunk_id`. The bundle agent prompts (both `loomcycle.yaml` and `loomcycle_oauth.yaml`) + the bundle README describe the new `[context]` block.

## What was tested

- `tsc --noEmit` + `vite build` clean.
- The bundle still loads after the prompt edit: `loomcycle --config bundles/document-agent/loomcycle.yaml` → `skills: loaded 4`, `doc-manager` registers (`GET /v1/_library/agents`).
- No Go logic changed (SPA + bundle yaml/README only); the binary rebuild just re-embeds the new SPA.

## Notes

- Outline is **titles only** (bounded by chunk count, not content size) + one chunk's body — keeps the first prompt reasonable; large docs degrade to "… use query_chunks".
- The selected-chunk block is only injected when the loaded detail matches the current `selected_chunk_id` (guards against a stale snapshot showing the wrong chunk).
- Follow-up to the merged RFC AM Phase 3 (#545); surfaced during the operator's testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
