### PR TITLE
fix(loop): drop the effort hint when downgrading a thinking model on fallback

### DIFF
--- a/internal/loop/fallback_test.go
+++ b/internal/loop/fallback_test.go
@@ -1043,6 +1043,70 @@ func TestFallback_DowngradesThinkingModelOnForeignHistory(t *testing.T) {
 	}
 }
 
+// TestFallback_DowngradeDropsEffortHint is the regression for the 2026-07-01
+// production bug: an ollama-local qwen3.6 crash fell back to deepseek-v4-pro; the
+// loop downgraded it to the "non-thinking" deepseek-v4-flash, yet the call still
+// 400'd with "reasoning_content ... must be passed back". Cause: the effort hint
+// (high, inherited from the qwen3.6 thinking run) survived the downgrade and the
+// driver maps Request.Effort → reasoning_effort, which re-enables thinking mode on
+// the flash model — so the just-stripped, reasoning-less history was rejected. The
+// downgrade must ALSO clear the effort hint, else the non-thinking sibling is
+// silently put back into thinking mode.
+func TestFallback_DowngradeDropsEffortHint(t *testing.T) {
+	failing := &tieredProvider{
+		id:     "ollama-local",
+		errors: []error{fmt.Errorf("ollama-local 500: llama-server process no longer running")},
+	}
+	healthy := &downgradingRecorder{
+		recordingProvider: &recordingProvider{
+			tieredProvider: &tieredProvider{
+				id:        "deepseek",
+				responses: [][]providers.Event{successResponse()},
+			},
+		},
+	}
+	// Prior reasoning-less assistant turn (foreign provider produced it) → the
+	// downgrade branch fires.
+	prior := []providers.Message{
+		{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "first"}}},
+		{Role: "assistant", Content: []providers.ContentBlock{{Type: "text", Text: "ok"}}},
+	}
+
+	opts := RunOptions{
+		Provider:       failing,
+		Model:          "qwen3.6:latest",
+		Effort:         "high",
+		MaxIterations:  5,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "second"}}}},
+		PriorMessages:  prior,
+		OnEvent:        func(providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: true, MaxAttempts: 3, UserTierName: "free"},
+		// Re-resolve to the deepseek thinking model, carrying the agent's effort
+		// forward (as the real resolver does) — this is the value that must be
+		// dropped when the downgrade fires.
+		ReResolve: func(_ context.Context, _, _ string, _ error) (providers.Provider, string, string, error) {
+			return healthy, "deepseek-v4-pro", "high", nil
+		},
+	}
+	if _, err := Run(context.Background(), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := healthy.snapshotRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("downgrade target got %d Calls, want 1", len(reqs))
+	}
+	if reqs[0].Model != "deepseek-v4-flash" {
+		t.Errorf("fallback leg ran on model %q, want deepseek-v4-flash", reqs[0].Model)
+	}
+	// The core assertion: no effort hint reaches the downgraded (non-thinking)
+	// request, so the driver omits reasoning_effort and flash stays out of
+	// thinking mode. Fails on the pre-fix code, where Effort == "high" survives.
+	if reqs[0].Effort != "" {
+		t.Errorf("downgraded request carried Effort %q, want \"\" (effort must be dropped so reasoning_effort doesn't re-enable thinking)", reqs[0].Effort)
+	}
+}
+
 // TestFallback_NoDowngradeWithoutAssistantTurn — a fresh history (no assistant
 // turn yet) is fine for a thinking model: there's no prior turn to demand
 // reasoning_content for, so the loop must NOT downgrade.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -662,9 +662,23 @@ func tryProviderFallback(
 		if sibling, downgraded := dg.NonThinkingSibling(newModel); downgraded {
 			emit(providers.Event{
 				Type: providers.EventModelDowngraded,
-				Text: fmt.Sprintf("downgraded %s to non-thinking %s on switch to %s: the fallback history carries assistant turns without reasoning_content, which the thinking model would reject", newModel, sibling, newProvider.ID()),
+				Text: fmt.Sprintf("downgraded %s to non-thinking %s on switch to %s (dropped the effort hint): the fallback history carries assistant turns without reasoning_content, which the thinking model would reject", newModel, sibling, newProvider.ID()),
 			})
 			newModel = sibling
+			_ = 0 // FIX DISABLED FOR TEST
+			// Also drop the effort hint. A "non-thinking sibling" is only actually
+			// non-thinking if the request doesn't ALSO carry a reasoning_effort
+			// that turns thinking back ON. DeepSeek's V4 line is hybrid: the driver
+			// maps Request.Effort → reasoning_effort (openai driver), and
+			// reasoning_effort re-enables thinking mode REGARDLESS of the
+			// -flash/-pro model name. Without this, the downgraded flash request
+			// still runs in thinking mode and 400s on the (reasoning-less,
+			// just-stripped) history with "reasoning_content ... must be passed
+			// back" — silently defeating the downgrade. Production 2026-07-01: an
+			// ollama-local qwen3.6 crash fell back to deepseek-v4-pro, the loop
+			// downgraded it to deepseek-v4-flash, and the call STILL 400'd because
+			// effort=high (inherited from the qwen3.6 thinking run) kept thinking on.
+			newEffort = ""
 		}
 	}
 


### PR DESCRIPTION
## Why (the production incident)

A `company-researcher` sub-run on **ollama-local** (`qwen3.6:latest`, `effort=high`) hit `llama-server process no longer running` and fell back to **deepseek**. The loop's R2 thinking-model downgrade (#472) fired **correctly** — `deepseek-v4-pro` → the "non-thinking" `deepseek-v4-flash`, because the fallback history's assistant turns are reasoning-less — yet the call **still 400'd**:

```
openai 400: {"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API.", ...}}
```

The transcript evidence: `PROVIDER_FALLBACK` (ollama-local → deepseek-v4-pro) → `MODEL_DOWNGRADED` (v4-pro → v4-flash) → `ERROR` (the 400), all at the same second.

## Root cause

The downgrade swapped the **model** but not the **effort** hint. `opts.Effort` (`high`, inherited from the qwen3.6 thinking run) survived the switch (`tryProviderFallback` sets `opts.Effort = newEffort` unconditionally), and the openai/deepseek driver maps `Request.Effort` → `reasoning_effort` on the wire (`internal/providers/openai/driver.go`). DeepSeek's V4 line is **hybrid**: `reasoning_effort` re-enables thinking mode **regardless of the `-flash`/`-pro` model name**. So the "non-thinking" flash request ran in thinking mode and rejected the just-stripped, reasoning-less history — silently defeating the downgrade.

## The fix

When the `ThinkingDowngrader` swaps in the non-thinking sibling, also clear the effort hint (`newEffort = ""`). The driver then omits `reasoning_effort` (`omitempty`) and the sibling actually stays out of thinking mode. 

- **Provider-agnostic** — any `ThinkingDowngrader` benefits.
- **Scoped to the downgrade branch only** — a fresh-history thinking fallback (no reasoning-less turn to satisfy) keeps its effort and its thinking model unchanged.
- Runtime-only; no wire/schema/UI change.

## What was tested

- **`TestFallback_DowngradeDropsEffortHint`** reproduces the incident (ollama-local crash → `deepseek-v4-pro` with `effort=high` → downgrade to `deepseek-v4-flash`) and asserts the recorded request carries **no** effort. **Fails on the pre-fix code** (`Effort "high"` survives → the exact 400); passes with the fix. Verified by temporarily reverting the one-line fix and watching the test fail.
- The existing downgrade tests (`TestFallback_DowngradesThinkingModelOnForeignHistory`, `TestFallback_NoDowngradeWithoutAssistantTurn`) still pass.
- **`go test ./...`** clean; `go build -o bin/loomcycle` OK.

## Note

The VM that produced this runs a build that already has the #472 downgrade (it fired), so this is a genuine current-code bug, not just an old build — the downgrade needed to also drop the effort hint. Deploy this to resolve it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)