### PR TITLE
feat(credential): secure per-tenant credential store — CredentialDef (RFC AR)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/concurrency"
 	"github.com/denn-gubsky/loomcycle/internal/config"
 	"github.com/denn-gubsky/loomcycle/internal/coord"
+	"github.com/denn-gubsky/loomcycle/internal/credential"
 	"github.com/denn-gubsky/loomcycle/internal/heartbeat"
 	"github.com/denn-gubsky/loomcycle/internal/help"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
@@ -882,6 +883,14 @@ func main() {
 	}
 	allTools = append(allTools, volumeDefTool)
 
+	// RFC AR — the CredentialDef tool (secure per-tenant credential store).
+	// Engine (store + Sealer) is late-bound below, once the store + the master
+	// key (LOOMCYCLE_SECRET_KEY) are available. In-loop with tenant/user/agent
+	// scope isolation; the plaintext value is masked from the persisted
+	// transcript at store time (see maskCredentialCreateValue).
+	credentialDefTool := &builtin.CredentialDef{}
+	allTools = append(allTools, credentialDefTool)
+
 	// RFC AL — the Path tool (Unix-like VFS over the dirents substrate). Store
 	// late-bound below alongside the other substrate tools.
 	pathTool := &builtin.Path{}
@@ -1265,6 +1274,15 @@ func main() {
 	agentDefTool.Store = storeIface
 	skillDefTool.Store = storeIface
 	volumeDefTool.Store = storeIface
+	// RFC AR — build the credential Sealer (per-tenant AES-GCM under the master
+	// KEK) + Engine now that the store exists. A malformed LOOMCYCLE_SECRET_KEY
+	// is fatal (fail-closed); an empty key leaves the inline backend disabled.
+	credSealer, credErr := credential.NewSealer(cfg.Env.SecretKey, cfg.Env.SecretKeyPrevious)
+	if credErr != nil {
+		log.Fatalf("credential: invalid LOOMCYCLE_SECRET_KEY: %v", credErr)
+	}
+	credEngine := credential.NewEngine(storeIface, credSealer)
+	credentialDefTool.Engine = credEngine
 	pathTool.Store = storeIface
 	documentTool.Store = storeIface
 	skillTool.Store = storeIface

--- a/internal/api/grpc/server_test.go
+++ b/internal/api/grpc/server_test.go
@@ -859,6 +859,9 @@ func (m *mockConnector) OperatorTokenDef(context.Context, json.RawMessage) (conn
 func (m *mockConnector) VolumeDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
+func (m *mockConnector) CredentialDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
 func (m *mockConnector) Path(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -486,6 +486,14 @@ func (s *Server) VolumeDef(ctx context.Context, input json.RawMessage) (connecto
 	return s.dispatchBuiltin(ctx, "VolumeDef", input)
 }
 
+// CredentialDef dispatches to the RFC AR secure credential store tool. In the
+// per-agent dispatcher (s.tools), so it routes through dispatchBuiltin; what the
+// MCP `credentialdef` meta-tool + in-band calls reach. Tenant/user identity comes
+// from the operator-trust ctx the transport stamped, never the wire.
+func (s *Server) CredentialDef(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
+	return s.dispatchBuiltin(ctx, "CredentialDef", input)
+}
+
 func (s *Server) Evaluation(ctx context.Context, input json.RawMessage) (connector.ToolResult, error) {
 	return s.dispatchBuiltin(ctx, "Evaluation", input)
 }

--- a/internal/api/http/credential_redact_test.go
+++ b/internal/api/http/credential_redact_test.go
@@ -1,0 +1,43 @@
+package http
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestMaskCredentialCreateValue pins the RFC AR no-leak invariant: a
+// CredentialDef create tool-call's plaintext `value` is masked out of the
+// persisted transcript, deterministically and independent of the general
+// redactor toggle.
+func TestMaskCredentialCreateValue(t *testing.T) {
+	create := json.RawMessage(`{"op":"create","name":"serper","value":"sk-super-secret"}`)
+
+	for _, name := range []string{"CredentialDef", "credentialdef"} {
+		out := maskCredentialCreateValue(name, create)
+		if strings.Contains(string(out), "sk-super-secret") {
+			t.Errorf("%s: plaintext value survived masking: %s", name, out)
+		}
+		if !strings.Contains(string(out), "redacted") {
+			t.Errorf("%s: expected a redaction marker: %s", name, out)
+		}
+	}
+
+	// A non-credential tool is never touched, even if it has a value field.
+	other := json.RawMessage(`{"value":"keep-me"}`)
+	if got := maskCredentialCreateValue("Bash", other); string(got) != string(other) {
+		t.Errorf("non-credential tool input mangled: %s", got)
+	}
+
+	// get/list/delete carry no secret — left unchanged.
+	get := json.RawMessage(`{"op":"get","name":"serper"}`)
+	if got := maskCredentialCreateValue("CredentialDef", get); string(got) != string(get) {
+		t.Errorf("credential get input mangled: %s", got)
+	}
+
+	// Malformed credential input is blanked defensively (never persisted raw).
+	bad := json.RawMessage(`{"op":"create","value":"leak`)
+	if got := maskCredentialCreateValue("CredentialDef", bad); strings.Contains(string(got), "leak") {
+		t.Errorf("malformed credential input not defensively blanked: %s", got)
+	}
+}

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -4412,13 +4412,23 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		// still forwards the ORIGINAL event: the live SSE caller is the trust
 		// boundary that already holds the secret, so we don't mangle its stream.
 		toStore := ev
-		if s.redactor.Enabled() && (ev.Type == providers.EventToolCall || ev.Type == providers.EventToolResult) {
+		if ev.Type == providers.EventToolCall || ev.Type == providers.EventToolResult {
 			if ev.ToolUse != nil {
 				tu := *ev.ToolUse // copy so we don't mutate the event fwd() sends
-				tu.Input = s.redactor.Bytes(tu.Input)
+				if s.redactor.Enabled() {
+					tu.Input = s.redactor.Bytes(tu.Input)
+				}
+				// ALWAYS mask a CredentialDef create's plaintext `value` field,
+				// independent of the general redactor toggle: it's a known
+				// secret-bearing arg, and the tool-call event is persisted BEFORE
+				// the tool runs (so post-hoc value-registration is too late — a
+				// deterministic field mask is the timing-safe fix). RFC AR.
+				tu.Input = maskCredentialCreateValue(tu.Name, tu.Input)
 				toStore.ToolUse = &tu
 			}
-			toStore.Text = s.redactor.String(ev.Text)
+			if s.redactor.Enabled() {
+				toStore.Text = s.redactor.String(ev.Text)
+			}
 		}
 		payload, err := json.Marshal(toStore)
 		if err == nil {
@@ -4428,6 +4438,33 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		}
 		fwd(ev)
 	}
+}
+
+// maskCredentialCreateValue blanks the plaintext `value` field of a CredentialDef
+// create tool-call before it is persisted (RFC AR), so an agent that creates a
+// credential in-band never leaves the secret in the events BLOB / snapshots /
+// audit. Applied UNCONDITIONALLY (not gated on the general redactor toggle): the
+// tool-call event is stored before the tool runs, so a deterministic field mask
+// — not post-hoc value registration — is the timing-safe fix. Non-credential
+// tools pass through unchanged; get/list/delete carry no secret; a credential
+// input that won't parse is blanked defensively.
+func maskCredentialCreateValue(toolName string, input json.RawMessage) json.RawMessage {
+	if toolName != "CredentialDef" && toolName != "credentialdef" {
+		return input
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(input, &m); err != nil {
+		return json.RawMessage(`{"_redacted":"credential input"}`)
+	}
+	if _, ok := m["value"]; !ok {
+		return input
+	}
+	m["value"] = json.RawMessage(`"[redacted]"`)
+	out, err := json.Marshal(m)
+	if err != nil {
+		return json.RawMessage(`{"_redacted":"credential input"}`)
+	}
+	return out
 }
 
 // secretEnvValues extracts the VALUES of secret-classified env vars (by name)

--- a/internal/api/mcp/handlers.go
+++ b/internal/api/mcp/handlers.go
@@ -118,6 +118,12 @@ var handlersByName = map[string]toolHandler{
 	"volumedef": wrapBuiltin("volumedef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.VolumeDef(ctx, in)
 	}),
+	// RFC AR — secure per-tenant credential store. Tenant/user identity from the
+	// principal ctx (RFC AG mcpPrincipalCtx), never the wire; get/list metadata
+	// only. ops: create/get/list/delete.
+	"credentialdef": wrapBuiltin("credentialdef", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
+		return c.CredentialDef(ctx, in)
+	}),
 	"evaluation": wrapBuiltin("evaluation", func(c connector.Connector, ctx context.Context, in json.RawMessage) (connector.ToolResult, error) {
 		return c.Evaluation(ctx, in)
 	}),

--- a/internal/api/mcp/http_transport_test.go
+++ b/internal/api/mcp/http_transport_test.go
@@ -179,6 +179,9 @@ func (m *httpMockConnector) OperatorTokenDef(context.Context, json.RawMessage) (
 func (m *httpMockConnector) VolumeDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, errors.New("not implemented")
 }
+func (m *httpMockConnector) CredentialDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, errors.New("not implemented")
+}
 func (m *httpMockConnector) Path(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, errors.New("not implemented")
 }

--- a/internal/api/mcp/server_test.go
+++ b/internal/api/mcp/server_test.go
@@ -257,6 +257,9 @@ func (m *mockConnector) OperatorTokenDef(context.Context, json.RawMessage) (conn
 func (m *mockConnector) VolumeDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
+func (m *mockConnector) CredentialDef(context.Context, json.RawMessage) (connector.ToolResult, error) {
+	return connector.ToolResult{}, nil
+}
 func (m *mockConnector) Path(context.Context, json.RawMessage) (connector.ToolResult, error) {
 	return connector.ToolResult{}, nil
 }
@@ -389,12 +392,15 @@ func TestServer_ToolsList_ReturnsFullCatalogue(t *testing.T) {
 	if err := json.Unmarshal(resps[0].Result, &result); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if len(result.Tools) != 46 {
-		t.Errorf("got %d tools, want 46 (path + document on top of volumedef + the spawn_runs + compact_run list)", len(result.Tools))
+	if len(result.Tools) != 47 {
+		t.Errorf("got %d tools, want 47 (+credentialdef on top of the path/document/volumedef/spawn_runs/compact_run list)", len(result.Tools))
 	}
 	names := map[string]bool{}
 	for _, td := range result.Tools {
 		names[td.Name] = true
+	}
+	if !names["credentialdef"] {
+		t.Error("catalogue missing the credentialdef meta-tool")
 	}
 	// Spot-check across categories — through the v1.x additions.
 	for _, want := range []string{"spawn_run", "spawn_runs", "compact_run", "register_agent", "memory", "agentdef", "skilldef", "mcpserverdef", "scheduledef", "a2aservercarddef", "a2aagentdef", "webhookdef", "memorybackenddef", "operatortokendef", "volumedef", "path", "document", "pause_runtime", "create_snapshot", "get_snapshot", "resolve_probe", "interruption_resolve", "register_hook", "list_hooks", "delete_hook", "list_channels", "stream_user_run_states", "publish_channel", "subscribe_channel", "peek_channel", "ack_channel"} {

--- a/internal/api/mcp/toolauthz.go
+++ b/internal/api/mcp/toolauthz.go
@@ -54,6 +54,7 @@ var tenantConfinableTools = map[string]bool{
 	"webhookdef":       true,
 	"memorybackenddef": true,
 	"volumedef":        true,
+	"credentialdef":    true, // RFC AR — tenant/user-confined secure credential store
 
 	// Per-(scope, scope_id, tenant) data tools.
 	"memory":     true,

--- a/internal/api/mcp/tools.go
+++ b/internal/api/mcp/tools.go
@@ -265,6 +265,11 @@ func toolDescriptors() []loommcp.ToolDescriptor {
 			InputSchema: builtinSchema("volumedef"),
 		},
 		{
+			Name:        "credentialdef",
+			Description: "CredentialDef tool ops (create/get/list/delete). RFC AR secure per-tenant credential store — named API secrets encrypted at rest, scoped tenant|user|agent, referenced elsewhere as $cred:<name> and bound server-side (the model never sees the value). user scope keys on YOUR subject (per-user tokens, e.g. a personal Telegram/Slack bot token); tenant scope is shared. get/list return metadata only, never the secret. Requires LOOMCYCLE_SECRET_KEY. Tenant-confined. Pass-through.",
+			InputSchema: builtinSchema("credentialdef"),
+		},
+		{
 			Name:        "path",
 			Description: "Path tool ops (resolve/ls/stat/mkdir/mv/rm). RFC AL Unix-like VFS over the dirents table — address Memory entries, Volume mounts, and Documents by human-readable paths (e.g. /docs/launch). Scope-aware (agent/user/tenant, default agent) and tenant-isolated; segments are [a-zA-Z0-9._-], no \"..\". mkdir is a no-op (dirs are implicit). Pass-through.",
 			InputSchema: builtinSchema("path"),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1946,6 +1946,16 @@ type Env struct {
 	// hashing OperatorTokenDef tokens (RFC L). A stolen DB dump without
 	// the pepper yields no usable token lookup. Secret — never logged.
 	OperatorTokenPepper string
+	// SecretKey (LOOMCYCLE_SECRET_KEY) is the deployment master key (KEK) for
+	// the RFC AR CredentialDef inline backend: a base64-encoded 32-byte value
+	// from which a per-tenant DEK is derived (HKDF) to AES-256-GCM-encrypt
+	// stored credentials. Unset → the inline backend is disabled (fail-closed;
+	// external backends still work). Secret — never logged, never interpolated.
+	SecretKey string
+	// SecretKeyPrevious (LOOMCYCLE_SECRET_KEY_PREVIOUS) is the prior KEK during
+	// a rotation grace window: rows sealed under it still decrypt while new
+	// writes use SecretKey. Optional. Secret.
+	SecretKeyPrevious string
 	// AuditLogPath is the JSONL sink for OperatorTokenDef mutations
 	// (RFC L). Empty = no file audit (a NopSink is wired).
 	AuditLogPath string
@@ -2760,6 +2770,8 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		PublicURL:                 strings.TrimRight(strings.TrimSpace(os.Getenv("LOOMCYCLE_PUBLIC_URL")), "/"),
 		AuthToken:                 os.Getenv("LOOMCYCLE_AUTH_TOKEN"),
 		OperatorTokenPepper:       os.Getenv("LOOMCYCLE_OPERATOR_TOKEN_PEPPER"),
+		SecretKey:                 os.Getenv("LOOMCYCLE_SECRET_KEY"),
+		SecretKeyPrevious:         os.Getenv("LOOMCYCLE_SECRET_KEY_PREVIOUS"),
 		AuditLogPath:              os.Getenv("LOOMCYCLE_AUDIT_LOG_PATH"),
 		AuthVerbose:               os.Getenv("LOOMCYCLE_AUTH_VERBOSE") == "1",
 		DataDir:                   getenvDefault("LOOMCYCLE_DATA_DIR", "./data"),
@@ -3859,6 +3871,8 @@ var expandDenyNames = map[string]bool{
 	"LOOMCYCLE_OPERATOR_TOKEN_PEPPER":      true, // RFC L token-hash pepper (S1: the high-value miss)
 	"LOOMCYCLE_MCP_UPSTREAM_TOKEN":         true, // thin-client upstream MCP bearer
 	"LOOMCYCLE_OTEL_EXPORTER_OTLP_HEADERS": true, // collector auth headers
+	"LOOMCYCLE_SECRET_KEY":                 true, // RFC AR CredentialDef master KEK
+	"LOOMCYCLE_SECRET_KEY_PREVIOUS":        true, // RFC AR KEK rotation grace key
 }
 
 // secretEnvSuffixes are the env-var NAME patterns this project classifies as

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -222,6 +222,14 @@ type Connector interface {
 	// dispatch through this single Connector method.
 	VolumeDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
 
+	// CredentialDef — RFC AR secure per-tenant credential store. Op-discriminated
+	// (create / get / list / delete). TENANT-CONFINED (ScopeTenant): the tool
+	// stamps the caller's authoritative tenant, and for scope=user the caller's
+	// OWN subject (per-user tokens). get/list return metadata only — never a
+	// secret. Reachable via the MCP meta-tool `credentialdef` and in-band
+	// (allowed_tools:[CredentialDef]); dispatches through this single method.
+	CredentialDef(ctx context.Context, input json.RawMessage) (ToolResult, error)
+
 	// --- Pause/Resume/Snapshot (real in v0.8.18) ---
 	//
 	// Wire shapes finalised v0.8.15. Real implementations landed in

--- a/internal/credential/backend.go
+++ b/internal/credential/backend.go
@@ -1,0 +1,84 @@
+package credential
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Backend identifiers. inline stores the secret sealed in the DB; the others
+// store only a POINTER (addr/path) and fetch at bind time from an external
+// secret manager. v1 implements inline; the externals are locked-interface
+// stubs (RFC AR Phase 4).
+const (
+	BackendInline            = "inline"
+	BackendVault             = "vault"
+	BackendAWSSecretsManager = "aws_sm"
+	BackendGCPSecretManager  = "gcp_sm"
+	BackendOnePassword       = "onepassword"
+)
+
+// ErrUnsupportedBackend is returned when a credential names an external backend
+// this build doesn't implement yet.
+var ErrUnsupportedBackend = errors.New("credential: external backend not supported in this build (use backend=inline)")
+
+// KnownBackend reports whether name is a recognised backend id.
+func KnownBackend(name string) bool {
+	switch name {
+	case BackendInline, BackendVault, BackendAWSSecretsManager, BackendGCPSecretManager, BackendOnePassword:
+		return true
+	}
+	return false
+}
+
+// Backend turns a stored credential definition into its plaintext secret value
+// at bind time. The interface is locked in v1; only inline is implemented.
+type Backend interface {
+	Name() string
+	// Resolve returns the plaintext secret for a stored definition. For inline,
+	// id binds the ciphertext to its row (GCM AAD); external backends ignore it.
+	Resolve(ctx context.Context, def json.RawMessage, id Identity) (string, error)
+}
+
+// inlineDefinition is the stored `definition` shape for backend=inline: the
+// sealed envelope, no plaintext.
+type inlineDefinition struct {
+	Value Sealed `json:"value"`
+}
+
+// inlineBackend decrypts sealed values with the deployment Sealer.
+type inlineBackend struct{ sealer *Sealer }
+
+func (b inlineBackend) Name() string { return BackendInline }
+
+func (b inlineBackend) Resolve(_ context.Context, def json.RawMessage, id Identity) (string, error) {
+	var d inlineDefinition
+	if err := json.Unmarshal(def, &d); err != nil {
+		return "", fmt.Errorf("credential: malformed inline definition: %w", err)
+	}
+	pt, err := b.sealer.Open(d.Value, id)
+	if err != nil {
+		return "", err
+	}
+	return string(pt), nil
+}
+
+// sealInline builds the stored definition for a plaintext secret.
+func (b inlineBackend) sealInline(plaintext string, id Identity) (json.RawMessage, error) {
+	sealed, err := b.sealer.Seal([]byte(plaintext), id)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(inlineDefinition{Value: sealed})
+}
+
+// externalStub is a placeholder for the Phase-4 external backends: the pointer
+// definition can be stored, but resolution isn't wired yet.
+type externalStub struct{ name string }
+
+func (b externalStub) Name() string { return b.name }
+
+func (b externalStub) Resolve(context.Context, json.RawMessage, Identity) (string, error) {
+	return "", fmt.Errorf("%w: %q", ErrUnsupportedBackend, b.name)
+}

--- a/internal/credential/crypto.go
+++ b/internal/credential/crypto.go
@@ -1,0 +1,218 @@
+// Package credential implements loomcycle's per-tenant secure credential store
+// (RFC AR CredentialDef). This file is the crypto core: envelope encryption of
+// secret values with a per-tenant key derived from one deployment master key.
+//
+// loomcycle otherwise keeps secret *values* out of the DB (it stores
+// ${LOOMCYCLE_*} references and resolves them from host env at use time, F32).
+// CredentialDef is the first primitive that must hold secret *bytes* at rest, so
+// it brings its own encryption:
+//
+//   - KEK (key-encryption key): one deployment master key, LOOMCYCLE_SECRET_KEY,
+//     a base64-encoded 32-byte value. Never stored; lives only in process env.
+//   - DEK (data-encryption key): derived per tenant via HKDF-SHA256(KEK,
+//     info=tenant) at use time — no DEK table, no wrapping (mirrors SQL-Memory's
+//     per-scope HMAC-derived password).
+//   - AES-256-GCM with a random 96-bit nonce. The GCM AAD binds the ciphertext
+//     to its credential row (key_id|tenant|scope|scope_id|name), so a raw row
+//     copied to another tenant/name fails authentication — defense-in-depth
+//     beneath the app-layer tenant scoping.
+//
+// Each ciphertext records the KEK *fingerprint* (key_id) that sealed it, so a
+// KEK rotation (set LOOMCYCLE_SECRET_KEY=new, LOOMCYCLE_SECRET_KEY_PREVIOUS=old)
+// still opens old rows — no version bookkeeping, no schema change; a lazy
+// re-encrypt-on-write sweep migrates them (see NeedsReseal).
+//
+// Fail-closed: with no KEK configured, Seal/Open return ErrNoKey — the inline
+// backend is disabled and the runtime NEVER falls back to storing plaintext.
+package credential
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// hkdfSalt is a fixed, non-secret domain-separation salt. The secret is the
+// KEK; per-tenant separation comes from the HKDF info string. A constant salt
+// is standard for HKDF when the input key material is already high-entropy.
+var hkdfSalt = []byte("loomcycle/credentialdef/hkdf/v1")
+
+var (
+	// ErrNoKey is returned when no KEK is configured — the inline backend is
+	// disabled. Callers surface this as "set LOOMCYCLE_SECRET_KEY to store
+	// inline credentials" rather than ever writing plaintext.
+	ErrNoKey = errors.New("credential: inline backend disabled (LOOMCYCLE_SECRET_KEY not set)")
+	// ErrDecrypt is a deliberately opaque failure for a wrong key, tampered
+	// ciphertext, an unknown key fingerprint (rotated out), or a row whose
+	// identity (tenant/scope/name) doesn't match the AAD it was sealed with.
+	// Never distinguishes the cause (no oracle).
+	ErrDecrypt = errors.New("credential: decrypt failed (wrong key, tampered data, or mismatched identity)")
+)
+
+// Sealer performs envelope encryption of credential secret values. Construct
+// via NewSealer; it is immutable and safe for concurrent use.
+type Sealer struct {
+	keks      map[string][]byte // key_id (KEK fingerprint) → 32-byte KEK
+	currentID string            // fingerprint of the KEK new writes use
+}
+
+// keyID is a short, non-secret fingerprint of a KEK — the first 8 bytes of its
+// SHA-256, hex-encoded. Like a GPG key fingerprint: identifies which key sealed
+// a ciphertext without revealing the key (preimage-resistant, truncated).
+func keyID(kek []byte) string {
+	sum := sha256.Sum256(kek)
+	return hex.EncodeToString(sum[:8])
+}
+
+// NewSealer builds a Sealer from the current and optional previous master keys,
+// each a base64-encoded 32-byte value (generate with `openssl rand -base64 32`).
+// An empty currentB64 yields a disabled Sealer (Enabled()==false; Seal/Open
+// return ErrNoKey) — the fail-closed posture. previousB64 (optional) lets a KEK
+// rotation still open rows sealed under the prior key.
+func NewSealer(currentB64, previousB64 string) (*Sealer, error) {
+	s := &Sealer{keks: map[string][]byte{}}
+	if strings.TrimSpace(currentB64) == "" {
+		return s, nil // disabled — no key configured
+	}
+	cur, err := decodeKey(currentB64)
+	if err != nil {
+		return nil, fmt.Errorf("LOOMCYCLE_SECRET_KEY: %w", err)
+	}
+	s.currentID = keyID(cur)
+	s.keks[s.currentID] = cur
+	if strings.TrimSpace(previousB64) != "" {
+		prev, err := decodeKey(previousB64)
+		if err != nil {
+			return nil, fmt.Errorf("LOOMCYCLE_SECRET_KEY_PREVIOUS: %w", err)
+		}
+		// If previous == current (mid-rotation misconfig) the map just holds one
+		// entry; harmless.
+		s.keks[keyID(prev)] = prev
+	}
+	return s, nil
+}
+
+func decodeKey(b64 string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(b64))
+	if err != nil {
+		return nil, fmt.Errorf("not valid base64: %w", err)
+	}
+	if len(raw) != 32 {
+		return nil, fmt.Errorf("must decode to 32 bytes for AES-256 (got %d)", len(raw))
+	}
+	return raw, nil
+}
+
+// Enabled reports whether inline encryption is available (a KEK is configured).
+func (s *Sealer) Enabled() bool { return len(s.keks) > 0 }
+
+// Identity binds a sealed value to the credential row it belongs to. It becomes
+// the GCM AAD, so decryption only succeeds when the row's identity matches what
+// was sealed — a ciphertext copied to another tenant/scope/name won't open.
+type Identity struct {
+	TenantID string
+	Scope    string
+	ScopeID  string
+	Name     string
+}
+
+// aad renders (key_id + row identity) as authenticated (not encrypted)
+// associated data. Field separation via the ASCII unit separator (0x1f), which
+// the credential name/scope charset excludes, so distinct tuples can't collide.
+func (id Identity) aad(kid string) []byte {
+	return fmt.Appendf(nil, "%s\x1f%s\x1f%s\x1f%s\x1f%s",
+		kid, id.TenantID, id.Scope, id.ScopeID, id.Name)
+}
+
+// Sealed is the persisted envelope (stored as JSON in the credential row's
+// definition.value). It carries no secret without the KEK.
+type Sealed struct {
+	KeyID      string `json:"key_id"`     // KEK fingerprint that sealed this
+	Nonce      string `json:"nonce"`      // base64, 96-bit GCM nonce
+	Ciphertext string `json:"ciphertext"` // base64, GCM output (ct||tag)
+}
+
+// dek derives the per-tenant data-encryption key from the KEK identified by kid.
+func (s *Sealer) dek(kid, tenantID string) ([]byte, error) {
+	kek, ok := s.keks[kid]
+	if !ok {
+		return nil, ErrNoKey
+	}
+	return hkdf.Key(sha256.New, kek, hkdfSalt, "credentialdef:v1:tenant:"+tenantID, 32)
+}
+
+func (s *Sealer) gcm(kid, tenantID string) (cipher.AEAD, error) {
+	dek, err := s.dek(kid, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}
+
+// Seal encrypts plaintext for the given credential identity under the current
+// KEK. Returns ErrNoKey when no KEK is configured (fail-closed).
+func (s *Sealer) Seal(plaintext []byte, id Identity) (Sealed, error) {
+	if !s.Enabled() {
+		return Sealed{}, ErrNoKey
+	}
+	gcm, err := s.gcm(s.currentID, id.TenantID)
+	if err != nil {
+		return Sealed{}, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return Sealed{}, err
+	}
+	ct := gcm.Seal(nil, nonce, plaintext, id.aad(s.currentID))
+	return Sealed{
+		KeyID:      s.currentID,
+		Nonce:      base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.StdEncoding.EncodeToString(ct),
+	}, nil
+}
+
+// Open decrypts a sealed value for the given credential identity. It returns
+// ErrDecrypt (opaque) for any failure — wrong/unknown key, tampered bytes, or
+// an identity that doesn't match the AAD the value was sealed with.
+func (s *Sealer) Open(sealed Sealed, id Identity) ([]byte, error) {
+	if !s.Enabled() {
+		return nil, ErrNoKey
+	}
+	gcm, err := s.gcm(sealed.KeyID, id.TenantID)
+	if err != nil {
+		// Unknown key fingerprint (rotated out) — treat as undecryptable.
+		return nil, ErrDecrypt
+	}
+	nonce, err := base64.StdEncoding.DecodeString(sealed.Nonce)
+	if err != nil || len(nonce) != gcm.NonceSize() {
+		return nil, ErrDecrypt
+	}
+	ct, err := base64.StdEncoding.DecodeString(sealed.Ciphertext)
+	if err != nil {
+		return nil, ErrDecrypt
+	}
+	pt, err := gcm.Open(nil, nonce, ct, id.aad(sealed.KeyID))
+	if err != nil {
+		return nil, ErrDecrypt
+	}
+	return pt, nil
+}
+
+// NeedsReseal reports whether a sealed value was written under a non-current KEK
+// and should be re-sealed under the current one (lazy re-encrypt-on-write during
+// a KEK rotation).
+func (s *Sealer) NeedsReseal(sealed Sealed) bool {
+	return s.Enabled() && sealed.KeyID != s.currentID
+}

--- a/internal/credential/crypto_test.go
+++ b/internal/credential/crypto_test.go
@@ -1,0 +1,134 @@
+package credential
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"testing"
+)
+
+// testKey returns a deterministic, valid 32-byte base64 KEK for tests.
+func testKey(b byte) string {
+	return base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{b}, 32))
+}
+
+func mustSealer(t *testing.T, cur, prev string) *Sealer {
+	t.Helper()
+	s, err := NewSealer(cur, prev)
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	return s
+}
+
+var idA = Identity{TenantID: "tnt-a", Scope: "tenant", ScopeID: "", Name: "serper_api_key"}
+
+func TestSealer_RoundTrip(t *testing.T) {
+	s := mustSealer(t, testKey(1), "")
+	if !s.Enabled() {
+		t.Fatal("sealer with a key should be Enabled")
+	}
+	secret := []byte("sk-super-secret-value-123")
+	sealed, err := s.Seal(secret, idA)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if sealed.Ciphertext == "" || sealed.Nonce == "" || sealed.KeyID == "" {
+		t.Fatalf("sealed envelope incomplete: %+v", sealed)
+	}
+	// The plaintext must not appear anywhere in the envelope.
+	if bytes.Contains([]byte(sealed.Ciphertext+sealed.Nonce), secret) {
+		t.Fatal("plaintext leaked into the sealed envelope")
+	}
+	got, err := s.Open(sealed, idA)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Fatalf("round-trip = %q, want %q", got, secret)
+	}
+}
+
+func TestSealer_AADBindsIdentity(t *testing.T) {
+	s := mustSealer(t, testKey(1), "")
+	sealed, err := s.Seal([]byte("v"), idA)
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	// Every single-field divergence in the identity must fail decryption.
+	cases := map[string]Identity{
+		"other tenant":  {TenantID: "tnt-b", Scope: idA.Scope, ScopeID: idA.ScopeID, Name: idA.Name},
+		"other scope":   {TenantID: idA.TenantID, Scope: "user", ScopeID: idA.ScopeID, Name: idA.Name},
+		"other scopeid": {TenantID: idA.TenantID, Scope: idA.Scope, ScopeID: "u2", Name: idA.Name},
+		"other name":    {TenantID: idA.TenantID, Scope: idA.Scope, ScopeID: idA.ScopeID, Name: "exa_api_key"},
+	}
+	for label, id := range cases {
+		if _, err := s.Open(sealed, id); !errors.Is(err, ErrDecrypt) {
+			t.Errorf("Open under %s identity = %v, want ErrDecrypt (a copied row must not decrypt)", label, err)
+		}
+	}
+}
+
+func TestSealer_Disabled(t *testing.T) {
+	s := mustSealer(t, "", "")
+	if s.Enabled() {
+		t.Fatal("sealer with no key should be disabled")
+	}
+	if _, err := s.Seal([]byte("v"), idA); !errors.Is(err, ErrNoKey) {
+		t.Errorf("Seal with no key = %v, want ErrNoKey (fail-closed, never plaintext)", err)
+	}
+	if _, err := s.Open(Sealed{KeyID: "x", Nonce: "x", Ciphertext: "x"}, idA); !errors.Is(err, ErrNoKey) {
+		t.Errorf("Open with no key = %v, want ErrNoKey", err)
+	}
+}
+
+func TestSealer_Tamper(t *testing.T) {
+	s := mustSealer(t, testKey(1), "")
+	sealed, _ := s.Seal([]byte("do-not-tamper"), idA)
+	raw, _ := base64.StdEncoding.DecodeString(sealed.Ciphertext)
+	raw[0] ^= 0xff // flip a byte
+	sealed.Ciphertext = base64.StdEncoding.EncodeToString(raw)
+	if _, err := s.Open(sealed, idA); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("Open of tampered ciphertext = %v, want ErrDecrypt", err)
+	}
+}
+
+func TestSealer_BadKey(t *testing.T) {
+	if _, err := NewSealer("not-valid-base64!!!", ""); err == nil {
+		t.Error("NewSealer with non-base64 key should error")
+	}
+	if _, err := NewSealer(base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{1}, 16)), ""); err == nil {
+		t.Error("NewSealer with a 16-byte key should error (need 32 for AES-256)")
+	}
+}
+
+func TestSealer_KEKRotation(t *testing.T) {
+	old := mustSealer(t, testKey(1), "")
+	sealedOld, _ := old.Seal([]byte("rotated-secret"), idA)
+
+	// Rotate: current=key2, previous=key1. Old rows still open; new writes use key2.
+	rotated := mustSealer(t, testKey(2), testKey(1))
+	got, err := rotated.Open(sealedOld, idA)
+	if err != nil || string(got) != "rotated-secret" {
+		t.Fatalf("post-rotation Open of an old-key row = (%q,%v), want the secret", got, err)
+	}
+	if !rotated.NeedsReseal(sealedOld) {
+		t.Error("NeedsReseal should be true for a row sealed under the previous key")
+	}
+	resealed, _ := rotated.Seal([]byte("rotated-secret"), idA)
+	if resealed.KeyID == sealedOld.KeyID {
+		t.Error("re-seal should use the new current key (different key_id)")
+	}
+	if rotated.NeedsReseal(resealed) {
+		t.Error("a freshly re-sealed row should not need re-sealing")
+	}
+
+	// After the grace window ends (only key2 configured), old-key rows no longer open.
+	final := mustSealer(t, testKey(2), "")
+	if _, err := final.Open(sealedOld, idA); !errors.Is(err, ErrDecrypt) {
+		t.Errorf("once the previous key is dropped, old rows = %v, want ErrDecrypt", err)
+	}
+	if _, err := final.Open(resealed, idA); err != nil {
+		t.Errorf("the re-sealed row should still open under the current key: %v", err)
+	}
+}

--- a/internal/credential/engine.go
+++ b/internal/credential/engine.go
@@ -1,0 +1,145 @@
+package credential
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Engine is the domain layer over the credential store + crypto — the single
+// entry point the credentialdef tool and the runtime-side $cred: resolver share.
+// Its metadata-returning ops (Get/List/PutInline) strip the sealed definition;
+// only Resolve produces a plaintext, and Resolve is called ONLY by runtime
+// binding code (MCP $cred: substitution, provider/tool injection) — never a
+// model-facing tool path.
+type Engine struct {
+	store  store.Store
+	sealer *Sealer
+	inline inlineBackend
+}
+
+// NewEngine builds an Engine over a store and a Sealer (the Sealer may be
+// disabled — no KEK — in which case PutInline fails and inline resolves error).
+func NewEngine(st store.Store, sealer *Sealer) *Engine {
+	return &Engine{store: st, sealer: sealer, inline: inlineBackend{sealer: sealer}}
+}
+
+// InlineEnabled reports whether inline (encrypted) credentials can be stored.
+func (e *Engine) InlineEnabled() bool { return e.sealer.Enabled() }
+
+// PutInline seals plaintext and upserts the row (create / update / rotate —
+// rotation re-seals in place with a fresh nonce). Returns row METADATA only
+// (Definition stripped). Fails with ErrNoKey when no KEK is configured.
+func (e *Engine) PutInline(ctx context.Context, id Identity, plaintext string, expiresAt *time.Time) (store.CredentialDefRow, error) {
+	if !e.sealer.Enabled() {
+		return store.CredentialDefRow{}, ErrNoKey
+	}
+	def, err := e.inline.sealInline(plaintext, id)
+	if err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	row, err := e.store.CredentialDefPut(ctx, store.CredentialDefRow{
+		TenantID: id.TenantID, Scope: id.Scope, ScopeID: id.ScopeID, Name: id.Name,
+		Backend: BackendInline, Definition: def, ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	return stripSecret(row), nil
+}
+
+// Get returns row metadata (Definition stripped). *ErrNotFound on a miss.
+func (e *Engine) Get(ctx context.Context, id Identity) (store.CredentialDefRow, error) {
+	row, err := e.store.CredentialDefGet(ctx, id.TenantID, id.Scope, id.ScopeID, id.Name)
+	if err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	return stripSecret(row), nil
+}
+
+// List returns metadata for a single (tenant, scope, scope_id) bucket.
+func (e *Engine) List(ctx context.Context, tenantID, scope, scopeID string) ([]store.CredentialDefRow, error) {
+	rows, err := e.store.CredentialDefList(ctx, tenantID, scope, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i] = stripSecret(rows[i])
+	}
+	return rows, nil
+}
+
+// Delete removes a credential row. Returns (found, error).
+func (e *Engine) Delete(ctx context.Context, id Identity) (bool, error) {
+	return e.store.CredentialDefDelete(ctx, id.TenantID, id.Scope, id.ScopeID, id.Name)
+}
+
+// Resolved is a successful credential resolution: the plaintext plus the scope
+// it was found in (for audit + the redactor).
+type Resolved struct {
+	Value   string
+	Scope   string
+	ScopeID string
+	Backend string
+}
+
+// Resolve finds a credential by NAME using scope precedence agent > user >
+// tenant — the most specific wins, so a user's own token shadows a tenant
+// default of the same name (per-user Telegram/Slack channels). It then decrypts
+// via the row's backend. RUNTIME-SIDE ONLY: the returned plaintext must go
+// straight to a header/env/provider, never into a transcript. agentName/userID
+// may be "" (that scope is skipped). Returns (_, false, nil) when the name is
+// absent from every visible scope.
+func (e *Engine) Resolve(ctx context.Context, tenantID, agentName, userID, name string) (Resolved, bool, error) {
+	buckets := []struct{ scope, id string }{
+		{"agent", agentName},
+		{"user", userID},
+		{"tenant", ""},
+	}
+	for _, b := range buckets {
+		if b.scope != "tenant" && b.id == "" {
+			continue // no identity for this scope on the run
+		}
+		row, err := e.store.CredentialDefGet(ctx, tenantID, b.scope, b.id, name)
+		if err != nil {
+			var nf *store.ErrNotFound
+			if errors.As(err, &nf) {
+				continue // not in this scope — try the next
+			}
+			return Resolved{}, false, err
+		}
+		backend, err := e.backendFor(row.Backend)
+		if err != nil {
+			return Resolved{}, false, err
+		}
+		val, err := backend.Resolve(ctx, row.Definition, Identity{
+			TenantID: tenantID, Scope: b.scope, ScopeID: b.id, Name: name,
+		})
+		if err != nil {
+			return Resolved{}, false, err
+		}
+		return Resolved{Value: val, Scope: b.scope, ScopeID: b.id, Backend: row.Backend}, true, nil
+	}
+	return Resolved{}, false, nil
+}
+
+func (e *Engine) backendFor(name string) (Backend, error) {
+	switch name {
+	case BackendInline:
+		return e.inline, nil
+	case BackendVault, BackendAWSSecretsManager, BackendGCPSecretManager, BackendOnePassword:
+		return externalStub{name: name}, nil
+	default:
+		return nil, fmt.Errorf("credential: unknown backend %q", name)
+	}
+}
+
+// stripSecret returns a copy of the row with the sealed Definition removed — the
+// only shape that ever leaves the engine toward a caller/log (metadata only).
+func stripSecret(row store.CredentialDefRow) store.CredentialDefRow {
+	row.Definition = nil
+	return row
+}

--- a/internal/credential/engine_test.go
+++ b/internal/credential/engine_test.go
@@ -1,0 +1,109 @@
+package credential
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+func newEngine(t *testing.T, kek string) *Engine {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	sealer, err := NewSealer(kek, "")
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	return NewEngine(st, sealer)
+}
+
+func TestEngine_PutResolveRoundTrip(t *testing.T) {
+	e := newEngine(t, testKey(1))
+	ctx := context.Background()
+	id := Identity{TenantID: "t", Scope: "tenant", Name: "serper"}
+
+	meta, err := e.PutInline(ctx, id, "sk-secret", nil)
+	if err != nil {
+		t.Fatalf("PutInline: %v", err)
+	}
+	if meta.Definition != nil {
+		t.Error("PutInline returned the sealed definition; must be metadata-only")
+	}
+	if meta.Backend != "inline" {
+		t.Errorf("backend = %q, want inline", meta.Backend)
+	}
+
+	res, found, err := e.Resolve(ctx, "t", "", "", "serper")
+	if err != nil || !found {
+		t.Fatalf("Resolve: found=%v err=%v", found, err)
+	}
+	if res.Value != "sk-secret" || res.Scope != "tenant" {
+		t.Errorf("Resolve = %+v, want sk-secret@tenant", res)
+	}
+
+	if got, _ := e.Get(ctx, id); got.Definition != nil {
+		t.Error("Get leaked the sealed definition; must be metadata-only")
+	}
+}
+
+func TestEngine_ResolvePrecedence(t *testing.T) {
+	e := newEngine(t, testKey(1))
+	ctx := context.Background()
+	put := func(scope, scopeID, val string) {
+		if _, err := e.PutInline(ctx, Identity{TenantID: "t", Scope: scope, ScopeID: scopeID, Name: "telegram"}, val, nil); err != nil {
+			t.Fatalf("put %s/%s: %v", scope, scopeID, err)
+		}
+	}
+	put("tenant", "", "team-token")
+	put("user", "userA", "A-token")
+	put("agent", "agent-x", "agent-token")
+
+	// user A shadows the tenant default.
+	if res, found, _ := e.Resolve(ctx, "t", "", "userA", "telegram"); !found || res.Value != "A-token" || res.Scope != "user" {
+		t.Errorf("userA resolve = %+v (found=%v), want A-token@user", res, found)
+	}
+	// user B (no override) falls back to the tenant default.
+	if res, found, _ := e.Resolve(ctx, "t", "", "userB", "telegram"); !found || res.Value != "team-token" || res.Scope != "tenant" {
+		t.Errorf("userB resolve = %+v, want team-token@tenant", res)
+	}
+	// agent scope is the most specific — wins over user + tenant.
+	if res, found, _ := e.Resolve(ctx, "t", "agent-x", "userA", "telegram"); !found || res.Value != "agent-token" || res.Scope != "agent" {
+		t.Errorf("agent resolve = %+v, want agent-token@agent", res)
+	}
+	// no user/agent id → tenant default.
+	if res, found, _ := e.Resolve(ctx, "t", "", "", "telegram"); !found || res.Value != "team-token" {
+		t.Errorf("bare resolve = %+v, want team-token", res)
+	}
+}
+
+func TestEngine_MissAndFailClosed(t *testing.T) {
+	ctx := context.Background()
+	e := newEngine(t, testKey(1))
+	if _, found, err := e.Resolve(ctx, "t", "", "", "absent"); err != nil || found {
+		t.Errorf("resolve of absent = (found=%v, err=%v), want (false, nil)", found, err)
+	}
+
+	disabled := newEngine(t, "") // no KEK
+	if disabled.InlineEnabled() {
+		t.Error("engine with no KEK should report InlineEnabled()==false")
+	}
+	if _, err := disabled.PutInline(ctx, Identity{TenantID: "t", Scope: "tenant", Name: "x"}, "v", nil); err == nil {
+		t.Error("PutInline with no KEK must fail (never store plaintext)")
+	}
+}
+
+func TestEngine_ResolveIsTenantIsolated(t *testing.T) {
+	e := newEngine(t, testKey(1))
+	ctx := context.Background()
+	if _, err := e.PutInline(ctx, Identity{TenantID: "tnt-a", Scope: "tenant", Name: "serper"}, "a-secret", nil); err != nil {
+		t.Fatal(err)
+	}
+	// A different tenant resolving the same name gets nothing.
+	if _, found, _ := e.Resolve(ctx, "tnt-b", "", "", "serper"); found {
+		t.Error("tenant B resolved tenant A's credential — isolation breach")
+	}
+}

--- a/internal/store/postgres/credential_defs.go
+++ b/internal/store/postgres/credential_defs.go
@@ -1,0 +1,90 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// CredentialDef* implements the RFC AR secure credential store on Postgres.
+// Flat (tenant_id, scope, scope_id, name) table; `definition` holds only sealed
+// ciphertext (inline backend) or an external-backend pointer — never a
+// plaintext secret. See internal/store/store.go for the contract.
+
+func (s *Store) CredentialDefPut(ctx context.Context, row store.CredentialDefRow) (store.CredentialDefRow, error) {
+	now := time.Now().UTC()
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO credential_defs (tenant_id, scope, scope_id, name, backend, definition, expires_at, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)
+		 ON CONFLICT (tenant_id, scope, scope_id, name) DO UPDATE SET
+		     backend    = EXCLUDED.backend,
+		     definition = EXCLUDED.definition,
+		     expires_at = EXCLUDED.expires_at,
+		     updated_at = EXCLUDED.updated_at`,
+		row.TenantID, row.Scope, row.ScopeID, row.Name, row.Backend, string(row.Definition),
+		row.ExpiresAt, now, now,
+	); err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	return s.CredentialDefGet(ctx, row.TenantID, row.Scope, row.ScopeID, row.Name)
+}
+
+func (s *Store) CredentialDefGet(ctx context.Context, tenantID, scope, scopeID, name string) (store.CredentialDefRow, error) {
+	var (
+		out        store.CredentialDefRow
+		definition string
+	)
+	err := s.pool.QueryRow(ctx,
+		`SELECT tenant_id, scope, scope_id, name, backend, definition::text, expires_at, created_at, updated_at
+		 FROM credential_defs WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND name = $4`,
+		tenantID, scope, scopeID, name,
+	).Scan(&out.TenantID, &out.Scope, &out.ScopeID, &out.Name, &out.Backend, &definition, &out.ExpiresAt, &out.CreatedAt, &out.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return store.CredentialDefRow{}, &store.ErrNotFound{Kind: "credential_def", ID: name}
+	}
+	if err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	return out, nil
+}
+
+func (s *Store) CredentialDefList(ctx context.Context, tenantID, scope, scopeID string) ([]store.CredentialDefRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT tenant_id, scope, scope_id, name, backend, definition::text, expires_at, created_at, updated_at
+		 FROM credential_defs WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 ORDER BY name`,
+		tenantID, scope, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.CredentialDefRow
+	for rows.Next() {
+		var (
+			r          store.CredentialDefRow
+			definition string
+		)
+		if err := rows.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &r.Name, &r.Backend, &definition, &r.ExpiresAt, &r.CreatedAt, &r.UpdatedAt); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) CredentialDefDelete(ctx context.Context, tenantID, scope, scopeID, name string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM credential_defs WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3 AND name = $4`,
+		tenantID, scope, scopeID, name)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/store/postgres/migrations/0051_credential_defs.down.sql
+++ b/internal/store/postgres/migrations/0051_credential_defs.down.sql
@@ -1,0 +1,6 @@
+-- 0051_credential_defs.down.sql — drop the RFC AR CredentialDef table.
+-- Dropping the rows unmaps every tenant/user credential; nothing external is
+-- touched (external-backend pointers just become dangling; inline ciphertext is
+-- unrecoverable without the KEK anyway).
+
+DROP TABLE IF EXISTS credential_defs;

--- a/internal/store/postgres/migrations/0051_credential_defs.up.sql
+++ b/internal/store/postgres/migrations/0051_credential_defs.up.sql
@@ -1,0 +1,30 @@
+-- 0051_credential_defs.up.sql — RFC AR CredentialDef: the secure per-tenant
+-- credential store.
+--
+-- A FLAT (tenant_id, scope, scope_id, name) table, like volume_defs — NOT the
+-- content-addressed/versioned Def shape. `definition` holds ONLY sealed
+-- ciphertext (inline backend: AES-256-GCM under a per-tenant HKDF-derived key,
+-- see internal/credential) or an external-backend pointer (vault/aws_sm/gcp_sm/
+-- onepassword) — NEVER a plaintext secret.
+--
+-- scope is 'tenant' | 'user' | 'agent'; scope_id is '' for tenant, the user
+-- subject for user scope, the agent name for agent scope. Together with name
+-- they form the PK so user A's "telegram_bot_token" can't collide with user B's,
+-- and a tenant default coexists with per-user overrides. '' = the shared/
+-- operator/legacy tenant (the RFC N axis).
+--
+-- This table is EXCLUDED from snapshots (secrets don't ride out on backups; a
+-- restore re-provisions), mirroring operator_token_defs.
+
+CREATE TABLE credential_defs (
+    tenant_id   TEXT        NOT NULL DEFAULT '',
+    scope       TEXT        NOT NULL,
+    scope_id    TEXT        NOT NULL DEFAULT '',
+    name        TEXT        NOT NULL,
+    backend     TEXT        NOT NULL,
+    definition  JSONB       NOT NULL,
+    expires_at  TIMESTAMPTZ,
+    created_at  TIMESTAMPTZ NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, scope, scope_id, name)
+);

--- a/internal/store/sqlite/credential_defs.go
+++ b/internal/store/sqlite/credential_defs.go
@@ -1,0 +1,115 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// CredentialDef* implements the RFC AR secure credential store on SQLite. Flat
+// (tenant_id, scope, scope_id, name) table; `definition` holds only sealed
+// ciphertext (inline backend) or an external-backend pointer — never a
+// plaintext secret. See internal/store/store.go for the contract.
+
+func (s *Store) CredentialDefPut(ctx context.Context, row store.CredentialDefRow) (store.CredentialDefRow, error) {
+	now := time.Now()
+	var expires sql.NullInt64
+	if row.ExpiresAt != nil {
+		expires = sql.NullInt64{Int64: row.ExpiresAt.UnixNano(), Valid: true}
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO credential_defs (tenant_id, scope, scope_id, name, backend, definition, expires_at, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(tenant_id, scope, scope_id, name) DO UPDATE SET
+		     backend    = excluded.backend,
+		     definition = excluded.definition,
+		     expires_at = excluded.expires_at,
+		     updated_at = excluded.updated_at`,
+		row.TenantID, row.Scope, row.ScopeID, row.Name, row.Backend, string(row.Definition),
+		expires, now.UnixNano(), now.UnixNano(),
+	); err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	// Re-read so created_at reflects the original insert on an update.
+	return s.CredentialDefGet(ctx, row.TenantID, row.Scope, row.ScopeID, row.Name)
+}
+
+func (s *Store) CredentialDefGet(ctx context.Context, tenantID, scope, scopeID, name string) (store.CredentialDefRow, error) {
+	var (
+		out        store.CredentialDefRow
+		definition string
+		expires    sql.NullInt64
+		createdAt  int64
+		updatedAt  int64
+	)
+	err := s.db.QueryRowContext(ctx,
+		`SELECT tenant_id, scope, scope_id, name, backend, definition, expires_at, created_at, updated_at
+		 FROM credential_defs WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND name = ?`,
+		tenantID, scope, scopeID, name,
+	).Scan(&out.TenantID, &out.Scope, &out.ScopeID, &out.Name, &out.Backend, &definition, &expires, &createdAt, &updatedAt)
+	if err == sql.ErrNoRows {
+		return store.CredentialDefRow{}, &store.ErrNotFound{Kind: "credential_def", ID: name}
+	}
+	if err != nil {
+		return store.CredentialDefRow{}, err
+	}
+	out.Definition = json.RawMessage(definition)
+	if expires.Valid {
+		t := time.Unix(0, expires.Int64)
+		out.ExpiresAt = &t
+	}
+	out.CreatedAt = time.Unix(0, createdAt)
+	out.UpdatedAt = time.Unix(0, updatedAt)
+	return out, nil
+}
+
+func (s *Store) CredentialDefList(ctx context.Context, tenantID, scope, scopeID string) ([]store.CredentialDefRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT tenant_id, scope, scope_id, name, backend, definition, expires_at, created_at, updated_at
+		 FROM credential_defs WHERE tenant_id = ? AND scope = ? AND scope_id = ? ORDER BY name`,
+		tenantID, scope, scopeID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []store.CredentialDefRow
+	for rows.Next() {
+		var (
+			r          store.CredentialDefRow
+			definition string
+			expires    sql.NullInt64
+			createdAt  int64
+			updatedAt  int64
+		)
+		if err := rows.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &r.Name, &r.Backend, &definition, &expires, &createdAt, &updatedAt); err != nil {
+			return nil, err
+		}
+		r.Definition = json.RawMessage(definition)
+		if expires.Valid {
+			t := time.Unix(0, expires.Int64)
+			r.ExpiresAt = &t
+		}
+		r.CreatedAt = time.Unix(0, createdAt)
+		r.UpdatedAt = time.Unix(0, updatedAt)
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+func (s *Store) CredentialDefDelete(ctx context.Context, tenantID, scope, scopeID, name string) (bool, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM credential_defs WHERE tenant_id = ? AND scope = ? AND scope_id = ? AND name = ?`,
+		tenantID, scope, scopeID, name)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -543,6 +543,23 @@ func (s *Store) migrate(ctx context.Context) error {
 			updated_at  INTEGER NOT NULL,
 			PRIMARY KEY (tenant_id, name)
 		)`,
+		// RFC AR CredentialDef — the secure per-tenant credential store. Flat
+		// (tenant_id, scope, scope_id, name) key; definition holds ONLY sealed
+		// ciphertext (inline backend, see internal/credential) or an external
+		// pointer — never a plaintext secret. scope/scope_id isolate user A's
+		// token from user B's. Excluded from snapshots.
+		`CREATE TABLE IF NOT EXISTS credential_defs (
+			tenant_id   TEXT NOT NULL DEFAULT '',
+			scope       TEXT NOT NULL,
+			scope_id    TEXT NOT NULL DEFAULT '',
+			name        TEXT NOT NULL,
+			backend     TEXT NOT NULL,
+			definition  TEXT NOT NULL,
+			expires_at  INTEGER,
+			created_at  INTEGER NOT NULL,
+			updated_at  INTEGER NOT NULL,
+			PRIMARY KEY (tenant_id, scope, scope_id, name)
+		)`,
 		// RFC AL Path primitive — the dirent (path tree) substrate. Maps a
 		// (tenant_id, scope, scope_id, parent_path, name) coordinate to a
 		// backing resource (kind + resource_ref json). PK is the full

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1233,6 +1233,24 @@ type Store interface {
 	// op, which deletes the row AND the files behind a four-way fence.
 	VolumeDefDelete(ctx context.Context, tenantID, name string) (bool, error)
 
+	// ---- RFC AR CredentialDef — secure per-tenant credential store ----
+	//
+	// A flat (tenant_id, scope, scope_id, name) table. The `definition` holds
+	// ONLY sealed ciphertext (inline backend — see internal/credential) or an
+	// external-backend pointer (vault/aws_sm/…) — NEVER a plaintext secret. All
+	// four methods scope by (tenant_id, scope, scope_id): tenant isolation AND
+	// user/agent-scope isolation are enforced at the store boundary and
+	// re-checked at the tool layer (opaque-404). scope_id is "" for tenant
+	// scope, the user subject for user scope, the agent name for agent scope.
+	//
+	// CredentialDefPut UPSERTs the (tenant_id, scope, scope_id, name) row
+	// (create + update + rotate all map to it; rotation re-seals in place).
+	// CredentialDefGet returns *ErrNotFound on a miss.
+	CredentialDefPut(ctx context.Context, row CredentialDefRow) (CredentialDefRow, error)
+	CredentialDefGet(ctx context.Context, tenantID, scope, scopeID, name string) (CredentialDefRow, error)
+	CredentialDefList(ctx context.Context, tenantID, scope, scopeID string) ([]CredentialDefRow, error)
+	CredentialDefDelete(ctx context.Context, tenantID, scope, scopeID, name string) (bool, error)
+
 	// ---- RFC AL Path primitive — the dirent (path tree) substrate ----
 	//
 	// A dirent maps a (tenant_id, scope, scope_id, parent_path, name)
@@ -2273,6 +2291,33 @@ type VolumeDefRow struct {
 	Definition json.RawMessage `json:"definition"`
 	CreatedAt  time.Time       `json:"created_at"`
 	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// CredentialDefRow is a single RFC AR credential: a named secret scoped to a
+// (tenant, scope, scope_id) bucket. Definition holds ONLY sealed ciphertext
+// (inline backend) or an external-backend pointer — NEVER a plaintext secret;
+// callers that surface a row to a client MUST strip Definition (metadata-only).
+type CredentialDefRow struct {
+	// TenantID is the RFC N tenant-isolation axis. "" = shared/operator/legacy.
+	// Set from the authoritative principal at the write site, never the wire.
+	TenantID string `json:"tenant_id,omitempty"`
+	// Scope is "tenant" | "user" | "agent". ScopeID is "" for tenant, the user
+	// subject for user scope, the agent name for agent scope — together with
+	// name they form the row key, so user A's token can't collide with B's.
+	Scope   string `json:"scope"`
+	ScopeID string `json:"scope_id"`
+	Name    string `json:"name"`
+	// Backend is "inline" (sealed value) | "vault" | "aws_sm" | "gcp_sm" |
+	// "onepassword" (pointer only).
+	Backend string `json:"backend"`
+	// Definition is the sealed value ({"value":{key_id,nonce,ciphertext}}) for
+	// inline, or the external pointer JSON. Never plaintext, never logged.
+	Definition json.RawMessage `json:"definition"`
+	// ExpiresAt is an optional advisory soft-expiry (rotation reminder); nil =
+	// no expiry. Not enforced at resolve in v1.
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
 }
 
 // DirentRow is one entry in the RFC AL Path tree: it names a backing resource

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -273,6 +273,7 @@ func Run(t *testing.T, factory Factory) {
 		// RFC AH Phase 2a VolumeDef substrate — flat (tenant, name) table.
 		{"VolumeDefCreateAndGet", testVolumeDefCreateAndGet},
 		{"VolumeDefTenantIsolation", testVolumeDefTenantIsolation},
+		{"CredentialDefScopeIsolation", testCredentialDefScopeIsolation},
 		{"VolumeDefDelete", testVolumeDefDelete},
 		{"VolumeDefList", testVolumeDefList},
 		{"VolumeDefCreateUpdatesDefinition", testVolumeDefCreateUpdatesDefinition},
@@ -7123,6 +7124,84 @@ func testVolumeDefTenantIsolation(t *testing.T, s store.Store) {
 	}
 	if _, err := s.VolumeDefGetByName(ctx, "tenant-b", "work"); err != nil {
 		t.Errorf("tenant B's row vanished after A's delete: %v", err)
+	}
+}
+
+func mkCredentialDef(tenant, scope, scopeID, name, value string) store.CredentialDefRow {
+	return store.CredentialDefRow{
+		TenantID: tenant, Scope: scope, ScopeID: scopeID, Name: name,
+		Backend:    "inline",
+		Definition: json.RawMessage(fmt.Sprintf(`{"value":%q}`, value)),
+	}
+}
+
+// testCredentialDefScopeIsolation pins the RFC AR isolation boundary across both
+// the tenant axis AND the user/agent scope axis: user A's per-user token must
+// never collide with user B's, a per-user override coexists with a tenant
+// default of the same name, and list is scoped to a single bucket.
+func testCredentialDefScopeIsolation(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// Tenant isolation: the same (scope, name) in two tenants don't clobber.
+	if _, err := s.CredentialDefPut(ctx, mkCredentialDef("tenant-a", "tenant", "", "serper", "sealed-a")); err != nil {
+		t.Fatalf("put tenant-a serper: %v", err)
+	}
+	if _, err := s.CredentialDefPut(ctx, mkCredentialDef("tenant-b", "tenant", "", "serper", "sealed-b")); err != nil {
+		t.Fatalf("put tenant-b serper: %v", err)
+	}
+	gotA, err := s.CredentialDefGet(ctx, "tenant-a", "tenant", "", "serper")
+	if err != nil || !jsonEqual(gotA.Definition, `{"value":"sealed-a"}`) {
+		t.Errorf("tenant A serper = (%s, %v), want sealed-a", gotA.Definition, err)
+	}
+
+	// User-scope isolation: two users in the SAME tenant, SAME name → distinct.
+	if _, err := s.CredentialDefPut(ctx, mkCredentialDef("tenant-a", "user", "userA", "telegram", "tokA")); err != nil {
+		t.Fatalf("put userA telegram: %v", err)
+	}
+	if _, err := s.CredentialDefPut(ctx, mkCredentialDef("tenant-a", "user", "userB", "telegram", "tokB")); err != nil {
+		t.Fatalf("put userB telegram: %v", err)
+	}
+	uA, err := s.CredentialDefGet(ctx, "tenant-a", "user", "userA", "telegram")
+	if err != nil || !jsonEqual(uA.Definition, `{"value":"tokA"}`) {
+		t.Errorf("userA telegram = (%s, %v), want tokA", uA.Definition, err)
+	}
+	uB, err := s.CredentialDefGet(ctx, "tenant-a", "user", "userB", "telegram")
+	if err != nil || !jsonEqual(uB.Definition, `{"value":"tokB"}`) {
+		t.Errorf("userB telegram = (%s, %v), want tokB (user A's token leaked to B)", uB.Definition, err)
+	}
+
+	// Scope shadowing: a tenant default of the same name coexists with the
+	// per-user overrides (distinct rows, no clobber).
+	if _, err := s.CredentialDefPut(ctx, mkCredentialDef("tenant-a", "tenant", "", "telegram", "teamTok")); err != nil {
+		t.Fatalf("put tenant telegram default: %v", err)
+	}
+	if uA2, _ := s.CredentialDefGet(ctx, "tenant-a", "user", "userA", "telegram"); !jsonEqual(uA2.Definition, `{"value":"tokA"}`) {
+		t.Errorf("userA telegram override clobbered by the tenant default: %s", uA2.Definition)
+	}
+
+	// List is scoped to a single (tenant, scope, scope_id) bucket.
+	listUA, err := s.CredentialDefList(ctx, "tenant-a", "user", "userA")
+	if err != nil {
+		t.Fatalf("list userA: %v", err)
+	}
+	if len(listUA) != 1 || listUA[0].Name != "telegram" {
+		t.Errorf("list userA = %d rows %v, want exactly [telegram] (leaked another bucket)", len(listUA), listUA)
+	}
+
+	// Delete A's tenant serper leaves tenant B's untouched.
+	found, err := s.CredentialDefDelete(ctx, "tenant-a", "tenant", "", "serper")
+	if err != nil || !found {
+		t.Fatalf("delete tenant-a serper: found=%v err=%v", found, err)
+	}
+	if _, err := s.CredentialDefGet(ctx, "tenant-b", "tenant", "", "serper"); err != nil {
+		t.Errorf("tenant B's serper vanished after A's delete: %v", err)
+	}
+
+	// A miss is *ErrNotFound.
+	_, err = s.CredentialDefGet(ctx, "tenant-a", "user", "userA", "nope")
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("get of a missing credential = %v, want *ErrNotFound", err)
 	}
 }
 

--- a/internal/tools/builtin/credentialdef.go
+++ b/internal/tools/builtin/credentialdef.go
@@ -1,0 +1,228 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/credential"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// CredentialDef is the RFC AR secure per-tenant credential store tool. It stores
+// named secrets (API tokens, per-user Telegram/Slack bot tokens, …) encrypted
+// at rest, scoped tenant | user | agent, that other Defs reference by name as
+// $cred:<name> and the runtime binds server-side (the model never sees the
+// value).
+//
+// Security invariants:
+//   - scope_id is derived from the caller's authoritative identity, NEVER the
+//     wire. user scope stamps the caller's OWN subject, so a user can only
+//     author/read their own credentials; agent scope stamps the calling agent.
+//   - get/list return METADATA ONLY — never a secret value.
+//   - create's plaintext `value` is field-masked out of the persisted transcript
+//     (see CredentialValueField + the redaction path in internal/api/http).
+//   - the plaintext is sealed via the credential.Engine (AES-256-GCM under a
+//     per-tenant HKDF key); nothing plaintext ever hits the store.
+type CredentialDef struct {
+	// Engine is the credential domain layer (store + crypto). Required.
+	Engine *credential.Engine
+}
+
+// CredentialToolName is the in-band tool name (allowed_tools:[CredentialDef]).
+const CredentialToolName = "CredentialDef"
+
+// CredentialValueField is the create-op input field carrying the plaintext
+// secret. The transcript redactor masks it so a create tool-call never persists
+// the value (the tool-call event is stored before the tool runs, so masking —
+// not post-hoc registration — is the timing-safe fix).
+const CredentialValueField = "value"
+
+func (c *CredentialDef) Name() string { return CredentialToolName }
+
+func (c *CredentialDef) Description() string {
+	return "Store and manage encrypted API credentials (RFC AR). Named secrets scoped tenant | user | agent, " +
+		"encrypted at rest, that other config references as $cred:<name> and the runtime binds server-side — the " +
+		"model never sees the value. user scope keys on YOUR subject (per-user tokens, e.g. a personal Telegram/Slack " +
+		"bot token); tenant scope is shared across the tenant. Ops: create (store/rotate a value), get + list (metadata " +
+		"only, never the secret), delete. Requires LOOMCYCLE_SECRET_KEY for the inline backend."
+}
+
+const credentialDefInputSchema = `{
+  "type": "object",
+  "properties": {
+    "op":         {"type": "string", "enum": ["create","get","list","delete"], "description": "The operation."},
+    "name":       {"type": "string", "description": "Credential name (charset ^[A-Za-z0-9_-]{1,128}$). Referenced elsewhere as $cred:<name>. Required for create/get/delete."},
+    "scope":      {"type": "string", "enum": ["tenant","user","agent"], "description": "Which bucket (default tenant). user = the calling principal's own subject (per-user tokens); agent = the calling agent. scope_id is derived from your identity, never supplied."},
+    "value":      {"type": "string", "description": "create only: the plaintext secret to encrypt (inline backend). Masked from the persisted transcript; never returned."},
+    "backend":    {"type": "string", "enum": ["inline"], "description": "create only: storage backend (default inline; external backends are a future addition)."},
+    "expires_at": {"type": "string", "description": "create only: optional RFC3339 soft-expiry (advisory rotation reminder)."}
+  },
+  "required": ["op"]
+}`
+
+func (c *CredentialDef) InputSchema() json.RawMessage {
+	return json.RawMessage(credentialDefInputSchema)
+}
+
+type credentialDefInput struct {
+	Op        string `json:"op"`
+	Name      string `json:"name"`
+	Scope     string `json:"scope"`
+	Value     string `json:"value"`
+	Backend   string `json:"backend"`
+	ExpiresAt string `json:"expires_at"`
+}
+
+var credNameRe = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+
+func (c *CredentialDef) Execute(ctx context.Context, raw json.RawMessage) (tools.Result, error) {
+	if c.Engine == nil {
+		return errResult("CredentialDef tool: not configured (no credential engine)"), nil
+	}
+	var in credentialDefInput
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return errResult("invalid input JSON: " + err.Error()), nil
+	}
+	tenantID, scope, scopeID, serr := c.resolveScope(ctx, in.Scope)
+	if serr != nil {
+		return errResult(serr.Error()), nil
+	}
+	switch in.Op {
+	case "create":
+		return c.execCreate(ctx, tenantID, scope, scopeID, in)
+	case "get":
+		return c.execGet(ctx, tenantID, scope, scopeID, in)
+	case "list":
+		return c.execList(ctx, tenantID, scope, scopeID)
+	case "delete":
+		return c.execDelete(ctx, tenantID, scope, scopeID, in)
+	case "":
+		return errResult("missing required field: op"), nil
+	default:
+		return errResult(fmt.Sprintf("unknown op %q (must be one of: create, get, list, delete)", in.Op)), nil
+	}
+}
+
+// resolveScope derives the authoritative (tenant, scope, scope_id) from the run
+// identity — NEVER the wire. Default scope is tenant. user stamps the caller's
+// own subject; agent stamps the calling agent. This is the user/agent-scope
+// isolation crux: a user can't address another user's credentials.
+func (c *CredentialDef) resolveScope(ctx context.Context, requested string) (tenantID, scope, scopeID string, err error) {
+	tenantID = tools.RunIdentity(ctx).TenantID
+	if requested == "" {
+		requested = "tenant"
+	}
+	switch requested {
+	case "tenant":
+		return tenantID, "tenant", "", nil
+	case "user":
+		uid := tools.RunIdentity(ctx).UserID
+		if uid == "" {
+			return "", "", "", errors.New("CredentialDef: scope=user requires a user_id on the run")
+		}
+		return tenantID, "user", uid, nil
+	case "agent":
+		name := tools.AgentName(ctx)
+		if name == "" {
+			return "", "", "", errors.New("CredentialDef: scope=agent requires a yaml-declared agent (no agent name on the run)")
+		}
+		return tenantID, "agent", name, nil
+	default:
+		return "", "", "", fmt.Errorf("CredentialDef: unknown scope %q (tenant | user | agent)", requested)
+	}
+}
+
+func (c *CredentialDef) execCreate(ctx context.Context, tenantID, scope, scopeID string, in credentialDefInput) (tools.Result, error) {
+	if !credNameRe.MatchString(in.Name) {
+		return errResult("create: name must match ^[A-Za-z0-9_-]{1,128}$"), nil
+	}
+	backend := in.Backend
+	if backend == "" {
+		backend = credential.BackendInline
+	}
+	if backend != credential.BackendInline {
+		return errResult(fmt.Sprintf("create: backend %q is not supported yet (use inline)", backend)), nil
+	}
+	if in.Value == "" {
+		return errResult("create: value is required (the plaintext secret to encrypt)"), nil
+	}
+	if !c.Engine.InlineEnabled() {
+		return errResult("create: inline credential storage is disabled — the operator must set LOOMCYCLE_SECRET_KEY"), nil
+	}
+	var expires *time.Time
+	if in.ExpiresAt != "" {
+		t, perr := time.Parse(time.RFC3339, in.ExpiresAt)
+		if perr != nil {
+			return errResult("create: expires_at must be RFC3339 (e.g. 2026-12-31T00:00:00Z)"), nil
+		}
+		expires = &t
+	}
+	id := credential.Identity{TenantID: tenantID, Scope: scope, ScopeID: scopeID, Name: in.Name}
+	row, err := c.Engine.PutInline(ctx, id, in.Value, expires)
+	if err != nil {
+		return errResult("create: " + err.Error()), nil
+	}
+	return jsonResult(credentialMeta(row, "stored"))
+}
+
+func (c *CredentialDef) execGet(ctx context.Context, tenantID, scope, scopeID string, in credentialDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("get: name is required"), nil
+	}
+	row, err := c.Engine.Get(ctx, credential.Identity{TenantID: tenantID, Scope: scope, ScopeID: scopeID, Name: in.Name})
+	if err != nil {
+		var nf *store.ErrNotFound
+		if errors.As(err, &nf) {
+			return errResult(fmt.Sprintf("get: no credential %q in %s scope", in.Name, scope)), nil
+		}
+		return errResult("get: " + err.Error()), nil
+	}
+	return jsonResult(credentialMeta(row, ""))
+}
+
+func (c *CredentialDef) execList(ctx context.Context, tenantID, scope, scopeID string) (tools.Result, error) {
+	rows, err := c.Engine.List(ctx, tenantID, scope, scopeID)
+	if err != nil {
+		return errResult("list: " + err.Error()), nil
+	}
+	out := make([]map[string]any, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, credentialMeta(r, ""))
+	}
+	return jsonResult(map[string]any{"scope": scope, "credentials": out})
+}
+
+func (c *CredentialDef) execDelete(ctx context.Context, tenantID, scope, scopeID string, in credentialDefInput) (tools.Result, error) {
+	if in.Name == "" {
+		return errResult("delete: name is required"), nil
+	}
+	found, err := c.Engine.Delete(ctx, credential.Identity{TenantID: tenantID, Scope: scope, ScopeID: scopeID, Name: in.Name})
+	if err != nil {
+		return errResult("delete: " + err.Error()), nil
+	}
+	return jsonResult(map[string]any{"name": in.Name, "scope": scope, "deleted": found})
+}
+
+// credentialMeta renders a row as METADATA ONLY — never the sealed definition or
+// the secret value. `note` is an optional status word (e.g. "stored").
+func credentialMeta(row store.CredentialDefRow, note string) map[string]any {
+	m := map[string]any{
+		"name":       row.Name,
+		"scope":      row.Scope,
+		"backend":    row.Backend,
+		"created_at": row.CreatedAt,
+		"updated_at": row.UpdatedAt,
+	}
+	if row.ExpiresAt != nil {
+		m["expires_at"] = *row.ExpiresAt
+	}
+	if note != "" {
+		m["status"] = note
+	}
+	return m
+}

--- a/internal/tools/builtin/credentialdef_test.go
+++ b/internal/tools/builtin/credentialdef_test.go
@@ -1,0 +1,116 @@
+package builtin
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/credential"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+func credFixture(t *testing.T, userID string, kek string) (*CredentialDef, context.Context) {
+	t.Helper()
+	st, err := sqlite.Open(":memory:")
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	sealer, err := credential.NewSealer(kek, "")
+	if err != nil {
+		t.Fatalf("NewSealer: %v", err)
+	}
+	tool := &CredentialDef{Engine: credential.NewEngine(st, sealer)}
+	ctx := tools.WithAgentName(context.Background(), "agent-1")
+	ctx = tools.WithRunIdentity(ctx, tools.RunIdentityValue{AgentID: "a", UserID: userID, TenantID: "tnt"})
+	return tool, ctx
+}
+
+func credExec(t *testing.T, c *CredentialDef, ctx context.Context, body string) (map[string]any, tools.Result) {
+	t.Helper()
+	res, err := c.Execute(ctx, json.RawMessage(body))
+	if err != nil {
+		t.Fatalf("Execute hard error: %v", err)
+	}
+	var out map[string]any
+	if !res.IsError {
+		_ = json.Unmarshal([]byte(res.Text), &out)
+	}
+	return out, res
+}
+
+func testKEK() string { return base64.StdEncoding.EncodeToString(make([]byte, 32)) }
+
+func TestCredentialDefTool_CreateGetIsMetadataOnly(t *testing.T) {
+	c, ctx := credFixture(t, "u1", testKEK())
+
+	out, res := credExec(t, c, ctx, `{"op":"create","scope":"tenant","name":"serper","value":"sk-secret-xyz"}`)
+	if res.IsError {
+		t.Fatalf("create: %q", res.Text)
+	}
+	// The create result must never echo the plaintext value.
+	if strings.Contains(res.Text, "sk-secret-xyz") {
+		t.Errorf("create result leaked the plaintext value: %s", res.Text)
+	}
+	if out["name"] != "serper" || out["backend"] != "inline" {
+		t.Errorf("create meta = %s", res.Text)
+	}
+
+	// get returns metadata, never the value.
+	_, res = credExec(t, c, ctx, `{"op":"get","scope":"tenant","name":"serper"}`)
+	if res.IsError || strings.Contains(res.Text, "sk-secret-xyz") {
+		t.Errorf("get should return metadata only, no value: %s (err=%v)", res.Text, res.IsError)
+	}
+}
+
+func TestCredentialDefTool_UserScopeStampsOwnSubject(t *testing.T) {
+	// user u1 stores a user-scoped token.
+	c1, ctx1 := credFixture(t, "u1", testKEK())
+	if _, res := credExec(t, c1, ctx1, `{"op":"create","scope":"user","name":"telegram","value":"u1-token"}`); res.IsError {
+		t.Fatalf("u1 create: %q", res.Text)
+	}
+	// A different user (u2) on the SAME engine/store can't see u1's user-scoped
+	// credential — the tool stamps scope_id from the caller's own subject.
+	c2 := &CredentialDef{Engine: c1.Engine}
+	ctx2 := tools.WithRunIdentity(tools.WithAgentName(context.Background(), "agent-1"),
+		tools.RunIdentityValue{AgentID: "a", UserID: "u2", TenantID: "tnt"})
+	_, res := credExec(t, c2, ctx2, `{"op":"get","scope":"user","name":"telegram"}`)
+	if !res.IsError {
+		t.Errorf("user u2 resolved u1's user-scoped credential — isolation breach: %s", res.Text)
+	}
+	// u2 lists their own (empty) user bucket — must not include u1's.
+	out, _ := credExec(t, c2, ctx2, `{"op":"list","scope":"user"}`)
+	if creds, _ := out["credentials"].([]any); len(creds) != 0 {
+		t.Errorf("u2's user-scope list leaked u1's credential: %v", creds)
+	}
+}
+
+func TestCredentialDefTool_FailClosedNoKEK(t *testing.T) {
+	c, ctx := credFixture(t, "u1", "") // no KEK
+	_, res := credExec(t, c, ctx, `{"op":"create","scope":"tenant","name":"x","value":"v"}`)
+	if !res.IsError || !strings.Contains(res.Text, "LOOMCYCLE_SECRET_KEY") {
+		t.Errorf("create with no KEK should fail pointing at LOOMCYCLE_SECRET_KEY; got %q (err=%v)", res.Text, res.IsError)
+	}
+}
+
+func TestCredentialDefTool_ScopeUserRequiresUserID(t *testing.T) {
+	c, ctx := credFixture(t, "", testKEK()) // no user id on the run
+	_, res := credExec(t, c, ctx, `{"op":"create","scope":"user","name":"x","value":"v"}`)
+	if !res.IsError {
+		t.Error("scope=user with no user_id on the run should error")
+	}
+}
+
+func TestMaskCredentialCreateValue_ViaTool(t *testing.T) {
+	// The redaction of the create `value` lives in internal/api/http
+	// (maskCredentialCreateValue); here we just assert the tool's own result
+	// never contains the value (covered above) and that a bad-name create is
+	// refused before any store write.
+	c, ctx := credFixture(t, "u1", testKEK())
+	if _, res := credExec(t, c, ctx, `{"op":"create","scope":"tenant","name":"bad name!","value":"v"}`); !res.IsError {
+		t.Error("create with an invalid name charset should be refused")
+	}
+}

--- a/internal/tools/builtin/wrapper_schemas.go
+++ b/internal/tools/builtin/wrapper_schemas.go
@@ -34,6 +34,7 @@ var mcpWrapperSchemas = map[string]string{
 	"memorybackenddef": memoryBackendDefInputSchema,
 	"operatortokendef": operatorTokenDefInputSchema,
 	"volumedef":        volumeDefInputSchema,
+	"credentialdef":    credentialDefInputSchema,
 	"evaluation":       evaluationInputSchema,
 	"context":          contextInputSchema,
 	"path":             pathInputSchema,


### PR DESCRIPTION
Implements the **secure-storage core** of RFC AR — a scope-aware (tenant/user/agent), encrypted-at-rest named credential store so tenants can define + manage their own API keys (provider keys, search-provider keys, **per-user Telegram/Slack bot tokens**) without operator/host access. This is the "define + store" half; the `$cred:` **consumption** wiring (MCP servers / providers / the per-user messaging def) is the explicit follow-on PR.

## Why
loomcycle had **no per-tenant secret store and no encryption-at-rest** — it kept secret *values* out of the DB and resolved `${LOOMCYCLE_*}` host-env refs at use time (F32), which tenants can't set. CredentialDef gives per-tenant/per-user secrets a durable, encrypted, isolated home.

## What
- **Crypto** (`internal/credential/crypto.go`): AES-256-GCM envelope encryption; per-tenant DEK via **HKDF-SHA256** from one deployment master key `LOOMCYCLE_SECRET_KEY`; ciphertext tagged with the KEK fingerprint (rotation via `LOOMCYCLE_SECRET_KEY_PREVIOUS` + lazy re-encrypt); GCM **AAD binds each ciphertext to its row identity** (a copied row won't decrypt); **fail-closed** with no KEK.
- **Store** (both backends + migration `0051` + contract): flat `credential_defs` keyed `(tenant_id, scope, scope_id, name)`, holding **only ciphertext or an external pointer, never plaintext**; excluded from snapshots by omission. Contract test covers tenant **and** user-scope isolation on sqlite + postgres.
- **Engine** (`engine.go`): scope-precedence resolve **agent > user > tenant** — a user's own token shadows the tenant default (the per-user channel case); metadata-only reads; plaintext only via `Resolve` for runtime binding.
- **Tool** (`credentialdef.go`): `create/get/list/delete`, exposed in-band (`allowed_tools:[CredentialDef]`) and as the MCP `credentialdef` meta-tool (tenant-confinable). `scope_id` stamped from the caller's authoritative identity — **user scope keys on the caller's own subject**, so a user can't address another user's credentials. `get`/`list` are **metadata-only**.
- **No-leak on create**: a create tool-call's plaintext `value` is masked out of the persisted transcript at store time (`maskCredentialCreateValue`) — unconditional (independent of the general redactor), because the tool-call event is persisted *before* the tool runs, so a deterministic field mask is the timing-safe fix.

**No new plaintext ever hits the store, transcript, audit, or snapshots.**

## Tested
`go test ./...` + full build clean. New tests: crypto round-trip / AAD-binding / tamper / fail-closed / KEK-rotation; engine put-resolve / scope precedence / tenant isolation; store contract scope-isolation (sqlite + postgres); tool metadata-only / user-scope isolation / fail-closed / bad-name; the create-value mask. `LOOMCYCLE_SECRET_KEY` (+ `_PREVIOUS`) added to the `${}`-exfil denylist (completeness test passes).

## Explicit follow-on (PR-2)
`$cred:<name>` substitution at MCP bind (reusing the F32 machinery) + resolved-value redactor registration; the per-agent provider-key seam (`providers.RunMeta`); a bundled **Telegram/Slack** MCPServerDef consuming a user-scoped `$cred:` token (the per-user-channel E2E); external backends (vault/aws_sm/…) are Phase 4 (interface locked, stubbed).

Design recorded in RFC AR (loomcycle Document, "Security addendum" section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbE8LYMPeqnctgGQT7ErAD