### PR TITLE
feat(ollama): map the effort hint to Ollama's `think` flag

### DIFF
--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -233,16 +233,15 @@ func (d *Driver) Capabilities() providers.Capabilities {
 		// LOOMCYCLE_OLLAMA*_NUM_CTX) that is the exact window; else 0 here
 		// ("unknown") and the per-call /api/ps value fills it in once loaded.
 		MaxContextTokens: d.numCtx,
-		SupportsThinking: false,
-		// Ollama has no operator-controlled thinking-budget knob today.
-		// Reasoning models (qwen3, deepseek-r1, hermes3) decide whether
-		// to think based on their own defaults; the message.thinking
-		// field is now surfaced as EventThinking so adapters can render
-		// or hide the trace, but loomcycle has no input-side hint that
-		// would dial it up or down. SupportsEffort=false signals to the
-		// loop that an Ollama-routed agent's effort hint is dropped, so
-		// the loop logs once per Run for operator visibility.
-		SupportsEffort: false,
+		SupportsThinking: true,
+		// The effort hint drives Ollama's top-level `think` flag (see
+		// buildRequestBody): medium/high enable a reasoning model's
+		// thinking trace, low disables it, empty leaves the model default.
+		// Ollama populates message.thinking only when think=true, which is
+		// then surfaced as EventThinking. SupportsEffort=true so the loop
+		// forwards the hint rather than logging it as dropped. The model
+		// must be thinking-capable (qwen3, gemma4, deepseek-r1, …).
+		SupportsEffort: true,
 		// Vision depends on the pulled model (llava, llama3.2-vision, …).
 		// Report true and treat model choice as the operator's responsibility
 		// (RFC AT §5.4); a non-vision model's failure surfaces via the existing
@@ -347,6 +346,11 @@ type wireRequest struct {
 	Messages []wireMessage `json:"messages"`
 	Tools    []wireTool    `json:"tools,omitempty"`
 	Options  *wireOptions  `json:"options,omitempty"`
+	// Think toggles a reasoning model's thinking trace via Ollama's /api/chat
+	// `think` field. nil omits it (model default); set from the agent's effort
+	// hint. Ollama populates message.thinking only when this is true, and
+	// errors if the resolved model isn't thinking-capable.
+	Think *bool `json:"think,omitempty"`
 }
 
 type wireOptions struct {
@@ -396,6 +400,20 @@ func (d *Driver) buildRequestBody(req providers.Request) ([]byte, error) {
 	w := wireRequest{
 		Model:  req.Model,
 		Stream: true,
+	}
+
+	// Map the effort hint to Ollama's `think` flag: medium/high enable the
+	// reasoning trace, low disables it, empty leaves the model default. The
+	// model must be thinking-capable (qwen3, gemma4, deepseek-r1, …); Ollama
+	// errors on `think` for models that can't reason, so this is operator
+	// opt-in via effort.
+	switch req.Effort {
+	case "medium", "high":
+		think := true
+		w.Think = &think
+	case "low":
+		think := false
+		w.Think = &think
 	}
 
 	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 || d.numGpu > 0 ||

--- a/internal/providers/ollama/effort_test.go
+++ b/internal/providers/ollama/effort_test.go
@@ -1,29 +1,71 @@
 package ollama
 
 import (
-	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+	"encoding/json"
 	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
 )
 
-// Ollama doesn't translate effort — it has no operator-controlled
-// thinking-budget knob today. The capability flag tells the loop
-// to log "effort dropped" once per Run for visibility. These tests
-// pin both the capability contract and the silent-drop invariant.
+// Ollama maps the agent's effort hint to its top-level `think` flag, which
+// turns a reasoning model's thinking trace on/off. These tests pin both the
+// capability contract and the effort→think wire translation.
 
-func TestCapabilities_SupportsEffortIsFalse(t *testing.T) {
-	// SupportsEffort=false means: the loop logs "effort dropped"
-	// when an agent declares effort on an Ollama-resolved run.
-	// Operators see clearly that the hint was discarded rather
-	// than silently believing the agent thought hard.
+func TestCapabilities_SupportsEffortIsTrue(t *testing.T) {
+	// SupportsEffort=true: the loop forwards the effort hint to the driver,
+	// which translates it into `think` rather than dropping it.
 	d := New("", "", "http://localhost:11434", streamhttp.Options{}, nil)
-	if d.Capabilities().SupportsEffort {
-		t.Error("Ollama driver must report SupportsEffort=false (no thinking-budget knob today)")
+	caps := d.Capabilities()
+	if !caps.SupportsEffort {
+		t.Error("Ollama driver must report SupportsEffort=true (effort drives `think`)")
+	}
+	if !caps.SupportsThinking {
+		t.Error("Ollama driver must report SupportsThinking=true")
 	}
 }
 
-// We don't test the wire body here because Ollama's Capabilities
-// flag is the contract — drivers with SupportsEffort=false promise
-// the field is dropped, but they don't have to make it visible at
-// the wire level. The loop's log-once-per-Run is the operator-
-// facing signal. The behavior is exercised end-to-end in the
-// internal/loop tests via fakeProvider with SupportsEffort=false.
+func TestBuildRequestBody_EffortMapsToThink(t *testing.T) {
+	d := New("", "", "http://localhost:11434", streamhttp.Options{}, nil)
+	req := func(effort string) providers.Request {
+		return providers.Request{
+			Model:  "qwen3",
+			Effort: effort,
+			Messages: []providers.Message{
+				{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+			},
+		}
+	}
+
+	cases := []struct {
+		effort   string
+		wantSet  bool // is `think` present on the wire?
+		wantBool bool // its value when present
+	}{
+		{"high", true, true},
+		{"medium", true, true},
+		{"low", true, false},
+		{"", false, false},
+	}
+	for _, c := range cases {
+		body, err := d.buildRequestBody(req(c.effort))
+		if err != nil {
+			t.Fatalf("effort %q: buildRequestBody: %v", c.effort, err)
+		}
+		var w struct {
+			Think *bool `json:"think"`
+		}
+		if err := json.Unmarshal(body, &w); err != nil {
+			t.Fatalf("effort %q: unmarshal: %v", c.effort, err)
+		}
+		if c.wantSet {
+			if w.Think == nil {
+				t.Errorf("effort %q: want think=%v, got omitted", c.effort, c.wantBool)
+			} else if *w.Think != c.wantBool {
+				t.Errorf("effort %q: want think=%v, got %v", c.effort, c.wantBool, *w.Think)
+			}
+		} else if w.Think != nil {
+			t.Errorf("effort %q: want think omitted, got %v", c.effort, *w.Think)
+		}
+	}
+}


### PR DESCRIPTION
## Why

We had no way to enable a **local reasoning model's** thinking trace. Ollama's `/api/chat` takes a top-level **`think`** boolean (qwen3, deepseek-r1, gemma-thinking, …) that turns the trace on/off and routes it to the `message.thinking` field — but loomcycle never sent it. So a thinking-capable Ollama model ran on its own default, and an `effort` hint on an Ollama agent was logged as *"dropped"*.

This closes the last gap in loomcycle's "thinking" surface. The cloud drivers already enable thinking from the per-agent `effort` hint (Anthropic `thinking.budget_tokens`, OpenAI `reasoning_effort`, Gemini `thinkingConfig`); Ollama now does too.

## What

`buildRequestBody` translates `effort` into `think`:

| `effort` | `think` on the wire |
|---|---|
| `medium` / `high` | `true` (enable the trace) |
| `low` | `false` (suppress it) |
| unset (`""`) | omitted (model default) |

The trace returns as `EventThinking` (already parsed from `message.thinking`). `Capabilities()` now reports `SupportsThinking=true` + `SupportsEffort=true` so the loop forwards the hint instead of logging it as dropped — verified the **only** behavioral consumer of `SupportsEffort` is that drop-log (`loop.go:1136`). Applies to both `ollama` (cloud) and `ollama-local` (one driver).

### Behavior change (intentional, consistent with the other providers)
Setting `effort` on an Ollama agent whose model is **not** thinking-capable now sends `think:true` and Ollama errors clearly, where before the hint was a silent no-op. This mirrors Anthropic/OpenAI/Gemini (which 400 on effort + a non-reasoning model). Pick a thinking-capable model when you set effort on Ollama.

## Provenance + verification

Drafted by another agent and left committed on a local-only branch off `main`; I un-wrapped it into this single clean commit, softened a version-pin in a comment, verified it, and deleted the duplicate branch. Verification:
- `go build ./...` + `go test ./...` clean; `gofmt`/`go vet` clean.
- Confirmed `SupportsEffort` has no consumer beyond the drop-log, so flipping it `true` only stops the (now-misleading) log.

## Tested

`TestCapabilities_SupportsEffortIsTrue` (the capability contract) + `TestBuildRequestBody_EffortMapsToThink` (`high`/`medium`→`think:true`, `low`→`false`, `""`→omitted on the wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)