### PR TITLE
fix(runstate): deliver events under the lock to end a send-on-closed panic

### DIFF
--- a/internal/runstate/bus.go
+++ b/internal/runstate/bus.go
@@ -188,19 +188,32 @@ func (b *Bus) publishLocal(evt RunStateEvent) {
 	if evt.TS.IsZero() {
 		evt.TS = time.Now().UTC()
 	}
+	// Deliver UNDER b.mu — the SAME lock unsubscribe() closes sub.ch under.
+	// Previously publishLocal snapshotted the subscribers, released the lock,
+	// then sent — so unsubscribe()'s close() could interleave between the
+	// snapshot and the send and panic with "send on closed channel". The
+	// non-blocking select does NOT save it: a send on a closed channel is a
+	// "ready" case, so the runtime chooses it (and panics) rather than taking
+	// default. That panic fires on the backplane fan-out goroutine (no recover)
+	// → process crash. A non-blocking select can't stall the critical section
+	// (a full buffer takes default instantly), so holding the lock through
+	// delivery is cheap and makes send-vs-close mutually exclusive.
 	b.mu.Lock()
-	matches := make([]*subscription, 0, len(b.byUser[evt.UserID])+len(b.byUser[""]))
-	matches = append(matches, b.byUser[evt.UserID]...)
-	if evt.UserID != "" {
-		matches = append(matches, b.byUser[""]...)
-	}
-	b.mu.Unlock()
-
-	for _, sub := range matches {
+	defer b.mu.Unlock()
+	deliver := func(sub *subscription) {
 		select {
 		case sub.ch <- evt:
 		default:
 			atomic.AddInt64(&sub.dropped, 1)
+		}
+	}
+	for _, sub := range b.byUser[evt.UserID] {
+		deliver(sub)
+	}
+	if evt.UserID != "" {
+		// Global (user="") subscribers also see every user-scoped event.
+		for _, sub := range b.byUser[""] {
+			deliver(sub)
 		}
 	}
 }
@@ -258,11 +271,12 @@ func (b *Bus) unsubscribe(sub *subscription) {
 	} else {
 		b.byUser[sub.userID] = subs
 	}
-	// Close exactly once. Buffered sends from a concurrent Publish
-	// can race with this close; we accept losing the very last in-
-	// flight event on a closing subscription as the cost of a clean
-	// close. The drain is fine — the SSE handler is the only reader
-	// and it cancels its ctx before calling Close.
+	// Close under b.mu — publishLocal now delivers under the same lock, so a
+	// concurrent Publish can no longer interleave a send between the
+	// subscriber snapshot and the close (which panicked "send on closed
+	// channel"). The removal above + this close are one atomic critical
+	// section: once removed from b.byUser, no publishLocal can observe this
+	// sub, so the close is safe.
 	close(sub.ch)
 }
 

--- a/internal/runstate/bus_panic_test.go
+++ b/internal/runstate/bus_panic_test.go
@@ -1,0 +1,48 @@
+package runstate
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestBus_PublishConcurrentCloseNoPanic is the regression for the
+// send-on-closed-channel panic: publishLocal snapshotted the subscribers,
+// released the lock, then sent — so unsubscribe()'s close() could interleave
+// and the send would panic (the select default does NOT save a send on a closed
+// channel). On the backplane goroutine (no recover) that crashed the process.
+//
+// This hammers Publish from several goroutines while a subscriber rapidly
+// Subscribe/Close-cycles the SAME user key, forcing the send-vs-close race. On
+// the pre-fix code it panics "send on closed channel" (crashing the test); with
+// delivery under the lock it completes cleanly. Run under -race in CI.
+func TestBus_PublishConcurrentCloseNoPanic(t *testing.T) {
+	b := NewBus()
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					b.Publish(RunStateEvent{UserID: "u"})
+				}
+			}
+		}()
+	}
+
+	// Churn subscriptions on the same key the publishers target: each Subscribe
+	// makes the sub visible to publishLocal; each Close removes + closes its
+	// channel — the exact interleaving that panicked.
+	for i := 0; i < 5000; i++ {
+		sub := b.Subscribe("u")
+		sub.Close()
+	}
+
+	close(stop)
+	wg.Wait()
+}


### PR DESCRIPTION
## Why (crash — HIGH)

Found in the full-repo security review. `runstate.Bus.publishLocal` snapshotted the matching subscribers under `b.mu`, **released the lock**, then sent on each `sub.ch` — while `unsubscribe()` closes `sub.ch` under `b.mu`. A `close()` could interleave between the snapshot and the send, and the send then **panicked "send on closed channel"**. The non-blocking `select { case ch<-evt: default: }` does *not* save it — a send on a closed channel is a "ready" case, so the runtime selects it (and panics) rather than taking `default`.

On the `SubscribeBackplane` fan-out goroutine (no `recover`) this **crashes the whole process** whenever an SSE/gRPC run-state subscriber disconnects while a run finishes; on the HTTP/interactive paths `recoveryMiddleware` / the run's `recover` contained it to a 500 / failed-run. The in-code comment claiming the race merely "loses the last in-flight event" was wrong.

## What

Deliver **under `b.mu`** (the same lock the close takes). A non-blocking select can't stall the critical section (a full buffer takes `default` instantly), so holding the lock through delivery is cheap and makes send-vs-close mutually exclusive: once a sub is removed from `b.byUser` under the lock, no `publishLocal` can observe it, so the close is safe. Also simplified the delivery to iterate the maps directly (no snapshot alloc) and corrected the stale comment.

## What was tested

`TestBus_PublishConcurrentCloseNoPanic` — 4 goroutines hammering `Publish` while a subscriber `Subscribe`/`Close`-cycles the same key 5000×. **Panics "send on closed channel" on the pre-fix code** (verified by reverting `publishLocal` to the snapshot-then-send shape); passes clean **under `-race`** with the fix. Full `internal/runstate` package clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)