### PR TITLE
fix(ollama): surface in-stream error frames instead of a silent success

### DIFF
--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -530,10 +530,15 @@ func flattenMessage(m providers.Message) []wireMessage {
 // final or near-final line. So no accumulator is needed.
 
 type chunk struct {
-	Model      string  `json:"model"`
-	Message    message `json:"message"`
-	Done       bool    `json:"done"`
-	DoneReason string  `json:"done_reason"`
+	Model   string  `json:"model"`
+	Message message `json:"message"`
+	Done    bool    `json:"done"`
+	// Error is Ollama's in-stream fault. /api/chat commits a 200 and then, on
+	// a mid-generation failure (OOM, model unload, late context-overflow),
+	// writes a final NDJSON line {"error":"..."} with no done:true. Captured so
+	// streamEvents can surface it instead of ending as a silent clean stop.
+	Error      string `json:"error"`
+	DoneReason string `json:"done_reason"`
 
 	// Usage fields (only present on the final "done":true frame).
 	PromptEvalCount int `json:"prompt_eval_count"`
@@ -631,6 +636,16 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		var c chunk
 		if err := json.Unmarshal(line, &c); err != nil {
 			continue
+		}
+		// In-stream error frame ({"error":"..."} with no done:true). Flush any
+		// text already delivered (like the scanner-error path), then surface an
+		// EventError and stop — WITHOUT this the loop sees only a clean
+		// EventDone{StopReason:""} and treats a failed generation as success
+		// with truncated/empty output (no error, no fallback).
+		if c.Error != "" {
+			_ = flushText()
+			send(providers.Event{Type: providers.EventError, Error: "ollama: " + c.Error})
+			return
 		}
 		if model == "" && c.Model != "" {
 			model = c.Model

--- a/internal/providers/ollama/instream_error_test.go
+++ b/internal/providers/ollama/instream_error_test.go
@@ -1,0 +1,58 @@
+package ollama
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+)
+
+// TestStream_InStreamErrorEmitsEventError is the regression for Ollama's silent
+// in-stream failure: /api/chat commits a 200 then, on a mid-generation fault,
+// writes a final {"error":"..."} NDJSON line with no done:true. The chunk struct
+// had no Error field, so the frame was ignored and the run ended as a clean
+// EventDone{StopReason:""} — the loop treated a failed generation as success
+// with truncated/empty output and NO EventError. The driver must now surface it.
+func TestStream_InStreamErrorEmitsEventError(t *testing.T) {
+	frames := []string{
+		`{"model":"qwen3.6:latest","message":{"role":"assistant","content":"partial ans"},"done":false}` + "\n",
+		`{"error":"llama runner process has terminated: signal: killed"}` + "\n",
+	}
+	srv := fakeStream(t, frames)
+	defer srv.Close()
+
+	d := New("", "", srv.URL, streamhttp.Options{}, nil)
+	ch, err := d.Call(context.Background(), providers.Request{
+		Model:    "qwen3.6:latest",
+		Messages: []providers.Message{{Role: "user", Content: []providers.ContentBlock{{Type: "text", Text: "hi"}}}},
+	})
+	if err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+
+	var gotError bool
+	var errText string
+	var text strings.Builder
+	for ev := range ch {
+		switch ev.Type {
+		case providers.EventError:
+			gotError = true
+			errText = ev.Error
+		case providers.EventText:
+			text.WriteString(ev.Text)
+		}
+	}
+
+	if !gotError {
+		t.Fatal("in-stream {\"error\":...} frame must surface EventError (was silently swallowed → false success)")
+	}
+	if !strings.Contains(errText, "terminated") {
+		t.Errorf("EventError text = %q, want it to carry the Ollama error message", errText)
+	}
+	// Text delivered before the error is still flushed (not silently dropped).
+	if text.String() != "partial ans" {
+		t.Errorf("pre-error text = %q, want the delivered bytes flushed (%q)", text.String(), "partial ans")
+	}
+}


### PR DESCRIPTION
## Why (functional)

From the v1.9.0 review's driver-bug set. Ollama's `/api/chat` commits a 200 and then, on a mid-generation fault (OOM, model unload, late context-overflow surfaced mid-stream), writes a final NDJSON line `{"error":"..."}` with **no `done:true`**. The `chunk` struct had no `Error` field, so the frame unmarshaled to a zero chunk and was ignored: `c.Done` never fired, `stopReason` stayed `""`, and `streamEvents` ended with `EventDone{StopReason:""}`. The loop treats that as a clean terminal → the run **"succeeds"** with whatever text streamed before the fault (truncated, or empty) and **no `EventError`** — a silent failure, and provider-fallback never engages.

## What

Add `Error` to the `chunk` struct and, on a non-empty error frame, flush any already-delivered text (mirroring the scanner-error path) then emit `EventError` and stop. The run now fails loudly and fallback can take over.

Relevant to the local-model crashes behind the recent DeepSeek fallback incident (#608) — those `ollama-local` faults may have been surfacing as silent empties rather than errors.

## What was tested

`TestStream_InStreamErrorEmitsEventError` feeds a content frame then an `{"error"}` frame and asserts `EventError` fires (carrying the message) and the pre-error text is flushed. **Fails on the pre-fix code** (silently swallowed, verified). Existing ollama tests + `go build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)