### PR TITLE
fix(cli): honor config layering in validate/agents/doctor + opt-in Ollama think diagnostic

### DIFF
--- a/internal/cli/agents.go
+++ b/internal/cli/agents.go
@@ -39,7 +39,7 @@ func runAgentsList(args []string, stdout, stderr io.Writer) int {
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
-	cfg, err := config.Load(*cfgPath)
+	cfg, err := loadLayeredConfig(*cfgPath)
 	if err != nil {
 		return fail(stderr, "config: %v", err)
 	}

--- a/internal/cli/doctor_adapters.go
+++ b/internal/cli/doctor_adapters.go
@@ -46,7 +46,7 @@ func (r *realConfig) ListenAddrValue() string { return r.cfg.Env.ListenAddr }
 // loadConfigRealAdapter is the production seam for loadConfigForDoctor.
 // Tests override the package-level var to plug in a stub.
 func loadConfigRealAdapter(path string) (configForDoctor, error) {
-	cfg, err := config.Load(path)
+	cfg, err := loadLayeredConfig(path)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/loadcfg.go
+++ b/internal/cli/loadcfg.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/cmd/loomcycle/embedded"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// loadLayeredConfig assembles the SAME layered configuration the server builds
+// (RFC AN/AQ), so CLI introspection (validate / agents / doctor) reflects what
+// the running server actually resolves — embedded presets (LOOMCYCLE_PRESETS) as
+// the base, then LOOMCYCLE_CONFIG_DIR/*.yaml, then LOOMCYCLE_CONFIG_FILES, then
+// the explicit --config path (last wins).
+//
+// Before this, the CLI called config.Load(path) — a single file — so an agent
+// whose model is a preset-defined alias (e.g. `deepseek-pro` from the base
+// preset) reported a false "no provider resolved" in these tools even though
+// the running server resolved it fine. The layer set + precedence mirror
+// cmd/loomcycle/main.go's server assembly; the CLI variant omits the
+// server-only concerns (XDG auto-discovery beyond the explicit path, auth.env,
+// os.Exit) it doesn't need. With neither LOOMCYCLE_PRESETS nor the CONFIG_*
+// env vars set, behaviour is byte-identical to the old config.Load(path).
+func loadLayeredConfig(explicitPath string) (*config.Config, error) {
+	var layers []config.Layer
+
+	// Embedded presets — the base of the stack.
+	var presetNames []string
+	for _, n := range strings.Split(os.Getenv("LOOMCYCLE_PRESETS"), ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			presetNames = append(presetNames, n)
+		}
+	}
+	if len(presetNames) > 0 {
+		units, err := embedded.ResolveUnits(presetNames)
+		if err != nil {
+			return nil, fmt.Errorf("presets: %w", err)
+		}
+		for _, u := range units {
+			layers = append(layers, config.Layer{Name: u.Name, Data: u.Data})
+		}
+	}
+
+	// LOOMCYCLE_CONFIG_DIR — *.yaml/*.yml, lexical order.
+	if dir := strings.TrimSpace(os.Getenv("LOOMCYCLE_CONFIG_DIR")); dir != "" {
+		files, err := configDirYAMLs(dir)
+		if err != nil {
+			return nil, fmt.Errorf("LOOMCYCLE_CONFIG_DIR: %w", err)
+		}
+		for _, f := range files {
+			layers = append(layers, config.Layer{Name: f})
+		}
+	}
+
+	// LOOMCYCLE_CONFIG_FILES — colon-separated.
+	for _, f := range strings.Split(os.Getenv("LOOMCYCLE_CONFIG_FILES"), ":") {
+		if f = strings.TrimSpace(f); f != "" {
+			layers = append(layers, config.Layer{Name: f})
+		}
+	}
+
+	// The explicit --config path (highest precedence). When it's absent from
+	// disk but the presets/env layers already provide a config, skip it (a
+	// presets-only stack, RFC AQ); when there are no other layers, keep it so
+	// LoadLayers surfaces the same file-not-found error the CLI produced before.
+	if explicitPath = strings.TrimSpace(explicitPath); explicitPath != "" {
+		if _, err := os.Stat(explicitPath); err == nil || len(layers) == 0 {
+			layers = append(layers, config.Layer{Name: explicitPath})
+		}
+	}
+
+	return config.LoadLayers(layers...)
+}
+
+// configDirYAMLs lists *.yaml/*.yml in dir in lexical order — mirrors
+// cmd/loomcycle.configDirLayers (the server's LOOMCYCLE_CONFIG_DIR reader).
+func configDirYAMLs(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if n := e.Name(); strings.HasSuffix(n, ".yaml") || strings.HasSuffix(n, ".yml") {
+			files = append(files, filepath.Join(dir, n))
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}

--- a/internal/cli/loadcfg_test.go
+++ b/internal/cli/loadcfg_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadLayeredConfig_PresetAliasResolvesInOverlayAgent is the regression for
+// the CLI-doesn't-layer-presets bug: an overlay agent whose model is a
+// preset-defined alias (deepseek-pro, from the base preset) must resolve —
+// matching the running server — instead of the old false "no provider
+// resolved". Fail-before: with config.Load (single file) the base preset's
+// models map is absent and ResolveAgentModel errors.
+func TestLoadLayeredConfig_PresetAliasResolvesInOverlayAgent(t *testing.T) {
+	t.Setenv("LOOMCYCLE_PRESETS", "base")
+	dir := t.TempDir()
+	overlay := filepath.Join(dir, "overlay.yaml")
+	if err := os.WriteFile(overlay, []byte("agents:\n  probe: { model: deepseek-pro }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLayeredConfig(overlay)
+	if err != nil {
+		t.Fatalf("loadLayeredConfig: %v", err)
+	}
+	prov, model, err := cfg.ResolveAgentModel("probe")
+	if err != nil {
+		t.Fatalf("ResolveAgentModel: %v", err)
+	}
+	if prov != "deepseek" || model != "deepseek-v4-pro" {
+		t.Errorf("probe resolved to %s/%s, want deepseek/deepseek-v4-pro", prov, model)
+	}
+}
+
+// TestLoadLayeredConfig_NoPresetsUnchanged pins that without LOOMCYCLE_PRESETS
+// (and no CONFIG_* env), loading is byte-equivalent to the old single-file path:
+// an alias defined nowhere stays unresolved. Guards against the layering
+// silently changing behaviour for the common no-presets case.
+func TestLoadLayeredConfig_NoPresetsUnchanged(t *testing.T) {
+	t.Setenv("LOOMCYCLE_PRESETS", "")
+	t.Setenv("LOOMCYCLE_CONFIG_DIR", "")
+	t.Setenv("LOOMCYCLE_CONFIG_FILES", "")
+	dir := t.TempDir()
+	overlay := filepath.Join(dir, "overlay.yaml")
+	// A self-contained agent (explicit provider+model) so the load succeeds;
+	// then assert an UNDEFINED alias still fails to resolve.
+	if err := os.WriteFile(overlay, []byte("agents:\n  probe: { provider: deepseek, model: deepseek-v4-pro }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadLayeredConfig(overlay)
+	if err != nil {
+		t.Fatalf("loadLayeredConfig: %v", err)
+	}
+	if _, ok := cfg.Models["deepseek-pro"]; ok {
+		t.Error("deepseek-pro alias present without presets — layering leaked the base preset")
+	}
+}

--- a/internal/cli/validate.go
+++ b/internal/cli/validate.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sort"
-
-	"github.com/denn-gubsky/loomcycle/internal/config"
 )
 
 // RunValidate loads a YAML config and reports on its health. Returns:
@@ -42,7 +40,7 @@ func RunValidate(args []string, stdout, stderr io.Writer) int {
 	}
 	cfgPath := fs.Arg(0)
 
-	cfg, err := config.Load(cfgPath)
+	cfg, err := loadLayeredConfig(cfgPath)
 	if err != nil {
 		return fail(stderr, "config: %v", err)
 	}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -414,6 +416,15 @@ func (d *Driver) buildRequestBody(req providers.Request) ([]byte, error) {
 	case "low":
 		think := false
 		w.Think = &think
+	}
+	// Opt-in diagnostic (LOOMCYCLE_OLLAMA_DEBUG_THINK=1): log exactly what
+	// reaches the driver, so an operator debugging "no thinking trace" can
+	// confirm whether the effort hint arrived and whether `think` was set on
+	// the wire. Off by default (a per-request log line would otherwise be
+	// noise). Non-secret — model name + effort only.
+	if os.Getenv("LOOMCYCLE_OLLAMA_DEBUG_THINK") == "1" {
+		log.Printf("ollama think-diag: provider=%s model=%q effort=%q think_set=%v",
+			d.providerID, req.Model, req.Effort, w.Think != nil)
 	}
 
 	if req.Temperature != nil || req.MaxTokens > 0 || d.numCtx > 0 || d.numGpu > 0 ||


### PR DESCRIPTION
Two fixes toward the local-thinking work, bound for **v1.8.1**.

## 1. CLI tools ignored config layering (the reported alias bug)

`loomcycle validate` / `agents list` / `doctor` loaded a single file via `config.Load(path)` and **ignored `LOOMCYCLE_PRESETS` / `CONFIG_DIR` / `CONFIG_FILES`**. So an agent whose `model:` is a preset-defined alias (e.g. `deepseek-pro` from the `base` preset) showed a false **`no provider resolved`** in those tools — even though the running server resolves it fine.

Verified live on the deployed server: the `default` agent (pinned `deepseek-pro`) runs as `deepseek-v4-pro`. So **aliases work at runtime**; only the CLI validators were misleading — which is exactly what made it *look* like "model substitution doesn't work in agent definitions."

**Fix:** a shared `loadLayeredConfig` assembles the *same* layer stack the server builds (presets base → `CONFIG_DIR` → `CONFIG_FILES` → explicit `--config`, last wins); the three commands use it. With neither presets nor the `CONFIG_*` env set, behaviour is byte-identical to `config.Load(path)`.

Repro, now fixed:
```
LOOMCYCLE_PRESETS=base loomcycle agents list --config overlay.yaml
#  probe-alias  → deepseek / deepseek-v4-pro   (was: "no provider resolved")
```

## 2. Opt-in Ollama think diagnostic

`LOOMCYCLE_OLLAMA_DEBUG_THINK=1` makes the Ollama driver log each request's `provider/model/effort/think_set`. Off by default. This is the wire-level probe for the still-open "no thinking trace" issue: deploy v1.8.1, set the env, run one qwen3.6/effort:high fork, and the log tells us whether `effort:high` reached the driver and whether `think:true` was actually sent — the one datapoint a code read can't settle. (Also: a fresh v1.8.1 build rules out a stale-image cause for that issue.)

## Tested
- `loadLayeredConfig` resolves a base-preset alias in an overlay agent; no leakage without presets.
- `go test ./...` clean; `gofmt`/`vet` clean; binary rebuilt + repro verified.

Out of scope: `migrate`/`hash` still use `config.Load` (don't manifest the symptom) — a noted follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)