### PR TITLE
fix(grep): re-check symlink containment before opening walked files

### DIFF
--- a/internal/tools/builtin/grep.go
+++ b/internal/tools/builtin/grep.go
@@ -160,7 +160,7 @@ func (g *Grep) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 		before, after = args.Context, args.Context
 	}
 
-	res, err := grepWalk(searchRoot, re, args.Glob, mode, headLimit, maxBytes, before, after)
+	res, err := grepWalk(root, searchRoot, re, args.Glob, mode, headLimit, maxBytes, before, after)
 	if err != nil {
 		return errResult(err.Error()), nil
 	}
@@ -168,8 +168,19 @@ func (g *Grep) Execute(ctx context.Context, input json.RawMessage) (tools.Result
 }
 
 // grepWalk does the file iteration. Pulled out so tests can drive
-// it with a synthetic root.
-func grepWalk(searchRoot string, re *regexp.Regexp, glob, mode string, headLimit, maxBytes, before, after int) (string, error) {
+// it with a synthetic root. `root` is the sandbox volume root; every
+// walked entry is re-checked against it (symlink-resolved) before being
+// opened, so an in-volume symlink pointing outside the volume can't leak
+// out-of-volume file contents.
+func grepWalk(root, searchRoot string, re *regexp.Regexp, glob, mode string, headLimit, maxBytes, before, after int) (string, error) {
+	// Resolve the sandbox root ONCE; each walked file is checked against it
+	// below. A root that can't be resolved is a misconfiguration, not a
+	// per-file skip, so fail the walk.
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("sandbox root: %w", err)
+	}
+
 	var (
 		out      bytes.Buffer
 		results  int
@@ -185,7 +196,7 @@ func grepWalk(searchRoot string, re *regexp.Regexp, glob, mode string, headLimit
 	}
 	var perFile []fileMatch
 
-	err := filepath.WalkDir(searchRoot, func(path string, d os.DirEntry, walkErr error) error {
+	err = filepath.WalkDir(searchRoot, func(path string, d os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			// Skip dirs we can't enter; don't fail the whole walk.
 			return nil
@@ -199,7 +210,23 @@ func grepWalk(searchRoot string, re *regexp.Regexp, glob, mode string, headLimit
 				return nil
 			}
 		}
-		matches, perr := grepFile(path, re, mode == "content", before, after)
+		// Symlink containment: WalkDir does NOT descend symlinked DIRS, but it
+		// still yields a symlinked FILE entry (IsDir()==false) whose target
+		// grepFile's os.Open would FOLLOW — so an in-volume symlink to
+		// /etc/passwd (plantable via a rw Bash/Bashbox, or pre-existing in a
+		// mounted dir) leaks out-of-volume file CONTENTS. Read/Edit gate every
+		// open on resolveInsideRoot; Grep did not. Resolve the entry and
+		// re-assert it is inside the volume: an in-volume symlink resolves to
+		// its real in-volume path (still grepped); one that escapes is skipped,
+		// never opened.
+		resolved, rerr := filepath.EvalSymlinks(path)
+		if rerr != nil {
+			return nil // dangling / unreadable symlink → skip
+		}
+		if relInsideRoot(rootResolved, path, resolved) != nil {
+			return nil // escapes the volume → skip, never open
+		}
+		matches, perr := grepFile(resolved, re, mode == "content", before, after)
 		if perr != nil || len(matches) == 0 {
 			return nil
 		}

--- a/internal/tools/builtin/grep_symlink_test.go
+++ b/internal/tools/builtin/grep_symlink_test.go
@@ -1,0 +1,49 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestGrepWalk_DoesNotFollowSymlinkOutsideRoot is the regression for the Grep
+// sandbox escape: grepWalk opened each walked entry with os.Open WITHOUT
+// re-resolving symlinks/containment, so an in-volume symlink pointing outside
+// the volume (planted via a rw Bash/Bashbox, or pre-existing in a mounted dir)
+// was followed and its CONTENTS returned — unlike Read/Edit, which gate every
+// open on resolveInsideRoot. A "content" grep over such a volume leaked
+// out-of-volume file contents under the innocuous in-tree symlink name.
+func TestGrepWalk_DoesNotFollowSymlinkOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	const secret = "SECRET_TOKEN_a1b2c3"
+	// A secret file OUTSIDE the volume, also containing the search pattern.
+	if err := os.WriteFile(filepath.Join(outside, "creds"), []byte("FINDME "+secret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A benign in-volume file that also matches — proves grep still works.
+	if err := os.WriteFile(filepath.Join(root, "notes.txt"), []byte("FINDME inside\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// An in-volume symlink pointing OUT of the volume at the secret file.
+	if err := os.Symlink(filepath.Join(outside, "creds"), filepath.Join(root, "escape")); err != nil {
+		t.Skipf("symlinks unsupported on this platform: %v", err)
+	}
+
+	re := regexp.MustCompile("FINDME")
+	out, err := grepWalk(root, root, re, "", "content", 100, grepDefaultMaxOutputBytes, 0, 0)
+	if err != nil {
+		t.Fatalf("grepWalk: %v", err)
+	}
+	// The escape must NOT leak the out-of-volume file's contents.
+	if strings.Contains(out, secret) {
+		t.Fatalf("Grep leaked out-of-volume contents via an in-volume symlink:\n%s", out)
+	}
+	// ...but the legitimate in-volume match is still returned (grep works).
+	if !strings.Contains(out, "inside") {
+		t.Fatalf("Grep dropped a legitimate in-volume match:\n%s", out)
+	}
+}


### PR DESCRIPTION
## Why (security — HIGH, sandbox escape)

Found in the full-repo security review. `grepWalk` walked the volume with `filepath.WalkDir` and opened each matched entry via `os.Open` **without** re-resolving symlinks or re-checking containment. `WalkDir` does not descend symlinked *dirs*, but it still yields a symlinked *file* entry (`IsDir()==false`) — and `grepFile`'s `os.Open` then **follows** it. So an in-volume symlink pointing outside the sandbox (e.g. `/vol/x -> /etc/passwd`, plantable via a rw Bash/Bashbox or pre-existing in a mounted dir) was followed and, in `content` mode, its lines were returned under the innocuous in-tree name — a **sandbox read-boundary escape leaking out-of-volume file contents**.

`Read`/`Edit`/`Write` are immune (every open goes through `resolveInsideRoot`: `EvalSymlinks` + containment). Grep was the one built-in tool that opened raw walked paths.

## What

`grepWalk` now takes the sandbox `root` and, for each walked file, `EvalSymlinks` the entry + `relInsideRoot`-asserts it against the root before grepping the **resolved** path. An in-volume symlink to another in-volume file still resolves + greps (behaviour preserved); one that escapes the volume is skipped, never opened. Root resolved once up front.

## What was tested

`TestGrepWalk_DoesNotFollowSymlinkOutsideRoot` plants an in-volume symlink to an out-of-volume secret plus a benign in-volume match, and asserts the escape's contents are **not** returned while the in-volume match still is. **Fails on the pre-fix code** (verified — leaks `escape:1:FINDME SECRET_TOKEN...`); passes with the fix. Existing Grep tests still pass; `go build` clean.

## Follow-up
`Glob` shares the missing re-check but only discloses entry **names** — a lower-severity follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)