### PR TITLE
fix(a2a): authenticate peers via the operator-token substrate (close open A2A)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -40,7 +40,6 @@ import (
 	lchttp "github.com/denn-gubsky/loomcycle/internal/api/http"
 	webhookapi "github.com/denn-gubsky/loomcycle/internal/api/webhook"
 	"github.com/denn-gubsky/loomcycle/internal/audit"
-	"github.com/denn-gubsky/loomcycle/internal/auth"
 	"github.com/denn-gubsky/loomcycle/internal/channels"
 	"github.com/denn-gubsky/loomcycle/internal/cli"
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
@@ -1655,23 +1654,15 @@ func main() {
 	// registration happens on the shared grpc.Server further down.
 	var a2aServer *a2aapi.Server
 	if cfg.Env.A2AServerEnabled {
-		authToken := cfg.Env.AuthToken
-		var a2aAuth a2aapi.Authenticator
-		if authToken != "" {
-			// Reuse the same constant-time bearer check as the HTTP
-			// authMiddleware. The peer's bearer authenticates it as the
-			// principal; the name is opaque here (run attribution only).
-			a2aAuth = func(h http.Header) (string, bool) {
-				got := h.Get("Authorization")
-				if got == "" {
-					return "", false
-				}
-				if auth.CompareBearer(got, "Bearer "+authToken) {
-					return "a2a-peer", true
-				}
-				return "", false
-			}
-		}
+		// Authenticate A2A peers through the SAME operator-token substrate the
+		// HTTP/gRPC planes use — NOT just the legacy LOOMCYCLE_AUTH_TOKEN.
+		// srv.ResolvePrincipal handles both operator tokens and the legacy
+		// fallback (and correctly rejects a legacy secret HTTP has retired once
+		// an admin token exists); srv.AuthConfigured is the shared open-mode
+		// decision, evaluated per request. Previously this was gated on the
+		// legacy token alone, so an operator-token-only deployment left A2A
+		// unauthenticated (deps.Auth nil → anonymous-but-authenticated).
+		a2aAuth := a2aapi.FrontierAuthenticator(srv.AuthConfigured, srv.ResolvePrincipal)
 		a2aServer, err = a2aapi.New(context.Background(), a2aapi.Deps{
 			Cfg:   cfg,
 			Store: storeIface,

--- a/internal/api/a2a/auth.go
+++ b/internal/api/a2a/auth.go
@@ -1,0 +1,66 @@
+package a2a
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// FrontierAuthenticator builds the A2A frontier Authenticator so the A2A auth
+// decision matches the HTTP/gRPC plane. It authenticates every bearer through
+// the SAME operator-token substrate (resolve — which also handles the
+// legacy-token fallback, so a legacy secret that HTTP has retired once an admin
+// token exists is rejected here too), and it is DYNAMIC: the open-mode decision
+// (authConfigured) is evaluated per request, so minting the first admin token
+// at runtime closes A2A at the same moment it closes HTTP.
+//
+// Behaviour:
+//   - auth NOT configured (true open dev mode) → ("anonymous", true), mirroring
+//     the HTTP authMiddleware passthrough when no auth is set.
+//   - auth configured + valid bearer → (name, true), attributed by the
+//     principal's subject; legacy peers keep the historical "a2a-peer" name.
+//     The name is run-attribution only — never an authz allowlist (CLAUDE.md §8).
+//   - auth configured + missing/invalid bearer → ("", false); the
+//     principalInterceptor then rejects with ErrUnauthenticated before any run
+//     spawns.
+//
+// This fixes the gap where the authenticator was built ONLY from the legacy
+// LOOMCYCLE_AUTH_TOKEN: an operator-token-only deployment (no legacy secret —
+// the supported RFC AO / no-shell-mint posture) left Deps.Auth nil, so
+// principalInterceptor.Before treated every A2A request as authenticated
+// anonymous → unauthenticated run-spawn, cancel, and read while HTTP stayed
+// gated.
+func FrontierAuthenticator(
+	authConfigured func(context.Context) bool,
+	resolve func(context.Context, string) (auth.Principal, bool),
+) Authenticator {
+	return func(h http.Header) (string, bool) {
+		ctx := context.Background()
+		// Per-request open-mode check: no auth configured ⇒ anonymous, matching
+		// HTTP. Evaluated every call so a runtime-minted admin token flips A2A
+		// closed without a restart.
+		if authConfigured == nil || !authConfigured(ctx) {
+			return "anonymous", true
+		}
+		got := h.Get("Authorization")
+		const pfx = "Bearer "
+		if len(got) <= len(pfx) || !strings.EqualFold(got[:len(pfx)], pfx) {
+			return "", false
+		}
+		if resolve == nil {
+			return "", false
+		}
+		p, ok := resolve(ctx, got[len(pfx):])
+		if !ok {
+			return "", false
+		}
+		// Attribution name only. Preserve the legacy peer's historical
+		// "a2a-peer" name; attribute operator-token peers by their subject.
+		if p.Legacy || p.Subject == "" {
+			return "a2a-peer", true
+		}
+		return p.Subject, true
+	}
+}

--- a/internal/api/a2a/auth_test.go
+++ b/internal/api/a2a/auth_test.go
@@ -1,0 +1,70 @@
+package a2a
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+)
+
+// TestFrontierAuthenticator_OperatorTokenOnlyIsGated is the regression for the
+// A2A open-in-operator-token-only-mode bug: when auth is configured (an admin
+// OperatorTokenDef exists) but NO legacy LOOMCYCLE_AUTH_TOKEN is set, the
+// authenticator must still REQUIRE a valid bearer — the old code built the
+// authenticator only from the legacy token, so this posture left A2A open.
+func TestFrontierAuthenticator_OperatorTokenOnlyIsGated(t *testing.T) {
+	authConfigured := func(context.Context) bool { return true } // an admin token exists
+	resolve := func(_ context.Context, bearer string) (auth.Principal, bool) {
+		if bearer == "lct_alice" {
+			return auth.Principal{TenantID: "acme", Subject: "alice", Scopes: []string{auth.ScopeRunsCreate}}, true
+		}
+		return auth.Principal{}, false
+	}
+	authn := FrontierAuthenticator(authConfigured, resolve)
+
+	// No credential → rejected (the interceptor turns this into ErrUnauthenticated).
+	if _, ok := authn(http.Header{}); ok {
+		t.Error("operator-token-only mode: missing bearer must be rejected, got ok=true (A2A open!)")
+	}
+	// Wrong credential → rejected.
+	bad := http.Header{"Authorization": []string{"Bearer nope"}}
+	if _, ok := authn(bad); ok {
+		t.Error("operator-token-only mode: invalid bearer must be rejected")
+	}
+	// Valid operator token → accepted, attributed by subject.
+	good := http.Header{"Authorization": []string{"Bearer lct_alice"}}
+	name, ok := authn(good)
+	if !ok || name != "alice" {
+		t.Errorf("valid operator token: name=%q ok=%v, want (\"alice\", true)", name, ok)
+	}
+}
+
+// TestFrontierAuthenticator_OpenModeAnonymous: with no auth configured (true
+// open dev mode), the authenticator passes requests through as anonymous,
+// mirroring the HTTP authMiddleware.
+func TestFrontierAuthenticator_OpenModeAnonymous(t *testing.T) {
+	authn := FrontierAuthenticator(func(context.Context) bool { return false }, nil)
+	name, ok := authn(http.Header{})
+	if !ok || name != "anonymous" {
+		t.Errorf("open mode: name=%q ok=%v, want (\"anonymous\", true)", name, ok)
+	}
+}
+
+// TestFrontierAuthenticator_LegacyPeerKeepsName: a legacy-token peer keeps the
+// historical "a2a-peer" attribution name (no run-attribution regression), and
+// the legacy token resolving is delegated to resolve() — so once HTTP retires
+// it (an admin token exists → resolve returns false) A2A rejects it too.
+func TestFrontierAuthenticator_LegacyPeerKeepsName(t *testing.T) {
+	resolve := func(_ context.Context, bearer string) (auth.Principal, bool) {
+		if bearer == "legacy-secret" {
+			return auth.Principal{TenantID: "default", Subject: "default", Legacy: true, Scopes: []string{auth.ScopeAdmin}}, true
+		}
+		return auth.Principal{}, false
+	}
+	authn := FrontierAuthenticator(func(context.Context) bool { return true }, resolve)
+	name, ok := authn(http.Header{"Authorization": []string{"Bearer legacy-secret"}})
+	if !ok || name != "a2a-peer" {
+		t.Errorf("legacy peer: name=%q ok=%v, want (\"a2a-peer\", true)", name, ok)
+	}
+}


### PR DESCRIPTION
## Why (security — CRITICAL)

Found in the full-repo security review. The A2A frontier authenticator (`cmd/loomcycle/main.go`) was built **only** when the legacy `LOOMCYCLE_AUTH_TOKEN` was set. But HTTP's `authConfigured` also counts admin `OperatorTokenDef`s, so in the supported **operator-token-only** posture (mint an admin token, drop the legacy secret — the RFC AO / no-shell Web-UI mint flow, which `legacyFallbackDisabled` actively pushes operators toward), `deps.Auth` was **nil**. `principalInterceptor.Before` treats a nil authenticator as authenticated-**anonymous** (open mode) → with `LOOMCYCLE_A2A_ENABLED=1` and no legacy token, any unauthenticated peer could `message:send` (spawn arbitrary runs — LLM cost/DoS), cancel, and read, while HTTP stayed gated.

Secondary bug it also fixes: because the old gate was `AuthToken != ""` (not `legacyFallbackDisabled`), A2A kept accepting a legacy secret that HTTP had already retired once an admin token existed.

## What

New **`a2a.FrontierAuthenticator(authConfigured, resolve)`** wired from `srv.AuthConfigured` + `srv.ResolvePrincipal` — the same substrate the HTTP/gRPC planes use:
- authenticates every bearer through `ResolvePrincipal` (operator tokens **and** the legacy fallback — so a retired legacy secret is rejected here too);
- evaluates the open-mode decision **per request**, so minting the first admin token at runtime closes A2A at the same instant it closes HTTP (no restart);
- open dev mode (no auth configured) still passes through as anonymous, mirroring `authMiddleware`;
- legacy peers keep the historical `a2a-peer` attribution name (no run-attribution regression); operator peers are attributed by subject. Name is attribution only, never authz (CLAUDE.md §8).

The old inline legacy-only closure is removed; `deps.Auth` is now always non-nil from `main.go`.

## What was tested

- `TestFrontierAuthenticator_OperatorTokenOnlyIsGated` — the regression: with auth configured and no legacy token, a missing/invalid bearer is **rejected**. Fails on the pre-fix behavior (verified by neutering back to nil-auth open-mode → the test reports "A2A open!").
- `_OpenModeAnonymous`, `_LegacyPeerKeepsName`. Full `internal/api/a2a` package + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)