### PR TITLE
fix(ollama-local): raise the default header/idle timeout 300s → 600s

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -1,1 +1,614 @@
-cmd/loomcycle/embedded/env.insecure.example
+# loomcycle CONFIG (non-secret) — copy to .env.insecure and edit.
+#
+# This file holds ONLY non-secret operational config: listen address,
+# storage paths, host allowlists, feature flags, timeouts, and
+# the trigger-credential allowlists (which list env-var NAMES, never
+# values). Nothing here is a secret, so it is safe to read, diff, and —
+# if you keep your deployment in its own repo — commit.
+#
+# Companion file: .env.local (secrets — provider keys, the sidecar
+# bearer, the secret VALUES behind the names allowlisted below). See
+# `.env.local.example` and docs/CONFIGURATION.md §9c. Both files are
+# sourced at startup by loomcycle.sh / loomcycle-mcp.sh.
+
+# ─── Ollama base URLs (no auth; the hosted key lives in .env.local) ───
+#   `ollama` provider       = hosted ollama.com, Bearer auth via OLLAMA_API_KEY.
+#   `ollama-local` provider = local-network Ollama, no auth, default
+#                             http://localhost:11434. Driven by OLLAMA_BASE_URL.
+# Existing deploys with OLLAMA_BASE_URL=http://localhost:11434 keep working
+# unchanged — they now feed `ollama-local`. To opt out of the local
+# registration entirely, set OLLAMA_BASE_URL=disabled.
+OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_CLOUD_BASE_URL=https://ollama.com   # optional override
+#
+# num_ctx pins the input window Ollama runs every request in. Set it: without
+# an explicit num_ctx Ollama silently truncates the prompt at its 4096-token
+# default. It also doubles as the context window the interactive terminal's
+# gauge reports (used/max/%) — unset, the gauge can only show the absolute
+# used size (the per-model window isn't knowable from the driver).
+# LOOMCYCLE_OLLAMA_LOCAL_NUM_CTX=32768
+# LOOMCYCLE_OLLAMA_NUM_CTX=32768            # hosted ollama.com counterpart
+#
+# num_gpu forces how many model layers Ollama offloads to the GPU on every
+# ollama-local request. Leave unset to let Ollama auto-detect; set it (99 =
+# "all layers") when Ollama otherwise runs on CPU — common on integrated/APU
+# GPUs whose VRAM auto-detection is conservative. Global to ollama-local.
+# LOOMCYCLE_OLLAMA_LOCAL_NUM_GPU=99
+
+# ─── Sidecar listen ───────────────────────────────────────────────────
+# (The bearer token /v1 routes require is a secret — set LOOMCYCLE_AUTH_TOKEN
+# in .env.local.)
+LOOMCYCLE_LISTEN_ADDR=127.0.0.1:8787
+# The externally-reachable base URL for THIS instance (e.g. behind a tunnel/
+# proxy). Advertised to agents via `Context op=self` (server.url) so an agent —
+# especially one over the MCP transport — can identify the server it's talking
+# to. Optional; unset → self reports only the bind address.
+# LOOMCYCLE_PUBLIC_URL=https://loomcycle.example.com
+
+# ─── Storage ──────────────────────────────────────────────────────────
+LOOMCYCLE_DATA_DIR=./data
+
+# ─── Filesystem volumes (RFC AH Phase 3) ─────────────────────────────
+#
+# The file/exec tools (Read/Write/Edit/Glob/Grep/Bash/NotebookEdit) are
+# sandboxed to named VOLUMES, declared in the YAML `volumes:` block — NOT
+# via env vars. The legacy LOOMCYCLE_READ_ROOT / WRITE_ROOT / BASH_CWD jail
+# is RETIRED: setting one now fails startup with a migration hint.
+# Sandbox-by-default — an agent bound to no volume has no disk access.
+# To restore the old single shared jail, add to your loomcycle.yaml:
+#   volumes:
+#     default: { path: /srv/loomcycle/scratch, mode: rw, default: true }
+
+# HTTP + WebFetch tools — comma-separated suffix-match host allowlist.
+# Entry "example.com" matches "example.com" and "api.example.com" but
+# not "evilexample.com". Private IPs (RFC1918, loopback, link-local incl.
+# 169.254.169.254) are HARD-blocked at connect regardless of allowlist.
+# Loopback aliases on the list (localhost, 127.0.0.1, ::1, *.localhost)
+# are silently stripped at startup — use LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST
+# below to permit specific loopback hosts.
+# LOOMCYCLE_HTTP_HOST_ALLOWLIST=api.anthropic.com,api.brave.com,linkedin.com
+
+# Private-host exception. Hosts here may resolve to private IPs at
+# dial time — used to permit agent callbacks to a localhost-bound
+# application API. Suffix-matched the same way as the main allowlist.
+# Each entry must ALSO be on LOOMCYCLE_HTTP_HOST_ALLOWLIST (or be
+# carried per-call when LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1) to be
+# reachable; this var only lifts the IP-private rejection.
+# LOOMCYCLE_HTTP_PRIVATE_HOST_ALLOWLIST=localhost,127.0.0.1
+
+# Caller-authoritative mode for HTTP/WebFetch host allowlist.
+# When unset (default): caller's per-request allowed_hosts can ONLY
+# narrow the operator's static list. Trust model: operator owns the
+# host policy; caller fine-tunes per-call.
+# When =1: caller's allowed_hosts is the SOLE policy. Operator's
+# static list becomes a fallback for runs that don't carry their own
+# list. Trust model: caller (the application server) owns the host
+# policy; operator's list is just a default. Use when the application
+# manages a dynamic list of allowed hosts that changes faster than
+# loomcycle restarts. IP-level guard at dial still applies.
+# LOOMCYCLE_HTTP_CALLER_AUTHORITATIVE=1
+
+# Bash tool — explicitly opt-in. NOT a true sandbox: cwd-restricted,
+# env-scrubbed (only PATH leaks), output-bounded (1 MiB), time-capped
+# (30s default, 5min max). Run loomcycle inside a container if you
+# expose Bash to untrusted prompts. Bash requires a rw `volumes:` binding
+# (it runs in the bound volume's root) — see the volumes note above.
+# LOOMCYCLE_BASH_ENABLED=1
+
+# ─── Bashbox — TRUE in-process sandbox (RFC AJ, v1.3.0) ──────────────
+#
+# An alternative to Bash: a real sandbox (the pure-Go `gbash` engine) that
+# spawns NO OS process, roots every path at the agent's mounted volume, and has
+# NO network. Unlike Bash it HONORS read-only volumes (writes hit an in-RAM
+# overlay, never the host). Opt-in, then grant per agent via
+# `allowed_tools: [Bashbox]`. gbash is alpha — the per-agent gate is the escape
+# hatch. Defaults OFF.
+# LOOMCYCLE_BASHBOX_ENABLED=1
+#
+# Host-command fallback (RFC AJ §13): an operator allowlist of commands gbash
+# does NOT implement (e.g. git, gh) that may ESCAPE the sandbox to the real host
+# shell. Empty (default) = no fallback; every command stays sandboxed. Only
+# these names reach the host; requires a rw volume. Comma-separated.
+# LOOMCYCLE_BASHBOX_FALLBACK_COMMANDS=git,gh
+#
+# Env vars injected ONLY into fallback (host) commands — never the sandbox
+# (PATH always passes). Reference NAMES here; the secret VALUES live in
+# .env.local. Comma-separated.
+# LOOMCYCLE_BASHBOX_FALLBACK_ALLOWED_ENV=GH_TOKEN,HOME,SSH_AUTH_SOCK
+
+# ─── Skills (v0.4.0+) ────────────────────────────────────────────────
+#
+# Directory holding `<name>/SKILL.md` skill files (Approach A in
+# doc-internal/skills-design.md). Each agent's `skills:` YAML field
+# names skills under this root; loomcycle parses the SKILL.md
+# frontmatter, validates `allowed-tools` is a subset of the bundling
+# agent's `allowed_tools`, and concatenates the body onto the agent's
+# system_prompt at config-load. The bundled body lands inside the
+# cacheable system block, so subsequent runs replay at cache-read
+# rates.
+#
+# When unset, agents may NOT list skills (config-load fails with a
+# named error rather than silently dropping the skill body). When set
+# but empty/missing, config-load reports the unreadable directory.
+#
+# Skill bodies count as operator-authored content and are trusted —
+# they're loaded with the same trust as inline `system_prompt:`. Do
+# not point this at a directory writable by untrusted users.
+# LOOMCYCLE_SKILLS_ROOT=/srv/loomcycle/skills
+
+# ─── Agent directory discovery (v0.8.x+) ─────────────────────────────
+#
+# Directory of flat `<name>.md` files. When set, loomcycle parses each
+# file's YAML frontmatter as the base AgentDef and the body (after the
+# closing `---`) as the system prompt. The yaml `agents:` map remains
+# OPTIONAL and acts as an override layer — yaml entries with the same
+# name override per-field. Operators get a single source of truth in
+# the MD with targeted per-environment tweaks in yaml when needed.
+#
+# Why: synchronising the yaml `agents:` block with the MDs referenced
+# from `system_prompt_file` is recurring operational pain (every
+# dev↔main branch divergence breaks loomcycle on the deploy box).
+#
+# Frontmatter contract — these top-level keys are read by loomcycle
+# (Claude Code ignores unknown keys, so the same MD drives both):
+#   name                  # string; must equal filename sans .md
+#   description           # string; informational
+#   tools                 # string "A, B, C" OR list [A, B, C]
+#   allowed_tools         # list — wins when both `tools` and this set
+#   provider              # string; e.g. anthropic / openai / deepseek
+#   model                 # string; alias or full model ID
+#   tier                  # one of low / middle / high
+#   models                # map<tier-name, [{provider, model}, ...]>
+#   effort                # one of low / medium / high
+#   max_tokens            # int; per-iteration output cap
+#   skills                # list of skill names (LOOMCYCLE_SKILLS_ROOT)
+#   memory_scopes         # list — subset of {agent, user}
+#   memory_quota_bytes    # int; per-agent override
+#   providers             # list — per-agent ProviderPriority override
+#   system_prompt_file    # string; alternative to body
+#
+# Validation rules (Pin XOR Tier, Effort domain, MemoryScopes domain,
+# etc.) run unchanged on the merged map. A typo'd key is silently
+# dropped to zero today — keep that in mind when an agent doesn't
+# behave as expected.
+#
+# LOOMCYCLE_AGENTS_ROOT=/srv/loomcycle/agents
+
+# ─── Help topics (v0.8.8+) ───────────────────────────────────────────
+#
+# Loomcycle ships a small bundled set of help topics embedded in the
+# binary (loomcycle, scopes, subagents, experimentation, system-channels).
+# These are returned by the Context.help op:
+#
+#   {"op": "help"}              # index — name + description per topic
+#   {"op": "help", "topic": "scopes"}  # full markdown body of one topic
+#
+# Operators MAY point LOOMCYCLE_HELP_ROOT at a directory of `<name>.md`
+# files. Files in that directory follow the same frontmatter format
+# (`name:` must match the filename stem; `description:` is the index
+# one-liner; everything after the closing `---` is the body). A
+# filesystem topic with a name matching a bundled topic OVERRIDES the
+# bundled one — useful for replacing default guidance with deployment-
+# specific docs without rebuilding the binary.
+#
+# Unset = "bundled only" deployment shape (today's default).
+#
+# LOOMCYCLE_HELP_ROOT=/srv/loomcycle/help
+
+# ─── Memory tool (v0.8.0+) ───────────────────────────────────────────
+#
+# The Memory tool exposes persistent agent-scoped key/value storage to
+# the model (get / set / delete / list / incr). Storage rides the
+# existing Store backend (sqlite default, postgres opt-in).
+#
+# Per-agent yaml gates which scopes an agent may use:
+#   memory_scopes: [agent, user]          # required; empty = no Memory
+#   memory_quota_bytes: 5_000_000         # optional override; 0 = use default
+#
+# Per-write cap on the value payload (set / incr). Default 64 KB
+# (65536). 0 disables. Refuses obvious abuse like "stash an entire
+# transcript in one row".
+# LOOMCYCLE_MEMORY_MAX_VALUE_BYTES=65536
+
+# Default per-(scope, scope_id) byte cap. Default 1 MB (1048576).
+# 0 disables. Per-agent yaml memory_quota_bytes overrides this.
+# LOOMCYCLE_MEMORY_MAX_SCOPE_BYTES=1048576
+
+# TTL reaper goroutine cadence — periodic DELETE of expired rows.
+# Default 15 minutes. 0 disables (operators with an external reaper,
+# or dev/test runs that don't want background work, can opt out).
+# Read paths filter expired entries even when the reaper is off, so
+# agents never see stale values regardless.
+# LOOMCYCLE_MEMORY_SWEEP_MS=900000
+
+# ─── SQL Memory (RFC AA, v1.2.0) — and the Document primitive ────────
+#
+# A per-scope SQL database the runtime hosts as a third Memory facet (agents
+# query arbitrary SQL via the Memory tool's sql_* ops). It also BACKS the
+# Document primitive (RFC AK) — the chunk-structure tables live here, so
+# **Documents and the Web UI Document viewer/assistant require this enabled.**
+# Default OFF.
+# LOOMCYCLE_SQLMEM_ENABLED=1
+#
+# Per-scope ACL is per-agent yaml: `sql_scopes: [agent, user]` (empty = no SQL).
+#
+# Where the per-scope sqlite files live (default <DataDir>/sqlmem). Postgres
+# tier: set the DSN in .env.local (LOOMCYCLE_SQLMEM_PG_DSN — it carries a
+# password, so it is a SECRET, not config).
+# LOOMCYCLE_SQLMEM_ROOT=./data/sqlmem
+#
+# Guardrails (defense-in-depth; the Go statement validator blocks
+# ATTACH/PRAGMA/load_extension regardless):
+# LOOMCYCLE_SQLMEM_MAX_ROWS=10000              # cap rows returned per query
+# LOOMCYCLE_SQLMEM_STATEMENT_TIMEOUT_MS=5000   # per-statement wall clock
+# LOOMCYCLE_SQLMEM_TXN_TIMEOUT_MS=30000        # open-transaction lifetime
+# LOOMCYCLE_SQLMEM_MAX_OPEN_TXNS=64            # concurrent open txns cap
+# LOOMCYCLE_SQLMEM_MAX_TXN_DEPTH=8             # nested savepoint depth
+# LOOMCYCLE_SQLMEM_QUOTA_BYTES=52428800        # default per-scope DB byte cap (per-agent sql_quota_bytes overrides)
+# LOOMCYCLE_SQLMEM_TOTAL_MAX_BYTES=0           # global cap across all scope DBs (0 = unbounded)
+# LOOMCYCLE_SQLMEM_SNAPSHOT_MAX_SCOPE_BYTES=0  # cap a scope DB included in a snapshot (0 = no cap)
+# LOOMCYCLE_SQLMEM_GC_INTERVAL_MS=900000       # idle-scope reaper cadence
+# LOOMCYCLE_SQLMEM_SCOPE_TTL_MS=0              # evict a scope DB idle this long (0 = never)
+# LOOMCYCLE_SQLMEM_AUDIT_MODE=0                # 1 = log every statement (verbose)
+# LOOMCYCLE_SQLMEM_SHARED_SCHEMAS=             # comma-separated shared-schema names (advanced)
+
+# ─── Vector Memory (semantic recall) ────────────────────────────────
+#
+# Memory op=recall does embedding-based semantic search. sqlite tier uses
+# sqlite-vec; postgres tier uses pgvector. The embedder API key (if a hosted
+# embedder) is a SECRET → .env.local.
+# LOOMCYCLE_PGVECTOR_ENABLED=1                 # use pgvector on the postgres backend
+# LOOMCYCLE_SQLITE_VEC_PATH=                   # path to the sqlite-vec extension (.so/.dylib), if not auto-found
+# LOOMCYCLE_MEMORY_EMBED_BATCH_SIZE=64         # embed batch size for bulk recall indexing
+# LOOMCYCLE_MEMORY_EMBED_TIMEOUT_MS=30000      # per-embed-call timeout
+
+# ─── Provider streaming timeouts (v0.8.x+) ──────────────────────────
+#
+# Replaced the old wall-clock `http.Client.Timeout = 5 min` with a
+# pair of finer-grained ceilings:
+#
+#   - HEADER_TIMEOUT: per-attempt cap on time-to-first-byte. Set on
+#     each provider driver's http.Transport.ResponseHeaderTimeout.
+#     Generous default (60 s) accommodates cold-start cloud endpoints
+#     and warming Ollama models without leaving a stalled pre-stream
+#     connection open forever. Bump if you see "stream read: context
+#     deadline exceeded" errors during the FIRST few seconds of a
+#     run (rare).
+#   - IDLE_TIMEOUT: max gap between body bytes during a streaming
+#     response. The driver wraps resp.Body and resets a timer on
+#     every Read; if the timer fires (no bytes for this long), the
+#     request context is cancelled. Default 90 s. Bump if you see
+#     mid-stream "context deadline exceeded" errors on long final
+#     turns where the model is provably still emitting (e.g. a
+#     reasoning model with extended thinking pauses).
+#
+# Operators on networks with high TLS handshake latency or aggressive
+# NAT idle timeouts may want to bump HEADER_TIMEOUT to 90 000 ms; the
+# defaults are tuned for direct internet egress.
+# LOOMCYCLE_PROVIDER_HEADER_TIMEOUT_MS=60000
+# LOOMCYCLE_PROVIDER_IDLE_TIMEOUT_MS=90000
+#
+# The `ollama-local` provider is the exception: local generation is slow on
+# first-token (cold model load from disk + prompt eval over a large num_ctx
+# can take minutes on a consumer GPU/CPU), so it uses its OWN, more generous
+# default pair — 600 s / 600 s — instead of the cloud-shaped 60/90 above.
+# These override only ollama-local; hosted ollama.com and every other cloud
+# provider keep the global Provider*Timeout. Bump these if a slow local model
+# still trips a header/idle timeout before producing its first token.
+# LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=600000
+# LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=600000
+
+# ─── Provider fallback semantics (v0.8.13+) ──────────────────────────
+#
+# Cross-provider runtime fallback (v0.8.2) climbs through the user_tier
+# candidate list on retryable errors. Mid-conversation fallback can
+# trip provider-specific transcript translation bugs (DeepSeek
+# reasoning_content, Anthropic cache_control, Gemini thoughtSignature,
+# tool_call shape differences). Each requires its own translation
+# layer; the surface area grows over time.
+#
+# When this flag is set to "1", fallback is SUPPRESSED after the run
+# has completed at least one successful turn. The initial turn can
+# still fall back (so a stale-probe initial pick doesn't kill the
+# run). Once the transcript has provider-specific state, the run
+# stays on its current provider. Same-provider rate-limit retry
+# (internal/providers/ratelimit/) still covers transient errors
+# within one provider.
+#
+# Trade: a sustained outage of a provider mid-conversation will fail
+# the run instead of cascading to a fallback. Acceptable for most
+# production deployments — provider outages are rare and clients
+# retry; mid-conversation translation bugs are subtle and silent.
+#
+# When fallback is suppressed, loomcycle emits the typed event
+# `fallback_suppressed` on the SSE wire so operators can attribute
+# the failure to the policy rather than the resolver.
+#
+# Default OFF in v0.8.x; default-on planned for v0.9.x once
+# production-validated. Recommended for any deployment running runs
+# with thinking-mode providers (DeepSeek reasoner family,
+# gemini-2.5-flash with effort hint).
+# LOOMCYCLE_FALLBACK_PIN_AFTER_SUCCESS=1
+
+# ─── Process-resource metrics sampler (v0.8.x+) ──────────────────────
+#
+# Built-in CPU + memory sampler that runs as a background goroutine
+# while at least one agent run is active and persists samples to a
+# new `process_samples` table for capacity-planning. Sleep-when-idle:
+# no DB writes, no /proc reads when nothing is running.
+#
+# Default OFF in v0.8.x — set =1 to enable. Default-on planned for
+# v0.9.x once production-validated.
+# LOOMCYCLE_METRICS_ENABLED=1
+#
+# Sample cadence in milliseconds. Default 5 s (5000). Values below
+# 1 s are clamped up to 1 s — prevents accidental write-storms from
+# a typo'd 50 vs 5000. Storage estimate at defaults: ~210 MB/week
+# for a continuously-active deployment (5 s × 86 400 × 7 ≈ 121 K
+# rows × ~250 bytes each).
+# LOOMCYCLE_METRICS_SAMPLE_INTERVAL_MS=5000
+#
+# Retention in days. Default 7. Set 0 to disable automatic cleanup
+# (table grows unbounded). Lower this on slow disks or
+# storage-constrained deployments.
+# LOOMCYCLE_METRICS_RETENTION_DAYS=7
+#
+# Optional: also read /proc/stat + /proc/meminfo for SYSTEM-wide
+# CPU% + memory (not just loomcycle's process). Linux only;
+# silently ignored on macOS/Windows. Useful when correlating
+# loomcycle's behaviour with host pressure (e.g. ZFS ARC eating
+# RAM in a TrueNAS-hosted VM).
+# LOOMCYCLE_METRICS_COLLECT_SYSTEM=1
+#
+# Sweeper cadence (cleanup goroutine) in milliseconds. Default
+# 15 min. Set 0 to disable. Bounded retention requires BOTH a
+# non-zero retention AND non-zero sweep interval.
+# LOOMCYCLE_METRICS_SWEEP_INTERVAL_MS=900000
+#
+# Public API (bearer-authed):
+#   GET /v1/_metrics/samples?since=<RFC3339>&until=<RFC3339>&limit=N
+#   GET /v1/_metrics/runs/{run_id}    — peak/mean RSS + max CPU%
+#                                       for samples in the run window
+#   GET /v1/_metrics/summary?period=1h|24h|7d
+#                                     — aggregated buckets
+
+# ─── LoomCycle MCP / dynamic agents (v0.8.15+) ───────────────────────
+#
+# v0.8.15 introduced the `loomcycle mcp --config Y` subcommand: an
+# alternate front-end that exposes MCP tools over stdio so
+# orchestrators like Claude Code can drive loomcycle directly. See
+# `loomcycle-mcp.sh` at the repo root for the wrapper script that
+# Claude Code's .mcp.json should reference (sources .env.insecure +
+# .env.local then execs the binary).
+#
+# Dynamically-registered agents may by default NOT request the
+# privileged builtins (Bash, Write, Edit) in their allowed_tools —
+# those are stripped silently from the request. Operator opts in by
+# setting this to 1, after which dynamic agents can request any
+# builtin the operator's yaml exposes. Mirrors the v0.8.7/v0.8.8
+# default-deny pattern for new tool surfaces.
+#
+# IMPORTANT: only flip on when the MCP client itself is trusted
+# (operator-launched stdio = trusted; remote HTTP MCP would not be).
+# LOOMCYCLE_MCP_ALLOW_PRIVILEGED_TOOLS=1
+#
+# By default the MCPServerDef substrate (POST /v1/_mcpserverdef) may
+# register only http / streamable-http servers; a `stdio` server runs an
+# ARBITRARY LOCAL COMMAND, so dynamic stdio registration is off by default
+# (a second local-exec path alongside the Bash tool). Set this to 1 to let
+# operators register stdio MCP servers at runtime with command/args/env.
+# Static yaml `mcp_servers:` stdio entries are always allowed regardless.
+# LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1
+#
+# F32 — secret redaction at rest. ON BY DEFAULT: tool I/O (tool_call inputs +
+# tool_result outputs) is scanned for secret-shaped substrings and masked
+# BEFORE it is persisted to the events store (and thus to snapshots + the
+# /v1/_events audit API), so a token inlined on a Bash cmdline or echoed by a
+# tool isn't written to disk in cleartext. The live SSE stream is NOT redacted
+# (the caller already holds the secret). Set to 0 to DISABLE redaction (e.g. to
+# debug a transcript locally). Note: this is defense-in-depth — agents should
+# still pass secrets out-of-band (env / stdin / credential helper), never inline.
+# LOOMCYCLE_REDACT_SECRETS=0
+#
+# Default TTL for agents registered via mcp__loomcycle__register_agent
+# when the caller omits ttl_seconds. Default 86400 (24 h). Set 0 to
+# require callers to ALWAYS supply an explicit ttl_seconds (no
+# default-TTL registrations accepted). Set -1 from the caller side
+# (NOT here) for "no expiry" — operator must explicitly unregister.
+# Lower this on shared-operator setups where forgotten dynamic
+# agents would accumulate.
+# LOOMCYCLE_DYNAMIC_AGENT_DEFAULT_TTL_SECONDS=86400
+#
+# Cadence for the dynamic_agents TTL sweeper, in milliseconds.
+# Default 15 min (900000). Set 0 to disable the sweeper — expired
+# rows linger in the table but DynamicAgentGet still filters them
+# at read time, so functional correctness is preserved (only
+# storage reclamation is forgone). Disabling makes sense at low
+# registration volume where the table never grows enough to matter.
+# LOOMCYCLE_DYNAMIC_AGENT_SWEEP_INTERVAL_MS=900000
+
+# ---- v0.8.17 Pause / Resume / Snapshot ---------------------------------
+# Runtime-wide quiesce + cross-version-portable JSON snapshot. Operators
+# drive via /v1/_pause / /v1/_resume / /v1/_state HTTP endpoints OR the
+# matching CLI subcommands (loomcycle pause / resume / state / snapshot
+# / snapshots list/export/delete / restore). Agents never call these
+# directly. The pause Manager is always constructed (cheap; one atomic
+# + one channel) — no env flag is needed to ENABLE the feature.
+#
+# Default wait-for-non-idempotent-tools cap when POST /v1/_pause omits
+# timeout_ms. Default 0 ⇒ pause.DefaultPauseTimeout (30 s). Clamped at
+# pause.MaxPauseTimeout (5 min) regardless of value — operator typo
+# (300000 vs 30000) won't leave the runtime in StatePausing for an
+# extended period during which new runs 503.
+# LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS=30000
+
+# ---- RFC H inbound webhooks --------------------------------------------
+# External systems (GitHub/Gitea/Stripe/Linear/CI/n8n) trigger agent runs
+# or wake parked agents via signed POST /v1/_webhooks/{name}. Off by
+# default; the WebhookDef tool still authors/lists defs while disabled.
+# LOOMCYCLE_WEBHOOKS_ENABLED=1
+#
+# Secret resolution: a webhook's signing_secret_env / bearer_token_env /
+# user_credentials_from_env env-var NAMES must be authorized, or every
+# delivery 503s `secret_unresolvable`. (The NAMES are config and live
+# here; the secret VALUES live in .env.local.) A name is authorized
+# when ANY of:
+#   1. it is LOOMCYCLE_*-prefixed (or a known third-party name) — auto-
+#      allowed for the VERIFY secret only (consumed by the receiver, never
+#      reaches the agent). So signing_secret_env: LOOMCYCLE_X Just Works.
+#   2. it is declared by a STATIC (yaml) webhook — auto-trusted.
+#   3. it is listed here (comma-separated) or in the scheduler's shared
+#      LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST. REQUIRED for a runtime
+#      (webhookdef-tool) def's non-LOOMCYCLE_ credential env names — those
+#      do NOT get the namespace auto-allow (they reach the agent).
+# LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST=GITEA_WEBHOOK_SECRET,STRIPE_WH_SECRET
+#
+# Trusted-network ingress: honor `auth.kind: none` (skip HMAC) for a
+# receiver only reachable over an already-authenticated transport
+# (WireGuard/tailnet, mTLS). Default OFF — a none-auth webhook 503s
+# `unauthenticated_mode_disabled` until this is set.
+# LOOMCYCLE_WEBHOOKS_ALLOW_UNAUTHENTICATED=1
+#
+# Shared trigger-credential allowlist (also gates scheduled-run
+# user_credentials_from_env). Merged with LOOMCYCLE_WEBHOOKS_ENV_ALLOWLIST.
+# LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST=GITEA_API_TOKEN
+
+# ═══════════════════════════════════════════════════════════════════════
+#  Additional subsystems (all default-OFF or sensibly-defaulted; set only
+#  what you need). Secret VALUES (DSNs, signing keys, the token pepper,
+#  provider API keys, bearer tokens) always live in .env.local — only their
+#  non-secret toggles/NAMES belong here.
+# ═══════════════════════════════════════════════════════════════════════
+
+# ─── gRPC transport ──────────────────────────────────────────────────
+# Second wire surface alongside HTTP+SSE. Unset = gRPC server off.
+# LOOMCYCLE_GRPC_ADDR=127.0.0.1:8788
+
+# ─── Storage backend / Postgres (RFC I) ──────────────────────────────
+# Default sqlite (file under LOOMCYCLE_DATA_DIR). Set to postgres for the
+# production backend; the DSN itself is a SECRET → .env.local
+# (LOOMCYCLE_PG_DSN). Same for the SQL Memory PG DSN (LOOMCYCLE_SQLMEM_PG_DSN).
+# LOOMCYCLE_STORAGE_BACKEND=postgres
+# LOOMCYCLE_PG_AUTOMIGRATE=1            # run schema migrations on boot
+# LOOMCYCLE_PG_MAX_OPEN_CONNS=20
+# LOOMCYCLE_PG_MIN_IDLE_CONNS=2
+
+# ─── Scheduler (RFC E) ───────────────────────────────────────────────
+# Fires ScheduleDef cron/at runs. Off by default; the ScheduleDef tool still
+# authors/lists schedules while disabled. (Trigger-credential allowlist is
+# LOOMCYCLE_SCHEDULER_ENV_ALLOWLIST, above.)
+# LOOMCYCLE_SCHEDULER_ENABLED=1
+# LOOMCYCLE_SCHEDULER_TICK_SECONDS=10          # poll cadence for due schedules
+# LOOMCYCLE_SCHEDULER_FIRE_TIMEOUT_SECONDS=300 # per-fire run cap
+
+# ─── A2A — agent-to-agent interop (RFC G) ────────────────────────────
+# Inbound A2A server + outbound client. Off by default. The signing key is a
+# SECRET → .env.local (LOOMCYCLE_A2A_SIGNING_KEY).
+# LOOMCYCLE_A2A_ENABLED=1
+# LOOMCYCLE_A2A_PUBLIC_BASE_URL=https://agents.example.com  # advertised in the server card
+# LOOMCYCLE_A2A_SERVER_CARD=/srv/loomcycle/a2a-card.json    # optional static card override
+# LOOMCYCLE_A2A_TENANCY_ROUTING=1                           # route inbound by tenant
+
+# ─── Channel tool tuning (RFC S) ─────────────────────────────────────
+# Fan-in/out bus for ensemble coordination. The `channels:` yaml block declares
+# targets; these tune the runtime.
+# LOOMCYCLE_CHANNELS_SWEEP_MS=900000           # expired-message reaper cadence
+# LOOMCYCLE_CHANNELS_MAX_VALUE_BYTES=65536     # per-message payload cap
+# LOOMCYCLE_CHANNELS_LONGPOLL_CAP_MS=30000     # max Channel.await long-poll wait
+# LOOMCYCLE_CHANNELS_MAX_PENDING_DEFERRED=1000 # cap on parked await-ers
+
+# ─── Interruption (human-in-the-loop) ───────────────────────────────
+# Mirrors the yaml `interruption:` block (which takes precedence). Env defaults
+# when the yaml block is absent.
+# LOOMCYCLE_INTERRUPTION_DEFAULT_TIMEOUT_MS=3600000   # 1h
+# LOOMCYCLE_INTERRUPTION_MAX_TIMEOUT_MS=86400000      # 24h hard ceiling
+# LOOMCYCLE_INTERRUPTION_MAX_PENDING_PER_RUN=10
+# LOOMCYCLE_INTERRUPTION_HEARTBEAT_INTERVAL_MS=30000
+
+# ─── Pause / Resume / Snapshot (RFC X) extras ────────────────────────
+# (LOOMCYCLE_PAUSE_DEFAULT_TIMEOUT_MS is documented above.)
+# LOOMCYCLE_PAUSE_CACHE_TTL_MS=1000            # cross-replica pause-state cache TTL
+# LOOMCYCLE_SNAPSHOT_MAX_BYTES=0               # cap an exported snapshot (0 = unbounded)
+# RFC X Phase 3 — resume a fan-out PARENT mid-parallel_spawn on restore. Default
+# OFF (pause/snapshot/resume stays byte-identical until opt-in).
+# LOOMCYCLE_RESUME_FANOUT=1
+
+# ─── Multi-replica / HA (v0.9.x) ─────────────────────────────────────
+# Cross-replica cancel + pause + session locks. The Redis bus URL is REDIS_URL
+# (no LOOMCYCLE_ prefix); if it carries a password it is a SECRET → .env.local.
+# LOOMCYCLE_REPLICA_ID=replica-a              # stable id (default: hostname)
+# LOOMCYCLE_REPLICAS_STALE_AFTER_MS=60000     # mark a replica dead after silence
+# LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS=900000
+# LOOMCYCLE_HEARTBEAT_SWEEP_INTERVAL_MS=60000 # run-heartbeat sweeper cadence
+# LOOMCYCLE_HEARTBEAT_STALE_MS=600000         # reap a run with no heartbeat this long
+# LOOMCYCLE_SESSION_LOCK_GC_INTERVAL_MS=300000
+# LOOMCYCLE_SESSION_LOCK_MAX_IDLE_MS=600000
+# LOOMCYCLE_CANCEL_ACK_TIMEOUT_MS=5000        # wait for the owning replica to ack a cancel
+# LOOMCYCLE_RESOLVE_PROBE_INTERVAL_MS=900000  # provider reachability re-probe cadence
+
+# ─── OpenTelemetry (traces) ──────────────────────────────────────────
+# An OTLP endpoint enables tracing. Auth headers may carry a SECRET → put
+# LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS in .env.local if so.
+# LOOMCYCLE_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# LOOMCYCLE_OTEL_SERVICE_NAME=loomcycle
+# LOOMCYCLE_OTEL_TRACES_SAMPLER_RATIO=1.0     # 0.0–1.0 sample fraction
+
+# ─── Auth tuning (RFC L; the AUTH_TOKEN + token pepper are SECRETS) ──
+# LOOMCYCLE_AUTH_CACHE_TTL_SECONDS=60                 # operator-token lookup cache TTL
+# LOOMCYCLE_OPERATOR_TOKEN_ROTATION_GRACE_SECONDS=300 # accept a rotated-out token this long
+# LOOMCYCLE_AUTH_VERBOSE=1                             # log auth decisions (debug)
+
+# ─── MCP tuning ──────────────────────────────────────────────────────
+# (MCP_ALLOW_PRIVILEGED_TOOLS / MCP_ALLOW_DYNAMIC_STDIO are documented above;
+# the upstream bearer LOOMCYCLE_MCP_UPSTREAM_TOKEN is a SECRET → .env.local.)
+# LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS=16        # cap concurrent stdio-dispatch calls
+# LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS=0         # per spawn_run cap over MCP (0 = none)
+# LOOMCYCLE_MCP_RECIPES_ROOT=/srv/loomcycle/recipes  # optional MCP recipe dir
+
+# ─── Substrate def size caps ─────────────────────────────────────────
+# LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES=131072
+# LOOMCYCLE_AGENT_DEF_MAX_DESCRIPTION_BYTES=4096
+# LOOMCYCLE_AGENT_DEF_MAX_CODE_BYTES=262144    # code-js agent source cap
+# LOOMCYCLE_SKILL_DEF_MAX_BODY_BYTES=131072
+# LOOMCYCLE_SKILL_DEF_MAX_DESCRIPTION_BYTES=4096
+# LOOMCYCLE_EVALUATION_MAX_JUDGEMENT_BYTES=8192
+# LOOMCYCLE_EVALUATION_MAX_RATIONALE_BYTES=8192
+
+# ─── Concurrency / runtime knobs ─────────────────────────────────────
+# (Cluster-wide limits also live in the yaml `concurrency:` block.)
+# LOOMCYCLE_MAX_CONCURRENT_RUNS_PER_USER=0     # per-user admission cap (0 = unlimited)
+# LOOMCYCLE_TOOL_PARALLELISM=8                 # max parallel tool calls per iteration
+# LOOMCYCLE_SSE_KEEPALIVE_MS=15000             # SSE comment-ping cadence (proxy keep-alive)
+# LOOMCYCLE_EPHEMERAL_VOLUME_SWEEP_MS=900000   # run-scoped ephemeral-volume reaper cadence
+
+# ─── code-js provider (RFC J) — synthetic, deterministic, zero-cost ──
+# A goja-backed provider for stateless replay agents (load tests, deterministic
+# pipelines). Off by default.
+# LOOMCYCLE_CODE_AGENTS_ENABLED=1
+# LOOMCYCLE_CODE_AGENTS_ROOT=/srv/loomcycle/code-agents   # dir of <name>.js agents
+# LOOMCYCLE_CODE_AGENTS_DETERMINISTIC=1                   # pin Date/random for replay
+# LOOMCYCLE_CODE_AGENTS_RUN_TIMEOUT_SECONDS=30
+
+# ─── mock provider (cost-free load tests) ────────────────────────────
+# Canned responses with tunable latency/error injection — never hits a real API.
+# LOOMCYCLE_MOCK_ENABLED=1
+# LOOMCYCLE_MOCK_LATENCY_MS=200
+# LOOMCYCLE_MOCK_LATENCY_JITTER_MS=50
+# LOOMCYCLE_MOCK_429_RATE=0.0          # fraction of calls returning 429 (rate-limit)
+# LOOMCYCLE_MOCK_500_RATE=0.0          # fraction returning 500
+
+# ─── Anthropic OAuth (subscription) — RESEARCH/DEV ONLY ──────────────
+# Reverse-engineered subscription billing (see docs/PROVIDERS.md + the
+# bundles/document-agent/loomcycle_oauth.yaml variant). Opt-in flag here; tokens
+# persist at ~/.config/loomcycle/anthropic-oauth.json after `loomcycle anthropic
+# login`. Off by default → the `anthropic-oauth-dev` provider is absent.
+# LOOMCYCLE_ANTHROPIC_OAUTH_DEV_ENABLED=1
+# LOOMCYCLE_ANTHROPIC_OAUTH_CALLBACK_PORT=8788  # local browser-login callback port
+
+# ─── Hooks (RFC AF) ──────────────────────────────────────────────────
+# Tenant owners permitted to widen the host allowlist from a tool-use hook.
+# LOOMCYCLE_HOOKS_PERMIT_HOST_WIDEN_OWNERS=tenant-a,tenant-b
+
+# ─── Audit ───────────────────────────────────────────────────────────
+# Optional path for a structured audit log (in addition to the events store).
+# LOOMCYCLE_AUDIT_LOG_PATH=/var/log/loomcycle/audit.log

--- a/cmd/loomcycle/embedded/env.insecure.example
+++ b/cmd/loomcycle/embedded/env.insecure.example
@@ -291,12 +291,12 @@ LOOMCYCLE_DATA_DIR=./data
 # The `ollama-local` provider is the exception: local generation is slow on
 # first-token (cold model load from disk + prompt eval over a large num_ctx
 # can take minutes on a consumer GPU/CPU), so it uses its OWN, more generous
-# default pair — 300 s / 300 s — instead of the cloud-shaped 60/90 above.
+# default pair — 600 s / 600 s — instead of the cloud-shaped 60/90 above.
 # These override only ollama-local; hosted ollama.com and every other cloud
 # provider keep the global Provider*Timeout. Bump these if a slow local model
 # still trips a header/idle timeout before producing its first token.
-# LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=300000
-# LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=300000
+# LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS=600000
+# LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS=600000
 
 # ─── Provider fallback semantics (v0.8.13+) ──────────────────────────
 #

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3469,17 +3469,25 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		}
 	}
 
-	// Local Ollama gets a more generous default than the cloud providers:
-	// a cold model load + large-context prompt eval can take minutes to
-	// first token. Scoped to the ollama-local registration; see the field
-	// docs on Env.OllamaLocalHeaderTimeout.
-	cfg.Env.OllamaLocalHeaderTimeout = 300 * time.Second
+	// Local Ollama gets a MUCH more generous default than the cloud providers:
+	// a cold model load + large-context prompt eval genuinely takes minutes to
+	// first token — a 27B-class model at a 128K num_ctx on non-datacenter
+	// hardware routinely exceeds 5 min just to LOAD (Ollama sends no response
+	// headers until the model is resident + generation starts, so the header
+	// timeout covers LOAD time). The old 300s default surfaced as "net/http:
+	// timeout awaiting response headers" on exactly that setup — loomcycle
+	// giving up before a healthy local model had answered. 600s (10 min) is a
+	// realistic patient default; still bounded so a genuinely dead server fails
+	// over. A very large model / slow box raises
+	// LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS further. Scoped to the
+	// ollama-local registration; see the field docs on Env.OllamaLocalHeaderTimeout.
+	cfg.Env.OllamaLocalHeaderTimeout = 600 * time.Second
 	if v := os.Getenv("LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.OllamaLocalHeaderTimeout = time.Duration(n) * time.Millisecond
 		}
 	}
-	cfg.Env.OllamaLocalIdleTimeout = 300 * time.Second
+	cfg.Env.OllamaLocalIdleTimeout = 600 * time.Second
 	if v := os.Getenv("LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.OllamaLocalIdleTimeout = time.Duration(n) * time.Millisecond

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -916,10 +916,11 @@ agents:
 	}
 }
 
-// ollama-local gets a generous 300s/300s default timeout pair (cold local
-// model load + large-context eval is slow), distinct from the cloud-shaped
-// 60s/90s global default; the LOOMCYCLE_OLLAMA_LOCAL_* env vars override it
-// and the global Provider*Timeout is untouched.
+// ollama-local gets a generous 600s/600s default timeout pair (cold local
+// model load + large-context eval is slow — a 128K-ctx model can exceed 5 min
+// just to load), distinct from the cloud-shaped 60s/90s global default; the
+// LOOMCYCLE_OLLAMA_LOCAL_* env vars override it and the global Provider*Timeout
+// is untouched.
 func TestOllamaLocalTimeouts_DefaultsAndOverrides(t *testing.T) {
 	tmp := t.TempDir()
 	yamlPath := filepath.Join(tmp, "c.yaml")
@@ -933,25 +934,27 @@ agents:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Env.OllamaLocalHeaderTimeout != 300*time.Second {
-		t.Errorf("default header = %v, want 300s", cfg.Env.OllamaLocalHeaderTimeout)
+	if cfg.Env.OllamaLocalHeaderTimeout != 600*time.Second {
+		t.Errorf("default header = %v, want 600s (raised from 300s — cold 128K-ctx local models exceed 5 min to load)", cfg.Env.OllamaLocalHeaderTimeout)
 	}
-	if cfg.Env.OllamaLocalIdleTimeout != 300*time.Second {
-		t.Errorf("default idle = %v, want 300s", cfg.Env.OllamaLocalIdleTimeout)
+	if cfg.Env.OllamaLocalIdleTimeout != 600*time.Second {
+		t.Errorf("default idle = %v, want 600s", cfg.Env.OllamaLocalIdleTimeout)
 	}
 	// The local timeouts must NOT perturb the global cloud defaults.
 	if cfg.Env.ProviderHeaderTimeout != 60*time.Second {
 		t.Errorf("global header default perturbed: %v, want 60s", cfg.Env.ProviderHeaderTimeout)
 	}
 
-	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS", "600000")
+	// Override with values distinct from the 600s default so the test proves
+	// the env actually takes effect (a slow box raising past the default).
+	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS", "900000")
 	t.Setenv("LOOMCYCLE_OLLAMA_LOCAL_IDLE_TIMEOUT_MS", "450000")
 	cfg, err = Load(yamlPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Env.OllamaLocalHeaderTimeout != 600*time.Second {
-		t.Errorf("override header = %v, want 600s", cfg.Env.OllamaLocalHeaderTimeout)
+	if cfg.Env.OllamaLocalHeaderTimeout != 900*time.Second {
+		t.Errorf("override header = %v, want 900s", cfg.Env.OllamaLocalHeaderTimeout)
 	}
 	if cfg.Env.OllamaLocalIdleTimeout != 450*time.Second {
 		t.Errorf("override idle = %v, want 450s", cfg.Env.OllamaLocalIdleTimeout)


### PR DESCRIPTION
## Why

Reported from the JobEmber VM: a `company-researcher` run failed with
```
Post http://…:11434/api/chat: net/http: timeout awaiting response headers
```
loomcycle giving up on a **healthy** local model before it answered — "not patient enough with local models."

**Cause:** the ollama-local header timeout (time-to-first-response-header) defaulted to **300s**, but Ollama sends **no** response headers until the model is resident and generation starts — so the header timeout covers cold-**load** time. A 27B-class model at `num_ctx=131072` (128K, which the VM runs) routinely exceeds 5 min just to load on non-datacenter hardware. 300s was too impatient for exactly the large-context local setup these knobs exist for.

## What

Raise the ollama-local default **header and idle** timeouts **300s → 600s** (10 min) — a realistic patient default, still bounded so a genuinely dead server fails over. Scoped to `ollama-local`; the cloud `Provider*Timeout` (60s/90s) is untouched. Operators with a bigger model / slower box raise `LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS` further (example-env docs updated).

## What was tested

`TestOllamaLocalTimeouts_DefaultsAndOverrides` — the default now asserts **600s** (fails on the pre-fix 300s); the override test uses 900s to prove the env knob still takes effect above the default. `go build` clean.

## Note for the VM
600s is a better default, but a 128K cold-load on that specific box may still exceed it — recommend setting `LOOMCYCLE_OLLAMA_LOCAL_HEADER_TIMEOUT_MS` higher there (e.g. 900000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)