### PR TITLE
feat(webui): tenant import of Claude Code skills + MCP servers, for local LLMs (RFC AU)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
           cache-dependency-path: web/package-lock.json
       - run: npm ci
       - run: npm run typecheck
+      - run: npm run test
       - run: npm run build
 
   python-adapter:

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -342,16 +342,37 @@ func (s *Server) handleWhoami(w http.ResponseWriter, r *http.Request) {
 			"tenant_id": "default", "subject": "default",
 			"scopes": []string{auth.ScopeAdmin}, "is_admin": true,
 			"legacy": false, "open_mode": true,
+			"capabilities": s.serverCapabilities(),
 		})
 		return
 	}
 	writeJSONOK(w, map[string]any{
-		"tenant_id": p.TenantID,
-		"subject":   p.Subject,
-		"scopes":    p.Scopes,
-		"is_admin":  auth.HasScope(p.Scopes, auth.ScopeAdmin),
-		"legacy":    p.Legacy,
+		"tenant_id":    p.TenantID,
+		"subject":      p.Subject,
+		"scopes":       p.Scopes,
+		"is_admin":     auth.HasScope(p.Scopes, auth.ScopeAdmin),
+		"legacy":       p.Legacy,
+		"capabilities": s.serverCapabilities(),
 	})
+}
+
+// serverCapabilities is a NON-SECRET, booleans-only advertisement of runtime
+// posture the Web UI needs to gate its affordances (RFC AU) — notably whether a
+// tenant may import a stdio MCP server (host RCE, off by default). It is exposed
+// on the auth-only /v1/_me boot call to every principal, so it must never leak
+// operator infra detail: report only booleans/presence, NEVER the allowlist
+// CONTENTS (internal hostnames) or any secret.
+func (s *Server) serverCapabilities() map[string]any {
+	return map[string]any{
+		// Whether the MCPServerDef substrate accepts a dynamically-registered
+		// stdio server (LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO). The UI enables the
+		// stdio import path only when true, with a loud RCE warning.
+		"mcp_allow_dynamic_stdio": s.cfg.Env.MCPAllowDynamicStdio,
+		// Whether ANY http host allowlist is configured — so the UI can warn
+		// that an imported http MCP server will 422 unless its host is listed.
+		// Presence only; never the entries themselves.
+		"http_host_allowlist_configured": len(s.cfg.Env.HTTPHostAllowlist)+len(s.cfg.Env.HTTPPrivateHostAllowlist) > 0,
+	}
 }
 
 // principalTenantScope resolves the tenant a list read should be scoped

--- a/internal/api/http/whoami_capabilities_test.go
+++ b/internal/api/http/whoami_capabilities_test.go
@@ -1,0 +1,73 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestWhoami_CapabilitiesReflectConfig verifies the RFC AU capability
+// advertisement on GET /v1/_me: the UI needs mcp_allow_dynamic_stdio to gate the
+// stdio import path (host RCE), and http_host_allowlist_configured to warn about
+// http imports — and the block must NEVER leak the allowlist CONTENTS.
+func TestWhoami_CapabilitiesReflectConfig(t *testing.T) {
+	newServer := func(stdio bool, allowlist []string) *Server {
+		cfg := &config.Config{
+			Defaults:    config.Defaults{Provider: "scripted", Model: "stub-model"},
+			Concurrency: config.Concurrency{MaxConcurrentRuns: 1, MaxQueueDepth: 1, QueueTimeoutMS: 1000},
+		}
+		cfg.Env.AuthToken = "" // open mode → the no-principal whoami branch
+		cfg.Env.MCPAllowDynamicStdio = stdio
+		cfg.Env.HTTPHostAllowlist = allowlist
+		return New(cfg, &stubResolver{}, []tools.Tool{}, concurrency.New(1, 1, time.Second), nil)
+	}
+
+	get := func(t *testing.T, srv *Server) (map[string]any, string) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		srv.Mux().ServeHTTP(rec, httptest.NewRequest("GET", "/v1/_me", nil))
+		if rec.Code != 200 {
+			t.Fatalf("GET /v1/_me = %d, want 200; body=%s", rec.Code, rec.Body.String())
+		}
+		var body map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+			t.Fatalf("decode: %v; body=%s", err, rec.Body.String())
+		}
+		caps, ok := body["capabilities"].(map[string]any)
+		if !ok {
+			t.Fatalf("no capabilities object in /v1/_me; body=%s", rec.Body.String())
+		}
+		return caps, rec.Body.String()
+	}
+
+	t.Run("stdio off, no allowlist", func(t *testing.T) {
+		caps, _ := get(t, newServer(false, nil))
+		if caps["mcp_allow_dynamic_stdio"] != false {
+			t.Errorf("mcp_allow_dynamic_stdio = %v, want false", caps["mcp_allow_dynamic_stdio"])
+		}
+		if caps["http_host_allowlist_configured"] != false {
+			t.Errorf("http_host_allowlist_configured = %v, want false", caps["http_host_allowlist_configured"])
+		}
+	})
+
+	t.Run("stdio on, allowlist set — reflects flags but never leaks contents", func(t *testing.T) {
+		const secretHost = "internal-mcp.corp.example"
+		caps, raw := get(t, newServer(true, []string{secretHost}))
+		if caps["mcp_allow_dynamic_stdio"] != true {
+			t.Errorf("mcp_allow_dynamic_stdio = %v, want true", caps["mcp_allow_dynamic_stdio"])
+		}
+		if caps["http_host_allowlist_configured"] != true {
+			t.Errorf("http_host_allowlist_configured = %v, want true", caps["http_host_allowlist_configured"])
+		}
+		// The allowlist host must never appear in the response — booleans only.
+		if strings.Contains(raw, secretHost) {
+			t.Errorf("/v1/_me leaked an allowlist hostname %q; body=%s", secretHost, raw)
+		}
+	})
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -23,7 +23,8 @@
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^5.0.0",
         "typescript": "^5.5.0",
-        "vite": "^7.0.0"
+        "vite": "^7.0.0",
+        "vitest": "^4.1.9"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1223,6 +1224,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1267,6 +1275,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1323,11 +1349,134 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.28",
@@ -1397,6 +1546,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1449,6 +1608,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -1499,6 +1665,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -1618,6 +1804,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1648,6 +1844,27 @@
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1836,6 +2053,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1844,6 +2068,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -1861,6 +2116,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/typescript": {
@@ -1981,6 +2246,113 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.8",
@@ -26,6 +27,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^5.0.0",
     "typescript": "^5.5.0",
-    "vite": "^7.0.0"
+    "vite": "^7.0.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -248,6 +248,20 @@ export interface Principal {
   is_admin: boolean;
   legacy: boolean;
   open_mode?: boolean;
+  /**
+   * Non-secret, booleans-only runtime posture (RFC AU) the UI uses to gate
+   * affordances — notably whether a tenant may import a stdio MCP server (host
+   * RCE, off by default). Absent on older servers → treat every capability as
+   * false (safe default). NEVER carries allowlist contents or any secret.
+   */
+  capabilities?: ServerCapabilities;
+}
+
+export interface ServerCapabilities {
+  /** LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO — gates the stdio MCP import path. */
+  mcp_allow_dynamic_stdio?: boolean;
+  /** Whether any http host allowlist is configured (presence only). */
+  http_host_allowlist_configured?: boolean;
 }
 
 // getWhoami resolves the current principal. A 401 redirects to /login via

--- a/web/src/components/ImportModal.tsx
+++ b/web/src/components/ImportModal.tsx
@@ -1,0 +1,357 @@
+import { useMemo, useState } from "react";
+
+import {
+  createDef,
+  forkDef,
+  type LibraryEntry,
+  type ServerCapabilities,
+} from "../api";
+import {
+  detectKind,
+  parseSource,
+  resolvePreview,
+  type ImportCandidate,
+  type PreviewRow,
+} from "../lib/claudeImport";
+import { explainServerError } from "./LibraryEditModal";
+
+// LocalAgentSeed is what "Use with a local LLM" hands back to LibraryView to
+// prefill an agent-create modal (RFC AU §"Use with a local LLM").
+export interface LocalAgentSeed {
+  skills: string[];
+  mcpServers: string[];
+}
+
+export interface ImportModalProps {
+  // The tenant's current Library entries — used for dry-run collision
+  // resolution (create vs fork vs reclaim). Both kinds, since an mcp.json can
+  // define servers regardless of which tab launched the import.
+  skills: LibraryEntry[];
+  mcp: LibraryEntry[];
+  capabilities?: ServerCapabilities;
+  isTenant: boolean;
+  onClose: () => void;
+  onImported: () => void; // refresh the Library
+  onWireLocalAgent?: (seed: LocalAgentSeed) => void;
+}
+
+type Step = "source" | "preview" | "results";
+type SourceKind = "auto" | "skill" | "mcp";
+
+interface RowResult {
+  status: "pending" | "ok" | "error" | "skipped";
+  message?: string;
+}
+
+// ImportModal — RFC AU. A three-step flow (source → dry-run preview → commit)
+// that ingests a Claude Code SKILL.md or mcp.json into the tenant's substrate
+// via the existing create/fork endpoints. All parsing is client-side
+// (claudeImport.ts); the server 422s remain authoritative.
+export default function ImportModal(props: ImportModalProps) {
+  const [step, setStep] = useState<Step>("source");
+  const [text, setText] = useState("");
+  const [filename, setFilename] = useState<string | undefined>(undefined);
+  const [sourceKind, setSourceKind] = useState<SourceKind>("auto");
+  const [parseErrors, setParseErrors] = useState<string[]>([]);
+  const [parseWarnings, setParseWarnings] = useState<string[]>([]);
+  const [candidates, setCandidates] = useState<ImportCandidate[]>([]);
+  const [results, setResults] = useState<Record<number, RowResult>>({});
+  const [committing, setCommitting] = useState(false);
+
+  const stdioAllowed = props.capabilities?.mcp_allow_dynamic_stdio === true;
+  const httpAllowlistConfigured =
+    props.capabilities?.http_host_allowlist_configured === true;
+
+  const rows: PreviewRow[] = useMemo(
+    () =>
+      resolvePreview(
+        candidates,
+        { skills: props.skills, mcp: props.mcp },
+        { stdioAllowed, httpAllowlistConfigured, isTenant: props.isTenant },
+      ),
+    [candidates, props.skills, props.mcp, stdioAllowed, httpAllowlistConfigured, props.isTenant],
+  );
+
+  const importable = rows.filter((r) => r.action !== "blocked").length;
+
+  const doParse = () => {
+    const kind = sourceKind === "auto" ? detectKind(text, filename) : sourceKind;
+    if (kind === "unknown") {
+      setParseErrors([
+        "Could not tell if this is a SKILL.md or an mcp.json — pick the type below.",
+      ]);
+      setParseWarnings([]);
+      return;
+    }
+    const res = parseSource(text, kind, filename);
+    setParseErrors(res.errors);
+    setParseWarnings(res.warnings);
+    if (res.candidates.length === 0) return;
+    setCandidates(res.candidates);
+    setResults({});
+    setStep("preview");
+  };
+
+  const onFile = async (f: File | null) => {
+    if (!f) return;
+    setFilename(f.name);
+    setText(await f.text());
+    setParseErrors([]);
+  };
+
+  const renameCandidate = (i: number, name: string) =>
+    setCandidates((cs) => cs.map((c, idx) => (idx === i ? { ...c, name } : c)));
+
+  const commit = async () => {
+    setCommitting(true);
+    setStep("results");
+    const next: Record<number, RowResult> = {};
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i]!;
+      if (row.action === "blocked") {
+        next[i] = { status: "skipped", message: row.note };
+        setResults({ ...next });
+        continue;
+      }
+      next[i] = { status: "pending" };
+      setResults({ ...next });
+      const kind = row.candidate.kind === "skill" ? "skilldef" : "mcpserverdef";
+      try {
+        // Imported defs are promoted (active) immediately — the operator
+        // imported them to use them.
+        if (row.action === "fork") {
+          await forkDef(kind, row.candidate.name, row.candidate.overlay, true, row.parentDefId);
+        } else {
+          await createDef(kind, row.candidate.name, row.candidate.overlay, true);
+        }
+        next[i] = { status: "ok" };
+      } catch (e) {
+        next[i] = { status: "error", message: explainServerError(e) };
+      }
+      setResults({ ...next });
+    }
+    setCommitting(false);
+    props.onImported();
+  };
+
+  const importedSkills = rows
+    .filter((r, i) => results[i]?.status === "ok" && r.candidate.kind === "skill")
+    .map((r) => r.candidate.name);
+  const importedMcp = rows
+    .filter((r, i) => results[i]?.status === "ok" && r.candidate.kind === "mcp-server")
+    .map((r) => r.candidate.name);
+
+  return (
+    <div className="modal-overlay" onClick={committing ? undefined : props.onClose}>
+      <div className="modal library-modal" onClick={(e) => e.stopPropagation()}>
+        <h3>Import Claude Code skill / MCP server</h3>
+
+        {step === "source" && (
+          <>
+            <p className="library-modal-field-hint">
+              Paste or upload a <code>SKILL.md</code> or an{" "}
+              <code>mcp.json</code> / <code>.mcp.json</code>. Everything imports
+              into <strong>your tenant's</strong> storage.
+            </p>
+            <div className="library-form-row">
+              <label htmlFor="import-file">upload a file</label>
+              <input
+                id="import-file"
+                type="file"
+                accept=".md,.json,text/markdown,application/json"
+                onChange={(e) => onFile(e.target.files?.[0] ?? null)}
+                disabled={committing}
+              />
+            </div>
+            <div className="library-form-row">
+              <label htmlFor="import-text">…or paste the content</label>
+              <textarea
+                id="import-text"
+                className="library-prompt-textarea mono"
+                value={text}
+                onChange={(e) => {
+                  setText(e.target.value);
+                  setFilename(undefined);
+                }}
+                rows={12}
+                spellCheck={false}
+                placeholder={"---\nname: my-skill\ndescription: …\nallowed-tools: [WebFetch]\n---\n# Instructions…"}
+                disabled={committing}
+              />
+            </div>
+            <div className="library-form-row">
+              <label>type</label>
+              <div className="library-radio-group">
+                {(["auto", "skill", "mcp"] as SourceKind[]).map((k) => (
+                  <label key={k}>
+                    <input
+                      type="radio"
+                      name="import-kind"
+                      checked={sourceKind === k}
+                      onChange={() => setSourceKind(k)}
+                      disabled={committing}
+                    />{" "}
+                    {k === "auto" ? "auto-detect" : k === "skill" ? "skill" : "mcp config"}
+                  </label>
+                ))}
+              </div>
+            </div>
+            {parseErrors.map((e, i) => (
+              <div key={i} className="modal-err">
+                {e}
+              </div>
+            ))}
+            {parseWarnings.map((w, i) => (
+              <div key={i} className="library-models-warning">
+                {w}
+              </div>
+            ))}
+            <div className="modal-buttons">
+              <button type="button" onClick={props.onClose}>
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="primary"
+                onClick={doParse}
+                disabled={!text.trim()}
+              >
+                Preview →
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "preview" && (
+          <>
+            <p className="library-modal-field-hint">
+              {importable} of {rows.length} will be imported. Edit a name to
+              avoid a collision; blocked rows are skipped.
+            </p>
+            {parseWarnings.map((w, i) => (
+              <div key={i} className="library-models-warning">
+                {w}
+              </div>
+            ))}
+            <div className="import-preview-list">
+              {rows.map((row, i) => (
+                <div
+                  key={i}
+                  className={
+                    row.action === "blocked"
+                      ? "import-row import-row-blocked"
+                      : "import-row"
+                  }
+                >
+                  <div className="import-row-head">
+                    <span className={`import-action-badge import-action-${row.action}`}>
+                      {row.action}
+                    </span>
+                    <span className="def-pill mono">{row.candidate.kind}</span>
+                    {row.candidate.transport && (
+                      <span className="def-pill mono">{row.candidate.transport}</span>
+                    )}
+                    <input
+                      type="text"
+                      className="mono import-name-input"
+                      value={row.candidate.name}
+                      onChange={(e) => renameCandidate(i, e.target.value)}
+                      disabled={committing}
+                    />
+                  </div>
+                  {row.note && <div className="import-row-note">{row.note}</div>}
+                  {row.warnings.map((w, j) => (
+                    <div key={j} className="import-row-warning">
+                      {w}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+            <div className="modal-buttons">
+              <button type="button" onClick={() => setStep("source")} disabled={committing}>
+                ← Back
+              </button>
+              <button
+                type="button"
+                className="primary"
+                onClick={commit}
+                disabled={committing || importable === 0}
+              >
+                Import {importable} →
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "results" && (
+          <>
+            <div className="import-preview-list">
+              {rows.map((row, i) => {
+                const r = results[i];
+                return (
+                  <div key={i} className="import-row">
+                    <div className="import-row-head">
+                      <span className={`import-result-${r?.status ?? "pending"}`}>
+                        {r?.status === "ok"
+                          ? "✓"
+                          : r?.status === "error"
+                            ? "✗"
+                            : r?.status === "skipped"
+                              ? "—"
+                              : "…"}
+                      </span>
+                      <span className="def-pill mono">{row.candidate.name}</span>
+                    </div>
+                    {r?.message && <div className="import-row-warning">{r.message}</div>}
+                  </div>
+                );
+              })}
+            </div>
+
+            {!committing && (importedSkills.length > 0 || importedMcp.length > 0) && (
+              <div className="library-models-warning">
+                {importedMcp.length > 0 ? (
+                  <>
+                    Local models run skills fine, but small local models may{" "}
+                    <strong>silently ignore MCP tool calls</strong> — use a
+                    tool-capable model (<code>local-medium</code> /{" "}
+                    <code>local-coder</code>) or a cloud model.
+                  </>
+                ) : (
+                  <>Skills run on any local model.</>
+                )}
+              </div>
+            )}
+
+            <div className="modal-buttons">
+              {!committing &&
+                props.onWireLocalAgent &&
+                (importedSkills.length > 0 || importedMcp.length > 0) && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      props.onWireLocalAgent!({
+                        skills: importedSkills,
+                        mcpServers: importedMcp,
+                      })
+                    }
+                  >
+                    Use with a local LLM →
+                  </button>
+                )}
+              <button
+                type="button"
+                className="primary"
+                onClick={props.onClose}
+                disabled={committing}
+              >
+                Done
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/LibraryEditModal.tsx
+++ b/web/src/components/LibraryEditModal.tsx
@@ -59,6 +59,11 @@ export interface LibraryEditModalProps {
   // name collisions before round-tripping the server. Optional —
   // server-side check is authoritative.
   existingNames?: LibraryEntry[];
+  // RFC AU: whether the runtime permits dynamic stdio MCP servers
+  // (LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO). When false, the stdio transport
+  // option is hidden — a stdio server would 422 anyway. From
+  // principal.capabilities.mcp_allow_dynamic_stdio.
+  stdioAllowed?: boolean;
   onClose: () => void;
   onSaved: (row: DefRow) => void;
 }
@@ -85,6 +90,7 @@ export default function LibraryEditModal({
   mode,
   forkSource,
   existingNames,
+  stdioAllowed,
   onClose,
   onSaved,
 }: LibraryEditModalProps) {
@@ -222,7 +228,7 @@ export default function LibraryEditModal({
   );
 
   // --- MCP-flavor specific
-  type Transport = "http" | "streamable-http";
+  type Transport = "http" | "streamable-http" | "stdio";
   const [mcpTransport, setMcpTransport] = useState<Transport>(
     (pickString(forkSource?.definition, "transport") as Transport) ||
       "streamable-http",
@@ -239,6 +245,21 @@ export default function LibraryEditModal({
         : entries.map(([key, value]) => ({ key, value }));
     },
   );
+  // stdio transport (RFC AU / F31). Command runs on the loomcycle host — the
+  // transport option is only shown when stdioAllowed.
+  const [mcpCommand, setMcpCommand] = useState<string>(
+    pickString(forkSource?.definition, "command"),
+  );
+  const [mcpArgs, setMcpArgs] = useState<string>(
+    pickStringArray(forkSource?.definition, "args").join(", "),
+  );
+  const [mcpEnv, setMcpEnv] = useState<{ key: string; value: string }[]>(() => {
+    const e = pickStringMap(forkSource?.definition, "env");
+    const entries = Object.entries(e);
+    return entries.length === 0
+      ? [{ key: "", value: "" }]
+      : entries.map(([key, value]) => ({ key, value }));
+  });
 
   const titlePrefix = mode === "create" ? "Create" : "Edit (fork)";
   const titleLabel =
@@ -341,14 +362,18 @@ export default function LibraryEditModal({
       if (!skillBody.trim()) return "Skill body is required (substrate refuses empty bodies).";
     }
     if (kind === "mcp-server") {
-      if (!mcpUrl.trim()) return "URL is required.";
-      try {
-        const u = new URL(mcpUrl.trim());
-        if (u.protocol !== "http:" && u.protocol !== "https:") {
-          return "URL protocol must be http or https.";
+      if (mcpTransport === "stdio") {
+        if (!mcpCommand.trim()) return "Command is required for a stdio server.";
+      } else {
+        if (!mcpUrl.trim()) return "URL is required.";
+        try {
+          const u = new URL(mcpUrl.trim());
+          if (u.protocol !== "http:" && u.protocol !== "https:") {
+            return "URL protocol must be http or https.";
+          }
+        } catch {
+          return "URL is not a valid http(s) URI.";
         }
-      } catch {
-        return "URL is not a valid http(s) URI.";
       }
     }
     return null;
@@ -450,6 +475,22 @@ export default function LibraryEditModal({
       return ov;
     }
     // mcp-server
+    if (mcpTransport === "stdio") {
+      const env: Record<string, string> = {};
+      mcpEnv.forEach(({ key, value }) => {
+        const k = key.trim();
+        if (k) env[k] = value;
+      });
+      const ov: Record<string, unknown> = {
+        transport: "stdio",
+        command: mcpCommand.trim(),
+      };
+      const args = parseCommaList(mcpArgs);
+      if (args.length > 0) ov.args = args;
+      if (Object.keys(env).length > 0) ov.env = env;
+      if (description.trim()) ov.description = description.trim();
+      return ov;
+    }
     const headers: Record<string, string> = {};
     mcpHeaders.forEach(({ key, value }) => {
       const k = key.trim();
@@ -650,6 +691,13 @@ export default function LibraryEditModal({
             setUrl={setMcpUrl}
             headers={mcpHeaders}
             setHeaders={setMcpHeaders}
+            command={mcpCommand}
+            setCommand={setMcpCommand}
+            args={mcpArgs}
+            setArgs={setMcpArgs}
+            env={mcpEnv}
+            setEnv={setMcpEnv}
+            stdioAllowed={stdioAllowed === true}
             submitting={submitting}
           />
         )}
@@ -1303,30 +1351,91 @@ function SkillFields(props: {
   );
 }
 
+// KVGrid renders an editable key/value grid (used for both MCP http headers
+// and stdio env). Empty rows are dropped at buildOverlay time.
+function KVGrid(props: {
+  label: string;
+  rows: { key: string; value: string }[];
+  setRows: (v: { key: string; value: string }[]) => void;
+  keyPlaceholder: string;
+  valuePlaceholder: string;
+  submitting: boolean;
+}) {
+  const update = (i: number, patch: Partial<{ key: string; value: string }>) => {
+    const next = [...props.rows];
+    next[i] = { ...next[i]!, ...patch };
+    props.setRows(next);
+  };
+  const add = () => props.setRows([...props.rows, { key: "", value: "" }]);
+  const remove = (i: number) => {
+    if (props.rows.length === 1) {
+      props.setRows([{ key: "", value: "" }]);
+      return;
+    }
+    props.setRows(props.rows.filter((_, idx) => idx !== i));
+  };
+  return (
+    <div className="library-form-row">
+      <label>
+        {props.label}
+        <button
+          type="button"
+          className="library-schema-hint-toggle"
+          onClick={add}
+          disabled={props.submitting}
+        >
+          + add row
+        </button>
+      </label>
+      <div className="library-headers-grid">
+        {props.rows.map((h, i) => (
+          <div key={i} className="library-header-row">
+            <input
+              type="text"
+              placeholder={props.keyPlaceholder}
+              value={h.key}
+              onChange={(e) => update(i, { key: e.target.value })}
+              disabled={props.submitting}
+            />
+            <input
+              type="text"
+              placeholder={props.valuePlaceholder}
+              value={h.value}
+              onChange={(e) => update(i, { value: e.target.value })}
+              disabled={props.submitting}
+            />
+            <button
+              type="button"
+              onClick={() => remove(i)}
+              disabled={props.submitting}
+              title="remove"
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function McpFields(props: {
-  transport: "http" | "streamable-http";
-  setTransport: (v: "http" | "streamable-http") => void;
+  transport: "http" | "streamable-http" | "stdio";
+  setTransport: (v: "http" | "streamable-http" | "stdio") => void;
   url: string;
   setUrl: (v: string) => void;
   headers: { key: string; value: string }[];
   setHeaders: (v: { key: string; value: string }[]) => void;
+  command: string;
+  setCommand: (v: string) => void;
+  args: string;
+  setArgs: (v: string) => void;
+  env: { key: string; value: string }[];
+  setEnv: (v: { key: string; value: string }[]) => void;
+  stdioAllowed: boolean;
   submitting: boolean;
 }) {
-  const updateHeader = (i: number, patch: Partial<{ key: string; value: string }>) => {
-    const next = [...props.headers];
-    next[i] = { ...next[i]!, ...patch };
-    props.setHeaders(next);
-  };
-  const addHeader = () =>
-    props.setHeaders([...props.headers, { key: "", value: "" }]);
-  const removeHeader = (i: number) => {
-    if (props.headers.length === 1) {
-      props.setHeaders([{ key: "", value: "" }]);
-      return;
-    }
-    props.setHeaders(props.headers.filter((_, idx) => idx !== i));
-  };
-
+  const isStdio = props.transport === "stdio";
   return (
     <>
       <div className="library-form-row">
@@ -1354,63 +1463,89 @@ function McpFields(props: {
             />{" "}
             http
           </label>
-          <span className="library-radio-note">
-            stdio servers stay yaml-only
-          </span>
+          {props.stdioAllowed ? (
+            <label>
+              <input
+                type="radio"
+                name="lib-mcp-transport"
+                value="stdio"
+                checked={isStdio}
+                onChange={() => props.setTransport("stdio")}
+                disabled={props.submitting}
+              />{" "}
+              stdio
+            </label>
+          ) : (
+            <span className="library-radio-note">
+              stdio disabled (operator sets LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1)
+            </span>
+          )}
         </div>
       </div>
-      <div className="library-form-row">
-        <label htmlFor="lib-mcp-url">url</label>
-        <input
-          id="lib-mcp-url"
-          type="text"
-          value={props.url}
-          onChange={(e) => props.setUrl(e.target.value)}
-          disabled={props.submitting}
-          placeholder="https://n8n.example.com/mcp"
-        />
-      </div>
-      <div className="library-form-row">
-        <label>
-          headers
-          <button
-            type="button"
-            className="library-schema-hint-toggle"
-            onClick={addHeader}
-            disabled={props.submitting}
-          >
-            + add row
-          </button>
-        </label>
-        <div className="library-headers-grid">
-          {props.headers.map((h, i) => (
-            <div key={i} className="library-header-row">
-              <input
-                type="text"
-                placeholder="header-name"
-                value={h.key}
-                onChange={(e) => updateHeader(i, { key: e.target.value })}
-                disabled={props.submitting}
-              />
-              <input
-                type="text"
-                placeholder="value (e.g. Bearer ${LOOMCYCLE_X_TOKEN})"
-                value={h.value}
-                onChange={(e) => updateHeader(i, { value: e.target.value })}
-                disabled={props.submitting}
-              />
-              <button
-                type="button"
-                onClick={() => removeHeader(i)}
-                disabled={props.submitting}
-                title="remove"
-              >
-                ×
-              </button>
-            </div>
-          ))}
-        </div>
-      </div>
+      {isStdio ? (
+        <>
+          <div className="library-form-row">
+            <label htmlFor="lib-mcp-command">
+              command
+              <span className="library-modal-field-hint">
+                {" "}— runs on the loomcycle host (arbitrary command, RCE-class trust)
+              </span>
+            </label>
+            <input
+              id="lib-mcp-command"
+              type="text"
+              value={props.command}
+              onChange={(e) => props.setCommand(e.target.value)}
+              disabled={props.submitting}
+              placeholder="npx"
+            />
+          </div>
+          <div className="library-form-row">
+            <label htmlFor="lib-mcp-args">
+              args
+              <span className="library-modal-field-hint"> — comma-separated</span>
+            </label>
+            <input
+              id="lib-mcp-args"
+              type="text"
+              value={props.args}
+              onChange={(e) => props.setArgs(e.target.value)}
+              disabled={props.submitting}
+              placeholder="-y, @scope/server, ${LOOMCYCLE_ROOT}"
+            />
+          </div>
+          <KVGrid
+            label="env"
+            rows={props.env}
+            setRows={props.setEnv}
+            keyPlaceholder="ENV_NAME"
+            valuePlaceholder="value (e.g. ${LOOMCYCLE_X_TOKEN})"
+            submitting={props.submitting}
+          />
+        </>
+      ) : (
+        <>
+          <div className="library-form-row">
+            <label htmlFor="lib-mcp-url">url</label>
+            <input
+              id="lib-mcp-url"
+              type="text"
+              value={props.url}
+              onChange={(e) => props.setUrl(e.target.value)}
+              disabled={props.submitting}
+              placeholder="https://n8n.example.com/mcp"
+            />
+          </div>
+          <KVGrid
+            label="headers"
+            rows={props.headers}
+            setRows={props.setHeaders}
+            keyPlaceholder="header-name"
+            valuePlaceholder="value (e.g. Bearer ${LOOMCYCLE_X_TOKEN})"
+            submitting={props.submitting}
+          />
+        </>
+      )}
     </>
   );
 }
@@ -1705,7 +1840,7 @@ function parseCommaList(s: string): string[] {
 // matching on stable substrings ("matches a static cfg.", "not allowed",
 // etc.) keeps the UI useful without forcing a substrate-side error-code
 // taxonomy redesign.
-function explainServerError(e: unknown): string {
+export function explainServerError(e: unknown): string {
   const raw = e instanceof Error ? e.message : String(e);
   // jsonFetch throws "<status> <statusText>: <body>"; pull the JSON body
   const jsonIdx = raw.indexOf("{");
@@ -1747,7 +1882,7 @@ function explainServerError(e: unknown): string {
     return "Substrate is not configured. Operator's root config is missing.";
   }
   if (innerText.includes("not allowed for dynamic registration")) {
-    return "MCP server transport must be http or streamable-http. Use yaml for stdio servers.";
+    return "stdio MCP servers require the operator to set LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1 (host RCE opt-in), or declare the server in yaml mcp_servers:.";
   }
   if (innerText.includes("allowed_tools") && innerText.includes("widen")) {
     return "Fork can't add tools beyond the calling agent's ceiling. Trim allowed_tools.";

--- a/web/src/components/LineagePanel.tsx
+++ b/web/src/components/LineagePanel.tsx
@@ -51,6 +51,9 @@ export interface LineagePanelProps {
   // The callback receives the currently-selected entry's name so the
   // caller doesn't have to re-derive it.
   onRediscover?: (name: string) => void;
+  // RFC AU — "Import" CTA beside "+ New" (skills + mcp-servers tabs).
+  // Opens the Claude Code import flow. Optional.
+  onImport?: () => void;
 }
 
 export default function LineagePanel({
@@ -64,6 +67,7 @@ export default function LineagePanel({
   onRetireRow,
   onPromoteRow,
   onRediscover,
+  onImport,
 }: LineagePanelProps) {
   const [selectedName, setSelectedName] = useState<string>(() =>
     entries.length > 0 ? entries[0]!.name : "",
@@ -182,6 +186,16 @@ export default function LineagePanel({
             + New {newCtaLabel(kind)}
           </button>
         )}
+        {onImport && (
+          <button
+            type="button"
+            className="lineage-row-action"
+            onClick={onImport}
+            style={{ marginTop: 12, marginLeft: 8 }}
+          >
+            Import…
+          </button>
+        )}
       </div>
     );
   }
@@ -211,6 +225,16 @@ export default function LineagePanel({
                 title={`Re-run ${selectedName}'s tools/list handshake and refresh cached tools`}
               >
                 Rediscover tools 🔄
+              </button>
+            )}
+            {onImport && (
+              <button
+                type="button"
+                className="lineage-row-action"
+                onClick={onImport}
+                title="Import Claude Code skills / MCP servers"
+              >
+                Import…
               </button>
             )}
             {onCreateNew && (

--- a/web/src/lib/claudeImport.test.ts
+++ b/web/src/lib/claudeImport.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, it } from "vitest";
+
+import type { LibraryEntry } from "../api";
+import {
+  detectKind,
+  parseMcpJson,
+  parseSkillMarkdown,
+  parseSource,
+  resolvePreview,
+  rewriteEnvRefs,
+  sanitizeDefName,
+} from "./claudeImport";
+
+describe("sanitizeDefName", () => {
+  it("maps to the AgentDef charset", () => {
+    expect(sanitizeDefName("My Cool Skill")).toBe("My-Cool-Skill");
+    expect(sanitizeDefName("weird/name.v2")).toBe("weird-name-v2");
+    expect(sanitizeDefName("  --edges--  ")).toBe("edges");
+    expect(sanitizeDefName("keeps_under-score")).toBe("keeps_under-score");
+  });
+  it("collapses __ for mcp names (tool-delimiter ambiguity)", () => {
+    expect(sanitizeDefName("brave__search", { mcp: true })).toBe("brave_search");
+    expect(sanitizeDefName("a___b", { mcp: true })).toBe("a_b");
+    // non-mcp keeps the underscores
+    expect(sanitizeDefName("a__b")).toBe("a__b");
+  });
+  it("truncates to 128 and trims trailing hyphens", () => {
+    const s = sanitizeDefName("x".repeat(200));
+    expect(s.length).toBe(128);
+  });
+  it("returns empty for name-less input", () => {
+    expect(sanitizeDefName("   ")).toBe("");
+    expect(sanitizeDefName("///")).toBe("");
+  });
+});
+
+describe("rewriteEnvRefs", () => {
+  it("rewrites bare refs to the LOOMCYCLE_ namespace", () => {
+    const r = rewriteEnvRefs("Bearer ${TOKEN}");
+    expect(r.value).toBe("Bearer ${LOOMCYCLE_TOKEN}");
+    expect(r.refs).toEqual(["LOOMCYCLE_TOKEN"]);
+    expect(r.rewrites).toEqual([{ from: "${TOKEN}", to: "${LOOMCYCLE_TOKEN}" }]);
+  });
+  it("leaves already-prefixed refs untouched", () => {
+    const r = rewriteEnvRefs("${LOOMCYCLE_KEY}");
+    expect(r.value).toBe("${LOOMCYCLE_KEY}");
+    expect(r.rewrites).toEqual([]);
+    expect(r.refs).toEqual(["LOOMCYCLE_KEY"]);
+  });
+  it("handles multiple refs and plain text", () => {
+    const r = rewriteEnvRefs("${A}-${B}-plain");
+    expect(r.value).toBe("${LOOMCYCLE_A}-${LOOMCYCLE_B}-plain");
+    expect(r.refs.sort()).toEqual(["LOOMCYCLE_A", "LOOMCYCLE_B"]);
+  });
+});
+
+describe("parseSkillMarkdown", () => {
+  it("splits frontmatter (hyphenated allowed-tools) from body", () => {
+    const md = `---\nname: my-skill\ndescription: does a thing\nallowed-tools: [WebFetch, Read]\n---\n# Body\ninstructions here`;
+    const { candidate, error } = parseSkillMarkdown(md);
+    expect(error).toBeUndefined();
+    expect(candidate!.kind).toBe("skill");
+    expect(candidate!.name).toBe("my-skill");
+    expect(candidate!.overlay).toEqual({
+      body: "# Body\ninstructions here",
+      description: "does a thing",
+      allowed_tools: ["WebFetch", "Read"],
+    });
+  });
+  it("normalizes CRLF and accepts allowed-tools as a comma string", () => {
+    const md = `---\r\nname: s\r\nallowed-tools: WebFetch, Read\r\n---\r\nbody text`;
+    const { candidate } = parseSkillMarkdown(md);
+    expect(candidate!.overlay.allowed_tools).toEqual(["WebFetch", "Read"]);
+    expect(candidate!.overlay.body).toBe("body text");
+  });
+  it("treats a no-frontmatter file as body-only, using the fallback name", () => {
+    const { candidate, error } = parseSkillMarkdown("just a body", "from-dir");
+    expect(error).toBeUndefined();
+    expect(candidate!.name).toBe("from-dir");
+    expect(candidate!.overlay).toEqual({ body: "just a body" });
+  });
+  it("errors on empty body", () => {
+    const { error } = parseSkillMarkdown(`---\nname: s\n---\n   `);
+    expect(error).toMatch(/empty body/);
+  });
+  it("errors when no name is derivable", () => {
+    const { error } = parseSkillMarkdown("body with no name");
+    expect(error).toMatch(/no usable name/);
+  });
+  it("sanitizes the frontmatter name and warns", () => {
+    const { candidate } = parseSkillMarkdown(`---\nname: My Skill\n---\nbody`);
+    expect(candidate!.name).toBe("My-Skill");
+    expect(candidate!.warnings.some((w) => w.includes("sanitized"))).toBe(true);
+  });
+});
+
+describe("parseMcpJson", () => {
+  it("parses the wrapped mcpServers shape with an http server + header rewrite", () => {
+    const json = JSON.stringify({
+      mcpServers: {
+        brave: { type: "http", url: "https://api.brave.com/mcp", headers: { Authorization: "Bearer ${BRAVE_KEY}" } },
+      },
+    });
+    const r = parseMcpJson(json);
+    expect(r.errors).toEqual([]);
+    expect(r.candidates).toHaveLength(1);
+    const c = r.candidates[0]!;
+    expect(c.transport).toBe("http");
+    expect(c.overlay).toEqual({
+      transport: "http",
+      url: "https://api.brave.com/mcp",
+      headers: { Authorization: "Bearer ${LOOMCYCLE_BRAVE_KEY}" },
+    });
+    expect(c.secretRefs).toEqual(["LOOMCYCLE_BRAVE_KEY"]);
+  });
+  it("accepts the bare name→server map and detects stdio from command", () => {
+    const json = JSON.stringify({
+      fs: { command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "${ROOT}"], env: { TOKEN: "${TOKEN}" } },
+    });
+    const r = parseMcpJson(json);
+    expect(r.candidates).toHaveLength(1);
+    const c = r.candidates[0]!;
+    expect(c.transport).toBe("stdio");
+    expect(c.overlay).toEqual({
+      transport: "stdio",
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "${LOOMCYCLE_ROOT}"],
+      env: { TOKEN: "${LOOMCYCLE_TOKEN}" },
+    });
+    expect(c.secretRefs.sort()).toEqual(["LOOMCYCLE_ROOT", "LOOMCYCLE_TOKEN"]);
+  });
+  it("maps sse → streamable-http and defaults url-only to http", () => {
+    const r = parseMcpJson(
+      JSON.stringify({ mcpServers: { a: { type: "sse", url: "https://x/y" }, b: { url: "https://z/w" } } }),
+    );
+    const byName = Object.fromEntries(r.candidates.map((c) => [c.name, c.transport]));
+    expect(byName.a).toBe("streamable-http");
+    expect(byName.b).toBe("http");
+  });
+  it("collapses __ in server names", () => {
+    const r = parseMcpJson(JSON.stringify({ mcpServers: { "we__ird": { url: "https://x/y" } } }));
+    expect(r.candidates[0]!.name).toBe("we_ird");
+  });
+  it("warns on an unmapped registries block", () => {
+    const r = parseMcpJson(JSON.stringify({ registries: {}, mcpServers: { a: { url: "https://x/y" } } }));
+    expect(r.warnings.some((w) => w.includes("registries"))).toBe(true);
+  });
+  it("errors on invalid JSON", () => {
+    expect(parseMcpJson("{not json").errors[0]).toMatch(/not valid JSON/);
+  });
+});
+
+describe("detectKind", () => {
+  it("keys off filename then content", () => {
+    expect(detectKind("", "skills/foo/SKILL.md")).toBe("skill");
+    expect(detectKind("", "path/.mcp.json")).toBe("mcp");
+    expect(detectKind("---\nname: x\n---\nbody")).toBe("skill");
+    expect(detectKind(JSON.stringify({ mcpServers: { a: { url: "u" } } }))).toBe("mcp");
+    expect(detectKind("plain text no hints")).toBe("unknown");
+  });
+});
+
+// ---- preview / collision resolution ------------------------------------
+
+function entry(over: Partial<LibraryEntry> & { name: string }): LibraryEntry {
+  return {
+    source: "dynamic-only",
+    in_static: false,
+    in_substrate: true,
+    version_count: 1,
+    ...over,
+  };
+}
+
+describe("resolvePreview", () => {
+  const opts = { stdioAllowed: false, httpAllowlistConfigured: true, isTenant: true };
+
+  it("Create when no collision", () => {
+    const { candidate } = parseSkillMarkdown(`---\nname: fresh\n---\nbody`);
+    const rows = resolvePreview([candidate!], { skills: [], mcp: [] }, opts);
+    expect(rows[0]!.action).toBe("create");
+  });
+
+  it("Fork over a live dynamic skill, parent = active_def_id", () => {
+    const { candidate } = parseSkillMarkdown(`---\nname: dup\n---\nbody`);
+    const rows = resolvePreview(
+      [candidate!],
+      { skills: [entry({ name: "dup", active_def_id: "def_123" })], mcp: [] },
+      opts,
+    );
+    expect(rows[0]!.action).toBe("fork");
+    expect(rows[0]!.parentDefId).toBe("def_123");
+  });
+
+  it("Create (reclaims) when the only versions are retired", () => {
+    const { candidate } = parseSkillMarkdown(`---\nname: dup\n---\nbody`);
+    const rows = resolvePreview(
+      [candidate!],
+      { skills: [entry({ name: "dup", active_def_id: "def_9", active_retired: true })], mcp: [] },
+      opts,
+    );
+    expect(rows[0]!.action).toBe("create");
+  });
+
+  it("blocks a stdio server when the capability is off", () => {
+    const r = parseMcpJson(JSON.stringify({ mcpServers: { s: { command: "x" } } }));
+    const rows = resolvePreview(r.candidates, { skills: [], mcp: [] }, opts);
+    expect(rows[0]!.action).toBe("blocked");
+    expect(rows[0]!.note).toMatch(/LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO/);
+  });
+
+  it("allows a stdio server with an RCE warning when the capability is on", () => {
+    const r = parseMcpJson(JSON.stringify({ mcpServers: { s: { command: "x" } } }));
+    const rows = resolvePreview(r.candidates, { skills: [], mcp: [] }, { ...opts, stdioAllowed: true });
+    expect(rows[0]!.action).toBe("create");
+    expect(rows[0]!.warnings.some((w) => w.includes("RCE"))).toBe(true);
+  });
+
+  it("MCP static-name → per-tenant override (Create) for a tenant, Fork otherwise", () => {
+    const r = parseMcpJson(JSON.stringify({ mcpServers: { brave: { url: "https://x/y" } } }));
+    const staticHit = { skills: [], mcp: [entry({ name: "brave", in_static: true, source: "static-only" as const, in_substrate: false, active_def_id: undefined })] };
+    expect(resolvePreview(r.candidates, staticHit, { ...opts, isTenant: true })[0]!.action).toBe("create");
+    expect(resolvePreview(r.candidates, staticHit, { ...opts, isTenant: false })[0]!.action).toBe("fork");
+  });
+
+  it("warns about secret refs (tenant can't provision host env)", () => {
+    const r = parseMcpJson(JSON.stringify({ mcpServers: { a: { url: "https://x", headers: { A: "${K}" } } } }));
+    const rows = resolvePreview(r.candidates, { skills: [], mcp: [] }, opts);
+    expect(rows[0]!.warnings.some((w) => w.includes("LOOMCYCLE_K"))).toBe(true);
+  });
+});
+
+describe("parseSource dispatch", () => {
+  it("routes skill vs mcp", () => {
+    expect(parseSource("---\nname: s\n---\nbody", "skill").candidates[0]!.kind).toBe("skill");
+    expect(parseSource(JSON.stringify({ mcpServers: { a: { url: "u" } } }), "mcp").candidates[0]!.kind).toBe("mcp-server");
+  });
+});

--- a/web/src/lib/claudeImport.ts
+++ b/web/src/lib/claudeImport.ts
@@ -1,0 +1,469 @@
+// claudeImport.ts — RFC AU. Pure, browser-side parser that maps Claude Code
+// skills (SKILL.md) and MCP tool-servers (mcp.json / .mcp.json) onto loomcycle
+// substrate overlays, for the Web-UI import flow. It mirrors the Go reference
+// (internal/skills/loader.go parseSkill, internal/claudeimport/{skill,mcp}.go)
+// but emits `skilldef` / `mcpserverdef` overlays directly instead of yaml — the
+// tenant-safe POST /v1/_skilldef / /v1/_mcpserverdef write path already exists.
+//
+// No network, no React — unit-testable in isolation. Parsing is intentionally
+// client-side (RFC AU decision): the common case is a frontmatter split + a JSON
+// map, and the write path is already exposed and tenant-scoped.
+// js-yaml v4 `load` is the SAFE loader — DEFAULT_SCHEMA has no code-execution
+// tags (the unsafe schema is opt-in). Matches LibraryEditModal's usage.
+import { load as yamlLoad } from "js-yaml";
+
+import type { LibraryEntry } from "../api";
+
+export type ImportKind = "skill" | "mcp-server";
+export type Transport = "http" | "streamable-http" | "stdio";
+
+// An env-var reference we rewrote to the LOOMCYCLE_ namespace (mirrors the Go
+// importer's rewriteEnvRefs). Surfaced in the preview so the operator sees what
+// they must provision on the host — a tenant can't set host env vars.
+export interface EnvRewrite {
+  from: string; // e.g. "${TOKEN}"
+  to: string; // e.g. "${LOOMCYCLE_TOKEN}"
+}
+
+export interface ImportCandidate {
+  kind: ImportKind;
+  name: string; // sanitized, substrate-ready
+  originalName: string; // as found in the source (pre-sanitization)
+  overlay: Record<string, unknown>; // the create/fork overlay body
+  transport?: Transport; // mcp-server only
+  /** LOOMCYCLE_* env vars this server needs the operator to provision. */
+  secretRefs: string[];
+  /** ${FOO}→${LOOMCYCLE_FOO} rewrites applied (for the preview). */
+  envRewrites: EnvRewrite[];
+  warnings: string[];
+}
+
+export interface ParseResult {
+  candidates: ImportCandidate[];
+  /** Fatal errors — the input could not be parsed into any candidate. */
+  errors: string[];
+  /** Non-fatal, source-level notes (e.g. an unmapped `registries` block). */
+  warnings: string[];
+}
+
+// ---- name sanitization -------------------------------------------------
+
+// sanitizeDefName maps an arbitrary source name onto the AgentDef charset
+// (^[A-Za-z0-9_-]{1,128}$) so imported names are consistent even though the
+// skill/mcp substrates don't (yet) validate the charset. For MCP names, `__`
+// is collapsed to `_` first: the tool-naming scheme is `mcp__<server>__<tool>`,
+// so a `__` inside the server name makes that delimiter ambiguous.
+export function sanitizeDefName(raw: string, opts?: { mcp?: boolean }): string {
+  let s = (raw ?? "").trim();
+  if (opts?.mcp) s = s.replace(/_{2,}/g, "_");
+  s = s.replace(/[^A-Za-z0-9_-]+/g, "-"); // disallowed runs → single hyphen
+  s = s.replace(/^-+|-+$/g, ""); // strip leading/trailing hyphens
+  if (s.length > 128) s = s.slice(0, 128).replace(/-+$/g, "");
+  return s;
+}
+
+// ---- env-ref rewrite ---------------------------------------------------
+
+const ENV_REF_RE = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+
+// rewriteEnvRefs rewrites ${FOO}→${LOOMCYCLE_FOO} (leaving already-prefixed
+// refs untouched), mirroring the Go importer. Returns the rewritten string,
+// the list of rewrites, and the set of resulting LOOMCYCLE_ var names.
+export function rewriteEnvRefs(value: string): {
+  value: string;
+  rewrites: EnvRewrite[];
+  refs: string[];
+} {
+  const rewrites: EnvRewrite[] = [];
+  const refs = new Set<string>();
+  const out = value.replace(ENV_REF_RE, (_m, inner: string) => {
+    if (inner.startsWith("LOOMCYCLE_")) {
+      refs.add(inner);
+      return "${" + inner + "}";
+    }
+    const to = "LOOMCYCLE_" + inner;
+    rewrites.push({ from: "${" + inner + "}", to: "${" + to + "}" });
+    refs.add(to);
+    return "${" + to + "}";
+  });
+  return { value: out, rewrites, refs: [...refs] };
+}
+
+// ---- skill parsing -----------------------------------------------------
+
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  // Claude Code uses the hyphenated key; loomcycle's overlay uses underscore.
+  "allowed-tools"?: unknown;
+  allowed_tools?: unknown;
+}
+
+function coerceStringList(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x).trim()).filter(Boolean);
+  if (typeof v === "string")
+    return v
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean);
+  return [];
+}
+
+// parseSkillMarkdown maps a SKILL.md (frontmatter + body) to a skilldef
+// candidate. fallbackName seeds the name when the frontmatter omits it (e.g.
+// the `skills/<name>/SKILL.md` directory, or an uploaded filename's parent).
+export function parseSkillMarkdown(
+  text: string,
+  fallbackName?: string,
+): { candidate?: ImportCandidate; error?: string } {
+  const norm = text.replace(/\r\n/g, "\n");
+  let fm: SkillFrontmatter = {};
+  let body = norm;
+
+  if (norm.startsWith("---\n")) {
+    // Find the closing fence: a line that is exactly "---".
+    const end = norm.indexOf("\n---", 3);
+    if (end !== -1) {
+      const fmText = norm.slice(4, end + 1);
+      // consume the closing fence + following newline
+      let rest = norm.slice(end + 4);
+      if (rest.startsWith("\n")) rest = rest.slice(1);
+      body = rest;
+      try {
+        const parsed = yamlLoad(fmText);
+        if (parsed && typeof parsed === "object") fm = parsed as SkillFrontmatter;
+      } catch (e) {
+        return { error: `frontmatter is not valid YAML: ${e instanceof Error ? e.message : String(e)}` };
+      }
+    }
+  }
+
+  const warnings: string[] = [];
+  const originalName = String(fm.name ?? fallbackName ?? "").trim();
+  const name = sanitizeDefName(originalName);
+  if (!name) {
+    return { error: "skill has no usable name — add a `name:` frontmatter field or set one below." };
+  }
+  if (name !== originalName && originalName) {
+    warnings.push(`name sanitized: "${originalName}" → "${name}"`);
+  }
+  if (!body.trim()) {
+    return { error: `skill "${name}" has an empty body — the substrate refuses empty skills.` };
+  }
+  if (body.length > 100 * 1024) {
+    warnings.push("body is large (>100KB) — may exceed the operator's LOOMCYCLE_SKILL_DEF_MAX_BODY_BYTES cap.");
+  }
+
+  const allowedTools = coerceStringList(fm["allowed-tools"] ?? fm.allowed_tools);
+  const overlay: Record<string, unknown> = { body };
+  const description = typeof fm.description === "string" ? fm.description.trim() : "";
+  if (description) overlay.description = description;
+  if (allowedTools.length > 0) overlay.allowed_tools = allowedTools;
+
+  return {
+    candidate: {
+      kind: "skill",
+      name,
+      originalName: originalName || name,
+      overlay,
+      secretRefs: [],
+      envRewrites: [],
+      warnings,
+    },
+  };
+}
+
+// ---- mcp parsing -------------------------------------------------------
+
+interface RawMcpServer {
+  type?: string;
+  transport?: string;
+  command?: string;
+  args?: unknown;
+  env?: Record<string, unknown>;
+  url?: string;
+  headers?: Record<string, unknown>;
+  description?: string;
+}
+
+function detectTransport(s: RawMcpServer): Transport {
+  const t = String(s.type ?? s.transport ?? "").toLowerCase();
+  if (t === "stdio") return "stdio";
+  // loomcycle has no `sse` transport — map it to streamable-http (the streaming
+  // HTTP transport). An explicit `http` stays http.
+  if (t === "streamable-http" || t === "streamablehttp" || t === "sse") return "streamable-http";
+  if (t === "http") return "http";
+  if (s.command) return "stdio";
+  // url-only, no type → http (matches the Go importer default).
+  return "http";
+}
+
+// looksLikeServerMap reports whether a bare object is a map of server-name →
+// server-spec (each value an object with command or url), so we can accept the
+// un-wrapped `.mcp.json` shape as well as the `{ mcpServers: {...} }` wrapper.
+function looksLikeServerMap(o: Record<string, unknown>): boolean {
+  const vals = Object.values(o);
+  if (vals.length === 0) return false;
+  return vals.every(
+    (v) => v && typeof v === "object" && ("command" in (v as object) || "url" in (v as object)),
+  );
+}
+
+// parseMcpJson maps an mcp.json / .mcp.json to per-server mcpserverdef
+// candidates. Accepts both `{ mcpServers: {...} }` and a bare `{ name: {...} }`.
+export function parseMcpJson(text: string): ParseResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(text) as Record<string, unknown>;
+  } catch (e) {
+    return { candidates: [], errors: [`not valid JSON: ${e instanceof Error ? e.message : String(e)}`], warnings: [] };
+  }
+  if (!obj || typeof obj !== "object") {
+    return { candidates: [], errors: ["expected a JSON object of MCP servers"], warnings: [] };
+  }
+
+  if ("registries" in obj) {
+    warnings.push("`registries` block ignored — loomcycle has no remote-registry surface (airgapped-friendly).");
+  }
+
+  let servers: Record<string, unknown>;
+  if (obj.mcpServers && typeof obj.mcpServers === "object") {
+    servers = obj.mcpServers as Record<string, unknown>;
+  } else if (looksLikeServerMap(obj)) {
+    servers = obj;
+  } else {
+    return {
+      candidates: [],
+      errors: ['no MCP servers found (expected a "mcpServers" object or a bare name→server map)'],
+      warnings,
+    };
+  }
+
+  const candidates: ImportCandidate[] = [];
+  for (const [rawName, rawSpec] of Object.entries(servers)) {
+    if (rawName === "mcpServers" || rawName === "registries") continue;
+    if (!rawSpec || typeof rawSpec !== "object") {
+      warnings.push(`server "${rawName}": skipped (not an object)`);
+      continue;
+    }
+    const spec = rawSpec as RawMcpServer;
+    const warns: string[] = [];
+    const name = sanitizeDefName(rawName, { mcp: true });
+    if (!name) {
+      warnings.push(`server "${rawName}": skipped (name has no usable characters)`);
+      continue;
+    }
+    if (name !== rawName) warns.push(`name sanitized: "${rawName}" → "${name}"`);
+
+    const transport = detectTransport(spec);
+    const overlay: Record<string, unknown> = { transport };
+    const rewrites: EnvRewrite[] = [];
+    const refs = new Set<string>();
+    const collect = (v: string): string => {
+      const r = rewriteEnvRefs(v);
+      rewrites.push(...r.rewrites);
+      r.refs.forEach((x) => refs.add(x));
+      return r.value;
+    };
+
+    if (transport === "stdio") {
+      if (!spec.command) {
+        warnings.push(`server "${rawName}": stdio server has no command — skipped.`);
+        continue;
+      }
+      overlay.command = collect(String(spec.command));
+      const args = coerceStringList(spec.args).map(collect);
+      if (args.length > 0) overlay.args = args;
+      if (spec.env && typeof spec.env === "object") {
+        const env: Record<string, string> = {};
+        for (const [k, v] of Object.entries(spec.env)) env[k] = collect(String(v));
+        if (Object.keys(env).length > 0) overlay.env = env;
+      }
+    } else {
+      if (!spec.url) {
+        warnings.push(`server "${rawName}": http server has no url — skipped.`);
+        continue;
+      }
+      overlay.url = collect(String(spec.url));
+      if (spec.headers && typeof spec.headers === "object") {
+        const headers: Record<string, string> = {};
+        for (const [k, v] of Object.entries(spec.headers)) headers[k] = collect(String(v));
+        if (Object.keys(headers).length > 0) overlay.headers = headers;
+      }
+    }
+    if (typeof spec.description === "string" && spec.description.trim()) {
+      overlay.description = spec.description.trim();
+    }
+
+    candidates.push({
+      kind: "mcp-server",
+      name,
+      originalName: rawName,
+      overlay,
+      transport,
+      secretRefs: [...refs],
+      envRewrites: rewrites,
+      warnings: warns,
+    });
+  }
+
+  if (candidates.length === 0 && errors.length === 0) {
+    errors.push("no importable MCP servers found.");
+  }
+  return { candidates, errors, warnings };
+}
+
+// ---- auto-detect + unified entry --------------------------------------
+
+export type DetectedKind = "skill" | "mcp" | "unknown";
+
+// detectKind guesses whether a blob is a SKILL.md or an mcp.json, from the
+// filename first, then the content. `unknown` → the UI should let the operator
+// pick.
+export function detectKind(text: string, filename?: string): DetectedKind {
+  const fn = (filename ?? "").toLowerCase();
+  if (fn.endsWith("skill.md")) return "skill";
+  if (fn.endsWith(".mcp.json") || fn.endsWith("mcp.json") || fn.endsWith(".json")) return "mcp";
+  if (fn.endsWith(".md")) return "skill";
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("---")) return "skill";
+  if (trimmed.startsWith("{")) {
+    try {
+      const o = JSON.parse(text) as Record<string, unknown>;
+      if (o && typeof o === "object" && (o.mcpServers || looksLikeServerMap(o))) return "mcp";
+    } catch {
+      /* not JSON */
+    }
+  }
+  return "unknown";
+}
+
+// parseSource parses a single blob given an explicit kind (from auto-detect or
+// an operator override) into candidates.
+export function parseSource(
+  text: string,
+  kind: "skill" | "mcp",
+  filename?: string,
+): ParseResult {
+  if (kind === "skill") {
+    const fallback = deriveSkillName(filename);
+    const { candidate, error } = parseSkillMarkdown(text, fallback);
+    if (error) return { candidates: [], errors: [error], warnings: [] };
+    return { candidates: candidate ? [candidate] : [], errors: [], warnings: [] };
+  }
+  return parseMcpJson(text);
+}
+
+// deriveSkillName pulls a name from a `skills/<name>/SKILL.md` path or a plain
+// `<name>.md` filename, for when the frontmatter omits `name`.
+function deriveSkillName(filename?: string): string | undefined {
+  if (!filename) return undefined;
+  const parts = filename.split("/").filter(Boolean);
+  const base = parts[parts.length - 1] ?? "";
+  if (base.toLowerCase() === "skill.md" && parts.length >= 2) return parts[parts.length - 2];
+  if (base.toLowerCase().endsWith(".md")) return base.slice(0, -3);
+  return undefined;
+}
+
+// ---- preview / collision resolution ------------------------------------
+
+export type PreviewAction = "create" | "fork" | "blocked";
+
+export interface PreviewRow {
+  candidate: ImportCandidate;
+  action: PreviewAction;
+  /** For fork: the parent def to hang off (omit → bootstrap-from-static). */
+  parentDefId?: string;
+  note?: string; // why fork / why blocked
+  warnings: string[]; // candidate warnings + resolution + capability warnings
+}
+
+export interface ResolveOpts {
+  stdioAllowed: boolean;
+  httpAllowlistConfigured: boolean;
+  /** A non-admin tenant may create a per-tenant override of a static MCP name;
+   *  skills always fork over a static name. */
+  isTenant: boolean;
+}
+
+// reclaimable mirrors LibraryEditModal.validateLocal: a name with no live active
+// version (all retired) and not static can be (re)created — it just allocates
+// the next version. (skills/mcp LibraryEntry omit live_version_count, so we key
+// on active_def_id + active_retired, matching the modal.)
+function reclaimable(hit: LibraryEntry): boolean {
+  return !hit.in_static && (!hit.active_def_id || hit.active_retired === true);
+}
+
+// resolvePreview turns candidates + the existing tenant Library entries into
+// per-row create/fork/blocked decisions and warnings — the dry-run table. Pure:
+// the server 422s stay authoritative; this only fails fast + guides.
+export function resolvePreview(
+  candidates: ImportCandidate[],
+  existing: { skills: LibraryEntry[]; mcp: LibraryEntry[] },
+  opts: ResolveOpts,
+): PreviewRow[] {
+  return candidates.map((c) => {
+    const warnings = [...c.warnings];
+    const entries = c.kind === "skill" ? existing.skills : existing.mcp;
+    const hit = entries.find((e) => e.name === c.name);
+
+    // Capability / secret warnings.
+    if (c.kind === "mcp-server") {
+      if (c.transport === "stdio" && !opts.stdioAllowed) {
+        return {
+          candidate: c,
+          action: "blocked",
+          note: "stdio import is off. Set LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1 (host RCE — operator opt-in), or declare it in yaml mcp_servers:.",
+          warnings,
+        };
+      }
+      if (c.transport === "stdio") {
+        warnings.push("⚠ stdio runs an arbitrary command on the loomcycle host (RCE-class trust).");
+      }
+      if (c.transport !== "stdio" && !opts.httpAllowlistConfigured) {
+        warnings.push("no http host allowlist is configured — this will 422 unless the operator lists the host.");
+      }
+      if (c.secretRefs.length > 0) {
+        warnings.push(
+          `needs host env: ${c.secretRefs.join(", ")} — a tenant can't set these; ask your operator to provision them (the ref is stored, never the value).`,
+        );
+      }
+    }
+
+    let action: PreviewAction = "create";
+    let parentDefId: string | undefined;
+    let note: string | undefined;
+
+    if (hit) {
+      if (c.kind === "skill") {
+        if (hit.in_static || (hit.active_def_id && !reclaimable(hit))) {
+          action = "fork";
+          parentDefId =
+            hit.active_def_id && !hit.active_def_id.startsWith("static:") ? hit.active_def_id : undefined;
+          note = hit.in_static
+            ? "a skill of this name is defined in yaml — importing forks a tenant version over it."
+            : "an active version exists — importing adds a new version (fork).";
+        } else if (reclaimable(hit)) {
+          note = "a retired version of this name exists — importing reclaims it (new version).";
+        }
+      } else {
+        // MCP: a tenant MAY create a per-tenant override of a static-named
+        // server (RFC N); only a live dynamic version forces a fork.
+        if (hit.active_def_id && !reclaimable(hit)) {
+          action = "fork";
+          parentDefId = !hit.active_def_id.startsWith("static:") ? hit.active_def_id : undefined;
+          note = "an active version exists — importing adds a new version (fork).";
+        } else if (hit.in_static && opts.isTenant) {
+          note = "a server of this name is defined in yaml — importing creates a per-tenant override.";
+        } else if (hit.in_static && !opts.isTenant) {
+          action = "fork";
+          note = "a server of this name is defined in yaml — importing forks a version over it.";
+        }
+      }
+    }
+
+    return { candidate: c, action, parentDefId, note, warnings };
+  });
+}

--- a/web/src/pages/LibraryView.tsx
+++ b/web/src/pages/LibraryView.tsx
@@ -16,6 +16,8 @@ import LibraryEditModal, {
   type ModalKind,
   type ModalMode,
 } from "../components/LibraryEditModal";
+import ImportModal, { type LocalAgentSeed } from "../components/ImportModal";
+import { usePrincipal } from "../components/Layout";
 
 // LibraryView is the v0.9.x Introspection surface — three sub-tabs
 // over the AgentDef / SkillDef / MCPServerDef substrates. Each
@@ -52,6 +54,16 @@ export default function LibraryView() {
     mode: ModalMode;
     forkSource?: DefRow;
   } | null>(null);
+  // RFC AU — the Claude Code import flow (skills + mcp tabs).
+  const [importOpen, setImportOpen] = useState(false);
+
+  const principal = usePrincipal();
+  const capabilities = principal?.capabilities;
+  const stdioAllowed = capabilities?.mcp_allow_dynamic_stdio === true;
+  // A non-admin principal is a tenant operator (tenant_id≠"") — it may create a
+  // per-tenant override of a static-named MCP server; admin/open-mode can't at
+  // the shared "" tenant, so the preview treats a static collision as a fork.
+  const isTenant = principal ? !principal.is_admin : false;
 
   useEffect(() => {
     let cancelled = false;
@@ -93,12 +105,33 @@ export default function LibraryView() {
     sub === "skills" ? "skill" : sub === "mcp-servers" ? "mcp-server" : "agent";
   const tabSubstrate: SubstrateKind =
     sub === "skills" ? "skilldef" : sub === "mcp-servers" ? "mcpserverdef" : "agentdef";
-  const tabEntries: LibraryEntry[] =
-    sub === "skills" ? skills : sub === "mcp-servers" ? mcps : agents;
 
   const handleCreate = () => setModal({ kind: tabKind, mode: "create" });
   const handleEdit = (row: DefRow) =>
     setModal({ kind: tabKind, mode: "fork", forkSource: row });
+
+  // After an import, "Use with a local LLM" opens the agent-create modal
+  // prefilled with the imported skills + mcp tools on a local model. A synthetic
+  // create-mode forkSource seeds the fields (create ignores forkSource for the
+  // write — it only prefills), so no new modal prop is needed.
+  const handleWireLocalAgent = (seed: LocalAgentSeed) => {
+    const definition: Record<string, unknown> = { model: "local-medium" };
+    if (seed.skills.length > 0) definition.skills = seed.skills;
+    const allowed = seed.mcpServers.map((s) => `mcp__${s}__*`);
+    if (allowed.length > 0) definition.allowed_tools = allowed;
+    setImportOpen(false);
+    setModal({
+      kind: "agent",
+      mode: "create",
+      forkSource: {
+        def_id: "prefill:local-agent",
+        name: "",
+        version: 0,
+        created_at: "",
+        definition,
+      },
+    });
+  };
   const handlePromote = async (row: DefRow) => {
     try {
       await promoteDef(tabSubstrate, row.def_id);
@@ -173,6 +206,7 @@ export default function LibraryView() {
             onEditRow={handleEdit}
             onRetireRow={handleRetire}
             onPromoteRow={handlePromote}
+            onImport={() => setImportOpen(true)}
           />
         )}
         {sub === "mcp-servers" && (
@@ -187,6 +221,7 @@ export default function LibraryView() {
             onRetireRow={handleRetire}
             onPromoteRow={handlePromote}
             onRediscover={handleRediscover}
+            onImport={() => setImportOpen(true)}
           />
         )}
       </div>
@@ -195,12 +230,26 @@ export default function LibraryView() {
           kind={modal.kind}
           mode={modal.mode}
           forkSource={modal.forkSource}
-          existingNames={tabEntries}
+          existingNames={
+            modal.kind === "agent" ? agents : modal.kind === "skill" ? skills : mcps
+          }
+          stdioAllowed={stdioAllowed}
           onClose={() => setModal(null)}
           onSaved={() => {
             setModal(null);
             refreshNow();
           }}
+        />
+      )}
+      {importOpen && (
+        <ImportModal
+          skills={skills}
+          mcp={mcps}
+          capabilities={capabilities}
+          isTenant={isTenant}
+          onClose={() => setImportOpen(false)}
+          onImported={refreshNow}
+          onWireLocalAgent={handleWireLocalAgent}
         />
       )}
       <Outlet />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5949,3 +5949,83 @@ button.primary:disabled {
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
+
+/* ── RFC AU — Claude Code import (ImportModal) preview + results ────────── */
+.import-preview-list {
+  max-height: 46vh;
+  overflow-y: auto;
+  margin: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.import-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  background: var(--bg-soft);
+}
+.import-row-blocked {
+  opacity: 0.55;
+}
+.import-row-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.import-name-input {
+  flex: 1 1 160px;
+  min-width: 120px;
+  padding: 3px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-soft-2);
+  color: var(--fg);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.import-action-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+.import-action-create {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.import-action-fork {
+  color: var(--running);
+  border-color: var(--running);
+}
+.import-action-blocked {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+.import-row-note {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.import-row-warning {
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--running);
+}
+.import-result-ok {
+  color: var(--accent);
+  font-weight: 700;
+}
+.import-result-error {
+  color: var(--danger);
+  font-weight: 700;
+}
+.import-result-skipped,
+.import-result-pending {
+  color: var(--fg-soft);
+  font-weight: 700;
+}


### PR DESCRIPTION
Implements **RFC AU** (Phases 1 + 2): a self-service Web UI flow letting a `substrate:tenant` operator import Claude Code **skills** (`SKILL.md`) and **MCP tool-servers** (`mcp.json`) into their own tenant storage, then wire them to a **local-LLM** agent.

## Why
A tenant already *owns* SkillDefs/MCPServerDefs in its tenant (RFC AF/N) and the Library UI lists + create/fork-edits them (RFC AS) — but had no way to *bring in* an existing Claude Code skill folder / `mcp.json`. The only importer, `loomcycle import claude-code`, writes yaml to disk (operator/CLI scope), not per-tenant substrate rows. This closes that gap in the browser.

## What
- **Import flow** (`ImportModal.tsx`): an "Import…" button on the Library **Skills** and **MCP Servers** subtabs → **Source** (upload a `SKILL.md`/`mcp.json`, or paste; auto-detect + override) → **Preview** (dry-run: per-row create/fork/blocked, editable name, collision + warning surface) → **Commit** (sequential `createDef`/`forkDef`, per-row status).
- **Client-side parser** (`web/src/lib/claudeImport.ts`, pure + 28 unit tests): mirrors the Go importer — frontmatter split (hyphenated `allowed-tools`→`allowed_tools`), wrapped/bare `mcpServers`, transport detection (`sse`→`streamable-http`), `${FOO}`→`${LOOMCYCLE_FOO}` rewrite, name sanitization to the AgentDef charset (collapsing `__` in mcp names), and create/fork/blocked resolution.
- **stdio (host RCE) safely gated**: `GET /v1/_me` now advertises a booleans-only `capabilities` block (`mcp_allow_dynamic_stdio`, `http_host_allowlist_configured`) — **never the allowlist contents**. The UI enables stdio import only when the operator set `LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1`, with a loud RCE warning; off → the row is blocked, naming the flag. `LibraryEditModal`'s `McpFields` gains `command`/`args`/`env` (so imported stdio defs are editable).
- **Use with a local LLM**: after import, prefills the agent-create modal with `model: local-medium` + the imported skills + `mcp__<server>__*` tools, warning that small local models silently ignore tool calls (native ollama function-calling, no repair shim).

**No new backend routes, no parse endpoint, no substrate schema change** — the tenant-safe write path (`POST /v1/_skilldef`, `/v1/_mcpserverdef`, both `ScopeTenant`) and the MCP overlay's `command`/`args`/`env` already existed. The only backend change is the read-only `/v1/_me` capability block.

## Security posture (RFC AU §7)
- stdio = host RCE → strictly operator-flag-gated (default off = default safe), loud warning; secret refs rewritten to `${LOOMCYCLE_*}` and **stored as refs, never values** (a tenant can't provision host env → the preview says so and lists the exact var names); http SSRF stays enforced server-side (the UI only warns + surfaces the 422); names sanitized client-side; `/v1/_me` never leaks allowlist contents.

## Tested
- **Go**: `go test ./...` clean; new `TestWhoami_CapabilitiesReflectConfig` (flags reflect cfg; allowlist host never in the body). `gofmt`/`vet` clean.
- **Web**: new **vitest** harness (the project had none) + `npm run test` wired into CI; 28 parser/preview unit tests pass; `npm run typecheck` clean; `make build-all` embeds + builds.
- **Manual**: booted the binary with `LOOMCYCLE_MCP_ALLOW_DYNAMIC_STDIO=1 LOOMCYCLE_HTTP_HOST_ALLOWLIST=example.com` → `GET /v1/_me` returns `capabilities: {mcp_allow_dynamic_stdio: true, http_host_allowlist_configured: true}` with **no** leak of `example.com`.

RFC: `loomcycle-internal/doc-internal/rfcs/webui-import-skills-mcp.md`. Open questions from the RFC (url-only default transport, multi-file skills, `.zip`/batch = Phase 3) are noted there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD