### PR TITLE
feat(usage): per-scope token-usage & cost attribution ledger — Phase 1 (RFC AV)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,17 @@ jobs:
         run: go build -o bin/loomcycle ./cmd/loomcycle
 
       - name: Test (race detector)
-        # 120s is per-package. As the codebase grew (A2A added four more
-        # race-instrumented test packages), `go test -race ./...` runs more
-        # package binaries concurrently, and on a CPU-constrained CI runner
-        # that contention pushed the slow internal/api/http suite (~68s on a
-        # fast local box) past the 120s deadline despite no change to that
-        # package. 300s gives headroom under load while still catching a
-        # genuine deadlock.
-        run: go test -race -timeout 300s ./...
+        # Per-package timeout. `-race` instrumentation runs several-fold slower,
+        # and `go test ./...` runs package binaries concurrently, so on a
+        # CPU-constrained CI runner the largest suites contend for cores. This
+        # was bumped 120s→300s once already as the codebase grew; the two
+        # largest suites have since crept up again — measured locally under
+        # -race on an idle box, internal/tools/builtin ~176s and
+        # internal/api/http ~161s (both PASS, no deadlock), but under CI
+        # contention they crossed the 300s deadline. 900s gives generous
+        # headroom under load while still catching a genuine deadlock (a hung
+        # test still fails, just later). No package should approach it.
+        run: go test -race -timeout 900s ./...
 
       - name: gofmt check
         run: |

--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1308,13 +1308,15 @@ func main() {
 	// below; provider drivers + WebSearch consult it via the run ctx. Fails soft
 	// (a lookup error → no override → host key), never blocking a run on a KEK
 	// gap. Reused by every transport since gRPC routes through the http Server.
-	credResolver := providers.CredentialResolver(func(ctx context.Context, name string) (string, bool) {
+	credResolver := providers.CredentialResolver(func(ctx context.Context, name string) (providers.CredentialResolution, bool) {
 		ri := tools.RunIdentity(ctx)
 		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
 		if err != nil || !found {
-			return "", false
+			return providers.CredentialResolution{}, false
 		}
-		return res.Value, true
+		// RFC AV: carry the owning scope + scope_id so a driver can tag usage
+		// (operator vs tenant/user spend) from the same resolve it uses for the key.
+		return providers.CredentialResolution{Value: res.Value, Scope: res.Scope, ScopeID: res.ScopeID}, true
 	})
 	pathTool.Store = storeIface
 	documentTool.Store = storeIface

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -4388,6 +4388,7 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		return fwd
 	}
 	var mu sync.Mutex
+	var usageCallIdx int // RFC AV: per-call ledger row index within this run
 	return func(ev providers.Event) {
 		// Track parked (awaiting_input) state for the compaction boundary gate
 		// (handleCompactRun's IsParked check). The run is parked when it emits
@@ -4428,6 +4429,13 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 			}
 			return
 		}
+		// RFC AV: append one per-call usage row (which key paid + priced cost).
+		// Additive side-effect — the event still persists + forwards through the
+		// general path below (it is also stored as a "usage" event, unchanged).
+		if ev.Type == providers.EventUsage && ev.Usage != nil {
+			s.recordCallUsage(ctx, runID, usageCallIdx, ev.Usage)
+			usageCallIdx++
+		}
 		// F32: redact secrets out of the PERSISTED copy only — the tool_call
 		// input and tool_result text are the surfaces where a token inlined on a
 		// Bash cmdline / echoed by a tool would otherwise hit the events BLOB
@@ -4461,6 +4469,86 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		}
 		fwd(ev)
 	}
+}
+
+// recordCallUsage appends one per-call token_usage row (RFC AV): who paid
+// (credential source from the driver-stamped Usage), what served it
+// (provider/model), the token buckets, and the priced cost. Identity comes from
+// the run ctx (never the wire). A store error is logged, not fatal — usage
+// telemetry must never fail a run.
+func (s *Server) recordCallUsage(ctx context.Context, runID string, iteration int, u *providers.Usage) {
+	if s.store == nil || u == nil {
+		return
+	}
+	ri := tools.RunIdentity(ctx)
+	source := u.CredentialSource
+	if source == "" {
+		source = "operator" // no override fired → operator host key paid
+	}
+	// Attribute a sub-agent's call to its spawn-tree root so a fan-out's cost
+	// rolls up to the originating request; empty for a top-level run.
+	parentRunID := ""
+	if ri.RootRunID != "" && ri.RootRunID != runID {
+		parentRunID = ri.RootRunID
+	}
+	cost, currency := s.priceCall(u.Provider, u.Model, u)
+	row := store.TokenUsageRow{
+		RunID:               runID,
+		TenantID:            ri.TenantID,
+		UserID:              ri.UserID,
+		AgentID:             ri.AgentID,
+		ParentRunID:         parentRunID,
+		Iteration:           iteration,
+		Provider:            u.Provider,
+		Model:               u.Model,
+		CredentialSource:    source,
+		CredentialScopeID:   u.CredentialScopeID,
+		InputTokens:         u.InputTokens,
+		OutputTokens:        u.OutputTokens,
+		CacheCreationTokens: u.CacheCreationTokens,
+		CacheReadTokens:     u.CacheReadTokens,
+		Cost:                cost,
+		CostCurrency:        currency,
+		TS:                  time.Now(),
+	}
+	if err := s.store.RecordCallUsage(ctx, row); err != nil {
+		log.Printf("store: RecordCallUsage failed (run=%s iter=%d): %v", runID, iteration, err)
+	}
+}
+
+// runSummarySource returns the credential source to record on the run summary,
+// mirroring the per-call rule (RFC AV): an empty source on a run that actually
+// served an iteration (Provider set) means the operator host key paid → report
+// "operator", consistent with the ledger rows. A run that never completed an
+// iteration (no Provider) leaves it empty (NULL — no key paid).
+func runSummarySource(u providers.Usage) string {
+	if u.CredentialSource == "" && u.Provider != "" {
+		return "operator"
+	}
+	return u.CredentialSource
+}
+
+// priceCall computes a call's money cost (RFC AV, O1: loomcycle owns pricing). A
+// provider/gateway-reported cost wins when present; otherwise the operator's
+// pricing table prices it. An empty returned currency means UNPRICED (model
+// absent from the table) — the store persists a NULL cost, distinct from a
+// genuine zero (e.g. code-js / mock, which carry a currency).
+func (s *Server) priceCall(provider, model string, u *providers.Usage) (float64, string) {
+	if u.ProviderReportedCost > 0 {
+		cur := u.ProviderCostCurrency
+		if cur == "" {
+			cur = "USD"
+		}
+		return u.ProviderReportedCost, cur
+	}
+	if s.cfg == nil {
+		return 0, "" // unpriced (no config — e.g. a minimal test server)
+	}
+	cost, currency, ok := s.cfg.Pricing.Cost(provider, model, u.InputTokens, u.OutputTokens, u.CacheCreationTokens, u.CacheReadTokens)
+	if !ok {
+		return 0, "" // unpriced → NULL cost
+	}
+	return cost, currency
 }
 
 // maskCredentialCreateValue blanks the plaintext `value` field of a CredentialDef
@@ -6031,7 +6119,12 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
 		Provider:            res.Usage.Provider,
+		// RFC AV: carry the cost + credential-source summary on cancel too, so a
+		// partially-completed cancelled run still attributes its spend.
+		CredentialSource:  runSummarySource(res.Usage),
+		CredentialScopeID: res.Usage.CredentialScopeID,
 	}
+	usage.Cost, usage.CostCurrency = s.priceCall(res.Usage.Provider, res.Usage.Model, &res.Usage)
 	if err := s.store.FinishRun(bg, runID, store.RunCancelled, reason, usage, ""); err != nil {
 		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
 	}
@@ -6146,7 +6239,13 @@ func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, 
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
 		Provider:            res.Usage.Provider,
+		// RFC AV: per-run cost + credential-source summary. Cost is best-effort
+		// (priced from the run's final provider/model + summed tokens); the exact
+		// per-call split lives in token_usage. Source is the last iteration's key.
+		CredentialSource:  runSummarySource(res.Usage),
+		CredentialScopeID: res.Usage.CredentialScopeID,
 	}
+	usage.Cost, usage.CostCurrency = s.priceCall(res.Usage.Provider, res.Usage.Model, &res.Usage)
 	if err := s.store.FinishRun(bg, runID, status, res.StopReason, usage, errMsg); err != nil {
 		log.Printf("store: FinishRun failed (run=%s): %v", runID, err)
 	}

--- a/internal/api/http/usage_attribution_test.go
+++ b/internal/api/http/usage_attribution_test.go
@@ -1,0 +1,135 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// TestUsageAttribution_RecordsPerCallLedgerAndRunSummary is the RFC AV Phase 1
+// end-to-end: a run whose driver-stamped Usage carries a credential source
+// produces a token_usage row (priced from the operator table) AND a per-run
+// cost + credential_source summary on the runs row. A tenant-key run attributes
+// to the tenant; an operator-key run to the operator — the operator-vs-tenant
+// distinction the whole feature exists for.
+func TestUsageAttribution_RecordsPerCallLedgerAndRunSummary(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"solo": {Model: "stub-model", SystemPrompt: "you are solo"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+		// loomcycle owns pricing (RFC AV O1): $3 / 1M input, $15 / 1M output.
+		Pricing: config.PricingConfig{
+			Currency: "USD",
+			Models:   map[string]config.ModelPrice{"scripted/stub-model": {Input: 3, Output: 15}},
+		},
+	}
+	cfg.Env.AuthToken = ""
+
+	// Call 0 (run A): a tenant's own key paid. Call 1 (run B): operator key
+	// (empty source ⇒ recorded as "operator"). Model is set so the pricing key
+	// "scripted/stub-model" resolves.
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{
+					InputTokens: 1000, OutputTokens: 500, Model: "stub-model",
+					CredentialSource: "tenant", CredentialScopeID: "tenant-x"}},
+			},
+			{
+				{Type: providers.EventText, Text: "hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{
+					InputTokens: 2000, OutputTokens: 1000, Model: "stub-model"}}, // no source ⇒ operator
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "usage.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	postRun := func(agentID string) {
+		resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+			`{"agent":"solo","agent_id":"`+agentID+`","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+		))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 200 {
+			b, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d: %s", resp.StatusCode, b)
+		}
+		_, _ = io.ReadAll(resp.Body) // drain to completion (finishRun runs in-path)
+	}
+	postRun("solo-tenant")
+	postRun("solo-operator")
+
+	ctx := context.Background()
+
+	// --- Run A: tenant key paid. ---
+	runA, err := st.GetRunByAgentID(ctx, "solo-tenant")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID(solo-tenant): %v", err)
+	}
+	rowsA, err := st.TokenUsageForRun(ctx, runA.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rowsA) != 1 {
+		t.Fatalf("run A ledger rows = %d, want 1", len(rowsA))
+	}
+	rA := rowsA[0]
+	if rA.CredentialSource != "tenant" || rA.CredentialScopeID != "tenant-x" {
+		t.Errorf("run A source = %q/%q, want tenant/tenant-x", rA.CredentialSource, rA.CredentialScopeID)
+	}
+	if rA.Provider != "scripted" || rA.Model != "stub-model" {
+		t.Errorf("run A provider/model = %q/%q, want scripted/stub-model", rA.Provider, rA.Model)
+	}
+	// Cost = (1000*3 + 500*15)/1e6 = 0.0105.
+	if rA.CostCurrency != "USD" || rA.Cost < 0.0104 || rA.Cost > 0.0106 {
+		t.Errorf("run A cost = %v %q, want ~0.0105 USD", rA.Cost, rA.CostCurrency)
+	}
+	// Per-run summary: source + a non-NULL cost, and the rollup matches.
+	if runA.CredentialSource != "tenant" {
+		t.Errorf("run A summary source = %q, want tenant", runA.CredentialSource)
+	}
+	if runA.Cost == nil {
+		t.Errorf("run A summary cost is NULL, want priced")
+	}
+	if runA.InputTokens != rA.InputTokens {
+		t.Errorf("rollup: runs.InputTokens=%d Σledger=%d", runA.InputTokens, rA.InputTokens)
+	}
+
+	// --- Run B: operator key paid (empty source ⇒ "operator"). ---
+	runB, err := st.GetRunByAgentID(ctx, "solo-operator")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID(solo-operator): %v", err)
+	}
+	rowsB, _ := st.TokenUsageForRun(ctx, runB.ID)
+	if len(rowsB) != 1 || rowsB[0].CredentialSource != "operator" {
+		t.Fatalf("run B rows=%d source=%v, want 1 operator", len(rowsB), rowsB)
+	}
+	if runB.CredentialSource != "operator" {
+		t.Errorf("run B summary source = %q, want operator", runB.CredentialSource)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,12 @@ type Config struct {
 	// embedder_not_configured. K/V Memory is unaffected.
 	Memory MemoryConfig `yaml:"memory"`
 
+	// Pricing is the operator-owned per-(provider, model) price table used to
+	// compute run + per-call cost (RFC AV). Non-secret; empty ⇒ costs are left
+	// unpriced (token counts still recorded). A provider-reported cost, when a
+	// driver/gateway returns one, overrides this table.
+	Pricing PricingConfig `yaml:"pricing,omitempty"`
+
 	// Principals declares static (tenant, subject, scopes) logins, each bound
 	// to a bearer secret held in an env var (RFC AO). The map key is an
 	// informational handle. Lets an operator declare a stable service identity

--- a/internal/config/pricing.go
+++ b/internal/config/pricing.go
@@ -1,0 +1,58 @@
+package config
+
+// pricing.go — RFC AV: the operator-owned price table + per-call cost math.
+//
+// loomcycle owns pricing (RFC AV decision O1): it already resolves
+// (provider, model) per run, so the prices live next to the data. Cost is
+// materialized at write time from the table current at that moment — a later
+// price edit never rewrites history. A provider/gateway-reported cost, when
+// present, overrides the table (handled by the caller, not here).
+
+// PricingConfig is the `pricing:` config block: a default currency + a map of
+// "provider/model" → per-1M-token unit prices.
+type PricingConfig struct {
+	// Currency is the default ISO currency for every model without its own
+	// override (e.g. "USD"). Empty defaults to "USD" at compute time.
+	Currency string `yaml:"currency,omitempty"`
+	// Models maps a "provider/model" key (the concrete served pair, aliases
+	// already resolved) to its unit prices.
+	Models map[string]ModelPrice `yaml:"models,omitempty"`
+}
+
+// ModelPrice is one model's per-1M-token prices, one per token bucket (each is
+// billed at a different rate). A per-model Currency overrides the table default.
+type ModelPrice struct {
+	Input      float64 `yaml:"input"`       // $ per 1M input tokens
+	Output     float64 `yaml:"output"`      // $ per 1M output tokens
+	CacheWrite float64 `yaml:"cache_write"` // $ per 1M cache-creation tokens
+	CacheRead  float64 `yaml:"cache_read"`  // $ per 1M cache-read tokens
+	Currency   string  `yaml:"currency,omitempty"`
+}
+
+// Cost returns the money cost of a call's token usage under this table, the
+// currency, and whether the (provider, model) pair was priced. Prices are per
+// 1M tokens. ok=false ⇒ unpriced (pair absent from the table) → the caller
+// records a NULL cost + a pricing_missing signal, never a guess. A found pair
+// with all-zero prices (or zero tokens) is a genuine zero cost and returns
+// (0, currency, true) — distinct from unpriced.
+func (p PricingConfig) Cost(provider, model string, in, out, cacheCreation, cacheRead int) (float64, string, bool) {
+	if len(p.Models) == 0 {
+		return 0, "", false
+	}
+	mp, ok := p.Models[provider+"/"+model]
+	if !ok {
+		return 0, "", false
+	}
+	currency := mp.Currency
+	if currency == "" {
+		currency = p.Currency
+	}
+	if currency == "" {
+		currency = "USD"
+	}
+	cost := (float64(in)*mp.Input +
+		float64(out)*mp.Output +
+		float64(cacheCreation)*mp.CacheWrite +
+		float64(cacheRead)*mp.CacheRead) / 1e6
+	return cost, currency, true
+}

--- a/internal/config/pricing_test.go
+++ b/internal/config/pricing_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 1e-9 }
+
+func TestPricing_Cost(t *testing.T) {
+	p := PricingConfig{
+		Currency: "USD",
+		Models: map[string]ModelPrice{
+			// $ per 1M tokens.
+			"anthropic/claude-opus-4-8": {Input: 15, Output: 75, CacheWrite: 18.75, CacheRead: 1.5},
+			"local/free-model":          {Input: 0, Output: 0, Currency: "EUR"},
+		},
+	}
+
+	// Priced pair: cost = Σ(tokens × price)/1e6.
+	// 1000*15 + 500*75 + 200*18.75 + 100*1.5 = 15000+37500+3750+150 = 56400 /1e6.
+	cost, cur, ok := p.Cost("anthropic", "claude-opus-4-8", 1000, 500, 200, 100)
+	if !ok || cur != "USD" || !approx(cost, 0.0564) {
+		t.Errorf("priced = (%v, %q, %v), want (0.0564, USD, true)", cost, cur, ok)
+	}
+
+	// Unknown (provider, model) → unpriced: ok=false, empty currency (→ NULL cost).
+	if cost, cur, ok := p.Cost("openai", "gpt-9", 100, 100, 0, 0); ok || cur != "" || cost != 0 {
+		t.Errorf("unpriced = (%v, %q, %v), want (0, \"\", false)", cost, cur, ok)
+	}
+
+	// Found pair, all-zero prices → a GENUINE zero cost (ok=true) with its own
+	// currency — distinct from unpriced.
+	if cost, cur, ok := p.Cost("local", "free-model", 999, 999, 0, 0); !ok || cur != "EUR" || cost != 0 {
+		t.Errorf("zero-priced = (%v, %q, %v), want (0, EUR, true)", cost, cur, ok)
+	}
+
+	// Empty table → everything unpriced.
+	if _, _, ok := (PricingConfig{}).Cost("anthropic", "claude-opus-4-8", 1, 1, 0, 0); ok {
+		t.Errorf("empty table must not price anything")
+	}
+
+	// Per-model currency overrides the table default; absent → table default →
+	// "USD" fallback.
+	p2 := PricingConfig{Models: map[string]ModelPrice{"x/y": {Input: 1}}}
+	if _, cur, _ := p2.Cost("x", "y", 1_000_000, 0, 0, 0); cur != "USD" {
+		t.Errorf("currency fallback = %q, want USD", cur)
+	}
+}

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1682,6 +1682,13 @@ outerLoop:
 			// reflects the post-fallback identity. Used by downstream
 			// analysis to quantify primary-vs-fallback routing.
 			totalUsage.Provider = opts.Provider.ID()
+			// RFC AV: carry the per-call credential source (which key paid,
+			// stamped by the driver) onto the run-level summary. The last
+			// successful iteration's source becomes runs.credential_source —
+			// best-effort for the summary; the exact per-call split is in the
+			// token_usage ledger (one row per EventUsage below).
+			totalUsage.CredentialSource = iterUsage.CredentialSource
+			totalUsage.CredentialScopeID = iterUsage.CredentialScopeID
 			// Stamp the serving model's context-window ceiling onto the
 			// per-iteration usage event so the UI can render a "context
 			// used / max" gauge. Set on iterUsage (discarded after this
@@ -1693,6 +1700,10 @@ outerLoop:
 			if iterUsage.MaxContextTokens == 0 {
 				iterUsage.MaxContextTokens = opts.Provider.Capabilities().MaxContextTokens
 			}
+			// RFC AV: stamp the serving provider onto the per-call usage event
+			// too (not just totalUsage) so the token_usage row records which
+			// provider actually served this call — exact across mid-run fallback.
+			iterUsage.Provider = opts.Provider.ID()
 			emit(providers.Event{Type: providers.EventUsage, Usage: iterUsage})
 			// Retain this turn's CURRENT context footprint (input + cache, i.e.
 			// what the request actually sent — NOT cumulative totalUsage, which

--- a/internal/providers/anthropic/credkey_test.go
+++ b/internal/providers/anthropic/credkey_test.go
@@ -7,30 +7,31 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/providers"
 )
 
-// A run whose tenant/user stored ANTHROPIC_API_KEY authenticates with THAT key;
-// a run without one uses the operator host key (RFC AR).
-func TestCallKey_OverridesHostKey(t *testing.T) {
+// A run whose tenant/user stored ANTHROPIC_API_KEY authenticates with THAT key
+// (and the resolved scope is reported for usage attribution); a run without one
+// uses the operator host key with source "operator" (RFC AR / RFC AV).
+func TestResolveKey_OverridesHostKey(t *testing.T) {
 	d := &Driver{apiKey: "host-key"}
 
-	if got := d.callKey(context.Background()); got != "host-key" {
-		t.Errorf("no resolver: callKey = %q, want host-key", got)
+	if key, source, _ := d.resolveKey(context.Background()); key != "host-key" || source != "operator" {
+		t.Errorf("no resolver: (%q, %q), want (host-key, operator)", key, source)
 	}
 
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
 		if name == "ANTHROPIC_API_KEY" {
-			return "tenant-key", true
+			return providers.CredentialResolution{Value: "tenant-key", Scope: "tenant"}, true
 		}
-		return "", false
+		return providers.CredentialResolution{}, false
 	})
-	if got := d.callKey(ctx); got != "tenant-key" {
-		t.Errorf("with override: callKey = %q, want tenant-key", got)
+	if key, source, _ := d.resolveKey(ctx); key != "tenant-key" || source != "tenant" {
+		t.Errorf("with override: (%q, %q), want (tenant-key, tenant)", key, source)
 	}
 
 	// A resolver that only knows a DIFFERENT provider's key leaves us on the host key.
-	ctxOther := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "openai-key", name == "OPENAI_API_KEY"
+	ctxOther := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "openai-key"}, name == "OPENAI_API_KEY"
 	})
-	if got := d.callKey(ctxOther); got != "host-key" {
-		t.Errorf("unrelated override: callKey = %q, want host-key", got)
+	if key, source, _ := d.resolveKey(ctxOther); key != "host-key" || source != "operator" {
+		t.Errorf("unrelated override: (%q, %q), want (host-key, operator)", key, source)
 	}
 }

--- a/internal/providers/anthropic/driver.go
+++ b/internal/providers/anthropic/driver.go
@@ -52,16 +52,17 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 
 func (d *Driver) ID() string { return "anthropic" }
 
-// callKey returns the API key to authenticate an inference request: a
-// tenant/user credential named ANTHROPIC_API_KEY overrides the operator's host
-// key when the run has one (RFC AR), else the host key. Only the token-consuming
-// inference path uses this — model-availability probes (fetchModels) stay on the
-// operator key, since which models are reachable is an operator concern.
-func (d *Driver) callKey(ctx context.Context) string {
-	if k, ok := providers.ResolveCredential(ctx, "ANTHROPIC_API_KEY"); ok {
-		return k
+// resolveKey returns the API key to authenticate an inference request AND which
+// credential scope it came from. A tenant/user credential named
+// ANTHROPIC_API_KEY overrides the operator's host key (RFC AR); source is
+// "operator" when none did. The source/scopeID ride the per-call Usage so the
+// server can attribute spend (RFC AV). Model-availability probes (fetchModels)
+// stay on the operator key — which models are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
+	if r, ok := providers.ResolveCredentialFull(ctx, "ANTHROPIC_API_KEY"); ok {
+		return r.Value, r.Scope, r.ScopeID
 	}
-	return d.apiKey
+	return d.apiKey, "operator", ""
 }
 
 func (d *Driver) Capabilities() providers.Capabilities {
@@ -98,6 +99,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	// (idempotent).
 	streamCtx, cancelStream := context.WithCancel(ctx)
 
+	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
+	// attempt) so the header uses it and the source rides the per-call Usage.
+	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.
 		// Retries surface as separate sibling spans so operators see
@@ -117,7 +122,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		httpReq.Header.Set("x-api-key", d.callKey(spanCtx))
+		httpReq.Header.Set("x-api-key", apiKey)
 		httpReq.Header.Set("anthropic-version", apiVersion)
 		resp, err := d.http.Do(httpReq)
 		if err != nil {
@@ -154,7 +159,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	out := make(chan providers.Event, 16)
 	go func() {
 		defer cancelStream()
-		streamEvents(streamCtx, resp.Body, out)
+		streamEvents(streamCtx, resp.Body, out, credSource, credScopeID)
 	}()
 	return out, nil
 }
@@ -414,7 +419,7 @@ type sseFrame struct {
 	data  []byte
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, credSource, credScopeID string) {
 	defer body.Close()
 	defer close(out)
 
@@ -474,6 +479,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 	// Final done event with stop_reason + usage + the accumulated thinking
 	// block (Reasoning text + Signature) for the loop to stamp onto the
 	// assistant Message — Anthropic replays it on the tool-use continuation.
+	// RFC AV: tag the per-call usage with which credential scope paid.
+	if usage != nil {
+		usage.CredentialSource = credSource
+		usage.CredentialScopeID = credScopeID
+	}
 	send(providers.Event{
 		Type:               providers.EventDone,
 		StopReason:         stopReason,

--- a/internal/providers/credresolver.go
+++ b/internal/providers/credresolver.go
@@ -5,19 +5,30 @@ import "context"
 // credResolverKey is the ctx key for the per-run credential resolver.
 type credResolverKey struct{}
 
+// CredentialResolution is the result of resolving a credential override: the
+// value to use plus WHICH scope owned the override, so a caller can attribute
+// usage (RFC AV — operator vs tenant/user spend). Scope is "agent" | "user" |
+// "tenant"; ScopeID is the owning subject/tenant id ("" for tenant scope).
+type CredentialResolution struct {
+	Value   string
+	Scope   string
+	ScopeID string
+}
+
 // CredentialResolver resolves a credential by its well-known env-var NAME (e.g.
 // "ANTHROPIC_API_KEY", "BRAVE_API_KEY") for the run whose ctx this is, returning
-// (value, true) when the tenant/user has stored one that should OVERRIDE the
-// operator's host key. It reads the run identity from ctx internally and applies
-// scope precedence (agent > user > tenant). RFC AR: a tenant's own provider key
-// is used for that tenant/user's requests; the operator key is the fallback.
+// the resolution + true when the tenant/user has stored one that should OVERRIDE
+// the operator's host key. It reads the run identity from ctx internally and
+// applies scope precedence (agent > user > tenant). RFC AR: a tenant's own
+// provider key is used for that tenant/user's requests; the operator key is the
+// fallback. RFC AV: the returned Scope/ScopeID tag the usage record.
 //
 // It lives on the leaf providers package so LLM drivers can consult it without
 // importing internal/tools (the provider→loop→tools layering boundary); builtin
 // tools (WebSearch) may import providers and use it too. The resolver returns a
 // NAME→value lookup, never carries a secret in ctx — the value is fetched +
 // decrypted on demand.
-type CredentialResolver func(ctx context.Context, name string) (string, bool)
+type CredentialResolver func(ctx context.Context, name string) (CredentialResolution, bool)
 
 // WithCredentialResolver stamps r onto ctx. The run-launch sites set it from the
 // credential engine; it flows via ctx to every provider Call and tool Execute.
@@ -28,18 +39,30 @@ func WithCredentialResolver(ctx context.Context, r CredentialResolver) context.C
 	return context.WithValue(ctx, credResolverKey{}, r)
 }
 
-// ResolveCredential resolves the credential named name for the run's ctx,
-// returning (value, true) on a hit. Safe when no resolver is stamped (returns
-// "", false → callers fall back to the operator's host key). This is the single
-// call site a driver / tool uses to honor a tenant-supplied key override.
-func ResolveCredential(ctx context.Context, name string) (string, bool) {
+// ResolveCredentialFull resolves the credential named name for the run's ctx,
+// returning the full resolution (value + owning scope) + true on a hit. Safe
+// when no resolver is stamped (returns zero, false → callers fall back to the
+// operator's host key). A hit with an empty value is treated as a miss — an
+// empty override must never blank the host key.
+func ResolveCredentialFull(ctx context.Context, name string) (CredentialResolution, bool) {
 	r, ok := ctx.Value(credResolverKey{}).(CredentialResolver)
 	if !ok || r == nil {
+		return CredentialResolution{}, false
+	}
+	res, found := r(ctx, name)
+	if !found || res.Value == "" {
+		return CredentialResolution{}, false
+	}
+	return res, true
+}
+
+// ResolveCredential is the value-only convenience over ResolveCredentialFull:
+// the single call site a driver / tool uses when it needs only the key to send
+// (the override value), not the owning scope.
+func ResolveCredential(ctx context.Context, name string) (string, bool) {
+	res, ok := ResolveCredentialFull(ctx, name)
+	if !ok {
 		return "", false
 	}
-	v, found := r(ctx, name)
-	if !found || v == "" {
-		return "", false
-	}
-	return v, true
+	return res.Value, true
 }

--- a/internal/providers/credresolver_test.go
+++ b/internal/providers/credresolver_test.go
@@ -10,14 +10,17 @@ func TestResolveCredential_NoResolver(t *testing.T) {
 	if v, ok := ResolveCredential(context.Background(), "ANTHROPIC_API_KEY"); ok || v != "" {
 		t.Fatalf("ResolveCredential on bare ctx = (%q, %v), want (\"\", false)", v, ok)
 	}
+	if _, ok := ResolveCredentialFull(context.Background(), "ANTHROPIC_API_KEY"); ok {
+		t.Errorf("ResolveCredentialFull on bare ctx should miss")
+	}
 }
 
 func TestResolveCredential_Stamped(t *testing.T) {
-	ctx := WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
+	ctx := WithCredentialResolver(context.Background(), func(_ context.Context, name string) (CredentialResolution, bool) {
 		if name == "ANTHROPIC_API_KEY" {
-			return "sk-tenant", true
+			return CredentialResolution{Value: "sk-tenant", Scope: "tenant"}, true
 		}
-		return "", false
+		return CredentialResolution{}, false
 	})
 	if v, ok := ResolveCredential(ctx, "ANTHROPIC_API_KEY"); !ok || v != "sk-tenant" {
 		t.Errorf("hit = (%q, %v), want (sk-tenant, true)", v, ok)
@@ -28,14 +31,28 @@ func TestResolveCredential_Stamped(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialFull_CarriesScope(t *testing.T) {
+	// RFC AV: the owning scope + scope_id ride the resolution for usage tagging.
+	ctx := WithCredentialResolver(context.Background(), func(_ context.Context, name string) (CredentialResolution, bool) {
+		return CredentialResolution{Value: "tok", Scope: "user", ScopeID: "u-42"}, name == "TELEGRAM_TOKEN"
+	})
+	res, ok := ResolveCredentialFull(ctx, "TELEGRAM_TOKEN")
+	if !ok || res.Value != "tok" || res.Scope != "user" || res.ScopeID != "u-42" {
+		t.Errorf("full = %+v ok=%v, want {tok user u-42} true", res, ok)
+	}
+}
+
 func TestResolveCredential_EmptyValueIsNotAnOverride(t *testing.T) {
 	// A resolver that returns ("", true) must NOT override — an empty override
 	// would blank the host key and break auth. Treated as a miss.
-	ctx := WithCredentialResolver(context.Background(), func(context.Context, string) (string, bool) {
-		return "", true
+	ctx := WithCredentialResolver(context.Background(), func(context.Context, string) (CredentialResolution, bool) {
+		return CredentialResolution{Value: "", Scope: "tenant"}, true
 	})
 	if v, ok := ResolveCredential(ctx, "ANTHROPIC_API_KEY"); ok || v != "" {
 		t.Errorf("empty override = (%q, %v), want (\"\", false)", v, ok)
+	}
+	if _, ok := ResolveCredentialFull(ctx, "ANTHROPIC_API_KEY"); ok {
+		t.Errorf("empty override (full) should be a miss")
 	}
 }
 

--- a/internal/providers/gemini/credkey_test.go
+++ b/internal/providers/gemini/credkey_test.go
@@ -9,13 +9,13 @@ import (
 
 func TestCallKey_OverridesHostKey(t *testing.T) {
 	d := &Driver{apiKey: "host-key"}
-	if got := d.callKey(context.Background()); got != "host-key" {
-		t.Errorf("no resolver: callKey = %q, want host-key", got)
+	if got, _, _ := d.resolveKey(context.Background()); got != "host-key" {
+		t.Errorf("no resolver: resolveKey = %q, want host-key", got)
 	}
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-gemini", name == "GEMINI_API_KEY"
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-gemini"}, name == "GEMINI_API_KEY"
 	})
-	if got := d.callKey(ctx); got != "tenant-gemini" {
-		t.Errorf("with override: callKey = %q, want tenant-gemini", got)
+	if got, _, _ := d.resolveKey(ctx); got != "tenant-gemini" {
+		t.Errorf("with override: resolveKey = %q, want tenant-gemini", got)
 	}
 }

--- a/internal/providers/gemini/driver.go
+++ b/internal/providers/gemini/driver.go
@@ -78,15 +78,17 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 
 func (d *Driver) ID() string { return "gemini" }
 
-// callKey returns the API key for an inference request: a tenant/user credential
-// named GEMINI_API_KEY overrides the operator host key when the run has one (RFC
-// AR), else the host key. Model-availability probes (fetchModels) stay on the
-// host key.
-func (d *Driver) callKey(ctx context.Context) string {
-	if k, ok := providers.ResolveCredential(ctx, "GEMINI_API_KEY"); ok {
-		return k
+// resolveKey returns the API key to authenticate an inference request AND which
+// credential scope it came from. A tenant/user credential named GEMINI_API_KEY
+// overrides the operator's host key (RFC AR); source is "operator" when none
+// did. The source/scopeID ride the per-call Usage so the server can attribute
+// spend (RFC AV). Model-availability probes (fetchModels) stay on the host key
+// — which models are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
+	if r, ok := providers.ResolveCredentialFull(ctx, "GEMINI_API_KEY"); ok {
+		return r.Value, r.Scope, r.ScopeID
 	}
-	return d.apiKey
+	return d.apiKey, "operator", ""
 }
 
 func (d *Driver) Capabilities() providers.Capabilities {
@@ -127,6 +129,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	streamCtx, cancelStream := context.WithCancel(ctx)
 
+	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
+	// attempt) so the header uses it and the source rides the per-call Usage.
+	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+
 	url := d.baseURL + "/models/" + req.Model + ":streamGenerateContent?alt=sse"
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.
@@ -143,8 +149,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		if key := d.callKey(spanCtx); key != "" {
-			httpReq.Header.Set("x-goog-api-key", key)
+		if apiKey != "" {
+			httpReq.Header.Set("x-goog-api-key", apiKey)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {
@@ -179,7 +185,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	out := make(chan providers.Event, 16)
 	go func() {
 		defer cancelStream()
-		streamEvents(streamCtx, resp.Body, out, req.Model)
+		streamEvents(streamCtx, resp.Body, out, req.Model, credSource, credScopeID)
 	}()
 	return out, nil
 }
@@ -442,7 +448,7 @@ type chunkUsage struct {
 	ThoughtsTokenCount int `json:"thoughtsTokenCount"`
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, requestModel string) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, requestModel, credSource, credScopeID string) {
 	defer body.Close()
 	defer close(out)
 
@@ -549,6 +555,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 
 	if usage == nil {
 		usage = &providers.Usage{Model: model}
+	}
+	// RFC AV: tag the per-call usage with which credential scope paid.
+	if usage != nil {
+		usage.CredentialSource = credSource
+		usage.CredentialScopeID = credScopeID
 	}
 	send(providers.Event{
 		Type:       providers.EventDone,

--- a/internal/providers/ollama/credkey_test.go
+++ b/internal/providers/ollama/credkey_test.go
@@ -10,20 +10,20 @@ import (
 // Hosted ollama.com honors an OLLAMA_API_KEY override; ollama-local is
 // unauthenticated local-network, so no override ever applies there (RFC AR).
 func TestCallKey_HostedOverride_LocalNever(t *testing.T) {
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-ollama", name == "OLLAMA_API_KEY"
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-ollama"}, name == "OLLAMA_API_KEY"
 	})
 
 	hosted := &Driver{providerID: "ollama", apiKey: "host-key"}
-	if got := hosted.callKey(ctx); got != "tenant-ollama" {
-		t.Errorf("hosted with override: callKey = %q, want tenant-ollama", got)
+	if got, _, _ := hosted.resolveKey(ctx); got != "tenant-ollama" {
+		t.Errorf("hosted with override: resolveKey = %q, want tenant-ollama", got)
 	}
-	if got := hosted.callKey(context.Background()); got != "host-key" {
-		t.Errorf("hosted no resolver: callKey = %q, want host-key", got)
+	if got, _, _ := hosted.resolveKey(context.Background()); got != "host-key" {
+		t.Errorf("hosted no resolver: resolveKey = %q, want host-key", got)
 	}
 
 	local := &Driver{providerID: "ollama-local", apiKey: ""}
-	if got := local.callKey(ctx); got != "" {
-		t.Errorf("ollama-local must never take an override: callKey = %q, want empty", got)
+	if got, _, _ := local.resolveKey(ctx); got != "" {
+		t.Errorf("ollama-local must never take an override: resolveKey = %q, want empty", got)
 	}
 }

--- a/internal/providers/ollama/driver.go
+++ b/internal/providers/ollama/driver.go
@@ -223,19 +223,20 @@ func (d *Driver) queryLoadedContext(model string) int {
 
 func (d *Driver) ID() string { return d.providerID }
 
-// callKey returns the Bearer key for a hosted-ollama.com inference request: a
-// tenant/user credential named OLLAMA_API_KEY overrides the operator host key
-// when the run has one (RFC AR), else the host key. Only "ollama" (hosted)
-// authenticates — "ollama-local" is unauthenticated local-network, so no
-// override applies there.
-func (d *Driver) callKey(ctx context.Context) string {
-	if d.providerID != "ollama" {
-		return d.apiKey
+// resolveKey returns the Bearer key to authenticate an inference request AND
+// which credential scope it came from. On hosted "ollama" a tenant/user
+// credential named OLLAMA_API_KEY overrides the operator's host key (RFC AR);
+// "ollama-local" is unauthenticated local-network, so no override applies and
+// the source stays "operator". The source/scopeID ride the per-call Usage so
+// the server can attribute spend (RFC AV). Model-availability probes
+// (queryLoadedContext) stay on the operator key.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
+	if d.providerID == "ollama" {
+		if r, ok := providers.ResolveCredentialFull(ctx, "OLLAMA_API_KEY"); ok {
+			return r.Value, r.Scope, r.ScopeID
+		}
 	}
-	if k, ok := providers.ResolveCredential(ctx, "OLLAMA_API_KEY"); ok {
-		return k
-	}
-	return d.apiKey
+	return d.apiKey, "operator", ""
 }
 
 func (d *Driver) Capabilities() providers.Capabilities {
@@ -280,6 +281,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	streamCtx, cancelStream := context.WithCancel(ctx)
 
+	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
+	// attempt) so the header uses it and the source rides the per-call Usage.
+	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.
 		// d.providerID is "ollama" (cloud) or "ollama-local" — the
@@ -297,8 +302,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "application/x-ndjson")
-		if key := d.callKey(spanCtx); key != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+key)
+		if apiKey != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {
@@ -335,7 +340,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		defer cancelStream()
 		// maxCtxFn is evaluated lazily at the done frame (model loaded by
 		// then) so the usage event carries the model's real loaded window.
-		streamEvents(streamCtx, resp.Body, out, len(req.Tools) > 0, func() int { return d.contextWindow(req.Model) })
+		streamEvents(streamCtx, resp.Body, out, len(req.Tools) > 0, func() int { return d.contextWindow(req.Model) }, credSource, credScopeID)
 	}()
 	return out, nil
 }
@@ -583,7 +588,7 @@ type chunkToolCallFn struct {
 
 // maxCtxFn (optional) returns the model's effective context window; called
 // once at the done frame to stamp usage.MaxContextTokens. nil → not stamped.
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, wantTools bool, maxCtxFn func() int) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, wantTools bool, maxCtxFn func() int, credSource, credScopeID string) {
 	defer body.Close()
 	defer close(out)
 
@@ -776,6 +781,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 	}
 
+	// RFC AV: tag the per-call usage with which credential scope paid.
+	if usage != nil {
+		usage.CredentialSource = credSource
+		usage.CredentialScopeID = credScopeID
+	}
 	send(providers.Event{Type: providers.EventDone, StopReason: stopReason, Usage: usage})
 }
 

--- a/internal/providers/openai/credkey_test.go
+++ b/internal/providers/openai/credkey_test.go
@@ -14,11 +14,11 @@ func TestCallKey_DefaultEnvName(t *testing.T) {
 	if d.keyEnvName != "OPENAI_API_KEY" {
 		t.Fatalf("default keyEnvName = %q, want OPENAI_API_KEY", d.keyEnvName)
 	}
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-openai", name == "OPENAI_API_KEY"
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-openai"}, name == "OPENAI_API_KEY"
 	})
-	if got := d.callKey(ctx); got != "tenant-openai" {
-		t.Errorf("callKey = %q, want tenant-openai", got)
+	if got, _, _ := d.resolveKey(ctx); got != "tenant-openai" {
+		t.Errorf("resolveKey = %q, want tenant-openai", got)
 	}
 }
 
@@ -29,18 +29,18 @@ func TestCallKey_SetKeyEnvName_DeepSeek(t *testing.T) {
 	d := New("host-key", "", streamhttp.Options{}, nil)
 	d.SetKeyEnvName("DEEPSEEK_API_KEY")
 
-	deepseekOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-deepseek", name == "DEEPSEEK_API_KEY"
+	deepseekOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-deepseek"}, name == "DEEPSEEK_API_KEY"
 	})
-	if got := d.callKey(deepseekOnly); got != "tenant-deepseek" {
-		t.Errorf("callKey = %q, want tenant-deepseek", got)
+	if got, _, _ := d.resolveKey(deepseekOnly); got != "tenant-deepseek" {
+		t.Errorf("resolveKey = %q, want tenant-deepseek", got)
 	}
 
 	// A stored OPENAI_API_KEY is the wrong name for a DeepSeek driver → host key.
-	openaiOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-openai", name == "OPENAI_API_KEY"
+	openaiOnly := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-openai"}, name == "OPENAI_API_KEY"
 	})
-	if got := d.callKey(openaiOnly); got != "host-key" {
-		t.Errorf("callKey = %q, want host-key (OPENAI name must not apply to DeepSeek)", got)
+	if got, _, _ := d.resolveKey(openaiOnly); got != "host-key" {
+		t.Errorf("resolveKey = %q, want host-key (OPENAI name must not apply to DeepSeek)", got)
 	}
 }

--- a/internal/providers/openai/driver.go
+++ b/internal/providers/openai/driver.go
@@ -64,15 +64,18 @@ func New(apiKey, baseURL string, streamOpts streamhttp.Options, httpClient *http
 // but must resolve DEEPSEEK_API_KEY, not OPENAI_API_KEY.
 func (d *Driver) SetKeyEnvName(name string) { d.keyEnvName = name }
 
-// callKey returns the API key for an inference request: a tenant/user credential
-// named d.keyEnvName overrides the operator host key when the run has one (RFC
-// AR), else the host key. Model-availability probes (fetchModels) stay on the
-// host key.
-func (d *Driver) callKey(ctx context.Context) string {
-	if k, ok := providers.ResolveCredential(ctx, d.keyEnvName); ok {
-		return k
+// resolveKey returns the API key to authenticate an inference request AND which
+// credential scope it came from. A tenant/user credential named d.keyEnvName
+// (default "OPENAI_API_KEY"; the DeepSeek wrapper sets "DEEPSEEK_API_KEY")
+// overrides the operator's host key (RFC AR); source is "operator" when none
+// did. The source/scopeID ride the per-call Usage so the server can attribute
+// spend (RFC AV). Model-availability probes (fetchModels) stay on the host key
+// — which models are reachable is an operator concern.
+func (d *Driver) resolveKey(ctx context.Context) (key, source, scopeID string) {
+	if r, ok := providers.ResolveCredentialFull(ctx, d.keyEnvName); ok {
+		return r.Value, r.Scope, r.ScopeID
 	}
-	return d.apiKey
+	return d.apiKey, "operator", ""
 }
 
 func (d *Driver) ID() string { return "openai" }
@@ -111,6 +114,10 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 
 	streamCtx, cancelStream := context.WithCancel(ctx)
 
+	// RFC AR/AV: resolve the key + its owning scope ONCE per call (not per retry
+	// attempt) so the header uses it and the source rides the per-call Usage.
+	apiKey, credSource, credScopeID := d.resolveKey(ctx)
+
 	attempt := func(attemptCtx context.Context) (*http.Response, error) {
 		// v0.10.0 OTEL: one loomcycle.provider.call span per attempt.
 		// The provider attribute defaults to "openai" but a wrapping
@@ -134,8 +141,8 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 		}
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
-		if key := d.callKey(spanCtx); key != "" {
-			httpReq.Header.Set("Authorization", "Bearer "+key)
+		if apiKey != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 		resp, err := d.http.Do(httpReq)
 		if err != nil {
@@ -170,7 +177,7 @@ func (d *Driver) Call(ctx context.Context, req providers.Request) (<-chan provid
 	out := make(chan providers.Event, 16)
 	go func() {
 		defer cancelStream()
-		streamEvents(streamCtx, resp.Body, out)
+		streamEvents(streamCtx, resp.Body, out, credSource, credScopeID)
 	}()
 	return out, nil
 }
@@ -583,7 +590,7 @@ type toolAccumulator struct {
 	args strings.Builder
 }
 
-func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event) {
+func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.Event, credSource, credScopeID string) {
 	defer body.Close()
 	defer close(out)
 
@@ -764,6 +771,11 @@ func streamEvents(ctx context.Context, body io.ReadCloser, out chan<- providers.
 		}
 	}
 
+	// RFC AV: tag the per-call usage with which credential scope paid.
+	if usage != nil {
+		usage.CredentialSource = credSource
+		usage.CredentialScopeID = credScopeID
+	}
 	send(providers.Event{
 		Type:       providers.EventDone,
 		StopReason: stopReason,

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -850,4 +850,23 @@ type Usage struct {
 	// so older consumers and the run-final totalUsage (which leaves it 0)
 	// are unaffected.
 	MaxContextTokens int `json:"max_context_tokens,omitempty"`
+
+	// --- RFC AV: per-call usage attribution (all additive, omitempty). ---
+
+	// CredentialSource names which key paid for this call: "operator" (the
+	// host key), or "tenant" / "user" when an RFC AR override fired at that
+	// scope. Empty ⇒ operator (the default for every call with no override).
+	// The driver stamps it from the same resolve it uses to pick the key, so
+	// there is no extra credential-store read. CredentialScopeID is the owning
+	// subject/tenant id of an override ("" for operator / tenant scope). These
+	// let the server attribute spend to the operator vs the tenant/user.
+	CredentialSource  string `json:"credential_source,omitempty"`
+	CredentialScopeID string `json:"credential_scope_id,omitempty"`
+
+	// ProviderReportedCost is the provider's / gateway's OWN cost figure for
+	// this call, when the response carries one (OpenRouter-style `usage.cost`);
+	// 0/absent ⇒ the server prices the call from its pricing table. When set it
+	// is authoritative (never re-priced). ProviderCostCurrency pairs with it.
+	ProviderReportedCost float64 `json:"provider_reported_cost,omitempty"`
+	ProviderCostCurrency string  `json:"provider_cost_currency,omitempty"`
 }

--- a/internal/store/postgres/migrations/0052_token_usage_and_run_cost.down.sql
+++ b/internal/store/postgres/migrations/0052_token_usage_and_run_cost.down.sql
@@ -1,0 +1,6 @@
+-- 0052_token_usage_and_run_cost.down.sql — reverse RFC AV Phase 1 schema.
+DROP TABLE IF EXISTS token_usage;
+ALTER TABLE runs DROP COLUMN IF EXISTS cost;
+ALTER TABLE runs DROP COLUMN IF EXISTS cost_currency;
+ALTER TABLE runs DROP COLUMN IF EXISTS credential_source;
+ALTER TABLE runs DROP COLUMN IF EXISTS credential_scope_id;

--- a/internal/store/postgres/migrations/0052_token_usage_and_run_cost.up.sql
+++ b/internal/store/postgres/migrations/0052_token_usage_and_run_cost.up.sql
@@ -1,0 +1,49 @@
+-- 0052_token_usage_and_run_cost.up.sql — RFC AV: per-scope token-usage & cost
+-- attribution (operator vs tenant key).
+--
+-- token_usage is the append-only per-CALL ledger (one row per LLM call) beneath
+-- the per-run summary on runs. Its load-bearing column is credential_source
+-- (operator|tenant|user, + credential_scope_id): when a tenant runs on the
+-- operator's key the tokens are the operator's bill AND the tenant's
+-- consumption; when a tenant's own key (RFC AR override) pays, only the tenant's.
+-- The operator bill (source=operator) and each tenant's consumption/self-funded
+-- spend then fall out of the SAME rows — two queries over one flag, no
+-- double-entry. No secrets: token counts, provider/model, the owning scope id
+-- (already non-secret, like user_id) and the computed/provider-reported cost.
+--
+-- runs gains the per-run cost + credential-source SUMMARY: the durable record
+-- (the ledger is prunable). cost is NULL when unpriced (model absent from the
+-- pricing table), distinct from a genuine zero cost (mock / code-js).
+
+CREATE TABLE token_usage (
+    id                    BIGSERIAL   PRIMARY KEY,
+    run_id                TEXT        NOT NULL,
+    session_id            TEXT,
+    tenant_id             TEXT        NOT NULL DEFAULT '',
+    user_id               TEXT,
+    agent_id              TEXT,
+    parent_run_id         TEXT,
+    iteration             INTEGER     NOT NULL DEFAULT 0,
+    provider              TEXT        NOT NULL,
+    model                 TEXT        NOT NULL,
+    credential_source     TEXT        NOT NULL,
+    credential_scope_id   TEXT        NOT NULL DEFAULT '',
+    input_tokens          BIGINT      NOT NULL DEFAULT 0,
+    output_tokens         BIGINT      NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT      NOT NULL DEFAULT 0,
+    cache_read_tokens     BIGINT      NOT NULL DEFAULT 0,
+    -- DOUBLE PRECISION (not NUMERIC): cost is a derived, display-oriented
+    -- summary figure, so a clean float scan across both backends (sqlite REAL)
+    -- is worth more than arbitrary-precision decimal here. NULL ⇒ unpriced.
+    cost                  DOUBLE PRECISION,
+    cost_currency         TEXT,
+    ts                    TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX token_usage_by_run    ON token_usage (run_id);
+CREATE INDEX token_usage_tenant_ts ON token_usage (tenant_id, ts);
+CREATE INDEX token_usage_source_ts ON token_usage (credential_source, ts);
+
+ALTER TABLE runs ADD COLUMN cost                DOUBLE PRECISION;
+ALTER TABLE runs ADD COLUMN cost_currency       TEXT;
+ALTER TABLE runs ADD COLUMN credential_source   TEXT;
+ALTER TABLE runs ADD COLUMN credential_scope_id TEXT;

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -393,6 +393,11 @@ func (s *Store) AppendEvent(ctx context.Context, runID string, eventType string,
 // updated or not (matches SQLite adapter contract).
 func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunStatus, stopReason string, usage store.Usage, errMsg string) error {
 	completed := time.Now().UTC()
+	// RFC AV: cost is NULL when unpriced (empty currency), distinct from a zero.
+	var costArg interface{}
+	if usage.CostCurrency != "" {
+		costArg = usage.Cost
+	}
 	_, err := s.pool.Exec(ctx,
 		`UPDATE runs SET
 			status = $2,
@@ -404,18 +409,102 @@ func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunSta
 			cache_read_tokens = $8,
 			model = $9,
 			provider = $10,
-			error = $11
-		 WHERE id = $1 AND status = $12`,
+			error = $11,
+			cost = $12,
+			cost_currency = $13,
+			credential_source = $14,
+			credential_scope_id = $15
+		 WHERE id = $1 AND status = $16`,
 		runID, string(status), completed, nullableText(stopReason),
 		usage.InputTokens, usage.OutputTokens,
 		usage.CacheCreationTokens, usage.CacheReadTokens,
 		nullableText(usage.Model), nullableText(usage.Provider), nullableText(errMsg),
+		costArg, nullableText(usage.CostCurrency),
+		nullableText(usage.CredentialSource), nullableText(usage.CredentialScopeID),
 		string(store.RunRunning),
 	)
 	if err != nil {
 		return fmt.Errorf("finish run: %w", err)
 	}
 	return nil
+}
+
+// RecordCallUsage appends one per-call usage row (RFC AV). Append-only; cost is
+// NULL when unpriced (empty currency), distinct from a genuine zero.
+func (s *Store) RecordCallUsage(ctx context.Context, row store.TokenUsageRow) error {
+	ts := row.TS
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	}
+	var costArg interface{}
+	if row.CostCurrency != "" {
+		costArg = row.Cost
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO token_usage (
+			run_id, session_id, tenant_id, user_id, agent_id, parent_run_id,
+			iteration, provider, model, credential_source, credential_scope_id,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, ts
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+		row.RunID, nullableText(row.SessionID), row.TenantID, nullableText(row.UserID),
+		nullableText(row.AgentID), nullableText(row.ParentRunID),
+		row.Iteration, row.Provider, row.Model, row.CredentialSource, row.CredentialScopeID,
+		row.InputTokens, row.OutputTokens, row.CacheCreationTokens, row.CacheReadTokens,
+		costArg, nullableText(row.CostCurrency), ts,
+	)
+	if err != nil {
+		return fmt.Errorf("record call usage: %w", err)
+	}
+	return nil
+}
+
+// TokenUsageForRun returns all per-call usage rows for a run, oldest first.
+func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.TokenUsageRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT run_id, session_id, tenant_id, user_id, agent_id, parent_run_id,
+			iteration, provider, model, credential_source, credential_scope_id,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, ts
+		 FROM token_usage WHERE run_id = $1 ORDER BY iteration ASC, id ASC`, runID)
+	if err != nil {
+		return nil, fmt.Errorf("token usage for run: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TokenUsageRow
+	for rows.Next() {
+		var r store.TokenUsageRow
+		var sessionID, userID, agentID, parentRunID, costCurrency *string
+		var cost *float64
+		if err := rows.Scan(
+			&r.RunID, &sessionID, &r.TenantID, &userID, &agentID, &parentRunID,
+			&r.Iteration, &r.Provider, &r.Model, &r.CredentialSource, &r.CredentialScopeID,
+			&r.InputTokens, &r.OutputTokens, &r.CacheCreationTokens, &r.CacheReadTokens,
+			&cost, &costCurrency, &r.TS,
+		); err != nil {
+			return nil, fmt.Errorf("scan token usage: %w", err)
+		}
+		if sessionID != nil {
+			r.SessionID = *sessionID
+		}
+		if userID != nil {
+			r.UserID = *userID
+		}
+		if agentID != nil {
+			r.AgentID = *agentID
+		}
+		if parentRunID != nil {
+			r.ParentRunID = *parentRunID
+		}
+		if cost != nil {
+			r.Cost = *cost
+		}
+		if costCurrency != nil {
+			r.CostCurrency = *costCurrency
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // GetTranscript returns every event for the session, ordered by seq.
@@ -604,6 +693,7 @@ func (s *Store) GetRunByAgentID(ctx context.Context, agentID string) (store.Run,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.agent_id = $1 ORDER BY r.started_at DESC LIMIT 1`, agentID,
@@ -633,6 +723,7 @@ func (s *Store) RunByIdempotencyKey(ctx context.Context, key string) (store.Run,
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.idempotency_key = $1 LIMIT 1`, key,
@@ -658,6 +749,7 @@ func (s *Store) GetRun(ctx context.Context, runID string) (store.Run, error) {
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.id = $1`, runID,
@@ -730,6 +822,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1
@@ -741,6 +834,7 @@ func (s *Store) ListActiveRunsByUser(ctx context.Context, userID string, status 
 			        r.model, r.provider, r.error,
 			        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 			        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 			        s.agent
 			 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 			 WHERE r.user_id = $1 AND r.status = $2
@@ -766,6 +860,7 @@ func (s *Store) ListRunsByParentAgentID(ctx context.Context, parentAgentID strin
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.parent_agent_id = $1
@@ -867,6 +962,7 @@ func (s *Store) ListPausedRuns(ctx context.Context) ([]store.Run, error) {
 		        r.model, r.provider, r.error,
 		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
 		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
 		 WHERE r.pause_state = $1
@@ -5893,6 +5989,9 @@ func scanRun(r rowScanner) (store.Run, error) {
 		lastHeartbeatAt                                       *time.Time
 		sessAgent                                             *string
 
+		cost                                              *float64
+		costCurrency, credentialSource, credentialScopeID *string
+
 		interactive bool
 		statusStr   string
 	)
@@ -5904,6 +6003,7 @@ func scanRun(r rowScanner) (store.Run, error) {
 		&userTier,
 		&agentDefID, &pauseState, &replicaID, &parentContext, &idempotencyKey, &tenantID,
 		&interactive,
+		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -5966,6 +6066,18 @@ func scanRun(r rowScanner) (store.Run, error) {
 		out.TenantID = *tenantID
 	}
 	out.Interactive = interactive
+	if cost != nil {
+		out.Cost = cost
+	}
+	if costCurrency != nil {
+		out.CostCurrency = *costCurrency
+	}
+	if credentialSource != nil {
+		out.CredentialSource = *credentialSource
+	}
+	if credentialScopeID != nil {
+		out.CredentialScopeID = *credentialScopeID
+	}
 	if sessAgent != nil {
 		out.Agent = *sessAgent
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -122,6 +122,35 @@ func (s *Store) migrate(ctx context.Context) error {
 			error                    TEXT
 		)`,
 		`CREATE INDEX IF NOT EXISTS runs_by_session ON runs(session_id)`,
+		// RFC AV — per-call token-usage + cost ledger (one row per LLM call).
+		// Append-only; the runs row carries the per-run summary. No secrets:
+		// token counts, provider/model, the owning credential scope id (already
+		// non-secret, like user_id), and the computed/reported cost. cost REAL
+		// nullable ⇒ unpriced (unknown model) distinct from a zero cost.
+		`CREATE TABLE IF NOT EXISTS token_usage (
+			id                    INTEGER PRIMARY KEY AUTOINCREMENT,
+			run_id                TEXT NOT NULL,
+			session_id            TEXT,
+			tenant_id             TEXT NOT NULL DEFAULT '',
+			user_id               TEXT,
+			agent_id              TEXT,
+			parent_run_id         TEXT,
+			iteration             INTEGER NOT NULL DEFAULT 0,
+			provider              TEXT NOT NULL,
+			model                 TEXT NOT NULL,
+			credential_source     TEXT NOT NULL,
+			credential_scope_id   TEXT NOT NULL DEFAULT '',
+			input_tokens          INTEGER NOT NULL DEFAULT 0,
+			output_tokens         INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+			cost                  REAL,
+			cost_currency         TEXT,
+			ts                    INTEGER NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS token_usage_by_run ON token_usage(run_id)`,
+		`CREATE INDEX IF NOT EXISTS token_usage_tenant_ts ON token_usage(tenant_id, ts)`,
+		`CREATE INDEX IF NOT EXISTS token_usage_source_ts ON token_usage(credential_source, ts)`,
 		`CREATE TABLE IF NOT EXISTS events (
 			seq        INTEGER PRIMARY KEY AUTOINCREMENT,
 			session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -852,6 +881,14 @@ func (s *Store) migrate(ctx context.Context) error {
 		// paused run can be re-dispatched with the correct park-vs-complete
 		// semantics. NULL/0 on legacy rows + batch runs; CreateRun stamps it.
 		`ALTER TABLE runs ADD COLUMN interactive INTEGER NOT NULL DEFAULT 0`,
+		// RFC AV — per-run cost + credential-source summary. cost REAL nullable
+		// (NULL ⇒ unpriced, distinct from a genuine zero); credential_source is
+		// "operator"|"tenant"|"user" for the run's primary key source. Idempotent
+		// on fresh deploys (declared in CREATE TABLE runs above once upgraded).
+		`ALTER TABLE runs ADD COLUMN cost REAL`,
+		`ALTER TABLE runs ADD COLUMN cost_currency TEXT`,
+		`ALTER TABLE runs ADD COLUMN credential_source TEXT`,
+		`ALTER TABLE runs ADD COLUMN credential_scope_id TEXT`,
 	}
 	for _, q := range addColumns {
 		if _, err := s.db.ExecContext(ctx, q); err != nil {
@@ -1160,6 +1197,12 @@ func (s *Store) AppendEvent(ctx context.Context, runID string, eventType string,
 // guard so a slow-to-finish goroutine can't overwrite a cancellation.)
 func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunStatus, stopReason string, usage store.Usage, errMsg string) error {
 	now := time.Now().UnixNano()
+	// RFC AV: cost is stored NULL when the run was not priced (empty currency),
+	// distinct from a genuine zero cost (which carries a currency).
+	var costArg interface{}
+	if usage.CostCurrency != "" {
+		costArg = usage.Cost
+	}
 	_, err := s.db.ExecContext(ctx,
 		`UPDATE runs SET
 			status                = ?,
@@ -1171,15 +1214,88 @@ func (s *Store) FinishRun(ctx context.Context, runID string, status store.RunSta
 			cache_read_tokens     = ?,
 			model                 = ?,
 			provider              = ?,
-			error                 = ?
+			error                 = ?,
+			cost                  = ?,
+			cost_currency         = ?,
+			credential_source     = ?,
+			credential_scope_id   = ?
 		WHERE id = ? AND status = ?`,
 		string(status), now, stopReason,
 		usage.InputTokens, usage.OutputTokens,
 		usage.CacheCreationTokens, usage.CacheReadTokens,
 		usage.Model, nilIfEmpty(usage.Provider), errMsg,
+		costArg, nilIfEmpty(usage.CostCurrency),
+		nilIfEmpty(usage.CredentialSource), nilIfEmpty(usage.CredentialScopeID),
 		runID, string(store.RunRunning),
 	)
 	return err
+}
+
+// RecordCallUsage appends one per-call usage row (RFC AV). Append-only insert;
+// cost is stored NULL when unpriced (empty currency), distinct from zero.
+func (s *Store) RecordCallUsage(ctx context.Context, row store.TokenUsageRow) error {
+	ts := row.TS
+	if ts.IsZero() {
+		ts = time.Now()
+	}
+	var costArg interface{}
+	if row.CostCurrency != "" {
+		costArg = row.Cost
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO token_usage (
+			run_id, session_id, tenant_id, user_id, agent_id, parent_run_id,
+			iteration, provider, model, credential_source, credential_scope_id,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, ts
+		) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)`,
+		row.RunID, nilIfEmpty(row.SessionID), row.TenantID, nilIfEmpty(row.UserID),
+		nilIfEmpty(row.AgentID), nilIfEmpty(row.ParentRunID),
+		row.Iteration, row.Provider, row.Model, row.CredentialSource, row.CredentialScopeID,
+		row.InputTokens, row.OutputTokens, row.CacheCreationTokens, row.CacheReadTokens,
+		costArg, nilIfEmpty(row.CostCurrency), ts.UnixNano(),
+	)
+	return err
+}
+
+// TokenUsageForRun returns all per-call usage rows for a run, oldest first.
+func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.TokenUsageRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT run_id, session_id, tenant_id, user_id, agent_id, parent_run_id,
+			iteration, provider, model, credential_source, credential_scope_id,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, ts
+		 FROM token_usage WHERE run_id = ? ORDER BY iteration ASC, id ASC`,
+		runID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.TokenUsageRow
+	for rows.Next() {
+		var r store.TokenUsageRow
+		var sessionID, userID, agentID, parentRunID, costCurrency sql.NullString
+		var cost sql.NullFloat64
+		var tsNano int64
+		if err := rows.Scan(
+			&r.RunID, &sessionID, &r.TenantID, &userID, &agentID, &parentRunID,
+			&r.Iteration, &r.Provider, &r.Model, &r.CredentialSource, &r.CredentialScopeID,
+			&r.InputTokens, &r.OutputTokens, &r.CacheCreationTokens, &r.CacheReadTokens,
+			&cost, &costCurrency, &tsNano,
+		); err != nil {
+			return nil, err
+		}
+		r.SessionID = sessionID.String
+		r.UserID = userID.String
+		r.AgentID = agentID.String
+		r.ParentRunID = parentRunID.String
+		r.Cost = cost.Float64
+		r.CostCurrency = costCurrency.String
+		r.TS = time.Unix(0, tsNano)
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // GetTranscript returns all events for a session, ordered by seq ascending.
@@ -1365,6 +1481,8 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 	var idempotencyKey sql.NullString
 	var tenantID sql.NullString
 	var interactive sql.NullInt64
+	var cost sql.NullFloat64
+	var costCurrency, credentialSource, credentialScopeID sql.NullString
 	var sessAgent sql.NullString
 	var status string
 	if err := scanner.Scan(
@@ -1376,6 +1494,7 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		&userTier,
 		&agentDefID, &pauseState, &parentContext, &idempotencyKey, &tenantID,
 		&interactive,
+		&cost, &costCurrency, &credentialSource, &credentialScopeID,
 		&sessAgent,
 	); err != nil {
 		return store.Run{}, err
@@ -1437,6 +1556,19 @@ func scanRun(scanner interface{ Scan(...any) error }) (store.Run, error) {
 		r.TenantID = tenantID.String
 	}
 	r.Interactive = interactive.Valid && interactive.Int64 != 0
+	if cost.Valid {
+		v := cost.Float64
+		r.Cost = &v
+	}
+	if costCurrency.Valid {
+		r.CostCurrency = costCurrency.String
+	}
+	if credentialSource.Valid {
+		r.CredentialSource = credentialSource.String
+	}
+	if credentialScopeID.Valid {
+		r.CredentialScopeID = credentialScopeID.String
+	}
 	if sessAgent.Valid {
 		r.Agent = sessAgent.String
 	}
@@ -1459,6 +1591,7 @@ const runColumns = `r.id, r.session_id, r.status, r.started_at, r.completed_at,
 		r.user_tier,
 		r.agent_def_id, r.pause_state, r.parent_context, r.idempotency_key, r.tenant_id,
 		r.interactive,
+		r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		s.agent`
 
 // runFromTable is the canonical FROM clause paired with runColumns.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -257,6 +257,16 @@ type Run struct {
 	// re-dispatched on another instance with the correct park-vs-complete
 	// semantics. false on legacy rows + batch runs.
 	Interactive bool `json:"interactive,omitempty"`
+
+	// --- RFC AV: per-run cost + credential-source summary. ---
+	// Cost is nil when the run was never priced (legacy rows, or an unknown
+	// model absent from the pricing table). CredentialSource is the primary key
+	// source ("operator"|"tenant"|"user"); the exact per-call split lives in
+	// token_usage. All optional/nullable for back-compat with pre-RFC-AV rows.
+	Cost              *float64 `json:"cost,omitempty"`
+	CostCurrency      string   `json:"cost_currency,omitempty"`
+	CredentialSource  string   `json:"credential_source,omitempty"`
+	CredentialScopeID string   `json:"credential_scope_id,omitempty"`
 }
 
 // PauseState constants — the wire string values stored in runs.pause_state.
@@ -313,6 +323,54 @@ type Usage struct {
 	// model-name conventions. Differs from agent yaml when v0.8.2
 	// fallback engaged.
 	Provider string
+
+	// --- RFC AV: per-run cost + credential-source summary ---
+	// Cost is the run's computed money cost; CostCurrency names its unit
+	// (e.g. "USD"). An empty CostCurrency ⇒ the run was not priced (unknown
+	// model in the pricing table) and Cost is persisted as NULL, distinct
+	// from a genuine zero cost (mock / code-js, which carry a currency).
+	Cost         float64
+	CostCurrency string
+	// CredentialSource is the run's primary key source: "operator" (host key)
+	// or "tenant"/"user" when an RFC AR override paid. CredentialScopeID is the
+	// override owner. Best-effort per-run summary; the exact per-call split
+	// lives in token_usage.
+	CredentialSource  string
+	CredentialScopeID string
+}
+
+// TokenUsageRow is one LLM call's usage + cost, the append-only per-call ledger
+// beneath the runs summary (RFC AV). One row is written per EventUsage. It holds
+// no secrets — token counts, provider/model, the owning credential scope id
+// (already non-secret, like user_id), and the computed/provider-reported cost.
+type TokenUsageRow struct {
+	RunID       string
+	SessionID   string
+	TenantID    string
+	UserID      string
+	AgentID     string
+	ParentRunID string
+	// Iteration is the 0-based call index within the run (ordering + dedup).
+	Iteration int
+
+	Provider string
+	Model    string
+	// CredentialSource is "operator" | "tenant" | "user"; CredentialScopeID is
+	// the override owner ("" for operator / tenant scope).
+	CredentialSource  string
+	CredentialScopeID string
+
+	InputTokens         int
+	OutputTokens        int
+	CacheCreationTokens int
+	CacheReadTokens     int
+
+	// Cost is the call's money cost; CostCurrency its unit. An empty currency
+	// ⇒ unpriced (unknown model) → Cost stored NULL, distinct from a zero cost.
+	Cost         float64
+	CostCurrency string
+
+	TS time.Time
 }
 
 // RunIdentity carries the v0.4 tracking fields a CreateRun caller can
@@ -507,6 +565,15 @@ type Store interface {
 	// stop reason (or error message, when status is "failed"). Idempotent:
 	// calling on an already-finished run is a no-op.
 	FinishRun(ctx context.Context, runID string, status RunStatus, stopReason string, usage Usage, errMsg string) error
+
+	// RecordCallUsage appends one per-call usage row (RFC AV). Append-only; the
+	// caller supplies a fully-formed row (identity + tokens + priced cost). It
+	// is the granular ledger beneath the FinishRun per-run summary.
+	RecordCallUsage(ctx context.Context, row TokenUsageRow) error
+
+	// TokenUsageForRun returns all per-call usage rows for a run, oldest first.
+	// Used by the rollup invariant test + (later) the archiver.
+	TokenUsageForRun(ctx context.Context, runID string) ([]TokenUsageRow, error)
 
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -335,6 +335,9 @@ func Run(t *testing.T, factory Factory) {
 		// fallback-routed runs.
 		{"FinishRunPersistsProvider", testFinishRunPersistsProvider},
 		{"FinishRunPersistsProviderEmpty", testFinishRunPersistsProviderEmpty},
+		// RFC AV — per-call usage ledger + per-run cost/source summary.
+		{"TokenUsageLedger", testTokenUsageLedger},
+		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -570,6 +573,106 @@ func testFinishRunPersistsProviderEmpty(t *testing.T, s store.Store) {
 	}
 	if got.Provider != "" {
 		t.Errorf("Provider = %q, want empty string", got.Provider)
+	}
+}
+
+// testTokenUsageLedger exercises the RFC AV per-call ledger: RecordCallUsage
+// inserts + TokenUsageForRun reads back, credential_source distinguishes
+// operator vs tenant, cost is NULL when unpriced (empty currency) vs a genuine
+// zero, and the per-run summary (Σ token_usage) matches the FinishRun rollup.
+func testTokenUsageLedger(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "tenant-x", "default", "")
+	run, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_usage_ledger", TenantID: "tenant-x", UserID: "u1"})
+
+	// Call 0: operator key paid, priced (USD). Call 1: a tenant override paid,
+	// left unpriced (unknown model) → NULL cost.
+	rows := []store.TokenUsageRow{
+		{RunID: run.ID, TenantID: "tenant-x", UserID: "u1", AgentID: "a_usage_ledger", Iteration: 0,
+			Provider: "anthropic", Model: "claude-opus-4-8", CredentialSource: "operator",
+			InputTokens: 100, OutputTokens: 50, Cost: 0.0564, CostCurrency: "USD"},
+		{RunID: run.ID, TenantID: "tenant-x", UserID: "u1", AgentID: "a_usage_ledger", Iteration: 1,
+			Provider: "deepseek", Model: "deepseek-v4-flash", CredentialSource: "tenant", CredentialScopeID: "tenant-x",
+			InputTokens: 200, OutputTokens: 80, Cost: 0, CostCurrency: ""}, // unpriced → NULL
+	}
+	for _, r := range rows {
+		if err := s.RecordCallUsage(ctx, r); err != nil {
+			t.Fatalf("RecordCallUsage: %v", err)
+		}
+	}
+
+	got, err := s.TokenUsageForRun(ctx, run.ID)
+	if err != nil {
+		t.Fatalf("TokenUsageForRun: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("rows = %d, want 2", len(got))
+	}
+	if got[0].CredentialSource != "operator" || got[1].CredentialSource != "tenant" {
+		t.Errorf("sources = %q,%q want operator,tenant", got[0].CredentialSource, got[1].CredentialSource)
+	}
+	if got[1].CredentialScopeID != "tenant-x" {
+		t.Errorf("scope_id = %q, want tenant-x", got[1].CredentialScopeID)
+	}
+	if got[0].CostCurrency != "USD" || got[0].Cost == 0 {
+		t.Errorf("row0 cost = (%v,%q), want (0.0564,USD)", got[0].Cost, got[0].CostCurrency)
+	}
+	// Unpriced row: empty currency round-trips (NULL cost); Cost stays 0.
+	if got[1].CostCurrency != "" || got[1].Cost != 0 {
+		t.Errorf("row1 (unpriced) = (%v,%q), want (0,\"\")", got[1].Cost, got[1].CostCurrency)
+	}
+
+	// Rollup invariant: the per-run summary the loop would write (Σ of the calls)
+	// must equal the sum of the ledger rows. Simulate FinishRun with those sums.
+	var inSum, outSum int
+	for _, r := range got {
+		inSum += r.InputTokens
+		outSum += r.OutputTokens
+	}
+	if err := s.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn",
+		store.Usage{InputTokens: inSum, OutputTokens: outSum, Model: "claude-opus-4-8", Provider: "anthropic"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	fin, _ := s.GetRunByAgentID(ctx, "a_usage_ledger")
+	if fin.InputTokens != inSum || fin.OutputTokens != outSum {
+		t.Errorf("rollup mismatch: runs=(%d,%d) Σledger=(%d,%d)", fin.InputTokens, fin.OutputTokens, inSum, outSum)
+	}
+}
+
+// testFinishRunPersistsCostAndSource verifies the per-run cost + credential
+// source summary round-trips, and that an UNPRICED run (empty currency) stores a
+// NULL cost (GetRun.Cost == nil), distinct from a priced zero.
+func testFinishRunPersistsCostAndSource(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+
+	// Priced + tenant-sourced run.
+	run1, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_cost_priced"})
+	if err := s.FinishRun(ctx, run1.ID, store.RunCompleted, "end_turn",
+		store.Usage{InputTokens: 10, Model: "m", Provider: "anthropic",
+			Cost: 1.25, CostCurrency: "USD", CredentialSource: "tenant", CredentialScopeID: "tenant-x"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	got1, _ := s.GetRunByAgentID(ctx, "a_cost_priced")
+	if got1.Cost == nil || *got1.Cost != 1.25 || got1.CostCurrency != "USD" {
+		t.Errorf("priced cost = %v %q, want 1.25 USD", got1.Cost, got1.CostCurrency)
+	}
+	if got1.CredentialSource != "tenant" || got1.CredentialScopeID != "tenant-x" {
+		t.Errorf("source = %q/%q, want tenant/tenant-x", got1.CredentialSource, got1.CredentialScopeID)
+	}
+
+	// Unpriced run (empty currency) → NULL cost.
+	run2, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "a_cost_unpriced"})
+	if err := s.FinishRun(ctx, run2.ID, store.RunCompleted, "end_turn",
+		store.Usage{InputTokens: 10, Model: "m", Provider: "openai", CredentialSource: "operator"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := s.GetRunByAgentID(ctx, "a_cost_unpriced")
+	if got2.Cost != nil {
+		t.Errorf("unpriced cost = %v, want nil (NULL)", *got2.Cost)
+	}
+	if got2.CredentialSource != "operator" {
+		t.Errorf("source = %q, want operator", got2.CredentialSource)
 	}
 }
 

--- a/internal/tools/builtin/websearch_credkey_test.go
+++ b/internal/tools/builtin/websearch_credkey_test.go
@@ -33,8 +33,8 @@ func TestWebSearch_BraveKeyOverride(t *testing.T) {
 	}
 
 	// (2) Tenant override → the tenant key is sent instead of the host key.
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-brave", name == "BRAVE_API_KEY"
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-brave"}, name == "BRAVE_API_KEY"
 	})
 	if res, err := ws.Execute(ctx, input); err != nil || res.IsError {
 		t.Fatalf("override call failed: err=%v res=%+v", err, res)
@@ -61,8 +61,8 @@ func TestWebSearch_TenantKeyEnablesWithNoHostKey(t *testing.T) {
 		t.Errorf("no host key + no override should refuse, got %+v", res)
 	}
 
-	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (string, bool) {
-		return "tenant-brave", name == "BRAVE_API_KEY"
+	ctx := providers.WithCredentialResolver(context.Background(), func(_ context.Context, name string) (providers.CredentialResolution, bool) {
+		return providers.CredentialResolution{Value: "tenant-brave"}, name == "BRAVE_API_KEY"
 	})
 	if res, err := ws.Execute(ctx, json.RawMessage(`{"query":"x"}`)); err != nil || res.IsError {
 		t.Fatalf("tenant key should enable the call: err=%v res=%+v", err, res)


### PR DESCRIPTION
## Why

PRs #630/#631/#632 let a tenant use **its own** provider key, but nothing recorded **whose key paid** — so a correct operator-vs-tenant cost report was impossible. This is the accounting foundation the operator asked for:

- an **operator-key** run → counts toward **both** the operator's provider bill **and** the tenant's consumption;
- a **tenant-key** run (RFC AR override) → counts toward the **tenant only**.

RFC AV, Phase 1 = **the records** (reports + retention = Phase 2, budgets = Phase 3). Design doc: `loomcycle-internal/doc-internal/rfcs/usage-cost-attribution.md` (design-locked, O1/O2 resolved).

## What

- **Schema** (both backends + migration `0052`): a per-**CALL** append-only **`token_usage`** ledger — `run/tenant/user/agent`, `provider/model`, **`credential_source`** (`operator｜tenant｜user`) + `credential_scope_id`, the 4 token buckets, `cost` — plus a per-run **cost + credential_source summary** on `runs`. Per-call granularity is exact even when a run **fails over provider mid-flight**. `cost` is `DOUBLE PRECISION`, `NULL` when unpriced (unknown model) — distinct from a genuine zero.
- **Propagation:** `providers.Usage` gains additive `CredentialSource` / `CredentialScopeID` / `ProviderReportedCost`. The credential resolver now carries the owning scope (`ResolveCredentialFull`); **each driver stamps the source onto the per-call Usage from the same resolve it already does for the key — no extra credential-store read** (anthropic/openai/gemini/ollama; deepseek via openai). The loop stamps the serving provider on the per-call event.
- **Server:** prices each call (**a provider-reported cost wins**, else the operator **`pricing:`** table — loomcycle owns pricing, O1) and writes one `token_usage` row per `EventUsage`; `FinishRun` writes the run's cost + credential_source summary. Usage telemetry **never fails a run** (store errors logged, not propagated).

`credential_source` semantics: `operator` = host key; `tenant`/`user` = an override paid at that scope. The **"count for both" rule is two queries over one flag** — no double-entry.

## Report math (Phase 2 will expose this; the data is captured now)

| Figure | Query |
|---|---|
| Operator's real provider spend | Σ where `credential_source='operator'` |
| Tenant consumption (all) | Σ where `tenant_id=X` |
| Tenant self-funded | Σ where `tenant_id=X AND credential_source IN ('tenant','user')` |

## Write path

The per-call insert is **synchronous**, alongside the existing per-event `AppendEvent` (same cost profile). Async buffering is a deliberate **Phase-2** optimization that should cover both writers together.

## Tested

`go test ./...` clean (exit 0), `gofmt` + `go vet` clean, binary builds.
- **pricing unit** — priced / unpriced / zero-priced / currency fallback / per-1M math.
- **store contract (both backends)** — `RecordCallUsage`↔`TokenUsageForRun` round-trip, operator-vs-tenant source, NULL-cost-when-unpriced, the rollup invariant, and the `FinishRun` cost/source summary round-trip.
- **driver credkey tests** updated to `resolveKey` (returns key **+ source**), incl. deepseek's `DEEPSEEK_API_KEY` isolation and ollama-local never-overrides.
- **E2E** through the real server + loop with a scripted provider: a tenant-key run and an operator-key run each produce a priced `token_usage` row **and** a matching per-run summary.

## Not in this PR (by design)

`GET /v1/_usage` + Web UI + the rollup-and-prune sweeper + the old-run archiver (Phase 2); budgets/limits (Phase 3). Async write buffering (Phase 2). `ProviderReportedCost` field exists but no native driver returns a cost today (O3) — gateways can populate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)