### PR TITLE
fix(grpc): enforce tenant/subject isolation on read + channel RPCs

### DIFF
--- a/internal/api/grpc/channels.go
+++ b/internal/api/grpc/channels.go
@@ -47,6 +47,9 @@ func (s *Server) PublishChannel(ctx context.Context, req *loomcyclepb.PublishCha
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
 	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
+	}
 	resp, err := s.connector.PublishChannel(ctx, connector.ChannelPublishRequest{
 		Channel:   req.GetChannel(),
 		Scope:     req.GetScope(),
@@ -73,6 +76,9 @@ func (s *Server) PublishChannel(ctx context.Context, req *loomcyclepb.PublishCha
 func (s *Server) SubscribeChannel(ctx context.Context, req *loomcyclepb.SubscribeChannelRequest) (*loomcyclepb.SubscribeChannelResponse, error) {
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
 	}
 	resp, err := s.connector.SubscribeChannel(ctx, connector.ChannelSubscribeRequest{
 		Channel:     req.GetChannel(),
@@ -105,6 +111,9 @@ func (s *Server) PeekChannel(ctx context.Context, req *loomcyclepb.PeekChannelRe
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
 	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
+	}
 	resp, err := s.connector.PeekChannel(ctx, connector.ChannelPeekRequest{
 		Channel:     req.GetChannel(),
 		Scope:       req.GetScope(),
@@ -134,6 +143,9 @@ func (s *Server) AckChannel(ctx context.Context, req *loomcyclepb.AckChannelRequ
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
 	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
+	}
 	resp, err := s.connector.AckChannel(ctx, connector.ChannelAckRequest{
 		Channel: req.GetChannel(),
 		Scope:   req.GetScope(),
@@ -152,6 +164,9 @@ func (s *Server) AckChannel(ctx context.Context, req *loomcyclepb.AckChannelRequ
 func (s *Server) AwaitChannels(ctx context.Context, req *loomcyclepb.AwaitChannelsRequest) (*loomcyclepb.AwaitChannelsResponse, error) {
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
 	}
 	resp, err := s.connector.AwaitChannels(ctx, connector.ChannelAwaitRequest{
 		Channels:    req.GetChannels(),
@@ -194,6 +209,9 @@ func (s *Server) AwaitChannels(ctx context.Context, req *loomcyclepb.AwaitChanne
 func (s *Server) BroadcastChannels(ctx context.Context, req *loomcyclepb.BroadcastChannelsRequest) (*loomcyclepb.BroadcastChannelsResponse, error) {
 	if s.connector == nil {
 		return nil, status.Error(codes.Unavailable, "connector not wired")
+	}
+	if err := principalMayUseChannelScope(ctx, req.GetScope(), req.GetScopeId()); err != nil {
+		return nil, err
 	}
 	resp, err := s.connector.BroadcastChannels(ctx, connector.ChannelBroadcastRequest{
 		Channels:  req.GetChannels(),

--- a/internal/api/grpc/n8n.go
+++ b/internal/api/grpc/n8n.go
@@ -54,10 +54,18 @@ func (s *Server) StreamUserRunStates(req *loomcyclepb.StreamUserRunStatesRequest
 		return status.Error(codes.InvalidArgument, "user_id is required")
 	}
 
+	// Tenant isolation (RFC L/N): confine the stream to the caller's tenant,
+	// mirroring the HTTP handleStreamUserAgents which sets TenantID/TenantScoped
+	// from principalTenantScope. Without this a scoped principal streamed every
+	// tenant's live run-state transitions (the connector filter is gated on
+	// TenantScoped, which the gRPC path previously left false).
+	tenantID, allTenants := grpcTenantScope(stream.Context())
 	cReq := connector.StreamUserRunStatesRequest{
-		UserID:   req.GetUserId(),
-		Statuses: req.GetStatuses(),
-		Agent:    req.GetAgent(),
+		UserID:       req.GetUserId(),
+		Statuses:     req.GetStatuses(),
+		Agent:        req.GetAgent(),
+		TenantID:     tenantID,
+		TenantScoped: !allTenants,
 	}
 
 	visit := func(evt connector.RunStateEvent) error {

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -200,6 +200,12 @@ func (s *Server) GetAgent(ctx context.Context, req *loomcyclepb.GetAgentRequest)
 		}
 		return nil, status.Errorf(codes.Internal, "store: %v", err)
 	}
+	// Tenant isolation (RFC L/N): fold a cross-tenant run into the same opaque
+	// NotFound the HTTP handleGetAgent returns via tenantStore.GetRunByAgentID —
+	// agent ids are not secret, so the gate must not be an existence oracle.
+	if !grpcTenantVisible(ctx, run.TenantID) {
+		return nil, status.Errorf(codes.NotFound, "no run found for agent_id %q", agentID)
+	}
 	_, live := s.cancelReg.Get(agentID)
 	return runToProto(run, live), nil
 }
@@ -273,6 +279,11 @@ func (s *Server) ListUserAgents(ctx context.Context, req *loomcyclepb.ListUserAg
 	}
 	out := &loomcyclepb.ListUserAgentsResponse{Agents: make([]*loomcyclepb.Agent, 0, len(runs))}
 	for _, r := range runs {
+		// Tenant isolation (RFC L/N): drop cross-tenant rows, mirroring the HTTP
+		// handleListUserAgents post-filter driven by principalTenantScope.
+		if !grpcTenantVisible(ctx, r.TenantID) {
+			continue
+		}
 		_, live := s.cancelReg.Get(r.AgentID)
 		out.Agents = append(out.Agents, runToProto(r, live))
 	}
@@ -295,12 +306,20 @@ func (s *Server) GetTranscript(ctx context.Context, req *loomcyclepb.GetTranscri
 	if s.store == nil {
 		return nil, status.Error(codes.FailedPrecondition, "transcript requires persistence (Store not configured)")
 	}
-	if _, err := s.store.GetSession(ctx, sessionID); err != nil {
+	sess, err := s.store.GetSession(ctx, sessionID)
+	if err != nil {
 		var nf *store.ErrNotFound
 		if errors.As(err, &nf) {
 			return nil, status.Errorf(codes.NotFound, "session %q not found", sessionID)
 		}
 		return nil, status.Errorf(codes.Internal, "store: %v", err)
+	}
+	// Tenant isolation (RFC L/N): a transcript exposes the session's full
+	// history, so gate it on the session's tenant exactly as the HTTP
+	// handleTranscript does via tenantStore.GetSession — a cross-tenant session
+	// folds into the same opaque NotFound (session ids are not secret).
+	if !grpcTenantVisible(ctx, sess.TenantID) {
+		return nil, status.Errorf(codes.NotFound, "session %q not found", sessionID)
 	}
 	events, err := s.store.GetTranscript(ctx, sessionID)
 	if err != nil {

--- a/internal/api/grpc/tenant.go
+++ b/internal/api/grpc/tenant.go
@@ -1,0 +1,71 @@
+// tenant.go — gRPC-side tenant/subject isolation helpers.
+//
+// RFC L/N tenant isolation on the HTTP transport lives entirely in the http
+// package's handlers (tenantStore / principalTenantScope /
+// requirePrincipalOwnsPathUser). The gRPC interceptors authenticate + stamp the
+// principal and enforce SCOPE, but historically performed no tenant/subject ROW
+// filtering — so a scoped principal could read/stream/act across tenants over
+// gRPC that HTTP folds away. These helpers are the gRPC twins of the HTTP
+// choke-points; every tenant-bearing gRPC read must run through them so the two
+// transports enforce the identical boundary. Keep in lockstep with
+// internal/api/http/tenant_store.go (tenantScopeFromCtx) and auth_principal.go
+// (requirePrincipalOwnsPathUser).
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// grpcTenantScope resolves (tenantID, allTenants) from the ctx principal the
+// auth interceptor stamped — the gRPC twin of the HTTP tenantScopeFromCtx.
+// No principal (open dev mode), the single-operator legacy principal, and any
+// substrate:admin principal all see every tenant; a scoped principal is
+// confined to its own tenant.
+func grpcTenantScope(ctx context.Context) (tenantID string, allTenants bool) {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return "", true
+	}
+	return p.TenantID, false
+}
+
+// grpcTenantVisible reports whether a row owned by rowTenant is in the caller's
+// tenant scope. Callers fold a false result into an opaque NotFound so the gate
+// is not a cross-tenant existence oracle (ids are not secret).
+func grpcTenantVisible(ctx context.Context, rowTenant string) bool {
+	tenantID, all := grpcTenantScope(ctx)
+	return all || rowTenant == tenantID
+}
+
+// principalMayUseChannelScope enforces the same channel-scope authz the HTTP
+// channel routes apply: the operator "global" scope is admin-only (HTTP serves
+// it solely under the substrate:admin /v1/_channels/* routes) and a "user"
+// scope is confined to the caller's own subject (HTTP userChannelScopeID →
+// requirePrincipalOwnsPathUser). Admin / legacy / open (no principal) bypass,
+// matching the HTTP exemption set. Returns a gRPC status error to surface as-is,
+// or nil when the (scope, scopeID) pair is allowed.
+func principalMayUseChannelScope(ctx context.Context, scope, scopeID string) error {
+	p, ok := auth.PrincipalFromContext(ctx)
+	if !ok || p.Legacy || auth.HasScope(p.Scopes, auth.ScopeAdmin) {
+		return nil
+	}
+	switch scope {
+	case "user":
+		// A non-admin may touch only its OWN user-scoped channel. Opaque
+		// NotFound (not PermissionDenied) mirrors the HTTP 404 "unknown_channel"
+		// so the gate isn't a cross-subject existence oracle.
+		if scopeID != p.Subject {
+			return status.Error(codes.NotFound, "no such channel")
+		}
+		return nil
+	default:
+		// "global" / "" (and any other non-user scope) is the operator plane;
+		// HTTP admits it only on the substrate:admin /v1/_channels/* routes.
+		return status.Error(codes.PermissionDenied, "channel scope requires admin")
+	}
+}

--- a/internal/api/grpc/tenant_isolation_test.go
+++ b/internal/api/grpc/tenant_isolation_test.go
@@ -1,0 +1,142 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/denn-gubsky/loomcycle/internal/api/grpc/loomcyclepb"
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// These regression tests close the gRPC cross-tenant isolation gap: the gRPC
+// handlers authenticate + enforce scope but historically did NO tenant/subject
+// row-filtering (that lived only in the HTTP handlers), so a scoped principal
+// could read/stream/act across tenants over gRPC that HTTP folds away. Each
+// test drives the handler directly with an auth.Principal-bearing ctx (the same
+// ctx the interceptor stamps in the live path).
+
+func tenantTestServer(t *testing.T) (*Server, store.Store) {
+	t.Helper()
+	st := newTestStore(t)
+	adapter := New(Config{Store: st, CancelReg: cancel.NewRegistry()})
+	return adapter, st
+}
+
+// seedRun creates a session + run in the given tenant and returns the agent id.
+func seedRun(t *testing.T, st store.Store, tenant, user, agentID string) string {
+	t.Helper()
+	ctx := context.Background()
+	sess, err := st.CreateSession(ctx, tenant, "default", user)
+	if err != nil {
+		t.Fatalf("CreateSession(%s): %v", tenant, err)
+	}
+	if _, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{
+		AgentID: agentID, UserID: user, TenantID: tenant,
+	}); err != nil {
+		t.Fatalf("CreateRun(%s): %v", tenant, err)
+	}
+	return agentID
+}
+
+func scopedCtx(tenant, subject string, scopes ...string) context.Context {
+	return auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: tenant, Subject: subject, Scopes: scopes})
+}
+
+// TestGrpcGetAgent_CrossTenantFoldsNotFound: a tenant-acme principal must not
+// read a tenant-evil run's metadata over gRPC — it folds to NotFound (the
+// opaque posture HTTP handleGetAgent gets from tenantStore.GetRunByAgentID).
+func TestGrpcGetAgent_CrossTenantFoldsNotFound(t *testing.T) {
+	adapter, st := tenantTestServer(t)
+	seedRun(t, st, "evil", "mallory", "a_evil")
+	seedRun(t, st, "acme", "alice", "a_acme")
+
+	acme := scopedCtx("acme", "alice", auth.ScopeRunsRead)
+
+	if _, err := adapter.GetAgent(acme, &loomcyclepb.GetAgentRequest{AgentId: "a_evil"}); status.Code(err) != codes.NotFound {
+		t.Errorf("cross-tenant GetAgent code=%s, want NotFound", status.Code(err))
+	}
+	if _, err := adapter.GetAgent(acme, &loomcyclepb.GetAgentRequest{AgentId: "a_acme"}); err != nil {
+		t.Errorf("own-tenant GetAgent: %v, want ok", err)
+	}
+	// An admin principal crosses tenants by design.
+	admin := scopedCtx("acme", "ops", auth.ScopeAdmin)
+	if _, err := adapter.GetAgent(admin, &loomcyclepb.GetAgentRequest{AgentId: "a_evil"}); err != nil {
+		t.Errorf("admin GetAgent cross-tenant: %v, want ok", err)
+	}
+}
+
+// TestGrpcGetTranscript_CrossTenantFoldsNotFound: a cross-tenant session's
+// transcript folds to NotFound (a transcript exposes the whole conversation).
+func TestGrpcGetTranscript_CrossTenantFoldsNotFound(t *testing.T) {
+	adapter, st := tenantTestServer(t)
+	ctx := context.Background()
+	evilSess, _ := st.CreateSession(ctx, "evil", "default", "mallory")
+	acmeSess, _ := st.CreateSession(ctx, "acme", "default", "alice")
+
+	acme := scopedCtx("acme", "alice", auth.ScopeRunsRead)
+	if _, err := adapter.GetTranscript(acme, &loomcyclepb.GetTranscriptRequest{SessionId: evilSess.ID}); status.Code(err) != codes.NotFound {
+		t.Errorf("cross-tenant GetTranscript code=%s, want NotFound", status.Code(err))
+	}
+	if _, err := adapter.GetTranscript(acme, &loomcyclepb.GetTranscriptRequest{SessionId: acmeSess.ID}); err != nil {
+		t.Errorf("own-tenant GetTranscript: %v, want ok", err)
+	}
+}
+
+// TestGrpcListUserAgents_DropsCrossTenant: when the same user_id has runs in
+// two tenants, a scoped principal sees only its own tenant's rows.
+func TestGrpcListUserAgents_DropsCrossTenant(t *testing.T) {
+	adapter, st := tenantTestServer(t)
+	// Same user id "shared" owns a run under each tenant.
+	seedRun(t, st, "evil", "shared", "a_evil_shared")
+	seedRun(t, st, "acme", "shared", "a_acme_shared")
+
+	acme := scopedCtx("acme", "shared", auth.ScopeRunsRead)
+	resp, err := adapter.ListUserAgents(acme, &loomcyclepb.ListUserAgentsRequest{UserId: "shared"})
+	if err != nil {
+		t.Fatalf("ListUserAgents: %v", err)
+	}
+	for _, a := range resp.GetAgents() {
+		if a.GetAgentId() == "a_evil_shared" {
+			t.Errorf("scoped ListUserAgents leaked a cross-tenant run: %s", a.GetAgentId())
+		}
+	}
+	if len(resp.GetAgents()) != 1 || resp.GetAgents()[0].GetAgentId() != "a_acme_shared" {
+		t.Errorf("scoped list = %v, want only a_acme_shared", resp.GetAgents())
+	}
+}
+
+// TestGrpcChannelScope_ConfinedToSubjectAndAdmin locks the channel-scope gate:
+// a non-admin may touch only its own user scope; another subject folds to
+// NotFound and the operator global scope is admin-only.
+func TestGrpcChannelScope_ConfinedToSubjectAndAdmin(t *testing.T) {
+	tenantAlice := scopedCtx("acme", "alice", auth.ScopeChannelRead, auth.ScopeChannelPublish)
+
+	// Own user scope — allowed.
+	if err := principalMayUseChannelScope(tenantAlice, "user", "alice"); err != nil {
+		t.Errorf("own user scope denied: %v", err)
+	}
+	// Another subject — opaque NotFound.
+	if err := principalMayUseChannelScope(tenantAlice, "user", "bob"); status.Code(err) != codes.NotFound {
+		t.Errorf("cross-subject user scope code=%s, want NotFound", status.Code(err))
+	}
+	// Operator global scope — admin-only → PermissionDenied for a tenant token.
+	if err := principalMayUseChannelScope(tenantAlice, "global", ""); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("global scope for tenant token code=%s, want PermissionDenied", status.Code(err))
+	}
+	if err := principalMayUseChannelScope(tenantAlice, "", ""); status.Code(err) != codes.PermissionDenied {
+		t.Errorf("default(global) scope for tenant token code=%s, want PermissionDenied", status.Code(err))
+	}
+	// Admin bypasses all of it.
+	admin := scopedCtx("acme", "ops", auth.ScopeAdmin)
+	for _, sc := range []struct{ scope, id string }{{"user", "bob"}, {"global", ""}} {
+		if err := principalMayUseChannelScope(admin, sc.scope, sc.id); err != nil {
+			t.Errorf("admin denied scope=%q id=%q: %v", sc.scope, sc.id, err)
+		}
+	}
+}


### PR DESCRIPTION
## Why (security — CRITICAL)

Found in the full-repo security review. The gRPC transport authenticated and enforced per-RPC **scope** but performed **no tenant/subject row-filtering** — that logic lives entirely in the HTTP handlers (`tenantStore` / `principalTenantScope` / `requirePrincipalOwnsPathUser`) and was never shared with the connector/store the gRPC methods call. In **multi-tenant mode** (any deployment with `OperatorTokenDef`s minted — the principal wiring in `main.go` is unconditional), a `substrate:tenant` (or any `runs:read` / `channel:*`) token could, over gRPC:

- read **any tenant's** session transcript (`GetTranscript`), run metadata (`GetAgent`), per-user run list (`ListUserAgents`);
- stream **any tenant's** live run-state transitions (`StreamUserRunStates` — the connector filter is gated on `TenantScoped`, which the gRPC path left `false`);
- read/write **any subject's** channels and the operator `global` scope (`Publish/Subscribe/Peek/Ack/Await/Broadcast`).

Each is tenant-folded on the HTTP sibling. IDs are non-secret by the project's own model, so these were practically exploitable — the exact posture RFC L/AF/AS exist to protect. Inert in single-tenant / legacy-token / open mode.

## What

- New `internal/api/grpc/tenant.go` — gRPC twins of the HTTP choke-points: `grpcTenantScope` / `grpcTenantVisible` (mirror `tenantScopeFromCtx`) and `principalMayUseChannelScope` (mirror `userChannelScopeID` + the admin-only global gate). Admin / legacy / open-mode bypass, matching the HTTP exemption set exactly.
- `GetAgent` / `GetTranscript`: fold a cross-tenant row into the same opaque `NotFound`.
- `ListUserAgents`: drop cross-tenant rows.
- `StreamUserRunStates`: set `TenantID` / `TenantScoped` from the principal.
- The 6 channel RPCs: gate `(scope, scope_id)` — own subject for `user`, admin-only for `global`.

**Cancel is intentionally not touched here** — `CancelAgent` shares `connector.CancelRun` with the HTTP + MCP transports; it's fixed at the connector level in a follow-up PR so all three transports gate cancel once (avoids overlapping edits).

## What was tested

`TestGrpcGetAgent_CrossTenantFoldsNotFound`, `TestGrpcGetTranscript_CrossTenantFoldsNotFound`, `TestGrpcListUserAgents_DropsCrossTenant`, `TestGrpcChannelScope_ConfinedToSubjectAndAdmin`. **All four fail on the pre-fix code** (verified by neutering the guards → the cross-tenant reads return OK and the global scope is admitted) and pass with the fix. Full `internal/api/grpc` package + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)