### PR TITLE
feat(usage): GET /v1/_usage — token-usage & cost report — Phase 2a (RFC AV)

### DIFF
--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -528,6 +528,12 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_events":
 		return auth.ScopeTenant
+	// RFC AV: the usage/cost report. token_usage rows carry tenant_id, so
+	// handleUsageReport tenant-scopes the aggregation (a tenant operator sees
+	// only its own tenant's spend; admin sees all + the ?tenant= focus).
+	// ScopeAdmin also satisfies. Read-only GET.
+	case path == "/v1/_usage":
+		return auth.ScopeTenant
 	// Routing view (GET /v1/_routing). Tenant-readable so a tenant operator's UI
 	// can see the resolved model cascade per tier; the HANDLER strips the live
 	// provider reachability / infra detail for a non-admin caller (admin gets the

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -2335,6 +2335,7 @@ func (s *Server) Mux() http.Handler {
 	// optional type + date-range filter. Drives the Web UI's
 	// /ui/audit page. Bearer-authed admin surface.
 	mux.Handle("GET /v1/_events", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListEvents))))
+	mux.Handle("GET /v1/_usage", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleUsageReport))))
 	// v0.8.22 substrate admin endpoints. Bearer-authed; accept the
 	// same op-discriminated JSON body as the in-process tool +
 	// dispatch through the Connector with operator-trust ctx.

--- a/internal/api/http/usage_report.go
+++ b/internal/api/http/usage_report.go
@@ -1,0 +1,106 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// usageReportResponse is the wire shape of GET /v1/_usage (RFC AV Phase 2).
+type usageReportResponse struct {
+	GroupBy []string               `json:"group_by"`
+	From    string                 `json:"from,omitempty"`
+	To      string                 `json:"to,omitempty"`
+	Rows    []store.UsageAggregate `json:"rows"`
+}
+
+// handleUsageReport serves GET /v1/_usage — aggregated token usage + cost from
+// the RFC AV ledger, for building spend reports.
+//
+// Query params (all optional):
+//
+//	group_by=tenant,source,provider,model,user   dimensions to group by
+//	                                              (default: tenant,source)
+//	from=RFC3339   ts >= from
+//	to=RFC3339     ts <= to
+//	tenant=acme    admin-only focus on one tenant (a tenant operator is always
+//	               scoped to its own tenant; the param is ignored/logged)
+//
+// Tenant scoping (RFC AS): admin/legacy/open see all tenants (honoring ?tenant=);
+// a substrate:tenant operator sees only its own tenant. The operator bill is
+// group_by=source filtered to credential_source=operator; a tenant's consumption
+// is the rows for its tenant; its self-funded spend is source in {tenant,user}.
+// Read-only; 503 when the server has no store.
+func (s *Server) handleUsageReport(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; usage reporting requires a persistent store")
+		return
+	}
+	q := r.URL.Query()
+
+	var query store.UsageQuery
+
+	// group_by → validated dimensions (default tenant,source: the operator-vs-
+	// tenant view). An unknown dimension is a 400, not silently dropped.
+	groupRaw := q.Get("group_by")
+	if strings.TrimSpace(groupRaw) == "" {
+		groupRaw = "tenant,source"
+	}
+	var groupNames []string
+	for _, part := range strings.Split(groupRaw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if _, ok := store.UsageDimColumn(store.UsageDimension(part)); !ok {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"unknown group_by dimension: "+part+" (allowed: tenant,user,provider,model,source)")
+			return
+		}
+		query.GroupBy = append(query.GroupBy, store.UsageDimension(part))
+		groupNames = append(groupNames, part)
+	}
+
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "bad_request", "from must be RFC3339: "+err.Error())
+			return
+		}
+		query.From = t
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeJSONError(w, http.StatusBadRequest, "bad_request", "to must be RFC3339: "+err.Error())
+			return
+		}
+		query.To = t
+	}
+
+	// Tenant-scope the report (RFC AS): a tenant operator is confined to its own
+	// tenant; admin sees all + an optional ?tenant= focus.
+	if tenantID, all := s.principalTenantScope(r.Context(), q.Get("tenant")); !all {
+		query.TenantID = tenantID
+	}
+
+	rows, err := s.store.UsageReport(r.Context(), query)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	resp := usageReportResponse{GroupBy: groupNames, Rows: rows}
+	if !query.From.IsZero() {
+		resp.From = query.From.Format(time.RFC3339)
+	}
+	if !query.To.IsZero() {
+		resp.To = query.To.Format(time.RFC3339)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/api/http/usage_report_test.go
+++ b/internal/api/http/usage_report_test.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/concurrency"
+	"github.com/denn-gubsky/loomcycle/internal/config"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
+)
+
+// GET /v1/_usage aggregates the ledger and validates group_by. Open mode = admin
+// (sees all tenants); the tenant-confinement path is the shared
+// principalTenantScope, covered by the events-audit tests.
+func TestUsageReport_Endpoint(t *testing.T) {
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "usagerep.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	ctx := context.Background()
+	seed := []store.TokenUsageRow{
+		{RunID: "r1", TenantID: "acme", Provider: "anthropic", Model: "m", CredentialSource: "operator", InputTokens: 100, Cost: 1.0, CostCurrency: "USD"},
+		{RunID: "r2", TenantID: "acme", Provider: "anthropic", Model: "m", CredentialSource: "tenant", InputTokens: 200, Cost: 2.0, CostCurrency: "USD"},
+		{RunID: "r3", TenantID: "globex", Provider: "openai", Model: "m", CredentialSource: "operator", InputTokens: 400, Cost: 4.0, CostCurrency: "USD"},
+	}
+	for _, r := range seed {
+		if err := st.RecordCallUsage(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 2, MaxQueueDepth: 2, QueueTimeoutMS: 500}}
+	cfg.Env.AuthToken = "" // open mode → admin, sees all tenants
+	srv := New(cfg, &stubResolver{p: &scriptedProvider{}}, []tools.Tool{}, concurrency.New(2, 2, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Group by tenant,source over all tenants.
+	var got usageReportResponse
+	resp, err := http.Get(ts.URL + "/v1/_usage?group_by=tenant,source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, b)
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+
+	if len(got.Rows) != 3 {
+		t.Fatalf("rows = %d, want 3: %+v", len(got.Rows), got.Rows)
+	}
+	// Operator bill across tenants = 1.0 (acme) + 4.0 (globex) = 5.0.
+	var opCost, acmeCost float64
+	for _, a := range got.Rows {
+		if a.CredentialSource == "operator" {
+			opCost += a.Cost
+		}
+		if a.TenantID == "acme" {
+			acmeCost += a.Cost
+		}
+	}
+	if opCost != 5.0 {
+		t.Errorf("operator bill = %v, want 5.0", opCost)
+	}
+	if acmeCost != 3.0 {
+		t.Errorf("acme consumption = %v, want 3.0", acmeCost)
+	}
+
+	// An unknown group_by dimension is a 400 (whitelist guard).
+	bad, err := http.Get(ts.URL + "/v1/_usage?group_by=tenant,bogus")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer bad.Body.Close()
+	if bad.StatusCode != 400 {
+		t.Errorf("bad group_by status = %d, want 400", bad.StatusCode)
+	}
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -507,6 +507,75 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
+// UsageReport aggregates token_usage for a report (RFC AV Phase 2). Mirrors the
+// sqlite implementation: the five dimension columns SELECTed in
+// UsageCanonicalDims order (column when grouped, else literal ”), a fixed
+// 13-column result. ts is TIMESTAMPTZ here, so window bounds pass as time.Time.
+func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
+	grouped := map[store.UsageDimension]bool{}
+	for _, d := range q.GroupBy {
+		if _, ok := store.UsageDimColumn(d); ok {
+			grouped[d] = true
+		}
+	}
+	var dimExprs, groupCols []string
+	for _, d := range store.UsageCanonicalDims {
+		col, _ := store.UsageDimColumn(d)
+		if grouped[d] {
+			dimExprs = append(dimExprs, col)
+			groupCols = append(groupCols, col)
+		} else {
+			dimExprs = append(dimExprs, "''")
+		}
+	}
+	query := `SELECT ` + strings.Join(dimExprs, ", ") + `,
+		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
+		COALESCE(SUM(cost),0), COUNT(*),
+		COALESCE(SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END),0),
+		COALESCE(MAX(cost_currency),'')
+		FROM token_usage`
+	var conds []string
+	var args []any
+	n := 0
+	ph := func(v any) string { n++; args = append(args, v); return fmt.Sprintf("$%d", n) }
+	if q.TenantID != "" {
+		conds = append(conds, "tenant_id = "+ph(q.TenantID))
+	}
+	if !q.From.IsZero() {
+		conds = append(conds, "ts >= "+ph(q.From))
+	}
+	if !q.To.IsZero() {
+		conds = append(conds, "ts <= "+ph(q.To))
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	if len(groupCols) > 0 {
+		query += " GROUP BY " + strings.Join(groupCols, ", ")
+	}
+	query += " ORDER BY COALESCE(SUM(cost),0) DESC"
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("usage report: %w", err)
+	}
+	defer rows.Close()
+	var out []store.UsageAggregate
+	for rows.Next() {
+		var a store.UsageAggregate
+		if err := rows.Scan(
+			&a.TenantID, &a.UserID, &a.Provider, &a.Model, &a.CredentialSource,
+			&a.InputTokens, &a.OutputTokens, &a.CacheCreationTokens, &a.CacheReadTokens,
+			&a.Cost, &a.CallCount, &a.UnpricedCalls, &a.Currency,
+		); err != nil {
+			return nil, fmt.Errorf("scan usage aggregate: %w", err)
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
 // GetTranscript returns every event for the session, ordered by seq.
 // Empty slice (not error) when the session has no events yet.
 func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Event, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1298,6 +1298,76 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
+// UsageReport aggregates token_usage for a report (RFC AV Phase 2). The five
+// dimension columns are SELECTed in UsageCanonicalDims order — the column when
+// grouped, else the literal ” — so the result is a fixed 13-column shape. ts is
+// stored as unix-nano here, so the window bounds are compared as nanos.
+func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
+	grouped := map[store.UsageDimension]bool{}
+	for _, d := range q.GroupBy {
+		if _, ok := store.UsageDimColumn(d); ok {
+			grouped[d] = true
+		}
+	}
+	var dimExprs, groupCols []string
+	for _, d := range store.UsageCanonicalDims {
+		col, _ := store.UsageDimColumn(d)
+		if grouped[d] {
+			dimExprs = append(dimExprs, col)
+			groupCols = append(groupCols, col)
+		} else {
+			dimExprs = append(dimExprs, "''")
+		}
+	}
+	query := `SELECT ` + strings.Join(dimExprs, ", ") + `,
+		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
+		COALESCE(SUM(cost),0), COUNT(*),
+		COALESCE(SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END),0),
+		COALESCE(MAX(cost_currency),'')
+		FROM token_usage`
+	var conds []string
+	var args []any
+	if q.TenantID != "" {
+		conds = append(conds, "tenant_id = ?")
+		args = append(args, q.TenantID)
+	}
+	if !q.From.IsZero() {
+		conds = append(conds, "ts >= ?")
+		args = append(args, q.From.UnixNano())
+	}
+	if !q.To.IsZero() {
+		conds = append(conds, "ts <= ?")
+		args = append(args, q.To.UnixNano())
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	if len(groupCols) > 0 {
+		query += " GROUP BY " + strings.Join(groupCols, ", ")
+	}
+	query += " ORDER BY COALESCE(SUM(cost),0) DESC"
+
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.UsageAggregate
+	for rows.Next() {
+		var a store.UsageAggregate
+		if err := rows.Scan(
+			&a.TenantID, &a.UserID, &a.Provider, &a.Model, &a.CredentialSource,
+			&a.InputTokens, &a.OutputTokens, &a.CacheCreationTokens, &a.CacheReadTokens,
+			&a.Cost, &a.CallCount, &a.UnpricedCalls, &a.Currency,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
 // GetTranscript returns all events for a session, ordered by seq ascending.
 func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Event, error) {
 	if _, err := s.GetSession(ctx, sessionID); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -373,6 +373,82 @@ type TokenUsageRow struct {
 	TS time.Time
 }
 
+// UsageDimension is a whitelisted grouping axis for a usage report (RFC AV
+// Phase 2). The string value maps to a token_usage column; the whitelist is the
+// injection guard — a caller-supplied group_by is validated against these.
+type UsageDimension string
+
+const (
+	UsageByTenant   UsageDimension = "tenant"
+	UsageByUser     UsageDimension = "user"
+	UsageByProvider UsageDimension = "provider"
+	UsageByModel    UsageDimension = "model"
+	UsageBySource   UsageDimension = "source" // credential_source (operator|tenant|user)
+)
+
+// UsageQuery filters + groups a usage report.
+type UsageQuery struct {
+	// TenantID scopes to one tenant; "" = all tenants (admin only — the handler
+	// enforces this via principalTenantScope).
+	TenantID string
+	// From/To bound the window on ts (inclusive); zero = unbounded on that end.
+	From, To time.Time
+	// GroupBy is the ordered set of dimensions to group by (validated against the
+	// UsageBy* whitelist). Empty ⇒ a single grand-total row.
+	GroupBy []UsageDimension
+}
+
+// UsageAggregate is one grouped row of a usage report. Only the dimensions named
+// in the query's GroupBy are populated; the rest are "".
+type UsageAggregate struct {
+	TenantID         string `json:"tenant_id,omitempty"`
+	UserID           string `json:"user_id,omitempty"`
+	Provider         string `json:"provider,omitempty"`
+	Model            string `json:"model,omitempty"`
+	CredentialSource string `json:"credential_source,omitempty"`
+
+	InputTokens         int64 `json:"input_tokens"`
+	OutputTokens        int64 `json:"output_tokens"`
+	CacheCreationTokens int64 `json:"cache_creation_tokens"`
+	CacheReadTokens     int64 `json:"cache_read_tokens"`
+
+	// Cost is the summed money cost of the PRICED calls in the group; Currency is
+	// a representative unit (mixed currencies are not summed meaningfully — a v1
+	// caveat; single-currency deployments are the common case). UnpricedCalls
+	// counts calls with no cost (model absent from the pricing table) so a report
+	// can surface a "pricing incomplete" signal instead of silently undercounting.
+	Cost          float64 `json:"cost"`
+	Currency      string  `json:"currency,omitempty"`
+	CallCount     int64   `json:"call_count"`
+	UnpricedCalls int64   `json:"unpriced_calls"`
+}
+
+// UsageCanonicalDims is the fixed order the report's 5 dimension columns are
+// SELECTed + scanned in, shared by both backends so the scan target order can't
+// drift from the query. A grouped dimension SELECTs its column; an ungrouped one
+// SELECTs ” — keeping the result a fixed 13-column shape regardless of group_by.
+var UsageCanonicalDims = []UsageDimension{UsageByTenant, UsageByUser, UsageByProvider, UsageByModel, UsageBySource}
+
+// UsageDimColumn maps a whitelisted dimension to its token_usage column name.
+// The whitelist IS the SQL-injection guard — only these five map to a column, so
+// a caller-supplied group_by can never inject arbitrary SQL. ok=false rejects an
+// unknown dimension.
+func UsageDimColumn(d UsageDimension) (col string, ok bool) {
+	switch d {
+	case UsageByTenant:
+		return "tenant_id", true
+	case UsageByUser:
+		return "user_id", true
+	case UsageByProvider:
+		return "provider", true
+	case UsageByModel:
+		return "model", true
+	case UsageBySource:
+		return "credential_source", true
+	}
+	return "", false
+}
+
 // RunIdentity carries the v0.4 tracking fields a CreateRun caller can
 // supply. Zero-value fields mean "no value" — implementations must
 // store them as NULL (or empty string for TEXT columns) so historical
@@ -574,6 +650,12 @@ type Store interface {
 	// TokenUsageForRun returns all per-call usage rows for a run, oldest first.
 	// Used by the rollup invariant test + (later) the archiver.
 	TokenUsageForRun(ctx context.Context, runID string) ([]TokenUsageRow, error)
+
+	// UsageReport aggregates the token_usage ledger for a report (RFC AV Phase 2):
+	// summed tokens + cost grouped by the requested dimensions, over an optional
+	// tenant + time window. The operator bill (source=operator) and per-tenant
+	// consumption fall out of the group-by + a source dimension.
+	UsageReport(ctx context.Context, q UsageQuery) ([]UsageAggregate, error)
 
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -338,6 +338,7 @@ func Run(t *testing.T, factory Factory) {
 		// RFC AV — per-call usage ledger + per-run cost/source summary.
 		{"TokenUsageLedger", testTokenUsageLedger},
 		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
+		{"UsageReport", testUsageReport},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -673,6 +674,78 @@ func testFinishRunPersistsCostAndSource(t *testing.T, s store.Store) {
 	}
 	if got2.CredentialSource != "operator" {
 		t.Errorf("source = %q, want operator", got2.CredentialSource)
+	}
+}
+
+// testUsageReport exercises the RFC AV Phase 2 aggregation: grouping,
+// tenant/window scoping, the operator-vs-tenant split, and the unpriced-call
+// count. Rows are inserted directly (no run needed — token_usage has no FK).
+func testUsageReport(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	mk := func(tenant, source string, in int, cost float64, cur string) store.TokenUsageRow {
+		return store.TokenUsageRow{
+			RunID: "r_" + tenant + source, TenantID: tenant, Provider: "anthropic", Model: "m",
+			CredentialSource: source, InputTokens: in, Cost: cost, CostCurrency: cur,
+		}
+	}
+	rows := []store.TokenUsageRow{
+		mk("A", "operator", 100, 1.0, "USD"),
+		mk("A", "tenant", 200, 2.0, "USD"),
+		mk("B", "operator", 400, 4.0, "USD"),
+		// tenant A, operator, UNPRICED (empty currency) — counts tokens, no cost.
+		{RunID: "r_unpriced", TenantID: "A", Provider: "openai", Model: "x",
+			CredentialSource: "operator", InputTokens: 50, CostCurrency: ""},
+	}
+	for _, r := range rows {
+		if err := s.RecordCallUsage(ctx, r); err != nil {
+			t.Fatalf("RecordCallUsage: %v", err)
+		}
+	}
+
+	sum := func(aggs []store.UsageAggregate, tenant, source string) (in int64, cost float64, unpriced int64, found bool) {
+		for _, a := range aggs {
+			if a.TenantID == tenant && a.CredentialSource == source {
+				return a.InputTokens, a.Cost, a.UnpricedCalls, true
+			}
+		}
+		return 0, 0, 0, false
+	}
+
+	// Group by (tenant, source), all tenants.
+	all, err := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
+	if err != nil {
+		t.Fatalf("UsageReport: %v", err)
+	}
+	// A/operator merges the priced + unpriced rows: 150 tokens, cost 1.0, 1 unpriced.
+	if in, cost, unpriced, ok := sum(all, "A", "operator"); !ok || in != 150 || cost != 1.0 || unpriced != 1 {
+		t.Errorf("A/operator = (in=%d cost=%v unpriced=%d ok=%v), want (150,1,1,true)", in, cost, unpriced, ok)
+	}
+	if in, cost, _, ok := sum(all, "A", "tenant"); !ok || in != 200 || cost != 2.0 {
+		t.Errorf("A/tenant = (%d,%v,%v), want (200,2,true)", in, cost, ok)
+	}
+	if in, cost, _, ok := sum(all, "B", "operator"); !ok || in != 400 || cost != 4.0 {
+		t.Errorf("B/operator = (%d,%v,%v), want (400,4,true)", in, cost, ok)
+	}
+
+	// Tenant-scoped to A → no B rows.
+	onlyA, _ := s.UsageReport(ctx, store.UsageQuery{TenantID: "A", GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
+	for _, a := range onlyA {
+		if a.TenantID == "B" {
+			t.Errorf("tenant-scoped report leaked tenant B: %+v", a)
+		}
+	}
+
+	// Operator bill = group by source, filter source=operator across all tenants:
+	// cost 1.0 (A) + 4.0 (B) = 5.0.
+	bySource, _ := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageBySource}})
+	var opCost float64
+	for _, a := range bySource {
+		if a.CredentialSource == "operator" {
+			opCost = a.Cost
+		}
+	}
+	if opCost != 5.0 {
+		t.Errorf("operator bill = %v, want 5.0", opCost)
 	}
 }
 


### PR DESCRIPTION
## Why

Phase 1 (#633) records **which key paid** for every call. This is the **reporting surface** over that ledger — the "audit + report token usage / money spent" deliverable. The operator-vs-tenant split you specified falls out of the grouping:

- **operator bill** = rows where `credential_source = operator`
- **tenant consumption** = a tenant's rows (any source)
- **tenant self-funded** = its rows where `source ∈ {tenant, user}`

## What

- **`store.UsageReport(UsageQuery) → []UsageAggregate`** — grouped `SUM` over `token_usage`: per-bucket tokens, summed cost, call count, and an **unpriced-call count** so a report can surface "pricing incomplete" instead of silently undercounting. `group_by` is a **whitelist** (`UsageDimColumn`) — the SQL-injection guard; the five dimension columns SELECT in a fixed canonical order (grouped→column, else `''`) so the scan can't drift from the query. Both backends (sqlite compares the `ts` window as unix-nano; postgres as `TIMESTAMPTZ`).
- **`GET /v1/_usage?group_by=&from=&to=&tenant=`** — `handleUsageReport`. **Tenant-scoped** via `principalTenantScope` (RFC AS): admin/legacy/open see all + a `?tenant=` focus; a `substrate:tenant` operator is confined to its own tenant. Gate case → `ScopeTenant` (mirrors `/v1/_events`). An unknown `group_by` dimension → **400**. Default grouping `tenant,source` (the operator-vs-tenant view).

Example: `GET /v1/_usage?group_by=tenant,source,model&from=2026-07-01T00:00:00Z` →
```jsonc
{ "group_by": ["tenant","source","model"], "from": "...", "rows": [
  { "tenant_id": "acme", "credential_source": "operator", "model": "claude-opus-4-8",
    "input_tokens": 12000, "output_tokens": 4000, "cost": 0.48, "currency": "USD",
    "call_count": 30, "unpriced_calls": 0 }, ... ] }
```

## Tested

`go test ./...` clean, gofmt + vet clean, binary builds.
- **store contract (both backends):** grouping, the operator-vs-tenant split (operator bill = 5.0 across two tenants), tenant scoping (no cross-tenant leak), and the unpriced-call count merged into a group.
- **endpoint (httptest + sqlite):** all-tenants aggregation, operator bill + per-tenant consumption sums, and a **400** on an unknown `group_by` dimension.

## Not in this PR (by design)

- **Phase 2b:** retention — `usage_archive` + the rollup-and-prune sweeper + the old-run archiver + the `usage:` config; the report will then union recent `token_usage` ∪ `usage_archive`.
- **Phase 2c:** the Web UI Usage page + gRPC/TS adapter parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)