### PR TITLE
feat(authz): tenant-scope the Library list endpoints (RFC AS Phase 1)

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -69,6 +69,13 @@ func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request)
 	// Substrate side — keyed by name for the merge below. Nil-safe:
 	// when store is unset (tests), the substrate map stays empty and
 	// only static cfg entries surface.
+	// RFC AS: tenant-scope the listing by the authenticated principal. Admin /
+	// legacy / open see all (with the optional ?tenant= focus); a
+	// substrate:tenant principal sees ONLY its tenant's substrate rows. The
+	// list store methods are tenant-blind, so this filter is the gate that
+	// closes the cross-tenant name leak.
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
 	subRows := map[string]store.AgentDefNameSummary{}
 	if s.store != nil {
 		rows, err := s.store.AgentDefListNames(r.Context())
@@ -77,6 +84,9 @@ func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		for _, row := range rows {
+			if !all && row.TenantID != tenantID {
+				continue
+			}
 			subRows[row.Name] = row
 		}
 	}
@@ -84,7 +94,13 @@ func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request)
 	entries := make([]LibraryEntry, 0, len(s.cfg.Agents)+len(subRows))
 	seen := map[string]struct{}{}
 
+	// Operator-global static cfg agents belong to the shared operator scope —
+	// surfaced only in the all-tenants (admin/open) view, never to a
+	// tenant-scoped principal (RFC AS §2.2).
 	for name, def := range s.cfg.Agents {
+		if !all {
+			continue
+		}
 		entry := LibraryEntry{
 			Name:             name,
 			InStatic:         true,
@@ -125,6 +141,8 @@ func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request)
 
 // handleListLibrarySkills serves GET /v1/_library/skills.
 func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request) {
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
 	subRows := map[string]store.SkillDefNameSummary{}
 	if s.store != nil {
 		rows, err := s.store.SkillDefListNames(r.Context())
@@ -133,6 +151,9 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 			return
 		}
 		for _, row := range rows {
+			if !all && row.TenantID != tenantID {
+				continue
+			}
 			subRows[row.Name] = row
 		}
 	}
@@ -141,7 +162,11 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 	entries := make([]LibraryEntry, 0, len(staticNames)+len(subRows))
 	seen := map[string]struct{}{}
 
+	// Operator-global static skills — admin/open view only (RFC AS §2.2).
 	for _, name := range staticNames {
+		if !all {
+			continue
+		}
 		sk, _ := s.skillSet.Get(name)
 		entry := LibraryEntry{
 			Name:             name,
@@ -185,6 +210,8 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 // the entry omits `discovered_tools` — the operator can re-check
 // after the pool finishes init.
 func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Request) {
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
 	subRows := map[string]store.MCPServerDefNameSummary{}
 	if s.store != nil {
 		rows, err := s.store.MCPServerDefListNames(r.Context())
@@ -193,6 +220,9 @@ func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Requ
 			return
 		}
 		for _, row := range rows {
+			if !all && row.TenantID != tenantID {
+				continue
+			}
 			subRows[row.Name] = row
 		}
 	}
@@ -200,7 +230,11 @@ func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Requ
 	entries := make([]LibraryEntry, 0, len(s.cfg.MCPServers)+len(subRows))
 	seen := map[string]struct{}{}
 
+	// Operator-global static MCP servers — admin/open view only (RFC AS §2.2).
 	for name, srv := range s.cfg.MCPServers {
+		if !all {
+			continue
+		}
 		var discoveredTools json.RawMessage
 		if s.mcpPoolInspector != nil {
 			discoveredTools = s.mcpPoolInspector(name)

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -356,5 +357,106 @@ func TestUnifiedLibrary_OldEndpoints_StillWork(t *testing.T) {
 	}
 	if len(resp.Names) != 1 || resp.Names[0].Name != "x" {
 		t.Errorf("old endpoint shape changed: %+v", resp.Names)
+	}
+}
+
+// callLibraryAgents invokes the handler directly with an injected principal
+// (bypassing authMiddleware, which would re-resolve from the bearer) so each
+// case exercises a specific principal's tenant scope.
+func callLibraryAgents(t *testing.T, srv *Server, p auth.Principal) []string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v1/_library/agents", nil)
+	req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+	srv.handleListLibraryAgents(rec, req)
+	es := decodeLibraryEntries(t, rec)
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.Name
+	}
+	return out
+}
+
+// TestUnifiedLibrary_Agents_TenantIsolation (RFC AS Phase 1) pins that the
+// library listing is tenant-scoped: a substrate:tenant principal sees ONLY its
+// own tenant's substrate agents — not other tenants', not the operator-global
+// static cfg agents — while a substrate:admin principal sees all. Fail-before:
+// the pre-RFC-AS handler called the tenant-blind AgentDefListNames and merged
+// cfg.Agents unconditionally, so any authenticated principal could enumerate
+// every tenant's agent names.
+func TestUnifiedLibrary_Agents_TenantIsolation(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"global-static": {Model: "x", SystemPrompt: "operator-global"},
+	}, nil)
+	defer cleanup()
+
+	ctx := t.Context()
+	mustDef := func(defID, name, tenant string) {
+		if _, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+			DefID: defID, Name: name, Version: 1, TenantID: tenant,
+			Definition: []byte(`{}`), CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatalf("AgentDefCreate(%s): %v", name, err)
+		}
+		if err := s.AgentDefSetActive(ctx, tenant, name, defID, ""); err != nil {
+			t.Fatalf("AgentDefSetActive(%s): %v", name, err)
+		}
+	}
+	mustDef("def_acme", "acme-agent", "acme")
+	mustDef("def_globex", "globex-agent", "globex")
+
+	// A substrate:tenant principal sees only its own tenant — no cross-tenant
+	// rows, no operator-global static.
+	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "acme", Subject: "acme-op", Scopes: []string{auth.ScopeTenant}}); len(got) != 1 || got[0] != "acme-agent" {
+		t.Fatalf("acme tenant sees %v, want [acme-agent] only", got)
+	}
+	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "globex", Subject: "globex-op", Scopes: []string{auth.ScopeTenant}}); len(got) != 1 || got[0] != "globex-agent" {
+		t.Fatalf("globex tenant sees %v, want [globex-agent] only", got)
+	}
+
+	// A substrate:admin principal sees everything: both tenants' substrate rows
+	// plus the operator-global static agent.
+	got := callLibraryAgents(t, srv, auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}})
+	if len(got) != 3 {
+		t.Fatalf("admin sees %v, want all 3 (acme-agent, globex-agent, global-static)", got)
+	}
+}
+
+// TestUnifiedLibrary_Agents_AdminTenantFocus (RFC AS Phase 1) pins the admin
+// ?tenant= focus: a substrate:admin with ?tenant=acme sees only acme's
+// substrate rows (acting as a view of that tenant), and the operator-global
+// static agent is excluded from a focused view.
+func TestUnifiedLibrary_Agents_AdminTenantFocus(t *testing.T) {
+	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
+		"global-static": {Model: "x"},
+	}, nil)
+	defer cleanup()
+	ctx := t.Context()
+	for _, d := range []struct{ id, name, tenant string }{
+		{"def_acme", "acme-agent", "acme"},
+		{"def_globex", "globex-agent", "globex"},
+	} {
+		if _, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+			DefID: d.id, Name: d.name, Version: 1, TenantID: d.tenant,
+			Definition: []byte(`{}`), CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+		_ = s.AgentDefSetActive(ctx, d.tenant, d.name, d.id, "")
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v1/_library/agents?tenant=acme", nil)
+	req = req.WithContext(auth.WithPrincipal(req.Context(), auth.Principal{
+		TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin},
+	}))
+	srv.handleListLibraryAgents(rec, req)
+	es := decodeLibraryEntries(t, rec)
+	if len(es) != 1 || es[0].Name != "acme-agent" {
+		names := make([]string, len(es))
+		for i, e := range es {
+			names[i] = e.Name
+		}
+		t.Fatalf("admin ?tenant=acme sees %v, want [acme-agent] only", names)
 	}
 }


### PR DESCRIPTION
Implements the **"Library first"** slice of **RFC AS Phase 1** — tenant-scoping the management read endpoints + closing the latent cross-tenant leak.

## Problem
`GET /v1/_library/{agents,skills,mcp-servers}` called the **tenant-blind** `*DefListNames` store methods (which return *every* tenant's rows) and merged the **operator-global static cfg** defs unconditionally. The route is auth-only (no scope gate), so **any authenticated principal — including a `substrate:tenant` token — could enumerate every tenant's def names + version metadata.** It's also what made the WebUI Library un-showable to tenant operators (it would leak other tenants' defs).

## Fix
Scope each list by the authenticated principal via the existing `principalTenantScope(ctx, ?tenant)` helper:
- **admin / legacy / open** → see all, honoring the `?tenant=` focus;
- **`substrate:tenant`** → only its own tenant's substrate rows;
- **operator-global static cfg defs** are excluded from a tenant-scoped view (RFC AS §2.2 — they belong to the shared operator scope).

Minimal change in the 3 handlers (`library_unified.go`): filter substrate rows by `(tenant, all)` and gate the static merge on `all`.

## Already in place (no change needed)
- Per-def **detail/get** reads are already tenant-guarded (`execGet` → `defCallerIsAdmin`).
- **`/v1/_me`** already returns the principal's `scopes` + `tenant_id` (RFC AS §3 was already implemented).

## Tests
- **`TestUnifiedLibrary_Agents_TenantIsolation`** — a `substrate:tenant` principal sees only its own tenant; admin sees all three. Fail-before: pre-fix the tenant principal saw all 3 (the leak).
- **`TestUnifiedLibrary_Agents_AdminTenantFocus`** — admin `?tenant=acme` sees only acme (and not the operator-global static agent).
- All 8 existing admin-path library tests unchanged. `go test ./internal/api/http/` green; `go test ./...` clean except the pre-existing, env-dependent `TestLoadExample` (`/work/sandbox` must exist on disk — fails identically on `main`).

## Scope / follow-ups
This is the **Library** slice. The remaining RFC AS Phase 1 surfaces (schedules / channels / integrations / memory / documents / volumes / interrupts, plus the `Pool.Tools()` / `ListAgents` tenant-blind paths) are the **same `principalTenantScope` pattern** and are queued as follow-up PRs, per the RFC's "Library first" phasing. **Phase 2** (the frontend per-surface nav model) and **Phase 2.5** (admin act-as-tenant writes) remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)