### PR TITLE
chore(python): sync adapter version to 1.11.0

### DIFF
--- a/adapters/python/loomcycle/__init__.py
+++ b/adapters/python/loomcycle/__init__.py
@@ -124,4 +124,4 @@ __all__ = [
     "SubstrateToolRefusedError",
 ]
 
-__version__ = "1.4.0"
+__version__ = "1.11.0"

--- a/adapters/python/pyproject.toml
+++ b/adapters/python/pyproject.toml
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loomcycle"
-version = "1.4.0"
+version = "1.11.0"
 description = "Async Python client for loomcycle's gRPC API — full 44-RPC parity (run streaming, interactive sessions, batch fan-out, compaction, pause/resume/snapshot, substrate defs, volumes, Path VFS, chunked-graph Documents, channels)"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Realigns the Python adapter with the main loomcycle version. It was pinned at **1.4.0** while the runtime reached **1.11.0** — the adapter rides its own `python-v*` tags, so PyPI had fallen behind `main`.

Bumping to **1.11.0** publishes the gRPC surface accrued since 1.4.0:
- RFC AV **`usage_report()`** (#638)
- RFC AW **`list_token_limits()` / `set_token_limit()` / `delete_token_limit()`** + the `limit` event on the event stream (#643)

## What
- `adapters/python/pyproject.toml` → `1.11.0`
- `adapters/python/loomcycle/__init__.py` `__version__` → `1.11.0`

Both sites bumped in lockstep so the `publish-python-adapter` workflow's tag/version guard (it **hard-errors** on mismatch) passes on a `python-v1.11.0` tag. No code change; 116 adapter tests pass, import clean.

**After merge:** I'll cut the **`python-v1.11.0`** tag to publish `loomcycle==1.11.0` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)