### PR TITLE
fix(loop): remove committed debug artifact in the downgrade branch

### DIFF
--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -665,7 +665,6 @@ func tryProviderFallback(
 				Text: fmt.Sprintf("downgraded %s to non-thinking %s on switch to %s (dropped the effort hint): the fallback history carries assistant turns without reasoning_content, which the thinking model would reject", newModel, sibling, newProvider.ID()),
 			})
 			newModel = sibling
-			_ = 0 // FIX DISABLED FOR TEST
 			// Also drop the effort hint. A "non-thinking sibling" is only actually
 			// non-thinking if the request doesn't ALSO carry a reasoning_effort
 			// that turns thinking back ON. DeepSeek's V4 line is hybrid: the driver


### PR DESCRIPTION
## Why
A `_ = 0 // FIX DISABLED FOR TEST` line slipped into `tryProviderFallback`'s R2 thinking-downgrade branch during the #608 regression-test proof and was committed + shipped in v1.9.0. It's a functional no-op (the `newEffort = ""` on the next line still runs, so the #608 fix is intact), but the "FIX DISABLED" comment is misleading and a future edit near it could delete the real fix believing it was intentionally disabled.

## What
Remove the one dead line. No behaviour change.

## Tested
`TestFallback_DowngradeDropsEffortHint` still passes; `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)