### PR TITLE
docs: soften Postgres version requirements (≥14 floor, not a pin)

### DIFF
--- a/deploy/truenas/README.md
+++ b/deploy/truenas/README.md
@@ -13,7 +13,7 @@ Compose app engine). **RFC AR.** Two routes — both documented in
 Both routes share the same shape: the binary's **embedded presets** (RFC AQ)
 supply the provider/tier matrix (`LOOMCYCLE_PRESETS`); a thin overlay supplies the
 agent **Volumes** (RFC AH) mapped to ZFS datasets; **secrets** are TrueNAS-managed
-env (never a yaml layer); storage is your **existing Postgres 16** (the app bundles
+env (never a yaml layer); storage is your **existing Postgres ≥ 14** (the app bundles
 no DB). Ingress/TLS is out of scope — the container binds `0.0.0.0:8787`; front it
 with your existing tunnel/proxy.
 

--- a/deploy/truenas/catalog/README.md
+++ b/deploy/truenas/catalog/README.md
@@ -9,7 +9,7 @@ This is the TrueNAS SCALE **catalog app** source (Electric Eel 24.10+). The
 provider/tier matrix is supplied by the binary's embedded presets (RFC AQ) — the
 install form picks presets, the secrets, your Postgres DSN, the port, and the
 dataset mounts. Secrets are TrueNAS-managed env; the app bundles no database
-(point it at your existing Postgres 16). Ingress/TLS is the operator's existing
+(point it at your existing Postgres ≥ 14). Ingress/TLS is the operator's existing
 tunnel/proxy.
 
 See [`../../../docs/TRUENAS.md`](../../../docs/TRUENAS.md) for the install/edit/

--- a/deploy/truenas/catalog/questions.yaml
+++ b/deploy/truenas/catalog/questions.yaml
@@ -8,7 +8,7 @@ groups:
   - name: Secrets
     description: Bearer token, pepper, and provider API keys (masked, env-only).
   - name: Storage (Postgres)
-    description: Your existing Postgres 16 — loomcycle bundles no database.
+    description: Your existing Postgres (v14 or newer) — loomcycle bundles no database.
   - name: Runtime Options
     description: Non-secret operational config.
   - name: Network

--- a/deploy/truenas/docker-compose.yaml
+++ b/deploy/truenas/docker-compose.yaml
@@ -8,7 +8,7 @@
 #   1. Create datasets and chown them to the distroless uid (65532):
 #        mkdir -p /mnt/tank/loomcycle/{data,config,work}
 #        chown -R 65532:65532 /mnt/tank/loomcycle
-#   2. Create the loomcycle databases in your existing Postgres 16 (DB-per-service):
+#   2. Create the loomcycle databases in your existing Postgres ≥ 14 (DB-per-service):
 #        CREATE DATABASE loomcycle;  CREATE DATABASE loomcycle_sqlmem;
 #      and a least-privilege role (see ../docs/TRUENAS.md §Postgres).
 #   3. Drop a thin overlay at /mnt/tank/loomcycle/config/loomcycle.yaml that maps
@@ -57,7 +57,7 @@ services:
       # The thin overlay (your volumes: block etc.) layered over the presets.
       LOOMCYCLE_CONFIG_DIR: /config
 
-      # Storage — your existing Postgres 16 (the app does NOT bundle a DB).
+      # Storage — your existing Postgres ≥ 14 (the app does NOT bundle a DB).
       LOOMCYCLE_STORAGE_BACKEND: postgres
       LOOMCYCLE_PG_DSN: ${LOOMCYCLE_PG_DSN:?set LOOMCYCLE_PG_DSN}
       LOOMCYCLE_SQLMEM_PG_DSN: ${LOOMCYCLE_SQLMEM_PG_DSN:-}

--- a/docker-compose.cluster.yaml
+++ b/docker-compose.cluster.yaml
@@ -23,6 +23,7 @@
 
 services:
   postgres:
+    # Any Postgres ≥ 14 works; 16 here is just a tested default.
     image: postgres:16
     container_name: loomcycle-cluster-pg
     restart: unless-stopped

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -53,6 +53,7 @@ services:
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
 
   # --- Postgres backend (uncomment for v0.10.x+ Vector Memory / HA) ---
+  # Any Postgres ≥ 14 works; 16 here is just a tested default.
   # postgres:
   #   image: postgres:16
   #   container_name: loomcycle-pg

--- a/docs/POSTGRES.md
+++ b/docs/POSTGRES.md
@@ -45,7 +45,14 @@ Env wins over yaml when both are set. Defaults (omit to use these):
 | `pg_min_idle_conns` | 4 |
 | `pg_automigrate` | false |
 
-Postgres ≥ 14 required.
+**Postgres ≥ 14 required** — that's the floor, not a pin. loomcycle uses no
+version-locked SQL features, so any newer major (15, 16, 17, 18, …) works
+unchanged; pick whatever your platform ships. The `postgres:16` images in the
+example composes are a tested default, not a requirement. The one version-gated
+piece is **pgvector** (only needed for Vector Memory / `recall`): it supports
+PostgreSQL 13–18, so install the extension package matching your server's major
+(e.g. `postgresql-18-pgvector`, or a `pgvector/pgvector:pg18` image). Without
+pgvector, the embeddings table is skipped gracefully and everything else runs.
 
 ## Schema migrations
 

--- a/docs/TRUENAS.md
+++ b/docs/TRUENAS.md
@@ -21,7 +21,7 @@ also 25.04 Fangtooth). The pre-24.10 Helm/k8s app format does not apply.
 |---|---|
 | All providers + tiers (`LOOMCYCLE_PRESETS=base`), OAuth/local overlays, the `document-agent` Document Assistant | Which presets to enable |
 | The runtime, Web UI, MCP server, all tools | The bearer token + provider API key(s) |
-| Migrations (`loomcycle migrate up`) | A Postgres 16 connection (the app bundles **no** DB) |
+| Migrations (`loomcycle migrate up`) | A Postgres ≥ 14 connection (the app bundles **no** DB) |
 | — | The ZFS datasets agents may read/write (RFC AH Volumes) |
 
 Secrets are **TrueNAS-managed env**, never written to a YAML layer. loomcycle does
@@ -31,7 +31,7 @@ not source `.env.local` in a container — only real env + the mounted overlay.
 
 ## Prerequisites (on the TrueNAS host)
 
-1. **Postgres 16** reachable from the apps network (your existing instance,
+1. **Postgres ≥ 14** reachable from the apps network (your existing instance,
    DB-per-service — see [`POSTGRES.md`](POSTGRES.md)). Create the databases:
    ```sql
    CREATE DATABASE loomcycle;

--- a/examples/observability/grafana-tempo/compose.yaml
+++ b/examples/observability/grafana-tempo/compose.yaml
@@ -47,6 +47,7 @@ services:
         condition: service_started
 
   postgres:
+    # Any Postgres ≥ 14 works; 16 here is just a tested default.
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: loomcycle


### PR DESCRIPTION
## Why
A user installing the TrueNAS app runs **Postgres 18** and asked whether the `16` in the docs was a hard requirement. It isn't — but several places worded it like one. loomcycle's actual floor is **Postgres ≥ 14** (`docs/POSTGRES.md`), it uses no version-locked SQL features, and any newer major (15/16/17/18) works. The app/examples **bundle no required DB version** — they connect to the operator's existing instance, and the `postgres:16` images are a tested default. pgvector (needed only for Vector Memory) supports PG 13–18 and degrades gracefully when absent.

## What
Softens version wording across the deploy + storage docs so nothing reads as a mandatory `16`:

**TrueNAS deploy artifacts** ("Postgres 16" → "Postgres ≥ 14"):
- `deploy/truenas/docker-compose.yaml` (2 comments)
- `deploy/truenas/README.md`
- `deploy/truenas/catalog/README.md`
- `deploy/truenas/catalog/questions.yaml` (Storage group description → "v14 or newer")
- `docs/TRUENAS.md` (capabilities table + Prerequisites)

**Core storage docs / examples:**
- `docs/POSTGRES.md` — expand the terse "Postgres ≥ 14 required." into an explicit "floor, not a pin" statement (newer majors work; example `postgres:16` is a tested default; pgvector 13–18 + graceful degradation).
- `docker-compose.cluster.yaml`, `docker-compose.example.yaml`, `examples/observability/grafana-tempo/compose.yaml` — one-line "any Postgres ≥ 14 works" note above the `postgres:16` pins (pins kept for reproducibility).

Docs/comments only — **no runtime, schema, or wire change.** Left as-is on purpose: CI's pinned `pgvector/pgvector:pg16` (test infra — pinning a tested version is correct), the `postgres:16-alpine` benchmark-fixture reference in `docs/POSTGRES.md` (records what was measured), and `REVISIONS.md` historical entries. The per-feature floors in `docs/MULTI-REPLICA.md` (12+) and `docs/SQL_MEMORY.md` (13+) are already soft and accommodate PG18 — left untouched to avoid inaccurately tightening them.

## Tested
- `grep` confirms no remaining hard "Postgres 16" requirement wording in `deploy/truenas/`, `docs/`, or the example composes.
- All edited YAML files (`questions.yaml`, `docker-compose.yaml`, `docker-compose.cluster.yaml`, `docker-compose.example.yaml`, `grafana-tempo/compose.yaml`) re-parse as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)