### PR TITLE
fix(usage): polish fixes from the RFC AV code review (#9–15)

### DIFF
--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -6141,12 +6141,20 @@ func (s *Server) finishRunCancelled(_ context.Context, runID string, res loop.Ru
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
 		Provider:            res.Usage.Provider,
-		// RFC AV: carry the cost + credential-source summary on cancel too, so a
-		// partially-completed cancelled run still attributes its spend.
+		// RFC AV: carry the credential-source summary on cancel too, so a
+		// partially-completed cancelled run still attributes its spend. Cost is set
+		// below from the ledger (the calls that completed before cancel).
 		CredentialSource:  runSummarySource(res.Usage),
 		CredentialScopeID: res.Usage.CredentialScopeID,
 	}
-	usage.Cost, usage.CostCurrency = s.priceCall(res.Usage.Provider, res.Usage.Model, &res.Usage)
+	// runs.cost = Σ(the run's per-call ledger) — the calls that completed before the
+	// cancel. Authoritative over pricing cumulative tokens at the final model (which
+	// disagrees on a mid-run fallback). Error → leave NULL, never fail the write.
+	if cost, currency, _, err := s.store.RunCostSummary(bg, runID); err != nil {
+		log.Printf("store: RunCostSummary failed (run=%s): %v", runID, err)
+	} else {
+		usage.Cost, usage.CostCurrency = cost, currency
+	}
 	if err := s.store.FinishRun(bg, runID, store.RunCancelled, reason, usage, ""); err != nil {
 		log.Printf("store: FinishRun(cancelled) failed (run=%s): %v", runID, err)
 	}
@@ -6261,13 +6269,23 @@ func (s *Server) finishRun(_ context.Context, runID string, res loop.RunResult, 
 		CacheReadTokens:     res.Usage.CacheReadTokens,
 		Model:               res.Usage.Model,
 		Provider:            res.Usage.Provider,
-		// RFC AV: per-run cost + credential-source summary. Cost is best-effort
-		// (priced from the run's final provider/model + summed tokens); the exact
-		// per-call split lives in token_usage. Source is the last iteration's key.
+		// RFC AV: per-run credential-source summary is the last iteration's key;
+		// the exact per-call split lives in token_usage. Cost is set below from the
+		// ledger (not priced here) so runs.cost == Σ(ledger).
 		CredentialSource:  runSummarySource(res.Usage),
 		CredentialScopeID: res.Usage.CredentialScopeID,
 	}
-	usage.Cost, usage.CostCurrency = s.priceCall(res.Usage.Provider, res.Usage.Model, &res.Usage)
+	// runs.cost is the SUM of the run's per-call ledger costs (authoritative) — NOT
+	// the final model × cumulative tokens, which disagrees with the ledger on a
+	// mid-run fallback. All EventUsage rows are written synchronously (via
+	// makeRecordingEmit) before finishRun runs, so the ledger is complete here. A
+	// summary error is logged, not fatal — leave the cost NULL rather than fail the
+	// terminal write; currency "" ⇒ unpriced (NULL), preserving NULL-vs-zero.
+	if cost, currency, _, err := s.store.RunCostSummary(bg, runID); err != nil {
+		log.Printf("store: RunCostSummary failed (run=%s): %v", runID, err)
+	} else {
+		usage.Cost, usage.CostCurrency = cost, currency
+	}
 	if err := s.store.FinishRun(bg, runID, status, res.StopReason, usage, errMsg); err != nil {
 		log.Printf("store: FinishRun failed (run=%s): %v", runID, err)
 	}

--- a/internal/api/http/usage_attribution_test.go
+++ b/internal/api/http/usage_attribution_test.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -213,5 +214,111 @@ func TestUsageAttribution_LedgerRowCarriesRunIdentity(t *testing.T) {
 	}
 	if r.SessionID == "" || r.SessionID != run.SessionID {
 		t.Errorf("row SessionID = %q, want run's session %q", r.SessionID, run.SessionID)
+	}
+}
+
+// noopUsageTool lets a scripted run take a SECOND model iteration (tool_use →
+// tool_result → model call) so the loop makes two priced calls in ONE run —
+// required by the fix-9 regression to exercise a mid-run model change.
+type noopUsageTool struct{}
+
+func (noopUsageTool) Name() string                 { return "Noop" }
+func (noopUsageTool) Description() string          { return "does nothing" }
+func (noopUsageTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (noopUsageTool) Execute(_ context.Context, _ json.RawMessage) (tools.Result, error) {
+	return tools.Result{Text: "ok"}, nil
+}
+
+// TestUsageAttribution_RunCostIsSumOfLedgerNotFinalModel is the fix-9 regression:
+// runs.cost must equal Σ(the run's per-call token_usage costs), NOT the final
+// model priced over cumulative tokens. finishRun used to price res.Usage (final
+// model × summed tokens); on a run that changed model mid-flight (fallback) that
+// disagreed with the ledger, which prices each call at its OWN model. Here call 0
+// runs on an expensive model and call 1 on a cheap one, so the two pricings differ
+// sharply. Fails on the pre-fix code (runs.cost ≈ 0.002, not Σ(ledger) ≈ 0.101).
+func TestUsageAttribution_RunCostIsSumOfLedgerNotFinalModel(t *testing.T) {
+	cfg := &config.Config{
+		Defaults: config.Defaults{Provider: "scripted", Model: "model-a"},
+		Agents: map[string]config.AgentDef{
+			"solo": {Model: "model-a", AllowedTools: []string{"Noop"}, SystemPrompt: "you are solo"},
+		},
+		Concurrency: config.Concurrency{MaxConcurrentRuns: 4, MaxQueueDepth: 4, QueueTimeoutMS: 1000},
+		// model-a is 100× the price of model-b, so summing per-call (ledger) vs
+		// pricing the final model over cumulative tokens give very different numbers.
+		Pricing: config.PricingConfig{
+			Currency: "USD",
+			Models: map[string]config.ModelPrice{
+				"scripted/model-a": {Input: 100, Output: 100}, // expensive (served call 0)
+				"scripted/model-b": {Input: 1, Output: 1},     // cheap (served call 1, the final)
+			},
+		},
+	}
+	cfg.Env.AuthToken = ""
+
+	prov := &scriptedProvider{
+		scripts: [][]providers.Event{
+			// Call 0: model-a, 1000 input tokens, tool_call(Noop) → continue.
+			{
+				{Type: providers.EventToolCall, ToolUse: &providers.ToolUse{ID: "tu1", Name: "Noop", Input: json.RawMessage(`{}`)}},
+				{Type: providers.EventDone, StopReason: "tool_use", Usage: &providers.Usage{InputTokens: 1000, OutputTokens: 0, Model: "model-a"}},
+			},
+			// Call 1: model-b (the FINAL model), 1000 output tokens, end_turn.
+			{
+				{Type: providers.EventText, Text: "done"},
+				{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{InputTokens: 0, OutputTokens: 1000, Model: "model-b"}},
+			},
+		},
+	}
+
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "usage.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	srv := New(cfg, &stubResolver{p: prov}, []tools.Tool{noopUsageTool{}}, concurrency.New(4, 4, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"solo","agent_id":"fallback-run","segments":[{"role":"user","content":[{"type":"trusted-text","text":"go"}]}]}`,
+	))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d: %s", resp.StatusCode, b)
+	}
+	_, _ = io.ReadAll(resp.Body) // drain to completion (finishRun runs in-path)
+
+	ctx := context.Background()
+	run, err := st.GetRunByAgentID(ctx, "fallback-run")
+	if err != nil {
+		t.Fatalf("GetRunByAgentID: %v", err)
+	}
+	rows, err := st.TokenUsageForRun(ctx, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("ledger rows = %d, want 2 (one per call)", len(rows))
+	}
+	var ledgerSum float64
+	for _, r := range rows {
+		ledgerSum += r.Cost
+	}
+	// Σ(ledger) = model-a(1000 in × 100/1e6 = 0.1) + model-b(1000 out × 1/1e6 = 0.001) = 0.101.
+	if run.Cost == nil {
+		t.Fatalf("runs.cost is NULL, want the priced Σ(ledger)")
+	}
+	if diff := *run.Cost - ledgerSum; diff > 1e-9 || diff < -1e-9 {
+		t.Errorf("runs.cost = %v, want Σ(ledger) = %v", *run.Cost, ledgerSum)
+	}
+	// Guard explicitly against the pre-fix value: pricing the final model (model-b)
+	// over cumulative tokens (2000) = 0.002 — nowhere near Σ(ledger) ≈ 0.101.
+	if *run.Cost < 0.05 {
+		t.Errorf("runs.cost = %v looks like final-model×cumulative pricing (~0.002), not Σ(ledger) (~0.101)", *run.Cost)
 	}
 }

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -507,28 +507,31 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
+// RunCostSummary sums a run's per-call token_usage ledger (RFC AV). COUNT(cost)
+// counts non-NULL costs (unpriced rows store NULL cost), so priced>0 ⇒ at least
+// one call was priced; MAX(cost_currency) ignores NULLs so it returns the currency
+// among the priced rows (or ” when none priced ⇒ unpriced run). This makes
+// runs.cost == Σ(ledger) by construction (see the interface doc).
+func (s *Store) RunCostSummary(ctx context.Context, runID string) (float64, string, bool, error) {
+	var cost float64
+	var currency string
+	var priced int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(cost),0), COALESCE(MAX(cost_currency),''), COUNT(cost)
+		 FROM token_usage WHERE run_id = $1`, runID).Scan(&cost, &currency, &priced)
+	if err != nil {
+		return 0, "", false, fmt.Errorf("run cost summary: %w", err)
+	}
+	return cost, currency, priced > 0, nil
+}
+
 // UsageReport aggregates recent per-call token_usage UNION the compact
 // usage_archive rollup (RFC AV Phase 2b), so a pruned window still reports.
 // Mirrors the sqlite implementation: five dimension columns in
 // UsageCanonicalDims order (column when grouped, else ”), a fixed 13-column
 // result. ts / period_start are TIMESTAMPTZ, so window bounds pass as time.Time.
 func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
-	grouped := map[store.UsageDimension]bool{}
-	for _, d := range q.GroupBy {
-		if _, ok := store.UsageDimColumn(d); ok {
-			grouped[d] = true
-		}
-	}
-	var dimExprs, groupCols []string
-	for _, d := range store.UsageCanonicalDims {
-		col, _ := store.UsageDimColumn(d)
-		if grouped[d] {
-			dimExprs = append(dimExprs, col)
-			groupCols = append(groupCols, col)
-		} else {
-			dimExprs = append(dimExprs, "''")
-		}
-	}
+	dimExprs, groupCols := store.UsageGroupColumns(q.GroupBy)
 	var args []any
 	n := 0
 	ph := func(v any) string { n++; args = append(args, v); return fmt.Sprintf("$%d", n) }
@@ -579,11 +582,13 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
 		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
 		COALESCE(SUM(cost),0), COALESCE(SUM(call_count),0), COALESCE(SUM(unpriced_calls),0),
-		COALESCE(MAX(cost_currency),'')
+		cost_currency
 		FROM (` + inner + `) u`
-	if len(groupCols) > 0 {
-		query += " GROUP BY " + strings.Join(groupCols, ", ")
-	}
+	// cost_currency is ALWAYS in the GROUP BY so a row never sums across currencies
+	// — each output row is single-currency (unpriced rows, currency '', group
+	// together). A single-currency deployment still yields one row per bucket.
+	groupCols = append(groupCols, "cost_currency")
+	query += " GROUP BY " + strings.Join(groupCols, ", ")
 	query += " ORDER BY COALESCE(SUM(cost),0) DESC"
 
 	rows, err := s.pool.Query(ctx, query, args...)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1321,6 +1321,24 @@ func (s *Store) TokenUsageForRun(ctx context.Context, runID string) ([]store.Tok
 	return out, rows.Err()
 }
 
+// RunCostSummary sums a run's per-call token_usage ledger (RFC AV). COUNT(cost)
+// counts non-NULL costs (unpriced rows store NULL cost), so priced>0 ⇒ at least
+// one call was priced; MAX(cost_currency) ignores NULLs so it returns the currency
+// among the priced rows (or ” when none priced ⇒ unpriced run). This makes
+// runs.cost == Σ(ledger) by construction (see the interface doc).
+func (s *Store) RunCostSummary(ctx context.Context, runID string) (float64, string, bool, error) {
+	var cost float64
+	var currency string
+	var priced int64
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(cost),0), COALESCE(MAX(cost_currency),''), COUNT(cost)
+		 FROM token_usage WHERE run_id = ?`, runID).Scan(&cost, &currency, &priced)
+	if err != nil {
+		return 0, "", false, err
+	}
+	return cost, currency, priced > 0, nil
+}
+
 // nanosPerDay is the day bucket for the usage rollup's period_start (ts is
 // stored as unix-nano in sqlite).
 const nanosPerDay = int64(86400) * int64(1e9)
@@ -1331,22 +1349,7 @@ const nanosPerDay = int64(86400) * int64(1e9)
 // UsageCanonicalDims order — the column when grouped, else ” — a fixed
 // 13-column shape. ts / period_start are unix-nano, so window bounds are nanos.
 func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
-	grouped := map[store.UsageDimension]bool{}
-	for _, d := range q.GroupBy {
-		if _, ok := store.UsageDimColumn(d); ok {
-			grouped[d] = true
-		}
-	}
-	var dimExprs, groupCols []string
-	for _, d := range store.UsageCanonicalDims {
-		col, _ := store.UsageDimColumn(d)
-		if grouped[d] {
-			dimExprs = append(dimExprs, col)
-			groupCols = append(groupCols, col)
-		} else {
-			dimExprs = append(dimExprs, "''")
-		}
-	}
+	dimExprs, groupCols := store.UsageGroupColumns(q.GroupBy)
 	// Per-source WHERE (tenant + window). token_usage windows on ts (exact);
 	// usage_archive on period_start (day-truncated UTC midnight). Args are
 	// appended in placeholder order (token_usage first). floorFromDay floors the
@@ -1398,11 +1401,13 @@ func (s *Store) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.Us
 		COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
 		COALESCE(SUM(cache_creation_tokens),0), COALESCE(SUM(cache_read_tokens),0),
 		COALESCE(SUM(cost),0), COALESCE(SUM(call_count),0), COALESCE(SUM(unpriced_calls),0),
-		COALESCE(MAX(cost_currency),'')
+		cost_currency
 		FROM (` + inner + `)`
-	if len(groupCols) > 0 {
-		query += " GROUP BY " + strings.Join(groupCols, ", ")
-	}
+	// cost_currency is ALWAYS in the GROUP BY so a row never sums across currencies
+	// — each output row is single-currency (unpriced rows, currency '', group
+	// together). A single-currency deployment still yields one row per bucket.
+	groupCols = append(groupCols, "cost_currency")
+	query += " GROUP BY " + strings.Join(groupCols, ", ")
 	query += " ORDER BY COALESCE(SUM(cost),0) DESC"
 
 	args := append(append([]any{}, tuArgs...), uaArgs...)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -418,10 +418,12 @@ type UsageAggregate struct {
 	CacheReadTokens     int64 `json:"cache_read_tokens"`
 
 	// Cost is the summed money cost of the PRICED calls in the group; Currency is
-	// a representative unit (mixed currencies are not summed meaningfully — a v1
-	// caveat; single-currency deployments are the common case). UnpricedCalls
-	// counts calls with no cost (model absent from the pricing table) so a report
-	// can surface a "pricing incomplete" signal instead of silently undercounting.
+	// the group's exact currency — UsageReport groups by cost_currency so a row is
+	// never summed across currencies (mixing them would be meaningless). A group
+	// with a real cost is one-per-currency; unpriced rows (currency "") group
+	// together. UnpricedCalls counts calls with no cost (model absent from the
+	// pricing table) so a report can surface a "pricing incomplete" signal instead
+	// of silently undercounting.
 	Cost          float64 `json:"cost"`
 	Currency      string  `json:"currency,omitempty"`
 	CallCount     int64   `json:"call_count"`
@@ -452,6 +454,32 @@ func UsageDimColumn(d UsageDimension) (col string, ok bool) {
 		return "credential_source", true
 	}
 	return "", false
+}
+
+// UsageGroupColumns builds a usage report's per-dimension SELECT expressions and
+// GROUP BY column list, in UsageCanonicalDims order: a grouped dimension emits its
+// column into BOTH lists; an ungrouped one emits the literal ” into dimExprs only,
+// keeping the SELECT a fixed 5-dimension shape regardless of group_by. Shared by
+// both backends so the scan-target order can't drift from the query — and it's
+// dialect-independent (no ?/$N placeholders, no day-floor math, which genuinely
+// differ between backends and are NOT shared).
+func UsageGroupColumns(groupBy []UsageDimension) (dimExprs, groupCols []string) {
+	grouped := map[UsageDimension]bool{}
+	for _, d := range groupBy {
+		if _, ok := UsageDimColumn(d); ok {
+			grouped[d] = true
+		}
+	}
+	for _, d := range UsageCanonicalDims {
+		col, _ := UsageDimColumn(d)
+		if grouped[d] {
+			dimExprs = append(dimExprs, col)
+			groupCols = append(groupCols, col)
+		} else {
+			dimExprs = append(dimExprs, "''")
+		}
+	}
+	return dimExprs, groupCols
 }
 
 // RunIdentity carries the v0.4 tracking fields a CreateRun caller can
@@ -655,6 +683,16 @@ type Store interface {
 	// TokenUsageForRun returns all per-call usage rows for a run, oldest first.
 	// Used by the rollup invariant test + (later) the archiver.
 	TokenUsageForRun(ctx context.Context, runID string) ([]TokenUsageRow, error)
+
+	// RunCostSummary sums a run's per-call token_usage ledger into its authoritative
+	// per-run cost (RFC AV): cost = SUM(token_usage.cost), currency = MAX(cost_currency)
+	// among priced rows, priced = at least one non-NULL cost row. FinishRun uses this
+	// so runs.cost == Σ(ledger) BY CONSTRUCTION — it can't disagree with the ledger on
+	// a mid-run fallback (where pricing the final model × cumulative tokens differs
+	// from summing each call at its own model). An unpriced run (no priced rows) yields
+	// currency="" so the caller stores a NULL cost, preserving the NULL-vs-zero
+	// distinction (a genuine zero — mock/code-js — carries a currency).
+	RunCostSummary(ctx context.Context, runID string) (cost float64, currency string, priced bool, err error)
 
 	// UsageReport aggregates the token_usage ledger for a report (RFC AV Phase 2):
 	// summed tokens + cost grouped by the requested dimensions, over an optional

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -338,7 +338,9 @@ func Run(t *testing.T, factory Factory) {
 		// RFC AV — per-call usage ledger + per-run cost/source summary.
 		{"TokenUsageLedger", testTokenUsageLedger},
 		{"FinishRunPersistsCostAndSource", testFinishRunPersistsCostAndSource},
+		{"RunCostSummary", testRunCostSummary},
 		{"UsageReport", testUsageReport},
+		{"UsageReportPerCurrency", testUsageReportPerCurrency},
 		{"UsageRollupAndPrune", testUsageRollupAndPrune},
 		{"UsageReportArchiveWindowBoundary", testUsageReportArchiveWindowBoundary},
 		{"SessionArchiver", testSessionArchiver},
@@ -680,6 +682,53 @@ func testFinishRunPersistsCostAndSource(t *testing.T, s store.Store) {
 	}
 }
 
+// testRunCostSummary is the fix-9 store-contract check: RunCostSummary sums the
+// per-call ledger, reports the priced currency, and distinguishes a priced run
+// from an unpriced one (currency "" ⇒ the FinishRun caller stores a NULL cost).
+// Runs on both backends (the sqlite unit + the postgres CI job).
+func testRunCostSummary(t *testing.T, s store.Store) {
+	ctx := context.Background()
+
+	// Priced run: two calls at different costs → summed, currency reported, priced.
+	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: "rcs1", TenantID: "t", Provider: "p", Model: "m",
+		CredentialSource: "operator", InputTokens: 10, Cost: 0.25, CostCurrency: "USD"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: "rcs1", TenantID: "t", Provider: "p", Model: "m2",
+		Iteration: 1, CredentialSource: "operator", InputTokens: 20, Cost: 0.75, CostCurrency: "USD"}); err != nil {
+		t.Fatal(err)
+	}
+	cost, currency, priced, err := s.RunCostSummary(ctx, "rcs1")
+	if err != nil {
+		t.Fatalf("RunCostSummary(priced): %v", err)
+	}
+	if !priced || currency != "USD" || cost < 0.999 || cost > 1.001 {
+		t.Errorf("priced run = (cost=%v currency=%q priced=%v), want (1.0,USD,true)", cost, currency, priced)
+	}
+
+	// Unpriced run: a row with no currency (NULL cost) → priced=false, currency "".
+	if err := s.RecordCallUsage(ctx, store.TokenUsageRow{RunID: "rcs2", TenantID: "t", Provider: "p", Model: "x",
+		CredentialSource: "operator", InputTokens: 5, CostCurrency: ""}); err != nil {
+		t.Fatal(err)
+	}
+	cost2, currency2, priced2, err := s.RunCostSummary(ctx, "rcs2")
+	if err != nil {
+		t.Fatalf("RunCostSummary(unpriced): %v", err)
+	}
+	if priced2 || currency2 != "" || cost2 != 0 {
+		t.Errorf("unpriced run = (cost=%v currency=%q priced=%v), want (0,\"\",false)", cost2, currency2, priced2)
+	}
+
+	// A run with no ledger rows at all → unpriced (never priced).
+	_, cur3, priced3, err := s.RunCostSummary(ctx, "rcs-none")
+	if err != nil {
+		t.Fatalf("RunCostSummary(empty): %v", err)
+	}
+	if priced3 || cur3 != "" {
+		t.Errorf("no-ledger run = (currency=%q priced=%v), want (\"\",false)", cur3, priced3)
+	}
+}
+
 // testUsageReport exercises the RFC AV Phase 2 aggregation: grouping,
 // tenant/window scoping, the operator-vs-tenant split, and the unpriced-call
 // count. Rows are inserted directly (no run needed — token_usage has no FK).
@@ -705,9 +754,9 @@ func testUsageReport(t *testing.T, s store.Store) {
 		}
 	}
 
-	sum := func(aggs []store.UsageAggregate, tenant, source string) (in int64, cost float64, unpriced int64, found bool) {
+	sum := func(aggs []store.UsageAggregate, tenant, source, currency string) (in int64, cost float64, unpriced int64, found bool) {
 		for _, a := range aggs {
-			if a.TenantID == tenant && a.CredentialSource == source {
+			if a.TenantID == tenant && a.CredentialSource == source && a.Currency == currency {
 				return a.InputTokens, a.Cost, a.UnpricedCalls, true
 			}
 		}
@@ -719,14 +768,19 @@ func testUsageReport(t *testing.T, s store.Store) {
 	if err != nil {
 		t.Fatalf("UsageReport: %v", err)
 	}
-	// A/operator merges the priced + unpriced rows: 150 tokens, cost 1.0, 1 unpriced.
-	if in, cost, unpriced, ok := sum(all, "A", "operator"); !ok || in != 150 || cost != 1.0 || unpriced != 1 {
-		t.Errorf("A/operator = (in=%d cost=%v unpriced=%d ok=%v), want (150,1,1,true)", in, cost, unpriced, ok)
+	// A/operator splits by currency (fix-10 — never sum across currencies): the
+	// priced USD row (100 tok, 1.0) and the unpriced '' row (50 tok, 1 unpriced) do
+	// NOT merge into one 150-token row.
+	if in, cost, unpriced, ok := sum(all, "A", "operator", "USD"); !ok || in != 100 || cost != 1.0 || unpriced != 0 {
+		t.Errorf("A/operator/USD = (in=%d cost=%v unpriced=%d ok=%v), want (100,1,0,true)", in, cost, unpriced, ok)
 	}
-	if in, cost, _, ok := sum(all, "A", "tenant"); !ok || in != 200 || cost != 2.0 {
+	if in, cost, unpriced, ok := sum(all, "A", "operator", ""); !ok || in != 50 || cost != 0 || unpriced != 1 {
+		t.Errorf("A/operator/unpriced = (in=%d cost=%v unpriced=%d ok=%v), want (50,0,1,true)", in, cost, unpriced, ok)
+	}
+	if in, cost, _, ok := sum(all, "A", "tenant", "USD"); !ok || in != 200 || cost != 2.0 {
 		t.Errorf("A/tenant = (%d,%v,%v), want (200,2,true)", in, cost, ok)
 	}
-	if in, cost, _, ok := sum(all, "B", "operator"); !ok || in != 400 || cost != 4.0 {
+	if in, cost, _, ok := sum(all, "B", "operator", "USD"); !ok || in != 400 || cost != 4.0 {
 		t.Errorf("B/operator = (%d,%v,%v), want (400,4,true)", in, cost, ok)
 	}
 
@@ -739,16 +793,55 @@ func testUsageReport(t *testing.T, s store.Store) {
 	}
 
 	// Operator bill = group by source, filter source=operator across all tenants:
-	// cost 1.0 (A) + 4.0 (B) = 5.0.
+	// cost 1.0 (A) + 4.0 (B) = 5.0. Sum across the operator's currency rows (only
+	// the USD row carries cost; the '' unpriced row is 0).
 	bySource, _ := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageBySource}})
 	var opCost float64
 	for _, a := range bySource {
 		if a.CredentialSource == "operator" {
-			opCost = a.Cost
+			opCost += a.Cost
 		}
 	}
 	if opCost != 5.0 {
 		t.Errorf("operator bill = %v, want 5.0", opCost)
+	}
+}
+
+// testUsageReportPerCurrency is the fix-10 regression: UsageReport must never sum
+// across currencies. Two priced calls in the SAME (tenant, source) bucket but with
+// different currencies (USD + EUR) must yield TWO rows — one per currency, each
+// with its own cost — not one row summing 1.5+2.5 under an arbitrary MAX label.
+func testUsageReportPerCurrency(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	rows := []store.TokenUsageRow{
+		{RunID: "r_usd", TenantID: "MC", Provider: "anthropic", Model: "m",
+			CredentialSource: "operator", InputTokens: 100, Cost: 1.5, CostCurrency: "USD"},
+		{RunID: "r_eur", TenantID: "MC", Provider: "anthropic", Model: "m",
+			CredentialSource: "operator", InputTokens: 200, Cost: 2.5, CostCurrency: "EUR"},
+	}
+	for _, r := range rows {
+		if err := s.RecordCallUsage(ctx, r); err != nil {
+			t.Fatalf("RecordCallUsage: %v", err)
+		}
+	}
+	rep, err := s.UsageReport(ctx, store.UsageQuery{GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageBySource}})
+	if err != nil {
+		t.Fatalf("UsageReport: %v", err)
+	}
+	byCurrency := map[string]store.UsageAggregate{}
+	for _, a := range rep {
+		if a.TenantID == "MC" && a.CredentialSource == "operator" {
+			byCurrency[a.Currency] = a
+		}
+	}
+	if len(byCurrency) != 2 {
+		t.Fatalf("MC/operator rows = %d, want 2 (one per currency): %+v", len(byCurrency), rep)
+	}
+	if a := byCurrency["USD"]; a.Cost != 1.5 || a.InputTokens != 100 {
+		t.Errorf("USD row = (cost=%v in=%d), want (1.5,100)", a.Cost, a.InputTokens)
+	}
+	if a := byCurrency["EUR"]; a.Cost != 2.5 || a.InputTokens != 200 {
+		t.Errorf("EUR row = (cost=%v in=%d), want (2.5,200)", a.Cost, a.InputTokens)
 	}
 }
 

--- a/internal/usage/sweeper.go
+++ b/internal/usage/sweeper.go
@@ -294,6 +294,14 @@ func (s *Sweeper) archiveSessionsOnce(parent context.Context) (int, error) {
 	}
 	deleted := 0
 	for _, sid := range sessions {
+		// The whole batch shares one 2-minute deadline. Once it expires, every
+		// remaining export/DeleteSessionCascade would fail with the same ctx error —
+		// stop cleanly and return what we finished, instead of logging a burst of
+		// "context deadline exceeded" once per remaining session. The next tick
+		// resumes from where this one stopped (PrunableAgedSessions is re-queried).
+		if ctx.Err() != nil {
+			break
+		}
 		if s.runMode == "export+prune" {
 			if err := s.exportSession(ctx, sid); err != nil {
 				// Never delete a session we failed to export — retry next tick.

--- a/internal/usage/sweeper_test.go
+++ b/internal/usage/sweeper_test.go
@@ -220,6 +220,72 @@ func TestArchiveSessionsOnce(t *testing.T) {
 	})
 }
 
+// cancelAfterFirstDeleteStore wraps a real store but cancels a captured context
+// right after the FIRST DeleteSessionCascade succeeds — simulating the shared
+// batch deadline expiring mid-batch. Used by the fix-11 regression.
+type cancelAfterFirstDeleteStore struct {
+	store.Store
+	cancel  context.CancelFunc
+	deletes int
+}
+
+func (c *cancelAfterFirstDeleteStore) DeleteSessionCascade(ctx context.Context, id string) error {
+	c.deletes++
+	err := c.Store.DeleteSessionCascade(ctx, id)
+	if c.deletes == 1 {
+		c.cancel() // the batch's 2-minute deadline "expires" after one delete
+	}
+	return err
+}
+
+// TestArchiveSessionsOnce_StopsOnExpiredDeadline is the fix-11 regression: the
+// archiver batch shares one deadline, so once it expires mid-batch every remaining
+// DeleteSessionCascade would fail with the same ctx error. The loop must break at
+// the next iteration and return what it finished — not iterate the whole batch
+// against a dead ctx (a burst of "context deadline exceeded" logs). Three sessions
+// are prunable, but the ctx dies after the first delete → exactly one delete runs.
+func TestArchiveSessionsOnce_StopsOnExpiredDeadline(t *testing.T) {
+	ctx := context.Background()
+	future := func() time.Time { return time.Now().Add(48 * time.Hour) }
+	st := newTestStore(t)
+
+	// Seed three aged, all-terminal (prunable) sessions.
+	for _, agentID := range []string{"exp-a", "exp-b", "exp-c"} {
+		sess, err := st.CreateSession(ctx, "t", "default", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		run, err := st.CreateRun(ctx, sess.ID, store.RunIdentity{AgentID: agentID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := st.FinishRun(ctx, run.ID, store.RunCompleted, "end_turn", store.Usage{Model: "m", Provider: "p"}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	parent, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	wrapped := &cancelAfterFirstDeleteStore{Store: st, cancel: cancel}
+	sw := New(wrapped, Config{
+		RunRetention:     24 * time.Hour,
+		RunRetentionMode: "prune",
+		Logger:           func(string, ...any) {},
+		Now:              future,
+	})
+
+	n, err := sw.archiveSessionsOnce(parent)
+	if err != nil {
+		t.Fatalf("archiveSessionsOnce err = %v, want nil (clean early stop)", err)
+	}
+	if n != 1 {
+		t.Errorf("deleted = %d, want 1 (batch stopped after the deadline expired)", n)
+	}
+	if wrapped.deletes != 1 {
+		t.Errorf("DeleteSessionCascade called %d times, want 1 (loop must break, not run against a dead ctx)", wrapped.deletes)
+	}
+}
+
 // TestSweeperRun_StopsOnContextDone asserts the goroutine exits cleanly
 // when its context is cancelled, so shutdown doesn't leak the sweeper
 // goroutine past the Store's close.


### PR DESCRIPTION
The lower-severity remainder of the review. **Stacked on #639 (findings #1–8)** — it targets that branch; merge #639 first, then this rebases onto main cleanly.

## Fixes

- **#9 — `runs.cost` disagreed with `SUM(token_usage.cost)` on mid-run fallback** (priced from the final model × cumulative tokens). Fix: `runs.cost` is now the **sum of the run's per-call ledger costs** — `store.RunCostSummary(run_id)` (both backends), used by `finishRun`/`finishRunCancelled`; NULL preserved when no priced rows. `runs.cost == Σ ledger` by construction.
- **#10 — UsageReport summed cost across mixed currencies** with an arbitrary `MAX` label. Fix: `cost_currency` is in the `GROUP BY`, so each report row is single-currency (unpriced rows group under `''`); single-currency deployments are unchanged.
- **#11 — archiver batch shared one 2-minute ctx** and kept iterating with a dead ctx on timeout. Fix: `break` on `ctx.Err()`.
- **#12 — `token_usage.session_id`:** already fixed in #639 (recordCallUsage sets it); confirmed by the identity regression test. No change.
- **#13 — nil-embed `store.Store` test doubles:** verified no current test path invokes the new methods on a nil embed (wrappers embed *real* stores; the nil embeds are on non-run paths). Latent + fail-loud; no churn.
- **#15 — extracted the duplicated UsageReport dim-builder loop** into `store.UsageGroupColumns` (dialect-independent); the `?`/`$N` + day-floor SQL stays per-backend. *(#14 resolveKey/toRFC3339 duplication deliberately deferred — cosmetic.)*

## Tested

`go test ./...` clean (exit 0), gofmt + vet clean, binary builds. Regressions for #9/#10/#11 verified fail-before / pass-after (both backends where applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)