### PR TITLE
fix(authz): surface inline top-level skills in the Library (RFC AQ bundles)

### DIFF
--- a/internal/api/http/library_unified.go
+++ b/internal/api/http/library_unified.go
@@ -159,14 +159,33 @@ func (s *Server) handleListLibrarySkills(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	staticNames := s.skillSet.Names() // nil-safe — Set.Names handles nil receiver
-	entries := make([]LibraryEntry, 0, len(staticNames)+len(subRows))
-	seen := map[string]struct{}{}
+	// Static skills come from TWO sources, merged (inline OVERLAYS root on a name
+	// collision, matching resolveSkills): the SkillsRoot-loaded skillSet AND the
+	// inline top-level `skills:` map (cfg.Skills). RFC AQ bundles define their
+	// skills inline via cfg.Skills — resolveSkills bakes those bodies into agent
+	// prompts but they never enter the root-loaded skillSet, so without this
+	// merge a bundled skill was invisible in the Library for EVERY principal
+	// (the agents handler reads cfg.Agents; this one only read the root set).
+	// Operator-global catalog floor — shown to every principal incl. a tenant
+	// operator (see handleListLibraryAgents).
+	staticSkills := map[string]*skills.Skill{}
+	for _, name := range s.skillSet.Names() { // nil-safe — Set.Names handles nil receiver
+		if sk, ok := s.skillSet.Get(name); ok {
+			staticSkills[name] = sk
+		}
+	}
+	for name, spec := range s.cfg.Skills {
+		staticSkills[name] = &skills.Skill{
+			Name:         name,
+			Description:  spec.Description,
+			AllowedTools: spec.AllowedTools,
+			Body:         spec.Body,
+		}
+	}
 
-	// Operator-global static skills — the shared catalog floor, shown to every
-	// principal incl. a tenant operator (see handleListLibraryAgents).
-	for _, name := range staticNames {
-		sk, _ := s.skillSet.Get(name)
+	entries := make([]LibraryEntry, 0, len(staticSkills)+len(subRows))
+	seen := map[string]struct{}{}
+	for name, sk := range staticSkills {
 		entry := LibraryEntry{
 			Name:             name,
 			InStatic:         true,

--- a/internal/api/http/library_unified_test.go
+++ b/internal/api/http/library_unified_test.go
@@ -483,3 +483,41 @@ func TestUnifiedLibrary_Agents_AdminTenantFocus(t *testing.T) {
 		t.Fatalf("admin ?tenant=acme sees %v, want [acme-agent global-static] (focused tenant + shared static, no globex)", names)
 	}
 }
+
+// TestUnifiedLibrary_Skills_InlineCfgSurfaced pins that inline top-level
+// `skills:` (cfg.Skills — how RFC AQ bundles define their skills) are surfaced
+// in the Library, to BOTH admin and a tenant operator. Fail-before: the handler
+// read only the SkillsRoot-loaded skillSet, so a bundled inline skill (not in
+// the root) was invisible to everyone (the deployed document-agent's four skills
+// showed 0).
+func TestUnifiedLibrary_Skills_InlineCfgSurfaced(t *testing.T) {
+	srv, _, cleanup := libraryUnifiedFixture(t, nil, nil)
+	defer cleanup()
+	srv.cfg.Skills = map[string]config.SkillSpec{
+		"semantic-chunking": {
+			Description:  "split prose into a chunk hierarchy",
+			AllowedTools: []string{"Document"},
+			Body:         "# Semantic chunking\n\nMethod…",
+		},
+	}
+	call := func(p auth.Principal) []LibraryEntry {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/v1/_library/skills", nil)
+		req = req.WithContext(auth.WithPrincipal(req.Context(), p))
+		srv.handleListLibrarySkills(rec, req)
+		return decodeLibraryEntries(t, rec)
+	}
+	// Admin sees the inline skill (was invisible — only the root set was read).
+	admin := call(auth.Principal{TenantID: "default", Subject: "ops", Scopes: []string{auth.ScopeAdmin}})
+	if len(admin) != 1 || admin[0].Name != "semantic-chunking" || !admin[0].InStatic {
+		t.Fatalf("admin sees %+v, want 1 in_static [semantic-chunking]", admin)
+	}
+	if len(admin[0].StaticDefinition) == 0 {
+		t.Errorf("inline skill should carry static_definition (body/description)")
+	}
+	// A tenant operator sees it too (shared catalog floor, #580).
+	tenant := call(auth.Principal{TenantID: "acme", Subject: "op", Scopes: []string{auth.ScopeTenant}})
+	if len(tenant) != 1 || tenant[0].Name != "semantic-chunking" {
+		t.Fatalf("tenant sees %+v, want [semantic-chunking]", tenant)
+	}
+}


### PR DESCRIPTION
## Why

On the live v1.6.4 box, the tenant token sees 13 agents but **0 skills** — and so does admin. RFC AQ bundles (e.g. `document-agent`'s four skills) define their skills **inline** under the top-level `skills:` map (`cfg.Skills`). `resolveSkills` bakes those bodies into the agents' system prompts and then **discards** its union set; `main.go` loads the server's `skillSet` from `LOOMCYCLE_SKILLS_ROOT` only. So a bundled inline skill never entered the enumerated set, and `handleListLibrarySkills` (which read only `skillSet`) showed it to **no one**. The agents handler reads `cfg.Agents`; the skills handler didn't read the parallel inline source.

## What

`handleListLibrarySkills` now merges **both** sources — the root `skillSet` UNION `cfg.Skills` (inline overlays root on a name collision, matching `resolveSkills`), each built into a `skills.Skill` for `marshalStaticSkill`. Operator-global → shown to every principal incl. a tenant operator (the #580 catalog-floor posture).

**MCP servers need no change**: bundles ship none (`mcp_servers: {}`), and the mcp-servers handler already reads `cfg.MCPServers` as a single source (shown to tenants since #580) — an empty list just means none are configured in the deployment. (A static MCP server added to the overlay, or a tenant `MCPServerDef`, shows up automatically.)

## What was tested

- `TestUnifiedLibrary_Skills_InlineCfgSurfaced` — seeds `cfg.Skills`, asserts both admin and a tenant operator see the inline skill with its `static_definition`. **Revert-checked**: admin saw `[]` on the unfixed handler.
- `go test ./internal/api/http/` green; `go build` clean. Backend-only — the Web UI skills tab already renders these entries.

## Note on the marketing document (separate)

Still investigating live: the doc isn't reachable under any scope/subject I swept in the `loomcycle-dev` tenant. Most likely it **never persisted** — it was created *before* you granted `CREATEROLE`, so SQL-Memory provisioning failed and no dirent/document was written. The browse-by-subject feature itself works (verified). Re-running the marketing agent now (Documents work post-grant) should create it; then the topbar subject picker will reach it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)