### PR TITLE
feat: chat + chat-local bundle, and a num_gpu knob for ollama-local

### DIFF
--- a/bundles/chat/README.md
+++ b/bundles/chat/README.md
@@ -1,0 +1,56 @@
+# chat bundle
+
+Two general-purpose **conversational agents** for direct chatting in the
+loomcycle interactive `/run` terminal:
+
+| Agent | Routing | Use it for |
+|---|---|---|
+| **`chat`** | `tier: middle` | Everyday chat that routes per your `provider_priority` (cloud-capable, falls back across providers). |
+| **`chat-local`** | pinned `model: local-medium` → **ollama-local** | Private / offline chat that runs entirely on your local model and never leaves the box. |
+
+This is a **first-class, reusable bundle** — not an `examples/` experiment.
+
+```
+bundles/chat/
+├── loomcycle.yaml   # the chat + chat-local agents (identical to the embedded copy)
+└── README.md
+```
+
+The binary ships an **embedded** copy at
+[`cmd/loomcycle/embedded/bundles/chat.yaml`](../../cmd/loomcycle/embedded/bundles/chat.yaml)
+(`go:embed`). `bundles/chat/loomcycle.yaml` is the in-repo source mirror — keep the
+two identical (`chat` has no split-out skills, so they are byte-for-byte the same).
+
+## Enable
+
+```sh
+# the bundle carries no provider matrix — pair it with `base`
+LOOMCYCLE_PRESETS=base,chat
+```
+
+then start an interactive run with `chat` or `chat-local` from the `/run` terminal.
+
+## Toolset
+
+Both agents get: `Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox,
+Bash, Document, Memory, Path, Skill` (plus `Context`, auto-added).
+
+### Requirements
+
+- **A read-write volume.** The agents declare no `volumes:`, so they use the
+  operator's **default** volume — define one with `default: true, mode: rw` (or
+  bind one per agent in your overlay). Without it, the file/shell tools are
+  registered-but-idle.
+- **`LOOMCYCLE_SQLMEM_ENABLED=1`** — Document (and SQL-backed Memory) need it.
+- **`BRAVE_API_KEY`** + **`LOOMCYCLE_HTTP_HOST_ALLOWLIST`** — for WebSearch/WebFetch.
+- **`LOOMCYCLE_BASHBOX_ENABLED=1`** (and `LOOMCYCLE_BASH_ENABLED=1` for raw Bash).
+- **`chat-local` context window** is the GLOBAL `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX`
+  env (e.g. `131072` for 128K) — it is not a per-agent yaml field. To force GPU
+  offload on a box where Ollama falls back to CPU, set
+  `LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU=99`.
+
+## Overriding
+
+The operator overlay can re-declare any field (last layer wins per field) — swap
+the tier, change the model, adjust sampling, narrow `allowed_tools`. It cannot
+**widen** `allowed_tools` beyond what the bundle grants.

--- a/bundles/chat/loomcycle.yaml
+++ b/bundles/chat/loomcycle.yaml
@@ -1,0 +1,101 @@
+# embedded bundle: chat
+# Two general-purpose conversational agents for direct chatting in the
+# interactive /run terminal:
+#   chat        — tier:middle (routes per your provider_priority; cloud-capable)
+#   chat-local  — pinned to the local middle model (ollama-local); never leaves the box
+#
+# Selected via `LOOMCYCLE_PRESETS=…,chat`. This bundle carries NO provider matrix:
+# `chat` needs a `middle` tier and `chat-local` needs the `local-medium` alias from
+# another layer — select `base` alongside it (or supply your own).
+#
+# Requirements for the full toolset:
+#   - File/shell tools (Read/Write/Edit/Grep/Glob/Bash/Bashbox) need a read-write
+#     volume. These agents declare no `volumes:`, so they use the operator's
+#     DEFAULT volume — define a `volumes:` entry with `default: true, mode: rw`
+#     (or bind one per agent in your overlay). Without it, those tools are
+#     registered-but-idle.
+#   - Document + Memory need LOOMCYCLE_SQLMEM_ENABLED=1 (Document is SQL-backed).
+#   - WebSearch needs BRAVE_API_KEY; WebFetch/WebSearch need LOOMCYCLE_HTTP_HOST_ALLOWLIST.
+#   - Bashbox needs LOOMCYCLE_BASHBOX_ENABLED=1; Bash needs LOOMCYCLE_BASH_ENABLED=1.
+#   - chat-local's large context window is the GLOBAL LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX
+#     env (e.g. 131072 for 128K) — it can't be set per-agent in yaml.
+#
+# The operator overlay can override any field by re-declaring the key (last layer
+# wins per field). It cannot WIDEN allowed_tools (the AgentDef ceiling is unchanged).
+
+agents:
+  chat:
+    tier: middle
+    effort: medium
+    # max_tokens intentionally OMITTED — each provider applies its own default
+    # (Anthropic defaults to 8192; ollama generates until the context fills).
+    # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
+    unbounded_iterations: true              # interactive chat parks at end_turn
+    allowed_tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill]
+    memory_scopes: [user]
+    sql_scopes: [user]                      # Document is SQL-Memory-backed
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are CHAT, a helpful, direct general-purpose assistant for an operator
+      working in the loomcycle terminal. Hold a natural multi-turn conversation:
+      answer questions, reason through problems, and reach for your tools when
+      they make the answer better or are needed to act.
+
+      ## Tools
+      - Web: use WebSearch to find current information and WebFetch to read a
+        specific URL. Search when the answer depends on recent or external facts
+        rather than guessing.
+      - Files: Read / Write / Edit / Grep / Glob operate inside your bound working
+        volume. Grep/Glob to locate things first, Read to inspect, Edit for
+        in-place changes.
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        a few host commands (git, gh, curl, jq, rsync) are available through its
+        fallback. Bash is the unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path: use Document for structured chunked documents,
+        Memory to remember durable facts across turns (user scope), and Path to
+        navigate the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous instead of
+        guessing.
+      - When you act with a tool, briefly say what you did and what you found.
+
+  chat-local:
+    model: local-medium                     # → ollama-local; local-only, no cloud fallback
+    effort: medium
+    # max_tokens OMITTED — ollama-local generates until the context window fills
+    # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
+    unbounded_iterations: true
+    allowed_tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
+      you run entirely on the operator's LOCAL model (ollama-local) — nothing you
+      process leaves the box. Favor this for private or offline work.
+
+      ## Tools
+      - Web: WebSearch for current information, WebFetch to read a specific URL.
+      - Files: Read / Write / Edit / Grep / Glob inside your bound working volume
+        (Grep/Glob to find, Read to inspect, Edit for in-place changes).
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        git, gh, curl, jq, rsync are available via its fallback. Bash is the
+        unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path for structured documents, durable user-scope
+        memory, and the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous.
+      - You run on a local model, so keep tool use deliberate and reasoning
+        efficient — prefer one focused search/read over many speculative calls.

--- a/cmd/loomcycle/embedded/bundles/chat.yaml
+++ b/cmd/loomcycle/embedded/bundles/chat.yaml
@@ -1,0 +1,101 @@
+# embedded bundle: chat
+# Two general-purpose conversational agents for direct chatting in the
+# interactive /run terminal:
+#   chat        — tier:middle (routes per your provider_priority; cloud-capable)
+#   chat-local  — pinned to the local middle model (ollama-local); never leaves the box
+#
+# Selected via `LOOMCYCLE_PRESETS=…,chat`. This bundle carries NO provider matrix:
+# `chat` needs a `middle` tier and `chat-local` needs the `local-medium` alias from
+# another layer — select `base` alongside it (or supply your own).
+#
+# Requirements for the full toolset:
+#   - File/shell tools (Read/Write/Edit/Grep/Glob/Bash/Bashbox) need a read-write
+#     volume. These agents declare no `volumes:`, so they use the operator's
+#     DEFAULT volume — define a `volumes:` entry with `default: true, mode: rw`
+#     (or bind one per agent in your overlay). Without it, those tools are
+#     registered-but-idle.
+#   - Document + Memory need LOOMCYCLE_SQLMEM_ENABLED=1 (Document is SQL-backed).
+#   - WebSearch needs BRAVE_API_KEY; WebFetch/WebSearch need LOOMCYCLE_HTTP_HOST_ALLOWLIST.
+#   - Bashbox needs LOOMCYCLE_BASHBOX_ENABLED=1; Bash needs LOOMCYCLE_BASH_ENABLED=1.
+#   - chat-local's large context window is the GLOBAL LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX
+#     env (e.g. 131072 for 128K) — it can't be set per-agent in yaml.
+#
+# The operator overlay can override any field by re-declaring the key (last layer
+# wins per field). It cannot WIDEN allowed_tools (the AgentDef ceiling is unchanged).
+
+agents:
+  chat:
+    tier: middle
+    effort: medium
+    # max_tokens intentionally OMITTED — each provider applies its own default
+    # (Anthropic defaults to 8192; ollama generates until the context fills).
+    # Pinning a value would only IMPOSE a per-reply cap, not add headroom.
+    unbounded_iterations: true              # interactive chat parks at end_turn
+    allowed_tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill]
+    memory_scopes: [user]
+    sql_scopes: [user]                      # Document is SQL-Memory-backed
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are CHAT, a helpful, direct general-purpose assistant for an operator
+      working in the loomcycle terminal. Hold a natural multi-turn conversation:
+      answer questions, reason through problems, and reach for your tools when
+      they make the answer better or are needed to act.
+
+      ## Tools
+      - Web: use WebSearch to find current information and WebFetch to read a
+        specific URL. Search when the answer depends on recent or external facts
+        rather than guessing.
+      - Files: Read / Write / Edit / Grep / Glob operate inside your bound working
+        volume. Grep/Glob to locate things first, Read to inspect, Edit for
+        in-place changes.
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        a few host commands (git, gh, curl, jq, rsync) are available through its
+        fallback. Bash is the unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path: use Document for structured chunked documents,
+        Memory to remember durable facts across turns (user scope), and Path to
+        navigate the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous instead of
+        guessing.
+      - When you act with a tool, briefly say what you did and what you found.
+
+  chat-local:
+    model: local-medium                     # → ollama-local; local-only, no cloud fallback
+    effort: medium
+    # max_tokens OMITTED — ollama-local generates until the context window fills
+    # (set the window via LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX, e.g. 131072 for 128K).
+    unbounded_iterations: true
+    allowed_tools: [Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill]
+    memory_scopes: [user]
+    sql_scopes: [user]
+    sampling:
+      temperature: 0.7
+    compaction:
+      enabled: true
+      autocompact_at_pct: 80
+    system_prompt: |
+      You are CHAT-LOCAL, the same helpful general-purpose assistant as CHAT, but
+      you run entirely on the operator's LOCAL model (ollama-local) — nothing you
+      process leaves the box. Favor this for private or offline work.
+
+      ## Tools
+      - Web: WebSearch for current information, WebFetch to read a specific URL.
+      - Files: Read / Write / Edit / Grep / Glob inside your bound working volume
+        (Grep/Glob to find, Read to inspect, Edit for in-place changes).
+      - Shell: Bashbox is a sandboxed shell (rooted at your volume, no network);
+        git, gh, curl, jq, rsync are available via its fallback. Bash is the
+        unsandboxed escape hatch — prefer Bashbox.
+      - Document / Memory / Path for structured documents, durable user-scope
+        memory, and the virtual filesystem.
+
+      ## Style
+      - Be concise and concrete; lead with the answer, then the reasoning.
+      - Ask a clarifying question when the request is ambiguous.
+      - You run on a local model, so keep tool use deliberate and reasoning
+        efficient — prefer one focused search/read over many speculative calls.

--- a/cmd/loomcycle/embedded/env.insecure.example
+++ b/cmd/loomcycle/embedded/env.insecure.example
@@ -28,6 +28,12 @@ OLLAMA_BASE_URL=http://localhost:11434
 # used size (the per-model window isn't knowable from the driver).
 # LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=32768
 # LOOMCYCLE_OLLAMA_NUM_CTX=32768            # hosted ollama.com counterpart
+#
+# num_gpu forces how many model layers Ollama offloads to the GPU on every
+# ollama-local request. Leave unset to let Ollama auto-detect; set it (99 =
+# "all layers") when Ollama otherwise runs on CPU — common on integrated/APU
+# GPUs whose VRAM auto-detection is conservative. Global to ollama-local.
+# LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU=99
 
 # ─── Sidecar listen ───────────────────────────────────────────────────
 # (The bearer token /v1 routes require is a secret — set LOOMCYCLE_AUTH_TOKEN

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2680,7 +2680,8 @@ func newProviderResolver(cfg *config.Config) *providerResolver {
 			IdleTimeout:   cfg.Env.OllamaLocalIdleTimeout,
 		}
 		pr.ollamaLocal = ollama.New("ollama-local", "", cfg.Env.OllamaBaseURL, localStreamOpts, nil).
-			WithNumCtx(cfg.Env.OllamaLocalNumCtx)
+			WithNumCtx(cfg.Env.OllamaLocalNumCtx).
+			WithNumGpu(cfg.Env.OllamaLocalNumGpu)
 	}
 	// DeepSeek opts in via DEEPSEEK_API_KEY. Optional DEEPSEEK_BASE_URL
 	// overrides the public endpoint for self-hosted OpenAI-compatible

--- a/deploy/truenas/catalog/questions.yaml
+++ b/deploy/truenas/catalog/questions.yaml
@@ -46,6 +46,8 @@ questions:
                 description: local — Ollama-local on top (needs base)
               - value: document-agent
                 description: document-agent — the Document Assistant (needs SQL Memory)
+              - value: chat
+                description: chat — general chat agents (chat + chat-local; needs base)
 
   # ── Secrets (private: UI-masked; written to container env, never a yaml layer) ─
   - variable: auth_token
@@ -366,6 +368,12 @@ questions:
           - variable: LOOMCYCLE_OLLAMA_NUM_CTX
             label: LOOMCYCLE_OLLAMA_NUM_CTX
             description: '(example: 32768)'
+            schema:
+              type: string
+              default: ""
+          - variable: LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU
+            label: LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU
+            description: 'num_gpu forces how many model layers Ollama offloads to the GPU on every ollama-local request. Leave unset to let Ollama auto-detect; set it (99 = "all layers") when Ollama otherwise runs on CPU — common on integrated/APU GPUs whose VRAM auto-detection is conservative. Global to ollama-local. (example: 99)'
             schema:
               type: string
               default: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1888,6 +1888,15 @@ type Env struct {
 	// what runs on a local box, so the right value almost certainly
 	// differs too.
 	OllamaNumCtx int
+	// OllamaLocalNumGpu sets options.num_gpu on every chat request the
+	// `ollama-local` driver sends — the number of model layers Ollama
+	// offloads to the GPU. Default 0 = omit (Ollama auto-detects). Set
+	// it (e.g. 99 = "all layers") to force GPU offload on a box where
+	// Ollama otherwise falls back to CPU — common on integrated/APU
+	// GPUs that auto-detection underestimates. Global to ollama-local,
+	// like num_ctx: num_gpu is a model-LOAD parameter, not a per-request
+	// knob. Env: LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU.
+	OllamaLocalNumGpu int
 	// DeepSeekAPIKey enables the `provider: deepseek` driver. Empty
 	// = provider not registered (agents that ask for it fail at
 	// resolve time, mirroring OpenAI / Anthropic behaviour).
@@ -2950,6 +2959,15 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_OLLAMA_NUM_CTX"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.OllamaNumCtx = n
+		}
+	}
+	// LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU forces the number of model layers
+	// Ollama offloads to the GPU on every ollama-local request — see the
+	// field doc on Env.OllamaLocalNumGpu. 0/unset = omit (Ollama
+	// auto-detects); a literal 0 must NOT be sent (it would force CPU).
+	if v := os.Getenv("LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.OllamaLocalNumGpu = n
 		}
 	}
 	// LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS overrides the default 15-min

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -52,6 +52,7 @@ type Driver struct {
 	http        *http.Client
 	idleTimeout time.Duration
 	numCtx      int // 0 = omit (Ollama server default applies)
+	numGpu      int // 0 = omit (Ollama auto-detects GPU layers); >0 forces offload
 	// ctxCache memoises each model's loaded context window read from
 	// /api/ps (model name → ctxCacheEntry), so the gauge lookup costs one
 	// cheap request per model, not per turn. Concurrent-safe (the Driver is
@@ -115,6 +116,28 @@ func New(providerID, apiKey, baseURL string, streamOpts streamhttp.Options, http
 func (d *Driver) WithNumCtx(n int) *Driver {
 	if n > 0 {
 		d.numCtx = n
+	}
+	return d
+}
+
+// WithNumGpu sets the Ollama options.num_gpu that the driver includes on
+// every chat request — the number of model layers offloaded to the GPU.
+// Returns the same Driver for chaining at registration time:
+//
+//	pr.ollamaLocal = ollama.New(...).WithNumGpu(99)
+//
+// Default 0 = don't set, letting Ollama auto-detect how many layers fit on
+// the GPU. The knob exists because that auto-detection underestimates VRAM
+// on some setups (notably integrated/APU GPUs), silently running inference
+// on the CPU. Forcing a high value (99 = "all layers") makes Ollama offload
+// the whole model; Ollama clamps to the model's actual layer count, so an
+// over-large value is safe. A literal 0 must NOT be sent — that would force
+// CPU-only — which is why both this setter and the omitempty tag guard it.
+//
+// Not safe to call concurrently with Call(); intended for registration.
+func (d *Driver) WithNumGpu(n int) *Driver {
+	if n > 0 {
+		d.numGpu = n
 	}
 	return d
 }
@@ -325,6 +348,7 @@ type wireOptions struct {
 	Temperature *float64 `json:"temperature,omitempty"`
 	NumPredict  int      `json:"num_predict,omitempty"` // Ollama's name for max_tokens
 	NumCtx      int      `json:"num_ctx,omitempty"`     // input-window size; 0 = Ollama server default
+	NumGpu      int      `json:"num_gpu,omitempty"`     // GPU layers to offload; 0 = omit (a literal 0 forces CPU)
 	// Ollama options sampling knobs. frequency/presence_penalty exist on some
 	// models but vary; we plumb the broadly-supported set.
 	TopP *float64 `json:"top_p,omitempty"`
@@ -365,12 +389,13 @@ func (d *Driver) buildRequestBody(req providers.Request) ([]byte, error) {
 		Stream: true,
 	}
 
-	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 ||
+	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 || d.numGpu > 0 ||
 		req.TopP != nil || req.TopK != nil || req.Seed != nil || len(req.Stop) > 0 {
 		w.Options = &wireOptions{
 			Temperature: req.Temperature,
 			NumPredict:  req.MaxTokens,
 			NumCtx:      d.numCtx,
+			NumGpu:      d.numGpu,
 			TopP:        req.TopP,
 			TopK:        req.TopK,
 			Seed:        req.Seed,

--- a/internal/providers/ollama/driver_test.go
+++ b/internal/providers/ollama/driver_test.go
@@ -308,6 +308,75 @@ func TestRequestBody_NumCtxPropagated(t *testing.T) {
 	}
 }
 
+// TestRequestBody_NumGpuOmittedByDefault pins that no num_gpu field is sent
+// when the driver was built without WithNumGpu. The omitempty tag is
+// load-bearing: a literal "num_gpu":0 would force Ollama to run CPU-only.
+func TestRequestBody_NumGpuOmittedByDefault(t *testing.T) {
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "llama3.1",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	if strings.Contains(string(captured), `"num_gpu"`) {
+		t.Errorf("num_gpu appeared in body without WithNumGpu; body:\n%s", string(captured))
+	}
+}
+
+// TestRequestBody_NumGpuPropagated pins the headline path: after
+// WithNumGpu(99), every chat request carries options.num_gpu=99 — the
+// knob that forces GPU offload on boxes (e.g. APUs) where Ollama's
+// auto-detection otherwise falls back to CPU.
+func TestRequestBody_NumGpuPropagated(t *testing.T) {
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprint(w, `{"model":"x","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil).WithNumGpu(99)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3.6:27b",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	if !strings.Contains(string(captured), `"num_gpu":99`) {
+		t.Errorf("num_gpu=99 missing from body; body:\n%s", string(captured))
+	}
+	// A bare WithNumGpu must not leak unrelated options (omitempty).
+	if strings.Contains(string(captured), `"temperature"`) || strings.Contains(string(captured), `"num_predict"`) {
+		t.Errorf("WithNumGpu leaked unrelated options fields; body:\n%s", string(captured))
+	}
+}
+
 // TestRequestBody_NumCtxCombinesWithTemperatureAndMaxTokens: when the
 // caller passes Temperature + MaxTokens AND the driver was configured
 // with WithNumCtx, all three end up in the single options object. Pins


### PR DESCRIPTION
## Why
Two needs from running loomcycle on a TrueNAS box:
1. **Ready-to-use chat agents** for the interactive `/run` terminal — one cloud-capable, one local-only.
2. **Force GPU offload** for `ollama-local`: on a Ryzen-APU box, Ollama's auto-detection underestimates VRAM and silently runs on the CPU. loomcycle had no way to set `num_gpu`.

## What

### `num_gpu` knob (runtime)
New global env **`LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU`**, mirroring the existing `NUM_CTX` plumbing exactly: `Env.OllamaLocalNumGpu` → `Driver.WithNumGpu(n)` → `wireOptions.num_gpu` on every `ollama-local` request. `num_gpu` is a model-**load** parameter (not per-request), so it's global to the driver — same scope as `num_ctx`. `omitempty` + an `n>0` guard are load-bearing (a literal `"num_gpu":0` would force CPU-only). Wired on the ollama-local constructor only (meaningless for hosted ollama.com).

### `chat` bundle
Embedded bundle (`LOOMCYCLE_PRESETS=base,chat`), shipped like `document-agent`:
| Agent | Routing |
|---|---|
| `chat` | `tier: middle` — routes per `provider_priority`, cloud-capable |
| `chat-local` | `model: local-medium` — pinned `ollama-local`, local-only |

Both grant: `Read, Write, Edit, Grep, Glob, WebSearch, WebFetch, Bashbox, Bash, Document, Memory, Path, Skill` (+ `Context`). `max_tokens` is **omitted** so each provider uses its own default rather than an imposed per-reply cap; compaction on; `unbounded_iterations` for interactive use. No provider matrix (needs `base`), no hardcoded `volumes:` (uses the operator's default volume). Embedded copy is authoritative; `bundles/chat/` mirrors it + README.

### Docs / deployment
`LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU` added to the embedded `.env.insecure.example` (so `env-template` + the generated TrueNAS questions advertise it); `chat` added to the catalog `questions.yaml` presets enum + the `num_gpu` env option.

## Tested
- `go test ./internal/providers/ollama/...` — new num_gpu tests pass; `go test ./...` clean **except** the pre-existing `TestLoadExample` (`/work/sandbox` must exist on disk — env-specific, fails identically on `main`, unrelated to this change).
- `make build` → `loomcycle presets` lists `chat`; clean boot with `LOOMCYCLE_PRESETS=base,chat` registers both agents (confirmed via `GET /v1/_library/agents`) with no load errors (invalid `allowed_tools` would be fatal at load, so the tool names are validated).
- Driver unit test asserts `"num_gpu":99` reaches the wire body and no unrelated options leak.

## Deploy (the user's live box, via Apps → loomcycle → Edit)
- `LOOMCYCLE_PRESETS: "base,document-agent,chat"`
- `LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU: "99"`, `LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX: "131072"` (128K)

Distinct from the open PRs #570 (TrueNAS docs) and #571 (Web UI run-row). INSTALL.md intentionally not touched here to avoid clashing with #570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)