### PR TITLE
fix(mcp): opt-in DNS-rebinding guard on the MCP-HTTP client (default allow)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1007,6 +1007,12 @@ func main() {
 				return mcphttp.New(mcphttp.Config{
 					URL:     config.ExpandEnv(spec.URL),
 					Headers: hdrs,
+					// DNS-rebinding guard: OFF by default (MCP servers are commonly
+					// on localhost/private-net), opt in via
+					// LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS=0. HTTPPrivateHostAllowlist
+					// exempts specific internal MCP hosts when the block is on.
+					BlockPrivateIPs:      !cfg.Env.MCPAllowPrivateIPs,
+					PrivateHostAllowlist: cfg.Env.HTTPPrivateHostAllowlist,
 				})
 			case "stdio":
 				// F31: a runtime-registered stdio server. The substrate only

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1960,6 +1960,13 @@ type Env struct {
 	// callbacks to a localhost-bound application API. Default empty
 	// (no exception). Example: "localhost,127.0.0.1".
 	HTTPPrivateHostAllowlist []string
+	// MCPAllowPrivateIPs controls whether the MCP-HTTP client may dial
+	// private/loopback/metadata IPs. DEFAULT true (MCP servers are commonly
+	// operator-run on localhost / a private network — incl. loomcycle's own
+	// jobs-search-agent /api/mcp consumer). Set LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS=0
+	// to enable a dial-time DNS-rebinding block; HTTPPrivateHostAllowlist then
+	// exempts specific internal MCP hosts.
+	MCPAllowPrivateIPs bool
 	// HTTPCallerAuthoritative flips the per-request allowed_hosts
 	// trust model: when true, caller's list is the sole policy
 	// (operator's HTTPHostAllowlist becomes a fallback for runs that
@@ -2750,6 +2757,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		DataDir:                   getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
 		HTTPHostAllowlist:         splitCSV(os.Getenv("LOOMCYCLE_HTTP_HOST_ALLOWLIST")),
 		HTTPPrivateHostAllowlist:  splitCSV(os.Getenv("LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST")),
+		MCPAllowPrivateIPs:        getenvBool("LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS", true),
 		HTTPCallerAuthoritative:   os.Getenv("LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE") == "1",
 		ResumeFanout:              os.Getenv("LOOMCYCLE_RESUME_FANOUT") == "1",
 		BraveAPIKey:               os.Getenv("BRAVE_API_KEY"),
@@ -3867,6 +3875,21 @@ func getenvDefault(name, dflt string) string {
 		return v
 	}
 	return dflt
+}
+
+// getenvBool reads a boolean env var with an explicit default. Unset → dflt;
+// "1"/"true"/"yes"/"on" → true; "0"/"false"/"no"/"off" → false (case-
+// insensitive). An unrecognised non-empty value → dflt (fail-safe to the
+// documented default rather than silently flipping).
+func getenvBool(name string, dflt bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return dflt
+	}
 }
 
 // discoverAgents walks LOOMCYCLE_AGENTS_ROOT, parses each `<name>.md`

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -1,0 +1,124 @@
+// Package netguard is the shared SSRF dial-time guard: it refuses to connect to
+// private / loopback / link-local addresses (incl. the cloud metadata endpoint
+// 169.254.169.254), filtering at DIAL time so DNS-rebinding and redirect targets
+// are re-checked on every new connection — not at a one-shot validate. It is a
+// leaf (only net / net/http) so every outbound-HTTP caller (the HTTP/WebFetch
+// tools, the mem9 MemoryBackend client, the MCP-HTTP client) shares ONE
+// implementation and a new caller can't copy the weak first-layer URL check
+// without this load-bearing guard — the drift class the v1.9.x security review
+// found in the mem9 backend.
+package netguard
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// IsPrivateIP reports whether ip is loopback / link-local / multicast /
+// unspecified / RFC1918-private. A nil ip is treated as private (fail-closed).
+func IsPrivateIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate()
+}
+
+// hostAllowed suffix-matches host against an operator vouch list (case- and
+// trailing-dot-insensitive): an entry "internal.example" matches
+// "internal.example" and "mcp.internal.example". Empty host / empty entries
+// never match. Mirrors the HTTP tool's host matcher so the private-host
+// allowlist means the same thing everywhere.
+func hostAllowed(host string, allowlist []string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	if host == "" {
+		return false
+	}
+	for _, entry := range allowlist {
+		entry = strings.ToLower(strings.TrimSuffix(entry, "."))
+		if entry == "" {
+			continue
+		}
+		if host == entry || strings.HasSuffix(host, "."+entry) {
+			return true
+		}
+	}
+	return false
+}
+
+// GuardedDialContext returns a DialContext that resolves the host and dials only
+// public addresses, with a socket-level Control re-check after the OS resolves
+// the address. allowPrivate lifts the block entirely (tests / an operator
+// opt-out); privateHostAllowlist (suffix-matched) exempts specific hosts an
+// operator has vouched are safe on a private network.
+func GuardedDialContext(allowPrivate bool, privateHostAllowlist []string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		hostExempt := hostAllowed(host, privateHostAllowlist)
+
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		candidates := ips
+		if !allowPrivate && !hostExempt {
+			candidates = candidates[:0]
+			for _, ip := range ips {
+				if !IsPrivateIP(ip.IP) {
+					candidates = append(candidates, ip)
+				}
+			}
+			if len(candidates) == 0 {
+				return nil, fmt.Errorf("blocked: %s has no public addresses (got %d private)", host, len(ips))
+			}
+		}
+		d := net.Dialer{
+			Timeout: 10 * time.Second,
+			Control: func(_, address string, _ syscall.RawConn) error {
+				if allowPrivate || hostExempt {
+					return nil
+				}
+				ip, _, _ := net.SplitHostPort(address)
+				if parsed := net.ParseIP(ip); parsed != nil && IsPrivateIP(parsed) {
+					return fmt.Errorf("blocked: socket-level address %s is private", ip)
+				}
+				return nil
+			},
+		}
+		var lastErr error
+		for _, ip := range candidates {
+			conn, derr := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if derr == nil {
+				return conn, nil
+			}
+			lastErr = derr
+		}
+		return nil, lastErr
+	}
+}
+
+// NewGuardedClient returns an *http.Client that BLOCKS private-IP dials (subject
+// to privateHostAllowlist) and bounds redirects — each hop re-dials through the
+// guard, so a 302 to an internal/metadata IP is refused too. For callers that
+// always want the block (mem9, the MCP-HTTP client when the operator opts in).
+func NewGuardedClient(timeout time.Duration, privateHostAllowlist []string) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{DialContext: GuardedDialContext(false, privateHostAllowlist)},
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return errors.New("too many redirects")
+			}
+			return nil
+		},
+	}
+}

--- a/internal/netguard/netguard_test.go
+++ b/internal/netguard/netguard_test.go
@@ -1,0 +1,44 @@
+package netguard
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestIsPrivateIP(t *testing.T) {
+	private := []string{"127.0.0.1", "::1", "10.0.0.5", "192.168.1.1", "172.16.0.1", "169.254.169.254", "0.0.0.0"}
+	for _, s := range private {
+		if !IsPrivateIP(net.ParseIP(s)) {
+			t.Errorf("IsPrivateIP(%s) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"8.8.8.8", "1.1.1.1"} {
+		if IsPrivateIP(net.ParseIP(s)) {
+			t.Errorf("IsPrivateIP(%s) = true, want false", s)
+		}
+	}
+	if !IsPrivateIP(nil) {
+		t.Error("IsPrivateIP(nil) = false, want true (fail-closed)")
+	}
+}
+
+// TestNewGuardedClient_BlocksLoopback: the always-block client refuses a
+// loopback (private) target unless the host is on the allowlist.
+func TestNewGuardedClient_BlocksLoopback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	defer srv.Close()
+
+	if resp, err := NewGuardedClient(5*time.Second, nil).Get(srv.URL); err == nil {
+		_ = resp.Body.Close()
+		t.Fatalf("guarded client reached loopback %s — guard not applied", srv.URL)
+	}
+	host, _, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	resp, err := NewGuardedClient(5*time.Second, []string{host}).Get(srv.URL)
+	if err != nil {
+		t.Fatalf("allowlisted host should dial through: %v", err)
+	}
+	_ = resp.Body.Close()
+}

--- a/internal/tools/builtin/httptool.go
+++ b/internal/tools/builtin/httptool.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/netguard"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -325,13 +326,7 @@ func hostAllowedExtras(host string, extras []string) bool {
 // link-local (169.254/16, fe80::/10) — including the AWS/GCP metadata service
 // at 169.254.169.254 — multicast, and unspecified (0.0.0.0, ::).
 // IPv6 ULAs (fc00::/7) too.
-func isPrivateIP(ip net.IP) bool {
-	if ip == nil {
-		return true
-	}
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
-		ip.IsMulticast() || ip.IsUnspecified() || ip.IsPrivate() {
-		return true
-	}
-	return false
-}
+// isPrivateIP delegates to the shared netguard classifier (single source of
+// truth used by the dial guard too). Kept as a package-local alias so its
+// callers (dialContext, a2aagentdef.requireSafeGRPCEndpoint) are unchanged.
+func isPrivateIP(ip net.IP) bool { return netguard.IsPrivateIP(ip) }

--- a/internal/tools/builtin/ssrf.go
+++ b/internal/tools/builtin/ssrf.go
@@ -2,93 +2,23 @@ package builtin
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"net"
 	"net/http"
-	"syscall"
 	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/netguard"
 )
 
-// guardedDialContext is the shared SSRF-blocking dialer used by the HTTP/WebFetch
-// tools AND the mem9 MemoryBackend client. It resolves the host and refuses to
-// connect to any private / loopback / link-local address (incl. the cloud
-// metadata endpoint 169.254.169.254) — filtering at DIAL time, so DNS-rebinding
-// and redirect targets are re-checked on every new connection, not just at a
-// one-shot validate. A socket-level Control hook re-asserts the block after the
-// OS resolves the address.
-//
-// allowPrivate lifts the block entirely (tests / an operator opt-in). Otherwise
-// privateHostAllowlist (suffix-matched via hostAllowed) exempts specific hosts
-// the operator has vouched are safe to reach on a private network. Extracted
-// from HTTP.dialContext so a new caller (mem9) can't copy the weak first-layer
-// URL check without this load-bearing dial-time guard — the exact class of gap
-// the v1.9.x security review found in the mem9 backend.
-func guardedDialContext(allowPrivate bool, privateHostAllowlist []string) func(ctx context.Context, network, addr string) (net.Conn, error) {
-	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		host, port, err := net.SplitHostPort(addr)
-		if err != nil {
-			return nil, err
-		}
-		hostExempt := hostAllowed(host, privateHostAllowlist)
+// guardedDialContext + newSSRFGuardedClient delegate to the shared
+// internal/netguard guard so the HTTP/WebFetch tools, the mem9 backend client,
+// and the MCP-HTTP client all share ONE dial-time SSRF implementation — no
+// weak-copy drift (the class the v1.9.x review found). Thin wrappers keep the
+// existing call sites (HTTP.dialContext, buildMem9) unchanged.
 
-		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-		if err != nil {
-			return nil, err
-		}
-		candidates := ips
-		if !allowPrivate && !hostExempt {
-			candidates = candidates[:0]
-			for _, ip := range ips {
-				if !isPrivateIP(ip.IP) {
-					candidates = append(candidates, ip)
-				}
-			}
-			if len(candidates) == 0 {
-				return nil, fmt.Errorf("blocked: %s has no public addresses (got %d private)", host, len(ips))
-			}
-		}
-		d := net.Dialer{
-			Timeout: 10 * time.Second,
-			Control: func(_, address string, _ syscall.RawConn) error {
-				if allowPrivate || hostExempt {
-					return nil
-				}
-				ip, _, _ := net.SplitHostPort(address)
-				if parsed := net.ParseIP(ip); parsed != nil && isPrivateIP(parsed) {
-					return fmt.Errorf("blocked: socket-level address %s is private", ip)
-				}
-				return nil
-			},
-		}
-		var lastErr error
-		for _, ip := range candidates {
-			conn, derr := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
-			if derr == nil {
-				return conn, nil
-			}
-			lastErr = derr
-		}
-		return nil, lastErr
-	}
+func guardedDialContext(allowPrivate bool, privateHostAllowlist []string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	return netguard.GuardedDialContext(allowPrivate, privateHostAllowlist)
 }
 
-// newSSRFGuardedClient returns an *http.Client whose transport dials through
-// guardedDialContext (private IPs blocked, subject to privateHostAllowlist) and
-// whose redirects are bounded — each redirect hop is a fresh connection that
-// re-runs the dial guard, so a 302 to an internal/metadata IP is refused too.
-// Used for the mem9 backend client, which was previously a plain http.Client
-// with no SSRF guard (a model-authored base_url could reach 169.254.169.254 and
-// exfiltrate the allowlisted X-API-Key).
 func newSSRFGuardedClient(timeout time.Duration, privateHostAllowlist []string) *http.Client {
-	return &http.Client{
-		Timeout:   timeout,
-		Transport: &http.Transport{DialContext: guardedDialContext(false, privateHostAllowlist)},
-		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
-			if len(via) >= 5 {
-				return errors.New("too many redirects")
-			}
-			return nil
-		},
-	}
+	return netguard.NewGuardedClient(timeout, privateHostAllowlist)
 }

--- a/internal/tools/mcp/http/client.go
+++ b/internal/tools/mcp/http/client.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/netguard"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 	"github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
@@ -45,6 +46,16 @@ type Config struct {
 	// HTTPClient overrides the default. Tests pass an httptest-driven
 	// client; production passes nil to use the package default.
 	HTTPClient *http.Client
+	// BlockPrivateIPs, when true, makes the default client refuse to dial
+	// private / loopback / metadata IPs at connect time (DNS-rebinding
+	// protection). DEFAULT false: MCP servers are commonly operator-run on
+	// localhost / a private network — including loomcycle's own jobs-search-agent
+	// /api/mcp consumer — so blocking by default would break them. Operators opt
+	// in via LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS=0. Ignored when HTTPClient is set.
+	BlockPrivateIPs bool
+	// PrivateHostAllowlist exempts specific hosts from BlockPrivateIPs (the
+	// operator's vouch list, reusing LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST).
+	PrivateHostAllowlist []string
 }
 
 // Client speaks MCP over HTTP. Implements mcp.Caller.
@@ -67,7 +78,14 @@ func New(cfg Config) (*Client, error) {
 	}
 	hc := cfg.HTTPClient
 	if hc == nil {
-		hc = &http.Client{Timeout: defaultTimeout}
+		if cfg.BlockPrivateIPs {
+			// Opt-in DNS-rebinding guard: an allowlisted MCP host that rebinds to
+			// a private/metadata IP is refused at dial time. Default path stays a
+			// plain client (unchanged) so internal/localhost MCP servers work.
+			hc = netguard.NewGuardedClient(defaultTimeout, cfg.PrivateHostAllowlist)
+		} else {
+			hc = &http.Client{Timeout: defaultTimeout}
+		}
 	}
 	return &Client{
 		url:     cfg.URL,

--- a/internal/tools/mcp/http/dns_rebind_test.go
+++ b/internal/tools/mcp/http/dns_rebind_test.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNew_BlockPrivateIPs is the DNS-rebinding guard: the MCP-HTTP client
+// blocks private-IP dials ONLY when BlockPrivateIPs is set (opt-in via
+// LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS=0). The default must still reach a
+// localhost/private MCP server (the common deployment — incl. jobs-search-agent's
+// /api/mcp), so blocking by default would be a breaking change.
+func TestNew_BlockPrivateIPs(t *testing.T) {
+	srv := newFakeServer(t, "ok") // loopback httptest server
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Default: reaches the loopback MCP server (unchanged behaviour).
+	c, err := New(Config{URL: srv.URL})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Call(ctx, "initialize", map[string]any{}); err != nil {
+		t.Fatalf("default client should reach the loopback MCP server, got: %v", err)
+	}
+
+	// Opt-in block: the loopback dial is refused.
+	blocked, err := New(Config{URL: srv.URL, BlockPrivateIPs: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blocked.Call(ctx, "initialize", map[string]any{}); err == nil || !strings.Contains(err.Error(), "blocked") {
+		t.Fatalf("BlockPrivateIPs client must refuse the loopback dial, got: %v", err)
+	}
+
+	// The operator's private-host allowlist exempts the internal MCP host.
+	host, _, _ := net.SplitHostPort(srv.Listener.Addr().String())
+	allowed, err := New(Config{URL: srv.URL, BlockPrivateIPs: true, PrivateHostAllowlist: []string{host}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := allowed.Call(ctx, "initialize", map[string]any{}); err != nil {
+		t.Fatalf("allowlisted internal MCP host should dial through: %v", err)
+	}
+}


### PR DESCRIPTION
## Why (security — MEDIUM; DNS-rebinding)

From the v1.9.0 review. The MCP-HTTP client dialed with a plain `http.Client` and re-resolved DNS at connect with no IP check, so an **allowlisted MCP host that rebinds to a private/metadata IP** (`169.254.169.254`) reached the internal address.

A blanket private-IP block **can't be the default**: MCP servers are commonly operator-run on localhost / a private network — including loomcycle's own primary consumer, **jobs-search-agent's `/api/mcp`** — so default-blocking would break them. (Per the chosen posture: opt-out env, default allow.)

## What

- A DNS-rebinding dial guard that is **OFF by default** (behaviour unchanged) and **opt-in via `LOOMCYCLE_MCP_ALLOW_PRIVATE_IPS=0`**. When enabled, the MCP-HTTP client refuses private-IP dials at connect time (rebinding/redirect-safe); `LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST` exempts specific internal MCP hosts. The default path stays a plain client — byte-identical.
- Extracts the SSRF dial guard into a shared leaf **`internal/netguard`** (`IsPrivateIP` / `GuardedDialContext` / `NewGuardedClient`) so the HTTP/WebFetch tools, the mem9 client, and now the MCP-HTTP client share **one** implementation — closing the copy-without-the-guard drift the review flagged. `builtin/ssrf.go` + `builtin.isPrivateIP` now delegate (httptool's 23 tests validate the transitive path).

## What was tested

- `netguard`: `IsPrivateIP` table + `NewGuardedClient` (blocks loopback, allowlist exempts).
- `TestNew_BlockPrivateIPs` — **default reaches a loopback MCP server (no breakage)**, `BlockPrivateIPs` refuses it, the allowlist exempts it.
- `getenvBool` default-true. Full `go test ./...` + build clean; the whole `builtin` suite passes (refactor behaviour-preserving).

## Deferred (documented)
The **A2A-gRPC** endpoint's dial guard is SDK-level (grpc-go dialer); `requireSafeGRPCEndpoint` stays the literal-IP guard — a code-acknowledged deferral, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)