### PR TITLE
fix(loop): forward EventThinking to consumers (root cause of missing thinking traces)

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1502,6 +1502,18 @@ outerLoop:
 			case providers.EventText:
 				iterText += ev.Text
 				emit(ev)
+			case providers.EventThinking:
+				// Forward the live reasoning trace to the consumer (SSE / gRPC /
+				// adapters) so a UI can render "thinking…" as the model streams
+				// it. Deliberately NOT accumulated into the assistant message
+				// content and NOT echoed into the next request — the full trace
+				// is carried separately on EventDone.Reasoning (see
+				// providers.EventThinking). Before this case existed the switch
+				// had no branch for EventThinking (and no default), so every
+				// provider's streamed thinking was silently dropped here and
+				// never reached any client — the driver emitted it, the loop ate
+				// it. Regression: TestRun_ForwardsEventThinking.
+				emit(ev)
 			case providers.EventToolCall:
 				// Some providers (Ollama) don't issue tool_call IDs. Anthropic
 				// and OpenAI both 400 if we replay an empty-ID tool_use in the

--- a/internal/loop/thinking_test.go
+++ b/internal/loop/thinking_test.go
@@ -1,0 +1,73 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// thinkingProvider streams a thinking chunk, then text, then done — mirroring a
+// reasoning model (Ollama message.thinking / Anthropic thinking_delta /
+// DeepSeek reasoning_content) that surfaces its trace out-of-band.
+type thinkingProvider struct{}
+
+func (thinkingProvider) ID() string                                   { return "thinking-llm" }
+func (thinkingProvider) Probe(context.Context) error                  { return nil }
+func (thinkingProvider) ListModels(context.Context) ([]string, error) { return nil, nil }
+func (thinkingProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true, SupportsThinking: true}
+}
+func (thinkingProvider) Call(_ context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event, 4)
+	ch <- providers.Event{Type: providers.EventThinking, Text: "Let me work through this: 40 / 0.8 = 50."}
+	ch <- providers.Event{Type: providers.EventText, Text: "The original price was $50."}
+	ch <- providers.Event{Type: providers.EventDone, StopReason: "end_turn", Reasoning: "Let me work through this: 40 / 0.8 = 50.", Usage: &providers.Usage{}}
+	close(ch)
+	return ch, nil
+}
+
+// TestRun_ForwardsEventThinking is the regression for the loop dropping the
+// reasoning trace: the loop's event switch had no EventThinking case (and no
+// default), so a driver's streamed thinking never reached the caller's OnEvent
+// — no client (SSE/gRPC/adapter) could render it, for any provider. Fail-before:
+// the switch ignores EventThinking, so `events` contains text/done but no
+// thinking, and this assertion fails.
+func TestRun_ForwardsEventThinking(t *testing.T) {
+	var events []providers.Event
+	_, err := Run(context.Background(), RunOptions{
+		Provider:   thinkingProvider{},
+		Model:      "reasoner",
+		Tools:      []tools.Tool{noopTool{}},
+		Dispatcher: tools.NewDispatcher([]tools.Tool{noopTool{}}),
+		Segments:   []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "shirt costs $40 after 20% off; original?"}}}},
+		OnEvent:    func(ev providers.Event) { events = append(events, ev) },
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var thinking, text int
+	var firstThinking string
+	for _, ev := range events {
+		switch ev.Type {
+		case providers.EventThinking:
+			thinking++
+			if firstThinking == "" {
+				firstThinking = ev.Text
+			}
+		case providers.EventText:
+			text++
+		}
+	}
+	if thinking == 0 {
+		t.Fatalf("EventThinking was not forwarded to OnEvent — the loop dropped the reasoning trace; got events %+v", events)
+	}
+	if firstThinking == "" {
+		t.Errorf("forwarded EventThinking carried no text")
+	}
+	if text == 0 {
+		t.Errorf("expected the user-facing text to still be forwarded alongside thinking")
+	}
+}


### PR DESCRIPTION
## Root cause of the missing thinking traces

The loop's per-iteration event switch (`internal/loop/loop.go`) handled `EventText` / `EventToolCall` / `EventDone` / `EventError` — but had **no case for `EventThinking` and no `default`**. So when a driver streamed a reasoning trace on the event channel, the loop **silently dropped it** — it never called `emit(ev)`, so `EventThinking` never reached `OnEvent` → never reached the SSE/gRPC stream. **No client could render "thinking…" for any provider.**

This is exactly the loomboard report. The full diagnostic chain, now closed:
- ✅ loomcycle sends Ollama `think:true` — confirmed live via the v1.8.1 `LOOMCYCLE_OLLAMA_DEBUG_THINK` probe: `effort="high" think_set=true`.
- ✅ Ollama generates the trace — confirmed by direct `/api/chat` replays (qwen3.6 streams `message.thinking`, 500+ frames, even with the exact system prompt + tools + `num_gpu`).
- ✅ the driver emits `EventThinking` (all of Ollama/Anthropic/OpenAI-DeepSeek do, on the channel).
- ❌ **the loop dropped it** ← the bug.

## Fix

One case: `case providers.EventThinking: emit(ev)`. The trace is forwarded live to the consumer but — as before — **not** accumulated into the assistant message content and **not** echoed into the next request; the full concatenated trace still rides on `EventDone.Reasoning`. 

Provider-agnostic — fixes thinking display for Ollama, Anthropic, OpenAI, DeepSeek, Gemini all at once.

### Safe downstream (verified)
- `replayTranscript` has no `thinking` case → skips those event rows (no history contamination).
- `eventToProto` is field-based → maps `EventThinking` to `{Type:"thinking", Text}`, so **gRPC** clients now receive it too.

## Tested
`TestRun_ForwardsEventThinking` — a fake provider streams `EventThinking` on the channel; asserts `OnEvent` receives it alongside text. **Fails on the unfixed loop** (only text/usage/done arrive), passes with the fix. `go test ./...` clean.

Bound for **v1.8.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)