### PR TITLE
feat(limits): per-scope token budgets (soft+hard) + limit event — RFC AW Phase 1

### DIFF
--- a/cmd/loomcycle/main.go
+++ b/cmd/loomcycle/main.go
@@ -2140,6 +2140,14 @@ func main() {
 		log.Printf("usage: sweeper disabled (LOOMCYCLE_USAGE_SWEEPER=0 or no Store)")
 	}
 
+	// RFC AW: seed the per-scope token-budget tracker from the RFC AV ledger
+	// (month-to-date counters + the token_limits ceilings). Non-fatal — a
+	// seeding fault leaves the counters empty (fail-open: budgets must never
+	// block the runtime from starting). No-op when the server has no store.
+	if err := srv.SeedLimits(bgCtx); err != nil {
+		log.Printf("limits: seed failed (budgets start empty until next write): %v", err)
+	}
+
 	// Memory tool TTL sweeper. Cheap periodic DELETE of expired rows.
 	// The store also filters expired entries at read time, so this
 	// goroutine only matters for keeping the table small over the

--- a/internal/api/grpc/server.go
+++ b/internal/api/grpc/server.go
@@ -1221,6 +1221,10 @@ func mapRunnerErr(err error) error {
 		// Runtime-wide pause in effect (RFC X) — new runs rejected until
 		// resume. Unavailable mirrors the HTTP 503 gate.
 		return status.Error(codes.Unavailable, err.Error())
+	case errors.Is(err, runner.ErrTokenLimitExceeded):
+		// Per-scope token budget hard cap reached (RFC AW). ResourceExhausted
+		// mirrors the HTTP 429 refusal + the backpressure/quota flavors above.
+		return status.Error(codes.ResourceExhausted, err.Error())
 	default:
 		return status.Errorf(codes.Internal, "runner: %v", err)
 	}

--- a/internal/api/http/auth_principal.go
+++ b/internal/api/http/auth_principal.go
@@ -534,6 +534,13 @@ func requiredScopeFor(method, path string) string {
 	// ScopeAdmin also satisfies. Read-only GET.
 	case path == "/v1/_usage":
 		return auth.ScopeTenant
+	// RFC AW: the token-budget management surface (GET list + PUT upsert + DELETE).
+	// Tenant-readable/writable so a tenant operator manages its own tenant + user
+	// budgets; the handler enforces the operator-global + cross-tenant admin
+	// restriction (a scoped caller writing the operator scope or a foreign tenant
+	// gets 403). ScopeAdmin also satisfies. Mirrors /v1/_usage's posture.
+	case path == "/v1/_limits":
+		return auth.ScopeTenant
 	// Routing view (GET /v1/_routing). Tenant-readable so a tenant operator's UI
 	// can see the resolved model cascade per tier; the HANDLER strips the live
 	// provider reachability / infra detail for a non-admin caller (admin gets the

--- a/internal/api/http/limits_admin.go
+++ b/internal/api/http/limits_admin.go
@@ -1,0 +1,249 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// RFC AW — the /v1/_limits management surface for per-scope token budgets.
+//
+// Tenant scoping mirrors /v1/_usage (RFC AS): admin/legacy/open see every row
+// and may focus one tenant via ?tenant=; a substrate:tenant operator sees +
+// writes ONLY its own tenant_id rows (its tenant + its users). The
+// operator-global cap (tenant_id='', scope='operator') and cross-tenant rows
+// are admin-only. The write path stamps the tenant from the principal for a
+// scoped caller — the wire tenant_id is never trusted for confinement.
+
+// limitScopes is the closed set of valid scope axes.
+var limitScopes = map[string]bool{"operator": true, "tenant": true, "user": true}
+
+// limitRowResponse is one token_limits row plus its live month-to-date usage.
+type limitRowResponse struct {
+	TenantID  string `json:"tenant_id"`
+	Scope     string `json:"scope"`
+	ScopeID   string `json:"scope_id,omitempty"`
+	SoftLimit *int64 `json:"soft_limit,omitempty"`
+	HardLimit *int64 `json:"hard_limit,omitempty"`
+	Used      int64  `json:"used"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+	UpdatedBy string `json:"updated_by,omitempty"`
+}
+
+type limitsListResponse struct {
+	Limits []limitRowResponse `json:"limits"`
+}
+
+// handleLimitsList serves GET /v1/_limits — the token budgets visible to the
+// caller, each with its current month-to-date usage from the tracker.
+func (s *Server) handleLimitsList(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; token budgets require a persistent store")
+		return
+	}
+	rows, err := s.store.TokenLimitsAll(r.Context())
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	tenantID, all := s.principalTenantScope(r.Context(), r.URL.Query().Get("tenant"))
+	out := make([]limitRowResponse, 0, len(rows))
+	for _, row := range rows {
+		if !all && row.TenantID != tenantID {
+			continue // a tenant operator sees only its own tenant's rows
+		}
+		resp := limitRowResponse{
+			TenantID:  row.TenantID,
+			Scope:     row.Scope,
+			ScopeID:   row.ScopeID,
+			SoftLimit: row.SoftLimit,
+			HardLimit: row.HardLimit,
+			Used:      s.limits.UsedFor(row.Scope, row.TenantID, row.ScopeID),
+			UpdatedBy: row.UpdatedBy,
+		}
+		if !row.UpdatedAt.IsZero() {
+			resp.UpdatedAt = row.UpdatedAt.UTC().Format(time.RFC3339)
+		}
+		out = append(out, resp)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(limitsListResponse{Limits: out})
+}
+
+// limitPutRequest is the PUT /v1/_limits body. tenant_id is a pointer so an
+// admin can address any tenant; it is IGNORED for confinement on a scoped
+// caller (stamped from the principal).
+type limitPutRequest struct {
+	TenantID  *string `json:"tenant_id"`
+	Scope     string  `json:"scope"`
+	ScopeID   string  `json:"scope_id"`
+	SoftLimit *int64  `json:"soft_limit"`
+	HardLimit *int64  `json:"hard_limit"`
+}
+
+// handleLimitPut serves PUT /v1/_limits — upsert one budget row. Tenant-scoped:
+// a substrate:tenant caller may write only its own tenant's tenant/user rows;
+// the operator scope + any cross-tenant write is admin-only (403).
+func (s *Server) handleLimitPut(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; token budgets require a persistent store")
+		return
+	}
+	var body limitPutRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096)).Decode(&body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error())
+		return
+	}
+	if !limitScopes[body.Scope] {
+		writeJSONError(w, http.StatusBadRequest, "bad_request",
+			"scope must be one of: operator, tenant, user")
+		return
+	}
+	if (body.SoftLimit != nil && *body.SoftLimit < 0) || (body.HardLimit != nil && *body.HardLimit < 0) {
+		writeJSONError(w, http.StatusBadRequest, "bad_request", "soft_limit/hard_limit must be >= 0")
+		return
+	}
+
+	tenantID, scopeID, ok := s.resolveLimitWrite(w, r, body.Scope, deref(body.TenantID), body.ScopeID)
+	if !ok {
+		return
+	}
+
+	row := store.TokenLimitRow{
+		TenantID:  tenantID,
+		Scope:     body.Scope,
+		ScopeID:   scopeID,
+		SoftLimit: body.SoftLimit,
+		HardLimit: body.HardLimit,
+		UpdatedAt: time.Now().UTC(),
+		UpdatedBy: principalSubject(r.Context()),
+	}
+	if err := s.store.TokenLimitPut(r.Context(), row); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if err := s.limits.ReloadLimits(r.Context()); err != nil {
+		// The row is persisted; a reload fault just means the cached ceiling
+		// lags until the next reload/seed. Log-and-continue (advisory).
+		writeJSONError(w, http.StatusInternalServerError, "internal", "limit stored but reload failed: "+err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(limitRowResponse{
+		TenantID:  row.TenantID,
+		Scope:     row.Scope,
+		ScopeID:   row.ScopeID,
+		SoftLimit: row.SoftLimit,
+		HardLimit: row.HardLimit,
+		Used:      s.limits.UsedFor(row.Scope, row.TenantID, row.ScopeID),
+		UpdatedAt: row.UpdatedAt.Format(time.RFC3339),
+		UpdatedBy: row.UpdatedBy,
+	})
+}
+
+// handleLimitDelete serves DELETE /v1/_limits?scope=&scope_id=&tenant= — remove
+// a budget (→ unlimited again). Same tenant-scope gate as the PUT.
+func (s *Server) handleLimitDelete(w http.ResponseWriter, r *http.Request) {
+	if s.store == nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "store_unavailable",
+			"store not configured; token budgets require a persistent store")
+		return
+	}
+	q := r.URL.Query()
+	scope := q.Get("scope")
+	if !limitScopes[scope] {
+		writeJSONError(w, http.StatusBadRequest, "bad_request",
+			"scope must be one of: operator, tenant, user")
+		return
+	}
+	tenantID, scopeID, ok := s.resolveLimitWrite(w, r, scope, q.Get("tenant"), q.Get("scope_id"))
+	if !ok {
+		return
+	}
+	if err := s.store.TokenLimitDelete(r.Context(), tenantID, scope, scopeID); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
+		return
+	}
+	if err := s.limits.ReloadLimits(r.Context()); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "internal", "limit deleted but reload failed: "+err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// resolveLimitWrite validates + resolves the authoritative (tenant_id, scope_id)
+// for a write, enforcing the RFC AW tenant confinement:
+//   - operator scope: admin-only; tenant_id and scope_id forced to "".
+//   - tenant scope: scope_id must be "" (the whole tenant); a scoped caller is
+//     confined to its own tenant, an admin may target any via wireTenant.
+//   - user scope: scope_id (the subject) required.
+//
+// Returns ok=false and writes the error response when the caller is not
+// entitled or the shape is invalid.
+func (s *Server) resolveLimitWrite(w http.ResponseWriter, r *http.Request, scope, wireTenant, scopeID string) (tenantID, resolvedScopeID string, ok bool) {
+	// all == admin / legacy / open mode → full authority (may write any tenant
+	// + the operator scope). A scoped substrate:tenant caller has all=false.
+	callerTenant, all := tenantScopeFromCtx(r.Context())
+
+	switch scope {
+	case "operator":
+		if !all {
+			writeJSONError(w, http.StatusForbidden, "forbidden",
+				"the operator-global budget is admin-only")
+			return "", "", false
+		}
+		// operator scope is a single global row; ignore any tenant/scope id.
+		return "", "", true
+	case "tenant":
+		if scopeID != "" {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"scope_id must be empty for scope=tenant")
+			return "", "", false
+		}
+	case "user":
+		if scopeID == "" {
+			writeJSONError(w, http.StatusBadRequest, "bad_request",
+				"scope_id (the user subject) is required for scope=user")
+			return "", "", false
+		}
+	}
+
+	// tenant / user scope: resolve the authoritative tenant.
+	if all {
+		// Admin may address any tenant; the wire tenant_id is authoritative here.
+		return wireTenant, scopeID, true
+	}
+	// Scoped caller: confined to its own tenant. A wire tenant_id that disagrees
+	// is a cross-tenant attempt → 403 (never silently rewritten to a foreign id).
+	if wireTenant != "" && wireTenant != callerTenant {
+		writeJSONError(w, http.StatusForbidden, "forbidden",
+			"a tenant operator may only manage budgets in its own tenant")
+		return "", "", false
+	}
+	return callerTenant, scopeID, true
+}
+
+// principalSubject returns the ctx principal's subject for the updated_by audit
+// column (empty for open/legacy mode).
+func principalSubject(ctx context.Context) string {
+	if p, ok := auth.PrincipalFromContext(ctx); ok {
+		return p.Subject
+	}
+	return ""
+}
+
+// deref returns the pointed-to string, or "" when the pointer is nil.
+func deref(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/internal/api/http/limits_admin_test.go
+++ b/internal/api/http/limits_admin_test.go
@@ -1,0 +1,231 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/auth"
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+func i64p(v int64) *int64 { return &v }
+
+// seedOperatorUsage records a token_usage row so the operator month-to-date
+// counter is non-zero after SeedLimits.
+func seedOperatorUsage(t *testing.T, srv *Server, inputTokens int) {
+	t.Helper()
+	if err := srv.store.RecordCallUsage(context.Background(), store.TokenUsageRow{
+		RunID: "seed_run", TenantID: "", UserID: "seed", Provider: "p", Model: "m",
+		CredentialSource: "operator", InputTokens: inputTokens, TS: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("seed usage: %v", err)
+	}
+}
+
+// completingProvider is a stub that finishes a run in one iteration (text +
+// done), so a POST /v1/runs returns after the run completes and events persist.
+func completingProvider() *scriptedProvider {
+	return &scriptedProvider{scripts: [][]providers.Event{{
+		{Type: providers.EventText, Text: "hi"},
+		{Type: providers.EventDone, StopReason: "end_turn", Usage: &providers.Usage{}},
+	}}}
+}
+
+// TestLimits_HardLimitRefusesRun is the RFC AW admission regression: an operator
+// hard ceiling below the month-to-date usage refuses a new POST /v1/runs with
+// 429 + code:"token_limit_exceeded", and NO run is started. Fails before the
+// admission Check is wired (the run would 200).
+func TestLimits_HardLimitRefusesRun(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+	seedOperatorUsage(t, srv, 1000)
+	if err := srv.store.TokenLimitPut(ctx, store.TokenLimitRow{Scope: "operator", HardLimit: i64p(500), UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.SeedLimits(ctx); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","user_id":"alice","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("hard limit must refuse with 429; got %d\nbody: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "token_limit_exceeded") {
+		t.Fatalf("body missing token_limit_exceeded: %s", body)
+	}
+}
+
+// TestLimits_SoftLimitEmitsEventInTranscript is the RFC AW soft-crossing
+// regression: with the operator soft ceiling below usage, the run STARTS (200)
+// and a `limit` event (severity soft) is persisted in the transcript. Fails
+// before the soft-at-admission emit is wired (no limit event lands).
+func TestLimits_SoftLimitEmitsEventInTranscript(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	ctx := context.Background()
+	seedOperatorUsage(t, srv, 1000)
+	if err := srv.store.TokenLimitPut(ctx, store.TokenLimitRow{Scope: "operator", SoftLimit: i64p(500), UpdatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.SeedLimits(ctx); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/v1/runs", "application/json", strings.NewReader(
+		`{"agent":"default","user_id":"alice","segments":[{"role":"user","content":[{"type":"trusted-text","text":"hi"}]}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("soft limit must allow the run; got %d\nbody: %s", resp.StatusCode, body)
+	}
+
+	events, _, err := srv.store.ListEvents(ctx, store.EventFilter{Type: "limit"}, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) == 0 {
+		t.Fatalf("expected a persisted `limit` event in the transcript; found none")
+	}
+	var ev providers.Event
+	if err := json.Unmarshal(events[0].Payload, &ev); err != nil {
+		t.Fatalf("decode limit event: %v", err)
+	}
+	if ev.Type != providers.EventLimit || ev.Limit == nil {
+		t.Fatalf("event is not a populated limit event: %+v", ev)
+	}
+	if ev.Limit.Severity != "soft" || ev.Limit.Scope != "operator" {
+		t.Fatalf("limit event payload wrong: %+v", ev.Limit)
+	}
+}
+
+// TestLimits_PutGetDeleteRoundTrip exercises the admin surface as an admin
+// principal: PUT a tenant budget, GET it back (with live usage), DELETE it.
+func TestLimits_PutGetDeleteRoundTrip(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	adminCtx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "ops", Subject: "root", Scopes: []string{auth.ScopeAdmin}})
+
+	// PUT a tenant budget for acme.
+	putBody, _ := json.Marshal(limitPutRequest{
+		TenantID: strPtr("acme"), Scope: "tenant", SoftLimit: i64p(100), HardLimit: i64p(200),
+	})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/_limits", bytes.NewReader(putBody)).WithContext(adminCtx)
+	srv.handleLimitPut(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	// GET the list — the acme tenant row must be present with the tiers.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/v1/_limits", nil).WithContext(adminCtx)
+	srv.handleLimitsList(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, want 200", rec.Code)
+	}
+	var list limitsListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, row := range list.Limits {
+		if row.TenantID == "acme" && row.Scope == "tenant" {
+			found = true
+			if row.SoftLimit == nil || *row.SoftLimit != 100 || row.HardLimit == nil || *row.HardLimit != 200 {
+				t.Fatalf("acme row tiers wrong: %+v", row)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("acme tenant row not in list: %+v", list.Limits)
+	}
+
+	// DELETE it.
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodDelete, "/v1/_limits?scope=tenant&tenant=acme", nil).WithContext(adminCtx)
+	srv.handleLimitDelete(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE status = %d, want 204; body: %s", rec.Code, rec.Body.String())
+	}
+	rows, err := srv.store.TokenLimitsAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if r.TenantID == "acme" && r.Scope == "tenant" {
+			t.Fatalf("acme row still present after delete: %+v", r)
+		}
+	}
+}
+
+// TestLimits_TenantScopingConfinesWrites is the RFC AW tenant-isolation
+// regression: a substrate:tenant operator may NOT write the operator-global row
+// nor a foreign tenant's row (403), and its own-tenant write is stamped from the
+// principal (never the wire tenant_id).
+func TestLimits_TenantScopingConfinesWrites(t *testing.T) {
+	srv, _ := makeServer(t, completingProvider(), makeBaseConfig())
+	tenantCtx := auth.WithPrincipal(context.Background(),
+		auth.Principal{TenantID: "acme", Subject: "op@acme", Scopes: []string{auth.ScopeTenant}})
+
+	call := func(body limitPutRequest) *httptest.ResponseRecorder {
+		b, _ := json.Marshal(body)
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPut, "/v1/_limits", bytes.NewReader(b)).WithContext(tenantCtx)
+		srv.handleLimitPut(rec, req)
+		return rec
+	}
+
+	// Operator-global write → 403.
+	if rec := call(limitPutRequest{Scope: "operator", HardLimit: i64p(10)}); rec.Code != http.StatusForbidden {
+		t.Fatalf("operator write by tenant op: status = %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	// Cross-tenant write → 403.
+	if rec := call(limitPutRequest{Scope: "tenant", TenantID: strPtr("evil"), HardLimit: i64p(10)}); rec.Code != http.StatusForbidden {
+		t.Fatalf("cross-tenant write: status = %d, want 403; body: %s", rec.Code, rec.Body.String())
+	}
+	// Own-tenant write (no wire tenant_id) → 200, stamped to acme.
+	if rec := call(limitPutRequest{Scope: "user", ScopeID: "u1", HardLimit: i64p(10)}); rec.Code != http.StatusOK {
+		t.Fatalf("own-tenant write: status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	rows, err := srv.store.TokenLimitsAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, r := range rows {
+		if r.Scope == "user" && r.ScopeID == "u1" {
+			found = true
+			if r.TenantID != "acme" {
+				t.Fatalf("user row stamped tenant = %q, want acme (from principal)", r.TenantID)
+			}
+			if r.UpdatedBy != "op@acme" {
+				t.Fatalf("updated_by = %q, want op@acme", r.UpdatedBy)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("own-tenant user row not persisted: %+v", rows)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/api/http/server.go
+++ b/internal/api/http/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/denn-gubsky/loomcycle/internal/contextplugin"
 	"github.com/denn-gubsky/loomcycle/internal/coord"
 	"github.com/denn-gubsky/loomcycle/internal/hooks"
+	"github.com/denn-gubsky/loomcycle/internal/limits"
 	"github.com/denn-gubsky/loomcycle/internal/lookup"
 	"github.com/denn-gubsky/loomcycle/internal/loop"
 	"github.com/denn-gubsky/loomcycle/internal/metrics"
@@ -123,6 +124,13 @@ type Server struct {
 	// (open-mode / no KEK). cmd/loomcycle/main.go calls SetCredentialResolver
 	// after construction. Reads run identity from the ctx it's given.
 	credResolver providers.CredentialResolver
+
+	// limits is the RFC AW per-scope token-budget tracker: month-to-date
+	// counters + cached soft/hard ceilings, checked at admission and
+	// incremented from recordCallUsage. Always non-nil after New() (a nil store
+	// yields a no-op tracker); its methods are nil-safe. Seeded from the ledger
+	// at boot via SeedLimits (main.go).
+	limits *limits.Tracker
 
 	// hookRegistry holds the runtime-registered tool-use hooks (the
 	// /v1/hooks endpoints write into this), and hookDispatcher is the
@@ -399,6 +407,10 @@ func New(cfg *config.Config, pr ProviderResolver, builtinTools []tools.Tool, sem
 		hookDispatcher: hooks.NewDispatcher(hookReg, nil),
 		startedAt:      time.Now(),
 	}
+	// RFC AW: per-scope token-budget tracker. limits.New(nil) is a no-op tracker
+	// (Check always allows, Add no-ops), so a store-less server keeps today's
+	// unlimited behavior. Seeded from the ledger at boot via SeedLimits.
+	s.limits = limits.New(st)
 	// F32: build the secret redactor from the process env (secret-classified
 	// names only). Default-ON; LOOMCYCLE_REDACT_SECRETS=0 leaves s.redactor nil
 	// (its methods are nil-safe, so makeRecordingEmit just skips redaction).
@@ -1850,6 +1862,16 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 		}
 		return fmt.Errorf("%w: %v", runner.ErrInternal, err)
 	}
+	// RFC AW token-budget admission: refuse a NEW run whose (tenant, user) has a
+	// hard ceiling at/over its month-to-date cap (checked AFTER the slot so a
+	// refusal doesn't leave one held, but BEFORE `defer release()` so the manual
+	// release() here isn't double-fired). Soft crossings (limitDec.Soft) don't
+	// block — they're emitted as warning events once the run's emit exists.
+	limitDec := s.limits.Check(effectiveTenantID, effectiveUserID)
+	if !limitDec.Allowed {
+		release()
+		return fmt.Errorf("%w: %s", runner.ErrTokenLimitExceeded, limitDec.Refusal.Message)
+	}
 	defer release()
 
 	// ---- Tool filtering + host narrowing ----
@@ -2015,6 +2037,12 @@ func (s *Server) RunOnce(ctx context.Context, in runner.RunInput, cb runner.RunC
 			cb.OnEvent(ev)
 		}
 	})
+	// RFC AW: emit any soft budget crossings the admission check found, so the
+	// warning lands at run start in the transcript/stream (dedup'd once-per-run
+	// by makeRecordingEmit's seenLimit set).
+	for _, info := range limitDec.Soft {
+		emit(providers.Event{Type: providers.EventLimit, Limit: &info})
+	}
 
 	// PR 2: operator steering queue for this run (in-flight input injection).
 	steerQ, onSteer, deregSteer := s.makeSteer(ctx, runID, agentID, sessionID, effectiveUserID, emit)
@@ -2340,6 +2368,12 @@ func (s *Server) Mux() http.Handler {
 	// /ui/audit page. Bearer-authed admin surface.
 	mux.Handle("GET /v1/_events", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleListEvents))))
 	mux.Handle("GET /v1/_usage", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleUsageReport))))
+	// RFC AW — per-scope token budgets (list / upsert / delete). Tenant-scoped
+	// (the handlers confine a substrate:tenant caller to its own tenant + reject
+	// the operator-global / cross-tenant writes with 403).
+	mux.Handle("GET /v1/_limits", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleLimitsList))))
+	mux.Handle("PUT /v1/_limits", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleLimitPut))))
+	mux.Handle("DELETE /v1/_limits", recoveryMiddleware(s.authMiddleware(http.HandlerFunc(s.handleLimitDelete))))
 	// v0.8.22 substrate admin endpoints. Bearer-authed; accept the
 	// same op-discriminated JSON body as the in-process tool +
 	// dispatch through the Connector with operator-trust ctx.
@@ -3168,6 +3202,17 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 		writeQuotaError(w, err)
 		return
 	}
+	// RFC AW token-budget admission: refuse with 429 when a hard ceiling for the
+	// run's (tenant, user) is at/over its month-to-date cap. Release the slot
+	// first so the refusal doesn't leak it; checked BEFORE `defer release()` so
+	// the manual release() isn't double-fired. Soft crossings are emitted as
+	// warning events once the run's emit exists (below).
+	limitDec := s.limits.Check(req.TenantID, req.UserID)
+	if !limitDec.Allowed {
+		release()
+		writeTokenLimitError(w, limitDec.Refusal)
+		return
+	}
 	defer release()
 
 	// Filter tools by agent allowlist + caller request.
@@ -3410,6 +3455,11 @@ func (s *Server) handleRuns(w http.ResponseWriter, r *http.Request) {
 	// Persist under runCtx so events survive a client disconnect on an
 	// interactive run (runCtx tracks the request for a normal run).
 	emit := s.makeRecordingEmit(runCtx, runID, rid, sessionID, streamFwd)
+	// RFC AW: emit any soft budget crossings found at admission so the warning
+	// lands at run start (dedup'd once-per-run by makeRecordingEmit).
+	for _, info := range limitDec.Soft {
+		emit(providers.Event{Type: providers.EventLimit, Limit: &info})
+	}
 
 	// PR 2: operator steering queue for this run (in-flight input injection).
 	steerQ, onSteer, deregSteer := s.makeSteer(runCtx, runID, agentID, sessionID, req.UserID, emit)
@@ -3760,6 +3810,16 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		writeQuotaError(w, err)
 		return
 	}
+	// RFC AW token-budget admission: a continuation starts a new turn/run, so
+	// refuse with 429 when the session's (tenant, user) hard ceiling is at/over
+	// its month-to-date cap. Release the slot first; check BEFORE `defer
+	// release()` so the manual release() isn't double-fired.
+	limitDec := s.limits.Check(sess.TenantID, sess.UserID)
+	if !limitDec.Allowed {
+		release()
+		writeTokenLimitError(w, limitDec.Refusal)
+		return
+	}
 	defer release()
 
 	// RFC N FIX 2-mcp: a continuation advertises at the SESSION's
@@ -3926,6 +3986,11 @@ func (s *Server) handleMessages(w http.ResponseWriter, r *http.Request) {
 		ParentContext:   body.ParentContext,   // v0.12.x: opaque tracking lineage, inherited by sub-agents
 	}
 	emit := s.makeRecordingEmit(r.Context(), run.ID, rid, id, stream.send)
+	// RFC AW: emit any soft budget crossings found at admission so the warning
+	// lands at run start (dedup'd once-per-run by makeRecordingEmit).
+	for _, info := range limitDec.Soft {
+		emit(providers.Event{Type: providers.EventLimit, Limit: &info})
+	}
 
 	// PR 2: operator steering queue for this continuation run.
 	steerQ, onSteer, deregSteer := s.makeSteer(r.Context(), run.ID, agentID, id, sess.UserID, emit)
@@ -4405,6 +4470,27 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, rid tools.
 	}
 	var mu sync.Mutex
 	var usageCallIdx int // RFC AV: per-call ledger row index within this run
+	// RFC AW: emit a budget `limit` event at most ONCE per (scope, severity)
+	// this run, so neither the soft-at-admission events nor repeated in-flight
+	// crossings spam the transcript. emitLimitLocked persists (a "limit" row)
+	// + forwards it; the caller must hold mu. Shared by BOTH the incoming
+	// EventLimit path (soft-at-admission, routed here) and the recordCallUsage
+	// in-flight crossings below, so the dedup set covers both.
+	seenLimit := map[string]bool{}
+	emitLimitLocked := func(info providers.LimitInfo) {
+		key := info.Scope + "|" + info.Severity
+		if seenLimit[key] {
+			return
+		}
+		seenLimit[key] = true
+		lev := providers.Event{Type: providers.EventLimit, Limit: &info}
+		if payload, err := json.Marshal(lev); err == nil {
+			if err := s.store.AppendEvent(ctx, runID, string(providers.EventLimit), payload); err != nil {
+				log.Printf("store: AppendEvent failed (run=%s type=limit): %v", runID, err)
+			}
+		}
+		fwd(lev)
+	}
 	return func(ev providers.Event) {
 		// Track parked (awaiting_input) state for the compaction boundary gate
 		// (handleCompactRun's IsParked check). The run is parked when it emits
@@ -4445,11 +4531,22 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, rid tools.
 			}
 			return
 		}
+		// RFC AW: a budget `limit` event (soft-at-admission emitted at the run
+		// site via this same callback) routes through the dedup + persist +
+		// forward helper, so it lands once as a "limit" transcript row.
+		if ev.Type == providers.EventLimit && ev.Limit != nil {
+			emitLimitLocked(*ev.Limit)
+			return
+		}
 		// RFC AV: append one per-call usage row (which key paid + priced cost).
 		// Additive side-effect — the event still persists + forwards through the
 		// general path below (it is also stored as a "usage" event, unchanged).
+		// RFC AW: recordCallUsage also increments the budget counters and returns
+		// any tier this call crossed (in-flight crossing) → emitted after the
+		// usage event itself is persisted+forwarded, below.
+		var crossings []providers.LimitInfo
 		if ev.Type == providers.EventUsage && ev.Usage != nil {
-			s.recordCallUsage(ctx, runID, rid, sessionID, usageCallIdx, ev.Usage)
+			crossings = s.recordCallUsage(ctx, runID, rid, sessionID, usageCallIdx, ev.Usage)
 			usageCallIdx++
 		}
 		// F32: redact secrets out of the PERSISTED copy only — the tool_call
@@ -4484,6 +4581,12 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, rid tools.
 			}
 		}
 		fwd(ev)
+		// RFC AW: emit any in-flight budget crossing AFTER the usage event it
+		// rode in on is persisted+forwarded, still under mu so the transcript
+		// order is stable. Dedup'd once-per-(scope,severity) per run.
+		for _, info := range crossings {
+			emitLimitLocked(info)
+		}
 	}
 }
 
@@ -4494,9 +4597,14 @@ func (s *Server) makeRecordingEmit(ctx context.Context, runID string, rid tools.
 // wire) — makeRecordingEmit is constructed before WithRunIdentity stamps the
 // loop ctx, so reading it here would attribute every row to "". A store error
 // is logged, not fatal — usage telemetry must never fail a run.
-func (s *Server) recordCallUsage(ctx context.Context, runID string, rid tools.RunIdentityValue, sessionID string, iteration int, u *providers.Usage) {
+//
+// RFC AW: also increments the in-memory token-budget counters for the run's
+// (tenant, user) by this call's total tokens and RETURNS the tiers this call
+// newly crossed, so makeRecordingEmit can emit a `limit` event. Nil tracker /
+// zero tokens → nil.
+func (s *Server) recordCallUsage(ctx context.Context, runID string, rid tools.RunIdentityValue, sessionID string, iteration int, u *providers.Usage) []providers.LimitInfo {
 	if s.store == nil || u == nil {
-		return
+		return nil
 	}
 	source := u.CredentialSource
 	if source == "" {
@@ -4532,6 +4640,38 @@ func (s *Server) recordCallUsage(ctx context.Context, runID string, rid tools.Ru
 	if err := s.store.RecordCallUsage(ctx, row); err != nil {
 		log.Printf("store: RecordCallUsage failed (run=%s iter=%d): %v", runID, iteration, err)
 	}
+	// RFC AW: increment the month-to-date budget counters + report any tier this
+	// call newly crossed (in-flight crossing). Nil-safe (no-op tracker → nil).
+	total := int64(u.InputTokens + u.OutputTokens + u.CacheCreationTokens + u.CacheReadTokens)
+	return s.limits.Add(rid.TenantID, rid.UserID, total)
+}
+
+// SeedLimits loads the RFC AW token-budget counters + ceilings from the store at
+// boot. Non-fatal: a seeding error leaves the counters empty (fail-open — a
+// budgeting fault must not block the runtime). Called from main.go once the
+// store is ready.
+func (s *Server) SeedLimits(ctx context.Context) error {
+	return s.limits.Seed(ctx)
+}
+
+// writeTokenLimitError writes the RFC AW hard-limit admission refusal as HTTP
+// 429 with a structured body naming the tripped scope, so an adapter can branch
+// on `code:"token_limit_exceeded"` and surface used/limit. The refusal names
+// only the CALLER's own tripped scope (not a cross-tenant oracle).
+func writeTokenLimitError(w http.ResponseWriter, info *providers.LimitInfo) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	body := map[string]any{
+		"code":     "token_limit_exceeded",
+		"error":    info.Message,
+		"scope":    info.Scope,
+		"scope_id": info.ScopeID,
+		"used":     info.Used,
+		"limit":    info.Limit,
+		"window":   info.Window,
+		"message":  info.Message,
+	}
+	_ = json.NewEncoder(w).Encode(body)
 }
 
 // runSummarySource returns the credential source to record on the run summary,

--- a/internal/limits/tracker.go
+++ b/internal/limits/tracker.go
@@ -1,0 +1,299 @@
+// Package limits implements RFC AW per-scope token budgets: an in-memory,
+// month-to-date token counter per (operator | tenant | user) scope, checked at
+// run admission against store-backed soft/hard ceilings.
+//
+// The counter is seeded at boot from the RFC AV usage ledger and incremented on
+// every per-call usage record, so admission reads are O(1) with no per-run
+// query. A scope with no limit row is unlimited (today's behavior). The window
+// is the calendar month in UTC; counters reset on the first mutation after a
+// month boundary. Enforcement is advisory (decision #O2): under multi-replica
+// each replica counts only its own calls, so a hard ceiling can be briefly
+// overshot across replicas — budgets bound spend, they are not a security
+// control. Fail-open on a store fault: a budgeting error must never take the
+// runtime down.
+package limits
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/providers"
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// Store is the minimal store surface the tracker needs (RFC AW): the RFC AV
+// usage aggregation to seed the month-to-date counters, and the token_limits
+// rows for the cached ceilings. Declared locally so the package depends only on
+// what it uses.
+type Store interface {
+	UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error)
+	TokenLimitsAll(ctx context.Context) ([]store.TokenLimitRow, error)
+}
+
+// tierPair is a scope's cached soft/hard ceilings; a nil pointer = that tier
+// unset (no ceiling on that severity).
+type tierPair struct {
+	soft *int64
+	hard *int64
+}
+
+// Decision is the admission verdict for a run (RFC AW). When Allowed is false a
+// hard ceiling tripped and Refusal names it; when Allowed is true, Soft carries
+// any soft ceilings the run has already crossed (emit as a warning at run start).
+type Decision struct {
+	Allowed bool
+	Refusal *providers.LimitInfo
+	Soft    []providers.LimitInfo
+}
+
+// Tracker holds the process-local month-to-date counters + the cached limits.
+type Tracker struct {
+	mu    sync.RWMutex
+	store Store
+	// now is the clock, injectable for tests. Defaults to time.Now.
+	now func() time.Time
+
+	month    time.Time        // current UTC month-start the counters cover
+	operator int64            // operator-global MTD tokens
+	tenant   map[string]int64 // tenant_id -> MTD tokens
+	user     map[string]int64 // userKey(tenant, subject) -> MTD tokens
+
+	// limits is the cached ceilings, keyed limitKey(scope, tenant, scopeID).
+	limits map[string]tierPair
+}
+
+// New builds a tracker over st. A nil store yields a no-op tracker: Check always
+// allows and Add is a no-op, so a store-less deployment keeps today's unlimited
+// behavior.
+func New(st Store) *Tracker {
+	return &Tracker{
+		store:  st,
+		now:    time.Now,
+		tenant: map[string]int64{},
+		user:   map[string]int64{},
+		limits: map[string]tierPair{},
+	}
+}
+
+// monthStartUTC returns the first instant (00:00 UTC) of now's calendar month.
+func monthStartUTC(now time.Time) time.Time {
+	y, m, _ := now.UTC().Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, time.UTC)
+}
+
+// tokensOf sums the four token buckets — the total the budget counts (RFC AW #5).
+func (t *Tracker) tokensOf(a store.UsageAggregate) int64 {
+	return a.InputTokens + a.OutputTokens + a.CacheCreationTokens + a.CacheReadTokens
+}
+
+// Seed loads the current month-to-date counters from the RFC AV ledger and the
+// ceilings from token_limits. Called once at boot; safe to call again. A no-op
+// (nil) for a store-less tracker.
+func (t *Tracker) Seed(ctx context.Context) error {
+	if t == nil || t.store == nil {
+		return nil
+	}
+	month := monthStartUTC(t.now())
+	aggs, err := t.store.UsageReport(ctx, store.UsageQuery{
+		From:    month,
+		GroupBy: []store.UsageDimension{store.UsageByTenant, store.UsageByUser},
+	})
+	if err != nil {
+		return err
+	}
+	tenant := make(map[string]int64)
+	user := make(map[string]int64)
+	var operator int64
+	for _, a := range aggs {
+		tok := t.tokensOf(a)
+		operator += tok
+		tenant[a.TenantID] += tok
+		user[userKey(a.TenantID, a.UserID)] += tok
+	}
+	lm, err := t.loadLimits(ctx)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.month = month
+	t.operator = operator
+	t.tenant = tenant
+	t.user = user
+	t.limits = lm
+	t.mu.Unlock()
+	return nil
+}
+
+// ReloadLimits refreshes only the cached ceilings (after a limits CRUD change).
+func (t *Tracker) ReloadLimits(ctx context.Context) error {
+	if t == nil || t.store == nil {
+		return nil
+	}
+	lm, err := t.loadLimits(ctx)
+	if err != nil {
+		return err
+	}
+	t.mu.Lock()
+	t.limits = lm
+	t.mu.Unlock()
+	return nil
+}
+
+func (t *Tracker) loadLimits(ctx context.Context) (map[string]tierPair, error) {
+	rows, err := t.store.TokenLimitsAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	lm := make(map[string]tierPair, len(rows))
+	for _, r := range rows {
+		lm[limitKey(r.Scope, r.TenantID, r.ScopeID)] = tierPair{soft: r.SoftLimit, hard: r.HardLimit}
+	}
+	return lm, nil
+}
+
+// Add increments the three scope counters (operator, tenant, user) by tokens and
+// returns the tiers this add NEWLY crossed (was below the tier before this add,
+// at or above it after) across the three scopes. Dedup once-per-run is the
+// caller's job. A no-op returning nil for a store-less tracker or a zero add.
+func (t *Tracker) Add(tenantID, userID string, tokens int64) []providers.LimitInfo {
+	if t == nil || t.store == nil || tokens <= 0 {
+		return nil
+	}
+	uk := userKey(tenantID, userID)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.rolloverLocked()
+
+	var crossed []providers.LimitInfo
+	crossed = appendCrossings(crossed, "operator", "", t.operator, t.operator+tokens, t.limits[limitKey("operator", "", "")])
+	t.operator += tokens
+
+	tb := t.tenant[tenantID]
+	crossed = appendCrossings(crossed, "tenant", tenantID, tb, tb+tokens, t.limits[limitKey("tenant", tenantID, "")])
+	t.tenant[tenantID] = tb + tokens
+
+	ub := t.user[uk]
+	crossed = appendCrossings(crossed, "user", userID, ub, ub+tokens, t.limits[limitKey("user", tenantID, userID)])
+	t.user[uk] = ub + tokens
+
+	return crossed
+}
+
+// Check is the admission verdict for a run's (tenant, user): refuse when ANY
+// scope's hard tier is set and month-to-date usage is at/over it (most-
+// restrictive wins; the first tripped scope in operator→tenant→user order is
+// named); otherwise allow, reporting any soft tiers already exceeded. A store-
+// less tracker always allows.
+func (t *Tracker) Check(tenantID, userID string) Decision {
+	if t == nil || t.store == nil {
+		return Decision{Allowed: true}
+	}
+	uk := userKey(tenantID, userID)
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	// After a month boundary but before the next Add resets the counters, treat
+	// usage as 0 so admission doesn't refuse against last month's total (Add
+	// performs the actual reset on the next write).
+	rolled := !monthStartUTC(t.now()).Equal(t.month)
+	usedOf := func(cur int64) int64 {
+		if rolled {
+			return 0
+		}
+		return cur
+	}
+
+	scopes := []struct {
+		scope, scopeID string
+		used           int64
+		tp             tierPair
+	}{
+		{"operator", "", usedOf(t.operator), t.limits[limitKey("operator", "", "")]},
+		{"tenant", tenantID, usedOf(t.tenant[tenantID]), t.limits[limitKey("tenant", tenantID, "")]},
+		{"user", userID, usedOf(t.user[uk]), t.limits[limitKey("user", tenantID, userID)]},
+	}
+
+	for _, sc := range scopes {
+		if sc.tp.hard != nil && sc.used >= *sc.tp.hard {
+			info := makeLimitInfo(sc.scope, sc.scopeID, "hard", sc.used, *sc.tp.hard)
+			return Decision{Allowed: false, Refusal: &info}
+		}
+	}
+	var soft []providers.LimitInfo
+	for _, sc := range scopes {
+		if sc.tp.soft != nil && sc.used >= *sc.tp.soft {
+			soft = append(soft, makeLimitInfo(sc.scope, sc.scopeID, "soft", sc.used, *sc.tp.soft))
+		}
+	}
+	return Decision{Allowed: true, Soft: soft}
+}
+
+// UsedFor returns a scope's current month-to-date token total (RFC AW), for the
+// /v1/_limits UI showing usage against each ceiling. scopeID is the tenant id
+// for scope=tenant and the user subject for scope=user.
+func (t *Tracker) UsedFor(scope, tenantID, scopeID string) int64 {
+	if t == nil || t.store == nil {
+		return 0
+	}
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if !monthStartUTC(t.now()).Equal(t.month) {
+		return 0 // a new month with no writes yet reads as zero spend
+	}
+	switch scope {
+	case "operator":
+		return t.operator
+	case "tenant":
+		return t.tenant[tenantID]
+	case "user":
+		return t.user[userKey(tenantID, scopeID)]
+	}
+	return 0
+}
+
+// rolloverLocked resets the counters when the wall clock has crossed into a new
+// calendar month. Caller must hold the write lock.
+func (t *Tracker) rolloverLocked() {
+	if cur := monthStartUTC(t.now()); !cur.Equal(t.month) {
+		t.month = cur
+		t.operator = 0
+		t.tenant = map[string]int64{}
+		t.user = map[string]int64{}
+	}
+}
+
+// appendCrossings appends a LimitInfo for each tier (soft, then hard) that the
+// [before, after) increment newly crossed.
+func appendCrossings(dst []providers.LimitInfo, scope, scopeID string, before, after int64, tp tierPair) []providers.LimitInfo {
+	if tp.soft != nil && before < *tp.soft && after >= *tp.soft {
+		dst = append(dst, makeLimitInfo(scope, scopeID, "soft", after, *tp.soft))
+	}
+	if tp.hard != nil && before < *tp.hard && after >= *tp.hard {
+		dst = append(dst, makeLimitInfo(scope, scopeID, "hard", after, *tp.hard))
+	}
+	return dst
+}
+
+func userKey(tenantID, subject string) string { return tenantID + "\x00" + subject }
+
+func limitKey(scope, tenantID, scopeID string) string {
+	return scope + "|" + tenantID + "|" + scopeID
+}
+
+func makeLimitInfo(scope, scopeID, severity string, used, limit int64) providers.LimitInfo {
+	label := scope
+	if scopeID != "" {
+		label = scope + " " + scopeID
+	}
+	return providers.LimitInfo{
+		Scope:    scope,
+		ScopeID:  scopeID,
+		Severity: severity,
+		Window:   "month",
+		Used:     used,
+		Limit:    limit,
+		Message:  fmt.Sprintf("%s %s token budget reached: %d of %d tokens this month", label, severity, used, limit),
+	}
+}

--- a/internal/limits/tracker_test.go
+++ b/internal/limits/tracker_test.go
@@ -1,0 +1,216 @@
+package limits
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/denn-gubsky/loomcycle/internal/store"
+)
+
+// fakeStore is an in-memory Store for the tracker tests: canned usage
+// aggregates for Seed + a settable limit-row set.
+type fakeStore struct {
+	aggs   []store.UsageAggregate
+	limits []store.TokenLimitRow
+	err    error
+}
+
+func (f *fakeStore) UsageReport(ctx context.Context, q store.UsageQuery) ([]store.UsageAggregate, error) {
+	return f.aggs, f.err
+}
+func (f *fakeStore) TokenLimitsAll(ctx context.Context) ([]store.TokenLimitRow, error) {
+	return f.limits, f.err
+}
+
+func i64(v int64) *int64 { return &v }
+
+func agg(tenant, user string, in, out int64) store.UsageAggregate {
+	return store.UsageAggregate{TenantID: tenant, UserID: user, InputTokens: in, OutputTokens: out}
+}
+
+// TestTracker_UnlimitedWhenNoRows: no limit rows → every run allowed regardless
+// of spend, no soft events.
+func TestTracker_UnlimitedWhenNoRows(t *testing.T) {
+	tr := New(&fakeStore{aggs: []store.UsageAggregate{agg("acme", "u1", 10_000, 5_000)}})
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	dec := tr.Check("acme", "u1")
+	if !dec.Allowed || dec.Refusal != nil || len(dec.Soft) != 0 {
+		t.Fatalf("no limit rows must allow with no soft events; got %+v", dec)
+	}
+}
+
+// TestTracker_NilStoreAllows: a store-less tracker always allows + Add no-ops.
+func TestTracker_NilStoreAllows(t *testing.T) {
+	tr := New(nil)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if crossed := tr.Add("acme", "u1", 1_000_000); crossed != nil {
+		t.Fatalf("nil-store Add must be a no-op; got %+v", crossed)
+	}
+	if dec := tr.Check("acme", "u1"); !dec.Allowed {
+		t.Fatalf("nil-store Check must allow; got %+v", dec)
+	}
+}
+
+// TestTracker_SoftCrossingAllowsWithEvent: a tenant over its soft tier (but under
+// hard, or no hard) is allowed, with a soft LimitInfo reported.
+func TestTracker_SoftCrossingAllowsWithEvent(t *testing.T) {
+	fs := &fakeStore{
+		aggs:   []store.UsageAggregate{agg("acme", "u1", 600, 0)},
+		limits: []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", SoftLimit: i64(500)}},
+	}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	dec := tr.Check("acme", "u1")
+	if !dec.Allowed || dec.Refusal != nil {
+		t.Fatalf("soft-only crossing must allow; got %+v", dec)
+	}
+	if len(dec.Soft) != 1 || dec.Soft[0].Scope != "tenant" || dec.Soft[0].Severity != "soft" {
+		t.Fatalf("want one soft tenant event; got %+v", dec.Soft)
+	}
+}
+
+// TestTracker_HardCrossingRefuses: a scope at/over its hard tier refuses.
+func TestTracker_HardCrossingRefuses(t *testing.T) {
+	fs := &fakeStore{
+		aggs:   []store.UsageAggregate{agg("acme", "u1", 900, 0)},
+		limits: []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)}},
+	}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	dec := tr.Check("acme", "u1")
+	if dec.Allowed || dec.Refusal == nil {
+		t.Fatalf("hard crossing must refuse; got %+v", dec)
+	}
+	if dec.Refusal.Scope != "tenant" || dec.Refusal.Severity != "hard" || dec.Refusal.Limit != 800 {
+		t.Fatalf("refusal payload wrong; got %+v", dec.Refusal)
+	}
+}
+
+// TestTracker_MostRestrictiveWins: a user hard tier tighter than the tenant's
+// decides the refusal (both would refuse; the user scope is named because its
+// ceiling is the one actually crossed).
+func TestTracker_MostRestrictiveWins(t *testing.T) {
+	fs := &fakeStore{
+		aggs: []store.UsageAggregate{agg("acme", "u1", 150, 0)},
+		limits: []store.TokenLimitRow{
+			{TenantID: "acme", Scope: "tenant", HardLimit: i64(10_000)},           // not crossed
+			{TenantID: "acme", Scope: "user", ScopeID: "u1", HardLimit: i64(100)}, // crossed
+		},
+	}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	dec := tr.Check("acme", "u1")
+	if dec.Allowed || dec.Refusal == nil {
+		t.Fatalf("user hard crossing must refuse; got %+v", dec)
+	}
+	if dec.Refusal.Scope != "user" || dec.Refusal.ScopeID != "u1" {
+		t.Fatalf("want user scope refusal; got %+v", dec.Refusal)
+	}
+}
+
+// TestTracker_OperatorScopeSumsAllTenants: the operator-global counter is the sum
+// across every tenant/user, so an operator hard tier refuses even a fresh tenant.
+func TestTracker_OperatorScopeSumsAllTenants(t *testing.T) {
+	fs := &fakeStore{
+		aggs: []store.UsageAggregate{
+			agg("acme", "u1", 400, 0),
+			agg("beta", "u2", 400, 0),
+		},
+		limits: []store.TokenLimitRow{{Scope: "operator", HardLimit: i64(500)}},
+	}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// A brand-new tenant with zero of its own spend is still refused by the
+	// operator-global cap (800 >= 500).
+	dec := tr.Check("gamma", "u9")
+	if dec.Allowed || dec.Refusal == nil || dec.Refusal.Scope != "operator" {
+		t.Fatalf("operator-global cap must refuse across tenants; got %+v", dec)
+	}
+}
+
+// TestTracker_AddReturnsCrossingsOnce: Add reports a tier only on the increment
+// that crosses it, not on subsequent adds already past it.
+func TestTracker_AddReturnsCrossingsOnce(t *testing.T) {
+	fs := &fakeStore{limits: []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", SoftLimit: i64(100), HardLimit: i64(300)}}}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// First add stays below soft → no crossing.
+	if c := tr.Add("acme", "u1", 50); len(c) != 0 {
+		t.Fatalf("below-soft add should cross nothing; got %+v", c)
+	}
+	// Second add crosses soft (50→150).
+	c := tr.Add("acme", "u1", 100)
+	if len(c) != 1 || c[0].Severity != "soft" {
+		t.Fatalf("want one soft crossing; got %+v", c)
+	}
+	// Third add stays between soft and hard → no new crossing.
+	if c := tr.Add("acme", "u1", 100); len(c) != 0 {
+		t.Fatalf("already-past-soft add should cross nothing; got %+v", c)
+	}
+	// Fourth add crosses hard (250→350).
+	c = tr.Add("acme", "u1", 100)
+	if len(c) != 1 || c[0].Severity != "hard" {
+		t.Fatalf("want one hard crossing; got %+v", c)
+	}
+}
+
+// TestTracker_MonthRolloverResets: a wall-clock month boundary resets the
+// counters on the next Add, so last month's spend no longer refuses.
+func TestTracker_MonthRolloverResets(t *testing.T) {
+	fs := &fakeStore{
+		aggs:   []store.UsageAggregate{agg("acme", "u1", 900, 0)},
+		limits: []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)}},
+	}
+	tr := New(fs)
+	now := time.Date(2026, 1, 15, 12, 0, 0, 0, time.UTC)
+	tr.now = func() time.Time { return now }
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if dec := tr.Check("acme", "u1"); dec.Allowed {
+		t.Fatal("January spend over hard must refuse")
+	}
+	// Advance the clock into February. Check reads zero (rolled), and Add resets.
+	now = time.Date(2026, 2, 1, 0, 0, 1, 0, time.UTC)
+	if dec := tr.Check("acme", "u1"); !dec.Allowed {
+		t.Fatalf("new month must reset admission; got %+v", dec)
+	}
+	tr.Add("acme", "u1", 10)
+	if got := tr.UsedFor("tenant", "acme", ""); got != 10 {
+		t.Fatalf("after rollover UsedFor = %d, want 10 (reset + this add)", got)
+	}
+}
+
+// TestTracker_ReloadLimits picks up a new ceiling without a re-seed of counters.
+func TestTracker_ReloadLimits(t *testing.T) {
+	fs := &fakeStore{aggs: []store.UsageAggregate{agg("acme", "u1", 900, 0)}}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if dec := tr.Check("acme", "u1"); !dec.Allowed {
+		t.Fatal("no rows yet → allowed")
+	}
+	fs.limits = []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)}}
+	if err := tr.ReloadLimits(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if dec := tr.Check("acme", "u1"); dec.Allowed {
+		t.Fatal("after ReloadLimits the hard tier must refuse")
+	}
+}

--- a/internal/providers/provider.go
+++ b/internal/providers/provider.go
@@ -499,6 +499,19 @@ const (
 	// a crash-recovery/resume rebuild reconstructs the compacted form, not the
 	// full history. The full transcript is retained (non-destructive audit).
 	EventContextCompaction EventType = "context_compaction"
+
+	// EventLimit carries a per-scope token-budget crossing (RFC AW): a soft
+	// crossing (warn, run continues) or a hard crossing (a mid-run notice; the
+	// run still finishes, but the NEXT run for the scope is refused at
+	// admission). The Limit field carries the structured payload.
+	//
+	// Unlike EventUsage/EventThinking, EventLimit is SERVER-generated (the
+	// admission gate + recordCallUsage increment path), never emitted by a
+	// provider driver — so the loop's per-iteration event switch needs NO case
+	// for it. It is forwarded to consumers + persisted as a transcript row
+	// through the server's makeRecordingEmit path (soft-at-admission + in-flight
+	// crossing), so the /run terminal + chat render a budget banner.
+	EventLimit EventType = "limit"
 )
 
 // Event is one streamed datum from a provider call (or, after the loop layer
@@ -560,6 +573,10 @@ type Event struct {
 	// ContextCompaction carries the structured payload on EventContextCompaction
 	// (the conversation summary that replaces prior history). Nil otherwise.
 	ContextCompaction *ContextCompactionEventInfo `json:"context_compaction,omitempty"`
+
+	// Limit carries the structured payload on EventLimit (a per-scope
+	// token-budget crossing, RFC AW). Nil on all other event types.
+	Limit *LimitInfo `json:"limit,omitempty"`
 
 	// StopReason is set on the final assistant Event of a provider call:
 	// "end_turn" | "tool_use" | "max_tokens" | "stop_sequence".
@@ -775,6 +792,31 @@ type ContextCompactionEventInfo struct {
 	// Trigger is "manual" | "auto" | "self" — which path fired the compaction.
 	// Surfaced for metrics + the UI; not used by replay.
 	Trigger string `json:"trigger,omitempty"`
+}
+
+// LimitInfo is the structured payload on EventLimit (RFC AW — per-scope token
+// budgets). It names which scope tripped, how hard, and where the scope stands
+// against its ceiling, so a UI can render "tenant acme at 1.2M / 1M tokens this
+// month" without a follow-up fetch. No secrets: Scope/ScopeID are a
+// tenant/subject id (already non-secret, like user_id) and the counts are
+// integers. Wire-stable; field names are part of the RFC AW contract.
+type LimitInfo struct {
+	// Scope is which axis tripped: "operator" | "tenant" | "user".
+	Scope string `json:"scope"`
+	// ScopeID is the tripped scope's id — the tenant id for scope=tenant, the
+	// user subject for scope=user, "" for the operator-global scope.
+	ScopeID string `json:"scope_id,omitempty"`
+	// Severity is "soft" (warn, run continues) or "hard" (this run finishes but
+	// the next is refused at admission).
+	Severity string `json:"severity"`
+	// Window is the budget window; "month" (calendar month, UTC) in Phase 1.
+	Window string `json:"window"`
+	// Used is the scope's month-to-date token total at the crossing.
+	Used int64 `json:"used"`
+	// Limit is the tier that was crossed (the soft or hard ceiling).
+	Limit int64 `json:"limit"`
+	// Message is a human-readable banner string. Optional.
+	Message string `json:"message,omitempty"`
 }
 
 // HostWideningEventInfo is the structured payload on EventHostWidened

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -93,6 +93,11 @@ var (
 	// quiescing for a snapshot; retry after resume. Wire: HTTP 503 / gRPC
 	// Unavailable.
 	ErrRuntimePaused = errors.New("runtime paused")
+	// ErrTokenLimitExceeded — a per-scope token budget's HARD ceiling is at/over
+	// its month-to-date cap, so the run is refused at admission (RFC AW). The
+	// operator/tenant/user has spent its monthly token budget; retry next month
+	// or raise the limit. Wire: HTTP 429 / gRPC ResourceExhausted.
+	ErrTokenLimitExceeded = errors.New("token_limit_exceeded")
 	// ErrInternal — unexpected error from store / loop / providers.
 	// Wire: HTTP 500 / gRPC Internal.
 	ErrInternal = errors.New("internal error")

--- a/internal/store/postgres/migrations/0054_token_limits.down.sql
+++ b/internal/store/postgres/migrations/0054_token_limits.down.sql
@@ -1,0 +1,2 @@
+-- 0054_token_limits.down.sql — drop the RFC AW per-scope token budgets table.
+DROP TABLE IF EXISTS token_limits;

--- a/internal/store/postgres/migrations/0054_token_limits.up.sql
+++ b/internal/store/postgres/migrations/0054_token_limits.up.sql
@@ -1,0 +1,25 @@
+-- 0054_token_limits.up.sql — RFC AW: per-scope token budgets (soft + hard).
+--
+-- token_limits is the dynamic, tenant-scoped budget primitive: one calendar-month
+-- token ceiling per (operator | tenant | user) scope. A row's absence = unlimited
+-- (today's behavior). A NULL soft_limit or hard_limit = that tier unset. No
+-- secrets: scope ids (tenant / subject, already non-secret like user_id) and
+-- integer amounts.
+--
+--   operator row: tenant_id='', scope='operator', scope_id=''      (admin-only)
+--   tenant   row: tenant_id=X,  scope='tenant',   scope_id=''      (tenant operator)
+--   user     row: tenant_id=X,  scope='user',     scope_id=<subject>
+--
+-- soft/hard are BIGINT nullable (token counts); the enforced total is
+-- input+output+cache_creation+cache_read for the scope this calendar month (UTC).
+
+CREATE TABLE token_limits (
+    tenant_id   TEXT        NOT NULL DEFAULT '',
+    scope       TEXT        NOT NULL,
+    scope_id    TEXT        NOT NULL DEFAULT '',
+    soft_limit  BIGINT,
+    hard_limit  BIGINT,
+    updated_at  TIMESTAMPTZ NOT NULL,
+    updated_by  TEXT        NOT NULL DEFAULT '',
+    PRIMARY KEY (tenant_id, scope, scope_id)
+);

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -525,6 +525,63 @@ func (s *Store) RunCostSummary(ctx context.Context, runID string) (float64, stri
 	return cost, currency, priced > 0, nil
 }
 
+// TokenLimitPut upserts one per-scope token budget (RFC AW). A nil soft/hard
+// stores NULL for that tier (unset).
+func (s *Store) TokenLimitPut(ctx context.Context, row store.TokenLimitRow) error {
+	updatedAt := row.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO token_limits (tenant_id, scope, scope_id, soft_limit, hard_limit, updated_at, updated_by)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7)
+		 ON CONFLICT (tenant_id, scope, scope_id) DO UPDATE SET
+		   soft_limit = EXCLUDED.soft_limit,
+		   hard_limit = EXCLUDED.hard_limit,
+		   updated_at = EXCLUDED.updated_at,
+		   updated_by = EXCLUDED.updated_by`,
+		row.TenantID, row.Scope, row.ScopeID, row.SoftLimit, row.HardLimit, updatedAt, row.UpdatedBy,
+	)
+	if err != nil {
+		return fmt.Errorf("token limit put: %w", err)
+	}
+	return nil
+}
+
+// TokenLimitDelete removes a scope's budget (→ unlimited). No-op when absent.
+func (s *Store) TokenLimitDelete(ctx context.Context, tenantID, scope, scopeID string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM token_limits WHERE tenant_id = $1 AND scope = $2 AND scope_id = $3`,
+		tenantID, scope, scopeID)
+	if err != nil {
+		return fmt.Errorf("token limit delete: %w", err)
+	}
+	return nil
+}
+
+// TokenLimitsAll returns every token-limit row (RFC AW) for the tracker cache.
+func (s *Store) TokenLimitsAll(ctx context.Context) ([]store.TokenLimitRow, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT tenant_id, scope, scope_id, soft_limit, hard_limit, updated_at, updated_by
+		 FROM token_limits`)
+	if err != nil {
+		return nil, fmt.Errorf("token limits all: %w", err)
+	}
+	defer rows.Close()
+	var out []store.TokenLimitRow
+	for rows.Next() {
+		var r store.TokenLimitRow
+		var soft, hard *int64
+		if err := rows.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &soft, &hard, &r.UpdatedAt, &r.UpdatedBy); err != nil {
+			return nil, fmt.Errorf("scan token limit: %w", err)
+		}
+		r.SoftLimit = soft
+		r.HardLimit = hard
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // UsageReport aggregates recent per-call token_usage UNION the compact
 // usage_archive rollup (RFC AV Phase 2b), so a pruned window still reports.
 // Mirrors the sqlite implementation: five dimension columns in

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -174,6 +174,20 @@ func (s *Store) migrate(ctx context.Context) error {
 			PRIMARY KEY (period_start, tenant_id, user_id, provider, model, credential_source)
 		)`,
 		`CREATE INDEX IF NOT EXISTS usage_archive_tenant_period ON usage_archive(tenant_id, period_start)`,
+		// RFC AW — per-scope token budgets (soft + hard). A row's absence =
+		// unlimited; a NULL soft/hard = that tier unset. No secrets: scope ids
+		// (tenant / subject, already non-secret) + integer token amounts.
+		// updated_at is unix-nano. Mirrors postgres migration 0054.
+		`CREATE TABLE IF NOT EXISTS token_limits (
+			tenant_id   TEXT NOT NULL DEFAULT '',
+			scope       TEXT NOT NULL,
+			scope_id    TEXT NOT NULL DEFAULT '',
+			soft_limit  INTEGER,
+			hard_limit  INTEGER,
+			updated_at  INTEGER NOT NULL,
+			updated_by  TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (tenant_id, scope, scope_id)
+		)`,
 		`CREATE TABLE IF NOT EXISTS events (
 			seq        INTEGER PRIMARY KEY AUTOINCREMENT,
 			session_id TEXT NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
@@ -1337,6 +1351,67 @@ func (s *Store) RunCostSummary(ctx context.Context, runID string) (float64, stri
 		return 0, "", false, err
 	}
 	return cost, currency, priced > 0, nil
+}
+
+// TokenLimitPut upserts one per-scope token budget (RFC AW). A nil soft/hard
+// stores NULL for that tier. updated_at is stored as unix-nano.
+func (s *Store) TokenLimitPut(ctx context.Context, row store.TokenLimitRow) error {
+	updatedAt := row.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = time.Now().UTC()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO token_limits (tenant_id, scope, scope_id, soft_limit, hard_limit, updated_at, updated_by)
+		 VALUES (?,?,?,?,?,?,?)
+		 ON CONFLICT (tenant_id, scope, scope_id) DO UPDATE SET
+		   soft_limit = excluded.soft_limit,
+		   hard_limit = excluded.hard_limit,
+		   updated_at = excluded.updated_at,
+		   updated_by = excluded.updated_by`,
+		row.TenantID, row.Scope, row.ScopeID,
+		nullableInt64(row.SoftLimit), nullableInt64(row.HardLimit),
+		updatedAt.UnixNano(), row.UpdatedBy,
+	)
+	return err
+}
+
+// TokenLimitDelete removes a scope's budget (→ unlimited). No-op when absent.
+func (s *Store) TokenLimitDelete(ctx context.Context, tenantID, scope, scopeID string) error {
+	_, err := s.db.ExecContext(ctx,
+		`DELETE FROM token_limits WHERE tenant_id = ? AND scope = ? AND scope_id = ?`,
+		tenantID, scope, scopeID)
+	return err
+}
+
+// TokenLimitsAll returns every token-limit row (RFC AW) for the tracker cache.
+func (s *Store) TokenLimitsAll(ctx context.Context) ([]store.TokenLimitRow, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT tenant_id, scope, scope_id, soft_limit, hard_limit, updated_at, updated_by
+		 FROM token_limits`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.TokenLimitRow
+	for rows.Next() {
+		var r store.TokenLimitRow
+		var soft, hard sql.NullInt64
+		var updatedNano int64
+		if err := rows.Scan(&r.TenantID, &r.Scope, &r.ScopeID, &soft, &hard, &updatedNano, &r.UpdatedBy); err != nil {
+			return nil, err
+		}
+		if soft.Valid {
+			v := soft.Int64
+			r.SoftLimit = &v
+		}
+		if hard.Valid {
+			v := hard.Int64
+			r.HardLimit = &v
+		}
+		r.UpdatedAt = time.Unix(0, updatedNano)
+		out = append(out, r)
+	}
+	return out, rows.Err()
 }
 
 // nanosPerDay is the day bucket for the usage rollup's period_start (ts is
@@ -6662,6 +6737,15 @@ func nilIfEmpty(s string) any {
 		return nil
 	}
 	return s
+}
+
+// nullableInt64 returns nil when p is nil so the SQL driver writes NULL — for
+// a genuinely-unset tier, distinct from a zero limit (RFC AW token budgets).
+func nullableInt64(p *int64) any {
+	if p == nil {
+		return nil
+	}
+	return *p
 }
 
 // ---- v0.8.x Process-resource metrics sampler ----

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -373,6 +373,22 @@ type TokenUsageRow struct {
 	TS time.Time
 }
 
+// TokenLimitRow is one per-scope token budget (RFC AW). Scope is
+// "operator" | "tenant" | "user"; ScopeID is the tenant/subject id ("" for
+// operator/tenant scope, the user subject for scope=user). SoftLimit/HardLimit
+// are nullable (*int64): nil = that tier unset (the enforcement treats an unset
+// tier as "no ceiling on this axis"). No secrets — scope ids are already
+// non-secret (like user_id) and the amounts are integers.
+type TokenLimitRow struct {
+	TenantID  string
+	Scope     string
+	ScopeID   string
+	SoftLimit *int64
+	HardLimit *int64
+	UpdatedAt time.Time
+	UpdatedBy string
+}
+
 // UsageDimension is a whitelisted grouping axis for a usage report (RFC AV
 // Phase 2). The string value maps to a token_usage column; the whitelist is the
 // injection guard — a caller-supplied group_by is validated against these.
@@ -701,6 +717,20 @@ type Store interface {
 	// per-call rows UNION the compact usage_archive rollup, so old (pruned)
 	// windows still report.
 	UsageReport(ctx context.Context, q UsageQuery) ([]UsageAggregate, error)
+
+	// TokenLimitPut upserts one per-scope token budget on its
+	// (tenant_id, scope, scope_id) primary key (RFC AW). A nil SoftLimit/
+	// HardLimit stores NULL for that tier (unset). Idempotent.
+	TokenLimitPut(ctx context.Context, row TokenLimitRow) error
+
+	// TokenLimitDelete removes the budget for a scope → the scope is unlimited
+	// again. A no-op (no error) when the row does not exist.
+	TokenLimitDelete(ctx context.Context, tenantID, scope, scopeID string) error
+
+	// TokenLimitsAll returns every token-limit row (RFC AW). The in-memory limits
+	// tracker caches these at boot + on CRUD; tenant filtering for the read API
+	// happens at the HTTP layer, so this returns all rows unscoped.
+	TokenLimitsAll(ctx context.Context) ([]TokenLimitRow, error)
 
 	// RollupAndPruneUsage folds every token_usage row older than olderThan into
 	// usage_archive (day-bucketed, summed per dimension tuple) and deletes the

--- a/internal/store/storetest/contract.go
+++ b/internal/store/storetest/contract.go
@@ -343,6 +343,9 @@ func Run(t *testing.T, factory Factory) {
 		{"UsageReportPerCurrency", testUsageReportPerCurrency},
 		{"UsageRollupAndPrune", testUsageRollupAndPrune},
 		{"UsageReportArchiveWindowBoundary", testUsageReportArchiveWindowBoundary},
+		// RFC AW — per-scope token budgets: upsert / get-all / delete round-trip
+		// incl. nullable tiers.
+		{"TokenLimits", testTokenLimits},
 		{"SessionArchiver", testSessionArchiver},
 		// RFC AF (v1.0.1): the cluster hook registry persists the
 		// authoritative tenant_id. Exercises the new column's INSERT/SELECT
@@ -943,6 +946,103 @@ func testUsageReportArchiveWindowBoundary(t *testing.T, s store.Store) {
 	}
 	if rep[0].InputTokens != 100 {
 		t.Errorf("windowed archive report = %d tokens, want 100 (from-day bucket included, prior day excluded)", rep[0].InputTokens)
+	}
+}
+
+// testTokenLimits exercises the RFC AW token_limits store: upsert (both tiers,
+// then a re-upsert overwrite), get-all across scopes with nullable tiers, and
+// delete. It also proves the NULL-vs-zero distinction survives the round-trip (a
+// nil tier reads back nil, a zero tier reads back a real 0).
+func testTokenLimits(t *testing.T, s store.Store) {
+	ctx := context.Background()
+	i64 := func(v int64) *int64 { return &v }
+
+	all, err := s.TokenLimitsAll(ctx)
+	if err != nil {
+		t.Fatalf("TokenLimitsAll (empty): %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("fresh store has %d limit rows, want 0", len(all))
+	}
+
+	// Operator-global: hard only (soft unset). Tenant: both. User: soft=0 (a
+	// real zero, distinct from unset) + hard nil.
+	rows := []store.TokenLimitRow{
+		{TenantID: "", Scope: "operator", ScopeID: "", HardLimit: i64(1_000_000), UpdatedBy: "admin"},
+		{TenantID: "acme", Scope: "tenant", ScopeID: "", SoftLimit: i64(500), HardLimit: i64(800), UpdatedBy: "admin"},
+		{TenantID: "acme", Scope: "user", ScopeID: "u1", SoftLimit: i64(0), UpdatedBy: "op@acme"},
+	}
+	for _, r := range rows {
+		if err := s.TokenLimitPut(ctx, r); err != nil {
+			t.Fatalf("TokenLimitPut(%s/%s): %v", r.Scope, r.ScopeID, err)
+		}
+	}
+
+	byKey := func() map[string]store.TokenLimitRow {
+		got, err := s.TokenLimitsAll(ctx)
+		if err != nil {
+			t.Fatalf("TokenLimitsAll: %v", err)
+		}
+		m := make(map[string]store.TokenLimitRow, len(got))
+		for _, r := range got {
+			m[r.TenantID+"|"+r.Scope+"|"+r.ScopeID] = r
+		}
+		return m
+	}
+
+	m := byKey()
+	if len(m) != 3 {
+		t.Fatalf("got %d rows, want 3", len(m))
+	}
+	op := m["|operator|"]
+	if op.SoftLimit != nil {
+		t.Errorf("operator soft = %v, want nil (unset)", *op.SoftLimit)
+	}
+	if op.HardLimit == nil || *op.HardLimit != 1_000_000 {
+		t.Errorf("operator hard = %v, want 1000000", op.HardLimit)
+	}
+	usr := m["acme|user|u1"]
+	if usr.SoftLimit == nil || *usr.SoftLimit != 0 {
+		t.Errorf("user soft = %v, want a real 0 (not nil)", usr.SoftLimit)
+	}
+	if usr.HardLimit != nil {
+		t.Errorf("user hard = %v, want nil", *usr.HardLimit)
+	}
+
+	// Upsert overwrite: raise the tenant hard tier + clear its soft tier.
+	if err := s.TokenLimitPut(ctx, store.TokenLimitRow{
+		TenantID: "acme", Scope: "tenant", ScopeID: "", HardLimit: i64(2000), UpdatedBy: "admin2",
+	}); err != nil {
+		t.Fatalf("TokenLimitPut (overwrite): %v", err)
+	}
+	m = byKey()
+	if len(m) != 3 {
+		t.Fatalf("after overwrite got %d rows, want 3 (upsert must not insert a dup)", len(m))
+	}
+	tn := m["acme|tenant|"]
+	if tn.SoftLimit != nil {
+		t.Errorf("tenant soft after overwrite = %v, want nil (cleared)", *tn.SoftLimit)
+	}
+	if tn.HardLimit == nil || *tn.HardLimit != 2000 {
+		t.Errorf("tenant hard after overwrite = %v, want 2000", tn.HardLimit)
+	}
+	if tn.UpdatedBy != "admin2" {
+		t.Errorf("tenant updated_by = %q, want admin2", tn.UpdatedBy)
+	}
+
+	// Delete the user row → unlimited again. Deleting a missing row is a no-op.
+	if err := s.TokenLimitDelete(ctx, "acme", "user", "u1"); err != nil {
+		t.Fatalf("TokenLimitDelete: %v", err)
+	}
+	if err := s.TokenLimitDelete(ctx, "acme", "user", "nope"); err != nil {
+		t.Fatalf("TokenLimitDelete (absent) should be a no-op: %v", err)
+	}
+	m = byKey()
+	if _, ok := m["acme|user|u1"]; ok {
+		t.Error("user row still present after delete")
+	}
+	if len(m) != 2 {
+		t.Fatalf("after delete got %d rows, want 2", len(m))
 	}
 }
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -93,6 +93,22 @@ export interface ListAgentsResponse {
   agents: Agent[];
 }
 
+// LimitEventInfo mirrors providers.LimitInfo — the sidecar on a `limit`
+// event (RFC AW per-scope token budgets). The event is SERVER-generated
+// (not from a provider): emitted once per (scope, severity) per run when a
+// scope crosses its soft/hard ceiling. Present identically on the live SSE
+// `limit` frame and the persisted `limit` transcript row, so the terminal
+// renders both through the same path. Non-secret (ids + integer counts).
+export interface LimitEventInfo {
+  scope: string; // operator | tenant | user
+  scope_id?: string; // tenant id / user subject; "" for operator-global
+  severity: "soft" | "hard" | string; // soft = warn, hard = next run refused
+  window: string; // "month" (calendar month, UTC) in Phase 1
+  used: number; // month-to-date token total at the crossing
+  limit: number; // the tier crossed (the soft or hard ceiling)
+  message?: string;
+}
+
 // EventPayload mirrors providers.Event on the server side. Carried
 // inside `TranscriptEvent.event` (the wire shape from
 // /v1/sessions/{id}/transcript wraps each row with seq/run_id/ts_ns
@@ -139,6 +155,9 @@ export interface EventPayload {
   // "context_compaction" sidecar — the conversation before this marker was
   // summarized to free context (interactive compaction).
   context_compaction?: { summary?: string; before_tokens?: number; after_tokens?: number };
+  // "limit" sidecar (RFC AW) — a per-scope token-budget crossing. Present on
+  // both the live SSE `limit` frame and the persisted `limit` transcript row.
+  limit?: LimitEventInfo;
 }
 
 // v0.9.x — payloads for event types whose shape doesn't fit
@@ -2339,4 +2358,79 @@ export function getUsage(
   if (params.tenant) q.set("tenant", params.tenant);
   const qs = q.toString();
   return jsonFetch<UsageReportResponse>(`/v1/_usage${qs ? "?" + qs : ""}`);
+}
+
+// --- RFC AW: per-scope token budgets (GET/PUT/DELETE /v1/_limits) ---
+
+// TokenLimit is one token_limits row plus its live month-to-date usage
+// (mirrors limitRowResponse). soft_limit/hard_limit are number|null — null
+// (the wire omits an unset tier) means "no ceiling on that severity". `used`
+// is the scope's calendar-month token total. Tenant-scoped server-side: a
+// substrate:tenant operator sees only its own tenant + users; admin sees all
+// (or one tenant via ?tenant=).
+export interface TokenLimit {
+  tenant_id?: string;
+  scope: string; // operator | tenant | user
+  scope_id?: string; // tenant id / user subject; "" for operator-global
+  soft_limit: number | null;
+  hard_limit: number | null;
+  used: number;
+  updated_at?: string;
+  updated_by?: string;
+}
+
+export interface LimitsResponse {
+  limits: TokenLimit[];
+}
+
+// listLimits fetches the budgets visible to the caller. tenant is the admin-
+// only focus (?tenant=); ignored server-side for a tenant operator.
+export function listLimits(tenant?: string): Promise<LimitsResponse> {
+  const q = tenant ? `?tenant=${encodeURIComponent(tenant)}` : "";
+  return jsonFetch<LimitsResponse>(`/v1/_limits${q}`);
+}
+
+// LimitPutBody upserts one budget row. Send a number to set a tier, or null /
+// omit to leave it unset. tenant_id addresses a tenant (admin only); a tenant
+// operator's tenant is stamped from the principal server-side, and the
+// operator scope + any cross-tenant write is refused (403) for a tenant
+// operator. scope_id is the user subject (scope=user); it must be empty for
+// scope=tenant and scope=operator.
+export interface LimitPutBody {
+  tenant_id?: string;
+  scope: string;
+  scope_id?: string;
+  soft_limit?: number | null;
+  hard_limit?: number | null;
+}
+
+export function putLimit(body: LimitPutBody): Promise<TokenLimit> {
+  return jsonFetch<TokenLimit>("/v1/_limits", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// deleteLimit removes a budget row (→ unlimited again). 204 No Content, so it
+// uses a raw fetch (jsonFetch would choke parsing the empty body) — mirrors
+// deleteSnapshot. tenant is the admin-only focus (ignored for a tenant op).
+export async function deleteLimit(
+  scope: string,
+  scopeId?: string,
+  tenant?: string,
+): Promise<void> {
+  const q = new URLSearchParams();
+  q.set("scope", scope);
+  if (scopeId) q.set("scope_id", scopeId);
+  if (tenant) q.set("tenant", tenant);
+  const resp = await fetch(baseURL + `/v1/_limits?${q.toString()}`, {
+    method: "DELETE",
+    credentials: "same-origin",
+  });
+  if (!resp.ok) {
+    if (redirectToLoginOn401(resp.status)) return;
+    const body = await resp.text();
+    throw new Error(`${resp.status} ${resp.statusText}: ${body.slice(0, 200)}`);
+  }
 }

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import {
   Camera,
   Coins,
   FolderTree,
+  Gauge,
   HardDrive,
   Library,
   ListTree,
@@ -81,6 +82,11 @@ const NAV_ITEMS: NavItem[] = [
   // ScopeTenant-gated and the handler tenant-scopes the aggregation (a tenant
   // operator sees only its own tenant's spend; admin sees all + ?tenant=).
   { to: "/usage", label: "usage", Icon: Coins, vis: "tenant" },
+  // limits: per-scope monthly token budgets (RFC AW). Tenant-visible: GET/PUT/
+  // DELETE /v1/_limits is ScopeTenant-gated and the handler tenant-scopes the
+  // rows + confines writes (a tenant operator manages only its own tenant +
+  // users; admin sees all + ?tenant=).
+  { to: "/limits", label: "limits", Icon: Gauge, vis: "tenant" },
   { to: "/activity", label: "activity", Icon: Activity, vis: "admin" },
 ];
 

--- a/web/src/components/TerminalTranscript.tsx
+++ b/web/src/components/TerminalTranscript.tsx
@@ -246,6 +246,21 @@ function formatLine(row: TranscriptEvent): FormattedLine {
       const sizes = before > 0 && after > 0 ? ` (~${fmtTokens(before)} → ~${fmtTokens(after)})` : "";
       return { key, ts, kind, cls: "tl-meta", payload: `↯ context compacted${sizes}` };
     }
+    case "limit": {
+      // RFC AW per-scope token-budget crossing — a banner line, amber for a
+      // soft warning, red for a hard cap (colored via .limit-banner in CSS).
+      const li = ev.limit;
+      const sev = li?.severity === "hard" ? "hard" : "soft";
+      const icon = sev === "hard" ? "⛔" : "⚠";
+      const who = li ? (li.scope_id ? `${li.scope} ${li.scope_id}` : li.scope) : "";
+      const when = li?.window === "month" ? "this month" : li?.window ? `this ${li.window}` : "";
+      const used = (li?.used ?? 0).toLocaleString();
+      const limit = (li?.limit ?? 0).toLocaleString();
+      return {
+        key, ts, kind, cls: `limit-banner ${sev}`,
+        payload: `${icon} token budget (${sev}): ${who} used ${used}/${limit} ${when}`.trimEnd(),
+      };
+    }
     case "started":
       return { key, ts, kind, cls: "tl-meta", payload: "" };
     case "session":

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -17,6 +17,7 @@ import SnapshotsView from "./pages/SnapshotsView";
 import AuditView from "./pages/AuditView";
 import RoutingView from "./pages/RoutingView";
 import UsageView from "./pages/UsageView";
+import LimitsView from "./pages/LimitsView";
 import ActivityMonitor from "./pages/ActivityMonitor";
 import LibraryView from "./pages/LibraryView";
 import IntegrationsView from "./pages/IntegrationsView";
@@ -86,6 +87,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
           <Route path="audit" element={<AuditView />} />
           <Route path="routing" element={<RoutingView />} />
           <Route path="usage" element={<UsageView />} />
+          <Route path="limits" element={<LimitsView />} />
           <Route path="activity" element={<ActivityMonitor />} />
           <Route path="settings" element={<SettingsView />} />
           <Route path="*" element={<Navigate to="/agents" replace />} />

--- a/web/src/pages/LimitsView.tsx
+++ b/web/src/pages/LimitsView.tsx
@@ -1,0 +1,364 @@
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import {
+  LimitPutBody,
+  TokenLimit,
+  deleteLimit,
+  listLimits,
+  putLimit,
+} from "../api";
+
+// LimitsView — GET/PUT/DELETE /v1/_limits (RFC AW Phase 1).
+//
+// Per-scope monthly token budgets: a soft ceiling (warn, the run continues) and
+// a hard ceiling (this run finishes, the next is refused at admission) on a
+// scope's calendar-month token total. Each row shows live month-to-date `used`
+// so an operator sets a budget against real consumption. Tenant-scoped by the
+// API (RFC AS): a substrate:tenant operator manages only its own tenant + its
+// users; an admin sees all rows and may focus one tenant via ?tenant=. The page
+// is data-driven — no client-side role branch (the server scopes + gates).
+
+const SCOPES = ["operator", "tenant", "user"] as const;
+type Scope = (typeof SCOPES)[number];
+
+// fmtTokens mirrors UsageView's compact K/M formatter for the read-only `used`
+// column. The soft/hard editors show raw integers instead (you type into them).
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+// parseLimit converts an editor string to the wire value: empty = null (leave
+// the tier unset — no ceiling), otherwise a non-negative integer. type=number
+// inputs make a malformed entry near-impossible; a stray one coerces to null
+// (unset) rather than sending garbage, and the server also rejects negatives.
+function parseLimit(s: string): number | null {
+  const t = s.trim();
+  if (t === "") return null;
+  const n = Math.floor(Number(t));
+  return Number.isFinite(n) && n >= 0 ? n : null;
+}
+
+// rowKey uniquely identifies a budget row across tenants + scopes (an admin's
+// list can hold same-scope rows for many tenants).
+function rowKey(r: TokenLimit): string {
+  return `${r.tenant_id ?? ""}|${r.scope}|${r.scope_id ?? ""}`;
+}
+
+export default function LimitsView() {
+  const [rows, setRows] = useState<TokenLimit[] | null>(null);
+  const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [tenant, setTenant] = useState("");
+
+  const fetchLimits = useCallback(async () => {
+    setLoading(true);
+    setErr("");
+    try {
+      const resp = await listLimits(tenant.trim() || undefined);
+      setRows(resp.limits ?? []);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, [tenant]);
+
+  useEffect(() => {
+    void fetchLimits();
+    // Run once on mount; subsequent fetches are driven by refresh (which reads
+    // the current tenant box) so a half-typed filter doesn't spam the endpoint.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="limits-view">
+      <div className="limits-header">
+        <div>
+          <h1>limits</h1>
+          <p className="limits-sub">
+            Per-scope monthly token budgets — a <code>soft</code> warning and a{" "}
+            <code>hard</code> cap (the next run is refused once crossed). Set a
+            ceiling against each scope's live month-to-date usage.
+          </p>
+        </div>
+        <div className="limits-actions">
+          <label className="limits-tenant">
+            tenant
+            <input
+              type="text"
+              placeholder="(admin focus)"
+              value={tenant}
+              onChange={(e) => setTenant(e.target.value)}
+            />
+          </label>
+          <button
+            type="button"
+            className="ghost-btn"
+            onClick={() => void fetchLimits()}
+            disabled={loading}
+          >
+            {loading ? "loading…" : "refresh"}
+          </button>
+        </div>
+      </div>
+
+      {err && <div className="err">{err}</div>}
+
+      <AddLimitForm tenantFocus={tenant.trim()} onSaved={fetchLimits} />
+
+      {rows && rows.length > 0 && (
+        <div className="limits-table-wrap">
+          <table className="limits-table">
+            <thead>
+              <tr>
+                {/* tenant column added beyond the base spec: an admin's list
+                    spans tenants and a scope=tenant row's scope_id is empty, so
+                    the tenant id is the only disambiguator. */}
+                <th>tenant</th>
+                <th>scope</th>
+                <th>scope_id</th>
+                <th className="num">used (mtd)</th>
+                <th className="num">soft</th>
+                <th className="num">hard</th>
+                <th className="limits-actions-col"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => (
+                <LimitRow key={rowKey(r)} row={r} onChanged={fetchLimits} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {rows && rows.length === 0 && (
+        <div className="empty">no budgets set — every scope is unlimited.</div>
+      )}
+    </div>
+  );
+}
+
+// LimitRow is one editable budget row. The soft/hard ceilings are always-live
+// number inputs (empty = unset); Save upserts, Remove deletes (→ unlimited).
+function LimitRow({
+  row,
+  onChanged,
+}: {
+  row: TokenLimit;
+  onChanged: () => Promise<void>;
+}) {
+  const [soft, setSoft] = useState<string>(row.soft_limit == null ? "" : String(row.soft_limit));
+  const [hard, setHard] = useState<string>(row.hard_limit == null ? "" : String(row.hard_limit));
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  // Re-sync the drafts when the persisted row changes under us (a refresh after
+  // this or another operator's write). Keyed on the values, not the object.
+  useEffect(() => {
+    setSoft(row.soft_limit == null ? "" : String(row.soft_limit));
+    setHard(row.hard_limit == null ? "" : String(row.hard_limit));
+  }, [row.soft_limit, row.hard_limit]);
+
+  const save = async () => {
+    setBusy(true);
+    setErr("");
+    try {
+      const body: LimitPutBody = {
+        scope: row.scope,
+        soft_limit: parseLimit(soft),
+        hard_limit: parseLimit(hard),
+      };
+      // tenant_id addresses the row's tenant (admin); harmlessly ignored for a
+      // scoped operator (its own tenant is stamped server-side).
+      if (row.tenant_id) body.tenant_id = row.tenant_id;
+      // scope_id carries the user subject only; tenant/operator rows have "".
+      if (row.scope === "user" && row.scope_id) body.scope_id = row.scope_id;
+      await putLimit(body);
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const remove = async () => {
+    setBusy(true);
+    setErr("");
+    try {
+      await deleteLimit(
+        row.scope,
+        row.scope === "user" ? row.scope_id : undefined,
+        row.tenant_id || undefined,
+      );
+      await onChanged();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <tr>
+        <td>{row.tenant_id || "—"}</td>
+        <td>{row.scope}</td>
+        <td className="limits-scopeid">{row.scope_id || "—"}</td>
+        <td className="num">{fmtTokens(row.used)}</td>
+        <td className="num">
+          <input
+            className="limits-num"
+            type="number"
+            min={0}
+            step={1000}
+            placeholder="∞"
+            value={soft}
+            onChange={(e) => setSoft(e.target.value)}
+            disabled={busy}
+          />
+        </td>
+        <td className="num">
+          <input
+            className="limits-num"
+            type="number"
+            min={0}
+            step={1000}
+            placeholder="∞"
+            value={hard}
+            onChange={(e) => setHard(e.target.value)}
+            disabled={busy}
+          />
+        </td>
+        <td className="limits-row-actions">
+          <button type="button" className="ghost-btn" onClick={() => void save()} disabled={busy}>
+            {busy ? "…" : "save"}
+          </button>
+          <button
+            type="button"
+            className="ghost-btn limits-remove"
+            onClick={() => void remove()}
+            disabled={busy}
+          >
+            remove
+          </button>
+        </td>
+      </tr>
+      {err && (
+        <tr>
+          <td colSpan={7}>
+            <div className="err limits-row-err">{err}</div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+// AddLimitForm creates a new budget row. Scope drives which id fields apply:
+//   operator — global, no ids;
+//   tenant   — tenant_id names the tenant (scope_id must be empty);
+//   user     — scope_id is the subject, tenant_id names its tenant.
+// A tenant operator may leave tenant_id blank (stamped from its identity).
+function AddLimitForm({
+  tenantFocus,
+  onSaved,
+}: {
+  tenantFocus: string;
+  onSaved: () => Promise<void>;
+}) {
+  const [scope, setScope] = useState<Scope>("tenant");
+  const [tenantId, setTenantId] = useState("");
+  const [scopeId, setScopeId] = useState("");
+  const [soft, setSoft] = useState("");
+  const [hard, setHard] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState("");
+
+  const submit = async (e: FormEvent) => {
+    e.preventDefault();
+    setBusy(true);
+    setErr("");
+    try {
+      const body: LimitPutBody = {
+        scope,
+        soft_limit: parseLimit(soft),
+        hard_limit: parseLimit(hard),
+      };
+      if (scope !== "operator") {
+        // Fall back to the admin tenant-focus box when the field is blank.
+        const t = tenantId.trim() || tenantFocus;
+        if (t) body.tenant_id = t;
+      }
+      if (scope === "user") {
+        if (!scopeId.trim()) {
+          setErr("scope_id (the user subject) is required for scope=user");
+          setBusy(false);
+          return;
+        }
+        body.scope_id = scopeId.trim();
+      }
+      await putLimit(body);
+      setScopeId("");
+      setSoft("");
+      setHard("");
+      await onSaved();
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <form className="limits-add" onSubmit={submit}>
+      <span className="limits-add-label">add budget</span>
+      <select value={scope} onChange={(e) => setScope(e.target.value as Scope)}>
+        {SCOPES.map((s) => (
+          <option key={s} value={s}>
+            {s}
+          </option>
+        ))}
+      </select>
+      {scope !== "operator" && (
+        <input
+          type="text"
+          placeholder={tenantFocus ? `tenant (${tenantFocus})` : "tenant id"}
+          value={tenantId}
+          onChange={(e) => setTenantId(e.target.value)}
+          title="Tenant id (admin). Leave blank as a tenant operator — stamped from your identity."
+        />
+      )}
+      {scope === "user" && (
+        <input
+          type="text"
+          placeholder="user subject"
+          value={scopeId}
+          onChange={(e) => setScopeId(e.target.value)}
+        />
+      )}
+      <input
+        type="number"
+        min={0}
+        step={1000}
+        placeholder="soft"
+        value={soft}
+        onChange={(e) => setSoft(e.target.value)}
+      />
+      <input
+        type="number"
+        min={0}
+        step={1000}
+        placeholder="hard"
+        value={hard}
+        onChange={(e) => setHard(e.target.value)}
+      />
+      <button type="submit" className="ghost-btn" disabled={busy}>
+        {busy ? "…" : "add"}
+      </button>
+      {err && <span className="err limits-add-err">{err}</span>}
+    </form>
+  );
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6158,3 +6158,125 @@ button.primary:disabled {
   color: var(--accent);
   font-size: 11px;
 }
+
+/* --- RFC AW: per-scope token budgets (LimitsView) --------------------------
+   Mirrors the .usage-* console conventions (--bg-soft cards, --mono table). */
+.limits-view {
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow: auto;
+}
+.limits-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.limits-header h1 {
+  margin: 0;
+}
+.limits-sub {
+  margin: 4px 0 0;
+  color: var(--fg-soft);
+  font-size: 13px;
+  max-width: 62ch;
+}
+.limits-actions {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+.limits-tenant {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+  color: var(--fg-soft);
+}
+/* Add-budget row: same soft card as .usage-controls, laid out inline. */
+.limits-add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: var(--lc-radius-sm);
+}
+.limits-add-label {
+  color: var(--fg-soft);
+  font-size: 12px;
+  margin-right: 4px;
+}
+.limits-add-err {
+  flex-basis: 100%;
+  margin: 4px 0 0;
+}
+.limits-table-wrap {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.limits-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+  font-family: var(--mono);
+}
+.limits-table th,
+.limits-table td {
+  text-align: left;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.limits-table th {
+  background: var(--bg-soft);
+  color: var(--fg-soft);
+  font-weight: 600;
+  position: sticky;
+  top: 0;
+}
+.limits-table th.num,
+.limits-table td.num {
+  text-align: right;
+}
+.limits-table tbody tr:hover {
+  background: var(--bg-soft-2);
+}
+.limits-scopeid {
+  color: var(--fg-soft);
+}
+.limits-num {
+  width: 10ch;
+  text-align: right;
+  font-family: var(--mono);
+}
+.limits-row-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+.limits-remove {
+  color: var(--failed);
+}
+.limits-row-err {
+  margin: 0;
+}
+
+/* limit crossing in the run terminal (TerminalTranscript): a colored banner
+   line — amber for a soft warning, red for a hard cap. The row keeps the
+   terminal grid (.tl-row); these only recolor + embolden the message cell. */
+.limit-banner .tl-payload {
+  font-weight: 600;
+}
+.limit-banner.soft .tl-payload {
+  color: #fbbf24;
+}
+.limit-banner.hard .tl-payload {
+  color: var(--failed);
+}


### PR DESCRIPTION
Phase 3 of the usage line ([RFC AW](../loomcycle-internal)) — makes RFC AV's per-scope usage **enforceable**. Enforce a **calendar-month** token ceiling per **operator / tenant / user**, configured **dynamically in the Web UI**. **No row = unlimited** (unchanged). **Most-restrictive** of the three scopes wins.

- **Soft** = warn: emit a first-class `limit` event, the run **continues**.
- **Hard** = refuse **new** runs at admission (**429**); an in-flight run that crosses a hard limit emits the event but **finishes** (no mid-run abort).

## Backend

- **`providers.Event` `EventLimit` + `LimitInfo`** `{scope, scope_id, severity, window, used, limit, message}` — server-generated (admission + `recordCallUsage`), carried on SSE + persisted as a `limit` transcript row.
- **`token_limits`** table (migration `0054`, both backends; PK `tenant/scope/scope_id`; nullable soft/hard) + `TokenLimitPut/Delete/TokenLimitsAll` + contract test.
- **`internal/limits.Tracker`** — in-memory calendar-month (UTC) counters per scope, boot-seeded from the ledger (`store.UsageReport`) and incremented on every `recordCallUsage` (**O1: in-memory**); `Check(tenant,user)` → most-restrictive `Decision`; `Add` returns newly-crossed thresholds; month rollover resets. **Advisory** under multi-replica (**O2**).
- **Admission** — `limits.Check` at all three HTTP run-start sites after `AcquireForUser`; hard → **release the slot** + 429 `token_limit_exceeded` (RunOnce returns `runner.ErrTokenLimitExceeded` → gRPC `ResourceExhausted` so the shared runner path stays honest); soft → run starts + emits a soft `limit` event.
- **`GET/PUT/DELETE /v1/_limits`** — tenant-scoped (`ScopeTenant`; a tenant operator writes only its own tenant/users; operator-global + cross-tenant are admin-only). `GET` returns each row's **live month-to-date `used`**.

## Web UI

- A **Limits** page (nav `vis:"tenant"`) — CRUD over `/v1/_limits` with month-to-date usage shown next to each budget; admin `?tenant` focus.
- The **run terminal** renders the `limit` event as a banner (amber soft / red hard) — from both the live SSE stream and the persisted transcript row.

## Tested

`go test ./...` clean (exit 0), gofmt + vet clean, Go binary (embeds UI) + TS build clean. **Fail-before** regressions for the admission-refuse (429), the soft-event-in-transcript, and the tracker `Check`; store contract on both backends. **Live smoke:** `PUT` a tenant limit → `GET` shows it with live `used`.

## Not in this PR (RFC AW phasing)

- **Phase 2:** `EventLimit` on gRPC (`eventToProto` + proto) + TS/Python adapters + MCP run-stream; the `/v1/_limits` CRUD on gRPC/MCP/adapters; admission gating on the gRPC / MCP / scheduler / webhook / A2A trigger surfaces (Phase 1 gates the HTTP run paths + the shared runner error path).
- **Phase 3:** `$`-denominated cost budgets + alert hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)