### PR TITLE
feat(credential): tenant/user provider-key override by env-var name (RFC AR)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1302,6 +1302,20 @@ func main() {
 		ri := tools.RunIdentity(ctx)
 		return credEngine.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, s, nil)
 	}
+	// RFC AR: resolve a tenant/user credential by env-var NAME (ANTHROPIC_API_KEY,
+	// BRAVE_API_KEY, …) for the run's identity, so a tenant's own key overrides
+	// the operator host key (scope agent>user>tenant). Wired onto the Server
+	// below; provider drivers + WebSearch consult it via the run ctx. Fails soft
+	// (a lookup error → no override → host key), never blocking a run on a KEK
+	// gap. Reused by every transport since gRPC routes through the http Server.
+	credResolver := providers.CredentialResolver(func(ctx context.Context, name string) (string, bool) {
+		ri := tools.RunIdentity(ctx)
+		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
+		if err != nil || !found {
+			return "", false
+		}
+		return res.Value, true
+	})
 	pathTool.Store = storeIface
 	documentTool.Store = storeIface
 	skillTool.Store = storeIface
@@ -1403,6 +1417,9 @@ func main() {
 	// server's tool set, which isn't in allTools here (F45). New re-points any
 	// Context tool to the COMPLETE post-append catalog, so don't set it here.
 	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
+	// RFC AR: stamp the credential resolver onto each run so a tenant/user's own
+	// provider key (ANTHROPIC_API_KEY, BRAVE_API_KEY, …) overrides the host key.
+	srv.SetCredentialResolver(credResolver)
 
 	// RFC AA SQL Memory (Phase 1). Off by default; constructed only when the
 	// operator enables it. The manager hosts per-scope sqlite databases that

--- a/docs/CREDENTIALS.md
+++ b/docs/CREDENTIALS.md
@@ -71,11 +71,48 @@ unresolved `$cred:` ref drops the header (no literal token is ever sent).
 > can't carry per-user tokens. Use an http MCP server (token as a per-request
 > header) for the per-user case.
 
+## Overriding a provider / tool API key by its env-var name
+
+Some credentials aren't referenced with `$cred:` — they **override the operator's
+host key automatically**, keyed by the credential's *name*. Store a credential
+**named after the well-known env var** and loomcycle uses it for that
+tenant/user's requests, falling back to the operator's key when absent. Scope
+precedence is the same **agent > user > tenant**, and the key stays runtime-side —
+the model never sees it.
+
+| Store a credential named | …and it overrides the host key for |
+|--------------------------|------------------------------------|
+| `ANTHROPIC_API_KEY`      | Anthropic LLM calls                |
+| `OPENAI_API_KEY`         | OpenAI LLM calls                   |
+| `DEEPSEEK_API_KEY`       | DeepSeek LLM calls                 |
+| `GEMINI_API_KEY`         | Gemini LLM calls                   |
+| `OLLAMA_API_KEY`         | hosted ollama.com LLM calls        |
+| `BRAVE_API_KEY`          | the `WebSearch` tool               |
+
+So a tenant that stores its own `ANTHROPIC_API_KEY` (scope `tenant`) has every
+run in that tenant bill Anthropic to **its** key; a single user that stores one
+(scope `user`) shadows the tenant default for **that user's** runs only. A tenant
+with no override transparently uses the operator's host key. A `BRAVE_API_KEY`
+credential even lets a tenant search on its own Brave quota when the operator set
+no host key at all.
+
+```jsonc
+// as a substrate:tenant operator, over MCP or HTTP
+credentialdef  op=create  scope=tenant  name=ANTHROPIC_API_KEY  value=sk-ant-…
+```
+
+> This override happens only on the **inference / tool request** path.
+> Model-*availability* probes stay on the operator key (which models are reachable
+> is an operator concern), and `ollama-local` is unauthenticated so it never takes
+> an override.
+
 ## Limitations / roadmap
 
 - Tenants can't set host env, so a `$cred:` value must be provisioned as a
   CredentialDef (above), not a `${LOOMCYCLE_*}` ref.
+- The provider-key override attributes spend to the run's tenant/user identity;
+  per-key usage **accounting / limits** (audit + report + cap per scope) is the
+  next step, tracked separately.
 - External backends (Vault / AWS SM / GCP SM / 1Password) — interface locked,
   implementation is RFC AR Phase 4.
-- A bundled search/messaging MCP catalog + the per-agent LLM-provider-key seam
-  are follow-ons (RFC AR).
+- A bundled search/messaging MCP catalog is a follow-on (RFC AR).

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -233,6 +233,8 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, run.ID, run.AgentID, run.SessionID, run.UserID, emit)
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// RFC AR: honor a tenant/user provider-key override on the resumed run too.
+	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:        run.UserID,
 		TenantID:      run.TenantID,

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -116,6 +116,14 @@ type Server struct {
 	// doc-internal/rfcs/model-resolution-matrix.md.
 	resolver *resolve.Resolver
 
+	// credResolver resolves a tenant/user credential by its env-var NAME (RFC
+	// AR): a run whose tenant/user stored e.g. ANTHROPIC_API_KEY / BRAVE_API_KEY
+	// overrides the operator's host key for that run. Stamped onto each run's
+	// loopCtx so provider drivers + WebSearch honor it; nil = never override
+	// (open-mode / no KEK). cmd/loomcycle/main.go calls SetCredentialResolver
+	// after construction. Reads run identity from the ctx it's given.
+	credResolver providers.CredentialResolver
+
 	// hookRegistry holds the runtime-registered tool-use hooks (the
 	// /v1/hooks endpoints write into this), and hookDispatcher is the
 	// loop-side adapter the agent loop calls into when dispatching
@@ -784,6 +792,12 @@ func (s *Server) SessionLocks() *runner.SessionLockMap { return s.sessionLocks }
 // no resolver is set, every agent uses the explicit-pin path
 // (cfg.ResolveAgentModel) — back-compat with v0.6.x.
 func (s *Server) SetResolver(r *resolve.Resolver) { s.resolver = r }
+
+// SetCredentialResolver wires the RFC AR credential resolver (env-var-name →
+// tenant/user credential value, scope agent>user>tenant). The Server stamps it
+// onto each run's ctx so provider drivers + WebSearch prefer a tenant-supplied
+// key over the operator host key. Nil ⇒ overrides disabled.
+func (s *Server) SetCredentialResolver(r providers.CredentialResolver) { s.credResolver = r }
 
 // markStalledFn returns a closure suitable for loop.RunOptions.MarkStalled.
 // The loop invokes the closure with the LIVE (provider, model) for the
@@ -1994,6 +2008,9 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	defer deregSteer()
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
+	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
+	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          effectiveUserID,
 		TenantID:        effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
@@ -3389,6 +3406,9 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Skill tool's subset check on each call) read it via ctx instead
 	// of being constructed per-run.
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
+	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
+	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
 	// Stash the run's identity so the Agent built-in tool's
 	// SubAgentRunner can inherit user_id and set parent_agent_id on
 	// any sub-runs it spawns.
@@ -3894,6 +3914,9 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	heartbeat := s.makeHeartbeat(run.ID)
 
 	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
+	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
+	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
 	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
 		UserID:          sess.UserID,
 		TenantID:        sess.TenantID, // RFC L: tenant from the session (authoritative at creation)

--- a/internal/providers/anthropic/credkey_test.go
+++ b/internal/providers/anthropic/credkey_test.go
@@ -1,0 +1,36 @@
+package anthropic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// A run whose tenant/user stored ANTHROPIC_API_KEY authenticates with THAT key;
+// a run without one uses the operator host key (RFC AR).
+func TestCallKey_OverridesHostKey(t *testing.T) {
+	d := &Driver{apiKey: "host-key"}
+
+	if got := d.callKey(context.Background()); got != "host-key" {
+		t.Errorf("no resolver: callKey = %q, want host-key", got)
+	}
+
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		if name == "ANTHROPIC_API_KEY" {
+			return "tenant-key", true
+		}
+		return "", false
+	})
+	if got := d.callKey(ctx); got != "tenant-key" {
+		t.Errorf("with override: callKey = %q, want tenant-key", got)
+	}
+
+	// A resolver that only knows a DIFFERENT provider's key leaves us on the host key.
+	ctxOther := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "openai-key", name == "OPENAI_API_KEY"
+	})
+	if got := d.callKey(ctxOther); got != "host-key" {
+		t.Errorf("unrelated override: callKey = %q, want host-key", got)
+	}
+}

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -52,6 +52,18 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 
 func (d *Driver) ID() string { return "anthropic" }
 
+// callKey returns the API key to authenticate an inference request: a
+// tenant/user credential named ANTHROPIC_API_KEY overrides the operator's host
+// key when the run has one (RFC AR), else the host key. Only the token-consuming
+// inference path uses this — model-availability probes (fetchModels) stay on the
+// operator key, since which models are reachable is an operator concern.
+func (d *Driver) callKey(ctx context.Context) string {
+	if k, ok := providers.ResolveCredential(ctx, "ANTHROPIC_API_KEY"); ok {
+		return k
+	}
+	return d.apiKey
+}
+
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		NativePromptCache: true,
@@ -105,7 +117,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		httpReq.Header.Set("x-api-key", d.apiKey)
+		httpReq.Header.Set("x-api-key", d.callKey(spanCtx))
 		httpReq.Header.Set("anthropic-version", apiVersion)
 		resp, err := d.http.Do(httpReq)
 		if err != nil {

--- a/internal/providers/credresolver.go
+++ b/internal/providers/credresolver.go
@@ -1,0 +1,45 @@
+package providers
+
+import "context"
+
+// credResolverKey is the ctx key for the per-run credential resolver.
+type credResolverKey struct{}
+
+// CredentialResolver resolves a credential by its well-known env-var NAME (e.g.
+// "ANTHROPIC_API_KEY", "BRAVE_API_KEY") for the run whose ctx this is, returning
+// (value, true) when the tenant/user has stored one that should OVERRIDE the
+// operator's host key. It reads the run identity from ctx internally and applies
+// scope precedence (agent > user > tenant). RFC AR: a tenant's own provider key
+// is used for that tenant/user's requests; the operator key is the fallback.
+//
+// It lives on the leaf providers package so LLM drivers can consult it without
+// importing internal/tools (the provider→loop→tools layering boundary); builtin
+// tools (WebSearch) may import providers and use it too. The resolver returns a
+// NAME→value lookup, never carries a secret in ctx — the value is fetched +
+// decrypted on demand.
+type CredentialResolver func(ctx context.Context, name string) (string, bool)
+
+// WithCredentialResolver stamps r onto ctx. The run-launch sites set it from the
+// credential engine; it flows via ctx to every provider Call and tool Execute.
+func WithCredentialResolver(ctx context.Context, r CredentialResolver) context.Context {
+	if r == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, credResolverKey{}, r)
+}
+
+// ResolveCredential resolves the credential named name for the run's ctx,
+// returning (value, true) on a hit. Safe when no resolver is stamped (returns
+// "", false → callers fall back to the operator's host key). This is the single
+// call site a driver / tool uses to honor a tenant-supplied key override.
+func ResolveCredential(ctx context.Context, name string) (string, bool) {
+	r, ok := ctx.Value(credResolverKey{}).(CredentialResolver)
+	if !ok || r == nil {
+		return "", false
+	}
+	v, found := r(ctx, name)
+	if !found || v == "" {
+		return "", false
+	}
+	return v, true
+}

--- a/internal/providers/credresolver_test.go
+++ b/internal/providers/credresolver_test.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveCredential_NoResolver(t *testing.T) {
+	// A bare ctx has no resolver → callers fall back to the host key.
+	if v, ok := ResolveCredential(context.Background(), "ANTHROPIC_API_KEY"); ok || v != "" {
+		t.Fatalf("ResolveCredential on bare ctx = (%q, %v), want (\"\", false)", v, ok)
+	}
+}
+
+func TestResolveCredential_Stamped(t *testing.T) {
+	ctx := WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		if name == "ANTHROPIC_API_KEY" {
+			return "sk-tenant", true
+		}
+		return "", false
+	})
+	if v, ok := ResolveCredential(ctx, "ANTHROPIC_API_KEY"); !ok || v != "sk-tenant" {
+		t.Errorf("hit = (%q, %v), want (sk-tenant, true)", v, ok)
+	}
+	// A name the resolver doesn't know → no override.
+	if v, ok := ResolveCredential(ctx, "OPENAI_API_KEY"); ok || v != "" {
+		t.Errorf("miss = (%q, %v), want (\"\", false)", v, ok)
+	}
+}
+
+func TestResolveCredential_EmptyValueIsNotAnOverride(t *testing.T) {
+	// A resolver that returns ("", true) must NOT override — an empty override
+	// would blank the host key and break auth. Treated as a miss.
+	ctx := WithCredentialResolver(context.Background(), func(context.Context, string) (string, bool) {
+		return "", true
+	})
+	if v, ok := ResolveCredential(ctx, "ANTHROPIC_API_KEY"); ok || v != "" {
+		t.Errorf("empty override = (%q, %v), want (\"\", false)", v, ok)
+	}
+}
+
+func TestWithCredentialResolver_NilIsNoop(t *testing.T) {
+	// Stamping a nil resolver leaves the ctx clean (open-mode / no KEK path).
+	ctx := WithCredentialResolver(context.Background(), nil)
+	if _, ok := ResolveCredential(ctx, "ANTHROPIC_API_KEY"); ok {
+		t.Errorf("nil resolver should not resolve anything")
+	}
+}

--- a/internal/providers/deepseek/driver.go
+++ b/internal/providers/deepseek/driver.go
@@ -56,7 +56,12 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if baseURL == "" {
 		baseURL = defaultBaseURL
 	}
-	return &Driver{inner: openai.New(apiKey, baseURL, streamOpts, httpClient)}
+	inner := openai.New(apiKey, baseURL, streamOpts, httpClient)
+	// RFC AR: a tenant/user overrides its own DeepSeek key by the env-var name
+	// DEEPSEEK_API_KEY, not OPENAI_API_KEY — the wrapped driver would otherwise
+	// resolve the OpenAI name.
+	inner.SetKeyEnvName("DEEPSEEK_API_KEY")
+	return &Driver{inner: inner}
 }
 
 // ID returns "deepseek" so the provider resolver in cmd/loomcycle

--- a/internal/providers/gemini/credkey_test.go
+++ b/internal/providers/gemini/credkey_test.go
@@ -1,0 +1,21 @@
+package gemini
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+func TestCallKey_OverridesHostKey(t *testing.T) {
+	d := &Driver{apiKey: "host-key"}
+	if got := d.callKey(context.Background()); got != "host-key" {
+		t.Errorf("no resolver: callKey = %q, want host-key", got)
+	}
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-gemini", name == "GEMINI_API_KEY"
+	})
+	if got := d.callKey(ctx); got != "tenant-gemini" {
+		t.Errorf("with override: callKey = %q, want tenant-gemini", got)
+	}
+}

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -78,6 +78,17 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 
 func (d *Driver) ID() string { return "gemini" }
 
+// callKey returns the API key for an inference request: a tenant/user credential
+// named GEMINI_API_KEY overrides the operator host key when the run has one (RFC
+// AR), else the host key. Model-availability probes (fetchModels) stay on the
+// host key.
+func (d *Driver) callKey(ctx context.Context) string {
+	if k, ok := providers.ResolveCredential(ctx, "GEMINI_API_KEY"); ok {
+		return k
+	}
+	return d.apiKey
+}
+
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		// Gemini has implicit prompt caching on long contexts but no
@@ -132,8 +143,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		if d.apiKey != "" {
-			httpReq.Header.Set("x-goog-api-key", d.apiKey)
+		if key := d.callKey(spanCtx); key != "" {
+			httpReq.Header.Set("x-goog-api-key", key)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {

--- a/internal/providers/ollama/credkey_test.go
+++ b/internal/providers/ollama/credkey_test.go
@@ -1,0 +1,29 @@
+package ollama
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// Hosted ollama.com honors an OLLAMA_API_KEY override; ollama-local is
+// unauthenticated local-network, so no override ever applies there (RFC AR).
+func TestCallKey_HostedOverride_LocalNever(t *testing.T) {
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-ollama", name == "OLLAMA_API_KEY"
+	})
+
+	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
+	if got := hosted.callKey(ctx); got != "tenant-ollama" {
+		t.Errorf("hosted with override: callKey = %q, want tenant-ollama", got)
+	}
+	if got := hosted.callKey(context.Background()); got != "host-key" {
+		t.Errorf("hosted no resolver: callKey = %q, want host-key", got)
+	}
+
+	local := &Driver{providerID: "ollama-local", apiKey: ""}
+	if got := local.callKey(ctx); got != "" {
+		t.Errorf("ollama-local must never take an override: callKey = %q, want empty", got)
+	}
+}

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -223,6 +223,21 @@ func (d *Driver) queryLoadedContext(model string) int {
 
 func (d *Driver) ID() string { return d.providerID }
 
+// callKey returns the Bearer key for a hosted-ollama.com inference request: a
+// tenant/user credential named OLLAMA_API_KEY overrides the operator host key
+// when the run has one (RFC AR), else the host key. Only "ollama" (hosted)
+// authenticates — "ollama-local" is unauthenticated local-network, so no
+// override applies there.
+func (d *Driver) callKey(ctx context.Context) string {
+	if d.providerID != "ollama" {
+		return d.apiKey
+	}
+	if k, ok := providers.ResolveCredential(ctx, "OLLAMA_API_KEY"); ok {
+		return k
+	}
+	return d.apiKey
+}
+
 func (d *Driver) Capabilities() providers.Capabilities {
 	return providers.Capabilities{
 		NativePromptCache: false,
@@ -282,8 +297,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "application/x-ndjson")
-		if d.apiKey != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+		if key := d.callKey(spanCtx); key != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+key)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {

--- a/internal/providers/openai/credkey_test.go
+++ b/internal/providers/openai/credkey_test.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/providers/streamhttp"
+)
+
+// The OpenAI driver resolves the override under OPENAI_API_KEY by default.
+func TestCallKey_DefaultEnvName(t *testing.T) {
+	d := New("host-key", "", streamhttp.Options{}, nil)
+	if d.keyEnvName != "OPENAI_API_KEY" {
+		t.Fatalf("default keyEnvName = %q, want OPENAI_API_KEY", d.keyEnvName)
+	}
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-openai", name == "OPENAI_API_KEY"
+	})
+	if got := d.callKey(ctx); got != "tenant-openai" {
+		t.Errorf("callKey = %q, want tenant-openai", got)
+	}
+}
+
+// SetKeyEnvName (used by the DeepSeek wrapper, which reuses this driver) points
+// the override at DEEPSEEK_API_KEY — an OPENAI_API_KEY credential must NOT leak
+// into a DeepSeek run, and vice versa.
+func TestCallKey_SetKeyEnvName_DeepSeek(t *testing.T) {
+	d := New("host-key", "", streamhttp.Options{}, nil)
+	d.SetKeyEnvName("DEEPSEEK_API_KEY")
+
+	deepseekOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-deepseek", name == "DEEPSEEK_API_KEY"
+	})
+	if got := d.callKey(deepseekOnly); got != "tenant-deepseek" {
+		t.Errorf("callKey = %q, want tenant-deepseek", got)
+	}
+
+	// A stored OPENAI_API_KEY is the wrong name for a DeepSeek driver → host key.
+	openaiOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-openai", name == "OPENAI_API_KEY"
+	})
+	if got := d.callKey(openaiOnly); got != "host-key" {
+		t.Errorf("callKey = %q, want host-key (OPENAI name must not apply to DeepSeek)", got)
+	}
+}

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -35,6 +35,11 @@ type Driver struct {
 	baseURL     string
 	http        *http.Client
 	idleTimeout time.Duration
+	// keyEnvName is the well-known env-var NAME whose tenant/user credential
+	// overrides the operator host key for an inference request (RFC AR).
+	// Defaults to "OPENAI_API_KEY"; the DeepSeek wrapper points it at
+	// "DEEPSEEK_API_KEY" via SetKeyEnvName since it reuses this driver.
+	keyEnvName string
 }
 
 // New constructs a Driver. baseURL may be empty for the default endpoint, or
@@ -51,7 +56,23 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 	if httpClient == nil {
 		httpClient = streamhttp.NewClient(streamOpts.HeaderTimeout)
 	}
-	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout}
+	return &Driver{apiKey: apiKey, baseURL: baseURL, http: httpClient, idleTimeout: streamOpts.IdleTimeout, keyEnvName: "OPENAI_API_KEY"}
+}
+
+// SetKeyEnvName overrides the env-var name whose tenant/user credential shadows
+// the host key (RFC AR). Used by the DeepSeek wrapper, which reuses this driver
+// but must resolve DEEPSEEK_API_KEY, not OPENAI_API_KEY.
+func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
+
+// callKey returns the API key for an inference request: a tenant/user credential
+// named d.keyEnvName overrides the operator host key when the run has one (RFC
+// AR), else the host key. Model-availability probes (fetchModels) stay on the
+// host key.
+func (d *Driver) callKey(ctx context.Context) string {
+	if k, ok := providers.ResolveCredential(ctx, d.keyEnvName); ok {
+		return k
+	}
+	return d.apiKey
 }
 
 func (d *Driver) ID() string { return "openai" }
@@ -113,8 +134,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		if d.apiKey != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+d.apiKey)
+		if key := d.callKey(spanCtx); key != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+key)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {

--- a/internal/tools/builtin/websearch.go
+++ b/internal/tools/builtin/websearch.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/denn-gubsky/loomcycle/internal/providers"
 	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
@@ -97,7 +98,15 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 	if strings.TrimSpace(args.Query) == "" {
 		return tools.Result{Text: "query is required", IsError: true}, nil
 	}
-	if s.APIKey == "" {
+	// RFC AR: a tenant/user credential named BRAVE_API_KEY overrides the
+	// operator host key for that run (scope precedence agent > user > tenant),
+	// so a tenant can search on its own Brave quota; the host key is the
+	// fallback. The key stays runtime-side — never surfaced to the model.
+	apiKey := s.APIKey
+	if k, ok := providers.ResolveCredential(ctx, "BRAVE_API_KEY"); ok {
+		apiKey = k
+	}
+	if apiKey == "" {
 		return tools.Result{Text: "WebSearch requires BRAVE_API_KEY; refusing", IsError: true}, nil
 	}
 	max := args.MaxResults
@@ -130,7 +139,7 @@ func (s *WebSearch) Execute(ctx context.Context, input json.RawMessage) (tools.R
 		return tools.Result{Text: "build request: " + err.Error(), IsError: true}, nil
 	}
 	httpReq.Header.Set("Accept", "application/json")
-	httpReq.Header.Set("X-Subscription-Token", s.APIKey)
+	httpReq.Header.Set("X-Subscription-Token", apiKey)
 
 	client := s.HTTPClient
 	if client == nil {

--- a/internal/tools/builtin/websearch_credkey_test.go
+++ b/internal/tools/builtin/websearch_credkey_test.go
@@ -1,0 +1,73 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+)
+
+// A tenant/user credential named BRAVE_API_KEY overrides the operator host key
+// on the actual outbound request; without one the host key is used (RFC AR).
+func TestWebSearch_BraveKeyOverride(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Subscription-Token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"web":{"results":[{"title":"t","url":"https://e.com","description":"d"}]}}`))
+	}))
+	defer srv.Close()
+
+	input := json.RawMessage(`{"query":"hello"}`)
+
+	// (1) No override → host key on the wire.
+	ws := &WebSearch{APIKey: "host-key", Endpoint: srv.URL}
+	if res, err := ws.Execute(context.Background(), input); err != nil || res.IsError {
+		t.Fatalf("host-key call failed: err=%v res=%+v", err, res)
+	}
+	if gotToken != "host-key" {
+		t.Errorf("no override: X-Subscription-Token = %q, want host-key", gotToken)
+	}
+
+	// (2) Tenant override → the tenant key is sent instead of the host key.
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-brave", name == "BRAVE_API_KEY"
+	})
+	if res, err := ws.Execute(ctx, input); err != nil || res.IsError {
+		t.Fatalf("override call failed: err=%v res=%+v", err, res)
+	}
+	if gotToken != "tenant-brave" {
+		t.Errorf("override: X-Subscription-Token = %q, want tenant-brave", gotToken)
+	}
+}
+
+// A tenant may search on its own Brave quota even when the operator set no host
+// key: the tenant BRAVE_API_KEY both enables the call and is what's sent.
+func TestWebSearch_TenantKeyEnablesWithNoHostKey(t *testing.T) {
+	var gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotToken = r.Header.Get("X-Subscription-Token")
+		_, _ = w.Write([]byte(`{"web":{"results":[]}}`))
+	}))
+	defer srv.Close()
+
+	ws := &WebSearch{APIKey: "", Endpoint: srv.URL} // operator set no key
+
+	// Without a tenant key the tool refuses (unchanged behavior).
+	if res, _ := ws.Execute(context.Background(), json.RawMessage(`{"query":"x"}`)); !res.IsError {
+		t.Errorf("no host key + no override should refuse, got %+v", res)
+	}
+
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+		return "tenant-brave", name == "BRAVE_API_KEY"
+	})
+	if res, err := ws.Execute(ctx, json.RawMessage(`{"query":"x"}`)); err != nil || res.IsError {
+		t.Fatalf("tenant key should enable the call: err=%v res=%+v", err, res)
+	}
+	if gotToken != "tenant-brave" {
+		t.Errorf("X-Subscription-Token = %q, want tenant-brave", gotToken)
+	}
+}


### PR DESCRIPTION
## Why

PR #630/#631 shipped the encrypted **CredentialDef** store and `$cred:` consumption for MCP servers — but the **LLM provider drivers still baked the operator's host key at `New()`** and `WebSearch` used the operator's Brave key. A tenant could not bill its own provider account for its own runs.

Per the operator's ask: **a tenant designates its provider key by the env-var *name*.** If a tenant stores an `ANTHROPIC_API_KEY`, it overrides the operator's `ANTHROPIC_API_KEY` for that tenant/user's requests; the same rule covers API-key-gated tools like `BRAVE_API_KEY`. This also sets up per-tenant/user **usage attribution** (the audit / report / limit follow-on).

## What

- **`internal/providers/credresolver.go`** — a ctx-carried `CredentialResolver` (`WithCredentialResolver` / `ResolveCredential`). Lives on the leaf `providers` package so drivers consult it without importing `internal/tools`; builtin tools import `providers` and use it too. An **empty override is treated as a miss** (never blanks the host key).
- **Drivers honor the override on the inference path only** (the `spanCtx` that carries the run ctx):
  - `anthropic` → `ANTHROPIC_API_KEY`
  - `openai` → `OPENAI_API_KEY` (configurable `keyEnvName`; the **DeepSeek** wrapper points the reused driver at `DEEPSEEK_API_KEY`)
  - `gemini` → `GEMINI_API_KEY`
  - hosted `ollama` → `OLLAMA_API_KEY` (**`ollama-local` never overrides** — it's unauthenticated)
  - Model-**availability** probes (`fetchModels`) stay on the operator key — which models are reachable is an operator concern.
- **`WebSearch`** resolves `BRAVE_API_KEY`; a tenant key even **enables** search when the operator set no host key at all.
- **Wiring:** `Server.credResolver` + `SetCredentialResolver`; `main.go` builds the resolver over the credential engine and stamps it onto each run's `loopCtx` at the top-level launch sites (RunOnce / continue / continuation / resume). **Sub-agents inherit** via `subRunCtx←ctx`; **gRPC** routes through the same http Server. **Fail-soft:** no KEK / no stored credential → no override → host key.

Scope precedence is the existing **agent > user > tenant**; the key stays runtime-side and never reaches the model.

## Tested

`go test ./...` (exit 0), `gofmt` + `go vet` clean, `go build`. New tests:
- **providers seam:** no-resolver, stamped, empty-value-is-not-an-override, nil-noop.
- **driver `callKey`:** anthropic/gemini override + fallback; openai default name **+ `SetKeyEnvName` isolates `DEEPSEEK_API_KEY` from `OPENAI_API_KEY`**; ollama hosted-override vs `ollama-local`-never.
- **websearch (httptest):** `BRAVE_API_KEY` on the wire overrides host; tenant key enables the call with no host key; no-override sends the host key.

Docs: `docs/CREDENTIALS.md` gains an "Overriding a provider / tool API key by its env-var name" section with the name→target table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)