### PR TITLE
feat(config): define skills inline in YAML (top-level skills: map)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -682,6 +682,24 @@ model: sonnet
 
 No `tier:` — uses pin path. `model: sonnet` expands via `models:` alias to `(anthropic, claude-sonnet-4-6)`. This agent never falls through to a non-Anthropic provider.
 
+**Defining skills inline (the top-level `skills:` map)** — instead of a `LOOMCYCLE_SKILLS_ROOT` directory of `SKILL.md` files, you can define skills directly in YAML, at the same level as `agents:` and `models:`:
+
+```yaml
+skills:
+  voice-applier:
+    description: Apply the house voice to drafted copy.   # informational
+    allowed_tools: [Read]     # must be a SUBSET of the bundling agent's allowed_tools
+    body: |
+      When rewriting, prefer active voice and short sentences …
+agents:
+  cv-rewriter:
+    allowed_tools: [Read, Skill]
+    skills: [voice-applier]   # references the inline skill by name (same field as before)
+    model: sonnet
+```
+
+An agent's `skills: [name]` resolves against the inline `skills:` map **first**, then `LOOMCYCLE_SKILLS_ROOT` (inline wins on a name collision); either source alone is fine — **no skills root is required** when every referenced skill is defined inline. Inline skills **merge by key across config layers** (§9e), exactly like `agents:` — so a bundled config layer can ship an agent *and* its skills together, and a later layer can override a skill by re-declaring its key. The same security invariant holds: a skill's `allowed_tools` must be ⊆ the bundling agent's, or config-load fails. (`SKILL.md` frontmatter uses the hyphenated `allowed-tools`; the inline map uses `allowed_tools` to match the rest of the loomcycle YAML.)
+
 **Multi-tool research agent**:
 
 ```yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,16 @@ import (
 
 // Config is the top-level YAML structure plus env-derived fields.
 type Config struct {
-	Defaults    Defaults             `yaml:"defaults"`
-	Models      map[string]ModelRef  `yaml:"models"`
-	Agents      map[string]AgentDef  `yaml:"agents"`
+	Defaults Defaults            `yaml:"defaults"`
+	Models   map[string]ModelRef `yaml:"models"`
+	Agents   map[string]AgentDef `yaml:"agents"`
+	// Skills defines skills INLINE, at the same level as `agents:` — a
+	// name→SkillSpec map whose bodies an agent's `skills: [name]` field
+	// references, with no LOOMCYCLE_SKILLS_ROOT directory of SKILL.md files
+	// required. Inline skills merge by key across config layers (RFC AN)
+	// like `agents`/`models`, and OVERLAY the root directory on a name
+	// collision (resolveSkills); the root stays supported as a fallback.
+	Skills      map[string]SkillSpec `yaml:"skills,omitempty"`
 	MCPServers  map[string]MCPServer `yaml:"mcp_servers"`
 	Concurrency Concurrency          `yaml:"concurrency"`
 	Cache       CacheConfig          `yaml:"cache"`
@@ -4056,17 +4063,33 @@ func resolveSystemPromptFiles(cfg *Config, configPath string) error {
 	return nil
 }
 
+// SkillSpec is an INLINE skill definition — the value type of the top-level
+// `skills:` map. It mirrors a SKILL.md loaded from LOOMCYCLE_SKILLS_ROOT but is
+// defined in YAML: the map key is the skill name an agent's `skills: [name]`
+// references; Body is the markdown bundled onto the agent's system_prompt at
+// config-load; AllowedTools is the skill's tool requirement, which resolveSkills
+// enforces is a SUBSET of the bundling agent's allowed_tools (a skill may never
+// widen the agent's tool set). Uses the underscore `allowed_tools` key to match
+// the rest of the loomcycle YAML (the SKILL.md frontmatter uses hyphenated
+// `allowed-tools`).
+type SkillSpec struct {
+	Description  string   `yaml:"description"`
+	AllowedTools []string `yaml:"allowed_tools"`
+	Body         string   `yaml:"body"`
+}
+
 // resolveSkills bundles skill bodies into agent system prompts and
 // validates each skill's allowed-tools is a subset of the bundling
 // agent's allowed_tools. Static bundling — see Approach A in
 // doc-internal/skills-design.md.
 //
 // Errors:
-//   - SkillsRoot unset but an agent lists `skills:` (silent drop would
-//     produce agents whose prompts reference skills the runtime never
-//     loaded; loud failure forces the operator to fix the config)
-//   - skills root unreadable / not a directory
-//   - agent references an unknown skill name
+//   - an agent references a skill defined in NEITHER the top-level `skills:`
+//     map NOR LOOMCYCLE_SKILLS_ROOT (silent drop would produce agents whose
+//     prompts reference skills the runtime never loaded; loud failure forces
+//     the operator to fix the config). An unset/empty skills root is NOT an
+//     error on its own — inline `skills:` can satisfy an agent entirely.
+//   - skills root set but unreadable / not a directory
 //   - skill demands a tool the agent doesn't grant (security invariant)
 //
 // SECURITY: the subset check uses internal/tools/policy.matches so
@@ -4078,21 +4101,23 @@ func resolveSystemPromptFiles(cfg *Config, configPath string) error {
 //     (skill demands broader access than agent grants)
 //   - skill `[Edit]`, agent `[Read]` → ERROR (skill widens)
 func resolveSkills(cfg *Config) error {
-	// Fast-fail when skills root is unset but agents list skills. We
-	// could no-op silently, but that produces agents whose prompts
-	// reference skills the runtime never bundled — exactly the failure
-	// mode this whole feature was added to fix.
-	if cfg.Env.SkillsRoot == "" {
-		for name, def := range cfg.Agents {
-			if len(def.Skills) > 0 {
-				return fmt.Errorf("agent %q: lists skills %v but LOOMCYCLE_SKILLS_ROOT is not set", name, def.Skills)
-			}
-		}
-		return nil
-	}
+	// Build the skill registry from two sources: the LOOMCYCLE_SKILLS_ROOT
+	// directory (file-backed SKILL.md; an empty root yields an empty set, no
+	// error) and the top-level `skills:` map (inline, merged across config
+	// layers by key like `agents:`). Inline definitions OVERLAY the root on a
+	// name collision — config is authoritative. An agent's skills may thus be
+	// satisfied entirely from inline defs with no skills root set.
 	set, err := skills.LoadSet(cfg.Env.SkillsRoot)
 	if err != nil {
 		return fmt.Errorf("load skills: %w", err)
+	}
+	for skillName, spec := range cfg.Skills {
+		set.Add(&skills.Skill{
+			Name:         skillName,
+			Description:  spec.Description,
+			AllowedTools: spec.AllowedTools,
+			Body:         spec.Body,
+		})
 	}
 	for name, def := range cfg.Agents {
 		if len(def.Skills) == 0 {
@@ -4110,7 +4135,7 @@ func resolveSkills(cfg *Config) error {
 		for _, skillName := range def.Skills {
 			sk, ok := set.Get(skillName)
 			if !ok {
-				return fmt.Errorf("agent %q: unknown skill %q (skills root: %s)", name, skillName, cfg.Env.SkillsRoot)
+				return fmt.Errorf("agent %q: unknown skill %q — define it under the top-level `skills:` map or as a SKILL.md under LOOMCYCLE_SKILLS_ROOT (%q)", name, skillName, cfg.Env.SkillsRoot)
 			}
 			// SECURITY: enforce skill.allowed-tools ⊆ agent.allowed_tools.
 			var widening []string

--- a/internal/config/skills_inline_test.go
+++ b/internal/config/skills_inline_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// agentWithSkills builds a minimal Config for resolveSkills: one agent that
+// lists the given skills, with the given allowed_tools + base prompt.
+func agentWithSkills(skillsRoot string, inline map[string]SkillSpec, agentAllowed, agentSkills []string) *Config {
+	return &Config{
+		Skills: inline,
+		Agents: map[string]AgentDef{
+			"a": {SystemPrompt: "BASE", AllowedTools: agentAllowed, Skills: agentSkills},
+		},
+		Env: Env{SkillsRoot: skillsRoot},
+	}
+}
+
+func TestResolveSkills_InlineNoRoot(t *testing.T) {
+	// An inline skill with NO LOOMCYCLE_SKILLS_ROOT set must resolve (the
+	// fast-fail relaxation) and bake its body onto the agent prompt.
+	cfg := agentWithSkills("", map[string]SkillSpec{
+		"chunker": {Description: "split prose", AllowedTools: []string{"Read"}, Body: "CHUNK GUIDANCE"},
+	}, []string{"Read"}, []string{"chunker"})
+	if err := resolveSkills(cfg); err != nil {
+		t.Fatalf("resolveSkills: %v", err)
+	}
+	got := cfg.Agents["a"]
+	if got.SystemPromptBase != "BASE" {
+		t.Errorf("SystemPromptBase = %q, want BASE (captured pre-bake)", got.SystemPromptBase)
+	}
+	if !strings.Contains(got.SystemPrompt, "CHUNK GUIDANCE") {
+		t.Errorf("skill body not bundled into the prompt: %q", got.SystemPrompt)
+	}
+}
+
+func TestResolveSkills_InlineWideningRefused(t *testing.T) {
+	// A skill may not widen the agent's tool set — even inline.
+	cfg := agentWithSkills("", map[string]SkillSpec{
+		"writer": {AllowedTools: []string{"Edit"}, Body: "x"},
+	}, []string{"Read"}, []string{"writer"})
+	if err := resolveSkills(cfg); err == nil || !strings.Contains(err.Error(), "not granted") {
+		t.Errorf("err = %v, want a tool-widening refusal", err)
+	}
+}
+
+func TestResolveSkills_InlineOverlaysRoot(t *testing.T) {
+	// A name defined in BOTH the root dir and inline → inline wins.
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "dup")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: dup\n---\nFROM ROOT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := agentWithSkills(root, map[string]SkillSpec{
+		"dup": {Body: "FROM INLINE"},
+	}, nil, []string{"dup"})
+	if err := resolveSkills(cfg); err != nil {
+		t.Fatalf("resolveSkills: %v", err)
+	}
+	sp := cfg.Agents["a"].SystemPrompt
+	if !strings.Contains(sp, "FROM INLINE") || strings.Contains(sp, "FROM ROOT") {
+		t.Errorf("inline must overlay the root; got %q", sp)
+	}
+}
+
+func TestResolveSkills_UnknownSkillErrors(t *testing.T) {
+	// A skill in neither source → a clear error naming both.
+	cfg := agentWithSkills("", nil, []string{"Read"}, []string{"nope"})
+	err := resolveSkills(cfg)
+	if err == nil || !strings.Contains(err.Error(), "unknown skill") {
+		t.Fatalf("err = %v, want an unknown-skill error", err)
+	}
+	if !strings.Contains(err.Error(), "skills:") || !strings.Contains(err.Error(), "LOOMCYCLE_SKILLS_ROOT") {
+		t.Errorf("error should name both sources; got %v", err)
+	}
+}
+
+func TestResolveSkills_RootStillWorks(t *testing.T) {
+	// Back-compat: a root-only skill (no inline) still resolves.
+	root := t.TempDir()
+	skillDir := filepath.Join(root, "rooted")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("ROOT BODY"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := agentWithSkills(root, nil, nil, []string{"rooted"})
+	if err := resolveSkills(cfg); err != nil {
+		t.Fatalf("resolveSkills: %v", err)
+	}
+	if !strings.Contains(cfg.Agents["a"].SystemPrompt, "ROOT BODY") {
+		t.Errorf("root skill body not bundled: %q", cfg.Agents["a"].SystemPrompt)
+	}
+}

--- a/internal/skills/add_test.go
+++ b/internal/skills/add_test.go
@@ -1,0 +1,24 @@
+package skills
+
+import "testing"
+
+func TestSet_Add(t *testing.T) {
+	set, err := LoadSet("") // empty root → non-nil empty set
+	if err != nil {
+		t.Fatal(err)
+	}
+	set.Add(&Skill{Name: "x", Body: "first"})
+	if sk, ok := set.Get("x"); !ok || sk.Body != "first" {
+		t.Fatalf("Get after Add = (%+v, %v), want body=first", sk, ok)
+	}
+	// Add overwrites by name (inline-overlays-root semantics).
+	set.Add(&Skill{Name: "x", Body: "second"})
+	if sk, _ := set.Get("x"); sk.Body != "second" {
+		t.Errorf("Add did not overwrite: body=%q, want second", sk.Body)
+	}
+	// Nameless / nil are no-ops, not panics.
+	set.Add(&Skill{Name: ""})
+	set.Add(nil)
+	var nilSet *Set
+	nilSet.Add(&Skill{Name: "y"}) // nil receiver no-op
+}

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -78,6 +78,21 @@ func (s *Set) Get(name string) (*Skill, bool) {
 	return sk, ok
 }
 
+// Add inserts or replaces a skill by its Name. Used to OVERLAY inline
+// config-defined skills (the top-level `skills:` map) onto a file-loaded
+// Set — an inline definition wins on a name collision with the
+// LOOMCYCLE_SKILLS_ROOT directory (config is authoritative). No-op on a
+// nil receiver or a nameless skill.
+func (s *Set) Add(sk *Skill) {
+	if s == nil || sk == nil || sk.Name == "" {
+		return
+	}
+	if s.skills == nil {
+		s.skills = map[string]*Skill{}
+	}
+	s.skills[sk.Name] = sk
+}
+
 // Names returns all loaded skill names sorted lexicographically. Used
 // by the diagnostic startup log.
 func (s *Set) Names() []string {


### PR DESCRIPTION
## Why

Skills could only be **referenced by name** (`agents.<a>.skills: [name]`) and **loaded from a single `LOOMCYCLE_SKILLS_ROOT`** directory of `SKILL.md` files — there was no way to define a skill **inline** in YAML. This blocks shipping an agent + its skills as one self-contained config layer (and was the awkward part of RFC AQ's embedded-bundle design — which needed an embedded skills *directory* + a single-root workaround).

This adds inline skills as a prerequisite, so a YAML file can carry skills at the same level as `agents:`.

## What

- **`config.SkillSpec`** `{description, allowed_tools, body}` + **`Config.Skills map[string]SkillSpec`** (`yaml:"skills"`) — a top-level map alongside `agents:`/`models:`. It **merges by key across config layers** (RFC AN) for free, like `agents:`.
- **`resolveSkills`** now builds the skill registry from **both** sources — the `LOOMCYCLE_SKILLS_ROOT` directory **and** the inline `skills:` map — with **inline overlaying the root** on a name collision (new `skills.Set.Add`). The old "`SkillsRoot` unset + an agent lists skills → fatal" fast-fail is **relaxed**: an empty root is fine, and an agent's skills can be satisfied entirely inline; an unresolved name now errors per-skill, naming **both** sources.
- The `skill.allowed_tools ⊆ agent.allowed_tools` security invariant is **unchanged** and applies to inline skills (a skill may never widen the agent's tool set).
- Back-compat: a root-only config behaves exactly as before. (`SKILL.md` frontmatter keeps `allowed-tools`; the inline map uses `allowed_tools` to match the rest of the loomcycle YAML.)

```yaml
skills:
  voice-applier:
    allowed_tools: [Read]      # ⊆ the bundling agent's allowed_tools
    body: |
      Apply the house voice …
agents:
  cv-rewriter:
    allowed_tools: [Read, Skill]
    skills: [voice-applier]    # same field as before; now resolvable inline
```

## Tested

- `internal/config` — inline skill resolves with **no root** + bakes its body; inline **overlays** the root on a name clash; **root-only still works** (back-compat); unknown skill errors **naming both sources**; tool-**widening refused**.
- `internal/skills` — `Set.Add` insert / overwrite / nil-safe.
- **Manual** (`loomcycle validate`): a config with inline skills + no `LOOMCYCLE_SKILLS_ROOT` validates **OK**; the widening + undefined-skill cases error cleanly.
- `go test ./...` green; `gofmt` + `go vet` clean.

> This is the enabler the upcoming RFC AQ (embedded config presets + agent/skill bundles) builds on — a bundle's embedded YAML can now carry its agent **and** its skills inline, riding the config-layer mechanism instead of an embedded skills directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD
