### PR TITLE
feat(api): GET /v1/_models — expose configured model aliases (so forks can track aliases)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -507,6 +507,14 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_events":
 		return auth.ScopeTenant
+	// Configured model aliases (GET /v1/_models) — non-secret global config
+	// (provider + model names). Tenant-readable so a tenant operator's UI can
+	// offer aliases in a model picker + store the alias on a fork (so it tracks
+	// the operator's local override). Not tenant-scoped data (the alias map is
+	// global), so every authed caller sees the same set; ScopeAdmin also
+	// satisfies. Read-only GET.
+	case path == "/v1/_models":
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -255,6 +255,9 @@ func TestRequiredScopeFor(t *testing.T) {
 		// RFC AS: the audit/event log is tenant-reachable (handleListEvents
 		// scopes the result via the event's owning session's tenant).
 		{"GET", "/v1/_events", auth.ScopeTenant},
+		// Configured model aliases — tenant-readable so a tenant operator's UI
+		// can offer aliases in a model picker (non-secret global config).
+		{"GET", "/v1/_models", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/api/http/models_admin.go
+++ b/internal/api/http/models_admin.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// modelAliasesResponse is the wire shape for GET /v1/_models: the operator's
+// configured model aliases (the top-level `models:` map — RFC AN). A UI (e.g.
+// loomboard) reads this to offer aliases in a model picker and STORE the alias
+// on an agent/fork instead of a concrete model. Storing the alias means the
+// agent tracks the operator's local override of that alias — retarget it once in
+// yaml and every agent using it follows, no re-fork — whereas a concrete model
+// pins a specific tag that only a new fork can change.
+type modelAliasesResponse struct {
+	Aliases map[string]modelAliasWire `json:"aliases"`
+}
+
+type modelAliasWire struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+// handleListModels returns the configured model aliases (cfg.Models). Non-secret
+// — provider + model names only, the same shape an operator writes in yaml.
+// Tenant-readable: a substrate:tenant operator's UI needs the alias list to
+// build a model picker; the aliases are global config (not tenant-scoped), so
+// every authed caller sees the same set. json.Marshal emits the map with keys
+// sorted, so the output is stable.
+func (s *Server) handleListModels(w http.ResponseWriter, _ *http.Request) {
+	resp := modelAliasesResponse{Aliases: make(map[string]modelAliasWire, len(s.cfg.Models))}
+	for name, ref := range s.cfg.Models {
+		resp.Aliases[name] = modelAliasWire{Provider: ref.Provider, Model: ref.Model}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(resp)
+}

--- a/internal/api/http/models_admin_test.go
+++ b/internal/api/http/models_admin_test.go
@@ -1,0 +1,51 @@
+package http
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+)
+
+// TestListModels_ReturnsConfiguredAliases: GET /v1/_models surfaces the
+// top-level `models:` map (alias -> provider/model) so a UI can offer aliases in
+// a model picker and store the alias on a fork (tracking the operator's local
+// override) instead of a concrete model.
+func TestListModels_ReturnsConfiguredAliases(t *testing.T) {
+	cfg := &config.Config{
+		Models: map[string]config.ModelRef{
+			"local-medium": {Provider: "ollama-local", Model: "qwen3.6:latest"},
+			"deepseek-pro": {Provider: "deepseek", Model: "deepseek-v4-pro"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	cfg.Env.AuthToken = ""
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/_models")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	var got modelAliasesResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if lm := got.Aliases["local-medium"]; lm.Provider != "ollama-local" || lm.Model != "qwen3.6:latest" {
+		t.Errorf("local-medium = %+v, want ollama-local/qwen3.6:latest", lm)
+	}
+	if dp := got.Aliases["deepseek-pro"]; dp.Provider != "deepseek" || dp.Model != "deepseek-v4-pro" {
+		t.Errorf("deepseek-pro = %+v, want deepseek/deepseek-v4-pro", dp)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2239,6 +2239,12 @@ func (s *Server) Mux() http.Handler {
 	// after adding a model to the upstream console without waiting
 	// 15 min for the next periodic probe.
 	mux.Handle("GET /v1/_providers/{id}/models", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleProviderModels))))
+	// Configured model aliases (the top-level `models:` map). Tenant-readable
+	// so a UI can offer aliases in a model picker and store the alias on an
+	// agent/fork (which then tracks the operator's local override) instead of a
+	// concrete model. Non-secret global config; scope-gated to substrate:tenant
+	// in requiredScopeFor.
+	mux.Handle("GET /v1/_models", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListModels))))
 	// v0.7.3+ user picker — admin-style endpoint surfacing distinct
 	// user_ids that have runs in the store. Bearer-authed; drives
 	// the Web UI's run-list user dropdown.


### PR DESCRIPTION
## Why

You asked for bundled resources to use model aliases so a user can retarget them in local YAML without re-forking agents. The audit showed loomcycle **already** does its part:
- Bundled agents use aliases/tiers (`chat`→`tier: middle`, `chat-local`→`model: local-medium`, `doc-manager`→`tier: middle`).
- The AgentDef create path stores the model **verbatim** and expands aliases only at **runtime** — so an agent/fork defined with `model: local-medium` already follows a local override, no re-fork.

The real gap was **discovery**: loomcycle exposed only concrete per-provider models (`GET /v1/_providers/{id}/models`) and the resolver matrix — never the **alias map** (`cfg.Models`). So loomboard's model picker had no aliases to offer and fell back to concrete models, which is why the forks pinned `qwen3.6:latest` instead of `local-medium`.

## What

`GET /v1/_models` returns the configured aliases:
```json
{ "aliases": {
    "local-medium": { "provider": "ollama-local", "model": "qwen3.6:latest" },
    "deepseek-pro": { "provider": "deepseek", "model": "deepseek-v4-pro" }
} }
```
- Non-secret global config (provider + model names — the same shape written in yaml).
- **Tenant-readable**: `requiredScopeFor` gates it at `substrate:tenant` (like the Library views), so a tenant operator's UI can read it. Aliases aren't tenant-scoped, so every authed caller sees the same set (`substrate:admin` also satisfies).

With this, loomboard can offer aliases in its picker and store the **alias** on a fork → the fork tracks the operator's local-YAML override, closing the "retarget without re-forking" loop end-to-end.

## Tested
- `TestListModels_ReturnsConfiguredAliases` — endpoint returns the alias map.
- Route-scope table pins `GET /v1/_models` → `ScopeTenant`.
- `go test ./...` clean; gofmt/vet clean.

## Follow-ups (not in this PR)
- `@loomcycle/client.listModels()` for adapter consumers that don't call HTTP directly.
- loomboard-side: offer aliases in the model picker + store the alias on forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)