### PR TITLE
feat: image / vision input across all providers (RFC AT)

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -180,3 +180,76 @@ The OAuth-dev provider is single-operator, single-machine. There's no token-sync
 - Pi (`earendil-works/pi`, 51K stars): the source of the OAuth client_id + flow shape.
 - The internal RFC at `~/work/loomcycle-internal/doc-internal/rfcs/anthropic-oauth-dev.md` (locked 2026-05-19) documents the full design + decisions.
 - `Context.help(topic="loomcycle")` from inside an agent prompt for the in-substrate description.
+
+## Image / vision input (RFC AT)
+
+loomcycle accepts image input as a content block on a `user`-role segment. It is
+additive and backward-compatible — text-only callers are unchanged, and there is
+no new endpoint.
+
+### Sending an image
+
+A caller adds an `image` block alongside text blocks in a `user` segment of
+`POST /v1/runs` (or `POST /v1/sessions/{id}/messages` for a continuation turn):
+
+```json
+{
+  "agent": "vision-agent",
+  "segments": [{
+    "role": "user",
+    "content": [
+      {"type": "trusted-text", "text": "What's in this picture?"},
+      {"type": "image", "media_type": "image/png", "data": "<base64 bytes, no data: prefix>"}
+    ]
+  }]
+}
+```
+
+- **`media_type`** must be one of `image/png`, `image/jpeg`, `image/gif`,
+  `image/webp` (the common denominator across all vision providers).
+- **`data`** is the raw base64 of the image bytes — **no `data:` prefix**. There
+  is deliberately **no URL form**: accepting a URL would make loomcycle fetch
+  arbitrary hosts (SSRF). The OpenAI driver builds the `data:` URI internally.
+- Images are valid only in `user`-role segments.
+
+### Per-provider serialization
+
+Each driver serializes the block natively — no conversion to text:
+
+| Provider | Wire form |
+|---|---|
+| `anthropic` (+ `anthropic-oauth-dev`) | `{"type":"image","source":{"type":"base64","media_type","data"}}` |
+| `openai` | user message `content` becomes the array form with an `image_url` part holding a `data:` URI |
+| `gemini` | a part with `inlineData: {mimeType, data}` |
+| `ollama` / `ollama-local` | the user message's `images: [base64]` field |
+| `deepseek` | **not supported** — DeepSeek text models reject images |
+
+### The capability gate
+
+A provider advertises `SupportsVision`; the loop refuses an image sent to a
+text-only provider/model **before** the call, emitting a clear error event
+("model X on provider Y does not support image input") rather than letting the
+image be silently dropped or the provider return an opaque 400. This makes a
+provider-fallback onto a text-only model fail loudly. Per-model nuance (a legacy
+text-only model on an otherwise vision-capable provider — `claude-2`/
+`claude-instant`, `gpt-3.5*`, the original `gpt-4`/`gpt-4-32k` snapshots) is
+refined inside the driver; unknown models default to supported (a wrong guess
+surfaces as a provider error, never a silent drop). For Ollama the model must be
+a vision model (llava, llama3.2-vision, …) — that's the operator's choice.
+
+### Request body cap
+
+Inline base64 makes requests larger, so the run-ingest body cap (`POST /v1/runs`
+and `POST /v1/sessions/{id}/messages`) defaults to **16 MiB** and is tunable via
+`LOOMCYCLE_MAX_REQUEST_BYTES` (bytes). An over-cap request returns
+`413 Request Entity Too Large`. Consumers should resample images to a sane max
+edge (~1568px) before sending to keep them small and bound token cost.
+
+### Caveats
+
+- **gRPC/proto parity is deferred** — HTTP is the consumer path. gRPC callers
+  cannot send images yet.
+- **No image output** (generation), no audio/video.
+- A vision model can be influenced by text rendered *inside* an image
+  (prompt-injection-via-image) — inherent to any vision system, not defended at
+  the wire.

--- a/internal/api/http/request_cap_test.go
+++ b/internal/api/http/request_cap_test.go
@@ -1,0 +1,79 @@
+package http
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// capCfg builds a minimal config with a small MaxRequestBytes so the cap can be
+// exercised without posting megabytes.
+func capCfg(limit int64) *config.Config {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"a": {Model: "stub-model", SystemPrompt: "x"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+	}
+	cfg.Env.AuthToken = ""
+	cfg.Env.MaxRequestBytes = limit
+	return cfg
+}
+
+func capServer(t *testing.T, limit int64) *httptest.Server {
+	t.Helper()
+	prov := &scriptedProvider{scripts: [][]providers.Event{{
+		{Type: providers.EventText, Text: "ok"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 1, OutputTokens: 1}},
+	}}}
+	srv := New(capCfg(limit), &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestRequestCap_OverLimitReturns413: a /v1/runs body larger than the configured
+// cap is rejected with 413 (not silently processed).
+func TestRequestCap_OverLimitReturns413(t *testing.T) {
+	ts := capServer(t, 512)
+	// A body comfortably over 512 bytes: pad the text block.
+	big := strings.Repeat("A", 4096)
+	payload := fmt.Sprintf(`{"agent":"a","segments":[{"role":"user","content":[{"type":"trusted-text","text":%q}]}]}`, big)
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 413; body: %s", resp.StatusCode, body)
+	}
+}
+
+// TestRequestCap_UnderLimitAccepted: a /v1/runs body under the cap is NOT
+// rejected by the byte cap — it reaches the handler and runs (200).
+func TestRequestCap_UnderLimitAccepted(t *testing.T) {
+	ts := capServer(t, 16<<20)
+	payload := `{"agent":"a","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -356,6 +356,22 @@ type Server struct {
 // The cancel registry is also constructed here. It's always present
 // (empty if no run has started) so handler code can call its methods
 // unconditionally without nil-checking.
+// defaultMaxRequestBytes is the run-ingest body cap used when the operator
+// hasn't set one (and the fallback for tests that build a bare config). 16 MiB
+// fits inline base64 image content (RFC AT); LOOMCYCLE_MAX_REQUEST_BYTES tunes
+// the configured value.
+const defaultMaxRequestBytes = 16 << 20
+
+// maxRequestBytes returns the configured run-ingest body cap, falling back to
+// defaultMaxRequestBytes when unset (<=0) so a bare-config Server never caps at
+// zero bytes (which MaxBytesReader would treat as "reject every body").
+func (s *Server) maxRequestBytes() int64 {
+	if n := s.cfg.Env.MaxRequestBytes; n > 0 {
+		return n
+	}
+	return defaultMaxRequestBytes
+}
+
 func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem *concurrency.Semaphore, st store.Store) *Server {
 	// Hook registry is constructed with the operator-yaml host-widen
 	// permit list (cfg.Hooks.PermitHostWiden.Owners). Without an entry
@@ -2963,11 +2979,17 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 		return
 	}
-	// Cap body at 1 MiB so a malicious caller can't exhaust memory by
-	// streaming a huge body. ReadHeaderTimeout doesn't cover the body.
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	// Cap the body so a malicious caller can't exhaust memory by streaming a
+	// huge body (ReadHeaderTimeout doesn't cover the body). Default 16 MiB to
+	// fit inline base64 image content (RFC AT); LOOMCYCLE_MAX_REQUEST_BYTES.
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxRequestBytes())
 	var req runRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, fmt.Sprintf("request body exceeds the %d-byte limit", maxErr.Limit), http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -3579,7 +3601,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
 		return
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	// Default 16 MiB to fit inline base64 image content on a continuation turn
+	// (RFC AT); LOOMCYCLE_MAX_REQUEST_BYTES. MaxBytesReader still hard-stops.
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxRequestBytes())
 
 	id := r.PathValue("id")
 	if id == "" {
@@ -3589,6 +3613,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 
 	var body messagesRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			http.Error(w, fmt.Sprintf("request body exceeds the %d-byte limit", maxErr.Limit), http.StatusRequestEntityTooLarge)
+			return
+		}
 		http.Error(w, "bad json: "+err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/internal/api/http/server_test.go
+++ b/internal/api/http/server_test.go
@@ -345,10 +345,10 @@ func TestAuthRequired(t *testing.T) {
 	}
 }
 
-// Regression: bodies larger than the cap are rejected, not silently read into
-// memory. We send valid JSON whose `text` field is large enough to cross the
-// 1 MiB cap — without MaxBytesReader, the decoder happily reads it all and
-// returns 200. With MaxBytesReader, the decoder fails mid-parse.
+// Regression: bodies larger than the cap (LOOMCYCLE_MAX_REQUEST_BYTES) are
+// rejected, not silently read into memory. We send valid JSON whose `text`
+// field is large enough to cross the configured cap — without MaxBytesReader
+// the decoder reads it all and returns 200; with it, the request is rejected.
 func TestRunsRejectsOversizedBody(t *testing.T) {
 	cfg := &config.Config{
 		Defaults: config.Defaults{Provider: "stub", Model: "stub-model"},
@@ -357,6 +357,9 @@ func TestRunsRejectsOversizedBody(t *testing.T) {
 		},
 		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
 	}
+	// Pin a small cap (the default is now 16 MiB, RFC AT) so the rejection is
+	// exercised without posting 16+ MiB.
+	cfg.Env.MaxRequestBytes = 1 << 20
 	provider := &stubProvider{events: []providers.Event{
 		{Type: providers.EventDone, StopReason: "end_turn"},
 	}}
@@ -364,7 +367,7 @@ func TestRunsRejectsOversizedBody(t *testing.T) {
 	ts := httptest.NewServer(srv.Mux())
 	defer ts.Close()
 
-	// 2 MiB of "x" inside a valid JSON string — guaranteed to cross 1 MiB cap.
+	// 2 MiB of "x" inside a valid JSON string — guaranteed to cross the 1 MiB cap.
 	huge := strings.Repeat("x", 2<<20)
 	body := `{"agent":"default","segments":[{"role":"user","content":[{"type":"trusted-text","text":"` + huge + `"}]}]}`
 
@@ -373,8 +376,8 @@ func TestRunsRejectsOversizedBody(t *testing.T) {
 		t.Fatalf("post: %v", err)
 	}
 	defer resp.Body.Close()
-	// MaxBytesReader returns 400 (decoder sees a "http: request body too large"
-	// error mid-parse) or 413. Anything 2xx means the cap was bypassed.
+	// Over-cap bodies return 413 (RFC AT; previously 400). Anything 2xx means
+	// the cap was bypassed.
 	if resp.StatusCode == http.StatusOK {
 		t.Errorf("status = 200 — oversized body was accepted (MaxBytesReader missing)")
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1926,7 +1926,14 @@ type Env struct {
 	// self then reports only the bind ListenAddr (and the A2A advertise URL if
 	// that's configured). LOOMCYCLE_PUBLIC_URL.
 	PublicURL string
-	AuthToken string
+	// MaxRequestBytes caps the JSON body the run-ingest paths accept
+	// (POST /v1/runs and POST /v1/sessions/{id}/messages). Default 16 MiB —
+	// raised from the historical 1 MiB so a request can carry inline base64
+	// image content (RFC AT). MaxBytesReader still hard-stops at this bound;
+	// operators tune it down to shrink the per-request memory ceiling.
+	// LOOMCYCLE_MAX_REQUEST_BYTES (bytes; <=0 ignored, default kept).
+	MaxRequestBytes int64
+	AuthToken       string
 	// OperatorTokenPepper is prepended to a bearer before SHA-256 when
 	// hashing OperatorTokenDef tokens (RFC L). A stolen DB dump without
 	// the pepper yields no usable token lookup. Secret — never logged.
@@ -3141,6 +3148,15 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 			} else {
 				cfg.Env.ChannelsMaxValueBytes = n
 			}
+		}
+	}
+	// Run-ingest body cap (RFC AT). Default 16 MiB so a request can carry an
+	// inline base64 image; a positive override tunes it, a non-positive value
+	// is ignored (keep the default — the cap is a security floor).
+	cfg.Env.MaxRequestBytes = 16 << 20
+	if v := os.Getenv("LOOMCYCLE_MAX_REQUEST_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.Env.MaxRequestBytes = n
 		}
 	}
 	cfg.Env.ChannelsSweepInterval = 15 * time.Minute

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1138,13 +1138,14 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	}
 
 	// Vision gate (RFC AT). If this run carries an image content block — fresh
-	// or replayed from a prior turn — validate it and refuse before the call
-	// when the resolved provider/model can't accept image input. This is what
-	// makes a fallback onto a text-only model (or DeepSeek's text endpoint)
-	// fail loudly here instead of the image being silently dropped or the
-	// provider returning an opaque 400. Once per Run: the (provider, model) is
-	// fixed across iterations, and PriorMessages were validated when first sent
-	// so only the fresh segments need re-validating.
+	// or replayed from a prior turn — validate it and refuse before the first
+	// call when the resolved provider can't accept image input (e.g. an agent
+	// whose tier resolved to DeepSeek's text endpoint). This fails loudly here
+	// instead of the image being silently dropped. Checked once at the resolved
+	// provider: a mid-run fallback to a non-vision provider is caught by the
+	// driver's own per-model gate (a clear error) / surfaces as a provider
+	// error, never a silent drop. PriorMessages were validated when first sent,
+	// so only the fresh segments need re-validating here.
 	if messagesHaveImage(messages) {
 		if err := validateImageSegments(opts.Segments); err != nil {
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -8,6 +8,7 @@ package loop
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,11 +40,21 @@ type PromptSegment struct {
 //   - "trusted-text"     : text the loop trusts; goes through verbatim.
 //   - "untrusted-block"  : text from an external source; wrapped in <untrusted>
 //     tags before being sent to the model.
+//   - "image"            : inline image input (RFC AT); valid only in a
+//     user-role segment, capability-gated per provider/model.
 type PromptContentBlock struct {
 	Type      string `json:"type"`
 	Text      string `json:"text"`
 	Cacheable bool   `json:"cacheable,omitempty"`
 	Kind      string `json:"kind,omitempty"` // for untrusted-block: e.g. "web_content", "uploaded_cv"
+
+	// Image fields (Type == "image", RFC AT). MediaType is one of the
+	// whitelisted image media types (image/png|jpeg|gif|webp); Data is the
+	// base64 of the image bytes with NO "data:" prefix (the driver builds any
+	// data-URI form internally). There is deliberately no URL form — accepting
+	// a URL would make loomcycle fetch arbitrary hosts (SSRF); see RFC AT §6.
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
 }
 
 // codeJSProviderID is the synthetic replay provider's ID — must match
@@ -1126,6 +1137,26 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 		}
 	}
 
+	// Vision gate (RFC AT). If this run carries an image content block — fresh
+	// or replayed from a prior turn — validate it and refuse before the call
+	// when the resolved provider/model can't accept image input. This is what
+	// makes a fallback onto a text-only model (or DeepSeek's text endpoint)
+	// fail loudly here instead of the image being silently dropped or the
+	// provider returning an opaque 400. Once per Run: the (provider, model) is
+	// fixed across iterations, and PriorMessages were validated when first sent
+	// so only the fresh segments need re-validating.
+	if messagesHaveImage(messages) {
+		if err := validateImageSegments(opts.Segments); err != nil {
+			emit(providers.Event{Type: providers.EventError, Error: err.Error()})
+			return RunResult{}, err
+		}
+		if !opts.Provider.Capabilities().SupportsVision {
+			msg := fmt.Sprintf("model %q on provider %q does not support image input", opts.Model, opts.Provider.ID())
+			emit(providers.Event{Type: providers.EventError, Error: msg})
+			return RunResult{}, errors.New(msg)
+		}
+	}
+
 	emit(providers.Event{Type: providers.EventStarted})
 
 	// Context compaction (v2): a self-request flag the Context op=compact tool
@@ -1965,6 +1996,61 @@ var allowedUntrustedKinds = map[string]bool{
 	"run_metadata":  true, // non-secret metadata projected from an external trigger body
 }
 
+// validImageMediaTypes is the whitelist of media types an "image" content
+// block may declare (RFC AT). It is the common denominator across all four
+// vision providers (Anthropic's set); anything else is rejected before the
+// call rather than letting a provider 400 on an unsupported type.
+var validImageMediaTypes = map[string]bool{
+	"image/png":  true,
+	"image/jpeg": true,
+	"image/gif":  true,
+	"image/webp": true,
+}
+
+// validateImageSegments validates every "image" block in the inbound segments
+// (RFC AT §4.3): an image is valid only in a user-role segment, must carry a
+// whitelisted media_type, and its Data must decode as base64. It returns a
+// descriptive error — surfaced to the caller as an EventError before any
+// provider call — so a malformed image fails fast and clearly instead of
+// reaching a provider as an opaque 400. flattenContent itself has no error
+// channel, so this is the single validation choke point.
+func validateImageSegments(segs []PromptSegment) error {
+	for _, s := range segs {
+		for _, c := range s.Content {
+			if c.Type != "image" {
+				continue
+			}
+			if s.Role != "user" {
+				return fmt.Errorf("image content is only allowed in user-role segments (got role %q)", s.Role)
+			}
+			if !validImageMediaTypes[c.MediaType] {
+				return fmt.Errorf("unsupported image media_type %q (allowed: image/png, image/jpeg, image/gif, image/webp)", c.MediaType)
+			}
+			if c.Data == "" {
+				return errors.New("image content block has empty data")
+			}
+			if _, err := base64.StdEncoding.DecodeString(c.Data); err != nil {
+				return fmt.Errorf("image content block data is not valid base64: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+// messagesHaveImage reports whether any assembled message (prior-turn or
+// fresh) carries an image content block — the signal the loop uses to decide
+// whether the vision capability gate applies for this run.
+func messagesHaveImage(messages []providers.Message) bool {
+	for _, m := range messages {
+		for _, c := range m.Content {
+			if c.Type == "image" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // FlattenContent is the public version of flattenContent for callers that
 // need to apply the same trust-escaping rules during transcript replay
 // (continuation endpoint). External callers should not depend on this for
@@ -1997,6 +2083,13 @@ func flattenContent(c PromptContentBlock) providers.ContentBlock {
 			Type: "text",
 			Text: fmt.Sprintf("<%s>\n%s\n</%s>", kind, safe, kind),
 		}
+	case "image":
+		// Images are NOT tag-fenced: untrusted-block fencing defends against
+		// text that reads as instructions, but an image is opaque bytes to the
+		// wire. Media-type/base64 validity is enforced upstream in
+		// validateImageSegments (before any provider call), not here — this
+		// function has no error channel. See RFC AT §4.3/§6.
+		return providers.ContentBlock{Type: "image", MediaType: c.MediaType, Data: c.Data}
 	default: // "trusted-text"
 		return providers.ContentBlock{Type: "text", Text: c.Text, Cacheable: c.Cacheable}
 	}

--- a/internal/loop/vision_test.go
+++ b/internal/loop/vision_test.go
@@ -1,0 +1,195 @@
+package loop
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// visionProvider records the request it was handed, whether it was called, and
+// advertises vision support per a flag — so a test can prove an image reaches
+// the provider on a vision-capable model and is refused before the call on a
+// text-only one.
+type visionProvider struct {
+	id     string
+	vision bool
+	mu     sync.Mutex
+	called bool
+	got    []providers.Message
+}
+
+func (p *visionProvider) ID() string                                   { return p.id }
+func (p *visionProvider) Probe(context.Context) error                  { return nil }
+func (p *visionProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (p *visionProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true, SupportsVision: p.vision}
+}
+func (p *visionProvider) Call(_ context.Context, req providers.Request) (<-chan providers.Event, error) {
+	p.mu.Lock()
+	p.called = true
+	p.got = req.Messages
+	p.mu.Unlock()
+	ch := make(chan providers.Event, 1)
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+func (p *visionProvider) wasCalled() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.called
+}
+
+func (p *visionProvider) imageBlocks() []providers.ContentBlock {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var out []providers.ContentBlock
+	for _, m := range p.got {
+		for _, c := range m.Content {
+			if c.Type == "image" {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
+const testPNGB64 = "iVBORw0KGgo=" // valid base64 (decodes); contents irrelevant to the wire validation
+
+func imageSegs() []PromptSegment {
+	return []PromptSegment{{Role: "user", Content: []PromptContentBlock{
+		{Type: "trusted-text", Text: "describe this"},
+		{Type: "image", MediaType: "image/png", Data: testPNGB64},
+	}}}
+}
+
+// TestFlattenContent_ImagePassesThrough: an image block flattens to a provider
+// image ContentBlock carrying media_type + data verbatim and is NOT tag-fenced.
+func TestFlattenContent_ImagePassesThrough(t *testing.T) {
+	got := flattenContent(PromptContentBlock{Type: "image", MediaType: "image/jpeg", Data: testPNGB64})
+	if got.Type != "image" {
+		t.Fatalf("Type = %q, want image", got.Type)
+	}
+	if got.MediaType != "image/jpeg" || got.Data != testPNGB64 {
+		t.Fatalf("media/data not carried through: %+v", got)
+	}
+	if got.Text != "" {
+		t.Errorf("image block should carry no text, got %q", got.Text)
+	}
+}
+
+// TestRun_ImageReachesVisionProvider: on a vision-capable provider the image
+// block flows through to the provider request intact.
+func TestRun_ImageReachesVisionProvider(t *testing.T) {
+	prov := &visionProvider{id: "vision-llm", vision: true}
+	_, err := Run(context.Background(), RunOptions{
+		Provider:   prov,
+		Model:      "vision-model",
+		Tools:      []tools.Tool{noopTool{}},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:   imageSegs(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	imgs := prov.imageBlocks()
+	if len(imgs) != 1 {
+		t.Fatalf("want 1 image block reaching provider, got %d", len(imgs))
+	}
+	if imgs[0].MediaType != "image/png" || imgs[0].Data != testPNGB64 {
+		t.Errorf("image not carried to provider: %+v", imgs[0])
+	}
+}
+
+// TestRun_ImageGatedOnTextOnlyProvider: an image sent to a SupportsVision=false
+// provider is refused BEFORE the call — Run errors, an EventError is emitted,
+// and Provider.Call is never invoked (so the image is never silently dropped).
+func TestRun_ImageGatedOnTextOnlyProvider(t *testing.T) {
+	prov := &visionProvider{id: "text-only", vision: false}
+	var events []providers.Event
+	_, err := Run(context.Background(), RunOptions{
+		Provider:   prov,
+		Model:      "text-model",
+		Tools:      []tools.Tool{noopTool{}},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:   imageSegs(),
+		OnEvent:    func(ev providers.Event) { events = append(events, ev) },
+	})
+	if err == nil {
+		t.Fatal("want error gating image on a text-only provider, got nil")
+	}
+	if prov.wasCalled() {
+		t.Error("Provider.Call must NOT be invoked when the image is gated")
+	}
+	var sawErr bool
+	for _, ev := range events {
+		if ev.Type == providers.EventError && strings.Contains(ev.Error, "does not support image input") {
+			sawErr = true
+		}
+	}
+	if !sawErr {
+		t.Errorf("want an EventError naming the missing vision support, got events %+v", events)
+	}
+}
+
+// TestValidateImageSegments rejects malformed images (bad role, media type,
+// empty/invalid base64) and accepts a well-formed one.
+func TestValidateImageSegments(t *testing.T) {
+	valid := base64.StdEncoding.EncodeToString([]byte("hello-bytes"))
+	cases := []struct {
+		name    string
+		segs    []PromptSegment
+		wantErr string // substring; "" means expect no error
+	}{
+		{
+			name:    "valid user image",
+			segs:    []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "image", MediaType: "image/webp", Data: valid}}}},
+			wantErr: "",
+		},
+		{
+			name:    "image in system role rejected",
+			segs:    []PromptSegment{{Role: "system", Content: []PromptContentBlock{{Type: "image", MediaType: "image/png", Data: valid}}}},
+			wantErr: "user-role",
+		},
+		{
+			name:    "unsupported media type rejected",
+			segs:    []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "image", MediaType: "image/tiff", Data: valid}}}},
+			wantErr: "unsupported image media_type",
+		},
+		{
+			name:    "empty data rejected",
+			segs:    []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "image", MediaType: "image/png", Data: ""}}}},
+			wantErr: "empty data",
+		},
+		{
+			name:    "non-base64 data rejected",
+			segs:    []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "image", MediaType: "image/png", Data: "not base64!!!"}}}},
+			wantErr: "not valid base64",
+		},
+		{
+			name:    "text-only segments pass",
+			segs:    []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+			wantErr: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateImageSegments(tc.segs)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("want no error, got %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -60,6 +60,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		MaxContextTokens:  200_000,
 		SupportsThinking:  true,
 		SupportsEffort:    true,
+		SupportsVision:    true, // per-model refined by anthropicSupportsVision
 	}
 }
 
@@ -196,14 +197,23 @@ type wireMessage struct {
 }
 
 type wireContentBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text,omitempty"`
-	ID        string          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
-	Input     json.RawMessage `json:"input,omitempty"`
-	ToolUseID string          `json:"tool_use_id,omitempty"`
-	Content   string          `json:"content,omitempty"`
-	IsError   bool            `json:"is_error,omitempty"`
+	Type      string           `json:"type"`
+	Text      string           `json:"text,omitempty"`
+	ID        string           `json:"id,omitempty"`
+	Name      string           `json:"name,omitempty"`
+	Input     json.RawMessage  `json:"input,omitempty"`
+	ToolUseID string           `json:"tool_use_id,omitempty"`
+	Content   string           `json:"content,omitempty"`
+	IsError   bool             `json:"is_error,omitempty"`
+	Source    *wireImageSource `json:"source,omitempty"` // type == "image" (RFC AT)
+}
+
+// wireImageSource is Anthropic's inline base64 image source block:
+// {"type":"base64","media_type":"image/png","data":"<base64>"}.
+type wireImageSource struct {
+	Type      string `json:"type"` // always "base64" (no URL form — RFC AT §6)
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 func buildRequestBody(req providers.Request) ([]byte, error) {
@@ -289,6 +299,13 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 		w.System = append(w.System, out)
 	}
 
+	// Refuse an image to a text-only Claude model before the call — a clear
+	// error beats Anthropic's opaque 400 (RFC AT §4.4/§5.1). The loop's coarse
+	// gate only knows the provider supports vision; per-model nuance lives here.
+	if providers.RequestHasImage(req) && !anthropicSupportsVision(req.Model) {
+		return nil, fmt.Errorf("anthropic model %q does not support image input", req.Model)
+	}
+
 	for _, m := range req.Messages {
 		wm := wireMessage{Role: m.Role}
 		for _, c := range m.Content {
@@ -316,8 +333,30 @@ func toWireBlock(c providers.ContentBlock) wireContentBlock {
 			Content:   c.Text,
 			IsError:   c.IsError,
 		}
+	case "image":
+		return wireContentBlock{Type: "image", Source: &wireImageSource{
+			Type:      "base64",
+			MediaType: c.MediaType,
+			Data:      c.Data,
+		}}
 	default: // "text"
 		return wireContentBlock{Type: "text", Text: c.Text}
+	}
+}
+
+// anthropicSupportsVision reports whether the named Claude model accepts image
+// input. Every modern Claude family (3 / 3.5 / 3.7 / 4.x) is multimodal; the
+// genuinely text-only legacy families are claude-2 and claude-instant. An
+// unknown model defaults to supported — a wrong guess surfaces as a provider
+// 400, not a silent drop (RFC AT §7). Capabilities() takes no model arg, so
+// this is the per-model affordance (mirrors anthropicEffortBudget).
+func anthropicSupportsVision(model string) bool {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "claude-2"), strings.Contains(m, "claude-instant"):
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/providers/anthropic/vision_test.go
+++ b/internal/providers/anthropic/vision_test.go
@@ -1,0 +1,80 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+const visTestB64 = "iVBORw0KGgo="
+
+func imageReq(model string) providers.Request {
+	return providers.Request{
+		Model: model,
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "what is this"},
+			{Type: "image", MediaType: "image/png", Data: visTestB64},
+		}}},
+	}
+}
+
+// TestVision_AnthropicImageBlockWireShape: an image content block serializes to
+// Anthropic's {"type":"image","source":{"type":"base64","media_type","data"}}.
+func TestVision_AnthropicImageBlockWireShape(t *testing.T) {
+	body, err := buildRequestBody(imageReq("claude-sonnet-4-6"))
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var w struct {
+		Messages []struct {
+			Content []struct {
+				Type   string `json:"type"`
+				Source *struct {
+					Type      string `json:"type"`
+					MediaType string `json:"media_type"`
+					Data      string `json:"data"`
+				} `json:"source"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(w.Messages) != 1 || len(w.Messages[0].Content) != 2 {
+		t.Fatalf("unexpected message shape: %s", body)
+	}
+	img := w.Messages[0].Content[1]
+	if img.Type != "image" || img.Source == nil {
+		t.Fatalf("second block not an image source: %s", body)
+	}
+	if img.Source.Type != "base64" || img.Source.MediaType != "image/png" || img.Source.Data != visTestB64 {
+		t.Errorf("image source wrong: %+v", img.Source)
+	}
+}
+
+// TestVision_AnthropicRejectsImageOnTextOnlyModel: a legacy text-only family
+// (claude-2 / claude-instant) is refused before the call with a clear error
+// rather than an opaque provider 400.
+func TestVision_AnthropicRejectsImageOnTextOnlyModel(t *testing.T) {
+	for _, model := range []string{"claude-2.1", "claude-instant-1.2"} {
+		if _, err := buildRequestBody(imageReq(model)); err == nil {
+			t.Errorf("model %q: want error refusing image, got nil", model)
+		}
+	}
+}
+
+func TestAnthropicSupportsVision(t *testing.T) {
+	vision := []string{"claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5", "claude-3-5-sonnet", "claude-3-opus"}
+	textOnly := []string{"claude-2.1", "claude-2.0", "claude-instant-1.2"}
+	for _, m := range vision {
+		if !anthropicSupportsVision(m) {
+			t.Errorf("anthropicSupportsVision(%q) = false, want true", m)
+		}
+	}
+	for _, m := range textOnly {
+		if anthropicSupportsVision(m) {
+			t.Errorf("anthropicSupportsVision(%q) = true, want false", m)
+		}
+	}
+}

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -82,6 +82,11 @@ func (d *Driver) ID() string { return "deepseek" }
 func (d *Driver) Capabilities() providers.Capabilities {
 	caps := d.inner.Capabilities()
 	caps.SupportsThinking = true
+	// DeepSeek's text models don't accept image input. The inner OpenAI driver
+	// reports SupportsVision=true (RFC AT), so override to false here — the
+	// loop then gates an image to DeepSeek upstream with a clear error rather
+	// than the inner OpenAI wire builder producing an image_url DeepSeek 400s on.
+	caps.SupportsVision = false
 	return caps
 }
 

--- a/internal/providers/deepseek/driver_test.go
+++ b/internal/providers/deepseek/driver_test.go
@@ -134,6 +134,13 @@ func TestDriver_CapabilitiesMostlyMatchOpenAI(t *testing.T) {
 	if !caps.SupportsThinking {
 		t.Errorf("SupportsThinking = false, want true (deepseek-v4-pro / deepseek-reasoner are thinking-class)")
 	}
+	// DeepSeek text models don't accept images. The inner OpenAI driver reports
+	// SupportsVision=true (RFC AT); DeepSeek must override to false so the loop
+	// gates an image to DeepSeek upstream instead of the inner OpenAI wire
+	// builder producing an image_url DeepSeek 400s on.
+	if caps.SupportsVision {
+		t.Errorf("SupportsVision = true, want false (DeepSeek text models reject image input)")
+	}
 }
 
 // TestIsThinkingModel covers the per-model affordance the driver

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -97,6 +97,10 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// request (see Call).
 		SupportsThinking: true,
 		SupportsEffort:   true,
+		// All current Gemini models (2.5 flash / pro) are multimodal.
+		// No per-model gate — operator-trust per RFC AT §5.3; a non-vision
+		// model surfaces via the existing provider-fallback error.
+		SupportsVision: true,
 	}
 }
 
@@ -189,6 +193,16 @@ type wirePart struct {
 	Text             string                `json:"text,omitempty"`
 	FunctionCall     *wireFunctionCall     `json:"functionCall,omitempty"`
 	FunctionResponse *wireFunctionResponse `json:"functionResponse,omitempty"`
+	InlineData       *wireInlineData       `json:"inlineData,omitempty"` // type == "image" (RFC AT)
+}
+
+// wireInlineData is Gemini's inline binary part: {"mimeType","data"} with the
+// data being raw base64 (no "data:" prefix). camelCase keys match the rest of
+// this driver (functionCall/functionResponse); the Gemini API also accepts the
+// snake_case form.
+type wireInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
 }
 
 type wireFunctionCall struct {
@@ -313,6 +327,8 @@ func flattenMessageContent(msg providers.Message) ([]wirePart, error) {
 			if c.Text != "" {
 				out = append(out, wirePart{Text: c.Text})
 			}
+		case "image":
+			out = append(out, wirePart{InlineData: &wireInlineData{MimeType: c.MediaType, Data: c.Data}})
 		case "tool_use":
 			out = append(out, wirePart{FunctionCall: &wireFunctionCall{
 				Name: c.ToolName,

--- a/internal/providers/gemini/vision_test.go
+++ b/internal/providers/gemini/vision_test.go
@@ -1,0 +1,49 @@
+package gemini
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+const visTestB64 = "iVBORw0KGgo="
+
+// TestVision_GeminiInlineData: an image content block serializes to a Gemini
+// part carrying inlineData {mimeType, data}.
+func TestVision_GeminiInlineData(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "gemini-2.5-flash",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "what is this"},
+			{Type: "image", MediaType: "image/jpeg", Data: visTestB64},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var w struct {
+		Contents []struct {
+			Parts []struct {
+				Text       string `json:"text"`
+				InlineData *struct {
+					MimeType string `json:"mimeType"`
+					Data     string `json:"data"`
+				} `json:"inlineData"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.Unmarshal(body, &w); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(w.Contents) != 1 || len(w.Contents[0].Parts) != 2 {
+		t.Fatalf("unexpected content shape: %s", body)
+	}
+	img := w.Contents[0].Parts[1]
+	if img.InlineData == nil {
+		t.Fatalf("second part missing inlineData: %s", body)
+	}
+	if img.InlineData.MimeType != "image/jpeg" || img.InlineData.Data != visTestB64 {
+		t.Errorf("inlineData wrong: %+v", img.InlineData)
+	}
+}

--- a/internal/providers/mock/driver.go
+++ b/internal/providers/mock/driver.go
@@ -139,6 +139,9 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		NativePromptCache: false,
 		SupportsThinking:  false,
 		SupportsEffort:    false,
+		// The mock is a test double — accept image content so loop-level
+		// vision tests (RFC AT) can route an image through to a provider.
+		SupportsVision: true,
 	}
 }
 

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -243,6 +243,11 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// loop that an Ollama-routed agent's effort hint is dropped, so
 		// the loop logs once per Run for operator visibility.
 		SupportsEffort: false,
+		// Vision depends on the pulled model (llava, llama3.2-vision, …).
+		// Report true and treat model choice as the operator's responsibility
+		// (RFC AT §5.4); a non-vision model's failure surfaces via the existing
+		// provider-fallback error rather than a silent drop.
+		SupportsVision: true,
 	}
 }
 
@@ -361,6 +366,10 @@ type wireMessage struct {
 	Role      string         `json:"role"`
 	Content   string         `json:"content"`
 	ToolCalls []wireToolCall `json:"tool_calls,omitempty"`
+	// Images carries inline base64 image data on a user message (RFC AT).
+	// Ollama's /api/chat takes images: [base64] alongside content; vision
+	// depends on the pulled model (llava, llama3.2-vision, …).
+	Images []string `json:"images,omitempty"`
 }
 
 type wireToolCall struct {
@@ -456,9 +465,11 @@ func flattenMessage(m providers.Message) []wireMessage {
 		return []wireMessage{{Role: "assistant", Content: text.String(), ToolCalls: calls}}
 	}
 
-	// user role: split tool_result into role:"tool" entries.
+	// user role: split tool_result into role:"tool" entries; text + image
+	// blocks form one user message (images attach to it as images: [base64]).
 	var out []wireMessage
 	var userText strings.Builder
+	var images []string
 	for _, c := range m.Content {
 		switch c.Type {
 		case "tool_result":
@@ -468,10 +479,12 @@ func flattenMessage(m providers.Message) []wireMessage {
 				userText.WriteString("\n")
 			}
 			userText.WriteString(c.Text)
+		case "image":
+			images = append(images, c.Data)
 		}
 	}
-	if userText.Len() > 0 {
-		out = append([]wireMessage{{Role: "user", Content: userText.String()}}, out...)
+	if userText.Len() > 0 || len(images) > 0 {
+		out = append([]wireMessage{{Role: "user", Content: userText.String(), Images: images}}, out...)
 	}
 	return out
 }

--- a/internal/providers/ollama/vision_test.go
+++ b/internal/providers/ollama/vision_test.go
@@ -1,0 +1,76 @@
+package ollama
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+)
+
+const visTestB64 = "iVBORw0KGgo="
+
+// TestVision_OllamaImagesField: an image content block on a user message
+// serializes to Ollama's message.images: [base64] alongside the text content.
+func TestVision_OllamaImagesField(t *testing.T) {
+	var captured []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/ps" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
+		captured, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		fmt.Fprint(w, `{"model":"llava","message":{"role":"assistant","content":""},"done":true}`+"\n")
+	}))
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model: "llava",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "describe this"},
+			{Type: "image", MediaType: "image/png", Data: visTestB64},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	for range ch {
+	}
+
+	var w struct {
+		Messages []struct {
+			Role    string   `json:"role"`
+			Content string   `json:"content"`
+			Images  []string `json:"images"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(captured, &w); err != nil {
+		t.Fatalf("decode body: %v (%s)", err, captured)
+	}
+	var user *struct {
+		Role    string   `json:"role"`
+		Content string   `json:"content"`
+		Images  []string `json:"images"`
+	}
+	for i := range w.Messages {
+		if w.Messages[i].Role == "user" {
+			user = &w.Messages[i]
+		}
+	}
+	if user == nil {
+		t.Fatalf("no user message in body: %s", captured)
+	}
+	if user.Content != "describe this" {
+		t.Errorf("content = %q, want %q", user.Content, "describe this")
+	}
+	if len(user.Images) != 1 || user.Images[0] != visTestB64 {
+		t.Errorf("images = %v, want [%q]", user.Images, visTestB64)
+	}
+}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -70,6 +70,7 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// passes through; operators using effort with non-reasoning
 		// models will see the API's 400 surface clearly.
 		SupportsEffort: true,
+		SupportsVision: true, // per-model refined by openaiSupportsVision
 	}
 }
 
@@ -207,8 +208,14 @@ type wireStreamOptions struct {
 }
 
 type wireMessage struct {
-	Role       string         `json:"role"`
-	Content    string         `json:"content,omitempty"`
+	Role string `json:"role"`
+	// Content is `any` so a user message can carry EITHER the flat string form
+	// (text-only — byte-identical to the pre-vision path) OR the content-array
+	// form []wireContentPart when an image block is present (RFC AT). omitempty
+	// drops only a nil interface — assistant/user paths therefore leave Content
+	// nil (not "") to keep the empty-content omission (RFC Q); tool messages
+	// force content present via MarshalJSON below.
+	Content    any            `json:"content,omitempty"`
 	Name       string         `json:"name,omitempty"`
 	ToolCallID string         `json:"tool_call_id,omitempty"`
 	ToolCalls  []wireToolCall `json:"tool_calls,omitempty"`
@@ -234,13 +241,31 @@ func (m wireMessage) MarshalJSON() ([]byte, error) {
 		// The outer Content (no omitempty, depth 0) overrides the
 		// embedded alias's omitempty content (depth 1) — encoding/json
 		// resolves the same-name conflict in favour of the shallower
-		// field, so `content` is always emitted for tool messages.
+		// field, so `content` is always emitted for tool messages. A
+		// tool message's content is always the flat string form, so the
+		// `any` coerces cleanly (zero value "" when no output).
+		txt, _ := m.Content.(string)
 		return json.Marshal(struct {
 			alias
 			Content string `json:"content"`
-		}{alias: alias(m), Content: m.Content})
+		}{alias: alias(m), Content: txt})
 	}
 	return json.Marshal(alias(m))
+}
+
+// wireContentPart is one element of the OpenAI content-array form, used only
+// when a user message carries an image (RFC AT). A part is either a text part
+// or an image_url part holding an inline data-URI.
+type wireContentPart struct {
+	Type     string        `json:"type"` // "text" | "image_url"
+	Text     string        `json:"text,omitempty"`
+	ImageURL *wireImageURL `json:"image_url,omitempty"`
+}
+
+// wireImageURL carries the data-URI the driver builds internally from the image
+// block's media_type + base64. Callers never send URLs (SSRF — RFC AT §6).
+type wireImageURL struct {
+	URL string `json:"url"` // "data:<media_type>;base64,<data>"
 }
 
 type wireToolCall struct {
@@ -266,6 +291,14 @@ type wireFunction struct {
 }
 
 func buildRequestBody(req providers.Request) ([]byte, error) {
+	// Refuse an image to a text-only OpenAI model before the call — a clear
+	// error beats an opaque provider 400 (RFC AT §5.2). DeepSeek (which
+	// delegates Call here) never reaches this: its Capabilities advertises
+	// SupportsVision=false, so the loop gates an image to DeepSeek upstream.
+	if providers.RequestHasImage(req) && !openaiSupportsVision(req.Model) {
+		return nil, fmt.Errorf("openai model %q does not support image input", req.Model)
+	}
+
 	w := wireRequest{
 		Model:            req.Model,
 		MaxTokens:        req.MaxTokens,
@@ -348,17 +381,25 @@ func flattenMessage(m providers.Message) []wireMessage {
 		// in the thinking mode must be passed back"). omitempty keeps
 		// the field off the wire for non-thinking models / non-DeepSeek
 		// endpoints; vanilla OpenAI ignores unknown fields anyway.
-		return []wireMessage{{
-			Role:             "assistant",
-			Content:          text.String(),
-			ToolCalls:        calls,
-			ReasoningContent: m.Reasoning,
-		}}
+		wm := wireMessage{Role: "assistant", ToolCalls: calls, ReasoningContent: m.Reasoning}
+		// Leave Content nil (omitted) for a tool_calls-only assistant turn —
+		// both OpenAI and DeepSeek require that (RFC Q). Now that Content is
+		// `any`, an empty string "" would be EMITTED by omitempty, so only set
+		// it when there is text.
+		if text.Len() > 0 {
+			wm.Content = text.String()
+		}
+		return []wireMessage{wm}
 	}
 
-	// user role: split tool_result blocks into their own messages.
+	// user role: tool_result blocks become their own role:"tool" messages; text
+	// + image blocks form one user message. An image forces the OpenAI
+	// content-array form (text + image_url parts, original order); a text-only
+	// turn keeps the flat string content (byte-identical to the pre-vision path).
 	var out []wireMessage
 	var userText strings.Builder
+	var parts []wireContentPart
+	hasImage := false
 	for _, c := range m.Content {
 		switch c.Type {
 		case "tool_result":
@@ -372,13 +413,51 @@ func flattenMessage(m providers.Message) []wireMessage {
 				userText.WriteString("\n")
 			}
 			userText.WriteString(c.Text)
+			parts = append(parts, wireContentPart{Type: "text", Text: c.Text})
+		case "image":
+			hasImage = true
+			parts = append(parts, wireContentPart{
+				Type:     "image_url",
+				ImageURL: &wireImageURL{URL: "data:" + c.MediaType + ";base64," + c.Data},
+			})
 		}
 	}
-	if userText.Len() > 0 {
-		// Plain user text comes first; tool messages follow.
+	switch {
+	case hasImage:
+		// Plain user content (array form) comes first; tool messages follow.
+		out = append([]wireMessage{{Role: "user", Content: parts}}, out...)
+	case userText.Len() > 0:
 		out = append([]wireMessage{{Role: "user", Content: userText.String()}}, out...)
 	}
 	return out
+}
+
+// openaiSupportsVision reports whether the named OpenAI model accepts image
+// input. The modern multimodal families (gpt-4o, gpt-4.1, gpt-4-turbo, the
+// gpt-5 line, the o-series) support it; the legacy text-only families
+// (gpt-3.5-turbo and the original gpt-4 / gpt-4-32k snapshots) do not. An
+// unknown model defaults to supported — a wrong guess surfaces as a provider
+// 400, never a silent drop, and never wrongly BLOCKS a valid request (RFC AT
+// §7). Capabilities() takes no model arg, so this is the per-model affordance.
+func openaiSupportsVision(model string) bool {
+	m := strings.ToLower(model)
+	if strings.HasPrefix(m, "gpt-3.5") {
+		return false
+	}
+	return !openaiTextOnlyModels[m]
+}
+
+// openaiTextOnlyModels are the exact original gpt-4 snapshots that predate
+// vision (gpt-4-turbo and later are multimodal). Matched exactly — NOT by
+// prefix — so a turbo/preview snapshot like gpt-4-0125-preview is not wrongly
+// gated.
+var openaiTextOnlyModels = map[string]bool{
+	"gpt-4":          true,
+	"gpt-4-0314":     true,
+	"gpt-4-0613":     true,
+	"gpt-4-32k":      true,
+	"gpt-4-32k-0314": true,
+	"gpt-4-32k-0613": true,
 }
 
 // --- streaming response parsing ---

--- a/internal/providers/openai/vision_test.go
+++ b/internal/providers/openai/vision_test.go
@@ -1,0 +1,100 @@
+package openai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+const visTestB64 = "iVBORw0KGgo="
+
+// TestVision_OpenAIImageUsesContentArray: a user message with an image
+// serializes to the content-array form — a text part plus an image_url part
+// whose url is the inline data-URI the driver builds from media_type + base64.
+func TestVision_OpenAIImageUsesContentArray(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "describe"},
+			{Type: "image", MediaType: "image/png", Data: visTestB64},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	user := findByRole(t, decodeWireMessages(t, body), "user")
+	var parts []struct {
+		Type     string `json:"type"`
+		Text     string `json:"text"`
+		ImageURL *struct {
+			URL string `json:"url"`
+		} `json:"image_url"`
+	}
+	if err := json.Unmarshal(user["content"], &parts); err != nil {
+		t.Fatalf("user content is not an array: %s (%v)", user["content"], err)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("want 2 content parts, got %d: %s", len(parts), user["content"])
+	}
+	if parts[0].Type != "text" || parts[0].Text != "describe" {
+		t.Errorf("part 0 not the text part: %+v", parts[0])
+	}
+	if parts[1].Type != "image_url" || parts[1].ImageURL == nil {
+		t.Fatalf("part 1 not an image_url part: %+v", parts[1])
+	}
+	if want := "data:image/png;base64," + visTestB64; parts[1].ImageURL.URL != want {
+		t.Errorf("image_url.url = %q, want %q", parts[1].ImageURL.URL, want)
+	}
+}
+
+// TestVision_TextOnlyUserKeepsFlatString: a text-only user message keeps the
+// flat string content form — the pre-vision path is unchanged (no regression
+// to the content-array form for non-image turns).
+func TestVision_TextOnlyUserKeepsFlatString(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model: "gpt-4o",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+			{Type: "text", Text: "hello"},
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	user := findByRole(t, decodeWireMessages(t, body), "user")
+	if string(user["content"]) != `"hello"` {
+		t.Errorf("text-only content = %s, want flat string \"hello\"", user["content"])
+	}
+}
+
+// TestVision_OpenAIRejectsImageOnTextOnlyModel: a known text-only model is
+// refused before the call with a clear error.
+func TestVision_OpenAIRejectsImageOnTextOnlyModel(t *testing.T) {
+	for _, model := range []string{"gpt-3.5-turbo", "gpt-4", "gpt-4-32k"} {
+		_, err := buildRequestBody(providers.Request{
+			Model: model,
+			Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{
+				{Type: "image", MediaType: "image/png", Data: visTestB64},
+			}}},
+		})
+		if err == nil || !strings.Contains(err.Error(), "does not support image input") {
+			t.Errorf("model %q: want image-refusal error, got %v", model, err)
+		}
+	}
+}
+
+func TestOpenAISupportsVision(t *testing.T) {
+	vision := []string{"gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4.1", "gpt-5", "gpt-5.4-mini", "o3", "gpt-4-0125-preview"}
+	textOnly := []string{"gpt-3.5-turbo", "gpt-3.5-turbo-0613", "gpt-4", "gpt-4-0314", "gpt-4-0613", "gpt-4-32k"}
+	for _, m := range vision {
+		if !openaiSupportsVision(m) {
+			t.Errorf("openaiSupportsVision(%q) = false, want true", m)
+		}
+	}
+	for _, m := range textOnly {
+		if openaiSupportsVision(m) {
+			t.Errorf("openaiSupportsVision(%q) = true, want false", m)
+		}
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -78,6 +78,17 @@ type Capabilities struct {
 	MaxContextTokens  int
 	SupportsThinking  bool
 
+	// SupportsVision signals that this provider can accept image content
+	// blocks (RFC AT) on at least some of its models. The loop uses it as a
+	// coarse pre-call gate: an image sent to a SupportsVision=false provider
+	// (or a fallback that routed there) fails loudly with an EventError
+	// instead of the image being silently dropped or the provider returning
+	// an opaque 400. Per-model nuance (a legacy non-vision model on an
+	// otherwise vision-capable provider) is enforced inside the driver via a
+	// helper (e.g. anthropicSupportsVision(model)), mirroring how
+	// SupportsEffort is coarse here but refined per-call in the driver.
+	SupportsVision bool
+
 	// SupportsEffort signals that the driver translates Request.Effort
 	// into a native wire parameter when set. Anthropic maps it to a
 	// `thinking.budget_tokens` block; OpenAI to `reasoning_effort`;
@@ -206,6 +217,15 @@ type ContentBlock struct {
 	ToolName  string          `json:"name,omitempty"`
 	ToolInput json.RawMessage `json:"input,omitempty"`
 	IsError   bool            `json:"is_error,omitempty"`
+
+	// Image fields (Type == "image", RFC AT). MediaType is a whitelisted
+	// image media type (image/png|jpeg|gif|webp); Data is the raw base64 of
+	// the image bytes with NO "data:" prefix. Each driver serializes these
+	// into its own wire form (Anthropic source block / OpenAI image_url
+	// data-URI / Gemini inlineData / Ollama images[]). Empty for every
+	// non-image block.
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
 }
 
 // ToolSpec describes one tool to the model.

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -228,6 +228,22 @@ type ContentBlock struct {
 	Data      string `json:"data,omitempty"`
 }
 
+// RequestHasImage reports whether any message in the request carries an image
+// content block (RFC AT). Drivers whose vision support is per-model (Anthropic,
+// OpenAI) use it to refuse an image to a known text-only model with a clear
+// error before the HTTP call, rather than letting the provider return an opaque
+// 400.
+func RequestHasImage(req Request) bool {
+	for _, m := range req.Messages {
+		for _, c := range m.Content {
+			if c.Type == "image" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ToolSpec describes one tool to the model.
 type ToolSpec struct {
 	Name        string          `json:"name"`


### PR DESCRIPTION
## Why

loomcycle is text-only today — there is no way to send an image to a model (`openai_compat.go` literally drops image parts, and there's no image handling in `internal/providers` or `internal/loop`). Every target provider supports image input natively, and the motivating consumer is loomboard's chat attachments. This adds **one** new `image` content block, carried end to end and serialized natively by every vision-capable provider. Implements **RFC AT**.

Additive + backward-compatible: text-only callers are unchanged; no new endpoint or transport.

## What

A `user`-role segment can carry an `image` block (`media_type` whitelist: png/jpeg/gif/webp; `data` = raw base64, **no URL form** — SSRF). The block threads through the existing `flattenContent` → `providers.ContentBlock` → per-driver conversion seams. Layered commits:

1. **loop** — `PromptContentBlock`/`providers.ContentBlock` gain `MediaType`+`Data`; `Capabilities.SupportsVision`; `flattenContent` `image` case; a once-per-run pre-call **validate** (user-role only, media-type whitelist, base64-decodes) **+ capability gate** (image → non-vision provider → clear `EventError` before the call, never a silent drop).
2. **anthropic** — native `{"type":"image","source":{base64,…}}`; `anthropicSupportsVision(model)` (gates `claude-2`/`claude-instant`).
3. **openai (+deepseek)** — user `content` → parts array (`text` + `image_url` data-URI), preserving the RFC Q empty-content invariant (`Content` is now `any`; tool messages still force content, tool_calls-only assistant still omits it); `openaiSupportsVision(model)` (gates `gpt-3.5*` + the original `gpt-4`/`gpt-4-32k` snapshots, exact-match so `gpt-4-0125-preview` isn't wrongly gated). **DeepSeek overrides `SupportsVision=false`** (it delegates `Capabilities()` to the inner OpenAI driver) so the loop gates it upstream.
4. **gemini** — `inlineData {mimeType, data}`.
5. **ollama** — message `images: [base64]`.
6. **http** — the run-ingest body cap (`/v1/runs`, `/v1/sessions/{id}/messages`) is now `LOOMCYCLE_MAX_REQUEST_BYTES` (default **16 MiB**, was a hardcoded 1 MiB); over-cap → **413** (was 400).
7. **docs** — `docs/PROVIDERS.md` "Image / vision input" section.

The per-model gate helpers default unknown models to **supported** — a wrong guess surfaces as a provider error, never a silent drop and never a wrongly-blocked valid request (RFC AT §7).

### Out of scope (per RFC AT)
gRPC/proto image parity (HTTP is the consumer path), image *output*, audio/video, image *URLs*, and the `@loomcycle/client` `image` variant (loomboard consumer follow-up).

## Tested

- `go test ./...` clean (the one local `TestLoadExample` failure is a pre-existing stray uncommitted edit to `loomcycle.example.yaml` adding a `/work/sandbox` volume — **not in this branch's commits**; passes on a clean checkout).
- New tests: loop passthrough + gate (image → non-vision provider errors, `Provider.Call` never invoked) + `validateImageSegments` table; per-driver wire-shape (Anthropic source block, OpenAI content-array data-URI, Gemini inlineData, Ollama images[]); OpenAI text-only-stays-flat-string + the unchanged RFC Q empty-content invariants; DeepSeek caps; body cap over→413 / under→200.
- `gofmt`/`go vet` clean; `make`-equivalent binary build OK.
- **Recommended pre-merge manual check:** `curl` a small base64 image to a real vision model per provider where a key is available (no provider key was used here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)