### PR TITLE
feat(webui): recognize K/M/G shorthand in the token-limit editors

### DIFF
--- a/web/src/lib/tokenAmount.test.ts
+++ b/web/src/lib/tokenAmount.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseTokenAmount, fmtTokens, amountHint } from "./tokenAmount";
+
+describe("parseTokenAmount", () => {
+  it("parses plain integers", () => {
+    expect(parseTokenAmount("5000000")).toBe(5000000);
+    expect(parseTokenAmount("0")).toBe(0);
+  });
+
+  it("recognizes K/M/G/B/T suffixes, case-insensitive", () => {
+    expect(parseTokenAmount("500k")).toBe(500000);
+    expect(parseTokenAmount("500K")).toBe(500000);
+    expect(parseTokenAmount("5m")).toBe(5000000);
+    expect(parseTokenAmount("5M")).toBe(5000000);
+    expect(parseTokenAmount("2G")).toBe(2000000000);
+    expect(parseTokenAmount("2b")).toBe(2000000000); // B alias for G
+    expect(parseTokenAmount("1T")).toBe(1000000000000);
+  });
+
+  it("accepts a decimal mantissa", () => {
+    expect(parseTokenAmount("1.5M")).toBe(1500000);
+    expect(parseTokenAmount("2.5k")).toBe(2500);
+    expect(parseTokenAmount("0.5G")).toBe(500000000);
+  });
+
+  it("ignores commas / underscores / spaces as separators", () => {
+    expect(parseTokenAmount("5,000,000")).toBe(5000000);
+    expect(parseTokenAmount("5_000_000")).toBe(5000000);
+    expect(parseTokenAmount(" 5 M ")).toBe(5000000);
+  });
+
+  it("returns null for an empty entry (tier unset)", () => {
+    expect(parseTokenAmount("")).toBeNull();
+    expect(parseTokenAmount("   ")).toBeNull();
+  });
+
+  it("returns undefined for an unparseable entry", () => {
+    expect(parseTokenAmount("5X")).toBeUndefined();
+    expect(parseTokenAmount("abc")).toBeUndefined();
+    expect(parseTokenAmount("M")).toBeUndefined(); // suffix with no number
+    expect(parseTokenAmount("-5")).toBeUndefined(); // no negatives
+    expect(parseTokenAmount("5MM")).toBeUndefined();
+  });
+});
+
+describe("fmtTokens", () => {
+  it("scales through K/M/G/T", () => {
+    expect(fmtTokens(500)).toBe("500");
+    expect(fmtTokens(1500)).toBe("1.5K");
+    expect(fmtTokens(5000000)).toBe("5.00M");
+    expect(fmtTokens(2000000000)).toBe("2.00G");
+    expect(fmtTokens(1000000000000)).toBe("1.00T");
+  });
+});
+
+describe("amountHint", () => {
+  it("shows the exact value when a shorthand was recognized", () => {
+    expect(amountHint("5M")).toEqual({ text: "= 5,000,000", invalid: false });
+    expect(amountHint("1.5m")).toEqual({ text: "= 1,500,000", invalid: false });
+    expect(amountHint("2G")).toEqual({ text: "= 2,000,000,000", invalid: false });
+  });
+
+  it("shows no hint when the entry already reads as the number", () => {
+    expect(amountHint("5000000")).toBeNull(); // plain integer
+    expect(amountHint("5,000,000")).toBeNull(); // separators only, same value
+    expect(amountHint("")).toBeNull(); // empty
+  });
+
+  it("flags an unparseable entry", () => {
+    expect(amountHint("5X")).toEqual({ text: "not a number", invalid: true });
+  });
+});

--- a/web/src/lib/tokenAmount.ts
+++ b/web/src/lib/tokenAmount.ts
@@ -1,0 +1,60 @@
+// tokenAmount — human-friendly token amounts for the RFC AW limits editor.
+//
+// Token budgets are large (millions), so typing raw integers into the soft/hard
+// fields is error-prone (a dropped or extra zero is a 10× budget mistake). These
+// helpers let an operator type a shorthand — 500K, 5M, 2G — and see the exact
+// value it resolves to, while the wire still carries a plain integer.
+
+// The suffix multipliers (case-insensitive). B is an alias for G (billion), T is
+// trillion — included for completeness though token counts rarely reach them.
+const UNITS: Record<string, number> = {
+  k: 1e3,
+  m: 1e6,
+  g: 1e9,
+  b: 1e9,
+  t: 1e12,
+};
+
+// parseTokenAmount converts a limits-editor entry to the wire value:
+//   ""               → null       (tier unset — no ceiling)
+//   "5000000"        → 5000000    (plain integer)
+//   "500k" "5M" "1.5m" "2G" → the scaled integer (case-insensitive, optional
+//                              decimal mantissa)
+//   commas / underscores / spaces are ignored as digit separators
+//   anything else    → undefined  (invalid — the caller flags it and never sends
+//                                   garbage; the tri-state keeps "unset" (null)
+//                                   distinct from "typo" (undefined))
+export function parseTokenAmount(s: string): number | null | undefined {
+  const t = s.trim().replace(/[_,\s]/g, "");
+  if (t === "") return null;
+  const m = /^(\d+(?:\.\d+)?)([kmgbt])?$/i.exec(t);
+  if (!m) return undefined;
+  const mult = m[2] ? UNITS[m[2].toLowerCase()] : 1;
+  const n = Math.floor(parseFloat(m[1]) * mult);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
+// fmtTokens renders a counter compactly (1_500_000 → "1.50M"), K/M/G/T. The
+// read-only `used` column uses it; it also mirrors the shorthand the editor
+// accepts so display and input speak the same units.
+export function fmtTokens(n: number): string {
+  if (n >= 1e12) return (n / 1e12).toFixed(2) + "T";
+  if (n >= 1e9) return (n / 1e9).toFixed(2) + "G";
+  if (n >= 1e6) return (n / 1e6).toFixed(2) + "M";
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + "K";
+  return String(n);
+}
+
+// amountHint is the live "recognition" feedback for an editor entry: the exact
+// grouped integer once a shorthand or separator was applied ("5M" → "= 5,000,000"),
+// or an invalid marker for a typo. Returns null when there's nothing worth
+// showing — an empty field, or a plain integer that already reads as-is.
+export function amountHint(s: string): { text: string; invalid: boolean } | null {
+  const t = s.trim();
+  if (t === "") return null;
+  const v = parseTokenAmount(t);
+  if (v === undefined) return { text: "not a number", invalid: true };
+  if (v === null) return null;
+  if (String(v) === t.replace(/[_,\s]/g, "")) return null; // plain integer, no transform
+  return { text: "= " + v.toLocaleString("en-US"), invalid: false };
+}

--- a/web/src/pages/LimitsView.tsx
+++ b/web/src/pages/LimitsView.tsx
@@ -6,6 +6,7 @@ import {
   listLimits,
   putLimit,
 } from "../api";
+import { amountHint, fmtTokens, parseTokenAmount } from "../lib/tokenAmount";
 
 // LimitsView — GET/PUT/DELETE /v1/_limits (RFC AW Phase 1).
 //
@@ -20,29 +21,49 @@ import {
 const SCOPES = ["operator", "tenant", "user"] as const;
 type Scope = (typeof SCOPES)[number];
 
-// fmtTokens mirrors UsageView's compact K/M formatter for the read-only `used`
-// column. The soft/hard editors show raw integers instead (you type into them).
-function fmtTokens(n: number): string {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(2) + "M";
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
-  return String(n);
-}
-
-// parseLimit converts an editor string to the wire value: empty = null (leave
-// the tier unset — no ceiling), otherwise a non-negative integer. type=number
-// inputs make a malformed entry near-impossible; a stray one coerces to null
-// (unset) rather than sending garbage, and the server also rejects negatives.
-function parseLimit(s: string): number | null {
-  const t = s.trim();
-  if (t === "") return null;
-  const n = Math.floor(Number(t));
-  return Number.isFinite(n) && n >= 0 ? n : null;
-}
-
 // rowKey uniquely identifies a budget row across tenants + scopes (an admin's
 // list can hold same-scope rows for many tenants).
 function rowKey(r: TokenLimit): string {
   return `${r.tenant_id ?? ""}|${r.scope}|${r.scope_id ?? ""}`;
+}
+
+// TokenAmountInput is the soft/hard ceiling editor: a text field (not type=number,
+// which rejects letters) that accepts a plain integer OR a shorthand — 500K, 5M,
+// 2G — and shows the exact value it resolves to as live feedback. parseTokenAmount
+// does the recognition on save; this only renders the input + the hint.
+function TokenAmountInput({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+}) {
+  const hint = amountHint(value);
+  return (
+    <div className="limits-amount">
+      <input
+        className="limits-num"
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        spellCheck={false}
+        placeholder={placeholder}
+        title="A number or shorthand: 500K, 5M, 2G. Empty = unlimited."
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+      />
+      {hint && (
+        <span className={"limits-amount-hint" + (hint.invalid ? " invalid" : "")}>
+          {hint.text}
+        </span>
+      )}
+    </div>
+  );
 }
 
 export default function LimitsView() {
@@ -79,7 +100,9 @@ export default function LimitsView() {
           <p className="limits-sub">
             Per-scope monthly token budgets — a <code>soft</code> warning and a{" "}
             <code>hard</code> cap (the next run is refused once crossed). Set a
-            ceiling against each scope's live month-to-date usage.
+            ceiling against each scope's live month-to-date usage. Amounts accept{" "}
+            <code>K</code>/<code>M</code>/<code>G</code> shorthand (e.g.{" "}
+            <code>5M</code> = 5,000,000).
           </p>
         </div>
         <div className="limits-actions">
@@ -162,13 +185,20 @@ function LimitRow({
   }, [row.soft_limit, row.hard_limit]);
 
   const save = async () => {
+    // undefined = a non-empty entry that didn't parse (a typo); null = unset.
+    const softV = parseTokenAmount(soft);
+    const hardV = parseTokenAmount(hard);
+    if (softV === undefined || hardV === undefined) {
+      setErr("enter a number or shorthand like 500K, 5M, 2G");
+      return;
+    }
     setBusy(true);
     setErr("");
     try {
       const body: LimitPutBody = {
         scope: row.scope,
-        soft_limit: parseLimit(soft),
-        hard_limit: parseLimit(hard),
+        soft_limit: softV,
+        hard_limit: hardV,
       };
       // tenant_id addresses the row's tenant (admin); harmlessly ignored for a
       // scoped operator (its own tenant is stamped server-side).
@@ -209,26 +239,18 @@ function LimitRow({
         <td className="limits-scopeid">{row.scope_id || "—"}</td>
         <td className="num">{fmtTokens(row.used)}</td>
         <td className="num">
-          <input
-            className="limits-num"
-            type="number"
-            min={0}
-            step={1000}
-            placeholder="∞"
+          <TokenAmountInput
             value={soft}
-            onChange={(e) => setSoft(e.target.value)}
+            onChange={setSoft}
+            placeholder="∞"
             disabled={busy}
           />
         </td>
         <td className="num">
-          <input
-            className="limits-num"
-            type="number"
-            min={0}
-            step={1000}
-            placeholder="∞"
+          <TokenAmountInput
             value={hard}
-            onChange={(e) => setHard(e.target.value)}
+            onChange={setHard}
+            placeholder="∞"
             disabled={busy}
           />
         </td>
@@ -279,13 +301,20 @@ function AddLimitForm({
 
   const submit = async (e: FormEvent) => {
     e.preventDefault();
+    // undefined = a non-empty entry that didn't parse (a typo); null = unset.
+    const softV = parseTokenAmount(soft);
+    const hardV = parseTokenAmount(hard);
+    if (softV === undefined || hardV === undefined) {
+      setErr("enter a number or shorthand like 500K, 5M, 2G");
+      return;
+    }
     setBusy(true);
     setErr("");
     try {
       const body: LimitPutBody = {
         scope,
-        soft_limit: parseLimit(soft),
-        hard_limit: parseLimit(hard),
+        soft_limit: softV,
+        hard_limit: hardV,
       };
       if (scope !== "operator") {
         // Fall back to the admin tenant-focus box when the field is blank.
@@ -339,22 +368,8 @@ function AddLimitForm({
           onChange={(e) => setScopeId(e.target.value)}
         />
       )}
-      <input
-        type="number"
-        min={0}
-        step={1000}
-        placeholder="soft"
-        value={soft}
-        onChange={(e) => setSoft(e.target.value)}
-      />
-      <input
-        type="number"
-        min={0}
-        step={1000}
-        placeholder="hard"
-        value={hard}
-        onChange={(e) => setHard(e.target.value)}
-      />
+      <TokenAmountInput value={soft} onChange={setSoft} placeholder="soft" disabled={busy} />
+      <TokenAmountInput value={hard} onChange={setHard} placeholder="hard" disabled={busy} />
       <button type="submit" className="ghost-btn" disabled={busy}>
         {busy ? "…" : "add"}
       </button>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -6256,6 +6256,26 @@ button.primary:disabled {
   text-align: right;
   font-family: var(--mono);
 }
+/* Soft/hard editor: the input stacks over its live "= 5,000,000" recognition
+   hint. inline-flex so it sits inline among the add-form's other controls; the
+   hint only renders when there's something to show, so the extra row height is
+   transient. */
+.limits-amount {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.limits-amount-hint {
+  font-size: 10px;
+  line-height: 1;
+  color: var(--fg-soft);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+.limits-amount-hint.invalid {
+  color: var(--failed);
+}
 .limits-row-actions {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Why
The RFC AW limits editor used `type=number` fields, so setting a **5,000,000**-token budget meant typing (and eye-counting) seven zeros. A dropped or extra zero is a silent **10× budget mistake** — exactly the kind of error a token budget exists to prevent.

## What
The soft/hard fields now accept a human **shorthand** and show a live recognition hint:

- **`500K`, `5M`, `2G`** (also `B`=giga, `T`=tera) — case-insensitive, optional decimal (`1.5M`), commas/underscores as separators.
- A live **`= 5,000,000`** hint appears under the field as you type, so you confirm the value before saving; a typo shows **`not a number`** and blocks the save (never silently sends garbage).
- The wire still carries a plain integer — this is input/display sugar only, no server change.

### Files
- **`web/src/lib/tokenAmount.ts`** (new, unit-tested) — `parseTokenAmount` (tri-state: `null`=unset, `undefined`=typo, `number`=parsed), `fmtTokens` (extended to **G/T** so the read-only `used` column and the input speak the same units), `amountHint` (the live feedback). In `web/src/lib/` + vitest, matching the `claudeImport.ts` convention.
- **`LimitsView.tsx`** — a `TokenAmountInput` component (text input + hint) replaces the four `type=number` fields; save/add parse the shorthand and block on an unparseable entry; the header documents the shorthand. Removes the now-duplicated local `fmtTokens`/`parseLimit`.

## Tested
- **vitest 38/38** — `tokenAmount.test.ts` covers K/M/G/B/T suffixes, decimals, separators, empty→null, typo→undefined, `fmtTokens` scaling, and the hint states.
- `make build-all` clean (UI rebuilt + embedded). No Go change.

Scoped to `LimitsView` only (the sole editable token input), so it's independent of the open #647 (UsageView) — no file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)