### PR TITLE
fix(webui): keep agent name beside the status badges in run rows

### DIFF
--- a/web/src/components/AgentsTree.tsx
+++ b/web/src/components/AgentsTree.tsx
@@ -169,12 +169,14 @@ function AgentsTreeNode({ node, depth, expandedMap, setExpanded, selectedId, onS
         >
           {hasChildren ? (expanded ? "▼" : "▶") : "·"}
         </button>
-        <span className={`pill ${a.status}`}>{a.status}</span>
-        {a.interactive && (
-          <span className="pill-interactive" title="Interactive session — parks for operator steering; re-attachable in the run terminal">
-            interactive
-          </span>
-        )}
+        <span className="row-badges">
+          <span className={`pill ${a.status}`}>{a.status}</span>
+          {a.interactive && (
+            <span className="pill-interactive" title="Interactive session — parks for operator steering; re-attachable in the run terminal">
+              interactive
+            </span>
+          )}
+        </span>
         {onSelect ? (
           <button
             type="button"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -342,13 +342,25 @@ textarea::placeholder {
 }
 .node .row {
   display: grid;
-  grid-template-columns: 14px 80px 1fr 200px 120px auto;
+  /* col 2 is `auto` (not a fixed pill width) so the status + interactive
+   * badges share one cell sized to their content — otherwise the extra
+   * interactive pill takes its own grid track and shoves the agent name
+   * (the 1fr column) far to the right. See .row-badges below. */
+  grid-template-columns: 14px auto 1fr 200px 120px auto;
   gap: 12px;
   align-items: center;
   padding: 6px 8px;
   background: var(--bg-soft);
   border: 1px solid var(--border);
   border-radius: 4px;
+}
+/* Status pill + the optional `interactive` pill live in a single grid cell
+ * so the agent name stays in the 1fr column directly after the badges. */
+.row-badges {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
 }
 .tree-caret {
   background: transparent;


### PR DESCRIPTION
## Why
In the runs list, the agent name (and run id) were shoved far to the right with a large gap after the status badges — only on **interactive** runs. (Reported with a screenshot of a CANCELLED + `interactive` run where `analyst` sat at the right edge.)

## Root cause
The run-row is a CSS grid templated for exactly four items — `caret | status | name(1fr) | time`:

```css
.agents-view .node .row { grid-template-columns: 14px auto 1fr 80px; }
```

An interactive run renders a **second** pill (`interactive`) as its own grid item, so it took the `1fr` (name) track and every later item shifted one column right — pushing the agent-link past the slack. The base `.node .row` grid (used by the orchestrator tree) had the same flaw.

## Fix
- Wrap the status pill + the optional `interactive` pill in a single `.row-badges` flex cell, so they share one grid track and the agent name stays in the `1fr` column **directly after the badges**.
- Widen the base `.node .row` badge column from a fixed `80px` to `auto` so the grouped badges fit (the `.agents-view` grid was already `auto`).

Two files: `web/src/components/AgentsTree.tsx` (JSX wrapper) + `web/src/styles.css` (grid + `.row-badges`). Non-interactive rows are unchanged (single badge in the same cell). Affects both the agents-view panel and the orchestrator tree, since both render `AgentsTree`.

## Tested
- `make build-ui` builds clean.
- `git status` shows only `web/src` changes — `internal/webui/dist/*` stays gitignored and is rebuilt by CI/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)