### PR TITLE
fix(webui): auto-close the Document Assistant when its run stops

### DIFF
--- a/web/src/components/DocumentAssistantPanel.tsx
+++ b/web/src/components/DocumentAssistantPanel.tsx
@@ -18,7 +18,8 @@ import LiveRunPane from "./LiveRunPane";
 // of having to blind-probe. Each steer keeps a lighter preamble with the live
 // selection's current content. The run's user_id is the principal's subject, so
 // the agent's Document tool (scope=user) operates on the same documents the
-// viewer shows. onChanged fires at each turn boundary to refresh.
+// viewer shows. onChanged fires at each turn boundary to refresh; onStopped
+// fires when the run reaches a terminal state so the viewer closes the panel.
 
 const ASSISTANT_AGENT = "doc-manager";
 // Cap the injected outline so a huge document can't blow up the first prompt.
@@ -33,6 +34,9 @@ export interface DocumentAssistantPanelProps {
   chunks: ChunkRow[];
   selectedChunk: ChunkDetail | null;
   onChanged: () => void;
+  // Called when the run stops (completed/cancelled/failed) so the viewer can
+  // close the panel; `error` is set only on failure (so it isn't lost on close).
+  onStopped: (error?: string) => void;
 }
 
 // outlineText renders the chunk hierarchy as an indented, body-less list
@@ -74,6 +78,7 @@ export default function DocumentAssistantPanel({
   chunks,
   selectedChunk,
   onChanged,
+  onStopped,
 }: DocumentAssistantPanelProps) {
   const principal = usePrincipal();
   const run = useRunStream();
@@ -146,19 +151,28 @@ export default function DocumentAssistantPanel({
     [started, run, contextPreamble, principal, documentId, scope],
   );
 
-  // Refresh the viewer at each turn boundary: when the agent parks awaiting
-  // input, or when the run completes. Edge-triggered so it fires once per turn.
+  // Refresh the viewer when the agent parks awaiting input (a turn finished).
+  // Edge-triggered so it fires once per turn.
   const prevAwait = useRef(false);
   useEffect(() => {
     if (run.awaitingInput && !prevAwait.current) onChanged();
     prevAwait.current = run.awaitingInput;
   }, [run.awaitingInput, onChanged]);
-  const prevDone = useRef(false);
+
+  // When the run STOPS (completed / cancelled / failed — i.e. no longer running
+  // or parked), refresh once more and close the panel. On failure surface the
+  // error to the viewer so it isn't lost when the panel disappears. Edge-
+  // triggered + gated on `started` so the initial idle state doesn't trigger it.
+  const prevTerminal = useRef(false);
   useEffect(() => {
-    const done = run.status === "completed";
-    if (done && !prevDone.current) onChanged();
-    prevDone.current = done;
-  }, [run.status, onChanged]);
+    const terminal =
+      run.status === "completed" || run.status === "cancelled" || run.status === "failed";
+    if (started && terminal && !prevTerminal.current) {
+      onChanged();
+      onStopped(run.status === "failed" ? run.error || "the assistant run failed" : undefined);
+    }
+    prevTerminal.current = terminal;
+  }, [run.status, run.error, started, onChanged, onStopped]);
 
   if (available === false) {
     return (

--- a/web/src/components/DocumentViewer.tsx
+++ b/web/src/components/DocumentViewer.tsx
@@ -270,6 +270,10 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
           chunks={chunks}
           selectedChunk={selectedDetail}
           onChanged={refresh}
+          onStopped={(e) => {
+            setAssistantOpen(false);
+            if (e) setErr("Assistant: " + e);
+          }}
         />
       )}
       {editing && (


### PR DESCRIPTION
## Why

Testing surfaced it: when the assistant's interactive run reaches a terminal state — you hit **Cancel** in the panel, or the run completes/fails — the panel stayed open showing a dead/idle session. It should close when the agent stops.

## What

`DocumentAssistantPanel` gains an `onStopped(error?)` callback. A terminal-status effect (edge-triggered, gated on `started` so the initial idle state doesn't fire it) runs when `status` becomes `completed` / `cancelled` / `failed`: it refreshes the viewer once more (the agent may have edited before stopping) and calls `onStopped`. `DocumentViewer` closes the panel (`setAssistantOpen(false)`) and, on **failure**, surfaces the error in its banner so it isn't lost when the panel disappears. Reopening the panel remounts a fresh run (the parked/interactive flow is unchanged — a panel that's still *running or parked* stays open).

## Tested

- `tsc --noEmit` + `vite build` clean. WebUI-only — no Go change.
- Logic walk-through: parked turns (status `running` + `awaitingInput`) keep the panel open; only a terminal status closes it; Cancel → `cancelled` → close; a failed spawn → `failed` → close + error in the viewer banner.

Follow-up to the merged RFC AM Phase 3 (#545) Document Assistant; surfaced during the operator's testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
