### PR TITLE
feat(context): Context op=self reports tenant, principal credentials + server URL

### DIFF
--- a/cmd/loomcycle/embedded/env.insecure.example
+++ b/cmd/loomcycle/embedded/env.insecure.example
@@ -39,6 +39,11 @@ OLLAMA_BASE_URL=http://localhost:11434
 # (The bearer token /v1 routes require is a secret — set LOOMCYCLE_AUTH_TOKEN
 # in .env.local.)
 LOOMCYCLE_LISTEN_ADDR=127.0.0.1:8787
+# The externally-reachable base URL for THIS instance (e.g. behind a tunnel/
+# proxy). Advertised to agents via `Context op=self` (server.url) so an agent —
+# especially one over the MCP transport — can identify the server it's talking
+# to. Optional; unset → self reports only the bind address.
+# LOOMCYCLE_PUBLIC_URL=https://loomcycle.example.com
 
 # ─── Storage ──────────────────────────────────────────────────────────
 LOOMCYCLE_DATA_DIR=./data

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1919,7 +1919,14 @@ type Env struct {
 	// rather than the public AI Studio API. Empty = public endpoint.
 	GeminiBaseURL string
 	ListenAddr    string
-	AuthToken     string
+	// PublicURL is the operator's externally-reachable base URL for THIS
+	// loomcycle instance (e.g. behind a tunnel/proxy). Advertised to agents via
+	// `Context op=self` (server.url) so an agent — especially one connected over
+	// the MCP transport — can identify the server it's talking to. Empty = unset;
+	// self then reports only the bind ListenAddr (and the A2A advertise URL if
+	// that's configured). LOOMCYCLE_PUBLIC_URL.
+	PublicURL string
+	AuthToken string
 	// OperatorTokenPepper is prepended to a bearer before SHA-256 when
 	// hashing OperatorTokenDef tokens (RFC L). A stolen DB dump without
 	// the pepper yields no usable token lookup. Secret — never logged.
@@ -2728,6 +2735,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		GeminiAPIKey:              os.Getenv("GEMINI_API_KEY"),
 		GeminiBaseURL:             os.Getenv("GEMINI_BASE_URL"),
 		ListenAddr:                getenvDefault("LOOMCYCLE_LISTEN_ADDR", "127.0.0.1:8787"),
+		PublicURL:                 strings.TrimRight(strings.TrimSpace(os.Getenv("LOOMCYCLE_PUBLIC_URL")), "/"),
 		AuthToken:                 os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
 		OperatorTokenPepper:       os.Getenv("LOOMCYCLE_OPERATOR_TOKEN_PEPPER"),
 		AuditLogPath:              os.Getenv("LOOMCYCLE_AUDIT_LOG_PATH"),

--- a/internal/tools/builtin/context.go
+++ b/internal/tools/builtin/context.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/help"
 	"github.com/denn-gubsky/loomcycle/internal/providers"
@@ -28,8 +29,10 @@ import (
 //
 // Nine ops total — PR 1 ships four of them:
 //
-//	self        — identity bundle (agent name, run/agent ids, user, tier,
-//	              resolved provider + model + sampling)
+//	self        — identity bundle (agent name, run/agent ids, user, tenant,
+//	              tier, resolved provider + model + sampling; the `principal`
+//	              credential block — subject/tenant/scopes/token id, never the
+//	              bearer; and the `server` it's connected to — listen_addr + url)
 //	tools       — post-filter tool catalog
 //	doc         — detailed schema/docstring for one tool by name
 //	permissions — gates that apply to the caller (tool ACL, host policy, scopes)
@@ -189,9 +192,15 @@ func (c *Context) execCompact(ctx context.Context) (tools.Result, error) {
 func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 	ident := tools.RunIdentity(ctx)
 	out := map[string]any{
-		"agent_name":   tools.AgentName(ctx),
-		"agent_id":     ident.AgentID,
-		"user_id":      ident.UserID,
+		"agent_name": tools.AgentName(ctx),
+		"agent_id":   ident.AgentID,
+		"user_id":    ident.UserID,
+		// tenant_id is the RFC L data-isolation boundary this run acts within
+		// (paired with user_id). Non-secret; always stamped on the run identity
+		// ("" / "default" for the single-tenant/legacy case). Surfaced so an
+		// agent — especially one over the MCP transport — can tell which tenant
+		// it's operating as.
+		"tenant_id":    ident.TenantID,
 		"user_tier":    ident.UserTier,
 		"agent_def_id": ident.AgentDefID,
 		// run_id is the store row id (r_<hex>). Surfacing it lets
@@ -284,6 +293,42 @@ func (c *Context) execSelf(ctx context.Context) (tools.Result, error) {
 		out["network"] = map[string]any{
 			"allowed_hosts": nonNilStrings(c.Cfg.Env.HTTPHostAllowlist),
 			"source":        "operator_default",
+		}
+	}
+	// principal: the resolved auth identity (RFC L) — WHO this run acts as and
+	// what its credential may do. Non-secret: subject + tenant + scopes + the
+	// token DEF id and the 6-char log-correlation suffix; NEVER the bearer
+	// itself. Present when the run carries an authenticated principal (every MCP
+	// / authed-HTTP path — the case where an agent needs to identify its own
+	// credentials); omitted in open mode (no auth configured), where the flat
+	// tenant_id / user_id above are still the identity.
+	if p, ok := auth.PrincipalFromContext(ctx); ok {
+		out["principal"] = map[string]any{
+			"tenant_id":    p.TenantID,
+			"subject":      p.Subject,
+			"scopes":       nonNilStrings(p.Scopes),
+			"is_admin":     auth.HasScope(p.Scopes, auth.ScopeAdmin),
+			"legacy":       p.Legacy,
+			"token_def_id": p.TokenDefID,
+			"token_suffix": p.TokenSuffix,
+		}
+	}
+	// server: which loomcycle instance this run is on, so an agent (especially an
+	// MCP client) can identify the server it's connected to. listen_addr is the
+	// bind address; url is the operator's advertised public base URL
+	// (LOOMCYCLE_PUBLIC_URL, falling back to the A2A advertise URL) when set.
+	if c.Cfg != nil {
+		server := map[string]any{}
+		if c.Cfg.Env.ListenAddr != "" {
+			server["listen_addr"] = c.Cfg.Env.ListenAddr
+		}
+		if u := c.Cfg.Env.PublicURL; u != "" {
+			server["url"] = u
+		} else if u := c.Cfg.Env.A2APublicBaseURL; u != "" {
+			server["url"] = u
+		}
+		if len(server) > 0 {
+			out["server"] = server
 		}
 	}
 	return okJSON(out)

--- a/internal/tools/builtin/context_test.go
+++ b/internal/tools/builtin/context_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/help"
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -52,6 +53,7 @@ func contextFixture(t *testing.T) (*Context, context.Context) {
 	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{
 		AgentID:    "a_test",
 		UserID:     "alice",
+		TenantID:   "acme",
 		UserTier:   "medium",
 		AgentDefID: "def_abc",
 	})
@@ -81,6 +83,11 @@ func TestContextTool_SelfReturnsIdentity(t *testing.T) {
 	}
 	if out["user_id"] != "alice" {
 		t.Errorf("user_id = %v, want alice", out["user_id"])
+	}
+	// tenant_id: the RFC L isolation boundary, surfaced so an agent can identify
+	// which tenant it acts within.
+	if out["tenant_id"] != "acme" {
+		t.Errorf("tenant_id = %v, want acme", out["tenant_id"])
 	}
 	if out["user_tier"] != "medium" {
 		t.Errorf("user_tier = %v, want medium", out["user_tier"])
@@ -1173,5 +1180,92 @@ func TestContextTool_HelpUnknownTopic(t *testing.T) {
 	}
 	if !strings.Contains(res.Text, "available:") {
 		t.Errorf("error should list available topics: %q", res.Text)
+	}
+}
+
+// TestContextTool_SelfPrincipalAndServer pins the identity additions to op=self:
+// the `principal` block (the authenticated credential — subject/tenant/scopes/
+// token id + suffix, NEVER the bearer) and the `server` block (listen_addr +
+// the advertised public url), so an MCP agent can identify its credentials and
+// the server it's connected to.
+func TestContextTool_SelfPrincipalAndServer(t *testing.T) {
+	tool := &Context{
+		Cfg: &config.Config{Env: config.Env{
+			ListenAddr: "0.0.0.0:8787",
+			PublicURL:  "https://loomcycle.example.com",
+		}},
+	}
+	ctx := tools.WithAgentName(context.Background(), "worker")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a1", UserID: "tok-acme-svc", TenantID: "acme"})
+	ctx = auth.WithPrincipal(ctx, auth.Principal{
+		TenantID:    "acme",
+		Subject:     "tok-acme-svc",
+		Scopes:      []string{auth.ScopeTenant, auth.ScopeRunsCreate},
+		TokenDefID:  "def_marketing",
+		TokenSuffix: "ab12cd",
+	})
+
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
+	if res.IsError {
+		t.Fatalf("self: %s", res.Text)
+	}
+	out := decodeResult(t, res.Text)
+
+	if out["tenant_id"] != "acme" {
+		t.Errorf("tenant_id = %v, want acme", out["tenant_id"])
+	}
+
+	p, ok := out["principal"].(map[string]any)
+	if !ok {
+		t.Fatalf("principal block missing/wrong type: %v (%T)", out["principal"], out["principal"])
+	}
+	if p["subject"] != "tok-acme-svc" || p["tenant_id"] != "acme" {
+		t.Errorf("principal identity wrong: %+v", p)
+	}
+	if p["token_def_id"] != "def_marketing" || p["token_suffix"] != "ab12cd" {
+		t.Errorf("principal token id/suffix wrong: %+v", p)
+	}
+	if p["is_admin"] != false || p["legacy"] != false {
+		t.Errorf("principal flags wrong: is_admin=%v legacy=%v", p["is_admin"], p["legacy"])
+	}
+	scopes, _ := p["scopes"].([]any)
+	if len(scopes) != 2 {
+		t.Errorf("principal scopes = %v, want 2", p["scopes"])
+	}
+	// The bearer must NEVER appear.
+	if strings.Contains(res.Text, "Bearer") || strings.Contains(strings.ToLower(res.Text), "secret") {
+		t.Errorf("self leaked a secret-looking field:\n%s", res.Text)
+	}
+
+	srv, ok := out["server"].(map[string]any)
+	if !ok {
+		t.Fatalf("server block missing/wrong type: %v", out["server"])
+	}
+	if srv["listen_addr"] != "0.0.0.0:8787" {
+		t.Errorf("server.listen_addr = %v, want 0.0.0.0:8787", srv["listen_addr"])
+	}
+	if srv["url"] != "https://loomcycle.example.com" {
+		t.Errorf("server.url = %v, want the public url", srv["url"])
+	}
+}
+
+// TestContextTool_SelfServerFallsBackToA2AURL pins that when LOOMCYCLE_PUBLIC_URL
+// is unset, server.url falls back to the A2A advertise URL (and listen_addr is
+// always present).
+func TestContextTool_SelfServerFallsBackToA2AURL(t *testing.T) {
+	tool := &Context{Cfg: &config.Config{Env: config.Env{
+		ListenAddr:       "127.0.0.1:8787",
+		A2APublicBaseURL: "https://a2a.example.com",
+	}}}
+	ctx := tools.WithRunIdentity(context.Background(), tools.RunIdentityValue{AgentID: "a1"})
+	res, _ := tool.Execute(ctx, json.RawMessage(`{"op":"self"}`))
+	out := decodeResult(t, res.Text)
+	srv, _ := out["server"].(map[string]any)
+	if srv == nil || srv["url"] != "https://a2a.example.com" || srv["listen_addr"] != "127.0.0.1:8787" {
+		t.Errorf("server fallback wrong: %+v", out["server"])
+	}
+	// Open mode (no principal) → no principal block, but identity still present.
+	if _, hasP := out["principal"]; hasP {
+		t.Errorf("principal block should be omitted in open mode (no auth principal)")
 	}
 }


### PR DESCRIPTION
## Why

An agent — especially one connected over the **MCP transport** — couldn't identify its **tenant**, its **credential**, or which **loomcycle server** it's talking to from `Context op=self`. It surfaced `agent_id` / `user_id` / `provider` / `model`, but not the tenant, the auth principal, or a server URL.

## What

`execSelf` now also returns:

- **`tenant_id`** — the RFC L isolation boundary (from `RunIdentity`; always present, paired with `user_id`).
- **`principal`** — the resolved auth identity, present when the run carries one (every MCP / authed-HTTP path): `subject`, `tenant_id`, `scopes`, `is_admin`, `legacy`, `token_def_id`, and the 6-char `token_suffix` log handle. **Non-secret — never the bearer.** Omitted in open mode (no principal); the flat `tenant_id`/`user_id` remain.
- **`server`** — `{ listen_addr, url }` so the agent can identify the instance. `url` is a new **`LOOMCYCLE_PUBLIC_URL`** (the operator's advertised external base URL), falling back to the A2A advertise URL when that's all that's set; `listen_addr` is always the bind address.

All additive tool output, so it flows through **every transport** (MCP / HTTP `/v1/_context`-style dispatch / in-band) with no wire change. Adds `LOOMCYCLE_PUBLIC_URL` to config + the embedded env template, and updates the self-op doc.

## What was tested

- `TestContextTool_SelfReturnsIdentity` gains a `tenant_id` assertion.
- `TestContextTool_SelfPrincipalAndServer` — the `principal` + `server` blocks (subject/tenant/scopes/token id+suffix, `is_admin`/`legacy`), and **asserts no `Bearer`/secret-looking field leaks**.
- `TestContextTool_SelfServerFallsBackToA2AURL` — `url` falls back to the A2A advertise URL; `principal` omitted in open mode.
- `go test ./internal/tools/builtin/` green; `go build` clean.

Candidate for the next patch (v1.6.7). After deploy, set `LOOMCYCLE_PUBLIC_URL` on the VM so agents see the real server URL (else they get the bind `listen_addr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)