### PR TITLE
fix(usage): Web UI Usage page blanks when a report has no rows

### DIFF
--- a/internal/api/http/usage_report.go
+++ b/internal/api/http/usage_report.go
@@ -93,6 +93,14 @@ func (s *Server) handleUsageReport(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusInternalServerError, "internal", err.Error())
 		return
 	}
+	// A Go nil slice marshals to JSON `null`, but the wire contract (and every
+	// client's type, e.g. the Web UI's `rows: UsageAggregate[]`) is a JSON array.
+	// Normalize an empty result to `[]` so a no-usage window (a fresh deploy, or a
+	// tenant with no spend yet) doesn't send `"rows": null` — which crashed the
+	// Web UI's `resp.rows.length`.
+	if rows == nil {
+		rows = []store.UsageAggregate{}
+	}
 	resp := usageReportResponse{GroupBy: groupNames, Rows: rows}
 	if !query.From.IsZero() {
 		resp.From = query.From.Format(time.RFC3339)

--- a/internal/api/http/usage_report_test.go
+++ b/internal/api/http/usage_report_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -86,5 +87,40 @@ func TestUsageReport_Endpoint(t *testing.T) {
 	defer bad.Body.Close()
 	if bad.StatusCode != 400 {
 		t.Errorf("bad group_by status = %d, want 400", bad.StatusCode)
+	}
+}
+
+// TestUsageReport_EmptyRowsIsArrayNotNull guards the Web-UI crash: a no-usage
+// window must serialize `"rows":[]`, not `"rows":null` (a Go nil slice). The UI
+// types rows as an array and does `resp.rows.length`; a null crashed the page to
+// a blank overlay. Asserts the RAW body — decoding into the struct would coerce
+// null→nil and hide the regression (len(nil)==0 either way).
+func TestUsageReport_EmptyRowsIsArrayNotNull(t *testing.T) {
+	st, err := storesqlite.Open(filepath.Join(t.TempDir(), "usage_empty.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+
+	cfg := &config.Config{Concurrency: config.Concurrency{MaxConcurrentRuns: 2, MaxQueueDepth: 2, QueueTimeoutMS: 500}}
+	cfg.Env.AuthToken = "" // open mode → admin
+	srv := New(cfg, &stubResolver{p: &scriptedProvider{}}, []tools.Tool{}, concurrency.New(2, 2, time.Second), st)
+	ts := httptest.NewServer(srv.Mux())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/_usage?group_by=tenant,source")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), `"rows":null`) {
+		t.Fatalf(`empty report serialized "rows":null (crashes the Web UI); want "rows":[]. body=%s`, body)
+	}
+	if !strings.Contains(string(body), `"rows":[]`) {
+		t.Fatalf(`empty report must serialize "rows":[]; body=%s`, body)
 	}
 }

--- a/web/src/pages/UsageView.tsx
+++ b/web/src/pages/UsageView.tsx
@@ -134,6 +134,11 @@ export default function UsageView() {
 
   const sourceGrouped = dims.has("source");
 
+  // The server sends `rows: []` for an empty window, but a Go nil slice can
+  // still arrive as JSON null; guard so a no-usage report never crashes the page
+  // on `.length`/`.map` (mirrors LimitsView's `resp.limits ?? []`).
+  const rows = resp?.rows ?? [];
+
   return (
     <div className="usage-view">
       <div className="usage-header">
@@ -232,7 +237,7 @@ export default function UsageView() {
         </div>
       )}
 
-      {resp && resp.rows.length > 0 && (
+      {rows.length > 0 && (
         <div className="usage-table-wrap">
           <table className="usage-table">
             <thead>
@@ -248,7 +253,7 @@ export default function UsageView() {
               </tr>
             </thead>
             <tbody>
-              {resp.rows.map((r, i) => (
+              {rows.map((r, i) => (
                 <tr key={i}>
                   {activeDims.map((d) => (
                     <td key={d.key} className={d.key === "source" ? `usage-src usage-src-${r.credential_source}` : ""}>
@@ -277,7 +282,7 @@ export default function UsageView() {
         </div>
       )}
 
-      {resp && resp.rows.length === 0 && (
+      {resp && rows.length === 0 && (
         <div className="empty">no usage in this window.</div>
       )}
     </div>


### PR DESCRIPTION
## Symptom
The **Usage** page shows an empty screen — a blank "overlay" — while the left-nav clicks keep working underneath. Hits any account with **no usage in the window**: a fresh deployment, or a tenant with no spend yet.

## Root cause
`GET /v1/_usage` builds `usageReportResponse{Rows: rows}` straight from the store, and a **Go nil slice marshals to JSON `null`**. The Web UI types the field as `rows: UsageAggregate[]` and calls `resp.rows.length` at two sites (`UsageView.tsx:235`/`:280`), so `null.length` **throws during render** → the routed view crashes to blank while the `Layout` (nav) stays mounted → "clicks continue working."

`LimitsView` already guarded this (`resp.limits ?? []`); `UsageView` guarded `totals` but not the two length checks — an inconsistency this fixes.

## Fix (both sides)
- **Server** (`usage_report.go`): normalize an empty result to `[]` before encoding, so the wire matches the declared array contract for **every** client — the Web UI *and* the TS adapter's `usageReport()` — not just this page.
- **UI** (`UsageView.tsx`): derive `const rows = resp?.rows ?? []` and use it for the `.length`/`.map` sites (mirrors `LimitsView`), so the page can't crash even if some other endpoint ever returns null.

## Tested
- `TestUsageReport_EmptyRowsIsArrayNotNull` — asserts the **raw** body is `"rows":[]`, not `"rows":null` (decoding into the struct would coerce null→nil and hide the bug). **Verified fail-before / pass-after.**
- `go test ./...` clean; `make build-all` clean (UI rebuilt + embedded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)