### PR TITLE
fix(memory): block SSRF + API-key exfil via a model-authored mem9 base_url

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -777,6 +777,10 @@ func main() {
 		// its X-API-Key. Reuses the scheduler/webhook env allowlist — no
 		// new credential surface (Decision 10).
 		EnvAllowlist: memoryEnvAllowlist,
+		// SSRF: the mem9 client blocks private/loopback/metadata IPs at dial
+		// time; this reuses the HTTP tool's private-host vouch list so an
+		// operator with an internal mem9 host exempts it the same way.
+		PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,
 	}
 	allTools = append(allTools, memoryTool)
 

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/tools"
@@ -242,57 +241,13 @@ func (h *HTTP) do(ctx context.Context, method, rawURL string, headers map[string
 // The Control hook is a belt-and-braces re-check at the syscall layer
 // in case the kernel ends up dialing a different address than the IP
 // we passed (rare but possible if the address gets transformed).
+// dialContext is the HTTP/WebFetch tool's SSRF-blocking dialer. It delegates to
+// the shared guardedDialContext (see ssrf.go) so the identical dial-time
+// private-IP guard backs the mem9 backend client too — one implementation, no
+// weak-copy drift. AllowPrivateIPs is the tests-only global lift;
+// PrivateHostAllowlist is the operator's per-host opt-in.
 func (h *HTTP) dialContext(ctx context.Context, network, addr string) (net.Conn, error) {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return nil, err
-	}
-	// PrivateHostAllowlist: hostname-side opt-in to the private-IP
-	// block. If host is on the list, dial-layer private-IP rejection
-	// is skipped for THIS dial. Distinct from AllowPrivateIPs (which
-	// is the global tests-only flag); this one is operator-opt-in
-	// scoped to specific hostnames so e.g. localhost can be reached
-	// without disabling the SSRF block for the rest of the universe.
-	hostExempt := hostAllowed(host, h.PrivateHostAllowlist)
-
-	ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, err
-	}
-	candidates := ips
-	if !h.AllowPrivateIPs && !hostExempt {
-		candidates = candidates[:0]
-		for _, ip := range ips {
-			if !isPrivateIP(ip.IP) {
-				candidates = append(candidates, ip)
-			}
-		}
-		if len(candidates) == 0 {
-			return nil, fmt.Errorf("blocked: %s has no public addresses (got %d private)", host, len(ips))
-		}
-	}
-	d := net.Dialer{
-		Timeout: 10 * time.Second,
-		Control: func(network, address string, c syscall.RawConn) error {
-			if h.AllowPrivateIPs || hostExempt {
-				return nil
-			}
-			ip, _, _ := net.SplitHostPort(address)
-			if parsed := net.ParseIP(ip); parsed != nil && isPrivateIP(parsed) {
-				return fmt.Errorf("blocked: socket-level address %s is private", ip)
-			}
-			return nil
-		},
-	}
-	var lastErr error
-	for _, ip := range candidates {
-		conn, err := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-		if err == nil {
-			return conn, nil
-		}
-		lastErr = err
-	}
-	return nil, lastErr
+	return guardedDialContext(h.AllowPrivateIPs, h.PrivateHostAllowlist)(ctx, network, addr)
 }
 
 // hostAllowed reports whether host is permitted by the allowlist.

--- a/internal/tools/builtin/memory.go
+++ b/internal/tools/builtin/memory.go
@@ -108,6 +108,14 @@ type Memory struct {
 	// unauthenticated call).
 	EnvAllowlist map[string]bool
 
+	// PrivateHostAllowlist exempts specific hosts from the mem9 client's
+	// dial-time private-IP SSRF block (set in main.go from
+	// cfg.Env.HTTPPrivateHostAllowlist — the same operator vouch list the HTTP
+	// tool uses). Empty = every private/loopback/metadata IP is refused for
+	// mem9 dials, so a model-authored base_url can't reach an internal host.
+	// An operator running an internal mem9 backend adds its host here.
+	PrivateHostAllowlist []string
+
 	// SqlMem is the RFC AA SQL Memory manager backing sql_query / sql_exec.
 	// Nil = the SQL ops refuse with "SQL Memory is not enabled on this
 	// server" (the subsystem is off by default; main.go sets it only when
@@ -209,6 +217,11 @@ func (m *Memory) memoryLayer(ctx context.Context) (memrank.MemoryLayer, bool) {
 //
 // Credentials are resolved PER OP by the injected CredentialResolver, not
 // here; this only validates that the Def is structurally constructible.
+// mem9RequestTimeout is the per-op HTTP timeout for the guarded mem9 client.
+// Matches mem9.New's own default (used when Config.HTTPClient is nil), so
+// swapping in the SSRF-guarded client keeps the timeout behaviour unchanged.
+const mem9RequestTimeout = 10 * time.Second
+
 func (m *Memory) buildMem9(ctx context.Context, name string, def config.MemoryBackend) memrank.Backend {
 	tenancy, prefix, err := resolveTenancy(ctx, def.TenancyStrategy)
 	if err != nil {
@@ -218,12 +231,18 @@ func (m *Memory) buildMem9(ctx context.Context, name string, def config.MemoryBa
 
 	resolver := m.mem9CredentialResolver(def, def.TenancyStrategy, prefix)
 
+	// SSRF guard: dial through the shared private-IP-blocking client so a
+	// model-authored base_url cannot reach an internal/loopback/metadata host
+	// and exfiltrate the operator-allowlisted X-API-Key. Blocks at DIAL time
+	// (rebinding/redirect-safe); the operator's HTTP private-host allowlist
+	// (m.PrivateHostAllowlist) exempts a legitimately-private mem9 host.
 	b := mem9.New(mem9.Config{
 		BaseURL:            def.Config.BaseURL,
 		APIVersion:         def.Config.APIVersion,
 		Tenancy:            tenancy,
 		CredentialResolver: resolver,
 		BackendName:        name,
+		HTTPClient:         newSSRFGuardedClient(mem9RequestTimeout, m.PrivateHostAllowlist),
 	})
 
 	// fallback_on_error=inprocess wraps the remote backend so a Mem9

--- a/internal/tools/builtin/ssrf.go
+++ b/internal/tools/builtin/ssrf.go
@@ -1,0 +1,94 @@
+package builtin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// guardedDialContext is the shared SSRF-blocking dialer used by the HTTP/WebFetch
+// tools AND the mem9 MemoryBackend client. It resolves the host and refuses to
+// connect to any private / loopback / link-local address (incl. the cloud
+// metadata endpoint 169.254.169.254) — filtering at DIAL time, so DNS-rebinding
+// and redirect targets are re-checked on every new connection, not just at a
+// one-shot validate. A socket-level Control hook re-asserts the block after the
+// OS resolves the address.
+//
+// allowPrivate lifts the block entirely (tests / an operator opt-in). Otherwise
+// privateHostAllowlist (suffix-matched via hostAllowed) exempts specific hosts
+// the operator has vouched are safe to reach on a private network. Extracted
+// from HTTP.dialContext so a new caller (mem9) can't copy the weak first-layer
+// URL check without this load-bearing dial-time guard — the exact class of gap
+// the v1.9.x security review found in the mem9 backend.
+func guardedDialContext(allowPrivate bool, privateHostAllowlist []string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		hostExempt := hostAllowed(host, privateHostAllowlist)
+
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		candidates := ips
+		if !allowPrivate && !hostExempt {
+			candidates = candidates[:0]
+			for _, ip := range ips {
+				if !isPrivateIP(ip.IP) {
+					candidates = append(candidates, ip)
+				}
+			}
+			if len(candidates) == 0 {
+				return nil, fmt.Errorf("blocked: %s has no public addresses (got %d private)", host, len(ips))
+			}
+		}
+		d := net.Dialer{
+			Timeout: 10 * time.Second,
+			Control: func(_, address string, _ syscall.RawConn) error {
+				if allowPrivate || hostExempt {
+					return nil
+				}
+				ip, _, _ := net.SplitHostPort(address)
+				if parsed := net.ParseIP(ip); parsed != nil && isPrivateIP(parsed) {
+					return fmt.Errorf("blocked: socket-level address %s is private", ip)
+				}
+				return nil
+			},
+		}
+		var lastErr error
+		for _, ip := range candidates {
+			conn, derr := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if derr == nil {
+				return conn, nil
+			}
+			lastErr = derr
+		}
+		return nil, lastErr
+	}
+}
+
+// newSSRFGuardedClient returns an *http.Client whose transport dials through
+// guardedDialContext (private IPs blocked, subject to privateHostAllowlist) and
+// whose redirects are bounded — each redirect hop is a fresh connection that
+// re-runs the dial guard, so a 302 to an internal/metadata IP is refused too.
+// Used for the mem9 backend client, which was previously a plain http.Client
+// with no SSRF guard (a model-authored base_url could reach 169.254.169.254 and
+// exfiltrate the allowlisted X-API-Key).
+func newSSRFGuardedClient(timeout time.Duration, privateHostAllowlist []string) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{DialContext: guardedDialContext(false, privateHostAllowlist)},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/tools/builtin/ssrf_test.go
+++ b/internal/tools/builtin/ssrf_test.go
@@ -1,0 +1,39 @@
+package builtin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestNewSSRFGuardedClient_BlocksLoopback is the regression for the mem9 SSRF
+// hole: the mem9 backend used a plain http.Client with no dial-time guard, so a
+// model-authored base_url could reach a private/loopback/metadata address (and
+// exfiltrate the allowlisted X-API-Key). The guarded client must refuse a
+// private (loopback) target unless the operator allowlists the host.
+func TestNewSSRFGuardedClient_BlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// No allowlist → the loopback (private) address is refused at dial time.
+	blocked := newSSRFGuardedClient(5*time.Second, nil)
+	if resp, err := blocked.Get(srv.URL); err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("guarded client reached a loopback address %s — SSRF guard not applied", srv.URL)
+	}
+
+	// The operator's private-host allowlist exempts the host → the dial proceeds.
+	host := mustHost(t, srv.URL)
+	allowed := newSSRFGuardedClient(5*time.Second, []string{host})
+	resp, err := allowed.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("allowlisted host should dial through: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Why (security — HIGH)

Found in the full-repo security review. A `kind=mem9` `MemoryBackendDef` `base_url` was validated only by `requireHTTPURL` (scheme + host — **no** private-IP block), and the mem9 client (`internal/memory/backends/mem9`) dialed with a plain `http.Client` (no SSRF `DialContext`, follows redirects). An agent with the `MemoryBackendDef` tool (`self` scope suffices; MCP grants `any`) could fork its backend with `base_url=http://169.254.169.254/…` — the next `Memory` op then POSTed to the internal/metadata host **with the operator-allowlisted `X-API-Key` attached**, returning the response into memory: **SSRF + credential exfiltration**, coupled.

The A2A/`httptool` paths already block private IPs at dial time; the mem9 path had copied the weak first-layer URL check **without** that load-bearing guard — the exact drift class the review flagged.

## What

- Extracted `HTTP.dialContext` into a shared **`guardedDialContext`** (`internal/tools/builtin/ssrf.go`) so one implementation backs both the HTTP tool and mem9 — a new caller can't copy the weak check again. `HTTP.dialContext` now delegates to it (behaviour-preserving; its 23 tests still pass).
- **`newSSRFGuardedClient`** — bounded redirects; each hop re-dials through the guard, so a 302 to an internal IP is refused too.
- `buildMem9` builds the mem9 client with it. Blocks at **dial time** → DNS-rebinding / redirect-safe, unlike a one-shot validate.
- Operator escape hatch: a legitimately-private mem9 host is exempted via the existing `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST` (reused as the private-host vouch list; wired to a new `Memory.PrivateHostAllowlist`).

**Behaviour change:** an operator currently running mem9 on a private IP must add its host to `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST` after upgrade.

## What was tested

`TestNewSSRFGuardedClient_BlocksLoopback` — the guarded client refuses a loopback (private) target and the allowlist exempts it; a plain client (the pre-fix mem9 path) would reach it. The `httptool` suite (23 tests, incl. `dialContext` / `AllowPrivateIPs` / `PrivateHostAllowlist`) still passes, confirming the extraction is behaviour-preserving. Full `internal/tools/builtin` package + `go build` clean.

## Follow-up (separate MEDIUM finding)
The MCP-HTTP client and A2A-gRPC endpoint have the same missing dial-time guard (DNS-rebinding). They live in other packages; a follow-up can point them at `guardedDialContext` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)