### PR TITLE
fix(webhook): pin user_tier to the def — the payload can't select the cost tier

### DIFF
--- a/internal/api/webhook/runinput.go
+++ b/internal/api/webhook/runinput.go
@@ -153,16 +153,16 @@ func buildRunInput(w config.Webhook, proj projectResult, envAllowlist map[string
 	return runner.RunInput{
 		Agent:    w.Agent,
 		Segments: []loop.PromptSegment{seg},
-		// UserID + UserTier are projected from the EXTERNAL, attacker-
-		// influenceable payload when the operator maps them. UserTier
-		// selects the provider/model policy and UserID keys on_complete
-		// scope / quota — so a payload value steers routing/scope. The
-		// caller (deliverSpawn) rejects an unknown UserTier (parity with the
-		// HTTP path); constraining WHICH valid tier a payload may select, or
-		// pinning these from the Def, is an operator-config decision (the
-		// values are only as trustworthy as the per-Def signing secret).
+		// UserID is projected from the EXTERNAL, attacker-influenceable payload
+		// when the operator maps it (attribution / on_complete scope).
+		//
+		// UserTier is PINNED from the STATIC def `w` — NEVER from the payload:
+		// it selects the provider/model policy (cost), so a signed sender must
+		// not be able to pick the most expensive tier. A payload-mapped
+		// user_tier is deliberately ignored here (load-time warning flags it).
+		// deliverSpawn still rejects an unknown w.UserTier (typo guard).
 		UserID:          proj.Fields["user_id"],
-		UserTier:        proj.Fields["user_tier"],
+		UserTier:        w.UserTier,
 		UserCredentials: creds,
 		// Metadata is the static, operator-authored def blob → TRUSTED.
 		// PayloadMetadata is projected from the inbound body → UNTRUSTED.

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -316,13 +316,12 @@ func (rec *Receiver) deliverSpawn(ctx context.Context, w http.ResponseWriter, sp
 	}
 	in := buildRunInput(wd, proj, rec.envAllowlist, rec.getenv, rec.logf)
 
-	// user_tier may be projected from the (attacker-influenceable) payload
-	// when the operator maps it; it selects the provider/model policy. The
-	// webhook spawn path bypasses the HTTP handler's user_tier validation,
-	// so an unknown tier would otherwise be silently dropped to the agent
-	// default — surface it loudly instead, mirroring the HTTP 400 and the
-	// never-silently-degrade contract. (Restricting WHICH valid tier the
-	// payload may select is an operator-config concern noted in the docs.)
+	// user_tier is PINNED from the def (buildRunInput sets it from w.UserTier,
+	// never the payload — a signed sender can't pick the cost tier). It still
+	// bypasses the HTTP handler's tier validation, so an unknown DEF tier (an
+	// operator typo) would silently drop to the agent default — surface it
+	// loudly instead, mirroring the HTTP 400 and the never-silently-degrade
+	// contract.
 	if in.UserTier != "" && len(rec.cfg.UserTiers) > 0 {
 		if _, ok := rec.cfg.UserTiers[in.UserTier]; !ok {
 			rec.finish(span, name, did, "rejected_unknown_user_tier", "")

--- a/internal/api/webhook/usertier_test.go
+++ b/internal/api/webhook/usertier_test.go
@@ -26,21 +26,20 @@ func receiverWithTiers(t *testing.T, wh config.Webhook, tiers map[string]config.
 	})
 }
 
-// TestReceiver_RejectsUnknownUserTierFromPayload pins the spawn-path tier
-// guard: a payload-projected user_tier not in cfg.UserTiers is rejected with
-// 400 (parity with the HTTP handler) instead of being silently dropped to the
-// agent default. Regression-grade: pre-fix deliverSpawn never validated it,
-// so the run was spawned (202) under the agent default.
-func TestReceiver_RejectsUnknownUserTierFromPayload(t *testing.T) {
+// TestReceiver_RejectsUnknownDefUserTier: an unknown tier PINNED in the def (an
+// operator typo) is rejected with 400 (the spawn-path typo guard), not silently
+// dropped to the agent default.
+func TestReceiver_RejectsUnknownDefUserTier(t *testing.T) {
 	secret := "shhh"
 	now := time.Unix(1_700_000_000, 0)
-	body := []byte(`{"goal":"x","tier":"nonexistent"}`)
+	body := []byte(`{"goal":"x"}`)
 	wh := config.Webhook{
 		Enabled:        true,
 		Delivery:       "spawn",
 		Agent:          "responder",
+		UserTier:       "nonexistent", // Def-pinned bad tier
 		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
-		PayloadMapping: map[string]string{"goal": "$.goal", "user_tier": "$.tier"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
 	}
 	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
 	rec := receiverWithTiers(t, wh, map[string]config.UserTier{"premium": {}}, fr, map[string]string{"WH_SECRET": secret}, now)
@@ -48,42 +47,69 @@ func TestReceiver_RejectsUnknownUserTierFromPayload(t *testing.T) {
 	h := http.Header{}
 	h.Set("X-Hub-Signature-256", githubSig(secret, body))
 	w := doPost(rec, "gh", body, h)
-
 	if w.Code != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400 for unknown user_tier; body=%s", w.Code, w.Body.String())
+		t.Fatalf("status = %d, want 400 for an unknown def user_tier; body=%s", w.Code, w.Body.String())
 	}
 	if fr.called {
-		t.Error("runner was invoked for a delivery with an unknown user_tier; must be rejected before spawn")
+		t.Error("runner invoked despite an unknown def user_tier")
 	}
 }
 
-// TestReceiver_AcceptsKnownUserTierFromPayload confirms a configured tier
-// still spawns and flows through to the run input.
-func TestReceiver_AcceptsKnownUserTierFromPayload(t *testing.T) {
+// TestReceiver_AcceptsDefPinnedUserTier: a tier pinned in the def flows through
+// to the run input and spawns.
+func TestReceiver_AcceptsDefPinnedUserTier(t *testing.T) {
+	secret := "shhh"
+	now := time.Unix(1_700_000_000, 0)
+	body := []byte(`{"goal":"x"}`)
+	wh := config.Webhook{
+		Enabled:        true,
+		Delivery:       "spawn",
+		Agent:          "responder",
+		UserTier:       "premium",
+		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		PayloadMapping: map[string]string{"goal": "$.goal"},
+	}
+	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
+	rec := receiverWithTiers(t, wh, map[string]config.UserTier{"premium": {}}, fr, map[string]string{"WH_SECRET": secret}, now)
+
+	h := http.Header{}
+	h.Set("X-Hub-Signature-256", githubSig(secret, body))
+	w := doPost(rec, "gh", body, h)
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
+	}
+	if got := fr.input().UserTier; got != "premium" {
+		t.Errorf("UserTier = %q, want premium (from the def pin)", got)
+	}
+}
+
+// TestReceiver_PayloadCannotSelectUserTier is the regression: a signed sender
+// must NOT be able to pick the (cost) tier via the payload. The def pins "basic";
+// the payload maps user_tier→"premium"; the run must execute as "basic". Pre-fix,
+// buildRunInput took UserTier from proj.Fields → the sender got "premium".
+func TestReceiver_PayloadCannotSelectUserTier(t *testing.T) {
 	secret := "shhh"
 	now := time.Unix(1_700_000_000, 0)
 	body := []byte(`{"goal":"x","tier":"premium"}`)
 	wh := config.Webhook{
-		Enabled:        true,
-		Delivery:       "spawn",
-		Agent:          "responder",
-		Auth:           config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		Enabled:  true,
+		Delivery: "spawn",
+		Agent:    "responder",
+		UserTier: "basic", // operator pin
+		Auth:     config.WebhookAuth{Kind: "hmac", Header: "X-Hub-Signature-256", SigningSecretEnv: "WH_SECRET"},
+		// A malicious/over-reaching mapping that tries to select the premium tier.
 		PayloadMapping: map[string]string{"goal": "$.goal", "user_tier": "$.tier"},
 	}
 	fr := &fakeRunner{runID: "run-1", agentID: "agent-1"}
-	rec := receiverWithTiers(t, wh, map[string]config.UserTier{"premium": {}}, fr, map[string]string{"WH_SECRET": secret}, now)
+	rec := receiverWithTiers(t, wh, map[string]config.UserTier{"basic": {}, "premium": {}}, fr, map[string]string{"WH_SECRET": secret}, now)
 
 	h := http.Header{}
 	h.Set("X-Hub-Signature-256", githubSig(secret, body))
 	w := doPost(rec, "gh", body, h)
-
 	if w.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202; body=%s", w.Code, w.Body.String())
 	}
-	if !fr.called {
-		t.Fatal("runner was not invoked for a valid tier")
-	}
-	if got := fr.input().UserTier; got != "premium" {
-		t.Errorf("UserTier = %q, want premium", got)
+	if got := fr.input().UserTier; got != "basic" {
+		t.Errorf("UserTier = %q, want basic — the payload must NOT override the def-pinned tier", got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1690,9 +1690,17 @@ type A2AExpectedSkill struct {
 // parity. on_complete reuses ScheduledRunHook — the same hook shape
 // ScheduleDef uses — rather than a parallel type.
 type Webhook struct {
-	Enabled                bool              `json:"enabled,omitempty" yaml:"enabled"`
-	Delivery               string            `json:"delivery,omitempty" yaml:"delivery"`
-	Agent                  string            `json:"agent,omitempty" yaml:"agent"`
+	Enabled  bool   `json:"enabled,omitempty" yaml:"enabled"`
+	Delivery string `json:"delivery,omitempty" yaml:"delivery"`
+	Agent    string `json:"agent,omitempty" yaml:"agent"`
+	// UserTier PINS the spawned run's user_tier (provider/model routing +
+	// cost). SECURITY: it comes from this STATIC operator-authored def ONLY —
+	// the inbound payload can NOT select it (a signed sender must not be able
+	// to pick the most expensive tier). "" = the resolver's default tier. A
+	// payload_mapping that targets user_tier is ignored (a load-time warning
+	// flags it). To route different senders to different tiers, declare
+	// separate webhooks.
+	UserTier               string            `json:"user_tier,omitempty" yaml:"user_tier"`
 	Channel                string            `json:"channel,omitempty" yaml:"channel"`
 	Auth                   WebhookAuth       `json:"auth,omitempty" yaml:"auth"`
 	RateLimit              WebhookRateLimit  `json:"rate_limit,omitempty" yaml:"rate_limit"`
@@ -4669,6 +4677,14 @@ func validate(c *Config) error {
 	for wname, wh := range c.Webhooks {
 		if err := validateStaticWebhook(wname, wh); err != nil {
 			return err
+		}
+		// user_tier is Def-pinned (webhooks.<name>.user_tier). A payload_mapping
+		// targeting "user_tier" is now silently ineffective (the payload can't
+		// select the cost tier) — warn so the operator moves it to the def.
+		if _, mapped := wh.PayloadMapping["user_tier"]; mapped {
+			c.Warnings = append(c.Warnings, fmt.Sprintf(
+				"webhooks.%s: payload_mapping targets \"user_tier\", but user_tier is pinned from the def (set webhooks.%s.user_tier) and the payload value is IGNORED",
+				wname, wname))
 		}
 	}
 	// RFC AH: validate the top-level `volumes:` map. Each path must


### PR DESCRIPTION
## Why (security — MEDIUM)

From the v1.9.0 review. A webhook spawn projected `user_tier` from the (attacker-influenceable) signed payload (`proj.Fields["user_tier"]`), validating only that the tier **exists** in `cfg.UserTiers` — not **which** one. So any holder of the per-Def signing secret could select the most expensive tier (premium model routing) on every delivery.

## What (chosen posture: pin to the WebhookDef)

`user_tier` is now **pinned from the static, operator-authored WebhookDef** — a new `webhooks.<name>.user_tier`. `buildRunInput` sets `UserTier` from `w.UserTier`, **never from the payload**, so a signed sender can no longer pick the cost tier. `""` = the resolver's default tier. A `payload_mapping` that targets `user_tier` is ignored and flagged with a **config-load warning** so the operator moves it to the def. `deliverSpawn` still rejects an unknown *def* tier (operator-typo guard). To route different senders to different tiers, declare separate webhooks.

`user_id` stays payload-projectable (attribution, not cost) — out of scope.

## What was tested

- `TestReceiver_PayloadCannotSelectUserTier` — the def pins `basic`, the payload maps `user_tier`→`premium`; the run executes as `basic`. **Fails on the pre-fix code** (the sender got `premium`, verified).
- `TestReceiver_AcceptsDefPinnedUserTier`, `TestReceiver_RejectsUnknownDefUserTier` — the two old payload-tier tests rewritten for the def-pinned model.

Full `go test ./...` + build clean.

## Migration note
An operator who currently maps `user_tier` in `payload_mapping` gets a load-time warning; move the tier to `webhooks.<name>.user_tier`. Unmapped webhooks are unaffected (default tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)