### PR TITLE
fix(limits): close 4 RFC AW code-review findings (cross-tenant oracle + 3)

### DIFF
--- a/internal/api/grpc/limits.go
+++ b/internal/api/grpc/limits.go
@@ -24,7 +24,8 @@ import (
 // doesn't hard-depend on the tracker's construction and tests can stub it.
 type tokenLimitTracker interface {
 	UsedFor(scope, tenantID, scopeID string) int64
-	ReloadLimits(ctx context.Context) error
+	PutLimit(row store.TokenLimitRow)
+	DeleteLimit(scope, tenantID, scopeID string)
 }
 
 // TokenLimit manages per-scope token budgets (RFC AW), the gRPC twin of
@@ -93,10 +94,9 @@ func (s *Server) tokenLimitSet(ctx context.Context, req *loomcyclepb.TokenLimitR
 	if err := s.store.TokenLimitPut(ctx, row); err != nil {
 		return nil, status.Errorf(codes.Internal, "put token limit: %v", err)
 	}
-	if err := s.reloadLimits(ctx); err != nil {
-		// The row is persisted; a reload fault just lags the cached ceiling.
-		return nil, status.Errorf(codes.Internal, "limit stored but reload failed: %v", err)
-	}
+	// Reflect the persisted row into the live ceiling cache (O(1), can't fail),
+	// so the budget is enforced immediately — never stored-but-unenforced.
+	s.putLimit(row)
 	return &loomcyclepb.TokenLimitResponse{Limits: []*loomcyclepb.TokenLimitEntry{s.tokenLimitEntry(row)}}, nil
 }
 
@@ -110,9 +110,8 @@ func (s *Server) tokenLimitDelete(ctx context.Context, req *loomcyclepb.TokenLim
 	if err := s.store.TokenLimitDelete(ctx, tenantID, req.GetScope(), scopeID); err != nil {
 		return nil, status.Errorf(codes.Internal, "delete token limit: %v", err)
 	}
-	if err := s.reloadLimits(ctx); err != nil {
-		return nil, status.Errorf(codes.Internal, "limit deleted but reload failed: %v", err)
-	}
+	// Drop the ceiling from the live cache immediately (O(1), can't fail).
+	s.deleteLimit(req.GetScope(), tenantID, scopeID)
 	return &loomcyclepb.TokenLimitResponse{}, nil
 }
 
@@ -159,11 +158,20 @@ func (s *Server) usedFor(scope, tenantID, scopeID string) int64 {
 	return s.limits.UsedFor(scope, tenantID, scopeID)
 }
 
-// reloadLimits refreshes the shared tracker's cached ceilings after a write;
-// a no-op when no tracker is wired.
-func (s *Server) reloadLimits(ctx context.Context) error {
+// putLimit reflects a persisted budget row into the shared tracker's live
+// ceiling cache after a write; a no-op when no tracker is wired.
+func (s *Server) putLimit(row store.TokenLimitRow) {
 	if s.limits == nil {
-		return nil
+		return
 	}
-	return s.limits.ReloadLimits(ctx)
+	s.limits.PutLimit(row)
+}
+
+// deleteLimit drops a budget from the shared tracker's live ceiling cache after
+// a delete; a no-op when no tracker is wired.
+func (s *Server) deleteLimit(scope, tenantID, scopeID string) {
+	if s.limits == nil {
+		return
+	}
+	s.limits.DeleteLimit(scope, tenantID, scopeID)
 }

--- a/internal/api/http/connector_impl.go
+++ b/internal/api/http/connector_impl.go
@@ -72,6 +72,7 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		finalUsage                         *providers.Usage
 		finalStopReason                    string
 		lastErrorMsg                       string
+		limitCrossings                     []providers.LimitInfo
 	)
 	cb := runner.RunCallbacks{
 		OnRegistered: func(agentID, runID, sessionID, _ string) {
@@ -85,6 +86,14 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 				if ev.Usage != nil {
 					u := *ev.Usage
 					finalUsage = &u
+				}
+			case providers.EventLimit:
+				// RFC AW: surface any token-budget crossing on the BLOCKING
+				// spawn result too — this path serves the non-streaming caller
+				// (spawn_run/spawn_runs without run-event notifications), the
+				// exact consumer SpawnRunResult.Limits exists for.
+				if ev.Limit != nil {
+					limitCrossings = append(limitCrossings, *ev.Limit)
 				}
 			case providers.EventDone:
 				finalStopReason = ev.StopReason
@@ -110,6 +119,7 @@ func (s *Server) SpawnRun(ctx context.Context, req connector.SpawnRunRequest) (c
 		StopReason:    finalStopReason,
 		FinalText:     finalText,
 		Usage:         finalUsage,
+		Limits:        limitCrossings,    // RFC AW: budget crossings, omitempty
 		ParentContext: req.ParentContext, // v0.12.x: echo the lineage back to the caller
 	}
 	switch {

--- a/internal/api/http/limits_admin.go
+++ b/internal/api/http/limits_admin.go
@@ -122,12 +122,10 @@ func (s *Server) handleLimitPut(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	if err := s.limits.ReloadLimits(r.Context()); err != nil {
-		// The row is persisted; a reload fault just means the cached ceiling
-		// lags until the next reload/seed. Log-and-continue (advisory).
-		writeJSONError(w, http.StatusInternalServerError, "internal", "limit stored but reload failed: "+err.Error())
-		return
-	}
+	// Reflect the persisted row into the live ceiling cache (O(1), can't fail),
+	// so the new budget is enforced immediately — no store re-read that could
+	// leave the row stored-but-unenforced.
+	s.limits.PutLimit(row)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(limitRowResponse{
@@ -160,10 +158,8 @@ func (s *Server) handleLimitDelete(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
-	if err := s.limits.ReloadLimits(r.Context()); err != nil {
-		writeJSONError(w, http.StatusInternalServerError, "internal", "limit deleted but reload failed: "+err.Error())
-		return
-	}
+	// Drop the ceiling from the live cache immediately (O(1), can't fail).
+	s.limits.DeleteLimit(scope, tenantID, scopeID)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/api/webhook/server.go
+++ b/internal/api/webhook/server.go
@@ -494,6 +494,12 @@ func (rec *Receiver) spawnSetupErrorResponse(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, runner.ErrUnknownAgent), errors.Is(err, runner.ErrUnknownProvider), errors.Is(err, runner.ErrInvalidArgument):
 		writeError(w, http.StatusBadRequest, "invalid_run", "")
+	case errors.Is(err, runner.ErrTokenLimitExceeded):
+		// RFC AW: a per-scope hard token budget refused the run at admission.
+		// Mirror the HTTP run endpoint's 429 so a webhook client branches the
+		// same way (retry-next-window / raise-limit) rather than treating it as
+		// a transient 503 and retry-storming a budget-exhausted scope.
+		writeError(w, http.StatusTooManyRequests, "token_limit_exceeded", "")
 	case errors.Is(err, runner.ErrBackpressure), errors.Is(err, runner.ErrPerUserQuotaExhausted):
 		writeError(w, http.StatusServiceUnavailable, "runtime_unavailable", "")
 	default:

--- a/internal/api/webhook/tokenlimit_test.go
+++ b/internal/api/webhook/tokenlimit_test.go
@@ -1,0 +1,39 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/denn-gubsky/loomcycle/internal/runner"
+)
+
+// TestSpawnSetupError_TokenLimitMaps429 is the RFC AW regression: a webhook run
+// refused at admission by a hard token budget must map to 429
+// "token_limit_exceeded" (mirroring the HTTP run endpoint), not the generic 503
+// — so a webhook client branches retry-next-window instead of retry-storming a
+// budget-exhausted scope. Fails on the pre-fix code (falls to the default 503).
+func TestSpawnSetupError_TokenLimitMaps429(t *testing.T) {
+	rec := &Receiver{}
+
+	w := httptest.NewRecorder()
+	rec.spawnSetupErrorResponse(w, runner.ErrTokenLimitExceeded)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("token-limit refusal status = %d, want 429", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "token_limit_exceeded" {
+		t.Fatalf("error code = %q, want token_limit_exceeded", body["error"])
+	}
+
+	// A generic setup error still maps to the transient 503 (unchanged).
+	w2 := httptest.NewRecorder()
+	rec.spawnSetupErrorResponse(w2, runner.ErrBackpressure)
+	if w2.Code != http.StatusServiceUnavailable {
+		t.Fatalf("backpressure status = %d, want 503", w2.Code)
+	}
+}

--- a/internal/limits/tracker.go
+++ b/internal/limits/tracker.go
@@ -126,19 +126,34 @@ func (t *Tracker) Seed(ctx context.Context) error {
 	return nil
 }
 
-// ReloadLimits refreshes only the cached ceilings (after a limits CRUD change).
-func (t *Tracker) ReloadLimits(ctx context.Context) error {
+// PutLimit updates the ONE cached ceiling for a scope after a successful store
+// write, so the new budget is enforced immediately. This deliberately avoids a
+// full re-read of every row (loadLimits): a re-read can fail on a transient
+// store fault, which would leave the row persisted-on-disk but the in-memory
+// ceiling stale — a budget silently unenforced until the next reload/reboot.
+// A single-key map write under the lock can't fail. Nil-safe (store-less no-op).
+func (t *Tracker) PutLimit(row store.TokenLimitRow) {
 	if t == nil || t.store == nil {
-		return nil
-	}
-	lm, err := t.loadLimits(ctx)
-	if err != nil {
-		return err
+		return
 	}
 	t.mu.Lock()
-	t.limits = lm
-	t.mu.Unlock()
-	return nil
+	defer t.mu.Unlock()
+	if t.limits == nil {
+		t.limits = map[string]tierPair{}
+	}
+	t.limits[limitKey(row.Scope, row.TenantID, row.ScopeID)] = tierPair{soft: row.SoftLimit, hard: row.HardLimit}
+}
+
+// DeleteLimit drops the cached ceiling for a scope after a successful store
+// delete (→ unlimited again). Same rationale as PutLimit: an in-memory delete
+// can't fail, so the cache never lags the persisted state. Nil-safe.
+func (t *Tracker) DeleteLimit(scope, tenantID, scopeID string) {
+	if t == nil || t.store == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.limits, limitKey(scope, tenantID, scopeID))
 }
 
 func (t *Tracker) loadLimits(ctx context.Context) (map[string]tierPair, error) {
@@ -283,6 +298,24 @@ func limitKey(scope, tenantID, scopeID string) string {
 }
 
 func makeLimitInfo(scope, scopeID, severity string, used, limit int64) providers.LimitInfo {
+	// The operator scope's used/limit are PLATFORM-WIDE aggregates summed across
+	// every tenant. This LimitInfo is delivered over a RUN channel — the 429
+	// refusal body, the SSE/transcript limit event, the gRPC event, the MCP
+	// spawn_run result — all visible to the run's own tenant+user. Exposing the
+	// operator figures to a tenant is therefore a cross-tenant oracle (a tenant
+	// could subtract its own spend to infer other tenants' aggregate activity),
+	// which is exactly what writeTokenLimitError promises NOT to do. Redact the
+	// numbers here and carry only severity + a generic message; an operator still
+	// reads the real operator figures from the admin console (/v1/_limits →
+	// Tracker.UsedFor), which never routes through this constructor.
+	if scope == "operator" {
+		return providers.LimitInfo{
+			Scope:    scope,
+			Severity: severity,
+			Window:   "month",
+			Message:  fmt.Sprintf("service %s token budget reached; please retry later", severity),
+		}
+	}
 	label := scope
 	if scopeID != "" {
 		label = scope + " " + scopeID

--- a/internal/limits/tracker_test.go
+++ b/internal/limits/tracker_test.go
@@ -196,8 +196,10 @@ func TestTracker_MonthRolloverResets(t *testing.T) {
 	}
 }
 
-// TestTracker_ReloadLimits picks up a new ceiling without a re-seed of counters.
-func TestTracker_ReloadLimits(t *testing.T) {
+// TestTracker_PutDeleteLimit picks up / drops a ceiling in the live cache
+// without a re-seed of counters — the O(1) path the CRUD handlers use so a
+// persisted budget is never left stored-but-unenforced by a failed re-read.
+func TestTracker_PutDeleteLimit(t *testing.T) {
 	fs := &fakeStore{aggs: []store.UsageAggregate{agg("acme", "u1", 900, 0)}}
 	tr := New(fs)
 	if err := tr.Seed(context.Background()); err != nil {
@@ -206,11 +208,59 @@ func TestTracker_ReloadLimits(t *testing.T) {
 	if dec := tr.Check("acme", "u1"); !dec.Allowed {
 		t.Fatal("no rows yet → allowed")
 	}
-	fs.limits = []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)}}
-	if err := tr.ReloadLimits(context.Background()); err != nil {
+	// PutLimit reflects a persisted ceiling into the cache immediately.
+	tr.PutLimit(store.TokenLimitRow{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)})
+	if dec := tr.Check("acme", "u1"); dec.Allowed {
+		t.Fatal("after PutLimit the hard tier must refuse")
+	}
+	// DeleteLimit drops it again → unlimited.
+	tr.DeleteLimit("tenant", "acme", "")
+	if dec := tr.Check("acme", "u1"); !dec.Allowed {
+		t.Fatal("after DeleteLimit the scope must be unlimited again")
+	}
+}
+
+// TestTracker_OperatorCrossingRedactsFigures verifies the RFC AW cross-tenant
+// oracle fix: an operator-scope (platform-wide) budget crossing delivered over
+// a run channel carries NO used/limit numbers (they aggregate every tenant),
+// only a generic message — while a tenant/user scope keeps its own figures.
+func TestTracker_OperatorCrossingRedactsFigures(t *testing.T) {
+	fs := &fakeStore{
+		aggs:   []store.UsageAggregate{agg("acme", "u1", 900, 0)},
+		limits: []store.TokenLimitRow{{Scope: "operator", HardLimit: i64(800)}},
+	}
+	tr := New(fs)
+	if err := tr.Seed(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	if dec := tr.Check("acme", "u1"); dec.Allowed {
-		t.Fatal("after ReloadLimits the hard tier must refuse")
+	dec := tr.Check("acme", "u1")
+	if dec.Allowed || dec.Refusal == nil {
+		t.Fatal("operator hard cap (800) < used (900) must refuse")
+	}
+	r := dec.Refusal
+	if r.Scope != "operator" {
+		t.Fatalf("refusal scope = %q, want operator", r.Scope)
+	}
+	if r.Used != 0 || r.Limit != 0 {
+		t.Fatalf("operator figures leaked to a tenant caller: used=%d limit=%d (want 0/0)", r.Used, r.Limit)
+	}
+	if r.ScopeID != "" {
+		t.Fatalf("operator scope_id leaked: %q", r.ScopeID)
+	}
+	// A tenant-scope refusal, by contrast, keeps its own (non-cross-tenant) figures.
+	fs2 := &fakeStore{
+		aggs:   []store.UsageAggregate{agg("acme", "u1", 900, 0)},
+		limits: []store.TokenLimitRow{{TenantID: "acme", Scope: "tenant", HardLimit: i64(800)}},
+	}
+	tr2 := New(fs2)
+	if err := tr2.Seed(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	d2 := tr2.Check("acme", "u1")
+	if d2.Allowed || d2.Refusal == nil || d2.Refusal.Scope != "tenant" {
+		t.Fatal("tenant hard cap must refuse with scope=tenant")
+	}
+	if d2.Refusal.Used != 900 || d2.Refusal.Limit != 800 {
+		t.Fatalf("tenant figures wrongly redacted: used=%d limit=%d (want 900/800)", d2.Refusal.Used, d2.Refusal.Limit)
 	}
 }


### PR DESCRIPTION
A high-effort code review of the RFC AW token-budgets feature (#642 Phase 1 + #643 Phase 2) surfaced 7 candidates. 4 are real defects (fixed here); 3 are documented-as-designed (see below).

## Fixed

**1 · HIGH — cross-tenant oracle.** The `operator` scope's `used`/`limit` are **platform-wide aggregates summed across every tenant**, yet `Tracker.Check` returned them to *any* caller and `writeTokenLimitError` serialized them into the 429 body — plus the soft/in-flight `limit` events on a tenant's own run stream. That directly contradicts `writeTokenLimitError`'s own comment: *"names only the CALLER's own tripped scope (not a cross-tenant oracle)."* A tenant could subtract its own spend to infer other tenants' aggregate activity. **Fix:** `makeLimitInfo` — the sole run-facing `LimitInfo` producer (the admin console reads operator figures via `Tracker.UsedFor`, never this path) — redacts the operator scope's `used`/`limit`/`scope_id`, carrying only severity + a generic message. Enforcement is unchanged: an operator-global hard cap still refuses the run.

**2 · MED — stored-but-unenforced budget.** A transient `ReloadLimits` (full re-read) fault on `PUT`/`DELETE /v1/_limits` returned 500 *after* the row was already persisted, leaving the in-memory ceiling stale — the budget silently unenforced until the next reload/reboot, with a comment that wrongly claimed "log-and-continue (advisory)". **Fix at altitude:** replace the full re-read with an O(1) `Tracker.PutLimit`/`DeleteLimit` that updates the one cached ceiling under the lock and *cannot fail*, so the persisted state and cache never diverge. `ReloadLimits` is now unused and removed (HTTP + gRPC handlers + the gRPC tracker interface updated in lockstep).

**3 · MED — webhook status drift.** A sync webhook run refused by a hard budget mapped to the generic 503 (`spawnSetupErrorResponse` had no `ErrTokenLimitExceeded` case) despite its comment claiming it mirrors the HTTP run endpoint (429). A webhook client would treat the refusal as transient and retry-storm a budget-exhausted scope. **Fix:** add the 429 `token_limit_exceeded` case.

**4 · MED — blocking spawn missed crossings.** Only the streaming MCP path populated `SpawnRunResult.Limits`; the blocking `connector.SpawnRun` (and thus `SpawnRunBatch`) had no `EventLimit` case, so the exact non-streaming caller the field exists for got no crossings. **Fix:** accumulate `EventLimit` in the blocking `OnEvent`.

## Documented, not fixed
- **Interactive `/v1/runs/{id}/input`, sub-agent / `parallel_spawn`** — these feed *already-admitted, in-flight* work; RFC AW's rule is "hard = refuse **new** runs; in-flight warns-but-finishes." Naively gating `handleRunInput` would wrongly refuse legitimate steering of a running run. Counters still increment (`Add`), so overshoot is visible and the next top-level run refuses.
- **LLM gateway** (`/v1/_llm/chat`, `/v1/chat/completions`, `/v1/embeddings`) — a pass-through shim that records no usage to the ledger, so budgets can't see it regardless; gating it is a Phase-3 scope expansion.
- Store `*int64` nullable scan + gRPC list-filter duplication — verified correct/benign style nits.

## Tested
`go test ./...` clean, gofmt/vet clean. New regressions (both verified failing on the unfixed code):
- `TestTracker_OperatorCrossingRedactsFigures` — operator refusal carries `used=0`/`limit=0`/`scope_id=""`; a tenant refusal keeps its own `900`/`800` (fail-before: leaked `900`/`800`).
- `TestSpawnSetupError_TokenLimitMaps429` — 429 + `token_limit_exceeded`; backpressure still 503 (fail-before: 503).
- `TestTracker_PutDeleteLimit` — `PutLimit` enforces immediately, `DeleteLimit` clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)