### PR TITLE
fix(openai): reasoning models use max_completion_tokens, not max_tokens

### DIFF
--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -171,12 +171,18 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 //     into separate role:"tool" messages.
 
 type wireRequest struct {
-	Model       string        `json:"model"`
-	Messages    []wireMessage `json:"messages"`
-	Tools       []wireTool    `json:"tools,omitempty"`
-	MaxTokens   int           `json:"max_tokens,omitempty"`
-	Temperature *float64      `json:"temperature,omitempty"`
-	Stream      bool          `json:"stream"`
+	Model     string        `json:"model"`
+	Messages  []wireMessage `json:"messages"`
+	Tools     []wireTool    `json:"tools,omitempty"`
+	MaxTokens int           `json:"max_tokens,omitempty"`
+	// MaxCompletionTokens is the reasoning-model spelling of the output cap.
+	// OpenAI's o-series / GPT-5 reasoning models REJECT max_tokens with a 400
+	// ("Unsupported parameter: max_tokens … use max_completion_tokens instead")
+	// — buildRequestBody sends exactly one of the two based on the model. Chat
+	// models (gpt-4o, DeepSeek's OpenAI-compat surface) keep max_tokens.
+	MaxCompletionTokens int      `json:"max_completion_tokens,omitempty"`
+	Temperature         *float64 `json:"temperature,omitempty"`
+	Stream              bool     `json:"stream"`
 
 	// Sampling knobs OpenAI's /v1/chat/completions accepts (DeepSeek's
 	// OpenAI-compat surface inherits the same field names). top_k is NOT an
@@ -301,7 +307,6 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 
 	w := wireRequest{
 		Model:            req.Model,
-		MaxTokens:        req.MaxTokens,
 		Temperature:      req.Temperature,
 		TopP:             req.TopP,
 		FrequencyPenalty: req.FrequencyPenalty,
@@ -317,6 +322,16 @@ func buildRequestBody(req providers.Request) ([]byte, error) {
 		// receive values from the validated Effort enum at the config
 		// layer.
 		ReasoningEffort: req.Effort,
+	}
+
+	// Reasoning models (o-series / GPT-5) reject max_tokens and require
+	// max_completion_tokens; chat models (gpt-4o) and DeepSeek's OpenAI-compat
+	// surface keep max_tokens. Send exactly one, by model — omitempty drops a
+	// zero cap either way.
+	if openaiIsReasoningModel(req.Model) {
+		w.MaxCompletionTokens = req.MaxTokens
+	} else {
+		w.MaxTokens = req.MaxTokens
 	}
 
 	// System blocks become a single role:"system" message at the top.
@@ -430,6 +445,28 @@ func flattenMessage(m providers.Message) []wireMessage {
 		out = append([]wireMessage{{Role: "user", Content: userText.String()}}, out...)
 	}
 	return out
+}
+
+// openaiIsReasoningModel reports whether the named model is an OpenAI reasoning
+// model (o-series or GPT-5 line) that requires max_completion_tokens and rejects
+// max_tokens. Match is by name so the shared driver serves DeepSeek safely:
+// deepseek-* never matches, so DeepSeek keeps max_tokens (its OpenAI-compat
+// surface accepts it). gpt-4o is NOT a reasoning model — the "gpt-5" substring
+// won't match it, and the o-series prefixes are anchored so "gpt-4o" is excluded.
+// An unknown model is treated as a chat model (keeps max_tokens); a wrong guess
+// surfaces as a provider 400, never a silent drop.
+func openaiIsReasoningModel(model string) bool {
+	m := strings.ToLower(model)
+	if strings.Contains(m, "gpt-5") {
+		return true
+	}
+	// o-series: o1 / o3 / o4 (+ future o5), optionally suffixed (-mini, dates).
+	for _, p := range []string{"o1", "o3", "o4", "o5"} {
+		if m == p || strings.HasPrefix(m, p+"-") {
+			return true
+		}
+	}
+	return false
 }
 
 // openaiSupportsVision reports whether the named OpenAI model accepts image

--- a/internal/providers/openai/maxtokens_test.go
+++ b/internal/providers/openai/maxtokens_test.go
@@ -1,0 +1,54 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// TestBuildRequestBody_MaxTokensSpellingByModel is the regression for the OpenAI
+// reasoning-model 400: o-series / GPT-5 models REJECT max_tokens and require
+// max_completion_tokens, while chat models (gpt-4o) and DeepSeek's OpenAI-compat
+// surface keep max_tokens. The driver previously always sent max_tokens → any
+// reasoning model with an explicit max_tokens 400'd on the first call.
+func TestBuildRequestBody_MaxTokensSpellingByModel(t *testing.T) {
+	cases := []struct {
+		model     string
+		reasoning bool // expect max_completion_tokens (else max_tokens)
+	}{
+		{"o1", true}, {"o3", true}, {"o3-mini", true}, {"o4-mini", true},
+		{"gpt-5", true}, {"gpt-5.4", true}, {"gpt-5.4-mini", true},
+		{"gpt-4o", false}, {"gpt-4o-mini", false}, {"gpt-4-turbo", false},
+		// DeepSeek shares this driver and MUST keep max_tokens.
+		{"deepseek-v4-pro", false}, {"deepseek-reasoner", false},
+	}
+	for _, c := range cases {
+		body, err := buildRequestBody(providers.Request{
+			Model:     c.model,
+			MaxTokens: 1234,
+			Messages:  []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+		})
+		if err != nil {
+			t.Fatalf("%s: buildRequestBody: %v", c.model, err)
+		}
+		var parsed struct {
+			MaxTokens           int `json:"max_tokens"`
+			MaxCompletionTokens int `json:"max_completion_tokens"`
+		}
+		if err := json.Unmarshal(body, &parsed); err != nil {
+			t.Fatalf("%s: unmarshal: %v", c.model, err)
+		}
+		if c.reasoning {
+			if parsed.MaxCompletionTokens != 1234 || parsed.MaxTokens != 0 {
+				t.Errorf("%s (reasoning): max_tokens=%d max_completion_tokens=%d, want completion=1234 + no max_tokens",
+					c.model, parsed.MaxTokens, parsed.MaxCompletionTokens)
+			}
+		} else {
+			if parsed.MaxTokens != 1234 || parsed.MaxCompletionTokens != 0 {
+				t.Errorf("%s (chat): max_tokens=%d max_completion_tokens=%d, want max_tokens=1234 + no completion field",
+					c.model, parsed.MaxTokens, parsed.MaxCompletionTokens)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Why (functional)

From the v1.9.0 review's driver-bug set. OpenAI's o-series / GPT-5 **reasoning models reject `max_tokens`** with a 400 (`Unsupported parameter: max_tokens … use max_completion_tokens instead`). `buildRequestBody` always sent `max_tokens`, so any run routed to an OpenAI reasoning model (the bundled config ships `gpt-5.4` aliases) with an explicit `max_tokens` failed on the first call.

## What

Send `max_completion_tokens` for reasoning models, `max_tokens` for chat models — chosen by **model name** so the shared driver still serves **DeepSeek** safely (`deepseek-*` never matches → keeps `max_tokens`, which its OpenAI-compat surface accepts). `gpt-4o` is not matched (the `gpt-5` substring misses it; o-series prefixes are anchored so `gpt-4o` is excluded). `omitempty` drops a zero cap either way. New `openaiIsReasoningModel` helper sits beside `openaiSupportsVision`.

## What was tested

`TestBuildRequestBody_MaxTokensSpellingByModel` — a table over `o1`/`o3`/`o4`/`gpt-5*` (→ `max_completion_tokens`) vs `gpt-4o` / `deepseek-*` (→ `max_tokens`). **Fails on the pre-fix code** (reasoning models got `max_tokens`, verified). Existing openai tests + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)