### PR TITLE
feat(mcp): per-operation scope gate + tools/list filter on /v1/_mcp

### DIFF
--- a/internal/api/mcp/server.go
+++ b/internal/api/mcp/server.go
@@ -331,7 +331,7 @@ func (s *Server) handleFrame(ctx context.Context, frame []byte, stdout io.Writer
 	case "initialize":
 		s.handleInitialize(stdout, req)
 	case "tools/list":
-		s.handleToolsList(stdout, req)
+		s.handleToolsList(ctx, stdout, req)
 	case "tools/call":
 		s.handleToolsCall(ctx, stdout, req)
 	default:
@@ -394,9 +394,18 @@ func (s *Server) handleInitialize(stdout io.Writer, req loommcp.Request) {
 	s.writeResult(stdout, req.ID, result)
 }
 
-// handleToolsList returns the static tool descriptor catalogue.
-func (s *Server) handleToolsList(stdout io.Writer, req loommcp.Request) {
-	descs := toolDescriptors()
+// handleToolsList returns the tool descriptor catalogue, filtered to the tools
+// the authenticated principal may call (RFC AG §3.3). A non-admin (substrate:
+// tenant) session never sees the admin-only meta-tools; stdio / admin sessions
+// see everything. The hide is UX — the tools/call gate is the enforcement.
+func (s *Server) handleToolsList(ctx context.Context, stdout io.Writer, req loommcp.Request) {
+	all := toolDescriptors()
+	descs := make([]loommcp.ToolDescriptor, 0, len(all))
+	for _, d := range all {
+		if principalMayCallTool(ctx, d.Name) {
+			descs = append(descs, d)
+		}
+	}
 	result := loommcp.ToolsListResult{Tools: descs}
 	s.writeResult(stdout, req.ID, result)
 }
@@ -414,6 +423,15 @@ func (s *Server) handleToolsCall(ctx context.Context, stdout io.Writer, req loom
 	handler, ok := toolHandlerByName(params.Name)
 	if !ok {
 		s.writeError(stdout, req.ID, -32601, "unknown tool: "+params.Name)
+		return
+	}
+
+	// Per-operation authz (RFC AG §3.3). A non-admin principal that calls an
+	// admin-only meta-tool (hidden from its tools/list) is refused here — the
+	// gate, not the hide, is the enforcement boundary. No principal (stdio) or
+	// an admin principal passes through unchanged.
+	if !principalMayCallTool(ctx, params.Name) {
+		s.writeError(stdout, req.ID, mcpErrForbidden, params.Name+": forbidden — requires substrate:admin")
 		return
 	}
 

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -304,8 +305,16 @@ func (m *mockConnector) BroadcastChannels(context.Context, connector.ChannelBroa
 // captured separately.
 func driveServer(t *testing.T, srv *Server, input string) (responses []loommcp.Response, notifications []loommcp.Notification) {
 	t.Helper()
+	return driveServerCtx(t, srv, context.Background(), input)
+}
+
+// driveServerCtx is driveServer with a caller-supplied base ctx — used to drive
+// the server as a specific authenticated principal (auth.WithPrincipal) so the
+// tools/list filter + tools/call gate (RFC AG §3.3) can be exercised.
+func driveServerCtx(t *testing.T, srv *Server, base context.Context, input string) (responses []loommcp.Response, notifications []loommcp.Notification) {
+	t.Helper()
 	stdout := &bytes.Buffer{}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(base, 5*time.Second)
 	defer cancel()
 	if err := srv.Serve(ctx, strings.NewReader(input), stdout); err != nil {
 		t.Fatalf("Serve: %v", err)
@@ -392,6 +401,77 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 		if !names[want] {
 			t.Errorf("missing tool %q in tools/list", want)
 		}
+	}
+}
+
+// TestServer_ToolsList_FiltersAdminToolsForTenant drives tools/list as a
+// non-admin (substrate:tenant) principal and asserts the admin-only meta-tools
+// are absent while the tenant-confinable ones remain (RFC AG §3.3). Contrast
+// with TestServer_ToolsList_ReturnsFullCatalogue (no principal → full set).
+func TestServer_ToolsList_FiltersAdminToolsForTenant(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{"substrate:tenant"}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}` + "\n"
+	resps, _ := driveServerCtx(t, srv, ctx, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	var result loommcp.ToolsListResult
+	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	names := map[string]bool{}
+	for _, td := range result.Tools {
+		names[td.Name] = true
+	}
+	for _, hidden := range []string{"operatortokendef", "pause_runtime", "restore_snapshot", "list_channels", "register_hook", "delete_hook"} {
+		if names[hidden] {
+			t.Errorf("admin-only tool %q must be hidden from a tenant principal's tools/list", hidden)
+		}
+	}
+	for _, shown := range []string{"document", "agentdef", "memory", "spawn_run", "path", "context"} {
+		if !names[shown] {
+			t.Errorf("tenant-confinable tool %q must remain in a tenant principal's tools/list", shown)
+		}
+	}
+}
+
+// TestServer_ToolsCall_GatesAdminToolForTenant is the RFC AG §3.3 / §6
+// enforcement test: a non-admin principal that calls a (hidden) admin-only tool
+// anyway gets a clean forbidden error — the gate, not just the hide. Fail-before:
+// drop the principalMayCallTool check in handleToolsCall and the call dispatches
+// (pause_runtime returns a tool result instead of mcpErrForbidden).
+func TestServer_ToolsCall_GatesAdminToolForTenant(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{"substrate:tenant"}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pause_runtime","arguments":{}}}` + "\n"
+	resps, _ := driveServerCtx(t, srv, ctx, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error == nil {
+		t.Fatalf("expected a JSON-RPC error for a gated tool, got result: %s", resps[0].Result)
+	}
+	if resps[0].Error.Code != mcpErrForbidden {
+		t.Errorf("error code = %d, want mcpErrForbidden (%d)", resps[0].Error.Code, mcpErrForbidden)
+	}
+}
+
+// TestServer_ToolsCall_AdminToolAllowedForNoPrincipal confirms the gate is inert
+// on the stdio / no-principal path: pause_runtime dispatches (operator-trust),
+// it is NOT a forbidden error. (It may surface a tool-level error from the mock
+// connector, but never mcpErrForbidden.)
+func TestServer_ToolsCall_AdminToolAllowedForNoPrincipal(t *testing.T) {
+	srv := New(Config{Connector: &mockConnector{}, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"pause_runtime","arguments":{}}}` + "\n"
+	resps, _ := driveServer(t, srv, in)
+	if len(resps) != 1 {
+		t.Fatalf("got %d responses, want 1", len(resps))
+	}
+	if resps[0].Error != nil && resps[0].Error.Code == mcpErrForbidden {
+		t.Errorf("no-principal (stdio) path must not be gated; got forbidden error")
 	}
 }
 

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -1,0 +1,127 @@
+package mcp
+
+import (
+	"context"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// mcpErrForbidden is the JSON-RPC error code returned when a principal calls a
+// meta-tool its scopes don't permit. It sits in the implementation-defined
+// server-error range (-32000..-32099) so a client can distinguish "forbidden"
+// from -32601 "unknown tool" and -32603 "internal error".
+const mcpErrForbidden = -32001
+
+// tenantConfinableTools is the explicit allowlist of /v1/_mcp meta-tools a
+// non-admin (substrate:tenant) principal may list + call. Membership means the
+// underlying tool keys on RunIdentity.TenantID — so the mcpPrincipalCtx tenant
+// stamp plus the tool's own tenant filter confine it — NOT that this map grants
+// any capability itself.
+//
+// A tool ABSENT from this set requires substrate:admin: deny-by-default, so a
+// newly added meta-tool is admin-only until it is explicitly classified
+// tenant-safe here (RFC AG §2 / §5). This mirrors requiredScopeFor's
+// default-deny arm on the HTTP plane — the enforcement-correctness lives in this
+// map, not the router, so an unclassified tool must fail closed.
+//
+// The route gate keeps /v1/_mcp at substrate:admin today (RFC AG Phase 2 opens
+// it to tenant tokens), so for real traffic every caller is admin and this map
+// is inert. It is built + tested now as defense-in-depth, ahead of the flip.
+var tenantConfinableTools = map[string]bool{
+	// Run lifecycle — tenant flows via the run identity (applyPrincipal on
+	// the wire identity lands in RFC AG Phase 1).
+	"spawn_run":   true,
+	"spawn_runs":  true,
+	"cancel_run":  true,
+	"get_run":     true,
+	"compact_run": true,
+	"list_runs":   true,
+
+	// Agent management.
+	"register_agent":   true,
+	"unregister_agent": true,
+	"list_agents":      true,
+
+	// Def authoring — each stamps the row's tenant from ctx and opaque-404s
+	// cross-tenant reads.
+	"agentdef":         true,
+	"skilldef":         true,
+	"mcpserverdef":     true,
+	"scheduledef":      true,
+	"a2aservercarddef": true,
+	"a2aagentdef":      true,
+	"webhookdef":       true,
+	"memorybackenddef": true,
+	"volumedef":        true,
+
+	// Per-(scope, scope_id, tenant) data tools.
+	"memory":     true,
+	"channel":    true,
+	"channeldef": true,
+	"path":       true,
+	"document":   true,
+
+	// Per-run / per-user — tenant inherited; the underlying tool applies its
+	// own own-subject / cross-tenant-404 gate.
+	"evaluation":             true,
+	"context":                true,
+	"interruption_resolve":   true,
+	"publish_channel":        true,
+	"subscribe_channel":      true,
+	"peek_channel":           true,
+	"ack_channel":            true,
+	"stream_user_run_states": true,
+}
+
+// adminOnlyTools enumerates the runtime-global / operator-plane meta-tools that
+// have NO tenant dimension and so cannot be confined — they stay admin-only
+// (RFC AG §2). The gate does NOT consult this set (it relies on
+// tenantConfinableTools + deny-by-default); it exists so the drift test can
+// assert every dispatchable tool is *consciously* classified as one or the
+// other, and that the two sets are disjoint. Adding a meta-tool without
+// classifying it here turns the drift test red.
+var adminOnlyTools = map[string]bool{
+	"operatortokendef": true, // token minting — no tenant dimension.
+
+	// Runtime-global control + introspection.
+	"pause_runtime":     true,
+	"resume_runtime":    true,
+	"get_runtime_state": true,
+	"resolve_probe":     true,
+
+	// Snapshots capture / restore cross-tenant state.
+	"create_snapshot":  true,
+	"list_snapshots":   true,
+	"get_snapshot":     true,
+	"export_snapshot":  true,
+	"restore_snapshot": true,
+	"delete_snapshot":  true,
+
+	// Hook management is tenant-isolated after PR #508, so RFC AG §2 flags it
+	// as a Phase-2 promotion candidate; keep it admin-only until the route opens.
+	"register_hook": true,
+	"list_hooks":    true,
+	"delete_hook":   true,
+
+	// Operator aggregate over every scope.
+	"list_channels": true,
+}
+
+// principalMayCallTool reports whether the principal on ctx may list/invoke
+// toolName over the /v1/_mcp transport (RFC AG §3.3):
+//
+//   - No principal (stdio / open mode): process-local operator-trust → every tool.
+//   - Admin principal (substrate:admin, incl. the legacy token): every tool.
+//   - Non-admin (substrate:tenant) principal: only the tenant-confinable
+//     allowlist; everything else — including an unclassified new tool — is
+//     admin-only (deny-by-default).
+func principalMayCallTool(ctx context.Context, toolName string) bool {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok {
+		return true
+	}
+	if auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return true
+	}
+	return tenantConfinableTools[toolName]
+}

--- a/internal/api/mcp/toolauthz_test.go
+++ b/internal/api/mcp/toolauthz_test.go
@@ -1,0 +1,100 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// TestToolClassification_EveryDispatchableToolClassified is the drift guard for
+// RFC AG §3.3: every tool in handlersByName must be CONSCIOUSLY classified as
+// either tenant-confinable or admin-only, and the two sets must be disjoint and
+// contain no phantom (non-dispatchable) names. Adding a meta-tool to
+// handlersByName without classifying it turns this test red — which is the
+// point: the gate fails closed (deny-by-default → admin), but a silent
+// admin-only default for a tool that SHOULD be tenant-safe is a usability bug we
+// want caught at compile-test time, not in production.
+func TestToolClassification_EveryDispatchableToolClassified(t *testing.T) {
+	for name := range handlersByName {
+		inTenant := tenantConfinableTools[name]
+		inAdmin := adminOnlyTools[name]
+		switch {
+		case inTenant && inAdmin:
+			t.Errorf("tool %q is in BOTH tenantConfinableTools and adminOnlyTools (must be exactly one)", name)
+		case !inTenant && !inAdmin:
+			t.Errorf("tool %q is dispatchable but UNCLASSIFIED — add it to tenantConfinableTools or adminOnlyTools (RFC AG §3.3)", name)
+		}
+	}
+	// No phantom classifications: every classified name must be dispatchable.
+	for name := range tenantConfinableTools {
+		if _, ok := handlersByName[name]; !ok {
+			t.Errorf("tenantConfinableTools has %q which is not in handlersByName (stale entry)", name)
+		}
+	}
+	for name := range adminOnlyTools {
+		if _, ok := handlersByName[name]; !ok {
+			t.Errorf("adminOnlyTools has %q which is not in handlersByName (stale entry)", name)
+		}
+	}
+}
+
+// TestPrincipalMayCallTool_NoPrincipal pins the stdio / open-mode path: with no
+// authenticated principal on ctx, every tool — including admin-only ones — is
+// callable (process-local operator-trust). Regressing this would break the
+// stdio MCP server (Claude Code etc.).
+func TestPrincipalMayCallTool_NoPrincipal(t *testing.T) {
+	ctx := context.Background()
+	for _, name := range []string{"document", "agentdef", "operatortokendef", "restore_snapshot"} {
+		if !principalMayCallTool(ctx, name) {
+			t.Errorf("no-principal path must allow %q (operator-trust)", name)
+		}
+	}
+}
+
+// TestPrincipalMayCallTool_Admin: an admin principal (incl. the legacy token,
+// which carries ScopeAdmin) may call every tool.
+func TestPrincipalMayCallTool_Admin(t *testing.T) {
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "root", Scopes: []string{auth.ScopeAdmin}})
+	for name := range handlersByName {
+		if !principalMayCallTool(ctx, name) {
+			t.Errorf("admin principal must be allowed %q", name)
+		}
+	}
+}
+
+// TestPrincipalMayCallTool_NonAdmin is the load-bearing assertion for RFC AG
+// Phase 2: a substrate:tenant principal may call the tenant-confinable tools
+// (document/agentdef/memory/spawn_run/…) but NOT the admin-only ones
+// (operatortokendef/restore_snapshot/pause_runtime/list_channels/register_hook).
+// This is the enforcement the route-flip relies on.
+func TestPrincipalMayCallTool_NonAdmin(t *testing.T) {
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{"substrate:tenant"}})
+
+	allowed := []string{"document", "agentdef", "skilldef", "memory", "channel", "path", "spawn_run", "context", "evaluation"}
+	for _, name := range allowed {
+		if !principalMayCallTool(ctx, name) {
+			t.Errorf("tenant principal must be allowed tenant-confinable tool %q", name)
+		}
+	}
+	denied := []string{"operatortokendef", "restore_snapshot", "pause_runtime", "get_runtime_state", "list_channels", "register_hook", "delete_hook"}
+	for _, name := range denied {
+		if principalMayCallTool(ctx, name) {
+			t.Errorf("tenant principal must NOT be allowed admin-only tool %q (RFC AG §2)", name)
+		}
+	}
+}
+
+// TestPrincipalMayCallTool_DenyByDefault is the fail-closed guard: a tool a
+// non-admin can't be classified for (e.g. a not-yet-added tool name) is denied.
+// Mirrors requiredScopeFor's default-deny arm — a forgotten admin meta-tool must
+// not leak to tenants (RFC AG §5).
+func TestPrincipalMayCallTool_DenyByDefault(t *testing.T) {
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{"substrate:tenant"}})
+	if principalMayCallTool(ctx, "some_future_unclassified_admin_tool") {
+		t.Errorf("an unclassified tool must default to admin-only for a tenant principal (deny-by-default)")
+	}
+}


### PR DESCRIPTION
## Why

`/v1/_mcp` multiplexes ~46 meta-tools — token minting, runtime admin, snapshot restore alongside `agentdef` and `spawn_run` — onto **one** JSON-RPC endpoint. The HTTP REST plane gives each operation its own path + its own `requiredScopeFor` gate; the MCP transport collapses them, so **per-operation authz must live in the MCP layer, not the route gate** (RFC AG §1.2). Before `/v1/_mcp` can open to `substrate:tenant` tokens (RFC AG Phase 2), the layer needs to decide what a non-admin principal may *see* and *call*.

This is the **second half of RFC AG Phase 0**. The first half — `mcpPrincipalCtx`, the tenant/user identity stamp — shipped in #549. Together they make the MCP layer scope-aware and tenant-stamping; the route still stays `substrate:admin`, so this is **pure hardening / defense-in-depth** until the Phase 2 flip.

## What

Classify every dispatchable meta-tool (RFC AG §2) and enforce per principal:

- **`tenantConfinableTools`** — the explicit allowlist of tools that key on `RunIdentity.TenantID` (def authoring, run lifecycle, `memory`/`channel`/`channeldef`/`path`/`document`, the per-run/per-user tools). Membership means the tool is confined by the `mcpPrincipalCtx` tenant stamp + the tool's own tenant filter — the map grants nothing itself.
- **`principalMayCallTool(ctx, name)`** — no principal (stdio / open mode) or an admin principal → every tool; a non-admin → only the allowlist. A tool **absent** from the allowlist requires admin: **deny-by-default**, mirroring `requiredScopeFor`'s default-deny arm — a newly added meta-tool is admin-only until explicitly classified tenant-safe (RFC AG §5).
- **`handleToolsList`** now filters by the principal (a tenant session never *sees* the admin-only tools); **`handleToolsCall`** gates before dispatch and returns a clean JSON-RPC forbidden error (`mcpErrForbidden` = `-32001`, distinguishable from `-32601` unknown-tool) if a hidden tool is called anyway — the gate is the enforcement, the hide is UX (RFC AG §3.3 / §6).
- **`adminOnlyTools`** — the companion set, used **only** by the drift test (the gate relies on deny-by-default), so every dispatchable tool must be consciously classified into exactly one disjoint set.

### Scope of this PR

- Route gate **unchanged** (`/v1/_mcp` stays `substrate:admin`) — the flip is RFC AG Phase 2.
- Run-lifecycle wire-identity override (`applyPrincipal`) is **RFC AG Phase 1** (separate PR) — the gate here lets a tenant *reach* `spawn_run`; Phase 1 stops them forging another tenant's `tenant_id` in the body.
- Hook meta-tools stay admin-only here; RFC AG §2 flags them as a Phase-2 promotion (they're already tenant-isolated post-#508).

## Tested

`internal/api/mcp/toolauthz_test.go` + `server_test.go`:
- **Drift test** — every `handlersByName` entry is classified into exactly one of the two disjoint sets; no phantom (non-dispatchable) classifications. Adding a meta-tool without classifying it turns this red.
- **Predicate tests** — no-principal allows all (stdio operator-trust); admin allows all; non-admin allow-list (`document`/`agentdef`/`memory`/`spawn_run`/…) vs deny-list (`operatortokendef`/`restore_snapshot`/`pause_runtime`/`list_channels`/`register_hook`); deny-by-default for an unclassified name.
- **Behavioral** — `tools/list` as a tenant principal hides the admin tools + keeps the tenant tools; `tools/call` of `pause_runtime` as a tenant principal returns `mcpErrForbidden`; the no-principal path is **not** gated. **Fail-before verified**: neutering the `handleToolsCall` gate lets `pause_runtime` dispatch (returns a pause status) instead of the forbidden error.
- The no-principal full-catalogue test still returns all **46** tools (behavior unchanged for stdio / admin).
- `go test ./...` green; `gofmt` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
