### PR TITLE
feat(webui): Settings hub — tenant token generation + operability toolkit (admin)

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1104,6 +1104,10 @@ loomcycle presets show base        # print a unit's YAML (read or fork it)
 loomcycle env-template             # print the embedded .env.insecure.example
 ```
 
+On a no-shell deployment the same three are read-only in the **Web UI Settings
+hub** (the top-right gear → **Presets**, admin-only) — backed by
+`GET /v1/_presets`, `/v1/_presets/{name}`, `/v1/_env_template`.
+
 **Selecting them.** `LOOMCYCLE_PRESETS=base,document-agent` (comma-separated,
 ordered) — or the repeatable `--preset` flag (flags override the env list) —
 layers the named units as the **base** of the config stack, under your files:

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -244,6 +244,11 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/hooks", auth.ScopeTenant},
 		{"GET", "/v1/hooks", auth.ScopeTenant},
 		{"DELETE", "/v1/hooks/h_1", auth.ScopeTenant},
+		// RFC AQ: the embedded preset/env-template read endpoints fall under the
+		// /v1/_* operator-admin default (the Settings hub is admin-only).
+		{"GET", "/v1/_presets", auth.ScopeAdmin},
+		{"GET", "/v1/_presets/base", auth.ScopeAdmin},
+		{"GET", "/v1/_env_template", auth.ScopeAdmin},
 		// Consumer gateway endpoints are NOT admin.
 		{"POST", "/v1/_llm/chat", ""},
 		{"POST", "/v1/chat/completions", ""},

--- a/internal/api/http/presets_admin.go
+++ b/internal/api/http/presets_admin.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
+)
+
+// RFC AQ — read-only HTTP introspection of the embedded config presets/bundles
+// and the env catalogue, mirroring the `loomcycle presets` / `env-template` CLI
+// so they're reachable from the Web UI Settings hub (TrueNAS has no shell —
+// RFC AR). All three fall under the /v1/_* operator-admin scope gate
+// (requiredScopeFor): admin-only, like the rest of the Settings surface. The
+// content is non-secret (only token_env *names*), so the gate is about keeping
+// the operability hub coherent, not about secrecy.
+
+// handleListPresets serves GET /v1/_presets — the embedded units (presets +
+// bundles) with name/kind/description, for the Settings → Presets list.
+func (s *Server) handleListPresets(w http.ResponseWriter, r *http.Request) {
+	units := embedded.Units()
+	out := make([]map[string]any, 0, len(units))
+	for _, u := range units {
+		out = append(out, map[string]any{
+			"name":        u.Name,
+			"kind":        u.Kind,
+			"description": u.Description,
+		})
+	}
+	writeJSONOK(w, map[string]any{"units": out})
+}
+
+// handleShowPreset serves GET /v1/_presets/{name} — one unit's YAML (read or
+// fork it). Unknown name → 404.
+func (s *Server) handleShowPreset(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	data, err := embedded.Show(name)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "unknown_preset", err.Error())
+		return
+	}
+	writeJSONOK(w, map[string]any{"name": name, "yaml": string(data)})
+}
+
+// handleEnvTemplate serves GET /v1/_env_template — the embedded
+// .env.insecure.example (non-secret env catalogue) so an operator can scaffold
+// .env.insecure from the Web UI without a source checkout.
+func (s *Server) handleEnvTemplate(w http.ResponseWriter, r *http.Request) {
+	writeJSONOK(w, map[string]any{"env": string(embedded.EnvTemplate())})
+}

--- a/internal/api/http/presets_admin_test.go
+++ b/internal/api/http/presets_admin_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The presets/env-template handlers serve only embedded content (no store/config
+// deps), so a zero Server suffices. Scope-gating is exercised by the
+// requiredScopeFor tests; these assert the handler bodies.
+
+func TestHandleListPresets(t *testing.T) {
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.handleListPresets(rec, httptest.NewRequest(http.MethodGet, "/v1/_presets", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Units []struct {
+			Name, Kind, Description string
+		} `json:"units"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byName := map[string]string{}
+	for _, u := range resp.Units {
+		byName[u.Name] = u.Kind
+	}
+	if byName["base"] != "preset" || byName["document-agent"] != "bundle" {
+		t.Errorf("units missing base(preset)/document-agent(bundle): %v", byName)
+	}
+}
+
+func TestHandleShowPreset(t *testing.T) {
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_presets/base", nil)
+	req.SetPathValue("name", "base")
+	s.handleShowPreset(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "provider_priority") {
+		t.Errorf("base YAML should contain provider_priority, got: %s", rec.Body.String())
+	}
+
+	// Unknown name → 404.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/_presets/nope", nil)
+	req.SetPathValue("name", "nope")
+	s.handleShowPreset(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("unknown preset status = %d, want 404", rec.Code)
+	}
+}
+
+func TestHandleEnvTemplate(t *testing.T) {
+	s := &Server{}
+	rec := httptest.NewRecorder()
+	s.handleEnvTemplate(rec, httptest.NewRequest(http.MethodGet, "/v1/_env_template", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "LOOMCYCLE_") {
+		t.Errorf("env template should contain LOOMCYCLE_ vars")
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2374,6 +2374,12 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("GET /v1/_webhookdef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListWebhookDefNames))))
 	mux.Handle("GET /v1/_memorybackenddef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListMemoryBackendDefNames))))
 	mux.Handle("GET /v1/_operatortokendef/names", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListOperatorTokenDefNames))))
+	// RFC AQ — read-only embedded preset/bundle + env-template introspection
+	// (the `loomcycle presets` / `env-template` CLI, web-reachable for the
+	// Settings hub). Admin-gated via the /v1/_* default in requiredScopeFor.
+	mux.Handle("GET /v1/_presets", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListPresets))))
+	mux.Handle("GET /v1/_presets/{name}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleShowPreset))))
+	mux.Handle("GET /v1/_env_template", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleEnvTemplate))))
 	// v0.9.x Library v2 — unified enumeration that merges static cfg
 	// + substrate views into one envelope per entry. The names/* sister
 	// endpoints above stay as-is for backwards compat with external

--- a/internal/help/builtin/operator-tokens.md
+++ b/internal/help/builtin/operator-tokens.md
@@ -82,6 +82,17 @@ token is rotated, not recovered. The same operations are available over
 HTTP (`POST /v1/_operatortokendef`), gRPC, the MCP `operatortokendef`
 meta-tool, and the TS client's `operatorTokenDef()`.
 
+### From the Web UI (no shell)
+
+When the binary's CLI isn't reachable — a packaged deployment such as the
+TrueNAS app — the same lifecycle is in the **Settings hub**: sign in with an
+admin (root) token, click the **gear** (top-right), and open **Tokens**.
+Generate (the secret is revealed once with a copy button), list, rotate, and
+retire — backed by the same `POST /v1/_operatortokendef`. The gear and the
+Tokens panel are **admin-only** (a `substrate:tenant` session never sees them);
+the Settings hub also surfaces the embedded **Presets** (RFC AQ), **Runtime**
+(pause/resume), and **Health**.
+
 ## Rotation grace
 
 `rotate` mints a new token for the same principal and marks the prior

--- a/internal/webui/webui.go
+++ b/internal/webui/webui.go
@@ -67,6 +67,24 @@ func Handler(prefix string, secureCookie bool) http.Handler {
 		serveFile(w, "index.html")
 	})
 
+	// Logout — clears the session cookie and bounces to the login page. The
+	// cookie is HttpOnly, so JS can't clear it; this server route is the only
+	// way to end a Web UI session. A full navigation to <prefix>/logout (not a
+	// router push) runs this handler before React Router sees the path. More
+	// specific than the catch-all below, so Go 1.22 ServeMux routes here first.
+	mux.HandleFunc(fmt.Sprintf("GET %s/logout", prefix), func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     SessionCookie,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+			Secure:   secureCookie || r.TLS != nil,
+			MaxAge:   -1, // delete now
+		})
+		http.Redirect(w, r, prefix+"/login", http.StatusFound)
+	})
+
 	mux.HandleFunc(fmt.Sprintf("GET %s/", prefix), func(w http.ResponseWriter, r *http.Request) {
 		rel := strings.TrimPrefix(r.URL.Path, prefix+"/")
 		if rel == "" {

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -43,6 +43,33 @@ func TestHandler_TokenQueryRedirectsAndSetsCookie(t *testing.T) {
 	}
 }
 
+func TestHandler_LogoutClearsCookieAndRedirects(t *testing.T) {
+	h := Handler("/ui", false)
+	req := httptest.NewRequest("GET", "/ui/logout", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302 (logout redirect)", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/ui/login" {
+		t.Errorf("Location = %q, want /ui/login", loc)
+	}
+	var found *http.Cookie
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == SessionCookie {
+			found = c
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s cookie in response — logout must emit a clearing Set-Cookie", SessionCookie)
+	}
+	// A deletion cookie: empty value + MaxAge<0 (the browser drops it).
+	if found.Value != "" || found.MaxAge >= 0 {
+		t.Errorf("logout cookie not a deletion: value=%q MaxAge=%d (want \"\" and <0)", found.Value, found.MaxAge)
+	}
+}
+
 func TestHandler_SecureCookieFlag(t *testing.T) {
 	// secureCookie=true forces the Secure attribute even when r.TLS is
 	// nil — covers the operator behind a TLS terminator.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2082,3 +2082,109 @@ export function userEchoTranscript(seq: number, text: string): TranscriptEvent {
     event: { type: "user_echo", text },
   };
 }
+
+// ─── RFC AQ / RFC L — Settings hub: embedded presets + operator tokens ───────
+
+export interface PresetUnit {
+  name: string;
+  kind: string; // "preset" | "bundle"
+  description: string;
+}
+
+// listPresets / showPreset / getEnvTemplate mirror the `loomcycle presets` /
+// `env-template` CLI over HTTP (admin-gated) — the embedded config base, viewable
+// on a no-shell deployment.
+export function listPresets(): Promise<{ units: PresetUnit[] }> {
+  return jsonFetch<{ units: PresetUnit[] }>("/v1/_presets");
+}
+
+export function showPreset(name: string): Promise<{ name: string; yaml: string }> {
+  return jsonFetch<{ name: string; yaml: string }>(`/v1/_presets/${encodeURIComponent(name)}`);
+}
+
+export function getEnvTemplate(): Promise<{ env: string }> {
+  return jsonFetch<{ env: string }>("/v1/_env_template");
+}
+
+// Operator/tenant token management (RFC L). POST /v1/_operatortokendef dispatches
+// by `op`. A refused op returns 422 {code:"tool_refused", error, tool}; the
+// helper surfaces the human-readable `error`.
+export interface OperatorTokenNameSummary {
+  name: string;
+  tenant_id: string;
+  subject: string;
+  token_count: number;
+  has_current: boolean;
+  last_updated: string;
+}
+
+export interface OperatorTokenCreateResult {
+  def_id: string;
+  name: string;
+  tenant_id: string;
+  subject: string;
+  allowed_scopes: string[];
+  created_at: string;
+  token: string; // plaintext — shown ONCE, never retrievable again
+  token_suffix: string;
+  warning: string;
+  retired: boolean;
+}
+
+async function postOperatorToken<T>(input: Record<string, unknown>): Promise<T> {
+  const resp = await fetch(baseURL + "/v1/_operatortokendef", {
+    method: "POST",
+    credentials: "same-origin",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!resp.ok) {
+    if (redirectToLoginOn401(resp.status)) return new Promise<T>(() => {});
+    const raw = await resp.text();
+    let msg = `${resp.status} ${resp.statusText}: ${raw.slice(0, 200)}`;
+    try {
+      const env = JSON.parse(raw);
+      if (env && typeof env.error === "string") msg = env.error;
+    } catch {
+      // non-JSON body — keep the status-line message
+    }
+    throw new Error(msg);
+  }
+  return resp.json() as Promise<T>;
+}
+
+// listOperatorTokens returns one summary per token NAME (no secrets).
+export function listOperatorTokens(): Promise<{ names: OperatorTokenNameSummary[] }> {
+  return jsonFetch<{ names: OperatorTokenNameSummary[] }>("/v1/_operatortokendef/names");
+}
+
+export function mintOperatorToken(req: {
+  name: string;
+  tenant_id: string;
+  subject?: string;
+  scopes?: string[];
+}): Promise<OperatorTokenCreateResult> {
+  return postOperatorToken<OperatorTokenCreateResult>({ op: "create", ...req });
+}
+
+export function rotateOperatorToken(name: string, graceSeconds?: number): Promise<OperatorTokenCreateResult> {
+  const input: Record<string, unknown> = { op: "rotate", name };
+  if (graceSeconds && graceSeconds > 0) input.grace_seconds = graceSeconds;
+  return postOperatorToken<OperatorTokenCreateResult>(input);
+}
+
+export function retireOperatorToken(
+  name: string,
+): Promise<{ def_id: string; name: string; retired: boolean }> {
+  return postOperatorToken<{ def_id: string; name: string; retired: boolean }>({ op: "retire", name });
+}
+
+// The RFC L closed scope catalog — the token-mint form's scope choices.
+export const TOKEN_SCOPES = [
+  "substrate:tenant",
+  "substrate:admin",
+  "runs:create",
+  "runs:read",
+  "channel:publish",
+  "channel:read",
+] as const;

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import {
   HardDrive,
   Library,
   ListTree,
+  LogOut,
   type LucideIcon,
   Moon,
   PanelLeftClose,
@@ -357,6 +358,13 @@ export default function Layout() {
               <Settings size={16} />
             </NavLink>
           )}
+          {/* Sign out — clears the HttpOnly session cookie via the server's
+              /ui/logout route (JS can't clear it) and bounces to /login. A
+              full-page anchor (not a router push) so the Go handler runs.
+              Available to every authenticated role, not just admin. */}
+          <a href="/ui/logout" className="logout-btn" title="Sign out" aria-label="Sign out">
+            <LogOut size={16} />
+          </a>
         </header>
         <main className="content">
           <Outlet context={{ userId, principal: principal ?? null, focusTenant }} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import {
   Plug,
   Radio,
   ScrollText,
+  Settings,
   Sun,
 } from "lucide-react";
 import { Principal, UserSummary, getHealth, getWhoami, listUsers } from "../api";
@@ -347,6 +348,15 @@ export default function Layout() {
               </form>
             )}
           </div>
+          {/* Settings hub — operator/admin-only gear, rightmost. Web-reaches the
+              critical CLI surfaces (tokens, presets, runtime, health) for no-shell
+              deployments (the TrueNAS RFC AR prerequisite). Hidden for tenants; the
+              page re-guards, and the backend gates each surface server-side. */}
+          {isAdmin && (
+            <NavLink to="/settings" className="settings-gear" title="Settings" aria-label="Settings">
+              <Settings size={16} />
+            </NavLink>
+          )}
         </header>
         <main className="content">
           <Outlet context={{ userId, principal: principal ?? null, focusTenant }} />

--- a/web/src/components/TokenManager.tsx
+++ b/web/src/components/TokenManager.tsx
@@ -1,0 +1,298 @@
+import { useEffect, useState } from "react";
+import {
+  OperatorTokenCreateResult,
+  OperatorTokenNameSummary,
+  TOKEN_SCOPES,
+  listOperatorTokens,
+  mintOperatorToken,
+  retireOperatorToken,
+  rotateOperatorToken,
+} from "../api";
+
+// TokenManager is the Settings → Tokens panel (RFC L token minting, web-reachable
+// for no-shell deployments — RFC AR/TrueNAS). It mirrors the `loomcycle
+// operator-token` CLI: generate a tenant/operator token (shown ONCE), list the
+// existing names, rotate, and retire. Admin-only — the backend gates
+// POST /v1/_operatortokendef at substrate:admin and SettingsView only renders
+// this for an is_admin principal, so this is the redundant client-side half.
+const DEFAULT_SCOPES = ["substrate:tenant"];
+
+export default function TokenManager() {
+  const [names, setNames] = useState<OperatorTokenNameSummary[]>([]);
+  const [listErr, setListErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Mint form.
+  const [name, setName] = useState("");
+  const [tenantId, setTenantId] = useState("");
+  const [subject, setSubject] = useState("");
+  const [scopes, setScopes] = useState<string[]>(DEFAULT_SCOPES);
+  const [busy, setBusy] = useState(false);
+  const [formErr, setFormErr] = useState<string | null>(null);
+
+  // The show-once secret (from create OR rotate). Cleared by the operator.
+  const [minted, setMinted] = useState<OperatorTokenCreateResult | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const refresh = async () => {
+    setLoading(true);
+    try {
+      const resp = await listOperatorTokens();
+      setNames(resp.names ?? []);
+      setListErr(null);
+    } catch (e) {
+      setListErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const toggleScope = (s: string) => {
+    setScopes((cur) => (cur.includes(s) ? cur.filter((x) => x !== s) : [...cur, s]));
+  };
+
+  const doMint = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (busy) return;
+    setFormErr(null);
+    if (!name.trim() || !tenantId.trim()) {
+      setFormErr("name and tenant are required");
+      return;
+    }
+    if (scopes.length === 0) {
+      setFormErr("select at least one scope");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await mintOperatorToken({
+        name: name.trim(),
+        tenant_id: tenantId.trim(),
+        subject: subject.trim() || undefined,
+        scopes,
+      });
+      setMinted(res);
+      setCopied(false);
+      // Clear the form for the next mint; keep the tenant (operators often mint
+      // several tokens for one tenant).
+      setName("");
+      setSubject("");
+      setScopes(DEFAULT_SCOPES);
+      await refresh();
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doRotate = async (n: string) => {
+    if (busy) return;
+    if (!confirm(`Rotate token "${n}"? The current secret keeps working during the grace window, then stops. A fresh secret is shown once.`)) {
+      return;
+    }
+    setBusy(true);
+    setFormErr(null);
+    try {
+      const res = await rotateOperatorToken(n);
+      setMinted(res);
+      setCopied(false);
+      await refresh();
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doRetire = async (n: string) => {
+    if (busy) return;
+    if (!confirm(`Retire token "${n}"? Its secret stops authenticating immediately. This cannot be undone (mint a new token to replace it).`)) {
+      return;
+    }
+    setBusy(true);
+    setFormErr(null);
+    try {
+      await retireOperatorToken(n);
+      await refresh();
+    } catch (e) {
+      setFormErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyToken = async () => {
+    if (!minted) return;
+    try {
+      await navigator.clipboard.writeText(minted.token);
+      setCopied(true);
+    } catch {
+      // Clipboard may be unavailable (insecure context); the token is visible
+      // for manual copy regardless.
+    }
+  };
+
+  return (
+    <div className="settings-panel">
+      <h2>Tokens</h2>
+      <p className="settings-help">
+        Mint per-principal bearer tokens (RFC L). Each binds an authoritative{" "}
+        <code>tenant</code> + <code>subject</code> + scopes. A{" "}
+        <code>substrate:tenant</code> token gives a downstream service full power
+        within its own tenant; <code>substrate:admin</code> is full operator
+        power. The secret is shown <strong>once</strong> and never retrievable
+        again.
+      </p>
+
+      {minted && (
+        <div className="token-reveal">
+          <div className="token-reveal-head">
+            <strong>New token for “{minted.name}”</strong>
+            <span className="token-reveal-warn">{minted.warning}</span>
+          </div>
+          <div className="token-reveal-row">
+            <code className="token-secret">{minted.token}</code>
+            <button type="button" onClick={copyToken} className="primary-btn">
+              {copied ? "copied ✓" : "copy"}
+            </button>
+            <button type="button" onClick={() => setMinted(null)} className="ghost-btn">
+              dismiss
+            </button>
+          </div>
+          <div className="token-reveal-meta">
+            tenant <code>{minted.tenant_id}</code> · subject{" "}
+            <code>{minted.subject}</code> · scopes{" "}
+            <code>{minted.allowed_scopes.join(", ")}</code>
+          </div>
+        </div>
+      )}
+
+      <form className="token-form" onSubmit={doMint}>
+        <div className="token-form-grid">
+          <label>
+            name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="jobember-prod"
+              pattern="[a-zA-Z0-9_-]{1,64}"
+              title="letters, digits, _ and - (1–64 chars)"
+            />
+          </label>
+          <label>
+            tenant
+            <input
+              type="text"
+              value={tenantId}
+              onChange={(e) => setTenantId(e.target.value)}
+              placeholder="jobember"
+              pattern="[a-zA-Z0-9_-]{1,64}"
+              title="letters, digits, _ and - (1–64 chars)"
+            />
+          </label>
+          <label>
+            subject <span className="optional">(optional)</span>
+            <input
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder={name ? `tok-${name}` : "tok-<name>"}
+              pattern="[a-zA-Z0-9_-]{1,64}"
+              title="letters, digits, _ and - (1–64 chars)"
+            />
+          </label>
+        </div>
+        <fieldset className="token-scopes">
+          <legend>scopes</legend>
+          {TOKEN_SCOPES.map((s) => (
+            <label key={s} className="scope-check">
+              <input
+                type="checkbox"
+                checked={scopes.includes(s)}
+                onChange={() => toggleScope(s)}
+              />
+              <code>{s}</code>
+            </label>
+          ))}
+        </fieldset>
+        {formErr && <div className="settings-error">{formErr}</div>}
+        <button type="submit" className="primary-btn" disabled={busy}>
+          {busy ? "working…" : "Generate token"}
+        </button>
+      </form>
+
+      <h3 className="settings-subhead">Existing tokens</h3>
+      {listErr && <div className="settings-error">{listErr}</div>}
+      {loading ? (
+        <div className="settings-muted">loading…</div>
+      ) : names.length === 0 ? (
+        <div className="settings-muted">No tokens minted yet.</div>
+      ) : (
+        <table className="settings-table">
+          <thead>
+            <tr>
+              <th>name</th>
+              <th>tenant</th>
+              <th>subject</th>
+              <th>status</th>
+              <th>updated</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {names.map((t) => (
+              <tr key={t.name}>
+                <td>
+                  <code>{t.name}</code>
+                </td>
+                <td>
+                  <code>{t.tenant_id}</code>
+                </td>
+                <td>
+                  <code>{t.subject}</code>
+                </td>
+                <td>
+                  {t.has_current ? (
+                    <span className="status-pill status-ok">active</span>
+                  ) : (
+                    <span className="status-pill status-retired">retired</span>
+                  )}
+                  {t.token_count > 1 && (
+                    <span className="settings-muted"> · {t.token_count} versions</span>
+                  )}
+                </td>
+                <td className="settings-muted">
+                  {new Date(t.last_updated).toLocaleString()}
+                </td>
+                <td className="settings-row-actions">
+                  <button
+                    type="button"
+                    className="ghost-btn"
+                    disabled={busy || !t.has_current}
+                    onClick={() => doRotate(t.name)}
+                  >
+                    rotate
+                  </button>
+                  <button
+                    type="button"
+                    className="ghost-btn danger"
+                    disabled={busy || !t.has_current}
+                    onClick={() => doRetire(t.name)}
+                  >
+                    retire
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -23,6 +23,7 @@ import PathTreeView from "./pages/PathTreeView";
 import DocumentsView from "./pages/DocumentsView";
 import ChannelsView from "./pages/ChannelsView";
 import SchedulesView from "./pages/SchedulesView";
+import SettingsView from "./pages/SettingsView";
 import Layout from "./components/Layout";
 import AgentIdRedirect from "./components/AgentIdRedirect";
 import LoginView from "./pages/LoginView";
@@ -82,6 +83,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="snapshots" element={<SnapshotsView />} />
           <Route path="audit" element={<AuditView />} />
           <Route path="activity" element={<ActivityMonitor />} />
+          <Route path="settings" element={<SettingsView />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />
         </Route>
       </Routes>

--- a/web/src/pages/SettingsView.tsx
+++ b/web/src/pages/SettingsView.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  HealthResponse,
+  PresetUnit,
+  RuntimeStateResponse,
+  getEnvTemplate,
+  getHealth,
+  getRuntimeState,
+  listPresets,
+  pauseRuntime,
+  resumeRuntime,
+  showPreset,
+} from "../api";
+import { usePrincipal } from "../components/Layout";
+import TokenManager from "../components/TokenManager";
+
+// SettingsView is the operator Settings hub (top-bar gear). It web-reaches the
+// critical `loomcycle` CLI surfaces so a no-shell deployment (TrueNAS — RFC AR)
+// stays operable: tenant/operator tokens (RFC L), the embedded config presets
+// (RFC AQ), runtime quiesce, and health. Admin-only — the gear is rendered for
+// is_admin in the Layout, and this view re-guards (a tenant that deep-links here
+// is told it's operator-only). Surfaces that already have their own pages
+// (snapshots, audit) are linked, not duplicated.
+type Section = "tokens" | "presets" | "runtime" | "health";
+
+const SECTIONS: { id: Section; label: string }[] = [
+  { id: "tokens", label: "Tokens" },
+  { id: "presets", label: "Presets" },
+  { id: "runtime", label: "Runtime" },
+  { id: "health", label: "Health" },
+];
+
+export default function SettingsView() {
+  const principal = usePrincipal();
+  const [section, setSection] = useState<Section>("tokens");
+
+  if (principal && !principal.is_admin) {
+    return (
+      <div className="settings-view">
+        <div className="settings-panel">
+          <h2>Settings</h2>
+          <p className="settings-muted">
+            Settings is operator-admin only. Sign in with an admin (root) token
+            to manage tokens, presets, and runtime.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="settings-view">
+      <nav className="settings-tabs">
+        {SECTIONS.map((s) => (
+          <button
+            key={s.id}
+            type="button"
+            className={"settings-tab" + (section === s.id ? " active" : "")}
+            onClick={() => setSection(s.id)}
+          >
+            {s.label}
+          </button>
+        ))}
+      </nav>
+      <div className="settings-body">
+        {section === "tokens" && <TokenManager />}
+        {section === "presets" && <PresetsSection />}
+        {section === "runtime" && <RuntimeSection />}
+        {section === "health" && <HealthSection />}
+      </div>
+    </div>
+  );
+}
+
+// ─── Presets ─────────────────────────────────────────────────────────────────
+
+function PresetsSection() {
+  const [units, setUnits] = useState<PresetUnit[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [yaml, setYaml] = useState<string>("");
+  const [yamlBusy, setYamlBusy] = useState(false);
+
+  useEffect(() => {
+    listPresets()
+      .then((r) => setUnits(r.units ?? []))
+      .catch((e) => setErr(e instanceof Error ? e.message : String(e)));
+  }, []);
+
+  const view = async (name: string) => {
+    setSelected(name);
+    setYamlBusy(true);
+    try {
+      if (name === "__env__") {
+        const r = await getEnvTemplate();
+        setYaml(r.env);
+      } else {
+        const r = await showPreset(name);
+        setYaml(r.yaml);
+      }
+    } catch (e) {
+      setYaml("# error: " + (e instanceof Error ? e.message : String(e)));
+    } finally {
+      setYamlBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-panel">
+      <h2>Embedded presets &amp; bundles</h2>
+      <p className="settings-help">
+        Config layers shipped inside the binary (RFC AQ). Select them with{" "}
+        <code>LOOMCYCLE_PRESETS=base,document-agent</code> as the base of the
+        config stack. These are read-only here — copy a unit's YAML to fork it.
+      </p>
+      {err && <div className="settings-error">{err}</div>}
+      <div className="presets-layout">
+        <div className="presets-list">
+          {units.map((u) => (
+            <button
+              key={u.name}
+              type="button"
+              className={"presets-item" + (selected === u.name ? " active" : "")}
+              onClick={() => view(u.name)}
+            >
+              <div className="presets-item-head">
+                <code>{u.name}</code>
+                <span className={"kind-pill kind-" + u.kind}>{u.kind}</span>
+              </div>
+              <div className="presets-item-desc">{u.description}</div>
+            </button>
+          ))}
+          <button
+            type="button"
+            className={"presets-item" + (selected === "__env__" ? " active" : "")}
+            onClick={() => view("__env__")}
+          >
+            <div className="presets-item-head">
+              <code>.env.insecure.example</code>
+              <span className="kind-pill kind-env">env</span>
+            </div>
+            <div className="presets-item-desc">
+              The non-secret env catalogue (the <code>env-template</code> CLI).
+            </div>
+          </button>
+        </div>
+        <div className="presets-viewer">
+          {selected ? (
+            yamlBusy ? (
+              <div className="settings-muted">loading…</div>
+            ) : (
+              <pre className="settings-code">{yaml}</pre>
+            )
+          ) : (
+            <div className="settings-muted">Select a unit to view its YAML.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Runtime (pause / resume / state) ────────────────────────────────────────
+
+function RuntimeSection() {
+  const [state, setState] = useState<RuntimeStateResponse | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [flash, setFlash] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    try {
+      setState(await getRuntimeState());
+      setUnavailable(false);
+      setErr(null);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes("503")) setUnavailable(true);
+      else setErr(msg);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+    const t = setInterval(refresh, 5_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const doPause = async () => {
+    if (busy) return;
+    if (!confirm("Pause the runtime? In-flight idempotent tools are cancelled immediately; non-idempotent tools get a 30-second wind-down. New runs return 503 until you resume.")) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const r = await pauseRuntime();
+      setState({ state: r.state as RuntimeStateResponse["state"], paused_runs_count: r.paused_runs_count });
+      setFlash(`paused (${r.duration_ms} ms, ${r.force_cancelled_count} force-cancelled, ${r.paused_runs_count} paused runs)`);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const doResume = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const r = await resumeRuntime();
+      setState({ state: r.state as RuntimeStateResponse["state"], paused_runs_count: 0 });
+      setFlash(`resumed (${r.resumed_runs_count} runs released)`);
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="settings-panel">
+      <h2>Runtime</h2>
+      <p className="settings-help">
+        Quiesce the runtime for a maintenance window or a consistent snapshot
+        (the <code>pause</code> / <code>resume</code> CLI). Paused: new runs
+        return 503; in-flight runs park at a safe boundary.
+      </p>
+      {unavailable ? (
+        <div className="settings-muted">
+          Pause/resume is not wired on this instance.
+        </div>
+      ) : (
+        <>
+          <div className="runtime-state">
+            state:{" "}
+            <span className={"status-pill status-" + (state?.state === "running" ? "ok" : "warn")}>
+              {state?.state ?? "…"}
+            </span>
+            {state && state.paused_runs_count > 0 && (
+              <span className="settings-muted"> · {state.paused_runs_count} paused runs</span>
+            )}
+          </div>
+          <div className="settings-row-actions">
+            <button type="button" className="ghost-btn danger" disabled={busy || state?.state !== "running"} onClick={doPause}>
+              pause
+            </button>
+            <button type="button" className="primary-btn" disabled={busy || state?.state === "running"} onClick={doResume}>
+              resume
+            </button>
+          </div>
+          {flash && <div className="settings-flash">{flash}</div>}
+        </>
+      )}
+      {err && <div className="settings-error">{err}</div>}
+
+      <h3 className="settings-subhead">Snapshots</h3>
+      <p className="settings-help">
+        Capture / restore runtime state for HA and migration.{" "}
+        <Link to="/snapshots">Open the Snapshots page →</Link>
+      </p>
+      <h3 className="settings-subhead">Audit</h3>
+      <p className="settings-help">
+        Token mint/rotate/retire and other admin actions are recorded.{" "}
+        <Link to="/audit">Open the Audit log →</Link>
+      </p>
+    </div>
+  );
+}
+
+// ─── Health ──────────────────────────────────────────────────────────────────
+
+function HealthSection() {
+  const [health, setHealth] = useState<HealthResponse | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = async () => {
+    try {
+      setHealth(await getHealth());
+      setErr(null);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  return (
+    <div className="settings-panel">
+      <h2>Health</h2>
+      <p className="settings-help">
+        Liveness + the running binary version (the <code>health</code> /{" "}
+        <code>doctor</code> CLIs). For deeper checks (provider keys, storage), run{" "}
+        <code>loomcycle doctor</code> where the binary is available.
+      </p>
+      {err && <div className="settings-error">{err}</div>}
+      {health && (
+        <table className="settings-table">
+          <tbody>
+            <tr>
+              <td>status</td>
+              <td>
+                <span className={"status-pill status-" + (health.ok ? "ok" : "warn")}>
+                  {health.ok ? "ok" : "degraded"}
+                </span>
+              </td>
+            </tr>
+            <tr>
+              <td>version</td>
+              <td>
+                <code>{health.version || "unknown"}</code>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      )}
+      <button type="button" className="ghost-btn" onClick={refresh}>
+        refresh
+      </button>
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5373,3 +5373,360 @@ button.primary:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ======================================================
+ * Settings hub — the top-bar gear → /settings.
+ * Tokens / presets / runtime / health, web-reaching the
+ * critical CLI surfaces for no-shell deployments (TrueNAS).
+ * ====================================================== */
+.settings-gear {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 28px;
+  background: transparent;
+  color: var(--lc-text-muted);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  cursor: pointer;
+  padding: 0;
+}
+.settings-gear:hover,
+.settings-gear.active {
+  color: var(--lc-text);
+  border-color: var(--lc-accent);
+}
+
+.settings-view {
+  padding: var(--lc-space-3);
+  max-width: 980px;
+  margin: 0 auto;
+  width: 100%;
+}
+.settings-tabs {
+  display: flex;
+  gap: var(--lc-space-1);
+  border-bottom: 1px solid var(--lc-rule);
+  margin-bottom: var(--lc-space-3);
+}
+.settings-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-base);
+  padding: var(--lc-space-1) var(--lc-space-2);
+  cursor: pointer;
+  margin-bottom: -1px;
+}
+.settings-tab:hover {
+  color: var(--lc-text);
+}
+.settings-tab.active {
+  color: var(--lc-text);
+  border-bottom-color: var(--lc-accent);
+  font-weight: 600;
+}
+
+.settings-panel {
+  background: var(--lc-surface);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius);
+  padding: var(--lc-space-3);
+}
+.settings-panel h2 {
+  margin: 0 0 var(--lc-space-1);
+  font-size: var(--lc-text-lg);
+}
+.settings-subhead {
+  margin: var(--lc-space-3) 0 var(--lc-space-1);
+  font-size: var(--lc-text-md);
+}
+.settings-help {
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-sm);
+  line-height: 1.5;
+  margin: 0 0 var(--lc-space-2);
+}
+.settings-help code,
+.settings-panel code {
+  font-family: var(--lc-font-mono);
+  font-size: 0.92em;
+  background: var(--lc-surface-2);
+  padding: 1px 5px;
+  border-radius: var(--lc-radius-sm);
+}
+.settings-muted {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+}
+.settings-error {
+  color: var(--lc-failed);
+  background: rgba(255, 93, 104, 0.1);
+  border: 1px solid rgba(255, 93, 104, 0.3);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-1) var(--lc-space-2);
+  font-size: var(--lc-text-sm);
+  margin: var(--lc-space-1) 0;
+}
+.settings-flash {
+  color: var(--lc-completed);
+  font-size: var(--lc-text-sm);
+  margin-top: var(--lc-space-1);
+}
+
+.settings-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--lc-text-sm);
+}
+.settings-table th {
+  text-align: left;
+  color: var(--lc-text-muted);
+  font-weight: 600;
+  padding: var(--lc-space-1);
+  border-bottom: 1px solid var(--lc-rule);
+}
+.settings-table td {
+  padding: var(--lc-space-1);
+  border-bottom: 1px solid var(--lc-rule);
+  vertical-align: middle;
+}
+.settings-row-actions {
+  display: flex;
+  gap: var(--lc-space-1);
+  align-items: center;
+}
+
+/* Buttons */
+.primary-btn,
+.ghost-btn {
+  font-size: var(--lc-text-sm);
+  padding: 6px 12px;
+  border-radius: var(--lc-radius-sm);
+  cursor: pointer;
+  border: 1px solid var(--lc-rule);
+}
+.primary-btn {
+  background: var(--lc-accent);
+  color: var(--lc-text-inverse);
+  border-color: var(--lc-accent);
+  font-weight: 600;
+}
+.primary-btn:hover:not(:disabled) {
+  background: var(--lc-accent-hover);
+}
+.ghost-btn {
+  background: transparent;
+  color: var(--lc-text);
+}
+.ghost-btn:hover:not(:disabled) {
+  border-color: var(--lc-accent);
+}
+.ghost-btn.danger {
+  color: var(--lc-failed);
+}
+.ghost-btn.danger:hover:not(:disabled) {
+  border-color: var(--lc-failed);
+}
+.primary-btn:disabled,
+.ghost-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Status pills */
+.status-pill {
+  display: inline-block;
+  font-size: var(--lc-text-xs);
+  font-weight: 600;
+  padding: 1px 8px;
+  border-radius: 999px;
+}
+.status-ok {
+  background: rgba(78, 201, 176, 0.16);
+  color: var(--lc-completed);
+}
+.status-warn {
+  background: rgba(240, 160, 64, 0.16);
+  color: var(--lc-running);
+}
+.status-retired {
+  background: var(--lc-surface-2);
+  color: var(--lc-text-faint);
+}
+
+/* Token reveal (shown once) */
+.token-reveal {
+  background: var(--lc-accent-soft);
+  border: 1px solid var(--lc-accent);
+  border-radius: var(--lc-radius);
+  padding: var(--lc-space-2);
+  margin-bottom: var(--lc-space-3);
+}
+.token-reveal-head {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--lc-space-2);
+  margin-bottom: var(--lc-space-1);
+  flex-wrap: wrap;
+}
+.token-reveal-warn {
+  color: var(--lc-running);
+  font-size: var(--lc-text-xs);
+}
+.token-reveal-row {
+  display: flex;
+  gap: var(--lc-space-1);
+  align-items: center;
+  flex-wrap: wrap;
+}
+.token-secret {
+  flex: 1;
+  min-width: 220px;
+  font-family: var(--lc-font-mono);
+  font-size: var(--lc-text-sm);
+  background: var(--lc-bg);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: 6px 10px;
+  word-break: break-all;
+}
+.token-reveal-meta {
+  margin-top: var(--lc-space-1);
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-xs);
+}
+
+/* Token mint form */
+.token-form {
+  margin-bottom: var(--lc-space-3);
+}
+.token-form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--lc-space-2);
+  margin-bottom: var(--lc-space-2);
+}
+.token-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: var(--lc-text-sm);
+  color: var(--lc-text-muted);
+}
+.token-form input[type="text"] {
+  background: var(--lc-input-bg);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  color: var(--lc-text);
+  padding: 6px 10px;
+  font-size: var(--lc-text-sm);
+}
+.token-form .optional {
+  color: var(--lc-text-faint);
+  font-weight: 400;
+}
+.token-scopes {
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-1) var(--lc-space-2);
+  margin-bottom: var(--lc-space-2);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--lc-space-2);
+}
+.token-scopes legend {
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-sm);
+  padding: 0 4px;
+}
+.scope-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: var(--lc-text-sm);
+}
+
+/* Presets viewer */
+.presets-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 320px) 1fr;
+  gap: var(--lc-space-2);
+}
+@media (max-width: 720px) {
+  .presets-layout {
+    grid-template-columns: 1fr;
+  }
+}
+.presets-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--lc-space-1);
+}
+.presets-item {
+  text-align: left;
+  background: var(--lc-surface-2);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-1) var(--lc-space-2);
+  cursor: pointer;
+  color: var(--lc-text);
+}
+.presets-item:hover {
+  border-color: var(--lc-accent);
+}
+.presets-item.active {
+  border-color: var(--lc-accent);
+  background: var(--lc-accent-soft);
+}
+.presets-item-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--lc-space-1);
+}
+.presets-item-desc {
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-xs);
+  margin-top: 3px;
+  line-height: 1.4;
+}
+.kind-pill {
+  font-size: var(--lc-text-xs);
+  padding: 0 7px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+.kind-preset {
+  background: rgba(80, 140, 220, 0.16);
+  color: #6fa8e8;
+}
+.kind-bundle {
+  background: var(--lc-accent-soft);
+  color: var(--lc-accent);
+}
+.kind-env {
+  background: rgba(176, 139, 208, 0.16);
+  color: var(--lc-cancelled);
+}
+.presets-viewer {
+  min-width: 0;
+}
+.settings-code {
+  background: var(--lc-bg);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  padding: var(--lc-space-2);
+  font-family: var(--lc-font-mono);
+  font-size: var(--lc-text-xs);
+  line-height: 1.5;
+  overflow-x: auto;
+  max-height: 60vh;
+  white-space: pre;
+}
+.runtime-state {
+  font-size: var(--lc-text-sm);
+  margin-bottom: var(--lc-space-2);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5398,6 +5398,24 @@ button.primary:disabled {
   border-color: var(--lc-accent);
 }
 
+.logout-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 28px;
+  background: transparent;
+  color: var(--lc-text-muted);
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius-sm);
+  cursor: pointer;
+  padding: 0;
+}
+.logout-btn:hover {
+  color: var(--lc-failed);
+  border-color: var(--lc-failed);
+}
+
 .settings-view {
   padding: var(--lc-space-3);
   max-width: 980px;


### PR DESCRIPTION
## Why

When loomcycle runs as a packaged app — the upcoming TrueNAS Scale deployment (RFC AR) — **operators have no shell**, so the critical `loomcycle` CLI surfaces are unreachable. This adds a **Settings hub** (top-right gear → `/settings`, admin-only) that web-reaches them. The headline is **tenant/operator token generation**, gated to a root/admin login, since that's the TrueNAS-blocking piece (you can't mint a tenant token without the CLI today). Sequenced **before RFC AR** as the user requested.

Delivered directly as a PR (not an RFC): the token-minting backend already exists (`POST /v1/_operatortokendef`), role-awareness already exists (`/v1/_me` → `is_admin`), and this matches how past Web UI surfaces shipped — confirmed with the maintainer. Scope confirmed as **tokens + a broader operability toolkit**.

## What

Four commits:

1. **`feat(api)`** — read-only HTTP introspection of the embedded config base so the UI can show it on a no-shell box: `GET /v1/_presets`, `/v1/_presets/{name}`, `/v1/_env_template` (the `loomcycle presets` / `env-template` CLI). Serve the `cmd/loomcycle/embedded` resolver; admin-gated via the `/v1/_*` default in `requiredScopeFor`.
2. **`feat(webui)`** — the Settings hub: a top-right gear (rendered only for `is_admin`) → `/settings` with four sections:
   - **Tokens** (RFC L) — generate a token (name, tenant, subject, scopes), revealed **once** with a copy button; list names with active/retired status; rotate; retire. Admin-gated client-side **and** server-side (`substrate:admin`).
   - **Presets** (RFC AQ) — browse the embedded presets/bundles + env catalogue, view YAML.
   - **Runtime** — pause/resume + live `/v1/_state`, with links to the existing Snapshots + Audit pages (no duplication).
   - **Health** — liveness + version.
3. **`docs`** — the `operator-tokens` help topic gains a "From the Web UI (no shell)" section; CONFIGURATION.md §9f notes the presets viewer.

Existing surfaces (snapshots page, topbar pause control) are **linked/kept, not duplicated**. New `api.ts` surface for tokens + presets; Settings-hub CSS uses the `--lc-*` design tokens (theme-aware, responsive).

## Security

- "Root loomcycle token" → `is_admin` (the legacy `LOOMCYCLE_AUTH_TOKEN` and any minted `substrate:admin` token). The gear is hidden for non-admins, `SettingsView` re-guards a deep-link, and the backend gates `POST /v1/_operatortokendef` at `substrate:admin` regardless of the UI — so the client gate is the redundant half, never the only one.
- The minted secret follows the backend's once-shown contract: held in component state, cleared on dismiss, never logged.
- The new read endpoints are admin-gated (a `requiredScopeFor` regression test asserts it); their content is non-secret (only `token_env` names).

## Tested

- **Go:** `go test ./...` green; new handler tests (`/v1/_presets`, `/{name}` 404, `/v1/_env_template`) + a `requiredScopeFor` assertion that all three are admin-gated. `gofmt`/`go vet ./...` clean.
- **Web:** `tsc --noEmit` clean; `make build-all` (UI embeds + binary).
- **Manual end-to-end:** booted with an admin token + `LOOMCYCLE_PRESETS=base`; minted a `substrate:tenant` token (secret returned once), listed names, viewed presets + env-template, unauth → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD