### PR TITLE
fix(path): synthesize implicit directories in one-level ls (RFC AL)

### DIFF
--- a/internal/tools/builtin/pathtool.go
+++ b/internal/tools/builtin/pathtool.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -154,22 +155,70 @@ func (p *Path) ls(ctx context.Context, tenantID, scope, scopeID string, in pathI
 		return errResult(err.Error()), nil
 	}
 	prefix := dirPrefix(canonical)
-	var rows []store.DirentRow
+
+	// Recursive ls returns every descendant dirent, flat (full paths).
 	if in.Recursive {
-		rows, err = p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, prefix)
-	} else {
-		rows, err = p.Store.DirentList(ctx, tenantID, scope, scopeID, prefix)
+		rows, err := p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, prefix)
+		if err != nil {
+			return errResult("ls: " + err.Error()), nil
+		}
+		entries := make([]pathEntry, 0, len(rows))
+		for _, r := range rows {
+			if in.KindFilter != "" && r.Kind != in.KindFilter {
+				continue
+			}
+			entries = append(entries, pathEntry{Name: r.Name, Kind: r.Kind, FullPath: r.ParentPath + r.Name, ResourceRef: r.ResourceRef})
+		}
+		return jsonResult(map[string]any{"path": canonical, "entries": entries})
 	}
+
+	// One-level ls. Directories are IMPLICIT (S3-style, RFC AL): a document at
+	// /a/b/c writes a dirent under parent_path=/a/b/ but no row for /a or /a/b.
+	// A plain DirentList (exact parent match) would therefore return only the
+	// explicit direct children (leaves + mkdir'd dirs) and hide the /a/b
+	// "folder" that clearly exists. So scan the subtree once and synthesize the
+	// immediate child directories from descendants' parent paths. (Path segments
+	// are ASCII per pathSegmentRe, so byte-index splitting is safe; ls is an
+	// operator/agent op over a per-scope tree, not a run hot-path.)
+	rows, err := p.Store.DirentListUnder(ctx, tenantID, scope, scopeID, prefix)
 	if err != nil {
 		return errResult("ls: " + err.Error()), nil
 	}
 	entries := make([]pathEntry, 0, len(rows))
+	seen := make(map[string]bool)     // explicit direct-child names (leaf or dir)
+	implicit := make(map[string]bool) // synthesized child-directory names
 	for _, r := range rows {
-		if in.KindFilter != "" && r.Kind != in.KindFilter {
+		if r.ParentPath == prefix {
+			// An explicit direct child.
+			seen[r.Name] = true
+			if in.KindFilter != "" && r.Kind != in.KindFilter {
+				continue
+			}
+			entries = append(entries, pathEntry{Name: r.Name, Kind: r.Kind, FullPath: r.ParentPath + r.Name, ResourceRef: r.ResourceRef})
 			continue
 		}
-		entries = append(entries, pathEntry{Name: r.Name, Kind: r.Kind, FullPath: r.ParentPath + r.Name, ResourceRef: r.ResourceRef})
+		// A deeper descendant: its first segment below prefix is an implicit
+		// directory child of the listed path.
+		rest := strings.TrimPrefix(r.ParentPath, prefix)
+		if i := strings.IndexByte(rest, '/'); i >= 0 {
+			rest = rest[:i]
+		}
+		if rest != "" {
+			implicit[rest] = true
+		}
 	}
+	// Add implicit directories that aren't shadowed by an explicit direct child
+	// (a mkdir'd directory of the same name wins). Skipped when a kind_filter
+	// excludes directories.
+	if in.KindFilter == "" || in.KindFilter == "directory" {
+		for name := range implicit {
+			if seen[name] {
+				continue
+			}
+			entries = append(entries, pathEntry{Name: name, Kind: "directory", FullPath: prefix + name})
+		}
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
 	return jsonResult(map[string]any{"path": canonical, "entries": entries})
 }
 

--- a/internal/tools/builtin/pathtool_test.go
+++ b/internal/tools/builtin/pathtool_test.go
@@ -81,6 +81,84 @@ func TestPath_LsOneLevel(t *testing.T) {
 	}
 }
 
+// lsEntryKinds flattens an ls result to name→kind for assertions.
+func lsEntryKinds(out map[string]any) map[string]string {
+	m := map[string]string{}
+	entries, _ := out["entries"].([]any)
+	for _, e := range entries {
+		em, _ := e.(map[string]any)
+		name, _ := em["name"].(string)
+		kind, _ := em["kind"].(string)
+		m[name] = kind
+	}
+	return m
+}
+
+// TestPath_LsSynthesizesImplicitDirs: directories are implicit (S3-style), so a
+// document at /loomcycle/rfcs/<name> creates no dirent row for /loomcycle/rfcs.
+// One-level `ls /loomcycle` must still surface `rfcs/` as a synthesized
+// directory alongside the explicit leaf `marketing`. Fails on the pre-fix code,
+// which listed only exact-parent rows (just `marketing`).
+func TestPath_LsSynthesizesImplicitDirs(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/loomcycle/", "marketing", "document")
+	seedAgent(t, s, "/loomcycle/rfcs/", "agent-teams", "document")
+	seedAgent(t, s, "/loomcycle/rfcs/", "policies", "document")
+
+	out, res := pathExec(t, p, ctx, `{"op":"ls","path":"/loomcycle"}`)
+	if res.IsError {
+		t.Fatalf("ls: %q", res.Text)
+	}
+	got := lsEntryKinds(out)
+	if len(got) != 2 {
+		t.Fatalf("ls /loomcycle = %d entries, want 2 (marketing + implicit rfcs/): %s", len(got), res.Text)
+	}
+	if got["marketing"] != "document" {
+		t.Errorf("marketing kind = %q, want document", got["marketing"])
+	}
+	if got["rfcs"] != "directory" {
+		t.Errorf("rfcs should be synthesized as an implicit directory; entries=%s", res.Text)
+	}
+
+	// `ls /` synthesizes the top-level implicit directory.
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/"}`)
+	if lsEntryKinds(out)["loomcycle"] != "directory" {
+		t.Errorf("ls / should synthesize /loomcycle as a directory; entries=%s", res.Text)
+	}
+
+	// kind_filter=document hides the synthesized directory; =directory shows only it.
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/loomcycle","kind_filter":"document"}`)
+	docs := lsEntryKinds(out)
+	if _, ok := docs["rfcs"]; ok {
+		t.Errorf("kind_filter=document must exclude the implicit dir rfcs; entries=%s", res.Text)
+	}
+	if docs["marketing"] != "document" {
+		t.Errorf("kind_filter=document should still include marketing; entries=%s", res.Text)
+	}
+	out, res = pathExec(t, p, ctx, `{"op":"ls","path":"/loomcycle","kind_filter":"directory"}`)
+	dirs := lsEntryKinds(out)
+	if dirs["rfcs"] != "directory" || len(dirs) != 1 {
+		t.Errorf("kind_filter=directory should show only the implicit rfcs; entries=%s", res.Text)
+	}
+}
+
+// TestPath_LsExplicitDirShadowsImplicit: a mkdir'd directory and descendants of
+// the same name collapse to a single entry (no duplicate), and the explicit
+// row's identity wins.
+func TestPath_LsExplicitDirShadowsImplicit(t *testing.T) {
+	p, ctx, s := pathFixture(t)
+	seedAgent(t, s, "/", "rfcs", "directory")    // explicit mkdir'd dir
+	seedAgent(t, s, "/rfcs/", "one", "document") // descendant → also implies /rfcs
+	out, res := pathExec(t, p, ctx, `{"op":"ls","path":"/"}`)
+	if res.IsError {
+		t.Fatalf("ls: %q", res.Text)
+	}
+	got := lsEntryKinds(out)
+	if len(got) != 1 || got["rfcs"] != "directory" {
+		t.Errorf("ls / should show exactly one `rfcs` directory (no implicit duplicate); entries=%s", res.Text)
+	}
+}
+
 func TestPath_ResolveAndStat(t *testing.T) {
 	p, ctx, s := pathFixture(t)
 	seedAgent(t, s, "/notes/", "x", "memory_entry")


### PR DESCRIPTION
## Why
Operator report: `ls /loomcycle/` showed only the leaf `marketing` document, **not** the `rfcs/` folder — even though `ls /loomcycle/rfcs/` returns three documents. Directories in the Path VFS are implicit (S3-style, RFC AL): a document at `/loomcycle/rfcs/<name>` writes a dirent under `parent_path=/loomcycle/rfcs/` but no row for `/loomcycle/rfcs`. The one-level `ls` used `DirentList` (an **exact** `parent_path` match), so it returned only explicit direct children and never synthesized the parent-directory entries a tree view needs.

## What
Non-recursive `Path op=ls` now scans the subtree once (`DirentListUnder`) and **synthesizes the immediate child directories** from descendants' parent paths, alongside the explicit direct-child rows:
- An explicit `mkdir`'d directory of the same name **shadows** the synthesized one (no duplicate).
- A `kind_filter` that excludes directories drops the synthesized entries; `kind_filter=directory` shows them.
- **Recursive** `ls` is unchanged (it already returns every descendant with full paths).
- Path segments are ASCII (`pathSegmentRe`), so byte-index segment splitting is safe; `ls` is an operator/agent op over a per-scope tree, not a run hot-path.

The change is in the **shared tool**, so every consumer benefits with no per-transport work: the MCP/agent `Path` tool, the Web UI Path-tree browser (RFC AM), and in-band callers all now see implicit folders.

No store change, no schema change, no new API.

## Tested
`go test ./internal/tools/builtin/... ./internal/store/...` clean (incl. the Postgres store contract). New regression tests, verified to **fail on the pre-fix exact-match**:
- `TestPath_LsSynthesizesImplicitDirs` — `ls /loomcycle` surfaces `marketing` (document) + synthesized `rfcs` (directory); `ls /` synthesizes `loomcycle`; kind_filter behavior.
- `TestPath_LsExplicitDirShadowsImplicit` — a `mkdir`'d dir + descendants of the same name collapse to one entry.
Existing `TestPath_LsOneLevel` still passes (a deep child whose name matches an explicit leaf stays shadowed). `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD