### PR TITLE
feat(authz): off-run Path/Document browse honors a caller-chosen subject (RFC AS)

### DIFF
--- a/internal/api/http/substrate_admin.go
+++ b/internal/api/http/substrate_admin.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/connector"
@@ -107,7 +108,7 @@ func (s *Server) handleSubstrateVolumeDef(w http.ResponseWriter, r *http.Request
 // user-scope tree an agent run for this principal uses (see
 // substrateAdminUserCtx).
 func (s *Server) handleSubstratePath(w http.ResponseWriter, r *http.Request) {
-	s.dispatchSubstrateCtx(w, r, "Path", s.Path, substrateAdminUserCtx)
+	s.dispatchSubstrateCtx(w, r, "Path", s.Path, s.substrateBrowseCtxFn(r))
 }
 
 // handleSubstrateDocument serves POST /v1/_document.
@@ -115,7 +116,7 @@ func (s *Server) handleSubstratePath(w http.ResponseWriter, r *http.Request) {
 // USER-aware ctx so off-run user-scoped documents interoperate with the
 // principal's agent runs (see substrateAdminUserCtx).
 func (s *Server) handleSubstrateDocument(w http.ResponseWriter, r *http.Request) {
-	s.dispatchSubstrateCtx(w, r, "Document", s.Document, substrateAdminUserCtx)
+	s.dispatchSubstrateCtx(w, r, "Document", s.Document, s.substrateBrowseCtxFn(r))
 }
 
 // dispatchSubstrate is the shared body of the substrate-def handlers.
@@ -315,6 +316,70 @@ func substrateAdminUserCtx(ctx context.Context) context.Context {
 		AgentID:  substrateAdminAgentID,
 		TenantID: principal.TenantID,
 	})
+}
+
+// substrateBrowseCtxFn returns the scope ctx builder for the off-run Path +
+// Document BROWSE endpoints (RFC AS). It extends substrateAdminUserCtx with an
+// optional caller-chosen subject (?scope_id=) and tenant (?tenant=) so an
+// operator can inspect a tree/document owned by a subject OTHER than its own —
+// the fix for "a doc an MCP agent created under its own subject is invisible to
+// every human login". Authz mirrors principalTenantScope:
+//
+//   - admin / legacy / open: may browse ANY (tenant, scope_id) — sees every
+//     primitive across the deployment.
+//   - substrate:tenant: the tenant is FORCED to the principal's own (a tenant
+//     can't read another tenant); scope_id may be any subject WITHIN that tenant
+//     (the whole-tenant model — subjects share their tenant's workspace).
+//
+// scope_id overrides BOTH the user-scope id (RunIdentity.UserID) and the
+// agent-scope id (agent name), so it selects the right tree whichever `scope`
+// the request asks for. With neither param set the behaviour is byte-identical
+// to substrateAdminUserCtx (the caller's own subject), so existing clients are
+// unaffected.
+func (s *Server) substrateBrowseCtxFn(r *http.Request) func(context.Context) context.Context {
+	reqScopeID := strings.TrimSpace(r.URL.Query().Get("scope_id"))
+	reqTenant := strings.TrimSpace(r.URL.Query().Get("tenant"))
+	return func(ctx context.Context) context.Context {
+		base := substrateAdminUserCtx(ctx)
+		if reqScopeID == "" && reqTenant == "" {
+			return base // no override → caller's own subject (back-compat)
+		}
+		p, ok := auth.PrincipalFromContext(ctx)
+		// Open mode (no principal) is unrestricted (is_admin-equivalent), like
+		// handleWhoami/principalTenantScope — honor both overrides.
+		admin := !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin)
+
+		tenantID := ""
+		subject := ""
+		if ok {
+			tenantID = p.TenantID
+			subject = p.Subject
+		}
+		if admin {
+			if reqTenant != "" {
+				tenantID = reqTenant
+			}
+			if reqScopeID != "" {
+				subject = reqScopeID
+			}
+		} else {
+			// substrate:tenant — tenant stays the principal's own (reqTenant
+			// IGNORED, never widens); scope_id may target any subject in it.
+			if reqScopeID != "" {
+				subject = reqScopeID
+			}
+		}
+		// Override BOTH the user id and the agent name so resolveScope picks the
+		// requested tree for scope=user OR scope=agent.
+		return tools.WithAgentName(
+			tools.WithRunIdentity(base, tools.RunIdentityValue{
+				UserID:   subject,
+				AgentID:  substrateAdminAgentID,
+				TenantID: tenantID,
+			}),
+			subject,
+		)
+	}
 }
 
 // handleSubstrateOperatorTokenDef serves POST /v1/_operatortokendef.

--- a/internal/api/http/substrate_admin_test.go
+++ b/internal/api/http/substrate_admin_test.go
@@ -559,3 +559,36 @@ func postAdmin(t *testing.T, ts *httptest.Server, path, body string) *http.Respo
 	}
 	return resp
 }
+
+// TestSubstrateBrowseCtxFn_Authz (RFC AS) pins the off-run Path/Document browse
+// scope override: ?scope_id= picks a subject other than the caller's own, and
+// ?tenant= an other tenant — but a substrate:tenant principal may NEVER cross
+// its own tenant (the cross-tenant read boundary), while admin may target any
+// (tenant, subject). With no params the caller's own identity is preserved.
+func TestSubstrateBrowseCtxFn_Authz(t *testing.T) {
+	s := &Server{}
+	build := func(query string, p auth.Principal) (tools.RunIdentityValue, string) {
+		req := httptest.NewRequest("POST", "/v1/_path"+query, nil)
+		ctx := auth.WithPrincipal(req.Context(), p)
+		out := s.substrateBrowseCtxFn(req)(ctx)
+		return tools.RunIdentity(out), tools.AgentName(out)
+	}
+	admin := auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}}
+	tenant := auth.Principal{TenantID: "loomcycle-dev", Subject: "tok-ld2", Scopes: []string{auth.ScopeTenant}}
+
+	// Admin may target any tenant + subject (sees every primitive).
+	if ri, an := build("?scope_id=marketing&tenant=acme", admin); ri.UserID != "marketing" || ri.TenantID != "acme" || an != "marketing" {
+		t.Errorf("admin override: ri=%+v agent=%q, want user=marketing tenant=acme agent=marketing", ri, an)
+	}
+	// SECURITY: a tenant principal's ?tenant= is IGNORED — tenant stays its own;
+	// scope_id is honored (any subject within its tenant).
+	if ri, an := build("?scope_id=marketing&tenant=acme", tenant); ri.TenantID != "loomcycle-dev" {
+		t.Errorf("tenant must NOT cross tenant via ?tenant=: got tenant=%q, want loomcycle-dev (ri=%+v agent=%q)", ri.TenantID, ri, an)
+	} else if ri.UserID != "marketing" || an != "marketing" {
+		t.Errorf("tenant scope_id override: ri=%+v agent=%q, want user/agent=marketing", ri, an)
+	}
+	// No params → caller's own subject preserved (back-compat with substrateAdminUserCtx).
+	if ri, _ := build("", tenant); ri.UserID != "tok-ld2" || ri.TenantID != "loomcycle-dev" {
+		t.Errorf("no-override must keep own identity: ri=%+v", ri)
+	}
+}


### PR DESCRIPTION
## Why

Confirmed live on your TrueNAS instance: a Document/Path created by an MCP agent under *its own* subject is invisible to every human login — the off-run `/v1/_path` + `/v1/_document` browse endpoints key `scope_id` to the **caller's own subject** (`substrateAdminUserCtx`), with no way to inspect another subject's tree. (Browsing as `tok-loomcycle-dev2`, all scopes were empty because the marketing doc lives under the agent's subject.)

Your decision: **admin sees every primitive; a tenant sees its own tenant's** — via a user-picker that accepts a manually-entered subject.

## What (backend half)

`substrateBrowseCtxFn` — the two browse handlers now honor an optional `?scope_id=` (the subject / agent-name to browse) and `?tenant=` override, stamped into the dispatch `RunIdentity` so `resolveScope` selects the requested tree for `scope=user` **or** `scope=agent`. Authz mirrors `principalTenantScope`:

- **admin / legacy / open** → may target **any** `(tenant, scope_id)` — see every primitive.
- **substrate:tenant** → tenant **forced** to the principal's own (`?tenant=` ignored — the cross-tenant read boundary); `scope_id` may target any subject **within** that tenant (whole-tenant model).

With neither param set, behavior is **byte-identical** to before (caller's own subject) — existing clients unaffected. Route gate unchanged (`/v1/_path` + `/v1/_document` are already `ScopeTenant`).

## What was tested

- `TestSubstrateBrowseCtxFn_Authz` — admin may target any tenant+subject; a `substrate:tenant` principal's `?tenant=` is **ignored** (stays its own tenant) while `scope_id` is honored; no-param preserves own identity. The cross-tenant block is the security-critical assertion.
- `go test ./internal/api/http/` green; `go build` clean.

## Follow-ups
- **Frontend** (next PR): the Web UI user-picker accepts a manual subject that drives `?scope_id=` (and admin's tenant focus drives `?tenant=`).
- **Deploy note**: separately, the SQL-Memory Postgres role needs `CREATEROLE` (per `docs/SQL_MEMORY.md`) — the TrueNAS `INSTALL.md` omits it; a docs fix is coming. (You've already applied `ALTER ROLE loomcycle CREATEROLE` on the live box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)