### PR TITLE
fix(authz): show operator-global static defs to tenant operators in the Library

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -94,13 +94,14 @@ func (s *Server) handleListLibraryAgents(w http.ResponseWriter, r *http.Request)
 	entries := make([]LibraryEntry, 0, len(s.cfg.Agents)+len(subRows))
 	seen := map[string]struct{}{}
 
-	// Operator-global static cfg agents belong to the shared operator scope —
-	// surfaced only in the all-tenants (admin/open) view, never to a
-	// tenant-scoped principal (RFC AS §2.2).
+	// Operator-global static cfg agents are the shared agent catalog (no tenant
+	// axis) — surfaced to EVERY principal, including a substrate:tenant operator.
+	// This mirrors the static-volume "bind floor" (volumes_read.go shows static
+	// volumes to all tenants): a static def is operator-global, not another
+	// tenant's private substrate row, so showing it read-only to a tenant
+	// operator is not a cross-tenant leak — it lets the tenant see (and run/fork)
+	// the bundled/preset agents. Only the substrate rows above are tenant-scoped.
 	for name, def := range s.cfg.Agents {
-		if !all {
-			continue
-		}
 		entry := LibraryEntry{
 			Name:             name,
 			InStatic:         true,
@@ -162,11 +163,9 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 	entries := make([]LibraryEntry, 0, len(staticNames)+len(subRows))
 	seen := map[string]struct{}{}
 
-	// Operator-global static skills — admin/open view only (RFC AS §2.2).
+	// Operator-global static skills — the shared catalog floor, shown to every
+	// principal incl. a tenant operator (see handleListLibraryAgents).
 	for _, name := range staticNames {
-		if !all {
-			continue
-		}
 		sk, _ := s.skillSet.Get(name)
 		entry := LibraryEntry{
 			Name:             name,
@@ -230,11 +229,9 @@ func (s *Server) handleListLibraryMcpServers(w http.ResponseWriter, r *http.Requ
 	entries := make([]LibraryEntry, 0, len(s.cfg.MCPServers)+len(subRows))
 	seen := map[string]struct{}{}
 
-	// Operator-global static MCP servers — admin/open view only (RFC AS §2.2).
+	// Operator-global static MCP servers — the shared catalog floor, shown to
+	// every principal incl. a tenant operator (see handleListLibraryAgents).
 	for name, srv := range s.cfg.MCPServers {
-		if !all {
-			continue
-		}
 		var discoveredTools json.RawMessage
 		if s.mcpPoolInspector != nil {
 			discoveredTools = s.mcpPoolInspector(name)

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -377,12 +377,32 @@ func callLibraryAgents(t *testing.T, srv *Server, p auth.Principal) []string {
 	return out
 }
 
+// sameNameSet reports whether got and want contain the same names (order-
+// independent). Library entries are sorted by name, but the tenant tests assert
+// on membership, so compare as sets.
+func sameNameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	set := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		set[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 // TestUnifiedLibrary_Agents_TenantIsolation (RFC AS Phase 1) pins that the
-// library listing is tenant-scoped: a substrate:tenant principal sees ONLY its
-// own tenant's substrate agents — not other tenants', not the operator-global
-// static cfg agents — while a substrate:admin principal sees all. Fail-before:
-// the pre-RFC-AS handler called the tenant-blind AgentDefListNames and merged
-// cfg.Agents unconditionally, so any authenticated principal could enumerate
+// library listing is tenant-scoped for SUBSTRATE rows: a substrate:tenant
+// principal sees its own tenant's substrate agents PLUS the operator-global
+// static cfg agents (the shared catalog floor, shown to every principal like
+// the static-volume bind floor) — but NEVER another tenant's substrate rows.
+// A substrate:admin principal sees all. Fail-before: the pre-RFC-AS handler
+// called the tenant-blind AgentDefListNames, so any principal could enumerate
 // every tenant's agent names.
 func TestUnifiedLibrary_Agents_TenantIsolation(t *testing.T) {
 	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
@@ -405,27 +425,28 @@ func TestUnifiedLibrary_Agents_TenantIsolation(t *testing.T) {
 	mustDef("def_acme", "acme-agent", "acme")
 	mustDef("def_globex", "globex-agent", "globex")
 
-	// A substrate:tenant principal sees only its own tenant — no cross-tenant
-	// rows, no operator-global static.
-	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "acme", Subject: "acme-op", Scopes: []string{auth.ScopeTenant}}); len(got) != 1 || got[0] != "acme-agent" {
-		t.Fatalf("acme tenant sees %v, want [acme-agent] only", got)
+	// A substrate:tenant principal sees its own tenant's substrate row PLUS the
+	// operator-global static — but NOT another tenant's substrate row.
+	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "acme", Subject: "acme-op", Scopes: []string{auth.ScopeTenant}}); !sameNameSet(got, []string{"acme-agent", "global-static"}) {
+		t.Fatalf("acme tenant sees %v, want [acme-agent global-static] (own substrate + shared static, no globex)", got)
 	}
-	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "globex", Subject: "globex-op", Scopes: []string{auth.ScopeTenant}}); len(got) != 1 || got[0] != "globex-agent" {
-		t.Fatalf("globex tenant sees %v, want [globex-agent] only", got)
+	if got := callLibraryAgents(t, srv, auth.Principal{TenantID: "globex", Subject: "globex-op", Scopes: []string{auth.ScopeTenant}}); !sameNameSet(got, []string{"globex-agent", "global-static"}) {
+		t.Fatalf("globex tenant sees %v, want [globex-agent global-static] (own substrate + shared static, no acme)", got)
 	}
 
 	// A substrate:admin principal sees everything: both tenants' substrate rows
 	// plus the operator-global static agent.
 	got := callLibraryAgents(t, srv, auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}})
-	if len(got) != 3 {
+	if !sameNameSet(got, []string{"acme-agent", "globex-agent", "global-static"}) {
 		t.Fatalf("admin sees %v, want all 3 (acme-agent, globex-agent, global-static)", got)
 	}
 }
 
 // TestUnifiedLibrary_Agents_AdminTenantFocus (RFC AS Phase 1) pins the admin
-// ?tenant= focus: a substrate:admin with ?tenant=acme sees only acme's
-// substrate rows (acting as a view of that tenant), and the operator-global
-// static agent is excluded from a focused view.
+// ?tenant= focus: a substrate:admin with ?tenant=acme sees acme's substrate
+// rows + the shared operator-global static (acting as a view of that tenant,
+// which now includes the shared catalog floor) — but NOT another tenant's
+// substrate rows.
 func TestUnifiedLibrary_Agents_AdminTenantFocus(t *testing.T) {
 	srv, s, cleanup := libraryUnifiedFixture(t, map[string]config.AgentDef{
 		"global-static": {Model: "x"},
@@ -452,11 +473,13 @@ func TestUnifiedLibrary_Agents_AdminTenantFocus(t *testing.T) {
 	}))
 	srv.handleListLibraryAgents(rec, req)
 	es := decodeLibraryEntries(t, rec)
-	if len(es) != 1 || es[0].Name != "acme-agent" {
-		names := make([]string, len(es))
-		for i, e := range es {
-			names[i] = e.Name
-		}
-		t.Fatalf("admin ?tenant=acme sees %v, want [acme-agent] only", names)
+	names := make([]string, len(es))
+	for i, e := range es {
+		names[i] = e.Name
+	}
+	// The focused view is "as tenant acme": acme's substrate row + the shared
+	// static, but NOT globex's substrate row.
+	if !sameNameSet(names, []string{"acme-agent", "global-static"}) {
+		t.Fatalf("admin ?tenant=acme sees %v, want [acme-agent global-static] (focused tenant + shared static, no globex)", names)
 	}
 }


### PR DESCRIPTION
## Why

You upgraded to v1.6.3 and a `substrate:tenant` operator (jobember-editor) saw **zero agents** in the Library — but the **bundled agents should be visible**.

RFC AS Phase 1 (#575) tenant-scoped the Library list, but it skipped **every operator-global static cfg entry** for a tenant principal (`if !all { continue }`). Static defs — the bundled/preset agents (`chat`, `document-agent`, …) and any operator-declared yaml agents/skills/mcp-servers — are **operator-global**, not another tenant's private substrate rows. Hiding them isn't closing a leak; it's hiding the shared catalog. (Static **Volumes** already work the right way — `volumes_read.go` shows them to every tenant as "the bind floor".)

## What

In `handleListLibrary{Agents,Skills,McpServers}`, surface operator-global static entries to **every** principal, including a `substrate:tenant` operator:

- The `StaticDefinition` body is operator-global and non-secret, returned **inline** in the list (no separate gated detail call), so this is a complete fix, not a half one.
- The **substrate-row merge stays tenant-scoped** — a tenant still sees only its OWN substrate defs and **never another tenant's**. The real isolation property is preserved.
- A tenant can now see + run the bundled agents, and fork a static into a tenant-owned def (the write path is already tenant-stamped, RFC AF).

This mirrors the static-volume "bind floor" posture exactly.

## What was tested

- `TestUnifiedLibrary_Agents_TenantIsolation` updated to assert the new contract: a tenant sees its own substrate row **plus** the shared static, and **never** the other tenant's substrate row. **Revert-checked**: fails on the unfixed code (`acme tenant sees [acme-agent], want [acme-agent global-static]`).
- `TestUnifiedLibrary_Agents_AdminTenantFocus` updated: an admin `?tenant=acme` focus now sees acme's row + the shared static (still not globex's row).
- `go test ./internal/api/http/` — full package green; `go build` clean.

Backend-only — the SPA already renders `InStatic` entries; no UI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)