### PR TITLE
fix(anthropic): replay the thinking block on tool-use continuations

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -4013,6 +4013,12 @@ func replayTranscript(events []store.Event) []providers.Message {
 	// with "reasoning_content in the thinking mode must be passed
 	// back". Empty for non-thinking models.
 	var asstReasoning string
+	// asstReasoningSignature is the Anthropic thinking-block seal paired with
+	// asstReasoning — restored so a RESUMED thinking+tool-use run replays the
+	// block with its signature and doesn't 400 on the continuation ("a final
+	// assistant message must start with a thinking block"). Empty for
+	// non-Anthropic / non-thinking runs.
+	var asstReasoningSignature string
 
 	flushAssistant := func() {
 		if asstText.Len() == 0 && len(asstTools) == 0 {
@@ -4024,13 +4030,15 @@ func replayTranscript(events []store.Event) []providers.Message {
 		}
 		content = append(content, asstTools...)
 		messages = append(messages, providers.Message{
-			Role:      "assistant",
-			Content:   content,
-			Reasoning: asstReasoning,
+			Role:               "assistant",
+			Content:            content,
+			Reasoning:          asstReasoning,
+			ReasoningSignature: asstReasoningSignature,
 		})
 		asstText.Reset()
 		asstTools = nil
 		asstReasoning = ""
+		asstReasoningSignature = ""
 	}
 	flushPendingTools := func() {
 		if len(pendingToolResults) == 0 {
@@ -4110,6 +4118,7 @@ func replayTranscript(events []store.Event) []providers.Message {
 			var pe providers.Event
 			if err := json.Unmarshal(ev.Payload, &pe); err == nil {
 				asstReasoning = pe.Reasoning
+				asstReasoningSignature = pe.ReasoningSignature
 			}
 			// End-of-run boundary — used both mid-conversation (the
 			// per-iteration assistant turn closes here) and at the
@@ -4155,6 +4164,7 @@ func replayTranscript(events []store.Event) []providers.Message {
 			asstTools = nil
 			pendingToolResults = nil
 			asstReasoning = ""
+			asstReasoningSignature = ""
 		}
 	}
 	flushAssistant()

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -637,6 +637,11 @@ func tryProviderFallback(
 	for i := range messages {
 		if messages[i].Role == "assistant" && messages[i].Reasoning != "" {
 			messages[i].Reasoning = ""
+			// Zero the Anthropic thinking-block signature too — it is only
+			// valid for the model that produced it, so it must never ride to a
+			// different provider (the new provider ignores the field, but the
+			// deepseek→other→anthropic bounce must not replay a stale seal).
+			messages[i].ReasoningSignature = ""
 			stripped++
 		}
 	}
@@ -1510,6 +1515,12 @@ outerLoop:
 		// per DeepSeek's roundtrip contract. Empty for non-thinking
 		// providers.
 		var iterReasoning string
+		// iterReasoningSignature holds the Anthropic extended-thinking block's
+		// signature (paired with iterReasoning); stamped onto the assistant
+		// Message so the Anthropic driver replays the thinking block, seal
+		// included, on the tool-use continuation (else Anthropic 400s). Empty
+		// for non-Anthropic / non-thinking turns.
+		var iterReasoningSignature string
 
 		for ev := range ch {
 			switch ev.Type {
@@ -1550,6 +1561,7 @@ outerLoop:
 				iterStop = ev.StopReason
 				iterUsage = ev.Usage
 				iterReasoning = ev.Reasoning
+				iterReasoningSignature = ev.ReasoningSignature
 			case providers.EventError:
 				// v0.8.2 classification: build the RAW error string so
 				// the status-prefix regex sees the bare "<name>
@@ -1630,9 +1642,10 @@ outerLoop:
 			)
 		}
 		messages = append(messages, providers.Message{
-			Role:      "assistant",
-			Content:   assistantBlocks,
-			Reasoning: iterReasoning,
+			Role:               "assistant",
+			Content:            assistantBlocks,
+			Reasoning:          iterReasoning,
+			ReasoningSignature: iterReasoningSignature,
 		})
 		// Mark the run "past turn one." Any subsequent retryable
 		// error that would have triggered cross-provider fallback

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -206,6 +206,12 @@ type wireContentBlock struct {
 	Content   string           `json:"content,omitempty"`
 	IsError   bool             `json:"is_error,omitempty"`
 	Source    *wireImageSource `json:"source,omitempty"` // type == "image" (RFC AT)
+	// Thinking + Signature carry an extended-thinking block replayed on a
+	// tool-use continuation (type == "thinking"). Anthropic verifies Signature
+	// against Thinking and 400s on a mismatch or a missing block, so both are
+	// sent together and only when both are present.
+	Thinking  string `json:"thinking,omitempty"`
+	Signature string `json:"signature,omitempty"`
 }
 
 // wireImageSource is Anthropic's inline base64 image source block:
@@ -308,6 +314,21 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 
 	for _, m := range req.Messages {
 		wm := wireMessage{Role: m.Role}
+		// Replay the assistant turn's extended-thinking block FIRST. When
+		// extended thinking is enabled and the turn used tools, Anthropic
+		// requires the prior assistant message to start with its thinking
+		// block, seal included — else the tool-use continuation 400s with "a
+		// final assistant message must start with a thinking block". The loop
+		// stamps Reasoning (thinking text) + ReasoningSignature onto the
+		// Message from EventDone; both must be present to reconstruct a block
+		// the API will accept (a bare/unsigned block 400s differently).
+		if m.Role == "assistant" && m.Reasoning != "" && m.ReasoningSignature != "" {
+			wm.Content = append(wm.Content, wireContentBlock{
+				Type:      "thinking",
+				Thinking:  m.Reasoning,
+				Signature: m.ReasoningSignature,
+			})
+		}
 		for _, c := range m.Content {
 			wm.Content = append(wm.Content, toWireBlock(c))
 		}
@@ -403,6 +424,12 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	var current pendingBlock
 	var stopReason string
 	var usage *providers.Usage
+	// Accumulate the extended-thinking block (text + its signature_delta seal)
+	// so EventDone can carry them for the next-turn replay Anthropic requires
+	// on tool-use continuations. Standard (non-interleaved) thinking emits one
+	// block per assistant turn, so a single text buffer + signature suffices.
+	var reasoning strings.Builder
+	var signature string
 	// Resolved model alias from message_start. Anthropic sometimes
 	// returns a date-suffixed alias (`claude-haiku-4-5-20251001`)
 	// distinct from the request alias (`claude-haiku-4-5`); capture
@@ -415,7 +442,7 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		if len(line) == 0 {
 			// dispatch frame
 			if frame.event != "" || len(frame.data) > 0 {
-				if !processFrame(frame, &current, &stopReason, &model, &usage, send) {
+				if !processFrame(frame, &current, &stopReason, &model, &usage, &reasoning, &signature, send) {
 					return
 				}
 			}
@@ -432,8 +459,16 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		send(providers.Event{Type: providers.EventError, Error: "stream read: " + err.Error()})
 		return
 	}
-	// Final done event with stop_reason + usage.
-	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
+	// Final done event with stop_reason + usage + the accumulated thinking
+	// block (Reasoning text + Signature) for the loop to stamp onto the
+	// assistant Message — Anthropic replays it on the tool-use continuation.
+	send(providers.Event{
+		Type:               providers.EventDone,
+		StopReason:         stopReason,
+		Usage:              usage,
+		Reasoning:          reasoning.String(),
+		ReasoningSignature: signature,
+	})
 }
 
 type pendingBlock struct {
@@ -451,6 +486,8 @@ func processFrame(
 	stopReason *string,
 	model *string,
 	usage **providers.Usage,
+	reasoning *strings.Builder,
+	signature *string,
 	send func(providers.Event) bool,
 ) bool {
 	switch f.event {
@@ -499,6 +536,7 @@ func processFrame(
 				Type        string `json:"type"`
 				Text        string `json:"text"`
 				Thinking    string `json:"thinking"`
+				Signature   string `json:"signature"`
 				PartialJSON string `json:"partial_json"`
 			} `json:"delta"`
 		}
@@ -512,14 +550,18 @@ func processFrame(
 			}
 		case "thinking_delta":
 			// Anthropic extended-thinking chunks. Surfaced live as
-			// EventThinking so consumers can render the trace
-			// independently of EventText. The signature_delta type
-			// (carrying the cryptographic seal of the thinking block)
-			// is intentionally not surfaced — it's metadata for the
-			// next-turn echo, not user-visible content.
+			// EventThinking so consumers can render the trace independently of
+			// EventText, AND accumulated so EventDone can carry the full
+			// thinking text for the next-turn replay (below).
+			reasoning.WriteString(ev.Delta.Thinking)
 			if !send(providers.Event{Type: providers.EventThinking, Text: ev.Delta.Thinking}) {
 				return false
 			}
+		case "signature_delta":
+			// The cryptographic seal of the thinking block. Not user-visible
+			// content, but REQUIRED to replay the block on a tool-use
+			// continuation — Anthropic 400s without it. Captured for EventDone.
+			*signature = ev.Delta.Signature
 		case "input_json_delta":
 			current.toolInput.WriteString(ev.Delta.PartialJSON)
 		}

--- a/internal/providers/anthropic/thinking_roundtrip_test.go
+++ b/internal/providers/anthropic/thinking_roundtrip_test.go
@@ -1,0 +1,116 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestRequestBody_ReplaysThinkingBlockOnToolContinuation is the regression for
+// the Anthropic thinking+tools 400: with extended thinking enabled (effort) and
+// a tool call, the prior assistant turn must be replayed STARTING with its
+// thinking block (text + signature) or the continuation 400s with "a final
+// assistant message must start with a thinking block". The loop now carries the
+// block on Message.Reasoning + ReasoningSignature; buildRequestBody must emit it
+// first in that assistant message's content.
+func TestRequestBody_ReplaysThinkingBlockOnToolContinuation(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model:  "claude-sonnet-4-6",
+		Effort: "high", // thinking stays enabled on the continuation request
+		Messages: []providers.Message{
+			{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "do a thing"}}},
+			{
+				Role:               "assistant",
+				Reasoning:          "let me reason about this",
+				ReasoningSignature: "SIG_abc123",
+				Content: []providers.ContentBlock{
+					{Type: "tool_use", ToolUseID: "tu_1", ToolName: "Read", ToolInput: json.RawMessage(`{"path":"x"}`)},
+				},
+			},
+			{Role: "user", Content: []providers.ContentBlock{{Type: "tool_result", ToolUseID: "tu_1", Text: "file contents"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	var parsed struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type      string `json:"type"`
+				Thinking  string `json:"thinking"`
+				Signature string `json:"signature"`
+			} `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Messages) != 3 {
+		t.Fatalf("messages = %d, want 3", len(parsed.Messages))
+	}
+	asst := parsed.Messages[1]
+	if asst.Role != "assistant" {
+		t.Fatalf("messages[1] role = %q, want assistant", asst.Role)
+	}
+	// MUST start with the thinking block, seal included.
+	if len(asst.Content) == 0 || asst.Content[0].Type != "thinking" {
+		t.Fatalf("assistant turn must START with a thinking block; got %+v", asst.Content)
+	}
+	if asst.Content[0].Thinking != "let me reason about this" || asst.Content[0].Signature != "SIG_abc123" {
+		t.Errorf("thinking block = %+v, want the text + signature echoed verbatim", asst.Content[0])
+	}
+	// The tool_use block still follows it.
+	if len(asst.Content) < 2 || asst.Content[1].Type != "tool_use" {
+		t.Errorf("tool_use must follow the thinking block; got %+v", asst.Content)
+	}
+}
+
+// TestRequestBody_NoThinkingBlockWithoutSignature: a bare/unsigned thinking
+// block 400s differently, so the driver only replays a block when BOTH the text
+// and the signature are present.
+func TestRequestBody_NoThinkingBlockWithoutSignature(t *testing.T) {
+	body, err := buildRequestBody(providers.Request{
+		Model:  "claude-sonnet-4-6",
+		Effort: "high",
+		Messages: []providers.Message{
+			{Role: "assistant", Reasoning: "reasoned but no seal",
+				Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildRequestBody: %v", err)
+	}
+	if strings.Contains(string(body), `"thinking":"reasoned but no seal"`) {
+		t.Errorf("must NOT replay a thinking block without its signature:\n%s", body)
+	}
+}
+
+// TestProcessFrame_CapturesThinkingAndSignature: the driver accumulates the
+// thinking text (thinking_delta) and captures the seal (signature_delta) so
+// EventDone can carry them for the next-turn replay.
+func TestProcessFrame_CapturesThinkingAndSignature(t *testing.T) {
+	var current pendingBlock
+	var stop, model string
+	var usage *providers.Usage
+	var reasoning strings.Builder
+	var sig string
+	sink := func(providers.Event) bool { return true }
+
+	feed := func(event, data string) {
+		processFrame(sseFrame{event: event, data: []byte(data)},
+			&current, &stop, &model, &usage, &reasoning, &sig, sink)
+	}
+	feed("content_block_delta", `{"delta":{"type":"thinking_delta","thinking":"step one "}}`)
+	feed("content_block_delta", `{"delta":{"type":"thinking_delta","thinking":"step two"}}`)
+	feed("content_block_delta", `{"delta":{"type":"signature_delta","signature":"SEAL_xyz"}}`)
+
+	if got := reasoning.String(); got != "step one step two" {
+		t.Errorf("accumulated thinking = %q, want %q", got, "step one step two")
+	}
+	if sig != "SEAL_xyz" {
+		t.Errorf("captured signature = %q, want SEAL_xyz", sig)
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -198,6 +198,18 @@ type Message struct {
 	// (vanilla OpenAI ignores unknown fields anyway, but no point
 	// sending bytes that mean nothing).
 	Reasoning string `json:"reasoning_content,omitempty"`
+
+	// ReasoningSignature is the cryptographic seal Anthropic returns for an
+	// extended-thinking block (the signature_delta). When extended thinking is
+	// enabled AND the turn uses tools, Anthropic requires the previous
+	// assistant turn to be replayed with its thinking block INCLUDING this
+	// signature, verbatim — otherwise the continuation 400s ("a final
+	// assistant message must start with a thinking block"). The Anthropic
+	// driver pairs it with Reasoning (the thinking text) to reconstruct that
+	// block in buildRequestBody. Empty for non-Anthropic / non-thinking turns;
+	// zeroed alongside Reasoning on a cross-provider fallback (a signature is
+	// only valid for the model that produced it).
+	ReasoningSignature string `json:"reasoning_signature,omitempty"`
 }
 
 // ContentBlock is one piece of message content. Type discriminates the union.
@@ -561,6 +573,13 @@ type Event struct {
 	// echoes it back to the API per DeepSeek's contract. Empty for
 	// non-thinking models.
 	Reasoning string `json:"reasoning,omitempty"`
+
+	// ReasoningSignature is Anthropic's extended-thinking block signature
+	// (signature_delta), set on EventDone alongside Reasoning. The loop stamps
+	// it onto the assistant Message so the Anthropic driver can replay the
+	// thinking block with its seal on the next (tool-use continuation) request.
+	// Empty for non-Anthropic / non-thinking turns.
+	ReasoningSignature string `json:"reasoning_signature,omitempty"`
 }
 
 // RetryInfo accompanies an EventRetry. Each field is set every time.


### PR DESCRIPTION
## Why (functional — HIGH; breaks a common config)

Found in the full-repo security/code review. With **extended thinking enabled** (`effort: medium|high` on a sonnet/opus model) **and a tool call**, every run hard-failed on its **second turn**:

```
400 … "When `thinking` is enabled, a final assistant message must start with a thinking block …"
```

The driver enabled thinking on every request (effort persists across iterations) but never preserved the thinking block: the stream's `signature_delta` was dropped ("intentionally not surfaced"), the loop didn't accumulate `EventThinking`, and Anthropic's `EventDone` carried no `Reasoning`. So the replayed assistant turn started with text/`tool_use` — which Anthropic rejects when thinking is on. **Any `effort`-set Anthropic tool-using agent broke on the continuation.**

## What

Capture the thinking block + its seal and replay it, mirroring the existing DeepSeek `reasoning_content` round-trip:

- **driver parse** — accumulate `thinking_delta` text + capture `signature_delta`; emit both on `EventDone` (`Reasoning` + new `ReasoningSignature`).
- **`providers.Message` / `Event`** — add `ReasoningSignature` (the Anthropic seal paired with `Reasoning`).
- **loop** — stamp `Reasoning` + `ReasoningSignature` onto the assistant `Message`; the cross-provider strip zeroes **both** (a seal is only valid for the model that produced it).
- **driver `buildRequestBody`** — prepend a `{type:thinking, thinking, signature}` block to an assistant turn that carries both — **only when both are present** (a bare/unsigned block 400s differently).
- **`replayTranscript`** — restore the signature alongside `Reasoning` so a **resumed** thinking+tool-use run replays correctly.

**Scope:** standard (non-interleaved) extended thinking — one thinking block per assistant turn (loomcycle sends no interleaved-thinking beta header), which the single `Reasoning`+signature pair represents faithfully.

## What was tested

- `TestRequestBody_ReplaysThinkingBlockOnToolContinuation` — the assistant turn **starts with** the thinking block, text+signature echoed verbatim. **Fails on the pre-fix code** (verified — `got [tool_use]`).
- `TestRequestBody_NoThinkingBlockWithoutSignature` — the both-required guard.
- `TestProcessFrame_CapturesThinkingAndSignature` — parse accumulates thinking text + captures the seal.
- Full `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)