### PR TITLE
feat(routing): a routing view — see the live provider/model cascade per tier

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -507,6 +507,12 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_events":
 		return auth.ScopeTenant
+	// Routing view (GET /v1/_routing). Tenant-readable so a tenant operator's UI
+	// can see the resolved model cascade per tier; the HANDLER strips the live
+	// provider reachability / infra detail for a non-admin caller (admin gets the
+	// full availability view). ScopeAdmin also satisfies. Read-only GET.
+	case path == "/v1/_routing":
+		return auth.ScopeTenant
 	// Everything else under /v1/_* is OPERATOR-admin: token minting
 	// (_operatortokendef), runtime admin (pause/resume/state/snapshots/metrics),
 	// resolver, cross-tenant user focus.

--- a/internal/api/http/auth_principal_test.go
+++ b/internal/api/http/auth_principal_test.go
@@ -255,6 +255,9 @@ func TestRequiredScopeFor(t *testing.T) {
 		// RFC AS: the audit/event log is tenant-reachable (handleListEvents
 		// scopes the result via the event's owning session's tenant).
 		{"GET", "/v1/_events", auth.ScopeTenant},
+		// The routing view is tenant-reachable; the handler strips infra detail
+		// for a non-admin caller.
+		{"GET", "/v1/_routing", auth.ScopeTenant},
 		// RFC AF: hooks are tenant-confined now that the registry is
 		// tenant-isolated (stamp on register, tenant-filtered Match, scoped
 		// List/Delete). substrate:admin still satisfies.

--- a/internal/api/http/routing.go
+++ b/internal/api/http/routing.go
@@ -1,0 +1,183 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+)
+
+// routingResponse is GET /v1/_routing: for each user_tier × tier, the ordered
+// provider/model cascade a consumer would hit (top → fallbacks), so an operator
+// can see which providers/models runs resolve to right now.
+//
+// Two views by principal (RFC AS posture):
+//   - admin: live availability per candidate (reachable/stalled/rate-limited),
+//     which entry is currently SELECTED (first available = what runs now), plus
+//     an active-providers header.
+//   - substrate:tenant: the config cascade only (provider/model per tier,
+//     `primary` = the configured top). No provider reachability / infra detail.
+type routingResponse struct {
+	GeneratedAt time.Time         `json:"generated_at"`
+	Admin       bool              `json:"admin"`
+	Providers   []routingProvider `json:"providers,omitempty"` // admin-only
+	UserTiers   []routingUserTier `json:"user_tiers"`
+}
+
+type routingProvider struct {
+	Provider  string `json:"provider"`
+	Reachable bool   `json:"reachable"`
+	Excluded  bool   `json:"excluded"`
+	LastError string `json:"last_error,omitempty"`
+}
+
+type routingUserTier struct {
+	// Name is the user_tier name; "" in library-mode (no user_tiers configured).
+	Name  string        `json:"name"`
+	Tiers []routingTier `json:"tiers"`
+}
+
+type routingTier struct {
+	Tier    string             `json:"tier"` // low / middle / high
+	Cascade []routingCandidate `json:"cascade"`
+}
+
+type routingCandidate struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+	Primary  bool   `json:"primary"` // first in config order (the configured top)
+	// Admin-only live-availability fields (nil/omitted for a tenant view).
+	Available   *bool `json:"available,omitempty"`
+	Selected    *bool `json:"selected,omitempty"` // first AVAILABLE — what runs now
+	Stalled     *bool `json:"stalled,omitempty"`
+	RateLimited *bool `json:"rate_limited,omitempty"`
+	Reachable   *bool `json:"reachable,omitempty"`
+}
+
+// handleRouting serves GET /v1/_routing. Tenant-readable (see requiredScopeFor):
+// a substrate:tenant operator gets the config cascade; an admin (or legacy/open)
+// additionally gets live availability + the active-providers header.
+func (s *Server) handleRouting(w http.ResponseWriter, r *http.Request) {
+	if s.resolver == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "resolver_unavailable",
+			"resolver not configured; the server is in degraded startup mode")
+		return
+	}
+	// Admin ⇒ full view (availability + infra). A non-admin principal
+	// (substrate:tenant) ⇒ config cascade only. Open mode (no principal stamped)
+	// is dev/admin, so it gets the full view.
+	admin := true
+	if p, ok := auth.PrincipalFromContext(r.Context()); ok {
+		admin = auth.HasScope(p.Scopes, auth.ScopeAdmin)
+	}
+
+	snap := s.resolver.Snapshot()
+
+	// user_tiers, sorted; library-mode (none configured) → a single "" entry.
+	utNames := make([]string, 0, len(s.cfg.UserTiers))
+	for name := range s.cfg.UserTiers {
+		utNames = append(utNames, name)
+	}
+	sort.Strings(utNames)
+	if len(utNames) == 0 {
+		utNames = []string{""}
+	}
+
+	tierNames := s.routingTierNames()
+
+	resp := routingResponse{GeneratedAt: time.Now().UTC(), Admin: admin}
+	for _, ut := range utNames {
+		overlay := s.userTierOverlay(ut)
+		rut := routingUserTier{Name: ut}
+		for _, tier := range tierNames {
+			casc := s.resolver.Cascade(resolve.AgentRequest{Name: "routing-view", Tier: tier, UserTier: overlay})
+			rt := routingTier{Tier: tier}
+			selectedMarked := false
+			for i, c := range casc {
+				rc := routingCandidate{Provider: c.Provider, Model: c.Model, Primary: i == 0}
+				if admin {
+					av, stalled, rateLimited, reachable := availStatus(snap, c.Provider, c.Model)
+					sel := av && !selectedMarked
+					if sel {
+						selectedMarked = true
+					}
+					rc.Available = &av
+					rc.Selected = &sel
+					rc.Stalled = &stalled
+					rc.RateLimited = &rateLimited
+					rc.Reachable = &reachable
+				}
+				rt.Cascade = append(rt.Cascade, rc)
+			}
+			rut.Tiers = append(rut.Tiers, rt)
+		}
+		resp.UserTiers = append(resp.UserTiers, rut)
+	}
+
+	if admin {
+		provNames := make([]string, 0, len(snap))
+		for p := range snap {
+			provNames = append(provNames, p)
+		}
+		sort.Strings(provNames)
+		for _, p := range provNames {
+			a := snap[p]
+			resp.Providers = append(resp.Providers, routingProvider{
+				Provider:  p,
+				Reachable: a.Reachable,
+				Excluded:  a.Excluded,
+				LastError: a.LastError,
+			})
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(resp)
+}
+
+// routingTierNames returns the configured tier names (keys of cfg.Tiers) in a
+// stable, human order: low → middle → high first, then any others sorted.
+func (s *Server) routingTierNames() []string {
+	pref := []string{"low", "middle", "high"}
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range pref {
+		if _, ok := s.cfg.Tiers[p]; ok {
+			out = append(out, p)
+			seen[p] = true
+		}
+	}
+	var extra []string
+	for name := range s.cfg.Tiers {
+		if !seen[name] {
+			extra = append(extra, name)
+		}
+	}
+	sort.Strings(extra)
+	return append(out, extra...)
+}
+
+// availStatus derives one candidate's live availability from the resolver
+// snapshot, mirroring ModelStatus's usability rule (provider reachable + model
+// listed + not stalled + not rate-limited-unexpired).
+func availStatus(snap map[string]resolve.Availability, provider, model string) (available, stalled, rateLimited, reachable bool) {
+	a, ok := snap[provider]
+	if !ok {
+		return false, false, false, false
+	}
+	reachable = a.Reachable && !a.Excluded
+	ms, ok := a.Models[model]
+	if !ok {
+		return false, false, false, reachable
+	}
+	stalled = ms.Stalled
+	rateLimited = ms.RateLimited && time.Now().Before(ms.RateLimitedUntil)
+	available = reachable && ms.Listed && !ms.Stalled && !rateLimited
+	return available, stalled, rateLimited, reachable
+}

--- a/internal/api/http/routing_test.go
+++ b/internal/api/http/routing_test.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/resolve"
+)
+
+func routingTestServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := &config.Config{
+		ProviderPriority: []string{"deepseek", "anthropic"},
+		Tiers: map[string][]config.TierCandidate{
+			"middle": {
+				{Provider: "deepseek", Model: "deepseek-v4-pro"},
+				{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+			},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 100},
+	}
+	cfg.Env.AuthToken = ""
+	srv := New(cfg, &stubResolver{}, nil, concurrency.New(1, 1, time.Second), nil)
+	res := resolve.NewResolver([]string{"deepseek", "anthropic"}, map[string][]resolve.Candidate{
+		"middle": {
+			{Provider: "deepseek", Model: "deepseek-v4-pro"},
+			{Provider: "anthropic", Model: "claude-sonnet-4-6"},
+		},
+	})
+	// Seed availability so Snapshot() has entries (the admin view's provider
+	// header + per-candidate availability). deepseek up, anthropic down — so the
+	// admin view's "selected" lands on the reachable primary.
+	res.SetReachable("deepseek", true, []string{"deepseek-v4-pro"}, "")
+	res.SetReachable("anthropic", false, nil, "probe failed")
+	srv.SetResolver(res)
+	return srv
+}
+
+func routingFor(t *testing.T, srv *Server, scopes []string) routingResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/v1/_routing", nil)
+	req = req.WithContext(auth.WithPrincipal(req.Context(), auth.Principal{Scopes: scopes}))
+	rr := httptest.NewRecorder()
+	srv.handleRouting(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp routingResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v; body: %s", err, rr.Body.String())
+	}
+	return resp
+}
+
+// TestRouting_AdminSeesCascadeAndAvailability: an admin gets the ordered cascade
+// (deepseek primary, anthropic fallback) with live-availability fields populated
+// and the active-providers header.
+func TestRouting_AdminSeesCascadeAndAvailability(t *testing.T) {
+	srv := routingTestServer(t)
+	resp := routingFor(t, srv, []string{auth.ScopeAdmin})
+
+	if !resp.Admin {
+		t.Error("admin=false for an admin principal")
+	}
+	if len(resp.UserTiers) != 1 { // no user_tiers configured → single library-mode entry
+		t.Fatalf("user_tiers = %d, want 1", len(resp.UserTiers))
+	}
+	var mid *routingTier
+	for i := range resp.UserTiers[0].Tiers {
+		if resp.UserTiers[0].Tiers[i].Tier == "middle" {
+			mid = &resp.UserTiers[0].Tiers[i]
+		}
+	}
+	if mid == nil || len(mid.Cascade) != 2 {
+		t.Fatalf("middle cascade = %+v, want 2 candidates", mid)
+	}
+	if mid.Cascade[0].Provider != "deepseek" || !mid.Cascade[0].Primary {
+		t.Errorf("cascade[0] = %+v, want deepseek primary", mid.Cascade[0])
+	}
+	if mid.Cascade[1].Provider != "anthropic" || mid.Cascade[1].Primary {
+		t.Errorf("cascade[1] = %+v, want anthropic non-primary", mid.Cascade[1])
+	}
+	// deepseek is up + listed → available and selected (what runs now).
+	if mid.Cascade[0].Available == nil || !*mid.Cascade[0].Available ||
+		mid.Cascade[0].Selected == nil || !*mid.Cascade[0].Selected {
+		t.Errorf("cascade[0] (deepseek) should be available + selected; got %+v", mid.Cascade[0])
+	}
+	// anthropic is down → not available, not selected.
+	if mid.Cascade[1].Available == nil || *mid.Cascade[1].Available ||
+		mid.Cascade[1].Selected == nil || *mid.Cascade[1].Selected {
+		t.Errorf("cascade[1] (anthropic, down) should be unavailable + not selected; got %+v", mid.Cascade[1])
+	}
+	if len(resp.Providers) == 0 {
+		t.Error("admin response must include the active-providers header")
+	}
+}
+
+// TestRouting_TenantGetsStrippedView: a substrate:tenant principal sees the
+// config cascade (provider/model per tier) but NOT the live availability fields
+// or the active-providers infra header.
+func TestRouting_TenantGetsStrippedView(t *testing.T) {
+	srv := routingTestServer(t)
+	resp := routingFor(t, srv, []string{auth.ScopeTenant})
+
+	if resp.Admin {
+		t.Error("admin=true for a tenant principal")
+	}
+	if len(resp.Providers) != 0 {
+		t.Errorf("tenant must not see the active-providers header; got %+v", resp.Providers)
+	}
+	var mid *routingTier
+	for i := range resp.UserTiers[0].Tiers {
+		if resp.UserTiers[0].Tiers[i].Tier == "middle" {
+			mid = &resp.UserTiers[0].Tiers[i]
+		}
+	}
+	if mid == nil || len(mid.Cascade) != 2 {
+		t.Fatalf("middle cascade = %+v, want 2 candidates", mid)
+	}
+	// Cascade (provider/model + primary) is present...
+	if mid.Cascade[0].Provider != "deepseek" || mid.Cascade[0].Model != "deepseek-v4-pro" {
+		t.Errorf("cascade[0] = %+v, want deepseek/deepseek-v4-pro", mid.Cascade[0])
+	}
+	// ...but the live-availability/infra fields are stripped.
+	if mid.Cascade[0].Available != nil || mid.Cascade[0].Selected != nil ||
+		mid.Cascade[0].Stalled != nil || mid.Cascade[0].Reachable != nil {
+		t.Errorf("tenant cascade must NOT carry availability/infra fields; got %+v", mid.Cascade[0])
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2230,6 +2230,11 @@ func (s *Server) Mux() http.Handler {
 	mux.Handle("DELETE /v1/hooks/{id}", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleDeleteHook))))
 	// v0.7.x resolver introspection — operator-only debug surface.
 	mux.Handle("GET /v1/_resolver", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleResolverSnapshot))))
+	// Routing view: per user_tier × tier, the resolved provider/model cascade
+	// (top → fallbacks). Tenant-readable (config cascade only); admin also gets
+	// live availability + the active-providers header. Scope-gated in
+	// requiredScopeFor.
+	mux.Handle("GET /v1/_routing", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleRouting))))
 	// Operator-triggered immediate re-probe (issue #88) — unsticks the
 	// availability matrix after a transient outage without a restart,
 	// instead of waiting up to a full probe interval for the next tick.

--- a/internal/resolve/matrix.go
+++ b/internal/resolve/matrix.go
@@ -447,6 +447,38 @@ func (r *Resolver) resolvePin(req AgentRequest) (Decision, error) {
 	}, nil
 }
 
+// Cascade returns the ordered (provider, model) candidates the resolver would
+// walk for req's TIER — priority order × tier candidates, the SAME sequence
+// Resolve's inner loop visits — WITHOUT availability filtering. It's the config
+// cascade (top → fallbacks); callers annotate each entry with Snapshot() to show
+// live availability. Used by the admin routing view so an operator can see what
+// providers/models a consumer would hit for each user_tier × tier.
+//
+// Empty when the tier has no candidates, the user_tier grants no provider, or
+// the agent's providers ∩ user_tier priority is empty (the resolver would refuse
+// the run). Reuses candidatesFor/priorityFor so it can't drift from Resolve's
+// order. Lock-free: candidatesFor/priorityFor read immutable config, not the
+// mutable availability matrix.
+func (r *Resolver) Cascade(req AgentRequest) []Candidate {
+	if req.Tier == "" {
+		return nil
+	}
+	candidates := r.candidatesFor(req)
+	priority, refused := r.priorityFor(req)
+	if refused || len(candidates) == 0 || len(priority) == 0 {
+		return nil
+	}
+	out := make([]Candidate, 0, len(candidates))
+	for _, p := range priority {
+		for _, c := range candidates {
+			if c.Provider == p {
+				out = append(out, c)
+			}
+		}
+	}
+	return out
+}
+
 // candidatesFor returns the candidate list the resolver should walk
 // for this request, applying the v0.8.2 overlay precedence:
 //

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2234,3 +2234,49 @@ export const TOKEN_SCOPES = [
   "channel:publish",
   "channel:read",
 ] as const;
+
+// ---- Routing view (GET /v1/_routing) ----
+// For each user_tier × tier, the ordered provider/model cascade a consumer
+// resolves to right now. The admin view additionally carries live availability
+// per candidate + an active-providers header; a substrate:tenant view is the
+// config cascade only (availability/infra fields are absent — the API omits
+// them, so the UI keys rendering off their presence, not `admin`).
+export interface RoutingCandidate {
+  provider: string;
+  model: string;
+  primary: boolean; // configured top of the cascade
+  // Admin-only live-availability fields (undefined in a tenant view).
+  available?: boolean;
+  selected?: boolean; // first AVAILABLE — what runs now
+  stalled?: boolean;
+  rate_limited?: boolean;
+  reachable?: boolean;
+}
+
+export interface RoutingTier {
+  tier: string; // low / middle / high
+  cascade: RoutingCandidate[];
+}
+
+export interface RoutingUserTier {
+  name: string; // "" in library-mode (no user_tiers configured)
+  tiers: RoutingTier[];
+}
+
+export interface RoutingProvider {
+  provider: string;
+  reachable: boolean;
+  excluded: boolean;
+  last_error?: string;
+}
+
+export interface RoutingResponse {
+  generated_at: string;
+  admin: boolean;
+  providers?: RoutingProvider[]; // admin-only
+  user_tiers: RoutingUserTier[];
+}
+
+export function getRouting(): Promise<RoutingResponse> {
+  return jsonFetch<RoutingResponse>("/v1/_routing");
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import {
   Play,
   Plug,
   Radio,
+  Route,
   ScrollText,
   Settings,
   Sun,
@@ -70,6 +71,11 @@ const NAV_ITEMS: NavItem[] = [
   // audit is tenant-visible (RFC AS): handleListEvents tenant-scopes the result
   // via the event's owning session, so a tenant sees only its own events.
   { to: "/audit", label: "audit", Icon: ScrollText, vis: "tenant" },
+  // routing: the provider/model cascade a consumer resolves to right now.
+  // Tenant-visible (RFC AS): GET /v1/_routing is ScopeTenant-gated and the
+  // handler strips live availability + the infra provider-header for a
+  // non-admin principal (config cascade only).
+  { to: "/routing", label: "routing", Icon: Route, vis: "tenant" },
   { to: "/activity", label: "activity", Icon: Activity, vis: "admin" },
 ];
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -15,6 +15,7 @@ import MemoryView from "./pages/MemoryView";
 import InterruptInbox from "./pages/InterruptInbox";
 import SnapshotsView from "./pages/SnapshotsView";
 import AuditView from "./pages/AuditView";
+import RoutingView from "./pages/RoutingView";
 import ActivityMonitor from "./pages/ActivityMonitor";
 import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
@@ -82,6 +83,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="interrupts" element={<InterruptInbox />} />
           <Route path="snapshots" element={<SnapshotsView />} />
           <Route path="audit" element={<AuditView />} />
+          <Route path="routing" element={<RoutingView />} />
           <Route path="activity" element={<ActivityMonitor />} />
           <Route path="settings" element={<SettingsView />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />

--- a/web/src/pages/RoutingView.tsx
+++ b/web/src/pages/RoutingView.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  RoutingCandidate,
+  RoutingResponse,
+  RoutingTier,
+  getRouting,
+} from "../api";
+
+// RoutingView — GET /v1/_routing.
+//
+// Answers "which provider + model will a consumer actually hit right now?"
+// for every user_tier × tier. This is the resolution the loop performs at
+// run time (per-agent overrides aside), surfaced so an operator can verify
+// their provider_priority / tier config before a consumer discovers it the
+// hard way.
+//
+// Two shapes, driven by the API (not a client-side role check): an admin
+// response carries live availability per candidate (which one is SELECTED —
+// the first reachable = what runs now) plus an active-providers header; a
+// substrate:tenant response is the config cascade only. The UI keys the
+// availability rendering off `resp.admin` AND field presence, so a stripped
+// tenant payload simply renders the cascade without dots.
+
+// tierOrder gives low/middle/high a stable visual rank; anything else sorts
+// after, preserving server order.
+function tierRank(tier: string): number {
+  const i = ["low", "middle", "high"].indexOf(tier);
+  return i === -1 ? 99 : i;
+}
+
+export default function RoutingView() {
+  const [resp, setResp] = useState<RoutingResponse | null>(null);
+  const [err, setErr] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const fetchRouting = useCallback(async () => {
+    setLoading(true);
+    setErr("");
+    try {
+      setResp(await getRouting());
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchRouting();
+  }, [fetchRouting]);
+
+  return (
+    <div className="routing-view">
+      <div className="routing-header">
+        <div>
+          <h1>routing</h1>
+          <p className="routing-sub">
+            The provider &amp; model each tier resolves to right now — top choice
+            first, then the fallback cascade.
+          </p>
+        </div>
+        <div className="routing-actions">
+          {resp && (
+            <span className="routing-generated">
+              as of {new Date(resp.generated_at).toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            type="button"
+            className="ghost-btn"
+            onClick={() => void fetchRouting()}
+            disabled={loading}
+          >
+            {loading ? "refreshing…" : "refresh"}
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="err">{err}</div>}
+
+      {resp && resp.admin && resp.providers && resp.providers.length > 0 && (
+        <div className="routing-providers">
+          <span className="routing-providers-label">providers</span>
+          {resp.providers.map((p) => {
+            const up = p.reachable && !p.excluded;
+            return (
+              <span
+                key={p.provider}
+                className={`routing-provider-chip ${up ? "up" : "down"}`}
+                title={
+                  p.excluded
+                    ? "excluded from routing"
+                    : p.last_error || (up ? "reachable" : "unreachable")
+                }
+              >
+                <span
+                  className={`routing-dot ${up ? "up" : "down"}`}
+                  aria-hidden="true"
+                />
+                {p.provider}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {resp && resp.admin && (
+        <div className="routing-legend">
+          <span>
+            <span className="routing-dot up" /> available
+          </span>
+          <span>
+            <span className="routing-dot down" /> unavailable
+          </span>
+          <span className="routing-selected-key">selected</span> = what runs now
+          (first available).
+        </div>
+      )}
+
+      {resp && !resp.admin && (
+        <p className="routing-tenant-note">
+          Configured cascade. Live provider reachability is available to admins.
+        </p>
+      )}
+
+      {resp &&
+        resp.user_tiers.map((ut) => (
+          <section key={ut.name || "__default__"} className="routing-usertier">
+            <h2>
+              {ut.name ? (
+                <>
+                  user tier <code>{ut.name}</code>
+                </>
+              ) : (
+                "default routing"
+              )}
+            </h2>
+            <div className="routing-tier-grid">
+              {[...ut.tiers]
+                .sort((a, b) => tierRank(a.tier) - tierRank(b.tier))
+                .map((t) => (
+                  <TierCard key={t.tier} tier={t} admin={resp.admin} />
+                ))}
+            </div>
+          </section>
+        ))}
+
+      {resp && resp.user_tiers.length === 0 && (
+        <div className="empty">no tiers configured.</div>
+      )}
+    </div>
+  );
+}
+
+function TierCard({ tier, admin }: { tier: RoutingTier; admin: boolean }) {
+  return (
+    <div className="routing-tier-card">
+      <div className="routing-tier-title">{tier.tier}</div>
+      {tier.cascade.length === 0 ? (
+        <div className="routing-tier-empty">no candidates</div>
+      ) : (
+        <ol className="routing-cascade">
+          {tier.cascade.map((c, i) => (
+            <CandidateRow
+              key={`${c.provider}/${c.model}/${i}`}
+              c={c}
+              admin={admin}
+            />
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+function CandidateRow({ c, admin }: { c: RoutingCandidate; admin: boolean }) {
+  // Availability dots only render when the field is present (admin payload).
+  const hasAvail = admin && c.available !== undefined;
+  const selected = c.selected === true;
+  const rowClass = [
+    "routing-cand",
+    selected ? "selected" : "",
+    hasAvail && !c.available ? "unavail" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <li className={rowClass}>
+      <span className="routing-rank">{c.primary ? "top" : "fallback"}</span>
+      {hasAvail && (
+        <span
+          className={`routing-dot ${c.available ? "up" : "down"}`}
+          title={candidateStatusText(c)}
+          aria-hidden="true"
+        />
+      )}
+      <span className="routing-provider">{c.provider}</span>
+      <span className="routing-model" title={c.model}>
+        {c.model}
+      </span>
+      {selected && <span className="routing-selected-badge">selected</span>}
+    </li>
+  );
+}
+
+// candidateStatusText: a human hover string for the availability dot.
+function candidateStatusText(c: RoutingCandidate): string {
+  if (c.available) return "available";
+  if (c.reachable === false) return "provider unreachable";
+  if (c.stalled) return "model stalled";
+  if (c.rate_limited) return "rate-limited";
+  return "unavailable";
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5760,3 +5760,192 @@ button.primary:disabled {
   font-size: var(--lc-text-sm);
   margin-bottom: var(--lc-space-2);
 }
+
+/* ---- Routing view (GET /v1/_routing) --------------------------------- */
+.routing-view {
+  padding: var(--lc-space-3);
+}
+.routing-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--lc-space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--lc-space-2);
+}
+.routing-header h1 {
+  margin: 0;
+  font-size: var(--lc-text-xl);
+}
+.routing-sub {
+  margin: var(--lc-space-1) 0 0;
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-sm);
+  max-width: 60ch;
+}
+.routing-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--lc-space-2);
+}
+.routing-generated {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-xs);
+}
+.routing-tenant-note {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+  margin: 0 0 var(--lc-space-2);
+}
+
+/* Active-providers header (admin only). */
+.routing-providers {
+  display: flex;
+  align-items: center;
+  gap: var(--lc-space-1);
+  flex-wrap: wrap;
+  margin-bottom: var(--lc-space-2);
+}
+.routing-providers-label {
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-right: var(--lc-space-1);
+}
+.routing-provider-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--lc-text-sm);
+  padding: 2px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--lc-rule);
+  background: var(--lc-surface);
+}
+.routing-provider-chip.down {
+  color: var(--lc-text-faint);
+}
+
+/* Availability dot — reused in the header chips, the legend, and rows. */
+.routing-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--lc-text-faint);
+  flex: none;
+}
+.routing-dot.up {
+  background: var(--lc-completed);
+}
+.routing-dot.down {
+  background: var(--lc-failed);
+}
+
+.routing-legend {
+  display: flex;
+  align-items: center;
+  gap: var(--lc-space-2);
+  flex-wrap: wrap;
+  color: var(--lc-text-muted);
+  font-size: var(--lc-text-xs);
+  margin-bottom: var(--lc-space-3);
+}
+.routing-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.routing-selected-key {
+  color: var(--lc-accent);
+  font-weight: 600;
+}
+
+.routing-usertier {
+  margin-bottom: var(--lc-space-4);
+}
+.routing-usertier h2 {
+  font-size: var(--lc-text-md);
+  margin: 0 0 var(--lc-space-2);
+  color: var(--lc-text);
+}
+.routing-usertier h2 code {
+  font-family: var(--lc-font-mono);
+  font-size: 0.9em;
+  background: var(--lc-surface-2);
+  padding: 1px 6px;
+  border-radius: var(--lc-radius-sm);
+}
+
+.routing-tier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--lc-space-2);
+}
+.routing-tier-card {
+  border: 1px solid var(--lc-rule);
+  border-radius: var(--lc-radius);
+  background: var(--lc-surface);
+  padding: var(--lc-space-2);
+}
+.routing-tier-title {
+  font-size: var(--lc-text-sm);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--lc-text-muted);
+  margin-bottom: var(--lc-space-1);
+}
+.routing-tier-empty {
+  color: var(--lc-text-faint);
+  font-size: var(--lc-text-sm);
+  font-style: italic;
+}
+.routing-cascade {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.routing-cand {
+  display: flex;
+  align-items: center;
+  gap: var(--lc-space-1);
+  padding: 5px 6px;
+  border-radius: var(--lc-radius-sm);
+  font-size: var(--lc-text-sm);
+}
+.routing-cand.selected {
+  background: var(--lc-accent-soft);
+}
+.routing-cand.unavail .routing-model,
+.routing-cand.unavail .routing-provider {
+  color: var(--lc-text-faint);
+}
+.routing-rank {
+  font-size: var(--lc-text-xs);
+  color: var(--lc-text-muted);
+  min-width: 4.5em;
+}
+.routing-provider {
+  font-weight: 600;
+}
+.routing-model {
+  font-family: var(--lc-font-mono);
+  font-size: 0.9em;
+  color: var(--lc-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.routing-selected-badge {
+  margin-left: auto;
+  font-size: var(--lc-text-xs);
+  font-weight: 600;
+  color: var(--lc-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}


### PR DESCRIPTION
## Why

Operators had no way to see **which provider + model a consumer's run resolves to right now** short of triggering a run and reading logs. When a deployment leans on per-user-tier `provider_priority` overlays — e.g. a `public` tier confined to DeepSeek, a `sensitive` tier preferring Anthropic — an operator wants to *verify* that routing before a consumer discovers it the hard way.

Requested: "add an informative page … with currently active providers and active top and fallback models for each tier and each user tier, so admin can check which providers and models will be used by consumers at the moment." Chosen shape (via the earlier clarifying questions): a **new `routing` nav item**, and **tenants see a limited subset**.

## What

**`GET /v1/_routing`** — for each `user_tier × tier`, the ordered provider/model cascade the resolver would walk (top → fallbacks). Two views by principal, mirroring the RFC AS tenant-operator posture:

- **admin** (or legacy/open): live availability per candidate (reachable / stalled / rate-limited), which entry is currently **selected** (first available = what runs now), plus an **active-providers** header.
- **`substrate:tenant`**: the **config cascade only** (provider/model per tier, `primary` = the configured top). The handler strips the availability / infra fields for a non-admin caller.

The cascade comes from a new **`resolve.Resolver.Cascade`**, which reuses the existing `candidatesFor`/`priorityFor` so it visits candidates in the **same order** as `Resolve`'s inner loop (priority-outer, candidates-inner) and can't drift from real resolution. It's availability-agnostic (config order only); the handler annotates each entry from `Snapshot()`. Lock-free — it reads immutable config, not the mutable availability matrix.

The route is scope-gated in `requiredScopeFor` to **`ScopeTenant`** (admin also satisfies), placed **before** the `/v1/_*` catch-all that would otherwise pin it to `ScopeAdmin` — the same pattern as the RFC AS library/events routes.

**Web UI**: a new `routing` left-nav item (`vis: "tenant"`, between *audit* and *activity*). The page is **data-driven, not role-driven**: availability dots, the *selected* badge, the legend, and the providers header render only when those fields are present in the response, so a stripped tenant payload naturally renders the plain cascade with no dots — no client-side role check.

## What was tested

- **Backend unit** — `TestRouting_AdminSeesCascadeAndAvailability` (ordered cascade + availability fields + provider header; deepseek-up / anthropic-down seeded so `selected` lands on the reachable primary) and `TestRouting_TenantGetsStrippedView` (config cascade present, availability / infra fields absent). The route-scope table gains `/v1/_routing = ScopeTenant`.
- **`go test ./...`** — clean.
- **`npx tsc --noEmit`** — clean; `make build-ui` embeds the SPA.
- **Manual** — booted with a 3-user-tier config; `GET /v1/_routing` confirmed `public` shows DeepSeek-only, `sensitive` puts Anthropic first, `default` shows the DeepSeek→Anthropic fallback. A Playwright screenshot confirmed the nav item, the cascade cards, the red provider dots (no keys → all down), and the legend all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)