### PR TITLE
fix(webui): don't let the UI mint substrate:admin tokens (lockout footgun)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2180,9 +2180,15 @@ export function retireOperatorToken(
 }
 
 // The RFC L closed scope catalog — the token-mint form's scope choices.
+// Scopes the Web UI is allowed to MINT. `substrate:admin` is deliberately
+// EXCLUDED: minting a global admin token trips the runtime's no-lockout
+// migration gate (legacyFallbackDisabled), which disables the
+// LOOMCYCLE_AUTH_TOKEN login — and the UI mint loses the show-once secret in
+// the resulting logout, locking the operator out entirely. Admin tokens must
+// be created from the CLI (`loomcycle operator-token create --scopes
+// substrate:admin …`), which prints the new token so access is never lost.
 export const TOKEN_SCOPES = [
   "substrate:tenant",
-  "substrate:admin",
   "runs:create",
   "runs:read",
   "channel:publish",

--- a/web/src/components/TokenManager.tsx
+++ b/web/src/components/TokenManager.tsx
@@ -144,9 +144,17 @@ export default function TokenManager() {
         Mint per-principal bearer tokens (RFC L). Each binds an authoritative{" "}
         <code>tenant</code> + <code>subject</code> + scopes. A{" "}
         <code>substrate:tenant</code> token gives a downstream service full power
-        within its own tenant; <code>substrate:admin</code> is full operator
-        power. The secret is shown <strong>once</strong> and never retrievable
-        again.
+        within its own tenant. The secret is shown <strong>once</strong> and
+        never retrievable again.
+      </p>
+      <p className="settings-help">
+        <strong>Admin tokens are CLI-only.</strong> The UI cannot mint a{" "}
+        <code>substrate:admin</code> token on purpose: doing so disables the{" "}
+        <code>LOOMCYCLE_AUTH_TOKEN</code> login (the no-lockout migration gate)
+        and the show-once secret is lost in the logout — a guaranteed lockout.
+        Create admin tokens from the CLI, which prints the new token so you keep
+        access: <code>loomcycle operator-token create --tenant default --scopes
+        substrate:admin --name &lt;name&gt;</code>.
       </p>
 
       {minted && (


### PR DESCRIPTION
## Why
Minting a `substrate:admin` operator token in the Web UI **locks the operator out**. The runtime's no-lockout migration gate (`legacyFallbackDisabled`, `internal/api/http/auth_principal.go:244-269`) disables the `LOOMCYCLE_AUTH_TOKEN` login as soon as the first active admin-scoped token exists. In the UI flow that's lethal:
1. minting the admin token trips the gate → the legacy login is disabled;
2. the operator's current (legacy-token) session is invalidated → immediate logout;
3. the show-once secret is lost in the logout → **no working credential left.**

Hit live on the JobEmber VPS this week — required a direct DB retire of the admin token to recover.

## What
- **`web/src/api.ts`** — remove `substrate:admin` from `TOKEN_SCOPES` (the UI-mintable list). The mint form's scope checkboxes are generated from it, so the UI can now only mint `substrate:tenant` (and lesser) tokens.
- **`web/src/components/TokenManager.tsx`** — updated copy: a clear "**Admin tokens are CLI-only**" note explaining the lockout and pointing to `loomcycle operator-token create --tenant default --scopes substrate:admin --name <name>` (the CLI prints the new token, so access is never lost).

## Why UI-only (not an API block)
The CLI `operator-token create` mints through the **same** HTTP endpoint, so rejecting `substrate:admin` server-side would also break the CLI. The correct boundary is the UI form; the API still accepts `substrate:admin` for the CLI path.

## Tested
- `make build-ui` builds clean.
- `git status` shows only `web/src` changes — `internal/webui/dist/*` stays gitignored (CI/release rebuild).

## Follow-ups worth considering (not in this PR)
- The CLI `operator-token create --help` prints the `$LOOMCYCLE_AUTH_TOKEN` **value** as the `-token` flag default (cleartext secret leak) — should show `$LOOMCYCLE_AUTH_TOKEN` literally.
- Optionally, a runtime guard: refuse to mint an admin-scoped token when the requester is authed via the legacy fallback unless a `--force`/confirm is passed (protects the CLI legacy-authed path too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)