### PR TITLE
fix(authz): open the Library list routes to substrate:tenant (RFC AS Phase 1)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -477,6 +477,20 @@ func requiredScopeFor(method, path string) string {
 	// not the /v1/_volumedef def-authoring route.
 	case path == "/v1/_volumes" || path == "/v1/_volumes/ephemeral":
 		return auth.ScopeTenant
+	// RFC AS Phase 1: the unified Library list views (agents / skills /
+	// mcp-servers). #575 tenant-scoped the HANDLERS (a substrate:tenant
+	// principal sees only its own tenant's substrate rows; operator-global
+	// statics excluded), but the routes stayed at the /v1/_* ScopeAdmin
+	// catch-all below — so a tenant token was 403'd at the gate before the
+	// scoped handler could run, leaving #575's tenant branch unreachable
+	// (and the Library invisible to a tenant operator). Grant ScopeTenant
+	// here so the reads are actually reachable; the handler still confines
+	// the result to the caller's tenant (ScopeAdmin also satisfies, so admin
+	// + ?tenant= focus is unchanged). GET-only views — the def-AUTHORING
+	// writes live at /v1/_agentdef etc. (isTenantConfinedDefPath, already
+	// ScopeTenant), not at this path. Mirrors the /v1/_*def/names posture.
+	case path == "/v1/_library/agents" || path == "/v1/_library/skills" || path == "/v1/_library/mcp-servers":
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, audit, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -238,6 +238,13 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/_a2aagentdef", auth.ScopeTenant},
 		{"POST", "/v1/_a2aservercarddef", auth.ScopeTenant},
 		{"GET", "/v1/_a2aservercarddef/names", auth.ScopeTenant},
+		// RFC AS Phase 1: the unified Library list views are tenant-reachable
+		// (the handler tenant-scopes the result, #575). Without this, the
+		// /v1/_* catch-all below 403'd a tenant token before the scoped
+		// handler ran — so #575's tenant branch was unreachable.
+		{"GET", "/v1/_library/agents", auth.ScopeTenant},
+		{"GET", "/v1/_library/skills", auth.ScopeTenant},
+		{"GET", "/v1/_library/mcp-servers", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.


### PR DESCRIPTION
## Why

The original report: a `jobember-editor` token minted for the `jobember` tenant with **every** non-admin scope checked still showed **no Library** in the loomcycle Web UI menu. Tenant operators should be able to manage every primitive scoped to their own tenant.

The Library backend leak this completes was already partly addressed: **#575** tenant-scoped the `GET /v1/_library/{agents,skills,mcp-servers}` *handlers* (a `substrate:tenant` principal sees only its own tenant's substrate rows; operator-global statics excluded). But #575 left the **route gate** untouched. Those three paths still fall through to the `/v1/_*` → `ScopeAdmin` catch-all in `requiredScopeFor`, so the `authMiddleware` **403s a `substrate:tenant` token at the gate before the scoped handler ever runs**. The net effect: #575's tenant branch was dead code for tenant tokens, and the Library stayed unreachable for a tenant operator.

This is the missing half of #575.

## What

- `internal/api/http/auth_principal.go` — add an explicit `requiredScopeFor` case granting **`ScopeTenant`** to `GET /v1/_library/agents|skills|mcp-servers`, placed before the `/v1/_*` `ScopeAdmin` catch-all. Mirrors the `/v1/_*def/names` posture (`isTenantConfinedDefPath`) and `/v1/_volumes`.
  - The handler still confines the result to the caller's tenant (#575), so this only makes the **already-scoped** reads *reachable* — no new data is exposed.
  - `substrate:admin` still satisfies `ScopeTenant` (`auth.HasScope`), so admin + the `?tenant=` focus are unchanged.
  - GET-only views; def-**authoring** writes live at `/v1/_agentdef` etc. (already `ScopeTenant`), not at this path.

## Scope

Backend-only, per **RFC AS §8 Phase 1** ("Library first… this alone closes the leak, no UI change yet"). The per-surface **nav un-gating** that makes the Library menu item *visible* to a tenant operator (`Layout.tsx` `adminOnly` → a `"tenant"` visibility class) is **Phase 2** and is **not** in this PR.

## What was tested

- `go test ./internal/api/http/ -run 'TestRequiredScopeFor|TestAuthMiddleware'` — pass.
- **Regression test**: `TestRequiredScopeFor` now asserts the three Library routes resolve to `ScopeTenant`. Revert-checked: on the unfixed code the test fails with `= "substrate:admin", want "substrate:tenant"` for all three.
- `go test ./internal/api/http/` — full package green (19.7s).
- `go test ./...` — green except the pre-existing, env-dependent `TestLoadExample` (`/work/sandbox` must exist on disk; fails identically on `main`, unrelated to this change).
- `go build -o bin/loomcycle ./cmd/loomcycle` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)