### PR TITLE
feat(auth,mcp): open /v1/_mcp to substrate:tenant + promote hook tools (RFC AG Phase 2)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -444,12 +444,22 @@ func requiredScopeFor(method, path string) string {
 	// also satisfies it). The handlers stamp the principal's authoritative tenant
 	// (dispatchSubstrate → RunIdentity) and 404 cross-tenant reads, so a tenant
 	// operator authors ONLY its own surface. DELIBERATELY EXCLUDES
-	// /v1/_operatortokendef (token minting) and /v1/_mcp (the loomcycle-as-MCP-
-	// server transport — operatorCtx grants it global-operator authority with no
-	// per-principal tenant/scope confinement, so it MUST stay ScopeAdmin); the
-	// catch-all below keeps minting, the MCP transport, and runtime-admin at
-	// ScopeAdmin.
+	// /v1/_operatortokendef (token minting — no tenant dimension, stays ScopeAdmin
+	// via the catch-all below). /v1/_mcp (the loomcycle-as-MCP-server transport)
+	// now has its OWN ScopeTenant case below: RFC AG made it per-principal
+	// (mcpPrincipalCtx stamps the tenant + a per-tool gate withholds the admin
+	// meta-tools), so it no longer needs to be operator-only.
 	case isTenantConfinedDefPath(path):
+		return auth.ScopeTenant
+	// RFC AG Phase 2: the loomcycle-as-MCP-server HTTP transport. With Phase 0
+	// (mcpPrincipalCtx tenant/user stamp + the per-tool tools/call gate +
+	// tools/list filter) and Phase 1 (applyPrincipal on spawn) in place, the
+	// transport is per-principal and tenant-confined — a substrate:tenant token
+	// may OPEN an MCP session, and the per-tool gate INSIDE still withholds the
+	// admin-only meta-tools (mint / runtime-admin / snapshots). The route gate
+	// only decides "may open a session at all". ScopeAdmin also satisfies
+	// ScopeTenant (auth.HasScope), so admin sessions are unchanged.
+	case path == "/v1/_mcp":
 		return auth.ScopeTenant
 	// RFC AH Phase 4: the two read-only volume views (GET /v1/_volumes +
 	// /v1/_volumes/ephemeral). Same tenant-confined posture as the def plane —
@@ -551,13 +561,13 @@ func requiredScopeFor(method, path string) string {
 // only the POST route (its `list` op dispatches via the body, not a GET
 // /names route). It DELIBERATELY EXCLUDES:
 //   - /v1/_operatortokendef — token minting stays operator-only.
-//   - /v1/_mcp — the loomcycle-as-MCP-server HTTP transport. That surface runs
-//     under operatorCtx (mcp/context.go), which grants global-operator authority
-//     (Admin token-minting + "any"-scope cross-tenant def authoring + runtime
-//     admin) with NO per-principal tenant/scope confinement, so it MUST keep
-//     ScopeAdmin. Note /v1/_mcpserverdef (a def family, in the loop below) IS
-//     the tenant-confined "dynamic MCP tools ingestion" surface — it mounts an
-//     external MCP server's tools for the tenant, and is tenant-stamped.
+//   - /v1/_mcp — handled by its OWN ScopeTenant case in requiredScopeFor (RFC AG
+//     Phase 2 made the MCP transport per-principal: mcpPrincipalCtx stamps the
+//     tenant, a per-tool gate withholds the admin meta-tools). It is NOT in this
+//     def-family helper because it is a transport, not a def family. Note
+//     /v1/_mcpserverdef (a def family, in the loop below) IS the tenant-confined
+//     "dynamic MCP tools ingestion" surface — it mounts an external MCP server's
+//     tools for the tenant, and is tenant-stamped.
 //   - runtime-admin / resolver / audit — keep ScopeAdmin via the /v1/_* catch-all.
 //
 // The def handlers confine a non-admin principal to its own tenant (write-stamp

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -217,14 +217,13 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"GET", "/v1/_resolver", auth.ScopeAdmin},
 		{"POST", "/v1/_pause", auth.ScopeAdmin},
 		{"GET", "/metrics", auth.ScopeAdmin},
-		// RFC AF: /v1/_mcp (the loomcycle-as-MCP-server HTTP transport) STAYS
-		// operator-only. It runs under operatorCtx — global-operator authority with
-		// NO per-principal tenant/scope confinement — so a tenant token must NOT
-		// reach it (it could mint tokens / author cross-tenant defs). The
-		// tenant-confined "dynamic MCP tools ingestion" surface is the
-		// /v1/_mcpserverdef def family below, which IS tenant-stamped.
-		{"POST", "/v1/_mcp", auth.ScopeAdmin},
-		{"DELETE", "/v1/_mcp", auth.ScopeAdmin},
+		// RFC AG Phase 2: /v1/_mcp (the loomcycle-as-MCP-server HTTP transport) is
+		// now substrate:tenant — the transport is per-principal (mcpPrincipalCtx
+		// stamps the tenant + a per-tool gate withholds the admin meta-tools), so
+		// the route gate only decides "may open a session". substrate:admin still
+		// satisfies it (admin sessions unchanged).
+		{"POST", "/v1/_mcp", auth.ScopeTenant},
+		{"DELETE", "/v1/_mcp", auth.ScopeTenant},
 		// RFC AF: def-authoring (8 families, incl. _mcpserverdef) + hooks are
 		// tenant-confined (substrate:tenant; substrate:admin still satisfies). The
 		// handlers confine a non-admin principal to its own tenant.
@@ -294,8 +293,10 @@ func TestAuthMiddleware_403InsufficientScope(t *testing.T) {
 
 // TestAuthMiddleware_RFCAFTenantToken drives the full RFC AF posture through
 // the real middleware: a substrate:tenant token is ADMITTED on the
-// tenant-confined def + hook plane but REFUSED (403) on the operator plane
-// (token minting, the MCP-server transport, runtime admin).
+// tenant-confined def + hook plane and (RFC AG Phase 2) may OPEN an MCP session
+// on /v1/_mcp, but is REFUSED (403) on the operator plane (token minting,
+// runtime admin). Inside an MCP session the per-tool gate still withholds the
+// admin-only meta-tools — covered by the internal/api/mcp tool-gate tests.
 func TestAuthMiddleware_RFCAFTenantToken(t *testing.T) {
 	s, st := tokenAuthServer(t, "legacy")
 	seedToken(t, st, "lct_tenant", "jobember", "svc", []string{auth.ScopeTenant}, time.Time{})
@@ -305,6 +306,7 @@ func TestAuthMiddleware_RFCAFTenantToken(t *testing.T) {
 		{"GET", "/v1/_agentdef/names"},
 		{"POST", "/v1/_mcpserverdef"}, // dynamic MCP ingestion — confined
 		{"POST", "/v1/hooks"},         // tenant-isolated hooks
+		{"POST", "/v1/_mcp"},          // RFC AG Phase 2: may OPEN an MCP session
 	}
 	for _, c := range admitted {
 		var reached bool
@@ -320,7 +322,6 @@ func TestAuthMiddleware_RFCAFTenantToken(t *testing.T) {
 
 	refused := []struct{ method, path string }{
 		{"POST", "/v1/_operatortokendef"}, // token minting — operator-only
-		{"POST", "/v1/_mcp"},              // MCP-server transport — global operator
 		{"POST", "/v1/_pause"},            // runtime admin
 	}
 	for _, c := range refused {

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -425,12 +425,12 @@ func TestServer_ToolsList_FiltersAdminToolsForTenant(t *testing.T) {
 	for _, td := range result.Tools {
 		names[td.Name] = true
 	}
-	for _, hidden := range []string{"operatortokendef", "pause_runtime", "restore_snapshot", "list_channels", "register_hook", "delete_hook"} {
+	for _, hidden := range []string{"operatortokendef", "pause_runtime", "restore_snapshot", "list_channels"} {
 		if names[hidden] {
 			t.Errorf("admin-only tool %q must be hidden from a tenant principal's tools/list", hidden)
 		}
 	}
-	for _, shown := range []string{"document", "agentdef", "memory", "spawn_run", "path", "context"} {
+	for _, shown := range []string{"document", "agentdef", "memory", "spawn_run", "path", "context", "register_hook", "list_hooks", "delete_hook"} {
 		if !names[shown] {
 			t.Errorf("tenant-confinable tool %q must remain in a tenant principal's tools/list", shown)
 		}

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -71,6 +71,17 @@ var tenantConfinableTools = map[string]bool{
 	"peek_channel":           true,
 	"ack_channel":            true,
 	"stream_user_run_states": true,
+
+	// Hook management — RFC AG Phase 2 promotion. The connector's hook methods
+	// derive the owning tenant from the principal on ctx (tenantScopeFromCtx):
+	// register stamps the tenant, list/delete are tenant-scoped (opaque-404
+	// cross-tenant), and a tenant-scoped hook fires only on its own tenant's runs.
+	// So a tenant operator manages ONLY its own hooks — same posture as the
+	// already-ScopeTenant HTTP /v1/hooks routes. The privileged host-WIDEN
+	// capability stays gated by the operator-yaml owner allowlist, not this map.
+	"register_hook": true,
+	"list_hooks":    true,
+	"delete_hook":   true,
 }
 
 // adminOnlyTools enumerates the runtime-global / operator-plane meta-tools that
@@ -96,12 +107,6 @@ var adminOnlyTools = map[string]bool{
 	"export_snapshot":  true,
 	"restore_snapshot": true,
 	"delete_snapshot":  true,
-
-	// Hook management is tenant-isolated after PR #508, so RFC AG §2 flags it
-	// as a Phase-2 promotion candidate; keep it admin-only until the route opens.
-	"register_hook": true,
-	"list_hooks":    true,
-	"delete_hook":   true,
 
 	// Operator aggregate over every scope.
 	"list_channels": true,

--- a/internal/api/mcp/toolauthz_test.go
+++ b/internal/api/mcp/toolauthz_test.go
@@ -73,13 +73,13 @@ func TestPrincipalMayCallTool_NonAdmin(t *testing.T) {
 	ctx := auth.WithPrincipal(context.Background(),
 		auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{"substrate:tenant"}})
 
-	allowed := []string{"document", "agentdef", "skilldef", "memory", "channel", "path", "spawn_run", "context", "evaluation"}
+	allowed := []string{"document", "agentdef", "skilldef", "memory", "channel", "path", "spawn_run", "context", "evaluation", "register_hook", "list_hooks", "delete_hook"}
 	for _, name := range allowed {
 		if !principalMayCallTool(ctx, name) {
 			t.Errorf("tenant principal must be allowed tenant-confinable tool %q", name)
 		}
 	}
-	denied := []string{"operatortokendef", "restore_snapshot", "pause_runtime", "get_runtime_state", "list_channels", "register_hook", "delete_hook"}
+	denied := []string{"operatortokendef", "restore_snapshot", "pause_runtime", "get_runtime_state", "list_channels"}
 	for _, name := range denied {
 		if principalMayCallTool(ctx, name) {
 			t.Errorf("tenant principal must NOT be allowed admin-only tool %q (RFC AG §2)", name)


### PR DESCRIPTION
## Why

This is **RFC AG Phase 2 — the route flip**, the PR where the three prior hardening PRs become load-bearing together. Until now `/v1/_mcp` stayed `substrate:admin`-gated *because* the transport ran every request as a global operator (RFC AF deliberately left it admin-only). Phase 0 (`mcpPrincipalCtx` #549 + the per-tool `tools/call` gate + `tools/list` filter #550) and Phase 1 (`applyPrincipal` on spawn #551) closed that gap — the transport is now **per-principal and tenant-confined** — so the route can open to tenant tokens.

## What

- **`requiredScopeFor`: `/v1/_mcp` moves `substrate:admin` → `substrate:tenant`.** The route gate now only decides *"may this principal **open** an MCP session"*. What's callable **inside** the session is decided by the per-tool gate from #550 — a `substrate:tenant` session still cannot see or reach the admin-only meta-tools (token mint / runtime-admin / snapshots): they're filtered out of its `tools/list` and `-32001`-gated on `tools/call`. `substrate:admin` satisfies `substrate:tenant` (`auth.HasScope`), so **admin sessions are unchanged**. The stale "MUST stay ScopeAdmin" comments are updated.

- **Promote the hook meta-tools** (`register_hook` / `list_hooks` / `delete_hook`) from admin-only to tenant-confinable. **Verified safe**: the connector's hook methods derive the owning tenant from the principal on ctx — `tenantScopeFromCtx` reads `auth.PrincipalFromContext`, which is threaded onto the MCP ctx — so `register` stamps the tenant, `list`/`delete` are tenant-scoped (opaque-404 cross-tenant), and a tenant-scoped hook fires only on its own tenant's runs. Identical posture to the already-`ScopeTenant` HTTP `/v1/hooks` routes. The privileged host-**widen** capability stays gated by the operator-yaml owner allowlist, not the gate map.

### Net effect

A `substrate:tenant` token can now drive an MCP session **confined to its own tenant**: author/run/manage its own defs, runs, memory, channels, documents, paths, and hooks — but mint nothing, touch no other tenant, and reach no runtime-global control.

### What's left in RFC AG

- **Phase 3** — docs (`--upstream` works with a tenant bearer; CONFIGURATION.md + operator-tokens help). Then **RFC AO** (config-declared `principals:`).
- Out of scope here (noted in #551): `cancel_run`/`get_run`/`compact_run` cross-tenant confinement (`agent_id`-keyed; a connector-lookup concern, the same on HTTP) and `list_runs` ctx-tenant scoping.

## Tested

`internal/api/http`:
- `TestRequiredScopeFor` pins `POST`/`DELETE /v1/_mcp` → `substrate:tenant`. **Fail-before verified**: removing the case drops it to `ScopeAdmin` via the `/v1/_*` catch-all and both the table test and the middleware test fail.
- `TestAuthMiddleware_RFCAFTenantToken` now **admits** a `substrate:tenant` token on `POST /v1/_mcp` while still **refusing** the operator plane (mint, pause).

`internal/api/mcp`:
- The tenant principal now lists + may call the hook tools; the drift test keeps every dispatchable tool in exactly one disjoint set.

`go test ./...` green; `gofmt` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
