### PR TITLE
feat(deploy): loomcycle on TrueNAS SCALE — app skeleton (RFC AR Phase 1)

### DIFF
--- a/deploy/truenas/README.md
+++ b/deploy/truenas/README.md
@@ -1,0 +1,27 @@
+# loomcycle on TrueNAS SCALE
+
+Run loomcycle as a TrueNAS SCALE application (Electric Eel 24.10+, the Docker
+Compose app engine). **RFC AR.** Two routes — both documented in
+[`../../docs/TRUENAS.md`](../../docs/TRUENAS.md):
+
+| File | Route | When |
+|---|---|---|
+| [`docker-compose.yaml`](docker-compose.yaml) | **Custom app** (Apps → Discover → ⋮ → *Install via YAML*, paste) | Fastest. Works today; you edit the compose directly. |
+| [`catalog/`](catalog/) | **Catalog app** (install wizard via `questions.yaml`) | Formal packaging — an install/edit form, published to a train. |
+| [`loomcycle.overlay.example.yaml`](loomcycle.overlay.example.yaml) | the thin overlay (agent `volumes:` block) both routes mount | Copy to your config dataset. |
+
+Both routes share the same shape: the binary's **embedded presets** (RFC AQ)
+supply the provider/tier matrix (`LOOMCYCLE_PRESETS`); a thin overlay supplies the
+agent **Volumes** (RFC AH) mapped to ZFS datasets; **secrets** are TrueNAS-managed
+env (never a yaml layer); storage is your **existing Postgres 16** (the app bundles
+no DB). Ingress/TLS is out of scope — the container binds `0.0.0.0:8787`; front it
+with your existing tunnel/proxy.
+
+> **Catalog app caveat.** `catalog/templates/docker-compose.yaml` uses the TrueNAS
+> Jinja2 + `ix-lib` render library, which TrueNAS's catalog CI vendors at build
+> time (it is **not** committed here). Render-validate the catalog app on your
+> TrueNAS version before publishing (RFC AR open question — schema-dialect drift).
+> The **custom-app `docker-compose.yaml` is plain compose** and needs no library —
+> start there.
+
+Start with [`../../docs/TRUENAS.md`](../../docs/TRUENAS.md).

--- a/deploy/truenas/catalog/README.md
+++ b/deploy/truenas/catalog/README.md
@@ -1,0 +1,17 @@
+# loomcycle
+
+A high-load agentic runtime — one Go binary that owns the LLM tool-use loop
+end-to-end (model → tool_use → tool_result → model), runs as a sidecar, and is
+consumed over HTTP+SSE / gRPC / MCP. Multi-provider (Anthropic, OpenAI, DeepSeek,
+Gemini, Ollama), multi-tenant, multi-agent. Apache-2.0.
+
+This is the TrueNAS SCALE **catalog app** source (Electric Eel 24.10+). The
+provider/tier matrix is supplied by the binary's embedded presets (RFC AQ) — the
+install form picks presets, the secrets, your Postgres DSN, the port, and the
+dataset mounts. Secrets are TrueNAS-managed env; the app bundles no database
+(point it at your existing Postgres 16). Ingress/TLS is the operator's existing
+tunnel/proxy.
+
+See [`../../../docs/TRUENAS.md`](../../../docs/TRUENAS.md) for the install/edit/
+upgrade runbook, and [`../docker-compose.yaml`](../docker-compose.yaml) for the
+no-wizard custom-app paste route.

--- a/deploy/truenas/catalog/app.yaml
+++ b/deploy/truenas/catalog/app.yaml
@@ -1,0 +1,39 @@
+annotations:
+  min_scale_version: 24.10.2.2
+app_version: "1.6.0"
+capabilities: []
+categories:
+- productivity
+changelog_url: https://github.com/denn-gubsky/loomcycle/blob/main/REVISIONS.md
+date_added: '2026-06-23'
+description: loomcycle is a high-load agentic runtime — one Go binary that owns the
+  LLM tool-use loop end-to-end, runs as a sidecar, and is consumed over HTTP+SSE /
+  gRPC / MCP. Multi-provider, multi-tenant, multi-agent.
+home: https://github.com/denn-gubsky/loomcycle
+host_mounts: []
+icon: https://raw.githubusercontent.com/denn-gubsky/loomcycle/main/web/public/loomcycle-logo.svg
+keywords:
+- ai
+- agents
+- llm
+- mcp
+lib_version: 2.3.4
+lib_version_hash: ""
+maintainers:
+- email: dgubsky@waverleysoftware.com
+  name: denn-gubsky
+  url: https://github.com/denn-gubsky/loomcycle
+name: loomcycle
+run_as_context:
+- description: loomcycle runs as the distroless nonroot user (uid 65532). The mapped
+    datasets must be owned by 65532:65532.
+  gid: 65532
+  group_name: nonroot
+  uid: 65532
+  user_name: nonroot
+sources:
+- https://github.com/denn-gubsky/loomcycle
+- https://hub.docker.com/r/denngubsky/loomcycle
+title: loomcycle
+train: community
+version: 0.1.0

--- a/deploy/truenas/catalog/ix_values.yaml
+++ b/deploy/truenas/catalog/ix_values.yaml
@@ -1,0 +1,16 @@
+# Static defaults — images + template constants (not user-editable). RFC AR.
+images:
+  image:
+    repository: denngubsky/loomcycle
+    # PIN to a tag that includes the embedded presets (RFC AQ) — the dialog's
+    # preset selector renders from the binary. Bump app_version in app.yaml in
+    # lockstep on an image bump.
+    tag: latest
+consts:
+  app_container_name: loomcycle
+  # distroless nonroot — the image is fixed at uid/gid 65532 (no arbitrary-uid
+  # support), so this is a constant, not a user question.
+  uid: 65532
+  gid: 65532
+  data_path: /data
+  config_path: /config

--- a/deploy/truenas/catalog/questions.yaml
+++ b/deploy/truenas/catalog/questions.yaml
@@ -1,0 +1,335 @@
+# loomcycle install/edit dialog (RFC AR). The provider/tier matrix comes from the
+# binary's EMBEDDED presets (RFC AQ) — this form only collects the thin,
+# deployment-specific overlay: which presets, the secrets, the Postgres DSNs, a
+# few runtime knobs, the port, and the dataset mounts.
+groups:
+  - name: Providers & Presets
+    description: Pick the embedded provider/tier presets and built-in agents.
+  - name: Secrets
+    description: Bearer token, pepper, and provider API keys (masked, env-only).
+  - name: Storage (Postgres)
+    description: Your existing Postgres 16 — loomcycle bundles no database.
+  - name: Runtime Options
+    description: Non-secret operational config.
+  - name: Network
+    description: The HTTP+SSE / Web UI port.
+  - name: Storage (Datasets)
+    description: ZFS datasets for loomcycle's data, the config overlay, and agent Volumes.
+
+questions:
+  # ── Providers & Presets ───────────────────────────────────────────────────
+  - variable: presets
+    label: Config presets
+    description: |
+      Embedded presets/bundles layered as the config base (LOOMCYCLE_PRESETS).
+      `base` is the full provider matrix; `oauth`/`local` prepend a provider on
+      top; `document-agent` registers the Document Assistant (needs SQL Memory).
+    group: Providers & Presets
+    schema:
+      type: list
+      default:
+        - base
+      items:
+        - variable: preset
+          label: Preset
+          schema:
+            type: string
+            required: true
+            enum:
+              - value: base
+                description: base — all providers + tiers (the base matrix)
+              - value: oauth
+                description: oauth — Anthropic OAuth-dev on top (needs base)
+              - value: local
+                description: local — Ollama-local on top (needs base)
+              - value: document-agent
+                description: document-agent — the Document Assistant (needs SQL Memory)
+
+  # ── Secrets (private: UI-masked; written to container env, never a yaml layer) ─
+  - variable: auth_token
+    label: Auth token (LOOMCYCLE_AUTH_TOKEN)
+    description: The bearer for every /v1/* endpoint + the Web UI login. Generate with `openssl rand -hex 32`.
+    group: Secrets
+    schema:
+      type: string
+      required: true
+      private: true
+  - variable: token_pepper
+    label: Operator-token pepper
+    description: Hardens minted operator-token hashes (LOOMCYCLE_OPERATOR_TOKEN_PEPPER). Optional but recommended.
+    group: Secrets
+    schema:
+      type: string
+      private: true
+  - variable: anthropic_api_key
+    label: ANTHROPIC_API_KEY
+    group: Secrets
+    schema:
+      type: string
+      private: true
+  - variable: openai_api_key
+    label: OPENAI_API_KEY
+    group: Secrets
+    schema:
+      type: string
+      private: true
+  - variable: deepseek_api_key
+    label: DEEPSEEK_API_KEY
+    group: Secrets
+    schema:
+      type: string
+      private: true
+  - variable: gemini_api_key
+    label: GEMINI_API_KEY
+    group: Secrets
+    schema:
+      type: string
+      private: true
+
+  # ── Storage (Postgres) ────────────────────────────────────────────────────
+  - variable: pg_dsn
+    label: Postgres DSN (LOOMCYCLE_PG_DSN)
+    description: 'e.g. postgres://loomcycle:PASSWORD@10.0.0.5:5432/loomcycle?sslmode=disable'
+    group: Storage (Postgres)
+    schema:
+      type: string
+      required: true
+      private: true
+  - variable: sqlmem_pg_dsn
+    label: SQL Memory DSN (LOOMCYCLE_SQLMEM_PG_DSN)
+    description: Optional — the SQL-Memory aux database (a separate DB / least-privilege role). Required if SQL Memory is enabled.
+    group: Storage (Postgres)
+    schema:
+      type: string
+      private: true
+  - variable: sqlmem_enabled
+    label: Enable SQL Memory
+    description: Required by the document-agent bundle. Needs the DSN above.
+    group: Storage (Postgres)
+    schema:
+      type: boolean
+      default: false
+  - variable: automigrate
+    label: Auto-migrate on boot
+    description: Apply pending schema migrations on start (LOOMCYCLE_PG_AUTOMIGRATE=1). Simplest for a single operator. Disable to run `loomcycle migrate up` yourself before deploy.
+    group: Storage (Postgres)
+    schema:
+      type: boolean
+      default: true
+
+  # ── Runtime Options ───────────────────────────────────────────────────────
+  - variable: additional_envs
+    label: Additional environment variables
+    description: |
+      Any other non-secret knob from the env catalogue — see `loomcycle env-template`
+      (or the Settings → Presets panel in the Web UI). e.g. LOOMCYCLE_BASH_ENABLED,
+      LOOMCYCLE_HTTP_HOST_ALLOWLIST, OLLAMA_BASE_URL.
+    group: Runtime Options
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: env
+          label: Environment Variable
+          schema:
+            type: dict
+            attrs:
+              - variable: name
+                label: Name
+                schema:
+                  type: string
+                  required: true
+              - variable: value
+                label: Value
+                schema:
+                  type: string
+
+  # ── Network ───────────────────────────────────────────────────────────────
+  - variable: network
+    label: ""
+    group: Network
+    schema:
+      type: dict
+      attrs:
+        - variable: web_port
+          label: Web port
+          schema:
+            type: dict
+            attrs:
+              - variable: bind_mode
+                label: Port bind mode
+                schema:
+                  type: string
+                  default: published
+                  enum:
+                    - value: published
+                      description: Publish on the host (front with your tunnel/proxy)
+                    - value: exposed
+                      description: Expose for inter-container access only
+                    - value: ""
+                      description: None
+              - variable: port_number
+                label: Port number
+                schema:
+                  type: int
+                  default: 8787
+                  min: 1
+                  max: 65535
+                  required: true
+
+  # ── Storage (Datasets) ────────────────────────────────────────────────────
+  # All mapped datasets must be owned by uid:gid 65532:65532 (the distroless user).
+  - variable: data
+    label: Data storage (LOOMCYCLE_DATA_DIR → /data)
+    description: loomcycle's own local state — SQL-Memory cache + snapshots.
+    group: Storage (Datasets)
+    schema:
+      type: dict
+      attrs:
+        - variable: type
+          label: Type
+          schema:
+            type: string
+            required: true
+            default: ix_volume
+            enum:
+              - value: host_path
+                description: Host Path (an existing dataset)
+              - value: ix_volume
+                description: ixVolume (dataset created by the system)
+        - variable: ix_volume_config
+          label: ixVolume configuration
+          schema:
+            type: dict
+            show_if: [["type", "=", "ix_volume"]]
+            $ref:
+              - normalize/ix_volume
+            attrs:
+              - variable: dataset_name
+                label: Dataset name
+                schema:
+                  type: string
+                  required: true
+                  hidden: true
+                  default: data
+        - variable: host_path_config
+          label: Host path configuration
+          schema:
+            type: dict
+            show_if: [["type", "=", "host_path"]]
+            attrs:
+              - variable: path
+                label: Host path
+                schema:
+                  type: hostpath
+                  required: true
+
+  - variable: config
+    label: Config overlay (read-only → /config)
+    description: |
+      A dataset holding loomcycle.yaml — the thin overlay (your agent `volumes:`
+      block). Copy deploy/truenas/loomcycle.overlay.example.yaml into it.
+    group: Storage (Datasets)
+    schema:
+      type: dict
+      attrs:
+        - variable: type
+          label: Type
+          schema:
+            type: string
+            required: true
+            default: host_path
+            enum:
+              - value: host_path
+                description: Host Path (an existing dataset)
+              - value: ix_volume
+                description: ixVolume (dataset created by the system)
+        - variable: ix_volume_config
+          label: ixVolume configuration
+          schema:
+            type: dict
+            show_if: [["type", "=", "ix_volume"]]
+            $ref:
+              - normalize/ix_volume
+            attrs:
+              - variable: dataset_name
+                label: Dataset name
+                schema:
+                  type: string
+                  required: true
+                  hidden: true
+                  default: config
+        - variable: host_path_config
+          label: Host path configuration
+          schema:
+            type: dict
+            show_if: [["type", "=", "host_path"]]
+            attrs:
+              - variable: path
+                label: Host path
+                schema:
+                  type: hostpath
+                  required: true
+
+  - variable: additional_storage
+    label: Agent Volumes (RFC AH)
+    description: |
+      ZFS datasets agents may read/write, each mounted at an in-container path that
+      your config overlay's `volumes:` block maps a name to (e.g. mount_path
+      /mnt/work ↔ overlay `work: { path: /mnt/work }`).
+    group: Storage (Datasets)
+    schema:
+      type: list
+      default: []
+      items:
+        - variable: store
+          label: Volume
+          schema:
+            type: dict
+            attrs:
+              - variable: type
+                label: Type
+                schema:
+                  type: string
+                  required: true
+                  default: host_path
+                  enum:
+                    - value: host_path
+                      description: Host Path (an existing dataset)
+                    - value: ix_volume
+                      description: ixVolume (dataset created by the system)
+              - variable: read_only
+                label: Read-only
+                schema:
+                  type: boolean
+                  default: false
+              - variable: mount_path
+                label: Mount path (in container)
+                description: Must match the `path` of a `volumes:` entry in your overlay.
+                schema:
+                  type: path
+                  required: true
+              - variable: host_path_config
+                label: Host path configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "host_path"]]
+                  attrs:
+                    - variable: path
+                      label: Host path
+                      schema:
+                        type: hostpath
+                        required: true
+              - variable: ix_volume_config
+                label: ixVolume configuration
+                schema:
+                  type: dict
+                  show_if: [["type", "=", "ix_volume"]]
+                  $ref:
+                    - normalize/ix_volume
+                  attrs:
+                    - variable: dataset_name
+                      label: Dataset name
+                      schema:
+                        type: string
+                        required: true

--- a/deploy/truenas/catalog/templates/docker-compose.yaml
+++ b/deploy/truenas/catalog/templates/docker-compose.yaml
@@ -1,0 +1,61 @@
+{#
+  loomcycle catalog template (RFC AR) — Jinja2 + the TrueNAS ix-lib render library.
+
+  ⚠️  SCAFFOLD — render-validate on your TrueNAS version before publishing.
+  The ix-lib (ix_lib.base.render) is vendored into templates/library/ by TrueNAS's
+  catalog CI from app.yaml:lib_version; it is NOT committed here. Method signatures
+  (esp. the healthcheck EXEC form — distroless has no shell, so the test must be
+  ["CMD", "/usr/local/bin/loomcycle", "health"], not a CMD-SHELL string) and the
+  storage/perms model must be verified against the pinned lib version. The
+  VALIDATED, working route is the custom-app ../docker-compose.yaml.
+
+  Dataset ownership: the image is fixed at uid/gid 65532 — chown the mapped
+  datasets to 65532:65532 (see ../../docs/TRUENAS.md). Migrations run in-process
+  when "Auto-migrate on boot" is on (LOOMCYCLE_PG_AUTOMIGRATE); otherwise run
+  `loomcycle migrate up` before deploy.
+#}
+{% set tpl = ix_lib.base.render.Render(values) %}
+
+{% set c1 = tpl.add_container(values.consts.app_container_name, "image") %}
+{% do c1.set_user(values.consts.uid, values.consts.gid) %}
+{% do c1.healthcheck.set_custom_test("/usr/local/bin/loomcycle health") %}
+
+{# ── Runtime + presets ── #}
+{% do c1.environment.add_env("LOOMCYCLE_LISTEN_ADDR", "0.0.0.0:8787") %}
+{% do c1.environment.add_env("LOOMCYCLE_PRESETS", values.presets | join(",")) %}
+{% do c1.environment.add_env("LOOMCYCLE_CONFIG_DIR", values.consts.config_path) %}
+{% do c1.environment.add_env("LOOMCYCLE_DATA_DIR", values.consts.data_path) %}
+
+{# ── Storage (Postgres) ── #}
+{% do c1.environment.add_env("LOOMCYCLE_STORAGE_BACKEND", "postgres") %}
+{% do c1.environment.add_env("LOOMCYCLE_PG_DSN", values.pg_dsn) %}
+{% if values.sqlmem_pg_dsn %}
+{% do c1.environment.add_env("LOOMCYCLE_SQLMEM_PG_DSN", values.sqlmem_pg_dsn) %}
+{% endif %}
+{% do c1.environment.add_env("LOOMCYCLE_SQLMEM_ENABLED", "1" if values.sqlmem_enabled else "0") %}
+{% do c1.environment.add_env("LOOMCYCLE_PG_AUTOMIGRATE", "1" if values.automigrate else "0") %}
+
+{# ── Secrets ── #}
+{% do c1.environment.add_env("LOOMCYCLE_AUTH_TOKEN", values.auth_token) %}
+{% if values.token_pepper %}
+{% do c1.environment.add_env("LOOMCYCLE_OPERATOR_TOKEN_PEPPER", values.token_pepper) %}
+{% endif %}
+{% if values.anthropic_api_key %}{% do c1.environment.add_env("ANTHROPIC_API_KEY", values.anthropic_api_key) %}{% endif %}
+{% if values.openai_api_key %}{% do c1.environment.add_env("OPENAI_API_KEY", values.openai_api_key) %}{% endif %}
+{% if values.deepseek_api_key %}{% do c1.environment.add_env("DEEPSEEK_API_KEY", values.deepseek_api_key) %}{% endif %}
+{% if values.gemini_api_key %}{% do c1.environment.add_env("GEMINI_API_KEY", values.gemini_api_key) %}{% endif %}
+
+{# ── Any other non-secret knob (env catalogue) ── #}
+{% do c1.environment.add_user_envs(values.additional_envs) %}
+
+{# ── Network + storage ── #}
+{% do c1.add_port(values.network.web_port) %}
+{% do c1.add_storage(values.consts.data_path, values.data) %}
+{% do c1.add_storage(values.consts.config_path, values.config) %}
+{% for store in values.additional_storage %}
+{% do c1.add_storage(store.mount_path, store) %}
+{% endfor %}
+
+{% do tpl.portals.add(values.network.web_port) %}
+
+{{ tpl.render() | tojson }}

--- a/deploy/truenas/catalog/templates/test_values/basic-values.yaml
+++ b/deploy/truenas/catalog/templates/test_values/basic-values.yaml
@@ -1,0 +1,33 @@
+# CI render-test input (a fully-answered `values`). Mirrors questions.yaml +
+# the system-injected ix_volumes map. Used by the TrueNAS catalog render harness.
+presets:
+  - base
+auth_token: test-token-do-not-use
+token_pepper: ""
+anthropic_api_key: ""
+openai_api_key: ""
+deepseek_api_key: ""
+gemini_api_key: ""
+pg_dsn: postgres://loomcycle:pw@10.0.0.5:5432/loomcycle?sslmode=disable
+sqlmem_pg_dsn: ""
+sqlmem_enabled: false
+automigrate: true
+additional_envs: []
+network:
+  web_port:
+    bind_mode: published
+    port_number: 8787
+data:
+  type: ix_volume
+  ix_volume_config:
+    dataset_name: data
+    create_host_path: true
+config:
+  type: ix_volume
+  ix_volume_config:
+    dataset_name: config
+    create_host_path: true
+additional_storage: []
+ix_volumes:
+  data: /opt/tests/mnt/data
+  config: /opt/tests/mnt/config

--- a/deploy/truenas/docker-compose.yaml
+++ b/deploy/truenas/docker-compose.yaml
@@ -1,0 +1,95 @@
+# loomcycle on TrueNAS SCALE — custom-app (paste-compose) deployment.
+#
+# RFC AR Phase 1. This is the FAST route: TrueNAS SCALE (Electric Eel 24.10+) →
+# Apps → Discover → ⋮ → "Install via YAML" → paste this file. (The formal catalog
+# app with an install wizard lives in ./catalog/ — see ../docs/TRUENAS.md.)
+#
+# Before you install — on the TrueNAS host:
+#   1. Create datasets and chown them to the distroless uid (65532):
+#        mkdir -p /mnt/tank/loomcycle/{data,config,work}
+#        chown -R 65532:65532 /mnt/tank/loomcycle
+#   2. Create the loomcycle databases in your existing Postgres 16 (DB-per-service):
+#        CREATE DATABASE loomcycle;  CREATE DATABASE loomcycle_sqlmem;
+#      and a least-privilege role (see ../docs/TRUENAS.md §Postgres).
+#   3. Drop a thin overlay at /mnt/tank/loomcycle/config/loomcycle.yaml that maps
+#      your agent Volumes to the mounted host paths — copy loomcycle.overlay.example.yaml.
+#   4. Edit the env values + host paths below, then paste.
+#
+# loomcycle's provider/tier matrix comes from the EMBEDDED presets (RFC AQ) via
+# LOOMCYCLE_PRESETS — you don't write provider yaml. Secrets are TrueNAS-managed
+# env here, never a yaml layer. Ingress (TLS) is out of scope: the container binds
+# 0.0.0.0:8787 on the app network; front it with your existing tunnel/proxy.
+
+name: loomcycle
+
+services:
+  # One-shot schema migration. Runs `loomcycle migrate up` against Postgres, then
+  # exits; the runtime waits for it to complete. Decoupled from the image deploy
+  # (LOOMCYCLE_PG_AUTOMIGRATE=0 on the runtime) so a schema bump is explicit.
+  loomcycle-migrate:
+    image: denngubsky/loomcycle:latest # PIN a tag that includes RFC AQ (≥ the next release); :latest is for testing only
+    user: "65532:65532"
+    restart: "no"
+    command: ["migrate", "up"]
+    environment:
+      LOOMCYCLE_STORAGE_BACKEND: postgres
+      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN:?set LOOMCYCLE_PG_DSN}
+      LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN:-}
+
+  loomcycle:
+    image: denngubsky/loomcycle:latest # PIN a tag that includes RFC AQ (≥ the next release); :latest is for testing only
+    user: "65532:65532"
+    restart: unless-stopped
+    depends_on:
+      loomcycle-migrate:
+        condition: service_completed_successfully
+    ports:
+      # The app network port. Front with your tunnel/proxy — no public bind here.
+      - "8787:8787"
+    environment:
+      # Bind all interfaces inside the container (the port mapping above reaches it).
+      LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
+
+      # Provider/tier base from the embedded presets (RFC AQ). Add bundles/overlays:
+      #   base,oauth          → OAuth on top of the base matrix
+      #   base,document-agent → also register the Document Assistant agent
+      LOOMCYCLE_PRESETS: ${LOOMCYCLE_PRESETS:-base}
+      # The thin overlay (your volumes: block etc.) layered over the presets.
+      LOOMCYCLE_CONFIG_DIR: /config
+
+      # Storage — your existing Postgres 16 (the app does NOT bundle a DB).
+      LOOMCYCLE_STORAGE_BACKEND: postgres
+      LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN:?set LOOMCYCLE_PG_DSN}
+      LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN:-}
+      LOOMCYCLE_SQLMEM_ENABLED: ${LOOMCYCLE_SQLMEM_ENABLED:-0}
+      # Migrations run in the init service above; the runtime must NOT auto-migrate.
+      LOOMCYCLE_PG_AUTOMIGRATE: "0"
+      # Local state (sqlmem cache, snapshots) on the data dataset.
+      LOOMCYCLE_DATA_DIR: /data
+
+      # Secrets — TrueNAS-managed env, never a yaml layer. Generate the token with
+      # `openssl rand -hex 32`; the pepper hardens minted operator-token hashes.
+      LOOMCYCLE_AUTH_TOKEN: ${LOOMCYCLE_AUTH_TOKEN:?set LOOMCYCLE_AUTH_TOKEN}
+      LOOMCYCLE_OPERATOR_TOKEN_PEPPER: ${LOOMCYCLE_OPERATOR_TOKEN_PEPPER:-}
+      # Provider keys — set whichever the selected presets route to.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
+    volumes:
+      # loomcycle's own data (sqlmem cache, snapshots). chown 65532:65532.
+      - /mnt/tank/loomcycle/data:/data
+      # The thin overlay dir (read-only) — drop loomcycle.yaml here (volumes: block).
+      - /mnt/tank/loomcycle/config:/config:ro
+      # Agent filesystem Volume(s) (RFC AH) → ZFS datasets. The overlay's volumes:
+      # block maps a name to the IN-CONTAINER path (e.g. work → /mnt/work). Add a
+      # mount + an overlay entry per agent volume. (The catalog app turns this into
+      # repeating form rows — RFC AR Phase 2.)
+      - /mnt/tank/loomcycle/work:/mnt/work
+    healthcheck:
+      # distroless has no curl — the binary's own probe GETs /healthz.
+      test: ["CMD", "/usr/local/bin/loomcycle", "health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/deploy/truenas/loomcycle.overlay.example.yaml
+++ b/deploy/truenas/loomcycle.overlay.example.yaml
@@ -1,0 +1,36 @@
+# loomcycle TrueNAS overlay — the thin, deployment-specific layer.
+#
+# Copy to your config dataset as loomcycle.yaml (the compose mounts that dataset
+# at /config and selects it via LOOMCYCLE_CONFIG_DIR). It is layered OVER the
+# embedded presets (RFC AQ): the presets supply the provider/tier matrix, this
+# file supplies only what's specific to this box — chiefly the agent Volumes
+# (RFC AH) mapped to the host datasets the compose mounted.
+#
+# Keep secrets OUT of this file — they're TrueNAS-managed env (the compose). This
+# overlay is non-secret config only.
+
+# Agent filesystem Volumes (RFC AH). Each `path` is the IN-CONTAINER mount point
+# (the right-hand side of the compose volume mount), which must already exist —
+# the bind mount creates it. Bind an agent to a volume with a per-agent
+# `volumes: [name]`; an agent with none, plus a `default: true` volume, binds to
+# default. With NO default and no binding, an agent has no filesystem access.
+volumes:
+  work:
+    path: /mnt/work        # ← matches the compose mount: /mnt/tank/loomcycle/work:/mnt/work
+    mode: rw
+    default: true
+  # Add a row here AND a compose mount per additional dataset, e.g.:
+  # reference:
+  #   path: /mnt/reference
+  #   mode: ro
+
+# You can also override anything the presets set (last layer wins) or add agents,
+# e.g. retarget the built-in document-agent's tier, or define your own agent:
+#
+# agents:
+#   my-agent:
+#     tier: middle
+#     allowed_tools: [Read, Write, Edit, Grep, Glob]
+#     volumes: [work]
+#     system_prompt: |
+#       …

--- a/docs/TRUENAS.md
+++ b/docs/TRUENAS.md
@@ -1,0 +1,154 @@
+# Running loomcycle on TrueNAS SCALE
+
+**Why a packaged app, not hand-rolled compose-over-SSH?** TrueNAS operators expect
+to install from a form, edit it later in the UI, and let dataset snapshots back it
+up — not SSH in to hand-edit YAML. What made that practical is **embedded presets**
+(RFC AQ): the binary ships the provider/tier matrix and the built-in agents inside
+itself, so the install form only collects the *thin, deployment-specific* overlay —
+which presets, the secrets, your Postgres DSN, and which datasets the agents may
+touch. This is the first entry in loomcycle's operator-cookbook of deployment
+postures. **The thesis: on TrueNAS, loomcycle is install-the-app-fill-the-form, and
+everything provider-shaped already lives in the image.**
+
+Applies to **TrueNAS SCALE Electric Eel 24.10+** (the Docker-Compose app engine;
+also 25.04 Fangtooth). The pre-24.10 Helm/k8s app format does not apply.
+
+---
+
+## What you provide vs. what the image provides
+
+| The image (RFC AQ) | You (the form / overlay) |
+|---|---|
+| All providers + tiers (`LOOMCYCLE_PRESETS=base`), OAuth/local overlays, the `document-agent` Document Assistant | Which presets to enable |
+| The runtime, Web UI, MCP server, all tools | The bearer token + provider API key(s) |
+| Migrations (`loomcycle migrate up`) | A Postgres 16 connection (the app bundles **no** DB) |
+| — | The ZFS datasets agents may read/write (RFC AH Volumes) |
+
+Secrets are **TrueNAS-managed env**, never written to a YAML layer. loomcycle does
+not source `.env.local` in a container — only real env + the mounted overlay.
+
+---
+
+## Prerequisites (on the TrueNAS host)
+
+1. **Postgres 16** reachable from the apps network (your existing instance,
+   DB-per-service — see [`POSTGRES.md`](POSTGRES.md)). Create the databases:
+   ```sql
+   CREATE DATABASE loomcycle;
+   CREATE DATABASE loomcycle_sqlmem;   -- only if you enable SQL Memory
+   CREATE ROLE loomcycle LOGIN PASSWORD '…';
+   GRANT ALL PRIVILEGES ON DATABASE loomcycle TO loomcycle;
+   GRANT ALL PRIVILEGES ON DATABASE loomcycle_sqlmem TO loomcycle;
+   ```
+2. **Datasets**, owned by the distroless uid (the image is fixed at **65532**):
+   ```sh
+   mkdir -p /mnt/tank/loomcycle/{data,config,work}
+   chown -R 65532:65532 /mnt/tank/loomcycle
+   ```
+   - `data` → loomcycle's own state (SQL-Memory cache, snapshots).
+   - `config` → the thin overlay (`loomcycle.yaml`).
+   - `work` (and any more) → agent filesystem Volumes (RFC AH).
+3. The **config overlay**: copy
+   [`deploy/truenas/loomcycle.overlay.example.yaml`](../deploy/truenas/loomcycle.overlay.example.yaml)
+   to `/mnt/tank/loomcycle/config/loomcycle.yaml` and edit its `volumes:` block so
+   each entry's `path` is the **in-container** mount point you'll map below.
+
+---
+
+## Two routes
+
+| Route | How | When |
+|---|---|---|
+| **A — custom app** | Apps → Discover → ⋮ → *Install via YAML*, paste the compose | Fastest, works today; edit the compose directly. |
+| **B — catalog app** | Install wizard from a published train | Formal — a form you re-open to edit; needs render-validation first. |
+
+### Route A — custom app (paste compose)
+
+1. Edit [`deploy/truenas/docker-compose.yaml`](../deploy/truenas/docker-compose.yaml):
+   set the env values (`LOOMCYCLE_AUTH_TOKEN`, `LOOMCYCLE_PG_DSN`, provider keys,
+   `LOOMCYCLE_PRESETS`) and the host-path mounts to your datasets. **Pin the image
+   tag** to a release that includes RFC AQ (the preset machinery) — `:latest` is for
+   testing only.
+2. Apps → **Discover Apps** → the **⋮** menu → **Install via YAML**. Name it
+   `loomcycle`, paste the file, install.
+3. The `loomcycle-migrate` service runs `migrate up` once; the runtime waits for it,
+   then serves on `:8787`. Watch the app logs for `loomcycle listening`.
+
+### Route B — catalog app (wizard)
+
+The catalog source is [`deploy/truenas/catalog/`](../deploy/truenas/catalog/)
+(`app.yaml`, `questions.yaml`, `ix_values.yaml`, `templates/`). The install form
+groups: **Providers & Presets** (multiselect), **Secrets**, **Storage (Postgres)**,
+**Runtime Options**, **Network**, **Storage (Datasets)**.
+
+> **⚠️ Validate before publishing.** `templates/docker-compose.yaml` uses the TrueNAS
+> Jinja2 + `ix-lib` render library, which the catalog CI vendors at build time (it is
+> not committed). Render-test it on **your** TrueNAS version and ix-lib release
+> before publishing to a train — confirm in particular the **healthcheck exec form**
+> (distroless has no shell, so the test must be `["CMD","/usr/local/bin/loomcycle",
+> "health"]`, not a shell string) and the storage model. Until then, use **Route A**.
+
+To publish: add `deploy/truenas/catalog/` as `ix-dev/community/loomcycle/` in a
+catalog/train git repo (the `truenas/apps` layout), let its CI vendor the library +
+generate the `trains/` output, and point TrueNAS at the catalog.
+
+---
+
+## Postgres & migrations
+
+- `LOOMCYCLE_STORAGE_BACKEND=postgres`, `LOOMCYCLE_PG_DSN=…` (store),
+  `LOOMCYCLE_SQLMEM_PG_DSN=…` (SQL Memory, only if `LOOMCYCLE_SQLMEM_ENABLED=1`).
+- **Migrations are decoupled from the image deploy.** Route A runs them in a one-shot
+  `loomcycle-migrate` init service (`LOOMCYCLE_PG_AUTOMIGRATE=0` on the runtime).
+  Route B exposes an **Auto-migrate on boot** toggle (`=1`, default on for a single
+  operator) — or turn it off and run `loomcycle migrate up` yourself before deploy.
+- TrueNAS dataset snapshots back up `data` + your agent datasets; that's orthogonal
+  to loomcycle's own `/v1/_snapshots`.
+
+## Volumes → datasets (RFC AH)
+
+Each agent Volume is **a host dataset mounted into the container** + **a `volumes:`
+entry in the overlay** that names it. The mount's in-container path must equal the
+overlay entry's `path`:
+
+```
+compose:  /mnt/tank/loomcycle/work : /mnt/work        ┐ same in-container path
+overlay:  volumes: { work: { path: /mnt/work, mode: rw, default: true } } ┘
+```
+
+An agent bound to `work` (or any agent, if `work` is `default: true`) reads/writes
+that dataset, confined by RFC AH. With no `default` and no binding, an agent has no
+filesystem access. Adding a Volume = a new mount + a new overlay entry + redeploy.
+(Route B turns these into repeating form rows — RFC AR Phase 2.) **All mapped
+datasets must be `chown`ed to 65532:65532.**
+
+## Presets & secrets
+
+- **Presets** (`LOOMCYCLE_PRESETS`, comma-separated, ordered): `base` for the full
+  matrix; add `oauth` or `local` to prepend a provider on top; add `document-agent`
+  to register the Document Assistant (needs `LOOMCYCLE_SQLMEM_ENABLED=1` + a `middle`
+  tier). Browse them with `loomcycle presets` or the Web UI **Settings → Presets**.
+- **Mint tenant tokens from the Web UI** (no shell needed): sign in with the admin
+  (root) token, click the gear → **Settings → Tokens** ([`operator-tokens`](../internal/help/builtin/operator-tokens.md)).
+
+## Health & upgrade
+
+- **Health:** the container `HEALTHCHECK` is `loomcycle health` (GETs the unauth
+  `/healthz` — distroless has no `curl`).
+- **Upgrade:** bump the image tag → new binary → refreshed embedded presets
+  automatically; your form answers / overlay persist. Run `migrate up` (or leave
+  auto-migrate on) if the new version bumped the Postgres schema.
+
+## Ingress (out of scope)
+
+loomcycle has no built-in TLS. The container binds `0.0.0.0:8787` on the apps
+network; front it with your existing tunnel/proxy (the house posture is a Cloudflare
+Tunnel — no exposed host ports). The form does not imply a public bind.
+
+## Version pinning
+
+Pin both the **loomcycle image tag** (a release with RFC AQ) and the **TrueNAS
+version** you validated against (`app.yaml: annotations.min_scale_version`, set to
+`24.10.2.2`). The `questions.yaml`/`app.yaml` schema is stable across Electric Eel →
+Fangtooth; the gating field is `lib_version` (the ix-lib render API). Re-validate on
+a major TrueNAS upgrade.


### PR DESCRIPTION
## Why

The last step of the TrueNAS line. RFC AQ baked the provider/tier matrix + built-in agents into the binary; this packages loomcycle as a **TrueNAS SCALE application** (Electric Eel 24.10+ Docker-Compose engine) so an operator installs from a form and edits it in the UI instead of hand-writing compose + datasets + config over SSH. The embedded presets are the enabler — the install form only collects the thin, deployment-specific overlay (presets, secrets, the PG DSN, which datasets agents may touch).

This is **RFC AR Phase 1** (the app skeleton). Pure packaging — **no new loomcycle runtime/Go surface**.

## What — `deploy/truenas/` + `docs/TRUENAS.md`

Two routes, because a TrueNAS catalog app requires a Jinja2 + `ix-lib` template that the catalog CI vendors at build time (not committable here, and not render-validatable locally):

1. **`docker-compose.yaml` — custom-app paste route (the working path today).** Plain compose, **validated with `docker compose config`**: a one-shot `loomcycle-migrate` init service + the runtime, external Postgres 16, `LOOMCYCLE_PRESETS=base`, a config-overlay + data + agent-Volume dataset mounts, `user: 65532:65532`, and a **distroless-safe healthcheck** (`["CMD","/usr/local/bin/loomcycle","health"]` — exec form, no curl).
2. **`catalog/` — catalog-app source** to the ix-dev schema (`app.yaml`, `ix_values.yaml`, `questions.yaml`, `templates/docker-compose.yaml` (ix-lib), `test_values/`, `README.md`). The install form: presets multiselect, masked secrets, PG DSNs, an auto-migrate toggle, an additional-envs repeater, the port, and `host_path`/`ixVolume` storage incl. an agent-Volume list. **Flagged as a scaffold to render-validate on a real TrueNAS** (RFC open-Q #3) — the working route until then is #1.
3. **`loomcycle.overlay.example.yaml`** — the thin overlay (agent `volumes:` block) both routes mount; **`README.md`** — the dir map.
4. **`docs/TRUENAS.md`** — install/edit/upgrade runbook: prerequisites (PG DBs+roles, datasets chowned to 65532, the overlay), both routes, migrations, Volumes→datasets (the mount↔overlay path coupling), presets + Web-UI token minting, health + upgrade, ingress-out-of-scope, version pinning.

Researched the current TrueNAS Electric Eel/Fangtooth app format (the `truenas/apps` ix-dev layout, the `questions.yaml` schema, the ix-lib render API) before authoring — the catalog files mirror a real community app's structure.

## Tested

- `docker compose -f deploy/truenas/docker-compose.yaml config` — **valid** (both services, `depends_on` completion gate, healthcheck resolved).
- All catalog/overlay YAML parses; `questions.yaml` = 16 questions / 6 groups, correct `groups:`+`questions:` shape.
- `go build ./...` clean (no Go changed).
- **Not** validated: the catalog Jinja2 template render (needs a live TrueNAS + the vendored ix-lib) — explicitly flagged in the file header, the dir README, and `docs/TRUENAS.md`.

## Scope / deferrals

Phase 2 (the richer Volume repeating-rows UX, full `.env.insecure` form coverage, publish to a train) and Phase 3 (HA multi-replica on TrueNAS) are per the RFC. With this, **RFC AR is the first concrete entry in the operator-cookbook of deployment postures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD