### PR TITLE
docs(truenas): wire LOOMCYCLE_PUBLIC_URL in the deploy compose + INSTALL.md

### DIFF
--- a/deploy/truenas/INSTALL.md
+++ b/deploy/truenas/INSTALL.md
@@ -164,6 +164,7 @@ services:
     environment:
       # --- non-secret ("insecure") operational config — safe to keep inline ---
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
+      LOOMCYCLE_PUBLIC_URL: "http://TRUENAS_SCALE_HOST:8787"   # externally-reachable base URL (your tunnel/proxy host, or this for direct LAN); agents read it via `Context op=self` (≥ v1.6.7)
       LOOMCYCLE_PRESETS: "base,document-agent"   # base matrix + the Document Assistant
       LOOMCYCLE_CONFIG_DIR: /config
       LOOMCYCLE_STORAGE_BACKEND: postgres

--- a/deploy/truenas/docker-compose.yaml
+++ b/deploy/truenas/docker-compose.yaml
@@ -49,6 +49,11 @@ services:
     environment:
       # Bind all interfaces inside the container (the port mapping above reaches it).
       LOOMCYCLE_LISTEN_ADDR: "0.0.0.0:8787"
+      # The externally-reachable base URL agents see via `Context op=self`
+      # (server.url) so an agent — especially over MCP — can identify the server
+      # it's talking to. Set it to however you front this app (your tunnel/proxy
+      # hostname). Optional (≥ v1.6.7; older tags ignore it).
+      LOOMCYCLE_PUBLIC_URL: ${LOOMCYCLE_PUBLIC_URL:-}
 
       # Provider/tier base from the embedded presets (RFC AQ). Add bundles/overlays:
       #   base,oauth          → OAuth on top of the base matrix


### PR DESCRIPTION
## Why

v1.6.7's `Context op=self` reports a `server.url` from **`LOOMCYCLE_PUBLIC_URL`** so an agent (especially over MCP) can identify the instance it's connected to. The TrueNAS deploy artifacts didn't surface the knob, so operators wouldn't know to set it.

## What (docs/template only)

- **`deploy/truenas/docker-compose.yaml`** — `LOOMCYCLE_PUBLIC_URL: ${LOOMCYCLE_PUBLIC_URL:-}` in the loomcycle service's non-secret `environment:` block.
- **`deploy/truenas/INSTALL.md`** (Phase 5 paste compose) — an inline `LOOMCYCLE_PUBLIC_URL` with the `TRUENAS_SCALE_HOST` placeholder + a note that it's the externally-reachable base URL (your tunnel/proxy host, or `http://host:8787` for direct LAN).

Optional; ignored by tags `< v1.6.7`. No runtime change. The **catalog wizard** already picks it up from the embedded `env.insecure.example` (added in #592) on the next `loomcycle truenas-questions` regen, so no questions.yaml edit is needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)