### PR TITLE
fix(api): tenant-gate run cancel + interrupt-resolve on every transport

### DIFF
--- a/internal/api/http/cancel_resolve_tenant_test.go
+++ b/internal/api/http/cancel_resolve_tenant_test.go
@@ -1,0 +1,161 @@
+package http
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/cancel"
+	"github.com/denn-gubsky/loomcycle/internal/connector"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// These regression tests close the cross-tenant cancel + interrupt-resolve gap:
+// both mutations were keyed only by id with no tenant-ownership check (unlike
+// the steer + compact siblings), so a tenant-B token could cancel a tenant-A
+// run (cross-tenant DoS, cluster-broadcast) or resolve a tenant-A pending
+// interrupt (steering another tenant's paused run). Covered on all three
+// transports: the HTTP handlers directly, and connector.{CancelRun,
+// InterruptionResolve} which back gRPC + MCP.
+
+func tenantPrincipalCtx(tenant, subject string, scopes ...string) context.Context {
+	return auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: tenant, Subject: subject, Scopes: scopes})
+}
+
+// registerLiveCancel registers a live cancel handle for agentID; the returned
+// func reports whether it was ever cancelled.
+func registerLiveCancel(t *testing.T, s *Server, runID, agentID, user string) func() bool {
+	t.Helper()
+	var cancelled atomic.Bool
+	if err := s.cancelReg.Register(cancel.Entry{
+		AgentID: agentID, RunID: runID, UserID: user, StartedAt: time.Now(),
+	}, func(error) { cancelled.Store(true) }); err != nil {
+		t.Fatalf("cancelReg.Register: %v", err)
+	}
+	t.Cleanup(func() { s.cancelReg.Deregister(agentID) })
+	return cancelled.Load
+}
+
+func TestHandleCancelAgent_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_cx")
+	wasCancelled := registerLiveCancel(t, s, runID, "a_acme_cx", "alice")
+
+	cancelFor := func(tenant, subject string) int {
+		r := httptest.NewRequest(http.MethodPost, "/v1/agents/a_acme_cx/cancel", nil)
+		r.SetPathValue("agent_id", "a_acme_cx")
+		r = r.WithContext(tenantPrincipalCtx(tenant, subject, auth.ScopeRunsCreate))
+		rr := httptest.NewRecorder()
+		s.handleCancelAgent(rr, r)
+		return rr.Code
+	}
+
+	// Cross-tenant → opaque 404 and the run is NOT cancelled.
+	if code := cancelFor("evil", "mallory"); code != http.StatusNotFound {
+		t.Errorf("cross-tenant cancel status=%d, want 404", code)
+	}
+	if wasCancelled() {
+		t.Fatal("cross-tenant cancel actually cancelled another tenant's run")
+	}
+	// Own tenant → cancels.
+	if code := cancelFor("acme", "alice"); code != http.StatusOK {
+		t.Errorf("own-tenant cancel status=%d, want 200", code)
+	}
+	if !wasCancelled() {
+		t.Error("own-tenant cancel did not cancel the run")
+	}
+}
+
+func TestCancelRun_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_conn")
+	wasCancelled := registerLiveCancel(t, s, runID, "a_acme_conn", "alice")
+
+	// Cross-tenant (gRPC/MCP path) → ErrNotFound, run untouched.
+	_, err := s.CancelRun(tenantPrincipalCtx("evil", "mallory", auth.ScopeRunsCreate), "a_acme_conn", "")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("cross-tenant CancelRun err=%v, want *store.ErrNotFound", err)
+	}
+	if wasCancelled() {
+		t.Fatal("cross-tenant CancelRun cancelled another tenant's run")
+	}
+	// Own tenant → cancels.
+	if _, err := s.CancelRun(tenantPrincipalCtx("acme", "alice", auth.ScopeRunsCreate), "a_acme_conn", ""); err != nil {
+		t.Errorf("own-tenant CancelRun: %v", err)
+	}
+	if !wasCancelled() {
+		t.Error("own-tenant CancelRun did not cancel the run")
+	}
+}
+
+func TestHandleResolveInterrupt_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	ctx := context.Background()
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_intr")
+	if _, err := st.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: "intr_http", RunID: runID, UserID: "alice", Question: "approve?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+
+	resolveFor := func(tenant, subject string) int {
+		r := httptest.NewRequest(http.MethodPost,
+			"/v1/runs/"+runID+"/interrupts/intr_http/resolve",
+			strings.NewReader(`{"kind":"question","answer":"yes"}`))
+		r.SetPathValue("run_id", runID)
+		r.SetPathValue("interrupt_id", "intr_http")
+		r.Header.Set("Content-Type", "application/json")
+		r = r.WithContext(tenantPrincipalCtx(tenant, subject, auth.ScopeRunsCreate))
+		rr := httptest.NewRecorder()
+		s.handleResolveInterrupt(rr, r)
+		return rr.Code
+	}
+
+	// Cross-tenant → opaque 404 and the interrupt stays PENDING (not steered).
+	if code := resolveFor("evil", "mallory"); code != http.StatusNotFound {
+		t.Errorf("cross-tenant resolve status=%d, want 404", code)
+	}
+	if row, _ := st.InterruptGet(ctx, "intr_http"); row.Status != store.InterruptStatusPending {
+		t.Fatalf("cross-tenant resolve changed interrupt status to %q — another tenant's run was steered", row.Status)
+	}
+	// Own tenant → the gate passes (not a 404).
+	if code := resolveFor("acme", "alice"); code == http.StatusNotFound {
+		t.Errorf("own-tenant resolve got 404 — the tenant gate rejected a legitimate caller")
+	}
+}
+
+func TestInterruptionResolve_RejectsCrossTenant(t *testing.T) {
+	s, st := tokenAuthServer(t, "")
+	ctx := context.Background()
+	runID := seedRunInTenant(t, st, "acme", "alice", "a_acme_intr2")
+	if _, err := st.InterruptCreate(ctx, store.InterruptRow{
+		InterruptID: "intr_conn", RunID: runID, UserID: "alice", Question: "approve?", CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("InterruptCreate: %v", err)
+	}
+
+	// Cross-tenant (MCP path) → ErrNotFound, interrupt stays pending.
+	_, err := s.InterruptionResolve(tenantPrincipalCtx("evil", "mallory", auth.ScopeRunsCreate),
+		connector.InterruptionResolveRequest{InterruptID: "intr_conn", RunID: runID, Answer: "yes"})
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("cross-tenant InterruptionResolve err=%v, want *store.ErrNotFound", err)
+	}
+	if row, _ := st.InterruptGet(ctx, "intr_conn"); row.Status != store.InterruptStatusPending {
+		t.Fatalf("cross-tenant InterruptionResolve changed status to %q", row.Status)
+	}
+	// Own tenant → the gate passes (no ErrNotFound; may proceed to resolve).
+	_, err = s.InterruptionResolve(tenantPrincipalCtx("acme", "alice", auth.ScopeRunsCreate),
+		connector.InterruptionResolveRequest{InterruptID: "intr_conn", RunID: runID, Answer: "yes"})
+	if errors.As(err, &nf) {
+		t.Errorf("own-tenant InterruptionResolve got ErrNotFound — the tenant gate rejected a legitimate caller")
+	}
+}

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -207,6 +207,17 @@ func (s *Server) CancelRun(ctx context.Context, agentID, reason string) (connect
 	if agentID == "" {
 		return connector.CancelRunResult{}, fmt.Errorf("agent_id required")
 	}
+	// Tenant ownership gate (RFC L/N): this method backs gRPC CancelAgent + the
+	// MCP cancel_run tool, both of which dispatch with a principal-bearing ctx.
+	// A cancel keyed only by agent_id must not reach another tenant's run (ids
+	// are not secret; cluster cancel broadcasts). tenantStore folds a
+	// cross-tenant/missing run into an opaque ErrNotFound; open/legacy/admin see
+	// all tenants so behaviour is unchanged for them.
+	if s.store != nil {
+		if _, err := s.tenantStore(ctx).GetRunByAgentID(ctx, agentID); err != nil {
+			return connector.CancelRunResult{}, err
+		}
+	}
 	res, ok := s.cancelReg.Cancel(agentID, reason)
 	if !ok {
 		// Run may already have completed. Check the store to
@@ -984,6 +995,14 @@ func (s *Server) InterruptionResolve(ctx context.Context, req connector.Interrup
 	}
 	if row.RunID != req.RunID {
 		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: interrupt %q does not belong to run %q", req.InterruptID, req.RunID)
+	}
+	// Tenant ownership gate (RFC L/N): the run this interrupt belongs to must be
+	// in the caller's tenant, else resolving it steers ANOTHER tenant's paused
+	// run. Backs the MCP interruption_resolve tool (principal-bearing ctx). The
+	// row.RunID==req.RunID check above only blocks retargeting within a tenant.
+	// tenantStore folds a cross-tenant/missing run into an opaque ErrNotFound.
+	if _, err := s.tenantStore(ctx).GetRun(ctx, row.RunID); err != nil {
+		return connector.InterruptionResolveResult{}, err
 	}
 	if row.Status != store.InterruptStatusPending {
 		return connector.InterruptionResolveResult{}, fmt.Errorf("interruption_resolve: already %s", row.Status)

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -5073,6 +5073,26 @@ func (s *Server) handleCancelAgent(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<10)).Decode(&body)
 	}
 
+	// Tenant ownership gate (RFC L/N): a cancel keyed only by agent_id must not
+	// reach another tenant's run — ids are not secret and in cluster mode the
+	// cancel BROADCASTS to every replica. tenantStore folds a cross-tenant or
+	// missing run into an opaque 404 (mirrors the steer + compact
+	// run-mutations, which were migrated onto the accessor; cancel was the gap).
+	// admin / legacy / open see all tenants → unchanged.
+	if s.store != nil {
+		if _, err := s.tenantStore(r.Context()).GetRunByAgentID(r.Context(), agentID); err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprintf(w, `{"code":"unknown_agent_id","error":"no run found for agent_id %q"}`, agentID)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	res, ok := s.cancelReg.Cancel(agentID, body.Reason)
 	if ok {
 		// v0.12.2: Cancel may now return ok=true with res.Cancelled=false
@@ -5234,6 +5254,20 @@ func (s *Server) handleResolveInterrupt(w http.ResponseWriter, r *http.Request) 
 		// row's run_id. Prevents one user's resolve from being
 		// retargeted at another run's interrupt by URL manipulation.
 		http.Error(w, "interrupt does not belong to that run", http.StatusNotFound)
+		return
+	}
+	// Tenant ownership gate (RFC L/N): the run this interrupt belongs to must be
+	// in the caller's tenant — otherwise a resolve injects the caller's answer
+	// into ANOTHER tenant's paused run, steering it (e.g. approving a gated
+	// action). run/interrupt ids are not secret; the row.RunID==runID check
+	// above only blocks URL retargeting WITHIN a tenant, it is NOT a tenant
+	// check. tenantStore folds a cross-tenant/missing run into an opaque 404.
+	if _, err := s.tenantStore(r.Context()).GetRun(r.Context(), row.RunID); err != nil {
+		if errors.As(err, &nf) {
+			http.Error(w, "interrupt not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if row.Status != store.InterruptStatusPending {


### PR DESCRIPTION
## Why (security — HIGH)

Found in the full-repo security review. **cancel** and **interrupt-resolve** were the two run-state mutations still keyed only by id with **no tenant-ownership check** (steer + compact were already migrated onto `tenantStore`). A tenant-B token (holding `runs:create`) could:

- **cancel a tenant-A run** — cross-tenant DoS, and in cluster mode the cancel *broadcasts* to every replica;
- **resolve a tenant-A pending interrupt** — inject its answer into another tenant's paused run, steering it (e.g. approving a gated/destructive action).

run/agent/interrupt ids are non-secret by the project's model. Present on **all three transports**: the HTTP handlers directly (`handleCancelAgent`, `handleResolveInterrupt`) and `connector.{CancelRun, InterruptionResolve}` which back gRPC `CancelAgent` + the MCP `cancel_run` / `interruption_resolve` tools.

## What

Gate all four sites on the caller's tenant via `s.tenantStore(ctx)` — `GetRunByAgentID` / `GetRun` fold a cross-tenant or missing run into an opaque `404` / `ErrNotFound` (no existence oracle), mirroring the steer + compact mutations. The pre-existing `row.RunID == runID` check only blocked URL retargeting *within* a tenant; it was never a tenant check. admin / legacy / open see all tenants → unchanged.

## What was tested

`TestHandleCancelAgent_RejectsCrossTenant`, `TestCancelRun_RejectsCrossTenant`, `TestHandleResolveInterrupt_RejectsCrossTenant`, `TestInterruptionResolve_RejectsCrossTenant` — each asserts a cross-tenant call is refused **and** the run stays un-cancelled / the interrupt stays pending, while the own-tenant call still succeeds. Verified they fail on the pre-fix code (neutered the connector gate → "cross-tenant CancelRun cancelled another tenant's run"). Full `internal/api/http` package + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)