### PR TITLE
feat(config): provider prepend-merge — one-provider-per-file presets (RFC AQ Phase 2)

### DIFF
--- a/cmd/loomcycle/embedded/presets/local.yaml
+++ b/cmd/loomcycle/embedded/presets/local.yaml
@@ -1,32 +1,25 @@
 # RFC AQ embedded preset: local
 #
-# Local-first (Ollama on your workstation / LAN), with a single cloud entry to
-# catch outages and oversized prefills. SELF-CONTAINED — selecting it alone
-# (`LOOMCYCLE_PRESETS=local`) resolves a complete provider matrix without `base`.
-# NO agents, NO secrets. Mirrors the provider half of
-# `loomcycle.local-interactive.example.yaml`.
+# Local-first (Ollama on your workstation / LAN). ONE PROVIDER PER FILE — it adds
+# the local models and PREPENDS ollama-local (RFC AQ §3 !prepend), so it composes
+# onto `base` without restating the matrix. The two intended uses:
+#   LOOMCYCLE_PRESETS=base,local   → local on top of base's full matrix, so cloud
+#                                    providers remain as fallback (recommended).
+#   LOOMCYCLE_PRESETS=local        → pure local: ollama-local only, no cloud.
 #
-# Set OLLAMA_BASE_URL to your Ollama host (default http://localhost:11434) and
-# ANTHROPIC_API_KEY for the cloud fallback (swap for whichever you have a key for).
+# Set OLLAMA_BASE_URL to your Ollama host (default http://localhost:11434). NO
+# secrets here.
 
 models:
   local-fast:  { provider: ollama-local, model: gemma4:9b }        # quick / low-context
   local-chat:  { provider: ollama-local, model: qwen3.6:27b }      # general reasoning
   local-coder: { provider: ollama-local, model: qwen3-coder-next } # coding / review
-  cloud-sonnet: { provider: anthropic, model: claude-sonnet-4-6 }  # cloud fallback
 
-# Local first; the cloud entry catches outages and oversized prefills.
-provider_priority:
-  - ollama-local
-  - anthropic
+# !prepend → ollama-local goes on top; with `base` its cloud providers follow as
+# fallback (dedup keeps ollama-local's promoted position).
+provider_priority: !prepend [ollama-local]
 
 tiers:
-  low:    [local-fast,  cloud-sonnet]
-  middle: [local-chat,  cloud-sonnet]
-  high:   [local-coder, cloud-sonnet]
-
-user_tiers:
-  default:
-    provider_priority: [ollama-local, anthropic]
-    fallback_on_error: true
-    max_fallback_attempts: 2
+  low:    !prepend [local-fast]
+  middle: !prepend [local-chat]
+  high:   !prepend [local-coder]

--- a/cmd/loomcycle/embedded/presets/oauth.yaml
+++ b/cmd/loomcycle/embedded/presets/oauth.yaml
@@ -1,0 +1,25 @@
+# RFC AQ embedded preset: oauth
+#
+# OAuth-first (Anthropic OAuth-dev on top). ONE PROVIDER PER FILE — it adds only
+# the OAuth provider and PREPENDS it (RFC AQ §3 !prepend), so it composes onto
+# `base` without restating the provider matrix. Select it AFTER base:
+#   LOOMCYCLE_PRESETS=base,oauth
+# yields provider_priority = [anthropic-oauth-dev, <base order…>] and each tier
+# with the OAuth alias on top — OAuth-first with full fallback, no restatement.
+#
+# Requires the OAuth-dev provider (LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1 + a
+# `loomcycle anthropic login`). NO secrets here. Selected alone (no base) it
+# resolves an OAuth-only matrix.
+
+models:
+  oauth-haiku:  { provider: anthropic-oauth-dev, model: claude-haiku-4-5 }
+  oauth-sonnet: { provider: anthropic-oauth-dev, model: claude-sonnet-4-6 }
+  oauth-opus:   { provider: anthropic-oauth-dev, model: claude-opus-4-7 }
+
+# !prepend → merge in front of the accumulated provider_priority (not replace).
+provider_priority: !prepend [anthropic-oauth-dev]
+
+tiers:
+  low:    !prepend [oauth-haiku]
+  middle: !prepend [oauth-sonnet]
+  high:   !prepend [oauth-opus]

--- a/cmd/loomcycle/embedded/presets_test.go
+++ b/cmd/loomcycle/embedded/presets_test.go
@@ -18,6 +18,7 @@ func TestUnits_RegistryShape(t *testing.T) {
 	want := map[string]string{
 		"base":           "preset",
 		"local":          "preset",
+		"oauth":          "preset",
 		"document-agent": "bundle",
 	}
 	for name, kind := range want {

--- a/cmd/loomcycle/presets_integration_test.go
+++ b/cmd/loomcycle/presets_integration_test.go
@@ -121,6 +121,60 @@ func TestSelectPresetNames(t *testing.T) {
 	}
 }
 
+// TestEmbedded_OAuthPrependsWithoutRestatement is the RFC AQ §3 headline: the
+// one-provider-per-file oauth preset composes onto base via !prepend — OAuth on
+// top of provider_priority AND each tier, with base's providers retained as
+// fallback and NO restatement.
+func TestEmbedded_OAuthPrependsWithoutRestatement(t *testing.T) {
+	cfg, err := config.LoadLayers(layersFor(t, "base", "oauth")...)
+	if err != nil {
+		t.Fatalf("LoadLayers(base, oauth): %v", err)
+	}
+	if len(cfg.ProviderPriority) == 0 || cfg.ProviderPriority[0] != "anthropic-oauth-dev" {
+		t.Errorf("provider_priority[0] = %v, want anthropic-oauth-dev on top", cfg.ProviderPriority)
+	}
+	// base's matrix is retained (fallback) — the prepend didn't restate/replace it.
+	for _, want := range []string{"deepseek", "openai", "anthropic"} {
+		if !sliceHas(cfg.ProviderPriority, want) {
+			t.Errorf("base provider %q dropped from provider_priority: %v", want, cfg.ProviderPriority)
+		}
+	}
+	// Each tier has the OAuth alias on top (a bare alias parses to {Model: alias}).
+	if len(cfg.Tiers["middle"]) == 0 || cfg.Tiers["middle"][0].Model != "oauth-sonnet" {
+		t.Errorf("tiers.middle = %+v, want oauth-sonnet first", cfg.Tiers["middle"])
+	}
+	if len(cfg.Tiers["high"]) == 0 || cfg.Tiers["high"][0].Model != "oauth-opus" {
+		t.Errorf("tiers.high = %+v, want oauth-opus first", cfg.Tiers["high"])
+	}
+}
+
+// TestEmbedded_LocalPrepends: base + local puts ollama-local + the local tier
+// candidates on top while keeping base's cloud providers as fallback.
+func TestEmbedded_LocalPrepends(t *testing.T) {
+	cfg, err := config.LoadLayers(layersFor(t, "base", "local")...)
+	if err != nil {
+		t.Fatalf("LoadLayers(base, local): %v", err)
+	}
+	if len(cfg.ProviderPriority) == 0 || cfg.ProviderPriority[0] != "ollama-local" {
+		t.Errorf("provider_priority[0] = %v, want ollama-local on top", cfg.ProviderPriority)
+	}
+	if !sliceHas(cfg.ProviderPriority, "anthropic") {
+		t.Errorf("base cloud fallback dropped from provider_priority: %v", cfg.ProviderPriority)
+	}
+	if len(cfg.Tiers["low"]) == 0 || cfg.Tiers["low"][0].Model != "local-fast" {
+		t.Errorf("tiers.low = %+v, want local-fast first", cfg.Tiers["low"])
+	}
+}
+
+func sliceHas(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
 func agentNames(cfg *config.Config) []string {
 	out := make([]string, 0, len(cfg.Agents))
 	for n := range cfg.Agents {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1058,10 +1058,26 @@ level *before* typed unmarshal, so a key's presence is explicit:
 | Section | Merge result |
 |---|---|
 | `agents`, `models`, `mcp_servers`, `channels`, `volumes`, `user_tiers`, `webhooks`, `a2a_*`, `memory_backends`, `scheduled_runs`, `principals` | **by key** — a new entry is added; a same-named entry **field-merges** (last wins per field, matching the `LOOMCYCLE_AGENTS_ROOT` / `mergeAgentDef` precedent) |
-| `tiers` | per-tier **by key**; each tier's candidate list **replaces** wholesale |
-| `provider_priority`, `context_plugins` | **replaced** wholesale (no implicit append — restate the full list) |
+| `tiers` | per-tier **by key**; each tier's candidate list **replaces** wholesale (or composes when the overlay tags it `!prepend` / `!append` — see below) |
+| `provider_priority`, `context_plugins` | **replaced** wholesale by default; an overlay can **compose** instead by tagging the sequence `!prepend` / `!append` (RFC AQ — see below) |
 | `defaults`, `concurrency`, `cache`, `storage`, `interruption`, `hooks`, `memory` | **field-by-field** (a layer may override one field) |
 | top-level scalars | last layer wins |
+
+**Composing sequences — `!prepend` / `!append` (RFC AQ).** An overlay sequence
+tagged `!prepend` merges its items in FRONT of the accumulated sequence;
+`!append` merges them AFTER; an **untagged** sequence still replaces wholesale.
+Duplicates (deep-equal) are dropped keeping the **first** occurrence — so
+`!prepend`-ing a re-listed provider promotes it. A tagged merge is a deliberate
+compose, so it is **not** a cross-layer conflict (no override warning, never trips
+`LOOMCYCLE_CONFIG_STRICT`). This is what lets the embedded `oauth` / `local`
+presets (§9f) be one-provider-per-file:
+
+```yaml
+# an overlay that puts OAuth on top WITHOUT restating the base matrix:
+provider_priority: !prepend [anthropic-oauth-dev]
+tiers:
+  middle: !prepend [oauth-sonnet]
+```
 
 **Conflicts are explicit.** Every leaf a later layer *replaces* (a key set
 differently in an earlier layer) is logged at startup
@@ -1089,8 +1105,10 @@ base — and built-in agents — **without a source checkout**. Two kinds:
 
 - **Presets** — pure provider/tier/model config (no agents, no secrets — only
   `token_env` *names*). `base` is the full provider matrix (mirrors the provider
-  half of `loomcycle.example.yaml`); `local` is a self-contained Ollama-first
-  matrix.
+  half of `loomcycle.example.yaml`); `oauth` and `local` are one-provider-per-file
+  overlays that `!prepend` their provider onto `base` (§9e) — `oauth` puts
+  Anthropic OAuth-dev on top, `local` puts Ollama on top, each keeping base's
+  matrix as fallback.
 - **Bundles** — a preset that *also* defines an agent and its skills **inline**
   (the top-level `skills:` map, §7). `document-agent` ships the `doc-manager`
   Document Assistant agent + its four skills — no skills directory, no
@@ -1113,8 +1131,12 @@ ordered) — or the repeatable `--preset` flag (flags override the env list) —
 layers the named units as the **base** of the config stack, under your files:
 
 ```sh
-LOOMCYCLE_PRESETS=base,document-agent loomcycle --config ~/.config/loomcycle/loomcycle.yaml
+# OAuth-first base + the Document Assistant, under your thin overlay:
+LOOMCYCLE_PRESETS=base,oauth,document-agent loomcycle --config ~/.config/loomcycle/loomcycle.yaml
 ```
+
+Because `oauth` / `local` `!prepend` (§9e), `base,oauth` resolves to OAuth on top
+with base's providers retained as fallback — no restatement of the matrix.
 
 The **full precedence chain** (base → top, last wins, RFC AN merge):
 
@@ -1136,9 +1158,7 @@ before (no presets) — embedded presets are a deliberate opt-in, not a silent n
 base. `document-agent` needs SQL Memory (`LOOMCYCLE_SQLMEM_ENABLED=1`) + a
 `middle` tier to actually run; absent those it's a registered-but-idle def.
 
-*(Deferred: a provider prepend-merge — `!prepend`/`!append` tags so a preset can
-be one-provider-per-file — and a `LOOMCYCLE_CONFIG_DIR` dir-of-layers — RFC AQ
-Phases 2–3.)*
+*(Deferred: a `LOOMCYCLE_CONFIG_DIR` dir-of-layers convention — RFC AQ Phase 3.)*
 
 ---
 

--- a/internal/config/layering.go
+++ b/internal/config/layering.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"os"
-	"reflect"
 
 	"gopkg.in/yaml.v3"
 )
@@ -19,28 +18,41 @@ type Layer struct {
 	Data []byte
 }
 
-// RFC AN — config layering. mergeLayers reads + env-expands + deep-merges N
-// config layers at the YAML-tree level (before typed unmarshal, so a key's
+// RFC AQ §3 — opt-in sequence-merge tags. A sequence in an overlay tagged
+// !prepend merges its items IN FRONT of the accumulated sequence; !append merges
+// them AFTER; an untagged sequence replaces wholesale (RFC AN, unchanged).
+const (
+	tagPrepend = "!prepend"
+	tagAppend  = "!append"
+	tagSeq     = "!!seq"
+	tagMap     = "!!map"
+)
+
+// RFC AN + RFC AQ — config layering. mergeLayers reads + env-expands + deep-merges
+// N config layers at the YAML-tree level (before typed unmarshal, so a key's
 // PRESENCE is explicit — no Go zero-value / omitempty ambiguity). Layers merge
-// left→right, last layer wins; it returns the merged tree plus a list of every
-// leaf a later layer REPLACED (for the startup override log / strict-mode fatal).
+// left→right, last layer wins; it returns the merged root MAPPING node plus a list
+// of every leaf a later layer REPLACED (for the startup override log / strict-mode
+// fatal).
 //
-// A layer's bytes come from Layer.Data (an embedded preset/bundle — RFC AQ) when
-// set, else from reading Layer.Name as a file path. Either way the rest of the
-// fold is identical, so an embedded preset and a disk file compose exactly alike.
+// The merge runs over yaml.Node (not map[string]any) because a map decode DISCARDS
+// each sequence's YAML tag — and RFC AQ's !prepend/!append composition needs that
+// tag (§3.3). A layer's bytes come from Layer.Data (an embedded preset/bundle) when
+// set, else from reading Layer.Name as a file path.
 //
 // One recursive rule covers every section (no per-section special-casing):
-// mapping ⊕ mapping → merge keys recursively; anything else (scalar, sequence,
-// type mismatch) → the later layer's value replaces. So agents/models/skills/
-// volumes/mcp_servers/channels/... merge by key (a same-named entry field-merges,
-// matching the mergeAgentDef precedent); provider_priority/context_plugins
-// (sequences) replace wholesale; struct sections (defaults/concurrency/...) merge
+// mapping ⊕ mapping → merge keys recursively; an overlay sequence tagged
+// !prepend/!append ⊕ a base sequence → compose (RFC AQ); anything else (scalar,
+// untagged sequence, type mismatch) → the later layer's value replaces. So
+// agents/models/skills/volumes/mcp_servers/channels/... merge by key (a same-named
+// entry field-merges, matching the mergeAgentDef precedent); provider_priority /
+// tier candidate lists replace wholesale UNLESS tagged; struct sections merge
 // field-by-field.
 //
 // Each layer keeps its OWN expandEnv raw-text stage, so a later layer can't inject
 // ${ENV} into an earlier layer's text (no cross-layer interpolation surprises).
-func mergeLayers(layers []Layer) (map[string]any, []string, error) {
-	merged := map[string]any{}
+func mergeLayers(layers []Layer) (*yaml.Node, []string, error) {
+	merged := &yaml.Node{Kind: yaml.MappingNode, Tag: tagMap}
 	var overrides []string
 	for _, l := range layers {
 		raw := l.Data
@@ -52,57 +64,150 @@ func mergeLayers(layers []Layer) (map[string]any, []string, error) {
 			raw = b
 		}
 		expanded := expandEnv(string(raw))
-		var tree map[string]any
-		if err := yaml.Unmarshal([]byte(expanded), &tree); err != nil {
+		var doc yaml.Node
+		if err := yaml.Unmarshal([]byte(expanded), &doc); err != nil {
 			return nil, nil, fmt.Errorf("parse %s: %w", l.Name, err)
 		}
-		if tree == nil {
+		if len(doc.Content) == 0 {
 			continue // empty / all-comments layer
 		}
-		merged = mergeTree(merged, tree, l.Name, "", &overrides)
+		root := doc.Content[0]
+		if root.Kind != yaml.MappingNode {
+			return nil, nil, fmt.Errorf("parse %s: top-level YAML must be a mapping", l.Name)
+		}
+		mergeNodes(merged, root, l.Name, "", &overrides)
 	}
 	return merged, overrides, nil
 }
 
-// mergeConfigFiles is the file-path-only entry point retained for the historical
-// callers/tests; it adapts paths to Layer values and delegates to mergeLayers.
+// mergeConfigFiles is the file-path, map-returning entry point retained for the
+// historical callers/tests; it merges via mergeLayers and decodes the node tree
+// to map[string]any.
 func mergeConfigFiles(files []string) (map[string]any, []string, error) {
 	layers := make([]Layer, len(files))
 	for i, f := range files {
 		layers[i] = Layer{Name: f}
 	}
-	return mergeLayers(layers)
+	node, overrides, err := mergeLayers(layers)
+	if err != nil {
+		return nil, nil, err
+	}
+	m := map[string]any{}
+	if err := node.Decode(&m); err != nil {
+		return nil, nil, fmt.Errorf("decode merged tree: %w", err)
+	}
+	return m, overrides, nil
 }
 
-// mergeTree folds overlay onto base in place and returns base. overrides
-// accumulates the dotted path of every leaf the overlay REPLACED with a
-// different value (a real cross-layer conflict — adding a brand-new key, or
-// re-setting a key to the same value, is not a conflict). file is the overlay's
-// source, named in the override record.
-func mergeTree(base, overlay map[string]any, file, prefix string, overrides *[]string) map[string]any {
-	if base == nil {
-		base = map[string]any{}
-	}
-	for k, ov := range overlay {
-		path := k
+// mergeNodes folds the overlay mapping node onto base (mutated in place). overrides
+// accumulates the dotted path of every leaf the overlay REPLACED with a different
+// value — a real cross-layer conflict. Adding a new key, re-setting a key to the
+// same value, or an opt-in !prepend/!append sequence merge are NOT conflicts. Both
+// nodes are MappingNodes (Content is a flat [key,value,key,value,...] list).
+func mergeNodes(base, overlay *yaml.Node, file, prefix string, overrides *[]string) {
+	for i := 0; i+1 < len(overlay.Content); i += 2 {
+		k := overlay.Content[i]
+		ov := overlay.Content[i+1]
+		path := k.Value
 		if prefix != "" {
-			path = prefix + "." + k
+			path = prefix + "." + k.Value
 		}
-		if bv, exists := base[k]; exists {
-			bm, bIsMap := bv.(map[string]any)
-			om, oIsMap := ov.(map[string]any)
-			if bIsMap && oIsMap {
-				// Two mappings → recurse (merge keys); no conflict at this level.
-				base[k] = mergeTree(bm, om, file, path, overrides)
-				continue
-			}
-			// Scalar / sequence / type-mismatch → later replaces. Record it as a
-			// conflict only when the value actually changes.
-			if !reflect.DeepEqual(bv, ov) {
+		bi := mapValueIndex(base, k.Value)
+		if bi < 0 {
+			// New key — take it. A tagged sequence with no base to merge against is
+			// just its items (strip the tag so the final decode doesn't choke on it).
+			normalizeSeqTag(ov)
+			base.Content = append(base.Content, k, ov)
+			continue
+		}
+		bv := base.Content[bi]
+		switch {
+		case bv.Kind == yaml.MappingNode && ov.Kind == yaml.MappingNode:
+			mergeNodes(bv, ov, file, path, overrides)
+		case ov.Kind == yaml.SequenceNode && (ov.Tag == tagPrepend || ov.Tag == tagAppend) && bv.Kind == yaml.SequenceNode:
+			// RFC AQ opt-in sequence merge — a deliberate compose, not a conflict.
+			base.Content[bi] = mergeSeq(bv, ov, ov.Tag)
+		default:
+			// scalar / untagged sequence / type-mismatch → later replaces. Record
+			// it as a conflict only when the value actually changes.
+			normalizeSeqTag(ov)
+			if !nodeEqual(bv, ov) {
 				*overrides = append(*overrides, fmt.Sprintf("%s (set by %s, overriding an earlier layer)", path, file))
 			}
+			base.Content[bi] = ov
 		}
-		base[k] = ov
 	}
-	return base
+}
+
+// mapValueIndex returns the index of key's VALUE node within a MappingNode's
+// Content, or -1 if the key is absent.
+func mapValueIndex(m *yaml.Node, key string) int {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+// mergeSeq composes two sequence nodes per the overlay's tag: !prepend puts the
+// overlay's items in front of base's, !append after; duplicate items (deep-equal)
+// are dropped keeping the FIRST occurrence — so !prepend of a re-listed provider
+// promotes it and drops the lower copy. The result is a plain (!!seq) sequence.
+func mergeSeq(base, overlay *yaml.Node, tag string) *yaml.Node {
+	var ordered []*yaml.Node
+	if tag == tagPrepend {
+		ordered = append(ordered, overlay.Content...)
+		ordered = append(ordered, base.Content...)
+	} else {
+		ordered = append(ordered, base.Content...)
+		ordered = append(ordered, overlay.Content...)
+	}
+	out := &yaml.Node{Kind: yaml.SequenceNode, Tag: tagSeq}
+	for _, n := range ordered {
+		dup := false
+		for _, kept := range out.Content {
+			if nodeEqual(kept, n) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			out.Content = append(out.Content, n)
+		}
+	}
+	return out
+}
+
+// normalizeSeqTag clears a !prepend/!append tag from a sequence node that is taken
+// as-is (a new key, or a replace) rather than merged — so the leftover custom tag
+// never reaches the final decode (which would fail to resolve it).
+func normalizeSeqTag(n *yaml.Node) {
+	if n.Kind == yaml.SequenceNode && (n.Tag == tagPrepend || n.Tag == tagAppend) {
+		n.Tag = tagSeq
+	}
+}
+
+// nodeEqual reports deep value-equality of two YAML nodes (kind + scalar
+// value/tag, recursing into collections). Used for sequence de-dup and for the
+// "same value re-set isn't a conflict" rule.
+func nodeEqual(a, b *yaml.Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Kind == yaml.ScalarNode {
+		return a.Value == b.Value && a.Tag == b.Tag
+	}
+	if len(a.Content) != len(b.Content) {
+		return false
+	}
+	for i := range a.Content {
+		if !nodeEqual(a.Content[i], b.Content[i]) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/config/prepend_merge_test.go
+++ b/internal/config/prepend_merge_test.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"testing"
+)
+
+// seqStrings decodes a merged map's sequence value to []string for assertions.
+func seqStrings(t *testing.T, v any) []string {
+	t.Helper()
+	items, ok := v.([]any)
+	if !ok {
+		t.Fatalf("not a sequence: %#v", v)
+	}
+	out := make([]string, len(items))
+	for i, it := range items {
+		s, ok := it.(string)
+		if !ok {
+			t.Fatalf("sequence item %d not a string: %#v", i, it)
+		}
+		out[i] = s
+	}
+	return out
+}
+
+func eqStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestMerge_PrependComposesNotReplaces (RFC AQ §3): an overlay sequence tagged
+// !prepend merges its items in front of the base sequence instead of replacing —
+// and is NOT recorded as a cross-layer override (it's a deliberate compose).
+func TestMerge_PrependComposesNotReplaces(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek, openai, anthropic]\n")
+	over := writeYAML(t, dir, "over.yaml", "provider_priority: !prepend [anthropic-oauth-dev]\n")
+	merged, overrides, err := mergeConfigFiles([]string{base, over})
+	if err != nil {
+		t.Fatalf("mergeConfigFiles: %v", err)
+	}
+	got := seqStrings(t, merged["provider_priority"])
+	want := []string{"anthropic-oauth-dev", "deepseek", "openai", "anthropic"}
+	if !eqStrings(got, want) {
+		t.Errorf("provider_priority = %v, want %v (prepend in front, no restatement)", got, want)
+	}
+	if len(overrides) != 0 {
+		t.Errorf("a !prepend merge must NOT record a conflict; got %v", overrides)
+	}
+}
+
+// TestMerge_AppendAndDedupKeepFirst: !append puts items after; a duplicate (by
+// deep equality) is dropped keeping the FIRST occurrence.
+func TestMerge_AppendAndDedupKeepFirst(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek, openai]\n")
+	over := writeYAML(t, dir, "over.yaml", "provider_priority: !append [openai, ollama]\n")
+	merged, _, err := mergeConfigFiles([]string{base, over})
+	if err != nil {
+		t.Fatalf("mergeConfigFiles: %v", err)
+	}
+	got := seqStrings(t, merged["provider_priority"])
+	// [deepseek, openai] ++ [openai, ollama] → dedup keep-first → [deepseek, openai, ollama]
+	want := []string{"deepseek", "openai", "ollama"}
+	if !eqStrings(got, want) {
+		t.Errorf("provider_priority = %v, want %v (append + dedup keep-first)", got, want)
+	}
+}
+
+// TestMerge_PrependPromotesDuplicate: !prepend a provider already present pulls it
+// to the FRONT and drops the lower copy (keep-first across the composed order).
+func TestMerge_PrependPromotesDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek, openai, anthropic]\n")
+	over := writeYAML(t, dir, "over.yaml", "provider_priority: !prepend [anthropic]\n")
+	merged, _, err := mergeConfigFiles([]string{base, over})
+	if err != nil {
+		t.Fatalf("mergeConfigFiles: %v", err)
+	}
+	got := seqStrings(t, merged["provider_priority"])
+	want := []string{"anthropic", "deepseek", "openai"}
+	if !eqStrings(got, want) {
+		t.Errorf("provider_priority = %v, want %v (anthropic promoted, lower copy dropped)", got, want)
+	}
+}
+
+// TestMerge_UntaggedSequenceStillReplaces: the RFC AN default is unchanged — an
+// untagged overlay sequence replaces wholesale (and IS a recorded conflict).
+func TestMerge_UntaggedSequenceStillReplaces(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek, openai]\n")
+	over := writeYAML(t, dir, "over.yaml", "provider_priority: [anthropic]\n")
+	merged, overrides, err := mergeConfigFiles([]string{base, over})
+	if err != nil {
+		t.Fatalf("mergeConfigFiles: %v", err)
+	}
+	got := seqStrings(t, merged["provider_priority"])
+	if !eqStrings(got, []string{"anthropic"}) {
+		t.Errorf("provider_priority = %v, want [anthropic] (untagged replaces)", got)
+	}
+	if !containsSub(overrides, "provider_priority") {
+		t.Errorf("an untagged replace must record an override; got %v", overrides)
+	}
+}
+
+// TestLoad_PrependNotAConflictUnderStrict: a !prepend compose must NOT trip
+// LOOMCYCLE_CONFIG_STRICT (it's not a clobber) — while an untagged replace still
+// would. The strict half is the fail-before for the gate.
+func TestLoad_PrependNotAConflictUnderStrict(t *testing.T) {
+	t.Setenv("LOOMCYCLE_CONFIG_STRICT", "1")
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", "provider_priority: [deepseek]\n")
+	over := writeYAML(t, dir, "over.yaml", "provider_priority: !prepend [anthropic]\n")
+	cfg, err := Load(base, over)
+	if err != nil {
+		t.Fatalf("strict Load with a !prepend merge should succeed: %v", err)
+	}
+	if len(cfg.ProviderPriority) != 2 || cfg.ProviderPriority[0] != "anthropic" {
+		t.Errorf("provider_priority = %v, want [anthropic, deepseek]", cfg.ProviderPriority)
+	}
+}
+
+// TestLoad_TierCandidatePrepend: the tag works on a nested tier candidate list
+// (a sequence inside the tiers map), composing into cfg.Tiers.
+func TestLoad_TierCandidatePrepend(t *testing.T) {
+	dir := t.TempDir()
+	base := writeYAML(t, dir, "base.yaml", `
+models:
+  deepseek-pro: { provider: deepseek, model: deepseek-v4-pro }
+  oauth-sonnet: { provider: anthropic-oauth-dev, model: claude-sonnet-4-6 }
+tiers:
+  middle: [deepseek-pro]
+`)
+	over := writeYAML(t, dir, "over.yaml", `
+tiers:
+  middle: !prepend [oauth-sonnet]
+`)
+	cfg, err := Load(base, over)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	mid := cfg.Tiers["middle"]
+	if len(mid) != 2 {
+		t.Fatalf("tiers.middle has %d candidates, want 2 (composed): %+v", len(mid), mid)
+	}
+	// The OAuth alias is first (prepended), the base candidate second. A bare
+	// alias parses to TierCandidate{Model: <alias>} (provider resolved later).
+	if mid[0].Model != "oauth-sonnet" {
+		t.Errorf("tiers.middle[0] = %+v, want the prepended oauth-sonnet first", mid[0])
+	}
+	if mid[1].Model != "deepseek-pro" {
+		t.Errorf("tiers.middle[1] = %+v, want the base deepseek-pro second", mid[1])
+	}
+}


### PR DESCRIPTION
## Why

RFC AQ Phase 1 shipped embedded presets, but config layering **replaced sequences wholesale** — so a preset that wants "OAuth on top" had to restate the *entire* `provider_priority` + every tier (exactly what `bundles/document-agent/loomcycle_oauth.yaml` did). You couldn't write "one provider per file" and have them compose. This is **RFC AQ Phase 2**: an opt-in sequence-merge so a preset adds *one* provider and prepends it.

## What

Three commits:

1. **`feat(config)` engine** — opt-in `!prepend` / `!append` sequence-merge tags (realizes RFC AN §9). The merge now runs over **`yaml.Node`** instead of `map[string]any`, because a map decode discards each sequence's YAML tag and the compose needs it. An overlay sequence tagged `!prepend` merges its items in front of the accumulated sequence, `!append` after; duplicates (deep-equal) drop keeping the **first** occurrence; an **untagged** sequence still replaces (RFC AN unchanged). A tagged merge is a deliberate compose — **not** a cross-layer conflict (no override warning, never trips `LOOMCYCLE_CONFIG_STRICT`).
2. **`feat(config)` presets** — `presets/oauth.yaml` (new) and a rewritten `presets/local.yaml` are now **one-provider-per-file**: each adds its provider + aliases + tier candidates and `!prepend`s. `LOOMCYCLE_PRESETS=base,oauth` → OAuth on top of `provider_priority` AND every tier, with base's matrix retained as fallback, **no restatement**.
3. **`docs(config)`** — §9e merge table + a "Composing sequences" subsection; §9f updated (oauth/local are prepend overlays; Phase-2 deferral dropped, only Phase-3 `LOOMCYCLE_CONFIG_DIR` remains).

## Compatibility

Additive. Untagged sequences behave byte-identically to RFC AN — **all existing layering tests pass unchanged**. The engine swap (map → node) keeps the same final stage (marshal merged node → unmarshal into `Config`); `mergeConfigFiles` keeps its `map[string]any` shape for the historical callers/tests by decoding the node.

## Tested

- **Unit:** prepend composes in front (no restatement, not a conflict); append + dedup keep-first; prepend promotes a duplicate; untagged still replaces + records; `!prepend` survives `LOOMCYCLE_CONFIG_STRICT`; nested tier-candidate-list prepend composes into `cfg.Tiers`.
- **Integration:** `base,oauth` → `anthropic-oauth-dev` first in `provider_priority` AND each tier, base providers retained; `base,local` → `ollama-local` first + cloud fallback retained.
- **Manual:** `loomcycle presets` lists oauth; `presets show oauth`; boot `base,oauth` composes without error.
- `go test ./...` green; `gofmt`/`go vet` clean.

After this, **only RFC AQ Phase 3 (`LOOMCYCLE_CONFIG_DIR`) remains** before RFC AR (TrueNAS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD