### PR TITLE
feat(authz): tenant-scope the Web UI schedules surface (RFC AS)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -491,6 +491,15 @@ func requiredScopeFor(method, path string) string {
 	// ScopeTenant), not at this path. Mirrors the /v1/_*def/names posture.
 	case path == "/v1/_library/agents" || path == "/v1/_library/skills" || path == "/v1/_library/mcp-servers":
 		return auth.ScopeTenant
+	// RFC AS: the Web UI schedules surface (list-all + per-def state / run-now /
+	// pause / resume). list-all is tenant-scoped (the handler filters substrate
+	// schedules to the caller's tenant; operator-global static crons stay
+	// admin-only); the per-def ops confine a substrate:tenant principal to its
+	// OWN tenant's schedule defs (opaque-404 cross-tenant + statics, which have
+	// no ScheduleDef row). ScopeAdmin also satisfies. The def-AUTHORING writes
+	// live at /v1/_scheduledef (isTenantConfinedDefPath, already ScopeTenant).
+	case strings.HasPrefix(path, "/v1/_schedules/"):
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, audit, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -245,6 +245,13 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"GET", "/v1/_library/agents", auth.ScopeTenant},
 		{"GET", "/v1/_library/skills", auth.ScopeTenant},
 		{"GET", "/v1/_library/mcp-servers", auth.ScopeTenant},
+		// RFC AS: the schedules surface (list-all + per-def ops) is tenant-
+		// reachable; the handlers confine a tenant to its own schedule defs.
+		{"GET", "/v1/_schedules/list-all", auth.ScopeTenant},
+		{"GET", "/v1/_schedules/sd_1/state", auth.ScopeTenant},
+		{"POST", "/v1/_schedules/sd_1/run-now", auth.ScopeTenant},
+		{"POST", "/v1/_schedules/sd_1/pause", auth.ScopeTenant},
+		{"POST", "/v1/_schedules/sd_1/resume", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/api/http/schedules_admin.go
+++ b/internal/api/http/schedules_admin.go
@@ -15,6 +15,7 @@
 package http
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -24,6 +25,28 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 )
+
+// scheduleDefTenantVisible reports whether the caller may act on the schedule
+// def_id (RFC AS). Admin / legacy / open → always. A substrate:tenant principal
+// → only if the def belongs to its tenant. A static yaml schedule has no
+// ScheduleDef row, so ScheduleDefGet returns ErrNotFound → a tenant gets false
+// (operator-global crons stay admin-managed). The per-def handlers surface a
+// false as an opaque 404, indistinguishable from an unknown or cross-tenant
+// def_id (no existence oracle).
+func (s *Server) scheduleDefTenantVisible(ctx context.Context, defID string) bool {
+	tenantID, all := s.principalTenantScope(ctx, "")
+	if all {
+		return true
+	}
+	if s.store == nil {
+		return false
+	}
+	row, err := s.store.ScheduleDefGet(ctx, defID)
+	if err != nil {
+		return false
+	}
+	return row.TenantID == tenantID
+}
 
 // ScheduleListEntry is one row in the /ui/schedules list. Mirrors
 // LibraryEntry's shape so the UI can reuse rendering logic. Static
@@ -48,7 +71,16 @@ type schedulesListResponse struct {
 }
 
 // handleListSchedules serves GET /v1/_schedules/list-all.
+//
+// RFC AS: tenant-scoped. A substrate:tenant principal sees only the schedules
+// IT authored (its own tenant's substrate rows); admin / legacy / open see all
+// (honoring the ?tenant= focus). Operator-global static yaml schedules are
+// operator automation (global crons), NOT a tenant's primitives, so they stay
+// in the all-tenants (admin) view only — a tenant can't manage them anyway (the
+// per-def ops below opaque-404 a static for a tenant).
 func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+
 	subRows := map[string]store.ScheduleDefNameSummary{}
 	if s.store != nil {
 		rows, err := s.store.ScheduleDefListNames(r.Context())
@@ -57,6 +89,9 @@ func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		for _, row := range rows {
+			if !all && row.TenantID != tenantID {
+				continue
+			}
 			subRows[row.Name] = row
 		}
 	}
@@ -65,6 +100,9 @@ func (s *Server) handleListSchedules(w http.ResponseWriter, r *http.Request) {
 	seen := map[string]struct{}{}
 
 	for name, sr := range s.cfg.ScheduledRuns {
+		if !all {
+			continue
+		}
 		entry := ScheduleListEntry{
 			Name:             name,
 			InStatic:         true,
@@ -122,6 +160,10 @@ func (s *Server) handleGetScheduleState(w http.ResponseWriter, r *http.Request) 
 	}
 	if s.store == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable", "no store configured")
+		return
+	}
+	if !s.scheduleDefTenantVisible(r.Context(), defID) {
+		writeJSONError(w, http.StatusNotFound, "not_found", "no run-state row for def_id")
 		return
 	}
 	row, err := s.store.ScheduleRunStateGet(r.Context(), defID)
@@ -182,6 +224,10 @@ func (s *Server) handleScheduleRunNow(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable", "no store configured")
 		return
 	}
+	if !s.scheduleDefTenantVisible(r.Context(), defID) {
+		writeJSONError(w, http.StatusNotFound, "not_found", "no run-state row for def_id (def may not be promoted, or has been retired)")
+		return
+	}
 	// Pre-flight existence check so unknown def_ids return 404 instead
 	// of the FK-constraint-violation 500 the bare upsert would produce.
 	// Matches the 404 shape of pause/resume. The state-row check is
@@ -221,6 +267,10 @@ func (s *Server) handleSchedulePause(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable", "no store configured")
 		return
 	}
+	if !s.scheduleDefTenantVisible(r.Context(), defID) {
+		writeJSONError(w, http.StatusNotFound, "not_found", "no run-state row for def_id")
+		return
+	}
 	// "Indefinite pause" — 100 years from now. Year 9999 would
 	// overflow SQLite's int64-nanosecond timestamp storage; 100 years
 	// is safely under int64.MaxInt64 nanos (~2262-04-11) and matches
@@ -250,6 +300,10 @@ func (s *Server) handleScheduleResume(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.store == nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable", "no store configured")
+		return
+	}
+	if !s.scheduleDefTenantVisible(r.Context(), defID) {
+		writeJSONError(w, http.StatusNotFound, "not_found", "no run-state row for def_id")
 		return
 	}
 	if err := s.store.ScheduleRunStatePause(r.Context(), defID, time.Time{}); err != nil {

--- a/internal/api/http/schedules_admin_test.go
+++ b/internal/api/http/schedules_admin_test.go
@@ -8,12 +8,119 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
+
+// schedulesTenantFixture builds a Server with one operator-global static yaml
+// schedule + two substrate schedules owned by different tenants (acme, globex),
+// each with a seeded run-state row. Handlers are called directly with an
+// injected principal so each case exercises a specific tenant scope (RFC AS).
+func schedulesTenantFixture(t *testing.T) (srv *Server, acmeDef, globexDef string) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+
+	cfg := &config.Config{
+		ScheduledRuns: map[string]config.ScheduledRun{
+			"yaml-sched": {Agent: "researcher", Schedule: "0 6 * * *", Enabled: true},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	cfg.Env.AuthToken = "test-token"
+
+	ctx := t.Context()
+	defJSON, _ := json.Marshal(map[string]any{"agent": "researcher", "schedule": "0 9 * * 1", "enabled": true})
+	mk := func(defID, name, tenant string) {
+		if _, err := st.ScheduleDefCreate(ctx, store.ScheduleDefRow{
+			DefID: defID, Name: name, TenantID: tenant, Definition: defJSON,
+		}); err != nil {
+			t.Fatalf("ScheduleDefCreate(%s): %v", name, err)
+		}
+		if err := st.ScheduleDefSetActive(ctx, tenant, name, defID, "test"); err != nil {
+			t.Fatalf("ScheduleDefSetActive(%s): %v", name, err)
+		}
+		if err := st.ScheduleRunStateSeed(ctx, defID, time.Now().Add(time.Hour)); err != nil {
+			t.Fatalf("ScheduleRunStateSeed(%s): %v", name, err)
+		}
+	}
+	acmeDef, globexDef = "sd_acme", "sd_globex"
+	mk(acmeDef, "acme-sched", "acme")
+	mk(globexDef, "globex-sched", "globex")
+
+	srv = New(cfg, &stubResolver{}, []tools.Tool{}, concurrency.New(1, 1, time.Second), st)
+	return srv, acmeDef, globexDef
+}
+
+// TestSchedulesList_TenantScoped (RFC AS) — a substrate:tenant principal sees
+// only the schedules IT authored (its own tenant's substrate rows), not another
+// tenant's and not the operator-global static yaml cron; admin sees all. Fails
+// on the pre-RFC-AS handler (which listed every tenant's defs + the static).
+func TestSchedulesList_TenantScoped(t *testing.T) {
+	srv, _, _ := schedulesTenantFixture(t)
+	call := func(p auth.Principal) []string {
+		req := httptest.NewRequest("GET", "/v1/_schedules/list-all", nil)
+		req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+		rec := httptest.NewRecorder()
+		srv.handleListSchedules(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+		var env schedulesListResponse
+		if err := json.NewDecoder(rec.Body).Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		names := make([]string, len(env.Entries))
+		for i, e := range env.Entries {
+			names[i] = e.Name
+		}
+		return names
+	}
+	if got := call(auth.Principal{TenantID: "acme", Subject: "acme-op", Scopes: []string{auth.ScopeTenant}}); len(got) != 1 || got[0] != "acme-sched" {
+		t.Fatalf("acme tenant sees %v, want [acme-sched] only (no globex, no static)", got)
+	}
+	if got := call(auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}}); len(got) != 3 {
+		t.Fatalf("admin sees %v, want all 3 (acme-sched, globex-sched, yaml-sched)", got)
+	}
+}
+
+// TestSchedulePause_TenantConfined (RFC AS) — a substrate:tenant principal may
+// pause only its OWN tenant's schedule def; another tenant's def (and a static /
+// unknown def) opaque-404s. Admin acts on any. Fails on the pre-RFC-AS handler
+// (which paused any def_id for any authenticated caller).
+func TestSchedulePause_TenantConfined(t *testing.T) {
+	srv, acmeDef, globexDef := schedulesTenantFixture(t)
+	pause := func(p auth.Principal, defID string) int {
+		req := httptest.NewRequest("POST", "/v1/_schedules/"+defID+"/pause", nil)
+		req.SetPathValue("def_id", defID)
+		req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+		rec := httptest.NewRecorder()
+		srv.handleSchedulePause(rec, req)
+		return rec.Code
+	}
+	acme := auth.Principal{TenantID: "acme", Subject: "acme-op", Scopes: []string{auth.ScopeTenant}}
+	admin := auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}}
+
+	if c := pause(acme, acmeDef); c != http.StatusOK {
+		t.Errorf("acme pausing its own schedule = %d, want 200", c)
+	}
+	if c := pause(acme, globexDef); c != http.StatusNotFound {
+		t.Errorf("acme pausing globex's schedule = %d, want 404 (cross-tenant opaque)", c)
+	}
+	if c := pause(acme, "sd_nope"); c != http.StatusNotFound {
+		t.Errorf("acme pausing unknown/static def = %d, want 404", c)
+	}
+	if c := pause(admin, globexDef); c != http.StatusOK {
+		t.Errorf("admin pausing any schedule = %d, want 200", c)
+	}
+}
 
 // schedulesAdminFixture spins up an HTTP server with one yaml-defined
 // schedule + one substrate-defined schedule, ready for the list +


### PR DESCRIPTION
## Why

After RFC AS Phase 2 made the **schedules** nav item visible to a `substrate:tenant` operator, the page returned **403 "insufficient scope"** — the `/v1/_schedules/*` endpoints (list-all + per-def state / run-now / pause / resume) were pinned to `substrate:admin` by the `/v1/_*` route-gate catch-all. A tenant could already *author* schedules at `/v1/_scheduledef` (tenant-confined) but then couldn't see or manage them. This is the third of the approved RFC AS follow-ups.

## What

Open `/v1/_schedules/*` to `substrate:tenant` and confine every handler to the caller's tenant:

- **`list-all`** — substrate schedules filtered to the caller's tenant (admin / legacy / open see all + honor the `?tenant=` focus). Operator-global **static yaml** schedules are operator automation (global crons), **not** a tenant's primitives, so they stay in the admin/all view only.
- **`state` / `run-now` / `pause` / `resume`** — each resolves the def's owning tenant via `ScheduleDefGet(def_id)` and **opaque-404s** a cross-tenant def for a tenant principal (no existence oracle). A static schedule has no `ScheduleDef` row → a tenant gets the same 404 (operator crons stay admin-managed); admin acts on any def. `schedule_run_state` has no tenant column, so the def row is the ownership source of truth.

Route gate: `strings.HasPrefix(path, "/v1/_schedules/")` → `ScopeTenant` (placed before the `/v1/_*` admin catch-all; `ScopeAdmin` still satisfies it).

## What was tested

- `TestRequiredScopeFor` — the five `/v1/_schedules/*` routes resolve to `ScopeTenant`.
- `TestSchedulesList_TenantScoped` — a tenant sees only its own substrate schedule (not another tenant's, not the static); admin sees all three.
- `TestSchedulePause_TenantConfined` — a tenant pauses its own (200), another tenant's → 404, unknown/static → 404; admin → 200.
- **Revert-checked**: both handler tests fail on the unfixed code (`acme tenant sees [acme-sched globex-sched yaml-sched]`; `acme pausing globex's schedule = 200, want 404`).
- `go test ./internal/api/http/` green; `go build` clean.

Backend-only; the SPA already calls these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)