### PR TITLE
feat(usage): retention — rollup-and-prune sweeper + usage_archive — Phase 2b (RFC AV)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -78,6 +78,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	storepostgres "github.com/denn-gubsky/loomcycle/internal/store/postgres"
 	storesqlite "github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/usage"
 
 	googlegrpc "google.golang.org/grpc"
 
@@ -2073,6 +2074,30 @@ func main() {
 		go sweeper.Run(bgCtx)
 	} else {
 		log.Printf("heartbeat: sweeper disabled (LOOMCYCLE_HEARTBEAT_SWEEPER=0 or no Store)")
+	}
+
+	// Usage rollup-and-prune sweeper (RFC AV Phase 2b) — same placement
+	// rationale as the heartbeat sweeper above: runs AFTER the cluster
+	// block so it can pick up the advisoryLock. In single-replica mode
+	// advisoryLock stays nil and the sweeper's lock-gating branch is
+	// bypassed. Pruning is a compaction to daily usage_archive buckets,
+	// not data loss — billing totals are preserved.
+	if cfg.Env.UsageSweeperEnabled && storeIface != nil {
+		uCfg := usage.Config{
+			Interval:        cfg.Env.UsageSweepInterval,
+			DetailRetention: cfg.Env.UsageDetailRetention,
+		}
+		// Same typed-nil guard as the heartbeat block: only assign the
+		// interface field from a non-nil pointer, or the sweeper's
+		// nil-check would see a non-nil interface wrapping a nil pointer.
+		if advisoryLock != nil {
+			uCfg.AdvisoryLock = advisoryLock
+			uCfg.AdvisoryLockKey = coord.LockKeyUsageSweeper
+		}
+		usageSweeper := usage.New(storeIface, uCfg)
+		go usageSweeper.Run(bgCtx)
+	} else {
+		log.Printf("usage: sweeper disabled (LOOMCYCLE_USAGE_SWEEPER=0 or no Store)")
 	}
 
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2087,6 +2087,23 @@ type Env struct {
 	// expected per-iteration time so live runs in long tool calls
 	// aren't sweeped. Env: LOOMCYCLE_HEARTBEAT_STALE_MS.
 	HeartbeatStaleAfter time.Duration
+
+	// UsageSweeperEnabled controls the RFC AV Phase 2b usage
+	// rollup-and-prune sweeper. When true (default), a goroutine
+	// periodically folds token_usage rows older than
+	// UsageDetailRetention into the day-bucketed usage_archive and
+	// deletes them — bounding the per-call detail table without losing
+	// billing totals (the archive preserves exact per-dimension sums).
+	// Disable with LOOMCYCLE_USAGE_SWEEPER=0 (e.g. when an external job
+	// owns retention in a multi-replica deployment).
+	UsageSweeperEnabled bool
+	// UsageSweepInterval is the sweep tick rate. Default 1h.
+	// Env: LOOMCYCLE_USAGE_SWEEP_INTERVAL_MS.
+	UsageSweepInterval time.Duration
+	// UsageDetailRetention is the cutoff: token_usage rows older than
+	// this are rolled up into usage_archive and pruned. Default 720h
+	// (30 days). Env: LOOMCYCLE_USAGE_DETAIL_RETENTION_MS.
+	UsageDetailRetention time.Duration
 	// ReplicasSweepInterval is the dead-replica reaper's tick rate.
 	// Default 60s. Tunable mostly for tests / crash-recovery load
 	// experiments — leave at default in production.
@@ -2798,6 +2815,7 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 		// env var below was set. The fallbacks are applied in
 		// cmd/loomcycle/main.go where the goroutines are started.
 		HeartbeatSweeperEnabled: true,
+		UsageSweeperEnabled:     true,
 	}
 
 	// RFC AH Phase 3 — the legacy filesystem jail is retired. The three env
@@ -2961,6 +2979,19 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 	if v := os.Getenv("LOOMCYCLE_HEARTBEAT_STALE_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.HeartbeatStaleAfter = time.Duration(n) * time.Millisecond
+		}
+	}
+	// Usage rollup-and-prune sweeper (RFC AV Phase 2b). Optional; the
+	// New() constructor applies the 1h/720h fallbacks when these stay 0.
+	cfg.Env.UsageSweeperEnabled = os.Getenv("LOOMCYCLE_USAGE_SWEEPER") != "0"
+	if v := os.Getenv("LOOMCYCLE_USAGE_SWEEP_INTERVAL_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.UsageSweepInterval = time.Duration(n) * time.Millisecond
+		}
+	}
+	if v := os.Getenv("LOOMCYCLE_USAGE_DETAIL_RETENTION_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.UsageDetailRetention = time.Duration(n) * time.Millisecond
 		}
 	}
 	if v := os.Getenv("LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS"); v != "" {

--- a/internal/coord/advisory_lock.go
+++ b/internal/coord/advisory_lock.go
@@ -125,6 +125,10 @@ var (
 	// sweep of ephemeral volumes whose owning run is terminal (not paused), so
 	// only one replica per tick runs the fenced os.RemoveAll.
 	LockKeyEphemeralVolumeSweeper int64
+	// LockKeyUsageSweeper gates the RFC AV Phase 2b token-usage
+	// rollup-and-prune, so only one replica per tick folds old
+	// token_usage rows into usage_archive and deletes them.
+	LockKeyUsageSweeper int64
 )
 
 func init() {
@@ -137,6 +141,7 @@ func init() {
 	LockKeyReplicasSweeper = fnvKey("replicas_sweeper")
 	LockKeyResumePausedRuns = fnvKey("resume_paused_runs")
 	LockKeyEphemeralVolumeSweeper = fnvKey("ephemeral_volume_sweeper")
+	LockKeyUsageSweeper = fnvKey("usage_sweeper")
 }
 
 // fnvKey hashes a sweeper-name string to a stable int64 lock key.

--- a/internal/coord/advisory_lock_test.go
+++ b/internal/coord/advisory_lock_test.go
@@ -26,8 +26,9 @@ func TestFnvKey_Stable(t *testing.T) {
 		"metrics_sweeper":       fnvKey("metrics_sweeper"),
 		"dynamic_agent_sweeper": fnvKey("dynamic_agent_sweeper"),
 		"replicas_sweeper":      fnvKey("replicas_sweeper"),
+		"usage_sweeper":         fnvKey("usage_sweeper"),
 	}
-	// All seven must be distinct.
+	// All eight must be distinct.
 	seen := map[int64]string{}
 	for name, key := range cases {
 		if other, dup := seen[key]; dup {

--- a/internal/store/postgres/migrations/0053_usage_archive.down.sql
+++ b/internal/store/postgres/migrations/0053_usage_archive.down.sql
@@ -1,0 +1,2 @@
+-- 0053_usage_archive.down.sql — reverse RFC AV Phase 2b archive.
+DROP TABLE IF EXISTS usage_archive;

--- a/internal/store/postgres/migrations/0053_usage_archive.up.sql
+++ b/internal/store/postgres/migrations/0053_usage_archive.up.sql
@@ -1,0 +1,32 @@
+-- 0053_usage_archive.up.sql — RFC AV Phase 2b: the compact usage rollup.
+--
+-- The per-call token_usage ledger (0052) is high-volume — one row per LLM call.
+-- The rollup-and-prune sweeper periodically folds rows older than the detail
+-- retention window into this table (one row per period × the full report
+-- dimension set) and deletes the raw rows, so token_usage stays bounded while
+-- the exact per-(tenant,user,provider,model,source) totals — including the
+-- operator-vs-tenant split — are preserved forever at low cardinality.
+--
+-- period_start is the bucket start (day-truncated ts). The PK is the full
+-- dimension tuple so a re-run of the sweeper for the same window folds
+-- idempotently (ON CONFLICT adds). user_id is stored '' (not NULL) so it is
+-- part of a stable PK. Reports UNION this with the recent token_usage rows.
+
+CREATE TABLE usage_archive (
+    period_start          TIMESTAMPTZ      NOT NULL,
+    tenant_id             TEXT             NOT NULL DEFAULT '',
+    user_id               TEXT             NOT NULL DEFAULT '',
+    provider              TEXT             NOT NULL,
+    model                 TEXT             NOT NULL,
+    credential_source     TEXT             NOT NULL,
+    input_tokens          BIGINT           NOT NULL DEFAULT 0,
+    output_tokens         BIGINT           NOT NULL DEFAULT 0,
+    cache_creation_tokens BIGINT           NOT NULL DEFAULT 0,
+    cache_read_tokens     BIGINT           NOT NULL DEFAULT 0,
+    cost                  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    cost_currency         TEXT             NOT NULL DEFAULT '',
+    call_count            BIGINT           NOT NULL DEFAULT 0,
+    unpriced_calls        BIGINT           NOT NULL DEFAULT 0,
+    PRIMARY KEY (period_start, tenant_id, user_id, provider, model, credential_source)
+);
+CREATE INDEX usage_archive_tenant_period ON usage_archive (tenant_id, period_start);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -507,10 +507,11 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
-// UsageReport aggregates token_usage for a report (RFC AV Phase 2). Mirrors the
-// sqlite implementation: the five dimension columns SELECTed in
-// UsageCanonicalDims order (column when grouped, else literal ”), a fixed
-// 13-column result. ts is TIMESTAMPTZ here, so window bounds pass as time.Time.
+// UsageReport aggregates recent per-call token_usage UNION the compact
+// usage_archive rollup (RFC AV Phase 2b), so a pruned window still reports.
+// Mirrors the sqlite implementation: five dimension columns in
+// UsageCanonicalDims order (column when grouped, else ”), a fixed 13-column
+// result. ts / period_start are TIMESTAMPTZ, so window bounds pass as time.Time.
 func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
 	grouped := map[store.UsageDimension]bool{}
 	for _, d := range q.GroupBy {
@@ -528,29 +529,47 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 			dimExprs = append(dimExprs, "''")
 		}
 	}
-	query := `SELECT ` + strings.Join(dimExprs, ", ") + `,
-		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
-		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
-		COALESCE(SUM(cost),0), COUNT(*),
-		COALESCE(SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END),0),
-		COALESCE(MAX(cost_currency),'')
-		FROM token_usage`
-	var conds []string
 	var args []any
 	n := 0
 	ph := func(v any) string { n++; args = append(args, v); return fmt.Sprintf("$%d", n) }
-	if q.TenantID != "" {
-		conds = append(conds, "tenant_id = "+ph(q.TenantID))
+	// Build a per-source WHERE (tenant + window). Called token_usage first so the
+	// placeholder order in args matches the SQL text order.
+	where := func(tsCol string) string {
+		var conds []string
+		if q.TenantID != "" {
+			conds = append(conds, "tenant_id = "+ph(q.TenantID))
+		}
+		if !q.From.IsZero() {
+			conds = append(conds, tsCol+" >= "+ph(q.From))
+		}
+		if !q.To.IsZero() {
+			conds = append(conds, tsCol+" <= "+ph(q.To))
+		}
+		if len(conds) == 0 {
+			return ""
+		}
+		return " WHERE " + strings.Join(conds, " AND ")
 	}
-	if !q.From.IsZero() {
-		conds = append(conds, "ts >= "+ph(q.From))
-	}
-	if !q.To.IsZero() {
-		conds = append(conds, "ts <= "+ph(q.To))
-	}
-	if len(conds) > 0 {
-		query += " WHERE " + strings.Join(conds, " AND ")
-	}
+	tuWhere := where("ts")
+	uaWhere := where("period_start")
+
+	inner := `SELECT tenant_id, COALESCE(user_id,'') AS user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			COALESCE(cost,0) AS cost, COALESCE(cost_currency,'') AS cost_currency,
+			1 AS call_count, CASE WHEN cost IS NULL THEN 1 ELSE 0 END AS unpriced_calls
+		FROM token_usage` + tuWhere + `
+		UNION ALL
+		SELECT tenant_id, user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, call_count, unpriced_calls
+		FROM usage_archive` + uaWhere
+
+	query := `SELECT ` + strings.Join(dimExprs, ", ") + `,
+		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
+		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
+		COALESCE(SUM(cost),0), COALESCE(SUM(call_count),0), COALESCE(SUM(unpriced_calls),0),
+		COALESCE(MAX(cost_currency),'')
+		FROM (` + inner + `) u`
 	if len(groupCols) > 0 {
 		query += " GROUP BY " + strings.Join(groupCols, ", ")
 	}
@@ -574,6 +593,51 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		out = append(out, a)
 	}
 	return out, rows.Err()
+}
+
+// RollupAndPruneUsage folds token_usage rows older than olderThan into
+// usage_archive (day-bucketed via date_trunc) and deletes them, in one
+// transaction (RFC AV Phase 2b). Idempotent via the archive PK. Returns the raw
+// rows pruned.
+func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (int, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("begin rollup tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO usage_archive (period_start, tenant_id, user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, call_count, unpriced_calls)
+		SELECT date_trunc('day', ts) AS period_start, tenant_id, COALESCE(user_id,''), provider, model, credential_source,
+			SUM(input_tokens), SUM(output_tokens), SUM(cache_creation_tokens), SUM(cache_read_tokens),
+			SUM(COALESCE(cost,0)), COALESCE(MAX(cost_currency),''),
+			COUNT(*), SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END)
+		FROM token_usage WHERE ts < $1
+		GROUP BY date_trunc('day', ts), tenant_id, COALESCE(user_id,''), provider, model, credential_source
+		ON CONFLICT (period_start, tenant_id, user_id, provider, model, credential_source) DO UPDATE SET
+			input_tokens          = usage_archive.input_tokens + excluded.input_tokens,
+			output_tokens         = usage_archive.output_tokens + excluded.output_tokens,
+			cache_creation_tokens = usage_archive.cache_creation_tokens + excluded.cache_creation_tokens,
+			cache_read_tokens     = usage_archive.cache_read_tokens + excluded.cache_read_tokens,
+			cost                  = usage_archive.cost + excluded.cost,
+			cost_currency         = CASE WHEN usage_archive.cost_currency = '' THEN excluded.cost_currency ELSE usage_archive.cost_currency END,
+			call_count            = usage_archive.call_count + excluded.call_count,
+			unpriced_calls        = usage_archive.unpriced_calls + excluded.unpriced_calls`,
+		olderThan,
+	); err != nil {
+		return 0, fmt.Errorf("rollup usage: %w", err)
+	}
+	res, err := tx.Exec(ctx, `DELETE FROM token_usage WHERE ts < $1`, olderThan)
+	if err != nil {
+		return 0, fmt.Errorf("prune usage: %w", err)
+	}
+	pruned := int(res.RowsAffected())
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("commit rollup tx: %w", err)
+	}
+	return pruned, nil
 }
 
 // GetTranscript returns every event for the session, ordered by seq.

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -151,6 +151,29 @@ func (s *Store) migrate(ctx context.Context) error {
 		`CREATE INDEX IF NOT EXISTS token_usage_by_run ON token_usage(run_id)`,
 		`CREATE INDEX IF NOT EXISTS token_usage_tenant_ts ON token_usage(tenant_id, ts)`,
 		`CREATE INDEX IF NOT EXISTS token_usage_source_ts ON token_usage(credential_source, ts)`,
+		// RFC AV Phase 2b — the compact usage rollup. The sweeper folds
+		// token_usage rows older than the detail-retention window into one row per
+		// (period × dimension tuple) then deletes the raw rows. period_start is the
+		// day-truncated ts (unix-nano). PK = the full dimension tuple so a re-run
+		// folds idempotently. Reports UNION this with recent token_usage.
+		`CREATE TABLE IF NOT EXISTS usage_archive (
+			period_start          INTEGER NOT NULL,
+			tenant_id             TEXT NOT NULL DEFAULT '',
+			user_id               TEXT NOT NULL DEFAULT '',
+			provider              TEXT NOT NULL,
+			model                 TEXT NOT NULL,
+			credential_source     TEXT NOT NULL,
+			input_tokens          INTEGER NOT NULL DEFAULT 0,
+			output_tokens         INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
+			cost                  REAL NOT NULL DEFAULT 0,
+			cost_currency         TEXT NOT NULL DEFAULT '',
+			call_count            INTEGER NOT NULL DEFAULT 0,
+			unpriced_calls        INTEGER NOT NULL DEFAULT 0,
+			PRIMARY KEY (period_start, tenant_id, user_id, provider, model, credential_source)
+		)`,
+		`CREATE INDEX IF NOT EXISTS usage_archive_tenant_period ON usage_archive(tenant_id, period_start)`,
 		`CREATE TABLE IF NOT EXISTS events (
 			seq        INTEGER PRIMARY KEY AUTOINCREMENT,
 			session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -1298,10 +1321,15 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
-// UsageReport aggregates token_usage for a report (RFC AV Phase 2). The five
-// dimension columns are SELECTed in UsageCanonicalDims order — the column when
-// grouped, else the literal ” — so the result is a fixed 13-column shape. ts is
-// stored as unix-nano here, so the window bounds are compared as nanos.
+// nanosPerDay is the day bucket for the usage rollup's period_start (ts is
+// stored as unix-nano in sqlite).
+const nanosPerDay = int64(86400) * int64(1e9)
+
+// UsageReport aggregates recent per-call token_usage UNION the compact
+// usage_archive rollup (RFC AV Phase 2b), so a window that has been pruned to
+// the archive still reports. The five dimension columns are SELECTed in
+// UsageCanonicalDims order — the column when grouped, else ” — a fixed
+// 13-column shape. ts / period_start are unix-nano, so window bounds are nanos.
 func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
 	grouped := map[store.UsageDimension]bool{}
 	for _, d := range q.GroupBy {
@@ -1319,35 +1347,54 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 			dimExprs = append(dimExprs, "''")
 		}
 	}
+	// Per-source WHERE (tenant + window). token_usage windows on ts; usage_archive
+	// on period_start. Args are appended in placeholder order (token_usage first).
+	where := func(tsCol string) (string, []any) {
+		var conds []string
+		var args []any
+		if q.TenantID != "" {
+			conds = append(conds, "tenant_id = ?")
+			args = append(args, q.TenantID)
+		}
+		if !q.From.IsZero() {
+			conds = append(conds, tsCol+" >= ?")
+			args = append(args, q.From.UnixNano())
+		}
+		if !q.To.IsZero() {
+			conds = append(conds, tsCol+" <= ?")
+			args = append(args, q.To.UnixNano())
+		}
+		if len(conds) == 0 {
+			return "", nil
+		}
+		return " WHERE " + strings.Join(conds, " AND "), args
+	}
+	tuWhere, tuArgs := where("ts")
+	uaWhere, uaArgs := where("period_start")
+
+	inner := `SELECT tenant_id, COALESCE(user_id,'') AS user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			COALESCE(cost,0) AS cost, COALESCE(cost_currency,'') AS cost_currency,
+			1 AS call_count, CASE WHEN cost IS NULL THEN 1 ELSE 0 END AS unpriced_calls
+		FROM token_usage` + tuWhere + `
+		UNION ALL
+		SELECT tenant_id, user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, call_count, unpriced_calls
+		FROM usage_archive` + uaWhere
+
 	query := `SELECT ` + strings.Join(dimExprs, ", ") + `,
 		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
 		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
-		COALESCE(SUM(cost),0), COUNT(*),
-		COALESCE(SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(cost),0), COALESCE(SUM(call_count),0), COALESCE(SUM(unpriced_calls),0),
 		COALESCE(MAX(cost_currency),'')
-		FROM token_usage`
-	var conds []string
-	var args []any
-	if q.TenantID != "" {
-		conds = append(conds, "tenant_id = ?")
-		args = append(args, q.TenantID)
-	}
-	if !q.From.IsZero() {
-		conds = append(conds, "ts >= ?")
-		args = append(args, q.From.UnixNano())
-	}
-	if !q.To.IsZero() {
-		conds = append(conds, "ts <= ?")
-		args = append(args, q.To.UnixNano())
-	}
-	if len(conds) > 0 {
-		query += " WHERE " + strings.Join(conds, " AND ")
-	}
+		FROM (` + inner + `)`
 	if len(groupCols) > 0 {
 		query += " GROUP BY " + strings.Join(groupCols, ", ")
 	}
 	query += " ORDER BY COALESCE(SUM(cost),0) DESC"
 
+	args := append(append([]any{}, tuArgs...), uaArgs...)
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -1366,6 +1413,51 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		out = append(out, a)
 	}
 	return out, rows.Err()
+}
+
+// RollupAndPruneUsage folds token_usage rows older than olderThan into
+// usage_archive (day-bucketed) and deletes them, in one transaction (RFC AV
+// Phase 2b). Idempotent via the archive PK. Returns the raw rows pruned.
+func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (int, error) {
+	cutoff := olderThan.UnixNano()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO usage_archive (period_start, tenant_id, user_id, provider, model, credential_source,
+			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+			cost, cost_currency, call_count, unpriced_calls)
+		SELECT (ts/?)*? AS period_start, tenant_id, COALESCE(user_id,''), provider, model, credential_source,
+			SUM(input_tokens), SUM(output_tokens), SUM(cache_creation_tokens), SUM(cache_read_tokens),
+			SUM(COALESCE(cost,0)), COALESCE(MAX(cost_currency),''),
+			COUNT(*), SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END)
+		FROM token_usage WHERE ts < ?
+		GROUP BY period_start, tenant_id, COALESCE(user_id,''), provider, model, credential_source
+		ON CONFLICT(period_start, tenant_id, user_id, provider, model, credential_source) DO UPDATE SET
+			input_tokens          = input_tokens + excluded.input_tokens,
+			output_tokens         = output_tokens + excluded.output_tokens,
+			cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+			cache_read_tokens     = cache_read_tokens + excluded.cache_read_tokens,
+			cost                  = cost + excluded.cost,
+			cost_currency         = CASE WHEN usage_archive.cost_currency = '' THEN excluded.cost_currency ELSE usage_archive.cost_currency END,
+			call_count            = call_count + excluded.call_count,
+			unpriced_calls        = unpriced_calls + excluded.unpriced_calls`,
+		nanosPerDay, nanosPerDay, cutoff,
+	); err != nil {
+		return 0, err
+	}
+	res, err := tx.ExecContext(ctx, `DELETE FROM token_usage WHERE ts < ?`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return int(n), nil
 }
 
 // GetTranscript returns all events for a session, ordered by seq ascending.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -654,8 +654,17 @@ type Store interface {
 	// UsageReport aggregates the token_usage ledger for a report (RFC AV Phase 2):
 	// summed tokens + cost grouped by the requested dimensions, over an optional
 	// tenant + time window. The operator bill (source=operator) and per-tenant
-	// consumption fall out of the group-by + a source dimension.
+	// consumption fall out of the group-by + a source dimension. Reads recent
+	// per-call rows UNION the compact usage_archive rollup, so old (pruned)
+	// windows still report.
 	UsageReport(ctx context.Context, q UsageQuery) ([]UsageAggregate, error)
+
+	// RollupAndPruneUsage folds every token_usage row older than olderThan into
+	// usage_archive (day-bucketed, summed per dimension tuple) and deletes the
+	// rolled-up raw rows, in one transaction. Idempotent — re-running a window
+	// folds via the archive PK (ON CONFLICT adds). Returns the count of raw rows
+	// pruned. The rollup-and-prune sweeper calls this on a timer (RFC AV Phase 2b).
+	RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (pruned int, err error)
 
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -339,6 +339,7 @@ func Run(t *testing.T, factory Factory) {
 		{"TokenUsageLedger", testTokenUsageLedger},
 		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
 		{"UsageReport", testUsageReport},
+		{"UsageRollupAndPrune", testUsageRollupAndPrune},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -746,6 +747,60 @@ func testUsageReport(t *testing.T, s store.Store) {
 	}
 	if opCost != 5.0 {
 		t.Errorf("operator bill = %v, want 5.0", opCost)
+	}
+}
+
+// testUsageRollupAndPrune exercises RFC AV Phase 2b retention: old token_usage
+// rows fold into usage_archive (same day+dims merge) and are deleted, the report
+// unions archive + recent, and a re-run is a no-op (idempotent).
+func testUsageRollupAndPrune(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	old := time.Now().Add(-10 * 24 * time.Hour)
+	recent := time.Now()
+	mk := func(in int, cost float64, ts time.Time) store.TokenUsageRow {
+		return store.TokenUsageRow{
+			RunID: "r", TenantID: "A", Provider: "anthropic", Model: "m",
+			CredentialSource: "operator", InputTokens: in, Cost: cost, CostCurrency: "USD", TS: ts,
+		}
+	}
+	// Two OLD rows (same day + dims → merge in archive) + one RECENT row.
+	for _, r := range []store.TokenUsageRow{mk(100, 1.0, old), mk(200, 2.0, old), mk(50, 0.5, recent)} {
+		if err := s.RecordCallUsage(ctx, r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cutoff := time.Now().Add(-5 * 24 * time.Hour)
+	pruned, err := s.RollupAndPruneUsage(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("RollupAndPruneUsage: %v", err)
+	}
+	if pruned != 2 {
+		t.Errorf("pruned = %d, want 2 (the two old rows)", pruned)
+	}
+	// Recent detail survives; old detail is gone.
+	if rows, _ := s.TokenUsageForRun(ctx, "r"); len(rows) != 1 || rows[0].InputTokens != 50 {
+		t.Errorf("token_usage after prune = %+v, want the single recent row", rows)
+	}
+	// Report unions archive (300 tok / 3.0 cost, 2 calls) + recent (50 / 0.5, 1):
+	// 350 tokens, 3.5 cost, 3 calls.
+	rep, _ := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
+	if len(rep) != 1 {
+		t.Fatalf("report rows = %d, want 1: %+v", len(rep), rep)
+	}
+	a := rep[0]
+	if a.InputTokens != 350 || a.Cost != 3.5 || a.CallCount != 3 {
+		t.Errorf("unioned report = (in=%d cost=%v calls=%d), want (350,3.5,3)", a.InputTokens, a.Cost, a.CallCount)
+	}
+
+	// Idempotent: a second prune of the same window moves nothing (old rows gone).
+	if pruned2, _ := s.RollupAndPruneUsage(ctx, cutoff); pruned2 != 0 {
+		t.Errorf("second prune = %d, want 0 (idempotent)", pruned2)
+	}
+	// And the archive didn't double-count.
+	rep2, _ := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
+	if len(rep2) != 1 || rep2[0].InputTokens != 350 {
+		t.Errorf("report after idempotent re-run = %+v, want unchanged 350", rep2)
 	}
 }
 

--- a/internal/usage/sweeper.go
+++ b/internal/usage/sweeper.go
@@ -1,0 +1,205 @@
+// Package usage runs the periodic token-usage rollup-and-prune sweeper
+// alongside the HTTP server (RFC AV Phase 2b). Without it, the
+// token_usage detail table grows unbounded — one row per LLM call,
+// forever — even though anything past the detail-retention window is
+// only ever read in aggregate.
+//
+// The sweeper is store-agnostic — it calls store.RollupAndPruneUsage on
+// a timer and logs the count. The Store adapter owns the atomic
+// "fold old detail rows into usage_archive (day-bucketed) then delete
+// them" transaction. Pruning is a compaction to daily buckets, NOT data
+// loss: the archive preserves the exact per-dimension totals
+// (tenant/user/provider/model/credential-source), so UsageReport still
+// returns the same numbers — it just reads them from the archive union
+// instead of scanning individual call rows.
+package usage
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Config carries the sweeper's tuning knobs. Zero/missing values fall
+// back to defaults documented per-field.
+type Config struct {
+	// Interval is how often the sweeper wakes up to roll up + prune.
+	// Default 1h. The work is cheap and idempotent, so the exact cadence
+	// isn't load-bearing — hourly keeps the detail table from drifting
+	// far past the retention window between ticks.
+	Interval time.Duration
+
+	// DetailRetention is the cutoff: token_usage rows older than this are
+	// folded into usage_archive and deleted. Default 720h (30 days).
+	// Recent detail is kept verbatim so per-call debugging / attribution
+	// stays possible within the window; older activity survives only as
+	// day-bucketed archive aggregates.
+	DetailRetention time.Duration
+
+	// Logger is the structured logger used for sweep results. Defaults
+	// to log.Printf when nil. Errors are logged at every tick;
+	// successful sweeps with zero rows are logged only periodically
+	// (the runtime is fine; chattering would just be noise).
+	Logger func(format string, args ...any)
+
+	// AdvisoryLock is the singleton-sweeper gate. When set, each tick
+	// acquires the lock before calling sweepOnce — only one replica per
+	// cluster runs the prune per tick. Nil = single-replica mode (every
+	// replica sweeps; the SQL is idempotent so concurrent sweeps stay
+	// correct, just noisy).
+	//
+	// Interface-typed (not *coord.AdvisoryLock concretely) so this
+	// package stays free of an internal/coord import. The interface
+	// declares only the surface the sweeper needs.
+	AdvisoryLock AdvisoryLocker
+
+	// AdvisoryLockKey is the lock-key int64 (typically coord.LockKeyUsageSweeper).
+	// Only consulted when AdvisoryLock is non-nil.
+	AdvisoryLockKey int64
+
+	// Now is the clock sweepOnce reads to compute the retention cutoff
+	// (cutoff = Now() - DetailRetention). Nil defaults to time.Now.
+	// Injectable so tests can pin the cutoff deterministically instead of
+	// racing real wall-clock elapsed time against DetailRetention.
+	Now func() time.Time
+}
+
+// AdvisoryLocker is the minimum surface the sweeper needs from
+// internal/coord.AdvisoryLock. Defined here so internal/usage stays
+// free of the internal/coord import. *coord.AdvisoryLock satisfies it
+// implicitly.
+type AdvisoryLocker interface {
+	TryRun(ctx context.Context, lockKey int64, fn func(ctx context.Context) error) (bool, error)
+}
+
+const (
+	defaultInterval        = 1 * time.Hour
+	defaultDetailRetention = 720 * time.Hour // 30 days
+)
+
+// Sweeper periodically folds old token_usage rows into usage_archive and
+// deletes them. Construct via New, then call Run(ctx) on a goroutine
+// that owns the lifecycle.
+type Sweeper struct {
+	store           store.Store
+	interval        time.Duration
+	detailRetention time.Duration
+	logf            func(format string, args ...any)
+	lock            AdvisoryLocker
+	lockKey         int64
+	now             func() time.Time
+}
+
+// New constructs a Sweeper with the supplied tuning. A nil store means
+// "no persistence" (the Server can run without a Store) — Run is then a
+// no-op.
+func New(st store.Store, cfg Config) *Sweeper {
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultInterval
+	}
+	if cfg.DetailRetention <= 0 {
+		cfg.DetailRetention = defaultDetailRetention
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.Printf
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return &Sweeper{
+		store:           st,
+		interval:        cfg.Interval,
+		detailRetention: cfg.DetailRetention,
+		logf:            cfg.Logger,
+		lock:            cfg.AdvisoryLock,
+		lockKey:         cfg.AdvisoryLockKey,
+		now:             cfg.Now,
+	}
+}
+
+// Run drives the sweep loop until ctx is done. Each tick calls
+// RollupAndPruneUsage with cutoff = now - DetailRetention. The first
+// tick fires after Interval (not immediately) so a fresh process doesn't
+// prune the moment it boots.
+//
+// This function blocks. Caller is expected to start it on a goroutine.
+func (s *Sweeper) Run(ctx context.Context) {
+	if s.store == nil {
+		return
+	}
+	s.logf("usage: sweeper starting (interval=%s, detail_retention=%s)", s.interval, s.detailRetention)
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+
+	// Track consecutive zero-row sweeps so the no-op log line is emitted
+	// on the first sweep, then suppressed until either a non-zero sweep
+	// or every Nth tick (roughly daily at the default 1h interval —
+	// enough to confirm the goroutine is alive without flooding the log).
+	const noOpHeartbeatEvery = 24
+	noOpStreak := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.logf("usage: sweeper stopping (ctx done)")
+			return
+		case <-t.C:
+			// When an AdvisoryLock is wired (cluster mode), gate the
+			// sweep behind the lock so only one replica per tick actually
+			// runs the prune. Single-replica path (lock == nil) sweeps
+			// unconditionally.
+			var (
+				n   int
+				err error
+			)
+			if s.lock != nil {
+				acquired, lockErr := s.lock.TryRun(ctx, s.lockKey, func(ctx context.Context) error {
+					// Capture into outer n + err directly. We deliberately
+					// return nil from fn so TryRun's err signals ONLY
+					// infra failures (pool acquire, pg_try_advisory_lock
+					// failure), keeping the sweep-failed log line below
+					// distinct from the advisory-lock-failed log line.
+					n, err = s.sweepOnce(ctx)
+					return nil
+				})
+				if lockErr != nil {
+					s.logf("usage: advisory lock infra error: %v", lockErr)
+					continue
+				}
+				if !acquired {
+					// Another replica is running this tick — silent.
+					continue
+				}
+			} else {
+				n, err = s.sweepOnce(ctx)
+			}
+			if err != nil {
+				s.logf("usage: sweep failed: %v", err)
+				continue
+			}
+			if n > 0 {
+				s.logf("usage: rolled up + pruned %d detail row(s)", n)
+				noOpStreak = 0
+				continue
+			}
+			if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
+				s.logf("usage: sweep tick — 0 detail rows to prune (streak=%d)", noOpStreak)
+			}
+			noOpStreak++
+		}
+	}
+}
+
+// sweepOnce runs one rollup-and-prune. Exposed as a method (vs inlined
+// in Run) so tests can drive ticks deterministically without a real
+// Ticker. ctx is the parent's; the RollupAndPruneUsage call gets a
+// derived 30s timeout so a hung backend can't stall the goroutine
+// indefinitely.
+func (s *Sweeper) sweepOnce(parent context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(parent, 30*time.Second)
+	defer cancel()
+	cutoff := s.now().Add(-s.detailRetention)
+	return s.store.RollupAndPruneUsage(ctx, cutoff)
+}

--- a/internal/usage/sweeper_test.go
+++ b/internal/usage/sweeper_test.go
@@ -1,0 +1,139 @@
+package usage
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+)
+
+// newTestStore opens a fresh sqlite store for the sweeper tests. Sweeper
+// logic is store-agnostic; using sqlite keeps the tests fast and doesn't
+// require a Postgres fixture. (The rollup-and-prune SQL itself is
+// exercised against both backends by the store contract suite.)
+func newTestStore(t *testing.T) *sqlite.Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.db")
+	s, err := sqlite.Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+// TestSweeperOnce_PrunesOldDetail exercises sweepOnce against a real
+// store without spinning the Run loop. Two token_usage rows older than
+// the retention window are folded + deleted; a recent row is left in the
+// detail table. The clock is pinned via Config.Now so the cutoff lands
+// deterministically between the old and recent rows — no dependence on
+// wall-clock elapsed time.
+func TestSweeperOnce_PrunesOldDetail(t *testing.T) {
+	st := newTestStore(t)
+	ctx := context.Background()
+
+	// Pinned "now"; cutoff = now - retention window.
+	now := time.Now()
+	const retention = 24 * time.Hour
+
+	mk := func(runID string, in int, ts time.Time) store.TokenUsageRow {
+		return store.TokenUsageRow{
+			RunID: runID, TenantID: "A", Provider: "anthropic", Model: "m",
+			CredentialSource: "operator", InputTokens: in, Cost: 1.0, CostCurrency: "USD", TS: ts,
+		}
+	}
+	// Two OLD rows (well past the window) + one RECENT row (inside it).
+	seed := []store.TokenUsageRow{
+		mk("old", 100, now.Add(-48*time.Hour)),
+		mk("old", 200, now.Add(-48*time.Hour)),
+		mk("recent", 50, now.Add(-1*time.Hour)),
+	}
+	for _, r := range seed {
+		if err := st.RecordCallUsage(ctx, r); err != nil {
+			t.Fatalf("RecordCallUsage: %v", err)
+		}
+	}
+
+	sw := New(st, Config{
+		Interval:        1 * time.Hour, // unused — we drive sweepOnce directly
+		DetailRetention: retention,
+		Logger:          func(format string, args ...any) {}, // silence
+		Now:             func() time.Time { return now },     // cutoff == now-24h
+	})
+
+	n, err := sw.sweepOnce(ctx)
+	if err != nil {
+		t.Fatalf("sweepOnce: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("sweepOnce pruned %d, want 2 (the two old rows)", n)
+	}
+
+	// The recent detail row survives; the old detail is gone.
+	if rows, _ := st.TokenUsageForRun(ctx, "recent"); len(rows) != 1 {
+		t.Errorf("recent run detail = %d rows, want 1 (should be spared)", len(rows))
+	}
+	if rows, _ := st.TokenUsageForRun(ctx, "old"); len(rows) != 0 {
+		t.Errorf("old run detail = %d rows, want 0 (should be pruned)", len(rows))
+	}
+
+	// Idempotent: a second sweep with the same clock prunes nothing.
+	if n2, err := sw.sweepOnce(ctx); err != nil || n2 != 0 {
+		t.Errorf("second sweepOnce = (%d, %v), want (0, nil) — should be idempotent", n2, err)
+	}
+}
+
+// TestSweeperRun_StopsOnContextDone asserts the goroutine exits cleanly
+// when its context is cancelled, so shutdown doesn't leak the sweeper
+// goroutine past the Store's close.
+func TestSweeperRun_StopsOnContextDone(t *testing.T) {
+	st := newTestStore(t)
+	sw := New(st, Config{
+		Interval:        10 * time.Millisecond,
+		DetailRetention: 1 * time.Hour,
+		Logger:          func(format string, args ...any) {},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		sw.Run(ctx)
+		close(done)
+	}()
+
+	// Let the sweeper run a few ticks, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// goroutine exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("sweeper did not exit within 2s of ctx cancellation")
+	}
+}
+
+// TestSweeperRun_NilStoreNoOp asserts Run returns immediately when the
+// Store is nil — relevant for callers that construct the Sweeper
+// unconditionally and let nil flow through.
+func TestSweeperRun_NilStoreNoOp(t *testing.T) {
+	sw := New(nil, Config{
+		Interval:        1 * time.Millisecond,
+		DetailRetention: 1 * time.Millisecond,
+		Logger:          func(format string, args ...any) {},
+	})
+	done := make(chan struct{})
+	go func() {
+		sw.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+		// returned immediately
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Run with nil store should be a no-op; instead it blocked")
+	}
+}


### PR DESCRIPTION
## Why

The per-call `token_usage` ledger (Phase 1) is high-volume — one row per LLM call. Phase 2b bounds it **without losing billing fidelity**: a periodic sweeper folds rows older than the detail-retention window into a compact `usage_archive` rollup (one row per **day × the full report dimension tuple**, including `credential_source`) and deletes the raw rows. This is **compaction to daily buckets, not data loss** — the operator-vs-tenant split stays exact forever at low cardinality.

## What

- **`usage_archive`** (migration `0053` + sqlite migrate): PK `(period_start, tenant, user, provider, model, credential_source)` so a sweeper re-run folds **idempotently** (`ON CONFLICT` accumulates).
- **`store.RollupAndPruneUsage(olderThan)`** — one transaction: `INSERT..SELECT` day-bucketed (sqlite `ts/nanosPerDay`; postgres `date_trunc('day', ts)`) into `usage_archive` with `ON CONFLICT` accumulate, then `DELETE` the rolled rows. Returns the pruned count. Both backends.
- **`store.UsageReport`** now aggregates **recent `token_usage` UNION `usage_archive`** over the window — token_usage rows count as 1 call each; archive rows carry their pre-summed `call_count`/`unpriced_calls`. A pruned window still reports fully.
- **`internal/usage.Sweeper`** mirrors the heartbeat sweeper: interval loop (first tick after `Interval`), **singleton via the coord advisory lock** in cluster mode (`LockKeyUsageSweeper`), `sweepOnce` derives `cutoff = now - DetailRetention`.
- **Env knobs:** `LOOMCYCLE_USAGE_SWEEPER` (default **on**), `LOOMCYCLE_USAGE_SWEEP_INTERVAL_MS` (default **1h**), `LOOMCYCLE_USAGE_DETAIL_RETENTION_MS` (default **720h / 30d**). Wired in `main.go` after the heartbeat block.

## Tested

`go test ./...` clean, gofmt + vet clean, binary builds.
- **store contract (both backends):** old rows fold into the archive (same day+dims merge), raw rows pruned, the report **UNIONs** archive + recent (350 tok / 3.5 cost / 3 calls), and a **second prune is a no-op** (idempotent — no double-count).
- **usage sweeper unit test (sqlite):** cutoff derivation + pruned-count propagation, ctx-done stop, nil-store no-op.

## Not in this PR (by design)

- **2b2:** the **old-run archiver** (prune / export aged *completed* runs + their events) — a broader, higher-risk change to the runs/events lifecycle, isolated to its own PR.
- **2c:** the Web UI Usage page + gRPC/TS adapter parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)