### PR TITLE
feat(config,auth): config-declared principals — static (tenant,user) logins (RFC AO Phase 1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -233,6 +233,13 @@ func (s *Server) resolvePrincipalUncached(ctx context.Context, bearer, hash stri
 			return auth.Principal{}, false, false
 		}
 	}
+	// Config-declared principals (RFC AO) — static service identities from the
+	// `principals:` block, matched constant-time. Tried AFTER the minted
+	// substrate (a minted def wins a value clash) and BEFORE the legacy
+	// fallback. A definitive, cacheable outcome.
+	if p, ok := auth.MatchDeclared(bearer, s.cfg.ResolvedPrincipals); ok {
+		return p, true, true
+	}
 	// Legacy shared-secret fallback.
 	if s.cfg.Env.AuthToken != "" && auth.CompareBearer(bearer, s.cfg.Env.AuthToken) {
 		if s.legacyFallbackDisabled(ctx) {

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -412,3 +412,37 @@ func TestApplyPrincipal_LegacyHonorsWireUserID(t *testing.T) {
 		t.Errorf("legacy+empty = (%q,%q), want (default,default)", tenant, subject)
 	}
 }
+
+// TestResolvePrincipal_DeclaredPrincipal drives the full bearer resolver through
+// RFC AO's added step: a config-declared principal resolves to its
+// (tenant, subject, scopes); the minted substrate (step 1) and the legacy
+// fallback (step 3) still resolve to their own principals — the declared step
+// sits between them and only matches its own secret. Fail-before: remove the
+// MatchDeclared block in resolvePrincipalUncached and the declared bearer falls
+// through to legacy (≠ its value) → unresolved.
+func TestResolvePrincipal_DeclaredPrincipal(t *testing.T) {
+	s, st := tokenAuthServer(t, "legacy-secret")
+	s.cfg.ResolvedPrincipals = []auth.DeclaredPrincipal{
+		{Secret: "lct_marketing", Principal: auth.Principal{TenantID: "acme", Subject: "marketing", Scopes: []string{auth.ScopeTenant}, TokenDefID: "cfg:marketing"}},
+	}
+	// A minted def whose token value differs from the declared one.
+	seedToken(t, st, "lct_minted", "beta", "svc", []string{auth.ScopeRunsCreate}, time.Time{})
+
+	// Declared bearer → its own principal (non-legacy).
+	if p, ok := s.resolvePrincipal(context.Background(), "lct_marketing"); !ok || p.TenantID != "acme" || p.Subject != "marketing" || p.Legacy {
+		t.Errorf("declared resolve = (%+v, %v), want acme/marketing non-legacy", p, ok)
+	}
+	// Minted def still resolves (precedence step 1, unaffected).
+	if p, ok := s.resolvePrincipal(context.Background(), "lct_minted"); !ok || p.TenantID != "beta" || p.Subject != "svc" {
+		t.Errorf("minted resolve = (%+v, %v), want beta/svc", p, ok)
+	}
+	// Legacy token still resolves (precedence step 3; declared is tried first
+	// but only matches its own secret).
+	if p, ok := s.resolvePrincipal(context.Background(), "legacy-secret"); !ok || !p.Legacy {
+		t.Errorf("legacy resolve = (%+v, %v), want the legacy principal", p, ok)
+	}
+	// Unknown bearer → unresolved.
+	if _, ok := s.resolvePrincipal(context.Background(), "lct_unknown"); ok {
+		t.Error("unknown bearer must not resolve")
+	}
+}

--- a/internal/auth/declared.go
+++ b/internal/auth/declared.go
@@ -1,0 +1,42 @@
+package auth
+
+// RFC AO — config-declared principals. An operator declares static
+// (tenant, subject, scopes) logins in the `principals:` config block, each bound
+// to a bearer SECRET held in an env var (in .env.local, never in yaml). At
+// config load the runtime resolves those into a []DeclaredPrincipal table; the
+// bearer resolver matches a presented token against it (between the minted
+// OperatorTokenDef substrate and the legacy fallback). The payoff: one declared
+// token used for both the Web UI login and an MCP thin client resolves to the
+// SAME (tenant, subject) on every transport (composes with RFC AG's
+// UserID = principal.Subject), so an MCP agent's user-scoped Documents/Memory
+// land where the UI reads them.
+
+// DeclaredPrincipal binds a config-declared bearer secret to the authoritative
+// Principal it resolves to. Secret is the raw token value read from the
+// principal's token_env at config load; it is matched constant-time and is never
+// logged or echoed.
+type DeclaredPrincipal struct {
+	Secret    string
+	Principal Principal
+}
+
+// MatchDeclared returns the Principal for the declared entry whose secret equals
+// bearer, matched with the length-independent constant-time CompareBearer (same
+// hardened compare the legacy token uses — no timing side channel). It scans ALL
+// entries without short-circuiting on a match, so total time does not depend on
+// which entry (if any) matched. Returns (_, false) when none match. (Config load
+// rejects two declared principals sharing a secret, so at most one matches.)
+func MatchDeclared(bearer string, declared []DeclaredPrincipal) (Principal, bool) {
+	var matched Principal
+	found := false
+	for _, d := range declared {
+		if d.Secret == "" {
+			continue // an inert principal (empty token_env at boot)
+		}
+		if CompareBearer(bearer, d.Secret) {
+			matched = d.Principal
+			found = true
+		}
+	}
+	return matched, found
+}

--- a/internal/auth/declared_test.go
+++ b/internal/auth/declared_test.go
@@ -1,0 +1,40 @@
+package auth
+
+import "testing"
+
+func TestMatchDeclared(t *testing.T) {
+	declared := []DeclaredPrincipal{
+		{Secret: "lct_marketing", Principal: Principal{TenantID: "acme", Subject: "marketing", Scopes: []string{ScopeTenant}}},
+		{Secret: "lct_ops", Principal: Principal{TenantID: "", Subject: "ops", Scopes: []string{ScopeAdmin}}},
+		{Secret: "", Principal: Principal{Subject: "inert"}}, // empty token_env at boot → inert, must be skipped
+	}
+
+	t.Run("matches by secret to its principal", func(t *testing.T) {
+		p, ok := MatchDeclared("lct_marketing", declared)
+		if !ok || p.TenantID != "acme" || p.Subject != "marketing" {
+			t.Errorf("got (%+v, %v), want the acme/marketing principal", p, ok)
+		}
+		p, ok = MatchDeclared("lct_ops", declared)
+		if !ok || p.Subject != "ops" || !HasScope(p.Scopes, ScopeAdmin) {
+			t.Errorf("got (%+v, %v), want the ops/admin principal", p, ok)
+		}
+	})
+
+	t.Run("non-matching bearer", func(t *testing.T) {
+		if _, ok := MatchDeclared("lct_nope", declared); ok {
+			t.Error("a non-declared bearer must not match")
+		}
+	})
+
+	t.Run("empty bearer never matches the inert entry", func(t *testing.T) {
+		if _, ok := MatchDeclared("", declared); ok {
+			t.Error("empty bearer must not match (incl. the inert empty-secret entry)")
+		}
+	})
+
+	t.Run("nil table", func(t *testing.T) {
+		if _, ok := MatchDeclared("lct_marketing", nil); ok {
+			t.Error("no declared principals → no match")
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/denn-gubsky/loomcycle/internal/agents"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/skills"
 	"github.com/denn-gubsky/loomcycle/internal/tools/policy"
@@ -189,6 +190,20 @@ type Config struct {
 	// vector ops on the Memory tool refuse with
 	// embedder_not_configured. K/V Memory is unaffected.
 	Memory MemoryConfig `yaml:"memory"`
+
+	// Principals declares static (tenant, subject, scopes) logins, each bound
+	// to a bearer secret held in an env var (RFC AO). The map key is an
+	// informational handle. Lets an operator declare a stable service identity
+	// in config and hand the same token to the Web UI and an MCP thin client so
+	// both authenticate as the same (tenant, subject). The secret never appears
+	// in yaml — only `token_env` (the env-var name) does.
+	Principals map[string]PrincipalDef `yaml:"principals,omitempty"`
+
+	// ResolvedPrincipals is the boot-resolved token→Principal table built from
+	// Principals during validate (each token_env read from the environment).
+	// The auth-layer bearer resolver matches a presented token against it.
+	// Not in YAML; carries the resolved secrets, so it is never serialized.
+	ResolvedPrincipals []auth.DeclaredPrincipal `yaml:"-"`
 
 	// Env-derived; not in YAML.
 	Env Env `yaml:"-"`
@@ -4526,6 +4541,12 @@ func validate(c *Config) error {
 	// Paths are resolved to absolute IN PLACE so the run-start binding
 	// resolution gets a stable absolute Root regardless of process cwd.
 	if err := validateVolumes(c); err != nil {
+		return err
+	}
+	// RFC AO: validate the principals: block + build the resolved token→Principal
+	// table (reads each token_env from the environment). A bad scope/env-name
+	// fails load; an empty token_env makes that principal inert + warns.
+	if err := resolvePrincipals(c); err != nil {
 		return err
 	}
 	for name, agent := range c.Agents {

--- a/internal/config/principals.go
+++ b/internal/config/principals.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// PrincipalDef is one config-declared principal (RFC AO). `tenant` MAY be empty
+// (the shared/operator tenant — where an admin identity lives); `subject` is
+// required (it is the authoritative user id, and the scope_id for user-scoped
+// tools). `scopes` is the granted set, validated against the closed catalog;
+// empty means a principal that can authenticate but is gated out of everything
+// (default-deny — useful for a read-nothing identity, but normally you list
+// scopes). `token_env` names a LOOMCYCLE_*-prefixed (or allowlisted) env var
+// holding the bearer SECRET — the yaml carries the NAME, never the value.
+type PrincipalDef struct {
+	Tenant   string   `yaml:"tenant"`
+	Subject  string   `yaml:"subject"`
+	Scopes   []string `yaml:"scopes"`
+	TokenEnv string   `yaml:"token_env"`
+}
+
+// resolvePrincipals validates the `principals:` block and builds
+// c.ResolvedPrincipals (RFC AO). Called from validate after the env block is
+// populated; it reads each token_env from the process environment directly
+// (mirroring how Load reads every other secret).
+//
+//   - subject required; token_env required + LOOMCYCLE_*-allowlisted; scopes ∈
+//     the closed catalog — a violation FAILS config load (a typo in a scope or
+//     env name must not silently ship a mis-scoped or inert identity).
+//   - a token_env that is EMPTY at boot → the principal is INERT (skipped, no
+//     entry in the table) + a startup warning. Fail-safe: a missing secret means
+//     "no token resolves to this identity", never an open door.
+//   - two declared principals whose token_env values resolve to the SAME secret
+//     → config-load error (a bearer must not map to two identities). Resolution
+//     order (minted OperatorTokenDef → declared → legacy) handles a
+//     declared-vs-minted value clash deterministically: the minted def wins.
+func resolvePrincipals(c *Config) error {
+	if len(c.Principals) == 0 {
+		return nil
+	}
+	// Map iteration order is randomized; sort for deterministic warnings, a
+	// stable resolved slice, and a deterministic collision-victim message.
+	names := make([]string, 0, len(c.Principals))
+	for name := range c.Principals {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	secretOwner := make(map[string]string, len(names)) // secret value → first declaring name
+	for _, name := range names {
+		def := c.Principals[name]
+		if def.Subject == "" {
+			return fmt.Errorf("principals.%s: subject is required", name)
+		}
+		if def.TokenEnv == "" {
+			return fmt.Errorf("principals.%s: token_env is required", name)
+		}
+		if !ExpandEnvAllowed(def.TokenEnv) {
+			return fmt.Errorf("principals.%s: token_env %q must be LOOMCYCLE_*-prefixed (or an allowlisted name)", name, def.TokenEnv)
+		}
+		// Never let token_env name one of loomcycle's OWN infrastructure secrets
+		// (DB DSN, the legacy auth token, the token-hash pepper, the upstream MCP
+		// bearer, OTEL headers): reusing an infra secret as a declared-principal
+		// bearer is a misconfiguration, and the authoritative denylist already
+		// guards these everywhere else (exp7 C2 / the v0.34.0 review S1).
+		if expandDenyNames[def.TokenEnv] {
+			return fmt.Errorf("principals.%s: token_env %q is one of loomcycle's own infrastructure secrets and cannot be reused as a principal bearer", name, def.TokenEnv)
+		}
+		if bad := auth.UnknownScopes(def.Scopes); len(bad) > 0 {
+			return fmt.Errorf("principals.%s: unknown scope(s) %v (not in the closed catalog)", name, bad)
+		}
+		secret := os.Getenv(def.TokenEnv)
+		if secret == "" {
+			c.Warnings = append(c.Warnings, fmt.Sprintf("principals.%s: token_env %s is empty — principal is inert (no token resolves to it)", name, def.TokenEnv))
+			continue
+		}
+		if prev, dup := secretOwner[secret]; dup {
+			return fmt.Errorf("principals.%s: token_env %s resolves to the same secret as principals.%s — a bearer cannot map to two identities", name, def.TokenEnv, prev)
+		}
+		secretOwner[secret] = name
+		c.ResolvedPrincipals = append(c.ResolvedPrincipals, auth.DeclaredPrincipal{
+			Secret: secret,
+			Principal: auth.Principal{
+				TenantID:   def.Tenant,
+				Subject:    def.Subject,
+				Scopes:     append([]string(nil), def.Scopes...),
+				TokenDefID: "cfg:" + name,
+			},
+		})
+	}
+	return nil
+}

--- a/internal/config/principals_test.go
+++ b/internal/config/principals_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+func TestResolvePrincipals_Valid(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TOKEN_MARKETING", "lct_marketing_secret")
+	c := &Config{Principals: map[string]PrincipalDef{
+		"marketing": {Tenant: "acme", Subject: "marketing", Scopes: []string{auth.ScopeRunsCreate, auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_TOKEN_MARKETING"},
+	}}
+	if err := resolvePrincipals(c); err != nil {
+		t.Fatalf("resolvePrincipals: %v", err)
+	}
+	if len(c.ResolvedPrincipals) != 1 {
+		t.Fatalf("got %d resolved principals, want 1", len(c.ResolvedPrincipals))
+	}
+	dp := c.ResolvedPrincipals[0]
+	if dp.Secret != "lct_marketing_secret" {
+		t.Errorf("secret = %q, want the env value", dp.Secret)
+	}
+	if dp.Principal.TenantID != "acme" || dp.Principal.Subject != "marketing" {
+		t.Errorf("principal = %+v, want acme/marketing", dp.Principal)
+	}
+	if dp.Principal.TokenDefID != "cfg:marketing" {
+		t.Errorf("TokenDefID = %q, want cfg:marketing", dp.Principal.TokenDefID)
+	}
+	if dp.Principal.Legacy {
+		t.Error("a declared principal must not be Legacy")
+	}
+}
+
+func TestResolvePrincipals_MissingSubject(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TOKEN_X", "lct_x")
+	c := &Config{Principals: map[string]PrincipalDef{
+		"x": {Tenant: "acme", Scopes: []string{auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_TOKEN_X"},
+	}}
+	if err := resolvePrincipals(c); err == nil || !strings.Contains(err.Error(), "subject is required") {
+		t.Errorf("err = %v, want a 'subject is required' error", err)
+	}
+}
+
+func TestResolvePrincipals_UnknownScope(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TOKEN_X", "lct_x")
+	c := &Config{Principals: map[string]PrincipalDef{
+		"x": {Subject: "x", Scopes: []string{"not:a:real:scope"}, TokenEnv: "LOOMCYCLE_TOKEN_X"},
+	}}
+	if err := resolvePrincipals(c); err == nil || !strings.Contains(err.Error(), "unknown scope") {
+		t.Errorf("err = %v, want an 'unknown scope' error", err)
+	}
+}
+
+func TestResolvePrincipals_NonAllowlistedTokenEnv(t *testing.T) {
+	t.Setenv("FOO_TOKEN", "lct_x")
+	c := &Config{Principals: map[string]PrincipalDef{
+		"x": {Subject: "x", Scopes: []string{auth.ScopeTenant}, TokenEnv: "FOO_TOKEN"},
+	}}
+	if err := resolvePrincipals(c); err == nil || !strings.Contains(err.Error(), "LOOMCYCLE_") {
+		t.Errorf("err = %v, want a token_env-allowlist error", err)
+	}
+}
+
+func TestResolvePrincipals_InfraSecretTokenEnvIsError(t *testing.T) {
+	// Pointing token_env at one of loomcycle's own infra secrets must be refused
+	// even though it is LOOMCYCLE_*-prefixed (denylist guard).
+	t.Setenv("LOOMCYCLE_AUTH_TOKEN", "legacy-secret")
+	c := &Config{Principals: map[string]PrincipalDef{
+		"x": {Subject: "x", Scopes: []string{auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_AUTH_TOKEN"},
+	}}
+	if err := resolvePrincipals(c); err == nil || !strings.Contains(err.Error(), "infrastructure secret") {
+		t.Errorf("err = %v, want an infra-secret token_env error", err)
+	}
+}
+
+func TestResolvePrincipals_EmptyTokenEnvIsInert(t *testing.T) {
+	// LOOMCYCLE_TOKEN_ABSENT is deliberately NOT set → the principal is inert.
+	c := &Config{Principals: map[string]PrincipalDef{
+		"absent": {Subject: "absent", Scopes: []string{auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_TOKEN_ABSENT"},
+	}}
+	if err := resolvePrincipals(c); err != nil {
+		t.Fatalf("an empty token_env must NOT fail load: %v", err)
+	}
+	if len(c.ResolvedPrincipals) != 0 {
+		t.Errorf("an inert principal must not be in the resolved table; got %d", len(c.ResolvedPrincipals))
+	}
+	if len(c.Warnings) == 0 || !strings.Contains(strings.Join(c.Warnings, "\n"), "inert") {
+		t.Errorf("an empty token_env must warn (inert); warnings = %v", c.Warnings)
+	}
+}
+
+func TestResolvePrincipals_DuplicateSecretIsError(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TOKEN_A", "lct_same")
+	t.Setenv("LOOMCYCLE_TOKEN_B", "lct_same") // same value → ambiguous identity
+	c := &Config{Principals: map[string]PrincipalDef{
+		"a": {Subject: "a", Scopes: []string{auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_TOKEN_A"},
+		"b": {Subject: "b", Scopes: []string{auth.ScopeTenant}, TokenEnv: "LOOMCYCLE_TOKEN_B"},
+	}}
+	if err := resolvePrincipals(c); err == nil || !strings.Contains(err.Error(), "same secret") {
+		t.Errorf("err = %v, want a duplicate-secret config error", err)
+	}
+}


### PR DESCRIPTION
## Why

loomcycle resolves a bearer to an `auth.Principal` from exactly two sources: the legacy `LOOMCYCLE_AUTH_TOKEN` (subject `"default"`) and runtime-minted `OperatorTokenDef` rows. Neither lets an operator **declare** a stable `(tenant, subject)` service identity in config and hand the *same* token to the Web UI login and an MCP thin client. So the UI (`principal.Subject`) and an MCP agent end up as different users and their user-scoped Memory/Documents never line up.

This is **RFC AO Phase 1** — the companion to RFC AG (#549–#553). AG made `/v1/_mcp` authenticate as `principal.Subject`; AO lets the operator **declare** those principals. Together they close the cross-transport identity gap the RFC AM Document Assistant hit (a thin-client agent's document landed under `mcp-operator`, invisible to the UI under `default`).

## What

```yaml
principals:
  marketing:
    tenant: acme
    subject: marketing
    scopes: [runs:create, runs:read, substrate:tenant]
    token_env: LOOMCYCLE_TOKEN_MARKETING   # the SECRET lives in .env.local
```

- **`config`** — a top-level `principals:` map (`name → {tenant, subject, scopes[], token_env}`). `token_env` names a `LOOMCYCLE_*`-allowlisted env var holding the bearer secret; the yaml carries only the **name**. At `validate`, `resolvePrincipals` reads each `token_env` and builds `Config.ResolvedPrincipals` (a token→Principal table).
  - **Validation (fails load):** `subject` required; `token_env` required + allowlisted + **not one of loomcycle's own infra secrets** (reuses the authoritative `expandDenyNames` denylist — can't point it at the DSN/pepper/auth-token); `scopes ∈` the closed catalog.
  - **Fail-safe:** an empty `token_env` at boot → the principal is **inert** (skipped) + a startup warning. Two declared principals sharing a secret → **config-load error**.
- **`auth`** — `auth.DeclaredPrincipal` + `auth.MatchDeclared`, matching a bearer with the hardened length-independent `CompareBearer` (no timing side channel), scanning all entries without short-circuit.
- **The bearer resolver** (`resolvePrincipalUncached`, shared by HTTP **and** gRPC) gains a step **between** the minted substrate and the legacy fallback: **minted → declared → legacy** (a minted def wins a value clash, deterministically). A declared principal is `Legacy=false` with a synthetic `TokenDefID` `cfg:<name>`, then flows through `applyPrincipal` / `substrateAdminUserCtx` / `mcpPrincipalCtx` **unchanged** — so one declared token resolves to the same `(tenant, subject)` on every transport.

### The payoff (with RFC AG)

```
LOOMCYCLE_TOKEN_MARKETING=lct_…          # .env.local
# Web UI:      /ui/login?token=$LOOMCYCLE_TOKEN_MARKETING       → (acme, marketing)
# MCP wrapper: LOOMCYCLE_MCP_UPSTREAM_TOKEN=$LOOMCYCLE_TOKEN_MARKETING → (acme, marketing)
```

Both resolve to `(acme, marketing)`; the agent's user-scoped Documents/Memory land where the UI reads them — by construction.

### Scope

**Phase 1 = surface + resolver only.** Phase 2 (docs + examples — `docs/CONFIGURATION.md` "Declared principals", `.env.insecure.example` / `.env.local.example` shapes, the `bundles/document-agent/` + thin-client wrapper guidance) follows as a separate PR, matching the RFC's phasing.

## Tested

- **`internal/auth`** — `MatchDeclared` match / no-match / inert-skip / nil.
- **`internal/config`** — valid build; missing-subject / unknown-scope / non-allowlisted `token_env` / **infra-secret `token_env`** all fail load; empty `token_env` → inert + warning; duplicate secret → error.
- **`internal/api/http`** — a declared bearer resolves to its `(tenant, subject)` via the full `resolvePrincipal` path while the minted def + legacy token still resolve to their own. **Fail-before verified**: removing the `MatchDeclared` step leaves the declared bearer unresolved.
- `go build ./...` (no import cycle — `config` → `auth` is acyclic), `go test ./...` green, `gofmt` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
