### PR TITLE
feat(webui): browse Paths/Documents by subject via the topbar picker (RFC AS)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -690,6 +690,18 @@ async function postJSON<T>(path: string, body: string | undefined): Promise<T> {
 export type PathScope = "agent" | "user" | "tenant";
 export type DocScope = "agent" | "user";
 
+// BrowseScope is an optional override for the off-run Path/Document endpoints
+// (RFC AS): which subject's tree (scopeId → ?scope_id=) and, for an admin, which
+// tenant (tenant → ?tenant=). Both are CALLER-AUTHORITATIVE only in the sense
+// that the SERVER re-checks them — a substrate:tenant principal's ?tenant= is
+// ignored (confined to its own tenant); scope_id picks any subject it may see.
+// Unset fields are omitted, so the server falls back to the caller's own
+// subject (byte-identical to the pre-RFC-AS behaviour).
+export interface BrowseScope {
+  scopeId?: string;
+  tenant?: string;
+}
+
 // PathEntry is one dirent in an `ls` listing.
 export interface PathEntry {
   name: string;
@@ -701,8 +713,15 @@ export interface PathEntry {
 // substratePost POSTs a tool op to an off-run substrate endpoint. A 200 returns
 // the tool's JSON result verbatim; a 422 tool refusal carries {code,error,tool}
 // — surface the human-readable `error` (e.g. "Documents require SQL Memory").
-async function substratePost<T>(path: string, body: unknown): Promise<T> {
-  const resp = await fetch(baseURL + path, {
+async function substratePost<T>(path: string, body: unknown, browse?: BrowseScope): Promise<T> {
+  let url = baseURL + path;
+  if (browse && (browse.scopeId || browse.tenant)) {
+    const q = new URLSearchParams();
+    if (browse.scopeId) q.set("scope_id", browse.scopeId);
+    if (browse.tenant) q.set("tenant", browse.tenant);
+    url += `?${q.toString()}`;
+  }
+  const resp = await fetch(url, {
     method: "POST",
     credentials: "same-origin",
     headers: { "Content-Type": "application/json", Accept: "application/json" },
@@ -727,21 +746,28 @@ export function pathLs(
   path: string,
   scope: PathScope,
   recursive = false,
+  browse?: BrowseScope,
 ): Promise<{ path: string; entries: PathEntry[] }> {
-  return substratePost("/v1/_path", { op: "ls", path, scope, recursive });
+  return substratePost("/v1/_path", { op: "ls", path, scope, recursive }, browse);
 }
 
 // pathMkdir materializes an empty `directory` dirent (RFC AM); idempotent.
 export function pathMkdir(
   path: string,
   scope: PathScope,
+  browse?: BrowseScope,
 ): Promise<{ ok: boolean; created: boolean; path: string }> {
-  return substratePost("/v1/_path", { op: "mkdir", path, scope });
+  return substratePost("/v1/_path", { op: "mkdir", path, scope }, browse);
 }
 
 // pathMv renames/relocates a dirent (atomic; cascades a subtree; no-clobber).
-export function pathMv(from: string, to: string, scope: PathScope): Promise<{ ok: boolean }> {
-  return substratePost("/v1/_path", { op: "mv", path: from, to, scope });
+export function pathMv(
+  from: string,
+  to: string,
+  scope: PathScope,
+  browse?: BrowseScope,
+): Promise<{ ok: boolean }> {
+  return substratePost("/v1/_path", { op: "mv", path: from, to, scope }, browse);
 }
 
 // pathRm removes a dirent (recursive required for a non-empty branch). Removes
@@ -750,8 +776,9 @@ export function pathRm(
   path: string,
   scope: PathScope,
   recursive = false,
+  browse?: BrowseScope,
 ): Promise<{ ok: boolean; n_removed: number }> {
-  return substratePost("/v1/_path", { op: "rm", path, scope, recursive });
+  return substratePost("/v1/_path", { op: "rm", path, scope, recursive }, browse);
 }
 
 // documentCreate makes a new chunked-graph Document and names it in the Path
@@ -761,8 +788,9 @@ export function documentCreate(
   title: string,
   path: string,
   scope: DocScope,
+  browse?: BrowseScope,
 ): Promise<{ document_id: string; root_chunk_id: string; title: string; path?: string }> {
-  return substratePost("/v1/_document", { op: "create_document", title, path, scope });
+  return substratePost("/v1/_document", { op: "create_document", title, path, scope }, browse);
 }
 
 // documentDelete removes a Document by id: SQL rows + Memory bodies + the Path
@@ -770,8 +798,9 @@ export function documentCreate(
 export function documentDelete(
   id: string,
   scope: DocScope,
+  browse?: BrowseScope,
 ): Promise<{ deleted: boolean; document_id: string; n_chunks_deleted: number }> {
-  return substratePost("/v1/_document", { op: "delete_document", id, scope });
+  return substratePost("/v1/_document", { op: "delete_document", id, scope }, browse);
 }
 
 // ChunkRow is the structural record returned by query_chunks (no body — kept
@@ -797,17 +826,22 @@ export interface ChunkDetail extends ChunkRow {
 export function documentQueryChunks(
   documentId: string,
   scope: DocScope,
+  browse?: BrowseScope,
 ): Promise<{ chunks: ChunkRow[] }> {
-  return substratePost("/v1/_document", {
-    op: "query_chunks",
-    document_id: documentId,
-    scope,
-    limit: 1000,
-  });
+  return substratePost(
+    "/v1/_document",
+    {
+      op: "query_chunks",
+      document_id: documentId,
+      scope,
+      limit: 1000,
+    },
+    browse,
+  );
 }
 
-export function documentGetChunk(id: string, scope: DocScope): Promise<ChunkDetail> {
-  return substratePost("/v1/_document", { op: "get_chunk", id, scope });
+export function documentGetChunk(id: string, scope: DocScope, browse?: BrowseScope): Promise<ChunkDetail> {
+  return substratePost("/v1/_document", { op: "get_chunk", id, scope }, browse);
 }
 
 // documentUpdateChunk applies an optimistic-concurrency update — pass the
@@ -818,8 +852,9 @@ export function documentUpdateChunk(
   revision: number,
   patch: { body?: string; fields?: unknown; title?: string; status?: string; type?: string },
   scope: DocScope,
+  browse?: BrowseScope,
 ): Promise<ChunkDetail> {
-  return substratePost("/v1/_document", { op: "update_chunk", id, revision, scope, ...patch });
+  return substratePost("/v1/_document", { op: "update_chunk", id, revision, scope, ...patch }, browse);
 }
 
 // documentExportMd renders the document to Markdown. includeMetadata=true is
@@ -828,13 +863,18 @@ export function documentExportMd(
   documentId: string,
   scope: DocScope,
   includeMetadata: boolean,
+  browse?: BrowseScope,
 ): Promise<{ markdown: string; title: string; document_id: string }> {
-  return substratePost("/v1/_document", {
-    op: "export_md",
-    document_id: documentId,
-    scope,
-    include_metadata: includeMetadata,
-  });
+  return substratePost(
+    "/v1/_document",
+    {
+      op: "export_md",
+      document_id: documentId,
+      scope,
+      include_metadata: includeMetadata,
+    },
+    browse,
+  );
 }
 
 // AuditEvent mirrors wireEvent in internal/api/http/events_audit.go.

--- a/web/src/components/ChunkEditorModal.tsx
+++ b/web/src/components/ChunkEditorModal.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from "react";
-import { type ChunkDetail, type DocScope, documentUpdateChunk } from "../api";
+import { type BrowseScope, type ChunkDetail, type DocScope, documentUpdateChunk } from "../api";
 
 // ChunkEditorModal edits one chunk's content — title, type, status, Markdown
 // body, and (optional) typed fields as JSON. Save is an optimistic-concurrency
@@ -10,11 +10,14 @@ import { type ChunkDetail, type DocScope, documentUpdateChunk } from "../api";
 export interface ChunkEditorModalProps {
   chunk: ChunkDetail;
   scope: DocScope;
+  // browse (RFC AS) — edit a chunk under the browsed subject's document, not
+  // necessarily the caller's own (server re-authorizes). Unset → own subject.
+  browse?: BrowseScope;
   onClose: () => void;
   onSaved: (updated: ChunkDetail) => void;
 }
 
-export default function ChunkEditorModal({ chunk, scope, onClose, onSaved }: ChunkEditorModalProps) {
+export default function ChunkEditorModal({ chunk, scope, browse, onClose, onSaved }: ChunkEditorModalProps) {
   const [title, setTitle] = useState(chunk.title);
   const [type, setType] = useState(chunk.type ?? "");
   const [status, setStatus] = useState(chunk.status ?? "");
@@ -48,7 +51,7 @@ export default function ChunkEditorModal({ chunk, scope, onClose, onSaved }: Chu
     }
     setBusy(true);
     try {
-      const updated = await documentUpdateChunk(chunk.id, chunk.revision, patch, scope);
+      const updated = await documentUpdateChunk(chunk.id, chunk.revision, patch, scope, browse);
       onSaved(updated);
       onClose();
     } catch (ex) {

--- a/web/src/components/DocumentViewer.tsx
+++ b/web/src/components/DocumentViewer.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
+  type BrowseScope,
   type ChunkDetail,
   type ChunkRow,
   type DocScope,
@@ -31,12 +32,16 @@ export interface DocumentViewerProps {
   // titleHint shows immediately (e.g. the Path-tree name) until the root chunk
   // title loads.
   titleHint?: string;
+  // browse (RFC AS) selects whose subject's document to read — threaded into the
+  // off-run /v1/_document calls as ?scope_id= / ?tenant=. Unset → the caller's
+  // own subject (default). The server re-authorizes it.
+  browse?: BrowseScope;
 }
 
 // View mode for the selected-chunk pane (not the whole document).
 type Mode = "chunks" | "markdown";
 
-export default function DocumentViewer({ documentId, scope, titleHint }: DocumentViewerProps) {
+export default function DocumentViewer({ documentId, scope, titleHint, browse }: DocumentViewerProps) {
   const [chunks, setChunks] = useState<ChunkRow[]>([]);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [selectedDetail, setSelectedDetail] = useState<ChunkDetail | null>(null);
@@ -68,7 +73,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
     let cancelled = false;
     setLoading(true);
     setErr(null);
-    documentQueryChunks(documentId, scope)
+    documentQueryChunks(documentId, scope, browse)
       .then((resp) => {
         if (cancelled) return;
         const rows = resp.chunks ?? [];
@@ -80,7 +85,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
     return () => {
       cancelled = true;
     };
-  }, [documentId, scope, reload]);
+  }, [documentId, scope, reload, browse]);
 
   // Reset selection + view when the document changes.
   useEffect(() => {
@@ -97,13 +102,13 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
       return;
     }
     let cancelled = false;
-    documentGetChunk(selectedId, scope)
+    documentGetChunk(selectedId, scope, browse)
       .then((d) => !cancelled && setSelectedDetail(d))
       .catch((e) => !cancelled && setErr(e instanceof Error ? e.message : String(e)));
     return () => {
       cancelled = true;
     };
-  }, [selectedId, scope, reload]);
+  }, [selectedId, scope, reload, browse]);
 
   // Assemble the selected chunk + its sub-chunks into one Markdown string for the
   // markdown view (fetches each descendant's body; heading depth is relative to
@@ -123,7 +128,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
       n.children.forEach((c) => walk(c, depth + 1));
     };
     walk(node, 0);
-    Promise.all(items.map((it) => documentGetChunk(it.node.row.id, scope)))
+    Promise.all(items.map((it) => documentGetChunk(it.node.row.id, scope, browse)))
       .then((details) => {
         if (cancelled) return;
         const md = items
@@ -139,7 +144,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
     return () => {
       cancelled = true;
     };
-  }, [mode, selectedId, tree, scope, reload]);
+  }, [mode, selectedId, tree, scope, reload, browse]);
 
   const onSelect = useCallback((n: ChunkNode) => setSelectedId(n.row.id), []);
 
@@ -147,7 +152,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
   // metadata comments), independent of the selected-chunk view above.
   const download = useCallback(async () => {
     try {
-      const r = await documentExportMd(documentId, scope, true);
+      const r = await documentExportMd(documentId, scope, true, browse);
       const blob = new Blob([r.markdown], { type: "text/markdown" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -158,7 +163,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     }
-  }, [documentId, scope]);
+  }, [documentId, scope, browse]);
 
   return (
     <div className="doc-viewer">
@@ -276,6 +281,7 @@ export default function DocumentViewer({ documentId, scope, titleHint }: Documen
         <ChunkEditorModal
           chunk={editing}
           scope={scope}
+          browse={browse}
           onClose={() => setEditing(null)}
           onSaved={refresh}
         />

--- a/web/src/pages/PathTreeView.tsx
+++ b/web/src/pages/PathTreeView.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
 import {
+  type BrowseScope,
   type DocScope,
   type PathEntry,
   type PathScope,
@@ -10,6 +11,7 @@ import {
   pathMv,
   pathRm,
 } from "../api";
+import { useFocusTenant, useUserId } from "../components/Layout";
 import Splitter from "../components/Splitter";
 import DocumentViewer from "../components/DocumentViewer";
 import PathTree, {
@@ -64,11 +66,25 @@ export default function PathTreeView() {
   const [loading, setLoading] = useState(false);
   const [modal, setModal] = useState<ModalState | null>(null);
 
+  // RFC AS: the active subject + tenant focus from the topbar drive WHICH
+  // subject's tree this console browses (?scope_id= / ?tenant=). The server
+  // authorizes: an admin may target any subject/tenant; a substrate:tenant
+  // operator is confined to its own tenant but may browse any subject in it.
+  // Empty fields are omitted → the caller's own subject (default). Memoized on
+  // the primitives so changing the picked subject re-fetches without an
+  // identity-churn render loop.
+  const userId = useUserId();
+  const focusTenant = useFocusTenant();
+  const browse = useMemo<BrowseScope>(
+    () => ({ scopeId: userId || undefined, tenant: focusTenant || undefined }),
+    [userId, focusTenant],
+  );
+
   const refresh = useCallback(async () => {
     setLoading(true);
     setErr(null);
     try {
-      const resp = await pathLs("/", scope, true);
+      const resp = await pathLs("/", scope, true, browse);
       setEntries(resp.entries ?? []);
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
@@ -76,7 +92,7 @@ export default function PathTreeView() {
     } finally {
       setLoading(false);
     }
-  }, [scope]);
+  }, [scope, browse]);
 
   // Reload whenever the scope changes (and on mount). Clear the selection so a
   // stale path from the previous scope doesn't drive the detail pane.
@@ -110,12 +126,12 @@ export default function PathTreeView() {
         const name = v.name.trim();
         if (!NAME_RE.test(name)) throw new Error("name may contain only [A-Za-z0-9._-]");
         const p = joinPath(currentDir, name);
-        await pathMkdir(p, scope);
+        await pathMkdir(p, scope, browse);
         await refresh();
         setSelectedPath(p);
       },
     });
-  }, [currentDir, currentDirLabel, scope, refresh]);
+  }, [currentDir, currentDirLabel, scope, browse, refresh]);
 
   const newDocument = useCallback(() => {
     setModal({
@@ -130,12 +146,12 @@ export default function PathTreeView() {
         if (!NAME_RE.test(name)) throw new Error("name may contain only [A-Za-z0-9._-]");
         const title = v.title.trim() || name;
         const p = joinPath(currentDir, name);
-        await documentCreate(title, p, scope as DocScope);
+        await documentCreate(title, p, scope as DocScope, browse);
         await refresh();
         setSelectedPath(p);
       },
     });
-  }, [currentDir, currentDirLabel, scope, refresh]);
+  }, [currentDir, currentDirLabel, scope, browse, refresh]);
 
   const renameSelected = useCallback(() => {
     if (!selected) return;
@@ -146,12 +162,12 @@ export default function PathTreeView() {
       onSubmit: async (v) => {
         const to = v.to.trim();
         if (!to.startsWith("/")) throw new Error("path must start with /");
-        await pathMv(selected.fullPath, to, scope);
+        await pathMv(selected.fullPath, to, scope, browse);
         await refresh();
         setSelectedPath(to);
       },
     });
-  }, [selected, scope, refresh]);
+  }, [selected, scope, browse, refresh]);
 
   const deleteSelected = useCallback(() => {
     if (!selected) return;
@@ -166,7 +182,7 @@ export default function PathTreeView() {
         danger: true,
         onSubmit: async () => {
           if (!id) throw new Error("this document dirent has no document_id");
-          await documentDelete(id, scope as DocScope);
+          await documentDelete(id, scope as DocScope, browse);
           await refresh();
           setSelectedPath(undefined);
         },
@@ -191,14 +207,14 @@ export default function PathTreeView() {
       danger: true,
       onSubmit: async () => {
         for (const id of docIds) {
-          await documentDelete(id, scope as DocScope);
+          await documentDelete(id, scope as DocScope, browse);
         }
-        await pathRm(selected.fullPath, scope, true);
+        await pathRm(selected.fullPath, scope, true, browse);
         await refresh();
         setSelectedPath(undefined);
       },
     });
-  }, [selected, scope, refresh]);
+  }, [selected, scope, browse, refresh]);
 
   const mutable = selected && (selected.kind === "directory" || selected.kind === "document");
 
@@ -244,6 +260,16 @@ export default function PathTreeView() {
           </div>
           <p className="paths-context">
             new items → <code>{currentDirLabel}</code>
+            {browse.scopeId && (
+              <>
+                {" · "}subject <code>{browse.scopeId}</code>
+              </>
+            )}
+            {browse.tenant && (
+              <>
+                {" · "}tenant <code>{browse.tenant}</code>
+              </>
+            )}
           </p>
           {err && <div className="paths-err">{err}</div>}
           {loading && entries.length === 0 ? (
@@ -273,6 +299,7 @@ export default function PathTreeView() {
                   documentId={(selected.resourceRef as { document_id?: string })?.document_id ?? ""}
                   scope={scope === "agent" ? "agent" : "user"}
                   titleHint={selected.name}
+                  browse={browse}
                 />
               </div>
             ) : (


### PR DESCRIPTION
## Why

The Path/Document console only ever showed the **logged-in principal's own** subject's tree — so a doc an MCP agent created under its own subject was unreachable from the UI (confirmed live: every scope was empty for the viewing token). #582 shipped the backend (`?scope_id=` / `?tenant=` with admin/tenant authz). This is the visible half — wiring the Web UI to drive it, per your spec: *admin sees every primitive; a tenant sees its own tenant's; the user picker accepts a manually-entered subject.*

## What

- **`api.ts`** — a `BrowseScope { scopeId?, tenant? }` threaded (optional, trailing) through `substratePost` + the path/document functions, appended as `?scope_id=` / `?tenant=`. Unset → omitted → caller's own subject (**byte-identical** to before; no existing call site changes).
- **`PathTreeView`** — reads the topbar picker subject (`useUserId`) + the admin tenant focus (`useFocusTenant`) into a memoized `browse`, threaded through ls / mkdir / mv / rm / document create+delete and into `DocumentViewer`. A toolbar hint shows the active subject/tenant.
- **`DocumentViewer` + `ChunkEditorModal`** — take a `browse` prop, threaded through query_chunks / get_chunk / export_md / update_chunk, so **viewing and editing** operate under the browsed subject.

The topbar user-picker already supports manual subject entry and is shown to tenant operators, so an operator just types a subject to switch the browsed tree. The server re-authorizes: **admin → any subject/tenant; substrate:tenant → its own tenant, any subject in it** (`substrateBrowseCtxFn`, #582). The DocumentAssistant (agent spawn) is a separate mechanism and stays in the caller's own scope — out of scope here.

## What was tested

- `npm run build` (tsc + vite) clean; `make build-all` embeds + builds the binary clean.
- Backend authz is covered by `TestSubstrateBrowseCtxFn_Authz` (#582, merged): admin may cross; a `substrate:tenant` principal's `?tenant=` is ignored.
- No vitest harness in `web/`; the embedded `dist/` is gitignored (CI/`make build-all` rebuild) — this PR commits only `web/src`.

Acceptance (post-deploy): log in, type the marketing agent's subject in the topbar picker, open its `/docs/marketing/...` tree. (Note: that doc may need re-creating now that SQL-Memory `CREATEROLE` is granted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)