### PR TITLE
feat(mcp): apply the principal to spawn_run / spawn_runs wire identity (RFC AG Phase 1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -281,26 +281,20 @@ func (s *Server) legacyFallbackDisabled(ctx context.Context) bool {
 // and a caller must not be able to spoof another subject.
 func (s *Server) applyPrincipal(ctx context.Context, wireTenant, wireUser string) (tenant, subject string) {
 	p, ok := auth.PrincipalFromContext(ctx)
-	if !ok {
-		return wireTenant, wireUser
-	}
-	if p.Legacy {
-		subject = p.Subject
-		if wireUser != "" {
-			subject = wireUser
+	tenant, subject = auth.ResolveWireIdentity(p, ok, wireTenant, wireUser)
+	// Log a disagreement only for a REAL principal (legacy honors the wire
+	// user_id by design; no-principal is the open-mode passthrough). Triage
+	// only — the override itself is the security property and lives in
+	// auth.ResolveWireIdentity, the rule shared with the MCP transport.
+	if ok && !p.Legacy {
+		if wireTenant != "" && wireTenant != p.TenantID {
+			log.Printf("auth: identity_overridden kind=tenant wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)
 		}
-		// Tenant stays the legacy default ("default"): the shared token is
-		// single-tenant by construction, and tenant routing is a real
-		// isolation axis we don't let the wire steer here.
-		return p.TenantID, subject
+		if wireUser != "" && wireUser != p.Subject {
+			log.Printf("auth: identity_overridden kind=subject wire=%q principal=%q token_def=%q", wireUser, p.Subject, p.TokenDefID)
+		}
 	}
-	if wireTenant != "" && wireTenant != p.TenantID {
-		log.Printf("auth: identity_overridden kind=tenant wire=%q principal=%q token_def=%q", wireTenant, p.TenantID, p.TokenDefID)
-	}
-	if wireUser != "" && wireUser != p.Subject {
-		log.Printf("auth: identity_overridden kind=subject wire=%q principal=%q token_def=%q", wireUser, p.Subject, p.TokenDefID)
-	}
-	return p.TenantID, p.Subject
+	return tenant, subject
 }
 
 // sessionOwnershipOK reports whether the ctx principal may continue or read

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -7,11 +7,30 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/runner"
 	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
+
+// applyPrincipalToSpawn makes the authenticated principal authoritative over a
+// FRESH run's wire tenant_id/user_id (RFC AG §3.2 — the MCP analogue of HTTP's
+// applyPrincipal). Without it a tenant could spawn a run in another tenant by
+// putting tenant_id in the JSON body. The rule is the shared
+// auth.ResolveWireIdentity (one source of truth across HTTP + MCP).
+//
+// Continuations (session_id set) are skipped: the session's identity is
+// authoritative and the connector ignores these fields for a session_id call —
+// the cross-tenant-continuation guard is a separate concern (sessionOwnership),
+// out of scope for this wire-identity override.
+func applyPrincipalToSpawn(ctx context.Context, req *connector.SpawnRunRequest) {
+	if req.SessionID != "" {
+		return
+	}
+	p, ok := auth.PrincipalFromContext(ctx)
+	req.TenantID, req.UserID = auth.ResolveWireIdentity(p, ok, req.TenantID, req.UserID)
+}
 
 // toolHandler is the uniform signature every dispatch entry follows.
 // Returns the MCP CallToolResult directly (not raw JSON) so the server
@@ -198,6 +217,10 @@ func handleSpawnRun(ctx context.Context, env *handlerEnv, args json.RawMessage) 
 		req.ParentContext = nil
 	}
 
+	// RFC AG §3.2: the authenticated principal is authoritative over the wire
+	// tenant_id/user_id (a tenant can't forge another tenant's id in the body).
+	applyPrincipalToSpawn(ctx, &req)
+
 	// RFC P — transport timeout. A per-call timeout_ms (caller, narrowing)
 	// over the operator default bounds how long this spawn_run CALL blocks
 	// the MCP transport; on expiry we cancel the run (it honors ctx) and
@@ -274,6 +297,10 @@ func handleSpawnRuns(ctx context.Context, env *handlerEnv, args json.RawMessage)
 		if sp.ParentContext.IsZero() {
 			sp.ParentContext = nil
 		}
+		// RFC AG §3.2: stamp the caller's authoritative identity on every child
+		// (batch children are fresh runs — Agent required above, no session_id),
+		// so a forged tenant_id in any child spec can't cross the tenant boundary.
+		applyPrincipalToSpawn(ctx, sp)
 	}
 	res, err := env.connector.SpawnRunBatch(ctx, req)
 	if err != nil {

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -566,6 +566,91 @@ func TestServer_SpawnRun_BlockingPath(t *testing.T) {
 // TestServer_SpawnRun_CarriesCompaction verifies a per-run compaction block on
 // a spawn_run call decodes into SpawnRunRequest.Compaction (the new per-run
 // config surface; the connector then carries it to runner.RunInput).
+// TestServer_SpawnRun_AppliesPrincipalOverWireIdentity is the RFC AG §3.2
+// enforcement: a non-legacy principal is authoritative over the wire
+// tenant_id/user_id, so a forged tenant_id in the spawn_run body cannot place
+// the run in another tenant. Fail-before: drop applyPrincipalToSpawn in
+// handleSpawnRun and the connector sees the forged "evil"/"mallory".
+func TestServer_SpawnRun_AppliesPrincipalOverWireIdentity(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice"}) // real (non-legacy) principal
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"evil","user_id":"mallory"}}}` + "\n"
+	driveServerCtx(t, srv, ctx, in)
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.TenantID != "acme" || stored.UserID != "alice" {
+		t.Errorf("connector saw (tenant=%q,user=%q), want (acme,alice) — wire claims must be overridden", stored.TenantID, stored.UserID)
+	}
+}
+
+// TestServer_SpawnRun_LegacyHonorsWireUserID: under the legacy token the wire
+// user_id is honored (single-operator, no-boundary; F18) but the tenant stays
+// the legacy default. Mirrors HTTP's applyPrincipal via the shared rule.
+func TestServer_SpawnRun_LegacyHonorsWireUserID(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "default", Subject: "default", Scopes: []string{auth.ScopeAdmin}, Legacy: true})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"ignored","user_id":"exp1"}}}` + "\n"
+	driveServerCtx(t, srv, ctx, in)
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.TenantID != "default" || stored.UserID != "exp1" {
+		t.Errorf("legacy spawn saw (tenant=%q,user=%q), want (default,exp1)", stored.TenantID, stored.UserID)
+	}
+}
+
+// TestServer_SpawnRun_NoPrincipalPassesWireThrough: on the stdio / open path
+// (no principal) the caller-supplied identity passes through unchanged.
+func TestServer_SpawnRun_NoPrincipalPassesWireThrough(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"agent":"qa","segments":[],"tenant_id":"wire-t","user_id":"wire-u"}}}` + "\n"
+	driveServer(t, srv, in)
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.TenantID != "wire-t" || stored.UserID != "wire-u" {
+		t.Errorf("no-principal spawn saw (tenant=%q,user=%q), want the wire values", stored.TenantID, stored.UserID)
+	}
+}
+
+// TestServer_SpawnRun_ContinuationSkipsOverride: a continuation (session_id set)
+// must NOT have its identity rewritten — the session's stored identity is
+// authoritative downstream, and the connector ignores these fields for a
+// session_id call. So applyPrincipalToSpawn is a deliberate no-op here.
+func TestServer_SpawnRun_ContinuationSkipsOverride(t *testing.T) {
+	mc := &mockConnector{spawnResult: connector.SpawnRunResult{Status: "completed"}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice"})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_run","arguments":{"session_id":"s_prior","segments":[],"tenant_id":"wire-t"}}}` + "\n"
+	driveServerCtx(t, srv, ctx, in)
+	stored, _ := mc.spawnReq.Load().(connector.SpawnRunRequest)
+	if stored.TenantID != "wire-t" {
+		t.Errorf("continuation tenant = %q, want it left untouched (wire-t) — override must skip continuations", stored.TenantID)
+	}
+}
+
+// TestServer_SpawnRuns_AppliesPrincipalToEachChild: the RFC Y batch fan-out
+// stamps the caller's authoritative identity on EVERY child, so a forged
+// tenant_id in any child spec can't cross the tenant boundary (RFC AG §3.2).
+func TestServer_SpawnRuns_AppliesPrincipalToEachChild(t *testing.T) {
+	mc := &mockConnector{batchResult: connector.BatchSpawnResult{}}
+	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})
+	ctx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "alice"})
+	in := `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"spawn_runs","arguments":{"spawns":[{"agent":"a","segments":[],"tenant_id":"evil"},{"agent":"b","segments":[],"tenant_id":"evil2","user_id":"mallory"}]}}}` + "\n"
+	driveServerCtx(t, srv, ctx, in)
+	stored, _ := mc.batchReq.Load().(connector.BatchSpawnRequest)
+	if len(stored.Spawns) != 2 {
+		t.Fatalf("connector saw %d spawns, want 2", len(stored.Spawns))
+	}
+	for i, sp := range stored.Spawns {
+		if sp.TenantID != "acme" || sp.UserID != "alice" {
+			t.Errorf("child[%d] = (tenant=%q,user=%q), want (acme,alice)", i, sp.TenantID, sp.UserID)
+		}
+	}
+}
+
 func TestServer_SpawnRun_CarriesCompaction(t *testing.T) {
 	mc := &mockConnector{spawnResult: connector.SpawnRunResult{AgentID: "a", RunID: "r", Status: "completed"}}
 	srv := New(Config{Connector: mc, Logf: func(string, ...any) {}})

--- a/internal/auth/principal.go
+++ b/internal/auth/principal.go
@@ -49,6 +49,35 @@ func PrincipalFromContext(ctx context.Context) (Principal, bool) {
 	return p, ok
 }
 
+// ResolveWireIdentity makes a principal authoritative over caller-asserted wire
+// tenant_id/user_id (RFC L Decision 5) and is the SINGLE source of truth for the
+// override rule shared by every run-triggering surface (HTTP applyPrincipal, the
+// MCP run-lifecycle handlers, …). It is pure / side-effect-free: callers that
+// want triage logging on a disagreement compare the inputs to the outputs
+// themselves.
+//
+// Rules:
+//   - No principal (open / un-authed): wire values pass through unchanged.
+//   - Legacy (LOOMCYCLE_AUTH_TOKEN, F18): single-operator, no-boundary mode —
+//     HONOR the wire user_id (the placeholder subject only when the caller omits
+//     it), but keep the legacy tenant (tenant routing is a real isolation axis
+//     the wire must not steer).
+//   - Real OperatorTokenDef principal: STRICT override to (p.TenantID,
+//     p.Subject) — a caller must not be able to spoof another subject/tenant.
+func ResolveWireIdentity(p Principal, ok bool, wireTenant, wireUser string) (tenant, subject string) {
+	if !ok {
+		return wireTenant, wireUser
+	}
+	if p.Legacy {
+		subject = p.Subject
+		if wireUser != "" {
+			subject = wireUser
+		}
+		return p.TenantID, subject
+	}
+	return p.TenantID, p.Subject
+}
+
 // SubjectForFairness returns the authoritative fairness key: the
 // principal's Subject when one is stamped, else the supplied fallback
 // (the wire user_id, used in open mode / un-authed internal paths). This

--- a/internal/auth/principal_test.go
+++ b/internal/auth/principal_test.go
@@ -20,6 +20,56 @@ func TestPrincipalContext_RoundTrip(t *testing.T) {
 	}
 }
 
+// TestResolveWireIdentity pins the shared identity-override rule (RFC L
+// Decision 5 / RFC AG §3.2) used by both HTTP applyPrincipal and the MCP
+// run-lifecycle handlers. The three branches: no-principal passthrough, legacy
+// honors-wire-user/keeps-tenant, real-principal strict override.
+func TestResolveWireIdentity(t *testing.T) {
+	cases := []struct {
+		name            string
+		p               Principal
+		ok              bool
+		wireT, wireU    string
+		wantT, wantSubj string
+	}{
+		{
+			name:  "no_principal_passthrough",
+			ok:    false,
+			wireT: "wire-t", wireU: "wire-u",
+			wantT: "wire-t", wantSubj: "wire-u",
+		},
+		{
+			name:  "real_principal_strict_override",
+			p:     Principal{TenantID: "acme", Subject: "alice"},
+			ok:    true,
+			wireT: "forged-tenant", wireU: "forged-bob",
+			wantT: "acme", wantSubj: "alice",
+		},
+		{
+			name:  "legacy_honors_wire_user_keeps_tenant",
+			p:     Principal{TenantID: "default", Subject: "default", Legacy: true},
+			ok:    true,
+			wireT: "ignored-tenant", wireU: "exp1",
+			wantT: "default", wantSubj: "exp1",
+		},
+		{
+			name:  "legacy_empty_wire_falls_back_to_placeholder",
+			p:     Principal{TenantID: "default", Subject: "default", Legacy: true},
+			ok:    true,
+			wireT: "", wireU: "",
+			wantT: "default", wantSubj: "default",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotT, gotS := ResolveWireIdentity(tc.p, tc.ok, tc.wireT, tc.wireU)
+			if gotT != tc.wantT || gotS != tc.wantSubj {
+				t.Errorf("ResolveWireIdentity = (%q,%q), want (%q,%q)", gotT, gotS, tc.wantT, tc.wantSubj)
+			}
+		})
+	}
+}
+
 func TestSubjectForFairness(t *testing.T) {
 	// Principal present → its Subject wins over the wire fallback.
 	ctx := WithPrincipal(context.Background(), Principal{Subject: "alice"})


### PR DESCRIPTION
## Why

The run-lifecycle MCP handlers passed each request's caller-asserted wire `tenant_id`/`user_id` straight to the connector (RFC AG §1.1 **Drop #2**). There was no MCP analogue of HTTP's `applyPrincipal`, so a caller could **spawn a run in another tenant** by setting `tenant_id` in the `spawn_run` / `spawn_runs` JSON body.

This is **RFC AG Phase 1**. (Phase 0 — `mcpPrincipalCtx` #549 + the tools gate #550 — already landed.)

## What

Two commits:

1. **`refactor(auth)`** — extract the principal-over-wire override rule (RFC L Decision 5: no-principal passthrough / legacy honors-wire-user-keeps-tenant / real-principal strict override) out of HTTP's `applyPrincipal` into a pure **`auth.ResolveWireIdentity`** — one source of truth for a security-critical rule now shared by HTTP and MCP. HTTP's `applyPrincipal` delegates to it and keeps its triage logging. **Behavior-preserving**: the existing `TestApplyPrincipal_*` HTTP tests pass unchanged + a new `auth` table test pins all three branches.

2. **`feat(mcp)`** — add `applyPrincipalToSpawn(ctx, *SpawnRunRequest)` and call it in `handleSpawnRun` and per-child in `handleSpawnRuns`. A fresh run's `tenant_id`/`user_id` are forced to the authenticated principal's. **Continuations (`session_id` set) are skipped** — the session's identity is authoritative downstream and the connector ignores those fields for a `session_id` call.

### Scope

- `spawn_run` + `spawn_runs` are the only run-lifecycle handlers that carry wire identity. `cancel_run` / `get_run` / `compact_run` are `agent_id`-keyed (nothing to override) and `ListRunsFilter` has **no** `tenant_id` field — their cross-tenant read/act confinement is a connector-lookup concern (the same on HTTP), deferred.
- The `/v1/_mcp` route is still `substrate:admin` (RFC AG Phase 2 flips it), so this **hardens the spawn path ahead of the flip** rather than changing live behavior. The MCP override does not emit the HTTP path's `identity_overridden` triage log (the override itself is the security property; logging is an easy follow-up if wanted).

## Tested

`internal/auth` + `internal/api/mcp`:
- `TestResolveWireIdentity` — the shared rule's three branches.
- `spawn_run` with a forged `tenant_id`/`user_id` under a **real** principal → connector sees the principal's identity. **Fail-before verified**: without the override the connector sees the forged `evil`/`mallory`.
- **legacy** honors the wire `user_id` + keeps the default tenant; **no-principal** (stdio) passes the wire values through; a **continuation** is left untouched; **`spawn_runs`** stamps every child.
- HTTP `TestApplyPrincipal_*` unchanged (refactor is behavior-preserving). `go test ./...` green; `gofmt` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
