### PR TITLE
fix(mcp): thin client self-recovers from dropped upstream connections

### DIFF
--- a/.env.insecure.example
+++ b/.env.insecure.example
@@ -564,6 +564,11 @@ LOOMCYCLE_DATA_DIR=./data
 # LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS=16        # cap concurrent stdio-dispatch calls
 # LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS=0         # per spawn_run cap over MCP (0 = none)
 # LOOMCYCLE_MCP_RECIPES_ROOT=/srv/loomcycle/recipes  # optional MCP recipe dir
+# Thin-client (`loomcycle mcp --upstream`) connection self-recovery. Defaults
+# heal an idle-dropped connection + a server restart transparently; tune only
+# for a slow-to-restart upstream or a flaky link.
+# LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS=60000    # max wait for response headers (stall guard)
+# LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS=5       # reconnect tries after a transport error (0 = off)
 
 # ─── Substrate def size caps ─────────────────────────────────────────
 # LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES=131072

--- a/cmd/loomcycle/embedded/env.insecure.example
+++ b/cmd/loomcycle/embedded/env.insecure.example
@@ -564,6 +564,11 @@ LOOMCYCLE_DATA_DIR=./data
 # LOOMCYCLE_MCP_MAX_CONCURRENT_CALLS=16        # cap concurrent stdio-dispatch calls
 # LOOMCYCLE_MCP_SPAWN_RUN_TIMEOUT_MS=0         # per spawn_run cap over MCP (0 = none)
 # LOOMCYCLE_MCP_RECIPES_ROOT=/srv/loomcycle/recipes  # optional MCP recipe dir
+# Thin-client (`loomcycle mcp --upstream`) connection self-recovery. Defaults
+# heal an idle-dropped connection + a server restart transparently; tune only
+# for a slow-to-restart upstream or a flaky link.
+# LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS=60000    # max wait for response headers (stall guard)
+# LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS=5       # reconnect tries after a transport error (0 = off)
 
 # ─── Substrate def size caps ─────────────────────────────────────────
 # LOOMCYCLE_AGENT_DEF_MAX_DEFINITION_BYTES=131072

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -240,6 +240,47 @@ func printVersion() {
 		buildVersion, buildCommit, buildTime, runtime.Version())
 }
 
+// mcpProxyHeaderTimeout reads LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS (the
+// thin-client's time-to-response-headers bound; a stalled upstream must not
+// hang a frame forever, and Claude Code's tool-idle timeout doesn't cover stdio
+// servers). Unset / invalid → 0, letting NewProxyClient apply its default.
+func mcpProxyHeaderTimeout() time.Duration {
+	v := os.Getenv("LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS")
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return time.Duration(n) * time.Millisecond
+}
+
+// mcpProxyReconnectDelays reads LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS and
+// builds the thin-client's transport-error backoff schedule: an immediate first
+// retry, then geometric waits (500ms doubling) capped at 4s. Unset → nil, so
+// NewProxyClient applies its default schedule; 0 → an empty schedule (retry
+// disabled — one attempt only).
+func mcpProxyReconnectDelays() []time.Duration {
+	v := os.Getenv("LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS")
+	if v == "" {
+		return nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return nil
+	}
+	delays := make([]time.Duration, n)
+	for i := 1; i < n; i++ {
+		d := 500 * time.Millisecond * (1 << (i - 1))
+		if d > 4*time.Second {
+			d = 4 * time.Second
+		}
+		delays[i] = d
+	}
+	return delays
+}
+
 // selectPresetNames resolves the RFC AQ embedded-preset selection: --preset
 // flags, if any, override LOOMCYCLE_PRESETS (comma-separated, ordered). Empty /
 // unset → no presets (opt-in default — exactly today's behaviour). Order is
@@ -472,6 +513,11 @@ func main() {
 			Upstream: *upstream,
 			Token:    os.Getenv("LOOMCYCLE_MCP_UPSTREAM_TOKEN"),
 			Logf:     log.Printf, // stderr; never stdout (stdout is the JSON-RPC wire)
+			// Self-recovery knobs (defaults applied by NewProxyClient when unset).
+			// The thin client boots with NO config load, so these are read straight
+			// from the environment.
+			ResponseHeaderTimeout: mcpProxyHeaderTimeout(),
+			ReconnectDelays:       mcpProxyReconnectDelays(),
 		})
 		log.Printf("mcp: thin-client mode → upstream %s (no local runtime)", *upstream)
 		err := pc.Serve(proxyCtx, os.Stdin, os.Stdout)

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -21,9 +21,24 @@ The most common consumer is Claude Code: you can ask Claude to "spawn a `qa-agen
 So there's exactly **one** authoritative runtime per state, and `loomcycle mcp` runs one of two ways:
 
 - **embedded** — `loomcycle mcp --config loomcycle.yaml`. One process that is *both* the runtime and the MCP server. A single process → a single bus → the cross-process problem can't arise. Use this when the MCP server *is* your loomcycle (a laptop, a dev box).
-- **thin client** — `loomcycle mcp --upstream http://127.0.0.1:8788` (bearer via `LOOMCYCLE_MCP_UPSTREAM_TOKEN`). Runs as a stdio↔`/v1/_mcp` proxy to an **already-running** runtime and boots **no runtime of its own**. Every call — including `interruption_resolve` — lands on the runtime that owns the run, so it wakes correctly. This is the supported way to add an MCP surface next to a running server or a multi-replica cluster (point `--upstream` at any replica or the load balancer). The proxy returns a clean JSON-RPC error (never hangs) if the upstream is unreachable or drops a stream.
+- **thin client** — `loomcycle mcp --upstream http://127.0.0.1:8788` (bearer via `LOOMCYCLE_MCP_UPSTREAM_TOKEN`). Runs as a stdio↔`/v1/_mcp` proxy to an **already-running** runtime and boots **no runtime of its own**. Every call — including `interruption_resolve` — lands on the runtime that owns the run, so it wakes correctly. This is the supported way to add an MCP surface next to a running server or a multi-replica cluster (point `--upstream` at any replica or the load balancer). The proxy returns a clean JSON-RPC error (never hangs) only after self-recovery is exhausted.
 
 > **`--no-http` was removed (v0.23.0).** It only muted the listener while still booting a *full second runtime* — the anti-pattern this whole section replaces. Use `--upstream` (thin client) to add an MCP surface next to a runtime, or plain `loomcycle mcp` for a standalone single-host runtime.
+
+### Connection self-recovery
+
+Claude Code (and MCP hosts generally) **never auto-reconnect a stdio server** — if the proxy surfaces a recoverable fault, you'd have to reload plugins / relaunch. So the proxy owns 100% of recovery and transparently heals the connection so tools keep working across:
+
+- **an idle-reaped keep-alive socket** (the "connection lost a few minutes after the last tool call" symptom — the runtime's HTTP server closes idle connections after 120s). The proxy uses a sub-120s `IdleConnTimeout` so it reopens *before* the server closes, and retries on a fresh connection if one still goes stale.
+- **an upstream restart** — a connection refused/reset during the restart window is retried with bounded backoff, and the invalidated session is re-handshaked (replay `initialize` → fresh `Mcp-Session-Id`) then the frame is retried. All single-flighted; the client never sees it.
+- **a stalled upstream** — a `ResponseHeaderTimeout` bounds the wait for response *headers* (a streaming `spawn_run` still holds its body open for the whole run) so a hung upstream can't wedge a frame forever.
+
+Tunable via env (sensible defaults; unset = default):
+
+| Env var | Default | Effect |
+|---|---|---|
+| `LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS` | `60000` | Max wait for the upstream's response headers before treating the frame as a transport error. |
+| `LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS` | `5` | Number of reconnect attempts after a transport error (immediate, then 500ms → 1s → 2s → 4s backoff). `0` disables retry. |
 
 `loomcycle doctor` WARNs (it doesn't FAIL) when the configured listen address is already in use — that usually means a runtime already owns this state; add an MCP surface with `--upstream`, don't start a second runtime.
 

--- a/internal/api/mcp/proxy.go
+++ b/internal/api/mcp/proxy.go
@@ -24,9 +24,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	loommcp "github.com/denn-gubsky/loomcycle/internal/tools/mcp"
 )
@@ -43,8 +45,28 @@ type ProxyConfig struct {
 	Logf func(format string, v ...any)
 	// Client overrides the HTTP client. nil → a default with no overall
 	// timeout (a streaming spawn_run holds the response open for the
-	// whole run; an overall timeout would truncate it).
+	// whole run; an overall timeout would truncate it) but WITH a
+	// ResponseHeaderTimeout and a sub-server-idle IdleConnTimeout (see below).
 	Client *http.Client
+	// ReconnectDelays is the backoff schedule for re-establishing a dropped
+	// upstream connection after a transport error (an idle-reaped keep-alive
+	// socket, or a brief server restart). Each entry is slept before the next
+	// reconnect attempt; the first (index 0) is normally 0 for an immediate
+	// retry. nil → a sensible default; a non-nil empty slice disables retry
+	// (one attempt only — used by tests asserting fast failure).
+	ReconnectDelays []time.Duration
+	// ResponseHeaderTimeout bounds the wait for the upstream's response
+	// HEADERS (not the streaming body — safe for a long spawn_run, whose
+	// headers arrive immediately). Applied only when Client is nil. 0 → a
+	// 60s default; use a large value to effectively disable.
+	ResponseHeaderTimeout time.Duration
+	// IdleConnTimeout closes pooled idle connections after this long. Applied
+	// only when Client is nil. 0 → a 90s default, deliberately below the
+	// runtime HTTP server's 120s IdleTimeout so the client reopens BEFORE the
+	// server closes an idle keep-alive socket (which otherwise surfaces as a
+	// transport error on the next call — the "drops a few minutes after last
+	// use" symptom).
+	IdleConnTimeout time.Duration
 }
 
 // ProxyClient is the thin-client MCP transport. Construct via
@@ -52,7 +74,18 @@ type ProxyConfig struct {
 type ProxyClient struct {
 	cfg    ProxyConfig
 	mcpURL string
-	client *http.Client
+	// client carries the ResponseHeaderTimeout — used for fast frames whose
+	// headers arrive promptly. streamClient has NO header timeout — used for
+	// agent-run / LLM tools (see longRunTools) whose response headers can
+	// legitimately arrive minutes late; a header-timeout retry there would
+	// DOUBLE-EXECUTE the run. When ProxyConfig.Client is set both point at it.
+	client       *http.Client
+	streamClient *http.Client
+
+	// reconnectDelays is the resolved transport-error backoff schedule (from
+	// cfg.ReconnectDelays or the default). Its length bounds the number of
+	// reconnect retries before a transport failure is surfaced to the client.
+	reconnectDelays []time.Duration
 
 	// writeMu serialises stdout writes so concurrent forwards (and the
 	// SSE frames of a streaming spawn_run) can't interleave bytes.
@@ -84,22 +117,83 @@ const mcpSessionExpiredCode = -32001
 // replayed after a re-handshake to mark the fresh session initialized.
 var initializedNotification = []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
 
+// defaultReconnectDelays is the transport-error backoff schedule when the
+// caller supplies none: an immediate retry (handles an idle-reaped socket
+// while the server is up), then growing waits that ride out a brief server
+// restart. Capped so a truly-dead upstream still surfaces an error in ~7.5s.
+var defaultReconnectDelays = []time.Duration{0, 500 * time.Millisecond, time.Second, 2 * time.Second, 4 * time.Second}
+
+const (
+	defaultResponseHeaderTimeout = 60 * time.Second
+	// Below the runtime HTTP server's 120s IdleTimeout — reopen before it closes.
+	defaultIdleConnTimeout = 90 * time.Second
+)
+
+// longRunTools are MCP tools whose upstream response can legitimately take
+// minutes — an agent run or an LLM call — so the thin client MUST NOT impose a
+// ResponseHeaderTimeout on them: a spawn_run without runEvents is single-shot
+// JSON whose headers arrive only after the WHOLE run completes, and even a
+// runEvents stream's first frame waits on the model. A header-timeout error
+// triggers a reconnect retry (forward), and re-POSTing an in-flight spawn_run /
+// compaction / evaluation would DOUBLE-EXECUTE it. Extend this set when adding
+// an MCP tool that runs an agent or calls a model.
+var longRunTools = map[string]bool{
+	"spawn_run":   true,
+	"spawn_runs":  true,
+	"compact_run": true,
+	"evaluation":  true,
+}
+
+// newProxyTransport builds the thin client's HTTP transport. headerTimeout=0
+// disables the ResponseHeaderTimeout (for the long-run client). idleTimeout
+// closes pooled idle connections before the server severs them.
+func newProxyTransport(idleTimeout, headerTimeout time.Duration) *http.Transport {
+	return &http.Transport{
+		Proxy:                 http.ProxyFromEnvironment,
+		DialContext:           (&net.Dialer{Timeout: 10 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       idleTimeout,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: headerTimeout, // 0 → none (long-run tools)
+	}
+}
+
 // NewProxyClient builds a thin-client proxy targeting Upstream.
 func NewProxyClient(cfg ProxyConfig) *ProxyClient {
 	if cfg.Logf == nil {
 		cfg.Logf = defaultLogf
 	}
-	client := cfg.Client
-	if client == nil {
-		// No overall timeout: streaming spawn_run holds the response
-		// open for the run's duration. Per-request cancellation rides
-		// the request context instead.
-		client = &http.Client{}
+	client, streamClient := cfg.Client, cfg.Client
+	if cfg.Client == nil {
+		hdrTimeout := cfg.ResponseHeaderTimeout
+		if hdrTimeout == 0 {
+			hdrTimeout = defaultResponseHeaderTimeout
+		}
+		idleTimeout := cfg.IdleConnTimeout
+		if idleTimeout == 0 {
+			idleTimeout = defaultIdleConnTimeout
+		}
+		// Neither client has an overall timeout: a streaming spawn_run holds
+		// the response BODY open for the whole run. ResponseHeaderTimeout (on
+		// `client` only) bounds the wait for response HEADERS on FAST frames, so
+		// a stalled upstream can't hang such a frame forever — Claude Code's own
+		// tool-idle timeout does NOT apply to stdio servers, so nothing else
+		// bounds it. Per-request cancellation rides the request context.
+		client = &http.Client{Transport: newProxyTransport(idleTimeout, hdrTimeout)}
+		streamClient = &http.Client{Transport: newProxyTransport(idleTimeout, 0)}
+	}
+	delays := cfg.ReconnectDelays
+	if delays == nil {
+		delays = defaultReconnectDelays
 	}
 	return &ProxyClient{
-		cfg:    cfg,
-		mcpURL: strings.TrimRight(cfg.Upstream, "/") + "/v1/_mcp",
-		client: client,
+		cfg:             cfg,
+		mcpURL:          strings.TrimRight(cfg.Upstream, "/") + "/v1/_mcp",
+		client:          client,
+		streamClient:    streamClient,
+		reconnectDelays: delays,
 	}
 }
 
@@ -135,14 +229,14 @@ func (p *ProxyClient) Serve(ctx context.Context, stdin io.Reader, stdout io.Writ
 			// forwarding anything that will need it (the upstream requires
 			// Mcp-Session-Id on every non-initialize request).
 			p.setInitFrame(line)
-			p.forward(reqCtx, line, stdout, true)
+			p.forward(reqCtx, line, stdout)
 			continue
 		}
 
 		p.wg.Add(1)
 		go func(fr []byte) {
 			defer p.wg.Done()
-			p.forward(reqCtx, fr, stdout, true)
+			p.forward(reqCtx, fr, stdout)
 		}(line)
 	}
 
@@ -154,17 +248,51 @@ func (p *ProxyClient) Serve(ctx context.Context, stdin io.Reader, stdout io.Writ
 	return ctx.Err()
 }
 
-// forward POSTs one JSON-RPC frame to the upstream /v1/_mcp and relays
-// the response (single JSON frame, or each SSE data frame) to stdout.
-// allowReinit gates the transparent re-handshake on a session-expiry: it is
-// true for client-originated frames and false for the single retry after a
-// re-handshake (so a still-failing upstream can't loop).
-func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Writer, allowReinit bool) {
+// forward POSTs one JSON-RPC frame to the upstream /v1/_mcp and relays the
+// response, transparently recovering from a dropped upstream connection. It
+// owns the transport-error reconnect loop: a connection refused/reset/EOF —
+// an idle-reaped keep-alive socket (the "drops a few minutes after last use"
+// symptom) or a brief server restart — is retried on a fresh connection with
+// bounded backoff, rather than dead-ending as an error the MCP client can't
+// recover from (Claude Code never auto-reconnects a stdio server, so the proxy
+// must not surface a recoverable fault). A server-side session expiry
+// (404/-32001) is handled one level down in forwardOnce via the re-handshake;
+// a restart that BOTH drops the connection and invalidates the session
+// composes: reconnect here, then re-handshake there.
+func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Writer) {
+	isInit := frameMethod(frame) == "initialize"
+	for attempt := 0; ; attempt++ {
+		transportErr := p.forwardOnce(ctx, frame, stdout, !isInit)
+		if transportErr == nil {
+			return // response relayed — success, or a definitive error already sent
+		}
+		// A transport-level failure. initialize is never retried here (it IS the
+		// handshake, driven inline by Serve). Otherwise retry on a fresh
+		// connection until the backoff schedule is exhausted.
+		if isInit || attempt >= len(p.reconnectDelays) {
+			p.replyError(stdout, frame, "upstream unreachable: "+transportErr.Error())
+			return
+		}
+		p.cfg.Logf("mcp proxy: upstream connection error (%v) — reconnect attempt %d/%d", transportErr, attempt+1, len(p.reconnectDelays))
+		if !p.backoff(ctx, p.reconnectDelays[attempt]) {
+			return // ctx cancelled during backoff — shutting down
+		}
+	}
+}
+
+// forwardOnce performs a SINGLE POST + relay attempt. It returns a non-nil
+// error ONLY for a transport-level failure (the request never got a response)
+// that the caller should retry; a nil return means the response — a success,
+// an SSE stream, or a surfaced HTTP/JSON-RPC error — was already written to
+// stdout and the frame is done. allowReinit gates the one-shot transparent
+// re-handshake on a session-expiry (404/-32001); it is false on the single
+// retry after a re-handshake so a still-broken session can't loop.
+func (p *ProxyClient) forwardOnce(ctx context.Context, frame []byte, stdout io.Writer, allowReinit bool) error {
 	sentSID := p.sessionID()
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.mcpURL, bytes.NewReader(frame))
 	if err != nil {
 		p.replyError(stdout, frame, "build request: "+err.Error())
-		return
+		return nil // a malformed request won't be fixed by a retry
 	}
 	req.Header.Set("Content-Type", "application/json")
 	// Advertise both per the Streamable HTTP spec — strict servers 406
@@ -177,11 +305,19 @@ func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Write
 		req.Header.Set("Mcp-Session-Id", sentSID)
 	}
 
-	resp, err := p.client.Do(req)
+	// Route agent-run / LLM tools through the no-header-timeout client so a slow
+	// run isn't mistaken for a stall and retried (which would double-execute it).
+	client := p.client
+	if frameIsLongRun(frame) {
+		client = p.streamClient
+	}
+	resp, err := client.Do(req)
 	if err != nil {
-		// Don't leave the MCP client hanging on a dead upstream.
-		p.replyError(stdout, frame, "upstream unreachable: "+err.Error())
-		return
+		// Transport-level failure (connection refused/reset, EOF on a reaped
+		// keep-alive socket, or the header timeout firing): the request got no
+		// response. Signal the caller to reconnect+retry rather than surfacing
+		// a dead-end error the MCP client can't recover from.
+		return err
 	}
 	defer resp.Body.Close()
 
@@ -205,23 +341,25 @@ func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Write
 			if rerr := p.reinitialize(ctx, sentSID); rerr != nil {
 				p.cfg.Logf("mcp proxy: re-initialize after session expiry failed: %v", rerr)
 			} else {
-				p.forward(ctx, frame, stdout, false)
-				return
+				// Retry on the fresh session. A transport error on the retry
+				// bubbles up so the outer forward loop can reconnect+backoff.
+				return p.forwardOnce(ctx, frame, stdout, false)
 			}
 		}
 		p.replyError(stdout, frame, fmt.Sprintf("upstream HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body))))
-		return
+		return nil
 	}
 
 	if strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") {
 		// If the stream ends without ever delivering a frame carrying the
 		// request id (the final tools/call response), the upstream dropped
 		// mid-run — surface an error so the client isn't left waiting on a
-		// spawn_run that will never answer.
+		// spawn_run that will never answer. NOT retried: a spawn_run may have
+		// already partially executed server-side.
 		if !p.relaySSE(resp.Body, stdout) {
 			p.replyError(stdout, frame, "upstream SSE stream ended before the final response")
 		}
-		return
+		return nil
 	}
 
 	// Single application/json response. An empty body (a notification has
@@ -229,12 +367,29 @@ func (p *ProxyClient) forward(ctx context.Context, frame []byte, stdout io.Write
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		p.replyError(stdout, frame, "read upstream response: "+err.Error())
-		return
+		return nil
 	}
 	if len(bytes.TrimSpace(body)) == 0 {
-		return
+		return nil
 	}
 	p.writeLine(stdout, bytes.TrimRight(body, "\n"))
+	return nil
+}
+
+// backoff sleeps for d, returning false if ctx is cancelled first (the proxy
+// is shutting down) so the caller stops retrying. d<=0 sleeps not at all.
+func (p *ProxyClient) backoff(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // relaySSE reads the upstream text/event-stream and writes each JSON-RPC
@@ -413,4 +568,20 @@ func frameMethod(frame []byte) string {
 	}
 	_ = json.Unmarshal(frame, &probe)
 	return probe.Method
+}
+
+// frameIsLongRun reports whether a frame is a tools/call for a long-running
+// tool (an agent run or an LLM call — see longRunTools), which must bypass the
+// ResponseHeaderTimeout to avoid a retry double-executing it.
+func frameIsLongRun(frame []byte) bool {
+	var probe struct {
+		Method string `json:"method"`
+		Params struct {
+			Name string `json:"name"`
+		} `json:"params"`
+	}
+	if json.Unmarshal(frame, &probe) != nil {
+		return false
+	}
+	return probe.Method == "tools/call" && longRunTools[probe.Params.Name]
 }

--- a/internal/api/mcp/proxy_test.go
+++ b/internal/api/mcp/proxy_test.go
@@ -4,7 +4,9 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -279,8 +281,14 @@ func TestProxy_UpstreamHTTPErrorBecomesJSONRPC(t *testing.T) {
 }
 
 func TestProxy_DeadUpstreamRepliesError(t *testing.T) {
-	// Unreachable upstream → the proxy must reply with an error, not hang.
-	pc := NewProxyClient(ProxyConfig{Upstream: "http://127.0.0.1:1", Logf: func(string, ...any) {}})
+	// Unreachable upstream → the proxy exhausts its reconnect budget and then
+	// replies with an error, not hangs. A fast reconnect schedule keeps the
+	// test quick while still exercising the retry loop.
+	pc := NewProxyClient(ProxyConfig{
+		Upstream:        "http://127.0.0.1:1",
+		Logf:            func(string, ...any) {},
+		ReconnectDelays: []time.Duration{time.Millisecond, time.Millisecond},
+	})
 	h := newProxyHarness(t, pc)
 	defer h.close()
 
@@ -360,5 +368,241 @@ func TestProxy_ReinitializesOnSessionExpiry(t *testing.T) {
 	defer mu.Unlock()
 	if initCount < 2 {
 		t.Errorf("expected a transparent re-initialize (initCount>=2), got %d", initCount)
+	}
+}
+
+// flakyRT is a RoundTripper that returns a synthetic transport error on the
+// Nth request(s) named in failOn, and delegates everything else to inner. It
+// simulates an idle-reaped keep-alive socket or a connection dropped during an
+// upstream restart — the request never reaches the server.
+type flakyRT struct {
+	mu     sync.Mutex
+	n      int
+	failOn map[int]bool
+	inner  http.RoundTripper
+}
+
+func (f *flakyRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.n++
+	cur := f.n
+	fail := f.failOn[cur]
+	f.mu.Unlock()
+	if fail {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+		return nil, &net.OpError{Op: "read", Net: "tcp", Err: errors.New("connection reset by peer")}
+	}
+	return f.inner.RoundTrip(req)
+}
+
+// TestProxy_RecoversAfterTransportError: a tool call whose upstream connection
+// drops (an idle-reaped keep-alive socket, or the restart window) is retried on
+// a fresh connection rather than dead-ending — so the client gets a clean
+// result, no reload/relaunch. Fails on the pre-fix proxy, which surfaced the
+// transport error immediately with no retry.
+func TestProxy_RecoversAfterTransportError(t *testing.T) {
+	rec := &upstreamRec{}
+	up := mockUpstream(t, rec)
+	// req #1 = initialize (succeeds), req #2 = the first tools/call (drops),
+	// retry #3 = tools/call (succeeds).
+	flaky := &flakyRT{failOn: map[int]bool{2: true}, inner: http.DefaultTransport}
+	pc := NewProxyClient(ProxyConfig{
+		Upstream:        up.URL,
+		Logf:            func(string, ...any) {},
+		Client:          &http.Client{Transport: flaky},
+		ReconnectDelays: []time.Duration{0, time.Millisecond},
+	})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(2, "memory"))
+	got := h.waitResp(2, 3*time.Second)
+	if got.Error != nil {
+		t.Fatalf("expected transparent recovery after a transport error, got JSON-RPC error: %+v", got.Error)
+	}
+}
+
+// TestProxy_RecoversAcrossServerRestart composes the two recovery mechanisms:
+// the restart both DROPS the connection (transport error) AND invalidates the
+// session (404/-32001 on the stale id). The proxy must reconnect (backoff
+// retry) and then re-handshake, returning a clean result. This is the "doesn't
+// recover when the server restarts" symptom end-to-end.
+func TestProxy_RecoversAcrossServerRestart(t *testing.T) {
+	var mu sync.Mutex
+	initCount := 0
+	valid := "" // the session id the upstream currently accepts
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/_mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+		}
+		_ = json.Unmarshal(body, &p)
+
+		if p.Method == "initialize" {
+			mu.Lock()
+			initCount++
+			sid := "sess-" + itoa(int64(initCount))
+			if initCount >= 2 {
+				valid = sid // the re-handshake session is accepted; sess-1 stays "expired"
+			}
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sid)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}`))
+			return
+		}
+		if p.ID == nil { // notifications/initialized — no body
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		mu.Lock()
+		ok := valid != "" && r.Header.Get("Mcp-Session-Id") == valid
+		mu.Unlock()
+		if !ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(*p.ID) + `,"error":{"code":-32001,"message":"session not found or expired"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(*p.ID) + `,"result":{"ok":true}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Fail the first tools/call attempt (req #2) with a transport error to
+	// model the connection dropping during the restart; the reconnect retry
+	// then meets the invalidated session and re-handshakes.
+	flaky := &flakyRT{failOn: map[int]bool{2: true}, inner: http.DefaultTransport}
+	pc := NewProxyClient(ProxyConfig{
+		Upstream:        srv.URL,
+		Logf:            func(string, ...any) {},
+		Client:          &http.Client{Transport: flaky},
+		ReconnectDelays: []time.Duration{0, time.Millisecond},
+	})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(2, "memory"))
+	got := h.waitResp(2, 3*time.Second)
+	if got.Error != nil {
+		t.Fatalf("expected recovery across a restart (reconnect + re-handshake), got: %+v", got.Error)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if initCount < 2 {
+		t.Errorf("expected a re-handshake after the restart (initCount>=2), got %d", initCount)
+	}
+}
+
+// TestProxy_DefaultClientHasStallGuards pins the hardening: the default HTTP
+// client bounds time-to-response-headers (so a stalled upstream can't hang a
+// frame forever — nothing else does for a stdio server) and closes idle
+// connections below the runtime server's 120s IdleTimeout (so the client
+// reopens before the server severs an idle keep-alive socket).
+func TestProxy_DefaultClientHasStallGuards(t *testing.T) {
+	pc := NewProxyClient(ProxyConfig{Upstream: "http://127.0.0.1:8787", Logf: func(string, ...any) {}})
+	tr, ok := pc.client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("default client Transport = %T, want *http.Transport", pc.client.Transport)
+	}
+	if tr.ResponseHeaderTimeout <= 0 {
+		t.Errorf("ResponseHeaderTimeout = %v, want > 0 (a stalled upstream must not hang a frame forever)", tr.ResponseHeaderTimeout)
+	}
+	if tr.IdleConnTimeout <= 0 || tr.IdleConnTimeout >= 120*time.Second {
+		t.Errorf("IdleConnTimeout = %v, want 0 < t < 120s (below the server's 120s IdleTimeout)", tr.IdleConnTimeout)
+	}
+	if pc.client.Timeout != 0 {
+		t.Errorf("client.Timeout = %v, want 0 (a streaming spawn_run holds the body open for the whole run)", pc.client.Timeout)
+	}
+	if len(pc.reconnectDelays) == 0 {
+		t.Error("reconnectDelays is empty, want a default schedule so transport errors are retried")
+	}
+	// The long-run client must NOT carry a header timeout — a slow spawn_run
+	// whose headers arrive minutes late must not be mistaken for a stall.
+	str, ok := pc.streamClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("streamClient Transport = %T, want *http.Transport", pc.streamClient.Transport)
+	}
+	if str.ResponseHeaderTimeout != 0 {
+		t.Errorf("streamClient ResponseHeaderTimeout = %v, want 0 (agent-run tools must never header-timeout → double-execute)", str.ResponseHeaderTimeout)
+	}
+}
+
+// TestProxy_NoHeaderTimeoutOnSpawnRun guards the double-execution hazard: a
+// spawn_run whose response headers arrive later than the (fast-frame) header
+// timeout must NOT be retried — it runs on the no-header-timeout client. The
+// upstream must therefore see exactly ONE spawn_run, and the result must come
+// through. Without the long-run carve-out the header timeout would fire, the
+// reconnect loop would re-POST, and the agent run would execute twice.
+func TestProxy_NoHeaderTimeoutOnSpawnRun(t *testing.T) {
+	var mu sync.Mutex
+	spawnCount := 0
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/_mcp", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var p struct {
+			ID     *int64 `json:"id"`
+			Method string `json:"method"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &p)
+		if p.Method == "initialize" {
+			w.Header().Set("Mcp-Session-Id", "sess-1")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{}}`))
+			return
+		}
+		if p.Params.Name == "spawn_run" {
+			mu.Lock()
+			spawnCount++
+			mu.Unlock()
+			// Headers (and body) arrive only after a delay LONGER than the
+			// fast-frame header timeout — a slow model / long run. A retry-happy
+			// proxy would give up and re-POST before this returns.
+			time.Sleep(250 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(*p.ID) + `,"result":{"ok":true}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":` + itoa(*p.ID) + `,"result":{}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// A very short header timeout for FAST frames; the spawn_run must bypass it.
+	pc := NewProxyClient(ProxyConfig{
+		Upstream:              srv.URL,
+		Logf:                  func(string, ...any) {},
+		ResponseHeaderTimeout: 50 * time.Millisecond,
+		ReconnectDelays:       []time.Duration{0, time.Millisecond},
+	})
+	h := newProxyHarness(t, pc)
+	defer h.close()
+
+	h.send(initFrame())
+	h.waitResp(1, 2*time.Second)
+	h.send(callFrame(2, "spawn_run"))
+	got := h.waitResp(2, 3*time.Second)
+	if got.Error != nil {
+		t.Fatalf("spawn_run should complete on the no-header-timeout client, got: %+v", got.Error)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if spawnCount != 1 {
+		t.Fatalf("upstream saw spawn_run %d times, want exactly 1 (a header-timeout retry double-executes the run)", spawnCount)
 	}
 }


### PR DESCRIPTION
## Why

The Claude Code plugin's `loomcycle mcp --upstream` **thin client** kept losing its MCP connection — the marketing agent had to reload plugins / restart Claude Code a few minutes after the last tool call, and it never recovered when the TrueNAS runtime restarted.

Root cause: the proxy (`internal/api/mcp/proxy.go`) self-healed **exactly one** fault — an upstream `HTTP 404 + JSON-RPC -32001` "session expired". Everything else dead-ended:

- **Idle drop (few minutes after last use):** the runtime HTTP server closes idle keep-alive connections after **120s** (`main.go` `IdleTimeout`). The client's pooled socket goes half-open; the next POST fails with a **transport error**, which the proxy surfaced immediately with **no retry**.
- **Server restart:** connection-refused/reset during the restart window is also a transport error → same dead-end; even once the server is back, the first call could arrive before the `404/-32001` re-handshake path had a chance to fire.

MCP hosts **never auto-reconnect a stdio server** (confirmed: anthropics/claude-code#43177, closed "not planned"), and the proxy *is* a stdio server to Claude Code — so 100% of recovery must live in the proxy. When its tool calls started failing, the only recourse was a manual reload.

## What

`forward()` now owns a **bounded-backoff reconnect loop**, split from a single-attempt `forwardOnce()`:

- A **transport error** is retried on a fresh connection (immediate, then 500ms → 1s → 2s → 4s). This **composes** with the existing `404/-32001` re-handshake, so a restart that BOTH drops the connection and invalidates the session recovers transparently (reconnect here → re-handshake there → retry).
- The default client closes idle connections at **90s** (below the server's 120s) so it reopens *before* the server severs the socket.
- A **`ResponseHeaderTimeout` (60s)** bounds a stalled upstream on fast frames (nothing else does — Claude Code's tool-idle timeout doesn't apply to stdio servers). **Agent-run / LLM tools** (`spawn_run`, `spawn_runs`, `compact_run`, `evaluation`) route through a **no-header-timeout client**: their headers legitimately arrive minutes late (a slow local model / long run), and a header-timeout retry would **double-execute the run**.

All recovery stays single-flighted and bounded. Tunable via env (the thin client boots with no config):

| Env var | Default | Effect |
|---|---|---|
| `LOOMCYCLE_MCP_UPSTREAM_HEADER_TIMEOUT_MS` | `60000` | Max wait for response headers on fast frames. |
| `LOOMCYCLE_MCP_UPSTREAM_RECONNECT_ATTEMPTS` | `5` | Reconnect tries after a transport error (`0` disables). |

## What was tested

`go test ./...` clean. New regression tests in `internal/api/mcp/proxy_test.go`, each verified to **fail on the pre-fix code**:

- `TestProxy_RecoversAfterTransportError` — a dropped connection is retried, not surfaced as an error.
- `TestProxy_RecoversAcrossServerRestart` — reconnect + re-handshake compose across a restart.
- `TestProxy_NoHeaderTimeoutOnSpawnRun` — a slow `spawn_run` runs on the no-header-timeout client; upstream sees it **exactly once** (double-execution guard).
- `TestProxy_DefaultClientHasStallGuards` — default client has a header timeout + sub-120s idle timeout; the long-run client has none.

Runtime-only change (thin-client binary); no wire/schema change. Ships in the Homebrew `loomcycle` — reinstall the thin-client binary to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD