### PR TITLE
fix(concurrency): lock the per-user cap read + drain the terminal-error channel

### DIFF
--- a/internal/concurrency/peruser_race_test.go
+++ b/internal/concurrency/peruser_race_test.go
@@ -1,0 +1,42 @@
+package concurrency
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAcquireForUser_NoRaceWithCapSet is the regression for the unlocked read of
+// s.maxPerUser in AcquireForUser: WithPerUserCap writes it under s.mu, so the
+// bare read raced the setter (the API doc promises it's safe to call after the
+// semaphore is in use). Run under `go test -race`: this hammers AcquireForUser
+// concurrently with WithPerUserCap — the race detector fails the test on the
+// pre-fix code and passes once the read is taken under the lock.
+func TestAcquireForUser_NoRaceWithCapSet(t *testing.T) {
+	s := New(8, 16, time.Second)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				s.WithPerUserCap(n % 5) // runtime cap changes (the doc's "safe after in use")
+			}
+		}(i)
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				rel, err := s.AcquireForUser(context.Background(), "u")
+				if err == nil && rel != nil {
+					rel()
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/concurrency/semaphore.go
+++ b/internal/concurrency/semaphore.go
@@ -171,17 +171,20 @@ func (s *Semaphore) Acquire(ctx context.Context) (release func(), err error) {
 // returns *BackpressureError (HTTP 429). On ctx cancel, returns
 // ctx.Err().
 func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release func(), err error) {
-	perUserActive := s.maxPerUser > 0 && userID != ""
-
 	// v0.12.1: snapshot the quotaStore reference (and cap) outside the
 	// global-state mutex so the cluster-mode DB round-trip doesn't hold
 	// s.mu. Capturing here means a concurrent WithUserQuotaStore call
 	// can't swap modes mid-Acquire — the release/cancel paths use the
-	// same captured qs.
+	// same captured qs. perUserActive is derived from this LOCKED snapshot,
+	// not a second unlocked read of s.maxPerUser — WithPerUserCap writes it
+	// under s.mu, so an unlocked read here is a data race (flagged by -race;
+	// the cap setter is boot-time today but the API doc promises runtime-safe).
 	s.mu.Lock()
 	qs := s.quotaStore
 	cap := s.maxPerUser
 	s.mu.Unlock()
+
+	perUserActive := cap > 0 && userID != ""
 
 	// Cluster mode: acquire the per-user quota slot FIRST via the DB.
 	// On any later rejection (global-queue full, timeout, cancel), we
@@ -204,9 +207,12 @@ func (s *Semaphore) AcquireForUser(ctx context.Context, userID string) (release 
 		if s.perUser == nil {
 			s.perUser = map[string]int{}
 		}
-		if s.perUser[userID] >= s.maxPerUser {
+		// Use the locked snapshot `cap` (not s.maxPerUser) — consistent with the
+		// perUserActive gate above, and the error is built AFTER Unlock so a bare
+		// s.maxPerUser read there would be a data race with WithPerUserCap.
+		if s.perUser[userID] >= cap {
 			s.mu.Unlock()
-			return nil, &ErrPerUserQuotaExhausted{UserID: userID, Cap: s.maxPerUser}
+			return nil, &ErrPerUserQuotaExhausted{UserID: userID, Cap: cap}
 		}
 	}
 

--- a/internal/loop/drain_test.go
+++ b/internal/loop/drain_test.go
@@ -1,0 +1,83 @@
+package loop
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// errorThenTrailProvider emits an EventError and then MORE events (as a driver
+// may — a trailing EventDone). senderDone closes only once every event has been
+// consumed, so the test can detect whether the loop drained the channel.
+type errorThenTrailProvider struct {
+	senderDone chan struct{}
+}
+
+func (p *errorThenTrailProvider) ID() string                  { return "trail" }
+func (p *errorThenTrailProvider) Probe(context.Context) error { return nil }
+func (p *errorThenTrailProvider) ListModels(context.Context) ([]string, error) {
+	return []string{"m"}, nil
+}
+func (p *errorThenTrailProvider) Capabilities() providers.Capabilities {
+	return providers.Capabilities{Streaming: true}
+}
+func (p *errorThenTrailProvider) Call(ctx context.Context, _ providers.Request) (<-chan providers.Event, error) {
+	ch := make(chan providers.Event) // unbuffered → a trailing send blocks unless the loop drains
+	go func() {
+		defer close(p.senderDone)
+		send := func(ev providers.Event) bool {
+			select {
+			case ch <- ev:
+				return true
+			case <-ctx.Done(): // cleanup safety net so a leaked goroutine still exits
+				return false
+			}
+		}
+		if !send(providers.Event{Type: providers.EventError, Error: "trail 400: bad request"}) {
+			return
+		}
+		// Trailing events after the error — the loop MUST consume these.
+		for i := 0; i < 5; i++ {
+			if !send(providers.Event{Type: providers.EventText, Text: "x"}) {
+				return
+			}
+		}
+		_ = send(providers.Event{Type: providers.EventDone, StopReason: "end_turn"})
+		close(ch)
+	}()
+	return ch, nil
+}
+
+// TestRun_DrainsChannelOnTerminalError is the regression for the undrained
+// terminal EventError path: the loop returned after a non-retryable, no-fallback
+// in-stream error WITHOUT draining the provider channel, so a driver still
+// emitting events blocked its goroutine (bounded only by ctx-cancel / idle
+// timeout). The loop must drain — like the retry + fallback paths do.
+func TestRun_DrainsChannelOnTerminalError(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel) // unblock any leaked goroutine at test end (hygiene)
+
+	p := &errorThenTrailProvider{senderDone: make(chan struct{})}
+	opts := RunOptions{
+		Provider:       p,
+		Model:          "m",
+		MaxIterations:  3,
+		Segments:       []PromptSegment{{Role: "user", Content: []PromptContentBlock{{Type: "trusted-text", Text: "hi"}}}},
+		OnEvent:        func(providers.Event) {},
+		FallbackPolicy: FallbackPolicy{Enabled: false}, // no fallback → terminal error path
+	}
+	if _, err := Run(ctx, opts); err == nil {
+		t.Fatal("Run: expected a provider error")
+	}
+
+	// With the drain, the sender consumed every event and closed senderDone.
+	// Without it (pre-fix), the sender blocks on the first trailing send and
+	// senderDone never closes within the window.
+	select {
+	case <-p.senderDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider sender goroutine did not finish — the loop abandoned the channel (undrained terminal error)")
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1627,6 +1627,13 @@ outerLoop:
 					continue outerLoop
 				}
 				emit(ev)
+				// Drain any trailing events (a driver may emit an EventDone
+				// after EventError) so the sending goroutine doesn't block on
+				// the channel until ctx-cancel / the idle timeout — mirrors the
+				// same-provider-retry + fallback drains above. Without it, the
+				// terminal error path was the one branch that abandoned ch.
+				for range ch {
+				}
 				lcotel.SetSpanErrorMessage(iterSpan, ev.Error)
 				iterSpan.End()
 				return RunResult{Iterations: iter}, fmt.Errorf("provider error: %s", ev.Error)


### PR DESCRIPTION
## Why

Two independent concurrency-robustness defects from the v1.9.0 review.

1. **`Semaphore.AcquireForUser` read `s.maxPerUser` without the lock** (once at the top, once when building `ErrPerUserQuotaExhausted` *after* `Unlock`), racing `WithPerUserCap`'s mutex-guarded write. A real data race (`-race` flags it) — and the doc even promises `WithPerUserCap` is "safe to call after the semaphore is in use", which was false.
2. **`loop.Run`'s terminal in-stream `EventError` path** (non-retryable + no fallback) **returned without draining the provider channel**, unlike the same-provider-retry and fallback paths right beside it (which `for range ch` precisely because a driver may emit a trailing `EventDone` after `EventError`). A driver still sending then blocked its goroutine until ctx-cancel / the idle timeout — bounded today, a hard leak for any future unguarded-send driver.

## What

1. Derive `perUserActive` from the existing **locked snapshot** (`cap`) and report `cap` in the error — no bare `s.maxPerUser` read outside the lock remains.
2. Drain `ch` on the terminal error path too (matches the two adjacent paths).

## What was tested (both fail on the pre-fix code)

- `TestAcquireForUser_NoRaceWithCapSet` — hammers `AcquireForUser` + `WithPerUserCap` concurrently; the race detector **fails pre-fix** (two `DATA RACE` reports), passes clean under `-race` with the fix.
- `TestRun_DrainsChannelOnTerminalError` — a provider that emits `EventError` then more events on an unbuffered channel; asserts the sender goroutine finishes (loop drained). **Pre-fix the sender blocks and the test times out.**

`go build` + both packages clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)