### PR TITLE
feat(authz): tenant-scope the audit/event log via the owning session (RFC AS)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -500,9 +500,16 @@ func requiredScopeFor(method, path string) string {
 	// live at /v1/_scheduledef (isTenantConfinedDefPath, already ScopeTenant).
 	case strings.HasPrefix(path, "/v1/_schedules/"):
 		return auth.ScopeTenant
+	// RFC AS: the audit/event log. events carry no tenant column, but each is
+	// tied to a session (events.session_id NOT NULL) whose tenant_id is the
+	// event's tenant — so handleListEvents tenant-scopes the result (a tenant
+	// sees only its own tenant's events; admin sees all + the ?tenant= focus).
+	// ScopeAdmin also satisfies. Read-only GET.
+	case path == "/v1/_events":
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
-	// resolver, audit, cross-tenant user focus.
+	// resolver, cross-tenant user focus.
 	case strings.HasPrefix(path, "/v1/_"):
 		return auth.ScopeAdmin
 	// Hook registration / list / delete — RFC AF: tenant-confined. The hook

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -252,6 +252,9 @@ func TestRequiredScopeFor(t *testing.T) {
 		{"POST", "/v1/_schedules/sd_1/run-now", auth.ScopeTenant},
 		{"POST", "/v1/_schedules/sd_1/pause", auth.ScopeTenant},
 		{"POST", "/v1/_schedules/sd_1/resume", auth.ScopeTenant},
+		// RFC AS: the audit/event log is tenant-reachable (handleListEvents
+		// scopes the result via the event's owning session's tenant).
+		{"GET", "/v1/_events", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/api/http/events_audit.go
+++ b/internal/api/http/events_audit.go
@@ -98,6 +98,13 @@ func (s *Server) handleListEvents(w http.ResponseWriter, r *http.Request) {
 		offset = n
 	}
 
+	// RFC AS: tenant-scope the audit. admin / legacy / open see all (honoring an
+	// optional ?tenant= focus); a substrate:tenant principal sees only its own
+	// tenant's events (ListEvents filters via the owning session's tenant).
+	if tenantID, all := s.principalTenantScope(r.Context(), q.Get("tenant")); !all {
+		filter.TenantID = tenantID
+	}
+
 	events, total, err := s.store.ListEvents(r.Context(), filter, limit, offset)
 	if err != nil {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -525,19 +525,31 @@ func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit,
 		args  []any
 		i     = 1
 	)
+	// Columns are qualified with the `events.` table name so the optional
+	// sessions JOIN below stays unambiguous (valid with or without the JOIN).
 	if filter.Type != "" {
-		conds = append(conds, fmt.Sprintf("type = $%d", i))
+		conds = append(conds, fmt.Sprintf("events.type = $%d", i))
 		args = append(args, filter.Type)
 		i++
 	}
 	if !filter.From.IsZero() {
-		conds = append(conds, fmt.Sprintf("ts >= $%d", i))
+		conds = append(conds, fmt.Sprintf("events.ts >= $%d", i))
 		args = append(args, filter.From)
 		i++
 	}
 	if !filter.To.IsZero() {
-		conds = append(conds, fmt.Sprintf("ts <= $%d", i))
+		conds = append(conds, fmt.Sprintf("events.ts <= $%d", i))
 		args = append(args, filter.To)
+		i++
+	}
+	// RFC AS: tenant-scope via the owning session. events has no tenant column,
+	// but events.session_id is NOT NULL → sessions.tenant_id is the event's
+	// tenant. Empty TenantID = no filter (all tenants — the admin view).
+	from := "events"
+	if filter.TenantID != "" {
+		from = "events JOIN sessions ON sessions.id = events.session_id"
+		conds = append(conds, fmt.Sprintf("sessions.tenant_id = $%d", i))
+		args = append(args, filter.TenantID)
 		i++
 	}
 	where := ""
@@ -546,14 +558,14 @@ func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit,
 	}
 
 	var total int64
-	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM events "+where, args...).Scan(&total); err != nil {
+	if err := s.pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+from+" "+where, args...).Scan(&total); err != nil {
 		return nil, 0, fmt.Errorf("count events: %w", err)
 	}
 
 	args = append(args, limit, offset)
 	rows, err := s.pool.Query(ctx,
-		"SELECT seq, session_id, run_id, ts, type, payload FROM events "+where+
-			fmt.Sprintf(" ORDER BY ts DESC, seq DESC LIMIT $%d OFFSET $%d", i, i+1),
+		"SELECT events.seq, events.session_id, events.run_id, events.ts, events.type, events.payload FROM "+from+" "+where+
+			fmt.Sprintf(" ORDER BY events.ts DESC, events.seq DESC LIMIT $%d OFFSET $%d", i, i+1),
 		args...,
 	)
 	if err != nil {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1268,17 +1268,28 @@ func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit,
 		conds []string
 		args  []any
 	)
+	// Columns are qualified with the `events.` table name so the optional
+	// sessions JOIN below stays unambiguous (valid with or without the JOIN).
 	if filter.Type != "" {
-		conds = append(conds, "type = ?")
+		conds = append(conds, "events.type = ?")
 		args = append(args, filter.Type)
 	}
 	if !filter.From.IsZero() {
-		conds = append(conds, "ts >= ?")
+		conds = append(conds, "events.ts >= ?")
 		args = append(args, filter.From.UnixNano())
 	}
 	if !filter.To.IsZero() {
-		conds = append(conds, "ts <= ?")
+		conds = append(conds, "events.ts <= ?")
 		args = append(args, filter.To.UnixNano())
+	}
+	// RFC AS: tenant-scope via the owning session. events has no tenant column,
+	// but events.session_id is NOT NULL → sessions.tenant_id is the event's
+	// tenant. Empty TenantID = no filter (all tenants — the admin view).
+	from := "events"
+	if filter.TenantID != "" {
+		from = "events JOIN sessions ON sessions.id = events.session_id"
+		conds = append(conds, "sessions.tenant_id = ?")
+		args = append(args, filter.TenantID)
 	}
 	where := ""
 	if len(conds) > 0 {
@@ -1289,14 +1300,14 @@ func (s *Store) ListEvents(ctx context.Context, filter store.EventFilter, limit,
 	// complexity on SQLite. Cheap because the WHERE narrows via the
 	// new indexes.
 	var total int64
-	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM events "+where, args...).Scan(&total); err != nil {
+	if err := s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+from+" "+where, args...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
 	args = append(args, limit, offset)
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT seq, session_id, run_id, ts, type, payload FROM events "+where+
-			" ORDER BY ts DESC, seq DESC LIMIT ? OFFSET ?",
+		"SELECT events.seq, events.session_id, events.run_id, events.ts, events.type, events.payload FROM "+from+" "+where+
+			" ORDER BY events.ts DESC, events.seq DESC LIMIT ? OFFSET ?",
 		args...,
 	)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -279,6 +279,12 @@ type EventFilter struct {
 	Type string
 	From time.Time
 	To   time.Time
+	// TenantID, when non-empty, restricts the result to events whose owning
+	// session belongs to that tenant (RFC AS — tenant-scoped audit). The events
+	// table carries no tenant column, but events.session_id is NOT NULL and
+	// sessions.tenant_id is the event's tenant, so ListEvents JOINs sessions
+	// when this is set. Empty = no tenant filter (every tenant — the admin view).
+	TenantID string
 }
 
 // Event is one streamed datum, persisted append-only. Payload is the JSON

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -324,6 +324,7 @@ func Run(t *testing.T, factory Factory) {
 		{"InterruptIDIsMonotonicByTime", testInterruptIDIsMonotonicByTime},
 		// v0.8.21 audit-view cross-session event listing.
 		{"ListEventsFilterByTypeAndRange", testListEventsFilterByTypeAndRange},
+		{"ListEventsFilterByTenant", testListEventsFilterByTenant},
 		{"ListEventsPaginationAndTotal", testListEventsPaginationAndTotal},
 		// v0.8.21 awaited-state derivation needs last-event-per-run.
 		{"GetLastEventForRunEmpty", testGetLastEventForRunEmpty},
@@ -6770,6 +6771,54 @@ func testListEventsFilterByTypeAndRange(t *testing.T, s store.Store) {
 	}
 	if total3 != 1 || len(got3) != 1 || got3[0].Type != "tool_call" {
 		t.Errorf("type+to mismatch: total=%d got=%v", total3, got3)
+	}
+}
+
+// testListEventsFilterByTenant pins the RFC AS tenant-scoped audit: EventFilter
+// .TenantID restricts the result to events whose owning session belongs to that
+// tenant (events carry no tenant column — the filter JOINs sessions). Empty
+// TenantID returns every tenant's events.
+func testListEventsFilterByTenant(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	acme, _ := s.CreateSession(ctx, "acme", "default", "alice")
+	acmeRun, _ := s.CreateRun(ctx, acme.ID, store.RunIdentity{AgentID: "a_acme"})
+	globex, _ := s.CreateSession(ctx, "globex", "default", "bob")
+	globexRun, _ := s.CreateRun(ctx, globex.ID, store.RunIdentity{AgentID: "a_globex"})
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(ctx, acmeRun.ID, "text", []byte(`{"t":"acme"}`)); err != nil {
+			t.Fatalf("AppendEvent acme: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if err := s.AppendEvent(ctx, globexRun.ID, "text", []byte(`{"t":"globex"}`)); err != nil {
+			t.Fatalf("AppendEvent globex: %v", err)
+		}
+	}
+
+	// Tenant filter → only that tenant's events (via the owning session).
+	got, total, err := s.ListEvents(ctx, store.EventFilter{TenantID: "acme"}, 50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(got) != 3 {
+		t.Fatalf("tenant=acme total=%d len=%d, want 3/3", total, len(got))
+	}
+	for _, ev := range got {
+		if ev.SessionID != acme.ID {
+			t.Errorf("tenant=acme leaked event from session %q (want %q)", ev.SessionID, acme.ID)
+		}
+	}
+	// No tenant filter → both tenants (5 total).
+	if _, totalAll, err := s.ListEvents(ctx, store.EventFilter{}, 50, 0); err != nil {
+		t.Fatal(err)
+	} else if totalAll != 5 {
+		t.Errorf("no tenant filter total = %d, want 5 (both tenants)", totalAll)
+	}
+	// Tenant + type compose (still tenant-scoped).
+	if _, totalCombo, err := s.ListEvents(ctx, store.EventFilter{TenantID: "globex", Type: "text"}, 50, 0); err != nil {
+		t.Fatal(err)
+	} else if totalCombo != 2 {
+		t.Errorf("tenant=globex type=text total = %d, want 2", totalCombo)
 	}
 }
 

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -67,7 +67,9 @@ const NAV_ITEMS: NavItem[] = [
   { to: "/interrupts", label: "interrupts", Icon: Bell, vis: "tenant" },
   { to: "/memory", label: "memory", Icon: Brain, vis: "admin" },
   { to: "/snapshots", label: "snapshots", Icon: Camera, vis: "admin" },
-  { to: "/audit", label: "audit", Icon: ScrollText, vis: "admin" },
+  // audit is tenant-visible (RFC AS): handleListEvents tenant-scopes the result
+  // via the event's owning session, so a tenant sees only its own events.
+  { to: "/audit", label: "audit", Icon: ScrollText, vis: "tenant" },
   { to: "/activity", label: "activity", Icon: Activity, vis: "admin" },
 ];
 


### PR DESCRIPTION
## Why

The audit view (`GET /v1/_events`) was `ScopeAdmin` and returned **every tenant's events** — a tenant operator couldn't see its own audit trail (nav item was admin-only; opening the route as-is would have leaked cross-tenant). This is **item 2** of the three you approved. The `events` table has no tenant column, but `events.session_id` is `NOT NULL` and `sessions.tenant_id` is the event's tenant — so a JOIN scopes it **without a schema migration** (your chosen approach).

## What

- **store** — `EventFilter` gains `TenantID`; `ListEvents` (sqlite + postgres) qualifies its columns with `events.` and, when `TenantID` is set, JOINs `sessions` (`sessions.id = events.session_id`) and filters `sessions.tenant_id`. Empty `TenantID` = no filter (all tenants) — **byte-identical** to before.
- **handler** — `handleListEvents` sets `filter.TenantID` from `principalTenantScope`: admin / legacy / open see all (honoring an optional `?tenant=` focus); a `substrate:tenant` principal sees only its own tenant's events.
- **route gate** — `/v1/_events` → `ScopeTenant` (`ScopeAdmin` still satisfies).
- **Web UI** — the `audit` nav item moves from admin-only to the `tenant` visibility class.

## What was tested

- New **`ListEventsFilterByTenant` store-contract test** — runs on **both sqlite and postgres** (closes the PG-parity gap that hid a past store bug, BUG-2): seeds two tenants' sessions+events, asserts the filter scopes correctly and composes with `Type`. **Revert-checked**: without the JOIN, `tenant=acme` returns all 5 (want 3).
- `TestRequiredScopeFor` gains `/v1/_events` → `ScopeTenant`.
- `go test ./...` green except the pre-existing env-only `TestLoadExample` (`/work/sandbox` must exist on disk; fails identically on `main`). `make build-all` clean.

This completes RFC AS items 1–3 (PRs #583, #584, this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)