### PR TITLE
feat(authz): tenant-scope the def-plane /names endpoints (RFC AS Phase 1)

### DIFF
--- a/internal/api/http/library_admin.go
+++ b/internal/api/http/library_admin.go
@@ -1,13 +1,20 @@
 // library_admin.go — v0.9.x Introspection: bearer-authed read-only
 // enumeration of every name declared in each substrate (AgentDef,
-// SkillDef, MCPServerDef). Drives the Web UI's `/ui/library` tab.
+// SkillDef, MCPServerDef, …). Drives the Web UI's `/ui/library` tab.
 //
-// These three handlers are the missing complement to the existing
+// These handlers are the missing complement to the existing
 // `POST /v1/_*` op-dispatched substrate endpoints. The op-dispatch
 // endpoints can list VERSIONS of a single name (`{op:"list", name:X}`),
 // but they cannot enumerate the set of declared names. The store
 // already exposes `*ListNames` helpers for snapshot + admin code
 // paths; these handlers wire those to bearer-authed GET endpoints.
+//
+// RFC AS Phase 1: the `*ListNames` store methods are tenant-BLIND (they
+// return every tenant's rows), so each handler scopes the result to the
+// authenticated principal via scopeNames — admin / legacy / open see all
+// (honoring the ?tenant= focus), a substrate:tenant principal sees only its
+// own tenant's rows. This closes the cross-tenant name leak (any authenticated
+// token could previously enumerate every tenant's def names).
 //
 // Read-only + bearer-authed. The same `authMiddleware` guards every
 // `/v1/_*` route — operator trust posture is identical to the
@@ -21,19 +28,38 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
 
+// scopeNames filters a tenant-blind *DefListNames result to the caller's tenant
+// scope (RFC AS Phase 1). `all` (admin / legacy / open) returns the rows
+// unchanged (never nil — adapter consumers `.length` without a null-check). A
+// substrate:tenant principal keeps only rows whose owning tenant matches;
+// tenantOf extracts that tenant from a row.
+func scopeNames[T any](rows []T, all bool, tenantID string, tenantOf func(T) string) []T {
+	if all {
+		if rows == nil {
+			return []T{}
+		}
+		return rows
+	}
+	out := make([]T, 0, len(rows))
+	for _, row := range rows {
+		if tenantOf(row) == tenantID {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
 // handleListAgentDefNames serves GET /v1/_agentdef/names.
-// Returns `{names: [AgentDefNameSummary, ...]}` ordered by name ASC.
-// Empty store returns `{names: []}` — never `null` — so adapter
-// consumers can `.length` without a null-check.
+// Returns `{names: [AgentDefNameSummary, ...]}` ordered by name ASC,
+// scoped to the caller's tenant (RFC AS Phase 1).
 func (s *Server) handleListAgentDefNames(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.store.AgentDefListNames(r.Context())
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.AgentDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.AgentDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -44,9 +70,8 @@ func (s *Server) handleListSkillDefNames(w http.ResponseWriter, r *http.Request)
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.SkillDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.SkillDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -57,9 +82,8 @@ func (s *Server) handleListMCPServerDefNames(w http.ResponseWriter, r *http.Requ
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.MCPServerDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.MCPServerDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -70,9 +94,8 @@ func (s *Server) handleListScheduleDefNames(w http.ResponseWriter, r *http.Reque
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.ScheduleDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.ScheduleDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -83,9 +106,8 @@ func (s *Server) handleListA2AServerCardDefNames(w http.ResponseWriter, r *http.
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.A2AServerCardDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.A2AServerCardDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -96,9 +118,8 @@ func (s *Server) handleListA2AAgentDefNames(w http.ResponseWriter, r *http.Reque
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.A2AAgentDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.A2AAgentDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -109,9 +130,8 @@ func (s *Server) handleListWebhookDefNames(w http.ResponseWriter, r *http.Reques
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.WebhookDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.WebhookDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
@@ -123,23 +143,23 @@ func (s *Server) handleListMemoryBackendDefNames(w http.ResponseWriter, r *http.
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.MemoryBackendDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.MemoryBackendDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 
 // handleListOperatorTokenDefNames serves GET /v1/_operatortokendef/names.
-// RFC L. Returns one summary per token name — NO secret material.
+// RFC L. Returns one summary per token name — NO secret material. Tenant-scoped
+// (RFC AS Phase 1): a substrate:tenant principal sees only its own tenant's
+// token names, never another tenant's; admin sees all.
 func (s *Server) handleListOperatorTokenDefNames(w http.ResponseWriter, r *http.Request) {
 	rows, err := s.store.OperatorTokenDefListNames(r.Context())
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "store_error", err.Error())
 		return
 	}
-	if rows == nil {
-		rows = []store.OperatorTokenDefNameSummary{}
-	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	rows = scopeNames(rows, all, tenantID, func(x store.OperatorTokenDefNameSummary) string { return x.TenantID })
 	writeJSONOK(w, map[string]any{"names": rows})
 }
 

--- a/internal/api/http/library_admin_test.go
+++ b/internal/api/http/library_admin_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/cancel"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
@@ -279,6 +280,88 @@ func TestAgentChannels_HappyPath(t *testing.T) {
 		if c.ScopeID != "alice" || string(c.Scope) != "agent" {
 			t.Errorf("channel %q has wrong scope: %+v", c.Channel, c)
 		}
+	}
+}
+
+// TestScopeNames (RFC AS Phase 1) unit-tests the shared tenant filter that
+// every /v1/_*def/names handler applies. Covers: all → passthrough (non-nil
+// even for a nil input); !all → keep only the caller's tenant; unknown tenant
+// → empty.
+func TestScopeNames(t *testing.T) {
+	type row struct{ tenant string }
+	tenantOf := func(r row) string { return r.tenant }
+	rows := []row{{"acme"}, {"globex"}, {"acme"}}
+
+	if got := scopeNames(rows, true, "", tenantOf); len(got) != 3 {
+		t.Errorf("all: got %d rows, want 3 (passthrough)", len(got))
+	}
+	if got := scopeNames[row](nil, true, "", tenantOf); got == nil || len(got) != 0 {
+		t.Errorf("all+nil: got %v, want non-nil empty", got)
+	}
+	if got := scopeNames(rows, false, "acme", tenantOf); len(got) != 2 {
+		t.Errorf("tenant=acme: got %d rows, want 2", len(got))
+	}
+	if got := scopeNames(rows, false, "nope", tenantOf); len(got) != 0 {
+		t.Errorf("tenant=nope: got %d rows, want 0", len(got))
+	}
+}
+
+// callAgentDefNames invokes the /v1/_agentdef/names handler directly with an
+// injected principal (bypassing authMiddleware, which would re-resolve from the
+// bearer), returning the def names in the response.
+func callAgentDefNames(t *testing.T, srv *Server, p auth.Principal, query string) []string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v1/_agentdef/names"+query, nil)
+	req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+	srv.handleListAgentDefNames(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Names []store.AgentDefNameSummary `json:"names"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	out := make([]string, len(resp.Names))
+	for i, n := range resp.Names {
+		out[i] = n.Name
+	}
+	return out
+}
+
+// TestLibraryAdmin_AgentDefNames_TenantIsolation (RFC AS Phase 1) pins the
+// wiring of principalTenantScope + scopeNames in a real /names handler: a
+// substrate:tenant principal sees only its own tenant; admin sees all; admin
+// ?tenant= focuses one. Fail-before: the handler returned the tenant-blind
+// AgentDefListNames result, leaking every tenant's names.
+func TestLibraryAdmin_AgentDefNames_TenantIsolation(t *testing.T) {
+	srv, s, cleanup := libraryFixture(t)
+	defer cleanup()
+	ctx := t.Context()
+	for _, d := range []struct{ id, name, tenant string }{
+		{"def_a", "acme-agent", "acme"},
+		{"def_g", "globex-agent", "globex"},
+	} {
+		if _, err := s.AgentDefCreate(ctx, store.AgentDefRow{
+			DefID: d.id, Name: d.name, Version: 1, TenantID: d.tenant,
+			Definition: []byte(`{}`), CreatedAt: time.Now(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tenant := auth.Principal{TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant}}
+	if got := callAgentDefNames(t, srv, tenant, ""); len(got) != 1 || got[0] != "acme-agent" {
+		t.Fatalf("acme tenant sees %v, want [acme-agent] only", got)
+	}
+	admin := auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}}
+	if got := callAgentDefNames(t, srv, admin, ""); len(got) != 2 {
+		t.Fatalf("admin sees %v, want both", got)
+	}
+	if got := callAgentDefNames(t, srv, admin, "?tenant=globex"); len(got) != 1 || got[0] != "globex-agent" {
+		t.Fatalf("admin ?tenant=globex sees %v, want [globex-agent] only", got)
 	}
 }
 


### PR DESCRIPTION
Continues **RFC AS Phase 1** after the Library (`/v1/_library/*`) slice (#575).

## Problem
The `GET /v1/_*def/names` endpoints (`library_admin.go`) all called **tenant-blind** `*DefListNames` store methods and returned **every tenant's** rows. The route is auth-only, so any authenticated principal — including a `substrate:tenant` token — could enumerate every tenant's def names + version metadata across **all eight def families**. This is the `/names` sibling of the leak #575 closed: that PR scoped the `/v1/_library/*` unified endpoints (agents/skills/mcp), but the parallel `/names` variants — **plus schedules, a2a-server-card, a2a-agent, webhooks, memory-backends, operator-tokens** — were still tenant-blind.

## Fix
A generic `scopeNames[T](rows, all, tenantID, tenantOf)` helper, applied to all nine `/names` handlers:
- **admin / legacy / open** → all rows (honoring the `?tenant=` focus);
- **`substrate:tenant`** → only its own tenant's rows.

`operator-token` names are tenant-scoped too (a tenant sees only its own; the summaries carry no secret material). One file (`library_admin.go`), uniform change.

## Tests
- **`TestScopeNames`** — the shared helper directly (passthrough when `all`, non-nil on nil input, filter by tenant, empty on unknown tenant) — covers every family via the one code path.
- **`TestLibraryAdmin_AgentDefNames_TenantIsolation`** — the wiring in a real handler: tenant sees its own only, admin sees all, admin `?tenant=globex` focuses one. Fail-before: pre-fix the tenant saw all.
- Existing admin-path `/names` tests unchanged. Full `internal/api/http` package green; `go test ./...` clean except the pre-existing env-dependent `TestLoadExample`.

## Scope / remaining Phase 1
Library (#575) + def-plane `/names` (this PR) cover all the **def-family** list endpoints. The remaining RFC AS Phase 1 surfaces — **channels, memory, documents, volumes, interrupts** — use different list mechanisms (not `*DefListNames`) and follow in subsequent PRs. Phase 2 (frontend nav) and Phase 2.5 (admin act-as-tenant) remain separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)