### PR TITLE
feat(config): LOOMCYCLE_CONFIG_DIR dir-of-layers (RFC AQ Phase 3)

### DIFF
--- a/cmd/loomcycle/autodiscover.go
+++ b/cmd/loomcycle/autodiscover.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 // autodiscover.go — v0.11.1 config auto-discovery.
@@ -74,4 +76,27 @@ func userOverrodeConfigFlag() bool {
 		}
 	})
 	return overrode
+}
+
+// configDirLayers returns the *.yaml / *.yml files directly under dir, sorted
+// lexically — the LOOMCYCLE_CONFIG_DIR layer group (RFC AQ §4). The directory
+// must exist and be readable (a set-but-missing dir is the operator's typo →
+// surfaced); an empty dir (no matching files) is fine, returning nil. Files in
+// subdirectories are ignored — a flat drop-in dir.
+func configDirLayers(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if name := e.Name(); strings.HasSuffix(name, ".yaml") || strings.HasSuffix(name, ".yml") {
+			files = append(files, filepath.Join(dir, name))
+		}
+	}
+	sort.Strings(files)
+	return files, nil
 }

--- a/cmd/loomcycle/autodiscover_test.go
+++ b/cmd/loomcycle/autodiscover_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConfigDirLayers: LOOMCYCLE_CONFIG_DIR enumerates *.yaml/*.yml directly
+// under the dir, sorted lexically; ignores non-YAML files and subdirectories.
+func TestConfigDirLayers(t *testing.T) {
+	dir := t.TempDir()
+	// Create out of order to prove the lexical sort.
+	for _, n := range []string{"30-z.yaml", "10-a.yaml", "20-b.yml"} {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte("provider_priority: [mock]\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Noise that must be ignored: a non-YAML file and a subdirectory.
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "nested", "ignored.yaml"), []byte("x: 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := configDirLayers(dir)
+	if err != nil {
+		t.Fatalf("configDirLayers: %v", err)
+	}
+	want := []string{
+		filepath.Join(dir, "10-a.yaml"),
+		filepath.Join(dir, "20-b.yml"),
+		filepath.Join(dir, "30-z.yaml"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d files %v, want %d %v", len(got), got, len(want), want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] = %s, want %s (lexical order)", i, got[i], want[i])
+		}
+	}
+}
+
+// TestConfigDirLayers_EmptyAndMissing: an empty dir → nil (no error); a missing
+// dir → error (the operator's typo is surfaced, not silently skipped).
+func TestConfigDirLayers_EmptyAndMissing(t *testing.T) {
+	empty := t.TempDir()
+	got, err := configDirLayers(empty)
+	if err != nil {
+		t.Fatalf("empty dir should not error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("empty dir should yield no files, got %v", got)
+	}
+
+	if _, err := configDirLayers(filepath.Join(empty, "does-not-exist")); err == nil {
+		t.Errorf("a missing LOOMCYCLE_CONFIG_DIR should error (caller exits)")
+	}
+}

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -503,12 +503,29 @@ func main() {
 		log.Printf("config: layering %d embedded preset(s)/bundle(s) as base: %s", len(presetNames), strings.Join(presetNames, ", "))
 	}
 
-	// Assemble the ordered config-FILE list (RFC AN). LOOMCYCLE_CONFIG_FILES
-	// (`:`-separated, for containers/systemd) layers as the base; explicit
-	// --config flags layer AFTER it, so an explicit flag always wins. With
-	// neither, fall back to the lone XDG-discovered default (today's behavior) —
-	// unless embedded presets are active, in which case a presets-only stack
-	// (no operator file) is allowed (RFC AQ bare-start).
+	// Assemble the operator's config-FILE layers (RFC AN/AQ). The precedence
+	// chain, base → top, last wins:
+	//   embedded presets → LOOMCYCLE_CONFIG_DIR/*.yaml → LOOMCYCLE_CONFIG_FILES → --config
+	// With none of these, fall back to the lone XDG-discovered default (today's
+	// behavior) — unless embedded presets are active, in which case a presets-only
+	// stack (no operator file) is allowed (RFC AQ bare-start).
+
+	// LOOMCYCLE_CONFIG_DIR (RFC AQ §4) — a directory whose *.yaml/*.yml files layer
+	// as a group, lexically, between the presets and CONFIG_FILES. For a mounted
+	// overlay dir or an image-baked drop-in set. Unset → skipped.
+	var configDirFiles []string
+	if dir := strings.TrimSpace(os.Getenv("LOOMCYCLE_CONFIG_DIR")); dir != "" {
+		files, err := configDirLayers(dir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "loomcycle: LOOMCYCLE_CONFIG_DIR: %v\n", err)
+			os.Exit(1)
+		}
+		configDirFiles = files
+		if len(files) > 0 {
+			log.Printf("config: layering %d file(s) from LOOMCYCLE_CONFIG_DIR=%s (lexical order)", len(files), dir)
+		}
+	}
+
 	var cfgFiles []string
 	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
 		if f = strings.TrimSpace(f); f != "" {
@@ -517,10 +534,9 @@ func main() {
 	}
 	cfgFiles = append(cfgFiles, cfgPaths...)
 
-	if len(cfgFiles) == 0 {
-		// v0.11.1 auto-discovery: no --config / env → walk the XDG paths. The
-		// search list is the same one `loomcycle doctor` uses, so the two stay
-		// in lockstep.
+	if len(cfgFiles) == 0 && len(configDirFiles) == 0 {
+		// No explicit operator config (dir or files) → v0.11.1 XDG auto-discovery.
+		// The search list is the same one `loomcycle doctor` uses (lockstep).
 		resolvedCfg, found := resolveConfigPath("loomcycle.yaml")
 		switch {
 		case found:
@@ -534,39 +550,43 @@ func main() {
 				fmt.Fprintf(os.Stderr, "    %s\n", p)
 			}
 			fmt.Fprintln(os.Stderr)
-			fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, pass --config <path>, or select an embedded base with LOOMCYCLE_PRESETS=base.")
+			fmt.Fprintln(os.Stderr, "Run `loomcycle init` to create one, pass --config <path>, set LOOMCYCLE_CONFIG_DIR, or select an embedded base with LOOMCYCLE_PRESETS=base.")
 			os.Exit(1)
 		}
 	} else {
-		// Explicit layers must each exist (no per-file XDG fallback — explicit
-		// means literal). Fail fast with the offending path.
+		// Explicit --config / CONFIG_FILES layers must each exist (no per-file XDG
+		// fallback — explicit means literal). The CONFIG_DIR files were already
+		// validated by configDirLayers. Fail fast with the offending path.
 		for _, f := range cfgFiles {
 			if _, err := os.Stat(f); err != nil {
 				fmt.Fprintf(os.Stderr, "loomcycle: config file not found: %s\n", f)
 				os.Exit(1)
 			}
 		}
-		if len(cfgFiles) > 1 {
-			log.Printf("config: layering %d files (last wins): %s", len(cfgFiles), strings.Join(cfgFiles, " ◁ "))
-		}
+	}
+
+	// The ordered disk-file layers: CONFIG_DIR first, then CONFIG_FILES/--config.
+	diskFiles := append(append([]string{}, configDirFiles...), cfgFiles...)
+	if len(diskFiles) > 1 {
+		log.Printf("config: layering %d files (last wins): %s", len(diskFiles), strings.Join(diskFiles, " ◁ "))
 	}
 	// Auto-load <configdir>/auth.env (companion to `loomcycle init
 	// --with-token`) BEFORE config.Load reads os.Getenv, so a persisted
 	// LOOMCYCLE_AUTH_TOKEN is in scope without a shell-rc edit. Set-if-unset
 	// (real env wins), so an explicit shell export still overrides it. Keyed on
-	// the LAST (authoritative) FILE layer — that's where an init-written auth.env
-	// lives. A presets-only stack has no config dir, so there's nothing to load.
-	if len(cfgFiles) > 0 {
-		if authEnvPath, n, err := cli.LoadAuthEnv(cfgFiles[len(cfgFiles)-1]); err != nil {
+	// the LAST (authoritative) disk-file layer — that's where an init-written
+	// auth.env lives. A presets-only stack has no file, so there's nothing to load.
+	if len(diskFiles) > 0 {
+		if authEnvPath, n, err := cli.LoadAuthEnv(diskFiles[len(diskFiles)-1]); err != nil {
 			log.Printf("auth.env: %v (continuing without it)", err)
 		} else if n > 0 {
 			log.Printf("auth.env: loaded %d var(s) from %s (a shell export overrides them)", n, authEnvPath)
 		}
 	}
 	// Build the full ordered layer list: embedded presets (base) ++ disk files.
-	layers := make([]config.Layer, 0, len(presetLayers)+len(cfgFiles))
+	layers := make([]config.Layer, 0, len(presetLayers)+len(diskFiles))
 	layers = append(layers, presetLayers...)
-	for _, f := range cfgFiles {
+	for _, f := range diskFiles {
 		layers = append(layers, config.Layer{Name: f})
 	}
 	cfg, err := config.LoadLayers(layers...)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1142,9 +1142,15 @@ The **full precedence chain** (base → top, last wins, RFC AN merge):
 
 ```
 embedded presets (LOOMCYCLE_PRESETS, in order)
-  → LOOMCYCLE_CONFIG_FILES   (':'-separated)
-  → --config flags           (your authoritative overlay, wins)
+  → LOOMCYCLE_CONFIG_DIR/*.yaml   (a dir of layers, lexical order)
+  → LOOMCYCLE_CONFIG_FILES        (':'-separated)
+  → --config flags                (your authoritative overlay, wins)
 ```
+
+`LOOMCYCLE_CONFIG_DIR` (RFC AQ) is a directory whose `*.yaml` / `*.yml` files
+layer as a group in lexical filename order (so prefix them `10-`, `20-`, …) —
+handy for a mounted overlay dir or an image-baked drop-in set. A set-but-missing
+dir is a fatal error; an empty dir is fine.
 
 So `base` supplies the provider matrix, `document-agent` registers `doc-manager`
 with its skills, and your `--config` wins on anything it sets (e.g. retarget the
@@ -1157,8 +1163,6 @@ case). An unknown unit name is a **fatal** error listing the available names.
 before (no presets) — embedded presets are a deliberate opt-in, not a silent new
 base. `document-agent` needs SQL Memory (`LOOMCYCLE_SQLMEM_ENABLED=1`) + a
 `middle` tier to actually run; absent those it's a registered-but-idle def.
-
-*(Deferred: a `LOOMCYCLE_CONFIG_DIR` dir-of-layers convention — RFC AQ Phase 3.)*
 
 ---
 


### PR DESCRIPTION
## Why

The last piece of RFC AQ. Phases 1–2 gave embedded presets + the `!prepend`/`!append` compose; this adds a **directory of config layers** so a deployment can drop YAML files into a mounted/baked dir and have them merge as a group — the shape RFC AR (TrueNAS) wants for its dataset overlay, and useful for any image-baked drop-in set.

## What

Completes the precedence chain (base → top, last wins):

```
embedded presets → LOOMCYCLE_CONFIG_DIR/*.yaml → LOOMCYCLE_CONFIG_FILES → --config
```

Two commits:

1. **`feat(config)`** — `configDirLayers(dir)` enumerates the dir's `*.yaml`/`*.yml` files in **lexical order** (ignoring non-YAML files + subdirectories — a flat drop-in dir). A set-but-missing dir is a **fatal** error (the operator's typo, surfaced); an empty dir is fine. `main.go` weaves it between the presets and the file layers; CONFIG_DIR files now count as operator config (so a CONFIG_DIR-only start doesn't fatal "no config" or fall through to XDG auto-discovery), and `auth.env` keys on the last disk layer across the combined list.
2. **`docs(config)`** — §9f precedence chain + usage note; Phase-3 deferral dropped.

Reuses the existing layering merge (including the `!prepend`/`!append` tags from Phase 2). Additive — unset → skipped, exactly today's behavior.

## Tested

- **Unit:** `configDirLayers` lexical sort, ignores non-YAML/subdirs; empty → nil, missing → error.
- **Manual boot:** `LOOMCYCLE_PRESETS=base` + `LOOMCYCLE_CONFIG_DIR=./confdir` (2 files) + `--config overlay.yaml` assembles in order — `base ◁ confdir/10-prepend.yaml ◁ confdir/20-defaults.yaml ◁ overlay.yaml` (last wins).
- `go test ./...` green; `gofmt`/`go vet` clean.

**This completes RFC AQ** (Phases 1–3 all shipped). RFC AR (loomcycle on TrueNAS Scale) is now fully unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD