### PR TITLE
feat(usage): old-run archiver — prune/export aged completed runs — Phase 2b2 (RFC AV)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2086,6 +2086,10 @@ func main() {
 		uCfg := usage.Config{
 			Interval:        cfg.Env.UsageSweepInterval,
 			DetailRetention: cfg.Env.UsageDetailRetention,
+			// RFC AV Phase 2b2 old-run archiver (opt-in; default OFF).
+			RunRetention:     cfg.Env.UsageRunRetention,
+			RunRetentionMode: cfg.Env.UsageRunRetentionMode,
+			ExportDir:        cfg.Env.UsageExportDir,
 		}
 		// Same typed-nil guard as the heartbeat block: only assign the
 		// interface field from a non-nil pointer, or the sweeper's

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2104,6 +2104,17 @@ type Env struct {
 	// this are rolled up into usage_archive and pruned. Default 720h
 	// (30 days). Env: LOOMCYCLE_USAGE_DETAIL_RETENTION_MS.
 	UsageDetailRetention time.Duration
+	// UsageRunRetention is the RFC AV Phase 2b2 old-run archiver cutoff:
+	// completed runs older than this are exported (per the mode) and
+	// deleted. Default 0 = OFF (run deletion is destructive — opt-in,
+	// unlike the lossless usage rollup). Env: LOOMCYCLE_USAGE_RUN_RETENTION_MS.
+	UsageRunRetention time.Duration
+	// UsageRunRetentionMode is "off" (default) | "prune" | "export+prune".
+	// Env: LOOMCYCLE_USAGE_RUN_RETENTION_MODE.
+	UsageRunRetentionMode string
+	// UsageExportDir is where export+prune writes run JSON (per-day subdir,
+	// one file per run). Required for export+prune. Env: LOOMCYCLE_USAGE_EXPORT_DIR.
+	UsageExportDir string
 	// ReplicasSweepInterval is the dead-replica reaper's tick rate.
 	// Default 60s. Tunable mostly for tests / crash-recovery load
 	// experiments — leave at default in production.
@@ -2994,6 +3005,14 @@ func LoadLayers(layers ...Layer) (*Config, error) {
 			cfg.Env.UsageDetailRetention = time.Duration(n) * time.Millisecond
 		}
 	}
+	// RFC AV Phase 2b2 old-run archiver (opt-in; default OFF).
+	if v := os.Getenv("LOOMCYCLE_USAGE_RUN_RETENTION_MS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.Env.UsageRunRetention = time.Duration(n) * time.Millisecond
+		}
+	}
+	cfg.Env.UsageRunRetentionMode = os.Getenv("LOOMCYCLE_USAGE_RUN_RETENTION_MODE")
+	cfg.Env.UsageExportDir = os.Getenv("LOOMCYCLE_USAGE_EXPORT_DIR")
 	if v := os.Getenv("LOOMCYCLE_REPLICAS_SWEEP_INTERVAL_MS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			cfg.Env.ReplicasSweepInterval = time.Duration(n) * time.Millisecond

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -640,6 +640,50 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 	return pruned, nil
 }
 
+// PrunableCompletedRuns lists terminal runs older than olderThan (RFC AV Phase
+// 2b2). completed_at is TIMESTAMPTZ here.
+func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]store.Run, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
+		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
+		        r.model, r.provider, r.error,
+		        r.agent_id, r.parent_agent_id, r.parent_run_id, r.user_id, r.last_heartbeat_at, r.user_tier,
+		        r.agent_def_id, r.pause_state, r.replica_id, r.parent_context, r.idempotency_key, r.tenant_id, r.interactive,
+		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
+		        s.agent
+		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
+		 WHERE r.status IN ($1, $2, $3) AND r.completed_at IS NOT NULL AND r.completed_at < $4
+		 ORDER BY r.completed_at ASC LIMIT $5`,
+		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),
+		olderThan, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list prunable runs: %w", err)
+	}
+	defer rows.Close()
+	return scanRunRows(rows)
+}
+
+// DeleteRunAndEvents deletes a run + its events in one tx (RFC AV Phase 2b2).
+// Events removed explicitly; token_usage intentionally left (own retention).
+func (s *Store) DeleteRunAndEvents(ctx context.Context, runID string) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin delete-run tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `DELETE FROM events WHERE run_id = $1`, runID); err != nil {
+		return fmt.Errorf("delete run events: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM runs WHERE id = $1`, runID); err != nil {
+		return fmt.Errorf("delete run: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
 // GetTranscript returns every event for the session, ordered by seq.
 // Empty slice (not error) when the session has no events yet.
 func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Event, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1460,6 +1460,52 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 	return int(n), nil
 }
 
+// PrunableCompletedRuns lists terminal runs older than olderThan (RFC AV Phase
+// 2b2). completed_at is unix-nano here.
+func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]store.Run, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+runColumns+` FROM `+runFromTable+`
+		 WHERE r.status IN (?, ?, ?) AND r.completed_at IS NOT NULL AND r.completed_at < ?
+		 ORDER BY r.completed_at ASC LIMIT ?`,
+		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),
+		olderThan.UnixNano(), limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.Run
+	for rows.Next() {
+		r, err := scanRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// DeleteRunAndEvents deletes a run + its events in one tx (RFC AV Phase 2b2).
+// Events are removed explicitly (not via FK cascade) so behavior is identical
+// regardless of the foreign_keys pragma; token_usage is intentionally left.
+func (s *Store) DeleteRunAndEvents(ctx context.Context, runID string) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE run_id = ?`, runID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM runs WHERE id = ?`, runID); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 // GetTranscript returns all events for a session, ordered by seq ascending.
 func (s *Store) GetTranscript(ctx context.Context, sessionID string) ([]store.Event, error) {
 	if _, err := s.GetSession(ctx, sessionID); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -666,6 +666,18 @@ type Store interface {
 	// pruned. The rollup-and-prune sweeper calls this on a timer (RFC AV Phase 2b).
 	RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (pruned int, err error)
 
+	// PrunableCompletedRuns returns terminal (completed/failed/cancelled) runs
+	// whose completed_at is older than olderThan, oldest first, capped at limit.
+	// The old-run archiver (RFC AV Phase 2b2) lists these to export and/or
+	// delete. Non-terminal runs (running/paused/pausing) are never returned.
+	PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]Run, error)
+
+	// DeleteRunAndEvents deletes a run and its events in one transaction (events
+	// removed explicitly, not relying on FK cascade). token_usage rows are LEFT
+	// INTACT — usage has its own retention (RollupAndPruneUsage), and the usage
+	// report does not join runs. RFC AV Phase 2b2.
+	DeleteRunAndEvents(ctx context.Context, runID string) error
+
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.
 	GetTranscript(ctx context.Context, sessionID string) ([]Event, error)

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -340,6 +340,7 @@ func Run(t *testing.T, factory Factory) {
 		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
 		{"UsageReport", testUsageReport},
 		{"UsageRollupAndPrune", testUsageRollupAndPrune},
+		{"RunArchiver", testRunArchiver},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -801,6 +802,70 @@ func testUsageRollupAndPrune(t *testing.T, s store.Store) {
 	rep2, _ := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
 	if len(rep2) != 1 || rep2[0].InputTokens != 350 {
 		t.Errorf("report after idempotent re-run = %+v, want unchanged 350", rep2)
+	}
+}
+
+// testRunArchiver exercises RFC AV Phase 2b2: PrunableCompletedRuns lists only
+// terminal runs within the age cutoff, and DeleteRunAndEvents removes the run +
+// its events while leaving token_usage (independent retention) intact.
+func testRunArchiver(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	sess, _ := s.CreateSession(ctx, "t", "default", "")
+
+	// runA: completed, with events + a usage row. runB: completed. runC: running.
+	runA, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-a"})
+	runB, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-b"})
+	runC, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-c"}) // stays running
+	for _, e := range []string{"text", "done"} {
+		if err := s.AppendEvent(ctx, runA.ID, e, []byte(`{}`)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: runA.ID, TenantID: "t", Provider: "p", Model: "m", CredentialSource: "operator", InputTokens: 10}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{runA.ID, runB.ID} {
+		if err := s.FinishRun(ctx, id, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// A future cutoff → both completed runs qualify; the running one never does.
+	got, err := s.PrunableCompletedRuns(ctx, time.Now().Add(time.Hour), 100)
+	if err != nil {
+		t.Fatalf("PrunableCompletedRuns: %v", err)
+	}
+	ids := map[string]bool{}
+	for _, r := range got {
+		ids[r.ID] = true
+	}
+	if !ids[runA.ID] || !ids[runB.ID] {
+		t.Errorf("prunable set missing a completed run: %v", ids)
+	}
+	if ids[runC.ID] {
+		t.Errorf("prunable set included the RUNNING run %s", runC.ID)
+	}
+	// A past cutoff → nothing (both completed just now).
+	if old, _ := s.PrunableCompletedRuns(ctx, time.Now().Add(-time.Hour), 100); len(old) != 0 {
+		t.Errorf("past-cutoff prunable = %d, want 0", len(old))
+	}
+
+	// Delete runA: run + events gone, token_usage preserved.
+	if err := s.DeleteRunAndEvents(ctx, runA.ID); err != nil {
+		t.Fatalf("DeleteRunAndEvents: %v", err)
+	}
+	if _, err := s.GetRun(ctx, runA.ID); err == nil {
+		t.Errorf("runA still present after delete")
+	}
+	if evs, _ := s.GetRunEventsSince(ctx, runA.ID, 0, 100); len(evs) != 0 {
+		t.Errorf("runA events survived delete: %d", len(evs))
+	}
+	if usage, _ := s.TokenUsageForRun(ctx, runA.ID); len(usage) != 1 {
+		t.Errorf("token_usage for deleted run = %d, want 1 (usage retention is independent)", len(usage))
+	}
+	// runC (running) untouched.
+	if _, err := s.GetRun(ctx, runC.ID); err != nil {
+		t.Errorf("runC (running) was affected: %v", err)
 	}
 }
 

--- a/internal/usage/sweeper.go
+++ b/internal/usage/sweeper.go
@@ -16,7 +16,10 @@ package usage
 
 import (
 	"context"
+	"encoding/json"
 	"log"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/denn-gubsky/loomcycle/internal/store"
@@ -37,6 +40,27 @@ type Config struct {
 	// stays possible within the window; older activity survives only as
 	// day-bucketed archive aggregates.
 	DetailRetention time.Duration
+
+	// --- RFC AV Phase 2b2: old-run archiver (OFF by default). ---
+	// Unlike the usage rollup above (lossless compaction to the archive), this
+	// DELETES aged completed runs + their events — the audit trail — so it is
+	// opt-in: zero RunRetention or an "off"/"" RunRetentionMode disables it.
+
+	// RunRetention is the cutoff for archiving completed runs: terminal runs
+	// whose completed_at is older than this are exported (if the mode says so)
+	// and deleted. Zero disables run archival entirely. token_usage is NOT
+	// touched — usage retention is DetailRetention above.
+	RunRetention time.Duration
+
+	// RunRetentionMode is one of "off" (default / ""), "prune" (delete aged
+	// completed runs + events), or "export+prune" (write each run + its events
+	// to ExportDir as JSON, then delete). An unknown value is treated as off.
+	RunRetentionMode string
+
+	// ExportDir is the directory export+prune writes run JSON into (one file per
+	// run under a per-day subdir). Required for export+prune; if empty, run
+	// archival is disabled (never delete a run we were asked to export).
+	ExportDir string
 
 	// Logger is the structured logger used for sweep results. Defaults
 	// to log.Printf when nil. Errors are logged at every tick;
@@ -77,15 +101,19 @@ type AdvisoryLocker interface {
 const (
 	defaultInterval        = 1 * time.Hour
 	defaultDetailRetention = 720 * time.Hour // 30 days
+	runPruneBatch          = 500             // completed runs archived per tick
 )
 
 // Sweeper periodically folds old token_usage rows into usage_archive and
-// deletes them. Construct via New, then call Run(ctx) on a goroutine
-// that owns the lifecycle.
+// deletes them, and (opt-in) archives aged completed runs. Construct via New,
+// then call Run(ctx) on a goroutine that owns the lifecycle.
 type Sweeper struct {
 	store           store.Store
 	interval        time.Duration
 	detailRetention time.Duration
+	runRetention    time.Duration
+	runMode         string
+	exportDir       string
 	logf            func(format string, args ...any)
 	lock            AdvisoryLocker
 	lockKey         int64
@@ -108,15 +136,38 @@ func New(st store.Store, cfg Config) *Sweeper {
 	if cfg.Now == nil {
 		cfg.Now = time.Now
 	}
+	mode := cfg.RunRetentionMode
+	if mode == "" {
+		mode = "off"
+	}
 	return &Sweeper{
 		store:           st,
 		interval:        cfg.Interval,
 		detailRetention: cfg.DetailRetention,
+		runRetention:    cfg.RunRetention,
+		runMode:         mode,
+		exportDir:       cfg.ExportDir,
 		logf:            cfg.Logger,
 		lock:            cfg.AdvisoryLock,
 		lockKey:         cfg.AdvisoryLockKey,
 		now:             cfg.Now,
 	}
+}
+
+// runArchivalEnabled reports whether the opt-in old-run archiver should run:
+// a positive RunRetention, a delete-bearing mode, and — for export+prune — a
+// configured ExportDir (never delete a run we were asked to export but can't).
+func (s *Sweeper) runArchivalEnabled() bool {
+	if s.runRetention <= 0 {
+		return false
+	}
+	switch s.runMode {
+	case "prune":
+		return true
+	case "export+prune":
+		return s.exportDir != ""
+	}
+	return false
 }
 
 // Run drives the sweep loop until ctx is done. Each tick calls
@@ -130,6 +181,11 @@ func (s *Sweeper) Run(ctx context.Context) {
 		return
 	}
 	s.logf("usage: sweeper starting (interval=%s, detail_retention=%s)", s.interval, s.detailRetention)
+	if s.runArchivalEnabled() {
+		s.logf("usage: old-run archiver ON (mode=%s, run_retention=%s, export_dir=%q)", s.runMode, s.runRetention, s.exportDir)
+	} else if s.runRetention > 0 && s.runMode == "export+prune" && s.exportDir == "" {
+		s.logf("usage: old-run archiver DISABLED — mode=export+prune requires LOOMCYCLE_USAGE_EXPORT_DIR")
+	}
 	t := time.NewTicker(s.interval)
 	defer t.Stop()
 
@@ -146,22 +202,28 @@ func (s *Sweeper) Run(ctx context.Context) {
 			s.logf("usage: sweeper stopping (ctx done)")
 			return
 		case <-t.C:
-			// When an AdvisoryLock is wired (cluster mode), gate the
-			// sweep behind the lock so only one replica per tick actually
-			// runs the prune. Single-replica path (lock == nil) sweeps
-			// unconditionally.
+			// When an AdvisoryLock is wired (cluster mode), gate the whole
+			// tick behind the lock so only one replica per tick runs the
+			// prune + run archival. Single-replica path (lock == nil) sweeps
+			// unconditionally. Both steps run under the SAME acquisition.
 			var (
-				n   int
-				err error
+				n, archived  int
+				err, archErr error
+				ranArchival  bool
 			)
+			doWork := func(ctx context.Context) {
+				n, err = s.sweepOnce(ctx)
+				if s.runArchivalEnabled() {
+					ranArchival = true
+					archived, archErr = s.archiveRunsOnce(ctx)
+				}
+			}
 			if s.lock != nil {
 				acquired, lockErr := s.lock.TryRun(ctx, s.lockKey, func(ctx context.Context) error {
-					// Capture into outer n + err directly. We deliberately
-					// return nil from fn so TryRun's err signals ONLY
-					// infra failures (pool acquire, pg_try_advisory_lock
-					// failure), keeping the sweep-failed log line below
-					// distinct from the advisory-lock-failed log line.
-					n, err = s.sweepOnce(ctx)
+					// Return nil so TryRun's err signals ONLY infra failures
+					// (pool acquire, pg_try_advisory_lock), kept distinct from
+					// the per-step failure logs below.
+					doWork(ctx)
 					return nil
 				})
 				if lockErr != nil {
@@ -173,21 +235,28 @@ func (s *Sweeper) Run(ctx context.Context) {
 					continue
 				}
 			} else {
-				n, err = s.sweepOnce(ctx)
+				doWork(ctx)
 			}
+			// Usage rollup-prune result.
 			if err != nil {
 				s.logf("usage: sweep failed: %v", err)
-				continue
-			}
-			if n > 0 {
+			} else if n > 0 {
 				s.logf("usage: rolled up + pruned %d detail row(s)", n)
 				noOpStreak = 0
-				continue
+			} else {
+				if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
+					s.logf("usage: sweep tick — 0 detail rows to prune (streak=%d)", noOpStreak)
+				}
+				noOpStreak++
 			}
-			if noOpStreak == 0 || noOpStreak%noOpHeartbeatEvery == 0 {
-				s.logf("usage: sweep tick — 0 detail rows to prune (streak=%d)", noOpStreak)
+			// Old-run archival result (only when enabled).
+			if ranArchival {
+				if archErr != nil {
+					s.logf("usage: run archival failed: %v", archErr)
+				} else if archived > 0 {
+					s.logf("usage: archived + pruned %d completed run(s) (mode=%s)", archived, s.runMode)
+				}
 			}
-			noOpStreak++
 		}
 	}
 }
@@ -202,4 +271,63 @@ func (s *Sweeper) sweepOnce(parent context.Context) (int, error) {
 	defer cancel()
 	cutoff := s.now().Add(-s.detailRetention)
 	return s.store.RollupAndPruneUsage(ctx, cutoff)
+}
+
+// archiveRunsOnce archives one batch of aged completed runs (RFC AV Phase 2b2):
+// list terminal runs older than the cutoff, export each (export+prune mode) then
+// delete it (run + events). Per-run failures are logged and skipped — a bad
+// export never deletes the run. Returns the number deleted. Given a longer
+// timeout than the usage prune because export writes files.
+func (s *Sweeper) archiveRunsOnce(parent context.Context) (int, error) {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
+	defer cancel()
+	cutoff := s.now().Add(-s.runRetention)
+	runs, err := s.store.PrunableCompletedRuns(ctx, cutoff, runPruneBatch)
+	if err != nil {
+		return 0, err
+	}
+	deleted := 0
+	for _, r := range runs {
+		if s.runMode == "export+prune" {
+			if err := s.exportRun(ctx, r); err != nil {
+				// Never delete a run we failed to export — retry next tick.
+				s.logf("usage: export run %s failed, skipping delete: %v", r.ID, err)
+				continue
+			}
+		}
+		if err := s.store.DeleteRunAndEvents(ctx, r.ID); err != nil {
+			s.logf("usage: delete run %s failed: %v", r.ID, err)
+			continue
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
+// exportRun writes a run + its events to ExportDir as JSON, under a per-day
+// subdir (bucketing by completed date keeps any single directory bounded). The
+// export dir is operator config, never model input.
+func (s *Sweeper) exportRun(ctx context.Context, r store.Run) error {
+	events, err := s.store.GetRunEventsSince(ctx, r.ID, 0, 1_000_000)
+	if err != nil {
+		return err
+	}
+	day := r.CompletedAt
+	if day.IsZero() {
+		day = r.StartedAt
+	}
+	dir := filepath.Join(s.exportDir, day.UTC().Format("2006-01-02"))
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	payload := struct {
+		Run    store.Run     `json:"run"`
+		Events []store.Event `json:"events"`
+	}{Run: r, Events: events}
+	blob, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	// 0o600: run transcripts may hold sensitive tool I/O; operator-only.
+	return os.WriteFile(filepath.Join(dir, r.ID+".json"), blob, 0o600)
 }

--- a/internal/usage/sweeper_test.go
+++ b/internal/usage/sweeper_test.go
@@ -1,7 +1,9 @@
 package usage
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -84,6 +86,97 @@ func TestSweeperOnce_PrunesOldDetail(t *testing.T) {
 	if n2, err := sw.sweepOnce(ctx); err != nil || n2 != 0 {
 		t.Errorf("second sweepOnce = (%d, %v), want (0, nil) — should be idempotent", n2, err)
 	}
+}
+
+// TestArchiveRunsOnce covers the RFC AV Phase 2b2 old-run archiver in both
+// modes: "prune" deletes an aged completed run + its events; "export+prune"
+// first writes the run JSON to the export dir, then deletes. The clock is
+// pinned into the future so a just-completed run lands past the cutoff.
+func TestArchiveRunsOnce(t *testing.T) {
+	ctx := context.Background()
+	// Pin now well past the run's completed_at so cutoff = now-24h > completed_at.
+	future := func() time.Time { return time.Now().Add(48 * time.Hour) }
+
+	seedCompletedRun := func(st *sqlite.Store, agentID string) string {
+		sess, err := st.CreateSession(ctx, "t", "default", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: agentID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.AppendEvent(ctx, run.ID, "text", []byte(`{"t":"hi"}`)); err != nil {
+			t.Fatal(err)
+		}
+		if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+			t.Fatal(err)
+		}
+		return run.ID
+	}
+
+	t.Run("prune", func(t *testing.T) {
+		st := newTestStore(t)
+		runID := seedCompletedRun(st, "prune-a")
+		sw := New(st, Config{
+			RunRetention:     24 * time.Hour,
+			RunRetentionMode: "prune",
+			Logger:           func(string, ...any) {},
+			Now:              future,
+		})
+		if !sw.runArchivalEnabled() {
+			t.Fatal("prune mode should be enabled")
+		}
+		n, err := sw.archiveRunsOnce(ctx)
+		if err != nil || n != 1 {
+			t.Fatalf("archiveRunsOnce = (%d, %v), want (1, nil)", n, err)
+		}
+		if _, err := st.GetRun(ctx, runID); err == nil {
+			t.Errorf("run survived prune")
+		}
+	})
+
+	t.Run("export+prune", func(t *testing.T) {
+		st := newTestStore(t)
+		exportDir := t.TempDir()
+		runID := seedCompletedRun(st, "export-a")
+		sw := New(st, Config{
+			RunRetention:     24 * time.Hour,
+			RunRetentionMode: "export+prune",
+			ExportDir:        exportDir,
+			Logger:           func(string, ...any) {},
+			Now:              future,
+		})
+		n, err := sw.archiveRunsOnce(ctx)
+		if err != nil || n != 1 {
+			t.Fatalf("archiveRunsOnce = (%d, %v), want (1, nil)", n, err)
+		}
+		if _, err := st.GetRun(ctx, runID); err == nil {
+			t.Errorf("run survived export+prune")
+		}
+		// A JSON export exists under a per-day subdir and mentions the run id.
+		matches, _ := filepath.Glob(filepath.Join(exportDir, "*", runID+".json"))
+		if len(matches) != 1 {
+			t.Fatalf("export file glob = %v, want exactly one %s.json", matches, runID)
+		}
+		blob, err := os.ReadFile(matches[0])
+		if err != nil || !bytes.Contains(blob, []byte(runID)) || !bytes.Contains(blob, []byte(`"events"`)) {
+			t.Errorf("export file missing run id / events: err=%v", err)
+		}
+	})
+
+	t.Run("export+prune without dir is disabled", func(t *testing.T) {
+		st := newTestStore(t)
+		sw := New(st, Config{
+			RunRetention:     24 * time.Hour,
+			RunRetentionMode: "export+prune", // no ExportDir
+			Logger:           func(string, ...any) {},
+			Now:              future,
+		})
+		if sw.runArchivalEnabled() {
+			t.Error("export+prune with no ExportDir must be disabled (never delete un-exported)")
+		}
+	})
 }
 
 // TestSweeperRun_StopsOnContextDone asserts the goroutine exits cleanly


### PR DESCRIPTION
## Why

The **"sweeper/archiver for old runs"** you asked for. Phase 2b bounded the usage ledger; this bounds the **runs/events** tables by retiring aged **completed** runs on a retention horizon. It's **OFF by default** — unlike the lossless usage rollup (2b), this **deletes the audit trail**, so it's strictly opt-in.

## What

- **`store.PrunableCompletedRuns(olderThan, limit)`** — terminal (`completed`/`failed`/`cancelled`) runs with `completed_at < cutoff`, oldest first, capped. Never returns running/paused runs. Both backends.
- **`store.DeleteRunAndEvents(runID)`** — deletes a run + its events in one transaction (events removed **explicitly**, not relying on FK cascade). **`token_usage` is left intact** — usage has its own retention (2b) and the report doesn't join runs.
- **`usage.Sweeper` gains a second, opt-in step:** when `RunRetention > 0` + a delete-bearing mode, each tick archives one batch (≤500) of aged completed runs, under the **same singleton advisory lock** as the usage rollup. `prune` deletes; `export+prune` first writes `{run, events}` JSON to a per-day subdir under `ExportDir`, then deletes (**a failed export never deletes** — retries next tick).
- **Env:** `LOOMCYCLE_USAGE_RUN_RETENTION_MS` (default **0 = OFF**), `LOOMCYCLE_USAGE_RUN_RETENTION_MODE` (`off｜prune｜export+prune`), `LOOMCYCLE_USAGE_EXPORT_DIR` (required for `export+prune`; missing → archiver stays off, logged).

```
usage:
  run_retention: 2160h        # LOOMCYCLE_USAGE_RUN_RETENTION_MS (90d) — 0 = off
  run_retention_mode: prune   # off | prune | export+prune
  export_dir: /var/lib/loomcycle/archive   # required for export+prune
```

## Tested

`go test ./...` clean, gofmt + vet clean, binary builds.
- **store contract (both backends):** the prunable set excludes the running run + honors the age cutoff (future cutoff → included, past → none); delete removes run+events, **preserves `token_usage`**, leaves other runs.
- **sweeper:** `prune` deletes; `export+prune` writes the per-day JSON (contains run id + events) then deletes; **`export+prune` with no `ExportDir` is disabled** (never deletes an un-exported run).
- **live smoke:** env knobs → `usage: old-run archiver ON (mode=prune, run_retention=2160h0m0s)` at boot.

## Remaining (RFC AV)

- gRPC/TS adapter parity for `/v1/_usage` (HTTP works; adapters follow).
- **Phase 3** — budgets/limits (spend caps + admission gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)