### PR TITLE
fix(usage): correctness + security fixes from the RFC AV code review (#1–8)

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -1296,12 +1296,34 @@ func main() {
 	}
 	credEngine := credential.NewEngine(storeIface, credSealer)
 	credentialDefTool.Engine = credEngine
+	// srv is assigned below at lchttp.New; the credential closures capture it by
+	// reference so a resolved value can be registered in the server's redactor.
+	// registerSecret is only CALLED during a run (long after srv exists), so the
+	// forward capture is safe (mirrors credSubstitute's own by-reference wiring).
+	var srv *lchttp.Server
+	// registerSecret masks a resolved credential value against a downstream echo:
+	// a $cred: value or a tenant/user provider-key that a tool later prints would
+	// otherwise land in the persisted transcript unredacted (RFC AV/AR). The
+	// server-global redactor dedups by value, so re-registering is cheap.
+	registerSecret := func(v string) {
+		if srv != nil {
+			if rd := srv.Redactor(); rd != nil {
+				rd.Register(v)
+			}
+		}
+	}
 	// Wire the $cred: header resolver the MCP http pool captured by reference
 	// above. Identity comes from the per-request ctx (tenant + user + agent), so
 	// a pooled client binds each request's own user-scoped token.
 	credSubstitute = func(ctx context.Context, s string) (string, []string, error) {
+		// Fast-path: when nothing can resolve (no KEK / no external backend) skip
+		// the store reads. Report any $cred: refs as unresolved so the caller still
+		// drops them (never send a literal token downstream).
+		if !credEngine.CanResolve() {
+			return s, credential.RefNames(s), nil
+		}
 		ri := tools.RunIdentity(ctx)
-		return credEngine.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, s, nil)
+		return credEngine.Substitute(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, s, registerSecret)
 	}
 	// RFC AR: resolve a tenant/user credential by env-var NAME (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for the run's identity, so a tenant's own key overrides
@@ -1310,11 +1332,25 @@ func main() {
 	// (a lookup error → no override → host key), never blocking a run on a KEK
 	// gap. Reused by every transport since gRPC routes through the http Server.
 	credResolver := providers.CredentialResolver(func(ctx context.Context, name string) (providers.CredentialResolution, bool) {
-		ri := tools.RunIdentity(ctx)
-		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
-		if err != nil || !found {
+		// Fast-path: no configured backend can resolve → skip the three per-call
+		// scope lookups that would only ever miss (they run on EVERY LLM call).
+		if !credEngine.CanResolve() {
 			return providers.CredentialResolution{}, false
 		}
+		ri := tools.RunIdentity(ctx)
+		res, found, err := credEngine.Resolve(ctx, ri.TenantID, tools.AgentName(ctx), ri.UserID, name)
+		if err != nil {
+			// A store/decrypt fault is NOT a legitimate miss — still fail soft to
+			// the host key (never block a run on a KEK gap), but make it observable
+			// so a silent bill-to-operator regression is diagnosable.
+			log.Printf("credential: resolve %q failed for tenant=%s: %v", name, ri.TenantID, err)
+			return providers.CredentialResolution{}, false
+		}
+		if !found {
+			return providers.CredentialResolution{}, false
+		}
+		// Mask a downstream echo of the override key in the transcript.
+		registerSecret(res.Value)
 		// RFC AV: carry the owning scope + scope_id so a driver can tag usage
 		// (operator vs tenant/user spend) from the same resolve it uses for the key.
 		return providers.CredentialResolution{Value: res.Value, Scope: res.Scope, ScopeID: res.ScopeID}, true
@@ -1419,7 +1455,7 @@ func main() {
 	// lchttp.New — it must include the Agent tool that New appends to the
 	// server's tool set, which isn't in allTools here (F45). New re-points any
 	// Context tool to the COMPLETE post-append catalog, so don't set it here.
-	srv := lchttp.New(cfg, pr, allTools, sem, storeIface)
+	srv = lchttp.New(cfg, pr, allTools, sem, storeIface)
 	// RFC AR: stamp the credential resolver onto each run so a tenant/user's own
 	// provider key (ANTHROPIC_API_KEY, BRAVE_API_KEY, …) overrides the host key.
 	srv.SetCredentialResolver(credResolver)

--- a/internal/api/http/redact_emit_test.go
+++ b/internal/api/http/redact_emit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/redact"
 	"github.com/denn-gubsky/loomcycle/internal/store"
 	"github.com/denn-gubsky/loomcycle/internal/store/sqlite"
+	"github.com/denn-gubsky/loomcycle/internal/tools"
 )
 
 // emitFixture builds a Server over in-memory sqlite with a session + run, so a
@@ -63,7 +64,7 @@ func TestRecordingEmit_RedactsSecretInToolResult(t *testing.T) {
 	defer cleanup()
 
 	var forwarded providers.Event
-	emit := srv.makeRecordingEmit(ctx, runID, func(ev providers.Event) { forwarded = ev })
+	emit := srv.makeRecordingEmit(ctx, runID, tools.RunIdentityValue{}, "", func(ev providers.Event) { forwarded = ev })
 
 	input := json.RawMessage(`{"command":"curl -H \"Authorization: token ` + emitSecret + `\" https://gitea"}`)
 	emit(providers.Event{
@@ -99,7 +100,7 @@ func TestRecordingEmit_NoRedactorWhenDisabled(t *testing.T) {
 	srv, st, runID, ctx, cleanup := emitFixture(t, nil) // redaction disabled
 	defer cleanup()
 
-	emit := srv.makeRecordingEmit(ctx, runID, func(providers.Event) {})
+	emit := srv.makeRecordingEmit(ctx, runID, tools.RunIdentityValue{}, "", func(providers.Event) {})
 	emit(providers.Event{
 		Type:    providers.EventToolResult,
 		ToolUse: &providers.ToolUse{ID: "t1", Name: "Bash", Input: json.RawMessage(`{"x":"y"}`)},
@@ -123,7 +124,7 @@ func TestRecordingEmit_SpawnLedgerStoredNotForwarded(t *testing.T) {
 	defer cleanup()
 
 	forwarded := 0
-	emit := srv.makeRecordingEmit(ctx, runID, func(providers.Event) { forwarded++ })
+	emit := srv.makeRecordingEmit(ctx, runID, tools.RunIdentityValue{}, "", func(providers.Event) { forwarded++ })
 
 	for _, typ := range []providers.EventType{providers.EventSpawnChildStarted, providers.EventSpawnChildResult} {
 		emit(providers.Event{

--- a/internal/api/http/resume.go
+++ b/internal/api/http/resume.go
@@ -227,15 +227,9 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 	}
 	s.publishRunState(meta, "running", "", "")
 
-	// Store-only emit (no live client to forward to) — the resumed turns
-	// append to the same run's transcript so a re-attaching operator tails them.
-	emit := s.makeRecordingEmit(runCtx, run.ID, func(providers.Event) {})
-	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, run.ID, run.AgentID, run.SessionID, run.UserID, emit)
-
-	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
-	// RFC AR: honor a tenant/user provider-key override on the resumed run too.
-	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
-	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
+	// Hoisted above the recording emit so resumed-turn usage is attributed under
+	// the run's true identity (see makeRecordingEmit) and WithRunIdentity reuses it.
+	rid := tools.RunIdentityValue{
 		UserID:        run.UserID,
 		TenantID:      run.TenantID,
 		AgentID:       run.AgentID,
@@ -244,7 +238,16 @@ func (s *Server) resumePausedRun(ctx context.Context, run store.Run) error {
 		ParentContext: run.ParentContext,
 		// UserBearer / UserCredentials are intentionally absent — secrets are
 		// never snapshotted, so a resumed run cannot restore them.
-	})
+	}
+	// Store-only emit (no live client to forward to) — the resumed turns
+	// append to the same run's transcript so a re-attaching operator tails them.
+	emit := s.makeRecordingEmit(runCtx, run.ID, rid, run.SessionID, func(providers.Event) {})
+	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, run.ID, run.AgentID, run.SessionID, run.UserID, emit)
+
+	loopCtx := tools.WithAgentTools(runCtx, toolNames(allowedTools))
+	// RFC AR: honor a tenant/user provider-key override on the resumed run too.
+	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
+	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	loopCtx = tools.WithHostPolicy(loopCtx, tools.HostPolicyValue{}) // no caller narrowing snapshotted; operator floor applies
 	loopCtx = tools.WithAgentName(loopCtx, run.Agent)
 	loopCtx = tools.WithMemoryPolicy(loopCtx, tools.MemoryPolicyValue{

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -1997,7 +1997,20 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	}
 
 	// ---- Build emit chain (record + forward to caller) ----
-	emit := s.makeRecordingEmit(ctx, runID, func(ev providers.Event) {
+	// Hoisted so the recording emit attributes usage under the run's true
+	// identity (makeRecordingEmit is built before WithRunIdentity below) and
+	// both consumers stamp the SAME value.
+	rid := tools.RunIdentityValue{
+		UserID:          effectiveUserID,
+		TenantID:        effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
+		AgentID:         agentID,
+		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		UserTier:        in.UserTier,
+		UserBearer:      in.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials: in.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+	}
+	emit := s.makeRecordingEmit(ctx, runID, rid, sessionID, func(ev providers.Event) {
 		if cb.OnEvent != nil {
 			cb.OnEvent(ev)
 		}
@@ -2011,16 +2024,7 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
-	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:          effectiveUserID,
-		TenantID:        effectiveTenantID, // RFC L: authoritative tenant (memory tenancy key)
-		AgentID:         agentID,
-		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
-		UserTier:        in.UserTier,
-		UserBearer:      in.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: in.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   in.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
-	})
+	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	loopCtx = tools.WithHostPolicy(loopCtx, hostPolicy)
 	// Memory tool policy: agent name + per-agent scope allowlist +
 	// per-agent quota override. The Memory tool reads these from ctx
@@ -3389,9 +3393,23 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	if req.Interactive {
 		streamFwd = func(providers.Event) {}
 	}
+	// Stash the run's identity so the Agent built-in tool's SubAgentRunner can
+	// inherit user_id and set parent_agent_id on any sub-runs it spawns.
+	// Hoisted above the recording emit so usage is attributed under the run's
+	// true identity (see makeRecordingEmit) and WithRunIdentity below reuses it.
+	rid := tools.RunIdentityValue{
+		UserID:          req.UserID,
+		TenantID:        req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
+		AgentID:         agentID,
+		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
+		UserTier:        req.UserTier,
+		UserBearer:      req.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+	}
 	// Persist under runCtx so events survive a client disconnect on an
 	// interactive run (runCtx tracks the request for a normal run).
-	emit := s.makeRecordingEmit(runCtx, runID, streamFwd)
+	emit := s.makeRecordingEmit(runCtx, runID, rid, sessionID, streamFwd)
 
 	// PR 2: operator steering queue for this run (in-flight input injection).
 	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, runID, agentID, sessionID, req.UserID, emit)
@@ -3410,19 +3428,7 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
-	// Stash the run's identity so the Agent built-in tool's
-	// SubAgentRunner can inherit user_id and set parent_agent_id on
-	// any sub-runs it spawns.
-	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:          req.UserID,
-		TenantID:        req.TenantID, // RFC L: authoritative tenant (memory tenancy key)
-		AgentID:         agentID,
-		RootRunID:       runID, // RFC AH Phase 2b: top-level run roots its own spawn tree
-		UserTier:        req.UserTier,
-		UserBearer:      req.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: req.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   req.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
-	})
+	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	// Stash the caller's host policy so any sub-agents spawned by the
 	// Agent tool inherit the same allowed_hosts / WebSearchFilter
 	// narrowing the parent received.
@@ -3907,7 +3913,19 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		"parent_context":  body.ParentContext, // v0.12.x: opaque tracking lineage (nil when absent)
 	})
 
-	emit := s.makeRecordingEmit(r.Context(), run.ID, stream.send)
+	// Hoisted above the recording emit so usage is attributed under the run's
+	// true identity (see makeRecordingEmit) and WithRunIdentity below reuses it.
+	rid := tools.RunIdentityValue{
+		UserID:          sess.UserID,
+		TenantID:        sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
+		AgentID:         agentID,
+		RootRunID:       run.ID, // RFC AH Phase 2b: continuation roots its own spawn tree
+		UserTier:        body.UserTier,
+		UserBearer:      body.UserBearer,      // v0.8.x: per-run MCP bearer
+		UserCredentials: body.UserCredentials, // v1.x RFC F: per-tool named credentials
+		ParentContext:   body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
+	}
+	emit := s.makeRecordingEmit(r.Context(), run.ID, rid, id, stream.send)
 
 	// PR 2: operator steering queue for this continuation run.
 	steerQ, onSteer, deregSteer := s.makeSteer(r.Context(), run.ID, agentID, id, sess.UserID, emit)
@@ -3918,16 +3936,7 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 	// RFC AR: honor a tenant/user provider-key override (ANTHROPIC_API_KEY,
 	// BRAVE_API_KEY, …) for this run. Sub-agents inherit it via subRunCtx←ctx.
 	loopCtx = providers.WithCredentialResolver(loopCtx, s.credResolver)
-	loopCtx = tools.WithRunIdentity(loopCtx, tools.RunIdentityValue{
-		UserID:          sess.UserID,
-		TenantID:        sess.TenantID, // RFC L: tenant from the session (authoritative at creation)
-		AgentID:         agentID,
-		RootRunID:       run.ID, // RFC AH Phase 2b: continuation roots its own spawn tree
-		UserTier:        body.UserTier,
-		UserBearer:      body.UserBearer,      // v0.8.x: per-run MCP bearer
-		UserCredentials: body.UserCredentials, // v1.x RFC F: per-tool named credentials
-		ParentContext:   body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
-	})
+	loopCtx = tools.WithRunIdentity(loopCtx, rid)
 	// Sub-agents spawned by this continuation must inherit the
 	// caller-authoritative host narrowing, same as runRequest +
 	// handleRuns. Without this, a sub-agent runs against the
@@ -4380,7 +4389,13 @@ func (s *Server) makeSteer(ctx context.Context, runID, agentID, sessionID, userI
 	return q, onSteer, dereg
 }
 
-func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(providers.Event)) func(providers.Event) {
+// rid + sessionID are passed EXPLICITLY (not read from ctx) because this
+// closure is built BEFORE tools.WithRunIdentity is stamped on the loop ctx —
+// reading tools.RunIdentity(ctx) here returned the zero value, so every
+// directly-invoked run's token_usage rows were attributed to tenant/user/
+// agent "" (and a sub-agent's rows got the parent's identity). recordCallUsage
+// uses these captured values so attribution matches the run's true identity.
+func (s *Server) makeRecordingEmit(ctx context.Context, runID string, rid tools.RunIdentityValue, sessionID string, fwd func(providers.Event)) func(providers.Event) {
 	if s.store == nil || runID == "" {
 		// Even on the store-less path, multiple concurrent callers
 		// could write to fwd in parallel. fwd itself (stream.send)
@@ -4434,7 +4449,7 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 		// Additive side-effect — the event still persists + forwards through the
 		// general path below (it is also stored as a "usage" event, unchanged).
 		if ev.Type == providers.EventUsage && ev.Usage != nil {
-			s.recordCallUsage(ctx, runID, usageCallIdx, ev.Usage)
+			s.recordCallUsage(ctx, runID, rid, sessionID, usageCallIdx, ev.Usage)
 			usageCallIdx++
 		}
 		// F32: redact secrets out of the PERSISTED copy only — the tool_call
@@ -4474,14 +4489,15 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, fwd func(p
 
 // recordCallUsage appends one per-call token_usage row (RFC AV): who paid
 // (credential source from the driver-stamped Usage), what served it
-// (provider/model), the token buckets, and the priced cost. Identity comes from
-// the run ctx (never the wire). A store error is logged, not fatal — usage
-// telemetry must never fail a run.
-func (s *Server) recordCallUsage(ctx context.Context, runID string, iteration int, u *providers.Usage) {
+// (provider/model), the token buckets, and the priced cost. Identity (rid) +
+// sessionID are passed EXPLICITLY by the caller (never read from ctx / the
+// wire) — makeRecordingEmit is constructed before WithRunIdentity stamps the
+// loop ctx, so reading it here would attribute every row to "". A store error
+// is logged, not fatal — usage telemetry must never fail a run.
+func (s *Server) recordCallUsage(ctx context.Context, runID string, rid tools.RunIdentityValue, sessionID string, iteration int, u *providers.Usage) {
 	if s.store == nil || u == nil {
 		return
 	}
-	ri := tools.RunIdentity(ctx)
 	source := u.CredentialSource
 	if source == "" {
 		source = "operator" // no override fired → operator host key paid
@@ -4489,15 +4505,16 @@ func (s *Server) recordCallUsage(ctx context.Context, runID string, iteration in
 	// Attribute a sub-agent's call to its spawn-tree root so a fan-out's cost
 	// rolls up to the originating request; empty for a top-level run.
 	parentRunID := ""
-	if ri.RootRunID != "" && ri.RootRunID != runID {
-		parentRunID = ri.RootRunID
+	if rid.RootRunID != "" && rid.RootRunID != runID {
+		parentRunID = rid.RootRunID
 	}
 	cost, currency := s.priceCall(u.Provider, u.Model, u)
 	row := store.TokenUsageRow{
 		RunID:               runID,
-		TenantID:            ri.TenantID,
-		UserID:              ri.UserID,
-		AgentID:             ri.AgentID,
+		SessionID:           sessionID,
+		TenantID:            rid.TenantID,
+		UserID:              rid.UserID,
+		AgentID:             rid.AgentID,
 		ParentRunID:         parentRunID,
 		Iteration:           iteration,
 		Provider:            u.Provider,
@@ -4864,11 +4881,25 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// event payload includes agent_def_id — unique to this path.
 	s.emitSystemPromptEvent(ctx, subRunID, def.SystemPrompt, defID, promptProv)
 
+	// The sub-run's own identity — hoisted so its recording emit attributes
+	// usage to the SUB (tenant/user/agent/session), not the parent, and
+	// WithRunIdentity below stamps the identical value onto subCtx.
+	subRID := tools.RunIdentityValue{
+		UserID:          parentIdentity.UserID,
+		TenantID:        parentIdentity.TenantID, // RFC L: sub-agents inherit the parent's authoritative tenant (same isolation boundary)
+		AgentID:         subAgentID,
+		RootRunID:       parentIdentity.RootRunID,             // RFC AH Phase 2b: INHERIT the tree's root id (do NOT overwrite)
+		UserTier:        parentIdentity.UserTier,              // v0.8.2: sub-agents inherit parent's user_tier
+		AgentDefID:      defID,                                // v0.8.7: surface pinned def_id via Context.self
+		UserBearer:      parentIdentity.UserBearer,            // v0.8.x: bearer inherited identically (same end-user)
+		UserCredentials: parentIdentity.UserCredentials,       // v1.x RFC F: credentials map inherited identically
+		ParentContext:   parentIdentity.ParentContext.Clone(), // v0.12.x: tracking lineage flows to grandchildren too
+	}
 	// Sub-emit records to the sub's transcript only — the parent's SSE
 	// stream is fwd=no-op so sub events don't bleed into the parent's
 	// event stream. The parent observes only the wrapping
 	// tool_call/tool_result on its own stream.
-	subEmit := s.makeRecordingEmit(ctx, subRunID, func(providers.Event) {})
+	subEmit := s.makeRecordingEmit(ctx, subRunID, subRID, subSessionID, func(providers.Event) {})
 
 	// Sub-run gets ITS OWN agent tools attached to ctx — the parent's
 	// tool list does not leak to the child (and vice versa). This
@@ -4879,17 +4910,7 @@ func (s *Server) runSubAgent(ctx context.Context, name string, prompt string, de
 	// recursive Agent tool call from this sub picks up the right
 	// parent_agent_id (= subAgentID).
 	subCtx := tools.WithAgentTools(subRunCtx, toolNames(subTools))
-	subCtx = tools.WithRunIdentity(subCtx, tools.RunIdentityValue{
-		UserID:          parentIdentity.UserID,
-		TenantID:        parentIdentity.TenantID, // RFC L: sub-agents inherit the parent's authoritative tenant (same isolation boundary)
-		AgentID:         subAgentID,
-		RootRunID:       parentIdentity.RootRunID,             // RFC AH Phase 2b: INHERIT the tree's root id (do NOT overwrite)
-		UserTier:        parentIdentity.UserTier,              // v0.8.2: sub-agents inherit parent's user_tier
-		AgentDefID:      defID,                                // v0.8.7: surface pinned def_id via Context.self
-		UserBearer:      parentIdentity.UserBearer,            // v0.8.x: bearer inherited identically (same end-user)
-		UserCredentials: parentIdentity.UserCredentials,       // v1.x RFC F: credentials map inherited identically
-		ParentContext:   parentIdentity.ParentContext.Clone(), // v0.12.x: tracking lineage flows to grandchildren too
-	})
+	subCtx = tools.WithRunIdentity(subCtx, subRID)
 	subCtx = tools.WithAgentName(subCtx, name)
 	// Sub-agents get THEIR OWN Memory policy from yaml — the parent's
 	// memory_scopes do NOT cascade. This matches the existing

--- a/internal/api/http/usage_attribution_test.go
+++ b/internal/api/http/usage_attribution_test.go
@@ -133,3 +133,85 @@ func TestUsageAttribution_RecordsPerCallLedgerAndRunSummary(t *testing.T) {
 		t.Errorf("run B summary source = %q, want operator", runB.CredentialSource)
 	}
 }
+
+// TestUsageAttribution_LedgerRowCarriesRunIdentity is the fix-1 regression: a
+// top-level run's per-call token_usage row must be attributed to the run's TRUE
+// identity — tenant/user/agent + session — not the zero value. makeRecordingEmit
+// was constructed BEFORE tools.WithRunIdentity stamped the loop ctx, so
+// recordCallUsage read tools.RunIdentity(ctx) == zero and every directly-invoked
+// run's ledger rows landed with tenant_id/user_id/agent_id all "" and session_id
+// unset. Fails on the pre-fix code (all four fields empty).
+func TestUsageAttribution_LedgerRowCarriesRunIdentity(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "stub-model"},
+		Agents: map[string]config.AgentDef{
+			"solo": {Model: "stub-model", SystemPrompt: "you are solo"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+		Pricing: config.PricingConfig{
+			Currency: "USD",
+			Models:   map[string]config.ModelPrice{"scripted/stub-model": {Input: 3, Output: 15}},
+		},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			{
+				{Type: providers.EventText, Text: "hi"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{
+					InputTokens: 1000, OutputTokens: 500, Model: "stub-model"}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "usage.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	// Open mode (AuthToken=="") passes wire tenant/user/agent_id through verbatim.
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"solo","agent_id":"agent-77","user_id":"u-alice","tenant_id":"acme","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, b)
+	}
+	_, _ = io.ReadAll(resp.Body) // drain to completion (recordCallUsage runs in-path)
+
+	ctx := context.Background()
+	run, err := st.GetRunByAgentID(ctx, "agent-77")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID(agent-77): %v", err)
+	}
+	rows, err := st.TokenUsageForRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("ledger rows = %d, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.TenantID != "acme" {
+		t.Errorf("row TenantID = %q, want acme", r.TenantID)
+	}
+	if r.UserID != "u-alice" {
+		t.Errorf("row UserID = %q, want u-alice", r.UserID)
+	}
+	if r.AgentID != "agent-77" {
+		t.Errorf("row AgentID = %q, want agent-77", r.AgentID)
+	}
+	if r.SessionID == "" || r.SessionID != run.SessionID {
+		t.Errorf("row SessionID = %q, want run's session %q", r.SessionID, run.SessionID)
+	}
+}

--- a/internal/credential/engine.go
+++ b/internal/credential/engine.go
@@ -30,6 +30,15 @@ func NewEngine(st store.Store, sealer *Sealer) *Engine {
 // InlineEnabled reports whether inline (encrypted) credentials can be stored.
 func (e *Engine) InlineEnabled() bool { return e.sealer.Enabled() }
 
+// CanResolve reports whether ANY credential could ever resolve in this build.
+// The inline backend needs the Sealer enabled (a configured KEK); external
+// backends are unimplemented stubs (RFC AR Phase 4), so nothing can resolve
+// through them yet. When this is false, the $cred: / provider-key resolvers skip
+// the per-call store reads entirely — with no way to resolve, the three scope
+// lookups on every LLM call would only ever miss. Extend the disjunction here
+// once an external backend is wired + configured.
+func (e *Engine) CanResolve() bool { return e.sealer.Enabled() }
+
 // PutInline seals plaintext and upserts the row (create / update / rotate —
 // rotation re-seals in place with a fresh nonce). Returns row METADATA only
 // (Definition stripped). Fails with ErrNoKey when no KEK is configured.

--- a/internal/credential/substitute.go
+++ b/internal/credential/substitute.go
@@ -14,6 +14,23 @@ var credTokenRe = regexp.MustCompile(`\$cred:([A-Za-z0-9_-]{1,128})`)
 // so callers skip the resolve path entirely when there's nothing to bind).
 func HasRef(s string) bool { return credTokenRe.MatchString(s) }
 
+// RefNames returns the <name> of every $cred:<name> token in s (nil when none).
+// The resolver fast-path uses it to report refs as unresolved WITHOUT a store
+// read when the engine can't resolve anything (CanResolve()==false) — so the
+// caller still drops those headers/env entries instead of sending a literal
+// "$cred:foo" downstream.
+func RefNames(s string) []string {
+	ms := credTokenRe.FindAllStringSubmatch(s, -1)
+	if len(ms) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, m[1])
+	}
+	return out
+}
+
 // Substitute replaces every $cred:<name> token in s with the resolved plaintext
 // credential for the given run identity (scope precedence agent > user > tenant,
 // so a user's own token shadows the tenant default). This is the runtime-side

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -15,9 +15,11 @@
 //     env, e.g. a token an agent fetched at runtime). Each rule targets a
 //     distinctive secret shape; see patternRules for the per-rule rationale.
 //
-// A Redactor is built once and is safe for concurrent String/Bytes calls (its
-// compiled state is read-only after New). The zero value / a nil *Redactor is a
-// no-op, so callers may hold a nil redactor when redaction is disabled.
+// A Redactor's static tiers are fixed at New; runtime-resolved secret values may
+// be added later via Register (RFC AV/AR). It is safe for concurrent
+// String/Bytes/Register calls — the registered set is guarded by an RWMutex. The
+// zero value / a nil *Redactor is a no-op, so callers may hold a nil redactor
+// when redaction is disabled.
 package redact
 
 import (
@@ -25,6 +27,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 )
 
 // minSecretLen is the shortest env value Tier A will mask. A shorter value is
@@ -32,10 +35,31 @@ import (
 // (e.g. an env var that happens to be set to "true") would be a false positive.
 const minSecretLen = 8
 
+// minDynamicSecretLen is the shortest runtime-registered (Register) value we
+// mask. Registered values are EXACT known secrets (zero false positives on the
+// exact string), so the floor only guards against masking trivially short
+// values that would appear everywhere.
+const minDynamicSecretLen = 4
+
+// dynamicMarker replaces a runtime-registered secret value. Register carries no
+// env NAME (the value is resolved at run time, e.g. an RFC AR $cred:), so unlike
+// Tier A's [redacted:NAME] the marker is generic.
+const dynamicMarker = "[redacted:credential]"
+
 // Redactor masks secret-shaped substrings.
 type Redactor struct {
 	replacer *strings.Replacer // Tier A: exact env-value → [redacted:NAME]; nil if none
 	patterns []patternRule     // Tier B: nil when patterns are disabled
+
+	// Tier A' — runtime-registered exact secret values (RFC AV/AR: resolved
+	// $cred: values + provider-key overrides). Registered as credentials resolve,
+	// so a downstream tool that echoes one is masked in the persisted transcript.
+	// dynamic is the deduped value set (bounds the inventory); dynReplacer is its
+	// compiled longest-first form, applied in String. Guarded by mu — Register
+	// takes Lock, String takes RLock.
+	mu          sync.RWMutex
+	dynamic     map[string]struct{}
+	dynReplacer *strings.Replacer
 }
 
 type patternRule struct {
@@ -103,14 +127,58 @@ func New(secrets map[string]string, withPatterns bool) *Redactor {
 	return r
 }
 
+// Register adds a runtime-resolved secret VALUE so a later tool_call/tool_result
+// that echoes it is masked in the persisted transcript (RFC AV/AR). Thread-safe
+// and safe to call concurrently with String/Bytes. Deduped by value (re-
+// registering is a no-op) so the set stays bounded by the distinct-credential
+// inventory, not per call. Values shorter than minDynamicSecretLen and a nil
+// redactor are ignored.
+func (r *Redactor) Register(value string) {
+	if r == nil || len(value) < minDynamicSecretLen {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, dup := r.dynamic[value]; dup {
+		return // already registered — keep the set bounded
+	}
+	if r.dynamic == nil {
+		r.dynamic = make(map[string]struct{})
+	}
+	r.dynamic[value] = struct{}{}
+	// Rebuild the replacer longest-value-first so a value that is a substring of
+	// another is masked as part of the longer match first (mirrors New's Tier A).
+	vals := make([]string, 0, len(r.dynamic))
+	for v := range r.dynamic {
+		vals = append(vals, v)
+	}
+	sort.Slice(vals, func(i, j int) bool { return len(vals[i]) > len(vals[j]) })
+	pairs := make([]string, 0, len(vals)*2)
+	for _, v := range vals {
+		pairs = append(pairs, v, dynamicMarker)
+	}
+	r.dynReplacer = strings.NewReplacer(pairs...)
+}
+
 // Enabled reports whether the redactor would mask anything. A no-op / nil
-// redactor returns false, letting callers skip the copy on the hot path.
+// redactor returns false, letting callers skip the copy on the hot path. When
+// static tiers are absent it consults the runtime-registered set under RLock;
+// the common case (patterns on) short-circuits before the lock.
 func (r *Redactor) Enabled() bool {
-	return r != nil && (r.replacer != nil || len(r.patterns) > 0)
+	if r == nil {
+		return false
+	}
+	if r.replacer != nil || len(r.patterns) > 0 {
+		return true
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.dynReplacer != nil
 }
 
 // String returns s with every recognised secret masked. Tier A (exact env
-// values) runs first, then the Tier-B patterns.
+// values) runs first, then the Tier-B patterns, then the runtime-registered
+// values (Tier A').
 func (r *Redactor) String(s string) string {
 	if !r.Enabled() || s == "" {
 		return s
@@ -120,6 +188,12 @@ func (r *Redactor) String(s string) string {
 	}
 	for _, p := range r.patterns {
 		s = p.re.ReplaceAllString(s, p.repl)
+	}
+	r.mu.RLock()
+	dyn := r.dynReplacer
+	r.mu.RUnlock()
+	if dyn != nil {
+		s = dyn.Replace(s)
 	}
 	return s
 }

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -137,3 +137,93 @@ func TestRedactor_NoOp(t *testing.T) {
 		t.Errorf("empty redactor mutated input: %q", got)
 	}
 }
+
+// TestRedactor_RegisterMasksDynamicValue is the fix-5 regression: a
+// runtime-resolved credential value (RFC AV/AR $cred: / provider-key override)
+// registered via Register is masked in a later transcript string — AND is left
+// intact BEFORE registration (a value the redactor doesn't hold isn't masked).
+// The pre-fix wiring passed register=nil, so a downstream echo of a resolved
+// credential persisted in cleartext.
+func TestRedactor_RegisterMasksDynamicValue(t *testing.T) {
+	// Patterns-only redactor: the raw credential doesn't match any Tier-B shape,
+	// and the surrounding text names no secret-shaped key, so it's masked ONLY
+	// because Register added it.
+	r := New(nil, true)
+	const secret = "aa11-bb22-cc33-dd44" // not a recognised secret shape
+
+	before := r.String("the value is " + secret + " today")
+	if !strings.Contains(before, secret) {
+		t.Fatalf("value should NOT be masked before Register; got %q", before)
+	}
+
+	r.Register(secret)
+	after := r.String("the value is " + secret + " today")
+	if strings.Contains(after, secret) {
+		t.Errorf("registered value survived redaction: %q", after)
+	}
+	if !strings.Contains(after, "[redacted:credential]") {
+		t.Errorf("expected the credential marker; got %q", after)
+	}
+	// Also masked inside a JSON leaf via Bytes.
+	b := r.Bytes(json.RawMessage(`{"note":"the value is ` + secret + ` here"}`))
+	if strings.Contains(string(b), secret) {
+		t.Errorf("registered value survived Bytes redaction: %s", b)
+	}
+}
+
+// TestRedactor_RegisterEnablesOtherwiseEmpty — an otherwise no-op redactor (no
+// env values, patterns off) becomes Enabled once a value is registered, so the
+// emit path (which gates on Enabled) actually applies it.
+func TestRedactor_RegisterEnablesOtherwiseEmpty(t *testing.T) {
+	r := New(nil, false)
+	if r.Enabled() {
+		t.Fatal("empty redactor should start disabled")
+	}
+	r.Register("super-secret-value")
+	if !r.Enabled() {
+		t.Error("redactor should be Enabled after Register")
+	}
+	if got := r.String("x super-secret-value y"); strings.Contains(got, "super-secret-value") {
+		t.Errorf("registered value not masked: %q", got)
+	}
+}
+
+// TestRedactor_RegisterDedupAndShortIgnored — re-registering the same value is a
+// no-op (the set stays bounded), and a too-short value is ignored (won't mask
+// noise).
+func TestRedactor_RegisterDedupAndShortIgnored(t *testing.T) {
+	r := New(nil, false)
+	r.Register("abcd-token-value")
+	r.Register("abcd-token-value") // dedup — no-op
+	if got := len(r.dynamic); got != 1 {
+		t.Errorf("dynamic set size = %d, want 1 after duplicate Register", got)
+	}
+	r.Register("xy") // below minDynamicSecretLen — ignored
+	if got := len(r.dynamic); got != 1 {
+		t.Errorf("dynamic set size = %d, want 1 (short value ignored)", got)
+	}
+}
+
+// TestRedactor_RegisterNilNoOp — Register on a nil redactor is a no-op (callers
+// hold a nil redactor when redaction is disabled).
+func TestRedactor_RegisterNilNoOp(t *testing.T) {
+	var nilR *Redactor
+	nilR.Register("whatever-value") // must not panic
+}
+
+// TestRedactor_RegisterConcurrent asserts concurrent Register + String don't
+// race (run under -race). Guards the RWMutex around the dynamic set.
+func TestRedactor_RegisterConcurrent(t *testing.T) {
+	r := New(nil, true)
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 500; i++ {
+			r.Register("secret-value-" + string(rune('A'+i%26)))
+		}
+		close(done)
+	}()
+	for i := 0; i < 500; i++ {
+		_ = r.String("some text with secret-value-A embedded")
+	}
+	<-done
+}

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -533,14 +533,25 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 	n := 0
 	ph := func(v any) string { n++; args = append(args, v); return fmt.Sprintf("$%d", n) }
 	// Build a per-source WHERE (tenant + window). Called token_usage first so the
-	// placeholder order in args matches the SQL text order.
-	where := func(tsCol string) string {
+	// placeholder order in args matches the SQL text order. token_usage windows on
+	// ts (exact); usage_archive on period_start (day-truncated UTC midnight), so
+	// its `from` bound is floored to the UTC day — see below.
+	where := func(tsCol string, floorFromDay bool) string {
 		var conds []string
 		if q.TenantID != "" {
 			conds = append(conds, "tenant_id = "+ph(q.TenantID))
 		}
 		if !q.From.IsZero() {
-			conds = append(conds, tsCol+" >= "+ph(q.From))
+			if floorFromDay {
+				// The archive is day-bucketed (period_start = UTC midnight), so an
+				// intra-day `from` (e.g. 12:00) compared exactly would drop the whole
+				// from-day bucket (period_start 00:00 < 12:00). Floor `from` to its
+				// UTC day so that bucket is included. This makes the boundary day
+				// over-inclusive at day granularity — never under-inclusive.
+				conds = append(conds, tsCol+" >= date_trunc('day', "+ph(q.From)+"::timestamptz AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'")
+			} else {
+				conds = append(conds, tsCol+" >= "+ph(q.From))
+			}
 		}
 		if !q.To.IsZero() {
 			conds = append(conds, tsCol+" <= "+ph(q.To))
@@ -550,8 +561,8 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		}
 		return " WHERE " + strings.Join(conds, " AND ")
 	}
-	tuWhere := where("ts")
-	uaWhere := where("period_start")
+	tuWhere := where("ts", false)
+	uaWhere := where("period_start", true)
 
 	inner := `SELECT tenant_id, COALESCE(user_id,'') AS user_id, provider, model, credential_source,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
@@ -598,7 +609,9 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 // RollupAndPruneUsage folds token_usage rows older than olderThan into
 // usage_archive (day-bucketed via date_trunc) and deletes them, in one
 // transaction (RFC AV Phase 2b). Idempotent via the archive PK. Returns the raw
-// rows pruned.
+// rows pruned. The day bucket is computed in UTC (date_trunc over ts AT TIME
+// ZONE 'UTC', re-stamped back to timestamptz) so period_start is UTC midnight
+// regardless of the session TZ — matching sqlite's UTC (ts/nanosPerDay) bucket.
 func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (int, error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -610,12 +623,12 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 		INSERT INTO usage_archive (period_start, tenant_id, user_id, provider, model, credential_source,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
 			cost, cost_currency, call_count, unpriced_calls)
-		SELECT date_trunc('day', ts) AS period_start, tenant_id, COALESCE(user_id,''), provider, model, credential_source,
+		SELECT date_trunc('day', ts AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS period_start, tenant_id, COALESCE(user_id,''), provider, model, credential_source,
 			SUM(input_tokens), SUM(output_tokens), SUM(cache_creation_tokens), SUM(cache_read_tokens),
 			SUM(COALESCE(cost,0)), COALESCE(MAX(cost_currency),''),
 			COUNT(*), SUM(CASE WHEN cost IS NULL THEN 1 ELSE 0 END)
 		FROM token_usage WHERE ts < $1
-		GROUP BY date_trunc('day', ts), tenant_id, COALESCE(user_id,''), provider, model, credential_source
+		GROUP BY date_trunc('day', ts AT TIME ZONE 'UTC') AT TIME ZONE 'UTC', tenant_id, COALESCE(user_id,''), provider, model, credential_source
 		ON CONFLICT (period_start, tenant_id, user_id, provider, model, credential_source) DO UPDATE SET
 			input_tokens          = usage_archive.input_tokens + excluded.input_tokens,
 			output_tokens         = usage_archive.output_tokens + excluded.output_tokens,
@@ -640,12 +653,46 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 	return pruned, nil
 }
 
-// PrunableCompletedRuns lists terminal runs older than olderThan (RFC AV Phase
-// 2b2). completed_at is TIMESTAMPTZ here.
-func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]store.Run, error) {
+// PrunableAgedSessions lists sessions where EVERY run is terminal + old (RFC AV
+// Phase 2b2). completed_at is TIMESTAMPTZ here. A session qualifies only when it
+// has no run in a non-terminal state (running/paused/pausing, by status OR
+// pause_state) and its most-recent completed_at is before olderThan — so an aged
+// run inside a still-active session is never pruned out from under a
+// continuation's whole-session transcript replay.
+func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error) {
 	if limit <= 0 {
 		limit = 500
 	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT session_id FROM runs
+		 GROUP BY session_id
+		 HAVING SUM(CASE WHEN status NOT IN ($1, $2, $3)
+		                   OR pause_state IN ('paused', 'pausing')
+		                 THEN 1 ELSE 0 END) = 0
+		    AND MAX(completed_at) IS NOT NULL
+		    AND MAX(completed_at) < $4
+		 ORDER BY MAX(completed_at) ASC
+		 LIMIT $5`,
+		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),
+		olderThan, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list prunable sessions: %w", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan prunable session id: %w", err)
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// RunsForSession returns every run in the session (any status), oldest first.
+func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.Run, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT r.id, r.session_id, r.status, r.started_at, r.completed_at, r.stop_reason,
 		        r.input_tokens, r.output_tokens, r.cache_creation_tokens, r.cache_read_tokens,
@@ -655,31 +702,34 @@ func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, 
 		        r.cost, r.cost_currency, r.credential_source, r.credential_scope_id,
 		        s.agent
 		 FROM runs r LEFT JOIN sessions s ON r.session_id = s.id
-		 WHERE r.status IN ($1, $2, $3) AND r.completed_at IS NOT NULL AND r.completed_at < $4
-		 ORDER BY r.completed_at ASC LIMIT $5`,
-		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),
-		olderThan, limit,
+		 WHERE r.session_id = $1
+		 ORDER BY r.started_at ASC`,
+		sessionID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("list prunable runs: %w", err)
+		return nil, fmt.Errorf("list runs for session: %w", err)
 	}
 	defer rows.Close()
 	return scanRunRows(rows)
 }
 
-// DeleteRunAndEvents deletes a run + its events in one tx (RFC AV Phase 2b2).
-// Events removed explicitly; token_usage intentionally left (own retention).
-func (s *Store) DeleteRunAndEvents(ctx context.Context, runID string) error {
+// DeleteSessionCascade deletes a session + all its runs + events in one tx (RFC
+// AV Phase 2b2). Events + runs removed explicitly, then the session row;
+// token_usage intentionally left (own retention).
+func (s *Store) DeleteSessionCascade(ctx context.Context, sessionID string) error {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin delete-run tx: %w", err)
+		return fmt.Errorf("begin delete-session tx: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
-	if _, err := tx.Exec(ctx, `DELETE FROM events WHERE run_id = $1`, runID); err != nil {
-		return fmt.Errorf("delete run events: %w", err)
+	if _, err := tx.Exec(ctx, `DELETE FROM events WHERE session_id = $1`, sessionID); err != nil {
+		return fmt.Errorf("delete session events: %w", err)
 	}
-	if _, err := tx.Exec(ctx, `DELETE FROM runs WHERE id = $1`, runID); err != nil {
-		return fmt.Errorf("delete run: %w", err)
+	if _, err := tx.Exec(ctx, `DELETE FROM runs WHERE session_id = $1`, sessionID); err != nil {
+		return fmt.Errorf("delete session runs: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `DELETE FROM sessions WHERE id = $1`, sessionID); err != nil {
+		return fmt.Errorf("delete session: %w", err)
 	}
 	return tx.Commit(ctx)
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1347,9 +1347,11 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 			dimExprs = append(dimExprs, "''")
 		}
 	}
-	// Per-source WHERE (tenant + window). token_usage windows on ts; usage_archive
-	// on period_start. Args are appended in placeholder order (token_usage first).
-	where := func(tsCol string) (string, []any) {
+	// Per-source WHERE (tenant + window). token_usage windows on ts (exact);
+	// usage_archive on period_start (day-truncated UTC midnight). Args are
+	// appended in placeholder order (token_usage first). floorFromDay floors the
+	// `from` bound to its UTC day for the archive branch — see below.
+	where := func(tsCol string, floorFromDay bool) (string, []any) {
 		var conds []string
 		var args []any
 		if q.TenantID != "" {
@@ -1358,7 +1360,16 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		}
 		if !q.From.IsZero() {
 			conds = append(conds, tsCol+" >= ?")
-			args = append(args, q.From.UnixNano())
+			from := q.From.UnixNano()
+			if floorFromDay {
+				// The archive is day-bucketed (period_start = UTC midnight), so an
+				// intra-day `from` (e.g. 12:00) compared exactly would drop the whole
+				// from-day bucket (period_start 00:00 < 12:00). Floor `from` to its
+				// UTC day so that bucket is included. This makes the boundary day
+				// over-inclusive at day granularity — never under-inclusive.
+				from = (from / nanosPerDay) * nanosPerDay
+			}
+			args = append(args, from)
 		}
 		if !q.To.IsZero() {
 			conds = append(conds, tsCol+" <= ?")
@@ -1369,8 +1380,8 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		}
 		return " WHERE " + strings.Join(conds, " AND "), args
 	}
-	tuWhere, tuArgs := where("ts")
-	uaWhere, uaArgs := where("period_start")
+	tuWhere, tuArgs := where("ts", false)
+	uaWhere, uaArgs := where("period_start", true)
 
 	inner := `SELECT tenant_id, COALESCE(user_id,'') AS user_id, provider, model, credential_source,
 			input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
@@ -1460,18 +1471,49 @@ func (s *Store) RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (i
 	return int(n), nil
 }
 
-// PrunableCompletedRuns lists terminal runs older than olderThan (RFC AV Phase
-// 2b2). completed_at is unix-nano here.
-func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]store.Run, error) {
+// PrunableAgedSessions lists sessions where EVERY run is terminal + old (RFC AV
+// Phase 2b2). completed_at is unix-nano here. A session qualifies only when it
+// has no run in a non-terminal state (running/paused/pausing, by status OR
+// pause_state) and its most-recent completed_at is before olderThan — so an
+// aged run inside a still-active session is never pruned out from under a
+// continuation's whole-session transcript replay.
+func (s *Store) PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error) {
 	if limit <= 0 {
 		limit = 500
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT `+runColumns+` FROM `+runFromTable+`
-		 WHERE r.status IN (?, ?, ?) AND r.completed_at IS NOT NULL AND r.completed_at < ?
-		 ORDER BY r.completed_at ASC LIMIT ?`,
+		`SELECT session_id FROM runs
+		 GROUP BY session_id
+		 HAVING SUM(CASE WHEN status NOT IN (?, ?, ?)
+		                   OR pause_state IN ('paused', 'pausing')
+		                 THEN 1 ELSE 0 END) = 0
+		    AND MAX(completed_at) IS NOT NULL
+		    AND MAX(completed_at) < ?
+		 ORDER BY MAX(completed_at) ASC
+		 LIMIT ?`,
 		string(store.RunCompleted), string(store.RunFailed), string(store.RunCancelled),
 		olderThan.UnixNano(), limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
+// RunsForSession returns every run in the session (any status), oldest first.
+func (s *Store) RunsForSession(ctx context.Context, sessionID string) ([]store.Run, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+runColumns+` FROM `+runFromTable+` WHERE r.session_id = ? ORDER BY r.started_at ASC`,
+		sessionID,
 	)
 	if err != nil {
 		return nil, err
@@ -1488,19 +1530,23 @@ func (s *Store) PrunableCompletedRuns(ctx context.Context, olderThan time.Time, 
 	return out, rows.Err()
 }
 
-// DeleteRunAndEvents deletes a run + its events in one tx (RFC AV Phase 2b2).
-// Events are removed explicitly (not via FK cascade) so behavior is identical
-// regardless of the foreign_keys pragma; token_usage is intentionally left.
-func (s *Store) DeleteRunAndEvents(ctx context.Context, runID string) error {
+// DeleteSessionCascade deletes a session + all its runs + events in one tx (RFC
+// AV Phase 2b2). Events + runs are removed explicitly (not via FK cascade) so
+// behavior is identical regardless of the foreign_keys pragma; token_usage is
+// intentionally left (independent retention).
+func (s *Store) DeleteSessionCascade(ctx context.Context, sessionID string) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE run_id = ?`, runID); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM events WHERE session_id = ?`, sessionID); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `DELETE FROM runs WHERE id = ?`, runID); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM runs WHERE session_id = ?`, sessionID); err != nil {
+		return err
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE id = ?`, sessionID); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -392,6 +392,11 @@ type UsageQuery struct {
 	// enforces this via principalTenantScope).
 	TenantID string
 	// From/To bound the window on ts (inclusive); zero = unbounded on that end.
+	// The recent (token_usage) rows are bounded EXACTLY. The archived (day-
+	// bucketed usage_archive) rows are bounded at DAY GRANULARITY: the `from`
+	// bound is floored to its UTC day so an intra-day `from` still includes that
+	// whole day's bucket (over-inclusive on the boundary day, never under). `to`
+	// naturally includes the to-day (a day-start period_start <= to).
 	From, To time.Time
 	// GroupBy is the ordered set of dimensions to group by (validated against the
 	// UsageBy* whitelist). Empty ⇒ a single grand-total row.
@@ -666,17 +671,25 @@ type Store interface {
 	// pruned. The rollup-and-prune sweeper calls this on a timer (RFC AV Phase 2b).
 	RollupAndPruneUsage(ctx context.Context, olderThan time.Time) (pruned int, err error)
 
-	// PrunableCompletedRuns returns terminal (completed/failed/cancelled) runs
-	// whose completed_at is older than olderThan, oldest first, capped at limit.
-	// The old-run archiver (RFC AV Phase 2b2) lists these to export and/or
-	// delete. Non-terminal runs (running/paused/pausing) are never returned.
-	PrunableCompletedRuns(ctx context.Context, olderThan time.Time, limit int) ([]Run, error)
+	// PrunableAgedSessions returns session ids where EVERY run is terminal
+	// (completed/failed/cancelled) with no run running/paused/pausing, and the
+	// session's most-recent completed_at is older than olderThan. Oldest first,
+	// capped at limit. The archiver (RFC AV Phase 2b2) prunes by SESSION, not by
+	// run — the continuation path replays GetTranscript(session_id) (all runs),
+	// so pruning one aged run inside a still-continued session would corrupt the
+	// transcript. A session with any non-terminal run is never returned.
+	PrunableAgedSessions(ctx context.Context, olderThan time.Time, limit int) ([]string, error)
 
-	// DeleteRunAndEvents deletes a run and its events in one transaction (events
-	// removed explicitly, not relying on FK cascade). token_usage rows are LEFT
-	// INTACT — usage has its own retention (RollupAndPruneUsage), and the usage
-	// report does not join runs. RFC AV Phase 2b2.
-	DeleteRunAndEvents(ctx context.Context, runID string) error
+	// RunsForSession returns every run in the session (any status), oldest first.
+	// The archiver uses it to export a session's runs before cascade-deleting it.
+	RunsForSession(ctx context.Context, sessionID string) ([]Run, error)
+
+	// DeleteSessionCascade deletes a session and all its runs + events in one
+	// transaction (events + runs removed explicitly, then the session row).
+	// token_usage rows are LEFT INTACT — usage has its own retention
+	// (RollupAndPruneUsage), and the usage report does not join runs/sessions.
+	// RFC AV Phase 2b2.
+	DeleteSessionCascade(ctx context.Context, sessionID string) error
 
 	// GetTranscript returns all events for a session, ordered by Seq.
 	// Returns an empty slice (not error) for a session with no runs yet.

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -340,7 +340,8 @@ func Run(t *testing.T, factory Factory) {
 		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
 		{"UsageReport", testUsageReport},
 		{"UsageRollupAndPrune", testUsageRollupAndPrune},
-		{"RunArchiver", testRunArchiver},
+		{"UsageReportArchiveWindowBoundary", testUsageReportArchiveWindowBoundary},
+		{"SessionArchiver", testSessionArchiver},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
 		// ordinals on a REAL backend (the go-postgres CI job) — SQLite skips
@@ -805,67 +806,142 @@ func testUsageRollupAndPrune(t *testing.T, s store.Store) {
 	}
 }
 
-// testRunArchiver exercises RFC AV Phase 2b2: PrunableCompletedRuns lists only
-// terminal runs within the age cutoff, and DeleteRunAndEvents removes the run +
-// its events while leaving token_usage (independent retention) intact.
-func testRunArchiver(t *testing.T, s store.Store) {
+// testUsageReportArchiveWindowBoundary is the fix-3 regression: an intra-day
+// `from` must still include the from-day's archived (day-bucketed) bucket. The
+// archive stores period_start at UTC midnight, so comparing an intra-day `from`
+// (e.g. 12:00) EXACTLY dropped the whole from-day bucket (period_start 00:00 <
+// 12:00). The report floors the archive `from` bound to its UTC day. A row on an
+// EARLIER day stays excluded — the floor extends only to the from-day, never
+// under. Fails on the pre-fix code (from-day bucket dropped → 0 rows).
+func testUsageReportArchiveWindowBoundary(t *testing.T, s store.Store) {
 	ctx := context.Background()
-	sess, _ := s.CreateSession(ctx, "t", "default", "")
+	day := func(y int, m time.Month, d, h int) time.Time {
+		return time.Date(y, m, d, h, 0, 0, 0, time.UTC)
+	}
+	// fromDay row (08:00, same UTC day as the intra-day `from` at 12:00) → its
+	// bucket must be INCLUDED. priorDay row (the day before) → EXCLUDED.
+	rows := []store.TokenUsageRow{
+		{RunID: "r_fromday", TenantID: "WB", Provider: "p", Model: "m",
+			CredentialSource: "operator", InputTokens: 100, Cost: 1.0, CostCurrency: "USD", TS: day(2026, 3, 15, 8)},
+		{RunID: "r_priorday", TenantID: "WB", Provider: "p", Model: "m",
+			CredentialSource: "operator", InputTokens: 999, Cost: 9.0, CostCurrency: "USD", TS: day(2026, 3, 14, 8)},
+	}
+	for _, r := range rows {
+		if err := s.RecordCallUsage(ctx, r); err != nil {
+			t.Fatalf("RecordCallUsage: %v", err)
+		}
+	}
+	// Roll both rows into the day-bucketed archive (cutoff after both).
+	if _, err := s.RollupAndPruneUsage(ctx, day(2026, 3, 16, 0)); err != nil {
+		t.Fatalf("RollupAndPruneUsage: %v", err)
+	}
 
-	// runA: completed, with events + a usage row. runB: completed. runC: running.
-	runA, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-a"})
-	runB, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-b"})
-	runC, _ := s.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "arch-c"}) // stays running
+	// Query with an intra-day `from` (12:00 on the from-day) — the from-day
+	// bucket must survive; the prior day must not.
+	rep, err := s.UsageReport(ctx, store.UsageQuery{
+		From:    day(2026, 3, 15, 12),
+		GroupBy: []store.UsageDimension{store.UsageByTenant},
+	})
+	if err != nil {
+		t.Fatalf("UsageReport: %v", err)
+	}
+	if len(rep) != 1 {
+		t.Fatalf("report rows = %d, want 1 (the from-day bucket): %+v", len(rep), rep)
+	}
+	if rep[0].InputTokens != 100 {
+		t.Errorf("windowed archive report = %d tokens, want 100 (from-day bucket included, prior day excluded)", rep[0].InputTokens)
+	}
+}
+
+// testSessionArchiver is the fix-4 regression: the aged-run archiver prunes by
+// SESSION, not by run — a session is prunable only when EVERY run in it is
+// terminal and old, and DeleteSessionCascade removes the whole session (runs +
+// events + session row) while leaving token_usage (independent retention)
+// intact. Pruning one aged run inside a still-active session would corrupt the
+// continuation replay (GetTranscript reads the whole session), so a session with
+// any running run is never prunable.
+func testSessionArchiver(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// Session A: two completed runs, all terminal + old → prunable wholesale.
+	sessA, _ := s.CreateSession(ctx, "t", "default", "")
+	runA1, _ := s.CreateRun(ctx, sessA.ID, store.RunIdentity{AgentID: "arch-a1"})
+	runA2, _ := s.CreateRun(ctx, sessA.ID, store.RunIdentity{AgentID: "arch-a2"})
 	for _, e := range []string{"text", "done"} {
-		if err := s.AppendEvent(ctx, runA.ID, e, []byte(`{}`)); err != nil {
+		if err := s.AppendEvent(ctx, runA1.ID, e, []byte(`{}`)); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: runA.ID, TenantID: "t", Provider: "p", Model: "m", CredentialSource: "operator", InputTokens: 10}); err != nil {
+	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: runA1.ID, SessionID: sessA.ID, TenantID: "t", Provider: "p", Model: "m", CredentialSource: "operator", InputTokens: 10}); err != nil {
 		t.Fatal(err)
 	}
-	for _, id := range []string{runA.ID, runB.ID} {
+	for _, id := range []string{runA1.ID, runA2.ID} {
 		if err := s.FinishRun(ctx, id, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	// A future cutoff → both completed runs qualify; the running one never does.
-	got, err := s.PrunableCompletedRuns(ctx, time.Now().Add(time.Hour), 100)
+	// Session B: one completed run + one still-running run → NOT prunable (the
+	// running run would lose its session's transcript).
+	sessB, _ := s.CreateSession(ctx, "t", "default", "")
+	runB1, _ := s.CreateRun(ctx, sessB.ID, store.RunIdentity{AgentID: "arch-b1"})
+	runB2, _ := s.CreateRun(ctx, sessB.ID, store.RunIdentity{AgentID: "arch-b2"}) // stays running
+	if err := s.FinishRun(ctx, runB1.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	_ = runB2
+
+	// A future cutoff → session A qualifies (all terminal); session B does not.
+	got, err := s.PrunableAgedSessions(ctx, time.Now().Add(time.Hour), 100)
 	if err != nil {
-		t.Fatalf("PrunableCompletedRuns: %v", err)
+		t.Fatalf("PrunableAgedSessions: %v", err)
 	}
 	ids := map[string]bool{}
-	for _, r := range got {
-		ids[r.ID] = true
+	for _, id := range got {
+		ids[id] = true
 	}
-	if !ids[runA.ID] || !ids[runB.ID] {
-		t.Errorf("prunable set missing a completed run: %v", ids)
+	if !ids[sessA.ID] {
+		t.Errorf("prunable set missing the all-terminal session A: %v", got)
 	}
-	if ids[runC.ID] {
-		t.Errorf("prunable set included the RUNNING run %s", runC.ID)
+	if ids[sessB.ID] {
+		t.Errorf("prunable set included session B, which has a RUNNING run: %v", got)
 	}
-	// A past cutoff → nothing (both completed just now).
-	if old, _ := s.PrunableCompletedRuns(ctx, time.Now().Add(-time.Hour), 100); len(old) != 0 {
+	// A past cutoff → nothing (session A's runs completed just now).
+	if old, _ := s.PrunableAgedSessions(ctx, time.Now().Add(-time.Hour), 100); len(old) != 0 {
 		t.Errorf("past-cutoff prunable = %d, want 0", len(old))
 	}
 
-	// Delete runA: run + events gone, token_usage preserved.
-	if err := s.DeleteRunAndEvents(ctx, runA.ID); err != nil {
-		t.Fatalf("DeleteRunAndEvents: %v", err)
+	// RunsForSession returns every run in the session (for export).
+	runs, err := s.RunsForSession(ctx, sessA.ID)
+	if err != nil {
+		t.Fatalf("RunsForSession: %v", err)
 	}
-	if _, err := s.GetRun(ctx, runA.ID); err == nil {
-		t.Errorf("runA still present after delete")
+	if len(runs) != 2 {
+		t.Errorf("RunsForSession(A) = %d runs, want 2", len(runs))
 	}
-	if evs, _ := s.GetRunEventsSince(ctx, runA.ID, 0, 100); len(evs) != 0 {
-		t.Errorf("runA events survived delete: %d", len(evs))
+
+	// DeleteSessionCascade: runs + events + session row gone, token_usage kept.
+	if err := s.DeleteSessionCascade(ctx, sessA.ID); err != nil {
+		t.Fatalf("DeleteSessionCascade: %v", err)
 	}
-	if usage, _ := s.TokenUsageForRun(ctx, runA.ID); len(usage) != 1 {
-		t.Errorf("token_usage for deleted run = %d, want 1 (usage retention is independent)", len(usage))
+	if _, err := s.GetRun(ctx, runA1.ID); err == nil {
+		t.Errorf("runA1 still present after cascade delete")
 	}
-	// runC (running) untouched.
-	if _, err := s.GetRun(ctx, runC.ID); err != nil {
-		t.Errorf("runC (running) was affected: %v", err)
+	if _, err := s.GetRun(ctx, runA2.ID); err == nil {
+		t.Errorf("runA2 still present after cascade delete")
+	}
+	if _, err := s.GetSession(ctx, sessA.ID); err == nil {
+		t.Errorf("session A row survived cascade delete")
+	}
+	if evs, _ := s.GetRunEventsSince(ctx, runA1.ID, 0, 100); len(evs) != 0 {
+		t.Errorf("session A events survived cascade delete: %d", len(evs))
+	}
+	if usage, _ := s.TokenUsageForRun(ctx, runA1.ID); len(usage) != 1 {
+		t.Errorf("token_usage for deleted session = %d, want 1 (usage retention is independent)", len(usage))
+	}
+	// Session B untouched.
+	if _, err := s.GetRun(ctx, runB2.ID); err != nil {
+		t.Errorf("session B run was affected: %v", err)
 	}
 }
 

--- a/internal/usage/sweeper.go
+++ b/internal/usage/sweeper.go
@@ -41,25 +41,28 @@ type Config struct {
 	// day-bucketed archive aggregates.
 	DetailRetention time.Duration
 
-	// --- RFC AV Phase 2b2: old-run archiver (OFF by default). ---
+	// --- RFC AV Phase 2b2: old-session archiver (OFF by default). ---
 	// Unlike the usage rollup above (lossless compaction to the archive), this
-	// DELETES aged completed runs + their events — the audit trail — so it is
+	// DELETES aged sessions + their runs + events — the audit trail — so it is
 	// opt-in: zero RunRetention or an "off"/"" RunRetentionMode disables it.
+	// Pruning is by SESSION (not by run): the continuation path replays the whole
+	// session transcript, so a session is only prunable once ALL its runs are
+	// terminal + old — pruning one aged run would corrupt a continued session.
 
-	// RunRetention is the cutoff for archiving completed runs: terminal runs
-	// whose completed_at is older than this are exported (if the mode says so)
-	// and deleted. Zero disables run archival entirely. token_usage is NOT
-	// touched — usage retention is DetailRetention above.
+	// RunRetention is the cutoff for archiving aged sessions: a session whose
+	// runs are all terminal and whose latest completed_at is older than this is
+	// exported (if the mode says so) and cascade-deleted. Zero disables archival
+	// entirely. token_usage is NOT touched — usage retention is DetailRetention.
 	RunRetention time.Duration
 
-	// RunRetentionMode is one of "off" (default / ""), "prune" (delete aged
-	// completed runs + events), or "export+prune" (write each run + its events
-	// to ExportDir as JSON, then delete). An unknown value is treated as off.
+	// RunRetentionMode is one of "off" (default / ""), "prune" (cascade-delete
+	// aged sessions + runs + events), or "export+prune" (write each session + its
+	// runs + events to ExportDir as JSON, then delete). Unknown → treated as off.
 	RunRetentionMode string
 
-	// ExportDir is the directory export+prune writes run JSON into (one file per
-	// run under a per-day subdir). Required for export+prune; if empty, run
-	// archival is disabled (never delete a run we were asked to export).
+	// ExportDir is the directory export+prune writes session JSON into (one file
+	// per session under a per-day subdir). Required for export+prune; if empty,
+	// archival is disabled (never delete a session we were asked to export).
 	ExportDir string
 
 	// Logger is the structured logger used for sweep results. Defaults
@@ -101,11 +104,11 @@ type AdvisoryLocker interface {
 const (
 	defaultInterval        = 1 * time.Hour
 	defaultDetailRetention = 720 * time.Hour // 30 days
-	runPruneBatch          = 500             // completed runs archived per tick
+	runPruneBatch          = 500             // aged sessions archived per tick
 )
 
 // Sweeper periodically folds old token_usage rows into usage_archive and
-// deletes them, and (opt-in) archives aged completed runs. Construct via New,
+// deletes them, and (opt-in) archives aged sessions. Construct via New,
 // then call Run(ctx) on a goroutine that owns the lifecycle.
 type Sweeper struct {
 	store           store.Store
@@ -215,7 +218,7 @@ func (s *Sweeper) Run(ctx context.Context) {
 				n, err = s.sweepOnce(ctx)
 				if s.runArchivalEnabled() {
 					ranArchival = true
-					archived, archErr = s.archiveRunsOnce(ctx)
+					archived, archErr = s.archiveSessionsOnce(ctx)
 				}
 			}
 			if s.lock != nil {
@@ -249,12 +252,12 @@ func (s *Sweeper) Run(ctx context.Context) {
 				}
 				noOpStreak++
 			}
-			// Old-run archival result (only when enabled).
+			// Old-session archival result (only when enabled).
 			if ranArchival {
 				if archErr != nil {
-					s.logf("usage: run archival failed: %v", archErr)
+					s.logf("usage: session archival failed: %v", archErr)
 				} else if archived > 0 {
-					s.logf("usage: archived + pruned %d completed run(s) (mode=%s)", archived, s.runMode)
+					s.logf("usage: archived + pruned %d completed session(s) (mode=%s)", archived, s.runMode)
 				}
 			}
 		}
@@ -273,30 +276,33 @@ func (s *Sweeper) sweepOnce(parent context.Context) (int, error) {
 	return s.store.RollupAndPruneUsage(ctx, cutoff)
 }
 
-// archiveRunsOnce archives one batch of aged completed runs (RFC AV Phase 2b2):
-// list terminal runs older than the cutoff, export each (export+prune mode) then
-// delete it (run + events). Per-run failures are logged and skipped — a bad
-// export never deletes the run. Returns the number deleted. Given a longer
-// timeout than the usage prune because export writes files.
-func (s *Sweeper) archiveRunsOnce(parent context.Context) (int, error) {
+// archiveSessionsOnce archives one batch of aged sessions (RFC AV Phase 2b2):
+// list sessions whose runs are ALL terminal + old, export each (export+prune
+// mode) then cascade-delete it (session + runs + events). Prunes by SESSION, not
+// by run: the continuation path replays the whole-session transcript, so pruning
+// one aged run inside a still-continued session would corrupt it. Per-session
+// failures are logged and skipped — a bad export never deletes the session.
+// Returns the number deleted. Given a longer timeout than the usage prune
+// because export writes files.
+func (s *Sweeper) archiveSessionsOnce(parent context.Context) (int, error) {
 	ctx, cancel := context.WithTimeout(parent, 2*time.Minute)
 	defer cancel()
 	cutoff := s.now().Add(-s.runRetention)
-	runs, err := s.store.PrunableCompletedRuns(ctx, cutoff, runPruneBatch)
+	sessions, err := s.store.PrunableAgedSessions(ctx, cutoff, runPruneBatch)
 	if err != nil {
 		return 0, err
 	}
 	deleted := 0
-	for _, r := range runs {
+	for _, sid := range sessions {
 		if s.runMode == "export+prune" {
-			if err := s.exportRun(ctx, r); err != nil {
-				// Never delete a run we failed to export — retry next tick.
-				s.logf("usage: export run %s failed, skipping delete: %v", r.ID, err)
+			if err := s.exportSession(ctx, sid); err != nil {
+				// Never delete a session we failed to export — retry next tick.
+				s.logf("usage: export session %s failed, skipping delete: %v", sid, err)
 				continue
 			}
 		}
-		if err := s.store.DeleteRunAndEvents(ctx, r.ID); err != nil {
-			s.logf("usage: delete run %s failed: %v", r.ID, err)
+		if err := s.store.DeleteSessionCascade(ctx, sid); err != nil {
+			s.logf("usage: delete session %s failed: %v", sid, err)
 			continue
 		}
 		deleted++
@@ -304,30 +310,50 @@ func (s *Sweeper) archiveRunsOnce(parent context.Context) (int, error) {
 	return deleted, nil
 }
 
-// exportRun writes a run + its events to ExportDir as JSON, under a per-day
-// subdir (bucketing by completed date keeps any single directory bounded). The
-// export dir is operator config, never model input.
-func (s *Sweeper) exportRun(ctx context.Context, r store.Run) error {
-	events, err := s.store.GetRunEventsSince(ctx, r.ID, 0, 1_000_000)
+// exportSession writes a session (its runs + all events) to ExportDir as JSON,
+// under a per-day subdir (bucketing by the session's latest completed date keeps
+// any single directory bounded). The export dir is operator config, never model
+// input.
+func (s *Sweeper) exportSession(ctx context.Context, sessionID string) error {
+	runs, err := s.store.RunsForSession(ctx, sessionID)
 	if err != nil {
 		return err
 	}
-	day := r.CompletedAt
+	events, err := s.store.GetTranscript(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	// Bucket by the session's latest completed_at (fall back to latest start,
+	// then to now if a session somehow has no timestamps).
+	var day time.Time
+	for _, r := range runs {
+		if !r.CompletedAt.IsZero() && r.CompletedAt.After(day) {
+			day = r.CompletedAt
+		}
+	}
 	if day.IsZero() {
-		day = r.StartedAt
+		for _, r := range runs {
+			if r.StartedAt.After(day) {
+				day = r.StartedAt
+			}
+		}
+	}
+	if day.IsZero() {
+		day = s.now()
 	}
 	dir := filepath.Join(s.exportDir, day.UTC().Format("2006-01-02"))
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err
 	}
 	payload := struct {
-		Run    store.Run     `json:"run"`
-		Events []store.Event `json:"events"`
-	}{Run: r, Events: events}
+		SessionID string        `json:"session_id"`
+		Runs      []store.Run   `json:"runs"`
+		Events    []store.Event `json:"events"`
+	}{SessionID: sessionID, Runs: runs, Events: events}
 	blob, err := json.MarshalIndent(payload, "", "  ")
 	if err != nil {
 		return err
 	}
 	// 0o600: run transcripts may hold sensitive tool I/O; operator-only.
-	return os.WriteFile(filepath.Join(dir, r.ID+".json"), blob, 0o600)
+	return os.WriteFile(filepath.Join(dir, sessionID+".json"), blob, 0o600)
 }

--- a/internal/usage/sweeper_test.go
+++ b/internal/usage/sweeper_test.go
@@ -88,16 +88,20 @@ func TestSweeperOnce_PrunesOldDetail(t *testing.T) {
 	}
 }
 
-// TestArchiveRunsOnce covers the RFC AV Phase 2b2 old-run archiver in both
-// modes: "prune" deletes an aged completed run + its events; "export+prune"
-// first writes the run JSON to the export dir, then deletes. The clock is
-// pinned into the future so a just-completed run lands past the cutoff.
-func TestArchiveRunsOnce(t *testing.T) {
+// TestArchiveSessionsOnce covers the RFC AV Phase 2b2 aged-SESSION archiver in
+// both modes: "prune" cascade-deletes an aged all-terminal session (its runs +
+// events); "export+prune" first writes the session JSON to the export dir, then
+// deletes. A session with a still-running run is NEVER pruned — the fix-4
+// regression: pruning per-run would corrupt a continued session's whole-session
+// transcript replay. The clock is pinned into the future so a just-completed
+// session lands past the cutoff.
+func TestArchiveSessionsOnce(t *testing.T) {
 	ctx := context.Background()
-	// Pin now well past the run's completed_at so cutoff = now-24h > completed_at.
+	// Pin now well past completed_at so cutoff = now-24h > completed_at.
 	future := func() time.Time { return time.Now().Add(48 * time.Hour) }
 
-	seedCompletedRun := func(st *sqlite.Store, agentID string) string {
+	// seedCompletedSession makes a session with one completed run (with events).
+	seedCompletedSession := func(st *sqlite.Store, agentID string) (sessID, runID string) {
 		sess, err := st.CreateSession(ctx, "t", "default", "")
 		if err != nil {
 			t.Fatal(err)
@@ -112,12 +116,12 @@ func TestArchiveRunsOnce(t *testing.T) {
 		if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
 			t.Fatal(err)
 		}
-		return run.ID
+		return sess.ID, run.ID
 	}
 
 	t.Run("prune", func(t *testing.T) {
 		st := newTestStore(t)
-		runID := seedCompletedRun(st, "prune-a")
+		sessID, runID := seedCompletedSession(st, "prune-a")
 		sw := New(st, Config{
 			RunRetention:     24 * time.Hour,
 			RunRetentionMode: "prune",
@@ -127,19 +131,22 @@ func TestArchiveRunsOnce(t *testing.T) {
 		if !sw.runArchivalEnabled() {
 			t.Fatal("prune mode should be enabled")
 		}
-		n, err := sw.archiveRunsOnce(ctx)
+		n, err := sw.archiveSessionsOnce(ctx)
 		if err != nil || n != 1 {
-			t.Fatalf("archiveRunsOnce = (%d, %v), want (1, nil)", n, err)
+			t.Fatalf("archiveSessionsOnce = (%d, %v), want (1, nil)", n, err)
 		}
 		if _, err := st.GetRun(ctx, runID); err == nil {
 			t.Errorf("run survived prune")
+		}
+		if _, err := st.GetSession(ctx, sessID); err == nil {
+			t.Errorf("session survived prune")
 		}
 	})
 
 	t.Run("export+prune", func(t *testing.T) {
 		st := newTestStore(t)
 		exportDir := t.TempDir()
-		runID := seedCompletedRun(st, "export-a")
+		sessID, runID := seedCompletedSession(st, "export-a")
 		sw := New(st, Config{
 			RunRetention:     24 * time.Hour,
 			RunRetentionMode: "export+prune",
@@ -147,21 +154,55 @@ func TestArchiveRunsOnce(t *testing.T) {
 			Logger:           func(string, ...any) {},
 			Now:              future,
 		})
-		n, err := sw.archiveRunsOnce(ctx)
+		n, err := sw.archiveSessionsOnce(ctx)
 		if err != nil || n != 1 {
-			t.Fatalf("archiveRunsOnce = (%d, %v), want (1, nil)", n, err)
+			t.Fatalf("archiveSessionsOnce = (%d, %v), want (1, nil)", n, err)
 		}
-		if _, err := st.GetRun(ctx, runID); err == nil {
-			t.Errorf("run survived export+prune")
+		if _, err := st.GetSession(ctx, sessID); err == nil {
+			t.Errorf("session survived export+prune")
 		}
-		// A JSON export exists under a per-day subdir and mentions the run id.
-		matches, _ := filepath.Glob(filepath.Join(exportDir, "*", runID+".json"))
+		// A JSON export exists under a per-day subdir named for the session and
+		// carries session_id + runs + events.
+		matches, _ := filepath.Glob(filepath.Join(exportDir, "*", sessID+".json"))
 		if len(matches) != 1 {
-			t.Fatalf("export file glob = %v, want exactly one %s.json", matches, runID)
+			t.Fatalf("export file glob = %v, want exactly one %s.json", matches, sessID)
 		}
 		blob, err := os.ReadFile(matches[0])
-		if err != nil || !bytes.Contains(blob, []byte(runID)) || !bytes.Contains(blob, []byte(`"events"`)) {
-			t.Errorf("export file missing run id / events: err=%v", err)
+		if err != nil ||
+			!bytes.Contains(blob, []byte(sessID)) ||
+			!bytes.Contains(blob, []byte(runID)) ||
+			!bytes.Contains(blob, []byte(`"runs"`)) ||
+			!bytes.Contains(blob, []byte(`"events"`)) {
+			t.Errorf("export file missing session_id / run id / runs / events: err=%v", err)
+		}
+	})
+
+	// fix-4 regression: a session with a still-running run must NOT be pruned,
+	// even if it also holds an aged completed run. Pruning per-run would leave
+	// the running run's continuation replay reading a broken transcript.
+	t.Run("session with running run is not pruned", func(t *testing.T) {
+		st := newTestStore(t)
+		sess, _ := st.CreateSession(ctx, "t", "default", "")
+		done, _ := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "mixed-done"})
+		running, _ := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: "mixed-running"}) // stays running
+		if err := st.FinishRun(ctx, done.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+			t.Fatal(err)
+		}
+		sw := New(st, Config{
+			RunRetention:     24 * time.Hour,
+			RunRetentionMode: "prune",
+			Logger:           func(string, ...any) {},
+			Now:              future,
+		})
+		n, err := sw.archiveSessionsOnce(ctx)
+		if err != nil || n != 0 {
+			t.Fatalf("archiveSessionsOnce = (%d, %v), want (0, nil) — session has a running run", n, err)
+		}
+		if _, err := st.GetRun(ctx, done.ID); err != nil {
+			t.Errorf("completed run in a still-active session was pruned: %v", err)
+		}
+		if _, err := st.GetRun(ctx, running.ID); err != nil {
+			t.Errorf("running run was pruned: %v", err)
 		}
 	})
 


### PR DESCRIPTION
A 10-angle self-review of the RFC AV usage-attribution line surfaced real defects, several in the already-merged Phase-1/2 code. This PR fixes the **critical + high + medium** cluster (findings #1–8); the low/polish set (#9–15) follows in a second PR.

## Fixes

- **#1 / #6 / #13 — CRITICAL: ledger rows carried a zero identity.** `makeRecordingEmit` was constructed *before* `WithRunIdentity` stamped the loop ctx, so `recordCallUsage` read an empty `RunIdentity` → every **directly-invoked** run's `token_usage` rows got `tenant_id=''`/`user_id=''`/`agent_id=''`, **breaking per-tenant/user cost reports on the primary path** (sub-agent rows got the *parent's* id; `session_id` was never set). Fix: `makeRecordingEmit`/`recordCallUsage` take the identity + `session_id` **explicitly** (hoisted before the call at all 5 sites incl. `resume.go`). **Regression test asserts the row's tenant/user/agent/session** — the prior test only checked cost/source, which is why this shipped.
- **#2 — Postgres archive day-bucket used session TZ**, sqlite used UTC → cross-backend divergence + wrong-day attribution on non-UTC servers. Fix: bucket in UTC to match sqlite.
- **#3 — windowed report dropped whole days over archived data** (intra-day `from` vs day-truncated `period_start`). Fix: floor `from` to its UTC day for the archive branch only (token_usage stays exact); boundary day is over-inclusive by day-granularity, never under.
- **#4 — HIGH: old-run archiver deleted events per-run, corrupting continued sessions** (continue replays the whole session). Fix: **prune by session** — `PrunableAgedSessions` (every run terminal by status+pause_state, `max(completed_at) < cutoff`) + `DeleteSessionCascade`; sweeper exports+deletes whole aged sessions. Removed the now-unused per-run methods.
- **#5 — HIGH: resolved credential values weren't registered in the redactor** → a downstream echo persisted the secret. Fix: thread-safe `Redactor.Register` (RWMutex, dedup, len≥4) wired into the `$cred:` substitute hook + the provider-key resolve.
- **#7 — resolver swallowed store/decrypt errors as "no override"** (silent mis-bill). Fix: log the error distinctly before failing soft to the host key.
- **#8 — resolver did 3 store reads per LLM call even with no KEK/credentials.** Fix: `Engine.CanResolve()` fast-path skips all reads when the inline backend is disabled. *(Per-run resolve memo for the KEK-set case is a documented TODO — a larger ctx-cache change; the fast-path fixes the stated finding.)*

## Tested

`go test ./...` clean (exit 0), gofmt + vet clean, binary builds. Regression tests **fail-before** for #1/#3/#4/#5, verified on both **sqlite and real Postgres** for the store fixes.

`★` These findings, and this fix set, came from running the review over the day's changes — #1 in particular defeated the feature on its main path and the original test missed it because it never asserted the row's tenant_id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)