### PR TITLE
fix(loop): re-check vision support on the provider-fallback target (RFC AT §4.4)

### DIFF
--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -16,20 +16,24 @@ import (
 // tieredProvider is a fakeProvider variant whose ID is configurable.
 // The fallback tests need two distinct providers with different IDs
 // so we can assert the EventProviderFallback payload carries the
-// correct new_provider name.
+// correct new_provider name. `supportsVision` overrides the default
+// Capabilities for the vision-mismatch fallback case (RFC AT §4.4) —
+// existing tests get the zero value (false), which matches the
+// pre-RFC-AT default and preserves their behaviour.
 type tieredProvider struct {
-	id        string
-	mu        sync.Mutex
-	responses [][]providers.Event
-	errors    []error // returned by Call() at the same index; nil → use responses[idx]
-	calls     int
+	id             string
+	mu             sync.Mutex
+	responses      [][]providers.Event
+	errors         []error // returned by Call() at the same index; nil → use responses[idx]
+	calls          int
+	supportsVision bool
 }
 
 func (p *tieredProvider) ID() string                                     { return p.id }
 func (p *tieredProvider) Probe(_ context.Context) error                  { return nil }
 func (p *tieredProvider) ListModels(_ context.Context) ([]string, error) { return []string{"m"}, nil }
 func (p *tieredProvider) Capabilities() providers.Capabilities {
-	return providers.Capabilities{Streaming: true}
+	return providers.Capabilities{Streaming: true, SupportsVision: p.supportsVision}
 }
 func (p *tieredProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
 	p.mu.Lock()
@@ -865,6 +869,104 @@ func (d *downgradingRecorder) NonThinkingSibling(model string) (string, bool) {
 		return "deepseek-v4-flash", true
 	default:
 		return "", false
+	}
+}
+
+// TestFallback_NonVisionTarget_SuppressesFallback is the RFC AT §4.4
+// regression: a mid-run fallback whose target lacks SupportsVision MUST be
+// refused with a clear EventFallbackSuppressed (and the original error
+// propagated), never silently swap so the image_url part can leak to a
+// text-only provider that 400s with "unknown variant 'image_url'". The
+// initial-call gate only checks the FIRST resolved provider; without
+// re-checking in tryProviderFallback, a swap from anthropic →
+// deepseek-text on a vision-bearing run would slip past both gates.
+// FAIL-BEFORE: pre-fix, EventProviderFallback fires + opts.Provider is
+// mutated to the non-vision target.
+func TestFallback_NonVisionTarget_SuppressesFallback(t *testing.T) {
+	failing := &tieredProvider{
+		id:             "anthropic",
+		supportsVision: true, // passes the initial-call gate
+		errors:         []error{fmt.Errorf("anthropic 503: service unavailable")},
+	}
+	textOnly := &tieredProvider{
+		id:             "deepseek",
+		supportsVision: false, // the bug-shaped target
+		// No scripted responses — the test asserts we NEVER reach Call().
+	}
+
+	var events []providers.Event
+	var mu sync.Mutex
+
+	opts := RunOptions{
+		Provider:      failing,
+		Model:         "claude-sonnet-4-6",
+		MaxIterations: 5,
+		// Image-bearing user segment is what makes the vision gate apply.
+		Segments: []PromptSegment{{
+			Role: "user",
+			Content: []PromptContentBlock{
+				{Type: "trusted-text", Text: "what's in this image?"},
+				{Type: "image", MediaType: "image/png", Data: testPNGB64},
+			},
+		}},
+		OnEvent: func(ev providers.Event) {
+			mu.Lock()
+			defer mu.Unlock()
+			events = append(events, ev)
+		},
+		FallbackPolicy: FallbackPolicy{
+			Enabled:      true,
+			MaxAttempts:  3,
+			UserTierName: "medium",
+		},
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return textOnly, "deepseek-v4-pro", "", nil
+		},
+	}
+	_, err := Run(context.Background(), opts)
+	if err == nil {
+		t.Fatal("Run: nil error, want the failing-provider's original error to propagate after refused fallback")
+	}
+	// Caller sees the ORIGINAL provider error, not a vision-specific one — the
+	// reason for the refusal goes via EventFallbackSuppressed below.
+	if !strings.Contains(err.Error(), "anthropic 503") {
+		t.Errorf("Run err = %q, want substring 'anthropic 503' (original error propagated)", err.Error())
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// EventFallbackSuppressed must be present, carrying the RFC AT §4.4 cite
+	// and the failed/target pair so an operator can audit.
+	var suppressed *providers.Event
+	for i := range events {
+		if events[i].Type == providers.EventFallbackSuppressed {
+			suppressed = &events[i]
+			break
+		}
+	}
+	if suppressed == nil {
+		t.Fatal("no EventFallbackSuppressed emitted; the refusal is invisible to the operator")
+	}
+	for _, want := range []string{"RFC AT §4.4", "image", "does not support vision", "anthropic", "deepseek"} {
+		if !strings.Contains(suppressed.Text, want) {
+			t.Errorf("suppressed.Text = %q\n  missing substring: %q", suppressed.Text, want)
+		}
+	}
+
+	// EventProviderFallback must NOT fire — no switch actually happened, so
+	// emitting it would lie to the operator about which provider ran.
+	for _, ev := range events {
+		if ev.Type == providers.EventProviderFallback {
+			t.Errorf("EventProviderFallback emitted: %+v — but the switch was refused, so this event should not fire", ev)
+		}
+	}
+
+	// The non-vision target must NEVER have been called.
+	textOnly.mu.Lock()
+	defer textOnly.mu.Unlock()
+	if textOnly.calls != 0 {
+		t.Errorf("textOnly.calls = %d, want 0 (the fallback target should not be reached)", textOnly.calls)
 	}
 }
 

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -563,6 +563,25 @@ func tryProviderFallback(
 		return fallbackOutcomeReResolveFailed
 	}
 
+	// RFC AT §4.4: if this run carries an image content block, the fallback
+	// target must also accept image input. The initial-call gate before the
+	// main loop only checks the FIRST resolved provider; without this re-check,
+	// a mid-run swap to a text-only provider (e.g. DeepSeek, which wraps the
+	// OpenAI driver and overrides SupportsVision=false) would let the image
+	// part reach the upstream and the provider would 400 with a raw
+	// "unknown variant 'image_url'" — exactly what RFC AT §4.4 says must NOT
+	// happen. Fail loudly here instead of leaking a request that's structurally
+	// invalid for the target. Skip *attempts++ + EventProviderFallback because
+	// no switch actually happens; emit EventFallbackSuppressed so the operator
+	// sees the refused candidate.
+	if messagesHaveImage(messages) && !newProvider.Capabilities().SupportsVision {
+		emit(providers.Event{
+			Type: providers.EventFallbackSuppressed,
+			Text: fmt.Sprintf("fallback from %s/%s to %s/%s suppressed: run carries an image but the fallback target does not support vision (RFC AT §4.4); run will fail with cause: %s", failedProvider, failedModel, newProvider.ID(), newModel, truncateError(cause)),
+		})
+		return fallbackOutcomeNotEligible
+	}
+
 	*attempts++
 
 	emit(providers.Event{
@@ -1142,10 +1161,11 @@ func Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	// call when the resolved provider can't accept image input (e.g. an agent
 	// whose tier resolved to DeepSeek's text endpoint). This fails loudly here
 	// instead of the image being silently dropped. Checked once at the resolved
-	// provider: a mid-run fallback to a non-vision provider is caught by the
-	// driver's own per-model gate (a clear error) / surfaces as a provider
-	// error, never a silent drop. PriorMessages were validated when first sent,
-	// so only the fresh segments need re-validating here.
+	// provider AND inside tryProviderFallback against the fallback target — a
+	// mid-run swap to a non-vision provider is refused with a clear
+	// EventFallbackSuppressed event (RFC AT §4.4), never a silent leak to a
+	// raw 400. PriorMessages were validated when first sent, so only the fresh
+	// segments need re-validating here.
 	if messagesHaveImage(messages) {
 		if err := validateImageSegments(opts.Segments); err != nil {
 			emit(providers.Event{Type: providers.EventError, Error: err.Error()})

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -315,25 +315,30 @@ const (
 	EventCacheInvalidated EventType = "cache_invalidated"
 
 	// EventFallbackSuppressed signals that a retryable error would
-	// have triggered a provider fallback, but the run was already
-	// past its first successful turn AND the operator opted into
-	// "pin provider after first successful turn" semantics
-	// (`LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1`). The cause error
-	// propagates to the caller; the run fails. Purely informational.
+	// have triggered a provider fallback, but the loop refused the
+	// switch. The cause error propagates to the caller; the run
+	// fails. Purely informational. Two refusal reasons emit it:
 	//
-	// Why: cross-provider mid-conversation fallback exposes a
-	// growing surface of provider-specific transcript translation
-	// bugs (Anthropic cache_control, DeepSeek reasoning_content,
-	// gemini thoughtSignature, tool_call shape differences). Each
-	// requires its own translation layer. Pinning after first
-	// success closes the entire class of bug in exchange for
-	// dropping resilience to mid-conversation provider issues —
-	// existing same-provider rate-limit retry (internal/providers/
-	// ratelimit/) still covers transient errors within one provider.
+	//  1. Pin-after-success: the run was already past its first
+	//     successful turn AND the operator opted into "pin provider
+	//     after first successful turn" (`LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1`).
+	//     Cross-provider mid-conversation fallback exposes a growing
+	//     surface of provider-specific transcript translation bugs
+	//     (Anthropic cache_control, DeepSeek reasoning_content, gemini
+	//     thoughtSignature, tool_call shape differences); pinning after
+	//     first success closes that class of bug in exchange for dropping
+	//     resilience to mid-conversation provider issues (same-provider
+	//     rate-limit retry in internal/providers/ratelimit/ still covers
+	//     transient errors within one provider).
+	//  2. Vision mismatch (RFC AT §4.4): the run carries an image content
+	//     block but the re-resolved fallback target does not support
+	//     vision (e.g. DeepSeek's text endpoint). Switching would let the
+	//     image part reach a provider that 400s on it ("unknown variant
+	//     'image_url'"), which RFC AT §4.4 says must not happen — so the
+	//     swap is refused before the call.
 	//
-	// The Text field carries a human-readable summary:
-	// "fallback to <new> suppressed: provider <old> pinned after
-	// first successful turn".
+	// The Text field carries a human-readable summary naming the failed
+	// and (for reason 2) the refused target provider/model.
 	EventFallbackSuppressed EventType = "fallback_suppressed"
 
 	// EventReasoningInvalidated signals that a v0.8.x runtime


### PR DESCRIPTION
## Why

Reported by the loomboard dev team: *"vision capability gate misses the provider-fallback target (image leaks to DeepSeek → raw 400)."*

The RFC AT vision gate runs once **before** the loop, against the **initially-resolved** provider only. When a vision-bearing run fails over mid-flight to a text-only provider, the gate never re-runs — so the `image_url` part reaches the fallback target and the provider returns a raw 400 (DeepSeek: `unknown variant 'image_url'`), exactly what RFC AT §4.4 says must not happen.

The driver-level per-model gate doesn't save DeepSeek either: DeepSeek delegates `Call` to the OpenAI driver, where `openaiSupportsVision("deepseek-*")` defaults to *supported*, so the `image_url` is built and leaks.

## What

`tryProviderFallback` now re-checks `SupportsVision` against the **re-resolved** `(provider, model)`. If the run carries an image and the target isn't vision-capable, the swap is refused:
- no `*attempts++`, no `EventProviderFallback` (no switch happened);
- an `EventFallbackSuppressed` is emitted with the RFC AT §4.4 cite + the failed/refused provider pair;
- the original provider error propagates — the run **fails loudly, never leaks**.

DeepSeek's `Capabilities().SupportsVision=false` (shipped in v1.7.0) makes the check fire for the motivating case. Also updated `providers.EventFallbackSuppressed`'s doc — it now has two emission reasons (pin-after-success *and* vision-mismatch), previously documented for only the first.

**Trade-off (intentional, matches the report):** refusing a candidate terminates the fallback cascade rather than skipping to a later vision-capable one. Safe (no leak, fails loudly); a skip-and-continue resolver pass can follow if resilience matters more than failing fast.

## Provenance + verification

These changes were drafted by another agent and left uncommitted on `main`; I verified them, added the missing doc-comment update, and moved them onto this branch. Verification:
- **Compiles** — `EventFallbackSuppressed` / `fallbackOutcomeNotEligible` / `truncateError` are all pre-existing (not invented).
- **Genuine regression test** — `TestFallback_NonVisionTarget_SuppressesFallback` fails on the unfixed loop (`Run err = "no scripted response … for deepseek"` — the swap proceeds and the target is called) and passes with the fix.
- `go test ./...` clean; `gofmt`/`go vet` clean; binary builds.

## Tested

`TestFallback_NonVisionTarget_SuppressesFallback`: a vision run failing over anthropic→deepseek-text emits `EventFallbackSuppressed`, never fires `EventProviderFallback`, never calls the target, and propagates the original `anthropic 503`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)