### PR TITLE
feat(config): layer multiple --config files with deep-merge (RFC AN Phase 1)

### DIFF
--- a/bundles/document-agent/README.md
+++ b/bundles/document-agent/README.md
@@ -36,12 +36,19 @@ loomcycle --config bundles/document-agent/loomcycle.yaml
 ```
 
 **Register in your own deployment:**
-1. Copy the `agents: doc-manager` block from `loomcycle.yaml` into your config.
+1. **Layer this bundle onto your config — no copy-paste** (RFC AN config
+   layering): pass both files, your authoritative one **last** so your
+   providers/tiers/volumes win while the bundle contributes `doc-manager`:
+   ```sh
+   loomcycle --config bundles/document-agent/loomcycle.yaml --config your.yaml
+   ```
+   (Or copy the `agents: doc-manager` block into your config by hand if you'd
+   rather keep one file.)
 2. Point `LOOMCYCLE_SKILLS_ROOT` at this bundle's `skills/` (or copy them into
    your skills root) so the four skills resolve.
 3. Ensure `LOOMCYCLE_SQLMEM_ENABLED=1`.
-4. Swap the provider/tier for your routing — the agent only needs a `middle`
-   tier to resolve.
+4. The agent only needs a `middle` tier to resolve — when layered, it uses your
+   config's routing (last wins).
 
 **Anthropic OAuth (subscription) variant:** `loomcycle_oauth.yaml` is the same
 agent with `anthropic-oauth-dev` first in every tier and the API-key/cloud

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -395,7 +395,13 @@ func main() {
 		}
 	}
 
-	cfgPath := flag.String("config", "loomcycle.yaml", "path to config YAML")
+	// --config is repeatable (RFC AN config layering): each flag adds a layer,
+	// merged left→right with last-wins. No flag → the XDG default below.
+	var cfgPaths []string
+	flag.Func("config", "path to config YAML (repeatable; layers deep-merge left→right, last wins)", func(v string) error {
+		cfgPaths = append(cfgPaths, v)
+		return nil
+	})
 	showVersion := flag.Bool("version", false, "print build identifier and exit")
 	// RFC R thin-client mode: `loomcycle mcp --upstream <url>` runs as a
 	// stdio↔/v1/_mcp proxy to an authoritative runtime, with NO local
@@ -445,30 +451,57 @@ func main() {
 		return
 	}
 
-	// v0.11.1 auto-discovery: when --config wasn't overridden AND
-	// the default file doesn't exist, walk the XDG paths. The
-	// search list is the same one `loomcycle doctor` uses, so the
-	// two stay in lockstep. Explicit --config /path is unchanged.
-	resolvedCfg, found := resolveConfigPath(*cfgPath)
-	if !found {
-		fmt.Fprintln(os.Stderr, "loomcycle: no config found at any of:")
-		for _, p := range configAutoDiscoveryPaths() {
-			fmt.Fprintf(os.Stderr, "    %s\n", p)
+	// Assemble the ordered config-layer list (RFC AN). LOOMCYCLE_CONFIG_FILES
+	// (`:`-separated, for containers/systemd) layers as the BASE; explicit
+	// --config flags layer AFTER it, so an explicit flag always wins. With
+	// neither, fall back to the lone XDG-discovered default (today's behavior).
+	var cfgFiles []string
+	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
+		if f = strings.TrimSpace(f); f != "" {
+			cfgFiles = append(cfgFiles, f)
 		}
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, or pass --config <path> to use an existing file.")
-		os.Exit(1)
+	}
+	cfgFiles = append(cfgFiles, cfgPaths...)
+
+	if len(cfgFiles) == 0 {
+		// v0.11.1 auto-discovery: no --config / env → walk the XDG paths. The
+		// search list is the same one `loomcycle doctor` uses, so the two stay
+		// in lockstep.
+		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
+		if !found {
+			fmt.Fprintln(os.Stderr, "loomcycle: no config found at any of:")
+			for _, p := range configAutoDiscoveryPaths() {
+				fmt.Fprintf(os.Stderr, "    %s\n", p)
+			}
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, or pass --config <path> to use an existing file.")
+			os.Exit(1)
+		}
+		cfgFiles = []string{resolvedCfg}
+	} else {
+		// Explicit layers must each exist (no per-file XDG fallback — explicit
+		// means literal). Fail fast with the offending path.
+		for _, f := range cfgFiles {
+			if _, err := os.Stat(f); err != nil {
+				fmt.Fprintf(os.Stderr, "loomcycle: config file not found: %s\n", f)
+				os.Exit(1)
+			}
+		}
+		if len(cfgFiles) > 1 {
+			log.Printf("config: layering %d files (last wins): %s", len(cfgFiles), strings.Join(cfgFiles, " ◁ "))
+		}
 	}
 	// Auto-load <configdir>/auth.env (companion to `loomcycle init
 	// --with-token`) BEFORE config.Load reads os.Getenv, so a persisted
 	// LOOMCYCLE_AUTH_TOKEN is in scope without a shell-rc edit. Set-if-unset
-	// (real env wins), so an explicit shell export still overrides it.
-	if authEnvPath, n, err := cli.LoadAuthEnv(resolvedCfg); err != nil {
+	// (real env wins), so an explicit shell export still overrides it. Keyed on
+	// the LAST (authoritative) layer — that's where an init-written auth.env lives.
+	if authEnvPath, n, err := cli.LoadAuthEnv(cfgFiles[len(cfgFiles)-1]); err != nil {
 		log.Printf("auth.env: %v (continuing without it)", err)
 	} else if n > 0 {
 		log.Printf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
 	}
-	cfg, err := config.Load(resolvedCfg)
+	cfg, err := config.Load(cfgFiles...)
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1013,6 +1013,57 @@ The embedded Web UI (`/ui`) has a dedicated **Volumes** tab (admin-gated, alongs
 
 ---
 
+## 9e. Config layering — stacking multiple config files (RFC AN)
+
+`--config` is **repeatable**, and the files are **deep-merged left→right, last
+wins** — so you can compose a bundled config with your own without copy-paste:
+
+```sh
+loomcycle --config bundles/document-agent/loomcycle.yaml \
+          --config ~/.config/loomcycle/loomcycle.yaml
+```
+
+Put your authoritative file **LAST**: the bundle contributes its `agents:` (e.g.
+`doc-manager`), and your file wins on `provider_priority` / `tiers` / `volumes` /
+`defaults` — so the bundle's agent runs on *your* routing and reads *your*
+`default` Volume. Containers/systemd can use the env form instead:
+`LOOMCYCLE_CONFIG_FILES=base.yaml:override.yaml` (`:`-separated). When both are
+set, `LOOMCYCLE_CONFIG_FILES` files layer as the **base** and explicit `--config`
+flags layer **after** them (an explicit flag always wins).
+
+**The merge rule (one rule, all sections).** Files are merged at the YAML-tree
+level *before* typed unmarshal, so a key's presence is explicit:
+
+> **mapping ⊕ mapping → merge keys recursively. Otherwise (scalar, sequence, or
+> type mismatch) → the later layer replaces.**
+
+| Section | Merge result |
+|---|---|
+| `agents`, `models`, `mcp_servers`, `channels`, `volumes`, `user_tiers`, `webhooks`, `a2a_*`, `memory_backends`, `scheduled_runs`, `principals` | **by key** — a new entry is added; a same-named entry **field-merges** (last wins per field, matching the `LOOMCYCLE_AGENTS_ROOT` / `mergeAgentDef` precedent) |
+| `tiers` | per-tier **by key**; each tier's candidate list **replaces** wholesale |
+| `provider_priority`, `context_plugins` | **replaced** wholesale (no implicit append — restate the full list) |
+| `defaults`, `concurrency`, `cache`, `storage`, `interruption`, `hooks`, `memory` | **field-by-field** (a layer may override one field) |
+| top-level scalars | last layer wins |
+
+**Conflicts are explicit.** Every leaf a later layer *replaces* (a key set
+differently in an earlier layer) is logged at startup
+(`config layer override: <dotted.path> (set by <file>, …)`). Set
+**`LOOMCYCLE_CONFIG_STRICT=1`** to make any cross-layer conflict a **fatal load
+error** (recommended for production — an accidental clobber of `provider_priority`
+or a host allowlist can't slip through silently). Adding a new key or re-setting a
+key to the *same* value is not a conflict.
+
+**Notes.** Each file keeps its own `${ENV}` expansion (a later layer can't inject
+into an earlier layer's text). The merged whole runs the **same `validate()`** as a
+single file — layering only *assembles* a config, it can't produce one a single
+file couldn't. A single `--config` is byte-identical to before. This is orthogonal
+to the `.env.local` / `.env.insecure` split (§9c) — that's env vars; this is YAML.
+Relative `system_prompt_file` paths resolve against the **last** file's directory
+(bundles should inline the prompt or use an absolute path). *(Deferred: an in-YAML
+`include:` directive and `loomcycle config render` — RFC AN Phases 2–3.)*
+
+---
+
 ## 10. Cross-references
 
 - [`loomcycle.example.yaml`](../loomcycle.example.yaml) — the repo-root reference yaml. All six user_tiers wired, inline comments on every section. Copy-paste and edit.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2573,7 +2573,16 @@ type Env struct {
 
 // Load reads a YAML file and the process env. Empty path returns defaults +
 // env only. Returns error on YAML parse failure or missing-required-field.
-func Load(path string) (*Config, error) {
+// Load reads, env-expands, merges, and validates one or more config files.
+// With a single path it is byte-identical to the historical single-file load.
+// With multiple paths (RFC AN config layering) the files are deep-merged at the
+// YAML-tree level left→right, last-layer-wins (so the operator's authoritative
+// file goes LAST); every replaced leaf is reported (a startup Warning, or a fatal
+// load error under LOOMCYCLE_CONFIG_STRICT=1). An empty/"" path is ignored
+// (the MDs-only / no-yaml deployment). Downstream — AGENTS_ROOT discovery,
+// system_prompt_file resolution, the env block, validate() — runs once over the
+// assembled whole, unchanged.
+func Load(paths ...string) (*Config, error) {
 	cfg := &Config{
 		Concurrency: Concurrency{
 			MaxConcurrentRuns: 8,
@@ -2586,18 +2595,58 @@ func Load(path string) (*Config, error) {
 		},
 	}
 
-	if path != "" {
-		raw, err := os.ReadFile(path)
+	// Drop empty paths (a "" arg = the no-yaml / MDs-only path).
+	files := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if p != "" {
+			files = append(files, p)
+		}
+	}
+	// primaryPath is the LAST (authoritative) file — used for configDir +
+	// relative system_prompt_file resolution. With multiple layers, a relative
+	// system_prompt_file therefore resolves against the last file's directory;
+	// bundles should inline the prompt or use an absolute path (RFC AN P1 caveat).
+	primaryPath := ""
+	if len(files) > 0 {
+		primaryPath = files[len(files)-1]
+	}
+
+	switch {
+	case len(files) == 1:
+		// Single file — the historical path, byte-identical (no merge round-trip).
+		raw, err := os.ReadFile(files[0])
 		if err != nil {
-			return nil, fmt.Errorf("read %s: %w", path, err)
+			return nil, fmt.Errorf("read %s: %w", files[0], err)
 		}
 		expanded := expandEnv(string(raw))
 		if err := yaml.Unmarshal([]byte(expanded), cfg); err != nil {
-			return nil, fmt.Errorf("parse %s: %w", path, err)
+			return nil, fmt.Errorf("parse %s: %w", files[0], err)
 		}
-		// Stash the config directory so callers (e.g. localapi.Build)
-		// can resolve relative paths declared inside the YAML.
-		if abs, err := filepath.Abs(filepath.Dir(path)); err == nil {
+		if abs, err := filepath.Abs(filepath.Dir(files[0])); err == nil {
+			cfg.configDir = abs
+		}
+	case len(files) > 1:
+		// RFC AN: deep-merge the YAML trees, then unmarshal the merged whole.
+		merged, overrides, err := mergeConfigFiles(files)
+		if err != nil {
+			return nil, err
+		}
+		if len(overrides) > 0 {
+			if os.Getenv("LOOMCYCLE_CONFIG_STRICT") == "1" {
+				return nil, fmt.Errorf("config: %d cross-layer override(s) with LOOMCYCLE_CONFIG_STRICT=1: %s", len(overrides), strings.Join(overrides, "; "))
+			}
+			for _, o := range overrides {
+				cfg.Warnings = append(cfg.Warnings, "config layer override: "+o)
+			}
+		}
+		out, err := yaml.Marshal(merged)
+		if err != nil {
+			return nil, fmt.Errorf("re-marshal merged config: %w", err)
+		}
+		if err := yaml.Unmarshal(out, cfg); err != nil {
+			return nil, fmt.Errorf("parse merged config: %w", err)
+		}
+		if abs, err := filepath.Abs(filepath.Dir(primaryPath)); err == nil {
 			cfg.configDir = abs
 		}
 	}
@@ -2624,7 +2673,7 @@ func Load(path string) (*Config, error) {
 	// paths still work; this matches the documented semantic ("relative
 	// paths resolve against the YAML config file's directory" reduces
 	// to "the process's cwd" when there is no YAML).
-	if err := resolveSystemPromptFiles(cfg, path); err != nil {
+	if err := resolveSystemPromptFiles(cfg, primaryPath); err != nil {
 		return nil, err
 	}
 

--- a/internal/config/layering.go
+++ b/internal/config/layering.go
@@ -1,0 +1,78 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RFC AN — config layering. mergeConfigFiles reads + env-expands + deep-merges N
+// config files at the YAML-tree level (before typed unmarshal, so a key's
+// PRESENCE is explicit — no Go zero-value / omitempty ambiguity). Files merge
+// left→right, last layer wins; it returns the merged tree plus a list of every
+// leaf a later layer REPLACED (for the startup override log / strict-mode fatal).
+//
+// One recursive rule covers every section (no per-section special-casing):
+// mapping ⊕ mapping → merge keys recursively; anything else (scalar, sequence,
+// type mismatch) → the later layer's value replaces. So agents/models/volumes/
+// mcp_servers/channels/... merge by key (a same-named entry field-merges, matching
+// the mergeAgentDef precedent); provider_priority/context_plugins (sequences)
+// replace wholesale; struct sections (defaults/concurrency/...) merge field-by-field.
+//
+// Each file keeps its OWN expandEnv raw-text stage, so a later layer can't inject
+// ${ENV} into an earlier layer's text (no cross-layer interpolation surprises).
+func mergeConfigFiles(files []string) (map[string]any, []string, error) {
+	merged := map[string]any{}
+	var overrides []string
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read %s: %w", f, err)
+		}
+		expanded := expandEnv(string(raw))
+		var tree map[string]any
+		if err := yaml.Unmarshal([]byte(expanded), &tree); err != nil {
+			return nil, nil, fmt.Errorf("parse %s: %w", f, err)
+		}
+		if tree == nil {
+			continue // empty / all-comments file
+		}
+		merged = mergeTree(merged, tree, f, "", &overrides)
+	}
+	return merged, overrides, nil
+}
+
+// mergeTree folds overlay onto base in place and returns base. overrides
+// accumulates the dotted path of every leaf the overlay REPLACED with a
+// different value (a real cross-layer conflict — adding a brand-new key, or
+// re-setting a key to the same value, is not a conflict). file is the overlay's
+// source, named in the override record.
+func mergeTree(base, overlay map[string]any, file, prefix string, overrides *[]string) map[string]any {
+	if base == nil {
+		base = map[string]any{}
+	}
+	for k, ov := range overlay {
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+		if bv, exists := base[k]; exists {
+			bm, bIsMap := bv.(map[string]any)
+			om, oIsMap := ov.(map[string]any)
+			if bIsMap && oIsMap {
+				// Two mappings → recurse (merge keys); no conflict at this level.
+				base[k] = mergeTree(bm, om, file, path, overrides)
+				continue
+			}
+			// Scalar / sequence / type-mismatch → later replaces. Record it as a
+			// conflict only when the value actually changes.
+			if !reflect.DeepEqual(bv, ov) {
+				*overrides = append(*overrides, fmt.Sprintf("%s (set by %s, overriding an earlier layer)", path, file))
+			}
+		}
+		base[k] = ov
+	}
+	return base
+}

--- a/internal/config/layering_test.go
+++ b/internal/config/layering_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeYAML(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func containsSub(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestMergeConfigFiles_Matrix exercises the one recursive merge rule across every
+// YAML kind (RFC AN §3): mapping ⊕ mapping → merge keys; scalar/sequence → replace.
+func TestMergeConfigFiles_Matrix(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", `
+listen_addr: "127.0.0.1:8787"
+provider_priority: [anthropic, openai]
+defaults:
+  model: base-model
+  effort: low
+agents:
+  doc-manager:
+    system_prompt: from-base
+    tier: middle
+`)
+	over := writeYAML(t, dir, "over.yaml", `
+listen_addr: "0.0.0.0:9000"
+provider_priority: [deepseek]
+defaults:
+  model: over-model
+agents:
+  doc-manager:
+    system_prompt: from-over
+  code-guru:
+    tier: high
+`)
+	merged, overrides, err := mergeConfigFiles([]string{base, over})
+	if err != nil {
+		t.Fatalf("mergeConfigFiles: %v", err)
+	}
+
+	// scalar → last wins.
+	if merged["listen_addr"] != "0.0.0.0:9000" {
+		t.Errorf("listen_addr = %v, want the later layer's value", merged["listen_addr"])
+	}
+	// sequence → replaced wholesale (NOT appended).
+	pp, _ := merged["provider_priority"].([]any)
+	if len(pp) != 1 || pp[0] != "deepseek" {
+		t.Errorf("provider_priority = %v, want [deepseek] (sequences replace, not append)", merged["provider_priority"])
+	}
+	// struct mapping → field-by-field (model overridden, effort kept).
+	d, _ := merged["defaults"].(map[string]any)
+	if d["model"] != "over-model" {
+		t.Errorf("defaults.model = %v, want over-model", d["model"])
+	}
+	if d["effort"] != "low" {
+		t.Errorf("defaults.effort = %v, want low (kept from base — field merge)", d["effort"])
+	}
+	// mapping of entries → union by key; a same-named entry field-merges.
+	ag, _ := merged["agents"].(map[string]any)
+	if len(ag) != 2 {
+		t.Fatalf("agents has %d entries, want 2 (union of doc-manager + code-guru)", len(ag))
+	}
+	dm, _ := ag["doc-manager"].(map[string]any)
+	if dm["system_prompt"] != "from-over" {
+		t.Errorf("doc-manager.system_prompt = %v, want from-over (overridden)", dm["system_prompt"])
+	}
+	if dm["tier"] != "middle" {
+		t.Errorf("doc-manager.tier = %v, want middle (kept — field merge, matches mergeAgentDef)", dm["tier"])
+	}
+	if _, ok := ag["code-guru"]; !ok {
+		t.Errorf("code-guru missing — a new key in a later layer must be added")
+	}
+
+	// Override records: exactly the REPLACED leaves — listen_addr,
+	// provider_priority, defaults.model, agents.doc-manager.system_prompt.
+	// NOT defaults.effort (kept), code-guru (new), doc-manager.tier (kept).
+	for _, want := range []string{"listen_addr", "provider_priority", "defaults.model", "agents.doc-manager.system_prompt"} {
+		if !containsSub(overrides, want) {
+			t.Errorf("override for %q not recorded; got %v", want, overrides)
+		}
+	}
+	for _, notWant := range []string{"defaults.effort", "code-guru", "doc-manager.tier"} {
+		if containsSub(overrides, notWant) {
+			t.Errorf("%q must NOT be an override (added/kept, not replaced); got %v", notWant, overrides)
+		}
+	}
+}
+
+// TestMergeConfigFiles_SameValueNotAConflict: re-setting a key to the SAME value
+// across layers is not a conflict (no override record, no strict-mode trip).
+func TestMergeConfigFiles_SameValueNotAConflict(t *testing.T) {
+	dir := t.TempDir()
+	a := writeYAML(t, dir, "a.yaml", "listen_addr: \"127.0.0.1:8787\"\n")
+	b := writeYAML(t, dir, "b.yaml", "listen_addr: \"127.0.0.1:8787\"\n")
+	_, overrides, err := mergeConfigFiles([]string{a, b})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(overrides) != 0 {
+		t.Errorf("identical value across layers must not record an override; got %v", overrides)
+	}
+}
+
+// TestLoad_LayeringMotivatingCase is the RFC AN headline: a bundle file
+// contributes its agent; the operator's file (LAST) wins on
+// providers/tiers/defaults — so the bundle agent runs on the operator's routing.
+func TestLoad_LayeringMotivatingCase(t *testing.T) {
+	dir := t.TempDir()
+	bundle := writeYAML(t, dir, "bundle.yaml", `
+agents:
+  doc-manager:
+    system_prompt: manage documents
+    tier: middle
+`)
+	operator := writeYAML(t, dir, "operator.yaml", `
+defaults:
+  model: op-model
+provider_priority: [mock]
+tiers:
+  middle:
+    - provider: mock
+      model: mock-model
+agents:
+  code-guru:
+    system_prompt: review code
+`)
+	cfg, err := Load(bundle, operator)
+	if err != nil {
+		t.Fatalf("Load(bundle, operator): %v", err)
+	}
+	if _, ok := cfg.Agents["doc-manager"]; !ok {
+		t.Errorf("doc-manager (from the bundle) missing in the merged config")
+	}
+	if _, ok := cfg.Agents["code-guru"]; !ok {
+		t.Errorf("code-guru (from the operator) missing in the merged config")
+	}
+	if cfg.Defaults.Model != "op-model" {
+		t.Errorf("defaults.model = %q, want op-model (operator file last → wins)", cfg.Defaults.Model)
+	}
+	if len(cfg.ProviderPriority) != 1 || cfg.ProviderPriority[0] != "mock" {
+		t.Errorf("provider_priority = %v, want [mock] (operator's)", cfg.ProviderPriority)
+	}
+}
+
+// TestLoad_StrictModeFatalOnConflict: a cross-layer conflict is a FATAL load
+// error under LOOMCYCLE_CONFIG_STRICT=1; without it, Load succeeds + warns
+// (last-wins). The without-strict half is the fail-before for the gate.
+func TestLoad_StrictModeFatalOnConflict(t *testing.T) {
+	dir := t.TempDir()
+	f1 := writeYAML(t, dir, "f1.yaml", "defaults:\n  model: m1\n")
+	f2 := writeYAML(t, dir, "f2.yaml", "defaults:\n  model: m2\n")
+
+	// Non-strict: succeeds, last wins, the override is surfaced as a warning.
+	cfg, err := Load(f1, f2)
+	if err != nil {
+		t.Fatalf("non-strict Load: %v", err)
+	}
+	if cfg.Defaults.Model != "m2" {
+		t.Errorf("defaults.model = %q, want m2 (last wins)", cfg.Defaults.Model)
+	}
+	if !containsSub(cfg.Warnings, "defaults.model") {
+		t.Errorf("expected a layer-override warning for defaults.model; got %v", cfg.Warnings)
+	}
+
+	// Strict: the same conflict is fatal.
+	t.Setenv("LOOMCYCLE_CONFIG_STRICT", "1")
+	if _, err := Load(f1, f2); err == nil || !strings.Contains(err.Error(), "STRICT") {
+		t.Errorf("strict Load err = %v, want a fatal STRICT conflict error", err)
+	}
+}
+
+// TestLoad_PerLayerEnvExpansion: each layer's ${ENV} is expanded against its own
+// raw text before merge — a later layer can't inject into an earlier one.
+func TestLoad_PerLayerEnvExpansion(t *testing.T) {
+	t.Setenv("LOOMCYCLE_TEST_PROVIDER", "mock")
+	dir := t.TempDir()
+	f1 := writeYAML(t, dir, "f1.yaml", "defaults:\n  model: m\n")
+	f2 := writeYAML(t, dir, "f2.yaml", "provider_priority: [\"${LOOMCYCLE_TEST_PROVIDER}\"]\n")
+	cfg, err := Load(f1, f2)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.ProviderPriority) != 1 || cfg.ProviderPriority[0] != "mock" {
+		t.Errorf("provider_priority = %v, want [mock] (per-layer ${ENV} expanded)", cfg.ProviderPriority)
+	}
+}


### PR DESCRIPTION
## Why

loomcycle loads exactly **one** config file (`config.Load(path string)`), so a **bundle** — e.g. `bundles/document-agent/loomcycle.yaml`, which ships the `doc-manager` agent — can't be composed with an operator's **local** config (their providers, tiers, `volumes:`, OAuth routing). Today you hand-copy the agent block and keep it in sync; a bundle can't contribute a shared section (a `volumes:` default, an `mcp_servers:` entry) without owning the whole file.

This is **RFC AN Phase 1** — ordered config layering — implemented for the current line.

## What

- **`--config` is repeatable** (`flag.Func`) + **`LOOMCYCLE_CONFIG_FILES`** (`:`-separated, for containers/systemd). Files deep-merge **left→right, last wins**:
  ```sh
  loomcycle --config bundles/document-agent/loomcycle.yaml --config ~/.config/loomcycle/loomcycle.yaml
  ```
  Put your authoritative file LAST → the bundle contributes `doc-manager`; your file wins on providers/tiers/volumes/defaults. Env-listed files layer as the **base**; explicit `--config` flags layer after (an explicit flag always wins). With neither, the XDG default discovery is unchanged.
- **`Load(paths ...string)`** — the old `Load(path)` is the one-arg case and is **byte-identical** (single file → the historical direct unmarshal, no merge round-trip). `internal/config/layering.go` merges the YAML trees *before* typed unmarshal with **one recursive rule**: *mapping ⊕ mapping → merge keys; scalar/sequence/type-mismatch → later replaces.* So `agents`/`models`/`volumes`/… merge by key (a same-named entry field-merges, matching the `mergeAgentDef` / `LOOMCYCLE_AGENTS_ROOT` precedent); `provider_priority` replaces; struct sections field-merge.
- **Conflicts are explicit.** Every leaf a later layer *replaces* is surfaced as a startup Warning; **`LOOMCYCLE_CONFIG_STRICT=1`** makes any cross-layer conflict a **fatal load error**. Adding a new key / re-setting the same value is not a conflict. Each file keeps its own `${ENV}` expansion (no cross-layer injection); the merged whole runs the existing `validate()`.

### Deferred (RFC AN P2/P3)

The in-YAML `include:` directive and a `loomcycle config render [--provenance]` subcommand — separate follow-ups. This PR is the core layering + the strict-mode guardrail.

## Tested

`internal/config/layering_test.go`:
- **Merge matrix** — mapping union, same-named-entry field-merge, sequence-replace (not append), scalar last-wins, the override-recording set (replaced leaves only, not new keys / unchanged values), same-value-not-a-conflict.
- **Motivating case** — `Load(bundle, operator)`: both agents present, operator's providers/tiers/`defaults` win.
- **Strict mode** — a cross-layer conflict is fatal under `LOOMCYCLE_CONFIG_STRICT=1`; the non-strict half (last-wins + warning) is the fail-before.
- **Per-layer `${ENV}`** expansion.
- **Manual smoke**: `loomcycle --config bundle --config operator` logs `config: layering 2 files (last wins)` and boots past config load.
- `go test ./...` green; `gofmt` + `go vet` clean; the existing single-file config suite passes unchanged (byte-identical one-file path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
