### PR TITLE
feat(webui): Usage page — token/cost report console — Phase 2c (RFC AV)

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -2294,3 +2294,49 @@ export interface RoutingResponse {
 export function getRouting(): Promise<RoutingResponse> {
   return jsonFetch<RoutingResponse>("/v1/_routing");
 }
+
+// --- RFC AV: token-usage & cost report (GET /v1/_usage) ---
+
+// UsageAggregate is one grouped row. Only the dimensions in the query's
+// group_by are populated; the rest are "".
+export interface UsageAggregate {
+  tenant_id?: string;
+  user_id?: string;
+  provider?: string;
+  model?: string;
+  credential_source?: string; // operator | tenant | user
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  cost: number;
+  currency?: string;
+  call_count: number;
+  unpriced_calls: number;
+}
+
+export interface UsageReportResponse {
+  group_by: string[];
+  from?: string;
+  to?: string;
+  rows: UsageAggregate[];
+}
+
+export interface UsageReportParams {
+  group_by?: string; // comma list of tenant,user,provider,model,source
+  from?: string; // RFC3339
+  to?: string; // RFC3339
+  tenant?: string; // admin-only focus; ignored for a tenant operator
+}
+
+export function getUsage(
+  params: UsageReportParams = {}
+): Promise<UsageReportResponse> {
+  const q = new URLSearchParams();
+  if (params.group_by) q.set("group_by", params.group_by);
+  if (params.from) q.set("from", params.from);
+  if (params.to) q.set("to", params.to);
+  if (params.tenant) q.set("tenant", params.tenant);
+  const qs = q.toString();
+  return jsonFetch<UsageReportResponse>(`/v1/_usage${qs ? "?" + qs : ""}`);
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import {
   Brain,
   CalendarClock,
   Camera,
+  Coins,
   FolderTree,
   HardDrive,
   Library,
@@ -76,6 +77,10 @@ const NAV_ITEMS: NavItem[] = [
   // handler strips live availability + the infra provider-header for a
   // non-admin principal (config cascade only).
   { to: "/routing", label: "routing", Icon: Route, vis: "tenant" },
+  // usage: token/cost report. Tenant-visible (RFC AV): GET /v1/_usage is
+  // ScopeTenant-gated and the handler tenant-scopes the aggregation (a tenant
+  // operator sees only its own tenant's spend; admin sees all + ?tenant=).
+  { to: "/usage", label: "usage", Icon: Coins, vis: "tenant" },
   { to: "/activity", label: "activity", Icon: Activity, vis: "admin" },
 ];
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -16,6 +16,7 @@ import InterruptInbox from "./pages/InterruptInbox";
 import SnapshotsView from "./pages/SnapshotsView";
 import AuditView from "./pages/AuditView";
 import RoutingView from "./pages/RoutingView";
+import UsageView from "./pages/UsageView";
 import ActivityMonitor from "./pages/ActivityMonitor";
 import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
@@ -84,6 +85,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="snapshots" element={<SnapshotsView />} />
           <Route path="audit" element={<AuditView />} />
           <Route path="routing" element={<RoutingView />} />
+          <Route path="usage" element={<UsageView />} />
           <Route path="activity" element={<ActivityMonitor />} />
           <Route path="settings" element={<SettingsView />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />

--- a/web/src/pages/UsageView.tsx
+++ b/web/src/pages/UsageView.tsx
@@ -1,0 +1,285 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { UsageAggregate, UsageReportResponse, getUsage } from "../api";
+
+// UsageView — GET /v1/_usage (RFC AV).
+//
+// Token usage + money spent from the per-call ledger (∪ the compact archive),
+// grouped by any of tenant / user / provider / model / source. The
+// operator-vs-tenant split is just `source` in the grouping: an operator-key run
+// bills the operator AND counts as tenant consumption; a tenant-key run counts
+// for the tenant only. Tenant-scoped by the API (a tenant operator sees only its
+// own tenant; admin sees all + an optional tenant focus).
+
+// The five whitelisted dimensions, in the server's canonical column order.
+const DIMENSIONS: { key: string; label: string }[] = [
+  { key: "tenant", label: "tenant" },
+  { key: "user", label: "user" },
+  { key: "provider", label: "provider" },
+  { key: "model", label: "model" },
+  { key: "source", label: "source" },
+];
+
+// toRFC3339 converts an <input type="datetime-local"> value (local time) to the
+// RFC3339 the server expects. Empty in → empty out (caller skips the param).
+function toRFC3339(local: string): string {
+  if (!local) return "";
+  const d = new Date(local);
+  if (isNaN(d.getTime())) return "";
+  return d.toISOString();
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+function fmtCost(cost: number, currency?: string): string {
+  const cur = currency || "USD";
+  const digits = cost !== 0 && Math.abs(cost) < 1 ? 4 : 2;
+  return `${cost.toFixed(digits)} ${cur}`;
+}
+
+// dimValue returns the cell text for a dimension on a row ("—" when blank, e.g.
+// an operator row has an empty scope, or a dimension not grouped).
+function dimValue(row: UsageAggregate, key: string): string {
+  switch (key) {
+    case "tenant":
+      return row.tenant_id || "—";
+    case "user":
+      return row.user_id || "—";
+    case "provider":
+      return row.provider || "—";
+    case "model":
+      return row.model || "—";
+    case "source":
+      return row.credential_source || "—";
+  }
+  return "";
+}
+
+export default function UsageView() {
+  // Default grouping is the operator-vs-tenant view.
+  const [dims, setDims] = useState<Set<string>>(
+    () => new Set(["tenant", "source"])
+  );
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [tenant, setTenant] = useState("");
+  const [resp, setResp] = useState<UsageReportResponse | null>(null);
+  const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const activeDims = useMemo(
+    () => DIMENSIONS.filter((d) => dims.has(d.key)),
+    [dims]
+  );
+
+  const fetchUsage = useCallback(async () => {
+    setLoading(true);
+    setErr("");
+    try {
+      const groupBy = DIMENSIONS.filter((d) => dims.has(d.key))
+        .map((d) => d.key)
+        .join(",");
+      setResp(
+        await getUsage({
+          group_by: groupBy || undefined,
+          from: toRFC3339(from) || undefined,
+          to: toRFC3339(to) || undefined,
+          tenant: tenant.trim() || undefined,
+        })
+      );
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [dims, from, to, tenant]);
+
+  useEffect(() => {
+    void fetchUsage();
+    // Run once on mount; subsequent fetches are driven by the Apply button so a
+    // half-typed filter doesn't spam the endpoint.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const toggleDim = (key: string) => {
+    setDims((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  // Totals + the operator-vs-tenant split (computed client-side from the rows;
+  // meaningful whenever `source` is grouped, else operator/tenant read 0).
+  const totals = useMemo(() => {
+    let cost = 0;
+    let operator = 0;
+    let tenantSpend = 0;
+    let unpriced = 0;
+    let currency = "";
+    for (const r of resp?.rows ?? []) {
+      cost += r.cost;
+      unpriced += r.unpriced_calls;
+      if (r.currency) currency = r.currency;
+      if (r.credential_source === "operator") operator += r.cost;
+      if (r.credential_source === "tenant" || r.credential_source === "user")
+        tenantSpend += r.cost;
+    }
+    return { cost, operator, tenantSpend, unpriced, currency };
+  }, [resp]);
+
+  const sourceGrouped = dims.has("source");
+
+  return (
+    <div className="usage-view">
+      <div className="usage-header">
+        <div>
+          <h1>usage</h1>
+          <p className="usage-sub">
+            Token usage &amp; cost from the per-call ledger. Group by{" "}
+            <code>source</code> for the operator-vs-tenant split.
+          </p>
+        </div>
+      </div>
+
+      <div className="usage-controls">
+        <div className="usage-dims">
+          <span className="usage-ctl-label">group by</span>
+          {DIMENSIONS.map((d) => (
+            <label key={d.key} className="usage-dim-chip">
+              <input
+                type="checkbox"
+                checked={dims.has(d.key)}
+                onChange={() => toggleDim(d.key)}
+              />
+              {d.label}
+            </label>
+          ))}
+        </div>
+        <div className="usage-range">
+          <label>
+            from
+            <input
+              type="datetime-local"
+              value={from}
+              onChange={(e) => setFrom(e.target.value)}
+            />
+          </label>
+          <label>
+            to
+            <input
+              type="datetime-local"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+            />
+          </label>
+          <label>
+            tenant
+            <input
+              type="text"
+              placeholder="(admin focus)"
+              value={tenant}
+              onChange={(e) => setTenant(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className="ghost-btn"
+            onClick={() => void fetchUsage()}
+            disabled={loading}
+          >
+            {loading ? "loading…" : "apply"}
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="err">{err}</div>}
+
+      {resp && (
+        <div className="usage-summary">
+          <div className="usage-stat">
+            <span className="usage-stat-label">total cost</span>
+            <span className="usage-stat-value">
+              {fmtCost(totals.cost, totals.currency)}
+            </span>
+          </div>
+          {sourceGrouped && (
+            <>
+              <div className="usage-stat">
+                <span className="usage-stat-label">operator bill</span>
+                <span className="usage-stat-value">
+                  {fmtCost(totals.operator, totals.currency)}
+                </span>
+              </div>
+              <div className="usage-stat">
+                <span className="usage-stat-label">tenant-funded</span>
+                <span className="usage-stat-value">
+                  {fmtCost(totals.tenantSpend, totals.currency)}
+                </span>
+              </div>
+            </>
+          )}
+          {totals.unpriced > 0 && (
+            <div className="usage-stat usage-warn">
+              <span className="usage-stat-label">unpriced calls</span>
+              <span className="usage-stat-value">{totals.unpriced}</span>
+            </div>
+          )}
+        </div>
+      )}
+
+      {resp && resp.rows.length > 0 && (
+        <div className="usage-table-wrap">
+          <table className="usage-table">
+            <thead>
+              <tr>
+                {activeDims.map((d) => (
+                  <th key={d.key}>{d.label}</th>
+                ))}
+                <th className="num">input</th>
+                <th className="num">output</th>
+                <th className="num">cache</th>
+                <th className="num">calls</th>
+                <th className="num">cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {resp.rows.map((r, i) => (
+                <tr key={i}>
+                  {activeDims.map((d) => (
+                    <td key={d.key} className={d.key === "source" ? `usage-src usage-src-${r.credential_source}` : ""}>
+                      {dimValue(r, d.key)}
+                    </td>
+                  ))}
+                  <td className="num">{fmtTokens(r.input_tokens)}</td>
+                  <td className="num">{fmtTokens(r.output_tokens)}</td>
+                  <td className="num">
+                    {fmtTokens(r.cache_creation_tokens + r.cache_read_tokens)}
+                  </td>
+                  <td className="num">
+                    {r.call_count}
+                    {r.unpriced_calls > 0 && (
+                      <span className="usage-unpriced" title="calls with no price">
+                        {" "}
+                        ({r.unpriced_calls} unpriced)
+                      </span>
+                    )}
+                  </td>
+                  <td className="num">{fmtCost(r.cost, r.currency)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {resp && resp.rows.length === 0 && (
+        <div className="empty">no usage in this window.</div>
+      )}
+    </div>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6029,3 +6029,132 @@ button.primary:disabled {
   color: var(--fg-soft);
   font-weight: 700;
 }
+
+/* --- RFC AV: usage / cost report (UsageView) --- */
+.usage-view {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow: auto;
+}
+.usage-header h1 {
+  margin: 0;
+}
+.usage-sub {
+  margin: 4px 0 0;
+  color: var(--fg-soft);
+  font-size: 13px;
+}
+.usage-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px 24px;
+  align-items: flex-end;
+  padding: 12px 14px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--lc-radius-sm);
+}
+.usage-ctl-label {
+  color: var(--fg-soft);
+  font-size: 12px;
+  margin-right: 8px;
+}
+.usage-dims {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+.usage-dim-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 12px;
+  font-family: var(--mono);
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  cursor: pointer;
+}
+.usage-range {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 12px;
+}
+.usage-range label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+.usage-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+.usage-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.usage-stat-label {
+  font-size: 11px;
+  color: var(--fg-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.usage-stat-value {
+  font-size: 20px;
+  font-weight: 700;
+  font-family: var(--mono);
+}
+.usage-stat.usage-warn .usage-stat-value {
+  color: var(--accent);
+}
+.usage-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.usage-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+.usage-table th,
+.usage-table td {
+  text-align: left;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.usage-table th {
+  background: var(--bg-soft);
+  color: var(--fg-soft);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+}
+.usage-table th.num,
+.usage-table td.num {
+  text-align: right;
+}
+.usage-table tbody tr:hover {
+  background: var(--bg-soft-2);
+}
+.usage-src-operator {
+  color: var(--fg-soft);
+}
+.usage-src-tenant,
+.usage-src-user {
+  font-weight: 700;
+}
+.usage-unpriced {
+  color: var(--accent);
+  font-size: 11px;
+}


### PR DESCRIPTION
## Why

Phase 2a shipped the `GET /v1/_usage` report API; Phase 2b bounded its ledger. This makes the reports **visible in the console** — the payoff of the whole feature. An operator (or a tenant operator) can now see token usage + money spent without hitting the API by hand.

## What

- **`UsageView.tsx`** — group-by chips (`tenant / user / provider / model / source`, default `tenant + source` = the operator-vs-tenant view), a from/to window, an admin tenant-focus box, and a table of tokens + cost per group. A **summary strip** shows total cost and — when grouped by `source` — the **operator bill vs tenant-funded** split, plus an unpriced-calls indicator (pricing incomplete).
- **`api.ts`** — `getUsage()` + `UsageAggregate` / `UsageReportResponse` types (mirrors `getRouting` / `listEvents`).
- **Nav** — a tenant-visible `usage` item (`vis:"tenant"` per RFC AS — `GET /v1/_usage` is `ScopeTenant`-gated and the handler tenant-scopes the aggregation, so a tenant operator sees only its own spend; admin sees all + `?tenant=`). Route wired in `main.tsx`.

```
Web UI ▸ Usage
  [✓ tenant] [ user ] [ provider ] [ model ] [✓ source]   from […] to […] tenant […]  [apply]
  total cost 34.70 USD    operator bill 22.60 USD    tenant-funded 12.10 USD
  ┌─────────┬──────────┬────────┬────────┬───────┬──────────┐
  │ tenant  │ source   │ input  │ output │ calls │ cost     │
  │ acme    │ operator │ 1.20M  │ 0.40M  │ 30    │ 18.40 USD│
  │ acme    │ tenant   │ 0.80M  │ 0.25M  │ 22    │ 12.10 USD│
  └─────────┴──────────┴────────┴────────┴───────┴──────────┘
```

## Tested

- `npm run build` (tsc typecheck + vite) clean.
- `go build` embeds the SPA.
- **Live smoke against the binary:** `/v1/_usage?group_by=tenant,source` → `200` (`{"group_by":["tenant","source"],"rows":null}` on an empty store), an unknown `group_by` → `400`, `/ui/` serves the page, and the usage sweeper boots.

`web/src` only — `internal/webui/dist` is gitignored and CI rebuilds it.

## Remaining (RFC AV)

- **2b2** — the old-run archiver (prune/export aged completed runs).
- gRPC/TS adapter parity for the usage endpoint (HTTP-first; adapters follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)